### PR TITLE
interface-vision/t-104 slice 25: adopt kr-container in AppMaker

### DIFF
--- a/components/pages/appmaker-page.vue
+++ b/components/pages/appmaker-page.vue
@@ -2,7 +2,7 @@
 <!-- AppMaker (appmaker/t-004): browse the app fleet, create a new app
      (self-serve; server enforces caps), and jump into each app's project. -->
 <template>
-  <section class="kr-unbound mx-auto max-w-6xl space-y-6 p-4">
+  <section class="kr-unbound kr-container space-y-6 p-4">
     <header class="flex flex-wrap items-center justify-between gap-3">
       <div>
         <p class="text-2xl font-bold">AppMaker</p>


### PR DESCRIPTION
### Task
`interface-vision/t-104`: drive live front-end consistency onto shared `kr-*` composition rules.

### What changed
- AppMaker (`components/pages/appmaker-page.vue`): replaced the hand-rolled `mx-auto max-w-6xl` root declarations with `kr-container` while retaining `kr-unbound`.
- This is declaration-equivalent: `kr-unbound` already supplies `w-full`; `kr-container` supplies `mx-auto w-full max-w-6xl`.
- Exact branch diff against fresh main is one file, one class substitution (+1/-1).

### Coordination
- Session: `20260809T181505Z-e58332`
- Conductor `interface-vision/t-104` was claimed by this exact session and verified as `status: review` before this PR opened.

### Verification / merge gate
Connector-only run: exact-head GitHub Actions are the executable gate. Merge only after every required check completes successfully. This `worker/*` branch does not receive an automatic Vercel preview under the current repository policy, and no visual delta is intended.

### Stakes
Reversible. No API, store, schema, database, art, production-data, or outward-facing content changes.

### Handoff
After merge, return the non-recurring `t-104` umbrella to `ready` with exact merge/check evidence and clear this session's claim.