### PR TITLE
fix(academy): clear Style Lab's upload target when leaving that tab

### DIFF
--- a/components/academy/academy-manager.vue
+++ b/components/academy/academy-manager.vue
@@ -152,6 +152,14 @@ watch(
   (tab) => {
     if (tab === 'stylelab') {
       configureStyleLabUploadTarget()
+    } else if (hasConfiguredUploadTarget.value) {
+      // Style Lab's ArtImage upload target is only meaningful while that tab
+      // is showing. Without this, switching to Timeline/Styles/Remix leaves
+      // the shared uploadStore target pointed at Style Lab's ArtImage upload,
+      // so any global upload trigger elsewhere on the page would keep
+      // offering "Upload image" for a tab the user already left.
+      uploadStore.clearTarget()
+      hasConfiguredUploadTarget.value = false
     }
 
     if (tabNeedsManagerData(tab)) {


### PR DESCRIPTION
### Task
ai-art-academy/t-010: Academy continuous improvement pass — lane 1 (front-end polish)  (kind: software)

### What changed / what I produced
- `components/academy/academy-manager.vue`: the tab watcher that configures a shared `uploadStore` target for Style Lab's ArtImage upload now also clears it when the user switches to Timeline/Styles/Remix, not only when the whole Academy manager unmounts.
- Previously, opening Style Lab then switching to any other Academy tab left the shared upload target pointed at Style Lab's ArtImage upload for as long as Academy stayed mounted — any other consumer of that shared target (e.g. a global upload trigger elsewhere on the page) would keep offering "Upload image" for a tab the user already left.

### How I verified
- `npm run test` (vue-tsc --noEmit) — exit 0, no errors.
- `npx prettier --check components/academy/academy-manager.vue` — clean.
- `npm run test:academy-style-detail-callers` — passes (unrelated caller-list invariant, ran as a sanity check since it touches the same component family).

### Stakes
reversible

### Kaizen suggestion
`academy-manager.vue`'s tab-driven upload-target lifecycle (set on entering Style Lab, clear on leaving) is a pattern other multi-tab managers with a similar shared-singleton `uploadStore` target could reuse if they ever gain more than one tab — worth a shared composable if a third manager needs it.

### Notes for reviewer
Conductor task: `ai-art-academy/t-010` (recurring continuous-improvement task, never reaches `done`). This closes out this cycle's lane 1.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1F5FkthuJuxJauuEXcKKY)_