### PR TITLE
Backdrop art for ten more pages, including the front door

### DIFF
--- a/content/academy.md
+++ b/content/academy.md
@@ -15,6 +15,9 @@ dashboardKey: academy
 dashboardTab: timeline
 loadingMessage: Restoring the frescoes...
 refreshLabel: Refresh Academy
+backgroundMobile: background/academy-mobile.webp
+backgroundTablet: background/academy-tablet.webp
+backgroundDesktop: background/academy-desktop.webp
 ---
 
 :academy-manager

--- a/content/coloring.md
+++ b/content/coloring.md
@@ -15,6 +15,9 @@ dashboardTab: coloring
 cards: navCards
 loadingMessage: Sharpening the crayons...
 refreshLabel: Refresh the coloring book
+backgroundMobile: background/coloring-mobile.webp
+backgroundTablet: background/coloring-tablet.webp
+backgroundDesktop: background/coloring-desktop.webp
 ---
 
 :coloring-book-page

--- a/content/conductor.md
+++ b/content/conductor.md
@@ -14,6 +14,9 @@ dashboardTab: conductor
 cards: conductorCards
 loadingMessage: Loading plans...
 refreshLabel: Refresh Plan
+backgroundMobile: background/conductor-mobile.webp
+backgroundTablet: background/conductor-tablet.webp
+backgroundDesktop: background/conductor-desktop.webp
 ---
 
 :conductor-manager

--- a/content/giving.md
+++ b/content/giving.md
@@ -14,6 +14,9 @@ dashboardKey: giftshop
 dashboardTab: community
 loadingMessage: Loading giving page...
 refreshLabel: Refresh giving page
+backgroundMobile: background/giving-mobile.webp
+backgroundTablet: background/giving-tablet.webp
+backgroundDesktop: background/giving-desktop.webp
 ---
 
 :giving-page

--- a/content/index.md
+++ b/content/index.md
@@ -14,6 +14,9 @@ tabKey: dashboard
 cards: navCards
 loadingMessage: Loading the homepage
 refreshLabel: Refresh
+backgroundMobile: background/index-mobile.webp
+backgroundTablet: background/index-tablet.webp
+backgroundDesktop: background/index-desktop.webp
 ---
 
 :home-feed-placeholder

--- a/content/packs.md
+++ b/content/packs.md
@@ -13,6 +13,9 @@ dashboardTab: packs
 cards: navCards
 loadingMessage: Packing the crate...
 refreshLabel: Refresh Packmaker
+backgroundMobile: background/packs-mobile.webp
+backgroundTablet: background/packs-tablet.webp
+backgroundDesktop: background/packs-desktop.webp
 ---
 
 :packmaker-page

--- a/content/resources.md
+++ b/content/resources.md
@@ -13,6 +13,9 @@ channelKey: play
 tabKey: resources
 loadingMessage: Loading resource gallery...
 refreshLabel: Refresh Resources
+backgroundMobile: background/resources-mobile.webp
+backgroundTablet: background/resources-tablet.webp
+backgroundDesktop: background/resources-desktop.webp
 ---
 
 :resource-gallery

--- a/content/sanctuary.md
+++ b/content/sanctuary.md
@@ -15,6 +15,9 @@ dashboardTab: community
 cards: navCards
 loadingMessage: Loading sanctuary...
 refreshLabel: Refresh Sanctuary
+backgroundMobile: background/sanctuary-mobile.webp
+backgroundTablet: background/sanctuary-tablet.webp
+backgroundDesktop: background/sanctuary-desktop.webp
 ---
 
 :giftshop-manager

--- a/content/serendipity.md
+++ b/content/serendipity.md
@@ -12,6 +12,9 @@ tabKey: serendipity
 dashboardKey: scenario
 dashboardTab: serendipity
 cards: navCards
+backgroundMobile: background/serendipity-mobile.webp
+backgroundTablet: background/serendipity-tablet.webp
+backgroundDesktop: background/serendipity-desktop.webp
 ---
 
 :serendipity-page

--- a/content/stories.md
+++ b/content/stories.md
@@ -14,6 +14,9 @@ tabKey: scenarios
 dashboardKey: scenario
 dashboardTab: scenarios
 cards: scenarioCards
+backgroundMobile: background/stories-mobile.webp
+backgroundTablet: background/stories-tablet.webp
+backgroundDesktop: background/stories-desktop.webp
 ---
 
 :scenario-manager

--- a/stores/seeds/pageBackdropArtPrompts.ts
+++ b/stores/seeds/pageBackdropArtPrompts.ts
@@ -146,6 +146,72 @@ const PAGES: PageSeed[] = [
     scene:
       'The gift shop at the end of the tour: warm crowded shelves of enamel pins, plush oddities, printed shirts on racks and postcard spinners lining both side walls, festoon lights strung overhead, an open doorway of daylight beyond. Cheerful, souvenir-bright, and deliberately a little kitsch.',
   },
+
+  /*
+   * Second batch. `index` leads it because it is the front door — the one page
+   * every visitor sees, and the only one where a missing backdrop is a first
+   * impression rather than a gap.
+   */
+  {
+    page: 'index',
+    title: 'Kind Robots — Dashboard Room',
+    scene:
+      'The dashboard room: a warm circular hall at golden hour with tall arched doorways set all around the wall, each opening onto a glimpse of somewhere different — a workshop, a night sky, a gallery, a garden. Worn wooden floor, a domed skylight above, motes drifting in the light. Welcoming and full of directions to go, with the middle of the room deliberately clear.',
+  },
+  {
+    page: 'sanctuary',
+    title: 'Sanctuary',
+    scene:
+      'A sanctuary garden at dusk: a sheltered walled courtyard of soft greenery, a still reflecting pool off-centre, climbing vines and hanging lanterns along both walls, low stone benches at the edges. Butterflies drift through the warm air. Quiet, safe and unhurried — the calmest scene in the set.',
+  },
+  {
+    page: 'academy',
+    title: 'Art Academy',
+    scene:
+      "An art academy studio: a high-windowed atelier with plaster casts and anatomical models on shelves down one side, easels and stools ranged along the other, master studies pinned in rows on the far wall. Cool north light, chalk dust in the air, a faint smell of turpentine implied. Studious and generous rather than austere.",
+  },
+  {
+    page: 'coloring',
+    title: 'Coloring Book',
+    scene:
+      'A coloring table seen from above and slightly off-centre: a big paper-strewn work surface where line-art pages, fat wax crayons, pencil stubs and half-filled palettes spread to the edges, some pages still pure black-and-white outline and others blazing with colour. Bright, tactile and childlike without being twee.',
+  },
+  {
+    page: 'stories',
+    title: 'Stories — Story Maker Room',
+    scene:
+      'A multiverse of doors: a vast soft-lit space where dozens of freestanding doorframes float at different depths and angles, each ajar on a sliver of a different world — snow, neon, jungle, deep sea. Mist below, warm light above, the doors clustering to the left and right and thinning through the middle.',
+  },
+  {
+    page: 'conductor',
+    title: 'Conductor Cockpit',
+    scene:
+      'A conductor cockpit: a wide dim control room with a curved bank of glowing schedule boards, plotting tables and brass instruments arranged along both flanks, cables looping overhead, a tall window onto a night landscape ahead. Focused, technical and calm — a place for watching many things at once.',
+  },
+  {
+    page: 'giving',
+    title: 'Giving & Support',
+    scene:
+      'A giving hall: a warm open room where long tables of carefully packed parcels and supplies recede to either side, ribbon and twine spools at the edges, an open double door spilling afternoon light. Generous, practical and unsentimental — the work of helping, not a symbol of it.',
+  },
+  {
+    page: 'packs',
+    title: 'Packmaker',
+    scene:
+      'A packing bench: a sturdy workshop table strewn with open crates, labelled tins, folded canvas and neatly bundled kits, shelving of prepared bundles rising on both sides, a stencil and ink pad to one corner. Orderly, satisfying, everything-in-its-place.',
+  },
+  {
+    page: 'resources',
+    title: 'Resources — Resource Gallery',
+    scene:
+      'A resource archive: a long hall of card-catalogue drawers, labelled canisters and spooled reels on deep shelves running away down both walls, rolling ladders on rails, a reading lectern at the near edge. Cool, ordered and quietly enormous.',
+  },
+  {
+    page: 'serendipity',
+    title: 'Serendipity — Story Door',
+    scene:
+      'The story door: a single ornate doorway standing free in a soft twilight meadow, its frame carved with small creatures, light spilling warm from the gap where it stands ajar. Tall grass and fireflies at the lower edges, deep blue sky above. Inviting and a little mysterious, with the space around the door left open.',
+  },
 ]
 
 function buildPrompt(seed: PageSeed, variant: BackdropVariant): string {


### PR DESCRIPTION
Extends the Stage 3 backdrop set from **10 pages to 20**, and the art queue from **30 prompts to 60**. Same mechanism, same priority band (100), **no code changes** — the rails from #1485 mean a page opts in with three frontmatter keys and nothing else.

## Why `index` leads

It's the front door: the one page every visitor sees, and the only one where a missing backdrop is a first impression rather than a gap. Its scene is the Dashboard Room the frontmatter already names — a warm circular hall of arched doorways, each opening on a glimpse of somewhere different, with the middle deliberately clear.

The rest: **Sanctuary, Art Academy, Coloring Book, Stories, Conductor, Giving, Packmaker, Resources, Serendipity.**

## Scenes come from the page, not from a template

Every scene is written from what the page already declares itself to be — its own `room` and `subtitle`:

| page | declared room | scene |
|---|---|---|
| serendipity | *Story Door* | a single ornate doorway standing free in a twilight meadow, light spilling from the gap |
| conductor | *Conductor Cockpit* | a dim control room of glowing schedule boards and plotting tables |
| stories | *Story Maker Room* | dozens of freestanding doorframes at different depths, each ajar on a different world |
| academy | *Art Academy* | a high-windowed atelier, plaster casts one side, easels the other |

That's the point of Stage 3: pages stop looking interchangeable, and the art *agrees with* the page instead of decorating it.

The scenery-not-subject rule carries through unchanged — quiet centre, interest at the edges, because UI is drawn on top and a strong central focal point lands underneath a card.

## Verification

60 prompts across 20 pages, 60 unique request IDs, and the bidirectional contract holds: every queued prompt is claimed by a page, and every declaring page has a prompt. Nothing generates art that renders nowhere, and nothing waits for art no one asked for.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_