### PR TITLE
audit:responsive: cover sanctuary-channel + no-channelKey content routes (t-103 slice 5)

### DIFF
--- a/utils/scripts/auditResponsiveLayout.mjs
+++ b/utils/scripts/auditResponsiveLayout.mjs
@@ -61,10 +61,14 @@ const ROUTES = flag(
   // newsfeed, voice-lab, watchlist, wonderlab, and the plan/projects/* case
   // studies (coat-dance, humboldt-scoop, ruler-hooked, sketchy) -- plus the
   // sibling `content/build/*` routes (animation-manager, hair-studio, mural),
-  // all resolved through pages/[...slug].vue by content path. None of these
-  // set requiredPermission -- all public. The sanctuary channel bucket and
-  // the no-channelKey /forum, /servers routes are left for a later slice.
-  // Track progress in
+  // all resolved through pages/[...slug].vue by content path. Slice 5 covers
+  // the `channelKey: sanctuary` bucket (about, cart, giving, mermaids,
+  // privacy, sanctuary itself) plus the two no-channelKey top-level content
+  // routes /forum and /servers. None of these set requiredPermission -- all
+  // public. Remaining gap: the static pages (/auth/google, /build-bench,
+  // /coloring-page, /music-mentor, /play/challenges/leaderboard,
+  // /play/video-generator) and the dynamic-path representatives (/users/1,
+  // /play/challenges/<slug>). Track progress in
   // projects/interface-vision/docs/t-102-reachable-surface-inventory.md.
   '/,/conductor,/dreams,/art,/bots,/characters,/rewards,/stories,' +
     '/account,/achievements,/chats,/dashboard,/for-you,/friends,/messages,/navigation,/register,/themes,/wallet,' +
@@ -73,7 +77,8 @@ const ROUTES = flag(
     '/play/challenges,/play/davinci,/play/memory,/play/screenfx,' +
     '/plan/newsfeed,/plan/voice-lab,/plan/watchlist,/plan/wonderlab,' +
     '/plan/projects/coat-dance,/plan/projects/humboldt-scoop,/plan/projects/ruler-hooked,/plan/projects/sketchy,' +
-    '/build/animation-manager,/build/hair-studio,/build/mural',
+    '/build/animation-manager,/build/hair-studio,/build/mural,' +
+    '/about,/cart,/giving,/mermaids,/privacy,/sanctuary,/forum,/servers',
 )
   .split(',')
   .map((r) => r.trim())


### PR DESCRIPTION
Stage 5 of the interface-vision/t-103 responsive-coverage sweep (slices 1-4: #1567, #1570, #1572, #1573).

Adds the `channelKey: sanctuary` bucket (`about`, `cart`, `giving`, `mermaids`, `privacy`, `sanctuary` itself) plus the two no-channelKey top-level content routes `/forum` and `/servers` to `auditResponsiveLayout.mjs`'s default `--routes` coverage.

All 8 routes resolve through `pages/[...slug].vue` by content path (verified against the actual `content/channels/sanctuary/*.md` / `content/forum.md` / `content/servers.md` frontmatter) and none set `requiredPermission` -- all public.

Coverage per the t-102 inventory (`projects/interface-vision/docs/t-102-reachable-surface-inventory.md`): **48/59 → 56/59**.

Remaining gap for a later slice: the static pages (`/auth/google`, `/build-bench`, `/coloring-page`, `/music-mentor`, `/play/challenges/leaderboard`, `/play/video-generator`) and the dynamic-path representatives (`/users/1`, `/play/challenges/<slug>`).

## Verification

- `node --check` clean
- `eslint` clean
- `prettier --check` clean
- Pure route-list/comment change to the audit script itself, same shape as slices 3-4 -- no app code touched, so no responsive-layout-audit run is required before merge (per prior slices' precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5JqqGPeUAxBwyVRWsEVJH)_