### PR TITLE
Build the back of the card: info first, interactions after

### DIFF
--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -96,6 +96,67 @@
       />
     </section>
 
+    <!--
+      THE BACK OF THE CARD. One instance for the whole gallery, bound to
+      whichever Bot was picked -- the flip is a property of the gallery's
+      selection, not of forty-eight card components each carrying a dialog.
+    -->
+    <kr-card-flip v-model="infoOpen" :label="infoBot?.name || 'Bot'">
+      <template #back="{ close, commit }">
+        <kr-card-back
+          v-if="infoBot"
+          v-model:editing="infoEditing"
+          :title="infoBot.name || 'Unnamed Bot'"
+          :subtitle="infoBot.subtitle || ''"
+          :description="infoBot.description || infoBot.personality || ''"
+          :art-src="infoBot.avatarImage || ''"
+          :badges="infoBotBadges"
+          :can-edit="canEditInfoBot"
+          :can-interact="true"
+          interact-label="Chat"
+          @back="commit"
+          @interact="interactWithInfoBot"
+        >
+          <!-- The stats a BOT has and a Reward does not. kr-card-back never
+               learns what any of this means. -->
+          <template #details>
+            <dl class="grid grid-cols-2 gap-2 text-xs">
+              <div v-if="infoBot.personality" class="col-span-2">
+                <dt class="font-black uppercase opacity-55">Personality</dt>
+                <dd class="whitespace-pre-wrap">{{ infoBot.personality }}</dd>
+              </div>
+              <div v-if="infoBot.BotType">
+                <dt class="font-black uppercase opacity-55">Type</dt>
+                <dd>{{ infoBot.BotType }}</dd>
+              </div>
+              <div v-if="infoBot.name">
+                <dt class="font-black uppercase opacity-55">Handle</dt>
+                <dd class="break-words">{{ infoBot.name }}</dd>
+              </div>
+            </dl>
+          </template>
+
+          <template #edit="{ done }">
+            <add-bot mode="edit" @saved="done" @cancel="done" />
+          </template>
+        </kr-card-back>
+
+        <!-- A Bot that vanished from the store while its panel was open (a
+             delete from another tab) would otherwise render an empty dialog
+             with no way out but Escape. -->
+        <div v-else class="p-6 text-center text-sm opacity-60">
+          <p>That Bot is no longer available.</p>
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm mt-3 rounded-xl"
+            @click="close"
+          >
+            Close
+          </button>
+        </div>
+      </template>
+    </kr-card-flip>
+
     <section class="min-h-0 flex-1 overflow-auto">
       <div
         v-if="isLoading || botStore.loading"
@@ -381,7 +442,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import type { Bot } from '~/prisma/generated/prisma/client'
 import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
 import { MODE_VARIANT, type GalleryMode } from '@/utils/galleryVocabulary'
@@ -678,13 +739,90 @@ async function refreshBots(force = false) {
   }
 }
 
+/*
+ * INFO FIRST, INTERACTION AFTER. Silas, 2026-08-08: "selecting the card brings
+ * us to the full info display with the animation ... think the back of a
+ * baseball card with stats ... info is first, and interactions come after."
+ *
+ * So picking a Bot in the grid no longer launches straight into the chat; it
+ * turns the card over. Chat is now a button on the back, which is what makes
+ * the interact tier a destination you choose rather than the only thing a
+ * click can do.
+ *
+ * THE DROPDOWN BRANCH IS WHY THIS LIVES IN THE GALLERY and not in bot-card.
+ * This gallery is also embedded as a PICKER inside bot-chat, where a click has
+ * to pick and nothing else -- an info panel there would be in the way. The card
+ * contract already puts the decision here: "A card is an entry point. It emits;
+ * the gallery decides what that means." A card that opened its own info panel
+ * would have decided, and the picker would have no way to opt out.
+ */
 async function selectBot(id: number) {
   if (isDropdownMode.value) {
     await botStore.selectBot(id)
     return
   }
 
-  await launchBotById(id)
+  infoBotId.value = id
+}
+
+const infoBotId = ref<number | null>(null)
+const infoEditing = ref(false)
+
+const infoBot = computed(
+  () => botStore.bots.find((entry) => entry.id === infoBotId.value) ?? null,
+)
+
+/*
+ * The id IS the open state -- one source of truth rather than a boolean that
+ * can disagree with it. Only the false direction is writable, because the flip
+ * closes itself (Escape, the backdrop) and needs somewhere to put that.
+ */
+const infoOpen = computed({
+  get: () => infoBotId.value !== null,
+  set: (value: boolean) => {
+    if (!value) {
+      infoBotId.value = null
+      infoEditing.value = false
+    }
+  },
+})
+
+const infoBotBadges = computed(() => {
+  const bot = infoBot.value
+  if (!bot) return []
+
+  return [bot.BotType, bot.isPublic ? 'Public' : 'Private']
+    .filter((entry): entry is string => Boolean(entry))
+    .map(String)
+})
+
+const canEditInfoBot = computed(() => {
+  const bot = infoBot.value
+  if (!bot) return false
+  return userStore.isAdmin || bot.userId === userStore.userId
+})
+
+/*
+ * add-bot edits whatever botStore is holding, so entering edit mode has to
+ * load the record FIRST -- opening the form against a stale editing target is
+ * how you save changes onto the wrong Bot.
+ */
+watch(infoEditing, async (isEditing) => {
+  if (!isEditing || !infoBotId.value) return
+  await botStore.startEditingBot(infoBotId.value)
+})
+
+/*
+ * Interact LEAVES. The chat surface is a working space and a centred modal is
+ * the wrong frame for it, so the panel closes and the interact tier takes over
+ * the page exactly as it did when a card click went straight there. Closing
+ * first means the flip plays out rather than being unmounted underneath the
+ * navigation.
+ */
+async function interactWithInfoBot() {
+  const id = infoBotId.value
+  infoOpen.value = false
+  if (id) await launchBotById(id)
 }
 
 function startAddingBot() {

--- a/components/gallery/kr-card-back.vue
+++ b/components/gallery/kr-card-back.vue
@@ -1,0 +1,216 @@
+<!-- /components/gallery/kr-card-back.vue -->
+<!--
+  The back of the card: everything about one object, and the buttons that act
+  on it.
+
+  WHY THIS EXISTS. Silas, 2026-08-08: "selecting the card brings us to the full
+  info display with the animation ... think the back of a baseball card with
+  stats. Then the edit option is just an on-screen change to the modal and
+  clicking returns to the info screen, with a back option to flip the card back
+  down to the gallery ... info is first, and interactions come after."
+
+  IT IS THE FRAME THE CARD CONTRACT ALREADY DESCRIBED. verifyCardActionContract
+  says of the pick action: "Model-specific verbs (`launch`, `adventure`,
+  `clone`, `delete`) are ADDITIONS, never replacements -- the interact tier is
+  where models legitimately differ, but the entry point is the frame." That
+  frame was specified and never built, so `open` went straight from the grid
+  into the model-specific tier with nothing shared in between. This is the
+  missing step, which is why it is one component for every object rather than
+  one per gallery.
+
+  WHAT IS SHARED AND WHAT IS NOT, the same split kr-entity-card-body settled:
+  art, title, badges, description, the action row and the info/edit swap are
+  here; the stats that only a Bot or only a Reward has go in `#details`, and
+  the form goes in `#edit`. Nothing model-specific is named in this file.
+
+  INTERACT LEAVES. `interact` is an emit, not a panel: the interact surfaces
+  are working spaces -- a chat window, an encounter engine -- and a centred
+  modal is the wrong frame for them. The host dismisses this and hands over to
+  the interact tier, so the tier keeps owning per-model behaviour exactly as it
+  does today and this only decides WHEN you get there.
+
+  NO STORE, NO FETCH. Same reason kr-gallery and kr-card-flip have none: a
+  shell that owns the consequence cannot be reused by the next caller.
+-->
+<template>
+  <section class="flex flex-col">
+    <!--
+      The art stays small here on purpose. On the front it is the whole card
+      because that is how you FIND a thing in a grid; on the back you have
+      already found it, and the stats are what you came for.
+    -->
+    <header
+      class="flex shrink-0 items-start gap-3 border-b border-base-300 bg-base-200/60 p-3"
+    >
+      <img
+        v-if="artSrc"
+        :src="artSrc"
+        :alt="title"
+        class="h-16 w-16 shrink-0 rounded-xl object-cover"
+      />
+
+      <div class="min-w-0 flex-1">
+        <h2 class="break-words text-lg font-black leading-tight">
+          {{ title }}
+        </h2>
+
+        <p v-if="subtitle" class="mt-0.5 text-xs text-base-content/60">
+          {{ subtitle }}
+        </p>
+
+        <div v-if="badges.length" class="mt-1.5 flex flex-wrap gap-1">
+          <span
+            v-for="badge in badges"
+            :key="badge"
+            class="badge badge-outline badge-sm"
+          >
+            {{ badge }}
+          </span>
+        </div>
+      </div>
+
+      <!--
+        `back` rather than a close X. Silas asked for "a back option to flip the
+        card back down to the gallery", and the host wires this to the flip's
+        `commit` so the turn plays in reverse -- returning to the grid is the
+        deliberate exit, not a dismissal.
+      -->
+      <button
+        type="button"
+        class="btn btn-ghost btn-sm shrink-0 rounded-xl"
+        @click="emit('back')"
+      >
+        <Icon name="kind-icon:arrow-left" class="h-4 w-4" />
+        Back
+      </button>
+    </header>
+
+    <div class="min-h-0 flex-1 p-3">
+      <!--
+        The edit form REPLACES the info body rather than flipping again --
+        "the edit option is just an on-screen change to the modal". A second
+        flip inside a flipped card would say the object changed, when all that
+        changed is what you are doing to it.
+      -->
+      <template v-if="editing">
+        <div class="mb-3 flex items-center justify-between gap-2">
+          <h3 class="text-sm font-black uppercase tracking-wide opacity-60">
+            Editing
+          </h3>
+
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs rounded-xl"
+            @click="editing = false"
+          >
+            <Icon name="kind-icon:x" class="h-3.5 w-3.5" />
+            Done
+          </button>
+        </div>
+
+        <slot name="edit" :done="stopEditing" />
+      </template>
+
+      <template v-else>
+        <p
+          v-if="description"
+          class="whitespace-pre-wrap text-sm text-base-content/75"
+        >
+          {{ description }}
+        </p>
+
+        <!-- The stats. Everything genuinely per-object lives here, and this
+             file never learns what any of it means. -->
+        <div class="mt-3">
+          <slot name="details" />
+        </div>
+
+        <!--
+          Reviews sit with the info, not with the actions. Silas: "this also
+          feels like it should be where we show the toggle to give a review,
+          which we've talked about as an interact object." Reacting to a thing
+          is a response to having read about it, so it belongs at the end of
+          the reading rather than in the row of things you can go and do.
+        -->
+        <div v-if="$slots.reviews" class="mt-4 border-t border-base-300 pt-3">
+          <slot name="reviews" />
+        </div>
+      </template>
+    </div>
+
+    <!--
+      Actions last, and only out of edit mode: while a form is open the buttons
+      that would navigate away from it are a trap.
+    -->
+    <footer
+      v-if="!editing && (canEdit || canInteract)"
+      class="flex shrink-0 items-center justify-end gap-2 border-t border-base-300 bg-base-200/60 p-3"
+    >
+      <button
+        v-if="canEdit"
+        type="button"
+        class="btn btn-outline btn-sm rounded-xl"
+        @click="editing = true"
+      >
+        <Icon name="kind-icon:edit" class="h-4 w-4" />
+        Edit
+      </button>
+
+      <button
+        v-if="canInteract"
+        type="button"
+        class="btn btn-primary btn-sm rounded-xl"
+        @click="emit('interact')"
+      >
+        {{ interactLabel }}
+        <Icon name="kind-icon:arrow-right" class="h-4 w-4" />
+      </button>
+    </footer>
+  </section>
+</template>
+
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    title: string
+    subtitle?: string
+    description?: string
+    artSrc?: string
+    badges?: string[]
+    canEdit?: boolean
+    canInteract?: boolean
+    /**
+     * What the interact tier is CALLED for this object -- "Chat", "Play",
+     * "Open". The verb is per-model even though the button is not, which is
+     * the same line verifyCardActionContract draws around `open`.
+     */
+    interactLabel?: string
+  }>(),
+  {
+    subtitle: '',
+    description: '',
+    artSrc: '',
+    badges: () => [],
+    canEdit: false,
+    canInteract: false,
+    interactLabel: 'Open',
+  },
+)
+
+const emit = defineEmits<{
+  back: []
+  interact: []
+}>()
+
+/*
+ * Uncontrolled unless the host binds it. defineModel keeps local state when
+ * nothing is passed, so a gallery that does not care about edit mode writes
+ * nothing, and one that does (to block a close mid-edit, say) can bind
+ * v-model:editing and see it.
+ */
+const editing = defineModel<boolean>('editing', { default: false })
+
+function stopEditing(): void {
+  editing.value = false
+}
+</script>

--- a/components/resources/resource-card.vue
+++ b/components/resources/resource-card.vue
@@ -144,8 +144,6 @@
       <!--
         `supportedServer` renders ONLY when it is not already overhead: it
         carries values like "SD15" beside a "SD 1.5" badge two inches up.
-        Compared with separators and case stripped, so SD15/SD 1.5 and
-        Flux.1 D/flux1-d collapse rather than sneaking through.
       -->
       <span v-if="showsServerBadge" class="badge badge-outline badge-xs w-fit">
         {{ resource.supportedServer }}
@@ -318,10 +316,27 @@ function normalizeModelToken(value: unknown): string {
     .replace(/[^a-z0-9]/g, '')
 }
 
+/*
+ * PREFIX, not equality. Comparing the two normalised tokens outright still let
+ * "SDXL" through beside an "SDXL 1.0" badge -- Silas, 2026-08-08, from the
+ * preview: "there is still a type listed twice : eg sdxl". The server field
+ * carries the family and the generation field carries family-plus-version, so
+ * the two are never going to be equal; one CONTAINING the other is what makes
+ * it a repeat.
+ *
+ * Biased toward collapsing -- "SD" beside "SDXL 1.0" goes too. Slightly
+ * aggressive, and deliberately the direction the brief asks for: a badge that
+ * only re-states a coarser version of what a neighbour already said is exactly
+ * the clutter being removed.
+ */
 const showsServerBadge = computed(() => {
   const server = normalizeModelToken(props.resource.supportedServer)
   if (!server) return false
-  return server !== normalizeModelToken(props.resource.generation)
+
+  const generation = normalizeModelToken(props.resource.generation)
+  if (!generation) return true
+
+  return !server.startsWith(generation) && !generation.startsWith(server)
 })
 
 const isEditable = computed(() =>

--- a/components/resources/resource-card.vue
+++ b/components/resources/resource-card.vue
@@ -14,13 +14,21 @@
   the same reason -- a card that owns the consequence cannot be reused or
   exhibited.
 
-  EDITING IS THE EXCEPTION, and only in placement. The card now owns the
-  GESTURE (kr-card-flip: turn over, grow, centre) while the gallery still owns
-  the FORM, handed in through the `edit` slot. Silas, 2026-08-08: "selecting
-  edit just creates the edit window at the very top of the gallery, which is
-  not ideal ... I believe it will take logic out of our galleries and towards
-  the cards themselves." The animation and the dialog plumbing are now the
-  card's; the save path is still the gallery's.
+  EDITING IS NOT HERE AT ALL any more, and neither is the flip. Silas,
+  2026-08-08: "selecting the card brings us to the full info display with the
+  animation ... think the back of a baseball card with stats. Then the edit
+  option is just an on-screen change to the modal." So the front's job is to
+  be findable in a grid and to emit `open`; everything you can READ about a
+  Resource, and the form, live on kr-card-back.
+
+  The card briefly owned that flip itself. It moved to the gallery because
+  bot-gallery -- the same pattern's first real test -- doubles as a PICKER
+  inside bot-chat, where a click must pick and an info panel would be in the
+  way. A card that opens its own panel has decided what being picked means,
+  which is exactly what verifyCardActionContract forbids, and the picker would
+  have no way to opt out. Resources has no picker embed today, but two
+  galleries answering the same question two different ways is how the drift
+  this stage exists to undo got started.
 
   The two busy flags are props rather than looked up, so this stays mountable
   in WonderLab from a plain fixture.
@@ -31,198 +39,190 @@
   inventing an `open` with nowhere to go.
 -->
 <template>
-  <kr-card-flip v-model="editOpen" :label="`Edit ${label}`">
-    <article
-      class="group flex h-full flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
+  <article
+    class="group flex h-full flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
+  >
+    <!--
+      IDENTITY OVERLAYS THE ART, per Silas 2026-08-08: "we should have the
+      image, the type and model info at top and overlaid is cool." Type and
+      base model are the two facts that never repeat below, which is what
+      makes them safe to put here.
+    -->
+    <!-- The art is the way IN. Selecting a Resource turns its card over to
+         the full record; the gallery decides that, not this file. -->
+    <button
+      type="button"
+      class="relative aspect-square w-full shrink-0 overflow-hidden bg-base-200 text-left"
+      :aria-label="`Open ${label}`"
+      @click="emit('open', resource.id)"
     >
-      <!--
-        IDENTITY OVERLAYS THE ART, per Silas 2026-08-08: "we should have the
-        image, the type and model info at top and overlaid is cool." Type and
-        base model are the two facts that never repeat below, which is what
-        makes them safe to put here.
-      -->
-      <div class="relative aspect-square shrink-0 overflow-hidden bg-base-200">
-        <img
-          :src="previewSrc"
-          :alt="label"
-          class="h-full w-full object-cover transition duration-300 group-hover:scale-[1.02]"
-          loading="lazy"
-        />
+      <img
+        :src="previewSrc"
+        :alt="label"
+        class="h-full w-full object-cover transition duration-300 group-hover:scale-[1.02]"
+        loading="lazy"
+      />
 
-        <div class="absolute left-2 top-2 flex flex-wrap gap-1">
-          <span class="badge badge-primary badge-sm">
-            {{ resource.resourceType }}
-          </span>
-          <span v-if="resource.generation" class="badge badge-neutral badge-sm">
-            {{ resource.generation }}
-          </span>
-          <span v-if="resource.isMature" class="badge badge-error badge-sm">
-            18+
-          </span>
-        </div>
-      </div>
-
-      <div class="flex flex-1 flex-col gap-2 p-3">
-        <!--
-          THE NAME GETS THE ROOM. Silas, 2026-08-08: "it was the actual title
-          that was cut off, so most of the time I could only see a fraction of
-          what the Lora was."
-
-          Two things made a two-line clamp fail on this catalog. Imported names
-          are long -- "[Exp] 每日渲染（风格）| Daily Render Style", "[LoRA]
-          Jellyfish forest / 水月森 / くらげの森" -- and they open with a
-          bracketed or underscored prefix ([LoRA], (color), _MOHAWK_) that is
-          the same across dozens of rows. So the clamp spent the visible lines
-          on the part that does not distinguish anything and elided the part
-          that does, which is why a grid of them reads as near-identical.
-
-          Three lines at `text-sm` holds roughly double the characters of two
-          at `text-base` while still reading as the heading. `break-words` is
-          for the unbroken runs ("_MOHAWK_Add_//COMICS"), which otherwise
-          overflow instead of wrapping.
-
-          Still CLAMPED, not free: kr-gallery's grid rows size to their tallest
-          card, so one pathological name would add height to every card on the
-          page. The clamp only hides overflow -- the full string stays in the
-          DOM for screen readers, `title` gives it back on hover, and the flip
-          side shows it in full.
-        -->
-        <h3
-          class="line-clamp-3 break-words text-sm font-black leading-snug"
-          :title="label"
-        >
-          {{ label }}
-        </h3>
-
-        <!--
-          The trigger is the word you type to activate a LoRA, and it used to
-          live in an `opacity-0 ... group-hover:opacity-100` panel over the
-          artwork -- so on a touch screen it could not be read at all. Putting
-          it on the card costs nothing a hover was giving anyone.
-
-          ONE line, not two. It competes with the name for the same column, and
-          the name is what Silas could not read; clamping the trigger tighter
-          is how the title got its third line without the card growing.
-        -->
-        <p
-          v-if="triggerText"
-          class="line-clamp-1 rounded-lg bg-base-200/70 px-2 py-1 font-mono text-xs text-base-content/80"
-          :title="triggerText"
-        >
-          {{ triggerText }}
-        </p>
-
-        <!--
-          Only PROSE survives here. The import writes descriptions like
-          "base: SD 1.5 | module: networks.lora | detected via civitai", which
-          restates the two badges overlaying the artwork and then adds where it
-          was scraped from -- three lines of card spent saying nothing the eye
-          has not already read. Silas: "too much text, especially repetitive
-          stuff". `isMachineDescription` drops those and keeps real ones.
-        -->
-        <p
-          v-if="humanDescription"
-          class="line-clamp-2 text-xs text-base-content/60"
-        >
-          {{ humanDescription }}
-        </p>
-
-        <!--
-          `supportedServer` renders ONLY when it is not already overhead: it
-          carries values like "SD15" beside a "SD 1.5" badge two inches up.
-          Compared with separators and case stripped, so SD15/SD 1.5 and
-          Flux.1 D/flux1-d collapse rather than sneaking through.
-        -->
-        <span
-          v-if="showsServerBadge"
-          class="badge badge-outline badge-xs w-fit"
-        >
-          {{ resource.supportedServer }}
+      <div class="absolute left-2 top-2 flex flex-wrap gap-1">
+        <span class="badge badge-primary badge-sm">
+          {{ resource.resourceType }}
         </span>
+        <span v-if="resource.generation" class="badge badge-neutral badge-sm">
+          {{ resource.generation }}
+        </span>
+        <span v-if="resource.isMature" class="badge badge-error badge-sm">
+          18+
+        </span>
+      </div>
+    </button>
 
-        <div class="mt-auto flex flex-col gap-1.5 pt-1">
-          <div class="grid grid-cols-2 gap-1.5">
-            <button
-              type="button"
-              class="btn btn-primary btn-xs rounded-xl"
-              @click="emit('add-to-build', resource)"
-            >
-              Add to build
-            </button>
-            <button
-              type="button"
-              class="btn btn-secondary btn-xs rounded-xl"
-              @click="emit('start-fresh', resource)"
-            >
-              Start fresh
-            </button>
-          </div>
+    <div class="flex flex-1 flex-col gap-2 p-3">
+      <!--
+        THE NAME GETS THE ROOM. Silas, 2026-08-08: "it was the actual title
+        that was cut off, so most of the time I could only see a fraction of
+        what the Lora was."
 
-          <!--
-            The preview pair and Edit are secondary, so they are icon buttons
-            on one line rather than two more full-width rows. Five stacked
-            call-to-actions made every card taller than its own artwork.
-          -->
-          <div class="flex items-center gap-1.5">
-            <button
-              type="button"
-              class="btn btn-ghost btn-xs flex-1 rounded-xl"
-              :disabled="generatingPreview"
-              title="Generate preview"
-              @click="emit('generate-preview', resource)"
-            >
-              <span
-                v-if="generatingPreview"
-                class="loading loading-spinner loading-xs"
-              />
-              <Icon v-else name="kind-icon:sparkles" class="h-3.5 w-3.5" />
-              Preview
-            </button>
+        Two things made a two-line clamp fail on this catalog. Imported names
+        are long -- "[Exp] 每日渲染（风格）| Daily Render Style", "[LoRA]
+        Jellyfish forest / 水月森 / くらげの森" -- and they open with a
+        bracketed or underscored prefix ([LoRA], (color), _MOHAWK_) that is
+        the same across dozens of rows. So the clamp spent the visible lines
+        on the part that does not distinguish anything and elided the part
+        that does, which is why a grid of them reads as near-identical.
 
-            <button
-              type="button"
-              class="btn btn-ghost btn-xs flex-1 rounded-xl"
-              :disabled="uploadingPreview"
-              title="Upload preview"
-              @click="emit('upload-preview', resource)"
-            >
-              <span
-                v-if="uploadingPreview"
-                class="loading loading-spinner loading-xs"
-              />
-              <Icon v-else name="kind-icon:upload" class="h-3.5 w-3.5" />
-              Upload
-            </button>
+        Three lines at `text-sm` holds roughly double the characters of two
+        at `text-base` while still reading as the heading. `break-words` is
+        for the unbroken runs ("_MOHAWK_Add_//COMICS"), which otherwise
+        overflow instead of wrapping.
 
-            <button
-              v-if="isEditable"
-              type="button"
-              class="btn btn-ghost btn-xs rounded-xl"
-              title="Edit this Resource"
-              aria-label="Edit this Resource"
-              @click="startEdit"
-            >
-              <Icon name="kind-icon:edit" class="h-3.5 w-3.5" />
-            </button>
-          </div>
+        Still CLAMPED, not free: kr-gallery's grid rows size to their tallest
+        card, so one pathological name would add height to every card on the
+        page. The clamp only hides overflow -- the full string stays in the
+        DOM for screen readers, `title` gives it back on hover, and the flip
+        side shows it in full.
+      -->
+      <h3
+        class="line-clamp-3 break-words text-sm font-black leading-snug"
+        :title="label"
+      >
+        {{ label }}
+      </h3>
+
+      <!--
+        The trigger is the word you type to activate a LoRA, and it used to
+        live in an `opacity-0 ... group-hover:opacity-100` panel over the
+        artwork -- so on a touch screen it could not be read at all. Putting
+        it on the card costs nothing a hover was giving anyone.
+
+        ONE line, not two. It competes with the name for the same column, and
+        the name is what Silas could not read; clamping the trigger tighter
+        is how the title got its third line without the card growing.
+      -->
+      <p
+        v-if="triggerText"
+        class="line-clamp-1 rounded-lg bg-base-200/70 px-2 py-1 font-mono text-xs text-base-content/80"
+        :title="triggerText"
+      >
+        {{ triggerText }}
+      </p>
+
+      <!--
+        Only PROSE survives here. The import writes descriptions like
+        "base: SD 1.5 | module: networks.lora | detected via civitai", which
+        restates the two badges overlaying the artwork and then adds where it
+        was scraped from -- three lines of card spent saying nothing the eye
+        has not already read. Silas: "too much text, especially repetitive
+        stuff". `isMachineDescription` drops those and keeps real ones.
+      -->
+      <p
+        v-if="humanDescription"
+        class="line-clamp-2 text-xs text-base-content/60"
+      >
+        {{ humanDescription }}
+      </p>
+
+      <!--
+        `supportedServer` renders ONLY when it is not already overhead: it
+        carries values like "SD15" beside a "SD 1.5" badge two inches up.
+        Compared with separators and case stripped, so SD15/SD 1.5 and
+        Flux.1 D/flux1-d collapse rather than sneaking through.
+      -->
+      <span v-if="showsServerBadge" class="badge badge-outline badge-xs w-fit">
+        {{ resource.supportedServer }}
+      </span>
+
+      <div class="mt-auto flex flex-col gap-1.5 pt-1">
+        <div class="grid grid-cols-2 gap-1.5">
+          <button
+            type="button"
+            class="btn btn-primary btn-xs rounded-xl"
+            @click="emit('add-to-build', resource)"
+          >
+            Add to build
+          </button>
+          <button
+            type="button"
+            class="btn btn-secondary btn-xs rounded-xl"
+            @click="emit('start-fresh', resource)"
+          >
+            Start fresh
+          </button>
+        </div>
+
+        <!--
+          The preview pair and Edit are secondary, so they are icon buttons
+          on one line rather than two more full-width rows. Five stacked
+          call-to-actions made every card taller than its own artwork.
+        -->
+        <div class="flex items-center gap-1.5">
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs flex-1 rounded-xl"
+            :disabled="generatingPreview"
+            title="Generate preview"
+            @click="emit('generate-preview', resource)"
+          >
+            <span
+              v-if="generatingPreview"
+              class="loading loading-spinner loading-xs"
+            />
+            <Icon v-else name="kind-icon:sparkles" class="h-3.5 w-3.5" />
+            Preview
+          </button>
+
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs flex-1 rounded-xl"
+            :disabled="uploadingPreview"
+            title="Upload preview"
+            @click="emit('upload-preview', resource)"
+          >
+            <span
+              v-if="uploadingPreview"
+              class="loading loading-spinner loading-xs"
+            />
+            <Icon v-else name="kind-icon:upload" class="h-3.5 w-3.5" />
+            Upload
+          </button>
+
+          <button
+            v-if="isEditable"
+            type="button"
+            class="btn btn-ghost btn-xs rounded-xl"
+            title="Open this Resource"
+            aria-label="Open this Resource"
+            @click="emit('open', resource.id)"
+          >
+            <Icon name="kind-icon:info" class="h-3.5 w-3.5" />
+          </button>
         </div>
       </div>
-    </article>
-
-    <template #back="{ close, commit }">
-      <!--
-        The gallery fills this. The card knows the gesture, not the form: which
-        editor a Resource needs (add-model vs add-lora) and what saving means
-        are both store work, and this file stays fixture-mountable by not
-        knowing either.
-      -->
-      <slot name="edit" :resource="resource" :close="close" :commit="commit" />
-    </template>
-  </kr-card-flip>
+    </div>
+  </article>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import type { ResourceGalleryRecord } from '@/stores/resourceGalleryStore'
 
 const EDITABLE_TYPES = ['CHECKPOINT', 'LORA', 'LYCORIS']
@@ -240,24 +240,17 @@ const props = withDefaults(
 )
 
 const emit = defineEmits<{
-  edit: [resource: ResourceGalleryRecord]
+  /*
+   * `open` is the contract's pick action, and here it means "turn the card
+   * over". The GALLERY decides that, per verifyCardActionContract -- which is
+   * what lets a picker embed opt out while a browse gallery opens the back.
+   */
+  open: [id: number]
   'add-to-build': [resource: ResourceGalleryRecord]
   'start-fresh': [resource: ResourceGalleryRecord]
   'generate-preview': [resource: ResourceGalleryRecord]
   'upload-preview': [resource: ResourceGalleryRecord]
 }>()
-
-const editOpen = ref(false)
-
-/*
- * Still emits `edit`. The gallery no longer has to POSITION anything, but it
- * may still want to know (to mark a row dirty, to close a sibling), and
- * removing the emit would be a silent contract break for any other host.
- */
-function startEdit(): void {
-  editOpen.value = true
-  emit('edit', props.resource)
-}
 
 const previewSrc = computed(
   () =>

--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -461,13 +461,15 @@ onMounted(async () => {
       <div class="flex flex-wrap items-center justify-between gap-2">
         <div class="min-w-0">
           <h2 class="text-base font-bold">Resource Gallery</h2>
-          <p
-            class="hidden max-w-3xl truncate text-xs text-base-content/65 md:block"
-          >
-            Browse checkpoints, LoRAs, embeddings, and generation tools. Add one
-            to the current build, start fresh, or manufacture a preview when the
-            catalog arrived wearing a paper bag over its head.
-          </p>
+          <!--
+            TITLE ONLY. The blurb under it was `max-w-3xl`, so it claimed the
+            whole line and pushed Library/Discover/Add/Refresh onto a row of
+            their own -- Silas, 2026-08-08, of the preview: "still appears to
+            have multiple rows before the resource cards". It also truncated to
+            "...manufacture a preview wh...", so the row bought an unfinished
+            sentence. The page already carries a `?` help affordance, which is
+            where orientation prose belongs.
+          -->
         </div>
 
         <div class="flex shrink-0 items-center gap-2">

--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -58,6 +58,81 @@ const messageTone = ref<'success' | 'error'>('success')
 const activePreviewResourceId = ref<number | null>(null)
 const activeUploadResourceId = ref<number | null>(null)
 
+/*
+ * INFO FIRST. Selecting a Resource turns the card over to its stats rather
+ * than doing anything to it -- the same frame Bots uses, which is the point of
+ * kr-card-back existing rather than each gallery growing its own panel.
+ *
+ * The id is the open state so the two cannot disagree; only the false
+ * direction is writable, because the flip closes itself on Escape and the
+ * backdrop and needs somewhere to put that.
+ */
+const infoResourceId = ref<number | null>(null)
+
+const infoResource = computed(
+  () =>
+    resourceGalleryStore.resources.find(
+      (entry) => entry.id === infoResourceId.value,
+    ) ?? null,
+)
+
+const infoOpen = computed({
+  get: () => infoResourceId.value !== null,
+  set: (value: boolean) => {
+    if (!value) infoResourceId.value = null
+  },
+})
+
+function openResourceInfo(id: number): void {
+  infoResourceId.value = id
+}
+
+const infoResourceArt = computed(() => {
+  const entry = infoResource.value
+  if (!entry) return ''
+
+  return (
+    entry.ArtImage?.thumbnailPath ||
+    entry.ArtImage?.imagePath ||
+    entry.previewImageUrl ||
+    entry.imagePath ||
+    ''
+  )
+})
+
+const infoResourceTrigger = computed(() => {
+  const entry = infoResource.value
+  if (!entry) return ''
+  return entry.defaultTrigger || entry.triggerWords || entry.artPrompt || ''
+})
+
+/*
+ * The back shows a description only when there is one worth reading, on the
+ * same rule the card front uses -- an import string restating the badges is no
+ * more useful at full size than it was at card size.
+ */
+const infoResourceDescription = computed(() => {
+  const entry = infoResource.value
+  if (!entry) return ''
+  const text = (entry.description || '').trim()
+  return isMachineDescription(text) ? '' : text
+})
+
+const infoResourceBadges = computed(() => {
+  const entry = infoResource.value
+  if (!entry) return []
+
+  return [entry.resourceType, entry.generation, entry.isMature ? '18+' : '']
+    .filter((value): value is string => Boolean(value))
+    .map(String)
+})
+
+const canEditInfoResource = computed(() => {
+  const entry = infoResource.value
+  if (!entry) return false
+  return EDITABLE_RESOURCE_TYPES.includes(String(entry.resourceType))
+})
+
 const showAddChoice = ref(false)
 const showForm = ref(false)
 const formKind = ref<'CHECKPOINT' | 'LORA'>('CHECKPOINT')
@@ -93,6 +168,29 @@ async function handleSaved(
     return
   }
   closeForm()
+}
+
+const EDITABLE_RESOURCE_TYPES = ['CHECKPOINT', 'LORA', 'LYCORIS']
+
+/*
+ * Mirrors resource-card's rule so the front and the back agree about which
+ * descriptions are worth showing. Duplicated rather than imported for the same
+ * reason `label` already is: the card must stay mountable from a fixture, and
+ * importing from the gallery that renders it is the wrong direction.
+ */
+function isMachineDescription(text: string): boolean {
+  const segments = text
+    .split('|')
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+
+  if (segments.length < 2) return false
+
+  const fielded = segments.filter((segment) =>
+    /^[\w ]{2,24}:\s*\S/.test(segment),
+  ).length
+
+  return fielded >= 2 && fielded * 2 >= segments.length
 }
 
 const resourceTypes = computed(() => {
@@ -435,6 +533,76 @@ onMounted(async () => {
     </div>
 
     <!--
+      THE BACK OF THE CARD, one instance for the gallery. A Resource has no
+      interact tier -- verifyCardActionContract's note on this card says its
+      primary actions "are model-specific by nature", and there is no surface
+      to hand over to -- so the back carries info and Edit and stops there.
+      `can-interact` stays false rather than inventing a destination.
+    -->
+    <kr-card-flip
+      v-model="infoOpen"
+      :label="infoResource ? resourceLabel(infoResource) : 'Resource'"
+    >
+      <template #back="{ close, commit }">
+        <kr-card-back
+          v-if="infoResource"
+          :title="resourceLabel(infoResource)"
+          :subtitle="infoResource.generation || ''"
+          :description="infoResourceDescription"
+          :art-src="infoResourceArt"
+          :badges="infoResourceBadges"
+          :can-edit="canEditInfoResource"
+          @back="commit"
+        >
+          <template #details>
+            <dl class="grid grid-cols-2 gap-2 text-xs">
+              <div v-if="infoResourceTrigger" class="col-span-2">
+                <dt class="font-black uppercase opacity-55">Trigger</dt>
+                <dd class="break-words font-mono">{{ infoResourceTrigger }}</dd>
+              </div>
+              <div v-if="infoResource.supportedServer">
+                <dt class="font-black uppercase opacity-55">Server</dt>
+                <dd>{{ infoResource.supportedServer }}</dd>
+              </div>
+              <div v-if="infoResource.localPath" class="col-span-2">
+                <dt class="font-black uppercase opacity-55">Path</dt>
+                <dd class="break-all font-mono">
+                  {{ infoResource.localPath }}
+                </dd>
+              </div>
+            </dl>
+          </template>
+
+          <template #edit="{ done }">
+            <add-model
+              v-if="infoResource.resourceType === RESOURCE_TYPE.CHECKPOINT"
+              :model="infoResource"
+              @saved="(saved: Resource) => handleSaved(saved, done)"
+              @close="done"
+            />
+            <add-lora
+              v-else
+              :lora="infoResource"
+              @saved="(saved: Resource) => handleSaved(saved, done)"
+              @close="done"
+            />
+          </template>
+        </kr-card-back>
+
+        <div v-else class="p-6 text-center text-sm opacity-60">
+          <p>That Resource is no longer available.</p>
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm mt-3 rounded-xl"
+            @click="close"
+          >
+            Close
+          </button>
+        </div>
+      </template>
+    </kr-card-flip>
+
+    <!--
       ADD only. Editing an existing Resource flips its own card (see the `edit`
       slot on resource-card below); this pair is reached from the Add button,
       where there is no card to turn over yet, so it stays a panel.
@@ -565,38 +733,12 @@ onMounted(async () => {
           :resource="resourceById.get(Number(item.id))!"
           :generating-preview="activePreviewResourceId === Number(item.id)"
           :uploading-preview="activeUploadResourceId === Number(item.id)"
+          @open="openResourceInfo"
           @add-to-build="addToGeneration"
           @start-fresh="startGeneration"
           @generate-preview="generatePreview"
           @upload-preview="choosePreviewFile"
-        >
-          <!--
-            The editor rides the BACK OF THE CARD now. It used to render up at
-            the top of the page from a gallery-level `showForm`/`editing` pair,
-            so editing the last row scrolled you away from it -- Silas,
-            2026-08-08: "selecting edit just creates the edit window at the very
-            top of the gallery, which is not ideal."
-
-            The card owns the gesture and hands the record back through the
-            slot, so there is no gallery-level "which one is being edited"
-            state to keep in sync any more. Which editor a Resource needs is
-            still decided here, because that is store-shaped knowledge.
-          -->
-          <template #edit="{ resource, close, commit }">
-            <add-model
-              v-if="resource.resourceType === RESOURCE_TYPE.CHECKPOINT"
-              :model="resource"
-              @saved="(saved: Resource) => handleSaved(saved, commit)"
-              @close="close"
-            />
-            <add-lora
-              v-else
-              :lora="resource"
-              @saved="(saved: Resource) => handleSaved(saved, commit)"
-              @close="close"
-            />
-          </template>
-        </resource-card>
+        />
       </template>
 
       <template #empty>

--- a/utils/wonderlab/previewFixtures.ts
+++ b/utils/wonderlab/previewFixtures.ts
@@ -13,6 +13,24 @@ export type WonderLabPreviewFixture = {
 const fixtureDate = new Date('2026-01-01T00:00:00.000Z')
 
 const fixtures: Record<string, WonderLabPreviewFixture> = {
+  'kr-card-back': {
+    title: 'Card back specimen',
+    description:
+      'The shared info face every object gets when its card is turned over: art, title, badges, description, the per-model #details slot, and the Edit/Interact row. Presentational -- it reads no store, and `interact` is an emit because the interact surfaces are working spaces the host navigates to rather than panels this renders.',
+    viewport: 'tablet',
+    minHeight: '26rem',
+    props: {
+      title: 'Museum Placard Style',
+      subtitle: 'SDXL 1.0',
+      description:
+        'A synthetic object for checking the card back: header, badges, body and the action row together.',
+      badges: ['LORA', 'SDXL 1.0'],
+      canEdit: true,
+      canInteract: true,
+      interactLabel: 'Chat',
+    },
+  },
+
   'resource-card': {
     title: 'Resource card specimen',
     description:

--- a/wonderlab-rollout-artifacts/component-contract-verification.json
+++ b/wonderlab-rollout-artifacts/component-contract-verification.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": 1,
   "baseUrl": "https://kind-robots.vercel.app",
-  "checkedAt": "2026-08-08T12:38:37.384Z",
+  "checkedAt": "2026-08-08T12:55:50.711Z",
   "recordCount": 489,
   "canonicalStatusRecordCount": 489,
   "discoveredCount": 420,

--- a/wonderlab-rollout-artifacts/component-contract-verification.json
+++ b/wonderlab-rollout-artifacts/component-contract-verification.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": 1,
   "baseUrl": "https://kind-robots.vercel.app",
-  "checkedAt": "2026-08-08T11:51:21.207Z",
+  "checkedAt": "2026-08-08T12:38:37.384Z",
   "recordCount": 489,
   "canonicalStatusRecordCount": 489,
   "discoveredCount": 420,

--- a/wonderlab-rollout-artifacts/component-contract-verification.json
+++ b/wonderlab-rollout-artifacts/component-contract-verification.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": 1,
   "baseUrl": "https://kind-robots.vercel.app",
-  "checkedAt": "2026-08-08T11:25:05.326Z",
+  "checkedAt": "2026-08-08T11:51:21.207Z",
   "recordCount": 489,
   "canonicalStatusRecordCount": 489,
   "discoveredCount": 420,


### PR DESCRIPTION
> "selecting the card brings us to the full info display with the animation … think the back of a baseball card with stats. Then the edit option is just an on-screen change to the modal and clicking returns to the info screen, with a back option to flip the card back down to the gallery … info is first, and interactions come after."

## This is the frame the card contract already described

`verifyCardActionContract` says of the pick action, verbatim:

> Model-specific verbs (`launch`, `adventure`, `clone`, `delete`) are ADDITIONS, never replacements — **the interact tier is where models legitimately differ, but the entry point is the frame.**

That frame was specified and never built, so `open` went straight from the grid into the model-specific tier with nothing shared in between. `kr-card-back` is the missing step — which is why it's one component for every object rather than one per gallery.

| | |
| --- | --- |
| **shared** | art, title, badges, description, the action row, the info ⇄ edit swap |
| **per-model** | `#details` (a Bot's personality, a Resource's trigger and path) and `#edit` (the form) |

Nothing model-specific is named inside `kr-card-back`.

## Two design decisions worth naming

**Interact leaves.** The interact surfaces are working spaces — a chat window, an encounter engine — and a centred modal is the wrong frame for them. So the panel closes and the tier takes over the page exactly as it did when a click went straight there. The tier keeps owning per-model behaviour; this only decides *when* you reach it.

**Editing swaps the body in place** rather than flipping again. A second flip inside a flipped card would say the *object* changed, when all that changed is what you're doing to it.

## The flip is gallery-owned, and Bots is why

`bot-gallery` doubles as a **picker** inside `bot-chat`, where a click has to pick and nothing else — an info panel there would be in the way. The contract already puts the decision in the gallery: *"A card is an entry point. It emits; the gallery decides what that means."*

A card that opens its own panel has decided what being picked means, and the picker would have no way to opt out. So `resource-card` gives up the flip it briefly owned in #1607 and goes back to emitting `open`. Resources has no picker embed today, but two galleries answering the same question two different ways is how the drift this stage exists to undo got started.

## Per model

**Bots** — picking no longer launches straight into chat; Chat is a button on the back. The dropdown branch is untouched, so the picker still picks. Entering edit mode loads the record through `botStore.startEditingBot` first, because `add-bot` edits whatever the store holds and a stale target would save onto the wrong Bot.

**Resources** — same frame, no interact tier. A Resource has no surface to hand over to (the contract already notes this), so `can-interact` stays false rather than inventing a destination. The back also reuses the front's `isMachineDescription` rule: an import string restating the badges is no more useful at full size than it was at card size.

Both panels handle the record disappearing while open (a delete from another tab) rather than rendering an empty dialog with no way out but Escape.

## Not yet done

Reviews. `reactable-card` already owns the karma badge, reaction button and review panel across fourteen cards, and `kr-card-back` has the `#reviews` slot waiting for it — but moving it is its own change and worth seeing this land first.

Characters, Dreams, Rewards and Scenarios are unchanged; they get the same treatment once the shape is confirmed on the preview.

## Verification

- `npm run test` (vue-tsc) — clean. Caught `botType` → `BotType` before it shipped.
- `npx eslint` + `npx prettier` on all changed files — clean
- Swept **193 verification commands across all 57 workflow files**. 188 pass; the same 5 fail as on an unmodified tree, all Prisma pool timeouts (`P2039`) from the sandbox having no DB egress.

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_