### PR TITLE
interface-vision/t-104 slice 23: adopt kr-container in User Admin + Project Placement

### DIFF
--- a/components/projects/project-placement-manager.vue
+++ b/components/projects/project-placement-manager.vue
@@ -1,6 +1,6 @@
 <!-- /components/projects/project-placement-manager.vue -->
 <template>
-  <section class="mx-auto flex w-full max-w-6xl flex-col gap-4 p-4 sm:p-6">
+  <section class="kr-container flex flex-col gap-4 p-4 sm:p-6">
     <header class="overflow-hidden kr-panel p-0">
       <div class="flex flex-col gap-3 p-5 sm:flex-row sm:items-start sm:justify-between">
         <div class="min-w-0">

--- a/components/user/user-manager-directory.vue
+++ b/components/user/user-manager-directory.vue
@@ -7,7 +7,7 @@
   endpoints re-check admin server-side.
 -->
 <template>
-  <section class="mx-auto flex w-full max-w-6xl flex-col gap-4 p-4">
+  <section class="kr-container flex flex-col gap-4 p-4">
     <header
       class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between"
     >


### PR DESCRIPTION
### Task
interface-vision/t-104: drive front-end consistency onto shared `kr-*` components (kind: software, reversible)

### What changed
Declaration-equivalent substitution — `mx-auto w-full max-w-6xl` is byte-for-byte what `kr-container` itself `@apply`s in `assets/css/tailwind.css`:

- `components/user/user-manager-directory.vue` — Admin User Directory (`/user-admin`)
- `components/projects/project-placement-manager.vue` — Project Placement (`/project-placement`)

Both are Nuxt Content-mounted admin surfaces (`content/user-admin.md`, `content/project-placement.md`), confirmed reachable. All other utilities on the same element (`flex`, `flex-col`, `gap-4`, `p-4`[, `sm:p-6`]) preserved unchanged. Zero visual delta intended.

### How I verified
- `git diff --stat`: 2 files, 2/2 +/- — minimal, exactly the intended scope.
- `eslint` on both changed files: clean.
- `prettier --check`: pre-existing warning on `project-placement-manager.vue` confirmed present on baseline via `git stash` diff (not introduced by this change).
- `npm run test:layout-contract`: holds, 0 new violations.
- `vue-tsc --noEmit`: clean (exit 0).

### Stakes
reversible

### Kaizen
None new for this slice.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PRdfVn8MkpyS6C1ugukdDM)_