### PR TITLE
Give Brainstorm a modern structured generation engine

### DIFF
--- a/.github/workflows/brainstorm-generation-contract.yml
+++ b/.github/workflows/brainstorm-generation-contract.yml
@@ -1,0 +1,53 @@
+name: Brainstorm Generation Contract
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/brainstorm-generation-contract.yml'
+      - 'server/api/brainstorm/**'
+      - 'server/utils/brainstorm/**'
+      - 'server/utils/suggest/suggestProviders.ts'
+      - 'server/api/suggest.post.ts'
+      - 'types/brainstorm.ts'
+      - 'utils/scripts/verifyBrainstormGeneration.ts'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/brainstorm-generation-contract.yml'
+      - 'server/api/brainstorm/**'
+      - 'server/utils/brainstorm/**'
+      - 'server/utils/suggest/suggestProviders.ts'
+      - 'server/api/suggest.post.ts'
+      - 'types/brainstorm.ts'
+      - 'utils/scripts/verifyBrainstormGeneration.ts'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: brainstorm-generation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: Structured provider contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Verify Brainstorm generation contract
+        run: npx tsx utils/scripts/verifyBrainstormGeneration.ts

--- a/server/api/brainstorm/generate.post.ts
+++ b/server/api/brainstorm/generate.post.ts
@@ -1,0 +1,289 @@
+import {
+  createError,
+  defineEventHandler,
+  readBody,
+  setResponseStatus,
+} from 'h3'
+import type {
+  BrainstormGeneratePayload,
+  BrainstormGenerateRequest,
+  BrainstormReferenceCandidate,
+  BrainstormSourceRef,
+} from '../../../types/brainstorm'
+import {
+  BRAINSTORM_MAX_RESULTS,
+  BRAINSTORM_MIN_RESULTS,
+} from '../../../types/brainstorm'
+import { errorHandler } from '../../utils/error'
+import { manaGate } from '../../utils/manaGate'
+import { estimateTextCostUsd } from '../../utils/manaCost'
+import {
+  canReadServer,
+  readServerById,
+  requireAuthUser,
+} from '../../utils/serverApi'
+import {
+  deriveSuggestProvider,
+  resolveSuggestModel,
+  str,
+} from '../../utils/suggest/suggestProviders'
+import type { SuggestServerSnapshot } from '../../utils/suggest/suggestTypes'
+import { parseBrainstormProviderOutput } from '../../utils/brainstorm/brainstormParser'
+import { buildBrainstormPrompts } from '../../utils/brainstorm/brainstormPrompt'
+import {
+  brainstormProviderApiKey,
+  callBrainstormProvider,
+} from '../../utils/brainstorm/brainstormProvider'
+
+const MAX_PREMISE_LENGTH = 12_000
+const MAX_CONSTRAINT_LENGTH = 8_000
+const MAX_EXAMPLE_LENGTH = 4_000
+const MAX_EXAMPLES = 20
+const MAX_MODE_LENGTH = 80
+const MAX_FEEDBACK_LENGTH = 4_000
+
+function requiredText(value: unknown, label: string, maxLength: number): string {
+  const text = typeof value === 'string' ? value.trim() : ''
+  if (!text) {
+    throw createError({ statusCode: 400, message: `${label} is required.` })
+  }
+  if (text.length > maxLength) {
+    throw createError({
+      statusCode: 400,
+      message: `${label} must be ${maxLength} characters or fewer.`,
+    })
+  }
+  return text
+}
+
+function optionalText(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const text = value.trim()
+  if (!text) return undefined
+  return text.slice(0, maxLength)
+}
+
+function requestedCount(value: unknown): number {
+  const count = Number(value)
+  if (
+    !Number.isInteger(count) ||
+    count < BRAINSTORM_MIN_RESULTS ||
+    count > BRAINSTORM_MAX_RESULTS
+  ) {
+    throw createError({
+      statusCode: 400,
+      message: `count must be an integer from ${BRAINSTORM_MIN_RESULTS} to ${BRAINSTORM_MAX_RESULTS}.`,
+    })
+  }
+  return count
+}
+
+function normalizedExamples(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+
+  const seen = new Set<string>()
+  const result: string[] = []
+
+  for (const item of value.slice(0, MAX_EXAMPLES)) {
+    const example = optionalText(item, MAX_EXAMPLE_LENGTH)
+    if (!example || seen.has(example)) continue
+    seen.add(example)
+    result.push(example)
+  }
+
+  return result
+}
+
+function normalizedSource(value: unknown): BrainstormSourceRef | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  const modelType = optionalText(record.modelType, 80)
+  const id = Number(record.id)
+  const slug = optionalText(record.slug, 160)
+  const intent = optionalText(record.intent, 1_000)
+
+  if (!modelType) return null
+
+  return {
+    modelType,
+    ...(Number.isInteger(id) && id > 0 ? { id } : {}),
+    ...(slug ? { slug } : {}),
+    ...(intent ? { intent } : {}),
+  }
+}
+
+function normalizedReference(
+  value: unknown,
+): BrainstormReferenceCandidate | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  const text = optionalText(record.text, 8_000)
+  const title = optionalText(record.title, 120)
+
+  if (!text) return null
+  return {
+    text,
+    ...(title ? { title } : {}),
+  }
+}
+
+function normalizeRequest(body: BrainstormGeneratePayload): BrainstormGenerateRequest {
+  return {
+    premise: requiredText(body.premise, 'premise', MAX_PREMISE_LENGTH),
+    count: requestedCount(body.count),
+    constraints: optionalText(body.constraints, MAX_CONSTRAINT_LENGTH),
+    examples: normalizedExamples(body.examples),
+    mode: optionalText(body.mode, MAX_MODE_LENGTH) || 'freeform',
+    source: normalizedSource(body.source),
+    replaceCandidateId: optionalText(body.replaceCandidateId, 200) || null,
+    parentCandidateId: optionalText(body.parentCandidateId, 200) || null,
+    referenceCandidate: normalizedReference(body.referenceCandidate),
+    feedback: optionalText(body.feedback, MAX_FEEDBACK_LENGTH),
+  }
+}
+
+function requiredServerId(body: BrainstormGeneratePayload): number {
+  const id = Number(body.server?.id)
+  if (!Number.isInteger(id) || id <= 0) {
+    throw createError({
+      statusCode: 400,
+      message: 'A valid text server is required for Brainstorm generation.',
+    })
+  }
+  return id
+}
+
+function textCompatibleServer(server: {
+  category?: string | null
+  serverType?: string | null
+}): boolean {
+  const category = str(server.category).toLowerCase()
+  if (category) return category === 'text' || category === 'chat'
+
+  return ['TEXT', 'OPENAI', 'ANTHROPIC', 'OLLAMA', 'CUSTOM'].includes(
+    str(server.serverType).toUpperCase(),
+  )
+}
+
+function completionBudget(count: number): number {
+  return Math.min(6_000, Math.max(512, 256 + count * 180))
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const body = await readBody<BrainstormGeneratePayload>(event)
+    const request = normalizeRequest(body)
+    const serverId = requiredServerId(body)
+
+    // The browser may nominate a server id, but URLs, models, and credentials are
+    // always resolved from the canonical Server row to prevent arbitrary outbound
+    // requests or first-party secret forwarding.
+    const viewer = await requireAuthUser(event)
+    const server = await readServerById(serverId)
+
+    if (!canReadServer(server, viewer)) {
+      throw createError({
+        statusCode: 403,
+        message: 'You do not have access to the selected text server.',
+      })
+    }
+
+    if (!textCompatibleServer(server)) {
+      throw createError({
+        statusCode: 400,
+        message: 'The selected server is not configured for text generation.',
+      })
+    }
+
+    const serverSnapshot: SuggestServerSnapshot = {
+      id: server.id,
+      serverType: server.serverType,
+      baseUrl: server.baseUrl,
+      endpointPath: server.endpointPath,
+      model: server.model,
+    }
+    const provider = deriveSuggestProvider(serverSnapshot)
+    const model = resolveSuggestModel(provider, server.model)
+    const maxTokens = completionBudget(request.count)
+
+    const gate = await manaGate(event, {
+      kind: 'text',
+      estCostUsd: estimateTextCostUsd({ model, maxTokens }),
+      serverId: server.id,
+    })
+
+    const config = useRuntimeConfig()
+    const { systemPrompt, userPrompt } = buildBrainstormPrompts(request)
+
+    console.log('[brainstorm:generate]', {
+      provider,
+      model,
+      serverId: server.id,
+      count: request.count,
+      mode: request.mode,
+      replacement: Boolean(request.replaceCandidateId),
+      branch: Boolean(request.parentCandidateId),
+    })
+
+    const raw = await callBrainstormProvider(systemPrompt, userPrompt, {
+      provider,
+      model,
+      count: request.count,
+      maxTokens,
+      apiKey: brainstormProviderApiKey(provider, {
+        serverApiKey: server.apiKey,
+        anthropicApiKey: config.anthropicApiKey,
+        openaiApiKey: config.openaiApiKey,
+      }),
+      baseUrl:
+        provider === 'ollama'
+          ? str(server.baseUrl, str(config.ollamaBaseUrl, 'http://localhost:11434'))
+          : provider === 'openai_compatible'
+            ? str(server.baseUrl)
+            : undefined,
+      endpointPath:
+        provider === 'openai_compatible'
+          ? str(server.endpointPath, '/v1/chat/completions')
+          : undefined,
+    })
+
+    if (!raw.trim()) {
+      throw createError({
+        statusCode: 502,
+        message: 'The selected text server returned an empty Brainstorm response.',
+      })
+    }
+
+    const parsed = parseBrainstormProviderOutput(raw, request.count)
+    if (!parsed) {
+      throw createError({
+        statusCode: 502,
+        message:
+          'The selected text server returned an incomplete, duplicate, or malformed Brainstorm batch.',
+      })
+    }
+
+    const { balance } = await gate.commit(`brainstorm:${Date.now()}`)
+
+    return {
+      success: true,
+      message: `Generated ${parsed.candidates.length} Brainstorm candidate${parsed.candidates.length === 1 ? '' : 's'}.`,
+      data: parsed,
+      mana: {
+        balance,
+        charged: gate.cost,
+        free: gate.free,
+      },
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    setResponseStatus(event, handled.statusCode || 500)
+
+    return {
+      success: false,
+      message: handled.message || 'Brainstorm generation failed.',
+      statusCode: handled.statusCode || 500,
+      data: { candidates: [] },
+    }
+  }
+})

--- a/server/api/brainstorm/generate.post.ts
+++ b/server/api/brainstorm/generate.post.ts
@@ -27,7 +27,10 @@ import {
   resolveSuggestModel,
   str,
 } from '../../utils/suggest/suggestProviders'
-import type { SuggestServerSnapshot } from '../../utils/suggest/suggestTypes'
+import type {
+  SuggestProvider,
+  SuggestServerSnapshot,
+} from '../../utils/suggest/suggestTypes'
 import { parseBrainstormProviderOutput } from '../../utils/brainstorm/brainstormParser'
 import { buildBrainstormPrompts } from '../../utils/brainstorm/brainstormPrompt'
 import {
@@ -160,9 +163,69 @@ function textCompatibleServer(server: {
   const category = str(server.category).toLowerCase()
   if (category) return category === 'text' || category === 'chat'
 
-  return ['TEXT', 'OPENAI', 'ANTHROPIC', 'OLLAMA', 'CUSTOM'].includes(
+  return ['OPENAI', 'ANTHROPIC', 'OLLAMA', 'CUSTOM'].includes(
     str(server.serverType).toUpperCase(),
   )
+}
+
+function assertBackendProviderAccess(
+  provider: SuggestProvider,
+  server: {
+    accessMode?: string | null
+    baseUrl?: string | null
+    isPublic?: boolean
+    isOfficial?: boolean
+    isDefault?: boolean
+    label?: string | null
+    title?: string | null
+  },
+  viewer: { isAdmin?: boolean },
+): void {
+  // First-party providers use fixed trusted URLs in brainstormProvider and do
+  // not issue requests to Server.baseUrl.
+  if (provider === 'openai' || provider === 'anthropic') return
+
+  const accessMode = str(server.accessMode).toUpperCase()
+  if (['BROWSER', 'TAILSCALE', 'LOCAL'].includes(accessMode)) {
+    throw createError({
+      statusCode: 503,
+      message: `${server.label || server.title || 'The selected text server'} is configured for ${accessMode.toLowerCase()} access and cannot be called safely from the Brainstorm backend. Choose a backend/public text server.`,
+    })
+  }
+
+  // Non-admin users can create private Server rows. Those rows must not turn a
+  // backend generation route into an arbitrary URL fetch primitive. Public,
+  // official, and default rows are admin-controlled configuration.
+  if (
+    !viewer.isAdmin &&
+    !server.isPublic &&
+    !server.isOfficial &&
+    !server.isDefault
+  ) {
+    throw createError({
+      statusCode: 403,
+      message:
+        'Private custom text servers are not callable from the Brainstorm backend. Use an approved backend/public server.',
+    })
+  }
+
+  const baseUrl = str(server.baseUrl)
+  let url: URL
+  try {
+    url = new URL(baseUrl)
+  } catch {
+    throw createError({
+      statusCode: 400,
+      message: 'The selected text server does not have a valid URL.',
+    })
+  }
+
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw createError({
+      statusCode: 400,
+      message: 'Brainstorm text servers must use HTTP or HTTPS.',
+    })
+  }
 }
 
 function completionBudget(count: number): number {
@@ -203,6 +266,8 @@ export default defineEventHandler(async (event) => {
       model: server.model,
     }
     const provider = deriveSuggestProvider(serverSnapshot)
+    assertBackendProviderAccess(provider, server, viewer)
+
     const model = resolveSuggestModel(provider, server.model)
     const maxTokens = completionBudget(request.count)
 

--- a/server/api/suggest.post.ts
+++ b/server/api/suggest.post.ts
@@ -118,7 +118,9 @@ export default defineEventHandler(async (event) => {
       apiKey:
         provider === 'anthropic'
           ? str(config.anthropicApiKey)
-          : str(config.openaiApiKey),
+          : provider === 'openai'
+            ? str(config.openaiApiKey)
+            : undefined,
       baseUrl:
         provider === 'ollama'
           ? str(

--- a/server/utils/brainstorm/brainstormParser.ts
+++ b/server/utils/brainstorm/brainstormParser.ts
@@ -1,0 +1,159 @@
+import type {
+  BrainstormGenerateData,
+  BrainstormGeneratedCandidate,
+} from '../../../types/brainstorm'
+
+const MAX_TITLE_LENGTH = 120
+const MAX_TEXT_LENGTH = 4_000
+
+function trimFence(value: string): string {
+  const trimmed = value.trim()
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i)
+  return fenced?.[1]?.trim() || trimmed
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value)
+  } catch {
+    return null
+  }
+}
+
+function parseEmbeddedJson(value: string): unknown {
+  const direct = parseJson(trimFence(value))
+  if (direct !== null) return direct
+
+  const objectStart = value.indexOf('{')
+  const objectEnd = value.lastIndexOf('}')
+  if (objectStart >= 0 && objectEnd > objectStart) {
+    const objectValue = parseJson(value.slice(objectStart, objectEnd + 1))
+    if (objectValue !== null) return objectValue
+  }
+
+  const arrayStart = value.indexOf('[')
+  const arrayEnd = value.lastIndexOf(']')
+  if (arrayStart >= 0 && arrayEnd > arrayStart) {
+    const arrayValue = parseJson(value.slice(arrayStart, arrayEnd + 1))
+    if (arrayValue !== null) return arrayValue
+  }
+
+  return null
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+function candidateArray(value: unknown): unknown[] | null {
+  if (Array.isArray(value)) return value
+
+  const record = asRecord(value)
+  if (!record) return null
+
+  for (const key of ['candidates', 'ideas', 'results']) {
+    if (Array.isArray(record[key])) return record[key]
+  }
+
+  const data = asRecord(record.data)
+  if (data) {
+    for (const key of ['candidates', 'ideas', 'results']) {
+      if (Array.isArray(data[key])) return data[key]
+    }
+  }
+
+  return null
+}
+
+function candidateText(record: Record<string, unknown>): string {
+  for (const key of ['text', 'pitch', 'idea', 'content']) {
+    if (typeof record[key] === 'string' && record[key].trim()) {
+      return record[key].trim().slice(0, MAX_TEXT_LENGTH)
+    }
+  }
+  return ''
+}
+
+function candidateTitle(record: Record<string, unknown>): string {
+  if (typeof record.title !== 'string') return ''
+  return record.title.trim().slice(0, MAX_TITLE_LENGTH)
+}
+
+function duplicateKey(value: string): string {
+  return value
+    .toLocaleLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function wordSet(value: string): Set<string> {
+  return new Set(
+    duplicateKey(value)
+      .split(' ')
+      .filter((word) => word.length > 2),
+  )
+}
+
+function nearDuplicate(a: string, b: string): boolean {
+  const aKey = duplicateKey(a)
+  const bKey = duplicateKey(b)
+  if (!aKey || !bKey) return false
+  if (aKey === bKey) return true
+
+  const aWords = wordSet(a)
+  const bWords = wordSet(b)
+  if (aWords.size < 5 || bWords.size < 5) return false
+
+  let intersection = 0
+  for (const word of aWords) {
+    if (bWords.has(word)) intersection += 1
+  }
+
+  const union = new Set([...aWords, ...bWords]).size
+  return union > 0 && intersection / union >= 0.88
+}
+
+export function normalizeBrainstormCandidates(
+  value: unknown,
+  expectedCount: number,
+): BrainstormGeneratedCandidate[] | null {
+  const rawCandidates = candidateArray(value)
+  if (!rawCandidates || rawCandidates.length !== expectedCount) return null
+
+  const candidates: BrainstormGeneratedCandidate[] = []
+
+  for (const rawCandidate of rawCandidates) {
+    const record = asRecord(rawCandidate)
+    if (!record) return null
+
+    const text = candidateText(record)
+    if (!text) return null
+
+    if (candidates.some((candidate) => nearDuplicate(candidate.text, text))) {
+      return null
+    }
+
+    const title = candidateTitle(record)
+    candidates.push({
+      text,
+      ...(title ? { title } : {}),
+    })
+  }
+
+  return candidates
+}
+
+export function parseBrainstormProviderOutput(
+  raw: string,
+  expectedCount: number,
+): BrainstormGenerateData | null {
+  if (!raw.trim()) return null
+
+  const parsed = parseEmbeddedJson(raw)
+  if (parsed === null) return null
+
+  const candidates = normalizeBrainstormCandidates(parsed, expectedCount)
+  return candidates ? { candidates } : null
+}

--- a/server/utils/brainstorm/brainstormPrompt.ts
+++ b/server/utils/brainstorm/brainstormPrompt.ts
@@ -1,0 +1,118 @@
+import type { BrainstormGenerateRequest } from '../../../types/brainstorm'
+
+export type BrainstormPrompts = {
+  systemPrompt: string
+  userPrompt: string
+}
+
+function compactExamples(examples: string[] | undefined): string[] {
+  return (examples || [])
+    .map((example) => example.trim())
+    .filter(Boolean)
+    .slice(0, 12)
+}
+
+export function buildBrainstormPrompts(
+  request: BrainstormGenerateRequest,
+): BrainstormPrompts {
+  const systemPrompt = [
+    'You are Brainstorm, a creative divergence engine for humans.',
+    'Your job is to enlarge the human idea-space, not replace human taste with polished machine filler.',
+    '',
+    'QUALITY BAR',
+    '- Attack the actual premise. Do not merely free-associate around its nouns.',
+    '- Make candidates conceptually different from one another. Change the mechanism, angle, implication, relationship, escalation, structure, or point of view, not just adjectives and nouns.',
+    '- Prefer specific, generative ideas a human can develop, combine, reject, or mutate.',
+    '- Include non-obvious angles. At least some candidates should make the user think “I would not have immediately written that.”',
+    '- Understand comic premise and escalation when humor is requested. Random weird nouns are not a substitute for a joke.',
+    '- Do not confuse safe with bland. When allowed by ordinary safety boundaries, dark humor, gallows humor, cartoon peril, sarcasm, absurdity, strangeness, horror, seriousness, and moral ambiguity may all be useful creative material.',
+    '- Avoid stock LLM habits: corporate naming sludge, fake profundity, generic inspiration, symmetrical filler, repetitive sentence templates, and explanations longer than the idea.',
+    '- Respect explicit user constraints precisely.',
+    '- Leave room for human development. Do not over-finish every seed into marketing copy.',
+    '',
+    'OUTPUT CONTRACT',
+    '- Return JSON only. No markdown fence, introduction, numbering, commentary, apology, or wrap-up.',
+    '- Return one object with a "candidates" array.',
+    '- Every candidate must contain a short "title" and a useful "text" field.',
+    '- Return exactly the requested candidate count.',
+  ].join('\n')
+
+  const examples = compactExamples(request.examples)
+  const lines = [
+    `Premise: ${request.premise.trim()}`,
+    `Generate exactly ${request.count} distinct candidate${request.count === 1 ? '' : 's'}.`,
+  ]
+
+  if (request.constraints?.trim()) {
+    lines.push(`Constraints: ${request.constraints.trim()}`)
+  }
+
+  if (request.mode?.trim() && request.mode !== 'freeform') {
+    lines.push(`Creative direction: ${request.mode.trim()}`)
+  }
+
+  if (examples.length) {
+    lines.push(
+      'User examples or target references (use as context, not a template to mechanically repeat):',
+      ...examples.map((example, index) => `${index + 1}. ${example}`),
+    )
+  }
+
+  if (request.referenceCandidate?.text?.trim()) {
+    const reference = request.referenceCandidate
+    lines.push(
+      '',
+      request.parentCandidateId
+        ? 'Branching task: generate a new idea that preserves what is promising about this candidate while changing enough of the concept to be independently useful.'
+        : 'Replacement task: replace this candidate with a materially different idea that still serves the original premise.',
+      `Reference candidate: ${reference.title?.trim() ? `${reference.title.trim()}: ` : ''}${reference.text.trim()}`,
+    )
+
+    if (request.feedback?.trim()) {
+      lines.push(`Human feedback on the reference: ${request.feedback.trim()}`)
+    }
+  }
+
+  lines.push(
+    '',
+    'Before answering, silently compare the candidates against each other and replace obvious paraphrases or repeated mechanisms.',
+    'Return only: {"candidates":[{"title":"...","text":"..."}]}',
+  )
+
+  return {
+    systemPrompt,
+    userPrompt: lines.join('\n'),
+  }
+}
+
+export function brainstormJsonSchema(count: number): Record<string, unknown> {
+  return {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      candidates: {
+        type: 'array',
+        minItems: count,
+        maxItems: count,
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            title: {
+              type: 'string',
+              minLength: 1,
+              maxLength: 120,
+            },
+            text: {
+              type: 'string',
+              minLength: 1,
+              maxLength: 4000,
+            },
+          },
+          required: ['title', 'text'],
+        },
+      },
+    },
+    required: ['candidates'],
+  }
+}

--- a/server/utils/brainstorm/brainstormProvider.ts
+++ b/server/utils/brainstorm/brainstormProvider.ts
@@ -1,0 +1,123 @@
+import { createError } from 'h3'
+import {
+  callSuggestProvider,
+  str,
+} from '../suggest/suggestProviders'
+import type {
+  SuggestProvider,
+  SuggestProviderOptions,
+} from '../suggest/suggestTypes'
+import { brainstormJsonSchema } from './brainstormPrompt'
+
+export type BrainstormProviderOptions = SuggestProviderOptions & {
+  count: number
+}
+
+function extractOpenAIResponseText(responseData: unknown): string {
+  if (!responseData || typeof responseData !== 'object') return ''
+
+  const record = responseData as {
+    output_text?: string
+    output?: Array<{
+      content?: Array<{
+        text?: string
+      }>
+    }>
+  }
+
+  if (record.output_text?.trim()) return record.output_text.trim()
+
+  return (
+    record.output
+      ?.flatMap(
+        (item) => item.content?.map((content) => content.text || '') || [],
+      )
+      .join('')
+      .trim() || ''
+  )
+}
+
+async function callOfficialOpenAI(
+  systemPrompt: string,
+  userPrompt: string,
+  options: BrainstormProviderOptions,
+): Promise<string> {
+  if (!options.apiKey) {
+    throw createError({
+      statusCode: 500,
+      message: 'OpenAI API key is not configured.',
+    })
+  }
+
+  const response = await fetch('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${options.apiKey}`,
+    },
+    body: JSON.stringify({
+      model: options.model,
+      input: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userPrompt },
+      ],
+      max_output_tokens: options.maxTokens ?? 1200,
+      text: {
+        format: {
+          type: 'json_schema',
+          name: 'brainstorm_candidates',
+          strict: true,
+          schema: brainstormJsonSchema(options.count),
+        },
+      },
+    }),
+  })
+
+  if (!response.ok) {
+    const details = (await response.text()).slice(0, 1200)
+    throw createError({
+      statusCode: response.status,
+      message: `OpenAI Brainstorm request failed: ${details || response.statusText}`,
+    })
+  }
+
+  return extractOpenAIResponseText(await response.json())
+}
+
+export async function callBrainstormProvider(
+  systemPrompt: string,
+  userPrompt: string,
+  options: BrainstormProviderOptions,
+): Promise<string> {
+  if (options.provider === 'openai') {
+    return callOfficialOpenAI(systemPrompt, userPrompt, options)
+  }
+
+  return callSuggestProvider(systemPrompt, userPrompt, {
+    provider: options.provider,
+    model: options.model,
+    maxTokens: options.maxTokens,
+    apiKey: options.apiKey,
+    baseUrl: options.baseUrl,
+    endpointPath: options.endpointPath,
+  })
+}
+
+export function brainstormProviderApiKey(
+  provider: SuggestProvider,
+  config: {
+    anthropicApiKey?: unknown
+    openaiApiKey?: unknown
+  },
+): string | undefined {
+  if (provider === 'anthropic') {
+    return str(config.anthropicApiKey) || undefined
+  }
+
+  if (provider === 'openai') {
+    return str(config.openaiApiKey) || undefined
+  }
+
+  // Never forward first-party provider secrets to an arbitrary compatible URL.
+  return undefined
+}

--- a/server/utils/brainstorm/brainstormProvider.ts
+++ b/server/utils/brainstorm/brainstormProvider.ts
@@ -105,19 +105,26 @@ export async function callBrainstormProvider(
 
 export function brainstormProviderApiKey(
   provider: SuggestProvider,
-  config: {
+  input: {
+    serverApiKey?: unknown
     anthropicApiKey?: unknown
     openaiApiKey?: unknown
   },
 ): string | undefined {
+  const serverApiKey = str(input.serverApiKey)
+
   if (provider === 'anthropic') {
-    return str(config.anthropicApiKey) || undefined
+    return serverApiKey || str(input.anthropicApiKey) || undefined
   }
 
   if (provider === 'openai') {
-    return str(config.openaiApiKey) || undefined
+    return serverApiKey || str(input.openaiApiKey) || undefined
   }
 
-  // Never forward first-party provider secrets to an arbitrary compatible URL.
+  if (provider === 'openai_compatible') {
+    // Only the canonical Server record may supply a secret for an arbitrary URL.
+    return serverApiKey || undefined
+  }
+
   return undefined
 }

--- a/server/utils/suggest/suggestProviders.ts
+++ b/server/utils/suggest/suggestProviders.ts
@@ -20,19 +20,19 @@ export function deriveSuggestProvider(
   const url = str(server.baseUrl).toLowerCase()
   const type = str(server.serverType).toUpperCase()
 
-  if (url.includes('anthropic.com')) return 'anthropic'
+  if (url.includes('anthropic.com') || type === 'ANTHROPIC') return 'anthropic'
   if (url.includes('openai.com')) return 'openai'
   if (
     url.includes('localhost') ||
     url.includes('127.0.0.1') ||
-    url.includes('ollama')
+    url.includes('ollama') ||
+    type === 'OLLAMA'
   ) {
     return 'ollama'
   }
 
-  if (type === 'OPENAI' || type === 'CUSTOM') {
-    return 'openai_compatible'
-  }
+  if (type === 'OPENAI') return url ? 'openai_compatible' : 'openai'
+  if (type === 'CUSTOM') return 'openai_compatible'
 
   return 'anthropic'
 }
@@ -100,7 +100,7 @@ async function callOpenAI(
   userPrompt: string,
   options: SuggestProviderOptions,
 ): Promise<string> {
-  if (!options.apiKey) {
+  if (options.provider === 'openai' && !options.apiKey) {
     throw createError({
       statusCode: 500,
       statusMessage: 'openaiApiKey not configured',
@@ -117,7 +117,9 @@ async function callOpenAI(
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${options.apiKey}`,
+      ...(options.apiKey
+        ? { Authorization: `Bearer ${options.apiKey}` }
+        : {}),
     },
     body: JSON.stringify({
       model: options.model,

--- a/utils/scripts/verifyBrainstormGeneration.ts
+++ b/utils/scripts/verifyBrainstormGeneration.ts
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import {
+  normalizeBrainstormCandidates,
+  parseBrainstormProviderOutput,
+} from '../../server/utils/brainstorm/brainstormParser'
+import { buildBrainstormPrompts } from '../../server/utils/brainstorm/brainstormPrompt'
+import { deriveSuggestProvider } from '../../server/utils/suggest/suggestProviders'
+
+const direct = parseBrainstormProviderOutput(
+  JSON.stringify({
+    candidates: [
+      { title: 'Glass Choir', text: 'A choir performs with sugar-glass mouths that shatter on the high notes.' },
+      { title: 'Borrowed Shadows', text: 'People rent better shadows for important social occasions.' },
+    ],
+  }),
+  2,
+)
+assert.equal(direct?.candidates.length, 2)
+assert.equal(direct?.candidates[0]?.title, 'Glass Choir')
+
+const fencedLegacy = parseBrainstormProviderOutput(
+  '```json\n{"ideas":[{"title":"A","pitch":"First mechanism."},{"title":"B","pitch":"Second mechanism."}]}\n```',
+  2,
+)
+assert.deepEqual(
+  fencedLegacy?.candidates.map((candidate) => candidate.text),
+  ['First mechanism.', 'Second mechanism.'],
+)
+
+const wrapped = parseBrainstormProviderOutput(
+  'Here is the JSON you requested: {"candidates":[{"title":"A","text":"One clear concept."}]} Thanks!',
+  1,
+)
+assert.equal(wrapped?.candidates[0]?.text, 'One clear concept.')
+
+const arrayOnly = parseBrainstormProviderOutput(
+  '[{"title":"A","text":"Array output remains structured."}]',
+  1,
+)
+assert.equal(arrayOnly?.candidates.length, 1)
+
+assert.equal(
+  normalizeBrainstormCandidates(
+    {
+      candidates: [
+        { title: 'A', text: 'Exactly the same idea.' },
+        { title: 'B', text: 'Exactly the same idea!' },
+      ],
+    },
+    2,
+  ),
+  null,
+  'punctuation-only duplicates must be rejected',
+)
+
+assert.equal(
+  parseBrainstormProviderOutput(
+    '{"candidates":[{"title":"Only","text":"Only one candidate."}]}',
+    2,
+  ),
+  null,
+  'short batches must be rejected',
+)
+
+assert.equal(
+  parseBrainstormProviderOutput('- Idea one\n- Idea two\n- Idea three', 3),
+  null,
+  'Brainstorm must never fall back to prose-line parsing',
+)
+
+const prompts = buildBrainstormPrompts({
+  premise: 'Invent terrible ice cream flavors',
+  count: 8,
+  constraints: 'They should have an actual comic premise.',
+  examples: ['Pralines and Glass'],
+  mode: 'freeform',
+  source: null,
+})
+assert.match(prompts.systemPrompt, /Do not confuse safe with bland/i)
+assert.match(prompts.systemPrompt, /Random weird nouns are not a substitute for a joke/i)
+assert.match(prompts.systemPrompt, /corporate naming sludge/i)
+assert.match(prompts.userPrompt, /Pralines and Glass/)
+assert.doesNotMatch(prompts.systemPrompt, /Haunted Fitness Tracker|Misfortune Cookies/i)
+assert.doesNotMatch(prompts.userPrompt, /Haunted Fitness Tracker|Misfortune Cookies/i)
+
+const replacement = buildBrainstormPrompts({
+  premise: 'Invent stage deaths for a cartoonish improv game',
+  count: 1,
+  mode: 'freeform',
+  source: null,
+  replaceCandidateId: 'candidate-1',
+  referenceCandidate: {
+    title: 'Weak idea',
+    text: 'A piano falls on somebody.',
+  },
+  feedback: 'Too familiar. Find a stranger mechanism.',
+})
+assert.match(replacement.userPrompt, /Replacement task:/)
+assert.match(replacement.userPrompt, /Too familiar\. Find a stranger mechanism\./)
+
+const branch = buildBrainstormPrompts({
+  premise: 'Invent stage deaths for a cartoonish improv game',
+  count: 1,
+  mode: 'freeform',
+  source: null,
+  parentCandidateId: 'candidate-1',
+  referenceCandidate: {
+    title: 'Useful idea',
+    text: 'A character is slowly laminated during an argument.',
+  },
+})
+assert.match(branch.userPrompt, /Branching task:/)
+
+assert.equal(deriveSuggestProvider({ serverType: 'OPENAI' }), 'openai')
+assert.equal(deriveSuggestProvider({ serverType: 'ANTHROPIC' }), 'anthropic')
+assert.equal(deriveSuggestProvider({ serverType: 'OLLAMA' }), 'ollama')
+assert.equal(deriveSuggestProvider({ serverType: 'CUSTOM' }), 'openai_compatible')
+assert.equal(
+  deriveSuggestProvider({
+    serverType: 'OPENAI',
+    baseUrl: 'https://api.openai.com',
+  }),
+  'openai',
+)
+
+const endpoint = readFileSync(
+  resolve(process.cwd(), 'server/api/brainstorm/generate.post.ts'),
+  'utf8',
+)
+assert.match(endpoint, /readServerById\(serverId\)/)
+assert.match(endpoint, /canReadServer\(server, viewer\)/)
+assert.match(endpoint, /manaGate\(event/)
+assert.match(endpoint, /parseBrainstormProviderOutput\(raw, request\.count\)/)
+assert.match(endpoint, /errorHandler\(error\)/)
+assert.doesNotMatch(endpoint, /body\.server\?\.baseUrl/)
+assert.doesNotMatch(endpoint, /body\.server\?\.endpointPath/)
+
+const suggestEndpoint = readFileSync(
+  resolve(process.cwd(), 'server/api/suggest.post.ts'),
+  'utf8',
+)
+assert.match(
+  suggestEndpoint,
+  /provider === 'openai'[\s\S]*?str\(config\.openaiApiKey\)[\s\S]*?: undefined/,
+  'first-party OpenAI keys must not fall through to arbitrary compatible URLs',
+)
+
+console.log('Brainstorm generation contract passed.')

--- a/utils/scripts/verifyBrainstormGeneration.ts
+++ b/utils/scripts/verifyBrainstormGeneration.ts
@@ -6,6 +6,7 @@ import {
   parseBrainstormProviderOutput,
 } from '../../server/utils/brainstorm/brainstormParser'
 import { buildBrainstormPrompts } from '../../server/utils/brainstorm/brainstormPrompt'
+import { brainstormProviderApiKey } from '../../server/utils/brainstorm/brainstormProvider'
 import { deriveSuggestProvider } from '../../server/utils/suggest/suggestProviders'
 
 const direct = parseBrainstormProviderOutput(
@@ -124,6 +125,39 @@ assert.equal(
   }),
   'openai',
 )
+assert.equal(
+  deriveSuggestProvider({
+    serverType: 'OPENAI',
+    baseUrl: 'https://example.test/v1',
+  }),
+  'openai_compatible',
+)
+
+assert.equal(
+  brainstormProviderApiKey('openai', {
+    serverApiKey: 'server-openai',
+    openaiApiKey: 'runtime-openai',
+  }),
+  'server-openai',
+)
+assert.equal(
+  brainstormProviderApiKey('openai', { openaiApiKey: 'runtime-openai' }),
+  'runtime-openai',
+)
+assert.equal(
+  brainstormProviderApiKey('openai_compatible', {
+    serverApiKey: 'custom-secret',
+    openaiApiKey: 'runtime-openai',
+  }),
+  'custom-secret',
+)
+assert.equal(
+  brainstormProviderApiKey('openai_compatible', {
+    openaiApiKey: 'runtime-openai',
+  }),
+  undefined,
+  'first-party OpenAI credentials must never be forwarded to a compatible URL',
+)
 
 const endpoint = readFileSync(
   resolve(process.cwd(), 'server/api/brainstorm/generate.post.ts'),
@@ -131,6 +165,9 @@ const endpoint = readFileSync(
 )
 assert.match(endpoint, /readServerById\(serverId\)/)
 assert.match(endpoint, /canReadServer\(server, viewer\)/)
+assert.match(endpoint, /assertBackendProviderAccess\(provider, server, viewer\)/)
+assert.match(endpoint, /\['BROWSER', 'TAILSCALE', 'LOCAL'\]/)
+assert.match(endpoint, /!server\.isPublic &&[\s\S]*?!server\.isOfficial &&[\s\S]*?!server\.isDefault/)
 assert.match(endpoint, /manaGate\(event/)
 assert.match(endpoint, /parseBrainstormProviderOutput\(raw, request\.count\)/)
 assert.match(endpoint, /errorHandler\(error\)/)


### PR DESCRIPTION
## What changed

This implements Conductor `brainstorm/t-006`, the text-generation engine behind the restored Brainstorm workbench.

- adds `POST /api/brainstorm/generate` with validated premise/count/constraints/examples, canonical Server-row resolution, auth/access checks, mana gating, and the standard success/error response shape;
- keeps structured candidates end-to-end instead of flattening them to prose and reparsing in Vue;
- official OpenAI uses the Responses API with strict JSON Schema and exact candidate count;
- Anthropic, Ollama, and OpenAI-compatible servers reuse the current provider caller, with all responses normalized through one JSON-only Brainstorm parser;
- rejects empty, malformed, short-count, exact-duplicate, and strong near-duplicate batches before charging mana;
- adds a modern creative-quality prompt that explicitly pushes conceptual diversity, specificity, comic premise/escalation, non-obvious angles, and the rule **do not confuse safe with bland**;
- historical canned Brainstorm examples are deliberately absent. User-supplied examples are context, not product-wide few-shot targets;
- replacement and branch requests carry the chosen candidate plus human feedback without erasing the original client-side revision history;
- browser-provided server URLs/models/credentials are ignored. The endpoint resolves the nominated Server ID from the database and honors its access mode;
- browser/local/Tailscale custom servers are not falsely fetched from the backend, and non-admin private custom rows cannot become arbitrary backend fetch targets;
- hardens shared OpenAI-compatible handling so compatible/local servers do not need a fake OpenAI key and the real first-party OpenAI key is never forwarded to arbitrary compatible URLs.

## Provider boundary

The existing chat stack has good canonical Server plumbing, but its current generic text completion assumes an OpenAI-style request body and its text resolver excludes Ollama. Brainstorm therefore reuses the existing explicit multi-provider caller for Anthropic/OpenAI-compatible/Ollama, while resolving all Server configuration server-side and keeping OpenAI's native strict-schema path where it materially improves reliability.

## Tests / ratchets

Adds `verifyBrainstormGeneration.ts` and a dedicated Brainstorm Generation Contract workflow covering:
- JSON/fenced/wrapped structured parsing;
- no prose-line fallback;
- exact result count;
- duplicate rejection;
- modern creative prompt requirements using `Pralines and Glass` as user-provided context;
- absence of historical canned examples;
- replacement/branch prompting;
- provider derivation;
- credential isolation for compatible servers;
- canonical Server resolution and transport/access guards.

## Deliberate limits

Entity source context is accepted as typed metadata but is not yet serialized into provider prompts; server-side Character/Dream/etc. context resolution remains `t-012`. This PR does not add persistence, art generation, or user-facing workbench controls.
