### PR TITLE
fix(model-builder): restore accessible names to busy-state stage action buttons

### DIFF
--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -53,6 +53,7 @@
           type="button"
           class="btn btn-xs btn-ghost mr-auto gap-1 rounded-lg text-secondary"
           :disabled="isDrafting('pitch')"
+          title="Draft this pitch with AI"
           @click="draft('pitch')"
         >
           <span v-if="isDrafting('pitch')" class="loading loading-dots loading-xs" />
@@ -100,6 +101,7 @@
           type="button"
           class="btn btn-ghost btn-xs h-5 min-h-5 gap-1 rounded-md px-1.5 text-[10px] text-secondary"
           :disabled="isDrafting('fields')"
+          title="Draft the schema fields and relationships with AI"
           @click="draft('fields')"
         >
           <span v-if="isDrafting('fields')" class="loading loading-dots loading-xs" />
@@ -126,6 +128,7 @@
           type="button"
           class="btn btn-ghost btn-xs h-5 min-h-5 gap-1 rounded-md px-1.5 text-[10px] text-secondary"
           :disabled="isDrafting('artPrompt')"
+          title="Draft the generation prompt with AI"
           @click="draft('artPrompt')"
         >
           <span v-if="isDrafting('artPrompt')" class="loading loading-dots loading-xs" />
@@ -201,6 +204,7 @@
             type="button"
             class="btn btn-sm btn-primary flex-1 rounded-xl"
             :disabled="!isEditable('GENERATE_ASSETS') || isGenerating || isQueued"
+            :title="item.imagePath ? 'Regenerate candidate' : 'Generate candidate'"
             @click="store.generateItemAsset(item.id)"
           >
             <span v-if="isGenerating" class="loading loading-dots loading-sm" />
@@ -302,6 +306,7 @@
             item.stages.COMMIT.status === 'approved' ||
             isCommitting
           "
+          title="Execute commit"
           @click="store.commitItem(item.id)"
         >
           <span v-if="isCommitting" class="loading loading-dots loading-xs" />


### PR DESCRIPTION
### Task
model-builder/t-029: Polish and upgrade Model Builder front-end surface (kind: software)

### What changed / what I produced
- `components/model-builder/model-builder-item-panel.vue`: five per-stage action buttons — "Draft with AI" (pitch), "Draft" (fields), "Draft" (prompt), "Generate/Regenerate candidate", and "Execute commit" — lose their accessible name entirely while busy, because their only content during that state is an unlabeled `<span class="loading loading-dots ...">` with no `title`/`aria-label` fallback. The sibling "Auto" button in the same file already carries a static `title` for exactly this reason; the five buttons now follow that same pattern.
- No behavior/logic change — purely additive `title`/`:title` attributes.

### How I verified
- An Explore subagent read the full component against the exclusion list of every bug class fixed by prior same-day cycles on this recurring task (stale-snapshot commit race, run-scoped save banners, global banner live-region semantics, breadcrumb/History/Reset accessible names, batch-editor labels, source-picker persistence + icon-button labels, run-start/resume races) and against the existing `utils/scripts/verifyModelBuilder*.ts` guards (all server-side race/gate invariants, none touching accessible-name/loading-state text) to confirm this gap was genuinely new.
- `npx eslint` on the changed file: clean.
- `npx vue-tsc --noEmit`: clean (exit 0).
- `npm run test:layout-contract`: holds, 0 new violations.
- Confirmed the diff is exactly 5 additive lines (`git diff --stat`) — prettier's default `--write` reformatted unrelated pre-existing lines in this file (confirmed via `git stash` that `prettier --check` already failed before my change), so I reverted that and reapplied only the targeted attribute additions to keep the diff scoped to this fix.

### Stakes
reversible

### Flags for Reviewer
- `components/model-builder/model-builder-item-panel.vue` has pre-existing prettier formatting drift unrelated to this change (likely a prettier version/config difference between this sandbox and whatever last formatted the file). Not fixed here to keep this diff scoped — worth a dedicated pass if it bothers CI.

### Kaizen suggestion
A repo-wide grep for `<span v-if="is...ing" class="loading ...">` sibling to a button with no `title`/`aria-label` on the button itself would likely surface more instances of this exact pattern outside Model Builder.

### Notes for reviewer
Session: scheduled conductor sweep, 2026-08-11.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYqrbvJMSQY2b824ASgUtb)_