### PR TITLE
Fix collapsed login action in account switcher

### DIFF
--- a/components/navigation/login-switcher.vue
+++ b/components/navigation/login-switcher.vue
@@ -135,11 +135,11 @@
       <NuxtLink
         v-else
         to="/login"
-        class="btn btn-primary btn-sm rounded-2xl"
+        class="btn btn-primary btn-sm w-full justify-center gap-2 whitespace-nowrap rounded-2xl px-4"
         @click="store.close"
       >
-        <Icon name="kind-icon:login" class="h-4 w-4" />
-        Log in
+        <Icon name="kind-icon:login" class="h-4 w-4 shrink-0" />
+        <span class="shrink-0">Log in</span>
       </NuxtLink>
 
       <button


### PR DESCRIPTION
Fix the guest login action shown in the header account switcher.

- Make the guest `Log in` action explicitly full-width.
- Keep the icon and label on one line and centered.
- Prevent the icon/text from shrinking into the narrow wrapped pill shown in the dashboard popover.

No auth behavior changes; this is layout-only.