### PR TITLE
fix(academy): match empty-state icon to the actual empty-state reason

### DIFF
--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -406,7 +406,10 @@ const resultSummary = computed(() => {
 })
 
 const emptyStateIcon = computed(() => {
-  return lessonFilter.value === 'new' ? 'kind-icon:check' : 'kind-icon:search'
+  if (searchQuery.value) return 'kind-icon:search'
+  if (lessonFilter.value === 'new') return 'kind-icon:check'
+  if (lessonFilter.value === 'explored') return 'kind-icon:gallery'
+  return 'kind-icon:search'
 })
 
 const emptyStateMessage = computed(() => {


### PR DESCRIPTION
## What

`academy-styles-browser.vue`'s Style Gallery empty state showed a magnifying-glass (search) icon whenever the "Explored" filter had zero results, even with no search query active. The paired message in that case ("No explored lessons yet. Open one and your progress will appear here.") has nothing to do with a failed search, so the icon and copy told two different stories.

## Fix

`emptyStateIcon` now follows the same priority order as `emptyStateMessage`: active search query first, then filter-specific icon (checkmark for `new`, `kind-icon:gallery` — the same glyph already used for the "All" filter chip — for `explored`), falling back to the search icon only when nothing else applies.

## Verification

- `npx eslint components/academy/academy-styles-browser.vue` — clean
- `vue-tsc --noEmit` (full project) — clean
- Change is a single 4-line computed property, template/props/store untouched

## Context

conductor: `ai-art-academy/t-010` lane 1 (front-end polish pass, recurring continuous-improvement task).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qb3kXDkzQWUYFiEAzMji91)_