### PR TITLE
test(model-builder): enforce cancelled-run guard in required CI

### DIFF
--- a/utils/scripts/verifyModelBuilderRunWritableGuard.ts
+++ b/utils/scripts/verifyModelBuilderRunWritableGuard.ts
@@ -28,18 +28,19 @@
 // verifyModelBuilderCommitCancelledRunGuard.ts's preference for explicit,
 // narrow textual checks over a general-purpose static analyzer.
 //
-// This script is already wired into the required Contract Tests workflow. Two
-// sibling Model Builder guard scripts were callable from package.json but never
-// wired into that required job, which meant they could silently regress without
-// blocking a PR. Until the workflow is reorganized, this required entry point
-// also executes those two existing guards so the approved-asset and item-patch
-// stage invariants are enforced by required CI rather than living as dormant
-// npm scripts.
+// This script is already wired into the required Contract Tests workflow.
+// Three sibling Model Builder guard scripts are callable from package.json but
+// are not wired into that required job directly, which means they would be
+// non-blocking on their own. Until the workflow is reorganized, this required
+// entry point executes them too so cancelled-run completion, approved-asset,
+// and item-patch stage invariants are enforced by required CI rather than
+// living as dormant npm scripts.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { checkApprovedAssetGuard } from './verifyModelBuilderApprovedAssetGuard.js'
+import { checkCancelledRunGuard } from './verifyModelBuilderCancelledRunGuard.js'
 import { checkItemPatchStageGuard } from './verifyModelBuilderItemPatchStageGuard.js'
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url))
@@ -69,10 +70,6 @@ const ROUTES: RouteCheck[] = [
   },
 ]
 
-// Checks the fix's exact shape against the full source text of one route
-// file. Exported (rather than only exercised via main()) so the self-test
-// below can run it against synthetic route-shaped fixtures without touching
-// the real route files.
 export function checkRunWritableGuard(
   content: string,
   route: RouteCheck,
@@ -93,9 +90,6 @@ export function checkRunWritableGuard(
     return errors
   }
 
-  // Tolerant of the whitespace/indentation between the two statements
-  // (each route indents this pair differently) rather than requiring an
-  // exact adjacent line.
   const writablePattern = new RegExp(
     `assertRunAccess\\(\\s*${escapedVar},\\s*auth\\.user\\s*\\)\\s*\\n\\s*` +
       `assertRunWritable\\(\\s*${escapedVar}\\s*\\)`,
@@ -129,6 +123,7 @@ function main(): void {
     join(repositoryRoot, 'stores/modelBuilderStore.ts'),
     'utf8',
   )
+  allErrors.push(...checkCancelledRunGuard(storeContent))
   allErrors.push(...checkApprovedAssetGuard(storeContent))
 
   const runsIndexContent = readFileSync(
@@ -146,8 +141,9 @@ function main(): void {
 
   console.log(
     'Model Builder required guard contracts passed: all four write-capable ' +
-      'item routes refuse writes to CANCELLED runs, finished renders cannot ' +
-      'replace already-approved assets, and item PATCH writes cannot bypass ' +
+      'item routes refuse writes to CANCELLED runs, async completion cannot ' +
+      'persist after run cancellation, finished renders cannot replace ' +
+      'already-approved assets, and item PATCH writes cannot bypass ' +
       'server-stored stage review gates.',
   )
 }

--- a/utils/scripts/verifyModelBuilderRunWritableGuard.ts
+++ b/utils/scripts/verifyModelBuilderRunWritableGuard.ts
@@ -70,6 +70,10 @@ const ROUTES: RouteCheck[] = [
   },
 ]
 
+// Checks the fix's exact shape against the full source text of one route
+// file. Exported (rather than only exercised via main()) so the self-test
+// below can run it against synthetic route-shaped fixtures without touching
+// the real route files.
 export function checkRunWritableGuard(
   content: string,
   route: RouteCheck,
@@ -90,6 +94,9 @@ export function checkRunWritableGuard(
     return errors
   }
 
+  // Tolerant of the whitespace/indentation between the two statements
+  // (each route indents this pair differently) rather than requiring an
+  // exact adjacent line.
   const writablePattern = new RegExp(
     `assertRunAccess\\(\\s*${escapedVar},\\s*auth\\.user\\s*\\)\\s*\\n\\s*` +
       `assertRunWritable\\(\\s*${escapedVar}\\s*\\)`,


### PR DESCRIPTION
### Task
model-builder/t-029 recurring Model Builder polish / regression hardening

### Root cause
`test:model-builder-cancelled-run-guard` already existed and protected the async ArtJob completion path from persisting after run cancellation, but the required Contract Tests job never invoked it. The recent run-writable aggregator covered approved-asset and item-patch guards, leaving this sibling contract dormant.

### What changed
- Extended the already-required `verifyModelBuilderRunWritableGuard.ts` entry point to execute `checkCancelledRunGuard()` against `stores/modelBuilderStore.ts`.
- No runtime, API, schema, database, or UI behavior changes.
- One-file regression-hardening diff.

### Verification
- Conductor task is canonically `review` for session `20260810T151143Z-modelbuilder-t029-ly7vw`.
- Branch vs fresh main: exactly one file changed.
- Exact-head GitHub Actions are the merge gate; in particular Contract Tests must execute the updated required guard successfully, and TypeScript must pass.

### Stakes
reversible

### Flags for Reviewer
This closes the remaining dormant Model Builder `*-guard` package script that was not directly or indirectly required by Contract Tests. The previous cycle already aggregated approved-asset and item-patch guards into the same required entry point.

### Kaizen
Consider a meta-contract that enumerates every `test:model-builder-*-guard` package script and asserts each is direct or transitively reachable from the required Contract Tests job, so future guard additions cannot be decorative.