### PR TITLE
fix(model-builder): remount batch editor on quantity-group switch

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -317,6 +317,12 @@ jobs:
       - name: Model Builder stale-asset approval guard contract
         run: npm run test:model-builder-stale-asset-approval-guard
 
+      - name: Model Builder batch-editor key guard checker self-test
+        run: npm run test:model-builder-batch-editor-key-guard-selftest
+
+      - name: Model Builder batch-editor key guard contract
+        run: npm run test:model-builder-batch-editor-key-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -136,6 +136,7 @@
     <!-- Batch editor for the selected item's quantity group -->
     <model-builder-batch-editor
       v-if="selectedItem && showBatch"
+      :key="selectedItem.outputKey"
       :output-key="selectedItem.outputKey"
       @select-item="selectedItemId = $event"
     />

--- a/package.json
+++ b/package.json
@@ -178,6 +178,8 @@
     "test:model-builder-reset-run-guard": "tsx utils/scripts/verifyModelBuilderResetRunGuard.ts",
     "test:model-builder-stale-asset-approval-guard-selftest": "tsx utils/scripts/verifyModelBuilderStaleAssetApprovalGuard.test.ts",
     "test:model-builder-stale-asset-approval-guard": "tsx utils/scripts/verifyModelBuilderStaleAssetApprovalGuard.ts",
+    "test:model-builder-batch-editor-key-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchEditorKeyGuard.test.ts",
+    "test:model-builder-batch-editor-key-guard": "tsx utils/scripts/verifyModelBuilderBatchEditorKeyGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/utils/scripts/verifyModelBuilderBatchEditorKeyGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderBatchEditorKeyGuard.test.ts
@@ -1,0 +1,85 @@
+// /utils/scripts/verifyModelBuilderBatchEditorKeyGuard.test.ts
+//
+// Regression test for checkBatchEditorKeyGuard() in
+// verifyModelBuilderBatchEditorKeyGuard.ts (model-builder/t-029). Exercises
+// the real check against synthetic template-shaped fixtures covering: the
+// pre-fix shape (<model-builder-batch-editor> with no `:key` -- the exact
+// bug found by manual read-through), the fixed shape, and the tag being
+// absent entirely.
+import assert from 'node:assert/strict'
+
+import { checkBatchEditorKeyGuard } from './verifyModelBuilderBatchEditorKeyGuard.js'
+
+const BUGGY_FIXTURE = `
+<template>
+  <model-builder-batch-editor
+    v-if="selectedItem && showBatch"
+    :output-key="selectedItem.outputKey"
+    @select-item="selectedItemId = $event"
+  />
+
+  <model-builder-item-panel
+    v-if="selectedItem"
+    :key="selectedItem.id"
+    :item-id="selectedItem.id"
+  />
+</template>
+`
+
+const FIXED_FIXTURE = `
+<template>
+  <model-builder-batch-editor
+    v-if="selectedItem && showBatch"
+    :key="selectedItem.outputKey"
+    :output-key="selectedItem.outputKey"
+    @select-item="selectedItemId = $event"
+  />
+
+  <model-builder-item-panel
+    v-if="selectedItem"
+    :key="selectedItem.id"
+    :item-id="selectedItem.id"
+  />
+</template>
+`
+
+const MISSING_FIXTURE = `
+<template>
+  <model-builder-item-panel
+    v-if="selectedItem"
+    :key="selectedItem.id"
+    :item-id="selectedItem.id"
+  />
+</template>
+`
+
+const buggyErrors = checkBatchEditorKeyGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  1,
+  `expected the pre-fix shape to raise 1 error, got ${buggyErrors.length}: ` +
+    `${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(buggyErrors[0]!.includes(':key="selectedItem.outputKey"'))
+
+const fixedErrors = checkBatchEditorKeyGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingErrors = checkBatchEditorKeyGuard(MISSING_FIXTURE)
+assert.equal(
+  missingErrors.length,
+  1,
+  'expected a single "not found" violation when the batch-editor tag is ' +
+    `absent entirely, got ${missingErrors.length}: ${JSON.stringify(missingErrors)}`,
+)
+assert.ok(missingErrors[0]!.includes('Could not find'))
+
+console.log(
+  'Model Builder batch-editor key guard checker verified: flags the ' +
+    'pre-fix shape (no :key on <model-builder-batch-editor>), clears the ' +
+    'fixed shape, and flags the tag being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderBatchEditorKeyGuard.ts
+++ b/utils/scripts/verifyModelBuilderBatchEditorKeyGuard.ts
@@ -1,0 +1,108 @@
+// /utils/scripts/verifyModelBuilderBatchEditorKeyGuard.ts
+//
+// Regression guard (model-builder/t-029) -- model-builder-progress-matrix.vue
+// mounts <model-builder-batch-editor :output-key="selectedItem.outputKey" />
+// with no `:key`, while the very next element, <model-builder-item-panel>,
+// does carry one (`:key="selectedItem.id"`). Without a `:key`, switching the
+// selected item from one quantity/expansion group to a different one (both
+// showBatch-eligible) does not remount model-builder-batch-editor.vue --
+// Vue just patches the outputKey prop on the same instance. The component's
+// `group`/`fields` computeds correctly re-derive from the new prop, but its
+// local reactive state (`onlyEmpty`, `batchValues`) is never cleared on an
+// outputKey change, so a value typed into a "Set a field on all" control for
+// one group (e.g. Rewards) silently carries over into the next group's
+// identically-keyed field (e.g. Scenarios' own `theme`) with no timing/race
+// involved -- ordinary sequential use of the feature. Clicking Apply on the
+// leaked value writes it onto every item in the new group via
+// batchSetField/batchPushItems, with no warning the value came from a
+// different quantity group. Concrete repro: select a Rewards item, set
+// "Card theme" to `synthwave` (no Apply needed yet -- v-model already wrote
+// it into batchValues.theme), click a Scenarios item instead -- Scenarios'
+// own batch panel now shows `synthwave` pre-filled and Apply enabled.
+//
+// Fixed by adding `:key="selectedItem.outputKey"` to the
+// <model-builder-batch-editor> tag in model-builder-progress-matrix.vue,
+// mirroring the item-panel's own `:key="selectedItem.id"` immediately below
+// it -- forces a clean remount (and therefore fresh batchValues/onlyEmpty)
+// whenever the selected quantity group changes.
+//
+// This asserts the textual shape of that fix stays in place: a
+// `:key="selectedItem.outputKey"` attribute on the
+// <model-builder-batch-editor> tag, deliberately scoped to this one bug
+// shape, mirroring this project's other narrow textual guards over a
+// general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const MATRIX_PATH = join(
+  repositoryRoot,
+  'components/model-builder/model-builder-progress-matrix.vue',
+)
+
+const TAG_START = '<model-builder-batch-editor'
+const KEY_ATTR = ':key="selectedItem.outputKey"'
+
+// Checks the fix's exact shape against the full source text of
+// model-builder-progress-matrix.vue. Exported so the self-test below can
+// run it against synthetic buggy/fixed fixtures without touching the real
+// component file.
+export function checkBatchEditorKeyGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const startIndex = content.indexOf(TAG_START)
+  if (startIndex === -1) {
+    errors.push(
+      `Could not find \`${TAG_START}\` in model-builder-progress-matrix.vue ` +
+        '-- has the batch editor mount been renamed or restructured? If so, ' +
+        'this guard (and the bug it protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  const endIndex = content.indexOf('/>', startIndex)
+  const tag = content.slice(startIndex, endIndex === -1 ? undefined : endIndex)
+
+  if (!tag.includes(KEY_ATTR)) {
+    errors.push(
+      `<model-builder-batch-editor> does not carry \`${KEY_ATTR}\`. Without ` +
+        'it, switching the selected item between two different quantity ' +
+        'groups patches the same component instance instead of remounting ' +
+        'it, so local state (batchValues, onlyEmpty) from the previous ' +
+        "group leaks into the next group's batch panel -- an ordinary " +
+        "batch-edit-then-switch-item flow can silently write one group's " +
+        "field value onto a completely different group's items.",
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(MATRIX_PATH, 'utf8')
+  const errors = checkBatchEditorKeyGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder batch-editor key guard contract failed for ' +
+        'model-builder-progress-matrix.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder batch-editor key guard contract passed: ' +
+      '<model-builder-batch-editor> remounts on outputKey change, so ' +
+      "switching quantity groups can no longer leak one group's batch " +
+      "values into the next group's panel.",
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
model-builder/t-029: Polish and upgrade Model Builder front-end surface (kind: software, recurring)

### What changed / what I produced
- `model-builder-progress-matrix.vue` mounted `<model-builder-batch-editor>` with no `:key`, while the sibling `<model-builder-item-panel>` right below it does carry one (`:key="selectedItem.id"`). Without a `:key`, selecting an item in a *different* quantity group (e.g. Rewards -> Scenarios) patched the `outputKey` prop on the same batch-editor instance instead of remounting it, so its local reactive state (`batchValues`, `onlyEmpty`) leaked across groups: type a value into a "Set a field on all" control for one group, switch to a different group, and that value shows up pre-filled with Apply enabled against the new group's own items -- ordinary sequential use, no timing/race involved.
- Fixed by adding `:key="selectedItem.outputKey"` to the batch-editor mount, mirroring the item-panel's existing `:key` convention immediately below it.
- Added `utils/scripts/verifyModelBuilderBatchEditorKeyGuard.ts` (+ selftest) as a sibling regression guard, wired into `package.json`/`contract-tests.yml`, matching this project's one-guard-per-fix convention.

### How I verified
- Found via an Explore subagent given an explicit exclusion list of every model-builder/t-029 bug class already fixed today and a directive to read the actual component/store code rather than trust a summary.
- Read the actual component code directly to confirm before editing.
- `vue-tsc --noEmit` clean repo-wide.
- `eslint` clean on changed/new files.
- `prettier --check` clean on the new guard file (pre-existing drift on `model-builder-progress-matrix.vue`/`package.json` confirmed via `git stash` to predate this change).
- New guard + selftest pass; all 17 existing `test:model-builder-*` guard scripts still pass.
- `verifyCaptureGroupGuards.ts origin/main` clean; `npm run test:workflow-paths` green.
- `git diff --stat`: exactly 5 files (1 component line, 1 new guard + selftest, 2 wiring lines).

### Stakes
reversible

### Flags for Reviewer
(none)

### Kaizen suggestion
The `isCommitting`-guards-Edit-buttons item from a prior t-029 kaizen note (PR #1729) was checked as part of this cycle's investigation and is already fixed (PR #1734, predates today) -- worth removing from any lingering "still open" tracking if it shows up again.

### Notes for reviewer
Companion conductor PR: silasfelinus/conductor#2104 (roadmap state reconciliation + this task's `status: review`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RsSRv729RdexfH5aUYYQ71)_