### PR TITLE
Fix friendships.cy.ts split PENDING/ACCEPTED CI failure

### DIFF
--- a/cypress/e2e/api/friendships.cy.ts
+++ b/cypress/e2e/api/friendships.cy.ts
@@ -379,13 +379,15 @@ describe('Friendship / UserRelation API Tests', () => {
 
   it('keeps reverse family requests pending', () => {
     createRelation('PARENT').then((parentRow) => {
-      createRelation('CHILD', actorUserId, adminAuthHeaders()).then((childRow) => {
-        expect(parentRow.status).to.eq('PENDING')
-        expect(childRow.status).to.eq('PENDING')
+      createRelation('CHILD', actorUserId, adminAuthHeaders()).then(
+        (childRow) => {
+          expect(parentRow.status).to.eq('PENDING')
+          expect(childRow.status).to.eq('PENDING')
 
-        deleteRelation(parentRow.id)
-        deleteRelation(childRow.id, adminAuthHeaders())
-      })
+          deleteRelation(parentRow.id)
+          deleteRelation(childRow.id, adminAuthHeaders())
+        },
+      )
     })
   })
 
@@ -402,7 +404,8 @@ describe('Friendship / UserRelation API Tests', () => {
               row.userId === relatedUserId &&
               row.relatedUserId === actorUserId,
           )
-          expect(childRow, 'CHILD inverse created on accept').to.not.be.undefined
+          expect(childRow, 'CHILD inverse created on accept').to.not.be
+            .undefined
           if (childRow) track(childRow.id)
 
           deleteRelation(parentRow.id).then((response) => {
@@ -430,6 +433,37 @@ describe('Friendship / UserRelation API Tests', () => {
 
       deleteRelation(block.id).then((response) => {
         expect([200, 202, 204]).to.include(response.status)
+      })
+    })
+  })
+
+  // A test that throws mid-flow (e.g. after an accept but before its own
+  // cleanup delete) can leave the actor/related pair in a split state: one
+  // row reset to PENDING by a later retry's re-request, its already-ACCEPTED
+  // inverse untouched. Cypress reruns the `it` body on retry but not
+  // `before()`, so the pair persists across attempts unless something clears
+  // it in between. `afterEach` runs after every attempt (retried or not),
+  // so this guarantees the next attempt (or the next test) never inherits a
+  // stale FRIEND relation from a failed one. See the 2026-08-06/07 CI
+  // incident this fixes: a mid-test failure left one FRIEND row PENDING and
+  // its inverse ACCEPTED, which made "target sees pending request" fail on
+  // every subsequent run for that pair.
+  afterEach(() => {
+    if (!userToken || !actorUserId || !relatedUserId) return
+
+    listRelations(userHeaders()).then((rows) => {
+      const stray = rows.filter(
+        (row) =>
+          row.type === 'FRIEND' &&
+          ((row.userId === actorUserId &&
+            row.relatedUserId === relatedUserId) ||
+            (row.userId === relatedUserId &&
+              row.relatedUserId === actorUserId)),
+      )
+      stray.forEach((row) => {
+        const headers =
+          row.userId === actorUserId ? userHeaders() : adminAuthHeaders()
+        deleteRelation(row.id, headers).then(() => untrack(row.id))
       })
     })
   })

--- a/server/api/relations/index.post.ts
+++ b/server/api/relations/index.post.ts
@@ -132,6 +132,27 @@ export default defineEventHandler(async (event) => {
     }
   }
 
+  // A repeat request for an already-ACCEPTED relation must be a no-op, not a
+  // demotion back to PENDING. Without this guard, a duplicate/retried POST
+  // (e.g. a client retry, or two tabs racing) resets the forward row to
+  // PENDING while its already-ACCEPTED inverse row is left untouched,
+  // splitting one friendship into a self-contradictory PENDING/ACCEPTED pair
+  // that no later request can reconcile (see kind_robots CI incident
+  // 2026-08-06/07: this exact split state deadlocked friendships.cy.ts).
+  const existing = await prisma.userRelation.findUnique({
+    where: {
+      userId_relatedUserId_type: { userId, relatedUserId, type },
+    },
+  })
+  if (existing?.status === 'ACCEPTED') {
+    setResponseStatus(event, 200)
+    return {
+      success: true,
+      message: 'Relation already accepted.',
+      data: existing,
+    }
+  }
+
   // Fresh request → PENDING.
   const data = await prisma.userRelation.upsert({
     where: {


### PR DESCRIPTION
## What

Fixes the red `Cypress Tests` workflow on `main` (run [31126081707](https://github.com/silasfelinus/kind_robots/actions/runs/31126081707), ci-janitor Todo #1247).

## Root cause

Confirmed via the raw CI job log: `cypress/e2e/api/friendships.cy.ts` → "runs the complete friend request, accept, and removal lifecycle" failed both attempts on `expect(visible?.status, 'target sees pending request').to.eq('PENDING')` — actual was `'ACCEPTED'`.

Chain of events:
1. Attempt 1 hit a transient failure *after* successfully accepting the FRIEND request (forward row `ACCEPTED`, inverse row created `ACCEPTED`) but *before* its own cleanup delete ran — likely a hiccup in the final DELETE round-trip against the shared backend this suite documents prior flakiness against.
2. Cypress's built-in retry re-ran the `it()` body with the same actor/related user ids (retries don't re-run `before()`). The fresh `POST /api/relations` matched the existing row's unique key and the server's `upsert` **reset its status back to `PENDING`**, leaving the already-`ACCEPTED` inverse row untouched.
3. The test's direction-agnostic `findRelation()` lookup, ordered by `createdAt desc`, matched the stale `ACCEPTED` inverse row first → the "target sees pending request" assertion failed on the retry too, exactly as observed.

This is a genuine product data-integrity gap (a duplicate/retried friend request could silently split any real friendship into a self-contradictory PENDING/ACCEPTED pair), not just a test artifact — confirmed unrelated to the run's head commit (`f14d77a`, an unrelated Academy accessibility fix).

## Fix

- **`server/api/relations/index.post.ts`**: a repeat POST for a relation that is already `ACCEPTED` is now a no-op (returns the existing accepted row) instead of resetting it to `PENDING`.
- **`cypress/e2e/api/friendships.cy.ts`**: added an `afterEach` that clears any leftover FRIEND relation between the test's actor/related pair after every attempt, so a failed attempt can never hand a stale row to the retry or the next test.

No assertions were weakened, skipped, or deleted — the `afterEach` only strengthens cleanup, and the server change closes a self-contradictory state that could equally affect real users, not just this test.

## Verification

- `vue-tsc --noEmit` — clean
- `eslint` — clean
- `prettier --check` — clean
- Will confirm the `Cypress Tests` workflow goes green on this PR before merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QtvRSHbRbWHW3gxXWSGney)_