### PR TITLE
fix(model-builder): openRun() must not swap state.run when reopening the already-active run

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -328,6 +328,12 @@ jobs:
       - name: Model Builder run-writable guard contract
         run: npm run test:model-builder-run-writable-guard
 
+      - name: Model Builder open-run identity guard checker self-test
+        run: npm run test:model-builder-open-run-identity-guard-selftest
+
+      - name: Model Builder open-run identity guard contract
+        run: npm run test:model-builder-open-run-identity-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -161,6 +161,8 @@
     "test:model-builder-item-patch-stage-guard": "tsx utils/scripts/verifyModelBuilderItemPatchStageGuard.ts",
     "test:model-builder-run-writable-guard-selftest": "tsx utils/scripts/verifyModelBuilderRunWritableGuard.test.ts",
     "test:model-builder-run-writable-guard": "tsx utils/scripts/verifyModelBuilderRunWritableGuard.ts",
+    "test:model-builder-open-run-identity-guard-selftest": "tsx utils/scripts/verifyModelBuilderOpenRunIdentityGuard.test.ts",
+    "test:model-builder-open-run-identity-guard": "tsx utils/scripts/verifyModelBuilderOpenRunIdentityGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1795,6 +1795,17 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   }
 
   async function openRun(runId: string): Promise<void> {
+    // Reopening the run that's already active must not swap in a fresh object:
+    // fetchRuns()/the fallback fetch below both rebuild items via adaptRun/adaptItem,
+    // which reset the client-only artJobId/queueState fields to null. Replacing
+    // state.run here would orphan pollAsyncArtJob's reference to the live item object
+    // mid-poll, making an in-flight async generation silently vanish from the UI even
+    // though it's still running (and completes against the now-detached object).
+    if (state.run?.id === runId) {
+      state.step = 'run'
+      return
+    }
+
     const cached = state.runs.find((entry) => entry.id === runId)
     if (cached) {
       state.run = cached

--- a/utils/scripts/verifyModelBuilderOpenRunIdentityGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderOpenRunIdentityGuard.test.ts
@@ -1,0 +1,117 @@
+// /utils/scripts/verifyModelBuilderOpenRunIdentityGuard.test.ts
+//
+// Regression test for checkOpenRunIdentityGuard() in
+// verifyModelBuilderOpenRunIdentityGuard.ts (model-builder/t-029). Exercises
+// the real check against synthetic store-shaped fixtures covering: the
+// pre-fix shape (openRun replaces state.run unconditionally via the cache
+// lookup, even for the already-active run -- the exact bug found by manual
+// read-through), and the fixed shape (an identity check against
+// state.run?.id short-circuits before that lookup).
+import assert from 'node:assert/strict'
+
+import { checkOpenRunIdentityGuard } from './verifyModelBuilderOpenRunIdentityGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function openRun(runId: string): Promise<void> {
+    const cached = state.runs.find((entry) => entry.id === runId)
+    if (cached) {
+      state.run = cached
+      state.sourceType = cached.sourceType
+      state.recipeKey = cached.recipeKey
+      state.step = 'run'
+      setActiveRunId(Number(runId))
+      return
+    }
+
+    try {
+      const response = await performFetch<ServerRun>(
+        \`/api/model-builder/runs/\${runId}\`,
+      )
+      if (response.success && response.data) {
+        state.run = adaptRun(response.data)
+        state.sourceType = state.run.sourceType
+        state.recipeKey = state.run.recipeKey
+        state.step = 'run'
+        setActiveRunId(response.data.id)
+      } else if (!response.success) {
+        setStatus('error', response.message || 'Failed to open run.')
+      }
+    } catch (error) {
+      handleError(error, 'opening build run')
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function openRun(runId: string): Promise<void> {
+    if (state.run?.id === runId) {
+      state.step = 'run'
+      return
+    }
+
+    const cached = state.runs.find((entry) => entry.id === runId)
+    if (cached) {
+      state.run = cached
+      state.sourceType = cached.sourceType
+      state.recipeKey = cached.recipeKey
+      state.step = 'run'
+      setActiveRunId(Number(runId))
+      return
+    }
+
+    try {
+      const response = await performFetch<ServerRun>(
+        \`/api/model-builder/runs/\${runId}\`,
+      )
+      if (response.success && response.data) {
+        state.run = adaptRun(response.data)
+        state.sourceType = state.run.sourceType
+        state.recipeKey = state.run.recipeKey
+        state.step = 'run'
+        setActiveRunId(response.data.id)
+      } else if (!response.success) {
+        setStatus('error', response.message || 'Failed to open run.')
+      }
+    } catch (error) {
+      handleError(error, 'opening build run')
+    }
+  }
+`
+
+function run(): void {
+  const buggyErrors = checkOpenRunIdentityGuard(BUGGY_FIXTURE)
+  assert.equal(
+    buggyErrors.length,
+    1,
+    'expected the buggy fixture (no identity guard before the cache ' +
+      `lookup) to fail exactly once, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.match(buggyErrors[0]!, /state\.run\?\.id === runId/)
+
+  const fixedErrors = checkOpenRunIdentityGuard(FIXED_FIXTURE)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const missingFnErrors = checkOpenRunIdentityGuard(
+    'async function someOtherFunction(): Promise<void> {}',
+  )
+  assert.equal(
+    missingFnErrors.length,
+    1,
+    'expected a fixture with no openRun() to fail with a "could not find" error',
+  )
+  assert.match(
+    missingFnErrors[0]!,
+    /Could not find an async function named openRun/,
+  )
+
+  console.log(
+    'Model Builder open-run identity guard self-test passed: buggy fixture ' +
+      'fails, fixed fixture passes, missing-function fixture fails clearly.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderOpenRunIdentityGuard.ts
+++ b/utils/scripts/verifyModelBuilderOpenRunIdentityGuard.ts
@@ -1,0 +1,112 @@
+// /utils/scripts/verifyModelBuilderOpenRunIdentityGuard.ts
+//
+// Regression guard (model-builder/t-029, kaizen) -- openRun(runId) always
+// replaced state.run with a *different* object, even when the requested run
+// was already the active one. fetchRuns() (called by the run-history panel
+// on mount) and openRun's own fallback fetch both rebuild BuildRun/BuildItem
+// objects via adaptRun/adaptItem, which reset the client-only artJobId and
+// queueState fields to null (the server never returns them -- see the
+// BuildItem.artJobId doc comment). pollAsyncArtJob captures a reference to
+// the specific BuildItem object it was called with and polls against that
+// object only, independent of whatever object state.run currently points
+// to. So: user queues an async generate on an item, opens the run-history
+// panel (which silently refreshes state.runs with fresh objects), then
+// re-opens the same run they already had open -- openRun swapped in one of
+// those fresh objects, orphaning the in-flight poll. The UI now shows the
+// item as idle (no queued/rendering indicator, buttons re-enabled) while the
+// original job is still running in the background, inviting a second
+// concurrent generation and leaving the eventual first result to land
+// invisibly on the orphaned object.
+//
+// Fixed by short-circuiting at the top of openRun: if the requested runId is
+// already state.run's id, keep the live object in place (only update the
+// step) instead of looking it up in state.runs / re-fetching it.
+//
+// This asserts the textual shape of that fix stays in place: openRun's body
+// checks `state.run?.id === runId` (or an equivalent identity check against
+// its own runId parameter) strictly before the `state.runs.find(` cache
+// lookup that would otherwise unconditionally replace state.run.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'openRun'
+const CACHE_LOOKUP = 'state.runs.find('
+const IDENTITY_GUARD = /state\.run\?\.id\s*===\s*runId/
+
+// Checks the fix's exact shape against the full source text of a file
+// containing an `openRun`-named async function. Exported (rather than only
+// exercised via main()) so the self-test below can run it against synthetic
+// buggy/fixed fixtures without touching the real store file.
+export function checkOpenRunIdentityGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find an async function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  const cacheLookupIndex = fn.body.indexOf(CACHE_LOOKUP)
+  if (cacheLookupIndex === -1) {
+    errors.push(
+      `${FN_NAME}() no longer calls ${CACHE_LOOKUP} -- this guard's anchor ` +
+        'point has moved; re-check where the run-object replacement now ' +
+        'happens.',
+    )
+    return errors
+  }
+
+  const guardMatch = IDENTITY_GUARD.exec(fn.body)
+  if (!guardMatch || guardMatch.index >= cacheLookupIndex) {
+    errors.push(
+      `${FN_NAME}() does not check \`state.run?.id === runId\` before its ` +
+        `${CACHE_LOOKUP} cache lookup. Without this guard, re-opening the ` +
+        'run that is already active swaps state.run for a freshly-adapted ' +
+        'object (artJobId/queueState reset to null), orphaning any ' +
+        "pollAsyncArtJob poll still bound to the item's live object -- an " +
+        'in-flight async generation silently vanishes from the UI even ' +
+        'though it is still running.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkOpenRunIdentityGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder open-run identity guard contract failed for ' +
+        `${FN_NAME}() in modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder open-run identity guard contract passed: ' +
+      `${FN_NAME}() keeps the live state.run object in place when the ` +
+      'requested run is already active, before any cache lookup or ' +
+      'refetch could replace it.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
conductor/model-builder/t-029: Polish and upgrade Model Builder front-end surface (recurring). This cycle's follow-on found a real, previously-unfixed bug.

### What changed / what I produced
- `stores/modelBuilderStore.ts`: `openRun(runId)` now short-circuits when the requested run is already `state.run`'s id, instead of unconditionally swapping in a freshly-adapted object.
- New regression guard `utils/scripts/verifyModelBuilderOpenRunIdentityGuard.ts` + self-test, following the repo's existing `verifyModelBuilder*Guard.ts` pattern, wired into `package.json` and `.github/workflows/contract-tests.yml`.

### The bug
`openRun(runId)` always replaced `state.run` with a *different* object, even when the requested run was already active. `fetchRuns()` (called by the run-history panel on mount) and `openRun`'s own fallback fetch both rebuild `BuildRun`/`BuildItem` objects via `adaptRun`/`adaptItem`, which reset the client-only `artJobId`/`queueState` fields to `null` (the server never returns them). `pollAsyncArtJob` captures a reference to the specific `BuildItem` object it was called with and polls against that object only, independent of whatever object `state.run` currently points to.

**Concrete failure:** user queues an async generate on an item → opens the run-history panel (silently refreshes `state.runs` with fresh objects) → re-opens the same run they already had open. `openRun` swapped in one of those fresh objects, orphaning the in-flight poll. The UI now shows the item as idle (no queued/rendering indicator, buttons re-enabled) while the original job is still running, inviting a second concurrent generation, with the eventual first result landing invisibly on the orphaned object.

### How I verified
- `npx vue-tsc --noEmit` clean (0 errors) with the Prisma client freshly regenerated against schema. (Note: the *committed* `prisma/generated/` snapshot is stale relative to schema — missing the Brainstorm models added in #1718 — causing pre-existing TS errors in `server/api/brainstorm/**`; confirmed present on `origin/main` before this change too, via `git stash`, and left untouched as out of scope.)
- `eslint`/`prettier` clean on all changed/new files (`stores/modelBuilderStore.ts`'s 2 pre-existing `no-empty` errors and its pre-existing prettier drift confirmed present on `origin/main` before this change, unrelated to my diff).
- All 19 `test:model-builder-*` contract npm scripts pass, including the two new ones (self-test + contract for the new guard).

### Stakes
reversible

### Flags for Reviewer
- Spotted but did not touch: the committed `prisma/generated/` snapshot is out of sync with `prisma/brainstorm.prisma` (missing `BrainstormSession`/`BrainstormCandidate` client types), causing `vue-tsc` errors in `server/api/brainstorm/**` whenever the generated client isn't freshly regenerated first. Pre-existing, unrelated to this task — worth a follow-up task if `npm run test` (which doesn't force a fresh `prisma generate`) is relied on as a pass/fail signal anywhere.

### Kaizen suggestion
File a task to regenerate and commit a fresh `prisma/generated/` snapshot (or stop committing it at all, since `postinstall`/`nuxi prepare` already regenerates it on every `npm ci`) so a local `vue-tsc` run without an explicit `prisma generate` step doesn't show stale false-positive errors unrelated to whatever's actually being changed.

### Notes for reviewer
Conductor task `model-builder/t-029` claimed under session `claude-conductor-agentrun-20260810T153049Z`; will be flipped to review/done in the conductor repo once this merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_013cH3zDHAQBf6gHYFbexPiu)_