### PR TITLE
Remove temporary Vercel redeploy trigger

### DIFF
--- a/.vercel-redeploy-20260807
+++ b/.vercel-redeploy-20260807
@@ -1,1 +1,0 @@
-Temporary production redeploy trigger after ProxySQL frontend saturation recovery. Remove after migration verification.


### PR DESCRIPTION
Cleanup after the successful ProxySQL recovery redeploy. Removes only the temporary `.vercel-redeploy-20260807` root marker. No application behavior changes.