### PR TITLE
Run failed ArtJob repair before optional seeds

### DIFF
--- a/scripts/reconcile_failed_art_jobs_production.ts
+++ b/scripts/reconcile_failed_art_jobs_production.ts
@@ -1,0 +1,16 @@
+// scripts/reconcile_failed_art_jobs_production.ts
+//
+// One-time production wrapper. The underlying reconciler already retries a
+// transient database failure three times; this outer window lets a deployment
+// survive a longer ProxySQL pool outage without weakening the manual script's
+// normal bounded behavior.
+
+import { main as reconcileFailedArtJobs } from './reconcile_failed_art_jobs'
+import { withDatabaseRetry } from './lib/databaseRetry'
+
+await withDatabaseRetry(
+  'production failed ArtJob reconciliation',
+  async () => reconcileFailedArtJobs(),
+  3,
+  10_000,
+)

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -35,6 +35,12 @@ if (!isVercelBuild || isProductionDeployment) {
 
   run(
     tsxBinary,
+    ['scripts/reconcile_failed_art_jobs_production.ts', '--write'],
+    'Reconciling failed ArtJobs',
+  )
+
+  run(
+    tsxBinary,
     ['scripts/seed_achievements.ts', '--write'],
     'Reconciling canonical Achievement catalog',
   )
@@ -53,12 +59,6 @@ if (!isVercelBuild || isProductionDeployment) {
     tsxBinary,
     ['scripts/seed_contenders.ts', '--write'],
     'Seeding Challenge Center contenders',
-  )
-
-  run(
-    tsxBinary,
-    ['scripts/reconcile_failed_art_jobs.ts', '--write'],
-    'Reconciling failed ArtJobs',
   )
 } else {
   console.log(


### PR DESCRIPTION
## Why

Production deployment `dpl_5AWahPMj6hjCkyi7fB77fmoE46kw` never reached the requested failed-queue reconciliation. The pre-existing achievement seed exhausted its bounded retries first because ProxySQL returned `P2039` pool timeouts with zero available connections.

## What changed

- run the failed ArtJob reconciliation immediately after migrations, before achievement and contender housekeeping
- add a one-time production wrapper with a wider outer retry window for prolonged ProxySQL pool outages
- keep the manual reconciliation script dry-run by default and keep its normal retry behavior unchanged

## Safety

The underlying reconciliation still mutates only rows that remain `FAILED`, reuses valid ArtJob IDs, deletes only superseded or irreparable failures, and aborts unless the resulting FAILED count is zero.

## Verification

GitHub checks must complete successfully before merge. The next production deployment log must show the actual classification and `remaining FAILED=0`.