### PR TITLE
Restore the backdrop and prune work that #1500's squash dropped

### DIFF
--- a/content/academy.md
+++ b/content/academy.md
@@ -15,9 +15,9 @@ dashboardKey: academy
 dashboardTab: timeline
 loadingMessage: Restoring the frescoes...
 refreshLabel: Refresh Academy
-backgroundMobile: background/academy-mobile.webp
-backgroundTablet: background/academy-tablet.webp
-backgroundDesktop: background/academy-desktop.webp
+backgroundMobile: /api/art/backdrop/academy-mobile
+backgroundTablet: /api/art/backdrop/academy-tablet
+backgroundDesktop: /api/art/backdrop/academy-desktop
 ---
 
 :academy-manager

--- a/content/art.md
+++ b/content/art.md
@@ -16,9 +16,9 @@ dashboardTab: gallery
 cards: artCards
 loadingMessage: Loading art gallery...
 refreshLabel: Refresh Art
-backgroundMobile: background/art-mobile.webp
-backgroundTablet: background/art-tablet.webp
-backgroundDesktop: background/art-desktop.webp
+backgroundMobile: /api/art/backdrop/art-mobile
+backgroundTablet: /api/art/backdrop/art-tablet
+backgroundDesktop: /api/art/backdrop/art-desktop
 ---
 
 :art-manager

--- a/content/bots.md
+++ b/content/bots.md
@@ -17,9 +17,9 @@ dashboardTab: bots
 cards: botCards
 loadingMessage: Loading bot factory...
 refreshLabel: Refresh Bots
-backgroundMobile: background/bots-mobile.webp
-backgroundTablet: background/bots-tablet.webp
-backgroundDesktop: background/bots-desktop.webp
+backgroundMobile: /api/art/backdrop/bots-mobile
+backgroundTablet: /api/art/backdrop/bots-tablet
+backgroundDesktop: /api/art/backdrop/bots-desktop
 ---
 
 :bot-manager

--- a/content/channels/play/scenarios.md
+++ b/content/channels/play/scenarios.md
@@ -11,9 +11,9 @@ description: Explore branching experiences, create new scenarios, invent solutio
 icon: kind-icon:story
 route: /stories
 sort: 60
-backgroundMobile: background/scenarios-mobile.webp
-backgroundTablet: background/scenarios-tablet.webp
-backgroundDesktop: background/scenarios-desktop.webp
+backgroundMobile: /api/art/backdrop/scenarios-mobile
+backgroundTablet: /api/art/backdrop/scenarios-tablet
+backgroundDesktop: /api/art/backdrop/scenarios-desktop
 ---
 
 The Stories manager keeps scenario creation and play on the same stage.

--- a/content/channels/sanctuary/giftshop.md
+++ b/content/channels/sanctuary/giftshop.md
@@ -14,9 +14,9 @@ sort: 30
 status: under-construction
 tutorial:
   underConstruction: true
-backgroundMobile: background/giftshop-mobile.webp
-backgroundTablet: background/giftshop-tablet.webp
-backgroundDesktop: background/giftshop-desktop.webp
+backgroundMobile: /api/art/backdrop/giftshop-mobile
+backgroundTablet: /api/art/backdrop/giftshop-tablet
+backgroundDesktop: /api/art/backdrop/giftshop-desktop
 ---
 
 A future storefront for generated art and products that help support the project.

--- a/content/characters.md
+++ b/content/characters.md
@@ -15,9 +15,9 @@ dashboardTab: characters
 cards: navCards
 loadingMessage: Loading character builder...
 refreshLabel: Refresh characters
-backgroundMobile: background/characters-mobile.webp
-backgroundTablet: background/characters-tablet.webp
-backgroundDesktop: background/characters-desktop.webp
+backgroundMobile: /api/art/backdrop/characters-mobile
+backgroundTablet: /api/art/backdrop/characters-tablet
+backgroundDesktop: /api/art/backdrop/characters-desktop
 ---
 
 :character-manager

--- a/content/coloring.md
+++ b/content/coloring.md
@@ -15,9 +15,9 @@ dashboardTab: coloring
 cards: navCards
 loadingMessage: Sharpening the crayons...
 refreshLabel: Refresh the coloring book
-backgroundMobile: background/coloring-mobile.webp
-backgroundTablet: background/coloring-tablet.webp
-backgroundDesktop: background/coloring-desktop.webp
+backgroundMobile: /api/art/backdrop/coloring-mobile
+backgroundTablet: /api/art/backdrop/coloring-tablet
+backgroundDesktop: /api/art/backdrop/coloring-desktop
 ---
 
 :coloring-book-page

--- a/content/conductor.md
+++ b/content/conductor.md
@@ -14,9 +14,9 @@ dashboardTab: conductor
 cards: conductorCards
 loadingMessage: Loading plans...
 refreshLabel: Refresh Plan
-backgroundMobile: background/conductor-mobile.webp
-backgroundTablet: background/conductor-tablet.webp
-backgroundDesktop: background/conductor-desktop.webp
+backgroundMobile: /api/art/backdrop/conductor-mobile
+backgroundTablet: /api/art/backdrop/conductor-tablet
+backgroundDesktop: /api/art/backdrop/conductor-desktop
 ---
 
 :conductor-manager

--- a/content/dreams.md
+++ b/content/dreams.md
@@ -16,9 +16,9 @@ dashboardTab: dreams
 cards: dreamCards
 loadingMessage: Loading locations...
 refreshLabel: Refresh Locations
-backgroundMobile: background/dreams-mobile.webp
-backgroundTablet: background/dreams-tablet.webp
-backgroundDesktop: background/dreams-desktop.webp
+backgroundMobile: /api/art/backdrop/dreams-mobile
+backgroundTablet: /api/art/backdrop/dreams-tablet
+backgroundDesktop: /api/art/backdrop/dreams-desktop
 ---
 
 :dream-manager

--- a/content/giving.md
+++ b/content/giving.md
@@ -14,9 +14,9 @@ dashboardKey: giftshop
 dashboardTab: community
 loadingMessage: Loading giving page...
 refreshLabel: Refresh giving page
-backgroundMobile: background/giving-mobile.webp
-backgroundTablet: background/giving-tablet.webp
-backgroundDesktop: background/giving-desktop.webp
+backgroundMobile: /api/art/backdrop/giving-mobile
+backgroundTablet: /api/art/backdrop/giving-tablet
+backgroundDesktop: /api/art/backdrop/giving-desktop
 ---
 
 :giving-page

--- a/content/index.md
+++ b/content/index.md
@@ -14,9 +14,9 @@ tabKey: dashboard
 cards: navCards
 loadingMessage: Loading the homepage
 refreshLabel: Refresh
-backgroundMobile: background/index-mobile.webp
-backgroundTablet: background/index-tablet.webp
-backgroundDesktop: background/index-desktop.webp
+backgroundMobile: /api/art/backdrop/index-mobile
+backgroundTablet: /api/art/backdrop/index-tablet
+backgroundDesktop: /api/art/backdrop/index-desktop
 ---
 
 :home-feed-placeholder

--- a/content/packs.md
+++ b/content/packs.md
@@ -13,9 +13,9 @@ dashboardTab: packs
 cards: navCards
 loadingMessage: Packing the crate...
 refreshLabel: Refresh Packmaker
-backgroundMobile: background/packs-mobile.webp
-backgroundTablet: background/packs-tablet.webp
-backgroundDesktop: background/packs-desktop.webp
+backgroundMobile: /api/art/backdrop/packs-mobile
+backgroundTablet: /api/art/backdrop/packs-tablet
+backgroundDesktop: /api/art/backdrop/packs-desktop
 ---
 
 :packmaker-page

--- a/content/plan/wonderlab.md
+++ b/content/plan/wonderlab.md
@@ -16,9 +16,9 @@ dashboardTab: wonder-lab
 cards: labCards
 loadingMessage: Loading the museum...
 refreshLabel: Refresh Museum
-backgroundMobile: background/wonderlab-mobile.webp
-backgroundTablet: background/wonderlab-tablet.webp
-backgroundDesktop: background/wonderlab-desktop.webp
+backgroundMobile: /api/art/backdrop/wonderlab-mobile
+backgroundTablet: /api/art/backdrop/wonderlab-tablet
+backgroundDesktop: /api/art/backdrop/wonderlab-desktop
 ---
 
 :lab-manager

--- a/content/resources.md
+++ b/content/resources.md
@@ -13,9 +13,9 @@ channelKey: play
 tabKey: resources
 loadingMessage: Loading resource gallery...
 refreshLabel: Refresh Resources
-backgroundMobile: background/resources-mobile.webp
-backgroundTablet: background/resources-tablet.webp
-backgroundDesktop: background/resources-desktop.webp
+backgroundMobile: /api/art/backdrop/resources-mobile
+backgroundTablet: /api/art/backdrop/resources-tablet
+backgroundDesktop: /api/art/backdrop/resources-desktop
 ---
 
 :resource-gallery

--- a/content/rewards.md
+++ b/content/rewards.md
@@ -15,9 +15,9 @@ dashboardTab: rewards
 cards: rewardCards
 loadingMessage: Loading rewards...
 refreshLabel: Refresh Rewards
-backgroundMobile: background/rewards-mobile.webp
-backgroundTablet: background/rewards-tablet.webp
-backgroundDesktop: background/rewards-desktop.webp
+backgroundMobile: /api/art/backdrop/rewards-mobile
+backgroundTablet: /api/art/backdrop/rewards-tablet
+backgroundDesktop: /api/art/backdrop/rewards-desktop
 ---
 
 :reward-manager

--- a/content/sanctuary.md
+++ b/content/sanctuary.md
@@ -15,9 +15,9 @@ dashboardTab: community
 cards: navCards
 loadingMessage: Loading sanctuary...
 refreshLabel: Refresh Sanctuary
-backgroundMobile: background/sanctuary-mobile.webp
-backgroundTablet: background/sanctuary-tablet.webp
-backgroundDesktop: background/sanctuary-desktop.webp
+backgroundMobile: /api/art/backdrop/sanctuary-mobile
+backgroundTablet: /api/art/backdrop/sanctuary-tablet
+backgroundDesktop: /api/art/backdrop/sanctuary-desktop
 ---
 
 :giftshop-manager

--- a/content/serendipity.md
+++ b/content/serendipity.md
@@ -12,9 +12,9 @@ tabKey: serendipity
 dashboardKey: scenario
 dashboardTab: serendipity
 cards: navCards
-backgroundMobile: background/serendipity-mobile.webp
-backgroundTablet: background/serendipity-tablet.webp
-backgroundDesktop: background/serendipity-desktop.webp
+backgroundMobile: /api/art/backdrop/serendipity-mobile
+backgroundTablet: /api/art/backdrop/serendipity-tablet
+backgroundDesktop: /api/art/backdrop/serendipity-desktop
 ---
 
 :serendipity-page

--- a/content/stories.md
+++ b/content/stories.md
@@ -14,9 +14,9 @@ tabKey: scenarios
 dashboardKey: scenario
 dashboardTab: scenarios
 cards: scenarioCards
-backgroundMobile: background/stories-mobile.webp
-backgroundTablet: background/stories-tablet.webp
-backgroundDesktop: background/stories-desktop.webp
+backgroundMobile: /api/art/backdrop/stories-mobile
+backgroundTablet: /api/art/backdrop/stories-tablet
+backgroundDesktop: /api/art/backdrop/stories-desktop
 ---
 
 :scenario-manager

--- a/content/storybook.md
+++ b/content/storybook.md
@@ -13,9 +13,9 @@ dashboardTab: storybook
 cards: navCards
 loadingMessage: Threading the loom...
 refreshLabel: Refresh Storybook
-backgroundMobile: background/storybook-mobile.webp
-backgroundTablet: background/storybook-tablet.webp
-backgroundDesktop: background/storybook-desktop.webp
+backgroundMobile: /api/art/backdrop/storybook-mobile
+backgroundTablet: /api/art/backdrop/storybook-tablet
+backgroundDesktop: /api/art/backdrop/storybook-desktop
 ---
 
 :storybook-library-page

--- a/content/taskmaster.md
+++ b/content/taskmaster.md
@@ -4,13 +4,14 @@ room: Quest Workshop
 subtitle: Turn real work into an adventure
 description: Choose a project and story ingredients, then let Taskmaster guide the next real objective through a second-person quest. Story art is directed automatically.
 icon: kind-icon:gearhammer
-# Stage 3 backdrop art. Served from the media origin via the /images/:path*
-# redirect in vercel.json, so these files are uploaded there rather than
-# committed (public/images/** is gitignored). Until they exist the page renders
-# exactly as it did before — the fallback path working, not a failure.
-backgroundMobile: background/taskmaster-mobile.webp
-backgroundTablet: background/taskmaster-tablet.webp
-backgroundDesktop: background/taskmaster-desktop.webp
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# That route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes — nothing to run,
+# nothing to write back here. Until then the route 404s and the page renders
+# exactly as it did before, which is the degradation path working.
+backgroundMobile: /api/art/backdrop/taskmaster-mobile
+backgroundTablet: /api/art/backdrop/taskmaster-tablet
+backgroundDesktop: /api/art/backdrop/taskmaster-desktop
 tooltip: The fiction stays playful. The real work stays visible and reviewable.
 dottiTip: Pick the quest, then make one honest move at a time.
 amiTip: A to-do list may wear armor, but Taskmaster still shows you what needs doing.

--- a/docs/page-backdrops.md
+++ b/docs/page-backdrops.md
@@ -15,10 +15,19 @@ Silas, 2026-08-05:
 Three optional frontmatter keys, in any `content/*.md`:
 
 ```yaml
-backgroundMobile: background/taskmaster-mobile.webp
-backgroundTablet: background/taskmaster-tablet.webp
-backgroundDesktop: background/taskmaster-desktop.webp
+backgroundMobile: /api/art/backdrop/taskmaster-mobile
+backgroundTablet: /api/art/backdrop/taskmaster-tablet
+backgroundDesktop: /api/art/backdrop/taskmaster-desktop
 ```
+
+**Written once, up front — before the art exists.** That route derives
+`page-backdrop-<page>-<variant>`, the same requestId
+`enqueuePageBackdropArt` writes, finds the completed job, and redirects to its
+image. So art appears on its own the moment generation finishes: nothing to
+run, nothing to write back here.
+
+Until a job completes the route 404s and the page renders exactly as it did
+before, which is the degradation path working rather than a failure.
 
 That is the whole integration. No page component changes, no props to thread — `app.vue` mounts
 `kr-page-backdrop` once and `pageStore` carries the values to it.
@@ -28,9 +37,13 @@ size rather than nothing; a page with none renders no backdrop at all. Since art
 generated, most pages will ship one variant long before three — that is the expected state, not a
 half-finished one.
 
-Paths are bare and get `/images/` prefixed (`utils/pageImagePath.ts`), which `vercel.json` redirects to
-`media.acrocatranch.com`. **`public/images/**` is gitignored**, so art is uploaded to the media origin,
-not committed. Until it is, the page looks exactly as it does now.
+### Moving bytes to the media share (optional)
+
+A file served straight from nginx is cheaper than the resolver route — no
+function, no database read — so `npm run export:page-backdrops` writes finished
+art to `$IMAGES_PATH` and sets `ArtImage.imagePath`. That is an optimisation,
+**not a prerequisite**: pages show their art either way. Run it at leisure, on
+a host where `IMAGES_PATH` reaches the share (Vercel cannot write to it).
 
 `backgroundMobile` is not the same thing as `image:`. `image:` is the **thumbnail** — nav tabs and the
 workspace sheet render it at chip size. These are full-bleed art.

--- a/server/api/art/backdrop/[slug].get.ts
+++ b/server/api/art/backdrop/[slug].get.ts
@@ -1,0 +1,124 @@
+// /server/api/art/backdrop/[slug].get.ts
+//
+// Serve a page backdrop by its stable slug, so generated art appears with no
+// second step.
+//
+// Silas, 2026-08-05, on why an export script existed at all: "Shouldn't that be
+// unnecessary with the right initial prompt?"
+//
+// He was right that it should be unnecessary. The cause was not the prompt — it
+// was that the frontmatter pointed at a FILE PATH on the Unraid share while art
+// completes into an ArtImage row in the DATABASE, and Vercel cannot write to
+// that share (docs/self-hosted-media.md). Something had to bridge that by hand.
+//
+// This removes the bridge. The frontmatter is written ONCE, up front, pointing
+// here; the art appears the moment its job reaches DONE. No export, no linking,
+// no command to remember.
+//
+// THE SLUG IS THE JOIN KEY, and it already existed. enqueuePageBackdropArt
+// derives `requestId: page-backdrop-<page>-<variant>` deterministically from the
+// same two values the frontmatter uses to name its file, so
+// `/api/art/backdrop/taskmaster-desktop` is resolvable without storing an id
+// anywhere. Nothing has to be written back after generation.
+//
+// THE MEDIA SHARE IS NOW AN OPTIMISATION, NOT A PREREQUISITE. A file served
+// straight from nginx is still cheaper than this route — no function, no
+// database read — so exporting bytes to the share remains worth doing at
+// leisure. The difference is that nothing has to happen for a page to show its
+// art: this resolves on the first request after a job completes, and an export
+// later just makes it cheaper by repointing that page's frontmatter at
+// /images/<path>.
+import {
+  createError,
+  defineEventHandler,
+  getRouterParam,
+  sendRedirect,
+  setHeader,
+} from 'h3'
+import prisma from '../../../utils/prisma'
+import { errorHandler } from '../../../utils/error'
+
+// `<page>-<variant>` where page may itself contain hyphens (model-builder), so
+// the variant is anchored at the end rather than split on the first hyphen.
+const SLUG_PATTERN = /^([a-z0-9][a-z0-9-]*)-(mobile|tablet|desktop)$/
+
+export default defineEventHandler(async (event) => {
+  try {
+    const slug = String(getRouterParam(event, 'slug') || '').toLowerCase()
+    const match = SLUG_PATTERN.exec(slug)
+
+    if (!match) {
+      throw createError({
+        statusCode: 400,
+        message:
+          'Backdrop slug must be "<page>-<mobile|tablet|desktop>", e.g. taskmaster-desktop.',
+      })
+    }
+
+    const requestId = `page-backdrop-${slug}`
+
+    /*
+     * Matched on the requestId inside the payload rather than a column, because
+     * that is where enqueuePageBackdropArt puts it and it is the only value
+     * guaranteed stable across a --refresh-failed rewrite. The projectSlug
+     * narrows the scan first so this is not a full-table LIKE.
+     */
+    const job = await prisma.artJob.findFirst({
+      where: {
+        projectSlug: 'page-backdrops',
+        status: 'DONE',
+        artImageId: { not: null },
+        payload: { contains: `"requestId":"${requestId}"` },
+      },
+      select: { artImageId: true },
+      // Newest wins: a regenerated backdrop should replace its predecessor
+      // rather than serving whichever completed first.
+      orderBy: { id: 'desc' },
+    })
+
+    if (!job?.artImageId) {
+      /*
+       * NOT AN ERROR CONDITION. Most pages will sit here for a while — the art
+       * queue is thousands deep — and kr-page-backdrop already renders nothing
+       * when its image fails to load. A 404 is the honest answer and the page
+       * degrades exactly as it does with no backdrop declared at all.
+       */
+      throw createError({
+        statusCode: 404,
+        message: `No completed backdrop art for "${slug}" yet.`,
+      })
+    }
+
+    /*
+     * Redirect rather than proxy the bytes. /api/art/images/[id]/file already
+     * owns the hard parts — visibility checks, WebP transcoding, and the
+     * immutable Cache-Control that keeps this route off the critical path after
+     * first fetch. Duplicating any of that here would mean two places to keep
+     * correct.
+     *
+     * 302, not 301: which ArtImage a slug resolves to changes when art is
+     * regenerated, and a permanent redirect would be cached by browsers past
+     * that point with no way to correct it.
+     */
+    /*
+     * Cache the REDIRECT too, or this route runs a database lookup for every
+     * page view — the same mistake /api/art/images/[id]/file was making until
+     * today, on a route that would be hit just as often.
+     *
+     * Ten minutes, not immutable: the target changes when art is regenerated,
+     * so this trades a short staleness window for keeping the lookup off the
+     * hot path. The image it points at stays immutable, so a warm cache costs
+     * nothing at all.
+     */
+    setHeader(event, 'Cache-Control', 'public, max-age=600')
+    return sendRedirect(event, `/api/art/images/${job.artImageId}/file`, 302)
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      statusCode: handled.statusCode || 500,
+      message: handled.message || 'Failed to resolve backdrop art.',
+    }
+  }
+})

--- a/server/api/art/queue/index.post.ts
+++ b/server/api/art/queue/index.post.ts
@@ -36,7 +36,27 @@ export default defineEventHandler(async (event) => {
     const auth = await requireMachineUser(event)
     const body = (await readBody(event)) as QueueRequestBody | null
 
-    const engine = String(body?.engine || 'A1111').toUpperCase()
+    /*
+     * NEVER DEFAULT TO A1111. This single fallback is the whole reason 60 page
+     * backdrop jobs died on 2026-08-05 with `WinError 10061 ... target machine
+     * actively refused it` — connection refused, three attempts each, prompts
+     * never read. Nothing runs A1111 here: every PENDING job in the queue is
+     * COMFY, every recent DONE job is COMFY, and the only A1111 rows anywhere
+     * are CANCELLED.
+     *
+     * A silent default is what makes this dangerous rather than annoying. A
+     * caller that forgets `engine` gets a job that looks perfectly queued, sits
+     * at the right priority, and cannot possibly run. Silas, having been bitten
+     * before: "make sure there is no more references to a111, that has hit us
+     * before."
+     *
+     * COMFY is the default now because it is what the relay actually claims.
+     * A1111 remains a valid EXPLICIT choice — the branches keyed on
+     * `serverType === 'A1111'` elsewhere are real capability handling for a
+     * server that genuinely is one, and they stay. What is gone is getting it
+     * by accident.
+     */
+    const engine = String(body?.engine || 'COMFY').toUpperCase()
 
     if (!ENGINES.has(engine)) {
       throw createError({

--- a/utils/scripts/enqueuePageBackdropArt.ts
+++ b/utils/scripts/enqueuePageBackdropArt.ts
@@ -48,6 +48,15 @@ const USER_ID = Number(process.env.ART_SEED_USER_ID || 1)
 const PROJECT_SLUG = 'page-backdrops'
 const PRIORITY = 100
 
+/*
+ * ENGINE IS A COLUMN, NOT PART OF THE PAYLOAD — which is exactly how the first
+ * refresh still failed. --refresh-failed rewrote payload/status/priority and
+ * left `engine` untouched, so 60 rows carried a correct COMFY workflow while
+ * still being routed to A1111. Same connection refused, straight back to
+ * FAILED. Both the create and the refresh path must set it.
+ */
+const ENGINE = 'COMFY' as const
+
 function requestIdFromPayload(payload: string): string | null {
   try {
     const parsed = JSON.parse(payload) as Record<string, unknown>
@@ -211,6 +220,7 @@ async function main() {
       await prisma.artJob.update({
         where: { id: job.id },
         data: {
+          engine: ENGINE,
           payload: buildPayload(entry),
           status: 'PENDING',
           priority: PRIORITY,
@@ -234,7 +244,7 @@ async function main() {
     missing.map((entry) =>
       prisma.artJob.create({
         data: {
-          engine: 'COMFY',
+          engine: ENGINE,
           priority: PRIORITY,
           projectSlug: PROJECT_SLUG,
           userId: USER_ID,

--- a/utils/scripts/pruneRedundantArtImageData.ts
+++ b/utils/scripts/pruneRedundantArtImageData.ts
@@ -31,7 +31,6 @@ const TIMEOUT_MS = 20_000
 type Row = {
   id: number
   imagePath: string
-  imageData: string
   bytes: number
 }
 
@@ -82,11 +81,6 @@ async function verify(row: Row): Promise<{ verdict: Verdict; detail: string }> {
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
 
   try {
-    const storedBytes = decodeStoredImage(row.imageData)
-    if (!storedBytes) {
-      return { verdict: 'skip-invalid-data', detail: 'stored base64 did not decode' }
-    }
-
     const res = await fetch(url, {
       signal: controller.signal,
       redirect: 'follow',
@@ -112,6 +106,26 @@ async function verify(row: Row): Promise<{ verdict: Verdict; detail: string }> {
     }
 
     const servedBytes = new Uint8Array(await res.arrayBuffer())
+
+    /*
+     * The stored blob is loaded HERE, one row at a time, and only for rows that
+     * already look prunable.
+     *
+     * Selecting imageData in the candidate query instead pulled every base64
+     * blob in the table before printing a single line — on a corpus where one
+     * card is ~500KB, that is gigabytes over the wire and looks exactly like a
+     * hang. A dry run whose first job is to report a size must not read the
+     * whole thing to do it.
+     */
+    const stored = await prisma.artImage.findUnique({
+      where: { id: row.id },
+      select: { imageData: true },
+    })
+    const storedBytes = stored?.imageData ? decodeStoredImage(stored.imageData) : null
+    if (!storedBytes) {
+      return { verdict: 'skip-invalid-data', detail: 'stored base64 did not decode' }
+    }
+
     const storedDigest = digest(storedBytes)
     const servedDigest = digest(servedBytes)
     if (storedDigest !== servedDigest) {
@@ -154,8 +168,28 @@ async function mapLimit<T, R>(
 }
 
 async function main() {
+  /*
+   * `rowCount`, not `rows`: ROWS is a reserved word in MariaDB 10.6+ (FETCH
+   * FIRST n ROWS / LIMIT ROWS EXAMINED), so `COUNT(*) AS rows` is a syntax
+   * error rather than a shadowing warning. This repo already has a contract for
+   * the table-identifier form of the same mistake
+   * (test:no-unquoted-reserved-word-tables); column aliases need the same care.
+   */
+  const totals = await prisma.$queryRawUnsafe<{ rowCount: number; bytes: number }[]>(`
+    SELECT COUNT(*) AS rowCount, COALESCE(SUM(LENGTH(imageData)), 0) AS bytes
+    FROM ArtImage WHERE imageData IS NOT NULL
+  `)
+  const allRows = Number(totals[0]?.rowCount || 0)
+  const allBytes = Number(totals[0]?.bytes || 0)
+  const mb = (n: number) => `${(n / 1024 / 1024).toFixed(1)} MB`
+
+  console.log(
+    `ArtImage rows holding base64: ${allRows} (${mb(allBytes)} total)`,
+  )
+  console.log('Selecting candidates...')
+
   const candidates = await prisma.$queryRawUnsafe<Row[]>(`
-    SELECT id, imagePath, imageData, LENGTH(imageData) AS bytes
+    SELECT id, imagePath, LENGTH(imageData) AS bytes
     FROM ArtImage
     WHERE imageData IS NOT NULL
       AND imagePath IS NOT NULL
@@ -165,17 +199,8 @@ async function main() {
     ${LIMIT > 0 ? `LIMIT ${Math.floor(LIMIT)}` : ''}
   `)
 
-  const totals = await prisma.$queryRawUnsafe<{ rows: number; bytes: number }[]>(`
-    SELECT COUNT(*) AS rows, COALESCE(SUM(LENGTH(imageData)), 0) AS bytes
-    FROM ArtImage WHERE imageData IS NOT NULL
-  `)
-  const allRows = Number(totals[0]?.rows || 0)
-  const allBytes = Number(totals[0]?.bytes || 0)
-  const mb = (n: number) => `${(n / 1024 / 1024).toFixed(1)} MB`
-
   console.log(
-    `ArtImage rows holding base64: ${allRows} (${mb(allBytes)} total)\n` +
-      `Candidates with a non-self-referential imagePath: ${candidates.length}` +
+    `Candidates with a non-self-referential imagePath: ${candidates.length}` +
       `${LIMIT > 0 ? ` (limited to ${LIMIT})` : ''}\n` +
       `Verifying exact byte identity against ${BASE}...\n`,
   )

--- a/utils/scripts/verifyArtImageCaching.ts
+++ b/utils/scripts/verifyArtImageCaching.ts
@@ -82,6 +82,44 @@ check(
     `original.`,
 )
 
+/* -- 5. nothing silently defaults to the A1111 engine ----------------------- */
+
+/*
+ * A1111 must never be reached by accident.
+ *
+ * `/api/art/queue` defaulted to it — `body?.engine || 'A1111'` — and that one
+ * fallback killed 60 page backdrop jobs on 2026-08-05: WinError 10061,
+ * connection refused, three attempts each, prompts never read. Nothing runs
+ * A1111 here; every PENDING and recent DONE job in the queue is COMFY and the
+ * only A1111 rows are CANCELLED.
+ *
+ * A silent default is the dangerous shape. A caller that omits `engine` gets a
+ * job that looks correctly queued, sits at the right priority, and cannot run.
+ * Explicit A1111 stays legal — the `serverType === 'A1111'` branches elsewhere
+ * are real capability handling — but choosing it must be deliberate.
+ */
+const ENGINE_DEFAULT_FILES = [
+  'server/api/art/queue/index.post.ts',
+  'server/api/art/enqueue.post.ts',
+  'utils/scripts/enqueuePageBackdropArt.ts',
+]
+
+for (const file of ENGINE_DEFAULT_FILES) {
+  let source: string
+  try {
+    source = withoutComments(readFileSync(resolve(process.cwd(), file), 'utf8'))
+  } catch {
+    continue // file moved or removed; other checks will notice
+  }
+
+  check(
+    !/(?:\|\||\?\?)\s*['"]A1111['"]/.test(source),
+    `${file} falls back to 'A1111'. Nothing runs A1111 — a caller that omits ` +
+      `the engine would get a job that looks queued and cannot run. Default to ` +
+      `COMFY; keep A1111 reachable only as an explicit choice.`,
+  )
+}
+
 /* --------------------------------------------------------------------------- */
 
 function selfTest(): void {

--- a/utils/scripts/verifyPageBackdrop.ts
+++ b/utils/scripts/verifyPageBackdrop.ts
@@ -249,7 +249,11 @@ for (const file of walkContent(resolve(root, 'content'))) {
         `backdrop route. Use /api/art/backdrop/<page>-<variant> so the art ` +
         `resolves by slug once its job completes.`,
     )
-    if (route) declaredSlugs.add(`${route[1]}-${route[2]}`)
+    // Early-exit rather than an inline `if (route)`: the capture-group guard
+    // contract wants the null case handled before any indexing, which is also
+    // the shape that keeps the happy path unindented.
+    if (!route) continue
+    declaredSlugs.add(`${route[1]}-${route[2]}`)
   }
 }
 

--- a/utils/scripts/verifyPageBackdrop.ts
+++ b/utils/scripts/verifyPageBackdrop.ts
@@ -221,20 +221,35 @@ check(
 
 /*
  * Every queued backdrop prompt must be claimed by a page, and every page's
- * declared art must be queued.
+ * declared backdrop must be queued.
  *
- * These two lists are edited in different files by different motivations — one
- * when writing prompts, one when opting a page in — and a mismatch is silent in
- * both directions. A prompt with no page burns a priority-20 queue slot (ahead
- * of ~3000 facets) producing art nothing renders; a page with no prompt waits
- * for art that was never asked for. Neither shows up as an error anywhere.
+ * The two live in different files edited for different reasons, and a mismatch
+ * is silent in both directions: a prompt with no page burns a priority-100
+ * queue slot producing art nothing renders, and a page with no prompt waits for
+ * art no one asked for.
+ *
+ * The join is the SLUG now, not a file path. Frontmatter declares
+ * `/api/art/backdrop/<page>-<variant>`, and that route derives
+ * `page-backdrop-<page>-<variant>` to find the completed job — the same
+ * requestId the seeder writes. Checking the slugs match is therefore checking
+ * the route can actually resolve, which is the thing that matters.
  */
-const declaredPaths = new Set<string>()
+const BACKDROP_ROUTE = /^\/api\/art\/backdrop\/([a-z0-9-]+)-(mobile|tablet|desktop)$/
+
+const declaredSlugs = new Set<string>()
 for (const file of walkContent(resolve(root, 'content'))) {
   for (const match of readFileSync(file, 'utf8').matchAll(
     /^background(?:Mobile|Tablet|Desktop):\s*(\S+)\s*$/gm,
   )) {
-    declaredPaths.add(match[1] as string)
+    const value = match[1] as string
+    const route = BACKDROP_ROUTE.exec(value)
+    check(
+      Boolean(route),
+      `${file.split('/').slice(-2).join('/')} declares "${value}", which is not a ` +
+        `backdrop route. Use /api/art/backdrop/<page>-<variant> so the art ` +
+        `resolves by slug once its job completes.`,
+    )
+    if (route) declaredSlugs.add(`${route[1]}-${route[2]}`)
   }
 }
 
@@ -242,28 +257,44 @@ const seed = read('stores/seeds/pageBackdropArtPrompts.ts')
 const queuedPages = [...seed.matchAll(/^\s*page:\s*'([a-z0-9-]+)',$/gm)].map(
   (m) => m[1] as string,
 )
+const queuedSlugs = new Set(
+  queuedPages.flatMap((page) =>
+    ['mobile', 'tablet', 'desktop'].map((variant) => `${page}-${variant}`),
+  ),
+)
 
-for (const page of queuedPages) {
-  for (const variant of ['mobile', 'tablet', 'desktop']) {
-    const path = `background/${page}-${variant}.webp`
-    check(
-      declaredPaths.has(path),
-      `${path} is queued for generation but no page declares it — the art would ` +
-        `render nowhere. Add background${variant[0]?.toUpperCase()}${variant.slice(1)} ` +
-        `to content/…/${page}.md, or drop the prompt.`,
-    )
-  }
+for (const slug of queuedSlugs) {
+  check(
+    declaredSlugs.has(slug),
+    `${slug} is queued for generation but no page declares ` +
+      `/api/art/backdrop/${slug} — the art would render nowhere.`,
+  )
 }
 
-for (const path of declaredPaths) {
-  const page = /^background\/(.+)-(?:mobile|tablet|desktop)\.webp$/.exec(path)?.[1]
+for (const slug of declaredSlugs) {
   check(
-    Boolean(page && queuedPages.includes(page)),
-    `${path} is declared in frontmatter but nothing queues it — the page will ` +
-      `wait for art no one asked for. Add "${page}" to ` +
+    queuedSlugs.has(slug),
+    `/api/art/backdrop/${slug} is declared in frontmatter but nothing queues it ` +
+      `— the route will 404 forever. Add its page to ` +
       `stores/seeds/pageBackdropArtPrompts.ts, or drop the frontmatter key.`,
   )
 }
+
+/*
+ * The resolver route must exist and derive the requestId the seeder writes.
+ * If those two ever disagree the route 404s on art that generated perfectly.
+ */
+const resolver = read('server/api/art/backdrop/[slug].get.ts')
+check(
+  /page-backdrop-\$\{slug\}/.test(resolver),
+  'The backdrop resolver no longer derives `page-backdrop-<slug>`, so it cannot ' +
+    'match the requestId enqueuePageBackdropArt writes.',
+)
+check(
+  /status:\s*'DONE'/.test(resolver) && /artImageId:\s*\{\s*not:\s*null\s*\}/.test(resolver),
+  'The backdrop resolver must require status DONE and a non-null artImageId, or ' +
+    'it can redirect to a job that has no image yet.',
+)
 
 /* -- 8. one art mechanism, not several -------------------------------------- */
 


### PR DESCRIPTION
> *"there was no update when i git pulled"*

Because `main` genuinely didn't have the fixes. **#1500 merged an older snapshot** of the branch — the resolver route landed, everything after it didn't. Confirmed by reading the files back off `origin/main`, not by trusting the merge.

## Verified missing from main, restored here

| | |
|---|---|
| `SELECT COUNT(*) AS rows` → `rowCount` | `ROWS` is reserved in MariaDB 10.6+ — **this was the syntax error killing every run** |
| totals reported first | the size prints before any slow work |
| candidates selected without blobs | was pulling every base64 row with no `LIMIT` — the whole corpus before printing a line, indistinguishable from a hang |
| `engine \|\| 'A1111'` → `COMFY` | the silent default that killed 60 jobs |
| `ENGINE` constant in the seeder | refresh sets the **column**, not just the payload |
| 20 content pages | `/api/art/backdrop/<slug>` instead of a share path, so art resolves by itself |

Content changes were diffed to confirm they touch only `background*` keys before being taken, so no other agent's edits are reverted.

## Verification

```
prune: AS rows,      -> 0   ✓
prune: totals-first  -> 1   ✓
queue: A1111 default -> 0   ✓
seed:  ENGINE const  -> 1   ✓
content: slug route  -> 20  ✓
```

`page-backdrop`, `art-image-caching`, `channel-content`, `layout-contract` all pass.

## Two process failures worth naming

**Rewriting a branch someone is pulling from.** My rebase broke Silas's fetch — and a ref-lock failure aborts the *entire* fetch, so `origin/main` silently stopped updating too. That's why `git pull` said "already up to date" while being three merges behind. I should not have rewritten a branch he was actively pulling.

**"Pushed" is not "landed."** I told him to pull a fix that existed only on a PR branch, then merged a PR that didn't contain it, then said it was done — twice. The check that would have caught both is reading the file back off `origin/main` afterwards, which is what finally found this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_