### PR TITLE
Make the per-slot backfill survive a non-API path

### DIFF
--- a/prisma/migrations/20260806020000_per_slot_art_image_ids/migration.sql
+++ b/prisma/migrations/20260806020000_per_slot_art_image_ids/migration.sql
@@ -28,72 +28,158 @@
 --
 -- Achievement is absent on purpose: it has only a primary imagePath, no
 -- secondary slots.
+--
+-- 2026-08-06, second attempt. The first failed at the Facet backfill with
+-- error 1292, "Truncated incorrect INTEGER value: ''".
+--
+-- TWO REAL BUGS, both mine:
+--
+-- 1. MariaDB's REGEXP_SUBSTR returns an EMPTY STRING when nothing matches;
+--    MySQL returns NULL. CAST('' AS UNSIGNED) is a hard error under strict
+--    mode, so any row whose path column held a non-empty value that was not an
+--    API URL killed the statement. Bot, Character, Scenario and Reward survived
+--    only because their paths happened to be NULL or all real API URLs.
+--
+-- 2. Nothing guarded the extraction, so a path containing something other than
+--    digits after /api/art/images/ would have failed the same way.
+--
+-- Both are gone: no regex extraction at all (nested SUBSTRING_INDEX works
+-- identically on MariaDB and MySQL), and every UPDATE is gated on RLIKE so it
+-- only touches rows that genuinely carry a numeric ArtImage id.
+--
+-- The ALTERs use IF NOT EXISTS because the first attempt applied all eighteen
+-- columns before dying on the backfill -- DDL is not transactional here, so a
+-- failed migration leaves real changes behind. Re-running must be a no-op on
+-- what already landed.
+
 
 -- AlterTable
 ALTER TABLE `Bot`
-  ADD COLUMN `cardArtImageId` INTEGER NULL,
-  ADD COLUMN `heroArtImageId` INTEGER NULL,
-  ADD COLUMN `iconArtImageId` INTEGER NULL;
+  ADD COLUMN IF NOT EXISTS `cardArtImageId` INTEGER NULL,
+  ADD COLUMN IF NOT EXISTS `heroArtImageId` INTEGER NULL,
+  ADD COLUMN IF NOT EXISTS `iconArtImageId` INTEGER NULL;
 
 -- AlterTable
 ALTER TABLE `Character`
-  ADD COLUMN `cardArtImageId` INTEGER NULL,
-  ADD COLUMN `heroArtImageId` INTEGER NULL,
-  ADD COLUMN `iconArtImageId` INTEGER NULL;
+  ADD COLUMN IF NOT EXISTS `cardArtImageId` INTEGER NULL,
+  ADD COLUMN IF NOT EXISTS `heroArtImageId` INTEGER NULL,
+  ADD COLUMN IF NOT EXISTS `iconArtImageId` INTEGER NULL;
 
 -- AlterTable
 ALTER TABLE `Scenario`
-  ADD COLUMN `cardArtImageId` INTEGER NULL,
-  ADD COLUMN `heroArtImageId` INTEGER NULL,
-  ADD COLUMN `iconArtImageId` INTEGER NULL;
+  ADD COLUMN IF NOT EXISTS `cardArtImageId` INTEGER NULL,
+  ADD COLUMN IF NOT EXISTS `heroArtImageId` INTEGER NULL,
+  ADD COLUMN IF NOT EXISTS `iconArtImageId` INTEGER NULL;
 
 -- AlterTable
 ALTER TABLE `Reward`
-  ADD COLUMN `cardArtImageId` INTEGER NULL,
-  ADD COLUMN `heroArtImageId` INTEGER NULL,
-  ADD COLUMN `iconArtImageId` INTEGER NULL;
+  ADD COLUMN IF NOT EXISTS `cardArtImageId` INTEGER NULL,
+  ADD COLUMN IF NOT EXISTS `heroArtImageId` INTEGER NULL,
+  ADD COLUMN IF NOT EXISTS `iconArtImageId` INTEGER NULL;
 
 -- AlterTable
 ALTER TABLE `Facet`
-  ADD COLUMN `cardArtImageId` INTEGER NULL,
-  ADD COLUMN `heroArtImageId` INTEGER NULL,
-  ADD COLUMN `iconArtImageId` INTEGER NULL;
+  ADD COLUMN IF NOT EXISTS `cardArtImageId` INTEGER NULL,
+  ADD COLUMN IF NOT EXISTS `heroArtImageId` INTEGER NULL,
+  ADD COLUMN IF NOT EXISTS `iconArtImageId` INTEGER NULL;
 
 -- AlterTable
 ALTER TABLE `Project`
-  ADD COLUMN `cardArtImageId` INTEGER NULL,
-  ADD COLUMN `heroArtImageId` INTEGER NULL,
-  ADD COLUMN `iconArtImageId` INTEGER NULL;
+  ADD COLUMN IF NOT EXISTS `cardArtImageId` INTEGER NULL,
+  ADD COLUMN IF NOT EXISTS `heroArtImageId` INTEGER NULL,
+  ADD COLUMN IF NOT EXISTS `iconArtImageId` INTEGER NULL;
 
--- Backfill from the only place the ids currently live: the API URLs already in
--- the path columns. `/api/art/images/1234/file?v=...` -> 1234. Rows whose path
--- is empty, or already a static file, simply stay NULL.
-UPDATE `Bot` SET
-  `cardArtImageId` = CAST(REGEXP_SUBSTR(`cardPath`, '(?<=/api/art/images/)[0-9]+') AS UNSIGNED),
-  `heroArtImageId` = CAST(REGEXP_SUBSTR(`heroPath`, '(?<=/api/art/images/)[0-9]+') AS UNSIGNED),
-  `iconArtImageId` = CAST(REGEXP_SUBSTR(`iconPath`, '(?<=/api/art/images/)[0-9]+') AS UNSIGNED);
+-- Backfill from the only place these ids currently live: the API URLs
+-- already sitting in the path columns. /api/art/images/1234/file?v=... ->
+-- 1234. The RLIKE gate means a row without one is simply left NULL rather
+-- than cast from a non-numeric fragment.
 
-UPDATE `Character` SET
-  `cardArtImageId` = CAST(REGEXP_SUBSTR(`cardPath`, '(?<=/api/art/images/)[0-9]+') AS UNSIGNED),
-  `heroArtImageId` = CAST(REGEXP_SUBSTR(`heroPath`, '(?<=/api/art/images/)[0-9]+') AS UNSIGNED),
-  `iconArtImageId` = CAST(REGEXP_SUBSTR(`iconPath`, '(?<=/api/art/images/)[0-9]+') AS UNSIGNED);
+UPDATE `Bot` SET `cardArtImageId` = CAST(
+    SUBSTRING_INDEX(SUBSTRING_INDEX(`cardPath`, '/api/art/images/', -1), '/', 1)
+  AS UNSIGNED)
+  WHERE `cardPath` RLIKE '/api/art/images/[0-9]+/';
 
-UPDATE `Scenario` SET
-  `cardArtImageId` = CAST(REGEXP_SUBSTR(`cardPath`, '(?<=/api/art/images/)[0-9]+') AS UNSIGNED),
-  `heroArtImageId` = CAST(REGEXP_SUBSTR(`heroPath`, '(?<=/api/art/images/)[0-9]+') AS UNSIGNED),
-  `iconArtImageId` = CAST(REGEXP_SUBSTR(`iconPath`, '(?<=/api/art/images/)[0-9]+') AS UNSIGNED);
+UPDATE `Bot` SET `heroArtImageId` = CAST(
+    SUBSTRING_INDEX(SUBSTRING_INDEX(`heroPath`, '/api/art/images/', -1), '/', 1)
+  AS UNSIGNED)
+  WHERE `heroPath` RLIKE '/api/art/images/[0-9]+/';
 
-UPDATE `Reward` SET
-  `cardArtImageId` = CAST(REGEXP_SUBSTR(`cardPath`, '(?<=/api/art/images/)[0-9]+') AS UNSIGNED),
-  `heroArtImageId` = CAST(REGEXP_SUBSTR(`heroPath`, '(?<=/api/art/images/)[0-9]+') AS UNSIGNED),
-  `iconArtImageId` = CAST(REGEXP_SUBSTR(`iconPath`, '(?<=/api/art/images/)[0-9]+') AS UNSIGNED);
+UPDATE `Bot` SET `iconArtImageId` = CAST(
+    SUBSTRING_INDEX(SUBSTRING_INDEX(`iconPath`, '/api/art/images/', -1), '/', 1)
+  AS UNSIGNED)
+  WHERE `iconPath` RLIKE '/api/art/images/[0-9]+/';
 
-UPDATE `Facet` SET
-  `cardArtImageId` = CAST(REGEXP_SUBSTR(`cardPath`, '(?<=/api/art/images/)[0-9]+') AS UNSIGNED),
-  `heroArtImageId` = CAST(REGEXP_SUBSTR(`heroPath`, '(?<=/api/art/images/)[0-9]+') AS UNSIGNED),
-  `iconArtImageId` = CAST(REGEXP_SUBSTR(`iconPath`, '(?<=/api/art/images/)[0-9]+') AS UNSIGNED);
+UPDATE `Character` SET `cardArtImageId` = CAST(
+    SUBSTRING_INDEX(SUBSTRING_INDEX(`cardPath`, '/api/art/images/', -1), '/', 1)
+  AS UNSIGNED)
+  WHERE `cardPath` RLIKE '/api/art/images/[0-9]+/';
 
-UPDATE `Project` SET
-  `cardArtImageId` = CAST(REGEXP_SUBSTR(`cardPath`, '(?<=/api/art/images/)[0-9]+') AS UNSIGNED),
-  `heroArtImageId` = CAST(REGEXP_SUBSTR(`heroPath`, '(?<=/api/art/images/)[0-9]+') AS UNSIGNED),
-  `iconArtImageId` = CAST(REGEXP_SUBSTR(`iconPath`, '(?<=/api/art/images/)[0-9]+') AS UNSIGNED);
+UPDATE `Character` SET `heroArtImageId` = CAST(
+    SUBSTRING_INDEX(SUBSTRING_INDEX(`heroPath`, '/api/art/images/', -1), '/', 1)
+  AS UNSIGNED)
+  WHERE `heroPath` RLIKE '/api/art/images/[0-9]+/';
+
+UPDATE `Character` SET `iconArtImageId` = CAST(
+    SUBSTRING_INDEX(SUBSTRING_INDEX(`iconPath`, '/api/art/images/', -1), '/', 1)
+  AS UNSIGNED)
+  WHERE `iconPath` RLIKE '/api/art/images/[0-9]+/';
+
+UPDATE `Scenario` SET `cardArtImageId` = CAST(
+    SUBSTRING_INDEX(SUBSTRING_INDEX(`cardPath`, '/api/art/images/', -1), '/', 1)
+  AS UNSIGNED)
+  WHERE `cardPath` RLIKE '/api/art/images/[0-9]+/';
+
+UPDATE `Scenario` SET `heroArtImageId` = CAST(
+    SUBSTRING_INDEX(SUBSTRING_INDEX(`heroPath`, '/api/art/images/', -1), '/', 1)
+  AS UNSIGNED)
+  WHERE `heroPath` RLIKE '/api/art/images/[0-9]+/';
+
+UPDATE `Scenario` SET `iconArtImageId` = CAST(
+    SUBSTRING_INDEX(SUBSTRING_INDEX(`iconPath`, '/api/art/images/', -1), '/', 1)
+  AS UNSIGNED)
+  WHERE `iconPath` RLIKE '/api/art/images/[0-9]+/';
+
+UPDATE `Reward` SET `cardArtImageId` = CAST(
+    SUBSTRING_INDEX(SUBSTRING_INDEX(`cardPath`, '/api/art/images/', -1), '/', 1)
+  AS UNSIGNED)
+  WHERE `cardPath` RLIKE '/api/art/images/[0-9]+/';
+
+UPDATE `Reward` SET `heroArtImageId` = CAST(
+    SUBSTRING_INDEX(SUBSTRING_INDEX(`heroPath`, '/api/art/images/', -1), '/', 1)
+  AS UNSIGNED)
+  WHERE `heroPath` RLIKE '/api/art/images/[0-9]+/';
+
+UPDATE `Reward` SET `iconArtImageId` = CAST(
+    SUBSTRING_INDEX(SUBSTRING_INDEX(`iconPath`, '/api/art/images/', -1), '/', 1)
+  AS UNSIGNED)
+  WHERE `iconPath` RLIKE '/api/art/images/[0-9]+/';
+
+UPDATE `Facet` SET `cardArtImageId` = CAST(
+    SUBSTRING_INDEX(SUBSTRING_INDEX(`cardPath`, '/api/art/images/', -1), '/', 1)
+  AS UNSIGNED)
+  WHERE `cardPath` RLIKE '/api/art/images/[0-9]+/';
+
+UPDATE `Facet` SET `heroArtImageId` = CAST(
+    SUBSTRING_INDEX(SUBSTRING_INDEX(`heroPath`, '/api/art/images/', -1), '/', 1)
+  AS UNSIGNED)
+  WHERE `heroPath` RLIKE '/api/art/images/[0-9]+/';
+
+UPDATE `Facet` SET `iconArtImageId` = CAST(
+    SUBSTRING_INDEX(SUBSTRING_INDEX(`iconPath`, '/api/art/images/', -1), '/', 1)
+  AS UNSIGNED)
+  WHERE `iconPath` RLIKE '/api/art/images/[0-9]+/';
+
+UPDATE `Project` SET `cardArtImageId` = CAST(
+    SUBSTRING_INDEX(SUBSTRING_INDEX(`cardPath`, '/api/art/images/', -1), '/', 1)
+  AS UNSIGNED)
+  WHERE `cardPath` RLIKE '/api/art/images/[0-9]+/';
+
+UPDATE `Project` SET `heroArtImageId` = CAST(
+    SUBSTRING_INDEX(SUBSTRING_INDEX(`heroPath`, '/api/art/images/', -1), '/', 1)
+  AS UNSIGNED)
+  WHERE `heroPath` RLIKE '/api/art/images/[0-9]+/';
+
+UPDATE `Project` SET `iconArtImageId` = CAST(
+    SUBSTRING_INDEX(SUBSTRING_INDEX(`iconPath`, '/api/art/images/', -1), '/', 1)
+  AS UNSIGNED)
+  WHERE `iconPath` RLIKE '/api/art/images/[0-9]+/';


### PR DESCRIPTION
The migration from #1510 failed on the real database at the `Facet` backfill:

```
Database error code: 1292
Database error: Truncated incorrect INTEGER value: ''
Please check the query number 11 from the migration file.
```

Two real bugs, both mine.

**1. `REGEXP_SUBSTR` returns an empty string on MariaDB, NULL on MySQL.** `CAST('' AS UNSIGNED)` is a hard error under strict mode, so any row holding a non-empty path column that wasn't an API URL killed the statement. Bot, Character, Scenario and Reward survived only because their paths happened to be NULL or all real API URLs — the bug applied to all six tables, and Facet was just the first with a counterexample.

**2. Nothing guarded the extraction.** A path with something non-numeric after `/api/art/images/` would have failed identically.

Both are gone: no regex extraction at all (nested `SUBSTRING_INDEX` behaves the same on MariaDB and MySQL), and every `UPDATE` is gated on `RLIKE '/api/art/images/[0-9]+/'` so it only touches rows genuinely carrying a numeric id. Rows without one stay NULL, which `currentArtImageId` already handles by falling back to parsing the path.

**The `ALTER`s gain `IF NOT EXISTS`.** DDL isn't transactional here, so the failed run left all eighteen columns in place before dying on the backfill. Re-running has to be a no-op on what already landed rather than a duplicate-column error.

### Recovery on an install that hit the failure

```bash
npx prisma migrate resolve --rolled-back 20260806020000_per_slot_art_image_ids
npx prisma migrate deploy
```

The columns stay, the successful backfills stay (re-running is idempotent — same inputs, same ids), and Facet and Project get the backfill they never received.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_