### PR TITLE
interface-vision/t-104: extract kr-stat-tile primitive, migrate two hand-rolled callers

### DIFF
--- a/components/navigation/navigation-health.vue
+++ b/components/navigation/navigation-health.vue
@@ -42,48 +42,39 @@
     </div>
 
     <section class="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
-      <article class="stat rounded-2xl border border-base-300 bg-base-100 shadow-sm">
-        <div class="stat-title">Channels</div>
-        <div class="stat-value text-primary">{{ channels.length }}</div>
-        <div class="stat-desc">Resolved parent documents</div>
-      </article>
+      <kr-stat-tile
+        title="Channels"
+        :value="channels.length"
+        tone="primary"
+        desc="Resolved parent documents"
+      />
 
-      <article class="stat rounded-2xl border border-base-300 bg-base-100 shadow-sm">
-        <div class="stat-title">Tabs</div>
-        <div class="stat-value">{{ totalTabs }}</div>
-        <div class="stat-desc">Resolved child documents</div>
-      </article>
+      <kr-stat-tile title="Tabs" :value="totalTabs" desc="Resolved child documents" />
 
-      <article class="stat rounded-2xl border border-base-300 bg-base-100 shadow-sm">
-        <div class="stat-title">Shared routes</div>
-        <div class="stat-value text-secondary">{{ sharedRouteGroups.length }}</div>
-        <div class="stat-desc">Groups using ?tab= addressing</div>
-      </article>
+      <kr-stat-tile
+        title="Shared routes"
+        :value="sharedRouteGroups.length"
+        tone="secondary"
+        desc="Groups using ?tab= addressing"
+      />
 
-      <article class="stat rounded-2xl border border-base-300 bg-base-100 shadow-sm">
-        <div class="stat-title">Legacy adapters</div>
-        <div
-          class="stat-value"
-          :class="legacyAdapterFailureCount ? 'text-error' : 'text-warning'"
-        >
-          {{ legacyAdapterCount - legacyAdapterFailureCount }}/{{ legacyAdapterCount }}
-        </div>
-        <div class="stat-desc">
-          {{
-            legacyAdapterFailureCount
-              ? `${legacyAdapterFailureCount} failing navManifest validation`
-              : 'Tabs bridging old dashboards, all resolving'
-          }}
-        </div>
-      </article>
+      <kr-stat-tile
+        title="Legacy adapters"
+        :value="`${legacyAdapterCount - legacyAdapterFailureCount}/${legacyAdapterCount}`"
+        :tone="legacyAdapterFailureCount ? 'error' : 'warning'"
+        :desc="
+          legacyAdapterFailureCount
+            ? `${legacyAdapterFailureCount} failing navManifest validation`
+            : 'Tabs bridging old dashboards, all resolving'
+        "
+      />
 
-      <article class="stat rounded-2xl border border-base-300 bg-base-100 shadow-sm">
-        <div class="stat-title">Broken artwork</div>
-        <div class="stat-value" :class="brokenImages.size ? 'text-error' : 'text-success'">
-          {{ brokenImages.size }}
-        </div>
-        <div class="stat-desc">Detected by browser image loading</div>
-      </article>
+      <kr-stat-tile
+        title="Broken artwork"
+        :value="brokenImages.size"
+        :tone="brokenImages.size ? 'error' : 'success'"
+        desc="Detected by browser image loading"
+      />
     </section>
 
     <section

--- a/components/projects/project-placement-manager.vue
+++ b/components/projects/project-placement-manager.vue
@@ -35,23 +35,25 @@
 
     <template v-else>
       <section class="grid gap-3 sm:grid-cols-3">
-        <article class="stat rounded-2xl border border-base-300 bg-base-100 shadow-sm">
-          <div class="stat-title">Canonical placements</div>
-          <div class="stat-value text-primary">{{ expectedCount }}</div>
-          <div class="stat-desc">Defined in projectPlacements.ts</div>
-        </article>
+        <kr-stat-tile
+          title="Canonical placements"
+          :value="expectedCount"
+          tone="primary"
+          desc="Defined in projectPlacements.ts"
+        />
 
-        <article class="stat rounded-2xl border border-base-300 bg-base-100 shadow-sm">
-          <div class="stat-title">Projects loaded</div>
-          <div class="stat-value">{{ projectStore.projects.length }}</div>
-          <div class="stat-desc">Including inactive projects</div>
-        </article>
+        <kr-stat-tile
+          title="Projects loaded"
+          :value="projectStore.projects.length"
+          desc="Including inactive projects"
+        />
 
-        <article class="stat rounded-2xl border border-base-300 bg-base-100 shadow-sm">
-          <div class="stat-title">Placement matches</div>
-          <div class="stat-value text-secondary">{{ matchedCount }}</div>
-          <div class="stat-desc">Recognized by slug or conductor slug</div>
-        </article>
+        <kr-stat-tile
+          title="Placement matches"
+          :value="matchedCount"
+          tone="secondary"
+          desc="Recognized by slug or conductor slug"
+        />
       </section>
 
       <section

--- a/components/ui/kr-stat-tile.vue
+++ b/components/ui/kr-stat-tile.vue
@@ -1,0 +1,29 @@
+<!-- /components/ui/kr-stat-tile.vue -->
+<template>
+  <article
+    class="stat rounded-2xl border border-base-300 bg-base-100 shadow-sm"
+  >
+    <div class="stat-title">{{ title }}</div>
+    <div class="stat-value" :class="toneClass">{{ value }}</div>
+    <div v-if="desc" class="stat-desc">{{ desc }}</div>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    title: string
+    value: string | number
+    desc?: string
+    tone?: 'primary' | 'secondary' | 'success' | 'warning' | 'error'
+  }>(),
+  {
+    desc: '',
+    tone: undefined,
+  },
+)
+
+const toneClass = computed(() => (props.tone ? `text-${props.tone}` : ''))
+</script>

--- a/utils/wonderlab/previewFixturesCoverageClosure.ts
+++ b/utils/wonderlab/previewFixturesCoverageClosure.ts
@@ -282,6 +282,19 @@ const fixtures: Record<string, WonderLabPreviewFixture> = {
     skipReason:
       'Chat Card resolves participant identities and artwork through User, Bot, Character, and Art stores, marks messages read, and exposes reply/delete actions. It needs a seeded messaging fixture with actions disabled before standalone previewing is safe.',
   },
+  'kr-stat-tile': {
+    title: 'Stat Tile specimen',
+    description:
+      'A single DaisyUI stat tile -- title, value, and an optional description -- with an optional tone that colors the value. Presentational, reads no store.',
+    viewport: 'mobile',
+    minHeight: '10rem',
+    props: {
+      title: 'Shared routes',
+      value: 6,
+      desc: 'Groups using ?tab= addressing',
+      tone: 'secondary',
+    },
+  },
 }
 
 function normalizeFixtureKey(value: string): string {


### PR DESCRIPTION
### Task
interface-vision/t-104 (slice 7): Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- `components/ui/kr-stat-tile.vue`: new primitive for the `.stat rounded-2xl border border-base-300 bg-base-100 shadow-sm` tile shape (`stat-title`/`stat-value`/`stat-desc`), with `title`/`value`/`desc`/`tone` props. `tone` maps to a `text-${tone}` class on `stat-value` — covers every color variant the two live callers used (`primary`, `secondary`, `error`, `warning`, `success`, and the untoned default).
- `components/navigation/navigation-health.vue`: migrated all 5 stat tiles (Channels, Tabs, Shared routes, Legacy adapters, Broken artwork) onto `kr-stat-tile`, preserving the two conditionally-toned tiles' live branching (`legacyAdapterFailureCount ? 'error' : 'warning'`, `brokenImages.size ? 'error' : 'success'`) and the dynamic `desc` string on Legacy adapters exactly.
- `components/projects/project-placement-manager.vue`: migrated all 3 stat tiles (Canonical placements, Projects loaded, Placement matches) onto `kr-stat-tile`.

### Why this slice
Slice 6 flagged `kr-stat-tile` as a real, already-duplicated gap (not speculative infra) — these two files hand-roll the identical tile markup and were the only assessed candidates without an existing primitive. This slice closes that gap since the guardrail against building new primitive infra speculatively no longer applies (two live callers already exist).

### How I verified
- `npx eslint` on all 3 changed files: clean.
- `npx vue-tsc --noEmit -p tsconfig.json`: clean, exit 0.
- `npx prettier --check` on the new component and on every line actually changed: clean. (Both callers had pre-existing prettier drift on unrelated lines before this slice — CI only runs `lint:js`, not `lint:prettier`, confirmed by reading `.github/workflows/*.yml` — left untouched rather than bundling an unrelated whole-file reformat into this diff.)
- `npm run test:lint-ratchet`: holds, 392/27 unchanged.
- `npm run test:layout-contract`, `test:gallery-adoption`, `test:card-action-contract`, `test:narrative-kit`: all pass unchanged.

### Stakes
reversible

### Notes for reviewer
Conductor task `interface-vision/t-104` claimed for this slice (session `20260808T222711Z-iv-t104-s7-conductor`); roadmap updated with a slice-7 note and set to `status: review`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjeUWnBYRNDj3e6ZQ8u4dm)_