### PR TITLE
kind-robots/t-060: editable slug field + slug-specific 409 UX on New Project form

### DIFF
--- a/components/pages/conductor-project-gallery-page.vue
+++ b/components/pages/conductor-project-gallery-page.vue
@@ -35,7 +35,31 @@
               type="text"
               class="input input-bordered input-sm rounded-xl"
               placeholder="Project title"
+              @input="onTitleInput"
             />
+          </label>
+          <label class="form-control sm:col-span-2">
+            <span class="label-text text-xs">
+              Slug
+              <span class="opacity-60">(used as the project's URL/id)</span>
+            </span>
+            <input
+              ref="slugInputRef"
+              v-model="createForm.slug"
+              type="text"
+              class="input input-bordered input-sm rounded-xl font-mono"
+              :class="{ 'input-error': slugError }"
+              placeholder="project-slug"
+              @input="onSlugInput"
+              @blur="onSlugBlur"
+            />
+            <span v-if="slugError" class="label-text-alt mt-1 text-error">
+              {{ slugError }}
+            </span>
+            <span v-else class="label-text-alt mt-1 opacity-60">
+              Auto-filled from the title; edit it here if you'd rather choose
+              your own.
+            </span>
           </label>
           <label class="form-control sm:col-span-2">
             <span class="label-text text-xs">Description</span>
@@ -79,7 +103,7 @@
         <button
           type="button"
           class="btn btn-secondary btn-sm w-full rounded-xl"
-          :disabled="!createForm.title.trim() || projects.saving"
+          :disabled="!createForm.title.trim() || !!slugError || projects.saving"
           @click="createProject"
         >
           <span
@@ -276,6 +300,7 @@ import { useTodoStore } from '@/stores/todoStore'
 import { useGalleryPreferenceStore } from '@/stores/galleryPreferenceStore'
 import type { BuilderCard } from '@/stores/helpers/builderCards'
 import { IS_GALLERY_MODE, type GalleryMode } from '@/utils/galleryVocabulary'
+import { slugify } from '@/utils/slugify'
 
 const IMG_BASE =
   'https://raw.githubusercontent.com/silasfelinus/conductor/main/projects/images'
@@ -358,15 +383,57 @@ const createOpen = ref(false)
 const createError = ref('')
 const createForm = ref<{
   title: string
+  slug: string
   description: string
   status: Status
   priority: ProjectPriorityLevel
 }>({
   title: '',
+  slug: '',
   description: '',
   status: 'BRAINSTORM',
   priority: 'NORMAL',
 })
+// Slug auto-derives from the title until the user edits it directly — once
+// they've typed into the slug field themselves, title changes stop
+// overwriting their choice.
+const slugTouched = ref(false)
+const slugInputRef = ref<HTMLInputElement | null>(null)
+// `/api/projects` (server/api/projects/index.ts's normalizeSlug) lowercases,
+// collapses non-alphanumerics to single hyphens, and trims edge hyphens
+// server-side too — mirrored here so the field previews exactly what will
+// be sent rather than drifting from the route's own rule.
+const slugError = computed(() => {
+  // Don't flash "required" before the user has typed anything — the slug
+  // stays derived-but-empty until a title exists to derive it from.
+  if (!createForm.value.title.trim() && !createForm.value.slug.trim()) {
+    return ''
+  }
+  return createForm.value.slug.trim()
+    ? ''
+    : 'A slug is required — it becomes the project URL and conductor directory name.'
+})
+
+function onTitleInput() {
+  if (slugTouched.value) return
+  createForm.value.slug = slugify(createForm.value.title)
+}
+
+function onSlugInput() {
+  slugTouched.value = true
+  // Light-touch while typing: lowercase and drop disallowed characters, but
+  // don't collapse repeat/edge hyphens yet — full slugify() runs on blur and
+  // again before submit. Doing the full normalize on every keystroke would
+  // strip a hyphen the instant it's typed (it's trailing until the next
+  // character lands), making "my-project" impossible to type by hand.
+  createForm.value.slug = createForm.value.slug
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '')
+}
+
+function onSlugBlur() {
+  createForm.value.slug = slugify(createForm.value.slug)
+}
 const loading = computed(() => projects.loading || conductor.pending)
 const error = computed(() => projects.error || conductor.error || '')
 
@@ -606,24 +673,49 @@ async function createProject(): Promise<void> {
   createError.value = ''
   const title = createForm.value.title.trim()
   if (!title) return
+  const slug = slugify(createForm.value.slug || title)
+  createForm.value.slug = slug
+  if (!slug) {
+    createError.value =
+      'A slug is required — it becomes the project URL and conductor directory name.'
+    return
+  }
   try {
     const created = await projects.createProject({
       title,
+      slug,
       description: createForm.value.description.trim() || null,
       status: createForm.value.status,
       priority: createForm.value.priority,
     })
     createForm.value = {
       title: '',
+      slug: '',
       description: '',
       status: 'BRAINSTORM',
       priority: 'NORMAL',
     }
+    slugTouched.value = false
     createOpen.value = false
     page.setWorkspaceCardKey(slugFor(created))
   } catch (error) {
-    createError.value =
-      error instanceof Error ? error.message : 'Project could not be created.'
+    const statusCode =
+      error instanceof Error
+        ? (error as Error & { statusCode?: number }).statusCode
+        : undefined
+    if (statusCode === 409) {
+      // The generic Prisma-unique-constraint message ("Record already
+      // exists.") doesn't tell the user what to do. `slug` is the only
+      // field this form submits that a Project uniquely constrains, so a
+      // 409 here always means the slug is taken — point them straight at
+      // the field that fixes it instead.
+      createError.value = `The slug "${slug}" is already taken — try a different one below.`
+      slugTouched.value = true
+      slugInputRef.value?.focus()
+    } else {
+      createError.value =
+        error instanceof Error ? error.message : 'Project could not be created.'
+    }
   }
 }
 </script>

--- a/stores/projectStore.ts
+++ b/stores/projectStore.ts
@@ -9,10 +9,7 @@ import type {
   Project,
 } from '~/prisma/generated/prisma/client'
 import { performFetch } from '@/stores/utils'
-import {
-  PROJECT_PLACEMENTS,
-  placementLiveUrl,
-} from '~/utils/projectPlacements'
+import { PROJECT_PLACEMENTS, placementLiveUrl } from '~/utils/projectPlacements'
 
 export type ProjectWithRelations = Project & {
   Manager?: Pick<
@@ -87,8 +84,10 @@ function isCanonicalList(options: ProjectListOptions): boolean {
 }
 
 function coverageScore(options: ProjectListOptions): number {
-  return Number(options.includeInactive === true) * 2 +
+  return (
+    Number(options.includeInactive === true) * 2 +
     Number(options.includeMature === true)
+  )
 }
 
 function mergeProjectDetail(
@@ -253,7 +252,14 @@ export const useProjectStore = defineStore('projectStore', () => {
         body: JSON.stringify(input),
       })
       if (!response.success || !response.data) {
-        throw new Error(response.message || 'Failed to create Project.')
+        // Callers that need to tell a slug collision (409) apart from any
+        // other failure — to point the user back at the slug field instead
+        // of a generic message — read `.statusCode` off the thrown error.
+        const error = new Error(
+          response.message || 'Failed to create Project.',
+        ) as Error & { statusCode?: number }
+        error.statusCode = response.status
+        throw error
       }
       return replaceProject(response.data)
     } finally {
@@ -289,7 +295,9 @@ export const useProjectStore = defineStore('projectStore', () => {
       },
     )
     if (!response.success || !response.data) {
-      throw new Error(response.message || 'Failed to synchronize Project lifecycle.')
+      throw new Error(
+        response.message || 'Failed to synchronize Project lifecycle.',
+      )
     }
     return replaceProject(response.data)
   }


### PR DESCRIPTION
### Task
kind-robots/t-060: add an editable slug field and slug-specific 409 UX to the New Project form (kind: software)

### What changed / what I produced
- `conductor-project-gallery-page.vue`'s create-project form gains a Slug field, auto-derived from Title (`utils/slugify.ts`, the canonical app-wide slug rule) and live-editable — once the user types into the slug field directly, further title edits stop overwriting it.
- Slug input is lightly sanitized on every keystroke (lowercase, drop disallowed characters) without collapsing/trimming hyphens mid-type — a hyphen typed by hand would otherwise get stripped the instant it lands, since it's trailing until the next character arrives. Full normalization (`slugify()`) runs on blur and again right before submit.
- On a `409` from `POST /api/projects`, the form now shows `The slug "<slug>" is already taken — try a different one below.` instead of the generic Prisma `Record already exists.` message, and focuses the slug input so the user can actually act on it.
- `stores/projectStore.ts`'s `createProject()` now attaches the response status code to the thrown `Error` (`.statusCode`) so the component can tell a 409 apart from any other failure — purely additive, existing callers that only read `.message` (e.g. `conductor-page.vue`'s missing-Project backfill) are unaffected.

### How I verified
- `npx eslint components/pages/conductor-project-gallery-page.vue stores/projectStore.ts` — clean.
- `npx vue-tsc --noEmit` (full project) — clean.
- `npx prettier --check` — clean after `--write`.
- Traced `POST /api/projects` → `server/api/projects/index.ts`'s `normalizeSlug()` to confirm the front-end's `slugify()` (`utils/slugify.ts`) produces the same normalization the server applies, so the field previews what will actually be sent rather than drifting from the route's own rule.
- Confirmed `conductor-page.vue`'s separate `createProject()` call (an automated missing-Project backfill, not this form) already passes its own explicit `slug`/`conductorSlug` and only reads `.message` on error — unaffected by the additive `.statusCode` property.
- Did not run a live browser check — this sandbox's local `nuxt dev` can't reach the dummy `DATABASE_URL` (documented sandbox limitation); relying on the static checks above plus CI structural checks for this front-end-only change.

### Stakes
reversible

### Flags for Reviewer
- Front-end-only, as the task scoped: still calls the existing `POST /api/projects` route unchanged, no shared backend contract touched.
- The 409-means-slug-collision inference is a reasonable assumption (slug/conductorSlug is the only field this form submits that a Project uniquely constrains) rather than a backend-confirmed fact — if a future route change adds another unique field to this same create path, this UX would misattribute a different collision to the slug. Worth revisiting if `POST /api/projects` ever gains a second unique constraint reachable from this form.
- Companion conductor PR: closes out kind-robots/t-060's roadmap status alongside this.

### Kaizen suggestion
The three independently-maintained slug-collision checks (this route, `appmaker/scaffold-request.post.ts`, `appmaker/github/create-app.post.ts`) each re-derive the same "is this slug taken" logic. Consolidating into one shared helper is already scoped as the pitch at `pitches/2026-08-10-kind-robots-slug-integrity.md` (kind-robots/t-061) — this PR doesn't touch that, just flagging it stays relevant.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DY1si4ZXGnFUQ8kpyugR2j)_