### PR TITLE
one auto-import home per name: drop the artJobQueueSettings re-export

### DIFF
--- a/server/api/art/queue/claim.post.ts
+++ b/server/api/art/queue/claim.post.ts
@@ -28,10 +28,8 @@ import {
   artJobQueueAffinityKey,
   selectSmartQueueCandidate,
 } from '../../../utils/artJobQueueAffinity'
-import {
-  assertQueuedArtPromptContract,
-  reconcileQueuedArtJobCoverage,
-} from '../../../utils/artJobQueueCoverage'
+import { reconcileQueuedArtJobCoverage } from '../../../utils/artJobQueueCoverage'
+import { assertQueuedArtPromptContract } from '../../../utils/artJobQueueSettings'
 import {
   recordSamplerRepair,
   repairQueuedArtSampler,

--- a/server/utils/artJobQueueCoverage.ts
+++ b/server/utils/artJobQueueCoverage.ts
@@ -80,12 +80,13 @@ function hasRetry(payload: unknown): boolean {
 // Engine/sampler/prompt reading and the claim-time contract assertion live in
 // artJobQueueSettings.ts — they need no database, and this module's prisma
 // import made them unreachable from the DB-free contract-tests workflow.
-// Re-exported here so every existing caller keeps its import path.
-export {
-  inferQueuedArtEngine,
-  queuedArtSamplerSettings,
-  assertQueuedArtPromptContract,
-} from './artJobQueueSettings'
+//
+// They are deliberately NOT re-exported from here. Nuxt auto-imports every
+// export under server/utils, so a re-export registers the same name twice and
+// the build logs "Duplicated imports "assertQueuedArtPromptContract", the one
+// from artJobQueueCoverage.ts has been ignored" — three of those, twice per
+// build. Nitro picked the right module anyway, but a name with two auto-import
+// candidates is a coin toss nobody should have to think about. One home each.
 
 export function readFacetCoverageTarget(
   payload: unknown,

--- a/utils/scripts/verifyArtJobSamplerRepair.ts
+++ b/utils/scripts/verifyArtJobSamplerRepair.ts
@@ -246,24 +246,22 @@ assert.ok(
 )
 
 // Keep the reading helpers out of the prisma-importing module. Moving them back
-// would not break a single runtime caller — artJobQueueCoverage re-exports all
-// three — it would only make this file unrunnable in CI, silently, the way it
-// already was once.
+// would break no runtime caller — which is exactly why it would go unnoticed.
+// It would only make this file unrunnable in CI, silently, the way it already
+// was once.
 const settings = readFileSync('server/utils/artJobQueueSettings.ts', 'utf8')
 assert.ok(
   !/from '\.\/(prisma|artJobQueueCoverage)'/.test(settings),
   'artJobQueueSettings must stay database-free so the contract workflow can run it',
 )
+
+// And exactly one home per name. Nuxt auto-imports every export under
+// server/utils, so re-exporting these from artJobQueueCoverage registers each
+// name twice and the build logs "Duplicated imports ... has been ignored".
 const coverage = readFileSync('server/utils/artJobQueueCoverage.ts', 'utf8')
-for (const required of [
-  'inferQueuedArtEngine',
-  'queuedArtSamplerSettings',
-  'assertQueuedArtPromptContract',
-]) {
-  assert.ok(
-    coverage.includes(required),
-    `artJobQueueCoverage must keep re-exporting ${required} for existing callers`,
-  )
-}
+assert.ok(
+  !/export\s*\{[^}]*\}\s*from '\.\/artJobQueueSettings'/s.test(coverage),
+  'artJobQueueCoverage must not re-export artJobQueueSettings (auto-import collision)',
+)
 
 console.log('artJobSamplerRepair contract OK')

--- a/utils/scripts/verifyFacetCatalogMaintenance.ts
+++ b/utils/scripts/verifyFacetCatalogMaintenance.ts
@@ -18,10 +18,8 @@ const managerPath = path.join(root, 'components/facets/facet-manager.vue')
 const editorPath = path.join(root, 'components/facets/facet-editor.vue')
 const galleryPath = path.join(root, 'components/facets/facet-gallery.vue')
 const entityArtPath = path.join(root, 'server/utils/entityArt.ts')
-const queueCoveragePath = path.join(
-  root,
-  'server/utils/artJobQueueCoverage.ts',
-)
+const queueCoveragePath = path.join(root, 'server/utils/artJobQueueCoverage.ts')
+const queueSettingsPath = path.join(root, 'server/utils/artJobQueueSettings.ts')
 const queueClaimPath = path.join(root, 'server/api/art/queue/claim.post.ts')
 
 const cleanup = fs.readFileSync(cleanupPath, 'utf8')
@@ -34,6 +32,7 @@ const editor = fs.readFileSync(editorPath, 'utf8')
 const gallery = fs.readFileSync(galleryPath, 'utf8')
 const entityArt = fs.readFileSync(entityArtPath, 'utf8')
 const queueCoverage = fs.readFileSync(queueCoveragePath, 'utf8')
+const queueSettings = fs.readFileSync(queueSettingsPath, 'utf8')
 const queueClaim = fs.readFileSync(queueClaimPath, 'utf8')
 
 for (const required of [
@@ -104,7 +103,7 @@ for (const required of [
   'priorityFor',
   'artPrompt: entry.identityPrompt',
   "coverageMode: ALL_VARIANTS ? 'all-variants' : 'baseline'",
-  "payload: { contains: '\"entityType\":\"facet\"' }",
+  'payload: { contains: \'"entityType":"facet"\' }',
   'variant: ART_VARIANTS[0]',
 ]) {
   assert.ok(art.includes(required), `Missing Facet art contract: ${required}`)
@@ -174,13 +173,26 @@ for (const required of [
   'selectFacetCoverageKeeper',
   'payload.retry',
   'duplicate static delivery',
+]) {
+  assert.ok(
+    queueCoverage.includes(required),
+    `Missing queue coverage contract: ${required}`,
+  )
+}
+
+// The payload readers and the claim-time assertion moved to
+// artJobQueueSettings.ts (2026-08-09) so they stay reachable without a
+// database — artJobQueueCoverage imports prisma, which throws at import time
+// without DATABASE_URL, and that put the claim-time guard out of reach of the
+// DB-free contract-tests workflow. Same contract, asserted at its new home.
+for (const required of [
   'inferQueuedArtEngine',
   'queuedArtSamplerSettings',
   'assertQueuedArtPromptContract',
 ]) {
   assert.ok(
-    queueCoverage.includes(required),
-    `Missing queue coverage contract: ${required}`,
+    queueSettings.includes(required),
+    `Missing queued-art settings contract: ${required}`,
   )
 }
 


### PR DESCRIPTION
### Task
Follow-up to #1645 (merged). Kind: software.

### What this fixes

The production build for #1645 logs this three times, in each of two build phases:

```
Duplicated imports "assertQueuedArtPromptContract", the one from
/vercel/path0/server/utils/artJobQueueCoverage.ts has been ignored and
/vercel/path0/server/utils/artJobQueueSettings.ts is used
```

I found it reading the deploy logs while waiting for #1645 to reach production. Nuxt auto-imports every export under `server/utils`, so the compatibility re-export I added in #1645 registered `inferQueuedArtEngine`, `queuedArtSamplerSettings` and `assertQueuedArtPromptContract` a second time each.

Nothing was broken — Nitro resolved to `artJobQueueSettings`, which is the real implementation — but a name with two auto-import candidates is a coin toss nobody should have to reason about, and the warning would have sat in every build log from here on.

### What changed

- `artJobQueueCoverage.ts`: re-export block removed, replaced by a comment explaining why it must not come back.
- `claim.post.ts` (the only file that imported those names explicitly): takes `assertQueuedArtPromptContract` from `artJobQueueSettings`, keeps `reconcileQueuedArtJobCoverage` from `artJobQueueCoverage`.
- `verifyArtJobSamplerRepair.ts`: the assertion flips — it required the re-export, it now requires its absence.
- `verifyFacetCatalogMaintenance.ts`: its three reader-name assertions move to the module that now owns them rather than being dropped, with a note on why they moved.

### How I verified

- `npm run test` (vue-tsc `--noEmit`) — exit 0, zero errors.
- `tsx utils/scripts/verifyFacetCatalogMaintenance.ts` — passes.
- `tsx utils/scripts/verifyArtJobSamplerRepair.ts` with `DATABASE_URL` **unset**, matching how CI runs it — passes.
- `eslint` on all four touched files — clean.

The warning itself only reproduces in a full Nitro build, which does not run in this sandbox; I am matching the log line to its cause, not re-observing its absence. The next production build is the confirmation.

### Stakes
reversible — import-path move, no behavior change.

### Flags for Reviewer
- `claim.post.ts` still fails `prettier --check` on the pre-existing `| 'A1111' | 'COMFY'` union that is already unformatted on `main`. Left untouched so this diff is only the import swap.

### Notes for reviewer
Self-caught from #1645's own deploy log rather than from a failing check — nothing in CI flags an auto-import collision.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RiRyHC7xHFaPG2StQKqeX7)_