### PR TITLE
Flip the card to edit it; give the Resource name room to actually read

### DIFF
--- a/components/gallery/kr-card-flip.vue
+++ b/components/gallery/kr-card-flip.vue
@@ -42,7 +42,7 @@
         viewport is only meaningful from the body.
       -->
       <div
-        v-if="modelValue"
+        v-if="visible"
         class="kr-flip-backdrop"
         :class="{ 'is-shown': shown }"
         @click="close"
@@ -51,14 +51,17 @@
           <div
             ref="panelRef"
             class="kr-flip-panel"
-            :class="{ 'is-shown': shown }"
+            :class="{
+              'is-shown': shown,
+              'is-dismissing': leaving && exitMode === 'dismiss',
+            }"
             role="dialog"
             aria-modal="true"
             :aria-label="label"
             tabindex="-1"
           >
             <div class="kr-flip-panel-scroll">
-              <slot name="back" :close="close" />
+              <slot name="back" :close="close" :commit="commit" />
             </div>
           </div>
         </div>
@@ -81,20 +84,80 @@ withDefaults(
 const modelValue = defineModel<boolean>({ default: false })
 
 const panelRef = ref<HTMLElement | null>(null)
+
 /*
- * `shown` trails `modelValue` by a frame ON PURPOSE. The panel mounts in its
- * pre-flip state (turned away and small) and only then gets the class that
- * animates it in -- mount it already-open and the browser has no previous
- * value to transition FROM, so the flip and the growth are both skipped and it
- * simply appears.
+ * TWO flags, not one, because the panel has to outlive `modelValue`.
+ *
+ *   visible  owns the v-if, so it is what MOUNTS the panel
+ *   shown    owns the animated class, so it is what MOVES it
+ *
+ * `shown` trails `visible` by a frame on the way in: the panel mounts turned
+ * away and small, and only then gets the class that animates it. Mount it
+ * already-open and the browser has no previous value to transition FROM, so
+ * the flip and the growth are both skipped and it simply appears.
+ *
+ * On the way OUT the order reverses and the gap is a whole transition rather
+ * than a frame -- `shown` goes false to play the turn backwards, and only when
+ * that has finished does `visible` unmount it. Silas, 2026-08-08: "we need to
+ * reverse the animation if the edit is okayed or canceled, or the user clicks
+ * outside the card." Driving the v-if straight off `modelValue` made the panel
+ * vanish instead, which is the one thing an animation like this cannot do --
+ * the point of turning a card over is that you saw it turn.
  */
+const visible = ref(false)
 const shown = ref(false)
+
+/*
+ * TWO WAYS OUT, because they mean different things. Silas, 2026-08-08:
+ * "clicking outside the card or canceling should probably just be a quick
+ * cancel, reverse might be appropriate if clicking to save the edit, as it's
+ * more of a grand choice."
+ *
+ *   dismiss  backdrop, Escape, Cancel -- nothing happened, so it just goes.
+ *            A shrink and a fade, no rotation, out of the way in 160ms.
+ *   commit   Save -- something happened, so the card turns back over and you
+ *            watch it land. 340ms, the entrance played backwards.
+ *
+ * Both numbers must stay in step with the stylesheet below: they decide when
+ * the panel unmounts, so a timer shorter than its CSS cuts the end off the
+ * animation, and one longer leaves a finished panel sitting over the page.
+ */
+type ExitMode = 'dismiss' | 'commit'
+
+const EXIT_MS: Record<ExitMode, number> = {
+  dismiss: 160,
+  commit: 340,
+}
+
+let exitTimer: ReturnType<typeof setTimeout> | null = null
+
+function clearExitTimer(): void {
+  if (exitTimer) clearTimeout(exitTimer)
+  exitTimer = null
+}
+
+const exitMode = ref<ExitMode>('dismiss')
+/*
+ * `leaving` exists so the dismiss styling applies ONLY during a real exit.
+ * Keying the class off `!shown` alone would also match the moment before the
+ * entrance, when the panel is deliberately sitting in its turned-away state --
+ * the quick-exit transform would overwrite that and the flip-in would be lost.
+ */
+const leaving = ref(false)
 
 function open(): void {
   modelValue.value = true
 }
 
+/** Nothing happened: Escape, the backdrop, Cancel. Quick. */
 function close(): void {
+  exitMode.value = 'dismiss'
+  modelValue.value = false
+}
+
+/** Something happened: the slot saved. Turn the card back over. */
+function commit(): void {
+  exitMode.value = 'commit'
   modelValue.value = false
 }
 
@@ -102,8 +165,19 @@ function onKeydown(event: KeyboardEvent): void {
   if (event.key === 'Escape') close()
 }
 
+function releasePage(): void {
+  document.removeEventListener('keydown', onKeydown)
+  document.body.style.overflow = ''
+}
+
 watch(modelValue, async (isOpen) => {
   if (isOpen) {
+    // Reopening mid-exit: cancel the pending unmount rather than letting it
+    // fire later and tear down a panel that is on its way back in.
+    clearExitTimer()
+
+    leaving.value = false
+    visible.value = true
     document.addEventListener('keydown', onKeydown)
     // The page behind must not scroll while a centred panel is up; otherwise
     // dismissing returns you somewhere other than where you opened it.
@@ -115,9 +189,21 @@ watch(modelValue, async (isOpen) => {
     return
   }
 
-  document.removeEventListener('keydown', onKeydown)
-  document.body.style.overflow = ''
+  // Scrolling is handed back at the START of the exit, not the end: the panel
+  // is already leaving and holding the page frozen for another third of a
+  // second reads as lag.
+  releasePage()
+  leaving.value = true
   shown.value = false
+
+  clearExitTimer()
+  exitTimer = setTimeout(() => {
+    // Re-check rather than trusting the timer: a reopen inside the window
+    // should win, and clearExitTimer alone cannot cover a race that resolved
+    // between the two.
+    if (!modelValue.value) visible.value = false
+    exitTimer = null
+  }, EXIT_MS[exitMode.value])
 })
 
 /*
@@ -125,8 +211,8 @@ watch(modelValue, async (isOpen) => {
  * unscrollable -- a navigation away with the panel open would lock the app.
  */
 onBeforeUnmount(() => {
-  document.removeEventListener('keydown', onKeydown)
-  document.body.style.overflow = ''
+  clearExitTimer()
+  releasePage()
 })
 </script>
 
@@ -181,14 +267,35 @@ onBeforeUnmount(() => {
   /* Turned away and small: the card is face-down and further off. */
   transform: rotateY(-180deg) scale(0.55);
   opacity: 0;
+  /*
+   * The COMMIT exit, and also the pre-entrance state -- an element transitions
+   * out through its own rule, and the `.is-shown` rule below overrides it on
+   * the way in. 340ms matches EXIT_MS.commit.
+   */
   transition:
-    transform 520ms cubic-bezier(0.4, 0.1, 0.2, 1),
-    opacity 260ms ease;
+    transform 340ms cubic-bezier(0.4, 0.1, 0.2, 1),
+    opacity 240ms ease;
+}
+
+/*
+ * The DISMISS exit. It has to override the turned-away transform above rather
+ * than share it: a cancel drops the card where it stands instead of rotating
+ * it, so the only movement is a slight shrink. 160ms matches EXIT_MS.dismiss.
+ */
+.kr-flip-panel.is-dismissing {
+  transform: scale(0.96);
+  opacity: 0;
+  transition:
+    transform 160ms ease-in,
+    opacity 160ms ease-in;
 }
 
 .kr-flip-panel.is-shown {
   transform: rotateY(0deg) scale(1);
   opacity: 1;
+  transition:
+    transform 520ms cubic-bezier(0.4, 0.1, 0.2, 1),
+    opacity 260ms ease;
 }
 
 /* The panel clips; this scrolls. `min-height: 0` is the load-bearing half --

--- a/components/gallery/kr-card-flip.vue
+++ b/components/gallery/kr-card-flip.vue
@@ -1,0 +1,215 @@
+<!-- /components/gallery/kr-card-flip.vue -->
+<!--
+  Turn a card over to reveal its editing surface.
+
+  WHY THIS EXISTS. Silas, 2026-08-08, of the Resource gallery: "selecting edit
+  just creates the edit window at the very top of the gallery, which is not
+  ideal. What should happen is ... selecting to edit the image should do a
+  flip-card effect ... and do a growth effect so it looks like it's closer to
+  the user, centered, and show us the editable info." He also asked for it as a
+  general gallery behaviour rather than a Resources one-off, "as I believe it
+  will take logic out of our galleries and towards the cards themselves".
+
+  So this owns the whole gesture -- backdrop, centring, the flip, the growth,
+  focus, Escape, scroll lock -- and a gallery supplies only the two faces.
+
+  WHAT IT DELIBERATELY DOES NOT OWN. No store, no fetch, no save. It is the
+  same split kr-gallery keeps and for the same reason: a shell that owns a
+  consequence cannot be reused by the next caller. `saved`/`close` stay the
+  caller's business; this just stops showing the back when asked.
+
+  NOT components/navigation/flip-card.vue, which already existed and is a
+  different animation: that one spins a full 360deg and lands back on its
+  front, as a transition for dealing a card into place. This one is stateful --
+  it turns to the back and STAYS there until dismissed -- so the two cannot be
+  collapsed. The 3D mechanics are the same family on purpose (perspective on a
+  stage, preserve-3d on the mover, backface-visibility on each face), and the
+  reduced-motion escape hatch is copied from it verbatim.
+-->
+<template>
+  <div class="contents">
+    <!-- The front stays exactly where the grid put it. Flipping must not
+         reflow the grid: a card that vacates its cell makes every sibling jump
+         at the moment the user is trying to look at one thing. -->
+    <slot :open="open" :is-open="modelValue" />
+
+    <Teleport to="body">
+      <!--
+        Teleported because the panel has to escape the gallery's scroll owner
+        and its stacking context. kr-gallery's toolbar is `sticky z-20` inside
+        that scroller, so a panel rendered in place would be clipped by the
+        scroll container and could sit UNDER the toolbar. Centring on the
+        viewport is only meaningful from the body.
+      -->
+      <div
+        v-if="modelValue"
+        class="kr-flip-backdrop"
+        :class="{ 'is-shown': shown }"
+        @click="close"
+      >
+        <div class="kr-flip-stage" @click.stop>
+          <div
+            ref="panelRef"
+            class="kr-flip-panel"
+            :class="{ 'is-shown': shown }"
+            role="dialog"
+            aria-modal="true"
+            :aria-label="label"
+            tabindex="-1"
+          >
+            <div class="kr-flip-panel-scroll">
+              <slot name="back" :close="close" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { nextTick, onBeforeUnmount, ref, watch } from 'vue'
+
+withDefaults(
+  defineProps<{
+    /** Accessible name for the dialog; say what is being edited. */
+    label?: string
+  }>(),
+  { label: 'Edit' },
+)
+
+const modelValue = defineModel<boolean>({ default: false })
+
+const panelRef = ref<HTMLElement | null>(null)
+/*
+ * `shown` trails `modelValue` by a frame ON PURPOSE. The panel mounts in its
+ * pre-flip state (turned away and small) and only then gets the class that
+ * animates it in -- mount it already-open and the browser has no previous
+ * value to transition FROM, so the flip and the growth are both skipped and it
+ * simply appears.
+ */
+const shown = ref(false)
+
+function open(): void {
+  modelValue.value = true
+}
+
+function close(): void {
+  modelValue.value = false
+}
+
+function onKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') close()
+}
+
+watch(modelValue, async (isOpen) => {
+  if (isOpen) {
+    document.addEventListener('keydown', onKeydown)
+    // The page behind must not scroll while a centred panel is up; otherwise
+    // dismissing returns you somewhere other than where you opened it.
+    document.body.style.overflow = 'hidden'
+
+    await nextTick()
+    shown.value = true
+    panelRef.value?.focus()
+    return
+  }
+
+  document.removeEventListener('keydown', onKeydown)
+  document.body.style.overflow = ''
+  shown.value = false
+})
+
+/*
+ * Unmounting mid-flip would otherwise leave the listener attached and the body
+ * unscrollable -- a navigation away with the panel open would lock the app.
+ */
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', onKeydown)
+  document.body.style.overflow = ''
+})
+</script>
+
+<style scoped>
+.kr-flip-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: oklch(0% 0 0 / 0.55);
+  opacity: 0;
+  transition: opacity 260ms ease;
+}
+
+.kr-flip-backdrop.is-shown {
+  opacity: 1;
+}
+
+/* Perspective belongs to the STAGE, not the mover: on the mover it would be
+   recomputed as the element scales, which reads as a wobble rather than a
+   turn. */
+.kr-flip-stage {
+  perspective: 1600px;
+  display: flex;
+  width: 100%;
+  max-width: 44rem;
+  /*
+   * `100%` of the backdrop, NOT a dvh. The backdrop is `fixed; inset: 0` with
+   * 1rem of padding, so its content box already IS the viewport less the
+   * gutter -- and verifyLayoutContract forbids viewport units nested inside
+   * the h-dvh shell, which caught the `calc(100dvh - 2rem)` this replaced.
+   */
+  max-height: 100%;
+  align-items: center;
+  justify-content: center;
+}
+
+.kr-flip-panel {
+  display: flex;
+  width: 100%;
+  min-height: 0;
+  max-height: 100%;
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: 1.5rem;
+  background: var(--color-base-100, #fff);
+  box-shadow: 0 25px 60px oklch(0% 0 0 / 0.45);
+  transform-style: preserve-3d;
+  /* Turned away and small: the card is face-down and further off. */
+  transform: rotateY(-180deg) scale(0.55);
+  opacity: 0;
+  transition:
+    transform 520ms cubic-bezier(0.4, 0.1, 0.2, 1),
+    opacity 260ms ease;
+}
+
+.kr-flip-panel.is-shown {
+  transform: rotateY(0deg) scale(1);
+  opacity: 1;
+}
+
+/* The panel clips; this scrolls. `min-height: 0` is the load-bearing half --
+   a flex child defaults to `min-height: auto`, which refuses to shrink below
+   its content, so without it a long edit form pushes the panel past the
+   viewport instead of scrolling inside it. */
+.kr-flip-panel-scroll {
+  min-height: 0;
+  flex: 1;
+  overflow-y: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .kr-flip-panel,
+  .kr-flip-backdrop {
+    transition: none;
+  }
+
+  .kr-flip-panel {
+    transform: none;
+    opacity: 1;
+  }
+}
+</style>

--- a/components/resources/resource-card.vue
+++ b/components/resources/resource-card.vue
@@ -63,24 +63,50 @@
       </div>
 
       <div class="flex flex-1 flex-col gap-2 p-3">
-        <h3 class="line-clamp-2 text-base font-black leading-tight">
+        <!--
+          THE NAME GETS THE ROOM. Silas, 2026-08-08: "it was the actual title
+          that was cut off, so most of the time I could only see a fraction of
+          what the Lora was."
+
+          Two things made a two-line clamp fail on this catalog. Imported names
+          are long -- "[Exp] 每日渲染（风格）| Daily Render Style", "[LoRA]
+          Jellyfish forest / 水月森 / くらげの森" -- and they open with a
+          bracketed or underscored prefix ([LoRA], (color), _MOHAWK_) that is
+          the same across dozens of rows. So the clamp spent the visible lines
+          on the part that does not distinguish anything and elided the part
+          that does, which is why a grid of them reads as near-identical.
+
+          Three lines at `text-sm` holds roughly double the characters of two
+          at `text-base` while still reading as the heading. `break-words` is
+          for the unbroken runs ("_MOHAWK_Add_//COMICS"), which otherwise
+          overflow instead of wrapping.
+
+          Still CLAMPED, not free: kr-gallery's grid rows size to their tallest
+          card, so one pathological name would add height to every card on the
+          page. The clamp only hides overflow -- the full string stays in the
+          DOM for screen readers, `title` gives it back on hover, and the flip
+          side shows it in full.
+        -->
+        <h3
+          class="line-clamp-3 break-words text-sm font-black leading-snug"
+          :title="label"
+        >
           {{ label }}
         </h3>
 
         <!--
-          THE TRIGGER IS THE IDENTITY, so it is always on the card.
+          The trigger is the word you type to activate a LoRA, and it used to
+          live in an `opacity-0 ... group-hover:opacity-100` panel over the
+          artwork -- so on a touch screen it could not be read at all. Putting
+          it on the card costs nothing a hover was giving anyone.
 
-          It used to live in an `opacity-0 ... group-hover:opacity-100` panel
-          over the artwork. On a touch screen there is no hover, so the one
-          field that says what a LoRA actually DOES was unreachable -- which is
-          exactly what Silas reported from a tablet on 2026-08-08: "not enough
-          of the title info that we need, so I really can't tell what each lora
-          is meant to be." A reveal-on-hover affordance for the primary
-          identifying text is a desktop assumption, not a layout tweak.
+          ONE line, not two. It competes with the name for the same column, and
+          the name is what Silas could not read; clamping the trigger tighter
+          is how the title got its third line without the card growing.
         -->
         <p
           v-if="triggerText"
-          class="line-clamp-2 rounded-lg bg-base-200/70 px-2 py-1 font-mono text-xs leading-snug text-base-content/80"
+          class="line-clamp-1 rounded-lg bg-base-200/70 px-2 py-1 font-mono text-xs text-base-content/80"
           :title="triggerText"
         >
           {{ triggerText }}

--- a/components/resources/resource-card.vue
+++ b/components/resources/resource-card.vue
@@ -209,14 +209,14 @@
       </div>
     </article>
 
-    <template #back="{ close }">
+    <template #back="{ close, commit }">
       <!--
         The gallery fills this. The card knows the gesture, not the form: which
         editor a Resource needs (add-model vs add-lora) and what saving means
         are both store work, and this file stays fixture-mountable by not
         knowing either.
       -->
-      <slot name="edit" :resource="resource" :close="close" />
+      <slot name="edit" :resource="resource" :close="close" :commit="commit" />
     </template>
   </kr-card-flip>
 </template>

--- a/components/resources/resource-card.vue
+++ b/components/resources/resource-card.vue
@@ -2,26 +2,28 @@
 <!--
   One Resource (checkpoint, LoRA, LyCORIS) as a card.
 
-  Extracted from resource-gallery.vue when that grid moved onto kr-gallery.
-  The markup is unchanged; it needed an owner because a card inlined in an
-  `#item` slot reaches its record back through the slot's GalleryItem, and
-  every one of the ~20 references would have become
-  `resourceById.get(Number(item.id))!`.
+  Extracted from resource-gallery.vue when that grid moved onto kr-gallery. It
+  needed an owner because a card inlined in an `#item` slot reaches its record
+  back through the slot's GalleryItem, and every one of the ~20 references
+  would have become `resourceById.get(Number(item.id))!`.
 
   WHAT MOVED AND WHAT DID NOT. previewSrc and isEditable came with it -- pure
-  functions of the record, so they belong to the thing that draws it. The five
-  actions did NOT: generating a preview, uploading one, editing, and pushing a
-  Resource into the art build all reach stores and APIs, so they are emits and
-  the gallery decides what they mean. Same split the entity cards use, for the
-  same reason -- a card that owns the consequence cannot be reused or exhibited.
+  functions of the record, so they belong to the thing that draws it. The
+  build/preview actions did NOT: they reach stores and APIs, so they are emits
+  and the gallery decides what they mean. Same split the entity cards use, for
+  the same reason -- a card that owns the consequence cannot be reused or
+  exhibited.
 
-  `label` and `triggerText` are the card's own copies. The gallery keeps its
-  versions because the GENERATION path still needs them to build a prompt and
-  choose checkpoint vs LoRA, which is store work. Duplicated deliberately: the
-  alternative is the card importing from the gallery it is rendered by.
+  EDITING IS THE EXCEPTION, and only in placement. The card now owns the
+  GESTURE (kr-card-flip: turn over, grow, centre) while the gallery still owns
+  the FORM, handed in through the `edit` slot. Silas, 2026-08-08: "selecting
+  edit just creates the edit window at the very top of the gallery, which is
+  not ideal ... I believe it will take logic out of our galleries and towards
+  the cards themselves." The animation and the dialog plumbing are now the
+  card's; the save path is still the gallery's.
 
-  The two busy flags are props rather than looked up, so this stays mountable in
-  WonderLab from a plain fixture.
+  The two busy flags are props rather than looked up, so this stays mountable
+  in WonderLab from a plain fixture.
 
   NOT in verifyCardActionContract's ENTITY_CARDS: a Resource has no interact
   surface to `open`. Its primary actions are "add to build" and "start fresh",
@@ -29,113 +31,172 @@
   inventing an `open` with nowhere to go.
 -->
 <template>
-  <article
-    class="group flex min-h-[430px] flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
-  >
-    <div class="relative aspect-square overflow-hidden bg-base-200">
-      <img
-        :src="previewSrc"
-        :alt="label"
-        class="h-full w-full object-cover transition duration-300 group-hover:scale-[1.02]"
-        loading="lazy"
-      />
+  <kr-card-flip v-model="editOpen" :label="`Edit ${label}`">
+    <article
+      class="group flex h-full flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
+    >
+      <!--
+        IDENTITY OVERLAYS THE ART, per Silas 2026-08-08: "we should have the
+        image, the type and model info at top and overlaid is cool." Type and
+        base model are the two facts that never repeat below, which is what
+        makes them safe to put here.
+      -->
+      <div class="relative aspect-square shrink-0 overflow-hidden bg-base-200">
+        <img
+          :src="previewSrc"
+          :alt="label"
+          class="h-full w-full object-cover transition duration-300 group-hover:scale-[1.02]"
+          loading="lazy"
+        />
 
-      <div class="absolute left-2 top-2 flex flex-wrap gap-1">
-        <span class="badge badge-primary badge-sm">
-          {{ resource.resourceType }}
-        </span>
-        <span v-if="resource.generation" class="badge badge-neutral badge-sm">
-          {{ resource.generation }}
-        </span>
-        <span v-if="resource.isMature" class="badge badge-error badge-sm">
-          18+
-        </span>
+        <div class="absolute left-2 top-2 flex flex-wrap gap-1">
+          <span class="badge badge-primary badge-sm">
+            {{ resource.resourceType }}
+          </span>
+          <span v-if="resource.generation" class="badge badge-neutral badge-sm">
+            {{ resource.generation }}
+          </span>
+          <span v-if="resource.isMature" class="badge badge-error badge-sm">
+            18+
+          </span>
+        </div>
       </div>
 
-      <div
-        v-if="triggerText"
-        class="absolute inset-x-2 bottom-2 translate-y-2 rounded-2xl bg-base-100/95 p-2 text-xs opacity-0 shadow transition group-hover:translate-y-0 group-hover:opacity-100"
-      >
-        <span class="font-semibold">Trigger:</span>
-        {{ triggerText }}
-      </div>
-    </div>
-
-    <div class="flex flex-1 flex-col gap-3 p-4">
-      <div>
-        <h3 class="line-clamp-2 text-lg font-bold">
+      <div class="flex flex-1 flex-col gap-2 p-3">
+        <h3 class="line-clamp-2 text-base font-black leading-tight">
           {{ label }}
         </h3>
-        <p class="mt-1 line-clamp-3 text-sm text-base-content/65">
-          {{ resource.description || 'No description yet.' }}
-        </p>
-      </div>
 
-      <div class="flex flex-wrap gap-1 text-xs">
-        <span class="badge badge-outline badge-sm">
+        <!--
+          THE TRIGGER IS THE IDENTITY, so it is always on the card.
+
+          It used to live in an `opacity-0 ... group-hover:opacity-100` panel
+          over the artwork. On a touch screen there is no hover, so the one
+          field that says what a LoRA actually DOES was unreachable -- which is
+          exactly what Silas reported from a tablet on 2026-08-08: "not enough
+          of the title info that we need, so I really can't tell what each lora
+          is meant to be." A reveal-on-hover affordance for the primary
+          identifying text is a desktop assumption, not a layout tweak.
+        -->
+        <p
+          v-if="triggerText"
+          class="line-clamp-2 rounded-lg bg-base-200/70 px-2 py-1 font-mono text-xs leading-snug text-base-content/80"
+          :title="triggerText"
+        >
+          {{ triggerText }}
+        </p>
+
+        <!--
+          Only PROSE survives here. The import writes descriptions like
+          "base: SD 1.5 | module: networks.lora | detected via civitai", which
+          restates the two badges overlaying the artwork and then adds where it
+          was scraped from -- three lines of card spent saying nothing the eye
+          has not already read. Silas: "too much text, especially repetitive
+          stuff". `isMachineDescription` drops those and keeps real ones.
+        -->
+        <p
+          v-if="humanDescription"
+          class="line-clamp-2 text-xs text-base-content/60"
+        >
+          {{ humanDescription }}
+        </p>
+
+        <!--
+          `supportedServer` renders ONLY when it is not already overhead: it
+          carries values like "SD15" beside a "SD 1.5" badge two inches up.
+          Compared with separators and case stripped, so SD15/SD 1.5 and
+          Flux.1 D/flux1-d collapse rather than sneaking through.
+        -->
+        <span
+          v-if="showsServerBadge"
+          class="badge badge-outline badge-xs w-fit"
+        >
           {{ resource.supportedServer }}
         </span>
-        <!-- The "N checkpoint uses / N LoRA uses" badges lived here. They cost
-             two correlated aggregates per row on the catalog list query and
-             read 0 on every card; see the note on resourceGallerySelect. -->
-      </div>
 
-      <div class="mt-auto grid grid-cols-2 gap-2">
-        <button
-          type="button"
-          class="btn btn-primary btn-sm rounded-2xl"
-          @click="emit('add-to-build', resource)"
-        >
-          Add to build
-        </button>
-        <button
-          type="button"
-          class="btn btn-secondary btn-sm rounded-2xl"
-          @click="emit('start-fresh', resource)"
-        >
-          Start fresh
-        </button>
-        <button
-          type="button"
-          class="btn btn-outline btn-sm rounded-2xl"
-          :disabled="generatingPreview"
-          @click="emit('generate-preview', resource)"
-        >
-          <span
-            v-if="generatingPreview"
-            class="loading loading-spinner loading-xs"
-          />
-          Generate preview
-        </button>
-        <button
-          type="button"
-          class="btn btn-ghost btn-sm rounded-2xl"
-          :disabled="uploadingPreview"
-          @click="emit('upload-preview', resource)"
-        >
-          <span
-            v-if="uploadingPreview"
-            class="loading loading-spinner loading-xs"
-          />
-          Upload preview
-        </button>
-      </div>
+        <div class="mt-auto flex flex-col gap-1.5 pt-1">
+          <div class="grid grid-cols-2 gap-1.5">
+            <button
+              type="button"
+              class="btn btn-primary btn-xs rounded-xl"
+              @click="emit('add-to-build', resource)"
+            >
+              Add to build
+            </button>
+            <button
+              type="button"
+              class="btn btn-secondary btn-xs rounded-xl"
+              @click="emit('start-fresh', resource)"
+            >
+              Start fresh
+            </button>
+          </div>
 
-      <button
-        v-if="isEditable"
-        type="button"
-        class="btn btn-ghost btn-sm rounded-2xl"
-        @click="emit('edit', resource)"
-      >
-        <icon name="kind-icon:edit" class="h-4 w-4" />
-        Edit
-      </button>
-    </div>
-  </article>
+          <!--
+            The preview pair and Edit are secondary, so they are icon buttons
+            on one line rather than two more full-width rows. Five stacked
+            call-to-actions made every card taller than its own artwork.
+          -->
+          <div class="flex items-center gap-1.5">
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs flex-1 rounded-xl"
+              :disabled="generatingPreview"
+              title="Generate preview"
+              @click="emit('generate-preview', resource)"
+            >
+              <span
+                v-if="generatingPreview"
+                class="loading loading-spinner loading-xs"
+              />
+              <Icon v-else name="kind-icon:sparkles" class="h-3.5 w-3.5" />
+              Preview
+            </button>
+
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs flex-1 rounded-xl"
+              :disabled="uploadingPreview"
+              title="Upload preview"
+              @click="emit('upload-preview', resource)"
+            >
+              <span
+                v-if="uploadingPreview"
+                class="loading loading-spinner loading-xs"
+              />
+              <Icon v-else name="kind-icon:upload" class="h-3.5 w-3.5" />
+              Upload
+            </button>
+
+            <button
+              v-if="isEditable"
+              type="button"
+              class="btn btn-ghost btn-xs rounded-xl"
+              title="Edit this Resource"
+              aria-label="Edit this Resource"
+              @click="startEdit"
+            >
+              <Icon name="kind-icon:edit" class="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </article>
+
+    <template #back="{ close }">
+      <!--
+        The gallery fills this. The card knows the gesture, not the form: which
+        editor a Resource needs (add-model vs add-lora) and what saving means
+        are both store work, and this file stays fixture-mountable by not
+        knowing either.
+      -->
+      <slot name="edit" :resource="resource" :close="close" />
+    </template>
+  </kr-card-flip>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import type { ResourceGalleryRecord } from '@/stores/resourceGalleryStore'
 
 const EDITABLE_TYPES = ['CHECKPOINT', 'LORA', 'LYCORIS']
@@ -160,6 +221,18 @@ const emit = defineEmits<{
   'upload-preview': [resource: ResourceGalleryRecord]
 }>()
 
+const editOpen = ref(false)
+
+/*
+ * Still emits `edit`. The gallery no longer has to POSITION anything, but it
+ * may still want to know (to mark a row dirty, to close a sibling), and
+ * removing the emit would be a silent contract break for any other host.
+ */
+function startEdit(): void {
+  editOpen.value = true
+  emit('edit', props.resource)
+}
+
 const previewSrc = computed(
   () =>
     props.resource.ArtImage?.thumbnailPath ||
@@ -179,6 +252,58 @@ const triggerText = computed(
     props.resource.artPrompt ||
     '',
 )
+
+/**
+ * True for import-written metadata masquerading as a description --
+ * "base: SD 1.5 | module: networks.lora | detected via civitai".
+ *
+ * Structural rather than a list of known prefixes: what makes a string a
+ * record of fields instead of a sentence is that its pipe-separated segments
+ * are `label: value`.
+ *
+ * A MAJORITY, not all of them. Requiring every segment to be fielded looked
+ * tidier and was wrong on the exact strings this exists for: the real ones end
+ * "| detected via civitai", which has no colon, so an `every` test returned
+ * false and let the whole boilerplate through. Caught by running it over the
+ * strings in Silas's 2026-08-08 report rather than reasoning about it.
+ *
+ * The floor of two fielded segments is deliberate slack in the safe direction:
+ * "trigger: ranni | best at 0.7" is half prose and stays visible. Hiding a
+ * real description is a worse failure than keeping a dull one.
+ */
+function isMachineDescription(text: string): boolean {
+  const segments = text
+    .split('|')
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+
+  if (segments.length < 2) return false
+
+  const fielded = segments.filter((segment) =>
+    /^[\w ]{2,24}:\s*\S/.test(segment),
+  ).length
+
+  return fielded >= 2 && fielded * 2 >= segments.length
+}
+
+const humanDescription = computed(() => {
+  const text = (props.resource.description || '').trim()
+  if (!text || isMachineDescription(text)) return ''
+  return text
+})
+
+/** Separators and case removed, so "SD 1.5" and "SD15" compare equal. */
+function normalizeModelToken(value: unknown): string {
+  return String(value ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '')
+}
+
+const showsServerBadge = computed(() => {
+  const server = normalizeModelToken(props.resource.supportedServer)
+  if (!server) return false
+  return server !== normalizeModelToken(props.resource.generation)
+})
 
 const isEditable = computed(() =>
   EDITABLE_TYPES.includes(String(props.resource.resourceType)),

--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -582,17 +582,17 @@ onMounted(async () => {
             state to keep in sync any more. Which editor a Resource needs is
             still decided here, because that is store-shaped knowledge.
           -->
-          <template #edit="{ resource, close }">
+          <template #edit="{ resource, close, commit }">
             <add-model
               v-if="resource.resourceType === RESOURCE_TYPE.CHECKPOINT"
               :model="resource"
-              @saved="(saved: Resource) => handleSaved(saved, close)"
+              @saved="(saved: Resource) => handleSaved(saved, commit)"
               @close="close"
             />
             <add-lora
               v-else
               :lora="resource"
-              @saved="(saved: Resource) => handleSaved(saved, close)"
+              @saved="(saved: Resource) => handleSaved(saved, commit)"
               @close="close"
             />
           </template>

--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -61,7 +61,6 @@ const activeUploadResourceId = ref<number | null>(null)
 const showAddChoice = ref(false)
 const showForm = ref(false)
 const formKind = ref<'CHECKPOINT' | 'LORA'>('CHECKPOINT')
-const editing = ref<Partial<Resource> | null>(null)
 
 function openAddChoice(): void {
   showAddChoice.value = true
@@ -69,26 +68,30 @@ function openAddChoice(): void {
 
 function startAdd(kind: 'CHECKPOINT' | 'LORA'): void {
   formKind.value = kind
-  editing.value = null
   showAddChoice.value = false
-  showForm.value = true
-}
-
-function openEdit(resource: ResourceGalleryRecord): void {
-  formKind.value =
-    resource.resourceType === RESOURCE_TYPE.CHECKPOINT ? 'CHECKPOINT' : 'LORA'
-  editing.value = resource
   showForm.value = true
 }
 
 function closeForm(): void {
   showForm.value = false
   showAddChoice.value = false
-  editing.value = null
 }
 
-async function handleSaved(resource: Resource): Promise<void> {
+/*
+ * `done` is the closer for whichever surface is open: the Add panel passes
+ * none and falls back to closeForm, while a flipped card passes its own
+ * `close` so the card turns back over instead of the panel state changing
+ * underneath a dialog that is not on screen.
+ */
+async function handleSaved(
+  resource: Resource,
+  done?: () => void,
+): Promise<void> {
   await resourceGalleryStore.getResource(resource.id)
+  if (done) {
+    done()
+    return
+  }
   closeForm()
 }
 
@@ -431,15 +434,18 @@ onMounted(async () => {
       </div>
     </div>
 
+    <!--
+      ADD only. Editing an existing Resource flips its own card (see the `edit`
+      slot on resource-card below); this pair is reached from the Add button,
+      where there is no card to turn over yet, so it stays a panel.
+    -->
     <add-model
       v-if="showForm && formKind === 'CHECKPOINT'"
-      :model="editing"
       @saved="handleSaved"
       @close="closeForm"
     />
     <add-lora
       v-if="showForm && formKind === 'LORA'"
-      :lora="editing"
       @saved="handleSaved"
       @close="closeForm"
     />
@@ -559,12 +565,38 @@ onMounted(async () => {
           :resource="resourceById.get(Number(item.id))!"
           :generating-preview="activePreviewResourceId === Number(item.id)"
           :uploading-preview="activeUploadResourceId === Number(item.id)"
-          @edit="openEdit"
           @add-to-build="addToGeneration"
           @start-fresh="startGeneration"
           @generate-preview="generatePreview"
           @upload-preview="choosePreviewFile"
-        />
+        >
+          <!--
+            The editor rides the BACK OF THE CARD now. It used to render up at
+            the top of the page from a gallery-level `showForm`/`editing` pair,
+            so editing the last row scrolled you away from it -- Silas,
+            2026-08-08: "selecting edit just creates the edit window at the very
+            top of the gallery, which is not ideal."
+
+            The card owns the gesture and hands the record back through the
+            slot, so there is no gallery-level "which one is being edited"
+            state to keep in sync any more. Which editor a Resource needs is
+            still decided here, because that is store-shaped knowledge.
+          -->
+          <template #edit="{ resource, close }">
+            <add-model
+              v-if="resource.resourceType === RESOURCE_TYPE.CHECKPOINT"
+              :model="resource"
+              @saved="(saved: Resource) => handleSaved(saved, close)"
+              @close="close"
+            />
+            <add-lora
+              v-else
+              :lora="resource"
+              @saved="(saved: Resource) => handleSaved(saved, close)"
+              @close="close"
+            />
+          </template>
+        </resource-card>
       </template>
 
       <template #empty>

--- a/utils/scripts/verifyLayoutContract.ts
+++ b/utils/scripts/verifyLayoutContract.ts
@@ -78,6 +78,28 @@ const RULE_TITLES: Record<RuleId, string> = {
 
 /* screenfx is full-viewport effect canvases by design — genuinely exempt. */
 const VIEWPORT_EXEMPT = ['components/screenfx/', 'components/butterfly/']
+
+/**
+ * Source with comments removed, for the rules that scan raw text rather than
+ * the tokenizer's element stream.
+ *
+ * MENTION IS NOT USE. `no-viewport` tested the whole file, so a comment
+ * SAYING the words tripped it -- kr-card-flip.vue was flagged in 2026-08-08
+ * for a CSS comment reading "`100%` of the backdrop, NOT a dvh ...
+ * verifyLayoutContract forbids viewport units", i.e. for documenting its own
+ * compliance. The template rules never had this problem because the tokenizer
+ * already skips `<!-- -->`; this rule was the one reading `source` directly.
+ *
+ * `//` needs the negative lookbehind or every `https://` in a file becomes the
+ * start of a comment and everything after it on the line disappears.
+ */
+function codeOf(source: string): string {
+  return source
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/(?<!:)\/\/[^\n]*/g, ' ')
+}
+
 const SKIP_DIRS = new Set([
   'node_modules',
   '.nuxt',
@@ -802,7 +824,10 @@ function collect(): Record<RuleId, string[]> {
     }
 
     const exempt = VIEWPORT_EXEMPT.some((prefix) => r.startsWith(prefix))
-    if (!exempt && /\b(h-screen|min-h-screen)\b|100vh|100dvh/.test(source)) {
+    if (
+      !exempt &&
+      /\b(h-screen|min-h-screen)\b|100vh|100dvh/.test(codeOf(source))
+    ) {
       violations['no-viewport'].push(r)
     }
 

--- a/wonderlab-rollout-artifacts/component-contract-verification.json
+++ b/wonderlab-rollout-artifacts/component-contract-verification.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": 1,
   "baseUrl": "https://kind-robots.vercel.app",
-  "checkedAt": "2026-08-08T10:06:06.174Z",
+  "checkedAt": "2026-08-08T10:41:18.842Z",
   "recordCount": 489,
   "canonicalStatusRecordCount": 489,
   "discoveredCount": 420,

--- a/wonderlab-rollout-artifacts/component-contract-verification.json
+++ b/wonderlab-rollout-artifacts/component-contract-verification.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": 1,
   "baseUrl": "https://kind-robots.vercel.app",
-  "checkedAt": "2026-08-08T10:41:18.842Z",
+  "checkedAt": "2026-08-08T10:54:17.694Z",
   "recordCount": 489,
   "canonicalStatusRecordCount": 489,
   "discoveredCount": 420,

--- a/wonderlab-rollout-artifacts/component-contract-verification.json
+++ b/wonderlab-rollout-artifacts/component-contract-verification.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": 1,
   "baseUrl": "https://kind-robots.vercel.app",
-  "checkedAt": "2026-08-08T10:54:17.694Z",
+  "checkedAt": "2026-08-08T11:25:05.326Z",
   "recordCount": 489,
   "canonicalStatusRecordCount": 489,
   "discoveredCount": 420,


### PR DESCRIPTION
> "too much text, especially repetitive stuff, and not enough of the title info that we need, so I really can't tell what each lora is meant to be. also. selecting edit just creates the edit window at the very top of the gallery, which is not ideal … selecting to edit the image should do a flip-card effect … and do a growth effect so it looks like it's closer to the user, centered."
>
> …and the follow-up: *"It's not trigger words I was referring to, it was the actual title that was cut off, so most of the time I could only see a fraction of what the Lora was."*

## The name gets the room

Two things made a two-line clamp fail on this catalog:

- Imported names are long — `[Exp] 每日渲染（风格）| Daily Render Style`, `[LoRA] Jellyfish forest / 水月森 / くらげの森`
- They open with a bracketed or underscored prefix — `[LoRA]`, `(color)`, `_MOHAWK_` — that repeats across dozens of rows

So the clamp spent both visible lines on the part that distinguishes **nothing** and elided the part that does. That's why a screen of them reads as near-identical.

The name now gets **three lines at `text-sm`** — roughly double the characters of two at `text-base`, still reading as the heading — plus `break-words` for unbroken runs like `_MOHAWK_Add_//COMICS` that overflowed rather than wrapping, and a `title` for the full string on hover.

Still clamped rather than free: `kr-gallery`'s grid rows size to their tallest card, so one pathological name would add height to every card on the page.

The room came from the trigger line, which drops from two clamped lines to one.

## What else went, and why each was noise

| removed | reason |
| --- | --- |
| the description, when it's import boilerplate | `base: SD 1.5 \| module: networks.lora \| detected via civitai` restates the two badges overlaying the artwork, then names the scraper |
| the `supportedServer` badge, when it duplicates the base model | it renders `SD15` directly under an `SD 1.5` badge |
| two of five stacked full-width buttons | Preview and Upload now share a line, Edit is an icon — a card is no longer taller than its own art |

`isMachineDescription` is structural rather than a list of known prefixes: a **majority** of pipe-separated `label: value` segments. Real prose survives.

**I got that wrong first and caught it by testing.** My initial version required *every* segment to be fielded, which looked tidier and failed on the exact strings it exists for — the real ones end `| detected via civitai`, which has no colon, so `every` returned false and the whole boilerplate would have rendered anyway.

The trigger words also move out of a hover-only panel and onto the card — on a touch screen they couldn't be read at all — but at one line, since the name is what needed the space.

Image, type and base model stay overlaid on the art, per the brief.

## The flip

New `components/gallery/kr-card-flip.vue` owns the whole gesture — backdrop, centring, the turn, the growth, focus, Escape, scroll lock.

Deliberately **not** `components/navigation/flip-card.vue`, which already existed and is a different animation: that one spins a full 360° and lands back on its front, as a transition for dealing a card into place. This one is stateful — it turns to the back and *stays* there. Same 3D mechanics on purpose, and the reduced-motion escape hatch is copied verbatim.

It teleports to the body because `kr-gallery`'s toolbar is `sticky z-20` inside the scroll owner — a panel rendered in place would be clipped by that scroller and could sit *under* the toolbar.

### Where the logic landed

Per the ask — *"I believe it will take logic out of our galleries and towards the cards themselves"*:

- **The card owns the gesture.** `resource-card` wraps itself in `kr-card-flip`.
- **The gallery still owns the form**, handed in through an `edit` slot.

`resource-gallery` loses `editing` and `openEdit` **entirely** — there's no "which one is being edited" state left to keep in sync. Which editor a Resource needs stays with the gallery, because that's store-shaped knowledge, and the card stays fixture-mountable in WonderLab by not knowing it.

`add-model`/`add-lora` still render as a panel for the **Add** flow, where there's no card to turn over yet.

## Also fixed: a mention-vs-use bug in the layout contract

`no-viewport` tested the raw file, so a comment *saying* `100dvh` tripped it — `kr-card-flip` was flagged for a CSS comment documenting that it avoids viewport units. The template rules never had this problem because the tokenizer already skips `<!-- -->`; this rule was the one reading `source` directly.

It now strips comments first. The `//` pass needs a negative lookbehind or every `https://` eats the rest of its line.

**Verified by mutation**, not assumed: injected a real `100dvh` into the CSS → rule fails; removed it → clean.

## Verification

- `npm run test` (vue-tsc) — clean
- `npx eslint` + `npx prettier` on all changed files — clean
- Swept **193 verification commands across all 57 workflow files**. 188 pass; the same 5 fail as on an unmodified tree, all Prisma pool timeouts (`P2039`) from the sandbox having no DB egress.