### PR TITLE
fix(model-builder): keep run history open on failed load

### DIFF
--- a/components/model-builder/model-builder-run-history.vue
+++ b/components/model-builder/model-builder-run-history.vue
@@ -154,6 +154,7 @@ function progress(run: BuildRun): string {
 
 async function open(runId: string): Promise<void> {
   await store.openRun(runId)
+  if (store.run?.id !== runId) return
   emit('close')
 }
 


### PR DESCRIPTION
## Summary
- keep Model Builder Run History open when opening a run fails
- only dismiss the history panel once the requested run is actually active

## Root cause
`model-builder-run-history.vue` awaited `store.openRun(run.id)` and then always emitted `close`. `openRun()` deliberately leaves the active run unchanged when its fetch fails, so a transient failure dismissed the history UI and removed the immediate retry path.

## Scope
One Vue component, +2/-1. No API, schema, production-data, route, or layout changes.

Conductor: `model-builder/t-029`
Session: `2026-08-08T202645Z-model-builder-t029-k9r4`

## Verification
- source contract inspected: `openRun()` mutates `store.run` only on success
- branch diff is one commit ahead / zero behind current main, one file changed
- PR CI is the authoritative TypeScript/contract gate for this connector-only run
