### PR TITLE
Trigger the failed ArtJob reconciliation deployment

### DIFF
--- a/scripts/failed-artjob-repair-run-20260805.txt
+++ b/scripts/failed-artjob-repair-run-20260805.txt
@@ -1,0 +1,5 @@
+Failed ArtJob reconciliation deployment trigger.
+
+Operation: failed-artjobs-2026-08-05-retry-2
+Purpose: force the production build to run the already-merged reconciliation after Vercel skipped commit c7f47212797218eca946e230735e8db378357b6f following the prior deployment failure.
+Remove this marker after the production log verifies remaining FAILED=0.


### PR DESCRIPTION
Vercel skipped the prior merged retry commit after the preceding production deployment failed during an unrelated achievement seed. This marker creates a fresh audited commit so the already-merged failed ArtJob reconciliation runs in production. Remove the marker after deployment logs verify `remaining FAILED=0`.