### PR TITLE
refactor(ui): converge giftshop/wonderlab/dreams cards on kr-panel

### DIFF
--- a/components/dreams/daily-digest-object-dialog.vue
+++ b/components/dreams/daily-digest-object-dialog.vue
@@ -87,7 +87,7 @@
               <article
                 v-for="row in overviewRows"
                 :key="row.key"
-                class="rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm"
+                class="kr-panel p-4"
               >
                 <p class="text-xs font-black uppercase tracking-[0.14em] text-primary/75">
                   {{ row.label }}

--- a/components/giftshop/giftshop-interact.vue
+++ b/components/giftshop/giftshop-interact.vue
@@ -1,7 +1,7 @@
 <!-- /components/content/giftshop/giftshop-interact.vue -->
 <template>
   <section class="grid gap-4 lg:grid-cols-[1.15fr_0.85fr]">
-    <div class="rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm">
+    <div class="kr-panel p-4">
       <div class="flex flex-col gap-4">
         <div
           class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"
@@ -168,7 +168,7 @@
       </div>
     </div>
 
-    <aside class="rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm">
+    <aside class="kr-panel p-4">
       <div class="flex items-center justify-between gap-3">
         <div>
           <h3 class="text-xl font-black text-primary">Cart Nest</h3>

--- a/components/wonderlab/component-review-feed.vue
+++ b/components/wonderlab/component-review-feed.vue
@@ -59,7 +59,7 @@
       <article
         v-for="review in reviews"
         :key="review.id"
-        class="rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm"
+        class="kr-panel p-4"
       >
         <div class="flex items-start gap-3">
           <NuxtLink


### PR DESCRIPTION
## Summary
interface-vision/t-104 slice 10: migrate 3 more exact-match hand-rolled panel surfaces onto the shared `kr-panel` utility class.

- `components/giftshop/giftshop-interact.vue` — the two top-level panels (main content + cart aside)
- `components/wonderlab/component-review-feed.vue` — the review card
- `components/dreams/daily-digest-object-dialog.vue` — the overview row card

Each target was a byte-for-byte match of `kr-panel`'s baked-in `rounded-2xl border border-base-300 bg-base-100 shadow-sm` treatment, with only `p-4` padding differing from `kr-panel`'s default `p-6` — preserved as a utility override (`kr-panel p-4`), same pattern as slices 8-9. Zero visual delta; content, layout, and spacing unchanged.

## Verification
- `eslint` — clean on all 3 files (one pre-existing, unrelated `vue/no-mutating-props` error on `daily-digest-object-dialog.vue` line 520, confirmed present before this change too)
- `vue-tsc --noEmit` — clean
- `verifyLayoutContract.ts` — holds, no new violations
- `verifyLintRatchet.ts` — holds, 392/27 unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGeZoQLJWFjuT3ECRxKc3V)_