### PR TITLE
model-builder: resetAll() now clears all five store-wide in-flight singletons

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -287,6 +287,12 @@ jobs:
       - name: Model Builder commit stale-snapshot guard contract
         run: npm run test:model-builder-commit-stale-snapshot-guard
 
+      - name: Model Builder resetAll guard checker self-test
+        run: npm run test:model-builder-reset-all-guard-selftest
+
+      - name: Model Builder resetAll guard contract
+        run: npm run test:model-builder-reset-all-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -168,6 +168,8 @@
     "test:model-builder-commit-name-field-guard": "tsx utils/scripts/verifyModelBuilderCommitNameFieldGuard.ts",
     "test:model-builder-commit-stale-snapshot-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.test.ts",
     "test:model-builder-commit-stale-snapshot-guard": "tsx utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.ts",
+    "test:model-builder-reset-all-guard-selftest": "tsx utils/scripts/verifyModelBuilderResetAllGuard.test.ts",
+    "test:model-builder-reset-all-guard": "tsx utils/scripts/verifyModelBuilderResetAllGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1906,6 +1906,16 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     state.selections = {}
     state.run = null
     state.generatingItemId = null
+    // Clear the remaining store-wide "who's in flight" singletons too --
+    // they are not scoped to the run being abandoned here, so a reset while
+    // one is still claimed (e.g. mid auto-build or mid commit) would
+    // otherwise leak into the next run: its Auto-build/batch controls would
+    // read as busy until the abandoned run's own in-flight call resolves.
+    state.committingItemId = null
+    state.autoBuilding = false
+    state.autoBuildingItemId = null
+    state.batchingOutputKey = null
+    draftingField.value = null
     safeRemove(runIdKey)
     clearStatus()
   }

--- a/utils/scripts/verifyModelBuilderResetAllGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderResetAllGuard.test.ts
@@ -1,0 +1,90 @@
+// /utils/scripts/verifyModelBuilderResetAllGuard.test.ts
+//
+// Regression test for checkResetAllGuard() in
+// verifyModelBuilderResetAllGuard.ts (model-builder/t-029). Exercises the
+// real check against synthetic store-shaped fixtures covering: the pre-fix
+// shape (only generatingItemId cleared -- the exact gap found by manual
+// read-through), and the fixed shape (all five store-wide singletons
+// cleared).
+import assert from 'node:assert/strict'
+
+import { checkResetAllGuard } from './verifyModelBuilderResetAllGuard.js'
+
+const BUGGY_FIXTURE = `
+  function resetAll(): void {
+    state.step = 'source'
+    state.sourceType = null
+    state.sources = []
+    state.selectedSource = null
+    state.recipeKey = null
+    state.selections = {}
+    state.run = null
+    state.generatingItemId = null
+    safeRemove(runIdKey)
+    clearStatus()
+  }
+`
+
+const FIXED_FIXTURE = `
+  function resetAll(): void {
+    state.step = 'source'
+    state.sourceType = null
+    state.sources = []
+    state.selectedSource = null
+    state.recipeKey = null
+    state.selections = {}
+    state.run = null
+    state.generatingItemId = null
+    state.committingItemId = null
+    state.autoBuilding = false
+    state.autoBuildingItemId = null
+    state.batchingOutputKey = null
+    draftingField.value = null
+    safeRemove(runIdKey)
+    clearStatus()
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkResetAllGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  5,
+  `expected the pre-fix shape (only generatingItemId cleared) to raise 5 ` +
+    `errors, one per still-dangling singleton, got ${buggyErrors.length}: ` +
+    JSON.stringify(buggyErrors),
+)
+assert.ok(buggyErrors.some((e) => e.includes('committingItemId')))
+assert.ok(buggyErrors.some((e) => e.includes('autoBuilding = false')))
+assert.ok(buggyErrors.some((e) => e.includes('autoBuildingItemId')))
+assert.ok(buggyErrors.some((e) => e.includes('batchingOutputKey')))
+assert.ok(buggyErrors.some((e) => e.includes('draftingField.value')))
+
+const fixedErrors = checkResetAllGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingFnErrors = checkResetAllGuard(MISSING_FIXTURE)
+assert.equal(
+  missingFnErrors.length,
+  1,
+  'expected a single "function not found" violation when resetAll is absent',
+)
+assert.ok(missingFnErrors[0]!.includes('resetAll'))
+
+console.log(
+  'Model Builder resetAll guard checker verified: flags the pre-fix shape ' +
+    '(only generatingItemId cleared), clears the fixed shape (all five ' +
+    'store-wide singletons cleared), and flags resetAll being absent ' +
+    'entirely.',
+)

--- a/utils/scripts/verifyModelBuilderResetAllGuard.ts
+++ b/utils/scripts/verifyModelBuilderResetAllGuard.ts
@@ -1,0 +1,103 @@
+// /utils/scripts/verifyModelBuilderResetAllGuard.ts
+//
+// Regression guard (model-builder/t-029, kaizen) -- committingItemId,
+// autoBuilding, autoBuildingItemId, batchingOutputKey, and draftingField are
+// store-wide (not per-run) "who's in flight" singletons, documented as such
+// alongside generatingItemId (see the comment above the state interface).
+// resetAll() is the one path back to the very start of the wizard, and a
+// user can trigger it while one of those singletons is still claimed (e.g.
+// mid auto-build, mid commit, or mid a field draft) -- nothing disables the
+// header Reset button for that. Before this fix, resetAll() cleared
+// generatingItemId but left the other four dangling, so the abandoned run's
+// in-flight claim leaked into whatever the user did next: a brand-new run's
+// Auto-build/batch controls could read as busy (or, for batchingOutputKey,
+// a same-named output group could be wrongly disabled) until the abandoned
+// run's own in-flight network call happened to resolve on its own.
+//
+// This asserts the textual shape of that fix stays in place: resetAll()
+// sets committingItemId/autoBuildingItemId/batchingOutputKey to null,
+// autoBuilding to false, and draftingField.value to null, mirroring the
+// existing `state.generatingItemId = null` line -- deliberately scoped to
+// this one function/bug, same convention as the other
+// verifyModelBuilder*Guard.ts checkers in this directory.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'resetAll'
+
+const REQUIRED_STATEMENTS = [
+  'state.committingItemId = null',
+  'state.autoBuilding = false',
+  'state.autoBuildingItemId = null',
+  'state.batchingOutputKey = null',
+  'draftingField.value = null',
+]
+
+// Checks the fix's exact shape against the full source text of a file
+// containing a `resetAll`-named function. Exported (rather than only
+// exercised via main()) so the self-test below can run it against synthetic
+// buggy/fixed fixtures without touching the real store file.
+export function checkResetAllGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find a function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the leak it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  for (const statement of REQUIRED_STATEMENTS) {
+    if (!fn.body.includes(statement)) {
+      errors.push(
+        `${FN_NAME}() no longer contains \`${statement}\`. ` +
+          'committingItemId, autoBuilding, autoBuildingItemId, ' +
+          'batchingOutputKey, and draftingField are store-wide singletons, ' +
+          'not scoped to the run being abandoned -- resetAll() must clear ' +
+          'every one of them (alongside generatingItemId) or the next run ' +
+          "started after a reset can inherit the abandoned run's still-" +
+          'claimed in-flight state.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkResetAllGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder resetAll guard contract failed for ' +
+        `${FN_NAME}() in modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Model Builder resetAll guard contract passed: ${FN_NAME}() clears all ` +
+      'five store-wide in-flight singletons (generatingItemId, ' +
+      'committingItemId, autoBuilding/autoBuildingItemId, ' +
+      'batchingOutputKey, draftingField).',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
conductor/model-builder/t-029: Polish and upgrade Model Builder front-end surface (kind: software, recurring)

### What changed / what I produced
- `stores/modelBuilderStore.ts`: `resetAll()` (the header "Reset" action, always enabled outside `startingRun`/`resumingRun`) previously cleared only `state.generatingItemId`. `committingItemId`, `autoBuilding`, `autoBuildingItemId`, `batchingOutputKey`, and `draftingField` are documented as the same kind of store-wide (not per-run) "who's in flight" singleton, but were left dangling on reset.
- **Failure scenario before this fix:** a user clicks Reset while one of those four is still claimed (mid auto-build, mid commit, or mid a field draft). The abandoned run's claim survives the reset. If the user immediately starts a new run, its Auto-build/batch controls can read as busy (`autoBuilding`/`autoBuildingItemId`), or a same-named output group can be wrongly disabled (`batchingOutputKey`), until the abandoned run's own in-flight network call happens to resolve on its own (bounded only by things like the 60s commit timeout).
- Fixed by clearing all five singletons in `resetAll()`, mirroring the existing `generatingItemId` line.
- Added `utils/scripts/verifyModelBuilderResetAllGuard.ts` (+ `.test.ts`) as a regression guard, following the existing `verifyModelBuilder*.ts` pattern used for every other bug this recurring task has fixed, and wired it into `contract-tests.yml` alongside the other Model Builder guards.

### How I verified
- New guard self-test (`test:model-builder-reset-all-guard-selftest`) and contract (`test:model-builder-reset-all-guard`) both pass.
- `npx eslint stores/modelBuilderStore.ts`: 2 pre-existing `no-empty` errors (unrelated `catch {}` blocks, lines 203/210), confirmed present with and without this diff via `git stash`.
- `npx vue-tsc --noEmit` (full project): exit 0, no errors.
- `npx prettier --check`: `stores/modelBuilderStore.ts` and `package.json` carry pre-existing formatting drift, confirmed identical with and without this diff via `git stash` (same known prettier-version-mismatch prior cycles of this task have flagged) — left untouched rather than bundling an unrelated reformat into this fix.
- `git diff --stat`: exactly the intended 3 modified files + 2 new files.

### Stakes
reversible

### Flags for Reviewer
- Purely additive fix to one function's body plus a new regression guard — no behavior change to `resetRun` (which intentionally leaves these singletons alone, per its own "run stays valid and resumable" contract) or to `openRun`/`cancelRun`.

### Notes for reviewer
Conductor task: projects/model-builder/roadmap.yaml, t-029 (recurring "Polish and upgrade Model Builder front-end surface" lane).


---
_Generated by [Claude Code](https://claude.ai/code/session_01HLrLY8fBqvofPWRnHTsp75)_