### PR TITLE
kind-robots/t-063: guard Project creation surface drift

### DIFF
--- a/.github/workflows/project-creation-surfaces.yml
+++ b/.github/workflows/project-creation-surfaces.yml
@@ -27,13 +27,24 @@ jobs:
   verify:
     name: Verify documented Project creation surfaces
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     permissions:
       contents: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install parser dependency
+        run: npm ci --ignore-scripts
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
 
       - name: Scanner self-test
         run: node utils/scripts/verifyProjectCreationSurfaces.mjs --self-test

--- a/.github/workflows/project-creation-surfaces.yml
+++ b/.github/workflows/project-creation-surfaces.yml
@@ -1,0 +1,42 @@
+name: Project Creation Surfaces
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'server/**'
+      - 'scripts/**'
+      - 'utils/contracts/project-creation-call-sites.json'
+      - 'utils/scripts/verifyProjectCreationSurfaces.mjs'
+      - '.github/workflows/project-creation-surfaces.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/**'
+      - 'scripts/**'
+      - 'utils/contracts/project-creation-call-sites.json'
+      - 'utils/scripts/verifyProjectCreationSurfaces.mjs'
+      - '.github/workflows/project-creation-surfaces.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: project-creation-surfaces-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify documented Project creation surfaces
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Scanner self-test
+        run: node utils/scripts/verifyProjectCreationSurfaces.mjs --self-test
+
+      - name: Project creation surface contract
+        run: node utils/scripts/verifyProjectCreationSurfaces.mjs

--- a/utils/contracts/project-creation-call-sites.json
+++ b/utils/contracts/project-creation-call-sites.json
@@ -1,0 +1,10 @@
+{
+  "conductorDocument": "projects/kind-robots/PROJECT-CREATION.md",
+  "directCallSites": [
+    "server/api/appmaker/github/create-app.post.ts",
+    "server/api/appmaker/scaffold-request.post.ts",
+    "server/api/conductor/sync.post.ts",
+    "server/api/model-builder/items/[id]/commit.post.ts",
+    "server/api/projects/index.post.ts"
+  ]
+}

--- a/utils/scripts/verifyProjectCreationSurfaces.mjs
+++ b/utils/scripts/verifyProjectCreationSurfaces.mjs
@@ -9,86 +9,13 @@ import assert from 'node:assert/strict'
 import { readFileSync, readdirSync, statSync } from 'node:fs'
 import { dirname, extname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const contractPath = join(repoRoot, 'utils/contracts/project-creation-call-sites.json')
 const contract = JSON.parse(readFileSync(contractPath, 'utf8'))
 const sourceRoots = ['server', 'scripts']
 const sourceExtensions = new Set(['.ts', '.js', '.mjs', '.cjs'])
-const directCreatePattern = /\.\s*project\s*\.\s*create\s*\(/g
-
-function stripCommentsAndStrings(source) {
-  let output = ''
-  let state = 'code'
-
-  for (let index = 0; index < source.length; index += 1) {
-    const char = source[index]
-    const next = source[index + 1]
-
-    if (state === 'code') {
-      if (char === '/' && next === '/') {
-        state = 'line-comment'
-        output += '  '
-        index += 1
-      } else if (char === '/' && next === '*') {
-        state = 'block-comment'
-        output += '  '
-        index += 1
-      } else if (char === "'") {
-        state = 'single-quote'
-        output += ' '
-      } else if (char === '"') {
-        state = 'double-quote'
-        output += ' '
-      } else if (char === '`') {
-        state = 'template'
-        output += ' '
-      } else {
-        output += char
-      }
-      continue
-    }
-
-    if (state === 'line-comment') {
-      if (char === '\n') {
-        state = 'code'
-        output += '\n'
-      } else {
-        output += ' '
-      }
-      continue
-    }
-
-    if (state === 'block-comment') {
-      if (char === '*' && next === '/') {
-        state = 'code'
-        output += '  '
-        index += 1
-      } else {
-        output += char === '\n' ? '\n' : ' '
-      }
-      continue
-    }
-
-    const closingQuote =
-      state === 'single-quote' ? "'" : state === 'double-quote' ? '"' : '`'
-
-    if (char === '\\') {
-      output += ' '
-      if (next !== undefined) {
-        output += next === '\n' ? '\n' : ' '
-        index += 1
-      }
-    } else if (char === closingQuote) {
-      state = 'code'
-      output += ' '
-    } else {
-      output += char === '\n' ? '\n' : ' '
-    }
-  }
-
-  return output
-}
 
 function findSourceFiles(root) {
   if (!statSync(root).isDirectory()) return []
@@ -102,14 +29,50 @@ function findSourceFiles(root) {
   })
 }
 
+function scriptKindFor(path) {
+  return extname(path) === '.ts' ? ts.ScriptKind.TS : ts.ScriptKind.JS
+}
+
+function countDirectProjectCreateCalls(source, filename = 'contract.ts') {
+  const sourceFile = ts.createSourceFile(
+    filename,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKindFor(filename),
+  )
+  let count = 0
+
+  function visit(node) {
+    if (ts.isCallExpression(node)) {
+      const createAccess = node.expression
+      if (
+        ts.isPropertyAccessExpression(createAccess) &&
+        createAccess.name.text === 'create'
+      ) {
+        const projectAccess = createAccess.expression
+        if (
+          ts.isPropertyAccessExpression(projectAccess) &&
+          projectAccess.name.text === 'project'
+        ) {
+          count += 1
+        }
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return count
+}
+
 function findDirectProjectCreateSites() {
   const matches = new Set()
 
   for (const sourceRoot of sourceRoots) {
     for (const path of findSourceFiles(join(repoRoot, sourceRoot))) {
-      const codeOnly = stripCommentsAndStrings(readFileSync(path, 'utf8'))
-      directCreatePattern.lastIndex = 0
-      if (directCreatePattern.test(codeOnly)) {
+      const source = readFileSync(path, 'utf8')
+      if (countDirectProjectCreateCalls(source, path) > 0) {
         matches.add(relative(repoRoot, path).replaceAll('\\', '/'))
       }
     }
@@ -124,11 +87,10 @@ function runSelfTest() {
     // await prisma.project.create({ data: {} })
     /* database.project.create({ data: {} }) */
     const example = "prisma.project.create("
-    const template = \`tx.project.create(\`
+    const template = \`tx.project.create(\${'not code'})\`
     const project_create = () => undefined
   `
-  const codeOnly = stripCommentsAndStrings(sample)
-  assert.equal(codeOnly.match(directCreatePattern)?.length ?? 0, 1)
+  assert.equal(countDirectProjectCreateCalls(sample), 1)
 }
 
 if (process.argv.includes('--self-test')) {

--- a/utils/scripts/verifyProjectCreationSurfaces.mjs
+++ b/utils/scripts/verifyProjectCreationSurfaces.mjs
@@ -1,0 +1,171 @@
+// /utils/scripts/verifyProjectCreationSurfaces.mjs
+//
+// kind-robots/t-063: direct Project creation call sites are cross-repo product
+// surfaces documented in conductor/projects/kind-robots/PROJECT-CREATION.md.
+// Keep this local manifest in lockstep with that document so a new direct create
+// path cannot quietly appear without an explicit surface review.
+
+import assert from 'node:assert/strict'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { dirname, extname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const contractPath = join(repoRoot, 'utils/contracts/project-creation-call-sites.json')
+const contract = JSON.parse(readFileSync(contractPath, 'utf8'))
+const sourceRoots = ['server', 'scripts']
+const sourceExtensions = new Set(['.ts', '.js', '.mjs', '.cjs'])
+const directCreatePattern = /\.\s*project\s*\.\s*create\s*\(/g
+
+function stripCommentsAndStrings(source) {
+  let output = ''
+  let state = 'code'
+
+  for (let index = 0; index < source.length; index += 1) {
+    const char = source[index]
+    const next = source[index + 1]
+
+    if (state === 'code') {
+      if (char === '/' && next === '/') {
+        state = 'line-comment'
+        output += '  '
+        index += 1
+      } else if (char === '/' && next === '*') {
+        state = 'block-comment'
+        output += '  '
+        index += 1
+      } else if (char === "'") {
+        state = 'single-quote'
+        output += ' '
+      } else if (char === '"') {
+        state = 'double-quote'
+        output += ' '
+      } else if (char === '`') {
+        state = 'template'
+        output += ' '
+      } else {
+        output += char
+      }
+      continue
+    }
+
+    if (state === 'line-comment') {
+      if (char === '\n') {
+        state = 'code'
+        output += '\n'
+      } else {
+        output += ' '
+      }
+      continue
+    }
+
+    if (state === 'block-comment') {
+      if (char === '*' && next === '/') {
+        state = 'code'
+        output += '  '
+        index += 1
+      } else {
+        output += char === '\n' ? '\n' : ' '
+      }
+      continue
+    }
+
+    const closingQuote =
+      state === 'single-quote' ? "'" : state === 'double-quote' ? '"' : '`'
+
+    if (char === '\\') {
+      output += ' '
+      if (next !== undefined) {
+        output += next === '\n' ? '\n' : ' '
+        index += 1
+      }
+    } else if (char === closingQuote) {
+      state = 'code'
+      output += ' '
+    } else {
+      output += char === '\n' ? '\n' : ' '
+    }
+  }
+
+  return output
+}
+
+function findSourceFiles(root) {
+  if (!statSync(root).isDirectory()) return []
+
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(root, entry.name)
+    if (entry.isDirectory()) return findSourceFiles(path)
+    if (!entry.isFile()) return []
+    if (entry.name.endsWith('.d.ts')) return []
+    return sourceExtensions.has(extname(entry.name)) ? [path] : []
+  })
+}
+
+function findDirectProjectCreateSites() {
+  const matches = new Set()
+
+  for (const sourceRoot of sourceRoots) {
+    for (const path of findSourceFiles(join(repoRoot, sourceRoot))) {
+      const codeOnly = stripCommentsAndStrings(readFileSync(path, 'utf8'))
+      directCreatePattern.lastIndex = 0
+      if (directCreatePattern.test(codeOnly)) {
+        matches.add(relative(repoRoot, path).replaceAll('\\', '/'))
+      }
+    }
+  }
+
+  return [...matches].sort()
+}
+
+function runSelfTest() {
+  const sample = `
+    await tx.project.create({ data: {} })
+    // await prisma.project.create({ data: {} })
+    /* database.project.create({ data: {} }) */
+    const example = "prisma.project.create("
+    const template = \`tx.project.create(\`
+    const project_create = () => undefined
+  `
+  const codeOnly = stripCommentsAndStrings(sample)
+  assert.equal(codeOnly.match(directCreatePattern)?.length ?? 0, 1)
+}
+
+if (process.argv.includes('--self-test')) {
+  runSelfTest()
+  console.log('Project creation surface scanner self-test passed.')
+  process.exit(0)
+}
+
+assert.equal(
+  typeof contract.conductorDocument,
+  'string',
+  'project-creation-call-sites.json must name the owning Conductor document.',
+)
+assert.ok(
+  Array.isArray(contract.directCallSites),
+  'project-creation-call-sites.json must contain directCallSites.',
+)
+
+const documented = [...new Set(contract.directCallSites)].sort()
+const actual = findDirectProjectCreateSites()
+const undocumented = actual.filter((path) => !documented.includes(path))
+const stale = documented.filter((path) => !actual.includes(path))
+
+if (undocumented.length || stale.length) {
+  const details = []
+  if (undocumented.length) {
+    details.push(`Undocumented direct Project creation call sites:\n- ${undocumented.join('\n- ')}`)
+  }
+  if (stale.length) {
+    details.push(`Manifest entries no longer containing a direct Project create call:\n- ${stale.join('\n- ')}`)
+  }
+
+  throw new Error(
+    `${details.join('\n\n')}\n\nReview the surface change, update ${contract.conductorDocument} in Conductor, and update utils/contracts/project-creation-call-sites.json in the Kind Robots implementation.`,
+  )
+}
+
+console.log(
+  `Project creation surfaces verified: ${actual.length} direct call sites match the local mirror of ${contract.conductorDocument}.`,
+)


### PR DESCRIPTION
### Task
kind-robots/t-063: CI guard for undocumented Project-creation call sites (kind: software)

### What changed / what I produced
- Added `utils/contracts/project-creation-call-sites.json`, a small local mirror of the five direct Project-create call sites already documented in Conductor's `projects/kind-robots/PROJECT-CREATION.md`.
- Added `utils/scripts/verifyProjectCreationSurfaces.mjs`, which uses the TypeScript parser to find actual `.project.create(...)` call expressions under `server/` and `scripts/`, so comments, strings, templates, and similarly-named helpers cannot create false positives.
- The contract fails on either a newly-discovered call site or a stale manifest entry and tells the maintainer to review/update the Conductor surface document and local manifest together.
- Added `.github/workflows/project-creation-surfaces.yml`, a focused check triggered by relevant server/script/contract changes. It installs dependencies without lifecycle scripts, runs a parser self-test, then verifies repository parity.

### How I verified
- Live GitHub code search on current `main` found exactly five real source call sites: `server/api/projects/index.post.ts`, `server/api/conductor/sync.post.ts`, both AppMaker create routes, and Model Builder commit. The only additional repository search hit was generated Prisma model code, which is intentionally outside the scanner roots.
- Compared the branch to current `main`: exactly 3 new contract/CI files, no application or database code changed.
- First Actions pass exposed a real flaw in the original hand-written string/comment scanner: nested templates in AppMaker caused it to miss that route. Replaced the lexer with the TypeScript parser on the same PR branch rather than weakening the expectation.
- The corrected Actions check plus the repository's normal required PR checks must complete successfully on the exact final head before merge.

### Stakes
reversible

### Flags for Reviewer
- This intentionally uses the task-authorized local allowlist/mirror instead of fetching Conductor from Kind Robots CI. That avoids a cross-repo auth/network dependency inside the guard; failures explicitly point back to the canonical Conductor doc that must be updated with any real new surface.
- No migration, runtime route behavior, production data, publishing, secrets, or account configuration touched.

### Kaizen suggestion
If cross-repo checkout becomes a stable authenticated primitive for Kind Robots Actions, this local mirror could later be upgraded to parse `PROJECT-CREATION.md` directly. For now the TypeScript AST keeps the source-side detector precise without relying on brittle text matching.

Session: `20260810T061722Z-auto-e939f1`.