### PR TITLE
Make Art Trainer revisions queue real priority-100 redos

### DIFF
--- a/components/art/artjob-feedback-manager.vue
+++ b/components/art/artjob-feedback-manager.vue
@@ -13,8 +13,8 @@
             </span>
           </div>
           <p class="mt-1 text-xs text-base-content/60">
-            Conductor curates finished jobs. Your verdict becomes training context
-            for its next pass.
+            Review finished renders yourself. Promote and Reject save feedback;
+            Revise can queue a real prompt-only or image-guided replacement.
           </p>
         </div>
         <button
@@ -162,11 +162,17 @@
             <textarea
               v-model="notesByJob[job.id]"
               class="textarea textarea-bordered mt-2 min-h-20 w-full rounded-2xl text-xs"
-              placeholder="What worked, what failed, or how the next prompt should change…"
+              placeholder="What worked, what failed, or what should be remembered for the next attempt…"
             />
           </div>
 
-          <div class="mt-3 grid grid-cols-3 gap-2">
+          <artjob-trainer-redo-controls
+            :job="job"
+            :summary="notesByJob[job.id] || null"
+            :tags="tagsByJob[job.id] || []"
+          />
+
+          <div class="mt-3 grid grid-cols-2 gap-2">
             <button
               type="button"
               class="btn btn-success btn-sm rounded-2xl"
@@ -174,14 +180,6 @@
               @click="saveFeedback(job, 'PROMOTE')"
             >
               Promote
-            </button>
-            <button
-              type="button"
-              class="btn btn-warning btn-sm rounded-2xl"
-              :disabled="isSaving(job.id)"
-              @click="saveFeedback(job, 'REVISE')"
-            >
-              Revise
             </button>
             <button
               type="button"
@@ -320,51 +318,51 @@ function jobImageInfo(job: ArtJobRecord) {
   return artJobStore.imageInfoById[job.artImageId] || null
 }
 
-// Track srcs whose <img>/<video> failed to load (e.g. a path that 404s) so the
-// tile falls back to the diagnostic instead of a silent broken-image icon.
 const failedSrcs = ref<Set<string>>(new Set())
 function markImageFailed(job: ArtJobRecord) {
-  const s = jobImageSrc(job)
-  if (s) failedSrcs.value = new Set(failedSrcs.value).add(s)
+  const src = jobImageSrc(job)
+  if (src) failedSrcs.value = new Set(failedSrcs.value).add(src)
 }
 function jobImageFailed(job: ArtJobRecord): boolean {
-  const s = jobImageSrc(job)
-  return !!s && failedSrcs.value.has(s)
+  const src = jobImageSrc(job)
+  return Boolean(src && failedSrcs.value.has(src))
 }
 function jobImageShowable(job: ArtJobRecord): boolean {
-  return !!jobImageSrc(job) && !jobImageFailed(job)
+  return Boolean(jobImageSrc(job)) && !jobImageFailed(job)
 }
 
 function jobImageKind(job: ArtJobRecord): string {
   return jobImageInfo(job)?.kind ?? 'none'
 }
 
-// Short keyword under the placeholder; '' while the image is still loading.
 function jobImageReason(job: ArtJobRecord): string {
   if (jobImageFailed(job)) return 'load failed (404?)'
   const info = jobImageInfo(job)
   if (!info || info.kind !== 'none') return ''
-  const d = info.diag
-  if (!d.hasImageData && d.imagePath === '(none)' && d.path === '(none)') return 'no bytes stored'
-  if (d.imageDataShape === 'unusable') return 'bad imageData'
-  if (d.imagePath !== '(none)' || d.path !== '(none)') return 'unresolved path'
+  const diag = info.diag
+  if (!diag.hasImageData && diag.imagePath === '(none)' && diag.path === '(none)') {
+    return 'no bytes stored'
+  }
+  if (diag.imageDataShape === 'unusable') return 'bad imageData'
+  if (diag.imagePath !== '(none)' || diag.path !== '(none)') return 'unresolved path'
   return 'no source'
 }
 
-// Full field dump for the hover tooltip — what the row actually holds.
 function jobImageDiag(job: ArtJobRecord): string {
   const info = jobImageInfo(job)
   if (!info) return `ArtImage ${job.artImageId ?? '—'}: not loaded yet`
-  const d = info.diag
+  const diag = info.diag
   const lines = [
     `reason: ${info.reason}`,
-    `kind: ${info.kind}  ·  used: ${d.usedField}`,
-    `imageData: ${d.hasImageData ? d.imageDataShape : 'empty'}`,
-    `fileType: ${d.fileType}`,
-    `imagePath: ${d.imagePath}`,
-    `path: ${d.path}`,
+    `kind: ${info.kind}  ·  used: ${diag.usedField}`,
+    `imageData: ${diag.hasImageData ? diag.imageDataShape : 'empty'}`,
+    `fileType: ${diag.fileType}`,
+    `imagePath: ${diag.imagePath}`,
+    `path: ${diag.path}`,
   ]
-  if (jobImageFailed(job)) lines.unshift(`LOAD FAILED — attempted: ${jobImageSrc(job)}`)
+  if (jobImageFailed(job)) {
+    lines.unshift(`LOAD FAILED — attempted: ${jobImageSrc(job)}`)
+  }
   return lines.join('\n')
 }
 
@@ -422,7 +420,7 @@ async function saveFeedback(
       verdict,
       summary: notesByJob[job.id]?.trim() || null,
       tags: tagsByJob[job.id] || [],
-      rubricKey: 'silas-art-trainer-v1',
+      rubricKey: 'silas-art-trainer-v2',
     })
   } finally {
     savingIds.value = savingIds.value.filter((id) => id !== job.id)

--- a/components/art/artjob-trainer-redo-controls.vue
+++ b/components/art/artjob-trainer-redo-controls.vue
@@ -1,0 +1,187 @@
+<!-- /components/art/artjob-trainer-redo-controls.vue -->
+<template>
+  <details class="mt-3 rounded-2xl border border-warning/30 bg-warning/5 p-3">
+    <summary class="cursor-pointer list-none text-xs font-semibold marker:hidden">
+      <span class="flex flex-wrap items-center justify-between gap-2">
+        <span>Revise and queue a real redo</span>
+        <span class="badge badge-warning badge-outline badge-sm rounded-2xl">
+          priority 100
+        </span>
+      </span>
+    </summary>
+
+    <div class="mt-3 space-y-3">
+      <div class="grid gap-2 sm:grid-cols-2">
+        <label class="form-control gap-1">
+          <span class="text-[10px] font-semibold uppercase tracking-wide text-base-content/50">
+            Method
+          </span>
+          <select
+            v-model="mode"
+            class="select select-bordered select-sm rounded-xl"
+            :disabled="submitting"
+          >
+            <option value="TEXT">Prompt-only redo</option>
+            <option value="IMG2IMG" :disabled="!canUseImage">
+              Use finished image as base
+            </option>
+          </select>
+        </label>
+
+        <label v-if="mode === 'IMG2IMG'" class="form-control gap-1">
+          <span class="text-[10px] font-semibold uppercase tracking-wide text-base-content/50">
+            Model
+          </span>
+          <select
+            v-model="model"
+            class="select select-bordered select-sm rounded-xl"
+            :disabled="submitting"
+          >
+            <option value="SDXL">SDXL img2img</option>
+            <option value="KONTEXT">Kontext edit · slower</option>
+          </select>
+        </label>
+
+        <div
+          v-else
+          class="rounded-xl border border-base-300 bg-base-100/70 px-3 py-2 text-xs text-base-content/55"
+        >
+          <span class="font-semibold">Model:</span> SDXL · prompt only
+        </div>
+      </div>
+
+      <label class="form-control gap-1">
+        <span class="text-[10px] font-semibold uppercase tracking-wide text-base-content/50">
+          Revised prompt
+        </span>
+        <textarea
+          v-model="promptString"
+          class="textarea textarea-bordered min-h-28 w-full rounded-xl text-xs leading-relaxed"
+          maxlength="5000"
+          :disabled="submitting"
+          placeholder="Edit the original prompt into the version you actually want rendered…"
+        />
+      </label>
+
+      <p class="text-[11px] leading-relaxed text-base-content/50">
+        Prompt-only rebuilds from text. Image-guided uses this job’s finished ArtImage as the input while preserving the source job’s retry/destination lineage.
+      </p>
+
+      <p v-if="message" class="text-xs" :class="messageToneClass">
+        {{ message }}
+      </p>
+
+      <button
+        type="button"
+        class="btn btn-warning btn-sm w-full rounded-xl"
+        :disabled="submitting || promptString.trim().length < 3"
+        @click="queueRevision"
+      >
+        <span v-if="submitting" class="loading loading-spinner loading-xs" />
+        {{ submitting ? 'Queuing revision…' : 'Revise + queue redo' }}
+      </button>
+    </div>
+  </details>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import {
+  useArtJobStore,
+  type ArtJobRecord,
+} from '@/stores/artJobStore'
+import {
+  useArtTrainerStore,
+  type ArtTrainerRedoMode,
+  type ArtTrainerRedoModel,
+} from '@/stores/artTrainerStore'
+
+const props = defineProps<{
+  job: ArtJobRecord
+  summary?: string | null
+  tags?: string[]
+}>()
+
+const artJobStore = useArtJobStore()
+const trainerStore = useArtTrainerStore()
+const mode = ref<ArtTrainerRedoMode>('TEXT')
+const model = ref<ArtTrainerRedoModel>('SDXL')
+const promptString = ref(readJobPrompt(props.job))
+const message = ref('')
+const messageTone = ref<'success' | 'error'>('success')
+
+const submitting = computed(() => trainerStore.isSubmitting(props.job.id))
+const canUseImage = computed(() => {
+  return (
+    typeof props.job.artImageId === 'number' &&
+    props.job.artImageId > 0 &&
+    String(props.job.payload?.media || '').toLowerCase() !== 'video'
+  )
+})
+const messageToneClass = computed(() =>
+  messageTone.value === 'error' ? 'text-error' : 'text-success',
+)
+
+watch(
+  () => props.job.id,
+  () => {
+    mode.value = 'TEXT'
+    model.value = 'SDXL'
+    promptString.value = readJobPrompt(props.job)
+    message.value = ''
+  },
+)
+
+watch(canUseImage, (allowed) => {
+  if (!allowed && mode.value === 'IMG2IMG') mode.value = 'TEXT'
+})
+
+function readJobPrompt(job: ArtJobRecord): string {
+  const payload: Record<string, unknown> = job.payload || {}
+  for (const key of ['promptString', 'artPrompt', 'prompt']) {
+    const value = payload[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return ''
+}
+
+async function queueRevision(): Promise<void> {
+  if (submitting.value) return
+  message.value = ''
+
+  const result = await trainerStore.queueRedo(props.job, {
+    mode: mode.value,
+    model: model.value,
+    promptString: promptString.value,
+  })
+
+  if (!result.success || !result.jobId) {
+    message.value = result.message
+    messageTone.value = 'error'
+    return
+  }
+
+  const feedbackSaved = await artJobStore.submitFeedback(props.job.id, {
+    source: 'HUMAN',
+    verdict: 'REVISE',
+    summary: props.summary?.trim() || null,
+    reasons: [
+      `Queued trainer redo ArtJob ${result.jobId}`,
+      mode.value === 'IMG2IMG'
+        ? `${model.value} image-guided revision`
+        : 'SDXL prompt-only revision',
+    ],
+    tags: props.tags || [],
+    rubricKey: 'silas-art-trainer-v2',
+  })
+
+  if (!feedbackSaved) {
+    message.value = `ArtJob ${result.jobId} was queued, but saving the trainer verdict failed.`
+    messageTone.value = 'error'
+    return
+  }
+
+  message.value = `Queued ArtJob ${result.jobId} at priority 100.`
+  messageTone.value = 'success'
+}
+</script>

--- a/server/api/art/queue/[id]/trainer-redo.post.ts
+++ b/server/api/art/queue/[id]/trainer-redo.post.ts
@@ -1,0 +1,205 @@
+// /server/api/art/queue/[id]/trainer-redo.post.ts
+import {
+  createError,
+  defineEventHandler,
+  getRouterParam,
+  readBody,
+} from 'h3'
+import prisma from '../../../../utils/prisma'
+import { errorHandler } from '../../../../utils/error'
+import { requireMachineUser } from '../../../../utils/authGuard'
+import {
+  decodeArtJobPayload,
+  serializeArtJobPayload,
+} from '../../../../utils/artJobPayload'
+import {
+  applyArtJobOverrides,
+  prepareArtJobRetryPayload,
+} from '../../../../utils/artJobRetry'
+import { assessArtPrompt, cleanArtPrompt } from '../../../../utils/artPromptQuality'
+import {
+  buildWorkflowForEngine,
+  extractRenderRequest,
+} from '../../../comfy/utils/engineWorkflow'
+import { buildSdxlImg2ImgWorkflow } from '../../../comfy/sdxl/utils/workflow'
+import {
+  buildKontextWorkflow,
+  getKontextImageExtension,
+} from '../../../comfy/kontext/utils/workflow'
+
+type TrainerRedoMode = 'TEXT' | 'IMG2IMG'
+type TrainerRedoModel = 'SDXL' | 'KONTEXT'
+
+type TrainerRedoBody = {
+  mode?: string | null
+  model?: string | null
+  promptString?: string | null
+  sourceImageBase64?: string | null
+}
+
+function normalizeImageData(value: unknown): string {
+  const imageData = String(value || '').trim()
+  if (!imageData) return ''
+  return imageData.startsWith('data:image/')
+    ? imageData
+    : `data:image/png;base64,${imageData}`
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireMachineUser(event)
+    if (!auth.isAdmin && !auth.isServerKey) {
+      throw createError({
+        statusCode: 403,
+        message: 'Admin access required to queue trainer revisions.',
+      })
+    }
+
+    const id = Number(getRouterParam(event, 'id'))
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid job id.' })
+    }
+
+    const body = (await readBody(event).catch(() => null)) as TrainerRedoBody | null
+    const mode = String(body?.mode || 'TEXT').toUpperCase() as TrainerRedoMode
+    const model = String(body?.model || 'SDXL').toUpperCase() as TrainerRedoModel
+
+    if (mode !== 'TEXT' && mode !== 'IMG2IMG') {
+      throw createError({
+        statusCode: 400,
+        message: 'mode must be TEXT or IMG2IMG.',
+      })
+    }
+    if (model !== 'SDXL' && model !== 'KONTEXT') {
+      throw createError({
+        statusCode: 400,
+        message: 'model must be SDXL or KONTEXT.',
+      })
+    }
+    if (mode === 'TEXT' && model === 'KONTEXT') {
+      throw createError({
+        statusCode: 400,
+        message: 'Kontext trainer revisions require IMG2IMG mode.',
+      })
+    }
+
+    const source = await prisma.artJob.findUnique({ where: { id } })
+    if (!source) {
+      throw createError({ statusCode: 404, message: `Job ${id} not found.` })
+    }
+    if (source.status !== 'DONE' || !source.artImageId) {
+      throw createError({
+        statusCode: 409,
+        message: 'Trainer revisions require a completed source job with an ArtImage.',
+      })
+    }
+
+    const promptString = cleanArtPrompt(body?.promptString)
+    const promptAssessment = assessArtPrompt(promptString)
+    if (!promptAssessment.useful) {
+      throw createError({
+        statusCode: 422,
+        message: `Trainer revision blocked because the prompt is not usable (${promptAssessment.reasons.join(', ')}).`,
+      })
+    }
+
+    const prepared = prepareArtJobRetryPayload(
+      source.payload,
+      source.id,
+      source.artImageId,
+      'NEW_OUTPUT',
+      true,
+    )
+    const sourceRequest = extractRenderRequest(prepared)
+    const renderRequest = {
+      ...sourceRequest,
+      prompt: promptString,
+      seed: null,
+    }
+
+    // A trainer redo deliberately rebuilds the render graph instead of merely
+    // mutating the old one. That makes the two human-facing choices explicit:
+    // prompt-only SDXL, or image-guided SDXL/Kontext using the finished image.
+    if (mode === 'TEXT') {
+      prepared.workflow = buildWorkflowForEngine('comfy', renderRequest)
+      delete prepared.images
+    } else {
+      const imageData = normalizeImageData(body?.sourceImageBase64)
+      if (!imageData) {
+        throw createError({
+          statusCode: 400,
+          message: 'IMG2IMG trainer revisions require sourceImageBase64.',
+        })
+      }
+
+      const extension = getKontextImageExtension(imageData)
+      if (model === 'KONTEXT') {
+        const imageName = `kr_trainer_kontext_${crypto.randomUUID()}.${extension}`
+        prepared.workflow = buildKontextWorkflow({
+          prompt: promptString,
+          imageName,
+          width: renderRequest.width,
+          height: renderRequest.height,
+          seed: null,
+        })
+        prepared.images = [{ name: imageName, imageData }]
+      } else {
+        const imageName = `kr_trainer_sdxl_${crypto.randomUUID()}.${extension}`
+        const { workflow } = buildSdxlImg2ImgWorkflow({
+          prompt: promptString,
+          negativePrompt: renderRequest.negativePrompt,
+          imageName,
+          seed: null,
+          denoise: 0.55,
+          originalWeight: 0.55,
+        })
+        prepared.workflow = workflow
+        prepared.images = [{ name: imageName, imageData }]
+      }
+    }
+
+    const payload = applyArtJobOverrides(prepared, { promptString })
+    delete payload.resources
+    payload.trainerRedo = {
+      mode,
+      model,
+      sourceJobId: source.id,
+      sourceArtImageId: source.artImageId,
+      priority: 100,
+      requestedAt: new Date().toISOString(),
+    }
+
+    const job = await prisma.artJob.create({
+      data: {
+        engine: 'COMFY',
+        payload: serializeArtJobPayload(payload),
+        priority: 100,
+        projectSlug: source.projectSlug,
+        projectId: source.projectId,
+        userId: source.userId,
+      },
+    })
+
+    event.node.res.statusCode = 201
+    return {
+      success: true,
+      message: `Queued trainer revision as ArtJob ${job.id} at priority 100.`,
+      data: {
+        job: decodeArtJobPayload(job),
+        sourceJobId: source.id,
+        sourceArtImageId: source.artImageId,
+        mode,
+        model,
+      },
+      statusCode: 201,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      message: handled.message || 'Failed to queue trainer revision.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/api/art/queue/[id]/trainer-redo.post.ts
+++ b/server/api/art/queue/[id]/trainer-redo.post.ts
@@ -137,9 +137,11 @@ export default defineEventHandler(async (event) => {
         const imageName = `kr_trainer_kontext_${crypto.randomUUID()}.${extension}`
         prepared.workflow = buildKontextWorkflow({
           prompt: promptString,
+          negativePrompt: renderRequest.negativePrompt,
           imageName,
           width: renderRequest.width,
           height: renderRequest.height,
+          originalWeight: 0.55,
           seed: null,
         })
         prepared.images = [{ name: imageName, imageData }]
@@ -150,7 +152,6 @@ export default defineEventHandler(async (event) => {
           negativePrompt: renderRequest.negativePrompt,
           imageName,
           seed: null,
-          denoise: 0.55,
           originalWeight: 0.55,
         })
         prepared.workflow = workflow

--- a/stores/artTrainerStore.ts
+++ b/stores/artTrainerStore.ts
@@ -1,0 +1,121 @@
+// /stores/artTrainerStore.ts
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { performFetch } from '@/stores/utils'
+import type { ArtJobRecord } from '@/stores/artJobStore'
+
+export type ArtTrainerRedoMode = 'TEXT' | 'IMG2IMG'
+export type ArtTrainerRedoModel = 'SDXL' | 'KONTEXT'
+
+export type ArtTrainerRedoInput = {
+  mode: ArtTrainerRedoMode
+  model: ArtTrainerRedoModel
+  promptString: string
+}
+
+type TrainerRedoResponse = {
+  job: ArtJobRecord
+  sourceJobId: number
+  sourceArtImageId: number
+  mode: ArtTrainerRedoMode
+  model: ArtTrainerRedoModel
+}
+
+function blobToDataUri(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result || ''))
+    reader.onerror = () => reject(new Error('The source image could not be read.'))
+    reader.readAsDataURL(blob)
+  })
+}
+
+export const useArtTrainerStore = defineStore('artTrainerStore', () => {
+  const submittingJobIds = ref<number[]>([])
+  const error = ref<string | null>(null)
+
+  function isSubmitting(jobId: number): boolean {
+    return submittingJobIds.value.includes(jobId)
+  }
+
+  async function sourceImageDataUri(artImageId: number): Promise<string> {
+    const response = await fetch(`/api/art/images/${artImageId}/file`, {
+      credentials: 'include',
+      cache: 'no-store',
+    })
+    if (!response.ok) {
+      throw new Error(
+        `The finished image could not be loaded for img2img (${response.status}).`,
+      )
+    }
+    return blobToDataUri(await response.blob())
+  }
+
+  async function queueRedo(
+    job: ArtJobRecord,
+    input: ArtTrainerRedoInput,
+  ): Promise<{ success: boolean; message: string; jobId: number | null }> {
+    if (isSubmitting(job.id)) {
+      return { success: false, message: 'This revision is already being queued.', jobId: null }
+    }
+
+    submittingJobIds.value = [...submittingJobIds.value, job.id]
+    error.value = null
+
+    try {
+      const promptString = input.promptString.trim()
+      if (promptString.length < 3) {
+        throw new Error('Add a usable revised prompt before queuing the redo.')
+      }
+      if (input.mode === 'IMG2IMG' && (!job.artImageId || job.artImageId <= 0)) {
+        throw new Error('This finished job has no ArtImage to use as img2img input.')
+      }
+
+      const sourceImageBase64 =
+        input.mode === 'IMG2IMG' && job.artImageId
+          ? await sourceImageDataUri(job.artImageId)
+          : undefined
+
+      const response = await performFetch<TrainerRedoResponse>(
+        `/api/art/queue/${job.id}/trainer-redo`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            mode: input.mode,
+            model: input.mode === 'TEXT' ? 'SDXL' : input.model,
+            promptString,
+            ...(sourceImageBase64 ? { sourceImageBase64 } : {}),
+          }),
+        },
+        0,
+        60_000,
+      )
+
+      const jobId = Number(response.data?.job?.id)
+      if (!response.success || !Number.isInteger(jobId) || jobId <= 0) {
+        throw new Error(response.message || 'Trainer revision could not be queued.')
+      }
+
+      return {
+        success: true,
+        message: response.message || `Queued trainer revision as ArtJob ${jobId}.`,
+        jobId,
+      }
+    } catch (cause) {
+      const message =
+        cause instanceof Error ? cause.message : 'Trainer revision could not be queued.'
+      error.value = message
+      return { success: false, message, jobId: null }
+    } finally {
+      submittingJobIds.value = submittingJobIds.value.filter((id) => id !== job.id)
+    }
+  }
+
+  return {
+    submittingJobIds,
+    error,
+    isSubmitting,
+    queueRedo,
+  }
+})

--- a/stores/artTrainerStore.ts
+++ b/stores/artTrainerStore.ts
@@ -48,7 +48,12 @@ export const useArtTrainerStore = defineStore('artTrainerStore', () => {
         `The finished image could not be loaded for img2img (${response.status}).`,
       )
     }
-    return blobToDataUri(await response.blob())
+
+    const blob = await response.blob()
+    if (!blob.type.startsWith('image/')) {
+      throw new Error('This finished ArtJob is not an image and cannot use img2img.')
+    }
+    return blobToDataUri(blob)
   }
 
   async function queueRedo(
@@ -56,7 +61,11 @@ export const useArtTrainerStore = defineStore('artTrainerStore', () => {
     input: ArtTrainerRedoInput,
   ): Promise<{ success: boolean; message: string; jobId: number | null }> {
     if (isSubmitting(job.id)) {
-      return { success: false, message: 'This revision is already being queued.', jobId: null }
+      return {
+        success: false,
+        message: 'This revision is already being queued.',
+        jobId: null,
+      }
     }
 
     submittingJobIds.value = [...submittingJobIds.value, job.id]

--- a/stores/dailyDreamArchiveStore.ts
+++ b/stores/dailyDreamArchiveStore.ts
@@ -409,6 +409,7 @@ export const useDailyDreamArchiveStore = defineStore(
               isPublic: input.entity.isPublic ?? true,
               isMature: input.entity.isMature ?? false,
               designer: input.entity.designer || null,
+              priority: 100,
               ...(input.steps ? { steps: input.steps } : {}),
               ...(input.denoise != null ? { denoise: input.denoise } : {}),
               ...(input.originalWeight != null

--- a/utils/scripts/verifyDailyDreamArchiveWorkbench.ts
+++ b/utils/scripts/verifyDailyDreamArchiveWorkbench.ts
@@ -49,6 +49,7 @@ expectContains('components/dreams/daily-dream-object-art-workbench.vue', [
 
 expectContains('stores/dailyDreamArchiveStore.ts', [
   "'/api/art/enqueue'",
+  'priority: 100',
   '`/api/art/queue/${jobId}`',
   'entityArt:',
   'async function updateObject(',

--- a/utils/wonderlab/previewFixtureCatalog.ts
+++ b/utils/wonderlab/previewFixtureCatalog.ts
@@ -27,6 +27,10 @@ import {
   getWonderLabCoverageClosureFixture,
   listWonderLabCoverageClosureFixtureKeys,
 } from './previewFixturesCoverageClosure'
+import {
+  getWonderLabArtTrainerFixture,
+  listWonderLabArtTrainerFixtureKeys,
+} from './previewFixturesArtTrainer'
 
 export type {
   WonderLabPreviewFixture,
@@ -44,7 +48,8 @@ export function getWonderLabPreviewFixture(
     getWonderLabLearningControlFixture(componentName, sourcePath) ??
     getWonderLabBuilderRulerFixture(componentName, sourcePath) ??
     getWonderLabInteractionDisplayFixture(componentName, sourcePath) ??
-    getWonderLabCoverageClosureFixture(componentName, sourcePath)
+    getWonderLabCoverageClosureFixture(componentName, sourcePath) ??
+    getWonderLabArtTrainerFixture(componentName, sourcePath)
   )
 }
 
@@ -58,6 +63,7 @@ export function listWonderLabPreviewFixtureKeys(): string[] {
       ...listWonderLabBuilderRulerFixtureKeys(),
       ...listWonderLabInteractionDisplayFixtureKeys(),
       ...listWonderLabCoverageClosureFixtureKeys(),
+      ...listWonderLabArtTrainerFixtureKeys(),
     ]),
   ].sort()
 }

--- a/utils/wonderlab/previewFixturesArtTrainer.ts
+++ b/utils/wonderlab/previewFixturesArtTrainer.ts
@@ -1,0 +1,59 @@
+// /utils/wonderlab/previewFixturesArtTrainer.ts
+import type { WonderLabPreviewFixture } from './previewFixtures'
+
+const fixtures: Record<string, WonderLabPreviewFixture> = {
+  'artjob-trainer-redo-controls': {
+    title: 'Art Trainer redo controls',
+    description:
+      'A completed synthetic image job exposes prompt-only and image-guided redo choices without submitting, fetching, or mutating anything until the button is clicked.',
+    viewport: 'tablet',
+    minHeight: '28rem',
+    props: {
+      job: {
+        id: -1586,
+        status: 'DONE',
+        engine: 'COMFY',
+        priority: 0,
+        projectSlug: 'wonderlab-fixture',
+        projectId: null,
+        userId: 0,
+        artImageId: 4242,
+        error: null,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        payload: {
+          media: 'image',
+          promptString:
+            'A friendly brass robot tending a moonlit greenhouse, cinematic depth, no readable text.',
+        },
+      },
+      summary: 'Preserve the robot silhouette; make the greenhouse less cluttered.',
+      tags: ['composition', 'prompt-fit'],
+    },
+  },
+}
+
+function normalizeFixtureKey(value: string): string {
+  return value
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^.*\//, '')
+    .replace(/\.vue$/i, '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+}
+
+export function getWonderLabArtTrainerFixture(
+  componentName: string,
+  sourcePath = '',
+): WonderLabPreviewFixture | null {
+  const sourceKey = normalizeFixtureKey(sourcePath)
+  const componentKey = normalizeFixtureKey(componentName)
+  return fixtures[sourceKey] ?? fixtures[componentKey] ?? null
+}
+
+export function listWonderLabArtTrainerFixtureKeys(): string[] {
+  return Object.keys(fixtures).sort()
+}


### PR DESCRIPTION
## What changed
- Daily Dream archive art generation now enqueues at priority `100`.
- The Art Trainer no longer presents `Revise` as feedback-only behavior.
- Added an explicit redo control with:
  - prompt-only SDXL redo
  - image-guided SDXL img2img
  - image-guided Kontext edit (marked slower)
- Trainer redos always enqueue at priority `100`.
- Trainer redos preserve the source ArtJob retry/project/destination lineage, while rebuilding the render graph for the selected redo mode.
- A successful redo records the HUMAN `REVISE` verdict with the created ArtJob ID in feedback reasons.

## Root cause
The existing `Revise` button only called `/api/art/queue/:id/feedback`; it never called the queue/retry path, so no new ArtJob was created. Separately, Daily Dream art workbench requests omitted `priority`, so `/api/art/enqueue` defaulted them to `0`.

## Safety / behavior
- No schema or migration changes.
- No destructive ArtImage writes.
- Image-guided redo loads exactly the selected finished ArtImage and rejects non-image payloads.
- The new job is a `NEW_OUTPUT` retry descendant instead of overwriting the source image.

## Verification
Connector-only session: local checkout/`gh` is unavailable, so this PR is intentionally relying on the repository's required TypeScript/verify/format checks. I will inspect the completed runs and fix any failures before merge.