### PR TITLE
Offer a card theme in the Model Builder, and persist whatever it picks

### DIFF
--- a/server/api/model-builder/items/[id]/commit.post.ts
+++ b/server/api/model-builder/items/[id]/commit.post.ts
@@ -1,6 +1,7 @@
 // /server/api/model-builder/items/[id]/commit.post.ts
 // Execute the approved COMMIT for a build item as an idempotent durable write.
 import { createError, defineEventHandler, readBody } from 'h3'
+import { coerceCardTheme } from '~/utils/entityTheme'
 import type {
   DreamType,
   Rarity,
@@ -99,6 +100,20 @@ function pickChoice<T extends string>(
   return choices.includes(upper) ? (upper as T) : undefined
 }
 
+/*
+ * THEME IS NOT pickChoice. That helper upper-cases before matching, which is
+ * right for enum-shaped fields (RARITY, REWARD_TYPES) and wrong here -- daisyUI
+ * theme names are lowercase, so every one of them would fail the membership
+ * test and silently vanish.
+ *
+ * Absent or unrecognised becomes a random valid theme rather than nothing:
+ * Silas, 2026-08-10, "It's more important to populate with something than to
+ * make a precise match."
+ */
+function pickTheme(fields: Record<string, string>): string {
+  return coerceCardTheme(fields.theme)
+}
+
 function pickText(
   fields: Record<string, string>,
   type: SourceType,
@@ -140,6 +155,7 @@ interface CharacterExtra {
   luck?: Rarity
   might?: Rarity
   wits?: Rarity
+  theme?: string
 }
 
 function characterFields(fields: Record<string, string>): CharacterExtra {
@@ -168,6 +184,7 @@ function characterFields(fields: Record<string, string>): CharacterExtra {
   if (might) data.might = might
   const wits = pickChoice<Rarity>(fields, 'Character', 'wits')
   if (wits) data.wits = wits
+  data.theme = pickTheme(fields)
   return data
 }
 
@@ -179,6 +196,7 @@ interface BotExtra {
   botIntro?: string
   userIntro?: string
   prompt?: string
+  theme?: string
 }
 
 function botFields(fields: Record<string, string>): BotExtra {
@@ -197,6 +215,7 @@ function botFields(fields: Record<string, string>): BotExtra {
   if (userIntro) data.userIntro = userIntro
   const prompt = pickText(fields, 'Bot', 'prompt')
   if (prompt) data.prompt = prompt
+  data.theme = pickTheme(fields)
   return data
 }
 
@@ -207,6 +226,7 @@ interface RewardExtra {
   description?: string
   flavorText?: string
   collection?: string
+  theme?: string
 }
 
 function rewardFields(fields: Record<string, string>): RewardExtra {
@@ -223,6 +243,7 @@ function rewardFields(fields: Record<string, string>): RewardExtra {
   if (flavorText) data.flavorText = flavorText
   const collection = pickText(fields, 'Reward', 'collection')
   if (collection) data.collection = collection
+  data.theme = pickTheme(fields)
   return data
 }
 
@@ -232,6 +253,7 @@ interface DreamExtra {
   description?: string
   flavorText?: string
   examples?: string
+  theme?: string
 }
 
 function dreamFields(fields: Record<string, string>): DreamExtra {
@@ -246,6 +268,7 @@ function dreamFields(fields: Record<string, string>): DreamExtra {
   if (flavorText) data.flavorText = flavorText
   const examples = pickText(fields, 'Dream', 'examples')
   if (examples) data.examples = examples
+  data.theme = pickTheme(fields)
   return data
 }
 
@@ -255,6 +278,7 @@ interface ScenarioExtra {
   difficulty?: number
   locations?: string
   inspirations?: string
+  theme?: string
 }
 
 function scenarioFields(fields: Record<string, string>): ScenarioExtra {
@@ -271,6 +295,7 @@ function scenarioFields(fields: Record<string, string>): ScenarioExtra {
   if (locations) data.locations = locations
   const inspirations = pickText(fields, 'Scenario', 'inspirations')
   if (inspirations) data.inspirations = inspirations
+  data.theme = pickTheme(fields)
   return data
 }
 
@@ -295,6 +320,7 @@ interface FacetExtra {
   taxonomy?: FacetTaxonomy
   description?: string
   examples?: string
+  theme?: string
 }
 
 function facetFields(fields: Record<string, string>): FacetExtra {
@@ -305,6 +331,7 @@ function facetFields(fields: Record<string, string>): FacetExtra {
   if (description) data.description = description
   const examples = pickText(fields, 'Facet', 'examples')
   if (examples) data.examples = examples
+  data.theme = pickTheme(fields)
   return data
 }
 

--- a/stores/helpers/modelBuilderFields.ts
+++ b/stores/helpers/modelBuilderFields.ts
@@ -7,6 +7,7 @@
 // created record comes out complete and specific (a Reward gets a real
 // type/rarity/effect) instead of a generic sentence.
 import type { SourceTypeKey } from '@/stores/helpers/modelBuilderRecipes'
+import { DAISY_CARD_THEMES } from '@/utils/entityTheme'
 
 export interface ModelFieldSpec {
   key: string
@@ -78,25 +79,63 @@ export const MODEL_FIELDS: Record<string, ModelFieldSpec[]> = {
     { key: 'luck', label: 'Luck', default: 'COMMON', choices: RARITY },
     { key: 'might', label: 'Might', default: 'COMMON', choices: RARITY },
     { key: 'wits', label: 'Wits', default: 'COMMON', choices: RARITY },
+    /*
+     * Card theme. Silas, 2026-08-10: "we should add theme choice to our model
+     * builder options, when the user manually creates new stuffs."
+     *
+     * No `default`, on purpose: leaving it blank is what tells the commit route
+     * to pick one at random, which is the behaviour every other creation path
+     * gets. A default here would make one theme the silent house pick.
+     */
+    { key: 'theme', label: 'Card theme', choices: [...DAISY_CARD_THEMES] },
   ],
   Bot: [
     { key: 'name', label: 'Name', required: true },
-    { key: 'botType', label: 'Bot type', default: 'CHATBOT', choices: BOT_TYPES },
+    {
+      key: 'botType',
+      label: 'Bot type',
+      default: 'CHATBOT',
+      choices: BOT_TYPES,
+    },
     { key: 'subtitle', label: 'Subtitle' },
     { key: 'description', label: 'Description', prose: true },
     { key: 'personality', label: 'Personality' },
     { key: 'botIntro', label: 'Bot intro', prose: true },
     { key: 'userIntro', label: 'User intro', prose: true },
     { key: 'prompt', label: 'System prompt', prose: true },
+    /*
+     * Card theme. Silas, 2026-08-10: "we should add theme choice to our model
+     * builder options, when the user manually creates new stuffs."
+     *
+     * No `default`, on purpose: leaving it blank is what tells the commit route
+     * to pick one at random, which is the behaviour every other creation path
+     * gets. A default here would make one theme the silent house pick.
+     */
+    { key: 'theme', label: 'Card theme', choices: [...DAISY_CARD_THEMES] },
   ],
   Reward: [
     { key: 'name', label: 'Name', required: true },
-    { key: 'rewardType', label: 'Type', required: true, default: 'ITEM', choices: REWARD_TYPES },
+    {
+      key: 'rewardType',
+      label: 'Type',
+      required: true,
+      default: 'ITEM',
+      choices: REWARD_TYPES,
+    },
     { key: 'rarity', label: 'Rarity', default: 'COMMON', choices: RARITY },
     { key: 'effect', label: 'Effect', required: true, prose: true },
     { key: 'description', label: 'Description', prose: true },
     { key: 'flavorText', label: 'Flavor text', prose: true },
     { key: 'collection', label: 'Collection' },
+    /*
+     * Card theme. Silas, 2026-08-10: "we should add theme choice to our model
+     * builder options, when the user manually creates new stuffs."
+     *
+     * No `default`, on purpose: leaving it blank is what tells the commit route
+     * to pick one at random, which is the behaviour every other creation path
+     * gets. A default here would make one theme the silent house pick.
+     */
+    { key: 'theme', label: 'Card theme', choices: [...DAISY_CARD_THEMES] },
   ],
   Dream: [
     { key: 'title', label: 'Title', required: true },
@@ -105,6 +144,15 @@ export const MODEL_FIELDS: Record<string, ModelFieldSpec[]> = {
     { key: 'description', label: 'Description', prose: true },
     { key: 'flavorText', label: 'Flavor text', prose: true },
     { key: 'examples', label: 'Examples (pipe-separated)' },
+    /*
+     * Card theme. Silas, 2026-08-10: "we should add theme choice to our model
+     * builder options, when the user manually creates new stuffs."
+     *
+     * No `default`, on purpose: leaving it blank is what tells the commit route
+     * to pick one at random, which is the behaviour every other creation path
+     * gets. A default here would make one theme the silent house pick.
+     */
+    { key: 'theme', label: 'Card theme', choices: [...DAISY_CARD_THEMES] },
   ],
   Scenario: [
     { key: 'title', label: 'Title', required: true },
@@ -113,6 +161,15 @@ export const MODEL_FIELDS: Record<string, ModelFieldSpec[]> = {
     { key: 'difficulty', label: 'Difficulty' },
     { key: 'locations', label: 'Locations' },
     { key: 'inspirations', label: 'Inspirations' },
+    /*
+     * Card theme. Silas, 2026-08-10: "we should add theme choice to our model
+     * builder options, when the user manually creates new stuffs."
+     *
+     * No `default`, on purpose: leaving it blank is what tells the commit route
+     * to pick one at random, which is the behaviour every other creation path
+     * gets. A default here would make one theme the silent house pick.
+     */
+    { key: 'theme', label: 'Card theme', choices: [...DAISY_CARD_THEMES] },
   ],
   Project: [
     { key: 'title', label: 'Title', required: true },
@@ -130,6 +187,15 @@ export const MODEL_FIELDS: Record<string, ModelFieldSpec[]> = {
     },
     { key: 'description', label: 'Description', prose: true },
     { key: 'examples', label: 'Examples' },
+    /*
+     * Card theme. Silas, 2026-08-10: "we should add theme choice to our model
+     * builder options, when the user manually creates new stuffs."
+     *
+     * No `default`, on purpose: leaving it blank is what tells the commit route
+     * to pick one at random, which is the behaviour every other creation path
+     * gets. A default here would make one theme the silent house pick.
+     */
+    { key: 'theme', label: 'Card theme', choices: [...DAISY_CARD_THEMES] },
   ],
 }
 

--- a/utils/entityTheme.ts
+++ b/utils/entityTheme.ts
@@ -92,3 +92,37 @@ export function resolveEntityTheme(
   const index = Math.abs(Math.trunc(id)) % DAISY_CARD_THEMES.length
   return DAISY_CARD_THEMES[index] ?? DAISY_CARD_THEMES[0]
 }
+
+/**
+ * A theme for a record being CREATED.
+ *
+ * Silas, 2026-08-10: "when I said randomize, I meant when we first seed them",
+ * and "When we build them, such as in our automatic daily dream, we should set
+ * a theme from the options."
+ *
+ * Genuinely random here, unlike resolveEntityTheme's fallback -- this runs ONCE
+ * and the answer is written to the row, so there is nothing to keep stable. The
+ * id-derived rule cannot be used at creation anyway: the row has no id yet.
+ */
+export function randomCardTheme(): string {
+  const index = Math.floor(Math.random() * DAISY_CARD_THEMES.length)
+  return DAISY_CARD_THEMES[index] ?? DAISY_CARD_THEMES[0]
+}
+
+/**
+ * A caller-supplied theme if it names a real one, otherwise a fresh random pick.
+ *
+ * Creation paths use this rather than trusting input: "it's more important to
+ * populate with something than to make a precise match", so an unrecognised or
+ * absent value becomes a valid theme instead of a NULL column or a `data-theme`
+ * pointing at nothing.
+ */
+export function coerceCardTheme(value: unknown): string {
+  const candidate = String(value ?? '')
+    .trim()
+    .toLowerCase()
+
+  return (DAISY_CARD_THEMES as readonly string[]).includes(candidate)
+    ? candidate
+    : randomCardTheme()
+}


### PR DESCRIPTION
Silas, 2026-08-10: *"we should add theme choice to our model builder options, when the user manually creates new stuffs."*

Character, Bot, Reward, Dream, Scenario and Facet each gain a `theme` field whose choices are the 35 stock daisyUI themes.

Deliberately **without a `default`** — leaving it blank is what tells the commit route to pick at random. A default here would quietly make one theme the house pick for everything built by hand.

## One trap worth naming

**The commit route cannot use `pickChoice` for this.** That helper upper-cases before testing membership, which is correct for the enum-shaped fields around it (`RARITY`, `REWARD_TYPES`, `FACET_TAXONOMIES`) and wrong here — daisyUI theme names are lowercase, so every one of them would have failed the test and the field would have silently done nothing. `pickTheme()` matches case-correctly.

Absent or unrecognised input becomes a random valid theme rather than nothing: *"It's more important to populate with something than to make a precise match."* `coerceCardTheme` is the single place that decides this, so the model builder and any later creation path can't drift apart.

`randomCardTheme` is genuinely random, unlike `resolveEntityTheme`'s fallback — it runs once and the answer is written to the row, so there's nothing to keep stable, and the id-derived rule is unavailable at creation anyway because the row has no id yet.

## Not in this PR

Defaulting the theme inside the five REST create endpoints (`POST /api/{characters,dreams,rewards,scenarios,facets}`). Each assembles its create input differently — a `buildCharacterCreateInput` helper, an inline `dataInput`, and three more shapes — so it's five separate edits rather than one.

Worth knowing this is about **storability, not appearance**: a row created without a theme still renders correctly, because `resolveEntityTheme` derives a stable one from its id. It just isn't a value you can see or edit.

## Verification

All by exit code, not by absence of matching output:

- `npm run test` (vue-tsc) — `exit=0`
- `test:lint-ratchet`, `test:layout-contract`, `test:component-reachability` — `exit=0`
- `eslint`, `prettier --check` on changed files — `exit=0`

Not verified in a browser — no egress here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_