### PR TITLE
t-100: catch stored art paths that serve the app shell at HTTP 200

### DIFF
--- a/.github/workflows/stored-art-paths.yml
+++ b/.github/workflows/stored-art-paths.yml
@@ -1,0 +1,98 @@
+# Stored art paths must serve real images.
+#
+# interface-vision/t-100. Every one of the 227 Reward.imagePath values was
+# stored as `/rewards/...` when the files live at `/images/rewards/...` (#1446).
+# 214 of them served a 142 KB Nuxt app shell as text/html — at HTTP **200**,
+# because a missing asset under a non-/images path falls through to the SPA
+# catch-all instead of 404ing. curl, uptime monitors and link checkers all read
+# that as healthy. The layout audit could not see it either: kr-art-plate caught
+# the decode failure and swapped in its fallback, exactly as designed, so the
+# page looked fine while the art was wrong.
+#
+# This job asks the one question none of those ask — does the stored path
+# actually return image bytes?
+#
+# Nightly rather than per-PR: it is a check on DATA, which changes when rows are
+# written, not when code merges. A PR cannot introduce a bad stored path, and a
+# few hundred requests per run is not something to spend on every push.
+#
+# FAILS ON: a 2xx whose content-type is not an image (the silent path bug).
+# REPORTS ONLY: a genuine 404 — that is art backlog, expected and self-healing.
+#
+# Requires the same repository Actions secrets as fallback-snapshot.yml. The DB
+# host is a tailnet address, so without the Tailscale step this fails with a
+# misleading 10s Prisma pool timeout (`active=0 idle=0`) that reads like a dead
+# database rather than an unrouted one.
+name: Stored art paths
+
+on:
+  schedule:
+    - cron: '43 10 * * *' # daily, 10:43 UTC ≈ 2:43am Pacific
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Base URL to check against (defaults to production)'
+        required: false
+        default: ''
+
+concurrency:
+  group: stored-art-paths
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # ProxySQL enforces TLS; the adapter shared with server/utils/prisma.ts
+      # reads this CA to complete the handshake. Either form works.
+      DATABASE_SSL_CA_BASE64: ${{ secrets.DATABASE_SSL_CA_BASE64 }}
+      DATABASE_SSL_CA: ${{ secrets.DATABASE_SSL_CA }}
+      BASE_URL: ${{ github.event.inputs.base_url }}
+    steps:
+      - name: Require secrets
+        env:
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "::error::DATABASE_URL is empty. Add it as a REPOSITORY ACTIONS SECRET (repo Settings → Secrets and variables → Actions). Vercel env vars and .env files do not resolve here."
+            exit 1
+          fi
+          if [ -z "$TS_OAUTH_CLIENT_ID" ] || [ -z "$TS_OAUTH_SECRET" ]; then
+            echo "::error::TS_OAUTH_CLIENT_ID / TS_OAUTH_SECRET are empty. The database host is a tailnet address; without them this fails as a Prisma pool timeout that looks like a dead database."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      # Proves the classifier can still tell an app shell from an image before
+      # it is trusted to make that call about production. A checker only ever
+      # seen to pass is indistinguishable from one that cannot fail (t-063).
+      - name: Self-test the classifier
+        run: npx tsx utils/scripts/verifyStoredArtPaths.ts --self-test
+
+      # Placed after the npm/prisma steps so the tailnet session stays short —
+      # only the sweep itself needs the database.
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Sweep stored art paths
+        run: npx tsx utils/scripts/verifyStoredArtPaths.ts

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "test:gallery-adoption": "tsx utils/scripts/verifyGalleryAdoption.ts",
     "test:gallery-consistency": "tsx utils/scripts/verifyGalleryConsistency.ts",
     "test:earned-karma-wiring": "tsx utils/scripts/verifyEarnedKarmaWiring.ts",
+    "test:stored-art-paths": "tsx utils/scripts/verifyStoredArtPaths.ts",
+    "test:stored-art-paths:self": "tsx utils/scripts/verifyStoredArtPaths.ts --self-test",
     "test:channel-resolver": "tsx utils/scripts/verifyChannelResolver.ts",
     "test:data-surface-manifest": "tsx utils/scripts/verifyDataSurfaceManifest.ts",
     "test:nav-manifest": "tsx utils/scripts/verifyNavManifest.ts",

--- a/utils/scripts/verifyStoredArtPaths.ts
+++ b/utils/scripts/verifyStoredArtPaths.ts
@@ -1,0 +1,332 @@
+// /utils/scripts/verifyStoredArtPaths.ts
+//
+// interface-vision/t-100: catch stored art paths that serve something other
+// than an image, which no status-code check can see.
+//
+// THE DEFECT THIS EXISTS FOR. Every one of the 227 Reward.imagePath values was
+// stored as `/rewards/...` when the files live at `/images/rewards/...`
+// (kind_robots #1446). 214 of them served a 142 KB Nuxt app shell as
+// `text/html` — at HTTP **200**, because `/rewards/x.webp` does not 404, it
+// falls through to the SPA catch-all. curl, uptime monitors and link checkers
+// all read that as healthy. Only a consumer that inspects what came back can
+// tell, so that is what this does: it asserts the RESPONSE IS AN IMAGE, not
+// that the request succeeded.
+//
+// WHY THE LAYOUT AUDIT DID NOT CATCH IT. auditResponsiveLayout.mjs flags an
+// `<img>` whose naturalWidth is 0, which measures whether the UI broke. It
+// didn't: kr-art-plate caught the decode failure and swapped in its fallback,
+// exactly as designed. The art was wrong and the page still looked fine. That
+// is a different question from this one, and it needs a different check.
+//
+// WHAT COUNTS AS FAILURE. Only a 2xx whose content-type is not an image. A
+// 404 means the file is genuinely absent from the media host — art backlog,
+// which is expected and self-healing, and is reported but never fails the run.
+// Conflating the two would make this checker cry wolf on every gap in the art
+// queue and get it switched off.
+//
+//   npx tsx utils/scripts/verifyStoredArtPaths.ts                  # report
+//   npx tsx utils/scripts/verifyStoredArtPaths.ts --self-test      # no DB
+//   BASE_URL=https://preview.example npx tsx utils/scripts/verifyStoredArtPaths.ts
+//
+// The database is not reachable from an agent sandbox (TCP to the ProxySQL
+// port is blocked), so real runs happen in
+// .github/workflows/stored-art-paths.yml, which joins the tailnet first.
+import 'dotenv/config'
+import { PrismaClient } from './../../prisma/generated/prisma/client'
+import { createDatabaseAdapter } from './../../server/utils/databaseAdapterConfig'
+
+// Matches responsive-layout-audit.yml's production fallback, so both checks
+// measure the same deployment.
+const DEFAULT_BASE = 'https://kind-robots.vercel.app'
+
+/** How many paths to have in flight. 227 paths took ~90s at 12. */
+const CONCURRENCY = 12
+
+export type ArtPathVerdict =
+  /** A real image came back. */
+  | 'image'
+  /** 2xx, but not an image — the silent defect this script exists for. */
+  | 'shell'
+  /** Genuinely absent from the media host: art backlog, not a path bug. */
+  | 'missing'
+  /** Server-side failure; worth reporting, not attributable to the path. */
+  | 'error'
+
+/**
+ * The whole judgement, as a pure function of what came back, so it can be
+ * exercised without a database or a network (see --self-test).
+ *
+ * `status` 0 means the request never completed.
+ */
+export function classifyArtResponse(
+  status: number,
+  contentType: string | null,
+): ArtPathVerdict {
+  if (status === 404 || status === 410) return 'missing'
+  if (status < 200 || status >= 300) return 'error'
+
+  const type = (contentType ?? '').split(';')[0]?.trim().toLowerCase() ?? ''
+
+  // An empty content-type on a 200 is not provably an image, and the app shell
+  // case proves "2xx" alone means nothing. Require the positive signal.
+  return type.startsWith('image/') ? 'image' : 'shell'
+}
+
+/**
+ * Which stored values this script is responsible for. A path that is served by
+ * an API route (`/api/art/...`) or by an absolute URL is out of scope — those
+ * are generated at read time and cannot carry a stale stored prefix.
+ */
+export function isCheckableArtPath(value: unknown): value is string {
+  if (typeof value !== 'string') return false
+  const path = value.trim()
+  if (!path.startsWith('/')) return false
+  if (path.startsWith('/api/')) return false
+  return true
+}
+
+/** Runs `worker` over `items` with at most `limit` in flight. */
+async function mapLimited<T, R>(
+  items: readonly T[],
+  limit: number,
+  worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length)
+  let cursor = 0
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, async () => {
+      for (;;) {
+        const index = cursor++
+        if (index >= items.length) return
+        results[index] = await worker(items[index] as T)
+      }
+    }),
+  )
+
+  return results
+}
+
+async function probe(base: string, path: string): Promise<ArtPathVerdict> {
+  // GET, not HEAD: the SPA catch-all is a rendered response, and a HEAD against
+  // it has been seen to answer differently from the GET a browser actually
+  // makes. Check the thing the user's browser gets.
+  const res = await fetch(`${base}${path}`, {
+    method: 'GET',
+    redirect: 'follow',
+    headers: { accept: 'image/*,*/*' },
+  }).catch(() => null)
+
+  if (!res) return 'error'
+  // The body is not needed; releasing it keeps sockets from piling up.
+  await res.body?.cancel().catch(() => {})
+
+  return classifyArtResponse(res.status, res.headers.get('content-type'))
+}
+
+/* ------------------------------------------------------------------------ */
+
+function selfTest(): void {
+  const cases: Array<[number, string | null, ArtPathVerdict]> = [
+    // The exact production defect: 200, but the Nuxt app shell.
+    [200, 'text/html; charset=utf-8', 'shell'],
+    [200, 'text/html', 'shell'],
+    [200, null, 'shell'],
+    [200, '', 'shell'],
+    [200, 'application/json', 'shell'],
+    // Real art, including through the /images 307 to the media host.
+    [200, 'image/webp', 'image'],
+    [200, 'image/png', 'image'],
+    [200, 'IMAGE/JPEG', 'image'],
+    [200, 'image/svg+xml; charset=utf-8', 'image'],
+    [206, 'image/webp', 'image'],
+    // Absent from the media host: backlog, not a path bug.
+    [404, 'text/html', 'missing'],
+    [410, 'text/html', 'missing'],
+    // Everything else.
+    [500, 'text/html', 'error'],
+    [403, 'text/html', 'error'],
+    [0, null, 'error'],
+  ]
+
+  for (const [status, contentType, expected] of cases) {
+    const actual = classifyArtResponse(status, contentType)
+    if (actual !== expected) {
+      throw new Error(
+        `classifyArtResponse(${status}, ${JSON.stringify(contentType)}) = ` +
+          `${actual}, expected ${expected}`,
+      )
+    }
+  }
+
+  for (const checkable of ['/images/rewards/x.webp', '/rewards/x.webp']) {
+    if (!isCheckableArtPath(checkable)) {
+      throw new Error(`${checkable} should be checkable`)
+    }
+  }
+
+  for (const skipped of [
+    '/api/art/images/14913/file?v=2', // generated at read time
+    'https://media.acrocatranch.com/images/x.webp',
+    'images/x.webp', // not the stored shape
+    '',
+    null,
+    42,
+  ]) {
+    if (isCheckableArtPath(skipped)) {
+      throw new Error(`${JSON.stringify(skipped)} should be skipped`)
+    }
+  }
+
+  console.log('✅ verifyStoredArtPaths self-test passed.')
+}
+
+/* ------------------------------------------------------------------------ */
+
+type Source = {
+  label: string
+  rows: () => Promise<Array<Record<string, unknown>>>
+}
+
+async function collect(prisma: PrismaClient): Promise<Map<string, string[]>> {
+  // Every model whose stored art the site renders directly. cardPath/heroPath/
+  // iconPath are deliberately included: they are the columns t-064 added, and
+  // the same prefix mistake is available to them.
+  const art = {
+    imagePath: true,
+    cardPath: true,
+    heroPath: true,
+    iconPath: true,
+  }
+
+  const sources: Source[] = [
+    { label: 'Reward', rows: () => prisma.reward.findMany({ select: art }) },
+    {
+      label: 'Bot',
+      rows: () =>
+        prisma.bot.findMany({ select: { ...art, avatarImage: true } }),
+    },
+    {
+      label: 'Character',
+      rows: () => prisma.character.findMany({ select: art }),
+    },
+    { label: 'Dream', rows: () => prisma.dream.findMany({ select: art }) },
+    {
+      label: 'Scenario',
+      rows: () => prisma.scenario.findMany({ select: art }),
+    },
+    { label: 'Facet', rows: () => prisma.facet.findMany({ select: art }) },
+    {
+      label: 'ArtCollection',
+      rows: () =>
+        prisma.artCollection.findMany({ select: { imagePath: true } }),
+    },
+  ]
+
+  // path -> which models store it, so a failure names something actionable.
+  const byPath = new Map<string, string[]>()
+
+  for (const source of sources) {
+    for (const row of await source.rows()) {
+      for (const value of Object.values(row)) {
+        if (!isCheckableArtPath(value)) continue
+        const path = value.trim()
+        const owners = byPath.get(path) ?? []
+        if (!owners.includes(source.label)) owners.push(source.label)
+        byPath.set(path, owners)
+      }
+    }
+  }
+
+  return byPath
+}
+
+async function main(): Promise<void> {
+  if (process.argv.includes('--self-test')) {
+    selfTest()
+    return
+  }
+
+  // Always self-test before a real run: a sweep whose classifier is wrong is
+  // worse than no sweep, because it reports confidence it has not earned.
+  selfTest()
+
+  const base = (process.env.BASE_URL || DEFAULT_BASE).replace(/\/$/, '')
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) throw new Error('DATABASE_URL is missing')
+
+  const prisma = new PrismaClient({
+    adapter: createDatabaseAdapter(databaseUrl),
+  })
+  const byPath = await collect(prisma)
+  await prisma.$disconnect()
+
+  const paths = Array.from(byPath.keys()).sort()
+  console.log(
+    `📜 Checking ${paths.length} distinct stored art path(s) against ${base}`,
+  )
+
+  const verdicts = await mapLimited(paths, CONCURRENCY, (path) =>
+    probe(base, path),
+  )
+
+  const shell: string[] = []
+  const missing: string[] = []
+  const failed: string[] = []
+  let ok = 0
+
+  for (const [index, verdict] of verdicts.entries()) {
+    const path = paths[index] as string
+    const owners = byPath.get(path)?.join(', ') ?? '?'
+    if (verdict === 'image') ok += 1
+    else if (verdict === 'shell') shell.push(`${path}  [${owners}]`)
+    else if (verdict === 'missing') missing.push(`${path}  [${owners}]`)
+    else failed.push(`${path}  [${owners}]`)
+  }
+
+  console.log(
+    `\n   ✅ ${ok} serving an image` +
+      `\n   ❌ ${shell.length} serving a non-image at 2xx` +
+      `\n   🕳  ${missing.length} absent from the media host (art backlog)` +
+      `\n   ⚠️  ${failed.length} could not be checked`,
+  )
+
+  if (missing.length) {
+    console.log(`\n🕳  Missing art — expected and self-healing, not a failure:`)
+    for (const entry of missing.slice(0, 20)) console.log(`     ${entry}`)
+    if (missing.length > 20)
+      console.log(`     …and ${missing.length - 20} more`)
+  }
+
+  if (failed.length) {
+    console.log(`\n⚠️  Unreachable:`)
+    for (const entry of failed.slice(0, 20)) console.log(`     ${entry}`)
+  }
+
+  if (shell.length) {
+    console.log(
+      `\n❌ ${shell.length} stored path(s) return 2xx with a non-image body.` +
+        `\n   This is the silent failure mode: the request "succeeds", so every` +
+        `\n   status-code check reads it as healthy, while users get the app` +
+        `\n   shell where art should be. Check the stored prefix — /images is` +
+        `\n   the root that 307s to the media host.\n`,
+    )
+    for (const entry of shell) console.log(`     ${entry}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    '\n✅ Every stored art path serves a real image or is honestly absent.',
+  )
+}
+
+// Importable for the pure helpers without running the sweep.
+if (process.argv[1]?.endsWith('verifyStoredArtPaths.ts')) {
+  main().catch((error: unknown) => {
+    console.error(
+      `❌ ${error instanceof Error ? error.message : String(error)}`,
+    )
+    process.exitCode = 1
+  })
+}


### PR DESCRIPTION
## The gap

A missing asset under a non-`/images` path **does not 404**. It falls through to the SPA catch-all and returns **200 with a 142 KB Nuxt app shell**.

That is how all 227 `Reward.imagePath` values could be rooted at `/rewards/` instead of `/images/rewards/`, with 214 serving HTML, while curl, uptime monitors, and link checkers all read them as healthy (#1446).

The responsive-layout audit couldn't see it either — and not because it was broken. `kr-art-plate` caught the decode failure and swapped in its fallback, exactly as designed. **The page looked fine while the art was wrong.** "Did the UI break" and "is the stored data correct" are different questions, and only the first one had a check.

## The check

`verifyStoredArtPaths.ts` asks the second one: it sweeps every distinct stored art path across the seven models that hold one (`imagePath`/`cardPath`/`heroPath`/`iconPath`, plus `Bot.avatarImage`) and asserts **the response is an image** — not that the request succeeded.

### The failure/backlog split

This is the design decision that keeps it usable:

| Response | Verdict | Fails the run? |
|---|---|---|
| 2xx, `content-type: image/*` | healthy | no |
| **2xx, non-image body** | **the silent path bug** | **yes** |
| 404 / 410 | art backlog — expected, self-healing | no, reported only |
| other | unreachable | no, reported only |

Conflating the last two with the second would make this cry wolf on every gap in the art queue and get it switched off.

## Verified against production, not just fixtures

The task's bar was *"reintroduce a `/rewards/...` path and confirm the check goes red."* Run live against `kind-robots.vercel.app`:

```
shell    200  text/html;charset=utf-8   /rewards/item/alien-communicator.webp
image    200  image/webp    174358 B    /images/rewards/item/alien-communicator.webp
image    200  image/webp    212082 B    /images/rewards/skill/adhd-spark.webp
missing  404  text/html                 /images/rewards/item/<no-such-file>.webp
image    200  image/webp     69272 B    /images/botcafe.webp
```

The legacy prefix still reproduces the defect live, so the check demonstrably goes red on it.

The pure classifier is additionally mutation-verified three ways — each of these fails the self-test:

```
treat any 2xx as healthy          → caught (the exact bug that hid 214 rewards)
conflate 404 with a path bug      → caught
stop skipping /api/art routes     → caught
```

## Scheduling

Nightly (`.github/workflows/stored-art-paths.yml`), not per-PR: it checks **data**, which changes when rows are written, not when code merges. A PR cannot introduce a bad stored path.

It joins the tailnet before touching the DB — without that step the host resolves to nothing and Prisma reports a 10s pool timeout (`active=0 idle=0`) that reads like a dead database rather than an unrouted one. That trap has now bitten two dispatch-only workflows, so it is called out in the file header.

## ⚠️ Unrelated finding worth your eyes

`https://kindrobots.org/` currently returns **404 `x-vercel-error: DEPLOYMENT_NOT_FOUND`** — the apex domain has no deployment attached. `https://kind-robots.vercel.app` is serving fine, which is why CI and this PR are green. Not touched here since it's a domain-alias config issue, not code, but the public domain appears to be down.

## Verification

- `npm run test` (vue-tsc) — clean
- `test:stored-art-paths:self` — passes, mutation-verified above
- `npx eslint` on the new script — clean
- workflow YAML parses

Not run end-to-end against the database from this session: the sandbox cannot reach the ProxySQL port, which is why the sweep lives in a workflow. The first scheduled run (or a `workflow_dispatch`) will produce the real numbers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_