### PR TITLE
audit:responsive: cover plan/build-channel content routes (t-103 slice 4)

### DIFF
--- a/utils/scripts/auditResponsiveLayout.mjs
+++ b/utils/scripts/auditResponsiveLayout.mjs
@@ -57,15 +57,23 @@ const ROUTES = flag(
   // routes -- academy, facets, resources (shadowed by pages/resources.vue,
   // which is the page actually rendered at this path), serendipity,
   // storybook, taskmaster, and /play/challenges, /play/davinci, /play/memory,
-  // /play/screenfx. None of these set requiredPermission -- all public. The
-  // remaining `/plan/*`-prefixed and `/build/*` routes are left for a later
-  // slice. Track progress in
+  // /play/screenfx. Slice 4 covers the remaining `content/plan/*` pages --
+  // newsfeed, voice-lab, watchlist, wonderlab, and the plan/projects/* case
+  // studies (coat-dance, humboldt-scoop, ruler-hooked, sketchy) -- plus the
+  // sibling `content/build/*` routes (animation-manager, hair-studio, mural),
+  // all resolved through pages/[...slug].vue by content path. None of these
+  // set requiredPermission -- all public. The sanctuary channel bucket and
+  // the no-channelKey /forum, /servers routes are left for a later slice.
+  // Track progress in
   // projects/interface-vision/docs/t-102-reachable-surface-inventory.md.
   '/,/conductor,/dreams,/art,/bots,/characters,/rewards,/stories,' +
     '/account,/achievements,/chats,/dashboard,/for-you,/friends,/messages,/navigation,/register,/themes,/wallet,' +
     '/appmaker,/brainstorm,/coloring,/model-builder,/packs,/stylist,/wishmaster,/conductor-app,' +
     '/academy,/facets,/resources,/serendipity,/storybook,/taskmaster,' +
-    '/play/challenges,/play/davinci,/play/memory,/play/screenfx',
+    '/play/challenges,/play/davinci,/play/memory,/play/screenfx,' +
+    '/plan/newsfeed,/plan/voice-lab,/plan/watchlist,/plan/wonderlab,' +
+    '/plan/projects/coat-dance,/plan/projects/humboldt-scoop,/plan/projects/ruler-hooked,/plan/projects/sketchy,' +
+    '/build/animation-manager,/build/hair-studio,/build/mural',
 )
   .split(',')
   .map((r) => r.trim())


### PR DESCRIPTION
Stage 4 of the interface-vision/t-103 responsive-coverage sweep (slices 1-3: #1567, #1570, #1572).

Adds the remaining `content/plan/*` pages -- `newsfeed`, `voice-lab`, `watchlist`, `wonderlab`, and the `plan/projects/*` case studies (`coat-dance`, `humboldt-scoop`, `ruler-hooked`, `sketchy`) -- plus the sibling `content/build/*` routes (`animation-manager`, `hair-studio`, `mural`) to `auditResponsiveLayout.mjs`'s default `--routes` coverage.

All 11 routes resolve through `pages/[...slug].vue` by content path (verified against the actual `content/plan/*.md` / `content/build/*.md` frontmatter) and none set `requiredPermission` -- all public.

Coverage per the t-102 inventory (`projects/interface-vision/docs/t-102-reachable-surface-inventory.md`): **37/59 → 48/59**.

Remaining gap for a later slice: the sanctuary channel bucket (`/about`, `/cart`, `/giving`, `/mermaids`, `/privacy`, `/sanctuary`) and the no-channelKey routes (`/forum`, `/servers`).

## Verification

- `node --check` clean
- `eslint` clean
- `prettier --check` clean
- Pure route-list/comment change to the audit script itself, same shape as slice 3 (#1572) -- no app code touched, so no responsive-layout-audit run is required before merge (per slice 3's precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5JqqGPeUAxBwyVRWsEVJH)_