### PR TITLE
fix(model-builder): scope background save errors to their run

### DIFF
--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -644,14 +644,19 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     payload: Record<string, unknown>,
     meta?: { stage?: string; reason?: string },
   ): void {
+    const runId = state.run?.id
     performFetch(`/api/model-builder/items/${item.id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ ...payload, ...meta }),
     })
       .then((response) => {
-        if (!response.success) {
-          setStatus('error', response.message || 'Failed to save changes.')
+        if (!response.success && runId) {
+          setStatusForRun(
+            runId,
+            'error',
+            response.message || 'Failed to save changes.',
+          )
         }
       })
       .catch((error) => handleError(error, 'saving build item'))
@@ -669,6 +674,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     }>,
   ): void {
     if (!entries.length) return
+    const runId = state.run?.id
     performFetch('/api/model-builder/items/batch', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
@@ -681,8 +687,12 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       }),
     })
       .then((response) => {
-        if (!response.success) {
-          setStatus('error', response.message || 'Failed to save changes.')
+        if (!response.success && runId) {
+          setStatusForRun(
+            runId,
+            'error',
+            response.message || 'Failed to save changes.',
+          )
         }
       })
       .catch((error) => handleError(error, 'saving build items'))


### PR DESCRIPTION
## Summary
- capture the active Model Builder run ID before optimistic single-item PATCH persistence starts
- do the same for batch PATCH persistence
- route failed-save banners through the existing `setStatusForRun` guard, so a late failure from a run the user navigated away from cannot appear on the newly active run

Fixes #1725.

## Verification
- branch diff is one store file only: 14 additions / 4 deletions
- exact-head TypeScript and repository contract checks are the merge gates for this connector-only run

## Stakes
Reversible, client-only status/error presentation fix. No API/schema/database/ArtJob/production-data changes.

## Flags for reviewer
The underlying PATCH still runs and persists normally after navigation; this only scopes its failure banner to the originating run. Network exceptions continue through the existing `handleError` path unchanged.

## Kaizen suggestion
If this pattern recurs, consider a small static Model Builder guard requiring background async status writers to carry run ownership, but avoid expanding this bug fix merely to add another textual verifier.