### PR TITLE
Put the review section on the card back, where it was always slotted for

### DIFF
--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -171,6 +171,30 @@
             </button>
           </template>
 
+          <!--
+            REVIEWS LIVE ON THE BACK. Silas, 2026-08-10: "back: the rest of the
+            info, image, those buttons, and the review section."
+
+            They were not deleted, they were stranded -- reactable-card gates
+            its reaction button on `props.selected`, and since the card back
+            landed, clicking a tile sets the info id rather than the store's
+            current record, so nothing in a grid is ever "selected". Exactly
+            the same gate that hid edit/clone/delete.
+
+            allowReviews is still honoured here: a record that opted out of
+            reviews on the tile must not get them back on the back.
+          -->
+          <template #reviews>
+            <reaction-card
+              v-if="infoBot.allowReviews !== false"
+              :target-id="infoBot.id"
+              target-type="bot"
+              reaction-category="BOT"
+              :target-title="infoBot.name || 'Unnamed Bot'"
+              compact
+            />
+          </template>
+
           <template #edit="{ done }">
             <add-bot mode="edit" @saved="done" @cancel="done" />
           </template>

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -74,6 +74,30 @@
               </div>
             </dl>
           </template>
+
+          <!--
+            REVIEWS LIVE ON THE BACK. Silas, 2026-08-10: "back: the rest of the
+            info, image, those buttons, and the review section."
+
+            They were not deleted, they were stranded -- reactable-card gates
+            its reaction button on `props.selected`, and since the card back
+            landed, clicking a tile sets the info id rather than the store's
+            current record, so nothing in a grid is ever "selected". Exactly
+            the same gate that hid edit/clone/delete.
+
+            allowReviews is still honoured here: a record that opted out of
+            reviews on the tile must not get them back on the back.
+          -->
+          <template #reviews>
+            <reaction-card
+              v-if="infoCharacter.allowReviews !== false"
+              :target-id="infoCharacter.id"
+              target-type="character"
+              reaction-category="CHARACTER"
+              :target-title="infoCharacter.name || 'Unnamed Character'"
+              compact
+            />
+          </template>
         </kr-card-back>
 
         <div v-else class="p-6 text-center text-sm opacity-60">

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -246,6 +246,30 @@
 
           <!-- The same dream-maker the dreammaker TAB used to render. It edits
                whatever dreamStore holds, which the watch above loads first. -->
+          <!--
+            REVIEWS LIVE ON THE BACK. Silas, 2026-08-10: "back: the rest of the
+            info, image, those buttons, and the review section."
+
+            They were not deleted, they were stranded -- reactable-card gates
+            its reaction button on `props.selected`, and since the card back
+            landed, clicking a tile sets the info id rather than the store's
+            current record, so nothing in a grid is ever "selected". Exactly
+            the same gate that hid edit/clone/delete.
+
+            allowReviews is still honoured here: a record that opted out of
+            reviews on the tile must not get them back on the back.
+          -->
+          <template #reviews>
+            <reaction-card
+              v-if="infoDream.allowReviews !== false"
+              :target-id="infoDream.id"
+              target-type="dream"
+              reaction-category="DREAM"
+              :target-title="infoDream.title || 'Untitled Dream'"
+              compact
+            />
+          </template>
+
           <template #edit="{ done }">
             <dream-maker @saved="done" @created="done" />
           </template>

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -135,6 +135,30 @@
               </div>
             </dl>
           </template>
+
+          <!--
+            REVIEWS LIVE ON THE BACK. Silas, 2026-08-10: "back: the rest of the
+            info, image, those buttons, and the review section."
+
+            They were not deleted, they were stranded -- reactable-card gates
+            its reaction button on `props.selected`, and since the card back
+            landed, clicking a tile sets the info id rather than the store's
+            current record, so nothing in a grid is ever "selected". Exactly
+            the same gate that hid edit/clone/delete.
+
+            allowReviews is still honoured here: a record that opted out of
+            reviews on the tile must not get them back on the back.
+          -->
+          <template #reviews>
+            <reaction-card
+              v-if="infoReward.allowReviews !== false"
+              :target-id="infoReward.id"
+              target-type="reward"
+              reaction-category="REWARD"
+              :target-title="infoReward.name || 'Unnamed Reward'"
+              compact
+            />
+          </template>
         </kr-card-back>
 
         <div v-else class="p-6 text-center text-sm opacity-60">

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -104,6 +104,30 @@
               </div>
             </dl>
           </template>
+
+          <!--
+            REVIEWS LIVE ON THE BACK. Silas, 2026-08-10: "back: the rest of the
+            info, image, those buttons, and the review section."
+
+            They were not deleted, they were stranded -- reactable-card gates
+            its reaction button on `props.selected`, and since the card back
+            landed, clicking a tile sets the info id rather than the store's
+            current record, so nothing in a grid is ever "selected". Exactly
+            the same gate that hid edit/clone/delete.
+
+            allowReviews is still honoured here: a record that opted out of
+            reviews on the tile must not get them back on the back.
+          -->
+          <template #reviews>
+            <reaction-card
+              v-if="infoScenario.allowReviews !== false"
+              :target-id="infoScenario.id"
+              target-type="scenario"
+              reaction-category="SCENARIO"
+              :target-title="infoScenario.title || 'Untitled Scenario'"
+              compact
+            />
+          </template>
         </kr-card-back>
 
         <div v-else class="p-6 text-center text-sm opacity-60">


### PR DESCRIPTION
Silas, 2026-08-10: *"back: the rest of the info, image, those buttons, and the review section."*

`kr-card-back` has carried an **empty `#reviews` slot since it was built**, with a note saying reviews belong "at the end of the reading rather than in the row of things you can go and do". Nothing ever filled it. Five galleries now do — Bots, Characters, Dreams, Rewards, Scenarios.

## This is the same fault as the missing buttons

`reactable-card` gates its reaction button on `props.selected`. Since the card back landed, clicking a tile sets the gallery's *info id* rather than the store's current record — so nothing in a grid is ever "selected". **Edit, clone, delete and reviews all stopped rendering at once**, from one changed meaning of a single word, with no error anywhere to point at it. This is the last of the four.

`allowReviews` is still honoured: a record that opted out of reviews on the tile doesn't get them back on the back.

Resources are absent on purpose — `resource-card` has no reaction wiring at all, so Resources have never had reviews to relocate.

## Verification

- `npm run test` (vue-tsc) — clean
- `test:layout-contract`, `test:gallery-consistency`, `test:component-reachability`, `test:lint-ratchet` — pass
- `eslint` — the 4 reported errors in `character-gallery`/`dream-gallery` are pre-existing and baselined (the ratchet confirms it); they're in lines this PR doesn't touch

Not verified in a browser — no egress here.

## Still on the front

The **karma badge** renders on tiles regardless of `selected`, so it survived. It isn't in the "images, themed border, title, type icon" list, but it's a single small chip and removing it means unpicking the `earnedKarma` plumbing through six galleries — say the word and it goes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_