### PR TITLE
refactor(ui): migrate 3 more zero-padding/shadow-sm surfaces to kr-panel

### DIFF
--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -171,9 +171,7 @@
               </div>
 
               <div v-if="isSendingChat" class="flex justify-start">
-                <div
-                  class="rounded-2xl border border-base-300 bg-base-100 p-3 text-sm text-base-content/70 shadow-sm"
-                >
+                <div class="kr-panel p-3 text-sm text-base-content/70">
                   <span class="loading loading-dots loading-sm text-primary" />
                   Thinking in character...
                 </div>

--- a/components/navigation/workspace-sheet.vue
+++ b/components/navigation/workspace-sheet.vue
@@ -93,7 +93,7 @@
     </template>
 
     <template v-if="isBuilder">
-      <div class="rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm">
+      <div class="kr-panel p-4">
         <div class="mb-3 flex items-center justify-between gap-3">
           <p
             class="flex items-center gap-2 text-sm font-black uppercase tracking-widest text-base-content/45"
@@ -304,10 +304,7 @@
         </section>
       </div>
 
-      <div
-        v-else
-        class="rounded-2xl border border-dashed border-base-300 bg-base-100 p-6 text-center shadow-sm"
-      >
+      <div v-else class="kr-panel border-dashed text-center">
         <Icon
           name="kind-icon:cards"
           class="mx-auto h-12 w-12 text-base-content/25"

--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -395,9 +395,7 @@ onMounted(async () => {
       slot. The blurb survives at md+ only -- it is orientation text, and it was
       costing three rows on exactly the screens with the fewest to spare.
     -->
-    <header
-      class="rounded-2xl border border-base-300 bg-base-100 px-3 py-2 shadow-sm"
-    >
+    <header class="kr-panel px-3 py-2">
       <div class="flex flex-wrap items-center justify-between gap-2">
         <div class="min-w-0">
           <h2 class="text-base font-bold">Resource Gallery</h2>


### PR DESCRIPTION
interface-vision/t-104 slice 13.

Migrates the last remaining exact-match hand-rolled `kr-panel` surfaces (`rounded-2xl border border-base-300 bg-base-100 shadow-sm`) that don't involve translucency or hover-only shadows:

- `character-flip-card.vue`: chat "thinking" bubble → `kr-panel p-3`
- `workspace-sheet.vue`: builder card → `kr-panel p-4`; empty-state card → `kr-panel border-dashed text-center` (already at kr-panel's default `p-6`)
- `resource-gallery.vue`: header → `kr-panel px-3 py-2`

All zero visual delta — each preserves its original padding/border-style as a utility override on top of kr-panel's shared surface treatment.

Searched the broader `border-base-300` + `bg-base-100` corpus (~110 files) for more candidates: remaining matches either use `bg-base-100/90` or `/95` with `backdrop-blur` (frosted sticky headers — converting would lose the translucency, a real regression) or a non-`shadow-sm` shadow value (`shadow-md`/`xl`/`2xl`/`inner`, several with hover-only shadow), which would need case-by-case verification rather than a same-pattern batch. Left for a future slice.

Reformatted the three edited tags to single-line per Prettier once their class strings got short enough to fit (pre-existing unrelated formatting debt elsewhere in `workspace-sheet.vue` and `character-flip-card.vue` left untouched — confirmed present on `origin/main` before this change).

**Verified:**
- `eslint`: 0 new problems (one pre-existing, unrelated `no-unused-vars` error in `character-flip-card.vue`, confirmed present on `main`)
- `vue-tsc --noEmit`: clean
- Lint ratchet: unchanged (392/27)
- Layout contract: holds

---
_Generated by [Claude Code](https://claude.ai/code/session_013MBubKHPhzqHnPPKgZXHJf)_