### PR TITLE
audit:responsive: cover 8 reachable plan-channel public tool routes (t-103 slice 2)

### DIFF
--- a/utils/scripts/auditResponsiveLayout.mjs
+++ b/utils/scripts/auditResponsiveLayout.mjs
@@ -49,12 +49,15 @@ const BASE = flag('base', process.env.AUDIT_BASE || 'http://127.0.0.1:3000')
 const ROUTES = flag(
   'routes',
   // interface-vision/t-103: growing this list toward the t-102 inventory's
-  // full 51-route gap, in scoped slices. This slice adds the 11 reachable,
-  // non-admin `channelKey: home` routes -- the first bucket from that
-  // inventory's "Gaps" section. Track progress in
-  // projects/interface-vision/docs/t-102-reachable-surface-inventory.md.
+  // full 51-route gap, in scoped slices. Slice 1 added the 11 reachable,
+  // non-admin `channelKey: home` routes. Slice 2 adds 8 of the `channelKey:
+  // plan` public tool pages (no auth gate) -- appmaker, brainstorm, coloring,
+  // model-builder, packs, stylist, wishmaster, conductor-app. The remaining
+  // `/plan/*`-prefixed plan-channel routes are left for a later slice. Track
+  // progress in projects/interface-vision/docs/t-102-reachable-surface-inventory.md.
   '/,/conductor,/dreams,/art,/bots,/characters,/rewards,/stories,' +
-    '/account,/achievements,/chats,/dashboard,/for-you,/friends,/messages,/navigation,/register,/themes,/wallet',
+    '/account,/achievements,/chats,/dashboard,/for-you,/friends,/messages,/navigation,/register,/themes,/wallet,' +
+    '/appmaker,/brainstorm,/coloring,/model-builder,/packs,/stylist,/wishmaster,/conductor-app',
 )
   .split(',')
   .map((r) => r.trim())


### PR DESCRIPTION
### Task
interface-vision/t-103 (kind: software): Drive Phase 1 responsive/functionality findings to zero — slice 2

### What changed / what I produced
- Added 8 routes to `auditResponsiveLayout.mjs`'s default `--routes` list: `/appmaker`, `/brainstorm`, `/coloring`, `/model-builder`, `/packs`, `/stylist`, `/wishmaster`, `/conductor-app`.
- These are all public, non-admin, `channelKey: plan` tool pages, nav-reachable via the plan channel dropdown, per the `t-102` reachable-surface inventory's "Gaps" section (`projects/interface-vision/docs/t-102-reachable-surface-inventory.md`).
- Coverage moves from 19/59 to 27/59 reachable surfaces.
- Remaining `/plan/*`-prefixed plan-channel routes (`/plan/newsfeed`, `/plan/voice-lab`, `/plan/watchlist`, `/plan/wonderlab`, `/plan/projects/*`) are left for a future slice, consistent with the umbrella task's scoped-slice approach.

### How I verified
- Confirmed each of the 8 routes has both a `content/channels/plan/*.md` config entry with a matching `route:` field and a corresponding `content/*.md` page file that renders it (all 8 present).
- The `responsive-layout-audit.yml` CI check (`audit`) runs against the PR's Vercel preview and measures real geometry at phone/tablet/desktop widths — will confirm before merging.

### Stakes
reversible

### Flags for Reviewer
- None — straightforward, scoped continuation of the same slice pattern as #1567.

### Kaizen suggestion
Once all plan-channel gaps are covered, the next natural slice is the `play`-channel gap bucket (`/academy`, `/facets`, `/resources`, `/serendipity`, `/stories`, `/storybook`, `/taskmaster`) per the same inventory doc.

### Notes for reviewer
Companion conductor PR sets `interface-vision/t-103` to `status: review` and will close it out to `ready` (re-arming the umbrella task with updated progress notes) once this merges and the audit check is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdgCvWwHFhcjnZT5UHjS8b)_