### PR TITLE
audit workflow: bump timeout 20m -> 35m for the growing route list

### DIFF
--- a/.github/workflows/responsive-layout-audit.yml
+++ b/.github/workflows/responsive-layout-audit.yml
@@ -62,7 +62,15 @@ jobs:
       github.event_name != 'deployment_status' ||
       github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # interface-vision/t-103 grows the default --routes list in scoped slices
+    # as the phase-1 shrink-to-zero sweep proceeds. 20min covered the original
+    # 8 routes x 3 viewports; the first slice (19 routes, kind_robots #1567)
+    # already ran the job to ~20:18, right past that ceiling, and got
+    # cancelled mid-run rather than reporting a real result. 35min gives
+    # headroom for several more slices at this per-measurement rate (~21s);
+    # if the full 51-route gap ever lands in this one list, revisit with a
+    # matrix split instead of raising this again.
+    timeout-minutes: 35
 
     steps:
       - name: Checkout


### PR DESCRIPTION
### Task
interface-vision/t-103 follow-up: kind_robots #1567 (already merged) widened `auditResponsiveLayout.mjs`'s default `--routes` list from 8 to 19 routes, but its own CI `audit` run got cancelled mid-way — the job hit the workflow's prior 20-minute ceiling at ~20:18 rather than completing with a real pass/fail. This PR only fixes the timeout; it does not change what gets audited.

### What changed / what I produced
- `.github/workflows/responsive-layout-audit.yml`: `timeout-minutes: 20` -> `35`.

### How I verified
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/responsive-layout-audit.yml'))"` — valid YAML
- Math check against the cancelled run's own timing (kind_robots run 31177028472): 19 routes × 3 viewports ≈ 21s/measurement observed, ~1220s (~20.3min) total — 35min gives real headroom for this slice and several more before the ceiling needs revisiting again.

### Stakes
reversible

### Flags for Reviewer
- That same cancelled run did get far enough to surface one real finding worth a look — filed as `interface-vision/t-108` (a BROKEN-ART hit on `/navigation`, shared image path across a few site-directory cards) — not part of this PR's scope.

### Kaizen suggestion
If the umbrella sweep (t-103) eventually lands the full 51-route gap in this one list, this timeout will need raising again (or the job restructured as a matrix split across routes/viewports) rather than repeating this fix — worth deciding proactively once slices get much larger.

### Notes for reviewer

---
_Generated by [Claude Code](https://claude.ai/code/session_015hmaebDakfk2TFGusheL7e)_