### PR TITLE
Give Characters, Rewards and Scenarios the card back too

### DIFF
--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -35,6 +35,59 @@
       />
     </section>
 
+    <kr-card-flip
+      v-model="infoCharacterOpen"
+      :label="infoCharacter?.name || 'Character'"
+    >
+      <template #back="{ close, commit }">
+        <kr-card-back
+          v-if="infoCharacter"
+          v-model:editing="infoCharacterEditing"
+          :title="infoCharacter.name || 'Unnamed Character'"
+          :subtitle="infoCharacter.honorific || ''"
+          :description="infoCharacter.backstory || ''"
+          :art-src="infoCharacter.imagePath || ''"
+          :badges="infoCharacterBadges"
+          :can-interact="true"
+          interact-label="Chat"
+          @back="commit"
+          @interact="interactWithInfoCharacter"
+        >
+          <template #details>
+            <dl class="grid grid-cols-2 gap-2 text-xs">
+              <div v-if="infoCharacter.class">
+                <dt class="font-black uppercase opacity-55">Class</dt>
+                <dd>{{ infoCharacter.class }}</dd>
+              </div>
+              <div v-if="infoCharacter.genre">
+                <dt class="font-black uppercase opacity-55">Genre</dt>
+                <dd>{{ infoCharacter.genre }}</dd>
+              </div>
+              <div v-if="infoCharacter.charm">
+                <dt class="font-black uppercase opacity-55">Charm</dt>
+                <dd>{{ infoCharacter.charm }}</dd>
+              </div>
+              <div v-if="infoCharacter.empathy">
+                <dt class="font-black uppercase opacity-55">Empathy</dt>
+                <dd>{{ infoCharacter.empathy }}</dd>
+              </div>
+            </dl>
+          </template>
+        </kr-card-back>
+
+        <div v-else class="p-6 text-center text-sm opacity-60">
+          <p>That Character is no longer available.</p>
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm mt-3 rounded-xl"
+            @click="close"
+          >
+            Close
+          </button>
+        </div>
+      </template>
+    </kr-card-flip>
+
     <section class="min-h-0 flex-1 overflow-auto">
       <div
         v-if="isLoading || characterStore.loading"
@@ -704,8 +757,60 @@ async function refreshCharacters(force = false) {
  * variant interpret the same click differently.
  */
 function openCharacter(id: number) {
-  void characterStore.selectCharacter(id)
+  if (isDropdownMode.value) {
+    void characterStore.selectCharacter(id)
+    return
+  }
+
+  infoCharacterId.value = id
 }
+
+/* Interact LEAVES: the chat surface is a working space, not a panel. */
+function interactWithInfoCharacter() {
+  const id = infoCharacterId.value
+  infoCharacterOpen.value = false
+  if (id) void characterStore.selectCharacter(id)
+}
+
+/*
+ * INFO FIRST, INTERACTION AFTER -- the same frame Bots, Resources, Rewards and
+ * Scenarios use, and the reason kr-card-back is one component rather than one
+ * per gallery.
+ *
+ * THE DROPDOWN BRANCH COMES FIRST. This gallery is also embedded as a PICKER,
+ * where a click has to pick and nothing else. verifyCardActionContract puts
+ * that decision in the gallery -- "A card is an entry point. It emits; the
+ * gallery decides what that means" -- which is what lets browse and picker
+ * disagree about the same click.
+ */
+const infoCharacterId = ref<number | null>(null)
+const infoCharacterEditing = ref(false)
+
+const infoCharacter = computed(
+  () =>
+    characterStore.characters.find(
+      (entry) => entry.id === infoCharacterId.value,
+    ) ?? null,
+)
+
+const infoCharacterOpen = computed({
+  get: () => infoCharacterId.value !== null,
+  set: (value: boolean) => {
+    if (!value) {
+      infoCharacterId.value = null
+      infoCharacterEditing.value = false
+    }
+  },
+})
+
+const infoCharacterBadges = computed(() => {
+  const character = infoCharacter.value
+  if (!character) return []
+
+  return [character.class, character.genre, character.honorific]
+    .map((entry) => String(entry ?? '').trim())
+    .filter((entry) => entry.length > 0)
+})
 
 function selectCharacterFromEvent(event: Event) {
   const target = event.target as HTMLSelectElement

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -100,6 +100,55 @@
       <add-reward :mode="formMode" @saved="handleRewardSaved" />
     </section>
 
+    <kr-card-flip
+      v-model="infoRewardOpen"
+      :label="infoReward?.name || 'Reward'"
+    >
+      <template #back="{ close, commit }">
+        <kr-card-back
+          v-if="infoReward"
+          v-model:editing="infoRewardEditing"
+          :title="infoReward.name || 'Unnamed Reward'"
+          :subtitle="infoReward.collection || ''"
+          :description="infoReward.description || ''"
+          :art-src="infoReward.imagePath || ''"
+          :badges="infoRewardBadges"
+          :can-interact="true"
+          interact-label="Encounter"
+          @back="commit"
+          @interact="interactWithInfoReward"
+        >
+          <template #details>
+            <dl class="grid grid-cols-2 gap-2 text-xs">
+              <div v-if="infoReward.effect" class="col-span-2">
+                <dt class="font-black uppercase opacity-55">Effect</dt>
+                <dd class="whitespace-pre-wrap">{{ infoReward.effect }}</dd>
+              </div>
+              <div v-if="infoReward.rarity">
+                <dt class="font-black uppercase opacity-55">Rarity</dt>
+                <dd>{{ infoReward.rarity }}</dd>
+              </div>
+              <div v-if="infoReward.rewardType">
+                <dt class="font-black uppercase opacity-55">Type</dt>
+                <dd>{{ infoReward.rewardType }}</dd>
+              </div>
+            </dl>
+          </template>
+        </kr-card-back>
+
+        <div v-else class="p-6 text-center text-sm opacity-60">
+          <p>That Reward is no longer available.</p>
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm mt-3 rounded-xl"
+            @click="close"
+          >
+            Close
+          </button>
+        </div>
+      </template>
+    </kr-card-flip>
+
     <section class="min-h-0 flex-1 overflow-auto">
       <div
         v-if="isLoading"
@@ -681,8 +730,58 @@ async function selectReward(id: number) {
     return
   }
 
-  await rewardStore.startRewardInteraction(id)
+  infoRewardId.value = id
 }
+
+/* Interact LEAVES: the encounter surface is a working space, not a panel. */
+async function interactWithInfoReward() {
+  const id = infoRewardId.value
+  infoRewardOpen.value = false
+  if (id) await rewardStore.startRewardInteraction(id)
+}
+/*
+ * INFO FIRST, INTERACTION AFTER -- the same frame Bots and Resources use, and
+ * the reason kr-card-back exists as one component rather than one per gallery.
+ * Picking turns the card over; the model-specific thing you came to do is a
+ * button on the back.
+ *
+ * THE DROPDOWN BRANCH STAYS FIRST. This gallery is also embedded as a PICKER,
+ * where a click has to pick and nothing else -- an info panel there would be
+ * in the way. verifyCardActionContract puts that decision in the gallery ("A
+ * card is an entry point. It emits; the gallery decides what that means"),
+ * which is exactly what lets browse and picker disagree.
+ *
+ * The id IS the open state so the two cannot drift apart; only the false
+ * direction is writable, because the flip closes itself on Escape and the
+ * backdrop and needs somewhere to put that.
+ */
+const infoRewardId = ref<number | null>(null)
+const infoRewardEditing = ref(false)
+
+const infoReward = computed(
+  () =>
+    rewardStore.rewards.find((entry) => entry.id === infoRewardId.value) ??
+    null,
+)
+
+const infoRewardOpen = computed({
+  get: () => infoRewardId.value !== null,
+  set: (value: boolean) => {
+    if (!value) {
+      infoRewardId.value = null
+      infoRewardEditing.value = false
+    }
+  },
+})
+
+const infoRewardBadges = computed(() => {
+  const reward = infoReward.value
+  if (!reward) return []
+
+  return [reward.rewardType, reward.rarity]
+    .map((entry) => String(entry ?? '').trim())
+    .filter((entry) => entry.length > 0)
+})
 
 async function continueWithSelected() {
   const id = rewardStore.selectedReward?.id

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -66,6 +66,58 @@
       <add-scenario :mode="formMode" @saved="handleScenarioSaved" />
     </section>
 
+    <kr-card-flip
+      v-model="infoScenarioOpen"
+      :label="infoScenario?.title || 'Scenario'"
+    >
+      <template #back="{ close, commit }">
+        <kr-card-back
+          v-if="infoScenario"
+          v-model:editing="infoScenarioEditing"
+          :title="infoScenario.title || 'Untitled Scenario'"
+          :description="infoScenario.description || ''"
+          :art-src="infoScenario.imagePath || ''"
+          :badges="infoScenarioBadges"
+          :can-interact="true"
+          interact-label="Play"
+          @back="commit"
+          @interact="interactWithInfoScenario"
+        >
+          <template #details>
+            <dl class="grid grid-cols-2 gap-2 text-xs">
+              <div v-if="infoScenario.locations" class="col-span-2">
+                <dt class="font-black uppercase opacity-55">Locations</dt>
+                <dd class="whitespace-pre-wrap">
+                  {{ infoScenario.locations }}
+                </dd>
+              </div>
+              <div v-if="infoScenario.inspirations" class="col-span-2">
+                <dt class="font-black uppercase opacity-55">Inspirations</dt>
+                <dd class="whitespace-pre-wrap">
+                  {{ infoScenario.inspirations }}
+                </dd>
+              </div>
+              <div v-if="infoScenario.genres">
+                <dt class="font-black uppercase opacity-55">Genres</dt>
+                <dd>{{ infoScenario.genres }}</dd>
+              </div>
+            </dl>
+          </template>
+        </kr-card-back>
+
+        <div v-else class="p-6 text-center text-sm opacity-60">
+          <p>That Scenario is no longer available.</p>
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm mt-3 rounded-xl"
+            @click="close"
+          >
+            Close
+          </button>
+        </div>
+      </template>
+    </kr-card-flip>
+
     <section class="min-h-0 flex-1" :class="isRowMode ? '' : 'overflow-y-auto'">
       <div
         v-if="isLoading"
@@ -569,8 +621,64 @@ async function refreshScenarios(force = false) {
  * already changed before the gallery heard about it. It emits only now.
  */
 function openScenario(id: number) {
-  void scenarioStore.selectScenario(id)
+  if (isDropdownMode.value) {
+    void scenarioStore.selectScenario(id)
+    return
+  }
+
+  infoScenarioId.value = id
 }
+
+/* Interact LEAVES: the story surface is a working space, not a panel. */
+function interactWithInfoScenario() {
+  const id = infoScenarioId.value
+  infoScenarioOpen.value = false
+  if (id) void scenarioStore.selectScenario(id)
+}
+
+/*
+ * INFO FIRST, INTERACTION AFTER -- the same frame Bots, Resources and Rewards
+ * use, and the reason kr-card-back is one component rather than one per
+ * gallery. Picking turns the card over; the thing you came to do is a button
+ * on the back.
+ *
+ * THE DROPDOWN BRANCH COMES FIRST. This gallery is also embedded as a PICKER,
+ * where a click has to pick and nothing else. verifyCardActionContract puts
+ * that decision in the gallery -- "A card is an entry point. It emits; the
+ * gallery decides what that means" -- which is what lets browse and picker
+ * disagree about the same click.
+ *
+ * The id IS the open state so the two cannot drift; only the false direction
+ * is writable, because the flip closes itself on Escape and the backdrop.
+ */
+const infoScenarioId = ref<number | null>(null)
+const infoScenarioEditing = ref(false)
+
+const infoScenario = computed(
+  () =>
+    scenarioStore.scenarios.find(
+      (entry) => entry.id === infoScenarioId.value,
+    ) ?? null,
+)
+
+const infoScenarioOpen = computed({
+  get: () => infoScenarioId.value !== null,
+  set: (value: boolean) => {
+    if (!value) {
+      infoScenarioId.value = null
+      infoScenarioEditing.value = false
+    }
+  },
+})
+
+const infoScenarioBadges = computed(() => {
+  const scenario = infoScenario.value
+  if (!scenario) return []
+
+  return [scenario.genres, scenario.isMature ? '18+' : '']
+    .map((entry) => String(entry ?? '').trim())
+    .filter((entry) => entry.length > 0)
+})
 
 function selectScenarioFromEvent(event: Event) {
   const target = event.target as HTMLSelectElement


### PR DESCRIPTION
The remaining core objects that had one. Bots and Resources proved the shape; these three follow it exactly rather than each growing a variant — which is the whole reason `kr-card-back` is one component and not one per gallery.

| gallery | `#details` | interact |
| --- | --- | --- |
| Characters | class, genre, charm, empathy | **Chat** |
| Rewards | effect, rarity, type | **Encounter** |
| Scenarios | locations, inspirations, genres | **Play** |

Each also gets the id *as* the open state (so an open flag and a selected id can't drift apart) and a graceful panel for a record deleted while open.

## The dropdown branch is the load-bearing part

Every one of these galleries is also embedded as a **picker** — inside `bot-chat`, `character-chat`, `character-flip-card` — where a click has to pick and nothing else.

**Two of them didn't branch at all before this.** `openCharacter` and `openScenario` went straight to `selectCharacter` / `selectScenario` regardless of mode. That was fine while selecting *was* the whole behaviour — but now that picking and opening differ, the branch has to be explicit or the pickers break. Rewards already had it.

`verifyCardActionContract` still passes at **9 entity cards emitting `open` with none deciding its own consequence**, which is the check confirming this stayed in the gallery where it belongs.

## Badges, built the safe way

My first version filtered with an `entry is string` predicate. vue-tsc rejected it on Rewards: `rewardType` and `rarity` aren't plain strings, so the predicate wasn't assignable to its parameter.

All three now stringify first and filter on length, which doesn't care what the column's type is — the same shape works for an enum, a number, or null. Applied to all three rather than just the one that failed, since the others were only passing by luck of their column types.

## Dreams is deliberately not here

Its edit routes to the **dreammaker dashboard tab** rather than an inline form, so it needs a decision about where editing lives before it can take this frame — not a copy of it. Worth a conversation rather than a guess.

## Verification

- `npm run test` (vue-tsc) — clean
- `npm run test:layout-contract` — holds
- `npm run test:route-gallery-contract` — passes, 0 holdouts, 0 shadow browsers
- `npm run test:card-action-contract` — holds at 9 cards
- `npm run audit:wonderlab-previews -- --strict` — exit 0
- `npx eslint` — clean; the one remaining error in `character-gallery` (`characterGenres` unused) is pre-existing, confirmed by stashing and re-running

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_