### PR TITLE
Give the Icons row its text back, and teach the audit to see starved text

### DIFF
--- a/components/gallery/kr-entity-card-body.vue
+++ b/components/gallery/kr-entity-card-body.vue
@@ -83,25 +83,34 @@
     </div>
 
     <!--
-      pr-16 leaves the lane reactable-card's absolutely-positioned action
-      cluster (karma chip + React button, `right-2 top-2`) occupies. Without it
-      those controls sit on top of the title, which is only noticeable in this
-      variant because the row is short enough for `top-2` to reach the text.
+      TEXT GETS THE REST. An earlier pass reserved `pr-16` here for
+      reactable-card's absolutely-positioned action cluster, but that cluster is
+      hidden at rest and absent entirely when there is no karma to show — so on
+      a ~230px cell it was donating a quarter of the row to nothing and
+      truncating titles to "My Boss is...". Silas, 2026-08-05: "not enough space
+      given to the description."
+
+      Badges sit INLINE with the subtitle rather than on their own line, which
+      is what made a single chip cost a third of the row's height.
     -->
-    <div class="min-w-0 flex-1 pr-16">
+    <div class="min-w-0 flex-1 pr-1">
       <h2 class="truncate text-sm font-black leading-tight" :title="title">
         {{ title }}
       </h2>
 
-      <p v-if="subtitle" class="truncate text-xs text-base-content/60">
-        {{ subtitle }}
-      </p>
+      <div class="flex min-w-0 items-center gap-1.5">
+        <p
+          v-if="subtitle"
+          class="min-w-0 flex-1 truncate text-xs text-base-content/60"
+          :title="subtitle"
+        >
+          {{ subtitle }}
+        </p>
 
-      <div v-if="badges.length" class="mt-1 flex flex-wrap gap-1">
         <span
           v-for="badge in badges"
           :key="badge.label"
-          class="badge badge-xs"
+          class="badge badge-xs shrink-0"
           :class="badge.class || 'badge-primary'"
         >
           {{ badge.label }}

--- a/components/scenarios/scenario-card.vue
+++ b/components/scenarios/scenario-card.vue
@@ -216,9 +216,11 @@ const introCount = computed(() => {
 
 const badges = computed<EntityCardChip[]>(() => {
   const result: EntityCardChip[] = []
-  if (props.scenario.userId === userStore.userId) {
-    result.push({ label: 'Yours', class: 'badge-primary' })
-  }
+  // No 'Yours' chip. /stories shows the signed-in user their own scenarios, so
+  // it rendered on all 152 of them — a badge that is always true carries no
+  // information and cost a third of each icon row. Silas, 2026-08-05: "the
+  // owner info should not even be present on this gallery, and 'Yours' takes up
+  // a full third of the space."
   if (props.scenario.isMature) {
     result.push({ label: 'Mature', class: 'badge-warning' })
   }

--- a/utils/scripts/auditResponsiveLayout.mjs
+++ b/utils/scripts/auditResponsiveLayout.mjs
@@ -120,6 +120,7 @@ function collect(minFlexWidth) {
 
   const spill = []
   const crushed = []
+  const starved = []
   for (const el of document.querySelectorAll('body *')) {
     const b = el.getBoundingClientRect()
     if (!visible(el, b)) continue
@@ -147,6 +148,41 @@ function collect(minFlexWidth) {
           node: el,
           text: describe(el, `w=${Math.round(b.width)}`),
         })
+      }
+    }
+
+    /*
+     * STARVED TEXT — an element that truncates away most of what it says.
+     *
+     * This is the gap Silas named on 2026-08-05, after two rounds of reporting
+     * layout problems this audit had passed clean: "I'm a little surprised
+     * these things aren't flagged automatically." Nothing above catches it.
+     * `crushed` needs a box under minFlexWidth, and a truncating title in a
+     * comfortable 150px column is not crushed — it is just not showing its
+     * content. The gallery renders "My Boss is..." for "My Boss is a Dungeon
+     * Master" and every check reported healthy.
+     *
+     * It IS mechanically detectable: a single-line `truncate` (or a clamped
+     * block) that is hiding text has scrollWidth > clientWidth, and the ratio
+     * is how much of the string survives. Flagging below 60% keeps ordinary
+     * tidy truncation quiet while catching text that has effectively been
+     * deleted from the page.
+     */
+    if (b.width >= 1 && el.children.length === 0) {
+      const label = el.textContent.trim()
+      if (label.length >= 12) {
+        const cs = getComputedStyle(el)
+        const clips =
+          cs.textOverflow === 'ellipsis' ||
+          cs.overflow === 'hidden' ||
+          cs.webkitLineClamp !== 'none'
+        const shown = el.clientWidth / (el.scrollWidth || 1)
+        if (clips && el.scrollWidth > el.clientWidth + 1 && shown < 0.6) {
+          starved.push({
+            node: el,
+            text: describe(el, `showing ${Math.round(shown * 100)}%`),
+          })
+        }
       }
     }
   }
@@ -198,9 +234,22 @@ function collect(minFlexWidth) {
     horizontalScroll: de.scrollWidth > vw + 1,
     spill: spill.slice(0, 6).map((s) => s.text),
     crushed: crushed.slice(0, 6).map((c) => c.text),
+    starved: starved.slice(0, 8).map((s) => s.text),
+    starvedTotal: starved.length,
     brokenArt: brokenArt.slice(0, 8),
     brokenArtTotal: brokenArt.length,
   }
+}
+
+/**
+ * Text that truncates away most of itself. Printed for every route that has
+ * any, whether or not the route otherwise failed — the whole point is that
+ * these were invisible to the pass/fail line.
+ */
+function reportStarved(m) {
+  if (!m.starvedTotal) return
+  console.log(`         STARVED-TEXT ${m.starvedTotal} element(s):`)
+  for (const s of m.starved) console.log(`           ${s}`)
 }
 
 const browser = await chromium.launch({
@@ -281,6 +330,16 @@ for (const vp of VIEWPORTS) {
         console.log(`         BROKEN-ART ${m.brokenArtTotal} image(s):`)
         for (const a of m.brokenArt) console.log(`           ${a}`)
       }
+      reportStarved(m)
+    } else if (m.starvedTotal) {
+      // Reported, deliberately NOT counted as a failure yet. Starved text is
+      // new (2026-08-05) and the app has pre-existing truncation that would
+      // red-line every route on day one; a check that fails everything gets
+      // switched off rather than acted on. Surface it, work the number down,
+      // then decide whether it graduates to a failure or a ratcheted baseline
+      // like the layout contract's.
+      console.log(`${label} ⚠️`)
+      reportStarved(m)
     } else {
       console.log(`${label} ✅`)
     }


### PR DESCRIPTION
Follow-up on your second pass at `/stories` → Icons.

## The padding was mine

The previous commit reserved `pr-16` in the icon row for `reactable-card`'s absolutely-positioned action cluster. But that cluster is **hidden at rest** and **absent entirely** when there's no karma to show — so on a ~230px cell it was donating a quarter of the row to nothing.

That's why titles read "My Boss is…" for *"My Boss is a Dungeon Master"*. Now `pr-1`.

## Badges inline, and "Yours" gone

A single chip on its own `mt-1` line cost a third of the row's height. Subtitle and badges now share one line — subtitle flexes, badges `shrink-0`.

**"Yours" is removed from scenario-card entirely.** `/stories` shows you your own scenarios, so it rendered on all 152. A badge that is always true carries no information, and it was charging a third of every row for the privilege. "Mature" stays, because it isn't always true.

## The part that shouldn't have needed you

> *"I'm a little surprised these things aren't flagged automatically."*

You're right, and here's the actual reason: **nothing measured it.** `crushed` requires a box under `MIN_FLEX_WIDTH`, and a title truncating inside a comfortable 150px column isn't crushed — it's just not showing its content. No check looked at that. Two rounds of real defects passed this audit clean.

It's mechanically detectable. An element that clips (ellipsis / overflow-hidden / line-clamp) whose `scrollWidth > clientWidth` is hiding text, and the ratio is how much survives:

```
STARVED-TEXT 6 element(s):
  <h2 class="truncate text-sm font-black"> showing 35%
```

Below 60%, with at least 12 characters, is text that's effectively been deleted from the page. **"My Boss is…" shows about 35% and would have been flagged on sight.**

**Deliberately not a failure yet.** The app has pre-existing truncation that would red-line every route on day one, and a check that fails everything gets switched off rather than acted on. It prints `STARVED-TEXT` on any route that has it — *including routes that otherwise pass* — and marks them ⚠️. Once the number is worked down it can graduate to a hard failure or a ratcheted baseline like the layout contract's.

## On the wider question

To be straight about what I can and can't do: I can read screenshots you send, and they've been decisive every time. I **can't** capture them here — Chromium in this sandbox can't reach any https host, so Playwright can't drive a page. The audit *does* upload screenshots as artifacts in CI, but downloading those needs an authenticated fetch I don't have.

So the durable fix isn't "let me look" — it's making this class of problem measurable, which is what the detector above starts. If you want to go further, mockups would genuinely help for the *aesthetic* half (spacing rhythm, hierarchy, what a row should feel like); the *mechanical* half — truncation, overflow, collision, broken art — is checkable and should keep moving into CI.

## Verification

- `npm run test` (vue-tsc) — clean
- `test:layout-contract` — 0 violations, unchanged
- `test:gallery-consistency` — passes
- `test:lint-ratchet` — 396, unchanged
- `node --check` on the audit script, `npx eslint` on all touched files — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_