### PR TITLE
Quieten the Bot cards, stop the card back cropping art, scroll the chat

### DIFF
--- a/components/bots/bot-card.vue
+++ b/components/bots/bot-card.vue
@@ -279,14 +279,21 @@ const badges = computed<EntityCardChip[]>(() => {
   return result
 })
 
+/*
+ * NO THEME, NO DESIGNER. Silas, 2026-08-09: "I love the border around the
+ * gallery images, but we don't need the designer or theme text."
+ *
+ * Both were near-constant down the page -- the same handle on every card, and
+ * a palette name that the card's own `data-theme` border already SHOWS -- so
+ * they were a row of chips repeating what the eye had, on all 69 tiles. The
+ * theme still colours the frame; it just no longer also spells itself out.
+ *
+ * serverName survives because it varies and nothing else on the card carries
+ * it, but most Bots have none, so in practice the strip is now usually empty.
+ * Full provenance is on the card back, which is what the back is for.
+ */
 const metaChips = computed<EntityCardChip[]>(() => {
   const result: EntityCardChip[] = []
-  if (props.bot.theme) {
-    result.push({ label: props.bot.theme, class: 'badge-ghost' })
-  }
-  if (props.bot.designer) {
-    result.push({ label: props.bot.designer, class: 'badge-outline' })
-  }
   if (props.bot.serverName) {
     result.push({ label: props.bot.serverName, class: 'badge-info' })
   }

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -26,8 +26,23 @@
     {{ statusMessage }}
   </div>
 
+  <!--
+    BELOW xl THIS SCROLLS. Silas, 2026-08-09, from a tablet: "interact cannot
+    scroll, same as with resource."
+
+    At xl the two columns sit side by side, each bounded, each with its own
+    inner scroller -- so `overflow-hidden` here is correct and nothing needs to
+    move. Below xl `grid-cols-1` stacks them, and the stack is routinely taller
+    than the pane; with `overflow-hidden` still in force the overflow was
+    simply clipped and there was no way to reach the settings panel underneath
+    the conversation.
+
+    So the hidden overflow is now the WIDE case only. The panes keep their own
+    scrollers either way, which is why this does not turn into two competing
+    scroll owners at xl -- the same mistake that broke the card back in #1631.
+  -->
   <section
-    class="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-hidden xl:grid-cols-[minmax(0,1fr)_minmax(320px,420px)]"
+    class="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-y-auto xl:grid-cols-[minmax(0,1fr)_minmax(320px,420px)] xl:overflow-hidden"
   >
     <div
       class="grid min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden rounded-2xl border border-base-300 bg-base-100"

--- a/components/gallery/kr-card-back.vue
+++ b/components/gallery/kr-card-back.vue
@@ -52,23 +52,23 @@
         the FRONT of the card already uses, so turning it over reads as the
         same object rather than a different screen.
       -->
+      <!--
+        CONTAIN, not cover, and the title sits BELOW rather than on top.
+        Silas, 2026-08-09: "layout should be card like and not cut off the
+        image". `object-cover` filled the plate by cropping, which on a tall
+        Bot portrait meant slicing the head off; `object-contain` shows the
+        whole frame and letterboxes the remainder against the plate.
+
+        The title moved out of the scrim for the same reason -- a scrim over a
+        CONTAINED image sits on empty plate as often as on artwork, so it read
+        as a bar rather than a caption. Art up top, name beneath it: the shape
+        an actual card back has.
+      -->
       <div
         v-if="artSrc"
-        class="relative aspect-[4/3] max-h-56 w-full shrink-0 overflow-hidden bg-base-300"
+        class="relative aspect-[4/3] max-h-64 w-full shrink-0 overflow-hidden bg-neutral"
       >
-        <img :src="artSrc" :alt="title" class="h-full w-full object-cover" />
-
-        <div
-          class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 via-black/45 to-transparent p-3 pt-8"
-        >
-          <h2 class="break-words text-lg font-black leading-tight text-white">
-            {{ title }}
-          </h2>
-
-          <p v-if="subtitle" class="mt-0.5 text-xs text-white/75">
-            {{ subtitle }}
-          </p>
-        </div>
+        <img :src="artSrc" :alt="title" class="h-full w-full object-contain" />
 
         <div
           v-if="badges.length"
@@ -82,6 +82,16 @@
             {{ badge }}
           </span>
         </div>
+      </div>
+
+      <div v-if="artSrc" class="min-w-0 px-3 pb-3 pt-2">
+        <h2 class="break-words text-lg font-black leading-tight">
+          {{ title }}
+        </h2>
+
+        <p v-if="subtitle" class="mt-0.5 text-xs text-base-content/60">
+          {{ subtitle }}
+        </p>
       </div>
 
       <!-- No art: the title has to carry the header on its own, so it keeps


### PR DESCRIPTION
Three from a tablet.

## "we don't need the designer or theme text"

Both were near-constant down the page — the same handle on every card, and a palette name that the card's own `data-theme` border **already shows**. So the strip was chips repeating what the eye had, on all 69 tiles.

The theme still colours the frame; it just no longer also spells itself out. `serverName` survives because it varies and nothing else on the card carries it, so in practice the strip is now usually empty. Full provenance lives on the card back, which is what the back is for.

The border stays — glad it landed.

## "layout should be card like and not cut off the image"

The back's art plate was `object-cover`, which fills by **cropping** — on a tall Bot portrait that sliced the head off, exactly as your screenshot shows. It's `object-contain` now: the whole frame shows and the remainder letterboxes against the plate.

The title came out of the scrim as a consequence. A scrim over a *contained* image sits on empty plate as often as on artwork, so it read as a bar rather than a caption. Art up top, name beneath it — the shape an actual card back has.

## "interact cannot scroll, same as with resource"

Same symptom, **different cause** — worth separating, because the card-back fix (#1636, merged) wouldn't have touched this.

`bot-chat`'s grid is `overflow-hidden`, which is correct at `xl` where the two columns sit side by side, each bounded and each with its own inner scroller. Below `xl`, `grid-cols-1` stacks them, the stack is routinely taller than the pane, and the overflow was clipped — so there was no way to reach the settings panel underneath the conversation.

The hidden overflow is now the wide case only. The panes keep their own scrollers at both sizes, so this doesn't create two competing scroll owners at `xl` — the mistake that broke the card back in #1631 and had to be undone in #1636.

## Honest caveat

**The chat fix is unverified visually.** It's reasoned from the source and passes the layout contract, but the sandbox has no browser egress, so it wants a look on the preview before it's trusted. The other two are structural and low-risk.

## Verification

- `npm run test` (vue-tsc) — clean
- `npm run test:layout-contract` — holds, no new violations (relevant here, since the chat change adds a scroll region)
- `npm run audit:wonderlab-previews -- --strict` — exit 0
- `npx eslint` + `npx prettier` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_