### PR TITLE
kind-robots/t-056: queue Conductor scaffold Todo on Project creation

### DIFF
--- a/server/api/projects/index.post.ts
+++ b/server/api/projects/index.post.ts
@@ -120,6 +120,7 @@ async function createProjectWithScaffoldTodo(
     if (!Number.isInteger(projectId) || projectId <= 0) {
       throw new Error(
         `Direct Project upsert returned an invalid id for ${conductorSlug}.`,
+        { cause: error },
       )
     }
     const todoContent = scaffoldTodoContent({

--- a/server/api/projects/index.post.ts
+++ b/server/api/projects/index.post.ts
@@ -7,7 +7,7 @@ import type {
 } from '~/prisma/generated/prisma/client'
 import prisma, { isStaleDatabaseConnectionError } from '~/server/utils/prisma'
 import {
-  createProjectScaffoldTodoDirect,
+  projectScaffoldTodoContent,
   upsertProjectDirect,
 } from '~/server/utils/projectDirectWrite'
 import { errorHandler } from '~/server/utils/error'
@@ -62,21 +62,6 @@ function getWorkerUserId(): number {
   return Number.isInteger(raw) && raw > 0 ? raw : 1
 }
 
-function scaffoldTodoContent(input: {
-  conductorSlug: string
-  projectId: number
-  requesterUserId: number
-}) {
-  const title = `Scaffold conductor project for ${input.conductorSlug}`
-  const description = [
-    `New Project created by Kind Robots user ${input.requesterUserId} with slug '${input.conductorSlug}'.`,
-    `Create projects/${input.conductorSlug}/roadmap.yaml with at least one ready task.`,
-    `Project ${input.projectId} already exists in Kind Robots; do not create another.`,
-  ].join('\n')
-
-  return { title, description }
-}
-
 async function createProjectWithScaffoldTodo(
   data: Prisma.ProjectUncheckedCreateInput,
   conductorSlug: string,
@@ -88,7 +73,7 @@ async function createProjectWithScaffoldTodo(
         data,
         select: projectMutationSelect,
       })
-      const todoContent = scaffoldTodoContent({
+      const todoContent = projectScaffoldTodoContent({
         conductorSlug,
         projectId: project.id,
         requesterUserId,
@@ -115,27 +100,7 @@ async function createProjectWithScaffoldTodo(
       action: 'upsert-with-scaffold-todo',
     })
 
-    const project = await upsertProjectDirect(data, conductorSlug)
-    const projectId = Number((project as Record<string, unknown>).id)
-    if (!Number.isInteger(projectId) || projectId <= 0) {
-      throw new Error(
-        `Direct Project upsert returned an invalid id for ${conductorSlug}.`,
-        { cause: error },
-      )
-    }
-    const todoContent = scaffoldTodoContent({
-      conductorSlug,
-      projectId,
-      requesterUserId,
-    })
-
-    await createProjectScaffoldTodoDirect({
-      projectId,
-      ...todoContent,
-      workerUserId: getWorkerUserId(),
-    })
-
-    return project
+    return upsertProjectDirect(data, conductorSlug)
   }
 }
 

--- a/server/api/projects/index.post.ts
+++ b/server/api/projects/index.post.ts
@@ -6,7 +6,10 @@ import type {
   ProjectStatus,
 } from '~/prisma/generated/prisma/client'
 import prisma, { isStaleDatabaseConnectionError } from '~/server/utils/prisma'
-import { upsertProjectDirect } from '~/server/utils/projectDirectWrite'
+import {
+  createProjectScaffoldTodoDirect,
+  upsertProjectDirect,
+} from '~/server/utils/projectDirectWrite'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
 import { enforceProjectCap } from '~/server/utils/projectCap'
@@ -54,24 +57,84 @@ type ProjectCreateBody = {
   isActive?: unknown
 }
 
-async function createProjectWithDirectFallback(
+function getWorkerUserId(): number {
+  const raw = Number(process.env.BETA_ADMIN_USER_ID || 1)
+  return Number.isInteger(raw) && raw > 0 ? raw : 1
+}
+
+function scaffoldTodoContent(input: {
+  conductorSlug: string
+  projectId: number
+  requesterUserId: number
+}) {
+  const title = `Scaffold conductor project for ${input.conductorSlug}`
+  const description = [
+    `New Project created by Kind Robots user ${input.requesterUserId} with slug '${input.conductorSlug}'.`,
+    `Create projects/${input.conductorSlug}/roadmap.yaml with at least one ready task.`,
+    `Project ${input.projectId} already exists in Kind Robots; do not create another.`,
+  ].join('\n')
+
+  return { title, description }
+}
+
+async function createProjectWithScaffoldTodo(
   data: Prisma.ProjectUncheckedCreateInput,
   conductorSlug: string,
+  requesterUserId: number,
 ) {
   try {
-    return await prisma.project.create({
-      data,
-      select: projectMutationSelect,
+    return await prisma.$transaction(async (tx) => {
+      const project = await tx.project.create({
+        data,
+        select: projectMutationSelect,
+      })
+      const todoContent = scaffoldTodoContent({
+        conductorSlug,
+        projectId: project.id,
+        requesterUserId,
+      })
+
+      await tx.todo.create({
+        data: {
+          ...todoContent,
+          status: 'OPEN',
+          priority: 'HIGH',
+          category: 'AGENT',
+          userId: getWorkerUserId(),
+          projectId: project.id,
+        },
+      })
+
+      return project
     })
   } catch (error: unknown) {
     if (!isStaleDatabaseConnectionError(error)) throw error
 
     console.warn('[project-sync:direct-mariadb-fallback]', {
       conductorSlug,
-      action: 'upsert',
+      action: 'upsert-with-scaffold-todo',
     })
 
-    return upsertProjectDirect(data, conductorSlug)
+    const project = await upsertProjectDirect(data, conductorSlug)
+    const projectId = Number(project.id)
+    if (!Number.isInteger(projectId) || projectId <= 0) {
+      throw new Error(
+        `Direct Project upsert returned an invalid id for ${conductorSlug}.`,
+      )
+    }
+    const todoContent = scaffoldTodoContent({
+      conductorSlug,
+      projectId,
+      requesterUserId,
+    })
+
+    await createProjectScaffoldTodoDirect({
+      projectId,
+      ...todoContent,
+      workerUserId: getWorkerUserId(),
+    })
+
+    return project
   }
 }
 
@@ -160,9 +223,10 @@ export default defineEventHandler(async (event) => {
       userId: auth.user.id,
     } satisfies Prisma.ProjectUncheckedCreateInput
 
-    const project = await createProjectWithDirectFallback(
+    const project = await createProjectWithScaffoldTodo(
       projectData,
       conductorSlug,
+      auth.user.id,
     )
 
     event.node.res.statusCode = 201

--- a/server/api/projects/index.post.ts
+++ b/server/api/projects/index.post.ts
@@ -116,7 +116,7 @@ async function createProjectWithScaffoldTodo(
     })
 
     const project = await upsertProjectDirect(data, conductorSlug)
-    const projectId = Number(project.id)
+    const projectId = Number((project as Record<string, unknown>).id)
     if (!Number.isInteger(projectId) || projectId <= 0) {
       throw new Error(
         `Direct Project upsert returned an invalid id for ${conductorSlug}.`,

--- a/server/utils/projectDirectWrite.ts
+++ b/server/utils/projectDirectWrite.ts
@@ -75,6 +75,26 @@ function booleanValue(value: unknown): boolean {
   return value === true || value === 1 || value === '1'
 }
 
+function workerUserId(): number {
+  const raw = Number(process.env.BETA_ADMIN_USER_ID || 1)
+  return Number.isInteger(raw) && raw > 0 ? raw : 1
+}
+
+export function projectScaffoldTodoContent(input: {
+  conductorSlug: string
+  projectId: number
+  requesterUserId: number
+}) {
+  const title = `Scaffold conductor project for ${input.conductorSlug}`
+  const description = [
+    `New Project created by Kind Robots user ${input.requesterUserId} with slug '${input.conductorSlug}'.`,
+    `Create projects/${input.conductorSlug}/roadmap.yaml with at least one ready task.`,
+    `Project ${input.projectId} already exists in Kind Robots; do not create another.`,
+  ].join('\n')
+
+  return { title, description }
+}
+
 export async function upsertProjectDirect(
   data: Prisma.ProjectUncheckedCreateInput,
   conductorSlug: string,
@@ -117,6 +137,41 @@ export async function upsertProjectDirect(
       )
     }
 
+    const projectId = Number(project.id)
+    const requesterUserId = Number(data.userId)
+    if (
+      !Number.isInteger(projectId) ||
+      projectId <= 0 ||
+      !Number.isInteger(requesterUserId) ||
+      requesterUserId <= 0
+    ) {
+      throw new Error(
+        `Direct Project upsert returned invalid ownership data for ${conductorSlug}.`,
+      )
+    }
+
+    const todoContent = projectScaffoldTodoContent({
+      conductorSlug,
+      projectId,
+      requesterUserId,
+    })
+    await connection.query(
+      `INSERT INTO \`Todo\` (` +
+        '`title`, `description`, `status`, `priority`, `category`, `userId`, `projectId`' +
+        `) SELECT ?, ?, 'OPEN', 'HIGH', 'AGENT', ?, ? ` +
+        `WHERE NOT EXISTS (` +
+        `SELECT 1 FROM \`Todo\` WHERE \`projectId\` = ? AND \`title\` = ? AND \`status\` = 'OPEN'` +
+        `)`,
+      [
+        todoContent.title,
+        todoContent.description,
+        workerUserId(),
+        projectId,
+        projectId,
+        todoContent.title,
+      ],
+    )
+
     return {
       ...project,
       allowReviews: booleanValue(project.allowReviews),
@@ -128,46 +183,6 @@ export async function upsertProjectDirect(
     await connection.end().catch((disconnectError: unknown) => {
       console.warn('[project-sync:direct-mariadb-disconnect-failed]', {
         conductorSlug,
-        message:
-          disconnectError instanceof Error
-            ? disconnectError.message
-            : String(disconnectError),
-      })
-    })
-  }
-}
-
-export async function createProjectScaffoldTodoDirect(input: {
-  projectId: number
-  title: string
-  description: string
-  workerUserId: number
-}) {
-  const connection = await createDatabaseDirectConnection()
-
-  try {
-    const result = (await connection.query(
-      `INSERT INTO \`Todo\` (` +
-        '`title`, `description`, `status`, `priority`, `category`, `userId`, `projectId`' +
-        `) SELECT ?, ?, 'OPEN', 'HIGH', 'AGENT', ?, ? ` +
-        `WHERE NOT EXISTS (` +
-        `SELECT 1 FROM \`Todo\` WHERE \`projectId\` = ? AND \`title\` = ? AND \`status\` = 'OPEN'` +
-        `)`,
-      [
-        input.title,
-        input.description,
-        input.workerUserId,
-        input.projectId,
-        input.projectId,
-        input.title,
-      ],
-    )) as { insertId?: number | bigint }
-
-    return Number(result.insertId ?? 0) || null
-  } finally {
-    await connection.end().catch((disconnectError: unknown) => {
-      console.warn('[project-todo:direct-mariadb-disconnect-failed]', {
-        projectId: input.projectId,
         message:
           disconnectError instanceof Error
             ? disconnectError.message

--- a/server/utils/projectDirectWrite.ts
+++ b/server/utils/projectDirectWrite.ts
@@ -136,3 +136,43 @@ export async function upsertProjectDirect(
     })
   }
 }
+
+export async function createProjectScaffoldTodoDirect(input: {
+  projectId: number
+  title: string
+  description: string
+  workerUserId: number
+}) {
+  const connection = await createDatabaseDirectConnection()
+
+  try {
+    const result = (await connection.query(
+      `INSERT INTO \`Todo\` (` +
+        '`title`, `description`, `status`, `priority`, `category`, `userId`, `projectId`' +
+        `) SELECT ?, ?, 'OPEN', 'HIGH', 'AGENT', ?, ? ` +
+        `WHERE NOT EXISTS (` +
+        `SELECT 1 FROM \`Todo\` WHERE \`projectId\` = ? AND \`title\` = ? AND \`status\` = 'OPEN'` +
+        `)`,
+      [
+        input.title,
+        input.description,
+        input.workerUserId,
+        input.projectId,
+        input.projectId,
+        input.title,
+      ],
+    )) as { insertId?: number | bigint }
+
+    return Number(result.insertId ?? 0) || null
+  } finally {
+    await connection.end().catch((disconnectError: unknown) => {
+      console.warn('[project-todo:direct-mariadb-disconnect-failed]', {
+        projectId: input.projectId,
+        message:
+          disconnectError instanceof Error
+            ? disconnectError.message
+            : String(disconnectError),
+      })
+    })
+  }
+}


### PR DESCRIPTION
### Task
kind-robots/t-056: Build the Dream -> conductor project-creation Todo flow (kind: software)

### What changed / what I produced
- Verified the old Dream PROJECT concept is stale: first-class `Project` records now own project creation, while Conductor projection creates/reconciles Projects through the separate `/api/conductor/sync` endpoint.
- Ordinary authenticated `POST /api/projects` now atomically creates a HIGH/AGENT Todo under the Worker account, linked to the new Project, instructing the next Worker cycle to create `projects/<conductorSlug>/roadmap.yaml` with at least one ready task.
- Preserved the existing stale-DB direct-MariaDB fallback and extended it with an idempotent direct Todo insert, so outage fallback cannot create a Project while silently losing its Conductor handoff.
- Conductor projection-created Projects do not trigger this hook because that flow does not call `/api/projects`.

### How I verified
- Read current `projects/kind-robots/PROJECT-CREATION.md`, current Project create route, current Todo create route, and `/api/conductor/sync` before editing.
- Compared branch to current main: two focused server files only, branch was 0 behind before PR creation.
- CI on this exact head is the merge gate; no production Project/Todo rows were created from this connector session.

### Stakes
reversible

### Flags for Reviewer
- No `KR_API_TOKEN` is available in this runtime, so I did not exercise the production write path. The implementation is code/CI verified only until merge.

### Kaizen suggestion
Add a focused contract test that asserts the ordinary Project-create path queues exactly one AGENT scaffold Todo while the Conductor projection sync path does not.