### PR TITLE
fix(model-builder): resetRun() now clears all six store-wide in-flight singletons

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -293,6 +293,12 @@ jobs:
       - name: Model Builder resetAll guard contract
         run: npm run test:model-builder-reset-all-guard
 
+      - name: Model Builder resetRun guard checker self-test
+        run: npm run test:model-builder-reset-run-guard-selftest
+
+      - name: Model Builder resetRun guard contract
+        run: npm run test:model-builder-reset-run-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -170,6 +170,8 @@
     "test:model-builder-commit-stale-snapshot-guard": "tsx utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.ts",
     "test:model-builder-reset-all-guard-selftest": "tsx utils/scripts/verifyModelBuilderResetAllGuard.test.ts",
     "test:model-builder-reset-all-guard": "tsx utils/scripts/verifyModelBuilderResetAllGuard.ts",
+    "test:model-builder-reset-run-guard-selftest": "tsx utils/scripts/verifyModelBuilderResetRunGuard.test.ts",
+    "test:model-builder-reset-run-guard": "tsx utils/scripts/verifyModelBuilderResetRunGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1893,6 +1893,20 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   function resetRun(): void {
     state.run = null
     state.step = state.selectedSource ? 'recipe' : 'source'
+    // Clear the same store-wide "who's in flight" singletons resetAll() clears
+    // (see its comment) -- resetRun() is reachable from ordinary UI clicks
+    // ("New run" in the progress matrix and run history, plus cancelRun()
+    // cancelling the active run) without going through resetAll(), so it was
+    // leaking the same stale-busy-indicator bug through a second path: e.g.
+    // starting a batch on output group "rewards" in Run A, then resetting to
+    // Run B before it finishes left Run B's same-named "rewards" batch
+    // controls reading busy until Run A's abandoned call happened to resolve.
+    state.generatingItemId = null
+    state.committingItemId = null
+    state.autoBuilding = false
+    state.autoBuildingItemId = null
+    state.batchingOutputKey = null
+    draftingField.value = null
     safeRemove(runIdKey)
     clearStatus()
   }

--- a/utils/scripts/verifyModelBuilderResetRunGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderResetRunGuard.test.ts
@@ -1,0 +1,80 @@
+// /utils/scripts/verifyModelBuilderResetRunGuard.test.ts
+//
+// Regression test for checkResetRunGuard() in
+// verifyModelBuilderResetRunGuard.ts (model-builder/t-029). Exercises the
+// real check against synthetic store-shaped fixtures covering: the pre-fix
+// shape (no store-wide singletons cleared -- the exact gap found by manual
+// read-through), and the fixed shape (all six store-wide singletons
+// cleared).
+import assert from 'node:assert/strict'
+
+import { checkResetRunGuard } from './verifyModelBuilderResetRunGuard.js'
+
+const BUGGY_FIXTURE = `
+  function resetRun(): void {
+    state.run = null
+    state.step = state.selectedSource ? 'recipe' : 'source'
+    safeRemove(runIdKey)
+    clearStatus()
+  }
+`
+
+const FIXED_FIXTURE = `
+  function resetRun(): void {
+    state.run = null
+    state.step = state.selectedSource ? 'recipe' : 'source'
+    state.generatingItemId = null
+    state.committingItemId = null
+    state.autoBuilding = false
+    state.autoBuildingItemId = null
+    state.batchingOutputKey = null
+    draftingField.value = null
+    safeRemove(runIdKey)
+    clearStatus()
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkResetRunGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  6,
+  `expected the pre-fix shape (no singletons cleared) to raise 6 errors, ` +
+    `one per still-dangling singleton, got ${buggyErrors.length}: ` +
+    JSON.stringify(buggyErrors),
+)
+assert.ok(buggyErrors.some((e) => e.includes('generatingItemId')))
+assert.ok(buggyErrors.some((e) => e.includes('committingItemId')))
+assert.ok(buggyErrors.some((e) => e.includes('autoBuilding = false')))
+assert.ok(buggyErrors.some((e) => e.includes('autoBuildingItemId')))
+assert.ok(buggyErrors.some((e) => e.includes('batchingOutputKey')))
+assert.ok(buggyErrors.some((e) => e.includes('draftingField.value')))
+
+const fixedErrors = checkResetRunGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingFnErrors = checkResetRunGuard(MISSING_FIXTURE)
+assert.equal(
+  missingFnErrors.length,
+  1,
+  'expected a single "function not found" violation when resetRun is absent',
+)
+assert.ok(missingFnErrors[0]!.includes('resetRun'))
+
+console.log(
+  'Model Builder resetRun guard checker verified: flags the pre-fix shape ' +
+    '(no store-wide singletons cleared), clears the fixed shape (all six ' +
+    'store-wide singletons cleared), and flags resetRun being absent ' +
+    'entirely.',
+)

--- a/utils/scripts/verifyModelBuilderResetRunGuard.ts
+++ b/utils/scripts/verifyModelBuilderResetRunGuard.ts
@@ -1,0 +1,102 @@
+// /utils/scripts/verifyModelBuilderResetRunGuard.ts
+//
+// Regression guard (model-builder/t-029, kaizen) -- a sibling of
+// verifyModelBuilderResetAllGuard.ts for the same bug class reached through a
+// second path. generatingItemId, committingItemId, autoBuilding/
+// autoBuildingItemId, batchingOutputKey, and draftingField are store-wide
+// (not per-run) "who's in flight" singletons. resetAll() was fixed to clear
+// all five, but resetRun() -- reachable from ordinary UI clicks without going
+// through resetAll() ("New run" in the progress matrix and run history, plus
+// cancelRun() cancelling the active run) -- cleared none of them. Starting a
+// batch/auto-build/commit/draft on Run A, then resetting to Run B before it
+// finished left Run B inheriting the abandoned run's still-claimed in-flight
+// state: e.g. Run B's same-named output group ("rewards") read as busy until
+// Run A's abandoned batch call happened to resolve on its own.
+//
+// This asserts the textual shape of that fix stays in place: resetRun() sets
+// generatingItemId/committingItemId/autoBuildingItemId/batchingOutputKey to
+// null, autoBuilding to false, and draftingField.value to null -- deliberately
+// scoped to this one function/bug, same convention as the other
+// verifyModelBuilder*Guard.ts checkers in this directory.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'resetRun'
+
+const REQUIRED_STATEMENTS = [
+  'state.generatingItemId = null',
+  'state.committingItemId = null',
+  'state.autoBuilding = false',
+  'state.autoBuildingItemId = null',
+  'state.batchingOutputKey = null',
+  'draftingField.value = null',
+]
+
+// Checks the fix's exact shape against the full source text of a file
+// containing a `resetRun`-named function. Exported (rather than only
+// exercised via main()) so the self-test below can run it against synthetic
+// buggy/fixed fixtures without touching the real store file.
+export function checkResetRunGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find a function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the leak it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  for (const statement of REQUIRED_STATEMENTS) {
+    if (!fn.body.includes(statement)) {
+      errors.push(
+        `${FN_NAME}() no longer contains \`${statement}\`. ` +
+          'generatingItemId, committingItemId, autoBuilding, ' +
+          'autoBuildingItemId, batchingOutputKey, and draftingField are ' +
+          'store-wide singletons, not scoped to the run being abandoned -- ' +
+          'resetRun() must clear every one of them or a new run started ' +
+          "after it can inherit the abandoned run's still-claimed " +
+          'in-flight state.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkResetRunGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder resetRun guard contract failed for ' +
+        `${FN_NAME}() in modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Model Builder resetRun guard contract passed: ${FN_NAME}() clears all ` +
+      'six store-wide in-flight singletons (generatingItemId, ' +
+      'committingItemId, autoBuilding/autoBuildingItemId, ' +
+      'batchingOutputKey, draftingField).',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
model-builder/t-029: Polish and upgrade Model Builder front-end surface (recurring, kind: software)

### What changed / what I produced
`resetAll()` was already fixed (t-029 kaizen, PR #1778) to clear the five store-wide "who's in flight" singletons (`generatingItemId`, `committingItemId`, `autoBuilding`/`autoBuildingItemId`, `batchingOutputKey`, `draftingField`) that aren't scoped to the run being abandoned. `resetRun()` leaked the exact same bug through a second, more commonly-used path the existing guard didn't cover — it's reachable from ordinary UI clicks (`model-builder-progress-matrix.vue`'s "New run" button, `model-builder-run-history.vue`'s `startNew()`, and `cancelRun()` cancelling the active run) without ever going through `resetAll()`, and it cleared none of the six.

**Concrete trigger:** start a batch/auto-build action on Run A's output group `"rewards"` (`state.batchingOutputKey = 'rewards'`), then click "New run" (`resetRun()`) before it finishes and start Run B on the same recipe. Run B's same-named `"rewards"` batch controls (`model-builder-batch-editor.vue`) read as busy — no indication why — until Run A's abandoned batch loop happens to resolve on its own, which can take tens of seconds to minutes.

**Fix:** `resetRun()` now clears `generatingItemId`, `committingItemId`, `autoBuilding`, `autoBuildingItemId`, `batchingOutputKey`, and `draftingField`, mirroring `resetAll()`. Only preemptively clears the UI-facing "busy" flags — the abandoned run's background work is untouched (deliberately, per the existing doc comment on `createOwnedSingleton`/`release()`).

Adds `utils/scripts/verifyModelBuilderResetRunGuard.ts` (+ `.test.ts`), a sibling regression guard to `verifyModelBuilderResetAllGuard.ts`, wired into `package.json`/`contract-tests.yml` following the established one-guard-per-fix convention.

### How I verified
- New guard self-test + guard pass.
- All pre-existing `verifyModelBuilder*.ts` guards + selftests still pass (no regression).
- `eslint` on changed files clean (2 pre-existing unrelated `no-empty` errors in `modelBuilderStore.ts` confirmed via `git stash` to predate this change).
- `prettier --check` drift on `modelBuilderStore.ts`/`package.json` confirmed pre-existing via `git stash`, left untouched.
- `vue-tsc --noEmit` clean repo-wide.
- `npm run test:workflow-paths` green (new `contract-tests.yml` step references a real path).
- `git diff --stat` confirmed exactly 5 files, scoped to this fix.

### Stakes
reversible

### Flags for Reviewer
None — small, scoped, self-contained store fix plus its regression guard, same shape as the sibling `resetAll()` fix it mirrors.

### Kaizen suggestion
The two remaining store-wide-singleton entry points (`resetAll()`, `resetRun()`) are now both covered by dedicated guards. A future slice could add one shared helper (e.g. `clearInFlightSingletons()`) that both call, so a seventh singleton added later only needs one guard update instead of two — flagging as a nice-to-have, not blocking.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_012LS9PtRraiPK3Rg8cM3Diu

---
_Generated by [Claude Code](https://claude.ai/code/session_012LS9PtRraiPK3Rg8cM3Diu)_