### PR TITLE
interface-vision/t-108: dedupe simultaneous duplicate-URL image requests on /navigation

### DIFF
--- a/components/navigation/navigation-artwork.vue
+++ b/components/navigation/navigation-artwork.vue
@@ -1,0 +1,21 @@
+<!-- /components/navigation/navigation-artwork.vue -->
+<template>
+  <img
+    v-if="resolvedSrc"
+    :src="resolvedSrc"
+    :alt="alt"
+    loading="lazy"
+    class="h-full w-full object-cover"
+  />
+</template>
+
+<script setup lang="ts">
+import { useDedupedArtwork } from '@/composables/useDedupedArtwork'
+
+const props = defineProps<{
+  src?: string
+  alt?: string
+}>()
+
+const resolvedSrc = useDedupedArtwork(() => props.src)
+</script>

--- a/components/navigation/navigation-artwork.vue
+++ b/components/navigation/navigation-artwork.vue
@@ -1,15 +1,18 @@
 <!-- /components/navigation/navigation-artwork.vue -->
 <template>
-  <img
-    v-if="resolvedSrc"
-    :src="resolvedSrc"
-    :alt="alt"
-    loading="lazy"
-    class="h-full w-full object-cover"
-  />
+  <span ref="root" class="block h-full w-full">
+    <img
+      v-if="resolvedSrc"
+      :src="resolvedSrc"
+      :alt="alt"
+      loading="lazy"
+      class="h-full w-full object-cover"
+    />
+  </span>
 </template>
 
 <script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue'
 import { useDedupedArtwork } from '@/composables/useDedupedArtwork'
 
 const props = defineProps<{
@@ -17,5 +20,26 @@ const props = defineProps<{
   alt?: string
 }>()
 
-const resolvedSrc = useDedupedArtwork(() => props.src)
+const root = ref<HTMLElement>()
+const { resolvedSrc, request } = useDedupedArtwork()
+
+let observer: IntersectionObserver | undefined
+
+onMounted(() => {
+  if (!props.src || !import.meta.client || !root.value) return
+  observer = new IntersectionObserver(
+    (entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) {
+        request(props.src as string)
+        observer?.disconnect()
+      }
+    },
+    { rootMargin: '200px' },
+  )
+  observer.observe(root.value)
+})
+
+onBeforeUnmount(() => {
+  observer?.disconnect()
+})
 </script>

--- a/components/navigation/navigation-trimmed.vue
+++ b/components/navigation/navigation-trimmed.vue
@@ -74,12 +74,9 @@
             <span
               class="relative flex h-11 w-11 shrink-0 overflow-hidden rounded-lg bg-base-200"
             >
-              <img
-                v-if="tab.image"
+              <NavigationArtwork
                 :src="tab.image"
                 :alt="tab.title || tab.label"
-                loading="lazy"
-                class="h-full w-full object-cover"
               />
               <span
                 class="absolute inset-0 flex items-center justify-center bg-base-content/15"

--- a/composables/useDedupedArtwork.ts
+++ b/composables/useDedupedArtwork.ts
@@ -1,0 +1,48 @@
+// /composables/useDedupedArtwork.ts
+//
+// interface-vision/t-108: /navigation renders ~85 dashboard-tab icons, and
+// many distinct entries resolve to the exact same image path (five separate
+// content files can share one dashboardKey/dashboardTab pair). Mounting that
+// many identical-src <img> tags in the same tick fires that many simultaneous
+// first-time GETs for the one path -- the browser has never fetched it before
+// in this page load, so there is no warm cache entry for a later duplicate to
+// reuse, and the media origin sees a burst of concurrent identical requests
+// instead of one. kind_robots#1592 tried caching the /images/* redirect
+// response, which only helps a *second* visit reuse a *first* visit's cache
+// entry -- it does nothing for N tags racing each other on the very first
+// visit, which is the case that was actually flaking.
+//
+// This holds every occurrence but the first back until that first request has
+// settled (success or failure), so repeats always land on a now-warm cache
+// entry instead of piling onto the origin at once.
+import { ref, watchEffect, type Ref } from 'vue'
+
+const inFlight = new Map<string, Promise<void>>()
+
+export function useDedupedArtwork(
+  source: () => string | undefined,
+): Ref<string | undefined> {
+  const resolvedSrc = ref<string | undefined>()
+
+  watchEffect(async () => {
+    const url = source()
+    resolvedSrc.value = undefined
+    if (!url || !import.meta.client) return
+
+    let settle = inFlight.get(url)
+    if (!settle) {
+      settle = new Promise<void>((resolve) => {
+        const probe = new Image()
+        probe.onload = () => resolve()
+        probe.onerror = () => resolve()
+        probe.src = url
+      })
+      inFlight.set(url, settle)
+    }
+
+    await settle
+    if (source() === url) resolvedSrc.value = url
+  })
+
+  return resolvedSrc
+}

--- a/composables/useDedupedArtwork.ts
+++ b/composables/useDedupedArtwork.ts
@@ -1,34 +1,15 @@
 // /composables/useDedupedArtwork.ts
-//
-// interface-vision/t-108: /navigation renders ~85 dashboard-tab icons, and
-// many distinct entries resolve to the exact same image path (five separate
-// content files can share one dashboardKey/dashboardTab pair). Mounting that
-// many identical-src <img> tags in the same tick fires that many simultaneous
-// first-time GETs for the one path -- the browser has never fetched it before
-// in this page load, so there is no warm cache entry for a later duplicate to
-// reuse, and the media origin sees a burst of concurrent identical requests
-// instead of one. kind_robots#1592 tried caching the /images/* redirect
-// response, which only helps a *second* visit reuse a *first* visit's cache
-// entry -- it does nothing for N tags racing each other on the very first
-// visit, which is the case that was actually flaking.
-//
-// This holds every occurrence but the first back until that first request has
-// settled (success or failure), so repeats always land on a now-warm cache
-// entry instead of piling onto the origin at once.
-import { ref, watchEffect, type Ref } from 'vue'
+import { ref, type Ref } from 'vue'
 
 const inFlight = new Map<string, Promise<void>>()
 
-export function useDedupedArtwork(
-  source: () => string | undefined,
-): Ref<string | undefined> {
+export function useDedupedArtwork(): {
+  resolvedSrc: Ref<string | undefined>
+  request: (url: string) => void
+} {
   const resolvedSrc = ref<string | undefined>()
 
-  watchEffect(async () => {
-    const url = source()
-    resolvedSrc.value = undefined
-    if (!url || !import.meta.client) return
-
+  function request(url: string) {
     let settle = inFlight.get(url)
     if (!settle) {
       settle = new Promise<void>((resolve) => {
@@ -39,10 +20,10 @@ export function useDedupedArtwork(
       })
       inFlight.set(url, settle)
     }
+    settle.then(() => {
+      resolvedSrc.value = url
+    })
+  }
 
-    await settle
-    if (source() === url) resolvedSrc.value = url
-  })
-
-  return resolvedSrc
+  return { resolvedSrc, request }
 }


### PR DESCRIPTION
### Task
interface-vision/t-108: `/navigation`'s site-directory (~85 icons/page) flakes BROKEN-ART on a different image set each responsive-audit run (kind: software)

### What changed
- `composables/useDedupedArtwork.ts` (new): module-scoped in-flight map keyed by image URL. The first occurrence of a URL preloads it directly (native `Image()`); every later occurrence for the same URL awaits that first preload's settlement (success or failure) before pointing its own `<img>` at the URL.
- `components/navigation/navigation-artwork.vue` (new): thin wrapper so the composable can be called once per rendered tab (Vue composables must be called at a component's setup top level, not per `v-for` iteration).
- `components/navigation/navigation-trimmed.vue`: swapped the raw `<img>` in the site-directory card for `<NavigationArtwork>`.

### Why (root cause, continuing t-108's investigation)
kind_robots#1592 (merged 2026-08-08T02:12:49Z) added `Cache-Control: public, max-age=3600` to the `/images/*` redirect. The **post-merge** `responsive-layout-audit` run (31234573743, against the exact merge commit `d8d7b857`) still shows `/navigation` BROKEN-ART on phone (6 images) and desktop (3 images) — the same shared-URL images as every prior run (`dashboard-tabs/user/profile.webp`, `dashboard-tabs/giftshop/community.webp`).

Why #1592 didn't move the needle: caching the redirect response only lets a *second* visit reuse a *first* visit's cache entry. It does nothing when N `<img>` tags with the identical `src` all fire their first-ever GET for that path in the same tick on the very first page load — which is exactly what `/navigation` does with its ~85 tab icons, several of which resolve to one identical dashboard-tab image shared by multiple content entries (confirmed via `content/channels/**/*.md` frontmatter in t-108's earlier investigation).

This PR is complementary to #1592, not a replacement: #1592 makes the response cacheable at all; this makes sure duplicate requests are staggered so that cache actually gets a chance to be warm before the next duplicate fires.

### How I verified
- `npx eslint` on all three changed/new files — clean.
- `npx vue-tsc --noEmit` — clean.
- `npx prettier --check` — clean.
- No live GitHub Actions dispatch available from this sandbox — this PR's own deployment-triggered `responsive-layout-audit` is the real verification, same as t-108's prior rounds. Recommend reading the raw per-route log (not just the pass/fail summary) before merging, per the task's own established precedent.

### Stakes
reversible — new composable + wrapper component, one call-site swap; no other app code touched.

### Flags for Reviewer
This is t-108's 3rd attempt at a fix (2 prior fixes shipped and were then disproven by a fresh audit read). Please don't merge on structural CI alone — wait for this PR's own `responsive-layout-audit` result and read the raw `/navigation` BROKEN-ART lines directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0142MG9h3Ho8auC1UNJKwQRc)_