### PR TITLE
fix(model-builder): close cross-field/cross-item draft-clobber hole

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -263,6 +263,12 @@ jobs:
       - name: Model Builder draft textarea guard contract
         run: npm run test:model-builder-draft-textarea-guard
 
+      - name: Model Builder draft cross-field guard checker self-test
+        run: npm run test:model-builder-draft-cross-field-guard-selftest
+
+      - name: Model Builder draft cross-field guard contract
+        run: npm run test:model-builder-draft-cross-field-guard
+
       - name: Model Builder auto-build draft gate checker self-test
         run: npm run test:model-builder-auto-build-draft-gate-selftest
 

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -44,7 +44,7 @@
         rows="2"
         class="textarea textarea-bordered w-full rounded-xl text-sm"
         placeholder="Why this output exists and what it should convey…"
-        :disabled="!isEditable('PITCH') || isDrafting('pitch')"
+        :disabled="!isEditable('PITCH') || isAnyDraftInFlight"
         @change="store.updatePitch(item.id, pitch)"
       />
       <div class="mt-1.5 flex items-center justify-end gap-1.5">
@@ -52,7 +52,7 @@
           v-if="isEditable('PITCH')"
           type="button"
           class="btn btn-xs btn-ghost mr-auto gap-1 rounded-lg text-secondary"
-          :disabled="isDrafting('pitch')"
+          :disabled="isAnyDraftInFlight"
           title="Draft this pitch with AI"
           @click="draft('pitch')"
         >
@@ -100,7 +100,7 @@
           v-if="isEditable('FIELDS_AND_PROMPTS')"
           type="button"
           class="btn btn-ghost btn-xs h-5 min-h-5 gap-1 rounded-md px-1.5 text-[10px] text-secondary"
-          :disabled="isDrafting('fields')"
+          :disabled="isAnyDraftInFlight"
           title="Draft the schema fields and relationships with AI"
           @click="draft('fields')"
         >
@@ -116,7 +116,7 @@
         rows="2"
         class="textarea textarea-bordered mb-1.5 w-full rounded-xl text-sm"
         placeholder="Schema fields and relationships to write on commit…"
-        :disabled="!isEditable('FIELDS_AND_PROMPTS') || isDrafting('fields')"
+        :disabled="!isEditable('FIELDS_AND_PROMPTS') || isAnyDraftInFlight"
         @change="store.updateFields(item.id, fields)"
       />
       <div class="mb-0.5 flex items-center justify-between">
@@ -127,7 +127,7 @@
           v-if="isEditable('FIELDS_AND_PROMPTS')"
           type="button"
           class="btn btn-ghost btn-xs h-5 min-h-5 gap-1 rounded-md px-1.5 text-[10px] text-secondary"
-          :disabled="isDrafting('artPrompt')"
+          :disabled="isAnyDraftInFlight"
           title="Draft the generation prompt with AI"
           @click="draft('artPrompt')"
         >
@@ -143,7 +143,7 @@
         rows="2"
         class="textarea textarea-bordered w-full rounded-xl text-sm"
         placeholder="The prompt used to generate this asset…"
-        :disabled="!isEditable('FIELDS_AND_PROMPTS') || isDrafting('artPrompt')"
+        :disabled="!isEditable('FIELDS_AND_PROMPTS') || isAnyDraftInFlight"
         @change="store.updatePrompt(item.id, prompt)"
       />
       <div class="mt-1.5 flex justify-end gap-1.5">
@@ -374,6 +374,21 @@ function isDrafting(field: DraftField): boolean {
   )
 }
 
+// draftingField is a single store-wide slot (see modelBuilderStore.ts's
+// createOwnedSingleton comment) -- only one draft can genuinely be in flight
+// at a time, for any item/field in the whole run. isDrafting(field) alone
+// only reports whether *this exact* field owns that slot right now, so
+// gating each textarea/button on isDrafting(field) let a second click (a
+// sibling field on this item, or any field on a different item) silently
+// steal the slot out from under the first: the first field's isDrafting()
+// then flips to false, its textarea/button re-enable while its request is
+// still pending, and the eventual response can clobber whatever the user
+// typed in the meantime with no warning. Gating on "is *any* draft in
+// flight" instead closes that hole -- the spinner still only shows on the
+// field actually owning the slot (isDrafting), but nothing else becomes
+// editable/clickable until it's released.
+const isAnyDraftInFlight = computed(() => store.draftingField !== null)
+
 // A manual single-stage action already in flight for this item blocks Auto
 // too -- the store's autoBuildItem guard mirrors this, but the button must
 // disable in step or a click here is silently swallowed with no feedback.
@@ -382,9 +397,7 @@ const isManualActionInFlight = computed(
     isGenerating.value ||
     isQueued.value ||
     isCommitting.value ||
-    isDrafting('pitch') ||
-    isDrafting('fields') ||
-    isDrafting('artPrompt'),
+    isAnyDraftInFlight.value,
 )
 
 function draft(field: DraftField): void {

--- a/package.json
+++ b/package.json
@@ -158,6 +158,8 @@
     "test:model-builder-draft-approval-guard": "tsx utils/scripts/verifyModelBuilderDraftApprovalGuard.ts",
     "test:model-builder-draft-textarea-guard-selftest": "tsx utils/scripts/verifyModelBuilderDraftTextareaGuard.test.ts",
     "test:model-builder-draft-textarea-guard": "tsx utils/scripts/verifyModelBuilderDraftTextareaGuard.ts",
+    "test:model-builder-draft-cross-field-guard-selftest": "tsx utils/scripts/verifyModelBuilderDraftCrossFieldGuard.test.ts",
+    "test:model-builder-draft-cross-field-guard": "tsx utils/scripts/verifyModelBuilderDraftCrossFieldGuard.ts",
     "test:model-builder-auto-build-draft-gate-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildDraftGate.test.ts",
     "test:model-builder-auto-build-draft-gate": "tsx utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts",
     "test:model-builder-item-patch-stage-guard-selftest": "tsx utils/scripts/verifyModelBuilderItemPatchStageGuard.test.ts",

--- a/utils/scripts/verifyModelBuilderDraftCrossFieldGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderDraftCrossFieldGuard.test.ts
@@ -1,0 +1,150 @@
+// /utils/scripts/verifyModelBuilderDraftCrossFieldGuard.test.ts
+//
+// Regression test for checkDraftCrossFieldGuard() in
+// verifyModelBuilderDraftCrossFieldGuard.ts (model-builder/t-029). Exercises
+// the real check against synthetic component-shaped fixtures covering: the
+// pre-fix shape (buttons/isManualActionInFlight gated only on per-field
+// isDrafting(field), no isAnyDraftInFlight computed at all -- the exact bug
+// found by manual read-through), the fixed shape, and buttons missing
+// entirely.
+import assert from 'node:assert/strict'
+
+import { checkDraftCrossFieldGuard } from './verifyModelBuilderDraftCrossFieldGuard.js'
+
+const BUGGY_FIXTURE = `
+<template>
+  <button
+    type="button"
+    :disabled="isAutoBuilding || isManualActionInFlight"
+    @click="store.autoBuildItem(item.id)"
+  >
+    Auto
+  </button>
+  <button
+    type="button"
+    :disabled="isDrafting('pitch')"
+    @click="draft('pitch')"
+  >
+    Draft with AI
+  </button>
+  <button
+    type="button"
+    :disabled="isDrafting('fields')"
+    @click="draft('fields')"
+  >
+    Draft
+  </button>
+  <button
+    type="button"
+    :disabled="isDrafting('artPrompt')"
+    @click="draft('artPrompt')"
+  >
+    Draft
+  </button>
+</template>
+<script setup lang="ts">
+const isManualActionInFlight = computed(
+  () =>
+    isGenerating.value ||
+    isQueued.value ||
+    isCommitting.value ||
+    isDrafting('pitch') ||
+    isDrafting('fields') ||
+    isDrafting('artPrompt'),
+)
+</script>
+`
+
+const FIXED_FIXTURE = `
+<template>
+  <button
+    type="button"
+    :disabled="isAutoBuilding || isManualActionInFlight"
+    @click="store.autoBuildItem(item.id)"
+  >
+    Auto
+  </button>
+  <button
+    type="button"
+    :disabled="isAnyDraftInFlight"
+    @click="draft('pitch')"
+  >
+    Draft with AI
+  </button>
+  <button
+    type="button"
+    :disabled="isAnyDraftInFlight"
+    @click="draft('fields')"
+  >
+    Draft
+  </button>
+  <button
+    type="button"
+    :disabled="isAnyDraftInFlight"
+    @click="draft('artPrompt')"
+  >
+    Draft
+  </button>
+</template>
+<script setup lang="ts">
+const isAnyDraftInFlight = computed(() => store.draftingField !== null)
+
+const isManualActionInFlight = computed(
+  () =>
+    isGenerating.value ||
+    isQueued.value ||
+    isCommitting.value ||
+    isAnyDraftInFlight.value,
+)
+</script>
+`
+
+const MISSING_FIXTURE = `
+<template>
+  <div>no buttons here</div>
+</template>
+`
+
+const buggyErrors = checkDraftCrossFieldGuard(BUGGY_FIXTURE)
+// 1 (missing isAnyDraftInFlight computed) + 3 (each Draft button) + 1
+// (isManualActionInFlight missing the check) = 5
+assert.equal(
+  buggyErrors.length,
+  5,
+  `expected the pre-fix shape to raise 5 errors, got ${buggyErrors.length}: ` +
+    `${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(buggyErrors.some((e) => e.includes('isAnyDraftInFlight = computed')))
+assert.ok(buggyErrors.some((e) => e.includes("'pitch' Draft button")))
+assert.ok(buggyErrors.some((e) => e.includes("'fields' Draft button")))
+assert.ok(buggyErrors.some((e) => e.includes("'artPrompt' Draft button")))
+assert.ok(
+  buggyErrors.some((e) =>
+    e.includes('isManualActionInFlight does not include'),
+  ),
+)
+
+const fixedErrors = checkDraftCrossFieldGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingErrors = checkDraftCrossFieldGuard(MISSING_FIXTURE)
+// isAnyDraftInFlight computed missing (1) + 3 buttons not found +
+// isManualActionInFlight not found (1) = 5
+assert.equal(
+  missingErrors.length,
+  5,
+  'expected a "not found" violation for the computed, each of the three ' +
+    'buttons, and isManualActionInFlight when none are present, got ' +
+    `${missingErrors.length}: ${JSON.stringify(missingErrors)}`,
+)
+
+console.log(
+  'Model Builder draft cross-field guard checker verified: flags the ' +
+    'pre-fix shape (per-field isDrafting(field) gating only, no ' +
+    'isAnyDraftInFlight), clears the fixed shape, and flags the buttons/' +
+    'computed being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderDraftCrossFieldGuard.ts
+++ b/utils/scripts/verifyModelBuilderDraftCrossFieldGuard.ts
@@ -1,0 +1,170 @@
+// /utils/scripts/verifyModelBuilderDraftCrossFieldGuard.ts
+//
+// Regression guard (model-builder/t-029) -- draftingField is a single
+// store-wide slot (see modelBuilderStore.ts's createOwnedSingleton comment):
+// only one draft can genuinely be in flight at a time, for any item/field in
+// the whole run. Before this fix, each "Draft with AI" button in
+// model-builder-item-panel.vue was gated only on `isDrafting(thisField)` --
+// whether *that exact* field currently owned the slot. Nothing stopped a
+// second click on a *sibling* field (Pitch, then Fields, before Pitch's
+// request resolved) or the same/a different field on a *different* item
+// from being clickable while a first draft was still pending. That second
+// click silently reassigned the shared slot: the first field's
+// isDrafting(field) then flipped to false, its "Draft" button and textarea
+// re-enabled while its own request was still in flight, and the eventual
+// response could clobber whatever the user had typed in the meantime with
+// no warning beyond an unrelated success toast. Concrete repro: click
+// "Draft with AI" next to Pitch, then before it resolves click "Draft" next
+// to Fields, then type in the (now re-enabled) Pitch textarea -- the typed
+// text is silently lost the instant the original Pitch draft lands.
+//
+// Fixed by gating every "Draft with AI" / "Draft" button, and the
+// `isManualActionInFlight` computed that also blocks the "Auto" button, on
+// `isAnyDraftInFlight` (`store.draftingField !== null`) instead of the
+// narrower per-field `isDrafting(field)` -- nothing that can start or race a
+// second draft becomes clickable until the one shared slot is actually
+// released. (The three textareas' own `:disabled` binding got the same
+// treatment; that's covered by its own sibling guard,
+// verifyModelBuilderDraftTextareaGuard.ts.)
+//
+// This asserts the textual shape of the fix stays in place: an
+// `isAnyDraftInFlight` computed exists, defined off `store.draftingField`;
+// each of the three "Draft" buttons' `:disabled` binding includes it; and
+// `isManualActionInFlight` includes it too. Deliberately scoped to this one
+// component/bug, mirroring this project's other narrow textual guards over
+// a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const PANEL_PATH = join(
+  repositoryRoot,
+  'components/model-builder/model-builder-item-panel.vue',
+)
+
+const DRAFT_BUTTONS = [
+  { click: '@click="draft(\'pitch\')"', field: 'pitch' },
+  { click: '@click="draft(\'fields\')"', field: 'fields' },
+  { click: '@click="draft(\'artPrompt\')"', field: 'artPrompt' },
+] as const
+
+// Checks the fix's exact shape against the full source text of
+// model-builder-item-panel.vue. Exported so the self-test below can run it
+// against synthetic buggy/fixed fixtures without touching the real
+// component file.
+export function checkDraftCrossFieldGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const computedMatch =
+    /const isAnyDraftInFlight = computed\(\s*\(\)\s*=>\s*store\.draftingField\s*!==\s*null\s*\)/.exec(
+      content,
+    )
+  if (!computedMatch) {
+    errors.push(
+      'Could not find `const isAnyDraftInFlight = computed(() => ' +
+        'store.draftingField !== null)` in model-builder-item-panel.vue -- ' +
+        'has it been renamed or restructured? draftingField is a single ' +
+        'store-wide slot, so every draft-blocking UI affordance must key ' +
+        'off "is *any* draft in flight", not just "is *this* field ' +
+        'drafting".',
+    )
+  }
+
+  for (const { click, field } of DRAFT_BUTTONS) {
+    const clickIndex = content.indexOf(click)
+    if (clickIndex === -1) {
+      errors.push(
+        `Could not find a button with \`${click}\` in ` +
+          'model-builder-item-panel.vue -- has the Draft button for ' +
+          `'${field}' been renamed, removed, or restructured?`,
+      )
+      continue
+    }
+
+    // The :disabled attribute sits above @click in this template's button
+    // markup; search backward from @click to the button's opening tag.
+    const tagStart = content.lastIndexOf('<button', clickIndex)
+    if (tagStart === -1) {
+      errors.push(
+        `Could not find the opening <button> tag for \`${click}\` -- this ` +
+          "guard's anchor point has moved.",
+      )
+      continue
+    }
+    const tag = content.slice(tagStart, clickIndex)
+
+    const disabledMatch = /:disabled="([^"]*)"/.exec(tag)
+    if (!disabledMatch) {
+      errors.push(
+        `The '${field}' Draft button has no \`:disabled\` binding -- this ` +
+          "guard's anchor point has moved.",
+      )
+      continue
+    }
+
+    if (!disabledMatch[1]!.includes('isAnyDraftInFlight')) {
+      errors.push(
+        `The '${field}' Draft button's \`:disabled\` binding does not ` +
+          'include isAnyDraftInFlight. Gating only on ' +
+          `isDrafting('${field}') isn't enough: draftingField is a single ` +
+          'store-wide slot, so clicking this button while a *different* ' +
+          "field's (or item's) draft is still pending silently steals the " +
+          "slot out from under it -- re-enabling the other field's " +
+          'button/textarea while its own request is still in flight. ' +
+          'Gating on isAnyDraftInFlight (store.draftingField !== null) ' +
+          'closes that window.',
+      )
+    }
+  }
+
+  const manualActionMatch =
+    /const isManualActionInFlight = computed\(\s*\(\)\s*=>[\s\S]{0,400}?\)/.exec(
+      content,
+    )
+  if (!manualActionMatch) {
+    errors.push(
+      'Could not find the isManualActionInFlight computed in ' +
+        'model-builder-item-panel.vue -- has it been renamed or removed?',
+    )
+  } else if (!manualActionMatch[0].includes('isAnyDraftInFlight')) {
+    errors.push(
+      'isManualActionInFlight does not include isAnyDraftInFlight. The ' +
+        '"Auto" button (which starts autoBuildItem) is gated on this ' +
+        "computed; if it only checks this item's own isDrafting(field) " +
+        'calls, clicking Auto while a draft for a *different* item still ' +
+        'holds the shared draftingField slot will immediately race that ' +
+        'draft instead of being blocked.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(PANEL_PATH, 'utf8')
+  const errors = checkDraftCrossFieldGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder draft cross-field guard contract failed for ' +
+        'model-builder-item-panel.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder draft cross-field guard contract passed: every Draft ' +
+      "button and the Auto button's isManualActionInFlight gate all key " +
+      'off isAnyDraftInFlight, so a draft on one field/item can never be ' +
+      'silently stolen by starting another before it resolves.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}

--- a/utils/scripts/verifyModelBuilderDraftTextareaGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderDraftTextareaGuard.test.ts
@@ -3,9 +3,13 @@
 // Regression test for checkDraftTextareaGuard() in
 // verifyModelBuilderDraftTextareaGuard.ts (model-builder/t-029). Exercises
 // the real check against synthetic component-shaped fixtures covering: the
-// pre-fix shape (textareas disabled only on `!isEditable(...)`, with no
-// `isDrafting(field)` check -- the exact bug found by manual read-through),
-// the fixed shape, and one textarea missing entirely.
+// original pre-fix shape (textareas disabled only on `!isEditable(...)`,
+// with no drafting check at all), the narrower `isDrafting(field)`-only
+// shape (the first fix -- now itself insufficient, since a draft on a
+// sibling field or a different item silently steals the shared
+// `draftingField` slot and re-enables this textarea while its own request
+// is still in flight), the current fixed shape (`isAnyDraftInFlight`), and
+// one textarea missing entirely.
 import assert from 'node:assert/strict'
 
 import { checkDraftTextareaGuard } from './verifyModelBuilderDraftTextareaGuard.js'
@@ -36,7 +40,12 @@ const BUGGY_FIXTURE = `
 </template>
 `
 
-const FIXED_FIXTURE = `
+// The first fix's shape -- gates each textarea on its own field's
+// isDrafting(field) only. Passed the original guard, but is insufficient:
+// draftingField is one shared slot, so a draft started on a sibling field
+// (or a different item) silently steals it, and this textarea re-enables
+// while its own request is still pending.
+const NARROW_FIXTURE = `
 <template>
   <textarea
     v-model="pitch"
@@ -62,6 +71,32 @@ const FIXED_FIXTURE = `
 </template>
 `
 
+const FIXED_FIXTURE = `
+<template>
+  <textarea
+    v-model="pitch"
+    rows="2"
+    placeholder="Why this output exists…"
+    :disabled="!isEditable('PITCH') || isAnyDraftInFlight"
+    @change="store.updatePitch(item.id, pitch)"
+  />
+  <textarea
+    v-model="fields"
+    rows="2"
+    placeholder="Schema fields…"
+    :disabled="!isEditable('FIELDS_AND_PROMPTS') || isAnyDraftInFlight"
+    @change="store.updateFields(item.id, fields)"
+  />
+  <textarea
+    v-model="prompt"
+    rows="2"
+    placeholder="The prompt used…"
+    :disabled="!isEditable('FIELDS_AND_PROMPTS') || isAnyDraftInFlight"
+    @change="store.updatePrompt(item.id, prompt)"
+  />
+</template>
+`
+
 const MISSING_FIXTURE = `
 <template>
   <div>no textareas here</div>
@@ -72,12 +107,24 @@ const buggyErrors = checkDraftTextareaGuard(BUGGY_FIXTURE)
 assert.equal(
   buggyErrors.length,
   3,
-  `expected the pre-fix shape (no isDrafting checks) to raise 3 errors, ` +
+  `expected the pre-fix shape (no drafting checks) to raise 3 errors, ` +
     `got ${buggyErrors.length}: ${JSON.stringify(buggyErrors)}`,
 )
-assert.ok(buggyErrors[0]!.includes("isDrafting('pitch')"))
-assert.ok(buggyErrors[1]!.includes("isDrafting('fields')"))
-assert.ok(buggyErrors[2]!.includes("isDrafting('artPrompt')"))
+for (const error of buggyErrors) {
+  assert.ok(error.includes('isAnyDraftInFlight'))
+}
+
+const narrowErrors = checkDraftTextareaGuard(NARROW_FIXTURE)
+assert.equal(
+  narrowErrors.length,
+  3,
+  'expected the narrower isDrafting(field)-only shape (the superseded ' +
+    `first fix) to still raise 3 errors, got ${narrowErrors.length}: ` +
+    `${JSON.stringify(narrowErrors)}`,
+)
+for (const error of narrowErrors) {
+  assert.ok(error.includes('isAnyDraftInFlight'))
+}
 
 const fixedErrors = checkDraftTextareaGuard(FIXED_FIXTURE)
 assert.equal(
@@ -99,6 +146,7 @@ for (const error of missingErrors) {
 
 console.log(
   'Model Builder draft textarea guard checker verified: flags the pre-fix ' +
-    'shape (textareas missing isDrafting(field) in :disabled), clears the ' +
-    'fixed shape, and flags each textarea being absent entirely.',
+    'shape (no drafting check) and the superseded narrower ' +
+    'isDrafting(field)-only shape, clears the current isAnyDraftInFlight ' +
+    'shape, and flags each textarea being absent entirely.',
 )

--- a/utils/scripts/verifyModelBuilderDraftTextareaGuard.ts
+++ b/utils/scripts/verifyModelBuilderDraftTextareaGuard.ts
@@ -17,16 +17,32 @@
 // ref). No error, no warning beyond the unrelated "Drafted ... for ..."
 // success toast -- the typed text is just gone.
 //
-// Fixed by disabling each textarea while its own field is drafting, closing
-// the vulnerable window entirely: `:disabled="!isEditable('PITCH') ||
-// isDrafting('pitch')"` and the equivalent for fields/artPrompt.
+// Originally fixed by disabling each textarea while its own field was
+// drafting: `:disabled="!isEditable('PITCH') || isDrafting('pitch')"` and
+// the equivalent for fields/artPrompt.
 //
-// This asserts the textual shape of the fix stays in place: each of the
-// three textareas' `:disabled` attribute includes its matching
-// `isDrafting('field')` check alongside the existing `isEditable(...)` one.
-// Deliberately scoped to this one component/bug, mirroring
-// verifyModelBuilderDraftApprovalGuard.ts's preference for explicit, narrow
-// textual checks over a general-purpose static analyzer.
+// SUPERSEDED (model-builder/t-029, same recurring task, later slice): that
+// per-field check wasn't enough. `draftingField` is a single store-wide slot
+// (see modelBuilderStore.ts's createOwnedSingleton comment) -- only one
+// draft can genuinely be in flight at a time, for any item/field in the
+// whole run. Gating a textarea on `isDrafting('pitch')` alone only checks
+// whether *pitch* currently owns that slot; it says nothing about whether a
+// *different* field on this item (or any field on a *different* item) has
+// since stolen it. Clicking "Draft" on Fields while Pitch's draft was still
+// pending silently reassigned the slot to Fields -- `isDrafting('pitch')`
+// then flipped to `false`, the Pitch textarea re-enabled while its request
+// was still in flight, and the eventual response could clobber whatever the
+// user had typed in the meantime. Re-fixed by gating on `isAnyDraftInFlight`
+// (`store.draftingField !== null`) instead -- nothing re-enables until the
+// one draft slot is actually released, matching its real global-singleton
+// semantics.
+//
+// This asserts the textual shape of the current fix stays in place: each of
+// the three textareas' `:disabled` attribute includes `isAnyDraftInFlight`
+// alongside the existing `isEditable(...)` check. Deliberately scoped to
+// this one component/bug, mirroring verifyModelBuilderDraftApprovalGuard.ts's
+// preference for explicit, narrow textual checks over a general-purpose
+// static analyzer.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -84,16 +100,21 @@ export function checkDraftTextareaGuard(content: string): string[] {
       continue
     }
 
-    if (!disabledMatch[1]!.includes(`isDrafting('${field}')`)) {
+    if (!disabledMatch[1]!.includes('isAnyDraftInFlight')) {
       errors.push(
         `The \`${model}\` textarea's \`:disabled\` binding does not include ` +
-          `isDrafting('${field}'). The textarea binds to a local ref that ` +
-          'only pushes to the store on @change (blur), so while a draft is ' +
-          'in flight the store\'s own "don\'t clobber a newer edit" guard ' +
+          'isAnyDraftInFlight. The textarea binds to a local ref that only ' +
+          'pushes to the store on @change (blur), so while a draft is in ' +
+          'flight the store\'s own "don\'t clobber a newer edit" guard ' +
           "(liveValue !== current in draftText()) can't see text the user " +
           "is still mid-typing -- the draft's completion handler silently " +
-          "overwrites it via the local ref's watcher. Disabling the " +
-          'textarea while isDrafting(field) is true closes that window.',
+          "overwrites it via the local ref's watcher. Gating only on " +
+          `isDrafting('${field}') isn't enough: draftingField is a single ` +
+          'store-wide slot, so a draft started on a different field or a ' +
+          'different item silently steals it and re-enables this textarea ' +
+          'while its own request is still pending. Disabling while ' +
+          'isAnyDraftInFlight (store.draftingField !== null) closes that ' +
+          'window for good.',
       )
     }
   }
@@ -117,9 +138,11 @@ function main(): void {
 
   console.log(
     'Model Builder draft textarea guard contract passed: the Pitch, ' +
-      'Fields, and Generation prompt textareas all disable while their own ' +
-      'field is drafting, so a still-in-flight AI draft can never silently ' +
-      "overwrite text the user hasn't blurred/committed yet.",
+      'Fields, and Generation prompt textareas all disable while ANY ' +
+      'draft is in flight (isAnyDraftInFlight), so a still-in-flight AI ' +
+      'draft on this field, a sibling field, or a different item can ' +
+      "never silently overwrite text the user hasn't blurred/committed " +
+      'yet.',
   )
 }
 


### PR DESCRIPTION
### Task
model-builder/t-029: polish and upgrade the Model Builder front-end surface (kind: software, recurring)

### What changed / what I produced
- `stores/modelBuilderStore.ts`: no change (the underlying `draftingField` singleton is unchanged — see below).
- `components/model-builder/model-builder-item-panel.vue`: added `isAnyDraftInFlight` (`store.draftingField !== null`); every "Draft" button, all three textareas' `:disabled`, and the `isManualActionInFlight` computed (which also blocks "Auto") now gate on it instead of the narrower per-field `isDrafting(field)`.
- `utils/scripts/verifyModelBuilderDraftTextareaGuard.ts` (+ its self-test): updated to assert the new `isAnyDraftInFlight` shape — the fix changed what the textareas' `:disabled` bindings actually look like, so the old narrower assertion (`isDrafting('field')`) no longer matches and needed to move with it.
- Added `utils/scripts/verifyModelBuilderDraftCrossFieldGuard.ts` (+ its own self-test) as a sibling regression guard covering the Draft buttons and `isManualActionInFlight`, wired into `package.json`/`contract-tests.yml`.

### The bug
`draftingField` is a single store-wide slot (see `modelBuilderStore.ts`'s `createOwnedSingleton` comment) — only one draft can genuinely be in flight at a time, for any item/field in the whole run. PR #1787 fixed the case where a draft's *own* field silently overwrote text typed before blur, by disabling that field's textarea while `isDrafting(field)` was true. But every Draft button (and the textareas) were still gated only on that same narrow, per-field check — nothing stopped a *second* click on a *sibling* field (or a different item) while a first draft was still pending. That second click silently reassigned the shared slot: the first field's `isDrafting()` then flipped to `false`, its textarea/button re-enabled while its own request was still in flight, and the eventual response could clobber whatever the user had typed in the meantime — the exact PR #1787 bug, reopened via a different trigger.

Concrete repro:
1. Click "Draft with AI" next to Pitch.
2. Before it resolves, click "Draft" next to Fields (allowed — `isDrafting('fields')` was `false`). This silently steals the shared slot.
3. Pitch's textarea re-enables (`isDrafting('pitch')` is now `false`) even though its draft is still pending.
4. Type new Pitch text.
5. The pending Pitch draft resolves, its own "don't clobber a newer edit" check passes (the local ref was never pushed to the store via `@change`), and it silently overwrites the just-typed text with no warning beyond an unrelated success toast.

An even broader variant: switching to a *different* item mid-draft and clicking Draft there reproduces the same stomp, and also fools `autoBuildItem`'s own same-item concurrency guard.

### How I verified
- Dispatched an Explore subagent with an explicit exclusion list of every model-builder/t-029 bug class already fixed this cycle (resetAll/resetRun singleton clears, aria-pressed, draft-textarea-before-blur) and a directive to read every existing `verifyModelBuilder*.ts` guard directly rather than trust a summary. It found this.
- Read the actual store/component code directly to confirm before editing.
- `npx eslint` on all changed/added files — clean.
- `npx vue-tsc --noEmit` — 0 errors repo-wide.
- `npx prettier --check` — clean on all changed/added files (pre-existing drift on `model-builder-item-panel.vue`/`package.json` confirmed via `git stash` to predate this change).
- All 28 existing `test:model-builder-*` guard + self-test scripts still pass — no regressions.
- New guard + self-test: verified it fails against the pre-fix shape and the *narrower, superseded* `isDrafting(field)`-only shape, and passes against the current fixed shape.
- `verifyCaptureGroupGuards.ts origin/main` — clean (no new `.exec`/`.match` call sites).
- `npm run test:workflow-paths` — green (the new workflow step's `run:` path resolves to a real file).
- `git diff --stat` confirmed exactly 7 files, scoped to this fix.

### Stakes
reversible

### Flags for Reviewer
- None — scoped UI-gating change, no store/schema/API change. One accepted behavior change: a user can no longer start a second draft on a sibling field or a different item while one is pending (previously that "worked" only in the sense of not crashing — it silently corrupted whichever draft lost the race, so removing that capability is strictly a bug fix).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBWAvcTgrF92DAHodPSv8R)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBWAvcTgrF92DAHodPSv8R)_