### PR TITLE
Retry channel menu production deployment

### DIFF
--- a/utils/channelTabGroups.ts
+++ b/utils/channelTabGroups.ts
@@ -20,6 +20,8 @@ export function isAdminOnlyTab(
 export function channelTabGroups(
   channel: ResolvedChannel,
 ): ChannelTabGroup[] {
+  // The Admin channel is already an access boundary; only mixed channels need
+  // a second visual group for their admin-only destinations.
   if (channel.channelKey === 'admin') {
     return [
       {


### PR DESCRIPTION
### Task
Retry the production rollout of #1484 after Vercel's first production build was blocked by transient database connection saturation. (kind: software)

### What changed
- documented why the dedicated Admin channel bypasses mixed-channel route grouping
- no runtime behavior changes

### Why this PR exists
The #1484 preview was READY and all 13 GitHub workflows passed, but its first production deployment `dpl_uK1G63hmzj5LTDBaDWeNqJ2W9i6x` exhausted six migration connection retries because database user `kindrobot` was already at its 200-connection ceiling. This follow-up provided a clean Git-triggered deployment retry without altering the feature.

### Verification completed
- all 12 workflows triggered by this comment-only diff completed and passed
- TypeScript Type Check, Contract Tests, and Layout Contract passed
- Vercel preview `dpl_46RdyfKw4JjjsZY4VdrSVSUZmh4x` reached READY for commit `55d5da6425325adf3406fec4b7fdf46eccc87c7a`
- Vercel preview status check succeeded

### Production outcome
- merged as `895d622310c46a0bf01c4f67f551c1595a88a922`
- production deployment `dpl_DPC5DwwwahrHSDiZX4vDpax3p6bS` failed during `prisma migrate deploy`
- exact blocker: Prisma `P1001`, unable to reach database server at `acrocatranch.com:5544`
- the live production alias remains healthy on the prior build `ef44c5a42a10136d66e54a89ac501590e11738dd`, so the channel-menu feature is merged to `main` but not yet live

### Stakes
reversible; comment-only source change, no schema or data changes