### PR TITLE
interface-vision/t-104 slice 30: adopt kr-container on password reset

### DIFF
--- a/components/user/password-reset.vue
+++ b/components/user/password-reset.vue
@@ -5,7 +5,7 @@
   - ?token=... present: set a new password by consuming the token.
 -->
 <template>
-  <section class="mx-auto flex w-full max-w-md flex-col gap-5 p-6">
+  <section class="kr-container max-w-md flex flex-col gap-5 p-6">
     <header class="flex flex-col gap-1">
       <h1 class="text-2xl font-black">
         {{ hasToken ? 'Choose a new password' : 'Reset your password' }}


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Replaced the password-reset page root's hand-rolled `mx-auto w-full max-w-md` container vocabulary with `kr-container max-w-md`.
- Preserved `flex flex-col gap-5 p-6`, all reset/request behavior, auth/API calls, and the deliberate narrow `max-w-md` width.
- This is declaration-equivalent: `kr-container` owns `mx-auto w-full max-w-6xl`, while the utility-layer `max-w-md` keeps the page at its existing narrower measure.

### How I verified
- Conductor session-aware claim was consumed and canonical ownership verified for session `20260809T135951-0700-interface-vision-t104-s30-5f2c` before implementation.
- Conductor `status: review` was consumed and verified before this PR opened.
- Compared branch against fresh main `82c435d36976d209f47b1b2ae45774dcb900812e`: exactly one file, +1/-1.
- GitHub CI on this exact head is the executable verification source in this connector-only runtime; merge only after all required checks complete successfully.

### Stakes
reversible

### Flags for Reviewer
- This is slice 30 of the non-recurring t-104 consistency umbrella, not completion of t-104.
- No schema, migration, API, store, auth behavior, production data, or outward-facing content change.

### Kaizen suggestion
Continue shrinking exact container-vocabulary duplicates in small verified slices; avoid folding unrelated visual redesign into mechanical primitive adoption.