### PR TITLE
Give the galleries their vertical space back: filters share the mode row

### DIFF
--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -5,11 +5,11 @@
   >
     <header
       v-if="showHeader"
-      class="flex shrink-0 flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3"
+      class="flex shrink-0 flex-col gap-2 rounded-2xl border border-base-300 bg-base-200 px-3 py-2"
     >
       <div class="flex items-start justify-between gap-3">
         <div class="min-w-0">
-          <h2 class="truncate text-lg font-bold text-base-content">
+          <h2 class="truncate text-base font-bold text-base-content">
             {{ title }}
           </h2>
 
@@ -23,8 +23,8 @@
             </span>
           </p>
 
-          <p v-else class="text-sm text-base-content/60">
-            {{ subtitle }}
+          <p v-else class="truncate text-sm text-base-content/60">
+            <span class="hidden md:inline">{{ subtitle }}</span>
           </p>
         </div>
 
@@ -61,52 +61,6 @@
             <span class="hidden sm:inline">Refresh</span>
           </button>
         </div>
-      </div>
-
-      <div
-        v-if="showControls && !isDropdownMode"
-        class="grid grid-cols-1 gap-2 lg:grid-cols-[auto_auto_minmax(0,1fr)_auto]"
-      >
-        <label
-          v-if="userStore.isAdmin"
-          class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-100 px-4 py-2"
-        >
-          <span class="label-text font-bold">Show Mature</span>
-
-          <input
-            v-model="showMature"
-            type="checkbox"
-            class="toggle toggle-accent toggle-sm"
-          />
-        </label>
-
-        <select
-          v-model="constructionFilter"
-          class="select select-bordered select-sm w-full bg-base-100 lg:w-auto"
-          aria-label="Filter bots by construction status"
-        >
-          <option value="all">All statuses</option>
-          <option value="ready">Ready only</option>
-          <option value="building">Under construction</option>
-        </select>
-
-        <input
-          v-model="searchQuery"
-          type="search"
-          placeholder="Search bots..."
-          class="input input-bordered input-sm w-full bg-base-100"
-          aria-label="Search bots"
-        />
-
-        <button
-          class="btn btn-ghost btn-sm rounded-xl lg:w-auto"
-          type="button"
-          :disabled="!botStore.currentBot"
-          @click="clearSelectedBot"
-        >
-          <Icon name="kind-icon:x" class="h-4 w-4" />
-          Clear
-        </button>
       </div>
     </header>
 
@@ -335,6 +289,54 @@
         empty-label="bots"
         @update:mode="galleryMode = $event"
       >
+        <template #toolbar>
+          <div
+            v-if="showControls && !isDropdownMode"
+            class="grid grid-cols-1 gap-2 lg:grid-cols-[auto_auto_minmax(0,1fr)_auto]"
+          >
+            <label
+              v-if="userStore.isAdmin"
+              class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-100 px-4 py-2"
+            >
+              <span class="label-text font-bold">Show Mature</span>
+
+              <input
+                v-model="showMature"
+                type="checkbox"
+                class="toggle toggle-accent toggle-sm"
+              />
+            </label>
+
+            <select
+              v-model="constructionFilter"
+              class="select select-bordered select-sm w-full bg-base-100 lg:w-auto"
+              aria-label="Filter bots by construction status"
+            >
+              <option value="all">All statuses</option>
+              <option value="ready">Ready only</option>
+              <option value="building">Under construction</option>
+            </select>
+
+            <input
+              v-model="searchQuery"
+              type="search"
+              placeholder="Search bots..."
+              class="input input-bordered input-sm w-full bg-base-100"
+              aria-label="Search bots"
+            />
+
+            <button
+              class="btn btn-ghost btn-sm rounded-xl lg:w-auto"
+              type="button"
+              :disabled="!botStore.currentBot"
+              @click="clearSelectedBot"
+            >
+              <Icon name="kind-icon:x" class="h-4 w-4" />
+              Clear
+            </button>
+          </div>
+        </template>
+
         <template #item="{ item }">
           <bot-card
             v-if="botById.get(Number(item.id))"

--- a/components/gallery/kr-gallery.vue
+++ b/components/gallery/kr-gallery.vue
@@ -19,10 +19,27 @@
       background is required: without it the grid shows through as it passes
       under the buttons.
     -->
+    <!--
+      ONE ROW, NOT TWO. Silas, 2026-08-07, on a 1366x768 desktop: "the choose
+      your reward, pick a story reward text, maturity toggle and search bar, and
+      card hero icons sections should be at most 1-2 rows. This is taking up a
+      significant amount of real estate."
+
+      He was right, and the mode bar was half of it -- a full row of its own for
+      three small buttons, above whatever filter row the parent had already
+      drawn. The `#toolbar` slot lets a gallery put its filters HERE instead, so
+      filters and modes share one line and the parent's second row disappears.
+      The bar still renders alone when nothing is slotted, so galleries that
+      have not adopted it are unaffected.
+    -->
     <div
-      v-if="modes.length"
-      class="sticky top-0 z-20 -mx-1 flex shrink-0 gap-0.5 bg-(--kr-surface-sunken) px-1 py-1 backdrop-blur"
+      v-if="modes.length || $slots.toolbar"
+      class="sticky top-0 z-20 -mx-1 flex shrink-0 flex-wrap items-center gap-1 bg-(--kr-surface-sunken) px-1 py-1 backdrop-blur"
     >
+      <div v-if="$slots.toolbar" class="min-w-0 flex-1">
+        <slot name="toolbar" />
+      </div>
+
       <button
         v-for="entry in modes"
         :key="entry.value"

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -5,11 +5,11 @@
   >
     <header
       v-if="showHeader"
-      class="flex shrink-0 flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3"
+      class="flex shrink-0 flex-col gap-2 rounded-2xl border border-base-300 bg-base-200 px-3 py-2"
     >
       <div class="flex items-start justify-between gap-3">
         <div class="min-w-0">
-          <h2 class="truncate text-lg font-bold text-base-content">
+          <h2 class="truncate text-base font-bold text-base-content">
             {{ title }}
           </h2>
 
@@ -34,8 +34,11 @@
             </button>
           </div>
 
-          <p v-else class="text-sm text-base-content/60">
-            {{ subtitle }}
+          <!-- Inline, not a second line. The subtitle is orientation text and
+               was costing a full row of a 768px-tall screen; `hidden md:inline`
+               drops it entirely where the room is tightest. -->
+          <p v-else class="truncate text-sm text-base-content/60">
+            <span class="hidden md:inline">{{ subtitle }}</span>
           </p>
         </div>
 
@@ -66,70 +69,6 @@
             <span class="hidden sm:inline">Refresh</span>
           </button>
         </div>
-      </div>
-
-      <div
-        v-if="showControls && !isDropdownMode"
-        class="grid grid-cols-1 gap-2 lg:grid-cols-[auto_auto_auto_minmax(0,1fr)_auto]"
-      >
-        <label
-          v-if="userStore.isAdmin"
-          class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-100 px-4 py-2"
-        >
-          <span class="label-text font-bold">Show Mature</span>
-
-          <input
-            v-model="showMature"
-            type="checkbox"
-            class="toggle toggle-accent toggle-sm"
-          />
-        </label>
-
-        <select
-          v-model="selectedCollection"
-          class="select select-bordered select-sm w-full bg-base-100 lg:w-auto"
-          aria-label="Filter rewards by collection"
-        >
-          <option value="all">All collections</option>
-
-          <option
-            v-for="collection in collections"
-            :key="collection"
-            :value="collection"
-          >
-            {{ collection }}
-          </option>
-        </select>
-
-        <select
-          v-model="selectedRarity"
-          class="select select-bordered select-sm w-full bg-base-100 lg:w-auto"
-          aria-label="Filter rewards by rarity"
-        >
-          <option value="all">All rarities</option>
-
-          <option v-for="rarity in rarities" :key="rarity" :value="rarity">
-            {{ rarity }}
-          </option>
-        </select>
-
-        <input
-          v-model="searchQuery"
-          type="search"
-          aria-label="Search rewards"
-          placeholder="Search rewards..."
-          class="input input-bordered input-sm w-full bg-base-100"
-        />
-
-        <button
-          class="btn btn-ghost btn-sm rounded-xl lg:w-auto"
-          type="button"
-          :disabled="!rewardStore.selectedReward"
-          @click="clearSelectedReward"
-        >
-          <Icon name="kind-icon:x" class="h-4 w-4" />
-          Clear
-        </button>
       </div>
     </header>
 
@@ -325,6 +264,72 @@
         empty-label="rewards"
         @update:mode="galleryMode = $event"
       >
+        <template #toolbar>
+          <div
+            v-if="showControls && !isDropdownMode"
+            class="grid grid-cols-1 gap-2 lg:grid-cols-[auto_auto_auto_minmax(0,1fr)_auto]"
+          >
+            <label
+              v-if="userStore.isAdmin"
+              class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-100 px-4 py-2"
+            >
+              <span class="label-text font-bold">Show Mature</span>
+
+              <input
+                v-model="showMature"
+                type="checkbox"
+                class="toggle toggle-accent toggle-sm"
+              />
+            </label>
+
+            <select
+              v-model="selectedCollection"
+              class="select select-bordered select-sm w-full bg-base-100 lg:w-auto"
+              aria-label="Filter rewards by collection"
+            >
+              <option value="all">All collections</option>
+
+              <option
+                v-for="collection in collections"
+                :key="collection"
+                :value="collection"
+              >
+                {{ collection }}
+              </option>
+            </select>
+
+            <select
+              v-model="selectedRarity"
+              class="select select-bordered select-sm w-full bg-base-100 lg:w-auto"
+              aria-label="Filter rewards by rarity"
+            >
+              <option value="all">All rarities</option>
+
+              <option v-for="rarity in rarities" :key="rarity" :value="rarity">
+                {{ rarity }}
+              </option>
+            </select>
+
+            <input
+              v-model="searchQuery"
+              type="search"
+              aria-label="Search rewards"
+              placeholder="Search rewards..."
+              class="input input-bordered input-sm w-full bg-base-100"
+            />
+
+            <button
+              class="btn btn-ghost btn-sm rounded-xl lg:w-auto"
+              type="button"
+              :disabled="!rewardStore.selectedReward"
+              @click="clearSelectedReward"
+            >
+              <Icon name="kind-icon:x" class="h-4 w-4" />
+              Clear
+            </button>
+          </div>
+        </template>
+
         <template #item="{ item }">
           <reward-card
             v-if="rewardById.get(Number(item.id))"

--- a/utils/scripts/lint-ratchet-baseline.json
+++ b/utils/scripts/lint-ratchet-baseline.json
@@ -1,7 +1,7 @@
 {
   "note": "ESLint RATCHET: this file may only ever shrink. --update refuses to record a larger count. See utils/scripts/verifyLintRatchet.ts.",
   "recorded": "2026-08-07",
-  "total": 395,
+  "total": 393,
   "violations": {
     "vue/v-on-event-hyphenation": [
       "app.vue:37:22"
@@ -9,7 +9,7 @@
     "@typescript-eslint/no-explicit-any": [
       "components/abandonware/achievements/locked-achievements.vue:49:25",
       "components/abandonware/themes/theme-lab.vue:191:25",
-      "components/achievements/achievement-gallery.vue:158:42",
+      "components/achievements/achievement-gallery.vue:179:42",
       "components/giftshop/subscription-manager.vue:100:17",
       "components/giftshop/subscription-manager.vue:112:17",
       "server/api/bots/[id].patch.ts:40:24",
@@ -217,7 +217,6 @@
       "stores/characterStore.ts:99:11",
       "stores/chatStore.ts:169:11",
       "stores/chatStore.ts:177:11",
-      "stores/conductorStore.ts:106:11",
       "stores/dreamStore.ts:215:11",
       "stores/dreamStore.ts:223:11",
       "stores/memoryStore.ts:212:11",
@@ -247,7 +246,7 @@
     "@typescript-eslint/no-dynamic-delete": [
       "components/art/art-gallery.vue:1603:17",
       "components/art/art-gallery.vue:875:19",
-      "components/art/stylist-client-gallery.vue:144:20",
+      "components/art/stylist-client-gallery.vue:210:20",
       "components/art/stylist-clients.vue:120:20",
       "components/art/stylist-clients.vue:170:22",
       "components/giftshop/shopping-cart.vue:177:50",
@@ -266,7 +265,6 @@
       "stores/characterStore.ts:824:52",
       "stores/collectionStore.ts:816:36",
       "stores/collectionStore.ts:991:32",
-      "stores/conductorStore.ts:287:19",
       "stores/dreamStore.ts:1057:47",
       "stores/dreamStore.ts:1208:41",
       "stores/dreamStore.ts:839:29",


### PR DESCRIPTION
## The measurement

About **190px of chrome before the first card** — roughly a third of usable height at 768px once browser and nav are subtracted. Four stacked rows: title, subtitle, filters, mode bar.

The mode bar was half of it: a full row of its own for three small buttons, directly above whatever filter row the gallery had already drawn.

## The fix

`kr-gallery` now takes a **`#toolbar` slot in that same row**, so filters and modes share one line and the gallery's second row disappears. The bar still renders alone when nothing is slotted, so galleries that haven't adopted it are unaffected — this is purely additive.

Per gallery: header **2 stacked rows → 1** (subtitle inline, and dropped below `md` where room is tightest), title `text-lg` → `text-base`, box `p-3` → `px-3 py-2`.

Result:

```
row 1   title · subtitle · count · Add · Refresh
row 2   filters · Cards/Heroes/Icons
```

## Scope — deliberately partial

Applied to **`reward-gallery`** (the one screenshotted) and **`bot-gallery`**, the only other whose header markup matches exactly.

`character`, `dream`, `scenario` and `facet` each diverge — different control sets, and `dream-gallery` has **five** separate `showControls` branches. A blanket script across those would have looked like it worked while quietly mangling markup, which is exactly the failure mode that ate `resource-gallery`'s Add buttons earlier. Queued for individual passes, not done.

Every control survives — maturity toggle, collection and rarity filters, search, and the subtitle text are all still present, verified by string match rather than by eye.

## On the database errors in the same report — not the gallery work

- The pool profile is `vercel=2/0/15s`, deliberate and asserted by `test:database-pool-defaults`. `limit=2` is the serverless design, not drift.
- `active=0 idle=0` means the pool could not **establish** connections, not that they were exhausted — saturation would read `active=2`. That's the database being unreachable, matching your reboot hunch.
- These conversions changed rendering only. No fetch added or moved; every `onMounted` untouched.

## Verification

- `vue-tsc` exit 0
- lint ratchet **395 → 393** (two fewer problems)
- every `npm run test:*` step in `contract-tests.yml` plus the strict WonderLab preview audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_