### PR TITLE
Fix facet taxonomy Cypress assertion

### DIFF
--- a/cypress/e2e/api/facet-assignments.cy.ts
+++ b/cypress/e2e/api/facet-assignments.cy.ts
@@ -260,7 +260,7 @@ describe('Dream and Scenario Facet assignments', () => {
     }).then((response) => {
       expect(response.status).to.eq(200)
       expect(response.body.success).to.be.true
-      expect(response.body.data.kind).to.eq('THEME')
+      expect(response.body.data.taxonomy).to.eq('THEME')
       expect(response.body.data.description).to.eq('Everything cows, updated.')
       expect(response.body.data.aliases).to.include(facetSlug)
       expect(response.body.data.aliases).to.include(cowAlias)


### PR DESCRIPTION
## Root cause

The scheduled Cypress run against `d539b8f` failed the Facet assignment suite because the test PATCHed `taxonomy: 'THEME'` but asserted the retired response field `data.kind`. The API contract now returns `data.taxonomy`.

The same run also reported the old reverse-family friendship scenario. Current `main` already replaced that stale scenario with the active friendship lifecycle coverage, and the production deployment has advanced beyond the failed commit.

## Change

- Assert `response.body.data.taxonomy` in the Facet assignment Cypress spec.
- No API or production behavior changes.

## Evidence

- Failed Cypress run: `30962370201`
- Failing job: `92168848683`
- Diff: one line in `cypress/e2e/api/facet-assignments.cy.ts`

## Validation

Run the required PR checks, then deploy and rerun the scheduled Cypress workflow against production.