### PR TITLE
fix(a11y): give the async-queue generate button an accessible name

### DIFF
--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -218,6 +218,9 @@
             class="btn btn-sm btn-outline btn-primary rounded-xl"
             :disabled="!isEditable('GENERATE_ASSETS') || isGenerating || isQueued"
             title="Queue generation and keep working — polls in the background, no need to wait here."
+            :aria-label="
+              item.imagePath ? 'Queue regeneration in background' : 'Queue generation in background'
+            "
             @click="store.generateItemAssetAsync(item.id)"
           >
             <Icon name="kind-icon:clock" class="h-4 w-4" />


### PR DESCRIPTION
## Summary
- `model-builder-item-panel.vue`'s icon-only "queue generation in background" button (the clock-icon button next to Generate/Regenerate in the GENERATE_ASSETS stage) relied solely on a `title` attribute for its accessible name.
- Every other icon-only control in the same component tree (source-picker's view-mode buttons, run-history's cancel button) pairs `title` with an explicit `aria-label`.
- Added a dynamic `aria-label` mirroring the existing `title` text, so screen readers announce it consistently and it's distinguishable from the adjacent "Generate/Regenerate candidate" button.

No behavior/logic change — conductor model-builder/t-029 recurring polish task, next bounded slice.

## Verification
- `eslint` clean on the changed file.
- `prettier --check` flags this file, but confirmed via `git stash` against baseline `main` that the drift pre-dates this change (already noted in a prior slice of the same task) — left untouched.
- `vue-tsc --noEmit` clean repo-wide.
- `npm run test:layout-contract` holds (0 new violations; same unrelated pre-existing viewport-grid baseline improvement noted in recent slices).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hgauaf5VXSE8xa3nzSTCsZ)_