### PR TITLE
Serialize database-backed responsive audits

### DIFF
--- a/.github/workflows/responsive-layout-audit.yml
+++ b/.github/workflows/responsive-layout-audit.yml
@@ -44,13 +44,16 @@ on:
         required: false
         default: ''
 
-# A deployment URL is unique per commit, so keying concurrency by target_url
-# lets every preview commit run a separate 60-minute database-backed browser
-# crawl. Key by source ref instead: a newer push to the same branch cancels the
-# older audit, while separate PR branches remain independent.
+# Every audit currently shares the production ProxySQL user, so even separate
+# PR branches compete for the same 200 frontend sessions. Serialize the heavy
+# database-backed browser crawl globally until Preview has its own DB identity.
+# Keep the running audit rather than cancelling it: GitHub concurrency retains
+# at most one running + one pending job, replacing older pending work as newer
+# deployments arrive. The freshness check below then drops a queued preview if
+# its source branch has moved before it starts.
 concurrency:
-  group: responsive-layout-audit-${{ github.event.deployment.ref || github.ref_name }}
-  cancel-in-progress: true
+  group: responsive-layout-audit-database
+  cancel-in-progress: false
 
 jobs:
   audit:

--- a/utils/scripts/verifyDatabasePoolDefaults.ts
+++ b/utils/scripts/verifyDatabasePoolDefaults.ts
@@ -345,16 +345,23 @@ for (const maintenanceScript of [
   )
 }
 
-// Browser audits must collapse repeated commits on the same branch instead of
-// using the unique deployment URL as their concurrency identity. A deployment
-// whose branch head has already moved must exit before touching the database.
+// Browser audits still share one database identity, so only one heavy crawler
+// may run at a time across every PR and the hourly production sweep. GitHub may
+// retain one pending replacement, but it must not cancel a healthy running
+// audit just because another deployment arrived. A deployment whose branch head
+// moved while queued exits before touching the database.
 assert.match(
   responsiveAuditSource,
-  /group: responsive-layout-audit-\$\{\{ github\.event\.deployment\.ref \|\| github\.ref_name \}\}/,
+  /group: responsive-layout-audit-database/,
 )
+assert.match(responsiveAuditSource, /cancel-in-progress:\s*false/)
 assert.doesNotMatch(
   responsiveAuditSource,
   /group: responsive-layout-audit-\$\{\{ github\.event\.deployment_status\.target_url/,
+)
+assert.doesNotMatch(
+  responsiveAuditSource,
+  /group: responsive-layout-audit-\$\{\{ github\.event\.deployment\.ref/,
 )
 assert.match(responsiveAuditSource, /name: Check deployment freshness/)
 assert.match(responsiveAuditSource, /git ls-remote --heads origin/)
@@ -444,5 +451,5 @@ console.log(
     `production=${vercelDefaults.connectionLimit}/${vercelDefaults.minimumIdle}/` +
     `${vercelDefaults.idleTimeoutSeconds}s, preview=${previewDefaults.connectionLimit}/` +
     `${previewDefaults.minimumIdle}/${previewDefaults.idleTimeoutSeconds}s; ` +
-    'one Prisma client per process and stale preview audits cancelled.',
+    'one Prisma client per process and database-backed audits globally serialized.',
 )


### PR DESCRIPTION
PR #1580 reduced per-preview DB pressure and cancels stale same-branch deployment audits, but all Vercel previews still share the production ProxySQL identity until #1581 is completed.

This follow-up caps the heavyweight browser crawler itself:

- use one global `responsive-layout-audit-database` concurrency group across previews and the scheduled production sweep;
- keep `cancel-in-progress: false`, so one running audit can finish while GitHub retains at most one pending replacement instead of repeatedly restarting browser crawls during deployment churn;
- retain the deployment-freshness guard from #1580, so a queued preview whose branch has moved exits before touching the DB;
- update the database-capacity regression contract to require this global serialization.

Only the responsive-audit workflow and its existing capacity contract change. This is a temporary safety boundary while Preview and Production share one DB identity; #1581 tracks proper account-level isolation.