### PR TITLE
Reduce ProxySQL pressure from Vercel previews

### DIFF
--- a/.github/workflows/responsive-layout-audit.yml
+++ b/.github/workflows/responsive-layout-audit.yml
@@ -27,14 +27,8 @@ name: Responsive Layout Audit
 #                     fire, this still catches every regression within the hour.
 #
 #   deployment_status  the better signal IF Vercel's GitHub integration emits
-#                     it here — it would audit each PR's own preview, against
-#                     the real database, before the change reaches main. No
-#                     other workflow in this repo uses this event, so it is
-#                     UNVERIFIED. It is additive: if it never fires, nothing is
-#                     lost that the schedule does not already cover. Check the
-#                     Actions tab for runs triggered by `deployment_status`; if
-#                     there are none after a few PRs, delete that trigger rather
-#                     than leaving a line that looks like a gate and is not.
+#                     it here — it audits each PR's own preview, against the real
+#                     database, before the change reaches main.
 on:
   schedule:
     - cron: '41 * * * *'
@@ -50,8 +44,12 @@ on:
         required: false
         default: ''
 
+# A deployment URL is unique per commit, so keying concurrency by target_url
+# lets every preview commit run a separate 60-minute database-backed browser
+# crawl. Key by source ref instead: a newer push to the same branch cancels the
+# older audit, while separate PR branches remain independent.
 concurrency:
-  group: responsive-layout-audit-${{ github.event.deployment_status.target_url || github.ref }}
+  group: responsive-layout-audit-${{ github.event.deployment.ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -88,24 +86,53 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Check deployment freshness
+        id: freshness
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DEPLOY_REF: ${{ github.event.deployment.ref }}
+          DEPLOY_SHA: ${{ github.event.deployment.sha }}
+        run: |
+          set -euo pipefail
+          run_audit=true
+
+          if [ "$EVENT_NAME" = "deployment_status" ] && [ -n "${DEPLOY_REF:-}" ] && [ -n "${DEPLOY_SHA:-}" ]; then
+            branch="${DEPLOY_REF#refs/heads/}"
+            remote_sha="$(git ls-remote origin "refs/heads/${branch}" | awk 'NR == 1 {print $1}')"
+
+            if [ -z "$remote_sha" ]; then
+              echo "Skipping deployment ${DEPLOY_SHA:0:7}: source branch ${branch} no longer exists."
+              run_audit=false
+            elif [ "$remote_sha" != "$DEPLOY_SHA" ]; then
+              echo "Skipping superseded deployment ${DEPLOY_SHA:0:7}: ${branch} is now ${remote_sha:0:7}."
+              run_audit=false
+            fi
+          fi
+
+          echo "run_audit=$run_audit" >>"$GITHUB_OUTPUT"
+
       - name: Set up Node
+        if: steps.freshness.outputs.run_audit == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: npm
 
       - name: Install dependencies
+        if: steps.freshness.outputs.run_audit == 'true'
         run: npm ci
         env:
           CYPRESS_INSTALL_BINARY: '0'
 
       - name: Install Chromium
+        if: steps.freshness.outputs.run_audit == 'true'
         # Only Chromium — the audit measures layout, not cross-browser
         # behaviour, and pulling three engines would triple the install for no
         # extra signal.
         run: npx playwright install --with-deps chromium
 
       - name: Resolve target URL
+        if: steps.freshness.outputs.run_audit == 'true'
         id: target
         env:
           DEPLOY_URL: ${{ github.event.deployment_status.target_url }}
@@ -122,6 +149,7 @@ jobs:
           echo "Auditing $url"
 
       - name: Wait for the deployment to answer
+        if: steps.freshness.outputs.run_audit == 'true'
         env:
           BASE_URL: ${{ steps.target.outputs.url }}
         run: |
@@ -149,6 +177,7 @@ jobs:
           exit 1
 
       - name: Wait for the database
+        if: steps.freshness.outputs.run_audit == 'true'
         env:
           BASE_URL: ${{ steps.target.outputs.url }}
         run: |
@@ -177,6 +206,7 @@ jobs:
           exit 1
 
       - name: Audit responsive layout
+        if: steps.freshness.outputs.run_audit == 'true'
         env:
           BASE_URL: ${{ steps.target.outputs.url }}
           ROUTES: ${{ github.event.inputs.routes }}
@@ -188,19 +218,10 @@ jobs:
             npm run audit:responsive -- --base "$BASE_URL" --shots audit-shots
           fi
 
-      # Deliberately WITHOUT `--strict`, and `if: always()` so it still reports
-      # when the responsive sweep above fails.
-      #
-      # The script exits 1 on load failures on its own, which gates the
-      # INSTRUMENT -- every failure this step has actually hit was of that kind
-      # (Chromium not inheriting HTTPS_PROXY, a hardcoded browser path, a lead
-      # selector matching nothing), and each once produced output that read like
-      # a pass. `--strict` would additionally gate the FINDING, and most measured
-      # readings are over budget today against real pre-existing chrome, so
-      # turning it on would block every unrelated PR on a backlog. Add it once
-      # the routes are under budget; the numbers print either way.
+      # Deliberately WITHOUT `--strict`, and still runs when the responsive
+      # sweep above fails. A stale deployment never reaches this step.
       - name: Audit gallery chrome budget
-        if: always()
+        if: ${{ always() && steps.freshness.outputs.run_audit == 'true' }}
         env:
           BASE_URL: ${{ steps.target.outputs.url }}
         run: |
@@ -208,9 +229,9 @@ jobs:
           npm run audit:gallery-chrome -- --base "$BASE_URL"
 
       - name: Upload screenshots
-        # Always: a failure is exactly when the pictures are worth having, and
-        # a pass is worth spot-checking against.
-        if: always()
+        # Always for an audit that actually ran: a failure is exactly when the
+        # pictures are worth having, and a pass is worth spot-checking.
+        if: ${{ always() && steps.freshness.outputs.run_audit == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: responsive-audit-${{ github.run_id }}

--- a/.github/workflows/responsive-layout-audit.yml
+++ b/.github/workflows/responsive-layout-audit.yml
@@ -97,8 +97,8 @@ jobs:
           run_audit=true
 
           if [ "$EVENT_NAME" = "deployment_status" ] && [ -n "${DEPLOY_REF:-}" ] && [ -n "${DEPLOY_SHA:-}" ]; then
-            branch="${DEPLOY_REF#refs/heads/}"
-            remote_sha="$(git ls-remote origin "refs/heads/${branch}" | awk 'NR == 1 {print $1}')"
+            branch="$DEPLOY_REF"
+            remote_sha="$(git ls-remote --heads origin "$branch" | awk 'NR == 1 {print $1}')"
 
             if [ -z "$remote_sha" ]; then
               echo "Skipping deployment ${DEPLOY_SHA:0:7}: source branch ${branch} no longer exists."

--- a/scripts/proxysql-capacity-diagnostics.sh
+++ b/scripts/proxysql-capacity-diagnostics.sh
@@ -224,8 +224,10 @@ GROUP BY cli_host
 ORDER BY sessions DESC, oldest_state_ms DESC;
 "
 
+# ProxySQL's admin interface is SQLite-backed, so schema introspection uses
+# PRAGMA rather than MySQL SHOW COLUMNS.
 proxysql_sql_optional 'processlist schema for version reference' "
-SHOW COLUMNS FROM stats_mysql_processlist;
+PRAGMA table_info(stats_mysql_processlist);
 "
 
 mariadb_sql 'global and account ceilings' "

--- a/server/utils/databaseAdapterConfig.ts
+++ b/server/utils/databaseAdapterConfig.ts
@@ -21,10 +21,8 @@ import {
   DEFAULT_IDLE_TIMEOUT_SECONDS,
   DEFAULT_MINIMUM_IDLE,
   DEFAULT_PING_TIMEOUT_MS,
-  VERCEL_CONNECTION_LIMIT,
-  VERCEL_IDLE_TIMEOUT_SECONDS,
-  VERCEL_MINIMUM_IDLE,
   isVercelFunctionRuntime,
+  resolveDatabasePoolDefaults,
 } from './databasePoolDefaults'
 
 export type PrismaMariaDbConfig = ConstructorParameters<typeof PrismaMariaDb>[0]
@@ -72,6 +70,7 @@ export function readDatabaseUseTextProtocol(): boolean {
 export function buildDatabaseUrl(url: string): string {
   const parsed = new URL(url)
   const isVercelRuntime = isVercelFunctionRuntime()
+  const runtimePoolDefaults = resolveDatabasePoolDefaults()
   const connectTimeout = readPositiveInteger(
     parsed.searchParams.get('connectTimeout') ??
       process.env.DATABASE_CONNECT_TIMEOUT_MS,
@@ -108,13 +107,13 @@ export function buildDatabaseUrl(url: string): string {
     DEFAULT_PING_TIMEOUT_MS,
   )
   const connectionLimit = isVercelRuntime
-    ? Math.min(requestedConnectionLimit, VERCEL_CONNECTION_LIMIT)
+    ? Math.min(requestedConnectionLimit, runtimePoolDefaults.connectionLimit)
     : requestedConnectionLimit
   const idleTimeout = isVercelRuntime
-    ? Math.min(requestedIdleTimeout, VERCEL_IDLE_TIMEOUT_SECONDS)
+    ? Math.min(requestedIdleTimeout, runtimePoolDefaults.idleTimeoutSeconds)
     : requestedIdleTimeout
   const minimumIdle = isVercelRuntime
-    ? VERCEL_MINIMUM_IDLE
+    ? runtimePoolDefaults.minimumIdle
     : requestedMinimumIdle
 
   if (
@@ -124,6 +123,7 @@ export function buildDatabaseUrl(url: string): string {
       minimumIdle !== requestedMinimumIdle)
   ) {
     console.warn('[prisma] Clamped unsafe Vercel database pool override', {
+      profile: runtimePoolDefaults.profile,
       requestedConnectionLimit,
       requestedIdleTimeout,
       requestedMinimumIdle,

--- a/server/utils/databasePoolDefaults.ts
+++ b/server/utils/databasePoolDefaults.ts
@@ -1,19 +1,27 @@
 // /server/utils/databasePoolDefaults.ts
 //
-// Kind Robots currently has two materially different runtime shapes:
+// Kind Robots currently has three materially different runtime shapes:
 //
 // 1. A long-lived local Node/Nitro process, where retaining a small warm pool is
 //    useful and the process count is controlled.
-// 2. Vercel Node functions, where every warm lambda and every preview deployment
-//    can own an independent connector pool. A global minimumIdle=1 caused each
-//    warm lambda to retain a ProxySQL frontend session indefinitely, eventually
-//    filling the shared kindrobot 200-session frontend limit even though
-//    ProxySQL successfully multiplexed those clients onto <=40 MariaDB backends.
+// 2. Vercel production functions, where every warm lambda owns an independent
+//    connector pool and the per-process pool must stay deliberately small.
+// 3. Vercel preview functions, which can multiply rapidly across PR commits and
+//    browser audits. They get an even smaller pool so preview fan-out cannot
+//    consume the production ProxySQL frontend budget as quickly.
 //
-// Keep both profiles centralized and explicit. Never solve a serverless fan-out
+// A global minimumIdle=1 previously caused each warm lambda to retain a ProxySQL
+// frontend session indefinitely, eventually filling the shared kindrobot
+// 200-session frontend limit even though ProxySQL successfully multiplexed those
+// clients onto <=40 MariaDB backends.
+//
+// Keep these profiles centralized and explicit. Never solve a serverless fan-out
 // incident by weakening the healthy long-lived process, or vice versa.
 
-export type DatabasePoolProfile = 'long-lived' | 'vercel-function'
+export type DatabasePoolProfile =
+  | 'long-lived'
+  | 'vercel-function'
+  | 'vercel-preview'
 
 export type DatabasePoolDefaults = {
   profile: DatabasePoolProfile
@@ -34,8 +42,9 @@ export const LONG_LIVED_IDLE_TIMEOUT_SECONDS = 300
 export const LONG_LIVED_MINIMUM_IDLE = 1
 export const LONG_LIVED_PING_TIMEOUT_MS = 2_000
 
-// Vercel functions scale by process count, so the per-process pool must be
-// deliberately tiny and must not retain a connection merely to stay warm.
+// Production Vercel functions scale by process count, so the per-process pool
+// must be deliberately tiny and must not retain a connection merely to stay
+// warm.
 export const VERCEL_CONNECTION_LIMIT = 2
 export const VERCEL_CONNECT_TIMEOUT_MS = 5_000
 export const VERCEL_ACQUIRE_TIMEOUT_MS = 10_000
@@ -43,15 +52,40 @@ export const VERCEL_IDLE_TIMEOUT_SECONDS = 15
 export const VERCEL_MINIMUM_IDLE = 0
 export const VERCEL_PING_TIMEOUT_MS = 2_000
 
+// Preview deployments multiply faster than production because every PR commit
+// can create another warm deployment and its own browser audit. Give previews a
+// stricter envelope while they still share the production ProxySQL user.
+export const VERCEL_PREVIEW_CONNECTION_LIMIT = 1
+export const VERCEL_PREVIEW_IDLE_TIMEOUT_SECONDS = 5
+export const VERCEL_PREVIEW_MINIMUM_IDLE = 0
+
 export function isVercelFunctionRuntime(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
   return env.VERCEL === '1'
 }
 
+export function isVercelPreviewRuntime(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return env.VERCEL === '1' && env.VERCEL_ENV === 'preview'
+}
+
 export function resolveDatabasePoolDefaults(
   env: NodeJS.ProcessEnv = process.env,
 ): DatabasePoolDefaults {
+  if (isVercelPreviewRuntime(env)) {
+    return {
+      profile: 'vercel-preview',
+      connectionLimit: VERCEL_PREVIEW_CONNECTION_LIMIT,
+      connectTimeoutMs: VERCEL_CONNECT_TIMEOUT_MS,
+      acquireTimeoutMs: VERCEL_ACQUIRE_TIMEOUT_MS,
+      idleTimeoutSeconds: VERCEL_PREVIEW_IDLE_TIMEOUT_SECONDS,
+      minimumIdle: VERCEL_PREVIEW_MINIMUM_IDLE,
+      pingTimeoutMs: VERCEL_PING_TIMEOUT_MS,
+    }
+  }
+
   if (isVercelFunctionRuntime(env)) {
     return {
       profile: 'vercel-function',
@@ -103,7 +137,8 @@ if (
 
 for (const defaults of [
   resolveDatabasePoolDefaults({}),
-  resolveDatabasePoolDefaults({ VERCEL: '1' }),
+  resolveDatabasePoolDefaults({ VERCEL: '1', VERCEL_ENV: 'production' }),
+  resolveDatabasePoolDefaults({ VERCEL: '1', VERCEL_ENV: 'preview' }),
 ]) {
   if (defaults.acquireTimeoutMs <= defaults.connectTimeoutMs) {
     throw new Error(

--- a/utils/scripts/verifyDatabasePoolDefaults.ts
+++ b/utils/scripts/verifyDatabasePoolDefaults.ts
@@ -18,6 +18,9 @@ import {
   VERCEL_IDLE_TIMEOUT_SECONDS,
   VERCEL_MINIMUM_IDLE,
   VERCEL_PING_TIMEOUT_MS,
+  VERCEL_PREVIEW_CONNECTION_LIMIT,
+  VERCEL_PREVIEW_IDLE_TIMEOUT_SECONDS,
+  VERCEL_PREVIEW_MINIMUM_IDLE,
   resolveDatabasePoolDefaults,
 } from './../../server/utils/databasePoolDefaults'
 
@@ -45,7 +48,14 @@ function withEnvironment(
 }
 
 const longLivedDefaults = resolveDatabasePoolDefaults({})
-const vercelDefaults = resolveDatabasePoolDefaults({ VERCEL: '1' })
+const vercelDefaults = resolveDatabasePoolDefaults({
+  VERCEL: '1',
+  VERCEL_ENV: 'production',
+})
+const previewDefaults = resolveDatabasePoolDefaults({
+  VERCEL: '1',
+  VERCEL_ENV: 'preview',
+})
 
 // A controlled long-lived local process needs enough capacity for the app's
 // parallel route work and may retain one validated socket.
@@ -74,8 +84,8 @@ assert.ok(
   'The long-lived runtime must keep at least one warm connection.',
 )
 
-// Vercel scales by function-process count. A warm connection per lambda caused
-// 200 ProxySQL frontend sessions while MariaDB remained bounded near 40.
+// Production Vercel scales by function-process count. A warm connection per
+// lambda caused 200 ProxySQL frontend sessions while MariaDB remained bounded.
 assert.equal(vercelDefaults.profile, 'vercel-function')
 assert.equal(vercelDefaults.connectionLimit, VERCEL_CONNECTION_LIMIT)
 assert.equal(vercelDefaults.connectTimeoutMs, VERCEL_CONNECT_TIMEOUT_MS)
@@ -85,7 +95,7 @@ assert.equal(vercelDefaults.minimumIdle, VERCEL_MINIMUM_IDLE)
 assert.equal(vercelDefaults.pingTimeoutMs, VERCEL_PING_TIMEOUT_MS)
 assert.ok(
   vercelDefaults.connectionLimit <= 2,
-  'A Vercel function must not carry a server-sized connector pool.',
+  'A production Vercel function must not carry a server-sized connector pool.',
 )
 assert.equal(
   vercelDefaults.minimumIdle,
@@ -97,9 +107,33 @@ assert.ok(
   'Idle Vercel frontend sessions must retire promptly.',
 )
 
+// Preview deployments multiply across PR commits and browser audits. While they
+// still share the production ProxySQL user, each preview process gets one
+// connection maximum and retires it faster than production.
+assert.equal(previewDefaults.profile, 'vercel-preview')
+assert.equal(
+  previewDefaults.connectionLimit,
+  VERCEL_PREVIEW_CONNECTION_LIMIT,
+)
+assert.equal(
+  previewDefaults.idleTimeoutSeconds,
+  VERCEL_PREVIEW_IDLE_TIMEOUT_SECONDS,
+)
+assert.equal(previewDefaults.minimumIdle, VERCEL_PREVIEW_MINIMUM_IDLE)
+assert.equal(previewDefaults.connectionLimit, 1)
+assert.ok(
+  previewDefaults.connectionLimit < vercelDefaults.connectionLimit,
+  'Preview pool capacity must stay below production while previews share its DB user.',
+)
+assert.ok(
+  previewDefaults.idleTimeoutSeconds < vercelDefaults.idleTimeoutSeconds,
+  'Preview idle sessions must retire faster than production sessions.',
+)
+
 withEnvironment(
   {
     VERCEL: '1',
+    VERCEL_ENV: 'production',
     DATABASE_CONNECTION_LIMIT: '10',
     DATABASE_IDLE_TIMEOUT_SECONDS: '300',
     DATABASE_MINIMUM_IDLE: '1',
@@ -115,12 +149,12 @@ withEnvironment(
     assert.equal(
       resolved.searchParams.get('connectionLimit'),
       String(VERCEL_CONNECTION_LIMIT),
-      'Vercel must clamp stale URL and environment pool-size overrides.',
+      'Production Vercel must clamp stale URL and environment pool-size overrides.',
     )
     assert.equal(
       resolved.searchParams.get('idleTimeout'),
       String(VERCEL_IDLE_TIMEOUT_SECONDS),
-      'Vercel must retire idle ProxySQL frontends promptly despite stale overrides.',
+      'Production Vercel must retire idle ProxySQL frontends promptly despite stale overrides.',
     )
     assert.equal(
       resolved.searchParams.get('minimumIdle'),
@@ -132,7 +166,41 @@ withEnvironment(
 
 withEnvironment(
   {
+    VERCEL: '1',
+    VERCEL_ENV: 'preview',
+    DATABASE_CONNECTION_LIMIT: '10',
+    DATABASE_IDLE_TIMEOUT_SECONDS: '300',
+    DATABASE_MINIMUM_IDLE: '1',
+  },
+  () => {
+    const resolved = new URL(
+      buildDatabaseUrl(
+        'mysql://kindrobot:secret@database.example:5544/kindblank' +
+          '?connectionLimit=12&idleTimeout=600&minimumIdle=4',
+      ),
+    )
+
+    assert.equal(
+      resolved.searchParams.get('connectionLimit'),
+      String(VERCEL_PREVIEW_CONNECTION_LIMIT),
+      'Preview Vercel must clamp even production-safe overrides to its stricter pool.',
+    )
+    assert.equal(
+      resolved.searchParams.get('idleTimeout'),
+      String(VERCEL_PREVIEW_IDLE_TIMEOUT_SECONDS),
+      'Preview Vercel must retire frontend sessions aggressively.',
+    )
+    assert.equal(
+      resolved.searchParams.get('minimumIdle'),
+      String(VERCEL_PREVIEW_MINIMUM_IDLE),
+    )
+  },
+)
+
+withEnvironment(
+  {
     VERCEL: undefined,
+    VERCEL_ENV: undefined,
     DATABASE_CONNECTION_LIMIT: '10',
     DATABASE_IDLE_TIMEOUT_SECONDS: '300',
     DATABASE_MINIMUM_IDLE: '1',
@@ -151,7 +219,7 @@ withEnvironment(
   },
 )
 
-for (const defaults of [longLivedDefaults, vercelDefaults]) {
+for (const defaults of [longLivedDefaults, vercelDefaults, previewDefaults]) {
   assert.ok(
     defaults.acquireTimeoutMs > defaults.connectTimeoutMs,
     `${defaults.profile} acquire timeout must exceed its connect timeout.`,
@@ -178,6 +246,10 @@ const vercelBuildSource = readFileSync(
   new URL('../../scripts/vercel-build.mjs', import.meta.url),
   'utf8',
 )
+const responsiveAuditSource = readFileSync(
+  new URL('../../.github/workflows/responsive-layout-audit.yml', import.meta.url),
+  'utf8',
+)
 const directProbeSource = readFileSync(
   new URL('../../server/utils/databaseDirectProbe.ts', import.meta.url),
   'utf8',
@@ -201,34 +273,40 @@ const clientDiagnosticSource = readFileSync(
 )
 
 assert.match(poolDefaultsSource, /env\.VERCEL === '1'/)
+assert.match(poolDefaultsSource, /env\.VERCEL_ENV === 'preview'/)
 assert.match(poolDefaultsSource, /profile:\s*'vercel-function'/)
+assert.match(poolDefaultsSource, /profile:\s*'vercel-preview'/)
 assert.match(poolDefaultsSource, /VERCEL_CONNECTION_LIMIT = 2/)
 assert.match(poolDefaultsSource, /VERCEL_IDLE_TIMEOUT_SECONDS = 15/)
 assert.match(poolDefaultsSource, /VERCEL_MINIMUM_IDLE = 0/)
+assert.match(poolDefaultsSource, /VERCEL_PREVIEW_CONNECTION_LIMIT = 1/)
+assert.match(poolDefaultsSource, /VERCEL_PREVIEW_IDLE_TIMEOUT_SECONDS = 5/)
 assert.match(poolDefaultsSource, /LONG_LIVED_CONNECTION_LIMIT = 10/)
 assert.match(poolDefaultsSource, /LONG_LIVED_MINIMUM_IDLE = 1/)
 
-// Request-time Prisma and standalone scripts consume the same active runtime
-// defaults through the adapter. Long-lived overrides remain supported, while a
-// Vercel URL or environment cannot exceed the serverless safety envelope.
+// Request-time Prisma and standalone scripts consume the active runtime profile
+// through the adapter. Long-lived overrides remain supported, while every
+// Vercel environment is clamped to its own serverless safety envelope.
 assert.match(adapterSource, /process\.env\.DATABASE_CONNECTION_LIMIT/)
 assert.match(adapterSource, /process\.env\.DATABASE_IDLE_TIMEOUT_SECONDS/)
 assert.match(adapterSource, /process\.env\.DATABASE_MINIMUM_IDLE/)
 assert.match(adapterSource, /process\.env\.DATABASE_PING_TIMEOUT_MS/)
 assert.match(adapterSource, /isVercelFunctionRuntime\(\)/)
+assert.match(adapterSource, /resolveDatabasePoolDefaults\(\)/)
 assert.match(
   adapterSource,
-  /Math\.min\(requestedConnectionLimit, VERCEL_CONNECTION_LIMIT\)/,
+  /Math\.min\(requestedConnectionLimit, runtimePoolDefaults\.connectionLimit\)/,
 )
 assert.match(
   adapterSource,
-  /Math\.min\(requestedIdleTimeout, VERCEL_IDLE_TIMEOUT_SECONDS\)/,
+  /Math\.min\(requestedIdleTimeout, runtimePoolDefaults\.idleTimeoutSeconds\)/,
 )
 assert.match(
   adapterSource,
-  /isVercelRuntime\s*\?\s*VERCEL_MINIMUM_IDLE\s*:\s*requestedMinimumIdle/,
+  /isVercelRuntime\s*\?\s*runtimePoolDefaults\.minimumIdle\s*:\s*requestedMinimumIdle/,
 )
 assert.match(adapterSource, /Clamped unsafe Vercel database pool override/)
+assert.match(adapterSource, /profile:\s*runtimePoolDefaults\.profile/)
 assert.match(adapterSource, /pipelining:\s*readDatabasePipelining\(\)/)
 assert.match(adapterSource, /process\.env\.DATABASE_USE_TEXT_PROTOCOL/)
 assert.match(
@@ -267,6 +345,25 @@ for (const maintenanceScript of [
   )
 }
 
+// Browser audits must collapse repeated commits on the same branch instead of
+// using the unique deployment URL as their concurrency identity. A deployment
+// whose branch head has already moved must exit before touching the database.
+assert.match(
+  responsiveAuditSource,
+  /group: responsive-layout-audit-\$\{\{ github\.event\.deployment\.ref \|\| github\.ref_name \}\}/,
+)
+assert.doesNotMatch(
+  responsiveAuditSource,
+  /group: responsive-layout-audit-\$\{\{ github\.event\.deployment_status\.target_url/,
+)
+assert.match(responsiveAuditSource, /name: Check deployment freshness/)
+assert.match(responsiveAuditSource, /git ls-remote origin/)
+assert.match(responsiveAuditSource, /Skipping superseded deployment/)
+assert.match(
+  responsiveAuditSource,
+  /steps\.freshness\.outputs\.run_audit == 'true'/,
+)
+
 // The request-time singleton creates exactly one base Prisma client per process.
 assert.match(
   prismaSource,
@@ -304,6 +401,8 @@ assert.match(capacityDiagnosticSource, /cli_host/)
 assert.match(capacityDiagnosticSource, /frontend source totals/)
 assert.match(capacityDiagnosticSource, /proxysql_sql_optional/)
 assert.match(capacityDiagnosticSource, /Access_Denied_Max_User_Connections/)
+assert.match(capacityDiagnosticSource, /PRAGMA table_info\(stats_mysql_processlist\)/)
+assert.doesNotMatch(capacityDiagnosticSource, /SHOW COLUMNS FROM stats_mysql_processlist/)
 assert.doesNotMatch(
   capacityDiagnosticSource,
   /SELECT[^;]*(transaction_found|multiplex_disabled)/s,
@@ -342,6 +441,8 @@ assert.match(
 console.log(
   `Database pool profiles verified: local=${longLivedDefaults.connectionLimit}/` +
     `${longLivedDefaults.minimumIdle}/${longLivedDefaults.idleTimeoutSeconds}s, ` +
-    `vercel=${vercelDefaults.connectionLimit}/${vercelDefaults.minimumIdle}/` +
-    `${vercelDefaults.idleTimeoutSeconds}s; one Prisma client per process.`,
+    `production=${vercelDefaults.connectionLimit}/${vercelDefaults.minimumIdle}/` +
+    `${vercelDefaults.idleTimeoutSeconds}s, preview=${previewDefaults.connectionLimit}/` +
+    `${previewDefaults.minimumIdle}/${previewDefaults.idleTimeoutSeconds}s; ` +
+    'one Prisma client per process and stale preview audits cancelled.',
 )

--- a/utils/scripts/verifyDatabasePoolDefaults.ts
+++ b/utils/scripts/verifyDatabasePoolDefaults.ts
@@ -357,7 +357,7 @@ assert.doesNotMatch(
   /group: responsive-layout-audit-\$\{\{ github\.event\.deployment_status\.target_url/,
 )
 assert.match(responsiveAuditSource, /name: Check deployment freshness/)
-assert.match(responsiveAuditSource, /git ls-remote origin/)
+assert.match(responsiveAuditSource, /git ls-remote --heads origin/)
 assert.match(responsiveAuditSource, /Skipping superseded deployment/)
 assert.match(
   responsiveAuditSource,


### PR DESCRIPTION
Production ProxySQL repeatedly hit the `kindrobot` 200-frontend ceiling while MariaDB itself remained far below capacity. The post-restart census showed 9,814 denied frontend connections and later decay consistent with long-lived stale sockets.

This PR reduces the sources we can control in-repo:

- key Responsive Layout Audit concurrency by deployment **branch/ref**, not unique deployment URL, so a newer preview commit cancels the older 60-minute database-backed crawl;
- skip a deployment-status audit entirely when its commit is no longer the current remote branch head;
- give Vercel previews a stricter Prisma/MariaDB pool profile: `connectionLimit=1`, `minimumIdle=0`, `idleTimeout=5s`; production remains `2/0/15s`, local long-lived remains `10/1/300s`;
- clamp stale URL/env overrides to the active Vercel profile instead of one generic Vercel ceiling;
- fix ProxySQL processlist schema introspection to use SQLite `PRAGMA table_info(...)` instead of unsupported MySQL `SHOW COLUMNS`;
- extend `test:database-pool-defaults` to lock all of the above in as capacity regressions.

This does **not** change ProxySQL's server-side 8-hour `mysql-wait_timeout`, create a separate preview DB user, or change Vercel environment secrets. Those require infrastructure/environment configuration outside the repository.