### PR TITLE
storybook: show plot thread and artwork on review board

### DIFF
--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -365,9 +365,39 @@
               </dd>
             </div>
             <div class="kr-panel-flat p-3">
+              <dt class="text-xs font-bold text-base-content/55">Plot thread</dt>
+              <dd class="mt-2 flex items-center gap-3">
+                <div v-if="selectedScenario" class="w-16 shrink-0">
+                  <KrArtPlate
+                    :source="selectedScenario"
+                    variant="icon"
+                    shape="square"
+                    frame="thin"
+                    :alt="selectedScenario.title"
+                    placeholder-icon="kind-icon:map"
+                  />
+                </div>
+                <span class="text-sm">
+                  {{ selectedScenario?.title || 'Premise-led story' }}
+                </span>
+              </dd>
+            </div>
+            <div class="kr-panel-flat p-3">
               <dt class="text-xs font-bold text-base-content/55">Setting</dt>
-              <dd class="mt-1 text-sm">
-                {{ selectedLocation?.title || 'Invented from the premise' }}
+              <dd class="mt-2 flex items-center gap-3">
+                <div v-if="selectedLocation" class="w-16 shrink-0">
+                  <KrArtPlate
+                    :source="selectedLocation"
+                    variant="icon"
+                    shape="square"
+                    frame="thin"
+                    :alt="selectedLocation.title"
+                    placeholder-icon="kind-icon:moon"
+                  />
+                </div>
+                <span class="text-sm">
+                  {{ selectedLocation?.title || 'Invented from the premise' }}
+                </span>
               </dd>
             </div>
             <div class="kr-panel-flat p-3">


### PR DESCRIPTION
### Task
storybook/t-013: bring the remaining Storybook setup review surface up to the board language.

### Root cause
The final Story bible review omitted the selected Scenario entirely even though the World step can choose one and `beginStory()` persists it as the story's plot thread. The review also reduced the selected plot/setting ingredients back to text, losing the visual card language established in the ingredient pickers.

### What changed
- Add a Plot thread card to the final Story bible, showing the selected Scenario or an explicit premise-led fallback.
- Reuse `KrArtPlate` for compact Scenario and Location artwork inside the Plot thread and Setting review cards.
- No store, API, schema, persistence, generation, ArtJob, or production-data changes.

### Verification
- Conductor `storybook/t-013` is canonically `review` for session `20260811T041634Z-storybook-t013-231336` before this PR opened.
- Branch is exactly 1 commit ahead / 0 behind the current base used for this slice and changes one component: 32 additions / 2 deletions.
- Merge only after exact-head GitHub checks complete successfully.

### Stakes
reversible

### Flags for reviewer
This remains a bounded t-013 slice. Cast/Facet/Reward summaries are still text-forward, so close the task back to `ready` rather than `done` unless visual review proves this is sufficient.