### PR TITLE
audit:responsive: cover the 11 reachable 'home' channel routes

### DIFF
--- a/utils/scripts/auditResponsiveLayout.mjs
+++ b/utils/scripts/auditResponsiveLayout.mjs
@@ -48,7 +48,13 @@ const flag = (name, fallback) => {
 const BASE = flag('base', process.env.AUDIT_BASE || 'http://127.0.0.1:3000')
 const ROUTES = flag(
   'routes',
-  '/,/conductor,/dreams,/art,/bots,/characters,/rewards,/stories',
+  // interface-vision/t-103: growing this list toward the t-102 inventory's
+  // full 51-route gap, in scoped slices. This slice adds the 11 reachable,
+  // non-admin `channelKey: home` routes -- the first bucket from that
+  // inventory's "Gaps" section. Track progress in
+  // projects/interface-vision/docs/t-102-reachable-surface-inventory.md.
+  '/,/conductor,/dreams,/art,/bots,/characters,/rewards,/stories,' +
+    '/account,/achievements,/chats,/dashboard,/for-you,/friends,/messages,/navigation,/register,/themes,/wallet',
 )
   .split(',')
   .map((r) => r.trim())


### PR DESCRIPTION
### Task
interface-vision/t-103: Drive Phase 1 responsive/functionality findings to zero (kind: software) — first slice.

### What changed / what I produced
- `utils/scripts/auditResponsiveLayout.mjs`: default `--routes` list now also covers the 11 reachable, non-admin `channelKey: home` routes identified in the t-102 inventory: `/account`, `/achievements`, `/chats`, `/dashboard`, `/for-you`, `/friends`, `/messages`, `/navigation`, `/register`, `/themes`, `/wallet`.

### How I verified
- `node --check utils/scripts/auditResponsiveLayout.mjs` — valid syntax
- `npx eslint utils/scripts/auditResponsiveLayout.mjs` — clean
- Confirmed only 4 of these (account, friends, messages, wallet) carry `requiredPermission: authenticated` in their content frontmatter, so most of this slice measures the real page rather than a login wall — and even the gated ones measure real geometry a guest visitor actually encounters.
- Will watch this PR's own `audit` CI check (responsive-layout-audit against this PR's Vercel preview) for real findings — this PR is purely the route-list widening; any geometry defects it surfaces become their own scoped follow-up tasks per t-103's note ("split findings into dedicated tasks when they are larger than one PR").

### Stakes
reversible

### Flags for Reviewer
- This PR intentionally does not fix anything by itself — it only widens CI coverage. If the `audit` check comes back red, that is signal to act on (via a follow-up task), not a reason to block merging this widening.

### Kaizen suggestion
None new this cycle.

### Notes for reviewer
Companion conductor task interface-vision/t-103 stays open (umbrella sweep) after this slice — 40 gap routes remain.

---
_Generated by [Claude Code](https://claude.ai/code/session_015hmaebDakfk2TFGusheL7e)_