### PR TITLE
fix(nav): let channel-select shrink so the tab strip stops crushing on phone (interface-vision/t-109)

### DIFF
--- a/components/navigation/channel-select.vue
+++ b/components/navigation/channel-select.vue
@@ -4,7 +4,7 @@
     <button
       tabindex="0"
       type="button"
-      class="flex h-full min-h-10 shrink-0 items-center gap-2 overflow-hidden px-2 transition-all xl:gap-2.5 xl:px-3"
+      class="flex h-full min-h-10 w-full min-w-0 items-center gap-2 overflow-hidden px-2 transition-all xl:gap-2.5 xl:px-3"
       :class="
         seamless
           ? 'rounded-l-xl hover:bg-base-200'

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -34,10 +34,25 @@
            <h1> behind it. Silas, 2026-08-04: "I can't actually select the
            channel option anymore." The children round their own outer corners
            instead. -->
+      <!-- channel-select used to carry `shrink-0` here, which pinned it to its
+           full unclamped label width (e.g. "Sanctuary") no matter how little
+           room the row had left. Since the tab strip's own wrapper is
+           `flex-1` with a flex-basis of 0%, flexbox gives basis-0 items NO
+           share of the shrink deficit — so a shrink-0 sibling forces 100% of
+           any squeeze onto the tab strip instead, crushing `#channel-tab-strip`
+           to a several-pixel sliver on narrow phones (interface-vision/t-109:
+           /about, /cart, /giving, /mermaids, /privacy, /sanctuary, and
+           /auth/google, all only on the 390px phone viewport — there was
+           always enough room at tablet+). `shrink` (default flex-shrink: 1)
+           plus `min-w-0` here, and the matching `w-full min-w-0` replacing
+           channel-select's own internal `shrink-0` in channel-select.vue, let
+           the picker absorb the deficit first and truncate its label (the
+           span already had `min-w-0 truncate`, it just never got a chance to
+           engage) rather than starving the navigation the row exists for. -->
       <div
         class="flex h-10 min-h-10 min-w-0 flex-1 items-stretch rounded-xl border border-base-300 bg-base-100 shadow-sm sm:h-11 sm:min-h-11 xl:h-14 xl:min-h-14"
       >
-        <channel-select seamless class="shrink-0" />
+        <channel-select seamless class="min-w-0 shrink" />
 
         <!-- The horizontal strip owns clipping. This wrapper stays visible so
              the complete-tab menu can escape below the one-row header. -->
@@ -210,14 +225,7 @@
 </template>
 
 <script setup lang="ts">
-import {
-  computed,
-  nextTick,
-  onBeforeUnmount,
-  onMounted,
-  ref,
-  watch,
-} from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import type { ResolvedTab } from '@/stores/helpers/channelContent'
 import { useChannelContentStore } from '@/stores/channelContentStore'
@@ -430,9 +438,7 @@ function currentTabStartIndex(): number {
   let closestDistance = Number.POSITIVE_INFINITY
 
   buttons.forEach((button, index) => {
-    const distance = Math.abs(
-      tabOffset(button, firstButton) - strip.scrollLeft,
-    )
+    const distance = Math.abs(tabOffset(button, firstButton) - strip.scrollLeft)
 
     if (distance < closestDistance) {
       closestIndex = index
@@ -542,10 +548,7 @@ async function syncTabStrip(
 
 function scrollTabs(direction: -1 | 1): void {
   const currentStart = currentTabStartIndex()
-  scrollToTabIndex(
-    currentStart + direction * visibleTabCount.value,
-    'smooth',
-  )
+  scrollToTabIndex(currentStart + direction * visibleTabCount.value, 'smooth')
 }
 
 /**


### PR DESCRIPTION
interface-vision/t-109. t-103 slice 6's completed 60-minute responsive audit (kind_robots run 31207144813, against merge commit 7841e27 / PR #1575) flagged `<nav#channel-tab-strip>` CRUSHED to an 18px sliver on phone (390px) across all six sanctuary-channel routes (`/about`, `/cart`, `/giving`, `/mermaids`, `/privacy`, `/sanctuary`) and to 12px on `/auth/google`. Tablet (820px) and desktop passed on all seven.

## Root cause

`channel-select` (the channel picker button, left of the tab strip) carried `shrink-0`, pinning it to its full unclamped label width (e.g. "Sanctuary") no matter how little room the header row had left.

The tab strip's own wrapper is `flex-1` — Tailwind's `flex-1` is `flex: 1 1 0%`, i.e. a flex-basis of **0%**. Flexbox distributes shrink deficit proportional to `flex-shrink × flex-basis`; a basis-0 item gets **zero** share of that deficit regardless of its shrink factor. So with channel-select refusing to shrink at all (`shrink-0`), literally 100% of any squeeze in the row got forced onto the tab strip instead — crushing it to a few px while channel-select rendered at full width, unclipped.

## Fix

Let channel-select actually participate in the shrink:
- `workspace-header.vue`: `class="shrink-0"` → `class="min-w-0 shrink"` at the one call site (confirmed via repo-wide grep — `channel-select` is only ever mounted here).
- `channel-select.vue`: its own root button also carried an internal `shrink-0`; replaced with `w-full min-w-0` so it now stretches to (and shrinks with) whatever width flexbox assigns it, letting the label span's pre-existing `min-w-0 truncate` finally engage instead of being unreachable dead code.

Net effect: channel-select now absorbs the deficit first and truncates its label under pressure, protecting the tab strip — which is what the header row exists for — instead of the reverse. On wide viewports (desktop/tablet, where there's no deficit to distribute) the rendered result is unchanged.

Left a comment at the call site walking through the flex-basis-0 mechanics for the next person who hits this class of bug elsewhere in the header.

## Verification

- `eslint` — clean
- `vue-tsc --noEmit` — clean
- `prettier --check` — clean
- `utils/scripts/verifyLayoutContract.ts` — holds, no new violations
- No local dev server / Chromium available in this sandbox (documented sandbox limitation — DATABASE_URL is unreachable, and headless Chromium egress to `*.vercel.app` resets); relying on this repo's `responsive-layout-audit.yml` CI check against the PR's Vercel preview to confirm the crush is gone on `/about`, `/cart`, `/giving`, `/mermaids`, `/privacy`, `/sanctuary`, and `/auth/google` at 390px before merging, per AGENTS.md's documented verification path for this exact class of change.

Roadmap: `projects/interface-vision/roadmap.yaml` t-109 (conductor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4hixPYBBpgafCc694Xad3

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4hixPYBBpgafCc694Xad3)_