### PR TITLE
Stop the Bots and Rewards filter controls stacking a row each

### DIFF
--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -295,7 +295,21 @@
                  full-width row of its own -- four filters became four rows on a
                  phone, which is most of why /rewards spent 54% of a 390px
                  viewport before its first card. flex-wrap puts as many on a
-                 line as fit and only breaks when it must. -->
+                 line as fit and only breaks when it must.
+
+                 AND THE CHILDREN HAVE TO AGREE. Switching the container was
+                 only half the fix: the controls kept the `w-full` the grid had
+                 given them, and a `w-full` child fills its line and forces the
+                 next one to wrap, which is stacking by another name. The search
+                 box was the worst of it -- plain `w-full`, no responsive
+                 escape at all, so it took a row of its own at EVERY width,
+                 desktop included.
+
+                 So the selects size to their content and the search box is
+                 `flex-1` with a floor: it absorbs whatever slack is left on the
+                 line instead of claiming the whole one, and `min-w-32` is what
+                 makes it wrap rather than collapse to nothing when the line is
+                 full. resource-gallery's toolbar already worked this way. -->
           <div
             v-if="showControls && !isDropdownMode"
             class="flex flex-wrap items-center gap-1.5"
@@ -318,7 +332,7 @@
 
             <select
               v-model="constructionFilter"
-              class="select select-bordered select-sm w-full bg-base-100 lg:w-auto"
+              class="select select-bordered select-sm bg-base-100"
               aria-label="Filter bots by construction status"
             >
               <option value="all">All statuses</option>
@@ -330,12 +344,12 @@
               v-model="searchQuery"
               type="search"
               placeholder="Search bots..."
-              class="input input-bordered input-sm w-full bg-base-100"
+              class="input input-bordered input-sm min-w-32 flex-1 bg-base-100"
               aria-label="Search bots"
             />
 
             <button
-              class="btn btn-ghost btn-sm rounded-xl lg:w-auto"
+              class="btn btn-ghost btn-sm rounded-xl"
               type="button"
               :disabled="!botStore.currentBot"
               @click="clearSelectedBot"

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -270,7 +270,15 @@
                  full-width row of its own -- four filters became four rows on a
                  phone, which is most of why /rewards spent 54% of a 390px
                  viewport before its first card. flex-wrap puts as many on a
-                 line as fit and only breaks when it must. -->
+                 line as fit and only breaks when it must.
+
+                 AND THE CHILDREN HAVE TO AGREE -- see the longer note on the
+                 same block in bot-gallery.vue. A `w-full` child fills its line
+                 and forces the next one to wrap, so the controls kept stacking
+                 after the container was fixed; the search box had no responsive
+                 escape at all and took a row of its own even on desktop. This
+                 toolbar carries TWO selects rather than one, so it was paying
+                 an extra row for it. -->
           <div
             v-if="showControls && !isDropdownMode"
             class="flex flex-wrap items-center gap-1.5"
@@ -293,7 +301,7 @@
 
             <select
               v-model="selectedCollection"
-              class="select select-bordered select-sm w-full bg-base-100 lg:w-auto"
+              class="select select-bordered select-sm bg-base-100"
               aria-label="Filter rewards by collection"
             >
               <option value="all">All collections</option>
@@ -309,7 +317,7 @@
 
             <select
               v-model="selectedRarity"
-              class="select select-bordered select-sm w-full bg-base-100 lg:w-auto"
+              class="select select-bordered select-sm bg-base-100"
               aria-label="Filter rewards by rarity"
             >
               <option value="all">All rarities</option>
@@ -324,11 +332,11 @@
               type="search"
               aria-label="Search rewards"
               placeholder="Search rewards..."
-              class="input input-bordered input-sm w-full bg-base-100"
+              class="input input-bordered input-sm min-w-32 flex-1 bg-base-100"
             />
 
             <button
-              class="btn btn-ghost btn-sm rounded-xl lg:w-auto"
+              class="btn btn-ghost btn-sm rounded-xl"
               type="button"
               :disabled="!rewardStore.selectedReward"
               @click="clearSelectedReward"

--- a/wonderlab-rollout-artifacts/component-contract-verification.json
+++ b/wonderlab-rollout-artifacts/component-contract-verification.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": 1,
   "baseUrl": "https://kind-robots.vercel.app",
-  "checkedAt": "2026-08-08T06:59:48.486Z",
+  "checkedAt": "2026-08-08T07:14:41.769Z",
   "recordCount": 489,
   "canonicalStatusRecordCount": 489,
   "discoveredCount": 420,


### PR DESCRIPTION
## The bug

Both toolbars already carried a comment saying **"WRAP, do not stack"** — the container had been changed from `grid grid-cols-1 … lg:grid-cols-[…]` to `flex flex-wrap` for exactly that reason.

But only the container was changed. Every control kept the `w-full` the grid had given it, and **a `w-full` child fills its line and pushes the next one onto a new one** — which is stacking by another name. The comment described a fix that was half-applied.

The search box was the worst case: plain `w-full` with **no responsive escape at all**, so unlike the selects (`w-full lg:w-auto`) it claimed a row of its own at *every* width, desktop included.

## How it was found

The chrome audit reports two numbers per route, and the gap between them is the tell. On `/bots` at 1366×768:

| measurement | value |
| --- | --- |
| above the first **gallery** | 196px |
| above the first **card** | 324px |

That 128px is spent *inside* `kr-gallery` — but `kr-gallery`'s own bar is a single `py-1` row, nowhere near 128px. So it's the slotted toolbar wrapping. `reward-gallery` carries two selects rather than one and was paying an extra row again.

## The fix

Selects size to their content; the search box becomes `flex-1` with a `min-w-32` floor, so it absorbs whatever slack is left on the line instead of claiming the whole line. The floor is what makes it *wrap* rather than collapse to nothing when the line is full.

This is the shape `resource-gallery` and `icon-gallery` already use — they were the two toolbars that never had this bug, which is why they're the reference here rather than a new invention.

Also dropped: the dead `lg:w-auto` on the Clear buttons. With no base `w-full` left it described a layout that no longer existed.

**Deliberately untouched:** `bot-gallery`'s other `w-full` select (line ~177). That one is the dropdown-mode picker — a standalone control in its own block, where full width is correct.

## Verification

- `npm run test` (vue-tsc) — clean
- `npx eslint` + `npx prettier --check` on both files — clean
- Swept **192 verification commands across all 57 workflow files**. 187 pass; the same 5 fail as on an unmodified tree, all Prisma pool timeouts (`P2039`) from the sandbox having no DB egress — `cleanup-cypress-users`, `seed:davinci:verify`, `seed:davinci:playloop-verify`, `snapshotFallback`, `verifyStoredArtPaths`. None touch these files.
- The Responsive Layout Audit runs on this PR's preview against the real database and will re-measure the above-first-card figure for `/bots` and `/rewards`.

Follows #1601, which cut the chrome *above* these galleries; this cuts the chrome *inside* them.

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_