### PR TITLE
Put the ESLint ratchet back inside the required Contract verifiers job

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -15,39 +15,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # t-099: ESLint as a ratcheted gate — it never asks anyone to fix the
-  # pre-existing problems, only refuses NEW ones, per rule.
-  #
-  # Its OWN job on purpose. The contract-verifiers job below is a ~100-step
-  # serial chain under a 10-minute budget, and a full-repo `eslint .` is the
-  # single slowest check here (measured: 41s in CI, 73s locally) while depending
-  # on none of those steps. Serialising it inside that chain spends the shared
-  # budget for no reason; in parallel it costs no extra wall-clock at all.
-  lint-ratchet:
-    name: ESLint ratchet
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: 'npm'
-
-      # postinstall runs `nuxi prepare`, which generates the
-      # .nuxt/eslint.config.mjs that eslint.config.mjs extends.
-      - name: Install dependencies
-        run: npm ci
-        env:
-          CYPRESS_INSTALL_BINARY: '0'
-
-      - name: ESLint ratchet
-        run: npm run test:lint-ratchet
-
   contract-tests:
     name: Contract verifiers
     runs-on: ubuntu-latest
@@ -90,6 +57,19 @@ jobs:
 
       - name: Earned-karma wiring contract
         run: npm run test:earned-karma-wiring
+
+      # t-099: ESLint as a ratcheted gate — never asks anyone to fix the
+      # pre-existing problems, only refuses NEW ones, per rule.
+      #
+      # INSIDE this job deliberately, not a parallel one. `Contract verifiers`
+      # is a required status check on main; a separate job would not be, so the
+      # gate would run and report without ever being able to block a merge — a
+      # check that cannot fail a PR is not a gate. The cost of keeping it here
+      # is measured and small: 36s of ESLint on a 94s job under a 10-minute
+      # budget. If this ever does need its own job, the required-checks list in
+      # the repo ruleset has to gain that job's name in the same change.
+      - name: ESLint ratchet
+        run: npm run test:lint-ratchet
 
       - name: Data surface manifest contract
         run: npm run test:data-surface-manifest


### PR DESCRIPTION
## The gate wasn't gating

conductor/t-073 records Silas activating branch protection on `main` and requiring **TypeScript**, **Contract verifiers**, and **verify**. `list_branches` confirms `main` is now `protected: true`, where that task's own earlier API check had recorded `false`.

That makes the change I shipped in #1461 actively wrong. I had moved the ESLint ratchet into its own job named **"ESLint ratchet"** — which is *not* in the required list. So the gate ran, reported, and **could never block a merge**.

A check that cannot fail a PR is not a gate, and being a gate was the entire point of t-099.

## The reason for the split doesn't survive measurement either

I justified moving it out by saying the step had been observed blocking the verifier chain for over ten minutes. That was the checks API serving stale in-progress state, not the run. The real numbers from the completed run:

| | |
|---|---|
| ESLint step | **36s** |
| Contract verifiers job, total | **94s** |
| job timeout budget | 10 min |

36s onto 94s under a 10-minute budget is not a problem worth trading the gate for.

## What changed

The standalone `lint-ratchet` job is removed and the step goes back inline in `contract-tests`. The comment now records the constraint that caused this, so the next person to consider splitting it knows the cost:

> `Contract verifiers` is a required status check on main; a separate job would not be, so the gate would run and report without ever being able to block a merge. […] If this ever does need its own job, the required-checks list in the repo ruleset has to gain that job's name in the same change.

No change to the ratchet itself — same baseline (397), same per-rule semantics, same self-test.

## Verification

- workflow YAML parses; single job `contract-tests` / "Contract verifiers", 105 steps, ratchet step present
- `test:lint-ratchet` unchanged and passing at 397
- this PR's own run exercises it in the required job

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_