### PR TITLE
fix(model-builder): resumeRun() must not silently resume a CANCELLED run

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -341,6 +341,12 @@ jobs:
       - name: Model Builder auto-build approval-race guard contract
         run: npm run test:model-builder-auto-build-approval-race-guard
 
+      - name: Model Builder resume-cancelled-run guard checker self-test
+        run: npm run test:model-builder-resume-cancelled-run-guard-selftest
+
+      - name: Model Builder resume-cancelled-run guard contract
+        run: npm run test:model-builder-resume-cancelled-run-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -181,6 +181,8 @@
     "test:model-builder-asset-only-approval-guard": "tsx utils/scripts/verifyModelBuilderAssetOnlyApprovalGuard.ts",
     "test:model-builder-auto-build-approval-race-guard-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildApprovalRaceGuard.test.ts",
     "test:model-builder-auto-build-approval-race-guard": "tsx utils/scripts/verifyModelBuilderAutoBuildApprovalRaceGuard.ts",
+    "test:model-builder-resume-cancelled-run-guard-selftest": "tsx utils/scripts/verifyModelBuilderResumeCancelledRunGuard.test.ts",
+    "test:model-builder-resume-cancelled-run-guard": "tsx utils/scripts/verifyModelBuilderResumeCancelledRunGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -169,6 +169,7 @@ interface ServerItem {
 interface ServerRun {
   id: number
   createdAt: string
+  status?: string
   sourceType: string
   sourceId: number
   sourceLabel: string | null
@@ -1782,7 +1783,19 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         const response = await performFetch<ServerRun>(
           `/api/model-builder/runs/${remembered}`,
         )
-        if (response.success && response.data) data = response.data
+        if (
+          response.success &&
+          response.data &&
+          response.data.status !== 'CANCELLED'
+        ) {
+          data = response.data
+        } else if (response.success && response.data) {
+          // The remembered run exists but was cancelled (e.g. cancelled from
+          // another tab/run, so this tab's shared localStorage key was never
+          // cleared by cancelRun's own-run check). Stop remembering it so we
+          // don't keep resuming a dead run into a read-only 409 trap.
+          safeRemove(runIdKey)
+        }
       }
 
       if (!data) {

--- a/utils/scripts/verifyModelBuilderResumeCancelledRunGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderResumeCancelledRunGuard.test.ts
@@ -1,0 +1,136 @@
+// /utils/scripts/verifyModelBuilderResumeCancelledRunGuard.test.ts
+//
+// Regression test for checkResumeCancelledRunGuard() in
+// verifyModelBuilderResumeCancelledRunGuard.ts (model-builder/t-029).
+// Exercises the real check against synthetic store-shaped fixtures covering:
+// the pre-fix shape (remembered-id branch accepts any successful response,
+// no status check, no forgetting -- the exact bug found by manual
+// read-through), and the fixed shape (status checked, cancelled id forgotten
+// via safeRemove).
+import assert from 'node:assert/strict'
+
+import { checkResumeCancelledRunGuard } from './verifyModelBuilderResumeCancelledRunGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function resumeRun(): Promise<void> {
+    try {
+      const remembered = safeGet(runIdKey)
+      let data: ServerRun | undefined
+
+      if (remembered) {
+        const response = await performFetch<ServerRun>(
+          \`/api/model-builder/runs/\${remembered}\`,
+        )
+        if (response.success && response.data) data = response.data
+      }
+
+      if (!data) {
+        const response = await performFetch<ServerRun[]>(
+          '/api/model-builder/runs?take=1',
+        )
+        if (response.success && Array.isArray(response.data) && response.data.length) {
+          data = response.data[0]
+        }
+      }
+
+      if (data) {
+        state.run = adaptRun(data)
+        state.sourceType = data.sourceType as SourceTypeKey
+        state.recipeKey = data.recipeKey as RecipeKey
+        state.step = 'run'
+        setActiveRunId(data.id)
+      }
+    } catch {
+      // Not signed in, or no runs yet -- start fresh at the source picker.
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function resumeRun(): Promise<void> {
+    try {
+      const remembered = safeGet(runIdKey)
+      let data: ServerRun | undefined
+
+      if (remembered) {
+        const response = await performFetch<ServerRun>(
+          \`/api/model-builder/runs/\${remembered}\`,
+        )
+        if (
+          response.success &&
+          response.data &&
+          response.data.status !== 'CANCELLED'
+        ) {
+          data = response.data
+        } else if (response.success && response.data) {
+          safeRemove(runIdKey)
+        }
+      }
+
+      if (!data) {
+        const response = await performFetch<ServerRun[]>(
+          '/api/model-builder/runs?take=1',
+        )
+        if (response.success && Array.isArray(response.data) && response.data.length) {
+          data = response.data[0]
+        }
+      }
+
+      if (data) {
+        state.run = adaptRun(data)
+        state.sourceType = data.sourceType as SourceTypeKey
+        state.recipeKey = data.recipeKey as RecipeKey
+        state.step = 'run'
+        setActiveRunId(data.id)
+      }
+    } catch {
+      // Not signed in, or no runs yet -- start fresh at the source picker.
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkResumeCancelledRunGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  2,
+  `expected the pre-fix shape (missing status check AND missing ` +
+    `safeRemove call) to raise 2 errors, got ${buggyErrors.length}: ` +
+    `${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes("status !== 'CANCELLED'")),
+  'expected a violation for the missing status check',
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes('safeRemove(runIdKey)')),
+  'expected a violation for the missing safeRemove call',
+)
+
+const fixedErrors = checkResumeCancelledRunGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingFnErrors = checkResumeCancelledRunGuard(MISSING_FIXTURE)
+assert.equal(
+  missingFnErrors.length,
+  1,
+  'expected a single "function not found" violation when resumeRun is absent',
+)
+assert.ok(missingFnErrors[0]!.includes('resumeRun'))
+
+console.log(
+  'Model Builder resume-cancelled-run guard checker verified: flags the ' +
+    'pre-fix shape (missing status check and missing safeRemove-on-cancelled ' +
+    'call), clears the fixed shape, and flags resumeRun being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderResumeCancelledRunGuard.ts
+++ b/utils/scripts/verifyModelBuilderResumeCancelledRunGuard.ts
@@ -1,0 +1,134 @@
+// /utils/scripts/verifyModelBuilderResumeCancelledRunGuard.ts
+//
+// Regression guard (model-builder/t-029, kaizen) -- resumeRun()'s own doc
+// comment claims it resumes "the remembered run id if still present, else
+// the newest non-cancelled run for this user." The "non-cancelled" part was
+// only ever true on the *fallback* path (`GET /api/model-builder/runs?take=1`,
+// which excludes status: CANCELLED server-side by default) -- the
+// remembered-id path (`GET /api/model-builder/runs/:id`) has no status
+// filter at all and returns any run the caller owns, cancelled or not.
+// `modelBuilder:runId` is a single origin-wide localStorage key, and
+// cancelRun() only clears it when the run being cancelled is *this tab's*
+// currently active run (`if (state.run?.id === runId) resetRun()`) -- so
+// cancelling a different run than the one currently open (e.g. from the
+// Run History panel) can leave a now-CANCELLED id sitting in that shared
+// key. Before this fix, a later resumeRun() (e.g. on page reload) would
+// silently resume that dead run: the UI shows it as a normal, fully
+// interactive run with no cancelled indicator anywhere, every stage-mutating
+// action optimistically updates local state, and the background PATCH/POST
+// then 409s server-side on assertRunWritable's "this build run was
+// cancelled" check -- leaving the UI durably out of sync with the server for
+// the rest of the session.
+//
+// Fixed by checking `response.data.status !== 'CANCELLED'` before accepting
+// the remembered-id fetch's result, and forgetting the id (`safeRemove`) when
+// it turns out to be cancelled.
+//
+// This asserts the textual shape of that fix stays in place: resumeRun's
+// `if (remembered)` branch checks `.status !== 'CANCELLED'` on the
+// remembered-id response before assigning `data`, and the branch calls
+// `safeRemove(runIdKey)` for a run that fails that check. Deliberately
+// scoped to this one function/bug, mirroring
+// verifyModelBuilderCancelledRunGuard.ts's own narrow textual check over a
+// general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'resumeRun'
+const REMEMBERED_BRANCH = 'if (remembered)'
+const STATUS_CHECK = "status !== 'CANCELLED'"
+const FORGET_CALL = 'safeRemove(runIdKey)'
+const FALLBACK_BRANCH = 'if (!data)'
+
+// Checks the fix's exact shape against the full source text of a file
+// containing a `resumeRun`-named async function. Exported (rather than only
+// exercised via main()) so the self-test below can run it against synthetic
+// buggy/fixed fixtures without touching the real store file.
+export function checkResumeCancelledRunGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find an async function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  const rememberedIndex = fn.body.indexOf(REMEMBERED_BRANCH)
+  if (rememberedIndex === -1) {
+    errors.push(
+      `${FN_NAME}() no longer has an ${REMEMBERED_BRANCH} branch -- this ` +
+        'guard assumes the remembered-run-id fetch is still a distinct ' +
+        'code path from the newest-non-cancelled-run fallback.',
+    )
+    return errors
+  }
+
+  const fallbackIndex = fn.body.indexOf(FALLBACK_BRANCH, rememberedIndex)
+  const rememberedBranchEnd =
+    fallbackIndex === -1 ? fn.body.length : fallbackIndex
+
+  const statusCheckIndex = fn.body.indexOf(STATUS_CHECK, rememberedIndex)
+  if (statusCheckIndex === -1 || statusCheckIndex >= rememberedBranchEnd) {
+    errors.push(
+      `${FN_NAME}()'s ${REMEMBERED_BRANCH} branch does not check ` +
+        `\`${STATUS_CHECK}\` on the fetched run before accepting it. ` +
+        'GET /api/model-builder/runs/:id has no status filter, unlike the ' +
+        'take=1 fallback -- without this check, a cancelled run left in ' +
+        'the shared modelBuilder:runId localStorage key (e.g. cancelled ' +
+        "from a different tab's currently-active run) gets silently " +
+        'resumed into a fully-interactive UI whose every mutation then ' +
+        "409s server-side on assertRunWritable's cancelled check.",
+    )
+  }
+
+  const forgetCallIndex = fn.body.indexOf(FORGET_CALL, rememberedIndex)
+  if (forgetCallIndex === -1 || forgetCallIndex >= rememberedBranchEnd) {
+    errors.push(
+      `${FN_NAME}()'s ${REMEMBERED_BRANCH} branch does not call ` +
+        `${FORGET_CALL} when the remembered run turns out to be ` +
+        'cancelled -- without this, the same dead id stays remembered and ' +
+        'every future resumeRun() call keeps re-fetching and re-rejecting ' +
+        'it instead of falling through to a live run.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkResumeCancelledRunGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder resume-cancelled-run guard contract failed for ' +
+        `${FN_NAME}() in modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder resume-cancelled-run guard contract passed: ' +
+      `${FN_NAME}()'s remembered-id branch rejects and forgets a ` +
+      'cancelled run instead of silently resuming it.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
model-builder/t-029: Polish and upgrade Model Builder front-end surface (kind: software)

### What changed / what I produced
- `resumeRun()`'s remembered-run-id branch (`stores/modelBuilderStore.ts`) now rejects a fetched run whose `status === 'CANCELLED'` instead of accepting any successful response, and forgets the id (`safeRemove(runIdKey)`) when that happens.
- Added `status?: string` to the local `ServerRun` type so the check is typed (the server payload already includes it; the client type just didn't declare it).
- Added `utils/scripts/verifyModelBuilderResumeCancelledRunGuard.ts` (+ `.test.ts` selftest), wired into `package.json` and `contract-tests.yml`, matching this project's one-guard-per-fix convention.

### Root cause
`resumeRun()`'s own doc comment claims it resumes "the remembered run id if still present, else the newest non-cancelled run" — but that exclusion only ever happened on the *fallback* path (`GET /api/model-builder/runs?take=1`, which excludes `status: CANCELLED` server-side by default per `server/api/model-builder/runs/index.get.ts`). The remembered-id path (`GET /api/model-builder/runs/:id`) has no status filter at all — it returns any run the caller owns, cancelled or not.

`modelBuilder:runId` is a single origin-wide `localStorage` key, and `cancelRun()` only clears it when the run being cancelled is *this tab's* currently-active run (`if (state.run?.id === runId) resetRun()`). Cancelling a *different* run (e.g. from the Run History panel while another run is open) leaves a now-`CANCELLED` id sitting in that shared key untouched. A later `resumeRun()` — e.g. on page reload — then silently resumes the dead run: the UI shows it as a normal, fully interactive run with no cancelled indicator anywhere, every stage-mutating action optimistically updates local state, and the background PATCH/POST then 409s server-side on `assertRunWritable`'s "this build run was cancelled" check — leaving the UI durably out of sync with the server for the rest of the session.

### How I verified
- New guard selftest + contract both pass (`npm run test:model-builder-resume-cancelled-run-guard-selftest`, `npm run test:model-builder-resume-cancelled-run-guard`).
- All 21 existing `test:model-builder-*` guard/selftest pairs (42 scripts total) still pass.
- `npx vue-tsc --noEmit`: 0 errors repo-wide.
- `npx eslint` clean on all changed/new files (2 pre-existing `no-empty` errors in `modelBuilderStore.ts` at unrelated lines confirmed via `git stash` to predate this change).
- `npx prettier --check` clean on the new files (pre-existing drift on `modelBuilderStore.ts`/`package.json` confirmed via `git stash` to predate this change).
- `npm run test:workflow-paths`: passed (64 workflow files, 662 path refs).
- `verifyCaptureGroupGuards.ts origin/main`: passed (0 new/changed unguarded capture-group call sites).
- `git diff --stat`: exactly 5 files.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
`cancelRun()` only clears `modelBuilder:runId` when the cancelled run is this tab's own `state.run` — it could optionally also clear the shared key whenever it currently equals the cancelled run's id (regardless of which run is locally active), closing the race at the write site too rather than relying solely on `resumeRun()`'s read-side check. Left out of this PR to keep the fix narrowly scoped to one bug/one guard, per project convention.

### Notes for reviewer
Found via an Explore subagent given an explicit exclusion list of every model-builder/t-029 bug class already fixed earlier today (cross-field/cross-item draft-clobber, textarea-blur clobber, stale-asset approval, async-finalization approval, store-side approved-asset overwrite, aria-pressed, batch-editor `:key` leak, auto-build approval race, ASSET_ONLY generation-kind gating, source-picker thumbnail a11y) and a directive to read the store/component/server code directly rather than trust a summary.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SB9vhLuCSsX63gFk3g3g2R)_