### PR TITLE
fix(model-builder): announce async feedback

### DIFF
--- a/components/model-builder/model-builder-manager.vue
+++ b/components/model-builder/model-builder-manager.vue
@@ -61,6 +61,8 @@
         :class="
           store.statusTone === 'error' ? 'kr-note-error' : 'kr-note-success'
         "
+        :role="store.statusTone === 'error' ? 'alert' : 'status'"
+        aria-atomic="true"
       >
         {{ store.statusMessage }}
       </div>


### PR DESCRIPTION
### Task
model-builder/t-029 recurring polish pass

### What changed
- Give Model Builder's global async feedback banner explicit live-region semantics.
- Successful feedback uses `role="status"`; errors use `role="alert"`.
- Mark the message atomic so assistive tech announces the complete updated feedback.

### Why
The banner is the primary feedback surface for drafting, generation, commit, and persistence outcomes, but it was visually rendered only. Screen-reader users could miss both successes and actionable failures.

### Verification
- Compared branch against current `main`: exactly one component, 2 additions, no unrelated drift.
- Required PR checks must complete successfully on the exact head before merge.

### Stakes
reversible

### Flags for Reviewer
None. No API, schema, persistence, production-data, or generation behavior changes.

### Kaizen suggestion
Consider a future accessibility contract covering async status/alert regions across manager surfaces if this pattern recurs elsewhere.