### PR TITLE
interface-vision/t-108: cache the /images/* redirect response

### DIFF
--- a/.github/workflows/responsive-layout-audit.yml
+++ b/.github/workflows/responsive-layout-audit.yml
@@ -101,14 +101,28 @@ jobs:
 
           if [ "$EVENT_NAME" = "deployment_status" ] && [ -n "${DEPLOY_REF:-}" ] && [ -n "${DEPLOY_SHA:-}" ]; then
             branch="$DEPLOY_REF"
-            remote_sha="$(git ls-remote --heads origin "$branch" | awk 'NR == 1 {print $1}')"
 
-            if [ -z "$remote_sha" ]; then
-              echo "Skipping deployment ${DEPLOY_SHA:0:7}: source branch ${branch} no longer exists."
-              run_audit=false
-            elif [ "$remote_sha" != "$DEPLOY_SHA" ]; then
-              echo "Skipping superseded deployment ${DEPLOY_SHA:0:7}: ${branch} is now ${remote_sha:0:7}."
-              run_audit=false
+            if [[ "$branch" =~ ^[0-9a-f]{40}$ ]]; then
+              # Vercel sometimes sets the GitHub Deployment's `ref` to the
+              # commit SHA instead of the source branch name (observed
+              # 2026-08-08, kind_robots PR #1592: the run's own head_branch
+              # metadata correctly showed the real branch, but
+              # github.event.deployment.ref was the raw SHA) -- there's no
+              # branch tip to compare against in that case, so skip the
+              # staleness check entirely and just run the audit. Silently
+              # treating this as "branch no longer exists" made every such
+              # deployment a false-green skip with no audit ever run.
+              echo "Deployment ref is a commit SHA, not a branch name -- running the audit against ${DEPLOY_SHA:0:7} directly."
+            else
+              remote_sha="$(git ls-remote --heads origin "$branch" | awk 'NR == 1 {print $1}')"
+
+              if [ -z "$remote_sha" ]; then
+                echo "Skipping deployment ${DEPLOY_SHA:0:7}: source branch ${branch} no longer exists."
+                run_audit=false
+              elif [ "$remote_sha" != "$DEPLOY_SHA" ]; then
+                echo "Skipping superseded deployment ${DEPLOY_SHA:0:7}: ${branch} is now ${remote_sha:0:7}."
+                run_audit=false
+              fi
             fi
           fi
 

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,12 @@
       "permanent": false
     }
   ],
+  "headers": [
+    {
+      "source": "/images/:path*",
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=3600" }]
+    }
+  ],
   "git": {
     "deploymentEnabled": {
       "claude/*": true,


### PR DESCRIPTION
### Task
interface-vision/t-108: `/navigation`'s site-directory (~85 icons/page) flakes BROKEN-ART on a different image set each responsive-audit run (kind: software)

### What changed / what I produced
- `vercel.json`: added an explicit `Cache-Control: public, max-age=3600` header rule for `/images/:path*`, alongside the existing 307 redirect to the self-hosted media origin.
- `.github/workflows/responsive-layout-audit.yml`: fixed a real, previously-invisible bug found while waiting on this PR's own audit signal (see below).

### Root cause investigation (t-108)
- The `/navigation` site-directory renders each entry's dashboard-tab image as a plain native `<img>` (`components/navigation/navigation-trimmed.vue`) -- no `NuxtImg`/IPX, no custom cache/dedup layer (confirmed via repo-wide search).
- `stores/helpers/channelContent.ts`'s `imagePath()` / `stores/helpers/dashboardHelper.ts`'s `getDashboardTabImagePath()` both resolve unset-`image` tabs to `` `/images/dashboard-tabs/${dashboardKey}/${dashboardTab}.webp` ``. A repo-wide grep of `content/channels/**/*.md` confirms many collisions feeding this exact page, e.g. `user/profile` shared by 5 separate content files, `giftshop/community` by 2, `conductor/conductor` by 3.
- Every BROKEN-ART hit recorded across 4 prior audit runs (see task note) resolves to one of these shared/duplicate URLs -- never a uniquely-imaged tab.
- `vercel.json`'s `/images/:path*` rule 307-redirects to `media.acrocatranch.com`, which (per `docs/self-hosted-media.md`) already returns a 1-hour cache for normal media -- but the Vercel-side redirect response itself had no `Cache-Control`, so per HTTP semantics a 307 with no explicit freshness directive isn't browser-cached. Every duplicate `<img>` referencing the same dashboard-tab path therefore re-resolves the redirect (and re-issues a fresh origin request) instead of reusing a cached one, concentrating repeat identical-path requests in a short window right at page load.

### Fix (t-108)
Purely additive Vercel config: caching the redirect response lets the browser reuse a cached resolution across duplicate `<img>` references on the same page, cutting the number of near-simultaneous identical-path requests reaching the media origin -- the safest available mitigation from inside this repo. The actual media origin (Nginx/Traefik on an external Unraid box) is outside this repository; if a concurrency issue there is the deeper cause, this change reduces how often the browser triggers it without needing origin access.

### Second commit: audit workflow bug found while waiting on this PR's own signal
The deployment-triggered `audit` check reported `success` in ~7 seconds -- too fast for a real run. Its job log read: `Skipping deployment a1de6b6: source branch a1de6b6715d389f9f58b7be75ca469ee998a7ea9 no longer exists.` The freshness check's `DEPLOY_REF` (`github.event.deployment.ref`) was the raw commit SHA, not the branch name, even though this same workflow run's own `head_branch` metadata correctly showed `claude/relaxed-lovelace-h2cok2`. `git ls-remote --heads origin <40-hex-sha>` never matches, so the check always misread this as "branch deleted" and skipped -- silently, with the job still reporting green. This is a real gap in the audit gate that predates this PR (cause not confirmed -- Vercel appears to sometimes emit a SHA instead of a branch name for `deployment.ref`) and would have made **every** such deployment a false-green skip with no audit ever run.

Fix: when `DEPLOY_REF` matches a 40-hex-char SHA, skip the branch-staleness comparison (there's no branch tip to diff against) and run the audit directly. The existing branch-name path (staleness/deleted-branch detection) is unchanged.

### How I verified
- `python3 -c "import json; json.load(open('vercel.json'))"` -- valid JSON
- `npx prettier --check vercel.json` -- clean (formatted)
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/responsive-layout-audit.yml'))"` -- valid YAML
- Extracted the freshness-check shell logic and ran it directly (`bash -n` plus live execution against both a fake-SHA input and a fake-nonexistent-branch input) -- confirmed `run_audit=true` and `run_audit=false` respectively, matching intent. No live GitHub Actions dispatch available from this sandbox.
- Repo-wide grep confirms no other workflow directly validates `vercel.json`'s redirect/header rules.

### Stakes
reversible -- additive Vercel config plus a CI workflow logic fix; no app code touched

### Flags for Reviewer
- t-108's fix is a plausible, safe mitigation, not a proven one -- the task's own investigation couldn't rule in/out real origin-side concurrency behavior (outside this repo). Recommend leaving `interface-vision/t-108` at `status: review` rather than `done` until this PR's own (now-fixed) audit run, or a follow-up scheduled run against `main` after merge, shows `/navigation`'s BROKEN-ART rate actually drop across a few runs.
- The workflow fix is scoped narrowly (one new branch in the freshness check) but touches CI logic that gates every other layout PR in this repo -- worth a careful look given the blast radius, even though it's provably a strict widening (SHA case now runs instead of silently skipping; the existing branch-name path is byte-for-byte unchanged).

### Kaizen suggestion
Longer-term: content hygiene pass to stop letting unrelated content files share one `dashboardKey`/`dashboardTab` pair (the underlying reason so many `/navigation` cards point at identical URLs in the first place), independent of whether this caching mitigation fully resolves the flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)