### PR TITLE
feat(storybook): seed stories from Character and Scenario surfaces

### DIFF
--- a/components/characters/character-manager.vue
+++ b/components/characters/character-manager.vue
@@ -8,7 +8,23 @@
     @refresh="refreshManagerData"
   >
     <template #characters>
-      <character-interact class="h-full min-h-0 flex-1 overflow-hidden" />
+      <div class="flex h-full min-h-0 flex-1 flex-col gap-2">
+        <div
+          v-if="characterStore.selectedCharacter?.slug"
+          class="flex shrink-0 justify-end"
+        >
+          <button
+            type="button"
+            class="btn btn-primary btn-sm rounded-xl"
+            title="Start a Storybook story seeded with this Character"
+            @click="startStoryWithCharacter"
+          >
+            <Icon name="kind-icon:book-open" class="size-4" />
+            <span class="hidden sm:inline">Start a story with this</span>
+          </button>
+        </div>
+        <character-interact class="h-full min-h-0 flex-1 overflow-hidden" />
+      </div>
     </template>
 
     <template #adventure>
@@ -72,6 +88,12 @@ async function syncCharacterFromRoute(): Promise<void> {
 
   navStore.setDashboardTab(dashboardKey, 'characters')
   await characterStore.selectCharacter(id)
+}
+
+function startStoryWithCharacter(): void {
+  const slug = characterStore.selectedCharacter?.slug
+  if (!slug) return
+  void navigateTo({ path: '/storybook', query: { character: slug } })
 }
 
 async function refreshManagerData() {

--- a/components/scenarios/scenario-manager.vue
+++ b/components/scenarios/scenario-manager.vue
@@ -11,7 +11,23 @@
   >
     <!-- Scenarios: gallery → select → configure → story, all in place -->
     <template #scenarios>
-      <scenario-interact class="h-full min-h-0 flex-1 overflow-hidden" />
+      <div class="flex h-full min-h-0 flex-1 flex-col gap-2">
+        <div
+          v-if="scenarioStore.selectedScenario?.slug"
+          class="flex shrink-0 justify-end"
+        >
+          <button
+            type="button"
+            class="btn btn-primary btn-sm rounded-xl"
+            title="Start a Storybook story seeded with this Scenario"
+            @click="startStoryWithScenario"
+          >
+            <Icon name="kind-icon:book-open" class="size-4" />
+            <span class="hidden sm:inline">Start a story with this</span>
+          </button>
+        </div>
+        <scenario-interact class="h-full min-h-0 flex-1 overflow-hidden" />
+      </div>
     </template>
 
     <!-- Add: the "+" tab -->
@@ -94,6 +110,12 @@ function handleTabChange(tab: string) {
  */
 function handleScenarioSaved() {
   navStore.setDashboardTab(dashboardKey, 'scenarios')
+}
+
+function startStoryWithScenario(): void {
+  const slug = scenarioStore.selectedScenario?.slug
+  if (!slug) return
+  void navigateTo({ path: '/storybook', query: { scenario: slug } })
 }
 
 async function loadManagerData(force = false) {

--- a/utils/scripts/verifyStorybookObjectEntryLinks.mjs
+++ b/utils/scripts/verifyStorybookObjectEntryLinks.mjs
@@ -2,15 +2,15 @@
 //
 // Reviewer kaizen from kind_robots PR #1706 (conductor storybook/t-017): CI
 // caught layout and router-shape regressions during that review, but nothing
-// directly asserted the user-facing handoff itself -- that a Facet or Reward
-// detail surface can actually start a Storybook story seeded with that
-// object. This contract closes that gap.
+// directly asserted the user-facing handoff itself -- that an object detail
+// surface can actually start a Storybook story seeded with that object. This
+// contract closes that gap.
 //
 // Deliberately narrow: it checks that the CTA's click handler exists and
 // performs the navigation with the object's slug threaded through the right
 // query key, and that Storybook's own seedFromQuery() still consumes that
-// key into the matching setup-draft list. It does NOT assert button classes,
-// icon names, or layout -- a restyle of the CTA must not fail this check.
+// key into the matching setup draft. It does NOT assert button classes, icon
+// names, or layout -- a restyle of the CTA must not fail this check.
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
@@ -28,12 +28,10 @@ function includesAll(path, values) {
 
 const facetProfilePath = 'components/facets/facet-profile.vue'
 const rewardEncounterPath = 'components/rewards/reward-encounter.vue'
+const characterManagerPath = 'components/characters/character-manager.vue'
+const scenarioManagerPath = 'components/scenarios/scenario-manager.vue'
 const storybookPagePath = 'components/conductor/storybook-page.vue'
 
-// Facet detail surface: some element must wire a click to a handler that
-// navigates to Storybook carrying the selected Facet's slug through ?facet=.
-// The handler name and navigateTo call are asserted; the button/icon markup
-// around it is not.
 includesAll(facetProfilePath, [
   'startStoryWithFacet',
   '@click="startStoryWithFacet"',
@@ -41,7 +39,6 @@ includesAll(facetProfilePath, [
   'query: { facet: selectedFacet.value.slug }',
 ])
 
-// Reward encounter surface: same shape, through ?reward=.
 includesAll(rewardEncounterPath, [
   'startStoryWithReward',
   '@click="startStoryWithReward"',
@@ -49,20 +46,35 @@ includesAll(rewardEncounterPath, [
   'query: { reward: slug }',
 ])
 
-// Storybook itself must still consume both seed keys into the matching
-// setup-draft ingredient lists, on top of (not instead of) a restored draft.
+includesAll(characterManagerPath, [
+  'startStoryWithCharacter',
+  '@click="startStoryWithCharacter"',
+  "path: '/storybook'",
+  'query: { character: slug }',
+])
+
+includesAll(scenarioManagerPath, [
+  'startStoryWithScenario',
+  '@click="startStoryWithScenario"',
+  "path: '/storybook'",
+  'query: { scenario: slug }',
+])
+
 includesAll(storybookPagePath, [
   'function seedFromQuery',
   'seedFromQuery()',
   'route.query.facet',
   'route.query.reward',
+  'route.query.character',
+  'route.query.scenario',
   'draft.facetSlugs',
   'draft.rewardSlugs',
+  'draft.castSlugs',
+  'draft.scenarioSlug',
 ])
 
 console.log(
-  'Storybook object-entry links contract passed: Facet and Reward detail ' +
-    'surfaces carry their object slug into Storybook via ?facet=/?reward=, ' +
-    'and Storybook still seeds its setup draft from both -- independent of ' +
-    'either surface’s current button markup.',
+  'Storybook object-entry links contract passed: Facet, Reward, Character, ' +
+    'and Scenario working surfaces carry their object slug into Storybook, ' +
+    'and Storybook still seeds its setup draft from every supported key.',
 )


### PR DESCRIPTION
### Task
storybook/t-018: Give Scenario, Character, and Location surfaces the same "Start a story with this" entry point Facet and Reward have (kind: software)

### What changed / what I produced
- Added a Storybook CTA to the selected Character working surface, passing `?character=<slug>`.
- Added the equivalent CTA to the selected Scenario working surface, passing `?scenario=<slug>`.
- Extended `verifyStorybookObjectEntryLinks.mjs` so the existing required contract covers Character and Scenario in addition to Facet and Reward, and verifies Storybook still consumes those seed keys.
- Searched for an analogous standalone Location manager/detail surface and found none; Storybook already consumes `?location=`, so no speculative new Location surface was invented.

### How I verified
- Compared branch against current `main`: exactly 3 files changed, all within this task.
- Conductor task transitioned to `review` for session `20260810T182152Z-91159b` before this PR opened.
- CI on this exact head must complete successfully before merge.

### Stakes
reversible

### Flags for Reviewer
- `worker/*` does not receive a Vercel preview under current repo policy; for this UI change, rely on required CI before merge and verify the resulting production deployment after merge.

### Kaizen suggestion
Extract the repeated object-to-Storybook navigation into a tiny shared helper once a fifth detail surface needs it, so query-key wiring stays centralized without prematurely abstracting four small handlers.

### Notes for reviewer
The CTA is placed in each manager's selected-object working slot, above the existing interact surface, avoiding changes to the large Character chat and Scenario interaction engines.