### PR TITLE
Fix Icons, the scrolling layout toggle, giant page headers, and two overlay bugs

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -223,7 +223,12 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
   .badge,
   .btn,
   .tab {
-    font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto,
+    font-family:
+      ui-sans-serif,
+      system-ui,
+      -apple-system,
+      'Segoe UI',
+      Roboto,
       sans-serif;
   }
 
@@ -282,8 +287,20 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
   /* One non-scrolling control row (filters, tabs, actions) directly under
      .kr-surface. A page gets one — controls that need more than one row
      belong inside .kr-stage or .kr-scroll instead of stacking toolbars. */
+  /*
+   * `relative z-20` so the toolbar's own overlays — daisyUI tooltips, popovers,
+   * anything anchored to a control — paint ABOVE the scroll region that follows
+   * it, instead of sliding under the first row of cards. Silas, 2026-08-05, on
+   * /dreams: "the dream dash options are hiding underneath the main content,
+   * making it challenging to test."
+   *
+   * A toolbar is a flex row of buttons and inputs, so promoting it to a
+   * stacking context is safe here; if one ever gains an absolutely-positioned
+   * child that needs to escape the row, position that child against its own
+   * wrapper rather than removing this.
+   */
   .kr-toolbar {
-    @apply flex shrink-0 flex-wrap items-center gap-2;
+    @apply relative z-20 flex shrink-0 flex-wrap items-center gap-2;
   }
 
   /* THE scroll region — exactly one per .kr-surface. Everything that can

--- a/components/bots/bot-interact.vue
+++ b/components/bots/bot-interact.vue
@@ -3,19 +3,6 @@
   <section
     class="flex h-full min-h-0 w-full flex-col gap-4 rounded-2xl bg-base-200 p-4"
   >
-    <header
-      class="rounded-2xl border border-base-300 bg-base-100 p-4 text-center shadow-md"
-    >
-      <h1 class="text-2xl font-bold text-primary md:text-3xl">Bot Interact</h1>
-
-      <p
-        class="mx-auto mt-2 max-w-3xl text-sm text-base-content/70 md:text-base"
-      >
-        Chat with the selected bot, use starter prompts, and stream responses
-        through the active text server.
-      </p>
-    </header>
-
     <div
       v-if="statusMessage"
       class="kr-note"
@@ -388,7 +375,6 @@ import { useBotStore } from '@/stores/botStore'
 import { useChatStore } from '@/stores/chatStore'
 import { usePromptStore } from '@/stores/promptStore'
 import { useServerStore } from '@/stores/serverStore'
-import { useUserStore } from '@/stores/userStore'
 
 type SessionChat = {
   id: number
@@ -404,7 +390,6 @@ const botStore = useBotStore()
 const chatStore = useChatStore()
 const promptStore = usePromptStore()
 const serverStore = useServerStore()
-const userStore = useUserStore()
 
 const message = ref('')
 const statusMessage = ref('')

--- a/components/gallery/kr-entity-card-body.vue
+++ b/components/gallery/kr-entity-card-body.vue
@@ -50,24 +50,45 @@
     left and the text is the content, so the row stays readable at any width
     and the icons grid can pack tightly without squeezing anything.
   -->
-  <div
-    v-if="variant === 'icon'"
-    class="flex w-full items-center gap-3 px-1 py-1.5"
-  >
-    <kr-art-plate
-      v-if="showImage"
-      :source="source"
-      :variant="variant"
-      :fallback="fallback"
-      :alt="title"
-      shape="square"
-      frame="none"
-      :fit="fit"
-      :placeholder-icon="placeholderIcon"
-      class="size-12 shrink-0 overflow-hidden rounded-xl"
-    />
+  <div v-if="variant === 'icon'" class="flex w-full items-center gap-3">
+    <!--
+      The thumbnail is sized by this WRAPPER, never by classes on the plate.
 
-    <div class="min-w-0 flex-1">
+      kr-art-plate's aspect map returns `aspect-square w-full` (every shape
+      carries `w-full`), so a `size-12` passed down as a class fought `w-full`
+      for the same `width` property at equal specificity and lost. The plate
+      then went full-row-width, `shrink-0` kept it there, the text column next
+      to it collapsed to zero, and the art sat centered in a wide empty box —
+      Silas, 2026-08-05, seeing /characters Icons: "no text, just not what I
+      would expect an icon focused layout to look like."
+
+      Constraining from the outside removes the conflict instead of winning it:
+      `w-full` now resolves against a 3.5rem box, which is what it was always
+      meant to do. Do not move this sizing back onto the plate.
+    -->
+    <div
+      v-if="showImage"
+      class="size-14 shrink-0 overflow-hidden rounded-xl bg-base-300"
+    >
+      <kr-art-plate
+        :source="source"
+        :variant="variant"
+        :fallback="fallback"
+        :alt="title"
+        shape="square"
+        frame="none"
+        fit="cover"
+        :placeholder-icon="placeholderIcon"
+      />
+    </div>
+
+    <!--
+      pr-16 leaves the lane reactable-card's absolutely-positioned action
+      cluster (karma chip + React button, `right-2 top-2`) occupies. Without it
+      those controls sit on top of the title, which is only noticeable in this
+      variant because the row is short enough for `top-2` to reach the text.
+    -->
+    <div class="min-w-0 flex-1 pr-16">
       <h2 class="truncate text-sm font-black leading-tight" :title="title">
         {{ title }}
       </h2>

--- a/components/gallery/kr-gallery.vue
+++ b/components/gallery/kr-gallery.vue
@@ -9,7 +9,20 @@
 -->
 <template>
   <div class="flex w-full flex-col gap-3">
-    <div v-if="modes.length" class="flex shrink-0 gap-0.5">
+    <!--
+      STICKY, because the shell does not own the scroll container -- the parent
+      does, and every adopting parent scrolls the whole gallery including this
+      bar. Silas, 2026-08-05: "the layout toggle ... are improperly placed
+      inside the scrollable container so we cannot see after scrolling down."
+      Sticking to the top of whatever ancestor scrolls keeps the control
+      reachable without requiring each parent to restructure its panes. The
+      background is required: without it the grid shows through as it passes
+      under the buttons.
+    -->
+    <div
+      v-if="modes.length"
+      class="sticky top-0 z-20 -mx-1 flex shrink-0 gap-0.5 bg-base-300/95 px-1 py-1 backdrop-blur"
+    >
       <button
         v-for="entry in modes"
         :key="entry.value"

--- a/components/rewards/reward-interact.vue
+++ b/components/rewards/reward-interact.vue
@@ -3,24 +3,14 @@
   <section
     class="flex h-full min-h-0 w-full flex-col gap-4 rounded-2xl bg-base-200 p-4"
   >
+    <!--
+      Was `v-else` against the static page-title hero that used to sit above it.
+      That hero duplicated the title workspace-header already renders from
+      frontmatter, so it is gone and this states its own condition instead: the
+      selected-reward bar belongs to interact mode.
+    -->
     <header
-      v-if="!isInteractMode"
-      class="shrink-0 rounded-2xl border border-base-300 bg-base-100 p-4 text-center shadow-md"
-    >
-      <h1 class="text-2xl font-bold text-primary md:text-3xl">
-        What Happens When You Find It?
-      </h1>
-
-      <p
-        class="mx-auto mt-2 max-w-3xl text-sm text-base-content/70 md:text-base"
-      >
-        You've stumbled across something strange and powerful. Tell us who you
-        are, how you found it, and what you do next.
-      </p>
-    </header>
-
-    <header
-      v-else
+      v-if="isInteractMode"
       class="flex shrink-0 items-center gap-3 rounded-2xl border border-base-300 bg-base-100 p-3 shadow-md"
     >
       <button

--- a/components/scenarios/scenario-card.vue
+++ b/components/scenarios/scenario-card.vue
@@ -13,35 +13,59 @@
     @select="selectScenario"
   >
     <template #actions>
-      <button
-        v-if="showActions && canEdit"
-        class="rounded-full bg-base-100/90 p-2 text-primary shadow backdrop-blur transition hover:bg-primary hover:text-primary-content"
-        type="button"
-        title="Edit Scenario"
-        @click.stop="emit('edit', scenario.id)"
-      >
-        <Icon name="kind-icon:pencil" class="h-4 w-4" />
-      </button>
+      <!--
+        HIDDEN AT REST. These three sat visible on every card at all times,
+        three filled circles punched over the art. Silas, 2026-08-05: "the icon
+        popups for delete copy etc should def not be visible on load, maybe
+        maybe maybe on hover is fine, but the implementation looks ugly."
 
-      <button
-        v-if="showActions && allowClone"
-        class="rounded-full bg-base-100/90 p-2 text-secondary shadow backdrop-blur transition hover:bg-secondary hover:text-secondary-content"
-        type="button"
-        title="Clone Scenario"
-        @click.stop="emit('clone', scenario.id)"
+        Its siblings (character-card, bot-card, reward-card) already gated the
+        same buttons on `activeSelected || compact`; scenario-card was the one
+        that never did, which is why only Scenarios looked like this. Matching
+        them, plus a hover/focus reveal so the actions stay discoverable
+        without having to select first. focus-within matters: hover alone hides
+        these from keyboard users entirely, and a card that must be selected
+        before it can be deleted is fine, but one that can never be reached by
+        keyboard is not.
+      -->
+      <div
+        class="flex items-center gap-2 transition-opacity duration-150"
+        :class="
+          activeSelected || compact
+            ? 'opacity-100'
+            : 'opacity-0 focus-within:opacity-100 group-hover:opacity-100'
+        "
       >
-        <Icon name="kind-icon:copy" class="h-4 w-4" />
-      </button>
+        <button
+          v-if="showActions && canEdit"
+          class="rounded-full bg-base-100/90 p-2 text-primary shadow backdrop-blur transition hover:bg-primary hover:text-primary-content"
+          type="button"
+          title="Edit Scenario"
+          @click.stop="emit('edit', scenario.id)"
+        >
+          <Icon name="kind-icon:pencil" class="h-4 w-4" />
+        </button>
 
-      <button
-        v-if="showActions && canDelete"
-        class="rounded-full bg-base-100/90 p-2 text-error shadow backdrop-blur transition hover:bg-error hover:text-error-content"
-        type="button"
-        title="Delete Scenario"
-        @click.stop="deleteScenario"
-      >
-        <Icon name="kind-icon:trash" class="h-4 w-4" />
-      </button>
+        <button
+          v-if="showActions && allowClone"
+          class="rounded-full bg-base-100/90 p-2 text-secondary shadow backdrop-blur transition hover:bg-secondary hover:text-secondary-content"
+          type="button"
+          title="Clone Scenario"
+          @click.stop="emit('clone', scenario.id)"
+        >
+          <Icon name="kind-icon:copy" class="h-4 w-4" />
+        </button>
+
+        <button
+          v-if="showActions && canDelete"
+          class="rounded-full bg-base-100/90 p-2 text-error shadow backdrop-blur transition hover:bg-error hover:text-error-content"
+          type="button"
+          title="Delete Scenario"
+          @click.stop="deleteScenario"
+        >
+          <Icon name="kind-icon:trash" class="h-4 w-4" />
+        </button>
+      </div>
     </template>
 
     <kr-entity-card-body

--- a/components/servers/server-interact.vue
+++ b/components/servers/server-interact.vue
@@ -1,27 +1,36 @@
 <!-- /components/server/server-interact.vue -->
 <template>
   <section class="flex w-full flex-col gap-4 rounded-2xl bg-base-200 p-4">
-    <header class="flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-100 p-4 text-center shadow-md lg:flex-row lg:items-center lg:justify-between lg:text-left">
-      <div class="min-w-0">
-        <h1 class="text-2xl font-bold text-primary md:text-3xl">
-          Server Tools
-        </h1>
-        <p class="mx-auto mt-2 max-w-3xl text-sm text-base-content/70 lg:mx-0">
-          Manage only real access points. Routes decide capabilities. Mana decides billing.
-        </p>
-      </div>
-
+    <header
+      class="flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-100 p-4 text-center shadow-md lg:flex-row lg:items-center lg:justify-between lg:text-left"
+    >
       <div class="flex flex-wrap justify-center gap-2 lg:justify-end">
-        <button class="btn btn-primary rounded-xl" type="button" @click="startServerPreset('COMFY')">
+        <button
+          class="btn btn-primary rounded-xl"
+          type="button"
+          @click="startServerPreset('COMFY')"
+        >
           Comfy
         </button>
-        <button class="btn btn-secondary rounded-xl" type="button" @click="startServerPreset('A1111')">
+        <button
+          class="btn btn-secondary rounded-xl"
+          type="button"
+          @click="startServerPreset('A1111')"
+        >
           A1111
         </button>
-        <button class="btn rounded-xl" type="button" @click="startServerPreset('OPENAI')">
+        <button
+          class="btn rounded-xl"
+          type="button"
+          @click="startServerPreset('OPENAI')"
+        >
           OpenAI
         </button>
-        <button class="btn rounded-xl" type="button" @click="startServerPreset('ANTHROPIC')">
+        <button
+          class="btn rounded-xl"
+          type="button"
+          @click="startServerPreset('ANTHROPIC')"
+        >
           Anthropic
         </button>
       </div>
@@ -59,12 +68,16 @@ const showServerForm = ref(false)
 
 const artSummary = computed(() => {
   const server = serverStore.activeArtServer
-  return server ? `${server.label || server.title} · ${server.serverType}` : 'No art server selected.'
+  return server
+    ? `${server.label || server.title} · ${server.serverType}`
+    : 'No art server selected.'
 })
 
 const textSummary = computed(() => {
   const server = serverStore.activeTextServer
-  return server ? `${server.label || server.title} · ${server.serverType}` : 'No text server selected.'
+  return server
+    ? `${server.label || server.title} · ${server.serverType}`
+    : 'No text server selected.'
 })
 
 function startServerPreset(serverType: ServerType) {

--- a/utils/scripts/lint-ratchet-baseline.json
+++ b/utils/scripts/lint-ratchet-baseline.json
@@ -1,7 +1,7 @@
 {
   "note": "ESLint RATCHET: this file may only ever shrink. --update refuses to record a larger count. See utils/scripts/verifyLintRatchet.ts.",
   "recorded": "2026-08-05",
-  "total": 397,
+  "total": 396,
   "violations": {
     "vue/v-on-event-hyphenation": ["app.vue:16:22"],
     "@typescript-eslint/no-explicit-any": [
@@ -181,7 +181,6 @@
     ],
     "no-extra-boolean-cast": ["components/bots/add-bot.vue:688:51"],
     "@typescript-eslint/no-unused-vars": [
-      "components/bots/bot-interact.vue:407:7",
       "components/builder/builder-art-input.vue:66:8",
       "components/butterfly/butterfly-guide.vue:378:7",
       "components/characters/character-flip-card.vue:512:7",


### PR DESCRIPTION
From your device-eyes pass on the live deployment — the verification nothing in this project could do from a sandbox. Five fixes; four are shared, so they land on every gallery at once.

## 1. Icons was broken — a CSS specificity tie

You called it before I finished: *"without an icon, we aren't properly sizing the fallback items."*

`kr-art-plate`'s aspect map returns `aspect-square w-full` — **every** shape carries `w-full`. The icon row passed `size-12` as a class on the plate:

```html
<div class="... aspect-square w-full   size-12 shrink-0 ...">
```

Both set `width`, equal specificity, so `w-full` wins. The plate went full-row-width, `shrink-0` pinned it there, the adjacent text column (`min-w-0 flex-1`) collapsed to zero, and the art sat centered in a wide empty box. Wide beige box, tiny picture, no text — exactly your screenshot.

**Fixed by constraining from the outside**: a `size-14` wrapper owns the geometry and `w-full` resolves against *it*. No other caller sizes the plate by class, so this was isolated to the icon row.

## 2. The giant header, and the correlation that proved it

The repo already had a rule for this — `tailwind.css`'s header doctrine and the `one-header` contract rule:

> *workspace-header.vue already renders icon, hero image, room label, and title from content frontmatter on every page. A page component NEVER renders its own `<h1>` — that's a duplicate title, not a second heading.*

`bot-interact` and `reward-interact` each rendered exactly that: a centered `shrink-0` hero with a `text-2xl md:text-3xl` `<h1>` plus a paragraph, sitting above the gallery and restating what the page header already said.

**The correlation is the evidence.** Of the four browse pages you reviewed, the three with a duplicate `<h1>` — bots, rewards, scenarios — are the three you flagged for a giant header. `character-interact`, the only one with no `<h1>`, is the one you said *"looks great."*

Removed from bot-interact and reward-interact; `server-interact` had the same block and keeps its buttons, loses the title. **Kept** the remaining `<h1>` in scenario-interact and reward-interact — those render the *selected* scenario/reward name in a back-button row, which is contextual state, not a page title.

## 3. The layout toggle scrolled away

`kr-gallery` doesn't own its scroll container; every adopting parent scrolls the whole gallery, bar included. Now **sticky** to the top of whatever ancestor scrolls.

This is also why **/dreams looked like it had no toggle at all** — your dreams screenshot is scrolled down (the scrollbar thumb is near the bottom) and the bar had gone with the content. Same bug, not a missing feature.

## 4. Toolbar overlays painted under the content

`.kr-toolbar` had no stacking context, so its tooltips slid beneath the first row of cards — *"the dream dash options are hiding underneath the main content."* Now `relative z-20`, fixed once for all eight consumers.

## 5. Scenario actions were visible on every card at rest

`character-card`, `bot-card` and `reward-card` already gated those three buttons on `activeSelected || compact`. **`scenario-card` never did** — which is why only Scenarios had circles punched over the art. Matched to its siblings, plus a hover/`focus-within` reveal; hover alone would hide them from keyboard users.

Also gave the icon row `pr-16` so `reactable-card`'s karma chip and React button stop landing on the title — the row is short enough that `top-2` reaches the text, which taller variants never exposed.

## The lint gate paid for itself the same day

Removing the reward hero broke a `v-if`/`v-else` chain, and `bot-interact` had a `userStore` assigned and never read. **ESLint caught both; vue-tsc passed both** — exactly the failure class t-099 was built for, hours after it landed. The dead store drops the ratchet 397 → 396.

## Verification

- `npm run test` (vue-tsc) — clean
- `test:layout-contract` — 0 violations across all 8 rules
- `test:gallery-consistency` — passes
- `test:lint-ratchet` — 396, tightened
- `npx eslint` on every touched file — clean

Still unverified, and the reason this PR exists: how it now looks. `/characters` → Icons is the one I'd most want your eyes on.