### PR TITLE
interface-vision/t-104 slice 18: manual kr-panel-flat migration on 10 DaisyUI-adjacent occurrences

### DIFF
--- a/components/abandonware/butterfly/butterfly-demo.vue
+++ b/components/abandonware/butterfly/butterfly-demo.vue
@@ -4,7 +4,7 @@
     class="relative flex h-full w-full items-center justify-center rounded-2xl border border-base-300 bg-base-200 p-4"
   >
     <div
-      class="butterfly-card relative flex h-full w-full max-w-md flex-col items-center justify-center rounded-2xl border border-base-300 bg-base-100 p-6 text-base-content shadow-lg"
+      class="butterfly-card relative flex h-full w-full max-w-md flex-col items-center justify-center kr-panel-flat p-6 text-base-content shadow-lg"
     >
       <template v-if="currentButterfly">
         <div

--- a/components/art/art-maker.vue
+++ b/components/art/art-maker.vue
@@ -315,7 +315,7 @@
               </label>
 
               <label
-                class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-100 px-4 py-3"
+                class="label cursor-pointer justify-between kr-panel-flat px-4 py-3"
               >
                 <span class="label-text font-bold">Half CFG</span>
                 <input
@@ -327,7 +327,7 @@
               </label>
 
               <label
-                class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-100 px-4 py-3"
+                class="label cursor-pointer justify-between kr-panel-flat px-4 py-3"
               >
                 <span class="label-text font-bold">Public</span>
                 <input
@@ -339,7 +339,7 @@
               </label>
 
               <label
-                class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-100 px-4 py-3"
+                class="label cursor-pointer justify-between kr-panel-flat px-4 py-3"
               >
                 <span class="label-text font-bold">Mature</span>
                 <input

--- a/components/navigation/channel-select.vue
+++ b/components/navigation/channel-select.vue
@@ -41,7 +41,7 @@
     >
       <ul
         ref="channelMenu"
-        class="menu w-[min(22rem,calc(100vw-1rem))] flex-nowrap overflow-x-hidden kr-anchor-scroll rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl"
+        class="menu w-[min(22rem,calc(100vw-1rem))] flex-nowrap overflow-x-hidden kr-anchor-scroll kr-panel-flat p-2 shadow-2xl"
         :style="{
           maxHeight: `${channelMenuMaxHeight}px`,
           scrollbarGutter: 'stable',
@@ -129,7 +129,7 @@
       <div
         v-if="expandedChannel && submenuMode === 'flyout'"
         ref="channelFlyout"
-        class="channel-submenu absolute left-full z-120 ml-2 flex-nowrap overflow-x-hidden kr-anchor-scroll rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl"
+        class="channel-submenu absolute left-full z-120 ml-2 flex-nowrap overflow-x-hidden kr-anchor-scroll kr-panel-flat p-2 shadow-2xl"
         :class="channelFlyoutColumns === 2 ? 'w-[40rem]' : 'w-80'"
         :style="{
           top: `${channelFlyoutTop}px`,

--- a/components/navigation/notification-bell.vue
+++ b/components/navigation/notification-bell.vue
@@ -33,7 +33,7 @@
 
       <div
         tabindex="0"
-        class="dropdown-content z-50 mt-2 w-80 rounded-2xl border border-base-300 bg-base-100 p-2 shadow-xl"
+        class="dropdown-content z-50 mt-2 w-80 kr-panel-flat p-2 shadow-xl"
       >
         <div class="flex items-center justify-between px-2 py-1">
           <span class="font-black">Notifications</span>

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -137,7 +137,7 @@
 
             <ul
               tabindex="0"
-              class="dropdown-content menu absolute right-0 top-full z-120 mt-2 max-h-[min(70vh,28rem)] w-[min(18rem,calc(100vw-1rem))] flex-nowrap overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl"
+              class="dropdown-content menu absolute right-0 top-full z-120 mt-2 max-h-[min(70vh,28rem)] w-[min(18rem,calc(100vw-1rem))] flex-nowrap overflow-y-auto kr-panel-flat p-2 shadow-2xl"
               :aria-label="`${resolvedChannel?.label || 'Channel'} tabs`"
             >
               <li v-for="tab in resolvedTabs" :key="`all-${tab.tabKey}`">

--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -40,7 +40,7 @@
               <Icon name="kind-icon:download" class="size-4" /> Export
             </summary>
             <ul
-              class="menu dropdown-content z-20 mt-2 w-44 rounded-2xl border border-base-300 bg-base-100 p-2 shadow-xl"
+              class="menu dropdown-content z-20 mt-2 w-44 kr-panel-flat p-2 shadow-xl"
             >
               <li><button type="button" @click="downloadStory(undefined, 'markdown')">Markdown</button></li>
               <li><button type="button" @click="downloadStory(undefined, 'json')">JSON</button></li>

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -87,9 +87,7 @@
           label="Scenario Facets"
         />
 
-        <label
-          class="form-control rounded-2xl border border-base-300 bg-base-100 p-4"
-        >
+        <label class="form-control kr-panel-flat p-4">
           <span class="label">
             <span class="label-text font-bold">Inspirations</span>
           </span>

--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -293,7 +293,7 @@
           </button>
           <div
             tabindex="0"
-            class="dropdown-content z-10 mt-1 grid grid-cols-4 gap-1 rounded-2xl border border-base-300 bg-base-100 p-2 shadow-lg"
+            class="dropdown-content z-10 mt-1 grid grid-cols-4 gap-1 kr-panel-flat p-2 shadow-lg"
           >
             <button
               v-for="monthOption in MONTH_LABELS"


### PR DESCRIPTION
## Summary

Resolves 10 of the 16 exact-match `kr-panel-flat` candidates that `kr_panel_codemod.py`'s `SAFE_EXTRA_RE` allowlist deliberately leaves for manual per-file review (t-115/slice 15's stated policy: co-occurring DaisyUI component-root classes stay manual-judgment rather than folded into the general codemod, since a future daisyUI bump could add a conflicting declaration silently).

Verified each of the 5 co-occurring DaisyUI/local classes against the actual compiled Tailwind output (`npx @tailwindcss/cli`) before touching its file:

- `.menu` — display/width/flex-direction/padding/font-size only, no bg/border/radius
- `.label` — display/align-items/gap/whitespace/color only, no bg/border/radius
- `.dropdown-content` (bare, `.dropdown .dropdown-content`, `.menu .dropdown-content`, and the `.dropdown-{start,center,end,left,right,top,bottom}` position variants) — position/margin/padding/inset/translate/z-index/animation only, no bg/border/radius
- `.form-control` — zero generated rules in daisyUI 5.7.9 (dropped between v4→v5); completely inert, so no conflict is possible
- `channel-submenu` (`components/navigation/channel-select.vue`) — no CSS rule anywhere in the file, a bare marker class with zero visual effect
- `butterfly-card` (`components/abandonware/butterfly/butterfly-demo.vue`) — this file's own scoped style only sets `min-height: 22rem`, no bg/border/radius

## Migrated (10 occurrences / 8 files)

- `components/art/art-maker.vue` (3x `label` toggle rows)
- `components/navigation/channel-select.vue` (2x: channel menu + flyout submenu)
- `components/navigation/notification-bell.vue` (dropdown-content panel)
- `components/navigation/workspace-header.vue` (dropdown-content menu panel)
- `components/pages/storybook-library-page.vue` (menu dropdown-content export panel)
- `components/scenarios/add-scenario.vue` (form-control wrapper)
- `components/abandonware/butterfly/butterfly-demo.vue` (butterfly-card)
- `components/watchlist/watchlist-browse.vue` (dropdown-content year picker)

Every substitution preserves every other token on the element exactly — zero visual delta, same padding/layout/shadow utilities as before.

## Left excluded (confirmed real conflicts, unchanged from prior slices' judgment)

- `components/ui/kr-stat-tile.vue` — `.stat:not(:last-child)` sets `border-inline-end`
- `components/user/chat-gallery.vue` (x2), `pages/play/challenges/[slug].vue` (x2) — `.btn` sets `background-color`/`border-radius`/`border-width`; `.collapse` sets `border-radius` — both real components-layer conflicts

## Verification

- `eslint` clean on all 8 changed files
- `vue-tsc --noEmit` clean
- `test:lint-ratchet` unchanged (392/27)
- `test:layout-contract` holds (0 new violations)
- `prettier --check` clean (only reformatted `add-scenario.vue`, the one file whose formatting broke from this change's own line-length reduction — confirmed via `git stash` diff against baseline that the other 3 prettier warnings pre-existed this change)

Tracked in conductor `interface-vision/t-104`.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJHSjca7TUiK9pVfqNcrpu)_