### PR TITLE
Keep long channel flyouts vertically scrollable

### DIFF
--- a/components/navigation/channel-select.vue
+++ b/components/navigation/channel-select.vue
@@ -181,7 +181,7 @@
       <ul
         v-if="expandedChannel && submenuMode === 'flyout'"
         ref="channelFlyout"
-        class="channel-submenu menu absolute left-full z-120 ml-2 w-80 overflow-x-hidden kr-anchor-scroll rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl"
+        class="channel-submenu menu absolute left-full z-120 ml-2 w-80 flex-nowrap overflow-x-hidden kr-anchor-scroll rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl"
         :style="{
           top: `${channelFlyoutTop}px`,
           maxHeight: `${channelFlyoutMaxHeight}px`,

--- a/utils/scripts/verifyChannelContent.ts
+++ b/utils/scripts/verifyChannelContent.ts
@@ -45,6 +45,10 @@ const repositoryRoot = resolve(scriptDirectory, '../..')
 const contentDirectory = resolve(repositoryRoot, 'content')
 const channelsDirectory = resolve(contentDirectory, 'channels')
 const componentsDirectory = resolve(repositoryRoot, 'components')
+const channelSelectorFile = resolve(
+  componentsDirectory,
+  'navigation/channel-select.vue',
+)
 
 function cleanValue(value: string): string {
   const trimmed = value.trim()
@@ -198,11 +202,45 @@ function validatePageDocument(errors: string[], document: NavigationDocument): v
   validateAccess(errors, document)
 }
 
+async function validateChannelSelectorOverflow(errors: string[]): Promise<void> {
+  const source = await readFile(channelSelectorFile, 'utf8')
+  const flyoutClass = source.match(
+    /ref="channelFlyout"[\s\S]*?class="([^"]+)"/,
+  )?.[1]
+
+  if (!flyoutClass) {
+    errors.push(
+      'components/navigation/channel-select.vue: channel tab flyout class could not be resolved',
+    )
+    return
+  }
+
+  const classes = new Set(flyoutClass.split(/\s+/))
+  for (const requiredClass of [
+    'flex-nowrap',
+    'overflow-x-hidden',
+    'kr-anchor-scroll',
+  ]) {
+    if (!classes.has(requiredClass)) {
+      errors.push(
+        `components/navigation/channel-select.vue: channel tab flyout requires ${requiredClass} so long tab lists stay in one vertically scrollable column`,
+      )
+    }
+  }
+
+  if (!source.includes('maxHeight: `${channelFlyoutMaxHeight}px`')) {
+    errors.push(
+      'components/navigation/channel-select.vue: channel tab flyout must retain its viewport-derived maxHeight',
+    )
+  }
+}
+
 async function main(): Promise<void> {
   const documents = await Promise.all(
     (await markdownFiles(channelsDirectory)).map(readDocument),
   )
   const errors: string[] = []
+  await validateChannelSelectorOverflow(errors)
   const channels = documents.filter((item) => item.contentType === 'channel')
   const tabs = documents.filter((item) => item.contentType === 'tab')
   const channelsByKey = new Map(channels.map((channel) => [channel.channelKey, channel]))


### PR DESCRIPTION
## Root cause

The earlier viewport-height fix correctly constrained the channel-tab flyout, but the flyout itself still inherited DaisyUI menu wrapping. Once a channel had more tabs than fit vertically, the menu wrapped the remaining items into extra horizontal columns. Because the flyout also hides horizontal overflow, those columns were clipped out of existence instead of becoming vertically scrollable.

The primary channel list already had `flex-nowrap`; the secondary tab flyout did not.

## What changed

- add `flex-nowrap` to the channel-tab flyout so every tab stays in one vertical column and `kr-anchor-scroll` owns the overflow
- extend the existing channel-content contract to require the complete overflow combination: viewport-derived max height, no wrapping, hidden horizontal overflow, and vertical anchor scrolling

## Verification

- diff against the branch base is limited to `channel-select.vue` and the focused channel-content contract
- the new contract would fail on the exact pre-fix markup shown in the production screenshot
- GitHub Actions and the Vercel preview will provide TypeScript, formatting, contract, and browser/deployment validation

## Stakes

Reversible front-end regression fix. No API, schema, migration, ArtJob, or production-data changes.