### PR TITLE
fix(memory): finish the board-size and score pass

### DIFF
--- a/components/pages/memory-dungeon.vue
+++ b/components/pages/memory-dungeon.vue
@@ -904,7 +904,9 @@ function updateHighScore() {
 
   try {
     window.localStorage.setItem(HIGH_SCORE_STORAGE_KEY, String(score.value))
-  } catch {}
+  } catch {
+    // localStorage can be unavailable in privacy modes; the in-memory best still works.
+  }
 }
 
 async function submitCurrentScore() {

--- a/components/pages/memory-dungeon.vue
+++ b/components/pages/memory-dungeon.vue
@@ -627,6 +627,7 @@ const pendingCardSource = reactive<{
   collectionIds: [],
 })
 
+const HIGH_SCORE_STORAGE_KEY = 'memoryDungeonHighScore'
 const MAX_POSSIBLE_LIVES = 8
 const MIN_LEVEL_PAIRS = 4
 const MAX_LEVEL_PAIRS = 18
@@ -728,7 +729,7 @@ const DEATH_FLAVORS = [
   'Slain by your own memory. A poetic end.',
   "The Oracle whispers: 'Perhaps Wordle is more your speed.'",
   'The dungeon locks the exit. Your score remains as a warning to others.',
-  'Three lives, all spent. The dungeon offers its condolences. It is lying.',
+  'All your lives, all spent. The dungeon offers its condolences. It is lying.',
 ]
 
 const LEVEL_FLAVORS = [
@@ -887,6 +888,37 @@ function normalizeLegacyCardSource() {
   }
 }
 
+function loadHighScore() {
+  try {
+    const storedScore = Number(window.localStorage.getItem(HIGH_SCORE_STORAGE_KEY))
+    highScore.value = Number.isFinite(storedScore) ? Math.max(0, storedScore) : 0
+  } catch {
+    highScore.value = 0
+  }
+}
+
+function updateHighScore() {
+  if (score.value <= highScore.value) return
+
+  highScore.value = score.value
+
+  try {
+    window.localStorage.setItem(HIGH_SCORE_STORAGE_KEY, String(score.value))
+  } catch {}
+}
+
+async function submitCurrentScore() {
+  updateHighScore()
+  if (score.value <= 0) return
+
+  await achievementStore.initialize()
+  await achievementStore.updateMatchRecord(score.value)
+
+  if (score.value >= 50) {
+    await achievementStore.rewardAchievementByCode('memory-master')
+  }
+}
+
 const challenge = reactive({
   active: false,
   targetName: '',
@@ -979,7 +1011,7 @@ const boardLayout = computed(() => {
 
   return {
     ...best,
-    size: Math.max(1, Math.min(best.size, 260)),
+    size: Math.max(1, best.size),
   }
 })
 
@@ -1188,10 +1220,7 @@ function onMatch(matchedName: string) {
   }
 
   score.value += points
-
-  if (score.value > highScore.value) {
-    highScore.value = score.value
-  }
+  updateHighScore()
 
   addLog(`${pick(MATCH_FLAVORS)} (+${points})`, 'match')
 
@@ -1280,6 +1309,7 @@ function triggerGameOver() {
   cancelChallenge()
   deathFlavor.value = pick(DEATH_FLAVORS)
   addLog('💀 GAME OVER. The dungeon claims your score as a trophy.', 'system')
+  void submitCurrentScore()
 }
 
 function onLevelComplete() {
@@ -1290,10 +1320,7 @@ function onLevelComplete() {
   const bonus = completedLevel * 50
 
   score.value += bonus
-
-  if (score.value > highScore.value) {
-    highScore.value = score.value
-  }
+  updateHighScore()
 
   cancelChallenge()
   matchesSinceChallenge.value = 0
@@ -1313,6 +1340,7 @@ function onLevelComplete() {
   addLog(`✨ Level ${completedLevel} Bonus: +${bonus} pts`, 'system')
 
   grantFloorReward(wasFlawless) // random bonus on top, as before
+  void submitCurrentScore()
 
   setTimeout(async () => {
     level.value++
@@ -1517,10 +1545,7 @@ function grantFloorReward(wasFlawless: boolean) {
   if (!reward) return
 
   reward.apply()
-
-  if (score.value > highScore.value) {
-    highScore.value = score.value
-  }
+  updateHighScore()
 
   showAward(reward.icon, reward.title, reward.subtitle)
   addLog(`🎲 Floor reward: ${reward.title} — ${reward.subtitle}`, 'award')
@@ -1594,6 +1619,7 @@ function usePowerup(powerup: Powerup) {
 onMounted(async () => {
   normalizeLegacyCardSource()
   syncPendingSettings()
+  loadHighScore()
 
   if (!achievementStore.highMatchScores.length) {
     await achievementStore.fetchHighMatchScores()


### PR DESCRIPTION
Follow-up quality slice after #1758, from the same user-authorized Memory Dungeon layout review.

The second pass found three survivors:

- The board maximizer still had a 260px upper card cap. That is harmless at the original 1366×768 screenshot, but on a genuinely large display it contradicts the stated rule that cards should be as large as possible while fitting the screen.
- The custom dungeon component has its own accumulated run score, separate from `memoryStore.score`. It was updating a component-local `highScore` ref only, so reloads forgot Best and completed runs never reached the existing `matchRecord` leaderboard path.
- One death flavor still said “Three lives” after #1758 correctly restored per-difficulty lives (6/5/4/3).

This slice:

- removes the 260px upper cap while retaining the measured fit calculation and 1px safety floor;
- reloads/persists Best through the existing `memoryDungeonHighScore` localStorage key;
- submits the accumulated custom-dungeon score through `achievementStore.updateMatchRecord()` at floor completion and game over, and preserves the existing `memory-master` achievement threshold;
- makes the death copy agnostic to configured lives.

Scope remains one file: `components/pages/memory-dungeon.vue`.

Conductor: interface-vision/t-104, session `2026-08-11T095000Z-interface-vision-t104-memory-qc2-b4e9`.

Merge only after exact-head TypeScript and contract/layout/scroll checks complete successfully. Production deployment and `/play/memory` build identity will be verified after merge; rendered geometry remains covered by the repo's post-deploy responsive audit.