### PR TITLE
Clean the stale `workspace` wording from four of the five surfaces

### DIFF
--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -1,4 +1,4 @@
-<!-- /components/bots/bot-workspace.vue -->
+<!-- /components/bots/bot-chat.vue -->
 <!--
   The Bot working surface: the conversation, its controls, and the prompt
   preview. Split out of bot-interact.vue, which was 720 lines because all of

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -1,11 +1,11 @@
-<!-- /components/characters/character-workspace.vue -->
+<!-- /components/characters/character-chat.vue -->
 <!--
   The Character working surface: chat with them, or run an adventure.
 
   Split out of character-interact, which had grown to 923 lines -- 482 of
   template and 440 of script -- because both modes were inlined in the
   component whose only job is choosing between browsing and working.
-  dream-interact does that job in 57 lines because dream-workspace exists; this
+  dream-interact does that job in 57 lines because dream-narration exists; this
   is that, for Characters.
 
   Silas, 2026-08-06, on the interact tier: it "will be inevitably less

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -1,4 +1,4 @@
-<!-- /components/rewards/reward-workspace.vue -->
+<!-- /components/rewards/reward-encounter.vue -->
 <!--
   The Reward working surface: an encounter with a chosen Reward.
 
@@ -7,7 +7,7 @@
   component whose only job is choosing between browsing and working. Tone
   controls, prompt preview, session chat tracking, narrative turns and choices,
   and a hero-image carousel all sit here now. dream-interact does the same
-  routing job in 57 lines because dream-workspace exists; this is that.
+  routing job in 57 lines because dream-narration exists; this is that.
 
   Silas, 2026-08-06, on the interact tier: it "will be inevitably less
   consistent across models, since that's where we are actually hitting what we
@@ -15,7 +15,7 @@
   in the move -- the frame is what is shared, not the contents.
 
   The status banner came along rather than staying in the router: every
-  setStatus() call is a workspace action (prompt copied, story returned, story
+  setStatus() call is an encounter action (prompt copied, story returned, story
   continued), so it reports on this surface and belongs to it.
 -->
 <template>

--- a/components/scenarios/scenario-story.vue
+++ b/components/scenarios/scenario-story.vue
@@ -1,13 +1,13 @@
-<!-- /components/scenarios/scenario-workspace.vue -->
+<!-- /components/scenarios/scenario-story.vue -->
 <!--
   The Scenario working surface: configure a chosen Scenario, then play it.
 
   Split out of scenario-interact, which had grown to 531 lines because both
   phases were inlined in the router. dream-interact is 57 lines for the same
-  job, because its markup and its logic live in dream-workspace -- that is the
+  job, because its markup and its logic live in dream-narration -- that is the
   frame every model shares:
 
-    <x-gallery v-if="!selected" />     <x-workspace v-else />
+    <x-gallery v-if="!selected" />     <x-{activity} v-else />
 
   Silas, 2026-08-06: the interact tier "will be inevitably less consistent
   across models, since that's where we are actually hitting 'what we do with


### PR DESCRIPTION
The deferred comment cleanup. I'd held **all five** renamed surfaces on the grounds that editing them changes the `sourceHash` that carries their WonderLab reviews across the rename.

That was true of one file, not five — and I should have checked before generalising. Querying the production Component API rather than assuming:

| component | in production DB? |
| --- | --- |
| `bot-workspace` | absent |
| `character-workspace` | absent |
| `reward-workspace` | absent |
| `scenario-workspace` | absent |
| `dream-workspace` | **id 1981**, `sourceHash 7bc51fce…` |

The first four were created earlier today; reconcile has never seen them, so they hold no reviews and their hashes are free to change. Only `dream-workspace` is a real exhibit — **two reactions on it**, from Margin's Find and The Cartographer of Dreams — and its stored hash still matches `dream-narration.vue` byte for byte, so reconcile will match it by hash and carry those reviews to the new name.

## What changed

In the four safe files:

- header paths point at their real filenames
- references to `dream-workspace` become `dream-narration`
- the frame diagram reads `<x-{activity} v-else />` rather than naming a component that no longer exists
- "the workspace" becomes "the working surface"

`workspace-header` stays as-is in `reward-encounter` — that's the actual navigation component, and the reservation is the whole point.

## What's deliberately left

`dream-narration.vue` is untouched and is the only file still saying "workspace" in its header. It can be cleaned once an apply rollout has run and reconcile has moved the identity. Doing it now would trade two Character reviews for a tidier comment.

## Verification

- `dream-narration.vue` still hashes to `7bc51fce62c39b70`, matching what the production DB holds for component 1981
- `vue-tsc` exit 0
- ui-tier-vocabulary, route-gallery, entity-art and narrative-kit pass
- prettier and eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_