### PR TITLE
fix(model-builder): expose header control state

### DIFF
--- a/components/model-builder/model-builder-manager.vue
+++ b/components/model-builder/model-builder-manager.vue
@@ -27,6 +27,7 @@
                 ? 'btn-ghost text-base-content/60'
                 : 'btn-ghost text-base-content/30 pointer-events-none'
           "
+          :disabled="!crumb.enabled"
           @click="crumb.enabled && store.goToStep(crumb.step)"
         >
           <span class="opacity-50">{{ index + 1 }}.</span>
@@ -38,6 +39,8 @@
         type="button"
         class="btn btn-xs btn-ghost ml-auto h-7 min-h-7 rounded-xl px-2"
         :class="showHistory ? 'text-primary' : 'text-base-content/60 hover:text-primary'"
+        aria-label="Toggle run history"
+        :aria-pressed="showHistory"
         @click="showHistory = !showHistory"
       >
         <Icon name="kind-icon:clock" class="h-3.5 w-3.5" />
@@ -47,6 +50,7 @@
       <button
         type="button"
         class="btn btn-xs btn-ghost h-7 min-h-7 rounded-xl px-2 text-base-content/60 hover:text-error"
+        aria-label="Reset Model Builder"
         @click="store.resetAll()"
       >
         <Icon name="kind-icon:trash" class="h-3.5 w-3.5" />


### PR DESCRIPTION
### Task
model-builder/t-029 recurring front-end polish

### What changed
- give disabled Model Builder breadcrumb steps native `disabled` semantics instead of relying on pointer-events only
- keep responsive History and Reset controls explicitly named when their visible labels hide on small screens
- expose History's toggle state with `aria-pressed`

### Why
The disabled Recipe/Run crumbs were mouse-inert but still keyboard-focusable and announced as ordinary enabled buttons. On narrow layouts the History/Reset text is hidden, leaving icon-only controls without a guaranteed accessible name.

### Verification
- compared branch against current `main`: exactly one component changed, four additive attributes
- required GitHub checks must complete successfully on this exact head before merge

### Stakes
reversible

### Flags for reviewer
Accessibility-only UI semantics. No API, store, schema, persistence, route, or production-data behavior changes.

### Kaizen suggestion
None; this is the bounded accessibility finding for the recurring polish pass.