### PR TITLE
fix(art-styler): pin in-flight generation banner to snapshotted style, not live selection

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -542,7 +542,7 @@
       <div v-if="isGenerating" class="flex flex-col gap-2">
         <div class="flex items-center gap-2 text-xs font-semibold text-primary">
           <span class="loading loading-spinner loading-xs" />
-          Applying {{ selectedStyle?.label }} via Kontext…
+          Applying {{ generatingStyleLabel }} via Kontext…
         </div>
         <progress class="progress progress-primary w-full" />
       </div>
@@ -855,6 +855,12 @@ const extraPrompt = ref('')
 const useNegative = ref(true)
 const isPublic = ref(true)
 const isGenerating = ref(false)
+// Snapshot of the style being generated, separate from the live
+// `selectedStyle` ref -- a user can reselect a different style while a
+// generation is still in flight (see the `generationToken` comment below),
+// which would otherwise make the "Applying X via Kontext…" banner name a
+// style other than the one the in-flight request is actually for.
+const generatingStyleLabel = ref('')
 const errorMessage = ref('')
 const successMessage = ref('')
 const resultImage = ref<ArtImage | null>(null)
@@ -1447,13 +1453,14 @@ async function runStyleTransfer(): Promise<void> {
   if (!selectedStyle.value || !selectedSourceImage.value) return
 
   const token = ++generationToken
+  const style = selectedStyle.value
   errorMessage.value = ''
   successMessage.value = ''
   isGenerating.value = true
+  generatingStyleLabel.value = style.label
   resultImage.value = null
 
   try {
-    const style = selectedStyle.value
     const loraRef = buildLoraReference(style)
 
     const promptString = [


### PR DESCRIPTION
### Task
ai-art-academy/t-010 (conductor roadmap): Academy continuous improvement pass — lane 1, front-end polish.

### What changed / what I produced
- `components/art/art-styler.vue`: the in-progress "Applying X via Kontext…" banner bound directly to the live `selectedStyle` ref. Nothing in the component disables style/source reselection during generation (documented deliberately in the existing `generationToken` comment) — a user who reselects a different style mid-generation saw the banner switch names while the actual in-flight request was still for the original style. The eventual success/result correctly reattaches to the original style (existing token guard already handles that), so the banner's name directly contradicted what the user watched during the whole wait.
- Added a `generatingStyleLabel` ref, snapshotted alongside the existing `const style = selectedStyle.value` capture at the top of `runStyleTransfer`, and bound the banner to that instead of the live ref.

### How I verified
- `npx eslint components/art/art-styler.vue` — clean
- `npx prettier --check components/art/art-styler.vue` — clean
- Full-project `npm run test` (`vue-tsc --noEmit`) — exit 0, zero errors

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
`selectStyle()`/`clearSelection()` bump `generationToken` on every selection change but don't visually indicate to the user that reselecting mid-generation "abandons" the in-flight request's visible outcome (the result silently won't apply to what's on screen once it settles for the old style, if the token no longer matches — wait, actually the fix here makes the banner correct, but there's no toast/message when a still-completing generation's result gets suppressed because the user moved on). A future lane-1 pass could add a brief "previous generation for X was superseded" notice instead of the result just silently not appearing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G2HFsuDNGa2bPFR5hGAJ9C)_