### PR TITLE
100% Comfy: krea2 is the default, and nothing we build picks A1111

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -59,6 +59,15 @@ jobs:
       - name: ArtJob sampler repair contract
         run: npm run test:artjob-sampler-repair
 
+      # Everything the site generates runs on Comfy. A1111 stays supported for a
+      # user's own server, but no site path may pick it and nothing may pick it
+      # by default -- resource previews hardcoded A1111 and died on a refused
+      # connection every time. Also pins the txt2img/img2img defaults Silas
+      # specified (krea2 8 steps/cfg 1; sdxl img2img) and that every lane picks
+      # a fresh random seed rather than emitting a literal -1.
+      - name: Comfy-only generation contract
+        run: npm run test:comfy-only-generation
+
       - name: Channel content contract
         run: npm run test:channel-content
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "test:art-prompt-repair": "tsx utils/scripts/verifyArtPromptRepair.ts",
     "test:art-prompt-contract": "tsx utils/scripts/verifyArtPromptContract.ts",
     "test:artjob-sampler-repair": "tsx utils/scripts/verifyArtJobSamplerRepair.ts",
+    "test:comfy-only-generation": "tsx utils/scripts/verifyComfyOnlyGeneration.ts",
     "test:entity-art-prompt-framing": "tsx utils/scripts/verifyEntityArtPromptFraming.ts",
     "test:art-asset-suggest": "tsx utils/scripts/verifyArtAssetSuggest.ts",
     "test:artjob-bulk-scope": "tsx utils/scripts/verifyArtJobBulkScope.ts && tsx utils/scripts/verifyArtJobBulkCancel.ts",

--- a/server/api/art/enqueue.post.ts
+++ b/server/api/art/enqueue.post.ts
@@ -185,7 +185,10 @@ function narrativeRequest(
   ])
 
   if (product !== 'storybook' && product !== 'taskmaster') {
-    throw createError({ statusCode: 400, message: 'Invalid narrative product.' })
+    throw createError({
+      statusCode: 400,
+      message: 'Invalid narrative product.',
+    })
   }
   if (!sessionId || sessionId.length > 160 || !beatId || beatId.length > 160) {
     throw createError({
@@ -194,7 +197,10 @@ function narrativeRequest(
     })
   }
   if (!allowedMoments.has(moment)) {
-    throw createError({ statusCode: 400, message: 'Invalid narrative art moment.' })
+    throw createError({
+      statusCode: 400,
+      message: 'Invalid narrative art moment.',
+    })
   }
 
   const expectedKey = [product, sessionId, beatId, moment].join(':')
@@ -229,8 +235,18 @@ function facetRequest(body: ArtEnqueueRequest | null): {
   }
 }
 
+// Silas, 2026-08-09: "Nothing should be running a1111. We support it as in
+// users can add an a1111 server, but it's not used by me to build the site. We
+// are 100% comfy at this point ... comfy should generally be the default."
+//
+// So `a1111` stays a VALID engine — a user who has added their own Automatic1111
+// server can still ask for it by name — but it is no longer what you get by
+// saying nothing. An omitted engine now means krea2: Comfy, cfg 1, 8 steps,
+// random seed (server/api/comfy/krea2/utils/workflow.ts).
+const DEFAULT_ENQUEUE_ENGINE: EnqueueEngine = 'krea2'
+
 function normalizeEngine(value: unknown): EnqueueEngine {
-  const raw = String(value || 'a1111').toLowerCase()
+  const raw = String(value || DEFAULT_ENQUEUE_ENGINE).toLowerCase()
   const engine = ENGINE_ALIASES[raw] ?? raw
   if (
     engine === 'a1111' ||
@@ -309,7 +325,8 @@ export default defineEventHandler(async (event) => {
     ) {
       throw createError({
         statusCode: 400,
-        message: 'Entity recreation requires a prompt-only engine such as Krea 2.',
+        message:
+          'Entity recreation requires a prompt-only engine such as Krea 2.',
       })
     }
 
@@ -351,7 +368,8 @@ export default defineEventHandler(async (event) => {
     }
 
     const resolvedLora = await resolveEnqueueLoraResource({
-      body: (bodyWithEntityArt ?? {}) as ArtEnqueueRequest & Record<string, unknown>,
+      body: (bodyWithEntityArt ?? {}) as ArtEnqueueRequest &
+        Record<string, unknown>,
       engine,
       userId: gate.user.id,
       isAdmin,

--- a/server/api/comfy/sdxl/utils/workflow.ts
+++ b/server/api/comfy/sdxl/utils/workflow.ts
@@ -21,6 +21,24 @@ export type ComfyWorkflowInput = {
   steps?: number
   checkpoint?: string | null
   sampler?: string | null
+  /** Optional style LoRA, same shape the img2img builder takes. */
+  loraName?: string | null
+  loraStrength?: number | null
+  width?: number | null
+  height?: number | null
+  filenamePrefix?: string | null
+}
+
+/**
+ * A concrete, non-negative seed. Anything missing or negative becomes a fresh
+ * random one — every Comfy lane in the repo resolves here or in its own copy of
+ * this, so "unspecified seed" always means "different image", never "-1".
+ */
+function resolveSdxlSeed(seed?: number | null): number {
+  if (typeof seed === 'number' && Number.isFinite(seed) && seed >= 0) {
+    return Math.floor(seed)
+  }
+  return Math.floor(Math.random() * 2_147_483_647)
 }
 
 export function normalizeComfySampler(sampler?: string | null): string {
@@ -63,7 +81,11 @@ export function patchComfyWorkflow(
 ): void {
   const positiveText = input.prompt
   const negativeText = input.negativePrompt || ''
-  const seed = input.seed ?? -1
+  // Resolve, don't pass -1 through. generate.post.ts calls this immediately
+  // after buildDefaultComfyWorkflow with the SAME input, so a literal -1 here
+  // would overwrite the random seed the builder just picked and quietly pin the
+  // route to one image per Comfy install.
+  const seed = resolveSdxlSeed(input.seed)
   const steps = input.steps ?? 20
   const cfg = input.cfgValue || 3
   const sampler = normalizeComfySampler(input.sampler)
@@ -142,13 +164,6 @@ export type SdxlImg2ImgInput = {
 export const DEFAULT_SDXL_IMG2IMG_ORIGINAL_WEIGHT = 0.35
 const MIN_SDXL_IMG2IMG_DENOISE = 0.15
 
-function resolveSdxlSeed(seed?: number | null): number {
-  if (typeof seed === 'number' && Number.isFinite(seed) && seed >= 0) {
-    return Math.floor(seed)
-  }
-  return Math.floor(Math.random() * 2_147_483_647)
-}
-
 function clampUnit(value: number): number {
   return Math.min(1, Math.max(0, value))
 }
@@ -187,7 +202,8 @@ export function buildSdxlImg2ImgWorkflow(input: SdxlImg2ImgInput): {
 
   const loraName = input.loraName?.trim() || ''
   const loraStrength =
-    typeof input.loraStrength === 'number' && Number.isFinite(input.loraStrength)
+    typeof input.loraStrength === 'number' &&
+    Number.isFinite(input.loraStrength)
       ? input.loraStrength
       : 1
 
@@ -268,6 +284,16 @@ export function buildSdxlImg2ImgWorkflow(input: SdxlImg2ImgInput): {
   return { workflow, seed, denoise }
 }
 
+/**
+ * SDXL/SD15 txt2img on a NAMED checkpoint.
+ *
+ * This is not the default text-to-image lane — krea2 is (see
+ * server/api/art/enqueue.post.ts). Use this one only when the caller is
+ * generating *for* a specific checkpoint or LoRA and the model is the point of
+ * the image rather than an implementation detail: a Resource preview is the
+ * whole reason it still exists. Rendering that on krea2 would show the user a
+ * lovely picture of the wrong model.
+ */
 export function buildDefaultComfyWorkflow({
   prompt,
   negativePrompt,
@@ -276,8 +302,29 @@ export function buildDefaultComfyWorkflow({
   steps,
   checkpoint,
   sampler,
+  loraName,
+  loraStrength,
+  width,
+  height,
+  filenamePrefix,
 }: ComfyWorkflowInput): ComfyWorkflow {
-  return {
+  // A literal -1 used to reach the KSampler here, unlike every sibling builder
+  // (krea2, flux, kontext, sdxl-img2img) which all resolve through a
+  // random-seed helper. That silently pinned this lane to one seed per Comfy
+  // install: re-running a job returned the same image, and "generate another
+  // preview" was a no-op you could not see was a no-op.
+  const resolvedSeed = resolveSdxlSeed(seed)
+  const style = (loraName || '').trim()
+  const strength =
+    typeof loraStrength === 'number' && Number.isFinite(loraStrength)
+      ? loraStrength
+      : 1
+  // With a LoRA in the graph, model and CLIP come off the LoraLoader instead of
+  // the checkpoint — same wiring as buildSdxlImg2ImgWorkflow.
+  const modelSource: [string, number] = style ? ['10', 0] : ['1', 0]
+  const clipSource: [string, number] = style ? ['10', 1] : ['1', 1]
+
+  const workflow: ComfyWorkflow = {
     '1': {
       class_type: 'CheckpointLoaderSimple',
       inputs: {
@@ -288,7 +335,7 @@ export function buildDefaultComfyWorkflow({
       class_type: 'CLIPTextEncode',
       inputs: {
         text: prompt,
-        clip: ['1', 1],
+        clip: clipSource,
       },
       _meta: {
         title: 'Positive Prompt',
@@ -298,7 +345,7 @@ export function buildDefaultComfyWorkflow({
       class_type: 'CLIPTextEncode',
       inputs: {
         text: negativePrompt || '',
-        clip: ['1', 1],
+        clip: clipSource,
       },
       _meta: {
         title: 'Negative Prompt',
@@ -307,21 +354,21 @@ export function buildDefaultComfyWorkflow({
     '4': {
       class_type: 'EmptyLatentImage',
       inputs: {
-        width: 1024,
-        height: 1024,
+        width: width ?? 1024,
+        height: height ?? 1024,
         batch_size: 1,
       },
     },
     '5': {
       class_type: 'KSampler',
       inputs: {
-        seed: seed ?? -1,
+        seed: resolvedSeed,
         steps: steps ?? 20,
         cfg: cfgValue || 3,
         sampler_name: normalizeComfySampler(sampler),
         scheduler: 'normal',
         denoise: 1,
-        model: ['1', 0],
+        model: modelSource,
         positive: ['2', 0],
         negative: ['3', 0],
         latent_image: ['4', 0],
@@ -337,9 +384,25 @@ export function buildDefaultComfyWorkflow({
     '7': {
       class_type: 'SaveImage',
       inputs: {
-        filename_prefix: 'kindrobots',
+        filename_prefix: filenamePrefix || 'kindrobots',
         images: ['6', 0],
       },
     },
   }
+
+  if (style) {
+    workflow['10'] = {
+      class_type: 'LoraLoader',
+      inputs: {
+        model: ['1', 0],
+        clip: ['1', 1],
+        lora_name: style,
+        strength_model: strength,
+        strength_clip: strength,
+      },
+      _meta: { title: 'Style LoRA' },
+    }
+  }
+
+  return workflow
 }

--- a/server/api/resources/[id]/generate-preview.post.ts
+++ b/server/api/resources/[id]/generate-preview.post.ts
@@ -12,13 +12,27 @@ import { manaGate } from '~/server/utils/manaGate'
 import { estimateArtCostUsd } from '~/server/utils/manaCost'
 import { resourceGallerySelect, resourceGalleryWhere } from '../gallery'
 import { effectiveShowMature } from '~/server/utils/contentAccess'
+import { buildDefaultComfyWorkflow } from '~/server/api/comfy/sdxl/utils/workflow'
 
-const A1111_RESOURCE_FAMILIES: SupportedServer[] = [
+// Resource families the named-checkpoint Comfy graph can load. Named for what
+// they are — SD-lineage checkpoints — rather than for the engine that used to
+// render them; the engine is Comfy now, the model families are unchanged.
+const CHECKPOINT_RESOURCE_FAMILIES: SupportedServer[] = [
   SupportedServer.SD15,
   SupportedServer.SDXL,
   SupportedServer.GENERIC,
   SupportedServer.UNKNOWN,
 ]
+
+// Preview defaults. SDXL-lineage checkpoints are not distilled, so these are
+// ordinary SDXL numbers rather than krea2's 8/1 — but the seed is always random
+// (resolved inside the builder), same as every other Comfy lane.
+const PREVIEW_STEPS = 24
+const PREVIEW_CFG = 6
+const PREVIEW_SIZE = 768
+const PREVIEW_SAMPLER = 'Euler a'
+const PREVIEW_NEGATIVE_PROMPT =
+  'low quality, blurry, distorted, cropped, watermark, text, logo'
 
 function cleanModelName(value: string | null | undefined): string {
   return String(value || '').trim()
@@ -110,7 +124,7 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    if (!A1111_RESOURCE_FAMILIES.includes(resource.supportedServer)) {
+    if (!CHECKPOINT_RESOURCE_FAMILIES.includes(resource.supportedServer)) {
       throw createError({
         statusCode: 409,
         message: `Automatic previews for ${resource.supportedServer} resources need a compatible Comfy workflow. This Resource can still use an uploaded or imported preview.`,
@@ -125,15 +139,12 @@ export default defineEventHandler(async (event) => {
               {
                 resourceType: ResourceType.CHECKPOINT,
                 isActive: true,
-                supportedServer: { in: A1111_RESOURCE_FAMILIES },
+                supportedServer: { in: CHECKPOINT_RESOURCE_FAMILIES },
               },
               auth.isAdmin
                 ? {}
                 : {
-                    OR: [
-                      { isPublic: true },
-                      { userId: auth.user.id },
-                    ],
+                    OR: [{ isPublic: true }, { userId: auth.user.id }],
                   },
             ],
           },
@@ -150,7 +161,7 @@ export default defineEventHandler(async (event) => {
       throw createError({
         statusCode: 409,
         message:
-          'No accessible A1111-compatible checkpoint is available for this Resource.',
+          'No accessible SD-lineage checkpoint is available for this Resource.',
       })
     }
 
@@ -167,27 +178,50 @@ export default defineEventHandler(async (event) => {
 
     const promptString = buildPreviewPrompt(resource)
     const estimatedCostUsd = estimateArtCostUsd({
-      engine: 'a1111',
-      steps: 24,
-      width: 768,
-      height: 768,
+      engine: 'comfy',
+      steps: PREVIEW_STEPS,
+      width: PREVIEW_SIZE,
+      height: PREVIEW_SIZE,
     })
     const gate = await manaGate(event, {
       kind: 'art',
       estCostUsd: estimatedCostUsd,
     })
 
+    // Comfy, not A1111. This endpoint used to create `engine: 'A1111'` rows and
+    // every one of them died on a refused connection — nothing on the relay
+    // serves A1111 (ArtJob 8116, 2026-08-09, three attempts in two minutes).
+    //
+    // It does NOT use krea2, which is the default everywhere else. The entire
+    // point of this render is to show what THIS checkpoint or LoRA produces, so
+    // the resource's own model is the one thing that cannot be swapped for the
+    // house default. Comfy's named-checkpoint txt2img graph, with the LoRA wired
+    // in when the resource is one, and a random seed so "generate another
+    // preview" actually generates another preview.
+    const workflow = buildDefaultComfyWorkflow({
+      prompt: promptString,
+      negativePrompt: PREVIEW_NEGATIVE_PROMPT,
+      cfgValue: PREVIEW_CFG,
+      steps: PREVIEW_STEPS,
+      seed: null,
+      checkpoint: checkpointName,
+      sampler: PREVIEW_SAMPLER,
+      loraName,
+      loraStrength: loraName ? 1 : null,
+      width: PREVIEW_SIZE,
+      height: PREVIEW_SIZE,
+      filenamePrefix: 'kindrobots_resource_preview',
+    })
+
     const payload = {
+      workflow,
       promptString,
-      negativePrompt:
-        'low quality, blurry, distorted, cropped, watermark, text, logo',
-      steps: 24,
-      cfg: 6,
-      cfgHalf: false,
-      width: 768,
-      height: 768,
-      sampler: 'Euler a',
-      seed: -1,
+      negativePrompt: PREVIEW_NEGATIVE_PROMPT,
+      steps: PREVIEW_STEPS,
+      cfg: PREVIEW_CFG,
+      width: PREVIEW_SIZE,
+      height: PREVIEW_SIZE,
+      sampler: PREVIEW_SAMPLER,
       checkpoint: checkpointName,
       ...(loraName ? { loraName, loraStrength: 1 } : {}),
       save: {
@@ -209,7 +243,7 @@ export default defineEventHandler(async (event) => {
 
     const job = await prisma.artJob.create({
       data: {
-        engine: 'A1111',
+        engine: 'COMFY',
         payload: JSON.stringify(payload),
         priority: 1,
         projectSlug: 'resource-previews',

--- a/utils/scripts/enqueueTwistedFairyTalesArtPrompts.ts
+++ b/utils/scripts/enqueueTwistedFairyTalesArtPrompts.ts
@@ -10,6 +10,11 @@
 import 'dotenv/config'
 import prisma from './../../server/utils/prisma'
 import { twistedFairyTalesArtPrompts } from './../../stores/seeds/twistedFairyTalesArtPrompts'
+import {
+  buildKrea2WorkflowFromRequest,
+  KREA2_DEFAULT_CFG,
+  KREA2_DEFAULT_STEPS,
+} from './../../server/api/comfy/krea2/utils/workflow'
 
 const WRITE = process.argv.includes('--write')
 const USER_ID = Number(process.env.ART_SEED_USER_ID || 1)
@@ -89,7 +94,7 @@ async function main() {
     missing.map((entry) =>
       prisma.artJob.create({
         data: {
-          engine: 'A1111',
+          engine: 'COMFY',
           priority: PRIORITY,
           projectSlug: PROJECT_SLUG,
           userId: USER_ID,
@@ -102,6 +107,14 @@ async function main() {
             negativePrompt: entry.negativePrompt,
             width: entry.width,
             height: entry.height,
+            steps: KREA2_DEFAULT_STEPS,
+            cfg: KREA2_DEFAULT_CFG,
+            workflow: buildKrea2WorkflowFromRequest({
+              prompt: entry.promptString,
+              negativePrompt: entry.negativePrompt,
+              width: entry.width,
+              height: entry.height,
+            }).workflow,
             imagePath: entry.imagePath,
             sourceImages: entry.sourceImages,
             save: {

--- a/utils/scripts/migratePromptsToArtJobs.ts
+++ b/utils/scripts/migratePromptsToArtJobs.ts
@@ -7,7 +7,9 @@
 // truth (see /api/art/enqueue).
 //
 // Each migrated Prompt gets:
-//   - a new ArtJob (engine A1111, payload built from artPrompt/prompt + imagePath)
+//   - a new ArtJob (engine COMFY/krea2, payload built from artPrompt/prompt +
+//     imagePath). This said A1111 until 2026-08-09; nothing on the relay serves
+//     A1111, so a migration run would have produced rows that could only fail.
 //   - artStatus cleared to null so it is not double-processed by the deprecated
 //     /api/prompts/generate driver.
 //
@@ -18,6 +20,11 @@
 import 'dotenv/config'
 import { PrismaClient } from './../../prisma/generated/prisma/client'
 import { PrismaMariaDb } from '@prisma/adapter-mariadb'
+import {
+  buildKrea2WorkflowFromRequest,
+  KREA2_DEFAULT_CFG,
+  KREA2_DEFAULT_STEPS,
+} from './../../server/api/comfy/krea2/utils/workflow'
 
 const databaseUrl = process.env.DATABASE_URL
 if (!databaseUrl) throw new Error('DATABASE_URL is missing')
@@ -90,10 +97,14 @@ async function main() {
     await prisma.$transaction([
       prisma.artJob.create({
         data: {
-          engine: 'A1111',
+          engine: 'COMFY',
           userId: prompt.userId ?? FALLBACK_USER_ID,
           payload: JSON.stringify({
             promptString,
+            steps: KREA2_DEFAULT_STEPS,
+            cfg: KREA2_DEFAULT_CFG,
+            workflow: buildKrea2WorkflowFromRequest({ prompt: promptString })
+              .workflow,
             imagePath: prompt.imagePath ?? null,
             migratedFromPromptId: prompt.id,
             save: {

--- a/utils/scripts/verifyComfyOnlyGeneration.ts
+++ b/utils/scripts/verifyComfyOnlyGeneration.ts
@@ -1,0 +1,287 @@
+// Contract test: everything Kind Robots generates runs on Comfy.
+//
+// Silas, 2026-08-09, verbatim: "Nothing should be running a1111. We support it
+// as in users can add an a1111 server, but it's not used by me to build the
+// site. We are 100% comfy at this point ... any (all) gen tasks should be comfy,
+// and comfy should generally be the default (to be more specific, we should
+// have krea 2 with comfy, cfg 1, 8 steps, random seed, as the hard coded
+// defaults for any txt2img gen, and sdxl img2img with sensible defaults and
+// random seed for anything using img2img)."
+//
+// The distinction this file has to hold is narrow and easy to lose: A1111
+// remains a SUPPORTED engine — a user who adds their own Automatic1111 server
+// can still name it, and /api/art/generate still dials it — but nothing we
+// build for the site may choose it, and nothing may choose it by default.
+//
+// It was not academic. Resource previews hardcoded `engine: 'A1111'` and every
+// one of them died on a refused connection (ArtJob 8116, 2026-08-09: three
+// attempts, two minutes, dead), and /api/art/enqueue defaulted an omitted
+// engine to a1111, so "just enqueue this" meant "enqueue something that cannot
+// render".
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import {
+  buildKrea2WorkflowFromRequest,
+  KREA2_DEFAULT_CFG,
+  KREA2_DEFAULT_STEPS,
+} from '../../server/api/comfy/krea2/utils/workflow'
+import {
+  buildDefaultComfyWorkflow,
+  buildSdxlImg2ImgWorkflow,
+  patchComfyWorkflow,
+} from '../../server/api/comfy/sdxl/utils/workflow'
+
+type Nodes = Record<
+  string,
+  { class_type?: string; inputs?: Record<string, unknown> }
+>
+
+/**
+ * Source with comments removed, so a prose mention of the thing being banned
+ * does not read as the thing itself. The first version of this file failed on
+ * its own explanation of why A1111 was removed.
+ */
+function code(path: string): string {
+  return readFileSync(path, 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^[ \t]*\/\/.*$/gm, '')
+}
+
+function sampler(workflow: unknown): Record<string, unknown> {
+  const nodes = workflow as Nodes
+  const node = Object.values(nodes).find((n) => n.class_type === 'KSampler')
+  assert.ok(node?.inputs, 'workflow must contain a KSampler')
+  return node.inputs
+}
+
+// ── txt2img: krea2, cfg 1, 8 steps ──────────────────────────────────────────
+
+assert.equal(KREA2_DEFAULT_STEPS, 8, 'krea2 txt2img default is 8 steps')
+assert.equal(KREA2_DEFAULT_CFG, 1, 'krea2 txt2img default is cfg 1')
+
+const krea2 = sampler(
+  buildKrea2WorkflowFromRequest({ prompt: 'a brass orrery on a workbench' })
+    .workflow,
+)
+assert.equal(
+  krea2.steps,
+  8,
+  'an unspecified krea2 render must execute at 8 steps',
+)
+assert.equal(krea2.cfg, 1, 'an unspecified krea2 render must execute at cfg 1')
+
+// ── Random seed, everywhere, always ─────────────────────────────────────────
+//
+// "Random" is asserted as: two builds of an identical request differ, and
+// neither emits the literal -1 that ComfyUI would take at face value. A fixed
+// default seed is invisible — the image looks fine, it is just the SAME image
+// every time, and "generate another" silently does nothing.
+
+function seedOf(workflow: unknown): number {
+  const value = sampler(workflow).seed
+  assert.equal(typeof value, 'number', 'seed must be a resolved number')
+  return value as number
+}
+
+for (const [label, build] of [
+  [
+    'krea2 txt2img',
+    () => buildKrea2WorkflowFromRequest({ prompt: 'a lighthouse' }).workflow,
+  ],
+  [
+    'comfy named-checkpoint txt2img',
+    () =>
+      buildDefaultComfyWorkflow({
+        prompt: 'a lighthouse',
+        cfgValue: 6,
+        checkpoint: 'someCheckpoint.safetensors',
+      }),
+  ],
+  [
+    'sdxl img2img',
+    () =>
+      buildSdxlImg2ImgWorkflow({
+        prompt: 'a lighthouse',
+        imageName: 'source.png',
+        checkpoint: 'someCheckpoint.safetensors',
+      }).workflow,
+  ],
+] as Array<[string, () => unknown]>) {
+  const first = seedOf(build())
+  const second = seedOf(build())
+  assert.notEqual(first, -1, `${label} must not emit a literal -1 seed`)
+  assert.ok(first >= 0, `${label} seed must be non-negative`)
+  assert.notEqual(
+    first,
+    second,
+    `${label} must pick a fresh random seed per build`,
+  )
+}
+
+// Explicit seeds are honoured (checked directly rather than inside the loop).
+assert.equal(
+  seedOf(buildKrea2WorkflowFromRequest({ prompt: 'x', seed: 4242 }).workflow),
+  4242,
+  'an explicit krea2 seed must be preserved',
+)
+assert.equal(
+  seedOf(
+    buildDefaultComfyWorkflow({
+      prompt: 'x',
+      cfgValue: 6,
+      checkpoint: 'c.safetensors',
+      seed: 4242,
+    }),
+  ),
+  4242,
+  'an explicit txt2img seed must be preserved',
+)
+assert.equal(
+  seedOf(
+    buildSdxlImg2ImgWorkflow({
+      prompt: 'x',
+      imageName: 's.png',
+      checkpoint: 'c.safetensors',
+      seed: 4242,
+    }).workflow,
+  ),
+  4242,
+  'an explicit img2img seed must be preserved',
+)
+
+// The patcher must not undo the builder. sdxl/generate.post.ts calls
+// patchComfyWorkflow immediately after buildDefaultComfyWorkflow with the same
+// input, so a -1 here would overwrite the seed that was just resolved — the
+// builder fix alone would have been invisible on that route.
+const patched = buildDefaultComfyWorkflow({
+  prompt: 'a lighthouse',
+  cfgValue: 6,
+  checkpoint: 'c.safetensors',
+})
+patchComfyWorkflow(patched, {
+  prompt: 'a lighthouse',
+  cfgValue: 6,
+  checkpoint: 'c.safetensors',
+  seed: null,
+})
+assert.notEqual(
+  seedOf(patched),
+  -1,
+  'patchComfyWorkflow must resolve an unspecified seed, not write -1 over it',
+)
+assert.ok(seedOf(patched) >= 0)
+
+patchComfyWorkflow(patched, {
+  prompt: 'a lighthouse',
+  cfgValue: 6,
+  checkpoint: 'c.safetensors',
+  seed: 99,
+})
+assert.equal(seedOf(patched), 99, 'an explicit seed still wins in the patcher')
+
+// ── img2img: sdxl, sensible defaults ────────────────────────────────────────
+
+const img2img = buildSdxlImg2ImgWorkflow({
+  prompt: 'restyle this',
+  imageName: 'source.png',
+  checkpoint: 'someCheckpoint.safetensors',
+})
+const i2i = sampler(img2img.workflow)
+assert.equal(i2i.steps, 8, 'sdxl img2img default steps')
+assert.equal(i2i.cfg, 2, 'sdxl img2img default cfg')
+assert.equal(i2i.sampler_name, 'dpmpp_sde', 'sdxl img2img default sampler')
+assert.equal(i2i.scheduler, 'karras', 'sdxl img2img default scheduler')
+assert.ok(
+  typeof img2img.denoise === 'number' &&
+    img2img.denoise > 0 &&
+    img2img.denoise < 1,
+  'img2img denoise must leave some of the original image intact',
+)
+
+// ── The named-checkpoint lane carries its LoRA ──────────────────────────────
+//
+// Resource previews are the reason this lane exists, and half of them are for
+// a LoRA. Without the LoraLoader the preview renders the base checkpoint —
+// a plausible image of the wrong thing, which is worse than an error.
+
+const withLora = buildDefaultComfyWorkflow({
+  prompt: 'showcase',
+  cfgValue: 6,
+  checkpoint: 'base.safetensors',
+  loraName: 'style.safetensors',
+  loraStrength: 1,
+}) as Nodes
+const loader = Object.values(withLora).find(
+  (n) => n.class_type === 'LoraLoader',
+)
+assert.ok(loader, 'a named loraName must add a LoraLoader node')
+assert.equal(loader.inputs?.lora_name, 'style.safetensors')
+assert.deepEqual(
+  sampler(withLora).model,
+  ['10', 0],
+  'the KSampler must take its model from the LoRA, not the bare checkpoint',
+)
+const positive = withLora['2']
+assert.deepEqual(
+  positive?.inputs?.clip,
+  ['10', 1],
+  'text encoding must take CLIP from the LoRA too',
+)
+
+const withoutLora = buildDefaultComfyWorkflow({
+  prompt: 'showcase',
+  cfgValue: 6,
+  checkpoint: 'base.safetensors',
+}) as Nodes
+assert.ok(
+  !Object.values(withoutLora).some((n) => n.class_type === 'LoraLoader'),
+  'no LoRA node when none was asked for',
+)
+assert.deepEqual(sampler(withoutLora).model, ['1', 0])
+
+// ── No site-building path may choose A1111 ──────────────────────────────────
+
+const enqueue = code('server/api/art/enqueue.post.ts')
+assert.ok(
+  enqueue.includes("const DEFAULT_ENQUEUE_ENGINE: EnqueueEngine = 'krea2'"),
+  'the enqueue default engine must be krea2',
+)
+assert.ok(
+  !/String\(value \|\| 'a1111'\)/.test(enqueue),
+  'enqueue must not fall back to a1111 for an omitted engine',
+)
+assert.ok(
+  enqueue.includes("engine === 'a1111'"),
+  'a1111 must remain a VALID engine — users can add their own A1111 server',
+)
+
+// Every ArtJob row we create for the site is COMFY. A1111 rows are only ever
+// produced by a user naming that engine explicitly.
+for (const file of [
+  'server/api/resources/[id]/generate-preview.post.ts',
+  'utils/scripts/enqueueTwistedFairyTalesArtPrompts.ts',
+  'utils/scripts/migratePromptsToArtJobs.ts',
+]) {
+  const source = code(file)
+  assert.ok(
+    !/engine:\s*'A1111'/.test(source),
+    `${file} must not create A1111 ArtJob rows — nothing on the relay serves A1111`,
+  )
+  assert.ok(
+    /engine:\s*'COMFY'/.test(source),
+    `${file} must create COMFY ArtJob rows`,
+  )
+}
+
+// The synchronous relay-only surface is the ONE place A1111 survives on
+// purpose: it dials a server the user added, and asserts as much.
+const directRender = code('server/api/art/generate.post.ts')
+assert.ok(
+  directRender.includes('assertA1111Server'),
+  'the direct A1111 render surface is user-server-only and stays supported',
+)
+
+console.log(
+  'Comfy-only generation contract OK: krea2 8/1 txt2img, sdxl img2img, ' +
+    'random seeds everywhere, no site path on A1111.',
+)


### PR DESCRIPTION
### Task
Silas, 2026-08-09, direct instruction. Kind: software.

> Nothing should be running a1111. We support it as in users can add an a1111 server, but it's not used by me to build the site. We are 100% comfy at this point ... any (all) gen tasks should be comfy, and comfy should generally be the default (to be more specific, we should have krea 2 with comfy, cfg 1, 8 steps, random seed, as the hard coded defaults for any txt2img gen, and sdxl img2img with sensible defaults and random seed for anything using img2img)

### The line this keeps

**A1111 stays supported.** Users add their own Automatic1111 server, `/api/art/generate` still dials it (it asserts `assertA1111Server`), the enum and every server-management surface are untouched, and `engine: 'a1111'` is still a valid thing to ask `/api/art/enqueue` for. What changes is that nothing *we* build chooses it, and nothing chooses it by default.

### What changed

**Default engine.** `/api/art/enqueue` resolved an omitted engine to `'a1111'` — so "just enqueue this" meant "enqueue something the relay cannot render". It is `krea2` now: Comfy, 8 steps, cfg 1, random seed, all already the builder's own defaults.

**Resource previews.** Hardcoded `engine: 'A1111'`; every one died on a refused connection (ArtJob 8116 — three attempts, two minutes, dead). Now a Comfy named-checkpoint graph.

This one is **deliberately not krea2**, and it is the only judgement call in the PR. The whole point of that render is to show what *this* checkpoint or LoRA produces, so the resource's own model is the one thing that cannot be swapped for the house default — krea2 would produce a lovely picture of the wrong model. It renders on Comfy, on the resource's checkpoint, at ordinary SDXL numbers (24 steps / cfg 6 / 768²), with a random seed. If you'd rather previews just use krea2 and stop being model-specific, this is the hunk to change.

That lane needed two fixes before it was usable:

- **No LoRA support.** A LoRA preview would have silently rendered the base checkpoint — a plausible image of the wrong thing, worse than an error. It now wires a `LoraLoader` and takes model + CLIP from it, the same shape `buildSdxlImg2ImgWorkflow` already used.
- **A literal `-1` seed** went into the KSampler where every sibling builder (krea2, flux, kontext, sdxl-img2img) resolves a random one. That pinned the lane to one image per Comfy install: "generate another preview" was a no-op you could not see was a no-op. `patchComfyWorkflow` had the same `-1` and runs immediately after the builder on `sdxl/generate.post.ts`, so fixing only the builder would have been invisible on that route — both are fixed.

**Seed scripts.** `enqueueTwistedFairyTalesArtPrompts` (live — `npm run seed:twisted-fairy-tales`) and `migratePromptsToArtJobs` both created A1111 rows carrying no workflow at all. Both build krea2 graphs now.

**Already correct, now pinned by a test rather than by luck:** krea2 at 8 steps / cfg 1, sdxl img2img at 8 steps / cfg 2 / `dpmpp_sde` / `karras` with denoise short of 1, and a fresh random seed out of every lane.

### How I verified

Actually run:

- **`tsx utils/scripts/verifyComfyOnlyGeneration.ts` — passes.** New contract test. It asserts randomness by *building twice and comparing seeds*, not by reading the source, so a future regression to a fixed default fails here rather than shipping. It also covers the LoRA wiring, the patcher-overwrites-builder case, explicit seeds still winning, and that no site path creates `A1111` rows while `a1111` stays a valid requested engine.
- `npm run test` (vue-tsc `--noEmit`) — exit 0, zero errors.
- `verifyArtPromptContract`, `verifyArtJobSamplerRepair`, `verifyFacetCatalogMaintenance`, `verifyArtPromptRepair`, `verifyComfyModelPaths`, `verifyMaturityPrivacyContract` — all pass.
- `eslint` clean on every touched file; lint ratchet unchanged at 392.

The test's file-content assertions strip comments first — the first version failed on its own explanation of why A1111 was removed.

### Stakes
reversible — engine routing and defaults, no schema change, no migration.

### Flags for Reviewer
- **Kontext is untouched.** "Anything using img2img" would read on Flux Kontext too, but Kontext is a distinct instruction-editing capability with live callers (the coloring-book B&W conversion enqueues `engine: 'kontext'`). I read the instruction as being about *defaults*, not about removing a named engine you deliberately use. Say the word if you want it folded into sdxl img2img.
- The preview-vs-krea2 call above.
- `server/api/art/generate.post.ts` still says `engine: 'a1111'` in its mana-cost call. That is the user's-own-server synchronous surface and is the one place A1111 survives on purpose; the test pins it as such.

### Kaizen suggestion
`normalizeEngine`'s default was a one-word literal with no test, and it silently decided what happens for every caller that omits an engine. The same shape exists elsewhere — `GATE_ENGINE`, `ENGINE_ALIASES`, per-engine step/cfg tables — each a bare literal that changes behaviour repo-wide. Worth one table with the defaults named and asserted, rather than a default hiding in a `String(value || …)`.

### Notes for reviewer
No Conductor change needed: `consume_art_queue_core.py` already migrates every A1111 alias to krea2 and is Comfy-only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RiRyHC7xHFaPG2StQKqeX7)_