### PR TITLE
storybook: drag cast cards onto role slots

### DIFF
--- a/components/narrative/narrative-cast-card.vue
+++ b/components/narrative/narrative-cast-card.vue
@@ -7,8 +7,8 @@
   for why the board is tiered at all).
 
   Presentational only: the parent owns the role map and passes down which
-  role (if any) this member currently holds; this emits the chip press back
-  up rather than mutating anything itself.
+  role (if any) this member currently holds; this emits the chip press and
+  drag gestures back up rather than mutating anything itself.
 -->
 <template>
   <li
@@ -17,6 +17,9 @@
       role ? 'border-secondary/60 ring-1 ring-secondary/30' : 'border-base-300',
       size === 'back' ? 'opacity-90' : '',
     ]"
+    draggable="true"
+    @dragstart="startNativeDrag"
+    @dragend="emit('drag-cancel')"
   >
     <div class="relative">
       <kr-art-plate
@@ -28,8 +31,19 @@
         :placeholder-icon="member.icon || 'kind-icon:user'"
       />
 
-      <!-- The part, worn on the card. This is what makes the board readable
-           without reading: a glance says who leads and who opposes. -->
+      <button
+        type="button"
+        class="absolute right-2 top-2 z-10 cursor-grab touch-none rounded-lg bg-base-100/90 px-2 py-1 text-xs font-black shadow active:cursor-grabbing"
+        :aria-label="`Drag ${member.title} to a part`"
+        title="Drag to a part"
+        @pointerdown="startPointerDrag"
+        @pointermove="movePointerDrag"
+        @pointerup="finishPointerDrag"
+        @pointercancel="cancelPointerDrag"
+      >
+        <span aria-hidden="true">⋮⋮</span>
+      </button>
+
       <span
         v-if="role"
         class="badge badge-secondary badge-sm absolute left-2 top-2 gap-1 rounded-xl shadow"
@@ -50,11 +64,6 @@
       </span>
     </div>
 
-    <!--
-      Chips, not a dropdown. Pressing the active part again clears it, so
-      removing someone from a role costs the same one tap as giving them
-      one -- a dropdown makes "none" a hunt back through the list.
-    -->
     <div
       class="flex flex-wrap gap-1 p-2"
       role="group"
@@ -87,22 +96,71 @@ import type { NarrativeIngredientOption } from '@/utils/narrativeIngredients'
 
 const props = defineProps<{
   member: NarrativeIngredientOption
-  /** This member's current role key, or null when unassigned. */
   role: string | null
-  /**
-   * Board tier this card renders at. 'lead' is given prominence (protagonist
-   * / antagonist), 'support' is the default size, 'back' is ranked behind
-   * (ensemble and anyone not yet given a part) and reads as slightly
-   * receded rather than fully de-emphasised -- an unassigned card is still
-   * drawn quietly, not hidden.
-   */
   size: 'lead' | 'support' | 'back'
 }>()
 
 const emit = defineEmits<{
   'toggle-role': [key: string]
+  'drag-start': []
+  'drag-move': [x: number, y: number]
+  'drag-end': [x: number, y: number]
+  'drag-cancel': []
 }>()
 
 const roleLabel = computed(() => narrativeRoleLabel(props.role))
 const roleIcon = computed(() => narrativeRole(props.role)?.icon ?? '')
+
+let pointerId: number | null = null
+let pointerStartX = 0
+let pointerStartY = 0
+let pointerDragging = false
+
+function startNativeDrag(event: DragEvent): void {
+  if (event.dataTransfer) {
+    event.dataTransfer.effectAllowed = 'move'
+    event.dataTransfer.setData('text/plain', props.member.slug)
+  }
+  emit('drag-start')
+}
+
+function startPointerDrag(event: PointerEvent): void {
+  if (event.pointerType === 'mouse') return
+  pointerId = event.pointerId
+  pointerStartX = event.clientX
+  pointerStartY = event.clientY
+  pointerDragging = false
+  ;(event.currentTarget as HTMLElement).setPointerCapture(event.pointerId)
+}
+
+function movePointerDrag(event: PointerEvent): void {
+  if (event.pointerId !== pointerId) return
+  if (!pointerDragging) {
+    const distance = Math.hypot(
+      event.clientX - pointerStartX,
+      event.clientY - pointerStartY,
+    )
+    if (distance < 8) return
+    pointerDragging = true
+    emit('drag-start')
+  }
+  emit('drag-move', event.clientX, event.clientY)
+}
+
+function finishPointerDrag(event: PointerEvent): void {
+  if (event.pointerId !== pointerId) return
+  if (pointerDragging) emit('drag-end', event.clientX, event.clientY)
+  resetPointerDrag()
+}
+
+function cancelPointerDrag(event: PointerEvent): void {
+  if (event.pointerId !== pointerId) return
+  if (pointerDragging) emit('drag-cancel')
+  resetPointerDrag()
+}
+
+function resetPointerDrag(): void {
+  pointerId = null
+  pointerDragging = false
+}
 </script>

--- a/components/narrative/narrative-cast-card.vue
+++ b/components/narrative/narrative-cast-card.vue
@@ -17,11 +17,13 @@
       role ? 'border-secondary/60 ring-1 ring-secondary/30' : 'border-base-300',
       size === 'back' ? 'opacity-90' : '',
     ]"
-    draggable="true"
-    @dragstart="startNativeDrag"
-    @dragend="emit('drag-cancel')"
   >
-    <div class="relative">
+    <div
+      class="relative cursor-grab active:cursor-grabbing"
+      draggable="true"
+      @dragstart="startNativeDrag"
+      @dragend="emit('drag-cancel')"
+    >
       <kr-art-plate
         :source="member"
         variant="card"

--- a/components/narrative/narrative-role-assigner.vue
+++ b/components/narrative/narrative-role-assigner.vue
@@ -5,36 +5,13 @@
   Silas, 2026-08-06: "I'm imagining a layout that lets the user feel like they
   are selecting cards and creating a playboard that turns into a story."
 
-  The first version of this was a list of rows with a <select> in each. It
-  worked, and it was wrong twice over: it did not feel like anything, and it
-  did not even match the step directly above it, where the cast is chosen from
-  art-forward cards with selected rings and check badges
-  (narrative-ingredient-card.vue). Dropping from cards to a dropdown mid-flow
-  is the same hodgepodge this whole pass exists to remove.
+  The board arranges BY role. Protagonist(s) and antagonist(s) get the lead
+  row, supporting parts hold the middle row, and ensemble/unassigned share a
+  smaller back row. Card markup lives in narrative-cast-card.vue.
 
-  It also, at first, put every card in one uniform auto-fill grid regardless
-  of part — reading order, not story order. t-011 (2026-08-10) fixed that:
-  the board now arranges BY role instead. Protagonist(s) and antagonist(s) get
-  the lead row, given prominence and set facing each other rather than side by
-  side in the same line — a protagonist and an antagonist read as opposed, not
-  as neighbours. Supporting parts (love interest, mentor, foil, ally,
-  wildcard) hold the middle row at the original size. Ensemble and anyone not
-  yet given a part share the back row, smaller and slightly receded — ranked
-  behind without being hidden, since an unassigned card still has to be
-  readable and pressable. A board with nothing assigned collapses to exactly
-  one back row, which is the old uniform grid: this is additive, not a
-  rewrite of the unassigned state.
-
-  Card markup itself lives in narrative-cast-card.vue so the three tiers don't
-  triple it.
-
-  Presentational and controlled, the contract kr-gallery keeps: the parent owns
-  the cast and the role map, this emits changes, and it imports no store so it
-  can drop into Storybook now and Taskmaster or the Stage system later.
-
-  Roles stay OPTIONAL. An unassigned card is drawn quietly and produces exactly
-  the story-bible line it always did (see castLineWithRole), so a story that
-  ignores casting generates identically to before.
+  Presentational and controlled: the parent owns the cast and role map, this
+  emits changes, and it imports no store. Roles stay optional, and the role
+  chips remain the keyboard/accessibility path alongside drag-and-drop.
 -->
 <template>
   <div v-if="members.length" class="space-y-4">
@@ -42,9 +19,8 @@
       <div>
         <p class="text-sm font-black">The casting board</p>
         <p class="mt-0.5 text-xs leading-relaxed text-base-content/55">
-          Give anyone a part and the narrator is told what it means — a
-          protagonist is followed, an antagonist is opposed. Leave a card blank
-          and the story decides.
+          Drag a card onto a part, or use its buttons. Leave a card blank and
+          the story decides.
         </p>
       </div>
       <span
@@ -55,9 +31,35 @@
       </span>
     </div>
 
-    <!-- Lead row: protagonist(s) given prominence on one side, antagonist(s)
-         set opposite on the other. Only renders once someone actually holds
-         one of these parts. -->
+    <div class="rounded-2xl border border-base-300 bg-base-200/40 p-2.5">
+      <div
+        class="grid gap-2 [grid-template-columns:repeat(auto-fit,minmax(min(7.5rem,100%),1fr))]"
+        role="group"
+        aria-label="Casting role drop zones"
+      >
+        <div
+          v-for="option in NARRATIVE_ROLES"
+          :key="option.key"
+          :data-cast-role="option.key"
+          class="flex min-h-12 items-center gap-2 rounded-xl border border-dashed px-2.5 py-2 text-xs font-bold transition"
+          :class="
+            dragOverRole === option.key
+              ? 'border-secondary bg-secondary/15 ring-2 ring-secondary/30'
+              : draggingSlug
+                ? 'border-base-content/35 bg-base-100'
+                : 'border-base-300 bg-base-100/70'
+          "
+          @dragenter.prevent="dragOverRole = option.key"
+          @dragover.prevent="dragOverRole = option.key"
+          @dragleave="dragOverRole = null"
+          @drop.prevent="dropRole(option.key)"
+        >
+          <Icon :name="option.icon" class="size-4 shrink-0" aria-hidden="true" />
+          <span>{{ option.label }}</span>
+        </div>
+      </div>
+    </div>
+
     <div
       v-if="protagonists.length || antagonists.length"
       class="flex flex-wrap items-start justify-between gap-3"
@@ -71,6 +73,10 @@
           :role="roleFor(member.slug)"
           size="lead"
           @toggle-role="toggle(member.slug, $event)"
+          @drag-start="startDrag(member.slug)"
+          @drag-move="trackPointerDrag"
+          @drag-end="finishPointerDrag"
+          @drag-cancel="cancelDrag"
         />
       </ul>
       <ul
@@ -86,12 +92,14 @@
           :role="roleFor(member.slug)"
           size="lead"
           @toggle-role="toggle(member.slug, $event)"
+          @drag-start="startDrag(member.slug)"
+          @drag-move="trackPointerDrag"
+          @drag-end="finishPointerDrag"
+          @drag-cancel="cancelDrag"
         />
       </ul>
     </div>
 
-    <!-- Supporting row: everyone with a part that isn't lead or ensemble,
-         at the board's original card size. -->
     <ul
       v-if="supportingCast.length"
       class="grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(min(11rem,100%),1fr))]"
@@ -103,13 +111,13 @@
         :role="roleFor(member.slug)"
         size="support"
         @toggle-role="toggle(member.slug, $event)"
+        @drag-start="startDrag(member.slug)"
+        @drag-move="trackPointerDrag"
+        @drag-end="finishPointerDrag"
+        @drag-cancel="cancelDrag"
       />
     </ul>
 
-    <!-- Back row: ensemble and anyone not yet given a part. Ranked behind —
-         smaller and a touch quieter — but still fully readable and pressable,
-         since roles stay optional. This is the whole board when nothing has
-         been assigned yet. -->
     <ul
       v-if="backCast.length"
       class="grid gap-2.5 [grid-template-columns:repeat(auto-fill,minmax(min(8.5rem,100%),1fr))]"
@@ -121,13 +129,13 @@
         :role="roleFor(member.slug)"
         size="back"
         @toggle-role="toggle(member.slug, $event)"
+        @drag-start="startDrag(member.slug)"
+        @drag-move="trackPointerDrag"
+        @drag-end="finishPointerDrag"
+        @drag-cancel="cancelDrag"
       />
     </ul>
 
-    <!--
-      A WARNING, not a block. Two protagonists is unusual, not invalid, and
-      refusing to render it would be the tool arguing with the author.
-    -->
     <p
       v-if="duplicateWarning"
       class="kr-note kr-note-warning text-xs"
@@ -139,18 +147,17 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import {
   duplicateSingularRoles,
+  NARRATIVE_ROLES,
   narrativeCastTier,
   narrativeRoleLabel,
 } from '@/utils/narrativeRoles'
 import type { NarrativeIngredientOption } from '@/utils/narrativeIngredients'
 
 const props = defineProps<{
-  /** The chosen cast, in the parent's order. */
   members: NarrativeIngredientOption[]
-  /** slug -> role key. Members absent from the map are unassigned. */
   modelValue: Record<string, string>
 }>()
 
@@ -158,15 +165,11 @@ const emit = defineEmits<{
   'update:modelValue': [value: Record<string, string>]
 }>()
 
+const draggingSlug = ref<string | null>(null)
+const dragOverRole = ref<string | null>(null)
+
 const roleFor = (slug: string): string | null => props.modelValue[slug] ?? null
 
-/*
- * The board's three tiers. A member falls into exactly one, decided purely
- * by their current role — reassigning a part moves the card, nothing else
- * to track. `protagonist`/`antagonist` lead; the other five real roles hold
- * the supporting middle; `ensemble` and unassigned share the back row, since
- * neither has been given prominence.
- */
 const protagonists = computed(() =>
   props.members.filter(
     (member) => narrativeCastTier(roleFor(member.slug)) === 'protagonist',
@@ -189,17 +192,48 @@ const backCast = computed(() =>
 )
 
 function toggle(slug: string, key: string): void {
-  /*
-   * An unassigned member is ABSENT from the map rather than stored as ''. The
-   * map is persisted in the setup draft, and empty entries would survive there
-   * forever for cast members long since removed. Rebuilt by filtering rather
-   * than deleting a computed key, which the lint config forbids.
-   */
   const next = Object.fromEntries(
     Object.entries(props.modelValue).filter(([entry]) => entry !== slug),
   )
   if (roleFor(slug) !== key) next[slug] = key
   emit('update:modelValue', next)
+}
+
+function assignRole(slug: string, key: string): void {
+  emit('update:modelValue', { ...props.modelValue, [slug]: key })
+}
+
+function startDrag(slug: string): void {
+  draggingSlug.value = slug
+}
+
+function cancelDrag(): void {
+  draggingSlug.value = null
+  dragOverRole.value = null
+}
+
+function dropRole(key: string): void {
+  if (draggingSlug.value) assignRole(draggingSlug.value, key)
+  cancelDrag()
+}
+
+function roleAtPoint(x: number, y: number): string | null {
+  if (typeof document === 'undefined') return null
+  const slot = document
+    .elementFromPoint(x, y)
+    ?.closest('[data-cast-role]') as HTMLElement | null
+  const key = slot?.dataset.castRole ?? null
+  return key && NARRATIVE_ROLES.some((role) => role.key === key) ? key : null
+}
+
+function trackPointerDrag(x: number, y: number): void {
+  dragOverRole.value = roleAtPoint(x, y)
+}
+
+function finishPointerDrag(x: number, y: number): void {
+  const role = roleAtPoint(x, y)
+  if (role) dropRole(role)
+  else cancelDrag()
 }
 
 const assignedCount = computed(

--- a/utils/scripts/verifyNarrativeCastTiers.ts
+++ b/utils/scripts/verifyNarrativeCastTiers.ts
@@ -1,21 +1,8 @@
 // /utils/scripts/verifyNarrativeCastTiers.ts
 //
-// Kaizen from t-011 (kind_robots PR #1727): narrative-role-assigner.vue
-// groups cast members into three board tiers purely from their assigned
-// role -- protagonist/antagonist into the lead row (facing each other),
-// love-interest/mentor/foil/ally/wildcard into the supporting row, and
-// ensemble/unassigned into the back row -- but nothing asserted that
-// grouping in CI. eslint/vue-tsc/verifyNarrativeRoles.ts all passed without
-// ever checking tier placement, so a future edit could silently move a role
-// to the wrong tier, or collapse the branching entirely back to one flat
-// grid, and nothing would fail.
-//
-// The grouping logic now lives in narrativeCastTier() (utils/narrativeRoles),
-// extracted from the component so it is a pure function CI can feed a
-// synthetic member of every role through -- rather than only reachable by
-// mounting the component. Narrow by design, same spirit as
-// verifyStorybookObjectEntryLinks.mjs: this asserts the grouping itself, not
-// button markup, CSS classes, or layout.
+// Casting-board contract: role-to-tier grouping plus the interaction wiring
+// that lets cards move to role drop zones without removing the pressable-chip
+// accessibility fallback.
 //
 //   npx tsx utils/scripts/verifyNarrativeCastTiers.ts
 
@@ -37,8 +24,6 @@ function check(condition: boolean, message: string): void {
 
 const read = (path: string): string => readFileSync(resolve(root, path), 'utf8')
 
-/* --- the lead row: protagonist and antagonist, and only those two -------- */
-
 check(
   narrativeCastTier('protagonist') === 'protagonist',
   'a protagonist lands in the protagonist tier',
@@ -47,8 +32,6 @@ check(
   narrativeCastTier('antagonist') === 'antagonist',
   'an antagonist lands in the antagonist tier',
 )
-
-/* --- the supporting row: every other real, non-ensemble role ------------- */
 
 const supportingRoles = NARRATIVE_ROLE_KEYS.filter(
   (key) => key !== 'protagonist' && key !== 'antagonist' && key !== 'ensemble',
@@ -64,8 +47,6 @@ for (const key of supportingRoles) {
   )
 }
 
-/* --- the back row: ensemble and unassigned -------------------------------- */
-
 check(
   narrativeCastTier('ensemble') === 'back',
   'ensemble lands in the back tier',
@@ -78,46 +59,63 @@ check(
   narrativeCastTier(undefined) === 'back',
   'an unassigned member (undefined) lands in the back tier',
 )
-
-/* --- untrusted input: a stale/unknown role key should not vanish --------- */
-
 check(
   narrativeCastTier('villain') === 'support',
-  'an unknown/stale role key degrades to the supporting tier rather than ' +
-    'throwing or silently dropping the member off the board entirely',
+  'an unknown/stale role key degrades to the supporting tier rather than disappearing',
 )
 
-/* --- the wiring: the component must actually call this, not re-inline it - */
-/*
- * A CALL, not a mention. Asserting only that the file imports
- * narrativeCastTier would pass even if a future edit re-inlined the old
- * ad hoc role === 'protagonist' / role !== ... conditionals and left the
- * import dangling unused.
- */
 const component = read('components/narrative/narrative-role-assigner.vue')
 const calls = component.match(/narrativeCastTier\(/g) ?? []
 check(
   calls.length >= 4,
-  'the casting board calls narrativeCastTier() for each of its four tier ' +
-    'computeds (protagonists/antagonists/supportingCast/backCast), not an ' +
-    'inlined copy of the grouping logic',
+  'the casting board calls narrativeCastTier() for all four tier computeds',
 )
 check(
   !/roleFor\(member\.slug\)\s*===\s*'protagonist'/.test(component) &&
     !/roleFor\(member\.slug\)\s*===\s*'antagonist'/.test(component),
-  'the tier computeds no longer branch on role keys directly -- the shared ' +
-    'function is the single source of truth for tier placement',
+  'tier placement stays centralized in narrativeCastTier()',
+)
+
+const card = read('components/narrative/narrative-cast-card.vue')
+check(
+  /:data-cast-role="option\.key"/.test(component) &&
+    /@drop\.prevent="dropRole\(option\.key\)"/.test(component),
+  'each narrative role is rendered as an actual card drop zone',
+)
+check(
+  /draggable="true"/.test(card) && /@dragstart="startNativeDrag"/.test(card),
+  'cast cards support native mouse drag',
+)
+check(
+  /@pointerdown="startPointerDrag"/.test(card) &&
+    /event\.pointerType === 'mouse'/.test(card) &&
+    /setPointerCapture/.test(card) &&
+    /@pointermove="movePointerDrag"/.test(card) &&
+    /@pointerup="finishPointerDrag"/.test(card),
+  'cast cards provide a Pointer Events drag path for touch and pen',
+)
+check(
+  /class="[^"]*touch-none[^"]*"/.test(card),
+  'the touch drag handle suppresses browser panning while a pointer drag is active',
+)
+check(
+  /:aria-pressed="role === option\.key"/.test(card) &&
+    /@click="emit\('toggle-role', option\.key\)"/.test(card),
+  'pressable role chips remain as the keyboard/accessibility fallback',
+)
+check(
+  /elementFromPoint\(x, y\)/.test(component) &&
+    /closest\('\[data-cast-role\]'\)/.test(component),
+  'touch drag completion resolves the role slot under the pointer',
 )
 
 if (failures) {
   console.error(
-    `\nNarrative cast tiers contract failed with ${failures} error(s).`,
+    `\nNarrative casting-board contract failed with ${failures} error(s).`,
   )
   process.exitCode = 1
 } else {
   console.log(
-    '\nNarrative cast tiers contract passed: every role lands on the ' +
-      'casting board in its expected tier, and the board gets that ' +
-      'placement from the shared function rather than an inlined copy.',
+    '\nNarrative casting-board contract passed: role tiers, mouse drag, touch/pen drag, and chip fallback are all wired.',
   )
 }


### PR DESCRIPTION
### Task
storybook/t-012: Drag a character card onto a role slot (kind: software)

### What changed
- Added an explicit role-slot tray to the Storybook casting board.
- Cast artwork is natively draggable with a mouse; dropping onto a role assigns that part.
- Added a Pointer Events drag handle for touch/pen with an 8px movement threshold, pointer capture, hit-testing against the same role slots, and visual drop-target highlighting.
- Kept every existing role chip and its `aria-pressed` behavior intact as the keyboard/accessibility fallback.
- Extended the existing `verifyNarrativeCastTiers.ts` contract so CI also guards mouse drag, touch/pen drag, drop-zone wiring, and the chip fallback.

### Verification
- Conductor `storybook/t-012` is canonically `review` for session `20260811T012235Z-auto-bqbl06` before this PR opened.
- Branch is based on current Kind Robots `main` and is 0 commits behind; diff is exactly the two casting-board components plus the existing casting-board contract.
- This connector runtime has no local Kind Robots checkout, so exact-head GitHub Actions are the verification gate. Merge only after required checks finish successfully.
- `worker/*` branches do not receive Vercel previews under current repo policy; if merged, verify the resulting production deployment instead.

### Stakes
reversible

### Flags for Reviewer
The drag gesture only changes the same controlled role map the existing chips already mutate. No store, API, schema, persistence, ArtJob, or production-data behavior changes.

### Kaizen suggestion
If another board adopts card dragging, extract the small pointer-drag gesture into a reusable composable rather than cloning the pointer-capture/hit-test mechanics.