### PR TITLE
Expose Sharp libvips to the runtime linker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,10 @@ COPY . .
 
 RUN DATABASE_URL=mysql://kindrobots:build-only@127.0.0.1:3306/kindrobots npm ci --include=optional
 # Nuxt Image/IPX uses Sharp at runtime. Ask npm explicitly for the Linux x64
-# platform pair so both the native Sharp binding and its matching libvips
-# package are guaranteed to exist even when the lockfile was produced on
-# another platform.
-RUN npm install --no-save --package-lock=false --os=linux --cpu=x64 sharp@0.34.5
-RUN test -d /app/node_modules/@img/sharp-libvips-linux-x64
+# glibc platform pair so both the native Sharp binding and its matching libvips
+# package are guaranteed to exist even when the lockfile was produced elsewhere.
+RUN npm install --no-save --package-lock=false --os=linux --cpu=x64 --libc=glibc sharp@0.34.5
+RUN test -d /app/node_modules/@img/sharp-libvips-linux-x64/lib
 RUN DATABASE_URL=mysql://kindrobots:build-only@127.0.0.1:3306/kindrobots npm run build
 
 FROM node:24-bookworm-slim AS runtime
@@ -31,10 +30,11 @@ ENV NODE_ENV=production \
 COPY --from=build --chown=node:node /app/.output ./.output
 COPY --from=build --chown=node:node /app/node_modules ./node_modules
 COPY --from=build --chown=node:node /app/package.json ./package.json
-# Nitro bundles Sharp into its private node_modules tree but can omit Sharp's
-# optional libvips package. Put the matching package in the normal server
-# node_modules resolution path so bundled Sharp can load libvips at runtime.
-COPY --from=build --chown=node:node /app/node_modules/@img/sharp-libvips-linux-x64 /app/.output/server/node_modules/@img/sharp-libvips-linux-x64
+# Nitro bundles Sharp's native binding privately. Make the matching prebuilt
+# libvips shared libraries available to the system dynamic linker so the
+# binding can load regardless of Nitro's nested node_modules layout.
+COPY --from=build /app/node_modules/@img/sharp-libvips-linux-x64/lib/ /usr/local/lib/
+RUN ldconfig && test -e /usr/local/lib/libvips-cpp.so.8.17.3
 
 RUN ln -s /app/.output/public /app/public
 


### PR DESCRIPTION
### Root cause
The Bookworm image now loads Sharp's `linux-x64` native binding correctly, but the binding still fails because the dynamic linker cannot find `libvips-cpp.so.8.17.3`. The matching `@img/sharp-libvips-linux-x64` package is installed in the build stage, but Nitro's private bundle layout does not make its shared library discoverable at runtime.

### Fix
- Explicitly target Linux x64 glibc when installing Sharp 0.34.5.
- Assert the libvips package's `lib` directory exists during the image build.
- Copy the packaged libvips shared libraries into `/usr/local/lib` in the runtime image.
- Run `ldconfig` and assert `libvips-cpp.so.8.17.3` exists before producing the image.

This keeps the existing Bookworm base, env mount, cafepurr networking, port mapping, and media mount unchanged.

### Verification
CI covers the repository change. The decisive smoke test is rebuilding and starting the image on Alexandria; the Docker build itself now fails if the exact shared library that caused the crash is absent.

### Stakes
Reversible Docker packaging change only. No schema, secrets, DNS, OAuth, or production-data mutation.