### PR TITLE
Join the tailnet before talking to the database

### DIFF
--- a/.github/workflows/repair-reward-image-paths.yml
+++ b/.github/workflows/repair-reward-image-paths.yml
@@ -33,10 +33,17 @@ jobs:
       DATABASE_SSL_CA_BASE64: ${{ secrets.DATABASE_SSL_CA_BASE64 }}
       DATABASE_SSL_CA: ${{ secrets.DATABASE_SSL_CA }}
     steps:
-      - name: Require the database secret
+      - name: Require the database and tailnet secrets
+        env:
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
         run: |
           if [ -z "${DATABASE_URL}" ]; then
             echo "::error::DATABASE_URL secret is not set; nothing to do."
+            exit 1
+          fi
+          if [ -z "${TS_OAUTH_CLIENT_ID}" ] || [ -z "${TS_OAUTH_SECRET}" ]; then
+            echo "::error::TS_OAUTH_CLIENT_ID / TS_OAUTH_SECRET are empty. The database is only reachable over the tailnet; see fallback-snapshot.yml."
             exit 1
           fi
 
@@ -61,6 +68,20 @@ jobs:
       # refuses /api/art paths before pointing it at production.
       - name: Self-test the rewrite rule
         run: npm run test:reward-image-paths-selftest
+
+      # The database is NOT reachable from a bare runner — it lives behind
+      # Tailscale on the Unraid box, and DATABASE_URL's host is a tailnet
+      # address. Without this the Prisma adapter just times out its pool after
+      # 10s with "active=0 idle=0", which reads like a dead database rather
+      # than an unrouted one (observed on this workflow's first run, before
+      # this step existed). Same ephemeral-node setup fallback-snapshot.yml
+      # uses; placed after npm/prisma so the tailnet session stays short.
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
 
       - name: Repair reward image paths
         run: |

--- a/.github/workflows/retire-wonderlab-components.yml
+++ b/.github/workflows/retire-wonderlab-components.yml
@@ -30,10 +30,17 @@ jobs:
       DATABASE_SSL_CA_BASE64: ${{ secrets.DATABASE_SSL_CA_BASE64 }}
       DATABASE_SSL_CA: ${{ secrets.DATABASE_SSL_CA }}
     steps:
-      - name: Require the database secret
+      - name: Require the database and tailnet secrets
+        env:
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
         run: |
           if [ -z "${DATABASE_URL}" ]; then
             echo "::error::DATABASE_URL secret is not set; nothing to do."
+            exit 1
+          fi
+          if [ -z "${TS_OAUTH_CLIENT_ID}" ] || [ -z "${TS_OAUTH_SECRET}" ]; then
+            echo "::error::TS_OAUTH_CLIENT_ID / TS_OAUTH_SECRET are empty. The database is only reachable over the tailnet; see fallback-snapshot.yml."
             exit 1
           fi
 
@@ -53,6 +60,18 @@ jobs:
 
       - name: Generate Prisma client
         run: npx prisma generate
+
+      # The database is NOT reachable from a bare runner -- it lives behind
+      # Tailscale on the Unraid box, and DATABASE_URL's host is a tailnet
+      # address. Without this the Prisma adapter times out its pool after 10s
+      # with "active=0 idle=0", which reads like a dead database rather than an
+      # unrouted one. Same ephemeral-node setup fallback-snapshot.yml uses.
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
 
       - name: Retire components
         run: |


### PR DESCRIPTION
The reward-path repair workflow's first run failed on a pool timeout — `active=0 idle=0` after 10s — which reads like a dead database but isn't.

The database lives behind Tailscale on the Unraid box, and `DATABASE_URL`'s host is a tailnet address, so a bare runner has **no route to it at all**.

`fallback-snapshot.yml` already knew this — it joins the tailnet as an ephemeral node before its snapshot step, and its header says outright that the host must be the tailnet address, *not* the public hostname. The two dispatch-only maintenance workflows inherited only its `DATABASE_URL`/CA env block and not the Tailscale step, so **both were unrunnable**. `retire-wonderlab-components.yml` had the same gap and had never been run to find out.

Both now:
- join the tailnet after the npm/prisma steps (keeping the session short — same placement `fallback-snapshot.yml` uses)
- **fail fast** with a pointed message when the OAuth secrets are missing, instead of surfacing it ten seconds later as a connection-pool timeout

Verified: `test:workflow-pipefail`, `test:workflow-paths` (65 workflows, 756 path references), Prettier — all clean.

**Requires** `TS_OAUTH_CLIENT_ID` and `TS_OAUTH_SECRET` repository Actions secrets, the same pair `fallback-snapshot.yml` uses — which it has been using successfully on its daily schedule, so they exist.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_