### PR TITLE
One art mechanism: fold taskmaster-backdrop onto the shared layer, seed at priority 100

### DIFF
--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -6,7 +6,7 @@
   <section
     class="kr-surface taskmaster-shell relative min-h-0 gap-0 overflow-x-hidden rounded-[2rem] border border-secondary/25 bg-base-100"
   >
-    <TaskmasterBackdrop :image="tabImage" :compact="Boolean(store.session)" />
+    <TaskmasterBackdrop :compact="Boolean(store.session)" />
 
     <div class="relative z-10 flex min-h-0 flex-1 flex-col">
       <template v-if="!store.session">

--- a/components/taskmaster/taskmaster-backdrop.vue
+++ b/components/taskmaster/taskmaster-backdrop.vue
@@ -4,13 +4,20 @@
     :class="compact ? 'taskmaster-backdrop--compact' : ''"
     aria-hidden="true"
   >
-    <img
-      v-if="image && !imageFailed"
-      :src="image"
-      alt=""
-      class="taskmaster-backdrop__image absolute inset-0 h-full w-full object-cover"
-      @error="imageFailed = true"
-    />
+    <!--
+      NO <img> HERE ANY MORE. This used to render the page's `image` thumbnail
+      stretched to fill, as a stand-in for real backdrop art. Art now comes from
+      kr-page-backdrop (mounted once in app.vue, driven by the
+      backgroundMobile/Tablet/Desktop frontmatter keys), which gives Taskmaster
+      a proper per-breakpoint image instead of an upscaled
+      thumbnail — and gives every other page the same mechanism.
+
+      What survives here is what was always the good part: the hand-built scene.
+      Because kr-page-backdrop sits at z-0 in <main> and the page renders at
+      z-10, this whole layer already paints ON TOP of that art with no slot or
+      teleport needed — the islands, portal and path become foreground over the
+      artwork, which is what the mockup shows.
+    -->
     <div class="taskmaster-backdrop__sky absolute inset-0" />
     <div class="taskmaster-backdrop__portal absolute" />
     <div class="taskmaster-backdrop__island taskmaster-backdrop__island--one absolute" />
@@ -25,25 +32,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
-
-const props = withDefaults(
+withDefaults(
   defineProps<{
-    image?: string | null
     compact?: boolean
   }>(),
   {
-    image: null,
     compact: false,
-  },
-)
-
-const imageFailed = ref(false)
-
-watch(
-  () => props.image,
-  () => {
-    imageFailed.value = false
   },
 )
 </script>
@@ -69,12 +63,6 @@ watch(
     );
 }
 
-.taskmaster-backdrop__image {
-  object-position: 66% center;
-  opacity: 0.54;
-  filter: saturate(1.16) contrast(0.96);
-  transform: scale(1.025);
-}
 
 .taskmaster-backdrop__sky {
   background:
@@ -106,6 +94,72 @@ watch(
       ellipse at center,
       transparent 30%,
       color-mix(in oklab, var(--color-base-100) 28%, transparent) 100%
+    );
+}
+
+/*
+ * COMPOSING OVER REAL BACKDROP ART.
+ *
+ * Three layers above are opaque where it matters — the root's 145deg base, the
+ * sky's 96% left edge, and the wash's fully-opaque bottom stop. That is correct
+ * when this scene IS the background, and wrong the moment kr-page-backdrop is
+ * painting a photograph underneath: the art would be completely hidden and the
+ * whole per-breakpoint mechanism would silently do nothing on this page.
+ *
+ * `[data-kr-backdrop]` is set on <main> by app.vue only when the page actually
+ * declares backdrop art, so these overrides engage exactly when there is
+ * something behind to protect — the same signal the surface tokens use, for the
+ * same reason. With no art declared, none of this applies and the scene renders
+ * precisely as it did before.
+ *
+ * Only the GROUNDS are thinned. The portal, islands, clouds and path keep their
+ * own opacities untouched: they are the foreground, and over real artwork they
+ * are the point.
+ */
+[data-kr-backdrop] .taskmaster-backdrop {
+  background:
+    radial-gradient(
+      circle at 82% 16%,
+      color-mix(in oklab, var(--color-secondary) 26%, transparent),
+      transparent 27%
+    ),
+    radial-gradient(
+      circle at 16% 8%,
+      color-mix(in oklab, var(--color-info) 18%, transparent),
+      transparent 34%
+    );
+}
+
+[data-kr-backdrop] .taskmaster-backdrop__sky {
+  background:
+    radial-gradient(
+      circle at 72% 23%,
+      transparent 0 11rem,
+      color-mix(in oklab, var(--color-secondary) 16%, transparent) 16rem,
+      transparent 25rem
+    ),
+    linear-gradient(
+      90deg,
+      color-mix(in oklab, var(--color-base-100) 62%, transparent) 0%,
+      color-mix(in oklab, var(--color-base-100) 44%, transparent) 38%,
+      color-mix(in oklab, var(--color-base-100) 14%, transparent) 72%,
+      transparent 100%
+    );
+}
+
+[data-kr-backdrop] .taskmaster-backdrop__wash {
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--color-base-100) 8%, transparent) 0%,
+      transparent 34%,
+      color-mix(in oklab, var(--color-base-100) 34%, transparent) 76%,
+      color-mix(in oklab, var(--color-base-100) 62%, transparent) 100%
+    ),
+    radial-gradient(
+      ellipse at center,
+      transparent 30%,
+      color-mix(in oklab, var(--color-base-100) 18%, transparent) 100%
     );
 }
 
@@ -211,10 +265,6 @@ watch(
   box-shadow: 0 0 0.85rem color-mix(in oklab, var(--color-warning) 60%, transparent);
 }
 
-.taskmaster-backdrop--compact .taskmaster-backdrop__image {
-  opacity: 0.34;
-  filter: saturate(1.08) contrast(0.94);
-}
 
 .taskmaster-backdrop--compact .taskmaster-backdrop__portal {
   opacity: 0.34;
@@ -233,10 +283,6 @@ watch(
 }
 
 @media (max-width: 767px) {
-  .taskmaster-backdrop__image {
-    object-position: 68% top;
-    opacity: 0.48;
-  }
 
   .taskmaster-backdrop__sky {
     background:
@@ -247,6 +293,21 @@ watch(
         color-mix(in oklab, var(--color-base-100) 82%, transparent) 66%,
         var(--color-base-100) 100%
       );
+  }
+
+  /*
+   * The phone sky above ends on a fully-opaque stop, which would bury the
+   * bottom half of the mobile artwork — the variant most likely to exist first,
+   * since a phone is where Silas actually looks at this.
+   */
+  [data-kr-backdrop] .taskmaster-backdrop__sky {
+    background: linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--color-base-100) 8%, transparent) 0%,
+      color-mix(in oklab, var(--color-base-100) 18%, transparent) 34%,
+      color-mix(in oklab, var(--color-base-100) 44%, transparent) 66%,
+      color-mix(in oklab, var(--color-base-100) 66%, transparent) 100%
+    );
   }
 
   .taskmaster-backdrop__portal {

--- a/utils/scripts/enqueuePageBackdropArt.ts
+++ b/utils/scripts/enqueuePageBackdropArt.ts
@@ -13,12 +13,20 @@
 // DRY RUN BY DEFAULT, matching enqueueTwistedFairyTalesArtPrompts.ts. Queue
 // writes are the kind of thing you want to look at before doing.
 //
-// WHY PRIORITY 20. The relay claims work `ORDER BY priority DESC, id ASC`
-// (server/api/art/queue/claim.post.ts). The facet backlog does not set a
-// priority at all, so it sits at the schema default of 0; the Twisted Fairy
-// Tales batch sits at 10. 20 clears both, which is what "higher priority than
-// the 3000 ish facets" has to mean in practice — the number is not decorative,
-// it is the only thing that moves these to the front.
+// WHY PRIORITY 100. The relay claims work `ORDER BY priority DESC, id ASC`
+// (server/api/art/queue/claim.post.ts). The facet backlog never sets a priority,
+// so it sits at the schema default of 0; the Twisted Fairy Tales batch sits at
+// 10. The number is not decorative — it is the only thing that moves these to
+// the front of "the 3000 ish facets".
+//
+// 100 specifically, rather than any other clearing value, because migration
+// 20260805071500_prioritize_taskmaster_art_jobs already established it as THE
+// rush band by raising the pending Taskmaster package to exactly 100. A
+// different number here would leave two competing conventions for "ahead of the
+// backlog", and queue order would then depend on which convention a given batch
+// happened to use. Backdrop art is the same class of work as that package —
+// Stage 3 art that is being waited on — so it belongs in the same band rather
+// than straddling it.
 //
 // IDEMPOTENT. Jobs are matched by the `requestId` inside their payload, so
 // re-running only fills gaps. That matters more than usual here: a second run
@@ -31,7 +39,7 @@ import { pageBackdropArtPrompts } from './../../stores/seeds/pageBackdropArtProm
 const WRITE = process.argv.includes('--write')
 const USER_ID = Number(process.env.ART_SEED_USER_ID || 1)
 const PROJECT_SLUG = 'page-backdrops'
-const PRIORITY = 20
+const PRIORITY = 100
 
 function requestIdFromPayload(payload: string): string | null {
   try {

--- a/utils/scripts/verifyPageBackdrop.ts
+++ b/utils/scripts/verifyPageBackdrop.ts
@@ -30,12 +30,12 @@ import { join, resolve } from 'node:path'
 const root = process.cwd()
 const read = (rel: string) => readFileSync(resolve(root, rel), 'utf8')
 
-/** Every .md under content/, including the nested channel and plan pages. */
-function walkContent(dir: string, out: string[] = []): string[] {
+/** Every file with `ext` under `dir`, recursively. */
+function walkContent(dir: string, out: string[] = [], ext = '.md'): string[] {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry)
-    if (statSync(full).isDirectory()) walkContent(full, out)
-    else if (entry.endsWith('.md')) out.push(full)
+    if (statSync(full).isDirectory()) walkContent(full, out, ext)
+    else if (entry.endsWith(ext)) out.push(full)
   }
   return out
 }
@@ -262,6 +262,39 @@ for (const path of declaredPaths) {
     `${path} is declared in frontmatter but nothing queues it — the page will ` +
       `wait for art no one asked for. Add "${page}" to ` +
       `stores/seeds/pageBackdropArtPrompts.ts, or drop the frontmatter key.`,
+  )
+}
+
+/* -- 8. one art mechanism, not several -------------------------------------- */
+
+/*
+ * A page-specific backdrop component must not load its own art.
+ *
+ * This is the failure that actually happened on 2026-08-05, and it happened
+ * without anyone making a mistake: two agents solved "pages need backgrounds" in
+ * parallel — one generically (kr-page-backdrop + frontmatter keys), one
+ * bespoke (taskmaster-backdrop rendering the page thumbnail stretched to fill).
+ * Both shipped. Taskmaster ended up with two backdrops stacked, and it was
+ * invisible only because the generic layer's art had not been uploaded yet.
+ *
+ * Silas settled it: "lets go generic, because doing it right wins every time."
+ * Bespoke scenes stay as DECORATION over the shared art layer — they just do
+ * not source their own image. This check makes the next fork fail loudly at the
+ * moment it is introduced, rather than surfacing as a doubled background weeks
+ * later when someone finally uploads a file.
+ */
+for (const file of walkContent(resolve(root, 'components'), [], '.vue')) {
+  const name = file.split('/').pop() ?? ''
+  if (!/-backdrop\.vue$/.test(name)) continue
+  if (name === 'kr-page-backdrop.vue') continue // the one that IS the mechanism
+
+  const source = withoutComments(readFileSync(file, 'utf8'))
+  check(
+    !/<img\b/.test(source) && !/background-image\s*:/.test(source),
+    `${name} loads its own art (an <img> or background-image). Page backdrops ` +
+      `come from kr-page-backdrop via the background* frontmatter keys — a ` +
+      `second art source stacks two backdrops on the same page. Keep the ` +
+      `bespoke scene as decoration and drop the image.`,
   )
 }
 


### PR DESCRIPTION
> *"I normally side with bespoke, but lets go generic, because doing it right wins every time."*

## What happened

Two agents solved "pages need backgrounds" in parallel and both shipped:

- **generic** — `kr-page-backdrop` + `background*` frontmatter keys, mounted once in `app.vue`
- **bespoke** — `taskmaster-backdrop` rendering the page thumbnail stretched to fill

So Taskmaster had **two backdrops stacked**. It was invisible only because the generic layer's art isn't uploaded yet — the moment it lands, Taskmaster shows a photograph behind a CSS scene already covering it.

Nobody made a mistake; the work was concurrent and neither side could see the other. That's precisely why it needed a check rather than a note.

## They actually compose — no slot machinery needed

`kr-page-backdrop` sits at `z-0` inside `<main>`, the page renders at `z-10`. So `taskmaster-backdrop` **already paints on top of the art from where it is.** Dropping its `<img>` is the whole change.

The hand-built scene survives intact — sky, portal, floating islands, clouds, stepping path — and becomes foreground over real artwork, which is what the mockup shows. Taskmaster gets a proper per-breakpoint image instead of an upscaled thumbnail, and every other page gets the same mechanism.

Four layers had to be thinned to let art through: the root's opaque `145deg` base, the sky's 96% left edge, the wash's fully-opaque bottom stop, and the phone sky (which also ends opaque — the variant most likely to exist first, since a phone is where this actually gets looked at).

All four are gated on `[data-kr-backdrop]`, which `app.vue` sets **only** when the page declares art — so with no art declared, the scene renders exactly as before. Only the *grounds* are thinned; the portal, islands, clouds and path keep their own opacities, because over real artwork they're the point.

## Priority 20 → 100

Migration `20260805071500_prioritize_taskmaster_art_jobs` had already established **100** as the rush band. Leaving the seed at 20 would have put backdrop art above the facets but *below* the Taskmaster package, and left two competing conventions for "ahead of the backlog" — queue order would then depend on which convention a batch happened to use. Same class of work, same band.

## The check that makes it stick

A `*-backdrop.vue` component that isn't `kr-page-backdrop` may not load its own art — no `<img>`, no `background-image`.

Mutation-tested both ways: restoring the exact `<img>` that caused this, and a fresh bespoke backdrop using `background-image` instead. Both fail loudly at the moment of introduction, rather than surfacing as a doubled background weeks later when someone uploads a file.

## Verification

`vue-tsc` clean. `page-backdrop`, `layout-contract`, `component-reachability`, `gallery-consistency`, `lint-ratchet`, `channel-content`, and both Taskmaster contracts pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_