### PR TITLE
docs: update stale curate-request.post.ts comment (conductor kind-robots/t-051)

### DIFF
--- a/utils/scripts/verifyConductorApiAuthGuards.ts
+++ b/utils/scripts/verifyConductorApiAuthGuards.ts
@@ -10,9 +10,12 @@
 //     (server/utils/authGuard.ts)
 //   - validateApiKey(...) paired with a userIsAdmin(...) check
 //     (server/utils/validateKey.ts + server/utils/authUser.ts) -- the older
-//     pattern used by art-request.post.ts and curate-request.post.ts. It is
-//     functionally equivalent (same JWT / user-api-key / beta-admin-token
-//     resolution as requireAdminApiUser) so it is accepted, not flagged.
+//     pattern used by art-request.post.ts (curate-request.post.ts used to be
+//     a second example but was removed in PR #1244, 2026-08-01, when the
+//     curator vision-model pass it fed was retired -- see conductor
+//     kind-robots/t-051). It is functionally equivalent (same JWT /
+//     user-api-key / beta-admin-token resolution as requireAdminApiUser) so
+//     it is accepted, not flagged.
 import { readdirSync, readFileSync } from 'node:fs'
 import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'


### PR DESCRIPTION
### Task
conductor kind-robots/t-051: Investigate and document the disappearance of `server/api/conductor/curate-request.post.ts` (kind: software)

### What changed / what I produced
- `utils/scripts/verifyConductorApiAuthGuards.ts`'s auth-guard example comment still named `curate-request.post.ts` as a live example of the older `validateApiKey`/`userIsAdmin` pattern. That endpoint was removed in PR #1244 (2026-08-01), so the comment was stale and would send a future reader grepping for the filename to a dead end. Updated the comment to note the removal, the removing PR, and the conductor task with the full investigation.
- No functional/behavior change — comment only.

### How I verified
- Full investigation (done on the conductor side, `kind-robots/t-051`): unshallowed this checkout (`git fetch --unshallow`) since the default shallow clone's ~50-commit horizon doesn't reach back to 2026-07-14/08-01, and searched history with `git log --all --diff-filter=AD --follow` and `git log --all -S"curate-request.post"`. Found the endpoint added in `90e115751` (2026-07-14, "feat(artjob): front-end curate request for the ArtJob trainer") and deliberately removed in `5fa7f03b4` / PR #1244 (2026-08-01, "Show finished art for human review without a curator pass") — that PR removed the endpoint, its YAML helper, both store actions, and the front-end "Request curation" button/CTA together, so there is no dangling caller and nothing silently 404s.
- Confirmed no test references the removed filename (`grep -rn "curate-request"` across the repo now only matches this one comment).

### Stakes
reversible

### Notes for reviewer
Closes out conductor's `kind-robots/t-051` (already set to `done` there with the full investigation writeup — this PR is just the accompanying doc-accuracy fix in this repo).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Av1rLvxZhHJAitbt3V4waW)_