### PR TITLE
Run branch janitor immediately after PR closure

### DIFF
--- a/.github/workflows/branch-janitor.yml
+++ b/.github/workflows/branch-janitor.yml
@@ -1,6 +1,8 @@
 name: Branch janitor
 
 on:
+  pull_request:
+    types: [closed]
   schedule:
     - cron: "23 * * * *"
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- trigger the existing branch janitor whenever a pull request closes
- retain the hourly schedule and manual dispatch fallback
- let the janitor remove merged or patch-equivalent work branches promptly instead of leaving them until the next cron run

## Why
A merged branch from PR #1500 remained present after merge. The janitor already has conservative ancestry and patch-equivalence checks, but it only ran hourly or manually. PR-close is the natural cleanup hook.

## Validation
- workflow-only change
- preserves existing `contents: write`, full-history checkout, concurrency guard, dry-run input, and force-delete input
- no production data or application behavior changes

Session: `2026-08-05T221241Z-branch-janitor-prclose-x4k9`