### PR TITLE
fix(nav): repoint dead /builder route to /characters

### DIFF
--- a/stores/helpers/dashboardHelper.ts
+++ b/stores/helpers/dashboardHelper.ts
@@ -657,7 +657,13 @@ export const dashboardConfigs = {
         tagline: 'Build people, places, bots, rewards, and story fuel.',
         narrative:
           'Build the pieces of your world from reusable cards: profiles, dream seeds, characters, bots, rewards, scenarios, and art. Start small, stack boldly, and let the tiny construction goblins unionize later.',
-        route: '/builder',
+        // '/builder' was never a real route -- the multi-tab Builder dashboard
+        // (dashboardConfigs.builder, above) has no dedicated landing page, and
+        // its own UI (components/abandonware/builder/builder-manager.vue) was
+        // parked as unreachable by the orphan-component sweep (#1475). Route
+        // to dashboardConfigs.builder's own defaultTab destination instead of
+        // a dead link (interface-vision/t-107).
+        route: '/characters',
       },
       {
         key: 'games',

--- a/stores/helpers/narratorHelper.ts
+++ b/stores/helpers/narratorHelper.ts
@@ -146,7 +146,10 @@ export const narratorNavigationTree: NarratorNavAction[] = [
     description:
       'Create and expand Dreams, bots, stories, characters, and rewards.',
     icon: 'kind-icon:wand',
-    path: '/builder',
+    // '/builder' matched no page or content route -- see the identical fix
+    // and rationale on dashboardConfigs.footer's 'builder' tab in
+    // dashboardHelper.ts (interface-vision/t-107).
+    path: '/characters',
     flavor: 'Tools out. Sparks on.',
     prompt:
       'Help me build the next useful piece for this Dream. Suggest what to create next and why.',


### PR DESCRIPTION
### Task
interface-vision/t-107: Fix the dead `/builder` route referenced by two live nav sources (kind: software)

### What changed / what I produced
- `stores/helpers/dashboardHelper.ts`: `dashboardConfigs.footer`'s `builder` tab (label "Forge") now routes to `/characters` instead of the dead `/builder`.
- `stores/helpers/narratorHelper.ts`: the `builder` nav action's `path` now points to `/characters` for the same reason.
- Both carry a comment explaining the rationale and pointing back at each other.

### Root cause
Found while building the interface-vision/t-102 reachable-surface inventory: two live nav sources (a footer dashboard tab and a Dream-narrator nav action) pointed at `/builder`, which matches no `pages/**/*.vue` file and no Nuxt Content route — clicking either always 404s. Investigated why: the multi-tab "Builder" dashboard concept (`dashboardConfigs.builder`, unchanged by this PR) never had its own landing page — its individual tabs already route straight to each entity's own page (`/dreams`, `/characters`, `/bots`, `/rewards`, `/stories`, `/art`, ...). Its one-time wizard UI, `components/abandonware/builder/builder-manager.vue`, was parked as genuinely unreachable by the orphan-component sweep (#1475, 2026-08-05) — so there both was and is no live page `/builder` could ever have served.

### How I verified
- `dashboardConfigs.builder.defaultTab` is `'character'`, whose own tab already routes to `/characters` — used that as the principled "start here" destination rather than guessing, since it's the one place in the codebase that already answers "where does Builder land."
- Confirmed no other reference to the literal string `/builder` remains as a nav source (`grep -rn "'/builder'"` — the only survivor is an internal hydration-trigger gate in `plugins/20.facet-catalog.client.ts` that was already permanently dead code, since nothing ever successfully navigated to `/builder` in the first place; out of scope for this fix, left alone).
- `npx eslint stores/helpers/dashboardHelper.ts stores/helpers/narratorHelper.ts` — clean
- `npx vue-tsc --noEmit` — clean (exit 0, no errors)
- `npm run test:nav-manifest` — clean (5 channels, 56 tabs, 0 nav manifest errors)
- `npm run test:component-reachability` — clean (340 live components, 0 unreachable, self-test passed)

### Stakes
reversible

### Flags for Reviewer
- `plugins/20.facet-catalog.client.ts:265` still gates builder-card catalog hydration on `path === '/builder'`. This was already fully dead (that route was never reachable), and remains equally dead after this fix — not touched here since it's a separate concern from the nav-destination bug this task scoped. Worth a follow-up if the builder-card catalog hydration is still meant to matter for anything reachable today.

### Kaizen suggestion
`plugins/20.facet-catalog.client.ts`'s `/builder`-gated hydration path is dead code tied to the same retired Builder wizard as `builder-manager.vue` — worth a small follow-up task to either repoint it at a still-live entry point or remove it outright, so a future reader doesn't have to re-derive that it's inert.

### Notes for reviewer
Companion conductor PR closes out `interface-vision/t-107`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015hmaebDakfk2TFGusheL7e)_