### PR TITLE
fix(model-builder): guard auto-build approval against a concurrent stale race

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -335,6 +335,12 @@ jobs:
       - name: Model Builder ASSET_ONLY approval guard contract
         run: npm run test:model-builder-asset-only-approval-guard
 
+      - name: Model Builder auto-build approval-race guard checker self-test
+        run: npm run test:model-builder-auto-build-approval-race-guard-selftest
+
+      - name: Model Builder auto-build approval-race guard contract
+        run: npm run test:model-builder-auto-build-approval-race-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -179,6 +179,8 @@
     "test:model-builder-batch-editor-key-guard": "tsx utils/scripts/verifyModelBuilderBatchEditorKeyGuard.ts",
     "test:model-builder-asset-only-approval-guard-selftest": "tsx utils/scripts/verifyModelBuilderAssetOnlyApprovalGuard.test.ts",
     "test:model-builder-asset-only-approval-guard": "tsx utils/scripts/verifyModelBuilderAssetOnlyApprovalGuard.ts",
+    "test:model-builder-auto-build-approval-race-guard-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildApprovalRaceGuard.test.ts",
+    "test:model-builder-auto-build-approval-race-guard": "tsx utils/scripts/verifyModelBuilderAutoBuildApprovalRaceGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1522,7 +1522,20 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
           const drafted = await draftText(itemId, 'artPrompt')
           if (!drafted) return 'failed'
         }
-        approveStage(itemId, 'FIELDS_AND_PROMPTS')
+        // approveStage() unconditionally overwrites the stage's status --
+        // unlike finishGenerateAssets/finishCommit, it has no in-flight
+        // check. A concurrent Edit click on PITCH (clickable throughout
+        // auto-build; only isCommitting disables it) can markDownstreamStale
+        // this very stage while the awaits above are pending, and a 'stale'
+        // status here means the drafted content reflects the pre-edit pitch.
+        // Only approve if the stage is still the 'ready' state auto-build
+        // itself put it in -- otherwise it needs a fresh review, not a
+        // silent approval of stale content.
+        if (item.stages.FIELDS_AND_PROMPTS.status === 'ready') {
+          approveStage(itemId, 'FIELDS_AND_PROMPTS')
+        } else {
+          return 'failed'
+        }
       }
 
       if (item.stages.GENERATE_ASSETS.status !== 'approved') {
@@ -1530,7 +1543,16 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
           const generated = await generateItemAsset(itemId)
           if (!generated) return 'failed'
         }
-        approveStage(itemId, 'GENERATE_ASSETS')
+        // Same race as above: generateItemAsset() can return true (the
+        // network render succeeded) while finishGenerateAssets() correctly
+        // refused to write the result because a concurrent upstream edit
+        // already staled this stage. Trusting `generated` alone would
+        // silently re-approve the reopened-and-unreviewed candidate.
+        if (item.stages.GENERATE_ASSETS.status === 'ready') {
+          approveStage(itemId, 'GENERATE_ASSETS')
+        } else {
+          return 'failed'
+        }
       }
 
       if (item.stages.COMMIT.status !== 'approved') {

--- a/utils/scripts/verifyModelBuilderAutoBuildApprovalRaceGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildApprovalRaceGuard.test.ts
@@ -1,0 +1,165 @@
+// /utils/scripts/verifyModelBuilderAutoBuildApprovalRaceGuard.test.ts
+//
+// Regression test for checkAutoBuildApprovalRaceGuard() in
+// verifyModelBuilderAutoBuildApprovalRaceGuard.ts (model-builder/t-029).
+// Exercises the real check against synthetic store-shaped fixtures covering:
+// the pre-fix shape (approveStage called unconditionally after the await --
+// the exact bug found by manual read-through), the fixed shape (status
+// checked, non-ready branch bails), a guard present but missing its
+// `else { return 'failed' }` fallback, and autoBuildItem being absent
+// entirely.
+import assert from 'node:assert/strict'
+
+import { checkAutoBuildApprovalRaceGuard } from './verifyModelBuilderAutoBuildApprovalRaceGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function autoBuildItem(itemId: string): Promise<AutoBuildOutcome> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return 'failed'
+
+    autoBuildingItemSingleton.claim(item.id)
+    try {
+      if (item.stages.PITCH.status !== 'approved') {
+        approveStage(itemId, 'PITCH')
+      }
+
+      if (item.stages.FIELDS_AND_PROMPTS.status !== 'approved') {
+        if (!isAsset) {
+          const drafted = await draftText(itemId, 'fields')
+          if (!drafted) return 'failed'
+        }
+        approveStage(itemId, 'FIELDS_AND_PROMPTS')
+      }
+
+      if (item.stages.GENERATE_ASSETS.status !== 'approved') {
+        if (wantArt) {
+          const generated = await generateItemAsset(itemId)
+          if (!generated) return 'failed'
+        }
+        approveStage(itemId, 'GENERATE_ASSETS')
+      }
+
+      if (item.stages.COMMIT.status !== 'approved') {
+        return (await commitItem(itemId)) ? 'committed' : 'failed'
+      }
+      return 'committed'
+    } finally {
+      autoBuildingItemSingleton.release(item.id)
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function autoBuildItem(itemId: string): Promise<AutoBuildOutcome> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return 'failed'
+
+    autoBuildingItemSingleton.claim(item.id)
+    try {
+      if (item.stages.PITCH.status !== 'approved') {
+        approveStage(itemId, 'PITCH')
+      }
+
+      if (item.stages.FIELDS_AND_PROMPTS.status !== 'approved') {
+        if (!isAsset) {
+          const drafted = await draftText(itemId, 'fields')
+          if (!drafted) return 'failed'
+        }
+        if (item.stages.FIELDS_AND_PROMPTS.status === 'ready') {
+          approveStage(itemId, 'FIELDS_AND_PROMPTS')
+        } else {
+          return 'failed'
+        }
+      }
+
+      if (item.stages.GENERATE_ASSETS.status !== 'approved') {
+        if (wantArt) {
+          const generated = await generateItemAsset(itemId)
+          if (!generated) return 'failed'
+        }
+        if (item.stages.GENERATE_ASSETS.status === 'ready') {
+          approveStage(itemId, 'GENERATE_ASSETS')
+        } else {
+          return 'failed'
+        }
+      }
+
+      if (item.stages.COMMIT.status !== 'approved') {
+        return (await commitItem(itemId)) ? 'committed' : 'failed'
+      }
+      return 'committed'
+    } finally {
+      autoBuildingItemSingleton.release(item.id)
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkAutoBuildApprovalRaceGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  2,
+  'expected the pre-fix shape (both FIELDS_AND_PROMPTS and GENERATE_ASSETS ' +
+    `approveStage calls unguarded) to raise 2 errors, got ${buggyErrors.length}: ` +
+    JSON.stringify(buggyErrors),
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes("'FIELDS_AND_PROMPTS'")),
+  'expected a violation for the unguarded FIELDS_AND_PROMPTS approval',
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes("'GENERATE_ASSETS'")),
+  'expected a violation for the unguarded GENERATE_ASSETS approval',
+)
+
+const fixedErrors = checkAutoBuildApprovalRaceGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const NO_FALLBACK_FIXTURE = FIXED_FIXTURE.replace(
+  `        if (item.stages.GENERATE_ASSETS.status === 'ready') {
+          approveStage(itemId, 'GENERATE_ASSETS')
+        } else {
+          return 'failed'
+        }`,
+  `        if (item.stages.GENERATE_ASSETS.status === 'ready') {
+          approveStage(itemId, 'GENERATE_ASSETS')
+        }`,
+)
+const noFallbackErrors = checkAutoBuildApprovalRaceGuard(NO_FALLBACK_FIXTURE)
+assert.equal(
+  noFallbackErrors.length,
+  1,
+  'expected exactly one violation when the GENERATE_ASSETS guard is present ' +
+    `but missing its else { return 'failed' } fallback, got ${noFallbackErrors.length}: ` +
+    JSON.stringify(noFallbackErrors),
+)
+assert.ok(
+  noFallbackErrors[0]!.includes("'GENERATE_ASSETS'") &&
+    noFallbackErrors[0]!.includes('else'),
+)
+
+const missingFnErrors = checkAutoBuildApprovalRaceGuard(MISSING_FIXTURE)
+assert.equal(
+  missingFnErrors.length,
+  1,
+  'expected a single "function not found" violation when autoBuildItem is absent',
+)
+assert.ok(missingFnErrors[0]!.includes('autoBuildItem'))
+
+console.log(
+  'Model Builder auto-build approval-race guard checker verified: flags ' +
+    'unconditional approveStage calls after an await, flags a status guard ' +
+    "missing its else { return 'failed' } fallback, clears the fixed " +
+    'shape, and flags autoBuildItem being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderAutoBuildApprovalRaceGuard.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildApprovalRaceGuard.ts
@@ -1,0 +1,142 @@
+// /utils/scripts/verifyModelBuilderAutoBuildApprovalRaceGuard.ts
+//
+// Regression guard (model-builder/t-029) -- autoBuildItem()'s
+// FIELDS_AND_PROMPTS and GENERATE_ASSETS blocks each await a draft/generate
+// call and then call approveStage(itemId, 'KEY') unconditionally right
+// after. approveStage() (unlike finishGenerateAssets/finishCommit) has no
+// in-flight check of its own -- it unconditionally overwrites
+// item.stages[stageKey] to 'approved'. The Edit buttons in
+// model-builder-item-panel.vue are gated only by `:disabled="isCommitting"`,
+// not isAutoBuilding, so they stay clickable throughout an auto-build run: a
+// concurrent Edit click on an earlier stage calls reopenStage(), which
+// markDownstreamStale()s every stage after it, including whichever one
+// autoBuildItem is mid-await on. When that await resolves, its boolean
+// result (drafted / generated) only reflects whether the underlying network
+// call succeeded -- not whether the stage is still the same 'ready' state
+// autoBuildItem itself put it in. Before this fix, the unconditional
+// approveStage() call clobbered a correctly-set 'stale' back to 'approved',
+// silently re-approving unreviewed content and unlocking COMMIT on it.
+//
+// verifyModelBuilderCompletionGate.ts already guards this bug *class* for
+// direct `item.stages.KEY = ...` assignments after an await, but
+// approveStage() writes via bracket notation (`item.stages[stageKey] = ...`)
+// inside its own synchronous function body -- neither the direct-assignment
+// regex nor the isAsync-only function scan in that checker reaches a call
+// site like `approveStage(itemId, 'GENERATE_ASSETS')`. This is a narrower,
+// deliberately explicit companion check for exactly those two call sites,
+// mirroring verifyModelBuilderAutoBuildDraftGate.ts's preference for a
+// literal textual anchor over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'autoBuildItem'
+
+const APPROVAL_GATES = ['FIELDS_AND_PROMPTS', 'GENERATE_ASSETS'] as const
+
+// Checks the fix's exact shape against the full source text of a file
+// containing an `autoBuildItem`-named async function. Exported (rather than
+// only exercised via main()) so the self-test below can run it against
+// synthetic buggy/fixed fixtures without touching the real store file.
+export function checkAutoBuildApprovalRaceGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find an async function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  for (const stageKey of APPROVAL_GATES) {
+    const approvePattern = new RegExp(`approveStage\\(itemId, '${stageKey}'\\)`)
+    const approveMatch = approvePattern.exec(fn.body)
+    if (!approveMatch) {
+      errors.push(
+        `${FN_NAME}() no longer calls approveStage(itemId, '${stageKey}') ` +
+          "-- this guard's anchor point has moved.",
+      )
+      continue
+    }
+
+    // The status check must immediately gate the approveStage() call --
+    // require it as the `if` condition wrapping the call (allowing a
+    // reasonable amount of intervening whitespace/comment, but not an
+    // unrelated block of logic) rather than accepting a check anywhere
+    // earlier in the function body.
+    const before = fn.body.slice(0, approveMatch.index)
+    const guardPattern = new RegExp(
+      `if \\(item\\.stages\\.${stageKey}\\.status === 'ready'\\)\\s*\\{\\s*$`,
+    )
+    if (!guardPattern.test(before)) {
+      errors.push(
+        `${FN_NAME}()'s approveStage(itemId, '${stageKey}') call is not ` +
+          `immediately wrapped in ` +
+          `\`if (item.stages.${stageKey}.status === 'ready') { ... }\`. ` +
+          'Without that guard, a concurrent Edit click on an earlier stage ' +
+          '(clickable throughout auto-build -- the Edit buttons in ' +
+          'model-builder-item-panel.vue are gated only by isCommitting, ' +
+          'not isAutoBuilding) can markDownstreamStale() this stage while ' +
+          'the preceding await is pending. approveStage() has no in-flight ' +
+          'check of its own, so it would silently clobber the correctly-set ' +
+          "'stale' status back to 'approved', re-approving unreviewed " +
+          'content and unlocking COMMIT on it.',
+      )
+      continue
+    }
+
+    // The non-'ready' branch must not fall through to approveStage() --
+    // require an `else { return 'failed' }` (or equivalent bail) rather
+    // than just trusting the guard's braces to be closed correctly.
+    const approveEnd = approveMatch.index + approveMatch[0].length
+    const afterApprove = fn.body.slice(approveEnd, approveEnd + 200)
+    if (!/^\s*\}\s*else\s*\{\s*return 'failed'/.test(afterApprove)) {
+      errors.push(
+        `${FN_NAME}()'s '${stageKey}' approval guard does not fall back to ` +
+          `\`else { return 'failed' }\` when the stage is not 'ready'. ` +
+          'Without an explicit bail, a stage staled by a concurrent edit ' +
+          'would silently stay stale/unapproved with no signal to the ' +
+          'caller (batchAutoBuild/autoBuildRun) that this item needs ' +
+          're-review.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkAutoBuildApprovalRaceGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder auto-build approval-race guard contract failed for ' +
+        `${FN_NAME}() in modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder auto-build approval-race guard contract passed: ' +
+      `${FN_NAME}() only approves FIELDS_AND_PROMPTS/GENERATE_ASSETS after ` +
+      'confirming the stage is still ready, not concurrently staled.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
model-builder/t-029 (recurring): Polish and upgrade Model Builder front-end surface (kind: software)

### What changed / what I produced
- `autoBuildItem()`'s `FIELDS_AND_PROMPTS` and `GENERATE_ASSETS` blocks each await a draft/generate call, then called `approveStage()` unconditionally right after. `approveStage()` (unlike `finishGenerateAssets`/`finishCommit`) has no in-flight check of its own -- it unconditionally overwrites the stage's status to `'approved'`.
- The Edit buttons in `model-builder-item-panel.vue` are gated only by `:disabled="isCommitting"`, not `isAutoBuilding`, so they stay clickable throughout an auto-build run. A concurrent Edit click on an earlier stage calls `reopenStage()`, which `markDownstreamStale()`s every later stage -- including whichever one `autoBuildItem` is mid-await on. When that await resolves, its boolean result (`drafted`/`generated`) only reflects whether the underlying network call succeeded, not whether the stage is still the `'ready'` state auto-build put it in. The unconditional `approveStage()` call then clobbered a correctly-set `'stale'` status back to `'approved'`, silently re-approving unreviewed content and unlocking COMMIT on it.
- Fixed by checking the stage is still `'ready'` immediately before approving, bailing with `'failed'` otherwise.
- Added `utils/scripts/verifyModelBuilderAutoBuildApprovalRaceGuard.ts` (+ self-test), wired into `package.json`/`contract-tests.yml` -- a narrow companion to `verifyModelBuilderCompletionGate.ts`, which guards this same bug class for direct `item.stages.KEY` writes but doesn't reach an indirect `approveStage()` call site (bracket-notation write inside a synchronous function).

### How I verified
- Read `stores/modelBuilderStore.ts` (`autoBuildItem`, `approveStage`, `reopenStage`, `markDownstreamStale`, `finishGenerateAssets`) and `model-builder-item-panel.vue`'s Edit button bindings directly to confirm the race before editing.
- New guard self-test passes; new guard fails against the pre-fix code (`git stash`) and passes against the fixed code.
- All 19 pre-existing `test:model-builder-*` guard + self-test scripts pass.
- `eslint` clean on all changed/new files (2 pre-existing `no-empty` errors in `modelBuilderStore.ts`, confirmed via `git stash` to predate this change, unrelated to this diff).
- `prettier --check` clean on the 2 new files (pre-existing drift on `modelBuilderStore.ts`/`package.json` confirmed via `git stash` to predate this change).
- `vue-tsc --noEmit` clean repo-wide.
- `npm run test:workflow-paths` green.
- `git status --porcelain`: exactly 5 files.

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
`verifyModelBuilderCompletionGate.ts`'s scanner only catches direct `item.stages.KEY = ...` assignments after an await in an async function -- it can't see a write that happens indirectly through a synchronous helper call (`approveStage`, bracket notation). Worth considering whether that scanner should also flag *any* call to `approveStage`/`rejectStage` after an await with no adjacent status guard, generically, instead of relying on a new narrow guard file per call site as this cycle's fix (and `verifyModelBuilderAutoBuildDraftGate.ts` before it) had to add.

### Notes for reviewer
Found via an Explore subagent given an explicit exclusion list of every model-builder bug class already fixed today and directed to read the actual store/component code rather than trust a summary.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhyUNjTLndBBqS58ChwNJX)_