### PR TITLE
fix(art): make the diverse-cast direction opt-in instead of unconditional

### DIFF
--- a/server/utils/artJobNormalization.ts
+++ b/server/utils/artJobNormalization.ts
@@ -6,8 +6,33 @@ import {
 
 export const KIND_ROBOTS_REPO = 'silasfelinus/kind_robots'
 
-export const DEFAULT_ASSET_ART_DIRECTION =
-  'detailed mature western animation with multidimensional worldbuilding, expressive anatomy and faces, confident ink-like linework, dimensional shapes, rich controlled color, cinematic lighting, tactile environments, and clear readable silhouettes; cast characters naturally across many species, ages, body sizes, body shapes, gender presentations, and levels of conventional attractiveness; include robots only when the subject or scene explicitly calls for them'
+// The medium/rendering half of the house look. Safe for every subject, because
+// it describes how a thing is drawn, not what is in frame.
+export const DEFAULT_ASSET_ART_STYLE =
+  'detailed mature western animation with multidimensional worldbuilding, expressive anatomy and faces, confident ink-like linework, dimensional shapes, rich controlled color, cinematic lighting, tactile environments, and clear readable silhouettes'
+
+// The casting half. This used to be welded onto the style above and appended to
+// every prompt unconditionally, including prompts for inanimate objects. Its
+// original wording ("...include robots only when the subject or scene
+// explicitly calls for them") assumes a reader who can evaluate a condition.
+// Diffusion models cannot: Krea 2 reads "characters ... many species, ages,
+// body sizes, body shapes, gender presentations" as the densest concrete noun
+// phrase in the prompt and paints a crowd. That is how a Reward called
+// "Tidefortune Ladle" rendered as fifteen people and no ladle (2026-08-08).
+//
+// Append this ONLY when the frame genuinely contains people. Prompt producers
+// that know their subject should opt in; `replaceVagueArtDirection` below
+// cannot know, so it deliberately does not.
+export const DEFAULT_CAST_ART_DIRECTION =
+  'cast the people who appear naturally across many species, ages, body sizes, body shapes, gender presentations, and levels of conventional attractiveness'
+
+// For object, product, landscape, and architecture subjects — the counterweight
+// that keeps an empty frame empty. Stated positively because Krea 2 runs at
+// cfg 1, which makes the ComfyUI negative prompt inert (see
+// server/api/comfy/krea2/utils/workflow.ts); every constraint has to survive
+// inside the positive prompt.
+export const DEFAULT_UNPEOPLED_ART_DIRECTION =
+  'an unpeopled frame — the subject stands alone with no bystanders, onlookers, or crowd'
 
 const VAGUE_ART_DIRECTION =
   /\b(?:(?:rich|cohesive|friendly)\s+)?Kind Robots\s+(?:visual\s+)?(?:style|language)\b/gi
@@ -89,9 +114,20 @@ export function normalizeKindRobotsImagePath(value: unknown): string {
   return normalized
 }
 
+/**
+ * Swap the legacy "Kind Robots visual style" filler — which gives an image model
+ * no visual information — for the concrete house style.
+ *
+ * This substitutes the STYLE only. It runs over arbitrary prompt strings with no
+ * knowledge of whether the subject is a person, an object, or a landscape, so it
+ * must not inject a casting instruction: a missing diversity nudge on a legacy
+ * prompt is recoverable, a crowd of people standing in for a ladle is not.
+ * Producers that know their subject has people append
+ * DEFAULT_CAST_ART_DIRECTION themselves.
+ */
 export function replaceVagueArtDirection(value: string): string {
   return value
-    .replace(VAGUE_ART_DIRECTION, DEFAULT_ASSET_ART_DIRECTION)
+    .replace(VAGUE_ART_DIRECTION, DEFAULT_ASSET_ART_STYLE)
     .replace(/\s+/g, ' ')
     .trim()
 }

--- a/server/utils/conductorArtPrompt.ts
+++ b/server/utils/conductorArtPrompt.ts
@@ -4,7 +4,11 @@ import {
   cleanArtPrompt,
   isGenericArtLabel,
 } from './artPromptQuality'
-import { DEFAULT_ASSET_ART_DIRECTION } from './artJobNormalization'
+import {
+  DEFAULT_ASSET_ART_STYLE,
+  DEFAULT_CAST_ART_DIRECTION,
+  DEFAULT_UNPEOPLED_ART_DIRECTION,
+} from './artJobNormalization'
 
 type ArtPromptTarget = {
   sourceUrl: string
@@ -194,11 +198,16 @@ function contextualFallback(
 
   if (!subject || !context) return ''
 
+  // No LLM ran, so nothing here knows whether the subject has people in it.
+  // Default to the unpeopled direction: these are project, page, and product
+  // assets, where a spurious crowd is the common failure and a missing one is
+  // not. Prompts that want a cast get it from the LLM path below.
   const prompt = [
     `Create artwork for ${subject}.`,
     `Visible subject and scene context: ${context}.`,
     compositionFor(target),
-    DEFAULT_ASSET_ART_DIRECTION,
+    DEFAULT_ASSET_ART_STYLE,
+    DEFAULT_UNPEOPLED_ART_DIRECTION,
     'no readable text, no logos, no watermark, no collage',
   ].join(' ')
 
@@ -247,10 +256,16 @@ export async function buildContextualArtPrompt(
           'When a draft prompt is supplied, preserve its intended subject, objects, relationships, and exclusions. Enrich it; do not replace it with a different concept.',
           'Never treat a database id, filename number, or phrases such as “Image 529” as a subject.',
           'Never use “Kind Robots style”, “Kind Robots visual style”, “Kind Robots visual language”, or “cohesive visual style”; those phrases give an image model no visual information and often cause unwanted robots.',
-          `Use this concrete default art direction when the surrounding context does not specify another medium: ${DEFAULT_ASSET_ART_DIRECTION}.`,
+          `Use this concrete default art direction when the surrounding context does not specify another medium: ${DEFAULT_ASSET_ART_STYLE}.`,
           'Robots are not a default mascot. Include a robot only when the requested subject, story, or surrounding page context explicitly requires one.',
           'For software tools, dashboards, and project assets, prefer a concrete object, environment, mechanism, or visual metaphor over a generic character portrait.',
           'Do not invent a person, human face, headshot, mascot, or humanoid focal character unless the supplied context explicitly calls for one.',
+          // The image model cannot evaluate "only when the scene calls for it";
+          // you can. Decide here, and emit exactly one of these two clauses.
+          'Decide whether the finished image contains people at all, then commit to it in the prompt you return.',
+          `If people belong in the frame, include this clause verbatim: ${DEFAULT_CAST_ART_DIRECTION}.`,
+          `If the subject is an object, product, tool, mechanism, landscape, or empty interior, include this clause verbatim instead: ${DEFAULT_UNPEOPLED_ART_DIRECTION}.`,
+          'Never include both clauses. Never include the casting clause for an inanimate subject — image models read it as a literal instruction to paint a crowd, which erases the requested object.',
           'Return one vivid prompt only. No markdown, no JSON, no quotes.',
           'Describe the visible focal subject, supporting elements, action or state, setting, spatial arrangement, composition, camera or framing, lighting, color palette, materials or texture, mood, and concrete rendering style.',
           promptLengthDirection(target),

--- a/utils/scripts/verifyArtPromptRepair.ts
+++ b/utils/scripts/verifyArtPromptRepair.ts
@@ -5,7 +5,8 @@ import {
   isGenericArtLabel,
 } from '../../server/utils/artPromptQuality'
 import {
-  DEFAULT_ASSET_ART_DIRECTION,
+  DEFAULT_ASSET_ART_STYLE,
+  DEFAULT_CAST_ART_DIRECTION,
   normalizeKindRobotsImagePath,
   normalizeQueuedArtJobPayload,
 } from '../../server/utils/artJobNormalization'
@@ -72,7 +73,7 @@ const normalizedWorkflow = normalization.payload.workflow as Record<
   string,
   WorkflowNode
 >
-const defaultDirectionLead = DEFAULT_ASSET_ART_DIRECTION.split(';').at(0) ?? ''
+const defaultDirectionLead = DEFAULT_ASSET_ART_STYLE.split(';').at(0) ?? ''
 
 assert.equal(normalization.imagePathChanged, true)
 assert.equal(normalization.promptChanged, true)
@@ -90,6 +91,15 @@ assert.match(
   String(normalization.payload.promptString),
   new RegExp(defaultDirectionLead),
 )
+
+// The phrase substitution must never inject a casting instruction. It runs over
+// arbitrary prompts with no idea whether the subject is a person or a ladle, and
+// Krea 2 paints that clause literally. See artJobNormalization.ts.
+assert.doesNotMatch(
+  String(normalization.payload.promptString),
+  /cast the people who appear naturally/i,
+)
+assert.ok(!String(normalization.payload.promptString).includes(DEFAULT_CAST_ART_DIRECTION))
 
 const repaired = applyArtJobOverrides(structuredClone(payload), {
   promptString: strongPrompt,


### PR DESCRIPTION
## The bug

`DEFAULT_ASSET_ART_DIRECTION` welded a casting instruction onto the house style and appended the whole thing to every prompt that contained the phrase "Kind Robots visual style":

> detailed mature western animation with multidimensional worldbuilding, ... and clear readable silhouettes; **cast characters naturally across many species, ages, body sizes, body shapes, gender presentations, and levels of conventional attractiveness; include robots only when the subject or scene explicitly calls for them**

The second half is written for a reader who can evaluate a condition — "only when the subject or scene explicitly calls for them" only means something to something that reasons. Krea 2 is a distilled diffusion transformer with no instruction-following layer. It reads "characters ... many species, ages, body sizes, body shapes, gender presentations" as the densest concrete noun phrase in the prompt and paints exactly that.

On a prompt whose actual subject is inanimate, the crowd wins outright. The Reward `item-tidefortune-ladle` rendered as fifteen people and no ladle; 23 other Rewards came back the same way. Confirmed by decoding the prompt embedded in the rendered PNG's metadata.

## The change

Split the constant into three, so the casting decision is made by something that can actually make it:

| constant | when |
|---|---|
| `DEFAULT_ASSET_ART_STYLE` | always — medium and rendering only, safe for any subject |
| `DEFAULT_CAST_ART_DIRECTION` | opt-in, for frames that genuinely hold people |
| `DEFAULT_UNPEOPLED_ART_DIRECTION` | the counterweight for objects, products, landscapes, interfaces |

`replaceVagueArtDirection` now substitutes the **style only**. It runs over arbitrary prompt strings with no knowledge of whether the subject is a person, a ladle, or a dashboard, so it must not inject a cast. That is a deliberate trade: a missing diversity nudge on a legacy prompt is recoverable and invisible; a crowd standing in for the requested object is neither. Producers that know their subject opt in explicitly.

`conductorArtPrompt`'s LLM pass **can** evaluate the condition, so it is now told to decide up front and emit exactly one of the two clauses verbatim, never both — with a note explaining why the casting clause on an inanimate subject erases the object. Its non-LLM fallback defaults to unpeopled, which is right for the project, page, and product assets that path serves.

The unpeopled direction is phrased positively ("the subject stands alone with no bystanders") rather than as a negation, because Krea 2 runs at cfg 1 and the ComfyUI negative prompt is inert there — as `server/api/comfy/krea2/utils/workflow.ts` already notes. Every constraint has to survive inside the positive prompt.

## Testing

`utils/scripts/verifyArtPromptRepair.ts` keeps its existing assertions and gains one: the phrase substitution must never inject a casting instruction. Run via `npm run test:art-prompt-repair`.

I could not execute the TS verify scripts in this sandbox (no `node_modules`, and installing the full Nuxt toolchain risks the session's fixed disk allowance), so CI is the first real run of them. All call sites of the old constant were checked by grep and updated; the deprecated alias was removed rather than left in place, so any branch still importing it fails loudly at compile time instead of silently changing behaviour.

## Paired change

silasfelinus/conductor#1889 rewrites the daily-dream prompt builder to lead with physical subject description, backfills a required `look` field on all 26 affected Rewards, and drains the existing damage — 26 re-renders queued with the previous images preserved, 21 pending ArtJobs de-crowded or rebuilt. Safe to merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRr9oK8jpQKEd1sCM3NY1f

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRr9oK8jpQKEd1sCM3NY1f)_