### PR TITLE
fix(storybook): roll back a failed weaveBeat() call in answerCurrentBeat()

### DIFF
--- a/.github/workflows/storybook-answer-rollback-contract.yml
+++ b/.github/workflows/storybook-answer-rollback-contract.yml
@@ -1,0 +1,30 @@
+name: Storybook Answer Rollback Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: storybook-answer-rollback-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Storybook answer-rollback contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify Storybook answer rollback
+        run: node utils/scripts/verifyStorybookAnswerRollbackGuard.mjs

--- a/stores/storybookStore.ts
+++ b/stores/storybookStore.ts
@@ -727,9 +727,10 @@ export const useStorybookStore = defineStore('storybookStore', () => {
       return false
 
     const capturedAt = nowIso()
+    const branchEntryId = makeId()
     beat.answer = { text: clean, capturedAt }
     active.branchHistory.push({
-      id: makeId(),
+      id: branchEntryId,
       beatId: beat.id,
       question: beat.question,
       answer: clean,
@@ -738,9 +739,25 @@ export const useStorybookStore = defineStore('storybookStore', () => {
     active.updatedAt = capturedAt
     persist()
 
-    return weaveBeat(
+    const wove = await weaveBeat(
       `${PERSONA}\n\nSTORY BIBLE\n${biblePrompt(active.bible)}\n\n${statePrompt(active)}\n\n${phaseGuidance()}\n\nSTORY SO FAR\n${buildRecap()}\n\nContinue the story from the reader's latest choice. Preserve continuity, apply a fresh consequence or discovery when earned, and end with one new question.`,
     )
+
+    if (!wove) {
+      // Roll back the recorded answer so the reader isn't soft-locked: without
+      // this, `awaitingAnswer` stays false (the beat already has an answer)
+      // while `canFinish` may still be false too (too few beats), leaving no
+      // way forward except discarding the whole session.
+      beat.answer = undefined
+      const historyIndex = active.branchHistory.findIndex(
+        (entry) => entry.id === branchEntryId,
+      )
+      if (historyIndex !== -1) active.branchHistory.splice(historyIndex, 1)
+      active.updatedAt = nowIso()
+      persist()
+    }
+
+    return wove
   }
 
   async function finishStory(): Promise<boolean> {

--- a/utils/scripts/verifyStorybookAnswerRollbackGuard.mjs
+++ b/utils/scripts/verifyStorybookAnswerRollbackGuard.mjs
@@ -1,0 +1,96 @@
+// /utils/scripts/verifyStorybookAnswerRollbackGuard.mjs
+//
+// Regression guard (storybook/t-010, front-end polish). `answerCurrentBeat`
+// records the reader's answer on the current beat and a new branchHistory
+// entry, then calls `weaveBeat` to generate the next scene. If `weaveBeat`
+// fails (a transient generateText error, an unparsable response, or a thrown
+// error), the beat is left with an `answer` already set. That makes
+// `awaitingAnswer` false (it requires `currentBeat && !currentBeat.answer`),
+// disabling the composer -- and if the failure happens right after the
+// opening beat, `canFinish` is also false (it requires >= 2 beats), so no
+// "Finish this tale" escape exists either. The reader is soft-locked with no
+// way forward except discarding the entire session.
+//
+// This asserts the fix's shape stays in place: `answerCurrentBeat` awaits
+// `weaveBeat`'s result before returning, and on failure rolls the recorded
+// answer and branchHistory entry back out so `awaitingAnswer` becomes true
+// again and the reader can retry the same answer.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const STORE_PATH = 'stores/storybookStore.ts'
+const FN_NAME = 'answerCurrentBeat'
+
+function extractFunctionBody(content, name) {
+  const signaturePattern = new RegExp(`^ {2}async function ${name}\\s*\\(`, 'm')
+  const match = signaturePattern.exec(content)
+  if (!match) {
+    throw new Error(
+      `Could not find \` async function ${name}(\` in ${STORE_PATH} -- has ` +
+        'it been renamed, removed, or inlined? If so, this guard (and the ' +
+        'soft-lock it protects against) needs to move with it.',
+    )
+  }
+
+  const parenOpen = match.index + match[0].length - 1
+  let parenDepth = 0
+  let i = parenOpen
+  for (; i < content.length; i++) {
+    if (content[i] === '(') parenDepth++
+    else if (content[i] === ')') {
+      parenDepth--
+      if (parenDepth === 0) break
+    }
+  }
+  const braceOpen = content.indexOf('{', i)
+  let braceDepth = 0
+  let j = braceOpen
+  for (; j < content.length; j++) {
+    if (content[j] === '{') braceDepth++
+    else if (content[j] === '}') {
+      braceDepth--
+      if (braceDepth === 0) break
+    }
+  }
+  return content.slice(braceOpen, j + 1)
+}
+
+const content = readFileSync(resolve(process.cwd(), STORE_PATH), 'utf8')
+const body = extractFunctionBody(content, FN_NAME)
+
+const required = [
+  [
+    'const wove = await weaveBeat(',
+    'must await weaveBeat and keep its result before deciding to roll back',
+  ],
+  ['if (!wove) {', 'must branch on a failed weaveBeat call'],
+  [
+    'beat.answer = undefined',
+    'must clear the recorded answer on failure so awaitingAnswer can become true again',
+  ],
+  [
+    'active.branchHistory.splice(historyIndex, 1)',
+    'must remove the branchHistory entry it just pushed on failure',
+  ],
+  [
+    'return wove',
+    'must return the actual weaveBeat outcome, not a value computed before the rollback',
+  ],
+]
+
+for (const [needle, why] of required) {
+  assert.ok(
+    body.includes(needle),
+    `${FN_NAME}() no longer contains \`${needle}\` -- ${why}, or a failed ` +
+      'weaveBeat call soft-locks the reader (composer disabled, no Finish ' +
+      'button if the failure happens on the opening beat) with no way ' +
+      'forward except discarding the whole session.',
+  )
+}
+
+console.log(
+  `Storybook answer-rollback guard contract passed: ${FN_NAME}() rolls back ` +
+    'a failed weaveBeat call so the reader can retry instead of getting ' +
+    'soft-locked.',
+)


### PR DESCRIPTION
### Task
storybook/t-010: polish and upgrade the Storybook front-end surface (kind: software)

### What changed / what I produced
- `stores/storybookStore.ts`: `answerCurrentBeat()` now awaits `weaveBeat()`'s result before returning, and on failure rolls back the beat's just-recorded `answer` and the `branchHistory` entry it just pushed.
- Added `utils/scripts/verifyStorybookAnswerRollbackGuard.mjs` + its own `storybook-answer-rollback-contract.yml` workflow, matching this project's existing one-guard-per-fix convention (`storybook-branch-state-contract.yml` etc.).

### The bug
`answerCurrentBeat` set `beat.answer` and pushed a `branchHistory` entry, then called `weaveBeat` to generate the next scene. If `weaveBeat` failed for any reason (a transient `generateText` error, an unparsable/empty model response, or a thrown error), `active.beats` was left unchanged but the answer stayed recorded:
- `awaitingAnswer` requires `currentBeat && !currentBeat.answer` — now false, so the composer (`storybook-page.vue`) is disabled.
- `canFinish` requires `session.beats.length >= 2` — if the failure happens right after the opening beat (the most common early case), this is also false, so the "Finish this tale" escape never appears.

Concrete repro: start a story, answer the opening beat, have the generation call fail once. The reader sees the error message but has no composer and no finish button — the only way out is "New story" → discard, which throws away the whole session including the opening scene they already read and answered.

### How I verified
- `npx eslint stores/storybookStore.ts utils/scripts/verifyStorybookAnswerRollbackGuard.mjs` — one pre-existing, unrelated `no-useless-assignment` error at `storybookStore.ts:568` confirmed via `git stash` to predate this change (parsed-but-unused variable, nothing to do with `answerCurrentBeat`); the changed lines are clean.
- `npx vue-tsc --noEmit` — 0 errors repo-wide.
- `npx prettier --check` on all three changed/added files — clean.
- `npm run test:workflow-paths` — green (the new workflow file's `run:` path resolves to a real file).
- New guard: verified it fails against the pre-fix shape (`git stash` + run — 5/5 expected assertions fire) and passes against the fixed shape.
- Ran all four existing `verifyStorybook*.mjs` contracts — all still pass (no overlap/regression).

### Stakes
reversible

### Flags for Reviewer
- None — small, scoped, behavior-only change with a fixture-verified regression guard.

### Kaizen suggestion
`beginStory`'s opening `weaveBeat` call has the same "no retry affordance" shape if it fails (no beats exist yet, so there's nothing to roll back, but there's also no explicit retry button beyond re-submitting the setup form) — worth a look in a future storybook/t-010 pass. Also flagged by the same investigation: `derivedTitle`'s `split(/[.!?]/)[0]` mis-splits premises containing abbreviations (e.g. "Mr. Smith opens...") into a truncated title — cosmetic, small follow-up candidate.

### Notes for reviewer
Found via a dedicated Explore-subagent sweep of the Storybook store/components/composables, explicitly excluding the most recently merged storybook/t-010 fix (#1779, the tutorial-image placeholder swap) and cross-checked against all four existing `verifyStorybook*.mjs` contracts to confirm none already covered this failure path.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBnUrPy8oMm6JVErf6zkhB)_