### PR TITLE
fix(storybook): swap tutorial placeholder for the real tutorials/scenario/storybook image

### DIFF
--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -687,6 +687,7 @@ import { isNarrativeRoleKey } from '@/utils/narrativeRoles'
 import { useScenarioStore } from '@/stores/scenarioStore'
 import { useRoute, useRouter } from 'vue-router'
 import { beatIdFromTurnId, narrativeBeatsToTurns } from '@/utils/narrativeTurns'
+import { getTutorialImagePath } from '@/stores/helpers/tutorialCards'
 
 const { mode, setMode, dataTheme, modes } = useStorybookMode()
 
@@ -699,16 +700,7 @@ const router = useRouter()
 const facetStore = useFacetStore()
 const rewardStore = useRewardStore()
 
-/*
- * scenario/storybook.webp was never uploaded to the media share (confirmed
- * 404 against media.acrocatranch.com, sibling scenario/* tab images all
- * resolve fine — see interface-vision/t-111). The global
- * navigation-image-fallback plugin would eventually swap in the same
- * placeholder on error, but only after a real failed request and a second
- * network round trip, which is what the responsive audit's BROKEN-ART check
- * caught. Point at the working placeholder directly until real art exists.
- */
-const tabImage = computed(() => '/images/botcafe.webp')
+const tabImage = computed(() => getTutorialImagePath('scenario', 'storybook'))
 
 const setupStep = ref(0)
 const furthestStep = ref(0)


### PR DESCRIPTION
## Summary
- `storybook-page.vue`'s narrator-stage image (`tabImage`) fell back to the generic `/images/botcafe.webp` placeholder because `/images/tutorials/scenario/storybook.webp` had never been generated — tracked since 2026-07-28 by conductor `coloring-book/t-010`.
- That art request has since rendered (ArtJob 8248, status `DONE`) and is now live end-to-end through the home relay's media path: `kind-robots.vercel.app/images/tutorials/scenario/storybook.webp` → 307 → `media.acrocatranch.com/images/tutorials/scenario/storybook.webp` → 200.
- Swapped `tabImage` to use the existing `getTutorialImagePath('scenario', 'storybook')` helper (same one `tutorialCards.ts` already uses for this exact asset) instead of the hardcoded placeholder, and removed the now-stale explanatory comment.

No behavior/logic change beyond the image source — purely a real-asset swap-in.

## Verification
- `npx eslint components/conductor/storybook-page.vue`: clean.
- `npx vue-tsc --noEmit` (repo-wide): clean.
- `npx prettier --check`: clean.
- Confirmed the real image resolves 200 end-to-end via `curl -L` against both the production Vercel URL and the underlying media-share host before making the change.
- Per `distribute_images.py`'s own documented convention, `public/images/**` is git-ignored and ships via the home relay's direct media path, not git — so this PR intentionally does not add any binary image file, only the code change pointing at the now-live URL.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgJXXYKiYQYGQtxiZFJdVt)_