### PR TITLE
fix(deploy): let runtime recovery ship through transient seed outages

### DIFF
--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -6,6 +6,8 @@ const binExtension = process.platform === 'win32' ? '.cmd' : ''
 const prismaBinary = path.resolve(`node_modules/.bin/prisma${binExtension}`)
 const tsxBinary = path.resolve(`node_modules/.bin/tsx${binExtension}`)
 const nuxtBinary = path.resolve('node_modules/.bin/nuxt')
+const TRANSIENT_DATABASE_OUTPUT =
+  /ER_USER_LIMIT_REACHED|max_user_connections|pool timeout|failed to retrieve a connection|Max connect timeout reached|P1001|P1002|P1017|P2024|connection (?:closed|refused|reset)|connect(?:ion)? timeout/i
 
 function run(command, args, label) {
   console.log(`[vercel-build] ${label}`)
@@ -21,6 +23,30 @@ function run(command, args, label) {
   }
 }
 
+function runOptionalDatabaseMaintenance(command, args, label) {
+  console.log(`[vercel-build] ${label}`)
+
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    env: process.env,
+  })
+
+  if (result.stdout) process.stdout.write(result.stdout)
+  if (result.stderr) process.stderr.write(result.stderr)
+  if (result.error) throw result.error
+  if (result.status === 0) return
+
+  const output = `${result.stdout || ''}\n${result.stderr || ''}`
+  if (TRANSIENT_DATABASE_OUTPUT.test(output)) {
+    console.warn(
+      `[vercel-build] ${label} exhausted its bounded database retries; continuing so the application can deploy the safer runtime connection policy. Re-run this idempotent maintenance task after database capacity recovers.`,
+    )
+    return
+  }
+
+  throw new Error(`${label} exited with code ${result.status ?? 'unknown'}`)
+}
+
 const isVercelBuild = process.env.VERCEL === '1'
 const isProductionDeployment = process.env.VERCEL_ENV === 'production'
 
@@ -33,13 +59,13 @@ if (!isVercelBuild || isProductionDeployment) {
     'Applying production migrations',
   )
 
-  run(
+  runOptionalDatabaseMaintenance(
     tsxBinary,
     ['scripts/seed_achievements.ts', '--write'],
     'Reconciling canonical Achievement catalog',
   )
 
-  run(
+  runOptionalDatabaseMaintenance(
     tsxBinary,
     ['scripts/generate_achievement_art.ts', '--write'],
     'Queueing missing Achievement artwork',
@@ -49,7 +75,7 @@ if (!isVercelBuild || isProductionDeployment) {
     '[vercel-build] Skipping Facet catalog maintenance during deployment; run scripts/run_facet_catalog_maintenance.ts explicitly so a long-lived database mutation session cannot block application delivery.',
   )
 
-  run(
+  runOptionalDatabaseMaintenance(
     tsxBinary,
     ['scripts/seed_contenders.ts', '--write'],
     'Seeding Challenge Center contenders',

--- a/utils/scripts/verifyDatabasePoolDefaults.ts
+++ b/utils/scripts/verifyDatabasePoolDefaults.ts
@@ -236,11 +236,36 @@ assert.match(
   /return raw !== 'false' && raw !== '0' && raw !== 'no'/,
 )
 
-// Preview builds must not mutate the production database. Their deployed API
-// runtime may read it, but it receives the Vercel pool profile above.
+// Preview builds must not mutate the production database. Production migrations
+// remain mandatory, but idempotent maintenance may yield only after bounded
+// retries end in a recognized transient connection-capacity failure.
 assert.match(vercelBuildSource, /process\.env\.VERCEL_ENV === 'production'/)
 assert.match(vercelBuildSource, /Skipping migrations and database seeds/)
 assert.match(vercelBuildSource, /if \(!isVercelBuild \|\| isProductionDeployment\)/)
+assert.match(vercelBuildSource, /const TRANSIENT_DATABASE_OUTPUT/)
+assert.match(vercelBuildSource, /ER_USER_LIMIT_REACHED/)
+assert.match(vercelBuildSource, /pool timeout/)
+assert.match(vercelBuildSource, /runOptionalDatabaseMaintenance/)
+assert.match(
+  vercelBuildSource,
+  /run\(\s*process\.execPath,\s*\['scripts\/prisma-migrate-deploy\.mjs'\]/s,
+)
+assert.doesNotMatch(
+  vercelBuildSource,
+  /runOptionalDatabaseMaintenance\(\s*process\.execPath,\s*\['scripts\/prisma-migrate-deploy\.mjs'\]/s,
+)
+for (const maintenanceScript of [
+  'scripts/seed_achievements.ts',
+  'scripts/generate_achievement_art.ts',
+  'scripts/seed_contenders.ts',
+]) {
+  assert.match(
+    vercelBuildSource,
+    new RegExp(
+      `runOptionalDatabaseMaintenance\\([\\s\\S]*?${maintenanceScript.replaceAll('/', '\\/')}`,
+    ),
+  )
+}
 
 // The request-time singleton creates exactly one base Prisma client per process.
 assert.match(


### PR DESCRIPTION
## Incident follow-up

PR #1487 corrected the production Vercel pool from the stale `10 / 300s / 1` override to the safe `2 / 15s / 0` profile. Its production build proved the clamp was active and completed mandatory Prisma migrations, but then failed in the idempotent Achievement catalog reconciliation after three bounded attempts could not acquire one of the still-saturated ProxySQL frontend slots.

That leaves the runtime connection fix merged but not deployed.

## Change

- keep Prisma generation, production migrations, and the Nuxt build mandatory
- run the three idempotent deployment-maintenance tasks through a narrow nonblocking wrapper:
  - Achievement catalog reconciliation
  - missing Achievement art queueing
  - Challenge Center contender seeding
- continue only when the failed child output matches a recognized transient connection-capacity error such as `ER_USER_LIMIT_REACHED`, `pool timeout`, `P1001`, or connection timeout/reset
- continue emitting the complete child stdout/stderr before classifying it
- keep non-transient script, validation, and logic failures fatal
- tell operators exactly which idempotent task must be rerun after database capacity recovers
- extend the database/deployment contract to guarantee migrations never use the optional wrapper and all three maintenance commands do

## Why

Application delivery is the recovery mechanism: once the safer runtime reaches production, new Vercel processes stop recreating ten-connection pools and retain no mandatory idle frontend. An optional seed should not prevent that runtime from replacing the deployment that caused the saturation.

## Verification

GitHub Actions pending. The branch is current with `main` and changes only the Vercel build orchestrator plus its contract.