### PR TITLE
art queue: clamp out-of-band sampler settings at claim instead of failing the row

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -51,6 +51,14 @@ jobs:
       - name: Art prompt contract
         run: npm run test:art-prompt-contract
 
+      # The other side of that gate. Re-applying the contract at claim time also
+      # killed 8 pre-gate backlog rows over a step count and had 27 more queued
+      # to die the same way, so the claim path now clamps the sampler to the
+      # engine's ceiling before asserting. This keeps enqueue a hard rejection
+      # while the backlog self-heals — and fails if either half drifts.
+      - name: ArtJob sampler repair contract
+        run: npm run test:artjob-sampler-repair
+
       - name: Channel content contract
         run: npm run test:channel-content
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "test:art-request-yaml": "tsx utils/scripts/verifyArtRequestYaml.ts && tsx utils/scripts/verifyArtAssetSuggest.ts",
     "test:art-prompt-repair": "tsx utils/scripts/verifyArtPromptRepair.ts",
     "test:art-prompt-contract": "tsx utils/scripts/verifyArtPromptContract.ts",
+    "test:artjob-sampler-repair": "tsx utils/scripts/verifyArtJobSamplerRepair.ts",
     "test:entity-art-prompt-framing": "tsx utils/scripts/verifyEntityArtPromptFraming.ts",
     "test:art-asset-suggest": "tsx utils/scripts/verifyArtAssetSuggest.ts",
     "test:artjob-bulk-scope": "tsx utils/scripts/verifyArtJobBulkScope.ts && tsx utils/scripts/verifyArtJobBulkCancel.ts",

--- a/server/api/art/queue/claim.post.ts
+++ b/server/api/art/queue/claim.post.ts
@@ -32,6 +32,10 @@ import {
   assertQueuedArtPromptContract,
   reconcileQueuedArtJobCoverage,
 } from '../../../utils/artJobQueueCoverage'
+import {
+  recordSamplerRepair,
+  repairQueuedArtSampler,
+} from '../../../utils/artJobSamplerRepair'
 import { recordRelayClaimAttempt } from '../../../utils/relayAgentRegistry'
 import { isQueuePaused } from '../../../utils/queueControl'
 
@@ -245,17 +249,32 @@ export default defineEventHandler(async (event) => {
       let enrichedPayload
 
       try {
+        // A step or cfg above the engine's ceiling is the one contract
+        // violation with an objectively correct repair, so repair it instead of
+        // killing the row: clamp to the distilled limits first, then assert. On
+        // 2026-08-09 eight pre-gate jobs had already died on nothing but
+        // "krea2 ... got 20" with 27 more queued behind them, all of whose
+        // prompts were otherwise clean. Enqueue still rejects these outright, so
+        // producers writing new work still fail loudly; only the pre-gate
+        // backlog self-heals here. See server/utils/artJobSamplerRepair.ts.
+        const samplerRepair = repairQueuedArtSampler(
+          candidate.engine,
+          candidate.payload,
+        )
+
         // New enqueues pass the prompt contract at creation time. Old backlog
         // rows predate that boundary, so apply the same rules again immediately
         // before claim using the ACTUAL Comfy graph's engine/cfg/steps. This is
         // what prevents stale 20-step/cfg-7 Krea jobs from rendering just because
-        // they were already sitting in PENDING when the gate shipped.
-        assertQueuedArtPromptContract(candidate.engine, candidate.payload)
+        // they were already sitting in PENDING when the gate shipped — the clamp
+        // above fixes the sampler numbers, and everything a machine cannot
+        // safely rewrite (conditionals, format nouns, text piles) still fails.
+        assertQueuedArtPromptContract(candidate.engine, samplerRepair.payload)
 
-        const currentProvenance = readArtJobProvenance(candidate.payload)
+        const currentProvenance = readArtJobProvenance(samplerRepair.payload)
         enrichedPayload = enrichArtJobPayload(
           candidate.engine as 'A1111' | 'COMFY',
-          candidate.payload,
+          samplerRepair.payload,
           {
             projectSlug: candidate.projectSlug,
             idempotencyKey: currentProvenance?.idempotencyKey,
@@ -264,6 +283,11 @@ export default defineEventHandler(async (event) => {
               supportsCompletionProof,
           },
         ).payload
+        recordSamplerRepair(
+          enrichedPayload,
+          samplerRepair,
+          new Date().toISOString(),
+        )
       } catch (error: unknown) {
         const handled = errorHandler(error)
         const invalid = await prisma.artJob.updateMany({
@@ -274,10 +298,11 @@ export default defineEventHandler(async (event) => {
           },
           data: {
             status: 'FAILED',
-            error: `ArtJob validation failed before claim: ${handled.message}`.slice(
-              0,
-              4000,
-            ),
+            error:
+              `ArtJob validation failed before claim: ${handled.message}`.slice(
+                0,
+                4000,
+              ),
             claimedAt: null,
             claimedBy: null,
           },

--- a/server/api/art/queue/reenqueue-failed.post.ts
+++ b/server/api/art/queue/reenqueue-failed.post.ts
@@ -15,6 +15,10 @@ import {
   readArtJobProvenance,
 } from '../../../utils/artJobProvenance'
 import { normalizeQueuedArtJobPayload } from '../../../utils/artJobNormalization'
+import {
+  recordSamplerRepair,
+  repairQueuedArtSampler,
+} from '../../../utils/artJobSamplerRepair'
 import { refreshArtJobLoraResources } from '../../../utils/artJobResourceRefresh'
 
 const REQUEUE_CONCURRENCY = 10
@@ -45,9 +49,21 @@ function failureMessage(error: unknown): string {
   return String(error || 'Unknown requeue failure.')
 }
 
-async function requeueFailedJob(source: FailedJobSource): Promise<RequeueResult> {
+async function requeueFailedJob(
+  source: FailedJobSource,
+): Promise<RequeueResult> {
   const normalization = normalizeQueuedArtJobPayload(source.payload)
-  const resourceRefresh = await refreshArtJobLoraResources(normalization.payload)
+  // A job that failed the claim-time contract on nothing but an out-of-band
+  // step count would otherwise be requeued verbatim and fail again on the next
+  // poll — a requeue loop that repairs everything except the thing that killed
+  // it. Clamp the sampler here too, so a requeued row comes back legal.
+  const samplerRepair = repairQueuedArtSampler(
+    source.engine,
+    normalization.payload,
+  )
+  const resourceRefresh = await refreshArtJobLoraResources(
+    samplerRepair.payload,
+  )
   const priorProvenance = readArtJobProvenance(source.payload)
   const { payload } = enrichArtJobPayload(
     source.engine,
@@ -59,14 +75,17 @@ async function requeueFailedJob(source: FailedJobSource): Promise<RequeueResult>
     },
   )
 
+  const repairedAt = new Date().toISOString()
   payload.queueRepair = {
-    repairedAt: new Date().toISOString(),
+    repairedAt,
     imagePathChanged: normalization.imagePathChanged,
     promptChanged: normalization.promptChanged,
     loraPathChanged: resourceRefresh.changed,
     loraResourceIds: resourceRefresh.loraResourceIds,
     loraNames: resourceRefresh.loraNames,
+    samplerChanged: samplerRepair.changed,
   }
+  recordSamplerRepair(payload, samplerRepair, repairedAt)
 
   const updated = await prisma.artJob.updateMany({
     where: {

--- a/server/utils/artJobQueueCoverage.ts
+++ b/server/utils/artJobQueueCoverage.ts
@@ -25,7 +25,7 @@
 import type { ArtJob } from '~/prisma/generated/prisma/client'
 import prisma from './prisma'
 import { parseArtJobPayload } from './artJobPayload'
-import { assertArtPromptContract } from './artPromptContract'
+import { queuedArtPrompt } from './artJobQueueSettings'
 import { normalizeArtPrompt } from './artJobProvenance'
 
 export const FACET_COVERAGE_FIELD_ORDER = [
@@ -73,102 +73,19 @@ function positiveInteger(value: unknown): number | null {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : null
 }
 
-function finiteNumber(value: unknown): number | null {
-  const parsed = Number(value)
-  return Number.isFinite(parsed) ? parsed : null
-}
-
 function hasRetry(payload: unknown): boolean {
   return Object.keys(asRecord(asRecord(payload).retry)).length > 0
 }
 
-function workflowNodes(payload: unknown): JsonRecord[] {
-  return Object.values(asRecord(asRecord(payload).workflow)).map(asRecord)
-}
-
-/** Infer the model family from the actual Comfy graph, not only relay engine. */
-export function inferQueuedArtEngine(
-  payload: unknown,
-  fallbackEngine?: string | null,
-): string {
-  const record = asRecord(payload)
-  const explicit = clean(record.engine).toLowerCase()
-  if (explicit && explicit !== 'comfy') return explicit
-
-  let sawCheckpointLoader = false
-  for (const node of workflowNodes(record)) {
-    const classType = clean(node.class_type)
-    const inputs = asRecord(node.inputs)
-    const clipType = clean(inputs.type).toLowerCase()
-    const modelName = `${clean(inputs.unet_name)} ${clean(inputs.ckpt_name)}`.toLowerCase()
-
-    if (clipType === 'krea2' || modelName.includes('krea-2')) return 'krea2'
-    if (clipType === 'flux2' || modelName.includes('flux-2-klein')) return 'flux2'
-    if (classType === 'FluxGuidance' || clipType === 'flux') return 'flux'
-    if (classType === 'CheckpointLoaderSimple') sawCheckpointLoader = true
-  }
-
-  if (sawCheckpointLoader) return 'comfy'
-  return clean(fallbackEngine).toLowerCase()
-}
-
-/** Read the settings the sampler will actually execute. */
-export function queuedArtSamplerSettings(payload: unknown): {
-  steps: number | null
-  cfg: number | null
-} {
-  const record = asRecord(payload)
-  for (const node of workflowNodes(record)) {
-    if (clean(node.class_type) !== 'KSampler') continue
-    const inputs = asRecord(node.inputs)
-    return {
-      steps: finiteNumber(inputs.steps) ?? finiteNumber(record.steps),
-      cfg: finiteNumber(inputs.cfg) ?? finiteNumber(record.cfg),
-    }
-  }
-  return {
-    steps: finiteNumber(record.steps),
-    cfg: finiteNumber(record.cfg),
-  }
-}
-
-function queuedArtPrompt(payload: unknown): string {
-  const record = asRecord(payload)
-  const topLevel = clean(record.promptString) || clean(record.prompt)
-  if (topLevel) return topLevel
-
-  for (const node of workflowNodes(record)) {
-    const classType = clean(node.class_type)
-    if (classType !== 'CLIPTextEncode' && classType !== 'ImpactWildcardEncode') {
-      continue
-    }
-    const title = clean(asRecord(node._meta).title).toLowerCase()
-    if (title.includes('negative')) continue
-    const inputs = asRecord(node.inputs)
-    const prompt = clean(inputs.text) || clean(inputs.wildcard_text)
-    if (prompt) return prompt
-  }
-  return ''
-}
-
-/**
- * Apply today's prompt/model contract to old PENDING rows too. The enqueue gate
- * protects new work; this guard stops pre-gate backlog rows from quietly
- * rendering with stale Krea settings or known-bad prompt vocabulary.
- */
-export function assertQueuedArtPromptContract(
-  engine: string,
-  payload: unknown,
-): void {
-  const actualEngine = inferQueuedArtEngine(payload, engine)
-  const sampler = queuedArtSamplerSettings(payload)
-  assertArtPromptContract({
-    prompt: queuedArtPrompt(payload),
-    engine: actualEngine,
-    steps: sampler.steps,
-    cfg: sampler.cfg,
-  })
-}
+// Engine/sampler/prompt reading and the claim-time contract assertion live in
+// artJobQueueSettings.ts — they need no database, and this module's prisma
+// import made them unreachable from the DB-free contract-tests workflow.
+// Re-exported here so every existing caller keeps its import path.
+export {
+  inferQueuedArtEngine,
+  queuedArtSamplerSettings,
+  assertQueuedArtPromptContract,
+} from './artJobQueueSettings'
 
 export function readFacetCoverageTarget(
   payload: unknown,
@@ -183,7 +100,9 @@ export function readFacetCoverageTarget(
   return { facetId, field }
 }
 
-function readStaticDeliveryTarget(payload: unknown): StaticDeliveryTarget | null {
+function readStaticDeliveryTarget(
+  payload: unknown,
+): StaticDeliveryTarget | null {
   const record = asRecord(payload)
   if (hasRetry(record)) return null
   const targetRepo = clean(record.targetRepo).toLowerCase()
@@ -214,7 +133,9 @@ export function selectFacetCoverageKeeper<
 }
 
 async function cancelPending(ids: number[], reason: string): Promise<number> {
-  const uniqueIds = [...new Set(ids)].filter((id) => Number.isInteger(id) && id > 0)
+  const uniqueIds = [...new Set(ids)].filter(
+    (id) => Number.isInteger(id) && id > 0,
+  )
   if (!uniqueIds.length) return 0
   const result = await prisma.artJob.updateMany({
     where: {
@@ -235,7 +156,10 @@ async function reconcileFacetCoverage(
   candidate: QueueCandidate,
   parsedPayload: JsonRecord,
 ): Promise<CoverageResult | null> {
-  if (candidate.status !== 'PENDING' || candidate.projectSlug !== 'facet-catalog') {
+  if (
+    candidate.status !== 'PENDING' ||
+    candidate.projectSlug !== 'facet-catalog'
+  ) {
     return null
   }
   const target = readFacetCoverageTarget(parsedPayload)
@@ -288,10 +212,10 @@ async function reconcileFacetCoverage(
 
   const hasDisplayArt = Boolean(
     clean(facet.imagePath) ||
-      clean(facet.cardPath) ||
-      clean(facet.heroPath) ||
-      clean(facet.iconPath) ||
-      facet.artImageId,
+    clean(facet.cardPath) ||
+    clean(facet.heroPath) ||
+    clean(facet.iconPath) ||
+    facet.artImageId,
   )
 
   if (hasDisplayArt) {
@@ -386,7 +310,9 @@ async function reconcileStaticDelivery(
   })
 
   const matching = siblings.filter((job) => {
-    const siblingTarget = readStaticDeliveryTarget(parseArtJobPayload(job.payload))
+    const siblingTarget = readStaticDeliveryTarget(
+      parseArtJobPayload(job.payload),
+    )
     return (
       siblingTarget?.targetRepo === target.targetRepo &&
       siblingTarget.imagePath === target.imagePath &&

--- a/server/utils/artJobQueueSettings.ts
+++ b/server/utils/artJobQueueSettings.ts
@@ -1,0 +1,127 @@
+// /server/utils/artJobQueueSettings.ts
+//
+// Reading a queued ArtJob's real engine, sampler settings, and prompt out of its
+// payload, plus the claim-time re-application of the prompt contract built on
+// them. Extracted from artJobQueueCoverage.ts, which still re-exports all three
+// for its existing callers.
+//
+// The extraction is not cosmetic. artJobQueueCoverage imports prisma, and
+// prisma.ts throws at import time when DATABASE_URL is unset — so anything that
+// touched these pure functions dragged a database requirement along with it, and
+// the DB-free contract-tests workflow could not reach them. That is how a test
+// for the claim-time guard failed in CI while passing locally, where a
+// DATABASE_URL happened to be exported. These four functions need no database;
+// living apart from one keeps them testable in the workflow that gates every PR.
+import { assertArtPromptContract } from './artPromptContract'
+
+type JsonRecord = Record<string, unknown>
+
+function asRecord(value: unknown): JsonRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as JsonRecord
+}
+
+function clean(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function finiteNumber(value: unknown): number | null {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function workflowNodes(payload: unknown): JsonRecord[] {
+  return Object.values(asRecord(asRecord(payload).workflow)).map(asRecord)
+}
+
+/** Infer the model family from the actual Comfy graph, not only relay engine. */
+export function inferQueuedArtEngine(
+  payload: unknown,
+  fallbackEngine?: string | null,
+): string {
+  const record = asRecord(payload)
+  const explicit = clean(record.engine).toLowerCase()
+  if (explicit && explicit !== 'comfy') return explicit
+
+  let sawCheckpointLoader = false
+  for (const node of workflowNodes(record)) {
+    const classType = clean(node.class_type)
+    const inputs = asRecord(node.inputs)
+    const clipType = clean(inputs.type).toLowerCase()
+    const modelName =
+      `${clean(inputs.unet_name)} ${clean(inputs.ckpt_name)}`.toLowerCase()
+
+    if (clipType === 'krea2' || modelName.includes('krea-2')) return 'krea2'
+    if (clipType === 'flux2' || modelName.includes('flux-2-klein'))
+      return 'flux2'
+    if (classType === 'FluxGuidance' || clipType === 'flux') return 'flux'
+    if (classType === 'CheckpointLoaderSimple') sawCheckpointLoader = true
+  }
+
+  if (sawCheckpointLoader) return 'comfy'
+  return clean(fallbackEngine).toLowerCase()
+}
+
+/** Read the settings the sampler will actually execute. */
+export function queuedArtSamplerSettings(payload: unknown): {
+  steps: number | null
+  cfg: number | null
+} {
+  const record = asRecord(payload)
+  for (const node of workflowNodes(record)) {
+    if (clean(node.class_type) !== 'KSampler') continue
+    const inputs = asRecord(node.inputs)
+    return {
+      steps: finiteNumber(inputs.steps) ?? finiteNumber(record.steps),
+      cfg: finiteNumber(inputs.cfg) ?? finiteNumber(record.cfg),
+    }
+  }
+  return {
+    steps: finiteNumber(record.steps),
+    cfg: finiteNumber(record.cfg),
+  }
+}
+
+export function queuedArtPrompt(payload: unknown): string {
+  const record = asRecord(payload)
+  const topLevel = clean(record.promptString) || clean(record.prompt)
+  if (topLevel) return topLevel
+
+  for (const node of workflowNodes(record)) {
+    const classType = clean(node.class_type)
+    if (
+      classType !== 'CLIPTextEncode' &&
+      classType !== 'ImpactWildcardEncode'
+    ) {
+      continue
+    }
+    const title = clean(asRecord(node._meta).title).toLowerCase()
+    if (title.includes('negative')) continue
+    const inputs = asRecord(node.inputs)
+    const prompt = clean(inputs.text) || clean(inputs.wildcard_text)
+    if (prompt) return prompt
+  }
+  return ''
+}
+
+/**
+ * Apply today's prompt/model contract to old PENDING rows too. The enqueue gate
+ * protects new work; this guard stops pre-gate backlog rows from quietly
+ * rendering with stale Krea settings or known-bad prompt vocabulary.
+ *
+ * Callers clamp out-of-band sampler settings first (see artJobSamplerRepair.ts);
+ * what reaches here is what no machine can safely rewrite.
+ */
+export function assertQueuedArtPromptContract(
+  engine: string,
+  payload: unknown,
+): void {
+  const actualEngine = inferQueuedArtEngine(payload, engine)
+  const sampler = queuedArtSamplerSettings(payload)
+  assertArtPromptContract({
+    prompt: queuedArtPrompt(payload),
+    engine: actualEngine,
+    steps: sampler.steps,
+    cfg: sampler.cfg,
+  })
+}

--- a/server/utils/artJobSamplerRepair.ts
+++ b/server/utils/artJobSamplerRepair.ts
@@ -31,7 +31,7 @@
 //     backlog drains, and the repair is recorded on the payload so it is visible
 //     rather than silent.
 import { DISTILLED_ENGINE_LIMITS } from './artPromptContract'
-import { inferQueuedArtEngine } from './artJobQueueCoverage'
+import { inferQueuedArtEngine } from './artJobQueueSettings'
 import { parseArtJobPayload, type ArtJobPayloadRecord } from './artJobPayload'
 
 export type SamplerRepairEntry = {

--- a/server/utils/artJobSamplerRepair.ts
+++ b/server/utils/artJobSamplerRepair.ts
@@ -1,0 +1,147 @@
+// /server/utils/artJobSamplerRepair.ts
+//
+// Mechanical repair of out-of-band sampler settings on a queued ArtJob.
+//
+// The prompt contract (server/utils/artPromptContract.ts) shipped 2026-08-08 and
+// is re-applied at claim time so pre-gate backlog rows cannot render with stale
+// Krea settings. That guard did exactly what it was built to do — and then the
+// bill arrived: on 2026-08-09 eight ArtJobs enqueued 2026-08-02..04 (4843, 4844,
+// 4845, 4858, 4859, 4860, 4867, 4877) all died at claim with
+//
+//   [engine-step-mismatch] krea2 runs at roughly 12 steps or fewer; got 20.
+//
+// with a further 27 PENDING rows (7633..7965) carrying the identical defect and
+// queued to die the same way, one relay poll at a time. Their graphs were
+// otherwise fine: cfg had already been corrected to 1, the prompt text passed
+// every other rule, only `steps` was left at the pre-fix 20.
+//
+// Failing those is the wrong trade. The contract exists to stop BAD ART, and a
+// step count above the engine's ceiling is the one violation with an objectively
+// correct repair: clamp it. There is no authorial intent to preserve in "20
+// steps on a model distilled for 8" — it is a number the old queue builder wrote
+// before anyone knew better. Every other rule (a conditional the model cannot
+// evaluate, a format noun, a pile of text exclusions) needs a human to re-author
+// the prompt, and those still hard-fail.
+//
+// The split that keeps both properties:
+//   - ENQUEUE still rejects. A producer that sends krea2 at 20 steps gets a 422
+//     and fixes itself; "violations are hard errors, not warnings" is intact for
+//     everything writing new work.
+//   - CLAIM repairs, then asserts. Rows that predate the gate self-heal as the
+//     backlog drains, and the repair is recorded on the payload so it is visible
+//     rather than silent.
+import { DISTILLED_ENGINE_LIMITS } from './artPromptContract'
+import { inferQueuedArtEngine } from './artJobQueueCoverage'
+import { parseArtJobPayload, type ArtJobPayloadRecord } from './artJobPayload'
+
+export type SamplerRepairEntry = {
+  /** `payload.steps`, or `workflow.<nodeId>.inputs.cfg` — where the value lived. */
+  path: string
+  from: number
+  to: number
+}
+
+export type ArtJobSamplerRepairResult = {
+  payload: ArtJobPayloadRecord
+  changed: boolean
+  /** The model family the clamp was resolved against, for the audit record. */
+  engine: string
+  repairs: SamplerRepairEntry[]
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as Record<string, unknown>
+}
+
+function finiteNumber(value: unknown): number | null {
+  // `Number('')` is 0 and `Number(null)` is 0; neither is a sampler setting.
+  if (value === null || value === undefined || value === '') return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+/**
+ * Clamp `steps` and `cfg` to the ceiling the engine is distilled for, wherever
+ * they appear — the top-level payload fields the A1111 path reads AND every
+ * KSampler node in the Comfy graph, which is what actually executes.
+ *
+ * Non-distilled engines have no ceiling to clamp to and are returned untouched.
+ * The returned payload is a clone; the caller's input is never mutated.
+ */
+export function repairQueuedArtSampler(
+  engine: string | null | undefined,
+  rawPayload: unknown,
+): ArtJobSamplerRepairResult {
+  const payload = structuredClone(parseArtJobPayload(rawPayload))
+  const resolvedEngine = inferQueuedArtEngine(payload, engine)
+  const limits = DISTILLED_ENGINE_LIMITS[resolvedEngine]
+  const repairs: SamplerRepairEntry[] = []
+
+  if (!limits) {
+    return { payload, changed: false, engine: resolvedEngine, repairs }
+  }
+
+  const ceilings: Array<{ key: 'steps' | 'cfg'; max: number }> = [
+    { key: 'steps', max: limits.maxSteps },
+    { key: 'cfg', max: limits.cfg },
+  ]
+
+  const clamp = (
+    holder: Record<string, unknown>,
+    key: 'steps' | 'cfg',
+    max: number,
+    path: string,
+  ): void => {
+    const current = finiteNumber(holder[key])
+    if (current === null || current <= max) return
+    holder[key] = max
+    repairs.push({ path, from: current, to: max })
+  }
+
+  for (const { key, max } of ceilings) {
+    clamp(payload as Record<string, unknown>, key, max, `payload.${key}`)
+  }
+
+  // A graph can legitimately carry more than one KSampler (base pass plus a
+  // refiner); clamp each rather than the first one found.
+  for (const [nodeId, node] of Object.entries(asRecord(payload.workflow))) {
+    const record = asRecord(node)
+    if (String(record.class_type || '').trim() !== 'KSampler') continue
+    const inputs = record.inputs
+    if (!inputs || typeof inputs !== 'object' || Array.isArray(inputs)) continue
+    for (const { key, max } of ceilings) {
+      clamp(
+        inputs as Record<string, unknown>,
+        key,
+        max,
+        `workflow.${nodeId}.inputs.${key}`,
+      )
+    }
+  }
+
+  return {
+    payload,
+    changed: repairs.length > 0,
+    engine: resolvedEngine,
+    repairs,
+  }
+}
+
+/**
+ * Stamp the repair onto the payload so a clamped job is auditable after the
+ * fact — "why did this render at 12 steps when the row said 20" has an answer
+ * in the row itself, not only in a log line nobody kept.
+ */
+export function recordSamplerRepair(
+  payload: ArtJobPayloadRecord,
+  result: ArtJobSamplerRepairResult,
+  repairedAt: string,
+): void {
+  if (!result.changed) return
+  payload.samplerRepair = {
+    repairedAt,
+    engine: result.engine,
+    repairs: result.repairs,
+  }
+}

--- a/utils/scripts/verifyArtJobSamplerRepair.ts
+++ b/utils/scripts/verifyArtJobSamplerRepair.ts
@@ -1,0 +1,244 @@
+// Contract test for server/utils/artJobSamplerRepair.ts and the two callers
+// that decide whether a pre-gate backlog row renders or dies.
+//
+// The case this file exists for, in full: on 2026-08-09 the shared render queue
+// reported nine recent failures, eight of them identical —
+//
+//   ArtJob validation failed before claim: Art prompt rejected by the prompt
+//   contract (1 violation):
+//     [engine-step-mismatch] krea2 runs at roughly 12 steps or fewer; got 20.
+//
+// ArtJobs 4843/4844/4845/4858/4859/4860/4867/4877, all enqueued 2026-08-02..04,
+// all with cfg already correct at 1 and prompts that pass every other rule. A
+// scan of the full 2815-row PENDING backlog found 27 more (7633..7965) with the
+// same single defect and nothing else wrong. The gate was right to exist and
+// wrong to be terminal here: "20 steps on a model distilled for 8" is a number
+// to clamp, not a prompt to re-author.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import {
+  repairQueuedArtSampler,
+  recordSamplerRepair,
+} from '../../server/utils/artJobSamplerRepair'
+import { assertQueuedArtPromptContract } from '../../server/utils/artJobQueueCoverage'
+import { DISTILLED_ENGINE_LIMITS } from '../../server/utils/artPromptContract'
+
+/** The shape ArtJob 4877 actually carried, trimmed to what the gate reads. */
+function krea2JobAsShipped(steps: number, cfg: number) {
+  return {
+    promptString:
+      'Create artwork for Magic. Visible subject and scene context: a brass ' +
+      'orrery on a workbench, an unpeopled frame — the subject stands alone ' +
+      'with no bystanders, onlookers, or crowd',
+    width: 1024,
+    height: 1024,
+    steps,
+    cfg,
+    collection: 'krea2',
+    workflow: {
+      '1': {
+        inputs: { unet_name: 'Krea-2-Turbo-Q5_K_S.gguf' },
+        class_type: 'UnetLoaderGGUF',
+      },
+      '2': {
+        inputs: {
+          clip_name: 'qwen3vl_4b_fp8_scaled.safetensors',
+          type: 'krea2',
+        },
+        class_type: 'CLIPLoader',
+      },
+      '7': {
+        inputs: {
+          seed: 12345,
+          steps,
+          cfg: 1,
+          sampler_name: 'euler',
+          scheduler: 'simple',
+          denoise: 1,
+        },
+        class_type: 'KSampler',
+      },
+    },
+  }
+}
+
+// ── The exact failure, repaired ─────────────────────────────────────────────
+
+const shipped = krea2JobAsShipped(20, 7)
+
+// Unrepaired, this is precisely what killed the eight jobs.
+assert.throws(
+  () => assertQueuedArtPromptContract('COMFY', shipped),
+  /engine-step-mismatch/,
+  'the as-shipped 20-step krea2 job must still be rejected without repair',
+)
+
+const repaired = repairQueuedArtSampler('COMFY', shipped)
+assert.equal(
+  repaired.engine,
+  'krea2',
+  'engine is inferred from the Comfy graph',
+)
+assert.ok(repaired.changed, 'a 20-step krea2 job must report a repair')
+assert.doesNotThrow(
+  () => assertQueuedArtPromptContract('COMFY', repaired.payload),
+  'the repaired payload must pass the same gate that rejected the original',
+)
+
+// The clamp lands where the sampler actually reads it, not only on the metadata.
+const workflow = repaired.payload.workflow as Record<
+  string,
+  { inputs: Record<string, unknown> }
+>
+assert.equal(
+  workflow['7']!.inputs.steps,
+  DISTILLED_ENGINE_LIMITS.krea2!.maxSteps,
+  'the KSampler node is what executes — clamp it, not just payload.steps',
+)
+assert.equal(repaired.payload.steps, DISTILLED_ENGINE_LIMITS.krea2!.maxSteps)
+assert.equal(
+  repaired.payload.cfg,
+  DISTILLED_ENGINE_LIMITS.krea2!.cfg,
+  'a top-level cfg of 7 on a cfg-1 engine is also out of band',
+)
+
+// The caller's object is never mutated: claim.post.ts still reports the
+// original candidate elsewhere, and a silent in-place edit would desync it.
+assert.equal(shipped.steps, 20, 'repair must not mutate its input')
+assert.equal(shipped.workflow['7'].inputs.steps, 20)
+
+// ── What repair must NOT do ─────────────────────────────────────────────────
+
+// In-band settings are left exactly alone — no gratuitous payload churn across
+// a 2800-row backlog, and no "repaired" stamp on a job nothing was wrong with.
+const healthy = repairQueuedArtSampler('COMFY', krea2JobAsShipped(8, 1))
+assert.equal(healthy.changed, false, 'an 8-step krea2 job is already legal')
+assert.deepEqual(healthy.repairs, [])
+
+// A1111 and other non-distilled engines have no ceiling to clamp to. ArtJob
+// 8116 (A1111, 24 steps) failed on a refused ComfyUI connection, not on this —
+// clamping its steps would be inventing a rule the contract does not have.
+const a1111 = repairQueuedArtSampler('A1111', {
+  promptString: 'a lighthouse at dusk',
+  steps: 24,
+  cfg: 6,
+})
+assert.equal(a1111.changed, false, 'non-distilled engines are untouched')
+assert.equal(a1111.payload.steps, 24)
+
+// Repair is for the mechanical rules only. A prompt a machine cannot safely
+// rewrite must still fail loudly, exactly as it did before.
+const conditional = repairQueuedArtSampler('COMFY', {
+  ...krea2JobAsShipped(20, 7),
+  promptString:
+    'a treasure-card illustration of a ladle; include robots only when the ' +
+    'subject or scene explicitly calls for them',
+})
+assert.throws(
+  () => assertQueuedArtPromptContract('COMFY', conditional.payload),
+  /conditional-instruction|format-vocabulary/,
+  'clamping steps must not launder a prompt that needs re-authoring',
+)
+
+// Refiner graphs carry more than one KSampler; the first one is not the only one.
+const twoSamplers = repairQueuedArtSampler('COMFY', {
+  promptString: 'a brass orrery',
+  collection: 'krea2',
+  workflow: {
+    '2': { inputs: { type: 'krea2' }, class_type: 'CLIPLoader' },
+    '7': { inputs: { steps: 20, cfg: 1 }, class_type: 'KSampler' },
+    '9': { inputs: { steps: 30, cfg: 1 }, class_type: 'KSampler' },
+  },
+})
+const twoSamplerNodes = twoSamplers.payload.workflow as Record<
+  string,
+  { inputs: Record<string, unknown> }
+>
+assert.equal(twoSamplerNodes['7']!.inputs.steps, 12)
+assert.equal(
+  twoSamplerNodes['9']!.inputs.steps,
+  12,
+  'every KSampler is clamped',
+)
+
+// A missing/blank steps value is absent, not zero — Number('') is 0, and a
+// clamp that reads 0 would quietly rewrite "unset" into a real setting.
+const unset = repairQueuedArtSampler('COMFY', {
+  promptString: 'a brass orrery',
+  collection: 'krea2',
+  steps: '',
+  workflow: { '2': { inputs: { type: 'krea2' }, class_type: 'CLIPLoader' } },
+})
+assert.equal(unset.changed, false)
+assert.equal(unset.payload.steps, '', 'an unset value stays unset')
+
+// ── The audit stamp ─────────────────────────────────────────────────────────
+
+const stamped: Record<string, unknown> = {}
+recordSamplerRepair(stamped, repaired, '2026-08-09T12:00:00.000Z')
+const stamp = stamped.samplerRepair as {
+  engine: string
+  repairs: Array<{ path: string; from: number; to: number }>
+}
+assert.equal(stamp.engine, 'krea2')
+assert.ok(
+  stamp.repairs.some(
+    (r) => r.path === 'workflow.7.inputs.steps' && r.from === 20,
+  ),
+  'the stamp must name what changed and what it was',
+)
+
+const unstamped: Record<string, unknown> = {}
+recordSamplerRepair(unstamped, healthy, '2026-08-09T12:00:00.000Z')
+assert.equal(
+  unstamped.samplerRepair,
+  undefined,
+  'an untouched job gets no repair record',
+)
+
+// ── The callers stay wired ──────────────────────────────────────────────────
+//
+// The repair is worthless if a later refactor drops the call, and neither
+// caller is reachable from a DB-free test. Assert the wiring textually, the
+// same way verifyFacetCatalogMaintenance.ts guards the claim-time contract.
+
+const claim = readFileSync('server/api/art/queue/claim.post.ts', 'utf8')
+for (const required of [
+  'repairQueuedArtSampler',
+  'assertQueuedArtPromptContract(candidate.engine, samplerRepair.payload)',
+  'recordSamplerRepair',
+]) {
+  assert.ok(
+    claim.includes(required),
+    `claim.post.ts must repair the sampler before asserting: ${required}`,
+  )
+}
+assert.ok(
+  !claim.includes(
+    'assertQueuedArtPromptContract(candidate.engine, candidate.payload)',
+  ),
+  'claim.post.ts must assert against the REPAIRED payload, not the raw candidate',
+)
+
+const requeue = readFileSync(
+  'server/api/art/queue/reenqueue-failed.post.ts',
+  'utf8',
+)
+assert.ok(
+  requeue.includes('repairQueuedArtSampler'),
+  'requeueing a failed job must clamp the sampler, or it fails again at claim',
+)
+
+// The other half of the split: ENQUEUE must keep rejecting outright, so a
+// producer writing new work still fails loudly instead of being quietly fixed.
+const enqueue = readFileSync('server/api/art/enqueue.post.ts', 'utf8')
+assert.ok(
+  enqueue.includes('assertArtPromptContract'),
+  'the enqueue gate must stay a hard rejection',
+)
+assert.ok(
+  !enqueue.includes('repairQueuedArtSampler'),
+  'enqueue must NOT auto-repair — producers fix themselves, backlog self-heals',
+)
+
+console.log('artJobSamplerRepair contract OK')

--- a/utils/scripts/verifyArtJobSamplerRepair.ts
+++ b/utils/scripts/verifyArtJobSamplerRepair.ts
@@ -20,7 +20,11 @@ import {
   repairQueuedArtSampler,
   recordSamplerRepair,
 } from '../../server/utils/artJobSamplerRepair'
-import { assertQueuedArtPromptContract } from '../../server/utils/artJobQueueCoverage'
+// Imported from artJobQueueSettings, not artJobQueueCoverage: the latter pulls
+// in prisma, which throws at import time without DATABASE_URL, and this file
+// runs in the DB-free contract-tests workflow. That import is exactly what made
+// the first version of this test pass locally and fail in CI.
+import { assertQueuedArtPromptContract } from '../../server/utils/artJobQueueSettings'
 import { DISTILLED_ENGINE_LIMITS } from '../../server/utils/artPromptContract'
 
 /** The shape ArtJob 4877 actually carried, trimmed to what the gate reads. */
@@ -240,5 +244,26 @@ assert.ok(
   !enqueue.includes('repairQueuedArtSampler'),
   'enqueue must NOT auto-repair — producers fix themselves, backlog self-heals',
 )
+
+// Keep the reading helpers out of the prisma-importing module. Moving them back
+// would not break a single runtime caller — artJobQueueCoverage re-exports all
+// three — it would only make this file unrunnable in CI, silently, the way it
+// already was once.
+const settings = readFileSync('server/utils/artJobQueueSettings.ts', 'utf8')
+assert.ok(
+  !/from '\.\/(prisma|artJobQueueCoverage)'/.test(settings),
+  'artJobQueueSettings must stay database-free so the contract workflow can run it',
+)
+const coverage = readFileSync('server/utils/artJobQueueCoverage.ts', 'utf8')
+for (const required of [
+  'inferQueuedArtEngine',
+  'queuedArtSamplerSettings',
+  'assertQueuedArtPromptContract',
+]) {
+  assert.ok(
+    coverage.includes(required),
+    `artJobQueueCoverage must keep re-exporting ${required} for existing callers`,
+  )
+}
 
 console.log('artJobSamplerRepair contract OK')


### PR DESCRIPTION
### Task
Investigating the latest art-queue render failures (Silas-directed, 2026-08-09). Kind: software.

### The failure

`GET /api/art/queue/stats` reported 9 recent failures. Eight were byte-identical:

```
ArtJob validation failed before claim: Art prompt rejected by the prompt contract (1 violation):
  [engine-step-mismatch] krea2 runs at roughly 12 steps or fewer; got 20.
```

ArtJobs **4843, 4844, 4845, 4858, 4859, 4860, 4867, 4877** — all enqueued 2026-08-02..04, i.e. *before* the prompt contract shipped on 2026-08-08. Their cfg was already correct at 1, their prompts pass every other rule; the only thing wrong was a step count the old queue builder wrote.

I scanned the entire 2815-row PENDING backlog against the same rules. **27 more rows carry the identical single defect and nothing else** (7633, 7635, 7636, 7697–7701, 7895–7902, 7955–7965), each queued to die the same way, one relay poll at a time. No other contract rule is violated anywhere in the backlog.

(The 9th failure, ArtJob 8116, is an A1111 job that hit a refused ComfyUI connection — a relay outage, unrelated.)

### Root cause

Two layers, both correct in isolation:

1. `entry_to_job` in Conductor resolved **defaults** per engine (fixed 2026-08-08) but let an explicit `steps:` on a queue entry override untouched. Pre-fix entries carried 20.
2. `claim.post.ts` re-applies the prompt contract to pre-gate backlog rows so they cannot render with stale Krea settings — deliberately, and it works. But it is *terminal*: the row is marked FAILED.

Terminal is the wrong trade for this one rule. The contract exists to stop bad art, and a step count above the engine's ceiling is the only violation with an objectively correct repair — there is no authorial intent to preserve in "20 steps on a model distilled for 8". Every other rule (a conditional the model cannot evaluate, a format noun, a pile of text exclusions) needs a human to re-author the prompt.

### What changed

New `server/utils/artJobSamplerRepair.ts`, wired into two callers. The boundary moves rather than softens:

- **Enqueue still rejects outright** — a producer writing new work at 20 steps gets a 422 and fixes itself. "Violations are hard errors, not warnings" is intact for everything writing new work, and the test asserts enqueue does *not* gain the repair.
- **Claim clamps, then asserts** — `steps`/`cfg` are held to `DISTILLED_ENGINE_LIMITS` before the gate runs, so pre-gate rows self-heal as the backlog drains. Prompt-text violations still hard-fail exactly as before.
- **Requeue clamps too** — `reenqueue-failed` normalized paths, prompts and LoRAs but not the sampler, so requeuing one of these eight would have sent it straight back to fail again on the next poll.

The clamp reaches every `KSampler` node in the graph, not just `payload.steps`: the node is what executes, a refiner graph has more than one, and an unset value stays unset (`Number('')` is 0, which would otherwise be written back as a real setting). The repair is stamped onto the payload as `samplerRepair` so a job that rendered at 12 says why.

### How I verified

Actually run, not assumed:

- `tsx utils/scripts/verifyArtJobSamplerRepair.ts` — **passes**. New contract test built from ArtJob 4877's real payload: asserts the as-shipped job still throws unrepaired, passes after repair, that the KSampler node is clamped and the input object is not mutated, that in-band jobs get no change and no stamp, that A1111 is untouched, that a conditional/format prompt still throws after clamping, multi-KSampler graphs, and the enqueue/claim/requeue wiring.
- `tsx utils/scripts/verifyArtPromptContract.ts` — passes (unchanged).
- `tsx utils/scripts/verifyFacetCatalogMaintenance.ts` — passes; it text-asserts the claim-time contract wiring, so it would have caught the assert being dropped.
- `tsx utils/scripts/verifyArtPromptRepair.ts` — passes.
- `npm run test` (vue-tsc `--noEmit`, full project) — **exit 0, no errors**.
- `eslint` on all four touched/added TS files — clean.
- Live scan of all 2815 PENDING rows via `/api/art/queue` — the 27-row figure above is measured, not estimated.

Not verified: no render has been executed through the repaired path yet. The relay renders from the clamped graph, so the first repaired job is the proof; I'll requeue the eight failures after this deploys and confirm they render.

### Stakes
reversible — pure server-side clamp, no schema change, no data migration. Reverting restores the previous fail-at-claim behavior.

### Flags for Reviewer
- This deliberately makes the claim-time gate non-terminal for `engine-step-mismatch` / `engine-guidance-mismatch`. `artPromptContract.ts`'s header says "Violations are hard errors, not warnings" — that sentence is about producers failing loudly at enqueue, which is unchanged. If you'd rather the backlog rows die and be re-authored instead, this is the commit to reject.
- Top-level `payload.cfg` is clamped as well as the graph's. For krea2 rows that shipped with metadata cfg 7 and graph cfg 1 that means a payload edit on rows whose effective settings were already fine. It is honest — the metadata described a job that was never going to run that way — but it is churn.
- One unrelated formatting hunk was reverted rather than committed: `claim.post.ts` is already not prettier-clean on `main` (the `| 'A1111' | 'COMFY'` union), and `prettier --write` reformatted it. Left as-is to keep the diff scoped.

### Kaizen suggestion
`recheck_render_queue.py` shows the last N failures — "what just broke" — but not "how much more of this is coming", which is the number that decided this fix. Conductor gets `scripts/scan_art_queue_sampler.py` in the companion PR for exactly that. The deeper gap: nothing alerts when the same failure signature repeats across N consecutive jobs. Eight identical failures over ~6 days surfaced only because Silas asked.

### Notes for reviewer
Companion Conductor PR clamps the producer side (`entry_to_job` now holds an explicit `steps:`/`cfg:` to the same ceilings) and adds the backlog scanner. Neither side depends on the other to merge, but both are needed for the loop to close: this one repairs what is already queued, that one stops new rows being written out of band.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RiRyHC7xHFaPG2StQKqeX7)_