### PR TITLE
fix(model-builder): draft-clobber fix + security: gate random reward pick

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -257,6 +257,12 @@ jobs:
       - name: Model Builder draft approval guard contract
         run: npm run test:model-builder-draft-approval-guard
 
+      - name: Model Builder draft textarea guard checker self-test
+        run: npm run test:model-builder-draft-textarea-guard-selftest
+
+      - name: Model Builder draft textarea guard contract
+        run: npm run test:model-builder-draft-textarea-guard
+
       - name: Model Builder auto-build draft gate checker self-test
         run: npm run test:model-builder-auto-build-draft-gate-selftest
 

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -44,7 +44,7 @@
         rows="2"
         class="textarea textarea-bordered w-full rounded-xl text-sm"
         placeholder="Why this output exists and what it should convey…"
-        :disabled="!isEditable('PITCH')"
+        :disabled="!isEditable('PITCH') || isDrafting('pitch')"
         @change="store.updatePitch(item.id, pitch)"
       />
       <div class="mt-1.5 flex items-center justify-end gap-1.5">
@@ -116,7 +116,7 @@
         rows="2"
         class="textarea textarea-bordered mb-1.5 w-full rounded-xl text-sm"
         placeholder="Schema fields and relationships to write on commit…"
-        :disabled="!isEditable('FIELDS_AND_PROMPTS')"
+        :disabled="!isEditable('FIELDS_AND_PROMPTS') || isDrafting('fields')"
         @change="store.updateFields(item.id, fields)"
       />
       <div class="mb-0.5 flex items-center justify-between">
@@ -143,7 +143,7 @@
         rows="2"
         class="textarea textarea-bordered w-full rounded-xl text-sm"
         placeholder="The prompt used to generate this asset…"
-        :disabled="!isEditable('FIELDS_AND_PROMPTS')"
+        :disabled="!isEditable('FIELDS_AND_PROMPTS') || isDrafting('artPrompt')"
         @change="store.updatePrompt(item.id, prompt)"
       />
       <div class="mt-1.5 flex justify-end gap-1.5">

--- a/package.json
+++ b/package.json
@@ -156,6 +156,8 @@
     "test:model-builder-commit-cancelled-run-guard": "tsx utils/scripts/verifyModelBuilderCommitCancelledRunGuard.ts",
     "test:model-builder-draft-approval-guard-selftest": "tsx utils/scripts/verifyModelBuilderDraftApprovalGuard.test.ts",
     "test:model-builder-draft-approval-guard": "tsx utils/scripts/verifyModelBuilderDraftApprovalGuard.ts",
+    "test:model-builder-draft-textarea-guard-selftest": "tsx utils/scripts/verifyModelBuilderDraftTextareaGuard.test.ts",
+    "test:model-builder-draft-textarea-guard": "tsx utils/scripts/verifyModelBuilderDraftTextareaGuard.ts",
     "test:model-builder-auto-build-draft-gate-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildDraftGate.test.ts",
     "test:model-builder-auto-build-draft-gate": "tsx utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts",
     "test:model-builder-item-patch-stage-guard-selftest": "tsx utils/scripts/verifyModelBuilderItemPatchStageGuard.test.ts",

--- a/server/api/rewards/random.get.ts
+++ b/server/api/rewards/random.get.ts
@@ -1,13 +1,34 @@
 // /server/api/rewards/random.get.ts
 import { defineEventHandler } from 'h3'
 import prisma from '../../utils/prisma'
+import { getOptionalApiUser } from '../../utils/authGuard'
+import { viewablePackIds } from '../../utils/contentAccess'
 
-export default defineEventHandler(async () => {
+export default defineEventHandler(async (event) => {
   let response
 
   try {
-    // Count the total number of rewards in the database
-    const totalRewards = await prisma.reward.count()
+    const auth = await getOptionalApiUser(event)
+    const userId = auth?.user.id ?? null
+    const isAdmin = auth?.isAdmin ?? false
+    const packIds = userId && !isAdmin ? await viewablePackIds(userId) : []
+
+    const visibility = isAdmin
+      ? {}
+      : userId
+        ? {
+            OR: [
+              { isPublic: true },
+              { userId },
+              ...(packIds.length ? [{ packId: { in: packIds } }] : []),
+            ],
+          }
+        : { isPublic: true }
+
+    const where = { isActive: true, ...visibility }
+
+    // Count the total number of viewable rewards
+    const totalRewards = await prisma.reward.count({ where })
 
     if (totalRewards === 0) {
       return {
@@ -22,6 +43,7 @@ export default defineEventHandler(async () => {
 
     // Fetch a random reward from the database
     const randomReward = await prisma.reward.findFirst({
+      where,
       skip: randomOffset,
       take: 1,
     })

--- a/utils/scripts/verifyModelBuilderDraftTextareaGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderDraftTextareaGuard.test.ts
@@ -1,0 +1,104 @@
+// /utils/scripts/verifyModelBuilderDraftTextareaGuard.test.ts
+//
+// Regression test for checkDraftTextareaGuard() in
+// verifyModelBuilderDraftTextareaGuard.ts (model-builder/t-029). Exercises
+// the real check against synthetic component-shaped fixtures covering: the
+// pre-fix shape (textareas disabled only on `!isEditable(...)`, with no
+// `isDrafting(field)` check -- the exact bug found by manual read-through),
+// the fixed shape, and one textarea missing entirely.
+import assert from 'node:assert/strict'
+
+import { checkDraftTextareaGuard } from './verifyModelBuilderDraftTextareaGuard.js'
+
+const BUGGY_FIXTURE = `
+<template>
+  <textarea
+    v-model="pitch"
+    rows="2"
+    placeholder="Why this output exists…"
+    :disabled="!isEditable('PITCH')"
+    @change="store.updatePitch(item.id, pitch)"
+  />
+  <textarea
+    v-model="fields"
+    rows="2"
+    placeholder="Schema fields…"
+    :disabled="!isEditable('FIELDS_AND_PROMPTS')"
+    @change="store.updateFields(item.id, fields)"
+  />
+  <textarea
+    v-model="prompt"
+    rows="2"
+    placeholder="The prompt used…"
+    :disabled="!isEditable('FIELDS_AND_PROMPTS')"
+    @change="store.updatePrompt(item.id, prompt)"
+  />
+</template>
+`
+
+const FIXED_FIXTURE = `
+<template>
+  <textarea
+    v-model="pitch"
+    rows="2"
+    placeholder="Why this output exists…"
+    :disabled="!isEditable('PITCH') || isDrafting('pitch')"
+    @change="store.updatePitch(item.id, pitch)"
+  />
+  <textarea
+    v-model="fields"
+    rows="2"
+    placeholder="Schema fields…"
+    :disabled="!isEditable('FIELDS_AND_PROMPTS') || isDrafting('fields')"
+    @change="store.updateFields(item.id, fields)"
+  />
+  <textarea
+    v-model="prompt"
+    rows="2"
+    placeholder="The prompt used…"
+    :disabled="!isEditable('FIELDS_AND_PROMPTS') || isDrafting('artPrompt')"
+    @change="store.updatePrompt(item.id, prompt)"
+  />
+</template>
+`
+
+const MISSING_FIXTURE = `
+<template>
+  <div>no textareas here</div>
+</template>
+`
+
+const buggyErrors = checkDraftTextareaGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  3,
+  `expected the pre-fix shape (no isDrafting checks) to raise 3 errors, ` +
+    `got ${buggyErrors.length}: ${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(buggyErrors[0]!.includes("isDrafting('pitch')"))
+assert.ok(buggyErrors[1]!.includes("isDrafting('fields')"))
+assert.ok(buggyErrors[2]!.includes("isDrafting('artPrompt')"))
+
+const fixedErrors = checkDraftTextareaGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingErrors = checkDraftTextareaGuard(MISSING_FIXTURE)
+assert.equal(
+  missingErrors.length,
+  3,
+  'expected a "not found" violation for each of the three textareas when ' +
+    'none are present',
+)
+for (const error of missingErrors) {
+  assert.ok(error.includes('Could not find a textarea'))
+}
+
+console.log(
+  'Model Builder draft textarea guard checker verified: flags the pre-fix ' +
+    'shape (textareas missing isDrafting(field) in :disabled), clears the ' +
+    'fixed shape, and flags each textarea being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderDraftTextareaGuard.ts
+++ b/utils/scripts/verifyModelBuilderDraftTextareaGuard.ts
@@ -1,0 +1,128 @@
+// /utils/scripts/verifyModelBuilderDraftTextareaGuard.ts
+//
+// Regression guard (model-builder/t-029) -- the Pitch, Fields, and Generation
+// prompt textareas in model-builder-item-panel.vue bind to local component
+// refs (`pitch`/`fields`/`prompt`), not directly to the store, and only push
+// to the store on `@change` (i.e. on blur). draftText()'s own "don't clobber
+// a newer edit" guard (verifyModelBuilderDraftApprovalGuard.ts's
+// `liveValue !== current` check) only compares against the *store's* value,
+// so it can't see an edit the user is still mid-typing that hasn't been
+// blurred/committed yet. Before this fix, none of the three textareas
+// disabled while their own field was drafting (unlike the "Draft with AI"
+// buttons right next to them, which already gate on `isDrafting(field)`) --
+// so a user could click Draft, start typing their own text into the same
+// field before the response landed, and have it silently overwritten the
+// instant the draft applied via updatePitch/updateFields/updatePrompt (whose
+// watcher on the item's store value unconditionally overwrites the local
+// ref). No error, no warning beyond the unrelated "Drafted ... for ..."
+// success toast -- the typed text is just gone.
+//
+// Fixed by disabling each textarea while its own field is drafting, closing
+// the vulnerable window entirely: `:disabled="!isEditable('PITCH') ||
+// isDrafting('pitch')"` and the equivalent for fields/artPrompt.
+//
+// This asserts the textual shape of the fix stays in place: each of the
+// three textareas' `:disabled` attribute includes its matching
+// `isDrafting('field')` check alongside the existing `isEditable(...)` one.
+// Deliberately scoped to this one component/bug, mirroring
+// verifyModelBuilderDraftApprovalGuard.ts's preference for explicit, narrow
+// textual checks over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const PANEL_PATH = join(
+  repositoryRoot,
+  'components/model-builder/model-builder-item-panel.vue',
+)
+
+const TEXTAREAS = [
+  { model: 'v-model="pitch"', field: 'pitch' },
+  { model: 'v-model="fields"', field: 'fields' },
+  { model: 'v-model="prompt"', field: 'artPrompt' },
+] as const
+
+// Checks the fix's exact shape against the full source text of
+// model-builder-item-panel.vue. Exported (rather than only exercised via
+// main()) so the self-test below can run it against synthetic buggy/fixed
+// fixtures without touching the real component file.
+export function checkDraftTextareaGuard(content: string): string[] {
+  const errors: string[] = []
+
+  for (const { model, field } of TEXTAREAS) {
+    const modelIndex = content.indexOf(model)
+    if (modelIndex === -1) {
+      errors.push(
+        `Could not find a textarea with \`${model}\` in ` +
+          'model-builder-item-panel.vue -- has it been renamed, removed, or ' +
+          'restructured? If so, this guard (and the bug it protects ' +
+          'against) needs to move with it.',
+      )
+      continue
+    }
+
+    const tagEnd = content.indexOf('/>', modelIndex)
+    if (tagEnd === -1) {
+      errors.push(
+        `Could not find the closing \`/>\` of the \`${model}\` textarea -- ` +
+          "this guard's anchor point has moved.",
+      )
+      continue
+    }
+    const tag = content.slice(modelIndex, tagEnd)
+
+    const disabledMatch = /:disabled="([^"]*)"/.exec(tag)
+    if (!disabledMatch) {
+      errors.push(
+        `The \`${model}\` textarea has no \`:disabled\` binding -- this ` +
+          "guard's anchor point has moved; re-check how this field's " +
+          'editability is gated.',
+      )
+      continue
+    }
+
+    if (!disabledMatch[1]!.includes(`isDrafting('${field}')`)) {
+      errors.push(
+        `The \`${model}\` textarea's \`:disabled\` binding does not include ` +
+          `isDrafting('${field}'). The textarea binds to a local ref that ` +
+          'only pushes to the store on @change (blur), so while a draft is ' +
+          'in flight the store\'s own "don\'t clobber a newer edit" guard ' +
+          "(liveValue !== current in draftText()) can't see text the user " +
+          "is still mid-typing -- the draft's completion handler silently " +
+          "overwrites it via the local ref's watcher. Disabling the " +
+          'textarea while isDrafting(field) is true closes that window.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(PANEL_PATH, 'utf8')
+  const errors = checkDraftTextareaGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder draft textarea guard contract failed for ' +
+        'model-builder-item-panel.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder draft textarea guard contract passed: the Pitch, ' +
+      'Fields, and Generation prompt textareas all disable while their own ' +
+      'field is drafting, so a still-in-flight AI draft can never silently ' +
+      "overwrite text the user hasn't blurred/committed yet.",
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Commit 1 — model-builder/t-029: stop AI draft from silently clobbering unsaved typing

The Pitch, Fields, and Generation prompt textareas in `model-builder-item-panel.vue` bind to local component refs and only push to the store on `@change` (blur). `draftText()`'s own "don't clobber a newer edit" guard compares against the *store's* value, so it can't see text the user is still mid-typing that hasn't been blurred yet. When the draft response lands, its completion handler writes the new value into the store, and the textarea's watcher unconditionally overwrites whatever the user was typing — with no warning beyond the unrelated "Drafted ... for ..." success toast.

**Repro:** click "Draft with AI" next to Pitch, then type your own text into the same field before the ~60s `/api/suggest` call resolves. The typed text is silently replaced the instant the draft lands. Same mechanism for the Fields and Generation-prompt textareas.

**Fix:** disable each textarea while its own field is drafting, mirroring the `isDrafting(field)` gate already used on the adjacent "Draft with AI" buttons. This closes the window entirely.

Added `utils/scripts/verifyModelBuilderDraftTextareaGuard.ts` (+ self-test) as a sibling regression guard to the other `verifyModelBuilder*.ts` contracts, wired into `package.json` and `contract-tests.yml`.

## Commit 2 — digital-storefront/t-005: gate the random reward pick by visibility

t-005 flagged five Character/Reward read routes with no access check at all. #1668 (merged by Silas) closed four of them (`characters/[id]`, `characters/index`, `rewards/[id]`, `rewards/index`) using `canView()`/`viewablePackIds()`. `rewards/random.get.ts` was the fifth and was left with the identical gap: `prisma.reward.count()`/`findFirst()` with no `where` clause, so any caller could have a private, inactive, or pack-gated Reward handed to them by the random picker.

Applies the exact same `isActive: true` + `isPublic`/own/admin/Pack-Grant visibility `where` clause `rewards/index.get.ts` already uses, scoped to the count and the pick.

Silas already made the underlying access-policy call by merging #1668's identical fix for the other four routes — this finishes that already-approved, reversible change on the one route it missed, not a new security decision.

## Verification

- `eslint` clean on all changed/new files.
- `prettier --check` clean on new/changed files in these commits (pre-existing drift on `model-builder-item-panel.vue` and `package.json` confirmed via `git stash` to predate commit 1, left untouched).
- `vue-tsc --noEmit` clean repo-wide (checked after each commit).
- `verifyCaptureGroupGuards.ts origin/main` clean.
- All existing `verifyModelBuilder*.ts` guards + self-tests still pass (no regression).
- `npm run test:workflow-paths` green.
- `git diff --stat` per commit: exactly 5 files (commit 1), exactly 1 file (commit 2).

Both land on this session's single designated branch per this repo's session convention (one branch per session), hence one PR covering two independently-scoped, unrelated fixes.