### PR TITLE
Cap the hand at a sixth of the screen; one tools row; hub above the hand

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -160,8 +160,23 @@
     </section>
 
     <ClientOnly>
+      <!--
+        z-20, BELOW the header's z-30. Silas, 2026-08-11: "if it comes to it,
+        the login manager menu should be higher z than the hand."
+
+        It came to it. The account hub's panel is z-50, but that is z-50
+        *inside* workspace-header, and the header is z-30 — so the panel
+        competed with the hand as a z-30 thing against a z-40 one and lost
+        outright. Raising the panel could not have fixed it; the header's own
+        index is the ceiling for everything it contains.
+
+        The footer drops instead of the header rising, because the header
+        rising would put it over the startup loader (z-48/z-50) too. z-20 still
+        clears <main> and the workspace sheet, both of which live inside the
+        z-10 content section.
+      -->
       <section
-        class="kr-footer pointer-events-none fixed bottom-0 z-40 flex flex-col gap-2 px-2 sm:px-3 lg:flex-row lg:items-end"
+        class="kr-footer pointer-events-none fixed bottom-0 z-20 flex flex-col gap-2 px-2 sm:px-3 lg:flex-row lg:items-end"
         :style="footerVars"
       >
         <Transition name="kr-hand-slide">

--- a/components/navigation/account-hub.vue
+++ b/components/navigation/account-hub.vue
@@ -238,32 +238,49 @@
         </div>
       </div>
 
-      <!-- 2. TOOLS. The one reload in this panel, next to the server picker. -->
-      <div class="flex items-center gap-2">
+      <!--
+        2. TOOLS AND WALLET, one row. Silas, 2026-08-11: "karma and mana should
+        be inline with the server and reload icons, and reload does not need a
+        title."
+
+        These were two stacked rows, which read as two categories when they are
+        really one strip of small readouts and switches — four items that each
+        fit in a 36px square, spread over two lines of a 20rem panel with the
+        top one half empty. Reload lost its "Reload" text with them: it is the
+        only refresh control in the panel now, next to a server picker that is
+        plainly a server picker, and the title attribute still says what it
+        does on hover.
+
+        The wallet widgets stay as widgets rather than having their numbers
+        reprinted here: karma owns a transaction list and mana owns a refill
+        countdown and a top-up link, and copying the totals out would quietly
+        drop all of it.
+
+        `flex-wrap` because this row is now four items wide and the panel is
+        not: on a narrow phone the wallet drops to a second line by itself
+        instead of squeezing the picker.
+      -->
+      <div class="flex flex-wrap items-center gap-2">
         <server-selector />
 
         <button
           type="button"
-          class="btn btn-ghost btn-sm gap-1.5 rounded-xl"
+          class="btn btn-ghost btn-sm btn-square rounded-xl"
           title="Reload the app with the launch animation"
+          aria-label="Reload the app"
           @click="requestFullStartupReload"
         >
           <Icon name="kind-icon:refresh" class="h-4 w-4" />
-          <span class="text-xs font-bold">Reload</span>
         </button>
 
         <!-- Renders nothing until the cart has items, so it costs no row on
              the pages where there is nothing to check out. -->
         <cart-button />
-      </div>
 
-      <!-- 3. WALLET. The widgets themselves rather than their numbers copied
-              out: karma owns a transaction list and mana owns a refill
-              countdown and a top-up link, and reprinting the totals here would
-              quietly drop all of it. -->
-      <div v-if="userStore.isLoggedIn" class="flex items-center gap-2">
-        <karma-widget class="shrink-0" />
-        <mana-widget class="shrink-0" />
+        <template v-if="userStore.isLoggedIn">
+          <karma-widget class="shrink-0" />
+          <mana-widget class="shrink-0" />
+        </template>
       </div>
 
       <!-- 4. NOTIFICATIONS. The badge on the avatar is the summary; this is

--- a/components/navigation/workspace-hand.vue
+++ b/components/navigation/workspace-hand.vue
@@ -162,6 +162,7 @@ const handEl = ref<HTMLElement | null>(null)
 const scrollEl = ref<HTMLElement | null>(null)
 const stripEl = ref<HTMLElement | null>(null)
 const handWidth = ref(0)
+const viewportHeight = ref(0)
 /** The strip's real rendered height, used to size the scroll box. */
 const measuredStripHeightPx = ref(0)
 /** Whether cards exist off either edge — drives the fade, see edgeMask. */
@@ -223,6 +224,34 @@ const expandedScale = 2.1
 const footerHeightPx = 36
 const verticalPaddingPx = 8
 const expansionSafetyPx = 128
+
+/*
+ * THE HAND IS CAPPED AS A SHARE OF THE SCREEN, not just by card count.
+ *
+ * Silas, 2026-08-11: "card hand is too tall by about half on small displays,
+ * it should definitely not be 1/3 of the screen."
+ *
+ * Card width was chosen from the card COUNT alone -- ten cards meant 112px,
+ * on a phone and on a 4K monitor alike -- and height follows width through the
+ * 2:3 art. Measured at 390x667 that came to a 189px strip, 28.3% of the
+ * viewport, and the page above it lost every one of those pixels to
+ * --footer-h. The count is the wrong input on a short screen: it says nothing
+ * about how much screen there is to spend.
+ *
+ * A sixth of the viewport is the budget. At 390x667 that resolves to a 60px
+ * card and a 111px strip (16.6%) -- close to half what it was, and nowhere
+ * near a third. It binds only where the screen is genuinely short: a 1080px
+ * desktop still lands on the count cap unchanged.
+ */
+const handViewportShare = 0.17
+/* What the label band under the art actually measures -- text-[0.65rem] with
+   leading-none inside py-1.5. The 36px in footerHeightPx above is the older
+   formula's estimate and overshoots; this one is used to solve for a width
+   that hits a real height, so it has to be the measured number. */
+const cardLabelHeightPx = 22
+const absoluteMinCardWidthPx = 56
+/* The card art is aspect-2/3, so height is width x this. */
+const cardAspectRatio = 1.5
 
 const isBuilderDeck = computed(() => pageStore.cardsKey === 'builderCards')
 
@@ -290,6 +319,27 @@ const maxRestingCardWidthPx = computed(() => {
 })
 
 /**
+ * The widest a card may be: the smaller of what the count allows and what the
+ * screen height affords, never below absoluteMinCardWidthPx.
+ *
+ * Solved backwards from the height budget, because height is what was too big
+ * and width is the only dial: the art is a fixed 2:3, so a strip of
+ * `share x viewport` tall implies a card of `(budget - label) / 1.5` wide.
+ */
+const restingCardWidthCeilingPx = computed(() => {
+  const countCap = maxRestingCardWidthPx.value
+
+  if (!viewportHeight.value) return countCap
+
+  const heightBudget = viewportHeight.value * handViewportShare
+  const fromHeight = Math.floor(
+    (heightBudget - cardLabelHeightPx) / cardAspectRatio,
+  )
+
+  return Math.max(absoluteMinCardWidthPx, Math.min(countCap, fromHeight))
+})
+
+/**
  * Cards keep a legible width and the strip SCROLLS when they do not fit. This
  * used to divide the available width by the card count, which guaranteed they
  * always fit — and produced the worst of both outcomes on a phone.
@@ -321,12 +371,14 @@ const restingCardWidthPx = computed(() => {
     handWidth.value - horizontalPaddingPx,
   )
 
-  return Math.min(maxRestingCardWidthPx.value, widest)
+  return Math.min(restingCardWidthCeilingPx.value, widest)
 })
 
 const restingHandHeightPx = computed(() => {
   return Math.ceil(
-    restingCardWidthPx.value * 1.5 + footerHeightPx + verticalPaddingPx,
+    restingCardWidthPx.value * cardAspectRatio +
+      footerHeightPx +
+      verticalPaddingPx,
   )
 })
 
@@ -448,6 +500,17 @@ function publishHeight(): void {
   // Width drives card sizing.
   handWidth.value =
     scrollEl.value?.clientWidth ?? handEl.value?.clientWidth ?? 0
+
+  /*
+   * And so does the viewport's HEIGHT, now that the hand is capped at a share
+   * of the screen. Read here rather than from a ResizeObserver because none of
+   * the observed elements changes size when the window gets shorter -- the
+   * frame's height is derived from the card size, so observing it to decide
+   * the card size would be the loop. window.innerHeight is an independent
+   * input, which is what makes it safe.
+   */
+  viewportHeight.value =
+    (typeof window === 'undefined' ? 0 : window.innerHeight) || 0
 
   /*
    * Height flows back up. app.vue reserves --footer-h as padding under the
@@ -634,10 +697,18 @@ onMounted(() => {
   if (stripEl.value) {
     stripEl.value.addEventListener('wheel', handleWheel, { passive: false })
   }
+
+  // A window that gets shorter changes the height budget, and no observed
+  // element reports that.
+  window.addEventListener('resize', publishHeight)
+  window.visualViewport?.addEventListener('resize', publishHeight)
 })
 
 onBeforeUnmount(() => {
   observer?.disconnect()
+
+  window.removeEventListener('resize', publishHeight)
+  window.visualViewport?.removeEventListener('resize', publishHeight)
 
   if (stripEl.value) {
     stripEl.value.removeEventListener('wheel', handleWheel)


### PR DESCRIPTION
## Card hand height

> "card hand is too tall by about half on small displays, it should definitely not be 1/3 of the screen." — Silas, 2026-08-11

Card width was chosen from the card **count** alone — ten cards meant 112px on a phone and on a 4K monitor alike — and height follows width through the 2:3 art. The count is the wrong input on a short screen: it says nothing about how much screen there is to spend.

The hand now also has a height budget of a sixth of the viewport, and the card width is solved backwards from it.

| viewport | before | after |
|---|---|---|
| 390 × 667 | 189px (**28.3%**) | **111px (16.6%)** |
| 390 × 844 | 189px (22.4%) | 141px (16.7%) |
| 430 × 932 | 189px (20.3%) | 156px (16.7%) |
| 1280 × 720 | 191px (**26.5%**) | **122px (16.9%)** |
| 1920 × 1080 | 191px (17.7%) | 184px (17.0%) — count cap still binds |

Close to half on the small displays, a sixth everywhere, and a tall desktop left where it was.

`viewportHeight` is read in `publishHeight` rather than observed, deliberately: no observed element changes size when the window gets *shorter*, and observing the frame — whose height derives from the card size — to decide the card size would be the loop. `window.innerHeight` is an independent input, which is what makes it safe. A window resize listener covers what the ResizeObserver cannot see.

## Tools and wallet, one row

> "karma and mana should be inline with the server and reload icons, and reload does not need a title." — Silas, 2026-08-11

They were two stacked rows reading as two categories, when they are one strip of small readouts and switches — four items that each fit in a 36px square, spread over two lines of a 20rem panel with the top one half empty.

Reload loses its text label with them: it is the only refresh control in the panel, next to a server picker that is plainly a server picker, and the `title` still says what it does on hover. `flex-wrap` so the wallet drops to its own line on a narrow phone rather than squeezing the picker.

## Hub above the hand

> "if it comes to it, the login manager menu should be higher z than the hand." — Silas, 2026-08-11

It came to it. The account hub's panel is `z-50` — but that is z-50 *inside* `workspace-header*, and the header is `z-30`, so the panel competed with the hand as a z-30 thing against a z-40 one and lost. **Raising the panel could not have fixed it**; the header's own index is the ceiling for everything it contains.

The footer drops to `z-20` rather than the header rising, because a header above z-48 would also sit over the startup loader. z-20 still clears `<main>` and the workspace sheet, both inside the z-10 content section.

Verified by `elementFromPoint` in a forced overlap — `HAND` before, `PANEL` after.

## Verification

- **126/126** Contract-verifier commands green by exit code
- **95/105** verifiers from the other workflow files green; the 10 that fail need a database, a `WONDERLAB_ADMIN_TOKEN`, or a deployed `$BASE_URL`, and fail identically on `main`
- `vue-tsc --noEmit` clean
- `eslint` reports only the pre-existing `v-on-event-hyphenation` warning on an untouched line
- Zero page errors across 5 routes × 3 viewports with the hand open, resizing the window short and back at each

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbBrskaWwa4eGxxu3R6Zgh

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbBrskaWwa4eGxxu3R6Zgh)_