### PR TITLE
fix(db): enforce Vercel pool safety ceiling

### DIFF
--- a/server/utils/databaseAdapterConfig.ts
+++ b/server/utils/databaseAdapterConfig.ts
@@ -21,6 +21,10 @@ import {
   DEFAULT_IDLE_TIMEOUT_SECONDS,
   DEFAULT_MINIMUM_IDLE,
   DEFAULT_PING_TIMEOUT_MS,
+  VERCEL_CONNECTION_LIMIT,
+  VERCEL_IDLE_TIMEOUT_SECONDS,
+  VERCEL_MINIMUM_IDLE,
+  isVercelFunctionRuntime,
 } from './databasePoolDefaults'
 
 export type PrismaMariaDbConfig = ConstructorParameters<typeof PrismaMariaDb>[0]
@@ -67,62 +71,75 @@ export function readDatabaseUseTextProtocol(): boolean {
 
 export function buildDatabaseUrl(url: string): string {
   const parsed = new URL(url)
+  const isVercelRuntime = isVercelFunctionRuntime()
   const connectTimeout = readPositiveInteger(
-    process.env.DATABASE_CONNECT_TIMEOUT_MS,
+    parsed.searchParams.get('connectTimeout') ??
+      process.env.DATABASE_CONNECT_TIMEOUT_MS,
     DEFAULT_CONNECT_TIMEOUT_MS,
   )
   const acquireTimeout = readPositiveInteger(
-    process.env.DATABASE_ACQUIRE_TIMEOUT_MS,
+    parsed.searchParams.get('acquireTimeout') ??
+      process.env.DATABASE_ACQUIRE_TIMEOUT_MS,
     DEFAULT_ACQUIRE_TIMEOUT_MS,
   )
-  const connectionLimit = readPositiveInteger(
-    process.env.DATABASE_CONNECTION_LIMIT,
+  const requestedConnectionLimit = readPositiveInteger(
+    parsed.searchParams.get('connectionLimit') ??
+      process.env.DATABASE_CONNECTION_LIMIT,
     DEFAULT_CONNECTION_LIMIT,
   )
   const minDelayValidation = readNonNegativeInteger(
-    process.env.DATABASE_MIN_DELAY_VALIDATION_MS,
+    parsed.searchParams.get('minDelayValidation') ??
+      process.env.DATABASE_MIN_DELAY_VALIDATION_MS,
     0,
   )
-  const idleTimeout = readPositiveInteger(
-    process.env.DATABASE_IDLE_TIMEOUT_SECONDS,
+  const requestedIdleTimeout = readPositiveInteger(
+    parsed.searchParams.get('idleTimeout') ??
+      process.env.DATABASE_IDLE_TIMEOUT_SECONDS,
     DEFAULT_IDLE_TIMEOUT_SECONDS,
   )
-  const minimumIdle = readNonNegativeInteger(
-    process.env.DATABASE_MINIMUM_IDLE,
+  const requestedMinimumIdle = readNonNegativeInteger(
+    parsed.searchParams.get('minimumIdle') ??
+      process.env.DATABASE_MINIMUM_IDLE,
     DEFAULT_MINIMUM_IDLE,
   )
   const pingTimeout = readPositiveInteger(
-    process.env.DATABASE_PING_TIMEOUT_MS,
+    parsed.searchParams.get('pingTimeout') ??
+      process.env.DATABASE_PING_TIMEOUT_MS,
     DEFAULT_PING_TIMEOUT_MS,
   )
+  const connectionLimit = isVercelRuntime
+    ? Math.min(requestedConnectionLimit, VERCEL_CONNECTION_LIMIT)
+    : requestedConnectionLimit
+  const idleTimeout = isVercelRuntime
+    ? Math.min(requestedIdleTimeout, VERCEL_IDLE_TIMEOUT_SECONDS)
+    : requestedIdleTimeout
+  const minimumIdle = isVercelRuntime
+    ? VERCEL_MINIMUM_IDLE
+    : requestedMinimumIdle
 
-  if (!parsed.searchParams.has('connectTimeout')) {
-    parsed.searchParams.set('connectTimeout', String(connectTimeout))
+  if (
+    isVercelRuntime &&
+    (connectionLimit !== requestedConnectionLimit ||
+      idleTimeout !== requestedIdleTimeout ||
+      minimumIdle !== requestedMinimumIdle)
+  ) {
+    console.warn('[prisma] Clamped unsafe Vercel database pool override', {
+      requestedConnectionLimit,
+      requestedIdleTimeout,
+      requestedMinimumIdle,
+      connectionLimit,
+      idleTimeout,
+      minimumIdle,
+    })
   }
 
-  if (!parsed.searchParams.has('acquireTimeout')) {
-    parsed.searchParams.set('acquireTimeout', String(acquireTimeout))
-  }
-
-  if (!parsed.searchParams.has('connectionLimit')) {
-    parsed.searchParams.set('connectionLimit', String(connectionLimit))
-  }
-
-  if (!parsed.searchParams.has('minDelayValidation')) {
-    parsed.searchParams.set('minDelayValidation', String(minDelayValidation))
-  }
-
-  if (!parsed.searchParams.has('idleTimeout')) {
-    parsed.searchParams.set('idleTimeout', String(idleTimeout))
-  }
-
-  if (!parsed.searchParams.has('minimumIdle')) {
-    parsed.searchParams.set('minimumIdle', String(minimumIdle))
-  }
-
-  if (!parsed.searchParams.has('pingTimeout')) {
-    parsed.searchParams.set('pingTimeout', String(pingTimeout))
-  }
+  parsed.searchParams.set('connectTimeout', String(connectTimeout))
+  parsed.searchParams.set('acquireTimeout', String(acquireTimeout))
+  parsed.searchParams.set('connectionLimit', String(connectionLimit))
+  parsed.searchParams.set('minDelayValidation', String(minDelayValidation))
+  parsed.searchParams.set('idleTimeout', String(idleTimeout))
+  parsed.searchParams.set('minimumIdle', String(minimumIdle))
+  parsed.searchParams.set('pingTimeout', String(pingTimeout))
 
   if (!parsed.searchParams.has('pipelining')) {
     parsed.searchParams.set('pipelining', String(readDatabasePipelining()))

--- a/utils/scripts/verifyDatabasePoolDefaults.ts
+++ b/utils/scripts/verifyDatabasePoolDefaults.ts
@@ -31,14 +31,14 @@ function withEnvironment(
 
   try {
     for (const [key, value] of Object.entries(overrides)) {
-      if (value === undefined) delete process.env[key]
+      if (value === undefined) Reflect.deleteProperty(process.env, key)
       else process.env[key] = value
     }
 
     run()
   } finally {
     for (const [key, value] of Object.entries(previous)) {
-      if (value === undefined) delete process.env[key]
+      if (value === undefined) Reflect.deleteProperty(process.env, key)
       else process.env[key] = value
     }
   }

--- a/utils/scripts/verifyDatabasePoolDefaults.ts
+++ b/utils/scripts/verifyDatabasePoolDefaults.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
+import { buildDatabaseUrl } from './../../server/utils/databaseAdapterConfig'
 import {
   LONG_LIVED_ACQUIRE_TIMEOUT_MS,
   LONG_LIVED_CONNECTION_LIMIT,
@@ -19,6 +20,29 @@ import {
   VERCEL_PING_TIMEOUT_MS,
   resolveDatabasePoolDefaults,
 } from './../../server/utils/databasePoolDefaults'
+
+function withEnvironment(
+  overrides: Record<string, string | undefined>,
+  run: () => void,
+): void {
+  const previous = Object.fromEntries(
+    Object.keys(overrides).map((key) => [key, process.env[key]]),
+  )
+
+  try {
+    for (const [key, value] of Object.entries(overrides)) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+
+    run()
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+  }
+}
 
 const longLivedDefaults = resolveDatabasePoolDefaults({})
 const vercelDefaults = resolveDatabasePoolDefaults({ VERCEL: '1' })
@@ -71,6 +95,60 @@ assert.equal(
 assert.ok(
   vercelDefaults.idleTimeoutSeconds <= 30,
   'Idle Vercel frontend sessions must retire promptly.',
+)
+
+withEnvironment(
+  {
+    VERCEL: '1',
+    DATABASE_CONNECTION_LIMIT: '10',
+    DATABASE_IDLE_TIMEOUT_SECONDS: '300',
+    DATABASE_MINIMUM_IDLE: '1',
+  },
+  () => {
+    const resolved = new URL(
+      buildDatabaseUrl(
+        'mysql://kindrobot:secret@database.example:5544/kindblank' +
+          '?connectionLimit=12&idleTimeout=600&minimumIdle=4',
+      ),
+    )
+
+    assert.equal(
+      resolved.searchParams.get('connectionLimit'),
+      String(VERCEL_CONNECTION_LIMIT),
+      'Vercel must clamp stale URL and environment pool-size overrides.',
+    )
+    assert.equal(
+      resolved.searchParams.get('idleTimeout'),
+      String(VERCEL_IDLE_TIMEOUT_SECONDS),
+      'Vercel must retire idle ProxySQL frontends promptly despite stale overrides.',
+    )
+    assert.equal(
+      resolved.searchParams.get('minimumIdle'),
+      String(VERCEL_MINIMUM_IDLE),
+      'Vercel must never retain one frontend connection per warm function.',
+    )
+  },
+)
+
+withEnvironment(
+  {
+    VERCEL: undefined,
+    DATABASE_CONNECTION_LIMIT: '10',
+    DATABASE_IDLE_TIMEOUT_SECONDS: '300',
+    DATABASE_MINIMUM_IDLE: '1',
+  },
+  () => {
+    const resolved = new URL(
+      buildDatabaseUrl(
+        'mysql://kindrobot:secret@database.example:5544/kindblank' +
+          '?connectionLimit=12&idleTimeout=600&minimumIdle=4',
+      ),
+    )
+
+    assert.equal(resolved.searchParams.get('connectionLimit'), '12')
+    assert.equal(resolved.searchParams.get('idleTimeout'), '600')
+    assert.equal(resolved.searchParams.get('minimumIdle'), '4')
+  },
 )
 
 for (const defaults of [longLivedDefaults, vercelDefaults]) {
@@ -131,11 +209,26 @@ assert.match(poolDefaultsSource, /LONG_LIVED_CONNECTION_LIMIT = 10/)
 assert.match(poolDefaultsSource, /LONG_LIVED_MINIMUM_IDLE = 1/)
 
 // Request-time Prisma and standalone scripts consume the same active runtime
-// defaults through the adapter. Explicit DATABASE_* overrides remain supported.
+// defaults through the adapter. Long-lived overrides remain supported, while a
+// Vercel URL or environment cannot exceed the serverless safety envelope.
 assert.match(adapterSource, /process\.env\.DATABASE_CONNECTION_LIMIT/)
 assert.match(adapterSource, /process\.env\.DATABASE_IDLE_TIMEOUT_SECONDS/)
 assert.match(adapterSource, /process\.env\.DATABASE_MINIMUM_IDLE/)
 assert.match(adapterSource, /process\.env\.DATABASE_PING_TIMEOUT_MS/)
+assert.match(adapterSource, /isVercelFunctionRuntime\(\)/)
+assert.match(
+  adapterSource,
+  /Math\.min\(requestedConnectionLimit, VERCEL_CONNECTION_LIMIT\)/,
+)
+assert.match(
+  adapterSource,
+  /Math\.min\(requestedIdleTimeout, VERCEL_IDLE_TIMEOUT_SECONDS\)/,
+)
+assert.match(
+  adapterSource,
+  /isVercelRuntime\s*\?\s*VERCEL_MINIMUM_IDLE\s*:\s*requestedMinimumIdle/,
+)
+assert.match(adapterSource, /Clamped unsafe Vercel database pool override/)
 assert.match(adapterSource, /pipelining:\s*readDatabasePipelining\(\)/)
 assert.match(adapterSource, /process\.env\.DATABASE_USE_TEXT_PROTOCOL/)
 assert.match(


### PR DESCRIPTION
## Root cause

Production is not bypassing ProxySQL. The live errors prove it is reaching ProxySQL:

- ProxySQL error `9001`: `Max connect timeout reached while reaching hostgroup 10`
- Prisma pool failures report `active=0 idle=0 limit=10`
- the latest production build failed with `ER_USER_LIMIT_REACHED`: user `kindrobot` had reached its 200-connection frontend limit

PR #1412 added safe Vercel defaults (`connectionLimit=2`, `minimumIdle=0`, `idleTimeout=15`), but intentionally preserved explicit `DATABASE_*` and `DATABASE_URL` query overrides. Production still resolves to a ten-connection function pool, so a stale environment or URL override defeated the serverless profile and allowed warm Vercel processes to refill all 200 ProxySQL frontend slots.

## Changes

- hard-cap Vercel function pools at two connections even when URL or environment configuration requests more
- force Vercel `minimumIdle=0`
- cap Vercel idle retention at 15 seconds
- replace stale safety-sensitive URL query values with the resolved safe values
- preserve explicit URL and environment settings for the controlled long-lived runtime
- log numeric requested/effective values whenever an unsafe Vercel override is clamped
- add a regression test recreating the live bad configuration (`12/600/4` in the URL and `10/300/1` in environment) and requiring `2/15/0` on Vercel

## Verification

- branch is current with `main`
- diff is limited to `server/utils/databaseAdapterConfig.ts` and `utils/scripts/verifyDatabasePoolDefaults.ts`
- GitHub Actions pending
- local execution was unavailable in this connector-only session, so CI is the execution authority

## Production recovery note

This prevents new deployments from recreating the oversized pools. The 200 frontend sessions already retained by old deployment code may still require a one-time ProxySQL restart or targeted session cleanup before a production build can obtain the connection needed to deploy this fix. That production operation is intentionally not performed by this PR.