### PR TITLE
digital-storefront/t-003: seed KR-logo storefront ArtImage, retire pod-checkout, document cartItems split

### DIFF
--- a/scripts/seed_kr_logo_art_image.ts
+++ b/scripts/seed_kr_logo_art_image.ts
@@ -1,0 +1,126 @@
+// scripts/seed_kr_logo_art_image.ts
+//
+// Idempotent seed for the Kind Robots logo's ArtImage row
+// (digital-storefront/t-003, item 1: "seed a real KR-logo Product/POD SKU
+// -- currently MISSING entirely, no artImageId, no catalog row").
+//
+// Why an ArtImage row and not a new non-art-dependent SKU shape: PrintJob's
+// artImageId FK is required and non-nullable (prisma/schema.prisma), and
+// checkPrintEligibility (server/api/art/utils/printEligibility.ts) is
+// fundamentally ArtImage-shaped -- every POD-fulfilling path in this repo
+// (pod-checkout.post.ts, checkout.post.ts, the webhook's shared
+// createPrintJobIfEligible) already assumes one. Inventing a parallel
+// non-ArtImage SKU shape would need a schema change, which is out of this
+// task's scope. The Kind Robots logo already exists as a static asset
+// (public/icon-512x512.png, wired as the PWA icon in nuxt.config.ts) -- this
+// script gives it a real ArtImage row that points at that same file instead
+// of generating new art, so it can ride the existing pipeline unchanged.
+//
+// storefrontFeatured: true is what actually makes it purchasable today: the
+// live, working path is /api/art/storefront-featured -> giftshop-interact.vue's
+// "Featured prints" grid -> addFeaturedPrint -> the general cart -> checkout.post.ts
+// -> the webhook's handleGiftshopCartPurchase -> a real PrintJob. This is the
+// same live path every other real print already uses -- no route or component
+// changes needed. (A separate, dedicated Product/POD SKU with its own price via
+// pod-checkout.post.ts was considered and rejected: that route is orphaned dead
+// code with no reachable caller, see its own header comment -- creating a
+// Product row for it would be an inert row with no live checkout path to use it.)
+//
+// checkpointResourceId is left null so checkPrintEligibility's base-model
+// branch applies ("no checkpoint/LoRA override" -- eligible unconditionally).
+//
+// Wired into scripts/vercel-build.mjs's production-deploy maintenance step
+// (alongside seed_achievements.ts/seed_contenders.ts) so this row reconciles
+// itself on every production deploy instead of needing a one-off manual run.
+//
+// Usage:
+//   npx tsx scripts/seed_kr_logo_art_image.ts            # dry run (default)
+//   npx tsx scripts/seed_kr_logo_art_image.ts --write    # apply
+
+import 'dotenv/config'
+import { fileURLToPath } from 'node:url'
+import { PrismaClient } from '../prisma/generated/prisma/client'
+import { PrismaMariaDb } from '@prisma/adapter-mariadb'
+
+function createSeedPrismaClient(): PrismaClient {
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) throw new Error('DATABASE_URL is missing')
+  return new PrismaClient({ adapter: new PrismaMariaDb(databaseUrl) })
+}
+
+// fileName is the idempotency key: ArtImage has no unique slug column, so a
+// stable, human-recognizable fileName that nothing else would plausibly seed
+// stands in for one (same approach as looking a row up by a would-be-unique
+// business key before create).
+export const KR_LOGO_FILE_NAME = 'kind-robots-logo.png'
+export const KR_LOGO_IMAGE_PATH = '/icon-512x512.png'
+
+export type KrLogoArtImageData = {
+  userId: number
+  fileName: string
+  imagePath: string
+  path: string
+  isPublic: boolean
+  isMature: boolean
+  isActive: boolean
+  storefrontFeatured: boolean
+  checkpointResourceId: null
+  promptString: string
+}
+
+export const krLogoArtImageData: KrLogoArtImageData = {
+  userId: 10, // app-wide default/system owner id, matching ArtImage's own @default(10)
+  fileName: KR_LOGO_FILE_NAME,
+  imagePath: KR_LOGO_IMAGE_PATH,
+  path: KR_LOGO_IMAGE_PATH,
+  isPublic: true,
+  isMature: false,
+  isActive: true,
+  storefrontFeatured: true,
+  checkpointResourceId: null,
+  promptString: 'Kind Robots logo',
+}
+
+async function main() {
+  const WRITE = process.argv.includes('--write')
+
+  console.log(
+    `Would upsert one ArtImage row for '${KR_LOGO_FILE_NAME}' (storefrontFeatured: true).`,
+  )
+
+  if (!WRITE) {
+    console.log('[dry run] Re-run with --write to apply.')
+    return
+  }
+
+  const prisma = createSeedPrismaClient()
+  try {
+    const existing = await prisma.artImage.findFirst({
+      where: { fileName: KR_LOGO_FILE_NAME },
+      select: { id: true },
+    })
+
+    if (existing) {
+      await prisma.artImage.update({
+        where: { id: existing.id },
+        data: krLogoArtImageData,
+      })
+      console.log(`Updated existing ArtImage #${existing.id}.`)
+    } else {
+      const created = await prisma.artImage.create({
+        data: krLogoArtImageData,
+      })
+      console.log(`Created ArtImage #${created.id}.`)
+    }
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+// Run the CLI only when executed directly, not when imported.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -88,6 +88,12 @@ if (!isVercelBuild || isProductionDeployment) {
     ['scripts/seed_contenders.ts', '--write'],
     'Seeding Challenge Center contenders',
   )
+
+  runOptionalDatabaseMaintenance(
+    tsxBinary,
+    ['scripts/seed_kr_logo_art_image.ts', '--write'],
+    'Seeding Kind Robots logo storefront ArtImage row (digital-storefront/t-003)',
+  )
 } else {
   console.log(
     `[vercel-build] Skipping migrations and database seeds for Vercel ${process.env.VERCEL_ENV || 'unknown'} deployment`,

--- a/server/api/store/pod-checkout.post.ts
+++ b/server/api/store/pod-checkout.post.ts
@@ -6,6 +6,20 @@
 // PrintJob fulfillment record once payment completes. Submitting the order to
 // a POD vendor (Printful) is intentionally NOT part of this route — no
 // vendor account/API key exists yet (digital-storefront/t-015, needs-human).
+//
+// RETIRED (digital-storefront/t-003, item 3, 2026-08-08): this route is
+// orphaned. Its only caller, components/abandonware/giftshop/print-swag.vue,
+// lives under a path Nuxt's component auto-import ignores entirely
+// (nuxt.config.ts's `ignore: ['abandonware/**/*.vue']`), so <print-swag> can
+// never resolve to a component and this endpoint is unreachable from the live
+// app. Formally superseded by the general-cart featured-art path
+// (giftshop-interact.vue's addFeaturedPrint -> shopping-cart.vue ->
+// checkout.post.ts -> the webhook's handleGiftshopCartPurchase), which already
+// does end-to-end what this route was meant to do and is what the KR-logo SKU
+// (t-003 item 1) uses. Left in place rather than deleted, in case a future
+// per-instance-priced POD SKU flow wants a real, tested starting point — but
+// do not wire any new UI to it without first re-confirming it's still needed
+// over the general-cart path.
 import { createError, defineEventHandler, readBody } from 'h3'
 import Stripe from 'stripe'
 import prisma from '../../utils/prisma'

--- a/stores/seeds/cartItems.ts
+++ b/stores/seeds/cartItems.ts
@@ -1,4 +1,28 @@
 // /stores/seeds/cartItems.ts
+//
+// The generic, per-type catalog for the general multi-item giftshop cart.
+// server/api/stripe/checkout.post.ts trusts this array as its server-side
+// price source (looked up by id) -- it answers "what does a sticker
+// generically cost," not "what does this specific printed sticker of
+// ArtImage #42 cost."
+//
+// This intentionally coexists with real `Product` rows (digital-storefront/
+// t-003, item 4): product-checkout.post.ts and pod-checkout.post.ts price
+// per-(printType, artImageId) *instances* against the Product table, upserting
+// a row per specific print rather than per generic type. The two aren't
+// duplicate catalogs of the same thing -- they operate at different
+// granularities and the webhook bridges them: server/api/stripe/webhook.post.ts's
+// GIFTSHOP_TYPE_TO_PRODUCT_TYPE map + handleGiftshopCartPurchase takes whichever
+// cartItems.ts entry was purchased and lazily upserts a matching Product row
+// (slug: `giftshop-${catalogEntry.id}`) at fulfillment time, so every general-cart
+// purchase still ends up with a real Product audit row -- just created on
+// demand instead of pre-seeded. `donation` and `tokens` have no Product-table
+// equivalent at all (donation is recorded via the same lazy webhook upsert;
+// tokens calls applyMana() directly, no Entitlement/PrintJob involved).
+// Retiring this file in favor of pre-seeded Product rows would need either two
+// different key shapes in one table (generic-type rows and per-instance rows)
+// or rewriting checkout.post.ts's cart-price-trust model entirely -- a real
+// design change, not something to do incidentally alongside a catalog task.
 
 export interface CartItem {
   id: string


### PR DESCRIPTION
### Task
digital-storefront/t-003 (slice 1): Seed the KR-logo/DLC catalog and resolve the storefront's two pricing/POD-entry-point splits (kind: software)

### What changed / what I produced
- `scripts/seed_kr_logo_art_image.ts`: new idempotent seed for a real `ArtImage` row pointing at the existing `public/icon-512x512.png` logo asset (`storefrontFeatured: true`, `checkpointResourceId: null` so `checkPrintEligibility`'s base-model branch applies unconditionally). This is what actually makes the logo purchasable *today* via the live, working general-cart path (`/api/art/storefront-featured` → `giftshop-interact.vue`'s "Featured prints" → cart → `checkout.post.ts` → the webhook → a real `PrintJob`) — no new route or component needed. Wired into `scripts/vercel-build.mjs`'s production-deploy maintenance step (alongside `seed_achievements.ts`/`seed_contenders.ts`) so it reconciles on every deploy instead of needing a one-off manual `--write` run.
- `server/api/store/pod-checkout.post.ts`: documented as formally retired (item 3). Confirmed genuinely orphaned — its only caller, `components/abandonware/giftshop/print-swag.vue`, sits under a path `nuxt.config.ts`'s component auto-import ignores entirely (`ignore: ['abandonware/**/*.vue']`), so `<print-swag>` can never resolve. No code deleted, left inert as a starting point if a future per-instance-priced POD flow needs one.
- `stores/seeds/cartItems.ts`: documented why it intentionally coexists with per-instance `Product` rows (item 4) — generic per-type catalog (trusted by `checkout.post.ts`) vs. per-`(printType, artImageId)` instances created lazily at fulfillment by the webhook's `GIFTSHOP_TYPE_TO_PRODUCT_TYPE` map / `handleGiftshopCartPurchase`.

Item 2 (DLC live catalog + wiring `contentAccess.ts`'s `packId` check into the Dream/Facet/Character/Reward routes) is **not** in this slice — it touches four different, currently-inconsistent access-check implementations (one, `characters/[id].get.ts`, has a pre-existing unrelated access-control gap) plus a new admin route, genuinely larger/judgment-heavy work. Split into conductor `digital-storefront/t-004` as a follow-on.

### Why an ArtImage row instead of a standalone Product/POD SKU
`PrintJob.artImageId` is a required, non-nullable FK, and `checkPrintEligibility` is fundamentally `ArtImage`-shaped — every POD-fulfilling path in this repo already assumes one. A parallel non-ArtImage SKU shape would need a schema change (out of this task's code-only scope). A dedicated `Product`/POD-priced row via `pod-checkout.post.ts` was considered and rejected: that route is orphaned dead code with no reachable caller (see above), so a `Product` row for it would be inert with no live checkout path to use it. Seeding the `ArtImage` row instead makes the logo genuinely orderable today through the general-cart path every other real print already uses.

### How I verified
- `npx eslint` on all four changed/new files: 0 problems.
- `npx prettier --check`: clean.
- `npx vue-tsc --noEmit -p tsconfig.json`: clean, exit 0.
- `npm run test:lint-ratchet`: ratchet holds — 392 problems across 27 rules, unchanged.
- `npx tsx scripts/seed_kr_logo_art_image.ts` (dry run, no `--write`): validates.
- Did **not** run `--write` against a real database from this sandbox (no prod DB access here — same limitation digital-storefront/t-011's `seed_products.ts` had). The `vercel-build.mjs` wiring is what actually applies the seed, on the next production deploy.

### Stakes
reversible — purely additive data (one `ArtImage` row via an idempotent, upsert-by-`fileName` seed) plus documentation comments; no schema change, no route deleted, no live behavior change to any existing purchase path.

### Notes for reviewer
Conductor task `digital-storefront/t-003` claimed for this slice; roadmap will be updated with a slice note and item 2 split into a new task (`t-004`).


---
_Generated by [Claude Code](https://claude.ai/code/session_015mSTUJtcyNJKig8DWddwos)_