### PR TITLE
Recover legacy ArtJob prompts from Comfy workflows

### DIFF
--- a/server/utils/artJobProvenance.ts
+++ b/server/utils/artJobProvenance.ts
@@ -47,10 +47,6 @@ type ProvenanceOptions = {
 const TEXT_INPUT_PATTERN = /(^|_)(prompt|text)($|_)/i
 const MODEL_INPUT_PATTERN =
   /(^|_)(ckpt|checkpoint|unet|clip|vae|lora|controlnet|ipadapter|ip_adapter|upscale|model).*name($|_)/i
-const POSITIVE_PROMPT_NODE_TYPES = new Set([
-  'CLIPTextEncode',
-  'ImpactWildcardEncode',
-])
 
 function asRecord(value: unknown): ArtJobPayloadRecord {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return {}

--- a/server/utils/artJobProvenance.ts
+++ b/server/utils/artJobProvenance.ts
@@ -47,6 +47,10 @@ type ProvenanceOptions = {
 const TEXT_INPUT_PATTERN = /(^|_)(prompt|text)($|_)/i
 const MODEL_INPUT_PATTERN =
   /(^|_)(ckpt|checkpoint|unet|clip|vae|lora|controlnet|ipadapter|ip_adapter|upscale|model).*name($|_)/i
+const POSITIVE_PROMPT_NODE_TYPES = new Set([
+  'CLIPTextEncode',
+  'ImpactWildcardEncode',
+])
 
 function asRecord(value: unknown): ArtJobPayloadRecord {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
@@ -139,6 +143,46 @@ export function extractWorkflowTextCandidates(workflow: unknown): string[] {
   return [...new Set(values)].sort()
 }
 
+export function extractWorkflowPositivePromptCandidates(
+  workflow: unknown,
+): string[] {
+  const values: string[] = []
+
+  for (const nodeValue of Object.values(asRecord(workflow))) {
+    const node = asRecord(nodeValue)
+    const classType = String(node.class_type || '')
+    const inputs = asRecord(node.inputs)
+    const title = normalizeArtPrompt(asRecord(node._meta).title).toLowerCase()
+
+    if (title.includes('negative')) continue
+
+    const add = (value: unknown) => {
+      const prompt = normalizeArtPrompt(value)
+      if (prompt) values.push(prompt)
+    }
+
+    if (classType === 'CLIPTextEncode') {
+      add(inputs.text)
+      continue
+    }
+
+    if (classType === 'ImpactWildcardEncode') {
+      add(inputs.wildcard_text)
+      add(inputs.populated_text)
+      continue
+    }
+
+    if (
+      classType === 'PrimitiveStringMultiline' &&
+      title.includes('prompt')
+    ) {
+      add(inputs.value)
+    }
+  }
+
+  return [...new Set(values)].sort()
+}
+
 export function extractWorkflowModels(workflow: unknown): string[] {
   const values: string[] = []
 
@@ -155,9 +199,25 @@ export function extractWorkflowModels(workflow: unknown): string[] {
 }
 
 function requestPrompt(payload: ArtJobPayloadRecord): string {
-  return normalizeArtPrompt(
+  const explicit = normalizeArtPrompt(
     payload.promptString || payload.artPrompt || payload.prompt,
   )
+  if (explicit) return explicit
+
+  const workflowCandidates = extractWorkflowPositivePromptCandidates(
+    payload.workflow,
+  )
+  if (workflowCandidates.length === 1) return workflowCandidates[0]!
+
+  if (workflowCandidates.length > 1) {
+    throw createError({
+      statusCode: 400,
+      message:
+        'ArtJob payload is missing promptString and the workflow contains multiple distinct positive prompts. Refusing to guess which prompt owns the render.',
+    })
+  }
+
+  return ''
 }
 
 function cleanIdempotencyKey(value: unknown): string | null {

--- a/utils/scripts/repairMissingPromptArtJobs.ts
+++ b/utils/scripts/repairMissingPromptArtJobs.ts
@@ -1,0 +1,236 @@
+import 'dotenv/config'
+import { fileURLToPath } from 'node:url'
+import {
+  enrichArtJobPayload,
+  readArtJobProvenance,
+} from '../../server/utils/artJobProvenance'
+import {
+  parseArtJobPayload,
+  serializeArtJobPayload,
+  type ArtJobPayloadRecord,
+} from '../../server/utils/artJobPayload'
+import { normalizeQueuedArtJobPayload } from '../../server/utils/artJobNormalization'
+import { refreshArtJobLoraResources } from '../../server/utils/artJobResourceRefresh'
+import {
+  createScriptPrismaClient,
+  withDatabaseRetry,
+} from '../../scripts/lib/databaseRetry'
+
+const APPLY = process.argv.includes('--apply')
+const DEFAULT_LIMIT = 200
+const MAX_LIMIT = 1000
+const KIND_ROBOTS_REPO = 'silasfelinus/kind_robots'
+
+function asRecord(value: unknown): ArtJobPayloadRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as ArtJobPayloadRecord
+}
+
+function positiveInt(value: unknown): number | null {
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+function optionNumber(name: string, fallback: number): number {
+  const index = process.argv.indexOf(name)
+  if (index < 0) return fallback
+  const value = Number(process.argv[index + 1])
+  if (!Number.isFinite(value) || value <= 0) return fallback
+  return Math.min(Math.floor(value), MAX_LIMIT)
+}
+
+function missingPromptFailure(error: unknown): boolean {
+  const message = String(error || '')
+  return (
+    /requires a non-empty promptString/i.test(message) ||
+    /missing promptString/i.test(message)
+  )
+}
+
+function dailyDreamIdentity(payload: ArtJobPayloadRecord): {
+  isDailyDream: boolean
+  requestId: string | null
+  targetChanged: boolean
+} {
+  const target = asRecord(payload.dailyDreamTarget)
+  const conductor = asRecord(payload.conductorRequest)
+  const source = String(target.source || conductor.source || '').trim().toLowerCase()
+  const isDailyDream =
+    source === 'dream-cycle' ||
+    String(payload.collection || '').trim().toLowerCase() === 'dream-cycle'
+
+  if (!isDailyDream) {
+    return { isDailyDream: false, requestId: null, targetChanged: false }
+  }
+
+  let targetChanged = false
+  const requestId = String(target.requestId || conductor.id || '').trim() || null
+  const imagePath = String(target.imagePath || conductor.imagePath || '').trim()
+  const sourceUrl = String(target.sourceUrl || conductor.sourceUrl || '').trim()
+
+  if (imagePath && !String(payload.imagePath || '').trim()) {
+    payload.imagePath = imagePath
+    targetChanged = true
+  }
+  if (sourceUrl && !String(payload.sourceUrl || '').trim()) {
+    payload.sourceUrl = sourceUrl
+    targetChanged = true
+  }
+  if (imagePath && !String(payload.targetRepo || '').trim()) {
+    payload.targetRepo = KIND_ROBOTS_REPO
+    targetChanged = true
+  }
+
+  const entityId = positiveInt(target.entityId)
+  const model = String(target.model || '').trim().toLowerCase()
+  const entityType =
+    model === 'dream'
+      ? 'dream'
+      : model === 'character'
+        ? 'character'
+        : model === 'reward'
+          ? 'reward'
+          : model === 'scenario'
+            ? 'scenario'
+            : null
+
+  if (
+    entityType &&
+    entityId &&
+    !Object.keys(asRecord(payload.entityArt)).length
+  ) {
+    payload.entityArt = {
+      entityType,
+      entityId,
+      field: String(target.field || 'imagePath').trim() || 'imagePath',
+      preserveOriginal: true,
+      mode: 'recreate',
+    }
+    targetChanged = true
+  }
+
+  return { isDailyDream: true, requestId, targetChanged }
+}
+
+function promptPreview(value: unknown): string {
+  const text = String(value || '').replace(/\s+/g, ' ').trim()
+  return text.length > 120 ? `${text.slice(0, 117)}...` : text
+}
+
+async function repair(): Promise<void> {
+  const prisma = createScriptPrismaClient()
+  const limit = optionNumber('--limit', DEFAULT_LIMIT)
+
+  try {
+    const failed = await prisma.artJob.findMany({
+      where: { status: 'FAILED' },
+      orderBy: { id: 'desc' },
+      take: limit,
+      select: {
+        id: true,
+        engine: true,
+        payload: true,
+        priority: true,
+        projectSlug: true,
+        error: true,
+      },
+    })
+
+    const candidates = failed.filter((job) => missingPromptFailure(job.error))
+    console.log(
+      `[prompt-repair] ${APPLY ? 'APPLY' : 'DRY RUN'}: ${candidates.length} missing-prompt failure(s) among ${failed.length} recent FAILED ArtJobs.`,
+    )
+
+    let repaired = 0
+    let unresolved = 0
+    let dailyDreamCount = 0
+    let dailyDreamTargetsAdded = 0
+
+    for (const job of candidates) {
+      try {
+        const parsed = structuredClone(parseArtJobPayload(job.payload))
+        const daily = dailyDreamIdentity(parsed)
+        if (daily.isDailyDream) dailyDreamCount += 1
+        if (daily.targetChanged) dailyDreamTargetsAdded += 1
+
+        const normalized = normalizeQueuedArtJobPayload(parsed)
+        const resources = await refreshArtJobLoraResources(normalized.payload)
+        const prior = readArtJobProvenance(job.payload)
+        const projectSlug = daily.isDailyDream
+          ? 'dream-cycle'
+          : job.projectSlug
+        const { payload } = enrichArtJobPayload(
+          job.engine as 'A1111' | 'COMFY',
+          resources.payload,
+          {
+            projectSlug,
+            idempotencyKey: prior?.idempotencyKey || daily.requestId,
+            requireCompletionProof: prior?.requireCompletionProof,
+          },
+        )
+
+        payload.queueRepair = {
+          ...asRecord(payload.queueRepair),
+          repairedAt: new Date().toISOString(),
+          reason: 'missing-top-level-prompt-recovered-from-workflow',
+          previousError: String(job.error || '').slice(0, 1000),
+          dailyDreamTargetRepaired: daily.targetChanged,
+          imagePathChanged: normalized.imagePathChanged,
+          loraPathChanged: resources.changed,
+        }
+
+        console.log(
+          `[prompt-repair] ${job.id}: recoverable${daily.isDailyDream ? ' [dream-cycle]' : ''} prompt="${promptPreview(payload.promptString)}"${daily.targetChanged ? ' + target metadata' : ''}`,
+        )
+
+        if (APPLY) {
+          const updated = await prisma.artJob.updateMany({
+            where: { id: job.id, status: 'FAILED' },
+            data: {
+              payload: serializeArtJobPayload(payload),
+              status: 'PENDING',
+              attempts: 0,
+              claimedAt: null,
+              claimedBy: null,
+              error: null,
+              projectSlug,
+              priority: daily.isDailyDream ? 100 : job.priority,
+            },
+          })
+
+          if (updated.count !== 1) {
+            throw new Error(`ArtJob ${job.id} changed while it was being repaired.`)
+          }
+        }
+
+        repaired += 1
+      } catch (error) {
+        unresolved += 1
+        console.log(
+          `[prompt-repair] ${job.id}: SKIP ${error instanceof Error ? error.message : String(error)}`,
+        )
+      }
+    }
+
+    console.log(
+      `[prompt-repair] summary: recoverable=${repaired} unresolved=${unresolved} dream-cycle=${dailyDreamCount} dream-target-metadata-added=${dailyDreamTargetsAdded}${APPLY ? ' (requeued in place)' : ' (no writes)'}.`,
+    )
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function main(): Promise<void> {
+  await withDatabaseRetry('repair missing ArtJob prompts', async () => repair())
+}
+
+const isDirectRun = process.argv[1]
+  ? fileURLToPath(import.meta.url) === fileURLToPath(new URL(process.argv[1], 'file:'))
+  : false
+
+if (isDirectRun) {
+  main().catch((error) => {
+    console.error('[prompt-repair] failed', error)
+    process.exitCode = 1
+  })
+}

--- a/utils/scripts/verifyArtJobProvenance.ts
+++ b/utils/scripts/verifyArtJobProvenance.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import {
   assertArtImageMatchesCompletion,
   enrichArtJobPayload,
+  extractWorkflowPositivePromptCandidates,
   hashArtImageData,
   validateArtJobCompletionProof,
 } from '../../server/utils/artJobProvenance'
@@ -27,12 +28,29 @@ function workflow(prompt: string, seed: number) {
         seed,
         model: ['24', 0],
       },
+      _meta: { title: 'Positive Prompt' },
+    },
+  }
+}
+
+function simpleWorkflow(prompt: string, negative: string) {
+  return {
+    '3': {
+      class_type: 'CLIPTextEncode',
+      inputs: { text: prompt, clip: ['2', 0] },
+      _meta: { title: 'Positive Prompt' },
+    },
+    '4': {
+      class_type: 'CLIPTextEncode',
+      inputs: { text: negative, clip: ['2', 0] },
+      _meta: { title: 'Negative Prompt' },
     },
   }
 }
 
 const promptA = 'A vampire family portrait in a velvet crypt lounge.'
 const promptB = 'A lighthouse keeper confronting a sea monster.'
+const negativePrompt = 'text, watermark, blurry anatomy'
 const imageDataA = Buffer.from('job-a-pixels').toString('base64')
 const imageDataB = Buffer.from('job-b-pixels').toString('base64')
 const imageHashA = hashArtImageData(imageDataA)
@@ -78,6 +96,36 @@ assert.equal(
 assert.equal(attemptA.provenance.workflowPromptMatches, true)
 assert.ok(
   attemptA.provenance.expectedModels.includes('flux1-dev-Q8_0.gguf'),
+)
+
+const recoveredFromWorkflow = enrichArtJobPayload('COMFY', {
+  workflow: simpleWorkflow(promptA, negativePrompt),
+})
+assert.equal(recoveredFromWorkflow.payload.promptString, promptA)
+assert.equal(recoveredFromWorkflow.provenance.normalizedPrompt, promptA)
+assert.equal(recoveredFromWorkflow.provenance.workflowPromptMatches, true)
+assert.deepEqual(
+  extractWorkflowPositivePromptCandidates(
+    simpleWorkflow(promptA, negativePrompt),
+  ),
+  [promptA],
+  'negative conditioning must never be mistaken for a recoverable positive prompt',
+)
+
+assert.throws(
+  () =>
+    enrichArtJobPayload('COMFY', {
+      workflow: {
+        ...simpleWorkflow(promptA, negativePrompt),
+        '5': {
+          class_type: 'CLIPTextEncode',
+          inputs: { text: promptB, clip: ['2', 0] },
+          _meta: { title: 'Second Positive Prompt' },
+        },
+      },
+    }),
+  /multiple distinct positive prompts/i,
+  'missing top-level prompt metadata must not guess between distinct positive workflow prompts',
 )
 
 const attemptB = enrichArtJobPayload(


### PR DESCRIPTION
## What changed
- ArtJob provenance validation now recovers a missing top-level `promptString` when the Comfy workflow contains exactly one distinct positive prompt
- negative conditioning is explicitly excluded from recovery
- multiple distinct positive prompts still fail rather than guessing
- focused provenance regressions cover recovered prompts, negative exclusion, ambiguity rejection, and existing mismatch protection
- add `utils/scripts/repairMissingPromptArtJobs.ts`, dry-run by default, to repair already-FAILED missing-prompt rows in place rather than creating duplicate ArtJobs
- the repair also restores Daily Dream destination metadata and `entityArt` from V5 `dailyDreamTarget` metadata when available, including Dream/world/location targets now that Dream entityArt is supported

## Root cause
Historical and repair-shaped COMFY ArtJobs can retain their real positive prompt inside the workflow while lacking the redundant top-level `promptString`. The claim path re-runs provenance validation before handing a job to the relay and currently treats the missing top-level copy as fatal, so otherwise-renderable jobs are marked FAILED before Comfy sees them.

## Operational recovery
After merge/deploy, on Alexandria:

```bash
npx tsx utils/scripts/repairMissingPromptArtJobs.ts
npx tsx utils/scripts/repairMissingPromptArtJobs.ts --apply
```

The script updates only FAILED rows whose error specifically reports missing `promptString`; it creates no replacement rows and deletes nothing.