### PR TITLE
Move the Checkpoints and Stylist galleries onto kr-gallery (ratchet 12 → 10)

### DIFF
--- a/components/art/stylist-client-gallery.vue
+++ b/components/art/stylist-client-gallery.vue
@@ -8,14 +8,20 @@
       <div class="flex-1" />
       <select v-model="folderFilter" class="select select-bordered select-xs">
         <option value="">All folders</option>
-        <option v-for="folder in folders" :key="folder" :value="folder">{{ folder }}</option>
+        <option v-for="folder in folders" :key="folder" :value="folder">
+          {{ folder }}
+        </option>
       </select>
     </header>
 
     <div class="mb-3 flex flex-wrap items-end gap-2 rounded-xl bg-base-100 p-3">
       <label class="flex min-w-28 flex-col gap-1">
         <span class="text-xs font-bold">Folder</span>
-        <input v-model="uploadFolder" class="input input-bordered input-xs" placeholder="general" />
+        <input
+          v-model="uploadFolder"
+          class="input input-bordered input-xs"
+          placeholder="general"
+        />
       </label>
       <label class="flex min-w-28 flex-col gap-1">
         <span class="text-xs font-bold">Type</span>
@@ -29,9 +35,16 @@
       </label>
       <label class="flex min-w-44 flex-1 flex-col gap-1">
         <span class="text-xs font-bold">Caption</span>
-        <input v-model="uploadCaption" class="input input-bordered input-xs" placeholder="Color, formula, date, or notes" />
+        <input
+          v-model="uploadCaption"
+          class="input input-bordered input-xs"
+          placeholder="Color, formula, date, or notes"
+        />
       </label>
-      <label class="btn btn-primary btn-sm" :class="{ 'btn-disabled': uploading }">
+      <label
+        class="btn btn-primary btn-sm"
+        :class="{ 'btn-disabled': uploading }"
+      >
         <span v-if="uploading" class="loading loading-spinner loading-xs" />
         <Icon v-else name="kind-icon:upload" class="size-4" />
         Add photos
@@ -44,7 +57,10 @@
           @change="uploadPhotos"
         />
       </label>
-      <label class="btn btn-ghost btn-sm" :class="{ 'btn-disabled': uploading }">
+      <label
+        class="btn btn-ghost btn-sm"
+        :class="{ 'btn-disabled': uploading }"
+      >
         <Icon name="kind-icon:camera" class="size-4" />
         Take photo
         <input
@@ -58,60 +74,106 @@
       </label>
     </div>
 
-    <p v-if="error" class="mb-3 rounded-xl bg-error/10 p-2 text-xs text-error">{{ error }}</p>
-    <p v-if="loading" class="py-6 text-center text-sm text-base-content/50">Loading gallery…</p>
-    <p v-else-if="!filteredPhotos.length" class="py-6 text-center text-sm text-base-content/40">
-      No photos in this folder yet.
+    <p v-if="error" class="mb-3 rounded-xl bg-error/10 p-2 text-xs text-error">
+      {{ error }}
     </p>
-
-    <div v-else class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-      <article
-        v-for="photo in filteredPhotos"
-        :key="photo.id"
-        class="overflow-hidden rounded-xl border border-base-300 bg-base-100"
-      >
-        <div class="relative aspect-square bg-base-300">
-          <img
-            v-if="photoUrls[photo.id]"
-            :src="photoUrls[photo.id]"
-            :alt="photo.caption || `${client.name} ${photo.kind}`"
-            class="h-full w-full object-cover"
-          />
-          <span v-if="photo.isPrimary" class="badge badge-primary badge-sm absolute left-2 top-2">Primary</span>
-        </div>
-        <div class="flex flex-col gap-1 p-2">
-          <div class="flex flex-wrap gap-1">
-            <span class="badge badge-outline badge-xs">{{ photo.folder }}</span>
-            <span class="badge badge-ghost badge-xs">{{ photo.kind }}</span>
-          </div>
-          <p class="min-h-8 text-xs text-base-content/65">{{ photo.caption || 'No caption' }}</p>
-          <div class="flex flex-wrap gap-1">
-            <button
-              v-if="!photo.isPrimary"
-              type="button"
-              class="btn btn-primary btn-xs"
-              @click="setPrimary(photo.id)"
+    <!-- The shared shell owns the grid, the mode bar, and the loading and
+         empty states. The photo card stays bespoke: these are stylist client
+         photos with folder/kind badges and a primary flag, not entity art, so
+         the #item slot replaces kr-gallery's default card outright. -->
+    <kr-gallery
+      :items="galleryItems"
+      :mode="galleryMode"
+      :loading="loading"
+      empty-label="photos"
+      @update:mode="galleryMode = $event"
+    >
+      <template #item="{ item }">
+        <article
+          v-if="photoById.get(Number(item.id))"
+          class="overflow-hidden rounded-xl border border-base-300 bg-base-100"
+        >
+          <div class="relative aspect-square bg-base-300">
+            <img
+              v-if="photoUrls[Number(item.id)]"
+              :src="photoUrls[Number(item.id)]"
+              :alt="
+                photoById.get(Number(item.id))!.caption ||
+                `${client.name} ${photoById.get(Number(item.id))!.kind}`
+              "
+              class="h-full w-full object-cover"
+            />
+            <span
+              v-if="photoById.get(Number(item.id))!.isPrimary"
+              class="badge badge-primary badge-sm absolute left-2 top-2"
+              >Primary</span
             >
-              Set primary
-            </button>
-            <button type="button" class="btn btn-ghost btn-xs text-error" @click="removePhoto(photo.id)">
-              Delete
-            </button>
           </div>
-        </div>
-      </article>
-    </div>
+          <div class="flex flex-col gap-1 p-2">
+            <div class="flex flex-wrap gap-1">
+              <span class="badge badge-outline badge-xs">{{
+                photoById.get(Number(item.id))!.folder
+              }}</span>
+              <span class="badge badge-ghost badge-xs">{{
+                photoById.get(Number(item.id))!.kind
+              }}</span>
+            </div>
+            <p class="min-h-8 text-xs text-base-content/65">
+              {{ photoById.get(Number(item.id))!.caption || 'No caption' }}
+            </p>
+            <div class="flex flex-wrap gap-1">
+              <button
+                v-if="!photoById.get(Number(item.id))!.isPrimary"
+                type="button"
+                class="btn btn-primary btn-xs"
+                @click="setPrimary(Number(item.id))"
+              >
+                Set primary
+              </button>
+              <button
+                type="button"
+                class="btn btn-ghost btn-xs text-error"
+                @click="removePhoto(Number(item.id))"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </article>
+      </template>
+
+      <template #empty>
+        <p class="py-6 text-center text-sm text-base-content/40">
+          No photos in this folder yet.
+        </p>
+      </template>
+    </kr-gallery>
   </section>
 </template>
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
+import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
+import type { GalleryMode } from '@/utils/galleryVocabulary'
 import type { SuperkateCustomer } from '@/stores/superkateStore'
 import { performFetch } from '@/stores/utils'
 import { useUserStore } from '@/stores/userStore'
 
 const props = defineProps<{ client: SuperkateCustomer }>()
 const emit = defineEmits<{ changed: [] }>()
+
+const galleryMode = ref<GalleryMode>('cards')
+
+const galleryItems = computed<GalleryItem[]>(() =>
+  filteredPhotos.value.map((photo) => ({
+    id: photo.id,
+    title: photo.caption || `${photo.folder} · ${photo.kind}`,
+  })),
+)
+
+const photoById = computed(
+  () => new Map(filteredPhotos.value.map((photo) => [photo.id, photo])),
+)
 const userStore = useUserStore()
 
 type GalleryPhoto = {
@@ -133,9 +195,13 @@ const uploadCaption = ref('')
 const folderFilter = ref('')
 const photoUrls = reactive<Record<number, string>>({})
 
-const folders = computed(() => [...new Set(photos.value.map((photo) => photo.folder))].sort())
+const folders = computed(() =>
+  [...new Set(photos.value.map((photo) => photo.folder))].sort(),
+)
 const filteredPhotos = computed(() =>
-  folderFilter.value ? photos.value.filter((photo) => photo.folder === folderFilter.value) : photos.value,
+  folderFilter.value
+    ? photos.value.filter((photo) => photo.folder === folderFilter.value)
+    : photos.value,
 )
 
 function revoke(id: number) {
@@ -170,7 +236,9 @@ async function loadGallery() {
   }
   const next = response.data.photos || []
   const ids = new Set(next.map((photo) => photo.id))
-  Object.keys(photoUrls).forEach((id) => { if (!ids.has(Number(id))) revoke(Number(id)) })
+  Object.keys(photoUrls).forEach((id) => {
+    if (!ids.has(Number(id))) revoke(Number(id))
+  })
   photos.value = next
   await Promise.all(next.map(loadBlob))
   loading.value = false
@@ -210,7 +278,8 @@ async function setPrimary(photoId: number) {
     `/api/stylist/client/${props.client.id}/photo/${photoId}`,
     { method: 'PATCH', body: JSON.stringify({ isPrimary: true }) },
   )
-  if (!response.success) error.value = response.message || 'Could not select primary photo.'
+  if (!response.success)
+    error.value = response.message || 'Could not select primary photo.'
   await loadGallery()
   emit('changed')
 }
@@ -221,11 +290,14 @@ async function removePhoto(photoId: number) {
     `/api/stylist/client/${props.client.id}/photo/${photoId}`,
     { method: 'DELETE' },
   )
-  if (!response.success) error.value = response.message || 'Could not delete photo.'
+  if (!response.success)
+    error.value = response.message || 'Could not delete photo.'
   await loadGallery()
   emit('changed')
 }
 
 onMounted(loadGallery)
-onBeforeUnmount(() => Object.keys(photoUrls).forEach((id) => revoke(Number(id))))
+onBeforeUnmount(() =>
+  Object.keys(photoUrls).forEach((id) => revoke(Number(id))),
+)
 </script>

--- a/components/servers/checkpoint-gallery.vue
+++ b/components/servers/checkpoint-gallery.vue
@@ -93,39 +93,50 @@
       </label>
     </div>
 
-    <div
-      class="grid gap-3"
-      :class="compact ? 'grid-cols-1' : 'sm:grid-cols-2 xl:grid-cols-3'"
+    <!-- The shared shell owns the grid, the mode bar, and the empty state;
+         checkpoint-card stays the card. The compact variant is a PICKER, so it
+         passes `:modes="[]"` to hide the bar and pins to `icons`, the
+         row-shaped grid — the same call server-gallery makes. -->
+    <kr-gallery
+      :items="galleryItems"
+      :mode="compact ? 'icons' : galleryMode"
+      :modes="compact ? [] : [...GALLERY_MODES]"
+      empty-label="checkpoints"
+      @update:mode="galleryMode = $event"
     >
-      <checkpoint-card
-        v-for="checkpoint in filteredCheckpoints"
-        :key="checkpoint.id || checkpoint.name"
-        :checkpoint="checkpoint"
-        :compact="compact"
-        :show-image="showImages"
-        :show-description="showDescriptions"
-        :show-meta="showMeta"
-        :show-select-button="showSelectButtons"
-        :can-react="false"
-        @open="openCheckpoint"
-      />
-    </div>
+      <template #item="{ item }">
+        <checkpoint-card
+          v-if="checkpointByKey.get(String(item.id))"
+          :checkpoint="checkpointByKey.get(String(item.id))!"
+          :compact="compact"
+          :show-image="showImages"
+          :show-description="showDescriptions"
+          :show-meta="showMeta"
+          :show-select-button="showSelectButtons"
+          :can-react="false"
+          @open="openCheckpoint"
+        />
+      </template>
 
-    <div
-      v-if="!filteredCheckpoints.length"
-      class="rounded-2xl border border-dashed border-base-300 bg-base-200 p-6 text-center"
-    >
-      <p class="font-bold">No checkpoints found.</p>
-      <p class="text-sm text-base-content/60">
-        Try another filter or add a checkpoint.
-      </p>
-    </div>
+      <template #empty>
+        <div
+          class="rounded-2xl border border-dashed border-base-300 bg-base-200 p-6 text-center"
+        >
+          <p class="font-bold">No checkpoints found.</p>
+          <p class="text-sm text-base-content/60">
+            Try another filter or add a checkpoint.
+          </p>
+        </div>
+      </template>
+    </kr-gallery>
   </section>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import type { Resource } from '~/prisma/generated/prisma/client'
+import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
+import { GALLERY_MODES, type GalleryMode } from '@/utils/galleryVocabulary'
 import { useCheckpointStore } from '@/stores/checkpointStore'
 import { useServerStore } from '@/stores/serverStore'
 
@@ -233,6 +244,35 @@ const filteredCheckpoints = computed<Partial<Resource>[]>(() => {
       .some((value) => String(value).toLowerCase().includes(query))
   })
 })
+
+const galleryMode = ref<GalleryMode>('cards')
+
+/*
+ * Checkpoints are Partial<Resource>, so an id can be missing -- the old grid
+ * keyed on `checkpoint.id || checkpoint.name` for exactly that reason. The
+ * GalleryItem id keeps that fallback and the lookup is keyed by string so the
+ * two halves cannot drift apart.
+ */
+const checkpointKey = (checkpoint: Partial<Resource>): string =>
+  String(checkpoint.id ?? checkpoint.name ?? '')
+
+const galleryItems = computed<GalleryItem[]>(() =>
+  filteredCheckpoints.value.map((checkpoint) => ({
+    id: checkpointKey(checkpoint),
+    title: checkpoint.customLabel || checkpoint.name || 'Checkpoint',
+    description: checkpoint.description || undefined,
+  })),
+)
+
+const checkpointByKey = computed(
+  () =>
+    new Map(
+      filteredCheckpoints.value.map((checkpoint) => [
+        checkpointKey(checkpoint),
+        checkpoint,
+      ]),
+    ),
+)
 
 function selectSampler(event: Event): void {
   const target = event.target as HTMLSelectElement

--- a/utils/scripts/route-gallery-baseline.json
+++ b/utils/scripts/route-gallery-baseline.json
@@ -1,15 +1,13 @@
 {
   "note": "Route gallery RATCHET: this file may only ever shrink. --update refuses to record a larger count. See utils/scripts/verifyRouteGalleryContract.ts.",
   "recorded": "2026-08-07",
-  "total": 12,
+  "total": 10,
   "holdouts": {
     "achievement-gallery": ["/achievements", "/dashboard", "/themes"],
     "chat-gallery": ["/achievements", "/chats", "/dashboard", "/themes"],
     "friend-gallery": ["/achievements", "/dashboard", "/themes"],
     "theme-gallery": ["/achievements", "/dashboard", "/themes"],
     "art-gallery": ["/art", "/artjob"],
-    "checkpoint-gallery": ["/art", "/artjob", "/servers"],
-    "stylist-client-gallery": ["/art", "/artjob", "/stylist"],
     "dream-relationship-gallery": ["/brainstorm", "/dreams"],
     "scenario-relationship-gallery": ["/brainstorm", "/dreams"],
     "daily-digest-object-gallery": ["/for-you"],


### PR DESCRIPTION
Two more single-collection grids. Both keyed off the **viewport** while mounting inside panels:

```
checkpoint-gallery       sm:grid-cols-2 xl:grid-cols-3
stylist-client-gallery   grid-cols-2 sm:grid-cols-3 lg:grid-cols-4
```

On a wide screen those fire against a narrow container — the defect `MODE_GRID_CLASS` exists to remove.

## checkpoint-gallery

Follows `server-gallery` exactly, including the picker case: its compact variant passes `:modes="[]"` to hide the mode bar and pins to `icons`, because a picker offering Cards/Heroes/Icons is offering a choice with nowhere to land.

One wrinkle worth naming: checkpoints are `Partial<Resource>`, so an id can be **missing** — the old grid keyed on `checkpoint.id || checkpoint.name` for exactly that reason. A single `checkpointKey()` helper now feeds both the `GalleryItem` id and the lookup map, so the two halves can't drift apart.

## stylist-client-gallery

Keeps its bespoke card in the `#item` slot. These are client photos with folder/kind badges and a primary flag, not entity art, so there's no image for kr-gallery's default card to resolve — the slot replaces it outright. Its hand-rolled loading line and empty message move to the shell's `loading` prop and `#empty` slot.

## Watched to fail

Turning checkpoint-gallery's `<kr-gallery>` back into `class="kr-gallery"` drops the count 11 → 10 — adoption still counted at the element, not by substring.

## Verification

- `vue-tsc` exit 0
- lint ratchet **395, unchanged**
- card-action, route-gallery, gallery-adoption, gallery-consistency, layout, entity-art, narrative-kit, reachability and ui-tier-vocabulary all pass
- the one eslint error in `stylist-client-gallery` (`no-dynamic-delete`) is pre-existing and untouched

## Remaining

Ratchet **12 → 10**. Left: `resource-gallery` (590), `dream-relationship-gallery` (474), `scenario-relationship-gallery` (430) to finish the single-collection batch; then the four multi-collection panels; then the three page-sized, with `art-gallery` (1,653) last and alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_