### PR TITLE
t-068: finish the comment-aware forbid-scan sweep

### DIFF
--- a/utils/scripts/verifyDailyDreamFacets.ts
+++ b/utils/scripts/verifyDailyDreamFacets.ts
@@ -1,6 +1,7 @@
 // /utils/scripts/verifyDailyDreamFacets.ts
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import { containsCode } from './lib/sourceText'
 
 const root = process.cwd()
 
@@ -15,7 +16,7 @@ function requireText(path: string, text: string, value: string): void {
 }
 
 function forbidText(path: string, text: string, value: string): void {
-  if (text.includes(value)) {
+  if (containsCode(text, value)) {
     throw new Error(`${path} contains forbidden component request text: ${value}`)
   }
 }

--- a/utils/scripts/verifyFacetCanonicalMerges.ts
+++ b/utils/scripts/verifyFacetCanonicalMerges.ts
@@ -1,6 +1,7 @@
 // /utils/scripts/verifyFacetCanonicalMerges.ts
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import { containsCode } from './lib/sourceText'
 
 const root = process.cwd()
 
@@ -15,7 +16,7 @@ function requireText(path: string, text: string, value: string): void {
 }
 
 function forbidText(path: string, text: string, value: string): void {
-  if (text.includes(value)) {
+  if (containsCode(text, value)) {
     throw new Error(`${path} contains retired contract text: ${value}`)
   }
 }

--- a/utils/scripts/verifyFacetCatalogCutover.ts
+++ b/utils/scripts/verifyFacetCatalogCutover.ts
@@ -1,6 +1,7 @@
 // /utils/scripts/verifyFacetCatalogCutover.ts
 import { access, readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import { containsCode } from './lib/sourceText'
 
 const root = process.cwd()
 
@@ -15,7 +16,7 @@ function requireText(path: string, text: string, value: string): void {
 }
 
 function forbidText(path: string, text: string, value: string): void {
-  if (text.includes(value)) {
+  if (containsCode(text, value)) {
     throw new Error(`${path} contains retired runtime text: ${value}`)
   }
 }

--- a/utils/scripts/verifyFacetCuration.ts
+++ b/utils/scripts/verifyFacetCuration.ts
@@ -1,6 +1,7 @@
 // /utils/scripts/verifyFacetCuration.ts
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import { stripComments } from './lib/sourceText'
 
 const root = process.cwd()
 
@@ -28,7 +29,10 @@ function requireOrder(
 }
 
 function forbidFacetArtMutation(path: string, text: string): void {
-  const updateCalls = text.match(/prisma\.facet\.update\(\{[\s\S]*?\n\s*\}\)/g) ?? []
+  // Strip comments first (t-068): a doc comment showing a prisma.facet.update
+  // block to explain which fields are protected must not read as one.
+  const updateCalls =
+    stripComments(text).match(/prisma\.facet\.update\(\{[\s\S]*?\n\s*\}\)/g) ?? []
   const protectedFields = [
     'flavorText',
     'examples',

--- a/utils/scripts/verifyFacetPersonalityFamilies.ts
+++ b/utils/scripts/verifyFacetPersonalityFamilies.ts
@@ -1,6 +1,7 @@
 // /utils/scripts/verifyFacetPersonalityFamilies.ts
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import { containsCode } from './lib/sourceText'
 
 const root = process.cwd()
 
@@ -15,7 +16,7 @@ function requireText(path: string, text: string, value: string): void {
 }
 
 function forbidText(path: string, text: string, value: string): void {
-  if (text.includes(value)) {
+  if (containsCode(text, value)) {
     throw new Error(`${path} must not contain production mutation hook: ${value}`)
   }
 }

--- a/utils/scripts/verifyFacetTaxonomyAuthority.ts
+++ b/utils/scripts/verifyFacetTaxonomyAuthority.ts
@@ -2,6 +2,7 @@
 // Facet.kind is gone (t-072); FacetProfile.taxonomy is the sole authority.
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import { containsCode } from './lib/sourceText'
 
 const root = process.cwd()
 
@@ -16,7 +17,7 @@ function requireText(path: string, text: string, fragment: string): void {
 }
 
 function forbidText(path: string, text: string, fragment: string): void {
-  if (text.includes(fragment)) {
+  if (containsCode(text, fragment)) {
     throw new Error(`${path} contains deprecated kind authority: ${fragment}`)
   }
 }

--- a/utils/scripts/verifyGalleryConsistency.ts
+++ b/utils/scripts/verifyGalleryConsistency.ts
@@ -25,26 +25,23 @@
 
 import { readFile, readdir } from 'node:fs/promises'
 import { join } from 'node:path'
+import { stripComments } from './lib/sourceText'
 
 const failures: string[] = []
 const notes: string[] = []
 
-/**
- * Strip comments before any forbid-scan.
+/*
+ * WHY EVERY SCAN BELOW STRIPS COMMENTS FIRST.
  *
  * interface-vision t-068: "a doc comment can fail 29 source-text contracts".
  * This contract proved it on its own first run — scenario-card.vue was flagged
  * for hardcoding `variant="card"` when the only occurrence left was inside the
  * doc comment explaining that it USED to. A contract that punishes you for
  * documenting the thing it asked you to fix trains people to delete comments.
+ *
+ * The stripper itself lives in ./lib/sourceText, shared with every other
+ * forbid-scanning verifier and covered by verifySourceTextComments.test.ts.
  */
-function stripComments(src: string): string {
-  return src
-    .replace(/<!--[\s\S]*?-->/g, '') // template
-    .replace(/\/\*[\s\S]*?\*\//g, '') // block
-    .replace(/(^|[^:])\/\/[^\n]*/g, '$1') // line, sparing protocol slashes
-}
-
 const fail = (msg: string) => failures.push(msg)
 const ok = (msg: string) => notes.push(`ok - ${msg}`)
 

--- a/utils/scripts/verifyModelBuilderFacetSync.ts
+++ b/utils/scripts/verifyModelBuilderFacetSync.ts
@@ -1,6 +1,7 @@
 // /utils/scripts/verifyModelBuilderFacetSync.ts
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import { containsCode } from './lib/sourceText'
 
 const root = process.cwd()
 
@@ -15,7 +16,7 @@ function requireText(path: string, text: string, fragment: string): void {
 }
 
 function forbidText(path: string, text: string, fragment: string): void {
-  if (text.includes(fragment)) {
+  if (containsCode(text, fragment)) {
     throw new Error(`${path} contains retired Model Builder Facet text: ${fragment}`)
   }
 }

--- a/utils/scripts/verifyReactionSubPatchEnvelope.ts
+++ b/utils/scripts/verifyReactionSubPatchEnvelope.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { containsCode } from './lib/sourceText'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 
@@ -15,7 +16,7 @@ function requireText(source: string, text: string, label: string): void {
 }
 
 function forbidText(source: string, text: string, label: string): void {
-  if (source.includes(text)) {
+  if (containsCode(source, text)) {
     throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
   }
 }

--- a/utils/scripts/verifyResourceMutationOwnership.ts
+++ b/utils/scripts/verifyResourceMutationOwnership.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { containsCode } from './lib/sourceText'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 
@@ -15,7 +16,7 @@ function requireText(source: string, text: string, label: string): void {
 }
 
 function forbidText(source: string, text: string, label: string): void {
-  if (source.includes(text)) {
+  if (containsCode(source, text)) {
     throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
   }
 }

--- a/utils/scripts/verifyScenarioMutationInputParity.ts
+++ b/utils/scripts/verifyScenarioMutationInputParity.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { containsCode } from './lib/sourceText'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 
@@ -15,7 +16,7 @@ function requireText(source: string, text: string, label: string): void {
 }
 
 function forbidText(source: string, text: string, label: string): void {
-  if (source.includes(text)) {
+  if (containsCode(source, text)) {
     throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
   }
 }

--- a/utils/scripts/verifyServerMutationOwnership.ts
+++ b/utils/scripts/verifyServerMutationOwnership.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { containsCode } from './lib/sourceText'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 
@@ -15,7 +16,7 @@ function requireText(source: string, text: string, label: string): void {
 }
 
 function forbidText(source: string, text: string, label: string): void {
-  if (source.includes(text)) {
+  if (containsCode(source, text)) {
     throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
   }
 }

--- a/utils/scripts/verifySystemOptionFacetCutover.ts
+++ b/utils/scripts/verifySystemOptionFacetCutover.ts
@@ -5,6 +5,7 @@ import { resolve } from 'node:path'
 import { RewardType, Rarity } from '../../prisma/generated/prisma/enums'
 import { CREATABLE_DREAM_TYPES } from '../../stores/helpers/dreamHelper'
 import { SYSTEM_OPTION_FACET_TARGETS } from '../seeds/facetSystemOptionArtwork'
+import { containsCode } from './lib/sourceText'
 
 const root = process.cwd()
 
@@ -141,7 +142,7 @@ async function main(): Promise<void> {
   requireText(files.policy, text.policy, 'utils/scripts/seedSystemOptionFacets.ts')
 
   for (const forbidden of ['prisma.dreamFacet', 'prisma.rewardFacet']) {
-    if (text.seed.includes(forbidden)) {
+    if (containsCode(text.seed, forbidden)) {
       failures.push(
         `${files.seed} must not duplicate structural enum values into assignment tables (${forbidden}).`,
       )

--- a/utils/scripts/verifyThemeMutationInputParity.ts
+++ b/utils/scripts/verifyThemeMutationInputParity.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { containsCode } from './lib/sourceText'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 
@@ -15,7 +16,7 @@ function requireText(source: string, text: string, label: string): void {
 }
 
 function forbidText(source: string, text: string, label: string): void {
-  if (source.includes(text)) {
+  if (containsCode(source, text)) {
     throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
   }
 }

--- a/utils/scripts/verifyTodoMutationInputParity.ts
+++ b/utils/scripts/verifyTodoMutationInputParity.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { containsCode } from './lib/sourceText'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 
@@ -15,7 +16,7 @@ function requireText(source: string, text: string, label: string): void {
 }
 
 function forbidText(source: string, text: string, label: string): void {
-  if (source.includes(text)) {
+  if (containsCode(source, text)) {
     throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
   }
 }


### PR DESCRIPTION
Closes interface-vision/**t-068** — *"a doc comment can fail 29 source-text contracts"*.

PR #1351 extracted `utils/scripts/lib/sourceText` for exactly this and migrated the two files that had already been bitten. Ten verifiers use it today. **Fifteen more still scanned raw source**, so a comment explaining why something is absent could still fail the contract asking for its absence.

## The mechanical twelve

All share one shape — a `forbidText` helper guarding on `.includes` — so each is a one-line swap to `containsCode()`. Argument order differs between them (`(source, text)` vs `(path, text, fragment)`), so the guard was located and rewritten in place rather than pattern-replaced across files.

`verifyDailyDreamFacets` · `verifyFacetCanonicalMerges` · `verifyFacetCatalogCutover` · `verifyFacetPersonalityFamilies` · `verifyFacetTaxonomyAuthority` · `verifyModelBuilderFacetSync` · `verifyReactionSubPatchEnvelope` · `verifyResourceMutationOwnership` · `verifyScenarioMutationInputParity` · `verifyServerMutationOwnership` · `verifyThemeMutationInputParity` · `verifyTodoMutationInputParity`

## Three needed individual handling

- **`verifySystemOptionFacetCutover`** scanned inline in a `for…of` loop, not through a helper.
- **`verifyFacetCuration`** matches `prisma.facet.update({…})` **blocks** with a regex to check which fields they touch. A doc comment showing such a block to explain which fields are protected would have read as a real one — so it strips first and keeps the regex.
- **`verifyGalleryConsistency`** (written this week, *after* t-068 was filed) had its own private copy of the stripper, because the shared one wasn't on its radar — which is its own small argument for this sweep. It now imports the shared one, and its comment explains *why* the scans strip rather than restating the implementation.

## Four files deliberately untouched

My first grep flagged them; none is a forbid-scan. `verifyDaVinciNarration`, `verifyProjectMutationInputParity` and `verifyRewardMutationInputParity` merely contain the word *"forbids"* inside a check label or a required-text fragment, and `verifyWonderLabRegistryHealth` inside a comment.

## Direction preserved

`requireText` keeps reading **raw** source everywhere, matching the precedent `verifyFacetGallery` set — only the forbid direction is comment-aware.

## Verification

Proven both ways against a **real contract**, not a fixture:

| appended to `stores/themeStore.ts` | `verifyThemeMutationInputParity` |
| --- | --- |
| `// Intentionally never does \`userId ??\` — ownership comes from the session.` | **passes** ✅ |
| `const leak = payload.userId ?? 1` | **fails** ✅ |

All fifteen verifiers run clean · `verifySourceTextComments.test.ts` passes · `npm run test` (vue-tsc) clean · ESLint clean. Twelve of the touched files were already Prettier-dirty before this change and remain byte-comparable — no formatting regressions introduced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_