### PR TITLE
Set container-visible image storage path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       PORT: 3000
       NITRO_HOST: 0.0.0.0
       NITRO_PORT: 3000
+      IMAGES_PATH: /app/.output/public/images
     volumes:
       - ${KIND_ROBOTS_ENV_FILE:-./.env}:/config/kind-robots.env:ro
       - ${KIND_ROBOTS_MEDIA_PATH:-/mnt/user/pc/kindrobots/images}:/app/.output/public/images:rw


### PR DESCRIPTION
Keep the shared `.env` portable across WSL and Unraid by overriding `IMAGES_PATH` inside the container to the mounted media path `/app/.output/public/images`. This prevents a WSL-native `IMAGES_PATH` such as `/mnt/z/kindrobots/images` from being used inside Docker. No secrets, schema, DNS, OAuth, or production data changes.