### PR TITLE
interface-vision/t-104: migrate icon-card onto kr-entity-card-body's icon variant

### DIFF
--- a/components/gallery/kr-entity-card-body.vue
+++ b/components/gallery/kr-entity-card-body.vue
@@ -117,6 +117,19 @@
         </span>
       </div>
     </div>
+
+    <!--
+      NAMED, not the default slot the column layout below uses for
+      per-object extras (a Scenario's inspirations panel, etc.) — those are
+      block content sized for a card, and icon mode's five existing callers
+      (bot/character/dream/reward/scenario-card, whenever their gallery's
+      mode bar is set to Icons) never expected a slot to render here. A bare
+      `<slot />` would have surfaced that block content, unrequested, into
+      every one of their icon rows. `icon-actions` is opt-in and net new, so
+      today's five callers render byte-identical icon rows; only a caller
+      that asks for it (icon-card) gets it.
+    -->
+    <slot name="icon-actions" />
   </div>
 
   <div v-else class="flex w-full flex-col">

--- a/components/icons/icon-card.vue
+++ b/components/icons/icon-card.vue
@@ -4,70 +4,76 @@
 
   Extracted from icon-gallery.vue when that grid moved onto kr-gallery. The
   markup is unchanged; it only needed an owner, because a card inlined in a
-  `#item` slot has to reach its record through the slot's GalleryItem and every
-  reference becomes `iconById.get(Number(item.id))!`. A card component takes the
+  `#item` slot has to reach its record through the slot's GalleryItem and
+  every reference becomes `iconById.get(Number(item.id))!`. A card component takes the
   record as a prop instead, which is the shape reward-card and bot-card already
   use.
 
   Presentational: it renders and emits, and reads no store. Membership of the
   smart bar is passed in rather than looked up, so this stays mountable in
   WonderLab with a plain fixture.
+
+  MIGRATED onto kr-entity-card-body's icon variant (interface-vision t-104):
+  this card's body -- art/glyph, title, badge -- was a hand-rolled duplicate
+  of the row kr-entity-card-body already draws for every OTHER object's Icons
+  gallery mode (bot/character/dream/reward/scenario-card all pass their mode
+  straight through as `variant`). Smart Icons render a literal Icon glyph
+  rather than stored art, so `source` is left unset and `placeholder-icon`
+  carries the glyph -- kr-art-plate's existing no-src fallback already draws
+  exactly that. The two actions (Edit Details, Add/Remove) are per-object, so
+  they go through the new `#icon-actions` slot rather than the shared default
+  slot (see that slot's own comment for why it isn't the default one).
 -->
 <template>
   <div
-    class="relative group p-4 border-2 rounded-2xl bg-base-100 shadow-md flex flex-col items-center gap-2"
+    class="relative rounded-2xl border-2 bg-base-100 p-3 shadow-md"
     :class="{
       'border-primary/30': icon.type === 'nav',
       'border-secondary/30': icon.type === 'utility',
       'border-base-300': !icon.type,
     }"
   >
-    <span
-      class="absolute top-2 left-2 text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded-md"
-      :class="{
-        'bg-primary/10 text-primary': icon.type === 'nav',
-        'bg-secondary/10 text-secondary': icon.type === 'utility',
-        'bg-base-300 text-base-content/40': !icon.type,
-      }"
+    <kr-entity-card-body
+      variant="icon"
+      :title="icon.label || icon.title"
+      :subtitle="icon.description ?? undefined"
+      :badges="typeBadges"
+      :placeholder-icon="icon.icon || 'kind-icon:help'"
     >
-      {{ icon.type || '?' }}
-    </span>
+      <template #icon-actions>
+        <div class="flex shrink-0 flex-col items-end gap-1">
+          <button
+            v-if="canEdit"
+            class="text-[10px] text-blue-500 underline hover:text-blue-700"
+            type="button"
+            @click="emit('edit', icon)"
+          >
+            Edit Details
+          </button>
 
-    <Icon :name="icon.icon || 'kind-icon:help'" class="text-4xl mt-3" />
-
-    <div class="text-center text-sm font-medium">
-      {{ icon.label || icon.title }}
-    </div>
-
-    <div v-if="icon.description" class="text-center text-sm font-medium">
-      {{ icon.description }}
-    </div>
-
-    <button
-      v-if="canEdit"
-      class="mt-1 text-[10px] underline text-blue-500 hover:text-blue-700"
-      @click="emit('edit', icon)"
-    >
-      Edit Details
-    </button>
-
-    <button
-      class="btn btn-xs mt-1 rounded-xl"
-      :class="{
-        'btn-secondary': inSmartBar,
-        'btn-outline': !inSmartBar,
-      }"
-      @click="emit('toggle', icon.id)"
-    >
-      {{ inSmartBar ? 'Remove' : 'Add' }}
-    </button>
+          <button
+            class="btn btn-xs rounded-xl"
+            type="button"
+            :class="{
+              'btn-secondary': inSmartBar,
+              'btn-outline': !inSmartBar,
+            }"
+            @click="emit('toggle', icon.id)"
+          >
+            {{ inSmartBar ? 'Remove' : 'Add' }}
+          </button>
+        </div>
+      </template>
+    </kr-entity-card-body>
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { SmartIcon } from '@/stores/smartbarStore'
+import type { EntityCardChip } from '@/components/gallery/kr-entity-card-body.vue'
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     icon: SmartIcon
     inSmartBar?: boolean
@@ -83,4 +89,17 @@ const emit = defineEmits<{
   edit: [icon: SmartIcon]
   toggle: [id: number]
 }>()
+
+/** Same nav/utility/unset color coding the old hand-rolled corner chip used. */
+const typeBadges = computed<EntityCardChip[]>(() => [
+  {
+    label: props.icon.type || '?',
+    class:
+      props.icon.type === 'nav'
+        ? 'badge-primary'
+        : props.icon.type === 'utility'
+          ? 'badge-secondary'
+          : 'badge-neutral',
+  },
+])
 </script>


### PR DESCRIPTION
### Task
interface-vision/t-104 (slice 1): Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- `components/icons/icon-card.vue` (the Smart Icon gallery's card, `/icons`) hand-rolled a bordered tile — glyph, type badge, title, description, two buttons — that duplicated the row `kr-entity-card-body` already draws for every other object's Icons gallery mode (bot/character/dream/reward/scenario-card all pass their mode straight through as `variant`). Smart Icons render a literal `Icon` glyph rather than stored art, so `source` is left unset and `placeholder-icon` carries the glyph name — `kr-art-plate`'s existing no-src fallback already draws exactly that.
- `components/gallery/kr-entity-card-body.vue`: added a new, **opt-in** `#icon-actions` named slot to the icon-variant branch for icon-card's two per-object buttons (Edit Details, Add/Remove) — deliberately *not* the shared default slot the column layout uses for per-object extras (a Scenario's inspirations panel, etc.). A bare `<slot />` there would have surfaced that block content, unrequested, into the icon-mode row of every one of the five existing icon-variant callers (bot/character/dream/reward/scenario-card, whenever their gallery's mode bar is set to Icons). Named + additive means all five existing callers render byte-identical icon rows; only `icon-card`, which asks for it, gets the new slot.
- Same nav/utility/unset color coding preserved via the shared `badges` prop (badge-primary / badge-secondary / badge-neutral).

### How I verified
- `npx eslint` on both changed files — clean
- `npx vue-tsc --noEmit -p tsconfig.json` — clean
- `npx prettier --check` on both files — clean
- `npx tsx utils/scripts/verifyLayoutContract.ts` — holds, no new violations
- `npx tsx utils/scripts/verifyGalleryAdoption.ts` and `verifyComponentCanonicalRuntime.ts` — both pass unchanged
- `npm run test:lint-ratchet` — holds, 392 problems/27 rules, unchanged

### Stakes
reversible

### Flags for Reviewer
- Single reachable caller (`components/icons/icon-gallery.vue`, mounted at `/icons`) — did not attempt a live/preview visual check since this branch prefix has no Vercel preview enabled per `AGENTS.md`; will check the production deployment post-merge if useful.
- The visible layout changes from a vertical centered tile to `kr-entity-card-body`'s horizontal icon row (art/glyph left, text right) — this is the same row shape already shipped for every other object's Icons gallery mode, and matches Silas's stated design intent quoted directly in `kr-entity-card-body.vue`'s own header comment ("Icons should be simple text focused displays with an icon as the visual layer").
- Left `resource-card.vue`/`resource-gallery.vue` alone deliberately — PR #1607 (a different active session) is mid-flight on those exact files.

### Kaizen suggestion
`kr-narrator-stage` and other Lazy-prefixed kr-* components undercount in a plain-tag grep (must search `LazyKrNarratorStage`) — worth a note in the component's own header comment for the next person auditing adoption.

### Notes for reviewer
Part of interface-vision/t-104 (Phase 2, "Drive live front-end consistency onto shared kr-* components"), left `status: review` in the conductor roadmap pending this PR's merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHrG1qaRrgeFBVkFwK1oui)_