### PR TITLE
t-090: kr-chat-window forwards selectedKey, restoring two lost highlights

### DIFF
--- a/components/narrative/kr-chat-window.vue
+++ b/components/narrative/kr-chat-window.vue
@@ -105,6 +105,7 @@
           :choices="turn.choices"
           :disabled="isStreaming"
           :show-index="false"
+          :selected-key="selectedKey"
           @select="emit('choose', $event, turn)"
         />
 
@@ -117,7 +118,9 @@
       class="whitespace-pre-wrap rounded-2xl rounded-bl-sm border border-dashed border-secondary/40 bg-base-200/40 px-4 py-3 text-sm leading-relaxed"
       aria-hidden="true"
     >
-      <template v-if="visibleStreamingText">{{ visibleStreamingText }}</template>
+      <template v-if="visibleStreamingText">{{
+        visibleStreamingText
+      }}</template>
       <span v-else class="flex items-center gap-2 text-base-content/60">
         <span
           class="loading loading-dots loading-sm motion-reduce:hidden"
@@ -161,6 +164,17 @@ const props = withDefaults(
     /** Apply the 65ch reading measure. On for narration, off for chat chatter. */
     prose?: boolean
     autoScroll?: boolean
+    /**
+     * The choice already picked, forwarded to every turn's embedded
+     * kr-choice-list so it can ring the selection.
+     *
+     * kr-choice-list has always supported this; kr-chat-window just had no way
+     * to say it, so reward-interact (t-087) and scenario-interact (t-088) both
+     * LOST their "highlight the current pick" styling when they migrated onto
+     * the shared kit, and each accepted the regression as a kaizen note. Two
+     * surfaces is enough (t-090). Callers that omit it see no change.
+     */
+    selectedKey?: string | null
   }>(),
   {
     isStreaming: false,
@@ -170,6 +184,7 @@ const props = withDefaults(
     label: 'Conversation',
     prose: true,
     autoScroll: true,
+    selectedKey: null,
   },
 )
 

--- a/components/rewards/reward-interact.vue
+++ b/components/rewards/reward-interact.vue
@@ -177,6 +177,7 @@
           streaming-label="The narrative gremlin is writing..."
           empty-label="Start the encounter, then unleash the narrative gremlin."
           :prose="false"
+          :selected-key="lastChoiceKey"
           @choose="handleChoiceSelected"
         >
           <template v-if="canShowCustomFollowup" #footer>
@@ -866,7 +867,17 @@ const canShowCustomFollowup = computed(() =>
   Boolean(latestSessionChat.value?.botResponse),
 )
 
+/*
+ * The choice most recently picked, so kr-chat-window can ring it (t-090).
+ * This surface had that highlight before its migration onto the shared kit and
+ * lost it, because kr-chat-window had no way to forward a selectedKey to the
+ * choice lists it embeds. The key is the display key kr-choice-list emits, not
+ * the recovered path text, since that is what it compares against.
+ */
+const lastChoiceKey = ref<string | null>(null)
+
 function handleChoiceSelected(choice: NarrativeChoice) {
+  lastChoiceKey.value = choice.key
   // getStoryChoices keys are `${1|2|3}-${text}`; recover the raw path text
   // rather than repurposing the display label/hint, which are free to change.
   continueWithPath(choice.key.replace(/^[1-3]-/, ''))

--- a/components/scenarios/scenario-interact.vue
+++ b/components/scenarios/scenario-interact.vue
@@ -280,6 +280,7 @@
         :streaming-text="streamingStoryText"
         streaming-label="Story goblin thinking..."
         empty-label="The story will appear here once it begins."
+        :selected-key="lastReplyKey"
         @choose="handleReplyChosen"
       />
 
@@ -457,7 +458,17 @@ const streamingStoryText = computed(() => {
   return last?.isStreaming ? last.displayResponse : ''
 })
 
+/*
+ * The choice most recently picked, so kr-chat-window can ring it (t-090).
+ * This surface had that highlight before its migration onto the shared kit and
+ * lost it, because kr-chat-window had no way to forward a selectedKey to the
+ * choice lists it embeds. The key is the display key kr-choice-list emits, not
+ * the recovered path text, since that is what it compares against.
+ */
+const lastReplyKey = ref<string | null>(null)
+
 function handleReplyChosen(choice: NarrativeChoice) {
+  lastReplyKey.value = choice.key
   storyStore.selectReplyOption(choice.hint ?? choice.label)
 }
 


### PR DESCRIPTION
`kr-choice-list` has always supported `selectedKey` — scenario-interact's own
top-level intro picker uses it. `kr-chat-window` just had no way to *say* it, so
the choice lists it embeds could never ring the current pick.

That cost two surfaces their highlight. **reward-interact** (t-087, #1406) and
**scenario-interact** (t-088, #1408) both had a ring/border on the selected
option before migrating onto the shared kit; neither migration could preserve it,
both accepted the regression, and each left a kaizen note. t-090 promoted it once
the second surface hit the same wall.

An optional `selectedKey` prop now forwards to every turn's embedded
`kr-choice-list`. Callers that omit it see no change.

## One thing the task didn't anticipate

**Neither surface kept any "which choice was picked" state.** Both dispatched
straight through — `continueWithPath()` and `selectReplyOption()` — so there was
nothing to forward even once the prop existed. Each gains a small ref set in its
choose handler.

The key recorded is the **display key** `kr-choice-list` emits, not
reward-interact's recovered path text — it strips a `${1|2|3}-` prefix before
dispatching, and the display key is what `kr-choice-list` compares against.

## Verification

- `npm run test` (vue-tsc) — **exit 0**
- `test:narrative-kit` — passes
- `test:layout-contract` — holds
- `eslint` + `prettier` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_