### PR TITLE
Bundle Sharp libvips in Nitro Docker runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,12 @@ ENV NUXT_TELEMETRY_DISABLED=1
 COPY . .
 
 RUN DATABASE_URL=mysql://kindrobots:build-only@127.0.0.1:3306/kindrobots npm ci --include=optional
+# Nuxt Image/IPX uses Sharp at runtime. Ask npm explicitly for the Linux x64
+# platform pair so both the native Sharp binding and its matching libvips
+# package are guaranteed to exist even when the lockfile was produced on
+# another platform.
+RUN npm install --no-save --package-lock=false --os=linux --cpu=x64 sharp@0.34.5
+RUN test -d /app/node_modules/@img/sharp-libvips-linux-x64
 RUN DATABASE_URL=mysql://kindrobots:build-only@127.0.0.1:3306/kindrobots npm run build
 
 FROM node:24-bookworm-slim AS runtime
@@ -25,6 +31,10 @@ ENV NODE_ENV=production \
 COPY --from=build --chown=node:node /app/.output ./.output
 COPY --from=build --chown=node:node /app/node_modules ./node_modules
 COPY --from=build --chown=node:node /app/package.json ./package.json
+# Nitro bundles Sharp into its private node_modules tree but can omit Sharp's
+# optional libvips package. Put the matching package in the normal server
+# node_modules resolution path so bundled Sharp can load libvips at runtime.
+COPY --from=build --chown=node:node /app/node_modules/@img/sharp-libvips-linux-x64 /app/.output/server/node_modules/@img/sharp-libvips-linux-x64
 
 RUN ln -s /app/.output/public /app/public
 


### PR DESCRIPTION
### Root cause
The Bookworm image correctly moved Sharp from `linuxmusl-x64` to `linux-x64`, but Nitro's server bundle includes Sharp's native binding while omitting the matching optional `@img/sharp-libvips-linux-x64` package. Sharp 0.34.5 then fails at startup looking for `libvips-cpp.so.8.17.3`.

### Fix
- Explicitly install Sharp 0.34.5 for Linux x64 during the Docker build, per Nuxt Image's cross-platform guidance.
- Assert the matching libvips package exists during build.
- Copy `@img/sharp-libvips-linux-x64` into the server node_modules resolution path alongside Nitro output.
- Keep the existing Bookworm base and `.env` runtime mount unchanged.

### Verification
CI covers the repository change. The decisive smoke test is rebuilding on Alexandria and starting the Unraid container; the build now fails early if the libvips package is absent instead of producing a crash-looping image.

### Stakes
Reversible Docker packaging change only. No schema, secrets, DNS, OAuth, or production-data mutation.