### PR TITLE
Stop shipping real infrastructure values as prompt defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,8 @@
     "generatesmart": "node utils/scripts/generate-smart-icons.mjs",
     "test:api-client-followups": "tsx utils/scripts/verifyApiClientFollowups.ts",
     "offload:art-images": "tsx utils/scripts/offloadArtImageData.ts",
-    "test:art-image-offload": "tsx utils/scripts/verifyArtImageOffload.ts"
+    "test:art-image-offload": "tsx utils/scripts/verifyArtImageOffload.ts",
+    "offload:sample": "tsx utils/scripts/offloadArtImageData.ts --write --limit 20 --only-tagged"
   },
   "devDependencies": {
     "@nuxt/eslint": "^1.1.0",

--- a/scripts/write-env.sh
+++ b/scripts/write-env.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Write the .env a maintenance box needs, prompting for the password so it is
+# never typed into a shell history or pasted into a chat.
+#
+# Exists because the Unraid web terminal is an xterm.js canvas that mobile
+# browsers refuse to paste into, which makes a three-line export block
+# genuinely painful to enter by hand from a phone.
+#
+#   bash scripts/write-env.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+read -rp 'DB host:port [100.89.251.10:5544]: ' HOSTPORT
+HOSTPORT="${HOSTPORT:-100.89.251.10:5544}"
+read -rp 'DB name [kindblank_fresh]: ' DBNAME
+DBNAME="${DBNAME:-kindblank_fresh}"
+read -rp 'DB user [kindrobot]: ' DBUSER
+DBUSER="${DBUSER:-kindrobot}"
+read -rsp 'DB password: ' DBPASS
+echo
+read -rp 'IMAGES_PATH [/mnt/user/pc/kindrobots/images]: ' IMGPATH
+IMGPATH="${IMGPATH:-/mnt/user/pc/kindrobots/images}"
+
+umask 077
+cat > .env <<EOF
+DATABASE_URL="mysql://${DBUSER}:${DBPASS}@${HOSTPORT}/${DBNAME}?sslaccept=accept_invalid_certs"
+# ProxySQL presents a certificate the mariadb adapter cannot verify. The URL
+# already says accept_invalid_certs; the adapter reads this env var instead.
+DATABASE_SSL_REJECT_UNAUTHORIZED=false
+IMAGES_PATH=${IMGPATH}
+EOF
+
+echo "Wrote .env (mode $(stat -c '%a' .env))."
+echo
+echo "Prisma CLI commands do not read .env — load it into the shell first:"
+echo "  set -a; . ./.env; set +a"

--- a/scripts/write-env.sh
+++ b/scripts/write-env.sh
@@ -1,37 +1,76 @@
 #!/usr/bin/env bash
-# Write the .env a maintenance box needs, prompting for the password so it is
-# never typed into a shell history or pasted into a chat.
+# Write the .env a maintenance box needs, prompting for each value.
 #
 # Exists because the Unraid web terminal is an xterm.js canvas that mobile
-# browsers refuse to paste into, which makes a three-line export block
-# genuinely painful to enter by hand from a phone.
+# browsers refuse to paste into, which makes a multi-line export block painful
+# to enter by hand from a phone.
+#
+# NO DEFAULTS FOR INFRASTRUCTURE VALUES, deliberately. The first version of this
+# script shipped the real host, port, database name and user as prompt defaults
+# "for convenience", and GitGuardian flagged it immediately -- correctly. A
+# tailnet address, a port, a schema name and a username are not secrets in the
+# credential sense, but publishing them narrows an attacker's problem from "the
+# internet" to "this host, this port, this account, now guess the password."
+# Saving four keystrokes is not a reason to put them in a public repository.
+#
+# A re-run seeds from the existing .env instead, so the values stay on the box
+# that needs them and never enter git.
 #
 #   bash scripts/write-env.sh
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-read -rp 'DB host:port [100.89.251.10:5544]: ' HOSTPORT
-HOSTPORT="${HOSTPORT:-100.89.251.10:5544}"
-read -rp 'DB name [kindblank_fresh]: ' DBNAME
-DBNAME="${DBNAME:-kindblank_fresh}"
-read -rp 'DB user [kindrobot]: ' DBUSER
-DBUSER="${DBUSER:-kindrobot}"
-read -rsp 'DB password: ' DBPASS
-echo
-read -rp 'IMAGES_PATH [/mnt/user/pc/kindrobots/images]: ' IMGPATH
-IMGPATH="${IMGPATH:-/mnt/user/pc/kindrobots/images}"
+CURRENT_URL=""
+CURRENT_IMAGES=""
+if [ -f .env ]; then
+  CURRENT_URL="$(grep -E '^DATABASE_URL=' .env | head -1 | cut -d= -f2- | tr -d '"' || true)"
+  CURRENT_IMAGES="$(grep -E '^IMAGES_PATH=' .env | head -1 | cut -d= -f2- | tr -d '"' || true)"
+fi
+
+REUSE=n
+if [ -n "$CURRENT_URL" ]; then
+  read -rp 'An .env exists. Reuse its DATABASE_URL? [Y/n]: ' REUSE
+  REUSE="${REUSE:-Y}"
+fi
+
+case "$REUSE" in
+  Y | y)
+    DB_URL="$CURRENT_URL"
+    ;;
+  *)
+    read -rp 'DB host: ' DBHOST
+    read -rp 'DB port: ' DBPORT
+    read -rp 'DB name: ' DBNAME
+    read -rp 'DB user: ' DBUSER
+    read -rsp 'DB password: ' DBPASS
+    echo
+    DB_URL="mysql://${DBUSER}:${DBPASS}@${DBHOST}:${DBPORT}/${DBNAME}?sslaccept=accept_invalid_certs"
+    ;;
+esac
+
+if [ -n "$CURRENT_IMAGES" ]; then
+  read -rp "IMAGES_PATH [keep existing]: " IMGPATH
+  IMGPATH="${IMGPATH:-$CURRENT_IMAGES}"
+else
+  read -rp 'IMAGES_PATH (media share root): ' IMGPATH
+fi
+
+if [ -z "$DB_URL" ] || [ -z "$IMGPATH" ]; then
+  echo 'A database URL and IMAGES_PATH are both required. Nothing written.' >&2
+  exit 1
+fi
 
 umask 077
 cat > .env <<EOF
-DATABASE_URL="mysql://${DBUSER}:${DBPASS}@${HOSTPORT}/${DBNAME}?sslaccept=accept_invalid_certs"
+DATABASE_URL="${DB_URL}"
 # ProxySQL presents a certificate the mariadb adapter cannot verify. The URL
 # already says accept_invalid_certs; the adapter reads this env var instead.
 DATABASE_SSL_REJECT_UNAUTHORIZED=false
 IMAGES_PATH=${IMGPATH}
 EOF
 
-echo "Wrote .env (mode $(stat -c '%a' .env))."
+echo "Wrote .env (mode $(stat -c '%a' .env 2>/dev/null || echo 600))."
 echo
 echo "Prisma CLI commands do not read .env — load it into the shell first:"
 echo "  set -a; . ./.env; set +a"


### PR DESCRIPTION
GitGuardian flagged `scripts/write-env.sh` from #1515, correctly.

I had put the real host, port, database name and user in as prompt defaults so there'd be less to type from a phone. That published them in a public repository.

None of those four are secrets in the credential sense. Together they're still worth withholding — they narrow an attacker's problem from "the internet" to "this host, this port, this account, now guess the password." Saving four keystrokes was not worth that trade.

The script now prompts with no defaults and seeds a re-run from the existing `.env`, so the values live on the box that needs them and never enter git. Behaviour is otherwise unchanged: hidden password read, `umask 077`, and the reminder that the Prisma CLI needs `set -a; . ./.env; set +a`.

### Still exposed, from before this branch

Worth a separate decision, since removing them from the working tree doesn't remove them from history:

- `docs/runbooks/proxysql-connection-capacity.md:28` contains the same `100.89.251.10:5544` — pre-existing.
- `scripts/db-write-repro.mjs` has the user and database name in usage comments (password placeheld) — pre-existing.
- `docs/self-hosted-media.md` documents the share filesystem paths — pre-existing and arguably the point of the file.

The addresses are tailnet-only, so exposure is bounded, but the git history retains all of it regardless of what the tree says now.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_