### PR TITLE
fix(model-builder): avoid duplicate source labels for screen readers

### DIFF
--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -107,7 +107,7 @@
             <img
               v-if="recordImage(record)"
               :src="recordImage(record)"
-              :alt="store.sourceLabel(record)"
+              alt=""
               class="h-full w-full object-cover transition group-hover:scale-105"
               loading="lazy"
             />
@@ -146,7 +146,7 @@
             <img
               v-if="recordImage(record)"
               :src="recordImage(record)"
-              :alt="store.sourceLabel(record)"
+              alt=""
               class="h-full w-full object-cover"
               loading="lazy"
             />
@@ -189,7 +189,7 @@
             <img
               v-if="recordImage(record)"
               :src="recordImage(record)"
-              :alt="store.sourceLabel(record)"
+              alt=""
               class="h-full w-full object-cover"
               loading="lazy"
             />


### PR DESCRIPTION
## Summary
- make source-picker thumbnails decorative in gallery, grid, and list modes
- preserve the visible source label as the button's single accessible label
- no behavior, API, schema, persistence, or ArtJob changes

## Verification
- exact diff is one Vue component and three `alt=""` substitutions
- rely on required PR TypeScript/contract checks before merge

## Handoff
- Project/task: `model-builder/t-029`
- Session: `20260811T201943-0700-model-builder-t029-7c2a`
- Stakes: reversible
- Flags for reviewer: accessibility-only; the thumbnails are redundant with text inside the same button
- Kaizen: none; this is a bounded recurring-polish slice