### PR TITLE
Page-sized galleries: demo the shell in the style guide, exempt the carousel

### DIFF
--- a/components/ui/ui-gallery.vue
+++ b/components/ui/ui-gallery.vue
@@ -19,9 +19,7 @@
       automatically per theme and keep components consistent.
 -->
 <template>
-  <div
-    class="kr-gallery h-full min-h-0 overflow-y-auto bg-base-200 text-base-content"
-  >
+  <div class="h-full min-h-0 overflow-y-auto bg-base-200 text-base-content">
     <!-- Header + theme switcher -->
     <header
       class="sticky top-0 z-20 border-b border-base-300 bg-base-100/90 backdrop-blur"
@@ -142,7 +140,8 @@
               <li>
                 <code>.kr-unbound</code>
                 <span class="font-sans opacity-70"
-                  >— root-surface marker, no scroll/height of its own (MDC-mounted pages)</span
+                  >— root-surface marker, no scroll/height of its own
+                  (MDC-mounted pages)</span
                 >
               </li>
               <li>
@@ -336,6 +335,47 @@
       </section>
 
       <!-- Cards -->
+      <section id="gallery" class="scroll-mt-32 kr-section">
+        <SectionHeading
+          title="Gallery"
+          hint="The shared browse shell. Every core object's gallery insets this."
+        />
+
+        <!-- The style guide had `class="kr-gallery"` on its ROOT and no
+             kr-gallery anywhere in it -- a dead class (no CSS rule defines it)
+             that happened to shadow the component name. That is the exact
+             false positive the adoption check shipped with: a substring match
+             counted this page as an adopter while it demonstrated nothing.
+             The class is gone and this is the real thing. -->
+        <kr-gallery
+          :items="demoGalleryItems"
+          :mode="demoGalleryMode"
+          empty-label="specimens"
+          @update:mode="demoGalleryMode = $event"
+        >
+          <template #item="{ item, mode }">
+            <div
+              class="flex flex-col gap-1 rounded-2xl border border-base-300 bg-base-100 p-3"
+            >
+              <span class="text-smart-heading font-black">{{
+                item.title
+              }}</span>
+              <span class="text-smart-compact opacity-70">
+                {{ item.description }}
+              </span>
+              <span class="badge badge-ghost badge-sm w-fit">{{ mode }}</span>
+            </div>
+          </template>
+        </kr-gallery>
+
+        <p class="text-smart-compact mt-2 opacity-70">
+          The Cards / Heroes / Icons bar is the shell's, and it is sticky inside
+          whichever ancestor scrolls. Swap modes above and the grid changes with
+          it -- each mode is a different MODE_GRID_CLASS, container-responsive
+          rather than viewport-keyed.
+        </p>
+      </section>
+
       <section id="cards" class="scroll-mt-32 kr-section">
         <SectionHeading
           title="Cards"
@@ -557,7 +597,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
+import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
+import type { GalleryMode } from '@/utils/galleryVocabulary'
 import { useThemeStore } from '@/stores/themeStore'
 import { daisyuiThemes } from '@/stores/helpers/themeHelper'
 
@@ -570,6 +612,14 @@ function onThemeChange(event: Event) {
   themeStore.setActiveTheme(value)
 }
 
+const demoGalleryMode = ref<GalleryMode>('cards')
+
+const demoGalleryItems: GalleryItem[] = [
+  { id: 1, title: 'Specimen One', description: 'A card-shaped entry.' },
+  { id: 2, title: 'Specimen Two', description: 'Another, for spacing.' },
+  { id: 3, title: 'Specimen Three', description: 'And a third, for wrap.' },
+]
+
 const sections = [
   { id: 'conventions', label: 'Conventions' },
   { id: 'tokens', label: 'Tokens' },
@@ -578,6 +628,7 @@ const sections = [
   { id: 'badges', label: 'Badges' },
   { id: 'alerts', label: 'Alerts' },
   { id: 'callouts', label: 'Callouts' },
+  { id: 'gallery', label: 'Gallery' },
   { id: 'cards', label: 'Cards' },
   { id: 'forms', label: 'Forms' },
   { id: 'nav', label: 'Nav' },

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "test:deploy-wait-noop": "tsx utils/scripts/verifyDeployWaitNoOp.ts",
     "test:no-promise-in-store-state": "tsx utils/scripts/verifyNoPromiseInStoreState.ts",
     "test:ui-tier-vocabulary": "tsx utils/scripts/verifyUiTierVocabulary.ts",
+    "audit:gallery-chrome": "tsx utils/scripts/auditGalleryChrome.ts",
     "test:card-action-contract": "tsx utils/scripts/verifyCardActionContract.ts",
     "test:no-prisma-json-cast": "tsx utils/scripts/verifyNoPrismaJsonCast.ts",
     "test:admin-flag-casts": "tsx utils/scripts/verifyAdminFlagCasts.ts",

--- a/utils/scripts/auditGalleryChrome.ts
+++ b/utils/scripts/auditGalleryChrome.ts
@@ -1,0 +1,257 @@
+// /utils/scripts/auditGalleryChrome.ts
+//
+// How much screen does a gallery spend before showing you anything?
+//
+// WHY THIS EXISTS
+// ---------------
+// Silas, 2026-08-07, with a screenshot of /rewards on a 1366x768 desktop:
+//
+//   "the choose your reward, pick a story reward text, maturity toggle and
+//    search bar, and card hero icons sections should be at most 1-2 rows. This
+//    is taking up a significant amount of real estate ... I feel like this
+//    giant header problem should have been caught now that you can do these
+//    assessments directly."
+//
+// He is right, and the miss is instructive. Every gallery contract in this repo
+// checks STRUCTURE -- does this file mount kr-gallery, does the ratchet shrink,
+// does the card emit `open`. All of them passed while four stacked rows of
+// chrome ate a third of the viewport, because none of them renders anything.
+// Asserting on the source and trusting layout to follow is the same
+// mention-versus-use error the rest of these scripts exist to prevent, moved up
+// one level.
+//
+// So this one opens a real browser and measures pixels: the distance from the
+// top of the scroll container to the top of the first card. That number is the
+// budget, and it is the only one that answers the question actually asked.
+//
+//   npx tsx utils/scripts/auditGalleryChrome.ts --base https://<preview>.vercel.app
+//   npx tsx utils/scripts/auditGalleryChrome.ts --base http://localhost:3000 --strict
+//
+// `--strict` exits 1 when a route exceeds MAX_CHROME_FRACTION of the viewport
+// height. It is deliberately NOT wired into contract-tests.yml: it needs a
+// running deployment, so it belongs to the review step, not the unit gate.
+//
+// DATA IS NOT REQUIRED. The chrome renders whether or not the API answers --
+// the screenshot that prompted this had a database error in the body and the
+// header was still four rows tall. A route that fails to load its records
+// still reports a usable chrome height.
+
+import { chromium, type Browser, type Page } from 'playwright'
+
+/** 1366x768 is the machine Silas reported from; the rest bracket it. */
+export const BREAKPOINTS = [
+  { label: 'phone', width: 390, height: 844 },
+  { label: 'tablet', width: 820, height: 1180 },
+  { label: 'laptop', width: 1366, height: 768 },
+  { label: 'desktop', width: 1920, height: 1080 },
+] as const
+
+export const GALLERY_ROUTES = [
+  '/bots',
+  '/characters',
+  '/dreams',
+  '/facets',
+  '/rewards',
+  '/stories',
+  '/resources',
+  '/servers',
+  '/icons',
+  '/themes',
+  '/achievements',
+] as const
+
+/**
+ * A gallery may spend at most this fraction of the viewport before the first
+ * card. 0.33 is not arbitrary: the reported screenshot measured ~190px of
+ * 550px usable, and Silas called that "a significant amount of real estate".
+ */
+export const MAX_CHROME_FRACTION = 0.33
+
+export type ChromeReading = {
+  route: string
+  breakpoint: string
+  viewportHeight: number
+  chromePx: number | null
+  fraction: number | null
+  /**
+   * Why there is no number. NOT optional and NOT a bare null: the first version
+   * returned `chromePx: null` for both "the page rendered but held no cards"
+   * and "the page never loaded", then printed one dash for each and told the
+   * reader it was probably the API. It was actually ERR_CONNECTION_RESET -- the
+   * measurement had never happened. Same sentinel-versus-empty conflation this
+   * repo warns about in stores; a failure that reads as a legitimate empty is
+   * worse than a crash.
+   */
+  status: 'measured' | 'no-cards' | 'load-failed'
+  note?: string
+}
+
+/**
+ * Pixels above the first card, measured from the top of the page.
+ *
+ * Runs in the browser: finds the first element the shared shell emitted a card
+ * into, and returns its distance from the viewport top. Deliberately measures
+ * the RENDERED box rather than counting DOM rows -- a wrapped toolbar is one
+ * row on a wide screen and three on a phone, which is exactly the thing a
+ * source-level check cannot see.
+ */
+export async function measureChrome(page: Page): Promise<number | null> {
+  return page.evaluate(() => {
+    const candidates = [
+      '[data-kr-gallery-item]',
+      '.kr-gallery-grid > *',
+      'article',
+      '.card',
+    ]
+    for (const selector of candidates) {
+      const el = document.querySelector(selector)
+      if (!el) continue
+      const box = el.getBoundingClientRect()
+      if (box.height > 40) return Math.round(box.top)
+    }
+    return null
+  })
+}
+
+export async function auditRoute(
+  browser: Browser,
+  base: string,
+  route: string,
+): Promise<ChromeReading[]> {
+  const readings: ChromeReading[] = []
+  for (const bp of BREAKPOINTS) {
+    const page = await browser.newPage({
+      viewport: { width: bp.width, height: bp.height },
+    })
+    let chromePx: number | null = null
+    let loadError: string | null = null
+    try {
+      await page.goto(`${base}${route}`, {
+        waitUntil: 'domcontentloaded',
+        timeout: 45_000,
+      })
+      // Cards arrive after hydration + fetch; the chrome does not.
+      await page.waitForTimeout(2_500)
+      chromePx = await measureChrome(page)
+    } catch (error) {
+      loadError =
+        (error instanceof Error ? error.message.split('\n')[0] : null) ??
+        'load failed'
+    } finally {
+      await page.close()
+    }
+
+    /*
+     * Derived, not assigned in branches. The three outcomes are distinct and
+     * `loadError` is the only thing that separates a page that never arrived
+     * from one that arrived empty -- which is the whole point of this type.
+     */
+    const status: ChromeReading['status'] = loadError
+      ? 'load-failed'
+      : chromePx === null
+        ? 'no-cards'
+        : 'measured'
+    const note =
+      loadError ??
+      (chromePx === null ? 'page loaded, but rendered no cards' : undefined)
+    readings.push({
+      route,
+      breakpoint: bp.label,
+      viewportHeight: bp.height,
+      chromePx,
+      fraction: chromePx === null ? null : chromePx / bp.height,
+      status,
+      note,
+    })
+  }
+  return readings
+}
+
+/* -------------------------------------------------------------------------- */
+
+const args = process.argv.slice(2)
+const base = args[args.indexOf('--base') + 1]
+const strict = args.includes('--strict')
+
+if (!base || base.startsWith('--')) {
+  console.error(
+    'Usage: npx tsx utils/scripts/auditGalleryChrome.ts --base <url> [--strict]',
+  )
+  process.exit(2)
+}
+
+const only = args.includes('--route')
+  ? [args[args.indexOf('--route') + 1]!]
+  : null
+const routes = only ?? [...GALLERY_ROUTES]
+
+/*
+ * CHROMIUM_PATH lets a runner point at a browser it already has. This
+ * environment ships one at /opt/pw-browsers and sets
+ * PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD, but the pinned playwright expects a
+ * different revision directory and asks for `npx playwright install` -- which
+ * would pull ~150MB to re-download a browser already on disk.
+ */
+const executablePath = process.env.CHROMIUM_PATH || undefined
+const browser = await chromium.launch(executablePath ? { executablePath } : {})
+const all: ChromeReading[] = []
+for (const route of routes) {
+  all.push(...(await auditRoute(browser, base, route)))
+}
+await browser.close()
+
+console.log(`\nGallery chrome — pixels above the first card, ${base}\n`)
+console.log(
+  `${'route'.padEnd(14)}${BREAKPOINTS.map((b) => `${b.label} (${b.width})`.padEnd(16)).join('')}`,
+)
+const over: ChromeReading[] = []
+for (const route of routes) {
+  const row = all.filter((r) => r.route === route)
+  const cells = row.map((r) => {
+    if (r.chromePx === null) return '—'.padEnd(16)
+    const pct = Math.round((r.fraction ?? 0) * 100)
+    if ((r.fraction ?? 0) > MAX_CHROME_FRACTION) over.push(r)
+    return `${r.chromePx}px (${pct}%)`.padEnd(16)
+  })
+  console.log(`${route.padEnd(14)}${cells.join('')}`)
+}
+
+const failed = all.filter((r) => r.status === 'load-failed')
+const empty = all.filter((r) => r.status === 'no-cards')
+
+if (failed.length) {
+  console.error(
+    `\n${failed.length} reading(s) NEVER LOADED — nothing was measured:\n`,
+  )
+  for (const r of [...new Map(failed.map((r) => [r.note, r])).values()]) {
+    console.error(`  ${r.note}`)
+  }
+  console.error(
+    `\nThis is not a layout result. Run it from somewhere the browser can reach\n` +
+      `the deployment -- a sandbox may allow curl and still reset Chromium.`,
+  )
+  process.exitCode = 1
+}
+
+if (empty.length) {
+  console.log(
+    `\n${empty.length} reading(s) loaded but held no cards — the API, not the layout.`,
+  )
+}
+
+if (over.length) {
+  console.error(
+    `\n${over.length} reading(s) spend more than ${Math.round(MAX_CHROME_FRACTION * 100)}%` +
+      ` of the viewport on chrome:\n`,
+  )
+  for (const r of over) {
+    console.error(
+      `  ${r.route} @ ${r.breakpoint}: ${r.chromePx}px of ${r.viewportHeight}px`,
+    )
+  }
+  if (strict) process.exitCode = 1
+} else if (!failed.length && !empty.length) {
+  console.log(
+    `\nEvery gallery keeps its chrome under ${Math.round(MAX_CHROME_FRACTION * 100)}% of the viewport.`,
+  )
+}

--- a/utils/scripts/lint-ratchet-baseline.json
+++ b/utils/scripts/lint-ratchet-baseline.json
@@ -1,7 +1,7 @@
 {
   "note": "ESLint RATCHET: this file may only ever shrink. --update refuses to record a larger count. See utils/scripts/verifyLintRatchet.ts.",
   "recorded": "2026-08-07",
-  "total": 393,
+  "total": 392,
   "violations": {
     "vue/v-on-event-hyphenation": [
       "app.vue:37:22"
@@ -305,9 +305,9 @@
       "components/bots/add-bot.vue:688:51"
     ],
     "@typescript-eslint/unified-signatures": [
-      "components/dreams/dream-gallery.vue:490:4",
-      "components/dreams/dream-gallery.vue:491:4",
-      "components/dreams/dream-gallery.vue:491:4",
+      "components/dreams/dream-gallery.vue:501:4",
+      "components/dreams/dream-gallery.vue:502:4",
+      "components/dreams/dream-gallery.vue:502:4",
       "components/dreams/dream-list.vue:231:4",
       "components/dreams/dream-list.vue:232:4",
       "components/dreams/dream-list.vue:232:4",
@@ -428,8 +428,7 @@
       "utils/scripts/cypress-fast-fix.mjs:52:5",
       "utils/scripts/cypress-fast-fix.mjs:66:5",
       "utils/scripts/cypress-fast-repair.mjs:45:5",
-      "utils/scripts/cypress-fast-repair.mjs:59:5",
-      "utils/scripts/verifyConductorProjectRegistry.ts:77:41"
+      "utils/scripts/cypress-fast-repair.mjs:59:5"
     ],
     "(parse error)": [
       "server/api/reactions/index.post.ts:239:3"

--- a/utils/scripts/route-gallery-baseline.json
+++ b/utils/scripts/route-gallery-baseline.json
@@ -1,11 +1,9 @@
 {
   "note": "Route gallery RATCHET: this file may only ever shrink. --update refuses to record a larger count. See utils/scripts/verifyRouteGalleryContract.ts.",
   "recorded": "2026-08-07",
-  "total": 3,
+  "total": 1,
   "holdouts": {
-    "art-gallery": ["/art", "/artjob"],
-    "daily-digest-object-gallery": ["/for-you"],
-    "ui-gallery": ["/ui"]
+    "art-gallery": ["/art", "/artjob"]
   },
   "shadowTotal": 0,
   "shadows": {},

--- a/utils/scripts/verifyRouteGalleryContract.ts
+++ b/utils/scripts/verifyRouteGalleryContract.ts
@@ -331,6 +331,15 @@ const isGalleryComponent = (name: string): boolean =>
  * must be wrong to adopt -- not merely awkward.
  */
 export const NOT_GALLERIES: Record<string, string> = {
+  'daily-digest-object-gallery':
+    'A snap CAROUSEL, not a browse grid. On narrow screens it is ' +
+    '`flex snap-x snap-mandatory overflow-x-auto overscroll-x-contain` with ' +
+    'min-w-40 items -- you swipe it sideways -- and it only becomes a grid at ' +
+    '`lg`. kr-gallery has no carousel mode and adding one would repeat the ' +
+    'mistake `list` was removed for: a mode whose identity is a layout rather ' +
+    'than an image. Adopting would silently replace a deliberate horizontal ' +
+    'swipe with a vertical stack on every phone. It is a digest strip of at ' +
+    'most six items, not a surface anyone browses.',
   'chat-gallery':
     'An inbox and a transcript, not a browse surface. Its thread rows are ' +
     '`flex w-full` -- a 48px avatar plus name, title, preview and timestamp -- ' +


### PR DESCRIPTION
Two of the three page-sized holdouts. `art-gallery` (1,653) stays for its own pass.

## ui-gallery now demonstrates what it documents

It carried `class="kr-gallery"` on its **root** and mounted no kr-gallery anywhere — and **no CSS rule defines that class**, in this file or any other. A dead class that happened to shadow the component name.

That's precisely the false positive the original adoption check shipped with: a substring match counted the style guide as an adopter while it demonstrated nothing. The class is deleted, and a real Gallery section added with a live mode bar, wired into the jump nav beside Cards.

## daily-digest-object-gallery is a carousel

On narrow screens it's `flex snap-x snap-mandatory overflow-x-auto` with `min-w-40` items — you swipe it sideways — and only becomes a grid at `lg`. kr-gallery has no carousel mode, and adding one would repeat the mistake `list` was removed for.

Adopting would silently replace a deliberate horizontal swipe with a vertical stack on every phone. Joins `NOT_GALLERIES` with the reason recorded.

## The assessment, as a script

Your point stands. Every gallery contract here checks **structure** — does the file mount kr-gallery, does the ratchet shrink, does the card emit `open` — and all of them passed while four stacked rows ate a third of the viewport, because none of them renders anything. Asserting on source and trusting layout to follow is the same mention-versus-use error these scripts exist to prevent, moved up one level.

`auditGalleryChrome.ts` opens a real browser at four breakpoints (390 / 820 / 1366 / 1920) and measures the pixels above the first card, failing over `MAX_CHROME_FRACTION`. Not wired into `contract-tests.yml` — it needs a running deployment, so it belongs to review, not the unit gate.

## I could not run it here, and the first version lied about why

It reported `chromePx: null` for **both** "loaded but held no cards" and "never loaded at all", printed one dash for each, and told the reader it was probably the API.

It was `ERR_CONNECTION_RESET`. This sandbox permits `curl` to the deployment (200) but resets Chromium, so no measurement ever happened. Exactly the sentinel-versus-empty conflation the store conventions warn about — and a failure that reads as a legitimate empty is worse than a crash.

The three outcomes are now distinct, **derived** rather than assigned in branches, and a load failure exits non-zero and says so.

**So the visual pass is still owed, and now has a tool:**

```
npm run audit:gallery-chrome -- --base <preview-url> --strict
```

run from somewhere with browser egress.

## Verification

- `vue-tsc` exit 0
- lint ratchet **393 → 392**
- every `npm run test:*` step plus the strict WonderLab preview audit

**One holdout left: `art-gallery`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_