### PR TITLE
fix(cypress): retry cleanup DELETE on transient 5xx to stop false-red main

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -299,7 +299,45 @@ const deleteSeedUser = async (
 const cleanupKey = (request: CleanupRequest) =>
   `${request.method || 'DELETE'} ${request.url} ${request.label}`
 
-const runCleanupRequest = async (request: CleanupRequest) => {
+type CleanupResult = {
+  label: string
+  method: string
+  url: string
+  status: number
+  ok: boolean
+  body: unknown
+}
+
+const buildCleanupResult = async (
+  request: CleanupRequest,
+  response: Response,
+  ok: boolean,
+): Promise<CleanupResult> => ({
+  label: request.label,
+  method: request.method || 'DELETE',
+  url: request.url,
+  status: response.status,
+  ok,
+  body: await parseResponseBody(response),
+})
+
+// A cleanup DELETE hitting a transient 5xx (DB pool/transaction timeout under
+// load, the same class of hiccup DB_CONNECTION_FAILURE_PATTERN guards against
+// for the tests themselves) used to fail this single fetch and report the
+// user as "leaked" -- failing the whole after:run cleanup even though every
+// actual test passed (see the 2026-08-05 "Unable to start a transaction in
+// the given time" run: 480/480 tests green, job red solely on one unretried
+// cleanup DELETE). DELETE is idempotent here (expectedStatuses already
+// includes 404), so retrying with backoff is safe and turns a same-request
+// blip into a pass instead of a false-red main.
+const cleanupRetryLimit = 3
+const cleanupRetryDelayMs = 750
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const runCleanupRequest = async (
+  request: CleanupRequest,
+  attempt = 1,
+): Promise<CleanupResult> => {
   const response = await fetch(request.url, {
     method: request.method || 'DELETE',
     headers: {
@@ -309,15 +347,14 @@ const runCleanupRequest = async (request: CleanupRequest) => {
     body: request.body === undefined ? undefined : JSON.stringify(request.body),
   })
   const expectedStatuses = request.expectedStatuses || [200, 202, 204, 404]
+  const ok = expectedStatuses.includes(response.status)
 
-  return {
-    label: request.label,
-    method: request.method || 'DELETE',
-    url: request.url,
-    status: response.status,
-    ok: expectedStatuses.includes(response.status),
-    body: await parseResponseBody(response),
+  if (!ok && response.status >= 500 && attempt < cleanupRetryLimit) {
+    await sleep(cleanupRetryDelayMs * attempt)
+    return runCleanupRequest(request, attempt + 1)
   }
+
+  return buildCleanupResult(request, response, ok)
 }
 
 const deleteSweptRecord = async (


### PR DESCRIPTION
### Task
conductor Todo #1218 (CI-janitor): "Fix red CI: Kind Robots Cypress Tests" (kind: software)

### What changed / what I produced
- `runCleanupRequest` in `cypress.config.ts` (the `after:run` hook's per-test-user
  cleanup DELETE) now retries up to 3 times with backoff (750ms × attempt) when the
  response is a 5xx. The call is idempotent — `expectedStatuses` already includes
  404 — so retrying a same-request blip is safe.

### Root cause
The failing run (https://github.com/silasfelinus/kind_robots/actions/runs/31055114884,
commit `acced77`) had **all 480 Cypress tests pass** (471 passing, 9 pending, 0
failing — see "All specs passed!" in the log). The job still exited 1 because
`verify-cypress-cleanup.mjs` found one leaked test user:

```json
{
  "label": "fresh Cypress user 8673",
  "method": "DELETE",
  "url": "https://kind-robots.vercel.app/api/users/8673",
  "status": 500,
  "ok": false,
  "body": { "success": false, "message": "Database operation failed: Transaction API error: Unable to start a transaction in the given time." }
}
```

That DELETE is issued once, with no retry, by `runCleanupRequest`. A transient DB
transaction-pool timeout on that single fetch was enough to fail the whole job —
this is the same class of hiccup `DB_CONNECTION_FAILURE_PATTERN` already guards
against for the tests themselves (and matches the already-tracked ProxySQL
connection-pool capacity gap, `kindrobots-unraid/t-012`), just unhandled on the
cleanup path.

### How I verified
- `npm run test` (`nuxi prepare` + `vue-tsc --noEmit`) — passes, no new type errors.
- `npx eslint cypress.config.ts` — clean.
- Read the full failing run's logs end-to-end via the GitHub API to confirm the
  root cause (test suite green, cleanup DELETE red) before writing the fix.
- Did not re-run the live Cypress suite locally (no reachable DB in this sandbox
  per `AGENTS.md`); the next scheduled `Cypress Tests` run against `main` after
  merge is the real-world confirmation.

### Stakes
reversible

### Flags for Reviewer
- This only makes the cleanup step resilient to a transient 5xx; it does not fix
  the underlying DB pool/transaction-timeout capacity issue itself, which is
  already tracked separately as `kindrobots-unraid/t-012` (soft `needs-human`,
  needs Silas's hands-on ProxySQL admin access).
- Conductor Todo #1218 will be marked DONE via `complete_todo.py` once this
  merges and (ideally) a subsequent scheduled Cypress run confirms green.

### Kaizen suggestion
`deleteSweptRecord` (the orphan-fixture sweep further down the same file) has
the identical single-attempt-no-retry shape against the same backend — worth
the same treatment in a follow-up if this class of transient failure recurs
there too.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D6zvgTQJGakHSC8HqBGccg)_