### PR TITLE
Fix ArtJob queue preview fan-out and visual layout

### DIFF
--- a/components/art/art-manager.vue
+++ b/components/art/art-manager.vue
@@ -105,7 +105,7 @@
                 class="tab h-auto min-h-9 gap-2 rounded-xl px-4"
                 :class="{ 'tab-active': artJobWorkspaceTab === 'queue' }"
                 :aria-selected="artJobWorkspaceTab === 'queue'"
-                @click="artJobWorkspaceTab = 'queue'"
+                @click="selectArtJobWorkspace('queue')"
               >
                 Queue
                 <span
@@ -121,7 +121,7 @@
                 class="tab h-auto min-h-9 gap-2 rounded-xl px-4"
                 :class="{ 'tab-active': artJobWorkspaceTab === 'trainer' }"
                 :aria-selected="artJobWorkspaceTab === 'trainer'"
-                @click="artJobWorkspaceTab = 'trainer'"
+                @click="selectArtJobWorkspace('trainer')"
               >
                 Art trainer
                 <span
@@ -136,7 +136,7 @@
             <p class="hidden text-xs text-base-content/50 lg:block">
               {{
                 artJobWorkspaceTab === 'queue'
-                  ? 'Pipeline health, progress, and recovery controls'
+                  ? 'Jobs refresh every 15s; health summaries refresh every minute'
                   : 'Review finished renders and leave training feedback'
               }}
             </p>
@@ -238,6 +238,7 @@ type LegacyArtTab = ArtTab | 'upload'
 type ArtJobWorkspaceTab = 'queue' | 'trainer'
 
 const ART_JOB_REFRESH_INTERVAL_MS = 15_000
+const ART_JOB_STATS_REFRESH_INTERVAL_MS = 60_000
 
 const artJobStore = useArtJobStore()
 const artStore = useArtStore()
@@ -268,6 +269,7 @@ const artPreviewDialog = ref<HTMLDialogElement | null>(null)
 const artPreviewSrc = ref('')
 const artPreviewTitle = ref('Generated art')
 let artJobRefreshTimer: ReturnType<typeof setInterval> | null = null
+let artJobStatsRefreshTimer: ReturnType<typeof setInterval> | null = null
 
 const dashboardKey = computed(() => {
   return navStore.dashboardShell.dashboardKey || defaultDashboardKey
@@ -334,18 +336,42 @@ async function refreshManagerData() {
   await loadManagerData(true)
 }
 
-function stopArtJobLiveRefresh(): void {
-  if (!artJobRefreshTimer) return
-  clearInterval(artJobRefreshTimer)
-  artJobRefreshTimer = null
+async function selectArtJobWorkspace(tab: ArtJobWorkspaceTab): Promise<void> {
+  artJobWorkspaceTab.value = tab
+  if (
+    tab === 'trainer' &&
+    !artJobStore.trainerJobs.length &&
+    !artJobStore.loadingTrainerJobs
+  ) {
+    await artJobStore.fetchTrainerJobs()
+  }
 }
 
-async function refreshArtJobLiveData(): Promise<void> {
+function stopArtJobLiveRefresh(): void {
+  if (artJobRefreshTimer) {
+    clearInterval(artJobRefreshTimer)
+    artJobRefreshTimer = null
+  }
+  if (artJobStatsRefreshTimer) {
+    clearInterval(artJobStatsRefreshTimer)
+    artJobStatsRefreshTimer = null
+  }
+}
+
+async function refreshArtJobRows(): Promise<void> {
   if (!import.meta.client || !shouldLiveRefreshArtJobs.value) return
   if (document.visibilityState !== 'visible') return
-  if (artJobStore.loadingJobs || artJobStore.loadingStats) return
+  if (artJobStore.loadingJobs) return
 
-  await Promise.all([artJobStore.fetchJobs(), artJobStore.fetchStats()])
+  await artJobStore.fetchJobs()
+}
+
+async function refreshArtJobStats(): Promise<void> {
+  if (!import.meta.client || !shouldLiveRefreshArtJobs.value) return
+  if (document.visibilityState !== 'visible') return
+  if (artJobStore.loadingStats) return
+
+  await artJobStore.fetchStats()
 }
 
 function syncArtJobLiveRefresh(): void {
@@ -353,13 +379,17 @@ function syncArtJobLiveRefresh(): void {
   if (!import.meta.client || !shouldLiveRefreshArtJobs.value) return
 
   artJobRefreshTimer = setInterval(() => {
-    void refreshArtJobLiveData()
+    void refreshArtJobRows()
   }, ART_JOB_REFRESH_INTERVAL_MS)
+  artJobStatsRefreshTimer = setInterval(() => {
+    void refreshArtJobStats()
+  }, ART_JOB_STATS_REFRESH_INTERVAL_MS)
 }
 
 function handleVisibilityChange(): void {
   if (document.visibilityState === 'visible') {
-    void refreshArtJobLiveData()
+    void refreshArtJobRows()
+    void refreshArtJobStats()
   }
 }
 

--- a/components/art/artjob-queue-card.vue
+++ b/components/art/artjob-queue-card.vue
@@ -1,239 +1,337 @@
 <!-- /components/art/artjob-queue-card.vue -->
 <template>
   <article
-    class="flex min-w-0 flex-col gap-3 rounded-2xl border border-base-300 bg-base-200/30 p-3"
+    class="flex min-w-0 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-200/30"
   >
-    <div class="flex min-w-0 gap-3">
+    <div
+      class="relative flex aspect-[4/3] min-h-52 w-full items-center justify-center overflow-hidden bg-base-100"
+    >
       <a
         v-if="jobImageSrc && canShowJobContent"
         :href="jobImageSrc"
         target="_blank"
         rel="noopener"
-        class="shrink-0"
+        class="block h-full w-full"
         :title="`Open ArtImage ${job.artImageId}`"
       >
+        <video
+          v-if="jobImageKind === 'video'"
+          :src="jobImageSrc"
+          class="h-full w-full object-contain"
+          muted
+          playsinline
+          preload="metadata"
+        />
         <img
+          v-else
           :src="jobImageSrc"
           alt="Generated ArtJob output"
-          class="h-28 w-24 rounded-2xl border border-base-300 object-cover"
+          class="h-full w-full object-contain"
+          loading="lazy"
+          decoding="async"
           data-missing-image-report="false"
         />
       </a>
+
       <div
         v-else
-        class="flex h-28 w-24 shrink-0 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-100 px-2 text-center text-[10px] font-semibold uppercase text-base-content/40"
+        class="flex h-full w-full flex-col items-center justify-center gap-3 border-dashed border-base-300 bg-base-100 p-5 text-center"
       >
-        {{ canShowJobContent ? job.status : 'Mature hidden' }}
-      </div>
-
-      <div class="min-w-0 flex-1">
-        <div class="flex flex-wrap items-center gap-1">
-          <span class="font-mono text-xs font-semibold">#{{ job.id }}</span>
-          <span
-            class="badge badge-xs rounded-2xl"
-            :class="jobStatusClass(job.status)"
-          >
-            {{ job.status }}
-          </span>
-          <span class="badge badge-outline badge-xs rounded-2xl">{{
-            job.engine
-          }}</span>
-          <span
-            class="badge badge-xs rounded-2xl"
-            :class="jobVisibility.isMature ? 'badge-warning' : 'badge-outline'"
-          >
-            {{ jobVisibility.isMature ? 'Mature' : 'General' }}
-          </span>
-          <span
-            class="badge badge-xs rounded-2xl"
-            :class="
-              jobVisibility.isPublic
-                ? 'badge-success badge-outline'
-                : 'badge-neutral'
-            "
-          >
-            {{ jobVisibility.isPublic ? 'Public' : 'Private' }}
-          </span>
-          <span
-            v-if="job.projectSlug"
-            class="badge badge-secondary badge-xs rounded-2xl"
-          >
-            {{ job.projectSlug }}
-          </span>
-          <span
-            v-if="job.priority > 0"
-            class="badge badge-accent badge-xs rounded-2xl"
-          >
-            Priority {{ job.priority }}
-          </span>
-        </div>
-        <p
-          v-if="canShowJobContent"
-          class="mt-2 line-clamp-5 whitespace-pre-wrap text-sm font-medium leading-relaxed"
-        >
-          {{ jobPrompt || 'Prompt unavailable.' }}
-        </p>
-        <p
-          v-else
-          class="mt-2 rounded-xl border border-warning/30 bg-warning/10 p-2 text-xs text-warning-content"
-        >
-          Mature prompt and preview are hidden by your account setting.
-        </p>
-        <div class="mt-2 flex flex-wrap gap-1">
-          <span
-            v-for="setting in jobSettings.slice(0, 6)"
-            :key="setting"
-            class="badge badge-ghost badge-sm h-auto rounded-2xl py-1 text-[10px]"
-          >
-            {{ setting }}
-          </span>
-        </div>
-        <p class="mt-2 text-[11px] text-base-content/50">
-          {{ formatDateTime(job.createdAt) }} · attempt {{ job.attempts }} ·
-          priority {{ job.priority }}
-        </p>
-      </div>
-    </div>
-
-    <div
-      v-if="job.error"
-      class="rounded-2xl border border-error/30 bg-error/10 p-2 text-xs text-error"
-    >
-      {{ job.error }}
-    </div>
-
-    <details class="rounded-2xl border border-base-300 bg-base-100">
-      <summary class="cursor-pointer px-3 py-2 text-xs font-semibold">
-        Full prompt and generation fields
-      </summary>
-      <div class="flex flex-col gap-3 border-t border-base-300 p-3 text-xs">
-        <div
-          v-if="!canShowJobContent"
-          class="rounded-xl border border-warning/30 bg-warning/10 p-3 text-warning-content"
-        >
-          Enable mature content in your account settings to view or edit this
-          job's prompt and preview.
-        </div>
-        <template v-else>
-          <div>
-            <div
-              class="font-semibold uppercase tracking-wide text-base-content/50"
-            >
-              Prompt
-            </div>
-            <p class="mt-1 whitespace-pre-wrap leading-relaxed">
-              {{ jobPrompt }}
-            </p>
-          </div>
-          <div>
-            <div
-              class="font-semibold uppercase tracking-wide text-base-content/50"
-            >
-              Negative prompt
-            </div>
-            <p class="mt-1 whitespace-pre-wrap text-base-content/70">
-              {{ jobNegativePrompt || 'None' }}
-            </p>
-          </div>
-          <div class="flex flex-wrap gap-1">
-            <span
-              v-for="setting in jobSettings"
-              :key="setting"
-              class="badge badge-outline badge-sm h-auto rounded-2xl py-1 text-[10px]"
-            >
-              {{ setting }}
-            </span>
-          </div>
-        </template>
-      </div>
-    </details>
-
-    <div class="flex flex-wrap items-center justify-between gap-2">
-      <button
-        type="button"
-        class="btn btn-ghost btn-xs rounded-2xl"
-        :disabled="!jobPrompt || !canShowJobContent"
-        :title="
-          canShowJobContent
-            ? 'Copy prompt'
-            : 'Enable mature content to reveal this prompt'
-        "
-        @click="handleCopy"
-      >
-        {{ copied ? 'Copied' : 'Copy prompt' }}
-      </button>
-
-      <div class="flex flex-wrap items-center gap-1">
+        <span class="text-xs font-black uppercase tracking-widest text-base-content/35">
+          {{ canShowJobContent ? previewPlaceholder : 'Mature hidden' }}
+        </span>
         <button
-          v-if="job.status === 'PENDING'"
+          v-if="canLoadProtectedPreview"
           type="button"
-          class="btn btn-xs rounded-2xl"
-          :class="job.priority > 0 ? 'btn-outline' : 'btn-accent'"
-          :disabled="priorityStore.prioritizingJobIds.includes(job.id)"
-          @click="togglePriority"
+          class="btn btn-outline btn-sm rounded-2xl"
+          :disabled="isLoadingPreview"
+          @click="loadProtectedPreview"
         >
           <span
-            v-if="priorityStore.prioritizingJobIds.includes(job.id)"
+            v-if="isLoadingPreview"
             class="loading loading-spinner loading-xs"
           />
-          {{ job.priority > 0 ? 'Normal priority' : 'Move to front' }}
+          {{ isLoadingPreview ? 'Loading preview' : 'Load protected preview' }}
         </button>
-        <button
-          v-if="isEditableInPlace"
-          type="button"
-          class="btn btn-primary btn-xs rounded-2xl"
-          :disabled="!canShowJobContent"
-          @click="emit('edit', job, 'EDIT')"
+        <p
+          v-if="!canShowJobContent"
+          class="max-w-sm text-xs text-warning-content"
         >
-          Edit & queue
-        </button>
-        <button
-          v-else-if="job.status === 'RUNNING'"
-          type="button"
-          class="btn btn-primary btn-xs rounded-2xl"
-          :disabled="!canShowJobContent"
-          @click="emit('edit', job, 'NEW_OUTPUT')"
+          Enable mature content in your account settings to reveal this job.
+        </p>
+      </div>
+
+      <div class="absolute left-2 top-2 flex flex-wrap gap-1">
+        <span class="badge badge-neutral badge-sm rounded-2xl font-mono">
+          #{{ job.id }}
+        </span>
+        <span
+          class="badge badge-sm rounded-2xl"
+          :class="jobStatusClass(job.status)"
         >
-          Edit as new job
-        </button>
-        <button
-          v-if="job.status === 'DONE'"
-          type="button"
-          class="btn btn-primary btn-xs rounded-2xl"
-          :disabled="!canShowJobContent"
-          @click="emit('edit', job, 'NEW_OUTPUT')"
+          {{ job.status }}
+        </span>
+      </div>
+
+      <div class="absolute right-2 top-2 flex max-w-[65%] flex-wrap justify-end gap-1">
+        <span class="badge badge-outline badge-sm rounded-2xl">
+          {{ job.engine }}
+        </span>
+        <span
+          v-if="job.priority > 0"
+          class="badge badge-accent badge-sm rounded-2xl"
         >
-          Edited output
-        </button>
-        <button
-          v-if="job.status === 'DONE' && job.artImageId"
-          type="button"
-          class="btn btn-warning btn-xs rounded-2xl"
-          :disabled="!canShowJobContent"
-          @click="emit('edit', job, 'OVERWRITE')"
+          Priority {{ job.priority }}
+        </span>
+      </div>
+    </div>
+
+    <div class="flex min-w-0 flex-1 flex-col gap-3 p-3">
+      <div class="min-w-0">
+        <div class="flex flex-wrap items-start justify-between gap-2">
+          <div class="min-w-0 flex-1">
+            <h3 class="truncate text-base font-black" :title="jobTitle">
+              {{ jobTitle }}
+            </h3>
+            <p
+              v-if="jobPageLabel"
+              class="mt-0.5 truncate text-xs font-semibold text-primary"
+              :title="jobPageLabel"
+            >
+              Destination · {{ jobPageLabel }}
+            </p>
+          </div>
+          <span
+            v-if="jobVariant"
+            class="badge badge-ghost badge-sm rounded-2xl"
+          >
+            {{ jobVariant }}
+          </span>
+        </div>
+
+        <p
+          v-if="jobImagePath"
+          class="mt-1 truncate font-mono text-[10px] text-base-content/45"
+          :title="jobImagePath"
         >
-          Edit & replace
-        </button>
+          {{ jobImagePath }}
+        </p>
+      </div>
+
+      <div class="flex flex-wrap gap-1">
+        <span
+          class="badge badge-sm rounded-2xl"
+          :class="jobVisibility.isMature ? 'badge-warning' : 'badge-outline'"
+        >
+          {{ jobVisibility.isMature ? 'Mature' : 'General' }}
+        </span>
+        <span
+          class="badge badge-sm rounded-2xl"
+          :class="
+            jobVisibility.isPublic
+              ? 'badge-success badge-outline'
+              : 'badge-neutral'
+          "
+        >
+          {{ jobVisibility.isPublic ? 'Public' : 'Private' }}
+        </span>
+        <span
+          v-if="job.projectSlug"
+          class="badge badge-secondary badge-sm rounded-2xl"
+        >
+          {{ job.projectSlug }}
+        </span>
+        <span
+          v-if="jobRequestId"
+          class="badge badge-ghost badge-sm max-w-full truncate rounded-2xl"
+          :title="jobRequestId"
+        >
+          {{ jobRequestId }}
+        </span>
+      </div>
+
+      <p
+        v-if="canShowJobContent"
+        class="line-clamp-3 whitespace-pre-wrap text-sm leading-relaxed"
+      >
+        {{ jobPrompt || 'Prompt unavailable.' }}
+      </p>
+      <p
+        v-else
+        class="rounded-xl border border-warning/30 bg-warning/10 p-2 text-xs text-warning-content"
+      >
+        Mature prompt and preview are hidden by your account setting.
+      </p>
+
+      <div class="flex flex-wrap gap-1">
+        <span
+          v-for="setting in jobSettings.slice(0, 6)"
+          :key="setting"
+          class="badge badge-ghost badge-sm h-auto rounded-2xl py-1 text-[10px]"
+        >
+          {{ setting }}
+        </span>
+      </div>
+
+      <p class="text-[11px] text-base-content/50">
+        {{ formatDateTime(job.createdAt) }} · attempt {{ job.attempts }} ·
+        priority {{ job.priority }}
+      </p>
+
+      <div
+        v-if="job.error"
+        class="rounded-2xl border border-error/30 bg-error/10 p-2 text-xs text-error"
+      >
+        {{ job.error }}
+      </div>
+
+      <details class="rounded-2xl border border-base-300 bg-base-100">
+        <summary class="cursor-pointer px-3 py-2 text-xs font-semibold">
+          Full brief and generation fields
+        </summary>
+        <div class="flex flex-col gap-3 border-t border-base-300 p-3 text-xs">
+          <div
+            v-if="!canShowJobContent"
+            class="rounded-xl border border-warning/30 bg-warning/10 p-3 text-warning-content"
+          >
+            Enable mature content in your account settings to view or edit this
+            job's prompt and preview.
+          </div>
+          <template v-else>
+            <div v-if="jobPageLabel || jobImagePath">
+              <div
+                class="font-semibold uppercase tracking-wide text-base-content/50"
+              >
+                Destination
+              </div>
+              <p v-if="jobPageLabel" class="mt-1">{{ jobPageLabel }}</p>
+              <p
+                v-if="jobImagePath"
+                class="mt-1 break-all font-mono text-[10px] text-base-content/70"
+              >
+                {{ jobImagePath }}
+              </p>
+            </div>
+            <div>
+              <div
+                class="font-semibold uppercase tracking-wide text-base-content/50"
+              >
+                Prompt
+              </div>
+              <p class="mt-1 whitespace-pre-wrap leading-relaxed">
+                {{ jobPrompt }}
+              </p>
+            </div>
+            <div>
+              <div
+                class="font-semibold uppercase tracking-wide text-base-content/50"
+              >
+                Negative prompt
+              </div>
+              <p class="mt-1 whitespace-pre-wrap text-base-content/70">
+                {{ jobNegativePrompt || 'None' }}
+              </p>
+            </div>
+            <div class="flex flex-wrap gap-1">
+              <span
+                v-for="setting in jobSettings"
+                :key="setting"
+                class="badge badge-outline badge-sm h-auto rounded-2xl py-1 text-[10px]"
+              >
+                {{ setting }}
+              </span>
+            </div>
+          </template>
+        </div>
+      </details>
+
+      <div class="mt-auto flex flex-wrap items-center justify-between gap-2">
         <button
-          v-if="job.status === 'FAILED'"
           type="button"
           class="btn btn-ghost btn-xs rounded-2xl"
-          @click="artJobStore.requeueJob(job.id)"
-        >
-          Resume unchanged
-        </button>
-        <button
-          v-if="
-            job.status === 'PENDING' ||
-            job.status === 'RUNNING' ||
-            job.status === 'FAILED'
+          :disabled="!jobPrompt || !canShowJobContent"
+          :title="
+            canShowJobContent
+              ? 'Copy prompt'
+              : 'Enable mature content to reveal this prompt'
           "
-          type="button"
-          class="btn btn-ghost btn-xs rounded-2xl text-error"
-          @click="artJobStore.cancelJob(job.id)"
+          @click="handleCopy"
         >
-          {{ job.status === 'FAILED' ? 'Clear failure' : 'Cancel' }}
+          {{ copied ? 'Copied' : 'Copy prompt' }}
         </button>
+
+        <div class="flex flex-wrap items-center justify-end gap-1">
+          <button
+            v-if="job.status === 'PENDING'"
+            type="button"
+            class="btn btn-xs rounded-2xl"
+            :class="job.priority > 0 ? 'btn-outline' : 'btn-accent'"
+            :disabled="priorityStore.prioritizingJobIds.includes(job.id)"
+            @click="togglePriority"
+          >
+            <span
+              v-if="priorityStore.prioritizingJobIds.includes(job.id)"
+              class="loading loading-spinner loading-xs"
+            />
+            {{ job.priority > 0 ? 'Normal priority' : 'Move to front' }}
+          </button>
+          <button
+            v-if="isEditableInPlace"
+            type="button"
+            class="btn btn-primary btn-xs rounded-2xl"
+            :disabled="!canShowJobContent"
+            @click="emit('edit', job, 'EDIT')"
+          >
+            Edit & queue
+          </button>
+          <button
+            v-else-if="job.status === 'RUNNING'"
+            type="button"
+            class="btn btn-primary btn-xs rounded-2xl"
+            :disabled="!canShowJobContent"
+            @click="emit('edit', job, 'NEW_OUTPUT')"
+          >
+            Edit as new job
+          </button>
+          <button
+            v-if="job.status === 'DONE'"
+            type="button"
+            class="btn btn-primary btn-xs rounded-2xl"
+            :disabled="!canShowJobContent"
+            @click="emit('edit', job, 'NEW_OUTPUT')"
+          >
+            Edited output
+          </button>
+          <button
+            v-if="job.status === 'DONE' && job.artImageId"
+            type="button"
+            class="btn btn-warning btn-xs rounded-2xl"
+            :disabled="!canShowJobContent"
+            @click="emit('edit', job, 'OVERWRITE')"
+          >
+            Edit & replace
+          </button>
+          <button
+            v-if="job.status === 'FAILED'"
+            type="button"
+            class="btn btn-ghost btn-xs rounded-2xl"
+            @click="artJobStore.requeueJob(job.id)"
+          >
+            Resume unchanged
+          </button>
+          <button
+            v-if="
+              job.status === 'PENDING' ||
+              job.status === 'RUNNING' ||
+              job.status === 'FAILED'
+            "
+            type="button"
+            class="btn btn-ghost btn-xs rounded-2xl text-error"
+            @click="artJobStore.cancelJob(job.id)"
+          >
+            {{ job.status === 'FAILED' ? 'Clear failure' : 'Cancel' }}
+          </button>
+        </div>
       </div>
     </div>
   </article>
@@ -295,13 +393,19 @@ function nestedScalar(value: unknown, keys: string[], depth = 0): string {
   return ''
 }
 
-function payloadScalar(job: ArtJobRecord, keys: string[]): string {
+function directPayloadScalar(job: ArtJobRecord, keys: string[]): string {
   const payload = asRecord(job.payload)
   for (const key of keys) {
-    const direct = scalar(payload[key])
-    if (direct) return direct
+    const value = scalar(payload[key])
+    if (value) return value
   }
-  return nestedScalar(payload.workflow, keys)
+  return ''
+}
+
+function payloadScalar(job: ArtJobRecord, keys: string[]): string {
+  const direct = directPayloadScalar(job, keys)
+  if (direct) return direct
+  return nestedScalar(asRecord(job.payload).workflow, keys)
 }
 
 function workflowPrompt(
@@ -356,6 +460,46 @@ const canShowJobContent = computed<boolean>(
   () => !jobVisibility.value.isMature || artStore.showMature,
 )
 
+const jobTitle = computed<string>(() => {
+  return (
+    directPayloadScalar(props.job, ['title', 'label', 'name']) ||
+    props.job.projectSlug ||
+    `ArtJob #${props.job.id}`
+  )
+})
+
+const jobPage = computed<string>(() =>
+  directPayloadScalar(props.job, [
+    'page',
+    'pagePath',
+    'route',
+    'destinationPage',
+  ]),
+)
+
+const jobPageLabel = computed<string>(() => {
+  const page = jobPage.value
+  if (!page) return ''
+  if (page === 'index' || page === 'home') return '/'
+  return page.startsWith('/') ? page : `/${page}`
+})
+
+const jobVariant = computed<string>(() =>
+  directPayloadScalar(props.job, ['variant', 'breakpoint']),
+)
+
+const jobRequestId = computed<string>(() =>
+  directPayloadScalar(props.job, ['requestId', 'requestID', 'request_id']),
+)
+
+const jobImagePath = computed<string>(() =>
+  directPayloadScalar(props.job, [
+    'imagePath',
+    'outputPath',
+    'destinationPath',
+  ]),
+)
+
 const jobSettings = computed<string[]>(() => {
   const job = props.job
   const values = [
@@ -386,15 +530,56 @@ const jobSettings = computed<string[]>(() => {
     .map(([label, value]) => `${label}: ${value}`)
 })
 
+const publicImageSrc = computed<string>(() => {
+  const id = props.job.artImageId
+  if (typeof id !== 'number') return ''
+  if (!jobVisibility.value.isPublic || jobVisibility.value.isMature) return ''
+  const updatedAt = new Date(props.job.updatedAt).getTime()
+  const version = Number.isFinite(updatedAt) ? `?v=${updatedAt}` : ''
+  return `/api/art/images/${id}/file${version}`
+})
+
 const jobImageSrc = computed<string>(() => {
-  const job = props.job
-  if (typeof job.artImageId !== 'number') return ''
-  return artJobStore.imageSrcById[job.artImageId] || ''
+  const id = props.job.artImageId
+  if (typeof id !== 'number') return ''
+  return publicImageSrc.value || artJobStore.imageSrcById[id] || ''
+})
+
+const jobImageKind = computed<string>(() => {
+  const id = props.job.artImageId
+  if (typeof id !== 'number' || publicImageSrc.value) return 'image'
+  return artJobStore.imageInfoById[id]?.kind || 'image'
+})
+
+const isLoadingPreview = computed<boolean>(() => {
+  const id = props.job.artImageId
+  return typeof id === 'number' && artJobStore.loadingImageIds.includes(id)
+})
+
+const canLoadProtectedPreview = computed<boolean>(() => {
+  return (
+    canShowJobContent.value &&
+    typeof props.job.artImageId === 'number' &&
+    !publicImageSrc.value &&
+    !jobImageSrc.value
+  )
+})
+
+const previewPlaceholder = computed<string>(() => {
+  if (props.job.status !== 'DONE') return props.job.status
+  if (typeof props.job.artImageId !== 'number') return 'No output image'
+  return 'Protected output'
 })
 
 const isEditableInPlace = computed<boolean>(() =>
   ['PENDING', 'FAILED', 'CANCELLED'].includes(props.job.status),
 )
+
+async function loadProtectedPreview(): Promise<void> {
+  const id = props.job.artImageId
+  if (typeof id !== 'number') return
+  await artJobStore.loadJobImage(id)
+}
 
 async function handleCopy(): Promise<void> {
   if (!canShowJobContent.value) return

--- a/server/api/art/queue/stats.get.ts
+++ b/server/api/art/queue/stats.get.ts
@@ -7,6 +7,7 @@
 // and images created — over a configurable window.
 //
 // Query: ?window=<hours> (default 24, max 720)
+//        ?summary=true returns the lightweight queue-card summary only.
 import { defineEventHandler, getQuery } from 'h3'
 import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
@@ -16,14 +17,63 @@ import { requireAdminApiUser } from '../../../utils/authGuard'
 // than this is considered stuck (its relay likely died mid-render).
 const STALE_CLAIM_MINUTES = 15
 
+function countByStatus(
+  groups: { status: string; _count: { _all: number } }[],
+): Record<string, number> {
+  return groups.reduce<Record<string, number>>((acc, group) => {
+    acc[group.status] = group._count._all
+    return acc
+  }, {})
+}
+
 export default defineEventHandler(async (event) => {
   try {
     await requireAdminApiUser(event)
 
     const query = getQuery(event)
     const windowHours = Math.min(Math.max(Number(query.window) || 24, 1), 720)
+    const summaryOnly = ['1', 'true', 'yes'].includes(
+      String(query.summary || '').trim().toLowerCase(),
+    )
     const since = new Date(Date.now() - windowHours * 3_600_000)
     const staleBefore = new Date(Date.now() - STALE_CLAIM_MINUTES * 60_000)
+
+    if (summaryOnly) {
+      const [statusGroups, oldestPending] = await Promise.all([
+        prisma.artJob.groupBy({ by: ['status'], _count: { _all: true } }),
+        prisma.artJob.findFirst({
+          where: { status: 'PENDING' },
+          orderBy: { id: 'asc' },
+          select: { id: true, createdAt: true, engine: true, projectSlug: true },
+        }),
+      ])
+      const now = Date.now()
+
+      return {
+        success: true,
+        message: 'ArtJob pipeline summary.',
+        data: {
+          windowHours,
+          since,
+          queueDepth: countByStatus(statusGroups),
+          windowThroughput: {},
+          oldestPending: oldestPending
+            ? {
+                ...oldestPending,
+                ageSeconds: Math.round(
+                  (now - oldestPending.createdAt.getTime()) / 1000,
+                ),
+              }
+            : null,
+          staleRunningCount: 0,
+          staleRunning: [],
+          recentFailed: [],
+          imagesCreatedInWindow: 0,
+          imagesByServer: [],
+        },
+        statusCode: 200,
+      }
+    }
 
     const [
       statusGroups,
@@ -85,14 +135,6 @@ export default defineEventHandler(async (event) => {
       }),
     ])
 
-    const countByStatus = (
-      groups: { status: string; _count: { _all: number } }[],
-    ) =>
-      groups.reduce<Record<string, number>>((acc, g) => {
-        acc[g.status] = g._count._all
-        return acc
-      }, {})
-
     const now = Date.now()
 
     return {
@@ -115,9 +157,9 @@ export default defineEventHandler(async (event) => {
         staleRunning,
         recentFailed,
         imagesCreatedInWindow: imagesInWindow,
-        imagesByServer: imagesByServer.map((g) => ({
-          serverName: g.serverName,
-          count: g._count._all,
+        imagesByServer: imagesByServer.map((group) => ({
+          serverName: group.serverName,
+          count: group._count._all,
         })),
       },
       statusCode: 200,

--- a/server/api/art/queue/stats.get.ts
+++ b/server/api/art/queue/stats.get.ts
@@ -39,14 +39,23 @@ export default defineEventHandler(async (event) => {
     const staleBefore = new Date(Date.now() - STALE_CLAIM_MINUTES * 60_000)
 
     if (summaryOnly) {
-      const [statusGroups, oldestPending] = await Promise.all([
-        prisma.artJob.groupBy({ by: ['status'], _count: { _all: true } }),
-        prisma.artJob.findFirst({
-          where: { status: 'PENDING' },
-          orderBy: { id: 'asc' },
-          select: { id: true, createdAt: true, engine: true, projectSlug: true },
-        }),
-      ])
+      const [statusGroups, oldestPending, staleRunningCount] =
+        await Promise.all([
+          prisma.artJob.groupBy({ by: ['status'], _count: { _all: true } }),
+          prisma.artJob.findFirst({
+            where: { status: 'PENDING' },
+            orderBy: { id: 'asc' },
+            select: {
+              id: true,
+              createdAt: true,
+              engine: true,
+              projectSlug: true,
+            },
+          }),
+          prisma.artJob.count({
+            where: { status: 'RUNNING', claimedAt: { lt: staleBefore } },
+          }),
+        ])
       const now = Date.now()
 
       return {
@@ -65,7 +74,7 @@ export default defineEventHandler(async (event) => {
                 ),
               }
             : null,
-          staleRunningCount: 0,
+          staleRunningCount,
           staleRunning: [],
           recentFailed: [],
           imagesCreatedInWindow: 0,

--- a/stores/artJobStore.ts
+++ b/stores/artJobStore.ts
@@ -187,6 +187,7 @@ type ArtJobState = {
   trainerJobs: ArtJobRecord[]
   imageSrcById: Record<number, string>
   imageInfoById: Record<number, ArtImageSource>
+  loadingImageIds: number[]
   jobStatusFilter: ArtJobStatus | 'ALL'
   jobPage: number
   jobPageSize: number
@@ -209,12 +210,6 @@ type ArtJobState = {
   windowHours: number
 }
 
-const MAX_JOB_IMAGES = 240
-// Loading the queue used to fire every image request at once with Promise.all.
-// A full trainer page can contain hundreds of DB-backed image blobs, so that
-// burst exhausted the per-instance MariaDB pool and returned 503s. Keep the
-// browser below the gallery's established concurrency of four.
-const JOB_IMAGE_LOAD_CONCURRENCY = 4
 const DEFAULT_JOB_PAGE_SIZE = 20
 const MAX_JOB_PAGE_SIZE = 100
 
@@ -231,6 +226,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     trainerJobs: [],
     imageSrcById: {},
     imageInfoById: {},
+    loadingImageIds: [],
     jobStatusFilter: 'PENDING',
     jobPage: 1,
     jobPageSize: DEFAULT_JOB_PAGE_SIZE,
@@ -288,7 +284,10 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     state.loadingStats = true
     try {
       const res = await performFetch<QueueStats>(
-        `/api/art/queue/stats?window=${state.windowHours}`,
+        `/api/art/queue/stats?window=${state.windowHours}&summary=true`,
+        { method: 'GET' },
+        1,
+        30_000,
       )
       if (res.success && res.data) {
         state.stats = res.data
@@ -368,10 +367,9 @@ export const useArtJobStore = defineStore('artJobStore', () => {
       }>(`/api/art/queue?${params.toString()}`)
 
       if (res.success && res.data) {
-        const forceImageIds = completedOverwriteIds(res.data.jobs)
+        completedOverwriteIds(res.data.jobs)
         state.jobs = res.data.jobs
         applyPagination(res.data.pagination)
-        void loadJobImages(forceImageIds)
       } else if (!res.success) {
         state.error = res.message || 'Failed to load jobs.'
       }
@@ -399,7 +397,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
         '/api/art/queue?status=DONE&limit=200',
       )
       if (res.success && res.data) {
-        const forceImageIds = completedOverwriteIds(res.data.jobs)
+        completedOverwriteIds(res.data.jobs)
         // Every finished render is reviewable. This used to require a CURATOR
         // verdict, which meant a vision model had to score the image before a
         // human was allowed to see it -- so removing that model would have left
@@ -409,7 +407,6 @@ export const useArtJobStore = defineStore('artJobStore', () => {
         state.trainerJobs = res.data.jobs.filter((job) => {
           return typeof job.artImageId === 'number'
         })
-        void loadJobImages(forceImageIds)
       } else if (!res.success) {
         state.error = res.message || 'Failed to load curated jobs.'
       }
@@ -418,48 +415,33 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     }
   }
 
-  async function loadJobImages(forceIds: number[] = []): Promise<void> {
-    const ids = [
-      ...forceIds,
-      ...[...state.jobs, ...state.trainerJobs]
-        .filter((job) => {
-          return job.status === 'DONE' && typeof job.artImageId === 'number'
-        })
-        .map((job) => job.artImageId as number),
-    ]
-      .filter((id, index, all) => all.indexOf(id) === index)
-      .filter((id) => forceIds.includes(id) || !(id in state.imageSrcById))
-      .slice(0, MAX_JOB_IMAGES)
+  async function loadJobImage(id: number): Promise<boolean> {
+    if (!Number.isInteger(id) || id <= 0) return false
+    if (state.imageSrcById[id]) return true
+    if (state.loadingImageIds.includes(id)) return false
 
-    if (!ids.length) return
-
-    let nextIndex = 0
-    const worker = async () => {
-      while (nextIndex < ids.length) {
-        const id = ids[nextIndex]
-        nextIndex += 1
-        if (id === undefined) return
-
-        const res = await performFetch<ArtImage>(
-          `/api/art/image/${id}?includeImageData=true`,
-          { method: 'GET' },
-          1,
-          30_000,
-        )
-        if (res.success && res.data) {
-          const info = resolveArtImageSource(res.data)
-          state.imageInfoById[id] = info
-          state.imageSrcById[id] = info.src
-        }
+    state.loadingImageIds = [...state.loadingImageIds, id]
+    try {
+      const res = await performFetch<ArtImage>(
+        `/api/art/image/${id}?includeImageData=true`,
+        { method: 'GET' },
+        1,
+        30_000,
+      )
+      if (res.success && res.data) {
+        const info = resolveArtImageSource(res.data)
+        state.imageInfoById[id] = info
+        if (info.src) state.imageSrcById[id] = info.src
+        return Boolean(info.src)
       }
-    }
 
-    await Promise.all(
-      Array.from(
-        { length: Math.min(JOB_IMAGE_LOAD_CONCURRENCY, ids.length) },
-        worker,
-      ),
-    )
+      state.error = res.message || `Failed to load ArtImage ${id}.`
+      return false
+    } finally {
+      state.loadingImageIds = state.loadingImageIds.filter(
+        (imageId) => imageId !== id,
+      )
+    }
   }
 
   function replaceJob(updated: ArtJobRecord): void {
@@ -470,6 +452,14 @@ export const useArtJobStore = defineStore('artJobStore', () => {
       (job) => job.id === updated.id,
     )
     if (trainerIndex >= 0) state.trainerJobs[trainerIndex] = updated
+  }
+
+  async function refreshMutationViews(): Promise<void> {
+    await Promise.all([
+      fetchJobs(),
+      fetchStats(),
+      ...(state.trainerJobs.length ? [fetchTrainerJobs()] : []),
+    ])
   }
 
   async function submitFeedback(
@@ -499,7 +489,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
       body: JSON.stringify({}),
     })
     if (res.success) {
-      await Promise.all([fetchJobs(), fetchStats(), fetchTrainerJobs()])
+      await refreshMutationViews()
       return true
     }
     state.error = res.message || `Failed to requeue job ${id}.`
@@ -512,7 +502,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
       body: JSON.stringify({}),
     })
     if (res.success) {
-      await Promise.all([fetchJobs(), fetchStats(), fetchTrainerJobs()])
+      await refreshMutationViews()
       return true
     }
     state.error = res.message || `Failed to cancel job ${id}.`
@@ -579,7 +569,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
       })
 
       if (res.success && res.data?.job) {
-        await Promise.all([fetchJobs(), fetchStats(), fetchTrainerJobs()])
+        await refreshMutationViews()
         return res.data.job.id
       }
 
@@ -607,7 +597,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
       )
 
       if (res.success && res.data) {
-        await Promise.all([fetchJobs(), fetchStats(), fetchTrainerJobs()])
+        await refreshMutationViews()
         return res.data
       }
 
@@ -639,7 +629,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
 
       if (res.success && res.data) {
         if (!dryRun) {
-          await Promise.all([fetchJobs(), fetchStats(), fetchTrainerJobs()])
+          await refreshMutationViews()
         }
         return res.data
       }
@@ -657,7 +647,6 @@ export const useArtJobStore = defineStore('artJobStore', () => {
       fetchStats(),
       fetchUptime(),
       fetchJobs(),
-      fetchTrainerJobs(),
       fetchQueueControl(),
     ])
   }
@@ -674,6 +663,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     setJobPage,
     setJobPageSize,
     fetchTrainerJobs,
+    loadJobImage,
     submitFeedback,
     requeueJob,
     cancelJob,

--- a/stores/artJobStore.ts
+++ b/stores/artJobStore.ts
@@ -9,6 +9,7 @@ import type {
 import { performFetch } from '@/stores/utils'
 import { resolveArtImageSource } from '~/utils/artImageSource'
 import type { ArtImageSource } from '~/utils/artImageSource'
+import { resolveMaturityPrivacy } from '~/utils/maturityPrivacy'
 
 export type ArtJobStatus =
   | 'PENDING'
@@ -213,9 +214,16 @@ type ArtJobState = {
 const DEFAULT_JOB_PAGE_SIZE = 20
 const MAX_JOB_PAGE_SIZE = 100
 
+type JsonRecord = Record<string, unknown>
+
 function normalizePageSize(value: number): number {
   if (!Number.isFinite(value)) return DEFAULT_JOB_PAGE_SIZE
   return Math.min(Math.max(Math.floor(value), 1), MAX_JOB_PAGE_SIZE)
+}
+
+function asRecord(value: unknown): JsonRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as JsonRecord
 }
 
 export const useArtJobStore = defineStore('artJobStore', () => {
@@ -248,6 +256,23 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     error: null,
     windowHours: 24,
   })
+
+  function cachePublicImageUrls(jobs: ArtJobRecord[]): void {
+    for (const job of jobs) {
+      if (typeof job.artImageId !== 'number') continue
+      const visibility = resolveMaturityPrivacy(
+        asRecord(asRecord(job.payload).save),
+      )
+      if (!visibility.isPublic || visibility.isMature) continue
+
+      const updatedAt = new Date(job.updatedAt).getTime()
+      const version = Number.isFinite(updatedAt) ? `?v=${updatedAt}` : ''
+      const src = `/api/art/images/${job.artImageId}/file${version}`
+      const info = resolveArtImageSource({ imagePath: src, fileType: 'webp' })
+      state.imageSrcById[job.artImageId] = src
+      state.imageInfoById[job.artImageId] = info
+    }
+  }
 
   async function fetchQueueControl(): Promise<void> {
     const res = await performFetch<{ paused: boolean; pausedBy: string | null }>(
@@ -369,6 +394,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
       if (res.success && res.data) {
         completedOverwriteIds(res.data.jobs)
         state.jobs = res.data.jobs
+        cachePublicImageUrls(res.data.jobs)
         applyPagination(res.data.pagination)
       } else if (!res.success) {
         state.error = res.message || 'Failed to load jobs.'
@@ -407,6 +433,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
         state.trainerJobs = res.data.jobs.filter((job) => {
           return typeof job.artImageId === 'number'
         })
+        cachePublicImageUrls(state.trainerJobs)
       } else if (!res.success) {
         state.error = res.message || 'Failed to load curated jobs.'
       }

--- a/stores/utils.ts
+++ b/stores/utils.ts
@@ -52,6 +52,11 @@ function asRecord(value: unknown): JsonRecord {
   return value as JsonRecord
 }
 
+function resolveRequestUrl(url: string): string {
+  if (!import.meta.server || !url.startsWith('/')) return url
+  return new URL(url, useRequestURL()).toString()
+}
+
 function circuitIsOpen(): boolean {
   return import.meta.client && Date.now() < circuitOpenUntil
 }
@@ -336,6 +341,7 @@ export async function performFetch<T = unknown>(
   const userStore = useUserStore()
   const errorStore = useErrorStore()
   const token = userStore.token || userStore.user?.token || ''
+  const requestUrl = resolveRequestUrl(url)
 
   const normalizedHeaders = new Headers(options.headers ?? {})
 
@@ -382,7 +388,7 @@ export async function performFetch<T = unknown>(
     const timeoutId = setTimeout(() => controller.abort(), timeout)
 
     try {
-      const res = await fetch(url, {
+      const res = await fetch(requestUrl, {
         ...options,
         headers: normalizedHeaders,
         signal: controller.signal,


### PR DESCRIPTION
## Root cause

The ArtJob queue was doing three expensive things at once:

- `performFetch()` passed relative `/api/...` URLs to native `fetch()` during SSR, which produced `Failed to parse URL from /api/icons`.
- Opening the queue also fetched the hidden trainer list and then eagerly requested full image data one ArtImage at a time, up to 240 requests.
- The 24-hour stats endpoint ran seven aggregate queries every 15 seconds while those image requests were competing for the database pool.

## What changed

- Resolve relative API URLs against the active Nuxt request origin during SSR.
- Stop eager full-image loading from queue and trainer fetches.
- Use the existing cacheable `/api/art/images/:id/file` media route for public/general previews, with native lazy image loading.
- Load protected/private previews only when explicitly requested.
- Fetch trainer jobs only when the trainer tab is opened.
- Refresh queue rows every 15 seconds but health stats only every minute.
- Add a lightweight `summary=true` stats mode that runs three focused queries instead of seven, with a 30-second client timeout.
- Redesign ArtJob cards around a large preview and surface destination title, page/route, output path, variant, request ID, and compact generation metadata.

## Validation

- Reviewed the complete five-file PR diff after rebasing context against the latest `main`; the intervening main changes do not overlap these files.
- Auto-merge is enabled and waiting for the repository's required checks.
- No branch preview is expected because `worker/*` previews are disabled by repository Vercel policy; visual/runtime verification will run against production after merge.