### PR TITLE
Retrigger production deploy after ProxySQL recovery

### DIFF
--- a/docs/.vercel-redeploy-20260807
+++ b/docs/.vercel-redeploy-20260807
@@ -1,0 +1,1 @@
+Redeploy trigger for production migration recovery after ProxySQL frontend saturation was cleared on 2026-08-07.


### PR DESCRIPTION
No application behavior changes. This tiny marker exists only to retrigger the production Vercel build now that ProxySQL frontend saturation has been cleared, so the pending `ProjectStatus.CONTINUOUS` migration can run.