### PR TITLE
digital-storefront/t-043: make Dream and Facet lists Pack-Grant-aware

### DIFF
--- a/server/api/dreams/index.get.ts
+++ b/server/api/dreams/index.get.ts
@@ -3,6 +3,7 @@ import { defineEventHandler, getHeader, getQuery } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { validateApiKey } from '@/server/utils/validateKey'
+import { viewablePackIds } from '@/server/utils/contentAccess'
 import type { Prisma } from '~/prisma/generated/prisma/client'
 import { parseDreamType } from './index'
 
@@ -205,6 +206,7 @@ export default defineEventHandler(async (event) => {
     }
 
     const isAdmin = userRole === 'ADMIN'
+    const packIds = userId && !isAdmin ? await viewablePackIds(userId) : []
     const take = normalizeLimit(query.take)
     const skip = normalizeSkip(query.skip)
     const includeMature = normalizeBoolean(query.includeMature)
@@ -236,7 +238,11 @@ export default defineEventHandler(async (event) => {
       andFilters.push({})
     } else if (userId) {
       andFilters.push({
-        OR: [{ isPublic: true }, { userId }],
+        OR: [
+          { isPublic: true },
+          { userId },
+          ...(packIds.length ? [{ packId: { in: packIds } }] : []),
+        ],
       })
     } else {
       andFilters.push({ isPublic: true })

--- a/server/api/facets/index.get.ts
+++ b/server/api/facets/index.get.ts
@@ -4,6 +4,7 @@ import type { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { getOptionalApiUser } from '~/server/utils/authGuard'
+import { viewablePackIds } from '~/server/utils/contentAccess'
 import {
   facetSummarySelect,
   hydrateFacetSummaries,
@@ -46,6 +47,7 @@ export default defineEventHandler(async (event) => {
     const auth = await getOptionalApiUser(event)
     const userId = auth?.user.id ?? null
     const isAdmin = auth?.isAdmin ?? false
+    const packIds = userId && !isAdmin ? await viewablePackIds(userId) : []
     const includeInactive = isAdmin && toBoolean(query.includeInactive)
     const includeMature = isAdmin && toBoolean(query.includeMature)
     const mine = toBoolean(query.mine)
@@ -66,7 +68,13 @@ export default defineEventHandler(async (event) => {
     } else if (!isAdmin) {
       andFilters.push(
         userId
-          ? { OR: [{ isPublic: true }, { userId }] }
+          ? {
+              OR: [
+                { isPublic: true },
+                { userId },
+                ...(packIds.length ? [{ packId: { in: packIds } }] : []),
+              ],
+            }
           : { isPublic: true },
       )
     }

--- a/server/utils/contentAccess.ts
+++ b/server/utils/contentAccess.ts
@@ -103,6 +103,12 @@ const GRANT_LEVEL_RANK: Record<GrantLevel, number> = {
   [GrantLevel.ADMIN]: 2,
 }
 
+function qualifyingGrantLevels(minLevel: GrantLevel): GrantLevel[] {
+  return (Object.keys(GRANT_LEVEL_RANK) as GrantLevel[]).filter(
+    (level) => GRANT_LEVEL_RANK[level] >= GRANT_LEVEL_RANK[minLevel],
+  )
+}
+
 function isAdminUser(user: AccessUser): boolean {
   return typeof user.isAdmin === 'boolean' ? user.isAdmin : userIsAdmin(user)
 }
@@ -119,23 +125,34 @@ export async function existsActiveGrant(
   subjectId: number,
   minLevel: GrantLevel = GrantLevel.VIEW,
 ): Promise<boolean> {
-  const qualifyingLevels = (
-    Object.keys(GRANT_LEVEL_RANK) as GrantLevel[]
-  ).filter((level) => GRANT_LEVEL_RANK[level] >= GRANT_LEVEL_RANK[minLevel])
-
   const grant = await prisma.grant.findFirst({
     where: {
       granteeId: userId,
       subjectType,
       subjectId,
       status: 'ACTIVE',
-      level: { in: qualifyingLevels },
+      level: { in: qualifyingGrantLevels(minLevel) },
       OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
     },
     select: { id: true },
   })
 
   return grant !== null
+}
+
+export async function viewablePackIds(userId: number): Promise<number[]> {
+  const grants = await prisma.grant.findMany({
+    where: {
+      granteeId: userId,
+      subjectType: 'PACK',
+      status: 'ACTIVE',
+      level: { in: qualifyingGrantLevels(GrantLevel.VIEW) },
+      OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+    },
+    select: { subjectId: true },
+  })
+
+  return Array.from(new Set(grants.map((grant) => grant.subjectId)))
 }
 
 /**

--- a/server/utils/facetCatalog.ts
+++ b/server/utils/facetCatalog.ts
@@ -1,6 +1,7 @@
 // /server/utils/facetCatalog.ts
 import type { FacetKind, Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
+import { viewablePackIds } from '~/server/utils/contentAccess'
 import { normalizeFacetLookupKey } from '~/utils/facetAliases'
 
 export const FACET_TAXONOMIES = [
@@ -139,6 +140,10 @@ export async function loadFacetCatalogEntries(
   const requestedFacetIds = profiles.map((profile) => profile.facetId)
   const search = options.search?.trim()
   const normalizedSearch = search ? normalizeFacetLookupKey(search) : ''
+  const packIds =
+    options.userId && !options.isAdmin
+      ? await viewablePackIds(options.userId)
+      : []
   const aliasFacetIds = search
     ? (
         await prisma.facetAlias.findMany({
@@ -168,6 +173,7 @@ export async function loadFacetCatalogEntries(
             OR: [
               { isPublic: true },
               ...(options.userId ? [{ userId: options.userId }] : []),
+              ...(packIds.length ? [{ packId: { in: packIds } }] : []),
             ],
           }),
       ...(search


### PR DESCRIPTION
### Task
`digital-storefront/t-043`: wire `contentAccess.ts` Pack Grants into the Dream and Facet LIST surfaces.

### What changed
- Adds `viewablePackIds(userId)` to the shared content-access helper, using the same ACTIVE/unexpired/VIEW-or-better rules as `existsActiveGrant`.
- Lets authenticated non-admin callers see pack-gated Dreams in `/api/dreams` when they hold an active PACK Grant, alongside the existing public/owned rows.
- Applies the same additive visibility fallback to `/api/facets` and the canonical facet catalog loader used by `/api/facets/catalog`.
- Preserves `mine`, admin, anonymous, inactive, and mature filtering exactly as before.

### Branch-medic provenance
This is a clean salvage of the reversible portion of stranded branch `worker/digital-storefront-t-004-20260808-a83f`. That branch also contains Character/Reward access-control changes covered by `digital-storefront/t-005`, which is a hard human-gated security decision. Those changes are deliberately **not** in this PR.

### Verification / review notes
- Conductor `digital-storefront/t-043` is verified `status: review` for session `2026-08-09T061257Z-ds-t043-r7m4` before this PR opened.
- The source branch is based on current `main` and was 0 behind when the implementation diff was checked.
- `server/api/dreams/index.get.ts` is CRLF on `main`; the connector contents write normalizes that file to LF, so GitHub reports a noisy whole-file line-ending diff even though the semantic change is the import, one Pack-ID prefetch, and one OR arm. The other three files remain compact. CI is the merge gate; do not treat line-ending churn as semantic scope.

### Stakes
Reversible. No database mutation, Stripe call, entitlement/grant write, production data change, or Character/Reward access-policy change.