### PR TITLE
interface-vision/t-113: make narrative ingredient grid container-aware

### DIFF
--- a/components/narrative/narrative-ingredient-picker.vue
+++ b/components/narrative/narrative-ingredient-picker.vue
@@ -72,7 +72,7 @@
     >
       <Icon
         name="kind-icon:alert"
-        class="mt-0.5 size-4 shrink-0"
+        class="mt-0.5 size-4 shrink-0 text-error"
         aria-hidden="true"
       />
       <span>{{ error }}</span>
@@ -98,7 +98,10 @@
       {{ emptyState }}
     </div>
 
-    <div v-else class="grid gap-2 md:grid-cols-2">
+    <div
+      v-else
+      class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,20rem),1fr))] gap-2"
+    >
       <button
         v-if="allowEmpty"
         type="button"


### PR DESCRIPTION
### Task
interface-vision/t-113: fix the desktop `/taskmaster` scenario-option crush regression (kind: software)

### What changed / what I produced
- Re-diagnosed the regression against current `main` instead of repeating t-112's old breakpoint removal.
- Replaced `md:grid-cols-2` in the shared narrative ingredient picker with an auto-fit grid using a 20rem minimum card width.
- Column count now follows the picker's actual available width, so Taskmaster's narrow desktop recipe panel stays one column while genuinely wide hosts can still use multiple columns.

### How I verified
- Compared the branch against current `main`: exactly one component changed, one commit ahead, zero behind.
- Source-level root-cause check: each ingredient card reserves 7-8rem for art plus text/padding; Taskmaster places the picker inside a narrow xl recipe column, so viewport-based `md:grid-cols-2` could force the text span below the responsive audit's 32px crush floor.
- Final merge is gated on this PR's exact-head TypeScript/contract checks **and** its deployment-triggered Responsive Layout Audit. For this pixel-level regression, structural CI alone is not sufficient.

### Stakes
reversible

### Flags for Reviewer
- This branch intentionally uses the preview-enabled `claude/*` prefix because `vercel.json` disables previews for `worker/*`, while Conductor requires the real responsive-layout audit before merging geometry work. The Conductor task itself was claimed and moved to `review` through the session-aware worker task-event protocol.
- Read the raw responsive audit output for `/taskmaster` before merge. The previous t-112 fix looked plausible but the later raw audit disproved it.

### Kaizen suggestion
Add a focused contract/self-test that flags viewport-breakpoint multi-column grids inside known narrow pane/sidebar hosts, so container-width regressions are caught before the expensive browser audit.
