### PR TITLE
mermaids-of-venice/t-002: lorem-ipsum the personal note placeholder

### DIFF
--- a/components/pages/mermaids-page.vue
+++ b/components/pages/mermaids-page.vue
@@ -77,8 +77,9 @@
       <!--
         PERSONAL NOTE PLACEHOLDER
         Silas writes this section himself (conductor: mermaids-of-venice t-002).
-        Replace the placeholder paragraph below with his note, verbatim, and
-        remove the "coming soon" styling.
+        Filled with lorem ipsum at Silas's own direction ("just lorem ipsum it
+        for now") while he writes the real note. Replace the paragraph below
+        with his note, verbatim, and remove the "coming soon" styling.
       -->
       <div
         class="mb-4 rounded-2xl border border-dashed border-base-300 bg-base-100 p-5 shadow-sm"
@@ -96,8 +97,11 @@
           </h2>
         </div>
         <p class="text-sm italic leading-relaxed text-base-content/50">
-          Silas is writing this note himself, in his own hand, like everything
-          else here worth reading. It will appear soon.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+          ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat — Silas's real note will replace
+          this placeholder soon.
         </p>
       </div>
 


### PR DESCRIPTION
### Task
mermaids-of-venice/t-002: Personal note for the landing page (Silas writes it) (kind: content/software)

### What changed
- `components/pages/mermaids-page.vue`: replaced the italic "coming soon" placeholder text in the "A Note From Silas" section with lorem ipsum filler paragraph text, matching the intended length/flow of a real note.
- Dashed-border placeholder styling and the section header are unchanged — this still isn't the real note.

### Why
Silas, via Kind Robots For You (recorded on the roadmap task): *"I haven't written this yet, but just lorem ipsum it for now."*

### How I verified
- `npx eslint components/pages/mermaids-page.vue` — clean.
- `npx vue-tsc --noEmit` — clean.

### Stakes
reversible — placeholder copy only, no logic touched. The conductor task keeps `gate_human: true` / `approved_by_human: false` — only Silas can supply and approve the real note; this PR just fills the interim placeholder as directed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYGWyRr3FQxQjt9N4CsKDh)_