### PR TITLE
chore: add conservative branch janitor

### DIFF
--- a/.github/workflows/branch-janitor.yml
+++ b/.github/workflows/branch-janitor.yml
@@ -1,0 +1,39 @@
+name: Branch janitor
+
+on:
+  schedule:
+    - cron: "23 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Plan only; delete nothing"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: branch-janitor
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Delete merged branches and report stranded work
+        run: |
+          python scripts/branch_janitor.py \
+            ${{ (github.event.inputs.dry_run == 'true') && '--dry-run' || '' }} \
+            | tee -a "$GITHUB_STEP_SUMMARY"

--- a/scripts/branch_janitor.py
+++ b/scripts/branch_janitor.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Delete merged automation branches and report old unmerged branches."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from datetime import datetime, timezone
+
+DEFAULT_PREFIXES = ("claude/", "worker/", "agent/")
+
+
+def git(*args: str) -> str:
+    return subprocess.run(["git", *args], capture_output=True, text=True, check=False).stdout.strip()
+
+
+def remote_branches(prefixes: tuple[str, ...]) -> list[str]:
+    branches: list[str] = []
+    for ref in git("branch", "-r", "--format=%(refname:short)").splitlines():
+        ref = ref.strip()
+        if not ref.startswith("origin/") or "->" in ref:
+            continue
+        name = ref.removeprefix("origin/")
+        if name != "main" and any(name.startswith(prefix) for prefix in prefixes):
+            branches.append(name)
+    return branches
+
+
+def merged(branch: str) -> bool:
+    return subprocess.run(
+        ["git", "merge-base", "--is-ancestor", f"origin/{branch}", "origin/main"],
+        capture_output=True,
+        text=True,
+        check=False,
+    ).returncode == 0
+
+
+def age_hours(branch: str) -> float:
+    timestamp = git("log", "-1", "--format=%ct", f"origin/{branch}")
+    if not timestamp:
+        return 0.0
+    committed = datetime.fromtimestamp(int(timestamp), tz=timezone.utc)
+    return (datetime.now(timezone.utc) - committed).total_seconds() / 3600
+
+
+def delete(branch: str, dry_run: bool) -> bool:
+    if dry_run:
+        return True
+    return subprocess.run(
+        ["git", "push", "origin", "--delete", branch],
+        capture_output=True,
+        text=True,
+        check=False,
+    ).returncode == 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--stale-hours", type=float, default=12.0)
+    args = parser.parse_args()
+
+    git("fetch", "origin", "+refs/heads/*:refs/remotes/origin/*", "--prune")
+    deleted: list[str] = []
+    stranded: list[str] = []
+    active: list[str] = []
+    failed: list[str] = []
+
+    branches = remote_branches(DEFAULT_PREFIXES)
+    for branch in branches:
+        if merged(branch):
+            (deleted if delete(branch, args.dry_run) else failed).append(branch)
+        elif age_hours(branch) >= args.stale_hours:
+            stranded.append(branch)
+        else:
+            active.append(branch)
+
+    verb = "Would delete" if args.dry_run else "Deleted"
+    print(f"Considered {len(branches)} automation branch(es).")
+    print(f"{verb} (fully merged): {', '.join(deleted) or '(none)'}")
+    print(f"Stranded (review only): {', '.join(stranded) or '(none)'}")
+    print(f"Active (left alone): {', '.join(active) or '(none)'}")
+    if failed:
+        print(f"Delete failed: {', '.join(failed)}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add an hourly/manual branch-janitor workflow using the repository-scoped `GITHUB_TOKEN`
- delete only `claude/*`, `worker/*`, and `agent/*` branches whose tips are ancestors of `main`
- report stale unmerged branches without deleting them
- use a full-history checkout to avoid shallow-clone merge-base mistakes

Conductor task: `kind-robots/t-054`
Session: `2026-08-05T161305Z-kind-robots-t-054-v6k3`

## Safety
No application, database, deployment, billing, DNS, secret, or production-data changes. Unmerged branches are report-only.