### PR TITLE
Add --only-tagged so the filing path can actually be tested

### DIFF
--- a/utils/scripts/offloadArtImageData.ts
+++ b/utils/scripts/offloadArtImageData.ts
@@ -46,6 +46,19 @@ import {
 
 const WRITE = process.argv.includes('--write')
 
+/*
+ * Restrict to rows carrying an entity tag — the ones that file under
+ * {context}/{slug}/ rather than the landing zone.
+ *
+ * Added 2026-08-06 after the first --limit 20 run put all twenty in
+ * generated/: ordering by size selects the oldest, largest free-generation art,
+ * which legitimately has no entity behind it. 1,616 of 4,007 candidates ARE
+ * tagged, so "largest first" is simply the wrong sample for checking that
+ * filing works. This makes that check possible, and doubles as a way to move
+ * the art that matters most before the unclaimed backlog.
+ */
+const ONLY_TAGGED = process.argv.includes('--only-tagged')
+
 function numericFlag(name: string, fallback: number): number {
   const index = process.argv.indexOf(name)
   if (index === -1) return fallback
@@ -127,7 +140,10 @@ async function main() {
     `ArtImage rows holding at least ${MIN_BYTES} bytes: ${allRows} (${mb(allBytes)})`,
   )
   console.log(`Media root: ${root}`)
-  console.log(`Mode: ${WRITE ? 'WRITE — bytes will move' : 'dry run'}\n`)
+  console.log(
+    `Mode: ${WRITE ? 'WRITE — bytes will move' : 'dry run'}` +
+      `${ONLY_TAGGED ? '  (--only-tagged: entity art only)' : ''}\n`,
+  )
 
   /*
    * Ids and lengths only. Selecting imageData here would pull the entire 6 GB
@@ -143,6 +159,7 @@ async function main() {
     WHERE imageData IS NOT NULL
       AND LENGTH(imageData) >= ${Math.floor(MIN_BYTES)}
       AND (imagePath IS NULL OR imagePath = '' OR imagePath LIKE CONCAT('%/api/art/images/', id, '/file%'))
+      ${ONLY_TAGGED ? "AND path LIKE 'entity:%'" : ''}
     ORDER BY LENGTH(imageData) DESC
     ${LIMIT > 0 ? `LIMIT ${Math.floor(LIMIT)}` : ''}
   `)


### PR DESCRIPTION
The first `--limit 20 --write` run on the real database put all twenty files in `generated/`, which reads like the resolver failing. It isn't.

Ordering by size selects the oldest and largest free-generation art, which legitimately has no entity behind it. Measured on the live database:

```
candidates: 4007
  with an entity: tag in path -> 1616
  with an EntityArtImage link -> 0

most common path values among candidates:
   2388  null
      4  "[UserAvatar]"
      2  "entity:bot:3:current:cardPath"
      ...
```

1,616 of 4,007 candidates **do** carry a tag — largest-first is simply the wrong sample for checking that filing works.

`--only-tagged` restricts the candidate query to rows with an `entity:` tag, so twenty of them can be moved and inspected before committing to the full backlog. It also doubles as an operational nicety: move the art that entities actually display — bot cards, character portraits, achievement icons — ahead of the unclaimed remainder.

```bash
npm run offload:art-images -- --write --limit 20 --only-tagged
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_