### PR TITLE
Turn Taskmaster into a scene-led responsive Quest Desk

### DIFF
--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -4,728 +4,886 @@
      users choose story ingredients, never image-model settings. -->
 <template>
   <section
-    class="kr-surface taskmaster-shell min-h-0 gap-3 rounded-2xl border border-base-300 bg-base-100 p-3 sm:p-4"
+    class="kr-surface taskmaster-shell relative min-h-0 gap-0 overflow-x-hidden rounded-[2rem] border border-secondary/25 bg-base-100"
   >
-    <header
-      class="flex shrink-0 items-start gap-3 border-b border-base-300 pb-3"
-    >
-      <div
-        class="flex size-11 shrink-0 items-center justify-center rounded-2xl border border-secondary/30 bg-secondary/10 text-secondary shadow-sm"
-      >
-        <Icon name="kind-icon:gearhammer" class="size-5" />
-      </div>
-      <div class="min-w-0 flex-1">
-        <p
-          class="text-[0.65rem] font-black uppercase tracking-[0.18em] text-secondary"
-        >
-          Taskmaster
-        </p>
-        <h2 class="text-xl font-black leading-tight sm:text-2xl">
-          Turn the next real thing into a quest
-        </h2>
-        <p class="mt-1 max-w-2xl text-xs leading-relaxed text-base-content/60">
-          The story adds momentum. The real objective stays honest, visible, and
-          under your control.
-        </p>
-      </div>
-      <div class="flex shrink-0 flex-wrap justify-end gap-2">
-        <span
-          class="badge badge-success badge-outline hidden h-auto gap-1.5 rounded-xl px-2.5 py-1.5 text-[0.65rem] font-bold sm:flex"
-        >
-          <Icon name="kind-icon:shield" class="size-3.5" />
-          Nothing changes without approval
-        </span>
-        <button
-          v-if="store.session"
-          type="button"
-          class="btn btn-ghost btn-sm rounded-xl"
-          :disabled="store.isWeaving"
-          @click="startOver"
-        >
-          <Icon name="kind-icon:wand" class="size-4" />
-          <span class="hidden sm:inline">New quest</span>
-        </button>
-      </div>
-    </header>
+    <TaskmasterBackdrop :image="tabImage" :compact="Boolean(store.session)" />
 
-    <!-- SETUP: one document scroll, objective first, optional story recipe second. -->
-    <div v-if="!store.session" class="space-y-3">
-      <nav
-        class="flex items-center gap-2 overflow-hidden text-[0.7rem] font-bold"
-        aria-label="Quest setup progress"
-      >
-        <span class="flex items-center gap-1.5 text-base-content">
-          <span
-            class="flex size-6 items-center justify-center rounded-full bg-secondary text-secondary-content"
-          >
-            1
-          </span>
-          Objective
-        </span>
-        <span class="h-px min-w-5 max-w-14 flex-1 bg-base-300" />
-        <span class="flex items-center gap-1.5 text-base-content/45">
-          <span
-            class="flex size-6 items-center justify-center rounded-full border border-base-300 bg-base-200"
-          >
-            2
-          </span>
-          Recipe
-        </span>
-        <span class="h-px min-w-5 max-w-14 flex-1 bg-base-300" />
-        <span class="flex items-center gap-1.5 text-base-content/45">
-          <span
-            class="flex size-6 items-center justify-center rounded-full border border-base-300 bg-base-200"
-          >
-            3
-          </span>
-          Review
-        </span>
-      </nav>
-
-      <div
-        class="grid items-start gap-3 lg:grid-cols-[minmax(0,1.2fr)_minmax(20rem,0.8fr)]"
-      >
-        <section
-          class="space-y-3 rounded-2xl border border-base-300 bg-base-200/35 p-3 sm:p-4"
-        >
-          <div>
-            <p
-              class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-base-content/55"
+    <div class="relative z-10 flex min-h-0 flex-1 flex-col">
+      <template v-if="!store.session">
+        <header class="taskmaster-hero relative flex min-h-64 items-start p-4 sm:min-h-72 sm:p-6 lg:min-h-80 lg:p-8">
+          <div class="taskmaster-hero-copy max-w-2xl">
+            <span
+              class="inline-flex items-center gap-2 rounded-full border border-secondary/30 bg-base-100/80 px-3 py-1.5 text-[0.68rem] font-black uppercase tracking-[0.16em] text-secondary shadow-sm backdrop-blur"
             >
-              The real objective
+              <Icon name="kind-icon:gearhammer" class="size-4" />
+              The Quest Desk
+            </span>
+            <h2
+              class="mt-4 max-w-xl text-3xl font-black leading-[0.98] tracking-tight text-base-content sm:text-4xl lg:text-5xl"
+            >
+              Turn the next real thing into a quest
+            </h2>
+            <p
+              class="mt-3 max-w-lg text-sm font-semibold leading-relaxed text-base-content/70 sm:text-base"
+            >
+              Name what matters. Shape the adventure. Review the practical plan
+              before the story begins.
             </p>
+            <div class="mt-4 flex flex-wrap gap-2">
+              <span
+                class="inline-flex items-center gap-1.5 rounded-full border border-success/30 bg-base-100/80 px-2.5 py-1.5 text-[0.68rem] font-bold shadow-sm backdrop-blur"
+              >
+                <Icon name="kind-icon:shield" class="size-3.5 text-success" />
+                Nothing changes without approval
+              </span>
+              <span
+                class="hidden items-center gap-1.5 rounded-full border border-info/30 bg-base-100/80 px-2.5 py-1.5 text-[0.68rem] font-bold shadow-sm backdrop-blur sm:inline-flex"
+              >
+                <Icon name="kind-icon:sparkles" class="size-3.5 text-info" />
+                Story answers become progress proposals
+              </span>
+            </div>
+          </div>
+
+          <aside
+            class="taskmaster-guide-bubble absolute bottom-5 right-4 hidden w-64 rounded-[1.5rem_1.5rem_0.4rem_1.5rem] border border-secondary/30 bg-base-100/85 p-4 shadow-xl backdrop-blur-xl lg:block xl:right-8"
+          >
+            <div class="flex items-center gap-3">
+              <span
+                class="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-secondary text-secondary-content shadow-md"
+              >
+                <Icon name="kind-icon:magic" class="size-5" />
+              </span>
+              <div class="min-w-0">
+                <p
+                  class="text-[0.65rem] font-black uppercase tracking-[0.14em] text-secondary"
+                >
+                  Your guide
+                </p>
+                <h3 class="truncate text-lg font-black">Serendipity</h3>
+              </div>
+            </div>
+            <p class="mt-3 text-xs font-medium leading-relaxed text-base-content/65">
+              I’ll help turn this objective into an adventure that moves you
+              forward without disguising the real work.
+            </p>
+          </aside>
+        </header>
+
+        <TaskmasterQuestStepper
+          active="objective"
+          class="mx-3 -mt-5 sm:mx-5 lg:mx-8 lg:max-w-3xl"
+        />
+
+        <main
+          class="taskmaster-desk grid items-start gap-4 px-3 pb-28 pt-7 sm:px-5 sm:pt-8 lg:grid-cols-2 lg:px-8 xl:grid-cols-[minmax(0,1.12fr)_minmax(19rem,0.88fr)_minmax(17rem,0.72fr)]"
+        >
+          <section
+            class="taskmaster-panel taskmaster-panel--objective space-y-4 border border-info/30 p-4 sm:p-5"
+          >
+            <div class="flex items-start gap-3">
+              <span
+                class="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-info text-info-content shadow-md"
+              >
+                <Icon name="kind-icon:target" class="size-5" />
+              </span>
+              <div class="min-w-0 flex-1">
+                <p
+                  class="text-[0.68rem] font-black uppercase tracking-[0.15em] text-info"
+                >
+                  Your objective
+                </p>
+                <h3 class="mt-1 text-lg font-black sm:text-xl">
+                  What needs to move?
+                </h3>
+                <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+                  Be plain and specific. Serendipity can make it magical after it
+                  is honest.
+                </p>
+              </div>
+            </div>
+
             <textarea
               v-model="taskInput"
-              rows="4"
-              class="textarea textarea-bordered mt-2 w-full resize-none rounded-2xl bg-base-100 text-base font-semibold leading-relaxed sm:text-lg"
+              rows="5"
+              class="textarea textarea-bordered w-full resize-none rounded-2xl border-info/25 bg-base-100/90 text-base font-semibold leading-relaxed shadow-inner sm:text-lg"
               placeholder="Clean the garage, finish the proposal, decide which feature ships next…"
               :disabled="store.isWeaving"
             />
-          </div>
 
-          <label class="form-control w-full">
-            <div class="label py-1">
-              <span
-                class="label-text text-[0.68rem] font-black uppercase tracking-[0.12em] text-base-content/55"
+            <label class="form-control w-full">
+              <div class="label py-1">
+                <span
+                  class="label-text text-[0.68rem] font-black uppercase tracking-[0.12em] text-base-content/55"
+                >
+                  Project or task source
+                  <span class="font-normal normal-case tracking-normal">(optional)</span>
+                </span>
+              </div>
+              <select
+                v-model="selectedProjectSlug"
+                class="select select-bordered w-full rounded-xl border-info/20 bg-base-100/90"
+                :disabled="store.isWeaving"
               >
-                Project or task source
-                <span class="font-normal normal-case tracking-normal">(optional)</span>
-              </span>
-            </div>
-            <select
-              v-model="selectedProjectSlug"
-              class="select select-bordered w-full rounded-xl bg-base-100"
-              :disabled="store.isWeaving"
+                <option value="">No linked project</option>
+                <option
+                  v-for="project in projectStore.activeProjects"
+                  :key="project.slug ?? project.id"
+                  :value="project.slug"
+                >
+                  {{ project.title || project.slug }}
+                </option>
+              </select>
+            </label>
+
+            <div
+              class="flex items-start gap-2 rounded-2xl border border-success/25 bg-success/10 p-3 text-xs leading-relaxed text-base-content/65"
             >
-              <option value="">No linked project</option>
-              <option
-                v-for="project in projectStore.activeProjects"
-                :key="project.slug ?? project.id"
-                :value="project.slug"
-              >
-                {{ project.title || project.slug }}
-              </option>
-            </select>
-          </label>
+              <Icon
+                name="kind-icon:shield"
+                class="mt-0.5 size-4 shrink-0 text-success"
+              />
+              <p>
+                Real updates still require a separate <strong>Apply</strong>
+                action. The story may surprise you; the ledger may not.
+              </p>
+            </div>
+          </section>
 
-          <div class="border-t border-base-300 pt-3">
-            <div class="mb-2 flex flex-wrap items-end justify-between gap-2">
-              <div>
-                <p class="text-sm font-black">Need a spark?</p>
-                <p class="text-xs text-base-content/50">
-                  Start from a real task, a decision, or something around the house.
+          <section
+            class="taskmaster-panel taskmaster-panel--recipe border border-secondary/30 p-4 sm:p-5 xl:mt-5"
+          >
+            <div class="flex items-start gap-3">
+              <span
+                class="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-secondary text-secondary-content shadow-md"
+              >
+                <Icon name="kind-icon:flask" class="size-5" />
+              </span>
+              <div class="min-w-0 flex-1">
+                <p
+                  class="text-[0.68rem] font-black uppercase tracking-[0.15em] text-secondary"
+                >
+                  Quest recipe
+                </p>
+                <h3 class="mt-1 text-lg font-black">Shape the journey</h3>
+                <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+                  Choose story ingredients, never model machinery.
                 </p>
               </div>
-              <span class="badge badge-warning badge-outline badge-sm rounded-xl">
-                Human gates stay explicit
-              </span>
             </div>
-            <TaskmasterSampleTasks class="taskmaster-samples" />
-          </div>
-        </section>
 
-        <aside
-          class="space-y-4 rounded-2xl border border-base-300 bg-base-200/35 p-3 sm:p-4"
-        >
-          <div>
-            <p
-              class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-base-content/55"
-            >
-              Quest recipe
-            </p>
-            <p class="mt-1 text-xs leading-relaxed text-base-content/50">
-              Set the flavor without exposing image-model machinery.
-            </p>
-          </div>
-
-          <div class="space-y-2">
-            <p
-              class="text-[0.68rem] font-black uppercase tracking-[0.12em] text-base-content/55"
-            >
-              Tone
-            </p>
-            <kr-choice-list
-              layout="row"
-              label="Tone"
-              :choices="toneChoices"
-              :selected-key="selectedTone"
-              :disabled="store.isWeaving"
-              :show-index="false"
-              @select="selectedTone = $event.key as TaskmasterTone"
-            />
-          </div>
-
-          <details
-            class="group rounded-2xl border border-base-300 bg-base-100"
-          >
-            <summary
-              class="flex cursor-pointer list-none items-center gap-3 p-3 [&::-webkit-details-marker]:hidden"
-            >
-              <span
-                class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-secondary/10 text-secondary"
+            <details class="taskmaster-recipe-details group mt-4">
+              <summary
+                class="flex cursor-pointer list-none items-center gap-3 rounded-2xl border border-secondary/25 bg-base-100/85 p-3 md:hidden [&::-webkit-details-marker]:hidden"
               >
-                <Icon name="kind-icon:dream" class="size-5" />
-              </span>
-              <span class="min-w-0 flex-1">
-                <span
-                  class="block text-[0.65rem] font-black uppercase tracking-[0.12em] text-base-content/45"
+                <span class="min-w-0 flex-1">
+                  <span class="block text-sm font-black">Recipe ingredients</span>
+                  <span class="block truncate text-xs text-base-content/50">
+                    {{ selectedTone }} · {{ selectedLocationLabel }} ·
+                    {{ selectedGrammarLabel }}
+                  </span>
+                </span>
+                <Icon
+                  name="kind-icon:chevron-down"
+                  class="size-4 transition-transform group-open:rotate-180"
+                />
+              </summary>
+
+              <div class="taskmaster-recipe-body space-y-4 pt-4 md:pt-0">
+                <div class="space-y-2">
+                  <p
+                    class="text-[0.68rem] font-black uppercase tracking-[0.12em] text-base-content/55"
+                  >
+                    Tone
+                  </p>
+                  <kr-choice-list
+                    layout="row"
+                    label="Tone"
+                    :choices="toneChoices"
+                    :selected-key="selectedTone"
+                    :disabled="store.isWeaving"
+                    :show-index="false"
+                    @select="selectedTone = $event.key as TaskmasterTone"
+                  />
+                </div>
+
+                <details
+                  class="group rounded-2xl border border-base-300/90 bg-base-100/90"
                 >
-                  Setting
-                </span>
-                <span class="block truncate text-sm font-bold">
-                  {{ selectedLocationLabel }}
-                </span>
-              </span>
-              <Icon
-                name="kind-icon:chevron-down"
-                class="size-4 text-base-content/45 transition-transform group-open:rotate-180"
-              />
-            </summary>
-            <div class="border-t border-base-300 p-3">
-              <NarrativeIngredientPicker
-                v-model="selectedLocationSlug"
-                :items="locationOptions"
-                label="Setting"
-                helper="Choose a reusable LOCATION Dream. Artwork is shown when the location already has it."
-                empty-label="Anywhere"
-                empty-description="Let Taskmaster choose a setting that fits the objective and tone."
-                empty-icon="kind-icon:dream"
-                empty-state="No active LOCATION Dreams are available yet."
-                :disabled="store.isWeaving"
-                :loading="dreamStore.loading"
-                :error="dreamStore.error"
-                :initial-limit="5"
-              />
-            </div>
-          </details>
+                  <summary
+                    class="flex cursor-pointer list-none items-center gap-3 p-3 [&::-webkit-details-marker]:hidden"
+                  >
+                    <span
+                      class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-secondary/10 text-secondary"
+                    >
+                      <Icon name="kind-icon:dream" class="size-5" />
+                    </span>
+                    <span class="min-w-0 flex-1">
+                      <span
+                        class="block text-[0.65rem] font-black uppercase tracking-[0.12em] text-base-content/45"
+                      >
+                        Setting
+                      </span>
+                      <span class="block truncate text-sm font-bold">
+                        {{ selectedLocationLabel }}
+                      </span>
+                    </span>
+                    <Icon
+                      name="kind-icon:chevron-down"
+                      class="size-4 text-base-content/45 transition-transform group-open:rotate-180"
+                    />
+                  </summary>
+                  <div class="border-t border-base-300 p-3">
+                    <NarrativeIngredientPicker
+                      v-model="selectedLocationSlug"
+                      :items="locationOptions"
+                      label="Setting"
+                      helper="Choose a reusable LOCATION Dream. Artwork is shown when the location already has it."
+                      empty-label="Anywhere"
+                      empty-description="Let Taskmaster choose a setting that fits the objective and tone."
+                      empty-icon="kind-icon:dream"
+                      empty-state="No active LOCATION Dreams are available yet."
+                      :disabled="store.isWeaving"
+                      :loading="dreamStore.loading"
+                      :error="dreamStore.error"
+                      :initial-limit="5"
+                    />
+                  </div>
+                </details>
 
-          <details
-            class="group rounded-2xl border border-base-300 bg-base-100"
-          >
-            <summary
-              class="flex cursor-pointer list-none items-center gap-3 p-3 [&::-webkit-details-marker]:hidden"
-            >
-              <span
-                class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-info/10 text-info"
-              >
-                <Icon name="kind-icon:story" class="size-5" />
-              </span>
-              <span class="min-w-0 flex-1">
-                <span
-                  class="block text-[0.65rem] font-black uppercase tracking-[0.12em] text-base-content/45"
+                <details
+                  class="group rounded-2xl border border-base-300/90 bg-base-100/90"
                 >
-                  Genre, mood, and style
-                </span>
-                <span class="block truncate text-sm font-bold">
-                  {{ selectedGrammarLabel }}
-                </span>
-              </span>
-              <Icon
-                name="kind-icon:chevron-down"
-                class="size-4 text-base-content/45 transition-transform group-open:rotate-180"
-              />
-            </summary>
-            <div class="border-t border-base-300 p-3">
-              <NarrativeIngredientPicker
-                v-model="selectedGrammarSlug"
-                :items="grammarOptions"
-                label="Genre, mood, and style"
-                helper="Choose from the canonical Facet library. Cards use Facet artwork first and fall back to the Facet icon."
-                empty-label="Any adventure"
-                empty-description="Let Taskmaster choose the genre and story grammar automatically."
-                empty-icon="kind-icon:story"
-                empty-state="No active narrative Facets are available yet."
-                :disabled="store.isWeaving"
-                :loading="facetStore.loading"
-                :error="facetStore.error"
-                :initial-limit="8"
-              />
-            </div>
-          </details>
+                  <summary
+                    class="flex cursor-pointer list-none items-center gap-3 p-3 [&::-webkit-details-marker]:hidden"
+                  >
+                    <span
+                      class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-accent/10 text-accent"
+                    >
+                      <Icon name="kind-icon:story" class="size-5" />
+                    </span>
+                    <span class="min-w-0 flex-1">
+                      <span
+                        class="block text-[0.65rem] font-black uppercase tracking-[0.12em] text-base-content/45"
+                      >
+                        Genre, mood, and style
+                      </span>
+                      <span class="block truncate text-sm font-bold">
+                        {{ selectedGrammarLabel }}
+                      </span>
+                    </span>
+                    <Icon
+                      name="kind-icon:chevron-down"
+                      class="size-4 text-base-content/45 transition-transform group-open:rotate-180"
+                    />
+                  </summary>
+                  <div class="border-t border-base-300 p-3">
+                    <NarrativeIngredientPicker
+                      v-model="selectedGrammarSlug"
+                      :items="grammarOptions"
+                      label="Genre, mood, and style"
+                      helper="Choose from the canonical Facet library. Cards use Facet artwork first and fall back to the Facet icon."
+                      empty-label="Any adventure"
+                      empty-description="Let Taskmaster choose the genre and story grammar automatically."
+                      empty-icon="kind-icon:story"
+                      empty-state="No active narrative Facets are available yet."
+                      :disabled="store.isWeaving"
+                      :loading="facetStore.loading"
+                      :error="facetStore.error"
+                      :initial-limit="8"
+                    />
+                  </div>
+                </details>
 
-          <label class="form-control w-full">
-            <div class="label py-1">
-              <span
-                class="label-text text-[0.68rem] font-black uppercase tracking-[0.12em] text-base-content/55"
-              >
-                Extra flavor
-                <span class="font-normal normal-case tracking-normal">(optional)</span>
-              </span>
-            </div>
-            <input
-              v-model="vibeInput"
-              type="text"
-              placeholder="storm-lit, clockwork, defiant"
-              class="input input-bordered w-full rounded-xl bg-base-100"
-              :disabled="store.isWeaving"
-            />
-          </label>
+                <label class="form-control w-full">
+                  <div class="label py-1">
+                    <span
+                      class="label-text text-[0.68rem] font-black uppercase tracking-[0.12em] text-base-content/55"
+                    >
+                      Extra flavor
+                      <span class="font-normal normal-case tracking-normal">(optional)</span>
+                    </span>
+                  </div>
+                  <input
+                    v-model="vibeInput"
+                    type="text"
+                    placeholder="storm-lit, clockwork, defiant"
+                    class="input input-bordered w-full rounded-xl border-secondary/20 bg-base-100/90"
+                    :disabled="store.isWeaving"
+                  />
+                </label>
+              </div>
+            </details>
+          </section>
 
-          <div
-            class="flex items-start gap-2 rounded-xl border border-success/20 bg-success/5 p-2.5 text-[0.7rem] leading-relaxed text-base-content/60"
+          <aside
+            class="taskmaster-panel taskmaster-panel--sparks border border-accent/30 p-4 sm:p-5 lg:col-span-2 xl:col-span-1 xl:mt-10"
           >
-            <Icon name="kind-icon:shield" class="mt-0.5 size-4 shrink-0 text-success" />
-            <p>
-              Story answers become proposed progress. Real updates still require an
-              explicit <strong>Apply</strong> action.
-            </p>
-          </div>
-        </aside>
-      </div>
+            <TaskmasterSampleTasks />
 
-      <p v-if="store.errorMessage" class="text-xs text-error">
-        {{ store.errorMessage }}
-      </p>
+            <div
+              class="mt-4 rounded-[1.4rem_1.4rem_0.45rem_1.4rem] border border-secondary/25 bg-secondary/10 p-3"
+            >
+              <div class="flex items-center gap-2">
+                <span
+                  class="flex size-9 shrink-0 items-center justify-center rounded-xl bg-secondary text-secondary-content"
+                >
+                  <Icon name="kind-icon:magic" class="size-4" />
+                </span>
+                <div>
+                  <p
+                    class="text-[0.65rem] font-black uppercase tracking-[0.13em] text-secondary"
+                  >
+                    Serendipity says
+                  </p>
+                  <p class="text-sm font-black">Small steps still count as adventure.</p>
+                </div>
+              </div>
+            </div>
+          </aside>
+        </main>
 
-      <footer
-        class="sticky bottom-2 z-10 flex flex-wrap items-center gap-2 rounded-2xl border border-base-300 bg-base-100/95 p-3 shadow-lg backdrop-blur"
-      >
-        <p class="min-w-48 flex-1 text-xs leading-relaxed text-base-content/55">
-          Next: review a practical checkpoint plan before the story begins.
-        </p>
-        <button
-          type="button"
-          class="btn btn-ghost rounded-xl border border-base-300 bg-base-200"
-          :disabled="store.isWeaving || !canBegin"
-          @click="begin(true)"
-        >
-          <Icon name="kind-icon:wand" class="size-4" /> Surprise me
-        </button>
-        <button
-          type="button"
-          class="btn btn-secondary rounded-xl"
-          :disabled="store.isWeaving || !canBegin"
-          @click="begin(false)"
-        >
-          <span v-if="store.isWeaving" class="loading loading-dots loading-sm" />
-          <template v-else>
-            Build my quest
-            <Icon name="kind-icon:chevron-right" class="size-4" />
-          </template>
-        </button>
         <p
-          v-if="!canBegin"
-          class="w-full text-right text-[0.7rem] text-base-content/45"
+          v-if="store.errorMessage"
+          class="relative z-20 mx-4 mb-2 text-xs text-error sm:mx-6"
+          role="alert"
         >
-          Enter an objective or choose a linked project to begin.
-        </p>
-      </footer>
-    </div>
-
-    <!-- PLAN REVIEW: practical actions dominate; story flavor becomes context. -->
-    <div
-      v-else-if="store.session.status === 'draft'"
-      class="grid items-start gap-3 lg:grid-cols-[minmax(0,1.15fr)_minmax(18rem,0.85fr)]"
-    >
-      <section
-        class="space-y-3 rounded-2xl border border-secondary/25 bg-secondary/5 p-3 sm:p-4"
-      >
-        <div class="flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <p
-              class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-secondary/75"
-            >
-              Review the practical plan
-            </p>
-            <h3 class="mt-1 text-xl font-black">
-              The quest starts with real checkpoints
-            </h3>
-            <p class="mt-1 text-xs leading-relaxed text-base-content/55">
-              Taskmaster weaves these actions into the fiction in order. Nothing is
-              written back without a separate Apply action.
-            </p>
-          </div>
-          <span class="badge badge-secondary rounded-xl">
-            {{ store.session.checkpoints.length }} checkpoints
-          </span>
-        </div>
-
-        <ol class="space-y-2">
-          <li
-            v-for="(checkpoint, index) in store.session.checkpoints"
-            :key="checkpoint.id"
-            class="flex items-start gap-3 rounded-2xl border border-base-300 bg-base-100 p-3"
-          >
-            <span
-              class="flex size-7 shrink-0 items-center justify-center rounded-full bg-secondary text-xs font-black text-secondary-content"
-            >
-              {{ index + 1 }}
-            </span>
-            <div class="min-w-0 flex-1">
-              <p class="font-bold">{{ checkpoint.title }}</p>
-              <p v-if="checkpoint.detail" class="mt-1 text-xs text-base-content/55">
-                {{ checkpoint.detail }}
-              </p>
-              <p
-                class="mt-1 text-[0.65rem] font-bold uppercase tracking-wide text-base-content/35"
-              >
-                {{ checkpoint.sourceKind.replace('-', ' ') }}
-              </p>
-            </div>
-          </li>
-        </ol>
-      </section>
-
-      <aside class="space-y-3">
-        <section class="rounded-2xl border border-base-300 bg-base-200/35 p-4">
-          <p
-            class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-base-content/55"
-          >
-            Quest briefing
-          </p>
-          <dl class="mt-3 space-y-3 text-sm">
-            <div>
-              <dt class="text-[0.65rem] font-bold uppercase tracking-wide text-base-content/40">
-                Objective
-              </dt>
-              <dd class="mt-0.5 font-bold">
-                {{ store.session.seed.taskTitle || 'Linked project objective' }}
-              </dd>
-            </div>
-            <div class="grid grid-cols-2 gap-3">
-              <div>
-                <dt class="text-[0.65rem] font-bold uppercase tracking-wide text-base-content/40">
-                  Tone
-                </dt>
-                <dd class="mt-0.5 capitalize">{{ store.session.seed.tone }}</dd>
-              </div>
-              <div>
-                <dt class="text-[0.65rem] font-bold uppercase tracking-wide text-base-content/40">
-                  Setting
-                </dt>
-                <dd class="mt-0.5">
-                  {{ store.session.location?.title || 'Taskmaster chooses' }}
-                </dd>
-              </div>
-            </div>
-            <div v-if="store.session.genre">
-              <dt class="text-[0.65rem] font-bold uppercase tracking-wide text-base-content/40">
-                Genre
-              </dt>
-              <dd class="mt-0.5">{{ store.session.genre.title }}</dd>
-            </div>
-          </dl>
-        </section>
-
-        <div
-          class="flex items-start gap-2 rounded-2xl border border-success/25 bg-success/5 p-3 text-xs leading-relaxed text-base-content/60"
-        >
-          <Icon name="kind-icon:shield" class="mt-0.5 size-4 shrink-0 text-success" />
-          <p>
-            This review is the handrail: the fiction can be surprising, but the work
-            cannot silently change beneath it.
-          </p>
-        </div>
-
-        <p v-if="store.errorMessage" class="text-xs text-error">
           {{ store.errorMessage }}
         </p>
 
-        <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
+        <footer
+          class="taskmaster-action-rail sticky bottom-2 z-30 mx-3 mb-3 flex flex-wrap items-center gap-2 rounded-2xl border border-base-300/80 bg-base-100/90 p-2.5 shadow-2xl backdrop-blur-xl sm:mx-5 sm:p-3 lg:mx-8"
+        >
+          <p
+            class="hidden min-w-48 flex-1 text-xs font-medium leading-relaxed text-base-content/55 lg:block"
+          >
+            Next: review a practical checkpoint plan before the story begins.
+          </p>
           <button
             type="button"
-            class="btn btn-ghost rounded-xl border border-base-300 bg-base-100"
+            class="btn btn-ghost flex-1 rounded-xl border border-base-300 bg-base-100 sm:flex-none"
+            :disabled="store.isWeaving || !canBegin"
+            @click="begin(true)"
+          >
+            <Icon name="kind-icon:wand" class="size-4" />
+            Surprise me
+          </button>
+          <button
+            type="button"
+            class="taskmaster-primary-action btn flex-[1.3] rounded-xl border-0 text-primary-content shadow-lg sm:flex-none sm:px-8"
+            :disabled="store.isWeaving || !canBegin"
+            @click="begin(false)"
+          >
+            <span v-if="store.isWeaving" class="loading loading-dots loading-sm" />
+            <template v-else>
+              Build my quest
+              <Icon name="kind-icon:chevron-right" class="size-4" />
+            </template>
+          </button>
+          <p
+            v-if="!canBegin"
+            class="w-full text-center text-[0.68rem] text-base-content/45 sm:text-right"
+          >
+            Enter an objective or choose a linked project to begin.
+          </p>
+        </footer>
+      </template>
+
+      <template v-else-if="store.session.status === 'draft'">
+        <header class="taskmaster-state-hero relative px-4 pb-8 pt-5 sm:px-6 lg:px-8">
+          <div class="flex flex-wrap items-start justify-between gap-3">
+            <div class="max-w-2xl">
+              <p
+                class="text-[0.68rem] font-black uppercase tracking-[0.16em] text-secondary"
+              >
+                Quest briefing
+              </p>
+              <h2 class="mt-1 text-2xl font-black leading-tight sm:text-3xl">
+                Review the practical plan
+              </h2>
+              <p class="mt-2 max-w-xl text-sm leading-relaxed text-base-content/65">
+                The quest starts with real checkpoints. The story can embellish the
+                road, never quietly move the destination.
+              </p>
+            </div>
+            <button
+              type="button"
+              class="btn btn-ghost btn-sm rounded-xl border border-base-300 bg-base-100/80 backdrop-blur"
+              :disabled="store.isWeaving"
+              @click="startOver"
+            >
+              <Icon name="kind-icon:wand" class="size-4" />
+              Edit setup
+            </button>
+          </div>
+          <TaskmasterQuestStepper active="review" class="mt-5 max-w-3xl" />
+        </header>
+
+        <main
+          class="grid items-start gap-4 px-3 pb-6 sm:px-5 lg:grid-cols-[minmax(0,1.2fr)_minmax(18rem,0.8fr)] lg:px-8"
+        >
+          <section
+            class="taskmaster-panel taskmaster-panel--plan border border-secondary/30 p-4 sm:p-5"
+          >
+            <div class="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p
+                  class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-secondary"
+                >
+                  Practical route
+                </p>
+                <h3 class="mt-1 text-xl font-black">
+                  The quest starts with real checkpoints
+                </h3>
+                <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+                  Taskmaster weaves these actions into the fiction in order.
+                  Nothing is written back without a separate Apply action.
+                </p>
+              </div>
+              <span class="badge badge-secondary h-auto rounded-xl px-3 py-2">
+                {{ store.session.checkpoints.length }} checkpoints
+              </span>
+            </div>
+
+            <ol class="taskmaster-checkpoint-path mt-5 space-y-3">
+              <li
+                v-for="(checkpoint, index) in store.session.checkpoints"
+                :key="checkpoint.id"
+                class="taskmaster-checkpoint relative flex items-start gap-3 rounded-2xl border border-base-300/85 bg-base-100/90 p-3 shadow-sm backdrop-blur"
+              >
+                <span
+                  class="relative z-10 flex size-9 shrink-0 items-center justify-center rounded-full bg-secondary text-xs font-black text-secondary-content shadow-md"
+                >
+                  {{ index + 1 }}
+                </span>
+                <div class="min-w-0 flex-1 pt-1">
+                  <p class="font-black">{{ checkpoint.title }}</p>
+                  <p
+                    v-if="checkpoint.detail"
+                    class="mt-1 text-xs leading-relaxed text-base-content/55"
+                  >
+                    {{ checkpoint.detail }}
+                  </p>
+                  <p
+                    class="mt-2 text-[0.65rem] font-bold uppercase tracking-wide text-base-content/35"
+                  >
+                    {{ checkpoint.sourceKind.replace('-', ' ') }}
+                  </p>
+                </div>
+              </li>
+            </ol>
+          </section>
+
+          <aside class="space-y-4 lg:pt-8">
+            <section
+              class="taskmaster-panel taskmaster-panel--briefing border border-info/30 p-4"
+            >
+              <div class="flex items-center gap-3">
+                <span
+                  class="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-info text-info-content"
+                >
+                  <Icon name="kind-icon:map" class="size-5" />
+                </span>
+                <div>
+                  <p
+                    class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-info"
+                  >
+                    Quest briefing
+                  </p>
+                  <p class="text-base font-black">Check the map before departure</p>
+                </div>
+              </div>
+              <dl class="mt-4 space-y-3 text-sm">
+                <div>
+                  <dt
+                    class="text-[0.65rem] font-bold uppercase tracking-wide text-base-content/40"
+                  >
+                    Objective
+                  </dt>
+                  <dd class="mt-0.5 font-black">
+                    {{ store.session.seed.taskTitle || 'Linked project objective' }}
+                  </dd>
+                </div>
+                <div class="grid grid-cols-2 gap-3">
+                  <div>
+                    <dt
+                      class="text-[0.65rem] font-bold uppercase tracking-wide text-base-content/40"
+                    >
+                      Tone
+                    </dt>
+                    <dd class="mt-0.5 capitalize">{{ store.session.seed.tone }}</dd>
+                  </div>
+                  <div>
+                    <dt
+                      class="text-[0.65rem] font-bold uppercase tracking-wide text-base-content/40"
+                    >
+                      Setting
+                    </dt>
+                    <dd class="mt-0.5">
+                      {{ store.session.location?.title || 'Taskmaster chooses' }}
+                    </dd>
+                  </div>
+                </div>
+                <div v-if="store.session.genre">
+                  <dt
+                    class="text-[0.65rem] font-bold uppercase tracking-wide text-base-content/40"
+                  >
+                    Genre
+                  </dt>
+                  <dd class="mt-0.5">{{ store.session.genre.title }}</dd>
+                </div>
+              </dl>
+            </section>
+
+            <section
+              class="taskmaster-guide-card rounded-[1.7rem_1.7rem_0.5rem_1.7rem] border border-secondary/30 bg-base-100/85 p-4 shadow-xl backdrop-blur-xl"
+            >
+              <div class="flex items-start gap-3">
+                <span
+                  class="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-secondary text-secondary-content"
+                >
+                  <Icon name="kind-icon:magic" class="size-5" />
+                </span>
+                <div>
+                  <p
+                    class="text-[0.65rem] font-black uppercase tracking-[0.14em] text-secondary"
+                  >
+                    Serendipity's handrail
+                  </p>
+                  <p class="mt-1 text-xs leading-relaxed text-base-content/60">
+                    The fiction can be surprising, but the work cannot silently
+                    change beneath it.
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            <p v-if="store.errorMessage" class="text-xs text-error" role="alert">
+              {{ store.errorMessage }}
+            </p>
+
+            <button
+              type="button"
+              class="taskmaster-primary-action btn w-full rounded-xl border-0 text-primary-content shadow-lg"
+              :disabled="store.isWeaving || !store.session.checkpoints.length"
+              @click="store.startQuest()"
+            >
+              <Icon name="kind-icon:story" class="size-4" />
+              Start the adventure
+            </button>
+          </aside>
+        </main>
+      </template>
+
+      <template v-else>
+        <header
+          class="taskmaster-mission-banner relative mx-3 mt-3 flex flex-wrap items-center gap-3 rounded-2xl border border-info/30 bg-base-100/85 p-3 shadow-xl backdrop-blur-xl sm:mx-5 lg:mx-8"
+        >
+          <span
+            class="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-info text-info-content"
+          >
+            <Icon name="kind-icon:target" class="size-5" />
+          </span>
+          <div class="min-w-0 flex-1">
+            <p
+              class="text-[0.65rem] font-black uppercase tracking-[0.14em] text-info"
+            >
+              Current quest
+            </p>
+            <p class="truncate text-sm font-black sm:text-base">
+              {{ store.session.seed.taskTitle || 'Linked project objective' }}
+            </p>
+          </div>
+          <span
+            v-if="store.session.checkpoints.length"
+            class="badge badge-secondary h-auto rounded-xl px-3 py-2"
+          >
+            {{ store.remainingCheckpoints.length }} left
+          </span>
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm rounded-xl"
             :disabled="store.isWeaving"
             @click="startOver"
           >
-            Edit setup
+            New quest
           </button>
-          <button
-            type="button"
-            class="btn btn-secondary rounded-xl"
-            :disabled="store.isWeaving || !store.session.checkpoints.length"
-            @click="store.startQuest()"
-          >
-            <Icon name="kind-icon:story" class="size-4" /> Start the adventure
-          </button>
-        </div>
-      </aside>
-    </div>
+        </header>
 
-    <!-- QUEST: story and response on the left, real mission rail on the right. -->
-    <div
-      v-else
-      class="grid min-h-0 flex-1 items-start gap-3 lg:grid-cols-[minmax(0,1fr)_20rem]"
-    >
-      <div class="flex min-h-0 flex-col gap-3">
-        <LazyKrNarratorStage
-          :stage-image="tabImage"
-          class="taskmaster-stage min-h-56 shrink-0 lg:min-h-64"
-        />
-
-        <KrChatWindow
-          class="min-h-80 flex-1"
-          :turns="chatTurns"
-          label="Story transcript"
-          :is-streaming="store.isWeaving"
-          :streaming-text="store.streamingText"
-          streaming-label="Taskmaster is building the next scene…"
-          empty-label="Taskmaster is preparing the opening scene."
+        <main
+          class="grid min-h-0 flex-1 items-start gap-4 px-3 pb-5 pt-4 sm:px-5 lg:grid-cols-[minmax(0,1fr)_20rem] lg:px-8"
         >
-          <template #after-turn="{ turn }">
-            <NarrativeArtStatus
-              v-if="beatForTurn(turn)"
-              class="mt-2"
-              :art="beatForTurn(turn)?.art"
-              :label="`Illustration for ${store.session?.seed.taskTitle || 'this quest'}`"
-              @retry="store.retryBeatArt(beatForTurn(turn)!.id)"
+          <div class="flex min-h-0 flex-col gap-4">
+            <LazyKrNarratorStage
+              :stage-image="tabImage"
+              class="taskmaster-stage min-h-56 shrink-0 overflow-hidden rounded-[2rem] border border-secondary/25 shadow-xl lg:min-h-64"
             />
-          </template>
 
-          <template #footer>
-            <div
-              v-if="store.isComplete"
-              class="space-y-3 rounded-2xl border border-secondary/30 bg-secondary/5 p-4"
+            <KrChatWindow
+              class="taskmaster-chat min-h-80 flex-1 overflow-hidden rounded-[2rem] border border-base-300/80 bg-base-100/90 shadow-xl backdrop-blur-xl"
+              :turns="chatTurns"
+              label="Story transcript"
+              :is-streaming="store.isWeaving"
+              :streaming-text="store.streamingText"
+              streaming-label="Taskmaster is building the next scene…"
+              empty-label="Taskmaster is preparing the opening scene."
             >
-              <div class="text-center">
-                <p class="text-sm font-bold text-secondary">Quest complete</p>
-                <p class="mt-1 text-xs text-base-content/60">
-                  Review any real-world updates below before applying them.
-                </p>
-              </div>
-              <dl
-                v-if="sessionRecap.length"
-                class="grid gap-2 text-xs leading-relaxed sm:grid-cols-2"
-              >
+              <template #after-turn="{ turn }">
+                <NarrativeArtStatus
+                  v-if="beatForTurn(turn)"
+                  class="mt-2"
+                  :art="beatForTurn(turn)?.art"
+                  :label="`Illustration for ${store.session?.seed.taskTitle || 'this quest'}`"
+                  @retry="store.retryBeatArt(beatForTurn(turn)!.id)"
+                />
+              </template>
+
+              <template #footer>
                 <div
-                  v-for="item in sessionRecap"
-                  :key="item.label"
-                  class="rounded-xl border border-base-300 bg-base-100 p-3"
+                  v-if="store.isComplete"
+                  class="space-y-3 rounded-2xl border border-secondary/30 bg-secondary/10 p-4"
                 >
-                  <dt class="font-bold text-base-content/70">{{ item.label }}</dt>
-                  <dd class="mt-0.5 text-base-content/60">{{ item.value }}</dd>
-                </div>
-              </dl>
-            </div>
-
-            <div
-              v-if="store.pendingWriteBacks.length"
-              class="space-y-2 rounded-2xl border border-warning/30 bg-warning/5 p-4"
-            >
-              <div class="flex items-center gap-2">
-                <Icon name="kind-icon:gearhammer" class="size-4 text-warning" />
-                <h3 class="text-xs font-bold uppercase tracking-wide text-warning">
-                  Quest ledger
-                </h3>
-              </div>
-              <p class="text-[0.7rem] leading-relaxed text-base-content/50">
-                Nothing is written automatically. Apply only the updates you want.
-              </p>
-              <article
-                v-for="item in store.pendingWriteBacks"
-                :key="item.beatId"
-                class="rounded-xl border border-base-300 bg-base-100 p-3 text-xs leading-relaxed"
-              >
-                <div class="flex items-start gap-2">
-                  <div class="min-w-0 flex-1">
-                    <p class="font-bold">{{ item.title }}</p>
-                    <p class="mt-1 text-base-content/70">“{{ item.answer }}”</p>
-                    <p class="mt-1 text-base-content/50">
-                      <span class="font-semibold">Apply will:</span>
-                      {{ item.proposedWrite }}
+                  <div class="text-center">
+                    <p class="text-sm font-black text-secondary">Quest complete</p>
+                    <p class="mt-1 text-xs text-base-content/60">
+                      Review any real-world updates below before applying them.
                     </p>
                   </div>
-                  <span
-                    v-if="item.status === 'written'"
-                    class="badge badge-success badge-sm rounded-xl"
+                  <dl
+                    v-if="sessionRecap.length"
+                    class="grid gap-2 text-xs leading-relaxed sm:grid-cols-2"
                   >
-                    written
-                  </span>
-                  <button
-                    v-else
-                    type="button"
-                    class="btn btn-warning btn-xs rounded-xl"
-                    :disabled="item.status === 'queued'"
-                    @click="store.applyWriteBack(item.beatId)"
-                  >
-                    <span
-                      v-if="item.status === 'queued'"
-                      class="loading loading-spinner loading-xs"
-                    />
-                    <template v-else>Apply</template>
-                  </button>
+                    <div
+                      v-for="item in sessionRecap"
+                      :key="item.label"
+                      class="rounded-xl border border-base-300 bg-base-100 p-3"
+                    >
+                      <dt class="font-bold text-base-content/70">{{ item.label }}</dt>
+                      <dd class="mt-0.5 text-base-content/60">{{ item.value }}</dd>
+                    </div>
+                  </dl>
                 </div>
-              </article>
-            </div>
-          </template>
-        </KrChatWindow>
 
-        <section
-          v-if="
-            !store.isComplete && store.awaitingAnswer && store.currentCheckpoint
-          "
-          class="shrink-0 space-y-2 rounded-2xl border border-info/25 bg-info/5 p-3"
-        >
-          <div>
-            <p class="text-[0.7rem] font-bold uppercase tracking-wide text-info/75">
-              What happened in the real world?
-            </p>
-            <p class="mt-1 text-xs text-base-content/55">
-              Choose the honest checkpoint outcome, then describe what happened below.
-            </p>
-          </div>
-          <kr-choice-list
-            layout="row"
-            label="Checkpoint outcome"
-            :choices="outcomeChoices"
-            :selected-key="selectedOutcome"
-            :show-index="false"
-            @select="selectedOutcome = $event.key as TaskmasterCheckpointOutcome"
-          />
-        </section>
+                <div
+                  v-if="store.pendingWriteBacks.length"
+                  class="space-y-2 rounded-2xl border border-warning/30 bg-warning/10 p-4"
+                >
+                  <div class="flex items-center gap-2">
+                    <Icon name="kind-icon:gearhammer" class="size-4 text-warning" />
+                    <h3
+                      class="text-xs font-black uppercase tracking-wide text-warning"
+                    >
+                      Quest ledger
+                    </h3>
+                  </div>
+                  <p class="text-[0.7rem] leading-relaxed text-base-content/50">
+                    Nothing is written automatically. Apply only the updates you want.
+                  </p>
+                  <article
+                    v-for="item in store.pendingWriteBacks"
+                    :key="item.beatId"
+                    class="rounded-xl border border-base-300 bg-base-100 p-3 text-xs leading-relaxed"
+                  >
+                    <div class="flex items-start gap-2">
+                      <div class="min-w-0 flex-1">
+                        <p class="font-bold">{{ item.title }}</p>
+                        <p class="mt-1 text-base-content/70">“{{ item.answer }}”</p>
+                        <p class="mt-1 text-base-content/50">
+                          <span class="font-semibold">Apply will:</span>
+                          {{ item.proposedWrite }}
+                        </p>
+                      </div>
+                      <span
+                        v-if="item.status === 'written'"
+                        class="badge badge-success badge-sm rounded-xl"
+                      >
+                        written
+                      </span>
+                      <button
+                        v-else
+                        type="button"
+                        class="btn btn-warning btn-xs rounded-xl"
+                        :disabled="item.status === 'queued'"
+                        @click="store.applyWriteBack(item.beatId)"
+                      >
+                        <span
+                          v-if="item.status === 'queued'"
+                          class="loading loading-spinner loading-xs"
+                        />
+                        <template v-else>Apply</template>
+                      </button>
+                    </div>
+                  </article>
+                </div>
+              </template>
+            </KrChatWindow>
 
-        <NarrativeResponseComposer
-          v-if="!store.isComplete && !store.canClose"
-          v-model="answerInput"
-          class="shrink-0"
-          :options="store.currentBeat?.question.options ?? []"
-          :disabled="!store.awaitingAnswer"
-          :loading="store.isWeaving"
-          :placeholder="
-            store.awaitingAnswer
-              ? 'What do you do?'
-              : 'Taskmaster is building the next scene…'
-          "
-          button-label="Continue"
-          hint="Story answers become proposed progress first. Real task changes still require an explicit Apply action."
-          @submit="submitAnswer"
-        />
-      </div>
-
-      <aside class="space-y-3 lg:sticky lg:top-0">
-        <section
-          v-if="store.session.seed.taskTitle"
-          class="rounded-2xl border border-info/30 bg-info/5 p-3"
-        >
-          <p class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-info/80">
-            Real objective
-          </p>
-          <p class="mt-1 text-sm font-bold leading-relaxed">
-            {{ store.session.seed.taskTitle }}
-          </p>
-        </section>
-
-        <section
-          v-if="store.session.checkpoints.length"
-          class="rounded-2xl border border-secondary/20 bg-secondary/5 p-3"
-        >
-          <div class="flex flex-wrap items-center justify-between gap-2">
-            <div>
-              <p
-                class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-secondary/75"
-              >
-                Practical checkpoint plan
-              </p>
-              <p v-if="store.currentCheckpoint" class="mt-1 text-sm font-bold">
-                Current action: {{ store.currentCheckpoint.title }}
-              </p>
-              <p v-else class="mt-1 text-xs text-base-content/55">
-                Every planned checkpoint has an outcome.
-              </p>
-            </div>
-            <span class="badge badge-secondary badge-sm rounded-xl">
-              {{ store.remainingCheckpoints.length }} left
-            </span>
-          </div>
-          <details class="mt-3">
-            <summary
-              class="cursor-pointer text-[0.68rem] font-black uppercase tracking-wide text-secondary/65"
+            <section
+              v-if="!store.isComplete && store.awaitingAnswer && store.currentCheckpoint"
+              class="taskmaster-panel shrink-0 space-y-2 border border-info/30 p-3"
             >
-              Full checkpoint plan
-            </summary>
-            <ol class="mt-2 space-y-2">
-              <li
-                v-for="checkpoint in store.session.checkpoints"
-                :key="checkpoint.id"
-                class="rounded-xl border border-base-300 bg-base-100 p-2.5 text-xs"
-              >
-                <div class="flex items-start justify-between gap-2">
-                  <p class="font-bold">{{ checkpoint.title }}</p>
-                  <span
-                    class="badge badge-sm rounded-xl"
-                    :class="
-                      checkpoint.status === 'completed'
-                        ? 'badge-success'
-                        : checkpoint.status === 'active'
-                          ? 'badge-secondary'
-                          : checkpoint.status === 'blocked' ||
-                              checkpoint.status === 'needs-info'
-                            ? 'badge-warning'
-                            : 'badge-ghost'
-                    "
-                  >
-                    {{ checkpoint.status.replace('-', ' ') }}
-                  </span>
-                </div>
-                <p v-if="checkpoint.proposedNote" class="mt-1 text-base-content/55">
-                  {{ checkpoint.proposedNote }}
+              <div>
+                <p
+                  class="text-[0.7rem] font-black uppercase tracking-wide text-info"
+                >
+                  What happened in the real world?
                 </p>
-              </li>
-            </ol>
-          </details>
-        </section>
+                <p class="mt-1 text-xs text-base-content/55">
+                  Choose the honest checkpoint outcome, then describe what happened
+                  below.
+                </p>
+              </div>
+              <kr-choice-list
+                layout="row"
+                label="Checkpoint outcome"
+                :choices="outcomeChoices"
+                :selected-key="selectedOutcome"
+                :show-index="false"
+                @select="selectedOutcome = $event.key as TaskmasterCheckpointOutcome"
+              />
+            </section>
 
-        <div
-          v-if="store.currentHookContext && store.awaitingAnswer"
-          class="flex items-start gap-2 rounded-2xl border border-info/30 bg-info/5 p-3"
-        >
-          <Icon name="kind-icon:alert" class="mt-0.5 size-4 shrink-0 text-info" />
-          <div class="min-w-0 flex-1 text-xs leading-relaxed">
-            <p class="font-bold text-info">This scene connects to:</p>
-            <p class="mt-0.5 text-base-content/75">
-              {{ store.currentHookContext.title }}
-            </p>
-            <p class="mt-1 text-base-content/45">
-              An answer proposes progress. It does not approve or complete the work.
-            </p>
+            <NarrativeResponseComposer
+              v-if="!store.isComplete && !store.canClose"
+              v-model="answerInput"
+              class="shrink-0"
+              :options="store.currentBeat?.question.options ?? []"
+              :disabled="!store.awaitingAnswer"
+              :loading="store.isWeaving"
+              :placeholder="
+                store.awaitingAnswer
+                  ? 'What do you do?'
+                  : 'Taskmaster is building the next scene…'
+              "
+              button-label="Continue"
+              hint="Story answers become proposed progress first. Real task changes still require an explicit Apply action."
+              @submit="submitAnswer"
+            />
           </div>
-        </div>
 
-        <p v-if="store.errorMessage" class="text-xs text-error">
-          {{ store.errorMessage }}
-        </p>
+          <aside class="space-y-3 lg:sticky lg:top-0">
+            <section
+              v-if="store.session.seed.taskTitle"
+              class="taskmaster-panel border border-info/30 p-3"
+            >
+              <p
+                class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-info"
+              >
+                Real objective
+              </p>
+              <p class="mt-1 text-sm font-black leading-relaxed">
+                {{ store.session.seed.taskTitle }}
+              </p>
+            </section>
 
-        <section
-          v-if="store.canClose"
-          class="space-y-2 rounded-2xl border border-success/30 bg-success/5 p-3"
-        >
-          <div>
-            <p class="text-sm font-bold text-success">
-              All checkpoints have an outcome
+            <section
+              v-if="store.session.checkpoints.length"
+              class="taskmaster-panel border border-secondary/25 p-3"
+            >
+              <div class="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <p
+                    class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-secondary"
+                  >
+                    Practical checkpoint plan
+                  </p>
+                  <p v-if="store.currentCheckpoint" class="mt-1 text-sm font-black">
+                    Current action: {{ store.currentCheckpoint.title }}
+                  </p>
+                  <p v-else class="mt-1 text-xs text-base-content/55">
+                    Every planned checkpoint has an outcome.
+                  </p>
+                </div>
+                <span class="badge badge-secondary badge-sm rounded-xl">
+                  {{ store.remainingCheckpoints.length }} left
+                </span>
+              </div>
+              <details class="mt-3">
+                <summary
+                  class="cursor-pointer text-[0.68rem] font-black uppercase tracking-wide text-secondary/75"
+                >
+                  Full checkpoint plan
+                </summary>
+                <ol class="mt-2 space-y-2">
+                  <li
+                    v-for="checkpoint in store.session.checkpoints"
+                    :key="checkpoint.id"
+                    class="rounded-xl border border-base-300 bg-base-100/90 p-2.5 text-xs"
+                  >
+                    <div class="flex items-start justify-between gap-2">
+                      <p class="font-bold">{{ checkpoint.title }}</p>
+                      <span
+                        class="badge badge-sm rounded-xl"
+                        :class="
+                          checkpoint.status === 'completed'
+                            ? 'badge-success'
+                            : checkpoint.status === 'active'
+                              ? 'badge-secondary'
+                              : checkpoint.status === 'blocked' ||
+                                  checkpoint.status === 'needs-info'
+                                ? 'badge-warning'
+                                : 'badge-ghost'
+                        "
+                      >
+                        {{ checkpoint.status.replace('-', ' ') }}
+                      </span>
+                    </div>
+                    <p
+                      v-if="checkpoint.proposedNote"
+                      class="mt-1 text-base-content/55"
+                    >
+                      {{ checkpoint.proposedNote }}
+                    </p>
+                  </li>
+                </ol>
+              </details>
+            </section>
+
+            <div
+              v-if="store.currentHookContext && store.awaitingAnswer"
+              class="taskmaster-panel flex items-start gap-2 border border-info/30 p-3"
+            >
+              <Icon name="kind-icon:alert" class="mt-0.5 size-4 shrink-0 text-info" />
+              <div class="min-w-0 flex-1 text-xs leading-relaxed">
+                <p class="font-bold text-info">This scene connects to:</p>
+                <p class="mt-0.5 text-base-content/75">
+                  {{ store.currentHookContext.title }}
+                </p>
+                <p class="mt-1 text-base-content/45">
+                  An answer proposes progress. It does not approve or complete the
+                  work.
+                </p>
+              </div>
+            </div>
+
+            <p v-if="store.errorMessage" class="text-xs text-error" role="alert">
+              {{ store.errorMessage }}
             </p>
-            <p class="mt-0.5 text-xs text-base-content/55">
-              Review any optional Apply actions, then finish for a practical recap.
-            </p>
-          </div>
-          <button
-            type="button"
-            class="btn btn-success btn-sm w-full rounded-xl"
-            @click="store.closeStory()"
-          >
-            Finish the quest
-          </button>
-        </section>
-      </aside>
+
+            <section
+              v-if="store.canClose"
+              class="taskmaster-panel space-y-2 border border-success/30 p-3"
+            >
+              <div>
+                <p class="text-sm font-black text-success">
+                  All checkpoints have an outcome
+                </p>
+                <p class="mt-0.5 text-xs text-base-content/55">
+                  Review any optional Apply actions, then finish for a practical
+                  recap.
+                </p>
+              </div>
+              <button
+                type="button"
+                class="btn btn-success btn-sm w-full rounded-xl"
+                @click="store.closeStory()"
+              >
+                Finish the quest
+              </button>
+            </section>
+          </aside>
+        </main>
+      </template>
     </div>
   </section>
 </template>
@@ -777,10 +935,26 @@ const checkpointOutcomes: {
   label: string
   helper: string
 }[] = [
-  { value: 'completed', label: 'Completed', helper: 'The action is genuinely done.' },
-  { value: 'blocked', label: 'Blocked', helper: 'Something external prevents progress.' },
-  { value: 'deferred', label: 'Deferred', helper: 'This is intentionally postponed.' },
-  { value: 'needs-info', label: 'Needs info', helper: 'A question or missing fact comes next.' },
+  {
+    value: 'completed',
+    label: 'Completed',
+    helper: 'The action is genuinely done.',
+  },
+  {
+    value: 'blocked',
+    label: 'Blocked',
+    helper: 'Something external prevents progress.',
+  },
+  {
+    value: 'deferred',
+    label: 'Deferred',
+    helper: 'This is intentionally postponed.',
+  },
+  {
+    value: 'needs-info',
+    label: 'Needs info',
+    helper: 'A question or missing fact comes next.',
+  },
 ]
 
 const outcomeChoices = computed(() =>
@@ -986,3 +1160,129 @@ onMounted(() => {
   void store.loadRealSurfaces()
 })
 </script>
+
+<style scoped>
+.taskmaster-shell {
+  isolation: isolate;
+  box-shadow:
+    0 1px 0 color-mix(in oklab, var(--color-base-100) 75%, transparent) inset,
+    0 1.5rem 4rem color-mix(in oklab, var(--color-primary) 10%, transparent);
+}
+
+.taskmaster-hero-copy {
+  text-shadow: 0 2px 14px color-mix(in oklab, var(--color-base-100) 82%, transparent);
+}
+
+.taskmaster-panel {
+  position: relative;
+  background: color-mix(in oklab, var(--color-base-100) 90%, transparent);
+  box-shadow:
+    0 1px 0 color-mix(in oklab, var(--color-base-100) 82%, transparent) inset,
+    0 1.25rem 3rem color-mix(in oklab, var(--color-primary) 12%, transparent);
+  backdrop-filter: blur(18px) saturate(1.08);
+}
+
+.taskmaster-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0.35rem;
+  pointer-events: none;
+  border: 1px solid color-mix(in oklab, var(--color-base-100) 68%, transparent);
+  border-radius: inherit;
+}
+
+.taskmaster-panel--objective {
+  border-radius: 2rem 2rem 1.2rem 2rem;
+}
+
+.taskmaster-panel--recipe {
+  border-radius: 1.2rem 2rem 2rem 1.4rem;
+}
+
+.taskmaster-panel--sparks {
+  border-radius: 2rem 1.2rem 2rem 2rem;
+}
+
+.taskmaster-panel--plan {
+  border-radius: 2rem 2rem 1.2rem 2rem;
+}
+
+.taskmaster-panel--briefing {
+  border-radius: 1.4rem 2rem 2rem 1.4rem;
+}
+
+.taskmaster-primary-action {
+  background: linear-gradient(
+    115deg,
+    var(--color-secondary),
+    color-mix(in oklab, var(--color-secondary) 62%, var(--color-accent)),
+    var(--color-primary)
+  );
+}
+
+.taskmaster-primary-action:hover:not(:disabled) {
+  filter: saturate(1.08) brightness(1.04);
+}
+
+.taskmaster-checkpoint-path {
+  counter-reset: checkpoint;
+}
+
+.taskmaster-checkpoint:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  left: 1.72rem;
+  top: 3rem;
+  bottom: -1rem;
+  width: 2px;
+  background: repeating-linear-gradient(
+    to bottom,
+    color-mix(in oklab, var(--color-secondary) 58%, transparent) 0 0.35rem,
+    transparent 0.35rem 0.7rem
+  );
+}
+
+.taskmaster-stage :deep(img) {
+  object-position: 66% center;
+}
+
+@media (min-width: 768px) {
+  .taskmaster-recipe-details > summary {
+    display: none;
+  }
+
+  .taskmaster-recipe-details:not([open]) > .taskmaster-recipe-body {
+    display: block;
+  }
+}
+
+@media (max-width: 767px) {
+  .taskmaster-hero {
+    align-items: flex-end;
+    padding-bottom: 3.5rem;
+  }
+
+  .taskmaster-hero-copy {
+    max-width: 21rem;
+  }
+
+  .taskmaster-hero-copy h2 {
+    max-width: 17rem;
+  }
+
+  .taskmaster-panel {
+    backdrop-filter: blur(14px) saturate(1.04);
+  }
+
+  .taskmaster-action-rail {
+    padding-bottom: max(0.625rem, env(safe-area-inset-bottom));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .taskmaster-primary-action,
+  .taskmaster-panel {
+    scroll-behavior: auto;
+  }
+}
+</style>

--- a/components/taskmaster/taskmaster-backdrop.vue
+++ b/components/taskmaster/taskmaster-backdrop.vue
@@ -1,0 +1,280 @@
+<template>
+  <div
+    class="taskmaster-backdrop pointer-events-none absolute inset-0 overflow-hidden"
+    :class="compact ? 'taskmaster-backdrop--compact' : ''"
+    aria-hidden="true"
+  >
+    <img
+      v-if="image && !imageFailed"
+      :src="image"
+      alt=""
+      class="taskmaster-backdrop__image absolute inset-0 h-full w-full object-cover"
+      @error="imageFailed = true"
+    />
+    <div class="taskmaster-backdrop__sky absolute inset-0" />
+    <div class="taskmaster-backdrop__portal absolute" />
+    <div class="taskmaster-backdrop__island taskmaster-backdrop__island--one absolute" />
+    <div class="taskmaster-backdrop__island taskmaster-backdrop__island--two absolute" />
+    <div class="taskmaster-backdrop__cloud taskmaster-backdrop__cloud--one absolute" />
+    <div class="taskmaster-backdrop__cloud taskmaster-backdrop__cloud--two absolute" />
+    <div class="taskmaster-backdrop__path absolute" aria-hidden="true">
+      <span v-for="step in 9" :key="step" />
+    </div>
+    <div class="taskmaster-backdrop__wash absolute inset-0" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    image?: string | null
+    compact?: boolean
+  }>(),
+  {
+    image: null,
+    compact: false,
+  },
+)
+
+const imageFailed = ref(false)
+
+watch(
+  () => props.image,
+  () => {
+    imageFailed.value = false
+  },
+)
+</script>
+
+<style scoped>
+.taskmaster-backdrop {
+  background:
+    radial-gradient(
+      circle at 82% 16%,
+      color-mix(in oklab, var(--color-secondary) 36%, transparent),
+      transparent 27%
+    ),
+    radial-gradient(
+      circle at 16% 8%,
+      color-mix(in oklab, var(--color-info) 26%, transparent),
+      transparent 34%
+    ),
+    linear-gradient(
+      145deg,
+      color-mix(in oklab, var(--color-base-100) 88%, var(--color-info)),
+      color-mix(in oklab, var(--color-base-100) 72%, var(--color-secondary)) 54%,
+      color-mix(in oklab, var(--color-base-100) 78%, var(--color-accent))
+    );
+}
+
+.taskmaster-backdrop__image {
+  object-position: 66% center;
+  opacity: 0.54;
+  filter: saturate(1.16) contrast(0.96);
+  transform: scale(1.025);
+}
+
+.taskmaster-backdrop__sky {
+  background:
+    radial-gradient(
+      circle at 72% 23%,
+      transparent 0 11rem,
+      color-mix(in oklab, var(--color-secondary) 16%, transparent) 16rem,
+      transparent 25rem
+    ),
+    linear-gradient(
+      90deg,
+      color-mix(in oklab, var(--color-base-100) 96%, transparent) 0%,
+      color-mix(in oklab, var(--color-base-100) 77%, transparent) 38%,
+      color-mix(in oklab, var(--color-base-100) 24%, transparent) 72%,
+      color-mix(in oklab, var(--color-base-100) 8%, transparent) 100%
+    );
+}
+
+.taskmaster-backdrop__wash {
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--color-base-100) 12%, transparent) 0%,
+      transparent 34%,
+      color-mix(in oklab, var(--color-base-100) 60%, transparent) 76%,
+      var(--color-base-100) 100%
+    ),
+    radial-gradient(
+      ellipse at center,
+      transparent 30%,
+      color-mix(in oklab, var(--color-base-100) 28%, transparent) 100%
+    );
+}
+
+.taskmaster-backdrop__portal {
+  right: clamp(1.25rem, 5vw, 5rem);
+  top: clamp(2rem, 6vw, 5.5rem);
+  width: clamp(5.5rem, 12vw, 10.5rem);
+  aspect-ratio: 0.82;
+  border: clamp(0.35rem, 0.6vw, 0.7rem) solid
+    color-mix(in oklab, var(--color-warning) 76%, var(--color-secondary));
+  border-radius: 48% 48% 42% 42% / 42% 42% 58% 58%;
+  background:
+    radial-gradient(
+      ellipse,
+      color-mix(in oklab, var(--color-base-100) 72%, transparent) 0 8%,
+      color-mix(in oklab, var(--color-secondary) 76%, transparent) 9% 25%,
+      color-mix(in oklab, var(--color-primary) 74%, transparent) 26% 44%,
+      color-mix(in oklab, var(--color-info) 58%, transparent) 45% 58%,
+      transparent 60%
+    );
+  box-shadow:
+    0 0 0 0.35rem color-mix(in oklab, var(--color-secondary) 22%, transparent),
+    0 0 3.5rem color-mix(in oklab, var(--color-secondary) 52%, transparent);
+  opacity: 0.54;
+  transform: rotate(2deg);
+}
+
+.taskmaster-backdrop__portal::after {
+  content: '';
+  position: absolute;
+  inset: 12% 15%;
+  border: 2px dashed color-mix(in oklab, var(--color-base-100) 76%, transparent);
+  border-radius: inherit;
+  animation: taskmaster-portal-spin 22s linear infinite;
+}
+
+.taskmaster-backdrop__island {
+  width: clamp(8rem, 18vw, 17rem);
+  height: clamp(2.5rem, 5vw, 4.5rem);
+  border-radius: 50%;
+  background:
+    radial-gradient(
+      ellipse at 50% 10%,
+      color-mix(in oklab, var(--color-success) 48%, var(--color-base-100)),
+      color-mix(in oklab, var(--color-success) 30%, var(--color-base-300)) 48%,
+      transparent 51%
+    );
+  filter: drop-shadow(
+    0 1.25rem 1.2rem color-mix(in oklab, var(--color-primary) 20%, transparent)
+  );
+  opacity: 0.28;
+}
+
+.taskmaster-backdrop__island--one {
+  right: 22%;
+  top: 30%;
+  transform: rotate(-5deg);
+}
+
+.taskmaster-backdrop__island--two {
+  right: 4%;
+  top: 48%;
+  transform: scale(0.72) rotate(8deg);
+}
+
+.taskmaster-backdrop__cloud {
+  width: clamp(10rem, 24vw, 24rem);
+  height: clamp(3rem, 8vw, 7rem);
+  border-radius: 50%;
+  background: color-mix(in oklab, var(--color-base-100) 76%, transparent);
+  filter: blur(1rem);
+  opacity: 0.4;
+}
+
+.taskmaster-backdrop__cloud--one {
+  left: -5%;
+  top: 5%;
+}
+
+.taskmaster-backdrop__cloud--two {
+  right: 12%;
+  top: 8%;
+  transform: scale(0.72);
+}
+
+.taskmaster-backdrop__path {
+  right: clamp(1rem, 7vw, 7rem);
+  top: clamp(12rem, 30vw, 25rem);
+  display: flex;
+  width: clamp(7rem, 16vw, 15rem);
+  transform: rotate(72deg);
+  align-items: center;
+  justify-content: space-between;
+  opacity: 0.62;
+}
+
+.taskmaster-backdrop__path span {
+  width: clamp(0.45rem, 0.75vw, 0.8rem);
+  aspect-ratio: 1;
+  border: 2px solid color-mix(in oklab, var(--color-warning) 80%, var(--color-base-100));
+  border-radius: 9999px;
+  background: color-mix(in oklab, var(--color-base-100) 72%, transparent);
+  box-shadow: 0 0 0.85rem color-mix(in oklab, var(--color-warning) 60%, transparent);
+}
+
+.taskmaster-backdrop--compact .taskmaster-backdrop__image {
+  opacity: 0.34;
+  filter: saturate(1.08) contrast(0.94);
+}
+
+.taskmaster-backdrop--compact .taskmaster-backdrop__portal {
+  opacity: 0.34;
+  transform: scale(0.78) rotate(2deg);
+  transform-origin: top right;
+}
+
+.taskmaster-backdrop--compact .taskmaster-backdrop__path {
+  opacity: 0.32;
+}
+
+@keyframes taskmaster-portal-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 767px) {
+  .taskmaster-backdrop__image {
+    object-position: 68% top;
+    opacity: 0.48;
+  }
+
+  .taskmaster-backdrop__sky {
+    background:
+      linear-gradient(
+        180deg,
+        color-mix(in oklab, var(--color-base-100) 12%, transparent) 0%,
+        color-mix(in oklab, var(--color-base-100) 26%, transparent) 34%,
+        color-mix(in oklab, var(--color-base-100) 82%, transparent) 66%,
+        var(--color-base-100) 100%
+      );
+  }
+
+  .taskmaster-backdrop__portal {
+    right: 0.9rem;
+    top: 2.25rem;
+    opacity: 0.42;
+  }
+
+  .taskmaster-backdrop__island--one {
+    right: 28%;
+    top: 20%;
+  }
+
+  .taskmaster-backdrop__island--two,
+  .taskmaster-backdrop__cloud--two {
+    display: none;
+  }
+
+  .taskmaster-backdrop__path {
+    right: -1.5rem;
+    top: 14rem;
+    transform: rotate(88deg) scale(0.8);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .taskmaster-backdrop__portal::after {
+    animation: none;
+  }
+}
+</style>

--- a/components/taskmaster/taskmaster-quest-stepper.vue
+++ b/components/taskmaster/taskmaster-quest-stepper.vue
@@ -1,0 +1,72 @@
+<template>
+  <nav
+    class="taskmaster-stepper relative z-20 grid grid-cols-3 overflow-hidden rounded-2xl border border-base-300/80 bg-base-100/90 p-1.5 shadow-xl backdrop-blur-xl"
+    aria-label="Quest progress"
+  >
+    <div
+      v-for="(step, index) in steps"
+      :key="step.key"
+      class="relative flex min-w-0 items-center justify-center gap-2 rounded-xl px-2 py-2 text-center transition sm:justify-start sm:px-3"
+      :class="index <= activeIndex ? 'text-base-content' : 'text-base-content/40'"
+      :aria-current="step.key === active ? 'step' : undefined"
+    >
+      <span
+        class="flex size-7 shrink-0 items-center justify-center rounded-full border text-xs font-black shadow-sm"
+        :class="
+          step.key === active
+            ? 'border-secondary bg-secondary text-secondary-content'
+            : index < activeIndex
+              ? 'border-success bg-success text-success-content'
+              : 'border-base-300 bg-base-200'
+        "
+      >
+        <Icon
+          v-if="index < activeIndex"
+          name="kind-icon:check"
+          class="size-3.5"
+        />
+        <template v-else>{{ index + 1 }}</template>
+      </span>
+      <span class="min-w-0">
+        <span class="block truncate text-[0.7rem] font-black sm:text-xs">
+          {{ step.label }}
+        </span>
+        <span class="hidden truncate text-[0.62rem] text-base-content/50 lg:block">
+          {{ step.helper }}
+        </span>
+      </span>
+      <span
+        v-if="index < steps.length - 1"
+        class="absolute -right-1 top-1/2 hidden h-px w-2 bg-base-300 sm:block"
+      />
+    </div>
+  </nav>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+type QuestStep = 'objective' | 'recipe' | 'review'
+
+const props = withDefaults(
+  defineProps<{
+    active?: QuestStep
+  }>(),
+  {
+    active: 'objective',
+  },
+)
+
+const steps: Array<{ key: QuestStep; label: string; helper: string }> = [
+  { key: 'objective', label: 'Objective', helper: 'Name the real target' },
+  { key: 'recipe', label: 'Recipe', helper: 'Shape the adventure' },
+  { key: 'review', label: 'Review', helper: 'Check before acting' },
+]
+
+const activeIndex = computed(() =>
+  Math.max(
+    0,
+    steps.findIndex((step) => step.key === props.active),
+  ),
+)
+</script>

--- a/components/taskmaster/taskmaster-sample-tasks.vue
+++ b/components/taskmaster/taskmaster-sample-tasks.vue
@@ -2,75 +2,84 @@
 <template>
   <section
     v-if="!taskmasterStore.session"
-    class="rounded-2xl border border-secondary/25 bg-secondary/5 p-4"
+    class="space-y-3"
     aria-labelledby="taskmaster-samples-heading"
   >
-    <div class="flex flex-wrap items-start justify-between gap-3">
+    <div class="flex flex-wrap items-start justify-between gap-2">
       <div class="min-w-0">
-        <p class="text-[0.7rem] font-bold uppercase tracking-wide text-secondary/75">
-          Try a sample task
+        <p
+          class="text-[0.68rem] font-black uppercase tracking-[0.15em] text-accent"
+        >
+          Serendipity's sparks
         </p>
-        <h2 id="taskmaster-samples-heading" class="mt-1 text-lg font-black">
-          Start with a ready-made quest
-        </h2>
-        <p class="mt-1 max-w-3xl text-xs leading-relaxed text-base-content/55">
-          Pick an example to build a reviewable checkpoint plan. Nothing is applied or
-          marked complete automatically.
+        <h3 id="taskmaster-samples-heading" class="mt-1 text-base font-black">
+          Borrow a beginning
+        </h3>
+        <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+          Each spark builds a reviewable plan. Nothing is applied automatically.
         </p>
       </div>
       <span
         v-if="gateProject"
-        class="badge badge-warning badge-sm rounded-xl"
+        class="badge badge-warning badge-outline badge-sm h-auto rounded-xl py-1 text-[0.65rem]"
       >
-        {{ gateProject.gateCount }} current human
+        {{ gateProject.gateCount }} human
         {{ gateProject.gateCount === 1 ? 'gate' : 'gates' }}
       </span>
     </div>
 
-    <div class="mt-3 grid gap-2 md:grid-cols-2">
+    <div class="grid gap-2 sm:grid-cols-2 xl:grid-cols-1 2xl:grid-cols-2">
       <button
         v-for="sample in sampleTasks"
         :key="sample.id"
         type="button"
-        class="group rounded-2xl border p-3 text-left transition hover:-translate-y-0.5 hover:border-secondary/50 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70 disabled:cursor-wait disabled:opacity-60 motion-reduce:transform-none motion-reduce:transition-none"
+        class="taskmaster-spark group relative min-h-28 overflow-hidden rounded-2xl border p-3 text-left transition hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 disabled:cursor-wait disabled:opacity-60 motion-reduce:transform-none motion-reduce:transition-none"
         :class="
           sample.id === 'conductor-gates'
-            ? 'border-warning/40 bg-warning/5'
-            : 'border-base-300 bg-base-100'
+            ? 'border-warning/45 bg-warning/10'
+            : 'border-base-300/90 bg-base-100/90'
         "
         :disabled="startingId !== null || taskmasterStore.isWeaving"
         @click="useSample(sample)"
       >
-        <span class="flex items-start gap-3">
-          <span
-            class="flex size-9 shrink-0 items-center justify-center rounded-xl border border-current/15 bg-base-100/70 text-secondary"
-            aria-hidden="true"
-          >
+        <span
+          class="absolute -right-5 -top-5 size-20 rounded-full bg-accent/10 transition group-hover:scale-125 motion-reduce:transition-none"
+          aria-hidden="true"
+        />
+        <span class="relative flex h-full flex-col gap-2">
+          <span class="flex items-start justify-between gap-2">
             <span
-              v-if="startingId === sample.id"
-              class="loading loading-spinner loading-sm"
-            />
-            <Icon v-else :name="sample.icon" class="size-4" />
-          </span>
-          <span class="min-w-0 flex-1">
-            <span class="block text-sm font-black leading-snug">
-              {{ sample.task }}
-            </span>
-            <span class="mt-1 block text-xs leading-relaxed text-base-content/50">
-              {{ sample.helper }}
-            </span>
-            <span
-              v-if="sample.id === 'conductor-gates' && gateProject"
-              class="mt-2 block text-[0.68rem] font-bold uppercase tracking-wide text-warning"
+              class="flex size-10 shrink-0 items-center justify-center rounded-2xl border border-current/15 bg-base-100/80 text-accent shadow-sm"
+              aria-hidden="true"
             >
-              Starts with {{ gateProject.name }}
+              <span
+                v-if="startingId === sample.id"
+                class="loading loading-spinner loading-sm"
+              />
+              <Icon v-else :name="sample.icon" class="size-5" />
             </span>
+            <Icon
+              name="kind-icon:chevron-right"
+              class="mt-1 size-4 shrink-0 text-base-content/25 transition group-hover:translate-x-0.5 group-hover:text-accent motion-reduce:transition-none"
+            />
+          </span>
+          <span class="block text-sm font-black leading-snug">
+            {{ sample.task }}
+          </span>
+          <span class="block text-xs leading-relaxed text-base-content/50">
+            {{ sample.helper }}
+          </span>
+          <span
+            v-if="sample.id === 'conductor-gates' && gateProject"
+            class="mt-auto block text-[0.65rem] font-black uppercase tracking-wide text-warning"
+          >
+            Starts with {{ gateProject.name }}
           </span>
         </span>
       </button>
     </div>
 
-    <p v-if="errorMessage" class="mt-3 text-xs text-error" role="alert">
+    <p v-if="errorMessage" class="text-xs text-error" role="alert">
       {{ errorMessage }}
     </p>
   </section>
@@ -104,7 +113,7 @@ const sampleTasks: SampleTask[] = [
     id: 'conductor-gates',
     task: 'Look at my conductor repo and help me clear any current human gates.',
     helper:
-      'Loads the current Conductor surface and scopes the checkpoint plan to the project with the most needs-human work.',
+      'Load the current Conductor surface and start with the project carrying the most needs-human work.',
     icon: 'kind-icon:gearhammer',
     tone: 'adventurous',
     vibeTags: ['clear-eyed', 'collaborative', 'practical'],
@@ -113,7 +122,7 @@ const sampleTasks: SampleTask[] = [
   {
     id: 'ship-feature',
     task: 'Help me choose the next feature to ship and identify the smallest useful first step.',
-    helper: 'Turn an open-ended product decision into a short, concrete sequence.',
+    helper: 'Turn an open product decision into a short, concrete sequence.',
     icon: 'kind-icon:story',
     tone: 'mysterious',
     vibeTags: ['decisive', 'focused', 'small wins'],
@@ -129,7 +138,7 @@ const sampleTasks: SampleTask[] = [
   {
     id: 'hard-conversation',
     task: 'Help me prepare for a conversation I have been putting off.',
-    helper: 'Clarify the goal, gather the important facts, and plan the opening words.',
+    helper: 'Clarify the goal, gather the facts, and plan the opening words.',
     icon: 'kind-icon:alert',
     tone: 'tender',
     vibeTags: ['honest', 'calm', 'respectful'],


### PR DESCRIPTION
## What changed

- rebuild Taskmaster around a full-surface fantasy world using the stable Taskmaster dashboard art path
- add a responsive backdrop with portal, floating-island, cloud, and quest-path layers that gracefully falls back to theme-driven scenery
- add a dedicated Objective → Recipe → Review stepper
- replace the old uniform two-column form with an asymmetric Quest Desk:
  - objective desk
  - responsive recipe panel
  - Serendipity guide treatment
  - compact spark cards
  - persistent action rail
- make the recipe collapsible on mobile while remaining fully visible on tablet and desktop
- restyle draft review as a connected checkpoint route
- carry the same scenic/glass language into the active quest, transcript, mission rail, and write-back ledger

## Responsive behavior

- mobile: illustrated hero, overlapping stepper, one-column quest desk, collapsible recipe, touch-sized sticky actions
- tablet portrait: two-column desk where space allows, spark panel spanning the layout
- tablet landscape / desktop: three-part asymmetric desk with visible scene between cards and Serendipity positioned as guide rather than another generic form block

## Consistency

The redesign keeps the shared workspace header, `kr-surface`, DaisyUI controls, `kr-choice-list`, `NarrativeIngredientPicker`, `KrChatWindow`, `NarrativeResponseComposer`, narrator stage, and existing Taskmaster store/state machine. The only new primitives are Taskmaster-specific scene composition and quest navigation.

## Safety preserved

- practical checkpoint review still occurs before narration
- real outcomes remain explicit
- no automatic write-back
- Apply actions remain individually reviewable
- Storybook and Taskmaster state stay separate

## Verification

- TypeScript
- Contract Tests
- Taskmaster checkpoint engine contract
- Taskmaster sample task contract
- Narrative primitives and art contracts
- Layout / scroll ownership contracts
- Vercel preview and production verification