### PR TITLE
Make Daily Dream forbid checks comment-aware

### DIFF
--- a/utils/scripts/verifyDailyDreamFacets.ts
+++ b/utils/scripts/verifyDailyDreamFacets.ts
@@ -1,6 +1,7 @@
 // /utils/scripts/verifyDailyDreamFacets.ts
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import { containsCode } from './lib/sourceText'
 
 const root = process.cwd()
 
@@ -15,7 +16,7 @@ function requireText(path: string, text: string, value: string): void {
 }
 
 function forbidText(path: string, text: string, value: string): void {
-  if (text.includes(value)) {
+  if (containsCode(text, value)) {
     throw new Error(`${path} contains forbidden component request text: ${value}`)
   }
 }


### PR DESCRIPTION
## Summary
- route `verifyDailyDreamFacets.ts` forbid checks through the shared `containsCode()` helper
- preserve all require-style checks on raw source text
- prevent explanatory comments from tripping the contract while keeping executable forbidden calls detectable

## Conductor
- project: `interface-vision`
- task: `t-068`
- session: `2026-08-04T171309-0700-interface-vision-t-068-v6n2`

## Scope
One contract verifier only. No production behavior, database, workflow dispatch, or UI changes.