### PR TITLE
Paginate every gallery in the shell, drop the Resource _count, fix 320px selects

### DIFF
--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -454,8 +454,13 @@
           `density`; a second row of Cards/Heroes/Icons buttons would be two
           pickers steering one grid.
         -->
+        <!-- page-size 0: art-gallery pages itself. `galleryItems` is built
+             from pagedActiveImages, and its page size is a user control
+             (imagePageSize), so letting the shell page again would slice a
+             page into pages. -->
         <kr-gallery
           :items="galleryItems"
+          :page-size="0"
           :modes="[]"
           :density="viewSize"
           empty-label="art images"

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -332,7 +332,7 @@
 
             <select
               v-model="constructionFilter"
-              class="select select-bordered select-sm bg-base-100"
+              class="select select-bordered select-sm w-auto max-w-44 bg-base-100"
               aria-label="Filter bots by construction status"
             >
               <option value="all">All statuses</option>

--- a/components/facets/facet-gallery.vue
+++ b/components/facets/facet-gallery.vue
@@ -96,8 +96,11 @@
              so mounting it N times is structurally fine, and `:modes="[]"` drops
              its own mode bar -- the picker above drives every group at once, so
              the groups stay visually consistent instead of drifting apart. -->
+        <!-- page-size 0: entries are already capped per taxonomy group by
+             this file's own show-more (`slice(0, shown[taxonomy] ?? PAGE)`). -->
         <kr-gallery
           :items="group.entries.map(toGalleryItem)"
+          :page-size="0"
           :mode="mode"
           :modes="[]"
           empty-label="facets"

--- a/components/gallery/kr-gallery.vue
+++ b/components/gallery/kr-gallery.vue
@@ -52,11 +52,56 @@
       have not adopted it are unaffected.
     -->
     <div
-      v-if="modes.length || $slots.toolbar"
+      v-if="modes.length || $slots.toolbar || pageCount > 1"
       class="sticky top-0 z-20 -mx-1 flex shrink-0 flex-wrap items-center gap-1 bg-(--kr-surface-sunken) px-1 py-1 backdrop-blur"
     >
       <div v-if="$slots.toolbar" class="min-w-0 flex-1">
         <slot name="toolbar" />
+      </div>
+
+      <!--
+        THE PAGER RIDES THIS BAR rather than sitting in a band under the grid.
+        The bar is `sticky` inside whatever ancestor scrolls, so on a big
+        collection the control stays reachable instead of living a thousand
+        cards below the fold -- and a band of its own would spend a row, which
+        is the opposite of what this stage is for.
+
+        It renders only when there IS a second page, so every gallery that fits
+        on one is visually unchanged. That is also why `pageCount > 1` joins the
+        bar's own v-if above: theme-gallery's two grids pass `:modes="[]"` and
+        no toolbar, so without it they would page with no way to turn the page.
+      -->
+      <div
+        v-if="pageCount > 1"
+        class="ml-auto flex shrink-0 items-center gap-1"
+      >
+        <span class="text-xs tabular-nums text-base-content/60">
+          {{ pageRangeLabel }}
+        </span>
+
+        <button
+          type="button"
+          class="btn btn-ghost btn-xs rounded-xl"
+          :disabled="page === 0"
+          aria-label="Previous page"
+          @click="page--"
+        >
+          <Icon name="kind-icon:arrow-left" class="h-3.5 w-3.5" />
+        </button>
+
+        <span class="text-xs font-bold tabular-nums">
+          {{ page + 1 }}/{{ pageCount }}
+        </span>
+
+        <button
+          type="button"
+          class="btn btn-ghost btn-xs rounded-xl"
+          :disabled="page >= pageCount - 1"
+          aria-label="Next page"
+          @click="page++"
+        >
+          <Icon name="kind-icon:arrow-right" class="h-3.5 w-3.5" />
+        </button>
       </div>
 
       <button
@@ -149,7 +194,7 @@
       -->
       <template v-if="$slots.item">
         <slot
-          v-for="item in items"
+          v-for="item in pagedItems"
           :key="`slot-${item.id}`"
           name="item"
           :item="item"
@@ -160,7 +205,7 @@
       </template>
 
       <button
-        v-for="item in items"
+        v-for="item in pagedItems"
         v-else
         :key="item.id"
         type="button"
@@ -274,7 +319,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import {
   resolveArtVariantSrc,
   type ArtImageSrcLike,
@@ -336,6 +381,27 @@ const props = withDefaults(
     emptyLabel?: string
     skeletonCount?: number
     /**
+     * How many items to RENDER at once. Pass 0 to render every item.
+     *
+     * ON BY DEFAULT, DELIBERATELY. The original split gave this shell the grid
+     * and left paging to each caller, on the reasoning that pagination is the
+     * parent's business. In practice it meant every caller had to remember, and
+     * eleven of the thirteen did not: bot, character, dream, reward, scenario,
+     * icon, server, checkpoint, stylist-client, theme and achievement all
+     * handed over their whole filtered set. Only art-gallery paged; only
+     * facet-gallery capped, per taxonomy group.
+     *
+     * It surfaced on /resources first because that is the biggest table --
+     * Silas, 2026-08-08: "There seems to be no pagination. Are we trying to
+     * load thousands on one page? It freezes." Every other gallery had the same
+     * defect and was waiting to grow into it, which is the argument for fixing
+     * it HERE instead of pasting a slice into eleven more files.
+     *
+     * A default you opt OUT of is the right way round: forgetting it now costs
+     * a pager nobody needed, rather than a frozen tab.
+     */
+    pageSize?: number
+    /**
      * How many tiles per row, independent of which image `mode` loads. Omit to
      * let mode pick the grid, which is what every gallery but art-gallery does.
      * See the GalleryDensity note in utils/galleryVocabulary.ts for why this is
@@ -350,6 +416,7 @@ const props = withDefaults(
     error: '',
     emptyLabel: 'items',
     skeletonCount: 8,
+    pageSize: 48,
     density: undefined,
   },
 )
@@ -369,6 +436,43 @@ const gridClass = computed(() =>
     ? DENSITY_GRID_CLASS[props.density]
     : MODE_GRID_CLASS[props.mode],
 )
+const page = ref(0)
+
+const pageCount = computed(() => {
+  if (props.pageSize <= 0) return 1
+  return Math.max(1, Math.ceil(props.items.length / props.pageSize))
+})
+
+const pagedItems = computed(() => {
+  if (props.pageSize <= 0) return props.items
+  const start = page.value * props.pageSize
+  return props.items.slice(start, start + props.pageSize)
+})
+
+/*
+ * CLAMP, do not reset. `items` is recomputed on every keystroke of a parent's
+ * search box, so resetting to page 0 whenever it changed would make any page
+ * but the first unreachable. Clamping moves you only when the page you are on
+ * has genuinely stopped existing -- narrow 2,000 rows to 30 while on page 12
+ * and every later render would otherwise be an empty grid with no way back.
+ *
+ * pageCount is pinned to 1 while paging is off, so this is inert for opted-out
+ * callers rather than something they have to reason about.
+ */
+watch(pageCount, (count) => {
+  if (page.value > count - 1) page.value = count - 1
+})
+
+const pageRangeLabel = computed(() => {
+  const total = props.items.length
+  if (!total) return ''
+
+  const first = page.value * props.pageSize + 1
+  const last = Math.min(first + props.pageSize - 1, total)
+
+  return `${first}–${last} of ${total}`
+})
+
 const imageWrapClass = computed(() =>
   props.mode === 'heroes'
     ? 'min-h-64'

--- a/components/icons/icon-gallery.vue
+++ b/components/icons/icon-gallery.vue
@@ -48,7 +48,7 @@
         <div class="flex flex-wrap items-center gap-2">
           <select
             v-model="filterScope"
-            class="select select-bordered select-xs rounded-lg"
+            class="select select-bordered select-xs w-auto max-w-44 rounded-lg"
             aria-label="Filter icons by scope"
           >
             <option value="all">All Icons</option>
@@ -58,7 +58,7 @@
 
           <select
             v-model="filterType"
-            class="select select-bordered select-xs rounded-lg"
+            class="select select-bordered select-xs w-auto max-w-44 rounded-lg"
             aria-label="Filter icons by type"
           >
             <option value="">All Types</option>

--- a/components/resources/resource-card.vue
+++ b/components/resources/resource-card.vue
@@ -75,12 +75,9 @@
         <span class="badge badge-outline badge-sm">
           {{ resource.supportedServer }}
         </span>
-        <span class="badge badge-outline badge-sm">
-          {{ resource._count?.ArtImages || 0 }} checkpoint uses
-        </span>
-        <span class="badge badge-outline badge-sm">
-          {{ resource._count?.UsedInImages || 0 }} LoRA uses
-        </span>
+        <!-- The "N checkpoint uses / N LoRA uses" badges lived here. They cost
+             two correlated aggregates per row on the catalog list query and
+             read 0 on every card; see the note on resourceGallerySelect. -->
       </div>
 
       <div class="mt-auto grid grid-cols-2 gap-2">

--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -1,6 +1,6 @@
 <!-- /components/resources/resource-gallery.vue -->
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
 import {
   useResourceGalleryStore,
@@ -157,8 +157,62 @@ const filteredResources = computed(() => {
   })
 })
 
+/*
+ * PAGINATE THE RENDER. Silas, 2026-08-08, from a tablet: "Really think we might
+ * be getting an index overwhelm issue when getting resources. There seems to be
+ * no pagination. Are we trying to load thousands on one page? It freezes."
+ *
+ * We were. `/api/resources` is an unpaginated findMany over every active
+ * Resource, and this file handed the WHOLE filtered result to kr-gallery, so
+ * the browser built a resource-card for every row in the catalog at once.
+ *
+ * art-gallery already answered this and says so on `pagedActiveImages`: "Only
+ * the page, not the whole filtered set: pagination stays this component's job,
+ * and kr-gallery renders exactly what it is handed." This gallery was the
+ * outlier, so it adopts the same shape rather than inventing a second one.
+ *
+ * Note what is deliberately NOT paginated: `filteredResources` still runs over
+ * the full array, so search, the type filter and the base-model filter keep
+ * searching the entire catalog rather than only the visible page. The type and
+ * base-model dropdowns also derive their options from the full set (see
+ * `resourceTypes` / `generations`), which is why the fetch stays whole-catalog
+ * for now -- paginating the QUERY would empty those dropdowns, which is a
+ * separate change requiring the filters to move server-side.
+ */
+const RESOURCE_PAGE_SIZE = 48
+const resourcePage = ref(0)
+
+const pageCount = computed(() =>
+  Math.max(1, Math.ceil(filteredResources.value.length / RESOURCE_PAGE_SIZE)),
+)
+
+const pagedResources = computed(() => {
+  const start = resourcePage.value * RESOURCE_PAGE_SIZE
+  return filteredResources.value.slice(start, start + RESOURCE_PAGE_SIZE)
+})
+
+/*
+ * Narrowing the list under a reader's feet would otherwise strand them on a
+ * page that no longer exists -- filter 2,000 resources down to 30 while on page
+ * 12 and every subsequent render is an empty grid with no way back. Clamping
+ * rather than resetting to 0 keeps your place when the page is still valid.
+ */
+watch(pageCount, (count) => {
+  if (resourcePage.value > count - 1) resourcePage.value = count - 1
+})
+
+const pageRangeLabel = computed(() => {
+  const total = filteredResources.value.length
+  if (!total) return ''
+
+  const first = resourcePage.value * RESOURCE_PAGE_SIZE + 1
+  const last = Math.min(first + RESOURCE_PAGE_SIZE - 1, total)
+
+  return `${first}–${last} of ${total}`
+})
+
 const galleryItems = computed<GalleryItem[]>(() =>
-  filteredResources.value.map((resource) => ({
+  pagedResources.value.map((resource) => ({
     id: resource.id,
     title: resourceLabel(resource),
     description: resource.description || undefined,
@@ -167,7 +221,7 @@ const galleryItems = computed<GalleryItem[]>(() =>
 
 const resourceById = computed(
   () =>
-    new Map(filteredResources.value.map((resource) => [resource.id, resource])),
+    new Map(pagedResources.value.map((resource) => [resource.id, resource])),
 )
 
 function resourceLabel(resource: ResourceGalleryRecord): string {
@@ -478,9 +532,23 @@ onMounted(async () => {
             aria-label="Search Resources"
           />
 
+          <!--
+            `w-auto` IS LOad-BEARING, not tidying. DaisyUI 5 gives `.select`
+            `width: clamp(3rem, 20rem, 100%)` -- the PREFERRED value is 20rem,
+            so a select with no width utility is 320px wide no matter how short
+            its options are. Two of them claimed 640px of this row and pushed
+            the rest of the filters onto lines of their own; Silas, 2026-08-08,
+            reported /resources loading with "several rows" for exactly this.
+            The search box beside them looked fine only because it already
+            carried explicit `w-36 sm:w-52`.
+
+            `.select` is `inline-flex` with `overflow:hidden` and
+            `text-overflow:ellipsis` already, so sizing to content is safe: a
+            long option name truncates rather than reflowing the row.
+          -->
           <select
             v-model="resourceType"
-            class="select select-bordered select-xs rounded-2xl"
+            class="select select-bordered select-xs w-auto max-w-44 rounded-2xl"
             aria-label="Filter by resource type"
           >
             <option value="ALL">All types</option>
@@ -491,7 +559,7 @@ onMounted(async () => {
 
           <select
             v-model="generation"
-            class="select select-bordered select-xs rounded-2xl"
+            class="select select-bordered select-xs w-auto max-w-44 rounded-2xl"
             aria-label="Filter by base model"
           >
             <option value="ALL">All base models</option>
@@ -521,6 +589,52 @@ onMounted(async () => {
             visible-text="Mature LoRAs and checkpoint models are included."
             hidden-text="Mature LoRAs and checkpoint models are hidden."
           />
+
+          <!--
+            The pager rides the TOOLBAR, not a band under the grid. Two reasons:
+            the toolbar is `sticky` inside the parent's scroll owner, so with a
+            catalog this size the control stays reachable instead of living
+            2,000 cards below the fold; and the row has the space now that the
+            two selects are no longer 320px each. A band of its own would give
+            back the vertical space this whole change is trying to save.
+
+            Count first, then the controls: "1–48 of 2,317" answers "did my
+            filter do anything" without needing a separate badge for it.
+          -->
+          <div
+            v-if="filteredResources.length"
+            class="ml-auto flex shrink-0 items-center gap-1"
+          >
+            <span class="text-xs tabular-nums text-base-content/60">
+              {{ pageRangeLabel }}
+            </span>
+
+            <template v-if="pageCount > 1">
+              <button
+                type="button"
+                class="btn btn-ghost btn-xs rounded-2xl"
+                :disabled="resourcePage === 0"
+                aria-label="Previous page"
+                @click="resourcePage--"
+              >
+                <Icon name="kind-icon:arrow-left" class="h-3.5 w-3.5" />
+              </button>
+
+              <span class="text-xs tabular-nums font-bold">
+                {{ resourcePage + 1 }}/{{ pageCount }}
+              </span>
+
+              <button
+                type="button"
+                class="btn btn-ghost btn-xs rounded-2xl"
+                :disabled="resourcePage >= pageCount - 1"
+                aria-label="Next page"
+                @click="resourcePage++"
+              >
+                <Icon name="kind-icon:arrow-right" class="h-3.5 w-3.5" />
+              </button>
+            </template>
+          </div>
         </div>
       </template>
 

--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -1,6 +1,6 @@
 <!-- /components/resources/resource-gallery.vue -->
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
 import {
   useResourceGalleryStore,
@@ -158,61 +158,22 @@ const filteredResources = computed(() => {
 })
 
 /*
- * PAGINATE THE RENDER. Silas, 2026-08-08, from a tablet: "Really think we might
- * be getting an index overwhelm issue when getting resources. There seems to be
- * no pagination. Are we trying to load thousands on one page? It freezes."
+ * NO PAGING HERE. Silas, 2026-08-08: "There seems to be no pagination. Are we
+ * trying to load thousands on one page? It freezes." It did -- but the fix
+ * belongs to kr-gallery, not to this file. Eleven of the thirteen galleries had
+ * the same defect; /resources only reached it first because it is the biggest
+ * table. See the `pageSize` prop on kr-gallery.
  *
- * We were. `/api/resources` is an unpaginated findMany over every active
- * Resource, and this file handed the WHOLE filtered result to kr-gallery, so
- * the browser built a resource-card for every row in the catalog at once.
- *
- * art-gallery already answered this and says so on `pagedActiveImages`: "Only
- * the page, not the whole filtered set: pagination stays this component's job,
- * and kr-gallery renders exactly what it is handed." This gallery was the
- * outlier, so it adopts the same shape rather than inventing a second one.
- *
- * Note what is deliberately NOT paginated: `filteredResources` still runs over
- * the full array, so search, the type filter and the base-model filter keep
- * searching the entire catalog rather than only the visible page. The type and
- * base-model dropdowns also derive their options from the full set (see
- * `resourceTypes` / `generations`), which is why the fetch stays whole-catalog
- * for now -- paginating the QUERY would empty those dropdowns, which is a
- * separate change requiring the filters to move server-side.
+ * What stays whole-catalog on purpose: `filteredResources` runs over the entire
+ * array, so search and both dropdowns still cover the whole catalog rather than
+ * the visible page, and `resourceById` is a superset of whatever the shell
+ * chooses to render. The type and base-model options are DERIVED from the
+ * loaded set (see `resourceTypes` / `generations`), which is also why the FETCH
+ * is still whole-catalog: paginating the query would empty those dropdowns, and
+ * that needs the filters to move server-side first.
  */
-const RESOURCE_PAGE_SIZE = 48
-const resourcePage = ref(0)
-
-const pageCount = computed(() =>
-  Math.max(1, Math.ceil(filteredResources.value.length / RESOURCE_PAGE_SIZE)),
-)
-
-const pagedResources = computed(() => {
-  const start = resourcePage.value * RESOURCE_PAGE_SIZE
-  return filteredResources.value.slice(start, start + RESOURCE_PAGE_SIZE)
-})
-
-/*
- * Narrowing the list under a reader's feet would otherwise strand them on a
- * page that no longer exists -- filter 2,000 resources down to 30 while on page
- * 12 and every subsequent render is an empty grid with no way back. Clamping
- * rather than resetting to 0 keeps your place when the page is still valid.
- */
-watch(pageCount, (count) => {
-  if (resourcePage.value > count - 1) resourcePage.value = count - 1
-})
-
-const pageRangeLabel = computed(() => {
-  const total = filteredResources.value.length
-  if (!total) return ''
-
-  const first = resourcePage.value * RESOURCE_PAGE_SIZE + 1
-  const last = Math.min(first + RESOURCE_PAGE_SIZE - 1, total)
-
-  return `${first}–${last} of ${total}`
-})
-
 const galleryItems = computed<GalleryItem[]>(() =>
-  pagedResources.value.map((resource) => ({
+  filteredResources.value.map((resource) => ({
     id: resource.id,
     title: resourceLabel(resource),
     description: resource.description || undefined,
@@ -221,7 +182,7 @@ const galleryItems = computed<GalleryItem[]>(() =>
 
 const resourceById = computed(
   () =>
-    new Map(pagedResources.value.map((resource) => [resource.id, resource])),
+    new Map(filteredResources.value.map((resource) => [resource.id, resource])),
 )
 
 function resourceLabel(resource: ResourceGalleryRecord): string {
@@ -589,52 +550,6 @@ onMounted(async () => {
             visible-text="Mature LoRAs and checkpoint models are included."
             hidden-text="Mature LoRAs and checkpoint models are hidden."
           />
-
-          <!--
-            The pager rides the TOOLBAR, not a band under the grid. Two reasons:
-            the toolbar is `sticky` inside the parent's scroll owner, so with a
-            catalog this size the control stays reachable instead of living
-            2,000 cards below the fold; and the row has the space now that the
-            two selects are no longer 320px each. A band of its own would give
-            back the vertical space this whole change is trying to save.
-
-            Count first, then the controls: "1–48 of 2,317" answers "did my
-            filter do anything" without needing a separate badge for it.
-          -->
-          <div
-            v-if="filteredResources.length"
-            class="ml-auto flex shrink-0 items-center gap-1"
-          >
-            <span class="text-xs tabular-nums text-base-content/60">
-              {{ pageRangeLabel }}
-            </span>
-
-            <template v-if="pageCount > 1">
-              <button
-                type="button"
-                class="btn btn-ghost btn-xs rounded-2xl"
-                :disabled="resourcePage === 0"
-                aria-label="Previous page"
-                @click="resourcePage--"
-              >
-                <Icon name="kind-icon:arrow-left" class="h-3.5 w-3.5" />
-              </button>
-
-              <span class="text-xs tabular-nums font-bold">
-                {{ resourcePage + 1 }}/{{ pageCount }}
-              </span>
-
-              <button
-                type="button"
-                class="btn btn-ghost btn-xs rounded-2xl"
-                :disabled="resourcePage >= pageCount - 1"
-                aria-label="Next page"
-                @click="resourcePage++"
-              >
-                <Icon name="kind-icon:arrow-right" class="h-3.5 w-3.5" />
-              </button>
-            </template>
-          </div>
         </div>
       </template>
 

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -301,7 +301,7 @@
 
             <select
               v-model="selectedCollection"
-              class="select select-bordered select-sm bg-base-100"
+              class="select select-bordered select-sm w-auto max-w-44 bg-base-100"
               aria-label="Filter rewards by collection"
             >
               <option value="all">All collections</option>
@@ -317,7 +317,7 @@
 
             <select
               v-model="selectedRarity"
-              class="select select-bordered select-sm bg-base-100"
+              class="select select-bordered select-sm w-auto max-w-44 bg-base-100"
               aria-label="Filter rewards by rarity"
             >
               <option value="all">All rarities</option>

--- a/server/api/resources/gallery.ts
+++ b/server/api/resources/gallery.ts
@@ -43,12 +43,17 @@ export const resourceGallerySelect = {
   ArtImage: {
     select: resourcePreviewArtImageSelect,
   },
-  _count: {
-    select: {
-      ArtImages: true,
-      UsedInImages: true,
-    },
-  },
+  // NO `_count`. This carried `_count: { select: { ArtImages: true,
+  // UsedInImages: true } }`, which made the list query emit two correlated
+  // aggregates per row against ArtImage -- the most expensive thing in an
+  // already-unpaginated findMany over the whole Resource table, and the
+  // likeliest source of the /resources pool timeouts. What it bought was two
+  // card badges reading "0 checkpoint uses / 0 LoRA uses" -- zero on every card
+  // in the report Silas sent on 2026-08-08. Dropped on his call the same day.
+  //
+  // If per-resource usage counts return, they belong on the DETAIL fetch
+  // (`[id].get.ts`) or a separate endpoint for the visible page -- not on every
+  // row of the catalog listing.
 } satisfies Prisma.ResourceSelect
 
 export type ResourceGalleryRecord = Prisma.ResourceGetPayload<{

--- a/stores/resourceGalleryStore.ts
+++ b/stores/resourceGalleryStore.ts
@@ -17,10 +17,6 @@ export type ResourcePreviewArtImage = Pick<
 
 export type ResourceGalleryRecord = Resource & {
   ArtImage?: ResourcePreviewArtImage | null
-  _count?: {
-    ArtImages: number
-    UsedInImages: number
-  }
 }
 
 type PreviewJob = {
@@ -41,181 +37,202 @@ type PreviewStatusResult = {
   resource: ResourceGalleryRecord | null
 }
 
-export const useResourceGalleryStore = defineStore('resourceGalleryStore', () => {
-  const resources = ref<ResourceGalleryRecord[]>([])
-  const isLoading = ref(false)
-  const error = ref('')
-  const previewJobs = ref<Record<number, PreviewJob>>({})
+export const useResourceGalleryStore = defineStore(
+  'resourceGalleryStore',
+  () => {
+    const resources = ref<ResourceGalleryRecord[]>([])
+    const isLoading = ref(false)
+    const error = ref('')
+    const previewJobs = ref<Record<number, PreviewJob>>({})
 
-  function replaceResource(resource: ResourceGalleryRecord): void {
-    const index = resources.value.findIndex((entry) => entry.id === resource.id)
-
-    if (index === -1) {
-      resources.value.push(resource)
-    } else {
-      resources.value[index] = resource
-    }
-  }
-
-  async function loadResources(): Promise<ResourceGalleryRecord[]> {
-    isLoading.value = true
-    error.value = ''
-
-    try {
-      const response = await performFetch<ResourceGalleryRecord[]>('/api/resources')
-
-      if (!response.success || !response.data) {
-        throw new Error(response.message || 'Failed to load Resources.')
-      }
-
-      resources.value = response.data
-      return resources.value
-    } catch (cause) {
-      error.value =
-        cause instanceof Error ? cause.message : 'Failed to load Resources.'
-      handleError(cause, 'loading Resource gallery')
-      return []
-    } finally {
-      isLoading.value = false
-    }
-  }
-
-  async function getResource(id: number): Promise<ResourceGalleryRecord | null> {
-    try {
-      const response = await performFetch<ResourceGalleryRecord>(
-        `/api/resources/${id}`,
+    function replaceResource(resource: ResourceGalleryRecord): void {
+      const index = resources.value.findIndex(
+        (entry) => entry.id === resource.id,
       )
 
-      if (!response.success || !response.data) {
-        throw new Error(response.message || 'Failed to load Resource.')
+      if (index === -1) {
+        resources.value.push(resource)
+      } else {
+        resources.value[index] = resource
       }
-
-      replaceResource(response.data)
-      return response.data
-    } catch (cause) {
-      handleError(cause, `loading Resource ${id}`)
-      return null
     }
-  }
 
-  async function queuePreview(id: number): Promise<PreviewQueueResult | null> {
-    try {
-      const response = await performFetch<PreviewQueueResult>(
-        `/api/resources/${id}/generate-preview`,
-        { method: 'POST' },
-      )
+    async function loadResources(): Promise<ResourceGalleryRecord[]> {
+      isLoading.value = true
+      error.value = ''
 
-      if (!response.success || !response.data) {
-        throw new Error(response.message || 'Failed to queue Resource preview.')
+      try {
+        const response =
+          await performFetch<ResourceGalleryRecord[]>('/api/resources')
+
+        if (!response.success || !response.data) {
+          throw new Error(response.message || 'Failed to load Resources.')
+        }
+
+        resources.value = response.data
+        return resources.value
+      } catch (cause) {
+        error.value =
+          cause instanceof Error ? cause.message : 'Failed to load Resources.'
+        handleError(cause, 'loading Resource gallery')
+        return []
+      } finally {
+        isLoading.value = false
       }
-
-      previewJobs.value[id] = {
-        id: response.data.jobId,
-        status: response.data.status,
-      }
-      return response.data
-    } catch (cause) {
-      handleError(cause, `queueing Resource ${id} preview`)
-      throw cause
     }
-  }
 
-  async function refreshPreviewJob(
-    resourceId: number,
-    jobId: number,
-  ): Promise<PreviewStatusResult | null> {
-    try {
-      const response = await performFetch<PreviewStatusResult>(
-        `/api/resources/${resourceId}/preview-job/${jobId}`,
-      )
+    async function getResource(
+      id: number,
+    ): Promise<ResourceGalleryRecord | null> {
+      try {
+        const response = await performFetch<ResourceGalleryRecord>(
+          `/api/resources/${id}`,
+        )
 
-      if (!response.success || !response.data) {
-        throw new Error(response.message || 'Failed to inspect preview job.')
+        if (!response.success || !response.data) {
+          throw new Error(response.message || 'Failed to load Resource.')
+        }
+
+        replaceResource(response.data)
+        return response.data
+      } catch (cause) {
+        handleError(cause, `loading Resource ${id}`)
+        return null
+      }
+    }
+
+    async function queuePreview(
+      id: number,
+    ): Promise<PreviewQueueResult | null> {
+      try {
+        const response = await performFetch<PreviewQueueResult>(
+          `/api/resources/${id}/generate-preview`,
+          { method: 'POST' },
+        )
+
+        if (!response.success || !response.data) {
+          throw new Error(
+            response.message || 'Failed to queue Resource preview.',
+          )
+        }
+
+        previewJobs.value[id] = {
+          id: response.data.jobId,
+          status: response.data.status,
+        }
+        return response.data
+      } catch (cause) {
+        handleError(cause, `queueing Resource ${id} preview`)
+        throw cause
+      }
+    }
+
+    async function refreshPreviewJob(
+      resourceId: number,
+      jobId: number,
+    ): Promise<PreviewStatusResult | null> {
+      try {
+        const response = await performFetch<PreviewStatusResult>(
+          `/api/resources/${resourceId}/preview-job/${jobId}`,
+        )
+
+        if (!response.success || !response.data) {
+          throw new Error(response.message || 'Failed to inspect preview job.')
+        }
+
+        previewJobs.value[resourceId] = response.data.job
+
+        if (response.data.resource) {
+          replaceResource(response.data.resource)
+        }
+
+        return response.data
+      } catch (cause) {
+        handleError(cause, `checking Resource ${resourceId} preview`)
+        return null
+      }
+    }
+
+    async function waitForPreview(
+      resourceId: number,
+      jobId: number,
+      attempts = 120,
+    ): Promise<ResourceGalleryRecord | null> {
+      for (let attempt = 0; attempt < attempts; attempt += 1) {
+        const result = await refreshPreviewJob(resourceId, jobId)
+
+        if (!result) return null
+        if (result.resource) return result.resource
+        if (
+          result.job.status === 'FAILED' ||
+          result.job.status === 'CANCELLED'
+        ) {
+          throw new Error(
+            result.job.error || `Preview job ${result.job.status}.`,
+          )
+        }
+
+        await new Promise((resolve) => window.setTimeout(resolve, 2500))
       }
 
-      previewJobs.value[resourceId] = response.data.job
+      throw new Error(
+        'Preview generation is still running. Check the ArtJob queue.',
+      )
+    }
 
-      if (response.data.resource) {
+    async function generatePreview(
+      resourceId: number,
+    ): Promise<ResourceGalleryRecord | null> {
+      const queued = await queuePreview(resourceId)
+      if (!queued) return null
+      return await waitForPreview(resourceId, queued.jobId)
+    }
+
+    async function uploadPreview(input: {
+      resourceId: number
+      imageData: string
+      fileName: string
+      fileType?: string
+    }): Promise<ResourceGalleryRecord | null> {
+      try {
+        const response = await performFetch<{
+          artImageId: number
+          resource: ResourceGalleryRecord
+        }>(`/api/resources/${input.resourceId}/preview-image`, {
+          method: 'POST',
+          body: JSON.stringify({
+            imageData: input.imageData,
+            fileName: input.fileName,
+            fileType: input.fileType,
+          }),
+        })
+
+        if (!response.success || !response.data?.resource) {
+          throw new Error(
+            response.message || 'Failed to upload Resource preview.',
+          )
+        }
+
         replaceResource(response.data.resource)
+        return response.data.resource
+      } catch (cause) {
+        handleError(cause, `uploading Resource ${input.resourceId} preview`)
+        throw cause
       }
-
-      return response.data
-    } catch (cause) {
-      handleError(cause, `checking Resource ${resourceId} preview`)
-      return null
-    }
-  }
-
-  async function waitForPreview(
-    resourceId: number,
-    jobId: number,
-    attempts = 120,
-  ): Promise<ResourceGalleryRecord | null> {
-    for (let attempt = 0; attempt < attempts; attempt += 1) {
-      const result = await refreshPreviewJob(resourceId, jobId)
-
-      if (!result) return null
-      if (result.resource) return result.resource
-      if (result.job.status === 'FAILED' || result.job.status === 'CANCELLED') {
-        throw new Error(result.job.error || `Preview job ${result.job.status}.`)
-      }
-
-      await new Promise((resolve) => window.setTimeout(resolve, 2500))
     }
 
-    throw new Error('Preview generation is still running. Check the ArtJob queue.')
-  }
-
-  async function generatePreview(
-    resourceId: number,
-  ): Promise<ResourceGalleryRecord | null> {
-    const queued = await queuePreview(resourceId)
-    if (!queued) return null
-    return await waitForPreview(resourceId, queued.jobId)
-  }
-
-  async function uploadPreview(input: {
-    resourceId: number
-    imageData: string
-    fileName: string
-    fileType?: string
-  }): Promise<ResourceGalleryRecord | null> {
-    try {
-      const response = await performFetch<{
-        artImageId: number
-        resource: ResourceGalleryRecord
-      }>(`/api/resources/${input.resourceId}/preview-image`, {
-        method: 'POST',
-        body: JSON.stringify({
-          imageData: input.imageData,
-          fileName: input.fileName,
-          fileType: input.fileType,
-        }),
-      })
-
-      if (!response.success || !response.data?.resource) {
-        throw new Error(response.message || 'Failed to upload Resource preview.')
-      }
-
-      replaceResource(response.data.resource)
-      return response.data.resource
-    } catch (cause) {
-      handleError(cause, `uploading Resource ${input.resourceId} preview`)
-      throw cause
+    return {
+      resources,
+      isLoading,
+      error,
+      previewJobs,
+      loadResources,
+      getResource,
+      queuePreview,
+      refreshPreviewJob,
+      waitForPreview,
+      generatePreview,
+      uploadPreview,
     }
-  }
-
-  return {
-    resources,
-    isLoading,
-    error,
-    previewJobs,
-    loadResources,
-    getResource,
-    queuePreview,
-    refreshPreviewJob,
-    waitForPreview,
-    generatePreview,
-    uploadPreview,
-  }
-})
+  },
+)

--- a/wonderlab-rollout-artifacts/component-contract-verification.json
+++ b/wonderlab-rollout-artifacts/component-contract-verification.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": 1,
   "baseUrl": "https://kind-robots.vercel.app",
-  "checkedAt": "2026-08-08T07:14:41.769Z",
+  "checkedAt": "2026-08-08T08:15:00.011Z",
   "recordCount": 489,
   "canonicalStatusRecordCount": 489,
   "discoveredCount": 420,

--- a/wonderlab-rollout-artifacts/component-contract-verification.json
+++ b/wonderlab-rollout-artifacts/component-contract-verification.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": 1,
   "baseUrl": "https://kind-robots.vercel.app",
-  "checkedAt": "2026-08-08T08:15:00.011Z",
+  "checkedAt": "2026-08-08T10:06:06.174Z",
   "recordCount": 489,
   "canonicalStatusRecordCount": 489,
   "discoveredCount": 420,


### PR DESCRIPTION
Reported from a tablet: *"Really think we might be getting an index overwhelm issue when getting resources. There seems to be no pagination. Are we trying to load thousands on one page? It freezes. Also, several rows on load."*

Both halves confirmed, with **different causes** — and the pagination half turned out to be far more widespread than `/resources`.

## 1. The freeze — and it is not just Resources

`GET /api/resources` is a `findMany` with no `take`/`skip`, and `resource-gallery` handed the *whole* filtered result to `kr-gallery`, so the browser built a card for every row in the catalog at once.

My first pass fixed that in `resource-gallery` and described it as the outlier. Silas asked whether that was actually true — *"do you feel confident on that? We won't hit this problem with others if they grow giant?"* — and it wasn't. Checking all thirteen `kr-gallery` mounts:

| | galleries |
| --- | --- |
| pages itself | `art-gallery` (user-controlled page size) |
| caps itself | `facet-gallery` (show-more per taxonomy group) |
| **does not page** | **bot, character, dream, reward, scenario, icon, server, checkpoint, stylist-client, theme, achievement** |

**Eleven of thirteen had the same defect.** `art-gallery` was the outlier for *having* pagination. `/resources` merely hit the wall first because it's the biggest table — every other gallery was waiting to grow into it.

So paging moves **into the shell**, where forgetting it isn't possible, rather than being pasted into eleven more files.

`kr-gallery` gains `pageSize` (default 48; `0` opts out):

- The pager renders **only when there is a second page**, so galleries that fit on one are visually unchanged.
- It rides the **existing sticky bar**, not a new band. The bar sticks inside whatever ancestor scrolls, so the control stays reachable instead of sitting a thousand cards below the fold — and a new band would spend a row this stage is trying to save.
- `pageCount > 1` joins that bar's own `v-if`, because `theme-gallery`'s two grids pass `:modes="[]"` and no toolbar and would otherwise page with no way to turn the page.
- Page index **clamps rather than resets**: `items` recomputes on every keystroke of a parent's search box, so resetting to 0 on change would make any page but the first unreachable.
- `art-gallery` and `facet-gallery` pass `:page-size="0"` — both already page, and slicing a page into pages is the one way this could regress them.

`resource-gallery`'s own pagination is removed in favour of the shell's. What stays whole-catalog there is deliberate: `filteredResources` still spans the entire array, so search and both dropdowns cover the whole catalog rather than the visible page, and `resourceById` is a superset of whatever the shell renders.

## 2. The extra rows — a DaisyUI default

DaisyUI 5 sets `.select { width: clamp(3rem, 20rem, 100%) }`. The **preferred** value is `20rem`, so any select with no width utility is **320px wide regardless of its options**. Two of them claimed 640px of the filter row and pushed everything else onto its own line. The search box looked fine only because it already carried `w-36 sm:w-52`.

This also finishes #1602, which I got half-right: removing `w-full` from the bot/reward selects dropped them to DaisyUI's 320px default rather than content width. `bot-gallery`, `reward-gallery` and `icon-gallery` get `w-auto max-w-44` here — and that's also the real explanation for `/icons` measuring a phone-only 108px gap I'd earlier mis-attributed to wide button labels.

## 3. The database cost — dropped on Silas's call

The list select carried `_count: { select: { ArtImages: true, UsedInImages: true } }`, making the query emit **two correlated aggregates per row** against `ArtImage` — the most expensive thing in an already-unpaginated `findMany` over the whole table, and the likeliest source of the `/resources` pool timeouts.

What it bought was two badges reading `0 checkpoint uses / 0 LoRA uses` — zero on every card in the report. Removed from the select, the store type, and the card. If those counts return they belong on the detail fetch or a per-page endpoint, not on every row of the listing.

## Verification

- `npm run test` (vue-tsc) — clean, which also confirms dropping `_count` broke no consumers
- `npx eslint` + `npx prettier` on all changed files — clean. `art-gallery` reports 2 `no-dynamic-delete` errors; confirmed **pre-existing** by stashing and re-running (same 2, shifted 5 lines by prettier).
- Swept **193 verification commands across all 57 workflow files**. 188 pass; the same 5 fail as on an unmodified tree, all Prisma pool timeouts (`P2039`) from the sandbox having no DB egress. None touch these files.
- Rebased onto `main` at `111bfee`.