### PR TITLE
digital-storefront/t-040: vendor-agnostic POD submission client (guarded, inert without credentials)

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "test:model-builder-run-writable-guard-selftest": "tsx utils/scripts/verifyModelBuilderRunWritableGuard.test.ts",
     "test:model-builder-run-writable-guard": "tsx utils/scripts/verifyModelBuilderRunWritableGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
+    "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",
     "audit:wonderlab-previews": "tsx utils/scripts/auditWonderLabPreviews.ts",
     "components:manifest": "node utils/scripts/create-component-json.mjs",

--- a/server/api/store/podCatalog.ts
+++ b/server/api/store/podCatalog.ts
@@ -4,7 +4,11 @@
 // webhook's handleGiftshopCartPurchase (general multi-item cart, t-033).
 // Keys match both stores/seeds/cartItems.ts ids and pod-checkout.post.ts's
 // printType param — not real Printful catalog ids (no vendor account/API key
-// exists yet, digital-storefront/t-015, needs-human).
+// exists yet, digital-storefront/t-015, needs-human). Every printfulVariantId
+// below is a PLACEHOLDER_* string until then; server/utils/podVendorClient.ts's
+// isPlaceholderVariantId()/submitPodOrder() refuse to submit one to Printful,
+// so replacing these with real catalog ids is what actually unblocks
+// submission (digital-storefront/t-040) once an account exists.
 export const POD_CATALOG: Record<
   string,
   { title: string; priceCents: number; printfulVariantId: string }

--- a/server/utils/podVendorClient.ts
+++ b/server/utils/podVendorClient.ts
@@ -1,0 +1,166 @@
+// /server/utils/podVendorClient.ts
+//
+// Vendor-agnostic print-on-demand submission client (digital-storefront/t-040,
+// splitting the "reversible integration/test plumbing" half of the task from
+// the account-creation/credentials half, which stays needs-human).
+//
+// Printful was the provider decision (digital-storefront/t-015,
+// projects/digital-storefront/research/pod-provider.md) but no account or
+// API key has been provisioned yet. This module is structurally inert until
+// PRINTFUL_API_KEY is set in the environment: submitPodOrder() throws a
+// clear "not configured" error rather than attempting any network call, so
+// wiring it into a caller (e.g. the Stripe webhook's PrintJob creation) is
+// safe to land now and self-activates the moment Silas adds the key.
+//
+// Env vars this expects once an account exists (documented here since the
+// repo has no .env.example to add them to):
+//   PRINTFUL_API_KEY   - Printful Private Token / OAuth2 Bearer token
+//   PRINTFUL_STORE_ID  - Printful store id the Sync-Order API call targets
+import { createError } from 'h3'
+import type { PrintJobStatus } from '~/prisma/generated/prisma/client'
+
+export class PodVendorNotConfiguredError extends Error {
+  constructor() {
+    super(
+      'Printful is not configured (PRINTFUL_API_KEY missing) -- ' +
+        'digital-storefront/t-040 remains needs-human until Silas ' +
+        'provisions a vendor account.',
+    )
+    this.name = 'PodVendorNotConfiguredError'
+  }
+}
+
+export class PodVendorInvalidVariantError extends Error {
+  constructor(printfulVariantId: string) {
+    super(
+      `refusing to submit a PrintJob with placeholder variant id ` +
+        `"${printfulVariantId}" -- podCatalog.ts's ids are not real ` +
+        `Printful catalog ids yet (digital-storefront/t-015)`,
+    )
+    this.name = 'PodVendorInvalidVariantError'
+  }
+}
+
+export interface PodOrderRequest {
+  printfulVariantId: string
+  quantity: number
+  recipientName: string
+  addressLine1: string
+  addressLine2?: string
+  city: string
+  stateCode?: string
+  countryCode: string
+  zip: string
+  imageUrl: string
+}
+
+export interface PodOrderResult {
+  printfulOrderId: string
+  status: PrintJobStatus
+}
+
+// Any podCatalog.ts / test fixture id that hasn't been replaced with a real
+// Printful catalog variant id yet.
+export function isPlaceholderVariantId(printfulVariantId: string): boolean {
+  return printfulVariantId.startsWith('PLACEHOLDER_')
+}
+
+// Maps a Printful Sync-Order `status` value onto our PrintJobStatus enum.
+// Printful's real status vocabulary (draft/pending/inprocess/onhold/partial/
+// fulfilled/canceled/failed) per their Orders API docs. Exported standalone
+// so the mapping itself is testable without a live call.
+export function mapPrintfulStatus(printfulStatus: string): PrintJobStatus {
+  switch (printfulStatus) {
+    case 'pending':
+    case 'draft':
+      return 'SUBMITTED'
+    case 'inprocess':
+    case 'onhold':
+    case 'partial':
+      return 'IN_PRODUCTION'
+    case 'fulfilled':
+      return 'SHIPPED'
+    case 'canceled':
+    case 'failed':
+      return 'FAILED'
+    default:
+      // Unknown status from the vendor: don't guess at SHIPPED/FAILED,
+      // leave the job exactly where it already is (caller keeps existing
+      // status when this branch is hit -- see submitPodOrder's caller
+      // contract in the webhook wiring this unblocks).
+      return 'SUBMITTED'
+  }
+}
+
+function isConfigured(): boolean {
+  return Boolean(process.env.PRINTFUL_API_KEY)
+}
+
+// Submits a PrintJob to Printful's Sync-Order create endpoint. Throws
+// PodVendorNotConfiguredError if no API key is set (always true in this
+// sandbox/session) and PodVendorInvalidVariantError if the caller passes a
+// still-placeholder variant id -- both fail loudly before any network call
+// rather than silently no-op, so a caller can't accidentally treat "did
+// nothing" as "succeeded."
+export async function submitPodOrder(
+  request: PodOrderRequest,
+): Promise<PodOrderResult> {
+  if (isPlaceholderVariantId(request.printfulVariantId)) {
+    throw new PodVendorInvalidVariantError(request.printfulVariantId)
+  }
+  if (!isConfigured()) {
+    throw new PodVendorNotConfiguredError()
+  }
+
+  const storeId = process.env.PRINTFUL_STORE_ID
+  const response = await fetch('https://api.printful.com/orders', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.PRINTFUL_API_KEY}`,
+      'Content-Type': 'application/json',
+      ...(storeId ? { 'X-PF-Store-Id': storeId } : {}),
+    },
+    body: JSON.stringify({
+      recipient: {
+        name: request.recipientName,
+        address1: request.addressLine1,
+        address2: request.addressLine2,
+        city: request.city,
+        state_code: request.stateCode,
+        country_code: request.countryCode,
+        zip: request.zip,
+      },
+      items: [
+        {
+          sync_variant_id: request.printfulVariantId,
+          quantity: request.quantity,
+          files: [{ url: request.imageUrl }],
+        },
+      ],
+    }),
+  })
+
+  if (!response.ok) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: `Printful order submission failed: HTTP ${response.status}`,
+    })
+  }
+
+  const body = (await response.json()) as {
+    result: { id: number; status: string }
+  }
+
+  return {
+    printfulOrderId: String(body.result.id),
+    status: mapPrintfulStatus(body.result.status),
+  }
+}
+
+// True when submitPodOrder() would actually attempt a live call -- callers
+// (e.g. the webhook's PrintJob creation) use this to decide whether to try
+// submission at all, so an unconfigured environment stays a silent no-op
+// (today's behavior) instead of throwing on every checkout.
+export function isPodVendorConfigured(): boolean {
+  return isConfigured()
+}

--- a/utils/scripts/verifyPodVendorClient.test.ts
+++ b/utils/scripts/verifyPodVendorClient.test.ts
@@ -1,0 +1,69 @@
+// /utils/scripts/verifyPodVendorClient.test.ts
+//
+// Self-test for server/utils/podVendorClient.ts (digital-storefront/t-040).
+// No network access, no DB, no env vars set -- exercises the pure status
+// mapping plus the two guarded-throw paths (placeholder variant id,
+// unconfigured vendor) that keep submitPodOrder() structurally incapable of
+// a live call until Silas provisions PRINTFUL_API_KEY.
+import assert from 'node:assert/strict'
+
+import {
+  isPlaceholderVariantId,
+  mapPrintfulStatus,
+  isPodVendorConfigured,
+  submitPodOrder,
+  PodVendorNotConfiguredError,
+  PodVendorInvalidVariantError,
+} from '../../server/utils/podVendorClient'
+
+// -- isPlaceholderVariantId --------------------------------------------
+assert.equal(isPlaceholderVariantId('PLACEHOLDER_STICKER'), true)
+assert.equal(isPlaceholderVariantId('12345'), false)
+
+// -- mapPrintfulStatus ---------------------------------------------------
+assert.equal(mapPrintfulStatus('draft'), 'SUBMITTED')
+assert.equal(mapPrintfulStatus('pending'), 'SUBMITTED')
+assert.equal(mapPrintfulStatus('inprocess'), 'IN_PRODUCTION')
+assert.equal(mapPrintfulStatus('onhold'), 'IN_PRODUCTION')
+assert.equal(mapPrintfulStatus('partial'), 'IN_PRODUCTION')
+assert.equal(mapPrintfulStatus('fulfilled'), 'SHIPPED')
+assert.equal(mapPrintfulStatus('canceled'), 'FAILED')
+assert.equal(mapPrintfulStatus('failed'), 'FAILED')
+// Unknown vendor status: don't guess terminal states.
+assert.equal(mapPrintfulStatus('some_future_status'), 'SUBMITTED')
+
+// -- isPodVendorConfigured / submitPodOrder guards -----------------------
+// This process never has PRINTFUL_API_KEY set in CI or this sandbox, so the
+// "not configured" branch is the real, always-exercised path.
+assert.equal(process.env.PRINTFUL_API_KEY, undefined)
+assert.equal(isPodVendorConfigured(), false)
+
+const baseRequest = {
+  printfulVariantId: 'PLACEHOLDER_STICKER',
+  quantity: 1,
+  recipientName: 'Test Recipient',
+  addressLine1: '1 Test St',
+  city: 'Testville',
+  countryCode: 'US',
+  zip: '00000',
+  imageUrl: 'https://example.com/kr-logo.png',
+}
+
+await assert.rejects(
+  () => submitPodOrder(baseRequest),
+  PodVendorInvalidVariantError,
+  'expected a placeholder variant id to be rejected before checking configuration',
+)
+
+await assert.rejects(
+  () => submitPodOrder({ ...baseRequest, printfulVariantId: '98765' }),
+  PodVendorNotConfiguredError,
+  'expected an unconfigured vendor (no PRINTFUL_API_KEY) to throw rather than attempt a live call',
+)
+
+console.log(
+  'POD vendor client verified: status mapping is correct for every known ' +
+    'Printful status plus an unknown-status fallback, and submitPodOrder() ' +
+    'refuses placeholder variant ids and unconfigured credentials before ' +
+    'any network call -- structurally inert until PRINTFUL_API_KEY is set.',
+)


### PR DESCRIPTION
## Summary

Builds the "reversible integration/test plumbing" half of digital-storefront/t-040 ("Resolve the first real POD fulfillment path rather than stopping at a pending PrintJob"). The other half — an actual Printful account/API key, live order submission, and making the KR-logo item genuinely orderable — needs Silas and stays `needs-human` on the conductor roadmap.

Printful was the provider decision (digital-storefront/t-015, `projects/digital-storefront/research/pod-provider.md`), but no account/API key has ever been provisioned. `t-037`'s audit confirmed `PrintJob.printfulOrderId` is never set anywhere and `podCatalog.ts`'s vendor variant ids are still literal placeholders — no vendor integration code existed at all before this PR.

## What changed

- **`server/utils/podVendorClient.ts`** (new) — a Printful Sync-Order client (`submitPodOrder`) that is structurally incapable of a live network call right now:
  - Throws `PodVendorNotConfiguredError` if `PRINTFUL_API_KEY` isn't set (always true today).
  - Throws `PodVendorInvalidVariantError` if the caller passes a still-placeholder `podCatalog.ts` variant id (checked *before* the configuration check).
  - Exports `mapPrintfulStatus()` (Printful order status → our `PrintJobStatus` enum) as pure, independently-testable logic.
  - Exports `isPodVendorConfigured()` so a future caller (e.g. the Stripe webhook's `PrintJob` creation) can decide whether to attempt submission at all, keeping today's behavior (silent no-op, status stays `PENDING`) unchanged when unconfigured.
  - Documents the two env vars a real account will need (`PRINTFUL_API_KEY`, `PRINTFUL_STORE_ID`) since this repo has no `.env.example` to add them to.
- **`utils/scripts/verifyPodVendorClient.test.ts`** (new, `npm run test:pod-vendor-client-selftest`) — no network/DB dependency, exercises the full Printful status vocabulary mapping plus both guarded-throw paths.
- **`server/api/store/podCatalog.ts`** — header comment now points at the new guard so the placeholder-id story and its resolution live in one place.
- **`package.json`** — registers the new self-test script.

## Deliberately NOT in this PR

- No wiring into `server/api/stripe/webhook.post.ts` (`handleGiftshopCartPurchase`/`createPrintJobIfEligible`). That file handles real Stripe money flows today; wiring vendor submission into it deserves its own focused, carefully-reviewed change rather than riding along here.
- No inbound Printful webhook receiver (order-status sync) — speculative until an account/webhook-signing secret exists.
- No KR-logo `Product`/checkout seeding — a separate, adjacent audit gap, out of scope for this slice.
- No account creation, credentials, or live/sandbox order submission — needs Silas.

## Verification

- `eslint` clean on all touched/new files
- `vue-tsc --noEmit` clean
- `prettier --check` clean
- `npm run test:pod-vendor-client-selftest` passes
- `git diff --stat` confirms only the intended 4 files changed

## Stakes

Reversible. New code is additive-only and inert without `PRINTFUL_API_KEY`, which does not exist in any environment yet — no behavior change to any existing flow.

Tracked in conductor `digital-storefront/t-040`.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012nNPhfgyQnt8WEGYeBqcbN)_