### PR TITLE
Render the page backdrop on the server, not after hydration

### DIFF
--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -227,6 +227,25 @@ function syncPageStore(): void {
   pageStore.clearPage()
 }
 
+/*
+ * Populate the store during SETUP, not only on mount.
+ *
+ * activePage comes from an awaited useAsyncData, so the content is already
+ * resolved on the server — but syncPageStore only ran inside onMounted, which
+ * never fires there. The store stayed empty through SSR, so anything driven by
+ * it rendered nothing until hydration.
+ *
+ * The page backdrop made that visible: app.vue emits no backdrop element at all
+ * when pageStore reports no art, so every page load painted a backdrop-less
+ * first frame and then popped the art in. Title and description came from the
+ * same store and had the same gap.
+ *
+ * onMounted still runs it, which is a harmless no-op re-set on the client and
+ * still the right place to start the store's own async initialize and the
+ * route watcher.
+ */
+syncPageStore()
+
 onMounted(() => {
   pageStore.initialize()
   syncPageStore()

--- a/utils/scripts/verifyPageBackdrop.ts
+++ b/utils/scripts/verifyPageBackdrop.ts
@@ -407,6 +407,33 @@ for (const name of PAGE_ROOTS) {
   )
 }
 
+/* -- the store is populated during SSR, not only after hydration ------------ */
+
+/*
+ * pages/[...slug].vue resolves its content with an awaited useAsyncData, so the
+ * page IS known on the server. But syncPageStore() only ran inside onMounted,
+ * which never fires there — so pageStore stayed empty through SSR and anything
+ * reading it rendered nothing until hydration.
+ *
+ * The backdrop makes that visible: app.vue emits no backdrop element at all
+ * when the store reports no art, so every load painted a backdrop-less first
+ * frame and then popped the art in. Moving the call back inside onMounted would
+ * silently restore that flash on every page in the app.
+ */
+{
+  const slugPage = withoutComments(read('pages/[...slug].vue'))
+  const setupCall = slugPage.search(/^syncPageStore\(\)/m)
+  const mountedAt = slugPage.search(/onMounted\(/)
+
+  check(
+    setupCall !== -1 && (mountedAt === -1 || setupCall < mountedAt),
+    `pages/[...slug].vue must call syncPageStore() at setup scope, before ` +
+      `onMounted. onMounted never runs on the server, so a mount-only call ` +
+      `leaves pageStore empty through SSR and the backdrop renders only after ` +
+      `hydration — a visible flash on every page load.`,
+  )
+}
+
 function selfTest(): void {
   const collisions = collidingSchemaKeys(`
   amiTip: z.string().optional(),


### PR DESCRIPTION
`pages/[...slug].vue` resolves its content with an **awaited** `useAsyncData`, so the page is fully known on the server. But `syncPageStore()` was only called inside `onMounted()`, which never runs there — so `pageStore` stayed empty through SSR and everything reading it rendered nothing until hydration.

The backdrop made that visible. `app.vue` emits **no backdrop element at all** when the store reports no art, so every page load painted a backdrop-less first frame and then popped the art in. Title and description come from the same store and had the same gap.

`syncPageStore()` now runs at setup scope. `onMounted` keeps its call — a harmless re-set on the client, and still the right place to kick off the store's own async `initialize()` and the route watcher.

### Why this matters beyond the flash

It also makes visual judgement about the backdrops trustworthy. Until now the art arrived a beat after load, so "the backdrop looks wrong" and "the backdrop hasn't arrived yet" were indistinguishable. With SSR the first frame is the real one.

### Verification

`verifyPageBackdrop` fails if the setup call disappears or moves after `onMounted` — either silently restores the flash across every page in the app. Watched to fail by removing it.

Typecheck clean, layout contract holds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_