### PR TITLE
fix(model-builder): expose source picker toggle state

### DIFF
--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -23,6 +23,8 @@
               : 'btn-ghost text-base-content/50'
           "
           :title="mode.label"
+          :aria-label="`${mode.label} view`"
+          :aria-pressed="viewMode === mode.value"
           @click="setViewMode(mode.value)"
         >
           <Icon :name="mode.icon" class="h-3.5 w-3.5" />
@@ -42,6 +44,7 @@
             ? 'btn-primary'
             : 'btn-ghost border border-base-300 text-base-content/70'
         "
+        :aria-pressed="store.sourceType === type.key"
         @click="store.selectSourceType(type.key)"
       >
         <Icon :name="type.icon" class="h-4 w-4" />


### PR DESCRIPTION
### Task
model-builder/t-029 recurring polish pass

### What changed
- Give the icon-only Gallery/Grid/List controls explicit accessible names.
- Expose their selected state with `aria-pressed`.
- Expose the selected source-model type with `aria-pressed` as well.

### Scope
One component only. No API, store, persistence, schema, ArtJob, or production-data changes.

### Verification
Required exact-head GitHub checks must complete successfully before merge.

### Handoff
Reversible accessibility-only UI semantics. Conductor task was moved to `review` before this PR opened.