### PR TITLE
interface-vision/t-104: converge newsfeed feed-card onto kr-entity-card-body

### DIFF
--- a/components/newsfeed/feed-card.vue
+++ b/components/newsfeed/feed-card.vue
@@ -5,50 +5,20 @@
     :href="allowNavigation ? item.url : undefined"
     :target="allowNavigation ? '_blank' : undefined"
     :rel="allowNavigation ? 'noopener noreferrer' : undefined"
-    class="group flex h-full flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm transition-shadow duration-300 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 motion-safe:hover:-translate-y-0.5 motion-safe:transition-transform"
+    class="group flex h-full flex-col gap-2 overflow-hidden rounded-2xl border border-base-300 bg-base-100 p-3 shadow-sm transition-shadow duration-300 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 motion-safe:hover:-translate-y-0.5 motion-safe:transition-transform"
   >
-    <figure
-      v-if="showImage"
-      class="relative aspect-video w-full overflow-hidden bg-base-300"
+    <kr-entity-card-body
+      class="flex flex-1 flex-col"
+      :title="item.title"
+      :description="item.summary || undefined"
+      :show-description="Boolean(item.summary)"
+      :show-image="showImage"
+      :source="imageSource"
+      variant="hero"
+      :fallback="fallbackImageSrc"
+      hover-zoom
+      :badges="badges"
     >
-      <img
-        v-if="imageSrc && !imageFailed"
-        :src="imageSrc"
-        :alt="item.title"
-        class="h-full w-full object-cover motion-safe:transition-transform motion-safe:duration-300 motion-safe:group-hover:scale-[1.03]"
-        loading="lazy"
-        @error="imageFailed = true"
-      />
-      <img
-        v-else
-        :src="fallbackImageSrc"
-        :alt="item.title"
-        class="h-full w-full object-cover motion-safe:transition-transform motion-safe:duration-300 motion-safe:group-hover:scale-[1.03]"
-        loading="lazy"
-      />
-
-      <span
-        v-if="primaryCategory"
-        class="badge badge-primary badge-sm absolute left-2 top-2 rounded-xl shadow"
-      >
-        {{ primaryCategory }}
-      </span>
-    </figure>
-
-    <div class="flex flex-1 flex-col gap-2 p-3">
-      <h3
-        class="line-clamp-2 text-sm font-black leading-tight text-base-content sm:text-base"
-      >
-        {{ item.title }}
-      </h3>
-
-      <p
-        v-if="item.summary"
-        class="line-clamp-2 text-xs leading-relaxed text-base-content/65 sm:text-sm"
-      >
-        {{ item.summary }}
-      </p>
-
       <div
         class="mt-auto flex flex-wrap items-center justify-between gap-2 pt-1"
       >
@@ -84,14 +54,16 @@
           />
         </span>
       </div>
-    </div>
+    </kr-entity-card-body>
   </component>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import type { NewsFeedItem } from '@/stores/helpers/newsfeed'
 import { useFeedPreferenceStore } from '@/stores/feedPreferenceStore'
+import type { EntityCardChip } from '@/components/gallery/kr-entity-card-body.vue'
+import type { ArtImageSrcLike } from '@/utils/artImageSrc'
 
 const props = withDefaults(
   defineProps<{
@@ -107,10 +79,21 @@ const props = withDefaults(
 
 const feedPreferenceStore = useFeedPreferenceStore()
 
-const imageFailed = ref(false)
-
-const imageSrc = computed(() => props.item.image || '')
 const primaryCategory = computed(() => props.item.category?.[0] || '')
+
+// NewsFeedItem carries a plain `image` URL rather than the cardPath/heroPath/
+// iconPath shape most art-bearing records use -- kr-art-plate's resolver
+// chain falls through to `imagePath` for any variant that has no dedicated
+// path of its own, so wrapping it here is enough to reuse the same plate/
+// fallback/retry-on-error logic every other card gets instead of hand-rolling
+// a second <img>-with-@error pair.
+const imageSource = computed<ArtImageSrcLike>(() => ({
+  imagePath: props.item.image || null,
+}))
+
+const badges = computed<EntityCardChip[]>(() =>
+  primaryCategory.value ? [{ label: primaryCategory.value }] : [],
+)
 
 // A repeating flat icon on every image-less card reads as "a sea of empty
 // boxes" (Silas, 2026-07-25) -- pick one of 8 default illustrations per item


### PR DESCRIPTION
### Task
interface-vision/t-104 (slice 4): Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- `components/newsfeed/feed-card.vue`: migrated off its hand-rolled image+badge+title+description+footer markup onto `kr-entity-card-body`. It was structurally identical to the shape server-card/dream-card/bot-card already converged on (hero-shaped art with a top-left overlay badge, clamped title+description, per-object footer content).
- `NewsFeedItem` carries a plain `image` URL rather than the `cardPath`/`heroPath`/`iconPath` shape most art-bearing records use — wrapped it as `{ imagePath: item.image }` so `kr-art-plate`'s existing resolver/fallback/retry-on-error chain covers it instead of a hand-rolled second `<img>` with its own `@error` handler.
- `variant="hero"` matches `kr-art-plate`'s 16:9 aspect, the same ratio the original `aspect-video` figure used.
- Kept the source/perspective/relative-time footer row as default-slot content (genuinely per-object display, not a generic meta chip) and the `primaryCategory` badge via the `badges` prop (same top-left overlay spot the original absolute-positioned badge used).
- Outer wrapper keeps its `allowNavigation`-driven `a`/`article` swap exactly (`verifyWonderLabPassiveCardFixtures.ts` asserts the literal source patterns for this), now padded like every other converged card instead of running the image edge-to-edge — the edge-to-edge "poster" pattern was already retired repo-wide (see `dream-card.vue`'s own comment on the same convergence).

### How I verified
- `npx eslint components/newsfeed/feed-card.vue`: clean.
- `npx vue-tsc --noEmit -p tsconfig.json`: clean, exit 0.
- `npx prettier --check components/newsfeed/feed-card.vue`: clean.
- `npm run test:lint-ratchet`: holds, 392/27 unchanged.
- `npm run test:layout-contract`, `test:gallery-adoption`, `test:card-action-contract`, `test:narrative-kit`, `test:wonderlab-passive-card-fixtures`: all pass unchanged (the last one specifically asserts the `allowNavigation ? 'a' : 'article'` literal pattern I preserved).

### Stakes
reversible

### Flags for Reviewer
- Investigated two other candidates flagged by the prior slice's note before picking this one:
  - `components/resources/resource-card.vue` — turned out to be a **bad** migration target, not a stale-note oversight. It was substantially rewritten two commits ago (kind_robots #1607, #1611) directly per Silas's live feedback ("selecting the card brings us to the full info display with the animation... think the back of a baseball card") into a deliberately bespoke flip-card interaction with resource-specific primary actions (Add to build / Start fresh) that don't fit `kr-entity-card-body`'s `open`-centric contract. The file's own header comment explicitly documents why it opts out of `verifyCardActionContract`'s `ENTITY_CARDS`. Forcing this migration would contradict t-104's own "preserve deliberately bespoke surfaces" scope and very likely get rejected. Recommend the roadmap note stop listing it as an open candidate.
  - `components/dreams/daily-digest-object-gallery.vue` — confirmed still genuinely blocked: its item art is a fixed `h-16` banner that doesn't match any of `kr-art-plate`'s four aspect shapes (card/hero/square/wide), so this needs a real primitive addition (a new shape, or a `compact`/row density) before a mechanical swap is possible, not just a slice pick-up.
- `feed-card.vue`'s footer previously used a hand-rolled `mt-auto` to pin the source/time row to the card bottom regardless of title/summary length. No existing `kr-entity-card-body` adopter relies on that (none pass extra classes to force flex-grow), so I kept `mt-auto` plus an explicit `class="flex flex-1 flex-col"` on `kr-entity-card-body` to preserve the original bottom-pinned behavior — flagging this as a new (if small) pattern in case a Reviewer wants it generalized rather than one-off.

### Kaizen suggestion
`daily-digest-object-gallery.vue`'s fixed-height row card is a second live example (after the deferred chat-gallery date-divider gap) of a real, currently-missing `kr-art-plate`/`kr-entity-card-body` primitive — a short "row" or "banner" shape sized by height rather than aspect ratio. Worth its own small primitive task before more callers reinvent one.

### Notes for reviewer
Conductor task `interface-vision/t-104` claimed for this slice (session `2026-08-08T183755Z-iv-t104-slice4-fc9k`); roadmap will be updated with a slice-4 note (including correcting the resource-card.vue candidate) and set back to `status: ready` for the next slice, same multi-slice shape as t-103/t-104's prior slices.

---
_Generated by [Claude Code](https://claude.ai/code/session_0169rstte4GZGXa5hFBrUNhb)_