### PR TITLE
Defer JWT secret validation until auth is used

### DIFF
--- a/server/api/auth/index.ts
+++ b/server/api/auth/index.ts
@@ -8,15 +8,14 @@ import { userExists } from '../users'
 import prisma from '../../utils/prisma'
 import type { User } from '~/prisma/generated/prisma/client'
 
-const config = useRuntimeConfig()
-const JWT_SECRET = config.jwtSecret
+function getJwtSecret(): string {
+  const jwtSecret = useRuntimeConfig().jwtSecret
 
-if (!JWT_SECRET) {
-  throw new Error('JWT_SECRET is not configured.')
-}
+  if (typeof jwtSecret !== 'string' || !jwtSecret) {
+    throw new Error('JWT_SECRET is not configured or is not a string.')
+  }
 
-if (typeof JWT_SECRET !== 'string' || !JWT_SECRET) {
-  throw new Error('JWT_SECRET is not configured or is not a string.')
+  return jwtSecret
 }
 
 export const verifyJwtToken = async (
@@ -29,7 +28,7 @@ export const verifyJwtToken = async (
 }> => {
   try {
     const secretKey = crypto.createSecretKey(
-      Buffer.from(JWT_SECRET as string, 'utf-8'),
+      Buffer.from(getJwtSecret(), 'utf-8'),
     )
     const decoded = await jwtVerify(token, secretKey)
 
@@ -88,7 +87,7 @@ export const getUserDataByToken = async (token: string) => {
 
 export async function createToken(user: User): Promise<string> {
   try {
-    const secretKey = crypto.createSecretKey(Buffer.from(JWT_SECRET as string))
+    const secretKey = crypto.createSecretKey(Buffer.from(getJwtSecret()))
 
     const token = await new SignJWT({
       id: user.id,


### PR DESCRIPTION
### Root cause
The production Docker build runs `nuxi build`, which imports Nitro server modules during prerender. `server/api/auth/index.ts` read `useRuntimeConfig().jwtSecret` and threw at module import time, so a secret-free image build failed even though no auth operation was being performed.

### Fix
- Replace the module-level `JWT_SECRET` read/throw with `getJwtSecret()`.
- Resolve and validate the secret only inside JWT signing or verification.
- Keep the same runtime protection: actual auth still fails clearly if JWT_SECRET is missing.
- Do not inject a dummy JWT secret during Docker build, avoiding the risk of baking a fake secret into Nuxt runtime-config defaults.

### Verification intent
CI typecheck/contracts cover the code change. This specifically addresses the Alexandria Docker failure at `npm run build`; after merge the same documented Docker command should proceed past the missing-JWT error.

### Stakes
Reversible auth initialization cleanup; no schema, secret, DNS, or deployment mutation.