### PR TITLE
Clean newsfeed summaries and source warnings

### DIFF
--- a/server/utils/newsfeed.ts
+++ b/server/utils/newsfeed.ts
@@ -107,6 +107,33 @@ export function sanitizeText(
   return `${collapsed.slice(0, maxLength - 1).trimEnd()}…`
 }
 
+/**
+ * Several RSS generators repeat the headline as the first sentence of the
+ * description. The card already renders the headline, so remove only an exact
+ * case-insensitive prefix at a word/punctuation boundary.
+ */
+export function stripLeadingDuplicateTitle(
+  summary: string,
+  title: string,
+): string {
+  const cleanSummary = summary.trim()
+  const cleanTitle = title.trim()
+  if (!cleanSummary || !cleanTitle) return cleanSummary
+
+  const prefix = cleanSummary.slice(0, cleanTitle.length)
+  if (prefix.toLocaleLowerCase() !== cleanTitle.toLocaleLowerCase()) {
+    return cleanSummary
+  }
+
+  const boundary = cleanSummary.charAt(cleanTitle.length)
+  if (boundary && !/[\s:|–—-]/.test(boundary)) return cleanSummary
+
+  return cleanSummary
+    .slice(cleanTitle.length)
+    .replace(/^[\s:|–—-]+/, '')
+    .trim()
+}
+
 export function parseFeedXml(xml: string): RawFeedEntry[] {
   const rssItems = xml.match(/<item\b[\s\S]*?<\/item>/gi)
   if (rssItems) {
@@ -164,10 +191,16 @@ export function normalizeEntry(
 ): NewsFeedItem | null {
   if (!raw.title || !raw.link) return null
 
+  const title = sanitizeText(raw.title, MAX_TITLE_LENGTH)
+  const fullSummary = raw.description
+    ? sanitizeText(raw.description, Number.MAX_SAFE_INTEGER)
+    : ''
+  const summary = sanitizeText(stripLeadingDuplicateTitle(fullSummary, title))
+
   return {
     id: stableId(source.id, raw),
-    title: sanitizeText(raw.title, MAX_TITLE_LENGTH),
-    summary: raw.description ? sanitizeText(raw.description) : '',
+    title,
+    summary,
     source: source.name,
     sourceId: source.id,
     url: raw.link,
@@ -276,11 +309,21 @@ function matchesTagFilters(item: NewsFeedItem, feed: FeedDefinition): boolean {
   return true
 }
 
+/**
+ * Registry entries marked unverified are retained as research notes, but they
+ * are known-dead endpoints and must not become a permanent error banner.
+ */
+export function getRunnableFeedSources(
+  feed: FeedDefinition,
+): FeedSourceDefinition[] {
+  return getFeedSources(feed).filter((source) => source.verified)
+}
+
 /** Fetches every source in a feed in parallel and merges into one sorted, deduped list. */
 export async function aggregateFeed(
   feed: FeedDefinition,
 ): Promise<AggregatedFeed> {
-  const sources = getFeedSources(feed)
+  const sources = getRunnableFeedSources(feed)
   const results = await Promise.all(
     sources.map((source) => fetchSourceItems(source)),
   )

--- a/utils/scripts/verifyNewsfeedAggregation.ts
+++ b/utils/scripts/verifyNewsfeedAggregation.ts
@@ -14,9 +14,11 @@ import type { AddressInfo } from 'node:net'
 import {
   aggregateFeed,
   fetchSourceItems,
+  getRunnableFeedSources,
   normalizeEntry,
   parseFeedXml,
   sanitizeText,
+  stripLeadingDuplicateTitle,
 } from '../../server/utils/newsfeed'
 import type {
   FeedDefinition,
@@ -39,6 +41,23 @@ assert.equal(
   sanitizeText('a'.repeat(300)),
   `${'a'.repeat(279)}…`,
   'text longer than maxLength must be truncated with an ellipsis',
+)
+
+assert.equal(
+  stripLeadingDuplicateTitle(
+    'Fast... But Wrong? Meet Cache Invalidation This is Part 7 of the series.',
+    'Fast... But Wrong? Meet Cache Invalidation',
+  ),
+  'This is Part 7 of the series.',
+  'an RSS description that opens with the card title must not render the title twice',
+)
+assert.equal(
+  stripLeadingDuplicateTitle(
+    'GitHub Actions can test this repository.',
+    'Git',
+  ),
+  'GitHub Actions can test this repository.',
+  'a title that is only a prefix of the first summary word must not be stripped',
 )
 
 // --- parseFeedXml: RSS 2.0 -------------------------------------------------
@@ -131,6 +150,22 @@ assert.equal(
 )
 assert.deepEqual(normalized?.category, ['ai', 'research'])
 
+const duplicateTitleEntry = normalizeEntry(
+  {
+    title: 'Fast... But Wrong? Meet Cache Invalidation',
+    link: 'https://example.com/cache-invalidation',
+    description:
+      '<p>Fast... But Wrong? Meet Cache Invalidation</p><p>This is Part 7 of the series.</p>',
+    categories: ['architecture'],
+  },
+  FIXTURE_SOURCE,
+)
+assert.equal(
+  duplicateTitleEntry?.summary,
+  'This is Part 7 of the series.',
+  'normalization must remove a repeated headline before applying the summary length cap',
+)
+
 assert.equal(
   normalizeEntry(
     { title: undefined, link: 'https://example.com/x', categories: [] },
@@ -155,6 +190,24 @@ const noDateEntry = normalizeEntry(
 assert.ok(
   noDateEntry && !Number.isNaN(new Date(noDateEntry.publishedAt).getTime()),
   'a missing pubDate must fall back to a valid (epoch) timestamp, never NaN',
+)
+
+// --- getRunnableFeedSources: known-dead registry entries stay out of fetches -
+
+const mixedSourceFeed: FeedDefinition = {
+  slug: 'mixed-source-fixture',
+  title: 'Mixed Source Fixture',
+  description: 'test',
+  icon: 'kind-icon:test',
+  defaultEnabled: true,
+  sourceIds: ['who-news', 'gatesfoundation-ideas'],
+  defaultSort: 'recent',
+  topicPolitical: false,
+}
+assert.deepEqual(
+  getRunnableFeedSources(mixedSourceFeed).map((source) => source.id),
+  ['who-news'],
+  'known-dead unverified endpoints must remain documented but must not create a permanent source-error banner',
 )
 
 // --- fetchSourceItems: unreachable host must resolve, never throw ----------
@@ -261,9 +314,9 @@ async function run() {
   assert.equal(neverSucceededResult.stale, undefined)
 
   console.log(
-    'newsfeed aggregation verified: RSS + Atom parsing, sanitization, category ' +
-      'extraction, malformed-input safety, unreachable-source resilience, and ' +
-      'stale-source fallback.',
+    'newsfeed aggregation verified: RSS + Atom parsing, sanitization, duplicate-' +
+      'title cleanup, runnable-source filtering, category extraction, malformed-' +
+      'input safety, unreachable-source resilience, and stale-source fallback.',
   )
 }
 


### PR DESCRIPTION
### Task
Fix the noisy newsfeed output reported from production: repeated article titles inside summaries and a permanent source-error banner caused by endpoints already marked unverified. (kind: software)

### Root cause
- RSS descriptions from DEV Community and similar generators can begin with the exact article title; the card renders title and summary separately, so the headline appeared twice.
- Three sources still referenced by feed presets are deliberately recorded as `verified: false`, but aggregation fetched them anyway, guaranteeing the recurring “3 sources couldn't be reached” warning.

### What changed
- strip an exact, case-insensitive title prefix from normalized summaries only at a safe word/punctuation boundary
- perform that cleanup before applying the 280-character summary cap
- keep unverified source records as research/history, but exclude them from runtime fetches
- preserve real transient-source errors and stale-cache behavior for verified feeds
- add regression coverage for duplicate-title cleanup, prefix-boundary safety, and verified-source filtering

### Verification completed
- all 12 GitHub workflows completed and passed
- TypeScript Type Check passed
- Contract Tests passed, including the newsfeed aggregation self-test
- Layout Contract and the remaining project contract suites passed
- Vercel preview `dpl_6M82d6aUsHDoBFpBU5N821zbgZeP` reached READY for commit `b7d221a31c92608e9c67c8defa6d557ec18de633`
- preview `/api/newsfeed` returned HTTP 200 with `sourceErrors: []`
- preview DEV Community summaries begin with article content rather than repeating the exact headline

### Production outcome
- merged to `main`
- production deployment `dpl_964ojqkTvauMXQbHnpykYp4mAozZ` reached READY
- live `https://kind-robots.vercel.app/api/newsfeed` returned HTTP 200 with `sourceErrors: []`
- live DEV Community summaries no longer repeat their headlines
- working branch was deleted after merge

### Stakes
Reversible parser/selection behavior only. No schema, migration, database, ArtJob, or production-data changes.