### PR TITLE
Fix kr_panel_codemod.py's nested-&lt;template&gt; scoping bug (interface-vision/t-116)

### DIFF
--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -153,13 +153,21 @@ def process_file(path: Path):
     # line in the file shows as changed, not just the substituted ones.
     with open(path, "r", encoding="utf-8", newline="") as fh:
         text = fh.read()
-    # Only touch the <template> block, never <script>.
+    # Only touch the <template> block, never <script>. The file's root
+    # <template> is always the FIRST opening tag, but its closing tag is not
+    # necessarily the first `</template>` in the file: an SFC can nest a
+    # named-slot/conditional block like `<template v-if="..." #footer>`
+    # that closes with its own `</template>` well before the real end. A
+    # single `re.search` for `</template>` finds that inner close instead,
+    # silently truncating the scanned region and hiding every candidate
+    # after it (interface-vision/t-104 slice 19 / t-116). Use the LAST
+    # `</template>` in the file instead, which is always the root's.
     template_match = re.search(r"<template>", text)
     if not template_match:
         return None
-    template_end = re.search(r"</template>", text)
+    template_end_matches = list(re.finditer(r"</template>", text))
     template_start = template_match.end()
-    template_stop = template_end.start() if template_end else len(text)
+    template_stop = template_end_matches[-1].start() if template_end_matches else len(text)
 
     changes = []
     skips = []


### PR DESCRIPTION
### Task
interface-vision/t-116: Fix `kr_panel_codemod.py`'s nested-`<template>` scoping bug and re-run a corrected sweep (kind: software)

### What changed / what I produced
- `utils/scripts/codemods/kr_panel_codemod.py`: the scan for the end of an SFC's scannable template region used `re.search(r"</template>", text)` — the FIRST match in the file. Any file with a nested named-slot/conditional `<template v-if="..." #slot>` block that closes before the file's real closing `</template>` had everything after that inner close silently never scanned, so the codemod's "pool exhausted" conclusion (relied on by t-104 slices 15 and 18) was wrong.
- Fix: scan for the LAST `</template>` in the file instead of the first — the file's real closing tag for the root `<template>` is always the last one, regardless of how many nested template blocks close earlier.

### How I verified
- `python3 -m py_compile` clean.
- Inline regression check: built a synthetic `.vue` with a `<template v-if="x" #footer>...</template>` closing before the real end, followed by a genuine `kr-panel` candidate. Before the fix that candidate was invisible; after the fix `process_file` finds and substitutes it correctly.
- Re-ran the corrected codemod's dry-run across the full repo (no `--apply`, read-only): **21 files / 47 `kr-panel-flat` occurrences** now surface as candidates the buggy scan previously hid entirely. Skip pool is unchanged at 6 occurrences / 4 files (`kr-stat-tile.vue`, `chat-gallery.vue` x2, `challenges/[slug].vue` x2) — all genuine DaisyUI component-root conflicts already confirmed manual-review-only in prior slices.
- This PR does **not** apply any of the 47 newly-surfaced occurrences — per t-116's own scope, that's handed off to interface-vision/t-104 as further small, individually-verified slices, not a single giant sweep.

### Stakes
reversible

### Flags for Reviewer
- No behavior change to already-applied substitutions; this only widens what the codemod *sees*, it doesn't change how it decides safety.
- The 21-file/47-occurrence candidate list is recorded in the conductor roadmap task note for the next t-104 slice to pick up.

### Kaizen suggestion
A future t-104 slice could start with `components/pages/conductor-page.vue` (5 occurrences in one file) for the highest single-file yield from this newly-unlocked pool.

### Notes for reviewer
Full dry-run output (file/line before→after) is included in the conductor-side task note for interface-vision/t-116.


---
_Generated by [Claude Code](https://claude.ai/code/session_0133CUw7y82JmGg5KyrpAw45)_