### PR TITLE
ai-art-academy/t-010 (lane 1): stop clearQueue() from wiping unrelated Bot/Character/Dream/Reward/Scenario selection

### DIFF
--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -543,7 +543,7 @@ import { useCollectionStore } from '@/stores/collectionStore'
 import { useServerStore } from '@/stores/serverStore'
 import type { ArtImage } from '~/prisma/generated/prisma/client'
 
-withDefaults(defineProps<{ showModelConnect?: boolean }>(), {
+const props = withDefaults(defineProps<{ showModelConnect?: boolean }>(), {
   showModelConnect: false,
 })
 
@@ -734,7 +734,20 @@ function clearQueue() {
   connectedModelType.value = ''
   message.value = ''
   error.value = ''
-  clearModelSelection()
+  // Only relevant when the model-connect UI is actually shown -- every other
+  // caller (Academy Style Lab, art-maker, art-builder, add-bot/-character/
+  // -reward/-scenario, avatar-picker, ...) renders with showModelConnect
+  // false/default and never lets the visitor touch connectedModelType, so
+  // clearing it unconditionally was silently deselecting whatever bot/
+  // character/dream/reward/scenario the user had selected ELSEWHERE in the
+  // app the moment any unrelated upload batch here finished cleanly --
+  // botStore.deselectBot() and friends persist that null to localStorage
+  // immediately. Same class of "unrelated global Pinia singleton wiped by an
+  // Academy upload" bug already fixed for uploadStore.activeTarget (PRs
+  // #1058, #1063, #1067, #1162), just via a different store family.
+  if (props.showModelConnect) {
+    clearModelSelection()
+  }
 }
 
 function removeFile(index: number) {


### PR DESCRIPTION
### Task
conductor ai-art-academy/t-010 (recurring "Academy continuous improvement pass"), lane 1: front-end style/polish pass.

### The bug
`components/art/image-upload.vue`'s `clearQueue()` unconditionally called `clearModelSelection()` (`botStore.deselectBot()`, `characterStore.deselectCharacter()`, `dreamStore.deselectDream()`, `rewardStore.deselectReward()`, `scenarioStore.deselectScenario()`) — but the model-connect UI and its `connectedModelType` select only render when `showModelConnect` is true. Every real call site in the app (Academy Style Lab, `art-maker`, `art-builder`, `add-bot`/`-character`/`-reward`/`-scenario`, `avatar-picker`, ...) passes `showModelConnect` false/default, so a visitor never touches `connectedModelType` — yet `handleBatchUpload()` calls `clearQueue()` automatically after every fully-successful upload.

**Concrete failure:** a user mid-edit on `/add-bot?id=7` (`currentBot` set, persisted to `localStorage`) navigates to Academy Style Lab, uploads images purely for the gallery, and the successful upload silently nulls their in-progress Bot selection — persisted immediately via `botStore.persist()`. Same for Character/Dream/Reward/Scenario; `scenarioStore.deselectScenario()` additionally clears a shared sheet. Same bug class already fixed for `uploadStore.activeTarget` (PRs #1058, #1063, #1067, #1162), just via a different store family.

### Fix
Gate the `clearModelSelection()` call in `clearQueue()` on `props.showModelConnect`, matching the two other call sites (the select's `@change` and the "Unlink" button), which already only render inside `v-if="showModelConnect"`.

### How I verified
- `npm run test` (vue-tsc) — clean
- `npx eslint components/art/image-upload.vue` — clean
- `npx prettier --check components/art/image-upload.vue` — clean

### Stakes
reversible


---
_Generated by [Claude Code](https://claude.ai/code/session_01MjctCnz2YZDmMK1cvxeyVZ)_