### PR TITLE
fix(ui): use kr-note kr-note-{warning,error} for two remaining manager/admin notices

### DIFF
--- a/components/giftshop/giftshop-manager.vue
+++ b/components/giftshop/giftshop-manager.vue
@@ -108,7 +108,7 @@
 
       <div
         v-else
-        class="flex min-h-0 flex-1 items-center justify-center rounded-2xl border border-warning/40 bg-warning/10 p-4 text-warning"
+        class="flex min-h-0 flex-1 items-center justify-center kr-note kr-note-warning"
       >
         The butterflies misplaced tab
         <span class="mx-1 font-bold">{{ activeTab }}</span>

--- a/pages/admin/wonderlab-review-rollout.vue
+++ b/pages/admin/wonderlab-review-rollout.vue
@@ -38,7 +38,7 @@
       </section>
 
       <template v-else>
-        <p v-if="notice" class="rounded-2xl border border-error/40 bg-error/10 p-4 text-error">
+        <p v-if="notice" class="kr-note kr-note-error">
           {{ notice }}
         </p>
 


### PR DESCRIPTION
## Summary
interface-vision/t-104 slice 43 — continuing the authorized non-byte-exact "general layout pass" (slices 39-42). A fresh repo-wide grep (not from a stale candidate list) for the hand-rolled `rounded-2xl border border-{status}/40 bg-{status}/10 p-4 text-{status}` notice shape found exactly two remaining live, non-abandonware candidates.

## Changes
- `components/giftshop/giftshop-manager.vue`: unknown-tab fallback pane now uses `kr-note kr-note-warning` instead of the hand-rolled equivalent. Direct sibling precedent in 5 other `*-manager.vue` components (`user-manager.vue`, `lab-manager.vue`, `art-manager.vue`, `academy-manager.vue`, `server-manager.vue`) already converted in prior slices — same structural role, same class shape, pure dedup.
- `pages/admin/wonderlab-review-rollout.vue`: notice paragraph now uses `kr-note kr-note-error` instead of the hand-rolled equivalent. Precedent is cross-cutting (from the same `*-manager.vue` conversions establishing `kr-note` as canonical for this exact literal shape) rather than a same-directory sibling, but the class string is byte-identical to the established target shape.

No geometry or behavior change in either case.

## Verification
- `eslint` clean on changed lines — `giftshop-manager.vue`'s pre-existing unrelated `swarmMemo` unused-var error confirmed via `git stash` to predate this change; left untouched.
- `prettier --check` — `wonderlab-review-rollout.vue` carries pre-existing unrelated drift, confirmed via `git stash` against baseline `main`; left untouched, out of scope.
- `vue-tsc --noEmit` clean repo-wide.
- `npm run test:layout-contract` holds (0 new violations; the same unrelated pre-existing viewport-grid baseline improvement noted in slices 39-42 was observed again and left untouched, out of scope).
- `git diff --stat`: exactly 2 files / 1 net line each.

## Flags for Reviewer
- Neither file's pre-existing lint/format drift was touched — both confirmed pre-existing via `git stash` before attributing anything to this change.
- No new "manager"-pattern candidates remain after this fresh sweep for the exact hand-rolled shape; a future slice should widen the search shape (different padding/opacity/structural variants) if further progress is wanted, per this slice's investigation notes.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017d8z8267YzgUcJNzKJkydJ

---
_Generated by [Claude Code](https://claude.ai/code/session_017d8z8267YzgUcJNzKJkydJ)_