### PR TITLE
feat(chatgpt): expose private admin action schema

### DIFF
--- a/cypress/e2e/api/chatgpt-action.cy.ts
+++ b/cypress/e2e/api/chatgpt-action.cy.ts
@@ -1,0 +1,113 @@
+import {
+  bearerHeaders,
+  defaultApiBase,
+  getApiEnv,
+} from '../../support/api-auth'
+
+type OpenApiDocument = {
+  openapi?: string
+  info?: {
+    title?: string
+  }
+  servers?: Array<{
+    url?: string
+  }>
+  paths?: Record<
+    string,
+    {
+      post?: {
+        operationId?: string
+        security?: Array<Record<string, unknown>>
+      }
+    }
+  >
+  components?: {
+    securitySchemes?: Record<
+      string,
+      {
+        type?: string
+        scheme?: string
+      }
+    >
+    schemas?: Record<
+      string,
+      {
+        properties?: Record<
+          string,
+          {
+            enum?: string[]
+          }
+        >
+      }
+    >
+  }
+}
+
+type DescribeResponse = {
+  success?: boolean
+  operation?: string
+  data?: {
+    actor?: {
+      role?: string
+      source?: string
+    }
+    authentication?: {
+      acceptedCredentials?: string[]
+    }
+  }
+}
+
+describe('ChatGPT admin action bridge', () => {
+  it('publishes an importable bearer-auth OpenAPI schema', () => {
+    cy.request<OpenApiDocument>({
+      url: `${defaultApiBase}/chatgpt/openapi`,
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(200)
+      expect(response.body.openapi).to.eq('3.1.0')
+      expect(response.body.info?.title).to.eq('Kind Robots Admin Action')
+      expect(response.body.servers?.[0]?.url).to.eq(
+        'https://kind-robots.vercel.app',
+      )
+
+      const action = response.body.paths?.['/api/chatgpt']?.post
+      expect(action?.operationId).to.eq('executeKindRobotsOperation')
+      expect(action?.security).to.deep.include({ bearerAuth: [] })
+
+      const bearer = response.body.components?.securitySchemes?.bearerAuth
+      expect(bearer?.type).to.eq('http')
+      expect(bearer?.scheme).to.eq('bearer')
+
+      const operations =
+        response.body.components?.schemas?.KindRobotsOperation?.properties
+          ?.operation?.enum || []
+      expect(operations).to.include('meta.describe')
+      expect(operations).to.include('content.list')
+      expect(operations).to.include('content.update')
+      expect(operations).to.include('content.setActive')
+    })
+  })
+
+  it('accepts the existing admin token through Bearer auth', () => {
+    getApiEnv().then(({ apiBase, adminToken }) => {
+      cy.request<DescribeResponse>({
+        method: 'POST',
+        url: `${apiBase}/chatgpt`,
+        headers: bearerHeaders(adminToken),
+        body: {
+          operation: 'meta.describe',
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status, JSON.stringify(response.body)).to.eq(200)
+        expect(response.body.success, JSON.stringify(response.body)).to.eq(true)
+        expect(response.body.operation).to.eq('meta.describe')
+        expect(response.body.data?.actor?.role).to.eq('admin')
+        expect(response.body.data?.actor?.source).to.eq('beta-admin-token')
+        expect(
+          response.body.data?.authentication?.acceptedCredentials,
+        ).to.include('beta admin token')
+      })
+    })
+  })
+})

--- a/docs/chatgpt-admin-action.md
+++ b/docs/chatgpt-admin-action.md
@@ -1,0 +1,80 @@
+# ChatGPT Admin Action
+
+Kind Robots exposes its existing machine-content API as a private Custom GPT Action for
+ChatGPT Plus users. This gives ChatGPT authenticated access to supported live Kind Robots
+records without ever putting the admin credential in a conversation.
+
+## Production endpoints
+
+- Action schema: `https://kind-robots.vercel.app/api/chatgpt/openapi`
+- Machine API: `https://kind-robots.vercel.app/api/chatgpt`
+
+The action schema is public metadata. The machine API is not public: every operation still
+passes through the normal Kind Robots machine-user auth guard.
+
+## Credential
+
+Production already uses `ADMIN_TOKEN`. `server/utils/authGuard.ts` accepts that token as
+Bearer auth, validates the configured admin user, and resolves the request as an admin
+machine actor.
+
+Do not add the token to this repository, prompts, GPT instructions, knowledge files, or
+request bodies.
+
+## One-time ChatGPT Plus setup
+
+1. Open the GPT editor on chatgpt.com and create a private GPT, for example **Kind Robots Admin**.
+2. In **Configure → Actions**, create a new action.
+3. Set **Authentication** to **API key** and choose **Bearer**.
+4. Paste the value of `ADMIN_TOKEN` into the action's secret credential field. This is a
+   configuration secret, not conversation content.
+5. Import the OpenAPI schema from
+   `https://kind-robots.vercel.app/api/chatgpt/openapi`.
+6. In Preview, ask the GPT to run `meta.describe`. A successful response identifies the
+   actor role as `admin` and the auth source as `beta-admin-token`.
+7. Keep the GPT private unless there is a deliberate reason to share its admin capability.
+
+The API key is then supplied by ChatGPT as an `Authorization: Bearer ...` header. It is not
+part of the tool arguments visible to the model.
+
+## Supported operations
+
+The action intentionally fronts the existing machine-content API instead of creating a
+second admin implementation:
+
+- `meta.describe`
+- `content.create`
+- `content.get`
+- `content.list`
+- `content.update`
+- `content.setActive`
+- `image.upload`
+- `image.get`
+- `relation.add`
+- `relation.remove`
+- `relation.list`
+
+Call `meta.describe` before guessing fields on an unfamiliar model. It reports the current
+resource registry, readable/writable fields, filter fields, and authenticated actor.
+
+The generic API redacts configured credentials and private fields. It uses soft activation
+where supported rather than exposing a generic hard-delete operation.
+
+## Why this is an Action instead of MCP on Plus
+
+As of August 2026, ChatGPT Plus can build and use custom GPTs with Actions. Full custom MCP
+apps with write/modify actions are currently available to Business and Enterprise/Edu
+workspaces, not Plus. The machine-content service behind this Action can later be wrapped by
+an MCP transport without changing its authentication or content policy.
+
+## Security model
+
+- `ADMIN_TOKEN` remains the server's configured admin credential and the GPT Action's stored
+  API-key credential.
+- The public OpenAPI endpoint contains no secret.
+- The GPT sends the credential only in the Authorization header.
+- The machine-content API resolves the credential through the same `authGuard.ts` used by
+  other authenticated machine clients.
+- Admin-only resources remain admin-only.
+- Generic responses redact configured secret/private fields.
+- No generic hard-delete operation is exposed.

--- a/server/api/chatgpt/openapi.get.ts
+++ b/server/api/chatgpt/openapi.get.ts
@@ -1,0 +1,190 @@
+import { defineEventHandler, setHeader } from 'h3'
+import { ChatGptResourceSchema } from '~/server/chatgpt/schemas/operationSchemas'
+
+const OPERATION_NAMES = [
+  'content.create',
+  'content.get',
+  'content.list',
+  'content.update',
+  'content.setActive',
+  'image.upload',
+  'image.get',
+  'relation.add',
+  'relation.remove',
+  'relation.list',
+  'meta.describe',
+] as const
+
+const operationDescriptions = {
+  'content.create': 'Create a supported Kind Robots record.',
+  'content.get': 'Get one supported Kind Robots record by numeric id.',
+  'content.list': 'Search or list supported Kind Robots records.',
+  'content.update': 'Update editable scalar fields on a supported record.',
+  'content.setActive': 'Activate or deactivate a supported record without hard deletion.',
+  'image.upload': 'Store supplied image data and optionally connect it to supported records.',
+  'image.get': 'Read image metadata, path, or encoded image data.',
+  'relation.add': 'Add a supported relation between two records.',
+  'relation.remove': 'Remove a supported relation between two records.',
+  'relation.list': 'List supported relations from one record.',
+  'meta.describe': 'Describe the live machine-content API, actor, fields, filters, and capabilities.',
+} satisfies Record<(typeof OPERATION_NAMES)[number], string>
+
+function buildOperationDescription() {
+  return OPERATION_NAMES.map(
+    (operation) => `- ${operation}: ${operationDescriptions[operation]}`,
+  ).join('\n')
+}
+
+export default defineEventHandler((event) => {
+  setHeader(event, 'cache-control', 'public, max-age=300, s-maxage=300')
+
+  return {
+    openapi: '3.1.0',
+    info: {
+      title: 'Kind Robots Admin Action',
+      version: '1.0.0',
+      description:
+        'Authenticated machine access to live Kind Robots content. Configure the GPT Action with the existing Kind Robots ADMIN_TOKEN as a Bearer API key. Never place that token in prompts or request bodies.',
+    },
+    servers: [
+      {
+        url: 'https://kind-robots.vercel.app',
+        description: 'Kind Robots production',
+      },
+    ],
+    paths: {
+      '/api/chatgpt': {
+        post: {
+          operationId: 'executeKindRobotsOperation',
+          summary: 'Execute a Kind Robots machine-content operation',
+          description: [
+            'Use this action for authenticated reads and deliberate writes against the live Kind Robots database.',
+            'The server validates the operation-specific request shape, applies ownership/admin policy, and redacts credentials and private fields from generic responses.',
+            'Prefer meta.describe before guessing model fields or filters. Use content.setActive instead of hard deletion.',
+            '',
+            'Supported operations:',
+            buildOperationDescription(),
+          ].join('\n'),
+          security: [{ bearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/KindRobotsOperation' },
+              },
+            },
+          },
+          responses: {
+            '200': {
+              description: 'Operation completed.',
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/KindRobotsResponse' },
+                },
+              },
+            },
+            '400': { description: 'Invalid operation or request shape.' },
+            '401': { description: 'Missing, invalid, or expired credential.' },
+            '403': { description: 'Authenticated actor lacks permission.' },
+            '404': { description: 'Requested record was not found.' },
+            '409': { description: 'The requested write conflicts with existing data.' },
+            '422': { description: 'Request values do not match the live database schema.' },
+          },
+        },
+      },
+    },
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'Kind Robots ADMIN_TOKEN',
+          description:
+            'Configure this in the GPT Action authentication UI. Do not send the token as an operation field.',
+        },
+      },
+      schemas: {
+        ContentRef: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['resource', 'id'],
+          properties: {
+            resource: {
+              type: 'string',
+              enum: ChatGptResourceSchema.options,
+            },
+            id: { type: 'integer', minimum: 1 },
+          },
+        },
+        KindRobotsOperation: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['operation'],
+          description:
+            'Operation-specific fields are validated by the server. Call meta.describe to discover current writable fields and supported filters before mutating unfamiliar resources.',
+          properties: {
+            operation: {
+              type: 'string',
+              enum: OPERATION_NAMES,
+              description: buildOperationDescription(),
+            },
+            resource: {
+              type: 'string',
+              enum: ChatGptResourceSchema.options,
+              description:
+                'Required by content operations and optionally used by relation operations through ContentRef.',
+            },
+            id: {
+              type: 'integer',
+              minimum: 1,
+              description: 'Record id for content.get, content.update, content.setActive, or image.get.',
+            },
+            data: {
+              type: 'object',
+              additionalProperties: true,
+              description: 'Create/update fields, or image upload fields for image.upload.',
+            },
+            filter: {
+              type: 'object',
+              additionalProperties: true,
+              description:
+                'content.list filters. Common controls include q, ids, isActive, isPublic, isMature, userId, limit, offset, page, orderBy, and orderDirection.',
+            },
+            isActive: {
+              type: 'boolean',
+              description: 'New active state for content.setActive.',
+            },
+            format: {
+              type: 'string',
+              enum: ['metadata', 'dataUrl', 'path'],
+              description: 'Requested image.get representation.',
+            },
+            thumbnail: { type: 'boolean' },
+            maxWidth: { type: 'integer', minimum: 1 },
+            maxHeight: { type: 'integer', minimum: 1 },
+            quality: { type: 'integer', minimum: 1, maximum: 100 },
+            from: { $ref: '#/components/schemas/ContentRef' },
+            to: { $ref: '#/components/schemas/ContentRef' },
+            toResource: {
+              type: 'string',
+              enum: ChatGptResourceSchema.options,
+            },
+          },
+        },
+        KindRobotsResponse: {
+          type: 'object',
+          additionalProperties: true,
+          required: ['success', 'operation'],
+          properties: {
+            success: { type: 'boolean' },
+            operation: { type: 'string' },
+            resource: { type: 'string' },
+            data: {},
+            message: { type: 'string' },
+            meta: { type: 'object', additionalProperties: true },
+          },
+        },
+      },
+    },
+  }
+})


### PR DESCRIPTION
## What changed

- adds `GET /api/chatgpt/openapi`, an importable OpenAPI schema for a private Custom GPT Action
- fronts the existing `/api/chatgpt` machine-content API rather than adding a second admin backend
- uses the existing Bearer auth path, which already accepts production `ADMIN_TOKEN`
- adds Cypress coverage for the public schema and an authenticated `meta.describe` call
- documents the one-time private GPT setup and secret-handling model

## Why

ChatGPT.com cannot inherit a Windows environment variable. On ChatGPT Plus, custom GPT Actions are the supported way to store an API credential outside conversation text and call a private external API. Full custom MCP write apps currently require Business/Enterprise/Edu.

This makes the existing Kind Robots machine-content API directly usable from a private GPT while keeping `ADMIN_TOKEN` out of prompts, code, and request bodies.

## Security

- no new production secret
- no token value is committed or returned by the schema
- the action advertises Bearer auth only
- all calls still pass through `authGuard.ts`
- existing field redaction and admin/ownership policy remain authoritative
- no generic hard-delete action is exposed

## Validation

CI/typecheck plus `cypress/e2e/api/chatgpt-action.cy.ts` verify the schema contract and the existing admin Bearer path.