### PR TITLE
ai-art-academy/t-059: migrate art/* status banners to .kr-note (1/5)

### DIFF
--- a/components/art/add-collection.vue
+++ b/components/art/add-collection.vue
@@ -75,9 +75,7 @@
         v-if="message"
         class="rounded-2xl border p-3 text-sm font-semibold"
         :class="
-          messageTone === 'error'
-            ? 'border-error/40 bg-error/10 text-error'
-            : 'border-success/40 bg-success/10 text-success'
+          messageTone === 'error' ? 'kr-note-error' : 'kr-note-success'
         "
       >
         {{ message }}

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -626,9 +626,7 @@ const collectionButtonLabel = computed(() => {
 })
 
 const statusClass = computed(() =>
-  statusTone.value === 'error'
-    ? 'border-error/40 bg-error/10 text-error'
-    : 'border-success/40 bg-success/10 text-success',
+  statusTone.value === 'error' ? 'kr-note-error' : 'kr-note-success',
 )
 
 const hasDirtyFields = computed(() => {

--- a/components/art/art-maker.vue
+++ b/components/art/art-maker.vue
@@ -42,8 +42,8 @@
         class="flex items-start gap-2 rounded-2xl border p-3 text-sm font-semibold"
         :class="
           artStore.generationMessageTone === 'error'
-            ? 'border-error/40 bg-error/10 text-error'
-            : 'border-success/40 bg-success/10 text-success'
+            ? 'kr-note-error'
+            : 'kr-note-success'
         "
       >
         <icon

--- a/components/art/generate-button.vue
+++ b/components/art/generate-button.vue
@@ -92,8 +92,8 @@
       class="flex items-start gap-2 rounded-2xl border p-3 text-sm font-semibold"
       :class="
         artStore.generationMessageTone === 'error'
-          ? 'border-error/40 bg-error/10 text-error'
-          : 'border-success/40 bg-success/10 text-success'
+          ? 'kr-note-error'
+          : 'kr-note-success'
       "
     >
       <icon


### PR DESCRIPTION
## Summary
Scoped first slice of the kind_robots-wide sweep `ai-art-academy/t-059` tracks (follow-up to t-057's manager-component pass, kind_robots PR #1517). Replaces each hand-written `border-{status}/40 bg-{status}/10 text-{status}` triplet with the canonical `.kr-note-{status}` modifier class introduced by kind_robots PR #1514:

- `components/art/add-collection.vue`
- `components/art/art-interact.vue`
- `components/art/art-maker.vue`
- `components/art/generate-button.vue`

Deliberately did **not** add the `.kr-note` base class to any of these — each component's existing shape (`rounded-2xl border p-3 text-sm font-semibold`, some with an extra flex/gap wrapper) uses `p-3` instead of `.kr-note`'s own `p-4`, so forcing the base class would change layout, not just normalize color. Only the color modifier is swapped, matching t-057's precedent.

19 of the 22 non-manager components from t-059's original inventory remain (plus `dream-maker.vue`, which now also carries the pattern per a fresh grep) — left for follow-up scoped passes by component family, same as t-057's own note recommends.

## Verification
- `eslint` on all 4 changed files — 0 errors
- Full `vue-tsc --noEmit` typecheck — 0 errors
- Deliberately did not run `prettier --write` — all 4 files carry pre-existing formatting drift unrelated to this change (confirmed via `prettier --check` against unmodified `HEAD` before editing)

---
_Generated by [Claude Code](https://claude.ai/code/session_012UBu79jgYp6XGztvS56dYv)_