### PR TITLE
Serve mounted media through Nitro /images routes

### DIFF
--- a/server/routes/images/[...path].get.ts
+++ b/server/routes/images/[...path].get.ts
@@ -1,0 +1,69 @@
+import { createReadStream } from 'node:fs'
+import { stat } from 'node:fs/promises'
+import path from 'node:path'
+import {
+  createError,
+  defineEventHandler,
+  getRouterParam,
+  sendStream,
+  setResponseHeader,
+} from 'h3'
+import { getImageStorageRoot } from '~/server/utils/imageStorageRoot'
+
+const CONTENT_TYPES: Record<string, string> = {
+  '.avif': 'image/avif',
+  '.gif': 'image/gif',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.json': 'application/json; charset=utf-8',
+  '.mp4': 'video/mp4',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml; charset=utf-8',
+  '.webm': 'video/webm',
+  '.webp': 'image/webp',
+}
+
+export default defineEventHandler(async (event) => {
+  const rawPath = getRouterParam(event, 'path') || ''
+
+  let relativePath = rawPath
+  try {
+    relativePath = decodeURIComponent(rawPath)
+  } catch {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid image path' })
+  }
+
+  relativePath = relativePath.replace(/^\/+/, '')
+  if (!relativePath) {
+    throw createError({ statusCode: 404, statusMessage: 'Image not found' })
+  }
+
+  const root = getImageStorageRoot()
+  const filePath = path.resolve(root, relativePath)
+  const rootPrefix = root.endsWith(path.sep) ? root : `${root}${path.sep}`
+
+  if (!filePath.startsWith(rootPrefix)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid image path' })
+  }
+
+  let fileStat
+  try {
+    fileStat = await stat(filePath)
+  } catch {
+    throw createError({ statusCode: 404, statusMessage: 'Image not found' })
+  }
+
+  if (!fileStat.isFile()) {
+    throw createError({ statusCode: 404, statusMessage: 'Image not found' })
+  }
+
+  const contentType = CONTENT_TYPES[path.extname(filePath).toLowerCase()]
+  if (contentType) setResponseHeader(event, 'Content-Type', contentType)
+
+  setResponseHeader(event, 'Content-Length', String(fileStat.size))
+  setResponseHeader(event, 'Last-Modified', fileStat.mtime.toUTCString())
+  setResponseHeader(event, 'Cache-Control', 'public, max-age=3600')
+  setResponseHeader(event, 'X-Content-Type-Options', 'nosniff')
+
+  return sendStream(event, createReadStream(filePath))
+})

--- a/server/routes/images/[...path].get.ts
+++ b/server/routes/images/[...path].get.ts
@@ -26,7 +26,7 @@ const CONTENT_TYPES: Record<string, string> = {
 export default defineEventHandler(async (event) => {
   const rawPath = getRouterParam(event, 'path') || ''
 
-  let relativePath = rawPath
+  let relativePath: string
   try {
     relativePath = decodeURIComponent(rawPath)
   } catch {
@@ -60,7 +60,7 @@ export default defineEventHandler(async (event) => {
   const contentType = CONTENT_TYPES[path.extname(filePath).toLowerCase()]
   if (contentType) setResponseHeader(event, 'Content-Type', contentType)
 
-  setResponseHeader(event, 'Content-Length', String(fileStat.size))
+  setResponseHeader(event, 'Content-Length', fileStat.size)
   setResponseHeader(event, 'Last-Modified', fileStat.mtime.toUTCString())
   setResponseHeader(event, 'Cache-Control', 'public, max-age=3600')
   setResponseHeader(event, 'X-Content-Type-Options', 'nosniff')


### PR DESCRIPTION
### Root cause
Vercel makes legacy `/images/...` entity paths work by redirecting them to `https://media.acrocatranch.com/images/...`. The self-hosted Nitro server has no equivalent behavior. Its public-asset manifest is produced at build time, so files bind-mounted into `.output/public/images` at runtime are not discovered as static assets even though they exist on disk.

### Fix
- Add a catch-all Nitro route for `/images/**`.
- Resolve files from the existing `getImageStorageRoot()` / `IMAGES_PATH` contract.
- Stream runtime-mounted files with appropriate content type, size, modification time and one-hour cache headers.
- Reject path traversal and non-files.

This makes Alexandria's direct `:3009` path honor the same stable `/images/...` URL contract as Vercel without depending on Vercel's redirect layer.

### Reproduction
`/images/characters/bb-hope.webp` exists on `/mnt/user/pc/kindrobots/images` and returns 200 from `media.acrocatranch.com`, but 404s from Alexandria's Nitro server. Database-backed `/api/art/images/.../file` assets already work.

No schema, secrets, DNS, OAuth, or production-data changes.