### PR TITLE
audit:responsive: cover static + dynamic route representatives (t-103 slice 6)

### DIFF
--- a/.github/workflows/responsive-layout-audit.yml
+++ b/.github/workflows/responsive-layout-audit.yml
@@ -66,11 +66,23 @@ jobs:
     # as the phase-1 shrink-to-zero sweep proceeds. 20min covered the original
     # 8 routes x 3 viewports; the first slice (19 routes, kind_robots #1567)
     # already ran the job to ~20:18, right past that ceiling, and got
-    # cancelled mid-run rather than reporting a real result. 35min gives
-    # headroom for several more slices at this per-measurement rate (~21s);
-    # if the full 51-route gap ever lands in this one list, revisit with a
-    # matrix split instead of raising this again.
-    timeout-minutes: 35
+    # cancelled mid-run rather than reporting a real result. 35min covered
+    # slices 2-5. Slice 6 (kind_robots #1575) landed the full 64-route list --
+    # the "if the full gap ever lands" case this comment used to warn about --
+    # and 35min was not enough: measured run 31203187021 got cancelled at
+    # desktop/register, 149 of 192 route/viewport checks in, ~13.5s/check
+    # average. That rate projects the full run to ~44min including ~1.5min
+    # setup. Bumped to 60min for headroom rather than attempting a matrix
+    # split here: a route-viewport split is easy (any subset of --routes),
+    # but a *viewport* split is not, because
+    # verifyGalleryConsistency-equivalent cross-viewport backdrop check below
+    # (search "PER-BREAKPOINT BACKDROPS") requires all 3 viewports for a
+    # route in the SAME process to fire at all -- silently disabling it is a
+    # real regression risk, not a free parallelization win. If a future slice
+    # needs to grow this further, split the matrix by ROUTES (each shard runs
+    # all 3 viewports for its subset, preserving the per-route cross-viewport
+    # check), not by viewport.
+    timeout-minutes: 60
 
     steps:
       - name: Checkout

--- a/utils/scripts/auditResponsiveLayout.mjs
+++ b/utils/scripts/auditResponsiveLayout.mjs
@@ -64,11 +64,15 @@ const ROUTES = flag(
   // all resolved through pages/[...slug].vue by content path. Slice 5 covers
   // the `channelKey: sanctuary` bucket (about, cart, giving, mermaids,
   // privacy, sanctuary itself) plus the two no-channelKey top-level content
-  // routes /forum and /servers. None of these set requiredPermission -- all
-  // public. Remaining gap: the static pages (/auth/google, /build-bench,
-  // /coloring-page, /music-mentor, /play/challenges/leaderboard,
-  // /play/video-generator) and the dynamic-path representatives (/users/1,
-  // /play/challenges/<slug>). Track progress in
+  // routes /forum and /servers. Slice 6 covers the last gap from the t-102
+  // inventory: the 6 static `pages/**/*.vue` routes not yet audited
+  // (/auth/google, /build-bench, /coloring-page, /music-mentor,
+  // /play/challenges/leaderboard, /play/video-generator) plus one
+  // representative path each for the 2 dynamic route patterns (/users/[id],
+  // /play/challenges/[slug]) -- /users/1 and
+  // /play/challenges/neon-ramen-bar-icon, per the inventory's own chosen
+  // examples. None of these set requiredPermission -- all public. This
+  // closes the t-102 inventory's full non-admin, nav-linked gap list. See
   // projects/interface-vision/docs/t-102-reachable-surface-inventory.md.
   '/,/conductor,/dreams,/art,/bots,/characters,/rewards,/stories,' +
     '/account,/achievements,/chats,/dashboard,/for-you,/friends,/messages,/navigation,/register,/themes,/wallet,' +
@@ -78,7 +82,9 @@ const ROUTES = flag(
     '/plan/newsfeed,/plan/voice-lab,/plan/watchlist,/plan/wonderlab,' +
     '/plan/projects/coat-dance,/plan/projects/humboldt-scoop,/plan/projects/ruler-hooked,/plan/projects/sketchy,' +
     '/build/animation-manager,/build/hair-studio,/build/mural,' +
-    '/about,/cart,/giving,/mermaids,/privacy,/sanctuary,/forum,/servers',
+    '/about,/cart,/giving,/mermaids,/privacy,/sanctuary,/forum,/servers,' +
+    '/auth/google,/build-bench,/coloring-page,/music-mentor,/play/challenges/leaderboard,/play/video-generator,' +
+    '/users/1,/play/challenges/neon-ramen-bar-icon',
 )
   .split(',')
   .map((r) => r.trim())


### PR DESCRIPTION
### Task
interface-vision/t-103: Drive Phase 1 responsive/functionality findings to zero — slice 6 (kind: software)

### What changed / what I produced
- Added the last 8 routes from the t-102 reachable-surface inventory's gap list to `auditResponsiveLayout.mjs`'s default `ROUTES` coverage:
  - 6 static `pages/**/*.vue` routes: `/auth/google`, `/build-bench`, `/coloring-page`, `/music-mentor`, `/play/challenges/leaderboard`, `/play/video-generator`
  - 2 dynamic-route representatives (one path each, per the inventory's own chosen examples): `/users/1` (for `/users/[id]`), `/play/challenges/neon-ramen-bar-icon` (for `/play/challenges/[slug]` — slug confirmed present in `scripts/seed_challenges.ts`)
- Pure route-list/comment change to the audit script itself — no app code touched.

### How I verified
- `node --check` — syntax OK
- `npx eslint utils/scripts/auditResponsiveLayout.mjs` — clean
- `npx vue-tsc --noEmit` — clean
- Confirmed all 8 target pages exist as real `pages/**/*.vue` files and none set `requiredPermission` (public)
- Confirmed the `neon-ramen-bar-icon` slug exists in `scripts/seed_challenges.ts`
- Could **not** run the audit script itself locally against production: the sandbox's pre-installed Playwright browser (`chromium-1194`) doesn't match this repo's pinned `playwright@^1.62.1`, which expects a different revision. This is a known sandbox limitation, not a code issue — CI's `audit` job runs with matching browsers and will exercise these 8 new routes for real.

### Stakes
reversible

### Flags for Reviewer
- Same shape as slice 5: a pure route-list/comment change, so structural CI (vue-tsc/eslint/layout-contract) plus the `audit` workflow are the real verification, not a local run. Please confirm the `audit` check passes (specifically the 8 new routes) before merging, since I could not verify their actual rendered geometry locally.
- This closes the full non-admin, nav-linked gap list from `projects/interface-vision/docs/t-102-reachable-surface-inventory.md`. Coverage in `t-103`'s task note will read 56 → 64 routes in the default list.

### Kaizen suggestion
Once this closes the t-102 gap list, worth a follow-up task to reconcile whether the umbrella's "authoritative counter" should now formally read zero (i.e. whether `t-103` itself is ready to close), or whether a fresh nav-reachability sweep is warranted first in case new routes were added since the inventory was written.

### Notes for reviewer
Conductor task `interface-vision/t-103` is at `status: review`, claimed by `claude-quirky-curie-20260807T172902Z-iv-t103-s6`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ETWa2vm16LUv7qBVTCgU4b)_