### PR TITLE
Stop crushing three interface-vision Phase-1 findings: /storybook, /play/challenges, /taskmaster

### DIFF
--- a/components/conductor/challenge-center-page.vue
+++ b/components/conductor/challenge-center-page.vue
@@ -26,18 +26,6 @@
               <Icon name="kind-icon:trophy" class="size-8 text-primary" />
             </div>
 
-            <!--
-              basis-full: this row's icon is shrink-0 and the actions group
-              has no min-w-0 floor override, so with flex-1's default
-              flex-basis:0% this div contributed ~0 to flex-wrap's
-              line-collection step and never earned its own line -- all
-              three ended up sharing one row on phone, with the entire
-              shrink deficit landing on this one flexible child and
-              crushing it to a ~20px sliver (interface-vision/t-110).
-              basis-full forces a 100% hypothetical width up front, so it
-              wraps onto its own row below the icon instead; sm:basis-auto
-              restores the compact single-line layout once there's room.
-            -->
             <div class="min-w-0 flex-1 basis-full sm:basis-auto">
               <p
                 class="text-xs font-black uppercase tracking-[0.28em] text-primary"

--- a/components/conductor/challenge-center-page.vue
+++ b/components/conductor/challenge-center-page.vue
@@ -26,7 +26,19 @@
               <Icon name="kind-icon:trophy" class="size-8 text-primary" />
             </div>
 
-            <div class="min-w-0 flex-1">
+            <!--
+              basis-full: this row's icon is shrink-0 and the actions group
+              has no min-w-0 floor override, so with flex-1's default
+              flex-basis:0% this div contributed ~0 to flex-wrap's
+              line-collection step and never earned its own line -- all
+              three ended up sharing one row on phone, with the entire
+              shrink deficit landing on this one flexible child and
+              crushing it to a ~20px sliver (interface-vision/t-110).
+              basis-full forces a 100% hypothetical width up front, so it
+              wraps onto its own row below the icon instead; sm:basis-auto
+              restores the compact single-line layout once there's room.
+            -->
+            <div class="min-w-0 flex-1 basis-full sm:basis-auto">
               <p
                 class="text-xs font-black uppercase tracking-[0.28em] text-primary"
               >

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -14,7 +14,18 @@
       >
         <Icon name="kind-icon:book" class="size-6" />
       </div>
-      <div class="min-w-0 flex-1">
+      <!--
+        basis-full: header's siblings (the icon and the mode-toggle group)
+        are both shrink-0, so with flex-1's default flex-basis:0% this div
+        contributed ~0 to flex-wrap's line-collection step and never earned
+        its own line -- all three ended up sharing one row on phone, with
+        the entire shrink deficit landing on this one flexible child and
+        crushing it to a ~10px sliver (interface-vision/t-110). basis-full
+        forces a 100% hypothetical width up front, so it wraps onto its own
+        row below the icon instead; sm:basis-auto restores the compact
+        single-line layout once there's room for everything.
+      -->
+      <div class="min-w-0 flex-1 basis-full sm:basis-auto">
         <p class="text-2xl font-black leading-tight">
           Build a world, then step inside it
         </p>

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -14,17 +14,6 @@
       >
         <Icon name="kind-icon:book" class="size-6" />
       </div>
-      <!--
-        basis-full: header's siblings (the icon and the mode-toggle group)
-        are both shrink-0, so with flex-1's default flex-basis:0% this div
-        contributed ~0 to flex-wrap's line-collection step and never earned
-        its own line -- all three ended up sharing one row on phone, with
-        the entire shrink deficit landing on this one flexible child and
-        crushing it to a ~10px sliver (interface-vision/t-110). basis-full
-        forces a 100% hypothetical width up front, so it wraps onto its own
-        row below the icon instead; sm:basis-auto restores the compact
-        single-line layout once there's room for everything.
-      -->
       <div class="min-w-0 flex-1 basis-full sm:basis-auto">
         <p class="text-2xl font-black leading-tight">
           Build a world, then step inside it

--- a/components/narrative/narrative-ingredient-picker.vue
+++ b/components/narrative/narrative-ingredient-picker.vue
@@ -98,7 +98,20 @@
       {{ emptyState }}
     </div>
 
-    <div v-else class="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+    <!--
+      No xl:grid-cols-3. `xl:` is a viewport breakpoint, not a container
+      one -- Taskmaster's only usage of this picker sits inside its
+      "recipe" panel, one of three columns in a `main` grid that ALSO
+      switches on the same xl breakpoint, so 1440px viewport meant a
+      ~390-430px sidebar column asked to hold three cards at once. Each
+      card's fixed w-28/sm:w-32 image column ate most of that, crushing
+      the flexible text span to a 24px sliver (interface-vision/t-112,
+      kind_robots run 31207144813). Two columns fits the same sidebar
+      comfortably; both current call sites (Setting, Genre/mood/style)
+      only ever render in this narrow column, so there is no wide-usage
+      case this tier was serving.
+    -->
+    <div v-else class="grid gap-2 md:grid-cols-2">
       <button
         v-if="allowEmpty"
         type="button"

--- a/components/narrative/narrative-ingredient-picker.vue
+++ b/components/narrative/narrative-ingredient-picker.vue
@@ -98,19 +98,6 @@
       {{ emptyState }}
     </div>
 
-    <!--
-      No xl:grid-cols-3. `xl:` is a viewport breakpoint, not a container
-      one -- Taskmaster's only usage of this picker sits inside its
-      "recipe" panel, one of three columns in a `main` grid that ALSO
-      switches on the same xl breakpoint, so 1440px viewport meant a
-      ~390-430px sidebar column asked to hold three cards at once. Each
-      card's fixed w-28/sm:w-32 image column ate most of that, crushing
-      the flexible text span to a 24px sliver (interface-vision/t-112,
-      kind_robots run 31207144813). Two columns fits the same sidebar
-      comfortably; both current call sites (Setting, Genre/mood/style)
-      only ever render in this narrow column, so there is no wide-usage
-      case this tier was serving.
-    -->
     <div v-else class="grid gap-2 md:grid-cols-2">
       <button
         v-if="allowEmpty"


### PR DESCRIPTION
interface-vision/t-110 + t-112: three related phone/desktop crush findings from the same audit run ([31207144813](https://github.com/silasfelinus/kind_robots/actions/runs/31207144813)), same underlying flexbox mechanism, batched into one PR since the audit queue is serialized (one run at a time) and both fixes are small/independent.

## t-110: `/storybook` and `/play/challenges` title blocks crush on phone

Both routes have a header row: `shrink-0` icon, `min-w-0 flex-1` title block, `shrink-0` button group. Tailwind's `flex-1` sets `flex-basis: 0%`, and `min-w-0` removes the automatic min-content floor — so during flexbox's line-collection step the title block contributed ~0 to "does this line fit," and never wrapped onto its own line. All three siblings crammed onto one line on phone (390px), and the entire shrink deficit landed on the one flexible child: a **10px sliver on `/storybook`**, a **20px sliver on `/play/challenges`** (`CRUSHED <div> ... w=10 .min-w-0 flex-1`, `w=20 .min-w-0 flex-1`).

Fix: `basis-full sm:basis-auto` on each title block, forcing it to claim its own row on phone; reverts to the compact single-line layout at `sm:` where both routes already pass.

## t-112: `/taskmaster`'s recipe-panel ingredient cards crush on desktop

`narrative-ingredient-picker`'s grid used `xl:grid-cols-3` — a **viewport** breakpoint. Its only call site (Taskmaster's "recipe" panel) is one of three columns in a page grid that *also* switches at the same `xl` breakpoint, so a 1440px viewport meant a ~390-430px sidebar column was asked to hold three cards at once. Each card's fixed `w-28`/`sm:w-32` image ate most of that column, crushing the flexible text span to a **24px sliver** on all six option cards (`CRUSHED <span> ... w=24 .min-w-0 flex-1`).

Fix: drop the `xl:grid-cols-3` tier. `md:grid-cols-2` already fits the sidebar comfortably, and both current call sites (Setting, Genre/mood/style) only ever render in this narrow column — no wide-usage case depended on the third column.

## Verification
- `eslint` clean on all three changed files
- `vue-tsc --noEmit` clean (full project typecheck)
- No data/store contracts touched — pure layout class changes
- Will report the deployment-triggered `audit` job's raw per-route result before merging (queue is serialized behind other in-flight audit runs, so this may take a while)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WLft1fQfr5yxwsaBXQfYJi