### PR TITLE
test(storybook): add object-entry links contract for Facet/Reward -&gt; Storybook

### DIFF
--- a/.github/workflows/storybook-object-entry-links-contract.yml
+++ b/.github/workflows/storybook-object-entry-links-contract.yml
@@ -1,0 +1,30 @@
+name: Storybook Object-Entry Links Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: storybook-object-entry-links-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Facet/Reward -> Storybook object-entry contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify Storybook object-entry links
+        run: node utils/scripts/verifyStorybookObjectEntryLinks.mjs

--- a/utils/scripts/verifyStorybookObjectEntryLinks.mjs
+++ b/utils/scripts/verifyStorybookObjectEntryLinks.mjs
@@ -1,0 +1,68 @@
+// /utils/scripts/verifyStorybookObjectEntryLinks.mjs
+//
+// Reviewer kaizen from kind_robots PR #1706 (conductor storybook/t-017): CI
+// caught layout and router-shape regressions during that review, but nothing
+// directly asserted the user-facing handoff itself -- that a Facet or Reward
+// detail surface can actually start a Storybook story seeded with that
+// object. This contract closes that gap.
+//
+// Deliberately narrow: it checks that the CTA's click handler exists and
+// performs the navigation with the object's slug threaded through the right
+// query key, and that Storybook's own seedFromQuery() still consumes that
+// key into the matching setup-draft list. It does NOT assert button classes,
+// icon names, or layout -- a restyle of the CTA must not fail this check.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+function source(path) {
+  return readFileSync(resolve(process.cwd(), path), 'utf8')
+}
+
+function includesAll(path, values) {
+  const contents = source(path)
+  for (const value of values) {
+    assert.ok(contents.includes(value), `${path} must include ${value}`)
+  }
+}
+
+const facetProfilePath = 'components/facets/facet-profile.vue'
+const rewardEncounterPath = 'components/rewards/reward-encounter.vue'
+const storybookPagePath = 'components/conductor/storybook-page.vue'
+
+// Facet detail surface: some element must wire a click to a handler that
+// navigates to Storybook carrying the selected Facet's slug through ?facet=.
+// The handler name and navigateTo call are asserted; the button/icon markup
+// around it is not.
+includesAll(facetProfilePath, [
+  'startStoryWithFacet',
+  '@click="startStoryWithFacet"',
+  "path: '/storybook'",
+  'query: { facet: selectedFacet.value.slug }',
+])
+
+// Reward encounter surface: same shape, through ?reward=.
+includesAll(rewardEncounterPath, [
+  'startStoryWithReward',
+  '@click="startStoryWithReward"',
+  "path: '/storybook'",
+  'query: { reward: slug }',
+])
+
+// Storybook itself must still consume both seed keys into the matching
+// setup-draft ingredient lists, on top of (not instead of) a restored draft.
+includesAll(storybookPagePath, [
+  'function seedFromQuery',
+  'seedFromQuery()',
+  'route.query.facet',
+  'route.query.reward',
+  'draft.facetSlugs',
+  'draft.rewardSlugs',
+])
+
+console.log(
+  'Storybook object-entry links contract passed: Facet and Reward detail ' +
+    'surfaces carry their object slug into Storybook via ?facet=/?reward=, ' +
+    'and Storybook still seeds its setup draft from both -- independent of ' +
+    'either surface’s current button markup.',
+)


### PR DESCRIPTION
### Task
conductor storybook/t-017: Add a contract for Storybook object-entry links

### What changed / what I produced
- New `utils/scripts/verifyStorybookObjectEntryLinks.mjs`: a source-level contract asserting
  - `components/facets/facet-profile.vue` wires a `startStoryWithFacet` click handler that navigates to `/storybook` with `query: { facet: selectedFacet.value.slug }`
  - `components/rewards/reward-encounter.vue` wires a `startStoryWithReward` click handler that navigates to `/storybook` with `query: { reward: slug }`
  - `components/conductor/storybook-page.vue`'s `seedFromQuery()` still reads `route.query.facet`/`route.query.reward` and adds them into `draft.facetSlugs`/`draft.rewardSlugs`
- New `.github/workflows/storybook-object-entry-links-contract.yml` running it on push/PR to `main`, matching the existing `storybook-*-contract.yml` pattern (`storybook-studio-contract.yml`, `storybook-branch-state-contract.yml`, `storybook-session-library-contract.yml`).
- Deliberately does **not** assert button classes/icon names/layout — a CTA restyle must not fail this check, only removal of the actual slug-carrying navigation or the consuming `seedFromQuery()` logic.

### How I verified
- Ran `node utils/scripts/verifyStorybookObjectEntryLinks.mjs` locally against current `main` — passes.
- This runtime has no prepared `.nuxt/` (documented sandbox limitation), so full `eslint`/`vue-tsc` couldn't run locally; the script is plain Node ESM (no Vue/TS-specific syntax) matching the established `verifyStorybookStudio.mjs`/`verifyStorybookBranchState.mjs` pattern exactly. Relying on CI for the full check matrix.

### Stakes
reversible

### Flags for Reviewer
- No existing "run all contracts" registry to update — every other `verifyStorybook*.mjs` contract has its own dedicated workflow file only, same as this one.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013dGFikX8NPhP51nmUkvQah)_