### PR TITLE
Stop swallowing the native PWA install prompt

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -247,9 +247,6 @@ export default defineNuxtConfig({
       globPatterns: ['**/*.{js,css,ico,png,svg,webp,woff2}'],
       navigateFallback: null,
     },
-    client: {
-      installPrompt: true,
-    },
   },
 
   components: [


### PR DESCRIPTION
## Root cause

`pwa.client.installPrompt: true` tells `@vite-pwa/nuxt` to intercept `beforeinstallprompt`, call `preventDefault()`, and hold the event for custom `$pwa.install()` UI. Kind Robots does not implement that custom install UI, so Chromium logs that the banner was suppressed and never prompted.

## Fix

Remove the unused `client.installPrompt` interception. The manifest and service worker remain unchanged, and installable Chromium browsers can use their native install affordance again.

## Scope

One config file, three deleted lines. No visual, schema, API, or production-data changes.