### PR TITLE
Restore Memory Dungeon discovery and legacy Wonder routes

### DIFF
--- a/.github/workflows/wonderlab-public-acceptance.yml
+++ b/.github/workflows/wonderlab-public-acceptance.yml
@@ -7,6 +7,7 @@ on:
       - '.github/workflows/wonderlab-public-acceptance.yml'
       - 'cypress.public.config.ts'
       - 'cypress/public/wonderlab-responsive.cy.ts'
+      - 'nuxt.config.ts'
       - 'utils/scripts/verifyWonderLabPublicNavigation.ts'
       - 'stores/helpers/navigationRouteAccess.ts'
       - 'content/channels/plan/museum.md'
@@ -18,6 +19,7 @@ on:
       - '.github/workflows/wonderlab-public-acceptance.yml'
       - 'cypress.public.config.ts'
       - 'cypress/public/wonderlab-responsive.cy.ts'
+      - 'nuxt.config.ts'
       - 'utils/scripts/verifyWonderLabPublicNavigation.ts'
       - 'stores/helpers/navigationRouteAccess.ts'
       - 'content/channels/plan/museum.md'
@@ -82,6 +84,9 @@ jobs:
             '/plan/wonderlab',
             '/play/memory',
             '/play/screenfx',
+            '/memory',
+            '/wonder',
+            '/wonderlab',
             '1440',
             '390',
             'expectNoHorizontalOverflow',

--- a/content/channels/play/experiments.md
+++ b/content/channels/play/experiments.md
@@ -4,14 +4,15 @@ channelKey: play
 tabKey: experiments
 dashboardKey: wonder
 dashboardTab: memory-dungeon
-label: Experiments
-title: Lab Experiments
-subtitle: Prototypes, games, and unusual tools
-description: Explore active experiments and projects outside the standard workflow.
+label: Memory Dungeon
+title: Memory Dungeon
+subtitle: Match, survive, and loot
+summary: A roguelite memory-match dungeon with lives, levels, powerups, and surprise loot.
+description: Play the roguelite memory card dungeon with lives, levels, powerups, and surprise loot.
 icon: kind-icon:dungeon
 route: /play/memory
-sort: 110
+sort: 55
 requiredRole: GUEST
 ---
 
-A home for experiments that are still becoming themselves.
+Match cards, survive the dungeon, collect loot, and keep climbing.

--- a/cypress/public/wonderlab-responsive.cy.ts
+++ b/cypress/public/wonderlab-responsive.cy.ts
@@ -74,7 +74,7 @@ describe('Public WonderLab responsive acceptance', () => {
 
   it('restores URL-backed museum state', () => {
     cy.viewport(1280, 800)
-    visitWonderLab('/wonderlab?q=bot&status=WORKING&view=list&sort=REVIEWS')
+    visitWonderLab('/plan/wonderlab?q=bot&status=WORKING&view=list&sort=REVIEWS')
 
     cy.get('input[aria-label="Search WonderLab components"]').should(
       'have.value',
@@ -92,6 +92,20 @@ describe('Public WonderLab responsive acceptance', () => {
     cy.url().should('include', 'q=bot')
     cy.url().should('include', 'status=WORKING')
     cy.url().should('include', 'view=list')
+    expectNoHorizontalOverflow()
+  })
+
+  it('keeps legacy Wonder and Lab entry points useful', () => {
+    cy.viewport(1280, 800)
+
+    for (const path of ['/memory', '/wonder']) {
+      cy.visit(path)
+      cy.location('pathname').should('eq', '/play/memory')
+      cy.contains(/enter the dungeon/i, { timeout: 30_000 }).should('be.visible')
+    }
+
+    visitWonderLab('/wonderlab')
+    cy.location('pathname').should('eq', '/plan/wonderlab')
     expectNoHorizontalOverflow()
   })
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -312,16 +312,19 @@ export default defineNuxtConfig({
   },
 
   /*
-   * Storymaker was renamed to Storybook on 2026-08-02 (interface-vision t-002).
-   * The old path was a real, linkable route, so it redirects rather than 404s —
-   * a rename the user chose should not cost them their bookmarks or break any
-   * link already shared.
+   * Keep retired public entry points useful instead of turning bookmarks into
+   * dead ends. Memory Dungeon moved from /memory to /play/memory when Lab was
+   * dissolved; /wonder was the friendly entrance to that playful section.
+   * WonderLab Museum remains available at its canonical /plan/wonderlab route.
    *
-   * 301 rather than 302 because this is permanent: there is no plan to bring
-   * /storymaker back, and a permanent code lets crawlers and browsers stop
-   * asking.
+   * Storymaker was renamed to Storybook on 2026-08-02 (interface-vision t-002).
+   * 301 redirects are intentional because these legacy paths are permanent
+   * compatibility aliases, not temporary routing experiments.
    */
   routeRules: {
+    '/memory': { redirect: { to: '/play/memory', statusCode: 301 } },
+    '/wonder': { redirect: { to: '/play/memory', statusCode: 301 } },
+    '/wonderlab': { redirect: { to: '/plan/wonderlab', statusCode: 301 } },
     '/storymaker': { redirect: { to: '/storybook', statusCode: 301 } },
   },
 

--- a/utils/scripts/verifyWonderLabPublicNavigation.ts
+++ b/utils/scripts/verifyWonderLabPublicNavigation.ts
@@ -37,6 +37,36 @@ for (const tab of publicTabs) {
   assert.match(source, /^requiredRole:\s*GUEST$/m, `${tab.route} must be public`)
 }
 
+const memoryTabSource = await readFile(
+  'content/channels/play/experiments.md',
+  'utf8',
+)
+assert.match(
+  memoryTabSource,
+  /^label:\s*Memory Dungeon$/m,
+  'Memory Dungeon must be named explicitly in Play navigation',
+)
+assert.match(
+  memoryTabSource,
+  /^sort:\s*55$/m,
+  'Memory Dungeon must stay promoted among the primary Play destinations',
+)
+
+const legacyRoutes = [
+  { from: '/memory', to: '/play/memory' },
+  { from: '/wonder', to: '/play/memory' },
+  { from: '/wonderlab', to: '/plan/wonderlab' },
+] as const
+
+const nuxtConfig = await readFile('nuxt.config.ts', 'utf8')
+for (const { from, to } of legacyRoutes) {
+  const rule = `'${from}': { redirect: { to: '${to}', statusCode: 301 } }`
+  assert.ok(
+    nuxtConfig.includes(rule),
+    `${from} must permanently redirect to ${to}`,
+  )
+}
+
 const items: ChannelContentItem[] = [
   {
     contentType: 'channel',
@@ -99,5 +129,5 @@ for (const route of [...publicTabs.map((tab) => tab.route), '/play/davinci']) {
 }
 
 console.log(
-  'WonderLab public navigation verified: public WonderLab surfaces (Museum, Memory, Screen FX) allow direct guests while admin-only tools remain restricted.',
+  'WonderLab public navigation verified: Museum, Memory Dungeon, and Screen FX remain public; Memory Dungeon stays obvious in Play; legacy Wonder/Lab routes redirect safely.',
 )


### PR DESCRIPTION
## Root cause
The July 29 navigation consolidation moved the playable Memory Dungeon from `/memory` to `/play/memory` and explicitly dropped old-route persistence. The game remained live, but its Play navigation entry was renamed/genericized as `Experiments` and sorted near the end of the channel. `/wonder`, `/wonderlab`, and `/memory` consequently became dead or misleading entry points.

## Changes
- Rename the Play `Experiments` entry to **Memory Dungeon** and promote it from sort 110 to 55.
- Permanently redirect `/memory` and `/wonder` to `/play/memory`.
- Preserve the historical WonderLab Museum URL by redirecting `/wonderlab` to `/plan/wonderlab`.
- Extend the WonderLab public-navigation contract to protect the explicit Memory Dungeon label, promotion, and legacy redirects.
- Fix the deployed Cypress acceptance test to use `/plan/wonderlab` as the canonical museum URL and exercise the legacy aliases.
- Trigger the WonderLab acceptance workflow when `nuxt.config.ts` route rules change.

## Verification plan
- WonderLab public navigation contract in GitHub Actions.
- Required repository checks on the PR head.
- Vercel preview verification for `/play/memory`, `/memory`, `/wonder`, `/plan/wonderlab`, and `/wonderlab` before merge.

Direct user-requested navigation regression fix.