### PR TITLE
fix(characters): use kr-note kr-note-warning on flip-card empty state

### DIFF
--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -89,10 +89,7 @@
               :show-inline-interact="false"
             />
 
-            <div
-              v-else
-              class="rounded-2xl border border-warning/40 bg-warning/10 p-4 text-sm text-warning"
-            >
+            <div v-else class="kr-note kr-note-warning">
               No character selected. Return to the gallery and pick a beautiful
               little problem.
             </div>


### PR DESCRIPTION
interface-vision/t-104 slice 39 (non-byte-exact "general layout pass" authorized by Silas 2026-08-11, after the byte-exact kr-container/kr-panel substitution pool was exhausted at slice 37).

`character-flip-card.vue`'s "no character selected" empty-state notice was hand-rolled: `rounded-2xl border border-warning/40 bg-warning/10 p-4 text-sm text-warning` — missing `font-semibold`, the only delta from the canonical `.kr-note`/`.kr-note-warning` classes defined in `assets/css/tailwind.css`.

The identical copy ("No character selected. Return to the gallery and pick a beautiful little problem.") already renders via `kr-note kr-note-warning` in the sibling component `character-chat.vue`. Today the same user-facing message shows at two different font weights depending on which component displays it — a real, visible inconsistency, not just cosmetic dedup. This swaps `character-flip-card.vue` to match.

No geometry or behavior change beyond the corrected font weight (`font-semibold`).

Verified before opening: eslint clean on the changed lines (one pre-existing unrelated `userStore` unused-var error confirmed via `git stash` to predate this change), `vue-tsc --noEmit` clean, `npm run test:layout-contract` holds with zero new violations, prettier clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBYTDj9u4dz2RN1yv8pNnB)_