### PR TITLE
fix: make achievement records guest-safe

### DIFF
--- a/server/api/achievements/records.get.ts
+++ b/server/api/achievements/records.get.ts
@@ -2,11 +2,24 @@
 import { defineEventHandler } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
-import { requireApiUser } from '../../utils/authGuard'
+import { getOptionalApiUser } from '../../utils/authGuard'
 
 export default defineEventHandler(async (event) => {
   try {
-    const { user, isAdmin } = await requireApiUser(event)
+    const auth = await getOptionalApiUser(event)
+
+    if (!auth) {
+      event.node.res.statusCode = 200
+
+      return {
+        success: true,
+        message: 'No achievement records for guest sessions.',
+        data: [],
+        statusCode: 200,
+      }
+    }
+
+    const { user, isAdmin } = auth
 
     const data = await prisma.achievementRecord.findMany({
       where: isAdmin ? undefined : { userId: user.id },

--- a/utils/scripts/verifyAchievementStoreFetchSafety.ts
+++ b/utils/scripts/verifyAchievementStoreFetchSafety.ts
@@ -92,4 +92,22 @@ assert.ok(
   'Authenticated records must load before pending guest achievements migrate.',
 )
 
+const recordsRouteSource = readFileSync(
+  'server/api/achievements/records.get.ts',
+  'utf8',
+)
+assert.ok(
+  recordsRouteSource.includes('getOptionalApiUser(event)'),
+  'Achievement records GET must tolerate unauthenticated guest requests.',
+)
+assert.ok(
+  !recordsRouteSource.includes('requireApiUser(event)'),
+  'Achievement records GET must not turn guest reads into 401 responses.',
+)
+assert.match(
+  recordsRouteSource,
+  /if \(!auth\)[\s\S]*statusCode = 200[\s\S]*data: \[\][\s\S]*statusCode: 200/,
+  'Guest achievement record reads must return a successful empty list.',
+)
+
 console.log('Achievement store fetch safety contract passed.')


### PR DESCRIPTION
### What changed
- Rescued the unique work from stranded branch `worker/guest-achievement-records-safe-get` onto current `main`.
- `GET /api/achievements/records` now treats an unauthenticated guest as a valid empty scoped result instead of returning 401.
- Added the existing achievement fetch-safety contract assertions so the route cannot regress back to required auth.

### Why
Guest startup already avoids this authenticated fetch, but direct or stale clients can still hit the endpoint. A read-only records endpoint should degrade to an empty guest list rather than emit a noisy 401 when no user session exists.

### Scope
Exactly two files. No schema, migration, production-data mutation, publishing, billing, secrets, or account changes.

### Verification
CI must complete successfully on the exact PR head before merge.

### Branch-medic handoff
This PR supersedes `worker/guest-achievement-records-safe-get`, which was 2 commits ahead / 18 behind current main and had no PR.