### PR TITLE
ai-art-academy/t-010: group semantics for Academy/art-styler toggle clusters

### DIFF
--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -22,7 +22,11 @@
       </div>
 
       <div class="flex w-full flex-col gap-2 sm:w-auto sm:items-end">
-        <div class="join" aria-label="Filter Academy lessons by progress">
+        <div
+          class="join"
+          role="group"
+          aria-label="Filter Academy lessons by progress"
+        >
           <button
             v-for="option in lessonFilterOptions"
             :key="option.value"
@@ -67,7 +71,10 @@
           </button>
         </div>
 
-        <p class="text-xs font-semibold text-base-content/50" aria-live="polite">
+        <p
+          class="text-xs font-semibold text-base-content/50"
+          aria-live="polite"
+        >
           {{ resultSummary }}
         </p>
       </div>

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -29,6 +29,8 @@
         <div class="flex-1" />
         <div
           class="flex overflow-hidden rounded-lg border border-base-300 text-xs"
+          role="group"
+          aria-label="Source image tab"
         >
           <button
             type="button"
@@ -362,7 +364,11 @@
       </div>
     </Transition>
 
-    <div class="flex flex-wrap gap-1.5">
+    <div
+      class="flex flex-wrap gap-1.5"
+      role="group"
+      aria-label="Filter styles by category"
+    >
       <button
         v-for="cat in allCategories"
         :key="cat"
@@ -1283,8 +1289,7 @@ async function hydrateGalleryThumbs() {
           })
 
           const hydrated = fetched as
-            | (ArtImage & { thumbnailData?: string | null })
-            | null
+            (ArtImage & { thumbnailData?: string | null }) | null
 
           if (hydrated?.thumbnailData) {
             galleryThumbs.value = {


### PR DESCRIPTION
### Task
ai-art-academy/t-010: Academy continuous improvement pass — lane 1 (front-end style/polish pass on Academy or art-styler surfaces) (kind: software)

### What changed / what I produced
- `components/academy/academy-styles-browser.vue`: added `role="group"` to the lesson-progress filter buttons (All/New/Explored), which already had per-button `aria-pressed` but no group container semantics.
- `components/art/art-styler.vue`: added `role="group"` + `aria-label` to the source-image tab row (Upload/Gallery/Starters) and the style-category filter row, for the same reason.
- All three clusters already used `aria-pressed` correctly on each toggle button — the gap was purely at the container level, so assistive tech had no way to announce them as a related set of options.
- Picked up one pre-existing, unrelated Prettier formatting drift on a line in `art-styler.vue` while the file was open (a multi-line union type the repo's current Prettier version wants collapsed) — trivial whitespace-only, no behavior change.

### How I verified
- `npx prettier --check` on both changed files: clean.
- `npx eslint` on both changed files: clean.
- Full-project `npx vue-tsc --noEmit`: exit 0, zero errors.
- Read all five Academy components plus `art-styler.vue` and `academyStore.ts` in full before making a change, to avoid duplicating any bug class already fixed in a prior continuous-improvement cycle (see `projects/ai-art-academy/docs/continuous-improvement-run-log.md` in conductor).

### Stakes
reversible

### Notes for reviewer
Small, scoped, additive-only accessibility change. No behavior change for sighted/mouse users.


---
_Generated by [Claude Code](https://claude.ai/code/session_019F243G21GW2VybtsrygF7k)_