### PR TITLE
fix(model-builder): preserve quantity input interaction

### DIFF
--- a/components/model-builder/model-builder-recipe-selector.vue
+++ b/components/model-builder/model-builder-recipe-selector.vue
@@ -87,7 +87,7 @@
         <div
           v-if="output.quantity && store.selections[output.key]?.on"
           class="flex shrink-0 items-center gap-1"
-          @click.prevent
+          @click.stop
         >
           <span class="text-[10px] uppercase text-base-content/40">qty</span>
           <input


### PR DESCRIPTION
### Task
Conductor `model-builder/t-029` recurring polish pass.

### Root cause
Quantity inputs for recipe outputs live inside the wrapping output `<label>`. Their container used `@click.prevent` to avoid toggling the outer checkbox, but preventing the click's default action also interferes with the number input's native mouse behavior (focus/step controls).

### Change
Replace `@click.prevent` with `@click.stop`: keep the click from reaching the outer checkbox label while preserving the number input's native interaction.

### Verification
- Branch is exactly one commit ahead of current `main`.
- Diff is one line changed in `components/model-builder/model-builder-recipe-selector.vue`.
- CI on the exact PR head is the merge gate; do not merge until required checks finish successfully.

### Flags for Reviewer
Reversible front-end interaction fix only. No API, store, schema, persistence, ArtJob, production-data, or outward-facing changes.