### PR TITLE
audit:responsive: cover play-channel + /play/* subdir routes (t-103 slice 3)

### DIFF
--- a/utils/scripts/auditResponsiveLayout.mjs
+++ b/utils/scripts/auditResponsiveLayout.mjs
@@ -50,14 +50,22 @@ const ROUTES = flag(
   'routes',
   // interface-vision/t-103: growing this list toward the t-102 inventory's
   // full 51-route gap, in scoped slices. Slice 1 added the 11 reachable,
-  // non-admin `channelKey: home` routes. Slice 2 adds 8 of the `channelKey:
+  // non-admin `channelKey: home` routes. Slice 2 added 8 of the `channelKey:
   // plan` public tool pages (no auth gate) -- appmaker, brainstorm, coloring,
-  // model-builder, packs, stylist, wishmaster, conductor-app. The remaining
-  // `/plan/*`-prefixed plan-channel routes are left for a later slice. Track
-  // progress in projects/interface-vision/docs/t-102-reachable-surface-inventory.md.
+  // model-builder, packs, stylist, wishmaster, conductor-app. Slice 3 covers
+  // the `channelKey: play` bucket plus the sibling `content/play/*` subdir
+  // routes -- academy, facets, resources (shadowed by pages/resources.vue,
+  // which is the page actually rendered at this path), serendipity,
+  // storybook, taskmaster, and /play/challenges, /play/davinci, /play/memory,
+  // /play/screenfx. None of these set requiredPermission -- all public. The
+  // remaining `/plan/*`-prefixed and `/build/*` routes are left for a later
+  // slice. Track progress in
+  // projects/interface-vision/docs/t-102-reachable-surface-inventory.md.
   '/,/conductor,/dreams,/art,/bots,/characters,/rewards,/stories,' +
     '/account,/achievements,/chats,/dashboard,/for-you,/friends,/messages,/navigation,/register,/themes,/wallet,' +
-    '/appmaker,/brainstorm,/coloring,/model-builder,/packs,/stylist,/wishmaster,/conductor-app',
+    '/appmaker,/brainstorm,/coloring,/model-builder,/packs,/stylist,/wishmaster,/conductor-app,' +
+    '/academy,/facets,/resources,/serendipity,/storybook,/taskmaster,' +
+    '/play/challenges,/play/davinci,/play/memory,/play/screenfx',
 )
   .split(',')
   .map((r) => r.trim())


### PR DESCRIPTION
Stage 3 of interface-vision/t-103's responsive-audit coverage ratchet: adds the `channelKey: play` bucket plus its sibling `content/play/*` subdir routes.

**Routes added (10):** `/academy`, `/facets`, `/resources`, `/serendipity`, `/storybook`, `/taskmaster` (all `channelKey: play`, none `requiredPermission`-gated), plus `/play/challenges`, `/play/davinci`, `/play/memory`, `/play/screenfx`.

**Coverage: 27/59 → 37/59** per the t-102 gap inventory (`projects/interface-vision/docs/t-102-reachable-surface-inventory.md` in `conductor`).

## Notes

- `/resources` is shadowed: `content/resources.md` never renders because `pages/resources.vue` wins on Nuxt's routing precedence for an exact literal path. The audit measures `pages/resources.vue`, which is the page that actually renders at this path — same reasoning the t-102 inventory already used.
- `/play/challenges` is a plain content-rendered route (`content/play/challenges.md`); `pages/play/challenges/[slug].vue` and `pages/play/challenges/leaderboard.vue` are separate sub-paths and don't shadow it.
- Verified every route's source frontmatter has no `requiredPermission` before adding — all six `play`-channel pages and all four `content/play/*` files checked directly, not assumed.
- The remaining `/plan/*`-prefixed and `/build/*` gap routes are left for a later slice.

## Verification

- `node --check` on the edited script: clean.
- `npx eslint utils/scripts/auditResponsiveLayout.mjs`: clean.
- This is a route-list-only change (comment + string data), no logic touched.
- Will wait for the `responsive-layout-audit` (`audit`) check to go green before merging — it's the check that actually measures the new routes' geometry, not just structural CI.

Part of interface-vision/t-103 (see `conductor` repo's `projects/interface-vision/roadmap.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsAXAv535jAym8EugZWVEe)_