### PR TITLE
t-066: one earned-karma fetch, seven galleries wired

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Gallery consistency contract
         run: npm run test:gallery-consistency
 
+      - name: Earned-karma wiring contract
+        run: npm run test:earned-karma-wiring
+
       - name: Data surface manifest contract
         run: npm run test:data-surface-manifest
 

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -216,6 +216,7 @@
           :key="group.key"
           :collection="group.collection"
           :selected="activeGroupKey === group.key"
+          :earned-karma="earnedKarmaByCollectionId[group.id]"
           :compact="viewSize === 'xs' || viewSize === 'sm'"
           :show-stats="false"
           :show-select-button="false"
@@ -628,7 +629,6 @@ import { useArtStore } from '@/stores/artStore'
 import { useCollectionStore } from '@/stores/collectionStore'
 import { ErrorType, useErrorStore } from '@/stores/errorStore'
 import { useUserStore } from '@/stores/userStore'
-import { performFetch } from '@/stores/utils'
 
 type BatchFlagValue = 'keep' | 'true' | 'false'
 
@@ -941,7 +941,6 @@ const imagePage = ref(0)
 const folderPageSize = ref(24) // default 24
 const imagePageSize = ref(24)
 const hydratedImages = ref<Record<number, ArtImage>>({})
-const earnedKarmaByImageId = ref<Record<number, number>>({})
 const activeGroupKey = ref<string | null>(null)
 const selectedImageForOverlay = ref<ArtImage | null>(null)
 const viewSize = ref<ViewSize>('md')
@@ -1242,7 +1241,6 @@ watch(
     showMature.value,
   ],
   async () => {
-    void refreshEarnedKarma()
     await hydrateVisibleImages()
   },
 )
@@ -1279,7 +1277,6 @@ async function initializeGallery() {
       await fetchArtImagesSafely()
     }
 
-    void refreshEarnedKarma()
     await hydrateVisibleImages()
   } catch (error) {
     const message = getErrorMessage(error, 'Gallery failed to initialize.')
@@ -1492,39 +1489,27 @@ function clearSelectedImage() {
     artStore.deselectArtImage()
 }
 
-// interface-vision/t-046: batch-fetch earned karma for the current visible
-// page only (not the whole gallery), same "fetch on the rendered page, not
-// every filter keystroke" scoping as hydrateVisibleImages -- see
-// components/rewards/reward-gallery.vue for the reference wiring this
-// mirrors and server/api/economy/karma-earned.post.ts for the endpoint.
-async function refreshEarnedKarma() {
-  const ids = pagedActiveImages.value.map((image) => image.id)
+// interface-vision/t-046 scoping, t-066 implementation: earned karma is
+// fetched for the current visible PAGE only (not the whole gallery), the same
+// "fetch on the rendered page, not every filter keystroke" rule as
+// hydrateVisibleImages. useEarnedKarma watches that id list itself, so the
+// page/filter watch below no longer has to call refresh by hand; the explicit
+// Refresh button still does, because karma can change while the ids do not.
+const { earnedKarma: earnedKarmaByImageId, refresh: refreshEarnedKarma } =
+  useEarnedKarma('artImage', () => pagedActiveImages.value.map((i) => i.id))
 
-  if (!ids.length) {
-    earnedKarmaByImageId.value = {}
-    return
-  }
-
-  const res = await performFetch<
-    Array<{ refType: string; refId: string; earnedKarma: number }>
-  >('/api/economy/karma-earned', {
-    method: 'POST',
-    body: JSON.stringify({
-      items: ids.map((id) => ({ refType: 'artImage', refId: id })),
-    }),
-  })
-
-  if (!res.success || !Array.isArray(res.data)) return
-
-  const next: Record<number, number> = {}
-
-  for (const row of res.data) {
-    const id = Number(row.refId)
-    if (Number.isFinite(id)) next[id] = row.earnedKarma
-  }
-
-  earnedKarmaByImageId.value = next
-}
+// Collections earn karma the same way images do (reaction-category
+// ART_COLLECTION). Virtual groups — "Unsorted" and the folder-derived ones —
+// are excluded: they share the sentinel id -1 and have no ArtCollection row to
+// attribute karma to, so batching them would spend request slots on a lookup
+// that can only ever return 0.
+const { earnedKarma: earnedKarmaByCollectionId } = useEarnedKarma(
+  'artCollection',
+  () =>
+    pagedGroups.value
+      .filter((group) => !group.isVirtual && group.id > 0)
+      .map((group) => group.id),
+)
 
 async function hydrateVisibleImages() {
   const imagesNeedingData = pagedActiveImages.value.filter(shouldHydrateImage)

--- a/components/art/collection-card.vue
+++ b/components/art/collection-card.vue
@@ -8,6 +8,7 @@
     target-type="artCollection"
     reaction-category="ART_COLLECTION"
     :target-title="collectionLabel"
+    :earned-karma="earnedKarma"
     :card-class="isHiddenMature ? 'opacity-70' : ''"
     @select="selectCollection"
   >
@@ -246,6 +247,9 @@ const props = withDefaults(
     fallbackIcon?: string
     imageHeightClass?: string
     previewArtImage?: ArtImage | null
+    /** Total karma this collection has earned from reactions to it. Omit/undefined
+     *  renders no badge — see components/wonderlab/reactable-card.vue. */
+    earnedKarma?: number | null
   }>(),
   {
     selected: false,
@@ -267,6 +271,7 @@ const props = withDefaults(
     fallbackIcon: 'kind-icon:folder',
     imageHeightClass: 'h-48',
     previewArtImage: null,
+    earnedKarma: undefined,
   },
 )
 

--- a/components/bots/bot-card.vue
+++ b/components/bots/bot-card.vue
@@ -10,6 +10,7 @@
       target-type="bot"
       reaction-category="BOT"
       :target-title="botTitle"
+      :earned-karma="earnedKarma"
       @select="selectBot"
     >
       <template #actions>
@@ -195,6 +196,9 @@ const props = withDefaults(
      * utils/scripts/verifyGalleryConsistency.ts.
      */
     variant?: ArtVariant
+    /** Total karma this bot has earned from reactions to it. Omit/undefined
+     *  renders no badge — see components/wonderlab/reactable-card.vue. */
+    earnedKarma?: number | null
   }>(),
   {
     variant: 'card',
@@ -213,6 +217,7 @@ const props = withDefaults(
     allowClone: true,
     allowDelete: true,
     fallbackImage: '/images/bot.webp',
+    earnedKarma: undefined,
   },
 )
 

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -314,6 +314,7 @@
           :key="bot.id"
           :bot="bot"
           :selected="botStore.currentBot?.id === bot.id"
+          :earned-karma="earnedKarmaByBotId[bot.id]"
           v-bind="botCardProps"
           @select="selectBot"
           @edit="startEditingBotById"
@@ -339,6 +340,7 @@
             v-if="botById.get(Number(item.id))"
             :bot="botById.get(Number(item.id))!"
             :selected="botStore.currentBot?.id === item.id"
+            :earned-karma="earnedKarmaByBotId[Number(item.id)]"
             :variant="MODE_VARIANT[galleryMode]"
             v-bind="botCardProps"
             @select="selectBot"
@@ -603,6 +605,13 @@ const filteredBots = computed<Bot[]>(() => {
 
   return bots
 })
+
+// interface-vision/t-066: earned karma for the rendered set, batched through
+// the shared composable (see composables/useEarnedKarma.ts). Scoped to
+// filteredBots — the set the grid actually renders.
+const { earnedKarma: earnedKarmaByBotId } = useEarnedKarma('bot', () =>
+  filteredBots.value.map((bot) => bot.id),
+)
 
 onMounted(async () => {
   if (props.autoLoad) {

--- a/components/characters/character-card.vue
+++ b/components/characters/character-card.vue
@@ -9,6 +9,7 @@
     target-type="character"
     reaction-category="CHARACTER"
     :target-title="displayName"
+    :earned-karma="earnedKarma"
     @select="selectCharacter"
   >
     <template #actions>
@@ -203,6 +204,9 @@ const props = withDefaults(
      * utils/scripts/verifyGalleryConsistency.ts.
      */
     variant?: ArtVariant
+    /** Total karma this character has earned from reactions to it. Omit/undefined
+     *  renders no badge — see components/wonderlab/reactable-card.vue. */
+    earnedKarma?: number | null
   }>(),
   {
     variant: 'card',
@@ -223,6 +227,7 @@ const props = withDefaults(
     allowDelete: true,
     fallbackImage: '',
     imageFit: 'cover',
+    earnedKarma: undefined,
   },
 )
 

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -245,6 +245,7 @@
           :character="character"
           :selected="characterStore.selectedCharacter?.id === character.id"
           :is-selected="characterStore.selectedCharacter?.id === character.id"
+          :earned-karma="earnedKarmaByCharacterId[character.id]"
           v-bind="characterCardProps"
           @edit="startEditingCharacterById"
           @clone="cloneCharacterById"
@@ -267,6 +268,7 @@
             :character="characterById.get(Number(item.id))!"
             :selected="characterStore.selectedCharacter?.id === item.id"
             :is-selected="characterStore.selectedCharacter?.id === item.id"
+            :earned-karma="earnedKarmaByCharacterId[Number(item.id)]"
             :variant="MODE_VARIANT[galleryMode]"
             v-bind="characterCardProps"
             @edit="startEditingCharacterById"
@@ -522,6 +524,14 @@ const filteredCharacters = computed<Character[]>(() => {
 
   return characters
 })
+
+// interface-vision/t-066: earned karma for the rendered set, batched through
+// the shared composable (see composables/useEarnedKarma.ts). Scoped to
+// filteredCharacters — the set the grid actually renders.
+const { earnedKarma: earnedKarmaByCharacterId } = useEarnedKarma(
+  'character',
+  () => filteredCharacters.value.map((character) => character.id),
+)
 
 const exclusionSummary = computed(() => {
   const allCharacters = characterStore.characters ?? []

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -411,7 +411,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, ref } from 'vue'
 import type {
   ArtImage,
   Character,
@@ -427,24 +427,9 @@ import {
 import { useDreamStore, type DreamWithRelations } from '@/stores/dreamStore'
 import { useNavStore } from '@/stores/navStore'
 import { useUserStore } from '@/stores/userStore'
-import { performFetch } from '@/stores/utils'
 
-// interface-vision/t-048: batch-fetch earned karma for the broader visible
-// set (pre type/search refinement, same "don't re-fetch on every keystroke"
-// scoping as reward-gallery's reference wiring — see
-// components/rewards/reward-gallery.vue and
-// server/api/economy/karma-earned.post.ts for the endpoint). dream-gallery
-// has no paging concept (unlike art-gallery's pagedActiveImages), so the
-// broader galleryDreams set (filtered by ownership/mature/archived, not yet
-// by type/search) is the closest equivalent to a "rendered page".
-const KARMA_EARNED_BATCH_LIMIT = 200
-
-type KarmaEarnedRow = {
-  refType: string
-  refId: string
-  earnedKarma: number
-}
-
+// Earned karma comes from useEarnedKarma (t-066); the scoping decision below
+// is t-048's and is unchanged.
 type GalleryVariant = 'dashboard' | 'row' | 'dropdown'
 
 type DreamScenarioWithCharacters = Scenario & {
@@ -542,7 +527,6 @@ function closeSearchIfEmpty(): void {
 
 /** Which stored art the current mode asks dream-card for. */
 const modeVariant = computed(() => MODE_VARIANT[galleryMode.value])
-const earnedKarmaByDreamId = ref<Record<number, number>>({})
 
 const isDropdownMode = computed(() => props.variant === 'dropdown')
 const isRowMode = computed(() => props.variant === 'row')
@@ -651,52 +635,12 @@ const galleryDreams = computed<DreamWithRelations[]>(() => {
 })
 
 // Pre search/type refinement — those filters only narrow an already-fetched
-// set, so re-fetching on every keystroke would be wasted work.
-const visibleDreamIdsKey = computed(() =>
-  galleryDreams.value
-    .slice(0, KARMA_EARNED_BATCH_LIMIT)
-    .map((dream) => dream.id)
-    .join(','),
-)
-
-async function refreshEarnedKarma() {
-  const ids = galleryDreams.value
-    .slice(0, KARMA_EARNED_BATCH_LIMIT)
-    .map((dream) => dream.id)
-
-  if (!ids.length) {
-    earnedKarmaByDreamId.value = {}
-    return
-  }
-
-  const res = await performFetch<KarmaEarnedRow[]>(
-    '/api/economy/karma-earned',
-    {
-      method: 'POST',
-      body: JSON.stringify({
-        items: ids.map((id) => ({ refType: 'dream', refId: id })),
-      }),
-    },
-  )
-
-  if (!res.success || !Array.isArray(res.data)) return
-
-  const next: Record<number, number> = {}
-
-  for (const row of res.data) {
-    const id = Number(row.refId)
-    if (Number.isFinite(id)) next[id] = row.earnedKarma
-  }
-
-  earnedKarmaByDreamId.value = next
-}
-
-watch(
-  visibleDreamIdsKey,
-  () => {
-    void refreshEarnedKarma()
-  },
-  { immediate: true },
+// set, so re-fetching on every keystroke would be wasted work. dream-gallery
+// has no paging concept (unlike art-gallery's pagedActiveImages), so the
+// broader galleryDreams set (filtered by ownership/mature/archived, not yet by
+// type/search) is the closest equivalent to a "rendered page".
+const { earnedKarma: earnedKarmaByDreamId } = useEarnedKarma('dream', () =>
+  galleryDreams.value.map((dream) => dream.id),
 )
 
 const dreamTypes = computed(() => {

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -344,26 +344,18 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import type { Reward } from '~/prisma/generated/prisma/client'
 import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
 import { MODE_VARIANT, type GalleryMode } from '@/utils/galleryVocabulary'
 import { useRewardStore } from '@/stores/rewardStore'
 import type { Rarity } from '@/stores/rewardStore'
 import { useUserStore } from '@/stores/userStore'
-import { performFetch } from '@/stores/utils'
 
-// interface-vision/t-019 reference wiring: reward-gallery is the one list view
-// that batch-fetches earned karma for its cards (see
-// server/api/economy/karma-earned.post.ts). The remaining eleven
-// reactable-card consumers can copy this pattern.
-const KARMA_EARNED_BATCH_LIMIT = 200
-
-type KarmaEarnedRow = {
-  refType: string
-  refId: string
-  earnedKarma: number
-}
+// Earned karma comes from useEarnedKarma (t-066). This gallery wrote the first
+// copy of that fetch under t-019 and invited the other consumers to copy it;
+// the composable is that invitation answered properly, so there is one
+// implementation instead of twelve.
 
 type GalleryVariant = 'grid' | 'dashboard' | 'row' | 'dropdown'
 
@@ -413,7 +405,6 @@ const searchQuery = ref('')
 const isLoading = ref(false)
 const showRewardForm = ref(false)
 const formMode = ref<'add' | 'edit'>('add')
-const earnedKarmaByRewardId = ref<Record<number, number>>({})
 
 const rarityOrder: Record<Rarity, number> = {
   COMMON: 1,
@@ -534,52 +525,10 @@ const visibleRewards = computed<Reward[]>(() => {
 
 // Fetch earned karma for the broader visible set (pre search/collection/rarity
 // refinement) rather than re-fetching on every keystroke — those filters only
-// narrow an already-fetched set.
-const visibleRewardIdsKey = computed(() =>
-  visibleRewards.value
-    .slice(0, KARMA_EARNED_BATCH_LIMIT)
-    .map((reward) => reward.id)
-    .join(','),
-)
-
-async function refreshEarnedKarma() {
-  const ids = visibleRewards.value
-    .slice(0, KARMA_EARNED_BATCH_LIMIT)
-    .map((reward) => reward.id)
-
-  if (!ids.length) {
-    earnedKarmaByRewardId.value = {}
-    return
-  }
-
-  const res = await performFetch<KarmaEarnedRow[]>(
-    '/api/economy/karma-earned',
-    {
-      method: 'POST',
-      body: JSON.stringify({
-        items: ids.map((id) => ({ refType: 'reward', refId: id })),
-      }),
-    },
-  )
-
-  if (!res.success || !Array.isArray(res.data)) return
-
-  const next: Record<number, number> = {}
-
-  for (const row of res.data) {
-    const id = Number(row.refId)
-    if (Number.isFinite(id)) next[id] = row.earnedKarma
-  }
-
-  earnedKarmaByRewardId.value = next
-}
-
-watch(
-  visibleRewardIdsKey,
-  () => {
-    void refreshEarnedKarma()
-  },
-  { immediate: true },
+// narrow an already-fetched set. useEarnedKarma keys its watch on the id list,
+// so a refilter that yields the same rewards does not re-request.
+const { earnedKarma: earnedKarmaByRewardId } = useEarnedKarma('reward', () =>
+  visibleRewards.value.map((reward) => reward.id),
 )
 
 const collections = computed(() => {

--- a/components/scenarios/scenario-card.vue
+++ b/components/scenarios/scenario-card.vue
@@ -9,6 +9,7 @@
     target-type="scenario"
     reaction-category="SCENARIO"
     :target-title="scenarioTitle"
+    :earned-karma="earnedKarma"
     @select="selectScenario"
   >
     <template #actions>
@@ -112,6 +113,9 @@ const props = withDefaults(
      * the identical portrait card. Same prop, same default, as dream-card.
      */
     variant?: ArtVariant
+    /** Total karma this scenario has earned from reactions to it. Omit/undefined
+     *  renders no badge — see components/wonderlab/reactable-card.vue. */
+    earnedKarma?: number | null
   }>(),
   {
     selected: false,
@@ -127,6 +131,7 @@ const props = withDefaults(
     allowClone: true,
     variant: 'card',
     fallbackImage: '/images/scenarios/space.webp',
+    earnedKarma: undefined,
   },
 )
 

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -234,6 +234,7 @@
             :key="scenario.id"
             :scenario="scenario"
             :selected="scenarioStore.selectedScenario?.id === scenario.id"
+            :earned-karma="earnedKarmaByScenarioId[scenario.id]"
             v-bind="scenarioCardProps"
             @edit="startEditingScenarioById"
             @clone="cloneScenarioById"
@@ -258,6 +259,7 @@
               v-if="scenarioById.get(Number(item.id))"
               :scenario="scenarioById.get(Number(item.id))!"
               :selected="scenarioStore.selectedScenario?.id === item.id"
+              :earned-karma="earnedKarmaByScenarioId[Number(item.id)]"
               :variant="MODE_VARIANT[galleryMode]"
               v-bind="scenarioCardProps"
               @edit="startEditingScenarioById"
@@ -496,6 +498,14 @@ const filteredScenarios = computed<ScenarioWithRelations[]>(() => {
     )
   })
 })
+
+// interface-vision/t-066: earned karma for the rendered set, batched through
+// the shared composable (see composables/useEarnedKarma.ts). Scoped to
+// filteredScenarios — the set the grid actually renders.
+const { earnedKarma: earnedKarmaByScenarioId } = useEarnedKarma(
+  'scenario',
+  () => filteredScenarios.value.map((scenario) => scenario.id),
+)
 
 const selectedScenarioCharacters = computed(() => {
   return scenarioStore.selectedScenario?.Characters ?? []

--- a/composables/useEarnedKarma.ts
+++ b/composables/useEarnedKarma.ts
@@ -1,0 +1,105 @@
+// /composables/useEarnedKarma.ts
+//
+// interface-vision/t-066: one batch-fetch of earned karma for a gallery's
+// visible cards, shared by every reactable-card consumer.
+//
+// reward-gallery wrote this first (t-019) and its comment invited the other
+// eleven consumers to "copy this pattern." Two did — art-gallery (t-046) and
+// dream-gallery (t-048) — and by the third copy the pattern had already
+// drifted: two clamped to a 200-item batch and one did not, so a gallery
+// rendering more than 200 cards would have taken a 400 from the endpoint
+// instead of showing karma. Copying is how that happens; this is the pattern
+// as a function instead.
+//
+// SCOPING IS THE CALLER'S JOB. `visibleIds` should return the RENDERED set,
+// not the whole store — a page of art, not every image the user owns. It is a
+// getter rather than a ref so callers can pass a computed slice directly, and
+// the watch keys on the resulting id list, not on array identity, so
+// re-filtering that produces the same cards does not re-fetch.
+import { computed, ref, watch, type Ref } from 'vue'
+import { performFetch } from '@/stores/utils'
+import {
+  KARMA_EARNED_BATCH_LIMIT,
+  type KarmaRefType,
+} from '@/utils/karmaRefTypes'
+
+type KarmaEarnedRow = {
+  refType: string
+  refId: string
+  earnedKarma: number
+}
+
+export type UseEarnedKarma = {
+  /** Earned totals by object id. Ids absent from the map render nothing. */
+  earnedKarma: Ref<Record<number, number>>
+  /** Re-fetch now, e.g. after the user reacts to a card on this page. */
+  refresh: () => Promise<void>
+}
+
+export function useEarnedKarma(
+  refType: KarmaRefType,
+  visibleIds: () => ReadonlyArray<number | string | null | undefined>,
+): UseEarnedKarma {
+  const earnedKarma = ref<Record<number, number>>({})
+
+  // Deduplicate BEFORE clamping: a list holding the same id twice should not
+  // consume two of the 200 slots, and the endpoint drops duplicates anyway.
+  function batchIds(): number[] {
+    const ids = new Set<number>()
+
+    for (const raw of visibleIds()) {
+      const id = Number(raw)
+      if (!Number.isFinite(id)) continue
+      ids.add(id)
+      if (ids.size >= KARMA_EARNED_BATCH_LIMIT) break
+    }
+
+    return Array.from(ids)
+  }
+
+  const batchKey = computed(() => batchIds().join(','))
+
+  async function refresh(): Promise<void> {
+    const ids = batchIds()
+
+    if (!ids.length) {
+      earnedKarma.value = {}
+      return
+    }
+
+    const res = await performFetch<KarmaEarnedRow[]>(
+      '/api/economy/karma-earned',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          items: ids.map((id) => ({ refType, refId: id })),
+        }),
+      },
+    )
+
+    // A failed request (offline, or 401 for a signed-out visitor) leaves the
+    // previous totals in place rather than blanking every card — karma is
+    // decoration here, and flickering it off on a transient error is worse
+    // than showing a slightly stale number.
+    if (!res.success || !Array.isArray(res.data)) return
+
+    const next: Record<number, number> = {}
+
+    for (const row of res.data) {
+      const id = Number(row.refId)
+      if (Number.isFinite(id)) next[id] = row.earnedKarma
+    }
+
+    earnedKarma.value = next
+  }
+
+  watch(
+    batchKey,
+    () => {
+      void refresh()
+    },
+    { immediate: true },
+  )
+
+  return { earnedKarma, refresh }
+}

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "test:channel-content": "tsx utils/scripts/verifyChannelContent.ts",
     "test:gallery-adoption": "tsx utils/scripts/verifyGalleryAdoption.ts",
     "test:gallery-consistency": "tsx utils/scripts/verifyGalleryConsistency.ts",
+    "test:earned-karma-wiring": "tsx utils/scripts/verifyEarnedKarmaWiring.ts",
     "test:channel-resolver": "tsx utils/scripts/verifyChannelResolver.ts",
     "test:data-surface-manifest": "tsx utils/scripts/verifyDataSurfaceManifest.ts",
     "test:nav-manifest": "tsx utils/scripts/verifyNavManifest.ts",

--- a/server/api/economy/karma-earned.post.ts
+++ b/server/api/economy/karma-earned.post.ts
@@ -17,25 +17,17 @@ import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
+import {
+  KARMA_EARNED_BATCH_LIMIT,
+  KARMA_REF_TYPES,
+} from '@/utils/karmaRefTypes'
 
-// Keep in sync with ReactionTargetType (stores/reactionStore.ts) — the only
-// refType values any award call site currently writes.
-const ALLOWED_REF_TYPES = new Set([
-  'artImage',
-  'artCollection',
-  'bot',
-  'character',
-  'chat',
-  'component',
-  'dream',
-  'prompt',
-  'resource',
-  'reward',
-  'scenario',
-  'theme',
-])
+// t-066: this list and ReactionTargetType (stores/reactionStore.ts) used to be
+// two hand-maintained copies joined by a "keep in sync" comment. They are now
+// the same values — see utils/karmaRefTypes.ts for why these twelve.
+const ALLOWED_REF_TYPES = new Set<string>(KARMA_REF_TYPES)
 
-const BATCH_LIMIT = 200
+const BATCH_LIMIT = KARMA_EARNED_BATCH_LIMIT
 
 type KarmaEarnedRequestItem = {
   refType?: unknown

--- a/stores/reactionStore.ts
+++ b/stores/reactionStore.ts
@@ -6,6 +6,7 @@ import type {
   ReactionType,
   Reaction_reactionCategory,
 } from '~/prisma/generated/prisma/client'
+import type { KarmaRefType } from '~/utils/karmaRefTypes'
 import { performFetch, handleError } from './utils'
 import { useAchievementStore } from './achievementStore'
 import { useUserStore } from './userStore'
@@ -38,19 +39,10 @@ export const reactionCategories: ReactionCategoryEnum[] = [
   'THEME',
 ]
 
-export type ReactionTargetType =
-  | 'artImage'
-  | 'artCollection'
-  | 'bot'
-  | 'character'
-  | 'chat'
-  | 'component'
-  | 'dream'
-  | 'prompt'
-  | 'resource'
-  | 'reward'
-  | 'scenario'
-  | 'theme'
+// t-066: a reaction target and a karma-earning object are the same set by
+// construction — the REACTION_RECEIVED award derives refType straight from the
+// reaction's target field. See utils/karmaRefTypes.ts.
+export type ReactionTargetType = KarmaRefType
 
 type ReactionFetchKey = `${ReactionTargetType}:${number}`
 

--- a/utils/karmaRefTypes.ts
+++ b/utils/karmaRefTypes.ts
@@ -1,0 +1,52 @@
+// /utils/karmaRefTypes.ts
+//
+// interface-vision/t-066: the one definition of "which objects can earn karma."
+//
+// This list used to exist three times: as ALLOWED_REF_TYPES in
+// server/api/economy/karma-earned.post.ts (guarded by a `// Keep in sync with
+// ReactionTargetType` comment), as ReactionTargetType in
+// stores/reactionStore.ts, and implicitly in getExpectedTargetField's map in
+// server/api/reactions/index.post.ts. A comment is not a constraint; this
+// module makes the first two the same values, so a new reaction target can't
+// be added to one and silently missed by the other.
+//
+// WHY THESE TWELVE. KarmaTransaction.refType is never written by hand. The
+// only award call site that sets it (server/api/reactions/index.post.ts,
+// REACTION_RECEIVED) derives it generically from the reaction's target field —
+// `botId` becomes `bot`, `artImageId` becomes `artImage`. So the set of types
+// that can earn karma IS the set of reaction target fields, by construction;
+// there is no per-type award wiring to add before a gallery can display a
+// total. (The two hand-written refType call sites, 'prompt' and 'artImage' in
+// server/api/prompts/, both name types already in this list.)
+
+/** Every object type that a KarmaTransaction can be attributed to. */
+export const KARMA_REF_TYPES = [
+  'artImage',
+  'artCollection',
+  'bot',
+  'character',
+  'chat',
+  'component',
+  'dream',
+  'prompt',
+  'resource',
+  'reward',
+  'scenario',
+  'theme',
+] as const
+
+export type KarmaRefType = (typeof KARMA_REF_TYPES)[number]
+
+/**
+ * Maximum items in one /api/economy/karma-earned request. The endpoint rejects
+ * a larger batch with a 400, so callers must clamp to the same number — hence
+ * it lives here rather than being restated on each side.
+ */
+export const KARMA_EARNED_BATCH_LIMIT = 200
+
+export function isKarmaRefType(value: unknown): value is KarmaRefType {
+  return (
+    typeof value === 'string' &&
+    (KARMA_REF_TYPES as readonly string[]).includes(value)
+  )
+}

--- a/utils/scripts/verifyEarnedKarmaWiring.ts
+++ b/utils/scripts/verifyEarnedKarmaWiring.ts
@@ -1,0 +1,170 @@
+// /utils/scripts/verifyEarnedKarmaWiring.ts
+//
+// interface-vision/t-066. Two contracts, both of which were violated in
+// practice before this file existed.
+//
+// 1. ONE FETCH. /api/economy/karma-earned is requested from exactly one place
+//    on the client: composables/useEarnedKarma.ts. reward-gallery wrote the
+//    first copy under t-019 and its comment invited "the remaining eleven
+//    reactable-card consumers" to copy it. Two did, and by the third copy they
+//    had already diverged — two clamped to the endpoint's 200-item batch limit
+//    and one did not, so a gallery rendering more than 200 cards would have
+//    taken a 400 instead of showing karma. That is what copy-the-pattern buys;
+//    this check is what stops the twelfth copy.
+//
+// 2. THE REF TYPES ARE THE REACTION TARGETS. utils/karmaRefTypes.ts claims the
+//    set of karma-earning types is the set of reaction target fields "by
+//    construction," because the only award call site that writes refType
+//    derives it from the target field (`botId` -> `bot`). That claim is load
+//    bearing: it is why a new gallery needs no per-type award wiring before it
+//    can show a total. Here it is checked against the map it describes, so
+//    adding a reaction category without a karma refType (or the reverse) fails
+//    instead of silently producing cards whose karma is always zero.
+//
+//   npx tsx utils/scripts/verifyEarnedKarmaWiring.ts
+import { readFile } from 'node:fs/promises'
+import { readdirSync, statSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
+import { KARMA_REF_TYPES } from '../karmaRefTypes'
+import { containsCode } from './lib/sourceText'
+
+const root = process.cwd()
+
+/** The endpoint path, as it appears in a fetch call. */
+const ENDPOINT = '/api/economy/karma-earned'
+
+/** The single client-side owner of that fetch. */
+const OWNER = 'composables/useEarnedKarma.ts'
+
+/** Where the server derives refType from the reaction's target field. */
+const REACTION_ROUTE = 'server/api/reactions/index.post.ts'
+
+/** Client trees a gallery could plausibly fetch from. */
+const CLIENT_DIRS = ['components', 'composables', 'pages', 'stores', 'utils']
+
+const SKIP_DIRS = new Set(['node_modules', '.nuxt', '.output', 'dist'])
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry)) continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) walk(full, out)
+    else if (/\.(ts|vue)$/.test(entry)) out.push(full)
+  }
+  return out
+}
+
+/**
+ * The refTypes the reaction route can actually produce, read out of
+ * getExpectedTargetField's map: each `[Reaction_reactionCategory.X]: 'fooId'`
+ * entry yields `foo`. Entries mapped to `null` (MESSAGE) name no object and
+ * are correctly absent from the karma list.
+ */
+function reactionRefTypes(source: string): string[] {
+  const map = source.slice(
+    source.indexOf('function getExpectedTargetField'),
+    source.indexOf('function buildTargetWhere'),
+  )
+
+  if (!map) throw new Error(`Could not locate getExpectedTargetField in ${REACTION_ROUTE}.`)
+
+  return Array.from(map.matchAll(/:\s*'([a-zA-Z]+)Id'/g)).map(
+    (match) => match[1] as string,
+  )
+}
+
+function sorted(values: readonly string[]): string[] {
+  return [...values].sort((a, b) => a.localeCompare(b))
+}
+
+/**
+ * Mutation check for the parser above, per the t-063 rule that a checker only
+ * ever seen to pass is indistinguishable from one that cannot fail. A map
+ * missing an entry must be reported as missing, not silently tolerated.
+ */
+function verifyReactionRefTypesFixture(): void {
+  const fixture = `function getExpectedTargetField(category: X) {
+  const map = {
+    [X.BOT]: 'botId',
+    [X.ART_IMAGE]: 'artImageId',
+    [X.MESSAGE]: null,
+  }
+  return map[category] ?? null
+}
+function buildTargetWhere() {}`
+
+  const found = sorted(reactionRefTypes(fixture))
+  const expected = ['artImage', 'bot']
+
+  if (JSON.stringify(found) !== JSON.stringify(expected)) {
+    throw new Error(
+      `Self-test failed: parsed [${found.join(', ')}], expected [${expected.join(', ')}].`,
+    )
+  }
+}
+
+async function main(): Promise<void> {
+  verifyReactionRefTypesFixture()
+
+  const failures: string[] = []
+
+  /* --- contract 1: one fetch ------------------------------------------- */
+
+  const offenders: string[] = []
+
+  for (const dir of CLIENT_DIRS) {
+    for (const file of walk(resolve(root, dir))) {
+      const rel = relative(root, file).replace(/\\/g, '/')
+      if (rel === OWNER) continue
+      // This verifier names the endpoint in prose; so may a comment pointing
+      // a reader at the composable. Only real code counts.
+      if (rel.startsWith('utils/scripts/')) continue
+      if (containsCode(await readFile(file, 'utf8'), ENDPOINT)) offenders.push(rel)
+    }
+  }
+
+  if (offenders.length) {
+    failures.push(
+      `${ENDPOINT} must be requested only from ${OWNER}, but these fetch it directly:\n` +
+        offenders.map((path) => `    - ${path}`).join('\n') +
+        `\n  Use useEarnedKarma(refType, () => visibleIds) instead of a new copy.`,
+    )
+  }
+
+  /* --- contract 2: refTypes are the reaction targets -------------------- */
+
+  const route = await readFile(resolve(root, REACTION_ROUTE), 'utf8')
+  const fromReactions = sorted(reactionRefTypes(route))
+  const declared = sorted(KARMA_REF_TYPES)
+
+  const missing = fromReactions.filter((type) => !declared.includes(type))
+  const extra = declared.filter((type) => !fromReactions.includes(type))
+
+  if (missing.length) {
+    failures.push(
+      `${REACTION_ROUTE} can award karma to [${missing.join(', ')}], which utils/karmaRefTypes.ts ` +
+        `does not list — the endpoint would reject those objects with a 400.`,
+    )
+  }
+
+  if (extra.length) {
+    failures.push(
+      `utils/karmaRefTypes.ts lists [${extra.join(', ')}], which no reaction category targets — ` +
+        `a gallery wired to one would show a permanent zero.`,
+    )
+  }
+
+  if (failures.length) {
+    throw new Error(`Earned-karma wiring contract failed:\n- ${failures.join('\n- ')}`)
+  }
+
+  process.stdout.write(
+    `Earned-karma wiring verified: one fetch (${OWNER}), ` +
+      `${declared.length} refTypes matching ${REACTION_ROUTE}'s reaction targets.\n`,
+  )
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## What

reward-gallery wrote the earned-karma batch-fetch under t-019, and its comment invited *"the remaining eleven reactable-card consumers"* to copy the pattern. Two did — art-gallery (t-046) and dream-gallery (t-048).

By the third copy it had already drifted: **two clamped to the endpoint's 200-item batch limit and one did not**, so a gallery rendering more than 200 cards would have taken a 400 from `/api/economy/karma-earned` instead of showing karma. That is what "copy this pattern" buys.

So instead of writing a fourth copy, this replaces the three with `composables/useEarnedKarma.ts` and wires the galleries that were still unwired.

## Galleries: 3 → 7

| Gallery | refType | Status |
|---|---|---|
| reward | `reward` | moved onto composable |
| art (images) | `artImage` | moved onto composable |
| dream | `dream` | moved onto composable |
| bot | `bot` | **new** |
| character | `character` | **new** |
| scenario | `scenario` | **new** |
| art (collections) | `artCollection` | **new** |

The four new ones needed an `earnedKarma` prop threaded through their cards (`bot-card`, `character-card`, `scenario-card`, `collection-card`) down to `reactable-card`, the way `reward-card` already did. Each defaults to `undefined`, which renders no badge.

Deliberately skipped: `dream-list`'s scenario cards and `scenario-gallery`'s cast grid both pass `show-reaction="false"`, so there is no badge to populate. `model`/`lora`/`checkpoint` are not reaction targets at all.

## The check the task note asked for

The note said to check `server/utils/karma.ts` award call sites before assuming a type could earn karma. **It can, for all twelve** — the only call site that writes `refType` (`REACTION_RECEIVED`) derives it generically from the reaction's target field, `botId` → `bot`. So the karma-earning types *are* the reaction targets, by construction, and no per-type award wiring was needed for any of them.

## Collapsing the duplicated type lists

That finding made the duplication worth removing. `ALLOWED_REF_TYPES` (server) and `ReactionTargetType` (client store) were two hand-maintained copies of the same twelve values, joined by a `// Keep in sync with…` comment. Both now read `utils/karmaRefTypes.ts`, which also owns the batch limit the two sides have to agree on.

## New contract: `test:earned-karma-wiring`

A comment is not a constraint, so `utils/scripts/verifyEarnedKarmaWiring.ts` holds two invariants:

1. **One fetch.** Exactly one client-side file requests the endpoint. This is what stops the twelfth copy.
2. **RefTypes are the reaction targets.** The declared list is checked against `getExpectedTargetField`'s map, so a new reaction category can't ship a gallery whose karma is permanently zero (or a refType the endpoint 400s on).

Mutation-verified against all three failure modes rather than only observed to pass, per t-063:

```
drop a refType reactions can award  → fails, names `chat`
add a refType nothing targets       → fails, names `sandwich`
a gallery hand-rolls the fetch      → fails, names the file
restored                            → passes
```

## Verification

- `npm run test` (vue-tsc) — clean
- `test:earned-karma-wiring` — passes, mutation-verified above
- `test:gallery-adoption`, `test:gallery-consistency`, `test:layout-contract`, `test:nav-manifest`, `test:channel-content` — all pass; layout contract still at zero
- `npx eslint` on all touched files — **no new errors**; the 6 remaining are the pre-existing set t-099 tracks

Not verified from source: the badges' appearance on the four newly-wired galleries. They reuse `reactable-card`'s existing badge, which already renders on reward/art/dream, so the risk is low — but preview eyes on `/bots`, `/characters`, and `/scenarios` would confirm.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_