### PR TITLE
Redesign Taskmaster as an objective-first Quest Desk

### DIFF
--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -4,99 +4,117 @@
      users choose story ingredients, never image-model settings. -->
 <template>
   <section
-    class="kr-surface gap-4 rounded-2xl border border-base-300 bg-base-100 p-4"
+    class="kr-surface taskmaster-shell min-h-0 gap-3 rounded-2xl border border-base-300 bg-base-100 p-3 sm:p-4"
   >
-    <header class="flex shrink-0 items-start gap-3">
+    <header
+      class="flex shrink-0 items-start gap-3 border-b border-base-300 pb-3"
+    >
       <div
-        class="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-secondary/30 bg-secondary/10 text-secondary"
+        class="flex size-11 shrink-0 items-center justify-center rounded-2xl border border-secondary/30 bg-secondary/10 text-secondary shadow-sm"
       >
-        <Icon name="kind-icon:gearhammer" class="size-6" />
+        <Icon name="kind-icon:gearhammer" class="size-5" />
       </div>
       <div class="min-w-0 flex-1">
-        <h2 class="text-2xl font-black leading-tight">
-          Turn the next real thing into an adventure
+        <p
+          class="text-[0.65rem] font-black uppercase tracking-[0.18em] text-secondary"
+        >
+          Taskmaster
+        </p>
+        <h2 class="text-xl font-black leading-tight sm:text-2xl">
+          Turn the next real thing into a quest
         </h2>
-        <p class="mt-1 text-sm leading-relaxed text-base-content/70">
-          Name the real objective, choose the kind of story you want to inhabit,
-          and make one honest move at a time. Taskmaster handles narration and
-          art direction automatically.
+        <p class="mt-1 max-w-2xl text-xs leading-relaxed text-base-content/60">
+          The story adds momentum. The real objective stays honest, visible, and
+          under your control.
         </p>
       </div>
-      <div
-        v-if="store.session"
-        class="flex shrink-0 flex-wrap justify-end gap-2"
-      >
-        <button
-          v-if="store.canClose"
-          type="button"
-          class="btn btn-ghost btn-sm rounded-xl"
-          @click="store.closeStory()"
+      <div class="flex shrink-0 flex-wrap justify-end gap-2">
+        <span
+          class="badge badge-success badge-outline hidden h-auto gap-1.5 rounded-xl px-2.5 py-1.5 text-[0.65rem] font-bold sm:flex"
         >
-          <Icon name="kind-icon:moon" class="size-4" /> Finish the quest
-        </button>
+          <Icon name="kind-icon:shield" class="size-3.5" />
+          Nothing changes without approval
+        </span>
         <button
+          v-if="store.session"
           type="button"
           class="btn btn-ghost btn-sm rounded-xl"
           :disabled="store.isWeaving"
           @click="startOver"
         >
-          <Icon name="kind-icon:wand" class="size-4" /> New quest
+          <Icon name="kind-icon:wand" class="size-4" />
+          <span class="hidden sm:inline">New quest</span>
         </button>
       </div>
     </header>
 
-    <LazyKrNarratorStage :stage-image="tabImage" class="shrink-0" />
+    <!-- SETUP: one document scroll, objective first, optional story recipe second. -->
+    <div v-if="!store.session" class="space-y-3">
+      <nav
+        class="flex items-center gap-2 overflow-hidden text-[0.7rem] font-bold"
+        aria-label="Quest setup progress"
+      >
+        <span class="flex items-center gap-1.5 text-base-content">
+          <span
+            class="flex size-6 items-center justify-center rounded-full bg-secondary text-secondary-content"
+          >
+            1
+          </span>
+          Objective
+        </span>
+        <span class="h-px min-w-5 max-w-14 flex-1 bg-base-300" />
+        <span class="flex items-center gap-1.5 text-base-content/45">
+          <span
+            class="flex size-6 items-center justify-center rounded-full border border-base-300 bg-base-200"
+          >
+            2
+          </span>
+          Recipe
+        </span>
+        <span class="h-px min-w-5 max-w-14 flex-1 bg-base-300" />
+        <span class="flex items-center gap-1.5 text-base-content/45">
+          <span
+            class="flex size-6 items-center justify-center rounded-full border border-base-300 bg-base-200"
+          >
+            3
+          </span>
+          Review
+        </span>
+      </nav>
 
-    <!-- SETUP and PLAN REVIEW scroll as documents — a long form and a full
-         checkpoint list both legitimately run past the fold, so the page owns
-         the scroll for those two states. The quest itself does not; see below. -->
-    <div
-      v-if="!store.session || store.session.status === 'draft'"
-      class="kr-scroll space-y-4"
-    >
-      <template v-if="!store.session">
-        <TaskmasterSampleTasks />
-
-        <div class="space-y-5 rounded-2xl border border-secondary/20 bg-secondary/5 p-4">
+      <div
+        class="grid items-start gap-3 lg:grid-cols-[minmax(0,1.2fr)_minmax(20rem,0.8fr)]"
+      >
+        <section
+          class="space-y-3 rounded-2xl border border-base-300 bg-base-200/35 p-3 sm:p-4"
+        >
           <div>
-            <h3 class="text-xs font-bold uppercase tracking-wide text-secondary/70">
-              Build the quest
-            </h3>
-            <p class="mt-1 text-xs leading-relaxed text-base-content/55">
-              Story choices direct the art automatically. Model, sampler, step-count,
-              and other generator controls stay out of the way.
+            <p
+              class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-base-content/55"
+            >
+              The real objective
             </p>
+            <textarea
+              v-model="taskInput"
+              rows="4"
+              class="textarea textarea-bordered mt-2 w-full resize-none rounded-2xl bg-base-100 text-base font-semibold leading-relaxed sm:text-lg"
+              placeholder="Clean the garage, finish the proposal, decide which feature ships next…"
+              :disabled="store.isWeaving"
+            />
           </div>
 
           <label class="form-control w-full">
             <div class="label py-1">
-              <span class="label-text text-xs font-bold uppercase tracking-wide">
-                What do you need to accomplish?
-              </span>
-            </div>
-            <textarea
-              v-model="taskInput"
-              rows="2"
-              class="textarea textarea-bordered w-full rounded-xl text-sm leading-relaxed"
-              placeholder="Clean the garage, finish the proposal, decide which feature ships next…"
-              :disabled="store.isWeaving"
-            />
-            <div class="label py-1">
-              <span class="label-text-alt text-base-content/45">
-                You can enter a task directly, link a project below, or use both.
-              </span>
-            </div>
-          </label>
-
-          <label class="form-control w-full max-w-xl">
-            <div class="label py-1">
-              <span class="label-text text-xs font-bold uppercase tracking-wide">
-                Project or task source (optional)
+              <span
+                class="label-text text-[0.68rem] font-black uppercase tracking-[0.12em] text-base-content/55"
+              >
+                Project or task source
+                <span class="font-normal normal-case tracking-normal">(optional)</span>
               </span>
             </div>
             <select
               v-model="selectedProjectSlug"
-              class="select select-bordered w-full rounded-xl"
+              class="select select-bordered w-full rounded-xl bg-base-100"
               :disabled="store.isWeaving"
             >
               <option value="">No linked project</option>
@@ -110,8 +128,40 @@
             </select>
           </label>
 
+          <div class="border-t border-base-300 pt-3">
+            <div class="mb-2 flex flex-wrap items-end justify-between gap-2">
+              <div>
+                <p class="text-sm font-black">Need a spark?</p>
+                <p class="text-xs text-base-content/50">
+                  Start from a real task, a decision, or something around the house.
+                </p>
+              </div>
+              <span class="badge badge-warning badge-outline badge-sm rounded-xl">
+                Human gates stay explicit
+              </span>
+            </div>
+            <TaskmasterSampleTasks class="taskmaster-samples" />
+          </div>
+        </section>
+
+        <aside
+          class="space-y-4 rounded-2xl border border-base-300 bg-base-200/35 p-3 sm:p-4"
+        >
+          <div>
+            <p
+              class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-base-content/55"
+            >
+              Quest recipe
+            </p>
+            <p class="mt-1 text-xs leading-relaxed text-base-content/50">
+              Set the flavor without exposing image-model machinery.
+            </p>
+          </div>
+
           <div class="space-y-2">
-            <p class="text-xs font-bold uppercase tracking-wide text-base-content/55">
+            <p
+              class="text-[0.68rem] font-black uppercase tracking-[0.12em] text-base-content/55"
+            >
               Tone
             </p>
             <kr-choice-list
@@ -125,40 +175,101 @@
             />
           </div>
 
-          <NarrativeIngredientPicker
-            v-model="selectedLocationSlug"
-            :items="locationOptions"
-            label="Setting"
-            helper="Choose a reusable LOCATION Dream. Artwork is shown when the location already has it."
-            empty-label="Anywhere"
-            empty-description="Let Taskmaster choose a setting that fits the objective and tone."
-            empty-icon="kind-icon:dream"
-            empty-state="No active LOCATION Dreams are available yet."
-            :disabled="store.isWeaving"
-            :loading="dreamStore.loading"
-            :error="dreamStore.error"
-            :initial-limit="5"
-          />
+          <details
+            class="group rounded-2xl border border-base-300 bg-base-100"
+          >
+            <summary
+              class="flex cursor-pointer list-none items-center gap-3 p-3 [&::-webkit-details-marker]:hidden"
+            >
+              <span
+                class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-secondary/10 text-secondary"
+              >
+                <Icon name="kind-icon:dream" class="size-5" />
+              </span>
+              <span class="min-w-0 flex-1">
+                <span
+                  class="block text-[0.65rem] font-black uppercase tracking-[0.12em] text-base-content/45"
+                >
+                  Setting
+                </span>
+                <span class="block truncate text-sm font-bold">
+                  {{ selectedLocationLabel }}
+                </span>
+              </span>
+              <Icon
+                name="kind-icon:arrowdown"
+                class="size-4 text-base-content/45 transition-transform group-open:rotate-180"
+              />
+            </summary>
+            <div class="border-t border-base-300 p-3">
+              <NarrativeIngredientPicker
+                v-model="selectedLocationSlug"
+                :items="locationOptions"
+                label="Setting"
+                helper="Choose a reusable LOCATION Dream. Artwork is shown when the location already has it."
+                empty-label="Anywhere"
+                empty-description="Let Taskmaster choose a setting that fits the objective and tone."
+                empty-icon="kind-icon:dream"
+                empty-state="No active LOCATION Dreams are available yet."
+                :disabled="store.isWeaving"
+                :loading="dreamStore.loading"
+                :error="dreamStore.error"
+                :initial-limit="5"
+              />
+            </div>
+          </details>
 
-          <NarrativeIngredientPicker
-            v-model="selectedGrammarSlug"
-            :items="grammarOptions"
-            label="Genre, mood, and style"
-            helper="Choose from the canonical Facet library. Cards use Facet artwork first and fall back to the Facet icon."
-            empty-label="Any adventure"
-            empty-description="Let Taskmaster choose the genre and story grammar automatically."
-            empty-icon="kind-icon:story"
-            empty-state="No active narrative Facets are available yet."
-            :disabled="store.isWeaving"
-            :loading="facetStore.loading"
-            :error="facetStore.error"
-            :initial-limit="8"
-          />
+          <details
+            class="group rounded-2xl border border-base-300 bg-base-100"
+          >
+            <summary
+              class="flex cursor-pointer list-none items-center gap-3 p-3 [&::-webkit-details-marker]:hidden"
+            >
+              <span
+                class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-info/10 text-info"
+              >
+                <Icon name="kind-icon:story" class="size-5" />
+              </span>
+              <span class="min-w-0 flex-1">
+                <span
+                  class="block text-[0.65rem] font-black uppercase tracking-[0.12em] text-base-content/45"
+                >
+                  Genre, mood, and style
+                </span>
+                <span class="block truncate text-sm font-bold">
+                  {{ selectedGrammarLabel }}
+                </span>
+              </span>
+              <Icon
+                name="kind-icon:arrowdown"
+                class="size-4 text-base-content/45 transition-transform group-open:rotate-180"
+              />
+            </summary>
+            <div class="border-t border-base-300 p-3">
+              <NarrativeIngredientPicker
+                v-model="selectedGrammarSlug"
+                :items="grammarOptions"
+                label="Genre, mood, and style"
+                helper="Choose from the canonical Facet library. Cards use Facet artwork first and fall back to the Facet icon."
+                empty-label="Any adventure"
+                empty-description="Let Taskmaster choose the genre and story grammar automatically."
+                empty-icon="kind-icon:story"
+                empty-state="No active narrative Facets are available yet."
+                :disabled="store.isWeaving"
+                :loading="facetStore.loading"
+                :error="facetStore.error"
+                :initial-limit="8"
+              />
+            </div>
+          </details>
 
           <label class="form-control w-full">
             <div class="label py-1">
-              <span class="label-text text-xs font-bold uppercase tracking-wide">
-                Extra flavor (optional)
+              <span
+                class="label-text text-[0.68rem] font-black uppercase tracking-[0.12em] text-base-content/55"
+              >
+                Extra flavor
+                <span class="font-normal normal-case tracking-normal">(optional)</span>
               </span>
             </div>
             <input
@@ -170,62 +281,94 @@
             />
           </label>
 
-          <p v-if="store.errorMessage" class="text-xs text-error">
-            {{ store.errorMessage }}
-          </p>
-
-          <div class="flex flex-wrap items-center gap-2">
-            <button
-              type="button"
-              class="btn btn-secondary rounded-xl"
-              :disabled="store.isWeaving || !canBegin"
-              @click="begin(false)"
-            >
-              <span
-                v-if="store.isWeaving"
-                class="loading loading-dots loading-sm"
-              />
-              <template v-else>
-                <Icon name="kind-icon:gearhammer" class="size-4" /> Begin quest
-              </template>
-            </button>
-            <button
-              type="button"
-              class="btn btn-ghost rounded-xl border border-base-300 bg-base-100"
-              :disabled="store.isWeaving || !canBegin"
-              @click="begin(true)"
-            >
-              <Icon name="kind-icon:wand" class="size-4" /> Surprise me
-            </button>
-            <p v-if="!canBegin" class="text-xs text-base-content/50">
-              Enter an objective or choose a linked project to begin.
+          <div
+            class="flex items-start gap-2 rounded-xl border border-success/20 bg-success/5 p-2.5 text-[0.7rem] leading-relaxed text-base-content/60"
+          >
+            <Icon name="kind-icon:shield" class="mt-0.5 size-4 shrink-0 text-success" />
+            <p>
+              Story answers become proposed progress. Real updates still require an
+              explicit <strong>Apply</strong> action.
             </p>
           </div>
-        </div>
-      </template>
+        </aside>
+      </div>
 
-      <div
-        v-else-if="store.session.status === 'draft'"
-        class="space-y-4 rounded-2xl border border-secondary/25 bg-secondary/5 p-4"
+      <p v-if="store.errorMessage" class="text-xs text-error">
+        {{ store.errorMessage }}
+      </p>
+
+      <footer
+        class="sticky bottom-2 z-10 flex flex-wrap items-center gap-2 rounded-2xl border border-base-300 bg-base-100/95 p-3 shadow-lg backdrop-blur"
       >
-        <div>
-          <p class="text-xs font-bold uppercase tracking-wide text-secondary/70">
-            Review the practical plan
-          </p>
-          <h3 class="mt-1 text-xl font-black">The quest starts with real checkpoints</h3>
-          <p class="mt-1 text-sm leading-relaxed text-base-content/60">
-            Taskmaster will weave these actions into the fiction in order. The plan is
-            saved before narration begins, and no external task changes happen without
-            an explicit Apply action.
-          </p>
-        </div>
-        <article
-          v-for="(checkpoint, index) in store.session.checkpoints"
-          :key="checkpoint.id"
-          class="rounded-2xl border border-base-300 bg-base-100 p-3"
+        <p class="min-w-48 flex-1 text-xs leading-relaxed text-base-content/55">
+          Next: review a practical checkpoint plan before the story begins.
+        </p>
+        <button
+          type="button"
+          class="btn btn-ghost rounded-xl border border-base-300 bg-base-200"
+          :disabled="store.isWeaving || !canBegin"
+          @click="begin(true)"
         >
-          <div class="flex items-start gap-3">
-            <span class="badge badge-secondary badge-sm mt-0.5 rounded-xl">
+          <Icon name="kind-icon:wand" class="size-4" /> Surprise me
+        </button>
+        <button
+          type="button"
+          class="btn btn-secondary rounded-xl"
+          :disabled="store.isWeaving || !canBegin"
+          @click="begin(false)"
+        >
+          <span v-if="store.isWeaving" class="loading loading-dots loading-sm" />
+          <template v-else>
+            Build my quest
+            <Icon name="kind-icon:arrowright" class="size-4" />
+          </template>
+        </button>
+        <p
+          v-if="!canBegin"
+          class="w-full text-right text-[0.7rem] text-base-content/45"
+        >
+          Enter an objective or choose a linked project to begin.
+        </p>
+      </footer>
+    </div>
+
+    <!-- PLAN REVIEW: practical actions dominate; story flavor becomes context. -->
+    <div
+      v-else-if="store.session.status === 'draft'"
+      class="grid items-start gap-3 lg:grid-cols-[minmax(0,1.15fr)_minmax(18rem,0.85fr)]"
+    >
+      <section
+        class="space-y-3 rounded-2xl border border-secondary/25 bg-secondary/5 p-3 sm:p-4"
+      >
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p
+              class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-secondary/75"
+            >
+              Review the practical plan
+            </p>
+            <h3 class="mt-1 text-xl font-black">
+              The quest starts with real checkpoints
+            </h3>
+            <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+              Taskmaster weaves these actions into the fiction in order. Nothing is
+              written back without a separate Apply action.
+            </p>
+          </div>
+          <span class="badge badge-secondary rounded-xl">
+            {{ store.session.checkpoints.length }} checkpoints
+          </span>
+        </div>
+
+        <ol class="space-y-2">
+          <li
+            v-for="(checkpoint, index) in store.session.checkpoints"
+            :key="checkpoint.id"
+            class="flex items-start gap-3 rounded-2xl border border-base-300 bg-base-100 p-3"
+          >
+            <span
+              class="flex size-7 shrink-0 items-center justify-center rounded-full bg-secondary text-xs font-black text-secondary-content"
+            >
               {{ index + 1 }}
             </span>
             <div class="min-w-0 flex-1">
@@ -233,21 +376,72 @@
               <p v-if="checkpoint.detail" class="mt-1 text-xs text-base-content/55">
                 {{ checkpoint.detail }}
               </p>
-              <p class="mt-1 text-[0.7rem] uppercase tracking-wide text-base-content/40">
+              <p
+                class="mt-1 text-[0.65rem] font-bold uppercase tracking-wide text-base-content/35"
+              >
                 {{ checkpoint.sourceKind.replace('-', ' ') }}
               </p>
             </div>
-          </div>
-        </article>
-        <div class="flex flex-wrap gap-2">
-          <button
-            type="button"
-            class="btn btn-secondary rounded-xl"
-            :disabled="store.isWeaving || !store.session.checkpoints.length"
-            @click="store.startQuest()"
+          </li>
+        </ol>
+      </section>
+
+      <aside class="space-y-3">
+        <section class="rounded-2xl border border-base-300 bg-base-200/35 p-4">
+          <p
+            class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-base-content/55"
           >
-            <Icon name="kind-icon:story" class="size-4" /> Start the adventure
-          </button>
+            Quest briefing
+          </p>
+          <dl class="mt-3 space-y-3 text-sm">
+            <div>
+              <dt class="text-[0.65rem] font-bold uppercase tracking-wide text-base-content/40">
+                Objective
+              </dt>
+              <dd class="mt-0.5 font-bold">
+                {{ store.session.seed.taskTitle || 'Linked project objective' }}
+              </dd>
+            </div>
+            <div class="grid grid-cols-2 gap-3">
+              <div>
+                <dt class="text-[0.65rem] font-bold uppercase tracking-wide text-base-content/40">
+                  Tone
+                </dt>
+                <dd class="mt-0.5 capitalize">{{ store.session.seed.tone }}</dd>
+              </div>
+              <div>
+                <dt class="text-[0.65rem] font-bold uppercase tracking-wide text-base-content/40">
+                  Setting
+                </dt>
+                <dd class="mt-0.5">
+                  {{ store.session.location?.title || 'Taskmaster chooses' }}
+                </dd>
+              </div>
+            </div>
+            <div v-if="store.session.genre">
+              <dt class="text-[0.65rem] font-bold uppercase tracking-wide text-base-content/40">
+                Genre
+              </dt>
+              <dd class="mt-0.5">{{ store.session.genre.title }}</dd>
+            </div>
+          </dl>
+        </section>
+
+        <div
+          class="flex items-start gap-2 rounded-2xl border border-success/25 bg-success/5 p-3 text-xs leading-relaxed text-base-content/60"
+        >
+          <Icon name="kind-icon:shield" class="mt-0.5 size-4 shrink-0 text-success" />
+          <p>
+            This review is the handrail: the fiction can be surprising, but the work
+            cannot silently change beneath it.
+          </p>
+        </div>
+
+        <p v-if="store.errorMessage" class="text-xs text-error">
+          {{ store.errorMessage }}
+        </p>
+
+        <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
           <button
             type="button"
             class="btn btn-ghost rounded-xl border border-base-300 bg-base-100"
@@ -256,61 +450,211 @@
           >
             Edit setup
           </button>
+          <button
+            type="button"
+            class="btn btn-secondary rounded-xl"
+            :disabled="store.isWeaving || !store.session.checkpoints.length"
+            @click="store.startQuest()"
+          >
+            <Icon name="kind-icon:story" class="size-4" /> Start the adventure
+          </button>
         </div>
-      </div>
+      </aside>
     </div>
 
-    <!-- THE QUEST owns no scroll of its own. The chat window is the single
-         scroll region; the objective, the checkpoint rail, the outcome picker
-         and the composer stay pinned around it, so the two things a user needs
-         at all times — what they are actually doing, and what they answer with
-         — never scroll off. -->
-    <div v-else class="flex min-h-0 flex-1 flex-col gap-3">
-      <div class="shrink-0 space-y-3">
-        <div
+    <!-- QUEST: story and response on the left, real mission rail on the right. -->
+    <div
+      v-else
+      class="grid min-h-0 flex-1 items-start gap-3 lg:grid-cols-[minmax(0,1fr)_20rem]"
+    >
+      <div class="flex min-h-0 flex-col gap-3">
+        <LazyKrNarratorStage
+          :stage-image="tabImage"
+          class="taskmaster-stage min-h-56 shrink-0 lg:min-h-64"
+        />
+
+        <KrChatWindow
+          class="min-h-80 flex-1"
+          :turns="chatTurns"
+          label="Story transcript"
+          :is-streaming="store.isWeaving"
+          :streaming-text="store.streamingText"
+          streaming-label="Taskmaster is building the next scene…"
+          empty-label="Taskmaster is preparing the opening scene."
+        >
+          <template #after-turn="{ turn }">
+            <NarrativeArtStatus
+              v-if="beatForTurn(turn)"
+              class="mt-2"
+              :art="beatForTurn(turn)?.art"
+              :label="`Illustration for ${store.session?.seed.taskTitle || 'this quest'}`"
+              @retry="store.retryBeatArt(beatForTurn(turn)!.id)"
+            />
+          </template>
+
+          <template #footer>
+            <div
+              v-if="store.isComplete"
+              class="space-y-3 rounded-2xl border border-secondary/30 bg-secondary/5 p-4"
+            >
+              <div class="text-center">
+                <p class="text-sm font-bold text-secondary">Quest complete</p>
+                <p class="mt-1 text-xs text-base-content/60">
+                  Review any real-world updates below before applying them.
+                </p>
+              </div>
+              <dl
+                v-if="sessionRecap.length"
+                class="grid gap-2 text-xs leading-relaxed sm:grid-cols-2"
+              >
+                <div
+                  v-for="item in sessionRecap"
+                  :key="item.label"
+                  class="rounded-xl border border-base-300 bg-base-100 p-3"
+                >
+                  <dt class="font-bold text-base-content/70">{{ item.label }}</dt>
+                  <dd class="mt-0.5 text-base-content/60">{{ item.value }}</dd>
+                </div>
+              </dl>
+            </div>
+
+            <div
+              v-if="store.pendingWriteBacks.length"
+              class="space-y-2 rounded-2xl border border-warning/30 bg-warning/5 p-4"
+            >
+              <div class="flex items-center gap-2">
+                <Icon name="kind-icon:gearhammer" class="size-4 text-warning" />
+                <h3 class="text-xs font-bold uppercase tracking-wide text-warning">
+                  Quest ledger
+                </h3>
+              </div>
+              <p class="text-[0.7rem] leading-relaxed text-base-content/50">
+                Nothing is written automatically. Apply only the updates you want.
+              </p>
+              <article
+                v-for="item in store.pendingWriteBacks"
+                :key="item.beatId"
+                class="rounded-xl border border-base-300 bg-base-100 p-3 text-xs leading-relaxed"
+              >
+                <div class="flex items-start gap-2">
+                  <div class="min-w-0 flex-1">
+                    <p class="font-bold">{{ item.title }}</p>
+                    <p class="mt-1 text-base-content/70">“{{ item.answer }}”</p>
+                    <p class="mt-1 text-base-content/50">
+                      <span class="font-semibold">Apply will:</span>
+                      {{ item.proposedWrite }}
+                    </p>
+                  </div>
+                  <span
+                    v-if="item.status === 'written'"
+                    class="badge badge-success badge-sm rounded-xl"
+                  >
+                    written
+                  </span>
+                  <button
+                    v-else
+                    type="button"
+                    class="btn btn-warning btn-xs rounded-xl"
+                    :disabled="item.status === 'queued'"
+                    @click="store.applyWriteBack(item.beatId)"
+                  >
+                    <span
+                      v-if="item.status === 'queued'"
+                      class="loading loading-spinner loading-xs"
+                    />
+                    <template v-else>Apply</template>
+                  </button>
+                </div>
+              </article>
+            </div>
+          </template>
+        </KrChatWindow>
+
+        <section
+          v-if="
+            !store.isComplete && store.awaitingAnswer && store.currentCheckpoint
+          "
+          class="shrink-0 space-y-2 rounded-2xl border border-info/25 bg-info/5 p-3"
+        >
+          <div>
+            <p class="text-[0.7rem] font-bold uppercase tracking-wide text-info/75">
+              What happened in the real world?
+            </p>
+            <p class="mt-1 text-xs text-base-content/55">
+              Choose the honest checkpoint outcome, then describe what happened below.
+            </p>
+          </div>
+          <kr-choice-list
+            layout="row"
+            label="Checkpoint outcome"
+            :choices="outcomeChoices"
+            :selected-key="selectedOutcome"
+            :show-index="false"
+            @select="selectedOutcome = $event.key as TaskmasterCheckpointOutcome"
+          />
+        </section>
+
+        <NarrativeResponseComposer
+          v-if="!store.isComplete && !store.canClose"
+          v-model="answerInput"
+          class="shrink-0"
+          :options="store.currentBeat?.question.options ?? []"
+          :disabled="!store.awaitingAnswer"
+          :loading="store.isWeaving"
+          :placeholder="
+            store.awaitingAnswer
+              ? 'What do you do?'
+              : 'Taskmaster is building the next scene…'
+          "
+          button-label="Continue"
+          hint="Story answers become proposed progress first. Real task changes still require an explicit Apply action."
+          @submit="submitAnswer"
+        />
+      </div>
+
+      <aside class="space-y-3 lg:sticky lg:top-0">
+        <section
           v-if="store.session.seed.taskTitle"
           class="rounded-2xl border border-info/30 bg-info/5 p-3"
         >
-          <p class="text-[0.7rem] font-bold uppercase tracking-wide text-info/80">
+          <p class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-info/80">
             Real objective
           </p>
-          <p class="mt-1 text-sm font-semibold">
+          <p class="mt-1 text-sm font-bold leading-relaxed">
             {{ store.session.seed.taskTitle }}
           </p>
-        </div>
+        </section>
 
-        <!-- The current action stays visible; the full plan is one disclosure
-             away. Pinning an unbounded grid of every checkpoint would push the
-             story itself off the screen on a long quest. -->
         <section
           v-if="store.session.checkpoints.length"
           class="rounded-2xl border border-secondary/20 bg-secondary/5 p-3"
         >
           <div class="flex flex-wrap items-center justify-between gap-2">
             <div>
-              <p class="text-[0.7rem] font-bold uppercase tracking-wide text-secondary/75">
-                Practical checkpoint plan
+              <p
+                class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-secondary/75"
+              >
+                Mission rail
               </p>
-              <p v-if="store.currentCheckpoint" class="mt-1 text-sm font-semibold">
-                Current action: {{ store.currentCheckpoint.title }}
+              <p v-if="store.currentCheckpoint" class="mt-1 text-sm font-bold">
+                {{ store.currentCheckpoint.title }}
               </p>
               <p v-else class="mt-1 text-xs text-base-content/55">
-                All planned checkpoints have an outcome. Review any optional Apply
-                actions, then finish the quest.
+                Every planned checkpoint has an outcome.
               </p>
             </div>
             <span class="badge badge-secondary badge-sm rounded-xl">
-              {{ store.remainingCheckpoints.length }} remaining
+              {{ store.remainingCheckpoints.length }} left
             </span>
           </div>
-          <details class="mt-2">
+          <details class="mt-3">
             <summary
-              class="cursor-pointer text-[0.7rem] font-bold uppercase tracking-wide text-secondary/60"
+              class="cursor-pointer text-[0.68rem] font-black uppercase tracking-wide text-secondary/65"
             >
-              All {{ store.session.checkpoints.length }} checkpoints
+              Full checkpoint plan
             </summary>
-            <div class="mt-2 grid gap-2 sm:grid-cols-2">
-              <article
+            <ol class="mt-2 space-y-2">
+              <li
                 v-for="checkpoint in store.session.checkpoints"
                 :key="checkpoint.id"
                 class="rounded-xl border border-base-300 bg-base-100 p-2.5 text-xs"
@@ -336,8 +680,8 @@
                 <p v-if="checkpoint.proposedNote" class="mt-1 text-base-content/55">
                   {{ checkpoint.proposedNote }}
                 </p>
-              </article>
-            </div>
+              </li>
+            </ol>
           </details>
         </section>
 
@@ -345,20 +689,14 @@
           v-if="store.currentHookContext && store.awaitingAnswer"
           class="flex items-start gap-2 rounded-2xl border border-info/30 bg-info/5 p-3"
         >
-          <Icon
-            name="kind-icon:alert"
-            class="mt-0.5 size-4 shrink-0 text-info"
-          />
+          <Icon name="kind-icon:alert" class="mt-0.5 size-4 shrink-0 text-info" />
           <div class="min-w-0 flex-1 text-xs leading-relaxed">
-            <p class="font-bold text-info">
-              This scene connects to:
-              <span class="font-normal text-base-content/80">
-                {{ store.currentHookContext.title }}
-              </span>
+            <p class="font-bold text-info">This scene connects to:</p>
+            <p class="mt-0.5 text-base-content/75">
+              {{ store.currentHookContext.title }}
             </p>
-            <p class="mt-0.5 text-base-content/50">
-              Taskmaster never marks work done or approves a decision merely
-              because you answered the story.
+            <p class="mt-1 text-base-content/45">
+              An answer proposes progress. It does not approve or complete the work.
             </p>
           </div>
         </div>
@@ -366,182 +704,29 @@
         <p v-if="store.errorMessage" class="text-xs text-error">
           {{ store.errorMessage }}
         </p>
-      </div>
 
-      <KrChatWindow
-        class="min-h-0 flex-1"
-        :turns="chatTurns"
-        label="Story transcript"
-        :is-streaming="store.isWeaving"
-        :streaming-text="store.streamingText"
-        streaming-label="Taskmaster is building the next scene…"
-        empty-label="Taskmaster is preparing the opening scene."
-      >
-        <template #after-turn="{ turn }">
-          <NarrativeArtStatus
-            v-if="beatForTurn(turn)"
-            class="mt-2"
-            :art="beatForTurn(turn)?.art"
-            :label="`Illustration for ${store.session?.seed.taskTitle || 'this quest'}`"
-            @retry="store.retryBeatArt(beatForTurn(turn)!.id)"
-          />
-        </template>
-
-        <!-- Recap and ledger scroll WITH the quest. They belong to the end of
-             the story, and pinning them would eat the fold on completion —
-             exactly when the transcript is longest. -->
-        <template #footer>
-          <div
-            v-if="store.isComplete"
-            class="space-y-3 rounded-2xl border border-secondary/30 bg-secondary/5 p-4"
-          >
-            <div class="text-center">
-              <p class="text-sm font-bold text-secondary">Quest complete</p>
-              <p class="mt-1 text-xs text-base-content/60">
-                Review any real-world updates below before applying them.
-              </p>
-            </div>
-            <dl
-              v-if="sessionRecap.length"
-              class="grid gap-2 text-xs leading-relaxed sm:grid-cols-2"
-            >
-              <div
-                v-for="item in sessionRecap"
-                :key="item.label"
-                class="rounded-xl border border-base-300 bg-base-100 p-3"
-              >
-                <dt class="font-bold text-base-content/70">{{ item.label }}</dt>
-                <dd class="mt-0.5 text-base-content/60">{{ item.value }}</dd>
-              </div>
-            </dl>
-          </div>
-
-          <div
-            v-if="store.pendingWriteBacks.length"
-            class="space-y-2 rounded-2xl border border-warning/30 bg-warning/5 p-4"
-          >
-            <div class="flex items-center gap-2">
-              <Icon name="kind-icon:gearhammer" class="size-4 text-warning" />
-              <h3 class="text-xs font-bold uppercase tracking-wide text-warning">
-                Quest ledger
-              </h3>
-            </div>
-            <p class="text-[0.7rem] leading-relaxed text-base-content/50">
-              Nothing is written automatically. Apply only the updates you want.
+        <section
+          v-if="store.canClose"
+          class="space-y-2 rounded-2xl border border-success/30 bg-success/5 p-3"
+        >
+          <div>
+            <p class="text-sm font-bold text-success">
+              All checkpoints have an outcome
             </p>
-            <article
-              v-for="item in store.pendingWriteBacks"
-              :key="item.beatId"
-              class="rounded-xl border border-base-300 bg-base-100 p-3 text-xs leading-relaxed"
-            >
-              <div class="flex items-start gap-2">
-                <div class="min-w-0 flex-1">
-                  <p class="font-bold">{{ item.title }}</p>
-                  <p class="mt-1 text-base-content/70">“{{ item.answer }}”</p>
-                  <p class="mt-1 text-base-content/50">
-                    <span class="font-semibold">Apply will:</span>
-                    {{ item.proposedWrite }}
-                  </p>
-                </div>
-                <span
-                  v-if="item.status === 'written'"
-                  class="badge badge-success badge-sm rounded-xl"
-                >
-                  written
-                </span>
-                <button
-                  v-else
-                  type="button"
-                  class="btn btn-warning btn-xs rounded-xl"
-                  :disabled="item.status === 'queued'"
-                  @click="store.applyWriteBack(item.beatId)"
-                >
-                  <span
-                    v-if="item.status === 'queued'"
-                    class="loading loading-spinner loading-xs"
-                  />
-                  <template v-else>Apply</template>
-                </button>
-              </div>
-            </article>
+            <p class="mt-0.5 text-xs text-base-content/55">
+              Finish for a practical recap and optional Apply actions.
+            </p>
           </div>
-        </template>
-      </KrChatWindow>
+          <button
+            type="button"
+            class="btn btn-success btn-sm w-full rounded-xl"
+            @click="store.closeStory()"
+          >
+            Finish the quest
+          </button>
+        </section>
+      </aside>
     </div>
-
-    <section
-      v-if="
-        store.session &&
-        store.session.status !== 'draft' &&
-        !store.isComplete &&
-        store.awaitingAnswer &&
-        store.currentCheckpoint
-      "
-      class="shrink-0 space-y-2 rounded-2xl border border-info/25 bg-info/5 p-3"
-    >
-      <div>
-        <p class="text-[0.7rem] font-bold uppercase tracking-wide text-info/75">
-          What happened in the real world?
-        </p>
-        <p class="mt-1 text-xs text-base-content/55">
-          Choose the honest checkpoint outcome, then describe what happened below.
-        </p>
-      </div>
-      <!-- The honest-outcome picker was a fifth hand-rolled pick-one grid. It
-           is kr-choice-list now: same four outcomes, same aria-pressed, and the
-           helper text rides in as the choice's hint rather than as a second
-           span the shared component would have had to learn about. -->
-      <kr-choice-list
-        layout="row"
-        label="Checkpoint outcome"
-        :choices="outcomeChoices"
-        :selected-key="selectedOutcome"
-        :show-index="false"
-        @select="selectedOutcome = $event.key as TaskmasterCheckpointOutcome"
-      />
-    </section>
-
-    <section
-      v-if="store.session && store.session.status !== 'draft' && store.canClose"
-      class="flex shrink-0 flex-wrap items-center justify-between gap-3 rounded-2xl border border-success/30 bg-success/5 p-3"
-    >
-      <div>
-        <p class="text-sm font-bold text-success">All checkpoints have an outcome</p>
-        <p class="mt-0.5 text-xs text-base-content/55">
-          Finish the quest for a practical recap of completed, blocked, deferred,
-          and missing-information items.
-        </p>
-      </div>
-      <button
-        type="button"
-        class="btn btn-success btn-sm rounded-xl"
-        @click="store.closeStory()"
-      >
-        Finish the quest
-      </button>
-    </section>
-
-    <NarrativeResponseComposer
-      v-if="
-        store.session &&
-        store.session.status !== 'draft' &&
-        !store.isComplete &&
-        !store.canClose
-      "
-      v-model="answerInput"
-      class="shrink-0"
-      :options="store.currentBeat?.question.options ?? []"
-      :disabled="!store.awaitingAnswer"
-      :loading="store.isWeaving"
-      :placeholder="
-        store.awaitingAnswer
-          ? 'What do you do?'
-          : 'Taskmaster is building the next scene…'
-      "
-      button-label="Continue"
-      hint="Story answers become proposed progress first. Real task changes still require an explicit Apply action."
-      @submit="submitAnswer"
-    />
   </section>
 </template>
 
@@ -598,8 +783,6 @@ const checkpointOutcomes: {
   { value: 'needs-info', label: 'Needs info', helper: 'A question or missing fact comes next.' },
 ]
 
-/* The shared list speaks {key,label,hint}. Adapt the product's vocabulary here
-   rather than teaching kr-choice-list what a checkpoint outcome is. */
 const outcomeChoices = computed(() =>
   checkpointOutcomes.map((outcome) => ({
     key: outcome.value,
@@ -608,8 +791,6 @@ const outcomeChoices = computed(() =>
   })),
 )
 
-// Tones are stored lowercase; the old buttons leaned on a `capitalize` class.
-// Capitalize in the adapter so the shared list needs no per-caller styling.
 const toneChoices = computed(() =>
   TASKMASTER_TONES.map((tone) => ({
     key: tone,
@@ -617,15 +798,10 @@ const toneChoices = computed(() =>
   })),
 )
 
-/* Beats persist as one record per scene; the chat window speaks one message per
-   speaker. narrativeBeatsToTurns is shared with Storybook so neither product
-   re-derives the mapping. */
 const chatTurns = computed(() =>
   narrativeBeatsToTurns(store.session?.beats ?? []),
 )
 
-/* The beat a narration turn came from — null for the user's own turns, so a
-   scene's illustration renders once rather than beside the answer as well. */
 function beatForTurn(turn: NarrativeTurn) {
   const beatId = beatIdFromTurnId(turn.id)
   if (!beatId) return null
@@ -659,6 +835,13 @@ const locationOptions = computed<NarrativeIngredientOption[]>(() =>
   })),
 )
 
+const selectedLocationLabel = computed(
+  () =>
+    locationOptions.value.find(
+      (item) => item.slug === selectedLocationSlug.value,
+    )?.title || 'Let Taskmaster choose',
+)
+
 const storyGrammarTaxonomies = new Set(['GENRE', 'CORE', 'THEME', 'MOOD', 'STYLE'])
 const grammarFacets = computed(() =>
   facetStore.activeFacets.filter(
@@ -679,6 +862,13 @@ const grammarOptions = computed<NarrativeIngredientOption[]>(() =>
     icon: facet.icon,
     badge: taxonomyLabel(facet.taxonomy),
   })),
+)
+
+const selectedGrammarLabel = computed(
+  () =>
+    grammarOptions.value.find(
+      (item) => item.slug === selectedGrammarSlug.value,
+    )?.title || 'Any adventure',
 )
 
 const sessionRecap = computed(() => {

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -197,7 +197,7 @@
                 </span>
               </span>
               <Icon
-                name="kind-icon:arrowdown"
+                name="kind-icon:chevron-down"
                 class="size-4 text-base-content/45 transition-transform group-open:rotate-180"
               />
             </summary>
@@ -241,7 +241,7 @@
                 </span>
               </span>
               <Icon
-                name="kind-icon:arrowdown"
+                name="kind-icon:chevron-down"
                 class="size-4 text-base-content/45 transition-transform group-open:rotate-180"
               />
             </summary>
@@ -320,7 +320,7 @@
           <span v-if="store.isWeaving" class="loading loading-dots loading-sm" />
           <template v-else>
             Build my quest
-            <Icon name="kind-icon:arrowright" class="size-4" />
+            <Icon name="kind-icon:chevron-right" class="size-4" />
           </template>
         </button>
         <p
@@ -634,10 +634,10 @@
               <p
                 class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-secondary/75"
               >
-                Mission rail
+                Practical checkpoint plan
               </p>
               <p v-if="store.currentCheckpoint" class="mt-1 text-sm font-bold">
-                {{ store.currentCheckpoint.title }}
+                Current action: {{ store.currentCheckpoint.title }}
               </p>
               <p v-else class="mt-1 text-xs text-base-content/55">
                 Every planned checkpoint has an outcome.
@@ -714,7 +714,7 @@
               All checkpoints have an outcome
             </p>
             <p class="mt-0.5 text-xs text-base-content/55">
-              Finish for a practical recap and optional Apply actions.
+              Review any optional Apply actions, then finish for a practical recap.
             </p>
           </div>
           <button


### PR DESCRIPTION
## Summary

- replace the stacked Taskmaster setup with an objective-first responsive Quest Desk
- remove the generic narrator stage from setup and plan review, eliminating the mysterious md/lg blank slab
- collapse optional setting and genre libraries behind compact disclosures
- add an explicit write-back safety badge and a mobile-safe sticky action rail
- reframe active quests as story plus mission rail, with the real objective and checkpoint status kept visible
- give the active narrator stage an explicit responsive minimum height so its md grid cannot collapse

## Root cause

The shared narrator stage was mounted before Taskmaster had a quest to narrate. At `md`, its image panel drops the mobile minimum height while the stage itself had no explicit height, allowing an awkward collapsed or blank region. The stage also duplicated the page introduction and pushed the actual objective controls below generic Ami content.

## Verification plan

- TypeScript
- Contract verifiers, including Taskmaster checkpoint and layout contracts
- ESLint/Prettier through required CI
- Vercel preview deployment and `/taskmaster` SSR fetch at desktop/mobile-oriented markup breakpoints

## Conductor

Project: `taskmaster`
Task: `t-003`
Session: `2026-08-05T034300Z-taskmaster-t-003-gpt56-8f42`

## TALKBACK

- The Taskmaster product contract remains intact: real objectives and practical checkpoints stay visible, narrative choices only propose progress, and every write-back remains an explicit Apply action.
- This change deliberately keeps Taskmaster's state machine and store separate from Storybook; it is a presentation and information-architecture pass only.
- Dedicated Taskmaster artwork was already queued under ArtJobs 2846-2850 in the earlier t-003 pass; this PR does not create or mutate art jobs.