### PR TITLE
Stop fragmenting the art-image CDN cache, and stop crushing phone tabs to 31px

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -72,6 +72,12 @@ jobs:
       - name: Page backdrop contract
         run: npm run test:page-backdrop
 
+      # The app's busiest route by 3x. Its CDN cacheability is a multiplier on
+      # database sessions, so a silent regression here shows up as a
+      # connection-capacity incident rather than as anything looking broken.
+      - name: Art image caching contract
+        run: npm run test:art-image-caching
+
       # t-099: ESLint as a ratcheted gate — never asks anyone to fix the
       # pre-existing problems, only refuses NEW ones, per rule.
       #

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -685,6 +685,48 @@ function goBack(): void {
   white-space: nowrap;
   scroll-snap-align: start;
   scroll-snap-stop: always;
+
+  /*
+   * ENFORCE the minimum width, do not merely calculate with it.
+   *
+   * tabLayoutMetrics() already knows a tab needs 96/112/128px to be readable,
+   * but it only uses that to decide HOW MANY tabs fit; the width each tab
+   * actually gets is a percentage from tabButtonBasis. Those two agree only if
+   * the strip's clientWidth was measured correctly at the moment the count was
+   * computed. When it is measured before the strip is constrained — first
+   * paint, an in-flight layout, a resize that has not settled — capacity comes
+   * out too high, every tab is declared to fit, and each is handed an equal
+   * fraction of a much narrower strip.
+   *
+   * On a 390px phone that produced FOUR TABS AT 31px WIDE (measured on the
+   * deployed app, 2026-08-05: Dashboard / Register / Navigation / Themes). At
+   * that size a tab is an icon and a truncated letter — it looks like a
+   * rendering fault rather than navigation, which is worse than hiding it,
+   * because it tells the user nothing about where they are.
+   *
+   * Enforcing the floor in CSS makes the layout correct regardless of whether
+   * the measurement was right. Tabs that no longer fit overflow into the
+   * horizontal scroller this strip already is — snap points, hidden scrollbar
+   * and both arrow controls are all present and were always the intended
+   * behaviour for overflow. Degrading to "scroll to reach the rest" is
+   * strictly better than "every tab is illegible".
+   *
+   * Keep these three values in step with tabLayoutMetrics(); they are the same
+   * numbers expressed in rem.
+   */
+  min-width: 6rem; /* 96px — tabLayoutMetrics() mobile minimumTabWidth */
+}
+
+@media (min-width: 640px) {
+  .tab-button {
+    min-width: 7rem; /* 112px */
+  }
+}
+
+@media (min-width: 1280px) {
+  .tab-button {
+    min-width: 8rem; /* 128px */
+  }
 }
 
 .tab-strip::-webkit-scrollbar {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "test:component-reachability:self": "tsx utils/scripts/verifyComponentReachability.ts --self-test",
     "test:page-backdrop": "tsx utils/scripts/verifyPageBackdrop.ts",
     "test:page-backdrop:self": "tsx utils/scripts/verifyPageBackdrop.ts --self-test",
+    "test:art-image-caching": "tsx utils/scripts/verifyArtImageCaching.ts",
     "test:earned-karma-wiring": "tsx utils/scripts/verifyEarnedKarmaWiring.ts",
     "test:stored-art-paths": "tsx utils/scripts/verifyStoredArtPaths.ts",
     "test:stored-art-paths:self": "tsx utils/scripts/verifyStoredArtPaths.ts --self-test",

--- a/server/api/art/images/[id]/file.get.ts
+++ b/server/api/art/images/[id]/file.get.ts
@@ -105,13 +105,36 @@ export default defineEventHandler(async (event) => {
      * at once. The Cache-Control above is immutable for public art, so an
      * image converts once and is then served from CDN cache.
      */
-    const wantsWebp = (getHeader(event, 'accept') || '').includes('image/webp')
+    /*
+     * NO `Vary: Accept`, AND NO ACCEPT NEGOTIATION — deliberately, and this is
+     * the load-bearing part of this handler.
+     *
+     * Negotiating on Accept was correct HTTP, but it made the response depend
+     * on a request header, which forces `Vary: Accept`, which keys the CDN
+     * cache on that header's raw value. Browsers send wildly different strings
+     * for it — Chrome, Firefox and Safari each send a different list, and it
+     * changes between versions — so a single image fragmented into many cache
+     * entries, and every one of them had to be populated by invoking this
+     * function, hitting Prisma, and opening a ProxySQL session to read a
+     * LongText blob.
+     *
+     * That matters here more than almost anywhere else in the app: this route
+     * was 1591 requests in a two-hour window on 2026-08-05 — 34% of all
+     * function invocations and 3x the next busiest route — because gallery
+     * pages mount 140+ images at once. Fragmenting its cache multiplies
+     * database sessions by exactly the factor you least want during a
+     * connection-capacity incident.
+     *
+     * Always transcoding makes the response a pure function of the image id,
+     * so one cache entry serves every client forever under the immutable
+     * Cache-Control above. WebP has been universally supported since Safari 14
+     * (2020), and the two fallbacks below still cover every real failure —
+     * a client that somehow cannot read WebP is a far smaller risk than the
+     * cache behaviour this replaces.
+     */
     const canTranscode = TRANSCODABLE_TYPES.has(fileType)
 
-    // The response body now depends on Accept, so caches must key on it.
-    setHeader(event, 'Vary', 'Accept')
-
-    if (wantsWebp && canTranscode) {
+    if (canTranscode) {
       /*
        * Deliberate degradation, not error handling: any sharp failure (a
        * corrupt row, an unavailable native binding) must fall through to the

--- a/utils/scripts/verifyArtImageCaching.ts
+++ b/utils/scripts/verifyArtImageCaching.ts
@@ -1,0 +1,121 @@
+// /utils/scripts/verifyArtImageCaching.ts
+//
+// The busiest route in the app stays CDN-cacheable.
+//
+// `/api/art/images/[id]/file` was 1591 requests in a two-hour window on
+// 2026-08-05 — 34% of all Vercel function invocations and 3x the next busiest
+// route — because gallery pages mount 140+ images at once. Every request that
+// misses the CDN invokes the function, hits Prisma, and opens a ProxySQL
+// session to read a base64 LongText blob. So this route's cache behaviour is
+// not a performance detail; it is a multiplier on database sessions during
+// exactly the connection-capacity incidents this repo keeps having.
+//
+// THE SPECIFIC REGRESSION GUARDED. Serving WebP only when `Accept` advertises
+// it is correct HTTP, but it makes the response depend on a request header,
+// which requires `Vary: Accept`, which keys the CDN cache on that header's raw
+// value. Chrome, Firefox and Safari each send a different Accept string and it
+// changes between versions, so one image fragments into many cache entries —
+// each needing its own function invocation and database read to populate.
+//
+// Always transcoding makes the response a pure function of the image id: one
+// cache entry, served forever under the immutable Cache-Control. Reintroducing
+// either half — the Accept read or the Vary — silently restores the
+// fragmentation, and nothing about the app looks broken when it happens. That
+// is what makes it worth a test rather than a comment.
+//
+//   npx tsx utils/scripts/verifyArtImageCaching.ts
+//   npx tsx utils/scripts/verifyArtImageCaching.ts --self-test
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const ROUTE = 'server/api/art/images/[id]/file.get.ts'
+
+const failures: string[] = []
+const check = (ok: boolean, message: string) => {
+  if (!ok) failures.push(message)
+}
+
+/** Source with comments stripped, so prose about a rule never satisfies it. */
+export function withoutComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '')
+}
+
+const raw = readFileSync(resolve(process.cwd(), ROUTE), 'utf8')
+const code = withoutComments(raw)
+
+/* -- 1. no Vary, at all ----------------------------------------------------- */
+
+check(
+  !/setHeader\([^)]*['"]Vary['"]/i.test(code),
+  `${ROUTE} sets a Vary header. That keys the CDN cache on a request header ` +
+    `and fragments this route's cache across browsers — multiplying function ` +
+    `invocations and database sessions on the app's busiest endpoint.`,
+)
+
+/* -- 2. the response must not depend on Accept ------------------------------ */
+
+check(
+  !/getHeader\(\s*event\s*,\s*['"]accept['"]\s*\)/i.test(code),
+  `${ROUTE} reads the Accept header. The response body must be a pure function ` +
+    `of the image id so one CDN entry serves every client; negotiating on ` +
+    `Accept is what forces the Vary that fragments the cache.`,
+)
+
+/* -- 3. the cache must still be long-lived and immutable for public art ----- */
+
+check(
+  /max-age=31536000/.test(code) && /immutable/.test(code),
+  `${ROUTE} no longer serves public art as immutable with a one-year max-age. ` +
+    `Without that, cacheability collapses regardless of the Vary rules above.`,
+)
+
+/* -- 4. the degradation paths survive --------------------------------------- */
+
+// A transcode failure must fall through to the original bytes rather than 500:
+// serving a large image always beats serving none.
+check(
+  /catch\s*\(/.test(code) && /webp\.length\s*<\s*original\.length/.test(code),
+  `${ROUTE} lost a transcode fallback. Both must remain: a sharp failure falls ` +
+    `back to the original bytes, and a transcode that grew the file keeps the ` +
+    `original.`,
+)
+
+/* --------------------------------------------------------------------------- */
+
+function selfTest(): void {
+  // The checks read code, not prose — a comment explaining why Vary is wrong
+  // must not be mistaken for setting one.
+  const commentOnly = `
+    // setHeader(event, 'Vary', 'Accept') would fragment the cache.
+    /* getHeader(event, 'accept') is deliberately not read here. */
+    const x = 1
+  `
+  const stripped = withoutComments(commentOnly)
+  if (/setHeader\([^)]*['"]Vary['"]/i.test(stripped)) {
+    throw new Error('a commented-out Vary must not register as setting one')
+  }
+  if (/getHeader\(\s*event\s*,\s*['"]accept['"]\s*\)/i.test(stripped)) {
+    throw new Error('a commented-out Accept read must not register as reading it')
+  }
+  console.log('✅ verifyArtImageCaching self-test passed.')
+}
+
+if (process.argv.includes('--self-test')) {
+  selfTest()
+} else {
+  selfTest()
+
+  if (failures.length) {
+    console.error(`\n❌ Art image caching contract failed:\n`)
+    for (const failure of failures) console.error(`  - ${failure}`)
+    console.error('')
+    process.exitCode = 1
+  } else {
+    console.log(
+      'Art image caching contract passed: no Vary, no Accept dependence, ' +
+        'immutable public cache, both transcode fallbacks intact.',
+    )
+  }
+}


### PR DESCRIPTION
Two independent fixes, both on paths that were failing quietly.

## Art image caching

`/api/art/images/[id]/file` was **1591 requests in a two-hour window** on 2026-08-05 — 34% of all Vercel function invocations and **3× the next busiest route**, because gallery pages mount 140+ images at once. Every CDN miss invokes the function, hits Prisma, and opens a ProxySQL session to read a base64 `LongText` blob. This route's cacheability is a direct multiplier on database sessions during the connection-capacity incidents this repo keeps having.

It served WebP only when `Accept` advertised it — correct HTTP, and exactly why it had to send `Vary: Accept`. That keys the CDN cache on the header's raw value, and Chrome, Firefox and Safari each send a different `Accept` string that changes between versions. One image fragmented into many cache entries, each needing its own invocation and database read.

Always transcoding makes the response **a pure function of the image id**: one cache entry serves every client forever under the existing immutable `Cache-Control`. WebP has been universal since Safari 14 (2020), and both degradation paths are untouched — a sharp failure falls back to the original bytes, and a transcode that grew the file keeps the original.

**Deliberately not touching the Vercel env vars.** They still request `connectionLimit 10 / idle 300 / minimumIdle 1` and are saved only by the code's clamp (logged on every request). Changing production database config unsupervised overnight isn't the right call — it's written up separately.

## Phone tab strip

Four tabs rendered **31px wide** at 390px on the deployed app: Dashboard, Register, Navigation, Themes. At that size a tab is an icon and a truncated letter — it reads as a rendering fault rather than navigation, which is worse than hiding it.

`tabLayoutMetrics()` already knows a tab needs 96/112/128px, but only used that to decide **how many** tabs fit. The width each one gets is a percentage from `tabButtonBasis`, and those agree only if the strip's `clientWidth` was measured correctly when the count was computed. Measured before the strip is constrained — first paint, in-flight layout, unsettled resize — capacity comes out too high, every tab is declared to fit, and each gets an equal fraction of a much narrower strip.

Enforcing the floor in CSS makes the layout correct regardless of whether the measurement was right, and it applies before any JS runs. Overflow goes to the horizontal scroller this strip already is — snap points, hidden scrollbar and both arrows were always the intended overflow behaviour.

**Verified in a real browser**, not by reasoning about CSS:

| | widths | min | strip scrolls |
|---|---|---|---|
| before | 83, 68, 81, 66, 35… | **35px** | yes |
| after | 96, 96, 96, 96, 96… | **96px** | yes |

## The check

`verifyArtImageCaching.ts` guards the caching invariant, since a regression there looks like nothing at all until it surfaces as a connection incident. Four assertions, each mutation-tested: reinstating `Vary`, reinstating the `Accept` read, dropping `immutable`, and dropping either transcode fallback. It strips comments before reading, so prose explaining why `Vary` is wrong can't satisfy the rule forbidding it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_