### PR TITLE
Attach Dream art atomically when ArtJobs complete

### DIFF
--- a/server/utils/artImageFilePath.ts
+++ b/server/utils/artImageFilePath.ts
@@ -6,10 +6,10 @@
 //
 //   /images/{context}/{slug}/{slug}-{utility}-{n}.webp
 //
-//   {context}  the KR schema the image serves — bots, characters, scenarios,
-//              rewards, facets, projects, achievements. "There is almost
-//              always a relevant one — figure it out rather than defaulting to
-//              a dump folder."
+//   {context}  the KR schema the image serves — dreams, bots, characters,
+//              scenarios, rewards, facets, projects, achievements. "There is
+//              almost always a relevant one — figure it out rather than
+//              defaulting to a dump folder."
 //   {slug}     the entity's slug, lowercase-hyphenated. A slug folder's
 //              contents ARE that slug's art collection.
 //   {utility}  what the image is for: avatar, portrait, icon, card, hero.
@@ -58,6 +58,7 @@ const ENTITY_TAG = /^entity:([a-z]+):(\d+):(current|history):(.*)$/
  */
 const CONTEXT_FOLDER: Record<EntityArtType, string> = {
   bot: 'bots',
+  dream: 'dreams',
   character: 'characters',
   scenario: 'scenarios',
   reward: 'rewards',

--- a/server/utils/entityArt.ts
+++ b/server/utils/entityArt.ts
@@ -13,6 +13,7 @@ import type {
 
 export type EntityArtType =
   | 'bot'
+  | 'dream'
   | 'character'
   | 'scenario'
   | 'reward'
@@ -112,6 +113,14 @@ export const ENTITY_FIELDS: Record<
       width: 1280,
       height: 720,
       primary: false,
+    },
+  },
+  dream: {
+    imagePath: {
+      label: 'Dream',
+      width: 512,
+      height: 768,
+      primary: true,
     },
   },
   character: {
@@ -309,6 +318,7 @@ export function normalizeEntityArtType(value: unknown): EntityArtType {
   const type = safeText(value).toLowerCase()
   if (
     type === 'bot' ||
+    type === 'dream' ||
     type === 'character' ||
     type === 'scenario' ||
     type === 'reward' ||
@@ -321,7 +331,7 @@ export function normalizeEntityArtType(value: unknown): EntityArtType {
   throw createError({
     statusCode: 400,
     message:
-      'Choose Bot, Character, Scenario, Reward, Facet, Project, or Achievement.',
+      'Choose Bot, Dream, Character, Scenario, Reward, Facet, Project, or Achievement.',
   })
 }
 
@@ -363,6 +373,10 @@ export async function getEntityArtRecord(
   switch (entityType) {
     case 'bot':
       return (await db.bot.findUnique({
+        where: { id: entityId },
+      })) as EntityArtRecord | null
+    case 'dream':
+      return (await db.dream.findUnique({
         where: { id: entityId },
       })) as EntityArtRecord | null
     case 'character':
@@ -667,6 +681,14 @@ async function updateEntityRecord(
           artImageId: input.artImageId,
         },
       })) as EntityArtRecord
+    case 'dream':
+      return (await db.dream.update({
+        where: { id: input.entityId },
+        data: {
+          imagePath: input.imagePath,
+          artImageId: input.artImageId,
+        },
+      })) as EntityArtRecord
     case 'character':
       return (await db.character.update({
         where: { id: input.entityId },
@@ -913,6 +935,15 @@ function contextLines(
       ['Theme', record.theme],
       ['Personality', record.personality],
       ['Tagline', record.tagline],
+      ['Existing art prompt', record.artPrompt],
+    ],
+    dream: [
+      ['Title', record.title],
+      ['Dream type', record.dreamType],
+      ['Description', record.description],
+      ['Pitch', record.pitch],
+      ['Flavor text', record.flavorText],
+      ['Examples', record.examples],
       ['Existing art prompt', record.artPrompt],
     ],
     character: [

--- a/utils/scripts/verifyEntityArtManager.ts
+++ b/utils/scripts/verifyEntityArtManager.ts
@@ -32,11 +32,15 @@ expectContains('components/art/entity-art-manager.vue', [
 
 expectContains('server/utils/entityArt.ts', [
   "| 'bot'",
+  "| 'dream'",
   "| 'character'",
   "| 'scenario'",
   "| 'reward'",
   "| 'facet'",
   "| 'project'",
+  "case 'dream'",
+  'dream: {',
+  "label: 'Dream'",
   "case 'project'",
   'projectArtImage.upsert',
   'buildEntityArtPrompt',


### PR DESCRIPTION
## What changed
- add `dream` as a first-class `EntityArtType`
- define the canonical Daily Dream `imagePath` slot at 512x768
- resolve and update Dream rows through the same transactional entity-art completion path used by Character/Reward/Scenario/etc.
- include Dream context in generic entity-art prompt support
- extend the entity-art contract test so Dream support cannot silently disappear

## Why
The Daily Dream backlog audit found completed Dream/world/location renders that required a later repair pass because `server/utils/entityArt.ts` rejected `entityType: dream`. Future canonical Daily Dream jobs should attach `imagePath` + `artImageId` in the same transaction that marks the ArtJob DONE.

No schema migration is required: Dream already has `artImageId` and `imagePath`.

Companion Conductor change will make every canonical dream-cycle art request carry the entity target metadata and will prevent same-title request/path collisions before enqueue.