### PR TITLE
refactor: kr-manager panel shell + challenge collapse roots onto kr-panel-flat (interface-vision t-104 slice 34)

### DIFF
--- a/components/manager/kr-manager.vue
+++ b/components/manager/kr-manager.vue
@@ -123,7 +123,7 @@
       :key="renderedTab"
       :class="
         isPanelTab(renderedTab)
-          ? 'min-h-0 flex-1 overflow-y-auto overscroll-contain rounded-2xl border border-base-300 bg-base-100 p-4'
+          ? 'kr-panel-flat min-h-0 flex-1 overflow-y-auto overscroll-contain p-4'
           : 'flex h-full min-h-0 flex-1 flex-col overflow-hidden'
       "
     >

--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -315,7 +315,7 @@
 
                 <details
                   v-if="submission.promptUsed"
-                  class="collapse collapse-arrow mt-4 rounded-2xl border border-base-300 bg-base-100"
+                  class="collapse collapse-arrow kr-panel-flat mt-4"
                 >
                   <summary
                     class="collapse-title min-h-0 py-3 text-xs font-black uppercase tracking-wider"
@@ -331,7 +331,7 @@
 
                 <details
                   v-if="randomSelectionsList(submission).length"
-                  class="collapse collapse-arrow mt-3 rounded-2xl border border-base-300 bg-base-100"
+                  class="collapse collapse-arrow kr-panel-flat mt-3"
                 >
                   <summary
                     class="collapse-title min-h-0 py-3 text-xs font-black uppercase tracking-wider"


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 34: Drive live front-end consistency onto shared kr-* components and composition rules  (kind: software)

### What changed / what I produced
- `components/manager/kr-manager.vue`'s `isPanelTab` ternary: the hand-rolled `rounded-2xl border border-base-300 bg-base-100` root class → `kr-panel-flat`. This is the shared manager shell mounted by 10+ managers/galleries/interacts (bot, character, dream, reward, theme, facet, scenario, ...), so it's a high-leverage single substitution.
- `pages/play/challenges/[slug].vue`'s two `<details class="collapse collapse-arrow ...">` disclosure roots (prompt-used / random-rolls): same hand-rolled trio alongside DaisyUI's `collapse`/`collapse-arrow` and an `mt-3`/`mt-4` spacing utility (neither conflicts with the panel geometry) → `kr-panel-flat`.

No geometry or behavior change: `kr-panel-flat` is exactly `rounded-2xl border border-base-300 bg-base-100` (`assets/css/tailwind.css:537`), byte-identical to what was hand-written in both spots.

### How I verified
- `npx eslint` on both changed files: clean, no findings.
- `npx vue-tsc --noEmit`: clean (exit 0), no errors.
- `npm run test:layout-contract`: holds, 0 new violations.
- `npx prettier --check` on both files: passes.
- Reachability: `kr-manager.vue` confirmed mounted by `bot-interact.vue`, `bot-manager.vue`, `bot-gallery.vue`, `character-manager.vue`, `dream-manager.vue`, `reward-interact.vue`, `reward-manager.vue`, `theme-gallery.vue`, `facet-manager.vue`, `scenario-interact.vue`. `pages/play/challenges/[slug].vue` is a live dynamic route.
- Searched the full repo (token-set match against all three `kr-panel`/`kr-panel-muted`/`kr-panel-flat` variants) for any other exact, unmigrated matches; the rest found either mix `border-dashed` (a real visual difference — empty-state pattern, out of scope) or mix DaisyUI component classes with ambiguous conflict potential (`modal-box`, `.stat` — `kr-stat-tile.vue` was already hand-excluded by slice 12 for this reason).

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
The repo-wide `kr-panel`/`kr-panel-muted`/`kr-panel-flat` exact-token-set grep this slice used (Python: split each `class="..."` attribute into a token set, subset-match against each variant's defining classes, skip anything already carrying the variant class) surfaced the `border-dashed` empty-state family as a large (~15+ occurrence) pool that's visually adjacent but not byte-exact. Worth deciding once, explicitly, whether a fourth `kr-panel-flat-dashed`-style token (or a documented "dashed empty-state" utility) is worth introducing — recurring hand-written `rounded-2xl border border-dashed border-base-300 bg-base-100/200 p-N text-center` blocks across `model-builder-*`, `watchlist-browse.vue`, `dream-brainstorm.vue`, `newsfeed-feed.vue`, etc. suggest this specific empty-state shape is itself a real, un-deduped pattern — just a different one than kr-panel-flat's solid-border case.

### Notes for reviewer
Session: `20260810T002900Z-sched-conductor-t104-s34`. Companion conductor PR sets `interface-vision/t-104` back through `review`; merge order doesn't matter since neither PR references the other's files.


---
_Generated by [Claude Code](https://claude.ai/code/session_0137FUomKmZHhgNMsjZiD3z7)_