### PR TITLE
Use cafepurr for self-hosted Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,9 @@ services:
     volumes:
       - ${KIND_ROBOTS_ENV_FILE:-./.env}:/config/kind-robots.env:ro
       - ${KIND_ROBOTS_MEDIA_PATH:-/mnt/user/pc/kindrobots/images}:/app/.output/public/images:rw
+    networks:
+      - cafepurr
+
+networks:
+  cafepurr:
+    external: true


### PR DESCRIPTION
Keep the app-side Compose defaults aligned with the Unraid deployment.

- Preserve host port `3009 -> 3000`.
- Attach Kind Robots to the existing external `cafepurr` network.

No runtime code, secrets, DNS, OAuth, or production-data changes.