### PR TITLE
interface-vision t-104 slice 33: shopping-cart.vue root onto kr-container

### DIFF
--- a/components/giftshop/shopping-cart.vue
+++ b/components/giftshop/shopping-cart.vue
@@ -1,6 +1,6 @@
 <!-- /components/content/shop/shopping-cart.vue -->
 <template>
-  <section class="mx-auto max-w-5xl space-y-6 p-4 sm:p-6">
+  <section class="kr-container max-w-5xl space-y-6 p-4 sm:p-6">
     <div class="flex flex-wrap items-center justify-between gap-3">
       <div>
         <h1 class="flex items-center gap-2 text-2xl font-black text-primary">


### PR DESCRIPTION
Part of the interface-vision/t-104 layout-consistency umbrella (conductor).

`components/giftshop/shopping-cart.vue` root `<section>` now uses `kr-container max-w-5xl` instead of hand-rolled `mx-auto max-w-5xl`.

## New substitution shape

All 32 prior slices matched `mx-auto w-full max-w-*` byte-for-byte. This is the first slice to substitute `mx-auto max-w-*` **without** an explicit `w-full` — `kr-container` bakes `w-full` in, so this adds it. That's a no-op here: the root is a block-level `<section>` mounted in normal document flow (via `content/cart.md`'s MDC route, rendered through `:shopping-cart`), and a block element already fills its containing block's width by default. Adding an explicit `w-full` changes nothing about the rendered geometry.

Grepped the rest of the codebase for the same shape (`mx-auto max-w-*` root, no `w-full`) before scoping this to a single file — every other match either mixes in a competing layout primitive (`kr-surface`/`kr-unbound`/`kr-scroll` on the `wonderlab-review-*.vue` group and `giving-page.vue`/`pages/users/[id].vue`/etc., already correctly excluded by earlier slices for the same reason) or isn't a root element (`email-confirmation.vue`'s nested `<p>`), or mixes extra visual classes (`animation-tester.vue`, excluded in slice 31). `shopping-cart.vue` was the one clean candidate.

## Verification
- `eslint` on the changed file: 1 pre-existing `no-dynamic-delete` error, confirmed present on baseline `main` via `git stash` diff (unrelated to this line)
- `prettier --check`: pre-existing warning, same baseline confirmation
- `vue-tsc --noEmit`: clean
- `test:layout-contract`: holds, 0 new violations

No geometry or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E42WDYpqiCeiMmEzTDH242)_