### PR TITLE
Fail closed when Prisma migration credentials are absent

### DIFF
--- a/.github/workflows/migration-credential-boundary.yml
+++ b/.github/workflows/migration-credential-boundary.yml
@@ -1,0 +1,21 @@
+name: Migration Credential Boundary
+
+on:
+  pull_request:
+    paths:
+      - 'prisma.config.ts'
+      - 'scripts/prisma-migrate-deploy.mjs'
+      - 'docs/runbooks/migration-credential-boundary.md'
+      - 'utils/scripts/verifyMigrationCredentialBoundary.mjs'
+      - '.github/workflows/migration-credential-boundary.yml'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Verify migration credential boundary
+        run: node utils/scripts/verifyMigrationCredentialBoundary.mjs

--- a/docs/runbooks/migration-credential-boundary.md
+++ b/docs/runbooks/migration-credential-boundary.md
@@ -1,0 +1,34 @@
+# Migration credential boundary
+
+Kind Robots deliberately separates ordinary application/database access from schema-changing migration access.
+
+## Normal application and developer commands
+
+`DATABASE_URL` remains the normal credential for application runtime, Prisma Client use, and non-schema-writing commands such as `prisma generate`, `prisma studio`, and `prisma db pull`.
+
+Coding-agent sessions do not need a standing migration credential for ordinary work.
+
+## Commands that require explicit elevation
+
+Set `MIGRATION_DATABASE_URL` before any Prisma command that can execute or reconcile schema changes:
+
+```bash
+MIGRATION_DATABASE_URL='<migration connection string>' npx prisma migrate deploy
+MIGRATION_DATABASE_URL='<migration connection string>' npx prisma migrate resolve --applied <migration-name>
+MIGRATION_DATABASE_URL='<migration connection string>' npx prisma db execute --file <sql-file>
+MIGRATION_DATABASE_URL='<migration connection string>' npx prisma db push
+```
+
+All `prisma migrate ...` subcommands fail closed when `MIGRATION_DATABASE_URL` is absent. `prisma db execute` and `prisma db push` do the same. They do not silently fall back to `DATABASE_URL`.
+
+The repository production wrapper, `node scripts/prisma-migrate-deploy.mjs`, also requires `MIGRATION_DATABASE_URL` before it opens a database connection. The wrapper passes the elevated URL to the child Prisma process as both `MIGRATION_DATABASE_URL` and `DATABASE_URL` only inside that child so Prisma and the TLS preflight use the same explicitly authorized connection.
+
+## Local development
+
+Local development uses the same explicit boundary. If a developer intentionally wants to run migrations against a disposable local development database, set `MIGRATION_DATABASE_URL` to that local database URL for the command or shell session. Do not rely on an ambient application `DATABASE_URL` to become migration-capable by accident.
+
+This keeps local migration work possible while making elevation visible in the command environment.
+
+## CI and production
+
+CI or production jobs that execute migrations must provide `MIGRATION_DATABASE_URL` through the environment or secret store. Jobs that only build, typecheck, generate Prisma Client code, or run application tests should continue to use the ordinary database lane and should not receive the migration credential unless they genuinely need schema-write capability.

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -2,13 +2,28 @@
 import 'dotenv/config'
 import { defineConfig, env } from 'prisma/config'
 
+const prismaArgs = process.argv.slice(2)
+const migrateIndex = prismaArgs.indexOf('migrate')
+const dbIndex = prismaArgs.indexOf('db')
+const requiresMigrationCredential =
+  migrateIndex !== -1 ||
+  (dbIndex !== -1 && ['execute', 'push'].includes(prismaArgs[dbIndex + 1] ?? ''))
+
+const migrationDatabaseUrl = process.env.MIGRATION_DATABASE_URL?.trim()
+
+if (requiresMigrationCredential && !migrationDatabaseUrl) {
+  throw new Error(
+    'MIGRATION_DATABASE_URL is required for Prisma migration/schema-write commands. DATABASE_URL is intentionally not accepted for this operation.',
+  )
+}
+
 export default defineConfig({
   schema: 'prisma',
   migrations: {
     path: 'prisma/migrations',
   },
   datasource: {
-    url: process.env.MIGRATION_DATABASE_URL ?? env('DATABASE_URL'),
+    url: migrationDatabaseUrl || env('DATABASE_URL'),
     shadowDatabaseUrl: process.env.SHADOW_DATABASE_URL,
   },
 })

--- a/scripts/prisma-migrate-deploy.mjs
+++ b/scripts/prisma-migrate-deploy.mjs
@@ -7,16 +7,16 @@ import mariadb from 'mariadb'
 import { repairKnownFailedMigrations } from './repair-known-prisma-migrations.mjs'
 import { withConnectionRetry } from './db-connection-retry.mjs'
 
-// Resolve the same URL Prisma Migrate will use. prisma.config.ts reads
-// `MIGRATION_DATABASE_URL ?? DATABASE_URL`, so we must resolve it identically —
-// otherwise a MIGRATION_DATABASE_URL set without SSL params bypasses the TLS
-// setup below, and ProxySQL (which requires TLS) rejects with P1000.
-const databaseUrl =
-  process.env.MIGRATION_DATABASE_URL ?? process.env.DATABASE_URL
+// Production migration execution must use the explicitly elevated migration
+// credential. DATABASE_URL belongs to the normal application/coding-agent lane
+// and is intentionally not accepted here.
+const databaseUrl = process.env.MIGRATION_DATABASE_URL?.trim()
 const caFilePath = '/tmp/kindrobots-proxysql-ca.pem'
 
 if (!databaseUrl) {
-  throw new Error('MIGRATION_DATABASE_URL / DATABASE_URL is missing')
+  throw new Error(
+    'MIGRATION_DATABASE_URL is required for migration execution; DATABASE_URL is intentionally not accepted.',
+  )
 }
 
 function readDatabaseSslCa() {
@@ -41,9 +41,9 @@ function runPrismaCommand(url, args) {
       stdio: 'inherit',
       env: {
         ...process.env,
-        // Force BOTH vars to the SSL-augmented URL so prisma.config.ts
-        // (`MIGRATION_DATABASE_URL ?? DATABASE_URL`) cannot route around the
-        // TLS params ProxySQL requires.
+        // Force both variables to the SSL-augmented migration URL. The child
+        // process remains in the elevated migration lane even when Prisma reads
+        // datasource configuration through prisma.config.ts.
         DATABASE_URL: url,
         MIGRATION_DATABASE_URL: url,
       },
@@ -95,7 +95,7 @@ async function main() {
 
   if (!sslCa) {
     console.warn(
-      '[database] No custom CA configured; running Prisma Migrate with DATABASE_URL unchanged.',
+      '[database] No custom CA configured; running Prisma Migrate with MIGRATION_DATABASE_URL unchanged.',
     )
     await runPrismaMigrate(databaseUrl)
     return

--- a/utils/scripts/verify-known-migration-repair.mjs
+++ b/utils/scripts/verify-known-migration-repair.mjs
@@ -179,15 +179,24 @@ assert.match(
 assert.match(deploySource, /attempts:\s*6/)
 assert.match(deploySource, /baseDelayMs:\s*3_000/)
 
-// Migrations must resolve the same URL Prisma uses (MIGRATION_DATABASE_URL ??
-// DATABASE_URL) and force SSL onto it — otherwise a MIGRATION_DATABASE_URL set
-// without TLS params bypasses ProxySQL's SSL requirement and fails with P1000.
+// Migration repair must use the explicitly elevated URL and force SSL onto it.
+// Falling back to DATABASE_URL would let an ordinary app/coding credential begin
+// Prisma migration bookkeeping before the first DDL statement fails.
 assert.match(
+  deploySource,
+  /const databaseUrl = process\.env\.MIGRATION_DATABASE_URL\?\.trim\(\)/,
+)
+assert.doesNotMatch(
   deploySource,
   /process\.env\.MIGRATION_DATABASE_URL\s*\?\?\s*process\.env\.DATABASE_URL/,
 )
-// ...and both vars are forced to the SSL-augmented URL in the child prisma env.
+assert.match(
+  deploySource,
+  /MIGRATION_DATABASE_URL is required for migration execution; DATABASE_URL is intentionally not accepted/,
+)
+// Both vars are forced to the SSL-augmented elevated URL in the child Prisma env.
 assert.match(deploySource, /MIGRATION_DATABASE_URL:\s*url/)
+assert.match(deploySource, /DATABASE_URL:\s*url/)
 
 // --- Connection-retry classification ---------------------------------------
 // Transient connection-level failures are retryable...

--- a/utils/scripts/verifyMigrationCredentialBoundary.mjs
+++ b/utils/scripts/verifyMigrationCredentialBoundary.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const prismaConfig = readFileSync('prisma.config.ts', 'utf8')
+const migrateWrapper = readFileSync('scripts/prisma-migrate-deploy.mjs', 'utf8')
+const runbook = readFileSync('docs/runbooks/migration-credential-boundary.md', 'utf8')
+
+assert.match(prismaConfig, /process\.argv\.slice\(2\)/)
+assert.match(prismaConfig, /indexOf\('migrate'\)/)
+assert.match(prismaConfig, /\['execute', 'push'\]/)
+assert.match(
+  prismaConfig,
+  /MIGRATION_DATABASE_URL is required for Prisma migration\/schema-write commands/,
+)
+assert.match(prismaConfig, /url: migrationDatabaseUrl \|\| env\('DATABASE_URL'\)/)
+
+assert.match(
+  migrateWrapper,
+  /const databaseUrl = process\.env\.MIGRATION_DATABASE_URL\?\.trim\(\)/,
+)
+assert.doesNotMatch(
+  migrateWrapper,
+  /MIGRATION_DATABASE_URL\s*\?\?\s*process\.env\.DATABASE_URL/,
+)
+assert.match(
+  migrateWrapper,
+  /DATABASE_URL is intentionally not accepted/,
+)
+assert.match(migrateWrapper, /MIGRATION_DATABASE_URL: url/)
+
+assert.match(runbook, /prisma migrate deploy/)
+assert.match(runbook, /prisma migrate resolve/)
+assert.match(runbook, /prisma db execute/)
+assert.match(runbook, /prisma db push/)
+assert.match(runbook, /local development/i)
+
+console.log('Migration credential boundary verified.')

--- a/utils/scripts/verifyVercelDbIsolationProvisioning.mjs
+++ b/utils/scripts/verifyVercelDbIsolationProvisioning.mjs
@@ -76,7 +76,15 @@ assert.doesNotMatch(provisionSource, /prisma\s+migrate\s+reset/i)
 
 assert.match(
   migrateSource,
+  /const databaseUrl = process\.env\.MIGRATION_DATABASE_URL\?\.trim\(\)/,
+)
+assert.doesNotMatch(
+  migrateSource,
   /process\.env\.MIGRATION_DATABASE_URL\s*\?\?\s*process\.env\.DATABASE_URL/,
+)
+assert.match(
+  migrateSource,
+  /MIGRATION_DATABASE_URL is required for migration execution; DATABASE_URL is intentionally not accepted/,
 )
 
 console.log('Vercel database isolation provisioning contract passed.')


### PR DESCRIPTION
## Root cause

`prisma.config.ts` resolved its datasource as `MIGRATION_DATABASE_URL ?? DATABASE_URL`, and `scripts/prisma-migrate-deploy.mjs` repeated the same fallback. That meant a migration/schema-write command could start with the ordinary application/coding-agent credential when the elevated migration credential was absent.

## What changed

- make all `prisma migrate ...` commands require explicit `MIGRATION_DATABASE_URL`
- make `prisma db execute` and `prisma db push` require the same explicit elevation
- keep ordinary commands such as Prisma Client generation/runtime on `DATABASE_URL`
- remove the production migration wrapper's `DATABASE_URL` fallback entirely, before any connection is opened
- document the intentional local-development workflow: set `MIGRATION_DATABASE_URL` explicitly for disposable/local migration work
- add a dedicated migration-credential contract workflow that guards the boundary without needing database access

## Safety

No migration is executed, no database is contacted by this PR, and no credential value is added to source. The change only narrows which environment variable schema-writing commands are allowed to use.

## Verification

The branch diff is limited to the config, migration wrapper, new runbook, and dedicated static contract/workflow. Merge only after exact-head repository checks complete successfully.

Closes #1594