### PR TITLE
fix(nav): give the tab strip an explicit min-width so it actually overflows (interface-vision/t-109 follow-up)

### DIFF
--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -36,19 +36,18 @@
            instead. -->
       <!-- channel-select used to carry `shrink-0` here, which pinned it to its
            full unclamped label width (e.g. "Sanctuary") no matter how little
-           room the row had left. Since the tab strip's own wrapper is
-           `flex-1` with a flex-basis of 0%, flexbox gives basis-0 items NO
-           share of the shrink deficit — so a shrink-0 sibling forces 100% of
-           any squeeze onto the tab strip instead, crushing `#channel-tab-strip`
-           to a several-pixel sliver on narrow phones (interface-vision/t-109:
+           room the row had left, crushing `#channel-tab-strip` to a
+           several-pixel sliver on narrow phones (interface-vision/t-109:
            /about, /cart, /giving, /mermaids, /privacy, /sanctuary, and
            /auth/google, all only on the 390px phone viewport — there was
            always enough room at tablet+). `shrink` (default flex-shrink: 1)
            plus `min-w-0` here, and the matching `w-full min-w-0` replacing
            channel-select's own internal `shrink-0` in channel-select.vue, let
-           the picker absorb the deficit first and truncate its label (the
-           span already had `min-w-0 truncate`, it just never got a chance to
-           engage) rather than starving the navigation the row exists for. -->
+           the picker absorb a shrink deficit and truncate its label instead
+           of starving the navigation the row exists for -- but by itself
+           this was NOT enough to fix the crush: see the `.tab-strip`
+           min-width comment below for why, and the empirical confirmation
+           that this half alone still crushed identically. -->
       <div
         class="flex h-10 min-h-10 min-w-0 flex-1 items-stretch rounded-xl border border-base-300 bg-base-100 shadow-sm sm:h-11 sm:min-h-11 xl:h-14 xl:min-h-14"
       >
@@ -680,6 +679,42 @@ function goBack(): void {
   -ms-overflow-style: none;
   scroll-padding-inline: 0.375rem;
   overscroll-behavior-inline: contain;
+
+  /*
+   * Follow-up to the interface-vision/t-109 fix above: making channel-select
+   * shrinkable was necessary but not sufficient. `overflow-x: auto` makes an
+   * item's AUTOMATIC minimum size (the one used when min-width is `auto`)
+   * resolve to 0, per the flexbox spec -- so with no min-width set here, the
+   * browser never sees the row as overflowing at all: channel-select simply
+   * keeps its full content width (flex-grow: 0 means "don't grow past
+   * content", not "shrink to make room"), and this strip is handed whatever
+   * sliver is left over, same as before that fix. Confirmed empirically: PR
+   * #1577 shipped the shrinkable channel-select alone and the responsive
+   * audit (kind_robots run 31212650601, this PR's own head) still measured
+   * the identical crush -- w=18 on the six sanctuary routes, w=12 on
+   * /auth/google -- because shrink/grow never engaged without a real deficit
+   * to detect.
+   *
+   * An EXPLICIT min-width bypasses the automatic-minimum-is-0 rule, so the
+   * browser now genuinely detects overflow once channel-select's content
+   * plus this floor exceed the row -- at which point channel-select (now
+   * shrinkable) is the one that gives ground, per normal shrink-factor
+   * distribution. Matches tab-button's own floor below (same three values),
+   * since one visible, readable tab is the minimum this strip is for.
+   */
+  min-width: 6rem; /* 96px */
+}
+
+@media (min-width: 640px) {
+  .tab-strip {
+    min-width: 7rem; /* 112px */
+  }
+}
+
+@media (min-width: 1280px) {
+  .tab-strip {
+    min-width: 8rem; /* 128px */
+  }
 }
 
 .tab-button {


### PR DESCRIPTION
Follow-up to #1577 (interface-vision/t-109), which merged with a bug: it did not actually fix the crush it targeted.

## What happened

#1577 made `channel-select` shrinkable (`shrink` + `min-w-0` at the call site, `w-full min-w-0` replacing its internal `shrink-0`), on the theory that its old `shrink-0` was forcing 100% of the header row's shrink deficit onto `#channel-tab-strip`. Structural CI was green and the Vercel preview built successfully, and the PR was merged.

But the PR's **own** CI-triggered Responsive Layout Audit (kind_robots run [31212650601](https://github.com/silasfelinus/kind_robots/actions/runs/31212650601), against #1577's exact head `5a1893f`) shows the fix had **zero effect**: `/about`, `/cart`, `/giving`, `/mermaids`, `/privacy`, `/sanctuary`, and `/auth/google` all still crush `<nav#channel-tab-strip>` on phone (390px) to the **identical** `w=18` / `w=12` measured before the change. I've verified this directly from the raw job log (not just the summary line) — the merge review that approved #1577 appears to have misread that same log as passing.

## Why the first fix had no effect

`.tab-strip` sets `overflow-x: auto`. Per the flexbox spec, an item's **automatic minimum size** — the floor used when `min-width` is `auto`, the default — resolves to **0** on any axis with overflow other than `visible`. With no `min-width` set, the browser never detects the row as overflowing in the first place: `channel-select`'s `flex-grow: 0` only means "don't grow past your content," not "shrink to make room." So the shrink algorithm #1577 relies on never engages, and `channel-select` keeps its full label width regardless of how shrinkable it's marked — exactly what the identical-pixel measurement shows.

## Fix

Give `.tab-strip` an **explicit** `min-width` (96px / 112px / 128px, matching `tab-button`'s own existing floor at the same breakpoints). An explicit value bypasses the automatic-minimum-is-0 rule, so the browser now genuinely detects overflow once `channel-select`'s content plus this floor exceed the row — at which point `channel-select` (already shrinkable from #1577) is what actually gives ground.

## Verification

- `eslint`, `vue-tsc --noEmit`, `prettier --check`, `utils/scripts/verifyLayoutContract.ts` — all clean.
- Real verification is the same CI-triggered Responsive Layout Audit that caught this — watching for it against this PR's own preview before merging, and will read the raw per-route log rather than trusting only the pass/fail summary line, given what happened last time.

Roadmap: `projects/interface-vision/roadmap.yaml` t-109 (conductor) — will correct its note once this is confirmed green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4hixPYBBpgafCc694Xad3

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4hixPYBBpgafCc694Xad3)_