### PR TITLE
Add move-to-front controls for ArtJobs

### DIFF
--- a/components/art/artjob-queue-card.vue
+++ b/components/art/artjob-queue-card.vue
@@ -60,6 +60,12 @@
           >
             {{ job.projectSlug }}
           </span>
+          <span
+            v-if="job.priority > 0"
+            class="badge badge-accent badge-xs rounded-2xl"
+          >
+            Priority {{ job.priority }}
+          </span>
         </div>
         <p
           v-if="canShowJobContent"
@@ -159,6 +165,20 @@
 
       <div class="flex flex-wrap items-center gap-1">
         <button
+          v-if="job.status === 'PENDING'"
+          type="button"
+          class="btn btn-xs rounded-2xl"
+          :class="job.priority > 0 ? 'btn-outline' : 'btn-accent'"
+          :disabled="priorityStore.prioritizingJobIds.includes(job.id)"
+          @click="togglePriority"
+        >
+          <span
+            v-if="priorityStore.prioritizingJobIds.includes(job.id)"
+            class="loading loading-spinner loading-xs"
+          />
+          {{ job.priority > 0 ? 'Normal priority' : 'Move to front' }}
+        </button>
+        <button
           v-if="isEditableInPlace"
           type="button"
           class="btn btn-primary btn-xs rounded-2xl"
@@ -222,6 +242,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useArtJobStore, type ArtJobRecord } from '@/stores/artJobStore'
+import { useArtJobPriorityStore } from '@/stores/artJobPriorityStore'
 import { useArtStore } from '@/stores/artStore'
 import { resolveMaturityPrivacy } from '@/utils/maturityPrivacy'
 
@@ -237,6 +258,7 @@ const emit = defineEmits<{
 }>()
 
 const artJobStore = useArtJobStore()
+const priorityStore = useArtJobPriorityStore()
 const artStore = useArtStore()
 const copied = ref(false)
 
@@ -383,6 +405,14 @@ async function handleCopy(): Promise<void> {
   window.setTimeout(() => {
     copied.value = false
   }, 1500)
+}
+
+async function togglePriority(): Promise<void> {
+  if (props.job.priority > 0) {
+    await priorityStore.returnToNormal(props.job.id)
+    return
+  }
+  await priorityStore.moveToFront(props.job.id)
 }
 
 function jobStatusClass(status: string): string {

--- a/prisma/migrations/20260805071500_prioritize_taskmaster_art_jobs/migration.sql
+++ b/prisma/migrations/20260805071500_prioritize_taskmaster_art_jobs/migration.sql
@@ -1,0 +1,7 @@
+-- Put the currently queued Taskmaster art package ahead of the ordinary backlog.
+-- This is deliberately data-preserving and only touches still-pending work.
+UPDATE `ArtJob`
+SET `priority` = 100
+WHERE `status` = 'PENDING'
+  AND (`projectSlug` = 'taskmaster' OR `id` IN (2846, 2847, 2848, 2849, 2850))
+  AND `priority` < 100;

--- a/server/api/art/queue/[id]/priority.post.ts
+++ b/server/api/art/queue/[id]/priority.post.ts
@@ -1,0 +1,88 @@
+// /server/api/art/queue/[id]/priority.post.ts
+//
+// Admin action: change the priority of a pending ArtJob. The relay already
+// claims runnable work by priority DESC, id ASC, so raising a job here moves it
+// ahead of normal-priority work without rewriting timestamps or duplicating it.
+import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
+import prisma from '../../../../utils/prisma'
+import { errorHandler } from '../../../../utils/error'
+import { requireMachineUser } from '../../../../utils/authGuard'
+
+type PriorityBody = {
+  priority?: number | null
+}
+
+const MIN_PRIORITY = 0
+const MAX_PRIORITY = 1000
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireMachineUser(event)
+
+    if (!auth.isAdmin && !auth.isServerKey) {
+      throw createError({
+        statusCode: 403,
+        message: 'Admin access required to prioritize jobs.',
+      })
+    }
+
+    const id = Number(getRouterParam(event, 'id'))
+
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid job id.' })
+    }
+
+    const body = (await readBody(event).catch(() => null)) as PriorityBody | null
+    const priority = Number(body?.priority)
+
+    if (
+      !Number.isInteger(priority) ||
+      priority < MIN_PRIORITY ||
+      priority > MAX_PRIORITY
+    ) {
+      throw createError({
+        statusCode: 400,
+        message: `Priority must be an integer from ${MIN_PRIORITY} to ${MAX_PRIORITY}.`,
+      })
+    }
+
+    const job = await prisma.artJob.findUnique({ where: { id } })
+
+    if (!job) {
+      throw createError({ statusCode: 404, message: `Job ${id} not found.` })
+    }
+
+    if (job.status !== 'PENDING') {
+      throw createError({
+        statusCode: 409,
+        message: `Only PENDING jobs can change priority; job ${id} is ${job.status}.`,
+      })
+    }
+
+    const updated = await prisma.artJob.update({
+      where: { id },
+      data: { priority },
+    })
+
+    return {
+      success: true,
+      message:
+        priority > 0
+          ? `Job ${id} moved ahead with priority ${priority}.`
+          : `Job ${id} returned to normal priority.`,
+      data: { job: updated },
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+
+    event.node.res.statusCode = statusCode
+
+    return {
+      success: false,
+      message: handled.message || 'Failed to update art job priority.',
+      statusCode,
+    }
+  }
+})

--- a/server/api/art/queue/index.get.ts
+++ b/server/api/art/queue/index.get.ts
@@ -55,10 +55,14 @@ export default defineEventHandler(async (event) => {
     const totalCount = await prisma.artJob.count({ where })
     const pageCount = Math.max(1, Math.ceil(totalCount / pageSize))
     const page = Math.min(requestedPage, pageCount)
+    const orderBy: Prisma.ArtJobOrderByWithRelationInput[] =
+      status === 'PENDING'
+        ? [{ priority: 'desc' }, { id: 'asc' }]
+        : [{ id: 'desc' }]
 
     const storedJobs = await prisma.artJob.findMany({
       where,
-      orderBy: [{ id: 'desc' }],
+      orderBy,
       skip: (page - 1) * pageSize,
       take: pageSize,
     })

--- a/stores/artJobPriorityStore.ts
+++ b/stores/artJobPriorityStore.ts
@@ -1,0 +1,58 @@
+// /stores/artJobPriorityStore.ts
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { performFetch } from '@/stores/utils'
+import { useArtJobStore, type ArtJobRecord } from '@/stores/artJobStore'
+
+const FRONT_OF_QUEUE_PRIORITY = 100
+
+export const useArtJobPriorityStore = defineStore('artJobPriorityStore', () => {
+  const prioritizingJobIds = ref<number[]>([])
+  const error = ref<string | null>(null)
+
+  async function setPriority(id: number, priority: number): Promise<boolean> {
+    if (prioritizingJobIds.value.includes(id)) return false
+
+    prioritizingJobIds.value = [...prioritizingJobIds.value, id]
+    error.value = null
+
+    try {
+      const res = await performFetch<{ job: ArtJobRecord }>(
+        `/api/art/queue/${id}/priority`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ priority }),
+        },
+      )
+
+      if (!res.success || !res.data?.job) {
+        error.value = res.message || `Failed to update priority for job ${id}.`
+        return false
+      }
+
+      const artJobStore = useArtJobStore()
+      await Promise.all([artJobStore.fetchJobs(), artJobStore.fetchStats()])
+      return true
+    } finally {
+      prioritizingJobIds.value = prioritizingJobIds.value.filter(
+        (jobId) => jobId !== id,
+      )
+    }
+  }
+
+  function moveToFront(id: number): Promise<boolean> {
+    return setPriority(id, FRONT_OF_QUEUE_PRIORITY)
+  }
+
+  function returnToNormal(id: number): Promise<boolean> {
+    return setPriority(id, 0)
+  }
+
+  return {
+    prioritizingJobIds,
+    error,
+    setPriority,
+    moveToFront,
+    returnToNormal,
+  }
+})

--- a/stores/artJobPriorityStore.ts
+++ b/stores/artJobPriorityStore.ts
@@ -13,6 +13,7 @@ export const useArtJobPriorityStore = defineStore('artJobPriorityStore', () => {
   async function setPriority(id: number, priority: number): Promise<boolean> {
     if (prioritizingJobIds.value.includes(id)) return false
 
+    const artJobStore = useArtJobStore()
     prioritizingJobIds.value = [...prioritizingJobIds.value, id]
     error.value = null
 
@@ -27,10 +28,10 @@ export const useArtJobPriorityStore = defineStore('artJobPriorityStore', () => {
 
       if (!res.success || !res.data?.job) {
         error.value = res.message || `Failed to update priority for job ${id}.`
+        artJobStore.error = error.value
         return false
       }
 
-      const artJobStore = useArtJobStore()
       await Promise.all([artJobStore.fetchJobs(), artJobStore.fetchStats()])
       return true
     } finally {


### PR DESCRIPTION
## What changed

- add an admin/server-only endpoint for changing a PENDING ArtJob's priority
- add a small Pinia store for moving a job to the front or returning it to normal
- add `Move to front` / `Normal priority` controls and a visible priority badge to queue cards
- sort the PENDING queue browser by the same execution order the relay uses: priority descending, then oldest id first
- apply a data-preserving production migration that raises still-pending Taskmaster jobs to priority 100, including ArtJobs 2846–2850

## Why this works

The durable queue already had `ArtJob.priority`, enqueue already accepted priority, and relay claims already order by `priority DESC, id ASC`. Smart affinity selection is constrained to the highest-priority tier, so model affinity cannot leapfrog ordinary jobs over a prioritized one.

This fills the missing operational control rather than faking priority by changing timestamps or duplicating jobs.

## Safety

- only admins/server credentials can change priority
- only PENDING jobs can be reprioritized
- accepted values are bounded to integers from 0 through 1000
- the migration only touches still-pending Taskmaster work and never changes status, attempts, payload, or ownership

## Verification plan

- TypeScript
- required contract verifiers and ESLint ratchet
- Prisma migration validation
- production deploy applies the one-time Taskmaster priority bump
- confirm the PENDING dashboard lists priority-100 Taskmaster jobs first
