### PR TITLE
interface-vision/t-104 slice 22: adopt kr-container in Image Generator

### DIFF
--- a/components/art/art-maker.vue
+++ b/components/art/art-maker.vue
@@ -2,7 +2,7 @@
 <template>
   <section class="min-h-full w-full">
     <div
-      class="mx-auto flex min-h-full w-full max-w-6xl flex-col gap-4 rounded-2xl border border-base-300 bg-base-200 p-4 sm:p-6"
+      class="kr-container flex min-h-full flex-col gap-4 rounded-2xl border border-base-300 bg-base-200 p-4 sm:p-6"
     >
       <header
         class="kr-panel-flat p-4 sm:p-5"


### PR DESCRIPTION
## Task
interface-vision/t-104: Phase 2 shared-component consistency, slice 22

## What changed
- Replaced `art-maker.vue`'s hand-rolled `mx-auto w-full max-w-6xl` wrapper utilities with the declaration-equivalent shared `kr-container` primitive.
- Preserved every other class on the wrapper: flex, min-height, gap, rounding, border, background, padding, and responsive padding.
- Exact branch diff against fresh main is one file, +1/-1.

## Why this slice
After slice 21 moved Build Bench onto the same primitive, a live-code search found a small remaining declaration-equivalent candidate on the Image Generator, a daily-driver art surface. This is a bounded consistency adoption, not a redesign.

## Verification before PR
- Read current `kind_robots/AGENTS.md` and Interface Vision DESIGN-BRIEF.
- Confirmed `.kr-container` is exactly `mx-auto w-full max-w-6xl` in `assets/css/tailwind.css`.
- `compare_commits` against main `1bc5add96e45db73bd3f43f1e7c0beb078de9407`: exactly `components/art/art-maker.vue`, +1/-1.
- Conductor task moved and verified `claimed -> review` for session `2026-08-09T07:25:27-0700-pr1666-rv-a7c9` before this PR was opened.

## Stakes
reversible

## Handoff
Wait for the actual required GitHub checks to complete. Merge only if the exact head remains green; then return the non-recurring t-104 umbrella to `ready` with the merge/check evidence.