### PR TITLE
Move the Achievements and Friends panels onto kr-gallery (ratchet 7 → 5)

### DIFF
--- a/components/achievements/achievement-gallery.vue
+++ b/components/achievements/achievement-gallery.vue
@@ -52,21 +52,31 @@
           }}</span>
         </div>
         <div class="p-3">
-          <div v-if="earnedAchievements.length" class="grid grid-cols-1 gap-2">
-            <EarnedAchievementCard
-              v-for="earnedAchievement in earnedAchievements"
-              :key="earnedAchievement.id"
-              :achievement="earnedAchievement"
-              :acquired-at="earnedAchievement.acquiredAt"
-            />
-          </div>
-          <div
-            v-else
-            class="flex min-h-32 flex-col items-center justify-center rounded-xl border border-dashed border-base-300 p-4 text-center text-xs text-base-content/40"
+          <!-- `:modes="[]"` hides the bar. These are badge-sized items in a
+               one-third-width column, not art with three variants, and three
+               mode bars across three narrow columns would be noise. -->
+          <kr-gallery
+            :items="earnedItems"
+            :modes="[]"
+            empty-label="achievements"
           >
-            <Icon name="kind-icon:trophy" class="mb-2 h-8 w-8 opacity-30" />
-            No achievements earned yet.
-          </div>
+            <template #item="{ item }">
+              <EarnedAchievementCard
+                v-if="earnedById.get(Number(item.id))"
+                :achievement="earnedById.get(Number(item.id))!"
+                :acquired-at="earnedById.get(Number(item.id))!.acquiredAt"
+              />
+            </template>
+
+            <template #empty>
+              <div
+                class="flex min-h-32 flex-col items-center justify-center rounded-xl border border-dashed border-base-300 p-4 text-center text-xs text-base-content/40"
+              >
+                <Icon name="kind-icon:trophy" class="mb-2 h-8 w-8 opacity-30" />
+                No achievements earned yet.
+              </div>
+            </template>
+          </kr-gallery>
         </div>
       </div>
 
@@ -99,23 +109,31 @@
           }}</span>
         </div>
         <div class="p-3">
-          <div
-            v-if="unearnedAchievements.length"
-            class="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2"
+          <!-- The old grid was `md:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2`
+               -- VIEWPORT-keyed, inside a column that is a third of the page.
+               On a wide screen `xl:grid-cols-2` fired against a narrow column.
+               MODE_GRID_CLASS measures the container instead. -->
+          <kr-gallery
+            :items="unearnedItems"
+            :modes="[]"
+            empty-label="achievements"
           >
-            <UnearnedAchievementCard
-              v-for="achievement in unearnedAchievements"
-              :key="achievement.id"
-              :achievement="achievement"
-            />
-          </div>
-          <div
-            v-else
-            class="flex min-h-32 flex-col items-center justify-center rounded-xl border border-dashed border-success/30 bg-success/5 p-4 text-center text-xs text-success/70"
-          >
-            <Icon name="kind-icon:check" class="mb-2 h-8 w-8" />
-            All achievements discovered!
-          </div>
+            <template #item="{ item }">
+              <UnearnedAchievementCard
+                v-if="unearnedById.get(Number(item.id))"
+                :achievement="unearnedById.get(Number(item.id))!"
+              />
+            </template>
+
+            <template #empty>
+              <div
+                class="flex min-h-32 flex-col items-center justify-center rounded-xl border border-dashed border-success/30 bg-success/5 p-4 text-center text-xs text-success/70"
+              >
+                <Icon name="kind-icon:check" class="mb-2 h-8 w-8" />
+                All achievements discovered!
+              </div>
+            </template>
+          </kr-gallery>
         </div>
       </div>
     </div>
@@ -124,6 +142,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
 
 const achievementStore = useAchievementStore()
 const userStore = useUserStore()
@@ -145,7 +164,9 @@ function toIsoOrNull(value: unknown): string | null {
 const earnedAchievements = computed<EarnedAchievement[]>(() => {
   const uid = userStore.userId
   if (!uid) return []
-  const achievementById = new Map(achievementStore.achievements.map((m) => [m.id, m]))
+  const achievementById = new Map(
+    achievementStore.achievements.map((m) => [m.id, m]),
+  )
   const earned: EarnedAchievement[] = []
   for (const record of achievementStore.achievementRecords) {
     if (record.userId !== uid) continue
@@ -171,6 +192,33 @@ const unearnedAchievements = computed(() => {
   )
   return achievementStore.achievements.filter((m) => !earnedIds.has(m.id))
 })
+
+/*
+ * kr-gallery takes GalleryItems and hands one back to the #item slot, so each
+ * column maps its id to the real record. Earned keeps its own map because the
+ * card needs `acquiredAt`, which only the earned shape carries.
+ */
+const earnedItems = computed<GalleryItem[]>(() =>
+  earnedAchievements.value.map((achievement) => ({
+    id: achievement.id,
+    title: achievement.label || `Achievement ${achievement.id}`,
+  })),
+)
+
+const earnedById = computed(
+  () => new Map(earnedAchievements.value.map((a) => [a.id, a])),
+)
+
+const unearnedItems = computed<GalleryItem[]>(() =>
+  unearnedAchievements.value.map((achievement) => ({
+    id: achievement.id,
+    title: achievement.label || `Achievement ${achievement.id}`,
+  })),
+)
+
+const unearnedById = computed(
+  () => new Map(unearnedAchievements.value.map((a) => [a.id, a])),
+)
 
 const resetAchievements = () => {
   achievementStore.clearAllAchievementRecords()

--- a/components/user/friend-gallery.vue
+++ b/components/user/friend-gallery.vue
@@ -19,97 +19,116 @@
       </span>
     </div>
 
-    <!-- Empty state -->
-    <div
-      v-if="visibleUsers.length === 0"
-      class="flex flex-col items-center gap-2 py-12 text-base-content/50"
-    >
-      <Icon name="kind-icon:person" class="h-12 w-12" />
-      <p>No public profiles yet.</p>
-    </div>
+    <!-- The shared shell owns the grid and the empty state. The old user grid
+         was `grid-cols-2 md:grid-cols-3 lg:grid-cols-4` -- viewport-keyed --
+         and MODE_GRID_CLASS measures the container instead.
 
-    <!-- User grid -->
-    <div v-else class="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
-      <div
-        v-for="u in visibleUsers"
-        :key="u.id"
-        class="card relative rounded-xl bg-base-200 shadow"
-        :class="{ 'ring-2 ring-primary': u.id === currentUserId }"
-      >
-        <!-- "You" badge -->
-        <span
-          v-if="u.id === currentUserId"
-          class="badge badge-primary absolute left-2 top-2 text-[0.65rem]"
+         `:modes="[]"` hides the bar: these are avatars and buttons, not art at
+         three variants. The per-user art strip inside each card stays exactly
+         as it was -- it is a card detail, not a gallery.
+
+         The user id IS the GalleryItem id, so most of the card reads it
+         straight off the slot; only the three fields that need the whole
+         record go through the lookup. -->
+    <kr-gallery :items="galleryItems" :modes="[]" empty-label="profiles">
+      <template #item="{ item }">
+        <div
+          v-if="userById.get(Number(item.id))"
+          class="card relative rounded-xl bg-base-200 shadow"
+          :class="{ 'ring-2 ring-primary': Number(item.id) === currentUserId }"
         >
-          You
-        </span>
-
-        <div class="flex flex-col items-center p-4 pt-6">
-          <user-avatar :user-id="u.id" class="mb-2 h-20 w-20 rounded-full" />
-          <h3 class="text-center text-base font-bold">
-            {{ u.designerName || u.username || 'Unknown User' }}
-          </h3>
-          <p class="text-xs text-base-content/50 uppercase tracking-widest">
-            {{ formatRole(u.Role) }}
-          </p>
-
-          <div class="mt-3 flex gap-2">
-            <button
-              class="btn btn-primary btn-sm"
-              type="button"
-              @click="toggleCollection(u.id)"
-            >
-              {{ selectedUserId === u.id ? 'Hide' : 'Collection' }}
-            </button>
-
-            <button
-              v-if="isLoggedIn && u.id !== currentUserId"
-              class="btn btn-secondary btn-sm relative"
-              type="button"
-              @click="sendMessage(u.id)"
-            >
-              Message
-              <span
-                v-if="hasUnreadFrom(u.id)"
-                class="absolute -right-1 -top-1 flex h-2.5 w-2.5 rounded-full bg-error"
-              />
-            </button>
-          </div>
-        </div>
-
-        <!-- Art collection panel -->
-        <div v-if="selectedUserId === u.id" class="px-4 pb-4">
-          <h4 class="mb-2 text-sm font-semibold">Art Collection</h4>
-
-          <div
-            v-if="(userCollections[u.id] ?? []).length > 0"
-            class="grid grid-cols-2 gap-2"
+          <!-- "You" badge -->
+          <span
+            v-if="Number(item.id) === currentUserId"
+            class="badge badge-primary absolute left-2 top-2 text-[0.65rem]"
           >
-            <div
-              v-for="art in userCollections[u.id] ?? []"
-              :key="art.id"
-              class="rounded-md bg-base-100 p-1 shadow-sm"
-            >
-              <img
-                :src="artImages[art.id] || '/images/kindtitle.webp'"
-                alt="Art"
-                class="h-20 w-full rounded-md object-cover"
-                @error="handleImageError(art.id)"
-              />
+            You
+          </span>
+
+          <div class="flex flex-col items-center p-4 pt-6">
+            <user-avatar
+              :user-id="Number(item.id)"
+              class="mb-2 h-20 w-20 rounded-full"
+            />
+            <h3 class="text-center text-base font-bold">
+              {{
+                userById.get(Number(item.id))!.designerName ||
+                userById.get(Number(item.id))!.username ||
+                'Unknown User'
+              }}
+            </h3>
+            <p class="text-xs text-base-content/50 uppercase tracking-widest">
+              {{ formatRole(userById.get(Number(item.id))!.Role) }}
+            </p>
+
+            <div class="mt-3 flex gap-2">
+              <button
+                class="btn btn-primary btn-sm"
+                type="button"
+                @click="toggleCollection(Number(item.id))"
+              >
+                {{ selectedUserId === Number(item.id) ? 'Hide' : 'Collection' }}
+              </button>
+
+              <button
+                v-if="isLoggedIn && Number(item.id) !== currentUserId"
+                class="btn btn-secondary btn-sm relative"
+                type="button"
+                @click="sendMessage(Number(item.id))"
+              >
+                Message
+                <span
+                  v-if="hasUnreadFrom(Number(item.id))"
+                  class="absolute -right-1 -top-1 flex h-2.5 w-2.5 rounded-full bg-error"
+                />
+              </button>
             </div>
           </div>
 
-          <p v-else class="text-sm text-base-content/50">
-            No art in collection yet.
-          </p>
+          <!-- Art collection panel -->
+          <div v-if="selectedUserId === Number(item.id)" class="px-4 pb-4">
+            <h4 class="mb-2 text-sm font-semibold">Art Collection</h4>
+
+            <div
+              v-if="(userCollections[Number(item.id)] ?? []).length > 0"
+              class="grid grid-cols-2 gap-2"
+            >
+              <div
+                v-for="art in userCollections[Number(item.id)] ?? []"
+                :key="art.id"
+                class="rounded-md bg-base-100 p-1 shadow-sm"
+              >
+                <img
+                  :src="artImages[art.id] || '/images/kindtitle.webp'"
+                  alt="Art"
+                  class="h-20 w-full rounded-md object-cover"
+                  @error="handleImageError(art.id)"
+                />
+              </div>
+            </div>
+
+            <p v-else class="text-sm text-base-content/50">
+              No art in collection yet.
+            </p>
+          </div>
         </div>
-      </div>
-    </div>
+      </template>
+
+      <template #empty>
+        <div
+          class="flex flex-col items-center gap-2 py-12 text-base-content/50"
+        >
+          <Icon name="kind-icon:person" class="h-12 w-12" />
+          <p>No public profiles yet.</p>
+        </div>
+      </template>
+    </kr-gallery>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
 import { useUserStore } from '@/stores/userStore'
 import { useArtStore } from '@/stores/artStore'
 import { useChatStore } from '@/stores/chatStore'
@@ -136,6 +155,17 @@ const visibleUsers = computed(() => {
 
   return all.filter((u) => u.isPublic || u.id === uid)
 })
+
+const galleryItems = computed<GalleryItem[]>(() =>
+  visibleUsers.value.map((user) => ({
+    id: user.id,
+    title: user.designerName || user.username || 'Unknown User',
+  })),
+)
+
+const userById = computed(
+  () => new Map(visibleUsers.value.map((user) => [user.id, user])),
+)
 
 const selectedUserId = ref<number | null>(null)
 const userCollections = ref<Record<number, ArtImage[]>>({})

--- a/utils/scripts/route-gallery-baseline.json
+++ b/utils/scripts/route-gallery-baseline.json
@@ -1,11 +1,9 @@
 {
   "note": "Route gallery RATCHET: this file may only ever shrink. --update refuses to record a larger count. See utils/scripts/verifyRouteGalleryContract.ts.",
   "recorded": "2026-08-07",
-  "total": 7,
+  "total": 5,
   "holdouts": {
-    "achievement-gallery": ["/achievements", "/dashboard", "/themes"],
     "chat-gallery": ["/achievements", "/chats", "/dashboard", "/themes"],
-    "friend-gallery": ["/achievements", "/dashboard", "/themes"],
     "theme-gallery": ["/achievements", "/dashboard", "/themes"],
     "art-gallery": ["/art", "/artjob"],
     "daily-digest-object-gallery": ["/for-you"],


### PR DESCRIPTION
The first two multi-collection panels. Both keep their surrounding layout; only the collections move.

## achievement-gallery

Three columns — Earned, Leaderboard, Undiscovered — so it takes **two** `kr-gallery` instances and the leaderboard stays exactly as it is. A ranked table isn't a browse surface.

The real defect was in Undiscovered:

```
grid-cols-1 md:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2
```

Viewport-keyed, **inside a column that is a third of the page**. On a wide screen `xl:grid-cols-2` fired while the column it lives in was narrow — the container-vs-viewport mismatch again, and a particularly sharp case, because the container is a third the width of the thing the breakpoint was measuring.

## friend-gallery

Converts the user grid and leaves the per-user art strip alone — that strip is a card detail, not a gallery.

**No card extraction needed here**, unlike `resource-gallery`, because the user id *is* the `GalleryItem` id: twelve of the fifteen references read it straight off the slot, and only the three fields needing the whole record (`designerName`, `username`, `Role`) go through a lookup. Verified by counting rather than eyeballing — 13 old `u.id` refs, minus the `:key` kr-gallery now owns, equals 12 standalone reads, plus 3 inside the lookups.

Both panels pass `:modes="[]"`. Achievement badges and user avatars aren't art at three variants, and three mode bars across three narrow columns would be noise — the same call `server-gallery`'s picker variants make.

## Watched to fail — and the first attempt wasn't enough

Turning **one** of achievement-gallery's two `<kr-gallery>` mounts into `class="kr-gallery"` left the count **unchanged**, because the file still mounts the other. Only breaking both drops it 16 → 15.

Worth stating plainly: for a multi-collection panel this check answers *"does this file mount the shell at all"*, not *"did every collection keep it"*. That's a real limit of the metric, now known rather than assumed.

## Two slicing mistakes, caught before shipping

Both the same shape as the `resource-gallery` one:

1. The first friend-gallery pass invented a `friend` template local — Vue can't declare those.
2. The second swallowed the grid's own closing `</div>`.

Prettier rejected both outright. Redone against the grid's close, with an assertion that no `u.` reference survives the rewrite.

## Verification

- `vue-tsc` exit 0
- lint ratchet **395, unchanged**
- **every** `npm run test:*` step in `contract-tests.yml` plus the strict WonderLab preview audit — run in full rather than sampled, after that gate's ratchet caught me last round

## Remaining

Ratchet **7 → 5**. Left: `theme-gallery` and `chat-gallery` to finish the multi-collection batch, then the three page-sized (`art-gallery` at 1,653, `daily-digest-object-gallery`, `ui-gallery`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_