### PR TITLE
interface-vision/t-058: remove redundant nested scroll in butterfly-sanctuary.vue

### DIFF
--- a/components/butterfly/butterfly-sanctuary.vue
+++ b/components/butterfly/butterfly-sanctuary.vue
@@ -71,7 +71,7 @@
     >
       <aside
         v-show="mobilePanel === 'roster'"
-        class="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto bg-base-100 p-3"
+        class="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden bg-base-100 p-3"
       >
         <div class="shrink-0 rounded-xl border border-base-300 bg-base-200 p-3">
           <div
@@ -279,7 +279,7 @@
       class="grid min-h-0 flex-1 overflow-hidden lg:grid-cols-[17rem_1fr] xl:grid-cols-[18rem_1fr]"
     >
       <aside
-        class="flex min-h-0 flex-col gap-2 overflow-y-auto border-r border-base-300 bg-base-100 p-3"
+        class="flex min-h-0 flex-col gap-2 overflow-hidden border-r border-base-300 bg-base-100 p-3"
       >
         <div class="shrink-0 rounded-xl border border-base-300 bg-base-200 p-3">
           <div

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -4,7 +4,6 @@
   "violations": {
     "one-header": [],
     "one-scroll": [
-      "components/butterfly/butterfly-sanctuary.vue",
       "components/stages/stage-manager.vue",
       "components/wonderlab/mural-manager.vue"
     ],


### PR DESCRIPTION
### Task
interface-vision/t-058: Give one-scroll Shape B a two-owner grid primitive, and stop counting Shapes A/D (kind: software) — tenth slice

### What changed / what I produced
- `components/butterfly/butterfly-sanctuary.vue`'s roster `<aside>` (both the single-pane and two-pane layout branches) wrapped a fixed Summon/Selected header with a `flex-1 min-h-0` roster-list that already owns its own `overflow-y-auto` scroll region. The aside itself also carried `overflow-y-auto`, so the whole aside (sliding header cards + roster list together) and the inner roster list were both live, independent scroll owners at once — a genuine nested-scroll bug, not a Shape B two-owner grid case that needs the `.kr-panes` primitive (the sibling pane's own internal scroll, inside `butterfly-guide.vue`, isn't even visible to this file's static count).
- Swapped the aside's `overflow-y-auto` for `overflow-hidden` in both branches. `overflow:hidden` sets the same used `min-height:0` as `overflow-y-auto` per spec, so flex sizing is unaffected; the roster-list remains the sole real scroll owner.
- Ratcheted `utils/scripts/layout-contract-baseline.json`'s `one-scroll` bucket from 3 to 2. Two files remain on the allow-list: `stage-manager.vue` (footer-composer risk) and `mural-manager.vue` (3-pane, hardest case) — both need visual verification per prior t-058 slices' findings before a safe migration.

### How I verified
- `npm run test:layout-contract` — confirms the fix, ratchets 3→2, no new violations.
- `npx vue-tsc --noEmit` — clean.
- `npx eslint components/butterfly/butterfly-sanctuary.vue` — same 3 pre-existing import-ordering errors present on `main` before this change (confirmed via `git stash`); unrelated to this diff, left untouched per scope discipline.

### Stakes
reversible

### Flags for Reviewer
- No live/Vercel visual check performed — this change only removes a redundant `overflow` class; the remaining scroll owner (the roster list) and its CSS were already unchanged, so the visual risk is low, but a short-viewport edge case (very small `<aside>` height) will now clip rather than let the whole aside scroll, matching the single-scroll-owner pattern used elsewhere in the codebase (character-interact.vue, art-interact.vue).

### Kaizen suggestion
The one-scroll verifier only reads a single `.vue` file's own template — it can't see that `butterfly-guide.vue` (mounted in the sibling pane) also declares its own `overflow-y-auto`. That's a pre-existing, separately-tracked gap (t-058's own THIRD note), not something this slice attempts to fix.

### Notes for reviewer
conductor interface-vision/t-058 (tenth slice). Companion conductor PR updates the roadmap note and re-arms the task to `ready` for the remaining two files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTUfBemK5LfvJs5t6SVpUx)_