### PR TITLE
Make guest achievement record reads return 200

### DIFF
--- a/server/api/achievements/records.get.ts
+++ b/server/api/achievements/records.get.ts
@@ -2,11 +2,24 @@
 import { defineEventHandler } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
-import { requireApiUser } from '../../utils/authGuard'
+import { getOptionalApiUser } from '../../utils/authGuard'
 
 export default defineEventHandler(async (event) => {
   try {
-    const { user, isAdmin } = await requireApiUser(event)
+    const auth = await getOptionalApiUser(event)
+
+    if (!auth) {
+      event.node.res.statusCode = 200
+
+      return {
+        success: true,
+        message: 'No achievement records for guest sessions.',
+        data: [],
+        statusCode: 200,
+      }
+    }
+
+    const { user, isAdmin } = auth
 
     const data = await prisma.achievementRecord.findMany({
       where: isAdmin ? undefined : { userId: user.id },

--- a/utils/scripts/verifyAchievementStoreFetchSafety.ts
+++ b/utils/scripts/verifyAchievementStoreFetchSafety.ts
@@ -92,4 +92,22 @@ assert.ok(
   'Authenticated records must load before pending guest achievements migrate.',
 )
 
+const recordsRouteSource = readFileSync(
+  'server/api/achievements/records.get.ts',
+  'utf8',
+)
+assert.ok(
+  recordsRouteSource.includes('getOptionalApiUser(event)'),
+  'Achievement records GET must tolerate unauthenticated guest requests.',
+)
+assert.ok(
+  !recordsRouteSource.includes('requireApiUser(event)'),
+  'Achievement records GET must not turn guest reads into 401 responses.',
+)
+assert.match(
+  recordsRouteSource,
+  /if \(!auth\)[\s\S]*statusCode = 200[\s\S]*data: \[\][\s\S]*statusCode: 200/,
+  'Guest achievement record reads must return a successful empty list.',
+)
+
 console.log('Achievement store fetch safety contract passed.')


### PR DESCRIPTION
## Closed as unnecessary
The reported post-fix reproduction came from an Unraid container that had been restarted/force-updated after `git pull` but had **not rebuilt the Docker image from the updated checkout**. That means it was still serving the previous compiled Nuxt bundle, so the 401 did not demonstrate that the merged client-side auth gating failed.

Keeping `GET /api/achievements/records` authenticated is preferable. The original merged fix resolves user identity before achievement record sync and avoids the guest request at the caller.

No merge performed.