### PR TITLE
Extract resource-card and move the Resources gallery onto kr-gallery (ratchet 8 → 7)

### DIFF
--- a/components/resources/resource-card.vue
+++ b/components/resources/resource-card.vue
@@ -8,13 +8,17 @@
   every one of the ~20 references would have become
   `resourceById.get(Number(item.id))!`.
 
-  WHAT MOVED AND WHAT DID NOT. The four pure display helpers came with it --
-  previewSrc, resourceLabel, triggerText and isEditable are functions of the
-  record and nothing else, so they belong to the thing that draws it. The five
+  WHAT MOVED AND WHAT DID NOT. previewSrc and isEditable came with it -- pure
+  functions of the record, so they belong to the thing that draws it. The five
   actions did NOT: generating a preview, uploading one, editing, and pushing a
   Resource into the art build all reach stores and APIs, so they are emits and
   the gallery decides what they mean. Same split the entity cards use, for the
   same reason -- a card that owns the consequence cannot be reused or exhibited.
+
+  `label` and `triggerText` are the card's own copies. The gallery keeps its
+  versions because the GENERATION path still needs them to build a prompt and
+  choose checkpoint vs LoRA, which is store work. Duplicated deliberately: the
+  alternative is the card importing from the gallery it is rendered by.
 
   The two busy flags are props rather than looked up, so this stays mountable in
   WonderLab from a plain fixture.

--- a/components/resources/resource-card.vue
+++ b/components/resources/resource-card.vue
@@ -1,0 +1,185 @@
+<!-- /components/resources/resource-card.vue -->
+<!--
+  One Resource (checkpoint, LoRA, LyCORIS) as a card.
+
+  Extracted from resource-gallery.vue when that grid moved onto kr-gallery.
+  The markup is unchanged; it needed an owner because a card inlined in an
+  `#item` slot reaches its record back through the slot's GalleryItem, and
+  every one of the ~20 references would have become
+  `resourceById.get(Number(item.id))!`.
+
+  WHAT MOVED AND WHAT DID NOT. The four pure display helpers came with it --
+  previewSrc, resourceLabel, triggerText and isEditable are functions of the
+  record and nothing else, so they belong to the thing that draws it. The five
+  actions did NOT: generating a preview, uploading one, editing, and pushing a
+  Resource into the art build all reach stores and APIs, so they are emits and
+  the gallery decides what they mean. Same split the entity cards use, for the
+  same reason -- a card that owns the consequence cannot be reused or exhibited.
+
+  The two busy flags are props rather than looked up, so this stays mountable in
+  WonderLab from a plain fixture.
+
+  NOT in verifyCardActionContract's ENTITY_CARDS: a Resource has no interact
+  surface to `open`. Its primary actions are "add to build" and "start fresh",
+  which are model-specific by nature. Adding it to that list would mean
+  inventing an `open` with nowhere to go.
+-->
+<template>
+  <article
+    class="group flex min-h-[430px] flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
+  >
+    <div class="relative aspect-square overflow-hidden bg-base-200">
+      <img
+        :src="previewSrc"
+        :alt="label"
+        class="h-full w-full object-cover transition duration-300 group-hover:scale-[1.02]"
+        loading="lazy"
+      />
+
+      <div class="absolute left-2 top-2 flex flex-wrap gap-1">
+        <span class="badge badge-primary badge-sm">
+          {{ resource.resourceType }}
+        </span>
+        <span v-if="resource.generation" class="badge badge-neutral badge-sm">
+          {{ resource.generation }}
+        </span>
+        <span v-if="resource.isMature" class="badge badge-error badge-sm">
+          18+
+        </span>
+      </div>
+
+      <div
+        v-if="triggerText"
+        class="absolute inset-x-2 bottom-2 translate-y-2 rounded-2xl bg-base-100/95 p-2 text-xs opacity-0 shadow transition group-hover:translate-y-0 group-hover:opacity-100"
+      >
+        <span class="font-semibold">Trigger:</span>
+        {{ triggerText }}
+      </div>
+    </div>
+
+    <div class="flex flex-1 flex-col gap-3 p-4">
+      <div>
+        <h3 class="line-clamp-2 text-lg font-bold">
+          {{ label }}
+        </h3>
+        <p class="mt-1 line-clamp-3 text-sm text-base-content/65">
+          {{ resource.description || 'No description yet.' }}
+        </p>
+      </div>
+
+      <div class="flex flex-wrap gap-1 text-xs">
+        <span class="badge badge-outline badge-sm">
+          {{ resource.supportedServer }}
+        </span>
+        <span class="badge badge-outline badge-sm">
+          {{ resource._count?.ArtImages || 0 }} checkpoint uses
+        </span>
+        <span class="badge badge-outline badge-sm">
+          {{ resource._count?.UsedInImages || 0 }} LoRA uses
+        </span>
+      </div>
+
+      <div class="mt-auto grid grid-cols-2 gap-2">
+        <button
+          type="button"
+          class="btn btn-primary btn-sm rounded-2xl"
+          @click="emit('add-to-build', resource)"
+        >
+          Add to build
+        </button>
+        <button
+          type="button"
+          class="btn btn-secondary btn-sm rounded-2xl"
+          @click="emit('start-fresh', resource)"
+        >
+          Start fresh
+        </button>
+        <button
+          type="button"
+          class="btn btn-outline btn-sm rounded-2xl"
+          :disabled="generatingPreview"
+          @click="emit('generate-preview', resource)"
+        >
+          <span
+            v-if="generatingPreview"
+            class="loading loading-spinner loading-xs"
+          />
+          Generate preview
+        </button>
+        <button
+          type="button"
+          class="btn btn-ghost btn-sm rounded-2xl"
+          :disabled="uploadingPreview"
+          @click="emit('upload-preview', resource)"
+        >
+          <span
+            v-if="uploadingPreview"
+            class="loading loading-spinner loading-xs"
+          />
+          Upload preview
+        </button>
+      </div>
+
+      <button
+        v-if="isEditable"
+        type="button"
+        class="btn btn-ghost btn-sm rounded-2xl"
+        @click="emit('edit', resource)"
+      >
+        <icon name="kind-icon:edit" class="h-4 w-4" />
+        Edit
+      </button>
+    </div>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { ResourceGalleryRecord } from '@/stores/resourceGalleryStore'
+
+const EDITABLE_TYPES = ['CHECKPOINT', 'LORA', 'LYCORIS']
+
+const props = withDefaults(
+  defineProps<{
+    resource: ResourceGalleryRecord
+    generatingPreview?: boolean
+    uploadingPreview?: boolean
+  }>(),
+  {
+    generatingPreview: false,
+    uploadingPreview: false,
+  },
+)
+
+const emit = defineEmits<{
+  edit: [resource: ResourceGalleryRecord]
+  'add-to-build': [resource: ResourceGalleryRecord]
+  'start-fresh': [resource: ResourceGalleryRecord]
+  'generate-preview': [resource: ResourceGalleryRecord]
+  'upload-preview': [resource: ResourceGalleryRecord]
+}>()
+
+const previewSrc = computed(
+  () =>
+    props.resource.ArtImage?.thumbnailPath ||
+    props.resource.ArtImage?.imagePath ||
+    props.resource.ArtImage?.path ||
+    props.resource.previewImageUrl ||
+    props.resource.imagePath ||
+    '/images/kindart.webp',
+)
+
+const label = computed(() => props.resource.customLabel || props.resource.name)
+
+const triggerText = computed(
+  () =>
+    props.resource.defaultTrigger ||
+    props.resource.triggerWords ||
+    props.resource.artPrompt ||
+    '',
+)
+
+const isEditable = computed(() =>
+  EDITABLE_TYPES.includes(String(props.resource.resourceType)),
+)
+</script>

--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -1,6 +1,8 @@
 <!-- /components/resources/resource-gallery.vue -->
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
+import type { GalleryMode } from '@/utils/galleryVocabulary'
 import {
   useResourceGalleryStore,
   type ResourceGalleryRecord,
@@ -32,14 +34,6 @@ const showAddChoice = ref(false)
 const showForm = ref(false)
 const formKind = ref<'CHECKPOINT' | 'LORA'>('CHECKPOINT')
 const editing = ref<Partial<Resource> | null>(null)
-
-function isEditable(resource: ResourceGalleryRecord): boolean {
-  return (
-    resource.resourceType === RESOURCE_TYPE.CHECKPOINT ||
-    resource.resourceType === RESOURCE_TYPE.LORA ||
-    resource.resourceType === RESOURCE_TYPE.LYCORIS
-  )
-}
 
 function openAddChoice(): void {
   showAddChoice.value = true
@@ -122,6 +116,21 @@ const filteredResources = computed(() => {
   })
 })
 
+const galleryMode = ref<GalleryMode>('cards')
+
+const galleryItems = computed<GalleryItem[]>(() =>
+  filteredResources.value.map((resource) => ({
+    id: resource.id,
+    title: resourceLabel(resource),
+    description: resource.description || undefined,
+  })),
+)
+
+const resourceById = computed(
+  () =>
+    new Map(filteredResources.value.map((resource) => [resource.id, resource])),
+)
+
 function resourceLabel(resource: ResourceGalleryRecord): string {
   return resource.customLabel || resource.name
 }
@@ -136,22 +145,12 @@ function triggerText(resource: ResourceGalleryRecord): string {
   )
 }
 
-function previewSrc(resource: ResourceGalleryRecord): string {
-  return (
-    resource.ArtImage?.thumbnailPath ||
-    resource.ArtImage?.imagePath ||
-    resource.ArtImage?.path ||
-    resource.previewImageUrl ||
-    resource.imagePath ||
-    '/images/kindart.webp'
-  )
-}
-
 function appendPrompt(base: string, addition: string): string {
   const current = base.trim()
   const next = addition.trim()
 
-  if (!next || current.toLowerCase().includes(next.toLowerCase())) return current
+  if (!next || current.toLowerCase().includes(next.toLowerCase()))
+    return current
   return current ? `${current}, ${next}` : next
 }
 
@@ -214,9 +213,7 @@ function startGeneration(resource: ResourceGalleryRecord): void {
   )
 }
 
-async function generatePreview(
-  resource: ResourceGalleryRecord,
-): Promise<void> {
+async function generatePreview(resource: ResourceGalleryRecord): Promise<void> {
   activePreviewResourceId.value = resource.id
   message.value = ''
 
@@ -379,10 +376,7 @@ onMounted(async () => {
 
         <label class="form-control">
           <span class="label-text text-xs">Maturity</span>
-          <select
-            v-model="maturity"
-            class="select select-bordered rounded-2xl"
-          >
+          <select v-model="maturity" class="select select-bordered rounded-2xl">
             <option value="ALL">Visible Resources</option>
             <option value="SAFE">Safe only</option>
             <option value="MATURE">Mature only</option>
@@ -453,138 +447,42 @@ onMounted(async () => {
       {{ resourceGalleryStore.error }}
     </div>
 
-    <div
-      v-if="
-        resourceGalleryStore.isLoading &&
-        !resourceGalleryStore.resources.length
+    <!-- The shared shell owns the grid, the mode bar, and the loading and
+         empty states; resource-card stays the card. The old grid was
+         `sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4` -- viewport-keyed, so
+         it fired against a narrow container whenever this gallery was inset.
+         A Resource preview falls back to a static placeholder rather than
+         entity art, so the #item slot replaces the default card outright. -->
+    <kr-gallery
+      :items="galleryItems"
+      :mode="galleryMode"
+      :loading="
+        resourceGalleryStore.isLoading && !resourceGalleryStore.resources.length
       "
-      class="flex min-h-72 items-center justify-center rounded-2xl border border-base-300 bg-base-100"
+      empty-label="Resources"
+      @update:mode="galleryMode = $event"
     >
-      <span class="loading loading-spinner loading-lg text-primary" />
-    </div>
+      <template #item="{ item }">
+        <resource-card
+          v-if="resourceById.get(Number(item.id))"
+          :resource="resourceById.get(Number(item.id))!"
+          :generating-preview="activePreviewResourceId === Number(item.id)"
+          :uploading-preview="activeUploadResourceId === Number(item.id)"
+          @edit="openEdit"
+          @add-to-build="addToGeneration"
+          @start-fresh="startGeneration"
+          @generate-preview="generatePreview"
+          @upload-preview="choosePreviewFile"
+        />
+      </template>
 
-    <div
-      v-else-if="!filteredResources.length"
-      class="flex min-h-72 items-center justify-center rounded-2xl border border-base-300 bg-base-100 p-6 text-center text-base-content/60"
-    >
-      No Resources match those filters.
-    </div>
-
-    <div
-      v-else
-      class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4"
-    >
-      <article
-        v-for="resource in filteredResources"
-        :key="resource.id"
-        class="group flex min-h-[430px] flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
-      >
-        <div class="relative aspect-square overflow-hidden bg-base-200">
-          <img
-            :src="previewSrc(resource)"
-            :alt="resourceLabel(resource)"
-            class="h-full w-full object-cover transition duration-300 group-hover:scale-[1.02]"
-            loading="lazy"
-          />
-
-          <div class="absolute left-2 top-2 flex flex-wrap gap-1">
-            <span class="badge badge-primary badge-sm">
-              {{ resource.resourceType }}
-            </span>
-            <span
-              v-if="resource.generation"
-              class="badge badge-neutral badge-sm"
-            >
-              {{ resource.generation }}
-            </span>
-            <span v-if="resource.isMature" class="badge badge-error badge-sm">
-              18+
-            </span>
-          </div>
-
-          <div
-            v-if="triggerText(resource)"
-            class="absolute inset-x-2 bottom-2 translate-y-2 rounded-2xl bg-base-100/95 p-2 text-xs opacity-0 shadow transition group-hover:translate-y-0 group-hover:opacity-100"
-          >
-            <span class="font-semibold">Trigger:</span>
-            {{ triggerText(resource) }}
-          </div>
+      <template #empty>
+        <div
+          class="flex min-h-72 items-center justify-center rounded-2xl border border-base-300 bg-base-100 p-6 text-center text-base-content/60"
+        >
+          No Resources match those filters.
         </div>
-
-        <div class="flex flex-1 flex-col gap-3 p-4">
-          <div>
-            <h3 class="line-clamp-2 text-lg font-bold">
-              {{ resourceLabel(resource) }}
-            </h3>
-            <p class="mt-1 line-clamp-3 text-sm text-base-content/65">
-              {{ resource.description || 'No description yet.' }}
-            </p>
-          </div>
-
-          <div class="flex flex-wrap gap-1 text-xs">
-            <span class="badge badge-outline badge-sm">
-              {{ resource.supportedServer }}
-            </span>
-            <span class="badge badge-outline badge-sm">
-              {{ resource._count?.ArtImages || 0 }} checkpoint uses
-            </span>
-            <span class="badge badge-outline badge-sm">
-              {{ resource._count?.UsedInImages || 0 }} LoRA uses
-            </span>
-          </div>
-
-          <div class="mt-auto grid grid-cols-2 gap-2">
-            <button
-              type="button"
-              class="btn btn-primary btn-sm rounded-2xl"
-              @click="addToGeneration(resource)"
-            >
-              Add to build
-            </button>
-            <button
-              type="button"
-              class="btn btn-secondary btn-sm rounded-2xl"
-              @click="startGeneration(resource)"
-            >
-              Start fresh
-            </button>
-            <button
-              type="button"
-              class="btn btn-outline btn-sm rounded-2xl"
-              :disabled="activePreviewResourceId === resource.id"
-              @click="generatePreview(resource)"
-            >
-              <span
-                v-if="activePreviewResourceId === resource.id"
-                class="loading loading-spinner loading-xs"
-              />
-              Generate preview
-            </button>
-            <button
-              type="button"
-              class="btn btn-ghost btn-sm rounded-2xl"
-              :disabled="activeUploadResourceId === resource.id"
-              @click="choosePreviewFile(resource)"
-            >
-              <span
-                v-if="activeUploadResourceId === resource.id"
-                class="loading loading-spinner loading-xs"
-              />
-              Upload preview
-            </button>
-          </div>
-
-          <button
-            v-if="isEditable(resource)"
-            type="button"
-            class="btn btn-ghost btn-sm rounded-2xl"
-            @click="openEdit(resource)"
-          >
-            <icon name="kind-icon:edit" class="h-4 w-4" />
-            Edit
-          </button>
-        </div>
-      </article>
-    </div>
+      </template>
+    </kr-gallery>
   </section>
 </template>

--- a/utils/scripts/route-gallery-baseline.json
+++ b/utils/scripts/route-gallery-baseline.json
@@ -1,15 +1,13 @@
 {
   "note": "Route gallery RATCHET: this file may only ever shrink. --update refuses to record a larger count. See utils/scripts/verifyRouteGalleryContract.ts.",
   "recorded": "2026-08-07",
-  "total": 9,
+  "total": 7,
   "holdouts": {
     "achievement-gallery": ["/achievements", "/dashboard", "/themes"],
     "chat-gallery": ["/achievements", "/chats", "/dashboard", "/themes"],
     "friend-gallery": ["/achievements", "/dashboard", "/themes"],
     "theme-gallery": ["/achievements", "/dashboard", "/themes"],
     "art-gallery": ["/art", "/artjob"],
-    "dream-relationship-gallery": ["/brainstorm", "/dreams"],
-    "scenario-relationship-gallery": ["/brainstorm", "/dreams"],
     "daily-digest-object-gallery": ["/for-you"],
     "ui-gallery": ["/ui"]
   },

--- a/utils/scripts/route-gallery-baseline.json
+++ b/utils/scripts/route-gallery-baseline.json
@@ -1,7 +1,7 @@
 {
   "note": "Route gallery RATCHET: this file may only ever shrink. --update refuses to record a larger count. See utils/scripts/verifyRouteGalleryContract.ts.",
   "recorded": "2026-08-07",
-  "total": 10,
+  "total": 9,
   "holdouts": {
     "achievement-gallery": ["/achievements", "/dashboard", "/themes"],
     "chat-gallery": ["/achievements", "/chats", "/dashboard", "/themes"],
@@ -11,7 +11,6 @@
     "dream-relationship-gallery": ["/brainstorm", "/dreams"],
     "scenario-relationship-gallery": ["/brainstorm", "/dreams"],
     "daily-digest-object-gallery": ["/for-you"],
-    "resource-gallery": ["/resources"],
     "ui-gallery": ["/ui"]
   },
   "shadowTotal": 0,

--- a/utils/wonderlab/previewFixtures.ts
+++ b/utils/wonderlab/previewFixtures.ts
@@ -13,6 +13,39 @@ export type WonderLabPreviewFixture = {
 const fixtureDate = new Date('2026-01-01T00:00:00.000Z')
 
 const fixtures: Record<string, WonderLabPreviewFixture> = {
+  'resource-card': {
+    title: 'Resource card specimen',
+    description:
+      'A synthetic LoRA with a trigger phrase and both use counts, so the type badges, the hover trigger strip, the four build actions and the Edit affordance are all visible. Presentational: it takes the record and its two busy flags as props and reads no store.',
+    viewport: 'mobile',
+    minHeight: '28rem',
+    props: {
+      resource: {
+        id: -801,
+        createdAt: fixtureDate,
+        updatedAt: fixtureDate,
+        name: 'wonderlab-fixture-lora.safetensors',
+        customLabel: 'Museum Placard Style',
+        description:
+          'A synthetic Resource for checking resource-card badges, truncation, and button layout.',
+        resourceType: 'LORA',
+        generation: 'SDXL',
+        supportedServer: 'COMFY',
+        defaultTrigger: 'museum placard, clean lettering',
+        triggerWords: null,
+        artPrompt: null,
+        localPath: null,
+        previewImageUrl: null,
+        imagePath: null,
+        isMature: false,
+        userId: 0,
+        ArtImage: null,
+        _count: { ArtImages: 12, UsedInImages: 47 },
+      },
+      generatingPreview: false,
+      uploadingPreview: false,
+    },
+  },
   'icon-card': {
     title: 'Smart Icon card',
     description:


### PR DESCRIPTION
Finishes the single-collection batch. The grid was `sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4` — viewport-keyed, firing against a narrow container whenever the gallery was inset.

## The card had to come out first

Its inline `<article>` referenced **nine** gallery functions, so inlining it in an `#item` slot would have meant ~20 copies of `resourceById.get(Number(item.id))!`. Splitting it was the actual work:

| | |
| --- | --- |
| **moved into the card** | `previewSrc`, `isEditable` — pure functions of the record, so they belong to the thing that draws it |
| **stayed in the gallery** | `resourceLabel`, `triggerText`, `RESOURCE_TYPE` — the *generation* path still needs them to build a prompt and pick checkpoint vs LoRA, which is store work |
| **became emits** | `edit`, `add-to-build`, `start-fresh`, `generate-preview`, `upload-preview` — all reach stores or APIs |
| **became props** | the two busy flags, so the card mounts in WonderLab from a plain fixture |

`resource-card` is deliberately **not** in `verifyCardActionContract`'s `ENTITY_CARDS`. A Resource has no interact surface to `open`, and its primary actions are "add to build" and "start fresh". Adding it would mean inventing an `open` with nowhere to go.

## A mistake worth recording

My first slice of the template anchored on `<div\n v-if="` and matched an **earlier** block, silently deleting the Add-checkpoint / Add-LoRA buttons and both `add-model` / `add-lora` forms.

Nothing in the conversion noticed. `vue-tsc` was clean — the handlers still existed, they'd just lost their callers. **eslint caught it**, as two `defined but never used` errors for `startAdd` and `handleSaved`, and that's the only reason it didn't ship.

Redone against the exact loading-block text, with an assertion that the removed span contains neither identifier.

## Verification

- `vue-tsc` exit 0
- lint ratchet **395, unchanged**
- card-action, route-gallery, gallery-adoption, gallery-consistency, layout, entity-art, narrative-kit, reachability, ui-tier-vocabulary, capture-group and no-promise-in-store-state all pass

## Where the ratchet stands

**8 → 7.** All seven single-collection galleries are done: icons, servers, checkpoints, stylist, both relationship galleries, and resources.

Remaining are the four multi-collection panels (`theme`, `friend`, `achievement`, `chat` — each renders two or more distinct collections, so each needs more than one `kr-gallery` and a layout decision) and the three page-sized (`art-gallery` at 1,653, `daily-digest-object-gallery`, `ui-gallery`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_