### PR TITLE
Fix auth-state hydration races on initial load

### DIFF
--- a/components/admin/kind-loader.vue
+++ b/components/admin/kind-loader.vue
@@ -12,7 +12,7 @@
 
 <script setup lang="ts">
 // /components/content/story/kind-loader.vue
-import { onBeforeMount, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { useErrorStore, ErrorType } from '@/stores/errorStore'
 import { useViewportStore } from '@/stores/viewportStore'
@@ -312,17 +312,13 @@ watch(
   },
 )
 
-onBeforeMount(() => {
+onMounted(() => {
+  void ensureStoresInitialized()
+
   if (startupMode.value !== 'none') return
 
-  void ensureStoresInitialized()
   handleOverlayCovered()
   emitReadyOnce()
-})
-
-onMounted(() => {
-  if (startupMode.value !== 'full') return
-  void ensureStoresInitialized()
 })
 
 /*

--- a/middleware/navigation-access.global.ts
+++ b/middleware/navigation-access.global.ts
@@ -4,7 +4,7 @@ import { useChannelContentStore } from '@/stores/channelContentStore'
 import { useUserStore } from '@/stores/userStore'
 
 /*
- * How long navigation will wait on the user and channel stores before
+ * How long the first navigation will wait on the user and channel stores before
  * proceeding ungated. Comfortably above a healthy round trip and comfortably
  * below app.vue's 9s loader failsafe, so a degraded backend produces a usable
  * page rather than a race between two deadlines.
@@ -56,25 +56,26 @@ export default defineNuxtRouteMiddleware(async (to) => {
 
   const nuxtApp = useNuxtApp()
 
-  async function enforceNavigationAccess() {
+  const enforceNavigationAccess = async () => {
     const userStore = useUserStore()
     const channelContentStore = useChannelContentStore()
 
     /*
-     * BOUNDED. On normal client-side navigation this runs before the route
-     * resolves, so anything it awaits is on the critical path to the next page.
-     * On the initial SSR hydration the block below defers this whole function to
-     * app:mounted instead: restoring localStorage-backed identity before Vue has
-     * reconciled the server's guest markup changes header v-if branches and
-     * produces a real hydration mismatch.
+     * BOUNDED. This runs before the first route resolves, so anything it awaits
+     * is on the critical path to the app being visible at all -- and
+     * `channelContentStore.initialize()` ends in `queryCollection('channels')`,
+     * while `userStore.initialize()` reaches the API. Neither carried a deadline,
+     * so a slow or failing backend held the initial navigation open indefinitely.
+     * Production has been logging both since 2026-08-06: AbortErrors on
+     * `/[...slug]` and 40s function timeouts.
      *
-     * Timing out is SAFE, and deliberately so: the access check below opens
+     * Timing out here is SAFE, and deliberately so: the access check below opens
      * with `if (!access.matched || access.allowed) return`, and an unpopulated
      * channel list matches nothing. So the degraded outcome is "this middleware
      * declines to gate", never "this middleware locks someone out" or, worse,
-     * bounces them to /login while the page underneath is still suspended.
-     * Whatever did resolve is kept -- the stores hold their own state, and the
-     * losing promise still settles into them for the next navigation.
+     * bounces them to /login and back while the page underneath is still
+     * suspended. Whatever did resolve is kept -- the stores hold their own state,
+     * and the losing promise still settles into them for the next navigation.
      */
     await Promise.race([
       Promise.all([userStore.initialize(), channelContentStore.initialize()]),
@@ -140,17 +141,6 @@ export default defineNuxtRouteMiddleware(async (to) => {
     })
   }
 
-  /*
-   * Nuxt executes global route middleware twice for an SSR first load: once on
-   * the server, then again in the browser before hydration. This middleware is
-   * intentionally client-only because the session token lives in localStorage,
-   * but that means the browser pass must NOT restore user state until the server
-   * DOM has been hydrated. Nuxt documents this exact isHydrating/serverRendered
-   * guard for initial client middleware.
-   *
-   * We still run the access check immediately after app:mounted so direct loads
-   * of protected routes keep the same redirect behavior; only the timing moves.
-   */
   if (nuxtApp.isHydrating && nuxtApp.payload.serverRendered) {
     nuxtApp.hook('app:mounted', () => {
       void nuxtApp.runWithContext(enforceNavigationAccess)

--- a/middleware/navigation-access.global.ts
+++ b/middleware/navigation-access.global.ts
@@ -4,7 +4,7 @@ import { useChannelContentStore } from '@/stores/channelContentStore'
 import { useUserStore } from '@/stores/userStore'
 
 /*
- * How long the first navigation will wait on the user and channel stores before
+ * How long navigation will wait on the user and channel stores before
  * proceeding ungated. Comfortably above a healthy round trip and comfortably
  * below app.vue's 9s loader failsafe, so a degraded backend produces a usable
  * page rather than a race between two deadlines.
@@ -54,86 +54,109 @@ function consumeReturnPath(): string {
 export default defineNuxtRouteMiddleware(async (to) => {
   if (import.meta.server) return
 
-  const userStore = useUserStore()
-  const channelContentStore = useChannelContentStore()
+  const nuxtApp = useNuxtApp()
 
-  /*
-   * BOUNDED. This runs before the first route resolves, so anything it awaits
-   * is on the critical path to the app being visible at all -- and
-   * `channelContentStore.initialize()` ends in `queryCollection('channels')`,
-   * while `userStore.initialize()` reaches the API. Neither carried a deadline,
-   * so a slow or failing backend held the initial navigation open indefinitely.
-   * Production has been logging both since 2026-08-06: AbortErrors on
-   * `/[...slug]` and 40s function timeouts.
-   *
-   * Timing out here is SAFE, and deliberately so: the access check below opens
-   * with `if (!access.matched || access.allowed) return`, and an unpopulated
-   * channel list matches nothing. So the degraded outcome is "this middleware
-   * declines to gate", never "this middleware locks someone out" or, worse,
-   * bounces them to /login and back while the page underneath is still
-   * suspended. Whatever did resolve is kept -- the stores hold their own state,
-   * and the losing promise still settles into them for the next navigation.
-   */
-  await Promise.race([
-    Promise.all([userStore.initialize(), channelContentStore.initialize()]),
-    new Promise((resolve) => setTimeout(resolve, INITIALIZE_TIMEOUT_MS)),
-  ])
+  async function enforceNavigationAccess() {
+    const userStore = useUserStore()
+    const channelContentStore = useChannelContentStore()
 
-  const requestedLoginReturn = safeReturnPath(to.query.redirect)
+    /*
+     * BOUNDED. On normal client-side navigation this runs before the route
+     * resolves, so anything it awaits is on the critical path to the next page.
+     * On the initial SSR hydration the block below defers this whole function to
+     * app:mounted instead: restoring localStorage-backed identity before Vue has
+     * reconciled the server's guest markup changes header v-if branches and
+     * produces a real hydration mismatch.
+     *
+     * Timing out is SAFE, and deliberately so: the access check below opens
+     * with `if (!access.matched || access.allowed) return`, and an unpopulated
+     * channel list matches nothing. So the degraded outcome is "this middleware
+     * declines to gate", never "this middleware locks someone out" or, worse,
+     * bounces them to /login while the page underneath is still suspended.
+     * Whatever did resolve is kept -- the stores hold their own state, and the
+     * losing promise still settles into them for the next navigation.
+     */
+    await Promise.race([
+      Promise.all([userStore.initialize(), channelContentStore.initialize()]),
+      new Promise((resolve) => setTimeout(resolve, INITIALIZE_TIMEOUT_MS)),
+    ])
 
-  if (userStore.isLoggedIn && to.path === '/login' && requestedLoginReturn) {
-    return navigateTo(requestedLoginReturn, { replace: true })
-  }
+    const requestedLoginReturn = safeReturnPath(to.query.redirect)
 
-  // The existing login page sends successful sessions to /dashboard. Resume a
-  // previously denied channel destination from there without coupling the login
-  // component to the navigation system.
-  if (userStore.isLoggedIn && to.path === '/dashboard') {
-    const returnPath = consumeReturnPath()
-
-    if (returnPath && returnPath !== to.fullPath) {
-      return navigateTo(returnPath, { replace: true })
+    if (userStore.isLoggedIn && to.path === '/login' && requestedLoginReturn) {
+      return navigateTo(requestedLoginReturn, { replace: true })
     }
-  }
 
-  const requestedTab =
-    typeof to.query.tab === 'string' ? to.query.tab.trim() : ''
-  const access = evaluateNavigationRouteAccess(
-    channelContentStore.channels,
-    channelContentStore.visibleChannels,
-    {
-      path: to.path,
-      tabKey: requestedTab,
-    },
-  )
+    // The existing login page sends successful sessions to /dashboard. Resume a
+    // previously denied channel destination from there without coupling the login
+    // component to the navigation system.
+    if (userStore.isLoggedIn && to.path === '/dashboard') {
+      const returnPath = consumeReturnPath()
 
-  // Routes outside the content navigation graph are not this middleware's job.
-  if (!access.matched || access.allowed) return
+      if (returnPath && returnPath !== to.fullPath) {
+        return navigateTo(returnPath, { replace: true })
+      }
+    }
 
-  const requiresAccount =
-    Boolean(access.requiredRole && access.requiredRole !== 'GUEST') ||
-    accountPermissions.has(access.requiredPermission.toLowerCase())
+    const requestedTab =
+      typeof to.query.tab === 'string' ? to.query.tab.trim() : ''
+    const access = evaluateNavigationRouteAccess(
+      channelContentStore.channels,
+      channelContentStore.visibleChannels,
+      {
+        path: to.path,
+        tabKey: requestedTab,
+      },
+    )
 
-  if (!userStore.isLoggedIn && requiresAccount && to.path !== '/login') {
-    rememberReturnPath(to.fullPath)
+    // Routes outside the content navigation graph are not this middleware's job.
+    if (!access.matched || access.allowed) return
+
+    const requiresAccount =
+      Boolean(access.requiredRole && access.requiredRole !== 'GUEST') ||
+      accountPermissions.has(access.requiredPermission.toLowerCase())
+
+    if (!userStore.isLoggedIn && requiresAccount && to.path !== '/login') {
+      rememberReturnPath(to.fullPath)
+
+      return navigateTo({
+        path: '/login',
+        query: {
+          redirect: to.fullPath,
+        },
+        replace: true,
+      })
+    }
+
+    // Avoid an impossible redirect loop if Home is ever accidentally gated.
+    if (to.path === '/') return
 
     return navigateTo({
-      path: '/login',
+      path: '/',
       query: {
-        redirect: to.fullPath,
+        access: 'denied',
       },
       replace: true,
     })
   }
 
-  // Avoid an impossible redirect loop if Home is ever accidentally gated.
-  if (to.path === '/') return
+  /*
+   * Nuxt executes global route middleware twice for an SSR first load: once on
+   * the server, then again in the browser before hydration. This middleware is
+   * intentionally client-only because the session token lives in localStorage,
+   * but that means the browser pass must NOT restore user state until the server
+   * DOM has been hydrated. Nuxt documents this exact isHydrating/serverRendered
+   * guard for initial client middleware.
+   *
+   * We still run the access check immediately after app:mounted so direct loads
+   * of protected routes keep the same redirect behavior; only the timing moves.
+   */
+  if (nuxtApp.isHydrating && nuxtApp.payload.serverRendered) {
+    nuxtApp.hook('app:mounted', () => {
+      void nuxtApp.runWithContext(enforceNavigationAccess)
+    })
+    return
+  }
 
-  return navigateTo({
-    path: '/',
-    query: {
-      access: 'denied',
-    },
-    replace: true,
-  })
+  return enforceNavigationAccess()
 })

--- a/middleware/navigation-access.global.ts
+++ b/middleware/navigation-access.global.ts
@@ -3,12 +3,6 @@ import { evaluateNavigationRouteAccess } from '@/stores/helpers/navigationRouteA
 import { useChannelContentStore } from '@/stores/channelContentStore'
 import { useUserStore } from '@/stores/userStore'
 
-/*
- * How long the first navigation will wait on the user and channel stores before
- * proceeding ungated. Comfortably above a healthy round trip and comfortably
- * below app.vue's 9s loader failsafe, so a degraded backend produces a usable
- * page rather than a race between two deadlines.
- */
 const INITIALIZE_TIMEOUT_MS = 4000
 
 const navigationReturnStorageKey = 'kindrobots:navigation-return-to'
@@ -60,23 +54,6 @@ export default defineNuxtRouteMiddleware(async (to) => {
     const userStore = useUserStore()
     const channelContentStore = useChannelContentStore()
 
-    /*
-     * BOUNDED. This runs before the first route resolves, so anything it awaits
-     * is on the critical path to the app being visible at all -- and
-     * `channelContentStore.initialize()` ends in `queryCollection('channels')`,
-     * while `userStore.initialize()` reaches the API. Neither carried a deadline,
-     * so a slow or failing backend held the initial navigation open indefinitely.
-     * Production has been logging both since 2026-08-06: AbortErrors on
-     * `/[...slug]` and 40s function timeouts.
-     *
-     * Timing out here is SAFE, and deliberately so: the access check below opens
-     * with `if (!access.matched || access.allowed) return`, and an unpopulated
-     * channel list matches nothing. So the degraded outcome is "this middleware
-     * declines to gate", never "this middleware locks someone out" or, worse,
-     * bounces them to /login and back while the page underneath is still
-     * suspended. Whatever did resolve is kept -- the stores hold their own state,
-     * and the losing promise still settles into them for the next navigation.
-     */
     await Promise.race([
       Promise.all([userStore.initialize(), channelContentStore.initialize()]),
       new Promise((resolve) => setTimeout(resolve, INITIALIZE_TIMEOUT_MS)),

--- a/plugins/legacy-guest-session.client.ts
+++ b/plugins/legacy-guest-session.client.ts
@@ -1,16 +1,5 @@
 import { useUserStore } from '@/stores/userStore'
 
-/*
- * Session restoration is deliberately post-hydration. The server cannot read
- * the localStorage token, so it renders guest-facing markup. Restoring a saved
- * user before Vue has hydrated that markup changes auth-dependent header
- * branches underneath the hydration walker.
- *
- * This plugin used to start initialize() immediately (without awaiting it) to
- * avoid blocking app mount. That removed the startup stall, but left a race: a
- * fast auth response could still land before mount. app:mounted keeps the work
- * non-blocking while making the SSR/client boundary deterministic.
- */
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.hook('app:mounted', () => {
     const userStore = useUserStore()

--- a/plugins/legacy-guest-session.client.ts
+++ b/plugins/legacy-guest-session.client.ts
@@ -1,19 +1,26 @@
 import { useUserStore } from '@/stores/userStore'
 
 /*
- * Not async: a plugin's returned promise is awaited before the Vue app mounts,
- * so awaiting userStore.initialize() here blocked first paint of the entire
- * app on a network call. Retiring the legacy guest session is not urgent
- * enough to hold the app hostage.
+ * Session restoration is deliberately post-hydration. The server cannot read
+ * the localStorage token, so it renders guest-facing markup. Restoring a saved
+ * user before Vue has hydrated that markup changes auth-dependent header
+ * branches underneath the hydration walker.
+ *
+ * This plugin used to start initialize() immediately (without awaiting it) to
+ * avoid blocking app mount. That removed the startup stall, but left a race: a
+ * fast auth response could still land before mount. app:mounted keeps the work
+ * non-blocking while making the SSR/client boundary deterministic.
  */
-export default defineNuxtPlugin(() => {
-  const userStore = useUserStore()
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.hook('app:mounted', () => {
+    const userStore = useUserStore()
 
-  void (async () => {
-    await userStore.initialize()
+    void (async () => {
+      await userStore.initialize()
 
-    if (userStore.user?.id === 10) {
-      userStore.logout()
-    }
-  })()
+      if (userStore.user?.id === 10) {
+        userStore.logout()
+      }
+    })()
+  })
 })

--- a/utils/scripts/verifyNavigationRouteAccess.ts
+++ b/utils/scripts/verifyNavigationRouteAccess.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import {
   filterChannelsByRole,
   resolveChannels,
@@ -197,6 +198,41 @@ const adminAdmin = evaluateNavigationRouteAccess(channels, adminChannels, {
 })
 assert.equal(adminAdmin.allowed, true)
 
+const middlewareSource = readFileSync(
+  'middleware/navigation-access.global.ts',
+  'utf8',
+)
+assert.match(
+  middlewareSource,
+  /if \(nuxtApp\.isHydrating && nuxtApp\.payload\.serverRendered\) \{[\s\S]*?nuxtApp\.hook\('app:mounted',[\s\S]*?enforceNavigationAccess/,
+  'Initial SSR client navigation must defer localStorage-backed access enforcement until app:mounted.',
+)
+
+const legacySessionSource = readFileSync(
+  'plugins/legacy-guest-session.client.ts',
+  'utf8',
+)
+const sessionMountedIndex = legacySessionSource.indexOf("hook('app:mounted'")
+const sessionInitializeIndex = legacySessionSource.indexOf('userStore.initialize()')
+assert.ok(
+  sessionMountedIndex >= 0 &&
+    sessionInitializeIndex >= 0 &&
+    sessionMountedIndex < sessionInitializeIndex,
+  'Saved-session restoration must not initialize the user store before app:mounted.',
+)
+
+const loaderSource = readFileSync('components/admin/kind-loader.vue', 'utf8')
+assert.equal(
+  loaderSource.includes('onBeforeMount('),
+  false,
+  'The startup loader must not mutate app/store state from onBeforeMount during hydration.',
+)
+assert.match(
+  loaderSource,
+  /onMounted\(\(\) => \{\s+void ensureStoresInitialized\(\)[\s\S]*?if \(startupMode\.value !== 'none'\) return[\s\S]*?emitReadyOnce\(\)/,
+  'Store initialization and the reload-mode pageReady handoff must begin from onMounted.',
+)
+
 console.log(
-  'Navigation route access contract passed: unrelated, public, authenticated, member, shared-route, and admin destinations verified.',
+  'Navigation route access contract passed: unrelated, public, authenticated, member, shared-route, admin, and hydration-safe startup behavior verified.',
 )


### PR DESCRIPTION
## Root cause

The server cannot read the localStorage-backed session token, so SSR emits guest-facing markup. On the initial client navigation, the global navigation middleware restored the authenticated user before Vue finished hydrating that guest DOM. Auth-dependent header branches could therefore differ between the server HTML and the client's first render, producing `Hydration completed but contains mismatches`.

Two other startup paths had the same race shape: the legacy guest-session plugin could complete user initialization before mount, and reload-mode `kind-loader` started store initialization from `onBeforeMount`.

## Fix

- Defer initial client navigation access enforcement until `app:mounted` when hydrating an SSR payload, while preserving the same protected-route redirect immediately after mount.
- Restore saved sessions from the legacy client plugin only after `app:mounted`.
- Start `kind-loader` store initialization only from `onMounted`; reload-mode `pageReady` handoff moves there too.
- Extend the existing navigation-route-access contract to guard these hydration-safe startup boundaries.

The PWA `beforeinstallprompt.preventDefault()` console message is separate: the app enables @vite-pwa/nuxt's install-prompt interception but does not currently surface its custom install action. This PR does not change install behavior.

## Scope

Four files only. No schema, migration, API, production-data, art queue, or visual-layout changes.