### PR TITLE
interface-vision/t-081: surface a Facet create affordance on the Gallery tab

### DIFF
--- a/components/facets/facet-interact.vue
+++ b/components/facets/facet-interact.vue
@@ -20,16 +20,30 @@
   of what made the inline editor feel wrong.
 -->
 <template>
-  <facet-gallery
-    v-if="!selectedFacet"
-    :show-header="showHeader"
-    title="Facets"
-    subtitle="Pick a Facet to open its profile."
-    @select="openFacet"
-  />
+  <div v-if="!selectedFacet" class="flex h-full min-h-0 flex-col gap-2">
+    <div class="flex shrink-0 justify-end">
+      <button
+        type="button"
+        class="btn btn-secondary btn-sm rounded-xl"
+        @click="goToCreateFacet"
+      >
+        <Icon name="kind-icon:plus" class="size-3.5" />
+        New Facet
+      </button>
+    </div>
+    <facet-gallery
+      class="min-h-0 flex-1"
+      :show-header="showHeader"
+      title="Facets"
+      subtitle="Pick a Facet to open its profile."
+      @select="openFacet"
+    />
+  </div>
 
   <section v-else class="kr-surface">
-    <header class="kr-toolbar shrink-0 rounded-2xl border border-base-300 bg-base-100 p-3">
+    <header
+      class="kr-toolbar shrink-0 rounded-2xl border border-base-300 bg-base-100 p-3"
+    >
       <button
         type="button"
         class="btn btn-ghost btn-sm rounded-xl"
@@ -74,7 +88,10 @@
             {{ selectedFacet.flavorText }}
           </p>
 
-          <div v-if="selectedFacet.aliases.length" class="flex flex-wrap gap-1.5">
+          <div
+            v-if="selectedFacet.aliases.length"
+            class="flex flex-wrap gap-1.5"
+          >
             <span
               v-for="alias in selectedFacet.aliases"
               :key="alias"
@@ -85,12 +102,19 @@
           </div>
 
           <div class="flex flex-wrap gap-1.5 text-xs">
-            <span class="badge badge-sm">order {{ selectedFacet.sortOrder }}</span>
-            <span class="badge badge-sm">weight {{ selectedFacet.randomWeight }}</span>
+            <span class="badge badge-sm"
+              >order {{ selectedFacet.sortOrder }}</span
+            >
+            <span class="badge badge-sm"
+              >weight {{ selectedFacet.randomWeight }}</span
+            >
             <span v-if="selectedFacet.isRandomizable" class="badge badge-sm">
               randomizable
             </span>
-            <span v-if="selectedFacet.artRequired" class="badge badge-warning badge-sm">
+            <span
+              v-if="selectedFacet.artRequired"
+              class="badge badge-warning badge-sm"
+            >
               art expected
             </span>
           </div>
@@ -109,12 +133,14 @@ import {
   useFacetCatalogStore,
   type FacetCatalogEntry,
 } from '@/stores/facetCatalogStore'
+import { useNavStore } from '@/stores/navStore'
 
 withDefaults(defineProps<{ showHeader?: boolean }>(), { showHeader: true })
 
 const route = useRoute()
 const router = useRouter()
 const catalog = useFacetCatalogStore()
+const navStore = useNavStore()
 
 /* Resolved from the URL, so a Facet page can be linked, bookmarked and
    back-buttoned. Falls back to null when the slug names nothing, which keeps a
@@ -134,6 +160,22 @@ function closeFacet(): void {
   const query = { ...route.query }
   delete query.facet
   void router.push({ query })
+}
+
+/*
+ * The gallery is a deliberately read-only surface (verifyFacetGallery.ts
+ * forbids create/update/archive here) -- creation belongs to the Library
+ * tab's admin flow. This switches to it and pre-expands the create form via
+ * a one-shot ?create=1 query flag, so a visitor never has to already know
+ * Library exists just to add a Facet.
+ */
+function goToCreateFacet(): void {
+  navStore.setDashboardTab(
+    'facets',
+    'library',
+    'facet-interact create affordance',
+  )
+  void router.push({ query: { ...route.query, create: '1' } })
 }
 
 function taxonomyLabel(taxonomy: string): string {

--- a/components/facets/facet-manager.vue
+++ b/components/facets/facet-manager.vue
@@ -24,7 +24,10 @@
           Dreams, Rewards, Scenarios, art, and random generation.
         </p>
       </div>
-      <span v-if="facetStore.loading" class="loading loading-spinner loading-sm" />
+      <span
+        v-if="facetStore.loading"
+        class="loading loading-spinner loading-sm"
+      />
       <span class="badge badge-ghost">{{ filteredFacets.length }} shown</span>
     </header>
 
@@ -48,7 +51,9 @@
           {{ taxonomyLabel(taxonomy) }} ({{ taxonomyCounts[taxonomy] || 0 }})
         </option>
       </select>
-      <label class="ml-auto flex items-center gap-2 text-xs text-base-content/60">
+      <label
+        class="ml-auto flex items-center gap-2 text-xs text-base-content/60"
+      >
         <input
           v-model="showArchived"
           type="checkbox"
@@ -76,7 +81,10 @@
           :disabled="!createForm.title.trim() || facetStore.saving"
           @click="createFacet"
         >
-          <span v-if="facetStore.saving" class="loading loading-spinner loading-xs" />
+          <span
+            v-if="facetStore.saving"
+            class="loading loading-spinner loading-xs"
+          />
           <Icon v-else name="kind-icon:plus" class="size-3.5" />
           Create canonical Facet
         </button>
@@ -92,7 +100,9 @@
         class="overflow-hidden rounded-2xl border bg-base-100 transition-all"
         :class="[
           facet.isActive ? 'border-base-300' : 'border-error/40 opacity-60',
-          editingId === facet.id ? 'md:col-span-2 xl:col-span-3 ring-2 ring-secondary/60' : '',
+          editingId === facet.id
+            ? 'md:col-span-2 xl:col-span-3 ring-2 ring-secondary/60'
+            : '',
         ]"
       >
         <div
@@ -114,7 +124,10 @@
                 <span class="badge badge-secondary badge-xs">
                   {{ taxonomyLabel(facet.taxonomy) }}
                 </span>
-                <span v-if="facet.groupLabel" class="badge badge-outline badge-xs">
+                <span
+                  v-if="facet.groupLabel"
+                  class="badge badge-outline badge-xs"
+                >
                   {{ facet.groupLabel }}
                 </span>
                 <span v-if="!facet.isActive" class="badge badge-error badge-xs">
@@ -124,20 +137,28 @@
                   private
                 </span>
               </div>
-              <h2 class="mt-1 truncate text-base font-bold">{{ facet.title }}</h2>
+              <h2 class="mt-1 truncate text-base font-bold">
+                {{ facet.title }}
+              </h2>
               <p class="truncate text-xs text-base-content/40">
                 {{ facet.canonicalValue }}
-                <template v-if="facet.aliases.length"> · {{ facet.aliases.join(' · ') }}</template>
+                <template v-if="facet.aliases.length">
+                  · {{ facet.aliases.join(' · ') }}</template
+                >
               </p>
             </div>
             <button
               type="button"
               class="btn btn-ghost btn-xs rounded-xl"
-              :aria-label="editingId === facet.id ? 'Close editor' : `Edit ${facet.title}`"
+              :aria-label="
+                editingId === facet.id ? 'Close editor' : `Edit ${facet.title}`
+              "
               @click="toggleEdit(facet)"
             >
               <Icon
-                :name="editingId === facet.id ? 'kind-icon:x' : 'kind-icon:pencil'"
+                :name="
+                  editingId === facet.id ? 'kind-icon:x' : 'kind-icon:pencil'
+                "
                 class="size-4"
               />
             </button>
@@ -157,18 +178,25 @@
               {{ facet.artPrompt }}
             </p>
             <div class="mt-3 flex flex-wrap gap-1 text-[11px]">
-              <span class="badge badge-ghost badge-xs">order {{ facet.sortOrder }}</span>
-              <span class="badge badge-ghost badge-xs">weight {{ facet.randomWeight }}</span>
-              <span class="badge badge-ghost badge-xs">rank {{ facet.sourceRank }}</span>
+              <span class="badge badge-ghost badge-xs"
+                >order {{ facet.sortOrder }}</span
+              >
+              <span class="badge badge-ghost badge-xs"
+                >weight {{ facet.randomWeight }}</span
+              >
+              <span class="badge badge-ghost badge-xs"
+                >rank {{ facet.sourceRank }}</span
+              >
               <span class="badge badge-ghost badge-xs">
                 {{ facet.isRandomizable ? 'randomizable' : 'manual only' }}
               </span>
               <span class="badge badge-ghost badge-xs">
                 {{ facet.artRequired ? 'art expected' : 'art optional' }}
               </span>
-              <span v-if="facet.metadata" class="badge badge-ghost badge-xs">metadata</span>
+              <span v-if="facet.metadata" class="badge badge-ghost badge-xs"
+                >metadata</span
+              >
             </div>
-
           </template>
 
           <div v-else class="mt-4 space-y-4">
@@ -254,7 +282,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { useNavStore } from '@/stores/navStore'
 import {
   getDashboardDefaultTab,
@@ -276,6 +305,8 @@ import { resolveEntityArtwork } from '@/utils/artImageSrc'
 
 const dashboardKey = 'facets'
 const navStore = useNavStore()
+const route = useRoute()
+const router = useRouter()
 
 /* Same derivation every other manager uses: the nav store owns the selected tab
    and the dashboard definition owns the default, so a bad or absent value falls
@@ -312,7 +343,8 @@ const taxonomyCounts = computed(() => {
 const filteredFacets = computed(() => {
   const needle = normalizeFacetLookupKey(search.value)
   return visibleFacets.value.filter((facet) => {
-    if (taxonomyFilter.value && facet.taxonomy !== taxonomyFilter.value) return false
+    if (taxonomyFilter.value && facet.taxonomy !== taxonomyFilter.value)
+      return false
     if (!needle) return true
     const values = [
       facet.title,
@@ -342,6 +374,26 @@ onMounted(async () => {
     setError(error, 'Facets could not be loaded.')
   }
 })
+
+/*
+ * One-shot deep link from facet-interact's gallery-view "+ New Facet"
+ * affordance (t-081): the Gallery tab is read-only by contract, so it
+ * switches here via navStore and flags ?create=1 to pre-expand the create
+ * form instead of landing a visitor on a collapsed <details> with no hint
+ * it's there. Cleared immediately so it doesn't re-fire on a later
+ * same-tab navigation or survive a bookmark/share of the URL.
+ */
+watch(
+  () => route.query.create,
+  (value) => {
+    if (value !== '1') return
+    createOpen.value = true
+    const query = { ...route.query }
+    delete query.create
+    void router.replace({ query })
+  },
+  { immediate: true },
+)
 
 function taxonomyLabel(taxonomy: FacetTaxonomy): string {
   return taxonomy


### PR DESCRIPTION
### Task
interface-vision/t-081: Surface a Facet create affordance on the default /facets Gallery tab, not just Library

Kaizen from t-042 (kind_robots PR #1391): `components/facets/facet-manager.vue`'s "Library" tab already has a working "+ Create a canonical Facet" flow, but `/facets` defaults to the "Gallery" tab (`facet-interact.vue` -> `facet-gallery.vue`), which has no create affordance at all — a visitor has to already know to switch tabs to find it.

### What changed
- `components/facets/facet-interact.vue` — added a "+ New Facet" button above the gallery view (its wrapper, not `facet-gallery.vue` itself — that file is contractually read-only per `utils/scripts/verifyFacetGallery.ts`, which forbids `createFacet`/`updateFacet`/`archiveFacet`/`FacetProfileEditor` text there). The button switches the Facets dashboard to the Library tab via `navStore.setDashboardTab` and flags a one-shot `?create=1` query param.
- `components/facets/facet-manager.vue` — watches for `?create=1`, pre-expands the existing create `<details>` form, and clears the query param immediately so it doesn't re-fire on a later same-tab navigation or survive a bookmark/share of the URL.

### How I verified
- `npm run test` (vue-tsc) — clean
- `npx eslint` on both touched files — clean
- `npx prettier --check` on both touched files — clean
- `npm run test:layout-contract` — 0 violations across all 8 rules, unchanged
- `npm run test:facet-gallery` — the read-only gallery contract still passes (no create/update/archive text added to `facet-gallery.vue` itself)

### Stakes
reversible

### Flags for Reviewer
- Did not attempt a live browser/Vercel-preview check this pass — typecheck, lint, and the two relevant contract verifiers (layout-contract, facet-gallery) are the substitute, consistent with prior interface-vision sessions' documented sandbox limitations.
- Chose the "switch to Library pre-expanded" option from the task note's two suggestions over "open the same create form inline on Gallery," since the create form (and its `FacetProfileEditor`) is explicitly fenced out of the read-only gallery surface by contract.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MjctCnz2YZDmMK1cvxeyVZ)_