### PR TITLE
fix(model-builder): commit route no longer clobbers a stage reopened mid-commit

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -340,6 +340,12 @@ jobs:
       - name: Model Builder commit name/title field guard contract
         run: npm run test:model-builder-commit-name-field-guard
 
+      - name: Model Builder commit stale-snapshot guard checker self-test
+        run: npm run test:model-builder-commit-stale-snapshot-guard-selftest
+
+      - name: Model Builder commit stale-snapshot guard contract
+        run: npm run test:model-builder-commit-stale-snapshot-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -165,6 +165,8 @@
     "test:model-builder-open-run-identity-guard": "tsx utils/scripts/verifyModelBuilderOpenRunIdentityGuard.ts",
     "test:model-builder-commit-name-field-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitNameFieldGuard.test.ts",
     "test:model-builder-commit-name-field-guard": "tsx utils/scripts/verifyModelBuilderCommitNameFieldGuard.ts",
+    "test:model-builder-commit-stale-snapshot-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.test.ts",
+    "test:model-builder-commit-stale-snapshot-guard": "tsx utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/server/api/model-builder/items/[id]/commit.post.ts
+++ b/server/api/model-builder/items/[id]/commit.post.ts
@@ -921,8 +921,20 @@ export default defineEventHandler(async (event) => {
       throw writeError
     }
 
+    // Re-read stageStatuses immediately before this final write rather than
+    // reusing the request-start `item` snapshot: the write above (promote /
+    // update / create+link) can be a slow, multi-step transaction, and
+    // nothing blocks the client from reopening this item's other stages
+    // (PATCH /items/:id) while it's in flight. Building the full
+    // stageStatuses blob from a stale snapshot would silently clobber that
+    // concurrent edit -- restoring stages to 'approved' that the user just
+    // reopened -- so merge the COMMIT key into the current DB value instead.
+    const latest = await prisma.modelBuildItem.findUnique({
+      where: { id },
+      select: { stageStatuses: true },
+    })
     const stages = parseStoredJson<Record<string, unknown>>(
-      item.stageStatuses,
+      latest?.stageStatuses ?? item.stageStatuses,
       {},
     )
     stages.COMMIT = {

--- a/utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.test.ts
@@ -1,0 +1,94 @@
+// /utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.test.ts
+//
+// Regression test for checkCommitStaleSnapshotGuard() in
+// verifyModelBuilderCommitStaleSnapshotGuard.ts (model-builder/t-029).
+// Exercises the real check against synthetic commit.post.ts-shaped fixtures
+// covering: the pre-fix shape (stages built solely from the request-start
+// `item.stageStatuses` snapshot, the exact bug found by manual read-through),
+// the fixed shape (a fresh `findUnique` read merged in immediately before the
+// COMMIT assignment), and a missing-anchor fixture.
+import assert from 'node:assert/strict'
+
+import { checkCommitStaleSnapshotGuard } from './verifyModelBuilderCommitStaleSnapshotGuard.js'
+
+const BUGGY_FIXTURE = `
+    const stages = parseStoredJson<Record<string, unknown>>(
+      item.stageStatuses,
+      {},
+    )
+    stages.COMMIT = {
+      status: 'approved',
+      note: \`Committed → \${target.type} #\${target.id}\`,
+    }
+
+    const updated = await prisma.modelBuildItem.update({
+      where: { id },
+      data: {
+        targetType: target.type,
+        targetId: target.id,
+        stageStatuses: JSON.stringify(stages),
+      },
+    })
+`
+
+const FIXED_FIXTURE = `
+    const latest = await prisma.modelBuildItem.findUnique({
+      where: { id },
+      select: { stageStatuses: true },
+    })
+    const stages = parseStoredJson<Record<string, unknown>>(
+      latest?.stageStatuses ?? item.stageStatuses,
+      {},
+    )
+    stages.COMMIT = {
+      status: 'approved',
+      note: \`Committed → \${target.type} #\${target.id}\`,
+    }
+
+    const updated = await prisma.modelBuildItem.update({
+      where: { id },
+      data: {
+        targetType: target.type,
+        targetId: target.id,
+        stageStatuses: JSON.stringify(stages),
+      },
+    })
+`
+
+function run(): void {
+  const buggyErrors = checkCommitStaleSnapshotGuard(BUGGY_FIXTURE)
+  assert.equal(
+    buggyErrors.length,
+    2,
+    'expected the buggy fixture (no fresh findUnique re-read) to fail ' +
+      `twice, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.match(buggyErrors[0]!, /does not re-read stageStatuses/)
+  assert.match(buggyErrors[1]!, /exact stale-snapshot shape/)
+
+  const fixedErrors = checkCommitStaleSnapshotGuard(FIXED_FIXTURE)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const missingAnchorErrors = checkCommitStaleSnapshotGuard(
+    'const somethingElse = 1',
+  )
+  assert.equal(
+    missingAnchorErrors.length,
+    1,
+    'expected a fixture with no `stages.COMMIT = {` assignment to fail ' +
+      'with a "could not find" error',
+  )
+  assert.match(missingAnchorErrors[0]!, /Could not find/)
+
+  console.log(
+    'Model Builder commit stale-snapshot guard self-test passed: buggy ' +
+      'fixture fails twice, fixed fixture passes, missing-anchor fixture ' +
+      'fails clearly.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.ts
+++ b/utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.ts
@@ -1,0 +1,148 @@
+// /utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.ts
+//
+// Regression guard (model-builder/t-029, kaizen) -- items/[id]/commit.post.ts
+// fetches the build item once at the very top of the request handler and
+// holds that snapshot across several slow, awaited operations (the
+// idempotency claim, then the actual write -- promoteAsset / updateText /
+// createRecord+linkSourceToTarget, the last of which runs inside a
+// prisma.$transaction that can involve multiple round-trips including
+// facet-sync work). After all of that finishes, the route used to build the
+// item's *entire* stageStatuses blob from that original, now-stale snapshot
+// (`item.stageStatuses`) and write it back wholesale.
+//
+// Nothing in the UI blocks a user from clicking "Edit" on that same item's
+// already-approved FIELDS_AND_PROMPTS (or PITCH) stage while the commit POST
+// is still in flight -- isCommitting only disables the Commit button itself.
+// Reopening a stage fires a separate, fast PATCH /items/:id that sets that
+// stage back to 'ready' and marks GENERATE_ASSETS/COMMIT 'stale'. If that
+// PATCH lands before the commit route's slower write finishes, the commit
+// route's final update -- built from its pre-commit snapshot -- clobbers it:
+// it silently restores the reopened stage (and GENERATE_ASSETS) back to
+// 'approved' and sets COMMIT to 'approved', even though the user just
+// reopened a stage for editing and it now holds unreviewed content. The
+// "approved" badge then lies about what's actually stored.
+//
+// Fixed by re-fetching stageStatuses immediately before the final write and
+// merging only the COMMIT key into that fresh value, instead of reusing the
+// request-start snapshot.
+//
+// This asserts the textual shape of that fix stays in place: the final
+// `stages.COMMIT = {` assignment in commit.post.ts's default event handler
+// builds `stages` from a value re-read from the database just before that
+// assignment, not from the request-start `item.stageStatuses` snapshot alone.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const ROUTE_PATH = join(
+  repositoryRoot,
+  'server/api/model-builder/items/[id]/commit.post.ts',
+)
+
+const COMMIT_STAGE_ASSIGNMENT = 'stages.COMMIT = {'
+const STALE_SNAPSHOT_SOURCE =
+  'parseStoredJson<Record<string, unknown>>(\n      item.stageStatuses,\n      {},\n    )'
+
+// Finds the `const stages = parseStoredJson<...>(...)` statement that feeds
+// directly into the `stages.COMMIT = {` assignment, by locating the
+// assignment and scanning backwards to the nearest preceding `const stages =`
+// declaration. Returns the full slice from that declaration through the end
+// of the assignment's opening brace line, so the check is robust to unrelated
+// reformatting elsewhere in the file.
+export function extractFinalStageWrite(content: string): string | null {
+  const assignmentIndex = content.indexOf(COMMIT_STAGE_ASSIGNMENT)
+  if (assignmentIndex === -1) return null
+
+  const declAnchor = 'const stages ='
+  const declIndex = content.lastIndexOf(declAnchor, assignmentIndex)
+  if (declIndex === -1) return null
+
+  // A fresh re-fetch (if present) is declared just *before* `const stages =`
+  // (e.g. `const latest = await prisma....findUnique(...)`), not inside it --
+  // widen the slice's start to include that preceding statement when it's
+  // immediately adjacent, so the fresh-read check below can see it.
+  const latestAnchor = 'const latest ='
+  const latestIndex = content.lastIndexOf(latestAnchor, declIndex)
+  const start =
+    latestIndex !== -1 && declIndex - latestIndex < 500
+      ? latestIndex
+      : declIndex
+
+  return content.slice(start, assignmentIndex + COMMIT_STAGE_ASSIGNMENT.length)
+}
+
+// Checks the fix's exact shape against the full source text of a file
+// containing commit.post.ts's final stageStatuses read-modify-write. Exported
+// (rather than only exercised via main()) so the self-test below can run it
+// against synthetic buggy/fixed fixtures without touching the real route
+// file.
+export function checkCommitStaleSnapshotGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const slice = extractFinalStageWrite(content)
+  if (slice === null) {
+    errors.push(
+      `Could not find the \`const stages = ...\` declaration feeding \`${COMMIT_STAGE_ASSIGNMENT}\` ` +
+        'in commit.post.ts -- has the final stageStatuses write been renamed, ' +
+        'removed, or restructured? If so, this guard (and the bug it protects ' +
+        'against) needs to move with it.',
+    )
+    return errors
+  }
+
+  const hasFreshRead =
+    slice.includes('findUnique') &&
+    (slice.includes('latest?.stageStatuses') ||
+      slice.includes('latest.stageStatuses'))
+
+  if (!hasFreshRead) {
+    errors.push(
+      "commit.post.ts's final `stages.COMMIT = {...}` write does not re-read " +
+        'stageStatuses from the database immediately beforehand -- it appears ' +
+        'to build the full stageStatuses blob from the request-start `item` ' +
+        'snapshot alone. The write above this point (promoteAsset / updateText ' +
+        '/ createRecord+linkSourceToTarget) can be slow, and nothing blocks the ' +
+        "client from reopening another stage (PATCH /items/:id) while it's in " +
+        'flight -- without a fresh read here, that concurrent edit gets ' +
+        'silently clobbered back to "approved".',
+    )
+  }
+
+  if (slice.includes(STALE_SNAPSHOT_SOURCE)) {
+    errors.push(
+      'commit.post.ts still builds `stages` directly from `item.stageStatuses` ' +
+        '(the request-start snapshot) with no fresh re-fetch -- this is the ' +
+        'exact stale-snapshot shape the fix was meant to remove.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(ROUTE_PATH, 'utf8')
+  const errors = checkCommitStaleSnapshotGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder commit stale-snapshot guard contract failed for ' +
+        'server/api/model-builder/items/[id]/commit.post.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder commit stale-snapshot guard contract passed: the final ' +
+      'stageStatuses write re-reads the current DB value before merging in ' +
+      'COMMIT, instead of reusing the request-start snapshot.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
model-builder/t-029: recurring polish task (kind: software)

### What changed / what I produced
- `server/api/model-builder/items/[id]/commit.post.ts`: the commit route fetched the build item once at the top of the request and built the final `stageStatuses` write from that request-start snapshot, even though the write in between (`promoteAsset` / `updateText` / `createRecord`+`linkSourceToTarget`, the last inside a multi-step `prisma.$transaction`) can be slow. Nothing in the UI blocks a user from reopening another already-approved stage (`PATCH /items/:id`, a fast write) while the commit POST is still in flight — so the commit route's stale-snapshot final write could silently restore that reopened stage (and `GENERATE_ASSETS`) back to `approved` and set `COMMIT` to `approved`, even though the user just reopened it for editing and it now holds unreviewed content. Fixed by re-fetching `stageStatuses` immediately before the final write and merging only the `COMMIT` key into that fresh value.
- Added `utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.ts` (+ `.test.ts`) following the established `verifyModelBuilder*Guard.ts` pattern, wired into `package.json` and `contract-tests.yml`'s required Contract Tests job.

### How I verified
- New guard self-test + guard pass locally (`npx tsx utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.test.ts` / `.ts`).
- All 9 pre-existing `verifyModelBuilder*.ts` guards + selftests still pass (no regression).
- `npx eslint` clean on all changed files; `npx prettier --check` clean.
- Full-project `vue-tsc --noEmit` (`npm run test`) exit 0.
- `git diff --stat` scoped to exactly the route fix, the new guard pair, and the two wiring files (excluded an unrelated `prisma/generated/` regeneration-drift diff produced by local provisioning, same pre-existing drift noted in prior model-builder/t-029 cycles).

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
Model Builder's item-panel UI could disable a stage's "Edit" button while a commit is in-flight for the same item (client-side belt-and-suspenders on top of this server-side fix), so the race window closes at the source instead of only being made safe to lose.

### Notes for reviewer
Found via an Explore-agent read-through of the full Model Builder surface against the exclusion list of every bug class fixed by prior cycles of this recurring task — this is a distinct mechanism (server-side stale-snapshot full-object overwrite in `commit.post.ts`) from all of them.


---
_Generated by [Claude Code](https://claude.ai/code/session_0169aiNVjwo6oA5JxNsvth3C)_