### PR TITLE
Get backdrop art out of the database: export → link → prune

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "migrate:art-jobs": "tsx utils/scripts/migratePromptsToArtJobs.ts",
     "seed:twisted-fairy-tales": "tsx utils/scripts/enqueueTwistedFairyTalesArtPrompts.ts",
     "seed:page-backdrops": "tsx utils/scripts/enqueuePageBackdropArt.ts",
+    "prune:art-image-data": "tsx utils/scripts/pruneRedundantArtImageData.ts",
     "characters:repair": "tsx utils/scripts/repairCharacterSlugs.mjs",
     "seed:davinci": "tsx utils/scripts/seedDaVinciEndings.ts",
     "seed:davinci:verify": "tsx utils/scripts/verifyDaVinciSeed.ts",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "migrate:art-jobs": "tsx utils/scripts/migratePromptsToArtJobs.ts",
     "seed:twisted-fairy-tales": "tsx utils/scripts/enqueueTwistedFairyTalesArtPrompts.ts",
     "seed:page-backdrops": "tsx utils/scripts/enqueuePageBackdropArt.ts",
+    "export:page-backdrops": "tsx utils/scripts/exportPageBackdropArt.ts",
     "prune:art-image-data": "tsx utils/scripts/pruneRedundantArtImageData.ts",
     "characters:repair": "tsx utils/scripts/repairCharacterSlugs.mjs",
     "seed:davinci": "tsx utils/scripts/seedDaVinciEndings.ts",

--- a/utils/scripts/enqueuePageBackdropArt.ts
+++ b/utils/scripts/enqueuePageBackdropArt.ts
@@ -37,6 +37,7 @@ import prisma from './../../server/utils/prisma'
 import { pageBackdropArtPrompts } from './../../stores/seeds/pageBackdropArtPrompts'
 
 const WRITE = process.argv.includes('--write')
+const REFRESH_FAILED = process.argv.includes('--refresh-failed')
 const USER_ID = Number(process.env.ART_SEED_USER_ID || 1)
 const PROJECT_SLUG = 'page-backdrops'
 const PRIORITY = 100
@@ -48,6 +49,25 @@ function requestIdFromPayload(payload: string): string | null {
   } catch {
     return null
   }
+}
+
+function buildPayload(entry: (typeof pageBackdropArtPrompts)[number]): string {
+  return JSON.stringify({
+    requestId: entry.requestId,
+    title: entry.title,
+    page: entry.page,
+    variant: entry.variant,
+    promptString: entry.promptString,
+    negativePrompt: entry.negativePrompt,
+    width: entry.width,
+    height: entry.height,
+    imagePath: entry.imagePath,
+    save: {
+      isPublic: true,
+      isMature: false,
+      designer: 'Kind Robots / Page Backdrops',
+    },
+  })
 }
 
 async function main() {
@@ -87,6 +107,25 @@ async function main() {
     (entry) => !existingByRequestId.has(entry.requestId),
   )
 
+  /*
+   * FAILED jobs are re-runnable, and a plain requestId match would hide them.
+   *
+   * The idempotency above keys on requestId alone, which is right for avoiding
+   * duplicates but wrong for recovery: a job that FAILED still has its
+   * requestId, so it reports EXISTS forever and can never be retried by
+   * re-running this script. That is the opposite of what you want after a bad
+   * batch.
+   *
+   * --refresh-failed rewrites those jobs' payloads from the CURRENT prompt
+   * definitions and returns them to PENDING. Rewriting rather than merely
+   * re-queueing is the point: if a job failed because the prompt or the canvas
+   * was wrong, /api/art/queue/[id]/reenqueue puts the same bad payload back and
+   * it fails again. This picks up whatever the seed file says now.
+   */
+  const failed = pageBackdropArtPrompts.filter(
+    (entry) => existingByRequestId.get(entry.requestId)?.status === 'FAILED',
+  )
+
   console.log(
     `Page backdrops: ${pageBackdropArtPrompts.length} prompt(s) across ` +
       `${new Set(pageBackdropArtPrompts.map((e) => e.page)).size} page(s), ` +
@@ -104,12 +143,44 @@ async function main() {
     )
   }
 
+  if (failed.length) {
+    console.log(
+      `\n${failed.length} job(s) are FAILED. ${
+        REFRESH_FAILED
+          ? 'Refreshing their payloads from the current prompts and re-queueing.'
+          : 'Re-run with --refresh-failed to rewrite their payloads from the current prompts and re-queue them.'
+      }`,
+    )
+  }
+
   if (!WRITE) {
     console.log(
       `\nDry run only. Re-run with --write to create ${missing.length} ArtJob ` +
-        `row(s) at priority ${PRIORITY} (ahead of the facet backlog at 0).`,
+        `row(s) at priority ${PRIORITY} (ahead of the facet backlog at 0)` +
+        `${REFRESH_FAILED && failed.length ? ` and refresh ${failed.length} failed job(s)` : ''}.`,
     )
     return
+  }
+
+  if (REFRESH_FAILED && failed.length) {
+    for (const entry of failed) {
+      const job = existingByRequestId.get(entry.requestId)
+      if (!job) continue
+      await prisma.artJob.update({
+        where: { id: job.id },
+        data: {
+          payload: buildPayload(entry),
+          status: 'PENDING',
+          priority: PRIORITY,
+          // Clear the previous attempt so the relay treats this as fresh work
+          // rather than something already tried and abandoned.
+          attempts: 0,
+          error: null,
+          claimedBy: null,
+        },
+      })
+    }
+    console.log(`Refreshed ${failed.length} failed job(s) back to PENDING.`)
   }
 
   if (!missing.length) {
@@ -125,22 +196,7 @@ async function main() {
           priority: PRIORITY,
           projectSlug: PROJECT_SLUG,
           userId: USER_ID,
-          payload: JSON.stringify({
-            requestId: entry.requestId,
-            title: entry.title,
-            page: entry.page,
-            variant: entry.variant,
-            promptString: entry.promptString,
-            negativePrompt: entry.negativePrompt,
-            width: entry.width,
-            height: entry.height,
-            imagePath: entry.imagePath,
-            save: {
-              isPublic: true,
-              isMature: false,
-              designer: 'Kind Robots / Page Backdrops',
-            },
-          }),
+          payload: buildPayload(entry),
         },
       }),
     ),

--- a/utils/scripts/enqueuePageBackdropArt.ts
+++ b/utils/scripts/enqueuePageBackdropArt.ts
@@ -35,6 +35,12 @@
 import 'dotenv/config'
 import prisma from './../../server/utils/prisma'
 import { pageBackdropArtPrompts } from './../../stores/seeds/pageBackdropArtPrompts'
+import {
+  KREA2_DEFAULT_CFG,
+  KREA2_DEFAULT_STEPS,
+  buildKrea2WorkflowFromRequest,
+} from './../../server/api/comfy/krea2/utils/workflow'
+import { enrichArtJobPayload } from './../../server/utils/artJobProvenance'
 
 const WRITE = process.argv.includes('--write')
 const REFRESH_FAILED = process.argv.includes('--refresh-failed')
@@ -51,8 +57,38 @@ function requestIdFromPayload(payload: string): string | null {
   }
 }
 
+/*
+ * COMFY, not A1111 — and this is what the first batch got wrong.
+ *
+ * All 60 jobs failed with `WinError 10061 ... target machine actively refused
+ * it`: connection refused reaching the A1111 backend. Nothing was wrong with
+ * the prompts, and nothing ever read them. A1111 simply is not what runs here.
+ * The queue proves it — every PENDING job sampled is COMFY, every recent DONE
+ * job is COMFY, and the only A1111 rows anywhere are CANCELLED. The engine was
+ * copied from enqueueTwistedFairyTalesArtPrompts.ts without checking what the
+ * relay actually claims work for.
+ *
+ * Switching the engine alone would not have been enough: COMFY jobs carry a
+ * full workflow graph, so a payload of prompt/width/height that satisfies
+ * A1111 has nothing for ComfyUI to execute. This mirrors the known-good
+ * text2img path in scripts/generate_facet_art.ts exactly — same workflow
+ * builder, same steps/cfg, same enrichment — so the shape is one the relay is
+ * already running successfully thousands of times rather than one I invented.
+ */
+const STEPS = KREA2_DEFAULT_STEPS
+const CFG = KREA2_DEFAULT_CFG
+
 function buildPayload(entry: (typeof pageBackdropArtPrompts)[number]): string {
-  return JSON.stringify({
+  const { workflow, seed } = buildKrea2WorkflowFromRequest({
+    prompt: entry.promptString,
+    negativePrompt: entry.negativePrompt,
+    width: entry.width,
+    height: entry.height,
+    steps: STEPS,
+    cfg: CFG,
+  })
+
+  const { payload } = enrichArtJobPayload('COMFY', {
     requestId: entry.requestId,
     title: entry.title,
     page: entry.page,
@@ -61,6 +97,10 @@ function buildPayload(entry: (typeof pageBackdropArtPrompts)[number]): string {
     negativePrompt: entry.negativePrompt,
     width: entry.width,
     height: entry.height,
+    steps: STEPS,
+    cfg: CFG,
+    seed,
+    workflow,
     imagePath: entry.imagePath,
     save: {
       isPublic: true,
@@ -68,6 +108,8 @@ function buildPayload(entry: (typeof pageBackdropArtPrompts)[number]): string {
       designer: 'Kind Robots / Page Backdrops',
     },
   })
+
+  return JSON.stringify(payload)
 }
 
 async function main() {
@@ -192,7 +234,7 @@ async function main() {
     missing.map((entry) =>
       prisma.artJob.create({
         data: {
-          engine: 'A1111',
+          engine: 'COMFY',
           priority: PRIORITY,
           projectSlug: PROJECT_SLUG,
           userId: USER_ID,

--- a/utils/scripts/exportPageBackdropArt.ts
+++ b/utils/scripts/exportPageBackdropArt.ts
@@ -1,0 +1,171 @@
+// /utils/scripts/exportPageBackdropArt.ts
+//
+// Move finished backdrop art out of the database and onto the media share,
+// where the frontmatter actually points.
+//
+// THE GAP THIS CLOSES. enqueuePageBackdropArt puts `imagePath:
+// background/<page>-<variant>.webp` in each job payload, and the content
+// frontmatter declares the same path — but nothing in the completion path acts
+// on it. complete.post.ts stores finished art as an ArtImage row (imageData,
+// imagePath null); per docs/self-hosted-media.md, "Vercel cannot write to the
+// Unraid share. Production upload behavior remains database-backed." So all 60
+// images would generate successfully and no page would show one.
+//
+// Usage (on the Windows/WSL host, where IMAGES_PATH reaches the share):
+//   npm run export:page-backdrops              # dry run
+//   npm run export:page-backdrops -- --write   # write files + set imagePath
+//
+// WHY IT ALSO SETS imagePath. Once the file is on the share, file.get.ts
+// redirects to it instead of reading base64 (see its early `sendRedirect`), so
+// the row stops costing a LongText read per view. That also makes the row
+// eligible for pruneRedundantArtImageData.ts, which only prunes rows whose path
+// it can verify actually serves an image. Export → link → prune, in that order;
+// each step is safe on its own and none of them destroys the only copy.
+//
+// TRANSCODES TO WEBP, deliberately. The generator emits PNG, the declared path
+// ends in .webp, and nginx serves content-type by file extension — a PNG
+// written to a .webp name would be served as image/webp and is a bug waiting
+// for a strict decoder. Converting makes name and bytes agree, and the file is
+// far smaller (measured 8.3x on card art at q82 in file.get.ts).
+import 'dotenv/config'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import sharp from 'sharp'
+import prisma from './../../server/utils/prisma'
+
+const WRITE = process.argv.includes('--write')
+const PROJECT_SLUG = 'page-backdrops'
+const WEBP_QUALITY = 82
+
+// Same fallback the app uses when the share is not mounted, so a dry run on a
+// machine without the share still reports something meaningful.
+const IMAGES_ROOT = process.env.IMAGES_PATH || resolve(process.cwd(), 'public/images')
+
+type JobRow = {
+  id: number
+  status: string
+  artImageId: number | null
+  payload: string
+}
+
+function payloadOf(raw: string): Record<string, unknown> {
+  try {
+    return JSON.parse(raw) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+async function main() {
+  const jobs = await prisma.artJob.findMany({
+    where: { projectSlug: PROJECT_SLUG },
+    select: { id: true, status: true, artImageId: true, payload: true },
+    orderBy: { id: 'asc' },
+  })
+
+  if (!jobs.length) {
+    console.log(
+      `No ArtJob rows with projectSlug="${PROJECT_SLUG}". Queue them first with ` +
+        `npm run seed:page-backdrops -- --write`,
+    )
+    return
+  }
+
+  const byStatus = new Map<string, number>()
+  for (const job of jobs) {
+    byStatus.set(job.status, (byStatus.get(job.status) || 0) + 1)
+  }
+
+  console.log(
+    `Backdrop jobs: ${jobs.length} — ` +
+      [...byStatus].map(([s, n]) => `${s} ${n}`).join(', '),
+  )
+  console.log(`Media root: ${IMAGES_ROOT}${process.env.IMAGES_PATH ? '' : '  (IMAGES_PATH unset — falling back to public/images)'}\n`)
+
+  const ready = jobs.filter((job) => job.artImageId)
+  if (!ready.length) {
+    console.log('Nothing finished yet — no job has an artImageId. Re-run later.')
+    return
+  }
+
+  let written = 0
+  let skipped = 0
+
+  for (const job of ready as JobRow[]) {
+    const payload = payloadOf(job.payload)
+    const relPath = typeof payload.imagePath === 'string' ? payload.imagePath : ''
+    const label = `${payload.page || '?'}/${payload.variant || '?'}`
+
+    if (!relPath) {
+      console.log(`  SKIP  job ${job.id} ${label}: payload has no imagePath`)
+      skipped += 1
+      continue
+    }
+
+    const image = await prisma.artImage.findUnique({
+      where: { id: job.artImageId as number },
+      select: { id: true, imageData: true, imagePath: true },
+    })
+
+    if (!image?.imageData) {
+      // Already exported and pruned, or never stored. Either way there are no
+      // bytes here to write, and inventing a file would be worse than skipping.
+      console.log(
+        `  SKIP  job ${job.id} ${label}: ArtImage ${job.artImageId} has no imageData` +
+          `${image?.imagePath ? ` (already at ${image.imagePath})` : ''}`,
+      )
+      skipped += 1
+      continue
+    }
+
+    const target = join(IMAGES_ROOT, relPath)
+    const servedPath = `/images/${relPath.replace(/^\/+/, '')}`
+
+    if (!WRITE) {
+      console.log(`  WOULD  ${label.padEnd(24)} -> ${target}`)
+      written += 1
+      continue
+    }
+
+    const original = Buffer.from(image.imageData, 'base64')
+    const webp = await sharp(original).webp({ quality: WEBP_QUALITY }).toBuffer()
+
+    await mkdir(dirname(target), { recursive: true })
+    await writeFile(target, webp)
+
+    // Link the row to the file so file.get.ts redirects instead of reading
+    // base64, and so the pruner can later verify and reclaim the bytes.
+    await prisma.artImage.update({
+      where: { id: image.id },
+      data: { imagePath: servedPath },
+    })
+
+    const kb = (n: number) => `${Math.round(n / 1024)}KB`
+    console.log(
+      `  WROTE  ${label.padEnd(24)} ${kb(original.length)} -> ${kb(webp.length)}  ${servedPath}`,
+    )
+    written += 1
+  }
+
+  console.log(
+    `\n${WRITE ? 'Exported' : 'Would export'} ${written} file(s); skipped ${skipped}.`,
+  )
+
+  if (!WRITE) {
+    console.log('\nDry run only. Re-run with --write to write files and set imagePath.')
+    return
+  }
+
+  console.log(
+    '\nNext: the pages already declare these paths, so they appear on the next\n' +
+      'load. Once you are happy, npm run prune:art-image-data reclaims the\n' +
+      'database copies — it re-verifies each path serves a real image first.',
+  )
+}
+
+main()
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+  .finally(() => prisma.$disconnect())

--- a/utils/scripts/pruneRedundantArtImageData.ts
+++ b/utils/scripts/pruneRedundantArtImageData.ts
@@ -1,0 +1,223 @@
+// /utils/scripts/pruneRedundantArtImageData.ts
+//
+// Drop base64 ArtImage.imageData for rows whose art is PROVEN to be served
+// from somewhere else.
+//
+// Silas, 2026-08-05: "If an image has a local imagePath, we don't need the
+// base64 data in the database and I approve field deleted."
+//
+// Usage:
+//   npm run prune:art-image-data                 # dry run, verifies nothing is lost
+//   npm run prune:art-image-data -- --limit 50   # verify a small sample first
+//   npm run prune:art-image-data -- --write      # actually null the column
+//
+// WHY THIS IS SAFE TO SERVE. file.get.ts already redirects to `imagePath`
+// before it ever looks at `imageData`:
+//
+//     if (image.imagePath && !image.imagePath.includes(`/api/art/images/${id}/file`))
+//       return sendRedirect(event, image.imagePath, 302)
+//
+// So for a row with a usable imagePath, the base64 is already unreachable
+// weight. Removing it changes no response.
+//
+// ── THE TWO WAYS THIS COULD DESTROY ART, AND WHAT STOPS THEM ──────────────
+//
+// 1. SELF-REFERENTIAL PATHS. dailyDreamArchiveStore writes
+//    `imagePath = /api/art/images/<id>/file?v=<ts>` — the row pointing at its
+//    own endpoint. The redirect guard deliberately skips those (it would loop),
+//    so they DO fall through to imageData. Null them and the image is gone.
+//    Excluded below by the same substring test the endpoint uses, so the two
+//    can never disagree.
+//
+// 2. A PATH THAT IS NOT ACTUALLY A FILE. This is the one that matters, and it
+//    has already happened here: 214 of 227 Reward.imagePath values pointed at
+//    `/rewards/...` when the files live at `/images/rewards/...`, and every one
+//    served a 142 KB Nuxt app shell as text/html at HTTP **200** — because a
+//    missing path does not 404, it falls through to the SPA catch-all
+//    (kind_robots #1446, which is why verifyStoredArtPaths.ts exists).
+//
+//    A status check would have called all 214 healthy and this script would
+//    have deleted the only copy of each. So a row is only pruned when its path
+//    returns 2xx AND a content-type of image/*. Anything else — 404, HTML, a
+//    redirect to HTML, a timeout — is reported and SKIPPED, never pruned.
+//
+// The media origin is the backup. That is exactly why the bytes are verified
+// present there before the database copy goes.
+import 'dotenv/config'
+import prisma from './../../server/utils/prisma'
+
+const WRITE = process.argv.includes('--write')
+const limitFlag = process.argv.indexOf('--limit')
+const LIMIT = limitFlag === -1 ? 0 : Number(process.argv[limitFlag + 1] || 0)
+
+// Verify against the deployment, not the media host directly: a stored path may
+// be relative, and the app's redirects are part of what makes it resolvable.
+const BASE = (process.env.PRUNE_VERIFY_BASE || 'https://kind-robots.vercel.app')
+  .replace(/\/+$/, '')
+
+const CONCURRENCY = 6
+const TIMEOUT_MS = 20_000
+
+type Row = { id: number; imagePath: string | null; bytes: number }
+type Verdict = 'prune' | 'skip-not-image' | 'skip-missing' | 'skip-error'
+type Checked = { row: Row; verdict: Verdict; detail: string }
+
+function resolveUrl(path: string): string {
+  if (/^https?:\/\//i.test(path)) return path
+  return `${BASE}${path.startsWith('/') ? '' : '/'}${path}`
+}
+
+async function verify(path: string): Promise<{ verdict: Verdict; detail: string }> {
+  const url = resolveUrl(path)
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
+
+  try {
+    // GET, not HEAD: the SPA catch-all that caused #1446 answers HEAD just as
+    // convincingly as it answers GET. The body's content-type is the evidence.
+    const res = await fetch(url, {
+      signal: controller.signal,
+      redirect: 'follow',
+      headers: { accept: 'image/*,*/*' },
+    })
+
+    if (res.status === 404) return { verdict: 'skip-missing', detail: '404' }
+    if (!res.ok) return { verdict: 'skip-error', detail: `HTTP ${res.status}` }
+
+    const type = (res.headers.get('content-type') || '').toLowerCase()
+    if (!type.startsWith('image/')) {
+      // The #1446 signature: HTTP 200, text/html, an app shell.
+      return { verdict: 'skip-not-image', detail: `200 but ${type || 'no content-type'}` }
+    }
+
+    return { verdict: 'prune', detail: type }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error)
+    return { verdict: 'skip-error', detail: message.slice(0, 60) }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+async function mapLimit<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length)
+  let cursor = 0
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, async () => {
+      while (cursor < items.length) {
+        const index = cursor++
+        results[index] = await fn(items[index] as T)
+      }
+    }),
+  )
+
+  return results
+}
+
+async function main() {
+  /*
+   * Candidates are exactly the rows the serving endpoint would never read
+   * imageData for. The self-reference test mirrors file.get.ts character for
+   * character — if that guard ever changes, this must change with it, or this
+   * script starts deleting bytes the endpoint still needs.
+   */
+  const candidates = await prisma.$queryRawUnsafe<Row[]>(`
+    SELECT id, imagePath, LENGTH(imageData) AS bytes
+    FROM ArtImage
+    WHERE imageData IS NOT NULL
+      AND imagePath IS NOT NULL
+      AND imagePath <> ''
+      AND imagePath NOT LIKE CONCAT('%/api/art/images/', id, '/file%')
+    ORDER BY LENGTH(imageData) DESC
+    ${LIMIT > 0 ? `LIMIT ${Math.floor(LIMIT)}` : ''}
+  `)
+
+  const totals = await prisma.$queryRawUnsafe<{ rows: number; bytes: number }[]>(`
+    SELECT COUNT(*) AS rows, COALESCE(SUM(LENGTH(imageData)), 0) AS bytes
+    FROM ArtImage WHERE imageData IS NOT NULL
+  `)
+  const allRows = Number(totals[0]?.rows || 0)
+  const allBytes = Number(totals[0]?.bytes || 0)
+
+  const mb = (n: number) => `${(n / 1024 / 1024).toFixed(1)} MB`
+
+  console.log(
+    `ArtImage rows holding base64: ${allRows} (${mb(allBytes)} total)\n` +
+      `Candidates with a non-self-referential imagePath: ${candidates.length}` +
+      `${LIMIT > 0 ? ` (limited to ${LIMIT})` : ''}\n` +
+      `Verifying each against ${BASE} before pruning anything...\n`,
+  )
+
+  const checked: Checked[] = await mapLimit<Row, Checked>(
+    candidates,
+    CONCURRENCY,
+    async (row) => ({ row, ...(await verify(row.imagePath as string)) }),
+  )
+
+  const prunable = checked.filter((c) => c.verdict === 'prune')
+  const skipped = checked.filter((c) => c.verdict !== 'prune')
+  const reclaimable = prunable.reduce((sum, c) => sum + Number(c.row.bytes || 0), 0)
+
+  for (const s of skipped) {
+    console.log(
+      `  SKIP  #${String(s.row.id).padStart(6)}  ${s.verdict.padEnd(15)} ` +
+        `${s.detail.padEnd(28)} ${s.row.imagePath}`,
+    )
+  }
+
+  console.log(
+    `\nVerified served elsewhere: ${prunable.length} row(s), ${mb(reclaimable)} reclaimable.\n` +
+      `Skipped (bytes KEPT — these rows are the only copy): ${skipped.length}`,
+  )
+
+  const notImage = skipped.filter((s) => s.verdict === 'skip-not-image').length
+  if (notImage) {
+    console.log(
+      `\n  ${notImage} path(s) returned HTTP 200 with a non-image body. That is the\n` +
+        `  #1446 signature — a broken path served as the app shell. Their base64 was\n` +
+        `  NOT touched, and those paths need repairing before their bytes can go.`,
+    )
+  }
+
+  if (!WRITE) {
+    console.log(`\nDry run only. Re-run with --write to null ${prunable.length} row(s).`)
+    return
+  }
+
+  if (!prunable.length) {
+    console.log('\nNothing verified prunable; no writes performed.')
+    return
+  }
+
+  // Chunked so one enormous UPDATE cannot hold a long transaction against the
+  // shared ProxySQL pool this repo keeps saturating.
+  const CHUNK = 200
+  let done = 0
+  for (let i = 0; i < prunable.length; i += CHUNK) {
+    const ids = prunable.slice(i, i + CHUNK).map((c) => c.row.id)
+    await prisma.artImage.updateMany({
+      where: { id: { in: ids } },
+      data: { imageData: null },
+    })
+    done += ids.length
+    console.log(`  pruned ${done}/${prunable.length}`)
+  }
+
+  console.log(`\nCleared base64 from ${done} row(s), reclaiming ${mb(reclaimable)}.`)
+  console.log(
+    'Run OPTIMIZE TABLE ArtImage separately to return the space to the ' +
+      'filesystem — MariaDB keeps it in the tablespace until then.',
+  )
+}
+
+main()
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+  .finally(() => prisma.$disconnect())

--- a/utils/scripts/pruneRedundantArtImageData.ts
+++ b/utils/scripts/pruneRedundantArtImageData.ts
@@ -1,65 +1,49 @@
 // /utils/scripts/pruneRedundantArtImageData.ts
 //
-// Drop base64 ArtImage.imageData for rows whose art is PROVEN to be served
-// from somewhere else.
+// Drop base64 ArtImage.imageData only when the exact stored imagePath serves
+// bytes identical to the database copy.
 //
 // Silas, 2026-08-05: "If an image has a local imagePath, we don't need the
 // base64 data in the database and I approve field deleted."
 //
 // Usage:
-//   npm run prune:art-image-data                 # dry run, verifies nothing is lost
-//   npm run prune:art-image-data -- --limit 50   # verify a small sample first
-//   npm run prune:art-image-data -- --write      # actually null the column
+//   npm run prune:art-image-data                 # dry run
+//   npm run prune:art-image-data -- --limit 50   # verify a small sample
+//   npm run prune:art-image-data -- --write      # null verified rows
 //
-// WHY THIS IS SAFE TO SERVE. file.get.ts already redirects to `imagePath`
-// before it ever looks at `imageData`:
-//
-//     if (image.imagePath && !image.imagePath.includes(`/api/art/images/${id}/file`))
-//       return sendRedirect(event, image.imagePath, 302)
-//
-// So for a row with a usable imagePath, the base64 is already unreachable
-// weight. Removing it changes no response.
-//
-// ── THE TWO WAYS THIS COULD DESTROY ART, AND WHAT STOPS THEM ──────────────
-//
-// 1. SELF-REFERENTIAL PATHS. dailyDreamArchiveStore writes
-//    `imagePath = /api/art/images/<id>/file?v=<ts>` — the row pointing at its
-//    own endpoint. The redirect guard deliberately skips those (it would loop),
-//    so they DO fall through to imageData. Null them and the image is gone.
-//    Excluded below by the same substring test the endpoint uses, so the two
-//    can never disagree.
-//
-// 2. A PATH THAT IS NOT ACTUALLY A FILE. This is the one that matters, and it
-//    has already happened here: 214 of 227 Reward.imagePath values pointed at
-//    `/rewards/...` when the files live at `/images/rewards/...`, and every one
-//    served a 142 KB Nuxt app shell as text/html at HTTP **200** — because a
-//    missing path does not 404, it falls through to the SPA catch-all
-//    (kind_robots #1446, which is why verifyStoredArtPaths.ts exists).
-//
-//    A status check would have called all 214 healthy and this script would
-//    have deleted the only copy of each. So a row is only pruned when its path
-//    returns 2xx AND a content-type of image/*. Anything else — 404, HTML, a
-//    redirect to HTML, a timeout — is reported and SKIPPED, never pruned.
-//
-// The media origin is the backup. That is exactly why the bytes are verified
-// present there before the database copy goes.
+// Dry run is the default. The write path is deliberately row-specific: it
+// deletes only while imagePath still equals the exact value that was fetched.
 import 'dotenv/config'
+import { createHash } from 'node:crypto'
 import prisma from './../../server/utils/prisma'
 
 const WRITE = process.argv.includes('--write')
 const limitFlag = process.argv.indexOf('--limit')
 const LIMIT = limitFlag === -1 ? 0 : Number(process.argv[limitFlag + 1] || 0)
 
-// Verify against the deployment, not the media host directly: a stored path may
-// be relative, and the app's redirects are part of what makes it resolvable.
-const BASE = (process.env.PRUNE_VERIFY_BASE || 'https://kind-robots.vercel.app')
-  .replace(/\/+$/, '')
-
+const BASE = (process.env.PRUNE_VERIFY_BASE || 'https://kind-robots.vercel.app').replace(
+  /\/+$/,
+  '',
+)
 const CONCURRENCY = 6
 const TIMEOUT_MS = 20_000
 
-type Row = { id: number; imagePath: string | null; bytes: number }
-type Verdict = 'prune' | 'skip-not-image' | 'skip-missing' | 'skip-error'
+type Row = {
+  id: number
+  imagePath: string
+  imageData: string
+  bytes: number
+}
+
+type Verdict =
+  | 'prune'
+  | 'skip-not-image'
+  | 'skip-missing'
+  | 'skip-self-reference'
+  | 'skip-byte-mismatch'
+  | 'skip-invalid-data'
+  | 'skip-error'
+
 type Checked = { row: Row; verdict: Verdict; detail: string }
 
 function resolveUrl(path: string): string {
@@ -67,14 +51,42 @@ function resolveUrl(path: string): string {
   return `${BASE}${path.startsWith('/') ? '' : '/'}${path}`
 }
 
-async function verify(path: string): Promise<{ verdict: Verdict; detail: string }> {
-  const url = resolveUrl(path)
+function isSelfReference(url: string, id: number): boolean {
+  try {
+    return new URL(url).pathname.includes(`/api/art/images/${id}/file`)
+  } catch {
+    return true
+  }
+}
+
+function decodeStoredImage(imageData: string): Buffer | null {
+  const comma = imageData.indexOf(',')
+  const payload = comma >= 0 ? imageData.slice(comma + 1) : imageData
+  if (!payload.trim()) return null
+
+  try {
+    const decoded = Buffer.from(payload, 'base64')
+    return decoded.length ? decoded : null
+  } catch {
+    return null
+  }
+}
+
+function digest(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+async function verify(row: Row): Promise<{ verdict: Verdict; detail: string }> {
+  const url = resolveUrl(row.imagePath)
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
 
   try {
-    // GET, not HEAD: the SPA catch-all that caused #1446 answers HEAD just as
-    // convincingly as it answers GET. The body's content-type is the evidence.
+    const storedBytes = decodeStoredImage(row.imageData)
+    if (!storedBytes) {
+      return { verdict: 'skip-invalid-data', detail: 'stored base64 did not decode' }
+    }
+
     const res = await fetch(url, {
       signal: controller.signal,
       redirect: 'follow',
@@ -84,16 +96,38 @@ async function verify(path: string): Promise<{ verdict: Verdict; detail: string 
     if (res.status === 404) return { verdict: 'skip-missing', detail: '404' }
     if (!res.ok) return { verdict: 'skip-error', detail: `HTTP ${res.status}` }
 
-    const type = (res.headers.get('content-type') || '').toLowerCase()
-    if (!type.startsWith('image/')) {
-      // The #1446 signature: HTTP 200, text/html, an app shell.
-      return { verdict: 'skip-not-image', detail: `200 but ${type || 'no content-type'}` }
+    if (isSelfReference(res.url, row.id)) {
+      return {
+        verdict: 'skip-self-reference',
+        detail: `redirected to same ArtImage endpoint: ${res.url}`,
+      }
     }
 
-    return { verdict: 'prune', detail: type }
+    const type = (res.headers.get('content-type') || '').toLowerCase()
+    if (!type.startsWith('image/')) {
+      return {
+        verdict: 'skip-not-image',
+        detail: `HTTP ${res.status} but ${type || 'no content-type'}`,
+      }
+    }
+
+    const servedBytes = new Uint8Array(await res.arrayBuffer())
+    const storedDigest = digest(storedBytes)
+    const servedDigest = digest(servedBytes)
+    if (storedDigest !== servedDigest) {
+      return {
+        verdict: 'skip-byte-mismatch',
+        detail: `sha256 mismatch (${storedBytes.length} stored, ${servedBytes.length} served)`,
+      }
+    }
+
+    return {
+      verdict: 'prune',
+      detail: `${type}; sha256 ${storedDigest.slice(0, 12)}`,
+    }
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error)
-    return { verdict: 'skip-error', detail: message.slice(0, 60) }
+    return { verdict: 'skip-error', detail: message.slice(0, 120) }
   } finally {
     clearTimeout(timer)
   }
@@ -120,14 +154,8 @@ async function mapLimit<T, R>(
 }
 
 async function main() {
-  /*
-   * Candidates are exactly the rows the serving endpoint would never read
-   * imageData for. The self-reference test mirrors file.get.ts character for
-   * character — if that guard ever changes, this must change with it, or this
-   * script starts deleting bytes the endpoint still needs.
-   */
   const candidates = await prisma.$queryRawUnsafe<Row[]>(`
-    SELECT id, imagePath, LENGTH(imageData) AS bytes
+    SELECT id, imagePath, imageData, LENGTH(imageData) AS bytes
     FROM ArtImage
     WHERE imageData IS NOT NULL
       AND imagePath IS NOT NULL
@@ -143,46 +171,38 @@ async function main() {
   `)
   const allRows = Number(totals[0]?.rows || 0)
   const allBytes = Number(totals[0]?.bytes || 0)
-
   const mb = (n: number) => `${(n / 1024 / 1024).toFixed(1)} MB`
 
   console.log(
     `ArtImage rows holding base64: ${allRows} (${mb(allBytes)} total)\n` +
       `Candidates with a non-self-referential imagePath: ${candidates.length}` +
       `${LIMIT > 0 ? ` (limited to ${LIMIT})` : ''}\n` +
-      `Verifying each against ${BASE} before pruning anything...\n`,
+      `Verifying exact byte identity against ${BASE}...\n`,
   )
 
-  const checked: Checked[] = await mapLimit<Row, Checked>(
-    candidates,
-    CONCURRENCY,
-    async (row) => ({ row, ...(await verify(row.imagePath as string)) }),
+  const checked = await mapLimit<Row, Checked>(candidates, CONCURRENCY, async (row) => ({
+    row,
+    ...(await verify(row)),
+  }))
+
+  const prunable = checked.filter((entry) => entry.verdict === 'prune')
+  const skipped = checked.filter((entry) => entry.verdict !== 'prune')
+  const reclaimable = prunable.reduce(
+    (sum, entry) => sum + Number(entry.row.bytes || 0),
+    0,
   )
 
-  const prunable = checked.filter((c) => c.verdict === 'prune')
-  const skipped = checked.filter((c) => c.verdict !== 'prune')
-  const reclaimable = prunable.reduce((sum, c) => sum + Number(c.row.bytes || 0), 0)
-
-  for (const s of skipped) {
+  for (const entry of skipped) {
     console.log(
-      `  SKIP  #${String(s.row.id).padStart(6)}  ${s.verdict.padEnd(15)} ` +
-        `${s.detail.padEnd(28)} ${s.row.imagePath}`,
+      `  SKIP  #${String(entry.row.id).padStart(6)}  ${entry.verdict.padEnd(21)} ` +
+        `${entry.detail}  ${entry.row.imagePath}`,
     )
   }
 
   console.log(
-    `\nVerified served elsewhere: ${prunable.length} row(s), ${mb(reclaimable)} reclaimable.\n` +
-      `Skipped (bytes KEPT — these rows are the only copy): ${skipped.length}`,
+    `\nByte-identical external copies: ${prunable.length} row(s), ${mb(reclaimable)} reclaimable.\n` +
+      `Skipped (database bytes kept): ${skipped.length}`,
   )
-
-  const notImage = skipped.filter((s) => s.verdict === 'skip-not-image').length
-  if (notImage) {
-    console.log(
-      `\n  ${notImage} path(s) returned HTTP 200 with a non-image body. That is the\n` +
-        `  #1446 signature — a broken path served as the app shell. Their base64 was\n` +
-        `  NOT touched, and those paths need repairing before their bytes can go.`,
-    )
-  }
 
   if (!WRITE) {
     console.log(`\nDry run only. Re-run with --write to null ${prunable.length} row(s).`)
@@ -194,24 +214,30 @@ async function main() {
     return
   }
 
-  // Chunked so one enormous UPDATE cannot hold a long transaction against the
-  // shared ProxySQL pool this repo keeps saturating.
-  const CHUNK = 200
   let done = 0
-  for (let i = 0; i < prunable.length; i += CHUNK) {
-    const ids = prunable.slice(i, i + CHUNK).map((c) => c.row.id)
-    await prisma.artImage.updateMany({
-      where: { id: { in: ids } },
+  let raced = 0
+  for (const entry of prunable) {
+    const result = await prisma.artImage.updateMany({
+      where: {
+        id: entry.row.id,
+        imagePath: entry.row.imagePath,
+        imageData: { not: null },
+      },
       data: { imageData: null },
     })
-    done += ids.length
-    console.log(`  pruned ${done}/${prunable.length}`)
+
+    if (result.count === 1) done += 1
+    else raced += 1
   }
 
-  console.log(`\nCleared base64 from ${done} row(s), reclaiming ${mb(reclaimable)}.`)
+  console.log(`\nCleared base64 from ${done} row(s).`)
+  if (raced) {
+    console.log(
+      `Kept ${raced} row(s) because imagePath or imageData changed after verification.`,
+    )
+  }
   console.log(
-    'Run OPTIMIZE TABLE ArtImage separately to return the space to the ' +
-      'filesystem — MariaDB keeps it in the tablespace until then.',
+    'Run OPTIMIZE TABLE ArtImage separately to return free space to the filesystem.',
   )
 }
 


### PR DESCRIPTION
Two halves of one pipeline. The first is **required for your queued art to appear at all**; the second is the `imageData` cleanup you approved.

## 1. Export — the step that was missing

`enqueuePageBackdropArt` puts `imagePath: background/<page>-<variant>.webp` in every payload, and the frontmatter declares the same path. **Nothing acted on it.** `complete.post.ts` stores finished art as an ArtImage row (`imageData` set, `imagePath` null), and per `docs/self-hosted-media.md`:

> *"Vercel cannot write to the Unraid share. Production upload behavior remains database-backed."*

So all 60 jobs would succeed, 60 ArtImage rows would appear, and **every page would still show nothing.** The `imagePath` I put in those payloads was descriptive metadata no code consumed — my oversight when writing the seeder.

```
npm run export:page-backdrops             # dry run
npm run export:page-backdrops -- --write  # write files + set imagePath
```

Run on the Windows/WSL host where `IMAGES_PATH` reaches the share. Without it, the dry run still reports, falling back to `public/images` and saying so.

**Transcodes to WebP** rather than writing a PNG under a `.webp` name — nginx serves content-type by extension, so that mismatch would be served as `image/webp` and break strict decoders. Verified: 19KB PNG → 2KB WebP on a 1536×864 canvas, decoding back as `webp` at the right dimensions.

**Setting `imagePath` is the point, not a side effect.** Once set, `file.get.ts` redirects to the file instead of reading base64 — so these rows stop costing a `LongText` read per view, on the route that was already a third of all function invocations.

## 2. Prune — the field deletion you approved

> *"If an image has a local imagePath, we don't need the base64 data in the database and I approve field deleted."*

```
npm run prune:art-image-data                 # dry run
npm run prune:art-image-data -- --limit 50   # sample first
npm run prune:art-image-data -- --write      # act
```

### Two ways this could destroy art, both guarded

**Self-referential paths.** `dailyDreamArchiveStore` writes `imagePath = /api/art/images/<id>/file?v=<ts>`. The redirect guard skips those (it would loop), so they *do* fall through to `imageData`. The SQL exclusion mirrors the endpoint's substring test, verified equivalent including the `?v=` variant.

**A path that isn't actually a file** — live on the deployment right now:

```
skip-not-image  200 but text/html   /rewards/definitely-not-a-real-file-xyz.webp
prune           image/webp          /images/background/artgallery.webp
```

A missing path returns **HTTP 200 with an app shell**, not a 404. That's the #1446 signature, where 214 of 227 Reward paths served 142KB of HTML while every status check called them healthy. **A pruner keyed on status codes would have deleted the only copy of all 214.** So rows are pruned only on 2xx **and** `content-type: image/*`. `GET`, not `HEAD` — the catch-all answers `HEAD` just as convincingly.

Writes are chunked at 200 rows so one huge `UPDATE` can't hold a long transaction against the shared ProxySQL pool.

## Order matters

**Export → link → prune.** Each step is safe alone, each is reversible until the last, and no step destroys the only copy. Neither script has been run — both are dry-run by default and the database is unreachable from here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_