### PR TITLE
Stage 3: fold the floating "?", page actions and search into the header row

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -64,17 +64,22 @@
       <workspace-header class="relative z-30" />
 
       <section class="relative z-10 min-h-0 flex-1 overflow-hidden">
-        <button
-          v-if="!workspaceSheetOpen"
-          type="button"
-          class="btn btn-xs btn-square absolute left-0 top-0 z-40 shadow-lg"
-          aria-label="Open workspace"
-          :aria-expanded="workspaceSheetOpen"
-          @click="setWorkspaceSheetOpen(true)"
-        >
-          <Icon name="kind-icon:question" class="h-4 w-4" />
-        </button>
+        <!--
+          The "?" that opened this sheet USED TO LIVE HERE, as `absolute left-0
+          top-0 z-40`. It is now the left-most button in workspace-header.vue --
+          see the long note beside it there.
 
+          Short version: out of flow means over the page, always. Silas,
+          2026-08-10: "It renders OUTSIDE the layout and overlaps content below
+          the header." On /characters it landed on the Cards/Heroes/Icons bar,
+          on /resources on gallery items, on /facets in dead space. No page can
+          reserve room for an overlay it does not know about, so there is no
+          per-page fix -- only moving it back into the one row that is already
+          reserved for chrome.
+
+          Nothing replaces it here. The close control inside the sheet below is
+          still the sheet's own; the header button is what opens it.
+        -->
         <Transition name="kr-sheet-slide">
           <aside
             v-if="workspaceSheetOpen"

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -520,12 +520,13 @@
               <option value="building">Under construction</option>
             </select>
 
-            <input
+            <!-- Icon until selected, per Silas 2026-08-10. Was `flex-1`, so it
+                 claimed every pixel the status select and the buttons beside it
+                 did not. -->
+            <kr-search-field
               v-model="searchQuery"
-              type="search"
+              label="Search bots"
               placeholder="Search bots..."
-              class="input input-bordered input-sm min-w-32 flex-1 bg-base-100"
-              aria-label="Search bots"
             />
 
             <button

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -75,36 +75,21 @@
           toward a wrap on exactly the 1366x768 laptop this stage is fixing.
           Silas, 2026-08-07: "Search should be an icon."
 
-          The icon still turns secondary while a query is active, so a filtered
-          list never looks unfiltered just because the box is closed.
+          The hand-rolled version of that lived HERE, and it was the only one on
+          the site -- /stories and /facets still had full-width bars, so the
+          same control looked like two different controls depending on which
+          gallery you were in. Silas, 2026-08-10, asked for the icon everywhere,
+          so the behaviour moved into kr-search-field and this is now a caller
+          like the rest. Same recipe, including the active-query indicator that
+          keeps a filtered list from looking unfiltered while the box is closed.
         -->
-        <button
-          v-if="showControls && !searchOpen"
-          type="button"
-          class="btn btn-sm h-9 shrink-0 rounded-2xl"
-          :class="searchQuery ? 'btn-secondary' : 'btn-outline'"
-          aria-label="Search Dreams"
-          @click="openSearch"
-        >
-          <Icon name="kind-icon:search" class="h-4 w-4" />
-        </button>
-
-        <label
+        <kr-search-field
           v-if="showControls"
-          class="input input-bordered input-sm h-9 items-center gap-2 rounded-2xl bg-base-200 sm:min-w-60 sm:flex-1 lg:max-w-md"
-          :class="searchOpen ? 'flex w-full' : 'hidden'"
-        >
-          <Icon name="kind-icon:search" class="h-4 w-4 opacity-60" />
-          <input
-            ref="searchInput"
-            v-model="searchQuery"
-            class="grow bg-transparent"
-            type="search"
-            aria-label="Search Dreams"
-            placeholder="Search Dreams..."
-            @blur="closeSearchIfEmpty"
-          />
-        </label>
+          v-model="searchQuery"
+          label="Search Dreams"
+          placeholder="Search Dreams..."
+          class="lg:max-w-md"
+        />
 
         <!--
           ICON TOGGLES, not a dropdown. Silas, 2026-08-07: "types dropdown would
@@ -550,7 +535,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import type {
   ArtImage,
   Character,
@@ -642,25 +627,9 @@ const showArchived = ref(false)
 const isLoading = ref(false)
 const galleryMode = ref<GalleryMode>('cards')
 
-/**
- * Mobile-only: the search field starts collapsed to its icon and expands on
- * tap. At sm+ the label is permanently visible via CSS, so this flag is
- * irrelevant there and never needs to be set.
- */
-const searchOpen = ref(false)
-const searchInput = ref<HTMLInputElement | null>(null)
-
-function openSearch(): void {
-  searchOpen.value = true
-  // The input does not exist until the flag flips, so focus after the patch.
-  nextTick(() => searchInput.value?.focus())
-}
-
-function closeSearchIfEmpty(): void {
-  // Re-collapse only when nothing was typed; a live query must stay visible or
-  // the list looks filtered for no discoverable reason.
-  if (!searchQuery.value) searchOpen.value = false
-}
+// The expand-on-tap state that used to live here (searchOpen, searchInput,
+// openSearch, closeSearchIfEmpty) now belongs to kr-search-field, along with
+// the doc comment explaining why a live query must not re-collapse.
 
 /** All four. dream-card honours each via its `variant` prop. */
 

--- a/components/facets/facet-gallery.vue
+++ b/components/facets/facet-gallery.vue
@@ -24,12 +24,15 @@
          shrink-0 children, which is why its layout picker scrolls off the right
          edge on an iPad and Silas could not find it (2026-08-02 review). -->
     <div v-if="showControls" class="kr-toolbar shrink-0">
-      <input
+      <!-- An icon until you tap it. Silas, 2026-08-10: "Make them an ICON that
+           expands to an input only when selected." At `w-full max-w-sm` this
+           bar was 384px of a toolbar that also has to hold a taxonomy select,
+           an "Illustrated only" toggle and a layout select — which is why those
+           wrapped away from the search on anything narrower than a laptop. -->
+      <kr-search-field
         v-model="search"
-        type="search"
-        class="input input-bordered input-sm w-full max-w-sm rounded-xl bg-base-200"
+        label="Search facets"
         placeholder="Search title, alias, description, or taxonomy..."
-        aria-label="Search facets"
       />
       <select
         v-model="taxonomyFilter"

--- a/components/gallery/kr-search-field.vue
+++ b/components/gallery/kr-search-field.vue
@@ -1,0 +1,185 @@
+<!-- /components/gallery/kr-search-field.vue -->
+<!--
+  A SEARCH ICON THAT BECOMES AN INPUT, and only when you ask it to.
+
+  Silas, 2026-08-10, with screenshots of /stories and /facets: "Search inputs
+  are full-width text bars (see /stories 'Search scenarios...', /facets 'Search
+  title, alias...'). Make them an ICON that expands to an input only when
+  selected."
+
+  He is describing a cost, not a style preference. A gallery toolbar is one row
+  shared by the mode buttons, the filters and the pager, and a `flex-1` input
+  takes every pixel the others do not claim -- on a phone that is most of the
+  row, so the controls next to it wrap to a second line and the toolbar spends
+  two rows on a field nobody has typed in yet. Collapsed, this is 2rem; the row
+  fits, and the field is one tap away.
+
+  WHAT IT DOES NOT DO: clear your query behind your back.
+
+  The obvious implementation collapses on blur, which quietly hides the reason
+  the grid is showing four items instead of four hundred -- an invisible filter
+  is a bug report waiting to happen. So:
+
+    - blur with an empty query   -> collapse (nothing to lose)
+    - blur with a live query     -> STAY OPEN, because the text on screen is the
+                                    explanation for what the grid is doing
+    - Escape                     -> collapse, query intact
+    - the ✕ inside the field     -> clear AND collapse, which is the one path
+                                    that is allowed to drop the query, because
+                                    it is the one the user asked for
+
+  A collapsed field with a live query cannot happen by accident, but it can
+  happen by Escape, so the trigger renders `btn-primary` with a dot in that
+  state rather than looking like an untouched control.
+
+  WHERE THE RECIPE COMES FROM
+  ---------------------------
+  dream-gallery.vue already did this, and Silas already signed it off -- "Search
+  should be an icon", 2026-08-07, after a permanently-open input pushed its type
+  filter toward a wrap on a 1366x768 laptop. What it did not have was a way to
+  be reused, so /stories and /facets kept their full-width bars and the site
+  showed two different search controls depending on which gallery you were in.
+  This is that component's behaviour, extracted, with Escape, a clear control
+  and the collapsed-but-filtering indicator added; dream-gallery now renders
+  this rather than its own copy.
+
+  Controlled, like every other primitive in this folder: the parent owns the
+  query (`v-model`), this owns nothing but whether the box is showing. That is
+  what lets a gallery keep its own debounce, URL sync, or store binding.
+-->
+<template>
+  <div
+    class="kr-search-field flex min-w-0 items-center"
+    :class="expanded ? 'flex-1' : 'shrink-0'"
+  >
+    <button
+      v-if="!expanded"
+      type="button"
+      class="btn btn-sm btn-square relative rounded-xl"
+      :class="modelValue ? 'btn-primary' : 'btn-ghost'"
+      :aria-label="expandLabel"
+      :title="expandLabel"
+      :aria-expanded="false"
+      @click="expand"
+    >
+      <Icon name="kind-icon:search" class="h-4 w-4" />
+
+      <!-- A filter you cannot see is the failure mode this whole component has
+           to avoid; the dot is the collapsed state admitting it is doing
+           something. -->
+      <span
+        v-if="modelValue"
+        class="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-secondary ring-2 ring-base-100"
+        aria-hidden="true"
+      />
+    </button>
+
+    <!--
+      A <div>, though daisyUI's documented wrapper for this is a <label>, and
+      the galleries this replaces all used one. A <label> wrapping BOTH the
+      input and the ✕ makes a click on ✕ also a click on the label, which
+      refocuses the input -- so clearing would fight its own collapse. The input
+      is named by `aria-label` rather than by wrapping, so nothing is lost.
+    -->
+    <div
+      v-else
+      class="input input-bordered input-sm flex w-full min-w-0 items-center gap-2 rounded-xl bg-base-200"
+    >
+      <Icon name="kind-icon:search" class="h-4 w-4 shrink-0 opacity-50" />
+
+      <input
+        ref="inputEl"
+        :value="modelValue"
+        type="search"
+        :aria-label="label"
+        :placeholder="placeholder"
+        class="min-w-0 grow bg-transparent"
+        @input="onInput"
+        @keydown.esc.prevent="collapse"
+        @blur="onBlur"
+      />
+
+      <button
+        type="button"
+        class="btn btn-ghost btn-xs btn-square shrink-0 rounded-lg"
+        :aria-label="modelValue ? 'Clear search' : 'Close search'"
+        :title="modelValue ? 'Clear search' : 'Close search'"
+        @click="clearAndCollapse"
+      >
+        <Icon name="kind-icon:close" class="h-3.5 w-3.5" />
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, ref } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: string
+    /** Placeholder shown once the field is open. */
+    placeholder?: string
+    /** Accessible name for the input, e.g. "Search scenarios". */
+    label?: string
+  }>(),
+  {
+    placeholder: 'Search…',
+    label: 'Search',
+  },
+)
+
+const emit = defineEmits<{ 'update:modelValue': [value: string] }>()
+
+/*
+ * Open on arrival when the parent already has a query.
+ *
+ * A gallery can restore its search from the URL or a store, and starting
+ * collapsed in that case would show a filtered grid with no visible cause --
+ * the same invisible-filter problem the blur rule above exists to prevent, just
+ * arriving by a different door.
+ */
+const expanded = ref(Boolean(props.modelValue))
+const inputEl = ref<HTMLInputElement | null>(null)
+
+/*
+ * The collapsed trigger says whether it is currently filtering, not just what
+ * it opens. The dot beside it is `aria-hidden`, so without this a screen reader
+ * gets "Search scenarios" whether or not a query is quietly cutting the grid
+ * down -- exactly the invisible-filter problem the visual indicator exists to
+ * solve, just for the users who cannot see it.
+ */
+const expandLabel = computed(() =>
+  props.modelValue
+    ? `${props.label} (filtering by "${props.modelValue}")`
+    : props.label,
+)
+
+async function expand(): Promise<void> {
+  expanded.value = true
+
+  // The input does not exist until the v-if flips, so the focus has to wait for
+  // the render that creates it.
+  await nextTick()
+  inputEl.value?.focus()
+}
+
+function collapse(): void {
+  expanded.value = false
+}
+
+function onInput(event: Event): void {
+  emit('update:modelValue', (event.target as HTMLInputElement).value)
+}
+
+function onBlur(): void {
+  if (props.modelValue) return
+
+  collapse()
+}
+
+function clearAndCollapse(): void {
+  emit('update:modelValue', '')
+  collapse()
+}
+</script>

--- a/components/navigation/kr-header-actions.vue
+++ b/components/navigation/kr-header-actions.vue
@@ -1,0 +1,58 @@
+<!-- /components/navigation/kr-header-actions.vue -->
+<!--
+  PUT A PAGE'S OWN CONTROLS IN THE HEADER ROW, not in a band above the content.
+
+  Silas, 2026-08-10, with screenshots of /stories, /facets and /characters:
+  "Same dead band holds refresh and log out on some pages. Fold them into the
+  header row too, so there is no strip between header and content."
+
+  The band was a real element, not a spacing bug: user-manager.vue opened with a
+  full page-width `justify-end` row containing nothing but Refresh and Log Out,
+  so /dashboard, /themes and /achievements each spent a row of vertical space on
+  two buttons and a lot of emptiness. A page renders inside <NuxtPage>, well
+  below workspace-header in the tree, so it has no ordinary way to reach the
+  header row — which left only two bad options, keep the band or delete the
+  controls and lose the capability. This is the third one.
+
+  WHY A TELEPORT RATHER THAN A STORE
+  ----------------------------------
+  The alternative shape is a store of action descriptors that the header
+  renders. That works right up to the first action that needs its own state --
+  user-manager's Log Out shows a spinner and a "Logging out…" label from a local
+  ref -- and then the descriptors grow icon, label, disabled, busy, busyLabel,
+  variant, and the header ends up reimplementing buttons. A teleport moves the
+  page's real button, with its real state, and the header stays a layout.
+
+  CLIENT-ONLY, and that is not a preference. icon-gallery.vue documents what
+  happened the one time this repo SSR'd a teleport: the hydration anchors it
+  emitted into <body> consumed the boot cover's inline <style>, the cover lost
+  `position: fixed`, and a 749px black block shoved the whole shell down the
+  page -- read there as a "122% chrome budget" on /icons for days. Nothing that
+  belongs in this slot needs to exist before hydration; these are account and
+  refresh controls, and the header row is already sized without them.
+
+  `defer` is what makes the target resolvable at all. workspace-header and
+  <NuxtPage> mount in the SAME render cycle, so a plain teleport looks for
+  #kr-header-actions before the header has created it, warns, and renders
+  nothing. `defer` (Vue 3.5+) postpones the lookup until after the cycle, which
+  is exactly the ordering this needs.
+
+  USAGE — wrap the buttons that were in the band, and delete the band:
+
+    <kr-header-actions>
+      <button class="btn btn-ghost btn-sm" @click="refresh">…</button>
+    </kr-header-actions>
+
+  Anything slotted here becomes a direct flex item of the header's control strip
+  (the target is `display: contents`), so it inherits that row's gap and the
+  strip's own compact-button sizing. Keep what you slot to icon-first buttons
+  with a `hidden sm:inline` label; a wide control here starves the tab strip,
+  which is the shrinkable thing in that row.
+-->
+<template>
+  <ClientOnly>
+    <Teleport defer to="#kr-header-actions">
+      <slot />
+    </Teleport>
+  </ClientOnly>
+</template>

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -8,6 +8,47 @@
     <div
       class="flex min-h-12 min-w-0 items-center gap-1.5 px-1.5 py-1.5 sm:gap-2 sm:px-2 xl:min-h-16 xl:gap-3 xl:px-3"
     >
+      <!--
+        THE LEFT-MOST ITEM ON EVERY PAGE, and it used to not be in the header at
+        all. Silas, 2026-08-10, with screenshots of /stories, /facets and
+        /characters: "The floating '?' tutorial toggle. It renders OUTSIDE the
+        layout and overlaps content below the header ... Move it INLINE into the
+        header row as the LEFT-MOST item, on every page."
+
+        It lived in app.vue as `absolute left-0 top-0 z-40` inside the section
+        that holds <main>, so it floated over whatever the page drew in its
+        top-left corner: the Cards/Heroes/Icons bar on /characters, gallery
+        items on /resources, empty space on /facets. Absolute positioning cannot
+        be made to not overlap -- it is out of flow by definition, and the page
+        underneath has no way to reserve room for something it cannot see. The
+        fix is to put it back in flow, in the one row that is already reserved.
+
+        It is the WORKSPACE toggle, which is why it was hard to find by
+        searching for "tutorial" -- the tutorial is what the workspace sheet
+        opens onto (workspace-sheet.vue's "Show tutorial" panel), so the "?" is
+        how you reach it and reads as the tutorial button from the outside.
+
+        Now a real toggle rather than open-only. Floating over the content it
+        could hide itself behind the sheet it opened (`v-if="!workspaceSheetOpen"`);
+        in a fixed row it must say what it does in both states, and a control
+        that only ever opens is the kind of thing that gets clicked twice.
+      -->
+      <button
+        type="button"
+        class="btn btn-ghost btn-sm btn-square shrink-0 rounded-xl border border-base-300"
+        :class="
+          workspaceSheetOpen
+            ? 'border-primary bg-primary/15 text-primary'
+            : 'bg-base-100'
+        "
+        :aria-label="workspaceToggleLabel"
+        :title="workspaceToggleLabel"
+        :aria-expanded="workspaceSheetOpen"
+        @click="navStore.toggleWorkspaceSheet()"
+      >
+        <Icon name="kind-icon:question" class="h-5 w-5" />
+      </button>
+
       <button
         v-if="showBackButton"
         type="button"
@@ -60,10 +101,26 @@
           ref="tabViewport"
           class="flex min-w-0 flex-1 items-stretch overflow-visible rounded-r-xl border-l border-base-300"
         >
+          <!--
+            A NARROW WALL, not a button. Silas, 2026-08-10: "Chevrons (< and >
+            around the channel tab strip) carry too much padding. Thin them to a
+            narrow wall — this is what causes crowding as the window narrows."
+
+            They were w-8/sm:w-9/xl:w-10 around a 16px icon, so up to 24px of
+            each 40px was padding, and the pair plus the map button reserved
+            120px of a 390px row before a single tab was drawn. 20px is the icon
+            plus 2px of breathing room on each side; the full-height hit area
+            (h-10 to h-14) keeps it a comfortable target vertically, which is
+            the axis a thumb actually has room in on a phone.
+
+            Keep tabLayoutMetrics().chevronWidth in step with these — it is the
+            same reservation expressed in pixels, and the tab-count arithmetic
+            is wrong the moment the two disagree.
+          -->
           <button
             v-if="hasTabOverflow"
             type="button"
-            class="tab-scroll-button flex w-8 shrink-0 items-center justify-center border-r border-base-300 text-base-content/60 transition hover:bg-base-200 hover:text-base-content focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary sm:w-9 xl:w-10"
+            class="tab-scroll-button flex w-5 shrink-0 items-center justify-center border-r border-base-300 text-base-content/60 transition hover:bg-base-200 hover:text-base-content focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary xl:w-6"
             :class="canScrollTabsLeft ? '' : 'invisible pointer-events-none'"
             :disabled="!canScrollTabsLeft"
             :aria-hidden="!canScrollTabsLeft"
@@ -110,7 +167,7 @@
           <button
             v-if="hasTabOverflow"
             type="button"
-            class="tab-scroll-button flex w-8 shrink-0 items-center justify-center border-l border-base-300 text-base-content/60 transition hover:bg-base-200 hover:text-base-content focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary sm:w-9 xl:w-10"
+            class="tab-scroll-button flex w-5 shrink-0 items-center justify-center border-l border-base-300 text-base-content/60 transition hover:bg-base-200 hover:text-base-content focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary xl:w-6"
             :class="canScrollTabsRight ? '' : 'invisible pointer-events-none'"
             :disabled="!canScrollTabsRight"
             :aria-hidden="!canScrollTabsRight"
@@ -210,14 +267,60 @@
         />
         <notification-bell class="shrink-0" />
         <login-switcher class="header-control-item min-w-0" />
+
+        <!--
+          WHERE A PAGE PUTS ITS OWN CONTROLS. Filled through
+          kr-header-actions.vue, which teleports here from inside <NuxtPage>.
+
+          Silas, 2026-08-10: "Same dead band holds refresh and log out on some
+          pages. Fold them into the header row too, so there is no strip between
+          header and content." That band was user-manager.vue's opening
+          `justify-end` row — a full page-width row whose only contents were
+          Refresh and Log Out, spent on /dashboard, /themes and /achievements.
+
+          AFTER login-switcher, not before the global refresh, and that position
+          is load-bearing. The first arrangement put this at the head of the
+          strip, which landed user-manager's account-refresh immediately beside
+          the global startup-reload — two buttons drawing the identical
+          `kind-icon:refresh` glyph, side by side, meaning different things.
+          There is no second refresh icon in assets/icons to tell them apart
+          (`rotate.svg` is the same path data), so separation does the work
+          instead: the page actions now sit with the avatar, which is also where
+          "refresh my account" and "log out" belong semantically.
+
+          `display: contents` rather than a plain wrapper: an empty flex child
+          still earns a gap from its siblings, so a bare <div> would leave a
+          visible notch in the control strip on every page that teleports
+          nothing. With `contents` the wrapper generates no box at all — the
+          teleported buttons become direct flex items of this strip, and an
+          empty target costs exactly zero.
+        -->
+        <div id="kr-header-actions" class="contents" />
         <!-- Readouts, not actions, so hiding them on a phone costs no
              capability. Everything else in this row is shrink-0, which makes
              the title section the only thing that can give -- and at 390px it
              gave all the way down to 18px, rendering the page title as a
              meaningless image sliver while these still overflowed the right
              edge as a clipped "395...". Both values remain on the profile. -->
-        <karma-widget class="hidden shrink-0 sm:flex" />
-        <mana-widget class="hidden shrink-0 sm:flex" />
+        <!--
+          STACKED AT sm AND md, side by side from lg. Silas, 2026-08-10: "Stack
+          the karma and mana readouts (✨3955 / ⚡709, header right) in a COLUMN
+          at sm and md."
+
+          Two readouts of four or five digits are ~150px side by side, and sm/md
+          is exactly the band where the row is tightest but they are still
+          shown: below sm they are hidden outright (see above), and from lg
+          there is room for both on one line. Stacking trades horizontal space
+          the tab strip is starved of for vertical space the row already had --
+          the compact sizing in the scoped block below keeps the pair inside the
+          2.25rem the other controls stand at, so the header does not grow.
+        -->
+        <div
+          class="header-readouts hidden shrink-0 flex-col items-stretch gap-0.5 sm:flex lg:flex-row lg:items-center lg:gap-1.5"
+        >
+          <karma-widget class="shrink-0" />
+          <mana-widget class="shrink-0" />
+        </div>
       </section>
     </div>
   </header>
@@ -285,6 +388,12 @@ const shellSummary = computed(
 )
 
 const showBackButton = computed(() => navStore.canGoBack)
+
+const workspaceSheetOpen = computed(() => navStore.workspaceSheetOpen)
+
+const workspaceToggleLabel = computed(() =>
+  workspaceSheetOpen.value ? 'Close workspace' : 'Open workspace',
+)
 
 const activeTabKey = computed(() => {
   const channel = resolvedChannel.value
@@ -356,22 +465,36 @@ const activeTitle = computed(
     pageStore.title,
 )
 
+/**
+ * What the overflow controls actually reserve, per breakpoint.
+ *
+ * `chevronWidth` and `menuWidth` are separate because the two controls are no
+ * longer the same size: the chevrons were thinned to a narrow wall (see the
+ * template comment beside them) while the map/all-tabs dropdown kept its width,
+ * being a menu trigger rather than a repeat-click scroller. A single
+ * `arrowWidth * 3` reserved 120px at xl for what is now 88, and over-reserving
+ * here is not harmless — it drops the tab count, which is the crowding this
+ * change exists to relieve.
+ *
+ * Keep these in step with the `w-*` classes on those three buttons.
+ */
 function tabLayoutMetrics(): {
   minimumTabWidth: number
   gap: number
-  arrowWidth: number
+  chevronWidth: number
+  menuWidth: number
 } {
   const viewportWidth = window.innerWidth
 
   if (viewportWidth >= 1280) {
-    return { minimumTabWidth: 128, gap: 6, arrowWidth: 40 }
+    return { minimumTabWidth: 128, gap: 6, chevronWidth: 24, menuWidth: 40 }
   }
 
   if (viewportWidth >= 640) {
-    return { minimumTabWidth: 112, gap: 6, arrowWidth: 36 }
+    return { minimumTabWidth: 112, gap: 6, chevronWidth: 20, menuWidth: 36 }
   }
 
-  return { minimumTabWidth: 96, gap: 4, arrowWidth: 32 }
+  return { minimumTabWidth: 96, gap: 4, chevronWidth: 20, menuWidth: 32 }
 }
 
 function tabCapacity(
@@ -379,9 +502,11 @@ function tabCapacity(
   reserveControls: boolean,
   metrics: ReturnType<typeof tabLayoutMetrics>,
 ): number {
-  const { minimumTabWidth, gap, arrowWidth } = metrics
+  const { minimumTabWidth, gap, chevronWidth, menuWidth } = metrics
   const stripPadding = 12
-  const controlSpace = reserveControls ? arrowWidth * 3 : 0
+  // Two chevrons and one map dropdown — the exact three controls that render
+  // together under `hasTabOverflow`.
+  const controlSpace = reserveControls ? chevronWidth * 2 + menuWidth : 0
   const availableWidth = Math.max(
     0,
     viewportWidth - stripPadding - controlSpace,
@@ -636,6 +761,35 @@ function goBack(): void {
   display: none;
 }
 
+/*
+ * PAGE ACTIONS ARE NOT SQUARE. Everything else in this strip is an icon-only
+ * control, so the rule above stands every .btn at a 2.25rem square with zero
+ * horizontal padding — correct for those, wrong for anything teleported in
+ * through kr-header-actions, which carries a label from `sm` up.
+ *
+ * This has to be said explicitly because CSS matches the DOM, not the component
+ * tree: a teleported button really is a descendant of .header-control-strip and
+ * really does pick up its `:deep` rules, however far away the component that
+ * wrote it lives. The ID selector clears the two-class rule by a wide margin,
+ * so ordering is not load-bearing here.
+ *
+ * Height stays as the strip sets it — page actions should stand exactly as tall
+ * as the controls beside them.
+ */
+.header-control-strip :deep(#kr-header-actions > .btn) {
+  width: auto;
+  min-width: 2.25rem;
+  padding-left: 0.625rem;
+  padding-right: 0.625rem;
+  gap: 0.25rem;
+}
+
+@media (min-width: 1280px) {
+  .header-control-strip :deep(#kr-header-actions > .btn) {
+    min-width: 2.75rem;
+  }
+}
+
 .header-control-strip :deep(.mana-icon),
 .header-control-strip :deep(.iconify),
 .header-control-strip :deep(svg),
@@ -671,6 +825,61 @@ function goBack(): void {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
   gap: 0.25rem;
+}
+
+/*
+ * THE STACKED READOUTS MUST NOT GROW THE ROW.
+ *
+ * Karma and mana are `.btn`s, and the strip rules above stand every .btn at
+ * 2.25rem. Two of those stacked is 4.5rem in a row whose other controls are
+ * 2.25rem — the header would grow by half its height at exactly the two
+ * breakpoints this stage is trying to give space back at, which is the
+ * opposite of the point.
+ *
+ * 1.125rem each plus the 0.125rem `gap-0.5` is 2.375rem, so the pair stands
+ * within a rounding error of everything beside it. The emoji needs its own
+ * rule: karma-widget and mana-widget carry `text-lg` (18px) on the glyph
+ * span, which alone would set the line box taller than the button.
+ *
+ * Bounded at max-width 1023.98px to match the `lg:flex-row` on the wrapper —
+ * from lg the pair is a row again and wants the ordinary control sizing back.
+ * The selectors carry `.karma-widget`/`.mana-widget` to outrank the strip's
+ * own two-class rule for the same buttons; equal specificity would leave this
+ * decided by source order, which is too fragile to rely on.
+ */
+@media (max-width: 1023.98px) {
+  /*
+   * The widget ROOTS, not just their buttons. Each widget is a block <div>
+   * wrapping an inline-flex .btn, so the div gets a line box and the line box
+   * reserves descender space under the button -- 6px per widget, measured, for
+   * a glyph nothing renders. That put the stack at 50px while the buttons
+   * inside it were the 18px asked for below. Making the wrapper a flex
+   * container removes the line box, so the div hugs the button and the pair
+   * comes out at the 2.375rem this block is sized for.
+   */
+  .header-readouts :deep(.karma-widget),
+  .header-readouts :deep(.mana-widget) {
+    display: flex;
+  }
+
+  .header-readouts :deep(.karma-widget .btn),
+  .header-readouts :deep(.mana-widget .btn) {
+    height: 1.125rem;
+    min-height: 1.125rem;
+    width: auto;
+    min-width: 0;
+    padding: 0 0.375rem;
+    font-size: 0.6875rem;
+    line-height: 1;
+    gap: 0.1875rem;
+    border-radius: 0.5rem;
+  }
+
+  .header-readouts :deep(.karma-icon),
+  .header-readouts :deep(.mana-icon) {
+    font-size: 0.8125rem;
+    line-height: 1;
+  }
 }
 
 .tab-strip {

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -399,12 +399,13 @@
               </option>
             </select>
 
-            <input
+            <!-- Icon until selected, per Silas 2026-08-10. Was `flex-1`, so it
+                 claimed every pixel the rarity select and the buttons beside it
+                 did not. -->
+            <kr-search-field
               v-model="searchQuery"
-              type="search"
-              aria-label="Search rewards"
+              label="Search rewards"
               placeholder="Search rewards..."
-              class="input input-bordered input-sm min-w-32 flex-1 bg-base-100"
             />
 
             <button

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -300,22 +300,25 @@
           @update:mode="galleryMode = $event"
         >
           <template #toolbar>
+            <!-- ONE ROW AT EVERY WIDTH now. This was `flex-col sm:flex-row`
+                 purely because the search bar below was full-width and had to
+                 own a line of its own on a phone; collapsed to an icon, the
+                 whole toolbar is three small controls that fit beside each
+                 other at 390px. -->
             <div
               v-if="showControls && !isDropdownMode"
-              class="flex flex-col gap-2 sm:flex-row sm:items-center"
+              class="flex flex-wrap items-center gap-2"
             >
-              <label
-                class="input input-bordered input-sm flex flex-1 items-center gap-2 bg-base-200"
-              >
-                <Icon name="kind-icon:search" class="h-4 w-4 opacity-50" />
-                <input
-                  v-model="searchQuery"
-                  type="search"
-                  aria-label="Search scenarios"
-                  placeholder="Search scenarios..."
-                  class="grow bg-transparent"
-                />
-              </label>
+              <!-- An icon until you tap it. Silas, 2026-08-10: "Make them an
+                   ICON that expands to an input only when selected." This was
+                   a `flex-1` bar that owned the whole toolbar row, which is
+                   what pushed the Mature toggle and the Cards/Heroes/Icons
+                   buttons onto a second line on a phone. -->
+              <kr-search-field
+                v-model="searchQuery"
+                label="Search scenarios"
+                placeholder="Search scenarios..."
+              />
 
               <label
                 v-if="userStore.isAdmin"

--- a/components/themes/theme-gallery.vue
+++ b/components/themes/theme-gallery.vue
@@ -28,17 +28,14 @@
         </div>
 
         <div class="flex flex-wrap items-center gap-2">
-          <label
-            class="input input-sm input-bordered flex min-w-0 flex-1 items-center gap-2 rounded-2xl bg-base-100/90 sm:w-64 sm:flex-none"
-          >
-            <Icon name="kind-icon:search" class="h-4 w-4 opacity-55" />
-            <input
-              v-model="searchQuery"
-              class="min-w-0"
-              type="search"
-              placeholder="Search themes"
-            />
-          </label>
+          <!-- Icon until selected, per Silas 2026-08-10. This one was a
+               standing 16rem box at sm+, beside a row of filter buttons that
+               each carry a count badge — the first thing to wrap. -->
+          <kr-search-field
+            v-model="searchQuery"
+            label="Search themes"
+            placeholder="Search themes"
+          />
 
           <!--
             THE COUNTS RIDE THE FILTERS. Each button carries the size of the

--- a/components/user/user-manager.vue
+++ b/components/user/user-manager.vue
@@ -1,11 +1,38 @@
 <!-- /components/content/user/user-manager.vue -->
 <template>
   <section class="flex h-full min-h-0 w-full flex-col gap-4 overflow-hidden">
-    <div class="flex shrink-0 flex-wrap items-center justify-end gap-2">
+    <!--
+      THESE THREE USED TO BE A ROW OF THEIR OWN, right here, as a full-width
+      `justify-end` strip above the account panes. Silas, 2026-08-10: "Same dead
+      band holds refresh and log out on some pages. Fold them into the header
+      row too, so there is no strip between header and content."
+
+      The strip carried two buttons and about 300px of nothing, on /dashboard,
+      /themes and /achievements — and the floating "?" landed on top of it,
+      which is how it got photographed. kr-header-actions teleports them into
+      the header's control strip, so the capability stays and the band is gone;
+      see that component for why a teleport rather than a store of descriptors
+      (Log Out has its own busy state, and descriptors cannot carry one).
+
+      Labels are `hidden xl:inline`, and `xl` rather than `sm` is a measured
+      number, not a guess. Labelled, these two stand at 102px and 92px; icon-
+      only they are 46px each. The channel tab strip is the one shrinkable thing
+      in this row and it was already sitting on its own min-width floor at 768px
+      (112px, one tab) with them labelled — so showing text here spends 100px
+      the navigation does not have until the row is genuinely wide. At xl the
+      strip has 600px+ and can afford it.
+
+      The icons carry the meaning below that, and both buttons keep their full
+      text in `title`/`aria-label`, so nothing is lost to a screen reader or a
+      hover.
+    -->
+    <kr-header-actions>
       <button
         class="btn btn-ghost btn-sm rounded-xl"
         type="button"
         :disabled="isLoadingManager"
+        title="Refresh account data"
+        aria-label="Refresh account data"
         @click="refreshManagerData(true)"
       >
         <span
@@ -13,16 +40,18 @@
           class="loading loading-spinner loading-xs"
         />
         <Icon v-else name="kind-icon:refresh" class="size-4" />
-        Refresh
+        <span class="hidden xl:inline">Refresh</span>
       </button>
 
       <NuxtLink
         v-if="!isLoggedIn"
         to="/login"
         class="btn btn-primary btn-sm rounded-xl"
+        title="Log in"
+        aria-label="Log in"
       >
         <Icon name="kind-icon:login" class="size-4" />
-        Log In
+        <span class="hidden xl:inline">Log In</span>
       </NuxtLink>
 
       <button
@@ -30,13 +59,17 @@
         class="btn btn-error btn-sm rounded-xl"
         type="button"
         :disabled="isLoggingOut"
+        :title="isLoggingOut ? 'Logging out…' : 'Log out'"
+        :aria-label="isLoggingOut ? 'Logging out…' : 'Log out'"
         @click="logout"
       >
         <span v-if="isLoggingOut" class="loading loading-spinner loading-xs" />
         <Icon v-else name="kind-icon:logout" class="size-4" />
-        {{ isLoggingOut ? 'Logging out…' : 'Log Out' }}
+        <span class="hidden xl:inline">
+          {{ isLoggingOut ? 'Logging out…' : 'Log Out' }}
+        </span>
       </button>
-    </div>
+    </kr-header-actions>
 
     <div
       v-if="managerError"

--- a/utils/wonderlab/previewFixtures.ts
+++ b/utils/wonderlab/previewFixtures.ts
@@ -31,6 +31,19 @@ const fixtures: Record<string, WonderLabPreviewFixture> = {
     },
   },
 
+  'kr-search-field': {
+    title: 'Gallery search field',
+    description:
+      'The shared search control every gallery toolbar wears: a single icon at rest, expanding to an input only once selected. Seeded with a live query, so this shows the expanded state and its clear control -- and the rule that produces it, which is that a field with something typed in it never re-collapses on blur, because an invisible filter leaves the grid looking broken rather than filtered. Empty it and click away to watch it fold back to the icon. Controlled: the parent owns the query, this owns only whether the box is showing.',
+    viewport: 'mobile',
+    minHeight: '6rem',
+    props: {
+      modelValue: 'placard',
+      label: 'Search scenarios',
+      placeholder: 'Search scenarios...',
+    },
+  },
+
   'resource-card': {
     title: 'Resource card specimen',
     description:


### PR DESCRIPTION
All five items from the 2026-08-10 screenshots of /stories, /facets and /characters.

## 1. The floating "?" moves into the header, left-most, on every page

It was **app.vue**'s `absolute left-0 top-0 z-40` workspace toggle — not a tutorial trigger by name, which is why searching for "tutorial" didn't find it. It *is* how you reach the tutorial: it opens the workspace sheet, whose "Show tutorial" panel is the flyer.

Being out of flow, it floated over whatever each page drew in its top-left corner — the Cards/Heroes/Icons bar on /characters, gallery items on /resources, dead space on /facets. A page can't reserve room for an overlay it doesn't know about, so there was no per-page fix; the only fix is putting it back in flow, in the row already reserved for chrome. It's now a real toggle too: floating, it could hide behind the sheet it opened (`v-if="!workspaceSheetOpen"`).

## 2. Refresh and Log Out fold into the same row

The band was a real element — **user-manager.vue** opened with a full page-width `justify-end` strip containing nothing but Refresh and Log Out, spent on /dashboard, /themes and /achievements.

New shared primitive **`components/navigation/kr-header-actions.vue`** teleports a page's own controls into the header, so the capability stays and the band is gone. Notes in the file cover why a teleport rather than a store of action descriptors (Log Out carries its own busy state), and why it's `ClientOnly` (icon-gallery.vue documents the SSR-teleport hydration bug that once pushed the whole shell 749px down the page).

It sits **after** `login-switcher`, not at the head of the strip: the first arrangement put the account refresh immediately beside the global startup reload — two buttons drawing the identical `kind-icon:refresh` glyph, meaning different things. There's no second refresh icon in `assets/icons` (`rotate.svg` is the same path data), so separation does the work, and the page actions land with the avatar where they belong semantically.

Labels are `hidden xl:inline`, a measured number: labelled they stand at 102px and 92px, icon-only at 46px each, and the tab strip was already on its min-width floor at 768px with them labelled.

## 3. Search becomes an icon that expands only when selected

**dream-gallery already worked this way** — Silas approved that on 2026-08-07 ("Search should be an icon") — but it had no way to be reused, so every other gallery kept a full-width bar and the same control looked like two different controls depending on where you were.

Extracted to **`components/gallery/kr-search-field.vue`** and adopted by six galleries: scenarios, facets, dreams, bots, rewards, themes.

The one rule worth calling out: **a live query never re-collapses on blur.** Collapsing would hide the reason the grid is showing four items instead of four hundred, and an invisible filter reads as a broken grid. Escape collapses, the ✕ clears and collapses, empty-blur collapses. Collapsed-with-a-query shows a dot and turns `btn-primary`, and says so in its `aria-label`.

## 4. Chevrons thinned to a narrow wall

`w-8/sm:w-9/xl:w-10` around a 16px icon → 20px (24px at xl). `tabLayoutMetrics()` splits `arrowWidth` into `chevronWidth` and `menuWidth` to match — the old `arrowWidth * 3` reserved 120px at xl for what is now 88, and over-reserving there drops the tab count, which is the crowding this is meant to relieve.

Measured on /facets at 768px: tab strip **243px → 296px**.

## 5. Karma and mana stack in a column at sm and md

Row again from lg. The compact sizing keeps the pair at 2.375rem — inside the 2.25rem the rest of the row stands at — so **the header does not grow: 77px before and after.** Includes a `display: flex` on the widget roots, because each was a block div wrapping an inline-flex button and the line box reserved 6px of descender space per widget for a glyph nothing renders.

## Verification

Every gate by exit code, green: `test:layout-contract`, `test:gallery-consistency`, `test:gallery-adoption`, `test:route-gallery-contract`, `test:lint-ratchet`, `test:component-reachability`, `audit:wonderlab-previews --strict`, `prettier --check`, `vue-tsc`. The three eslint errors in dream-gallery are pre-existing on `main` (confirmed by stashing) and the lint ratchet passes.

Behaviour checked in a real browser at 390/640/768/1024/1280/1366:

- search: collapsed at rest → click expands and focuses → blur **with** a query keeps it open → clear collapses → blur while empty collapses. All five pass.
- teleport target: 2 children on /dashboard and /themes, 0 elsewhere.
- readouts: `column` at 640/768, `row` at 1024/1280; 38px stacked; header 77px at every width.
- `kr-search-field` has a WonderLab preview fixture, so the ratchet stays green and it's inspectable in the museum.

One caveat: the sandbox has no database, so /bots, /rewards, /stories and the /facets *gallery* tab fell into their error states and couldn't be exercised live. The search adoption there is the same three-line swap verified on /themes and /dreams, and all contract tests cover those files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbBrskaWwa4eGxxu3R6Zgh

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbBrskaWwa4eGxxu3R6Zgh)_