### PR TITLE
Accept Conductor continuous project lifecycle

### DIFF
--- a/server/utils/conductorProjectRegistry.ts
+++ b/server/utils/conductorProjectRegistry.ts
@@ -1,5 +1,6 @@
 export const CONDUCTOR_PROJECT_STATUSES = [
   'active',
+  'continuous',
   'paused',
   'finished',
   'retired',
@@ -54,6 +55,7 @@ const STATUS_TO_PROJECT: Record<
   ProjectLifecycleStatus
 > = {
   active: 'ACTIVE',
+  continuous: 'ACTIVE',
   paused: 'PAUSED',
   finished: 'DONE',
   retired: 'ARCHIVED',


### PR DESCRIPTION
Companion compatibility patch for Conductor portfolio reconciliation PR #1843.

Conductor is adding a `continuous` lifecycle for intentionally never-idle programs. Kind Robots should preserve that Conductor status in projections while continuing to use the existing Prisma `ProjectStatus.ACTIVE` runtime state.

Changes:
- accept `continuous` in `CONDUCTOR_PROJECT_STATUSES`
- map `continuous -> ACTIVE` for the existing Kind Robots Project lifecycle
- leave `ACTIVE -> active` reverse mapping unchanged because the DB enum intentionally does not try to infer whether an ACTIVE project is finite or continuous

No schema migration, production data mutation, UI change, secrets, billing, or deployment behavior change.