### PR TITLE
fix(db): restore on-demand connections in zero-idle Vercel pools

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify Prisma MariaDB connector
+        run: node scripts/ensure-prisma-mariadb-connector.mjs
+
       - name: Generate Prisma client
         run: npx prisma generate
 

--- a/scripts/ensure-prisma-mariadb-connector.mjs
+++ b/scripts/ensure-prisma-mariadb-connector.mjs
@@ -1,0 +1,105 @@
+// /scripts/ensure-prisma-mariadb-connector.mjs
+//
+// @prisma/adapter-mariadb 7.9.1 installs a private mariadb 3.4.5 copy.
+// That connector only grows a pool while idleConnections < minimumIdle, so a
+// serverless pool configured with minimumIdle=0 never opens its first socket
+// for a waiting query. It consequently times out forever at active=0 idle=0.
+//
+// The repository already installs a fixed top-level MariaDB connector. Remove
+// only the adapter's known-broken private copy before Prisma-backed scripts or
+// Nuxt bundling run, then prove Node resolves the adapter to a connector whose
+// pool can grow on demand. This is idempotent and modifies node_modules only.
+
+import { createRequire } from 'node:module'
+import { existsSync } from 'node:fs'
+import { readFile, rm } from 'node:fs/promises'
+import path from 'node:path'
+
+const require = createRequire(import.meta.url)
+const minimumFixedVersion = [3, 5, 0]
+
+function parseVersion(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version)
+  if (!match) throw new Error(`Unsupported MariaDB connector version: ${version}`)
+  return match.slice(1).map(Number)
+}
+
+function compareVersions(left, right) {
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] !== right[index]) return left[index] - right[index]
+  }
+  return 0
+}
+
+function supportsZeroIdlePools(version) {
+  return compareVersions(parseVersion(version), minimumFixedVersion) >= 0
+}
+
+async function readPackageVersion(packagePath) {
+  const packageJson = JSON.parse(await readFile(packagePath, 'utf8'))
+  if (typeof packageJson.version !== 'string') {
+    throw new Error(`Package at ${packagePath} has no string version`)
+  }
+  return packageJson.version
+}
+
+function findPackageRoot(entryPath) {
+  let directory = path.dirname(entryPath)
+
+  while (true) {
+    if (existsSync(path.join(directory, 'package.json'))) return directory
+    const parent = path.dirname(directory)
+    if (parent === directory) {
+      throw new Error(`Could not find package root for ${entryPath}`)
+    }
+    directory = parent
+  }
+}
+
+const adapterEntry = require.resolve('@prisma/adapter-mariadb')
+const adapterRoot = findPackageRoot(adapterEntry)
+const nestedConnectorRoot = path.join(adapterRoot, 'node_modules', 'mariadb')
+const nestedConnectorPackage = path.join(nestedConnectorRoot, 'package.json')
+const topLevelConnectorPackage = path.resolve('node_modules/mariadb/package.json')
+
+if (!existsSync(topLevelConnectorPackage)) {
+  throw new Error(
+    'The fixed top-level mariadb connector is missing; install dependencies before running this guard.',
+  )
+}
+
+const topLevelVersion = await readPackageVersion(topLevelConnectorPackage)
+if (!supportsZeroIdlePools(topLevelVersion)) {
+  throw new Error(
+    `Top-level mariadb ${topLevelVersion} cannot grow a minimumIdle=0 pool; require mariadb >=3.5.0.`,
+  )
+}
+
+let removedNestedVersion = null
+if (existsSync(nestedConnectorPackage)) {
+  const nestedVersion = await readPackageVersion(nestedConnectorPackage)
+
+  if (!supportsZeroIdlePools(nestedVersion)) {
+    removedNestedVersion = nestedVersion
+    await rm(nestedConnectorRoot, { recursive: true, force: true })
+  }
+}
+
+const adapterRequire = createRequire(path.join(adapterRoot, 'package.json'))
+const resolvedConnectorEntry = adapterRequire.resolve('mariadb')
+const resolvedConnectorRoot = findPackageRoot(resolvedConnectorEntry)
+const resolvedVersion = await readPackageVersion(
+  path.join(resolvedConnectorRoot, 'package.json'),
+)
+
+if (!supportsZeroIdlePools(resolvedVersion)) {
+  throw new Error(
+    `Prisma adapter still resolves mariadb ${resolvedVersion}; require >=3.5.0 for minimumIdle=0.`,
+  )
+}
+
+console.log('[database] Prisma MariaDB connector supports zero-idle pools', {
+  removedNestedVersion,
+  resolvedVersion,
+  resolvedFromTopLevel: path.resolve(resolvedConnectorRoot) === path.resolve('node_modules/mariadb'),
+})

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -6,6 +6,9 @@ const binExtension = process.platform === 'win32' ? '.cmd' : ''
 const prismaBinary = path.resolve(`node_modules/.bin/prisma${binExtension}`)
 const tsxBinary = path.resolve(`node_modules/.bin/tsx${binExtension}`)
 const nuxtBinary = path.resolve('node_modules/.bin/nuxt')
+const connectorGuard = path.resolve(
+  'scripts/ensure-prisma-mariadb-connector.mjs',
+)
 const TRANSIENT_DATABASE_OUTPUT =
   /ER_USER_LIMIT_REACHED|max_user_connections|pool timeout|failed to retrieve a connection|Max connect timeout reached|P1001|P1002|P1017|P2024|connection (?:closed|refused|reset)|connect(?:ion)? timeout/i
 
@@ -50,6 +53,11 @@ function runOptionalDatabaseMaintenance(command, args, label) {
 const isVercelBuild = process.env.VERCEL === '1'
 const isProductionDeployment = process.env.VERCEL_ENV === 'production'
 
+run(
+  process.execPath,
+  [connectorGuard],
+  'Ensuring Prisma MariaDB connector supports zero-idle pools',
+)
 run(prismaBinary, ['generate'], 'Generating Prisma client')
 
 if (!isVercelBuild || isProductionDeployment) {


### PR DESCRIPTION
## Incident root cause

Production Vercel functions were correctly clamped to `connectionLimit=2`, `minimumIdle=0`, and `idleTimeout=15`, but every Prisma query then timed out with:

```text
pool timeout: failed to retrieve a connection from pool after 10000ms
(pool connections: active=0 idle=0 limit=2)
```

The network, TLS, ProxySQL, credentials, migrations, and MariaDB capacity are healthy. The failure is inside the private MariaDB connector bundled by `@prisma/adapter-mariadb` 7.9.1:

- the adapter installs `mariadb 3.4.5`
- that pool implementation only creates connections while `idleConnections < minimumIdle`
- with `minimumIdle=0`, it never creates the first connection for a queued request
- the repository already installs top-level `mariadb 3.5.3`, whose pool creates a connection when requests are waiting

## Change

- add an idempotent build guard that removes only the adapter's known-broken private connector when it is older than 3.5.0
- verify the adapter then resolves to a connector that supports on-demand growth with `minimumIdle=0`
- run the guard before Prisma generation, migrations, maintenance tasks, and Nuxt bundling in Vercel
- run the same guard immediately after `npm ci` in TypeScript CI

## Why this shape

A package override would require regenerating the lockfile and changes Prisma's dependency graph globally. This guard is narrower: it modifies only installed `node_modules`, preserves the safe zero-idle serverless profile, is repeatable on cached Vercel installs, and fails loudly if the fixed top-level connector disappears.

## Production verification required

After merge and production deployment:

- `/api/health/database` must return HTTP 200
- runtime logs must stop reporting `active=0 idle=0 limit=2`
- ProxySQL frontend usage must remain bounded rather than returning to 200/200
- rerun the idempotent Achievement catalog and artwork maintenance that yielded during the incident
