### PR TITLE
interface-vision/t-079: wire entityArt.ts onto EntityArtImage joins

### DIFF
--- a/server/api/art/entities/[entityType]/[id]/history/[artImageId].delete.ts
+++ b/server/api/art/entities/[entityType]/[id]/history/[artImageId].delete.ts
@@ -8,7 +8,6 @@ import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
 import {
-  entityArtHistoryPrefix,
   listEntityArtHistory,
   resolveEntityArtTarget,
 } from '~/server/utils/entityArt'
@@ -32,26 +31,38 @@ export default defineEventHandler(async (event) => {
       defaultField,
       auth,
     )
-    const history = await prisma.artImage.findFirst({
+    const link = await prisma.entityArtImage.findUnique({
       where: {
-        id: artImageId,
-        path: {
-          startsWith: entityArtHistoryPrefix(
-            target.entityType,
-            target.entityId,
-          ),
+        entityType_entityId_artImageId: {
+          entityType: target.entityType,
+          entityId: target.entityId,
+          artImageId,
         },
       },
-      select: { id: true },
+      select: { artImageId: true },
     })
-    if (!history) {
+    if (!link) {
       throw createError({
         statusCode: 404,
         message: 'That image is not part of this inspiration history.',
       })
     }
 
-    await prisma.artImage.delete({ where: { id: artImageId } })
+    /*
+     * interface-vision/t-079: unlink only. A history join can now point at
+     * a real, still-referenced ArtImage row (the entity's own primary art,
+     * reused rather than duplicated) instead of always a throwaway private
+     * duplicate, so deleting the ArtImage row itself here would risk taking
+     * down art another slot, entity, or collection still depends on.
+     * Removing "from history" means removing the join, never the image.
+     */
+    await prisma.entityArtImage.deleteMany({
+      where: {
+        entityType: target.entityType,
+        entityId: target.entityId,
+        artImageId,
+      },
+    })
     return {
       success: true,
       message: 'Inspiration image removed.',

--- a/server/utils/entityArt.ts
+++ b/server/utils/entityArt.ts
@@ -458,6 +458,41 @@ function currentArtImageId(
   return primary && Number.isInteger(id) && id > 0 ? id : null
 }
 
+/*
+ * interface-vision/t-079: one join row is how an ArtImage becomes visible in
+ * an entity's history (listEntityArtHistory queries this table now, not
+ * ArtImage.path prefixes). Used both when an existing ArtImage is reused as
+ * history (no duplicate row) and when a fresh duplicate is created for the
+ * legacy no-artImageId fallback -- either way, the row that should show up
+ * in history needs a link. project keeps writing ProjectArtImage too: its
+ * own dedicated gallery endpoint (/api/projects/[id]/art) still reads that
+ * table unchanged, so both need to stay in sync at archive time.
+ */
+async function linkEntityArtImage(
+  db: EntityArtDb,
+  entityType: EntityArtType,
+  entityId: number,
+  artImageId: number,
+): Promise<void> {
+  await db.entityArtImage.upsert({
+    where: {
+      entityType_entityId_artImageId: { entityType, entityId, artImageId },
+    },
+    create: { entityType, entityId, artImageId },
+    update: {},
+  })
+
+  if (entityType === 'project') {
+    await db.projectArtImage.upsert({
+      where: {
+        projectId_artImageId: { projectId: entityId, artImageId },
+      },
+      create: { projectId: entityId, artImageId },
+      update: {},
+    })
+  }
+}
+
 async function createHistoryReference(
   db: EntityArtDb,
   input: {
@@ -504,18 +539,7 @@ async function createHistoryReference(
     },
   })
 
-  if (input.entityType === 'project') {
-    await db.projectArtImage.upsert({
-      where: {
-        projectId_artImageId: {
-          projectId: input.entityId,
-          artImageId: history.id,
-        },
-      },
-      create: { projectId: input.entityId, artImageId: history.id },
-      update: {},
-    })
-  }
+  await linkEntityArtImage(db, input.entityType, input.entityId, history.id)
 
   return history
 }
@@ -541,17 +565,24 @@ export async function archiveCurrentEntityArt(
     : path
   if (!referencePath) return null
 
-  if (input.entityType === 'project' && sourceArtImageId) {
-    await db.projectArtImage.upsert({
-      where: {
-        projectId_artImageId: {
-          projectId: input.entityId,
-          artImageId: sourceArtImageId,
-        },
-      },
-      create: { projectId: input.entityId, artImageId: sourceArtImageId },
-      update: {},
-    })
+  /*
+   * interface-vision/t-079: when the current slot already names a real
+   * ArtImage row (sourceArtImageId), archiving means "keep this row
+   * reachable from history" -- a join, not a copy. Previously only project
+   * got this treatment; every entity type has the same reusable id now, so
+   * every entity type gets the same non-duplicating archive. The
+   * createHistoryReference duplicate-row path below is now reached only by
+   * the legacy fallback: a bare path string with no artImageId behind it
+   * (e.g. an old Bot avatarImage set before this table tracked art), which
+   * still needs a real ArtImage row created before it can be linked at all.
+   */
+  if (sourceArtImageId) {
+    await linkEntityArtImage(
+      db,
+      input.entityType,
+      input.entityId,
+      sourceArtImageId,
+    )
     return db.artImage.findUnique({ where: { id: sourceArtImageId } })
   }
 
@@ -716,15 +747,16 @@ export async function applyEntityArtImage(
   let archivedId: number | null = null
   if (input.preserveOriginal) {
     if (input.archivedArtImageId) {
-      const reference = await createHistoryReference(db, {
-        entityType: target.entityType,
-        entityId: target.entityId,
-        field: target.field,
-        record: target.record,
-        referencePath: `/api/art/images/${input.archivedArtImageId}/file`,
-        sourceArtImageId: input.archivedArtImageId,
-      })
-      archivedId = reference.id
+      // The caller (the queue's overwrite-retry completion path) already
+      // created a standalone ArtImage row for the pre-overwrite snapshot --
+      // link it into history rather than duplicating it a second time.
+      await linkEntityArtImage(
+        db,
+        target.entityType,
+        target.entityId,
+        input.archivedArtImageId,
+      )
+      archivedId = input.archivedArtImageId
     } else {
       const archived = await archiveCurrentEntityArt(db, target)
       archivedId = archived?.id ?? null
@@ -767,38 +799,69 @@ export async function listEntityArtHistory(
   entityType: EntityArtType,
   entityId: number,
 ) {
-  const prefix = entityArtHistoryPrefix(entityType, entityId)
-  const rows = await db.artImage.findMany({
-    where: {
-      isActive: true,
-      path: { startsWith: prefix },
-    },
+  const historyPrefix = entityArtHistoryPrefix(entityType, entityId)
+  const currentPrefix = entityArtCurrentPath(entityType, entityId, '')
+
+  const links = await db.entityArtImage.findMany({
+    where: { entityType, entityId, ArtImage: { isActive: true } },
     orderBy: { createdAt: 'desc' },
     select: {
-      id: true,
       createdAt: true,
-      updatedAt: true,
-      fileName: true,
-      fileType: true,
-      imagePath: true,
-      path: true,
-      promptString: true,
-      artPrompt: true,
-      checkpoint: true,
-      checkpointResourceId: true,
-      designer: true,
-      isPublic: true,
-      isMature: true,
+      ArtImage: {
+        select: {
+          id: true,
+          createdAt: true,
+          updatedAt: true,
+          fileName: true,
+          fileType: true,
+          imagePath: true,
+          path: true,
+          promptString: true,
+          artPrompt: true,
+          checkpoint: true,
+          checkpointResourceId: true,
+          designer: true,
+          isPublic: true,
+          isMature: true,
+        },
+      },
     },
   })
 
-  return rows.map((row) => {
-    const field = safeText(row.path).slice(prefix.length).split(':')[0] || ''
-    let fieldLabel = 'Image'
-    try {
-      fieldLabel = getEntityArtFieldConfig(entityType, field).label
-    } catch {}
-    return { ...row, field, fieldLabel }
+  return links.map(({ createdAt: linkedAt, ArtImage: row }) => {
+    /*
+     * EntityArtImage doesn't carry which slot (field) an entry belongs to --
+     * the join is only (entityType, entityId, artImageId). field is only
+     * knowable when the joined ArtImage still carries one of entityArt.ts's
+     * own path tags: the legacy history-duplicate tag (row was created
+     * specifically as this field's history), or a reused primary image's
+     * current-slot tag from whenever it was last active in that field. A
+     * shared/plain ArtImage row carries neither, so field comes back
+     * undefined -- filteredHistory's `!item.field` fallback in
+     * entity-art-manager.vue already shows those under every slot rather
+     * than hiding them.
+     */
+    const path = safeText(row.path)
+    let field = ''
+    if (path.startsWith(historyPrefix)) {
+      field = path.slice(historyPrefix.length).split(':')[0] || ''
+    } else if (path.startsWith(currentPrefix)) {
+      field = path.slice(currentPrefix.length) || ''
+    }
+    let fieldLabel: string | undefined
+    if (field) {
+      try {
+        fieldLabel = getEntityArtFieldConfig(entityType, field).label
+      } catch {
+        field = ''
+      }
+    }
+    return {
+      ...row,
+      createdAt: linkedAt,
+      field: field || undefined,
+      fieldLabel,
+    }
   })
 }
 


### PR DESCRIPTION
### Task
interface-vision/t-079 (conductor): follow-on from t-028 (PR #1381), which shipped only the additive `EntityArtImage` schema (`entityType`, `entityId`, `artImageId`; FK on `artImageId` to `ArtImage`, cascade delete). This wires it in.

### What changed

1. **`archiveCurrentEntityArt`'s reuse-not-duplicate path is now generalized to every entity type.** Previously only `project` got the "upsert a join against the existing `artImageId`, no duplicate `ArtImage` row" treatment; every entity type gets it now via a new `linkEntityArtImage()` helper. `createHistoryReference`'s duplicate-row creation is reached only by the legacy fallback — a bare path string with no `artImageId` behind it.
2. **`listEntityArtHistory` now queries `EntityArtImage` for `(entityType, entityId)`** instead of `ArtImage.path.startsWith(...)`. `field`/`fieldLabel` (used to scope the history panel to the selected slot) are recovered best-effort from the joined `ArtImage`'s own path tag when present; a shared/plain `ArtImage` row has neither tag, so `field` comes back `undefined` — `entity-art-manager.vue`'s existing `filteredHistory` fallback already treats that as "show under every slot" rather than hiding it.
3. **The history delete endpoint now unlinks (`EntityArtImage.deleteMany`) instead of deleting the `ArtImage` row.** This is the main correctness fix the task called out: history entries can now point at real, still-referenced art (an entity's own primary image, reused rather than duplicated), so the old `prisma.artImage.delete(...)` could have taken down art another slot/entity/collection still depends on.
4. **`entityArtHistoryPrefix` is no longer used as a query mechanism anywhere** — no more `path: { startsWith }` in a Prisma where-clause. The function and its path tag stay only for the descriptive Studio path and the best-effort field recovery in #2.

Also fixed in passing: `applyEntityArtImage`'s `archivedArtImageId` branch (hit by the queue's overwrite-retry completion path) was calling `createHistoryReference` on an `ArtImage` id the caller had *already* freshly created as a standalone snapshot row — duplicating it a second time. It now links that row directly, same as the generalized archive path.

### How I verified
- `npm test` (vue-tsc) — clean.
- `tsx utils/scripts/verifyEntityArtManager.ts` and `verifyEntityArtPromptSuggest.ts` — both pass.
- `npx eslint` on both changed files — clean.
- `npx prisma validate` — clean.
- No local DB to exercise the Prisma calls end-to-end. Verified by read-through against the schema's `EntityArtImage` compound unique key (`entityType_entityId_artImageId`) and the callers' actual argument shapes — specifically traced the queue completion endpoint's two `applyEntityArtCompletion` call sites to confirm `archivedArtImageId` is always either omitted or a freshly-created standalone row, never a value that would make linking-instead-of-duplicating unsafe.

### Stakes
reversible

### Flags for Reviewer
- `field`/`fieldLabel` on history rows is now best-effort (not always recoverable, by design — the join table itself doesn't carry a `field` column, and this task deliberately scoped out further schema migrations). A row with no recoverable field shows under every slot's filtered view rather than none, matching the client's existing fallback.
- Not verified visually — no local dev server reachable in this sandbox (documented sandbox limitation).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0153F6TRYY17U1sL6E7uABVz)_