### PR TITLE
Let the card back fall back through the same art chain as the card front

### DIFF
--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -109,6 +109,7 @@
           :title="infoBot.name || 'Unnamed Bot'"
           :subtitle="infoBot.subtitle || ''"
           :description="infoBot.description || infoBot.personality || ''"
+          :source="infoBot"
           :art-src="infoBot.avatarImage || ''"
           :badges="infoBotBadges"
           :can-edit="canEditInfoBot"

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -46,6 +46,7 @@
           :title="infoCharacter.name || 'Unnamed Character'"
           :subtitle="infoCharacter.honorific || ''"
           :description="infoCharacter.backstory || ''"
+          :source="infoCharacter"
           :art-src="infoCharacter.imagePath || ''"
           :badges="infoCharacterBadges"
           :can-interact="true"

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -218,6 +218,7 @@
           :title="infoDream.title || 'Untitled Dream'"
           :subtitle="infoDream.flavorText || ''"
           :description="infoDream.description || infoDream.pitch || ''"
+          :source="infoDream"
           :art-src="infoDream.imagePath || ''"
           :badges="infoDreamBadges"
           :can-edit="true"

--- a/components/gallery/kr-card-back.vue
+++ b/components/gallery/kr-card-back.vue
@@ -72,11 +72,11 @@
         an actual card back has.
       -->
       <div
-        v-if="artSrc"
+        v-if="resolvedArtSrc"
         class="relative flex max-h-72 w-full shrink-0 justify-center overflow-hidden bg-base-200"
       >
         <img
-          :src="artSrc"
+          :src="resolvedArtSrc"
           :alt="title"
           class="max-h-72 w-auto max-w-full object-contain"
         />
@@ -95,7 +95,7 @@
         </div>
       </div>
 
-      <div v-if="artSrc" class="min-w-0 px-3 pb-3 pt-2">
+      <div v-if="resolvedArtSrc" class="min-w-0 px-3 pb-3 pt-2">
         <h2 class="break-words text-lg font-black leading-tight">
           {{ title }}
         </h2>
@@ -255,11 +255,32 @@
 </template>
 
 <script setup lang="ts">
-withDefaults(
+import { computed } from 'vue'
+import { resolveEntityArtwork, type ArtImageSrcLike } from '@/utils/artImageSrc'
+
+const props = withDefaults(
   defineProps<{
     title: string
     subtitle?: string
     description?: string
+    /**
+     * The record itself, so the back can fall back through the SAME art chain
+     * the front already uses.
+     *
+     * Silas, 2026-08-10: "only about half the bots are showing images when
+     * selecting ... as long as one exists (and it does because we clicked on it
+     * to select) we have something to show."
+     *
+     * Exactly right, and the asymmetry was the bug. The front renders through
+     * kr-art-plate with `:source="record"`, which resolves imagePath, cardPath,
+     * heroPath and iconPath; every gallery then handed this component ONE field
+     * (`avatarImage` for Bots, `imagePath` for the other five). A Bot with a
+     * cardPath and no avatarImage therefore had art on the tile and a blank
+     * plate on the back. resolveEntityArtwork walks the same order the front
+     * does, so the back can no longer show less than the front did.
+     */
+    source?: ArtImageSrcLike | null
+    /** Explicit first choice, tried before `source`'s chain. */
     artSrc?: string
     badges?: string[]
     canEdit?: boolean
@@ -274,12 +295,20 @@ withDefaults(
   {
     subtitle: '',
     description: '',
+    source: null,
     artSrc: '',
     badges: () => [],
     canEdit: false,
     canInteract: false,
     interactLabel: 'Open',
   },
+)
+
+const resolvedArtSrc = computed(
+  () =>
+    props.artSrc ||
+    (props.source ? resolveEntityArtwork(props.source) : '') ||
+    '',
 )
 
 const emit = defineEmits<{

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -111,6 +111,7 @@
           :title="infoReward.name || 'Unnamed Reward'"
           :subtitle="infoReward.collection || ''"
           :description="infoReward.description || ''"
+          :source="infoReward"
           :art-src="infoReward.imagePath || ''"
           :badges="infoRewardBadges"
           :can-interact="true"

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -76,6 +76,7 @@
           v-model:editing="infoScenarioEditing"
           :title="infoScenario.title || 'Untitled Scenario'"
           :description="infoScenario.description || ''"
+          :source="infoScenario"
           :art-src="infoScenario.imagePath || ''"
           :badges="infoScenarioBadges"
           :can-interact="true"


### PR DESCRIPTION
Silas, 2026-08-10: *"only about half the bots are showing images when selecting … as long as one exists (and it does because we clicked on it to select) we have something to show."*

Exactly right, and the asymmetry was the bug.

The card **front** renders through `kr-art-plate` with `:source="record"`, which resolves `imagePath → cardPath → heroPath → iconPath`. Every gallery then handed `kr-card-back` **one field** — `avatarImage` for Bots, `imagePath` for Characters, Dreams, Rewards and Scenarios. So a Bot with a `cardPath` and no `avatarImage` had art on the tile and a blank plate on the back. That's why it looked like roughly half of them: it's whichever half happen to store their art in the field the back was given.

`kr-card-back` now takes the record itself and resolves through `resolveEntityArtwork` — the same order the front walks. `artSrc` stays as the explicit first choice, so Bots still prefer `avatarImage` and only fall through when it's empty. **The back can no longer show less than the front did.**

Five galleries wired. `resource-gallery` already passed a four-field chain of its own (`ArtImage.thumbnailPath → ArtImage.imagePath → previewImageUrl → imagePath`) and needed nothing — which is what made the inconsistency easy to miss.

## Verification

- `npm run test` (vue-tsc) — clean
- `test:layout-contract`, `test:gallery-consistency`, `verifyCardActionContract` — pass
- `test:lint-ratchet` — 392 problems across 27 rules, unchanged
- `eslint` + `prettier` on changed files — clean (the 4 eslint errors reported in `character-gallery` and `dream-gallery` are pre-existing and baselined; they're in lines this PR doesn't touch)

Not verified in a browser — no egress here. The fix is structural: the back now calls the same resolver as the front, so any record the grid could draw, the back can draw.

## Not in this PR

The missing edit button is still open — the card back's Edit and its `can-edit` wiring are byte-identical to when it last worked, so it needs a different explanation than this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_