### PR TITLE
ai-art-academy/t-010 lane 1: fix duplicate accessible name on style-picker thumbnails

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -414,7 +414,7 @@
         >
           <img
             :src="style.previewImageSrc"
-            :alt="style.label"
+            alt=""
             class="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
           />
           <div


### PR DESCRIPTION
## What

`art-styler.vue`'s style-picker thumbnails carried `:alt="style.label"` on the preview `<img>`, while the *same* `style.label` text is also rendered as a visible caption `<span>` inside the same `<button>`. Since both are descendants of one interactive button, assistive tech computed a duplicated accessible name (e.g. "Watercolor, Watercolor, button").

This is the same bug class already found and fixed for Academy lesson thumbnails (`academy-styles-browser.vue`, PR #1530) — this fix closes the same gap in `art-styler.vue`'s shared style grid (used by Style Lab, Remix Studio, `art-manager.vue`, `image-card.vue`, and `coloring-page.vue`).

## Fix

Made the thumbnail image decorative (`alt=""`) since the visible `<span>{{ style.label }}</span>` caption already supplies the button's accessible name. The `:title="style.triggerPhrase"` tooltip and the visible caption are unchanged.

## Verification

- `eslint` on the changed file: clean
- `prettier --check`: clean
- `vue-tsc --noEmit`: clean (no new errors)
- Single-attribute template change, no props/emits/store/API/data-model changes — fully reversible.

## Flags for Reviewer

None. Low-risk, scoped, reversible accessibility fix; this is `ai-art-academy/t-010`'s recurring continuous-improvement task, lane 1 (front-end polish).

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJ81QqbJXJ5AYmheTzAMC2)_