### PR TITLE
Shorten what has to be typed on a maintenance box

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,8 @@
     "generatesmart": "node utils/scripts/generate-smart-icons.mjs",
     "test:api-client-followups": "tsx utils/scripts/verifyApiClientFollowups.ts",
     "offload:art-images": "tsx utils/scripts/offloadArtImageData.ts",
-    "test:art-image-offload": "tsx utils/scripts/verifyArtImageOffload.ts"
+    "test:art-image-offload": "tsx utils/scripts/verifyArtImageOffload.ts",
+    "offload:sample": "tsx utils/scripts/offloadArtImageData.ts --write --limit 20 --only-tagged"
   },
   "devDependencies": {
     "@nuxt/eslint": "^1.1.0",

--- a/scripts/write-env.sh
+++ b/scripts/write-env.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Write the .env a maintenance box needs, prompting for the password so it is
+# never typed into a shell history or pasted into a chat.
+#
+# Exists because the Unraid web terminal is an xterm.js canvas that mobile
+# browsers refuse to paste into, which makes a three-line export block
+# genuinely painful to enter by hand from a phone.
+#
+#   bash scripts/write-env.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+read -rp 'DB host:port [100.89.251.10:5544]: ' HOSTPORT
+HOSTPORT="${HOSTPORT:-100.89.251.10:5544}"
+read -rp 'DB name [kindblank_fresh]: ' DBNAME
+DBNAME="${DBNAME:-kindblank_fresh}"
+read -rp 'DB user [kindrobot]: ' DBUSER
+DBUSER="${DBUSER:-kindrobot}"
+read -rsp 'DB password: ' DBPASS
+echo
+read -rp 'IMAGES_PATH [/mnt/user/pc/kindrobots/images]: ' IMGPATH
+IMGPATH="${IMGPATH:-/mnt/user/pc/kindrobots/images}"
+
+umask 077
+cat > .env <<EOF
+DATABASE_URL="mysql://${DBUSER}:${DBPASS}@${HOSTPORT}/${DBNAME}?sslaccept=accept_invalid_certs"
+# ProxySQL presents a certificate the mariadb adapter cannot verify. The URL
+# already says accept_invalid_certs; the adapter reads this env var instead.
+DATABASE_SSL_REJECT_UNAUTHORIZED=false
+IMAGES_PATH=${IMGPATH}
+EOF
+
+echo "Wrote .env (mode $(stat -c '%a' .env))."
+echo
+echo "Prisma CLI commands do not read .env — load it into the shell first:"
+echo "  set -a; . ./.env; set +a"

--- a/scripts/write-env.sh
+++ b/scripts/write-env.sh
@@ -11,6 +11,10 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+urlencode() {
+  node -e "let value = ''; process.stdin.setEncoding('utf8'); process.stdin.on('data', chunk => { value += chunk }); process.stdin.on('end', () => process.stdout.write(encodeURIComponent(value)))"
+}
+
 read -rp 'DB host:port [100.89.251.10:5544]: ' HOSTPORT
 HOSTPORT="${HOSTPORT:-100.89.251.10:5544}"
 read -rp 'DB name [kindblank_fresh]: ' DBNAME
@@ -22,9 +26,13 @@ echo
 read -rp 'IMAGES_PATH [/mnt/user/pc/kindrobots/images]: ' IMGPATH
 IMGPATH="${IMGPATH:-/mnt/user/pc/kindrobots/images}"
 
+ENCODED_DBNAME="$(printf '%s' "$DBNAME" | urlencode)"
+ENCODED_DBUSER="$(printf '%s' "$DBUSER" | urlencode)"
+ENCODED_DBPASS="$(printf '%s' "$DBPASS" | urlencode)"
+
 umask 077
 cat > .env <<EOF
-DATABASE_URL="mysql://${DBUSER}:${DBPASS}@${HOSTPORT}/${DBNAME}?sslaccept=accept_invalid_certs"
+DATABASE_URL="mysql://${ENCODED_DBUSER}:${ENCODED_DBPASS}@${HOSTPORT}/${ENCODED_DBNAME}?sslaccept=accept_invalid_certs"
 # ProxySQL presents a certificate the mariadb adapter cannot verify. The URL
 # already says accept_invalid_certs; the adapter reads this env var instead.
 DATABASE_SSL_REJECT_UNAUTHORIZED=false


### PR DESCRIPTION
The Unraid web terminal is an xterm.js canvas, which mobile browsers refuse to paste into — so every command and the entire `.env` block has to be typed by hand when working from a phone.

**`scripts/write-env.sh`** prompts for host, database, user, password and `IMAGES_PATH`, then writes `.env` under `umask 077`. The password uses `read -rsp`, so it never lands in shell history. It also prints the reminder that the Prisma CLI does *not* read `.env` and needs `set -a; . ./.env; set +a` first — which is the exact thing that made `migrate resolve` fail on the first attempt.

**`npm run offload:sample`** is `--write --limit 20 --only-tagged` under a name that says what it does. Deliberately not a short alias for the unbounded run: it's capped at 20 rows and named "sample" so it can't be mistaken for a dry run by someone typing quickly on a phone.

```bash
bash scripts/write-env.sh
npm run offload:sample
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_