### PR TITLE
fix(storybook): stop requesting the missing scenario/storybook.webp asset (interface-vision/t-111)

### DIFF
--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -596,7 +596,6 @@ import { computed, onMounted, ref } from 'vue'
 import { useCharacterStore } from '@/stores/characterStore'
 import { useDreamStore } from '@/stores/dreamStore'
 import { useFacetStore } from '@/stores/facetStore'
-import { getDashboardTabImagePath } from '@/stores/helpers/dashboardHelper'
 import { useRewardStore } from '@/stores/rewardStore'
 import {
   STORYBOOK_NARRATOR_STYLES,
@@ -622,9 +621,16 @@ const router = useRouter()
 const facetStore = useFacetStore()
 const rewardStore = useRewardStore()
 
-const tabImage = computed(() =>
-  getDashboardTabImagePath('scenario', 'storybook'),
-)
+/*
+ * scenario/storybook.webp was never uploaded to the media share (confirmed
+ * 404 against media.acrocatranch.com, sibling scenario/* tab images all
+ * resolve fine — see interface-vision/t-111). The global
+ * navigation-image-fallback plugin would eventually swap in the same
+ * placeholder on error, but only after a real failed request and a second
+ * network round trip, which is what the responsive audit's BROKEN-ART check
+ * caught. Point at the working placeholder directly until real art exists.
+ */
+const tabImage = computed(() => '/images/botcafe.webp')
 
 const setupStep = ref(0)
 const furthestStep = ref(0)


### PR DESCRIPTION
### Task
interface-vision/t-111: `/storybook`'s hero image (`Ami-butterfly's stage`) is BROKEN-ART on tablet and desktop (kind: software)

### What changed / what I produced
- `components/conductor/storybook-page.vue`: `tabImage` (passed into `kr-narrator-stage` as `stage-image`) previously computed `getDashboardTabImagePath('scenario', 'storybook')` → `/images/dashboard-tabs/scenario/storybook.webp`. Confirmed via direct `curl` against the media origin that this specific file 404s — every sibling `scenario/*` tab image (`scenarios.webp`, `add.webp`, `taskmaster.webp`, `serendipity-voice.webp`) resolves fine (200), so this is a single missing asset, not a broken helper or a broader outage.
- Pointed `tabImage` directly at `/images/botcafe.webp` (the same placeholder `navigation-image-fallback.client.ts` already swaps in globally on image error) instead of the missing per-tab asset, so the page never issues the failing request in the first place.
- Dropped the now-unused `getDashboardTabImagePath` import from the file.

### How I verified
- `curl -sSI https://media.acrocatranch.com/images/dashboard-tabs/scenario/storybook.webp` → 404; sibling scenario tab images → 200; `/images/botcafe.webp` → 200.
- `npx eslint components/conductor/storybook-page.vue` — clean.
- `npx vue-tsc --noEmit` — clean.
- `npx prettier --check components/conductor/storybook-page.vue` — clean.
- Root cause of the audit finding: the global client-side fallback plugin *would* eventually swap in the same placeholder on `error`, but only after the original request actually fails and a second image finishes loading — the exact window `auditResponsiveLayout.mjs`'s `naturalWidth === 0` BROKEN-ART check is designed to catch. This change removes the failing request entirely rather than depending on that runtime race.

### Stakes
reversible

### Flags for Reviewer
- The real fix is generating and uploading real Storybook hero art to the self-hosted media share (`docs/self-hosted-media.md`) — that requires filesystem access to the Unraid share this sandbox doesn't have, so it's out of scope here. This PR closes the observable bug (broken image render / audit failure); the cosmetic placeholder can be swapped for real art in a follow-up whenever that art exists.

### Kaizen suggestion
`auditResponsiveLayout.mjs`'s own docstring already warns "DO NOT TRUST THIS CHECK AGAINST A LOCAL DEV SERVER" because `public/images` isn't in the repo — worth adding a lightweight CI step (or a `--check-assets` audit mode) that HEAD-requests every static `getDashboardTabImagePath`/`getNavHeroImagePath`/`getNavThumbImagePath` path against the media origin, so a missing asset like this one surfaces as a fast, cheap link-check rather than only showing up as a 60-minute responsive-audit BROKEN-ART finding.

### Notes for reviewer
Conductor PR (interface-vision/t-111 claim + `status: review`) opens alongside this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kr5ikz6zUz1HbSQ83kCRHh)_