### PR TITLE
Lazy-load workspace card catalogs per content page

### DIFF
--- a/.github/workflows/model-card-lazy-boundary.yml
+++ b/.github/workflows/model-card-lazy-boundary.yml
@@ -1,0 +1,24 @@
+name: Model Card Lazy Boundary
+
+on:
+  pull_request:
+    paths:
+      - 'stores/helpers/modelCards.ts'
+      - 'stores/pageStore.ts'
+      - 'pages/[...slug].vue'
+      - 'utils/scripts/verifyModelCardLazyBoundary.mjs'
+      - '.github/workflows/model-card-lazy-boundary.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify lazy workspace card boundary
+        run: node utils/scripts/verifyModelCardLazyBoundary.mjs

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -208,7 +208,7 @@ const isPageLoading = computed(() => {
   )
 })
 
-async function syncPageStore(): Promise<void> {
+function syncPageStore(): void {
   if (isLoginPath.value) {
     pageStore.clearPage()
     pageStore.setLoading(false)
@@ -224,22 +224,36 @@ async function syncPageStore(): Promise<void> {
 
   if (error.value) return
 
-  const page = activePage.value
-  if (page) {
-    const resolvedPath = contentPath.value
-    const cards = (page as CardContentPage).cards
-
-    if (typeof cards === 'string') {
-      await preloadModelCards(cards)
-    }
-
-    if (contentPath.value !== resolvedPath || activePage.value !== page) return
-
-    pageStore.setPage(page)
+  if (activePage.value) {
+    pageStore.setPage(activePage.value)
     return
   }
 
   pageStore.clearPage()
+}
+
+async function preloadAndSyncPageStore(): Promise<void> {
+  if (isLoginPath.value || isPageLoading.value || error.value) {
+    syncPageStore()
+    return
+  }
+
+  const page = activePage.value
+  if (!page) {
+    syncPageStore()
+    return
+  }
+
+  const resolvedPath = contentPath.value
+  const cards = (page as CardContentPage).cards
+
+  if (typeof cards === 'string') {
+    await preloadModelCards(cards)
+  }
+
+  if (contentPath.value !== resolvedPath || activePage.value !== page) return
+
+  syncPageStore()
 }
 
 /*
@@ -251,28 +265,30 @@ async function syncPageStore(): Promise<void> {
  * it rendered nothing until hydration.
  *
  * The page backdrop made that visible: app.vue emits no backdrop element at all
- * when pageStore reports no art, so every page load painted a backdrop-less
+ * when the store reports no art, so every page load painted a backdrop-less
  * first frame and then popped the art in. Title and description came from the
  * same store and had the same gap.
  *
- * Workspace card catalogs are also preloaded here before pageStore receives the
- * page. That keeps the card hand synchronous for SSR while allowing each deck to
- * remain a route-local chunk instead of pinning every catalog into app startup.
- *
- * onMounted still runs it, which is a harmless cached re-set on the client and
- * still the right place to start the store's own async initialize and the
- * route watcher.
+ * Workspace card catalogs are preloaded before this setup-scope synchronization.
+ * That keeps the card hand synchronous for SSR while allowing each deck to stay
+ * a route-local chunk instead of pinning every catalog into app startup.
  */
-await syncPageStore()
+if (activePage.value) {
+  const initialCards = (activePage.value as CardContentPage).cards
+  if (typeof initialCards === 'string') {
+    await preloadModelCards(initialCards)
+  }
+}
+syncPageStore()
 
 onMounted(() => {
   pageStore.initialize()
-  void syncPageStore()
+  void preloadAndSyncPageStore()
 
   watch(
     [activePage, status, error, contentPath, pagePayload, isLoginPath],
     () => {
-      void syncPageStore()
+      void preloadAndSyncPageStore()
     },
     { flush: 'post' },
   )

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -251,7 +251,7 @@ async function preloadAndSyncPageStore(): Promise<void> {
     await preloadModelCards(cards)
   }
 
-  if (contentPath.value !== resolvedPath || activePage.value !== page) return
+  if (contentPath.value !== resolvedPath || !hasResolvedCurrentPath.value) return
 
   syncPageStore()
 }

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -60,6 +60,7 @@
 import { computed, onMounted, watch } from 'vue'
 import { navigateTo, useRoute } from '#app'
 import type { ContentCollectionItem } from '@nuxt/content'
+import { preloadModelCards } from '@/stores/helpers/modelCards'
 import { usePageStore } from '@/stores/pageStore'
 
 type PagePayload = {
@@ -74,6 +75,10 @@ type NarratedContentPage = ContentCollectionItem & {
 
 type RedirectingContentPage = ContentCollectionItem & {
   redirect?: unknown
+}
+
+type CardContentPage = ContentCollectionItem & {
+  cards?: unknown
 }
 
 const route = useRoute()
@@ -203,7 +208,7 @@ const isPageLoading = computed(() => {
   )
 })
 
-function syncPageStore(): void {
+async function syncPageStore(): Promise<void> {
   if (isLoginPath.value) {
     pageStore.clearPage()
     pageStore.setLoading(false)
@@ -219,8 +224,18 @@ function syncPageStore(): void {
 
   if (error.value) return
 
-  if (activePage.value) {
-    pageStore.setPage(activePage.value)
+  const page = activePage.value
+  if (page) {
+    const resolvedPath = contentPath.value
+    const cards = (page as CardContentPage).cards
+
+    if (typeof cards === 'string') {
+      await preloadModelCards(cards)
+    }
+
+    if (contentPath.value !== resolvedPath || activePage.value !== page) return
+
+    pageStore.setPage(page)
     return
   }
 
@@ -240,20 +255,24 @@ function syncPageStore(): void {
  * first frame and then popped the art in. Title and description came from the
  * same store and had the same gap.
  *
- * onMounted still runs it, which is a harmless no-op re-set on the client and
+ * Workspace card catalogs are also preloaded here before pageStore receives the
+ * page. That keeps the card hand synchronous for SSR while allowing each deck to
+ * remain a route-local chunk instead of pinning every catalog into app startup.
+ *
+ * onMounted still runs it, which is a harmless cached re-set on the client and
  * still the right place to start the store's own async initialize and the
  * route watcher.
  */
-syncPageStore()
+await syncPageStore()
 
 onMounted(() => {
   pageStore.initialize()
-  syncPageStore()
+  void syncPageStore()
 
   watch(
     [activePage, status, error, contentPath, pagePayload, isLoginPath],
     () => {
-      syncPageStore()
+      void syncPageStore()
     },
     { flush: 'post' },
   )

--- a/stores/helpers/modelCards.ts
+++ b/stores/helpers/modelCards.ts
@@ -1,14 +1,5 @@
 // /stores/helpers/modelCards.ts
 import type { BuilderCard } from '@/stores/helpers/builderCards'
-import { ADVENTURE_CARDS } from '@/stores/helpers/adventureCards'
-import { ART_CARDS } from '@/stores/helpers/artCards'
-import { BOT_CARDS } from '@/stores/helpers/botCards'
-import { CONDUCTOR_CARDS } from '@/stores/helpers/conductorCards'
-import { DREAM_CARDS } from '@/stores/helpers/dreamCards'
-import { LAB_CARDS } from '@/stores/helpers/labCards'
-import { NAV_CARDS } from '@/stores/helpers/navCards'
-import { REWARD_CARDS } from '@/stores/helpers/rewardCards'
-import { SCENARIO_CARDS } from '@/stores/helpers/scenarioCards'
 
 export type BuilderCardsKey =
   | 'adventureCards'
@@ -22,26 +13,85 @@ export type BuilderCardsKey =
   | 'scenarioCards'
   | 'userCards'
 
-export const modelCards: Partial<Record<BuilderCardsKey, BuilderCard[]>> = {
-  adventureCards: ADVENTURE_CARDS,
-  artCards: ART_CARDS,
-  botCards: BOT_CARDS,
-  conductorCards: CONDUCTOR_CARDS,
-  dreamCards: DREAM_CARDS,
-  labCards: LAB_CARDS,
-  navCards: NAV_CARDS,
-  rewardCards: REWARD_CARDS,
-  scenarioCards: SCENARIO_CARDS,
+type LoadableBuilderCardsKey = Exclude<BuilderCardsKey, 'userCards'>
+
+const BUILDER_CARD_KEYS = new Set<BuilderCardsKey>([
+  'adventureCards',
+  'artCards',
+  'botCards',
+  'conductorCards',
+  'dreamCards',
+  'labCards',
+  'navCards',
+  'rewardCards',
+  'scenarioCards',
+  'userCards',
+])
+
+export const modelCards: Partial<Record<BuilderCardsKey, BuilderCard[]>> = {}
+
+const pendingLoads: Partial<
+  Record<LoadableBuilderCardsKey, Promise<BuilderCard[]>>
+> = {}
+
+const cardLoaders: Record<
+  LoadableBuilderCardsKey,
+  () => Promise<BuilderCard[]>
+> = {
+  adventureCards: async () =>
+    (await import('@/stores/helpers/adventureCards')).ADVENTURE_CARDS,
+  artCards: async () => (await import('@/stores/helpers/artCards')).ART_CARDS,
+  botCards: async () => (await import('@/stores/helpers/botCards')).BOT_CARDS,
+  conductorCards: async () =>
+    (await import('@/stores/helpers/conductorCards')).CONDUCTOR_CARDS,
+  dreamCards: async () =>
+    (await import('@/stores/helpers/dreamCards')).DREAM_CARDS,
+  labCards: async () => (await import('@/stores/helpers/labCards')).LAB_CARDS,
+  navCards: async () => (await import('@/stores/helpers/navCards')).NAV_CARDS,
+  rewardCards: async () =>
+    (await import('@/stores/helpers/rewardCards')).REWARD_CARDS,
+  scenarioCards: async () =>
+    (await import('@/stores/helpers/scenarioCards')).SCENARIO_CARDS,
 }
 
 export function isBuilderCardsKey(value: string): value is BuilderCardsKey {
-  return value in modelCards || value === 'userCards'
+  return BUILDER_CARD_KEYS.has(value as BuilderCardsKey)
+}
+
+function normalizeCardsKey(value?: string | null): BuilderCardsKey | null {
+  const key = (value ?? '').trim()
+  return key && isBuilderCardsKey(key) ? key : null
 }
 
 export function getModelCards(value?: string | null): BuilderCard[] {
-  const key = (value ?? '').trim()
+  const key = normalizeCardsKey(value)
+  return key ? modelCards[key] ?? [] : []
+}
 
-  if (!key || !isBuilderCardsKey(key)) return []
+export async function preloadModelCards(
+  value?: string | null,
+): Promise<BuilderCard[]> {
+  const key = normalizeCardsKey(value)
+  if (!key || key === 'userCards') return []
 
-  return modelCards[key as BuilderCardsKey] ?? []
+  const cached = modelCards[key]
+  if (cached) return cached
+
+  const pending = pendingLoads[key]
+  if (pending) return pending
+
+  const load = cardLoaders[key]().then((cards) => {
+    modelCards[key] = cards
+    delete pendingLoads[key]
+    return cards
+  })
+
+  pendingLoads[key] = load
+
+  try {
+    return await load
+  } catch (error) {
+    delete pendingLoads[key]
+    throw error
+  }
 }

--- a/stores/helpers/modelCards.ts
+++ b/stores/helpers/modelCards.ts
@@ -82,7 +82,7 @@ export async function preloadModelCards(
 
   const load = cardLoaders[key]().then((cards) => {
     modelCards[key] = cards
-    delete pendingLoads[key]
+    pendingLoads[key] = undefined
     return cards
   })
 
@@ -91,7 +91,7 @@ export async function preloadModelCards(
   try {
     return await load
   } catch (error) {
-    delete pendingLoads[key]
+    pendingLoads[key] = undefined
     throw error
   }
 }

--- a/utils/scripts/verifyModelCardLazyBoundary.mjs
+++ b/utils/scripts/verifyModelCardLazyBoundary.mjs
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs'
+
+const modelCards = readFileSync('stores/helpers/modelCards.ts', 'utf8')
+const slugPage = readFileSync('pages/[...slug].vue', 'utf8')
+const pageStore = readFileSync('stores/pageStore.ts', 'utf8')
+
+const deckModules = [
+  'adventureCards',
+  'artCards',
+  'botCards',
+  'conductorCards',
+  'dreamCards',
+  'labCards',
+  'navCards',
+  'rewardCards',
+  'scenarioCards',
+]
+
+const failures = []
+const check = (condition, message) => {
+  if (!condition) failures.push(message)
+}
+
+for (const moduleName of deckModules) {
+  check(
+    !new RegExp(`^import\\s+[^\\n]+helpers/${moduleName}['\"]`, 'm').test(
+      modelCards,
+    ),
+    `modelCards.ts statically imports ${moduleName}; that pins the deck into the eager pageStore graph.`,
+  )
+  check(
+    new RegExp(`import\\(['\"]@/stores/helpers/${moduleName}['\"]\\)`).test(
+      modelCards,
+    ),
+    `modelCards.ts has no dynamic loader for ${moduleName}.`,
+  )
+}
+
+check(
+  /export\s+async\s+function\s+preloadModelCards/.test(modelCards),
+  'modelCards.ts must expose preloadModelCards so the router can hydrate the requested deck before pageStore reads it.',
+)
+check(
+  /pendingLoads/.test(modelCards),
+  'modelCards.ts must deduplicate in-flight deck imports during client navigation.',
+)
+check(
+  /import\s+\{\s*preloadModelCards\s*\}\s+from\s+['\"]@\/stores\/helpers\/modelCards['\"]/.test(
+    slugPage,
+  ),
+  'pages/[...slug].vue must import preloadModelCards.',
+)
+check(
+  /await\s+preloadModelCards\(cards\)/.test(slugPage),
+  'pages/[...slug].vue must await the content page deck before committing the page to Pinia.',
+)
+check(
+  /await\s+syncPageStore\(\)/.test(slugPage),
+  'pages/[...slug].vue must await initial page-store synchronization during SSR.',
+)
+check(
+  /getModelCards\(value\)/.test(pageStore),
+  'pageStore.ts must continue reading the preloaded deck synchronously so SSR and hydration render the same hand.',
+)
+
+if (failures.length) {
+  console.error(`Model-card lazy boundary failed with ${failures.length} problem(s):`)
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log(
+  `Model-card lazy boundary passed: ${deckModules.length} workspace decks remain route-loaded and pageStore consumes the preloaded cache synchronously.`,
+)

--- a/utils/scripts/verifyModelCardLazyBoundary.mjs
+++ b/utils/scripts/verifyModelCardLazyBoundary.mjs
@@ -51,12 +51,16 @@ check(
   'pages/[...slug].vue must import preloadModelCards.',
 )
 check(
-  /await\s+preloadModelCards\(cards\)/.test(slugPage),
-  'pages/[...slug].vue must await the content page deck before committing the page to Pinia.',
+  /await\s+preloadModelCards\(initialCards\)/.test(slugPage),
+  'pages/[...slug].vue must preload the initial content-page deck during SSR.',
 )
 check(
-  /await\s+syncPageStore\(\)/.test(slugPage),
-  'pages/[...slug].vue must await initial page-store synchronization during SSR.',
+  /await\s+preloadModelCards\(cards\)/.test(slugPage),
+  'pages/[...slug].vue must await route-navigation deck loads before committing the page to Pinia.',
+)
+check(
+  /\nsyncPageStore\(\)\n\nonMounted\(/.test(slugPage),
+  'pages/[...slug].vue must synchronously commit the preloaded initial page before onMounted so SSR and hydration agree.',
 )
 check(
   /getModelCards\(value\)/.test(pageStore),

--- a/utils/scripts/verifyModelCardLazyBoundary.mjs
+++ b/utils/scripts/verifyModelCardLazyBoundary.mjs
@@ -23,47 +23,43 @@ const check = (condition, message) => {
 
 for (const moduleName of deckModules) {
   check(
-    !new RegExp(`^import\\s+[^\\n]+helpers/${moduleName}['\"]`, 'm').test(
-      modelCards,
-    ),
+    !modelCards.includes(`from '@/stores/helpers/${moduleName}'`),
     `modelCards.ts statically imports ${moduleName}; that pins the deck into the eager pageStore graph.`,
   )
   check(
-    new RegExp(`import\\(['\"]@/stores/helpers/${moduleName}['\"]\\)`).test(
-      modelCards,
-    ),
+    modelCards.includes(`import('@/stores/helpers/${moduleName}')`),
     `modelCards.ts has no dynamic loader for ${moduleName}.`,
   )
 }
 
 check(
-  /export\s+async\s+function\s+preloadModelCards/.test(modelCards),
+  modelCards.includes('export async function preloadModelCards'),
   'modelCards.ts must expose preloadModelCards so the router can hydrate the requested deck before pageStore reads it.',
 )
 check(
-  /pendingLoads/.test(modelCards),
+  modelCards.includes('pendingLoads'),
   'modelCards.ts must deduplicate in-flight deck imports during client navigation.',
 )
 check(
-  /import\s+\{\s*preloadModelCards\s*\}\s+from\s+['\"]@\/stores\/helpers\/modelCards['\"]/.test(
-    slugPage,
+  slugPage.includes(
+    "import { preloadModelCards } from '@/stores/helpers/modelCards'",
   ),
   'pages/[...slug].vue must import preloadModelCards.',
 )
 check(
-  /await\s+preloadModelCards\(initialCards\)/.test(slugPage),
+  slugPage.includes('await preloadModelCards(initialCards)'),
   'pages/[...slug].vue must preload the initial content-page deck during SSR.',
 )
 check(
-  /await\s+preloadModelCards\(cards\)/.test(slugPage),
+  slugPage.includes('await preloadModelCards(cards)'),
   'pages/[...slug].vue must await route-navigation deck loads before committing the page to Pinia.',
 )
 check(
-  /\nsyncPageStore\(\)\n\nonMounted\(/.test(slugPage),
+  slugPage.includes('\nsyncPageStore()\n\nonMounted('),
   'pages/[...slug].vue must synchronously commit the preloaded initial page before onMounted so SSR and hydration agree.',
 )
 check(
-  /getModelCards\(value\)/.test(pageStore),
+  pageStore.includes('getModelCards(value)'),
   'pageStore.ts must continue reading the preloaded deck synchronously so SSR and hydration render the same hand.',
 )
 


### PR DESCRIPTION
Continues the startup/bundle cleanup after #1772 and #1773.

Vercel's production build reports that the content-page card catalogs are dynamically imported by the Facet hydration plugin but simultaneously statically imported by `stores/helpers/modelCards.ts`, which is itself statically imported by `pageStore`. Vite therefore cannot split those deck modules out of the eager page graph.

This slice preserves the existing synchronous `pageStore.cards` contract while breaking that static bundle edge:

- `modelCards.ts` becomes a lazy registry with one dynamic loader per card catalog
- loaded decks are cached by registry key and concurrent imports are deduplicated
- `pages/[...slug].vue` preloads only the active page's declared `cards:` catalog
- initial synchronization is awaited during SSR before the page is committed to Pinia, so the workspace hand does not render empty and then pop in during hydration
- client navigation race-checks the content path/page after an async deck load before committing it
- a dedicated contract rejects static deck imports and protects the SSR preload boundary

No content frontmatter or card definitions change. `/bots` still gets `botCards`, `/dreams` still gets `dreamCards`, nav pages still get `navCards`, etc.; they just stop dragging every sibling deck into the pageStore module graph.

Verification target: exact-head TypeScript/contracts green, then compare Vercel build output against the current ~921.5 kB largest client chunk and confirm the model-card dynamic/static collision warnings are reduced/removed.