### PR TITLE
Bound the startup loader and first navigation; fix the bot sidebar scroll

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -257,6 +257,43 @@ function handlePageReady(): void {
   }
 }
 
+/*
+ * ARMED IN SETUP, NOT onMounted -- and that distinction is the whole bug.
+ *
+ * Silas, 2026-08-09: "Whenever I load the site from a non-root address of
+ * kind-robots.vercel.app/ we are seeing our loading animation on loop."
+ *
+ * The z-48 black base below is SSR-rendered and gated on `showLoader`, and only
+ * two things ever clear it: kind-loader's `pageReady` (inside <ClientOnly>, so
+ * it needs a mounted app) and this timer. Parking the timer in `onMounted` put
+ * BOTH escapes behind the same door.
+ *
+ * pages/[...slug].vue -- the page component for nearly every route, including
+ * `/` -- has a top-level `await useAsyncData(...)` in <script setup>. Nuxt
+ * wraps a page in `Suspense` with `suspensible: true`, which propagates to the
+ * root Suspense that `deferHydration()` is waiting on. So while that content
+ * query is outstanding the root never finishes hydrating, `onMounted` never
+ * fires, the failsafe is never armed, and the black cover has no upper bound at
+ * all. Production has been logging exactly that outstanding query since
+ * 2026-08-06: `[performFetch] Failed after 1 attempt(s): AbortError` on the
+ * `/[...slug]` route, alongside 40s function timeouts.
+ *
+ * setup() DOES run in that state -- hydration walks the root before it reaches
+ * the suspended child -- so a timer started here survives a page that never
+ * settles. A failsafe downstream of the thing it exists to catch is not a
+ * failsafe.
+ *
+ * The delay still clears the graceful path: loading-messages fades by ~5.7s
+ * worst case (INTRO_MAX_MS + the 650ms fade), so at 9s this only ever fires
+ * when the normal handoff did not.
+ */
+if (import.meta.client) {
+  failsafeTimeoutId = setTimeout(() => {
+    showLoader.value = false
+    failsafeTimeoutId = null
+  }, 9000)
+}
+
 const isMd = ref(false)
 const isXl = ref(false)
 
@@ -404,15 +441,10 @@ onMounted(async () => {
   xlMedia.addEventListener('change', syncBreakpoints)
 
   /*
-   * Last-resort only. The intro fades on its own by ~5.7s worst case
-   * (loading-messages.vue: INTRO_MAX_MS + the 650ms fade), so this must sit
-   * well clear of that — at 8s it used to rip the loader out mid-sequence and
-   * pre-empt the graceful fade on every slow load.
+   * The loader failsafe used to be armed HERE. It moved into setup() -- see the
+   * note beside `showLoader` -- because reaching this hook is precisely what a
+   * stalled page prevents.
    */
-  failsafeTimeoutId = setTimeout(() => {
-    showLoader.value = false
-    failsafeTimeoutId = null
-  }, 9000)
 })
 
 onBeforeUnmount(() => {

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -37,9 +37,11 @@
     simply clipped and there was no way to reach the settings panel underneath
     the conversation.
 
-    So the hidden overflow is now the WIDE case only. The panes keep their own
-    scrollers either way, which is why this does not turn into two competing
-    scroll owners at xl -- the same mistake that broke the card back in #1631.
+    So the hidden overflow is now the WIDE case only. That is only safe because
+    both panes own an inner scroller at xl -- the conversation via its
+    `minmax(0,1fr)` row, and the aside via the `overflow-y-auto` below. When
+    this comment was written the aside did NOT have one, so at xl its lower
+    sections were clipped unreachable; see the note on the <aside>.
   -->
   <section
     class="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-y-auto xl:grid-cols-[minmax(0,1fr)_minmax(320px,420px)] xl:overflow-hidden"
@@ -214,7 +216,29 @@
       </div>
     </div>
 
-    <aside class="flex min-h-0 flex-col gap-4 overflow-hidden">
+    <!--
+      THE SIDEBAR SCROLLS ITSELF. Silas, 2026-08-09, on a DESKTOP: "the bot
+      interact session controls window cannot vert scroll, so it's not just
+      mobile."
+
+      This was `overflow-hidden`, and the note on the grid above claimed "the
+      panes keep their own scrollers either way" -- which was true of the
+      conversation pane and false of this one. The aside stacks four sections
+      (Session Controls, Selected Bot, the art manager, Prompt Preview) that
+      together run well past any viewport, and only the Prompt Preview's <pre>
+      had a scroller of its own. At xl the aside is bounded by the grid row, so
+      `overflow-hidden` clipped the rest with no way to reach it. Below xl the
+      parent scrolls, which is why the tablet report read as fixed while the
+      desktop one did not.
+
+      SCOPED TO xl, so the two cases stay complementary rather than nested.
+      Below xl the section above owns the scroll for the whole stack and a
+      scroller here would be a second one inside it; at xl that section is
+      `overflow-hidden` and this is the only thing that can scroll the sidebar.
+      Exactly one scroll owner is live at any width, which is also what keeps
+      the one-scroll layout contract satisfied.
+    -->
+    <aside class="flex min-h-0 flex-col gap-4 xl:overflow-y-auto">
       <section class="kr-panel-flat p-4">
         <div class="mb-3 flex items-center justify-between gap-2">
           <div>
@@ -354,7 +378,14 @@
         ]"
       />
 
-      <section class="min-h-0 flex-1 overflow-hidden kr-panel-flat p-4">
+      <!--
+        `shrink-0` with a FIXED cap, not `flex-1` + `max-h-full`. Now that the
+        aside scrolls, it has no definite height for a percentage to resolve
+        against, so `max-h-full` on the <pre> below would have computed to
+        `none` and let a long prompt push every sibling out of reach -- the
+        same indefinite-parent trap that made the card back unscrollable.
+      -->
+      <section class="shrink-0 kr-panel-flat p-4">
         <div class="mb-3 flex items-center justify-between gap-2">
           <h2 class="text-lg font-bold text-base-content">Prompt Preview</h2>
 
@@ -369,7 +400,7 @@
         </div>
 
         <pre
-          class="max-h-full overflow-auto whitespace-pre-wrap rounded-2xl bg-base-200 p-3 text-xs text-base-content/70"
+          class="max-h-80 overflow-auto whitespace-pre-wrap rounded-2xl bg-base-200 p-3 text-xs text-base-content/70"
           >{{ promptPreview }}</pre>
       </section>
     </aside>

--- a/middleware/navigation-access.global.ts
+++ b/middleware/navigation-access.global.ts
@@ -3,6 +3,14 @@ import { evaluateNavigationRouteAccess } from '@/stores/helpers/navigationRouteA
 import { useChannelContentStore } from '@/stores/channelContentStore'
 import { useUserStore } from '@/stores/userStore'
 
+/*
+ * How long the first navigation will wait on the user and channel stores before
+ * proceeding ungated. Comfortably above a healthy round trip and comfortably
+ * below app.vue's 9s loader failsafe, so a degraded backend produces a usable
+ * page rather than a race between two deadlines.
+ */
+const INITIALIZE_TIMEOUT_MS = 4000
+
 const navigationReturnStorageKey = 'kindrobots:navigation-return-to'
 const accountPermissions = new Set([
   'authenticated',
@@ -49,9 +57,26 @@ export default defineNuxtRouteMiddleware(async (to) => {
   const userStore = useUserStore()
   const channelContentStore = useChannelContentStore()
 
-  await Promise.all([
-    userStore.initialize(),
-    channelContentStore.initialize(),
+  /*
+   * BOUNDED. This runs before the first route resolves, so anything it awaits
+   * is on the critical path to the app being visible at all -- and
+   * `channelContentStore.initialize()` ends in `queryCollection('channels')`,
+   * while `userStore.initialize()` reaches the API. Neither carried a deadline,
+   * so a slow or failing backend held the initial navigation open indefinitely.
+   * Production has been logging both since 2026-08-06: AbortErrors on
+   * `/[...slug]` and 40s function timeouts.
+   *
+   * Timing out here is SAFE, and deliberately so: the access check below opens
+   * with `if (!access.matched || access.allowed) return`, and an unpopulated
+   * channel list matches nothing. So the degraded outcome is "this middleware
+   * declines to gate", never "this middleware locks someone out" or, worse,
+   * bounces them to /login and back while the page underneath is still
+   * suspended. Whatever did resolve is kept -- the stores hold their own state,
+   * and the losing promise still settles into them for the next navigation.
+   */
+  await Promise.race([
+    Promise.all([userStore.initialize(), channelContentStore.initialize()]),
+    new Promise((resolve) => setTimeout(resolve, INITIALIZE_TIMEOUT_MS)),
   ])
 
   const requestedLoginReturn = safeReturnPath(to.query.redirect)


### PR DESCRIPTION
Two reports from 2026-08-09. The loading loop is the serious one.

## "loading animation on loop" from any non-root address

`app.vue` renders an SSR-rendered `z-48` black cover gated on `showLoader`, and exactly two things ever clear it: `kind-loader`'s `pageReady` (inside `<ClientOnly>`, so it needs a mounted app) and a 9s failsafe. **The failsafe was armed in `onMounted`** — which put both escapes behind the same door.

`pages/[...slug].vue`, the page component for nearly every route, has a top-level `await useAsyncData(...)` in `<script setup>`. Nuxt wraps a page in `Suspense` with `suspensible: true`, which propagates to the root Suspense that `deferHydration()` waits on. While that content query is outstanding the root never finishes hydrating, `onMounted` never fires, and the black cover has **no upper bound at all**. A failsafe downstream of the thing it exists to catch is not a failsafe.

`setup()` *does* run in that state — hydration walks the root before it reaches the suspended child — so the timer moves there. Nothing else about the sequence changes: the graceful handoff still fades by ~5.7s and the 9s timer only fires when it didn't.

The same critical path had a second unbounded wait. The global `navigation-access` middleware awaits `userStore.initialize()` and `channelContentStore.initialize()` before the first route resolves, with no deadline, and the latter ends in a `queryCollection('channels')`. That is now raced against a 4s timeout. **Timing out is the safe direction on purpose:** the access check opens with `if (!access.matched || access.allowed) return`, and an unpopulated channel list matches nothing — so the degraded outcome is "declines to gate," never "locks someone out" or, worse, bounces them to `/login` and back while the page underneath is still suspended.

### Why now, and why not `/`

Nothing in the loader changed recently — its current design landed 2026-08-05. What changed is the backend. Production runtime errors show, starting **2026-08-06T23:08** and ongoing:

- `[performFetch] Failed after 1 attempt(s): DOMException [AbortError]` on route `/[...slug]` — 303 occurrences, 61 users
- `Vercel Runtime Timeout Error: Task timed out after 40 seconds` on `/api/facets/catalog` and `/api/art/collection/folders`
- `pool failed to retrieve a connection from pool (active=0 idle=0 limit=1)` across ~24 API routes

So the loader has always been this fragile; it started biting when the API got slow enough to stall the content query. And `/` is the one path the middleware explicitly refuses to redirect (`// Avoid an impossible redirect loop if Home is ever accidentally gated`), so a deep link had a failure mode the root did not.

This bounds the symptom. It does **not** fix the API latency underneath — the pool limits in `server/utils/databasePoolDefaults.ts` are deliberate, documented output of a prior ProxySQL frontend-exhaustion incident, and that file explicitly warns against reflexively widening them. That's a separate call.

## "the bot interact session controls window cannot vert scroll, so it's not just mobile"

`bot-chat`'s `<aside>` was `overflow-hidden`, and the comment above it claimed both panes kept their own scrollers — true of the conversation pane, false of the sidebar. It stacks four sections (Session Controls, Selected Bot, the art manager, Prompt Preview) and only the Prompt Preview's `<pre>` could scroll, so at `xl` everything below the fold was clipped unreachable. Below `xl` the parent scrolls, which is why the tablet report read as fixed and the desktop one did not.

The sidebar's scroller is scoped to `xl` so exactly one owner is live at any width — which is also what keeps the `one-scroll` layout contract satisfied without reaching for the `.kr-panes` escape hatch (that would have changed the below-`xl` stacking this same file fixed yesterday). Prompt Preview swaps `flex-1` + `max-h-full` for a fixed cap, since a percentage max-height against a now-indefinite parent computes to `none`.

## Verification

- `npm run test` (vue-tsc) — clean
- `verify-startup-handoff.mjs` — passes (the z-48/z-49/z-50 stack and CSS-only cover release are unchanged)
- `test:layout-contract` — holds, `one-scroll` back to 0 new
- `test:lint-ratchet` — 392 problems across 27 rules, unchanged
- `verifyNavigationRouteAccess` — passes
- `prettier --check` on every changed file — clean

Not verified in a browser: no browser egress in this session, so the hydration-stall path is reasoned from the Suspense/`deferHydration` chain plus the production error signature, not watched to recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_