### PR TITLE
fix(art): collapse coverage backlog before rendering

### DIFF
--- a/server/api/art/queue/claim.post.ts
+++ b/server/api/art/queue/claim.post.ts
@@ -233,7 +233,10 @@ export default defineEventHandler(async (event) => {
       // variants. Reconcile only this candidate's equivalence class so a large
       // backlog is cleaned as it drains without adding an O(queue) sweep to
       // every relay poll. Explicit retry payloads are excluded by the policy.
-      const coverage = await reconcileQueuedArtJobCoverage(candidate)
+      const coverage = await reconcileQueuedArtJobCoverage({
+        ...candidate,
+        payload: serializeArtJobPayload(candidate.payload),
+      })
       if (coverage.skipCandidate) {
         skippedIds.push(candidate.id)
         continue

--- a/server/api/art/queue/claim.post.ts
+++ b/server/api/art/queue/claim.post.ts
@@ -28,6 +28,10 @@ import {
   artJobQueueAffinityKey,
   selectSmartQueueCandidate,
 } from '../../../utils/artJobQueueAffinity'
+import {
+  assertQueuedArtPromptContract,
+  reconcileQueuedArtJobCoverage,
+} from '../../../utils/artJobQueueCoverage'
 import { recordRelayClaimAttempt } from '../../../utils/relayAgentRegistry'
 import { isQueuePaused } from '../../../utils/queueControl'
 
@@ -225,9 +229,26 @@ export default defineEventHandler(async (event) => {
 
       if (!candidate) continue
 
+      // Baseline coverage is one useful image per entity, not four speculative
+      // variants. Reconcile only this candidate's equivalence class so a large
+      // backlog is cleaned as it drains without adding an O(queue) sweep to
+      // every relay poll. Explicit retry payloads are excluded by the policy.
+      const coverage = await reconcileQueuedArtJobCoverage(candidate)
+      if (coverage.skipCandidate) {
+        skippedIds.push(candidate.id)
+        continue
+      }
+
       let enrichedPayload
 
       try {
+        // New enqueues pass the prompt contract at creation time. Old backlog
+        // rows predate that boundary, so apply the same rules again immediately
+        // before claim using the ACTUAL Comfy graph's engine/cfg/steps. This is
+        // what prevents stale 20-step/cfg-7 Krea jobs from rendering just because
+        // they were already sitting in PENDING when the gate shipped.
+        assertQueuedArtPromptContract(candidate.engine, candidate.payload)
+
         const currentProvenance = readArtJobProvenance(candidate.payload)
         enrichedPayload = enrichArtJobPayload(
           candidate.engine as 'A1111' | 'COMFY',
@@ -250,7 +271,7 @@ export default defineEventHandler(async (event) => {
           },
           data: {
             status: 'FAILED',
-            error: `Prompt provenance validation failed before claim: ${handled.message}`.slice(
+            error: `ArtJob validation failed before claim: ${handled.message}`.slice(
               0,
               4000,
             ),

--- a/server/utils/artJobQueueCoverage.ts
+++ b/server/utils/artJobQueueCoverage.ts
@@ -1,0 +1,429 @@
+// /server/utils/artJobQueueCoverage.ts
+//
+// Claim-time queue hygiene for baseline artwork.
+//
+// The ArtJob fingerprint protects against byte-equivalent re-enqueues, but it
+// deliberately treats a different seed/workflow/slot as a different attempt.
+// That is correct for explicit rerenders and terrible for a coverage backlog:
+// the Facet catalog historically queued imagePath + iconPath + cardPath +
+// heroPath independently, so one database object could consume four renders
+// while another object still had none.
+//
+// This module applies two conservative rules immediately before claim:
+//   1. Facet baseline coverage keeps at most ONE active slot job, preferring
+//      imagePath -> cardPath -> heroPath -> iconPath. Existing art satisfies the
+//      baseline and cancels still-pending coverage work. RUNNING work is never
+//      cancelled.
+//   2. Static delivery jobs with the exact same repo + path + normalized prompt
+//      are duplicate work. Keep the candidate (or an already-RUNNING sibling)
+//      and cancel the other PENDING copies.
+//
+// Explicit retries carry payload.retry and are excluded from both policies.
+// Cancellation preserves the ArtJob row/provenance while removing it from the
+// runnable queue.
+
+import type { ArtJob } from '~/prisma/generated/prisma/client'
+import prisma from './prisma'
+import { parseArtJobPayload } from './artJobPayload'
+import { assertArtPromptContract } from './artPromptContract'
+import { normalizeArtPrompt } from './artJobProvenance'
+
+export const FACET_COVERAGE_FIELD_ORDER = [
+  'imagePath',
+  'cardPath',
+  'heroPath',
+  'iconPath',
+] as const
+
+type QueueCandidate = Pick<
+  ArtJob,
+  'id' | 'status' | 'projectSlug' | 'payload' | 'priority' | 'engine'
+>
+
+type JsonRecord = Record<string, unknown>
+
+type CoverageResult = {
+  skipCandidate: boolean
+  cancelledCount: number
+  reason?: string
+}
+
+type FacetCoverageTarget = {
+  facetId: number
+  field: string
+}
+
+type StaticDeliveryTarget = {
+  targetRepo: string
+  imagePath: string
+  prompt: string
+}
+
+function asRecord(value: unknown): JsonRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as JsonRecord
+}
+
+function clean(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function positiveInteger(value: unknown): number | null {
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+function finiteNumber(value: unknown): number | null {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function hasRetry(payload: unknown): boolean {
+  return Object.keys(asRecord(asRecord(payload).retry)).length > 0
+}
+
+function workflowNodes(payload: unknown): JsonRecord[] {
+  return Object.values(asRecord(asRecord(payload).workflow)).map(asRecord)
+}
+
+/** Infer the model family from the actual Comfy graph, not only relay engine. */
+export function inferQueuedArtEngine(
+  payload: unknown,
+  fallbackEngine?: string | null,
+): string {
+  const record = asRecord(payload)
+  const explicit = clean(record.engine).toLowerCase()
+  if (explicit && explicit !== 'comfy') return explicit
+
+  let sawCheckpointLoader = false
+  for (const node of workflowNodes(record)) {
+    const classType = clean(node.class_type)
+    const inputs = asRecord(node.inputs)
+    const clipType = clean(inputs.type).toLowerCase()
+    const modelName = `${clean(inputs.unet_name)} ${clean(inputs.ckpt_name)}`.toLowerCase()
+
+    if (clipType === 'krea2' || modelName.includes('krea-2')) return 'krea2'
+    if (clipType === 'flux2' || modelName.includes('flux-2-klein')) return 'flux2'
+    if (classType === 'FluxGuidance' || clipType === 'flux') return 'flux'
+    if (classType === 'CheckpointLoaderSimple') sawCheckpointLoader = true
+  }
+
+  if (sawCheckpointLoader) return 'comfy'
+  return clean(fallbackEngine).toLowerCase()
+}
+
+/** Read the settings the sampler will actually execute. */
+export function queuedArtSamplerSettings(payload: unknown): {
+  steps: number | null
+  cfg: number | null
+} {
+  const record = asRecord(payload)
+  for (const node of workflowNodes(record)) {
+    if (clean(node.class_type) !== 'KSampler') continue
+    const inputs = asRecord(node.inputs)
+    return {
+      steps: finiteNumber(inputs.steps) ?? finiteNumber(record.steps),
+      cfg: finiteNumber(inputs.cfg) ?? finiteNumber(record.cfg),
+    }
+  }
+  return {
+    steps: finiteNumber(record.steps),
+    cfg: finiteNumber(record.cfg),
+  }
+}
+
+function queuedArtPrompt(payload: unknown): string {
+  const record = asRecord(payload)
+  const topLevel = clean(record.promptString) || clean(record.prompt)
+  if (topLevel) return topLevel
+
+  for (const node of workflowNodes(record)) {
+    const classType = clean(node.class_type)
+    if (classType !== 'CLIPTextEncode' && classType !== 'ImpactWildcardEncode') {
+      continue
+    }
+    const title = clean(asRecord(node._meta).title).toLowerCase()
+    if (title.includes('negative')) continue
+    const inputs = asRecord(node.inputs)
+    const prompt = clean(inputs.text) || clean(inputs.wildcard_text)
+    if (prompt) return prompt
+  }
+  return ''
+}
+
+/**
+ * Apply today's prompt/model contract to old PENDING rows too. The enqueue gate
+ * protects new work; this guard stops pre-gate backlog rows from quietly
+ * rendering with stale Krea settings or known-bad prompt vocabulary.
+ */
+export function assertQueuedArtPromptContract(
+  engine: string,
+  payload: unknown,
+): void {
+  const actualEngine = inferQueuedArtEngine(payload, engine)
+  const sampler = queuedArtSamplerSettings(payload)
+  assertArtPromptContract({
+    prompt: queuedArtPrompt(payload),
+    engine: actualEngine,
+    steps: sampler.steps,
+    cfg: sampler.cfg,
+  })
+}
+
+export function readFacetCoverageTarget(
+  payload: unknown,
+): FacetCoverageTarget | null {
+  const record = asRecord(payload)
+  if (hasRetry(record)) return null
+  const entityArt = asRecord(record.entityArt)
+  if (clean(entityArt.entityType).toLowerCase() !== 'facet') return null
+  const facetId = positiveInteger(entityArt.entityId)
+  const field = clean(entityArt.field)
+  if (!facetId || !field) return null
+  return { facetId, field }
+}
+
+function readStaticDeliveryTarget(payload: unknown): StaticDeliveryTarget | null {
+  const record = asRecord(payload)
+  if (hasRetry(record)) return null
+  const targetRepo = clean(record.targetRepo).toLowerCase()
+  const imagePath = clean(record.imagePath).replace(/\\/g, '/')
+  const prompt = normalizeArtPrompt(queuedArtPrompt(record))
+  if (!targetRepo || !imagePath || !prompt) return null
+  return { targetRepo, imagePath, prompt }
+}
+
+function fieldRank(field: string): number {
+  const index = FACET_COVERAGE_FIELD_ORDER.indexOf(
+    field as (typeof FACET_COVERAGE_FIELD_ORDER)[number],
+  )
+  return index === -1 ? FACET_COVERAGE_FIELD_ORDER.length : index
+}
+
+export function selectFacetCoverageKeeper<
+  T extends { id: number; priority: number; field: string },
+>(jobs: T[]): T | null {
+  if (!jobs.length) return null
+  return [...jobs].sort((left, right) => {
+    const byField = fieldRank(left.field) - fieldRank(right.field)
+    if (byField) return byField
+    const byPriority = right.priority - left.priority
+    if (byPriority) return byPriority
+    return left.id - right.id
+  })[0]!
+}
+
+async function cancelPending(ids: number[], reason: string): Promise<number> {
+  const uniqueIds = [...new Set(ids)].filter((id) => Number.isInteger(id) && id > 0)
+  if (!uniqueIds.length) return 0
+  const result = await prisma.artJob.updateMany({
+    where: {
+      id: { in: uniqueIds },
+      status: 'PENDING',
+    },
+    data: {
+      status: 'CANCELLED',
+      claimedAt: null,
+      claimedBy: null,
+      error: reason.slice(0, 4000),
+    },
+  })
+  return result.count
+}
+
+async function reconcileFacetCoverage(
+  candidate: QueueCandidate,
+  parsedPayload: JsonRecord,
+): Promise<CoverageResult | null> {
+  if (candidate.status !== 'PENDING' || candidate.projectSlug !== 'facet-catalog') {
+    return null
+  }
+  const target = readFacetCoverageTarget(parsedPayload)
+  if (!target) return null
+
+  const facet = await prisma.facet.findUnique({
+    where: { id: target.facetId },
+    select: {
+      imagePath: true,
+      cardPath: true,
+      heroPath: true,
+      iconPath: true,
+      artImageId: true,
+    },
+  })
+
+  if (!facet) {
+    const cancelledCount = await cancelPending(
+      [candidate.id],
+      `Cancelled before claim: Facet ${target.facetId} no longer exists.`,
+    )
+    return {
+      skipCandidate: cancelledCount > 0,
+      cancelledCount,
+      reason: 'missing-facet',
+    }
+  }
+
+  const marker = `\"entityType\":\"facet\",\"entityId\":${target.facetId},`
+  const siblings = await prisma.artJob.findMany({
+    where: {
+      projectSlug: 'facet-catalog',
+      status: { in: ['PENDING', 'RUNNING'] },
+      payload: { contains: marker },
+    },
+    select: {
+      id: true,
+      status: true,
+      priority: true,
+      payload: true,
+    },
+  })
+
+  const active = siblings
+    .map((job) => ({
+      ...job,
+      target: readFacetCoverageTarget(parseArtJobPayload(job.payload)),
+    }))
+    .filter((job) => job.target?.facetId === target.facetId)
+
+  const hasDisplayArt = Boolean(
+    clean(facet.imagePath) ||
+      clean(facet.cardPath) ||
+      clean(facet.heroPath) ||
+      clean(facet.iconPath) ||
+      facet.artImageId,
+  )
+
+  if (hasDisplayArt) {
+    const pendingIds = active
+      .filter((job) => job.status === 'PENDING')
+      .map((job) => job.id)
+    const cancelledCount = await cancelPending(
+      pendingIds,
+      `Cancelled before claim: Facet ${target.facetId} already has display artwork; baseline coverage is satisfied.`,
+    )
+    return {
+      skipCandidate: pendingIds.includes(candidate.id),
+      cancelledCount,
+      reason: 'facet-already-covered',
+    }
+  }
+
+  const running = active.find((job) => job.status === 'RUNNING')
+  if (running) {
+    const pendingIds = active
+      .filter((job) => job.status === 'PENDING')
+      .map((job) => job.id)
+    const cancelledCount = await cancelPending(
+      pendingIds,
+      `Cancelled before claim: ArtJob ${running.id} is already rendering baseline art for Facet ${target.facetId}.`,
+    )
+    return {
+      skipCandidate: pendingIds.includes(candidate.id),
+      cancelledCount,
+      reason: 'facet-coverage-running',
+    }
+  }
+
+  const pending = active
+    .filter(
+      (job): job is typeof job & { target: FacetCoverageTarget } =>
+        job.status === 'PENDING' && Boolean(job.target),
+    )
+    .map((job) => ({
+      id: job.id,
+      priority: job.priority,
+      field: job.target.field,
+    }))
+
+  // A payload search from an older serialization may fail to return the current
+  // row. Keep the candidate in the decision set so it can never cancel itself
+  // merely because its siblings were encoded differently.
+  if (!pending.some((job) => job.id === candidate.id)) {
+    pending.push({
+      id: candidate.id,
+      priority: candidate.priority,
+      field: target.field,
+    })
+  }
+
+  const keeper = selectFacetCoverageKeeper(pending)
+  if (!keeper) return null
+  const duplicateIds = pending
+    .filter((job) => job.id !== keeper.id)
+    .map((job) => job.id)
+  const cancelledCount = await cancelPending(
+    duplicateIds,
+    `Cancelled before claim: Facet ${target.facetId} needs one baseline image, not four. Keeping ArtJob ${keeper.id} (${keeper.field}); fallback order is imagePath → cardPath → heroPath → iconPath.`,
+  )
+
+  return {
+    skipCandidate: candidate.id !== keeper.id,
+    cancelledCount,
+    reason: duplicateIds.length ? 'facet-coverage-deduped' : undefined,
+  }
+}
+
+async function reconcileStaticDelivery(
+  candidate: QueueCandidate,
+  parsedPayload: JsonRecord,
+): Promise<CoverageResult | null> {
+  if (candidate.status !== 'PENDING') return null
+  const target = readStaticDeliveryTarget(parsedPayload)
+  if (!target) return null
+
+  const pathNeedle = `\"imagePath\":${JSON.stringify(target.imagePath)}`
+  const siblings = await prisma.artJob.findMany({
+    where: {
+      status: { in: ['PENDING', 'RUNNING'] },
+      payload: { contains: pathNeedle },
+    },
+    select: {
+      id: true,
+      status: true,
+      payload: true,
+    },
+  })
+
+  const matching = siblings.filter((job) => {
+    const siblingTarget = readStaticDeliveryTarget(parseArtJobPayload(job.payload))
+    return (
+      siblingTarget?.targetRepo === target.targetRepo &&
+      siblingTarget.imagePath === target.imagePath &&
+      siblingTarget.prompt === target.prompt
+    )
+  })
+
+  const running = matching.find((job) => job.status === 'RUNNING')
+  const keeperId = running?.id ?? candidate.id
+  const duplicateIds = matching
+    .filter((job) => job.status === 'PENDING' && job.id !== keeperId)
+    .map((job) => job.id)
+
+  const cancelledCount = await cancelPending(
+    duplicateIds,
+    `Cancelled before claim: duplicate static delivery for ${target.targetRepo}:${target.imagePath}. Keeping ArtJob ${keeperId}.`,
+  )
+
+  return {
+    skipCandidate: keeperId !== candidate.id,
+    cancelledCount,
+    reason: duplicateIds.length ? 'static-delivery-deduped' : undefined,
+  }
+}
+
+/**
+ * Reconcile only the candidate's small equivalence class. This avoids a 2,600
+ * row sweep on every relay poll while still deleting redundant work naturally
+ * as the queue drains.
+ */
+export async function reconcileQueuedArtJobCoverage(
+  candidate: QueueCandidate,
+): Promise<CoverageResult> {
+  const parsedPayload = parseArtJobPayload(candidate.payload)
+  const facet = await reconcileFacetCoverage(candidate, parsedPayload)
+  if (facet) return facet
+  const staticDelivery = await reconcileStaticDelivery(candidate, parsedPayload)
+  if (staticDelivery) return staticDelivery
+  return { skipCandidate: false, cancelledCount: 0 }
+}

--- a/server/utils/artJobQueueCoverage.ts
+++ b/server/utils/artJobQueueCoverage.ts
@@ -264,7 +264,7 @@ async function reconcileFacetCoverage(
     }
   }
 
-  const marker = `\"entityType\":\"facet\",\"entityId\":${target.facetId},`
+  const marker = `"entityType":"facet","entityId":${target.facetId},`
   const siblings = await prisma.artJob.findMany({
     where: {
       projectSlug: 'facet-catalog',
@@ -372,7 +372,7 @@ async function reconcileStaticDelivery(
   const target = readStaticDeliveryTarget(parsedPayload)
   if (!target) return null
 
-  const pathNeedle = `\"imagePath\":${JSON.stringify(target.imagePath)}`
+  const pathNeedle = `"imagePath":${JSON.stringify(target.imagePath)}`
   const siblings = await prisma.artJob.findMany({
     where: {
       status: { in: ['PENDING', 'RUNNING'] },

--- a/utils/artImageSrc.ts
+++ b/utils/artImageSrc.ts
@@ -75,10 +75,9 @@ const VARIANT_DATA_KEYS = {
  * avatar or primary image. That left hundreds of rendered card images sitting in
  * the database, invisible.
  *
- * Degrades deliberately: variant path -> variant base64 -> the full-size
- * resolver -> `fallback`. A slot that has not rendered yet therefore behaves
- * exactly as it did before rather than leaving a hole, which is what lets this
- * ship while the render queue is still draining.
+ * Degrades deliberately: requested variant path -> requested variant base64 ->
+ * the full-size resolver -> `fallback`. A gallery that asks for a card therefore
+ * gets the card when one exists and the general imagePath when it does not.
  */
 export function resolveArtVariantSrc(
   image: ArtImageSrcLike,
@@ -95,28 +94,27 @@ export function resolveArtVariantSrc(
 }
 
 /**
- * Card-first display artwork for any entity that carries art, or null.
+ * General display artwork for an entity that carries art, or null.
  *
- * This chain -- `cardPath || imagePath || heroPath [|| iconPath]` -- had been
- * hand-written SIX times: utils/narrativeIngredients.ts, facet-gallery.vue,
- * facet-manager.vue, facet-picker.vue, character-facet-picker.vue,
- * reward-facet-picker.vue and art-facet-selector.vue each carried their own
- * copy. They had already drifted: some included iconPath, some did not.
+ * `imagePath` is the canonical baseline image: one good primary render is enough
+ * for an entity to be displayable everywhere because cards/heroes/icons can
+ * resize or crop it. Purpose-built variants remain optional enhancements. When a
+ * caller has no specific variant requirement, fall back in the stable order:
  *
- * Ordering is preserved rather than "improved". Asking resolveArtVariantSrc for
- * each variant in turn yields cardPath -> cardData -> imagePath -> imageData ->
- * heroPath -> ... -> iconPath, so the relative precedence of the three path
- * fields matches every copy this replaces; the base64 fallbacks are a superset,
- * reachable only where a path was absent and the old chain returned null.
+ *   imagePath -> cardPath -> heroPath -> iconPath
  *
- * Returns null, not '', because every caller tested truthiness to decide
- * between an <img> and a placeholder.
+ * Variant-aware galleries should keep using resolveArtVariantSrc(), which first
+ * asks for the requested shape and then falls back to imagePath.
  */
 export function resolveEntityArtwork(image: ArtImageSrcLike): string | null {
   return (
-    resolveArtVariantSrc(image, 'card') ||
-    resolveArtVariantSrc(image, 'hero') ||
-    resolveArtVariantSrc(image, 'icon') ||
+    resolveArtImageSrc(image) ||
+    cleanValue(image?.cardPath) ||
+    toArtDataUri(image?.cardData, image?.fileType) ||
+    cleanValue(image?.heroPath) ||
+    toArtDataUri(image?.heroData, image?.fileType) ||
+    cleanValue(image?.iconPath) ||
+    toArtDataUri(image?.iconData, image?.fileType) ||
     null
   )
 }

--- a/utils/scripts/verifyFacetCatalogMaintenance.ts
+++ b/utils/scripts/verifyFacetCatalogMaintenance.ts
@@ -18,6 +18,11 @@ const managerPath = path.join(root, 'components/facets/facet-manager.vue')
 const editorPath = path.join(root, 'components/facets/facet-editor.vue')
 const galleryPath = path.join(root, 'components/facets/facet-gallery.vue')
 const entityArtPath = path.join(root, 'server/utils/entityArt.ts')
+const queueCoveragePath = path.join(
+  root,
+  'server/utils/artJobQueueCoverage.ts',
+)
+const queueClaimPath = path.join(root, 'server/api/art/queue/claim.post.ts')
 
 const cleanup = fs.readFileSync(cleanupPath, 'utf8')
 const art = fs.readFileSync(artPath, 'utf8')
@@ -28,6 +33,8 @@ const manager = fs.readFileSync(managerPath, 'utf8')
 const editor = fs.readFileSync(editorPath, 'utf8')
 const gallery = fs.readFileSync(galleryPath, 'utf8')
 const entityArt = fs.readFileSync(entityArtPath, 'utf8')
+const queueCoverage = fs.readFileSync(queueCoveragePath, 'utf8')
+const queueClaim = fs.readFileSync(queueClaimPath, 'utf8')
 
 for (const required of [
   "designer: 'facet-catalog-merged'",
@@ -95,6 +102,70 @@ for (const required of [
 ]) {
   assert.ok(art.includes(required), `Missing Facet art contract: ${required}`)
 }
+
+/*
+ * Baseline coverage policy, 2026-08-08.
+ *
+ * Facets can still own four purpose-built slots, and the editor still exposes
+ * them for intentional curation. The automatic backlog is different: its job is
+ * to make every displayable object have something usable before spending three
+ * more renders improving the same object. Claim-time reconciliation therefore
+ * collapses active Facet coverage work to one job in this exact order. It never
+ * cancels RUNNING work and preserves cancelled ArtJob rows for provenance.
+ */
+for (const required of [
+  'FACET_COVERAGE_FIELD_ORDER',
+  "'imagePath'",
+  "'cardPath'",
+  "'heroPath'",
+  "'iconPath'",
+  "candidate.projectSlug !== 'facet-catalog'",
+  "status: { in: ['PENDING', 'RUNNING'] }",
+  "status: 'CANCELLED'",
+  'hasDisplayArt',
+  'selectFacetCoverageKeeper',
+  'payload.retry',
+  'duplicate static delivery',
+  'inferQueuedArtEngine',
+  'queuedArtSamplerSettings',
+  'assertQueuedArtPromptContract',
+]) {
+  assert.ok(
+    queueCoverage.includes(required),
+    `Missing queue coverage contract: ${required}`,
+  )
+}
+
+const imagePathOrder = queueCoverage.indexOf("'imagePath'")
+const cardPathOrder = queueCoverage.indexOf("'cardPath'")
+const heroPathOrder = queueCoverage.indexOf("'heroPath'")
+const iconPathOrder = queueCoverage.indexOf("'iconPath'")
+assert.ok(
+  imagePathOrder >= 0 &&
+    imagePathOrder < cardPathOrder &&
+    cardPathOrder < heroPathOrder &&
+    heroPathOrder < iconPathOrder,
+  'Baseline coverage fallback order must be imagePath -> cardPath -> heroPath -> iconPath.',
+)
+
+for (const required of [
+  'reconcileQueuedArtJobCoverage',
+  'assertQueuedArtPromptContract',
+  'const coverage = await reconcileQueuedArtJobCoverage(candidate)',
+  'if (coverage.skipCandidate)',
+  'ArtJob validation failed before claim',
+]) {
+  assert.ok(
+    queueClaim.includes(required),
+    `ArtJob claim must enforce queue coverage/quality guard: ${required}`,
+  )
+}
+
+assert.ok(
+  queueCoverage.includes("job.status === 'PENDING'") &&
+    !queueCoverage.includes("status: 'RUNNING',\n      claimedAt: null"),
+  'Coverage cleanup may cancel PENDING jobs but must never rewrite a RUNNING job to CANCELLED.',
+)
 
 for (const required of [
   'iconPath           String?',

--- a/utils/scripts/verifyFacetCatalogMaintenance.ts
+++ b/utils/scripts/verifyFacetCatalogMaintenance.ts
@@ -151,7 +151,8 @@ assert.ok(
 for (const required of [
   'reconcileQueuedArtJobCoverage',
   'assertQueuedArtPromptContract',
-  'const coverage = await reconcileQueuedArtJobCoverage(candidate)',
+  'const coverage = await reconcileQueuedArtJobCoverage',
+  'payload: serializeArtJobPayload(candidate.payload)',
   'if (coverage.skipCandidate)',
   'ArtJob validation failed before claim',
 ]) {


### PR DESCRIPTION
## Root cause

The durable ArtJob fingerprint correctly suppresses byte-equivalent re-enqueues, but it deliberately treats different slot/workflow/seed payloads as different attempts. Meanwhile the Facet catalog maintenance lane explicitly queues **imagePath + iconPath + cardPath + heroPath independently** for every art-required Facet. With a large catalog, that can spend four renders improving one object while another object still has no usable art at all.

That policy also predates today's prompt/model contract. Old PENDING rows can therefore contain Krea-inappropriate format language or stale sampler settings even though new enqueues are now rejected.

## What changed

- make `imagePath` the canonical generic entity fallback, then `cardPath`, `heroPath`, `iconPath`; variant-aware galleries still request their preferred shape first and fall back to `imagePath`
- add claim-time baseline coverage reconciliation for `facet-catalog` jobs:
  - if a Facet already has any display art, cancel remaining PENDING baseline jobs
  - if one sibling is already RUNNING, keep it and cancel PENDING siblings
  - otherwise keep one PENDING job only, preferring `imagePath -> cardPath -> heroPath -> iconPath`
  - explicit retry payloads are excluded
  - RUNNING jobs are never cancelled
- add conservative static-delivery dedupe for exact `targetRepo + imagePath + normalized prompt` duplicates; a RUNNING sibling wins, otherwise the selected candidate wins
- use `CANCELLED`, not row deletion, so redundant work leaves the runnable queue without destroying ArtJob provenance
- re-apply the current art prompt/model contract immediately before claim for old backlog rows, inferring the actual image engine and sampler settings from the Comfy workflow graph
  - Krea 2 jobs are therefore checked as Krea 2, not merely generic `COMFY`
  - stale Krea guidance/step settings and known-bad prompt shapes fail before spending a render
- extend the Facet maintenance contract verifier so coverage order and queue safety cannot silently drift back

## Why claim-time

This handles the 2,600+ existing backlog without requiring a destructive one-off database sweep or a new production credential path. Cleanup happens naturally as the relay reaches each equivalence class, before the render is claimed. It also defends against older producers that bypassed the modern enqueue boundary by writing ArtJobs directly.

## Production mutation status

This session does not have a valid Kind Robots JWT (`KR_API_TOKEN` is absent), and the production queue API correctly returned 401 to an unauthenticated read. I did **not** bypass that by writing raw SQL. No production ArtJobs were directly changed from this session; after merge/deploy, normal relay claims apply the cleanup policy.

## Verification

CI is the execution gate for this connector-only branch. The existing Facet Catalog Contract now includes the new coverage/quality assertions, in addition to the repository's required TypeScript / contract checks.

## Scope

Silas-directed Kind Robots runtime work; no Conductor roadmap task claimed. No schema migration. No new ArtJobs created by this PR.