### PR TITLE
Move the Bot tile's actions to the card back and strip it to art, title, type

### DIFF
--- a/components/bots/bot-card.vue
+++ b/components/bots/bot-card.vue
@@ -13,43 +13,8 @@
       :earned-karma="earnedKarma"
       @select="selectBot"
     >
-      <template #actions>
-        <button
-          v-if="
-            showActions && allowEdit && canEdit && (activeSelected || compact)
-          "
-          class="rounded-full bg-base-100/90 p-2 text-primary shadow backdrop-blur transition hover:bg-primary hover:text-primary-content"
-          type="button"
-          title="Edit Bot"
-          @click.stop="startEditing"
-        >
-          <Icon name="kind-icon:pencil" class="h-4 w-4" />
-        </button>
-
-        <button
-          v-if="showActions && allowClone && (activeSelected || compact)"
-          class="rounded-full bg-base-100/90 p-2 text-secondary shadow backdrop-blur transition hover:bg-secondary hover:text-secondary-content"
-          type="button"
-          title="Clone Bot"
-          @click.stop="startCloning"
-        >
-          <Icon name="kind-icon:copy" class="h-4 w-4" />
-        </button>
-
-        <button
-          v-if="showActions && canDelete && (activeSelected || compact)"
-          class="rounded-full bg-base-100/90 p-2 text-error shadow backdrop-blur transition hover:bg-error hover:text-error-content"
-          type="button"
-          title="Delete Bot"
-          @click.stop="deleteBot"
-        >
-          <Icon name="kind-icon:trash" class="h-4 w-4" />
-        </button>
-      </template>
-
       <kr-entity-card-body
         :title="botTitle"
-        :subtitle="bot.subtitle || ''"
         :source="bot"
         :variant="variant"
         :fallback="artFallbackSrc"
@@ -58,7 +23,6 @@
         :compact="compact"
         :selected="activeSelected"
         :badges="badges"
-        :meta="showMeta ? metaChips : []"
         shape="card"
         compact-shape="hero"
         placeholder-icon="kind-icon:robot"
@@ -72,7 +36,6 @@
             showPersonality ||
             showPromptPreview ||
             showLaunchButton ||
-            statusMessage ||
             showDebug)
         "
         class="mt-2 grid gap-2 rounded-2xl border border-primary/20 bg-primary/5 p-3"
@@ -129,14 +92,6 @@
           </button>
         </div>
 
-        <div
-          v-if="statusMessage"
-          class="rounded-2xl border p-3 text-sm"
-          :class="statusTone === 'error' ? 'kr-note-error' : 'kr-note-success'"
-        >
-          {{ statusMessage }}
-        </div>
-
         <details v-if="showDebug" class="kr-panel-flat p-2" @click.stop>
           <summary
             class="cursor-pointer text-xs font-bold text-base-content/70"
@@ -158,8 +113,6 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import type { Bot } from '~/prisma/generated/prisma/client'
 import { useBotStore } from '@/stores/botStore'
-import { useNavStore } from '@/stores/navStore'
-import { useUserStore } from '@/stores/userStore'
 import type { ArtVariant } from '@/utils/artImageSrc'
 import { botTypeMeta } from '@/utils/botTypeVocabulary'
 import type { EntityCardChip } from '@/components/gallery/kr-entity-card-body.vue'
@@ -223,11 +176,7 @@ const emit = defineEmits<{
 }>()
 
 const botStore = useBotStore()
-const navStore = useNavStore()
-const userStore = useUserStore()
 
-const statusMessage = ref('')
-const statusTone = ref<'success' | 'error'>('success')
 const loadedBotImage = ref('')
 
 const activeSelected = computed(() => {
@@ -299,43 +248,6 @@ const badges = computed<EntityCardChip[]>(() => {
   return result
 })
 
-/*
- * NO THEME, NO DESIGNER. Silas, 2026-08-09: "I love the border around the
- * gallery images, but we don't need the designer or theme text."
- *
- * Both were near-constant down the page -- the same handle on every card, and
- * a palette name that the card's own `data-theme` border already SHOWS -- so
- * they were a row of chips repeating what the eye had, on all 69 tiles. The
- * theme still colours the frame; it just no longer also spells itself out.
- *
- * serverName survives because it varies and nothing else on the card carries
- * it, but most Bots have none, so in practice the strip is now usually empty.
- * Full provenance is on the card back, which is what the back is for.
- */
-const metaChips = computed<EntityCardChip[]>(() => {
-  const result: EntityCardChip[] = []
-  if (props.bot.serverName) {
-    result.push({ label: props.bot.serverName, class: 'badge-info' })
-  }
-  return result
-})
-
-const canEdit = computed(() => {
-  return userStore.isAdmin || props.bot.userId === userStore.userId
-})
-
-const canDelete = computed(() => {
-  if (!props.allowDelete) return false
-  if (props.bot.canDelete === false) return false
-
-  return canEdit.value
-})
-
-function setStatus(message: string, tone: 'success' | 'error' = 'success') {
-  statusMessage.value = message
-  statusTone.value = tone
-}
-
 async function loadBotImage() {
   loadedBotImage.value = ''
 
@@ -362,43 +274,6 @@ async function loadBotImage() {
  */
 function selectBot() {
   emit('open', props.bot.id)
-}
-
-async function startEditing() {
-  const bot = await botStore.startEditingBot(props.bot.id)
-
-  if (!bot) {
-    setStatus('Bot could not be loaded for editing.', 'error')
-    return
-  }
-
-  navStore.setDashboardTab('bot', 'forge')
-  emit('edit', props.bot.id)
-  setStatus('Bot loaded for editing.')
-}
-
-async function startCloning() {
-  const bot = await botStore.startCloningBot(props.bot.id)
-
-  if (!bot) {
-    setStatus('Bot could not be cloned.', 'error')
-    return
-  }
-
-  emit('clone', props.bot.id)
-  setStatus('Bot cloned into the form.')
-}
-
-async function deleteBot() {
-  const result = await botStore.deleteBotById(props.bot.id)
-
-  if (result.success) {
-    emit('delete', props.bot.id)
-    setStatus(result.message || 'Bot deleted.')
-    return
-  }
-
-  setStatus(result.message || 'Failed to delete bot.', 'error')
 }
 
 /*

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -137,6 +137,40 @@
             </dl>
           </template>
 
+          <!--
+            THE TILE'S ACTIONS LIVE HERE. Silas, 2026-08-10: "all those
+            buttons that you said were gated on front should be on the back."
+
+            bot-card still carries edit/clone/delete circles, but they are
+            gated on `activeSelected || compact` -- and since the card back
+            landed, clicking a tile sets infoBotId rather than
+            botStore.currentBot, so nothing in the grid is ever "selected" and
+            those three never rendered. The back is where the object's actions
+            were always meant to end up; Edit already arrived through
+            `can-edit`, and these are the two that were still stranded.
+          -->
+          <template #actions>
+            <button
+              v-if="canCloneInfoBot"
+              type="button"
+              class="btn btn-outline btn-sm mr-auto rounded-xl"
+              @click="cloneInfoBot"
+            >
+              <Icon name="kind-icon:copy" class="h-4 w-4" />
+              Clone
+            </button>
+
+            <button
+              v-if="canDeleteInfoBot"
+              type="button"
+              class="btn btn-outline btn-error btn-sm rounded-xl"
+              @click="deleteInfoBot"
+            >
+              <Icon name="kind-icon:trash" class="h-4 w-4" />
+              Delete
+            </button>
+          </template>
+
           <template #edit="{ done }">
             <add-bot mode="edit" @saved="done" @cancel="done" />
           </template>
@@ -920,6 +954,46 @@ const infoBotBadges = computed(() => {
     .filter((entry): entry is string => Boolean(entry))
     .map(String)
 })
+
+/*
+ * Clone is offered to anyone who can open the panel -- it creates a NEW Bot
+ * owned by the cloner, so it needs no ownership of the original. Delete needs
+ * the same right as Edit, plus the record's own canDelete opt-out, which is
+ * exactly what bot-card's front button checked.
+ */
+const canCloneInfoBot = computed(() =>
+  Boolean(props.allowClone && infoBot.value),
+)
+
+const canDeleteInfoBot = computed(() => {
+  const bot = infoBot.value
+  if (!props.allowDelete || !bot) return false
+  if (bot.canDelete === false) return false
+
+  return canEditInfoBot.value
+})
+
+/*
+ * Both close the panel first. Clone opens the add form underneath it, and a
+ * deleted Bot's panel would otherwise sit there describing a record that no
+ * longer exists -- the same reason the `v-else` branch above exists for a Bot
+ * that vanished from another tab.
+ */
+async function cloneInfoBot() {
+  const id = infoBotId.value
+  infoOpen.value = false
+  if (id) await cloneBotById(id)
+}
+
+async function deleteInfoBot() {
+  const id = infoBotId.value
+  if (!id) return
+
+  infoOpen.value = false
+  const result = await botStore.deleteBotById(id)
+
+  if (result.success) handleBotDeleted(id)
+}
 
 const canEditInfoBot = computed(() => {
   const bot = infoBot.value


### PR DESCRIPTION
Silas, 2026-08-10: *"all those buttons that you said were gated on front should be on the back"*, and *"front: minimal text, just images, themed border, title, and type icon. back: the rest of the info, image, those buttons, and the review section."*

## Why the buttons went missing

`bot-card` still carried edit/clone/delete circles, gated on `activeSelected || compact`. But since the card back landed, clicking a tile sets `infoBotId` rather than `botStore.currentBot` — so **nothing in the grid is ever "selected"**, and those three never rendered anywhere. They weren't removed; they were stranded.

Edit had already reached the back through `can-edit`. Clone and Delete now join it in the same actions row.

- **Clone** is offered to anyone who can open the panel — it creates a *new* Bot owned by the cloner, so it needs no ownership of the original.
- **Delete** takes the same right as Edit plus the record's own `canDelete` opt-out, which is exactly what the front button checked.

## The tile

Subtitle and the meta chip row are gone, leaving the themed border, the art, the title, and the type glyph.

`Building` and `Selected` stay. Both are **state** rather than description, and `Building` is what the toolbar's construction filter acts on — hiding it would make that filter's effect invisible. Flagging it since the spec said "just title and type icon"; say the word and they go too.

Removing the buttons stranded their handlers as well: `startEditing`, `startCloning`, `deleteBot`, and with them `setStatus` and the status banner they were the only writers of, plus `canEdit`/`canDelete`/`metaChips` and the nav and user stores they used. All removed rather than left as unreachable code — the file is 96 lines lighter.

The selected-details section **stays**. It doesn't render in the grid (nothing is selected there), but `bot-chat`'s sidebar mounts this card with `:selected="true" :show-prompt-preview="true"`, so it's still the Selected Bot summary.

## Not in this PR: the review section

`reactable-card` gates its reaction panel on `props.selected` too — so reviews are unreachable on the tile for **exactly the same reason** the buttons were. But that component is shared by fourteen cards, so relocating it is its own change rather than a rider on this one. It's the next thing.

## Verification

- `npm run test` (vue-tsc) — clean
- `test:layout-contract`, `test:gallery-consistency`, `test:component-reachability`, `verifyCardActionContract`, `audit:wonderlab-previews --strict` — pass
- `test:lint-ratchet` — unchanged
- `eslint` + `prettier` on changed files — clean

Not verified in a browser — no egress here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_