### PR TITLE
ai-art-academy/t-010: lane 1 front-end polish — spacing consistency + kr-note

### DIFF
--- a/components/academy/academy-manager.vue
+++ b/components/academy/academy-manager.vue
@@ -45,7 +45,7 @@
         <div
           v-else-if="managerError"
           role="alert"
-          class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-error/40 bg-error/10 p-4 text-error"
+          class="kr-note kr-note-error flex min-h-0 flex-1 flex-col overflow-hidden"
         >
           <div class="flex flex-wrap items-center justify-between gap-3">
             <span>{{ managerError }}</span>
@@ -75,7 +75,8 @@
 
         <div
           v-else
-          class="flex min-h-0 flex-1 items-center justify-center rounded-2xl border border-warning/40 bg-warning/10 p-4 text-warning"
+          role="alert"
+          class="kr-note kr-note-warning flex min-h-0 flex-1 items-center justify-center"
         >
           Unknown academy tab: {{ activeTab }}
         </div>

--- a/components/academy/academy-remix.vue
+++ b/components/academy/academy-remix.vue
@@ -1,6 +1,6 @@
 <!-- /components/academy/academy-remix.vue -->
 <template>
-  <section class="flex flex-col gap-3">
+  <section class="flex flex-col gap-4">
     <header
       class="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-base-300 bg-base-200 p-4"
     >

--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -2,7 +2,7 @@
 <template>
   <section class="flex flex-col gap-4">
     <header
-      class="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-200 p-4"
+      class="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-base-300 bg-base-200 p-4"
     >
       <div class="flex min-w-0 flex-col gap-1">
         <h2


### PR DESCRIPTION
### Task
ai-art-academy/t-010: Academy continuous improvement pass — lane 1, front-end style/polish (kind: software, recurring never-idle task)

### What changed / what I produced
- `academy-remix.vue`: outer `<section>` `gap-3` → `gap-4`, matching the identical layout pattern already used in `academy-timeline.vue` and `academy-styles-browser.vue`.
- `academy-styles-browser.vue`: header `gap-3` → `gap-2`, matching the identical header pattern already used in `academy-timeline.vue` and `academy-remix.vue`.
- `academy-manager.vue`: replaced the two hand-written status-banner class combinations (`border-{status}/40 bg-{status}/10 text-{status}`) with the canonical `kr-note`/`kr-note-error`/`kr-note-warning` design-system primitives already defined in `assets/css/tailwind.css` (added specifically to replace this exact drifted pattern). Also added a missing `role="alert"` to the "Unknown academy tab" fallback banner — the error banner above it already had one, this one didn't.

All four changes are purely cosmetic/markup — no logic, props, or behavior touched.

### How I verified
- Dispatched an Explore agent over all 5 Academy components, the shared `academyStore.ts`/`academyStyles.ts`, and `assets/css/tailwind.css`'s `kr-*` primitives, cross-checked against every previously-fixed bug class recorded in conductor's `ai-art-academy/docs/continuous-improvement-run-log.md` lane-1 history (gallery pagination, focus restoration, aria-*/role wiring, uploadStore leaks, Remix Studio mark-viewed leak) to avoid re-proposing already-fixed work — none of that applies here, this is a fresh spacing/design-system-consistency pass, not a bug fix.
- `npx eslint` on all 3 changed files: clean.
- `npx prettier --check` on all 3 changed files: clean.
- Full-project `npm run test` (`vue-tsc --noEmit -p tsconfig.json`): exit 0, zero errors.

### Stakes
reversible

### Flags for Reviewer
- None — small, mechanical, scoped change.

### Kaizen suggestion
The `border-{status}/40 bg-{status}/10 text-{status}` hand-written pattern this PR replaces in `academy-manager.vue` is copy-pasted across roughly 50 other "manager" components app-wide (e.g. `components/art/art-manager.vue`). A dedicated sweep task to migrate all of them to `.kr-note` would be a good, mechanical, high-confidence follow-up for interface-vision or a future ai-art-academy lane-1 cycle — out of scope here since this pass stays Academy-only.

### Notes for reviewer
Conductor: ai-art-academy/t-010 (recurring lane-1/2/3/4 rotation). Roadmap/TALKBACK/run-log update to follow in a companion conductor PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNXwPmv6GKWVD8oaZnacXb)_