### PR TITLE
fix(nav): route scenario nav/audit entries to /stories, not dead /scenarios

### DIFF
--- a/stores/helpers/narratorHelper.ts
+++ b/stores/helpers/narratorHelper.ts
@@ -176,7 +176,7 @@ export const narratorNavigationTree: NarratorNavAction[] = [
     title: 'Scenarios',
     description: 'Choose a playable setup, location, or scene frame.',
     icon: 'kind-icon:map',
-    path: '/scenarios',
+    path: '/stories',
     flavor: 'The stage is waiting.',
     prompt:
       'Help me launch a scenario in this Dream. Use a vivid opening beat and end with choices.',
@@ -432,7 +432,7 @@ export const narratorCreateSpecs: NarratorCreateSpec[] = [
     type: 'scenario',
     title: 'New Scenario',
     icon: 'kind-icon:map',
-    builderPath: '/scenarios',
+    builderPath: '/stories',
     flavor: 'A new stage rolls into place.',
     prompt:
       'Create a single playable scenario for the Dream "{dream}". Return a title, a vivid location, a central tension, an opening intro beat, and 2–3 first choices.',
@@ -711,7 +711,7 @@ export function buildNarratorStarterPrompts(options: {
       icon: 'kind-icon:map',
       action: 'screen',
       screen: 'scenarios',
-      path: '/scenarios',
+      path: '/stories',
       flavor: 'The stage is waiting.',
       prompt: `Tell me a story in the Dream "${dreamTitle}". Use the selected scenario if one exists, and end with 2 or 3 choices.`,
     },

--- a/utils/scripts/auditResponsiveLayout.mjs
+++ b/utils/scripts/auditResponsiveLayout.mjs
@@ -48,7 +48,7 @@ const flag = (name, fallback) => {
 const BASE = flag('base', process.env.AUDIT_BASE || 'http://127.0.0.1:3000')
 const ROUTES = flag(
   'routes',
-  '/,/conductor,/dreams,/art,/bots,/characters,/rewards,/scenarios',
+  '/,/conductor,/dreams,/art,/bots,/characters,/rewards,/stories',
 )
   .split(',')
   .map((r) => r.trim())


### PR DESCRIPTION
### Task
conductor: interface-vision/t-102 (Build the canonical reachable-surface and responsive acceptance inventory) — a real navigation bug found incidentally while building the inventory, fixed as its own small scoped diff.

### What changed
`utils/scripts/coreObjectRoutes.ts` already documents `// NOT /scenarios.` — the Scenario object's real route is `/stories` — but three live Dream-narrator nav payloads in `stores/helpers/narratorHelper.ts` still pointed at the dead `/scenarios` path:
- the `'Scenarios'` nav action (`narratorNavigationTree`)
- the `'New Scenario'` builder create-spec (`narratorCreateSpecs`, `builderPath`)
- the `'Tell me a story'` starter prompt (`buildNarratorStarterPrompts`)

Same bug, independently, in `utils/scripts/auditResponsiveLayout.mjs`'s default `--routes` list — it was silently auditing a not-found page every run instead of the real Scenario surface (`/stories`).

All four now point at `/stories`.

### How I verified
- `npx eslint stores/helpers/narratorHelper.ts utils/scripts/auditResponsiveLayout.mjs` — clean
- `npx prettier --check` on both — clean on the actual diff (narratorHelper.ts carries one pre-existing, unrelated union-type formatting issue at lines 53–63 that predates this change and isn't touched by it)
- `npx vue-tsc --noEmit` (full project) — exit 0
- Confirmed no remaining `/scenarios` path references anywhere in either file after the fix

### Stakes
reversible

### Flags for Reviewer
None — pure literal string fixes, no logic change, no schema/API impact.

### Kaizen suggestion
The inventory build (t-102) also found a second, unrelated dead route: `stores/helpers/dashboardHelper.ts`'s `footer` dashboard's `builder` tab has `route: '/builder'`, which matches no content file or page anywhere, and `narratorHelper.ts`'s own `'builder'` nav action has the same dead `/builder` path. Left unfixed here since the correct destination isn't obvious (no single top-level page for the multi-tab Builder dashboard) — filed as a separate follow-up task rather than guessed at.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJzWJk3ZWKSRKV3Ypm8kZD)_