### PR TITLE
refactor(ui): migrate 4 more zero-padding/no-shadow surfaces to kr-panel-muted/kr-panel-flat

### DIFF
--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -215,7 +215,7 @@
     </div>
 
     <aside class="flex min-h-0 flex-col gap-4 overflow-hidden">
-      <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+      <section class="kr-panel-flat p-4">
         <div class="mb-3 flex items-center justify-between gap-2">
           <div>
             <h2 class="text-lg font-bold text-base-content">
@@ -281,9 +281,7 @@
             />
           </label>
 
-          <div
-            class="rounded-2xl border border-base-300 bg-base-200 p-3 text-sm"
-          >
+          <div class="kr-panel-muted p-3 text-sm">
             <p class="text-xs font-bold uppercase text-base-content/50">
               Active Text Server
             </p>
@@ -299,7 +297,7 @@
         </div>
       </section>
 
-      <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+      <section class="kr-panel-flat p-4">
         <h2 class="text-lg font-bold text-base-content">Selected Bot</h2>
 
         <bot-card
@@ -314,7 +312,7 @@
 
         <div
           v-else
-          class="mt-3 rounded-2xl border border-base-300 bg-base-200 p-4 text-sm text-base-content/55"
+          class="mt-3 kr-panel-muted p-4 text-sm text-base-content/55"
         >
           Pick a bot first. Even robots need casting.
         </div>
@@ -356,9 +354,7 @@
         ]"
       />
 
-      <section
-        class="min-h-0 flex-1 overflow-hidden rounded-2xl border border-base-300 bg-base-100 p-4"
-      >
+      <section class="min-h-0 flex-1 overflow-hidden kr-panel-flat p-4">
         <div class="mb-3 flex items-center justify-between gap-2">
           <h2 class="text-lg font-bold text-base-content">Prompt Preview</h2>
 

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -253,7 +253,7 @@
 
           <div
             v-if="botStore.currentBot"
-            class="rounded-2xl border border-base-300 bg-base-200 p-3 text-xs text-base-content/70"
+            class="kr-panel-muted p-3 text-xs text-base-content/70"
           >
             <p class="line-clamp-3">
               {{ selectedBotDescription }}

--- a/components/model/add-model.vue
+++ b/components/model/add-model.vue
@@ -145,7 +145,7 @@
     </label>
 
     <div
-      class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3 sm:flex-row sm:items-center sm:justify-between"
+      class="flex flex-col gap-3 kr-panel-muted p-3 sm:flex-row sm:items-center sm:justify-between"
     >
       <label class="label cursor-pointer justify-start gap-3">
         <input

--- a/components/user/user-manager.vue
+++ b/components/user/user-manager.vue
@@ -45,10 +45,7 @@
       {{ managerError }}
     </div>
 
-    <div
-      v-if="isLoadingManager"
-      class="shrink-0 rounded-2xl border border-base-300 bg-base-200 p-4"
-    >
+    <div v-if="isLoadingManager" class="shrink-0 kr-panel-muted p-4">
       <span class="loading loading-spinner loading-sm" />
       <span class="ml-2">Loading user account details...</span>
     </div>


### PR DESCRIPTION
interface-vision/t-104 slice 14.

With the exact `kr-panel` (`bg-base-100` + `shadow-sm`) candidate pool now exhausted (only `kr-stat-tile.vue` remains, deliberately excluded per slice 12's DaisyUI `stat`-class conflict), this slice extends the same zero-visual-delta migration to the two sibling `kr-panel` variants already defined in `tailwind.css` but never adopted:

- **`kr-panel-flat`** (`rounded-2xl border border-base-300 bg-base-100`, no shadow): `bot-chat.vue`'s three plain bordered sections → `kr-panel-flat p-4`
- **`kr-panel-muted`** (`rounded-2xl border border-base-300 bg-base-200`, `p-6` default): `add-model.vue`'s mature-content toggle row, `bot-chat.vue`'s active-server card and no-bot-selected notice, `bot-gallery.vue`'s bot description card, and `user-manager.vue`'s loading state → `kr-panel-muted` with the same padding-override pattern used throughout slices 8-13

All zero visual delta — each preserves its original padding/text-color utilities on top of the shared surface treatment.

**Verification:**
- `eslint`: 0 problems
- `vue-tsc --noEmit`: clean
- `verifyLintRatchet.ts`: unchanged (392/27)
- `verifyLayoutContract.ts`: holds, no new violations
- `prettier --check`: clean (reformatted `user-manager.vue`'s touched `div` to single-line once its class string got short enough to fit Prettier's line width, same discipline as slice 13)

**Flags for Reviewer:** kept scope to a small, individually-verified batch (4 files / 8 occurrences) consistent with prior slices, rather than the full candidate pools discovered this session — a grep sweep found ~114 files with an exact `kr-panel-muted` match and ~129 with an exact `kr-panel-flat` match. That's a much larger opportunity than this task's history anticipated (prior slices only tracked the `kr-panel`/`bg-base-100`+`shadow-sm` pool). Filing a kaizen task to either continue slicing through it or evaluate a scripted codemod given the scale.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017gZDGqgoV7GvAV19ChKu25)_