### PR TITLE
style(storybook): carry board cards into the premise step

### DIFF
--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -118,7 +118,7 @@
 
         <section
           v-if="setupStep === 0"
-          class="space-y-5 rounded-2xl border border-primary/20 bg-primary/5 p-4"
+          class="space-y-4 rounded-2xl border border-primary/20 bg-primary/5 p-4"
         >
           <div>
             <h2 class="text-lg font-black">The spark</h2>
@@ -128,39 +128,45 @@
             </p>
           </div>
 
-          <label class="form-control w-full">
-            <span
-              class="label-text mb-1 text-xs font-bold uppercase tracking-wide"
-            >
-              Working title (optional)
-            </span>
-            <input
-              v-model="store.setupDraft.title"
-              type="text"
-              class="input input-bordered w-full rounded-xl bg-base-100"
-              placeholder="The Clockwork Orchard"
-            />
-          </label>
+          <!-- Title and premise share one board card -- they're one decision
+               (what this story is), the same reasoning that keeps cast and
+               roles together on the casting board rather than splitting them
+               across screens. -->
+          <div class="kr-panel-flat space-y-3 p-3">
+            <label class="form-control w-full">
+              <span
+                class="label-text mb-1 text-xs font-bold uppercase tracking-wide"
+              >
+                Working title (optional)
+              </span>
+              <input
+                v-model="store.setupDraft.title"
+                type="text"
+                class="input input-bordered w-full rounded-xl bg-base-100"
+                placeholder="The Clockwork Orchard"
+              />
+            </label>
 
-          <label class="form-control w-full">
-            <span
-              class="label-text mb-1 text-xs font-bold uppercase tracking-wide"
-            >
-              Premise
-            </span>
-            <textarea
-              v-model="store.setupDraft.premise"
-              rows="5"
-              class="textarea textarea-bordered w-full rounded-xl bg-base-100 text-sm leading-relaxed"
-              placeholder="Every midnight, the town's abandoned observatory receives a letter from a star that should not exist…"
-            />
-            <span class="mt-1 text-[0.7rem] text-base-content/45">
-              This is creative direction, not a prompt for model or generator
-              settings.
-            </span>
-          </label>
+            <label class="form-control w-full">
+              <span
+                class="label-text mb-1 text-xs font-bold uppercase tracking-wide"
+              >
+                Premise
+              </span>
+              <textarea
+                v-model="store.setupDraft.premise"
+                rows="5"
+                class="textarea textarea-bordered w-full rounded-xl bg-base-100 text-sm leading-relaxed"
+                placeholder="Every midnight, the town's abandoned observatory receives a letter from a star that should not exist…"
+              />
+              <span class="mt-1 text-[0.7rem] text-base-content/45">
+                This is creative direction, not a prompt for model or generator
+                settings.
+              </span>
+            </label>
+          </div>
 
-          <div class="space-y-2">
+          <div class="kr-panel-flat space-y-2 p-3">
             <h3
               class="text-xs font-bold uppercase tracking-wide text-base-content/55"
             >
@@ -185,7 +191,7 @@
             </div>
           </div>
 
-          <div class="space-y-2">
+          <div class="kr-panel-flat space-y-2 p-3">
             <h3
               class="text-xs font-bold uppercase tracking-wide text-base-content/55"
             >


### PR DESCRIPTION
### Task
storybook/t-013: Bring the other three Storybook setup steps up to the board (kind: software)

### What changed / what I produced
- Wrapped the "The spark" step's title/premise fields, narrator-voice picker, and story-shape picker in `kr-panel-flat` board cards, matching the card language already carried into the casting board (#1735/#1736) and the world/flavor step's ingredient pickers (#1737).
- Title and premise share one card (they're one decision — what the story is); narrator voice and story shape each get their own card, mirroring how the world/flavor step wraps each field group.
- No store, API, or behavior changes — purely structural/visual, reusing the existing `.kr-panel-flat` utility class.

### How I verified
- `npx vue-tsc --noEmit` — clean
- `npx eslint components/conductor/storybook-page.vue` — clean
- `npx prettier --check components/conductor/storybook-page.vue` — clean (auto-formatted)
- Read through the resulting template diff to confirm labels/inputs/ARIA attributes are unchanged, only their wrapping containers moved.
- Could not drive a live browser in this sandbox (documented Chromium-through-proxy limitation); relying on the CI layout/accessibility checks plus this being a mechanical reuse of an already-shipped, already-verified pattern (#1737) rather than new design.

### Stakes
reversible

### Flags for Reviewer
- This is a bounded slice of storybook/t-013: only the premise step (setup step 0) is addressed here. The task's Review step (final setup step) already uses `kr-panel-flat` cards for its summary blocks and reads as reasonably board-like already, so I left it for a follow-up slice rather than guessing at a bigger redesign without visual feedback — the task's own open design question ("does the whole wizard become one board, or do steps stay distinct with shared card language") is still unresolved and better left to a session with visual verification.
- roadmap task left at `status: review`; will close to `done` after this merges.

### Kaizen suggestion
None new this cycle — this reuses an already-established pattern from #1737 rather than introducing anything novel.

### Notes for reviewer
storybook/t-013 recurring bounded-slice task; expect it to stay `ready` after this merges for the next slice (Review step composition).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXxu22JhkQrWJV3y8jSdaa)_