### PR TITLE
interface-vision/t-104 slice 26: adopt kr-container-wide in add-bot/add-character/add-reward/add-scenario

### DIFF
--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -1,7 +1,7 @@
 <!-- /components/content/bots/add-bot.vue -->
 <template>
   <div
-    class="mx-auto flex w-full max-w-7xl flex-col gap-6 rounded-2xl border border-base-300 bg-base-200 p-4"
+    class="kr-container-wide flex flex-col gap-6 rounded-2xl border border-base-300 bg-base-200 p-4"
   >
     <header class="text-center">
       <h1 class="text-3xl font-bold text-primary md:text-4xl">

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -1,7 +1,7 @@
 <!-- /components/characters/add-character.vue -->
 <template>
   <section
-    class="mx-auto flex w-full max-w-7xl flex-col gap-6 rounded-2xl border border-base-300 bg-base-200 p-4"
+    class="kr-container-wide flex flex-col gap-6 rounded-2xl border border-base-300 bg-base-200 p-4"
   >
     <header class="text-center">
       <h1 class="text-3xl font-black text-primary md:text-4xl">

--- a/components/rewards/add-reward.vue
+++ b/components/rewards/add-reward.vue
@@ -1,7 +1,7 @@
 <!-- /components/content/rewards/add-reward.vue -->
 <template>
   <div
-    class="mx-auto flex w-full max-w-7xl flex-col gap-6 rounded-2xl border border-base-300 bg-base-200 p-4"
+    class="kr-container-wide flex flex-col gap-6 rounded-2xl border border-base-300 bg-base-200 p-4"
   >
     <header class="text-center">
       <h1 class="text-3xl font-bold text-primary md:text-4xl">

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -1,7 +1,7 @@
 <!-- /components/content/weird/add-scenario.vue -->
 <template>
   <div
-    class="mx-auto flex w-full max-w-7xl flex-col gap-6 rounded-2xl border border-base-300 bg-base-200 p-4"
+    class="kr-container-wide flex flex-col gap-6 rounded-2xl border border-base-300 bg-base-200 p-4"
   >
     <header class="text-center">
       <h1 class="text-3xl font-bold text-primary md:text-4xl">


### PR DESCRIPTION
### Task
`interface-vision/t-104`: drive live front-end consistency onto shared `kr-*` composition rules.

### What changed
- `components/bots/add-bot.vue`, `components/characters/add-character.vue`, `components/rewards/add-reward.vue`, `components/scenarios/add-scenario.vue` — all four shared the identical root class string `mx-auto flex w-full max-w-7xl flex-col gap-6 rounded-2xl border border-base-300 bg-base-200 p-4`.
- Replaced `mx-auto w-full max-w-7xl` with `kr-container-wide`, which `@apply`s exactly `mx-auto w-full max-w-7xl` in `assets/css/tailwind.css`. Declaration-equivalent — all other utilities (`flex`, `flex-col`, `gap-6`, `rounded-2xl`, `border`, `border-base-300`, `bg-base-200`, `p-4`) preserved unchanged.
- Exact branch diff against fresh `main` is 4 files, 4/4 +/-, one class substitution each.

### Reachability
- `add-bot.vue` — mounted via `bot-manager.vue`/`bot-gallery.vue`.
- `add-character.vue` — mounted via `character-manager.vue`/`character-gallery.vue`.
- `add-reward.vue` — mounted via `reward-manager.vue`/`reward-gallery.vue`.
- `add-scenario.vue` — mounted via `scenario-manager.vue`/`scenario-gallery.vue`.

### How I verified
- `eslint` on all 4 files: clean, except `add-bot.vue`'s one pre-existing `no-extra-boolean-cast` warning at line 688, confirmed present on baseline via `git stash` diff (unrelated to this edit, nowhere near the changed line).
- `vue-tsc --noEmit`: clean (exit 0).
- `npm run test:layout-contract`: holds, 0 new violations.
- `prettier --check`: pre-existing warnings on `add-bot.vue`/`add-character.vue`/`add-reward.vue` confirmed present on baseline via `git stash` diff (not introduced by this change).

### Coordination
- Conductor `interface-vision/t-104` claimed by session `20260809T182857Z-w2f9k1`, verified `status: review` before this PR opened.

### Verification / merge gate
Connector-only run: exact-head GitHub Actions are the executable gate. Merge only after every required check completes successfully. This `worker/*` branch does not receive an automatic Vercel preview under the current repository policy, and no visual delta is intended.

### Stakes
Reversible. No API, store, schema, database, art, production-data, or outward-facing content changes.

### Handoff
After merge, return the non-recurring `t-104` umbrella to `ready` with exact merge/check evidence and clear this session's claim.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1Fdzz1MGXmZ9CSXkoGGJ3)_