### PR TITLE
ai-art-academy/t-057: migrate 4 manager components' status banners to .kr-note

### DIFF
--- a/components/dreams/dream-manager.vue
+++ b/components/dreams/dream-manager.vue
@@ -4,11 +4,7 @@
     <div
       v-if="isLoadingManager || managerError"
       class="mb-2 flex shrink-0 items-center gap-2 rounded-2xl border border-base-300 bg-base-100 px-3 py-2 text-xs shadow-sm"
-      :class="
-        managerError
-          ? 'border-error/40 bg-error/10 text-error'
-          : 'text-base-content/60'
-      "
+      :class="managerError ? 'kr-note-error' : 'text-base-content/60'"
     >
       <span
         v-if="isLoadingManager"

--- a/components/giftshop/giftshop-manager.vue
+++ b/components/giftshop/giftshop-manager.vue
@@ -48,8 +48,8 @@
               class="rounded-xl border p-3 text-center text-sm font-medium"
               :class="
                 manaTopupNotice === 'success'
-                  ? 'border-success/40 bg-success/10 text-success'
-                  : 'border-warning/40 bg-warning/10 text-warning'
+                  ? 'kr-note-success'
+                  : 'kr-note-warning'
               "
             >
               {{
@@ -63,8 +63,8 @@
               class="rounded-xl border p-3 text-center text-sm font-medium"
               :class="
                 subscriptionNotice === 'success'
-                  ? 'border-success/40 bg-success/10 text-success'
-                  : 'border-warning/40 bg-warning/10 text-warning'
+                  ? 'kr-note-success'
+                  : 'kr-note-warning'
               "
             >
               {{

--- a/components/model-builder/model-builder-manager.vue
+++ b/components/model-builder/model-builder-manager.vue
@@ -59,9 +59,7 @@
         v-if="store.statusMessage"
         class="shrink-0 border-b px-3 py-1 text-xs font-semibold"
         :class="
-          store.statusTone === 'error'
-            ? 'border-error/30 bg-error/10 text-error'
-            : 'border-success/30 bg-success/10 text-success'
+          store.statusTone === 'error' ? 'kr-note-error' : 'kr-note-success'
         "
       >
         {{ store.statusMessage }}

--- a/components/pages/conductor-pitch-manager.vue
+++ b/components/pages/conductor-pitch-manager.vue
@@ -98,7 +98,7 @@
       <div
         v-if="feedback"
         class="shrink-0 rounded-2xl border px-4 py-3 text-sm font-semibold"
-        :class="feedbackError ? 'border-error/30 bg-error/10 text-error' : 'border-success/30 bg-success/10 text-success'"
+        :class="feedbackError ? 'kr-note-error' : 'kr-note-success'"
       >
         {{ feedback }}
       </div>


### PR DESCRIPTION
### Task
ai-art-academy/t-057: migrate remaining hand-written status-banner classes to `.kr-note` across manager components (kind: software)

### What changed / what I produced
Scoped first pass on the sweep this task calls for. Replaces each hand-written `border-{status}/opacity bg-{status}/opacity text-{status}` triplet with the canonical `.kr-note-{status}` modifier class introduced by kind_robots PR #1514 (ai-art-academy/t-010 lane 1), normalizing two drifted `/30` opacity instances to the canonical `/40` in the same pass:

- `components/dreams/dream-manager.vue`
- `components/model-builder/model-builder-manager.vue`
- `components/giftshop/giftshop-manager.vue` (2 occurrences)
- `components/pages/conductor-pitch-manager.vue`

**Deliberately did NOT add the `.kr-note` base class** (which sets its own `rounded-2xl p-4 text-sm font-semibold` shape) to any of these — each component's existing shape classes differ from `.kr-note`'s box model (e.g. a `border-b`-only strip, different padding/text-size), so forcing the base class would change layout, not just normalize color. Only the color modifier is swapped in, which is the actual "canonical form" the kaizen note asks for (`border-{status}/40 bg-{status}/10 text-{status}`) and carries zero visual-shape risk.

**Scope:** `components/**/*manager.vue` only, excluding `components/abandonware/**` (retired, unused code — confirmed via its own historical `/components/...` doc-comment convention) and `components/academy/academy-manager.vue` (already done in #1514). 25 more non-manager components still carry the same hand-written pattern app-wide per the task's own note — left for a follow-up scoped pass, consistent with the note's own "split into a few scoped PRs by component family" guidance.

### How I verified
- `eslint` on the 4 files: 0 new errors (the 2 pre-existing unused-var errors in `giftshop-manager.vue` and `conductor-pitch-manager.vue` predate this change — confirmed via `git stash` diff against unmodified `HEAD`)
- Full `vue-tsc --noEmit` typecheck (`npm run test`): 0 errors
- Deliberately did **not** run `prettier --write` on these 4 files — they carry pre-existing formatting drift unrelated to this change (confirmed `prettier --check` already fails on unmodified `HEAD` for all 4), and a full reflow would balloon this diff into an unrelated whole-file reformat instead of the targeted color-class swap

### Stakes
reversible

### Notes for reviewer
Conductor task `ai-art-academy/t-057` tracked this; conductor-side roadmap update will follow in a companion conductor commit/PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBudYti2xa2uDEuQkVQ52d)_