### PR TITLE
interface-vision/t-104: migrate 4 more zero-padding surfaces to kr-panel (slice 12)

### DIFF
--- a/components/navigation/navigation-health.vue
+++ b/components/navigation/navigation-health.vue
@@ -1,9 +1,7 @@
 <!-- /components/navigation/navigation-health.vue -->
 <template>
   <section class="mx-auto flex w-full max-w-7xl flex-col gap-4 p-4 sm:p-6">
-    <header
-      class="overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm"
-    >
+    <header class="overflow-hidden kr-panel p-0">
       <div class="flex flex-col gap-3 p-5 sm:flex-row sm:items-start sm:justify-between">
         <div class="min-w-0">
           <div class="flex items-center gap-2">
@@ -122,7 +120,7 @@
       <article
         v-for="channel in channels"
         :key="channel.channelKey"
-        class="overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm"
+        class="overflow-hidden kr-panel p-0"
       >
         <header class="relative overflow-hidden border-b border-base-300 p-4">
           <img

--- a/components/navigation/workspace-sheet.vue
+++ b/components/navigation/workspace-sheet.vue
@@ -1,9 +1,7 @@
 <!-- /components/navigation/workspace-sheet.vue -->
 <template>
   <aside class="flex min-h-0 flex-col gap-4 overflow-y-auto p-1">
-    <div
-      class="overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm"
-    >
+    <div class="overflow-hidden kr-panel p-0">
       <div
         class="relative overflow-hidden bg-base-300"
         :class="{ 'aspect-4/3': !imagePath }"
@@ -124,7 +122,7 @@
         <section
           v-for="card in builderStore.completedCardList"
           :key="card.key"
-          class="group relative overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm transition-all duration-300 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"
+          class="group relative overflow-hidden kr-panel p-0 transition-all duration-300 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"
         >
           <div
             v-if="cardImagePath(card)"

--- a/components/projects/project-placement-manager.vue
+++ b/components/projects/project-placement-manager.vue
@@ -1,9 +1,7 @@
 <!-- /components/projects/project-placement-manager.vue -->
 <template>
   <section class="mx-auto flex w-full max-w-6xl flex-col gap-4 p-4 sm:p-6">
-    <header
-      class="overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm"
-    >
+    <header class="overflow-hidden kr-panel p-0">
       <div class="flex flex-col gap-3 p-5 sm:flex-row sm:items-start sm:justify-between">
         <div class="min-w-0">
           <div class="flex items-center gap-2">

--- a/components/resources/resource-card.vue
+++ b/components/resources/resource-card.vue
@@ -40,7 +40,7 @@
 -->
 <template>
   <article
-    class="group flex h-full flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
+    class="group flex h-full flex-col overflow-hidden kr-panel p-0 transition hover:-translate-y-0.5 hover:shadow-lg"
   >
     <!--
       IDENTITY OVERLAYS THE ART, per Silas 2026-08-08: "we should have the


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software) — slice 12

### What changed / what I produced
- `navigation-health.vue`: header + per-channel card, both hand-rolled exact `kr-panel` surfaces with no padding on the element itself → `kr-panel p-0`.
- `workspace-sheet.vue`: outer sheet wrapper + builder-preview card, same pattern → `kr-panel p-0`.
- `project-placement-manager.vue`: header → `kr-panel p-0`.
- `resource-card.vue`: card root → `kr-panel p-0`.

All four had `rounded-2xl border border-base-300 bg-base-100 shadow-sm` with no `p-*` class on the element itself (padding lives on inner children in every case), so `kr-panel p-0` preserves the exact zero-padding geometry. Zero visual delta.

**Deliberately skipped** `components/ui/kr-stat-tile.vue`'s identical class string: it also carries DaisyUI's `stat` class, whose own component-layer CSS supplies the tile's internal padding. Tailwind's utilities layer always wins over the components layer regardless of source order, so appending `kr-panel`'s `p-0` utility would zero out that padding — a real visual regression, not a zero-delta rename. Left as-is for a future slice.

### How I verified
- `npx eslint` on all 4 changed files: 0 problems.
- `npx prettier --check`: the exact lines I changed match Prettier's expected formatting byte-for-byte (verified against a full `npx prettier` dry-run diff); the file-level `--check` failures are pre-existing formatting debt elsewhere in each file, unrelated to this change — not touched, per the documented pitfall from t-104 slice 10 (`prettier --write` reformatting an entire file under a one-line intent).
- `npx vue-tsc --noEmit -p tsconfig.json`: clean, exit 0.
- `npx tsx utils/scripts/verifyLintRatchet.ts`: ratchet holds — 392 problems across 27 rules, unchanged.
- `npx tsx utils/scripts/verifyLayoutContract.ts`: holds, no new violations.
- No live DB in this sandbox — no integration/visual test run locally; relying on CI's `responsive-layout-audit` for cross-width geometry/screenshots.

### Stakes
reversible — pure Tailwind class-string equivalence, no behavior or markup structure change.

### Flags for Reviewer
- None.

### Kaizen suggestion
`kr-stat-tile.vue`'s primitive-vs-DaisyUI-component conflict (this PR's skip) suggests a `kr-panel-flat p-0`-style variant that never ships a padding utility at all might be a cleaner canonical form for "just the border/bg/rounded/shadow surface, no opinion on padding" — would remove the whole "does `p-0` fight something else's padding" class of judgment call for future slices.

### Notes for reviewer
Conductor task interface-vision/t-104 (multi-slice, remains open — this is slice 12).

---
🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Bn7s9sKsh4QcCNjxu33PDX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bn7s9sKsh4QcCNjxu33PDX)_