### PR TITLE
Build object-first comment migration foundation

### DIFF
--- a/.github/workflows/comment-migration-contract.yml
+++ b/.github/workflows/comment-migration-contract.yml
@@ -1,0 +1,32 @@
+name: Comment Migration Contract
+
+on:
+  pull_request:
+    paths:
+      - 'utils/comments/**'
+      - 'utils/scripts/verifyCommentMigrationFoundation.ts'
+      - 'docs/architecture/comment-migration-foundation.md'
+      - '.github/workflows/comment-migration-contract.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'utils/comments/**'
+      - 'utils/scripts/verifyCommentMigrationFoundation.ts'
+      - 'docs/architecture/comment-migration-foundation.md'
+      - '.github/workflows/comment-migration-contract.yml'
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: 0
+      - name: Verify object-first comment migration boundary
+        run: npx tsx utils/scripts/verifyCommentMigrationFoundation.ts

--- a/docs/architecture/comment-migration-foundation.md
+++ b/docs/architecture/comment-migration-foundation.md
@@ -1,0 +1,28 @@
+# Comment migration foundation
+
+WonderLab is retired. Its archived Bot and Character commentary is source material for voice, not a queue of pairings that must survive.
+
+## Current transition pass
+
+Generate fresh first-party comments only for low-stakes objects:
+
+- Resources
+- Rewards
+- Facets
+
+Do not generate transition comments for Dreams, Scenarios, Bots, or Characters. Those get later bespoke, ecosystem-aware passes.
+
+## Creative rules
+
+- Choose the target object first, then cast one or two speakers who make sense for it.
+- Existing object relationships and facet affinity are useful signals, never mandatory lore.
+- Historical WonderLab pairings have no preservation requirement. Keep strong voice evidence and chemistry; discard weak exchanges.
+- Do not paraphrase a Component review into a new object comment. New text should arise from the new object and the speakers' voices.
+- The archive may provide cadence, vocabulary, emotional habits, stage-direction habits, and other voice evidence.
+- Draft quality matters more than preserving row count. There is no target that all 706 historical entries must survive.
+
+## Publication gate
+
+Generation and curation may produce drafts automatically. No migrated comment is published until a calibration sample of the new exchanges receives human approval.
+
+The database may continue to call these records reviews/reactions internally. Product-facing copy and project discussion call them comments.

--- a/utils/comments/commentCasting.ts
+++ b/utils/comments/commentCasting.ts
@@ -1,0 +1,75 @@
+export type CommentTargetType = 'RESOURCE' | 'REWARD' | 'FACET'
+export type CommentSpeakerKind = 'BOT' | 'CHARACTER'
+
+export type CommentTargetProfile = {
+  type: CommentTargetType
+  id: number
+  title: string
+  description?: string | null
+  flavorText?: string | null
+  category?: string | null
+  tags?: string[]
+}
+
+export type CommentSpeakerCandidate = {
+  kind: CommentSpeakerKind
+  id: number
+  name: string
+  relationshipScore?: number
+  targetAffinityScore?: number
+  voiceEvidenceScore?: number
+  noveltyScore?: number
+}
+
+export type RankedCommentSpeaker = CommentSpeakerCandidate & {
+  score: number
+  reasons: string[]
+}
+
+const clamp = (value: number | undefined): number =>
+  Number.isFinite(value) ? Math.max(0, Math.min(100, Number(value))) : 0
+
+/**
+ * Rank speakers for a target object. This deliberately contains no historical
+ * WonderLab-pair signal: the museum corpus is voice evidence, not casting
+ * history. Target fit and real object relationships win; novelty only breaks
+ * otherwise-good ties.
+ */
+export function rankCommentSpeakers(
+  _target: CommentTargetProfile,
+  candidates: CommentSpeakerCandidate[],
+  limit = 2,
+): RankedCommentSpeaker[] {
+  const ranked = candidates.map((candidate) => {
+    const relationship = clamp(candidate.relationshipScore)
+    const affinity = clamp(candidate.targetAffinityScore)
+    const voice = clamp(candidate.voiceEvidenceScore)
+    const novelty = clamp(candidate.noveltyScore)
+    const reasons: string[] = []
+
+    if (relationship >= 60) reasons.push('direct object relationship')
+    else if (relationship > 0) reasons.push('weak object relationship')
+    if (affinity >= 60) reasons.push('strong target affinity')
+    else if (affinity > 0) reasons.push('target affinity')
+    if (voice >= 60) reasons.push('strong voice evidence')
+    else if (voice > 0) reasons.push('usable voice evidence')
+    if (novelty >= 60) reasons.push('fresh pairing opportunity')
+
+    return {
+      ...candidate,
+      // The weights encode the creative policy: cast for the thing in front of
+      // us, not for who happened to share a museum visit years ago.
+      score: relationship * 0.4 + affinity * 0.35 + voice * 0.2 + novelty * 0.05,
+      reasons,
+    }
+  })
+
+  return ranked
+    .sort(
+      (left, right) =>
+        right.score - left.score ||
+        left.kind.localeCompare(right.kind) ||
+        left.id - right.id,
+    )
+    .slice(0, Math.max(1, Math.min(2, Math.floor(limit))))
+}

--- a/utils/comments/commentDraftPrompt.ts
+++ b/utils/comments/commentDraftPrompt.ts
@@ -1,0 +1,135 @@
+import type {
+  CommentSpeakerKind,
+  CommentTargetProfile,
+} from '@/utils/comments/commentCasting'
+
+export type CommentVoiceEvidence = {
+  kind: CommentSpeakerKind
+  id: number
+  name: string
+  personality?: string | null
+  canonicalVoice?: string | null
+  sampleResponse?: string | null
+  archivedVoiceSamples?: string[]
+}
+
+export type CommentDraftPrompt = {
+  system: string
+  user: string
+  responseSchema: Record<string, unknown>
+}
+
+function compact(value: string | null | undefined): string {
+  return (value || '').replace(/\s+/g, ' ').trim()
+}
+
+function bounded(value: string | null | undefined, maximum = 900): string {
+  const normalized = compact(value)
+  return normalized.length <= maximum
+    ? normalized
+    : `${normalized.slice(0, maximum - 1).trimEnd()}…`
+}
+
+function targetBlock(target: CommentTargetProfile): string {
+  return [
+    `Type: ${target.type}`,
+    `ID: ${target.id}`,
+    `Title: ${bounded(target.title, 240)}`,
+    `Description: ${bounded(target.description) || 'Not provided'}`,
+    `Flavor: ${bounded(target.flavorText) || 'Not provided'}`,
+    `Category: ${bounded(target.category, 200) || 'Not provided'}`,
+    `Tags: ${(target.tags || []).map((tag) => bounded(tag, 100)).filter(Boolean).slice(0, 16).join(', ') || 'None'}`,
+  ].join('\n')
+}
+
+function speakerBlock(speaker: CommentVoiceEvidence): string {
+  const archived = (speaker.archivedVoiceSamples || [])
+    .map((sample) => bounded(sample, 600))
+    .filter(Boolean)
+    .slice(0, 4)
+
+  return [
+    `Speaker: ${speaker.name}`,
+    `Kind: ${speaker.kind}`,
+    `ID: ${speaker.id}`,
+    `Personality: ${bounded(speaker.personality) || 'Not provided'}`,
+    `Canonical voice: ${bounded(speaker.canonicalVoice) || 'Not provided'}`,
+    `Canonical sample: ${bounded(speaker.sampleResponse, 700) || 'Not provided'}`,
+    archived.length
+      ? `Archived voice evidence:\n${archived.map((sample) => `- ${sample}`).join('\n')}`
+      : 'Archived voice evidence: none selected',
+  ].join('\n')
+}
+
+/**
+ * Build a prompt for a brand-new exchange about a real object. Archived
+ * WonderLab comments are examples of how a speaker sounds, never text to
+ * rewrite and never evidence that two speakers belong together.
+ */
+export function buildCommentDraftPrompt(
+  target: CommentTargetProfile,
+  speakers: CommentVoiceEvidence[],
+): CommentDraftPrompt {
+  if (target.type !== 'RESOURCE' && target.type !== 'REWARD' && target.type !== 'FACET') {
+    throw new Error(`Transition comments do not support ${target.type}.`)
+  }
+  if (speakers.length < 1 || speakers.length > 2) {
+    throw new Error('A transition comment exchange needs one or two speakers.')
+  }
+  const authorKeys = speakers.map((speaker) => `${speaker.kind}:${speaker.id}`)
+  if (new Set(authorKeys).size !== authorKeys.length) {
+    throw new Error('A speaker may appear only once in an exchange.')
+  }
+
+  const system = [
+    'Write a tiny first-party interaction in the Kind Robots world.',
+    'The object is the reason this moment exists. Write from the object outward rather than forcing a pre-existing routine onto it.',
+    'These are COMMENTS, not product reviews. Do not discuss star ratings, implementation quality, usability, completeness, or whether something deserves approval.',
+    'Preserve each supplied speaker as a distinct person: cadence, vocabulary, emotional habits, eloquence, brevity, stage directions, and worldview may differ sharply.',
+    'Archived voice evidence is characterization evidence only. Never paraphrase an archived line, continue its museum situation, mention a Component, or assume two speakers have history merely because archived samples exist.',
+    'One speaker may set up and another may answer, undercut, misunderstand, escalate, soften, or simply react. Do not force a joke. A strong serious, quiet, strange, or nonverbal beat is equally valid.',
+    'Prefer concrete interaction with the target over exposition about it.',
+    'Keep each comment concise unless that specific speaker is canonically verbose. Most comments should be one to three sentences.',
+    'Do not invent major lore, relationships, ownership, past events, or capabilities not supported by the supplied target and speaker context.',
+    'Return only JSON matching the supplied schema.',
+  ].join('\n')
+
+  const user = [
+    'TARGET OBJECT',
+    targetBlock(target),
+    ...speakers.flatMap((speaker, index) => [
+      '',
+      `SPEAKER ${index + 1}`,
+      speakerBlock(speaker),
+    ]),
+    '',
+    'Write one comment for each supplied speaker, in the same order. The later speaker may respond to the earlier speaker when that creates a better scene, but the object must remain the anchor.',
+  ].join('\n')
+
+  return {
+    system,
+    user,
+    responseSchema: {
+      type: 'object',
+      required: ['comments'],
+      properties: {
+        comments: {
+          type: 'array',
+          minItems: speakers.length,
+          maxItems: speakers.length,
+          items: {
+            type: 'object',
+            required: ['authorKind', 'authorId', 'comment'],
+            properties: {
+              authorKind: { type: 'string', enum: ['BOT', 'CHARACTER'] },
+              authorId: { type: 'integer', minimum: 1 },
+              comment: { type: 'string', minLength: 1, maxLength: 1200 },
+            },
+            additionalProperties: false,
+          },
+        },
+      },
+      additionalProperties: false,
+    },
+  }
+}

--- a/utils/scripts/verifyCommentMigrationFoundation.ts
+++ b/utils/scripts/verifyCommentMigrationFoundation.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict'
+import { rankCommentSpeakers } from '@/utils/comments/commentCasting'
+import { buildCommentDraftPrompt } from '@/utils/comments/commentDraftPrompt'
+
+const target = {
+  type: 'FACET' as const,
+  id: 42,
+  title: 'Clockwork',
+  description: 'Brass gears, wound springs, mechanisms, and precise moving parts.',
+  tags: ['mechanical', 'brass'],
+}
+
+const ranked = rankCommentSpeakers(target, [
+  {
+    kind: 'CHARACTER',
+    id: 2,
+    name: 'Target-fit voice',
+    targetAffinityScore: 90,
+    voiceEvidenceScore: 80,
+  },
+  {
+    kind: 'BOT',
+    id: 1,
+    name: 'Relationship voice',
+    relationshipScore: 100,
+    voiceEvidenceScore: 40,
+  },
+  {
+    kind: 'BOT',
+    id: 3,
+    name: 'Museum nostalgia should not matter',
+    noveltyScore: 100,
+    voiceEvidenceScore: 20,
+  },
+])
+
+assert.equal(ranked.length, 2)
+assert.equal(ranked[0]?.id, 1)
+assert.equal(ranked[1]?.id, 2)
+assert.ok(ranked[0]?.reasons.includes('direct object relationship'))
+
+const prompt = buildCommentDraftPrompt(target, [
+  {
+    kind: 'BOT',
+    id: 1,
+    name: 'Copper Finch',
+    personality: 'Precise, dry, easily fascinated by mechanisms.',
+    canonicalVoice: 'Short declarative sentences with occasional technical metaphors.',
+    archivedVoiceSamples: ['A museum-era line used only to learn this voice.'],
+  },
+  {
+    kind: 'CHARACTER',
+    id: 2,
+    name: 'Mira',
+    personality: 'Impulsive and tactile.',
+    canonicalVoice: 'Talks with her hands and interrupts herself.',
+  },
+])
+
+assert.match(prompt.system, /COMMENTS, not product reviews/)
+assert.match(prompt.system, /characterization evidence only/)
+assert.match(prompt.system, /Never paraphrase an archived line/)
+assert.match(prompt.system, /object is the reason this moment exists/)
+assert.doesNotMatch(prompt.system, /preserve.*pair/i)
+assert.match(prompt.user, /TARGET OBJECT/)
+assert.match(prompt.user, /Clockwork/)
+assert.match(prompt.user, /Copper Finch/)
+assert.match(prompt.user, /Mira/)
+
+assert.throws(
+  () => buildCommentDraftPrompt({ ...target, type: 'DREAM' as never }, []),
+  /Transition comments do not support DREAM/,
+)
+assert.throws(
+  () => buildCommentDraftPrompt(target, []),
+  /one or two speakers/,
+)
+assert.throws(
+  () =>
+    buildCommentDraftPrompt(target, [
+      { kind: 'BOT', id: 1, name: 'Same' },
+      { kind: 'BOT', id: 1, name: 'Same again' },
+    ]),
+  /only once/,
+)
+
+console.log('Comment migration foundation contract passed.')


### PR DESCRIPTION
Part of #1761.

This creates the clean post-WonderLab creative boundary before any migrated prose is generated or published:

- defines the transition pass as Resources, Rewards, and Facets only
- explicitly excludes Dreams, Scenarios, Bots, and Characters for later ecosystem-aware authoring
- treats archived WonderLab material as optional voice evidence, never pairing history or text to paraphrase
- ranks speakers from the target outward using real relationship, target affinity, voice evidence, and a small novelty tiebreaker
- builds a fresh one-or-two-speaker JSON exchange prompt anchored to the selected object
- adds a dedicated contract that rejects unsupported target types, duplicate speakers, review language, and pair-preservation drift

No database data is written. No migrated comment is published. The first generated calibration examples remain the human creative gate before persistence/bulk generation.