### PR TITLE
Close the anonymous reaction read and spoofable write, without the gated migration

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Reaction target coverage contract
         run: npm run test:reaction-targets
 
+      - name: Reaction route auth contract
+        run: npm run test:reaction-route-auth
+
       - name: Component reachability contract
         run: npm run test:component-reachability
 

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "audit:gallery-chrome": "tsx utils/scripts/auditGalleryChrome.ts",
     "test:card-action-contract": "tsx utils/scripts/verifyCardActionContract.ts",
     "test:reaction-targets": "tsx utils/scripts/verifyReactionTargetCoverage.ts",
+    "test:reaction-route-auth": "tsx utils/scripts/verifyReactionRouteAuth.ts",
     "test:no-prisma-json-cast": "tsx utils/scripts/verifyNoPrismaJsonCast.ts",
     "test:admin-flag-casts": "tsx utils/scripts/verifyAdminFlagCasts.ts",
     "test:user-role-expand": "tsx utils/scripts/verifyUserRoleExpand.ts",

--- a/server/api/reactions/[id].get.ts
+++ b/server/api/reactions/[id].get.ts
@@ -1,35 +1,64 @@
 // /server/api/reactions/[id].get.ts
-import { defineEventHandler } from 'h3'
+//
+// Read one Reaction by its own id: the author's, or any of them for an admin.
+//
+// Securing GET /api/reactions (#1788) would have been cosmetic while this route
+// still returned an arbitrary row to anyone, since walking ids 1..N rebuilds
+// the same table one request at a time. Nothing in the app calls this -- the
+// store reads through /api/reactions/<target>/<id> and only ever PATCHes or
+// DELETEs by id -- so restricting it costs no existing behaviour.
+//
+// This is deliberately STRICTER than the per-target route, which serves any
+// reaction on a public object to anybody. Matching that would mean resolving
+// each reaction's target model to re-derive its visibility; owner-or-admin is
+// the conservative reading until there is a caller that needs more. Public
+// reading of reactions happens through the target route, which already checks
+// the target.
+import { createError, defineEventHandler } from 'h3'
 import { errorHandler } from '../../utils/error'
-import { fetchReactionById } from '.' // Ensure this path is correct based on your project structure
+import { requireApiUser } from '../../utils/authGuard'
+import { fetchReactionById } from '.'
 
 export default defineEventHandler(async (event) => {
   try {
+    const auth = await requireApiUser(event)
     const id = Number(event.context.params?.id)
 
-    if (isNaN(id) || id <= 0) {
-      throw new Error('A valid reaction ID is required.')
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'A valid reaction ID is required.',
+      })
     }
 
     const data = await fetchReactionById(id)
 
-    if (!data) {
-      throw new Error(`Reaction with ID ${id} not found.`)
+    // Same answer for "does not exist" and "not yours": a 403 here would
+    // confirm the row exists, which is the enumeration this route was leaking.
+    if (!data || (!auth.isAdmin && data.userId !== auth.user.id)) {
+      throw createError({
+        statusCode: 404,
+        message: `Reaction with ID ${id} not found.`,
+      })
     }
+
+    event.node.res.statusCode = 200
 
     return {
       success: true,
+      message: `Fetched reaction #${id}.`,
       data,
+      statusCode: 200,
     }
   } catch (error: unknown) {
-    const handledError = errorHandler(error)
+    const { success, message, statusCode } = errorHandler(error)
+    event.node.res.statusCode = statusCode || 500
+
     return {
-      success: false,
-      data: {
-        message:
-          handledError.message ||
-          'An error occurred while fetching the reaction.',
-      },
+      success,
+      message: message || 'An error occurred while fetching the reaction.',
+      data: null,
+      statusCode: statusCode || 500,
     }
   }
 })

--- a/server/api/reactions/index.get.ts
+++ b/server/api/reactions/index.get.ts
@@ -1,18 +1,87 @@
-// server/api/reactions/index.get.ts
-import { defineEventHandler } from 'h3'
+// /server/api/reactions/index.get.ts
+//
+// GET /api/reactions -- the caller's own reactions. Admins may read another
+// user's, or the whole table, by asking explicitly.
+//
+// This route used to call fetchAllReactions(), an unauthenticated
+// `prisma.reaction.findMany({})` that returned every Reaction row in the
+// database to anyone who asked: every comment, every rating, and the userId
+// behind each one, including reactions on records their owners had never made
+// public (#1788).
+//
+// It is scoped rather than deleted because "my reactions" is a legitimate
+// surface and the unscoped one was the defect. Nothing in the app called this
+// route -- the store reads through /api/reactions/<target>/<id> -- so the
+// blast radius of narrowing it is a caller we do not have.
+import { createError, defineEventHandler, getQuery } from 'h3'
 import { errorHandler } from '../../utils/error'
-import { fetchAllReactions } from '.'
+import prisma from '../../utils/prisma'
+import { requireApiUser } from '../../utils/authGuard'
 
-export default defineEventHandler(async () => {
+const MAX_TAKE = 200
+
+function toPositiveInt(value: unknown): number | null {
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+export default defineEventHandler(async (event) => {
   try {
-    const data = await fetchAllReactions()
+    const auth = await requireApiUser(event)
+    const query = getQuery<{ userId?: string; all?: string; take?: string; skip?: string }>(
+      event,
+    )
+
+    const requestedUserId = toPositiveInt(query.userId)
+    const wantsEveryone = query.all === 'true' || query.all === '1'
+
+    // Reading somebody else's reactions, or everybody's, is an admin act. A
+    // non-admin asking for either gets 403 rather than a silent downgrade to
+    // their own rows, so a broken caller fails loudly instead of looking like
+    // it worked.
+    if ((requestedUserId && requestedUserId !== auth.user.id) || wantsEveryone) {
+      if (!auth.isAdmin) {
+        throw createError({
+          statusCode: 403,
+          message: 'Only an admin may read another user’s reactions.',
+        })
+      }
+    }
+
+    const where =
+      wantsEveryone && auth.isAdmin
+        ? {}
+        : { userId: requestedUserId && auth.isAdmin ? requestedUserId : auth.user.id }
+
+    const take = Math.min(MAX_TAKE, toPositiveInt(query.take) ?? MAX_TAKE)
+    const skip = toPositiveInt(query.skip) ?? 0
+
+    const data = await prisma.reaction.findMany({
+      where,
+      orderBy: { updatedAt: 'desc' },
+      take,
+      skip,
+    })
+
+    event.node.res.statusCode = 200
 
     return {
       success: true,
+      message: `Fetched ${data.length} reaction(s).`,
       data,
+      count: data.length,
+      statusCode: 200,
     }
   } catch (error: unknown) {
-    console.error('Error fetching reactions in API handler:', error)
-    return errorHandler(error)
+    const { success, message, statusCode } = errorHandler(error)
+    event.node.res.statusCode = statusCode || 500
+
+    return {
+      success,
+      message: message || 'Failed to fetch reactions.',
+      data: [],
+      count: 0,
+      statusCode: statusCode || 500,
+    }
   }
 })

--- a/server/api/reactions/index.ts
+++ b/server/api/reactions/index.ts
@@ -1,172 +1,24 @@
 // /server/api/reactions/index.ts
-import { defineEventHandler, readBody, createError } from 'h3'
+//
+// Shared Reaction helpers. NOT a route handler -- same shape as
+// server/api/rewards/index.ts, resources/index.ts and facets/index.ts, which
+// are all helper modules with no default export. `/api/reactions` is served by
+// index.get.ts and index.post.ts.
+//
+// This file used to also export a default event handler: a second, older
+// create/update path that took `userId` straight from the request body, never
+// authenticated it, and ran none of the per-target access checks
+// index.post.ts applies. Anyone could POST a reaction as any user (#1788).
+// It was reachable for any method index.post.ts did not claim.
+//
+// Retired rather than hardened. index.post.ts is the canonical create path and
+// already does everything this did, correctly: it authenticates, derives the
+// reactor from the session, validates the category against a total map,
+// rejects unmapped targets, checks the target's visibility, and honours
+// allowReviews. A second implementation of the same endpoint is how the two
+// drifted apart in the first place.
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
-import {
-  ReactionType,
-  Reaction_reactionCategory,
-  type Prisma,
-} from '~/prisma/generated/prisma/client'
-
-type RequestData = {
-  userId: number
-  reactionType: string
-  reactionCategory?: string
-  artId?: number
-  artImageId?: number
-  componentId?: number
-  dreamId?: number
-  comment?: string
-  rating?: number
-}
-
-function toPositiveId(value: unknown): number | undefined {
-  const parsed = Number(value)
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined
-}
-
-function mapReactionType(type: string): ReactionType | undefined {
-  const normalizedType = type.toUpperCase() as keyof typeof ReactionType
-  return ReactionType[normalizedType]
-}
-
-function normalizeCategory(
-  requestData: RequestData,
-): Reaction_reactionCategory {
-  const explicit = requestData.reactionCategory
-
-  if (typeof explicit === 'string') {
-    const key = explicit.trim().toUpperCase().replace(/[\s-]+/g, '_')
-    const aliases: Record<string, Reaction_reactionCategory> = {
-      ART: Reaction_reactionCategory.ART_IMAGE,
-      ARTIMAGE: Reaction_reactionCategory.ART_IMAGE,
-      ART_IMAGE: Reaction_reactionCategory.ART_IMAGE,
-      IMAGE: Reaction_reactionCategory.ART_IMAGE,
-      COMPONENT: Reaction_reactionCategory.COMPONENT,
-      DREAM: Reaction_reactionCategory.DREAM,
-    }
-
-    const aliased = aliases[key]
-    if (aliased) return aliased
-
-    if (
-      Object.values(Reaction_reactionCategory).includes(
-        key as Reaction_reactionCategory,
-      )
-    ) {
-      return key as Reaction_reactionCategory
-    }
-  }
-
-  if (toPositiveId(requestData.dreamId)) return Reaction_reactionCategory.DREAM
-  if (toPositiveId(requestData.componentId))
-    return Reaction_reactionCategory.COMPONENT
-
-  return Reaction_reactionCategory.ART_IMAGE
-}
-
-function buildTarget(requestData: RequestData) {
-  const artImageId = toPositiveId(requestData.artImageId ?? requestData.artId)
-  const componentId = toPositiveId(requestData.componentId)
-  const dreamId = toPositiveId(requestData.dreamId)
-
-  if (dreamId) return { field: 'dreamId' as const, id: dreamId }
-  if (componentId) return { field: 'componentId' as const, id: componentId }
-  if (artImageId) return { field: 'artImageId' as const, id: artImageId }
-
-  return null
-}
-
-export default defineEventHandler(async (event) => {
-  try {
-    const requestData = await readBody<RequestData>(event)
-
-    if (!requestData) {
-      throw createError({ statusCode: 400, message: 'Invalid request data.' })
-    }
-
-    const userId = toPositiveId(requestData.userId)
-
-    if (!userId || !requestData.reactionType) {
-      throw createError({
-        statusCode: 400,
-        message: 'Missing required fields: userId or reactionType.',
-      })
-    }
-
-    const reactionType = mapReactionType(requestData.reactionType)
-
-    if (!reactionType) {
-      throw createError({ statusCode: 400, message: 'Invalid reactionType.' })
-    }
-
-    const target = buildTarget(requestData)
-
-    if (!target) {
-      throw createError({
-        statusCode: 400,
-        message: 'A dreamId, componentId, artImageId, or artId is required.',
-      })
-    }
-
-    const reactionCategory = normalizeCategory(requestData)
-    const targetWhere = { [target.field]: target.id }
-
-    const existingReaction = await prisma.reaction.findFirst({
-      where: {
-        userId,
-        reactionType,
-        reactionCategory,
-        ...targetWhere,
-      },
-    })
-
-    const mutationData: Prisma.ReactionUncheckedCreateInput = {
-      userId,
-      reactionType,
-      reactionCategory,
-      [target.field]: target.id,
-      comment: requestData.comment,
-      rating: Number.isFinite(Number(requestData.rating))
-        ? Math.max(0, Math.min(5, Math.round(Number(requestData.rating))))
-        : 0,
-    }
-
-    const reaction = existingReaction
-      ? await prisma.reaction.update({
-          where: { id: existingReaction.id },
-          data: mutationData,
-        })
-      : await prisma.reaction.create({ data: mutationData })
-
-    event.node.res.statusCode = existingReaction ? 200 : 201
-
-    return {
-      success: true,
-      reaction,
-      data: reaction,
-      message: existingReaction
-        ? 'Reaction updated successfully.'
-        : 'Reaction created successfully.',
-    }
-  } catch (error) {
-    const handled = errorHandler(error)
-    event.node.res.statusCode = handled.statusCode || 500
-
-    return {
-      success: false,
-      message: handled.message || 'Failed to create/update reaction.',
-    }
-  }
-})
-
-export async function fetchAllReactions() {
-  try {
-    return await prisma.reaction.findMany({})
-  } catch (error: unknown) {
-    throw errorHandler(error)
-  }
-}
 
 export async function fetchReactionById(id: number) {
   try {

--- a/utils/scripts/verifyReactionRouteAuth.ts
+++ b/utils/scripts/verifyReactionRouteAuth.ts
@@ -1,0 +1,131 @@
+// /utils/scripts/verifyReactionRouteAuth.ts
+//
+// No anonymous full-table reads, and no user-id spoofing, on the Reaction API.
+//
+// WHY
+// ---
+// #1788. Two legacy top-level routes predated the per-target auth semantics and
+// bypassed them entirely:
+//
+//   GET /api/reactions   called fetchAllReactions(), an unauthenticated
+//                        `prisma.reaction.findMany({})`, and returned every
+//                        Reaction row in the database -- comments, ratings and
+//                        the userId behind each one -- to anybody.
+//
+//   server/api/reactions/index.ts exported a second create/update handler that
+//                        read `userId` straight from the request body, never
+//                        authenticated it, and ran none of the target access
+//                        checks index.post.ts applies. Anyone could write a
+//                        reaction as any user, for any method index.post.ts
+//                        did not claim.
+//
+// Both are the kind of thing that comes back: the helper module is the natural
+// place to park "just one more" handler, and a scoped findMany is one careless
+// refactor away from being unscoped again. This asserts the shape rather than
+// the behaviour, because a route contract that needs a live database does not
+// run in CI -- and the shape is what regressed.
+//
+//   npx tsx utils/scripts/verifyReactionRouteAuth.ts
+import assert from 'node:assert/strict'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { stripComments } from './lib/sourceText'
+
+const reactionsDir = join(process.cwd(), 'server/api/reactions')
+
+// Comments here describe the very patterns being banned -- this file's own
+// header quotes `findMany({})`. Match code, not prose.
+const read = (file: string) =>
+  stripComments(readFileSync(join(reactionsDir, file), 'utf8'))
+
+// ---------------------------------------------------------------- helper module
+
+const helperModule = read('index.ts')
+
+assert.doesNotMatch(
+  helperModule,
+  /export default/,
+  'server/api/reactions/index.ts must stay a helper module with no default export, matching rewards/resources/facets. A default export here registers a second /api/reactions handler outside the authenticated create path.',
+)
+assert.doesNotMatch(
+  helperModule,
+  /fetchAllReactions/,
+  'fetchAllReactions() returned the whole Reaction table and must not come back, even unexported -- its only caller was the anonymous read this contract exists to prevent.',
+)
+
+// ---------------------------------------------------------------- no body userId
+
+// The authenticated routes derive the reactor from the session. A `userId` read
+// out of a request body is the spoofing hole, wherever it reappears.
+for (const file of readdirSync(reactionsDir).filter((name) => name.endsWith('.ts'))) {
+  const source = read(file)
+  assert.doesNotMatch(
+    source,
+    /body\.userId|requestData\.userId|\buserId\b\s*:\s*toPositiveId\(/,
+    `${file} takes userId from the request body. Caller identity comes from auth, never from the payload.`,
+  )
+}
+
+// ---------------------------------------------------------------- authenticated reads
+
+const listRoute = read('index.get.ts')
+
+assert.match(
+  listRoute,
+  /requireApiUser/,
+  'GET /api/reactions must authenticate. It used to serve the entire table anonymously.',
+)
+assert.doesNotMatch(
+  listRoute,
+  /findMany\(\s*\{\s*\}\s*\)/,
+  'GET /api/reactions must never issue an unscoped findMany.',
+)
+assert.match(
+  listRoute,
+  /isAdmin/,
+  'reading another user’s reactions, or everyone’s, must be gated on admin',
+)
+assert.match(
+  listRoute,
+  /userId: /,
+  'the default scope for GET /api/reactions is the caller’s own reactions',
+)
+
+const byIdRoute = read('[id].get.ts')
+
+assert.match(
+  byIdRoute,
+  /requireApiUser/,
+  'GET /api/reactions/<id> must authenticate: walking ids rebuilds the table one row at a time, which is the same leak the list route had.',
+)
+assert.match(
+  byIdRoute,
+  /data\.userId !== auth\.user\.id/,
+  'GET /api/reactions/<id> must return only the caller’s own reaction unless they are an admin',
+)
+assert.match(
+  byIdRoute,
+  /statusCode: 404/,
+  'a reaction the caller may not read must 404 rather than 403 -- a 403 confirms the row exists',
+)
+
+// ---------------------------------------------------------------- create path
+
+const createRoute = read('index.post.ts')
+
+assert.match(
+  createRoute,
+  /validateApiKey|requireApiUser|getOptionalApiUser/,
+  'POST /api/reactions must authenticate',
+)
+assert.match(
+  createRoute,
+  /assertReactionTargetAccessible/,
+  'POST /api/reactions must keep its per-target access check',
+)
+
+const routeFiles = readdirSync(reactionsDir).filter((name) => name.endsWith('.ts'))
+
+console.log(
+  `Reaction route auth verified: ${routeFiles.length} handler(s), no anonymous table reads, no body-supplied userId.`,
+)


### PR DESCRIPTION
### Task
Extract the security-only commit from #1774 (issue #1788) now that #1798 already
landed the reversible reaction-layer repair it depends on. Leaves the `allowReviews`
migration/backfill (`b54ec21`) gated in #1774 for Silas's decision — untouched here.

### What changed / what I produced
- `GET /api/reactions` (`fetchAllReactions()`) was an unauthenticated
  `prisma.reaction.findMany({})` returning the entire Reaction table — every
  comment, every rating, and the `userId` behind each one. Now requires auth and
  returns only the caller's own reactions, bounded.
- `server/api/reactions/index.ts` exported a second create/update handler that took
  `userId` from the request body with no auth and none of `index.post.ts`'s access
  checks — reachable independently of the canonical handler. Retired to a helper
  module with no default export (matching `rewards/`, `resources/`, `facets/`).
- `GET /api/reactions/[id]` returned an arbitrary row to anyone; now authenticates
  and 404s (not 403s) on someone else's reaction so the response doesn't confirm
  the row exists.
- Adds `utils/scripts/verifyReactionRouteAuth.ts`, asserting the route *shape*
  (no default export in the helper module, auth on both read paths, no
  body-supplied `userId` anywhere under `server/api/reactions/`).

### How I verified
- This is commit `d5bd7cf` from #1774 cherry-picked unmodified onto current `main`
  (which already contains `ee7ea1a` via #1798) — applied with no conflicts.
- Source PR (#1774) reports `vue-tsc --noEmit` clean at this commit in isolation,
  plus `test:reaction-route-auth`, `test:reaction-targets`,
  `test:earned-karma-wiring`, `test:card-action-contract`, `test:lint-ratchet`,
  `test:workflow-paths` all passing.
- Will merge only after this PR's own attached checks complete successfully.

### Stakes
reversible — access-control hardening only, no schema change, no data rewrite,
no default export removed that anything outside `server/api/reactions/` imports.

### Flags for Reviewer
- Deliberately excludes the gated migration/backfill `b54ec21` — that stays on
  #1774 for Silas.
- Closes issue #1788.

Closes #1788

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y53GF13TUinKb7wTGqYC3J

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y53GF13TUinKb7wTGqYC3J)_