### PR TITLE
security: gate Character and Reward reads by visibility

### DIFF
--- a/server/api/characters/[id].get.ts
+++ b/server/api/characters/[id].get.ts
@@ -1,43 +1,48 @@
-import { defineEventHandler } from 'h3'
+import { createError, defineEventHandler } from 'h3'
 import { errorHandler } from '../../utils/error'
 import prisma from '../../utils/prisma'
+import { getOptionalApiUser } from '../../utils/authGuard'
+import { canView } from '../../utils/contentAccess'
 
 export default defineEventHandler(async (event) => {
-  let response
-
   try {
     const id = Number(event.context.params?.id)
 
-    if (isNaN(id)) {
-      return {
-        success: false,
-        message: 'Invalid ID',
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({
         statusCode: 400,
-      }
+        message: 'Invalid ID. It must be a positive integer.',
+      })
     }
 
-    // Fetch the character by ID
-    const data = await prisma.character.findUnique({
-      where: { id },
-    })
+    const [data, auth] = await Promise.all([
+      prisma.character.findUnique({ where: { id } }),
+      getOptionalApiUser(event),
+    ])
+
     if (!data) {
-      return {
-        success: false,
-        message: 'Character not found',
-        statusCode: 404,
-      }
+      throw createError({ statusCode: 404, message: 'Character not found.' })
     }
 
-    response = {
+    if (!(await canView(data, null, auth?.user))) {
+      throw createError({
+        statusCode: auth ? 403 : 404,
+        message: auth
+          ? 'You do not have permission to view this Character.'
+          : 'Character not found.',
+      })
+    }
+
+    event.node.res.statusCode = 200
+    return {
       success: true,
       message: 'Character details fetched successfully.',
-      data, // Return the character details under data
+      data,
       statusCode: 200,
     }
-    event.node.res.statusCode = response.statusCode
   } catch (error: unknown) {
-    return errorHandler(error)
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return handled
   }
-
-  return response
 })

--- a/server/api/characters/index.get.ts
+++ b/server/api/characters/index.get.ts
@@ -1,66 +1,74 @@
-import { defineEventHandler } from 'h3'
+import { createError, defineEventHandler } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
+import { getOptionalApiUser } from '../../utils/authGuard'
+import { canView, viewablePackIds } from '../../utils/contentAccess'
 
 export default defineEventHandler(async (event) => {
   try {
     const id = event.context.params?.id ? Number(event.context.params.id) : null
+    const auth = await getOptionalApiUser(event)
+    const userId = auth?.user.id ?? null
+    const isAdmin = auth?.isAdmin ?? false
 
-    // Validate the ID if provided
-    if (id !== null && (isNaN(id) || id <= 0)) {
-      return {
-        success: false,
-        message: 'Invalid ID. It must be a positive integer.',
+    if (id !== null && (!Number.isInteger(id) || id <= 0)) {
+      throw createError({
         statusCode: 400,
-      }
+        message: 'Invalid ID. It must be a positive integer.',
+      })
     }
-
-    let data
 
     if (id !== null) {
-      // Fetch a specific character by ID
-      console.log(`Fetching character with ID: ${id}`)
-      data = await prisma.character.findUnique({
-        where: { id },
-      })
+      const data = await prisma.character.findUnique({ where: { id } })
 
       if (!data) {
-        return {
-          success: false,
-          message: `Character with ID ${id} not found.`,
+        throw createError({
           statusCode: 404,
-        }
+          message: `Character with ID ${id} not found.`,
+        })
       }
 
-      console.log(`Character with ID ${id} fetched successfully.`)
-    } else {
-      // Fetch all characters
-      data = await prisma.character.findMany()
+      if (!(await canView(data, null, auth?.user))) {
+        throw createError({
+          statusCode: auth ? 403 : 404,
+          message: auth
+            ? 'You do not have permission to view this Character.'
+            : 'Character not found.',
+        })
+      }
+
+      return {
+        success: true,
+        message: `Character with ID ${id} fetched successfully.`,
+        data,
+        statusCode: 200,
+      }
     }
+
+    const packIds = userId && !isAdmin ? await viewablePackIds(userId) : []
+    const where = isAdmin
+      ? undefined
+      : userId
+        ? {
+            OR: [
+              { isPublic: true },
+              { userId },
+              ...(packIds.length ? [{ packId: { in: packIds } }] : []),
+            ],
+          }
+        : { isPublic: true }
+
+    const data = await prisma.character.findMany({ where })
 
     return {
       success: true,
-      message: id
-        ? `Character with ID ${id} fetched successfully.`
-        : 'All characters fetched successfully.',
+      message: 'All viewable characters fetched successfully.',
       data,
       statusCode: 200,
     }
   } catch (error: unknown) {
-    console.error('Error occurred while fetching characters:', error)
-
-    // Use errorHandler to get the structured error response
-    const { success, message, statusCode } = errorHandler(error)
-    console.log('Error details after handling:', {
-      success,
-      message,
-      statusCode,
-    })
-
-    return {
-      success,
-      message,
-      statusCode,
-    }
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return handled
   }
 })

--- a/server/api/rewards/[id].get.ts
+++ b/server/api/rewards/[id].get.ts
@@ -2,6 +2,8 @@
 import { defineEventHandler, createError } from 'h3'
 import { fetchRewardById } from './index'
 import { errorHandler } from '../../utils/error'
+import { getOptionalApiUser } from '../../utils/authGuard'
+import { canView } from '../../utils/contentAccess'
 
 export default defineEventHandler(async (event) => {
   const id = Number(event.context.params?.id)
@@ -14,12 +16,24 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const data = await fetchRewardById(id)
+    const [data, auth] = await Promise.all([
+      fetchRewardById(id),
+      getOptionalApiUser(event),
+    ])
 
     if (!data) {
       throw createError({
         statusCode: 404,
         message: 'Reward not found.',
+      })
+    }
+
+    if (!(await canView(data, null, auth?.user))) {
+      throw createError({
+        statusCode: auth ? 403 : 404,
+        message: auth
+          ? 'You do not have permission to view this Reward.'
+          : 'Reward not found.',
       })
     }
 

--- a/server/api/rewards/index.get.ts
+++ b/server/api/rewards/index.get.ts
@@ -1,11 +1,38 @@
 // /server/api/rewards/index.get.ts
 import { defineEventHandler } from 'h3'
-import { fetchAllRewards } from './'
+import prisma from '../../utils/prisma'
+import { rewardInclude } from './'
 import { errorHandler } from '../../utils/error'
+import { getOptionalApiUser } from '../../utils/authGuard'
+import { viewablePackIds } from '../../utils/contentAccess'
 
 export default defineEventHandler(async (event) => {
   try {
-    const data = await fetchAllRewards()
+    const auth = await getOptionalApiUser(event)
+    const userId = auth?.user.id ?? null
+    const isAdmin = auth?.isAdmin ?? false
+    const packIds = userId && !isAdmin ? await viewablePackIds(userId) : []
+
+    const visibility = isAdmin
+      ? {}
+      : userId
+        ? {
+            OR: [
+              { isPublic: true },
+              { userId },
+              ...(packIds.length ? [{ packId: { in: packIds } }] : []),
+            ],
+          }
+        : { isPublic: true }
+
+    const data = await prisma.reward.findMany({
+      where: {
+        isActive: true,
+        ...visibility,
+      },
+      include: rewardInclude,
+      orderBy: [{ updatedAt: 'desc' }, { id: 'desc' }],
+    })
 
     event.node.res.statusCode = 200
 


### PR DESCRIPTION
### Task
digital-storefront/t-005: close the Character/Reward read-route access gap (kind: software)

### What changed / what I produced
- Rescued the useful security portion of the stranded `worker/digital-storefront-t-004-20260808-a83f` branch onto fresh `main`.
- Character detail/list reads now use the shared optional-auth + `canView`/`viewablePackIds` access rules.
- Reward detail/list reads now use the same visibility model while preserving active filtering and relation includes.
- Deliberately excluded the old branch's already-landed Dream/Facet/t-004 work and unrelated admin DLC product route.

### How I verified
- Compared this branch against current `main`: exactly 4 API route files changed, no stale t-004 files.
- CI must complete on this exact head before any merge decision.

### Stakes
security-sensitive / human-gated

### Flags for Reviewer
- Conductor `digital-storefront/t-005` is `needs-human` and explicitly asks Silas to decide this Character/Reward access policy. This PR must remain unmerged until that gate is cleared.
- This rescue exists so the security decision is represented by a reviewable PR instead of a stranded no-PR branch.

### Kaizen suggestion
Add contract coverage asserting anonymous, owner, admin, public, and Pack-Grant visibility parity across Dream/Facet/Character/Reward list and detail routes.