### PR TITLE
ai-art-academy/t-010: lane 1 front-end polish — fix style-thumbnail label contrast

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -424,7 +424,7 @@
             class="absolute inset-x-0 bottom-0 flex flex-col items-center gap-0.5 px-1.5 pb-2 pt-1"
           >
             <span
-              class="text-[0.65rem] font-black leading-tight text-white drop-shadow-md"
+              class="text-[0.65rem] font-black leading-tight text-base-content drop-shadow-md"
             >
               {{ style.label }}
             </span>


### PR DESCRIPTION
### Task
ai-art-academy/t-010: Academy continuous improvement pass, lane 1 (front-end style/polish). (kind: software)

### What changed / what I produced
- `components/art/art-styler.vue`: the style-picker grid overlays each thumbnail's label on a themed `bg-linear-to-t from-base-300/80` scrim, but hardcoded `text-white` instead of the design system's adaptive `text-base-content`.
- `base-300` is ~89% lightness in the storybook (light) theme, so white text on that scrim is nearly invisible — a real contrast/accessibility bug in light mode that happened to look fine in dark mode (`base-300` ~30% lightness there), which is likely why it went unnoticed.
- Matches the established sibling pattern already used for this exact scrim+caption shape elsewhere (`academy-style-detail.vue`'s example-works overlay: `from-base-300/90` + `text-base-content`).
- This component is shared across `art-manager`, `image-card`, `academy-manager`/`academy-remix` (Style Lab + Remix Studio), and `coloring-page`, so the fix applies everywhere the style grid renders — not just Academy.

### How I verified
- `npx eslint components/art/art-styler.vue` — clean
- `npx prettier --check components/art/art-styler.vue` — clean
- `npm run test` (full-project `vue-tsc --noEmit`) — exit 0, no errors

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
A quick grep for other `text-white`/`text-black` hardcodes paired with a *themed* (base-300-style) scrim rather than a genuinely theme-independent black/dark scrim would be worth a follow-up pass — this file had exactly one instance, but the pattern (themed scrim + non-adaptive text color) could recur elsewhere in the codebase.

### Notes for reviewer
Conductor task: ai-art-academy/t-010 (recurring "Academy continuous improvement pass," lane 1 this cycle). Conductor-side roadmap/run-log update lands in a companion conductor PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqfaACytDt7woUw65999Mv)_