### PR TITLE
fix(model-builder): refuse to approve a stale GENERATE_ASSETS candidate

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -311,6 +311,12 @@ jobs:
       - name: Model Builder resetRun guard contract
         run: npm run test:model-builder-reset-run-guard
 
+      - name: Model Builder stale-asset approval guard checker self-test
+        run: npm run test:model-builder-stale-asset-approval-guard-selftest
+
+      - name: Model Builder stale-asset approval guard contract
+        run: npm run test:model-builder-stale-asset-approval-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -412,6 +412,16 @@ const canApproveAssets = computed(() => {
   // A regenerate in flight means the current artImageId is about to be
   // replaced — approving now would commit a candidate the user never saw.
   if (isGenerating.value || isQueued.value) return false
+  // 'stale' means an upstream edit (reopening PITCH/FIELDS_AND_PROMPTS) marked
+  // this stage stale via markDownstreamStale after a candidate was already
+  // generated — but markDownstreamStale never clears artImageId/imagePath, so
+  // the item still carries the pre-edit candidate. Without this check, "Keep
+  // this asset" stayed clickable and approveStage would commit that stale
+  // image straight through with no re-review, silently pairing it with the
+  // just-edited (different) pitch/fields/prompt. Require a fresh regenerate
+  // first — isEditable('GENERATE_ASSETS') already keeps Generate/Regenerate
+  // enabled while stale.
+  if (item.value.stages.GENERATE_ASSETS.status === 'stale') return false
   // For image outputs, require a generated candidate first.
   if (item.value.generation === 'image') return Boolean(item.value.artImageId)
   return true

--- a/package.json
+++ b/package.json
@@ -176,6 +176,8 @@
     "test:model-builder-reset-all-guard": "tsx utils/scripts/verifyModelBuilderResetAllGuard.ts",
     "test:model-builder-reset-run-guard-selftest": "tsx utils/scripts/verifyModelBuilderResetRunGuard.test.ts",
     "test:model-builder-reset-run-guard": "tsx utils/scripts/verifyModelBuilderResetRunGuard.ts",
+    "test:model-builder-stale-asset-approval-guard-selftest": "tsx utils/scripts/verifyModelBuilderStaleAssetApprovalGuard.test.ts",
+    "test:model-builder-stale-asset-approval-guard": "tsx utils/scripts/verifyModelBuilderStaleAssetApprovalGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/utils/scripts/verifyModelBuilderStaleAssetApprovalGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderStaleAssetApprovalGuard.test.ts
@@ -1,0 +1,86 @@
+// /utils/scripts/verifyModelBuilderStaleAssetApprovalGuard.test.ts
+//
+// Regression test for checkStaleAssetApprovalGuard() in
+// verifyModelBuilderStaleAssetApprovalGuard.ts (model-builder/t-029).
+// Exercises the real check against synthetic component-shaped fixtures
+// covering: the pre-fix shape (canApproveAssets with no 'stale' check --
+// the exact bug found by manual read-through), the fixed shape, and the
+// computed being absent entirely.
+import assert from 'node:assert/strict'
+
+import { checkStaleAssetApprovalGuard } from './verifyModelBuilderStaleAssetApprovalGuard.js'
+
+const BUGGY_FIXTURE = `
+<script setup lang="ts">
+const canApproveAssets = computed(() => {
+  if (!item.value) return false
+  if (isLocked('GENERATE_ASSETS')) return false
+  if (isGenerating.value || isQueued.value) return false
+  if (item.value.generation === 'image') return Boolean(item.value.artImageId)
+  return true
+})
+
+function isLocked(stage: BuildStageKey): boolean {
+  const status = item.value?.stages[stage].status
+  return status === 'locked'
+}
+</script>
+`
+
+const FIXED_FIXTURE = `
+<script setup lang="ts">
+const canApproveAssets = computed(() => {
+  if (!item.value) return false
+  if (isLocked('GENERATE_ASSETS')) return false
+  if (isGenerating.value || isQueued.value) return false
+  if (item.value.stages.GENERATE_ASSETS.status === 'stale') return false
+  if (item.value.generation === 'image') return Boolean(item.value.artImageId)
+  return true
+})
+
+function isLocked(stage: BuildStageKey): boolean {
+  const status = item.value?.stages[stage].status
+  return status === 'locked'
+}
+</script>
+`
+
+const MISSING_FIXTURE = `
+<script setup lang="ts">
+function isLocked(stage: BuildStageKey): boolean {
+  const status = item.value?.stages[stage].status
+  return status === 'locked'
+}
+</script>
+`
+
+const buggyErrors = checkStaleAssetApprovalGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  1,
+  `expected the pre-fix shape to raise 1 error, got ${buggyErrors.length}: ` +
+    `${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(buggyErrors[0]!.includes("status === 'stale'"))
+
+const fixedErrors = checkStaleAssetApprovalGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingErrors = checkStaleAssetApprovalGuard(MISSING_FIXTURE)
+assert.equal(
+  missingErrors.length,
+  1,
+  'expected a single "not found" violation when canApproveAssets is absent ' +
+    `entirely, got ${missingErrors.length}: ${JSON.stringify(missingErrors)}`,
+)
+assert.ok(missingErrors[0]!.includes('Could not find'))
+
+console.log(
+  'Model Builder stale-asset approval guard checker verified: flags the ' +
+    "pre-fix shape (canApproveAssets missing the 'stale' check), clears the " +
+    'fixed shape, and flags the computed being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderStaleAssetApprovalGuard.ts
+++ b/utils/scripts/verifyModelBuilderStaleAssetApprovalGuard.ts
@@ -1,0 +1,116 @@
+// /utils/scripts/verifyModelBuilderStaleAssetApprovalGuard.ts
+//
+// Regression guard (model-builder/t-029) -- reopening an upstream stage
+// (PITCH or FIELDS_AND_PROMPTS) after GENERATE_ASSETS was already approved
+// calls reopenStage -> markDownstreamStale, which flips GENERATE_ASSETS to
+// 'stale' but never clears item.artImageId/item.imagePath (those are only
+// ever written by generateItemAsset/pollAsyncArtJob, on an actual new
+// render). Before this fix, the item panel's canApproveAssets computed
+// gated only on isLocked('GENERATE_ASSETS') (true solely for a literal
+// 'locked' status) plus isGenerating/isQueued and, for image outputs,
+// Boolean(item.artImageId) -- it never checked for 'stale'. So once a stage
+// went stale while the item still carried a leftover artImageId from
+// before the edit, "Keep this asset" stayed clickable and approveStage
+// would commit that pre-edit image straight through with no re-review,
+// silently pairing it with the just-edited (different) pitch/fields/
+// prompt. Concrete repro: approve GENERATE_ASSETS with a "red dragon"
+// image, click Edit on FIELDS_AND_PROMPTS, change the prompt to "a blue
+// whale", re-approve fields without regenerating, click "Keep this asset"
+// (still showing the red-dragon thumbnail) -- the committed record's
+// artImageId then durably mismatches its own text fields.
+//
+// Fixed by adding a check in canApproveAssets: when GENERATE_ASSETS is
+// 'stale', approval is refused until a fresh generateItemAsset/
+// generateItemAssetAsync call completes (which transitions the stage back
+// to 'ready' via finishGenerateAssets, only ever from 'in-progress' --
+// isEditable('GENERATE_ASSETS') already keeps the Generate/Regenerate
+// button enabled while stale, so this doesn't block the way forward, only
+// the shortcut around it).
+//
+// This asserts the textual shape of that fix stays in place: a check for
+// `item.value.stages.GENERATE_ASSETS.status === 'stale'` (returning false)
+// inside canApproveAssets, positioned before the function returns any other
+// truthy result -- deliberately scoped to this one bug shape, mirroring
+// this project's other narrow textual guards over a general-purpose static
+// analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const PANEL_PATH = join(
+  repositoryRoot,
+  'components/model-builder/model-builder-item-panel.vue',
+)
+
+const COMPUTED_START = 'const canApproveAssets = computed(() => {'
+const STALE_CHECK = "item.value.stages.GENERATE_ASSETS.status === 'stale'"
+
+// Checks the fix's exact shape against the full source text of
+// model-builder-item-panel.vue. Exported so the self-test below can run it
+// against synthetic buggy/fixed fixtures without touching the real
+// component file.
+export function checkStaleAssetApprovalGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const startIndex = content.indexOf(COMPUTED_START)
+  if (startIndex === -1) {
+    errors.push(
+      `Could not find \`${COMPUTED_START}\` in model-builder-item-panel.vue ` +
+        '-- has canApproveAssets been renamed or restructured? If so, this ' +
+        'guard (and the bug it protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  // The computed is a short arrow function body; find its closing `})` by
+  // scanning forward for the first `})` at the start of a line, matching
+  // this file's existing computed-body extraction convention.
+  const closeMatch = /\n\}\)/.exec(content.slice(startIndex))
+  const endIndex =
+    closeMatch && closeMatch.index !== undefined
+      ? startIndex + closeMatch.index
+      : content.length
+  const body = content.slice(startIndex, endIndex)
+
+  if (!body.includes(STALE_CHECK)) {
+    errors.push(
+      `canApproveAssets does not check \`${STALE_CHECK}\`. ` +
+        "markDownstreamStale/reopenStage flip GENERATE_ASSETS to 'stale' " +
+        'without ever clearing item.artImageId/item.imagePath, so without ' +
+        'this check a leftover pre-edit candidate stays approvable -- ' +
+        '"Keep this asset" commits it straight through, silently pairing a ' +
+        'stale image with the just-edited pitch/fields/prompt.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(PANEL_PATH, 'utf8')
+  const errors = checkStaleAssetApprovalGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder stale-asset approval guard contract failed for ' +
+        'model-builder-item-panel.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder stale-asset approval guard contract passed: ' +
+      'canApproveAssets refuses to approve a GENERATE_ASSETS candidate ' +
+      "while the stage is 'stale', so an edit-then-reapprove flow can no " +
+      'longer commit a leftover pre-edit image without a fresh regenerate.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
model-builder/t-029: polish and upgrade the Model Builder front-end surface (kind: software, recurring)

### The bug
Reopening an approved FIELDS_AND_PROMPTS (or PITCH) stage after a GENERATE_ASSETS candidate was already generated calls `reopenStage` -> `markDownstreamStale`, which flips GENERATE_ASSETS to `'stale'` but never clears `item.artImageId`/`item.imagePath` -- those are only ever written by an actual new render (`generateItemAsset`/`pollAsyncArtJob`). `canApproveAssets` gated only on `isLocked('GENERATE_ASSETS')` (true solely for a literal `'locked'` status), `isGenerating`/`isQueued`, and `Boolean(item.artImageId)` for image outputs -- it never checked for `'stale'`. So once stale with a leftover `artImageId`, "Keep this asset" stayed clickable and `approveStage` committed the pre-edit image straight through with no re-review, silently pairing it with the just-edited (different) fields/prompt.

**Concrete repro:** approve GENERATE_ASSETS with a "red dragon" candidate, click Edit on FIELDS_AND_PROMPTS, change the prompt to "a blue whale", re-approve fields without regenerating, then click "Keep this asset" (still showing the red-dragon thumbnail) -- the committed record's `artImageId` then durably mismatches its own text fields.

### The fix
Check `item.value.stages.GENERATE_ASSETS.status === 'stale'` in `canApproveAssets` and refuse approval until a fresh regenerate completes. `isEditable('GENERATE_ASSETS')` already keeps Generate/Regenerate enabled while stale, so this only removes the shortcut around it, not the way forward -- and the existing `'stale'` badge (`badge-warning`) already gives the user a visual cue.

Added `utils/scripts/verifyModelBuilderStaleAssetApprovalGuard.ts` (+ its own self-test) as a sibling regression guard, wired into `package.json`/`contract-tests.yml`, matching this project's one-guard-per-fix convention.

### How I verified
- Dispatched an Explore subagent with an explicit exclusion list of every model-builder/t-029 bug class already fixed this cycle (resetAll/resetRun singleton clears, cross-field/cross-item draft clobber, aria-pressed) and a directive to read every existing `verifyModelBuilder*.ts` guard directly rather than trust a summary. It found this.
- Read the actual store/component code directly to confirm before editing.
- `npx eslint` on changed/added files -- clean.
- `npx vue-tsc --noEmit` -- 0 errors repo-wide.
- `npx prettier --check` -- clean on new files; pre-existing drift on `model-builder-item-panel.vue`/`package.json` confirmed via `git stash` to predate this change.
- All 29 existing `test:model-builder-*` guard + self-test scripts still pass -- no regressions.
- New guard + self-test: verified it fails against the pre-fix shape and passes against the fixed shape.
- `verifyCaptureGroupGuards.ts origin/main` -- clean.
- `npm run test:workflow-paths` -- green.
- `git diff --stat` confirmed exactly 5 files, scoped to this fix.

### Stakes
reversible

### Flags for Reviewer
None -- scoped UI-gating change, no store/schema/API change. One accepted behavior change: a user can no longer approve a GENERATE_ASSETS candidate while the stage is stale; they must regenerate first. Previously that "worked" only in the sense of not crashing -- it silently committed a candidate mismatched with the current prompt/fields, so removing that shortcut is strictly a bug fix.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTZsAkCkn3AvYJcEZcMStW)_