### PR TITLE
style(storybook): carry board cards into narrative pickers

### DIFF
--- a/components/narrative/narrative-ingredient-multi-picker.vue
+++ b/components/narrative/narrative-ingredient-multi-picker.vue
@@ -1,7 +1,7 @@
 <!-- /components/narrative/narrative-ingredient-multi-picker.vue -->
 <template>
   <section
-    class="space-y-3"
+    class="kr-panel-flat space-y-3 p-3"
     role="group"
     :aria-labelledby="headingId"
     :aria-describedby="describedBy"

--- a/components/narrative/narrative-ingredient-picker.vue
+++ b/components/narrative/narrative-ingredient-picker.vue
@@ -1,7 +1,7 @@
 <!-- /components/narrative/narrative-ingredient-picker.vue -->
 <template>
   <section
-    class="space-y-3"
+    class="kr-panel-flat space-y-3 p-3"
     role="group"
     :aria-labelledby="headingId"
     :aria-describedby="helper ? helperId : undefined"


### PR DESCRIPTION
### Task
storybook/t-013, first bounded slice.

### What changed
- Promote the shared single-select and multi-select narrative ingredient pickers to `kr-panel-flat` cards with internal padding.
- This gives Storybook's World step the same raised-card language already used by the casting board and Story Bible review cards, without changing selection behavior, APIs, stores, or persistence.
- The shared primitives also stay visually consistent in Taskmaster, their only other app consumer.

### Verification
- Diff is limited to the two shared narrative picker roots; behavior and accessibility wiring are unchanged.
- Required exact-head GitHub checks must complete successfully before merge.

### Handoff
This intentionally does not mark t-013 done. Premise already has structure cards, but its title/premise composition and the final Review composition still merit a later bounded pass before the visual-acceptance gate t-016 is unblocked.