### PR TITLE
Block clickthrough during startup explore mode

### DIFF
--- a/components/screenfx/startup-animation.vue
+++ b/components/screenfx/startup-animation.vue
@@ -318,6 +318,7 @@ onBeforeUnmount(() => {
  */
 .startup-animation__stage--immersive {
   background: #000;
+  pointer-events: auto;
   opacity: 1;
 }
 

--- a/utils/scripts/verify-startup-handoff.mjs
+++ b/utils/scripts/verify-startup-handoff.mjs
@@ -156,6 +156,13 @@ assert.ok(
   'Immersive mode must own an opaque black screensaver backdrop so the live site cannot bleed through.',
 )
 
+assert.ok(
+  /\.startup-animation__stage--immersive\s*\{[^}]*pointer-events:\s*auto;/s.test(
+    startupAnimation,
+  ),
+  'Immersive mode must capture pointer input so clicks reach the startup effect instead of the loaded page underneath.',
+)
+
 /*
  * The intro visual is a real <img> with its own animation->logo fallback.
  * Never paint additional WebPs behind it in CSS: those backgrounds bypass the


### PR DESCRIPTION
## What changed
- Make the fullscreen startup effect stage capture pointer input while `Pause & explore` is active.
- Keep normal startup behavior unchanged outside immersive mode.
- Add a startup-contract regression assertion requiring immersive input capture.

## Root cause
The paused animation stayed visually fullscreen but `.startup-animation__stage` retained `pointer-events: none`, so clicks landed on the already-loaded application underneath, including external newsfeed links.

## User impact
Paused startup animations can still respond to mouse/click input, but the hidden loaded page can no longer receive those clicks.

## Validation
- Compared branch against `main`: only `components/screenfx/startup-animation.vue` and `utils/scripts/verify-startup-handoff.mjs` changed.
- Awaiting repository CI before merge.