### PR TITLE
Provision isolated Vercel database lanes

### DIFF
--- a/.github/workflows/vercel-db-isolation-contract.yml
+++ b/.github/workflows/vercel-db-isolation-contract.yml
@@ -1,0 +1,32 @@
+name: Vercel DB Isolation Contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/provision-vercel-db-isolation.sh'
+      - 'scripts/prisma-migrate-deploy.mjs'
+      - 'utils/scripts/verifyVercelDbIsolationProvisioning.mjs'
+      - '.github/workflows/vercel-db-isolation-contract.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: vercel-db-isolation-contract-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Provisioning contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify provisioning script
+        run: node utils/scripts/verifyVercelDbIsolationProvisioning.mjs

--- a/docs/runbooks/vercel-database-isolation.md
+++ b/docs/runbooks/vercel-database-isolation.md
@@ -1,0 +1,158 @@
+# Vercel database isolation runbook
+
+This is the durable repair for GitHub issue #1581. It separates Vercel Preview
+traffic and production migrations from the production `kindrobot` ProxySQL
+frontend budget.
+
+## Target topology
+
+```text
+Production runtime
+  DATABASE_URL -> kindrobot -> ProxySQL hostgroup 10 -> MariaDB
+  Vercel pool: max 2, minimumIdle 0, idle 15s
+
+Vercel Preview
+  DATABASE_URL -> kindrobot_preview -> ProxySQL hostgroup 20 -> same MariaDB
+  ProxySQL frontend max: 40
+  ProxySQL backend max: 8 per production backend row
+  MariaDB privileges: SELECT + SHOW VIEW only
+  Vercel pool: max 1, minimumIdle 0, idle 5s
+
+Production migrations
+  MIGRATION_DATABASE_URL -> kindrobot_migrate -> ProxySQL hostgroup 30 -> same MariaDB
+  ProxySQL frontend max: 8
+  ProxySQL backend max: 4 per production backend row
+  MariaDB privileges: ALL on the Kind Robots schema only, without GRANT OPTION
+```
+
+The production hostgroup remains unchanged. With the current single production
+backend capped at 40, the default isolated maxima are 40 + 8 + 4 = 52 possible
+ProxySQL backend connections. The provisioning script refuses to apply if that
+would leave less than 30 connections of MariaDB's global capacity in reserve.
+
+Preview is intentionally read-only. A preview that unexpectedly writes during a
+normal page load should fail visibly instead of mutating production data. Cypress
+remains manual while it still targets the production application and performs
+write-heavy API tests. If write-capable automated testing is needed again, give it
+a dedicated test database rather than granting Vercel Preview production-equivalent
+write access.
+
+## 1. Provision the database lanes on Alexandria
+
+From a current Kind Robots checkout on the Unraid host:
+
+```bash
+bash scripts/provision-vercel-db-isolation.sh
+```
+
+The default invocation is read-only and prints the planned topology without
+passwords. If the preflight is clean, apply it:
+
+```bash
+bash scripts/provision-vercel-db-isolation.sh --apply
+```
+
+The script:
+
+- discovers ProxySQL admin credentials from the existing container config;
+- discovers the MariaDB root password from the existing container environment when available;
+- derives the schema and TLS-user setting from the production `kindrobot` ProxySQL user;
+- refuses to reuse target hostgroups if they contain unrelated backends;
+- refuses to continue when generic ProxySQL query rules could route the new users away from their isolated hostgroups;
+- creates `kindrobot_preview` as a read-only MariaDB account;
+- creates `kindrobot_migrate` with schema-level migration privileges;
+- gives each account its own ProxySQL frontend ceiling and backend hostgroup;
+- hashes the stored ProxySQL passwords with `MYSQL_NATIVE_PASSWORD()`;
+- preserves MariaDB headroom before adding backend capacity;
+- changes ProxySQL `mysql-wait_timeout` from the old eight-hour retention window to 600000 ms (10 minutes);
+- loads the server/user/variable changes into ProxySQL runtime and saves them to disk;
+- verifies the runtime users, hostgroups, limits, and timeout;
+- writes the generated handoff values to `/mnt/user/pc/kindrobots-db-isolation.env` with mode 600;
+- writes a password-free pre-change ProxySQL snapshot next to that file.
+
+The credential file is deliberately not printed to the terminal. Keep it private.
+If the script is rerun, it reuses the saved credentials rather than silently
+rotating an already-provisioned account.
+
+## 2. Set Vercel environment variables
+
+In the Vercel project, open **Settings -> Environment Variables**. Environment
+variables are scoped by deployment environment, and changing them affects only
+new deployments.
+
+Use the values from `/mnt/user/pc/kindrobots-db-isolation.env`:
+
+1. Edit `DATABASE_URL` for **Preview only** and set it to the value of
+   `VERCEL_PREVIEW_DATABASE_URL`.
+2. Leave the existing `DATABASE_URL` for **Production** unchanged.
+3. Add `MIGRATION_DATABASE_URL` for **Production only** and set it to the value
+   of `VERCEL_PRODUCTION_MIGRATION_DATABASE_URL`.
+4. Do not add `MIGRATION_DATABASE_URL` to Preview. Preview builds intentionally
+   skip migrations and deployment-time database seeds.
+5. Keep the existing `DATABASE_SSL_CA_BASE64` / TLS settings in both environments.
+
+`prisma-migrate-deploy.mjs` already resolves
+`MIGRATION_DATABASE_URL ?? DATABASE_URL`, so no application-code switch is needed
+for production migrations.
+
+## 3. Redeploy and verify
+
+Redeploy one Preview first. Verify its database health endpoint and runtime logs.
+The preview should use the `vercel-preview` pool profile and remain functional for
+read paths.
+
+Then redeploy Production. The production build should show:
+
+```text
+[database] Verified TLS connection to ProxySQL before migration.
+48 migrations found
+No pending migrations to apply.
+```
+
+Run a fresh production direct probe:
+
+```text
+/api/health/database-direct -> 200
+```
+
+Finally capture each ProxySQL identity independently:
+
+```bash
+APP_DB_USER=kindrobot bash scripts/proxysql-capacity-diagnostics.sh \
+  | tee /mnt/user/pc/kindrobots-db-capacity-production.txt
+
+APP_DB_USER=kindrobot_preview bash scripts/proxysql-capacity-diagnostics.sh \
+  | tee /mnt/user/pc/kindrobots-db-capacity-preview.txt
+
+APP_DB_USER=kindrobot_migrate bash scripts/proxysql-capacity-diagnostics.sh \
+  | tee /mnt/user/pc/kindrobots-db-capacity-migration.txt
+```
+
+Expected results:
+
+- `kindrobot` remains on hostgroup 10 and below 200 frontend sessions;
+- `kindrobot_preview` is capped at 40 frontends and routes only to hostgroup 20;
+- `kindrobot_migrate` is capped at 8 frontends and routes only to hostgroup 30;
+- hostgroup 20 has an 8-connection backend cap per production backend row;
+- hostgroup 30 has a 4-connection backend cap per production backend row;
+- `mysql-wait_timeout` is 600000 ms;
+- a Preview deployment burst cannot make a fresh production direct probe fail;
+- `Access_Denied_Max_User_Connections` remains flat during an ordinary Preview/PR cycle.
+
+## 4. Cypress
+
+PR #1584 removed the automatic 30-minute Cypress schedule because that suite
+writes against production and was observed causing fresh pool-acquisition errors.
+Do not restore the schedule merely because Preview now has a read-only identity.
+Restore automated Cypress only after it has a write-capable test environment that
+is not the production database.
+
+## Rollback
+
+Do not drop the new accounts as a first response. To return Vercel to the old
+routing, restore the previous Preview `DATABASE_URL`, remove the Production-only
+`MIGRATION_DATABASE_URL`, and redeploy. The dedicated users and hostgroups are
+then dormant and can be inspected safely before any cleanup.
+
+The provisioning script writes a password-free `*-before-<timestamp>.txt` snapshot
+of the relevant ProxySQL users, servers, and timeout before it changes anything.

--- a/docs/runbooks/vercel-database-isolation.md
+++ b/docs/runbooks/vercel-database-isolation.md
@@ -67,7 +67,7 @@ The script:
 - changes ProxySQL `mysql-wait_timeout` from the old eight-hour retention window to 600000 ms (10 minutes);
 - loads the server/user/variable changes into ProxySQL runtime and saves them to disk;
 - verifies the runtime users, hostgroups, limits, and timeout;
-- writes the generated handoff values to `/mnt/user/pc/kindrobots-db-isolation.env` with mode 600;
+- writes the generated handoff values to `/mnt/user/pc/kindrobots-db-isolation/kindrobots-db-isolation.env` with mode 600 inside a mode-700 private directory;
 - writes a password-free pre-change ProxySQL snapshot next to that file.
 
 The credential file is deliberately not printed to the terminal. Keep it private.
@@ -80,7 +80,8 @@ In the Vercel project, open **Settings -> Environment Variables**. Environment
 variables are scoped by deployment environment, and changing them affects only
 new deployments.
 
-Use the values from `/mnt/user/pc/kindrobots-db-isolation.env`:
+Use the values from
+`/mnt/user/pc/kindrobots-db-isolation/kindrobots-db-isolation.env`:
 
 1. Edit `DATABASE_URL` for **Preview only** and set it to the value of
    `VERCEL_PREVIEW_DATABASE_URL`.

--- a/scripts/provision-vercel-db-isolation.sh
+++ b/scripts/provision-vercel-db-isolation.sh
@@ -1,0 +1,418 @@
+#!/usr/bin/env bash
+# Provision isolated ProxySQL/MariaDB identities for Vercel Preview and
+# production migrations. Run on Alexandria from the Kind Robots repository.
+#
+# Dry run (default):
+#   bash scripts/provision-vercel-db-isolation.sh
+#
+# Apply:
+#   bash scripts/provision-vercel-db-isolation.sh --apply
+#
+# Optional overrides:
+#   PROXYSQL_CONTAINER=proxysql
+#   MARIADB_CONTAINER=mariadb-kindrobots2
+#   APP_DB_USER=kindrobot
+#   PREVIEW_DB_USER=kindrobot_preview
+#   MIGRATION_DB_USER=kindrobot_migrate
+#   PRODUCTION_HOSTGROUP=10
+#   PREVIEW_HOSTGROUP=20
+#   MIGRATION_HOSTGROUP=30
+#   PREVIEW_FRONTEND_MAX=40
+#   MIGRATION_FRONTEND_MAX=8
+#   PREVIEW_BACKEND_MAX=8
+#   MIGRATION_BACKEND_MAX=4
+#   PROXYSQL_WAIT_TIMEOUT_MS=600000
+#   PUBLIC_PROXYSQL_HOST=acrocatranch.com
+#   PUBLIC_PROXYSQL_PORT=5544
+#   OUTPUT_FILE=/mnt/user/pc/kindrobots-db-isolation.env
+#
+# Existing dedicated users are never silently rotated. If they already exist,
+# reuse the generated OUTPUT_FILE or explicitly provide their passwords.
+
+set -Eeuo pipefail
+
+MODE='dry-run'
+if [[ "${1:-}" == '--apply' ]]; then
+  MODE='apply'
+elif [[ -n "${1:-}" ]]; then
+  printf 'Usage: %s [--apply]\n' "$0" >&2
+  exit 2
+fi
+
+PROXYSQL_CONTAINER="${PROXYSQL_CONTAINER:-proxysql}"
+MARIADB_CONTAINER="${MARIADB_CONTAINER:-mariadb-kindrobots2}"
+APP_DB_USER="${APP_DB_USER:-kindrobot}"
+PREVIEW_DB_USER="${PREVIEW_DB_USER:-kindrobot_preview}"
+MIGRATION_DB_USER="${MIGRATION_DB_USER:-kindrobot_migrate}"
+PRODUCTION_HOSTGROUP="${PRODUCTION_HOSTGROUP:-10}"
+PREVIEW_HOSTGROUP="${PREVIEW_HOSTGROUP:-20}"
+MIGRATION_HOSTGROUP="${MIGRATION_HOSTGROUP:-30}"
+PREVIEW_FRONTEND_MAX="${PREVIEW_FRONTEND_MAX:-40}"
+MIGRATION_FRONTEND_MAX="${MIGRATION_FRONTEND_MAX:-8}"
+PREVIEW_BACKEND_MAX="${PREVIEW_BACKEND_MAX:-8}"
+MIGRATION_BACKEND_MAX="${MIGRATION_BACKEND_MAX:-4}"
+PROXYSQL_WAIT_TIMEOUT_MS="${PROXYSQL_WAIT_TIMEOUT_MS:-600000}"
+PUBLIC_PROXYSQL_HOST="${PUBLIC_PROXYSQL_HOST:-acrocatranch.com}"
+PUBLIC_PROXYSQL_PORT="${PUBLIC_PROXYSQL_PORT:-5544}"
+OUTPUT_FILE="${OUTPUT_FILE:-/mnt/user/pc/kindrobots-db-isolation.env}"
+MARIADB_CONNECTION_RESERVE="${MARIADB_CONNECTION_RESERVE:-30}"
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+info() {
+  printf '%s\n' "$*"
+}
+
+command -v docker >/dev/null 2>&1 || fail 'docker is required on the Unraid host'
+command -v openssl >/dev/null 2>&1 || fail 'openssl is required to generate credentials'
+
+for container in "$PROXYSQL_CONTAINER" "$MARIADB_CONTAINER"; do
+  running="$(docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null || true)"
+  [[ "$running" == 'true' ]] || fail "container $container is not running"
+done
+
+for value in "$APP_DB_USER" "$PREVIEW_DB_USER" "$MIGRATION_DB_USER"; do
+  [[ "$value" =~ ^[A-Za-z0-9_.@-]+$ ]] || fail "unsupported database username: $value"
+done
+
+for value in "$PRODUCTION_HOSTGROUP" "$PREVIEW_HOSTGROUP" "$MIGRATION_HOSTGROUP" \
+  "$PREVIEW_FRONTEND_MAX" "$MIGRATION_FRONTEND_MAX" "$PREVIEW_BACKEND_MAX" \
+  "$MIGRATION_BACKEND_MAX" "$PROXYSQL_WAIT_TIMEOUT_MS" "$PUBLIC_PROXYSQL_PORT" \
+  "$MARIADB_CONNECTION_RESERVE"; do
+  [[ "$value" =~ ^[0-9]+$ ]] || fail "expected an integer, got: $value"
+done
+
+[[ "$PRODUCTION_HOSTGROUP" != "$PREVIEW_HOSTGROUP" ]] || fail 'Preview hostgroup must differ from production'
+[[ "$PRODUCTION_HOSTGROUP" != "$MIGRATION_HOSTGROUP" ]] || fail 'Migration hostgroup must differ from production'
+[[ "$PREVIEW_HOSTGROUP" != "$MIGRATION_HOSTGROUP" ]] || fail 'Preview and migration hostgroups must differ'
+[[ "$PROXYSQL_WAIT_TIMEOUT_MS" -ge 300000 ]] || fail 'ProxySQL wait timeout must remain at least 5 minutes'
+
+container_env_value() {
+  local container="$1"
+  local key="$2"
+  docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$container" 2>/dev/null \
+    | sed -n "s/^${key}=//p" \
+    | head -n 1
+}
+
+find_proxysql_admin_credentials() {
+  local credentials
+  credentials="$(
+    docker exec "$PROXYSQL_CONTAINER" sh -lc '
+      for file in /etc/proxysql.cnf /etc/proxysql/proxysql.cnf /var/lib/proxysql/proxysql.cnf; do
+        if [ -r "$file" ]; then
+          sed -nE '\''s/^[[:space:]]*admin_credentials[[:space:]]*=[[:space:]]*"([^";]+)(;[^"]*)?".*/\1/p'\'' "$file"
+          exit 0
+        fi
+      done
+    ' 2>/dev/null || true
+  )"
+
+  [[ -n "$credentials" ]] || return 1
+  PROXYSQL_ADMIN_USER="${credentials%%:*}"
+  PROXYSQL_ADMIN_PASSWORD="${credentials#*:}"
+  [[ -n "$PROXYSQL_ADMIN_USER" && -n "$PROXYSQL_ADMIN_PASSWORD" ]]
+}
+
+PROXYSQL_ADMIN_USER="${PROXYSQL_ADMIN_USER:-}"
+PROXYSQL_ADMIN_PASSWORD="${PROXYSQL_ADMIN_PASSWORD:-}"
+if [[ -z "$PROXYSQL_ADMIN_USER" || -z "$PROXYSQL_ADMIN_PASSWORD" ]]; then
+  find_proxysql_admin_credentials || fail \
+    'could not read ProxySQL admin_credentials; set PROXYSQL_ADMIN_USER and PROXYSQL_ADMIN_PASSWORD'
+fi
+
+MARIADB_ROOT_PASSWORD="${MARIADB_ROOT_PASSWORD:-}"
+if [[ -z "$MARIADB_ROOT_PASSWORD" ]]; then
+  MARIADB_ROOT_PASSWORD="$(container_env_value "$MARIADB_CONTAINER" MARIADB_ROOT_PASSWORD)"
+fi
+if [[ -z "$MARIADB_ROOT_PASSWORD" ]]; then
+  MARIADB_ROOT_PASSWORD="$(container_env_value "$MARIADB_CONTAINER" MYSQL_ROOT_PASSWORD)"
+fi
+
+proxysql_query() {
+  local sql="$1"
+  docker exec \
+    -e MYSQL_PWD="$PROXYSQL_ADMIN_PASSWORD" \
+    -e KR_SQL="$sql" \
+    -e KR_ADMIN_USER="$PROXYSQL_ADMIN_USER" \
+    "$PROXYSQL_CONTAINER" sh -lc '
+      client="$(command -v mariadb || command -v mysql || true)"
+      [ -n "$client" ] || exit 127
+      "$client" --protocol=tcp -h127.0.0.1 -P6032 -u"$KR_ADMIN_USER" --batch --skip-column-names --raw -e "$KR_SQL"
+    '
+}
+
+mariadb_query() {
+  local sql="$1"
+  if [[ -n "$MARIADB_ROOT_PASSWORD" ]]; then
+    docker exec \
+      -e MYSQL_PWD="$MARIADB_ROOT_PASSWORD" \
+      -e KR_SQL="$sql" \
+      "$MARIADB_CONTAINER" sh -lc '
+        client="$(command -v mariadb || command -v mysql || true)"
+        [ -n "$client" ] || exit 127
+        "$client" --protocol=socket -uroot --batch --skip-column-names --raw -e "$KR_SQL"
+      '
+  else
+    docker exec \
+      -e KR_SQL="$sql" \
+      "$MARIADB_CONTAINER" sh -lc '
+        client="$(command -v mariadb || command -v mysql || true)"
+        [ -n "$client" ] || exit 127
+        "$client" --protocol=socket -uroot --batch --skip-column-names --raw -e "$KR_SQL"
+      ' || fail 'root login failed; set MARIADB_ROOT_PASSWORD for provisioning'
+  fi
+}
+
+mariadb_user_exists() {
+  local username="$1"
+  mariadb_query "SELECT COUNT(*) FROM mysql.user WHERE User='${username}' AND Host='%';"
+}
+
+load_saved_credentials() {
+  [[ -f "$OUTPUT_FILE" ]] || return 0
+  local mode
+  mode="$(stat -c '%a' "$OUTPUT_FILE" 2>/dev/null || true)"
+  [[ "$mode" == '600' || "$mode" == '400' ]] || fail \
+    "refusing to source $OUTPUT_FILE because its mode is ${mode:-unknown}; chmod 600 first"
+  # shellcheck disable=SC1090
+  source "$OUTPUT_FILE"
+}
+
+load_saved_credentials
+PREVIEW_DB_PASSWORD="${PREVIEW_DB_PASSWORD:-}"
+MIGRATION_DB_PASSWORD="${MIGRATION_DB_PASSWORD:-}"
+
+prod_user_row="$(proxysql_query "
+SELECT default_schema, use_ssl
+FROM runtime_mysql_users
+WHERE username='${APP_DB_USER}' AND frontend=1
+LIMIT 1;
+")"
+[[ -n "$prod_user_row" ]] || fail "ProxySQL runtime user ${APP_DB_USER} was not found"
+
+IFS=$'\t' read -r DATABASE_NAME PROD_USE_SSL <<<"$prod_user_row"
+DATABASE_NAME="${DATABASE_NAME:-kindblank_fresh}"
+PROD_USE_SSL="${PROD_USE_SSL:-0}"
+[[ "$DATABASE_NAME" =~ ^[A-Za-z0-9_]+$ ]] || fail "unsupported database name: $DATABASE_NAME"
+[[ "$PROD_USE_SSL" =~ ^[01]$ ]] || fail "unexpected use_ssl value for ${APP_DB_USER}: $PROD_USE_SSL"
+
+prod_backend_count="$(proxysql_query "SELECT COUNT(*) FROM mysql_servers WHERE hostgroup_id=${PRODUCTION_HOSTGROUP};")"
+[[ "$prod_backend_count" -gt 0 ]] || fail "production hostgroup ${PRODUCTION_HOSTGROUP} has no backend servers"
+
+for target_hostgroup in "$PREVIEW_HOSTGROUP" "$MIGRATION_HOSTGROUP"; do
+  foreign_rows="$(proxysql_query "
+SELECT COUNT(*)
+FROM mysql_servers AS target
+WHERE target.hostgroup_id=${target_hostgroup}
+  AND NOT EXISTS (
+    SELECT 1
+    FROM mysql_servers AS prod
+    WHERE prod.hostgroup_id=${PRODUCTION_HOSTGROUP}
+      AND prod.hostname=target.hostname
+      AND prod.port=target.port
+  );
+")"
+  [[ "$foreign_rows" == '0' ]] || fail \
+    "hostgroup ${target_hostgroup} already contains backend rows unrelated to production hostgroup ${PRODUCTION_HOSTGROUP}"
+done
+
+generic_routing_rules="$(proxysql_query "
+SELECT COUNT(*)
+FROM mysql_query_rules
+WHERE active=1
+  AND (username IS NULL OR username='')
+  AND destination_hostgroup IS NOT NULL;
+")"
+[[ "$generic_routing_rules" == '0' ]] || fail \
+  "found ${generic_routing_rules} active generic ProxySQL query rule(s) with destination hostgroups; review routing before isolating users"
+
+mariadb_global_max="$(mariadb_query 'SELECT @@GLOBAL.max_connections;')"
+prod_backend_max="$(proxysql_query "SELECT COALESCE(SUM(max_connections),0) FROM mysql_servers WHERE hostgroup_id=${PRODUCTION_HOSTGROUP};")"
+planned_backend_max=$((
+  prod_backend_max +
+  prod_backend_count * PREVIEW_BACKEND_MAX +
+  prod_backend_count * MIGRATION_BACKEND_MAX
+))
+backend_budget=$((mariadb_global_max - MARIADB_CONNECTION_RESERVE))
+[[ "$planned_backend_max" -le "$backend_budget" ]] || fail \
+  "planned ProxySQL backend maxima total ${planned_backend_max}, exceeding MariaDB budget ${backend_budget} (${mariadb_global_max} max minus ${MARIADB_CONNECTION_RESERVE} reserve)"
+
+preview_exists="$(mariadb_user_exists "$PREVIEW_DB_USER")"
+migration_exists="$(mariadb_user_exists "$MIGRATION_DB_USER")"
+
+if [[ "$preview_exists" != '0' && -z "$PREVIEW_DB_PASSWORD" ]]; then
+  fail "MariaDB user ${PREVIEW_DB_USER}@% already exists but PREVIEW_DB_PASSWORD is unavailable; reuse $OUTPUT_FILE or provide PREVIEW_DB_PASSWORD explicitly"
+fi
+if [[ "$migration_exists" != '0' && -z "$MIGRATION_DB_PASSWORD" ]]; then
+  fail "MariaDB user ${MIGRATION_DB_USER}@% already exists but MIGRATION_DB_PASSWORD is unavailable; reuse $OUTPUT_FILE or provide MIGRATION_DB_PASSWORD explicitly"
+fi
+
+[[ -n "$PREVIEW_DB_PASSWORD" ]] || PREVIEW_DB_PASSWORD="$(openssl rand -hex 24)"
+[[ -n "$MIGRATION_DB_PASSWORD" ]] || MIGRATION_DB_PASSWORD="$(openssl rand -hex 24)"
+[[ "$PREVIEW_DB_PASSWORD" =~ ^[A-Za-z0-9]+$ ]] || fail 'Preview password must contain only letters and digits for safe non-interactive provisioning'
+[[ "$MIGRATION_DB_PASSWORD" =~ ^[A-Za-z0-9]+$ ]] || fail 'Migration password must contain only letters and digits for safe non-interactive provisioning'
+
+preview_url="mysql://${PREVIEW_DB_USER}:${PREVIEW_DB_PASSWORD}@${PUBLIC_PROXYSQL_HOST}:${PUBLIC_PROXYSQL_PORT}/${DATABASE_NAME}"
+migration_url="mysql://${MIGRATION_DB_USER}:${MIGRATION_DB_PASSWORD}@${PUBLIC_PROXYSQL_HOST}:${PUBLIC_PROXYSQL_PORT}/${DATABASE_NAME}"
+
+info 'Kind Robots Vercel database isolation'
+info "Mode: ${MODE}"
+info "Database: ${DATABASE_NAME}"
+info "Production lane: user=${APP_DB_USER} hostgroup=${PRODUCTION_HOSTGROUP} backendMax=${prod_backend_max}"
+info "Preview lane: user=${PREVIEW_DB_USER} frontendMax=${PREVIEW_FRONTEND_MAX} hostgroup=${PREVIEW_HOSTGROUP} backendMax/server=${PREVIEW_BACKEND_MAX} privileges=read-only"
+info "Migration lane: user=${MIGRATION_DB_USER} frontendMax=${MIGRATION_FRONTEND_MAX} hostgroup=${MIGRATION_HOSTGROUP} backendMax/server=${MIGRATION_BACKEND_MAX} privileges=schema-all"
+info "ProxySQL client idle timeout: ${PROXYSQL_WAIT_TIMEOUT_MS}ms"
+info "MariaDB backend budget check: planned=${planned_backend_max}, allowed=${backend_budget}, global=${mariadb_global_max}"
+info 'Passwords and URLs are intentionally not printed.'
+
+if [[ "$MODE" != 'apply' ]]; then
+  info ''
+  info 'Dry run complete. Re-run with --apply to provision these lanes.'
+  exit 0
+fi
+
+snapshot_dir="$(dirname "$OUTPUT_FILE")"
+mkdir -p "$snapshot_dir"
+chmod 700 "$snapshot_dir" 2>/dev/null || true
+snapshot_file="${OUTPUT_FILE%.env}-before-$(date -u +%Y%m%dT%H%M%SZ).txt"
+{
+  printf 'ProxySQL users (password omitted)\n'
+  proxysql_query "SELECT username,active,use_ssl,default_hostgroup,default_schema,schema_locked,transaction_persistent,frontend,backend,max_connections FROM mysql_users ORDER BY username,frontend DESC;"
+  printf '\nProxySQL servers\n'
+  proxysql_query "SELECT hostgroup_id,hostname,port,status,weight,max_connections,use_ssl,comment FROM mysql_servers ORDER BY hostgroup_id,hostname,port;"
+  printf '\nProxySQL wait timeout\n'
+  proxysql_query "SELECT variable_name,variable_value FROM global_variables WHERE variable_name='mysql-wait_timeout';"
+} >"$snapshot_file"
+chmod 600 "$snapshot_file"
+
+info "Saved pre-change configuration snapshot: $snapshot_file"
+
+mariadb_query "
+CREATE USER IF NOT EXISTS '${PREVIEW_DB_USER}'@'%' IDENTIFIED BY '${PREVIEW_DB_PASSWORD}';
+ALTER USER '${PREVIEW_DB_USER}'@'%' IDENTIFIED BY '${PREVIEW_DB_PASSWORD}';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${PREVIEW_DB_USER}'@'%';
+GRANT USAGE ON *.* TO '${PREVIEW_DB_USER}'@'%' WITH MAX_USER_CONNECTIONS ${PREVIEW_BACKEND_MAX};
+GRANT SELECT, SHOW VIEW ON \`${DATABASE_NAME}\`.* TO '${PREVIEW_DB_USER}'@'%';
+
+CREATE USER IF NOT EXISTS '${MIGRATION_DB_USER}'@'%' IDENTIFIED BY '${MIGRATION_DB_PASSWORD}';
+ALTER USER '${MIGRATION_DB_USER}'@'%' IDENTIFIED BY '${MIGRATION_DB_PASSWORD}';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${MIGRATION_DB_USER}'@'%';
+GRANT USAGE ON *.* TO '${MIGRATION_DB_USER}'@'%' WITH MAX_USER_CONNECTIONS ${MIGRATION_BACKEND_MAX};
+GRANT ALL PRIVILEGES ON \`${DATABASE_NAME}\`.* TO '${MIGRATION_DB_USER}'@'%';
+"
+
+proxysql_query "
+INSERT OR REPLACE INTO mysql_servers (
+  hostgroup_id, hostname, port, status, weight, max_connections,
+  max_replication_lag, use_ssl, comment
+)
+SELECT ${PREVIEW_HOSTGROUP}, hostname, port, status, weight, ${PREVIEW_BACKEND_MAX},
+       max_replication_lag, use_ssl, 'Kind Robots Vercel Preview isolation'
+FROM mysql_servers
+WHERE hostgroup_id=${PRODUCTION_HOSTGROUP};
+
+INSERT OR REPLACE INTO mysql_servers (
+  hostgroup_id, hostname, port, status, weight, max_connections,
+  max_replication_lag, use_ssl, comment
+)
+SELECT ${MIGRATION_HOSTGROUP}, hostname, port, status, weight, ${MIGRATION_BACKEND_MAX},
+       max_replication_lag, use_ssl, 'Kind Robots production migration isolation'
+FROM mysql_servers
+WHERE hostgroup_id=${PRODUCTION_HOSTGROUP};
+
+UPDATE mysql_users
+SET password=MYSQL_NATIVE_PASSWORD('${PREVIEW_DB_PASSWORD}'),
+    active=1,
+    use_ssl=${PROD_USE_SSL},
+    default_hostgroup=${PREVIEW_HOSTGROUP},
+    default_schema='${DATABASE_NAME}',
+    schema_locked=1,
+    transaction_persistent=1,
+    fast_forward=0,
+    backend=1,
+    frontend=1,
+    max_connections=${PREVIEW_FRONTEND_MAX}
+WHERE username='${PREVIEW_DB_USER}';
+INSERT INTO mysql_users (
+  username,password,active,use_ssl,default_hostgroup,default_schema,
+  schema_locked,transaction_persistent,fast_forward,backend,frontend,max_connections
+)
+SELECT '${PREVIEW_DB_USER}',MYSQL_NATIVE_PASSWORD('${PREVIEW_DB_PASSWORD}'),1,${PROD_USE_SSL},
+       ${PREVIEW_HOSTGROUP},'${DATABASE_NAME}',1,1,0,1,1,${PREVIEW_FRONTEND_MAX}
+WHERE NOT EXISTS (SELECT 1 FROM mysql_users WHERE username='${PREVIEW_DB_USER}');
+
+UPDATE mysql_users
+SET password=MYSQL_NATIVE_PASSWORD('${MIGRATION_DB_PASSWORD}'),
+    active=1,
+    use_ssl=${PROD_USE_SSL},
+    default_hostgroup=${MIGRATION_HOSTGROUP},
+    default_schema='${DATABASE_NAME}',
+    schema_locked=1,
+    transaction_persistent=1,
+    fast_forward=0,
+    backend=1,
+    frontend=1,
+    max_connections=${MIGRATION_FRONTEND_MAX}
+WHERE username='${MIGRATION_DB_USER}';
+INSERT INTO mysql_users (
+  username,password,active,use_ssl,default_hostgroup,default_schema,
+  schema_locked,transaction_persistent,fast_forward,backend,frontend,max_connections
+)
+SELECT '${MIGRATION_DB_USER}',MYSQL_NATIVE_PASSWORD('${MIGRATION_DB_PASSWORD}'),1,${PROD_USE_SSL},
+       ${MIGRATION_HOSTGROUP},'${DATABASE_NAME}',1,1,0,1,1,${MIGRATION_FRONTEND_MAX}
+WHERE NOT EXISTS (SELECT 1 FROM mysql_users WHERE username='${MIGRATION_DB_USER}');
+
+UPDATE global_variables
+SET variable_value='${PROXYSQL_WAIT_TIMEOUT_MS}'
+WHERE variable_name='mysql-wait_timeout';
+
+LOAD MYSQL SERVERS TO RUNTIME;
+SAVE MYSQL SERVERS TO DISK;
+LOAD MYSQL USERS TO RUNTIME;
+SAVE MYSQL USERS TO DISK;
+LOAD MYSQL VARIABLES TO RUNTIME;
+SAVE MYSQL VARIABLES TO DISK;
+"
+
+runtime_preview="$(proxysql_query "SELECT default_hostgroup,max_connections FROM runtime_mysql_users WHERE username='${PREVIEW_DB_USER}' AND frontend=1 LIMIT 1;")"
+runtime_migration="$(proxysql_query "SELECT default_hostgroup,max_connections FROM runtime_mysql_users WHERE username='${MIGRATION_DB_USER}' AND frontend=1 LIMIT 1;")"
+runtime_wait_timeout="$(proxysql_query "SELECT variable_value FROM runtime_global_variables WHERE variable_name='mysql-wait_timeout';")"
+preview_server_count="$(proxysql_query "SELECT COUNT(*) FROM runtime_mysql_servers WHERE hostgroup_id=${PREVIEW_HOSTGROUP} AND max_connections=${PREVIEW_BACKEND_MAX};")"
+migration_server_count="$(proxysql_query "SELECT COUNT(*) FROM runtime_mysql_servers WHERE hostgroup_id=${MIGRATION_HOSTGROUP} AND max_connections=${MIGRATION_BACKEND_MAX};")"
+
+[[ "$runtime_preview" == "${PREVIEW_HOSTGROUP}"$'\t'"${PREVIEW_FRONTEND_MAX}" ]] || fail "Preview runtime user verification failed: ${runtime_preview:-missing}"
+[[ "$runtime_migration" == "${MIGRATION_HOSTGROUP}"$'\t'"${MIGRATION_FRONTEND_MAX}" ]] || fail "Migration runtime user verification failed: ${runtime_migration:-missing}"
+[[ "$runtime_wait_timeout" == "$PROXYSQL_WAIT_TIMEOUT_MS" ]] || fail "ProxySQL wait timeout verification failed: ${runtime_wait_timeout:-missing}"
+[[ "$preview_server_count" == "$prod_backend_count" ]] || fail "Preview hostgroup verification failed: expected ${prod_backend_count} backend row(s), got ${preview_server_count}"
+[[ "$migration_server_count" == "$prod_backend_count" ]] || fail "Migration hostgroup verification failed: expected ${prod_backend_count} backend row(s), got ${migration_server_count}"
+
+umask 077
+cat >"$OUTPUT_FILE" <<EOF
+# Kind Robots database isolation credentials generated $(date -u +%Y-%m-%dT%H:%M:%SZ)
+# Keep this file private. It is intended only as a handoff into Vercel environment settings.
+PREVIEW_DB_USER=${PREVIEW_DB_USER}
+PREVIEW_DB_PASSWORD=${PREVIEW_DB_PASSWORD}
+MIGRATION_DB_USER=${MIGRATION_DB_USER}
+MIGRATION_DB_PASSWORD=${MIGRATION_DB_PASSWORD}
+DATABASE_NAME=${DATABASE_NAME}
+PUBLIC_PROXYSQL_HOST=${PUBLIC_PROXYSQL_HOST}
+PUBLIC_PROXYSQL_PORT=${PUBLIC_PROXYSQL_PORT}
+VERCEL_PREVIEW_DATABASE_URL=${preview_url}
+VERCEL_PRODUCTION_MIGRATION_DATABASE_URL=${migration_url}
+EOF
+chmod 600 "$OUTPUT_FILE"
+
+info ''
+info 'Provisioning succeeded.'
+info "Credential handoff file: $OUTPUT_FILE (mode 600; contents not printed)"
+info "Preview user ${PREVIEW_DB_USER} is read-only and isolated to hostgroup ${PREVIEW_HOSTGROUP}."
+info "Migration user ${MIGRATION_DB_USER} is isolated to hostgroup ${MIGRATION_HOSTGROUP}."
+info "ProxySQL mysql-wait_timeout is now ${PROXYSQL_WAIT_TIMEOUT_MS}ms."
+info ''
+info 'Next: set Vercel Preview DATABASE_URL from VERCEL_PREVIEW_DATABASE_URL and'
+info 'set Vercel Production MIGRATION_DATABASE_URL from VERCEL_PRODUCTION_MIGRATION_DATABASE_URL,'
+info 'then redeploy both environments and run scripts/proxysql-capacity-diagnostics.sh.'

--- a/scripts/provision-vercel-db-isolation.sh
+++ b/scripts/provision-vercel-db-isolation.sh
@@ -24,7 +24,7 @@
 #   PROXYSQL_WAIT_TIMEOUT_MS=600000
 #   PUBLIC_PROXYSQL_HOST=acrocatranch.com
 #   PUBLIC_PROXYSQL_PORT=5544
-#   OUTPUT_FILE=/mnt/user/pc/kindrobots-db-isolation.env
+#   OUTPUT_FILE=/mnt/user/pc/kindrobots-db-isolation/kindrobots-db-isolation.env
 #
 # Existing dedicated users are never silently rotated. If they already exist,
 # reuse the generated OUTPUT_FILE or explicitly provide their passwords.
@@ -54,7 +54,7 @@ MIGRATION_BACKEND_MAX="${MIGRATION_BACKEND_MAX:-4}"
 PROXYSQL_WAIT_TIMEOUT_MS="${PROXYSQL_WAIT_TIMEOUT_MS:-600000}"
 PUBLIC_PROXYSQL_HOST="${PUBLIC_PROXYSQL_HOST:-acrocatranch.com}"
 PUBLIC_PROXYSQL_PORT="${PUBLIC_PROXYSQL_PORT:-5544}"
-OUTPUT_FILE="${OUTPUT_FILE:-/mnt/user/pc/kindrobots-db-isolation.env}"
+OUTPUT_FILE="${OUTPUT_FILE:-/mnt/user/pc/kindrobots-db-isolation/kindrobots-db-isolation.env}"
 MARIADB_CONNECTION_RESERVE="${MARIADB_CONNECTION_RESERVE:-30}"
 
 fail() {

--- a/utils/scripts/verifyVercelDbIsolationProvisioning.mjs
+++ b/utils/scripts/verifyVercelDbIsolationProvisioning.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+
+const provisionPath = new URL(
+  '../../scripts/provision-vercel-db-isolation.sh',
+  import.meta.url,
+)
+const provisionSource = readFileSync(provisionPath, 'utf8')
+const migrateSource = readFileSync(
+  new URL('../../scripts/prisma-migrate-deploy.mjs', import.meta.url),
+  'utf8',
+)
+
+execFileSync('bash', ['-n', provisionPath.pathname], { stdio: 'inherit' })
+
+assert.match(provisionSource, /MODE='dry-run'/)
+assert.match(provisionSource, /--apply/)
+assert.match(provisionSource, /PREVIEW_DB_USER="\$\{PREVIEW_DB_USER:-kindrobot_preview\}"/)
+assert.match(
+  provisionSource,
+  /MIGRATION_DB_USER="\$\{MIGRATION_DB_USER:-kindrobot_migrate\}"/,
+)
+assert.match(provisionSource, /PREVIEW_HOSTGROUP="\$\{PREVIEW_HOSTGROUP:-20\}"/)
+assert.match(
+  provisionSource,
+  /MIGRATION_HOSTGROUP="\$\{MIGRATION_HOSTGROUP:-30\}"/,
+)
+assert.match(provisionSource, /PREVIEW_FRONTEND_MAX="\$\{PREVIEW_FRONTEND_MAX:-40\}"/)
+assert.match(
+  provisionSource,
+  /MIGRATION_FRONTEND_MAX="\$\{MIGRATION_FRONTEND_MAX:-8\}"/,
+)
+assert.match(provisionSource, /PREVIEW_BACKEND_MAX="\$\{PREVIEW_BACKEND_MAX:-8\}"/)
+assert.match(
+  provisionSource,
+  /MIGRATION_BACKEND_MAX="\$\{MIGRATION_BACKEND_MAX:-4\}"/,
+)
+assert.match(
+  provisionSource,
+  /PROXYSQL_WAIT_TIMEOUT_MS="\$\{PROXYSQL_WAIT_TIMEOUT_MS:-600000\}"/,
+)
+
+assert.match(
+  provisionSource,
+  /GRANT SELECT, SHOW VIEW ON \\`\$\{DATABASE_NAME\}\\`\.\* TO '\$\{PREVIEW_DB_USER\}'@'%'/,
+)
+assert.match(
+  provisionSource,
+  /GRANT ALL PRIVILEGES ON \\`\$\{DATABASE_NAME\}\\`\.\* TO '\$\{MIGRATION_DB_USER\}'@'%'/,
+)
+assert.match(provisionSource, /MAX_USER_CONNECTIONS \$\{PREVIEW_BACKEND_MAX\}/)
+assert.match(provisionSource, /MAX_USER_CONNECTIONS \$\{MIGRATION_BACKEND_MAX\}/)
+assert.match(provisionSource, /MYSQL_NATIVE_PASSWORD\('\$\{PREVIEW_DB_PASSWORD\}'\)/)
+assert.match(
+  provisionSource,
+  /MYSQL_NATIVE_PASSWORD\('\$\{MIGRATION_DB_PASSWORD\}'\)/,
+)
+assert.match(provisionSource, /generic ProxySQL query rule/)
+assert.match(provisionSource, /MARIADB_CONNECTION_RESERVE/)
+assert.match(provisionSource, /LOAD MYSQL SERVERS TO RUNTIME/)
+assert.match(provisionSource, /SAVE MYSQL SERVERS TO DISK/)
+assert.match(provisionSource, /LOAD MYSQL USERS TO RUNTIME/)
+assert.match(provisionSource, /SAVE MYSQL USERS TO DISK/)
+assert.match(provisionSource, /LOAD MYSQL VARIABLES TO RUNTIME/)
+assert.match(provisionSource, /SAVE MYSQL VARIABLES TO DISK/)
+assert.match(provisionSource, /Passwords and URLs are intentionally not printed/)
+assert.match(provisionSource, /chmod 600 "\$OUTPUT_FILE"/)
+assert.match(provisionSource, /VERCEL_PREVIEW_DATABASE_URL=/)
+assert.match(provisionSource, /VERCEL_PRODUCTION_MIGRATION_DATABASE_URL=/)
+
+assert.doesNotMatch(provisionSource, /DROP\s+DATABASE/i)
+assert.doesNotMatch(provisionSource, /DROP\s+USER/i)
+assert.doesNotMatch(provisionSource, /TRUNCATE\s+TABLE/i)
+assert.doesNotMatch(provisionSource, /prisma\s+migrate\s+reset/i)
+
+assert.match(
+  migrateSource,
+  /process\.env\.MIGRATION_DATABASE_URL\s*\?\?\s*process\.env\.DATABASE_URL/,
+)
+
+console.log('Vercel database isolation provisioning contract passed.')


### PR DESCRIPTION
Implements the repository-side provisioning half of issue 1581 so the Alexandria/Vercel cutover is a bounded, auditable operation instead of a pile of hand-written SQL.

### What changes

- Add `scripts/provision-vercel-db-isolation.sh`, dry-run by default and `--apply` for the actual change.
- Create a read-only `kindrobot_preview` MariaDB/ProxySQL lane on hostgroup 20 with a 40-frontend ProxySQL ceiling and an 8-connection backend cap per production backend row.
- Create `kindrobot_migrate` on hostgroup 30 with an 8-frontend ceiling and a 4-connection backend cap, with schema-level privileges for Prisma migrations.
- Preserve the existing production `kindrobot` lane on hostgroup 10.
- Reduce ProxySQL `mysql-wait_timeout` to 600000 ms (10 minutes) as the stale-client safety net.
- Refuse to apply if target hostgroups contain unrelated servers, generic ProxySQL destination rules could defeat user isolation, or the planned backend maxima would consume too much MariaDB connection headroom.
- Store generated handoff credentials in a private mode-700 directory and mode-600 file without printing passwords or URLs.
- Add `docs/runbooks/vercel-database-isolation.md` with the exact Vercel Preview `DATABASE_URL` and Production `MIGRATION_DATABASE_URL` handoff/verification procedure.
- Add a dedicated DB-free CI contract that syntax-checks the shell script and locks the safety invariants, including no database reset/drop paths.

### Why

Production and Vercel Preview currently share the same ProxySQL identity. We have already reduced per-lambda pool pressure and paused/serialized the heaviest automated callers, but that is containment rather than isolation. A preview burst should never be able to consume the production frontend budget or starve a production migration.

Preview is intentionally read-only. The scheduled Cypress suite remains disabled until it has a separate writable test database; granting production-equivalent writes to Preview would recreate a different version of the same coupling.

### Validation

The new `Vercel DB Isolation Contract` runs `bash -n` plus static safety assertions on every relevant PR change. Normal repository required checks also run before merge.

Issue 1581 remains incomplete until the script has been applied on Alexandria, the two Vercel environment variables have been switched, fresh deployments have been verified, and the denial counters remain flat under normal Preview churn.