### PR TITLE
interface-vision/t-104 slice 27: adopt kr-container on Wallet

### DIFF
--- a/components/pages/wallet-page.vue
+++ b/components/pages/wallet-page.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="kr-unbound w-full max-w-3xl mx-auto p-6 space-y-8">
+  <div class="kr-unbound kr-container max-w-3xl p-6 space-y-8">
     <div
       v-if="userStore.isGuest"
       class="rounded-2xl border border-accent/30 bg-(--kr-surface) p-6 text-center space-y-3"
@@ -24,57 +24,29 @@
               {{ karmaStore.balance }}
             </div>
           </div>
-          <button
-            class="btn btn-ghost btn-sm rounded-xl"
-            :disabled="karmaStore.loading"
-            @click="karmaStore.fetch()"
-          >
-            Refresh
-          </button>
+          <Icon name="kind-icon:sparkles" class="size-12 text-primary/30" />
         </div>
-
         <p class="text-sm text-base-content/60">
-          Earned by reacting, creating, sharing, and helping other Kind Robots
-          users — a running score of your community contribution.
+          Karma reflects positive participation across Kind Robots.
         </p>
-
-        <div v-if="karmaStore.loading" class="text-base-content/50 text-sm">
-          Loading…
-        </div>
-        <div
-          v-else-if="!karmaStore.transactions.length"
-          class="text-base-content/50 text-sm"
-        >
-          No karma activity yet. Go react, create, and share! 🌱
-        </div>
-        <ul
-          v-else
-          class="divide-y divide-base-content/10 rounded-xl border border-base-content/10 overflow-hidden"
-        >
-          <li
-            v-for="txn in karmaStore.transactions"
-            :key="txn.id"
-            class="flex items-center justify-between px-4 py-3 bg-base-100"
-          >
-            <div class="space-y-0.5">
-              <div class="text-sm font-medium">
-                {{ formatReason(txn.reason) }}
-              </div>
-              <div class="text-xs text-base-content/50">
-                {{ formatWhen(txn.createdAt) }}
-              </div>
-            </div>
-            <span
-              class="font-bold tabular-nums"
-              :class="txn.amount >= 0 ? 'text-success' : 'text-error'"
-            >
-              {{ txn.amount >= 0 ? '+' : '' }}{{ txn.amount }}
-            </span>
-          </li>
-        </ul>
       </section>
 
-      <mana-wallet />
+      <section
+        class="rounded-2xl border border-secondary/20 bg-base-100 shadow-lg p-6 space-y-4"
+      >
+        <div class="flex items-end justify-between">
+          <div>
+            <h2 class="text-sm text-base-content/60">Mana</h2>
+            <div class="text-5xl font-extrabold text-secondary tabular-nums">
+              {{ manaStore.mana }}
+            </div>
+          </div>
+          <Icon name="kind-icon:flame" class="size-12 text-secondary/30" />
+        </div>
+        <p class="text-sm text-base-content/60">
+          Mana powers creative tools and refills over time.
+        </p>
+      </section>
     </template>
   </div>
 </template>
@@ -82,29 +54,16 @@
 <script setup lang="ts">
 import { onMounted } from 'vue'
 import { useKarmaStore } from '@/stores/karmaStore'
+import { useManaStore } from '@/stores/manaStore'
 import { useUserStore } from '@/stores/userStore'
 
 const karmaStore = useKarmaStore()
+const manaStore = useManaStore()
 const userStore = useUserStore()
 
-function formatReason(reason: string): string {
-  return reason
-    .toLowerCase()
-    .split('_')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ')
-}
-
-function formatWhen(iso: string): string {
-  return new Date(iso).toLocaleString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-  })
-}
-
-onMounted(() => {
-  karmaStore.fetch()
+onMounted(async () => {
+  if (!userStore.isGuest) {
+    await Promise.all([karmaStore.fetchKarma(), manaStore.fetchMana()])
+  }
 })
 </script>

--- a/components/pages/wallet-page.vue
+++ b/components/pages/wallet-page.vue
@@ -24,29 +24,57 @@
               {{ karmaStore.balance }}
             </div>
           </div>
-          <Icon name="kind-icon:sparkles" class="size-12 text-primary/30" />
+          <button
+            class="btn btn-ghost btn-sm rounded-xl"
+            :disabled="karmaStore.loading"
+            @click="karmaStore.fetch()"
+          >
+            Refresh
+          </button>
         </div>
+
         <p class="text-sm text-base-content/60">
-          Karma reflects positive participation across Kind Robots.
+          Earned by reacting, creating, sharing, and helping other Kind Robots
+          users — a running score of your community contribution.
         </p>
+
+        <div v-if="karmaStore.loading" class="text-base-content/50 text-sm">
+          Loading…
+        </div>
+        <div
+          v-else-if="!karmaStore.transactions.length"
+          class="text-base-content/50 text-sm"
+        >
+          No karma activity yet. Go react, create, and share! 🌱
+        </div>
+        <ul
+          v-else
+          class="divide-y divide-base-content/10 rounded-xl border border-base-content/10 overflow-hidden"
+        >
+          <li
+            v-for="txn in karmaStore.transactions"
+            :key="txn.id"
+            class="flex items-center justify-between px-4 py-3 bg-base-100"
+          >
+            <div class="space-y-0.5">
+              <div class="text-sm font-medium">
+                {{ formatReason(txn.reason) }}
+              </div>
+              <div class="text-xs text-base-content/50">
+                {{ formatWhen(txn.createdAt) }}
+              </div>
+            </div>
+            <span
+              class="font-bold tabular-nums"
+              :class="txn.amount >= 0 ? 'text-success' : 'text-error'"
+            >
+              {{ txn.amount >= 0 ? '+' : '' }}{{ txn.amount }}
+            </span>
+          </li>
+        </ul>
       </section>
 
-      <section
-        class="rounded-2xl border border-secondary/20 bg-base-100 shadow-lg p-6 space-y-4"
-      >
-        <div class="flex items-end justify-between">
-          <div>
-            <h2 class="text-sm text-base-content/60">Mana</h2>
-            <div class="text-5xl font-extrabold text-secondary tabular-nums">
-              {{ manaStore.mana }}
-            </div>
-          </div>
-          <Icon name="kind-icon:flame" class="size-12 text-secondary/30" />
-        </div>
-        <p class="text-sm text-base-content/60">
-          Mana powers creative tools and refills over time.
-        </p>
-      </section>
+      <mana-wallet />
     </template>
   </div>
 </template>
@@ -54,16 +82,29 @@
 <script setup lang="ts">
 import { onMounted } from 'vue'
 import { useKarmaStore } from '@/stores/karmaStore'
-import { useManaStore } from '@/stores/manaStore'
 import { useUserStore } from '@/stores/userStore'
 
 const karmaStore = useKarmaStore()
-const manaStore = useManaStore()
 const userStore = useUserStore()
 
-onMounted(async () => {
-  if (!userStore.isGuest) {
-    await Promise.all([karmaStore.fetchKarma(), manaStore.fetchMana()])
-  }
+function formatReason(reason: string): string {
+  return reason
+    .toLowerCase()
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+function formatWhen(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+onMounted(() => {
+  karmaStore.fetch()
 })
 </script>


### PR DESCRIPTION
### Task
`interface-vision/t-104`: drive live front-end consistency onto shared `kr-*` composition rules.

### What changed
- `components/pages/wallet-page.vue`: replaced the hand-rolled `w-full max-w-3xl mx-auto` root declarations with `kr-container max-w-3xl` while retaining `kr-unbound`.
- Declaration-equivalent: `kr-container` owns `mx-auto w-full max-w-6xl`; the existing `max-w-3xl` utility remains the deliberate narrower override. `kr-unbound` and all spacing/behavior remain unchanged.
- Final compare against current main is one file only.

### Coordination
- Session: `2026-08-09T191330Z-interface-vision-t104-s27-q7m4`
- Conductor `interface-vision/t-104` was claimed by this exact session and verified `status: review` before this PR opened.

### Verification / merge gate
Connector-only run: exact-head GitHub Actions are the executable gate. Merge only after every required check completes successfully. No visual delta is intended.

### Stakes
Reversible. No API, store, schema, database, ArtJob, production-data, or outward-facing content changes.

### Handoff
After merge, return this non-recurring consistency umbrella to `ready` with exact merge/check evidence and clear this session's claim.