### PR TITLE
ai-art-academy/t-010: lane 3 — add previewImageSrc to spanish-golden-age and mannerism

### DIFF
--- a/stores/seeds/academyStyles.ts
+++ b/stores/seeds/academyStyles.ts
@@ -2017,6 +2017,7 @@ export const academyStyles: AcademyStyle[] = [
     name: 'Spanish Golden Age Painting',
     era: 'c. 1620–1680',
     sortYear: 1620,
+    previewImageSrc: '/images/academy/styles/spanish-golden-age.webp',
     region: 'Spain',
     keyIdeas:
       "Spanish Golden Age painting (Siglo de Oro) shares the Baroque's chiaroscuro and psychological intensity already taught in this curriculum, but pulls toward a different pole entirely. Where Italian Baroque leans into theatrical motion and Dutch Baroque turns that same light toward cozy domestic interiors, Spanish Golden Age painters used tenebrism to freeze a single suspended, almost sculptural moment: figures and objects modeled with an austere, unblinking clarity against a plain dark or neutral ground, with little movement, minimal ornament, and an intense devotional or psychological gravity. Favored subjects were saints in solitary contemplation, humble monastic scenes, royal portraits stripped of overt flattery, and devotional images painted with still-life precision. Painted mostly for Spanish churches, monasteries, and the royal court during Spain's political decline but cultural high point, the movement's sobriety and psychological directness later drew Édouard Manet and 19th-century Realists back to Madrid to study Velázquez directly.",
@@ -2056,6 +2057,7 @@ export const academyStyles: AcademyStyle[] = [
     name: 'Mannerism',
     era: 'c. 1520–1580',
     sortYear: 1520,
+    previewImageSrc: '/images/academy/styles/mannerism.webp',
     region: 'Italy',
     keyIdeas:
       "Mannerism grew directly out of the High Renaissance but deliberately pushed past its balance and naturalism into elegant artifice. Where Leonardo, Raphael, and Botticelli sought anatomical correctness and calm, stable compositions, Mannerist painters stretched the figure into impossibly long limbs and swan necks, twisted poses into serpentine, off-balance spirals, and cooled the palette into acidic, jewel-like color harmonies that read as sophisticated rather than natural. Faces became smooth, porcelain-cool, and faintly emotionally distant — beautiful but unreadable, a style built for court sophistication rather than devotional warmth. Working mostly for the Medici court in Florence and the papal court in Rome, Mannerist painters treated technical virtuosity as its own subject: an impossibly long neck or elongated fingers weren't mistakes, they were the point.",


### PR DESCRIPTION
### Task
ai-art-academy/t-010: Academy continuous improvement pass, lane 3 (inspiration/preview assets) (kind: software)

### What changed / what I produced
- `stores/seeds/academyStyles.ts`: added `previewImageSrc` to the `spanish-golden-age` and `mannerism` entries, pointing at `/images/academy/styles/<slug>.webp` — the same convention every other style entry already uses.

### Why
`scripts/verify_academy_style_preview_coverage.py` (conductor) only audits slugs that already set `previewImageSrc`, so it can't see a slug missing the field entirely. A manual sweep of all 44 `academyStyles.ts` entries found exactly these two with no `previewImageSrc` key at all — not just undelivered, but no preview-image slot in the front end whatsoever.

### How I verified
- Confirmed `previewImageSrc?: string` (optional string) in `stores/helpers/styleHelper.ts`'s style type — the two additions match the existing type and the convention used by all 42 other entries (field placed right after `sortYear`, before `region`).
- `git diff --stat`: 1 file changed, 2 insertions — no other lines touched.
- Did not run a full local `vue-tsc`/eslint pass (no local `node_modules` provisioned this cycle); this is a two-line, type-matching, precedent-identical data addition with no new TS surface, so I'm relying on CI's `TypeScript`/lint checks to confirm before merge.

### Stakes
reversible

### Flags for Reviewer
- Companion conductor PR queues `art-prompts.yaml` render requests for these two paths (`kind-robots-academy-style-preview-spanish-golden-age` / `-mannerism`). The images may land after this PR merges via the normal distribute-images pipeline — the field is safe to add ahead of the asset per existing precedent (american-luminism/egyptian-painting/heidelberg-school all shipped `previewImageSrc` before their files were confirmed delivered).

### Kaizen suggestion
Extend `verify_academy_style_preview_coverage.py` to also flag `academyStyles.ts` entries with no `previewImageSrc` field at all (not just undelivered ones) — that's the actual gap class this cycle found, and the script currently can't see it.

### Notes for reviewer
Small, additive, conductor-only-adjacent change; no behavior change for existing styles.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPYV55ZqRGoZTq4CPmaasi)_