### PR TITLE
Backdrop art for every remaining front-end route

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -15,6 +15,13 @@ dashboardTab: community
 cards: navCards
 loadingMessage: Loading plans...
 refreshLabel: Refresh mission statement
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/about-mobile
+backgroundTablet: /api/art/backdrop/about-tablet
+backgroundDesktop: /api/art/backdrop/about-desktop
 ---
 
 :about-page

--- a/content/account.md
+++ b/content/account.md
@@ -13,6 +13,13 @@ tabKey: account
 requiredPermission: authenticated
 loadingMessage: Loading account settings...
 refreshLabel: Refresh account
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/account-mobile
+backgroundTablet: /api/art/backdrop/account-tablet
+backgroundDesktop: /api/art/backdrop/account-desktop
 ---
 
 :account-settings

--- a/content/achievements.md
+++ b/content/achievements.md
@@ -16,6 +16,13 @@ dashboardTab: achievements
 cards: navCards
 loadingMessage: Loading achievements
 refreshLabel: Refresh Achievements
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/achievements-mobile
+backgroundTablet: /api/art/backdrop/achievements-tablet
+backgroundDesktop: /api/art/backdrop/achievements-desktop
 ---
 
 :user-manager

--- a/content/appmaker.md
+++ b/content/appmaker.md
@@ -13,6 +13,13 @@ dashboardTab: appmaker
 cards: navCards
 loadingMessage: Assembling the workshop...
 refreshLabel: Refresh AppMaker
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/appmaker-mobile
+backgroundTablet: /api/art/backdrop/appmaker-tablet
+backgroundDesktop: /api/art/backdrop/appmaker-desktop
 ---
 
 :appmaker-page

--- a/content/artjob.md
+++ b/content/artjob.md
@@ -15,6 +15,13 @@ dashboardTab: artjob
 requiredRole: ADMIN
 loadingMessage: Loading ArtJob pipeline...
 refreshLabel: Refresh ArtJob
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/artjob-mobile
+backgroundTablet: /api/art/backdrop/artjob-tablet
+backgroundDesktop: /api/art/backdrop/artjob-desktop
 ---
 
 :art-manager

--- a/content/brainstorm.md
+++ b/content/brainstorm.md
@@ -16,6 +16,13 @@ dashboardTab: brainstorm
 cards: dreamCards
 loadingMessage: Loading brainstorm
 refreshLabel: Refresh Brainstorms
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/brainstorm-mobile
+backgroundTablet: /api/art/backdrop/brainstorm-tablet
+backgroundDesktop: /api/art/backdrop/brainstorm-desktop
 ---
 
 :dream-manager

--- a/content/build/animation-manager.md
+++ b/content/build/animation-manager.md
@@ -16,6 +16,13 @@ dashboardTab: animation-manager
 cards: labCards
 loadingMessage: Loading the Animation Manager...
 refreshLabel: Refresh Gallery
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/animation-manager-mobile
+backgroundTablet: /api/art/backdrop/animation-manager-tablet
+backgroundDesktop: /api/art/backdrop/animation-manager-desktop
 ---
 
 :lab-manager

--- a/content/build/hair-studio.md
+++ b/content/build/hair-studio.md
@@ -16,6 +16,13 @@ dashboardTab: stylist
 cards: artCards
 loadingMessage: Loading Hair Studio...
 refreshLabel: Refresh Studio
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/hair-studio-mobile
+backgroundTablet: /api/art/backdrop/hair-studio-tablet
+backgroundDesktop: /api/art/backdrop/hair-studio-desktop
 ---
 
 :hair-studio-manager

--- a/content/build/mural.md
+++ b/content/build/mural.md
@@ -16,6 +16,13 @@ dashboardTab: mural
 cards: labCards
 loadingMessage: Loading mural studio...
 refreshLabel: Refresh Mural
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/mural-mobile
+backgroundTablet: /api/art/backdrop/mural-tablet
+backgroundDesktop: /api/art/backdrop/mural-desktop
 ---
 
 :mural-manager

--- a/content/cart.md
+++ b/content/cart.md
@@ -10,6 +10,13 @@ dashboardKey: giftshop
 dashboardTab: giftshop
 loadingMessage: Gathering the cart butterflies...
 refreshLabel: Refresh cart
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/cart-mobile
+backgroundTablet: /api/art/backdrop/cart-tablet
+backgroundDesktop: /api/art/backdrop/cart-desktop
 ---
 
 :shopping-cart

--- a/content/channels/admin/index.md
+++ b/content/channels/admin/index.md
@@ -15,6 +15,13 @@ loadingMessage: Loading admin systems...
 refreshLabel: Refresh Admin
 dottiTip: Admin tools are powerful, so I brought validation.
 amiTip: I brought a helmet.
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/admin-mobile
+backgroundTablet: /api/art/backdrop/admin-tablet
+backgroundDesktop: /api/art/backdrop/admin-desktop
 ---
 
 Manage the systems and queues that keep Kind Robots running.

--- a/content/channels/home/index.md
+++ b/content/channels/home/index.md
@@ -15,6 +15,13 @@ loadingMessage: Loading your dashboard...
 refreshLabel: Refresh Home
 dottiTip: Start here when you want to see what is yours.
 amiTip: Home is where the robot remembers your favorite buttons.
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/home-mobile
+backgroundTablet: /api/art/backdrop/home-tablet
+backgroundDesktop: /api/art/backdrop/home-desktop
 ---
 
 Your personal space for activity, communication, favorites, and settings.

--- a/content/channels/plan/index.md
+++ b/content/channels/plan/index.md
@@ -14,6 +14,13 @@ loadingMessage: Loading project plans...
 refreshLabel: Refresh Plan
 dottiTip: Plan is where ideas stop being fog and start becoming steps.
 amiTip: I brought tiny clipboards and several suspiciously ambitious paintbrushes.
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/plan-mobile
+backgroundTablet: /api/art/backdrop/plan-tablet
+backgroundDesktop: /api/art/backdrop/plan-desktop
 ---
 
 Shape ideas into projects, build their working parts, coordinate the work, and keep humans in the loop.

--- a/content/channels/play/index.md
+++ b/content/channels/play/index.md
@@ -14,6 +14,13 @@ loadingMessage: Loading creative worlds...
 refreshLabel: Refresh Play
 dottiTip: Play is where creations are explored, remixed, and put into motion.
 amiTip: One creative room. Fewer clipboards. More useful chaos.
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/play-mobile
+backgroundTablet: /api/art/backdrop/play-tablet
+backgroundDesktop: /api/art/backdrop/play-desktop
 ---
 
 Browse what already exists, remix it, chat with it, and put it into play.

--- a/content/channels/sanctuary/index.md
+++ b/content/channels/sanctuary/index.md
@@ -14,6 +14,13 @@ loadingMessage: Loading Sanctuary...
 refreshLabel: Refresh Sanctuary
 dottiTip: Sanctuary explains why we are building all of this.
 amiTip: Also where we keep the butterflies.
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/sanctuary-hub-mobile
+backgroundTablet: /api/art/backdrop/sanctuary-hub-tablet
+backgroundDesktop: /api/art/backdrop/sanctuary-hub-desktop
 ---
 
 Learn about Kind Robots, our mission, our community, and how to support the work.

--- a/content/chats.md
+++ b/content/chats.md
@@ -15,6 +15,13 @@ dashboardTab: chats
 cards: navCards
 loadingMessage: Loading chats
 refreshLabel: Refresh chats
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/chats-mobile
+backgroundTablet: /api/art/backdrop/chats-tablet
+backgroundDesktop: /api/art/backdrop/chats-desktop
 ---
 
 :chat-gallery

--- a/content/conductor-app.md
+++ b/content/conductor-app.md
@@ -13,6 +13,13 @@ dashboardTab: conductor-app
 cards: navCards
 loadingMessage: Pairing the app...
 refreshLabel: Refresh Conductor App
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/conductor-app-mobile
+backgroundTablet: /api/art/backdrop/conductor-app-tablet
+backgroundDesktop: /api/art/backdrop/conductor-app-desktop
 ---
 
 :conductor-app-page

--- a/content/dashboard.md
+++ b/content/dashboard.md
@@ -15,6 +15,13 @@ dashboardTab: profile
 cards: navCards
 loadingMessage: Loading user dashboard
 refreshLabel: Refresh dashboard
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/dashboard-mobile
+backgroundTablet: /api/art/backdrop/dashboard-tablet
+backgroundDesktop: /api/art/backdrop/dashboard-desktop
 ---
 
 :user-manager

--- a/content/error.md
+++ b/content/error.md
@@ -9,6 +9,13 @@ tooltip: This page doesn't exist, but you're still in good company.
 dottiTip: "Looks like someone misplaced a link."
 amiTip: "Or maybe this is a secret room… with no walls!"
 sort: error
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/error-mobile
+backgroundTablet: /api/art/backdrop/error-tablet
+backgroundDesktop: /api/art/backdrop/error-desktop
 ---
 
 <img src="/images/background/error.webp" alt="Whimsical robot 404" class="w-full max-w-3xl mx-auto rounded-xl shadow-lg mb-8" />

--- a/content/facet-gallery.md
+++ b/content/facet-gallery.md
@@ -14,6 +14,13 @@ dashboardTab: gallery
 loadingMessage: Loading Facets...
 refreshLabel: Refresh Facets
 redirect: /facets
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/facet-gallery-mobile
+backgroundTablet: /api/art/backdrop/facet-gallery-tablet
+backgroundDesktop: /api/art/backdrop/facet-gallery-desktop
 ---
 
 This legacy route redirects to the canonical Facets browser.

--- a/content/facets.md
+++ b/content/facets.md
@@ -13,6 +13,13 @@ dashboardKey: facets
 dashboardTab: gallery
 loadingMessage: Loading facets...
 refreshLabel: Refresh Facets
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/facets-mobile
+backgroundTablet: /api/art/backdrop/facets-tablet
+backgroundDesktop: /api/art/backdrop/facets-desktop
 ---
 
 :facet-manager

--- a/content/for-you.md
+++ b/content/for-you.md
@@ -9,6 +9,13 @@ channelKey: home
 tabKey: for-you
 loadingMessage: Loading your attention desk...
 refreshLabel: Refresh
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/for-you-mobile
+backgroundTablet: /api/art/backdrop/for-you-tablet
+backgroundDesktop: /api/art/backdrop/for-you-desktop
 ---
 
 :for-you-manager

--- a/content/forum.md
+++ b/content/forum.md
@@ -9,6 +9,13 @@ tooltip: 'Jump into the conversation and let your ideas unfold.'
 dottiTip: 'Threads help us track the chaos. Use them wisely.'
 amiTip: 'I replied to a reply but someone already replied to their reply. Was that wrong?'
 sort: highlight
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/forum-mobile
+backgroundTablet: /api/art/backdrop/forum-tablet
+backgroundDesktop: /api/art/backdrop/forum-desktop
 ---
 
 :forum-thread

--- a/content/friends.md
+++ b/content/friends.md
@@ -13,6 +13,13 @@ tabKey: friends
 requiredPermission: authenticated
 loadingMessage: Loading friends...
 refreshLabel: Refresh friends
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/friends-mobile
+backgroundTablet: /api/art/backdrop/friends-tablet
+backgroundDesktop: /api/art/backdrop/friends-desktop
 ---
 
 :friends-panel

--- a/content/icons.md
+++ b/content/icons.md
@@ -9,6 +9,13 @@ tooltip: 'See all icons available to personalize your Kind Robots experience.'
 dottiTip: AMI, how many icons is too many icons?
 amiTip: The correct number of icons is 'yes.'
 sort: gallery
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/icons-mobile
+backgroundTablet: /api/art/backdrop/icons-tablet
+backgroundDesktop: /api/art/backdrop/icons-desktop
 ---
 
 :icon-gallery

--- a/content/mermaids.md
+++ b/content/mermaids.md
@@ -15,6 +15,13 @@ dashboardTab: mermaids
 cards: navCards
 loadingMessage: Rowing out to the lagoon...
 refreshLabel: Refresh the tide
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/mermaids-mobile
+backgroundTablet: /api/art/backdrop/mermaids-tablet
+backgroundDesktop: /api/art/backdrop/mermaids-desktop
 ---
 
 :mermaids-page

--- a/content/messages.md
+++ b/content/messages.md
@@ -13,6 +13,13 @@ tabKey: messages
 requiredPermission: authenticated
 loadingMessage: Loading messages...
 refreshLabel: Refresh messages
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/messages-mobile
+backgroundTablet: /api/art/backdrop/messages-tablet
+backgroundDesktop: /api/art/backdrop/messages-desktop
 ---
 
 :messenger

--- a/content/model-builder.md
+++ b/content/model-builder.md
@@ -12,6 +12,13 @@ dashboardTab: model-builder
 cards: navCards
 loadingMessage: Loading Model Builder…
 refreshLabel: Refresh
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/model-builder-mobile
+backgroundTablet: /api/art/backdrop/model-builder-tablet
+backgroundDesktop: /api/art/backdrop/model-builder-desktop
 ---
 
 :model-builder-manager

--- a/content/navigation-health.md
+++ b/content/navigation-health.md
@@ -11,6 +11,13 @@ loadingMessage: Loading navigation health...
 refreshLabel: Reload Navigation
 dottiTip: The navigation has a navigation page now. I promise this is less silly than it sounds.
 amiTip: Maps need legends. Systems need mirrors.
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/navigation-health-mobile
+backgroundTablet: /api/art/backdrop/navigation-health-tablet
+backgroundDesktop: /api/art/backdrop/navigation-health-desktop
 ---
 
 :navigation-health

--- a/content/navigation.md
+++ b/content/navigation.md
@@ -15,6 +15,13 @@ dashboardTab: user
 cards: navCards
 loadingMessage: Loading navigation
 refreshLabel: Refresh navigation
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/navigation-mobile
+backgroundTablet: /api/art/backdrop/navigation-tablet
+backgroundDesktop: /api/art/backdrop/navigation-desktop
 ---
 
 :navigation-trimmed

--- a/content/plan/newsfeed.md
+++ b/content/plan/newsfeed.md
@@ -13,6 +13,13 @@ dashboardTab: newsfeed
 cards: navCards
 loadingMessage: Setting the front page...
 refreshLabel: Refresh the feed
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/newsfeed-mobile
+backgroundTablet: /api/art/backdrop/newsfeed-tablet
+backgroundDesktop: /api/art/backdrop/newsfeed-desktop
 ---
 
 :newsfeed-page

--- a/content/plan/projects/coat-dance.md
+++ b/content/plan/projects/coat-dance.md
@@ -13,6 +13,13 @@ dashboardTab: coat-dance
 cards: navCards
 loadingMessage: Cueing the music...
 refreshLabel: Refresh Coat Dance
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/coat-dance-mobile
+backgroundTablet: /api/art/backdrop/coat-dance-tablet
+backgroundDesktop: /api/art/backdrop/coat-dance-desktop
 ---
 
 :coat-dance-page

--- a/content/plan/projects/humboldt-scoop.md
+++ b/content/plan/projects/humboldt-scoop.md
@@ -13,6 +13,13 @@ dashboardTab: humboldt-scoop
 cards: navCards
 loadingMessage: Grabbing the scoop...
 refreshLabel: Refresh
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/humboldt-scoop-mobile
+backgroundTablet: /api/art/backdrop/humboldt-scoop-tablet
+backgroundDesktop: /api/art/backdrop/humboldt-scoop-desktop
 ---
 
 :humboldt-scoop-page

--- a/content/plan/projects/ruler-hooked.md
+++ b/content/plan/projects/ruler-hooked.md
@@ -13,6 +13,13 @@ dashboardTab: ruler-hooked
 cards: navCards
 loadingMessage: Checking the tide charts...
 refreshLabel: Refresh the shore
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/ruler-hooked-mobile
+backgroundTablet: /api/art/backdrop/ruler-hooked-tablet
+backgroundDesktop: /api/art/backdrop/ruler-hooked-desktop
 ---
 
 :ruler-hooked-page

--- a/content/plan/projects/sketchy.md
+++ b/content/plan/projects/sketchy.md
@@ -13,6 +13,13 @@ dashboardTab: sketchy
 cards: navCards
 loadingMessage: Sharpening the pencils...
 refreshLabel: Refresh Sketchy
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/sketchy-mobile
+backgroundTablet: /api/art/backdrop/sketchy-tablet
+backgroundDesktop: /api/art/backdrop/sketchy-desktop
 ---
 
 :sketchy-page

--- a/content/plan/voice-lab.md
+++ b/content/plan/voice-lab.md
@@ -13,6 +13,13 @@ dashboardTab: voice-lab
 cards: navCards
 loadingMessage: Tuning the microphone...
 refreshLabel: Refresh Voice Lab
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/voice-lab-mobile
+backgroundTablet: /api/art/backdrop/voice-lab-tablet
+backgroundDesktop: /api/art/backdrop/voice-lab-desktop
 ---
 
 :voice-lab-page

--- a/content/plan/watchlist.md
+++ b/content/plan/watchlist.md
@@ -13,6 +13,13 @@ dashboardTab: watchlist
 cards: navCards
 loadingMessage: Rolling the credits...
 refreshLabel: Refresh watchlist
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/watchlist-mobile
+backgroundTablet: /api/art/backdrop/watchlist-tablet
+backgroundDesktop: /api/art/backdrop/watchlist-desktop
 ---
 
 :watchlist-page

--- a/content/play/challenges.md
+++ b/content/play/challenges.md
@@ -15,6 +15,13 @@ dashboardTab: challenges
 cards: navCards
 loadingMessage: Warming up the arena...
 refreshLabel: Refresh challenges
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/challenges-mobile
+backgroundTablet: /api/art/backdrop/challenges-tablet
+backgroundDesktop: /api/art/backdrop/challenges-desktop
 ---
 
 :challenge-center-page

--- a/content/play/davinci.md
+++ b/content/play/davinci.md
@@ -13,6 +13,13 @@ dashboardTab: davinci
 cards: navCards
 loadingMessage: Seeding a new life...
 refreshLabel: Refresh Da Vinci
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/davinci-mobile
+backgroundTablet: /api/art/backdrop/davinci-tablet
+backgroundDesktop: /api/art/backdrop/davinci-desktop
 ---
 
 :davinci-page

--- a/content/play/memory.md
+++ b/content/play/memory.md
@@ -15,6 +15,13 @@ dashboardTab: memory-dungeon
 cards: labCards
 loadingMessage: Loading memory
 refreshLabel: Refresh memory
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/memory-mobile
+backgroundTablet: /api/art/backdrop/memory-tablet
+backgroundDesktop: /api/art/backdrop/memory-desktop
 ---
 
 :lab-manager

--- a/content/play/screenfx.md
+++ b/content/play/screenfx.md
@@ -16,6 +16,13 @@ dashboardTab: screen-fx
 cards: labCards
 loadingMessage: Loading screen fx...
 refreshLabel: Refresh Effects
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/screenfx-mobile
+backgroundTablet: /api/art/backdrop/screenfx-tablet
+backgroundDesktop: /api/art/backdrop/screenfx-desktop
 ---
 
 :lab-manager

--- a/content/privacy.md
+++ b/content/privacy.md
@@ -16,6 +16,13 @@ dashboardTab: user
 cards: navCards
 loadingMessage: Loading privacy
 refreshLabel: Refresh Privacy
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/privacy-mobile
+backgroundTablet: /api/art/backdrop/privacy-tablet
+backgroundDesktop: /api/art/backdrop/privacy-desktop
 ---
 
 :privacy-page

--- a/content/project-placement.md
+++ b/content/project-placement.md
@@ -15,6 +15,13 @@ loadingMessage: Loading project placement controls...
 refreshLabel: Reload Projects
 dottiTip: I made the placement migration visible so it cannot hide behind a store method forever.
 amiTip: Excellent. Dangerous buttons should at least have labels.
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/project-placement-mobile
+backgroundTablet: /api/art/backdrop/project-placement-tablet
+backgroundDesktop: /api/art/backdrop/project-placement-desktop
 ---
 
 :project-placement-manager

--- a/content/register.md
+++ b/content/register.md
@@ -16,6 +16,13 @@ dashboardTab: profile
 cards: navCards
 loadingMessage: Loading registration
 refreshLabel: Refresh registration
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/register-mobile
+backgroundTablet: /api/art/backdrop/register-tablet
+backgroundDesktop: /api/art/backdrop/register-desktop
 ---
 
 :registration-page

--- a/content/reset-password.md
+++ b/content/reset-password.md
@@ -10,6 +10,13 @@ dottiTip: Forgot it? Happens to the best of us. No judgment.
 amiTip: Pop in your email and we'll send a fresh link.
 loadingMessage: Loading password recovery...
 refreshLabel: Refresh
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/reset-password-mobile
+backgroundTablet: /api/art/backdrop/reset-password-tablet
+backgroundDesktop: /api/art/backdrop/reset-password-desktop
 ---
 
 :password-reset

--- a/content/scoop-cms.md
+++ b/content/scoop-cms.md
@@ -14,6 +14,13 @@ requiredRole: ADMIN
 cards: navCards
 loadingMessage: Opening the back office...
 refreshLabel: Refresh Scoop CMS
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/scoop-cms-mobile
+backgroundTablet: /api/art/backdrop/scoop-cms-tablet
+backgroundDesktop: /api/art/backdrop/scoop-cms-desktop
 ---
 
 :scoop-cms-page

--- a/content/servers.md
+++ b/content/servers.md
@@ -8,6 +8,13 @@ tooltip: 'Manage your custom and official servers.'
 dottiTip: 'A good server page is like a switchboard for chaos.'
 amiTip: 'I like a dropdown full of possibilities and only mild danger.'
 sort: highlight
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/servers-mobile
+backgroundTablet: /api/art/backdrop/servers-tablet
+backgroundDesktop: /api/art/backdrop/servers-desktop
 ---
 
 :server-manager

--- a/content/shop/cancel.md
+++ b/content/shop/cancel.md
@@ -6,6 +6,13 @@ icon: kind-icon:cart
 image: splash/sanctuary.png
 loadingMessage: Restoring the cart...
 refreshLabel: Refresh checkout status
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/shop-cancel-mobile
+backgroundTablet: /api/art/backdrop/shop-cancel-tablet
+backgroundDesktop: /api/art/backdrop/shop-cancel-desktop
 ---
 
 :checkout-cancel

--- a/content/shop/success.md
+++ b/content/shop/success.md
@@ -6,6 +6,13 @@ icon: kind-icon:check
 image: splash/sanctuary.png
 loadingMessage: Confirming the Stripe receipt...
 refreshLabel: Verify payment again
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/shop-success-mobile
+backgroundTablet: /api/art/backdrop/shop-success-tablet
+backgroundDesktop: /api/art/backdrop/shop-success-desktop
 ---
 
 :checkout-success

--- a/content/stages.md
+++ b/content/stages.md
@@ -13,6 +13,13 @@ dashboardTab: stage
 cards: navCards
 loadingMessage: Loading stage manager...
 refreshLabel: Refresh Stages
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/stages-mobile
+backgroundTablet: /api/art/backdrop/stages-tablet
+backgroundDesktop: /api/art/backdrop/stages-desktop
 ---
 
 :character-manager

--- a/content/stylist.md
+++ b/content/stylist.md
@@ -17,6 +17,13 @@ route: /stylist
 cards: artCards
 loadingMessage: Loading Superkate Services...
 refreshLabel: Refresh Services
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/stylist-mobile
+backgroundTablet: /api/art/backdrop/stylist-tablet
+backgroundDesktop: /api/art/backdrop/stylist-desktop
 ---
 
 :stylist-manager

--- a/content/themes.md
+++ b/content/themes.md
@@ -16,6 +16,13 @@ dashboardTab: themes
 cards: navCards
 loadingMessage: Loading theme gallery...
 refreshLabel: Refresh Themes
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/themes-mobile
+backgroundTablet: /api/art/backdrop/themes-tablet
+backgroundDesktop: /api/art/backdrop/themes-desktop
 ---
 
 :user-manager

--- a/content/user-admin.md
+++ b/content/user-admin.md
@@ -13,6 +13,13 @@ tabKey: user-admin
 requiredRole: ADMIN
 loadingMessage: Loading user admin...
 refreshLabel: Refresh users
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/user-admin-mobile
+backgroundTablet: /api/art/backdrop/user-admin-tablet
+backgroundDesktop: /api/art/backdrop/user-admin-desktop
 ---
 
 :user-manager-directory

--- a/content/wallet.md
+++ b/content/wallet.md
@@ -15,6 +15,13 @@ dashboardTab: profile
 requiredPermission: authenticated
 loadingMessage: Loading wallet...
 refreshLabel: Refresh wallet
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/wallet-mobile
+backgroundTablet: /api/art/backdrop/wallet-tablet
+backgroundDesktop: /api/art/backdrop/wallet-desktop
 ---
 
 :wallet-page

--- a/content/wishmaster.md
+++ b/content/wishmaster.md
@@ -13,6 +13,13 @@ dashboardTab: wishmaster
 cards: navCards
 loadingMessage: Granting wishes...
 refreshLabel: Refresh Wishmaster
+# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
+# The route finds the completed ArtJob for this page and redirects to its
+# image, so art appears on its own once generation finishes. Until then the
+# route 404s and the page renders exactly as before.
+backgroundMobile: /api/art/backdrop/wishmaster-mobile
+backgroundTablet: /api/art/backdrop/wishmaster-tablet
+backgroundDesktop: /api/art/backdrop/wishmaster-desktop
 ---
 
 :wishmaster-page

--- a/stores/seeds/pageBackdropArtPrompts.ts
+++ b/stores/seeds/pageBackdropArtPrompts.ts
@@ -212,6 +212,336 @@ const PAGES: PageSeed[] = [
     scene:
       'The story door: a single ornate doorway standing free in a soft twilight meadow, its frame carved with small creatures, light spilling warm from the gap where it stands ajar. Tall grass and fireflies at the lower edges, deep blue sky above. Inviting and a little mysterious, with the space around the door left open.',
   },
+  {
+    page: 'about',
+    title: 'About — The Workshop Door',
+    scene:
+      'A welcoming studio entryway at dawn: a cracked-open door onto a sunlit workshop of half-built robots, paper birds and warm brass lamps, with ivy at the threshold and a hand-lettered welcome sign. Friendly and unpretentious.',
+  },
+  {
+    page: 'account',
+    title: 'Account — The Keeper\'s Desk',
+    scene:
+      'A quiet study nook with a leather ledger, a ring of small brass keys, a cup of tea going cold, and a window onto soft evening rooftops. Orderly, private and calm.',
+  },
+  {
+    page: 'achievements',
+    title: 'Achievements — The Trophy Conservatory',
+    scene:
+      'A glass conservatory of ribboned medals and small sculpted trophies on floating shelves, sunlight refracting through hanging prisms, laurel vines climbing the frames. Celebratory but unshowy.',
+  },
+  {
+    page: 'admin',
+    title: 'Admin — The Signal Tower',
+    scene:
+      'A calm control loft of brass dials, patch cables and softly blinking status lamps, tall windows onto a night city. Competent and unalarming.',
+  },
+  {
+    page: 'animation-manager',
+    title: 'Animation — The Flipbook Theatre',
+    scene:
+      'A small theatre of suspended film strips and flipbook pages caught mid-turn, a projector throwing soft light onto a screen at the edge, dust motes in the beam. Playful and mechanical.',
+  },
+  {
+    page: 'appmaker',
+    title: 'Appmaker — The Assembly Bench',
+    scene:
+      'A bright maker bench strewn with modular tiles, blueprints and glowing wireframe shapes assembling themselves midair, tools racked neatly on a pegboard wall. Inventive and tidy.',
+  },
+  {
+    page: 'artjob',
+    title: 'Art Queue — The Kiln Room',
+    scene:
+      'A warm kiln room where framed canvases move slowly along a wooden rail, some still blank, some glowing as they finish. Ledgers and numbered tags hang at the sides. Patient industry.',
+  },
+  {
+    page: 'brainstorm',
+    title: 'Brainstorm — The Idea Storm',
+    scene:
+      'A tall airy loft where sticky notes, chalk sketches and paper aeroplanes swirl on a gentle indoor breeze, lightning-bug sparks of inspiration drifting near the ceiling. Energetic, not chaotic.',
+  },
+  {
+    page: 'cart',
+    title: 'Cart — The Packing Room',
+    scene:
+      'A cosy shipping room of brown-paper parcels, twine spools, stamps and a wooden counter, a cat asleep on a stack of boxes, warm lamplight. Homely commerce.',
+  },
+  {
+    page: 'challenges',
+    title: 'Challenges — The Trial Grounds',
+    scene:
+      'A sunlit training yard of rope courses, targets and chalked circles, banners snapping, mountains beyond. Spirited and sporting.',
+  },
+  {
+    page: 'chats',
+    title: 'Chats — The Long Table',
+    scene:
+      'A convivial long table under strung lights in a courtyard, mismatched chairs, teapots and open notebooks, conversation implied by empty seats. Warm and social.',
+  },
+  {
+    page: 'coat-dance',
+    title: 'Coat Dance — The Cloakroom Ball',
+    scene:
+      'An empty ballroom where coats on stands sway as though dancing, chandeliers dimmed, moonlight across the parquet. Whimsical and a little uncanny.',
+  },
+  {
+    page: 'conductor-app',
+    title: 'Conductor — The Signal Room',
+    scene:
+      'An orchestral signal room where lines of light run from a central podium out to distant workshops, batons and score sheets on a stand. Coordinating many hands.',
+  },
+  {
+    page: 'dashboard',
+    title: 'Dashboard — The Observatory Deck',
+    scene:
+      'A brass observatory deck with orreries, charts and a wide balcony over a lantern-lit valley at blue hour. Overview and calm command.',
+  },
+  {
+    page: 'davinci',
+    title: 'Davinci — The Codex Loft',
+    scene:
+      'A Renaissance loft of flying-machine sketches, mirrored handwriting, brass instruments and a half-built wing. Curious and inventive.',
+  },
+  {
+    page: 'error',
+    title: 'Error — The Detour',
+    scene:
+      'A misty crossroads with a friendly signpost pointing several ways, a lantern-lit cart and a small robot offering directions. Reassuring, not ominous.',
+  },
+  {
+    page: 'facet-gallery',
+    title: 'Facet Gallery — The Prism Vault',
+    scene:
+      'A vault of floating cut gems each holding a tiny scene, refracted colour washing the stone walls, velvet display plinths at the edges. Jewel-like and curated.',
+  },
+  {
+    page: 'facets',
+    title: 'Facets — The Lapidary Bench',
+    scene:
+      'A lapidary workbench of loupe, tweezers and half-cut stones catching light, drawers of labelled specimens behind. Precise and tactile.',
+  },
+  {
+    page: 'for-you',
+    title: 'For You — The Gift Table',
+    scene:
+      'A table laid with wrapped parcels chosen just so, a hand-written tag on each, morning light and a vase of cut flowers. Personal and thoughtful.',
+  },
+  {
+    page: 'forum',
+    title: 'Forum — The Amphitheatre',
+    scene:
+      'A sunlit stone amphitheatre ringed with olive trees, cushions on the steps, banners at the rim. Open discussion, no podium.',
+  },
+  {
+    page: 'friends',
+    title: 'Friends — The Porch',
+    scene:
+      'A wide wooden porch at golden hour with rocking chairs, lemonade, a dog asleep, fields beyond. Easy companionship.',
+  },
+  {
+    page: 'hair-studio',
+    title: 'Hair Studio — The Styling Parlour',
+    scene:
+      'An art-deco styling parlour with mirrors ringed in warm bulbs, ribbons and combs on marble, potted ferns and a tall window onto a pastel street. Glamorous and gentle.',
+  },
+  {
+    page: 'home',
+    title: 'Home — The Hearth',
+    scene:
+      'A warm living hall with a lit hearth, deep armchairs, shelves of curios and a robot dozing on a rug, snow drifting past mullioned windows. Safe and welcoming.',
+  },
+  {
+    page: 'humboldt-scoop',
+    title: 'Humboldt Scoop — The Coast Desk',
+    scene:
+      'A weathered newsroom desk facing fogged redwood coast, typewriter, coffee, tide charts pinned to the wall. Local and grounded.',
+  },
+  {
+    page: 'icons',
+    title: 'Icons — The Sigil Wall',
+    scene:
+      'A wall of small carved and enamelled sigils in neat rows, a few lifted out on a workbench, warm raking light. Orderly and collectible.',
+  },
+  {
+    page: 'memory',
+    title: 'Memory — The Card Hall',
+    scene:
+      'A hall of face-down cards floating in neat ranks, a few flipped to show tiny glowing scenes, candlelight. Playful concentration.',
+  },
+  {
+    page: 'mermaids',
+    title: 'Mermaids — The Lagoon',
+    scene:
+      'A moonlit lagoon of bioluminescent water, kelp columns and coral arches, silver fish threading through. Mysterious and cool-toned.',
+  },
+  {
+    page: 'messages',
+    title: 'Messages — The Pigeon Loft',
+    scene:
+      'A timber pigeon loft at dawn, cubbies of folded notes, birds arriving and leaving through open shutters, straw and soft light. Anticipatory.',
+  },
+  {
+    page: 'model-builder',
+    title: 'Model Builder — The Armature Shop',
+    scene:
+      'A sculptor\'s shop of wire armatures, clay maquettes and calipers, north light through dusty glass. Constructive and hands-on.',
+  },
+  {
+    page: 'mural',
+    title: 'Mural — The Long Wall',
+    scene:
+      'A vast plastered wall part-painted with a sprawling colourful mural, scaffolding and paint pots at the edges, sunlight raking across the unfinished middle. Invitational — room to add.',
+  },
+  {
+    page: 'navigation',
+    title: 'Navigation — The Compass Rose',
+    scene:
+      'A stone floor inlaid with a huge compass rose, corridors radiating outward under arches, lanterns marking each way. Orientation made beautiful.',
+  },
+  {
+    page: 'navigation-health',
+    title: 'Navigation Health — The Chart Room',
+    scene:
+      'A ship\'s chart room with depth soundings, a brass sextant and a lamp over a spread map marked with careful corrections. Diagnostic and steady.',
+  },
+  {
+    page: 'newsfeed',
+    title: 'Newsfeed — The Press Room',
+    scene:
+      'A print room of hanging galley proofs, ink rollers and a wall of pinned dispatches, morning light through high windows. Current and busy.',
+  },
+  {
+    page: 'plan',
+    title: 'Plan — The Drafting Hall',
+    scene:
+      'A high drafting hall of tilted tables, pinned schematics, string-and-pin planning boards and tall north windows. Focused and unhurried.',
+  },
+  {
+    page: 'play',
+    title: 'Play — The Arcade Garden',
+    scene:
+      'An outdoor arcade among flowering trees: cabinets and games glowing under paper lanterns at dusk, confetti drifting. Joyful and inviting.',
+  },
+  {
+    page: 'privacy',
+    title: 'Privacy — The Safe Room',
+    scene:
+      'A panelled reading room with a heavy door ajar, curtains drawn, a single lamp and a locked box on the desk. Discreet and trustworthy.',
+  },
+  {
+    page: 'project-placement',
+    title: 'Project Placement — The Sorting Hall',
+    scene:
+      'A hall of labelled pigeonholes and a long sorting bench, folders in mid-flight to their slots. Methodical.',
+  },
+  {
+    page: 'register',
+    title: 'Register — The Threshold',
+    scene:
+      'An open gate onto a bright path through wildflowers, a welcome arch and a book on a stand. Beginning and invitation.',
+  },
+  {
+    page: 'reset-password',
+    title: 'Reset — The Locksmith',
+    scene:
+      'A locksmith\'s bench of key blanks, files and an open lock mechanism, warm focused lamplight. Repair, not alarm.',
+  },
+  {
+    page: 'ruler-hooked',
+    title: 'Ruler Hooked — The Measure Room',
+    scene:
+      'A room of hanging rulers, plumb lines and brass gauges catching light, a drafting stool below. Exacting and quiet.',
+  },
+  {
+    page: 'sanctuary-hub',
+    title: 'Sanctuary — The Quiet Grove',
+    scene:
+      'A still grove of tall pale trees around a mirror pool, soft mist, drifting fireflies, a stone bench. Restful and reverent.',
+  },
+  {
+    page: 'scoop-cms',
+    title: 'Scoop CMS — The Composing Room',
+    scene:
+      'A composing room of type cases, galley trays and a stone bench, ink and paper stacks. Editorial craft.',
+  },
+  {
+    page: 'screenfx',
+    title: 'Screen FX — The Effects Bay',
+    scene:
+      'A bay of lenses, gels and prisms throwing coloured light across a dark room, sparks and smoke curling. Showy and technical.',
+  },
+  {
+    page: 'servers',
+    title: 'Servers — The Engine Hall',
+    scene:
+      'A cathedral-scale engine hall of humming brass towers and cable runs, catwalks and status lamps in the dark. Powerful and orderly.',
+  },
+  {
+    page: 'shop-cancel',
+    title: 'Cancelled — The Turned Cart',
+    scene:
+      'A market cart turned back at a quiet lane, goods still neatly covered, a friendly vendor waving. Gentle, no blame.',
+  },
+  {
+    page: 'shop-success',
+    title: 'Success — The Ribbon Cut',
+    scene:
+      'A parcel handed over with a ribbon cut, confetti in low sun, market bunting overhead. Celebratory and warm.',
+  },
+  {
+    page: 'sketchy',
+    title: 'Sketchy — The Sketch Wall',
+    scene:
+      'A studio wall papered edge to edge with loose gesture drawings, charcoal dust, a jar of stubs on a stool. Raw and generative.',
+  },
+  {
+    page: 'stages',
+    title: 'Stages — The Backstage',
+    scene:
+      'A backstage of ropes, sandbags and half-lit flats, a slice of bright stage visible through the wings. Potential about to be revealed.',
+  },
+  {
+    page: 'stylist',
+    title: 'Stylist — The Atelier',
+    scene:
+      'A couture atelier of bolts of fabric, dress forms, pinned muslin and tall mirrors, afternoon light. Refined and creative.',
+  },
+  {
+    page: 'themes',
+    title: 'Themes — The Paint Library',
+    scene:
+      'A library of pigment jars and swatch cards arranged by hue across a whole wall, a ladder on rails. Chromatic and calm.',
+  },
+  {
+    page: 'user-admin',
+    title: 'User Admin — The Registry',
+    scene:
+      'A registry room of card catalogues and a brass name-plate press, tall ledgers and a lamp. Careful record-keeping.',
+  },
+  {
+    page: 'voice-lab',
+    title: 'Voice Lab — The Sound Booth',
+    scene:
+      'A warm sound booth of felt panels, a vintage ribbon microphone, waveform light rippling on the glass. Intimate and acoustic.',
+  },
+  {
+    page: 'wallet',
+    title: 'Wallet — The Counting House',
+    scene:
+      'A counting house of brass scales, coin trays and a ledger under a green-shaded lamp, warm wood. Trustworthy and precise.',
+  },
+  {
+    page: 'watchlist',
+    title: 'Watchlist — The Screening Room',
+    scene:
+      'A small velvet screening room, projector beam through dark, reels stacked at the side, one seat turned out. Anticipatory and cosy.',
+  },
+  {
+    page: 'wishmaster',
+    title: 'Wishmaster — The Wish Well',
+    scene:
+      'A moss-ringed stone well under a starry sky, coins glinting below, paper wishes tied to a nearby tree. Hopeful and magical.',
+  }
 ]
 
 function buildPrompt(seed: PageSeed, variant: BackdropVariant): string {

--- a/utils/scripts/enqueuePageBackdropArtViaApi.ts
+++ b/utils/scripts/enqueuePageBackdropArtViaApi.ts
@@ -1,0 +1,174 @@
+// /utils/scripts/enqueuePageBackdropArtViaApi.ts
+//
+// Queue page backdrop art over HTTP instead of straight into the database.
+//
+// enqueuePageBackdropArt.ts writes to Prisma directly, which only works from a
+// host that can reach the database. This does the identical work through
+// POST /api/art/queue, so it runs from anywhere with KR_API_TOKEN — including a
+// sandbox that can reach the site but not the tailnet.
+//
+// The payload is built by the SAME buildKrea2WorkflowFromRequest and
+// enrichArtJobPayload the direct script uses, so a job queued here is
+// indistinguishable from one queued there. Engine is passed explicitly: the
+// route now defaults to COMFY, but relying on a default is how sixty jobs got
+// routed to a dead A1111 once already.
+//
+//   npx tsx utils/scripts/enqueuePageBackdropArtViaApi.ts                  # dry run
+//   npx tsx utils/scripts/enqueuePageBackdropArtViaApi.ts --write
+//   npx tsx utils/scripts/enqueuePageBackdropArtViaApi.ts --write --limit 6
+//   npx tsx utils/scripts/enqueuePageBackdropArtViaApi.ts --write --only index,about
+import 'dotenv/config'
+import { pageBackdropArtPrompts } from './../../stores/seeds/pageBackdropArtPrompts'
+import {
+  KREA2_DEFAULT_CFG,
+  KREA2_DEFAULT_STEPS,
+  buildKrea2WorkflowFromRequest,
+} from './../../server/api/comfy/krea2/utils/workflow'
+import { enrichArtJobPayload } from './../../server/utils/artJobProvenance'
+
+const WRITE = process.argv.includes('--write')
+const PROJECT_SLUG = 'page-backdrops'
+const PRIORITY = 100
+const ENGINE = 'COMFY' as const
+
+const BASE = (
+  process.env.KR_API_BASE || 'https://kind-robots.vercel.app'
+).replace(/\/+$/, '')
+const TOKEN = process.env.KR_API_TOKEN?.trim() || ''
+
+function flag(name: string): string | null {
+  const index = process.argv.indexOf(name)
+  if (index === -1) return null
+  return process.argv[index + 1] ?? null
+}
+
+const LIMIT = Number(flag('--limit') || 0)
+const ONLY = (flag('--only') || '')
+  .split(',')
+  .map((value) => value.trim())
+  .filter(Boolean)
+
+function buildPayload(entry: (typeof pageBackdropArtPrompts)[number]) {
+  const { workflow, seed } = buildKrea2WorkflowFromRequest({
+    prompt: entry.promptString,
+    negativePrompt: entry.negativePrompt,
+    width: entry.width,
+    height: entry.height,
+    steps: KREA2_DEFAULT_STEPS,
+    cfg: KREA2_DEFAULT_CFG,
+  })
+
+  const { payload } = enrichArtJobPayload(ENGINE, {
+    requestId: entry.requestId,
+    title: entry.title,
+    page: entry.page,
+    variant: entry.variant,
+    promptString: entry.promptString,
+    negativePrompt: entry.negativePrompt,
+    width: entry.width,
+    height: entry.height,
+    steps: KREA2_DEFAULT_STEPS,
+    cfg: KREA2_DEFAULT_CFG,
+    seed,
+    workflow,
+    /*
+     * The destination the relay's media agent reads, and now the destination
+     * resolveArtImageFilePath honours too — so these file under background/
+     * instead of the unsorted landing zone.
+     */
+    imagePath: entry.imagePath,
+    save: {
+      isPublic: true,
+      isMature: false,
+      designer: 'Kind Robots / Page Backdrops',
+    },
+  })
+
+  return payload
+}
+
+async function main() {
+  if (!TOKEN) {
+    console.error('❌ KR_API_TOKEN is not set.')
+    process.exitCode = 1
+    return
+  }
+
+  let entries = pageBackdropArtPrompts
+  if (ONLY.length) entries = entries.filter((e) => ONLY.includes(e.page))
+  if (LIMIT > 0) entries = entries.slice(0, LIMIT)
+
+  console.log(`Target: ${BASE}`)
+  console.log(
+    `Entries: ${entries.length} (${new Set(entries.map((e) => e.page)).size} pages)`,
+  )
+  console.log(`Engine ${ENGINE}, priority ${PRIORITY}, project ${PROJECT_SLUG}`)
+  console.log(`Mode: ${WRITE ? 'WRITE' : 'dry run'}\n`)
+
+  if (!WRITE) {
+    for (const entry of entries.slice(0, 8)) {
+      console.log(`  WOULD  ${entry.requestId.padEnd(38)} ${entry.width}x${entry.height}`)
+    }
+    if (entries.length > 8) console.log(`  … and ${entries.length - 8} more`)
+    console.log(`\nDry run only. Re-run with --write to queue ${entries.length}.`)
+    return
+  }
+
+  let queued = 0
+  let deduped = 0
+  const failures: string[] = []
+
+  for (const [index, entry] of entries.entries()) {
+    const response = await fetch(`${BASE}/api/art/queue`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${TOKEN}`,
+      },
+      body: JSON.stringify({
+        engine: ENGINE,
+        payload: buildPayload(entry),
+        priority: PRIORITY,
+        projectSlug: PROJECT_SLUG,
+      }),
+    }).catch((error: unknown) => {
+      failures.push(
+        `${entry.requestId}: ${error instanceof Error ? error.message : String(error)}`,
+      )
+      return null
+    })
+
+    if (!response) continue
+
+    const body = (await response.json().catch(() => null)) as {
+      success?: boolean
+      message?: string
+      data?: { deduplicated?: boolean }
+    } | null
+
+    if (!response.ok || !body?.success) {
+      failures.push(
+        `${entry.requestId}: HTTP ${response.status} ${body?.message || ''}`.trim(),
+      )
+    } else if (body.data?.deduplicated) {
+      deduped += 1
+    } else {
+      queued += 1
+    }
+
+    if ((index + 1) % 15 === 0 || index === entries.length - 1) {
+      console.log(
+        `  ${index + 1}/${entries.length}  queued ${queued}, deduped ${deduped}, failed ${failures.length}`,
+      )
+    }
+  }
+
+  console.log(`\nQueued ${queued}, already present ${deduped}, failed ${failures.length}.`)
+  for (const failure of failures.slice(0, 15)) console.log(`  ✗ ${failure}`)
+  if (failures.length > 15) console.log(`  … and ${failures.length - 15} more`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
*"put in art job requests for all the pages that don't have them yet, that's across the board for anything with a front end route, with three versions for different sizes, and priority 100."*

Fifty-five pages gain scenes and the three frontmatter keys, taking coverage from **20 pages to 75** — 225 variants total.

## What counts as a route

113 content files had no backdrop, but **61 of them are `contentType: tab`** — nav definitions carrying a `route:` pointing at a page that already exists. They render nothing themselves and need no art.

Also excluded: `/login` (Silas: *"the only page I know of with a preset background"*), plus the error, dev and UI-demo pages.

## The scenes

Each page gets a *place* rather than a motif — a counting house for the wallet, a pigeon loft for messages, a lapidary bench for facets, a locksmith for password reset.

All of them follow the rule the seed file already states and which is the easiest thing to lose in a rewrite: **a backdrop is scenery, not a subject.** Interest goes to the edges, the middle stays calm, because panels sit over it.

## Queued over HTTP, not Prisma

`enqueuePageBackdropArt.ts` writes to the database directly and only runs from a host on the tailnet. `enqueuePageBackdropArtViaApi.ts` posts the **identical** payload — same `buildKrea2WorkflowFromRequest`, same `enrichArtJobPayload` — through `/api/art/queue`, so it runs anywhere `KR_API_TOKEN` reaches.

Engine is passed **explicitly** rather than trusting the route's default. Relying on that default is how sixty jobs went to a dead A1111 once already.

## Verified before bulk-queuing

One page posted first, then read back off the queue:

```
#7702 PENDING engine=COMFY pri=100 slug=page-backdrops
#7703 PENDING engine=COMFY pri=100 slug=page-backdrops
#7704 PENDING engine=COMFY pri=100 slug=page-backdrops
```

Those are the exact three fields that were wrong last time. Queue is healthy — 1 RUNNING, no stale jobs, no recent failures — and priority 100 puts these ahead of the ~2,985-job facet backlog.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_