### PR TITLE
Fix guest achievement records 401 on startup

### DIFF
--- a/components/admin/kind-loader.vue
+++ b/components/admin/kind-loader.vue
@@ -170,20 +170,38 @@ async function initializeStores() {
       import('@/stores/themeStore'),
     ])
 
+    const userStore = useUserStore()
+    const achievementStore = useAchievementStore()
+
+    await errorStore.handleError(
+      async () => userStore.initialize?.(),
+      ErrorType.STORE_ERROR,
+      'Error initializing user store',
+    )
+
     await runWave('identity + chrome', [
-      useUserStore().initialize?.(),
       usePageStore().initialize?.(),
       useNavStore().initialize?.(),
       useSmartbarStore().initialize?.(),
       useConsoleStore().initialize?.(),
-      useAchievementStore().initialize?.({
-        fetchRemote: true,
-        migratePendingGuestAchievements: true,
-      }),
+      achievementStore.initialize?.(),
       useThemeStore().initialize({ fetchShared: true }),
     ])
 
-    await useAchievementStore().rewardAchievementForPath(route.path)
+    await runWave('achievement sync', [
+      achievementStore.fetchAchievements(true),
+      userStore.isLoggedIn
+        ? achievementStore.fetchAchievementRecords(true)
+        : undefined,
+    ])
+
+    await runWave('achievement migration', [
+      userStore.isLoggedIn
+        ? achievementStore.migratePendingGuestAchievements()
+        : undefined,
+    ])
+
+    await achievementStore.rewardAchievementForPath(route.path)
 
     const [{ useServerStore }, { useCheckpointStore }] = await Promise.all([
       import('@/stores/serverStore'),

--- a/utils/scripts/verifyAchievementStoreFetchSafety.ts
+++ b/utils/scripts/verifyAchievementStoreFetchSafety.ts
@@ -58,4 +58,38 @@ assert.ok(
   'Score loading must remain accurate across concurrent leaderboard requests.',
 )
 
+const loaderSource = readFileSync('components/admin/kind-loader.vue', 'utf8')
+const userInitializeIndex = loaderSource.indexOf('userStore.initialize?.()')
+const recordsFetchIndex = loaderSource.indexOf(
+  'achievementStore.fetchAchievementRecords(true)',
+)
+const migrationIndex = loaderSource.indexOf(
+  'achievementStore.migratePendingGuestAchievements()',
+)
+
+assert.ok(
+  userInitializeIndex >= 0 &&
+    recordsFetchIndex >= 0 &&
+    userInitializeIndex < recordsFetchIndex,
+  'Startup must resolve user identity before requesting achievement records.',
+)
+assert.ok(
+  loaderSource.includes('achievementStore.fetchAchievements(true)'),
+  'Guest startup must still refresh the public achievement catalog.',
+)
+assert.match(
+  loaderSource,
+  /userStore\.isLoggedIn\s*\?\s*achievementStore\.fetchAchievementRecords\(true\)\s*:\s*undefined/,
+  'Guest startup must not request authenticated achievement records.',
+)
+assert.match(
+  loaderSource,
+  /userStore\.isLoggedIn\s*\?\s*achievementStore\.migratePendingGuestAchievements\(\)\s*:\s*undefined/,
+  'Pending guest achievements must only migrate after authentication.',
+)
+assert.ok(
+  recordsFetchIndex < migrationIndex,
+  'Authenticated records must load before pending guest achievements migrate.',
+)
+
 console.log('Achievement store fetch safety contract passed.')


### PR DESCRIPTION
### Task
kind-robots/direct: Avoid guest achievement-record 401s (kind: software)

### What changed / what I produced
- Resolve the user store before achievement sync so startup knows whether the visitor is authenticated.
- Keep the public achievement catalog refresh for guests.
- Fetch `/api/achievements/records` only after `userStore.isLoggedIn` is true.
- Migrate pending guest achievements only after authenticated records have loaded.
- Extend the achievement-store safety contract to lock in the auth gate and ordering.

### How I verified
- Inspected the protected records route and global startup call chain through the GitHub connector.
- Confirmed the branch is 2 commits ahead of current `main`, 0 behind, with only `components/admin/kind-loader.vue` and `utils/scripts/verifyAchievementStoreFetchSafety.ts` changed.
- Local checkout execution was unavailable because the sandbox could not resolve `github.com`; required repository checks are being left to GitHub CI and will be checked before merge.

### Stakes
reversible

### Flags for Reviewer
- The records endpoint remains authenticated; this fixes the caller rather than weakening endpoint security.

### Kaizen suggestion
Keep private startup fetches explicitly gated behind resolved identity state rather than bundling public and authenticated fetches under one generic `fetchRemote` flag.

### Notes for reviewer
This is startup orchestration only. Guest achievement discovery remains local/public, while signed-in users still refresh records before pending guest awards migrate.