### PR TITLE
style(storybook): wrap extra story direction in a board card

### DIFF
--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -320,19 +320,21 @@
             :max-selections="3"
           />
 
-          <label class="form-control w-full">
-            <span
-              class="label-text mb-1 text-xs font-bold uppercase tracking-wide"
-            >
-              Extra story direction (optional)
-            </span>
-            <textarea
-              v-model="store.setupDraft.notes"
-              rows="3"
-              class="textarea textarea-bordered w-full rounded-xl bg-base-100 text-sm leading-relaxed"
-              placeholder="Keep the rivalry affectionate. Let every machine feel slightly alive. Avoid a chosen-one prophecy."
-            />
-          </label>
+          <div class="kr-panel-flat space-y-2 p-3">
+            <label class="form-control w-full">
+              <span
+                class="label-text mb-1 text-xs font-bold uppercase tracking-wide"
+              >
+                Extra story direction (optional)
+              </span>
+              <textarea
+                v-model="store.setupDraft.notes"
+                rows="3"
+                class="textarea textarea-bordered w-full rounded-xl bg-base-100 text-sm leading-relaxed"
+                placeholder="Keep the rivalry affectionate. Let every machine feel slightly alive. Avoid a chosen-one prophecy."
+              />
+            </label>
+          </div>
         </section>
 
         <section


### PR DESCRIPTION
### Task
storybook/t-013: bring the other three Storybook setup steps up to the board (kind: software)

### What changed / what I produced
- Wrapped the "Extra story direction (optional)" textarea on setup step 2 (World) in a `kr-panel-flat` card, matching every other field on setup steps 0-2 and the review step, which already carry that card language after three prior cycles today (#1740, #1741, #1745).
- This was the last remaining plain-form field in the wizard — the ingredient pickers (`NarrativeIngredientPicker`/`NarrativeIngredientMultiPicker`) already ship `kr-panel-flat` internally, and the premise/review sections were already converted.

### How I verified
- `npx vue-tsc --noEmit` — clean
- `npx eslint components/conductor/storybook-page.vue` — clean
- `npx prettier --check components/conductor/storybook-page.vue` — clean
- `git diff --stat` confirms exactly one file changed, scoped to the intended wrap

### Stakes
reversible

### Flags for Reviewer
With this merged, every field across all four setup steps and the review step shares the `kr-panel-flat` board-card language. Recommend treating storybook/t-013's original scope ("bring the other three Storybook setup steps up to the board") as complete — I'll mark the conductor task `done` rather than re-arming it `ready`, per the prior session's own note to assess exhaustion rather than assume another slice always exists.

### Kaizen suggestion
None new — the open design question the task originally posed ("one board vs. distinct steps sharing card language") is now answered in practice: the wizard kept its four distinct steps, and card language was extended to all of them instead of merging into one screen.

### Notes for reviewer
Companion conductor PR closes storybook/t-013 to `done` (not recurring re-arm) once this merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3DW439hoJpF7JkiuJ5Uak)_