### PR TITLE
fix(art): describe an art slot by its shape, not by naming it

### DIFF
--- a/.github/workflows/entity-art-manager-contract.yml
+++ b/.github/workflows/entity-art-manager-contract.yml
@@ -27,6 +27,9 @@ on:
       - 'server/utils/entityArt.ts'
       - 'utils/scripts/verifyArtQueueClaimFastPath.ts'
       - 'utils/scripts/verifyEntityArtManager.ts'
+      - 'utils/entityArtPromptFraming.ts'
+      - 'stores/dailyDreamArchiveStore.ts'
+      - 'utils/scripts/verifyEntityArtPromptFraming.ts'
       - 'utils/scripts/verifyDailyDreamArchiveWorkbench.ts'
       - 'utils/scripts/verifyEntityArtPromptSuggest.ts'
       - 'utils/scripts/verifyProjectArtPromptSuggest.ts'
@@ -48,6 +51,7 @@ jobs:
       - run: npx prisma generate
       - run: npx tsx utils/scripts/verifyArtQueueClaimFastPath.ts
       - run: npx tsx utils/scripts/verifyEntityArtManager.ts
+      - run: npx tsx utils/scripts/verifyEntityArtPromptFraming.ts
       - run: npx tsx utils/scripts/verifyDailyDreamArchiveWorkbench.ts
       - run: npx tsx utils/scripts/verifyEntityArtPromptSuggest.ts
       - run: npx tsx utils/scripts/verifyProjectArtPromptSuggest.ts

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "generate:achievement-art": "tsx scripts/generate_achievement_art.ts",
     "test:art-request-yaml": "tsx utils/scripts/verifyArtRequestYaml.ts && tsx utils/scripts/verifyArtAssetSuggest.ts",
     "test:art-prompt-repair": "tsx utils/scripts/verifyArtPromptRepair.ts",
+    "test:entity-art-prompt-framing": "tsx utils/scripts/verifyEntityArtPromptFraming.ts",
     "test:art-asset-suggest": "tsx utils/scripts/verifyArtAssetSuggest.ts",
     "test:artjob-bulk-scope": "tsx utils/scripts/verifyArtJobBulkScope.ts && tsx utils/scripts/verifyArtJobBulkCancel.ts",
     "test:artjob-lora-override": "tsx utils/scripts/verifyArtJobLoraOverride.ts",

--- a/server/utils/entityArt.ts
+++ b/server/utils/entityArt.ts
@@ -10,6 +10,10 @@ import type {
   Prisma,
   PrismaClient,
 } from '~/prisma/generated/prisma/client'
+import {
+  artContextRules,
+  artSlotFraming,
+} from '~/utils/entityArtPromptFraming'
 
 export type EntityArtType =
   | 'bot'
@@ -1022,11 +1026,12 @@ export function buildEntityArtPrompt(
   return [
     userPrompt.trim(),
     '',
-    `Create this as the ${field.label.toLowerCase()} artwork for the following ${target.entityType}.`,
+    // Describes the slot's shape rather than naming it. "the card artwork" made
+    // Krea 2 render a literal trading card. See utils/entityArtPromptFraming.ts.
+    `Compose this as ${artSlotFraming(field)} for the following ${target.entityType}.`,
     ...context,
     '',
-    'Treat the first paragraph as the primary art direction. Use the entity context for identity and continuity, not as a checklist or text to render.',
-    'Do not add captions, labels, UI chrome, watermarks, signatures, or readable text unless the primary art direction explicitly requests them.',
+    ...artContextRules('entity'),
   ]
     .filter(Boolean)
     .join('\n')

--- a/stores/dailyDreamArchiveStore.ts
+++ b/stores/dailyDreamArchiveStore.ts
@@ -12,6 +12,10 @@ import type {
   Scenario,
 } from '~/prisma/generated/prisma/client'
 import { performFetch } from '@/stores/utils'
+import {
+  artContextRules,
+  artSlotFraming,
+} from '~/utils/entityArtPromptFraming'
 
 export type DailyDreamArchiveArt = Pick<
   ArtImage,
@@ -213,11 +217,12 @@ function dreamArtPrompt(
   return [
     prompt.trim(),
     '',
-    `Create this as the ${slot.label.toLowerCase()} artwork for the following dream.`,
+    // Shape, not slot name: "the card artwork" made Krea 2 draw a literal
+    // trading card. See utils/entityArtPromptFraming.ts.
+    `Compose this as ${artSlotFraming(slot)} for the following dream.`,
     ...context,
     '',
-    'Treat the first paragraph as the primary art direction. Use the dream context for identity and continuity, not as text to render.',
-    'Do not add captions, labels, UI chrome, watermarks, signatures, or readable text unless the primary art direction explicitly requests them.',
+    ...artContextRules('dream'),
   ].join('\n')
 }
 

--- a/utils/entityArtPromptFraming.ts
+++ b/utils/entityArtPromptFraming.ts
@@ -1,0 +1,64 @@
+// /utils/entityArtPromptFraming.ts
+//
+// Shared framing/exclusion language for entity-art prompts, used by both the
+// server builder (server/utils/entityArt.ts) and the daily-dream archive store
+// (stores/dailyDreamArchiveStore.ts) so the two cannot drift.
+//
+// Both used to name the art slot directly:
+//
+//   `Create this as the ${slot.label.toLowerCase()} artwork for the following ...`
+//
+// which for a card slot produced "Create this as the card artwork". Krea 2 is a
+// distilled diffusion transformer on the Qwen-Image lineage — the strongest open
+// text renderer available — and it has no instruction-following layer. It read
+// "card" as the thing to draw and returned literal trading cards: title bar,
+// type line, and a rules box full of invented text (2026-08-08; the same defect
+// independently hit conductor's daily-dream builder, which said "treasure card
+// illustration").
+//
+// The slot's real intent is a shape, not an object. Describing the geometry gives
+// the model useful camera language and removes the format noun entirely.
+//
+// Both also ended with a pile of text nouns plus a conditional:
+//
+//   "Do not add captions, labels, UI chrome, watermarks, signatures, or readable
+//    text unless the primary art direction explicitly requests them."
+//
+// Two problems in one sentence. Krea 2 runs at cfg 1, which makes the ComfyUI
+// negative prompt inert, so every one of those six nouns lands in POSITIVE
+// conditioning on a text specialist. And "unless ... explicitly requests them"
+// is a condition the model cannot evaluate. Stated positively, once.
+
+export type ArtSlotShape = {
+  label: string
+  width: number
+  height: number
+}
+
+/**
+ * A geometric description of the slot, with no format nouns ("card", "icon",
+ * "hero", "banner", "emblem") that a diffusion model can mistake for the subject.
+ */
+export function artSlotFraming(slot: ArtSlotShape): string {
+  const { width, height } = slot
+  if (!width || !height) return 'a single balanced composition'
+  if (width === height) {
+    return width <= 320
+      ? 'a square composition with one bold shape that stays readable when small'
+      : 'a square composition centred on one clear subject'
+  }
+  return height > width
+    ? 'a vertical portrait composition with a clear foreground subject and layered depth'
+    : 'a wide landscape composition with depth and atmosphere'
+}
+
+/**
+ * The trailing guidance shared by every entity-art prompt. Keep it short: at
+ * cfg 1 these words are positive conditioning, not constraints.
+ */
+export function artContextRules(subjectNoun: string): string[] {
+  return [
+    `Treat the first paragraph as the primary art direction. Use the ${subjectNoun} context for identity and continuity, not as a checklist and not as text to render.`,
+    'Every surface in frame is blank and unmarked.',
+  ]
+}

--- a/utils/scripts/verifyEntityArtPromptFraming.ts
+++ b/utils/scripts/verifyEntityArtPromptFraming.ts
@@ -1,0 +1,86 @@
+// /utils/scripts/verifyEntityArtPromptFraming.ts
+//
+// Entity-art prompts must never name their slot ("card", "icon", "hero") or pile
+// up text nouns. Krea 2 is a distilled diffusion transformer on the Qwen-Image
+// lineage with no instruction-following layer, and it runs at cfg 1 — which
+// makes the ComfyUI negative prompt inert, so every word of the prompt is
+// positive conditioning.
+//
+// On 2026-08-08 "Create this as the card artwork for the following scenario"
+// produced literal trading cards: title bar, type line, and a rules box full of
+// invented text. The trailing "Do not add captions, labels, UI chrome,
+// watermarks, signatures, or readable text unless the primary art direction
+// explicitly requests them" contributed the rest — six text nouns plus a
+// condition the model cannot evaluate.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import {
+  artContextRules,
+  artSlotFraming,
+} from '../../utils/entityArtPromptFraming'
+
+// Format nouns a diffusion model can mistake for the subject.
+const SLOT_NOUNS = ['card', 'icon', 'hero', 'banner', 'emblem', 'thumbnail']
+
+const SLOTS = [
+  { label: 'Card', width: 512, height: 768 },
+  { label: 'Hero', width: 1280, height: 720 },
+  { label: 'Icon', width: 256, height: 256 },
+  { label: 'Avatar', width: 1024, height: 1024 },
+  { label: 'Reward', width: 1024, height: 1024 },
+]
+
+for (const slot of SLOTS) {
+  const framing = artSlotFraming(slot).toLowerCase()
+  assert.ok(framing.length > 0, `${slot.label} produced no framing`)
+  for (const noun of SLOT_NOUNS) {
+    assert.ok(
+      !framing.includes(noun),
+      `artSlotFraming(${slot.label}) leaked the format noun "${noun}": ${framing}`,
+    )
+  }
+}
+
+// Geometry, not the label, decides the framing.
+assert.match(artSlotFraming(SLOTS[0]!), /vertical portrait/)
+assert.match(artSlotFraming(SLOTS[1]!), /wide landscape/)
+assert.match(artSlotFraming(SLOTS[2]!), /square/)
+// A mislabelled slot still gets framing that matches its real aspect ratio.
+assert.match(
+  artSlotFraming({ label: 'Card', width: 1280, height: 720 }),
+  /wide landscape/,
+)
+// Degenerate dimensions must not throw or emit a slot noun.
+assert.ok(artSlotFraming({ label: 'Card', width: 0, height: 0 }).length > 0)
+
+// The trailing rules stay short and free of the noun pile.
+const rules = artContextRules('entity').join(' ').toLowerCase()
+for (const noun of ['captions', 'labels', 'ui chrome', 'watermarks', 'signatures']) {
+  assert.ok(!rules.includes(noun), `artContextRules still names "${noun}"`)
+}
+assert.ok(
+  !rules.includes('unless'),
+  'artContextRules still carries a conditional the image model cannot evaluate',
+)
+
+// Neither caller may reintroduce the slot-naming phrase.
+for (const file of [
+  'server/utils/entityArt.ts',
+  'stores/dailyDreamArchiveStore.ts',
+]) {
+  const source = readFileSync(new URL(`../../${file}`, import.meta.url), 'utf8')
+  const body = source
+    .split('\n')
+    .filter((line) => !line.trim().startsWith('//'))
+    .join('\n')
+  assert.ok(
+    !/Create this as the \$\{/.test(body),
+    `${file} names its art slot in the prompt again; use artSlotFraming()`,
+  )
+  assert.ok(
+    !/captions, labels, UI chrome/.test(body),
+    `${file} reintroduced the text-noun pile; use artContextRules()`,
+  )
+}
+
+console.log('Entity art prompt framing verified (no slot nouns, no text-noun pile).')


### PR DESCRIPTION
Third and most general instance of the defect from #1606. Found while verifying that fix — Silas reported about half the corrected daily-dream renders were covered in text.

## The bug

Both entity-art prompt builders opened by naming the slot:

```ts
`Create this as the ${slot.label.toLowerCase()} artwork for the following ${entityType}.`
```

For a card slot that reads **"Create this as the card artwork"**. Krea 2 is a distilled diffusion transformer on the Qwen-Image lineage — the strongest open text renderer available — with no instruction-following layer. It draws the noun. Result: literal trading cards with a title bar, a type line, and a rules box of invented text.

17 pending jobs were queued to do exactly that. Conductor's daily-dream builder hit the identical defect independently with `"treasure card illustration"` (silasfelinus/conductor#1896), which is what makes this worth fixing at the source rather than per-caller.

A slot's intent is a **shape**, not an object. `artSlotFraming()` derives framing from the slot's real dimensions:

| slot | before | after |
|---|---|---|
| Card 512×768 | "the card artwork" | "a vertical portrait composition with a clear foreground subject and layered depth" |
| Hero 1280×720 | "the hero artwork" | "a wide landscape composition with depth and atmosphere" |
| Icon 256×256 | "the icon artwork" | "a square composition with one bold shape that stays readable when small" |

That removes the format noun and replaces it with camera language the model can actually use. Geometry decides, not the label — a mislabelled slot still gets framing matching its true aspect ratio.

## Second defect in the same two lines

Both builders closed with:

> Do not add captions, labels, UI chrome, watermarks, signatures, or readable text **unless the primary art direction explicitly requests them.**

Two problems in one sentence. Krea 2 runs at **cfg 1**, which makes the ComfyUI negative prompt inert — so all six text nouns land in **positive** conditioning on a text specialist. And "unless … explicitly requests them" is a condition the model cannot evaluate. Same shape as the casting clause in #1606.

`artContextRules()` states it positively, once: *"Every surface in frame is blank and unmarked."*

## Why a shared module

`server/utils/entityArt.ts` and `stores/dailyDreamArchiveStore.ts` had independently duplicated both the slot-naming line and the text-noun pile. Fixing one would have left the other live. `utils/entityArtPromptFraming.ts` is importable from both server and client (same pattern as `utils/artFacetPrompt.ts`).

## Testing

`utils/scripts/verifyEntityArtPromptFraming.ts` asserts:
- no slot noun (`card`/`icon`/`hero`/`banner`/`emblem`/`thumbnail`) can appear in any framing
- geometry drives the result, including for a mislabelled slot
- degenerate dimensions don't throw
- `artContextRules` names none of the six text nouns and carries no `unless`
- both callers are grepped, so the phrase cannot be reintroduced

Wired into `entity-art-manager-contract.yml`, which already gates `server/utils/entityArt.ts`, plus an `npm run test:entity-art-prompt-framing` script alongside its siblings.

I could not run `tsx` in this sandbox (no `node_modules`, and installing the Nuxt toolchain risks the session's fixed disk allowance), so I verified the framing logic by reimplementing it standalone and confirmed the phrase is gone from both callers by grep. CI is the first real run of the verifier.

## Queue cleanup

The 53 stale pending jobs carrying `"A vertical trading-card illustration for this scenario"` are being rewritten in place. Their generator no longer exists in either repo — they're artifacts from a producer that was already replaced — so there's nothing further to fix at the source for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRr9oK8jpQKEd1sCM3NY1f

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRr9oK8jpQKEd1sCM3NY1f)_