### PR TITLE
fix(model-builder): honor user-typed name/title on CREATE commit

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -334,6 +334,12 @@ jobs:
       - name: Model Builder open-run identity guard contract
         run: npm run test:model-builder-open-run-identity-guard
 
+      - name: Model Builder commit name/title field guard checker self-test
+        run: npm run test:model-builder-commit-name-field-guard-selftest
+
+      - name: Model Builder commit name/title field guard contract
+        run: npm run test:model-builder-commit-name-field-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -163,6 +163,8 @@
     "test:model-builder-run-writable-guard": "tsx utils/scripts/verifyModelBuilderRunWritableGuard.ts",
     "test:model-builder-open-run-identity-guard-selftest": "tsx utils/scripts/verifyModelBuilderOpenRunIdentityGuard.test.ts",
     "test:model-builder-open-run-identity-guard": "tsx utils/scripts/verifyModelBuilderOpenRunIdentityGuard.ts",
+    "test:model-builder-commit-name-field-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitNameFieldGuard.test.ts",
+    "test:model-builder-commit-name-field-guard": "tsx utils/scripts/verifyModelBuilderCommitNameFieldGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/server/api/model-builder/items/[id]/commit.post.ts
+++ b/server/api/model-builder/items/[id]/commit.post.ts
@@ -736,12 +736,20 @@ export default defineEventHandler(async (event) => {
     }
     const sourceId = item.Run.sourceId
     const text = (item.pitch || item.fieldsDraft || '').trim()
+    const fieldMap = parseFieldLines(item.fieldsDraft)
+    // Every CREATE target's field spec declares a required 'name' or 'title'
+    // line (see MODEL_FIELDS in modelBuilderFields.ts) that the batch editor
+    // and per-item panel both surface as the record's actual name/title. Honor
+    // whatever the user (or AI drafter) put there before falling back to the
+    // pitch's first line -- otherwise a deliberately-typed name is silently
+    // discarded in favor of pitch text on commit.
     const name = (
+      fieldMap.name ||
+      fieldMap.title ||
       item.pitch?.split('\n')[0]?.trim() ||
       item.label ||
       'Untitled'
     ).slice(0, 255)
-    const fieldMap = parseFieldLines(item.fieldsDraft)
 
     if (item.idempotencyKey) {
       return {

--- a/utils/scripts/verifyModelBuilderCommitNameFieldGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderCommitNameFieldGuard.test.ts
@@ -1,0 +1,93 @@
+// /utils/scripts/verifyModelBuilderCommitNameFieldGuard.test.ts
+//
+// Regression test for checkCommitNameFieldGuard() in
+// verifyModelBuilderCommitNameFieldGuard.ts (model-builder/t-029). Exercises
+// the real check against synthetic commit.post.ts-shaped fixtures covering:
+// the pre-fix shape (name computed solely from the pitch's first line, the
+// exact bug found by manual read-through), the fixed shape (fieldMap.name /
+// fieldMap.title preferred ahead of the pitch fallback), and a
+// missing-anchor fixture.
+import assert from 'node:assert/strict'
+
+import { checkCommitNameFieldGuard } from './verifyModelBuilderCommitNameFieldGuard.js'
+
+const BUGGY_FIXTURE = `
+    const sourceId = item.Run.sourceId
+    const text = (item.pitch || item.fieldsDraft || '').trim()
+    const name = (
+      item.pitch?.split('\\n')[0]?.trim() ||
+      item.label ||
+      'Untitled'
+    ).slice(0, 255)
+    const fieldMap = parseFieldLines(item.fieldsDraft)
+`
+
+const FIXED_FIXTURE = `
+    const sourceId = item.Run.sourceId
+    const text = (item.pitch || item.fieldsDraft || '').trim()
+    const fieldMap = parseFieldLines(item.fieldsDraft)
+    const name = (
+      fieldMap.name ||
+      fieldMap.title ||
+      item.pitch?.split('\\n')[0]?.trim() ||
+      item.label ||
+      'Untitled'
+    ).slice(0, 255)
+`
+
+const PARTIAL_FIXTURE = `
+    const fieldMap = parseFieldLines(item.fieldsDraft)
+    const name = (
+      fieldMap.name ||
+      item.pitch?.split('\\n')[0]?.trim() ||
+      item.label ||
+      'Untitled'
+    ).slice(0, 255)
+`
+
+function run(): void {
+  const buggyErrors = checkCommitNameFieldGuard(BUGGY_FIXTURE)
+  assert.equal(
+    buggyErrors.length,
+    2,
+    'expected the buggy fixture (no fieldMap.name/title preference) to ' +
+      `fail twice, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.match(buggyErrors[0]!, /fieldMap\.name/)
+  assert.match(buggyErrors[1]!, /fieldMap\.title/)
+
+  const fixedErrors = checkCommitNameFieldGuard(FIXED_FIXTURE)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const partialErrors = checkCommitNameFieldGuard(PARTIAL_FIXTURE)
+  assert.equal(
+    partialErrors.length,
+    1,
+    'expected the partial fixture (name fixed, title still missing) to ' +
+      `fail exactly once, got: ${JSON.stringify(partialErrors)}`,
+  )
+  assert.match(partialErrors[0]!, /fieldMap\.title/)
+
+  const missingAnchorErrors = checkCommitNameFieldGuard(
+    'const somethingElse = 1',
+  )
+  assert.equal(
+    missingAnchorErrors.length,
+    1,
+    'expected a fixture with no `const name = (` assignment to fail with ' +
+      'a "could not find" error',
+  )
+  assert.match(missingAnchorErrors[0]!, /Could not find/)
+
+  console.log(
+    'Model Builder commit name/title field guard self-test passed: buggy ' +
+      'fixture fails twice, fixed fixture passes, partial fixture fails ' +
+      'once, missing-anchor fixture fails clearly.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderCommitNameFieldGuard.ts
+++ b/utils/scripts/verifyModelBuilderCommitNameFieldGuard.ts
@@ -1,0 +1,146 @@
+// /utils/scripts/verifyModelBuilderCommitNameFieldGuard.ts
+//
+// Regression guard (model-builder/t-029, kaizen) -- every CREATE target's
+// field spec in modelBuilderFields.ts (MODEL_FIELDS) declares a required
+// 'name' (Character/Bot/Reward) or 'title' (Dream/Scenario/Project/Facet)
+// line. defaultFieldsTemplate() pre-fills it, fieldsBrief() tells the AI
+// drafter it's required, and model-builder-batch-editor.vue renders it as a
+// labeled, red-asterisk "required" input the user can batch-set or hand-edit
+// directly in the per-item panel's raw fields textarea. None of that ever
+// reached items/[id]/commit.post.ts: the route computed the new record's
+// name/title solely from the first line of item.pitch (falling back to
+// item.label / 'Untitled'), so a name the user deliberately typed into the
+// required field was parsed into fieldMap, displayed, batch-applied, and
+// persisted to fieldsDraft -- but silently discarded in favor of pitch text
+// on commit. Concrete failure: type "Grommash Ironjaw" into the required
+// Name field of a CREATE Character item, approve every stage, commit -- the
+// resulting Character.name is the first line of the pitch, not "Grommash
+// Ironjaw". Same for Reward/Bot (.name) and Dream/Scenario/Project/Facet
+// (.title).
+//
+// Fixed by computing `name` from fieldMap.name / fieldMap.title first,
+// falling back to the pitch-derived heuristic only when neither is set.
+//
+// This asserts the textual shape of that fix stays in place: the `const
+// name = (` assignment in commit.post.ts's default event handler prefers
+// `fieldMap.name` and `fieldMap.title` (in that order) ahead of the
+// `item.pitch?.split('\n')[0]` fallback it used to rely on exclusively.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const ROUTE_PATH = join(
+  repositoryRoot,
+  'server/api/model-builder/items/[id]/commit.post.ts',
+)
+
+const NAME_ASSIGNMENT = 'const name = ('
+const PITCH_FALLBACK = "item.pitch?.split('\\n')[0]?.trim()"
+
+// Extracts the `const name = ( ... )` expression via paren matching from the
+// first `(` after the assignment, so the check is robust to reformatting of
+// the fallback chain inside it.
+export function extractNameAssignment(content: string): string | null {
+  const anchorIndex = content.indexOf(NAME_ASSIGNMENT)
+  if (anchorIndex === -1) return null
+
+  const parenOpen = anchorIndex + NAME_ASSIGNMENT.length - 1
+  let depth = 0
+  let i = parenOpen
+  for (; i < content.length; i++) {
+    if (content[i] === '(') depth++
+    else if (content[i] === ')') {
+      depth--
+      if (depth === 0) break
+    }
+  }
+  if (depth !== 0) return null
+
+  return content.slice(parenOpen, i + 1)
+}
+
+// Checks the fix's exact shape against the full source text of a file
+// containing commit.post.ts's `const name = (...)` assignment. Exported
+// (rather than only exercised via main()) so the self-test below can run it
+// against synthetic buggy/fixed fixtures without touching the real route
+// file.
+export function checkCommitNameFieldGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const expr = extractNameAssignment(content)
+  if (expr === null) {
+    errors.push(
+      `Could not find \`${NAME_ASSIGNMENT}\` in commit.post.ts -- has the ` +
+        'name/title computation been renamed, removed, or restructured? ' +
+        'If so, this guard (and the bug it protects against) needs to ' +
+        'move with it.',
+    )
+    return errors
+  }
+
+  const fallbackIndex = expr.indexOf(PITCH_FALLBACK)
+  if (fallbackIndex === -1) {
+    errors.push(
+      `\`${NAME_ASSIGNMENT}\` no longer contains the \`${PITCH_FALLBACK}\` ` +
+        "fallback -- this guard's anchor point has moved.",
+    )
+    return errors
+  }
+
+  const nameFieldIndex = expr.indexOf('fieldMap.name')
+  const titleFieldIndex = expr.indexOf('fieldMap.title')
+
+  if (nameFieldIndex === -1 || nameFieldIndex >= fallbackIndex) {
+    errors.push(
+      "commit.post.ts's name assignment does not prefer `fieldMap.name` " +
+        'ahead of the pitch-derived fallback. Every CREATE target that uses ' +
+        "a 'name' field (Character/Bot/Reward, per MODEL_FIELDS in " +
+        'modelBuilderFields.ts) exposes it as a required, user-editable ' +
+        'field in the batch editor and item panel -- without this, a ' +
+        'deliberately-typed name is silently discarded in favor of the ' +
+        "pitch's first line on commit.",
+    )
+  }
+
+  if (titleFieldIndex === -1 || titleFieldIndex >= fallbackIndex) {
+    errors.push(
+      "commit.post.ts's name assignment does not prefer `fieldMap.title` " +
+        'ahead of the pitch-derived fallback. Every CREATE target that uses ' +
+        "a 'title' field (Dream/Scenario/Project/Facet, per MODEL_FIELDS in " +
+        'modelBuilderFields.ts) exposes it as a required, user-editable ' +
+        'field in the batch editor and item panel -- without this, a ' +
+        'deliberately-typed title is silently discarded in favor of the ' +
+        "pitch's first line on commit.",
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(ROUTE_PATH, 'utf8')
+  const errors = checkCommitNameFieldGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder commit name/title field guard contract failed for ' +
+        'server/api/model-builder/items/[id]/commit.post.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder commit name/title field guard contract passed: CREATE ' +
+      'commits prefer the user-editable fieldMap.name/fieldMap.title over ' +
+      'the pitch-derived fallback.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
model-builder/t-029 recurring polish pass (conductor scheduled agent run)

### What changed / what I produced
- `server/api/model-builder/items/[id]/commit.post.ts`: the CREATE commit path computed the new record's `name`/`title` solely from the first line of `item.pitch`, discarding whatever the user (or AI drafter) typed into the field spec's required `name` (Character/Bot/Reward) or `title` (Dream/Scenario/Project/Facet) line — even though that same value is parsed into `fieldMap`, displayed, batch-editable, and persisted to `fieldsDraft`. Fixed by preferring `fieldMap.name` / `fieldMap.title` ahead of the pitch-derived fallback.
- Added `utils/scripts/verifyModelBuilderCommitNameFieldGuard.ts` (+ `.test.ts`) following the established `verifyModelBuilder*.ts` pattern, wired into `package.json` and `contract-tests.yml`'s required Contract Tests job.

### How I verified
- Read `commit.post.ts`'s `createRecord()` and all seven `*Fields()` helpers line-by-line to confirm none of them ever consumed `fieldMap.name`/`fieldMap.title` before this fix — concrete failure: type "Grommash Ironjaw" into a CREATE Character item's required Name field, approve every stage, commit — the resulting `Character.name` was the pitch's first line, not the typed name.
- New guard self-test passes (buggy/fixed/partial/missing-anchor fixtures); new guard passes against the real fixed file.
- All 9 pre-existing `verifyModelBuilder*.ts` guards + their self-tests still pass (no regression).
- `npx eslint` and `npx prettier --check` clean on all changed files.
- Full-project `npx vue-tsc --noEmit -p tsconfig.json` exit 0.

### Stakes
reversible

### Flags for Reviewer
- Conductor `model-builder/t-029` is recurring; rearm to `ready` on merge (not `done`).

### Kaizen suggestion
`prepareItemUpdate()` in `server/api/model-builder/runs/index.ts` derives no name/title validation either — the CREATE commit path now honors the field, but nothing asserts a *missing* required name/title is rejected server-side (only client-side via the batch editor's red-asterisk marker). Worth a follow-up guard asserting the commit route 400s on an empty required name/title rather than silently falling back to 'Untitled'.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HsvuMPiRNT25LZcc6LLwSM)_