### PR TITLE
Publish production Docker image to GHCR

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,0 +1,74 @@
+name: Publish Production Container
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - package.json
+      - package-lock.json
+      - prisma/**
+      - .github/workflows/publish-container.yml
+  workflow_dispatch:
+
+concurrency:
+  group: production-container-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-publish:
+    name: Build production image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+          labels: |
+            org.opencontainers.image.title=Kind Robots
+            org.opencontainers.image.description=Kind Robots production Nuxt/Nitro image
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Build and publish
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          pull: true
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
### What changes
- Add a production container workflow that builds the existing Dockerfile for linux/amd64.
- On every push to `main`, publish `ghcr.io/silasfelinus/kind_robots:latest` plus an immutable `sha-<commit>` tag.
- Add OCI source/revision metadata so the running container can report exactly which Git commit it contains.
- Build on Docker-related pull requests without publishing, so container packaging changes get a real image build before merge.
- Cache Buildx layers and cancel superseded builds so bursts of main merges converge on the newest image.

### Deployment behavior
If a future Docker build fails, `latest` is not replaced. Alexandria therefore remains on the previous deployable digest instead of auto-updating to a broken image.

### Follow-up
GitHub creates the first GHCR package private by default. Once this workflow first publishes from `main`, the package needs a one-time human visibility change to Public before anonymous Unraid pulls can work. The Unraid catalog companion PR switches DockerMan to the GHCR image and documents Force Update / CA Auto Update.

No runtime secrets, DNS, OAuth, database, or application behavior changes.