### PR TITLE
Use deployment-aware Google OAuth callback

### DIFF
--- a/server/api/auth/google/callback.ts
+++ b/server/api/auth/google/callback.ts
@@ -20,6 +20,15 @@ interface GoogleUserInfoResponse {
   picture: string
 }
 
+function getGoogleRedirectUri() {
+  return (
+    process.env.GOOGLE_REDIRECT_URI ||
+    (process.env.VERCEL
+      ? 'https://kind-robots.vercel.app/api/auth/google/callback'
+      : 'https://kindrobots.org/api/auth/google/callback')
+  )
+}
+
 export default defineEventHandler(async (event) => {
   const { code } = getQuery(event)
 
@@ -33,7 +42,14 @@ export default defineEventHandler(async (event) => {
 
   const clientId = process.env.GOOGLE_ID
   const clientSecret = process.env.GOOGLE_SECRET
-  const redirectUri = 'https://kind-robots.vercel.app/api/auth/google/callback'
+  const redirectUri = getGoogleRedirectUri()
+
+  if (!clientId || !clientSecret) {
+    throw createError({
+      statusCode: 500,
+      message: 'Google OAuth credentials are not configured',
+    })
+  }
 
   try {
     const tokenResponse = await $fetch<GoogleTokenResponse, string>(

--- a/server/api/auth/google/index.ts
+++ b/server/api/auth/google/index.ts
@@ -1,10 +1,26 @@
-import { defineEventHandler, setResponseStatus, setHeaders } from 'h3'
+import { createError, defineEventHandler, setHeaders, setResponseStatus } from 'h3'
+
+function getGoogleRedirectUri() {
+  return (
+    process.env.GOOGLE_REDIRECT_URI ||
+    (process.env.VERCEL
+      ? 'https://kind-robots.vercel.app/api/auth/google/callback'
+      : 'https://kindrobots.org/api/auth/google/callback')
+  )
+}
 
 export default defineEventHandler((event) => {
   const clientId = process.env.GOOGLE_ID
-  const redirectUri = 'https://kind-robots.vercel.app/api/auth/google/callback'
 
-  const googleOAuthURL = `https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=email%20profile`
+  if (!clientId) {
+    throw createError({
+      statusCode: 500,
+      message: 'Google OAuth client ID is not configured',
+    })
+  }
+
+  const redirectUri = getGoogleRedirectUri()
+  const googleOAuthURL = `https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=email%20profile`
 
   setResponseStatus(event, 302)
   setHeaders(event, { Location: googleOAuthURL })


### PR DESCRIPTION
Fix Google OAuth after the self-hosted kindrobots.org cutover.

- Stop hardcoding the Vercel callback in both the authorization redirect and token exchange.
- Honor `GOOGLE_REDIRECT_URI` from the runtime environment.
- Preserve the Vercel callback as the Vercel fallback when the variable is absent, and use kindrobots.org for self-hosted runtime fallback.
- Fail locally with a clear 500 if `GOOGLE_ID` or `GOOGLE_SECRET` is missing instead of sending `client_id=undefined` to Google.

The current `401 invalid_client` still requires verifying Alexandria's `GOOGLE_ID` matches the OAuth client in Google Cloud; this PR fixes the independent redirect-URI bug so the configured `GOOGLE_REDIRECT_URI=https://kindrobots.org/api/auth/google/callback` is actually used.