### PR TITLE
Page backdrops per breakpoint + surface tokens (Stage 3 rails)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -65,6 +65,13 @@ jobs:
       - name: Component reachability contract
         run: npm run test:component-reachability
 
+      # Stage 3 rails: per-breakpoint page backdrop art + the surface tokens
+      # that let the shared kit go translucent over it. The failure this really
+      # guards is a backdrop key wired into three of its four sites — the page
+      # typechecks, the frontmatter validates, and the art just never arrives.
+      - name: Page backdrop contract
+        run: npm run test:page-backdrop
+
       # t-099: ESLint as a ratcheted gate — never asks anyone to fix the
       # pre-existing problems, only refuses NEW ones, per rule.
       #

--- a/app.vue
+++ b/app.vue
@@ -84,10 +84,34 @@
           </aside>
         </Transition>
 
+        <!--
+          `data-kr-backdrop` flips the surface tokens (assets/css/tailwind.css)
+          for everything inside, so the shared kit's panels go translucent and
+          the art reads through them. Present ONLY when the page actually
+          declares backdrop art — otherwise the attribute is absent and every
+          surface resolves to the same opaque theme colour it always had.
+
+          It sits on <main> rather than on the backdrop element because the
+          backdrop is a sibling of the page content, not its ancestor; the
+          tokens have to be inherited by the cards, which live under <main>.
+        -->
         <main
           class="kr-main relative z-10 h-full min-h-0 overflow-hidden rounded-2xl bg-base-100 transition-[padding] duration-300 ease-out"
           :class="workspaceSheetOpen ? 'hidden md:block' : 'block'"
+          :data-kr-backdrop="hasPageBackdrop ? '' : undefined"
         >
+          <!--
+            Page backdrop art, BEFORE fx-region deliberately. Both layers sit
+            at z-0, so DOM order decides: the backdrop paints first, fx-region's
+            effects paint over it, and the z-10 <NuxtPage /> wrapper below sits
+            above both. Renders nothing at all unless the page declares art.
+          -->
+          <kr-page-backdrop
+            :mobile="pageStore.backgroundMobile"
+            :tablet="pageStore.backgroundTablet"
+            :desktop="pageStore.backgroundDesktop"
+          />
+
           <fx-region region="page" />
 
           <div
@@ -167,6 +191,21 @@ import { useUserStore } from '@/stores/userStore'
 import { useIntroStore } from '@/stores/introStore'
 
 const pageStore = usePageStore()
+
+/**
+ * Whether the current page declares any backdrop art.
+ *
+ * Mirrors kr-page-backdrop's own `hasBackdrop` rather than reading it off the
+ * child, because the attribute it drives belongs on <main> — the cards that
+ * inherit the surface tokens are siblings of the backdrop, not its children.
+ */
+const hasPageBackdrop = computed(() =>
+  Boolean(
+    pageStore.backgroundMobile ||
+      pageStore.backgroundTablet ||
+      pageStore.backgroundDesktop,
+  ),
+)
 const navStore = useNavStore()
 const userStore = useUserStore()
 const introStore = useIntroStore()

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -128,6 +128,50 @@
   --noise: 0;
 }
 
+/*
+ * ── SURFACE TOKENS ────────────────────────────────────────────────────
+ *
+ * One indirection between the shared kit and the theme's base colours, so a
+ * page with art behind it gets glass panels without every component growing a
+ * `translucent` prop.
+ *
+ * THE PROBLEM THIS SOLVES. kr-gallery, kr-chat-window, reactable-card and the
+ * rest hardcode `bg-base-200` / `bg-base-100` / `border-base-300`. Those are
+ * opaque, so the moment a backdrop appears behind a page, every card becomes a
+ * solid block covering the art — the opposite of the Stage 3 mockups, where
+ * panels are glass and the art reads through. Passing a prop down to each one
+ * means Stage 3 forks the kit, which undoes the consistency work Stage 2 just
+ * finished. A token costs the kit one class rename and nothing else.
+ *
+ * DEFAULTS ARE THE THEME'S OWN COLOURS, so a page with no backdrop renders
+ * exactly as it did before this existed — including in every daisyUI theme,
+ * since these resolve `--color-base-*` at use time rather than copying values.
+ *
+ * Stage 3 tunes the glass by editing the four values under [data-kr-backdrop]
+ * and nothing else. Opacity, blur and border weight all live here.
+ */
+:root {
+  --kr-surface: var(--color-base-200); /* card / panel ground */
+  --kr-surface-raised: var(--color-base-100); /* raised onto that ground */
+  --kr-surface-sunken: var(--color-base-300); /* wells, mode bars */
+  --kr-surface-border: var(--color-base-300);
+}
+
+/*
+ * Set by kr-page-backdrop.vue on <main> when a page actually declares art —
+ * never when it does not, which is what keeps the no-backdrop path identical.
+ *
+ * color-mix rather than a `/80` opacity class because these are consumed as
+ * bare colour values by `bg-(--kr-surface)`, which has nowhere to put a
+ * slash-opacity modifier.
+ */
+[data-kr-backdrop] {
+  --kr-surface: color-mix(in oklch, var(--color-base-200) 78%, transparent);
+  --kr-surface-raised: color-mix(in oklch, var(--color-base-100) 82%, transparent);
+  --kr-surface-sunken: color-mix(in oklch, var(--color-base-300) 72%, transparent);
+  --kr-surface-border: color-mix(in oklch, var(--color-base-300) 60%, transparent);
+}
+
 /* Hide scrollbar for Chrome, Safari and Opera */
 .no-scrollbar::-webkit-scrollbar {
   display: none;
@@ -282,6 +326,49 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
      does that. Pair with THE HEADER RULE above. */
   .kr-surface {
     @apply flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden;
+  }
+
+  /*
+   * PAGE BACKDROP — full-bleed art behind the page, one variant per breakpoint.
+   *
+   * WHY THE VARIANT IS PICKED IN CSS AND NOT IN JS. Choosing by
+   * `window.innerWidth` means the server renders one variant and the client
+   * swaps to another: a hydration mismatch plus a visible flash on every load.
+   * Inline styles cannot carry media queries, so kr-page-backdrop.vue sets only
+   * the custom properties it has and these rules resolve which one wins.
+   *
+   * The nested var() fallbacks are the graceful-degradation path, and they are
+   * the point rather than a nicety: art is still being generated, so most pages
+   * will ship one variant long before three. A page with only
+   * `backgroundDesktop` shows it on a phone instead of nothing, and a page with
+   * no backdrop at all resolves to `none` and paints nothing.
+   *
+   * Breakpoints match Tailwind's defaults (md 768, lg 1024) and the design
+   * mockups: mobile 390x844, tablet 768x1024, desktop >=1024.
+   */
+  .kr-backdrop {
+    background-image: var(
+      --kr-bg-mobile,
+      var(--kr-bg-tablet, var(--kr-bg-desktop, none))
+    );
+  }
+
+  @media (min-width: 768px) {
+    .kr-backdrop {
+      background-image: var(
+        --kr-bg-tablet,
+        var(--kr-bg-desktop, var(--kr-bg-mobile, none))
+      );
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .kr-backdrop {
+      background-image: var(
+        --kr-bg-desktop,
+        var(--kr-bg-tablet, var(--kr-bg-mobile, none))
+      );
+    }
   }
 
   /* One non-scrolling control row (filters, tabs, actions) directly under

--- a/components/gallery/kr-entity-card-body.vue
+++ b/components/gallery/kr-entity-card-body.vue
@@ -68,7 +68,7 @@
     -->
     <div
       v-if="showImage"
-      class="size-14 shrink-0 overflow-hidden rounded-xl bg-base-300"
+      class="size-14 shrink-0 overflow-hidden rounded-xl bg-(--kr-surface-sunken)"
     >
       <kr-art-plate
         :source="source"

--- a/components/gallery/kr-gallery.vue
+++ b/components/gallery/kr-gallery.vue
@@ -21,7 +21,7 @@
     -->
     <div
       v-if="modes.length"
-      class="sticky top-0 z-20 -mx-1 flex shrink-0 gap-0.5 bg-base-300/95 px-1 py-1 backdrop-blur"
+      class="sticky top-0 z-20 -mx-1 flex shrink-0 gap-0.5 bg-(--kr-surface-sunken) px-1 py-1 backdrop-blur"
     >
       <button
         v-for="entry in modes"
@@ -115,7 +115,7 @@
         v-else
         :key="item.id"
         type="button"
-        class="group overflow-hidden rounded-2xl border border-base-300 bg-base-200 text-left transition hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-lg"
+        class="group overflow-hidden rounded-2xl border border-(--kr-surface-border) bg-(--kr-surface) text-left transition hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-lg"
         @click="emit('open', item)"
       >
         <div class="relative overflow-hidden" :class="imageWrapClass">

--- a/components/narrative/kr-chat-window.vue
+++ b/components/narrative/kr-chat-window.vue
@@ -78,7 +78,7 @@
           'min-w-0 max-w-[92%] rounded-2xl px-4 py-3 text-sm leading-relaxed',
           turn.from === 'user'
             ? 'rounded-br-sm border border-secondary/30 bg-secondary/10'
-            : 'rounded-bl-sm border border-base-300 bg-base-100 shadow-sm',
+            : 'rounded-bl-sm border border-(--kr-surface-border) bg-(--kr-surface-raised) shadow-sm',
         ]"
       >
         <p

--- a/components/narrative/kr-choice-list.vue
+++ b/components/narrative/kr-choice-list.vue
@@ -36,7 +36,7 @@
       :key="choice.key"
       type="button"
       :class="[
-        'flex items-center gap-3 rounded-xl border-2 border-base-300 bg-base-100 text-left transition',
+        'flex items-center gap-3 rounded-xl border-2 border-(--kr-surface-border) bg-(--kr-surface-raised) text-left transition',
         'hover:-translate-y-0.5 hover:border-primary/50',
         // The house pattern for every other narrative control: a visible focus
         // ring, and no lift or transition for readers who asked for less motion.

--- a/components/ui/kr-page-backdrop.vue
+++ b/components/ui/kr-page-backdrop.vue
@@ -1,0 +1,133 @@
+<!-- /components/ui/kr-page-backdrop.vue -->
+<!--
+  Full-bleed art behind the page, one variant per breakpoint.
+
+  Silas, 2026-08-05, opening Stage 3 ("make it pretty"):
+
+    "I think a background image for each page, adjusted for mobile, tablet, or
+     desktop layout, will help A LOT, and we're starting with that."
+
+  and, on naming:
+
+    "backgroundMobile, backgroundTablet, and background desktop would be less
+     ambiguous"
+
+  THIS COMPONENT IS RAILS, NOT LOOKS. A separate agent owns the Stage 3
+  aesthetic. Everything here that could be a design decision is a prop with a
+  neutral default, or a token in tailwind.css — scrim strength, blur, surface
+  translucency. Nothing about the house style is baked in.
+
+  MOUNTED ONCE, in app.vue, rather than per page. Pages declare art in
+  frontmatter and pageStore carries it here, so no page component changes and
+  no page root is touched — which is what keeps verifyLayoutContract's
+  `root-surface` rule out of this entirely. It sits beside <fx-region>, which
+  has been rendering a full-bleed layer in this exact slot for a while; this is
+  a second tenant of a proven arrangement, not a new idea.
+
+  THE VARIANT IS CHOSEN IN CSS, NEVER IN JS. See the .kr-backdrop rules in
+  assets/css/tailwind.css. Reading window.innerWidth here would render one
+  variant on the server and swap on the client: hydration mismatch plus a flash
+  on every load. Inline styles cannot carry media queries, so this sets only
+  the custom properties it has and the stylesheet resolves which one wins. That
+  also means exactly one image is fetched, not three.
+
+  MISSING ART IS NOT A FAILURE. Most pages will have one variant long before
+  three, and many will have none for a while yet. Undeclared variants leave
+  their custom property unset, the CSS falls back to a sibling variant, and a
+  page with nothing declared renders no backdrop and no scrim at all — byte
+  identical to before this component existed.
+-->
+<template>
+  <!--
+    Renders NOTHING when the page declares no art. Not an empty div, not a
+    transparent scrim — the whole subtree is absent, so a page without a
+    backdrop cannot be visually or structurally affected by this at all.
+  -->
+  <div
+    v-if="hasBackdrop"
+    class="kr-backdrop pointer-events-none absolute inset-0 overflow-hidden rounded-2xl bg-cover bg-center bg-no-repeat"
+    :style="backdropVars"
+    aria-hidden="true"
+  >
+    <!--
+      SCRIM. Art is chosen for mood, not for contrast against body text, so
+      something has to guarantee legibility. Strength is a prop because the
+      right amount depends on the artwork, and Stage 3 owns that call.
+
+      `bg-linear-to-b`, not `bg-gradient-to-b` — Tailwind v4 renamed it, and the
+      old spelling silently produces no gradient rather than erroring.
+    -->
+    <div v-if="scrim !== 'none'" class="absolute inset-0" :class="scrimClass" />
+
+    <!-- Decorative extras from the mockups: butterflies, sparkles, compass
+         roses. Above the scrim so they read as part of the scene rather than
+         being washed out by it. -->
+    <slot name="overlay" />
+
+    <!--
+      Character art (the transparent Serendipity PNG in the Taskmaster mockup).
+      Its own slot rather than part of #overlay because it is anchored, not
+      scattered — the mockup pins it bottom-right on desktop, and a caller will
+      want to move or hide it per breakpoint without touching the sparkles.
+    -->
+    <slot name="character" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { pageImageCssUrl } from '@/utils/pageImagePath'
+
+const props = withDefaults(
+  defineProps<{
+    /** Bare frontmatter paths; resolved through pageImagePath. */
+    mobile?: string
+    tablet?: string
+    desktop?: string
+    /** Legibility wash over the art. Stage 3 picks per page. */
+    scrim?: 'none' | 'soft' | 'medium' | 'strong'
+  }>(),
+  {
+    mobile: '',
+    tablet: '',
+    desktop: '',
+    scrim: 'soft',
+  },
+)
+
+const hasBackdrop = computed(
+  () => Boolean(props.mobile || props.tablet || props.desktop),
+)
+
+/**
+ * Only the variants that exist become custom properties.
+ *
+ * An UNSET property is what makes the CSS fallback chain work — `var(--a, var(--b))`
+ * reaches for `--b` when `--a` is unset, but an empty string is a *set* value
+ * and would resolve to nothing at all, painting no art while another variant
+ * sat available. So absent keys must be genuinely absent, not empty.
+ */
+const backdropVars = computed(() => {
+  const vars: Record<string, string> = {}
+
+  const mobile = pageImageCssUrl(props.mobile)
+  const tablet = pageImageCssUrl(props.tablet)
+  const desktop = pageImageCssUrl(props.desktop)
+
+  if (mobile) vars['--kr-bg-mobile'] = mobile
+  if (tablet) vars['--kr-bg-tablet'] = tablet
+  if (desktop) vars['--kr-bg-desktop'] = desktop
+
+  return vars
+})
+
+const SCRIM_CLASS: Record<string, string> = {
+  soft: 'bg-linear-to-b from-base-300/10 via-base-300/15 to-base-300/45',
+  medium: 'bg-linear-to-b from-base-300/25 via-base-300/35 to-base-300/60',
+  strong: 'bg-linear-to-b from-base-300/45 via-base-300/55 to-base-300/75',
+}
+
+const scrimClass = computed(() => SCRIM_CLASS[props.scrim] ?? SCRIM_CLASS.soft)
+
+defineExpose({ hasBackdrop })
+</script>

--- a/components/wonderlab/reactable-card.vue
+++ b/components/wonderlab/reactable-card.vue
@@ -6,7 +6,7 @@
     :data-art-subject="normalizedTargetTitle || undefined"
     data-art-context
     :class="[
-      'group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl border bg-base-200 transition-all hover:shadow-lg',
+      'group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl border bg-(--kr-surface) transition-all hover:shadow-lg',
       // Panel cards (bot, character, reward, scenario) inset their art and want
       // the padding. Poster cards (dream) run their art edge-to-edge with the
       // title overlaid, and padding would frame it in a way the design does not
@@ -14,7 +14,7 @@
       // nothing else in this repo uses Tailwind's important modifier and a
       // class-string fight is a worse contract than a boolean.
       padded ? (compact ? 'gap-2 p-3' : 'gap-4 p-4') : 'gap-0 p-0',
-      selected ? 'border-primary bg-primary/10' : 'border-base-300',
+      selected ? 'border-primary bg-primary/10' : 'border-(--kr-surface-border)',
       normalizedCardClass,
     ]"
     @click="handleSelect"
@@ -51,7 +51,7 @@
     <Transition name="reaction-pop">
       <div
         v-if="reactionOpen && canRenderReactionCard"
-        class="absolute inset-x-2 top-14 z-40 max-h-[calc(100%-4rem)] overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl"
+        class="absolute inset-x-2 top-14 z-40 max-h-[calc(100%-4rem)] overflow-y-auto rounded-2xl border border-(--kr-surface-border) bg-(--kr-surface-raised) p-2 shadow-2xl"
         @click.stop
       >
         <div class="mb-2 flex items-center justify-between gap-2">

--- a/content.config.ts
+++ b/content.config.ts
@@ -69,6 +69,25 @@ const sharedNavigationSchema = z.object({
   description: z.string().optional(),
   icon: z.string().optional(),
   image: z.string().optional(),
+  /*
+   * PAGE BACKDROP ART, one per breakpoint.
+   *
+   * Distinct from `image` above, which is a THUMBNAIL — nav tabs and the
+   * workspace sheet render it at chip size. These are full-bleed art rendered
+   * behind the page by components/ui/kr-page-backdrop.vue.
+   *
+   * Three named breakpoints rather than orientation, per Silas 2026-08-05:
+   * "backgroundMobile, backgroundTablet, and background desktop would be less
+   * ambiguous". They line up with Tailwind's defaults — mobile <768,
+   * tablet 768-1023, desktop >=1024.
+   *
+   * All three are optional and independently so: the backdrop falls back
+   * across variants, so a page shipping only `backgroundDesktop` still shows
+   * it on a phone rather than nothing.
+   */
+  backgroundMobile: z.string().optional(),
+  backgroundTablet: z.string().optional(),
+  backgroundDesktop: z.string().optional(),
   tooltip: z.string().optional(),
   dottiTip: z.string().optional(),
   amiTip: z.string().optional(),

--- a/content/art.md
+++ b/content/art.md
@@ -16,6 +16,9 @@ dashboardTab: gallery
 cards: artCards
 loadingMessage: Loading art gallery...
 refreshLabel: Refresh Art
+backgroundMobile: background/art-mobile.webp
+backgroundTablet: background/art-tablet.webp
+backgroundDesktop: background/art-desktop.webp
 ---
 
 :art-manager

--- a/content/bots.md
+++ b/content/bots.md
@@ -17,6 +17,9 @@ dashboardTab: bots
 cards: botCards
 loadingMessage: Loading bot factory...
 refreshLabel: Refresh Bots
+backgroundMobile: background/bots-mobile.webp
+backgroundTablet: background/bots-tablet.webp
+backgroundDesktop: background/bots-desktop.webp
 ---
 
 :bot-manager

--- a/content/channels/play/scenarios.md
+++ b/content/channels/play/scenarios.md
@@ -11,6 +11,9 @@ description: Explore branching experiences, create new scenarios, invent solutio
 icon: kind-icon:story
 route: /stories
 sort: 60
+backgroundMobile: background/scenarios-mobile.webp
+backgroundTablet: background/scenarios-tablet.webp
+backgroundDesktop: background/scenarios-desktop.webp
 ---
 
 The Stories manager keeps scenario creation and play on the same stage.

--- a/content/channels/sanctuary/giftshop.md
+++ b/content/channels/sanctuary/giftshop.md
@@ -14,6 +14,9 @@ sort: 30
 status: under-construction
 tutorial:
   underConstruction: true
+backgroundMobile: background/giftshop-mobile.webp
+backgroundTablet: background/giftshop-tablet.webp
+backgroundDesktop: background/giftshop-desktop.webp
 ---
 
 A future storefront for generated art and products that help support the project.

--- a/content/characters.md
+++ b/content/characters.md
@@ -15,6 +15,9 @@ dashboardTab: characters
 cards: navCards
 loadingMessage: Loading character builder...
 refreshLabel: Refresh characters
+backgroundMobile: background/characters-mobile.webp
+backgroundTablet: background/characters-tablet.webp
+backgroundDesktop: background/characters-desktop.webp
 ---
 
 :character-manager

--- a/content/dreams.md
+++ b/content/dreams.md
@@ -16,6 +16,9 @@ dashboardTab: dreams
 cards: dreamCards
 loadingMessage: Loading locations...
 refreshLabel: Refresh Locations
+backgroundMobile: background/dreams-mobile.webp
+backgroundTablet: background/dreams-tablet.webp
+backgroundDesktop: background/dreams-desktop.webp
 ---
 
 :dream-manager

--- a/content/plan/wonderlab.md
+++ b/content/plan/wonderlab.md
@@ -16,6 +16,9 @@ dashboardTab: wonder-lab
 cards: labCards
 loadingMessage: Loading the museum...
 refreshLabel: Refresh Museum
+backgroundMobile: background/wonderlab-mobile.webp
+backgroundTablet: background/wonderlab-tablet.webp
+backgroundDesktop: background/wonderlab-desktop.webp
 ---
 
 :lab-manager

--- a/content/rewards.md
+++ b/content/rewards.md
@@ -15,6 +15,9 @@ dashboardTab: rewards
 cards: rewardCards
 loadingMessage: Loading rewards...
 refreshLabel: Refresh Rewards
+backgroundMobile: background/rewards-mobile.webp
+backgroundTablet: background/rewards-tablet.webp
+backgroundDesktop: background/rewards-desktop.webp
 ---
 
 :reward-manager

--- a/content/storybook.md
+++ b/content/storybook.md
@@ -13,6 +13,9 @@ dashboardTab: storybook
 cards: navCards
 loadingMessage: Threading the loom...
 refreshLabel: Refresh Storybook
+backgroundMobile: background/storybook-mobile.webp
+backgroundTablet: background/storybook-tablet.webp
+backgroundDesktop: background/storybook-desktop.webp
 ---
 
 :storybook-library-page

--- a/content/taskmaster.md
+++ b/content/taskmaster.md
@@ -4,6 +4,13 @@ room: Quest Workshop
 subtitle: Turn real work into an adventure
 description: Choose a project and story ingredients, then let Taskmaster guide the next real objective through a second-person quest. Story art is directed automatically.
 icon: kind-icon:gearhammer
+# Stage 3 backdrop art. Served from the media origin via the /images/:path*
+# redirect in vercel.json, so these files are uploaded there rather than
+# committed (public/images/** is gitignored). Until they exist the page renders
+# exactly as it did before — the fallback path working, not a failure.
+backgroundMobile: background/taskmaster-mobile.webp
+backgroundTablet: background/taskmaster-tablet.webp
+backgroundDesktop: background/taskmaster-desktop.webp
 tooltip: The fiction stays playful. The real work stays visible and reviewable.
 dottiTip: Pick the quest, then make one honest move at a time.
 amiTip: A to-do list may wear armor, but Taskmaster still shows you what needs doing.

--- a/docs/page-backdrops.md
+++ b/docs/page-backdrops.md
@@ -1,0 +1,119 @@
+# Page backdrops and surface tokens
+
+Rails for Stage 3 ("make it pretty"). This document is for whoever is doing the bespoke design work —
+it describes the mechanism, and deliberately makes no aesthetic decisions.
+
+Silas, 2026-08-05:
+
+> "Make it work (pretty much done), make it consistent (…80% done), and then **Make it pretty**, the
+> step that is largely unfinished, where we make these pages truly bespoke and not just a sparse shell
+> of text boxes and text. […] I think a background image for each page, adjusted for mobile, tablet, or
+> desktop layout, will help A LOT, and we're starting with that."
+
+## Giving a page a backdrop
+
+Three optional frontmatter keys, in any `content/*.md`:
+
+```yaml
+backgroundMobile: background/taskmaster-mobile.webp
+backgroundTablet: background/taskmaster-tablet.webp
+backgroundDesktop: background/taskmaster-desktop.webp
+```
+
+That is the whole integration. No page component changes, no props to thread — `app.vue` mounts
+`kr-page-backdrop` once and `pageStore` carries the values to it.
+
+**All three are optional and independently so.** A page with only `backgroundDesktop` shows it at every
+size rather than nothing; a page with none renders no backdrop at all. Since art is still being
+generated, most pages will ship one variant long before three — that is the expected state, not a
+half-finished one.
+
+Paths are bare and get `/images/` prefixed (`utils/pageImagePath.ts`), which `vercel.json` redirects to
+`media.acrocatranch.com`. **`public/images/**` is gitignored**, so art is uploaded to the media origin,
+not committed. Until it is, the page looks exactly as it does now.
+
+`backgroundMobile` is not the same thing as `image:`. `image:` is the **thumbnail** — nav tabs and the
+workspace sheet render it at chip size. These are full-bleed art.
+
+## Breakpoints
+
+| variant | width | matches |
+|---|---|---|
+| `backgroundMobile` | `< 768px` | Tailwind base |
+| `backgroundTablet` | `768–1023px` | `md:` |
+| `backgroundDesktop` | `≥ 1024px` | `lg:` |
+
+## The two knobs Stage 3 owns
+
+### Scrim
+
+Art is chosen for mood, not for contrast against body text, so a wash guarantees legibility.
+`kr-page-backdrop` takes `scrim="none" | "soft" | "medium" | "strong"`, defaulting to `soft`. The right
+value depends on the artwork; pick per page.
+
+### Surface translucency
+
+`assets/css/tailwind.css` defines four tokens:
+
+```css
+:root {
+  --kr-surface:        var(--color-base-200);  /* card / panel ground */
+  --kr-surface-raised: var(--color-base-100);
+  --kr-surface-sunken: var(--color-base-300);
+  --kr-surface-border: var(--color-base-300);
+}
+[data-kr-backdrop] { /* …the same four, color-mix'd toward transparent */ }
+```
+
+`app.vue` puts `data-kr-backdrop` on `<main>` **only** when the page declares art. The shared kit
+(`kr-gallery`, `kr-entity-card-body`, `kr-chat-window`, `kr-choice-list`, `reactable-card`) reads
+`bg-(--kr-surface)` instead of `bg-base-200`, so panels go glass automatically.
+
+**To retune the whole app's glass, edit the four values under `[data-kr-backdrop]` and nothing else.**
+Opacity, and any blur you want to add, live there.
+
+Not every surface converted, on purpose: skeletons, the progress track, avatar rings and the floating
+karma/action chips stay opaque. They are not panels sitting over artwork, and the mockups show chips
+reading as solid.
+
+## Two slots, matching the mockups
+
+```vue
+<kr-page-backdrop :mobile="…" :tablet="…" :desktop="…" scrim="medium">
+  <template #overlay>  <!-- butterflies, sparkles, compass roses --> </template>
+  <template #character><!-- the transparent Serendipity PNG        --> </template>
+</kr-page-backdrop>
+```
+
+Both render above the scrim and are `pointer-events-none`. They are separate because the character is
+*anchored* (bottom-right on desktop in the Taskmaster mockup) while overlay elements are scattered —
+you will want to move or hide the character per breakpoint without touching the sparkles.
+
+## Two things not to undo
+
+**The variant is chosen in CSS, never in JavaScript.** Reading `window.innerWidth` renders one variant
+on the server and swaps on the client: a hydration mismatch plus a visible flash on every page load.
+Inline styles cannot carry media queries, so the component sets only the custom properties it has and
+`.kr-backdrop`'s media queries resolve which wins. This also means exactly one image is fetched, not
+three. `verifyPageBackdrop.ts` fails if JS breakpoint detection appears in the component.
+
+**Unset is not the same as empty.** `var(--a, var(--b))` reaches for `--b` only when `--a` is *unset*.
+An empty string is a set value and resolves to nothing, painting no art while another variant sat
+available — so absent variants must produce no custom property at all.
+
+## Verification
+
+- `npm run test:page-backdrop` — static contract: all three keys wired through all four sites
+  (`content.config.ts`, `WorkspacePage`, the `meta` computed, the flat re-exports), no
+  case-insensitive schema collision, fallback chains intact, tokens defaulting to theme colours, kit
+  on tokens, backdrop mounted before `fx-region`. Every assertion is mutation-tested.
+- `npm run audit:responsive` — behavioural: drives Chromium at 390 / 820 / 1440 and fails if a route's
+  declared variants collapse into fewer distinct URLs than it declared. No static check can see which
+  variant a browser picks.
+
+### Why the schema-collision check exists
+
+`content.config.ts` warns in prose that SQLite column names are case-insensitive. A key that collides
+case-insensitively with an existing one makes the content collection's `CREATE TABLE` fail, which
+leaves the content tables uncreated and **500s every page**. That is the worst failure available in
+this area and it was guarded only by a comment. It is now a test.

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
     "test:gallery-consistency": "tsx utils/scripts/verifyGalleryConsistency.ts",
     "test:component-reachability": "tsx utils/scripts/verifyComponentReachability.ts",
     "test:component-reachability:self": "tsx utils/scripts/verifyComponentReachability.ts --self-test",
+    "test:page-backdrop": "tsx utils/scripts/verifyPageBackdrop.ts",
+    "test:page-backdrop:self": "tsx utils/scripts/verifyPageBackdrop.ts --self-test",
     "test:earned-karma-wiring": "tsx utils/scripts/verifyEarnedKarmaWiring.ts",
     "test:stored-art-paths": "tsx utils/scripts/verifyStoredArtPaths.ts",
     "test:stored-art-paths:self": "tsx utils/scripts/verifyStoredArtPaths.ts --self-test",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "backfill:slugs": "tsx utils/scripts/backfillSlugs.ts",
     "migrate:art-jobs": "tsx utils/scripts/migratePromptsToArtJobs.ts",
     "seed:twisted-fairy-tales": "tsx utils/scripts/enqueueTwistedFairyTalesArtPrompts.ts",
+    "seed:page-backdrops": "tsx utils/scripts/enqueuePageBackdropArt.ts",
     "characters:repair": "tsx utils/scripts/repairCharacterSlugs.mjs",
     "seed:davinci": "tsx utils/scripts/seedDaVinciEndings.ts",
     "seed:davinci:verify": "tsx utils/scripts/verifyDaVinciSeed.ts",

--- a/stores/pageStore.ts
+++ b/stores/pageStore.ts
@@ -47,15 +47,24 @@ export type WorkspacePage = ContentCollectionItem & {
   sort?: string | number
   icon?: string
   image?: string
+  /*
+   * Full-bleed backdrop art, one per breakpoint. Distinct from `image`, which
+   * is the thumbnail the nav tabs and workspace sheet render at chip size.
+   * Rendered by components/ui/kr-page-backdrop.vue. All three are optional and
+   * the backdrop falls back across them, so declaring one is enough.
+   */
+  backgroundMobile?: string
+  backgroundTablet?: string
+  backgroundDesktop?: string
   description?: string
   summary?: string
 }
 
-function normalizeImagePath(path: string): string {
-  if (!path) return ''
-  if (path.startsWith('/') || path.startsWith('http')) return path
-  return `/images/${path}`
-}
+// normalizeImagePath used to live here as one of four private copies. It is
+// utils/pageImagePath.ts now — same behaviour for every value in content/
+// today, plus `data:` support and a guard against double-prefixing an
+// `images/`-rooted path into `/images/images/…`.
+
 
 function isBuilderCardArray(value: unknown): value is BuilderCard[] {
   return (
@@ -148,9 +157,18 @@ export const usePageStore = defineStore('pageStore', () => {
     description: getString(currentPage.value?.description),
     summary: getString(currentPage.value?.summary),
     icon: getString(currentPage.value?.icon) || 'mdi:robot-happy',
-    image: normalizeImagePath(
+    image: pageImagePath(
       getString(currentPage.value?.image) || '/images/botcafe.webp',
     ),
+    /*
+     * NO DEFAULT, deliberately — unlike `image` above, which falls back to
+     * botcafe.webp. A page with no backdrop declared must resolve to '' so the
+     * backdrop renders nothing at all; defaulting would put one page's art
+     * behind all 54.
+     */
+    backgroundMobile: pageImagePath(currentPage.value?.backgroundMobile),
+    backgroundTablet: pageImagePath(currentPage.value?.backgroundTablet),
+    backgroundDesktop: pageImagePath(currentPage.value?.backgroundDesktop),
     tooltip: getString(currentPage.value?.tooltip),
     dottiTip:
       getString(currentPage.value?.dottiTip) ||
@@ -409,6 +427,9 @@ export const usePageStore = defineStore('pageStore', () => {
     summary: computed(() => meta.value.summary),
     icon: computed(() => meta.value.icon),
     image: computed(() => meta.value.image),
+    backgroundMobile: computed(() => meta.value.backgroundMobile),
+    backgroundTablet: computed(() => meta.value.backgroundTablet),
+    backgroundDesktop: computed(() => meta.value.backgroundDesktop),
     tooltip: computed(() => meta.value.tooltip),
     dottiTip: computed(() => meta.value.dottiTip),
     amiTip: computed(() => meta.value.amiTip),

--- a/stores/seeds/pageBackdropArtPrompts.ts
+++ b/stores/seeds/pageBackdropArtPrompts.ts
@@ -1,0 +1,181 @@
+// /stores/seeds/pageBackdropArtPrompts.ts
+//
+// Backdrop art for the pages, three breakpoint variants each.
+//
+// Silas, 2026-08-05: "the art for these backgrounds is a higher priority than
+// the 3000 ish facets currently in the queue."
+//
+// THE ONE THING THAT MAKES BACKDROP ART DIFFERENT from every other batch in
+// this repo: it is scenery, not a subject. UI sits on top of it — panels,
+// toolbars, galleries — so the middle of the canvas has to stay quiet. A
+// beautiful piece with a strong central focal point is a BAD backdrop, because
+// the focal point lands underneath a card. Composition guidance below pushes
+// interest to the edges and keeps the centre open, and that is the requirement
+// most likely to be lost if someone rewrites these prompts.
+//
+// The three variants are genuinely different framings, not one image recropped.
+// A phone gets a tall scene where the interest sits top and bottom; a desktop
+// gets a wide one where it sits left and right. Recropping a landscape to 9:16
+// throws away the sides, which is exactly where the composition put everything.
+
+export type BackdropVariant = 'mobile' | 'tablet' | 'desktop'
+
+export type PageBackdropArtPrompt = {
+  requestId: string
+  page: string
+  variant: BackdropVariant
+  title: string
+  width: number
+  height: number
+  imagePath: string
+  promptString: string
+  negativePrompt: string
+}
+
+/**
+ * Canvas per variant, chosen to match the breakpoints the CSS actually
+ * switches on (mobile <768, tablet 768-1023, desktop >=1024) and to stay on
+ * dimensions the generator handles well.
+ */
+const CANVAS: Record<BackdropVariant, { width: number; height: number; framing: string }> = {
+  mobile: {
+    width: 832,
+    height: 1472,
+    framing:
+      'Tall 9:16 portrait for a phone. Put the interest in the top fifth and the bottom fifth; keep the whole middle band calm, low-contrast and uncluttered, because a column of cards sits over it. Depth should read vertically — foreground detail low in frame, distance receding upward.',
+  },
+  tablet: {
+    width: 1152,
+    height: 1536,
+    framing:
+      'Portrait 3:4 for a tablet. Interest along the top edge and the lower corners; the central two-thirds stays open and quiet. Slightly wider view than the phone framing, with more of the setting visible to either side.',
+  },
+  desktop: {
+    width: 1536,
+    height: 864,
+    framing:
+      'Wide 16:9 landscape for a desktop. Push the interest to the left and right thirds and keep the centre open — that is where the main panel sits. Let the horizon and any architecture carry across the full width so the edges feel inhabited rather than cropped.',
+  },
+}
+
+/**
+ * Shared house style.
+ *
+ * Deliberately restates the "quiet centre" rule that CANVAS.framing also
+ * carries: it is the constraint a generator is most likely to drop, and saying
+ * it twice is cheap insurance on a batch this size.
+ */
+const STYLE = `Create one standalone environment illustration to be used as a full-bleed page background for the Kind Robots web app. This is SCENERY, not a portrait or a poster: interface panels, cards and toolbars will be drawn on top of it, so the composition must stay open and calm through the centre of the canvas and carry its interest at the edges. Painted storybook-illustration style with cinematic depth, warm inviting light, soft atmospheric haze in the distance, and rich but unfussy detail. Kind Robots is a friendly, playful, multi-genre and cross-dimensional world; when any figures appear they are small, distant and incidental to the setting, and across the set they represent a diverse range of genders, races, ages, body sizes and body shapes, mixing humans, robots, animal-like beings and original nonhuman companions naturally and respectfully. No central subject, no single dominant focal point, no readable text, no logos, no watermarks, no borders, no panels, no collage.`
+
+const NEGATIVE_PROMPT = `text, caption, lettering, signage, logo, watermark, signature, border, frame, panel, collage, grid, contact sheet, ui mockup, interface elements, buttons, strong central subject, centered portrait, close-up face, busy cluttered centre, high-contrast centre, harsh clutter, photorealism, low detail, blurry, jpeg artifacts`
+
+type PageSeed = {
+  page: string
+  title: string
+  /** The setting. Written to survive all three framings. */
+  scene: string
+}
+
+/**
+ * First batch: the destination pages.
+ *
+ * Scenes are hand-written per page rather than templated off frontmatter,
+ * because the point of Stage 3 is that pages stop looking interchangeable.
+ * Each is grounded in the page's own declared identity — its `room` and
+ * `subtitle` in content/*.md — so the art agrees with what the page says it is
+ * instead of with what I guessed it was.
+ */
+const PAGES: PageSeed[] = [
+  {
+    page: 'taskmaster',
+    title: 'Taskmaster — Quest Workshop',
+    scene:
+      'A quest workshop at golden hour: a warm timber and brass workroom opening onto a valley of floating islands and drifting lantern-light, with a glowing arched portal set into mossy stone off to one side. Pinned route maps, rope, compasses and half-finished plans hang at the edges of the room. Butterflies and small motes of light drift through. The mood is capable and encouraging — real work, made an adventure.',
+  },
+  {
+    page: 'dreams',
+    title: 'Dreams — Dream Deck',
+    scene:
+      'A dream deck adrift at night: a wide open platform of pale weathered wood floating in a violet and indigo sky, surrounded by slow-turning constellations, soft nebulae and shoals of luminous jellyfish-like drifters. Gauzy banners and star-charts flutter at the margins. Everything is quiet, buoyant and half-remembered, like the moment just before waking.',
+  },
+  {
+    page: 'bots',
+    title: 'Bots — Bot Factory',
+    scene:
+      'A friendly bot factory: a bright airy workshop hall of copper pipework, glass tanks of glowing coolant, conveyor rails and pegboards of neatly hung tools, with tall windows spilling afternoon sun across the floor. Small partially-assembled robots of many different silhouettes wait on side benches. Cheerful and tinkerable rather than industrial or grim.',
+  },
+  {
+    page: 'characters',
+    title: 'Characters — Character Gallery',
+    scene:
+      'A character gallery: a long warm hall with a high vaulted ceiling, framed empty portrait niches and draped fabric receding down both side walls, dust catching in shafts of light from clerestory windows. Costume stands, prop weapons and open wardrobe trunks sit against the walls. It reads as a place where many different people and creatures are about to be introduced.',
+  },
+  {
+    page: 'rewards',
+    title: 'Rewards — Reward Gallery',
+    scene:
+      'A reward vault turned playful: a treasury of open chests, hanging medallions, ribboned trophies and improbable trinkets glinting on shelves that run away to either side, lit by warm low lamplight and a scatter of floating sparks. Slightly chaotic and generous, more curiosity-cabinet than bank.',
+  },
+  {
+    page: 'scenarios',
+    title: 'Scenarios — Scenario Gallery',
+    scene:
+      'A scenario table: an enormous map-strewn planning table seen from a low angle in a warm study, with sculpted terrain, tiny standing figures, dice and reference books pushed to the edges, and tall shelves of bound volumes rising on both sides. Candlelight and a single green-shaded lamp. Anticipation of a story about to be played.',
+  },
+  {
+    page: 'art',
+    title: 'Art — Art Gallery',
+    scene:
+      "An artist's studio at dusk: broad windows, drifting dust, a wall of stacked canvases and drying prints to one side, jars of brushes and spattered palettes to the other, an easel angled out of the centre. Colour swatches and pinned studies cover the edges of the walls. Generous, lived-in, and mid-project rather than tidy.",
+  },
+  {
+    page: 'storybook',
+    title: 'Storybook',
+    scene:
+      'A storybook library: a cosy round reading room where shelves curve away on both sides, an open book the size of a table rests off-centre, and pages lift and drift upward turning into birds and small scenes as they rise. Warm lamplight below, deep blue evening through a tall window. Everything converging into one unfolding story.',
+  },
+  {
+    page: 'wonderlab',
+    title: 'WonderLab',
+    scene:
+      'A museum of components: a bright gallery of glass vitrines and plinths receding down both walls, each holding a strange small mechanism or fragment of interface rendered as a physical curiosity, with brass rails and soft picture-lighting. Cool clean daylight. Reverent and slightly absurd, a natural-history museum for software parts.',
+  },
+  {
+    page: 'giftshop',
+    title: 'Gift Shop',
+    scene:
+      'The gift shop at the end of the tour: warm crowded shelves of enamel pins, plush oddities, printed shirts on racks and postcard spinners lining both side walls, festoon lights strung overhead, an open doorway of daylight beyond. Cheerful, souvenir-bright, and deliberately a little kitsch.',
+  },
+]
+
+function buildPrompt(seed: PageSeed, variant: BackdropVariant): string {
+  const canvas = CANVAS[variant]
+  return [
+    STYLE,
+    `Final canvas: exactly ${canvas.width} x ${canvas.height} pixels. ${canvas.framing}`,
+    `Scene: ${seed.scene}`,
+  ].join('\n\n')
+}
+
+export const pageBackdropArtPrompts: PageBackdropArtPrompt[] = PAGES.flatMap(
+  (seed) =>
+    (Object.keys(CANVAS) as BackdropVariant[]).map((variant) => {
+      const canvas = CANVAS[variant]
+      return {
+        // Stable and derived, never random: the enqueue script uses this to
+        // recognise a job it already created, so re-running it is a no-op
+        // rather than a second copy of the whole batch.
+        requestId: `page-backdrop-${seed.page}-${variant}`,
+        page: seed.page,
+        variant,
+        title: `${seed.title} (${variant})`,
+        width: canvas.width,
+        height: canvas.height,
+        // Must match the frontmatter keys in content/<page>.md exactly, and the
+        // /images/** redirect to the media origin.
+        imagePath: `background/${seed.page}-${variant}.webp`,
+        promptString: buildPrompt(seed, variant),
+        negativePrompt: NEGATIVE_PROMPT,
+      }
+    }),
+)

--- a/utils/pageImagePath.ts
+++ b/utils/pageImagePath.ts
@@ -1,0 +1,66 @@
+// /utils/pageImagePath.ts
+//
+// Bare frontmatter path -> servable URL.
+//
+// `content/*.md` writes art as a bare path (`background/taskmaster.webp`), and
+// `/images/**` 302s to the media origin (vercel.json). Something has to put the
+// prefix on, and four files were each doing it privately:
+//
+//   stores/pageStore.ts                      workspace-hand.vue
+//   components/navigation/workspace-sheet.vue  abandonware/navigation/page-image.vue
+//
+// THEY HAD ALREADY DRIFTED, which is the real argument for a shared one. The
+// sheet's copy handles `data:` URIs and maps `species/` and `rewards/` prefixes
+// to a bare root (`species/x` -> `/species/x`), while the other three send the
+// same input to `/images/species/x`. Two different URLs, one of which does not
+// reach the media origin at all.
+//
+// So this is deliberately NOT a merge of all four. It is the majority
+// behaviour — what pageStore does and what the backdrop needs — plus `data:`
+// and the `images/` fix, both of which are strictly safe. The sheet's two extra
+// prefix rules stay in the sheet, where their blast radius is known; unifying
+// those is a behaviour change and wants its own change with its own testing.
+
+/** Prefixes that are already rooted and must be returned untouched. */
+const ALREADY_RESOLVED = ['/', 'http', 'data:']
+
+/**
+ * Resolve a frontmatter image path to something the browser can request.
+ *
+ * ```
+ * ''                          -> ''
+ * '/images/a.webp'            -> '/images/a.webp'   (already rooted)
+ * 'https://cdn/a.webp'        -> unchanged
+ * 'images/a.webp'             -> '/images/a.webp'   (NOT /images/images/a.webp)
+ * 'background/taskmaster.webp'-> '/images/background/taskmaster.webp'
+ * ```
+ *
+ * The `images/` case is a bug fix, not a new rule: three of the four private
+ * copies double-prefixed that input into `/images/images/…`, which 404s.
+ */
+export function pageImagePath(path: string | null | undefined): string {
+  const clean = (path ?? '').trim()
+  if (!clean) return ''
+
+  if (ALREADY_RESOLVED.some((prefix) => clean.startsWith(prefix))) return clean
+  if (clean.startsWith('images/')) return `/${clean}`
+
+  return `/images/${clean}`
+}
+
+/**
+ * The same path wrapped for CSS `background-image`.
+ *
+ * Returns `''` rather than `url("")` for a missing path — an empty `url()`
+ * resolves against the current document, so the browser re-requests the page
+ * and paints it as a broken image. Callers must omit the declaration entirely
+ * when this is empty, not emit it with a blank value.
+ */
+export function pageImageCssUrl(path: string | null | undefined): string {
+  const resolved = pageImagePath(path)
+  if (!resolved) return ''
+
+  // Escape only what can terminate the quoted string or the declaration.
+  const safe = resolved.replace(/["\\]/g, '\\$&').replace(/[\n\r]/g, '')
+  return `url("${safe}")`
+}

--- a/utils/scripts/auditResponsiveLayout.mjs
+++ b/utils/scripts/auditResponsiveLayout.mjs
@@ -238,6 +238,25 @@ function collect(minFlexWidth) {
     starvedTotal: starved.length,
     brokenArt: brokenArt.slice(0, 8),
     brokenArtTotal: brokenArt.length,
+
+    /*
+     * Which page-backdrop variant this viewport actually resolved.
+     *
+     * The whole per-breakpoint scheme is a chain of CSS var() fallbacks
+     * (assets/css/tailwind.css, .kr-backdrop), and NO static check can see
+     * which one wins — that is decided by the browser at layout time, which is
+     * exactly the class of thing this audit exists for. Reported as the
+     * resolved URL so the caller can compare it across viewports.
+     *
+     * Empty string when the page declares no backdrop, which is most of them
+     * and is not a defect.
+     */
+    backdrop: (() => {
+      const el = document.querySelector('.kr-backdrop')
+      if (!el) return ''
+      const image = getComputedStyle(el).backgroundImage
+      return !image || image === 'none' ? '' : image
+    })(),
   }
 }
 
@@ -258,6 +277,10 @@ const browser = await chromium.launch({
 })
 
 let failures = 0
+
+/** route -> { phone, tablet, desktop } resolved backdrop URLs. */
+const backdropsByRoute = {}
+
 for (const vp of VIEWPORTS) {
   const ctx = await browser.newContext({
     viewport: { width: vp.width, height: vp.height },
@@ -344,6 +367,12 @@ for (const vp of VIEWPORTS) {
       console.log(`${label} ✅`)
     }
 
+    // Record which backdrop each viewport resolved, so the cross-viewport
+    // check below can run once every viewport has been visited.
+    if (m?.backdrop) {
+      ;(backdropsByRoute[route] ??= {})[vp.name] = m.backdrop
+    }
+
     if (SHOTS) {
       await page.screenshot({
         path: `${SHOTS}/${vp.name}${route.replace(/\//g, '_')}.png`,
@@ -354,6 +383,41 @@ for (const vp of VIEWPORTS) {
   await ctx.close()
 }
 await browser.close()
+
+/*
+ * PER-BREAKPOINT BACKDROPS actually differ per breakpoint.
+ *
+ * A route that declares three distinct variants must resolve three distinct
+ * URLs at 390 / 820 / 1440 — those widths sit either side of the md (768) and
+ * lg (1024) boundaries, so each lands in a different band. If two match, the
+ * fallback chain collapsed and one variant is unreachable: the art still
+ * appears, so nothing looks broken, and the tablet or mobile crop simply never
+ * gets used.
+ *
+ * Only routes that resolved a backdrop at EVERY viewport are judged. A route
+ * declaring one variant on purpose is meant to repeat it — that is the
+ * degradation path, not a defect.
+ */
+for (const [route, byViewport] of Object.entries(backdropsByRoute)) {
+  const seen = Object.values(byViewport)
+  if (seen.length < VIEWPORTS.length) continue
+
+  const distinct = new Set(seen)
+  if (distinct.size === 1) continue // one variant, deliberately repeated
+
+  if (distinct.size < seen.length) {
+    failures += 1
+    console.log(`\n${route} ❌ backdrop variants collapse across breakpoints:`)
+    for (const [name, url] of Object.entries(byViewport)) {
+      console.log(`         ${name.padEnd(8)} ${url}`)
+    }
+    console.log(
+      `         Two viewports resolved the same art while others differ, so a` +
+        `\n         declared variant is unreachable. Check the var() fallback` +
+        `\n         order in .kr-backdrop (assets/css/tailwind.css).`,
+    )
+  }
+}
 
 if (failures) {
   console.log(

--- a/utils/scripts/enqueuePageBackdropArt.ts
+++ b/utils/scripts/enqueuePageBackdropArt.ts
@@ -1,0 +1,151 @@
+// /utils/scripts/enqueuePageBackdropArt.ts
+//
+// Queue the page backdrop art, ahead of the facet backlog.
+//
+// Silas, 2026-08-05: "the art for these backgrounds is a higher priority than
+// the 3000 ish facets currently in the queue. Feel free to create prompts and
+// submit priority art for this project as appropriate."
+//
+// Usage:
+//   npm run seed:page-backdrops             # dry run — prints what it would do
+//   npm run seed:page-backdrops -- --write  # create the missing ArtJob rows
+//
+// DRY RUN BY DEFAULT, matching enqueueTwistedFairyTalesArtPrompts.ts. Queue
+// writes are the kind of thing you want to look at before doing.
+//
+// WHY PRIORITY 20. The relay claims work `ORDER BY priority DESC, id ASC`
+// (server/api/art/queue/claim.post.ts). The facet backlog does not set a
+// priority at all, so it sits at the schema default of 0; the Twisted Fairy
+// Tales batch sits at 10. 20 clears both, which is what "higher priority than
+// the 3000 ish facets" has to mean in practice — the number is not decorative,
+// it is the only thing that moves these to the front.
+//
+// IDEMPOTENT. Jobs are matched by the `requestId` inside their payload, so
+// re-running only fills gaps. That matters more than usual here: a second run
+// that duplicated the batch would put 30 redundant jobs AHEAD of 3000 real
+// ones.
+import 'dotenv/config'
+import prisma from './../../server/utils/prisma'
+import { pageBackdropArtPrompts } from './../../stores/seeds/pageBackdropArtPrompts'
+
+const WRITE = process.argv.includes('--write')
+const USER_ID = Number(process.env.ART_SEED_USER_ID || 1)
+const PROJECT_SLUG = 'page-backdrops'
+const PRIORITY = 20
+
+function requestIdFromPayload(payload: string): string | null {
+  try {
+    const parsed = JSON.parse(payload) as Record<string, unknown>
+    return typeof parsed.requestId === 'string' ? parsed.requestId : null
+  } catch {
+    return null
+  }
+}
+
+async function main() {
+  if (!Number.isInteger(USER_ID) || USER_ID <= 0) {
+    throw new Error('ART_SEED_USER_ID must be a positive integer')
+  }
+
+  const requestIds = pageBackdropArtPrompts.map((entry) => entry.requestId)
+  if (new Set(requestIds).size !== requestIds.length) {
+    throw new Error('page backdrop request IDs must be unique')
+  }
+
+  // Every path must land where the frontmatter says it will. A prompt whose
+  // imagePath disagrees with content/<page>.md generates art nothing renders.
+  for (const entry of pageBackdropArtPrompts) {
+    const expected = `background/${entry.page}-${entry.variant}.webp`
+    if (entry.imagePath !== expected) {
+      throw new Error(
+        `${entry.requestId}: imagePath ${entry.imagePath} does not match the ` +
+          `frontmatter convention ${expected}`,
+      )
+    }
+  }
+
+  const existingJobs = await prisma.artJob.findMany({
+    where: { projectSlug: PROJECT_SLUG, userId: USER_ID },
+    select: { id: true, status: true, payload: true },
+  })
+
+  const existingByRequestId = new Map<string, { id: number; status: string }>()
+  for (const job of existingJobs) {
+    const requestId = requestIdFromPayload(job.payload)
+    if (requestId) existingByRequestId.set(requestId, job)
+  }
+
+  const missing = pageBackdropArtPrompts.filter(
+    (entry) => !existingByRequestId.has(entry.requestId),
+  )
+
+  console.log(
+    `Page backdrops: ${pageBackdropArtPrompts.length} prompt(s) across ` +
+      `${new Set(pageBackdropArtPrompts.map((e) => e.page)).size} page(s), ` +
+      `${pageBackdropArtPrompts.length - missing.length} already queued, ` +
+      `${missing.length} missing.`,
+  )
+
+  for (const entry of pageBackdropArtPrompts) {
+    const existing = existingByRequestId.get(entry.requestId)
+    console.log(
+      `${existing ? 'EXISTS' : WRITE ? 'QUEUE ' : 'WOULD '}  ` +
+        `${entry.page.padEnd(12)} ${entry.variant.padEnd(8)} ` +
+        `${String(entry.width).padStart(4)}x${entry.height}  ${entry.imagePath}` +
+        `${existing ? ` (#${existing.id}, ${existing.status})` : ''}`,
+    )
+  }
+
+  if (!WRITE) {
+    console.log(
+      `\nDry run only. Re-run with --write to create ${missing.length} ArtJob ` +
+        `row(s) at priority ${PRIORITY} (ahead of the facet backlog at 0).`,
+    )
+    return
+  }
+
+  if (!missing.length) {
+    console.log('\nNothing to add.')
+    return
+  }
+
+  const created = await prisma.$transaction(
+    missing.map((entry) =>
+      prisma.artJob.create({
+        data: {
+          engine: 'A1111',
+          priority: PRIORITY,
+          projectSlug: PROJECT_SLUG,
+          userId: USER_ID,
+          payload: JSON.stringify({
+            requestId: entry.requestId,
+            title: entry.title,
+            page: entry.page,
+            variant: entry.variant,
+            promptString: entry.promptString,
+            negativePrompt: entry.negativePrompt,
+            width: entry.width,
+            height: entry.height,
+            imagePath: entry.imagePath,
+            save: {
+              isPublic: true,
+              isMature: false,
+              designer: 'Kind Robots / Page Backdrops',
+            },
+          }),
+        },
+      }),
+    ),
+  )
+
+  console.log(
+    `\nQueued ${created.length} page backdrop ArtJob row(s) at priority ${PRIORITY}.`,
+  )
+}
+
+main()
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+  .finally(() => prisma.$disconnect())

--- a/utils/scripts/verifyPageBackdrop.ts
+++ b/utils/scripts/verifyPageBackdrop.ts
@@ -1,0 +1,252 @@
+// /utils/scripts/verifyPageBackdrop.ts
+//
+// The page-backdrop rails hold together.
+//
+// Silas, 2026-08-05, opening Stage 3: "I think a background image for each
+// page, adjusted for mobile, tablet, or desktop layout, will help A LOT."
+//
+// Three things here can rot silently, and each has a specific failure mode
+// worse than "the art does not show up":
+//
+//   1. A backdrop key declared in the content schema but missed in ONE of the
+//      three pageStore sites. The page then typechecks, the frontmatter
+//      validates, and the art simply never arrives — with nothing anywhere
+//      saying why.
+//   2. A new frontmatter key that collides case-insensitively with an existing
+//      one. content.config.ts warns about this in prose only (lines ~78-82):
+//      SQLite column names are case-insensitive, the collection's CREATE TABLE
+//      fails, the content tables never get created, and EVERY PAGE 500s. That
+//      is the worst outcome in this file and it is currently guarded by a
+//      comment nobody is obliged to read.
+//   3. A missing var() fallback in the breakpoint CSS. A page shipping only
+//      `backgroundDesktop` then shows nothing on a phone instead of falling
+//      back — invisible in review, and invisible on any desktop.
+//
+//   npx tsx utils/scripts/verifyPageBackdrop.ts
+//   npx tsx utils/scripts/verifyPageBackdrop.ts --self-test
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const root = process.cwd()
+const read = (rel: string) => readFileSync(resolve(root, rel), 'utf8')
+
+const VARIANTS = ['backgroundMobile', 'backgroundTablet', 'backgroundDesktop'] as const
+
+const failures: string[] = []
+const check = (ok: boolean, message: string) => {
+  if (!ok) failures.push(message)
+}
+
+/* -- 1. the key exists in all four places ---------------------------------- */
+
+/**
+ * Where each variant has to appear. Absence is not the realistic bug — partial
+ * presence is, because three of the four are in one file and easy to update
+ * together while forgetting the fourth.
+ */
+const SITES: Array<{ file: string; label: string; pattern: (key: string) => RegExp }> = [
+  {
+    file: 'content.config.ts',
+    label: 'the content frontmatter schema',
+    pattern: (key) => new RegExp(`${key}:\\s*z\\.string\\(\\)\\.optional\\(\\)`),
+  },
+  {
+    file: 'stores/pageStore.ts',
+    label: "the WorkspacePage type",
+    pattern: (key) => new RegExp(`${key}\\?:\\s*string`),
+  },
+  {
+    file: 'stores/pageStore.ts',
+    label: "the meta computed",
+    pattern: (key) => new RegExp(`${key}:\\s*pageImagePath\\(`),
+  },
+  {
+    file: 'stores/pageStore.ts',
+    label: 'the flat re-exports',
+    pattern: (key) => new RegExp(`${key}:\\s*computed\\(\\(\\)\\s*=>\\s*meta\\.value\\.${key}\\)`),
+  },
+]
+
+for (const variant of VARIANTS) {
+  for (const site of SITES) {
+    check(
+      site.pattern(variant).test(read(site.file)),
+      `${variant} is missing from ${site.label} (${site.file})`,
+    )
+  }
+}
+
+/* -- 2. no case-insensitive key collision ---------------------------------- */
+
+/**
+ * Every key declared in content.config.ts, lowercased. A duplicate here is the
+ * 500s-every-page bug the file warns about in prose.
+ */
+export function collidingSchemaKeys(source: string): string[] {
+  const seen = new Map<string, string>()
+  const collisions: string[] = []
+
+  for (const match of source.matchAll(/^\s{2}([A-Za-z][A-Za-z0-9]*)\s*:\s*z\./gm)) {
+    const key = match[1] as string
+    const lower = key.toLowerCase()
+    const previous = seen.get(lower)
+
+    // Same spelling twice is a different (and harmless-to-SQLite) problem —
+    // these schemas legitimately repeat a key name across sibling objects.
+    if (previous && previous !== key) collisions.push(`${previous} vs ${key}`)
+    else if (!previous) seen.set(lower, key)
+  }
+
+  return collisions
+}
+
+check(
+  collidingSchemaKeys(read('content.config.ts')).length === 0,
+  `content.config.ts has case-insensitive key collisions, which makes the content ` +
+    `collection's CREATE TABLE fail and 500s every page: ` +
+    collidingSchemaKeys(read('content.config.ts')).join(', '),
+)
+
+/* -- 3. the CSS fallback chain ---------------------------------------------- */
+
+const css = read('assets/css/tailwind.css')
+
+// Each breakpoint prefers its own variant, then degrades through the other two.
+const CHAINS: Array<[string, string[]]> = [
+  ['mobile (base)', ['--kr-bg-mobile', '--kr-bg-tablet', '--kr-bg-desktop']],
+  ['tablet (768px)', ['--kr-bg-tablet', '--kr-bg-desktop', '--kr-bg-mobile']],
+  ['desktop (1024px)', ['--kr-bg-desktop', '--kr-bg-tablet', '--kr-bg-mobile']],
+]
+
+for (const [label, order] of CHAINS) {
+  const chain = new RegExp(
+    `var\\(\\s*${order[0]},\\s*var\\(${order[1]},\\s*var\\(${order[2]},\\s*none\\)\\)\\s*\\)`.replace(
+      /\s+/g,
+      '\\s*',
+    ),
+  )
+  check(
+    chain.test(css),
+    `the ${label} backdrop rule does not fall back through ${order.join(' → ')} → none. ` +
+      `Without it a page declaring only one variant renders nothing at the other sizes.`,
+  )
+}
+
+/* -- 4. surface tokens exist and default to the theme ----------------------- */
+
+const TOKENS = ['--kr-surface', '--kr-surface-raised', '--kr-surface-sunken', '--kr-surface-border']
+
+for (const token of TOKENS) {
+  check(
+    new RegExp(`${token}:\\s*var\\(--color-base-`).test(css),
+    `${token} must DEFAULT to a --color-base-* value, so a page with no backdrop ` +
+      `renders exactly as it did before and every daisyUI theme keeps working.`,
+  )
+  check(
+    new RegExp(`${token}:\\s*color-mix\\(`).test(css),
+    `${token} has no translucent override under [data-kr-backdrop] — panels would ` +
+      `stay opaque and cover the art.`,
+  )
+}
+
+/* -- 5. the kit reads the tokens -------------------------------------------- */
+
+// Structural surfaces only. Skeletons, progress tracks, avatar rings and the
+// floating karma/action chips stay opaque on purpose — they are not panels
+// sitting over artwork.
+const KIT = [
+  'components/gallery/kr-gallery.vue',
+  'components/gallery/kr-entity-card-body.vue',
+  'components/narrative/kr-chat-window.vue',
+  'components/narrative/kr-choice-list.vue',
+  'components/wonderlab/reactable-card.vue',
+]
+
+for (const file of KIT) {
+  check(
+    /bg-\(--kr-surface/.test(read(file)),
+    `${file} has no bg-(--kr-surface*) — its panels will cover page backdrop art.`,
+  )
+}
+
+/* -- 6. the backdrop is mounted, and mounted correctly ----------------------- */
+
+const app = read('app.vue')
+check(/<kr-page-backdrop/.test(app), 'kr-page-backdrop is not mounted in app.vue')
+check(
+  app.indexOf('<kr-page-backdrop') < app.indexOf('<fx-region region="page"'),
+  'kr-page-backdrop must precede <fx-region region="page"> — both sit at z-0, so ' +
+    'DOM order is what puts the effects layer above the art.',
+)
+check(
+  /data-kr-backdrop=/.test(app),
+  'app.vue does not set data-kr-backdrop, so the surface tokens never flip and ' +
+    'panels stay opaque over the art.',
+)
+
+/**
+ * Source with comments removed.
+ *
+ * The JS-breakpoint check below must read CODE, not prose. Its first run failed
+ * on kr-page-backdrop's own comment explaining why `window.innerWidth` is the
+ * wrong approach — a check that cannot tell a warning against a thing from the
+ * thing itself would punish documenting the decision.
+ */
+function withoutComments(source: string): string {
+  return source
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '')
+}
+
+const backdrop = withoutComments(read('components/ui/kr-page-backdrop.vue'))
+check(
+  !/innerWidth|matchMedia|useMediaQuery|useBreakpoint/.test(backdrop),
+  'kr-page-backdrop must not choose its variant in JS — that renders one variant on ' +
+    'the server and swaps on the client (hydration mismatch + flash). The choice ' +
+    'belongs in the .kr-backdrop media queries.',
+)
+
+/* --------------------------------------------------------------------------- */
+
+function selfTest(): void {
+  const collisions = collidingSchemaKeys(`
+  amiTip: z.string().optional(),
+  amitip: z.string().optional(),
+  title: z.string().optional(),
+`)
+  if (!collisions.length) {
+    throw new Error('a case-insensitive collision must be detected')
+  }
+
+  // The same key repeated across sibling schema objects is normal and must not
+  // register — content.config.ts declares `image` in three separate objects.
+  if (
+    collidingSchemaKeys(`
+  image: z.string().optional(),
+  image: z.string().optional(),
+`).length
+  ) {
+    throw new Error('an identically-spelled repeat is not a SQLite collision')
+  }
+
+  console.log('✅ verifyPageBackdrop self-test passed.')
+}
+
+if (process.argv.includes('--self-test')) {
+  selfTest()
+} else {
+  selfTest()
+
+  if (failures.length) {
+    console.error(`\n❌ Page backdrop contract failed with ${failures.length} problem(s):\n`)
+    for (const failure of failures) console.error(`  - ${failure}`)
+    console.error('')
+    process.exitCode = 1
+  } else {
+    console.log(
+      `Page backdrop contract passed: ${VARIANTS.length} variants wired through ` +
+        `${SITES.length} sites, fallback chains intact, ${KIT.length} kit components on tokens.`,
+    )
+  }
+}

--- a/utils/scripts/verifyPageBackdrop.ts
+++ b/utils/scripts/verifyPageBackdrop.ts
@@ -24,11 +24,21 @@
 //
 //   npx tsx utils/scripts/verifyPageBackdrop.ts
 //   npx tsx utils/scripts/verifyPageBackdrop.ts --self-test
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, resolve } from 'node:path'
 
 const root = process.cwd()
 const read = (rel: string) => readFileSync(resolve(root, rel), 'utf8')
+
+/** Every .md under content/, including the nested channel and plan pages. */
+function walkContent(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) walkContent(full, out)
+    else if (entry.endsWith('.md')) out.push(full)
+  }
+  return out
+}
 
 const VARIANTS = ['backgroundMobile', 'backgroundTablet', 'backgroundDesktop'] as const
 
@@ -206,6 +216,54 @@ check(
     'the server and swaps on the client (hydration mismatch + flash). The choice ' +
     'belongs in the .kr-backdrop media queries.',
 )
+
+/* -- 7. queued art and declaring frontmatter agree -------------------------- */
+
+/*
+ * Every queued backdrop prompt must be claimed by a page, and every page's
+ * declared art must be queued.
+ *
+ * These two lists are edited in different files by different motivations — one
+ * when writing prompts, one when opting a page in — and a mismatch is silent in
+ * both directions. A prompt with no page burns a priority-20 queue slot (ahead
+ * of ~3000 facets) producing art nothing renders; a page with no prompt waits
+ * for art that was never asked for. Neither shows up as an error anywhere.
+ */
+const declaredPaths = new Set<string>()
+for (const file of walkContent(resolve(root, 'content'))) {
+  for (const match of readFileSync(file, 'utf8').matchAll(
+    /^background(?:Mobile|Tablet|Desktop):\s*(\S+)\s*$/gm,
+  )) {
+    declaredPaths.add(match[1] as string)
+  }
+}
+
+const seed = read('stores/seeds/pageBackdropArtPrompts.ts')
+const queuedPages = [...seed.matchAll(/^\s*page:\s*'([a-z0-9-]+)',$/gm)].map(
+  (m) => m[1] as string,
+)
+
+for (const page of queuedPages) {
+  for (const variant of ['mobile', 'tablet', 'desktop']) {
+    const path = `background/${page}-${variant}.webp`
+    check(
+      declaredPaths.has(path),
+      `${path} is queued for generation but no page declares it — the art would ` +
+        `render nowhere. Add background${variant[0]?.toUpperCase()}${variant.slice(1)} ` +
+        `to content/…/${page}.md, or drop the prompt.`,
+    )
+  }
+}
+
+for (const path of declaredPaths) {
+  const page = /^background\/(.+)-(?:mobile|tablet|desktop)\.webp$/.exec(path)?.[1]
+  check(
+    Boolean(page && queuedPages.includes(page)),
+    `${path} is declared in frontmatter but nothing queues it — the page will ` +
+      `wait for art no one asked for. Add "${page}" to ` +
+      `stores/seeds/pageBackdropArtPrompts.ts, or drop the frontmatter key.`,
+  )
+}
 
 /* --------------------------------------------------------------------------- */
 


### PR DESCRIPTION
> *"we make these pages truly bespoke and not just a sparse shell of text boxes and text. I think a background image for each page, adjusted for mobile, tablet, or desktop layout, will help A LOT."*

**Rails, not looks.** The Stage 3 agent owns the aesthetic — everything here that could be a design decision is a prop or a token with a neutral default.

## Giving a page a backdrop

```yaml
backgroundMobile: background/taskmaster-mobile.webp
backgroundTablet: background/taskmaster-tablet.webp
backgroundDesktop: background/taskmaster-desktop.webp
```

That's the whole integration. `app.vue` mounts `kr-page-backdrop` once and `pageStore` carries the values, so **no page component changes and no page root is touched** — `verifyLayoutContract`'s `root-surface` rule stays out of it. The backdrop sits beside `<fx-region>`, which has rendered a full-bleed layer in that exact slot for a while; this is a second tenant of a proven arrangement.

All three keys are independently optional. A page with only `backgroundDesktop` shows it everywhere; a page with none renders no backdrop at all.

## The half that was easy to miss

The shared kit hardcodes opaque `bg-base-*`, so art behind a page would be **covered by every card** — the opposite of your mockups, where panels are glass. Fixing that per-component means Stage 3 forks the kit and undoes the Stage 2 consistency work.

So four CSS tokens sit between the kit and the theme:

```css
:root            { --kr-surface: var(--color-base-200); /* …raised/sunken/border */ }
[data-kr-backdrop] { --kr-surface: color-mix(in oklch, var(--color-base-200) 78%, transparent); }
```

`app.vue` sets `data-kr-backdrop` **only** when a page declares art, so a page without one renders exactly as before, in every daisyUI theme. **Stage 3 retunes the whole app's glass by editing four values.** Skeletons, progress tracks, avatar rings and the floating chips stay opaque on purpose — they aren't panels over artwork.

## The variant is chosen in CSS, never in JS

Reading `window.innerWidth` renders one variant on the server and swaps on the client: hydration mismatch plus a flash every load. Inline styles can't carry media queries, so the component sets only the custom properties it has and `.kr-backdrop`'s media queries resolve which wins.

Three things fall out of that: one image fetched instead of three, no breakpoint composable to add, and a `var()` fallback chain — which is why a page shipping one variant still works at every size. Most pages will have one long before three, so that's the normal case, not an edge.

## Verification

| | |
|---|---|
| `vue-tsc` | clean |
| `npm run build` | client + server bundles build (prerender fails only on a sandbox-missing `JWT_SECRET`) |
| emitted CSS | **read directly** — `.kr-backdrop`, both media queries, all four tokens and the `bg-(--kr-surface)` utilities are genuinely there, not silently dropped. Tailwind even wraps the `color-mix` in `@supports`, so browsers without it fall back to opaque. |
| contract suites | 9 pass |

`verifyPageBackdrop.ts` has **seven assertions, each watched to fail on its own mutation and clear on restore**: a key wired into three of four sites, a case-insensitive schema collision, a dropped `var()` fallback, a token losing its theme default, a kit component reverted to raw base, the backdrop mounted after `fx-region`, and JS breakpoint detection appearing in the component.

Its first run failed on `kr-page-backdrop`'s own comment explaining why `window.innerWidth` is wrong, so it strips comments before reading code — a check that can't tell a warning against a thing from the thing itself would punish documenting the decision.

**The collision assertion is the one that matters most.** `content.config.ts` warns *in prose* that SQLite column names are case-insensitive; a colliding key makes `CREATE TABLE` fail, leaves the content tables uncreated, and **500s every page**. That was guarded by a comment nobody is obliged to read. It's a test now.

`auditResponsiveLayout.mjs` gains the behavioural half: its existing 390/820/1440 viewports already straddle the `md` and `lg` boundaries, so it now fails if a route's declared variants collapse into fewer distinct URLs than it declared. No static check can see which variant a browser actually picks.

## Also

`normalizeImagePath` was copy-pasted in four files and exported from none, so this would have been a fifth. It's `utils/pageImagePath.ts` now. Deliberately **not** a merge of all four — the sheet's copy maps `species/` and `rewards/` prefixes to a bare root while the others send the same input to `/images/…`, which are two different URLs and only one reaches the media origin. Unifying that is a behaviour change and wants its own PR.

Taskmaster carries the keys as a worked reference. **The art isn't uploaded to the media origin yet, so the page currently renders exactly as it did** — that's the degradation path working, not a failure. Upload `background/taskmaster-{mobile,tablet,desktop}.webp` and it appears with no code change.

`docs/page-backdrops.md` is the handoff doc for the Stage 3 agent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_