### PR TITLE
Extend kr-panel codemod allowlist, migrate 10 more kr-panel-flat occurrences (t-104 slice 15)

### DIFF
--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -56,7 +56,7 @@
           v-if="expandedSlug !== style.slug"
           :ref="(el) => setToggleRef(style.slug, el)"
           type="button"
-          class="group flex w-full flex-wrap items-center gap-3 rounded-2xl border border-base-300 bg-base-100 px-4 py-3 text-left transition-all hover:border-primary/50 hover:shadow-sm"
+          class="group flex w-full flex-wrap items-center gap-3 kr-panel-flat px-4 py-3 text-left transition-all hover:border-primary/50 hover:shadow-sm"
           aria-expanded="false"
           :aria-controls="`academy-style-detail-${style.slug}`"
           @click="expandedSlug = style.slug"

--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -62,7 +62,7 @@
       <div
         v-for="(item, i) in queuedFiles"
         :key="item.id"
-        class="group relative aspect-square overflow-hidden rounded-2xl border border-base-300 bg-base-100"
+        class="group relative aspect-square overflow-hidden kr-panel-flat"
       >
         <img
           :src="item.preview"

--- a/components/facets/facet-gallery.vue
+++ b/components/facets/facet-gallery.vue
@@ -4,10 +4,7 @@
     <!-- The shell renders the page title from content frontmatter (the brief's
          one-header rule), so this only carries the count and the loading state.
          showHeader lets a host that wants nothing at all drop even that. -->
-    <header
-      v-if="showHeader"
-      class="kr-toolbar shrink-0 rounded-2xl border border-base-300 bg-base-100 p-3"
-    >
+    <header v-if="showHeader" class="kr-toolbar shrink-0 kr-panel-flat p-3">
       <Icon name="kind-icon:tag" class="size-5 text-secondary" />
       <div class="min-w-0 flex-1">
         <p class="font-black">{{ title }}</p>

--- a/components/facets/facet-interact.vue
+++ b/components/facets/facet-interact.vue
@@ -41,9 +41,7 @@
   </div>
 
   <section v-else class="kr-surface">
-    <header
-      class="kr-toolbar shrink-0 rounded-2xl border border-base-300 bg-base-100 p-3"
-    >
+    <header class="kr-toolbar shrink-0 kr-panel-flat p-3">
       <button
         type="button"
         class="btn btn-ghost btn-sm rounded-xl"

--- a/components/model-builder/model-builder-run-history.vue
+++ b/components/model-builder/model-builder-run-history.vue
@@ -58,7 +58,7 @@
         <div
           v-for="run in store.runs"
           :key="run.id"
-          class="flex items-center gap-3 rounded-2xl border border-base-300 bg-base-100 p-3 transition hover:border-primary/50"
+          class="flex items-center gap-3 kr-panel-flat p-3 transition hover:border-primary/50"
           :class="
             run.id === store.run?.id ? 'border-primary/60 bg-primary/5' : ''
           "

--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -97,7 +97,7 @@
           v-for="record in store.sources"
           :key="record.id"
           type="button"
-          class="group flex flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100 text-left transition hover:border-primary hover:shadow-md"
+          class="group flex flex-col overflow-hidden kr-panel-flat text-left transition hover:border-primary hover:shadow-md"
           @click="store.selectSource(record)"
         >
           <div class="grid aspect-square w-full place-items-center overflow-hidden bg-base-200">
@@ -134,7 +134,7 @@
           v-for="record in store.sources"
           :key="record.id"
           type="button"
-          class="flex items-center gap-3 rounded-2xl border border-base-300 bg-base-100 p-2.5 text-left transition hover:border-primary hover:bg-base-200"
+          class="flex items-center gap-3 kr-panel-flat p-2.5 text-left transition hover:border-primary hover:bg-base-200"
           @click="store.selectSource(record)"
         >
           <div

--- a/components/navigation/workspace-sheet.vue
+++ b/components/navigation/workspace-sheet.vue
@@ -65,7 +65,7 @@
     <template v-if="tutorialChannelKey">
       <button
         type="button"
-        class="flex items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-100 px-4 py-3 text-left shadow-sm transition hover:border-primary/40"
+        class="flex items-center justify-between gap-3 kr-panel-flat px-4 py-3 text-left shadow-sm transition hover:border-primary/40"
         :aria-expanded="showTutorial"
         @click="showTutorial = !showTutorial"
       >

--- a/components/newsfeed/feed-card.vue
+++ b/components/newsfeed/feed-card.vue
@@ -5,7 +5,7 @@
     :href="allowNavigation ? item.url : undefined"
     :target="allowNavigation ? '_blank' : undefined"
     :rel="allowNavigation ? 'noopener noreferrer' : undefined"
-    class="group flex h-full flex-col gap-2 overflow-hidden rounded-2xl border border-base-300 bg-base-100 p-3 shadow-sm transition-shadow duration-300 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 motion-safe:hover:-translate-y-0.5 motion-safe:transition-transform"
+    class="group flex h-full flex-col gap-2 overflow-hidden kr-panel-flat p-3 shadow-sm transition-shadow duration-300 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 motion-safe:hover:-translate-y-0.5 motion-safe:transition-transform"
   >
     <kr-entity-card-body
       class="flex flex-1 flex-col"

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -2,7 +2,7 @@
 <template>
   <section class="kr-surface gap-4 rounded-2xl bg-base-200 p-3 sm:p-4">
     <header
-      class="kr-toolbar rounded-2xl border border-base-300 bg-base-100 px-4 py-3"
+      class="kr-toolbar kr-panel-flat px-4 py-3"
     >
       <Icon name="kind-icon:sparkles" class="h-5 w-5 shrink-0 text-primary" />
 

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -65,7 +65,7 @@ CLASS_ATTR_RE = re.compile(r'(?<![:\w-])class="([^"]*)"')
 # left completely alone and reported separately for manual review.
 SAFE_EXTRA_RE = re.compile(
     r"^("
-    r"(sm|md|lg|xl|2xl|hover|focus|focus-within|active|disabled|group-hover|dark|first|last|odd|even):.*|"
+    r"(sm|md|lg|xl|2xl|hover|focus|focus-within|focus-visible|active|disabled|group-hover|motion-safe|motion-reduce|dark|first|last|odd|even):.*|"
     r"(p|px|py|pt|pb|pl|pr|m|mx|my|mt|mb|ml|mr|gap|gap-x|gap-y|space-x|space-y)-\S+|"
     r"(w|h|min-w|min-h|max-w|max-h|size)-\S+|"
     r"(flex|inline-flex|grid|inline-grid|flex-col|flex-row|flex-wrap|flex-nowrap|flex-1|flex-auto|flex-none|flex-shrink|flex-shrink-0|shrink|shrink-0|flex-grow|flex-grow-0|grow|grow-0)|"
@@ -77,11 +77,34 @@ SAFE_EXTRA_RE = re.compile(
     r"(relative|absolute|fixed|sticky|static)|"
     r"(inset|top|left|right|bottom|z)-\S+|"
     r"(opacity|transition|duration|ease|animate)-\S+|"
+    r"transition|"
     r"(cursor)-\S+|"
     r"(mx-auto|my-auto|mt-auto|mb-auto|ml-auto|mr-auto)|"
-    r"kr-(pane|pane-scroll|surface|stage|unbound|container|container-wide|section)"
+    r"aspect-\S+|"
+    r"group|"
+    r"kr-(pane|pane-scroll|surface|stage|unbound|container|container-wide|section|toolbar)"
     r")$"
 )
+# 2026-08-09 (t-104 slice 15) additions, each verified against the compiled
+# Tailwind output (`npx @tailwindcss/cli -i assets/css/tailwind.css -o -`)
+# to declare NO background-color/border-color/border-radius of its own, so
+# none of them can affect the cascade question this allowlist exists to
+# police:
+#   - bare `group`/`transition` -- Tailwind's own marker/property-only
+#     utilities (`.group{}` has no declarations at all; `.transition{}` sets
+#     only transition-property/timing/duration).
+#   - `aspect-\S+` -- `aspect-ratio` only.
+#   - `focus-visible`/`motion-safe`/`motion-reduce` -- variant prefixes with
+#     the exact same non-effect as the already-allowlisted `hover`/`focus`.
+#   - `kr-toolbar` -- `@apply relative z-20 flex shrink-0 flex-wrap items-center
+#     gap-2` in tailwind.css; pure layout, same category as the other listed
+#     kr-* primitives.
+# Genuine DaisyUI component-root classes (stat, menu, dropdown-content, btn,
+# label, collapse, form-control, ...) are deliberately NOT added here even
+# where this slice's own empirical check found some of them (e.g. `.menu`,
+# `.label`) currently declare no conflicting background/border either --
+# policy stays conservative on daisyUI's own component classes since a
+# version bump could add one silently. Left for manual per-file review.
 
 
 def substitute_tokens(class_str):


### PR DESCRIPTION
## What

The exact-match `kr-panel`/`kr-panel-muted`/`kr-panel-flat` candidate pools were fully exhausted after slice 14 (#1646) — a dry run of `utils/scripts/codemods/kr_panel_codemod.py` found 0 automatable substitutions and 26 skips flagged as "unsafe extra tokens, needs manual review" across 20 files.

Rather than assume that allowlist was already complete, I checked each skip against the **actual compiled Tailwind output** (`npx @tailwindcss/cli -i assets/css/tailwind.css`). Of the 26, 10 occurrences across 9 files were false positives — tokens the codemod's `SAFE_EXTRA_RE` didn't recognize yet, but that verifiably declare zero `background-color`/`border-color`/`border-radius` of their own:

- bare `group` / `transition` — Tailwind's own marker/property-only utilities (`.group{}` has no declarations at all; `.transition{}` sets only `transition-property`/`timing`/`duration`)
- `aspect-square` — `aspect-ratio` only
- `focus-visible` / `motion-safe` — variant prefixes, same non-effect as the already-allowlisted `hover`/`focus`
- `kr-toolbar` — `@apply relative z-20 flex shrink-0 flex-wrap items-center gap-2` in `tailwind.css`, pure layout like the other allowlisted `kr-*` primitives

Extended `SAFE_EXTRA_RE` with these (documented inline with the verification method used), re-ran the codemod, and applied the resulting 10 occurrences across `academy-timeline.vue`, `image-upload.vue`, `facet-gallery.vue`, `facet-interact.vue`, `model-builder-run-history.vue`, `model-builder-source-picker.vue` (×2), `workspace-sheet.vue`, `feed-card.vue`, and `user-dashboard.vue`.

The remaining 16 skips across 11 files are genuine DaisyUI component-root classes (`stat`, `menu`, `dropdown-content`, `btn`, `label`, `collapse`, `form-control`) or a one-off local scoped class (`butterfly-card`) — **left excluded per policy**: even where this slice's own check found some of those DaisyUI classes (e.g. `.menu`, `.label`) currently declare no conflicting background/border either, a future daisyUI version could add one silently, so they stay manual-review candidates for a future slice, not this one.

## Verification

- `prettier --write` applied only to the 2 files whose formatting broke from this change's own line-length reduction (`facet-gallery.vue`, `facet-interact.vue`) — the 4 already-broken-before-this-change files (`model-builder-run-history.vue`, `model-builder-source-picker.vue`, `workspace-sheet.vue`, `user-dashboard.vue`) were confirmed pre-existing via `git stash` diff and left untouched.
- `eslint` — clean on all changed `.vue` files
- `test:lint-ratchet` — unchanged (392 problems / 27 rules)
- `vue-tsc --noEmit` — clean
- `test:layout-contract` — holds, 0 new violations

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRY5MVXqrFz3yumT8Zz2ZA)_