### PR TITLE
interface-vision/t-104: reuse compact art plate in Daily Dream bundle

### DIFF
--- a/components/dreams/daily-digest-object-gallery.vue
+++ b/components/dreams/daily-digest-object-gallery.vue
@@ -34,28 +34,32 @@
           :aria-label="`Open ${item.title}`"
           @click="selectedItem = item"
         >
-          <figure class="relative h-16 shrink-0 overflow-hidden bg-base-200">
-            <img
-              v-if="item.image"
-              :src="item.image"
-              :alt="`${item.title} artwork`"
-              class="absolute inset-0 size-full object-cover transition duration-300 group-hover:scale-[1.03]"
-            />
-            <div
-              v-else
-              class="absolute inset-0 flex items-center justify-center gap-2 px-2 text-center text-base-content/30"
-            >
-              <Icon :name="item.icon" class="size-6 opacity-45" />
-              <span class="text-[0.58rem] font-bold uppercase tracking-wide">
-                Awaiting art
+          <kr-art-plate
+            :source="{ imagePath: item.image || null }"
+            variant="hero"
+            shape="hero"
+            compact
+            frame="none"
+            :alt="`${item.title} artwork`"
+            :placeholder-icon="item.icon"
+            hover-zoom
+          >
+            <template #overlay>
+              <div
+                v-if="!item.image"
+                class="absolute inset-0 flex items-center justify-center pt-8 text-center text-base-content/30"
+              >
+                <span class="text-[0.58rem] font-bold uppercase tracking-wide">
+                  Awaiting art
+                </span>
+              </div>
+              <span
+                class="badge badge-neutral badge-xs absolute left-1.5 top-1.5 max-w-[calc(100%-0.75rem)] truncate rounded-md shadow"
+              >
+                {{ item.role }}
               </span>
-            </div>
-            <span
-              class="badge badge-neutral badge-xs absolute left-1.5 top-1.5 max-w-[calc(100%-0.75rem)] truncate rounded-md shadow"
-            >
-              {{ item.role }}
-            </span>
-          </figure>
+            </template>
+          </kr-art-plate>
 
           <div class="flex min-h-0 flex-1 flex-col p-2.5">
             <div class="flex items-start gap-1.5">

--- a/components/narrative/kr-art-plate.vue
+++ b/components/narrative/kr-art-plate.vue
@@ -80,6 +80,7 @@ const props = withDefaults(
      * shape.
      */
     shape?: ArtPlateShape
+    compact?: boolean
     /**
      * 'plate' is the white tipped-photo border the aesthetic is named for.
      * 'thin' is a plain hairline for inline thumbnails.
@@ -106,6 +107,7 @@ const props = withDefaults(
     fallback: '',
     alt: '',
     shape: 'plate',
+    compact: false,
     frame: 'plate',
     fit: 'cover',
     hoverZoom: false,
@@ -172,6 +174,8 @@ const src = computed(() => {
  * non-gallery surfaces that ask for them by name.
  */
 const aspectClass = computed(() => {
+  if (props.compact) return 'h-16 w-full'
+
   switch (props.shape) {
     case 'card':
       return 'aspect-2/3 w-full'
@@ -184,7 +188,6 @@ const aspectClass = computed(() => {
     case 'plate':
       return 'aspect-3/2 w-full'
     default:
-      // imagePath's shape. Square is the default because the stored image is.
       return 'aspect-square w-full'
   }
 })

--- a/components/narrative/kr-art-plate.vue
+++ b/components/narrative/kr-art-plate.vue
@@ -174,7 +174,7 @@ const src = computed(() => {
  * non-gallery surfaces that ask for them by name.
  */
 const aspectClass = computed(() => {
-  if (props.compact) return 'h-16 w-full'
+  if (props.compact) return 'h-16 w-full shrink-0'
 
   switch (props.shape) {
     case 'card':


### PR DESCRIPTION
### Task
interface-vision/t-104, slice 5: drive live front-end consistency onto shared kr-* components and composition rules.

### What changed
- Added an opt-in `compact` mode to `kr-art-plate`; it preserves the shared source resolution, fallback, placeholder, overlay, fit, and hover behavior while drawing a fixed `h-16` row/banner instead of an aspect-ratio plate. Existing callers are unchanged because the new prop defaults false.
- Migrated `daily-digest-object-gallery.vue` off its bespoke `<figure>/<img>` path and onto `kr-art-plate`, preserving the existing horizontal snap carousel, desktop grid, role badge, no-art label, text hierarchy, and open-details behavior.
- Kept this orthogonal to gallery mode/variant vocabulary. Daily Digest still owns its horizontal carousel layout; this slice closes the concrete art-primitive gap identified in slice 4 rather than inventing a fourth gallery mode.

### Verification
This automation runtime has no local Kind Robots checkout/dependencies, so PR CI is the executable authority. I inspected the current shared primitive, Daily Digest caller, gallery vocabulary, and the merged slice-4 implementation before changing the two files. TypeScript/contracts/layout checks must complete successfully on this exact head before merge.

### Stakes
Reversible.

### Handoff
Conductor claim/review session: `2026-08-08T191124Z-iv-t104-s5-r8q2`. t-104 remains a multi-slice consistency task after this unit; return it to `ready` after a green merge rather than falsely closing the umbrella.