### PR TITLE
fix(model-builder): expose selected recipe state

### DIFF
--- a/components/model-builder/model-builder-recipe-selector.vue
+++ b/components/model-builder/model-builder-recipe-selector.vue
@@ -37,6 +37,7 @@
             : 'btn-ghost border border-base-300'
         "
         :disabled="store.startingRun"
+        :aria-pressed="store.recipeKey === recipe.key"
         @click="store.selectRecipe(recipe.key)"
       >
         <span class="flex items-center gap-1.5 text-xs font-bold">


### PR DESCRIPTION
### Task
model-builder/t-029 recurring front-end polish

### What changed
- Exposes recipe-chip selection with native toggle-button semantics via `aria-pressed`.
- No behavior, API, store, persistence, schema, or ArtJob changes.

### Why
The recipe selector already renders its selected state visually (`btn-primary`) but the repeated buttons did not expose that state to assistive technology. This stranded branch contains a focused three-line accessibility fix and has no PR, so this branch-medic pass is rescuing it rather than duplicating the work.

### Verification
CI must complete successfully on the exact PR head before merge. Diff against current main is one Vue component, +2/-1, and the branch's only commit predates current main by one unrelated Storybook merge.

### Stakes
reversible

### Flags for Reviewer
None. Safe scoped accessibility change; merge only after exact-head required checks complete successfully.