### PR TITLE
fix(ssr): keep every Promise ref out of Pinia state, and contract it

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -46,6 +46,13 @@ jobs:
       - name: Channel content contract
         run: npm run test:channel-content
 
+      # A Promise returned from a Pinia setup store becomes SSR state, and
+      # devalue cannot serialize one -- so it is a 500 on EVERY page. This was
+      # fixed by hand twice and came back both times, because devalue reports
+      # only the first offender it meets. 53 were returned repo-wide.
+      - name: No Promise in Pinia store state
+        run: npm run test:no-promise-in-store-state
+
       - name: Channel resolver contract
         run: npm run test:channel-resolver
 

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -376,7 +376,7 @@ const currentUsername = computed(() =>
 )
 
 const isLoading = computed(() =>
-  Boolean(isRefreshing.value || chatStore.fetchHumanChatsPromise),
+  Boolean(isRefreshing.value || chatStore.isFetchingHumanChats),
 )
 
 const inboxChats = computed<ChatMessage[]>(() => {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "test:workflow-pipefail": "tsx utils/scripts/verifyWorkflowPipefail.ts",
     "test:deploy-wait-ancestry": "tsx utils/scripts/verifyDeployWaitAncestry.ts",
     "test:deploy-wait-noop": "tsx utils/scripts/verifyDeployWaitNoOp.ts",
+    "test:no-promise-in-store-state": "tsx utils/scripts/verifyNoPromiseInStoreState.ts",
     "test:no-prisma-json-cast": "tsx utils/scripts/verifyNoPrismaJsonCast.ts",
     "test:admin-flag-casts": "tsx utils/scripts/verifyAdminFlagCasts.ts",
     "test:user-role-expand": "tsx utils/scripts/verifyUserRoleExpand.ts",

--- a/stores/artStore.ts
+++ b/stores/artStore.ts
@@ -2672,9 +2672,14 @@ export const useArtStore = defineStore('artStore', () => {
 
     hoverArtImage,
     initializing,
-    initializePromise,
-    artImageRequestMap,
-    fetchAllArtImagesPromise,
+    /*
+     * Promise refs are deliberately NOT returned. In a Pinia setup store a
+     * returned ref becomes state, Nuxt serializes state into the SSR payload
+     * with devalue, and devalue cannot stringify a Promise -- which returned
+     * 500 on every page of the site. They stay private; re-entrancy is
+     * unaffected because the functions return the promise VALUE to callers.
+     * Guarded by utils/scripts/verifyNoPromiseInStoreState.ts.
+     */
 
     hasCachedImages,
     currentImagePath,

--- a/stores/botStore.ts
+++ b/stores/botStore.ts
@@ -970,10 +970,14 @@ export const useBotStore = defineStore('botStore', () => {
     lastError,
     error,
     pendingLaunchMessage,
-    initializePromise,
-    fetchBotsPromise,
-    loadBotByIdPromises,
-    botImagePromises,
+    /*
+     * Promise refs are deliberately NOT returned. In a Pinia setup store a
+     * returned ref becomes state, Nuxt serializes state into the SSR payload
+     * with devalue, and devalue cannot stringify a Promise -- which returned
+     * 500 on every page of the site. They stay private; re-entrancy is
+     * unaffected because the functions return the promise VALUE to callers.
+     * Guarded by utils/scripts/verifyNoPromiseInStoreState.ts.
+     */
 
     totalBots,
     selectedBotId,

--- a/stores/butterflyStore.ts
+++ b/stores/butterflyStore.ts
@@ -657,11 +657,16 @@ export const useButterflyStore = defineStore('butterflyStore', () => {
     loaderEffectName,
     logLoaderEffect,
     initializing,
-    initializePromise,
+    /*
+     * Promise refs are deliberately NOT returned. In a Pinia setup store a
+     * returned ref becomes state, Nuxt serializes state into the SSR payload
+     * with devalue, and devalue cannot stringify a Promise -- which returned
+     * 500 on every page of the site. They stay private; re-entrancy is
+     * unaffected because the functions return the promise VALUE to callers.
+     * Guarded by utils/scripts/verifyNoPromiseInStoreState.ts.
+     */
     gameInitialized,
     gameLoading,
-    initGamePromise,
-    startupSwarmPromise,
     loaderDebug,
     lastError,
     resetInitialization,

--- a/stores/cartStore.ts
+++ b/stores/cartStore.ts
@@ -455,10 +455,14 @@ export const useCartStore = defineStore('cartStore', () => {
     initializing,
     loading,
     lastError,
-    initializePromise,
-    checkoutPromise,
-    subscribePromise,
-    topupPromise,
+    /*
+     * Promise refs are deliberately NOT returned. In a Pinia setup store a
+     * returned ref becomes state, Nuxt serializes state into the SSR payload
+     * with devalue, and devalue cannot stringify a Promise -- which returned
+     * 500 on every page of the site. They stay private; re-entrancy is
+     * unaffected because the functions return the promise VALUE to callers.
+     * Guarded by utils/scripts/verifyNoPromiseInStoreState.ts.
+     */
 
     totalItems,
     totalPrice,

--- a/stores/channelContentStore.ts
+++ b/stores/channelContentStore.ts
@@ -301,7 +301,14 @@ export const useChannelContentStore = defineStore('channelContentStore', () => {
     initialized,
     loading,
     lastError,
-    initializePromise,
+    /*
+     * Promise refs are deliberately NOT returned. In a Pinia setup store a
+     * returned ref becomes state, Nuxt serializes state into the SSR payload
+     * with devalue, and devalue cannot stringify a Promise -- which returned
+     * 500 on every page of the site. They stay private; re-entrancy is
+     * unaffected because the functions return the promise VALUE to callers.
+     * Guarded by utils/scripts/verifyNoPromiseInStoreState.ts.
+     */
     initialize,
     hydrateActiveTabs,
     getChannel,

--- a/stores/characterStore.ts
+++ b/stores/characterStore.ts
@@ -920,9 +920,14 @@ export const useCharacterStore = defineStore('characterStore', () => {
     lastError,
     error,
     generationMode,
-    initializePromise,
-    fetchPromise,
-    fetchCharacterRewardsPromises,
+    /*
+     * Promise refs are deliberately NOT returned. In a Pinia setup store a
+     * returned ref becomes state, Nuxt serializes state into the SSR payload
+     * with devalue, and devalue cannot stringify a Promise -- which returned
+     * 500 on every page of the site. They stay private; re-entrancy is
+     * unaffected because the functions return the promise VALUE to callers.
+     * Guarded by utils/scripts/verifyNoPromiseInStoreState.ts.
+     */
     hasLoaded,
 
     initialize,

--- a/stores/chatStore.ts
+++ b/stores/chatStore.ts
@@ -278,6 +278,16 @@ export const useChatStore = defineStore('chatStore', () => {
   const fetchChatsPromise = ref<Promise<void> | null>(null)
   const lastFetchedUserId = ref<number | null>(null)
   const fetchHumanChatsPromise = ref<Promise<void> | null>(null)
+
+  /*
+   * A serializable view of the in-flight fetch, for the one consumer that
+   * needs it. chat-gallery.vue read `fetchHumanChatsPromise` directly for its
+   * truthiness -- but a Promise in store state is what devalue chokes on during
+   * SSR, so the promise stays private and this boolean is exported instead.
+   */
+  const isFetchingHumanChats = computed(() =>
+    Boolean(fetchHumanChatsPromise.value),
+  )
   const lastFetchedHumanUserId = ref<number | null>(null)
 
   const state = reactive<ChatStoreState>({
@@ -1684,6 +1694,7 @@ export const useChatStore = defineStore('chatStore', () => {
   }
 
   return {
+    isFetchingHumanChats,
     chats,
     unreadMessages,
     selectedChat,
@@ -1708,7 +1719,14 @@ export const useChatStore = defineStore('chatStore', () => {
      * serverStore already keeps its equivalent private, which is the pattern
      * this restores.
      */
-    fetchChatsPromise,
+    /*
+     * Promise refs are deliberately NOT returned. In a Pinia setup store a
+     * returned ref becomes state, Nuxt serializes state into the SSR payload
+     * with devalue, and devalue cannot stringify a Promise -- which returned
+     * 500 on every page of the site. They stay private; re-entrancy is
+     * unaffected because the functions return the promise VALUE to callers.
+     * Guarded by utils/scripts/verifyNoPromiseInStoreState.ts.
+     */
     lastFetchedUserId,
     state,
     textForm: computed(() => state.textForm),
@@ -1752,7 +1770,6 @@ export const useChatStore = defineStore('chatStore', () => {
     serverUsesOwnResource,
     getServerProvider,
     getTextStreamEndpoint,
-    fetchHumanChatsPromise,
     lastFetchedHumanUserId,
     humanChats,
     inboxChats,

--- a/stores/checkpointStore.ts
+++ b/stores/checkpointStore.ts
@@ -146,7 +146,6 @@ export const useCheckpointStore = defineStore('checkpointStore', () => {
   const modelLoading = ref(false)
   const modelStatusLoading = ref(false)
   const modelStatusError = ref('')
-  const fetchModelPromise = ref<Promise<void> | null>(null)
 
   const allCheckpoints = ref<Partial<Resource>[]>(validCheckpoints)
   const allSamplers = ref<Partial<Resource>[]>(validSamplers)
@@ -722,7 +721,14 @@ export const useCheckpointStore = defineStore('checkpointStore', () => {
     modelStatusError,
     modelUpdating,
     modelLoading,
-    fetchModelPromise,
+    /*
+     * Promise refs are deliberately NOT returned. In a Pinia setup store a
+     * returned ref becomes state, Nuxt serializes state into the SSR payload
+     * with devalue, and devalue cannot stringify a Promise -- which returned
+     * 500 on every page of the site. They stay private; re-entrancy is
+     * unaffected because the functions return the promise VALUE to callers.
+     * Guarded by utils/scripts/verifyNoPromiseInStoreState.ts.
+     */
     activeEngine,
     hasModelMismatch,
     initialize,

--- a/stores/collectionStore.ts
+++ b/stores/collectionStore.ts
@@ -1151,7 +1151,14 @@ export const useCollectionStore = defineStore('collectionStore', () => {
     allCollectionArtImages,
     allCollectionArtImageIds,
     hasFetched,
-    fetchPromise,
+    /*
+     * Promise refs are deliberately NOT returned. In a Pinia setup store a
+     * returned ref becomes state, Nuxt serializes state into the SSR payload
+     * with devalue, and devalue cannot stringify a Promise -- which returned
+     * 500 on every page of the site. They stay private; re-entrancy is
+     * unaffected because the functions return the promise VALUE to callers.
+     * Guarded by utils/scripts/verifyNoPromiseInStoreState.ts.
+     */
 
     fetchCollections,
     createCollection,

--- a/stores/consoleStore.ts
+++ b/stores/consoleStore.ts
@@ -227,7 +227,14 @@ export const useConsoleStore = defineStore('consoleStore', () => {
     level,
     loginStart,
     initialized,
-    initializePromise,
+    /*
+     * Promise refs are deliberately NOT returned. In a Pinia setup store a
+     * returned ref becomes state, Nuxt serializes state into the SSR payload
+     * with devalue, and devalue cannot stringify a Promise -- which returned
+     * 500 on every page of the site. They stay private; re-entrancy is
+     * unaffected because the functions return the promise VALUE to callers.
+     * Guarded by utils/scripts/verifyNoPromiseInStoreState.ts.
+     */
     hasFetched,
     userId,
     sessionDuration,

--- a/stores/dreamStore.ts
+++ b/stores/dreamStore.ts
@@ -2058,11 +2058,14 @@ export const useDreamStore = defineStore('dreamStore', () => {
     hasLoaded,
     error,
     lastError,
-    initializePromise,
-    fetchPromises,
-    fetchArtForDreamPromises,
-    createDreamPromise,
-    updateDreamPromise,
+    /*
+     * Promise refs are deliberately NOT returned. In a Pinia setup store a
+     * returned ref becomes state, Nuxt serializes state into the SSR payload
+     * with devalue, and devalue cannot stringify a Promise -- which returned
+     * 500 on every page of the site. They stay private; re-entrancy is
+     * unaffected because the functions return the promise VALUE to callers.
+     * Guarded by utils/scripts/verifyNoPromiseInStoreState.ts.
+     */
 
     numberOfRequests,
     temperature,

--- a/stores/navStore.ts
+++ b/stores/navStore.ts
@@ -734,7 +734,14 @@ export const useNavStore = defineStore('navStore', () => {
     isInitializing,
     loading,
     lastError,
-    initializePromise,
+    /*
+     * Promise refs are deliberately NOT returned. In a Pinia setup store a
+     * returned ref becomes state, Nuxt serializes state into the SSR payload
+     * with devalue, and devalue cannot stringify a Promise -- which returned
+     * 500 on every page of the site. They stay private; re-entrancy is
+     * unaffected because the functions return the promise VALUE to callers.
+     * Guarded by utils/scripts/verifyNoPromiseInStoreState.ts.
+     */
 
     dashboardShell,
     workspaceSheetOpen,

--- a/stores/promptStore.ts
+++ b/stores/promptStore.ts
@@ -1102,12 +1102,14 @@ export const usePromptStore = defineStore('promptStore', () => {
     isGeneratingFields,
     usingSnapshot,
     lastError,
-    initializePromise,
-    fetchPromise,
-    fetchPromptByIdPromises,
-    fetchArtByPromptIdPromises,
-    createPromptPromise,
-    updatePromptPromises,
+    /*
+     * Promise refs are deliberately NOT returned. In a Pinia setup store a
+     * returned ref becomes state, Nuxt serializes state into the SSR payload
+     * with devalue, and devalue cannot stringify a Promise -- which returned
+     * 500 on every page of the site. They stay private; re-entrancy is
+     * unaffected because the functions return the promise VALUE to callers.
+     * Guarded by utils/scripts/verifyNoPromiseInStoreState.ts.
+     */
 
     initialize,
     resetInitialization,

--- a/stores/reactionStore.ts
+++ b/stores/reactionStore.ts
@@ -471,9 +471,15 @@ export const useReactionStore = defineStore('reactionStore', () => {
     isInitialized,
     isInitializing,
     lastError,
-    initializePromise,
+    /*
+     * Promise refs are deliberately NOT returned. In a Pinia setup store a
+     * returned ref becomes state, Nuxt serializes state into the SSR payload
+     * with devalue, and devalue cannot stringify a Promise -- which returned
+     * 500 on every page of the site. They stay private; re-entrancy is
+     * unaffected because the functions return the promise VALUE to callers.
+     * Guarded by utils/scripts/verifyNoPromiseInStoreState.ts.
+     */
     loadingMap,
-    fetchPromises,
     loadedKeys,
 
     reactionTypes,

--- a/stores/resourceStore.ts
+++ b/stores/resourceStore.ts
@@ -695,9 +695,14 @@ export const useResourceStore = defineStore('resourceStore', () => {
     isInitialized,
     isLoading,
     hasLoaded,
-    initializePromise,
-    fetchPromise,
-    seedPromise,
+    /*
+     * Promise refs are deliberately NOT returned. In a Pinia setup store a
+     * returned ref becomes state, Nuxt serializes state into the SSR payload
+     * with devalue, and devalue cannot stringify a Promise -- which returned
+     * 500 on every page of the site. They stay private; re-entrancy is
+     * unaffected because the functions return the promise VALUE to callers.
+     * Guarded by utils/scripts/verifyNoPromiseInStoreState.ts.
+     */
     loadStore,
     getResources,
     seedResources,

--- a/stores/rewardStore.ts
+++ b/stores/rewardStore.ts
@@ -855,9 +855,14 @@ export const useRewardStore = defineStore('rewardStore', () => {
     hasLoaded,
     randomRewards,
 
-    initializePromise,
-    fetchPromise,
-    fetchRewardByIdPromises,
+    /*
+     * Promise refs are deliberately NOT returned. In a Pinia setup store a
+     * returned ref becomes state, Nuxt serializes state into the SSR payload
+     * with devalue, and devalue cannot stringify a Promise -- which returned
+     * 500 on every page of the site. They stay private; re-entrancy is
+     * unaffected because the functions return the promise VALUE to callers.
+     * Guarded by utils/scripts/verifyNoPromiseInStoreState.ts.
+     */
 
     totalRewards,
     hasUnsavedChanges,

--- a/stores/scenarioStore.ts
+++ b/stores/scenarioStore.ts
@@ -818,9 +818,14 @@ export const useScenarioStore = defineStore('scenarioStore', () => {
     currentChoice,
     storyHistory,
 
-    initializePromise,
-    fetchPromise,
-    fetchScenarioByIdPromises,
+    /*
+     * Promise refs are deliberately NOT returned. In a Pinia setup store a
+     * returned ref becomes state, Nuxt serializes state into the SSR payload
+     * with devalue, and devalue cannot stringify a Promise -- which returned
+     * 500 on every page of the site. They stay private; re-entrancy is
+     * unaffected because the functions return the promise VALUE to callers.
+     * Guarded by utils/scripts/verifyNoPromiseInStoreState.ts.
+     */
     hasLoaded,
 
     totalScenarios,

--- a/stores/serverStore.ts
+++ b/stores/serverStore.ts
@@ -2396,10 +2396,14 @@ export const useServerStore = defineStore('serverStore', () => {
     showHiddenServers,
     lastError,
 
-    initializePromise,
-    fetchPromise,
-    fetchServerByIdPromises,
-    healthPromises,
+    /*
+     * Promise refs are deliberately NOT returned. In a Pinia setup store a
+     * returned ref becomes state, Nuxt serializes state into the SSR payload
+     * with devalue, and devalue cannot stringify a Promise -- which returned
+     * 500 on every page of the site. They stay private; re-entrancy is
+     * unaffected because the functions return the promise VALUE to callers.
+     * Guarded by utils/scripts/verifyNoPromiseInStoreState.ts.
+     */
     hasLoaded,
 
     ownedServers,

--- a/stores/themeStore.ts
+++ b/stores/themeStore.ts
@@ -621,7 +621,14 @@ export const useThemeStore = defineStore('themeStore', () => {
     loadingThemes,
     usingSnapshot,
     lastError,
-    initializePromise,
+    /*
+     * Promise refs are deliberately NOT returned. In a Pinia setup store a
+     * returned ref becomes state, Nuxt serializes state into the SSR payload
+     * with devalue, and devalue cannot stringify a Promise -- which returned
+     * 500 on every page of the site. They stay private; re-entrancy is
+     * unaffected because the functions return the promise VALUE to callers.
+     * Guarded by utils/scripts/verifyNoPromiseInStoreState.ts.
+     */
     toggleMenu,
     setActiveTheme,
     updateBotTheme,

--- a/stores/userStore.ts
+++ b/stores/userStore.ts
@@ -865,7 +865,14 @@ export const useUserStore = defineStore('userStore', () => {
     recipient,
     googleToken,
     initialized,
-    initializePromise,
+    /*
+     * Promise refs are deliberately NOT returned. In a Pinia setup store a
+     * returned ref becomes state, Nuxt serializes state into the SSR payload
+     * with devalue, and devalue cannot stringify a Promise -- which returned
+     * 500 on every page of the site. They stay private; re-entrancy is
+     * unaffected because the functions return the promise VALUE to callers.
+     * Guarded by utils/scripts/verifyNoPromiseInStoreState.ts.
+     */
     isGuest,
     isLoggedIn,
     userId,
@@ -903,7 +910,6 @@ export const useUserStore = defineStore('userStore', () => {
     userImage,
     getUserNameByUserId,
     getUserById,
-    userByIdPromises,
     ensureRealUser,
   }
 })

--- a/utils/scripts/verifyNoPromiseInStoreState.ts
+++ b/utils/scripts/verifyNoPromiseInStoreState.ts
@@ -63,7 +63,8 @@ export function promiseRefNames(source: string): string[] {
     match;
     match = declaration.exec(source)
   ) {
-    const name = match[1] as string
+    const name = match?.[1]
+    if (!name) continue
     /*
      * Read the BALANCED <...> rather than regexing to the next `Promise`.
      *

--- a/utils/scripts/verifyNoPromiseInStoreState.ts
+++ b/utils/scripts/verifyNoPromiseInStoreState.ts
@@ -1,0 +1,209 @@
+// /utils/scripts/verifyNoPromiseInStoreState.ts
+//
+// A Promise in Pinia state takes production down. Every page, every route.
+//
+// WHAT HAPPENED, 2026-08-07
+// -------------------------
+// kind-robots.vercel.app returned 500 on every content route:
+//
+//   DevalueError: Cannot stringify a Promise or thenable
+//     path: '.pinia.pageStore.initializePromise'
+//     at renderPayloadJsonScript (chunks/routes/renderer.mjs:192:52)
+//
+// In a Pinia SETUP STORE every returned ref becomes state. Nuxt serializes that
+// state into the SSR payload with devalue, and devalue cannot stringify a
+// Promise -- so the render throws before a single byte reaches the browser.
+//
+// WHY THIS IS A CONTRACT AND NOT A CODE REVIEW NOTE
+// -------------------------------------------------
+// It was fixed twice by hand and came back both times, because devalue reports
+// only the FIRST unserializable value it meets:
+//
+//   fix pageStore   -> error moves to .pinia.chatStore.initializePromise
+//   fix chatStore   -> error moves to .pinia.navStore.initializePromise
+//
+// Each fix looked like a success and shipped a still-broken site. An exhaustive
+// sweep then found 37 returned Promise refs across 20 stores -- every one a
+// latent 500 waiting for the render that happens to populate it. This is not a
+// bug that can be chased; it has to be made unrepresentable.
+//
+// The rule is simple and total: a store may hold a Promise ref, but must not
+// RETURN one. Keeping it private preserves every re-entrancy guard in the repo
+// (initialize() still returns the promise VALUE to its caller) while keeping it
+// out of the serialized payload. serverStore already did this correctly, which
+// is how the intended pattern was known.
+//
+// If a consumer genuinely needs to know a request is in flight, export a
+// boolean computed -- see chatStore's isFetchingHumanChats, added for the one
+// component that was reading a promise for its truthiness.
+//
+//   npx tsx utils/scripts/verifyNoPromiseInStoreState.ts
+
+import { readFileSync, readdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const root = process.cwd()
+const STORES = resolve(root, 'stores')
+
+type Offence = { file: string; name: string }
+
+/**
+ * Refs whose declared type mentions Promise.
+ *
+ * Type-based rather than name-based on purpose: `actionLock`, `createLocks`
+ * and `mutationLocks` hold Promises without saying "promise" anywhere, and a
+ * name-shaped rule would miss exactly the ones nobody thought to name clearly.
+ */
+export function promiseRefNames(source: string): string[] {
+  const names: string[] = []
+  const declaration = /const\s+(\w+)\s*=\s*ref</g
+
+  for (
+    let match = declaration.exec(source);
+    match;
+    match = declaration.exec(source)
+  ) {
+    const name = match[1] as string
+    /*
+     * Read the BALANCED <...> rather than regexing to the next `Promise`.
+     *
+     * The first version used `ref<[^=]*?Promise\b`, which happily spanned
+     * newlines into a LATER declaration and reported `lastError` (a plain
+     * string ref) as a Promise -- 34 false positives on an already-fixed tree.
+     * Generic arguments nest and wrap across lines here
+     * (`ref<Record<number, Promise<Server | null>>>`), so the only honest way
+     * to read the type is to match the brackets.
+     */
+    let depth = 0
+    let end = match.index + match[0].length - 1
+    for (; end < source.length; end += 1) {
+      const char = source[end]
+      if (char === '<') depth += 1
+      else if (char === '>') {
+        depth -= 1
+        if (depth === 0) break
+      }
+    }
+    const type = source.slice(match.index, end + 1)
+    if (/\bPromise\b/.test(type)) names.push(name)
+  }
+  return names
+}
+
+/**
+ * Is `name` listed in a returned object literal — i.e. does it become state?
+ *
+ * A bare `  name,` line. Shorthand is how every store in this repo exposes its
+ * refs, so this is the shape that matters; an explicit `name: name` would slip
+ * past, and is worth revisiting if that style ever appears.
+ */
+export function isReturnedShorthand(source: string, name: string): boolean {
+  return new RegExp(`^[ \\t]+${name},[ \\t]*$`, 'm').test(source)
+}
+
+export function findOffences(
+  files: { file: string; source: string }[],
+): Offence[] {
+  const offences: Offence[] = []
+  for (const { file, source } of files) {
+    for (const name of promiseRefNames(source)) {
+      if (isReturnedShorthand(source, name)) offences.push({ file, name })
+    }
+  }
+  return offences.sort(
+    (a, b) => a.file.localeCompare(b.file) || a.name.localeCompare(b.name),
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+
+function selfTest(): void {
+  const fail = (message: string): never => {
+    throw new Error(message)
+  }
+
+  const returned = `
+    const initializePromise = ref<Promise<void> | null>(null)
+    return {
+      things,
+      initializePromise,
+    }
+  `
+  const kept = `
+    const initializePromise = ref<Promise<void> | null>(null)
+    return {
+      things,
+    }
+  `
+  if (!findOffences([{ file: 'a.ts', source: returned }]).length) {
+    fail('a returned Promise ref must be reported')
+  }
+  if (findOffences([{ file: 'a.ts', source: kept }]).length) {
+    fail(
+      'a PRIVATE Promise ref must not be reported — that is the fix, not the bug',
+    )
+  }
+
+  // Type-shaped, not name-shaped: these are the ones a name rule would miss.
+  const unnamed = `
+    const actionLock = ref<Promise<any> | null>(null)
+    const mutationLocks = ref<Partial<Record<string, Promise<void>>>>({})
+    return {
+      actionLock,
+      mutationLocks,
+    }
+  `
+  if (findOffences([{ file: 'b.ts', source: unnamed }]).length !== 2) {
+    fail('Promise-typed refs must be caught regardless of their name')
+  }
+
+  // A plain ref is not an offence, however it is named.
+  const innocent = `
+    const promiseCount = ref<number>(0)
+    return { promiseCount }
+  `
+  if (findOffences([{ file: 'c.ts', source: innocent }]).length) {
+    fail(
+      'a non-Promise ref must not be reported just for being called promise-ish',
+    )
+  }
+
+  console.log('✅ verifyNoPromiseInStoreState self-test passed.')
+}
+
+/* -------------------------------------------------------------------------- */
+
+selfTest()
+
+const files = readdirSync(STORES)
+  .filter((entry) => entry.endsWith('.ts') && !entry.endsWith('.test.ts'))
+  .map((entry) => ({
+    file: `stores/${entry}`,
+    source: readFileSync(resolve(STORES, entry), 'utf8'),
+  }))
+
+const offences = findOffences(files)
+
+if (offences.length) {
+  console.error(
+    `\nFAIL - ${offences.length} Promise ref(s) are returned from a Pinia store, and` +
+      ` will be serialized into the SSR payload:\n`,
+  )
+  for (const { file, name } of offences) {
+    console.error(`  ${file} -> ${name}`)
+  }
+  console.error(
+    `\nEach one is a 500 on every page the moment it is populated during a render:\n` +
+      `  DevalueError: Cannot stringify a Promise or thenable\n\n` +
+      `Keep the ref PRIVATE -- drop it from the returned object. Re-entrancy still\n` +
+      `works, because initialize() returns the promise VALUE to its caller. If a\n` +
+      `consumer needs "is this in flight?", export a boolean computed instead\n` +
+      `(see chatStore's isFetchingHumanChats).`,
+  )
+  process.exitCode = 1
+} else {
+  console.log(
+    `\nNo Promise reaches Pinia state: checked ${files.length} stores.` +
+      ` SSR payload serialization is safe.`,
+  )
+}


### PR DESCRIPTION
## The outage

Production returned 500 on every content route:

```
DevalueError: Cannot stringify a Promise or thenable
  path: '.pinia.pageStore.initializePromise'
  at renderPayloadJsonScript (chunks/routes/renderer.mjs:192:52)
```

In a Pinia **setup store every returned ref becomes state**. Nuxt serializes that state into the SSR payload with `devalue`, and `devalue` cannot stringify a Promise — so the render throws before a byte reaches the browser.

## Why this is a sweep and not another patch

It was fixed twice by hand and came back both times, because `devalue` reports only the **first** unserializable value it meets:

| fix | result |
| --- | --- |
| `pageStore` (#1540) | error moves to `.pinia.chatStore.initializePromise` |
| `chatStore` | error moves to `.pinia.navStore.initializePromise` |

Each fix looked like a success and shipped a still-broken site. An exhaustive sweep then found **53 returned Promise refs across 20 stores** — every one a latent 500 waiting for the render that happens to populate it.

## The fix

Each ref stays exactly where it is and keeps doing its job; it is only dropped from the returned object. Re-entrancy guards are unaffected — `initialize()` still returns the promise **value** to its caller, so `await store.initialize()` behaves identically. `serverStore` already did this correctly, which is how the intended pattern was known.

Two consumers needed a real replacement rather than a deletion:

- `components/user/chat-gallery.vue` read `chatStore.fetchHumanChatsPromise` for its truthiness → `chatStore` now exports an `isFetchingHumanChats` boolean computed.
- `checkpointStore.fetchModelPromise` had no readers at all once it left the return — dead code, deleted.

## The contract

`utils/scripts/verifyNoPromiseInStoreState.ts` makes the class unrepresentable rather than merely fixed.

It is **type-shaped, not name-shaped**, on purpose: `actionLock`, `createLocks` and `mutationLocks` hold Promises without saying "promise" anywhere, and a name rule would miss exactly the ones nobody thought to name clearly.

It reads the **balanced `<...>`** of each `ref` declaration rather than regexing forward to the next `Promise` — the first version spanned newlines into a *later* declaration and reported `lastError` (a plain string ref) as an offender, 34 false positives on an already-clean tree. Generic arguments nest and wrap here (`ref<Record<number, Promise<Server | null>>>`), so matching brackets is the only honest read.

Self-tests cover: returned Promise ref flagged; **private** Promise ref not flagged (that is the fix, not the bug); Promise-typed refs caught regardless of name; a `promiseCount: ref<number>` not flagged for being promise-ish.

Wired into `package.json` (`test:no-promise-in-store-state`) and `.github/workflows/contract-tests.yml`.

## Verification

- `npx tsx utils/scripts/verifyNoPromiseInStoreState.ts` → *"No Promise reaches Pinia state: checked 95 stores. SSR payload serialization is safe."*
- `vue-tsc` exit 0
- lint ratchet **396, unchanged**
- CRLF line endings preserved in `characterStore.ts` / `serverStore.ts` (an earlier scripted pass normalized them and inflated the diff to 3641 lines; restored via binary write)
- diff is **180 insertions / 55 deletions across 23 files**

Remaining `prettier --check` warnings on `characterStore`, `collectionStore`, `resourceStore`, `serverStore`, `userStore` are pre-existing drift already on `main`, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_