### PR TITLE
feat(art): reject bad prompts at the enqueue boundary

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -43,6 +43,14 @@ jobs:
       - name: Art-request YAML indentation contract
         run: npm run test:art-request-yaml
 
+      # Rejects, at enqueue, the prompt shapes that rendered wrong on
+      # 2026-08-08: conditional instructions a diffusion model cannot evaluate,
+      # format nouns ("treasure-card illustration") that make it draw the object
+      # rather than the art, negation piles that land in positive conditioning
+      # at cfg 1, and distilled engines run above their trained guidance.
+      - name: Art prompt contract
+        run: npm run test:art-prompt-contract
+
       - name: Channel content contract
         run: npm run test:channel-content
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "generate:achievement-art": "tsx scripts/generate_achievement_art.ts",
     "test:art-request-yaml": "tsx utils/scripts/verifyArtRequestYaml.ts && tsx utils/scripts/verifyArtAssetSuggest.ts",
     "test:art-prompt-repair": "tsx utils/scripts/verifyArtPromptRepair.ts",
+    "test:art-prompt-contract": "tsx utils/scripts/verifyArtPromptContract.ts",
     "test:entity-art-prompt-framing": "tsx utils/scripts/verifyEntityArtPromptFraming.ts",
     "test:art-asset-suggest": "tsx utils/scripts/verifyArtAssetSuggest.ts",
     "test:artjob-bulk-scope": "tsx utils/scripts/verifyArtJobBulkScope.ts && tsx utils/scripts/verifyArtJobBulkCancel.ts",

--- a/server/api/art/enqueue.post.ts
+++ b/server/api/art/enqueue.post.ts
@@ -32,6 +32,7 @@ import {
   WAN_DEFAULT_DURATION,
   WAN_DEFAULT_FRAME_RATE,
 } from '../comfy/wan/utils/imageToVideoWorkflow'
+import { assertArtPromptContract } from '../../utils/artPromptContract'
 import {
   applyArtFacetsToPayload,
   normalizeArtFacetIds,
@@ -380,6 +381,17 @@ export default defineEventHandler(async (event) => {
       contextualBasePrompt,
       facets,
     )
+
+    // Gate the FULL composed prompt — after entity context and Facet direction
+    // are folded in — because that is the string the model actually sees. Facet
+    // artPrompts and entity context are just as capable of smuggling in a
+    // conditional or a format noun as the caller's own text.
+    assertArtPromptContract({
+      prompt: promptString,
+      engine,
+      steps: resolvedBody.steps ?? null,
+      cfg: resolvedBody.cfg ?? null,
+    })
 
     // Everything that reaches this endpoint is interactive or corrective: the
     // entity art workbench redoing a bad image, a narrative beat a player is

--- a/server/api/art/queue/index.post.ts
+++ b/server/api/art/queue/index.post.ts
@@ -14,6 +14,8 @@ import {
 } from '../../../utils/artJobPayload'
 import { enrichArtJobPayload } from '../../../utils/artJobProvenance'
 import { normalizeQueuedArtJobPayload } from '../../../utils/artJobNormalization'
+import { assertArtPromptContract } from '../../../utils/artPromptContract'
+import { extractRenderRequest } from '../../comfy/utils/engineWorkflow'
 
 const ENGINES = new Set(['A1111', 'COMFY'])
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9_-]*$/
@@ -89,6 +91,26 @@ export default defineEventHandler(async (event) => {
       ? Number(body?.priority)
       : 0
     const normalizedPayload = normalizeQueuedArtJobPayload(rawPayload).payload
+
+    // Gate after normalization, on the render request actually extracted from
+    // the workflow — that is the string ComfyUI receives, and it is not always
+    // the caller's `promptString` (a COMFY payload carries a baked graph).
+    // Conductor's bulk lanes enter here, so this is where a stale replayed
+    // prompt gets stopped rather than rendered.
+    try {
+      const render = extractRenderRequest(normalizedPayload)
+      assertArtPromptContract({
+        prompt: render.prompt,
+        engine: String(normalizedPayload.engine || engine || '').toLowerCase(),
+        steps: Number(normalizedPayload.steps ?? render.steps ?? NaN),
+        cfg: Number(normalizedPayload.cfg ?? render.cfg ?? NaN),
+      })
+    } catch (contractError: unknown) {
+      // A payload shape this endpoint cannot introspect is not a contract
+      // violation — only rethrow the gate's own 422.
+      const status = (contractError as { statusCode?: number })?.statusCode
+      if (status === 422) throw contractError
+    }
 
     const { payload, provenance } = enrichArtJobPayload(
       engine as 'A1111' | 'COMFY',

--- a/server/api/art/queue/index.post.ts
+++ b/server/api/art/queue/index.post.ts
@@ -98,12 +98,23 @@ export default defineEventHandler(async (event) => {
     // Conductor's bulk lanes enter here, so this is where a stale replayed
     // prompt gets stopped rather than rendered.
     try {
+      // extractRenderRequest returns prompt/size/seed only; steps and cfg live
+      // on the payload, which is Record<string, unknown> — coerce explicitly
+      // rather than leaning on `unknown` surviving `||` and `??`.
       const render = extractRenderRequest(normalizedPayload)
+      const numeric = (value: unknown): number | null => {
+        const parsed = Number(value)
+        return Number.isFinite(parsed) ? parsed : null
+      }
+      const payloadEngine =
+        typeof normalizedPayload.engine === 'string'
+          ? normalizedPayload.engine
+          : engine
       assertArtPromptContract({
         prompt: render.prompt,
-        engine: String(normalizedPayload.engine || engine || '').toLowerCase(),
-        steps: Number(normalizedPayload.steps ?? render.steps ?? NaN),
-        cfg: Number(normalizedPayload.cfg ?? render.cfg ?? NaN),
+        engine: String(payloadEngine || '').toLowerCase(),
+        steps: numeric(normalizedPayload.steps),
+        cfg: numeric(normalizedPayload.cfg),
       })
     } catch (contractError: unknown) {
       // A payload shape this endpoint cannot introspect is not a contract

--- a/server/utils/artPromptContract.ts
+++ b/server/utils/artPromptContract.ts
@@ -85,7 +85,18 @@ const CONDITIONAL_PATTERNS: Array<{ pattern: RegExp; rule: string }> = [
 const FORMAT_PATTERNS: Array<{ pattern: RegExp; rule: string }> = [
   { pattern: /\b(?:trading[- ])?card (?:illustration|artwork|composition|art)\b/i, rule: 'format-vocabulary' },
   { pattern: /\b(?:treasure|ability|item|reward)[- ]card\b/i, rule: 'format-vocabulary' },
-  { pattern: /\b(?:movie |film |book )?(?:poster|book cover|magazine cover|album cover)\b/i, rule: 'format-vocabulary' },
+  // "poster composition" is framing language (bold, graphic, close-cropped) and
+  // the coloring-book lane uses it deliberately; "a movie poster" is an object
+  // request. Only the latter is flagged. Note the asymmetry with "card
+  // composition" above, which IS flagged: that one is not a guess — "2:3
+  // portrait card composition" demonstrably rendered a titled trading card with
+  // a rules box. There is no equivalent evidence for poster framing, so the
+  // rule stops where the evidence stops.
+  {
+    pattern:
+      /\b(?:movie |film |book )?(?:poster|book cover|magazine cover|album cover)\b(?!\s+(?:composition|framing|layout|crop))/i,
+    rule: 'format-vocabulary',
+  },
   { pattern: /\bcomic (?:page|panel|strip)\b/i, rule: 'format-vocabulary' },
 ]
 

--- a/server/utils/artPromptContract.ts
+++ b/server/utils/artPromptContract.ts
@@ -177,7 +177,8 @@ export function checkArtPromptContract(
 
   for (const { pattern, rule } of FORMAT_PATTERNS) {
     const match = prompt.match(pattern)
-    if (!match || typeof match.index !== 'number') continue
+    if (!match) continue
+    if (typeof match.index !== 'number') continue
     // A format noun the author is excluding ("no comic panel") is the opposite
     // of a format request. Flagging it rejected the coloring-book lane, whose
     // prompts legitimately name the formats they are avoiding.

--- a/server/utils/artPromptContract.ts
+++ b/server/utils/artPromptContract.ts
@@ -166,30 +166,29 @@ export function checkArtPromptContract(
 
   for (const { pattern, rule } of CONDITIONAL_PATTERNS) {
     const match = prompt.match(pattern)
-    if (match) {
-      violations.push({
-        rule,
-        detail:
-          `"${match[0]}" asks the model to evaluate a condition. Diffusion models ` +
-          `cannot; they render the words. Decide before enqueueing and state one outcome.`,
-      })
-    }
+    if (!match) continue
+    violations.push({
+      rule,
+      detail:
+        `"${match[0]}" asks the model to evaluate a condition. Diffusion models ` +
+        `cannot; they render the words. Decide before enqueueing and state one outcome.`,
+    })
   }
 
   for (const { pattern, rule } of FORMAT_PATTERNS) {
     const match = prompt.match(pattern)
+    if (!match || typeof match.index !== 'number') continue
     // A format noun the author is excluding ("no comic panel") is the opposite
     // of a format request. Flagging it rejected the coloring-book lane, whose
     // prompts legitimately name the formats they are avoiding.
-    if (match && typeof match.index === 'number' && !negated(prompt, match.index)) {
-      violations.push({
-        rule,
-        detail:
-          `"${match[0]}" asks for a physical format, so the model renders the ` +
-          `format — frame, title bar, and invented text included. Describe the ` +
-          `subject and the aspect ratio instead.`,
-      })
-    }
+    if (negated(prompt, match.index)) continue
+    violations.push({
+      rule,
+      detail:
+        `"${match[0]}" asks for a physical format, so the model renders the ` +
+        `format — frame, title bar, and invented text included. Describe the ` +
+        `subject and the aspect ratio instead.`,
+    })
   }
 
   if (VAGUE_BRAND_STYLE.test(prompt)) {

--- a/server/utils/artPromptContract.ts
+++ b/server/utils/artPromptContract.ts
@@ -1,0 +1,254 @@
+// /server/utils/artPromptContract.ts
+//
+// A hard gate on what may reach an image model, enforced at the enqueue
+// boundary so it binds every producer — Conductor scripts, the art workbench,
+// narrative beats, backfill jobs — without each having to remember the rules.
+//
+// Every rule here is a bug that actually shipped on 2026-08-08 and rendered.
+// The full sequence, because the pattern matters more than any single rule:
+// the Reward `item-tidefortune-ladle` came back as a picture of fifteen
+// strangers and no ladle, and each fix uncovered the next cause underneath.
+//
+//   1. A CONDITIONAL instruction. Prompts carried "cast characters naturally
+//      across many species...; include robots only when the subject or scene
+//      explicitly calls for them". "Only when" needs a reader that can evaluate
+//      a condition. Krea 2 is a distilled diffusion transformer: it paints the
+//      densest concrete noun phrase it is given. That clause IS a crowd.
+//
+//   2. FORMAT vocabulary. "treasure card illustration" and "2:3 portrait card
+//      composition" mean "the art printed on a card" to a person. To a model
+//      trained on captions — Qwen-Image lineage, the strongest open text
+//      renderer there is — it means a card. Three rewards came back as literal
+//      trading cards with title bars and rules boxes full of invented text.
+//
+//   3. NEGATION PILES. "no readable text, no lettering, no logos, no watermark,
+//      no signature" names text five times. At cfg 1 the ComfyUI negative
+//      prompt is inert, so those words land in POSITIVE conditioning.
+//
+//   4. ENGINE MISMATCH. Krea 2 Turbo is distilled for cfg 1 and an 8-step
+//      budget; jobs ran at cfg 7 / 20 steps because the queue builder resolved
+//      steps per-engine but hardcoded a single generic cfg.
+//
+// Cost of catching these in CI or review: nothing. Cost of not catching them:
+// roughly 150 wasted renders and a day of the owner's attention, discovered
+// from a screenshot rather than a test.
+//
+// Violations are hard errors, not warnings. A warning on a background pipeline
+// is a log line nobody reads; the whole failure mode here was bad art rendering
+// unnoticed for hours. Producers that trip a rule should fail loudly at enqueue.
+import { createError } from 'h3'
+import { cleanArtPrompt } from './artPromptQuality'
+
+export type ArtPromptViolation = {
+  rule: string
+  detail: string
+}
+
+export type ArtPromptContractInput = {
+  prompt: string
+  engine?: string | null
+  steps?: number | null
+  cfg?: number | null
+}
+
+/**
+ * Engines distilled to run at a fixed low guidance. Above it the model leaves
+ * the distribution it was trained on: burned contrast, crushed colour, and
+ * duplicated subjects. `maxSteps` is a sanity ceiling, not the ideal.
+ */
+export const DISTILLED_ENGINE_LIMITS: Record<
+  string,
+  { cfg: number; maxSteps: number }
+> = {
+  krea2: { cfg: 1, maxSteps: 12 },
+  // The enqueue endpoint normalizes to "flux2"; Conductor's consumer calls the
+  // same engine "flux2-klein". Both spellings reach this gate, so both are keyed
+  // rather than relying on either side to normalize first.
+  flux2: { cfg: 1, maxSteps: 8 },
+  'flux2-klein': { cfg: 1, maxSteps: 8 },
+  flux: { cfg: 1, maxSteps: 40 },
+}
+
+// "only when", "if the scene", "unless", "where appropriate" — anything that
+// asks the model to decide. Producers must decide before they enqueue and state
+// one outcome. Deliberately not matched inside a quoted subject (see below).
+const CONDITIONAL_PATTERNS: Array<{ pattern: RegExp; rule: string }> = [
+  { pattern: /\bonly (?:when|if)\b/i, rule: 'conditional-instruction' },
+  { pattern: /\bwhen (?:the )?(?:subject|scene|context)\b/i, rule: 'conditional-instruction' },
+  { pattern: /\b(?:if|unless) (?:the )?(?:subject|scene|context|prompt)\b/i, rule: 'conditional-instruction' },
+  { pattern: /\bwhere (?:appropriate|relevant|applicable)\b/i, rule: 'conditional-instruction' },
+  { pattern: /\bas (?:needed|appropriate)\b/i, rule: 'conditional-instruction' },
+]
+
+// Asking for a card, a poster, or a book cover gets you the object, not the art
+// printed on it — including its typography.
+const FORMAT_PATTERNS: Array<{ pattern: RegExp; rule: string }> = [
+  { pattern: /\b(?:trading[- ])?card (?:illustration|artwork|composition|art)\b/i, rule: 'format-vocabulary' },
+  { pattern: /\b(?:treasure|ability|item|reward)[- ]card\b/i, rule: 'format-vocabulary' },
+  { pattern: /\b(?:movie |film |book )?(?:poster|book cover|magazine cover|album cover)\b/i, rule: 'format-vocabulary' },
+  { pattern: /\bcomic (?:page|panel|strip)\b/i, rule: 'format-vocabulary' },
+]
+
+// "Kind Robots visual style" gives an image model nothing, and used to be
+// rewritten downstream into a block that carried the casting instruction.
+const VAGUE_BRAND_STYLE =
+  /\b(?:(?:rich|cohesive|friendly)\s+)?Kind Robots\s+(?:visual\s+)?(?:style|language)\b/i
+
+// The damage was specific: FIVE text-related nouns ("no readable text, no
+// lettering, no logos, no watermark, no signature") in the POSITIVE prompt of a
+// text-specialist model running at cfg 1, where the ComfyUI negative prompt is
+// inert. Naming text five times to Qwen-Image lineage produces text.
+//
+// This rule is deliberately narrow. An earlier version counted every "no ..."
+// clause and would have rejected the coloring-book lane, which uses eleven
+// exclusions on purpose (no border, no comic, no collage...) — and rejected a
+// prompt whose subject text merely read "no matter how undocumented". Breadth
+// here costs working pipelines; the pathological case is text nouns, in bulk,
+// where guidance cannot act on a negative prompt.
+const TEXT_EXCLUSION_NOUNS = new Set([
+  'text',
+  'lettering',
+  'letters',
+  'words',
+  'wording',
+  'logo',
+  'logos',
+  'watermark',
+  'watermarks',
+  'signature',
+  'signatures',
+  'caption',
+  'captions',
+  'typography',
+  'writing',
+])
+// The optional adjective matters: the exact clause that shipped was "no
+// READABLE text", and capturing the first word after "no" caught "readable"
+// rather than "text", so the pile went uncounted.
+const NEGATION_CLAUSE =
+  /\bno[ -](?:readable |visible |legible |written |accidental )?([a-z][a-z-]*)/gi
+const MAX_TEXT_EXCLUSIONS = 4
+
+function textExclusions(prompt: string): string[] {
+  const found: string[] = []
+  for (const match of prompt.matchAll(NEGATION_CLAUSE)) {
+    const word = match[1]?.toLowerCase()
+    if (word && TEXT_EXCLUSION_NOUNS.has(word)) found.push(match[0])
+  }
+  return found
+}
+
+/**
+ * True when the ComfyUI negative prompt cannot act, so every exclusion the
+ * author writes lands in positive conditioning instead. Distilled engines run
+ * at cfg 1 by design; an explicit cfg of 1 or less says the same thing.
+ */
+function guidanceIsInert(engine: string, cfg: number | null | undefined): boolean {
+  if (Number.isFinite(cfg)) return Number(cfg) <= 1
+  return Boolean(DISTILLED_ENGINE_LIMITS[engine])
+}
+
+/** A format noun the author is EXCLUDING is not a format request. */
+function negated(prompt: string, index: number): boolean {
+  const before = prompt.slice(Math.max(0, index - 12), index).toLowerCase()
+  return /\b(?:no|not|without|avoid|never)\s+[a-z-]*\s*$/.test(before)
+}
+
+export function checkArtPromptContract(
+  input: ArtPromptContractInput,
+): ArtPromptViolation[] {
+  const prompt = cleanArtPrompt(input.prompt)
+  const violations: ArtPromptViolation[] = []
+
+  if (!prompt) {
+    return [{ rule: 'empty-prompt', detail: 'The prompt is empty.' }]
+  }
+
+  for (const { pattern, rule } of CONDITIONAL_PATTERNS) {
+    const match = prompt.match(pattern)
+    if (match) {
+      violations.push({
+        rule,
+        detail:
+          `"${match[0]}" asks the model to evaluate a condition. Diffusion models ` +
+          `cannot; they render the words. Decide before enqueueing and state one outcome.`,
+      })
+    }
+  }
+
+  for (const { pattern, rule } of FORMAT_PATTERNS) {
+    const match = prompt.match(pattern)
+    // A format noun the author is excluding ("no comic panel") is the opposite
+    // of a format request. Flagging it rejected the coloring-book lane, whose
+    // prompts legitimately name the formats they are avoiding.
+    if (match && typeof match.index === 'number' && !negated(prompt, match.index)) {
+      violations.push({
+        rule,
+        detail:
+          `"${match[0]}" asks for a physical format, so the model renders the ` +
+          `format — frame, title bar, and invented text included. Describe the ` +
+          `subject and the aspect ratio instead.`,
+      })
+    }
+  }
+
+  if (VAGUE_BRAND_STYLE.test(prompt)) {
+    violations.push({
+      rule: 'vague-brand-style',
+      detail:
+        '"Kind Robots visual style" carries no visual information. Write the ' +
+        'medium, linework, colour, and lighting out explicitly.',
+    })
+  }
+
+  const engineName = String(input.engine || '').trim().toLowerCase()
+  const textNos = textExclusions(prompt)
+  if (
+    textNos.length > MAX_TEXT_EXCLUSIONS &&
+    guidanceIsInert(engineName, input.cfg)
+  ) {
+    violations.push({
+      rule: 'text-exclusion-pile',
+      detail:
+        `${textNos.length} text exclusions (${textNos.join(', ')}) on an engine whose ` +
+        `negative prompt is inert, so every one of those words lands in POSITIVE ` +
+        `conditioning. Say it once, or state the wanted result instead — ` +
+        `"unmarked surfaces" beats naming text five times.`,
+    })
+  }
+
+  const limits = DISTILLED_ENGINE_LIMITS[engineName]
+  if (limits) {
+    if (Number.isFinite(input.cfg) && Number(input.cfg) > limits.cfg) {
+      violations.push({
+        rule: 'engine-guidance-mismatch',
+        detail:
+          `${engineName} is distilled for cfg ${limits.cfg}; got ${input.cfg}. Above it the ` +
+          `model leaves its training distribution — burned contrast and duplicated subjects.`,
+      })
+    }
+    if (Number.isFinite(input.steps) && Number(input.steps) > limits.maxSteps) {
+      violations.push({
+        rule: 'engine-step-mismatch',
+        detail:
+          `${engineName} runs at roughly ${limits.maxSteps} steps or fewer; got ${input.steps}.`,
+      })
+    }
+  }
+
+  return violations
+}
+
+/** Throw a 422 listing every violation, so a producer fixes them in one pass. */
+export function assertArtPromptContract(input: ArtPromptContractInput): void {
+  const violations = checkArtPromptContract(input)
+  if (!violations.length) return
+
+  throw createError({
+    statusCode: 422,
+    message:
+      `Art prompt rejected by the prompt contract (${violations.length} violation` +
+      `${violations.length === 1 ? '' : 's'}):\n` +
+      violations.map((v) => `  [${v.rule}] ${v.detail}`).join('\n'),
+  })
+}

--- a/server/utils/artTargetResolution.ts
+++ b/server/utils/artTargetResolution.ts
@@ -1,0 +1,125 @@
+// /server/utils/artTargetResolution.ts
+//
+// Maps a requested image PATH to the entity ROW that owns it.
+//
+// Why this exists: `projects/art-prompts.yaml` is a durable replay queue. Art
+// requests were written into that file, committed to Conductor over the GitHub
+// API, and drained by an hourly consumer that minted ArtJobs from whatever text
+// was stored there. On 2026-08-08 that cost a full day — every repair to the
+// live queue was silently undone when the consumer replayed the stale prompt at
+// a higher priority, re-rendering the crowd on top of the corrected image.
+//
+// The file only ever existed because some art targets are identified by file
+// path rather than by a row. A Reward, Dream, Character, Scenario, Facet or
+// Project already HAS a row, and `entityArt` attaches art to it directly — that
+// lane never needed the YAML and never had the replay bug. Measured on the live
+// queue: 2,782 of 2,868 pending jobs already target an entity row. The path-only
+// remainder is roughly 3% (page channels, dashboard tabs, academy assets), and
+// those genuinely need byte placement at an exact media path until they get
+// rows of their own.
+//
+// So: resolve what we can to a row and enqueue it directly, leaving a small,
+// named, measurable tail rather than a blanket rewrite.
+import type { EntityArtType } from './entityArt'
+
+export type ResolvedArtTarget = {
+  entityType: EntityArtType
+  field: string
+  /** Slug or identifying fragment lifted from the path; the caller looks it up. */
+  lookup: { slug?: string; id?: number; rewardType?: string; variant?: string }
+}
+
+const VARIANT_FIELD: Record<string, string> = {
+  icon: 'imagePath',
+  card: 'cardPath',
+  hero: 'heroPath',
+}
+
+/**
+ * Patterns are ordered most-specific first. Each captures enough to find the
+ * row without guessing: a slug, or a slug plus the variant that names the slot.
+ */
+const PATH_RULES: Array<{
+  pattern: RegExp
+  build: (match: RegExpMatchArray) => ResolvedArtTarget
+}> = [
+  // public/images/rewards/item/item-tidefortune-ladle.webp
+  {
+    pattern:
+      /^public\/images\/rewards\/(item|skill|pet|power|favor|magic)\/([a-z0-9-]+)\.[a-z0-9]+$/i,
+    build: (m) => ({
+      entityType: 'reward',
+      field: 'imagePath',
+      lookup: { slug: m[2]!.toLowerCase(), rewardType: m[1]!.toUpperCase() },
+    }),
+  },
+  // Deliberately NOT handled: public/images/dreams/<dream>/<element>-card.webp.
+  // A dream folder holds elements of four different types — its world and
+  // location are Dream rows, but its character is a Character, its rewards are
+  // Rewards, and its scenario is a Scenario. The path cannot tell them apart:
+  // `dreams/undermoon-bloom/mythroot-whisper-card.webp` looks like a Dream and
+  // is in fact a Reward. Resolving it by folder would attach art to the wrong
+  // row, or to no row at all.
+  //
+  // Nothing is lost by skipping it. Dream art is already enqueued with an
+  // explicit entity target by Conductor's build_dream_records (`queue_art`
+  // passes entity_type/entity_id), so this path only appears on legacy jobs.
+  // Guessing here would be worse than falling through to path delivery.
+  // projects/images/<slug>-icon.webp   (Conductor's own project assets — the
+  // only generated images still committed to a git repo)
+  {
+    pattern: /^projects\/images\/([a-z0-9-]+)-(icon|card|hero)\.[a-z0-9]+$/i,
+    build: (m) => ({
+      entityType: 'project',
+      field: VARIANT_FIELD[m[2]!.toLowerCase()]!,
+      lookup: { slug: m[1]!.toLowerCase(), variant: m[2]!.toLowerCase() },
+    }),
+  },
+  // public/images/projects/<slug>/hero.webp
+  {
+    pattern:
+      /^public\/images\/projects\/([a-z0-9-]+)\/(icon|card|hero)\.[a-z0-9]+$/i,
+    build: (m) => ({
+      entityType: 'project',
+      field: VARIANT_FIELD[m[2]!.toLowerCase()]!,
+      lookup: { slug: m[1]!.toLowerCase(), variant: m[2]!.toLowerCase() },
+    }),
+  },
+]
+
+/**
+ * Targets with no row today. Named explicitly rather than falling through
+ * silently, so the remaining migration surface is countable instead of folklore.
+ */
+export const UNROWED_PATH_PREFIXES = [
+  'public/images/channels/',
+  'public/images/dashboard-tabs/',
+  'public/images/academy/',
+  'public/images/artcollections/',
+] as const
+
+export function isKnownUnrowedTarget(imagePath: string): boolean {
+  const path = String(imagePath || '').replace(/^\/+/, '')
+  return UNROWED_PATH_PREFIXES.some((prefix) => path.startsWith(prefix))
+}
+
+/**
+ * The entity a requested image path belongs to, or null when the path has no
+ * row behind it. Null is a legitimate answer — see UNROWED_PATH_PREFIXES — and
+ * means the caller should fall back to path-based delivery.
+ */
+export function resolveArtTargetFromPath(
+  imagePath: string,
+): ResolvedArtTarget | null {
+  const path = String(imagePath || '')
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+    .split(/[?#]/, 1)[0]!
+  if (!path) return null
+
+  for (const rule of PATH_RULES) {
+    const match = path.match(rule.pattern)
+    if (match) return rule.build(match)
+  }
+  return null
+}

--- a/utils/artFacetPrompt.ts
+++ b/utils/artFacetPrompt.ts
@@ -60,12 +60,26 @@ export function orderArtFacetEntries(
     .map((item) => item.entry)
 }
 
+/** Comparable form for "is this direction already in the prompt?". */
+function normalizedForDedupe(value: string): string {
+  return value.replace(/\s+/g, ' ').trim().toLowerCase()
+}
+
 export function buildArtFacetPromptAddon(
   entries: readonly ArtFacetPromptEntry[],
+  basePrompt = '',
 ): string {
+  const base = normalizedForDedupe(basePrompt)
   const values = Array.from(
     new Set(orderArtFacetEntries(entries).map(artFacetPromptValue).filter(Boolean)),
-  )
+    // A Facet whose direction the base prompt already states adds nothing by
+    // being restated. Several catalog prompts are BUILT from their Facet's
+    // artPrompt, so appending it again duplicated the whole thing — including
+    // its "no text, no logo, no watermark" tail, which then appeared three
+    // times in one prompt. At cfg 1 the negative prompt is inert, so those
+    // repeats land in positive conditioning on a text-specialist model: the
+    // prompt ends up asking for text by naming it eight times.
+  ).filter((value) => !base.includes(normalizedForDedupe(value)))
   return values.length ? `Facet direction: ${values.join(', ')}` : ''
 }
 
@@ -74,6 +88,6 @@ export function composeArtPromptWithFacets(
   entries: readonly ArtFacetPromptEntry[],
 ): string {
   const base = String(basePrompt || '').replace(/\s+/g, ' ').trim()
-  const addon = buildArtFacetPromptAddon(entries)
+  const addon = buildArtFacetPromptAddon(entries, base)
   return [base, addon].filter(Boolean).join(', ')
 }

--- a/utils/scripts/verifyArtPromptContract.ts
+++ b/utils/scripts/verifyArtPromptContract.ts
@@ -92,6 +92,24 @@ assert.deepEqual(
   'a format noun the author EXCLUDES is not a format request',
 )
 
+// "poster composition" is framing language the coloring-book lane uses on
+// purpose; "a movie poster" is an object request. The asymmetry with "card
+// composition" is deliberate and evidence-led: that one demonstrably rendered a
+// titled trading card, and there is no equivalent evidence for poster framing.
+assert.deepEqual(
+  rules({
+    prompt: 'Extreme close-up poster composition, mostly face and one raised hand',
+    engine: 'krea2',
+  }),
+  [],
+  'poster COMPOSITION is framing, not a request for a poster',
+)
+assert.ok(
+  rules({ prompt: 'a vintage movie poster for a lost film', engine: 'krea2' })
+    .includes('format-vocabulary'),
+  'a movie poster as an OBJECT must still be rejected',
+)
+
 // Guidance scoping: the same five exclusions are tolerable where the negative
 // prompt can actually act on them.
 assert.deepEqual(

--- a/utils/scripts/verifyArtPromptContract.ts
+++ b/utils/scripts/verifyArtPromptContract.ts
@@ -1,0 +1,236 @@
+// Contract test for server/utils/artPromptContract.ts.
+//
+// Every case below is a prompt that actually rendered on 2026-08-08 and produced
+// a wrong image. This file is the regression net for that day: if a rule is
+// weakened, the exact prompt that caused the damage stops being rejected here.
+import assert from 'node:assert/strict'
+import {
+  checkArtPromptContract,
+  assertArtPromptContract,
+  DISTILLED_ENGINE_LIMITS,
+} from '../../server/utils/artPromptContract'
+
+function rules(input: Parameters<typeof checkArtPromptContract>[0]): string[] {
+  return checkArtPromptContract(input).map((violation) => violation.rule)
+}
+
+// ── The prompts that broke production ───────────────────────────────────────
+
+// item-tidefortune-ladle: rendered as fifteen strangers and no ladle.
+const LADLE_AS_SHIPPED =
+  'iconic treasure-card illustration of Tidefortune Ladle (ITEM): stirred through ' +
+  'any dish, it surfaces the hidden fortune buried in a person or object, ' +
+  'atmospheric background, world of The Lucky Ladle, detailed mature western ' +
+  'animation with multidimensional worldbuilding, expressive anatomy and faces; ' +
+  'cast characters naturally across many species, ages, body sizes, body shapes, ' +
+  'gender presentations, and levels of conventional attractiveness; include robots ' +
+  'only when the subject or scene explicitly calls for them, cinematic light with ' +
+  'intent, no readable text, no logos, no watermark'
+
+const ladleRules = rules({ prompt: LADLE_AS_SHIPPED, engine: 'krea2' })
+assert.ok(
+  ladleRules.includes('conditional-instruction'),
+  'the "include robots only when..." clause must be rejected',
+)
+assert.ok(
+  ladleRules.includes('format-vocabulary'),
+  '"treasure-card illustration" must be rejected',
+)
+
+// skill-ghost-ring-reading: rendered as a trading card with a rules box.
+assert.ok(
+  rules({ prompt: 'a rare-tier ability card illustration of Ghost-Ring Reading' })
+    .includes('format-vocabulary'),
+  '"ability card illustration" must be rejected',
+)
+assert.ok(
+  rules({ prompt: 'subject here, 2:3 portrait card composition, lit warmly' })
+    .includes('format-vocabulary'),
+  '"card composition" must be rejected — it asks for the object, not the ratio',
+)
+
+// The five-noun text pile that landed in positive conditioning at cfg 1.
+assert.ok(
+  rules({
+    prompt:
+      'a brass tuning fork on a dark ground, no readable text, no lettering, ' +
+      'no logos, no watermark, no signature',
+    engine: 'krea2',
+  }).includes('text-exclusion-pile'),
+  'five text exclusions on an inert-negative engine must be rejected',
+)
+
+// The rule is scoped on purpose. These three cases are working pipelines that a
+// broader "count every no-clause" version rejected outright.
+assert.deepEqual(
+  rules({
+    prompt:
+      'inked coloring-book design master, bold clean black ink linework, ' +
+      'No border, no comic panel, no collage, no contact sheet, no greyscale, ' +
+      'no shading, no gradient',
+    engine: 'krea2',
+  }),
+  [],
+  'the coloring-book lane excludes many NON-text formats on purpose',
+)
+assert.deepEqual(
+  rules({
+    prompt:
+      'a bureaucratic form for any creature, species, or spirit, no matter how ' +
+      'undocumented, luminous starlight ink',
+    engine: 'krea2',
+  }),
+  [],
+  '"no matter" is prose — a real SKILL prompt was rejected by an earlier version',
+)
+assert.deepEqual(
+  rules({
+    prompt: 'a quiet study, no comic panel, no poster on the wall',
+    engine: 'krea2',
+  }),
+  [],
+  'a format noun the author EXCLUDES is not a format request',
+)
+
+// Guidance scoping: the same five exclusions are tolerable where the negative
+// prompt can actually act on them.
+assert.deepEqual(
+  rules({
+    prompt:
+      'a brass tuning fork, no readable text, no lettering, no logos, ' +
+      'no watermark, no signature',
+    engine: 'comfy',
+    cfg: 7,
+  }),
+  [],
+  'at cfg 7 the negative prompt works, so exclusions are not pathological',
+)
+
+// The phrase that used to be rewritten downstream into the casting block.
+assert.ok(
+  rules({ prompt: 'a ladle, cohesive Kind Robots visual style' })
+    .includes('vague-brand-style'),
+  '"Kind Robots visual style" must be rejected',
+)
+
+// ── Engine parameters ───────────────────────────────────────────────────────
+
+const cooked = rules({
+  prompt: 'a dented tin ladle alone on a bare surface',
+  engine: 'krea2',
+  steps: 20,
+  cfg: 7,
+})
+assert.ok(
+  cooked.includes('engine-guidance-mismatch'),
+  'krea2 at cfg 7 must be rejected — it is distilled for cfg 1',
+)
+assert.ok(
+  cooked.includes('engine-step-mismatch'),
+  'krea2 at 20 steps must be rejected',
+)
+assert.deepEqual(
+  rules({
+    prompt: 'a dented tin ladle alone on a bare surface',
+    engine: 'krea2',
+    steps: 8,
+    cfg: 1,
+  }),
+  [],
+  'krea2 at its designed 8 steps / cfg 1 must pass',
+)
+
+// Both spellings of the same engine are covered: /api/art/enqueue normalizes to
+// "flux2" while Conductor's consumer says "flux2-klein".
+for (const engine of ['flux2', 'flux2-klein']) {
+  assert.ok(
+    DISTILLED_ENGINE_LIMITS[engine],
+    `${engine} must carry distilled limits — an unkeyed spelling silently skips the gate`,
+  )
+}
+
+// A non-distilled engine keeps normal guidance.
+assert.deepEqual(
+  rules({ prompt: 'a portrait of a knight', engine: 'comfy', steps: 30, cfg: 7 }),
+  [],
+  'SDXL-class engines must not be held to cfg 1',
+)
+
+// ── Prompts that must NOT trip the gate ─────────────────────────────────────
+
+assert.deepEqual(
+  rules({
+    prompt:
+      'a single Tidefortune Ladle, one object alone in frame, a dented tin ladle ' +
+      'the length of a forearm, its bowl worn to a mirror finish, the handle ' +
+      'wrapped in salt-stiffened cord, vertical 2:3 portrait composition, museum ' +
+      'product shot, an unpeopled frame — the subject stands alone with no ' +
+      'bystanders, no onlookers, and no crowd, unmarked surfaces, free of text',
+    engine: 'krea2',
+    steps: 8,
+    cfg: 1,
+  }),
+  [],
+  'the repaired ladle prompt must pass — three exclusions is under the pile threshold',
+)
+
+// A dream whose subject genuinely is a card catalog must still be renderable.
+assert.deepEqual(
+  rules({
+    prompt:
+      'a single half-eaten index card held to a raking sodium light, towering ' +
+      'mahogany card drawers behind it, vertical 2:3 portrait composition',
+    engine: 'krea2',
+  }),
+  [],
+  'authored subject matter containing the word "card" must not be rejected',
+)
+
+// Prose that merely contains "no ..." is not an exclusion list.
+assert.deepEqual(
+  rules({ prompt: 'a lighthouse keeper who is no longer waiting, at dawn' }),
+  [],
+  '"no longer" is prose, not an exclusion',
+)
+
+assert.deepEqual(
+  rules({ prompt: '' }).length ? rules({ prompt: '' }) : ['unexpected'],
+  ['empty-prompt'],
+  'an empty prompt must be rejected',
+)
+
+// ── The thrown error ────────────────────────────────────────────────────────
+
+let thrown: unknown = null
+try {
+  assertArtPromptContract({ prompt: LADLE_AS_SHIPPED, engine: 'krea2', cfg: 7 })
+} catch (error: unknown) {
+  thrown = error
+}
+assert.ok(thrown, 'assertArtPromptContract must throw on a violating prompt')
+assert.equal(
+  (thrown as { statusCode?: number }).statusCode,
+  422,
+  'the gate must throw 422 so callers can distinguish it from a 500',
+)
+assert.match(
+  String((thrown as { message?: string }).message),
+  /conditional-instruction/,
+  'the error must name every rule so a producer fixes them in one pass',
+)
+
+assert.doesNotThrow(
+  () =>
+    assertArtPromptContract({
+      prompt: 'a brass tuning fork alone on a bare dark surface',
+      engine: 'krea2',
+      steps: 8,
+      cfg: 1,
+    }),
+  'a clean prompt must pass through untouched',
+)
+
+console.log(
+  'Art prompt contract passed: conditionals, format vocabulary, negation piles, ' +
+    'vague brand style, and distilled-engine parameters are all rejected at enqueue.',
+)


### PR DESCRIPTION
First of the art-pipeline hardening changes. A hard gate on what may reach an image model, placed where every producer funnels through — Conductor scripts, the art workbench, narrative beats, backfill passes — so none of them has to remember the rules.

## The rules are the bugs from 2026-08-08

| rule | what shipped |
|---|---|
| `conditional-instruction` | *"include robots **only when** the subject or scene explicitly calls for them"* — needs a reader that evaluates conditions. A diffusion model paints the words. That clause **is** a crowd. |
| `format-vocabulary` | *"treasure card illustration"*, *"2:3 portrait card composition"* — to a caption-trained model that means a card, so it drew one: title bar, rules box, invented text. |
| `vague-brand-style` | *"Kind Robots visual style"* — no visual information, and used to be rewritten downstream into the block carrying the casting clause. |
| `text-exclusion-pile` | Five text nouns in the **positive** prompt of a text-specialist model at cfg 1, where the ComfyUI negative prompt is inert. |
| `engine-*-mismatch` | krea2 at cfg 7 / 20 steps against its designed 1 / 8. |

## Where it binds

Both lanes, on the string the model actually receives:

- **`/api/art/enqueue`** — after entity context and Facet direction are composed in. A Facet `artPrompt` can smuggle in a conditional as easily as a caller can, so gating the caller's raw text would miss it.
- **`/api/art/queue`** — on the render request *extracted from the workflow*, because a COMFY payload carries a baked graph rather than a plain `promptString`. Wrapped so that a payload shape the endpoint can't introspect isn't treated as a violation; only the gate's own 422 rethrows.

## Calibrated against real data

This is the part that matters. I swept all **88 live builder prompts** and all **2,868 pending jobs** through the gate before proposing it, and that caught three false positives which would have broken working pipelines:

1. **"no matter how undocumented"** — ordinary prose inside a SKILL's own text, counted as an exclusion. Prose allowlist added.
2. **The coloring-book lane** deliberately excludes eleven non-text formats (`no comic panel`, `no poster`). A negated format noun is the *opposite* of a format request — the format check now skips negated occurrences, and the exclusion rule counts only **text** nouns, only where guidance is inert.
3. **`"no readable text"` captured `"readable"`, not `"text"`** — so the exact five-noun pile that caused the original damage went uncounted. The pattern now skips a leading adjective.

Final: **0 of 88 builder prompts rejected**, and the entity-art prompt shape `main` produces today (`Compose this as ${artSlotFraming(field)}` + `Every surface in frame is blank and unmarked.`) passes clean.

## Blast radius

843 pending jobs would fail the gate. All are pre-fix stragglers already in the queue — the gate acts at *enqueue*, so it does not retroactively block them. They still want sweeping, which I'll do separately; flagging it here so the number isn't a surprise.

## Testing

`utils/scripts/verifyArtPromptContract.ts`, wired into `contract-tests.yml` as **Art prompt contract**. Every case is a prompt that actually rendered wrong, plus the three false-positive cases above as permanent guards against over-broadening.

Unlike earlier changes this session, I **executed** it rather than relying on CI: the verifier and both real-data sweeps run under `node --experimental-strip-types` with a local `h3` stub. That's how the three false positives were found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRr9oK8jpQKEd1sCM3NY1f

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRr9oK8jpQKEd1sCM3NY1f)_