### PR TITLE
Fix tablet startup message clipping after orientation changes

### DIFF
--- a/components/admin/loading-messages.vue
+++ b/components/admin/loading-messages.vue
@@ -283,6 +283,7 @@ onBeforeUnmount(() => {
   display: grid;
   width: min(98vw, 64rem);
   height: min(92vh, 52rem);
+  height: min(92dvh, 52rem);
   /*
    * The heading row is deeper than the heading so the heading can sit at its
    * BOTTOM (see .loading-heading align-self) rather than at the top of the
@@ -291,8 +292,13 @@ onBeforeUnmount(() => {
    * nearly the full width -- so a top-anchored heading rendered underneath it
    * and both became unreadable. Silas: "it should be an easy fix to lower the
    * message nearer the logo."
+   *
+   * Both text bands are content-sized. The rotating message can wrap after an
+   * orientation change, so forcing its parent into an 8rem track clips longer
+   * messages while the logo track keeps the space instead.
    */
-  grid-template-rows: minmax(7rem, auto) minmax(0, 1fr) 8rem;
+  grid-template-rows:
+    minmax(7rem, auto) minmax(0, 1fr) minmax(8rem, auto);
   place-items: center;
   opacity: 1;
   transform: scale(1);
@@ -436,7 +442,7 @@ onBeforeUnmount(() => {
   display: grid;
   width: 100%;
   min-height: 8rem;
-  grid-template-rows: 4rem 4rem;
+  grid-template-rows: 4rem minmax(4rem, auto);
   place-items: center;
 }
 
@@ -449,6 +455,9 @@ onBeforeUnmount(() => {
 
 .loading-message {
   font-size: clamp(1.05rem, 2vw, 1.75rem);
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+  text-wrap: balance;
   will-change: transform, opacity;
 }
 


### PR DESCRIPTION
### Task
Direct Silas request: keep startup loading messages visible on tablet portrait/landscape changes. (kind: software)

### What changed / what I produced
- Replaced the fixed 8rem startup status track with a content-sized track, so two-line loading messages can grow without spilling below the loader grid.
- Made the message row itself `minmax(4rem, auto)` instead of a fixed 4rem.
- Switched the loader height to dynamic viewport units with a `vh` fallback so iOS orientation/browser-chrome changes recalculate the available height.
- Added balanced wrapping and explicit line-height/overflow handling for long rotating messages.

### Root cause
The tablet layout did not use the phone-only fixed status positioning. It kept the status inside a fixed 8rem grid track containing a fixed 4rem message row. When rotation changed the available width, longer messages wrapped to two lines but the grid still reserved one-line height, so the text overflowed downward and could be clipped. The `92vh` height also used the less reliable static viewport measurement on iOS during orientation changes.

### How I verified
- Compared the branch against current `main`: one file, 13 changed lines.
- Read the startup layout and message catalog together, including the longest messages and the tablet/phone breakpoint behavior.
- CI is the executable verification path for this connector-only change; I will wait for the completed checks before merging.

### Stakes
reversible

### Kaizen suggestion
Add the startup overlay to the responsive geometry audit with one deliberately long fixture message and an orientation-size pair, so text overflow becomes a measured regression rather than a screenshot-only discovery.

### Notes for reviewer
The existing mobile rule remains unchanged. This repairs the tablet/desktop grid path and modern iOS viewport sizing without moving the controls or logo.