### PR TITLE
Show every card title in full; card-hand switch becomes an icon in the row

### DIFF
--- a/components/navigation/account-hub.vue
+++ b/components/navigation/account-hub.vue
@@ -17,10 +17,15 @@
   role), as well as mana and token counts, then notifications."
 
     1. who you are      — and a button, because it opens the account menu
-    2. tools            — server picker, app reload
-    3. wallet           — karma and mana
-    4. notifications
-    5. maturity         — a preference, so it sits under the things it affects
+    2. tools            — server, reload, card hand, karma, mana
+    3. notifications
+    4. maturity         — a preference, so it sits under the things it affects
+
+  Tools and wallet were two rows until Silas collapsed them (2026-08-11:
+  "karma and mana should be inline with the server and reload icons"), and the
+  card-hand switch joined them a message later ("needs no explanation text and
+  sho[ul]d be in line between the refresh icon and the mana/karma section").
+  One strip of small controls, in his stated order.
 
   WHY ACCOUNT SWITCHING IS NESTED. The first version put the saved-login list,
   Save, Add and Logout on the panel directly, which meant the signed-in user
@@ -273,14 +278,43 @@
           <Icon name="kind-icon:refresh" class="h-4 w-4" />
         </button>
 
-        <!-- Renders nothing until the cart has items, so it costs no row on
-             the pages where there is nothing to check out. -->
-        <cart-button />
+        <!--
+          THE CARD HAND SWITCH, and it is just an icon. Silas, 2026-08-11: "the
+          card hand option needs no explanation text and sho[ul]d be in line
+          between the refresh icon and the mana/karma section."
+
+          It shipped a moment ago as a full-width labelled row with a
+          description underneath, which was the right shape when it sat alone
+          under a heading and the wrong one the moment this row existed. In a
+          strip of icons it is an icon: pressed state carries "on", the title
+          and aria-label carry the explanation, and the hand itself appearing
+          at the bottom of the screen is the rest of it.
+
+          `aria-pressed` rather than a checkbox, because that is what a toggle
+          button is -- the input version needed a <label> and visible text to
+          be reachable at all, which is exactly the text that had to go.
+        -->
+        <button
+          type="button"
+          class="btn btn-sm btn-square rounded-xl"
+          :class="navStore.workspaceHandOpen ? 'btn-primary' : 'btn-ghost'"
+          :aria-pressed="navStore.workspaceHandOpen"
+          :title="cardHandLabel"
+          :aria-label="cardHandLabel"
+          @click="navStore.toggleWorkspaceHand"
+        >
+          <Icon name="kind-icon:cards" class="h-4 w-4" />
+        </button>
 
         <template v-if="userStore.isLoggedIn">
           <karma-widget class="shrink-0" />
           <mana-widget class="shrink-0" />
         </template>
+
+        <!-- Renders nothing until the cart has items, so it costs no row on
+             the pages where there is nothing to check out. Last, so it cannot
+             come between the refresh and the wallet. -->
+        <cart-button />
       </div>
 
       <!-- 4. NOTIFICATIONS. The badge on the avatar is the summary; this is
@@ -336,56 +370,9 @@
         </div>
       </section>
 
-      <!--
-        5. PREFERENCES, rather than actions, so they sit last.
-
-        THE CARD HAND SWITCH USED TO BE A FLOATING BUTTON pinned to the
-        bottom-right corner of every page. Silas, 2026-08-11: "remove the front
-        end toggle for the card view, and put it in the login-manager menu. It
-        needs a real icon, but that's it, and no other conditionals, just a
-        toggle that controls whether the user sees our hand navigation menu on
-        the bottom of the page, remembered in localstorage."
-
-        "No other conditionals" is why this one carries no `v-if` at all, unlike
-        the maturity toggle below it — the hand is chrome every visitor sees,
-        signed in or not, so gating the switch on a login would strand guests
-        with whatever state they happened to land on.
-      -->
-      <label
-        class="flex cursor-pointer items-center justify-between gap-3 kr-panel-flat px-3 py-2"
-        title="Show or hide the card hand along the bottom of the page"
-      >
-        <span class="flex min-w-0 items-center gap-3">
-          <span
-            class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl"
-            :class="
-              navStore.workspaceHandOpen
-                ? 'bg-primary/15 text-primary'
-                : 'bg-base-200 text-base-content/55'
-            "
-          >
-            <Icon name="kind-icon:cards" class="h-5 w-5" />
-          </span>
-
-          <span class="min-w-0">
-            <span class="block text-sm font-bold text-base-content">
-              Card hand
-            </span>
-            <span class="block text-xs text-base-content/55">
-              Navigation cards along the bottom of the page.
-            </span>
-          </span>
-        </span>
-
-        <input
-          type="checkbox"
-          class="toggle toggle-primary toggle-sm shrink-0"
-          :checked="navStore.workspaceHandOpen"
-          aria-label="Show the card hand"
-          @change="onCardHandChange"
-        />
-      </label>
-
+      <!-- 5. MATURITY, a preference rather than an action, so it sits last.
+              The card-hand switch used to live down here as a labelled row;
+              it is now an icon in the tools strip above. -->
       <maturity-toggle
         v-if="showDashboardMaturityToggle && userStore.isLoggedIn"
         variant="resource"
@@ -474,9 +461,18 @@ function handlePointerDown(event: PointerEvent) {
   }
 }
 
-function onCardHandChange(event: Event): void {
-  navStore.setWorkspaceHandOpen((event.target as HTMLInputElement).checked)
-}
+/**
+ * The card-hand button's whole explanation, now that it has no visible text.
+ *
+ * It states the ACTION rather than the state, because that is what a title on
+ * a toggle button is read as ("Show the card hand" while hidden); the pressed
+ * styling and aria-pressed carry the state.
+ */
+const cardHandLabel = computed(() =>
+  navStore.workspaceHandOpen
+    ? 'Hide the card hand at the bottom of the page'
+    : 'Show the card hand at the bottom of the page',
+)
 
 function captureCurrent() {
   store.captureCurrentSession()

--- a/components/navigation/workspace-hand.vue
+++ b/components/navigation/workspace-hand.vue
@@ -94,9 +94,30 @@
                 </div>
               </div>
 
+              <!--
+                NO `truncate`. Silas, 2026-08-11: "the cards need to be wide
+                enough to show their full titles. full stop."
+
+                Width alone cannot deliver that on every deck. The nav decks
+                need 54-65px of text and are easy; /conductor carries "Humboldt
+                Impropriety Calendar", 170px of it, and a card wide enough for
+                that on one line is 182px -- a 294px hand, 44% of a phone, in
+                flat contradiction of the height rule from one message earlier.
+
+                So the title wraps instead of the card growing, and the card is
+                sized so that wrapping always suffices: at least as wide as the
+                longest WORD in the deck (nothing is ever cut mid-word) and at
+                least a third of the longest TITLE (so three lines always
+                fit). See labelFloorPx. line-clamp-3 is the backstop that
+                arithmetic already satisfies, not the mechanism.
+
+                `leading-tight` rather than `leading-none` because a
+                single-line label was the only thing `leading-none` ever had to
+                lay out.
+              -->
               <div class="w-full bg-base-100 px-1.5 py-1.5">
                 <p
-                  class="truncate text-center text-[0.65rem] font-black leading-none text-base-content/75 sm:text-xs"
+                  class="line-clamp-3 text-center text-[0.65rem] font-black leading-tight text-base-content/75 sm:text-xs"
                   :title="card.label"
                 >
                   {{ card.label }}
@@ -117,9 +138,20 @@
                 />
               </div>
 
+              <!--
+                The back's spacer carries the SAME label, invisibly, so the two
+                faces are exactly the same height. It used to be a single
+                `&nbsp;`, which matched a one-line front and stopped matching
+                the moment titles were allowed to wrap — a two-line front over
+                a one-line back makes the card change height mid-flip.
+                `invisible` is visibility:hidden, so it holds its box and stays
+                out of the accessibility tree.
+              -->
               <div class="w-full bg-base-100 px-1.5 py-1.5">
-                <p class="text-center text-[0.65rem] leading-none sm:text-xs">
-                  &nbsp;
+                <p
+                  class="invisible line-clamp-3 text-center text-[0.65rem] font-black leading-tight sm:text-xs"
+                >
+                  {{ card.label }}
                 </p>
               </div>
             </div>
@@ -163,6 +195,9 @@ const scrollEl = ref<HTMLElement | null>(null)
 const stripEl = ref<HTMLElement | null>(null)
 const handWidth = ref(0)
 const viewportHeight = ref(0)
+/** The narrowest card that shows every title in this deck. See measureLabelFloor. */
+const labelFloorPx = ref(0)
+let labelMetrics: CanvasRenderingContext2D | null = null
 /** The strip's real rendered height, used to size the scroll box. */
 const measuredStripHeightPx = ref(0)
 /** Whether cards exist off either edge — drives the fade, see edgeMask. */
@@ -250,6 +285,10 @@ const handViewportShare = 0.17
    that hits a real height, so it has to be the measured number. */
 const cardLabelHeightPx = 22
 const absoluteMinCardWidthPx = 56
+/** px-1.5 either side of the label, i.e. what the text does NOT get. */
+const labelPaddingPx = 12
+/** line-clamp-3 on the label — the same number the floor is solved against. */
+const labelMaxLines = 3
 /* The card art is aspect-2/3, so height is width x this. */
 const cardAspectRatio = 1.5
 
@@ -328,15 +367,26 @@ const maxRestingCardWidthPx = computed(() => {
  */
 const restingCardWidthCeilingPx = computed(() => {
   const countCap = maxRestingCardWidthPx.value
+  const fromHeight = viewportHeight.value
+    ? Math.floor(
+        (viewportHeight.value * handViewportShare - cardLabelHeightPx) /
+          cardAspectRatio,
+      )
+    : countCap
 
-  if (!viewportHeight.value) return countCap
-
-  const heightBudget = viewportHeight.value * handViewportShare
-  const fromHeight = Math.floor(
-    (heightBudget - cardLabelHeightPx) / cardAspectRatio,
+  /*
+   * The label floor OVERRIDES the height budget rather than being clamped by
+   * it. Silas said "full stop" about the titles and only "should definitely
+   * not be 1/3" about the height, so where they disagree the title wins — and
+   * because the floor is solved against three lines of wrapping rather than
+   * one, they barely disagree: the widest deck on the site asks for 78px where
+   * a 667px-tall phone's budget offers 60.
+   */
+  return Math.max(
+    absoluteMinCardWidthPx,
+    labelFloorPx.value,
+    Math.min(countCap, fromHeight),
   )
-
-  return Math.max(absoluteMinCardWidthPx, Math.min(countCap, fromHeight))
 })
 
 /**
@@ -494,8 +544,59 @@ function updateScrollEdges(): void {
   canScrollEnd.value = el.scrollLeft < max - 1
 }
 
+/**
+ * The narrowest card width at which no title in this deck is cut off.
+ *
+ * Two constraints, both satisfied by the same number:
+ *   - no word is ever broken, so the widest single word must fit one line;
+ *   - the whole title fits the three lines line-clamp-3 allows, so the total
+ *     text length divided by three must also fit.
+ *
+ * MEASURED WITH CANVAS, not with the DOM. The obvious version -- read a
+ * label's scrollWidth -- cannot work: scrollWidth returns max(content, box),
+ * so a card already wider than its text reports the BOX, the floor ratchets up
+ * to it, and the next pass reports wider still. measureText asks the font
+ * directly and is answering a question layout cannot influence, which is what
+ * makes it safe to feed back into the width it decides.
+ *
+ * Returns 0 if canvas is unavailable, which simply leaves the old
+ * count-and-height sizing in charge rather than failing.
+ */
+function measureLabelFloor(): number {
+  const sample = stripEl.value?.querySelector('.card-front p')
+  if (!sample) return 0
+
+  if (!labelMetrics) {
+    labelMetrics = document.createElement('canvas').getContext('2d')
+  }
+  if (!labelMetrics) return 0
+
+  const style = getComputedStyle(sample)
+  labelMetrics.font = `${style.fontWeight} ${style.fontSize} ${style.fontFamily}`
+
+  let widest = 0
+
+  for (const card of handCards.value) {
+    const label = card.label ?? ''
+    if (!label) continue
+
+    const whole = labelMetrics.measureText(label).width
+
+    for (const word of label.split(/\s+/)) {
+      if (word) widest = Math.max(widest, labelMetrics.measureText(word).width)
+    }
+
+    widest = Math.max(widest, whole / labelMaxLines)
+  }
+
+  // +1 for the sub-pixel the browser rounds against us at the ellipsis.
+  return widest ? Math.ceil(widest) + labelPaddingPx + 1 : 0
+}
+
 function publishHeight(): void {
   if (!import.meta.client) return
+
+  labelFloorPx.value = measureLabelFloor()
 
   // Width drives card sizing.
   handWidth.value =


### PR DESCRIPTION
## Card titles

> "the cards need to be wide enough to show their full titles. full stop." — Silas, 2026-08-11

Width alone cannot deliver that on every deck, and the arithmetic is worth recording:

| deck | longest title | width needed on one line |
|---|---|---|
| `/dashboard` | "Characters" — 54px | ~68px ✅ easy |
| `/bots` | "Presentation" — 56px | ~70px ✅ easy |
| `/conductor` | **"Humboldt Impropriety Calendar" — 170px** | **182px → a 294px hand, 44% of a 667px phone** ❌ |

That last row is in flat contradiction of the height rule from one message earlier. So the title **wraps** instead of the card growing, and the card is sized so wrapping always suffices:

```
width >= max(longest word, longest title / 3)
```

The first half means no word is ever broken; the second means the whole title fits the three lines `line-clamp-3` allows. The clamp is the backstop the arithmetic already satisfies, not the mechanism.

### Why canvas, not the DOM

Measured with `measureText` rather than reading a label's `scrollWidth`, and that is load-bearing. `scrollWidth` returns `max(content, box)` — so a card already wider than its text reports the **box**, the floor ratchets up to it, and the next pass reports wider still. `measureText` asks the font a question layout cannot influence, which is what makes it safe to feed back into the width it decides.

Verified against ratcheting by sweeping six viewports and returning: all three decks land on exactly the width and height they started at, and a given viewport always yields the same numbers.

### Result

Zero clipped labels on `/dashboard`, `/bots` and `/conductor` at 390, 768 and 1440. "Characters" was rendering as "Charac…". Heights stay well inside the ceiling from the last PR — worst case is `/conductor` at 390×667 (154px, 23.1%); `/dashboard` there is 125px (18.7%).

The card **back**'s spacer now carries the same label invisibly instead of a lone `&nbsp;`. It matched a one-line front and would have stopped matching the moment titles wrapped — a two-line front over a one-line back changes the card's height mid-flip.

## Card-hand switch

> "the card hand option needs no explanation text and sho[ul]d be in line between the refresh icon and the mana/karma section." — Silas, 2026-08-11

It shipped a moment ago as a full-width labelled row with a description underneath — the right shape when it sat alone under a heading, the wrong one the moment the tools row existed. In a strip of icons it is an icon: pressed state carries "on", the title and aria-label carry the explanation, and the hand appearing at the bottom of the screen is the rest of it.

`aria-pressed` on a button rather than a checkbox, because the input version needed a `<label>` and visible text to be reachable at all — exactly the text that had to go.

Order is his: **server, reload, card hand, karma, mana.** `cart-button` moves last so it can never come between the refresh and the wallet.

## Verification

- **126/126** Contract-verifier commands green by exit code
- **95/105** verifiers from the other workflow files green; the 10 that fail need a database, a `WONDERLAB_ADMIN_TOKEN`, or a deployed `$BASE_URL`, and fail identically on `main`
- `vue-tsc --noEmit` and `eslint` both clean on the changed files
- Label clipping checked programmatically (`scrollWidth > clientWidth`) across 3 decks × 3 viewports: zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbBrskaWwa4eGxxu3R6Zgh

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbBrskaWwa4eGxxu3R6Zgh)_