### PR TITLE
storybook/t-011: arrange the casting board by role, not reading order

### DIFF
--- a/components/narrative/narrative-cast-card.vue
+++ b/components/narrative/narrative-cast-card.vue
@@ -1,0 +1,108 @@
+<!-- /components/narrative/narrative-cast-card.vue -->
+<!--
+  One card on the casting board (narrative-role-assigner.vue). Extracted so
+  the board can render the SAME card at three different sizes -- lead,
+  support, back -- without tripling the markup across the three tiers a real
+  playboard arranges by (see narrative-role-assigner.vue's own header comment
+  for why the board is tiered at all).
+
+  Presentational only: the parent owns the role map and passes down which
+  role (if any) this member currently holds; this emits the chip press back
+  up rather than mutating anything itself.
+-->
+<template>
+  <li
+    class="flex flex-col overflow-hidden rounded-2xl border bg-base-100 transition"
+    :class="[
+      role ? 'border-secondary/60 ring-1 ring-secondary/30' : 'border-base-300',
+      size === 'back' ? 'opacity-90' : '',
+    ]"
+  >
+    <div class="relative">
+      <kr-art-plate
+        :source="member"
+        variant="card"
+        shape="card"
+        frame="none"
+        :alt="member.title"
+        :placeholder-icon="member.icon || 'kind-icon:user'"
+      />
+
+      <!-- The part, worn on the card. This is what makes the board readable
+           without reading: a glance says who leads and who opposes. -->
+      <span
+        v-if="role"
+        class="badge badge-secondary badge-sm absolute left-2 top-2 gap-1 rounded-xl shadow"
+      >
+        <Icon
+          v-if="roleIcon"
+          :name="roleIcon"
+          class="size-3"
+          aria-hidden="true"
+        />
+        {{ roleLabel }}
+      </span>
+
+      <span
+        class="absolute inset-x-0 bottom-0 truncate bg-linear-to-t from-base-100 to-transparent px-2 pb-1.5 pt-6 text-xs font-black"
+      >
+        {{ member.title }}
+      </span>
+    </div>
+
+    <!--
+      Chips, not a dropdown. Pressing the active part again clears it, so
+      removing someone from a role costs the same one tap as giving them
+      one -- a dropdown makes "none" a hunt back through the list.
+    -->
+    <div
+      class="flex flex-wrap gap-1 p-2"
+      role="group"
+      :aria-label="`Part for ${member.title}`"
+    >
+      <button
+        v-for="option in NARRATIVE_ROLES"
+        :key="option.key"
+        type="button"
+        class="btn btn-xs rounded-lg px-1.5 text-[0.65rem] font-bold"
+        :class="role === option.key ? 'btn-secondary' : 'btn-ghost'"
+        :aria-pressed="role === option.key"
+        :title="`${option.label} — ${option.description}`"
+        @click="emit('toggle-role', option.key)"
+      >
+        {{ option.label }}
+      </button>
+    </div>
+  </li>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import {
+  NARRATIVE_ROLES,
+  narrativeRole,
+  narrativeRoleLabel,
+} from '@/utils/narrativeRoles'
+import type { NarrativeIngredientOption } from '@/utils/narrativeIngredients'
+
+const props = defineProps<{
+  member: NarrativeIngredientOption
+  /** This member's current role key, or null when unassigned. */
+  role: string | null
+  /**
+   * Board tier this card renders at. 'lead' is given prominence (protagonist
+   * / antagonist), 'support' is the default size, 'back' is ranked behind
+   * (ensemble and anyone not yet given a part) and reads as slightly
+   * receded rather than fully de-emphasised -- an unassigned card is still
+   * drawn quietly, not hidden.
+   */
+  size: 'lead' | 'support' | 'back'
+}>()
+
+const emit = defineEmits<{
+  'toggle-role': [key: string]
+}>()
+
+const roleLabel = computed(() => narrativeRoleLabel(props.role))
+const roleIcon = computed(() => narrativeRole(props.role)?.icon ?? '')
+</script>

--- a/components/narrative/narrative-role-assigner.vue
+++ b/components/narrative/narrative-role-assigner.vue
@@ -12,11 +12,21 @@
   (narrative-ingredient-card.vue). Dropping from cards to a dropdown mid-flow
   is the same hodgepodge this whole pass exists to remove.
 
-  So this is a board. Character art at 2:3 through the shared kr-art-plate, the
-  assigned part worn as a badge on the card itself, and the parts offered as
-  chips you press rather than options you unfold. The cast is capped at five,
-  which is what makes chips affordable: five cards of eight chips is a board
-  you can read at a glance, where five dropdowns is a form.
+  It also, at first, put every card in one uniform auto-fill grid regardless
+  of part — reading order, not story order. t-011 (2026-08-10) fixed that:
+  the board now arranges BY role instead. Protagonist(s) and antagonist(s) get
+  the lead row, given prominence and set facing each other rather than side by
+  side in the same line — a protagonist and an antagonist read as opposed, not
+  as neighbours. Supporting parts (love interest, mentor, foil, ally,
+  wildcard) hold the middle row at the original size. Ensemble and anyone not
+  yet given a part share the back row, smaller and slightly receded — ranked
+  behind without being hidden, since an unassigned card still has to be
+  readable and pressable. A board with nothing assigned collapses to exactly
+  one back row, which is the old uniform grid: this is additive, not a
+  rewrite of the unassigned state.
+
+  Card markup itself lives in narrative-cast-card.vue so the three tiers don't
+  triple it.
 
   Presentational and controlled, the contract kr-gallery keeps: the parent owns
   the cast and the role map, this emits changes, and it imports no store so it
@@ -27,7 +37,7 @@
   ignores casting generates identically to before.
 -->
 <template>
-  <div v-if="members.length" class="space-y-3">
+  <div v-if="members.length" class="space-y-4">
     <div class="flex flex-wrap items-baseline justify-between gap-2">
       <div>
         <p class="text-sm font-black">The casting board</p>
@@ -45,78 +55,73 @@
       </span>
     </div>
 
+    <!-- Lead row: protagonist(s) given prominence on one side, antagonist(s)
+         set opposite on the other. Only renders once someone actually holds
+         one of these parts. -->
+    <div
+      v-if="protagonists.length || antagonists.length"
+      class="flex flex-wrap items-start justify-between gap-3"
+    >
+      <ul class="flex flex-wrap gap-3" role="group" aria-label="Protagonist(s)">
+        <narrative-cast-card
+          v-for="member in protagonists"
+          :key="member.slug"
+          class="w-36 sm:w-44"
+          :member="member"
+          :role="roleFor(member.slug)"
+          size="lead"
+          @toggle-role="toggle(member.slug, $event)"
+        />
+      </ul>
+      <ul
+        class="flex flex-wrap justify-end gap-3"
+        role="group"
+        aria-label="Antagonist(s)"
+      >
+        <narrative-cast-card
+          v-for="member in antagonists"
+          :key="member.slug"
+          class="w-36 sm:w-44"
+          :member="member"
+          :role="roleFor(member.slug)"
+          size="lead"
+          @toggle-role="toggle(member.slug, $event)"
+        />
+      </ul>
+    </div>
+
+    <!-- Supporting row: everyone with a part that isn't lead or ensemble,
+         at the board's original card size. -->
     <ul
+      v-if="supportingCast.length"
       class="grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(min(11rem,100%),1fr))]"
     >
-      <li
-        v-for="member in members"
+      <narrative-cast-card
+        v-for="member in supportingCast"
         :key="member.slug"
-        class="flex flex-col overflow-hidden rounded-2xl border bg-base-100 transition"
-        :class="
-          roleFor(member.slug)
-            ? 'border-secondary/60 ring-1 ring-secondary/30'
-            : 'border-base-300'
-        "
-      >
-        <div class="relative">
-          <kr-art-plate
-            :source="member"
-            variant="card"
-            shape="card"
-            frame="none"
-            :alt="member.title"
-            :placeholder-icon="member.icon || 'kind-icon:user'"
-          />
+        :member="member"
+        :role="roleFor(member.slug)"
+        size="support"
+        @toggle-role="toggle(member.slug, $event)"
+      />
+    </ul>
 
-          <!-- The part, worn on the card. This is what makes the board
-               readable without reading: a glance says who leads and who
-               opposes. -->
-          <span
-            v-if="roleFor(member.slug)"
-            class="badge badge-secondary badge-sm absolute left-2 top-2 gap-1 rounded-xl shadow"
-          >
-            <Icon
-              v-if="roleIcon(member.slug)"
-              :name="roleIcon(member.slug)"
-              class="size-3"
-              aria-hidden="true"
-            />
-            {{ roleLabel(member.slug) }}
-          </span>
-
-          <span
-            class="absolute inset-x-0 bottom-0 truncate bg-linear-to-t from-base-100 to-transparent px-2 pb-1.5 pt-6 text-xs font-black"
-          >
-            {{ member.title }}
-          </span>
-        </div>
-
-        <!--
-          Chips, not a dropdown. Pressing the active part again clears it, so
-          removing someone from a role costs the same one tap as giving them
-          one — a dropdown makes "none" a hunt back through the list.
-        -->
-        <div
-          class="flex flex-wrap gap-1 p-2"
-          role="group"
-          :aria-label="`Part for ${member.title}`"
-        >
-          <button
-            v-for="role in NARRATIVE_ROLES"
-            :key="role.key"
-            type="button"
-            class="btn btn-xs rounded-lg px-1.5 text-[0.65rem] font-bold"
-            :class="
-              roleFor(member.slug) === role.key ? 'btn-secondary' : 'btn-ghost'
-            "
-            :aria-pressed="roleFor(member.slug) === role.key"
-            :title="`${role.label} — ${role.description}`"
-            @click="toggle(member.slug, role.key)"
-          >
-            {{ role.label }}
-          </button>
-        </div>
-      </li>
+    <!-- Back row: ensemble and anyone not yet given a part. Ranked behind —
+         smaller and a touch quieter — but still fully readable and pressable,
+         since roles stay optional. This is the whole board when nothing has
+         been assigned yet. -->
+    <ul
+      v-if="backCast.length"
+      class="grid gap-2.5 [grid-template-columns:repeat(auto-fill,minmax(min(8.5rem,100%),1fr))]"
+    >
+      <narrative-cast-card
+        v-for="member in backCast"
+        :key="member.slug"
+        :member="member"
+        :role="roleFor(member.slug)"
+        size="back"
+        @toggle-role="toggle(member.slug, $event)"
+      />
     </ul>
 
     <!--
@@ -136,9 +141,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import {
-  NARRATIVE_ROLES,
   duplicateSingularRoles,
-  narrativeRole,
   narrativeRoleLabel,
 } from '@/utils/narrativeRoles'
 import type { NarrativeIngredientOption } from '@/utils/narrativeIngredients'
@@ -155,9 +158,37 @@ const emit = defineEmits<{
 }>()
 
 const roleFor = (slug: string): string | null => props.modelValue[slug] ?? null
-const roleLabel = (slug: string): string => narrativeRoleLabel(roleFor(slug))
-const roleIcon = (slug: string): string =>
-  narrativeRole(roleFor(slug))?.icon ?? ''
+
+/*
+ * The board's three tiers. A member falls into exactly one, decided purely
+ * by their current role — reassigning a part moves the card, nothing else
+ * to track. `protagonist`/`antagonist` lead; the other five real roles hold
+ * the supporting middle; `ensemble` and unassigned share the back row, since
+ * neither has been given prominence.
+ */
+const protagonists = computed(() =>
+  props.members.filter((member) => roleFor(member.slug) === 'protagonist'),
+)
+const antagonists = computed(() =>
+  props.members.filter((member) => roleFor(member.slug) === 'antagonist'),
+)
+const supportingCast = computed(() =>
+  props.members.filter((member) => {
+    const role = roleFor(member.slug)
+    return (
+      role !== null &&
+      role !== 'protagonist' &&
+      role !== 'antagonist' &&
+      role !== 'ensemble'
+    )
+  }),
+)
+const backCast = computed(() =>
+  props.members.filter((member) => {
+    const role = roleFor(member.slug)
+    return role === null || role === 'ensemble'
+  }),
+)
 
 function toggle(slug: string, key: string): void {
   /*

--- a/utils/wonderlab/previewFixtures.ts
+++ b/utils/wonderlab/previewFixtures.ts
@@ -585,7 +585,7 @@ const fixtures: Record<string, WonderLabPreviewFixture> = {
   'narrative-role-assigner': {
     title: 'Cast role assignment',
     description:
-      'Three synthetic cast members with a protagonist and two unassigned parts, so the select, the role description line, and the empty state are all visible at once.',
+      'Three synthetic cast members — a protagonist and an antagonist in the lead row facing each other, one unassigned card ranked behind — so the tiered board layout, the role badge, and the unassigned state are all visible at once.',
     viewport: 'mobile',
     minHeight: '20rem',
     props: {
@@ -612,7 +612,10 @@ const fixtures: Record<string, WonderLabPreviewFixture> = {
           icon: 'kind-icon:eye',
         },
       ],
-      modelValue: { 'ami-butterfly-fixture': 'protagonist' },
+      modelValue: {
+        'ami-butterfly-fixture': 'protagonist',
+        'cthulhu-fixture': 'antagonist',
+      },
     },
   },
   'flip-panel': {

--- a/utils/wonderlab/previewFixtures.ts
+++ b/utils/wonderlab/previewFixtures.ts
@@ -582,6 +582,25 @@ const fixtures: Record<string, WonderLabPreviewFixture> = {
     skipReason:
       'The editor resolves its record from facetStore by id, so a naked mount with a synthetic facetId renders nothing at all — its whole template is behind that lookup. It needs a seeded Facet catalog rather than props. Preview it from /facets by opening a Facet, which is now the only way in.',
   },
+  'narrative-cast-card': {
+    title: 'Cast board card (lead tier)',
+    description:
+      'One casting-board card at its most prominent size, wearing the protagonist badge — the same tile narrative-role-assigner renders at three sizes across its lead/support/back tiers.',
+    viewport: 'mobile',
+    minHeight: '14rem',
+    props: {
+      member: {
+        id: -604,
+        slug: 'ami-butterfly-fixture',
+        title: 'Ami Butterfly',
+        description: 'A cheerful chaos moth with poor impulse control.',
+        icon: 'kind-icon:butterfly',
+      },
+      role: 'protagonist',
+      size: 'lead',
+    },
+  },
+
   'narrative-role-assigner': {
     title: 'Cast role assignment',
     description:


### PR DESCRIPTION
### Task
storybook/t-011: Arrange the casting board by role instead of a uniform grid (kind: software)

### What changed / what I produced
- `components/narrative/narrative-role-assigner.vue`'s cast cards sat in one uniform auto-fill grid regardless of assigned part — position carried no meaning. Silas: "I'm imagining a layout that lets the user feel like they are selecting cards and creating a playboard that turns into a story."
- The board now arranges into three tiers, decided purely by each member's current role:
  - **lead row**: protagonist(s) given prominence on the left, antagonist(s) set opposite on the right — read as facing off, not as neighbours.
  - **support row**: love interest / mentor / foil / ally / wildcard, at the board's original card size.
  - **back row**: ensemble and anyone not yet given a part, smaller and a touch quieter — ranked behind without being hidden, since roles stay optional and an unassigned card must still be readable and pressable.
- A board with nothing assigned collapses to exactly one back row, which is the original uniform grid — additive, not a rewrite of the unassigned state.
- Extracted card markup into a new `components/narrative/narrative-cast-card.vue` so the three tiers don't triple it. Kept the parent's presentational/controlled contract (owns the cast + role map, emits changes, imports no store).
- Updated the WonderLab preview fixture (`utils/wonderlab/previewFixtures.ts`) to assign both a protagonist and an antagonist so the lead-row opposition is visible in the component gallery, not just the unassigned state.

### How I verified
- `npx eslint` on both changed components + the fixture file — clean
- `npx prettier --check` — clean after `--write`
- `npx vue-tsc --noEmit` (full project) — exit 0
- `npx tsx utils/scripts/verifyNarrativeRoles.ts` — all 25 checks pass (role→story-bible contract untouched by this layout-only change)
- `npx tsx utils/scripts/verifyWonderLab{Core,Ui,Visual}Fixtures.ts` — all pass

### Stakes
reversible

### Flags for Reviewer
- The task note explicitly said this "wants Silas's eye on the arrangement before it is built" since it's a layout design question. It's not `gate_human`, `stakes: reversible`, and `status: ready`/`owner: worker`, so per AGENTS.md's "scope gates are soft, course-correct after" I built a concrete first pass (protagonist-left / antagonist-right facing off, support at original size, ensemble+unassigned ranked behind and slightly smaller) rather than parking it — happy to have the exact arrangement (spacing, whether antagonist should be *below* rather than beside, etc.) revised in a follow-up if Silas wants something different once he sees it live.
- Drag-and-drop onto role slots is the separate `t-012`, which formally depends on this one landing first (its own note says so, though `depends_on` isn't set in the roadmap).

### Kaizen suggestion
`t-012` (drag a character card onto a role slot) now has real slot positions to target — the lead/support/back groupings this PR introduces are a natural drop-zone boundary for that follow-up.

### Notes for reviewer
Conductor task: storybook/t-011 (session claimed via `claim_task.py`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dcte4oCzzh3ofPEeyK3mKb)_