### PR TITLE
Production is 500 on every page: stop serializing a pending Promise into the SSR payload

### DIFF
--- a/stores/chatStore.ts
+++ b/stores/chatStore.ts
@@ -1692,7 +1692,22 @@ export const useChatStore = defineStore('chatStore', () => {
     pendingChatId,
     pendingChat,
     pendingText,
-    initializePromise,
+    /*
+     * initializePromise is deliberately NOT returned.
+     *
+     * In a Pinia setup store every returned ref becomes STATE, and Nuxt
+     * serializes that state into the SSR payload with devalue -- which cannot
+     * stringify a Promise:
+     *
+     *   DevalueError: Cannot stringify a Promise or thenable
+     *   path: '.pinia.chatStore.initializePromise'
+     *
+     * That threw on EVERY `/[...slug]` render, so production returned 500 on
+     * every content route. The ref is an in-flight re-entrancy guard, not state
+     * any consumer reads -- nothing outside these stores references it -- and
+     * serverStore already keeps its equivalent private, which is the pattern
+     * this restores.
+     */
     fetchChatsPromise,
     lastFetchedUserId,
     state,

--- a/stores/pageStore.ts
+++ b/stores/pageStore.ts
@@ -404,7 +404,22 @@ export const usePageStore = defineStore('pageStore', () => {
     cardsKey,
     workspaceCardKey,
     lastResolvedPath,
-    initializePromise,
+    /*
+     * initializePromise is deliberately NOT returned.
+     *
+     * In a Pinia setup store every returned ref becomes STATE, and Nuxt
+     * serializes that state into the SSR payload with devalue -- which cannot
+     * stringify a Promise:
+     *
+     *   DevalueError: Cannot stringify a Promise or thenable
+     *   path: '.pinia.pageStore.initializePromise'
+     *
+     * That threw on EVERY `/[...slug]` render, so production returned 500 on
+     * every content route. The ref is an in-flight re-entrancy guard, not state
+     * any consumer reads -- nothing outside these stores references it -- and
+     * serverStore already keeps its equivalent private, which is the pattern
+     * this restores.
+     */
     resolvedLocation,
     resolvedChannel,
     resolvedTab,


### PR DESCRIPTION
## Production is down

`https://kind-robots.vercel.app/` and every content route return **500**. Confirmed by request, and Vercel's runtime error grouping names the exact cause:

```
DevalueError: Cannot stringify a Promise or thenable — use stringifyAsync instead
  path: '.pinia.pageStore.initializePromise'
  at renderPayloadJsonScript (chunks/routes/renderer.mjs:192:52)
```

366 occurrences, 189 users, route `/[...slug]` — i.e. every content page on the site.

## The bug

In a Pinia **setup store**, every returned ref becomes state. Nuxt serializes that state into the SSR payload with `devalue`, and `devalue` cannot stringify a Promise. So `renderPayloadJsonScript` throws on every render.

`pageStore` and `chatStore` both returned their in-flight `initializePromise` re-entrancy guard. **`serverStore` has the identical guard and already keeps it private** — which is what makes this a regression rather than a design question: two stores drifted from the pattern the third still follows.

## The fix

Remove them from the returned object. That's all.

- Nothing outside these stores reads `.initializePromise` (grepped repo-wide).
- Both still use it internally — `initialize()` continues to return the promise value to its caller, so the re-entrancy guard is intact.
- **Fixing `pageStore` alone would not have been enough**: devalue throws on the first unserializable value it meets, so `chatStore`'s copy would simply have become the next error.

Scope is deliberately minimal — two removals and their explanation. Prettier wanted to reformat unrelated pre-existing drift in `pageStore.ts`; I reverted that and left it for a normal change rather than putting cosmetic churn in a production fix.

## This is also why CI has been failing elsewhere

The `audit` check on PR #1539 failed twice against its Vercel preview:

```
https://kind-robots-…vercel.app never returned 200 within 300s
  got 500; retrying in 10s...   (×28)
```

That is not #1539's code. Every preview 500s for the same reason production does, so **the `audit` gate cannot pass on any PR until this lands.** I initially assumed the failure was an artifact of my own empty commit superseding the deployment mid-run — it wasn't, and checking the current preview by hand is what showed the difference.

## Verification

- `vue-tsc` — **exit 0**
- The two remaining eslint errors in `chatStore.ts` (`no-empty`) are **pre-existing on main**, verified by linting the unmodified file; unrelated to this diff.

**Not reproducible locally** — SSR needs a database this sandbox cannot reach. The diagnosis comes from Vercel's runtime error grouping, which names the serializer path exactly, plus the store source. The confirming test is production returning 200 after deploy.

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_