### PR TITLE
Remove obsolete /wonder Memory Dungeon alias

### DIFF
--- a/.github/workflows/wonderlab-public-acceptance.yml
+++ b/.github/workflows/wonderlab-public-acceptance.yml
@@ -85,7 +85,6 @@ jobs:
             '/play/memory',
             '/play/screenfx',
             '/memory',
-            '/wonder',
             '/wonderlab',
             '1440',
             '390',

--- a/cypress/public/wonderlab-responsive.cy.ts
+++ b/cypress/public/wonderlab-responsive.cy.ts
@@ -95,14 +95,12 @@ describe('Public WonderLab responsive acceptance', () => {
     expectNoHorizontalOverflow()
   })
 
-  it('keeps legacy Wonder and Lab entry points useful', () => {
+  it('keeps legacy Memory and WonderLab entry points useful', () => {
     cy.viewport(1280, 800)
 
-    for (const path of ['/memory', '/wonder']) {
-      cy.visit(path)
-      cy.location('pathname').should('eq', '/play/memory')
-      cy.contains(/enter the dungeon/i, { timeout: 30_000 }).should('be.visible')
-    }
+    cy.visit('/memory')
+    cy.location('pathname').should('eq', '/play/memory')
+    cy.contains(/enter the dungeon/i, { timeout: 30_000 }).should('be.visible')
 
     visitWonderLab('/wonderlab')
     cy.location('pathname').should('eq', '/plan/wonderlab')

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -314,8 +314,8 @@ export default defineNuxtConfig({
   /*
    * Keep retired public entry points useful instead of turning bookmarks into
    * dead ends. Memory Dungeon moved from /memory to /play/memory when Lab was
-   * dissolved; /wonder was the friendly entrance to that playful section.
-   * WonderLab Museum remains available at its canonical /plan/wonderlab route.
+   * dissolved. WonderLab Museum remains available at its canonical
+   * /plan/wonderlab route.
    *
    * Storymaker was renamed to Storybook on 2026-08-02 (interface-vision t-002).
    * 301 redirects are intentional because these legacy paths are permanent
@@ -323,7 +323,6 @@ export default defineNuxtConfig({
    */
   routeRules: {
     '/memory': { redirect: { to: '/play/memory', statusCode: 301 } },
-    '/wonder': { redirect: { to: '/play/memory', statusCode: 301 } },
     '/wonderlab': { redirect: { to: '/plan/wonderlab', statusCode: 301 } },
     '/storymaker': { redirect: { to: '/storybook', statusCode: 301 } },
   },

--- a/utils/scripts/verifyWonderLabPublicNavigation.ts
+++ b/utils/scripts/verifyWonderLabPublicNavigation.ts
@@ -54,7 +54,6 @@ assert.match(
 
 const legacyRoutes = [
   { from: '/memory', to: '/play/memory' },
-  { from: '/wonder', to: '/play/memory' },
   { from: '/wonderlab', to: '/plan/wonderlab' },
 ] as const
 
@@ -66,6 +65,10 @@ for (const { from, to } of legacyRoutes) {
     `${from} must permanently redirect to ${to}`,
   )
 }
+assert.ok(
+  !nuxtConfig.includes("'/wonder': { redirect:"),
+  '/wonder must not be retained as a Memory Dungeon compatibility alias',
+)
 
 const items: ChannelContentItem[] = [
   {
@@ -129,5 +132,5 @@ for (const route of [...publicTabs.map((tab) => tab.route), '/play/davinci']) {
 }
 
 console.log(
-  'WonderLab public navigation verified: Museum, Memory Dungeon, and Screen FX remain public; Memory Dungeon stays obvious in Play; legacy Wonder/Lab routes redirect safely.',
+  'WonderLab public navigation verified: Museum, Memory Dungeon, and Screen FX remain public; Memory Dungeon stays obvious in Play; /memory and /wonderlab retain only their intended compatibility redirects.',
 )


### PR DESCRIPTION
## Correction
PR #1675 restored Memory Dungeon discovery correctly, but it also added `/wonder` as a permanent Memory Dungeon alias. That alias is not wanted and has no current navigation purpose.

## Changes
- Remove the `/wonder` → `/play/memory` route rule.
- Keep `/memory` → `/play/memory`.
- Keep `/wonderlab` → `/plan/wonderlab` for the museum.
- Remove `/wonder` from Cypress and workflow compatibility coverage.
- Add a navigation contract assertion that `/wonder` must not be reintroduced as a Memory Dungeon redirect.

No gameplay, tab ordering, or Memory Dungeon UI changes.