### PR TITLE
One header per gallery route: /bots, /rewards, /stories and /themes

### DIFF
--- a/academy-examples-contract.txt
+++ b/academy-examples-contract.txt
@@ -1,0 +1,5 @@
+
+> test:academy-examples-manifest
+> tsx utils/scripts/verifyAcademyExamplesManifest.ts
+
+Academy examples manifest contract passed: 21 entries validated from https://media.acrocatranch.com/images/academy/examples/examples.manifest.json plus 0 pending media entries against PUBLIC-DOMAIN-POLICY.md §3 and cross-checked against academyStyles.ts (media availability check skipped; set MEDIA_VERIFY_ASSETS=1 to enable).

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -383,6 +383,21 @@ const props = withDefaults(
     variant?: GalleryVariant
     title?: string
     subtitle?: string
+    /**
+     * The gallery's own title/subtitle band.
+     *
+     * TRUE BY DEFAULT, AND OFF ON THE ROUTE. kr-manager already renders this
+     * panel's title and summary from dashboardHelper config -- it says so
+     * itself, citing "the brief's one-header rule" -- so on /bots this band is a
+     * second page heading for the same panel.
+     *
+     * It stays available rather than being deleted because the same gallery is
+     * embedded as a PICKER inside bot-chat, where no manager sits above it and
+     * this title is the only label. Duplication on the ROUTE is not duplication
+     * everywhere, so bot-interact opts out explicitly and the default is left
+     * alone for the pickers. reward-gallery and scenario-gallery carry the same
+     * split for the same reason (character-chat, character-flip-card).
+     */
     showHeader?: boolean
     showImages?: boolean
     showControls?: boolean

--- a/components/bots/bot-interact.vue
+++ b/components/bots/bot-interact.vue
@@ -29,13 +29,13 @@
   <section
     class="flex h-full min-h-0 w-full flex-col gap-4 rounded-2xl bg-base-200 p-4"
   >
+    <!-- show-header off: kr-manager renders the panel title. See the
+         showHeader note in bot-gallery.vue. -->
     <bot-gallery
       v-if="!isInteractMode"
       class="min-h-0 flex-1"
       variant="dashboard"
-      title="Choose Your Bot"
-      subtitle="Pick a bot to start a focused chat session."
-      :show-header="true"
+      :show-header="false"
       :show-images="true"
       :show-controls="true"
       :show-card-actions="true"

--- a/components/rewards/reward-interact.vue
+++ b/components/rewards/reward-interact.vue
@@ -24,13 +24,12 @@
   <section
     class="flex h-full min-h-0 w-full flex-col gap-4 rounded-2xl bg-base-200 p-4"
   >
+    <!-- show-header off: kr-manager renders the panel title. See bot-gallery. -->
     <reward-gallery
       v-if="!isInteractMode"
       class="min-h-0 flex-1"
       variant="dashboard"
-      title="Choose Your Reward"
-      subtitle="Pick a story reward, artifact, power, pet, curse, or plot grenade."
-      :show-header="true"
+      :show-header="false"
       :show-images="true"
       :show-controls="true"
       :show-card-actions="true"

--- a/components/scenarios/scenario-interact.vue
+++ b/components/scenarios/scenario-interact.vue
@@ -30,12 +30,12 @@
       {{ storyStore.statusMessage }}
     </div>
 
+    <!-- show-header off: kr-manager renders the panel title. See bot-gallery. -->
     <scenario-gallery
       v-if="storyStore.phase === 'browse'"
       class="min-h-0 flex-1"
       variant="grid"
-      title="Choose Your Scenario"
-      subtitle="Tap a world to read it, configure it, and launch a story."
+      :show-header="false"
       :show-inspirations="false"
     />
 

--- a/components/themes/theme-gallery.vue
+++ b/components/themes/theme-gallery.vue
@@ -42,11 +42,26 @@
             />
           </label>
 
+          <!--
+            THE COUNTS RIDE THE FILTERS. Each button carries the size of the
+            group it selects, which is the same relationship the Projects
+            gallery settled on -- Silas, 2026-08-07, of a row of standing
+            count badges beside their own filter buttons: "none of those need
+            to be said, they are just duplicates of the same outputs better
+            done as toggles to actually select the appropriate group right
+            after it."
+
+            So `Default 32` is both the number and the control that shows you
+            those 32, and the separate default/shared/showing badge strip below
+            is gone. `All` carries the showing count, because "showing" and
+            "all" are the same number exactly when All is lit -- and when it is
+            not, the lit button is the count.
+          -->
           <div class="join">
             <button
               v-for="filter in themeFilters"
               :key="filter.value"
-              class="btn join-item btn-sm rounded-2xl"
+              class="btn join-item btn-sm gap-1 rounded-2xl"
               :class="
                 activeFilter === filter.value
                   ? 'btn-primary'
@@ -56,6 +71,9 @@
               @click="activeFilter = filter.value"
             >
               {{ filter.label }}
+              <span class="font-black opacity-70">
+                {{ filterCounts[filter.value] }}
+              </span>
             </button>
           </div>
 
@@ -65,28 +83,6 @@
           >
             <Icon name="kind-icon:check" class="h-3.5 w-3.5 shrink-0" />
             <span class="truncate">{{ activeThemeName }}</span>
-          </span>
-
-          <!--
-            THREE BADGES, NOT A STATS BAND. These counts used to be a
-            `grid-cols-3 divide-x` strip with its own top border -- a full row,
-            each cell a big number stacked over a tiny uppercase caption, for
-            three integers. Silas, 2026-08-07: "one devoted to the output count:
-            default, shared, showing, that's a lot of real estate for something
-            that could share the row above it."
-
-            Same three numbers, same order, on the line that was already here.
-          -->
-          <span class="flex flex-wrap items-center gap-1 text-xs">
-            <span class="badge badge-primary badge-sm rounded-lg">
-              {{ filteredDaisyThemes.length }} default
-            </span>
-            <span class="badge badge-secondary badge-sm rounded-lg">
-              {{ filteredSharedThemes.length }} shared
-            </span>
-            <span class="badge badge-accent badge-sm rounded-lg">
-              {{ visibleThemeCount }} showing
-            </span>
           </span>
         </div>
       </div>
@@ -108,29 +104,25 @@
           v-if="showDefaultThemes"
           class="rounded-2xl border border-base-300 bg-base-100 p-3 shadow"
         >
-          <div class="mb-3 flex items-center justify-between gap-3">
-            <div class="flex min-w-0 items-center gap-2">
-              <span
-                class="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-primary/15 text-primary"
-              >
-                <Icon name="kind-icon:palette" class="h-4 w-4" />
-              </span>
+          <!--
+            A SEPARATOR, ONLY WHEN THERE IS SOMETHING TO SEPARATE. This was an
+            icon tile, an `<h2>`, a subtitle and a count badge -- a full band
+            above the first swatch, and the third stacked heading on the route
+            after kr-manager's panel title and this gallery's own header.
 
-              <div class="min-w-0">
-                <h2 class="truncate text-base font-black text-base-content">
-                  Default Themes
-                </h2>
-
-                <p class="truncate text-xs text-base-content/55">
-                  Built-in DaisyUI palettes.
-                </p>
-              </div>
-            </div>
-
-            <span class="badge badge-primary badge-sm">
-              {{ filteredDaisyThemes.length }}
-            </span>
-          </div>
+            The heading's whole job is to tell two adjacent grids apart, so it
+            renders only when both are on screen (`showBothGroups`). Filter to
+            Default or Shared and the lit button already names what you are
+            looking at, so the band is deleted rather than restyled. The count
+            went to that button; the icon and the subtitle described a grid of
+            palettes that is directly visible underneath.
+          -->
+          <h2
+            v-if="showBothGroups"
+            class="mb-2 truncate text-xs font-black uppercase tracking-wide text-base-content/55"
+          >
+            Default
+          </h2>
 
           <!-- The shared shell owns the grid. The old class was
                `grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5
@@ -220,29 +212,13 @@
           v-if="showSharedThemes"
           class="rounded-2xl border border-base-300 bg-base-100 p-3 shadow"
         >
-          <div class="mb-3 flex items-center justify-between gap-3">
-            <div class="flex min-w-0 items-center gap-2">
-              <span
-                class="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-secondary/15 text-secondary"
-              >
-                <Icon name="kind-icon:sparkles" class="h-4 w-4" />
-              </span>
-
-              <div class="min-w-0">
-                <h2 class="truncate text-base font-black text-base-content">
-                  Shared Themes
-                </h2>
-
-                <p class="truncate text-xs text-base-content/55">
-                  Community and custom palettes.
-                </p>
-              </div>
-            </div>
-
-            <span class="badge badge-secondary badge-sm">
-              {{ filteredSharedThemes.length }}
-            </span>
-          </div>
+          <!-- Same separator rule as Default above. -->
+          <h2
+            v-if="showBothGroups"
+            class="mb-2 truncate text-xs font-black uppercase tracking-wide text-base-content/55"
+          >
+            Shared
+          </h2>
 
           <!-- Same shell, same six-breakpoint grid retired. Shared themes ARE
                records, so unlike the DaisyUI list above this one looks its
@@ -577,16 +553,25 @@ const showSharedThemes = computed(() => {
   return activeFilter.value === 'all' || activeFilter.value === 'shared'
 })
 
-const visibleThemeCount = computed(() => {
-  const defaultCount = showDefaultThemes.value
-    ? filteredDaisyThemes.value.length
-    : 0
-  const sharedCount = showSharedThemes.value
-    ? filteredSharedThemes.value.length
-    : 0
+/**
+ * Both grids are on screen at once only under `All`, which is the one case
+ * where a per-group heading earns its row.
+ */
+const showBothGroups = computed(
+  () => showDefaultThemes.value && showSharedThemes.value,
+)
 
-  return defaultCount + sharedCount
-})
+/**
+ * The size of the group each filter button selects, keyed by the button's own
+ * value so the template needs no branch. `all` is the sum rather than the total
+ * corpus because these lists are already search-filtered -- it has to answer
+ * "how many will I see if I press this", the same question the other two do.
+ */
+const filterCounts = computed<Record<ThemeFilter, number>>(() => ({
+  all: filteredDaisyThemes.value.length + filteredSharedThemes.value.length,
+  default: filteredDaisyThemes.value.length,
+  shared: filteredSharedThemes.value.length,
+}))
 
 function safeThemeValues(value: unknown): Record<string, string> {
   if (typeof value === 'string') {

--- a/facet-artwork-report.txt
+++ b/facet-artwork-report.txt
@@ -1,0 +1,2 @@
+Facet artwork migration verified: 297 direct visual Facet choices, 297 canonical titles, 297 declared image paths.
+NOTE: public/images/adventure is absent (it is gitignored), so the on-disk existence of those 297 paths was NOT checked. Declarations, precedence and title conflicts were.

--- a/facet-builder-coverage-report.txt
+++ b/facet-builder-coverage-report.txt
@@ -1,0 +1,295 @@
+Facet Builder coverage failed:
+- Human references missing Builder artwork: public/images/adventure/species/human.webp
+- Elf references missing Builder artwork: public/images/adventure/species/elf.webp
+- Dwarf references missing Builder artwork: public/images/adventure/species/dwarf.webp
+- Orc references missing Builder artwork: public/images/adventure/species/orc.webp
+- Goblin references missing Builder artwork: public/images/adventure/species/goblin.webp
+- Halfling references missing Builder artwork: public/images/adventure/species/halfling.webp
+- Gnome references missing Builder artwork: public/images/adventure/species/gnome.webp
+- Troll references missing Builder artwork: public/images/adventure/species/troll.webp
+- Ogre references missing Builder artwork: public/images/adventure/species/ogre.webp
+- Giant references missing Builder artwork: public/images/adventure/species/giant.webp
+- Catfolk references missing Builder artwork: public/images/adventure/species/catfolk.webp
+- Wolfkin references missing Builder artwork: public/images/adventure/species/wolfkin.webp
+- Foxkin references missing Builder artwork: public/images/adventure/species/foxkin.webp
+- Rabbitfolk references missing Builder artwork: public/images/adventure/species/rabbitfolk.webp
+- Bearfolk references missing Builder artwork: public/images/adventure/species/bearfolk.webp
+- Lizardfolk references missing Builder artwork: public/images/adventure/species/lizardfolk.webp
+- Frogfolk references missing Builder artwork: public/images/adventure/species/frogfolk.webp
+- Birdfolk references missing Builder artwork: public/images/adventure/species/birdfolk.webp
+- Sharkfolk references missing Builder artwork: public/images/adventure/species/sharkfolk.webp
+- Mothfolk references missing Builder artwork: public/images/adventure/species/mothfolk.webp
+- Fae references missing Builder artwork: public/images/adventure/species/fae.webp
+- Satyr references missing Builder artwork: public/images/adventure/species/satyr.webp
+- Merfolk references missing Builder artwork: public/images/adventure/species/merfolk.webp
+- Centaur references missing Builder artwork: public/images/adventure/species/centaur.webp
+- Minotaur references missing Builder artwork: public/images/adventure/species/minotaur.webp
+- Harpy references missing Builder artwork: public/images/adventure/species/harpy.webp
+- Sphinx references missing Builder artwork: public/images/adventure/species/sphinx.webp
+- Dragonkin references missing Builder artwork: public/images/adventure/species/dragonkin.webp
+- Phoenixborn references missing Builder artwork: public/images/adventure/species/phoenixborn.webp
+- Unicorn-Touched references missing Builder artwork: public/images/adventure/species/unicorn-touched.webp
+- Vampire references missing Builder artwork: public/images/adventure/species/vampire.webp
+- Werebeast references missing Builder artwork: public/images/adventure/species/werebeast.webp
+- Ghost references missing Builder artwork: public/images/adventure/species/ghost.webp
+- Skeleton references missing Builder artwork: public/images/adventure/species/skeleton.webp
+- Zombie references missing Builder artwork: public/images/adventure/species/zombie.webp
+- Ghoul references missing Builder artwork: public/images/adventure/species/ghoul.webp
+- Witchborn references missing Builder artwork: public/images/adventure/species/witchborn.webp
+- Shadowkin references missing Builder artwork: public/images/adventure/species/shadowkin.webp
+- Changeling references missing Builder artwork: public/images/adventure/species/changeling.webp
+- Nightmare references missing Builder artwork: public/images/adventure/species/nmare.webp
+- Robot references missing Builder artwork: public/images/adventure/species/robot.webp
+- Android references missing Builder artwork: public/images/adventure/species/android.webp
+- Golem references missing Builder artwork: public/images/adventure/species/golem.webp
+- Living Doll references missing Builder artwork: public/images/adventure/species/living-doll.webp
+- Slime references missing Builder artwork: public/images/adventure/species/slime.webp
+- Plantfolk references missing Builder artwork: public/images/adventure/species/plantfolk.webp
+- Mushroomfolk references missing Builder artwork: public/images/adventure/species/mushroomfolk.webp
+- Crystalborn references missing Builder artwork: public/images/adventure/species/crystalborn.webp
+- Starborn references missing Builder artwork: public/images/adventure/species/starborn.webp
+- Voidling references missing Builder artwork: public/images/adventure/species/voidling.webp
+- Siren references missing Builder artwork: public/images/adventure/species/siren.webp
+- Tardigrade references missing Builder artwork: public/images/adventure/species/tardigrade.webp
+- Axolotl references missing Builder artwork: public/images/adventure/species/axolotl.webp
+- Mantis Shrimp references missing Builder artwork: public/images/adventure/species/mantis-shrimp.webp
+- Murder of Crows references missing Builder artwork: public/images/adventure/species/murder-of-crows.webp
+- Leech references missing Builder artwork: public/images/adventure/species/leech.webp
+- Octopus references missing Builder artwork: public/images/adventure/species/octopus.webp
+- Elder God references missing Builder artwork: public/images/adventure/species/elder-god.webp
+- Platypus references missing Builder artwork: public/images/adventure/species/platypus.webp
+- Ankylosaurus references missing Builder artwork: public/images/adventure/species/ankylosaurus.webp
+- Angel references missing Builder artwork: public/images/adventure/species/angel.webp
+- Demon references missing Builder artwork: public/images/adventure/species/demon.webp
+- Trickster references missing Builder artwork: public/images/adventure/species/trickster.webp
+- Deity references missing Builder artwork: public/images/adventure/species/deity.webp
+- Fairy references missing Builder artwork: public/images/adventure/species/fairy.webp
+- Imp references missing Builder artwork: public/images/adventure/species/imp.webp
+- Gremlin references missing Builder artwork: public/images/adventure/species/gremlin.webp
+- Dryad references missing Builder artwork: public/images/adventure/species/dryad.webp
+- Luck Dragon references missing Builder artwork: public/images/adventure/species/luck-dragon.webp
+- Butterfly references missing Builder artwork: public/images/adventure/species/butterfly.webp
+- Spider references missing Builder artwork: public/images/adventure/species/spider.webp
+- Imaginary Friend references missing Builder artwork: public/images/adventure/species/imaginary-friend.webp
+- Poltergeist references missing Builder artwork: public/images/adventure/species/poltergeist.webp
+- Wendigo references missing Builder artwork: public/images/adventure/species/wendigo.webp
+- Cryptid references missing Builder artwork: public/images/adventure/species/cryptid.webp
+- Chupacabra references missing Builder artwork: public/images/adventure/species/chupacabra.webp
+- Leprechaun references missing Builder artwork: public/images/adventure/species/leprechaun.webp
+- Dragon references missing Builder artwork: public/images/adventure/species/dragon.webp
+- Whale references missing Builder artwork: public/images/adventure/species/whale.webp
+- Potted Geranium references missing Builder artwork: public/images/adventure/species/potted-geraniums.webp
+- SCP references missing Builder artwork: public/images/adventure/species/scp.webp
+- World Serpent references missing Builder artwork: public/images/adventure/species/world-serpent.webp
+- Sentient Spaceship references missing Builder artwork: public/images/adventure/species/sentient-spaceship.webp
+- Space Clown references missing Builder artwork: public/images/adventure/species/space-clown.webp
+- Kaiju references missing Builder artwork: public/images/adventure/species/kaiju.webp
+- Toon references missing Builder artwork: public/images/adventure/species/toon.webp
+- Yokai references missing Builder artwork: public/images/adventure/species/yokai.webp
+- Evolutionary Architect references missing Builder artwork: public/images/adventure/species/evolutionary-architect.webp
+- Backrooms Entity references missing Builder artwork: public/images/adventure/species/backrooms-entity.webp
+- Virus references missing Builder artwork: public/images/adventure/species/virus.webp
+- Scarecrow references missing Builder artwork: public/images/adventure/species/scarecrow.webp
+- Time Being references missing Builder artwork: public/images/adventure/species/time-being.webp
+- Blind Mole Rat references missing Builder artwork: public/images/adventure/species/blind-mole-rat.webp
+- Lion references missing Builder artwork: public/images/adventure/species/lion.webp
+- Cat references missing Builder artwork: public/images/adventure/species/cat.webp
+- Black-Footed Cat references missing Builder artwork: public/images/adventure/species/black-footed-cat.webp
+- Dog references missing Builder artwork: public/images/adventure/species/dog.webp
+- Rabbit references missing Builder artwork: public/images/adventure/species/rabbit.webp
+- Ocelot references missing Builder artwork: public/images/adventure/species/ocelot.webp
+- Lawful Good references missing Builder artwork: public/images/adventure/alignment/lawful-good.webp
+- Neutral Good references missing Builder artwork: public/images/adventure/alignment/neutral-good.webp
+- Chaotic Good references missing Builder artwork: public/images/adventure/alignment/chaotic-good.webp
+- Lawful Neutral references missing Builder artwork: public/images/adventure/alignment/lawful-neutral.webp
+- True Neutral references missing Builder artwork: public/images/adventure/alignment/neutral.webp
+- Chaotic Neutral references missing Builder artwork: public/images/adventure/alignment/chaotic-neutral.webp
+- Lawful Evil references missing Builder artwork: public/images/adventure/alignment/lawful-evil.webp
+- Neutral Evil references missing Builder artwork: public/images/adventure/alignment/neutral-evil.webp
+- Chaotic Evil references missing Builder artwork: public/images/adventure/alignment/chaotic-evil.webp
+- Appetite references missing Builder artwork: public/images/adventure/alignment/appetite.webp
+- Onanism references missing Builder artwork: public/images/adventure/alignment/onanism.webp
+- Safety references missing Builder artwork: public/images/adventure/alignment/safety.webp
+- Insatiable references missing Builder artwork: public/images/adventure/alignment/curious.webp
+- Petty references missing Builder artwork: public/images/adventure/alignment/petty.webp
+- Correct references missing Builder artwork: public/images/adventure/alignment/correct.webp
+- Loyal references missing Builder artwork: public/images/adventure/alignment/loyal.webp
+- Aesthetic references missing Builder artwork: public/images/adventure/alignment/aesthetic.webp
+- Utilitarian references missing Builder artwork: public/images/adventure/alignment/utilitarian.webp
+- Transactional references missing Builder artwork: public/images/adventure/alignment/transactional.webp
+- Rogue references missing Builder artwork: public/images/adventure/role/rogue.webp
+- Warrior references missing Builder artwork: public/images/adventure/role/warrior.webp
+- Wizard references missing Builder artwork: public/images/adventure/role/wizard.webp
+- Cleric references missing Builder artwork: public/images/adventure/role/cleric.webp
+- Bard references missing Builder artwork: public/images/adventure/role/bard.webp
+- Ranger references missing Builder artwork: public/images/adventure/role/ranger.webp
+- Paladin references missing Builder artwork: public/images/adventure/role/paladin.webp
+- Druid references missing Builder artwork: public/images/adventure/role/druid.webp
+- Monk references missing Builder artwork: public/images/adventure/role/monk.webp
+- Warlock references missing Builder artwork: public/images/adventure/role/warlock.webp
+- Artificer references missing Builder artwork: public/images/adventure/role/artificer.webp
+- Oracle references missing Builder artwork: public/images/adventure/role/oracle.webp
+- Witch references missing Builder artwork: public/images/adventure/role/witch.webp
+- Slacker references missing Builder artwork: public/images/adventure/role/slacker.webp
+- Netrunner references missing Builder artwork: public/images/adventure/role/netrunner.webp
+- Cupid references missing Builder artwork: public/images/adventure/role/cupid.webp
+- Accountant references missing Builder artwork: public/images/adventure/role/accountant.webp
+- Public Notary references missing Builder artwork: public/images/adventure/role/notary.webp
+- Politician references missing Builder artwork: public/images/adventure/role/politician.webp
+- Groupie references missing Builder artwork: public/images/adventure/role/groupie.webp
+- Musician references missing Builder artwork: public/images/adventure/role/musician.webp
+- Performance Artist references missing Builder artwork: public/images/adventure/role/performance-artist.webp
+- Bounty Hunter references missing Builder artwork: public/images/adventure/role/bounty-hunter.webp
+- Doctor references missing Builder artwork: public/images/adventure/role/doctor.webp
+- Lawyer references missing Builder artwork: public/images/adventure/role/lawyer.webp
+- Space Lawyer references missing Builder artwork: public/images/adventure/role/space-lawyer.webp
+- Criminal Mastermind references missing Builder artwork: public/images/adventure/role/criminal-mastermind.webp
+- Super Hero references missing Builder artwork: public/images/adventure/role/super-hero.webp
+- Super Villain references missing Builder artwork: public/images/adventure/role/super-villain.webp
+- Reporter references missing Builder artwork: public/images/adventure/role/reporter.webp
+- Clown references missing Builder artwork: public/images/adventure/role/clown.webp
+- Mime references missing Builder artwork: public/images/adventure/role/mime.webp
+- Assassin references missing Builder artwork: public/images/adventure/role/assassin.webp
+- NPC references missing Builder artwork: public/images/adventure/role/npc.webp
+- Gambler references missing Builder artwork: public/images/adventure/role/gambler.webp
+- Mad Scientist references missing Builder artwork: public/images/adventure/role/mad-scientist.webp
+- Alchemist references missing Builder artwork: public/images/adventure/role/alchemist.webp
+- Polymath references missing Builder artwork: public/images/adventure/role/polymath.webp
+- Poet references missing Builder artwork: public/images/adventure/role/poet.webp
+- Waste of Space references missing Builder artwork: public/images/adventure/role/waste-of-space.webp
+- Philanthropist references missing Builder artwork: public/images/adventure/role/philanthropist.webp
+- Troublemaker references missing Builder artwork: public/images/adventure/role/troublemaker.webp
+- Introverted references missing Builder artwork: public/images/adventure/quirks/introverted.webp
+- Extroverted references missing Builder artwork: public/images/adventure/quirks/extroverted.webp
+- Passionate references missing Builder artwork: public/images/adventure/quirks/passionate.webp
+- Hopeless Romantic references missing Builder artwork: public/images/adventure/quirks/hopeless-romantic.webp
+- Foolish references missing Builder artwork: public/images/adventure/quirks/foolish.webp
+- Easily Frustrated references missing Builder artwork: public/images/adventure/quirks/easily-frustrated.webp
+- Submissive references missing Builder artwork: public/images/adventure/quirks/submissive.webp
+- Dominant references missing Builder artwork: public/images/adventure/quirks/dominant.webp
+- Narcissistic references missing Builder artwork: public/images/adventure/quirks/narcissistic.webp
+- Nervous references missing Builder artwork: public/images/adventure/quirks/nervous.webp
+- Scatter-Brained references missing Builder artwork: public/images/adventure/quirks/scatter-brained.webp
+- Bookworm references missing Builder artwork: public/images/adventure/quirks/bookworm.webp
+- Book Smart references missing Builder artwork: public/images/adventure/quirks/book-smart.webp
+- Obsequious references missing Builder artwork: public/images/adventure/quirks/obsequious.webp
+- Driven references missing Builder artwork: public/images/adventure/quirks/driven.webp
+- Show-Off references missing Builder artwork: public/images/adventure/quirks/show-off.webp
+- Altruistic references missing Builder artwork: public/images/adventure/quirks/altruistic.webp
+- Generous references missing Builder artwork: public/images/adventure/quirks/generous.webp
+- Apathetic references missing Builder artwork: public/images/adventure/quirks/apathetic.webp
+- Sarcastic references missing Builder artwork: public/images/adventure/quirks/sarcastic.webp
+- Sense of Humor references missing Builder artwork: public/images/adventure/quirks/sense-of-humor.webp
+- Fatalistic references missing Builder artwork: public/images/adventure/quirks/fatalistic.webp
+- Optimist references missing Builder artwork: public/images/adventure/quirks/optimist.webp
+- Pessimist references missing Builder artwork: public/images/adventure/quirks/pessimist.webp
+- Logical references missing Builder artwork: public/images/adventure/quirks/logical.webp
+- Emotional references missing Builder artwork: public/images/adventure/quirks/emotional.webp
+- Charismatic references missing Builder artwork: public/images/adventure/quirks/charismatic.webp
+- Enthusiastic references missing Builder artwork: public/images/adventure/quirks/enthusiastic.webp
+- Energetic references missing Builder artwork: public/images/adventure/quirks/energetic.webp
+- Hyperactive references missing Builder artwork: public/images/adventure/quirks/hyperactive.webp
+- Ditzy references missing Builder artwork: public/images/adventure/quirks/ditzy.webp
+- Artistic references missing Builder artwork: public/images/adventure/quirks/artistic.webp
+- Authoritarian references missing Builder artwork: public/images/adventure/quirks/authoritarian.webp
+- Problem-Solver references missing Builder artwork: public/images/adventure/quirks/problem-solver.webp
+- Puzzler references missing Builder artwork: public/images/adventure/quirks/puzzler.webp
+- Devious references missing Builder artwork: public/images/adventure/quirks/devious.webp
+- Ignorant references missing Builder artwork: public/images/adventure/quirks/ignorant.webp
+- Obsessive references missing Builder artwork: public/images/adventure/quirks/obsessive.webp
+- Amoral references missing Builder artwork: public/images/adventure/quirks/amoral.webp
+- Inventive references missing Builder artwork: public/images/adventure/quirks/inventive.webp
+- Creative Writer references missing Builder artwork: public/images/adventure/quirks/creative-writer.webp
+- Secretive references missing Builder artwork: public/images/adventure/quirks/secretive.webp
+- Lone Wolf references missing Builder artwork: public/images/adventure/quirks/lone-wolf.webp
+- Team Player references missing Builder artwork: public/images/adventure/quirks/team-player.webp
+- Believes They're Psychic references missing Builder artwork: public/images/adventure/quirks/believes-psychic.webp
+- Metaphysical references missing Builder artwork: public/images/adventure/quirks/metaphysical.webp
+- Superstitious references missing Builder artwork: public/images/adventure/quirks/superstitious.webp
+- Overly Literal references missing Builder artwork: public/images/adventure/quirks/overly-literal.webp
+- Compulsively Honest references missing Builder artwork: public/images/adventure/quirks/compulsively-honest.webp
+- Pathological Liar references missing Builder artwork: public/images/adventure/quirks/pathological-liar.webp
+- Hoarder references missing Builder artwork: public/images/adventure/quirks/hoarder.webp
+- Conspiracy-Minded references missing Builder artwork: public/images/adventure/quirks/conspiracy-minded.webp
+- Soft-Spoken references missing Builder artwork: public/images/adventure/quirks/soft-spoken.webp
+- Brash references missing Builder artwork: public/images/adventure/quirks/brash.webp
+- Dramatic references missing Builder artwork: public/images/adventure/quirks/dramatic.webp
+- Deadpan references missing Builder artwork: public/images/adventure/quirks/deadpan.webp
+- Melancholy references missing Builder artwork: public/images/adventure/quirks/melancholy.webp
+- Cheerfully Morbid references missing Builder artwork: public/images/adventure/quirks/cheerfully-morbid.webp
+- Worrisome references missing Builder artwork: public/images/adventure/quirks/worrisome.webp
+- Reckless references missing Builder artwork: public/images/adventure/quirks/reckless.webp
+- Protective references missing Builder artwork: public/images/adventure/quirks/protective.webp
+- Jealous references missing Builder artwork: public/images/adventure/quirks/jealous.webp
+- Vindictive references missing Builder artwork: public/images/adventure/quirks/vindictive.webp
+- Diplomatic references missing Builder artwork: public/images/adventure/quirks/diplomatic.webp
+- Blunt references missing Builder artwork: public/images/adventure/quirks/blunt.webp
+- Curious references missing Builder artwork: public/images/adventure/quirks/curious.webp
+- Inquisitive references missing Builder artwork: public/images/adventure/quirks/inquisitive.webp
+- Gullible references missing Builder artwork: public/images/adventure/quirks/gullible.webp
+- Suspicious references missing Builder artwork: public/images/adventure/quirks/suspicious.webp
+- Perfectionist references missing Builder artwork: public/images/adventure/quirks/perfectionist.webp
+- Animist references missing Builder artwork: public/images/adventure/quirks/animist.webp
+- Serene references missing Builder artwork: public/images/adventure/quirks/serene.webp
+- Competitive references missing Builder artwork: public/images/adventure/quirks/competitive.webp
+- Flirtatious references missing Builder artwork: public/images/adventure/quirks/flirtatious.webp
+- Daydreamer references missing Builder artwork: public/images/adventure/quirks/daydreamer.webp
+- Daredevil references missing Builder artwork: public/images/adventure/quirks/daredevil.webp
+- Double-Jointed references missing Builder artwork: public/images/adventure/quirks/double-jointed.webp
+- Fortunate references missing Builder artwork: public/images/adventure/quirks/fortunate.webp
+- Heterochromia references missing Builder artwork: public/images/adventure/quirks/heterochromia.webp
+- Extra Body Part references missing Builder artwork: public/images/adventure/quirks/extra-body-part.webp
+- Musical references missing Builder artwork: public/images/adventure/quirks/musical.webp
+- Likes to Dance references missing Builder artwork: public/images/adventure/quirks/likes-to-dance.webp
+- Left-Handed references missing Builder artwork: public/images/adventure/quirks/left-handed.webp
+- Obsessive-Compulsive references missing Builder artwork: public/images/adventure/quirks/obsessive-compulsive.webp
+- Clumsy references missing Builder artwork: public/images/adventure/quirks/clumsy.webp
+- Notably Tall references missing Builder artwork: public/images/adventure/quirks/notably-tall.webp
+- Notably Short references missing Builder artwork: public/images/adventure/quirks/notably-short.webp
+- Kleptomaniac references missing Builder artwork: public/images/adventure/quirks/kleptomaniac.webp
+- Pyromaniac references missing Builder artwork: public/images/adventure/quirks/pyromaniac.webp
+- Lactose Intolerant references missing Builder artwork: public/images/adventure/quirks/lactose-intolerant.webp
+- Allergies references missing Builder artwork: public/images/adventure/quirks/allergies.webp
+- Addict references missing Builder artwork: public/images/adventure/quirks/addict.webp
+- Secret Identity references missing Builder artwork: public/images/adventure/quirks/secret-identity.webp
+- Always Online references missing Builder artwork: public/images/adventure/quirks/always-online.webp
+- Messy references missing Builder artwork: public/images/adventure/quirks/messy.webp
+- Fashionable references missing Builder artwork: public/images/adventure/quirks/fashionable.webp
+- Forgetful references missing Builder artwork: public/images/adventure/quirks/forgetful.webp
+- Animal Magnet references missing Builder artwork: public/images/adventure/quirks/animal-magnet.webp
+- Green Thumb references missing Builder artwork: public/images/adventure/quirks/green-thumb.webp
+- Insomniac references missing Builder artwork: public/images/adventure/quirks/insomniac.webp
+- Bad Luck Magnet references missing Builder artwork: public/images/adventure/quirks/bad-luck.webp
+- Hunted references missing Builder artwork: public/images/adventure/background/hunted.webp
+- Tragic Past references missing Builder artwork: public/images/adventure/background/tragic-past.webp
+- Blessed Life references missing Builder artwork: public/images/adventure/background/blessed-life.webp
+- Survivor references missing Builder artwork: public/images/adventure/background/survivor.webp
+- Exiled references missing Builder artwork: public/images/adventure/background/exiled.webp
+- Orphaned references missing Builder artwork: public/images/adventure/background/orphaned.webp
+- Resurrected references missing Builder artwork: public/images/adventure/background/resurrected.webp
+- Witch Blood references missing Builder artwork: public/images/adventure/background/witch-blood.webp
+- Escaped Cultist references missing Builder artwork: public/images/adventure/background/escaped-cultist.webp
+- Reformed Villain references missing Builder artwork: public/images/adventure/background/reformed-villain.webp
+- Rejected Destiny references missing Builder artwork: public/images/adventure/background/rejected-destiny.webp
+- Mutation references missing Builder artwork: public/images/adventure/background/mutation.webp
+- Child Prodigy references missing Builder artwork: public/images/adventure/background/child-prodigy.webp
+- Science Experiment references missing Builder artwork: public/images/adventure/background/science-experiment.webp
+- Cursed references missing Builder artwork: public/images/adventure/background/cursed.webp
+- Haunted references missing Builder artwork: public/images/adventure/background/haunted.webp
+- Chosen Wrong references missing Builder artwork: public/images/adventure/background/chosen-wrong.webp
+- Hidden Heir references missing Builder artwork: public/images/adventure/background/hidden-heir.webp
+- Lost Royal references missing Builder artwork: public/images/adventure/background/lost-royal.webp
+- Forbidden Born references missing Builder artwork: public/images/adventure/background/forbidden-born.webp
+- Omen Born references missing Builder artwork: public/images/adventure/background/omen-born.webp
+- Star Fallen references missing Builder artwork: public/images/adventure/background/star-fallen.webp
+- Time Lost references missing Builder artwork: public/images/adventure/background/time-lost.webp
+- World Stranded references missing Builder artwork: public/images/adventure/background/world-stranded.webp
+- Memory Erased references missing Builder artwork: public/images/adventure/background/memory-erased.webp
+- Name Stolen references missing Builder artwork: public/images/adventure/background/name-stolen.webp
+- Debt Born references missing Builder artwork: public/images/adventure/background/debt-born.webp
+- Miracle Child references missing Builder artwork: public/images/adventure/background/miracle-child.webp
+- Last of Kind references missing Builder artwork: public/images/adventure/background/last-of-kind.webp
+- Unmade references missing Builder artwork: public/images/adventure/background/unmade.webp
+- art:mode/mode/✦ Generate Art from Text has dedicated Builder artwork but field mode is not Facet-backed.
+- art:mode/mode/◐ Generate from Image has dedicated Builder artwork but field mode is not Facet-backed.
+- art:mode/mode/⊕ Kombine has dedicated Builder artwork but field mode is not Facet-backed.

--- a/wonderlab-rollout-artifacts/component-contract-verification.json
+++ b/wonderlab-rollout-artifacts/component-contract-verification.json
@@ -1,0 +1,25 @@
+{
+  "contractVersion": 1,
+  "baseUrl": "https://kind-robots.vercel.app",
+  "checkedAt": "2026-08-08T06:34:12.136Z",
+  "recordCount": 489,
+  "canonicalStatusRecordCount": 489,
+  "discoveredCount": 420,
+  "completeDiscoveredIdentityCount": 420,
+  "databaseOnlyCount": 69,
+  "statusCounts": {
+    "UNREVIEWED": 268,
+    "WORKING": 220,
+    "NEEDS_CONTEXT": 1,
+    "UNDER_CONSTRUCTION": 0,
+    "BROKEN": 0,
+    "RETIRED": 0,
+    "PREVIEW_UNSUPPORTED": 0
+  },
+  "invalidStatusCount": 0,
+  "retiredFieldExposureCount": 0,
+  "incompleteDiscoveredCount": 0,
+  "invalidStatusRows": [],
+  "retiredFieldRows": [],
+  "incompleteDiscoveredRows": []
+}

--- a/wonderlab-rollout-artifacts/component-contract-verification.json
+++ b/wonderlab-rollout-artifacts/component-contract-verification.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": 1,
   "baseUrl": "https://kind-robots.vercel.app",
-  "checkedAt": "2026-08-08T06:34:12.136Z",
+  "checkedAt": "2026-08-08T06:59:48.486Z",
   "recordCount": 489,
   "canonicalStatusRecordCount": 489,
   "discoveredCount": 420,


### PR DESCRIPTION
Two commits, both spending the same measurement: the chrome audit's last completed run on `main` (`681396f`, i.e. after #1597 fixed it measuring the wrong element).

Pixels above the first gallery:

| route | phone | tablet | laptop | desktop | galleries |
| --- | --- | --- | --- | --- | --- |
| `/bots` | 164px (19%) | 184px (16%) | 196px (26%) | 196px (18%) | 1 |
| **`/characters`** | **102px (12%)** | **110px (9%)** | **122px (16%)** | **122px (11%)** | 1 |
| `/dreams` | 228px (27%) | 152px (13%) | 164px (21%) | 164px (15%) | 1 |
| `/stories` | 206px (24%) | 226px (19%) | 238px (31%) | — | 1 |
| `/resources` | 164px (19%) | 188px (16%) | 168px (22%) | 168px (16%) | 1 |
| `/servers` | 86px (10%) | 94px (8%) | 106px (14%) | 106px (10%) | 4 |
| `/icons` | 154px (18%) | 130px (11%) | 142px (18%) | 142px (13%) | 1 |
| **`/themes`** | **396px (47%)** | 340px (29%) | **324px (42%)** | 324px (30%) | 2 |

---

## 1. Drop the duplicate gallery header on /bots, /rewards and /stories

`kr-manager` already renders each panel's title from its `dashboardHelper` config — and cites "the brief's one-header rule" in its own comment while doing it. But `bot-gallery`, `reward-gallery` and `scenario-gallery` each rendered a second title/subtitle band underneath, so those three routes opened with two stacked page headings.

`/characters` is the control: same manager shell, same gallery tier, same card grid — the only structural difference is that `character-gallery` has no header band. It is also the one route Silas singled out as "minimalist and much closer to what we want." That isolates the band as the cost.

**The band is not deleted.** These galleries are also embedded as **pickers** inside `bot-chat.vue`, `character-chat.vue` and `character-flip-card.vue`, where `title="Reward"` / `subtitle="Optional story item."` is the only label the picker gets. So `showHeader` stays true by default and is turned off only at the interact tier. The reasoning lives on `bot-gallery.vue`'s `showHeader` prop doc rather than in the three interact files, so those stay under the interact line-count ratchet (`bot-interact` 66 unchanged, `reward-interact` 60, −1).

## 2. Cut /themes from three stacked headings to one

The worst reading in the whole audit — 47% of a phone viewport before the first swatch.

`/themes` was paying for three headings: `kr-manager`'s panel title, then `theme-gallery`'s own header band (already suppressed there via `:show-header="false"`), then **each of the two grids opened with a full band of its own** — icon tile, `<h2>`, subtitle, count badge. So "Default Themes / Built-in DaisyUI palettes." sat directly above the first swatch.

Both fixes reuse the pattern the Projects gallery already settled on, from Silas on 2026-08-07: *"none of those need to be said, they are just duplicates of the same outputs better done as toggles to actually select the appropriate group right after it."*

- The `default` / `shared` / `showing` badge strip is gone; the counts moved **onto** the All/Default/Shared buttons that select those exact groups. Same three numbers, no separate row, each one now the control for what it counts.
- The per-grid bands collapse to a single uppercase label rendered **only under All**, where two grids really are adjacent and need telling apart. Filter to Default or Shared and the lit button already names the group.

## Verification

- `npm run test` (vue-tsc) — clean on both commits
- `npx eslint` + `npx prettier --check` on every changed file — clean
- Swept **192 verification commands across all 57 workflow files**, not just `contract-tests.yml`, before and after. 187 pass both times; the same 5 fail both times, all Prisma pool timeouts (`P2039`, `pool timeout … after 10009ms`) from the sandbox having no DB egress — `cleanup-cypress-users`, `seed:davinci:verify`, `seed:davinci:playloop-verify`, `snapshotFallback`, `verifyStoredArtPaths`. None touch these files, and none is newly broken.
- `test:route-gallery-contract` passes with the interact ratchet unchanged or shrinking.
- The Responsive Layout Audit runs on this PR's own preview against the real database and will re-measure all of these routes post-deploy.