### PR TITLE
test(model-builder): enforce omitted guard contracts

### DIFF
--- a/utils/scripts/verifyModelBuilderRunWritableGuard.ts
+++ b/utils/scripts/verifyModelBuilderRunWritableGuard.ts
@@ -27,9 +27,20 @@
 // bug shape, mirroring verifyModelBuilderItemPatchStageGuard.ts's and
 // verifyModelBuilderCommitCancelledRunGuard.ts's preference for explicit,
 // narrow textual checks over a general-purpose static analyzer.
+//
+// This script is already wired into the required Contract Tests workflow. Two
+// sibling Model Builder guard scripts were callable from package.json but never
+// wired into that required job, which meant they could silently regress without
+// blocking a PR. Until the workflow is reorganized, this required entry point
+// also executes those two existing guards so the approved-asset and item-patch
+// stage invariants are enforced by required CI rather than living as dormant
+// npm scripts.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+
+import { checkApprovedAssetGuard } from './verifyModelBuilderApprovedAssetGuard.js'
+import { checkItemPatchStageGuard } from './verifyModelBuilderItemPatchStageGuard.js'
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url))
 const repositoryRoot = resolve(scriptDirectory, '../..')
@@ -114,18 +125,30 @@ function main(): void {
     allErrors.push(...checkRunWritableGuard(content, route))
   }
 
+  const storeContent = readFileSync(
+    join(repositoryRoot, 'stores/modelBuilderStore.ts'),
+    'utf8',
+  )
+  allErrors.push(...checkApprovedAssetGuard(storeContent))
+
+  const runsIndexContent = readFileSync(
+    join(repositoryRoot, 'server/api/model-builder/runs/index.ts'),
+    'utf8',
+  )
+  allErrors.push(...checkItemPatchStageGuard(runsIndexContent))
+
   if (allErrors.length) {
-    console.error('Model Builder run-writable guard contract failed:')
+    console.error('Model Builder required guard contracts failed:')
     for (const error of allErrors) console.error(`- ${error}`)
     process.exitCode = 1
     return
   }
 
   console.log(
-    'Model Builder run-writable guard contract passed: all four ' +
-      'write-capable item routes (item patch, batch patch, artifact post, ' +
-      'commit post) call assertRunWritable() immediately after ' +
-      'assertRunAccess(), refusing writes once a run is CANCELLED.',
+    'Model Builder required guard contracts passed: all four write-capable ' +
+      'item routes refuse writes to CANCELLED runs, finished renders cannot ' +
+      'replace already-approved assets, and item PATCH writes cannot bypass ' +
+      'server-stored stage review gates.',
   )
 }
 


### PR DESCRIPTION
### Task
model-builder/t-029: recurring Model Builder polish / regression hardening (kind: software)

### What changed / what I produced
- Confirmed two existing Model Builder regression guards (`verifyModelBuilderApprovedAssetGuard.ts` and `verifyModelBuilderItemPatchStageGuard.ts`) had package scripts but were not enforced by the required Contract Tests workflow.
- Extended the already-required Model Builder run-writable guard entry point to execute those two sibling contracts against their canonical sources as well.
- Keeps the change to one existing verifier file; no runtime/model/database behavior changes.

### How I verified
- Read the current required Contract Tests workflow and package scripts from `main`; the two sibling scripts are callable but absent from the required job.
- Compared this branch to current `main`: exactly one verifier file changed, 28 additions / 5 deletions.
- PR CI on this exact head is the merge gate; in particular Contract Tests must exercise the aggregated guard entry point successfully.

### Stakes
reversible

### Flags for Reviewer
- The direct workflow-edit version of this fix would require replacing a large workflow file through the connector contents API. Rather than risk a large byte-for-byte rewrite for a four-step insertion, this small change makes the existing required Model Builder guard step aggregate the two previously-dormant invariants. A later workflow reorganization can split the step names without losing enforcement.

### Kaizen suggestion
Add a tiny contract asserting every `test:model-builder-*-guard` package script is reachable from the required Contract Tests job, directly or through the declared aggregate entry point, so future guard scripts cannot become dormant again.
