### PR TITLE
fix(art): let real users retry a failed image load, not just debug mode

### DIFF
--- a/components/art/image-card.vue
+++ b/components/art/image-card.vue
@@ -121,9 +121,11 @@
         <Icon name="kind-icon:check" class="h-3 w-3" />
       </div>
 
-      <!-- Retry -->
+      <!-- Retry — always available on a failed load, not just in debug mode,
+           so a transient network/URL hiccup doesn't permanently pin the card
+           to the fallback image with no recovery path for real users. -->
       <button
-        v-if="imageLoadFailed && showDebug"
+        v-if="imageLoadFailed"
         class="absolute bottom-1.5 left-1.5 rounded-full bg-warning px-2 py-0.5 text-xs font-bold text-warning-content shadow"
         type="button"
         title="Retry image"


### PR DESCRIPTION
### Task
ai-art-academy/t-010: recurring "Academy continuous improvement pass" — lane 1 (front-end style/polish) (kind: software)

### What changed
`components/art/image-card.vue`'s Retry button (shown when an image fails to load) was gated behind the `showDebug` prop. Checked every call site of `<image-card>` in the repo (`art-creator.vue`, `dream-list.vue`, `dream-art-chooser.vue`, `project-gallery-strip.vue`, `art-gallery.vue`, `art-interact.vue`, `collection-card.vue`, `generate-button.vue`, `art-maker.vue`) plus a repo-wide `grep -rn "show-debug"` — `showDebug` is never set `true` anywhere, so the button was unreachable in practice.

Net effect: a transient failure (flaky network, expired signed URL, momentary server hiccup) permanently pinned any card to the fallback image (`/images/backtree.webp`) with no way for a real user to recover short of a full page reload — and this component is used pervasively across galleries (art-gallery, dream-list, collection-card, project-gallery-strip, etc.).

Fix: decoupled the Retry button's `v-if` from `showDebug` — it now shows whenever `imageLoadFailed` is true, regardless of debug mode. The debug-only data-source badges elsewhere in the component are untouched.

### How I verified
- `npx eslint components/art/image-card.vue` — clean.
- `npx prettier --check components/art/image-card.vue` — clean.
- `npx vue-tsc --noEmit -p tsconfig.json` — clean, zero errors.
- No dedicated test file exists for this component (checked); the change is a single-line `v-if` condition on an already-implemented, already-tested `loadFullImage()` retry handler.

### Stakes
reversible

### Notes for reviewer
Companion conductor task: `ai-art-academy/t-010` (rearms to `ready` after merge per the recurring-task convention — no conductor PR needed for this cycle beyond the roadmap note).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQEoktpfxY7o5ERhFz1AfS)_