### PR TITLE
ai-art-academy/t-010: add Mannerism to academyStyles.ts (lane 4)

### DIFF
--- a/stores/seeds/academyStyles.ts
+++ b/stores/seeds/academyStyles.ts
@@ -2051,6 +2051,45 @@ export const academyStyles: AcademyStyle[] = [
         'Repaint this image in the Spanish Golden Age style: a single strong light source against a near-black or plain neutral ground (tenebrism), a restrained palette of umber, ochre, and black, sculptural clarity of form, and a quiet, solemn, devotional mood with minimal ornament. Preserve the source composition and subject.',
     },
   },
+  {
+    slug: 'mannerism',
+    name: 'Mannerism',
+    era: 'c. 1520–1580',
+    sortYear: 1520,
+    region: 'Italy',
+    keyIdeas:
+      "Mannerism grew directly out of the High Renaissance but deliberately pushed past its balance and naturalism into elegant artifice. Where Leonardo, Raphael, and Botticelli sought anatomical correctness and calm, stable compositions, Mannerist painters stretched the figure into impossibly long limbs and swan necks, twisted poses into serpentine, off-balance spirals, and cooled the palette into acidic, jewel-like color harmonies that read as sophisticated rather than natural. Faces became smooth, porcelain-cool, and faintly emotionally distant — beautiful but unreadable, a style built for court sophistication rather than devotional warmth. Working mostly for the Medici court in Florence and the papal court in Rome, Mannerist painters treated technical virtuosity as its own subject: an impossibly long neck or elongated fingers weren't mistakes, they were the point.",
+    recognitionCues: [
+      'Impossibly elongated limbs, necks, and fingers — figures stretched past anatomical correctness on purpose',
+      "Twisting, off-balance poses (the figura serpentinata) rather than the Renaissance's stable, centered stances",
+      'Smooth, cool, porcelain-like skin with a composed, faintly aloof expression — beautiful rather than warm or devotional',
+      "A restrained, acidic jewel-toned palette (cool pinks, acid greens, deep blues) rather than the Renaissance's warm earth tones",
+      "Shallow, ambiguous, or compressed pictorial space — a plain dark ground or a crowded stage rather than the Renaissance's deep, legible perspective",
+      'Technical virtuosity treated as the subject itself: the distortion reads as sophistication, not error',
+    ],
+    artists: [
+      {
+        name: 'Agnolo Bronzino',
+        years: '1503–1572',
+        note: "Medici court portraitist; this lesson's clearest generation-style anchor for cool, smooth, emotionally composed court portraiture.",
+      },
+      {
+        name: 'Parmigianino',
+        years: '1503–1540',
+        note: 'Pushed the movement\'s elongation furthest (his Madonna with the Long Neck is its most-cited example); this entry draws instead on one of his figure drawings.',
+      },
+      {
+        name: 'Perino del Vaga',
+        years: '1501–1547',
+        note: "A leading pupil of Raphael who carried Roman Mannerism's crowded, elegant figure groups into large-scale religious painting.",
+      },
+    ],
+    remix: {
+      mode: 'prompt',
+      template:
+        'Repaint this image as an Italian Mannerist painting: elegant, elongated figures in artificial, twisting poses, cool porcelain-smooth skin, a restrained jewel-toned palette against a plain or ambiguous dark ground, and a composed, faintly aloof emotional temperature rather than Baroque drama. Preserve the source composition and subject.',
+    },
+  },
 ]
 
 export const academyStylesBySlug: Record<string, AcademyStyle> = Object.assign(


### PR DESCRIPTION
### Task
ai-art-academy/t-010: Academy continuous improvement pass — lane 4 (curriculum depth) (kind: software)

### What changed / what I produced
- Added the Mannerism movement (`mannerism`) to `stores/seeds/academyStyles.ts`: Agnolo Bronzino (1503-1572), Parmigianino (1503-1540), and Perino del Vaga (1501-1547), with era, key ideas, recognition cues, artist notes, and a remix prompt template.
- Mirrors conductor's `curriculum-outline.md` §44 (v1.24 addition), part of the companion conductor PR.
- `exampleWorks`/`failureMode` intentionally omitted, per the established newly-added-style precedent (Tonalism, Barbizon School, Heidelberg School).

### How I verified
- All three artists verified `isPublicDomain: true` directly via the Metropolitan Museum of Art Collection API (`collectionapi.metmuseum.org`), reachable directly from this session's egress:
  - Bronzino, *Portrait of a Young Man* — object 435802, accession 29.100.16
  - Parmigianino, *Seated Figure of Mercury* — object 340445, accession 1997.154
  - Perino del Vaga, *The Holy Family with the Infant Saint John the Baptist* — object 441227, accession 2011.26
- Ran a full local `vue-tsc --noEmit -p tsconfig.json` (via `provision_kind_robots_deps.sh`): **0 errors**.
- Confirmed no duplicate slugs and a balanced diff (39 additive lines only, no other file touched).

### Stakes
reversible

### Kaizen suggestion
`list_curriculum_coverage.py` (conductor) is genuinely useful for lane-4 coverage checks but doesn't cross-check the era ranges it prints for overlaps — a small enhancement flagging two movements with overlapping era ranges *and* overlapping named artists would catch an accidental duplicate before a session spends research time on it.

### Notes for reviewer
Companion conductor PR: adds the same movement to `curriculum-outline.md` and documents a rejected Russian Constructivism candidate (rights-license failure at both Met and AIC) so a future lane-4 cycle doesn't re-research the same dead end.

---
_Generated by [Claude Code](https://claude.ai/code/session_011bDB23MJzeupLEpxAdxzKc)_