### PR TITLE
Store a card theme on every REST creation path

### DIFF
--- a/server/api/characters/mutation.ts
+++ b/server/api/characters/mutation.ts
@@ -1,4 +1,5 @@
 import { createError } from 'h3'
+import { coerceCardTheme } from '@/utils/entityTheme'
 import { Rarity, type Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '@/server/utils/prisma'
 
@@ -671,6 +672,9 @@ export async function buildCharacterCreateInput(options: {
   })
 
   return {
+    // Card theme, never NULL on creation -- see dreams/index.post.ts. This
+    // builder serves the batch route too, so both paths get one.
+    theme: coerceCardTheme((options.rawInput as { theme?: unknown })?.theme),
     User: { connect: { id: options.userId } },
     name: normalizeCharacterName(body.name),
     slug: options.slug,

--- a/server/api/dreams/index.post.ts
+++ b/server/api/dreams/index.post.ts
@@ -1,5 +1,6 @@
 // /server/api/dreams/index.post.ts
 import { createError, defineEventHandler, readBody } from 'h3'
+import { coerceCardTheme } from '@/utils/entityTheme'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
@@ -62,10 +63,7 @@ export default defineEventHandler(async (event) => {
       body.characterIds,
       'characterIds',
     )
-    const rewardIds = normalizeBoundedDreamIdArray(
-      body.rewardIds,
-      'rewardIds',
-    )
+    const rewardIds = normalizeBoundedDreamIdArray(body.rewardIds, 'rewardIds')
     const artImageIds = normalizeBoundedDreamIdArray(
       body.artImageIds,
       'artImageIds',
@@ -90,6 +88,11 @@ export default defineEventHandler(async (event) => {
       heroPath: normalizeOptionalText(body.heroPath) ?? null,
       highlightImage: normalizeOptionalText(body.highlightImage) ?? null,
       icon: normalizeOptionalText(body.icon) ?? 'kind-icon:dream',
+      // Card theme, never left NULL on creation. Silas, 2026-08-10: "When we
+      // build them, such as in our automatic daily dream, we should set a theme
+      // from the options." coerceCardTheme takes the caller's pick and
+      // substitutes a random valid one for anything absent or unrecognised.
+      theme: coerceCardTheme(body.theme),
       designer: normalizeOptionalText(body.designer) ?? sender,
       allowReviews: body.allowReviews ?? false,
       isPublic: body.isPublic ?? true,

--- a/server/api/facets/index.post.ts
+++ b/server/api/facets/index.post.ts
@@ -1,5 +1,6 @@
 // POST /api/facets
 import { createError, defineEventHandler, readBody } from 'h3'
+import { coerceCardTheme } from '@/utils/entityTheme'
 import type { CreationSource, Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
@@ -156,6 +157,8 @@ export default defineEventHandler(async (event) => {
         iconPath: optionalText(body.iconPath),
         icon: optionalText(body.icon),
         designer: optionalText(body.designer),
+        // Card theme, never NULL on creation -- see dreams/index.post.ts.
+        theme: coerceCardTheme((body as { theme?: unknown }).theme),
         creationSource,
         userId: auth.user.id,
         artImageId,

--- a/server/api/rewards/index.ts
+++ b/server/api/rewards/index.ts
@@ -1,5 +1,6 @@
 // /server/api/rewards/index.ts
 import { createError } from 'h3'
+import { coerceCardTheme } from '@/utils/entityTheme'
 import {
   Prisma,
   Rarity,
@@ -213,6 +214,9 @@ export function buildCreateData(
   const dreamIds = toPositiveIntArray(input.dreamIds)
 
   return {
+    // Card theme, never NULL on creation -- see dreams/index.post.ts. This
+    // builder serves createRewardsBatch too, so both paths get one.
+    theme: coerceCardTheme((input as { theme?: unknown }).theme),
     name,
     slug,
     description,

--- a/server/api/scenarios/create.ts
+++ b/server/api/scenarios/create.ts
@@ -1,7 +1,11 @@
 import prisma from '@/server/utils/prisma'
+import { coerceCardTheme } from '@/utils/entityTheme'
 import { errorHandler } from '@/server/utils/error'
 import { normalizeSlugInput } from '~/utils/slugify'
-import { ScenarioOutputType, type Prisma } from '~/prisma/generated/prisma/client'
+import {
+  ScenarioOutputType,
+  type Prisma,
+} from '~/prisma/generated/prisma/client'
 import {
   assertScenarioMutationInput,
   assertScenarioRelationsExist,
@@ -89,6 +93,9 @@ export async function buildScenarioCreateInput(
   return {
     User: { connect: { id: authenticatedUserId } },
     title,
+    // Card theme, never NULL on creation -- see the note in dreams/index.post.ts.
+    // This builder serves the batch route too, so both paths get one.
+    theme: coerceCardTheme(scenarioData.theme),
     slug: normalizeSlugInput(scenarioData.slug) ?? undefined,
     description: normalizeScenarioString(
       scenarioData.description,


### PR DESCRIPTION
Silas, 2026-08-10: *"any updates that we need, including rest endpoints, and then hopefully I can confirm we're all theme colored."*

The Model Builder already offered the choice (#1702); these are the other five doors into the same tables.

**The gap was storability, not appearance.** A record created through these landed with `theme = NULL`, which *looked* right — `resolveEntityTheme` derives a stable theme from the id — but stored nothing, so the value couldn't be seen or edited. Nothing was visibly broken, which is exactly why it was easy to miss.

Defaulted in the **shared builder** rather than the POST handler wherever one exists, so the batch routes get it too:

| Model | Insertion point | Covers |
|---|---|---|
| Dream | inline `dataInput` | `POST /api/dreams` |
| Scenario | `buildScenarioCreateInput` | single + batch |
| Character | `buildCharacterCreateInput` | single + batch |
| Reward | `buildCreateData` | `createReward` + `createRewardsBatch` |
| Facet | create literal | `POST /api/facets` |

Every one goes through `coerceCardTheme`, so an explicit pick wins and anything absent or unrecognised becomes a random valid theme — *"It's more important to populate with something than to make a precise match."* One decision point means the six creation paths can't drift apart.

**Facet and Reward take their theme through a cast.** Their request-body types are closed interfaces that don't list it, and widening those is a bigger change than this needs. The value is still validated by `coerceCardTheme`, so an unknown string can't reach the column.

## Verification

By exit code:

- `npm run test` (vue-tsc) — `exit=0`
- `test:lint-ratchet`, `test:layout-contract`, `test:component-reachability` — `exit=0`
- `eslint` reports one `consistent-type-imports` error in `rewards/index.ts` — **pre-existing**: the `Prisma` import block is untouched by this diff, and the ratchet confirms no rule got worse

Not verified against a live database — no DB access here.

## After this deploys

Everything should be theme-coloured, but the check that actually proves it is the migration, not this PR: `20260810000000_entity_card_themes` backfills existing rows and only runs on deploy. `SELECT COUNT(*) FROM Reward WHERE theme IS NULL` should be 0 afterwards, and stay 0 as new records arrive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZfmj6qJV5tZsG2N8AyDt)_