### PR TITLE
digital-storefront/t-038: drop guessed-artImageId demo item, source tokens from real catalog, fix stale mermaids-tab fallthrough

### DIFF
--- a/components/giftshop/giftshop-interact.vue
+++ b/components/giftshop/giftshop-interact.vue
@@ -158,10 +158,10 @@
             <button
               type="button"
               class="btn btn-sm btn-outline mt-4 rounded-2xl"
-              @click="addDemoItem(item)"
+              @click="addShowcaseItem(item)"
             >
               <Icon name="kind-icon:plus" class="h-4 w-4" />
-              Add demo item
+              Add to cart
             </button>
           </article>
         </div>
@@ -238,6 +238,7 @@ import {
   resolveArtImageSrc,
   resolveArtImageThumbSrc,
 } from '@/utils/artImageSrc'
+import { cartItems } from '@/stores/seeds/cartItems'
 import type { ArtImage } from '~/prisma/generated/prisma/client'
 
 // Placeholder print price until the POD product/pricing pipeline (digital-storefront
@@ -287,26 +288,32 @@ const giftshopFeatures: GiftshopFeature[] = [
   },
 ]
 
-const showcaseItems: ShowcaseItem[] = [
-  {
-    title: 'Butterfly Print',
-    icon: 'kind-icon:butterfly',
-    text: 'A placeholder print item until product cards get their full royal parade.',
-    type: 'print',
-    artImageId: 1,
-    imageUrl: '/images/butterfly-placeholder.webp',
-    price: 12,
-  },
-  {
-    title: 'Jellybean Token Pack',
-    icon: 'kind-icon:jellybean',
-    text: 'A tiny pile of imaginary nectar for keeping the robots politely caffeinated.',
-    type: 'tokens',
-    artImageId: 2,
-    imageUrl: '/images/jellybean-placeholder.webp',
-    price: 5,
-  },
-]
+// The print showcase item that used to live here was a guessed placeholder
+// (artImageId: 1, a fake image never validated against a real ArtImage). The
+// real Featured prints grid above sources genuine ArtImage rows via
+// /api/art/storefront-featured and supersedes it. Tokens have no equivalent
+// browsable section elsewhere, so it stays -- but now sourced from the real
+// cartItems catalog (the same array checkout.post.ts trusts server-side)
+// instead of a second hand-maintained copy of its price/label.
+const tokensCatalogEntry = cartItems.find((item) => item.id === 'tokens')
+
+const showcaseItems: ShowcaseItem[] = tokensCatalogEntry
+  ? [
+      {
+        title: tokensCatalogEntry.label,
+        icon: 'kind-icon:jellybean',
+        text: tokensCatalogEntry.description || tokensCatalogEntry.label,
+        type: tokensCatalogEntry.type,
+        // Non-art cart items (needsArt: false) use 0 as the client-side
+        // placeholder -- the server only requires/uses artImageId for
+        // needsArt items (see giving-page.vue's donation add for the same
+        // convention).
+        artImageId: 0,
+        imageUrl: tokensCatalogEntry.image,
+        price: tokensCatalogEntry.price,
+      },
+    ]
+  : []
 
 onMounted(() => {
   void cartStore.initialize()
@@ -336,7 +343,7 @@ function addFeaturedPrint(art: FeaturedArtImage) {
   goToCart()
 }
 
-function addDemoItem(item: ShowcaseItem) {
+function addShowcaseItem(item: ShowcaseItem) {
   cartStore.addItem({
     type: item.type,
     artImageId: item.artImageId,

--- a/components/giftshop/giftshop-manager.vue
+++ b/components/giftshop/giftshop-manager.vue
@@ -91,8 +91,8 @@
 
               <p class="text-sm leading-relaxed text-base-content/70">
                 The butterflies are drafting community guidelines in glitter
-                ink. This tab is wired to the dashboard canon and ready for
-                the real forum component when it lands.
+                ink. This tab is wired to the dashboard canon and ready for the
+                real forum component when it lands.
               </p>
             </div>
           </div>
@@ -186,6 +186,17 @@ const swarmMemo = computed(() => {
 
 onMounted(async () => {
   await refreshManagerData()
+
+  // The 'mermaids' tab routes to its own page (/mermaids) rather than
+  // rendering in-place here, but navStore's persisted dashboard tab can still
+  // land on 'mermaids' (e.g. a stale selection from a prior visit) when this
+  // component mounts on /sanctuary directly. Without this, activeTab falls
+  // through the template's catch-all "misplaced tab" warning instead of
+  // reaching the real content. Send the visitor where the tab itself points.
+  if (storedTab.value === 'mermaids') {
+    await router.replace('/mermaids')
+    return
+  }
 
   const topupQuery = route.query.manaTopup
   if (topupQuery === 'success' || topupQuery === 'cancelled') {


### PR DESCRIPTION
### Task
digital-storefront/t-038 (slice 1): Implement every missing storefront-owned catalog item found by the reality audit (kind: software)

### What changed / what I produced
- `components/giftshop/giftshop-interact.vue`: removed the "Butterfly Print" demo showcase card (a guessed `artImageId: 1`, never validated against a real `ArtImage` row) — the real Featured Prints grid immediately above it already covers this exact use case with genuine `storefrontFeatured`-backed art. Kept the "Jellybean Token Pack" sibling (no other UI path currently sells boost tokens) but now sources its label/price/description directly from `stores/seeds/cartItems.ts`'s real `tokens` entry — the same array `checkout.post.ts` trusts server-side for pricing — instead of a second hand-maintained duplicate. Uses `artImageId: 0` for the `needsArt: false` item, matching `giving-page.vue`'s existing donation-add convention.
- `components/giftshop/giftshop-manager.vue`: when `navStore`'s persisted dashboard tab is `'mermaids'` but the component mounts directly on `/sanctuary` (a stale-tab-selection edge case — the `mermaids` tab's own config routes to `/mermaids`, not in-place render), redirect to `/mermaids` instead of falling through to the template's catch-all "misplaced tab" warning.

### How I verified
- `npx eslint` on both changed files: 0 new problems. The one remaining error (`giftshop-manager.vue:171` unused `swarmMemo`) is pre-existing, already tracked in `utils/scripts/lint-ratchet-baseline.json` at that exact line/rule — unrelated to this change, left alone per scope discipline.
- `npm run test:lint-ratchet`: ratchet holds — 392 problems across 27 rules, unchanged.
- `npx vue-tsc --noEmit -p tsconfig.json`: clean, exit 0.
- `npx prettier --check`: clean on both files.

### Stakes
reversible

### Flags for Reviewer
- This is slice 1 of a larger task (digital-storefront/t-038). The remaining scope — seeding a real KR-logo Product/POD SKU, giving DLC a live catalog + admin route + `contentAccess.ts` wiring, and two pricing/POD-entry-point retirement decisions — is split into `digital-storefront/t-003` (conductor) as a dedicated follow-up; it needs real DB/design judgment this slice intentionally didn't attempt.

### Kaizen suggestion
`stores/seeds/cartItems.ts`'s `image` field (e.g. `/img/products/tokens.png`) and the removed demo card's placeholder images (`/images/butterfly-placeholder.webp`, `/images/jellybean-placeholder.webp`) don't actually exist under `public/` — a pre-existing broken-asset issue across the storefront's non-Product-backed cart items, out of this task's scope but worth its own small task.

### Notes for reviewer
Conductor task `digital-storefront/t-038` is at `status: review`, `remaining_scope_task: t-003` — do not close it `done` on this PR merging alone; the split scope in `t-003` is still open.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWJC9V3FVdCaxN9vC7cFJt)_