### PR TITLE
model-builder/t-029: stop autoBuildItem overwriting a hand-typed art prompt

### DIFF
--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1495,7 +1495,20 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
           const drafted = await draftText(itemId, 'fields')
           if (!drafted) return 'failed'
         }
-        if (wantArt) {
+        if (wantArt && !item.promptDraft.trim()) {
+          // Mirrors the PITCH branch above: only draft what's actually
+          // empty. Unlike fieldsDraft (always pre-filled with a non-empty
+          // defaultFieldsTemplate skeleton, so an emptiness check there could
+          // never fire and isn't a reliable signal of user intent),
+          // promptDraft starts genuinely empty -- so a non-empty value here
+          // can only mean the user already typed their own generation
+          // prompt (the "Generation prompt" textarea's @change handler
+          // persists it via updatePrompt) before clicking Auto. Drafting
+          // unconditionally, as this used to, silently discarded that
+          // hand-typed prompt for a fresh AI one the user never asked for or
+          // reviewed -- and generateItemAsset immediately renders art from
+          // it (`item.promptDraft.trim() || item.pitch.trim()`) instead of
+          // what they wrote.
           const drafted = await draftText(itemId, 'artPrompt')
           if (!drafted) return 'failed'
         }

--- a/utils/scripts/verifyModelBuilderAutoBuildDraftGate.test.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildDraftGate.test.ts
@@ -5,8 +5,9 @@
 // the real check against synthetic store-shaped fixtures covering: the
 // pre-fix shape (draftText's result discarded, approveStage called
 // unconditionally -- the exact bug found by manual read-through), the fixed
-// shape (result captured and gated), the same-item reentrancy guard, and
-// autoBuildItem being absent entirely.
+// shape (result captured and gated), the same-item reentrancy guard,
+// autoBuildItem being absent entirely, and (a later cycle) the artPrompt
+// draft not being gated behind `!item.promptDraft.trim()`.
 import assert from 'node:assert/strict'
 
 import { checkAutoBuildDraftGate } from './verifyModelBuilderAutoBuildDraftGate.js'
@@ -83,7 +84,7 @@ const FIXED_FIXTURE = `
           const drafted = await draftText(itemId, 'fields')
           if (!drafted) return 'failed'
         }
-        if (wantArt) {
+        if (wantArt && !item.promptDraft.trim()) {
           const drafted = await draftText(itemId, 'artPrompt')
           if (!drafted) return 'failed'
         }
@@ -119,10 +120,11 @@ const MISSING_FIXTURE = `
 const buggyErrors = checkAutoBuildDraftGate(BUGGY_FIXTURE)
 assert.equal(
   buggyErrors.length,
-  5,
-  'expected the pre-fix shape (three discarded draftText results plus the ' +
-    'missing same-item reentrancy guard plus the missing manual-action-in-' +
-    `flight guard) to raise 5 errors, got ${buggyErrors.length}: ` +
+  6,
+  'expected the pre-fix shape (three discarded draftText results, the ' +
+    'missing same-item reentrancy guard, the missing manual-action-in-' +
+    'flight guard, and the unguarded artPrompt draft) to raise 6 errors, ' +
+    `got ${buggyErrors.length}: ` +
     JSON.stringify(buggyErrors),
 )
 assert.ok(
@@ -146,6 +148,13 @@ assert.ok(
     (e) => e.includes('generatingItemId') && e.includes('manual'),
   ),
   'expected a violation for the missing manual-action-in-flight guard',
+)
+assert.ok(
+  buggyErrors.some(
+    (e) => e.includes("'artPrompt'") && e.includes('promptDraft.trim()'),
+  ),
+  'expected a violation for the artPrompt draft not being gated behind ' +
+    '!item.promptDraft.trim()',
 )
 
 const fixedErrors = checkAutoBuildDraftGate(FIXED_FIXTURE)
@@ -191,6 +200,25 @@ assert.ok(
     noManualGuardErrors[0]!.includes('manual'),
 )
 
+const UNGATED_ARTPROMPT_FIXTURE = FIXED_FIXTURE.replace(
+  "if (wantArt && !item.promptDraft.trim()) {\n          const drafted = await draftText(itemId, 'artPrompt')",
+  "if (wantArt) {\n          const drafted = await draftText(itemId, 'artPrompt')",
+)
+const ungatedArtPromptErrors = checkAutoBuildDraftGate(
+  UNGATED_ARTPROMPT_FIXTURE,
+)
+assert.equal(
+  ungatedArtPromptErrors.length,
+  1,
+  'expected exactly one violation when the artPrompt draft is gated only ' +
+    `behind wantArt, not also !item.promptDraft.trim(), got ${ungatedArtPromptErrors.length}: ` +
+    JSON.stringify(ungatedArtPromptErrors),
+)
+assert.ok(
+  ungatedArtPromptErrors[0]!.includes("'artPrompt'") &&
+    ungatedArtPromptErrors[0]!.includes('promptDraft.trim()'),
+)
+
 const missingFnErrors = checkAutoBuildDraftGate(MISSING_FIXTURE)
 assert.equal(
   missingFnErrors.length,
@@ -201,6 +229,7 @@ assert.ok(missingFnErrors[0]!.includes('autoBuildItem'))
 
 console.log(
   'Model Builder auto-build gate checker verified: flags discarded draft ' +
-    'results and missing same-item reentrancy protection, clears the fixed shape, ' +
+    'results, missing same-item reentrancy protection, an artPrompt draft ' +
+    'not gated behind !item.promptDraft.trim(), clears the fixed shape, ' +
     'and flags autoBuildItem being absent entirely.',
 )

--- a/utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts
@@ -40,6 +40,21 @@
 // Both of these entry guards return 'skipped' (not 'failed') -- t-037 gave
 // autoBuildItem() a three-way outcome ('committed' | 'skipped' | 'failed') so
 // batchAutoBuild/autoBuildRun can tell "busy, try again" apart from "broken."
+//
+// Also asserts a third, unrelated guard (same task, later cycle still): the
+// function's own doc comment promises "draft what's empty," and the PITCH
+// branch honors that (`if (!item.pitch.trim())` before drafting), but the
+// artPrompt draftText call used to fire unconditionally whenever `wantArt`
+// was true -- regardless of whether item.promptDraft already held content.
+// promptDraft starts genuinely empty (unlike fieldsDraft, which is always
+// pre-filled with a non-empty defaultFieldsTemplate skeleton and so can't
+// use the same empty check), so a non-empty value there can only mean the
+// user already typed their own generation prompt via the "Generation
+// prompt" textarea before clicking Auto. Drafting over it unconditionally
+// silently discarded that hand-typed prompt for a fresh, unreviewed AI one
+// -- and generateItemAsset immediately renders art from it instead of what
+// the user wrote. Fixed by gating the artPrompt draft behind
+// `!item.promptDraft.trim()`, mirroring the PITCH branch.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -171,6 +186,33 @@ export function checkAutoBuildDraftGate(content: string): string[] {
           'model-builder-item-panel.vue refuses to allow.',
       )
     }
+  }
+
+  // artPrompt-specific: draftText(itemId, 'artPrompt') must be gated behind
+  // `!item.promptDraft.trim()` (immediately, not just "called somewhere in
+  // the function") -- see the doc comment above for why promptDraft (unlike
+  // fieldsDraft) is a reliable "did the user already type one?" signal.
+  // Anchored to `wantArt && !item.promptDraft.trim()` as one condition,
+  // mirroring the exact shape of the fix, rather than accepting the check
+  // anywhere in an enclosing scope -- a `wantArt`-only outer if with the
+  // promptDraft check missing must still fail.
+  const artPromptEmptyGuard =
+    /if \(\s*wantArt\s*&&\s*!item\.promptDraft\.trim\(\)\s*\)\s*\{[\s\S]{0,1200}?await draftText\(itemId, 'artPrompt'\)/.exec(
+      fn.body,
+    )
+  if (!artPromptEmptyGuard) {
+    errors.push(
+      `${FN_NAME}() calls await draftText(itemId, 'artPrompt') without ` +
+        'gating it behind `if (wantArt && !item.promptDraft.trim())`. ' +
+        'promptDraft starts genuinely empty (unlike fieldsDraft, which is ' +
+        'always pre-filled with a non-empty defaultFieldsTemplate skeleton), ' +
+        'so a non-empty value can only mean the user already typed their ' +
+        'own generation prompt via the "Generation prompt" textarea before ' +
+        'clicking Auto. Drafting over it unconditionally silently discards ' +
+        'that hand-typed prompt for a fresh, unreviewed AI one, and ' +
+        'generateItemAsset then renders art from it instead of what the ' +
+        'user wrote.',
+    )
   }
 
   return errors


### PR DESCRIPTION
## Failure scenario

`autoBuildItem()` walks an item through PITCH → FIELDS_AND_PROMPTS → GENERATE_ASSETS → COMMIT "with sensible defaults: draft what's empty" (its own doc comment). The PITCH branch honors that contract — it only calls `draftText(itemId, 'pitch')` when `item.pitch` is empty. The FIELDS_AND_PROMPTS branch's `artPrompt` draft did not: it called `draftText(itemId, 'artPrompt')` unconditionally whenever art generation was wanted, regardless of whether `item.promptDraft` already held content.

This is reachable through completely normal use:

1. User opens an item and types their own text into the "Generation prompt" textarea (`model-builder-item-panel.vue`), which persists via `updatePrompt` on `@change`.
2. Before clicking "Approve fields & prompts", the user clicks the item's "Auto" button (or "Auto-build group" / "Auto-build all") to have the rest finished automatically.
3. `autoBuildItem()` silently redrafts `artPrompt` via `/api/suggest`, discarding the user's prompt for a fresh, unreviewed AI one — then `generateItemAsset` immediately renders art from `item.promptDraft.trim() || item.pitch.trim()`, i.e. the AI draft, never what the user actually wrote.

## Fix

Gate the `artPrompt` draft behind `!item.promptDraft.trim()`, mirroring the PITCH branch exactly (`stores/modelBuilderStore.ts`).

`fieldsDraft` is deliberately left alone: it's always pre-filled with a non-empty `defaultFieldsTemplate` skeleton at run creation, so an emptiness check there could never fire and wouldn't reliably distinguish "still just the skeleton" from "the user typed real content" — unlike `promptDraft`, which starts genuinely empty.

Also extends `utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts` (+ its `.test.ts`) with a new textual-shape check that the `artPrompt` `draftText()` call stays gated behind `wantArt && !item.promptDraft.trim()`, so a regression back to the unconditional draft fails this guard.

## Verification

- `npx tsx utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts` — pass
- `npx tsx utils/scripts/verifyModelBuilderAutoBuildDraftGate.test.ts` — pass
- All other `utils/scripts/verifyModelBuilder*.ts` guards (11 total, unchanged) — all pass, confirming the exclusion-list bug classes from prior cycles are still fixed
- `npx eslint` on all 3 changed files — same 2 pre-existing `no-empty` errors in `modelBuilderStore.ts` (lines 203/210, unrelated `catch {}` blocks in `safeSet`/`safeRemove`), confirmed pre-existing via `git stash` against the pre-change baseline
- `npx prettier --check` on all 3 changed files — same pre-existing formatting drift in `modelBuilderStore.ts` confirmed via `git stash`; the two `utils/scripts` files I touched are prettier-clean; my own edited region in `modelBuilderStore.ts` is untouched by the pre-existing drift diff (verified by isolating a `prettier --write` diff and confirming none of the hunks fall in the edited lines)
- `npx vue-tsc --noEmit -p tsconfig.json` — pass, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0133aL6mBHeKo1qp6gkXUaxg)_