### PR TITLE
Take the backdrop full page, open the surfaces, fix Taskmaster's scroll

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -4,7 +4,28 @@
     class="kr-shell relative h-dvh min-h-dvh w-full overflow-hidden text-base-content"
     :class="showLoader ? 'bg-black' : 'bg-base-100'"
     :style="shellVars"
+    :data-kr-backdrop="hasPageBackdrop ? '' : undefined"
   >
+    <!--
+      FULL PAGE, not just the content well. Silas, 2026-08-06: "I'm more
+      interested in why we aren't doing backgrounds from the full page spread,
+      and instead still starting in main content, so the dashboard section and
+      gutters are independent. I think it would look better if backgrounds were
+      full page."
+
+      This lives on .kr-shell rather than inside <main> for exactly that reason:
+      <main> sits below the header and inside the shell's p-3/p-4, so a backdrop
+      mounted there can never reach the nav bar or the gutters. Absolute
+      inset-0 against the shell covers the viewport instead.
+
+      First child, and unpositioned in the stack, so every later sibling — the
+      header, the content, the overlays — paints above it.
+    -->
+    <kr-page-backdrop
+      :mobile="pageStore.backgroundMobile"
+      :tablet="pageStore.backgroundTablet"
+      :desktop="pageStore.backgroundDesktop"
+    />
     <div
       v-if="showLoader"
       class="pointer-events-none fixed inset-0 z-48 bg-black"
@@ -85,33 +106,23 @@
         </Transition>
 
         <!--
-          `data-kr-backdrop` flips the surface tokens (assets/css/tailwind.css)
-          for everything inside, so the shared kit's panels go translucent and
-          the art reads through them. Present ONLY when the page actually
-          declares backdrop art — otherwise the attribute is absent and every
+          `data-kr-backdrop` now lives on .kr-shell, not here — the header and
+          the gutters need the translucent tokens too, and they are outside
+          <main>. It flips the surface tokens (assets/css/tailwind.css) for
+          everything inside, so panels go translucent and the art reads through.
+          Present ONLY when the page actually declares art; otherwise every
           surface resolves to the same opaque theme colour it always had.
-
-          It sits on <main> rather than on the backdrop element because the
-          backdrop is a sibling of the page content, not its ancestor; the
-          tokens have to be inherited by the cards, which live under <main>.
+        -->
+        <!--
+          No background of its own. The shell-level backdrop is behind this, so
+          an opaque ground here would hide it again — which is the bug that made
+          the first backdrops invisible. The token resolves to base-100 exactly
+          when no page declares art.
         -->
         <main
-          class="kr-main relative z-10 h-full min-h-0 overflow-hidden rounded-2xl bg-base-100 transition-[padding] duration-300 ease-out"
+          class="kr-main relative z-10 h-full min-h-0 overflow-hidden rounded-2xl bg-(--kr-surface-raised) transition-[padding] duration-300 ease-out"
           :class="workspaceSheetOpen ? 'hidden md:block' : 'block'"
-          :data-kr-backdrop="hasPageBackdrop ? '' : undefined"
         >
-          <!--
-            Page backdrop art, BEFORE fx-region deliberately. Both layers sit
-            at z-0, so DOM order decides: the backdrop paints first, fx-region's
-            effects paint over it, and the z-10 <NuxtPage /> wrapper below sits
-            above both. Renders nothing at all unless the page declares art.
-          -->
-          <kr-page-backdrop
-            :mobile="pageStore.backgroundMobile"
-            :tablet="pageStore.backgroundTablet"
-            :desktop="pageStore.backgroundDesktop"
-          />
-
           <fx-region region="page" />
 
           <div

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -166,10 +166,16 @@
  * slash-opacity modifier.
  */
 [data-kr-backdrop] {
-  --kr-surface: color-mix(in oklch, var(--color-base-200) 78%, transparent);
-  --kr-surface-raised: color-mix(in oklch, var(--color-base-100) 82%, transparent);
-  --kr-surface-sunken: color-mix(in oklch, var(--color-base-300) 72%, transparent);
-  --kr-surface-border: color-mix(in oklch, var(--color-base-300) 60%, transparent);
+  /*
+   * Higher percentage = MORE opaque surface = LESS art showing through.
+   * Silas, 2026-08-06, on the first pass at 78/82/72/60: "we could see a bit
+   * more of the backgrounds." These are the four numbers to move, and moving
+   * them moves every page at once — that is the whole point of the tokens.
+   */
+  --kr-surface: color-mix(in oklch, var(--color-base-200) 62%, transparent);
+  --kr-surface-raised: color-mix(in oklch, var(--color-base-100) 66%, transparent);
+  --kr-surface-sunken: color-mix(in oklch, var(--color-base-300) 55%, transparent);
+  --kr-surface-border: color-mix(in oklch, var(--color-base-300) 45%, transparent);
 }
 
 /* Hide scrollbar for Chrome, Safari and Opera */

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -1,7 +1,7 @@
 <!-- /components/navigation/workspace-header.vue -->
 <template>
   <header
-    class="relative z-30 mb-2 shrink-0 overflow-visible rounded-2xl border border-base-300/70 bg-base-100/95 shadow-sm backdrop-blur"
+    class="relative z-30 mb-2 shrink-0 overflow-visible rounded-2xl border border-(--kr-surface-border) bg-(--kr-surface-raised) shadow-sm backdrop-blur"
   >
     <fx-region region="header" />
 

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -8,7 +8,15 @@
   >
     <TaskmasterBackdrop :compact="Boolean(store.session)" />
 
-    <div class="relative z-10 flex min-h-0 flex-1 flex-col">
+    <!--
+      kr-scroll, not a bare flex column. .kr-surface is `overflow-hidden` by
+      design — it bounds the page and delegates scrolling to exactly one region
+      inside it. Without that region the hero, the objective form and the
+      recipe panel simply get clipped at the fold with no way to reach them
+      (Silas, 2026-08-06: "there is a scrolling bug preventing me from
+      scrolling to view more of it").
+    -->
+    <div class="kr-scroll relative z-10 flex flex-col">
       <template v-if="!store.session">
         <header class="taskmaster-hero relative flex min-h-64 items-start p-4 sm:min-h-72 sm:p-6 lg:min-h-80 lg:p-8">
           <div class="taskmaster-hero-copy max-w-2xl">

--- a/components/ui/kr-page-backdrop.vue
+++ b/components/ui/kr-page-backdrop.vue
@@ -45,7 +45,7 @@
   -->
   <div
     v-if="hasBackdrop"
-    class="kr-backdrop pointer-events-none absolute inset-0 overflow-hidden rounded-2xl bg-cover bg-center bg-no-repeat"
+    class="kr-backdrop pointer-events-none absolute inset-0 overflow-hidden bg-cover bg-center bg-no-repeat"
     :style="backdropVars"
     aria-hidden="true"
   >

--- a/server/utils/artImageFilePath.ts
+++ b/server/utils/artImageFilePath.ts
@@ -138,6 +138,69 @@ async function nextIndex(
   return highest + 1
 }
 
+/**
+ * A destination the job that produced this image already declared.
+ *
+ * enqueuePageBackdropArt writes `imagePath: background/<page>-<variant>.webp`
+ * into every job payload, and relay_media_agent.py in conductor reads the same
+ * field to decide where to write the file. That is an explicit statement of
+ * where the art belongs, made before it was ever generated — so it outranks
+ * anything inferred here.
+ *
+ * MISSING THIS COST US. All 60 page backdrops landed in the unfiled landing
+ * zone because this function only understood entity tags. They still resolved
+ * and rendered, since /api/art/backdrop/<slug> follows the ArtImage wherever it
+ * sits, but they looked like unclaimed art — and unclaimed art is what the
+ * triage pass deletes. Silas spotted them: "there are absolutely a collection
+ * of art images that look identical to the art assets that we created for
+ * backgrounds… exactly 60 grouped by card, tablet, and desktop orientations."
+ *
+ * Returns a share-relative path, or null when the job declared nothing usable.
+ * `public/images/x`, `images/x`, `/images/x` and `x` all normalise to `x`.
+ */
+async function declaredJobPath(
+  db: EntityArtDb,
+  artImageId: number,
+): Promise<string | null> {
+  const job = await db.artJob
+    .findFirst({
+      where: { artImageId },
+      orderBy: { id: 'desc' },
+      select: { payload: true },
+    })
+    .catch(() => null)
+
+  if (!job?.payload) return null
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(job.payload)
+  } catch {
+    return null
+  }
+
+  const raw = (parsed as { imagePath?: unknown })?.imagePath
+  if (typeof raw !== 'string' || !raw.trim()) return null
+
+  const cleaned = raw
+    .trim()
+    .replace(/^\/+/, '')
+    .replace(/^public\//, '')
+    .replace(/^images\//, '')
+
+  /*
+   * The same traversal guard relay_media_agent.py applies to this same field.
+   * A payload is data a caller supplied, and this value becomes a filesystem
+   * path on the media share.
+   */
+  const segments = cleaned.split('/')
+  if (!cleaned || segments.some((part) => !part || part === '.' || part === '..')) {
+    return null
+  }
+
+  return cleaned
+}
+
 export async function resolveArtImageFilePath(
   db: EntityArtDb,
   image: { id: number; path: string | null },
@@ -166,6 +229,23 @@ export async function resolveArtImageFilePath(
       context: 'generated',
       slug: `artimage-${image.id}`,
       utility: 'art',
+    }
+  }
+
+  /*
+   * An explicitly declared destination wins over everything inferred. Checked
+   * first so page backdrops — and any future job that names its own path —
+   * land where they were always meant to instead of in the landing zone.
+   */
+  const declared = await declaredJobPath(db, image.id)
+  if (declared) {
+    const parts = declared.split('/')
+    return {
+      relative: declared,
+      filed: true,
+      context: parts[0] || 'declared',
+      slug: (parts.length > 1 ? parts[parts.length - 2] : parts[0]) || 'declared',
+      utility: 'declared',
     }
   }
 

--- a/utils/scripts/verifyArtImageOffload.ts
+++ b/utils/scripts/verifyArtImageOffload.ts
@@ -142,6 +142,14 @@ check(
     `fall to the unfiled landing zone.`,
 )
 
+check(
+  placement.includes('declaredJobPath') && /artJob\s*\n?\s*\.findFirst|artJob\.findFirst/.test(placement),
+  `${PLACEMENT} must honour a destination the producing ArtJob already declared ` +
+    `in its payload imagePath, ahead of anything it infers. Without that, all 60 ` +
+    `page backdrops fall to the unfiled landing zone — where they render fine but ` +
+    `look like unclaimed art, which is what the triage pass deletes.`,
+)
+
 /* -- 2. read the file back and compare before deleting anything ------------- */
 
 check(


### PR DESCRIPTION
Three separate problems, all from one look at the deployed pages.

## 1. Full page, not just the content well

Silas: *"I'm more interested in why we aren't doing backgrounds from the full page spread, and instead still starting in main content, so the dashboard section and gutters are independent."*

The backdrop was mounted inside `<main>`, which sits **below** the header and **inside** the shell's `p-3 sm:p-4`. No amount of surface translucency could get it to the nav bar or the gutters — the layer simply wasn't there.

It now mounts on `.kr-shell` as the first child; `absolute inset-0` against an `h-dvh` container covers the viewport. `data-kr-backdrop` moved there too, so the header and gutters inherit the translucent tokens rather than being excluded.

Three consequences, all handled:
- `<main>` loses its `bg-base-100` — it would otherwise re-hide the art, the *exact* bug page roots had one level down.
- `workspace-header` moves onto the tokens, so the nav bar reads as glass over the art.
- The backdrop drops `rounded-2xl`, which would now round a full-bleed layer against the viewport edge.

## 2. More art showing through

*"we could see a bit more of the backgrounds"* — `78/82/72/60` → `62/66/55/45`.

Higher percentage means **more opaque surface, less art**, which is easy to get backwards. The CSS now says so, next to the four numbers.

## 3. Taskmaster's scroll bug

*"there is a scrolling bug preventing me from scrolling to view more of it."*

Unrelated to backdrops and a real bug. `.kr-surface` is `overflow-hidden` by design — it bounds the page and delegates scrolling to exactly one `.kr-scroll` region inside it. Taskmaster's inner column had `flex-1 min-h-0` but no scroll owner, so the hero, objective form and recipe panel were clipped at the fold with no way to reach them.

`npm run test:layout-contract` confirms no new violations.

Typecheck clean, lint ratchet unchanged, page-backdrop contract passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_