### PR TITLE
interface-vision/t-104 slice 29: adopt kr-container on Friends/Account/Ruler-Hooked

### DIFF
--- a/components/ruler-hooked/ruler-hooked-game.vue
+++ b/components/ruler-hooked/ruler-hooked-game.vue
@@ -4,7 +4,7 @@
      localStorage-backed store; no server round-trip is needed to play. -->
 <template>
   <ClientOnly>
-    <div class="mx-auto flex w-full max-w-3xl flex-col gap-4">
+    <div class="kr-container max-w-3xl flex flex-col gap-4">
       <template v-if="store.save">
         <RulerHookedStage :scene="store.scene" :regions="store.bundle.regions" />
 

--- a/components/user/account-settings.vue
+++ b/components/user/account-settings.vue
@@ -5,7 +5,7 @@
   from userStore and writes through accountStore's dedicated endpoints.
 -->
 <template>
-  <section class="mx-auto flex w-full max-w-3xl flex-col gap-6 p-4 sm:p-6">
+  <section class="kr-container max-w-3xl flex flex-col gap-6 p-4 sm:p-6">
     <header class="flex flex-col gap-1">
       <h1 class="text-2xl font-black">Account &amp; Privacy</h1>
       <p class="text-sm text-base-content/70">

--- a/components/user/friends-panel.vue
+++ b/components/user/friends-panel.vue
@@ -5,7 +5,7 @@
   "Message" hands off to the threaded messenger via conversationStore.
 -->
 <template>
-  <section class="mx-auto flex w-full max-w-3xl flex-col gap-6 p-4">
+  <section class="kr-container max-w-3xl flex flex-col gap-6 p-4">
     <header>
       <h1 class="text-2xl font-black">Friends</h1>
       <p class="text-sm text-base-content/70">


### PR DESCRIPTION
### Task
interface-vision/t-104: consistency umbrella, slice 29 (kind: software)

### What changed / what I produced
- `components/user/friends-panel.vue`, `components/user/account-settings.vue`, `components/ruler-hooked/ruler-hooked-game.vue`: root element's hand-rolled `mx-auto flex w-full max-w-3xl flex-col` replaced with `kr-container max-w-3xl flex flex-col` — declaration-equivalent (`.kr-container` `@apply`s `mx-auto w-full max-w-6xl`; the explicit `max-w-3xl` utility overrides it, same pattern as slice 27's Wallet adoption via `kr-container max-w-3xl`).

### How I verified
- Confirmed each candidate's root element is reachable: `content/friends.md`, `content/account.md` (MDC routes), and `components/conductor/ruler-hooked-page.vue`'s `#interactive` slot (mounted from `content/plan/projects/ruler-hooked.md`).
- `npx eslint` on the 3 changed files: clean.
- `vue-tsc --noEmit`: clean.
- `npm run test:layout-contract`: holds, 0 new violations.
- `npx prettier --check`: one pre-existing warning on `ruler-hooked-game.vue`, confirmed present on `main` before this change via `git stash`/re-check (unrelated to this diff).

### Stakes
reversible

### Flags for Reviewer
none

### Kaizen suggestion
Same as slice 27/28's open item: add contract coverage asserting every `kr-container`/`kr-container-wide` adoption's root element also declares `flex flex-col` (or an equivalent explicit override) so a future max-w override slice can't silently drop the layout intent.

### Notes for reviewer
Part of the interface-vision/t-104 recurring consistency umbrella (slice-by-slice `mx-auto`+`w-full`+`max-w-*` → `kr-container`/`kr-container-wide` migration).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzwbZktjiJPCs5jcQPiTMv)_