### PR TITLE
fix(model-builder): label batch field controls

### DIFF
--- a/components/model-builder/model-builder-batch-editor.vue
+++ b/components/model-builder/model-builder-batch-editor.vue
@@ -120,15 +120,17 @@
           :key="field.key"
           class="flex items-center gap-2"
         >
-          <span
+          <label
             class="w-24 shrink-0 truncate text-xs font-semibold text-base-content"
+            :for="batchFieldId(field.key)"
             :title="field.label"
           >
             {{ field.label }}
             <span v-if="field.required" class="text-error">*</span>
-          </span>
+          </label>
           <select
             v-if="field.choices"
+            :id="batchFieldId(field.key)"
             v-model="batchValues[field.key]"
             class="select select-bordered select-xs flex-1 bg-base-100"
           >
@@ -143,6 +145,7 @@
           </select>
           <input
             v-else
+            :id="batchFieldId(field.key)"
             v-model="batchValues[field.key]"
             type="text"
             :placeholder="field.default || 'value for all'"
@@ -152,6 +155,7 @@
             type="button"
             class="btn btn-xs rounded-lg"
             :disabled="batching || !batchValues[field.key]"
+            :aria-label="`Apply ${field.label} to all ${group.items.length} items`"
             @click="applyField(field.key)"
           >
             Apply
@@ -237,6 +241,10 @@ const autoBuildGroupTitle = computed(() =>
 
 const onlyEmpty = ref(false)
 const batchValues = reactive<Record<string, string>>({})
+
+function batchFieldId(key: string): string {
+  return `model-builder-batch-${props.outputKey}-${key}`
+}
 
 async function draftAll(field: DraftField): Promise<void> {
   if (!group.value) return


### PR DESCRIPTION
### Task
model-builder/t-029 recurring front-end polish

### Root cause
The Model Builder batch editor renders every shared field name in a visual `<span>` beside its `<select>` or `<input>`. Because the text is not an associated `<label>`, assistive technology reaches those controls without their visible field name. The repeated `Apply` buttons also all expose the same name with no field context.

### What changed
- Associate every batch field label with its select/input via a stable per-output/per-field id.
- Give each repeated Apply button a field-specific accessible name including the group size.
- No store, API, schema, persistence, generation, or production-data behavior changes.

### Verification
- Conductor `model-builder/t-029` is canonically `review` for session `20260811T031323Z-auto-9ed9cf` before this PR opened.
- Branch is exactly 1 commit ahead / 0 behind current `main` and changes one component: 10 additions / 2 deletions.
- This runtime has no local Kind Robots checkout, so exact-head GitHub Actions are the verification gate. Merge only after the attached required checks finish successfully.
- `worker/*` branches do not receive a Vercel preview under current repository policy; verify the post-merge production deployment if merged.

### Stakes
reversible

### Flags for reviewer
Accessibility-only semantics around existing batch-edit controls.