### PR TITLE
fix(user): use kr-note kr-note-{error,warning} in user-manager.vue

### DIFF
--- a/components/user/user-manager.vue
+++ b/components/user/user-manager.vue
@@ -20,10 +20,7 @@
       it -- the button was only ever a manual re-trigger.
     -->
 
-    <div
-      v-if="managerError"
-      class="shrink-0 rounded-2xl border border-error/40 bg-error/10 p-4 text-error"
-    >
+    <div v-if="managerError" class="shrink-0 kr-note kr-note-error">
       {{ managerError }}
     </div>
 
@@ -104,7 +101,7 @@
 
     <div
       v-else
-      class="flex min-h-0 flex-1 items-center justify-center rounded-2xl border border-warning/40 bg-warning/10 p-4 text-warning"
+      class="flex min-h-0 flex-1 items-center justify-center kr-note kr-note-warning"
     >
       Unknown user tab: {{ activeTab }}
     </div>


### PR DESCRIPTION
### Task
interface-vision/t-104: slice 40 of the authorized non-byte-exact "general layout pass" (kind: software)

### What changed / what I produced
- `components/user/user-manager.vue`: the `managerError` banner and the "Unknown user tab" fallback notice were hand-rolled (`rounded-2xl border border-{error,warning}/40 bg-{error,warning}/10 p-4 text-{error,warning}`), missing `text-sm font-semibold` from `kr-note`'s canonical shape.
- This is the exact runner-up candidate slice 39 flagged: "components/user/user-manager.vue's managerError/'Unknown user tab' notices follow the same hand-rolled pattern already converted in the live sibling academy-manager.vue — left for a future slice." academy-manager.vue already uses `kr-note kr-note-error` / `kr-note kr-note-warning` for the identical two notice types.
- Swapped both to `kr-note kr-note-error` / `kr-note kr-note-warning`. No geometry or behavior change; the visual delta is intentional (adds the missing `text-sm font-semibold` weight to match the canonical/sibling component), same category as slice 39's `character-flip-card.vue` fix.

### How I verified
- `git diff --stat`: exactly one file changed, `components/user/user-manager.vue`.
- `npx eslint components/user/user-manager.vue`: clean.
- `npx prettier --check components/user/user-manager.vue`: clean.
- `npx vue-tsc --noEmit`: clean.
- `npm run test:layout-contract`: holds, 0 new violations. An unrelated pre-existing viewport-grid baseline improvement (-2, `collection-picker.vue` / `facet-interact.vue`) was observed but left untouched, out of scope for this slice.

### Stakes
reversible

### Kaizen suggestion
The kr-note candidate sweep across slices 35/39/40 has been done by hand each time; a small script that greps every `class="..."` root/notice div for the `kr-note` token set (order-independent) and reports live (non-abandonware) near-misses missing only `text-sm`/`font-semibold` would make the next slice's search mechanical instead of manual re-derivation.

### Notes for reviewer
interface-vision/t-104 is a recurring non-recurring-per-slice umbrella task; the companion conductor PR records slice 40 and returns the task to `ready` for the next bounded slice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiGQWFLee6ghEJ3JiBVctJ)_