### PR TITLE
Force production deploy after ProxySQL recovery

### DIFF
--- a/.vercel-redeploy-20260807
+++ b/.vercel-redeploy-20260807
@@ -1,0 +1,1 @@
+Temporary production redeploy trigger after ProxySQL frontend saturation recovery. Remove after migration verification.

--- a/docs/.vercel-redeploy-20260807
+++ b/docs/.vercel-redeploy-20260807
@@ -1,1 +1,0 @@
-Redeploy trigger for production migration recovery after ProxySQL frontend saturation was cleared on 2026-08-07.


### PR DESCRIPTION
Removes the inert docs-only marker from #1564 and adds a temporary non-ignored root marker so Vercel actually performs a production build. No application behavior changes. Purpose: run the pending `ProjectStatus.CONTINUOUS` migration now that ProxySQL frontend saturation is cleared.