### PR TITLE
Fix chained art fallback failures in kr-art-plate

### DIFF
--- a/components/narrative/kr-art-plate.vue
+++ b/components/narrative/kr-art-plate.vue
@@ -125,18 +125,20 @@ const frameClass = computed(() => {
   }
 })
 
-// A broken URL should fall back rather than leave a dead frame. Reset whenever
-// the source changes, or one bad image would poison every later one.
-const failed = ref(false)
+const failedSources = ref<string[]>([])
 watch(
   () => [props.source, props.variant, props.fallback],
   () => {
-    failed.value = false
+    failedSources.value = []
   },
 )
 
-function onError(): void {
-  failed.value = true
+function onError(event: Event): void {
+  const failedSrc =
+    (event.currentTarget as HTMLImageElement | null)?.getAttribute('src') || ''
+  if (failedSrc && !failedSources.value.includes(failedSrc)) {
+    failedSources.value = [...failedSources.value, failedSrc]
+  }
 }
 
 const src = computed(() => {
@@ -145,9 +147,15 @@ const src = computed(() => {
     props.variant,
     props.fallback,
   )
-  if (!failed.value) return resolved
-  // Only fall back if the fallback is not itself the thing that just failed.
-  return resolved === props.fallback ? '' : props.fallback
+  if (resolved && !failedSources.value.includes(resolved)) return resolved
+  if (
+    props.fallback &&
+    props.fallback !== resolved &&
+    !failedSources.value.includes(props.fallback)
+  ) {
+    return props.fallback
+  }
+  return ''
 })
 
 /*


### PR DESCRIPTION
## Summary

Fixes `interface-vision/t-086`.

`kr-art-plate.vue` used one boolean to remember an image failure. That worked for one hop, but not two: after a primary source failed the component switched to `fallback`; if the fallback also failed, the boolean was already true and the computed source kept returning the broken fallback forever. The browser then painted alt text inside the art frame, matching the `/rewards` BROKEN-ART reports.

This change tracks failed source URLs individually:

- primary failure advances to fallback
- fallback failure advances to the placeholder icon
- source/variant/fallback changes reset the failure history

## Scope

- one component
- no API, store, schema, migration, or production-data changes
- preserves the existing primary → fallback → placeholder contract

## Verification

- CI must complete successfully before merge
- manual code-path review against `reward-card.vue -> kr-entity-card-body.vue -> kr-art-plate.vue`

## Conductor

- Project: `interface-vision`
- Task: `t-086`
- Session: `2026-08-04T222130Z-interface-vision-t-086-r2v6`
