### PR TITLE
davinci: add an exit control for an in-progress life run

### DIFF
--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -113,6 +113,15 @@
                 {{ chapterCount }}
               </template>
             </p>
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs gap-1 rounded-lg text-base-content/40 normal-case hover:text-error"
+              :disabled="submitting"
+              @click="abandonRun"
+            >
+              <Icon name="kind-icon:close" class="size-3.5" />
+              Abandon this life
+            </button>
           </div>
 
           <div class="grid grid-cols-5 gap-2 sm:grid-cols-10">
@@ -782,6 +791,20 @@ function playAgain() {
   narrationError.value = ''
   aiChapter.value = null
   phase.value = 'start'
+}
+
+// The only way to leave an in-progress run used to be manually clearing
+// STORAGE_KEY from localStorage — never exposed in the UI. This gives players
+// a real exit before MIN_CHAPTERS_BEFORE_ENDING, gated behind a confirm since
+// it discards real progress. Reuses playAgain()'s reset logic rather than
+// duplicating it.
+function abandonRun() {
+  if (submitting.value) return
+  const confirmed = window.confirm(
+    'Abandon this life and start over? This discards your progress so far.',
+  )
+  if (!confirmed) return
+  playAgain()
 }
 
 onMounted(() => {


### PR DESCRIPTION
### Task
davinci/t-023: Add an exit control for an in-progress Da Vinci life run (kind: software)

### What changed / what I produced
- Added a low-key "Abandon this life" button to the `phase === 'playing'` header row in `components/conductor/davinci-page.vue`.
- Added `abandonRun()`: gated behind `window.confirm` (matches the existing confirm pattern used elsewhere in the codebase, e.g. `art-gallery.vue`), then delegates to the existing `playAgain()` reset logic rather than duplicating it.

### How I verified
- `vue-tsc --noEmit`: clean (exit 0).
- `eslint components/conductor/davinci-page.vue`: clean (exit 0).
- `prettier --check`: clean.
- Reverted incidental `prisma/generated/**` regeneration drift from local dependency provisioning so the diff is scoped to the one intended file.

### Stakes
reversible

### Flags for Reviewer
- No visual/browser verification was possible from this sandbox (documented Chromium-through-proxy limitation in conductor `AGENTS.md`) — verified via typecheck/lint/prettier only, plus reading the existing `playAgain()`/`resumeRun()` flow to confirm the reset semantics match exactly.

### Kaizen suggestion
Add a contract-test guard asserting every long-running interactive flow (davinci, taskmaster, etc.) exposes a UI-level abandon/exit control rather than relying on a manually-cleared localStorage key — this bug class (silent unexposed exit) could recur in similar run-state components.

### Notes for reviewer
Conductor `davinci/t-023`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuUgnF8BEZgGFFEn6xGyeQ)_