### PR TITLE
storybook: add a contract for the casting board's role tiers

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -115,6 +115,13 @@ jobs:
       - name: Narrative roles contract
         run: npm run test:narrative-roles
 
+      # The casting board groups cast members into three tiers purely from
+      # their assigned role (t-011). Nothing asserted that grouping until
+      # now -- a future edit could silently move a role to the wrong tier,
+      # or collapse the branching back to one flat grid, with CI still green.
+      - name: Narrative cast tiers contract
+        run: npm run test:narrative-cast-tiers
+
       - name: Earned-karma wiring contract
         run: npm run test:earned-karma-wiring
 

--- a/components/narrative/narrative-role-assigner.vue
+++ b/components/narrative/narrative-role-assigner.vue
@@ -142,6 +142,7 @@
 import { computed } from 'vue'
 import {
   duplicateSingularRoles,
+  narrativeCastTier,
   narrativeRoleLabel,
 } from '@/utils/narrativeRoles'
 import type { NarrativeIngredientOption } from '@/utils/narrativeIngredients'
@@ -167,27 +168,24 @@ const roleFor = (slug: string): string | null => props.modelValue[slug] ?? null
  * neither has been given prominence.
  */
 const protagonists = computed(() =>
-  props.members.filter((member) => roleFor(member.slug) === 'protagonist'),
+  props.members.filter(
+    (member) => narrativeCastTier(roleFor(member.slug)) === 'protagonist',
+  ),
 )
 const antagonists = computed(() =>
-  props.members.filter((member) => roleFor(member.slug) === 'antagonist'),
+  props.members.filter(
+    (member) => narrativeCastTier(roleFor(member.slug)) === 'antagonist',
+  ),
 )
 const supportingCast = computed(() =>
-  props.members.filter((member) => {
-    const role = roleFor(member.slug)
-    return (
-      role !== null &&
-      role !== 'protagonist' &&
-      role !== 'antagonist' &&
-      role !== 'ensemble'
-    )
-  }),
+  props.members.filter(
+    (member) => narrativeCastTier(roleFor(member.slug)) === 'support',
+  ),
 )
 const backCast = computed(() =>
-  props.members.filter((member) => {
-    const role = roleFor(member.slug)
-    return role === null || role === 'ensemble'
-  }),
+  props.members.filter(
+    (member) => narrativeCastTier(roleFor(member.slug)) === 'back',
+  ),
 )
 
 function toggle(slug: string, key: string): void {

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "test:user-role-expand": "tsx utils/scripts/verifyUserRoleExpand.ts",
     "test:user-role-predicates": "tsx utils/scripts/verifyUserRolePredicates.ts",
     "test:narrative-roles": "tsx utils/scripts/verifyNarrativeRoles.ts",
+    "test:narrative-cast-tiers": "tsx utils/scripts/verifyNarrativeCastTiers.ts",
     "test:narrative-kit": "tsx utils/scripts/verifyNarrativeKit.ts",
     "test:child-maturity": "tsx utils/scripts/verifyChildMaturityRestriction.ts",
     "test:no-unquoted-reserved-word-tables": "tsx utils/scripts/verifyNoUnquotedReservedWordTables.ts",

--- a/utils/narrativeRoles.ts
+++ b/utils/narrativeRoles.ts
@@ -163,6 +163,33 @@ export function duplicateSingularRoles(
     .sort()
 }
 
+/** The casting board's three tiers. Lead is split into its two opposed parts
+ * so a caller can seat protagonist(s) and antagonist(s) on opposite sides
+ * rather than mixed into one row. */
+export type NarrativeCastTier =
+  'protagonist' | 'antagonist' | 'support' | 'back'
+
+/**
+ * Which tier of the casting board a role belongs in.
+ *
+ * `protagonist`/`antagonist` lead, given prominence and set opposite each
+ * other. The other five real roles (`love-interest`, `mentor`, `foil`,
+ * `ally`, `wildcard`) hold the supporting middle row. `ensemble` and an
+ * unassigned member (`null`) share the back row — ranked behind without
+ * being hidden, since roles stay optional and an unassigned card still has
+ * to be readable and pressable. Extracted from narrative-role-assigner.vue
+ * (t-011) so the grouping is a pure function CI can exercise directly rather
+ * than logic only reachable by mounting the component.
+ */
+export function narrativeCastTier(
+  roleKey: string | null | undefined,
+): NarrativeCastTier {
+  if (roleKey === 'protagonist') return 'protagonist'
+  if (roleKey === 'antagonist') return 'antagonist'
+  if (!roleKey || roleKey === 'ensemble') return 'back'
+  return 'support'
+}
+
 /**
  * The Cast line for the story bible.
  *

--- a/utils/scripts/verifyNarrativeCastTiers.ts
+++ b/utils/scripts/verifyNarrativeCastTiers.ts
@@ -1,0 +1,123 @@
+// /utils/scripts/verifyNarrativeCastTiers.ts
+//
+// Kaizen from t-011 (kind_robots PR #1727): narrative-role-assigner.vue
+// groups cast members into three board tiers purely from their assigned
+// role -- protagonist/antagonist into the lead row (facing each other),
+// love-interest/mentor/foil/ally/wildcard into the supporting row, and
+// ensemble/unassigned into the back row -- but nothing asserted that
+// grouping in CI. eslint/vue-tsc/verifyNarrativeRoles.ts all passed without
+// ever checking tier placement, so a future edit could silently move a role
+// to the wrong tier, or collapse the branching entirely back to one flat
+// grid, and nothing would fail.
+//
+// The grouping logic now lives in narrativeCastTier() (utils/narrativeRoles),
+// extracted from the component so it is a pure function CI can feed a
+// synthetic member of every role through -- rather than only reachable by
+// mounting the component. Narrow by design, same spirit as
+// verifyStorybookObjectEntryLinks.mjs: this asserts the grouping itself, not
+// button markup, CSS classes, or layout.
+//
+//   npx tsx utils/scripts/verifyNarrativeCastTiers.ts
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { NARRATIVE_ROLE_KEYS, narrativeCastTier } from '../narrativeRoles'
+
+const root = process.cwd()
+let failures = 0
+
+function check(condition: boolean, message: string): void {
+  if (condition) {
+    console.log(`ok - ${message}`)
+    return
+  }
+  failures += 1
+  console.error(`FAIL - ${message}`)
+}
+
+const read = (path: string): string => readFileSync(resolve(root, path), 'utf8')
+
+/* --- the lead row: protagonist and antagonist, and only those two -------- */
+
+check(
+  narrativeCastTier('protagonist') === 'protagonist',
+  'a protagonist lands in the protagonist tier',
+)
+check(
+  narrativeCastTier('antagonist') === 'antagonist',
+  'an antagonist lands in the antagonist tier',
+)
+
+/* --- the supporting row: every other real, non-ensemble role ------------- */
+
+const supportingRoles = NARRATIVE_ROLE_KEYS.filter(
+  (key) => key !== 'protagonist' && key !== 'antagonist' && key !== 'ensemble',
+)
+check(
+  supportingRoles.length > 0,
+  'there is at least one supporting role to check (vocabulary is not empty)',
+)
+for (const key of supportingRoles) {
+  check(
+    narrativeCastTier(key) === 'support',
+    `'${key}' lands in the supporting tier, not lead or back`,
+  )
+}
+
+/* --- the back row: ensemble and unassigned -------------------------------- */
+
+check(
+  narrativeCastTier('ensemble') === 'back',
+  'ensemble lands in the back tier',
+)
+check(
+  narrativeCastTier(null) === 'back',
+  'an unassigned member (null) lands in the back tier',
+)
+check(
+  narrativeCastTier(undefined) === 'back',
+  'an unassigned member (undefined) lands in the back tier',
+)
+
+/* --- untrusted input: a stale/unknown role key should not vanish --------- */
+
+check(
+  narrativeCastTier('villain') === 'support',
+  'an unknown/stale role key degrades to the supporting tier rather than ' +
+    'throwing or silently dropping the member off the board entirely',
+)
+
+/* --- the wiring: the component must actually call this, not re-inline it - */
+/*
+ * A CALL, not a mention. Asserting only that the file imports
+ * narrativeCastTier would pass even if a future edit re-inlined the old
+ * ad hoc role === 'protagonist' / role !== ... conditionals and left the
+ * import dangling unused.
+ */
+const component = read('components/narrative/narrative-role-assigner.vue')
+const calls = component.match(/narrativeCastTier\(/g) ?? []
+check(
+  calls.length >= 4,
+  'the casting board calls narrativeCastTier() for each of its four tier ' +
+    'computeds (protagonists/antagonists/supportingCast/backCast), not an ' +
+    'inlined copy of the grouping logic',
+)
+check(
+  !/roleFor\(member\.slug\)\s*===\s*'protagonist'/.test(component) &&
+    !/roleFor\(member\.slug\)\s*===\s*'antagonist'/.test(component),
+  'the tier computeds no longer branch on role keys directly -- the shared ' +
+    'function is the single source of truth for tier placement',
+)
+
+if (failures) {
+  console.error(
+    `\nNarrative cast tiers contract failed with ${failures} error(s).`,
+  )
+  process.exitCode = 1
+} else {
+  console.log(
+    '\nNarrative cast tiers contract passed: every role lands on the ' +
+      'casting board in its expected tier, and the board gets that ' +
+      'placement from the shared function rather than an inlined copy.',
+  )
+}


### PR DESCRIPTION
### Task
storybook/t-019: Add a contract asserting the casting board's role tiers group members correctly (kind: software)

### What changed / what I produced
- Extracted the casting board's tier-grouping logic out of `narrative-role-assigner.vue`'s inline computed filters into a pure, exported `narrativeCastTier()` function in `utils/narrativeRoles.ts`.
- Wired the component's four tier computeds (`protagonists`/`antagonists`/`supportingCast`/`backCast`) to call the shared function instead of re-inlining the role-key conditionals. Behavior is unchanged — same tiers, same rows.
- Added `utils/scripts/verifyNarrativeCastTiers.ts`: feeds a synthetic member of every real role (protagonist, antagonist, love-interest, mentor, foil, ally, wildcard), plus ensemble and unassigned (null/undefined), through `narrativeCastTier()` and asserts it lands in the expected tier. Also asserts the component actually *calls* the shared function (not just imports it) and no longer branches on role keys directly, so a future edit can't silently re-inline the old conditionals and drift from the tested logic.
- Wired the new check into `package.json` (`test:narrative-cast-tiers`) and `.github/workflows/contract-tests.yml`, next to the existing narrative-roles contract.

### How I verified
- `npx tsx utils/scripts/verifyNarrativeCastTiers.ts` — all checks pass.
- `npx tsx utils/scripts/verifyNarrativeRoles.ts` — still passes (no regression to the sibling contract).
- `npx vue-tsc --noEmit` — clean.
- `npx eslint` / `npx prettier --check` on all changed files — clean.
- Reverted incidental `prisma/generated/**` regeneration drift from local dependency provisioning before committing, keeping the diff scoped to the task.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
The same "logic lives only inside a component's `<script setup>`, so CI can't exercise it without mounting" shape likely recurs elsewhere in the narrative/casting surface — worth a quick grep for other computed-property groupings (e.g. in `narrative-cast-card.vue` or the story wizard steps) that would benefit from the same pure-function extraction before their own next edit silently drifts.

### Notes for reviewer
conductor: storybook/t-019, set to `status: review`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EA3vx3hNL4jG3R1REsDSKG)_