### PR TITLE
Make the card back scroll, animate, and look like a card

### DIFF
--- a/components/gallery/kr-card-back.vue
+++ b/components/gallery/kr-card-back.vue
@@ -39,17 +39,54 @@
       because that is how you FIND a thing in a grid; on the back you have
       already found it, and the stats are what you came for.
     -->
-    <header
-      class="flex shrink-0 items-start gap-3 border-b border-base-300 bg-base-200/60 p-3"
-    >
-      <img
-        v-if="artSrc"
-        :src="artSrc"
-        :alt="title"
-        class="h-16 w-16 shrink-0 rounded-xl object-cover"
-      />
+    <header class="relative shrink-0 border-b border-base-300 bg-base-200/60">
+      <!--
+        THE ART IS THE CARD, not a favicon beside a heading. It was a 64px
+        square thumbnail, which reads as a list row rather than the back of
+        something -- Silas, 2026-08-08: "should definitely look card like, with
+        better image size".
 
-      <div class="min-w-0 flex-1">
+        A 4:3 plate the width of the panel is what makes it a card again, and
+        it is capped rather than free so a tall image cannot push the stats off
+        a phone. The title sits in a scrim ON the art, the same relationship
+        the FRONT of the card already uses, so turning it over reads as the
+        same object rather than a different screen.
+      -->
+      <div
+        v-if="artSrc"
+        class="relative aspect-[4/3] max-h-56 w-full shrink-0 overflow-hidden bg-base-300"
+      >
+        <img :src="artSrc" :alt="title" class="h-full w-full object-cover" />
+
+        <div
+          class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 via-black/45 to-transparent p-3 pt-8"
+        >
+          <h2 class="break-words text-lg font-black leading-tight text-white">
+            {{ title }}
+          </h2>
+
+          <p v-if="subtitle" class="mt-0.5 text-xs text-white/75">
+            {{ subtitle }}
+          </p>
+        </div>
+
+        <div
+          v-if="badges.length"
+          class="absolute left-2 top-2 flex flex-wrap gap-1"
+        >
+          <span
+            v-for="badge in badges"
+            :key="badge"
+            class="badge badge-sm border-none bg-black/60 text-white"
+          >
+            {{ badge }}
+          </span>
+        </div>
+      </div>
+
+      <!-- No art: the title has to carry the header on its own, so it keeps
+           the badges beside it rather than leaving an empty plate. -->
+      <div v-else class="min-w-0 flex-1 p-3">
         <h2 class="break-words text-lg font-black leading-tight">
           {{ title }}
         </h2>
@@ -77,7 +114,7 @@
       -->
       <button
         type="button"
-        class="btn btn-ghost btn-sm shrink-0 rounded-xl"
+        class="btn btn-sm absolute right-2 top-2 rounded-xl border-none bg-black/55 text-white hover:bg-black/75"
         @click="emit('back')"
       >
         <Icon name="kind-icon:arrow-left" class="h-4 w-4" />
@@ -85,7 +122,13 @@
       </button>
     </header>
 
-    <div class="min-h-0 flex-1 p-3">
+    <!--
+      min-h-0 is what lets this shrink below its content so kr-card-flip's
+      scroll container has something to scroll. Without it the flex child is
+      floored at content height and the panel grows instead, which is the same
+      failure the stage's height fix addresses from the other end.
+    -->
+    <div class="min-h-0 flex-1 overflow-y-auto p-3">
       <!--
         The edit form REPLACES the info body rather than flipping again --
         "the edit option is just an on-screen change to the modal". A second

--- a/components/gallery/kr-card-flip.vue
+++ b/components/gallery/kr-card-flip.vue
@@ -183,7 +183,23 @@ watch(modelValue, async (isOpen) => {
     // dismissing returns you somewhere other than where you opened it.
     document.body.style.overflow = 'hidden'
 
+    /*
+     * TWO FRAMES, not nextTick. Silas, 2026-08-08: "no animation effect."
+     *
+     * nextTick only guarantees Vue has patched the DOM. The browser may not
+     * have computed style for the newly-inserted node yet, so setting
+     * `is-shown` in the same frame leaves the transition no previous value to
+     * animate FROM and it snaps straight to the end state -- the panel simply
+     * appears, which is the one thing a card turning over must not do.
+     *
+     * The first rAF fires before the next paint; the second lands after it, by
+     * which point the pre-flip transform is committed and the class change is
+     * a real transition. Vue's own <Transition> does the same internally.
+     */
     await nextTick()
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
+
     shown.value = true
     panelRef.value?.focus()
     return
@@ -247,8 +263,21 @@ onBeforeUnmount(() => {
    * 1rem of padding, so its content box already IS the viewport less the
    * gutter -- and verifyLayoutContract forbids viewport units nested inside
    * the h-dvh shell, which caught the `calc(100dvh - 2rem)` this replaced.
+   *
+   * HEIGHT, not max-height, and that distinction is the whole bug. The panel
+   * below caps itself with `max-height: 100%`, and a percentage resolves only
+   * against a parent's DEFINITE height -- a stage sized `max-height: 100%` is
+   * still auto-height, so that percentage computed to `none`, the panel grew
+   * as tall as its content, and on a phone it ran off the bottom with nothing
+   * to scroll. Silas, 2026-08-08: "on mobile and can't scroll ... Editing
+   * brings to an overly large screen with no scroll."
+   *
+   * `min-height: 0` lets this shrink inside the backdrop's flex line instead
+   * of being floored at its content height, which would put the bottom back
+   * off-screen by another route.
    */
-  max-height: 100%;
+  height: 100%;
+  min-height: 0;
   align-items: center;
   justify-content: center;
 }


### PR DESCRIPTION
> "on mobile and can't scroll, no animation effect. Back side of resources is positioned weirdly, should definitely look card like, with better image size … Editing brings to an overly large screen with no scroll."

Three separate bugs, all confirmed in the source.

## Scroll — a CSS percentage that resolved to nothing

The panel capped itself with `max-height: 100%`. Its parent stage was *also* sized `max-height: 100%` — which leaves the stage **auto-height**, and a percentage resolves only against a **definite** height.

So the panel's cap computed to `none`, it grew as tall as its content, and on a phone it ran off the bottom with nothing to scroll.

The stage now takes `height: 100%` of the backdrop — which is `fixed; inset: 0` and therefore definite — plus `min-height: 0` so it can still shrink inside the backdrop's flex line.

The card back's body gains its own `overflow-y-auto`. That's the same bug from the other end, and it's why **editing was worst**: the form is the tallest thing the panel ever holds.

## Animation — `nextTick` isn't a frame

`nextTick` only guarantees Vue has patched the DOM. The browser may not have computed style for the newly-inserted node yet, so setting `is-shown` in the same tick left the transition no previous value to animate *from* — it snapped straight to the end state.

Two `requestAnimationFrame`s now sit between mount and the class change: the first fires before the next paint, the second after it, by which point the pre-flip transform is committed. Vue's own `<Transition>` does the same internally.

## Card-like — the art was a favicon

It was a **64px square** beside a heading, which reads as a list row, not the back of something.

It's now a **4:3 plate the width of the panel**, with the title in a scrim over it and badges in the corner — the same relationship the *front* of the card already uses, so turning it over reads as the same object rather than a different screen. Capped at `max-h-56` so a tall image can't push the stats off a phone, and **Back** floats over the art instead of competing with the title for the row.

A record with no art keeps the old text header rather than rendering an empty plate.

## Also, to answer "not sure where to check"

Only **Bots** and **Resources** are wired to the card back. Characters and Scenarios still route straight to the interact tier, so the "unformatted interact" there is the old behaviour — not a broken back. Those roll out once you're happy with the shape.

## Verification

- `npm run test` (vue-tsc) — clean
- `npm run test:layout-contract` — holds, no new violations
- `npx eslint` + `npx prettier` on both changed files — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_