### PR TITLE
Move the Icons and Servers galleries onto kr-gallery (ratchet 14 → 12)

### DIFF
--- a/components/icons/icon-card.vue
+++ b/components/icons/icon-card.vue
@@ -1,0 +1,86 @@
+<!-- /components/icons/icon-card.vue -->
+<!--
+  One Smart Icon, as a card.
+
+  Extracted from icon-gallery.vue when that grid moved onto kr-gallery. The
+  markup is unchanged; it only needed an owner, because a card inlined in a
+  `#item` slot has to reach its record through the slot's GalleryItem and every
+  reference becomes `iconById.get(Number(item.id))!`. A card component takes the
+  record as a prop instead, which is the shape reward-card and bot-card already
+  use.
+
+  Presentational: it renders and emits, and reads no store. Membership of the
+  smart bar is passed in rather than looked up, so this stays mountable in
+  WonderLab with a plain fixture.
+-->
+<template>
+  <div
+    class="relative group p-4 border-2 rounded-2xl bg-base-100 shadow-md flex flex-col items-center gap-2"
+    :class="{
+      'border-primary/30': icon.type === 'nav',
+      'border-secondary/30': icon.type === 'utility',
+      'border-base-300': !icon.type,
+    }"
+  >
+    <span
+      class="absolute top-2 left-2 text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded-md"
+      :class="{
+        'bg-primary/10 text-primary': icon.type === 'nav',
+        'bg-secondary/10 text-secondary': icon.type === 'utility',
+        'bg-base-300 text-base-content/40': !icon.type,
+      }"
+    >
+      {{ icon.type || '?' }}
+    </span>
+
+    <Icon :name="icon.icon || 'kind-icon:help'" class="text-4xl mt-3" />
+
+    <div class="text-center text-sm font-medium">
+      {{ icon.label || icon.title }}
+    </div>
+
+    <div v-if="icon.description" class="text-center text-sm font-medium">
+      {{ icon.description }}
+    </div>
+
+    <button
+      v-if="canEdit"
+      class="mt-1 text-[10px] underline text-blue-500 hover:text-blue-700"
+      @click="emit('edit', icon)"
+    >
+      Edit Details
+    </button>
+
+    <button
+      class="btn btn-xs mt-1 rounded-xl"
+      :class="{
+        'btn-secondary': inSmartBar,
+        'btn-outline': !inSmartBar,
+      }"
+      @click="emit('toggle', icon.id)"
+    >
+      {{ inSmartBar ? 'Remove' : 'Add' }}
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { SmartIcon } from '@/stores/smartbarStore'
+
+withDefaults(
+  defineProps<{
+    icon: SmartIcon
+    inSmartBar?: boolean
+    canEdit?: boolean
+  }>(),
+  {
+    inSmartBar: false,
+    canEdit: false,
+  },
+)
+
+const emit = defineEmits<{
+  edit: [icon: SmartIcon]
+  toggle: [id: number]
+}>()
+</script>

--- a/components/icons/icon-gallery.vue
+++ b/components/icons/icon-gallery.vue
@@ -54,60 +54,28 @@
       </select>
     </div>
 
-    <!-- Icon Grid -->
-    <div class="grid grid-cols-[repeat(auto-fit,minmax(140px,1fr))] gap-6">
-      <div
-        v-for="icon in filteredIcons"
-        :key="icon.id"
-        class="relative group p-4 border-2 rounded-2xl bg-base-100 shadow-md flex flex-col items-center gap-2"
-        :class="{
-          'border-primary/30': icon.type === 'nav',
-          'border-secondary/30': icon.type === 'utility',
-          'border-base-300': !icon.type,
-        }"
-      >
-        <!-- Type badge -->
-        <span
-          class="absolute top-2 left-2 text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded-md"
-          :class="{
-            'bg-primary/10 text-primary': icon.type === 'nav',
-            'bg-secondary/10 text-secondary': icon.type === 'utility',
-            'bg-base-300 text-base-content/40': !icon.type,
-          }"
-        >
-          {{ icon.type || '?' }}
-        </span>
-
-        <Icon :name="icon.icon || 'kind-icon:help'" class="text-4xl mt-3" />
-
-        <div class="text-center text-sm font-medium">
-          {{ icon.label || icon.title }}
-        </div>
-
-        <div v-if="icon.description" class="text-center text-sm font-medium">
-          {{ icon.description }}
-        </div>
-
-        <button
-          v-if="isAdmin"
-          class="mt-1 text-[10px] underline text-blue-500 hover:text-blue-700"
-          @click="openEditModal(icon)"
-        >
-          Edit Details
-        </button>
-
-        <button
-          class="btn btn-xs mt-1 rounded-xl"
-          :class="{
-            'btn-secondary': isInSmartBar(icon.id),
-            'btn-outline': !isInSmartBar(icon.id),
-          }"
-          @click="toggleIcon(icon.id)"
-        >
-          {{ isInSmartBar(icon.id) ? 'Remove' : 'Add' }}
-        </button>
-      </div>
-    </div>
+    <!-- The shared shell owns the grid, the Cards/Heroes/Icons bar, and the
+         loading and empty states; icon-card stays the card. Smart Icons are
+         glyphs rather than art, so the #item slot replaces kr-gallery's default
+         card outright instead of handing it an image to resolve. -->
+    <kr-gallery
+      :items="galleryItems"
+      :mode="galleryMode"
+      :loading="smartbarStore.loading"
+      empty-label="icons"
+      @update:mode="galleryMode = $event"
+    >
+      <template #item="{ item }">
+        <icon-card
+          v-if="iconById.get(Number(item.id))"
+          :icon="iconById.get(Number(item.id))!"
+          :in-smart-bar="isInSmartBar(Number(item.id))"
+          :can-edit="isAdmin"
+          @edit="openEditModal"
+          @toggle="toggleIcon"
+        />
+      </template>
+    </kr-gallery>
 
     <!-- Edit Modal -->
     <Teleport to="body">
@@ -129,6 +97,8 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { storeToRefs } from 'pinia'
+import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
+import type { GalleryMode } from '@/utils/galleryVocabulary'
 import { useSmartbarStore, type SmartIcon } from '@/stores/smartbarStore'
 import { useUserStore } from '@/stores/userStore'
 
@@ -142,6 +112,7 @@ const selectedIcon = ref<SmartIcon | null>(null)
 
 const filterScope = ref<'all' | 'user' | 'public'>('all')
 const filterType = ref('')
+const galleryMode = ref<GalleryMode>('cards')
 
 const isAdmin = computed(() => userStore.isAdmin)
 
@@ -160,6 +131,23 @@ const filteredIcons = computed(() =>
     if (filterType.value && i.type !== filterType.value) return false
     return true
   }),
+)
+
+/*
+ * kr-gallery takes GalleryItems and hands one back to the #item slot, so the
+ * card reaches its record through this map. Title falls back to the icon's own
+ * name so the shared empty/loading states have something to say.
+ */
+const galleryItems = computed<GalleryItem[]>(() =>
+  filteredIcons.value.map((icon) => ({
+    id: icon.id,
+    title: icon.label || icon.title || `Icon ${icon.id}`,
+    description: icon.description || undefined,
+  })),
+)
+
+const iconById = computed(
+  () => new Map(filteredIcons.value.map((icon) => [icon.id, icon])),
 )
 
 function isInSmartBar(id: number) {

--- a/components/servers/server-gallery.vue
+++ b/components/servers/server-gallery.vue
@@ -1,7 +1,12 @@
 <!-- /components/server/server-gallery.vue -->
 <template>
-  <section class="flex h-full w-full flex-col gap-3 rounded-2xl bg-base-300 p-3">
-    <header v-if="showHeader" class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3">
+  <section
+    class="flex h-full w-full flex-col gap-3 rounded-2xl bg-base-300 p-3"
+  >
+    <header
+      v-if="showHeader"
+      class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3"
+    >
       <div class="flex items-start justify-between gap-3">
         <div class="min-w-0">
           <h2 class="truncate text-lg font-bold text-base-content">
@@ -30,7 +35,10 @@
           placeholder="Filter servers"
         />
 
-        <select v-model="selectedType" class="select select-bordered rounded-xl">
+        <select
+          v-model="selectedType"
+          class="select select-bordered rounded-xl"
+        >
           <option value="all">All types</option>
           <option value="A1111">A1111</option>
           <option value="COMFY">COMFY</option>
@@ -48,38 +56,61 @@
 
     <add-server v-if="showAddServer" />
 
-    <div v-if="serverStore.loading || isLoading" class="flex justify-center rounded-2xl bg-base-200 p-6">
-      <span class="loading loading-spinner loading-lg" />
-    </div>
+    <!-- The shared shell owns the grid, the mode bar, and the loading and empty
+         states; server-card stays the card.
 
-    <div v-else-if="filteredServers.length" class="grid gap-3" :class="gridClass">
-      <server-card
-        v-for="server in filteredServers"
-        :key="server.id"
-        :server="server"
-        :compact="variant === 'row' || variant === 'dropdown'"
-        :show-description="showDescriptions"
-        :show-meta="showMeta"
-        :show-use-buttons="showUseButtons"
-        :show-actions="showCardActions"
-        :allow-edit="showCardActions"
-        :allow-test="showCardActions"
-      />
-    </div>
+         The compact variants pass `:modes="[]"`, which hides the bar: a row or
+         a dropdown is a PICKER, not a gallery, and offering Cards/Heroes/Icons
+         inside one would be offering a choice that has nowhere to land. They
+         are pinned to `icons`, whose grid is the row-shaped one — and because
+         every MODE_GRID_CLASS is auto-fill over `minmax(min(X,100%),1fr)`, it
+         collapses to a single column in a narrow container on its own. -->
+    <kr-gallery
+      :items="galleryItems"
+      :mode="isCompact ? 'icons' : galleryMode"
+      :modes="isCompact ? [] : [...GALLERY_MODES]"
+      :loading="serverStore.loading || isLoading"
+      empty-label="servers"
+      @update:mode="galleryMode = $event"
+    >
+      <template #item="{ item }">
+        <server-card
+          v-if="serverById.get(Number(item.id))"
+          :server="serverById.get(Number(item.id))!"
+          :compact="isCompact"
+          :show-description="showDescriptions"
+          :show-meta="showMeta"
+          :show-use-buttons="showUseButtons"
+          :show-actions="showCardActions"
+          :allow-edit="showCardActions"
+          :allow-test="showCardActions"
+        />
+      </template>
 
-    <div v-else class="rounded-2xl border border-dashed border-base-300 bg-base-200 p-6 text-center">
-      <Icon name="kind-icon:server-off" class="mx-auto mb-2 h-8 w-8 text-base-content/40" />
-      <p class="font-bold">No matching servers.</p>
-      <p class="text-sm text-base-content/60">
-        Add a configured A1111, Comfy, OpenAI, Anthropic, or Custom endpoint.
-      </p>
-    </div>
+      <template #empty>
+        <div
+          class="rounded-2xl border border-dashed border-base-300 bg-base-200 p-6 text-center"
+        >
+          <Icon
+            name="kind-icon:server-off"
+            class="mx-auto mb-2 h-8 w-8 text-base-content/40"
+          />
+          <p class="font-bold">No matching servers.</p>
+          <p class="text-sm text-base-content/60">
+            Add a configured A1111, Comfy, OpenAI, Anthropic, or Custom
+            endpoint.
+          </p>
+        </div>
+      </template>
+    </kr-gallery>
   </section>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import type { Server, ServerType } from '~/prisma/generated/prisma/client'
+import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
+import { GALLERY_MODES, type GalleryMode } from '@/utils/galleryVocabulary'
 import { useServerStore } from '@/stores/serverStore'
 
 type GalleryVariant = 'dashboard' | 'row' | 'dropdown'
@@ -142,23 +173,55 @@ const isLoading = ref(false)
 const showAddServer = ref(false)
 
 const resolvedTitle = computed(() => {
-  return props.title || (props.mode === 'art' ? 'Art Servers' : props.mode === 'text' ? 'Text Servers' : 'Servers')
+  return (
+    props.title ||
+    (props.mode === 'art'
+      ? 'Art Servers'
+      : props.mode === 'text'
+        ? 'Text Servers'
+        : 'Servers')
+  )
 })
 
 const resolvedSubtitle = computed(() => {
-  return props.subtitle || 'Configured access points only. Route behavior lives in endpoints now.'
+  return (
+    props.subtitle ||
+    'Configured access points only. Route behavior lives in endpoints now.'
+  )
 })
 
-const gridClass = computed(() => {
-  if (props.variant === 'row' || props.variant === 'dropdown') return 'grid-cols-1'
-  return 'md:grid-cols-2 xl:grid-cols-3'
-})
+/*
+ * The grid moved to kr-gallery. What used to be `md:grid-cols-2 xl:grid-cols-3`
+ * is now MODE_GRID_CLASS, which is container-responsive rather than
+ * viewport-responsive -- this gallery is mounted inside manager panels, where
+ * `xl:` fired on a wide screen while the actual container was narrow.
+ */
+const isCompact = computed(
+  () => props.variant === 'row' || props.variant === 'dropdown',
+)
+
+const galleryMode = ref<GalleryMode>('cards')
+
+const galleryItems = computed<GalleryItem[]>(() =>
+  filteredServers.value.map((server) => ({
+    id: server.id,
+    title: server.title || server.label || `Server ${server.id}`,
+  })),
+)
+
+/** Slot props give back a GalleryItem, so map the id to the real record. */
+const serverById = computed(
+  () => new Map(filteredServers.value.map((server) => [server.id, server])),
+)
 
 const serversByMode = computed<Server[]>(() => {
   const servers = Array.isArray(serverStore.servers) ? serverStore.servers : []
 
   if (props.mode === 'art') {
-    return servers.filter((server) => server.serverType === 'A1111' || server.serverType === 'COMFY')
+    return servers.filter(
+      (server) =>
+        server.serverType === 'A1111' || server.serverType === 'COMFY',
+    )
   }
 
   if (props.mode === 'text') {
@@ -175,7 +238,11 @@ const filteredServers = computed<Server[]>(() => {
 
   return serversByMode.value.filter((server) => {
     if (!server.isActive) return false
-    if (selectedType.value !== 'all' && server.serverType !== selectedType.value) return false
+    if (
+      selectedType.value !== 'all' &&
+      server.serverType !== selectedType.value
+    )
+      return false
 
     if (!query) return true
 

--- a/utils/scripts/route-gallery-baseline.json
+++ b/utils/scripts/route-gallery-baseline.json
@@ -1,7 +1,7 @@
 {
   "note": "Route gallery RATCHET: this file may only ever shrink. --update refuses to record a larger count. See utils/scripts/verifyRouteGalleryContract.ts.",
   "recorded": "2026-08-07",
-  "total": 14,
+  "total": 12,
   "holdouts": {
     "achievement-gallery": ["/achievements", "/dashboard", "/themes"],
     "chat-gallery": ["/achievements", "/chats", "/dashboard", "/themes"],
@@ -13,9 +13,7 @@
     "dream-relationship-gallery": ["/brainstorm", "/dreams"],
     "scenario-relationship-gallery": ["/brainstorm", "/dreams"],
     "daily-digest-object-gallery": ["/for-you"],
-    "icon-gallery": ["/icons"],
     "resource-gallery": ["/resources"],
-    "server-gallery": ["/servers"],
     "ui-gallery": ["/ui"]
   },
   "shadowTotal": 0,

--- a/utils/wonderlab/previewFixtures.ts
+++ b/utils/wonderlab/previewFixtures.ts
@@ -13,6 +13,29 @@ export type WonderLabPreviewFixture = {
 const fixtureDate = new Date('2026-01-01T00:00:00.000Z')
 
 const fixtures: Record<string, WonderLabPreviewFixture> = {
+  'icon-card': {
+    title: 'Smart Icon card',
+    description:
+      'A nav-typed icon already in the smart bar, with the admin edit affordance on — so the type badge, the Remove state and the edit link are all visible at once. Presentational: it takes its record as a prop and reads no store.',
+    viewport: 'mobile',
+    minHeight: '12rem',
+    props: {
+      icon: {
+        id: -701,
+        title: 'Brainstorm',
+        label: 'Brainstorm',
+        icon: 'kind-icon:brain',
+        description: 'Open the idea forge.',
+        type: 'nav',
+        isPublic: true,
+        userId: 1,
+        createdAt: fixtureDate,
+        updatedAt: fixtureDate,
+      },
+      inSmartBar: true,
+      canEdit: true,
+    },
+  },
   'bot-card': {
     title: 'Bot Card specimen',
     description:


### PR DESCRIPTION
First two of the fourteen hand-rolled grids. Both single-collection; both now let the shared shell own the grid, the Cards/Heroes/Icons bar, and the loading and empty states. Each component keeps its header, filters and fetching — it stays the shell and insets the gallery, the same chrome-owns-the-panel shape the core objects use.

## Why the hand-rolled grids were worth giving up

Both keyed off the **viewport**:

```
server-gallery   md:grid-cols-2 xl:grid-cols-3
icon-gallery     grid-cols-[repeat(auto-fit,minmax(140px,1fr))]
```

These galleries mount *inside manager panels*, so on a wide screen `xl:` fired while the actual container was narrow — three columns crammed into a panel. `MODE_GRID_CLASS` is container-responsive instead, which is the bug that vocabulary was written to fix.

## `icon-card.vue`, extracted

The card markup is unchanged; it only needed an owner. A card inlined in an `#item` slot reaches its record back through the slot's `GalleryItem`, so every reference becomes `iconById.get(Number(item.id))!` — unreadable and easy to get wrong. A card component takes the record as a prop, which is the shape `reward-card` and `bot-card` already use.

It's presentational: smart-bar membership is passed in rather than looked up, so it mounts in WonderLab from a plain fixture — added, so the museum can exhibit it.

## Server pickers are not galleries

`server-gallery`'s `row` and `dropdown` variants are single-column **pickers**, and the Rule 3 shadow-browser detector deliberately doesn't treat those as browsers. Rather than fork the code path, they pass `:modes="[]"` — kr-gallery renders its bar behind `v-if="modes.length"` — and pin to `icons`, whose grid is the row-shaped one.

Every `MODE_GRID_CLASS` is `auto-fill` over `minmax(min(X,100%),1fr)`, so it collapses to one column in a narrow container on its own. The old `grid-cols-1` special case is deleted rather than reimplemented.

Smart Icons are glyphs rather than art, so icon-gallery's `#item` slot replaces kr-gallery's default card outright instead of handing it an image to resolve. That's what the slot is for, and kr-gallery stays store-free.

## Watched to fail

Turning icon-gallery's `<kr-gallery>` back into `class="kr-gallery"` drops the count 9 → 8. Adoption is still counted at the **element**, not by substring — the exact false positive the original adoption check shipped with.

## Verification

- `vue-tsc` exit 0
- route-gallery, gallery-adoption, gallery-consistency, layout, entity-art, narrative-kit, reachability, ui-tier-vocabulary, capture-group and no-promise-in-store-state all pass
- ratchet 14 → 12, and `--update` still refuses to record a larger count
- one pre-existing eslint attribute-order warning in icon-gallery's `Teleport` is untouched

## Remaining

Five more single-collection galleries (`checkpoint`, `stylist-client`, `resource`, `dream-relationship`, `scenario-relationship`), then the four multi-collection panels and three page-sized ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_