### PR TITLE
fix(art): page backdrops rendered a cast they were told to avoid

### DIFF
--- a/server/utils/artPromptContract.ts
+++ b/server/utils/artPromptContract.ts
@@ -78,6 +78,23 @@ const CONDITIONAL_PATTERNS: Array<{ pattern: RegExp; rule: string }> = [
   { pattern: /\b(?:if|unless) (?:the )?(?:subject|scene|context|prompt)\b/i, rule: 'conditional-instruction' },
   { pattern: /\bwhere (?:appropriate|relevant|applicable)\b/i, rule: 'conditional-instruction' },
   { pattern: /\bas (?:needed|appropriate)\b/i, rule: 'conditional-instruction' },
+  // The same bug wearing different words. Every page backdrop carried "...when
+  // any figures APPEAR they are small, distant and incidental to the setting",
+  // and none of the patterns above match it: the conditional attaches to a cast
+  // noun, not to "the subject" or "the scene". All 222 rendered with a cast —
+  // crowds in the side windows of voice-lab, a street full of figures in
+  // servers — because the model has no way to reach the "when" and simply
+  // paints the forty words of people that follow it.
+  //
+  // Scoped to a cast noun plus a PRESENCE verb, so ordinary prose that happens
+  // to say "when" about people is untouched: "a market at dusk when people
+  // light the lanterns" describes a scene, "when people appear" hands the model
+  // a decision it cannot make.
+  {
+    pattern:
+      /\b(?:when|if|where|whenever|unless)\s+(?:any\s+|some\s+|the\s+|no\s+)?(?:figures?|people|persons?|characters?|humans?|robots?|creatures?|bystanders?|crowds?|onlookers?)\s+(?:do\s+|are\s+|is\s+)?(?:appear|present|shown|show up|included|visible|featured|depicted)\b/i,
+    rule: 'conditional-instruction',
+  },
 ]
 
 // Asking for a card, a poster, or a book cover gets you the object, not the art

--- a/stores/seeds/pageBackdropArtPrompts.ts
+++ b/stores/seeds/pageBackdropArtPrompts.ts
@@ -57,7 +57,7 @@ const CANVAS: Record<
     width: 1536,
     height: 864,
     framing:
-      'Wide 16:9 landscape for a desktop. Push the interest to the left and right thirds and keep the centre open — that is where the main panel sits. Let the horizon and any architecture carry across the full width so the edges feel inhabited rather than cropped.',
+      'Wide 16:9 landscape for a desktop. Push the interest to the left and right thirds and keep the centre open — that is where the main panel sits. Let the horizon and any architecture carry across the full width so the edges read as more of the same place rather than a crop.',
   },
 }
 
@@ -67,8 +67,29 @@ const CANVAS: Record<
  * Deliberately restates the "quiet centre" rule that CANVAS.framing also
  * carries: it is the constraint a generator is most likely to drop, and saying
  * it twice is cheap insurance on a batch this size.
+ *
+ * BACKDROPS ARE UNPEOPLED. This used to read "...when any figures appear they
+ * are small, distant and incidental to the setting, and across the set they
+ * represent a diverse range of genders, races, ages, body sizes and body
+ * shapes, mixing humans, robots, animal-like beings and original nonhuman
+ * companions". Read by a person that is a restraint. Read by a diffusion model
+ * it is forty words of people with no way to evaluate the "when" — so all 222
+ * backdrops in the first batch rendered with a cast. voice-lab put a crowd of
+ * faces in both side windows; servers filled the street with a few dozen
+ * figures. Those are precisely the thirds where the composition guidance says
+ * to put the interest, and precisely where the UI panels do not cover them.
+ *
+ * The casting policy itself is right and lives on, in `CAST_DIRECTION` for art
+ * that actually has a cast. A page background is not that art. Same bug as the
+ * Tidefortune Ladle on 2026-08-08 — see server/utils/artPromptContract.ts,
+ * which now rejects this phrasing at enqueue.
  */
-const STYLE = `Create one standalone environment illustration to be used as a full-bleed page background for the Kind Robots web app. This is SCENERY, not a portrait or a poster: interface panels, cards and toolbars will be drawn on top of it, so the composition must stay open and calm through the centre of the canvas and carry its interest at the edges. Painted storybook-illustration style with cinematic depth, warm inviting light, soft atmospheric haze in the distance, and rich but unfussy detail. Kind Robots is a friendly, playful, multi-genre and cross-dimensional world; when any figures appear they are small, distant and incidental to the setting, and across the set they represent a diverse range of genders, races, ages, body sizes and body shapes, mixing humans, robots, animal-like beings and original nonhuman companions naturally and respectfully. No central subject, no single dominant focal point, no readable text, no logos, no watermarks, no borders, no panels, no collage.`
+// Scoped to PEOPLE on purpose, not to everything alive. Several scenes want
+// fauna or props — butterflies on taskmaster, jellyfish drifters on dreams,
+// half-assembled robots on the workbenches of bots — and a blanket "no
+// creatures, no robots" would fight the very scene it is wrapped around. What
+// broke the batch was a cast of characters, so that is what this excludes.
+const STYLE = `Create one standalone environment illustration to be used as a full-bleed page background for the Kind Robots web app. This is SCENERY: interface panels, cards and toolbars will be drawn on top of it, so the composition must stay open and calm through the centre of the canvas and carry its interest at the edges. Painted storybook-illustration style with cinematic depth, warm inviting light, soft atmospheric haze in the distance, and rich but unfussy detail. The place is empty of inhabitants — no people, no figures, no characters, no faces, no crowd, an unpeopled setting waiting to be entered. No central subject and no single dominant focal point; every surface unmarked and free of text.`
 
 const NEGATIVE_PROMPT = `text, caption, lettering, signage, logo, watermark, signature, border, frame, panel, collage, grid, contact sheet, ui mockup, interface elements, buttons, strong central subject, centered portrait, close-up face, busy cluttered centre, high-contrast centre, harsh clutter, photorealism, low detail, blurry, jpeg artifacts`
 
@@ -541,13 +562,13 @@ const PAGES: PageSeed[] = [
   },
 ]
 
+// The canvas size is a job parameter (CANVAS feeds width/height straight into
+// the render request), so it does not also need to be spelled out to the model.
+// It used to lead with "Final canvas: exactly 1536 x 864 pixels" — digits, in
+// the positive prompt, to a Qwen-Image-lineage model that renders text better
+// than anything else open. The framing sentence says the same thing in words.
 function buildPrompt(seed: PageSeed, variant: BackdropVariant): string {
-  const canvas = CANVAS[variant]
-  return [
-    STYLE,
-    `Final canvas: exactly ${canvas.width} x ${canvas.height} pixels. ${canvas.framing}`,
-    `Scene: ${seed.scene}`,
-  ].join('\n\n')
+  return [STYLE, CANVAS[variant].framing, `Scene: ${seed.scene}`].join('\n\n')
 }
 
 export const pageBackdropArtPrompts: PageBackdropArtPrompt[] = PAGES.flatMap(

--- a/utils/scripts/enqueuePageBackdropArtViaApi.ts
+++ b/utils/scripts/enqueuePageBackdropArtViaApi.ts
@@ -17,6 +17,7 @@
 //   npx tsx utils/scripts/enqueuePageBackdropArtViaApi.ts --write
 //   npx tsx utils/scripts/enqueuePageBackdropArtViaApi.ts --write --limit 6
 //   npx tsx utils/scripts/enqueuePageBackdropArtViaApi.ts --write --only index,about
+//   npx tsx utils/scripts/enqueuePageBackdropArtViaApi.ts --write --only mermaids --variant desktop
 import 'dotenv/config'
 import { pageBackdropArtPrompts } from './../../stores/seeds/pageBackdropArtPrompts'
 import {
@@ -46,6 +47,13 @@ const LIMIT = Number(flag('--limit') || 0)
 const ONLY = (flag('--only') || '')
   .split(',')
   .map((value) => value.trim())
+  .filter(Boolean)
+// A page has three genuinely different framings, so re-rendering one breakpoint
+// is a real thing to want — the desktop backdrop can be wrong while the phone
+// one is fine. Without this, repairing one image costs three renders.
+const VARIANTS = (flag('--variant') || '')
+  .split(',')
+  .map((value) => value.trim().toLowerCase())
   .filter(Boolean)
 
 function buildPayload(entry: (typeof pageBackdropArtPrompts)[number]) {
@@ -96,7 +104,13 @@ async function main() {
 
   let entries = pageBackdropArtPrompts
   if (ONLY.length) entries = entries.filter((e) => ONLY.includes(e.page))
+  if (VARIANTS.length) entries = entries.filter((e) => VARIANTS.includes(e.variant))
   if (LIMIT > 0) entries = entries.slice(0, LIMIT)
+  if (!entries.length) {
+    console.error('❌ No entries matched --only / --variant.')
+    process.exitCode = 1
+    return
+  }
 
   console.log(`Target: ${BASE}`)
   console.log(

--- a/utils/scripts/verifyArtPromptContract.ts
+++ b/utils/scripts/verifyArtPromptContract.ts
@@ -37,6 +37,41 @@ assert.ok(
   '"treasure-card illustration" must be rejected',
 )
 
+// The page-backdrop house style: the same conditional wearing different words.
+// Every one of the 222 backdrops rendered with a cast standing in the left and
+// right thirds — exactly where the composition guidance puts the interest, and
+// exactly where no UI panel covers them.
+const BACKDROP_AS_SHIPPED =
+  'Create one standalone environment illustration to be used as a full-bleed ' +
+  'page background. Kind Robots is a friendly, playful, multi-genre and ' +
+  'cross-dimensional world; when any figures appear they are small, distant and ' +
+  'incidental to the setting, and across the set they represent a diverse range ' +
+  'of genders, races, ages, body sizes and body shapes, mixing humans, robots, ' +
+  'animal-like beings and original nonhuman companions naturally and respectfully.'
+assert.ok(
+  rules({ prompt: BACKDROP_AS_SHIPPED, engine: 'krea2' })
+    .includes('conditional-instruction'),
+  'the "when any figures appear" casting conditional must be rejected',
+)
+
+// Scoped to a cast noun plus a presence verb, so prose about people is fine.
+assert.deepEqual(
+  rules({
+    prompt: 'a harbour market at dusk when people light the paper lanterns',
+    engine: 'krea2',
+  }),
+  [],
+  '"when people light..." is a described scene, not an instruction to evaluate',
+)
+assert.deepEqual(
+  rules({
+    prompt: 'a lone figure on a pier where creatures once nested, cold grey light',
+    engine: 'krea2',
+  }),
+  [],
+  '"where creatures once nested" is setting, not a conditional',
+)
+
 // skill-ghost-ring-reading: rendered as a trading card with a rules box.
 assert.ok(
   rules({ prompt: 'a rare-tier ability card illustration of Ghost-Ring Reading' })


### PR DESCRIPTION
Chasing the one FAILED job in the queue (7905, `background/mermaids-desktop.webp`) turned up the seventh producer of today's crowd bug — and this one had already shipped 222 images.

## The bug

`STYLE` in `stores/seeds/pageBackdropArtPrompts.ts` carried:

> …when any figures appear they are small, distant and incidental to the setting, and across the set they represent a diverse range of genders, races, ages, body sizes and body shapes, mixing humans, robots, animal-like beings and original nonhuman companions naturally and respectfully.

A person reads that as a restraint. A diffusion model has no way to reach the "when", so it renders the forty words of people that follow it. Every one of the 222 backdrops came out with a cast, standing in the left and right thirds — exactly where the composition guidance sends the interest, and exactly where no UI panel covers it. `voice-lab` has a crowd of faces pressed against both side windows; `servers` has a street full of figures; `mermaids` has a family group on the right arch.

Identical to the Tidefortune Ladle. The casting policy itself is right and lives on in `CAST_DIRECTION`, for art that actually has a cast. A page background is not that art.

## Changes

- **`stores/seeds/pageBackdropArtPrompts.ts`** — backdrops are explicitly unpeopled. Scoped to *people*, not everything alive: several scenes want butterflies, jellyfish drifters, or half-assembled robots on a workbench, and a blanket "no creatures" would fight the scene it wraps. Also dropped `Final canvas: exactly 1536 x 864 pixels` (digits in the positive prompt of the strongest open text renderer available, restating a job parameter the framing sentence already gives in words), dropped the format nouns in "not a portrait or a poster", and collapsed the five-noun text pile to one clause.
- **`server/utils/artPromptContract.ts`** — rejects this phrasing at enqueue. Scoped to a conditional + a cast noun + a *presence* verb, so `"a market at dusk when people light the lanterns"` (a described scene) passes while `"when people appear"` (a decision the model cannot make) does not.
- **`utils/scripts/verifyArtPromptContract.ts`** — the shipped backdrop style as a regression case, plus two prose cases that must keep passing.
- **`utils/scripts/enqueuePageBackdropArtViaApi.ts`** — `--variant`, so repairing one breakpoint costs one render instead of three.

## Verification

- Contract test green.
- Swept all **6,443** live queue prompts against the new rule: it fires on the 222 backdrops and **nothing else** — zero false positives.
- All 222 rebuilt prompts pass the contract.
- `mermaids-desktop` re-queued as job **8100** on the working krea2 lane (1536×864, 8 steps, cfg 1, priority 100); job 7905 cancelled with the diagnosis in its error.

## Not in this PR

The other **221** backdrops still carry the crowd. Re-rendering them is one command — `--write` with no `--only` — but it is 221 renders and a site-wide visual change, so it is Silas's call rather than something to fire off.

Separately: the SDXL trainer-redo lane has **never once succeeded** — 0 of 3,573 DONE jobs used `CheckpointLoaderSimple`; all 3,544 with a workflow used `UnetLoaderGGUF`. That is a relay-side checkpoint-naming problem, tracked in the companion conductor PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRr9oK8jpQKEd1sCM3NY1f

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRr9oK8jpQKEd1sCM3NY1f)_