### PR TITLE
interface-vision/t-104 slice 28: adopt kr-container-wide in Navigation Health

### DIFF
--- a/components/navigation/navigation-health.vue
+++ b/components/navigation/navigation-health.vue
@@ -1,6 +1,6 @@
 <!-- /components/navigation/navigation-health.vue -->
 <template>
-  <section class="mx-auto flex w-full max-w-7xl flex-col gap-4 p-4 sm:p-6">
+  <section class="kr-container-wide flex flex-col gap-4 p-4 sm:p-6">
     <header class="overflow-hidden kr-panel p-0">
       <div class="flex flex-col gap-3 p-5 sm:flex-row sm:items-start sm:justify-between">
         <div class="min-w-0">


### PR DESCRIPTION
Declaration-equivalent substitution: `mx-auto`/`w-full`/`max-w-7xl` on the root `<section>` of `components/navigation/navigation-health.vue` replaced with `kr-container-wide` (`.kr-container-wide { @apply mx-auto w-full max-w-7xl; }` in `assets/css/tailwind.css`). All other utilities (`flex`, `flex-col`, `gap-4`, `p-4`, `sm:p-6`) preserved unchanged.

Reachable via the `/navigation-health` MDC route (`content/navigation-health.md`).

Verified:
- `eslint` clean
- `vue-tsc --noEmit` clean
- `npm run test:layout-contract` holds (0 new violations)
- `prettier --check` warning confirmed pre-existing on baseline (via `git stash` diff), not introduced by this change

Part of the interface-vision/t-104 "drive live front-end consistency onto shared kr-* components" umbrella (slice 28).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQUUG6vsEa9hshioRqG5NG)_