### PR TITLE
Trim the Resource list payload; hydrate the full record on the card back

### DIFF
--- a/channel-artwork-audit.txt
+++ b/channel-artwork-audit.txt
@@ -1,0 +1,22 @@
+
+> audit:channel-assets
+> tsx utils/scripts/auditChannelAssets.ts
+
+Channel artwork audit checked 61 local URL references across 5 channels.
+Missing 16 resolved channel or tab image(s):
+- home: /images/channels/home/channel.webp (https://media.acrocatranch.com/images/channels/home/channel.webp)
+- home/registration: /images/dashboard-tabs/user/profile.webp (https://media.acrocatranch.com/images/dashboard-tabs/user/profile.webp)
+- home/navigation: /images/dashboard-tabs/user/profile.webp (https://media.acrocatranch.com/images/dashboard-tabs/user/profile.webp)
+- home/account: /images/dashboard-tabs/user/profile.webp (https://media.acrocatranch.com/images/dashboard-tabs/user/profile.webp)
+- home/wallet: /images/dashboard-tabs/user/profile.webp (https://media.acrocatranch.com/images/dashboard-tabs/user/profile.webp)
+- plan: /images/channels/plan/channel.webp (https://media.acrocatranch.com/images/channels/plan/channel.webp)
+- play: /images/channels/play/channel.webp (https://media.acrocatranch.com/images/channels/play/channel.webp)
+- play/resources: /images/channels/play/resources.webp (https://media.acrocatranch.com/images/channels/play/resources.webp)
+- play/storybook: /images/dashboard-tabs/scenario/storybook.webp (https://media.acrocatranch.com/images/dashboard-tabs/scenario/storybook.webp)
+- play/music-mentor: /images/channels/play/music-mentor.webp (https://media.acrocatranch.com/images/channels/play/music-mentor.webp)
+- play/video-generator: /images/channels/play/video-generator.webp (https://media.acrocatranch.com/images/channels/play/video-generator.webp)
+- sanctuary: /images/channels/sanctuary/channel.webp (https://media.acrocatranch.com/images/channels/sanctuary/channel.webp)
+- sanctuary/about: /images/dashboard-tabs/giftshop/community.webp (https://media.acrocatranch.com/images/dashboard-tabs/giftshop/community.webp)
+- sanctuary/giving: /images/dashboard-tabs/giftshop/community.webp (https://media.acrocatranch.com/images/dashboard-tabs/giftshop/community.webp)
+- sanctuary/privacy: /images/dashboard-tabs/user/profile.webp (https://media.acrocatranch.com/images/dashboard-tabs/user/profile.webp)
+- admin: /images/channels/admin/channel.webp (https://media.acrocatranch.com/images/channels/admin/channel.webp)

--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -83,8 +83,21 @@ const infoOpen = computed({
   },
 })
 
+/*
+ * HYDRATE ON OPEN. The list payload is trimmed to what a card draws, so a row
+ * in the grid is missing the fields the editor needs (civitaiUrl, hash, the
+ * timestamps). Fetching the full record by id when the card turns over is the
+ * "detail fetch, not every row" half of that trade -- getResource replaces the
+ * store entry in place, so the panel re-renders with the complete record and
+ * the form has everything it edits.
+ *
+ * Deliberately NOT awaited before opening: the panel shows the fields it
+ * already has immediately and fills in the rest, rather than making the flip
+ * wait on a round trip.
+ */
 function openResourceInfo(id: number): void {
   infoResourceId.value = id
+  void resourceGalleryStore.getResource(id)
 }
 
 const infoResourceArt = computed(() => {

--- a/server/api/resources/gallery.ts
+++ b/server/api/resources/gallery.ts
@@ -56,6 +56,54 @@ export const resourceGallerySelect = {
   // row of the catalog listing.
 } satisfies Prisma.ResourceSelect
 
+/**
+ * The LIST payload -- what a card in the grid actually draws, and nothing else.
+ *
+ * WHY IT IS SEPARATE FROM resourceGallerySelect. `/api/resources` is still an
+ * unpaginated findMany over the whole catalog (~1,500 rows and climbing),
+ * because the type and base-model dropdowns derive their options from the
+ * loaded set and paginating the query would empty them. That is a defensible
+ * trade only if each ROW is cheap, and it was not: the full select carried
+ * ~30 columns per row including several long strings nothing in the grid
+ * reads -- civitaiUrl, huggingUrl, customUrl, MediaPath, hash -- plus
+ * timestamps and ids used only by the editor.
+ *
+ * Silas, 2026-08-08, from a tablet: "there was also a loading errors and not
+ * all images every loaded ... which wasn't happening an hour ago, though then
+ * was desktop and this was tablet". A payload that a desktop absorbs and a
+ * tablet does not is a size problem, so this trims the row rather than the
+ * row count.
+ *
+ * Everything dropped here is still available -- the card back hydrates the
+ * full record through `/api/resources/[id]` when it opens, which is the same
+ * "detail fetch, not every row" split the `_count` note below argues for.
+ */
+export const resourceListSelect = {
+  id: true,
+  name: true,
+  customLabel: true,
+  description: true,
+  resourceType: true,
+  generation: true,
+  supportedServer: true,
+  localPath: true,
+  defaultTrigger: true,
+  triggerWords: true,
+  artPrompt: true,
+  previewImageUrl: true,
+  imagePath: true,
+  isMature: true,
+  isPublic: true,
+  userId: true,
+  ArtImage: {
+    select: resourcePreviewArtImageSelect,
+  },
+} satisfies Prisma.ResourceSelect
+
+export type ResourceListRecord = Prisma.ResourceGetPayload<{
+  select: typeof resourceListSelect
+}>
+
 export type ResourceGalleryRecord = Prisma.ResourceGetPayload<{
   select: typeof resourceGallerySelect
 }>

--- a/server/api/resources/index.get.ts
+++ b/server/api/resources/index.get.ts
@@ -4,6 +4,7 @@ import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { getOptionalApiUser } from '../../utils/authGuard'
 import {
+  resourceListSelect,
   resourceGallerySelect,
   resourceGalleryWhere,
   type ResourceGalleryRecord,
@@ -19,7 +20,10 @@ export default defineEventHandler(async (event) => {
         isAdmin: auth?.isAdmin ?? false,
         showMature: effectiveShowMature(auth?.user),
       }),
-      select: resourceGallerySelect,
+      // The LIST select, not the full one: this is every active Resource in
+      // one response, so the per-row cost is the whole cost. The card back
+      // fetches the rest by id when it opens.
+      select: resourceListSelect,
       orderBy: [{ customLabel: 'asc' }, { name: 'asc' }],
     })
 

--- a/wonderlab-preview-audit.txt
+++ b/wonderlab-preview-audit.txt
@@ -1,0 +1,34 @@
+
+> audit:wonderlab-previews
+> tsx utils/scripts/auditWonderLabPreviews.ts --strict
+
+WonderLab preview audit scanned 345 Vue components.
+51 required-prop components have fixture coverage or an explicit skip reason.
+27 required-prop components still need preview coverage.
+- components/art/art-facet-selector.vue: missing fixture props modelValue
+- components/art/artjob-editor.vue: missing fixture props job
+- components/art/artjob-queue-card.vue: missing fixture props job
+- components/art/entity-art-manager.vue: missing fixture props entity, entityType, slots
+- components/art/stylist-client-gallery.vue: missing fixture props client
+- components/art/stylist-mask-brush.vue: missing fixture props sourceImageData
+- components/characters/character-facet-picker.vue: missing fixture props modelValue
+- components/coloring/production-action-button.vue: missing fixture props confirmLabel, iconName, label
+- components/coloring/production-stage-card.vue: missing fixture props detail, iconName, label
+- components/content-visibility-controls.vue: missing fixture props isMature, isPublic
+- components/dreams/daily-digest-object-dialog.vue: missing fixture props entity, objectType
+- components/dreams/daily-digest-object-gallery.vue: missing fixture props dream
+- components/dreams/daily-dream-object-art-workbench.vue: missing fixture props canEdit, entity, objectType, slots
+- components/gallery/kr-entity-card-body.vue: missing fixture props title
+- components/gallery/kr-gallery.vue: missing fixture props items
+- components/narrative/kr-chat-window.vue: missing fixture props turns
+- components/narrative/kr-choice-list.vue: missing fixture props choices
+- components/narrative/narrative-ingredient-card.vue: missing fixture props item
+- components/narrative/narrative-ingredient-multi-picker.vue: missing fixture props items, label, modelValue
+- components/narrative/narrative-ingredient-picker.vue: missing fixture props items, label, modelValue
+- components/narrative/narrative-response-composer.vue: missing fixture props modelValue
+- components/newsfeed/newsfeed-filters.vue: missing fixture props items
+- components/rewards/reward-facet-picker.vue: missing fixture props modelValue
+- components/storybook/storybook-state-panel.vue: missing fixture props session
+- components/ui/allow-reviews-toggle.vue: missing fixture props allowReviews
+- components/video-lora-picker.vue: missing fixture props engine, modelValue, strength
+- components/watchlist/watchlist-entry-detail.vue: missing fixture props entry


### PR DESCRIPTION
> "there was also a loading errors and not all images every loaded … which wasn't happening an hour ago, though then was desktop and this was tablet"

A payload a desktop absorbs and a tablet does not is a **size** problem. So this trims the row, not the row count.

## Why not just paginate the query

`/api/resources` is still an unpaginated `findMany` over the whole catalog (~1,500 rows and climbing) — deliberately. The type and base-model dropdowns derive their options from the loaded set, so paginating the query would empty them. That's the bug already reported once in this sequence, and I'd rather not reintroduce it to fix a different one.

But that trade is only defensible if each **row** is cheap, and it wasn't: the list shared the full editor select, ~29 scalar columns per row.

## What goes

**13 of 29 columns**, including every long one nothing in the grid draws:

`civitaiUrl`, `huggingUrl`, `customUrl`, `MediaPath`, `hash`

…plus `createdAt`, `updatedAt`, `artImageId`, `isActive`, `civitaiModelId`, `civitaiModelVersionId`, `slug`, `commercialSafe` — all of which belong to the editor rather than the card.

## Nothing is lost, because the back hydrates

Opening a card now fires `getResource(id)` against `/api/resources/[id]`, which still uses the full select and replaces the store entry in place. The panel fills in and the form has everything it edits.

Deliberately **not awaited** before the flip: the panel shows the fields it already has and completes itself, rather than making the animation wait on a round trip.

This is the same "detail fetch, not every row" split the `_count` removal argued for in #1605, now applied to the columns as well as the aggregates.

## Honest scope

This reduces the payload; it does not prove it fixes the tablet failure. I can't reproduce that here (no DB egress, and no browser egress to the preview). If the errors persist after this, the next step is genuine server-side pagination with a separate cheap `distinct` endpoint feeding the two dropdowns — which is the real fix and a bigger change.

## Verification

- `npm run test` (vue-tsc) — clean
- `npx eslint` + `npx prettier` on all changed files — clean
- Full workflow sweep running; this PR's CI is the authoritative check either way

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_