### PR TITLE
fix(model-builder): identify run history actions

### DIFF
--- a/components/model-builder/model-builder-run-history.vue
+++ b/components/model-builder/model-builder-run-history.vue
@@ -99,6 +99,7 @@
             v-else
             type="button"
             class="btn btn-xs btn-error shrink-0 rounded-lg"
+            :aria-label="`Confirm cancellation of run ${run.sourceLabel || `#${run.sourceId}`}`"
             @click="confirmCancel(run.id)"
             @blur="armedRunId = null"
           >
@@ -108,6 +109,7 @@
           <button
             type="button"
             class="btn btn-xs btn-primary shrink-0 rounded-lg"
+            :aria-label="`Open run ${run.sourceLabel || `#${run.sourceId}`}`"
             @click="open(run.id)"
           >
             Open


### PR DESCRIPTION
### Task
model-builder/t-029 recurring polish lane.

### What changed
Model Builder run history has repeated `Open` controls and an armed `Confirm?` cancellation control for every row. Visible context makes those understandable visually, but their accessible names were identical across rows. This adds run-specific accessible names to both actions while leaving behavior and layout unchanged.

### Verification
- Scoped one-file template-only diff.
- No API, store, schema, persistence, or ArtJob changes.
- Required GitHub checks must complete successfully on the exact head before merge.

### Stakes
Reversible accessibility polish.

### Flags for Reviewer
None. This is not a human-gated or outward-facing change.

### Kaizen suggestion
Add a lightweight accessibility contract for repeated row actions in Model Builder history so generic labels do not regress.