### PR TITLE
ai-art-academy/t-010: lane 1 front-end polish — keyboard focus + generation-disabled gaps

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -517,6 +517,7 @@
               v-model="useNegative"
               type="checkbox"
               class="toggle toggle-primary toggle-xs"
+              :disabled="isGenerating"
             />
             <span class="label-text text-xs font-semibold">
               Inherit negative prompt
@@ -529,6 +530,7 @@
               v-model="isPublic"
               type="checkbox"
               class="toggle toggle-success toggle-xs"
+              :disabled="isGenerating"
             />
             <span class="label-text text-xs font-semibold">Public</span>
           </label>

--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -73,7 +73,7 @@
         <button
           v-if="!isUploading && !isFinalizingUpload"
           type="button"
-          class="btn btn-circle btn-error btn-xs absolute right-1 top-1 opacity-0 shadow transition-opacity group-hover:opacity-100"
+          class="btn btn-circle btn-error btn-xs absolute right-1 top-1 opacity-0 shadow transition-opacity focus:opacity-100 group-hover:opacity-100"
           :title="`Remove ${item.file.name}`"
           @click.stop="removeFile(i)"
         >


### PR DESCRIPTION
### Task
ai-art-academy/t-010: Academy continuous improvement pass, lane 1 (front-end style/polish)  (kind: software)

### What changed / what I produced
- `components/art/image-upload.vue`: the per-thumbnail "Remove" button in the upload queue grid was `opacity-0` at rest, revealed only via `group-hover:opacity-100`, with no focus-visible equivalent. A keyboard-only user tabbing onto it got no visible indication the control exists (WCAG 2.4.7 Focus Visible gap). Added `focus:opacity-100`, mirroring the pattern already established in `components/scenarios/scenario-card.vue` for the identical reason (that file has an explicit comment from Silas calling out hover-only visibility as a keyboard-accessibility bug).
- `components/art/art-styler.vue`: in the prompt panel, the `extraPrompt` textarea already grays out via `:disabled="isGenerating"`, but the two toggle checkboxes directly below it in the same panel ("Inherit negative prompt", "Public") had no such binding — an inconsistent affordance within one settings group. Added `:disabled="isGenerating"` to both.

### How I verified
- `npx prettier --check` on both changed files — clean
- `npx eslint` on both changed files — 0 errors
- `npm run test` (full-project `vue-tsc --noEmit`) — exit 0, 0 errors

### Stakes
reversible

### Flags for Reviewer
- None. Two one-line, additive Tailwind/Vue-binding changes, no template structure, script logic, store, or API changes.

### Kaizen suggestion
`components/art/entity-art-manager.vue` has the identical hover-only-visibility-with-no-focus-state bug on its remove button (line ~119) and two nav-arrow buttons (~183, ~191) — same fix pattern (`focus:opacity-100`), just outside Academy/art-styler scope for this pass.

### Notes for reviewer
Investigated via a background Explore pass across Academy + art-styler components before picking this candidate; cross-checked against `projects/ai-art-academy/docs/continuous-improvement-run-log.md` to confirm it doesn't duplicate the prior lane-1 cycle (PR #1518, a separate `text-white`→`text-base-content` contrast fix in `art-styler.vue`'s thumbnail caption).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScseJu17NMT9eSmorfPRYB)_