### PR TITLE
fix(academy): bind aria-controls only for the expanded style tile

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -136,6 +136,9 @@ jobs:
         shell: bash # pipefail: `| tee` otherwise swallows the exit status
         run: npm run test:academy-examples-manifest 2>&1 | tee academy-examples-contract.txt
 
+      - name: Academy style gallery disclosure contract
+        run: npm run test:academy-style-gallery-disclosure
+
       - name: Navigation route access contract
         run: npx tsx utils/scripts/verifyNavigationRouteAccess.ts
 

--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -147,7 +147,11 @@
             : 'border-base-300 bg-base-100 hover:border-primary/50 hover:shadow-sm'
         "
         :aria-expanded="expandedSlug === style.slug"
-        :aria-controls="`academy-style-detail-${style.slug}`"
+        :aria-controls="
+          expandedSlug === style.slug
+            ? `academy-style-detail-${style.slug}`
+            : undefined
+        "
         @click="expandedSlug = expandedSlug === style.slug ? null : style.slug"
       >
         <div

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "test:academy-style-detail-callers": "tsx utils/scripts/verifyAcademyStyleDetailCallers.ts",
     "test:academy-starter-manifest": "tsx utils/scripts/verifyAcademyStarterManifest.ts",
     "test:academy-examples-manifest": "tsx utils/scripts/verifyAcademyExamplesManifest.ts",
+    "test:academy-style-gallery-disclosure": "tsx utils/scripts/verifyAcademyStyleGalleryDisclosure.ts",
     "test:workflow-paths": "tsx utils/scripts/verifyWorkflowPaths.ts",
     "test:workflow-pipefail": "tsx utils/scripts/verifyWorkflowPipefail.ts",
     "test:deploy-wait-ancestry": "tsx utils/scripts/verifyDeployWaitAncestry.ts",

--- a/utils/scripts/verifyAcademyStyleGalleryDisclosure.ts
+++ b/utils/scripts/verifyAcademyStyleGalleryDisclosure.ts
@@ -1,0 +1,51 @@
+// /utils/scripts/verifyAcademyStyleGalleryDisclosure.ts
+//
+// Regression guard for ai-art-academy/t-010 (lane-1 accessibility audit,
+// 2026-08-06: see projects/ai-art-academy/docs/frontend-audits/2026-08-06-style-gallery-accessibility.md
+// in the conductor repo). Every lesson tile in academy-styles-browser.vue used to bind
+// `aria-controls` unconditionally to `academy-style-detail-${style.slug}`, but the detail
+// element with that id only exists in the DOM while that lesson is expanded
+// (`v-if="expandedStyle"`). That made every collapsed tile's `aria-controls` point at a
+// nonexistent element -- an inaccurate disclosure relationship for assistive technology,
+// and dozens of broken id references on initial render. Fixed by binding `aria-controls`
+// only for the currently expanded tile (`undefined` otherwise). This script fails CI if
+// the unconditional-binding regression reappears.
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const COMPONENT_PATH = path.resolve(
+  'components/academy/academy-styles-browser.vue',
+)
+
+const contents = fs.readFileSync(COMPONENT_PATH, 'utf8')
+
+// The regression pattern: aria-controls bound directly to a template-literal id with no
+// surrounding conditional. Matches e.g. `:aria-controls="`academy-style-detail-${style.slug}`"`.
+const UNCONDITIONAL_PATTERN =
+  /:aria-controls="`academy-style-detail-\$\{[^}]+\}`"/
+
+assert.ok(
+  !UNCONDITIONAL_PATTERN.test(contents),
+  'academy-styles-browser.vue binds aria-controls unconditionally to every lesson tile again ' +
+    '-- the controlled detail element only exists for the expanded tile, so this must be ' +
+    "conditional (undefined when collapsed). See t-010's 2026-08-06 lane-1 accessibility audit.",
+)
+
+// The expected repair: a ternary that resolves to undefined for every tile except the one
+// matching expandedSlug (component-agnostic about the exact variable name on the "collapsed"
+// branch, but it must resolve to undefined/null there).
+const CONDITIONAL_PATTERN =
+  /:aria-controls="\s*[\s\S]*?===\s*style\.slug\s*[\s\S]*?\?\s*`academy-style-detail-\$\{[^}]+\}`\s*:\s*undefined\s*"/
+
+assert.ok(
+  CONDITIONAL_PATTERN.test(contents),
+  'academy-styles-browser.vue is missing the conditional aria-controls binding that only ' +
+    "points at the expanded lesson's detail element (and undefined for every collapsed " +
+    "tile). See t-010's 2026-08-06 lane-1 accessibility audit for the exact expected shape.",
+)
+
+console.log(
+  'academy-styles-browser.vue disclosure contract verified: aria-controls is bound only for ' +
+    'the expanded lesson tile.',
+)


### PR DESCRIPTION
Implements the exact repair specified by `ai-art-academy/t-010`'s 2026-08-06 lane-1 accessibility audit (conductor repo, `projects/ai-art-academy/docs/frontend-audits/2026-08-06-style-gallery-accessibility.md`), which found and documented the defect but couldn't apply it in that session (connector-only, no local Vue test runner).

## Defect

Every lesson tile in `academy-styles-browser.vue` unconditionally bound `aria-controls` to `` `academy-style-detail-${style.slug}` ``, but the detail element with that id only renders while that specific lesson is expanded (`v-if="expandedStyle"`). Every collapsed tile therefore referenced a nonexistent element — an inaccurate disclosure relationship for assistive technology, and dozens of broken id references on initial render.

## Fix

`aria-controls` is now bound only for the currently expanded tile (`undefined` otherwise), matching the same tile's own `aria-expanded` logic.

## Regression guard

Added `utils/scripts/verifyAcademyStyleGalleryDisclosure.ts` (wired into `contract-tests.yml` as "Academy style gallery disclosure contract") — a static check that fails if the unconditional binding reappears. Spot-checked it against the pre-fix source (temporarily reintroduced the old binding) to confirm it actually fails on the regression, then reverted and confirmed it passes.

## Verification

- `npx eslint` — clean
- `npm run test` (`vue-tsc --noEmit`) — exit 0
- `npx prettier --check` — clean
- New verifier passes on the fix, fails on the pre-fix pattern (manually verified)

No production data, ArtJobs, publishing, secrets, billing, DNS, or account configuration touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DN9zw6c4oXGzLRQxBxYP5n)_