### PR TITLE
Fix Sharp runtime in self-hosted Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:24-alpine AS build
+FROM node:24-bookworm-slim AS build
 
 WORKDIR /app
 
@@ -8,10 +8,10 @@ ENV NUXT_TELEMETRY_DISABLED=1
 
 COPY . .
 
-RUN DATABASE_URL=mysql://kindrobots:build-only@127.0.0.1:3306/kindrobots npm ci
+RUN DATABASE_URL=mysql://kindrobots:build-only@127.0.0.1:3306/kindrobots npm ci --include=optional
 RUN DATABASE_URL=mysql://kindrobots:build-only@127.0.0.1:3306/kindrobots npm run build
 
-FROM node:24-alpine AS runtime
+FROM node:24-bookworm-slim AS runtime
 
 WORKDIR /app
 
@@ -35,4 +35,4 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=45s --retries=3 \
   CMD node -e "fetch('http://127.0.0.1:3000/api/health/database').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))"
 
-CMD ["node", "--env-file-if-exists=/config/kind-robots.env", ".output/server/index.mjs"]
+CMD ["node", ".output/server/index.mjs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=45s --retries=3 \
   CMD node -e "fetch('http://127.0.0.1:3000/api/health/database').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))"
 
-CMD ["node", ".output/server/index.mjs"]
+CMD ["node", "--env-file-if-exists=/config/kind-robots.env", ".output/server/index.mjs"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,5 +17,4 @@ services:
       NITRO_HOST: 0.0.0.0
       NITRO_PORT: 3000
     volumes:
-      - ${KIND_ROBOTS_ENV_FILE:-./.env}:/config/kind-robots.env:ro
       - ${KIND_ROBOTS_MEDIA_PATH:-/mnt/user/pc/kindrobots/images}:/app/.output/public/images:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,4 +17,5 @@ services:
       NITRO_HOST: 0.0.0.0
       NITRO_PORT: 3000
     volumes:
+      - ${KIND_ROBOTS_ENV_FILE:-./.env}:/config/kind-robots.env:ro
       - ${KIND_ROBOTS_MEDIA_PATH:-/mnt/user/pc/kindrobots/images}:/app/.output/public/images:rw


### PR DESCRIPTION
### Root cause
The Unraid container starts from `node:24-alpine`, so Nitro/Sharp loads the linuxmusl-x64 binding. At runtime that binding fails because `libvips-cpp.so.8.17.3` is unavailable in the Alpine runtime image, causing an immediate restart loop before Nuxt can serve traffic.

The separate `/config/kind-robots.env not found` message was traced to the host `.env` simply not being present yet, so the existing mounted-env contract is intentionally unchanged.

### Fix
- Switch build and runtime stages from `node:24-alpine` to `node:24-bookworm-slim` (glibc).
- Run `npm ci --include=optional` so Sharp's platform package is installed explicitly.
- Preserve the existing `/config/kind-robots.env` runtime loading and media mount behavior unchanged.

### Verification
- Final branch diff against main is exactly one file (`Dockerfile`), 3 additions / 3 deletions.
- CI will run the existing TypeScript and contract suites. The decisive runtime smoke remains rebuilding/running the image on Alexandria, where the original musl/libvips failure occurred.

### Stakes
Reversible container-base change only. No schema, secrets, DNS, OAuth, or production-data mutation.