### PR TITLE
fix(model-builder): expose stage statuses to assistive tech

### DIFF
--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -115,6 +115,7 @@
               class="text-center"
             >
               <span
+                role="img"
                 class="inline-flex h-5 w-5 items-center justify-center rounded-full text-[10px]"
                 :class="statusClass(item.stages[stage.key].status)"
                 :title="item.stages[stage.key].status"


### PR DESCRIPTION
### Task
model-builder/t-029 recurring polish

### What changed
- Added an explicit semantic role to each Model Builder stage-status badge.
- The badges already carry specific accessible labels such as `FIELDS: approved`; `role="img"` now gives those labels a semantic target instead of leaving them on a generic span whose label may be ignored by assistive technology.
- The child icon remains decorative (`aria-hidden="true"`).

### Scope
One additive template attribute in `components/model-builder/model-builder-progress-matrix.vue`. No behavior, API, store, persistence, schema, ArtJob, or production-data changes.

### Verification
- Read the full current component and audited the resulting branch diff against current main.
- Conductor claim and `status: review` transitions were processed and verified before this PR opened.
- Local shell/runtime is unavailable in this session, so GitHub Actions on this exact head are the TypeScript/contract verification gate.

### Stakes
Reversible, non-gated accessibility polish.

### Flags for Reviewer
Merge only after the attached exact-head required checks have completed successfully.