### PR TITLE
Report where the heavy ArtImage rows came from

### DIFF
--- a/utils/scripts/inspectArtImageData.ts
+++ b/utils/scripts/inspectArtImageData.ts
@@ -85,6 +85,99 @@ async function main() {
   for (const b of buckets) {
     console.log(`   ${String(b.bucket).padEnd(16)} ${String(Number(b.n)).padStart(6)} rows   ${Number(b.mb)} MB`)
   }
+
+  /*
+   * WHERE DID THESE COME FROM? Silas, 2026-08-06: "I am a bit confused about
+   * how we seem to still have the art data in the db when we have been
+   * generating art on our box, then moving it with our kr_relay. So where are
+   * these data sets coming from? Were they old ones that never got saved
+   * locally? Or duplicate data that already probably has a local file that we
+   * never connected?"
+   *
+   * The code answers half of it: /api/art/save-generated — the relay's upload
+   * hop — contains no reference to imagePath at all, and complete.post.ts only
+   * ever sets imagePath to null. So the relay CANNOT have linked a local file,
+   * and every relayed image is base64-in-database by construction.
+   *
+   * What the code cannot say is whether that is old history or still
+   * happening. Grouping the heavy rows by month settles it: a tail that stops
+   * a year ago is a migration leftover, and one that reaches this month means
+   * the pipeline is still filling the column today.
+   */
+  const byMonth = await prisma.$queryRawUnsafe<
+    { month: string; n: number; mb: number; withPath: number }[]
+  >(`
+    SELECT DATE_FORMAT(createdAt, '%Y-%m') AS month,
+           COUNT(*) AS n,
+           ROUND(SUM(LENGTH(imageData)) / 1048576, 1) AS mb,
+           SUM(CASE WHEN imagePath IS NOT NULL AND imagePath <> '' THEN 1 ELSE 0 END) AS withPath
+    FROM ArtImage
+    WHERE imageData IS NOT NULL AND LENGTH(imageData) >= 100000
+    GROUP BY month
+    ORDER BY month DESC
+    LIMIT 18
+  `)
+
+  console.log('\nRows holding 100 KB+, by month created (newest first):')
+  console.log('   month     rows       MB   with imagePath')
+  for (const m of byMonth) {
+    console.log(
+      `   ${String(m.month).padEnd(9)} ${String(Number(m.n)).padStart(4)} ${String(Number(m.mb)).padStart(8)} ` +
+        `${String(Number(m.withPath)).padStart(8)}`,
+    )
+  }
+
+  /*
+   * serverName is stamped by save-generated from the resolved Server record,
+   * so it says which box actually rendered these — the clearest signal for
+   * "is this the relay's output or something older".
+   */
+  const byServer = await prisma.$queryRawUnsafe<
+    { serverName: string | null; n: number; mb: number }[]
+  >(`
+    SELECT COALESCE(serverName, '(none recorded)') AS serverName,
+           COUNT(*) AS n,
+           ROUND(SUM(LENGTH(imageData)) / 1048576, 1) AS mb
+    FROM ArtImage
+    WHERE imageData IS NOT NULL AND LENGTH(imageData) >= 100000
+    GROUP BY serverName
+    ORDER BY mb DESC
+    LIMIT 12
+  `)
+
+  console.log('\nRows holding 100 KB+, by generating server:')
+  for (const s of byServer) {
+    console.log(
+      `   ${String(s.serverName).padEnd(28)} ${String(Number(s.n)).padStart(5)} rows   ${Number(s.mb)} MB`,
+    )
+  }
+
+  /*
+   * fileName and path are the only other place a local filename could have
+   * been recorded. If these are populated with something file-like, a twin may
+   * exist on disk under that name and could in principle be reconnected
+   * instead of re-exported.
+   */
+  const naming = await prisma.$queryRawUnsafe<
+    { hasFileName: number; hasPath: number; sampleFileName: string | null; samplePath: string | null }[]
+  >(`
+    SELECT SUM(CASE WHEN fileName IS NOT NULL AND fileName <> '' THEN 1 ELSE 0 END) AS hasFileName,
+           SUM(CASE WHEN path IS NOT NULL AND path <> '' THEN 1 ELSE 0 END) AS hasPath,
+           MAX(fileName) AS sampleFileName,
+           MAX(path) AS samplePath
+    FROM ArtImage
+    WHERE imageData IS NOT NULL AND LENGTH(imageData) >= 100000
+  `)
+
+  const n = naming[0]
+  console.log('\nCould these be reconnected to an existing file instead of re-exported?')
+  console.log(`   rows with a fileName: ${Number(n?.hasFileName || 0)}   e.g. ${JSON.stringify(n?.sampleFileName ?? null)}`)
+  console.log(`   rows with a path:     ${Number(n?.hasPath || 0)}   e.g. ${JSON.stringify(n?.samplePath ?? null)}`)
+  console.log(
+    '   (A bare "ArtImageUpload-<timestamp>" is not a file on the share — it is\n' +
+      '    the placeholder saveImage() invents. Only a real relative path could be\n' +
+      '    reconnected.)',
+  )
 }
 
 main()


### PR DESCRIPTION
Answers "if art is generated on the box and moved by kr_relay, why is it still in the database?"

Half is answerable from the code, and the answer is neither old rows nor unconnected duplicates: **`/api/art/save-generated` — the relay's upload hop — contains no reference to `imagePath` at all**, and `complete.post.ts` only ever sets `imagePath: null` (on archive snapshots). The relay could never have linked a local file, so every relayed image is base64-in-database by construction, including ones made today. Moving files with kr_relay never touched the database copy because nothing in kind_robots was listening for it.

What the code can't say is whether that's history or ongoing. This adds three groupings to `npm run inspect:art-image-data`:

- **heavy rows by month created** — a tail that stops a year ago is a migration leftover; one reaching this month means the pipeline is still filling the column
- **by generating server** — `serverName` is stamped from the resolved Server record, so it says which box actually rendered them
- **whether `fileName`/`path` hold anything file-like** — i.e. whether a twin could be reconnected on disk instead of re-exported. A bare `ArtImageUpload-<timestamp>` is the placeholder `saveImage()` invents, not a file on the share.

Read-only; `SELECT` only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_