### PR TITLE
Stop translucent surfaces stacking over the backdrop

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -114,13 +114,21 @@
           surface resolves to the same opaque theme colour it always had.
         -->
         <!--
-          No background of its own. The shell-level backdrop is behind this, so
-          an opaque ground here would hide it again — which is the bug that made
-          the first backdrops invisible. The token resolves to base-100 exactly
-          when no page declares art.
+          NO BACKGROUND AT ALL. This is a structural container, not a surface —
+          the page root inside it is the surface, and every page root already
+          reads a translucent token.
+          
+          Giving <main> a token too stacked two translucent layers over the art:
+          66% and then 66% of what was left is ~88% opaque, which is why the
+          first full-page attempt looked like no backdrop at all. Opacity
+          multiplies down a stack; only one layer in it may paint.
+          
+          Pages with no backdrop are unaffected — .kr-shell paints base-100
+          behind this, and the page root resolves to the same colour it always
+          had.
         -->
         <main
-          class="kr-main relative z-10 h-full min-h-0 overflow-hidden rounded-2xl bg-(--kr-surface-raised) transition-[padding] duration-300 ease-out"
+          class="kr-main relative z-10 h-full min-h-0 overflow-hidden rounded-2xl transition-[padding] duration-300 ease-out"
           :class="workspaceSheetOpen ? 'hidden md:block' : 'block'"
         >
           <fx-region region="page" />

--- a/utils/scripts/verifyPageBackdrop.ts
+++ b/utils/scripts/verifyPageBackdrop.ts
@@ -381,6 +381,32 @@ for (const name of PAGE_ROOTS) {
   )
 }
 
+/* -- only one layer between the art and the eye ---------------------------- */
+
+/*
+ * Opacity MULTIPLIES down a stack. Two translucent surfaces at 66% leave ~12%
+ * of the art visible, which reads as no backdrop at all — that is exactly what
+ * happened when <main> was given a surface token alongside the page root it
+ * contains (Silas, 2026-08-06: "Still not seeing backgrounds over the whole
+ * page").
+ *
+ * <main> is a structural container. The page root inside it is the surface.
+ * Giving <main> any background — a raw theme colour OR a token — puts a second
+ * layer in the stack and dims every backdrop in the app at once.
+ */
+{
+  const appSource = withoutComments(read('app.vue'))
+  const mainTag = appSource.match(/<main[^>]*>/)?.[0] ?? ''
+
+  check(
+    Boolean(mainTag) && !/\bbg-/.test(mainTag),
+    `app.vue's <main> must carry no background utility at all. It sits between ` +
+      `the shell-level backdrop and the page root's own translucent surface, so ` +
+      `anything it paints becomes a second layer — and two translucent layers ` +
+      `multiply into an effectively opaque one.`,
+  )
+}
+
 function selfTest(): void {
   const collisions = collidingSchemaKeys(`
   amiTip: z.string().optional(),


### PR DESCRIPTION
*"Still not seeing backgrounds over the whole page."*

I checked the deployed CSS first — `66%`/`55%`/`45%` were live, so #1522 had shipped and the backdrop was in the right place. The problem was one I introduced by moving it: **opacity multiplies down a stack.**

Before, `<main>` was opaque and the backdrop sat **inside** it, so exactly one translucent layer — the page root — stood between the art and the eye. Moving the backdrop out to `.kr-shell` put `<main>` in front of it too, and giving `<main>` a surface token made it a second layer:

```
0.66 + (0.34 × 0.66) ≈ 0.88 opaque
```

…before the scrim and Taskmaster's own gradient backdrop are counted. The art was rendering the whole time and was effectively invisible.

`<main>` is a **structural container, not a surface**. The page root inside it is the surface, and every page root already reads a translucent token — so `<main>` now carries no background at all.

Pages without a backdrop are unchanged: `.kr-shell` paints `base-100` behind it, and the page root resolves to the same colour it always had.

## Verification

`verifyPageBackdrop` now fails if `<main>` regains **any** `bg-` utility — a raw theme colour or a token, since either re-creates the stack. Watched to fail by adding `bg-base-100` back.

Layout contract holds, page-backdrop contract passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_