### PR TITLE
fix(model-builder): require artImageId for every ASSET_ONLY item, not just image-generation kind

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -323,6 +323,12 @@ jobs:
       - name: Model Builder batch-editor key guard contract
         run: npm run test:model-builder-batch-editor-key-guard
 
+      - name: Model Builder ASSET_ONLY approval guard checker self-test
+        run: npm run test:model-builder-asset-only-approval-guard-selftest
+
+      - name: Model Builder ASSET_ONLY approval guard contract
+        run: npm run test:model-builder-asset-only-approval-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -427,8 +427,21 @@ const canApproveAssets = computed(() => {
   // first — isEditable('GENERATE_ASSETS') already keeps Generate/Regenerate
   // enabled while stale.
   if (item.value.stages.GENERATE_ASSETS.status === 'stale') return false
-  // For image outputs, require a generated candidate first.
-  if (item.value.generation === 'image') return Boolean(item.value.artImageId)
+  // ASSET_ONLY items always write artImageId on commit (see
+  // server/api/model-builder/items/[id]/commit.post.ts), regardless of
+  // generation kind. Gating this only on generation === 'image' let
+  // ASSET_ONLY + non-image-kind outputs (e.g. 'plan'/'three-d' recipe
+  // entries like launch-plan, three-d-reference, reward-3d — several
+  // defaultOn) approve GENERATE_ASSETS with no candidate ever generated,
+  // since those kinds have no wired generator and always fall through
+  // this check. "Keep this asset" then looked identical to a real
+  // approval, COMMIT unlocked, and the server-side commit threw
+  // "Generate and keep an asset before committing" -- a dead end, since
+  // reopening the stage just re-shows the same always-enabled button.
+  // Text-generation UPDATE/CREATE items never need artImageId to commit
+  // (they commit on `text` instead), so this must key off `action`, not
+  // `generation`, to keep those correctly approvable.
+  if (item.value.action === 'ASSET_ONLY') return Boolean(item.value.artImageId)
   return true
 })
 

--- a/package.json
+++ b/package.json
@@ -180,6 +180,8 @@
     "test:model-builder-stale-asset-approval-guard": "tsx utils/scripts/verifyModelBuilderStaleAssetApprovalGuard.ts",
     "test:model-builder-batch-editor-key-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchEditorKeyGuard.test.ts",
     "test:model-builder-batch-editor-key-guard": "tsx utils/scripts/verifyModelBuilderBatchEditorKeyGuard.ts",
+    "test:model-builder-asset-only-approval-guard-selftest": "tsx utils/scripts/verifyModelBuilderAssetOnlyApprovalGuard.test.ts",
+    "test:model-builder-asset-only-approval-guard": "tsx utils/scripts/verifyModelBuilderAssetOnlyApprovalGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/utils/scripts/verifyModelBuilderAssetOnlyApprovalGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderAssetOnlyApprovalGuard.test.ts
@@ -1,0 +1,95 @@
+// /utils/scripts/verifyModelBuilderAssetOnlyApprovalGuard.test.ts
+//
+// Regression test for checkAssetOnlyApprovalGuard() in
+// verifyModelBuilderAssetOnlyApprovalGuard.ts (model-builder/t-029).
+// Exercises the real check against synthetic component-shaped fixtures
+// covering: the pre-fix shape (canApproveAssets keyed off
+// generation === 'image', letting every other generation kind fall through
+// to `return true` unconditionally -- the exact bug found by manual
+// read-through), the fixed shape (keyed off action === 'ASSET_ONLY'), and
+// the computed being absent entirely.
+import assert from 'node:assert/strict'
+
+import { checkAssetOnlyApprovalGuard } from './verifyModelBuilderAssetOnlyApprovalGuard.js'
+
+const BUGGY_FIXTURE = `
+<script setup lang="ts">
+const canApproveAssets = computed(() => {
+  if (!item.value) return false
+  if (isLocked('GENERATE_ASSETS')) return false
+  if (item.value.stages.GENERATE_ASSETS.status === 'in-progress') return false
+  if (isGenerating.value || isQueued.value) return false
+  if (item.value.stages.GENERATE_ASSETS.status === 'stale') return false
+  // For image outputs, require a generated candidate first.
+  if (item.value.generation === 'image') return Boolean(item.value.artImageId)
+  return true
+})
+
+function isLocked(stage: BuildStageKey): boolean {
+  const status = item.value?.stages[stage].status
+  return status === 'locked'
+}
+</script>
+`
+
+const FIXED_FIXTURE = `
+<script setup lang="ts">
+const canApproveAssets = computed(() => {
+  if (!item.value) return false
+  if (isLocked('GENERATE_ASSETS')) return false
+  if (item.value.stages.GENERATE_ASSETS.status === 'in-progress') return false
+  if (isGenerating.value || isQueued.value) return false
+  if (item.value.stages.GENERATE_ASSETS.status === 'stale') return false
+  if (item.value.action === 'ASSET_ONLY') return Boolean(item.value.artImageId)
+  return true
+})
+
+function isLocked(stage: BuildStageKey): boolean {
+  const status = item.value?.stages[stage].status
+  return status === 'locked'
+}
+</script>
+`
+
+const MISSING_FIXTURE = `
+<script setup lang="ts">
+function isLocked(stage: BuildStageKey): boolean {
+  const status = item.value?.stages[stage].status
+  return status === 'locked'
+}
+</script>
+`
+
+const buggyErrors = checkAssetOnlyApprovalGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  2,
+  `expected the pre-fix shape to raise 2 errors (missing action check + ` +
+    `stale generation-keyed check present), got ${buggyErrors.length}: ` +
+    `${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(buggyErrors[0]!.includes("action === 'ASSET_ONLY'"))
+assert.ok(buggyErrors[1]!.includes("generation === 'image'"))
+
+const fixedErrors = checkAssetOnlyApprovalGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingErrors = checkAssetOnlyApprovalGuard(MISSING_FIXTURE)
+assert.equal(
+  missingErrors.length,
+  1,
+  'expected a single "not found" violation when canApproveAssets is absent ' +
+    `entirely, got ${missingErrors.length}: ${JSON.stringify(missingErrors)}`,
+)
+assert.ok(missingErrors[0]!.includes('Could not find'))
+
+console.log(
+  'Model Builder ASSET_ONLY approval guard checker verified: flags the ' +
+    "pre-fix shape (canApproveAssets keyed off generation === 'image'), " +
+    "clears the fixed shape (keyed off action === 'ASSET_ONLY'), and " +
+    'flags the computed being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderAssetOnlyApprovalGuard.ts
+++ b/utils/scripts/verifyModelBuilderAssetOnlyApprovalGuard.ts
@@ -1,0 +1,128 @@
+// /utils/scripts/verifyModelBuilderAssetOnlyApprovalGuard.ts
+//
+// Regression guard (model-builder/t-029) -- canApproveAssets gated its final
+// "does this candidate exist" check on `item.value.generation === 'image'`,
+// falling through to `return true` unconditionally for every other
+// GenerationKind. Several real, catalogued recipe outputs are
+// `action: 'ASSET_ONLY'` paired with a non-image generation kind that has no
+// wired generator yet ('plan': photo-shoot-plan, video-shot-list,
+// commercial-treatment, launch-plan; 'three-d': three-d-reference,
+// reward-3d) -- and launch-plan is defaultOn inside marketing-deck, the
+// default recipe for a Project source, so an ordinary default build run
+// reaches this. For those items the "Generate Assets" section shows only a
+// "not yet wired into this front-end slice" message with no Generate
+// button, but "Keep this asset" sat enabled regardless. Clicking it flipped
+// GENERATE_ASSETS to 'approved' with item.artImageId still null; clicking
+// Execute commit then hit the server's ASSET_ONLY precondition in
+// server/api/model-builder/items/[id]/commit.post.ts ("Generate and keep an
+// asset before committing"), a dead end -- reopening the stage just re-shows
+// the same always-enabled button, so the item can never be committed.
+//
+// Fixed by keying the final check off `item.value.action === 'ASSET_ONLY'`
+// instead of `item.value.generation === 'image'`, matching what the server
+// actually requires at commit time: every ASSET_ONLY item needs a real
+// artImageId regardless of generation kind, while UPDATE/CREATE
+// (text-generation) items never need one and must stay unconditionally
+// approvable.
+//
+// This asserts the textual shape of that fix stays in place: a check for
+// `item.value.action === 'ASSET_ONLY'` (returning `Boolean(item.value.artImageId)`)
+// inside canApproveAssets, and that the old generation-keyed check is gone --
+// deliberately scoped to this one bug shape, mirroring this project's other
+// narrow textual guards over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const PANEL_PATH = join(
+  repositoryRoot,
+  'components/model-builder/model-builder-item-panel.vue',
+)
+
+const COMPUTED_START = 'const canApproveAssets = computed(() => {'
+const ACTION_CHECK =
+  "item.value.action === 'ASSET_ONLY') return Boolean(item.value.artImageId)"
+const STALE_GENERATION_CHECK =
+  "item.value.generation === 'image') return Boolean("
+
+// Checks the fix's exact shape against the full source text of
+// model-builder-item-panel.vue. Exported so the self-test below can run it
+// against synthetic buggy/fixed fixtures without touching the real
+// component file.
+export function checkAssetOnlyApprovalGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const startIndex = content.indexOf(COMPUTED_START)
+  if (startIndex === -1) {
+    errors.push(
+      `Could not find \`${COMPUTED_START}\` in model-builder-item-panel.vue ` +
+        '-- has canApproveAssets been renamed or restructured? If so, this ' +
+        'guard (and the bug it protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  // The computed is a short arrow function body; find its closing `})` by
+  // scanning forward for the first `})` at the start of a line, matching
+  // this file's existing computed-body extraction convention.
+  const closeMatch = /\n\}\)/.exec(content.slice(startIndex))
+  const endIndex =
+    closeMatch && closeMatch.index !== undefined
+      ? startIndex + closeMatch.index
+      : content.length
+  const body = content.slice(startIndex, endIndex)
+
+  if (!body.includes(ACTION_CHECK)) {
+    errors.push(
+      `canApproveAssets does not check \`${ACTION_CHECK}\`. Every ` +
+        'ASSET_ONLY item writes artImageId on commit regardless of ' +
+        'generation kind (see commit.post.ts) -- without this check, an ' +
+        "ASSET_ONLY item whose generation kind isn't 'image' (e.g. " +
+        "'plan'/'three-d' recipe outputs like launch-plan or " +
+        'three-d-reference, several defaultOn) can approve GENERATE_ASSETS ' +
+        'with no candidate ever generated, then dead-end at commit with ' +
+        '"Generate and keep an asset before committing".',
+    )
+  }
+
+  if (body.includes(STALE_GENERATION_CHECK)) {
+    errors.push(
+      'canApproveAssets still keys its final check off ' +
+        "`item.value.generation === 'image'` -- this is the pre-fix shape " +
+        'that let every non-image generation kind fall through to ' +
+        '`return true` unconditionally. Replace it with the ' +
+        "`item.value.action === 'ASSET_ONLY'` check instead.",
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(PANEL_PATH, 'utf8')
+  const errors = checkAssetOnlyApprovalGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder ASSET_ONLY approval guard contract failed for ' +
+        'model-builder-item-panel.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder ASSET_ONLY approval guard contract passed: ' +
+      'canApproveAssets requires a real artImageId for every ASSET_ONLY ' +
+      'item regardless of generation kind, so a non-image-kind ASSET_ONLY ' +
+      'output can no longer be approved and then dead-end at commit.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
Next polish slice on the recurring model-builder/t-029 roadmap task.

## The bug

`canApproveAssets` in `model-builder-item-panel.vue` gated its final "does a candidate exist" check on `generation === 'image'`, falling through to `return true` unconditionally for every other `GenerationKind`. Several real, catalogued `ASSET_ONLY` recipe outputs pair with a non-image generation kind that has no wired generator yet:

- `generation: 'plan'` — `photo-shoot-plan`, `video-shot-list`, `commercial-treatment`, and **`launch-plan` (defaultOn inside `marketing-deck`, the default recipe for a Project source)**
- `generation: 'three-d'` — `three-d-reference`, `reward-3d`

Since `launch-plan` is `defaultOn`, an ordinary user just accepting the default recipe for a Project source reaches this — no unusual path required.

**Repro:** pick a Project source, accept the default recipe (includes `launch-plan`), approve Pitch and Fields & Prompts, then on the `launch-plan` item the Generate Assets panel shows only a "not yet wired into this front-end slice" message — but "Keep this asset" sits enabled anyway. Clicking it flips `GENERATE_ASSETS` to `approved` with `item.artImageId` still `null`. Clicking "Execute commit" then hits the server's `ASSET_ONLY` precondition in `commit.post.ts` and throws `"Generate and keep an asset before committing"` — a dead end, since reopening the stage just re-shows the same always-enabled button. There is no way to ever commit that item through this UI.

## The fix

Key the check off `item.action === 'ASSET_ONLY'` instead of `item.generation === 'image'`, matching what the server actually requires at commit time: every `ASSET_ONLY` item needs a real `artImageId` regardless of generation kind, while text-generation `UPDATE`/`CREATE` items never need one and correctly stay unconditionally approvable.

## Regression guard

Added `utils/scripts/verifyModelBuilderAssetOnlyApprovalGuard.ts` (+ selftest), wired into `package.json`/`contract-tests.yml`, matching this project's one-guard-per-fix convention.

## Verification

- `vue-tsc --noEmit` (via `npm run test`): 0 errors repo-wide
- `eslint`: clean on all changed/new files
- `prettier --check`: clean on new files (pre-existing drift on `model-builder-item-panel.vue`/`package.json` confirmed via `git stash` to predate this change)
- All 30 existing `test:model-builder-*` guard + selftest scripts pass, plus the 2 new ones
- `verifyCaptureGroupGuards.ts origin/main`: clean
- `npm run test:workflow-paths`: green

`git diff --stat`: exactly 5 files (3 modified, 2 new).

Found via an Explore subagent given an explicit exclusion list of every model-builder/t-029 bug class already fixed today and a directive to read the actual component/store/route code directly rather than trust a summary.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7Q5bqixYDVzkim3Z15V5A)_