### PR TITLE
digital-storefront/t-039: fix subscribe.post.ts price-id gap, add topup/subscribe/cancel-subscription auth+validation coverage

### DIFF
--- a/cypress/e2e/api/stripe-checkout.cy.ts
+++ b/cypress/e2e/api/stripe-checkout.cy.ts
@@ -193,7 +193,153 @@ describe('Stripe Checkout Identity API Tests', () => {
     }).then((response) => {
       expect(response.status).to.eq(400)
       expect(response.body.success).to.eq(false)
-      expect(response.body.message).to.include('valid Stripe checkout session ID')
+      expect(response.body.message).to.include(
+        'valid Stripe checkout session ID',
+      )
+    })
+  })
+})
+
+// digital-storefront/t-039: topup/subscribe/cancel-subscription previously had
+// zero test coverage of any kind. Each route's real fulfillment step (creating
+// a live Stripe Checkout Session or cancelling a real subscription) needs a
+// configured Stripe account this suite doesn't have, but each route also does
+// real request-shape validation *before* it ever calls Stripe — the same
+// "cheap to verify, was never verified" gap stripe-checkout.cy.ts already
+// closed for checkout.post.ts/checkout-status.get.ts above.
+describe('Stripe Mana Top-up API Tests', () => {
+  let topupUrl = ''
+  let userToken = ''
+
+  before(() => {
+    return getApiEnv()
+      .then((env) => {
+        topupUrl = `${env.apiBase}/stripe/topup`
+        return createLoggedInTestUser()
+      })
+      .then((user) => {
+        userToken = user.token
+      })
+  })
+
+  it('rejects top-up without authentication', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: topupUrl,
+      headers: jsonHeaders(),
+      body: { tierId: 'small' },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(401)
+      expect(response.body.success).to.eq(false)
+    })
+  })
+
+  it('rejects top-up with an invalid token', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: topupUrl,
+      headers: invalidBearerHeaders(),
+      body: { tierId: 'small' },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(401)
+      expect(response.body.success).to.eq(false)
+    })
+  })
+
+  it('rejects unknown top-up tiers before contacting Stripe', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: topupUrl,
+      headers: bearerHeaders(userToken),
+      body: { tierId: 'gigantic' },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Invalid top-up tier')
+    })
+  })
+})
+
+describe('Stripe Subscription API Tests', () => {
+  let subscribeUrl = ''
+  let cancelSubscriptionUrl = ''
+  let userToken = ''
+
+  before(() => {
+    return getApiEnv()
+      .then((env) => {
+        subscribeUrl = `${env.apiBase}/stripe/subscribe`
+        cancelSubscriptionUrl = `${env.apiBase}/stripe/cancel-subscription`
+        return createLoggedInTestUser()
+      })
+      .then((user) => {
+        userToken = user.token
+      })
+  })
+
+  it('rejects subscribe checkout without authentication', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: subscribeUrl,
+      headers: jsonHeaders(),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(401)
+      expect(response.body.success).to.eq(false)
+    })
+  })
+
+  it('rejects subscribe checkout with an invalid token', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: subscribeUrl,
+      headers: invalidBearerHeaders(),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(401)
+      expect(response.body.success).to.eq(false)
+    })
+  })
+
+  it('rejects cancel-subscription without authentication', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: cancelSubscriptionUrl,
+      headers: jsonHeaders(),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(401)
+      expect(response.body.success).to.eq(false)
+    })
+  })
+
+  it('rejects cancel-subscription with an invalid token', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: cancelSubscriptionUrl,
+      headers: invalidBearerHeaders(),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(401)
+      expect(response.body.success).to.eq(false)
+    })
+  })
+
+  it('rejects cancelling a subscription the user does not have, without contacting Stripe', () => {
+    // A freshly created test user has no stripeSubscriptionId, so this route's
+    // own guard must reject before it ever calls stripe.subscriptions.cancel().
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: cancelSubscriptionUrl,
+      headers: bearerHeaders(userToken),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('No active subscription')
     })
   })
 })

--- a/server/api/stripe/subscribe.post.ts
+++ b/server/api/stripe/subscribe.post.ts
@@ -22,11 +22,32 @@ function getStripeClient() {
   return stripe
 }
 
+// Mirrors getStripeClient()'s explicit-guard shape (digital-storefront/t-039):
+// the bare `process.env.STRIPE_PRICE_ID!` non-null assertion this used to pass
+// straight into `line_items` doesn't check anything at runtime, so an unset
+// price id fell through to a raw Stripe "No such price: 'undefined'" API
+// error instead of the app's own structured 500 every other Stripe route
+// returns when its own required config is missing.
+function getSubscriptionPriceId() {
+  const priceId = process.env.STRIPE_PRICE_ID
+
+  if (!priceId) {
+    const error = new Error(
+      'Stripe subscription price is not configured',
+    ) as Error & { statusCode: number }
+    error.statusCode = 500
+    throw error
+  }
+
+  return priceId
+}
+
 export default defineEventHandler(async (event) => {
   try {
     const { user } = await requireApiUser(event)
 
     const stripe = getStripeClient()
+    const priceId = getSubscriptionPriceId()
     const email = user.email || `user-${user.id}@kindrobots.org`
 
     const customerId =
@@ -44,7 +65,7 @@ export default defineEventHandler(async (event) => {
       customer: customerId,
       line_items: [
         {
-          price: process.env.STRIPE_PRICE_ID!,
+          price: priceId,
           quantity: 1,
         },
       ],


### PR DESCRIPTION
### Task
digital-storefront/t-039: Run and repair the Stripe checkout/webhook/fulfillment matrix end-to-end (kind: software)

### What changed / what I produced
- `server/api/stripe/subscribe.post.ts`: replaced the bare `process.env.STRIPE_PRICE_ID!` non-null assertion with an explicit `getSubscriptionPriceId()` guard (mirrors `getStripeClient()`'s existing pattern used by every other Stripe route). Previously, an unconfigured `STRIPE_PRICE_ID` fell through to a raw Stripe `No such price: 'undefined'` API error instead of the app's own structured 500.
- `cypress/e2e/api/stripe-checkout.cy.ts`: `topup.post.ts`, `subscribe.post.ts`, and `cancel-subscription.post.ts` had **zero** test coverage of any kind before this PR. Added:
  - auth-rejection coverage (401, no token / invalid token) for all three routes
  - `topup.post.ts`'s tier-validation rejection (`Invalid top-up tier`), which runs before any Stripe call
  - `cancel-subscription.post.ts`'s no-active-subscription guard (`No active subscription`), which also runs before any Stripe call

### How I verified
- `npx eslint` on both changed files: clean (the Cypress spec is eslint-ignored by config, same as its sibling specs).
- `npx prettier --check`: clean.
- `npx vue-tsc --noEmit -p tsconfig.json`: clean, exit 0.
- `npm run test:lint-ratchet`: ratchet holds — 392 problems across 27 rules, unchanged.

### Stakes
reversible

### Flags for Reviewer
- This does **not** close the full scope of digital-storefront/t-039. A real end-to-end run (live/test-mode Checkout Session creation, signed webhook delivery, DB-persisted fulfillment state for PDF entitlement/mana top-up/POD PrintJob/DLC Grant/general cart) requires a configured `STRIPE_SECRET_KEY`/`STRIPE_WEBHOOK_SECRET` and a reachable database that this sandbox does not have — confirmed no `.env.example`, no CI workflow sets these as secrets, and the repo's only live-mode Cypress harness (`cypress.yml`) targets production and is currently manual-dispatch-only. This is the same credential/DB gap `t-037`'s audit already hit and explicitly deferred to this task.
- What *was* achievable offline (a real code-inspection bug fix + closing a previously-100%-untested route's cheap validation paths) is what this PR ships. The conductor roadmap note for t-039 documents the remaining credential-gated scope explicitly rather than silently treating this PR as a full close-out.

### Kaizen suggestion
Add a Stripe-webhook fixture test (constructing a `checkout.session.completed` event and signing it locally via `stripe.webhooks.generateTestHeaderString` — this needs no live Stripe account, just the `stripe` npm package) to directly exercise `webhook.post.ts`'s routing logic (`mana_topup` vs `subscription` vs `productSlug` vs `giftshop_checkout`) against a mocked Prisma client. That would close the webhook-routing coverage gap without needing live credentials, unlike the fulfillment-state assertions which do need a real DB.

### Notes for reviewer
Conductor task `digital-storefront/t-039` will be updated with this PR reference and the credential-gap note; see the conductor PR in the same session.

---
_Generated by [Claude Code](https://claude.ai/code/session_017ioT5sJYi1LqeKtxnpdprq)_