### PR TITLE
refactor(ui): codemod-migrate 236 exact-match kr-panel-flat surfaces (t-104/t-115)

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -78,7 +78,7 @@
         <Transition name="kr-sheet-slide">
           <aside
             v-if="workspaceSheetOpen"
-            class="absolute inset-y-0 left-0 z-30 flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-xl md:w-(--sheet-w)"
+            class="absolute inset-y-0 left-0 z-30 flex h-full min-h-0 w-full flex-col overflow-hidden kr-panel-flat shadow-xl md:w-(--sheet-w)"
           >
             <fx-region region="sheet" />
 

--- a/components/abandonware/art/art-creator.vue
+++ b/components/abandonware/art/art-creator.vue
@@ -49,7 +49,7 @@
 
       <div
         v-if="promptPreview"
-        class="mt-3 rounded-2xl border border-base-300 bg-base-100 p-3 text-xs leading-relaxed text-base-content/70"
+        class="mt-3 kr-panel-flat p-3 text-xs leading-relaxed text-base-content/70"
       >
         {{ promptPreview }}
       </div>
@@ -74,7 +74,7 @@
     <Transition name="art-creator-reveal">
       <div
         v-if="generatedImage"
-        class="rounded-2xl border border-base-300 bg-base-100 p-3"
+        class="kr-panel-flat p-3"
       >
         <image-card :art-image="generatedImage" />
       </div>

--- a/components/abandonware/bots/bot-intros.vue
+++ b/components/abandonware/bots/bot-intros.vue
@@ -18,9 +18,7 @@
       </p>
     </div>
 
-    <div
-      class="flex flex-col gap-2 rounded-2xl border border-base-300 bg-base-100 p-4"
-    >
+    <div class="flex flex-col gap-2 kr-panel-flat p-4">
       <div class="flex items-center justify-between">
         <span
           class="text-xs font-black uppercase tracking-widest text-primary/70"

--- a/components/abandonware/bots/text-generate.vue
+++ b/components/abandonware/bots/text-generate.vue
@@ -103,7 +103,7 @@
 
     <div
       v-if="showResult && resultText"
-      class="whitespace-pre-wrap rounded-2xl border border-base-300 bg-base-100 p-3 text-sm leading-relaxed"
+      class="whitespace-pre-wrap kr-panel-flat p-3 text-sm leading-relaxed"
     >
       {{ resultText }}
     </div>

--- a/components/abandonware/builder/art-builder.vue
+++ b/components/abandonware/builder/art-builder.vue
@@ -1,7 +1,7 @@
 <!-- /components/builder/art-builder.vue -->
 <template>
   <section
-    class="flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-100 p-4"
+    class="flex flex-col gap-4 kr-panel-flat p-4"
   >
     <!-- ── Header ──────────────────────────────────────────────────────── -->
     <header class="rounded-xl border border-base-300 bg-base-200/60 p-3">
@@ -76,7 +76,7 @@
         </div>
 
         <aside
-          class="flex flex-col gap-2 rounded-2xl border border-base-300 bg-base-100 p-4"
+          class="flex flex-col gap-2 kr-panel-flat p-4"
         >
           <h4
             class="flex items-center gap-2 text-sm font-black text-base-content"
@@ -170,7 +170,7 @@
         v-else-if="mode === 'generate'"
         class="grid grid-cols-1 gap-4 xl:grid-cols-[1fr_20rem]"
       >
-        <div class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <div class="kr-panel-flat p-4">
           <div class="mb-3 flex items-center gap-2">
             <span
               class="flex h-8 w-8 items-center justify-center rounded-lg bg-accent/15 text-accent"
@@ -190,7 +190,7 @@
         </div>
 
         <aside
-          class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-100 p-4"
+          class="flex flex-col gap-3 kr-panel-flat p-4"
         >
           <h4
             class="flex items-center gap-2 text-sm font-black text-base-content"

--- a/components/abandonware/builder/builder-card-grid.vue
+++ b/components/abandonware/builder/builder-card-grid.vue
@@ -1,7 +1,7 @@
 <!-- /components/builder/builder-card-grid.vue -->
 <template>
   <section
-    class="flex h-full min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100"
+    class="flex h-full min-h-0 flex-1 flex-col overflow-hidden kr-panel-flat"
   >
     <div
       class="flex shrink-0 flex-col gap-2 border-b border-base-300 p-4 sm:flex-row sm:items-end sm:justify-between"

--- a/components/abandonware/builder/builder-custom-input.vue
+++ b/components/abandonware/builder/builder-custom-input.vue
@@ -1,6 +1,6 @@
 <!-- /components/builder/builder-custom-input.vue -->
 <template>
-  <div v-if="step" class="rounded-2xl border border-base-300 bg-base-100 p-4">
+  <div v-if="step" class="kr-panel-flat p-4">
     <label class="form-control">
       <div class="label pb-1">
         <span class="label-text font-bold">{{ step.inputLabel || step.title }}</span>

--- a/components/abandonware/builder/builder-splash.vue
+++ b/components/abandonware/builder/builder-splash.vue
@@ -8,7 +8,7 @@
 -->
 <template>
   <section
-    class="relative grid min-h-full gap-6 overflow-hidden rounded-2xl border border-base-300 bg-base-100 p-5 lg:grid-cols-[minmax(0,1fr)_minmax(280px,440px)] lg:p-8"
+    class="relative grid min-h-full gap-6 overflow-hidden kr-panel-flat p-5 lg:grid-cols-[minmax(0,1fr)_minmax(280px,440px)] lg:p-8"
   >
     <!-- ambient wash: primary in one corner, secondary in the other -->
     <div

--- a/components/abandonware/builder/builder-stats-input.vue
+++ b/components/abandonware/builder/builder-stats-input.vue
@@ -37,7 +37,7 @@
       </button>
     </div>
 
-    <div class="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-base-300 bg-base-100 p-3">
+    <div class="flex flex-wrap items-center justify-between gap-2 kr-panel-flat p-3">
       <p class="text-sm font-semibold" :class="store.statAllocationComplete ? 'text-success' : 'text-base-content/50'">
         {{ store.statAllocationComplete ? 'Stats are allocated.' : 'Assign each number from 1 to 6 once.' }}
       </p>

--- a/components/abandonware/builder/builder-step-panel.vue
+++ b/components/abandonware/builder/builder-step-panel.vue
@@ -5,7 +5,7 @@
     class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
   >
     <section
-      class="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100"
+      class="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden kr-panel-flat"
     >
       <template v-if="store.activeSelectionPreview">
         <div class="flex h-full min-h-0 flex-col overflow-hidden">

--- a/components/abandonware/builder/builder-summary.vue
+++ b/components/abandonware/builder/builder-summary.vue
@@ -1,6 +1,6 @@
 <!-- /components/builder/builder-summary.vue -->
 <template>
-  <section class="flex min-h-full flex-col gap-4 rounded-2xl border border-base-300 bg-base-100 p-4">
+  <section class="flex min-h-full flex-col gap-4 kr-panel-flat p-4">
     <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
       <div>
         <p class="text-xs font-black uppercase tracking-widest text-success/80">Complete</p>

--- a/components/abandonware/butterfly/butterfly-grid.vue
+++ b/components/abandonware/butterfly/butterfly-grid.vue
@@ -9,7 +9,7 @@
       </div>
 
       <div class="grid grid-cols-1 gap-4 lg:grid-cols-4">
-        <label class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <label class="kr-panel-flat p-4">
           <div class="mb-2 font-semibold">Step size</div>
           <select v-model="stepSize" class="select select-bordered w-full rounded-2xl">
             <option :value="15">15°</option>
@@ -18,7 +18,7 @@
           </select>
         </label>
 
-        <label class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <label class="kr-panel-flat p-4">
           <div class="mb-2 font-semibold">Spread</div>
           <select v-model="spreadMode" class="select select-bordered w-full rounded-2xl">
             <option value="tight">[-step, 0, step]</option>
@@ -26,7 +26,7 @@
           </select>
         </label>
 
-        <label class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <label class="kr-panel-flat p-4">
           <div class="mb-2 font-semibold">Scale</div>
           <input
             v-model="scale"
@@ -39,7 +39,7 @@
           <div class="mt-2 text-sm font-mono">{{ scale.toFixed(2) }}</div>
         </label>
 
-        <div class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <div class="kr-panel-flat p-4">
           <div class="mb-2 font-semibold">Grid summary</div>
           <div class="text-sm">Combos: {{ combinations.length }}</div>
           <div class="text-sm">Marked ugly: {{ uglyCombos.length }}</div>
@@ -54,7 +54,7 @@
         </div>
       </div>
 
-      <div class="rounded-2xl border border-base-300 bg-base-100 p-4">
+      <div class="kr-panel-flat p-4">
         <div class="mb-2 font-semibold">Selected ugly combos</div>
         <pre class="max-h-56 overflow-auto rounded-2xl bg-base-200 p-3 text-xs font-mono">{{ uglyCombosJson }}</pre>
       </div>

--- a/components/abandonware/butterfly/butterfly-guide.vue
+++ b/components/abandonware/butterfly/butterfly-guide.vue
@@ -45,14 +45,10 @@
 
       <div class="min-h-0 flex-1 overflow-y-auto p-4">
         <div class="grid grid-cols-1 gap-3 xl:grid-cols-2">
-          <div
-            class="rounded-2xl border border-base-300 bg-base-100 p-1 xl:col-span-2"
-          >
+          <div class="kr-panel-flat p-1 xl:col-span-2">
             <butterfly-demo class="h-64 w-full" />
           </div>
-          <div
-            class="rounded-2xl border border-base-300 bg-base-100 p-3 xl:col-span-2"
-          >
+          <div class="kr-panel-flat p-3 xl:col-span-2">
             <div
               class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
             >
@@ -63,7 +59,7 @@
             </div>
           </div>
 
-          <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+          <div class="kr-panel-flat p-3">
             <div
               class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
             >
@@ -118,7 +114,7 @@
             </div>
           </div>
 
-          <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+          <div class="kr-panel-flat p-3">
             <div
               class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
             >
@@ -153,7 +149,7 @@
             </div>
           </div>
 
-          <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+          <div class="kr-panel-flat p-3">
             <div
               class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
             >
@@ -215,7 +211,7 @@
             </div>
           </div>
 
-          <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+          <div class="kr-panel-flat p-3">
             <div
               class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
             >
@@ -257,7 +253,7 @@
             </div>
           </div>
 
-          <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+          <div class="kr-panel-flat p-3">
             <div
               class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
             >
@@ -303,9 +299,7 @@
             </div>
           </div>
 
-          <div
-            class="rounded-2xl border border-base-300 bg-base-100 p-3 xl:col-span-2"
-          >
+          <div class="kr-panel-flat p-3 xl:col-span-2">
             <div
               class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
             >
@@ -351,9 +345,7 @@
             </div>
           </div>
 
-          <div
-            class="rounded-2xl border border-base-300 bg-base-100 p-3 xl:col-span-2"
-          >
+          <div class="kr-panel-flat p-3 xl:col-span-2">
             <div
               class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
             >

--- a/components/abandonware/butterfly/butterfly-lab.vue
+++ b/components/abandonware/butterfly/butterfly-lab.vue
@@ -10,7 +10,7 @@
       </div>
 
       <div
-        class="relative flex min-h-96 items-center justify-center overflow-hidden rounded-2xl border border-base-300 bg-base-100"
+        class="relative flex min-h-96 items-center justify-center overflow-hidden kr-panel-flat"
       >
         <div class="orientation-stage">
           <div class="orientation-guides" />
@@ -31,7 +31,7 @@
       </div>
 
       <div class="grid grid-cols-1 gap-4 lg:grid-cols-3">
-        <label class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <label class="kr-panel-flat p-4">
           <div class="mb-2 flex items-center justify-between">
             <span class="font-semibold">Rotate X</span>
             <span class="rounded-xl bg-base-200 px-3 py-1 text-sm font-mono">
@@ -48,7 +48,7 @@
           />
         </label>
 
-        <label class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <label class="kr-panel-flat p-4">
           <div class="mb-2 flex items-center justify-between">
             <span class="font-semibold">Rotate Y</span>
             <span class="rounded-xl bg-base-200 px-3 py-1 text-sm font-mono">
@@ -65,7 +65,7 @@
           />
         </label>
 
-        <label class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <label class="kr-panel-flat p-4">
           <div class="mb-2 flex items-center justify-between">
             <span class="font-semibold">Rotate Z</span>
             <span class="rounded-xl bg-base-200 px-3 py-1 text-sm font-mono">
@@ -84,7 +84,7 @@
       </div>
 
       <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <label class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <label class="kr-panel-flat p-4">
           <div class="mb-2 flex items-center justify-between">
             <span class="font-semibold">Scale</span>
             <span class="rounded-xl bg-base-200 px-3 py-1 text-sm font-mono">
@@ -101,7 +101,7 @@
           />
         </label>
 
-        <label class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <label class="kr-panel-flat p-4">
           <div class="mb-2 flex items-center justify-between">
             <span class="font-semibold">Wing Speed</span>
             <span class="rounded-xl bg-base-200 px-3 py-1 text-sm font-mono">
@@ -157,7 +157,7 @@
         </button>
       </div>
 
-      <div class="rounded-2xl border border-base-300 bg-base-100 p-4">
+      <div class="kr-panel-flat p-4">
         <div class="mb-2 text-sm font-semibold">Current transform</div>
         <pre
           class="overflow-x-auto whitespace-pre-wrap wrap-break-word rounded-2xl bg-base-200 p-3 text-xs font-mono"

--- a/components/abandonware/characters/character-sheet.vue
+++ b/components/abandonware/characters/character-sheet.vue
@@ -68,7 +68,7 @@
           v-else
           class="flex h-full min-h-128 w-full items-center justify-center bg-base-300 p-4 text-center"
         >
-          <div class="rounded-2xl border border-base-300 bg-base-100 p-5">
+          <div class="kr-panel-flat p-5">
             <Icon
               name="kind-icon:palette"
               class="mx-auto h-14 w-14 text-primary"
@@ -130,7 +130,7 @@
           <!-- Sidebar -->
           <aside class="flex flex-col gap-3">
             <!-- Portrait thumbnail -->
-            <article class="rounded-2xl border border-base-300 bg-base-100 p-3">
+            <article class="kr-panel-flat p-3">
               <div
                 class="relative flex aspect-square items-center justify-center overflow-hidden rounded-2xl border border-base-300 bg-base-300"
               >
@@ -160,7 +160,7 @@
             </article>
 
             <!-- Completion checklist -->
-            <article class="rounded-2xl border border-base-300 bg-base-100 p-4">
+            <article class="kr-panel-flat p-4">
               <h3 class="flex items-center gap-2 font-black text-base-content">
                 <Icon name="kind-icon:check" class="h-5 w-5 text-primary" />
                 Completion
@@ -195,7 +195,7 @@
           <!-- Main content -->
           <main class="flex min-w-0 flex-col gap-3">
             <!-- Identity block -->
-            <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+            <section class="kr-panel-flat p-4">
               <div class="flex items-start justify-between gap-3">
                 <div>
                   <p
@@ -367,7 +367,7 @@
               <aside class="flex flex-col gap-3">
                 <!-- Stat tiers -->
                 <article
-                  class="rounded-2xl border border-base-300 bg-base-100 p-4"
+                  class="kr-panel-flat p-4"
                 >
                   <div class="flex items-center justify-between gap-3">
                     <h3
@@ -422,7 +422,7 @@
 
                 <!-- Starting Skills (3 skill slots) -->
                 <article
-                  class="rounded-2xl border border-base-300 bg-base-100 p-4"
+                  class="kr-panel-flat p-4"
                 >
                   <h3
                     class="flex items-center gap-2 font-black text-base-content"

--- a/components/abandonware/pages/super-form.vue
+++ b/components/abandonware/pages/super-form.vue
@@ -4,7 +4,7 @@
     class="kr-unbound flex h-full min-h-0 items-center justify-center overflow-y-auto overscroll-contain p-3 sm:p-6"
   >
     <div
-      class="w-full max-w-xl rounded-2xl border border-base-300 bg-base-100 p-4 shadow-xl sm:p-6"
+      class="w-full max-w-xl kr-panel-flat p-4 shadow-xl sm:p-6"
     >
       <header class="mb-6 text-center">
         <site-logo class="mx-auto mb-4" />

--- a/components/abandonware/scenarios/scenario-intros.vue
+++ b/components/abandonware/scenarios/scenario-intros.vue
@@ -21,7 +21,7 @@
     <div
       v-for="(intro, index) in introEntries"
       :key="index"
-      class="flex flex-col gap-2 rounded-2xl border border-base-300 bg-base-100 p-4"
+      class="flex flex-col gap-2 kr-panel-flat p-4"
     >
       <div class="flex items-center justify-between">
         <span

--- a/components/abandonware/themes/add-theme.vue
+++ b/components/abandonware/themes/add-theme.vue
@@ -44,7 +44,7 @@
             <label
               v-for="color in colorKeys"
               :key="color"
-              class="flex items-center gap-3 rounded-2xl border border-base-300 bg-base-100 px-3 py-3"
+              class="flex items-center gap-3 kr-panel-flat px-3 py-3"
             >
               <span class="min-w-0 flex-1 truncate text-sm font-medium">
                 {{ themeStore.labelFromKey(color) }}
@@ -131,9 +131,7 @@
         </div>
 
         <div class="min-h-0">
-          <div
-            class="rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm"
-          >
+          <div class="kr-panel-flat p-4 shadow-sm">
             <div class="mb-3 flex items-center justify-between gap-3">
               <div>
                 <h3 class="text-lg font-semibold">Live Preview</h3>

--- a/components/abandonware/themes/theme-manager.vue
+++ b/components/abandonware/themes/theme-manager.vue
@@ -50,7 +50,7 @@
 
     <section
       v-else-if="activeTab === 'custom'"
-      class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100"
+      class="flex min-h-0 flex-1 flex-col overflow-hidden kr-panel-flat"
     >
       <div
         class="flex shrink-0 flex-wrap items-center justify-between gap-4 border-b border-base-300 bg-base-200 px-5 py-3"

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -1,8 +1,6 @@
 <!-- /components/academy/academy-style-detail.vue -->
 <template>
-  <article
-    class="flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-100 p-4"
-  >
+  <article class="flex flex-col gap-4 kr-panel-flat p-4">
     <header class="flex flex-wrap items-start justify-between gap-2">
       <div class="flex min-w-0 flex-col gap-1">
         <div class="flex flex-wrap items-center gap-2">

--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -81,7 +81,7 @@
     </header>
 
     <div
-      class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-100 p-4 sm:flex-row sm:items-center sm:justify-between"
+      class="flex flex-col gap-3 kr-panel-flat p-4 sm:flex-row sm:items-center sm:justify-between"
     >
       <div class="min-w-0 flex-1">
         <div class="flex items-center justify-between gap-3">

--- a/components/achievements/achievement-gallery.vue
+++ b/components/achievements/achievement-gallery.vue
@@ -5,7 +5,7 @@
   >
     <!-- ── Header ──────────────────────────────────────────────────────── -->
     <header
-      class="flex items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-100 px-4 py-3"
+      class="flex items-center justify-between gap-3 kr-panel-flat px-4 py-3"
     >
       <div class="flex items-center gap-3">
         <span
@@ -39,7 +39,7 @@
          (interface-vision t-047: one-scroll) ─────────────────────────── -->
     <div class="kr-scroll grid grid-cols-1 gap-4 lg:grid-cols-3">
       <!-- Earned -->
-      <div class="flex flex-col rounded-2xl border border-base-300 bg-base-100">
+      <div class="flex flex-col kr-panel-flat">
         <div class="flex items-center gap-2 border-b border-base-300 px-4 py-3">
           <span
             class="flex h-7 w-7 items-center justify-center rounded-lg bg-success/15 text-success"

--- a/components/art/add-collection.vue
+++ b/components/art/add-collection.vue
@@ -1,7 +1,7 @@
 <!-- /components/content/art/add-collection.vue -->
 <template>
   <section
-    class="rounded-2xl border border-base-300 bg-base-100 p-3"
+    class="kr-panel-flat p-3"
     :class="compact ? 'space-y-2' : 'space-y-3'"
   >
     <button

--- a/components/art/art-facet-selector.vue
+++ b/components/art/art-facet-selector.vue
@@ -1,6 +1,6 @@
 <!-- /components/art/art-facet-selector.vue -->
 <template>
-  <section class="space-y-2 rounded-2xl border border-base-300 bg-base-100 p-3">
+  <section class="space-y-2 kr-panel-flat p-3">
     <div class="flex items-center gap-2">
       <Icon name="kind-icon:tag" class="size-4 text-secondary" />
       <div class="min-w-0 flex-1">

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -4,7 +4,7 @@
     class="flex h-full min-h-0 w-full flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3"
   >
     <header
-      class="flex shrink-0 flex-col gap-2 rounded-2xl border border-base-300 bg-base-100 p-3 md:flex-row md:items-center md:justify-between"
+      class="flex shrink-0 flex-col gap-2 kr-panel-flat p-3 md:flex-row md:items-center md:justify-between"
     >
       <div class="min-w-0">
         <h1 class="text-xl font-black text-primary md:text-2xl">

--- a/components/art/art-maker.vue
+++ b/components/art/art-maker.vue
@@ -5,7 +5,7 @@
       class="mx-auto flex min-h-full w-full max-w-6xl flex-col gap-4 rounded-2xl border border-base-300 bg-base-200 p-4 sm:p-6"
     >
       <header
-        class="rounded-2xl border border-base-300 bg-base-100 p-4 sm:p-5"
+        class="kr-panel-flat p-4 sm:p-5"
       >
         <div
           class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between"
@@ -58,7 +58,7 @@
       </div>
 
       <section
-        class="grid grid-cols-1 gap-4 rounded-2xl border border-base-300 bg-base-100 p-4 lg:grid-cols-3"
+        class="grid grid-cols-1 gap-4 kr-panel-flat p-4 lg:grid-cols-3"
       >
         <label class="form-control">
           <span class="label">
@@ -184,7 +184,7 @@
       </section>
 
       <section
-        class="grid grid-cols-1 gap-4 rounded-2xl border border-base-300 bg-base-100 p-4 xl:grid-cols-[minmax(0,1fr)_320px]"
+        class="grid grid-cols-1 gap-4 kr-panel-flat p-4 xl:grid-cols-[minmax(0,1fr)_320px]"
       >
         <div class="flex min-h-0 flex-col gap-4">
           <label class="form-control">
@@ -374,7 +374,7 @@
         </aside>
       </section>
 
-      <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+      <section class="kr-panel-flat p-4">
         <div
           class="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
         >

--- a/components/art/art-test.vue
+++ b/components/art/art-test.vue
@@ -720,7 +720,7 @@ onMounted(async () => {
       >
         <div class="flex items-center gap-4">
           <div
-            class="flex h-14 w-14 items-center justify-center rounded-2xl border border-base-300 bg-base-100 text-3xl"
+            class="flex h-14 w-14 items-center justify-center kr-panel-flat text-3xl"
           >
             {{ endpointDef.icon }}
           </div>
@@ -1029,7 +1029,7 @@ onMounted(async () => {
             </div>
 
             <div class="grid gap-4 lg:grid-cols-[220px_1fr]">
-              <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+              <div class="kr-panel-flat p-3">
                 <img
                   :src="selectedAnimalDef.path"
                   :alt="selectedAnimalDef.label"
@@ -1082,7 +1082,7 @@ onMounted(async () => {
             </div>
 
             <div class="grid gap-4 lg:grid-cols-[220px_1fr]">
-              <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+              <div class="kr-panel-flat p-3">
                 <img
                   :src="selectedAnimalDef.path"
                   :alt="selectedAnimalDef.label"
@@ -1176,7 +1176,7 @@ onMounted(async () => {
             </div>
 
             <div class="grid gap-4 lg:grid-cols-2">
-              <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+              <div class="kr-panel-flat p-3">
                 <div class="mb-2 text-sm font-bold">
                   {{ selectedAnimalADef.label }}
                 </div>
@@ -1187,7 +1187,7 @@ onMounted(async () => {
                 />
               </div>
 
-              <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+              <div class="kr-panel-flat p-3">
                 <div class="mb-2 text-sm font-bold">
                   {{ selectedAnimalBDef.label }}
                 </div>
@@ -1231,7 +1231,7 @@ onMounted(async () => {
         >
           <div class="mb-3 text-lg font-bold">Payload Preview</div>
           <pre
-            class="overflow-x-auto rounded-2xl border border-base-300 bg-base-100 p-4 text-xs"
+            class="overflow-x-auto kr-panel-flat p-4 text-xs"
             >{{ JSON.stringify(builtPayload, null, 2) }}</pre
           >
         </div>
@@ -1276,7 +1276,7 @@ onMounted(async () => {
 
           <div
             v-if="generationMessage"
-            class="mt-3 rounded-2xl border border-base-300 bg-base-100 p-3 text-sm"
+            class="mt-3 kr-panel-flat p-3 text-sm"
           >
             {{ generationMessage }}
           </div>
@@ -1343,7 +1343,7 @@ onMounted(async () => {
         >
           <div class="mb-3 text-lg font-bold">Raw API / Store Result</div>
           <pre
-            class="overflow-x-auto rounded-2xl border border-base-300 bg-base-100 p-4 text-xs"
+            class="overflow-x-auto kr-panel-flat p-4 text-xs"
             >{{ JSON.stringify(resultData, null, 2) }}</pre
           >
         </div>

--- a/components/art/artjob-failed-page-requeue.vue
+++ b/components/art/artjob-failed-page-requeue.vue
@@ -1,9 +1,6 @@
 <!-- /components/art/artjob-failed-page-requeue.vue -->
 <template>
-  <section
-    v-if="failedJobIds.length || message"
-    class="rounded-2xl border border-base-300 bg-base-100 p-3"
-  >
+  <section v-if="failedJobIds.length || message" class="kr-panel-flat p-3">
     <div class="flex flex-wrap items-center justify-between gap-3">
       <div class="min-w-0">
         <h3 class="text-sm font-semibold">Failed-job recovery</h3>

--- a/components/art/artjob-feedback-manager.vue
+++ b/components/art/artjob-feedback-manager.vue
@@ -1,7 +1,7 @@
 <!-- /components/art/artjob-feedback-manager.vue -->
 <template>
   <section
-    class="flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100"
+    class="flex h-full min-h-0 flex-col overflow-hidden kr-panel-flat"
   >
     <div class="border-b border-base-300 p-3">
       <div class="flex flex-wrap items-start justify-between gap-2">

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -74,7 +74,7 @@
         <div
           v-for="status in summaryStatuses"
           :key="status"
-          class="rounded-2xl border border-base-300 bg-base-100 p-3"
+          class="kr-panel-flat p-3"
         >
           <div
             class="text-[11px] font-semibold uppercase tracking-wide text-base-content/50"
@@ -86,7 +86,7 @@
       </div>
 
       <div class="grid gap-3 xl:grid-cols-2">
-        <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+        <div class="kr-panel-flat p-3">
           <div class="mb-2 flex items-center justify-between gap-2">
             <h3 class="text-sm font-semibold">Private art servers</h3>
             <button
@@ -162,7 +162,7 @@
           </div>
         </div>
 
-        <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+        <div class="kr-panel-flat p-3">
           <div class="mb-2 flex items-center justify-between gap-2">
             <h3 class="text-sm font-semibold">Uptime · {{ windowHours }}h</h3>
             <div
@@ -221,7 +221,7 @@
         </div>
       </div>
 
-      <section class="rounded-2xl border border-base-300 bg-base-100 p-3">
+      <section class="kr-panel-flat p-3">
         <div class="flex flex-col gap-3">
           <div class="flex flex-wrap items-center justify-between gap-2">
             <div class="flex flex-wrap items-center gap-2">

--- a/components/art/artjob-queue-card.vue
+++ b/components/art/artjob-queue-card.vue
@@ -189,7 +189,7 @@
         {{ job.error }}
       </div>
 
-      <details class="rounded-2xl border border-base-300 bg-base-100">
+      <details class="kr-panel-flat">
         <summary class="cursor-pointer px-3 py-2 text-xs font-semibold">
           Full brief and generation fields
         </summary>

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -1,6 +1,6 @@
 <!-- /components/art/entity-art-manager.vue -->
 <template>
-  <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+  <section class="kr-panel-flat p-4">
     <header class="flex flex-wrap items-start gap-2">
       <div class="min-w-0 flex-1">
         <div class="flex items-center gap-2">

--- a/components/art/generate-button.vue
+++ b/components/art/generate-button.vue
@@ -109,7 +109,7 @@
 
     <div
       v-if="showResult && resultImage"
-      class="rounded-2xl border border-base-300 bg-base-100 p-3"
+      class="kr-panel-flat p-3"
     >
       <image-card :art-image="resultImage" />
     </div>

--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -108,9 +108,7 @@
 
     <!-- ── Metadata + options ─────────────────────────────────────────── -->
     <template v-if="queuedFiles.length">
-      <div
-        class="grid gap-4 rounded-2xl border border-base-300 bg-base-100 p-4"
-      >
+      <div class="grid gap-4 kr-panel-flat p-4">
         <!-- Collection selector -->
         <div class="flex flex-col gap-2">
           <label
@@ -363,10 +361,7 @@
         </select>
 
         <Transition name="fade">
-          <div
-            v-if="connectedModelType"
-            class="rounded-2xl border border-base-300 bg-base-100 p-3"
-          >
+          <div v-if="connectedModelType" class="kr-panel-flat p-3">
             <div
               v-if="connectedModelId"
               class="mb-2 flex items-center gap-2 rounded-xl bg-primary/10 px-3 py-2 text-xs"

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -24,7 +24,7 @@
       <section
         class="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_320px]"
       >
-        <div class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <div class="kr-panel-flat p-4">
           <div
             class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
           >
@@ -147,7 +147,7 @@
           </div>
         </div>
 
-        <aside class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <aside class="kr-panel-flat p-4">
           <div class="mb-4 flex items-center justify-between gap-2">
             <div>
               <h2 class="text-xl font-bold text-base-content">Avatar</h2>
@@ -208,7 +208,7 @@
         </aside>
       </section>
 
-      <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+      <section class="kr-panel-flat p-4">
         <div
           class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
         >
@@ -290,7 +290,7 @@
       </section>
 
       <section class="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <div class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <div class="kr-panel-flat p-4">
           <h2 class="mb-3 text-xl font-bold text-base-content">
             Personality and Prompt
           </h2>
@@ -337,7 +337,7 @@
           </div>
         </div>
 
-        <div class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <div class="kr-panel-flat p-4">
           <h2 class="mb-3 text-xl font-bold text-base-content">
             Conversation Intros
           </h2>
@@ -384,7 +384,7 @@
         </div>
       </section>
 
-      <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+      <section class="kr-panel-flat p-4">
         <div
           class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
         >

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -45,7 +45,7 @@
     class="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-y-auto xl:grid-cols-[minmax(0,1fr)_minmax(320px,420px)] xl:overflow-hidden"
   >
     <div
-      class="grid min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden rounded-2xl border border-base-300 bg-base-100"
+      class="grid min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden kr-panel-flat"
     >
       <div class="shrink-0 border-b border-base-300 p-4">
         <div

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -23,7 +23,7 @@
       <section
         class="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_340px]"
       >
-        <div class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <div class="kr-panel-flat p-4">
           <div
             class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
           >
@@ -144,7 +144,7 @@
           </div>
         </div>
 
-        <aside class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <aside class="kr-panel-flat p-4">
           <div class="mb-4 flex items-center justify-between gap-2">
             <div>
               <h2 class="text-xl font-bold text-base-content">Portrait</h2>
@@ -201,7 +201,7 @@
       </section>
 
       <section class="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <div class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <div class="kr-panel-flat p-4">
           <h2 class="mb-3 text-xl font-bold text-base-content">
             Personality and Voice
           </h2>
@@ -239,7 +239,7 @@
           </div>
         </div>
 
-        <div class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <div class="kr-panel-flat p-4">
           <h2 class="mb-3 text-xl font-bold text-base-content">
             Story and Motivation
           </h2>
@@ -279,7 +279,7 @@
         </div>
       </section>
 
-      <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+      <section class="kr-panel-flat p-4">
         <div
           class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
         >
@@ -324,7 +324,7 @@
         :character-id="currentCharacterId"
       />
 
-      <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+      <section class="kr-panel-flat p-4">
         <div
           class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
         >
@@ -397,7 +397,7 @@
         </div>
       </section>
 
-      <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+      <section class="kr-panel-flat p-4">
         <div
           class="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
         >

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -32,7 +32,7 @@
       class="kr-panes grid-cols-1 xl:grid-cols-[minmax(320px,440px)_minmax(0,1fr)]"
     >
       <aside class="kr-pane-scroll flex flex-col gap-4">
-        <section class="rounded-2xl border border-base-300 bg-base-100 p-3">
+        <section class="kr-panel-flat p-3">
           <div class="mb-3 flex items-center justify-between gap-3">
             <div class="min-w-0">
               <h2 class="truncate text-xl font-black text-base-content">
@@ -106,7 +106,7 @@
 
         <section
           v-if="characterStore.selectedCharacter"
-          class="rounded-2xl border border-base-300 bg-base-100 p-4"
+          class="kr-panel-flat p-4"
         >
           <h2 class="text-lg font-bold text-base-content">Stats</h2>
 
@@ -127,7 +127,7 @@
           </div>
         </section>
 
-        <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <section class="kr-panel-flat p-4">
           <h2 class="text-lg font-bold text-base-content">
             Interaction Summary
           </h2>
@@ -180,9 +180,7 @@
       </aside>
 
       <main class="kr-pane gap-4">
-        <div
-          class="flex shrink-0 flex-wrap gap-2 rounded-2xl border border-base-300 bg-base-100 p-2"
-        >
+        <div class="flex shrink-0 flex-wrap gap-2 kr-panel-flat p-2">
           <button
             v-for="tab in modeTabs"
             :key="tab.key"
@@ -199,10 +197,7 @@
         </div>
 
         <section class="kr-pane-scroll">
-          <article
-            v-if="activeMode === 'chat'"
-            class="rounded-2xl border border-base-300 bg-base-100 p-4"
-          >
+          <article v-if="activeMode === 'chat'" class="kr-panel-flat p-4">
             <div
               class="mb-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-between"
             >
@@ -354,7 +349,7 @@
 
           <article
             v-else-if="activeMode === 'adventure'"
-            class="rounded-2xl border border-base-300 bg-base-100 p-4"
+            class="kr-panel-flat p-4"
           >
             <h2 class="mb-3 text-xl font-bold text-base-content">
               Adventure Setup
@@ -423,7 +418,7 @@
 
           <article
             v-else-if="activeMode === 'prompt'"
-            class="rounded-2xl border border-base-300 bg-base-100 p-4"
+            class="kr-panel-flat p-4"
           >
             <h2 class="mb-3 text-xl font-bold text-base-content">
               Character Prompt
@@ -463,10 +458,7 @@
             </div>
           </article>
 
-          <article
-            v-else
-            class="rounded-2xl border border-base-300 bg-base-100 p-4"
-          >
+          <article v-else class="kr-panel-flat p-4">
             <h2 class="mb-3 text-xl font-bold text-base-content">
               Raw Character Context
             </h2>

--- a/components/characters/character-facet-picker.vue
+++ b/components/characters/character-facet-picker.vue
@@ -1,6 +1,6 @@
 <!-- /components/characters/character-facet-picker.vue -->
 <template>
-  <section class="space-y-3 rounded-2xl border border-base-300 bg-base-100 p-4">
+  <section class="space-y-3 kr-panel-flat p-4">
     <div class="flex flex-wrap items-center gap-2">
       <Icon name="kind-icon:tag" class="size-4 text-secondary" />
       <div class="min-w-0 flex-1">

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -3,9 +3,7 @@
   <section
     class="flex h-full min-h-0 w-full flex-col gap-4 rounded-2xl bg-base-200 p-4"
   >
-    <header
-      class="rounded-2xl border border-base-300 bg-base-100 p-4 text-center shadow-md"
-    >
+    <header class="kr-panel-flat p-4 text-center shadow-md">
       <h1 class="text-2xl font-bold text-primary md:text-3xl">
         Character Interact
       </h1>
@@ -39,9 +37,7 @@
     />
 
     <section v-else class="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
-      <div
-        class="flex shrink-0 flex-wrap gap-2 rounded-2xl border border-base-300 bg-base-100 p-2"
-      >
+      <div class="flex shrink-0 flex-wrap gap-2 kr-panel-flat p-2">
         <button
           v-for="tab in modeTabs"
           :key="tab.key"
@@ -71,7 +67,7 @@
         class="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-hidden xl:grid-cols-[minmax(0,1fr)_minmax(320px,420px)]"
       >
         <div class="flex min-h-0 min-w-0 flex-col gap-4 overflow-y-auto">
-          <article class="rounded-2xl border border-base-300 bg-base-100 p-4">
+          <article class="kr-panel-flat p-4">
             <div class="mb-3 flex items-center justify-between gap-2">
               <div>
                 <h2 class="text-xl font-bold text-base-content">
@@ -102,10 +98,7 @@
             </div>
           </article>
 
-          <article
-            v-if="activeMode === 'chat'"
-            class="rounded-2xl border border-base-300 bg-base-100 p-4"
-          >
+          <article v-if="activeMode === 'chat'" class="kr-panel-flat p-4">
             <div
               class="mb-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-between"
             >
@@ -251,7 +244,7 @@
 
           <article
             v-else-if="activeMode === 'adventure'"
-            class="rounded-2xl border border-base-300 bg-base-100 p-4"
+            class="kr-panel-flat p-4"
           >
             <h2 class="mb-3 text-xl font-bold text-base-content">
               Adventure Setup
@@ -307,7 +300,7 @@
 
           <article
             v-else-if="activeMode === 'prompt'"
-            class="rounded-2xl border border-base-300 bg-base-100 p-4"
+            class="kr-panel-flat p-4"
           >
             <h2 class="mb-3 text-xl font-bold text-base-content">
               Character Prompt
@@ -347,10 +340,7 @@
             </div>
           </article>
 
-          <article
-            v-else
-            class="rounded-2xl border border-base-300 bg-base-100 p-4"
-          >
+          <article v-else class="kr-panel-flat p-4">
             <h2 class="mb-3 text-xl font-bold text-base-content">
               Raw Character Context
             </h2>
@@ -364,7 +354,7 @@
         </div>
 
         <aside class="flex min-h-0 flex-col gap-4 overflow-hidden">
-          <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+          <section class="kr-panel-flat p-4">
             <h2 class="text-lg font-bold text-base-content">
               Interaction Summary
             </h2>
@@ -415,7 +405,7 @@
             </div>
           </section>
 
-          <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+          <section class="kr-panel-flat p-4">
             <div class="mb-3 flex items-center justify-between gap-2">
               <div>
                 <h2 class="text-lg font-bold text-base-content">
@@ -458,7 +448,7 @@
 
           <section
             v-if="adventurePrompt"
-            class="min-h-0 flex-1 overflow-hidden rounded-2xl border border-base-300 bg-base-100 p-4"
+            class="min-h-0 flex-1 overflow-hidden kr-panel-flat p-4"
           >
             <h2 class="mb-3 text-lg font-bold text-base-content">
               Adventure Prompt Preview

--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -34,7 +34,7 @@
 
     <div class="grid gap-5 xl:grid-cols-[minmax(18rem,0.8fr)_minmax(0,1.2fr)]">
       <article class="flex flex-col gap-3 rounded-3xl border border-base-300 bg-base-200/40 p-4">
-        <div class="relative overflow-hidden rounded-2xl border border-base-300 bg-base-100">
+        <div class="relative overflow-hidden kr-panel-flat">
           <img
             v-if="displayUrl"
             :src="displayUrl"

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -4,10 +4,7 @@
      undefined, which Vue drops entirely, leaving the reader's global theme
      in charge — see composables/useStorybookMode.ts. -->
 <template>
-  <section
-    :data-theme="dataTheme"
-    class="kr-surface gap-4 rounded-2xl border border-base-300 bg-base-100 p-4"
-  >
+  <section :data-theme="dataTheme" class="kr-surface gap-4 kr-panel-flat p-4">
     <header class="flex shrink-0 flex-wrap items-start gap-3">
       <div
         class="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-primary/30 bg-primary/10 text-primary"
@@ -345,9 +342,7 @@
           </div>
 
           <dl class="grid gap-3 md:grid-cols-2">
-            <div
-              class="rounded-2xl border border-base-300 bg-base-100 p-3 md:col-span-2"
-            >
+            <div class="kr-panel-flat p-3 md:col-span-2">
               <dt
                 class="text-[0.7rem] font-bold uppercase tracking-wide text-primary/70"
               >
@@ -357,19 +352,19 @@
                 {{ store.setupDraft.premise }}
               </dd>
             </div>
-            <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+            <div class="kr-panel-flat p-3">
               <dt class="text-xs font-bold text-base-content/55">Narration</dt>
               <dd class="mt-1 text-sm capitalize">
                 {{ store.setupDraft.narratorStyle }} · {{ structureLabel }}
               </dd>
             </div>
-            <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+            <div class="kr-panel-flat p-3">
               <dt class="text-xs font-bold text-base-content/55">Setting</dt>
               <dd class="mt-1 text-sm">
                 {{ selectedLocation?.title || 'Invented from the premise' }}
               </dd>
             </div>
-            <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+            <div class="kr-panel-flat p-3">
               <dt class="text-xs font-bold text-base-content/55">Cast</dt>
               <dd class="mt-1 text-sm">
                 {{
@@ -379,7 +374,7 @@
                 }}
               </dd>
             </div>
-            <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+            <div class="kr-panel-flat p-3">
               <dt class="text-xs font-bold text-base-content/55">Facets</dt>
               <dd class="mt-1 text-sm">
                 {{
@@ -389,9 +384,7 @@
                 }}
               </dd>
             </div>
-            <div
-              class="rounded-2xl border border-base-300 bg-base-100 p-3 md:col-span-2"
-            >
+            <div class="kr-panel-flat p-3 md:col-span-2">
               <dt class="text-xs font-bold text-base-content/55">
                 Possible Rewards
               </dt>
@@ -405,7 +398,7 @@
             </div>
             <div
               v-if="store.setupDraft.notes.trim()"
-              class="rounded-2xl border border-base-300 bg-base-100 p-3 md:col-span-2"
+              class="kr-panel-flat p-3 md:col-span-2"
             >
               <dt class="text-xs font-bold text-base-content/55">
                 Additional direction

--- a/components/content-visibility-controls.vue
+++ b/components/content-visibility-controls.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="space-y-2 rounded-2xl border border-base-300 bg-base-100 p-3">
+  <section class="space-y-2 kr-panel-flat p-3">
     <div class="flex flex-wrap items-start justify-between gap-2">
       <div>
         <h3 class="text-sm font-bold">Content visibility</h3>

--- a/components/dreams/dream-art-chooser.vue
+++ b/components/dreams/dream-art-chooser.vue
@@ -146,7 +146,7 @@
     </div>
 
     <div
-      class="mt-3 grid max-h-80 grid-cols-2 gap-2 overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
+      class="mt-3 grid max-h-80 grid-cols-2 gap-2 overflow-y-auto kr-panel-flat p-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
     >
       <image-card
         v-for="image in visibleImages"

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -3,7 +3,7 @@
   <section
     class="flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden rounded-2xl border border-base-300 bg-base-200 p-3"
   >
-    <header class="shrink-0 rounded-2xl border border-base-300 bg-base-100 p-4">
+    <header class="shrink-0 kr-panel-flat p-4">
       <div
         class="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between"
       >
@@ -70,7 +70,7 @@
       class="kr-panes grid-cols-1 xl:grid-cols-[22rem_minmax(0,1fr)_22rem]"
     >
       <aside
-        class="kr-pane rounded-2xl border border-base-300 bg-base-100"
+        class="kr-pane kr-panel-flat"
       >
         <div class="shrink-0 border-b border-base-300 bg-base-200 p-3">
           <div class="flex items-center justify-between gap-2">
@@ -140,7 +140,7 @@
         </div>
       </aside>
 
-      <main class="kr-pane rounded-2xl border border-base-300 bg-base-100">
+      <main class="kr-pane kr-panel-flat">
         <section class="shrink-0 border-b border-base-300 bg-base-200 p-3">
           <div class="grid gap-3 lg:grid-cols-[minmax(0,1fr)_14rem]">
             <label class="form-control">
@@ -256,7 +256,7 @@
               <article
                 v-for="candidate in candidates"
                 :key="candidate.id"
-                class="rounded-2xl border border-base-300 bg-base-100 p-3"
+                class="kr-panel-flat p-3"
                 :class="{
                   'border-success/60 bg-success/10':
                     candidate.status === 'accepted',
@@ -396,7 +396,7 @@
       </main>
 
       <aside
-        class="kr-pane gap-3 rounded-2xl border border-base-300 bg-base-100 p-3"
+        class="kr-pane gap-3 kr-panel-flat p-3"
       >
         <section class="rounded-2xl border border-base-300 bg-base-200 p-3">
           <h2 class="mb-3 text-lg font-black">Text Server</h2>

--- a/components/dreams/dream-list.vue
+++ b/components/dreams/dream-list.vue
@@ -1,8 +1,6 @@
 <!-- /components/dreams/dream-list.vue -->
 <template>
-  <section
-    class="flex min-h-0 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100"
-  >
+  <section class="flex min-h-0 flex-col overflow-hidden kr-panel-flat">
     <header
       class="flex shrink-0 items-start justify-between gap-2 border-b border-base-300 bg-base-200 p-3"
     >

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -74,7 +74,7 @@
     <main class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3">
       <div class="grid gap-3 xl:grid-cols-[minmax(0,1fr)_22rem]">
         <section class="grid gap-3">
-          <div class="rounded-2xl border border-base-300 bg-base-100 p-4">
+          <div class="kr-panel-flat p-4">
             <div class="grid gap-3 lg:grid-cols-[minmax(0,1fr)_14rem]">
               <label class="form-control">
                 <span class="label py-1">
@@ -140,7 +140,7 @@
             </div>
           </div>
 
-          <div class="rounded-2xl border border-base-300 bg-base-100 p-4">
+          <div class="kr-panel-flat p-4">
             <label class="form-control">
               <span class="label py-1">
                 <span
@@ -191,7 +191,7 @@
             label="Dream Facets"
           />
 
-          <div class="rounded-2xl border border-base-300 bg-base-100 p-4">
+          <div class="kr-panel-flat p-4">
             <div class="flex flex-wrap items-center justify-between gap-2">
               <div>
                 <h2 class="text-lg font-black">Art Prompt</h2>
@@ -216,7 +216,7 @@
             />
           </div>
 
-          <div class="rounded-2xl border border-base-300 bg-base-100 p-4">
+          <div class="kr-panel-flat p-4">
             <div class="grid gap-3 md:grid-cols-3">
               <label class="form-control">
                 <span class="label py-1"
@@ -276,7 +276,7 @@
         </section>
 
         <aside class="grid h-fit gap-3 xl:sticky xl:top-3">
-          <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+          <section class="kr-panel-flat p-4">
             <h2 class="text-lg font-black">Visibility</h2>
             <div class="mt-3 grid gap-2">
               <label
@@ -315,7 +315,7 @@
             </div>
           </section>
 
-          <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+          <section class="kr-panel-flat p-4">
             <h2 class="text-lg font-black">Preview</h2>
             <div
               class="mt-3 rounded-2xl border border-base-300 bg-base-200 p-3"
@@ -345,7 +345,7 @@
             </div>
           </section>
 
-          <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+          <section class="kr-panel-flat p-4">
             <h2 class="text-lg font-black">Checks</h2>
             <div class="mt-3 grid gap-2 text-sm">
               <div

--- a/components/dreams/dream-narration.vue
+++ b/components/dreams/dream-narration.vue
@@ -3,7 +3,7 @@
   <section
     class="flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden rounded-2xl border border-base-300 bg-base-200 p-3"
   >
-    <header class="shrink-0 rounded-2xl border border-base-300 bg-base-100 p-3">
+    <header class="shrink-0 kr-panel-flat p-3">
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div class="min-w-0">
           <h1 class="truncate text-lg font-black text-primary">
@@ -55,9 +55,7 @@
       </nav>
     </header>
 
-    <main
-      class="min-h-0 flex-1 overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-3"
-    >
+    <main class="min-h-0 flex-1 overflow-y-auto kr-panel-flat p-3">
       <div
         v-if="workspaceStore.dreamPanel === 'asset-sheet'"
         class="grid gap-3"

--- a/components/dreams/dream-relationship-gallery.vue
+++ b/components/dreams/dream-relationship-gallery.vue
@@ -5,9 +5,7 @@
            its own below it. These panels are inset inside a Dream workspace,
            so a second full-width band costs the host page a row it did not
            choose to spend. -->
-    <header
-      class="shrink-0 rounded-2xl border border-base-300 bg-base-100 px-3 py-2"
-    >
+    <header class="shrink-0 kr-panel-flat px-3 py-2">
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div class="min-w-0">
           <h2 class="truncate text-lg font-black text-base-content">

--- a/components/facets/facet-picker.vue
+++ b/components/facets/facet-picker.vue
@@ -1,6 +1,6 @@
 <!-- /components/facets/facet-picker.vue -->
 <template>
-  <section class="space-y-3 rounded-2xl border border-base-300 bg-base-100 p-4">
+  <section class="space-y-3 kr-panel-flat p-4">
     <div class="flex flex-wrap items-center gap-2">
       <Icon name="kind-icon:tag" class="size-4 text-secondary" />
       <div class="min-w-0 flex-1">

--- a/components/giftshop/giftshop-manager.vue
+++ b/components/giftshop/giftshop-manager.vue
@@ -3,7 +3,7 @@
   <section class="flex h-full min-h-0 w-full flex-col overflow-hidden">
     <div
       v-if="isLoadingManager || managerError"
-      class="mb-3 flex shrink-0 flex-wrap items-center justify-between gap-2 rounded-2xl border border-base-300 bg-base-100 p-3 text-sm shadow"
+      class="mb-3 flex shrink-0 flex-wrap items-center justify-between gap-2 kr-panel-flat p-3 text-sm shadow"
     >
       <p
         class="min-w-0 flex-1 text-base-content/70"
@@ -35,7 +35,7 @@
           activeTab === 'mana' ||
           activeTab === 'forum'
         "
-        class="flex h-full min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100"
+        class="flex h-full min-h-0 flex-1 flex-col overflow-hidden kr-panel-flat"
       >
         <div class="kr-scroll overscroll-contain p-4">
           <template v-if="activeTab === 'community'">

--- a/components/giftshop/shopping-cart.vue
+++ b/components/giftshop/shopping-cart.vue
@@ -56,7 +56,7 @@
         <article
           v-for="item in cartStore.items"
           :key="item.id"
-          class="flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm sm:flex-row sm:items-center"
+          class="flex flex-col gap-4 kr-panel-flat p-4 shadow-sm sm:flex-row sm:items-center"
         >
           <img
             :src="item.imageUrl"

--- a/components/lora/add-lora.vue
+++ b/components/lora/add-lora.vue
@@ -8,7 +8,7 @@
 -->
 <template>
   <form
-    class="flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-100 p-4"
+    class="flex flex-col gap-4 kr-panel-flat p-4"
     @submit.prevent="submitLora"
   >
     <div class="flex items-start justify-between gap-3">

--- a/components/model-builder/model-builder-batch-editor.vue
+++ b/components/model-builder/model-builder-batch-editor.vue
@@ -7,10 +7,7 @@
   fine-tuning to the existing item panel via the select-item event.
 -->
 <template>
-  <div
-    v-if="group"
-    class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-100 p-3"
-  >
+  <div v-if="group" class="flex flex-col gap-3 kr-panel-flat p-3">
     <!-- Header -->
     <div class="flex items-start justify-between gap-2">
       <div>

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -2,7 +2,7 @@
 <template>
   <div
     v-if="item"
-    class="flex min-h-0 flex-1 flex-col gap-2 rounded-2xl border border-base-300 bg-base-100 p-3"
+    class="flex min-h-0 flex-1 flex-col gap-2 kr-panel-flat p-3"
   >
     <div class="flex items-center gap-2">
       <h4 class="text-sm font-black text-base-content">{{ item.label }}</h4>

--- a/components/model/add-model.vue
+++ b/components/model/add-model.vue
@@ -9,7 +9,7 @@
 -->
 <template>
   <form
-    class="flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-100 p-4"
+    class="flex flex-col gap-4 kr-panel-flat p-4"
     @submit.prevent="submitModel"
   >
     <div class="flex items-start justify-between gap-3">

--- a/components/navigation/login-switcher.vue
+++ b/components/navigation/login-switcher.vue
@@ -26,7 +26,7 @@
 
     <section
       v-if="store.isOpen"
-      class="absolute right-0 top-full z-50 mt-2 flex w-80 max-w-[calc(100vw-1rem)] flex-col gap-3 rounded-2xl border border-base-300 bg-base-100 p-3 shadow-2xl"
+      class="absolute right-0 top-full z-50 mt-2 flex w-80 max-w-[calc(100vw-1rem)] flex-col gap-3 kr-panel-flat p-3 shadow-2xl"
     >
       <header class="flex items-center gap-3 rounded-2xl bg-base-200 p-3">
         <img

--- a/components/navigation/maturity-toggle.vue
+++ b/components/navigation/maturity-toggle.vue
@@ -6,7 +6,7 @@
   >
     <template v-if="variant === 'resource'">
       <label
-        class="flex cursor-pointer items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-100 px-3 py-2"
+        class="flex cursor-pointer items-center justify-between gap-3 kr-panel-flat px-3 py-2"
         :title="buttonTitle"
       >
         <span class="flex min-w-0 items-center gap-3">

--- a/components/navigation/navigation-trimmed.vue
+++ b/components/navigation/navigation-trimmed.vue
@@ -35,7 +35,7 @@
 
     <p
       v-if="!filteredChannels.length"
-      class="rounded-2xl border border-base-300 bg-base-100 p-6 text-center text-sm text-base-content/60"
+      class="kr-panel-flat p-6 text-center text-sm text-base-content/60"
     >
       No destinations match “{{ query }}”.
     </p>

--- a/components/navigation/server-selector.vue
+++ b/components/navigation/server-selector.vue
@@ -110,7 +110,7 @@
             </div>
 
             <div class="mt-3 grid gap-3">
-              <article class="rounded-2xl border border-base-300 bg-base-100 p-3">
+              <article class="kr-panel-flat p-3">
                 <div class="flex items-start justify-between gap-3">
                   <div class="min-w-0">
                     <p class="font-black">OpenAI</p>
@@ -164,7 +164,7 @@
                 </form>
               </article>
 
-              <article class="rounded-2xl border border-base-300 bg-base-100 p-3">
+              <article class="kr-panel-flat p-3">
                 <div class="flex items-start justify-between gap-3">
                   <div class="min-w-0">
                     <p class="font-black">Anthropic</p>
@@ -217,7 +217,7 @@
               <article
                 v-for="server in localServers"
                 :key="server.id"
-                class="rounded-2xl border border-base-300 bg-base-100 p-3"
+                class="kr-panel-flat p-3"
               >
                 <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <div class="min-w-0">

--- a/components/newsfeed/newsfeed-feed.vue
+++ b/components/newsfeed/newsfeed-feed.vue
@@ -95,7 +95,7 @@
 
       <div
         v-else-if="isLoading && !allItems.length"
-        class="flex min-h-40 items-center justify-center rounded-2xl border border-base-300 bg-base-100"
+        class="flex min-h-40 items-center justify-center kr-panel-flat"
       >
         <span class="loading loading-spinner loading-md text-primary" />
         <span class="sr-only">Loading the newsfeed…</span>

--- a/components/pages/wishmaster-page.vue
+++ b/components/pages/wishmaster-page.vue
@@ -45,7 +45,7 @@
         <h3 class="text-xs font-bold uppercase tracking-wide text-base-content/50">Recent wish dreams</h3>
         <span v-if="dreamStore.loading" class="loading loading-spinner loading-xs text-primary" />
       </div>
-      <article v-for="wish in recentWishes" :key="wish.id" class="rounded-2xl border border-base-300 bg-base-100 px-4 py-3">
+      <article v-for="wish in recentWishes" :key="wish.id" class="kr-panel-flat px-4 py-3">
         <div class="flex items-start gap-3">
           <Icon name="kind-icon:sparkles" class="mt-0.5 size-4 shrink-0 text-primary" />
           <div class="min-w-0 flex-1">

--- a/components/projects/project-placement-manager.vue
+++ b/components/projects/project-placement-manager.vue
@@ -55,7 +55,7 @@
       </section>
 
       <section
-        class="flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm sm:p-5"
+        class="flex flex-col gap-4 kr-panel-flat p-4 shadow-sm sm:p-5"
       >
         <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div>
@@ -117,7 +117,7 @@
 
       <section
         v-if="result"
-        class="grid gap-4 rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm md:grid-cols-2 xl:grid-cols-4 xl:p-5"
+        class="grid gap-4 kr-panel-flat p-4 shadow-sm md:grid-cols-2 xl:grid-cols-4 xl:p-5"
       >
         <article>
           <div class="flex items-center justify-between gap-2">

--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -442,10 +442,7 @@ onMounted(async () => {
       </div>
     </header>
 
-    <div
-      v-if="showAddChoice"
-      class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-100 p-4"
-    >
+    <div v-if="showAddChoice" class="flex flex-col gap-3 kr-panel-flat p-4">
       <p class="text-sm font-bold">What are you adding?</p>
       <div class="flex flex-wrap gap-2">
         <button

--- a/components/rewards/add-reward.vue
+++ b/components/rewards/add-reward.vue
@@ -149,7 +149,7 @@
         </label>
       </section>
 
-      <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+      <section class="kr-panel-flat p-4">
         <div class="mb-4">
           <h2 class="text-xl font-bold text-base-content">Publishing</h2>
           <p class="text-sm text-base-content/70">
@@ -182,7 +182,7 @@
         </div>
       </section>
 
-      <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+      <section class="kr-panel-flat p-4">
         <div
           class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
         >
@@ -204,7 +204,7 @@
         <choice-manager label="rewardEssence" model="Reward" />
       </section>
 
-      <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+      <section class="kr-panel-flat p-4">
         <div
           class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
         >

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -28,7 +28,7 @@
     -->
     <header
       v-if="isInteractMode"
-      class="flex shrink-0 items-center gap-3 rounded-2xl border border-base-300 bg-base-100 p-3 shadow-md"
+      class="flex shrink-0 items-center gap-3 kr-panel-flat p-3 shadow-md"
     >
       <button
         class="btn btn-ghost btn-sm shrink-0 rounded-xl"
@@ -75,7 +75,7 @@
       class="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-y-auto xl:grid-cols-[minmax(0,1fr)_minmax(320px,440px)] xl:overflow-hidden"
     >
       <div
-        class="grid min-h-[70vh] grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden rounded-2xl border border-base-300 bg-base-100 xl:min-h-0"
+        class="grid min-h-[70vh] grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden kr-panel-flat xl:min-h-0"
       >
         <div class="shrink-0 border-b border-base-300 p-4">
           <article v-if="rewardStore.selectedReward">
@@ -175,7 +175,7 @@
           @choose="handleChoiceSelected"
         >
           <template v-if="canShowCustomFollowup" #footer>
-            <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+            <div class="kr-panel-flat p-3">
               <label class="form-control">
                 <span class="label py-1">
                   <span

--- a/components/rewards/reward-facet-picker.vue
+++ b/components/rewards/reward-facet-picker.vue
@@ -1,6 +1,6 @@
 <!-- /components/rewards/reward-facet-picker.vue -->
 <template>
-  <section class="space-y-3 rounded-2xl border border-base-300 bg-base-100 p-4">
+  <section class="space-y-3 kr-panel-flat p-4">
     <div class="flex flex-wrap items-center gap-2">
       <Icon name="kind-icon:tag" class="size-4 text-secondary" />
       <div class="min-w-0 flex-1">

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -101,9 +101,7 @@
           />
         </label>
 
-        <details
-          class="rounded-2xl border border-base-300 bg-base-100 p-4 lg:col-span-2"
-        >
+        <details class="kr-panel-flat p-4 lg:col-span-2">
           <summary
             class="cursor-pointer text-sm font-bold text-base-content/60"
           >
@@ -119,7 +117,7 @@
         </details>
       </section>
 
-      <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+      <section class="kr-panel-flat p-4">
         <div class="mb-4">
           <h2 class="text-xl font-bold text-base-content">Publishing</h2>
           <p class="text-sm text-base-content/70">
@@ -153,7 +151,7 @@
         </div>
       </section>
 
-      <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+      <section class="kr-panel-flat p-4">
         <div class="mb-4 flex items-center justify-between gap-2">
           <div>
             <h2 class="text-xl font-bold text-base-content">Opening Choices</h2>
@@ -216,7 +214,7 @@
         </div>
       </section>
 
-      <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+      <section class="kr-panel-flat p-4">
         <div
           class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
         >

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -3,7 +3,7 @@
   <section class="flex h-full min-h-0 w-full flex-col gap-3">
     <header
       v-if="showHeader"
-      class="flex shrink-0 flex-col gap-2 rounded-2xl border border-base-300 bg-base-100 px-3 py-2"
+      class="flex shrink-0 flex-col gap-2 kr-panel-flat px-3 py-2"
     >
       <div class="flex items-center justify-between gap-3">
         <div class="min-w-0">

--- a/components/scenarios/scenario-relationship-gallery.vue
+++ b/components/scenarios/scenario-relationship-gallery.vue
@@ -5,9 +5,7 @@
            its own below it. These panels are inset inside a Dream workspace,
            so a second full-width band costs the host page a row it did not
            choose to spend. -->
-    <header
-      class="shrink-0 rounded-2xl border border-base-300 bg-base-100 px-3 py-2"
-    >
+    <header class="shrink-0 kr-panel-flat px-3 py-2">
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div class="min-w-0">
           <h2 class="truncate text-lg font-black text-base-content">
@@ -96,7 +94,7 @@
         v-else-if="!resolvedDreamId && requireDreamContext"
         class="flex h-full min-h-48 flex-col gap-3 rounded-2xl border border-warning/40 bg-warning/10 p-3"
       >
-        <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+        <div class="kr-panel-flat p-3">
           <h3 class="font-black text-warning">Choose a Dream first</h3>
           <p class="mt-1 text-sm text-base-content/70">
             This Scenario view needs a Dream anchor before it can show useful

--- a/components/scenarios/scenario-story.vue
+++ b/components/scenarios/scenario-story.vue
@@ -24,7 +24,7 @@
     class="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto overscroll-contain"
   >
     <div
-      class="flex shrink-0 items-center justify-between gap-2 rounded-2xl border border-base-300 bg-base-100 p-2 pl-1 shadow-sm"
+      class="flex shrink-0 items-center justify-between gap-2 kr-panel-flat p-2 pl-1 shadow-sm"
     >
       <div class="flex min-w-0 items-center gap-1">
         <button
@@ -109,7 +109,7 @@
 
     <article
       v-if="introChoices.length"
-      class="shrink-0 rounded-2xl border border-base-300 bg-base-100 p-4 shadow-md"
+      class="shrink-0 kr-panel-flat p-4 shadow-md"
     >
       <h2 class="text-smart-heading font-black text-base-content">
         How does it begin?
@@ -131,9 +131,7 @@
       />
     </article>
 
-    <article
-      class="shrink-0 rounded-2xl border border-base-300 bg-base-100 p-4 shadow-md"
-    >
+    <article class="shrink-0 kr-panel-flat p-4 shadow-md">
       <h2 class="text-smart-heading font-black text-base-content">Direction</h2>
 
       <p class="mt-0.5 text-smart text-base-content/60">
@@ -205,7 +203,7 @@
 
   <section
     v-else
-    class="grid min-h-0 flex-1 grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden rounded-2xl border border-base-300 bg-base-100"
+    class="grid min-h-0 flex-1 grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden kr-panel-flat"
   >
     <header
       class="flex shrink-0 items-center justify-between gap-3 border-b border-base-300 bg-base-100 p-3"

--- a/components/screenfx/animation-selector.vue
+++ b/components/screenfx/animation-selector.vue
@@ -1,7 +1,7 @@
 <!-- /components/screenfx/animation-selector.vue -->
 <template>
   <section
-    class="flex min-w-0 flex-col gap-4 rounded-2xl border border-base-300 bg-base-100 p-4"
+    class="flex min-w-0 flex-col gap-4 kr-panel-flat p-4"
   >
     <header class="flex flex-wrap items-start justify-between gap-3">
       <div class="flex min-w-0 items-center gap-3">

--- a/components/servers/add-checkpoint.vue
+++ b/components/servers/add-checkpoint.vue
@@ -1,7 +1,7 @@
 <!-- /components/content/art/add-checkpoint.vue -->
 <template>
   <form
-    class="flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-100 p-4"
+    class="flex flex-col gap-4 kr-panel-flat p-4"
     @submit.prevent="submitCheckpoint"
   >
     <div class="flex items-start justify-between gap-3">

--- a/components/servers/add-server.vue
+++ b/components/servers/add-server.vue
@@ -1,7 +1,7 @@
 <!-- /components/server/add-server.vue -->
 <template>
   <form
-    class="flex max-h-[min(760px,88vh)] flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100"
+    class="flex max-h-[min(760px,88vh)] flex-col overflow-hidden kr-panel-flat"
     @submit.prevent="saveServer"
   >
     <header

--- a/components/servers/server-interact.vue
+++ b/components/servers/server-interact.vue
@@ -2,7 +2,7 @@
 <template>
   <section class="flex w-full flex-col gap-4 rounded-2xl bg-base-200 p-4">
     <header
-      class="flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-100 p-4 text-center shadow-md lg:flex-row lg:items-center lg:justify-between lg:text-left"
+      class="flex flex-col gap-4 kr-panel-flat p-4 text-center shadow-md lg:flex-row lg:items-center lg:justify-between lg:text-left"
     >
       <div class="flex flex-wrap justify-center gap-2 lg:justify-end">
         <button
@@ -39,14 +39,14 @@
     <add-server v-if="showServerForm" />
 
     <div class="grid gap-4 lg:grid-cols-2">
-      <div class="rounded-2xl border border-base-300 bg-base-100 p-4">
+      <div class="kr-panel-flat p-4">
         <h2 class="font-black text-primary">Active Art Server</h2>
         <p class="mt-1 text-sm text-base-content/60">
           {{ artSummary }}
         </p>
       </div>
 
-      <div class="rounded-2xl border border-base-300 bg-base-100 p-4">
+      <div class="kr-panel-flat p-4">
         <h2 class="font-black text-secondary">Active Text Server</h2>
         <p class="mt-1 text-sm text-base-content/60">
           {{ textSummary }}

--- a/components/servers/server-manager.vue
+++ b/components/servers/server-manager.vue
@@ -3,7 +3,7 @@
   <section class="flex h-full min-h-0 flex-col overflow-hidden">
     <div
       v-if="isLoadingManager || managerError"
-      class="mb-4 shrink-0 rounded-2xl border border-base-300 bg-base-100 p-4"
+      class="mb-4 shrink-0 kr-panel-flat p-4"
     >
       <div v-if="isLoadingManager" class="flex items-center gap-2 text-sm">
         <span class="loading loading-spinner loading-sm text-primary" />

--- a/components/servers/server-status.vue
+++ b/components/servers/server-status.vue
@@ -1,6 +1,6 @@
 <!-- /components/content/art/server-model-status.vue -->
 <template>
-  <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+  <section class="kr-panel-flat p-4">
     <div class="flex flex-col gap-4">
       <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div class="min-w-0">

--- a/components/storybook/storybook-state-panel.vue
+++ b/components/storybook/storybook-state-panel.vue
@@ -12,7 +12,7 @@
     </summary>
 
     <div class="mt-3 grid gap-3 lg:grid-cols-3">
-      <section class="rounded-2xl border border-base-300 bg-base-100 p-3">
+      <section class="kr-panel-flat p-3">
         <h3 class="text-xs font-bold uppercase tracking-wide text-base-content/55">
           Inventory
         </h3>
@@ -51,7 +51,7 @@
         </p>
       </section>
 
-      <section class="rounded-2xl border border-base-300 bg-base-100 p-3">
+      <section class="kr-panel-flat p-3">
         <h3 class="text-xs font-bold uppercase tracking-wide text-base-content/55">
           Consequences
         </h3>
@@ -77,7 +77,7 @@
         </p>
       </section>
 
-      <section class="rounded-2xl border border-base-300 bg-base-100 p-3">
+      <section class="kr-panel-flat p-3">
         <h3 class="text-xs font-bold uppercase tracking-wide text-base-content/55">
           Branch path
         </h3>

--- a/components/themes/theme-gallery.vue
+++ b/components/themes/theme-gallery.vue
@@ -3,9 +3,7 @@
   <section
     class="flex h-full min-h-0 w-full flex-col gap-3 rounded-2xl bg-base-300 p-3"
   >
-    <header
-      class="shrink-0 overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow"
-    >
+    <header class="shrink-0 overflow-hidden kr-panel-flat shadow">
       <div
         class="flex flex-col gap-3 bg-linear-to-br from-primary/12 via-secondary/10 to-accent/10 p-3 lg:flex-row lg:items-center lg:justify-between"
       >
@@ -100,10 +98,7 @@
 
     <main class="min-h-0 flex-1 overflow-y-auto pr-1">
       <section class="flex flex-col gap-3">
-        <section
-          v-if="showDefaultThemes"
-          class="rounded-2xl border border-base-300 bg-base-100 p-3 shadow"
-        >
+        <section v-if="showDefaultThemes" class="kr-panel-flat p-3 shadow">
           <!--
             A SEPARATOR, ONLY WHEN THERE IS SOMETHING TO SEPARATE. This was an
             icon tile, an `<h2>`, a subtitle and a count badge -- a full band

--- a/components/ui/ui-gallery.vue
+++ b/components/ui/ui-gallery.vue
@@ -374,9 +374,7 @@
           @update:mode="demoGalleryMode = $event"
         >
           <template #item="{ item, mode }">
-            <div
-              class="flex flex-col gap-1 rounded-2xl border border-base-300 bg-base-100 p-3"
-            >
+            <div class="flex flex-col gap-1 kr-panel-flat p-3">
               <span class="text-smart-heading font-black">{{
                 item.title
               }}</span>

--- a/components/user/account-settings.vue
+++ b/components/user/account-settings.vue
@@ -32,7 +32,7 @@
       </div>
 
       <!-- ── Security ─────────────────────────────────────────────── -->
-      <div class="rounded-2xl border border-base-300 bg-base-100 p-5">
+      <div class="kr-panel-flat p-5">
         <h2 class="mb-1 text-lg font-black">Security</h2>
         <p class="mb-4 text-sm text-base-content/70">
           Update your password and verify your email address.
@@ -138,7 +138,7 @@
       </div>
 
       <!-- ── Privacy & Consent ────────────────────────────────────── -->
-      <div class="rounded-2xl border border-base-300 bg-base-100 p-5">
+      <div class="kr-panel-flat p-5">
         <h2 class="mb-1 text-lg font-black">Privacy &amp; Consent</h2>
         <p class="mb-4 text-sm text-base-content/70">
           Consent is the default here. Choose what you see and what others can
@@ -243,7 +243,7 @@
       </div>
 
       <!-- ── Newsletter ───────────────────────────────────────────── -->
-      <div class="rounded-2xl border border-base-300 bg-base-100 p-5">
+      <div class="kr-panel-flat p-5">
         <h2 class="mb-1 text-lg font-black">Updates &amp; Promotions</h2>
         <p class="mb-4 text-sm text-base-content/70">
           Can we email you updates? Pick a rhythm — we only send what you ask

--- a/components/user/avatar-picker.vue
+++ b/components/user/avatar-picker.vue
@@ -5,7 +5,7 @@
   >
     <!-- ── Header ──────────────────────────────────────────────────────── -->
     <header
-      class="flex shrink-0 items-center gap-3 rounded-2xl border border-base-300 bg-base-100 px-4 py-3"
+      class="flex shrink-0 items-center gap-3 kr-panel-flat px-4 py-3"
     >
       <span
         class="relative flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary/15 ring-2 ring-accent/40"
@@ -42,7 +42,7 @@
 
     <!-- ── Tabs ────────────────────────────────────────────────────────── -->
     <div
-      class="flex shrink-0 gap-1 rounded-2xl border border-base-300 bg-base-100 p-1"
+      class="flex shrink-0 gap-1 kr-panel-flat p-1"
       role="tablist"
     >
       <button

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -59,7 +59,7 @@
 
     <section
       v-if="!activeThread"
-      class="min-h-0 flex-1 overflow-hidden rounded-2xl border border-base-300 bg-base-100"
+      class="min-h-0 flex-1 overflow-hidden kr-panel-flat"
     >
       <div v-if="isLoading" class="flex h-full items-center justify-center p-6">
         <span class="loading loading-spinner loading-lg text-primary" />
@@ -179,7 +179,7 @@
 
     <section
       v-else
-      class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100"
+      class="flex min-h-0 flex-1 flex-col overflow-hidden kr-panel-flat"
     >
       <div
         class="flex shrink-0 items-center gap-3 border-b border-base-300 bg-base-200 p-3"

--- a/components/user/friends-panel.vue
+++ b/components/user/friends-panel.vue
@@ -14,10 +14,7 @@
     </header>
 
     <!-- Incoming requests -->
-    <div
-      v-if="friends.allIncomingRequests.length"
-      class="rounded-2xl border border-base-300 bg-base-100 p-4"
-    >
+    <div v-if="friends.allIncomingRequests.length" class="kr-panel-flat p-4">
       <h2 class="mb-3 text-lg font-black">Requests</h2>
       <div class="flex flex-col gap-2">
         <div
@@ -47,7 +44,7 @@
     </div>
 
     <!-- Your friends -->
-    <div class="rounded-2xl border border-base-300 bg-base-100 p-4">
+    <div class="kr-panel-flat p-4">
       <h2 class="mb-3 text-lg font-black">
         Your friends ({{ friends.friendCount }})
       </h2>
@@ -97,7 +94,7 @@
     </div>
 
     <!-- Find people -->
-    <div class="rounded-2xl border border-base-300 bg-base-100 p-4">
+    <div class="kr-panel-flat p-4">
       <h2 class="mb-3 text-lg font-black">Find people</h2>
       <input
         v-model="search"
@@ -160,10 +157,7 @@
     </div>
 
     <!-- Blocked -->
-    <div
-      v-if="friends.blockedIds.length"
-      class="rounded-2xl border border-base-300 bg-base-100 p-4"
-    >
+    <div v-if="friends.blockedIds.length" class="kr-panel-flat p-4">
       <h2 class="mb-3 text-lg font-black">Blocked</h2>
       <div class="flex flex-col gap-2">
         <div

--- a/components/user/messenger.vue
+++ b/components/user/messenger.vue
@@ -9,9 +9,7 @@
     class="kr-panes mx-auto h-[70vh] w-full max-w-5xl grid-cols-[auto_minmax(0,1fr)] p-3"
   >
     <!-- Conversation list -->
-    <aside
-      class="kr-pane w-full max-w-xs rounded-2xl border border-base-300 bg-base-100 sm:w-72"
-    >
+    <aside class="kr-pane w-full max-w-xs kr-panel-flat sm:w-72">
       <header
         class="flex items-center justify-between border-b border-base-300 p-3"
       >
@@ -66,7 +64,7 @@
     </aside>
 
     <!-- Active thread -->
-    <div class="kr-pane min-w-0 rounded-2xl border border-base-300 bg-base-100">
+    <div class="kr-pane min-w-0 kr-panel-flat">
       <template v-if="convo.activeId">
         <header class="flex items-center gap-2 border-b border-base-300 p-3">
           <div class="avatar">

--- a/components/user/password-reset.vue
+++ b/components/user/password-reset.vue
@@ -22,7 +22,7 @@
     <!-- Request-link mode -->
     <form
       v-if="!hasToken"
-      class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-100 p-5"
+      class="flex flex-col gap-3 kr-panel-flat p-5"
       @submit.prevent="onRequest"
     >
       <label class="flex flex-col gap-1">
@@ -50,7 +50,7 @@
     <!-- Set-new-password mode -->
     <form
       v-else
-      class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-100 p-5"
+      class="flex flex-col gap-3 kr-panel-flat p-5"
       @submit.prevent="onReset"
     >
       <label class="flex flex-col gap-1">

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -76,7 +76,7 @@
           >
             <aside class="flex w-full flex-col gap-3">
               <div
-                class="flex flex-col items-center gap-3 rounded-2xl border border-base-300 bg-base-100 p-4"
+                class="flex flex-col items-center gap-3 kr-panel-flat p-4"
               >
                 <user-avatar
                   class="h-24 w-24 rounded-full ring-2 ring-accent ring-offset-2 ring-offset-base-100"
@@ -91,7 +91,7 @@
                 </div>
               </div>
 
-              <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+              <div class="kr-panel-flat p-3">
                 <div class="mb-2 flex items-center gap-1.5">
                   <Icon
                     name="kind-icon:camera"
@@ -105,7 +105,7 @@
                 <image-upload class="w-full" />
               </div>
 
-              <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+              <div class="kr-panel-flat p-3">
                 <div class="flex flex-wrap items-center justify-center gap-3">
                   <jellybean-icon />
                   <theme-icon class="flex flex-row" />
@@ -117,7 +117,7 @@
               <animation-selector />
 
               <label
-                class="flex cursor-pointer items-center justify-between gap-4 rounded-2xl border border-base-300 bg-base-100 px-4 py-3"
+                class="flex cursor-pointer items-center justify-between gap-4 kr-panel-flat px-4 py-3"
               >
                 <span class="flex min-w-0 items-center gap-3">
                   <span
@@ -148,7 +148,7 @@
               <!-- Karma / mana / achievements ─────────────────────────────── -->
               <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
                 <div
-                  class="rounded-2xl border border-base-300 bg-base-100 p-4"
+                  class="kr-panel-flat p-4"
                 >
                   <div class="flex items-center gap-2">
                     <Icon
@@ -180,7 +180,7 @@
                 </div>
 
                 <div
-                  class="rounded-2xl border border-base-300 bg-base-100 p-4"
+                  class="kr-panel-flat p-4"
                 >
                   <div class="flex items-center gap-2">
                     <Icon
@@ -213,7 +213,7 @@
                 </div>
 
                 <div
-                  class="rounded-2xl border border-base-300 bg-base-100 p-4"
+                  class="kr-panel-flat p-4"
                 >
                   <div class="flex items-center gap-2">
                     <Icon
@@ -241,7 +241,7 @@
 
               <div
                 v-if="earnedAchievements.length"
-                class="rounded-2xl border border-base-300 bg-base-100 p-3"
+                class="kr-panel-flat p-3"
               >
                 <p class="mb-2 text-xs font-black uppercase tracking-widest text-base-content/50">
                   Recent achievements
@@ -260,7 +260,7 @@
               <!-- Theme / maturity / server preferences ───────────────────── -->
               <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
                 <div
-                  class="flex flex-col gap-2 rounded-2xl border border-base-300 bg-base-100 p-4"
+                  class="flex flex-col gap-2 kr-panel-flat p-4"
                 >
                   <div class="flex items-center gap-2">
                     <Icon
@@ -284,7 +284,7 @@
                 </div>
 
                 <div
-                  class="flex flex-col gap-2 rounded-2xl border border-base-300 bg-base-100 p-4"
+                  class="flex flex-col gap-2 kr-panel-flat p-4"
                 >
                   <label class="flex cursor-pointer items-center gap-2">
                     <Icon name="kind-icon:eye" class="h-5 w-5 text-warning" />
@@ -312,7 +312,7 @@
                 </div>
 
                 <div
-                  class="flex flex-col gap-2 rounded-2xl border border-base-300 bg-base-100 p-4"
+                  class="flex flex-col gap-2 kr-panel-flat p-4"
                 >
                   <div class="flex items-center gap-2">
                     <Icon

--- a/components/user/user-galleries.vue
+++ b/components/user/user-galleries.vue
@@ -3,7 +3,7 @@
   <section
     class="flex h-full min-h-0 w-full flex-col gap-4 overflow-hidden rounded-2xl border border-base-300 bg-base-200 p-4"
   >
-    <header class="shrink-0 rounded-2xl border border-base-300 bg-base-100 p-4">
+    <header class="shrink-0 kr-panel-flat p-4">
       <h2 class="text-xl font-black">User Galleries</h2>
       <p class="text-sm text-base-content/60">
         Records where <span class="font-bold">userId</span> matches this
@@ -28,7 +28,7 @@
         <article
           v-for="section in userOwnedSections"
           :key="section.key"
-          class="rounded-2xl border border-base-300 bg-base-100 p-3"
+          class="kr-panel-flat p-3"
         >
           <div
             class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between"
@@ -119,7 +119,7 @@
             <component
               :is="section.galleryComponent"
               v-if="sectionDisplayModes[section.key] === 'gallery'"
-              class="max-h-136 min-h-0 overflow-auto rounded-2xl border border-base-300 bg-base-100 p-2"
+              class="max-h-136 min-h-0 overflow-auto kr-panel-flat p-2"
             />
 
             <div
@@ -129,7 +129,7 @@
               <div
                 v-for="item in section.items"
                 :key="`${section.key}-${item.id}`"
-                class="rounded-2xl border border-base-300 bg-base-100 p-3"
+                class="kr-panel-flat p-3"
               >
                 <div class="flex items-start justify-between gap-3">
                   <div class="min-w-0">
@@ -153,7 +153,7 @@
 
               <div
                 v-if="section.items.length === 0"
-                class="rounded-2xl border border-base-300 bg-base-100 p-4 text-center"
+                class="kr-panel-flat p-4 text-center"
               >
                 <p class="font-black">No {{ section.label }} yet.</p>
                 <p class="mt-1 text-sm text-base-content/60">

--- a/components/user/user-manager-directory.vue
+++ b/components/user/user-manager-directory.vue
@@ -51,7 +51,7 @@
       {{ store.lastError }}
     </div>
 
-    <div class="overflow-x-auto rounded-2xl border border-base-300 bg-base-100">
+    <div class="overflow-x-auto kr-panel-flat">
       <table class="table table-sm">
         <thead>
           <tr>

--- a/components/user/user-panel.vue
+++ b/components/user/user-panel.vue
@@ -4,7 +4,7 @@
     class="flex h-full min-h-0 w-full flex-col gap-4 overflow-hidden rounded-2xl border border-base-300 bg-base-200 p-4"
   >
     <header
-      class="flex shrink-0 flex-col gap-3 rounded-2xl border border-base-300 bg-base-100 p-4 md:flex-row md:items-center md:justify-between"
+      class="flex shrink-0 flex-col gap-3 kr-panel-flat p-4 md:flex-row md:items-center md:justify-between"
     >
       <div class="min-w-0">
         <h2 class="truncate text-xl font-black">
@@ -39,7 +39,7 @@
 
     <form
       v-if="hasProfile"
-      class="min-h-0 flex-1 overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-4"
+      class="min-h-0 flex-1 overflow-y-auto kr-panel-flat p-4"
       @submit.prevent="updateProfile"
     >
       <div class="mb-4">

--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -41,7 +41,7 @@
       <!-- Most active month (BROWSE-UX.md §1) -->
       <p
         v-if="mostActiveMonth"
-        class="rounded-2xl border border-base-300 bg-base-100 px-4 py-2 text-center text-sm font-semibold text-base-content/70"
+        class="kr-panel-flat px-4 py-2 text-center text-sm font-semibold text-base-content/70"
       >
         You consumed the most in {{ mostActiveMonth.label }}:
         {{ mostActiveMonth.count }} entries
@@ -362,7 +362,7 @@
 
         <div
           v-else-if="isLoading && !entries.length"
-          class="flex min-h-32 items-center justify-center rounded-2xl border border-base-300 bg-base-100"
+          class="flex min-h-32 items-center justify-center kr-panel-flat"
         >
           <span class="loading loading-spinner loading-md text-primary" />
           <span class="sr-only">Loading entries…</span>

--- a/components/wonderlab/component-review-feed.vue
+++ b/components/wonderlab/component-review-feed.vue
@@ -39,7 +39,7 @@
 
     <div
       v-else-if="isLoading && !reviews.length"
-      class="mt-4 flex min-h-32 items-center justify-center rounded-2xl border border-base-300 bg-base-100"
+      class="mt-4 flex min-h-32 items-center justify-center kr-panel-flat"
     >
       <span class="loading loading-spinner loading-md text-primary" />
     </div>

--- a/components/wonderlab/lab-interact.vue
+++ b/components/wonderlab/lab-interact.vue
@@ -4,7 +4,7 @@
     class="flex h-full min-h-0 w-full flex-col gap-3 rounded-2xl bg-base-300 p-3"
   >
     <header
-      class="grid shrink-0 grid-cols-1 gap-3 rounded-2xl border border-base-300 bg-base-100 p-3 xl:grid-cols-[auto_minmax(0,1fr)_auto]"
+      class="grid shrink-0 grid-cols-1 gap-3 kr-panel-flat p-3 xl:grid-cols-[auto_minmax(0,1fr)_auto]"
     >
       <div v-if="showHeader" class="flex items-center gap-3">
         <div
@@ -109,7 +109,7 @@
       ]"
     >
       <aside
-        class="kr-pane rounded-2xl border border-base-300 bg-base-100"
+        class="kr-pane kr-panel-flat"
         :class="[selectedComponent ? 'hidden xl:flex' : 'flex']"
       >
         <div class="shrink-0 border-b border-base-300 p-3">
@@ -271,7 +271,7 @@
 
       <main
         v-if="selectedComponent"
-        class="kr-pane-scroll rounded-2xl border border-base-300 bg-base-100 p-3"
+        class="kr-pane-scroll kr-panel-flat p-3"
       >
         <article class="flex flex-col gap-4">
           <section class="rounded-2xl border border-base-300 bg-base-200 p-4">

--- a/components/wonderlab/mural-manager.vue
+++ b/components/wonderlab/mural-manager.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="flex h-full min-h-0 w-full flex-col gap-4 overflow-hidden">
-    <header class="shrink-0 rounded-2xl border border-base-300 bg-base-100 p-4">
+    <header class="shrink-0 kr-panel-flat p-4">
       <div
         class="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between"
       >
@@ -69,7 +69,7 @@
 
     <div
       v-if="!pageDefinition"
-      class="flex min-h-0 flex-1 items-center justify-center rounded-2xl border border-base-300 bg-base-100"
+      class="flex min-h-0 flex-1 items-center justify-center kr-panel-flat"
     >
       <span class="loading loading-spinner loading-lg text-primary" />
     </div>
@@ -78,7 +78,7 @@
       v-else
       class="kr-panes grid-cols-1 xl:grid-cols-[minmax(280px,360px)_minmax(0,1fr)_minmax(280px,360px)]"
     >
-      <aside class="kr-pane rounded-2xl border border-base-300 bg-base-100">
+      <aside class="kr-pane kr-panel-flat">
         <div class="shrink-0 border-b border-base-300 p-4">
           <h2 class="text-lg font-black">Saved Colors</h2>
           <p class="mt-1 text-sm text-base-content/60">
@@ -173,9 +173,7 @@
         </form>
       </aside>
 
-      <main
-        class="kr-pane-scroll rounded-2xl border border-base-300 bg-base-100 p-4"
-      >
+      <main class="kr-pane-scroll kr-panel-flat p-4">
         <div
           class="rounded-2xl border border-base-300 bg-base-200 p-3 shadow-inner"
         >
@@ -228,7 +226,7 @@
         </div>
       </main>
 
-      <aside class="kr-pane rounded-2xl border border-base-300 bg-base-100">
+      <aside class="kr-pane kr-panel-flat">
         <div class="shrink-0 border-b border-base-300 p-4">
           <h2 class="text-lg font-black">Sections & Groups</h2>
           <p class="mt-1 text-sm text-base-content/60">

--- a/components/wonderlab/reaction-card.vue
+++ b/components/wonderlab/reaction-card.vue
@@ -33,7 +33,7 @@
     </div>
 
     <div class="grid gap-4">
-      <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+      <div class="kr-panel-flat p-3">
         <div
           class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
         >

--- a/components/wonderlab/wonderlab-preview-host.vue
+++ b/components/wonderlab/wonderlab-preview-host.vue
@@ -149,10 +149,7 @@
         </div>
       </div>
 
-      <div
-        v-else
-        class="rounded-2xl border border-base-300 bg-base-100 p-4 shadow-inner"
-      >
+      <div v-else class="kr-panel-flat p-4 shadow-inner">
         <div
           class="mx-auto w-full transition-[max-width] duration-200"
           :class="viewportClass"

--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -282,7 +282,7 @@
 
                 <div
                   v-else-if="submission.outputText"
-                  class="rounded-2xl border border-base-300 bg-base-100 p-5"
+                  class="kr-panel-flat p-5"
                 >
                   <p
                     class="whitespace-pre-line text-sm leading-relaxed"

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""
+kr_panel_codemod.py — mechanical, byte-exact substitution of the hand-rolled
+kr-panel / kr-panel-muted / kr-panel-flat utility sequences for the shared
+class, in static `class="..."` attributes inside .vue templates only.
+
+Scope, deliberately narrow (interface-vision/t-115's "if (b)" instruction):
+  - Only static `class="..."` attributes (never `:class=`, `v-bind:class=`,
+    or any attribute containing Vue interpolation `{{ }}`).
+  - Only an EXACT, contiguous, space-separated token match of one of the
+    three variant sequences below, tried longest-first so a full kr-panel
+    match is never left as kr-panel-flat + stray p-6/shadow-sm tokens.
+  - Everything else in the class string (extra spacing utilities, responsive
+    prefixes, hover/dark variants, additional classes before or after) is
+    left completely untouched -- this is what keeps the substitution
+    zero-visual-delta: the replaced tokens compute to the exact same
+    declarations the shared class already applies, and nothing else moves.
+
+Deliberately NOT handled (left for manual slices, matching t-115's note):
+  - opacity variants (bg-base-100/50 etc.)
+  - reordered token sequences (e.g. "border-base-300 border rounded-2xl")
+  - anything inside `:class` bindings or <script> template strings
+
+Usage:
+    python3 kr_panel_codemod.py --root /path/to/kind_robots [--apply] [--limit N] [glob...]
+
+Without --apply, prints a dry-run report (file, line, before -> after) and a
+summary count per variant. With --apply, writes the changes to disk for the
+files matched (respecting --limit, applied in sorted-path order, so repeated
+runs make deterministic forward progress through the pool).
+"""
+import argparse
+import re
+import sys
+from pathlib import Path
+
+VARIANTS = [
+    # (name, token sequence, longest first)
+    ("kr-panel", ["rounded-2xl", "border", "border-base-300", "bg-base-100", "p-6", "shadow-sm"]),
+    ("kr-panel-muted", ["rounded-2xl", "border", "border-base-300", "bg-base-200", "p-6"]),
+    ("kr-panel-flat", ["rounded-2xl", "border", "border-base-300", "bg-base-100"]),
+]
+
+CLASS_ATTR_RE = re.compile(r'(?<![:\w-])class="([^"]*)"')
+
+# kr-panel/-flat/-muted are declared inside tailwind.css's `@layer components`
+# (assets/css/tailwind.css), the SAME layer DaisyUI's own component classes
+# (.stat, .card, .btn, .collapse, ...) live in. Bare Tailwind utility tokens
+# (rounded-2xl, border, bg-base-100, ...) are in the UTILITIES layer, which
+# always wins over components regardless of source order -- but a components-
+# layer kr-panel* class does NOT get that guarantee against another
+# components-layer class on the same element (confirmed against
+# interface-vision/t-104 slice 12's kr-stat-tile.vue finding: DaisyUI's
+# `.stat` supplies its own background/border, and which one wins then depends
+# on stylesheet source order, not HTML class order). So this codemod only
+# fires when every OTHER token on the element is a plain Tailwind utility
+# (spacing/sizing/layout/typography/shadow/position) or one of our own kr-*
+# layout primitives that are documented to carry no bg/border/rounded of
+# their own (kr-pane, kr-pane-scroll, kr-surface, kr-stage, kr-unbound,
+# kr-container, kr-container-wide, kr-section). Anything else -- most
+# importantly any bare DaisyUI component-root class (stat, card, btn,
+# collapse, alert, badge, menu, modal-box, tooltip, dropdown, input, select,
+# textarea, checkbox, radio, toggle, progress, table, stats, artboard,
+# chat-bubble, timeline, steps, kbd, diff, carousel, hero, label, ...) -- is
+# left completely alone and reported separately for manual review.
+SAFE_EXTRA_RE = re.compile(
+    r"^("
+    r"(sm|md|lg|xl|2xl|hover|focus|focus-within|active|disabled|group-hover|dark|first|last|odd|even):.*|"
+    r"(p|px|py|pt|pb|pl|pr|m|mx|my|mt|mb|ml|mr|gap|gap-x|gap-y|space-x|space-y)-\S+|"
+    r"(w|h|min-w|min-h|max-w|max-h|size)-\S+|"
+    r"(flex|inline-flex|grid|inline-grid|flex-col|flex-row|flex-wrap|flex-nowrap|flex-1|flex-auto|flex-none|flex-shrink|flex-shrink-0|shrink|shrink-0|flex-grow|flex-grow-0|grow|grow-0)|"
+    r"(items|justify|content|self|place)-\S+|"
+    r"(grid-cols|grid-rows|col-span|row-span|col-start|col-end)-\S+|"
+    r"shadow(-\S+)?|"
+    r"(text|font|leading|tracking|whitespace|break)-\S+|"
+    r"overflow(-\S+)?|"
+    r"(relative|absolute|fixed|sticky|static)|"
+    r"(inset|top|left|right|bottom|z)-\S+|"
+    r"(opacity|transition|duration|ease|animate)-\S+|"
+    r"(cursor)-\S+|"
+    r"(mx-auto|my-auto|mt-auto|mb-auto|ml-auto|mr-auto)|"
+    r"kr-(pane|pane-scroll|surface|stage|unbound|container|container-wide|section)"
+    r")$"
+)
+
+
+def substitute_tokens(class_str):
+    """Return (new_str, variant_counts, skipped) after longest-first contiguous
+    substitution, but ONLY where every other token in the class list is on
+    the safe-extras allowlist above; otherwise the match is skipped and
+    reported so a human can judge it (DaisyUI component-class risk)."""
+    tokens = [t for t in class_str.split(" ") if t]
+    other_tokens = []
+    matched_any = False
+    i = 0
+    n = len(tokens)
+    tmp_out = []
+    counts = {}
+    while i < n:
+        matched = False
+        for name, seq in VARIANTS:
+            L = len(seq)
+            if i + L <= n and tokens[i:i + L] == seq:
+                tmp_out.append(("VAR", name))
+                counts[name] = counts.get(name, 0) + 1
+                i += L
+                matched = True
+                matched_any = True
+                break
+        if not matched:
+            tmp_out.append(("TOK", tokens[i]))
+            other_tokens.append(tokens[i])
+            i += 1
+
+    if not matched_any:
+        return class_str, {}, False
+
+    unsafe = [t for t in other_tokens if not SAFE_EXTRA_RE.match(t)]
+    if unsafe:
+        return class_str, {}, True  # skipped: unsafe extra tokens present
+
+    out = [val for _kind, val in tmp_out]
+    return " ".join(out), counts, False
+
+
+def process_file(path: Path):
+    # newline='' disables universal-newline translation so CRLF files round-
+    # trip byte-for-byte on the lines this codemod doesn't touch -- without
+    # this, Python silently normalizes every \r\n to \n on write and every
+    # line in the file shows as changed, not just the substituted ones.
+    with open(path, "r", encoding="utf-8", newline="") as fh:
+        text = fh.read()
+    # Only touch the <template> block, never <script>.
+    template_match = re.search(r"<template>", text)
+    if not template_match:
+        return None
+    template_end = re.search(r"</template>", text)
+    template_start = template_match.end()
+    template_stop = template_end.start() if template_end else len(text)
+
+    changes = []
+    skips = []
+
+    def repl(m):
+        inner = m.group(1)
+        if "{{" in inner:
+            return m.group(0)  # never touch interpolated class strings
+        new_inner, counts, skipped = substitute_tokens(inner)
+        line_no = text.count("\n", 0, m.start()) + 1
+        if skipped:
+            skips.append((line_no, inner))
+            return m.group(0)
+        if new_inner != inner:
+            changes.append((line_no, inner, new_inner, counts))
+            return f'class="{new_inner}"'
+        return m.group(0)
+
+    before_template = text[:template_start]
+    template_body = text[template_start:template_stop]
+    after_template = text[template_stop:]
+
+    new_template_body = CLASS_ATTR_RE.sub(repl, template_body)
+
+    if not changes and not skips:
+        return None
+
+    new_text = before_template + new_template_body + after_template
+    return new_text, changes, skips
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", required=True)
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("--limit", type=int, default=None, help="max files to modify")
+    args = ap.parse_args()
+
+    root = Path(args.root)
+    files = sorted(root.rglob("*.vue"))
+    files = [f for f in files if "node_modules" not in f.parts and ".nuxt" not in f.parts]
+
+    total_files = 0
+    total_variant_counts = {}
+    modified = 0
+    total_skipped = 0
+    skipped_files = []
+
+    for f in files:
+        result = process_file(f)
+        if result is None:
+            continue
+        new_text, changes, skips = result
+        rel = f.relative_to(root)
+
+        if changes:
+            total_files += 1
+            for _, _, _, counts in changes:
+                for k, v in counts.items():
+                    total_variant_counts[k] = total_variant_counts.get(k, 0) + v
+            print(f"=== {rel} ({len(changes)} substitution(s)) ===")
+            for line_no, before, after, counts in changes:
+                print(f"  L{line_no}: {before!r}")
+                print(f"       -> {after!r}")
+            if args.apply and (args.limit is None or modified < args.limit):
+                with open(f, "w", encoding="utf-8", newline="") as fh:
+                    fh.write(new_text)
+                modified += 1
+
+        if skips:
+            total_skipped += len(skips)
+            skipped_files.append(str(rel))
+            print(f"--- SKIPPED (unsafe extra tokens, needs manual review): {rel} ---")
+            for line_no, inner in skips:
+                print(f"  L{line_no}: {inner!r}")
+
+    print("\n--- summary ---")
+    print(f"files with candidate substitutions: {total_files}")
+    for k, v in sorted(total_variant_counts.items()):
+        print(f"  {k}: {v} occurrence(s)")
+    print(f"occurrences skipped for manual review (unsafe extra tokens): {total_skipped} across {len(skipped_files)} file(s)")
+    if args.apply:
+        print(f"files actually modified (respecting --limit): {modified}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this is

`interface-vision/t-115` was filed by a prior session as a kaizen decision task: slices 8-14 hand-migrated 64 exact-match `kr-panel` occurrences one small verified batch at a time, then discovered the two sibling variants (`kr-panel-flat`, `kr-panel-muted`, both defined in `tailwind.css` but never adopted) have a much larger candidate pool — initially estimated ~129/~114 files. t-115 asked: keep hand-slicing, or write a scoped codemod?

**Decision: codemod**, strictly scoped to byte-for-byte exact matches (t-115's explicit condition for going this route).

## What the codemod does and doesn't touch

`utils/scripts/codemods/kr_panel_codemod.py` only fires on a **static** `class="..."` attribute (never `:class=`, never interpolated `{{ }}`) containing an **exact, contiguous, space-separated token run** for one of the three `tailwind.css` `@layer components` variants, tried longest-first (`kr-panel` → `kr-panel-muted` → `kr-panel-flat`).

It also requires every *other* token on the element to be a plain Tailwind utility (spacing/sizing/layout/shadow/position/etc.) or one of our own no-bg/border `kr-*` layout primitives (`kr-pane`, `kr-pane-scroll`, `kr-surface`, ...). Anything else — most importantly a bare **DaisyUI component-root class** (`stat`, `card`, `btn`, `collapse`, `menu`, `dropdown-content`, ...) — is skipped for manual review instead of substituted.

**Why that exclusion matters:** `kr-panel*` classes live in `tailwind.css`'s `@layer components` block — the *same* layer DaisyUI's own component classes occupy. Bare Tailwind utility tokens (`rounded-2xl`, `border`, `bg-base-100`, ...) are in the *utilities* layer, which always wins over components regardless of source order — but a components-layer `kr-panel*` class does **not** get that guarantee against another components-layer class on the same element. This is exactly why slice 12 hand-excluded `kr-stat-tile.vue` (DaisyUI `.stat` conflict); the codemod's allowlist reproduces that judgment mechanically instead of relying on a human noticing it every time it comes up.

Dry run found `kr-panel` and `kr-panel-muted`'s exact-match pools are actually **empty** right now: `kr-panel`'s was exhausted by slice 13, and every `bg-base-200` candidate in the repo uses padding other than `p-6` (so none are byte-exact `kr-panel-muted` matches). Only `kr-panel-flat` had real candidates: **236 occurrences across 97 files**, migrated here.

## Excluded from this batch (left for a follow-up slice)

- `components/dreams/dream-gallery.vue` — PR #1642 (open, actively under review by another session as of this PR) already touches this file; left untouched to avoid colliding with in-flight review.
- 26 occurrences across 20 files where another token on the element wasn't on the safe-extras allowlist (DaisyUI `stat`/`collapse`/`dropdown-content`/`menu`/`btn`/`label`/etc. co-occurring) — left for manual per-file judgment, same as slice 12's `kr-stat-tile.vue` call.
- 45 files that already failed `prettier --check` **before** this change (pre-existing, unrelated formatting drift) were left exactly as the codemod produced them, not reformatted, to keep this diff scoped to the class-substitution task. The 24 files whose formatting broke because of *this change's own* line-length reduction were `prettier --write`'d, matching slices 8-14's documented practice.

## Verification

- `npx eslint .` — clean; `verifyLintRatchet.ts` — unchanged, 392 problems / 27 rules
- `npm run test` (vue-tsc --noEmit) — clean
- `npx tsx utils/scripts/verifyLayoutContract.ts` — holds, no new violations
- `prettier --check` — clean on every file this change actually altered (pre-existing drift elsewhere left alone, see above)

Every substitution is a literal, order-preserving token swap to a class that expands to the exact same declarations — zero visual delta by construction, same discipline slices 8-14 applied by hand to the 64-candidate `kr-panel` pool.


---
_Generated by [Claude Code](https://claude.ai/code/session_018EaGXGp1ngVdfRTWpqRbUY)_