### PR TITLE
Size the channel menu to its channels, and move the card toggle into the hub

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -175,35 +175,21 @@
         </Transition>
       </section>
 
-      <div
-        class="pointer-events-auto fixed bottom-3 right-3 z-40 flex items-end gap-2"
-      >
-        <button
-          type="button"
-          class="kr-workspace-dock group relative shrink-0 overflow-hidden rounded-full border-2 border-primary/70 bg-base-100 shadow-2xl ring-2 ring-base-100/80 transition duration-200 hover:scale-105 hover:border-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-          :aria-label="bottomDockLabel"
-          :title="bottomDockLabel"
-          :aria-expanded="handOpen"
-          @click="toggleCards"
-        >
-          <div
-            class="absolute -inset-1 rounded-full bg-primary/20 opacity-0 blur-xl transition group-hover:opacity-100"
-          />
+      <!--
+        THE FLOATING CARD DOCK USED TO LIVE HERE, as a `fixed bottom-3 right-3`
+        circle that toggled the hand. Silas, 2026-08-11: "remove the front end
+        toggle for the card view, and put it in the login-manager menu ... no
+        other conditionals, just a toggle that controls whether the user sees
+        our hand navigation menu on the bottom of the page".
 
-          <span
-            class="relative flex h-full w-full items-center justify-center bg-primary/10 text-primary"
-          >
-            <Icon name="kind-icon:card" class="h-8 w-8" />
-          </span>
-
-          <span
-            class="absolute bottom-0.5 left-0.5 flex h-6 w-6 items-center justify-center rounded-full border border-base-300 bg-base-100/95 text-primary shadow"
-            aria-hidden="true"
-          >
-            <Icon :name="bottomDockActionIcon" class="h-3.5 w-3.5" />
-          </span>
-        </button>
-      </div>
+        It was the last floating control on the page, and it cost more than its
+        own footprint: the hand had to stop short of it horizontally (see the
+        note on `right` in footerVars below), so a button that only ever said
+        "show cards / hide cards" was permanently eating a corner of the cards
+        it toggled. Moving it into the account hub gives the hand the full
+        width back and puts the switch where every other app-level preference
+        already lives.
+      -->
 
       <template #fallback>
         <div
@@ -322,9 +308,12 @@ let xlMedia: MediaQueryList | null = null
  * and sceneChoices into the eager first-paint bundle for every visitor. It now
  * belongs to the dream interact surface, which loads it on demand.
  *
- * The dock is a plain two-state toggle: cards shown, or cards hidden.
+ * The hand is a plain two-state preference: cards shown, or cards hidden. It
+ * reads from navStore rather than a local ref because the switch that flips it
+ * now lives in the account hub -- a sibling several levels down, not an
+ * ancestor -- and because the preference is remembered across reloads.
  */
-const handOpen = ref(false)
+const { workspaceHandOpen: handOpen } = storeToRefs(navStore)
 
 function syncBreakpoints(): void {
   if (mdMedia) isMd.value = mdMedia.matches
@@ -333,13 +322,7 @@ function syncBreakpoints(): void {
 
 const SHEET_W_MD = '20rem'
 const SHEET_W_XL = '24rem'
-const DOCK_CIRCLE_MD = '4.5rem'
-const DOCK_CIRCLE_MOBILE = '5.25rem'
 const HAND_PANEL_H = '11.5rem'
-
-const dockCircle = computed(() => {
-  return isMd.value ? DOCK_CIRCLE_MD : DOCK_CIRCLE_MOBILE
-})
 
 const sheetWidth = computed(() => {
   if (!workspaceSheetOpen.value || !isMd.value) return '0px'
@@ -368,7 +351,6 @@ const footerHeight = computed(() => {
 const shellVars = computed<CSSProperties>(() => {
   return {
     '--sheet-w': sheetWidth.value,
-    '--dock-circle': dockCircle.value,
     '--footer-h': footerHeight.value,
     // Same measured height as --footer-h: the slot the hand sits in and the
     // padding the page reserves for it must be the same number, or the
@@ -382,34 +364,18 @@ const footerVars = computed<CSSProperties>(() => {
   return {
     left: 'var(--sheet-w)',
     /*
-     * Stop the hand before the dock button instead of running underneath it.
-     * The dock is a sibling overlay pinned bottom-right, so a footer ending at
-     * right:0 necessarily passes behind it — measured at 390px, the hand's
-     * right edge was 382 while the dock started at 294, so 88px of cards sat
-     * under the button and the last card could not be reached. Silas: "the
-     * toggle is still over the hand display ... [it] should stop horizontally
-     * before it hits the toggle."
-     *
-     * --dock-circle is the button's own size and 0.75rem matches its `right-3`
-     * inset, so this tracks the dock at every breakpoint rather than hardcoding
-     * a width that would drift the moment the button is resized.
+     * FULL WIDTH AGAIN. This used to read
+     * `calc(var(--dock-circle) + 0.75rem + 0.5rem)` so the hand would stop
+     * short of the floating card dock rather than run underneath it — measured
+     * at 390px, 88px of cards sat under the button and the last card could not
+     * be reached. That dock is gone (Silas moved the toggle into the account
+     * hub, 2026-08-11), so there is nothing in the bottom-right corner left to
+     * dodge and the cards get the width back.
      */
-    right: 'calc(var(--dock-circle) + 0.75rem + 0.5rem)',
+    right: '0px',
     height: 'var(--footer-h)',
   } as CSSProperties
 })
-
-const bottomDockLabel = computed(() =>
-  handOpen.value ? 'Hide cards' : 'Show cards',
-)
-
-const bottomDockActionIcon = computed(() =>
-  handOpen.value ? 'kind-icon:close' : 'kind-icon:card',
-)
-
-function toggleCards(): void {
-  handOpen.value = !handOpen.value
-}
 
 function setWorkspaceSheetOpen(value: boolean): void {
   navStore.setWorkspaceSheetOpen(value)
@@ -479,11 +445,6 @@ onBeforeUnmount(() => {
   padding-bottom: var(--footer-h);
 }
 
-.kr-workspace-dock {
-  height: var(--dock-circle);
-  width: var(--dock-circle);
-}
-
 @media (min-width: 768px) {
   .kr-main {
     padding-left: var(--sheet-w);
@@ -503,10 +464,29 @@ onBeforeUnmount(() => {
   transform: translateX(-1rem);
 }
 
+/*
+ * This rule used to be a dangling selector list — `.kr-hand-slide-enter-active,
+ * .kr-hand-slide-leave-active,` with a comma running straight into the
+ * @media below and no declaration block of its own. The parser swallowed
+ * both selectors into the at-rule's prelude, so the hand had no transition at
+ * all and the reduced-motion guard had nothing to guard. The guard existing is
+ * the evidence motion was intended here; this restores it, matching the
+ * sheet's timing above.
+ */
 .kr-hand-slide-enter-active,
-.kr-hand-slide-leave-active,
+.kr-hand-slide-leave-active {
+  transition:
+    opacity 240ms ease,
+    transform 240ms ease;
+}
+
+.kr-hand-slide-enter-from,
+.kr-hand-slide-leave-to {
+  opacity: 0;
+  transform: translateY(1rem);
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .kr-workspace-dock,
   .kr-hand-slide-enter-active,
   .kr-hand-slide-leave-active {
     transition: none;

--- a/components/navigation/account-hub.vue
+++ b/components/navigation/account-hub.vue
@@ -319,7 +319,56 @@
         </div>
       </section>
 
-      <!-- 5. MATURITY, a preference rather than an action, so it sits last. -->
+      <!--
+        5. PREFERENCES, rather than actions, so they sit last.
+
+        THE CARD HAND SWITCH USED TO BE A FLOATING BUTTON pinned to the
+        bottom-right corner of every page. Silas, 2026-08-11: "remove the front
+        end toggle for the card view, and put it in the login-manager menu. It
+        needs a real icon, but that's it, and no other conditionals, just a
+        toggle that controls whether the user sees our hand navigation menu on
+        the bottom of the page, remembered in localstorage."
+
+        "No other conditionals" is why this one carries no `v-if` at all, unlike
+        the maturity toggle below it — the hand is chrome every visitor sees,
+        signed in or not, so gating the switch on a login would strand guests
+        with whatever state they happened to land on.
+      -->
+      <label
+        class="flex cursor-pointer items-center justify-between gap-3 kr-panel-flat px-3 py-2"
+        title="Show or hide the card hand along the bottom of the page"
+      >
+        <span class="flex min-w-0 items-center gap-3">
+          <span
+            class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl"
+            :class="
+              navStore.workspaceHandOpen
+                ? 'bg-primary/15 text-primary'
+                : 'bg-base-200 text-base-content/55'
+            "
+          >
+            <Icon name="kind-icon:cards" class="h-5 w-5" />
+          </span>
+
+          <span class="min-w-0">
+            <span class="block text-sm font-bold text-base-content">
+              Card hand
+            </span>
+            <span class="block text-xs text-base-content/55">
+              Navigation cards along the bottom of the page.
+            </span>
+          </span>
+        </span>
+
+        <input
+          type="checkbox"
+          class="toggle toggle-primary toggle-sm shrink-0"
+          :checked="navStore.workspaceHandOpen"
+          aria-label="Show the card hand"
+          @change="onCardHandChange"
+        />
+      </label>
+
       <maturity-toggle
         v-if="showDashboardMaturityToggle && userStore.isLoggedIn"
         variant="resource"
@@ -332,6 +381,7 @@
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useLoginManagerStore } from '@/stores/loginStore'
 import { useMaturityPreferenceStore } from '@/stores/maturityPreferenceStore'
+import { useNavStore } from '@/stores/navStore'
 import {
   useNotificationStore,
   type AppNotification,
@@ -343,6 +393,7 @@ const store = useLoginManagerStore()
 const userStore = useUserStore()
 const notifications = useNotificationStore()
 const maturityPreferenceStore = useMaturityPreferenceStore()
+const navStore = useNavStore()
 const menuRef = ref<HTMLElement | null>(null)
 const fallbackAvatar = '/images/kindart.webp'
 
@@ -404,6 +455,10 @@ function handlePointerDown(event: PointerEvent) {
   if (!menuRef.value?.contains(target)) {
     store.close()
   }
+}
+
+function onCardHandChange(event: Event): void {
+  navStore.setWorkspaceHandOpen((event.target as HTMLInputElement).checked)
 }
 
 function captureCurrent() {

--- a/components/navigation/channel-select.vue
+++ b/components/navigation/channel-select.vue
@@ -39,9 +39,29 @@
       class="dropdown-content z-110 mt-2 kr-anchor-panes"
       @focusin="scheduleChannelMenuViewportUpdate"
     >
+      <!--
+        SIZED BY ITS OWN CONTENT, not by the tab lists. Silas, 2026-08-11:
+        "There is a weird gap with our channel selector, it looks like it's
+        always as large as the larger tab listings, but we would have room to
+        show the channel and tabs closer to their actual inline with their
+        header locations if we didn't make that choice."
+
+        He was reading it exactly right. This was `w-[min(22rem,...)]` — the
+        same literal 22rem the tab dropdown uses — so a list of five one-word
+        channel names was held open at the width of the longest TAB list on the
+        site. Measured on /dashboard at 1440: 352px of menu around 239px of
+        content, and the tab flyout consequently started at x=390 when the tab
+        control it stands in for sits at x=185 in the header.
+
+        `w-max` lets the four channel rows decide, with a floor so a short list
+        does not collapse into a sliver and the old 22rem kept as the cap for
+        narrow viewports (where it degrades to the viewport instead). The
+        flyout moves left by whatever the rows save, which is the whole of what
+        "closer to their header locations" asks for.
+      -->
       <ul
         ref="channelMenu"
-        class="menu w-[min(22rem,calc(100vw-1rem))] flex-nowrap overflow-x-hidden kr-anchor-scroll kr-panel-flat p-2 shadow-2xl"
+        class="menu w-max min-w-56 max-w-[min(22rem,calc(100vw-1rem))] flex-nowrap overflow-x-hidden kr-anchor-scroll kr-panel-flat p-2 shadow-2xl"
         :style="{
           maxHeight: `${channelMenuMaxHeight}px`,
           scrollbarGutter: 'stable',
@@ -107,12 +127,34 @@
             </button>
           </div>
 
+          <!--
+            THE BELOW-FALLBACK, AND IT IS INDENTED. Silas, 2026-08-11: the tabs
+            go to the right "unless we need the space, in which case there
+            still should be an indent."
+
+            `ms-5` plus the accent border is that indent: dropped below its
+            channel, a tab list has nothing but position to say which channel it
+            belongs to, and position alone reads as a sixth channel.
+
+            THIS PANEL IS ALLOWED TO WIDEN THE MENU, and that is not a
+            regression of the sizing fix above. Inline only ever runs where the
+            flyout could not fit — under about 582px — and at those widths the
+            menu's 14rem of channel names is sitting in a viewport with 350
+            spare. Pinning it (a `w-0 min-w-full` trick did exactly that in an
+            earlier pass) bought consistency at the price of a 173px-wide tab
+            list on a phone, with every summary ellipsised to three words.
+
+            What Silas objected to was the menu being 22rem "always", including
+            with nothing expanded. It now costs that width only while an inline
+            submenu is actually open, and only where opening one is the only
+            option.
+          -->
           <div
             v-if="
               submenuMode === 'inline' &&
               expandedChannelKey === channel.channelKey
             "
-            class="mt-1 rounded-xl border border-base-300/70 bg-base-200/60 p-1"
+            class="ms-5 mt-1 rounded-xl border border-base-300/70 border-s-2 border-s-primary/40 bg-base-200/60 p-1"
             :aria-label="channel.label + ' tabs'"
           >
             <ChannelTabList
@@ -183,6 +225,17 @@ const router = useRouter()
 const pageStore = usePageStore()
 const channelContentStore = useChannelContentStore()
 const expandedChannelKey = ref('')
+/*
+ * Whether the open submenu was opened by hovering rather than by pressing the
+ * chevron, so the chevron does not immediately undo the hover.
+ *
+ * Browsers synthesise mouseenter before click on a tap, so on a touch device
+ * wide enough for the flyout the two handlers fought each other: the tap's
+ * mouseenter opened the flyout, the tap's own click saw it already open and
+ * closed it, and the chevron did nothing at all. Every tablet was in that band
+ * once the menu narrowed and the flyout started fitting at 604px.
+ */
+const expandedByPointer = ref(false)
 const channelMenu = ref<HTMLElement | null>(null)
 const channelFlyout = ref<HTMLElement | null>(null)
 const channelFlyoutTop = ref(0)
@@ -275,6 +328,7 @@ function destinationTab(channel: ResolvedChannel): ResolvedTab | null {
 
 function closeChannelTabs(): void {
   expandedChannelKey.value = ''
+  expandedByPointer.value = false
   channelFlyoutColumns.value = 1
 }
 
@@ -404,6 +458,7 @@ function openChannelTabs(
 
   submenuMode.value = nextMode
   expandedChannelKey.value = channel.channelKey
+  expandedByPointer.value = !allowInline
   channelFlyoutColumns.value =
     nextMode === 'flyout' ? preferredFlyoutColumns(channel) : 1
 
@@ -418,6 +473,17 @@ function previewChannelTabs(channel: ResolvedChannel, event: Event): void {
 
 function toggleChannel(channel: ResolvedChannel, event: Event): void {
   if (expandedChannelKey.value === channel.channelKey) {
+    /*
+     * Already open, but only because the pointer passed over the row -- the
+     * user has not asked for it yet, so the first press CLAIMS it rather than
+     * dismissing it. Without this a tap is a no-op (see expandedByPointer) and
+     * a mouse user has to click the chevron twice to make a hover stick.
+     */
+    if (expandedByPointer.value) {
+      expandedByPointer.value = false
+      return
+    }
+
     closeChannelTabs()
     return
   }

--- a/components/navigation/channel-tab-list.vue
+++ b/components/navigation/channel-tab-list.vue
@@ -8,10 +8,8 @@
       :key="group.key"
       class="min-w-0"
       :class="{
-        'border-t border-base-300/70 pt-2':
-          index > 0 && effectiveColumns === 1,
-        'border-l border-base-300/70 pl-2':
-          index > 0 && effectiveColumns === 2,
+        'border-t border-base-300/70 pt-2': index > 0 && effectiveColumns === 1,
+        'border-l border-base-300/70 pl-2': index > 0 && effectiveColumns === 2,
       }"
       :aria-label="group.label || channel.label + ' tabs'"
     >
@@ -56,8 +54,22 @@
             <span
               class="flex min-w-0 flex-1 flex-col items-start leading-tight"
             >
-              <span class="flex max-w-full items-center gap-1">
-                <span class="truncate text-sm font-black">
+              <!--
+                `w-full`, not just `max-w-full`. The column above is
+                `items-start`, which makes every child size to its own
+                max-content on the cross axis — so `truncate` below had a box as
+                wide as its own text and never had anything to truncate. The
+                text simply ran out of the list: measured inside a 173px inline
+                submenu, one row reported a 498px scrollWidth against a 162px
+                button, and the overflow was being clipped mid-word by an
+                ancestor rather than ellipsised here.
+
+                Invisible until a caller got narrow. It surfaced when
+                channel-select stopped padding its menu out to 22rem, which is
+                the width that had been hiding it.
+              -->
+              <span class="flex w-full max-w-full items-center gap-1">
+                <span class="min-w-0 truncate text-sm font-black">
                   {{ tab.label }}
                 </span>
                 <span
@@ -70,7 +82,7 @@
               </span>
               <span
                 v-if="tab.summary || tab.description"
-                class="line-clamp-1 text-xs font-medium opacity-65"
+                class="line-clamp-1 w-full text-xs font-medium opacity-65"
               >
                 {{ tab.summary || tab.description }}
               </span>
@@ -88,10 +100,7 @@ import type {
   ResolvedChannel,
   ResolvedTab,
 } from '@/stores/helpers/channelContent'
-import {
-  channelTabGroups,
-  isAdminOnlyTab,
-} from '@/utils/channelTabGroups'
+import { channelTabGroups, isAdminOnlyTab } from '@/utils/channelTabGroups'
 
 const props = withDefaults(
   defineProps<{

--- a/stores/navStore.ts
+++ b/stores/navStore.ts
@@ -101,6 +101,17 @@ const navFavoritesStorageKey = 'navFavorites'
 const dashboardTabsStorageKey = 'dashboardTabs'
 const wonderLabFolderStorageKey = 'wonderLabFolder'
 const workspaceSheetOpenStorageKey = 'workspaceSheetOpen'
+/*
+ * Whether the card hand shows along the bottom of every page. Silas,
+ * 2026-08-11: "just a toggle that controls whether the user sees our hand
+ * navigation menu on the bottom of the page, remembered in localstorage".
+ *
+ * It lives here rather than as app.vue local state because the control that
+ * flips it is now inside the account hub, which is not an ancestor of the hand
+ * -- and because "remembered" means it has to survive a reload, which a ref in
+ * a component setup does not.
+ */
+const workspaceHandOpenStorageKey = 'workspaceHandOpen'
 
 const isClient = typeof window !== 'undefined'
 
@@ -187,6 +198,7 @@ export const useNavStore = defineStore('navStore', () => {
 
   const dashboardShell = ref<DashboardShellState>(defaultDashboardShellState())
   const workspaceSheetOpen = ref(false)
+  const workspaceHandOpen = ref(false)
 
   const routeHistory = ref<string[]>([])
   const currentIndex = ref(-1)
@@ -290,6 +302,13 @@ export const useNavStore = defineStore('navStore', () => {
     )
   }
 
+  function syncWorkspaceHandOpenToLocalStorage(): void {
+    safeSetLocalStorage(
+      workspaceHandOpenStorageKey,
+      String(workspaceHandOpen.value),
+    )
+  }
+
   function hydrateDashboardTabsFromLocalStorage(force = false): void {
     if (dashboardTabsHydrated.value && !force) return
 
@@ -314,6 +333,13 @@ export const useNavStore = defineStore('navStore', () => {
   function hydrateWorkspaceSheetOpenFromLocalStorage(): void {
     workspaceSheetOpen.value = safeParseBoolean(
       safeGetLocalStorage(workspaceSheetOpenStorageKey),
+      false,
+    )
+  }
+
+  function hydrateWorkspaceHandOpenFromLocalStorage(): void {
+    workspaceHandOpen.value = safeParseBoolean(
+      safeGetLocalStorage(workspaceHandOpenStorageKey),
       false,
     )
   }
@@ -461,6 +487,7 @@ export const useNavStore = defineStore('navStore', () => {
     hydrateDashboardTabsFromLocalStorage(force)
     hydrateWonderLabFolderFromLocalStorage()
     hydrateWorkspaceSheetOpenFromLocalStorage()
+    hydrateWorkspaceHandOpenFromLocalStorage()
   }
 
   function applyIconsFromSmartbar(): void {
@@ -499,6 +526,7 @@ export const useNavStore = defineStore('navStore', () => {
       hydrateDashboardTabsFromLocalStorage()
       hydrateWonderLabFolderFromLocalStorage()
       hydrateWorkspaceSheetOpenFromLocalStorage()
+      hydrateWorkspaceHandOpenFromLocalStorage()
       return
     }
 
@@ -531,6 +559,7 @@ export const useNavStore = defineStore('navStore', () => {
         hydrateDashboardTabsFromLocalStorage(force)
         hydrateWonderLabFolderFromLocalStorage()
         hydrateWorkspaceSheetOpenFromLocalStorage()
+        hydrateWorkspaceHandOpenFromLocalStorage()
 
         isInitialized.value = false
       } finally {
@@ -704,6 +733,15 @@ export const useNavStore = defineStore('navStore', () => {
     syncWorkspaceSheetOpenToLocalStorage()
   }
 
+  function setWorkspaceHandOpen(value: boolean): void {
+    workspaceHandOpen.value = value
+    syncWorkspaceHandOpenToLocalStorage()
+  }
+
+  function toggleWorkspaceHand(): void {
+    setWorkspaceHandOpen(!workspaceHandOpen.value)
+  }
+
   function closeWorkspaceSheet(): void {
     setWorkspaceSheetOpen(false)
   }
@@ -745,6 +783,7 @@ export const useNavStore = defineStore('navStore', () => {
 
     dashboardShell,
     workspaceSheetOpen,
+    workspaceHandOpen,
 
     routeHistory,
     currentIndex,
@@ -799,6 +838,8 @@ export const useNavStore = defineStore('navStore', () => {
 
     setWorkspaceSheetOpen,
     toggleWorkspaceSheet,
+    setWorkspaceHandOpen,
+    toggleWorkspaceHand,
     showWorkspaceSheet,
     hideWorkspaceSheet,
 


### PR DESCRIPTION
## The channel selector's weird gap

> "There is a weird gap with our channel selector, it looks like it's always as large as the larger tab listings, but we would have room to show the channel and tabs closer to their actual inline with their header locations if we didn't make that choice. If there is room, highlighting a channel should reveal the tab menu to it's right, not below it unless we need the space, in which case there still should be an indent." — Silas, 2026-08-11

He was reading it exactly right. The menu was `w-[min(22rem,calc(100vw-1rem))]` — the *same literal 22rem* the tab dropdown uses — so a list of four one-word channel names was held open at the width of the longest tab list on the site.

Measured on `/dashboard`:

| | before | after |
|---|---|---|
| menu width @1440 | 352px | **239px** (content: 239px) |
| menu width @1024 | 352px | **226px** |
| flyout opens at x | 390 | **277** (header tab control sits at x=185) |
| narrowest viewport with a flyout | ~700px | **~582px** |

`w-max`, a 14rem floor, and the old 22rem kept as the cap. The rows decide now.

**Below-fallback keeps an indent** (`ms-5` + an accent border). Dropped below its channel, a tab list has nothing but position to say which channel it belongs to, and position alone reads as a sixth channel.

That panel is allowed to widen the menu, deliberately. Inline only runs under ~582px, where the menu's 14rem sits in a viewport with 350 spare. An earlier pass pinned it with a `w-0 min-w-full` trick and bought consistency at the price of a 173px tab list on a phone with every summary ellipsised to three words. What was objected to was 22rem *always* — it now costs that only while an inline submenu is open, and only where opening one is the only option.

### Two bugs the narrowing exposed

**`channel-tab-list` never truncated.** The label column is `items-start`, so every child sized to its own max-content and `truncate` had a box as wide as its own text. Rows reported a **498px scrollWidth against a 162px button** — clipped mid-word by an ancestor rather than ellipsised here. `w-full` on the two inner spans fixes it for every caller. Invisible only because the 22rem was hiding it.

**Tapping the chevron did nothing on tablets.** Browsers synthesise `mouseenter` before `click`, so once the flyout started fitting at 604px the tap's mouseenter opened it and the tap's own click saw it open and closed it. The chevron now *claims* a hover-opened submenu on first press instead of dismissing it.

## The floating card dock

> "remove the front end toggle for the card view, and put it in the login-manager menu. It needs a real icon, but that's it, and no other conditionals, just a toggle that controls whether the user sees our hand navigation menu on the bottom of the page, remembered in localstorage." — Silas, 2026-08-11

Now a labelled switch in the account hub on `kind-icon:cards`, backed by `navStore.workspaceHandOpen` and persisted to localStorage beside `workspaceSheetOpen`.

"No other conditionals" is why it carries no `v-if` at all — the hand is chrome every visitor sees, so gating the switch on a login would strand guests with whatever state they landed on.

The dock cost more than its own footprint: the hand had to stop short of it horizontally, so a button that only ever said "show cards / hide cards" was permanently eating a corner of the cards it toggled. The footer runs to `right: 0` again and `--dock-circle` is retired.

## Drive-by

`app.vue`'s stylesheet had a dangling selector list — `.kr-hand-slide-enter-active, .kr-hand-slide-leave-active,` ran straight into the `@media` below with no declaration block. The parser swallowed both selectors into the at-rule's prelude, so the hand had no transition at all and the reduced-motion guard had nothing to guard. The guard's existence is the evidence motion was intended.

## Verification

- **126/126** Contract-verifier commands green by exit code
- **95** verifiers extracted from the other workflow files green; the 10 that fail need a database, a `WONDERLAB_ADMIN_TOKEN`, or a deployed `$BASE_URL`, and **fail identically on `main`**
- `vue-tsc --noEmit` clean
- `eslint` adds no new findings (the 2 errors in `navStore.ts` are byte-identical on `main`)
- Card-hand toggle exercised in a browser: flips → writes `workspaceHandOpen`, survives a reload, flips back; zero floating-dock elements remain
- Page errors and hydration warnings across 7 routes × 3 widths (1440/768/390) are identical to `main` (198/135, all from the absent DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbBrskaWwa4eGxxu3R6Zgh

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbBrskaWwa4eGxxu3R6Zgh)_