### PR TITLE
interface-vision/t-104 slice 31: adopt kr-container on 4 more root elements

### DIFF
--- a/components/giftshop/mana-wallet.vue
+++ b/components/giftshop/mana-wallet.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full max-w-3xl mx-auto p-6 space-y-8">
+  <div class="kr-container max-w-3xl p-6 space-y-8">
     <div class="text-center space-y-2">
       <h1 class="text-3xl font-extrabold text-primary">
         ⚡ {{ userStore.username }}'s Mana Wallet

--- a/components/giftshop/subscription-manager.vue
+++ b/components/giftshop/subscription-manager.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full max-w-5xl mx-auto space-y-10">
+  <div class="kr-container max-w-5xl space-y-10">
     <div class="text-center space-y-2">
       <h2 class="text-3xl font-extrabold text-primary-content">
         🧠 Choose Your Destiny Plan

--- a/components/user/forum-thread.vue
+++ b/components/user/forum-thread.vue
@@ -1,6 +1,6 @@
 <!-- /components/content/forum/forum-thread.vue -->
 <template>
-  <div class="space-y-6 w-full max-w-4xl mx-auto px-4 py-8">
+  <div class="kr-container max-w-4xl space-y-6 px-4 py-8">
     <div class="flex flex-wrap justify-center gap-2 mb-6">
       <button
         v-for="channel in allChannels"

--- a/components/user/login-persister.vue
+++ b/components/user/login-persister.vue
@@ -1,6 +1,6 @@
 <!-- /components/content/user/login-persister.vue -->
 <template>
-  <div class="w-full max-w-sm mx-auto space-y-2">
+  <div class="kr-container max-w-sm space-y-2">
     <div class="flex items-center space-x-2">
       <input
         id="stayLoggedIn"


### PR DESCRIPTION
## Why
Conductor `interface-vision/t-104` (recurring consistency-sweep umbrella) grepped the repo for root elements still using the hand-rolled `mx-auto` + `w-full` + `max-w-*` pattern instead of the shared `kr-container` primitive (`mx-auto w-full max-w-6xl`, overridable per-file with an explicit `max-w-*` utility — utilities beat components-layer classes regardless of source order, the same mechanism prior slices used).

## Change
Four root elements, no geometry or behavior change:
- `components/user/login-persister.vue` — `w-full max-w-sm mx-auto space-y-2` → `kr-container max-w-sm space-y-2`
- `components/user/forum-thread.vue` — `space-y-6 w-full max-w-4xl mx-auto px-4 py-8` → `kr-container max-w-4xl space-y-6 px-4 py-8`
- `components/giftshop/mana-wallet.vue` — `w-full max-w-3xl mx-auto p-6 space-y-8` → `kr-container max-w-3xl p-6 space-y-8`
- `components/giftshop/subscription-manager.vue` — `w-full max-w-5xl mx-auto space-y-10` → `kr-container max-w-5xl space-y-10`

Each is reachable: `login-persister.vue` via `<LoginPersister />` in `login-page.vue`; `forum-thread.vue` via `content/forum.md`; `mana-wallet.vue` and `subscription-manager.vue` via `giftshop-manager.vue` (`wallet-page.vue` / `giving-page.vue`).

Other candidates found by the same sweep were skipped as out of scope for a clean root-only exact-match slice: `messenger.vue` (root mixes `kr-panes`, a grid layout primitive, with arbitrary `h-[70vh]` — not a clean container substitution), `project-front-page.vue` and `achievement-art.vue` (the matching class is on a nested element, not the component root), `achievement-popup.vue` (nested modal-content div mixing border/bg/shadow classes with the geometry utilities), and `components/abandonware/wonderlab/lab-gallery.vue` (previously confirmed unreferenced anywhere, per an earlier slice's note).

## Verification
- `eslint` on changed files — clean except two pre-existing issues confirmed via `git stash` diff against baseline `main`: `subscription-manager.vue`'s two `no-explicit-any` errors and `forum-thread.vue`/`login-persister.vue`'s `vue/attributes-order` warnings, all present before this change.
- `vue-tsc --noEmit` — clean.
- `npm run test:layout-contract` — holds, 0 new violations.
- `npx prettier --check` on changed files — clean.

Not verified in a browser — no egress here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XkqQdiPikY6NBRKuBummG

---
_Generated by [Claude Code](https://claude.ai/code/session_014XkqQdiPikY6NBRKuBummG)_