### PR TITLE
chat-gallery is not a gallery: record the decision instead of forcing it

### DIFF
--- a/utils/scripts/route-gallery-baseline.json
+++ b/utils/scripts/route-gallery-baseline.json
@@ -1,9 +1,8 @@
 {
   "note": "Route gallery RATCHET: this file may only ever shrink. --update refuses to record a larger count. See utils/scripts/verifyRouteGalleryContract.ts.",
   "recorded": "2026-08-07",
-  "total": 4,
+  "total": 3,
   "holdouts": {
-    "chat-gallery": ["/achievements", "/chats", "/dashboard", "/themes"],
     "art-gallery": ["/art", "/artjob"],
     "daily-digest-object-gallery": ["/for-you"],
     "ui-gallery": ["/ui"]

--- a/utils/scripts/verifyRouteGalleryContract.ts
+++ b/utils/scripts/verifyRouteGalleryContract.ts
@@ -319,6 +319,30 @@ const isGalleryComponent = (name: string): boolean =>
  * deletes one bucket, and a NEW route rendering an existing holdout still
  * grows that bucket and fails.
  */
+/**
+ * Components named `*-gallery` that are NOT galleries, with the reason.
+ *
+ * The whole contract exists because a filename is not a shape -- that is how a
+ * second Facet browser hid inside facet-manager.vue. This is the same lesson
+ * pointing the other way: a component can be CALLED a gallery and not be one,
+ * and counting it as a holdout invents work that would make the UI worse.
+ *
+ * An entry here is a design decision, not a deferral. It must say why, and it
+ * must be wrong to adopt -- not merely awkward.
+ */
+export const NOT_GALLERIES: Record<string, string> = {
+  'chat-gallery':
+    'An inbox and a transcript, not a browse surface. Its thread rows are ' +
+    '`flex w-full` -- a 48px avatar plus name, title, preview and timestamp -- ' +
+    'and the narrowest kr-gallery mode is `cards` at minmax(min(11rem,100%),1fr), ' +
+    'which in a full-width panel yields five to eight columns and crushes every ' +
+    'row. No mode fits: `list` was the one that would have, and Silas removed it ' +
+    'from the vocabulary on 2026-08-03 ("List is the odd duck out ... kill line") ' +
+    'precisely because a mode whose identity is a layout rather than an image ' +
+    'cannot stay in lockstep with the schema. Adopting here would mean either ' +
+    'wrecking the inbox or resurrecting that mode.',
+}
+
 export function bucketHoldouts(
   routes: readonly { route: string; galleries: readonly string[] }[],
   adopted: (name: string) => boolean,
@@ -327,6 +351,7 @@ export function bucketHoldouts(
   for (const { route, galleries } of routes) {
     for (const gallery of galleries) {
       if (adopted(gallery)) continue
+      if (gallery in NOT_GALLERIES) continue
       ;(buckets[gallery] ??= []).push(route)
     }
   }
@@ -1151,7 +1176,22 @@ function main(): void {
   const baseline = loadRatchetBaseline<RouteGalleryBaseline>(BASELINE)
   const grown = grownRatchetBuckets(buckets, baseline?.holdouts ?? null)
 
-  const liveGalleries = new Set(routes.flatMap((entry) => entry.galleries))
+  for (const [name, reason] of Object.entries(NOT_GALLERIES)) {
+    console.log(`\nNot a gallery, by decision: ${name}`)
+    console.log(`  ${reason.replace(/(.{72}\S*)\s/g, '$1\n  ')}`)
+  }
+
+  /*
+   * NOT_GALLERIES leave the DENOMINATOR too, not just the holdout list.
+   * The headline is `liveGalleries.size - total`, so exempting one from
+   * `total` alone would silently count it as ADOPTED -- a number that reads
+   * like progress and is a lie. They are reported in their own section above.
+   */
+  const liveGalleries = new Set(
+    routes
+      .flatMap((entry) => entry.galleries)
+      .filter((gallery) => !(gallery in NOT_GALLERIES)),
+  )
   console.log(
     `\nLive galleries on ${SHARED_GALLERY}: ` +
       `${liveGalleries.size - total}/${liveGalleries.size}` +


### PR DESCRIPTION
The last "multi-collection panel" turned out not to be one, and I'd rather record that than force it.

## Why chat-gallery shouldn't adopt

It's an **inbox** and a **transcript**. Neither is a browse surface.

Its thread rows are `flex w-full items-start` — a 48px avatar beside a name, a title, a message preview and a timestamp. The narrowest kr-gallery mode is `cards` at `minmax(min(11rem,100%),1fr)`, which in a full-width panel yields **five to eight columns** and crushes every row. `icons` at 16rem is no better.

The mode that *would* have fit is `list` — and you removed it from the vocabulary on 2026-08-03:

> "List is the odd duck out ... the current List page is a GIGANTIC display of individual images ... kill line."

That removal was right for the reason `galleryVocabulary.ts` states: a mode whose identity is a *layout* rather than an *image* can't stay in lockstep with the schema. So adopting here means either wrecking the inbox or resurrecting a mode that was deliberately killed.

Converting it just to move a number would be the ratchet driving the design instead of describing it.

This contract exists because **a filename is not a shape** — that's how a second Facet browser hid inside `facet-manager.vue`. This is the same lesson pointing the other way: a component can be *called* a gallery and not be one.

## The arithmetic bug I nearly shipped

The headline is `liveGalleries.size - total`. Exempting an entry from `total` **alone** counted chat-gallery as **adopted** — printing `18/21`, a number that reads like progress and is a lie.

Caught by reading the arithmetic after the first version printed it. Exempted entries now leave both sides of the fraction: **17/20**.

## Watched to fail

- Exempting a *real* holdout (`art-gallery`, as a test) leaves the numerator at 17 and only shrinks the denominator — the escape hatch **cannot manufacture adoption**.
- A genuinely adopted gallery regressing still fails: breaking `theme-gallery`'s mounts reports `1 gallery/galleries got WORSE`.

## What this does not prevent

An exemption still removes an entry from the holdout **count**, so the ratchet can be moved by adding one. There's no mechanical way to check "is this really not a gallery."

The safeguard is that each entry needs a written reason in a reviewed diff, and the reason prints on every run. I'd rather state that limit than imply the guard is tighter than it is.

## Verification

- `vue-tsc` exit 0
- every `npm run test:*` step in `contract-tests.yml` plus the strict WonderLab preview audit

## Remaining

**17/20 adopted, 3 holdouts** — all page-sized: `art-gallery` (1,653), `daily-digest-object-gallery` (268), `ui-gallery` (656).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_