### PR TITLE
Move both relationship galleries onto kr-gallery (ratchet 10 → 8)

### DIFF
--- a/components/dreams/dream-narration.vue
+++ b/components/dreams/dream-narration.vue
@@ -1,11 +1,17 @@
-<!-- /components/dreams/dream-workspace.vue -->
+<!-- /components/dreams/dream-narration.vue -->
 <template>
-  <section class="flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden rounded-2xl border border-base-300 bg-base-200 p-3">
+  <section
+    class="flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden rounded-2xl border border-base-300 bg-base-200 p-3"
+  >
     <header class="shrink-0 rounded-2xl border border-base-300 bg-base-100 p-3">
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div class="min-w-0">
-          <h1 class="truncate text-lg font-black text-primary">{{ dreamTitle }}</h1>
-          <p class="truncate text-sm text-base-content/60">{{ selectedSummary }}</p>
+          <h1 class="truncate text-lg font-black text-primary">
+            {{ dreamTitle }}
+          </h1>
+          <p class="truncate text-sm text-base-content/60">
+            {{ selectedSummary }}
+          </p>
         </div>
 
         <div class="flex shrink-0 flex-wrap gap-2">
@@ -36,7 +42,11 @@
           :key="panel.key"
           type="button"
           class="btn btn-sm shrink-0 rounded-2xl"
-          :class="workspaceStore.dreamPanel === panel.key ? 'btn-primary text-white' : 'btn-ghost'"
+          :class="
+            workspaceStore.dreamPanel === panel.key
+              ? 'btn-primary text-white'
+              : 'btn-ghost'
+          "
           @click="workspaceStore.setDreamPanel(panel.key)"
         >
           <Icon :name="panel.icon" class="h-4 w-4" />
@@ -45,8 +55,13 @@
       </nav>
     </header>
 
-    <main class="min-h-0 flex-1 overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-3">
-      <div v-if="workspaceStore.dreamPanel === 'asset-sheet'" class="grid gap-3">
+    <main
+      class="min-h-0 flex-1 overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-3"
+    >
+      <div
+        v-if="workspaceStore.dreamPanel === 'asset-sheet'"
+        class="grid gap-3"
+      >
         <dream-pitch-sheet
           v-if="dreamStore.selectedDream"
           :key="dreamStore.selectedDream.id"
@@ -62,7 +77,8 @@
         <section class="rounded-2xl border border-base-300 bg-base-200 p-3">
           <h2 class="font-black">Organic Assets</h2>
           <p class="mt-1 text-sm text-base-content/60">
-            The selected Dream is the anchor. Use these panels to move through connected Dreams, Scenarios, Characters, Rewards, Art, and Chats.
+            The selected Dream is the anchor. Use these panels to move through
+            connected Dreams, Scenarios, Characters, Rewards, Art, and Chats.
           </p>
         </section>
       </div>
@@ -86,18 +102,28 @@
         :auto-load="false"
       />
 
-      <div v-else-if="workspaceStore.dreamPanel === 'characters'" class="grid gap-3">
+      <div
+        v-else-if="workspaceStore.dreamPanel === 'characters'"
+        class="grid gap-3"
+      >
         <section class="rounded-2xl border border-base-300 bg-base-200 p-3">
           <h2 class="font-black">Dream Cast</h2>
-          <p class="mt-1 text-sm text-base-content/60">Characters connected to this Dream.</p>
+          <p class="mt-1 text-sm text-base-content/60">
+            Characters connected to this Dream.
+          </p>
         </section>
         <dream-list list-type="cast" view-mode="grid" :show-refresh="false" />
       </div>
 
-      <div v-else-if="workspaceStore.dreamPanel === 'rewards'" class="grid gap-3">
+      <div
+        v-else-if="workspaceStore.dreamPanel === 'rewards'"
+        class="grid gap-3"
+      >
         <section class="rounded-2xl border border-base-300 bg-base-200 p-3">
           <h2 class="font-black">Dream Rewards</h2>
-          <p class="mt-1 text-sm text-base-content/60">Rewards and narrative items connected to this Dream.</p>
+          <p class="mt-1 text-sm text-base-content/60">
+            Rewards and narrative items connected to this Dream.
+          </p>
         </section>
         <dream-list list-type="items" view-mode="grid" :show-refresh="false" />
       </div>
@@ -114,7 +140,9 @@
       <div v-else class="grid gap-3">
         <section class="rounded-2xl border border-base-300 bg-base-200 p-3">
           <h2 class="font-black">Dream Chat</h2>
-          <p class="mt-1 text-sm text-base-content/60">Conversation threads attached to this Dream.</p>
+          <p class="mt-1 text-sm text-base-content/60">
+            Conversation threads attached to this Dream.
+          </p>
         </section>
         <dream-list list-type="chats" />
       </div>
@@ -127,7 +155,10 @@ import { computed, onMounted, ref, watch } from 'vue'
 import { useDreamStore } from '@/stores/dreamStore'
 import { useNavStore } from '@/stores/navStore'
 import { useScenarioStore } from '@/stores/scenarioStore'
-import { useWorkspaceStore, type DreamWorkspacePanel } from '@/stores/workspaceStore'
+import {
+  useWorkspaceStore,
+  type DreamWorkspacePanel,
+} from '@/stores/workspaceStore'
 
 const dreamStore = useDreamStore()
 const navStore = useNavStore()
@@ -146,7 +177,9 @@ const panels: { key: DreamWorkspacePanel; label: string; icon: string }[] = [
   { key: 'chat', label: 'Chat', icon: 'kind-icon:chat' },
 ]
 
-const dreamTitle = computed(() => dreamStore.selectedDream?.title || 'No Dream Selected')
+const dreamTitle = computed(
+  () => dreamStore.selectedDream?.title || 'No Dream Selected',
+)
 const selectedSummary = computed(() => dreamStore.selectedDreamSummary)
 
 watch(
@@ -163,7 +196,10 @@ onMounted(async () => {
   workspaceReady.value = true
 
   if (dreamStore.selectedDream?.id) {
-    workspaceStore.openDream(dreamStore.selectedDream.id, workspaceStore.dreamPanel)
+    workspaceStore.openDream(
+      dreamStore.selectedDream.id,
+      workspaceStore.dreamPanel,
+    )
   }
 
   await scenarioStore.initialize({ fetchRemote: true, includeSeeds: true })

--- a/components/dreams/dream-relationship-gallery.vue
+++ b/components/dreams/dream-relationship-gallery.vue
@@ -66,33 +66,52 @@
         </div>
       </div>
 
-      <div v-else class="dream-grid">
-        <dream-card
-          v-for="dream in filteredDreams"
-          :key="dream.id"
-          :dream="dream"
-          :selected="dreamStore.selectedDream?.id === dream.id"
-          :is-selected="dreamStore.selectedDream?.id === dream.id"
-          :compact="compact"
-          :show-image="showImages"
-          :show-actions="showCardActions"
-          :show-description="showDescriptions"
-          :show-meta="showMeta"
-          :show-stats="showStats"
-          :allow-edit="allowEdit"
-          :allow-delete="allowDelete"
-          image-fit="cover"
-          @open="selectDreamAndOpen"
-          @edit="startEditingDreamById"
-          @delete="handleDreamDeleted"
-        />
-      </div>
+      <!-- The shared shell owns the grid and the Cards/Heroes/Icons bar;
+           dream-card stays the card.
+
+           NOT a responsive fix, unlike the earlier conversions: `.dream-grid`
+           was already `auto-fill` over `minmax(min(220px,100%),1fr)`, which is
+           correct. What it lacked was the mode bar, and it was a second private
+           spelling of a grid the vocabulary already owns. Its
+           `.dream-grid > * { min-height: 20rem }` goes with it — kr-gallery's
+           cards grid sizes its own rows. -->
+      <kr-gallery
+        v-else
+        :items="galleryItems"
+        :mode="galleryMode"
+        empty-label="dreams"
+        @update:mode="galleryMode = $event"
+      >
+        <template #item="{ item }">
+          <dream-card
+            v-if="dreamById.get(Number(item.id))"
+            :dream="dreamById.get(Number(item.id))!"
+            :selected="dreamStore.selectedDream?.id === item.id"
+            :is-selected="dreamStore.selectedDream?.id === item.id"
+            :compact="compact"
+            :show-image="showImages"
+            :show-actions="showCardActions"
+            :show-description="showDescriptions"
+            :show-meta="showMeta"
+            :show-stats="showStats"
+            :allow-edit="allowEdit"
+            :allow-delete="allowDelete"
+            :variant="MODE_VARIANT[galleryMode]"
+            image-fit="cover"
+            @open="selectDreamAndOpen"
+            @edit="startEditingDreamById"
+            @delete="handleDreamDeleted"
+          />
+        </template>
+      </kr-gallery>
     </section>
   </section>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
+import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
+import { MODE_VARIANT, type GalleryMode } from '@/utils/galleryVocabulary'
 import type {
   ArtCollection,
   ArtImage,
@@ -251,6 +270,20 @@ const filteredDreams = computed<DreamWithRelations[]>(() => {
     dreamSearchText(dream).toLowerCase().includes(query),
   )
 })
+
+const galleryMode = ref<GalleryMode>('cards')
+
+const galleryItems = computed<GalleryItem[]>(() =>
+  filteredDreams.value.map((dream) => ({
+    id: dream.id,
+    title: dream.title || `Dream ${dream.id}`,
+    source: dream,
+  })),
+)
+
+const dreamById = computed(
+  () => new Map(filteredDreams.value.map((dream) => [dream.id, dream])),
+)
 
 const emptyTitle = computed(() => {
   if (searchQuery.value) return 'No connected Dreams match your search.'
@@ -459,16 +492,3 @@ function previewImage(dream: DreamWithRelations) {
   )
 }
 </script>
-
-<style scoped>
-.dream-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(220px, 100%), 1fr));
-  gap: 1rem;
-  align-items: stretch;
-}
-
-.dream-grid > * {
-  min-height: 20rem;
-}
-</style>

--- a/components/scenarios/scenario-relationship-gallery.vue
+++ b/components/scenarios/scenario-relationship-gallery.vue
@@ -129,33 +129,50 @@
         </button>
       </div>
 
-      <div v-else class="scenario-grid">
-        <ScenarioCard
-          v-for="scenario in filteredScenarios"
-          :key="scenario.id"
-          :scenario="scenario"
-          :selected="scenarioStore.selectedScenario?.id === scenario.id"
-          :show-image="showImages"
-          :compact="compact"
-          :show-actions="showCardActions"
-          :show-description="showDescriptions"
-          :show-meta="showMeta"
-          :show-inspirations="showInspirations"
-          :allow-edit="allowEdit"
-          :allow-delete="allowDelete"
-          :allow-clone="allowClone"
-          @open="selectScenarioById"
-          @edit="startEditingScenarioById"
-          @clone="cloneScenarioById"
-          @delete="handleScenarioDeleted"
-        />
-      </div>
+      <!-- The shared shell owns the grid and the Cards/Heroes/Icons bar;
+           ScenarioCard stays the card.
+
+           NOT a responsive fix: `.scenario-grid` was already `auto-fill` over
+           `minmax(min(240px,100%),1fr)`, which is correct. What it lacked was
+           the mode bar, and it was a private spelling of a grid the shared
+           vocabulary already owns. -->
+      <kr-gallery
+        v-else
+        :items="galleryItems"
+        :mode="galleryMode"
+        empty-label="scenarios"
+        @update:mode="galleryMode = $event"
+      >
+        <template #item="{ item }">
+          <ScenarioCard
+            v-if="scenarioById.get(Number(item.id))"
+            :scenario="scenarioById.get(Number(item.id))!"
+            :selected="scenarioStore.selectedScenario?.id === item.id"
+            :show-image="showImages"
+            :compact="compact"
+            :show-actions="showCardActions"
+            :show-description="showDescriptions"
+            :show-meta="showMeta"
+            :show-inspirations="showInspirations"
+            :allow-edit="allowEdit"
+            :allow-delete="allowDelete"
+            :allow-clone="allowClone"
+            :variant="MODE_VARIANT[galleryMode]"
+            @open="selectScenarioById"
+            @edit="startEditingScenarioById"
+            @clone="cloneScenarioById"
+            @delete="handleScenarioDeleted"
+          />
+        </template>
+      </kr-gallery>
     </section>
   </section>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
+import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
+import { MODE_VARIANT, type GalleryMode } from '@/utils/galleryVocabulary'
 import type { DreamWithRelations } from '@/stores/dreamStore'
 import type { ScenarioWithRelations } from '@/stores/scenarioStore'
 import { useScenarioStore } from '@/stores/scenarioStore'
@@ -283,6 +300,21 @@ const filteredScenarios = computed<ScenarioWithRelations[]>(() => {
     return scenarioSearchText(scenario).toLowerCase().includes(query)
   })
 })
+
+const galleryMode = ref<GalleryMode>('cards')
+
+const galleryItems = computed<GalleryItem[]>(() =>
+  filteredScenarios.value.map((scenario) => ({
+    id: scenario.id,
+    title: scenario.title || `Scenario ${scenario.id}`,
+    source: scenario,
+  })),
+)
+
+const scenarioById = computed(
+  () =>
+    new Map(filteredScenarios.value.map((scenario) => [scenario.id, scenario])),
+)
 
 const emptyTitle = computed(() => {
   if (searchQuery.value) return 'No scenarios match your search.'
@@ -448,12 +480,3 @@ function scenarioSearchText(scenario: ScenarioWithRelations) {
     .join(' ')
 }
 </script>
-
-<style scoped>
-.scenario-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(240px, 100%), 1fr));
-  gap: 1rem;
-  align-items: start;
-}
-</style>

--- a/utils/scripts/route-gallery-baseline.json
+++ b/utils/scripts/route-gallery-baseline.json
@@ -1,15 +1,13 @@
 {
   "note": "Route gallery RATCHET: this file may only ever shrink. --update refuses to record a larger count. See utils/scripts/verifyRouteGalleryContract.ts.",
   "recorded": "2026-08-07",
-  "total": 10,
+  "total": 8,
   "holdouts": {
     "achievement-gallery": ["/achievements", "/dashboard", "/themes"],
     "chat-gallery": ["/achievements", "/chats", "/dashboard", "/themes"],
     "friend-gallery": ["/achievements", "/dashboard", "/themes"],
     "theme-gallery": ["/achievements", "/dashboard", "/themes"],
     "art-gallery": ["/art", "/artjob"],
-    "dream-relationship-gallery": ["/brainstorm", "/dreams"],
-    "scenario-relationship-gallery": ["/brainstorm", "/dreams"],
     "daily-digest-object-gallery": ["/for-you"],
     "resource-gallery": ["/resources"],
     "ui-gallery": ["/ui"]


### PR DESCRIPTION
Both relationship galleries already mount `dream-card` and `ScenarioCard`, so only the grid moved.

## This one is not a responsive fix

Unlike the four conversions before it. `.dream-grid` and `.scenario-grid` were **already** `auto-fill` over `minmax(min(220px|240px, 100%), 1fr)` — correct, container-responsive, and in fact the shape `MODE_GRID_CLASS` was itself written from.

My first draft of these comments claimed they were viewport-keyed like the others. They weren't, and the comments now say the true thing. What these two actually lacked was the Cards/Heroes/Icons bar, plus they were private spellings of a grid the shared vocabulary already owns.

**One behaviour does not survive:** both scoped `<style>` blocks are deleted with their classes, which drops `.dream-grid > * { min-height: 20rem }`. kr-gallery doesn't replicate it — its cards grid sizes its own rows. Worth an eye on the preview; it's the only thing here that changes visually beyond the mode bar appearing.

## Also unblocks the deferred header

`dream-narration.vue` still read `<!-- /components/dreams/dream-workspace.vue -->`. I'd deferred it to protect two WonderLab reactions across the rename.

> "the wonderlab section is a novelty ... If Wonderlab loses the odd entry, I'm not upset. The front end is the important thing."

Right call, and the wrong trade for me to have made in the first place. The file says what it is now, and reconcile can sort the exhibit out whenever the rollout next runs.

## Verification

- `vue-tsc` exit 0
- lint ratchet **395, unchanged**
- card-action, route-gallery, gallery-adoption, gallery-consistency, layout, entity-art, narrative-kit, reachability, ui-tier-vocabulary and no-promise-in-store-state all pass

## Remaining

Ratchet **10 → 8**, and the single-collection batch is done except `resource-gallery`.

That one needs its inline `<article>` extracted into a `resource-card` first — the card depends on **nine** gallery functions (`generatePreview`, `startGeneration`, `addToGeneration`, `choosePreviewFile`, `openEdit`, `isEditable`, `previewSrc`, `resourceLabel`, `triggerText`), so it's a real props/emits split rather than a mechanical move. Left for its own PR rather than rushed in alongside these.

Then the four multi-collection panels, then the three page-sized with `art-gallery` (1,653) last and alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_