### PR TITLE
fix(pwa): mount VitePwaManifest so the manifest link actually ships

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -7,6 +7,18 @@
     :data-kr-backdrop="hasPageBackdrop ? '' : undefined"
   >
     <!--
+      ai-art-academy/t-062+t-063: @vite-pwa/nuxt does not inject the
+      <link rel="manifest"> tag automatically -- it only ships one via this
+      renderless component (module source: dist/runtime/components/
+      VitePwaManifest.js), which nuxt.config.ts's `pwa` block never mounted
+      anywhere. Without a linked manifest, browsers never satisfy the
+      installability criteria and `beforeinstallprompt` never fires, even
+      though /manifest.webmanifest itself resolves fine. Renders nothing;
+      mount once, root-level, so every route gets the link.
+    -->
+    <VitePwaManifest />
+
+    <!--
       FULL PAGE, not just the content well. Silas, 2026-08-06: "I'm more
       interested in why we aren't doing backgrounds from the full page spread,
       and instead still starting in main content, so the dashboard section and
@@ -221,8 +233,8 @@ const pageStore = usePageStore()
 const hasPageBackdrop = computed(() =>
   Boolean(
     pageStore.backgroundMobile ||
-      pageStore.backgroundTablet ||
-      pageStore.backgroundDesktop,
+    pageStore.backgroundTablet ||
+    pageStore.backgroundDesktop,
   ),
 )
 const navStore = useNavStore()


### PR DESCRIPTION
### Task
ai-art-academy/t-062 (Ship an installable/testable Android Academy app build) — investigating the shared PWA-installability precondition also blocking t-063 (iOS) (kind: software, cross-repo — task state lives in the conductor roadmap)

### What changed / what I produced
- `app.vue`: mounts `<VitePwaManifest />` (a renderless component `@vite-pwa/nuxt` ships specifically to inject `<link rel="manifest">` into the page head — `dist/runtime/components/VitePwaManifest.js`) once at the root, so every route gets it.

### Root cause
ai-art-academy/t-066 added `@vite-pwa/nuxt`'s config (manifest, service worker, icon set) to `nuxt.config.ts`, and `/manifest.webmanifest` has resolved correctly on production ever since — but the module does **not** auto-inject the manifest `<link>` tag into rendered pages. That injection only happens via the module's own `VitePwaManifest`/`NuxtPwaManifest` component, which t-066 never mounted anywhere. I confirmed this empirically: SSR-fetched the live production homepage via the Vercel MCP connector and found zero occurrences of the string "manifest" anywhere in `<head>`, despite `/manifest.webmanifest` itself returning valid JSON. Without a linked manifest, no browser will ever fire `beforeinstallprompt` or offer a home-screen install — the site was never actually installable, on any device, regardless of what t-062/t-063 tried to verify.

### How I verified
- `npx eslint app.vue`: clean (pre-existing unrelated warning only).
- `npx vue-tsc --noEmit -p tsconfig.json`: clean, exit 0.
- `npx prettier --check app.vue`: clean.
- `npm run test:lint-ratchet`: holds, 392/27 unchanged.
- `npm run test:layout-contract`, `npm run test:component-reachability`: both pass unchanged (0 new orphans/violations).
- `npx nuxi build`: client + server bundles compile successfully with the new component; the build's prerender step fails on an unrelated, pre-existing sandbox limitation (`JWT_SECRET is not configured`), not on anything in this change.
- Did **not** verify actual "Add to Home Screen" on a real Android/iOS device — that needs physical hardware this sandbox doesn't have. Will re-fetch the merged production homepage's `<head>` via the Vercel MCP connector after merge to confirm the `<link rel="manifest">` tag is now actually present server-rendered, which is the strongest signal available from this sandbox short of a real device.

### Stakes
reversible — purely additive markup (one renderless component mount), no existing behavior changed, no schema/config change beyond what t-066 already shipped.

### Flags for Reviewer
This fixes the shared blocker for both ai-art-academy/t-062 (Android) and t-063 (iOS) — same root cause, same fix, one PR. It does not itself close either task: real home-screen-install verification on Android Chrome / iOS Safari still needs a human with a physical device, which is genuinely outside what any sandboxed agent session can do. Conductor roadmap will record this fix and set both tasks to soft `needs-human` for that final device check rather than `done`.

### Notes for reviewer
Conductor tasks: ai-art-academy/t-062 (claimed for this fix), t-063 (same fix, noted as unblocked-but-still-needs-device-verification).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTUirTvQ6ugPsgse97pNfR)_