### PR TITLE
Keep PWA install cache to stable app chrome

### DIFF
--- a/.github/workflows/pwa-precache-budget.yml
+++ b/.github/workflows/pwa-precache-budget.yml
@@ -1,0 +1,26 @@
+name: PWA Precache Budget
+
+on:
+  pull_request:
+    paths:
+      - 'nuxt.config.ts'
+      - 'utils/scripts/verifyPwaPrecacheBudget.ts'
+      - '.github/workflows/pwa-precache-budget.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'nuxt.config.ts'
+      - 'utils/scripts/verifyPwaPrecacheBudget.ts'
+      - '.github/workflows/pwa-precache-budget.yml'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npx tsx utils/scripts/verifyPwaPrecacheBudget.ts

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -199,9 +199,11 @@ export default defineNuxtConfig({
   ],
 
   // ai-art-academy/t-066: installability foundation for t-062/t-063's mobile
-  // delivery path. Additive-only -- a manifest plus a cache-first service
-  // worker for the built static assets. Academy content is API-driven, so
-  // this deliberately does not build a full offline mode yet.
+  // delivery path. This is intentionally not a full offline application: pages
+  // are SSR/API-driven, so precaching hundreds of route-local JS chunks does
+  // not make an offline refresh work. It only makes every install/update fetch
+  // the whole product. Keep the service worker + manifest for installability
+  // and precache only the small, stable install chrome.
   pwa: {
     registerType: 'autoUpdate',
     manifest: {
@@ -224,10 +226,14 @@ export default defineNuxtConfig({
       ],
     },
     workbox: {
-      // Precache the built client bundle + static icons; cache-first is
-      // enough for a first pass since pages themselves are server-rendered
-      // per request, not precached.
-      globPatterns: ['**/*.{js,css,ico,png,svg,webp,woff2}'],
+      // No JS/CSS glob here on purpose. Route-local assets should be fetched
+      // when their feature is visited, not downloaded during PWA installation.
+      globPatterns: [
+        'icon-192x192.png',
+        'icon-512x512.png',
+        'apple-touch-icon.png',
+        'favicon.ico',
+      ],
       navigateFallback: null,
     },
   },

--- a/utils/scripts/verifyPwaPrecacheBudget.ts
+++ b/utils/scripts/verifyPwaPrecacheBudget.ts
@@ -1,0 +1,26 @@
+// /utils/scripts/verifyPwaPrecacheBudget.ts
+//
+// Kind Robots is installable, not a full offline app. Pages are SSR/API-driven,
+// so precaching every built JS chunk buys no offline refresh while forcing every
+// install/update to download the whole feature graph. Keep Workbox limited to
+// stable install chrome unless the product explicitly adopts an offline mode.
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const config = await readFile('nuxt.config.ts', 'utf8')
+const workbox = config.match(/workbox:\s*\{([\s\S]*?)\n\s*\},\n\s*\},/m)?.[1] ?? ''
+
+assert.ok(workbox, 'nuxt.config.ts must keep an explicit Workbox configuration')
+assert.doesNotMatch(
+  workbox,
+  /\*\.\{[^}]*\b(?:js|css)\b[^}]*\}|\*\.js|\*\.css/,
+  'PWA precache must not glob built JS/CSS; route-local bundles load on demand',
+)
+assert.match(workbox, /icon-192x192\.png/)
+assert.match(workbox, /icon-512x512\.png/)
+assert.match(workbox, /apple-touch-icon\.png/)
+assert.match(workbox, /navigateFallback:\s*null/)
+
+console.log(
+  'PWA precache budget verified: install chrome only; no whole-product JS/CSS precache.',
+)


### PR DESCRIPTION
Continues the startup/build-budget cleanup after #1772.

The first production build after WonderLab + SmartBar retirement still generated a PWA precache of **314 entries / 8060.20 KiB**. That is mostly because Workbox globbed every built JS/CSS chunk, including route-local feature code, even though Kind Robots does not claim full offline page support: pages remain SSR/API-driven and `navigateFallback` is intentionally null.

This slice makes the installability contract match the product contract:

- keep the manifest and generated service worker
- precache only stable install chrome (192/512 app icons, Apple touch icon, favicon)
- stop precaching every lazy JS/CSS/image/font asset during install/update
- add a regression verifier that rejects JS/CSS precache globs unless we explicitly redesign Kind Robots as a full offline app

Expected result: PWA install/update traffic drops from ~8 MiB / 314 entries to a tiny stable icon set, while route-local bundles continue loading normally when their feature is visited.

No visible UI behavior should change. Verification should use exact-head CI plus the Vercel preview/build log's actual Workbox `precache` count/size before merge.