### PR TITLE
interface-vision: use kr-panel-flat for recent Storybook cards

### DIFF
--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -102,7 +102,7 @@
         <article
           v-for="story in library.recentStories"
           :key="story.id"
-          class="flex min-w-0 flex-col rounded-2xl border border-base-300 bg-base-100 p-3"
+          class="kr-panel-flat flex min-w-0 flex-col p-3"
         >
           <div class="min-w-0 flex-1">
             <div class="flex items-start justify-between gap-2">


### PR DESCRIPTION
## Task
Conductor `interface-vision/t-104`, slice 17.

## What changed
Replaced the recent-story `<article>` surface in `components/pages/storybook-library-page.vue` from the hand-rolled `rounded-2xl border border-base-300 bg-base-100` trio to `kr-panel-flat`.

The existing `flex min-w-0 flex-col p-3` utilities are preserved, so this is intended as a zero-visual-delta consistency migration. The dashed empty state remains deliberately bespoke per Interface Vision guidance.

## Scope
One file, one class substitution. No behavior, store, API, database, or routing changes.

## Conductor
Session: `20260809T091147Z-auto-tbs8`
Task was claimed and moved to `review` through session-aware task events before this PR was opened.

## Verification
GitHub Actions on this exact head are the merge gate. Merge only after required checks complete successfully.