### PR TITLE
Repair Art Trainer checkpoint provenance and stale SDXL retries

### DIFF
--- a/.github/workflows/artjob-provenance-contract.yml
+++ b/.github/workflows/artjob-provenance-contract.yml
@@ -11,6 +11,8 @@ on:
       - "server/utils/artJobRetry.ts"
       - "utils/scripts/verifyArtJobProvenance.ts"
       - "utils/scripts/verifyArtJobLoraOverride.ts"
+      - "utils/scripts/verifyArtJobCheckpointRefresh.ts"
+      - "utils/scripts/repairTrainerCheckpointFailures.ts"
       - ".github/workflows/artjob-provenance-contract.yml"
   pull_request:
     branches: [main]
@@ -22,6 +24,8 @@ on:
       - "server/utils/artJobRetry.ts"
       - "utils/scripts/verifyArtJobProvenance.ts"
       - "utils/scripts/verifyArtJobLoraOverride.ts"
+      - "utils/scripts/verifyArtJobCheckpointRefresh.ts"
+      - "utils/scripts/repairTrainerCheckpointFailures.ts"
       - ".github/workflows/artjob-provenance-contract.yml"
   workflow_dispatch:
 
@@ -52,6 +56,9 @@ jobs:
 
       - name: Verify LoRA retry resource refresh
         run: npm run test:artjob-lora-override
+
+      - name: Verify checkpoint resource refresh
+        run: npx tsx utils/scripts/verifyArtJobCheckpointRefresh.ts
 
       - name: TypeScript check
         run: npm run test

--- a/.github/workflows/artjob-provenance-contract.yml
+++ b/.github/workflows/artjob-provenance-contract.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "server/api/art/queue/**"
+      - "server/api/comfy/sdxl/utils/workflow.ts"
       - "server/utils/artJobProvenance.ts"
       - "server/utils/artImageSeed.ts"
       - "server/utils/artJobResourceRefresh.ts"
@@ -18,6 +19,7 @@ on:
     branches: [main]
     paths:
       - "server/api/art/queue/**"
+      - "server/api/comfy/sdxl/utils/workflow.ts"
       - "server/utils/artJobProvenance.ts"
       - "server/utils/artImageSeed.ts"
       - "server/utils/artJobResourceRefresh.ts"

--- a/server/api/art/queue/[id]/requeue.post.ts
+++ b/server/api/art/queue/[id]/requeue.post.ts
@@ -11,7 +11,7 @@ import prisma from '../../../../utils/prisma'
 import { errorHandler } from '../../../../utils/error'
 import { requireMachineUser } from '../../../../utils/authGuard'
 import { serializeArtJobPayload } from '../../../../utils/artJobPayload'
-import { refreshArtJobLoraResources } from '../../../../utils/artJobResourceRefresh'
+import { refreshArtJobResources } from '../../../../utils/artJobResourceRefresh'
 
 type RequeueBody = {
   resetAttempts?: boolean
@@ -50,11 +50,13 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const resourceRefresh = await refreshArtJobLoraResources(job.payload)
+    const resourceRefresh = await refreshArtJobResources(job.payload)
     const payload = resourceRefresh.payload
     payload.queueRepair = {
       repairedAt: new Date().toISOString(),
-      loraPathChanged: resourceRefresh.changed,
+      resourcePathsChanged: resourceRefresh.changed,
+      checkpointResourceId: resourceRefresh.checkpointResourceId,
+      checkpointName: resourceRefresh.checkpointName,
       loraResourceIds: resourceRefresh.loraResourceIds,
       loraNames: resourceRefresh.loraNames,
     }
@@ -74,11 +76,13 @@ export default defineEventHandler(async (event) => {
     return {
       success: true,
       message: resourceRefresh.changed
-        ? `Job ${id} repaired from its current LoRA Resource and requeued (attempts ${updated.attempts}).`
+        ? `Job ${id} repaired from its current Resources and requeued (attempts ${updated.attempts}).`
         : `Job ${id} requeued (attempts ${updated.attempts}).`,
       data: {
         job: updated,
-        loraPathChanged: resourceRefresh.changed,
+        resourcePathsChanged: resourceRefresh.changed,
+        checkpointResourceId: resourceRefresh.checkpointResourceId,
+        checkpointName: resourceRefresh.checkpointName,
         loraResourceIds: resourceRefresh.loraResourceIds,
         loraNames: resourceRefresh.loraNames,
       },

--- a/server/api/art/queue/[id]/requeue.post.ts
+++ b/server/api/art/queue/[id]/requeue.post.ts
@@ -11,7 +11,10 @@ import prisma from '../../../../utils/prisma'
 import { errorHandler } from '../../../../utils/error'
 import { requireMachineUser } from '../../../../utils/authGuard'
 import { serializeArtJobPayload } from '../../../../utils/artJobPayload'
-import { refreshArtJobResources } from '../../../../utils/artJobResourceRefresh'
+import {
+  refreshArtJobCheckpointResource,
+  refreshArtJobLoraResources,
+} from '../../../../utils/artJobResourceRefresh'
 
 type RequeueBody = {
   resetAttempts?: boolean
@@ -50,15 +53,17 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const resourceRefresh = await refreshArtJobResources(job.payload)
-    const payload = resourceRefresh.payload
+    const checkpointRefresh = await refreshArtJobCheckpointResource(job.payload)
+    const loraRefresh = await refreshArtJobLoraResources(checkpointRefresh.payload)
+    const resourcePathsChanged = checkpointRefresh.changed || loraRefresh.changed
+    const payload = loraRefresh.payload
     payload.queueRepair = {
       repairedAt: new Date().toISOString(),
-      resourcePathsChanged: resourceRefresh.changed,
-      checkpointResourceId: resourceRefresh.checkpointResourceId,
-      checkpointName: resourceRefresh.checkpointName,
-      loraResourceIds: resourceRefresh.loraResourceIds,
-      loraNames: resourceRefresh.loraNames,
+      resourcePathsChanged,
+      checkpointResourceId: checkpointRefresh.checkpointResourceId,
+      checkpointName: checkpointRefresh.checkpointName,
+      loraResourceIds: loraRefresh.loraResourceIds,
+      loraNames: loraRefresh.loraNames,
     }
 
     const updated = await prisma.artJob.update({
@@ -75,16 +80,16 @@ export default defineEventHandler(async (event) => {
 
     return {
       success: true,
-      message: resourceRefresh.changed
+      message: resourcePathsChanged
         ? `Job ${id} repaired from its current Resources and requeued (attempts ${updated.attempts}).`
         : `Job ${id} requeued (attempts ${updated.attempts}).`,
       data: {
         job: updated,
-        resourcePathsChanged: resourceRefresh.changed,
-        checkpointResourceId: resourceRefresh.checkpointResourceId,
-        checkpointName: resourceRefresh.checkpointName,
-        loraResourceIds: resourceRefresh.loraResourceIds,
-        loraNames: resourceRefresh.loraNames,
+        resourcePathsChanged,
+        checkpointResourceId: checkpointRefresh.checkpointResourceId,
+        checkpointName: checkpointRefresh.checkpointName,
+        loraResourceIds: loraRefresh.loraResourceIds,
+        loraNames: loraRefresh.loraNames,
       },
       statusCode: 200,
     }

--- a/server/api/art/queue/[id]/trainer-redo.post.ts
+++ b/server/api/art/queue/[id]/trainer-redo.post.ts
@@ -10,12 +10,18 @@ import { errorHandler } from '../../../../utils/error'
 import { requireMachineUser } from '../../../../utils/authGuard'
 import {
   decodeArtJobPayload,
+  parseArtJobPayload,
   serializeArtJobPayload,
+  type ArtJobPayloadRecord,
 } from '../../../../utils/artJobPayload'
 import {
   applyArtJobOverrides,
   prepareArtJobRetryPayload,
 } from '../../../../utils/artJobRetry'
+import {
+  resolveActiveCheckpointResourceReference,
+  type ResolvedCheckpointResource,
+} from '../../../../utils/artJobResourceRefresh'
 import { assessArtPrompt, cleanArtPrompt } from '../../../../utils/artPromptQuality'
 import {
   buildWorkflowForEngine,
@@ -35,6 +41,13 @@ type TrainerRedoBody = {
   model?: string | null
   promptString?: string | null
   sourceImageBase64?: string | null
+  checkpointResourceId?: number | null
+  checkpoint?: string | null
+}
+
+function asRecord(value: unknown): ArtJobPayloadRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as ArtJobPayloadRecord
 }
 
 function normalizeImageData(value: unknown): string {
@@ -43,6 +56,56 @@ function normalizeImageData(value: unknown): string {
   return imageData.startsWith('data:image/')
     ? imageData
     : `data:image/png;base64,${imageData}`
+}
+
+async function resolveTrainerCheckpoint(input: {
+  body: TrainerRedoBody | null
+  sourcePayload: unknown
+  sourceArtImageId: number
+}): Promise<ResolvedCheckpointResource> {
+  const sourceImage = await prisma.artImage.findUnique({
+    where: { id: input.sourceArtImageId },
+    select: {
+      checkpointResourceId: true,
+      checkpoint: true,
+    },
+  })
+
+  if (!sourceImage) {
+    throw createError({
+      statusCode: 409,
+      message: `Source ArtImage ${input.sourceArtImageId} no longer exists.`,
+    })
+  }
+
+  const sourcePayload = parseArtJobPayload(input.sourcePayload)
+  const resources = asRecord(sourcePayload.resources)
+  const requestedResourceId =
+    Number(input.body?.checkpointResourceId) ||
+    Number(sourceImage.checkpointResourceId) ||
+    Number(resources.checkpointResourceId) ||
+    Number(sourcePayload.checkpointResourceId) ||
+    null
+
+  const checkpoint = await resolveActiveCheckpointResourceReference({
+    resourceId: requestedResourceId,
+    names: [
+      input.body?.checkpoint,
+      sourceImage.checkpoint,
+      resources.checkpointName,
+      sourcePayload.checkpoint,
+    ],
+  })
+
+  if (!checkpoint) {
+    throw createError({
+      statusCode: 409,
+      message:
+        'SDXL trainer revision could not resolve the requested/source checkpoint to an active CHECKPOINT Resource. Sync the checkpoint catalog or select a checkpoint Resource before retrying.',
+    })
+  }
+
+  return checkpoint
 }
 
 export default defineEventHandler(async (event) => {
@@ -103,6 +166,15 @@ export default defineEventHandler(async (event) => {
       })
     }
 
+    const checkpoint =
+      model === 'SDXL'
+        ? await resolveTrainerCheckpoint({
+            body,
+            sourcePayload: source.payload,
+            sourceArtImageId: source.artImageId,
+          })
+        : null
+
     const prepared = prepareArtJobRetryPayload(
       source.payload,
       source.id,
@@ -117,9 +189,6 @@ export default defineEventHandler(async (event) => {
       seed: null,
     }
 
-    // A trainer redo deliberately rebuilds the render graph instead of merely
-    // mutating the old one. That makes the two human-facing choices explicit:
-    // prompt-only SDXL, or image-guided SDXL/Kontext using the finished image.
     if (mode === 'TEXT') {
       prepared.workflow = buildWorkflowForEngine('comfy', renderRequest)
       delete prepared.images
@@ -151,6 +220,7 @@ export default defineEventHandler(async (event) => {
           prompt: promptString,
           negativePrompt: renderRequest.negativePrompt,
           imageName,
+          checkpoint: checkpoint?.localPath,
           seed: null,
           originalWeight: 0.55,
         })
@@ -159,14 +229,37 @@ export default defineEventHandler(async (event) => {
       }
     }
 
-    const payload = applyArtJobOverrides(prepared, { promptString })
-    delete payload.resources
+    const payload = applyArtJobOverrides(prepared, {
+      promptString,
+      checkpoint: checkpoint?.localPath,
+    })
+
+    if (checkpoint) {
+      payload.resources = {
+        checkpointResourceId: checkpoint.id,
+        checkpointName: checkpoint.localPath,
+        loraResourceIds: [],
+        loraNames: [],
+      }
+      payload.checkpointResourceId = checkpoint.id
+    } else {
+      delete payload.resources
+      delete payload.checkpointResourceId
+      delete payload.checkpoint
+    }
+
     payload.trainerRedo = {
       mode,
       model,
       sourceJobId: source.id,
       sourceArtImageId: source.artImageId,
       priority: 100,
+      ...(checkpoint
+        ? {
+            checkpointResourceId: checkpoint.id,
+            checkpointName: checkpoint.localPath,
+          }
+        : {}),
       requestedAt: new Date().toISOString(),
     }
 
@@ -191,6 +284,8 @@ export default defineEventHandler(async (event) => {
         sourceArtImageId: source.artImageId,
         mode,
         model,
+        checkpointResourceId: checkpoint?.id ?? null,
+        checkpointName: checkpoint?.localPath ?? null,
       },
       statusCode: 201,
     }

--- a/server/api/art/queue/[id]/trainer-redo.post.ts
+++ b/server/api/art/queue/[id]/trainer-redo.post.ts
@@ -50,6 +50,15 @@ function asRecord(value: unknown): ArtJobPayloadRecord {
   return value as ArtJobPayloadRecord
 }
 
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  const text = typeof value === 'string' ? value.trim() : ''
+  return text || undefined
+}
+
 function normalizeImageData(value: unknown): string {
   const imageData = String(value || '').trim()
   if (!imageData) return ''
@@ -188,6 +197,12 @@ export default defineEventHandler(async (event) => {
       prompt: promptString,
       seed: null,
     }
+    const inheritedSettings = {
+      steps: finiteNumber(prepared.steps),
+      cfg: finiteNumber(prepared.cfg),
+      sampler: nonEmptyString(prepared.sampler),
+      scheduler: nonEmptyString(prepared.scheduler),
+    }
 
     if (mode === 'TEXT') {
       prepared.workflow = buildWorkflowForEngine('comfy', renderRequest)
@@ -232,6 +247,7 @@ export default defineEventHandler(async (event) => {
     const payload = applyArtJobOverrides(prepared, {
       promptString,
       checkpoint: checkpoint?.localPath,
+      ...inheritedSettings,
     })
 
     if (checkpoint) {

--- a/server/api/comfy/sdxl/utils/workflow.ts
+++ b/server/api/comfy/sdxl/utils/workflow.ts
@@ -13,8 +13,6 @@ export type ComfyWorkflowNode = {
   _meta?: Record<string, unknown>
 }
 
-// The generation params the builder/patcher consume (the direct route's
-// GenerateComfyImageInput minus the transport-only server/workflow fields).
 export type ComfyWorkflowInput = {
   prompt: string
   cfgValue: number
@@ -59,8 +57,6 @@ function assignIfKeyExists(
   }
 }
 
-// Apply the request's prompt/seed/steps/cfg/sampler/checkpoint onto a
-// caller-supplied Comfy workflow, matching nodes by class_type + title.
 export function patchComfyWorkflow(
   workflow: ComfyWorkflow,
   input: ComfyWorkflowInput,
@@ -129,8 +125,6 @@ export function patchComfyWorkflow(
 export type SdxlImg2ImgInput = {
   prompt: string
   negativePrompt?: string | null
-  // Filename the relay uploads to Comfy's input folder (see the `images` payload
-  // the enqueue route builds), referenced by the LoadImage node below.
   imageName: string
   checkpoint?: string | null
   cfgValue?: number | null
@@ -138,32 +132,15 @@ export type SdxlImg2ImgInput = {
   seed?: number | null
   sampler?: string | null
   scheduler?: string | null
-  // How much of the ORIGINAL image to preserve, 0..1. denoise = 1 - originalWeight
-  // (floored to MIN_SDXL_IMG2IMG_DENOISE), so a higher weight keeps more of the
-  // source composition/subject and gives the checkpoint + style LoRA less room to
-  // repaint. When omitted, an explicit `denoise` is used; when both are omitted a
-  // restyle-friendly default is applied.
   originalWeight?: number | null
   denoise?: number | null
-  // Optional style LoRA. Unlike the Flux/Kontext model-only splice, SDXL style
-  // LoRAs frequently carry text-encoder weights, so a full LoraLoader (model +
-  // clip) is used and the CLIP encoders read through it too.
   loraName?: string | null
   loraStrength?: number | null
   filenamePrefix?: string | null
 }
 
-// Defaults tuned for the SDXL-Turbo base (dreamshaperXL_v21TurboDPMSDE): few
-// steps, low cfg, DPM++ SDE / Karras. A non-Turbo checkpoint still renders with
-// these but the UI is expected to expose step/cfg overrides.
 export const DEFAULT_SDXL_IMG2IMG_ORIGINAL_WEIGHT = 0.35
 const MIN_SDXL_IMG2IMG_DENOISE = 0.15
-// Subfolder-qualified, matching how ComfyUI lists a recursive checkpoints dir
-// (files live under SDXL/, Flux/, … so a bare filename would not resolve). The
-// styler is expected to pass the checkpoint Resource's real localPath; this is
-// only the fallback when none is supplied.
-const DEFAULT_SDXL_IMG2IMG_CHECKPOINT =
-  'SDXL/dreamshaperXL_v21TurboDPMSDE.safetensors'
 
 function resolveSdxlSeed(seed?: number | null): number {
   if (typeof seed === 'number' && Number.isFinite(seed) && seed >= 0) {
@@ -176,10 +153,6 @@ function clampUnit(value: number): number {
   return Math.min(1, Math.max(0, value))
 }
 
-// SDXL restyle: VAE-encode the source photo and sample from it at a reduced
-// denoise so the composition survives while the checkpoint (and optional style
-// LoRA) reinterpret the look. Mirrors the img2img shape of the Kontext builder,
-// but on a plain CheckpointLoaderSimple graph (baked CLIP + VAE).
 export function buildSdxlImg2ImgWorkflow(input: SdxlImg2ImgInput): {
   workflow: ComfyWorkflow
   seed: number
@@ -192,7 +165,13 @@ export function buildSdxlImg2ImgWorkflow(input: SdxlImg2ImgInput): {
     ? normalizeComfySampler(input.sampler)
     : 'dpmpp_sde'
   const scheduler = input.scheduler?.trim() || 'karras'
-  const checkpoint = input.checkpoint?.trim() || DEFAULT_SDXL_IMG2IMG_CHECKPOINT
+  const checkpoint = input.checkpoint?.trim()
+
+  if (!checkpoint) {
+    throw new Error(
+      'SDXL img2img requires an explicit checkpoint Resource path; refusing to build a workflow with a stale hard-coded fallback.',
+    )
+  }
 
   const originalWeight =
     typeof input.originalWeight === 'number' &&
@@ -212,7 +191,6 @@ export function buildSdxlImg2ImgWorkflow(input: SdxlImg2ImgInput): {
       ? input.loraStrength
       : 1
 
-  // Model + CLIP sources flip to the LoRA loader when a style LoRA is applied.
   const modelSource: [string, number] = loraName ? ['10', 0] : ['1', 0]
   const clipSource: [string, number] = loraName ? ['10', 1] : ['1', 1]
 

--- a/server/utils/artJobResourceRefresh.ts
+++ b/server/utils/artJobResourceRefresh.ts
@@ -25,10 +25,24 @@ function normalizeResourceIds(value: unknown): number[] {
   ]
 }
 
+function normalizeResourceId(value: unknown): number | null {
+  const id = Number(value)
+  return Number.isInteger(id) && id > 0 ? id : null
+}
+
 function normalizeLocalPath(value: unknown): string {
   return typeof value === 'string'
     ? value.trim().replaceAll('\\', '/')
     : ''
+}
+
+function normalizeIdentity(value: unknown): string {
+  return normalizeLocalPath(value).toLowerCase()
+}
+
+function pathBasename(value: unknown): string {
+  const normalized = normalizeIdentity(value).replace(/^\/+|\/+$/g, '')
+  return normalized.split('/').pop() || ''
 }
 
 function currentLoraResourceIds(payload: ArtJobPayloadRecord): number[] {
@@ -45,6 +59,196 @@ function currentLoraNames(payload: ArtJobPayloadRecord): string[] {
   return resources.loraNames
     .map(normalizeLocalPath)
     .filter((name): name is string => Boolean(name))
+}
+
+function currentCheckpointResourceId(
+  payload: ArtJobPayloadRecord,
+): number | null {
+  const resources = asRecord(payload.resources)
+  return (
+    normalizeResourceId(resources.checkpointResourceId) ||
+    normalizeResourceId(payload.checkpointResourceId)
+  )
+}
+
+function currentCheckpointName(payload: ArtJobPayloadRecord): string | null {
+  const resources = asRecord(payload.resources)
+  return (
+    normalizeLocalPath(resources.checkpointName) ||
+    normalizeLocalPath(payload.checkpoint) ||
+    null
+  )
+}
+
+export type ResolvedCheckpointResource = {
+  id: number
+  localPath: string
+}
+
+export async function resolveActiveCheckpointResourceReference(input: {
+  resourceId?: unknown
+  names?: unknown[]
+}): Promise<ResolvedCheckpointResource | null> {
+  const { default: prisma } = await import('./prisma')
+  const resourceId = normalizeResourceId(input.resourceId)
+
+  if (resourceId) {
+    const exact = await prisma.resource.findFirst({
+      where: {
+        id: resourceId,
+        isActive: true,
+        resourceType: ResourceType.CHECKPOINT,
+      },
+      select: { id: true, localPath: true },
+    })
+
+    if (exact) {
+      const localPath = normalizeLocalPath(exact.localPath)
+      if (!localPath) {
+        throw createError({
+          statusCode: 409,
+          message: `Checkpoint Resource ${resourceId} does not have a localPath for ComfyUI.`,
+        })
+      }
+      return { id: exact.id, localPath }
+    }
+  }
+
+  const requested = [
+    ...new Set((input.names || []).map(normalizeIdentity).filter(Boolean)),
+  ]
+  if (!requested.length) return null
+
+  const requestedBasenames = new Set(requested.map(pathBasename).filter(Boolean))
+  const resources = await prisma.resource.findMany({
+    where: {
+      isActive: true,
+      resourceType: ResourceType.CHECKPOINT,
+    },
+    select: {
+      id: true,
+      name: true,
+      customLabel: true,
+      localPath: true,
+    },
+    orderBy: { id: 'asc' },
+  })
+
+  const exactMatches = resources.filter((resource) => {
+    const identities = [
+      resource.localPath,
+      resource.name,
+      resource.customLabel,
+    ]
+      .map(normalizeIdentity)
+      .filter(Boolean)
+    return identities.some((identity) => requested.includes(identity))
+  })
+
+  const basenameMatches = resources.filter((resource) => {
+    const basename = pathBasename(resource.localPath || resource.name)
+    return basename && requestedBasenames.has(basename)
+  })
+
+  const matches = exactMatches.length ? exactMatches : basenameMatches
+  const distinctMatches = [...new Map(matches.map((item) => [item.id, item])).values()]
+
+  if (distinctMatches.length > 1) {
+    throw createError({
+      statusCode: 409,
+      message: `Checkpoint reference matches multiple active Resources (${distinctMatches
+        .map((resource) => resource.id)
+        .join(', ')}). Repair the Resource catalog instead of guessing.`,
+    })
+  }
+
+  const match = distinctMatches[0]
+  if (!match) return null
+
+  const localPath = normalizeLocalPath(match.localPath)
+  if (!localPath) {
+    throw createError({
+      statusCode: 409,
+      message: `Checkpoint Resource ${match.id} does not have a localPath for ComfyUI.`,
+    })
+  }
+
+  return { id: match.id, localPath }
+}
+
+export type ArtJobCheckpointResourceRefresh = {
+  payload: ArtJobPayloadRecord
+  changed: boolean
+  checkpointResourceId: number | null
+  checkpointName: string | null
+}
+
+export function applyResolvedCheckpointResourceToArtJobPayload(
+  rawPayload: unknown,
+  resource: ResolvedCheckpointResource,
+): ArtJobCheckpointResourceRefresh {
+  if (!Number.isInteger(resource.id) || resource.id <= 0) {
+    throw createError({
+      statusCode: 409,
+      message: 'Invalid checkpoint Resource id.',
+    })
+  }
+
+  const localPath = normalizeLocalPath(resource.localPath)
+  if (!localPath) {
+    throw createError({
+      statusCode: 409,
+      message: `Checkpoint Resource ${resource.id} does not have a localPath for ComfyUI.`,
+    })
+  }
+
+  const payload = structuredClone(parseArtJobPayload(rawPayload))
+  const before = JSON.stringify(payload)
+  applyArtJobOverrides(payload, { checkpoint: localPath })
+
+  const resources = asRecord(payload.resources)
+  resources.checkpointResourceId = resource.id
+  resources.checkpointName = localPath
+  payload.resources = resources
+  payload.checkpointResourceId = resource.id
+
+  return {
+    payload,
+    changed: before !== JSON.stringify(payload),
+    checkpointResourceId: resource.id,
+    checkpointName: localPath,
+  }
+}
+
+export async function refreshArtJobCheckpointResource(
+  rawPayload: unknown,
+): Promise<ArtJobCheckpointResourceRefresh> {
+  const payload = structuredClone(parseArtJobPayload(rawPayload))
+  const checkpointResourceId = currentCheckpointResourceId(payload)
+  const checkpointName = currentCheckpointName(payload)
+
+  if (!checkpointResourceId) {
+    return {
+      payload,
+      changed: false,
+      checkpointResourceId: null,
+      checkpointName,
+    }
+  }
+
+  const resource = await resolveActiveCheckpointResourceReference({
+    resourceId: checkpointResourceId,
+    names: checkpointName ? [checkpointName] : [],
+  })
+
+  if (!resource) {
+    throw createError({
+      statusCode: 409,
+      message: `Checkpoint Resource ${checkpointResourceId} is missing, inactive, or no longer a checkpoint Resource.`,
+    })
+  }
+
+  return applyResolvedCheckpointResourceToArtJobPayload(payload, resource)
 }
 
 export type ArtJobLoraResourceRefresh = {
@@ -138,4 +342,29 @@ export async function refreshArtJobLoraResources(
     id: resource.id,
     localPath: String(resource.localPath || ''),
   })
+}
+
+export type ArtJobResourceRefresh = {
+  payload: ArtJobPayloadRecord
+  changed: boolean
+  checkpointResourceId: number | null
+  checkpointName: string | null
+  loraResourceIds: number[]
+  loraNames: string[]
+}
+
+export async function refreshArtJobResources(
+  rawPayload: unknown,
+): Promise<ArtJobResourceRefresh> {
+  const checkpoint = await refreshArtJobCheckpointResource(rawPayload)
+  const lora = await refreshArtJobLoraResources(checkpoint.payload)
+
+  return {
+    payload: lora.payload,
+    changed: checkpoint.changed || lora.changed,
+    checkpointResourceId: checkpoint.checkpointResourceId,
+    checkpointName: checkpoint.checkpointName,
+    loraResourceIds: lora.loraResourceIds,
+    loraNames: lora.loraNames,
+  }
 }

--- a/utils/scripts/repairTrainerCheckpointFailures.ts
+++ b/utils/scripts/repairTrainerCheckpointFailures.ts
@@ -1,0 +1,319 @@
+import 'dotenv/config'
+import { fileURLToPath } from 'node:url'
+import { ResourceType } from '../../prisma/generated/prisma/client'
+import {
+  enrichArtJobPayload,
+  readArtJobProvenance,
+} from '../../server/utils/artJobProvenance'
+import {
+  parseArtJobPayload,
+  serializeArtJobPayload,
+  type ArtJobPayloadRecord,
+} from '../../server/utils/artJobPayload'
+import { normalizeQueuedArtJobPayload } from '../../server/utils/artJobNormalization'
+import { applyResolvedCheckpointResourceToArtJobPayload } from '../../server/utils/artJobResourceRefresh'
+import {
+  createScriptPrismaClient,
+  withDatabaseRetry,
+} from '../../scripts/lib/databaseRetry'
+
+const APPLY = process.argv.includes('--apply')
+const DEFAULT_LIMIT = 100
+const MAX_LIMIT = 1000
+
+function asRecord(value: unknown): ArtJobPayloadRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as ArtJobPayloadRecord
+}
+
+function positiveInt(value: unknown): number | null {
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+function optionNumber(name: string, fallback: number): number {
+  const index = process.argv.indexOf(name)
+  if (index < 0) return fallback
+  const value = Number(process.argv[index + 1])
+  if (!Number.isFinite(value) || value <= 0) return fallback
+  return Math.min(Math.floor(value), MAX_LIMIT)
+}
+
+function normalizePath(value: unknown): string {
+  return typeof value === 'string'
+    ? value.trim().replaceAll('\\', '/')
+    : ''
+}
+
+function normalizeIdentity(value: unknown): string {
+  return normalizePath(value).toLowerCase()
+}
+
+function basename(value: unknown): string {
+  const normalized = normalizeIdentity(value).replace(/^\/+|\/+$/g, '')
+  return normalized.split('/').pop() || ''
+}
+
+function checkpointFailure(error: unknown): boolean {
+  const message = String(error || '')
+  return (
+    /CheckpointLoaderSimple|ckpt_name/i.test(message) &&
+    /value_not_in_list|value not in list/i.test(message)
+  )
+}
+
+function workflowCheckpoint(payload: ArtJobPayloadRecord): string | null {
+  const workflow = asRecord(payload.workflow)
+  for (const nodeValue of Object.values(workflow)) {
+    const node = asRecord(nodeValue)
+    if (String(node.class_type || '') !== 'CheckpointLoaderSimple') continue
+    const checkpoint = normalizePath(asRecord(node.inputs).ckpt_name)
+    if (checkpoint) return checkpoint
+  }
+  return normalizePath(payload.checkpoint) || null
+}
+
+async function resolveCheckpoint(
+  prisma: ReturnType<typeof createScriptPrismaClient>,
+  input: {
+    resourceIds: Array<number | null>
+    names: unknown[]
+  },
+): Promise<{ id: number; localPath: string } | null> {
+  for (const id of input.resourceIds) {
+    if (!id) continue
+    const resource = await prisma.resource.findFirst({
+      where: {
+        id,
+        isActive: true,
+        resourceType: ResourceType.CHECKPOINT,
+      },
+      select: { id: true, localPath: true },
+    })
+    const localPath = normalizePath(resource?.localPath)
+    if (resource && localPath) return { id: resource.id, localPath }
+  }
+
+  const requested = [...new Set(input.names.map(normalizeIdentity).filter(Boolean))]
+  if (!requested.length) return null
+  const requestedBasenames = new Set(requested.map(basename).filter(Boolean))
+
+  const resources = await prisma.resource.findMany({
+    where: {
+      isActive: true,
+      resourceType: ResourceType.CHECKPOINT,
+    },
+    select: {
+      id: true,
+      name: true,
+      customLabel: true,
+      localPath: true,
+    },
+    orderBy: { id: 'asc' },
+  })
+
+  const exact = resources.filter((resource) =>
+    [resource.localPath, resource.name, resource.customLabel]
+      .map(normalizeIdentity)
+      .filter(Boolean)
+      .some((identity) => requested.includes(identity)),
+  )
+  const byBasename = resources.filter((resource) => {
+    const candidate = basename(resource.localPath || resource.name)
+    return candidate && requestedBasenames.has(candidate)
+  })
+  const matches = exact.length ? exact : byBasename
+  const distinct = [...new Map(matches.map((resource) => [resource.id, resource])).values()]
+
+  if (distinct.length !== 1) return null
+  const resource = distinct[0]!
+  const localPath = normalizePath(resource.localPath)
+  return localPath ? { id: resource.id, localPath } : null
+}
+
+async function repair(): Promise<void> {
+  const prisma = createScriptPrismaClient()
+  const limit = optionNumber('--limit', DEFAULT_LIMIT)
+
+  try {
+    const failed = await prisma.artJob.findMany({
+      where: { status: 'FAILED' },
+      orderBy: { id: 'desc' },
+      take: limit,
+      select: {
+        id: true,
+        engine: true,
+        payload: true,
+        priority: true,
+        projectSlug: true,
+        error: true,
+      },
+    })
+
+    const candidates = failed.filter((job) => {
+      const trainer = asRecord(parseArtJobPayload(job.payload).trainerRedo)
+      return (
+        job.engine === 'COMFY' &&
+        String(trainer.model || '').toUpperCase() === 'SDXL' &&
+        checkpointFailure(job.error)
+      )
+    })
+
+    console.log(
+      `[trainer-checkpoint-repair] ${APPLY ? 'APPLY' : 'DRY RUN'}: ${candidates.length} SDXL trainer checkpoint failure(s) among ${failed.length} recent FAILED ArtJobs.`,
+    )
+
+    let recoverable = 0
+    let unresolved = 0
+
+    for (const job of candidates) {
+      try {
+        const original = parseArtJobPayload(job.payload)
+        const trainer = asRecord(original.trainerRedo)
+        const failedResources = asRecord(original.resources)
+        const sourceArtImageId = positiveInt(trainer.sourceArtImageId)
+        const sourceJobId = positiveInt(trainer.sourceJobId)
+
+        if (!sourceArtImageId) {
+          throw new Error('trainerRedo.sourceArtImageId is missing.')
+        }
+
+        const [sourceImage, sourceJob] = await Promise.all([
+          prisma.artImage.findUnique({
+            where: { id: sourceArtImageId },
+            select: {
+              checkpointResourceId: true,
+              checkpoint: true,
+            },
+          }),
+          sourceJobId
+            ? prisma.artJob.findUnique({
+                where: { id: sourceJobId },
+                select: { payload: true },
+              })
+            : Promise.resolve(null),
+        ])
+
+        if (!sourceImage) {
+          throw new Error(`Source ArtImage ${sourceArtImageId} no longer exists.`)
+        }
+
+        const sourcePayload = sourceJob
+          ? parseArtJobPayload(sourceJob.payload)
+          : ({} as ArtJobPayloadRecord)
+        const sourceResources = asRecord(sourcePayload.resources)
+        const resource = await resolveCheckpoint(prisma, {
+          resourceIds: [
+            positiveInt(trainer.checkpointResourceId),
+            positiveInt(failedResources.checkpointResourceId),
+            positiveInt(sourceImage.checkpointResourceId),
+            positiveInt(sourceResources.checkpointResourceId),
+            positiveInt(sourcePayload.checkpointResourceId),
+          ],
+          names: [
+            trainer.checkpointName,
+            failedResources.checkpointName,
+            sourceImage.checkpoint,
+            sourceResources.checkpointName,
+            sourcePayload.checkpoint,
+          ],
+        })
+
+        if (!resource) {
+          throw new Error(
+            `Could not uniquely resolve source ArtImage ${sourceArtImageId} to an active CHECKPOINT Resource.`,
+          )
+        }
+
+        const oldCheckpoint = workflowCheckpoint(original)
+        if (
+          oldCheckpoint &&
+          normalizeIdentity(oldCheckpoint) === normalizeIdentity(resource.localPath)
+        ) {
+          throw new Error(
+            `Resource ${resource.id} still points at rejected checkpoint "${resource.localPath}"; repair the checkpoint Resource catalog before requeueing.`,
+          )
+        }
+
+        const refreshed = applyResolvedCheckpointResourceToArtJobPayload(
+          original,
+          resource,
+        )
+        const normalized = normalizeQueuedArtJobPayload(refreshed.payload)
+        const prior = readArtJobProvenance(job.payload)
+        const enriched = enrichArtJobPayload('COMFY', normalized.payload, {
+          projectSlug: job.projectSlug,
+          idempotencyKey: prior?.idempotencyKey,
+          requireCompletionProof: prior?.requireCompletionProof,
+        })
+        const payload = enriched.payload
+
+        payload.trainerRedo = {
+          ...asRecord(payload.trainerRedo),
+          checkpointResourceId: resource.id,
+          checkpointName: resource.localPath,
+        }
+        payload.queueRepair = {
+          ...asRecord(payload.queueRepair),
+          repairedAt: new Date().toISOString(),
+          reason: 'trainer-sdxl-checkpoint-resource-refresh',
+          previousCheckpoint: oldCheckpoint,
+          checkpointResourceId: resource.id,
+          checkpointName: resource.localPath,
+          previousError: String(job.error || '').slice(0, 1000),
+        }
+
+        console.log(
+          `[trainer-checkpoint-repair] ${job.id}: recoverable sourceImage=${sourceArtImageId} checkpoint=${JSON.stringify(oldCheckpoint)} -> Resource #${resource.id} ${JSON.stringify(resource.localPath)}`,
+        )
+
+        if (APPLY) {
+          const updated = await prisma.artJob.updateMany({
+            where: { id: job.id, status: 'FAILED' },
+            data: {
+              payload: serializeArtJobPayload(payload),
+              status: 'PENDING',
+              attempts: 0,
+              claimedAt: null,
+              claimedBy: null,
+              error: null,
+              priority: Math.max(100, job.priority),
+            },
+          })
+
+          if (updated.count !== 1) {
+            throw new Error(`ArtJob ${job.id} changed while it was being repaired.`)
+          }
+        }
+
+        recoverable += 1
+      } catch (error) {
+        unresolved += 1
+        console.log(
+          `[trainer-checkpoint-repair] ${job.id}: SKIP ${error instanceof Error ? error.message : String(error)}`,
+        )
+      }
+    }
+
+    console.log(
+      `[trainer-checkpoint-repair] summary: recoverable=${recoverable} unresolved=${unresolved}${APPLY ? ' (requeued in place)' : ' (no writes)'}.`,
+    )
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function main(): Promise<void> {
+  await withDatabaseRetry('repair Trainer checkpoint failures', async () => repair())
+}
+
+const isDirectRun = process.argv[1]
+  ? fileURLToPath(import.meta.url) === fileURLToPath(new URL(process.argv[1], 'file:'))
+  : false
+
+if (isDirectRun) {
+  main().catch((error) => {
+    console.error('[trainer-checkpoint-repair] failed', error)
+    process.exitCode = 1
+  })
+}

--- a/utils/scripts/verifyArtJobCheckpointRefresh.ts
+++ b/utils/scripts/verifyArtJobCheckpointRefresh.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { applyResolvedCheckpointResourceToArtJobPayload } from '../../server/utils/artJobResourceRefresh'
+import { buildSdxlImg2ImgWorkflow } from '../../server/api/comfy/sdxl/utils/workflow'
 
 {
   const refresh = applyResolvedCheckpointResourceToArtJobPayload(
@@ -37,6 +38,18 @@ import { applyResolvedCheckpointResourceToArtJobPayload } from '../../server/uti
   assert.equal(
     (refresh.payload.resources as any).checkpointName,
     'SDXL/current/model.safetensors',
+  )
+}
+
+{
+  assert.throws(
+    () =>
+      buildSdxlImg2ImgWorkflow({
+        prompt: 'A repaired image.',
+        imageName: 'source.png',
+      }),
+    /requires an explicit checkpoint Resource path/i,
+    'SDXL img2img must fail before queueing instead of injecting a stale checkpoint filename.',
   )
 }
 

--- a/utils/scripts/verifyArtJobCheckpointRefresh.ts
+++ b/utils/scripts/verifyArtJobCheckpointRefresh.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { applyResolvedCheckpointResourceToArtJobPayload } from '../../server/utils/artJobResourceRefresh'
+
+{
+  const refresh = applyResolvedCheckpointResourceToArtJobPayload(
+    {
+      checkpoint: 'SDXL/old-model.safetensors',
+      checkpointResourceId: 77,
+      resources: {
+        checkpointResourceId: 77,
+        checkpointName: 'SDXL/old-model.safetensors',
+      },
+      workflow: {
+        '1': {
+          class_type: 'CheckpointLoaderSimple',
+          inputs: { ckpt_name: 'SDXL/old-model.safetensors' },
+        },
+      },
+    },
+    {
+      id: 77,
+      localPath: 'SDXL/current/model.safetensors',
+    },
+  )
+
+  assert.equal(refresh.changed, true)
+  assert.equal(refresh.checkpointResourceId, 77)
+  assert.equal(refresh.checkpointName, 'SDXL/current/model.safetensors')
+  assert.equal(refresh.payload.checkpoint, 'SDXL/current/model.safetensors')
+  assert.equal(refresh.payload.checkpointResourceId, 77)
+  assert.equal(
+    (refresh.payload.workflow as any)['1'].inputs.ckpt_name,
+    'SDXL/current/model.safetensors',
+  )
+  assert.equal((refresh.payload.resources as any).checkpointResourceId, 77)
+  assert.equal(
+    (refresh.payload.resources as any).checkpointName,
+    'SDXL/current/model.safetensors',
+  )
+}
+
+{
+  const trainer = readFileSync(
+    new URL(
+      '../../server/api/art/queue/[id]/trainer-redo.post.ts',
+      import.meta.url,
+    ),
+    'utf8',
+  )
+
+  assert.match(
+    trainer,
+    /resolveTrainerCheckpoint\(/,
+    'Trainer SDXL revisions must resolve a checkpoint Resource before queueing.',
+  )
+  assert.match(
+    trainer,
+    /checkpoint: checkpoint\?\.localPath/,
+    'Trainer SDXL img2img must pass the resolved Resource localPath into its workflow.',
+  )
+  assert.match(
+    trainer,
+    /checkpointResourceId: checkpoint\.id/,
+    'Trainer SDXL revisions must preserve checkpoint Resource identity.',
+  )
+}
+
+{
+  const requeue = readFileSync(
+    new URL('../../server/api/art/queue/[id]/requeue.post.ts', import.meta.url),
+    'utf8',
+  )
+  assert.match(
+    requeue,
+    /await refreshArtJobResources\(/,
+    'Requeue must refresh checkpoint and LoRA Resource paths before returning a job to PENDING.',
+  )
+}
+
+{
+  const repair = readFileSync(
+    new URL('./repairTrainerCheckpointFailures.ts', import.meta.url),
+    'utf8',
+  )
+  assert.match(repair, /CheckpointLoaderSimple\|ckpt_name/)
+  assert.match(repair, /Resource .* still points at rejected checkpoint/)
+  assert.match(repair, /status: 'PENDING'/)
+  assert.match(repair, /attempts: 0/)
+}
+
+console.log('✅ verifyArtJobCheckpointRefresh: all assertions passed')

--- a/utils/scripts/verifyArtJobCheckpointRefresh.ts
+++ b/utils/scripts/verifyArtJobCheckpointRefresh.ts
@@ -73,8 +73,13 @@ import { applyResolvedCheckpointResourceToArtJobPayload } from '../../server/uti
   )
   assert.match(
     requeue,
-    /await refreshArtJobResources\(/,
-    'Requeue must refresh checkpoint and LoRA Resource paths before returning a job to PENDING.',
+    /await refreshArtJobCheckpointResource\(/,
+    'Requeue must refresh checkpoint Resources before returning a job to PENDING.',
+  )
+  assert.match(
+    requeue,
+    /await refreshArtJobLoraResources\(/,
+    'Requeue must continue refreshing LoRA Resources before returning a job to PENDING.',
   )
 }
 

--- a/utils/scripts/verifyArtJobCheckpointRefresh.ts
+++ b/utils/scripts/verifyArtJobCheckpointRefresh.ts
@@ -3,6 +3,12 @@ import { readFileSync } from 'node:fs'
 import { applyResolvedCheckpointResourceToArtJobPayload } from '../../server/utils/artJobResourceRefresh'
 import { buildSdxlImg2ImgWorkflow } from '../../server/api/comfy/sdxl/utils/workflow'
 
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
 {
   const refresh = applyResolvedCheckpointResourceToArtJobPayload(
     {
@@ -25,18 +31,23 @@ import { buildSdxlImg2ImgWorkflow } from '../../server/api/comfy/sdxl/utils/work
     },
   )
 
+  const workflow = asRecord(refresh.payload.workflow)
+  const checkpointNode = asRecord(workflow['1'])
+  const checkpointInputs = asRecord(checkpointNode.inputs)
+  const resources = asRecord(refresh.payload.resources)
+
   assert.equal(refresh.changed, true)
   assert.equal(refresh.checkpointResourceId, 77)
   assert.equal(refresh.checkpointName, 'SDXL/current/model.safetensors')
   assert.equal(refresh.payload.checkpoint, 'SDXL/current/model.safetensors')
   assert.equal(refresh.payload.checkpointResourceId, 77)
   assert.equal(
-    (refresh.payload.workflow as any)['1'].inputs.ckpt_name,
+    checkpointInputs.ckpt_name,
     'SDXL/current/model.safetensors',
   )
-  assert.equal((refresh.payload.resources as any).checkpointResourceId, 77)
+  assert.equal(resources.checkpointResourceId, 77)
   assert.equal(
-    (refresh.payload.resources as any).checkpointName,
+    resources.checkpointName,
     'SDXL/current/model.safetensors',
   )
 }


### PR DESCRIPTION
## What changed
- Art Trainer SDXL revisions now resolve the source/requested checkpoint through an active CHECKPOINT Resource instead of silently inheriting the stale DreamShaper fallback
- SDXL trainer jobs preserve `checkpointResourceId` + current Resource `localPath` in payload provenance
- normal queue requeue refreshes checkpoint Resources in addition to the existing LoRA refresh
- SDXL img2img workflow construction now fails closed when no explicit checkpoint Resource path was supplied, rather than manufacturing a doomed ArtJob with a hard-coded filename
- add `utils/scripts/repairTrainerCheckpointFailures.ts`, dry-run by default, to repair existing FAILED trainer jobs in place from their source ArtImage/source ArtJob checkpoint Resource
- the repair refuses to requeue if the Resource catalog still points at the exact checkpoint Comfy rejected
- add focused checkpoint resource contract coverage

## Root cause
The Art Trainer SDXL img2img path rebuilt the graph without passing a checkpoint, so `buildSdxlImg2ImgWorkflow()` inserted the hard-coded `SDXL/dreamshaperXL_v21TurboDPMSDE.safetensors`. Current ComfyUI no longer lists that checkpoint. The trainer route then deleted `payload.resources`, discarding the Resource identity that could have refreshed a moved model on retry.

The observed production failure is a ComfyUI `CheckpointLoaderSimple` HTTP 400 (`ckpt_name ... not in list`), not a missing prompt.

## Production recovery after merge/deploy
On Alexandria:

```bash
npx tsx utils/scripts/repairTrainerCheckpointFailures.ts
npx tsx utils/scripts/repairTrainerCheckpointFailures.ts --apply
```

The script touches only FAILED COMFY trainer-redo rows whose model is SDXL and whose error is a checkpoint `value_not_in_list`. It updates the same rows back to PENDING at priority >=100, resets attempts, and does not create duplicates.