### PR TITLE
Finish the gallery chrome pass, and remove a duplicate mode bar from /dreams

### DIFF
--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -382,11 +382,22 @@
              :mode is bound so the shell picks the right MODE_GRID_CLASS, and
              :modes="[]" hides ITS bar because this gallery already renders one
              in its toolbar above -- two bars driving one mode would be worse
-             than none. -->
+             than none.
+
+             THE PROP WAS MISSING. The comment above described the intent and
+             the binding was never written, so /dreams shipped with TWO mode
+             pickers: this gallery's button group in the toolbar and the shell's
+             own bar underneath it. Both drove `galleryMode`, so they stayed in
+             sync and nothing looked broken -- it just cost a whole row on the
+             busiest route, which is exactly the vertical budget Silas flagged
+             on 2026-08-07. Found while auditing gallery chrome, not by the
+             contract: "does it mount kr-gallery" cannot see a duplicated
+             control. -->
         <kr-gallery
           v-else
           :items="galleryItems"
           :mode="galleryMode"
+          :modes="[]"
           empty-label="dreams"
           @update:mode="galleryMode = $event"
         >

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -3,16 +3,16 @@
   <section class="flex h-full min-h-0 w-full flex-col gap-3">
     <header
       v-if="showHeader"
-      class="flex shrink-0 flex-col gap-3 rounded-2xl border border-base-300 bg-base-100 p-3"
+      class="flex shrink-0 flex-col gap-2 rounded-2xl border border-base-300 bg-base-100 px-3 py-2"
     >
       <div class="flex items-center justify-between gap-3">
         <div class="min-w-0">
-          <h2 class="truncate text-lg font-black text-base-content">
+          <h2 class="truncate text-base font-black text-base-content">
             {{ title }}
           </h2>
 
           <p class="truncate text-sm text-base-content/60">
-            {{ subtitle }}
+            <span class="hidden md:inline">{{ subtitle }}</span>
           </p>
         </div>
 
@@ -42,37 +42,6 @@
             <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
           </button>
         </div>
-      </div>
-
-      <div
-        v-if="showControls && !isDropdownMode"
-        class="flex flex-col gap-2 sm:flex-row sm:items-center"
-      >
-        <label
-          class="input input-bordered input-sm flex flex-1 items-center gap-2 bg-base-200"
-        >
-          <Icon name="kind-icon:search" class="h-4 w-4 opacity-50" />
-          <input
-            v-model="searchQuery"
-            type="search"
-            aria-label="Search scenarios"
-            placeholder="Search scenarios..."
-            class="grow bg-transparent"
-          />
-        </label>
-
-        <label
-          v-if="userStore.isAdmin"
-          class="label cursor-pointer gap-2 rounded-xl border border-base-300 bg-base-200 px-3 py-1.5"
-        >
-          <span class="label-text text-sm font-bold">Mature</span>
-
-          <input
-            v-model="showMature"
-            type="checkbox"
-            class="toggle toggle-accent toggle-sm"
-          />
-        </label>
       </div>
     </header>
 
@@ -256,6 +225,39 @@
           empty-label="scenarios"
           @update:mode="galleryMode = $event"
         >
+          <template #toolbar>
+            <div
+              v-if="showControls && !isDropdownMode"
+              class="flex flex-col gap-2 sm:flex-row sm:items-center"
+            >
+              <label
+                class="input input-bordered input-sm flex flex-1 items-center gap-2 bg-base-200"
+              >
+                <Icon name="kind-icon:search" class="h-4 w-4 opacity-50" />
+                <input
+                  v-model="searchQuery"
+                  type="search"
+                  aria-label="Search scenarios"
+                  placeholder="Search scenarios..."
+                  class="grow bg-transparent"
+                />
+              </label>
+
+              <label
+                v-if="userStore.isAdmin"
+                class="label cursor-pointer gap-2 rounded-xl border border-base-300 bg-base-200 px-3 py-1.5"
+              >
+                <span class="label-text text-sm font-bold">Mature</span>
+
+                <input
+                  v-model="showMature"
+                  type="checkbox"
+                  class="toggle toggle-accent toggle-sm"
+                />
+              </label>
+            </div>
+          </template>
+
           <template #item="{ item }">
             <ScenarioCard
               v-if="scenarioById.get(Number(item.id))"


### PR DESCRIPTION
Completes the 1–2 row budget across the core-object galleries. Each needed a **different** answer, which is why the blanket script was the wrong instinct:

| gallery | what it needed |
| --- | --- |
| `reward`, `bot`, `scenario` | filters lifted into `#toolbar`; header 2 stacked rows → 1 |
| `facet` | **left alone** — mounts one kr-gallery *per taxonomy group*, so slotting controls would duplicate them per group. Already a single header row plus one controls row. |
| `character` | **nothing to do** — renders no header, no search, no controls at all; the manager supplies the chrome |
| `dream` | see below |

## /dreams was shipping two mode pickers

Its own comment says:

> `:modes="[]"` hides ITS bar because this gallery already renders one in its toolbar above — two bars driving one mode would be worse than none.

**The prop was never written.** So the toolbar's button group *and* the shell's bar both rendered. Both bind `galleryMode`, so they stayed in sync and nothing looked broken — it just cost a whole row on the busiest route, which is exactly the vertical budget you flagged.

Worth noting *how* it surfaced: by reading the chrome, not by a contract. "Does this file mount kr-gallery" can't see a control rendered twice — the same blind spot as last round's "breaking one of two mounts leaves the count unchanged." The gallery contracts measure **adoption, not layout**, and that's now twice the distinction has hidden something real.

## The guard fired, and that's the point

`scenario-gallery`'s lift was asserted to contain a `<select>` — and scenario's controls are a search input and a Mature toggle, no select at all. The helper **refused** rather than moving markup it didn't recognise.

That's precisely the check the `resource-gallery` slice lacked when it silently ate the Add-checkpoint buttons.

## Also worth a later look

`character-gallery` accepts `title` and `subtitle` props and renders **neither** — so `character-interact` passes "Choose Your Character" into a void. Not this change, but it means Characters has no heading where Rewards has one.

## Verification

- `vue-tsc` exit 0
- lint ratchet **393, unchanged**
- every `npm run test:*` step in `contract-tests.yml` plus the strict WonderLab preview audit
- the three eslint `unified-signatures` errors in `dream-gallery` are pre-existing on its emits block, untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_