### PR TITLE
Stop editing a Bot from routing to chat; let the app remove the boot cover

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -220,6 +220,7 @@ import { useNavStore } from '@/stores/navStore'
 import { usePageStore } from '@/stores/pageStore'
 import { useUserStore } from '@/stores/userStore'
 import { useIntroStore } from '@/stores/introStore'
+import { retireBootCover } from '@/utils/startupLaunch'
 
 const pageStore = usePageStore()
 
@@ -291,6 +292,15 @@ if (import.meta.client) {
   failsafeTimeoutId = setTimeout(() => {
     showLoader.value = false
     failsafeTimeoutId = null
+
+    /*
+     * The server cover normally retires on its own 6s keyframe, or early via
+     * markAppReady() once kind-loader runs. Neither is guaranteed here -- this
+     * branch exists precisely for the case where the app never reached
+     * kind-loader, and the keyframe shares an inline <style> block that has
+     * been observed not to apply. Removing the node needs neither.
+     */
+    retireBootCover()
   }, 9000)
 }
 

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -934,7 +934,18 @@ const canEditInfoBot = computed(() => {
  * how you save changes onto the wrong Bot.
  */
 watch(infoEditing, async (isEditing) => {
-  if (!isEditing || !infoBotId.value) return
+  /*
+   * Leaving edit mode releases the routing flag `startEditingBot` set. Without
+   * this, a user who opened the editor from an in-progress chat would be held
+   * on the gallery afterwards -- the same bug bot-interact's isInteractMode
+   * note describes, pointing the other way.
+   */
+  if (!isEditing) {
+    botStore.editingBotId = null
+    return
+  }
+
+  if (!infoBotId.value) return
   await botStore.startEditingBot(infoBotId.value)
 })
 
@@ -1038,12 +1049,19 @@ function clearSelectedBot() {
   showBotForm.value = false
 }
 
+/*
+ * Both of these release the routing flag for the same reason the infoEditing
+ * watcher does: the in-gallery form is the other caller of startEditingBot,
+ * and a flag left set after it closes would pin the router to the gallery.
+ */
 function closeBotForm() {
   showBotForm.value = false
+  botStore.editingBotId = null
 }
 
 async function handleBotSaved() {
   showBotForm.value = false
+  botStore.editingBotId = null
   await refreshBots(true)
 }
 

--- a/components/bots/bot-interact.vue
+++ b/components/bots/bot-interact.vue
@@ -54,26 +54,11 @@ import { useChatStore } from '@/stores/chatStore'
 const botStore = useBotStore()
 const chatStore = useChatStore()
 
-/*
- * A conversation in progress keeps you in the chat surface even with no Bot
- * selected, which is why this is not simply `Boolean(currentBot)`.
- *
- * AND EDITING IS NOT INTERACTING. `startEditingBot` also sets `currentBot` --
- * add-bot reads it for its guard, its reviews toggle and its save target -- so
- * on this value alone, opening the editor read as "go and chat". It unmounted
- * bot-gallery, and with it the card back the editor renders inside, landing
- * the user in the chat surface instead. Silas, 2026-08-09: "edit just brings
- * me to interact, not an edit screen, so I can't test edit yet."
- *
- * botStore.editingBotId is what separates the two intentions; it is cleared by
- * selectBot/deselectBot/startAddingBot, so finishing an edit and then choosing
- * a Bot still routes here normally.
- */
-const isInteractMode = computed(() => {
-  if (botStore.editingBotId) return false
-
-  return (
-    Boolean(botStore.currentBot) || chatStore.sessionChats('bot').length > 0
-  )
-})
+// A live conversation keeps you here with no Bot selected; an open editor does
+// NOT, though it also sets currentBot -- see editingBotId in botStore.ts.
+const isInteractMode = computed(
+  () =>
+    !botStore.editingBotId &&
+    (Boolean(botStore.currentBot) || chatStore.sessionChats('bot').length > 0),
+)
 </script>

--- a/components/bots/bot-interact.vue
+++ b/components/bots/bot-interact.vue
@@ -57,9 +57,23 @@ const chatStore = useChatStore()
 /*
  * A conversation in progress keeps you in the chat surface even with no Bot
  * selected, which is why this is not simply `Boolean(currentBot)`.
+ *
+ * AND EDITING IS NOT INTERACTING. `startEditingBot` also sets `currentBot` --
+ * add-bot reads it for its guard, its reviews toggle and its save target -- so
+ * on this value alone, opening the editor read as "go and chat". It unmounted
+ * bot-gallery, and with it the card back the editor renders inside, landing
+ * the user in the chat surface instead. Silas, 2026-08-09: "edit just brings
+ * me to interact, not an edit screen, so I can't test edit yet."
+ *
+ * botStore.editingBotId is what separates the two intentions; it is cleared by
+ * selectBot/deselectBot/startAddingBot, so finishing an edit and then choosing
+ * a Bot still routes here normally.
  */
-const isInteractMode = computed(
-  () =>
-    Boolean(botStore.currentBot) || chatStore.sessionChats('bot').length > 0,
-)
+const isInteractMode = computed(() => {
+  if (botStore.editingBotId) return false
+
+  return (
+    Boolean(botStore.currentBot) || chatStore.sessionChats('bot').length > 0
+  )
+})
 </script>

--- a/server/plugins/00-startup-composition-shell.ts
+++ b/server/plugins/00-startup-composition-shell.ts
@@ -55,6 +55,30 @@ export default defineNitroPlugin((nitroApp) => {
       `<meta name="${STARTUP_ANIMATION_META_NAME}" content="${launchSrc}">`,
     )
 
+    /*
+     * THE LAYOUT-CRITICAL DECLARATIONS ARE ALSO INLINE BELOW, and the
+     * duplication is deliberate.
+     *
+     * Silas, 2026-08-09, on /bots: "Building Kind Robots" stays above the
+     * webp, unadorned -- the title in the page's own serif on the page's own
+     * background, the image at natural width, and the app pushed DOWN below it
+     * rather than covered by it. That is this element with none of the <style>
+     * block applied: no fixed positioning, no black ground, no title plate. It
+     * reproduced on both the full startup and the fast refresh, so it is not a
+     * sequence-selection bug.
+     *
+     * Why that block does not take effect is still unexplained. The served
+     * HTML is correct (verified against production: <body>, then the <style>,
+     * then the cover), there is no CSP, and unlayered CSS in <body> outranks
+     * the app's layered Tailwind anyway. So rather than keep guessing at the
+     * cause, the handful of declarations that decide whether this thing COVERS
+     * the page or SITS IN IT also ride on a style attribute, where they cannot
+     * be lost to stylesheet parsing or cascade at all.
+     *
+     * opacity/visibility/animation stay in the block alone, on purpose: a
+     * style attribute would outrank the html.kr-app-ready rule and pin the
+     * cover open. The escape hatches have to stay beatable.
+     */
     html.bodyPrepend.unshift(`
       <style>
         .kr-boot-cover {
@@ -166,9 +190,18 @@ export default defineNitroPlugin((nitroApp) => {
         }
       </style>
 
-      <div class="kr-boot-cover" aria-hidden="true">
+      <div
+        class="kr-boot-cover"
+        aria-hidden="true"
+        style="position: fixed; inset: 0; z-index: 30; display: grid; place-items: center; padding: 1rem; background: #000; color: #fff; pointer-events: none"
+      >
         <div class="kr-boot-cover__content">
-          <p class="kr-boot-cover__title">Building Kind Robots...</p>
+          <p
+            class="kr-boot-cover__title"
+            style="background: rgba(0, 0, 0, 0.78); color: #fff; padding: 0.65rem 1.2rem; text-align: center"
+          >
+            Building Kind Robots...
+          </p>
 
           <div class="kr-boot-cover__media-frame">
             <img

--- a/stores/botStore.ts
+++ b/stores/botStore.ts
@@ -14,10 +14,7 @@ import {
 } from './helpers/botHelper'
 import { performFetch, handleError } from './utils'
 import { loadSnapshot, markSnapshotActive } from './helpers/snapshotLoader'
-import {
-  mergeDefinedRecord,
-  reconcileRecordsById,
-} from './helpers/recordMerge'
+import { mergeDefinedRecord, reconcileRecordsById } from './helpers/recordMerge'
 import { useServerStore } from './serverStore'
 import { useUserStore } from './userStore'
 import { useAchievementStore } from './achievementStore'
@@ -118,6 +115,28 @@ function normalizeBotId(input: number | string | Bot | null | undefined) {
 export const useBotStore = defineStore('botStore', () => {
   const bots: Ref<Bot[]> = ref([])
   const currentBot: Ref<Bot | null> = ref(null)
+
+  /*
+   * WHICH BOT IS OPEN FOR EDITING -- distinct from which Bot you are talking
+   * to, even though both live in `currentBot`.
+   *
+   * `add-bot` in edit mode reads `currentBot` (its guard, its reviews toggle,
+   * its save target), so `startEditingBot` has to set it. But bot-interact.vue
+   * routes on exactly that value: `<bot-gallery v-if="!isInteractMode">` with
+   * `isInteractMode = Boolean(currentBot) || sessionChats.length`. So opening
+   * the editor unmounted the gallery -- and with it the card back the editor
+   * was rendering inside -- and dropped the user into the chat surface.
+   *
+   * Silas, 2026-08-09: "edit just brings me to interact, not an edit screen,
+   * so I can't test edit yet."
+   *
+   * This flag is what lets the router tell the two apart. It is deliberately
+   * cleared by every path that means "I am done editing / I want the Bot for
+   * something else": selecting a Bot to talk to, deselecting, and starting a
+   * new one. A stale flag would strand someone in the gallery unable to chat,
+   * which is the same bug pointing the other way.
+   */
+  const editingBotId: Ref<number | null> = ref(null)
   const botForm: Ref<BotForm> = ref({})
   const currentImagePath = ref('')
   const loading = ref(false)
@@ -376,6 +395,7 @@ export const useBotStore = defineStore('botStore', () => {
 
   function startAddingBot(overrides: Partial<BotForm> = {}): void {
     currentBot.value = null
+    editingBotId.value = null
     botForm.value = createDefaultBotForm(overrides)
     currentImagePath.value = botForm.value.avatarImage || ''
     pendingLaunchMessage.value = ''
@@ -405,6 +425,7 @@ export const useBotStore = defineStore('botStore', () => {
     }
 
     currentBot.value = bot
+    editingBotId.value = bot.id
     botForm.value = toBotForm(bot)
     currentImagePath.value = bot.avatarImage || ''
     pendingLaunchMessage.value = ''
@@ -569,6 +590,10 @@ export const useBotStore = defineStore('botStore', () => {
 
     if (!botId) return null
 
+    // Before the early return below: picking a Bot to talk to ends editing
+    // even when it is the Bot already loaded in the form.
+    editingBotId.value = null
+
     if (currentBot.value?.id === botId) return currentBot.value
 
     const found =
@@ -599,6 +624,7 @@ export const useBotStore = defineStore('botStore', () => {
 
   function deselectBot(): void {
     currentBot.value = null
+    editingBotId.value = null
     botForm.value = {}
     currentImagePath.value = ''
     pendingLaunchMessage.value = ''
@@ -999,6 +1025,7 @@ export const useBotStore = defineStore('botStore', () => {
     loadBotById,
     selectBot,
     deselectBot,
+    editingBotId,
     revertBotForm,
 
     startAddingBot,

--- a/utils/startupLaunch.ts
+++ b/utils/startupLaunch.ts
@@ -1,17 +1,44 @@
 export const FORCE_FULL_STARTUP_KEY = 'kind-robots-force-full-startup-v1'
 export const APP_READY_CLASS = 'kr-app-ready'
 
+export const BOOT_COVER_SELECTOR = '.kr-boot-cover'
+
 /*
  * Marks the app as mounted so the server-rendered boot cover retires early.
  *
- * The cover releases itself through a CSS animation regardless, so this is an
- * optimisation, never a requirement — if this never runs, the cover still
- * clears on its own. That is the whole point of the current design: nothing
- * about revealing the site depends on JavaScript succeeding.
+ * The cover releases itself through a CSS animation regardless, so the CLASS
+ * half of this is an optimisation, never a requirement — if this never runs,
+ * the cover still clears on its own. That is the whole point of the current
+ * design: nothing about revealing the site depends on JavaScript succeeding.
+ *
+ * BUT THE NODE REMOVAL IS NOT AN OPTIMISATION. Silas, 2026-08-09, on /bots:
+ * the cover was still on screen after the app had loaded, rendered UNSTYLED
+ * and in normal document flow — its title in the page's own serif on the page's
+ * own background rather than white-on-black, and the app pushed down below it
+ * instead of covered by it. Every escape the cover has (the release keyframe,
+ * the `html.kr-app-ready` rule) lives in the same inline <style> block that
+ * positions it, so if that block does not take effect the element is not merely
+ * mis-positioned — it is permanent, because the rules that would hide it are
+ * gone too. Nothing in the app removed it: `markAppReady` only added a class.
+ *
+ * The served HTML is correct (verified against production: `<body>` → the
+ * <style> → the cover, with `position: fixed` and a 6s release), so why that
+ * block did not apply in that session is NOT explained. This does not pretend
+ * to explain it — it removes the shared dependency, so a cover whose styles
+ * fail for any reason still cannot outlive the app that replaced it.
  */
+export function retireBootCover(): void {
+  if (!import.meta.client) return
+
+  document
+    .querySelectorAll(BOOT_COVER_SELECTOR)
+    .forEach((element) => element.remove())
+}
+
 export function markAppReady(): void {
   if (!import.meta.client) return
   document.documentElement.classList.add(APP_READY_CLASS)
+  retireBootCover()
 }
 
 export function requestFullStartupReload(): void {
@@ -41,9 +68,8 @@ export function consumeForcedFullStartup(): boolean {
 export function isBrowserReload(): boolean {
   if (!import.meta.client) return false
 
-  const navigation = performance.getEntriesByType(
-    'navigation',
-  )[0] as PerformanceNavigationTiming | undefined
+  const navigation = performance.getEntriesByType('navigation')[0] as
+    PerformanceNavigationTiming | undefined
 
   return navigation?.type === 'reload'
 }


### PR DESCRIPTION
Two follow-ups from testing on production.

## "edit just brings me to interact, not an edit screen"

`bot-interact.vue` is the router — `<bot-gallery v-if="!isInteractMode">` else `<bot-chat />`, with `isInteractMode = Boolean(currentBot) || sessionChats.length`. And `botStore.startEditingBot` sets `currentBot`; it has to, because `add-bot` in edit mode reads it for its guard, its reviews toggle, and its save target.

So opening the editor read as *"go and chat"*. It unmounted `bot-gallery`, and with it the card back the editor renders inside, landing the user in the chat surface. This hits **both** edit paths on `/bots` — the card back and the older in-gallery form — because both call `startEditingBot`.

`currentBot` was carrying two different questions: *which Bot am I talking to* and *which Bot am I editing*. `editingBotId` separates them, and the router ignores a selection that exists only to populate the form. It's cleared by `selectBot` (before its same-Bot early return), `deselectBot`, `startAddingBot`, and by the gallery when either editor closes — a flag left set would strand someone on the gallery unable to chat, which is this same bug pointing the other way.

## The boot cover outliving the app

Reported on `/bots`: the server boot cover still on screen after the app loaded, rendered **unstyled and in normal document flow** — its title in the page's own serif on the page's own background rather than white-on-black, and the app pushed down below it instead of covered by it.

**I could not reproduce or explain that**, and this change doesn't pretend to. The served HTML is correct — fetched from production, `<body>` is immediately followed by the inline `<style>` and then the cover, with `position: fixed`, `background: #000`, and a 6s release keyframe. There's no CSP, and nothing in `vercel.json` rewrites it. Why that block didn't take effect in that session is still open.

What this fixes is why the failure was **permanent**. Both of the cover's escapes — the release keyframe and the `html.kr-app-ready` rule — live in the same inline `<style>` block that positions it, and nothing ever removed the element: `markAppReady` only added a class. So a style block that doesn't take effect leaves a cover that isn't merely mis-positioned, it's unremovable.

`markAppReady` now also removes the node, and `app.vue`'s loader failsafe calls `retireBootCover` directly — that branch exists for the case where the app never reached `kind-loader`, so it can't rely on `kind-loader`'s call. Neither path depends on the CSS applying.

## Verification

- `npm run test` (vue-tsc) — clean
- `verify-startup-handoff.mjs` — passes (the cover is still JS-free by default; removal is additive)
- `test:layout-contract` — holds
- `test:lint-ratchet` — 392 problems across 27 rules, unchanged
- `prettier --check` on every changed file — clean

Not verified in a browser: no browser egress in this session. The routing fix is traced through the call chain (`startEditingBot` → `currentBot` → `isInteractMode` → `v-if`) rather than watched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_