### PR TITLE
Cap coding-agent database client pools

### DIFF
--- a/.github/workflows/vercel-db-isolation-contract.yml
+++ b/.github/workflows/vercel-db-isolation-contract.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'scripts/provision-vercel-db-isolation.sh'
       - 'scripts/provision-agent-db-lane.sh'
+      - 'scripts/tune-agent-database-url.sh'
       - 'scripts/prisma-migrate-deploy.mjs'
       - 'utils/scripts/verifyVercelDbIsolationProvisioning.mjs'
       - 'utils/scripts/verifyAgentDbLaneProvisioning.mjs'

--- a/docs/runbooks/agent-database-lane.md
+++ b/docs/runbooks/agent-database-lane.md
@@ -25,10 +25,13 @@ The agent lane defaults to:
 
 - ProxySQL frontend limit: 20 sessions;
 - ProxySQL/MariaDB backend limit: 6 connections per production backend row;
+- per-agent-process client pool target: 3 connections, zero minimum idle, 30-second idle expiry;
 - MariaDB privileges on the application schema: `SELECT`, `INSERT`, `UPDATE`, `DELETE`, `SHOW VIEW`;
 - no `CREATE`, `ALTER`, `DROP`, migration, routine, trigger, event, index, reference, or temporary-table privileges.
 
 This is intentionally not a migration identity. An agent that needs a schema change should produce or review the migration, but the schema-changing command should run only through the dedicated migration lane with explicit intent.
+
+Kind Robots uses Prisma 7 with `@prisma/adapter-mariadb`. The MariaDB driver adapter defaults to a pool of 10 connections, and the shared Kind Robots adapter also uses a 10-connection long-lived profile. Agent scripts are shorter-lived and may run in parallel, so their credential is tuned to a smaller three-connection client pool instead of relying on the generic long-lived default.
 
 ## Provision on Alexandria
 
@@ -65,6 +68,26 @@ Default handoff path:
 
 The directory is mode 700 and the file is mode 600. Do not paste the file into chat, issues, PRs, logs, or source control.
 
+After provisioning, tune the finished URL for coding-agent processes:
+
+```bash
+bash scripts/tune-agent-database-url.sh
+```
+
+This edits only the private `AGENT_DATABASE_URL` value. It does not rotate the password or change ProxySQL/MariaDB grants. The tuned URL carries these client-pool options:
+
+```text
+connectionLimit=3
+minimumIdle=0
+idleTimeout=30
+acquireTimeout=10000
+connectTimeout=5000
+minDelayValidation=0
+pipelining=false
+```
+
+The three-connection cap is deliberately below the lane's six-backend ceiling so one Claude process cannot occupy the entire backend lane. Two concurrent agent processes can still use the full six-connection backend allowance when necessary.
+
 ## Configure Claude
 
 The handoff file contains component fields plus one finished URL:
@@ -85,7 +108,7 @@ Remove the old production `DATABASE_URL` value instead of keeping both credentia
 
 Do **not** set a standing `MIGRATION_DATABASE_URL` for Claude. `prisma.config.ts` gives `MIGRATION_DATABASE_URL` precedence over `DATABASE_URL`, so defining it globally would silently give Prisma commands the schema-changing lane instead of the constrained agent lane.
 
-If Claude already has database TLS environment variables such as the ProxySQL CA settings, keep those unchanged. If the old `DATABASE_URL` carried transport-only query parameters, preserve only those required transport parameters on the new agent URL. Never preserve the old username or password.
+If Claude already has database TLS environment variables such as the ProxySQL CA settings, keep those unchanged. The tuning helper preserves the new identity and adds only client-pool/ProxySQL transport behavior to the generated URL. Never preserve the old username or password.
 
 ## Expected behavior
 
@@ -104,6 +127,12 @@ Claude should not be able to:
 - consume the production `kindrobot` ProxySQL frontend allowance.
 
 A schema-permission failure from the agent lane is therefore a safety boundary working as designed, not a reason to broaden the standing credential.
+
+## Read-only versus read/write agent identities
+
+A separate read-only coding-agent identity can be added later if operational experience shows that the extra credential switching is worth it. For the current workflow, the standing `kindrobot_agent` identity remains application read/write because many normal agent tasks intentionally finish with an `--apply` reconciliation or cleanup step. DDL remains the stronger boundary: schema-changing privileges never belong to the standing agent credential.
+
+HTTP method alone is not evidence that Preview needs database write privileges. For example, `POST /api/economy/karma-earned` is a batch read endpoint and performs a Prisma `groupBy` query only. Preview read-only compatibility should therefore be judged by actual database operations, not by whether a page calls POST endpoints.
 
 ## Verify after switching Claude
 

--- a/scripts/tune-agent-database-url.sh
+++ b/scripts/tune-agent-database-url.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Tighten the generated coding-agent DATABASE_URL without rotating credentials.
+# Run after scripts/provision-agent-db-lane.sh --apply.
+
+set -Eeuo pipefail
+
+OUTPUT_FILE="${OUTPUT_FILE:-/mnt/user/pc/kindrobots-db-agent/kindrobots-db-agent.env}"
+AGENT_CLIENT_CONNECTION_LIMIT="${AGENT_CLIENT_CONNECTION_LIMIT:-3}"
+AGENT_CLIENT_MINIMUM_IDLE="${AGENT_CLIENT_MINIMUM_IDLE:-0}"
+AGENT_CLIENT_IDLE_TIMEOUT_SECONDS="${AGENT_CLIENT_IDLE_TIMEOUT_SECONDS:-30}"
+AGENT_CLIENT_ACQUIRE_TIMEOUT_MS="${AGENT_CLIENT_ACQUIRE_TIMEOUT_MS:-10000}"
+AGENT_CLIENT_CONNECT_TIMEOUT_MS="${AGENT_CLIENT_CONNECT_TIMEOUT_MS:-5000}"
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v node >/dev/null 2>&1 || fail 'node is required to tune the agent database URL'
+[[ -f "$OUTPUT_FILE" ]] || fail "credential handoff file not found: $OUTPUT_FILE"
+
+mode="$(stat -c '%a' "$OUTPUT_FILE" 2>/dev/null || true)"
+[[ "$mode" == '600' || "$mode" == '400' ]] || fail \
+  "refusing to read $OUTPUT_FILE because its mode is ${mode:-unknown}; chmod 600 first"
+
+for value in \
+  "$AGENT_CLIENT_CONNECTION_LIMIT" \
+  "$AGENT_CLIENT_MINIMUM_IDLE" \
+  "$AGENT_CLIENT_IDLE_TIMEOUT_SECONDS" \
+  "$AGENT_CLIENT_ACQUIRE_TIMEOUT_MS" \
+  "$AGENT_CLIENT_CONNECT_TIMEOUT_MS"; do
+  [[ "$value" =~ ^[0-9]+$ ]] || fail "expected an integer, got: $value"
+done
+
+[[ "$AGENT_CLIENT_CONNECTION_LIMIT" -ge 1 ]] || fail 'Agent client connection limit must be at least 1'
+[[ "$AGENT_CLIENT_CONNECTION_LIMIT" -le 6 ]] || fail 'Agent client connection limit must not exceed the default six-backend agent lane'
+[[ "$AGENT_CLIENT_MINIMUM_IDLE" -le "$AGENT_CLIENT_CONNECTION_LIMIT" ]] || fail \
+  'Agent minimum idle must not exceed its connection limit'
+[[ "$AGENT_CLIENT_IDLE_TIMEOUT_SECONDS" -ge 1 ]] || fail 'Agent idle timeout must be at least one second'
+[[ "$AGENT_CLIENT_ACQUIRE_TIMEOUT_MS" -gt "$AGENT_CLIENT_CONNECT_TIMEOUT_MS" ]] || fail \
+  'Agent acquire timeout must exceed its connect timeout'
+
+OUTPUT_FILE="$OUTPUT_FILE" \
+AGENT_CLIENT_CONNECTION_LIMIT="$AGENT_CLIENT_CONNECTION_LIMIT" \
+AGENT_CLIENT_MINIMUM_IDLE="$AGENT_CLIENT_MINIMUM_IDLE" \
+AGENT_CLIENT_IDLE_TIMEOUT_SECONDS="$AGENT_CLIENT_IDLE_TIMEOUT_SECONDS" \
+AGENT_CLIENT_ACQUIRE_TIMEOUT_MS="$AGENT_CLIENT_ACQUIRE_TIMEOUT_MS" \
+AGENT_CLIENT_CONNECT_TIMEOUT_MS="$AGENT_CLIENT_CONNECT_TIMEOUT_MS" \
+node --input-type=module <<'NODE'
+import { chmodSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+
+const outputFile = process.env.OUTPUT_FILE
+if (!outputFile) throw new Error('OUTPUT_FILE is missing')
+
+const source = readFileSync(outputFile, 'utf8')
+const match = source.match(/^AGENT_DATABASE_URL=(.+)$/m)
+if (!match?.[1]) throw new Error('AGENT_DATABASE_URL is missing from the handoff file')
+
+const url = new URL(match[1])
+url.searchParams.set('connectionLimit', process.env.AGENT_CLIENT_CONNECTION_LIMIT ?? '3')
+url.searchParams.set('minimumIdle', process.env.AGENT_CLIENT_MINIMUM_IDLE ?? '0')
+url.searchParams.set('idleTimeout', process.env.AGENT_CLIENT_IDLE_TIMEOUT_SECONDS ?? '30')
+url.searchParams.set('acquireTimeout', process.env.AGENT_CLIENT_ACQUIRE_TIMEOUT_MS ?? '10000')
+url.searchParams.set('connectTimeout', process.env.AGENT_CLIENT_CONNECT_TIMEOUT_MS ?? '5000')
+url.searchParams.set('minDelayValidation', '0')
+url.searchParams.set('pipelining', 'false')
+
+const next = source.replace(/^AGENT_DATABASE_URL=.*$/m, `AGENT_DATABASE_URL=${url.toString()}`)
+const temporary = `${outputFile}.tmp-${process.pid}`
+writeFileSync(temporary, next, { mode: 0o600 })
+chmodSync(temporary, 0o600)
+renameSync(temporary, outputFile)
+chmodSync(outputFile, 0o600)
+NODE
+
+printf 'Agent DATABASE_URL pool tuning applied to %s (contents not printed).\n' "$OUTPUT_FILE"
+printf 'Client pool: connectionLimit=%s minimumIdle=%s idleTimeout=%ss acquireTimeout=%sms connectTimeout=%sms pipelining=false\n' \
+  "$AGENT_CLIENT_CONNECTION_LIMIT" \
+  "$AGENT_CLIENT_MINIMUM_IDLE" \
+  "$AGENT_CLIENT_IDLE_TIMEOUT_SECONDS" \
+  "$AGENT_CLIENT_ACQUIRE_TIMEOUT_MS" \
+  "$AGENT_CLIENT_CONNECT_TIMEOUT_MS"
+printf 'Use the resulting AGENT_DATABASE_URL as Claude\x27s DATABASE_URL.\n'

--- a/utils/scripts/verifyAgentDbLaneProvisioning.mjs
+++ b/utils/scripts/verifyAgentDbLaneProvisioning.mjs
@@ -3,9 +3,12 @@ import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 
 const scriptUrl = new URL('../../scripts/provision-agent-db-lane.sh', import.meta.url)
+const tuningUrl = new URL('../../scripts/tune-agent-database-url.sh', import.meta.url)
 const source = readFileSync(scriptUrl, 'utf8')
+const tuningSource = readFileSync(tuningUrl, 'utf8')
 
 execFileSync('bash', ['-n', scriptUrl.pathname], { stdio: 'inherit' })
+execFileSync('bash', ['-n', tuningUrl.pathname], { stdio: 'inherit' })
 
 assert.match(source, /MODE='dry-run'/)
 assert.match(source, /AGENT_DB_USER="\$\{AGENT_DB_USER:-kindrobot_agent\}"/)
@@ -57,5 +60,23 @@ assert.doesNotMatch(source, /printf[^\n]*(AGENT_DB_PASSWORD|agent_url)/)
 
 assert.match(source, /replace Claude's existing DATABASE_URL with the AGENT_DATABASE_URL value/)
 assert.match(source, /Do not give Claude MIGRATION_DATABASE_URL unless intentionally performing a migration/)
+
+assert.match(tuningSource, /AGENT_CLIENT_CONNECTION_LIMIT="\$\{AGENT_CLIENT_CONNECTION_LIMIT:-3\}"/)
+assert.match(tuningSource, /AGENT_CLIENT_MINIMUM_IDLE="\$\{AGENT_CLIENT_MINIMUM_IDLE:-0\}"/)
+assert.match(tuningSource, /AGENT_CLIENT_IDLE_TIMEOUT_SECONDS="\$\{AGENT_CLIENT_IDLE_TIMEOUT_SECONDS:-30\}"/)
+assert.match(tuningSource, /AGENT_CLIENT_ACQUIRE_TIMEOUT_MS="\$\{AGENT_CLIENT_ACQUIRE_TIMEOUT_MS:-10000\}"/)
+assert.match(tuningSource, /AGENT_CLIENT_CONNECT_TIMEOUT_MS="\$\{AGENT_CLIENT_CONNECT_TIMEOUT_MS:-5000\}"/)
+assert.match(tuningSource, /connection limit must not exceed the default six-backend agent lane/)
+assert.match(tuningSource, /url\.searchParams\.set\('connectionLimit'/)
+assert.match(tuningSource, /url\.searchParams\.set\('minimumIdle'/)
+assert.match(tuningSource, /url\.searchParams\.set\('idleTimeout'/)
+assert.match(tuningSource, /url\.searchParams\.set\('acquireTimeout'/)
+assert.match(tuningSource, /url\.searchParams\.set\('connectTimeout'/)
+assert.match(tuningSource, /url\.searchParams\.set\('minDelayValidation', '0'\)/)
+assert.match(tuningSource, /url\.searchParams\.set\('pipelining', 'false'\)/)
+assert.match(tuningSource, /AGENT_DATABASE_URL=\$\{url\.toString\(\)\}/)
+assert.match(tuningSource, /chmodSync\(outputFile, 0o600\)/)
+assert.doesNotMatch(tuningSource, /MIGRATION_DATABASE_URL/)
+assert.doesNotMatch(tuningSource, /console\.log\([^\n]*AGENT_DATABASE_URL/)
 
 console.log('Agent database lane provisioning contract passed.')


### PR DESCRIPTION
Follow-up to #1591 based on review of Claude's actual Kind Robots usage.

### What changed
- Add `scripts/tune-agent-database-url.sh` to tighten the private `AGENT_DATABASE_URL` after provisioning without rotating credentials or changing grants.
- Default the coding-agent client pool to `connectionLimit=3`, `minimumIdle=0`, `idleTimeout=30`, `acquireTimeout=10000`, `connectTimeout=5000`, `minDelayValidation=0`, and `pipelining=false`.
- Keep the standing agent identity application read/write. DDL remains forbidden.
- Extend the isolation contract to syntax-check and assert the client-pool envelope.
- Document why Prisma 7 / `@prisma/adapter-mariadb` means the old CPU×2+1 Prisma pool default does not apply here; the generic MariaDB adapter pool is 10, so the explicit agent cap is still worthwhile.
- Document that `POST /api/economy/karma-earned` is read-only at the database layer, so HTTP POST alone is not evidence that Preview needs write privileges.

### Why
Agent scripts are short-lived and may overlap. A three-connection per-process target prevents one Claude process from consuming the entire six-backend agent hostgroup while retaining enough concurrency for normal reconciliation work. The generated handoff remains one secret: Claude receives the tuned URL as ordinary `DATABASE_URL`; no standing `MIGRATION_DATABASE_URL` is introduced.