### PR TITLE
interface-vision/t-068: migrate three forbid scanners

### DIFF
--- a/utils/scripts/verifyDreamMutationInputParity.ts
+++ b/utils/scripts/verifyDreamMutationInputParity.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { containsCode } from './lib/sourceText'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 
@@ -15,7 +16,7 @@ function requireText(source: string, text: string, label: string): void {
 }
 
 function forbidText(source: string, text: string, label: string): void {
-  if (source.includes(text)) {
+  if (containsCode(source, text)) {
     throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
   }
 }

--- a/utils/scripts/verifyPromptCreateOwnership.ts
+++ b/utils/scripts/verifyPromptCreateOwnership.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { containsCode } from './lib/sourceText'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 
@@ -15,7 +16,7 @@ function requireText(source: string, text: string, label: string): void {
 }
 
 function forbidText(source: string, text: string, label: string): void {
-  if (source.includes(text)) {
+  if (containsCode(source, text)) {
     throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
   }
 }

--- a/utils/scripts/verifyReactionCreateInputBoundary.ts
+++ b/utils/scripts/verifyReactionCreateInputBoundary.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { containsCode } from './lib/sourceText'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 
@@ -15,7 +16,7 @@ function requireText(source: string, text: string, label: string): void {
 }
 
 function forbidText(source: string, text: string, label: string): void {
-  if (source.includes(text)) {
+  if (containsCode(source, text)) {
     throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
   }
 }


### PR DESCRIPTION
## Summary

- route Prompt ownership forbid checks through the shared comment-aware `containsCode` helper
- apply the same migration to Dream mutation parity and Reaction create-boundary contracts
- leave require-style checks on raw source so comments cannot satisfy required contract text

## Scope

Mechanical, contract-only slice of `conductor: interface-vision/t-068`. No production application code or runtime behavior changes.

## Validation

GitHub Actions must complete successfully before merge, including Contract Tests and TypeScript Type Check.

Conductor session: `2026-08-04T201211Z-interface-vision-t-068-j7k4`