### PR TITLE
kind-robots/t-057: add DB-free contract test for Project-create Todo parity

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -167,6 +167,9 @@ jobs:
       - name: Database pool defaults contract
         run: npm run test:database-pool-defaults
 
+      - name: Project scaffold Todo parity contract
+        run: npm run test:project-scaffold-todo-parity
+
       - name: Maturity and privacy generation contract
         run: npx tsx utils/scripts/verifyMaturityPrivacyContract.ts
 

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "test:animation-catalog": "tsx utils/scripts/verifyAnimationCatalog.ts",
     "test:animation-component-attempts": "tsx utils/scripts/verifyAnimationComponentAttempts.ts",
     "test:database-pool-defaults": "tsx utils/scripts/verifyDatabasePoolDefaults.ts",
+    "test:project-scaffold-todo-parity": "tsx utils/scripts/verifyProjectScaffoldTodoParity.ts",
     "test:academy-style-detail-callers": "tsx utils/scripts/verifyAcademyStyleDetailCallers.ts",
     "test:academy-starter-manifest": "tsx utils/scripts/verifyAcademyStarterManifest.ts",
     "test:academy-examples-manifest": "tsx utils/scripts/verifyAcademyExamplesManifest.ts",

--- a/utils/scripts/verifyProjectScaffoldTodoParity.ts
+++ b/utils/scripts/verifyProjectScaffoldTodoParity.ts
@@ -1,0 +1,140 @@
+// /utils/scripts/verifyProjectScaffoldTodoParity.ts
+//
+// Kaizen from interface-vision/kind-robots t-056 (kind_robots#1678, reviewed 2026-08-09):
+// the ordinary authenticated POST /api/projects path creates exactly one HIGH/AGENT
+// scaffold Todo per Project (via prisma $transaction, with an idempotent
+// direct-MariaDB-fallback equivalent when the pooled connection is stale), while
+// Conductor's separate /api/conductor/sync projection path reconciles Projects
+// through its own transaction and never queues one. That behavioral split had no
+// dedicated coverage -- verifyDatabasePoolDefaults.ts's assertions on this same
+// file only guard the fallback path's code *shape* (falls back to
+// upsertProjectDirect on a stale connection), not the Todo-creation behavior on
+// either path.
+//
+// No database is available to this DB-free contract suite (see
+// .github/workflows/contract-tests.yml's header), so this asserts the source-level
+// invariant instead of exercising a live request: every project-creation code path
+// that a real POST /api/projects call can take -- transaction success, and the
+// direct-MariaDB fallback taken on a stale pooled connection -- creates exactly one
+// OPEN/HIGH/AGENT Todo tied to the new project, and the Conductor sync projection
+// path creates none.
+
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+function countOccurrences(source: string, pattern: RegExp): number {
+  return source.match(pattern)?.length ?? 0
+}
+
+const projectCreateSource = readFileSync(
+  new URL('../../server/api/projects/index.post.ts', import.meta.url),
+  'utf8',
+)
+const directWriteSourceRaw = readFileSync(
+  new URL('../../server/utils/projectDirectWrite.ts', import.meta.url),
+  'utf8',
+)
+// The raw SQL identifiers in this file are backtick-quoted inline inside
+// template literals, so most (but not all -- one column list is a plain
+// single-quoted string) appear on disk as an escaped `\`` pair rather than a
+// bare backtick. Normalize both spellings to a bare backtick before matching
+// so these assertions don't depend on which quoting style a given line uses.
+const directWriteSource = directWriteSourceRaw.replaceAll('\\`', '`')
+const conductorSyncSource = readFileSync(
+  new URL('../../server/api/conductor/sync.post.ts', import.meta.url),
+  'utf8',
+)
+
+// --- Path 1: POST /api/projects, transaction path ---------------------------
+// Exactly one Todo is queued per Project create, inside the same transaction as
+// the Project row (so it can never observably exist without its Project, or vice
+// versa), tagged OPEN/HIGH/AGENT and linked via projectId.
+assert.equal(
+  countOccurrences(projectCreateSource, /tx\.todo\.create\(/g),
+  1,
+  'server/api/projects/index.post.ts must create exactly one Todo per Project, ' +
+    'not zero (silently dropped scaffold) and not more than one (duplicate Todo).',
+)
+assert.match(
+  projectCreateSource,
+  /const project = await tx\.project\.create\(\{[\s\S]*?\}\)[\s\S]*?await tx\.todo\.create\(\{/,
+  'The Todo must be created after the Project inside the same $transaction callback.',
+)
+assert.match(
+  projectCreateSource,
+  /status: 'OPEN',\s*\n\s*priority: 'HIGH',\s*\n\s*category: 'AGENT',/,
+)
+assert.match(projectCreateSource, /projectId: project\.id,/)
+
+// --- Path 2: POST /api/projects, direct-MariaDB fallback path ---------------
+// A stale pooled connection falls through to upsertProjectDirect, which must
+// carry the same one-Todo-per-Project guarantee via its own idempotent insert
+// (a plain second INSERT would duplicate the Todo on every retried fallback call
+// for the same Project, since the fallback path is not itself transactional).
+assert.match(
+  projectCreateSource,
+  /if \(!isStaleDatabaseConnectionError\(error\)\) throw error/,
+  'Only a stale-connection failure may fall through to the direct-MariaDB path.',
+)
+assert.match(
+  projectCreateSource,
+  /return upsertProjectDirect\(data, conductorSlug\)/,
+)
+assert.equal(
+  countOccurrences(directWriteSource, /INSERT INTO `Todo`/g),
+  1,
+  'server/utils/projectDirectWrite.ts must issue exactly one Todo insert per ' +
+    'upsertProjectDirect call.',
+)
+assert.match(
+  directWriteSource,
+  /SELECT \?, \?, 'OPEN', 'HIGH', 'AGENT', \?, \?/,
+  'The direct-write fallback must tag its Todo OPEN/HIGH/AGENT, matching the ' +
+    'transaction path exactly.',
+)
+assert.match(
+  directWriteSource,
+  /WHERE NOT EXISTS \(/,
+  'The direct-write fallback must guard its Todo insert with an idempotency ' +
+    'check, since upsertProjectDirect is not wrapped in a transaction and may be ' +
+    'retried for the same Project.',
+)
+assert.match(
+  directWriteSource,
+  /SELECT 1 FROM `Todo` WHERE `projectId` = \? AND `title` = \? AND `status` = 'OPEN'/,
+  'The idempotency guard must key on the same Project + title + OPEN status the ' +
+    'insert itself writes, or a retried fallback call could still duplicate the Todo.',
+)
+// The fallback's Todo insert must run after the Project row is written (and its
+// id read back), never before -- a Todo cannot reference a Project that does not
+// exist yet.
+const projectInsertIndex = directWriteSource.indexOf('INSERT INTO `Project`')
+const todoInsertIndex = directWriteSource.indexOf('INSERT INTO `Todo`')
+assert.ok(
+  projectInsertIndex >= 0 && todoInsertIndex > projectInsertIndex,
+  'The direct-write fallback must insert the Project before the Todo that references it.',
+)
+
+// --- Path 3: POST /api/conductor/sync (Conductor projection sync) -----------
+// The sync path creates/updates Project rows directly on its own prisma
+// transaction and must never queue a scaffold Todo -- these are pre-existing
+// Conductor-tracked projects being projected into kind_robots, not new user
+// submissions that need an agent to go scaffold a roadmap for them.
+assert.match(
+  conductorSyncSource,
+  /await tx\.project\.create\(\{/,
+  'Conductor sync must still create Project rows for new Conductor projects.',
+)
+assert.doesNotMatch(
+  conductorSyncSource,
+  /todo/i,
+  'server/api/conductor/sync.post.ts must never reference Todo in any form -- ' +
+    'the Conductor projection path must not queue a scaffold Todo the way ' +
+    'POST /api/projects does for a real user-submitted Project.',
+)
+
+console.log(
+  'Project scaffold Todo parity verified: POST /api/projects (transaction and ' +
+    'direct-fallback paths) each queue exactly one OPEN/HIGH/AGENT Todo per ' +
+    'Project; /api/conductor/sync queues none.',
+)


### PR DESCRIPTION
### Task
kind-robots/t-057: Add a contract test asserting Project-create queues exactly one AGENT scaffold Todo, Conductor sync does not (kind: software)

### What changed / what I produced
- New `utils/scripts/verifyProjectScaffoldTodoParity.ts`, a DB-free contract test (matching `contract-tests.yml`'s existing source-inspection `verify*.ts` convention — that workflow explicitly runs with no database) asserting:
  1. `POST /api/projects`' transaction path (`server/api/projects/index.post.ts`) creates exactly one Todo, after the Project, tagged `OPEN`/`HIGH`/`AGENT` and linked via `projectId`.
  2. Its direct-MariaDB fallback (`upsertProjectDirect` in `server/utils/projectDirectWrite.ts`, taken on a stale pooled connection) issues exactly one Todo insert, tagged the same way, guarded by the same idempotency check (`WHERE NOT EXISTS`), after the Project insert.
  3. `/api/conductor/sync`'s Project-create path (`server/api/conductor/sync.post.ts`) never references `Todo` in any form.
- Registered as `npm run test:project-scaffold-todo-parity` and wired into `contract-tests.yml`'s `Contract verifiers` job (a required status check on `main`).

### How I verified
- `npm run test:project-scaffold-todo-parity` passes locally.
- Manually verified the test actually catches a regression on each of the three invariants (removing the Todo creation → count assertion fails with `0 !== 1`; adding a Todo creation to the sync path → `doesNotMatch(/todo/i)` fails) and restores clean afterward, before wiring it into CI.
- `npx eslint` clean on the new file and the three files it reads.
- `vue-tsc --noEmit` clean.
- `npx prettier --check` clean.

### Stakes
reversible

### Flags for Reviewer
- This is a static source-inspection test, not a live-database integration test — deliberate, since `contract-tests.yml`'s own header says "No database or Nuxt build is needed, so these can gate every pull request." It asserts the source-level invariant (exactly one Todo insert, correctly tagged and ordered, on each of the two paths that can create one; zero references to Todo on the path that must not) rather than exercising a real request.
- The `directWriteSource` normalization (`.replaceAll('\\`', '\`')`) exists because `projectDirectWrite.ts`'s raw SQL identifiers are backtick-quoted inline inside template literals, so most (but not all — one column list is a plain single-quoted string) appear on disk as an escaped `` \` `` pair rather than a bare backtick. Worth a second look if that file's SQL string style ever changes.

### Kaizen suggestion
None new this task — this PR itself is a kaizen deliverable from t-056's review.

### Notes for reviewer
Claimed via `claim_task.py` (conductor `kind-robots/t-057`); companion conductor close-out PR to follow in the same session.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FJndDKPt57EF3LYef1gmU6)_