### PR TITLE
fix(art): use kr-note kr-note-{error,warning} in art-manager.vue

### DIFF
--- a/components/art/art-manager.vue
+++ b/components/art/art-manager.vue
@@ -16,7 +16,7 @@
 
     <div
       v-else-if="managerError"
-      class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-error/40 bg-error/10 p-4 text-error"
+      class="flex min-h-0 flex-1 flex-col overflow-hidden kr-note kr-note-error"
     >
       <div class="flex flex-wrap items-center justify-between gap-3">
         <span>{{ managerError }}</span>
@@ -164,7 +164,7 @@
 
         <div
           v-else
-          class="flex min-h-0 flex-1 items-center justify-center rounded-2xl border border-warning/40 bg-warning/10 p-4 text-warning"
+          class="flex min-h-0 flex-1 items-center justify-center kr-note kr-note-warning"
         >
           Unknown image tab: {{ activeTab }}
         </div>


### PR DESCRIPTION
### Task
interface-vision/t-104: slice 41 of the authorized non-byte-exact "general layout pass" (kind: software)

### What changed / what I produced
- `components/art/art-manager.vue`: the `managerError` banner and the "Unknown image tab" fallback notice were hand-rolled (`rounded-2xl border border-{error,warning}/40 bg-{error,warning}/10 p-4 text-{error,warning}`), missing `text-sm font-semibold` from `kr-note`'s canonical shape.
- Strong sibling precedent: `academy-manager.vue` is an almost byte-identical twin component already using `kr-note kr-note-error flex min-h-0 flex-1 flex-col overflow-hidden` for the same `managerError`/Retry-button block, and `kr-note kr-note-warning flex min-h-0 flex-1 items-center justify-center` for the same `"Unknown {tab}: {{ activeTab }}"` fallback. `user-manager.vue` (slice 40) converted the identical `managerError` pattern for a third `*-manager.vue` component.
- Swapped both to `kr-note kr-note-error` / `kr-note kr-note-warning`. No geometry or behavior change.

### How I verified
- `git diff --stat`: exactly one file changed, 2 insertions / 2 deletions.
- `npx eslint components/art/art-manager.vue`: clean.
- `npx vue-tsc --noEmit`: clean.
- `npm run test:layout-contract`: holds, 0 new violations. An unrelated pre-existing viewport-grid baseline improvement (-2, same two files noted in slice 40) was observed but left untouched, out of scope.
- Prettier: this file was already not prettier-clean before this change (confirmed via `git stash` against baseline `main` — same pre-existing formatting drift documented in kind_robots PR #1759/model-builder t-029). Rather than let `prettier --write` reformat ~190 unrelated lines, reverted that and reapplied only the two targeted class swaps, so the diff is scoped exactly to the fix.

### Stakes
reversible

### Flags for Reviewer
- `art-manager.vue` is not currently prettier-clean on `main` independent of this PR — a future slice or dedicated task may want to run a full-file `prettier --write` separately from a content change, same open item as PR #1759 flagged for `model-builder-item-panel.vue`.

### Kaizen suggestion
An Explore-agent sweep this slice turned up several more live "manager"-pattern components with the same un-converted `managerError`/"Unknown {x} tab" shape: `components/servers/server-manager.vue`, `components/wonderlab/lab-manager.vue`, `components/newsfeed/newsfeed-feed.vue`, `components/wonderlab/component-review-feed.vue`, `components/wonderlab/component-sync.vue`, and `components/resources/resource-gallery.vue`. Good fodder for the next 1-2 slices — will be recorded in the umbrella task's note.

### Notes for reviewer
interface-vision/t-104 is a recurring non-recurring-per-slice umbrella task; the companion conductor PR records slice 41 and returns the task to `ready` for the next bounded slice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiGQWFLee6ghEJ3JiBVctJ)_