### PR TITLE
Restore preserved abandonware tree

### DIFF
--- a/components/abandonware/achievements/locked-achievements.vue
+++ b/components/abandonware/achievements/locked-achievements.vue
@@ -1,0 +1,52 @@
+<!-- /components/content/achievements/locked-achievements.vue -->
+<template>
+  <div>
+    <h2 class="text-xl font-bold mb-4">Locked Achievements</h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div
+        v-for="achievement in lockedAchievements"
+        :key="achievement.id"
+        class="card bg-base-300 rounded-2xl p-4 transition duration-300 ease-in-out relative"
+      >
+        <div class="text-center">
+          <!-- Achievement Icon with fallback -->
+          <Icon
+            :name="achievement.icon ?? 'default-icon'"
+            class="text-6xl mb-2"
+          />
+          <!-- Achievement Label -->
+          <div class="text-xl font-bold text-gray-700">
+            {{ achievement.label }}
+          </div>
+          <!-- Subtle Hint -->
+          <div v-if="achievement.subtleHint" class="text-sm text-gray-500">
+            {{ achievement.subtleHint }}
+          </div>
+          <!-- Question Mark Icon for Directions -->
+          <div class="absolute top-2 right-2 z-6">
+            <nuxt-link :to="achievement.pageHint || '#'">
+              <Icon name="kind-icon:question" class="text-blue-500 text-2xl" />
+            </nuxt-link>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useAchievementStore } from '@/stores/achievementStore'
+import { useUserStore } from '@/stores/userStore'
+
+const achievementStore = useAchievementStore()
+const userStore = useUserStore()
+const achievements = computed(() => achievementStore.achievements)
+const userAchievements = computed(() => userStore.achievements)
+
+const lockedAchievements = computed(() => {
+  return achievements.value.filter(
+    (achievement: { id: any }) => !userAchievements.value?.includes(achievement.id),
+  )
+})
+</script>

--- a/components/abandonware/art/art-creator.vue
+++ b/components/abandonware/art/art-creator.vue
@@ -1,0 +1,300 @@
+<!-- /components/art/art-creator.vue -->
+<template>
+  <section class="flex w-full flex-col gap-3">
+    <art-facet-selector
+      v-model="artFacetDraft.selectedIds"
+      label="Creative Facets"
+      :compact="true"
+    />
+
+    <div class="rounded-2xl border border-base-300 bg-base-200 p-4">
+      <div
+        class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+      >
+        <div class="flex min-w-0 items-start gap-3">
+          <span
+            class="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-primary/15 text-primary"
+          >
+            <icon :name="displayIcon" class="h-6 w-6" />
+          </span>
+
+          <div class="min-w-0">
+            <p class="truncate text-sm font-black text-primary">
+              {{ displayTitle }}
+            </p>
+            <p class="mt-1 text-xs font-semibold text-base-content/55">
+              {{ statusLabel }}
+            </p>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          class="btn rounded-2xl font-black"
+          :class="canGenerate ? 'btn-primary' : 'btn-disabled'"
+          :disabled="!canGenerate"
+          @click="generateImage"
+        >
+          <span v-if="artStore.isGenerating" class="flex items-center gap-2">
+            <span class="loading loading-dots loading-sm" />
+            Generating…
+          </span>
+
+          <span v-else class="flex items-center gap-2">
+            <icon name="kind-icon:sparkles" class="h-5 w-5" />
+            Generate
+          </span>
+        </button>
+      </div>
+
+      <div
+        v-if="promptPreview"
+        class="mt-3 kr-panel-flat p-3 text-xs leading-relaxed text-base-content/70"
+      >
+        {{ promptPreview }}
+      </div>
+
+      <div
+        v-if="message"
+        class="mt-3 flex items-start gap-2 rounded-2xl border p-3 text-sm font-semibold"
+        :class="
+          messageTone === 'error'
+            ? 'border-error/40 bg-error/10 text-error'
+            : 'border-success/40 bg-success/10 text-success'
+        "
+      >
+        <icon
+          :name="messageTone === 'error' ? 'kind-icon:alert' : 'kind-icon:check'"
+          class="mt-0.5 h-4 w-4 shrink-0"
+        />
+        <span>{{ message }}</span>
+      </div>
+    </div>
+
+    <Transition name="art-creator-reveal">
+      <div
+        v-if="generatedImage"
+        class="kr-panel-flat p-3"
+      >
+        <image-card :art-image="generatedImage" />
+      </div>
+    </Transition>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import type { ArtImage } from '~/prisma/generated/prisma/client'
+import { ErrorType, useErrorStore } from '@/stores/errorStore'
+import { useArtStore, type GenerateArtData } from '@/stores/artStore'
+import { useArtFacetDraftStore } from '@/stores/artFacetDraftStore'
+
+const props = withDefaults(
+  defineProps<{
+    purpose?: string
+    modelId?: number | null
+    modelTitle?: string
+    prompt?: string
+    imageRole?: string
+    icon?: string
+    showPreview?: boolean
+    overrides?: Partial<GenerateArtData>
+  }>(),
+  {
+    purpose: 'art',
+    modelId: null,
+    modelTitle: 'Untitled',
+    prompt: '',
+    imageRole: 'image',
+    icon: '',
+    showPreview: true,
+    overrides: () => ({}),
+  },
+)
+
+const emit = defineEmits<{
+  update: [
+    payload: {
+      prompt?: string
+      imagePath?: string | null
+      artImageId?: number | null
+      artImage?: ArtImage | null
+    },
+  ]
+  generated: [image: ArtImage]
+  failed: [message: string]
+}>()
+
+const artStore = useArtStore()
+const artFacetDraft = useArtFacetDraftStore()
+const errorStore = useErrorStore()
+
+const localMessage = ref('')
+const localMessageTone = ref<'success' | 'error'>('success')
+const generatedImage = ref<ArtImage | null>(null)
+
+const cleanPrompt = computed(() => props.prompt.trim())
+
+const displayIcon = computed(() => {
+  if (props.icon) return props.icon
+  if (props.imageRole === 'portrait') return 'kind-icon:portrait'
+  if (props.purpose === 'character') return 'kind-icon:character'
+  return 'kind-icon:image'
+})
+
+const displayTitle = computed(() => {
+  const role = props.imageRole || 'image'
+  const title = props.modelTitle?.trim() || 'Untitled'
+  return `${title} ${role}`
+})
+
+const promptPreview = computed(() => {
+  if (!props.showPreview || !cleanPrompt.value) return ''
+  const decorated = artFacetDraft.decorateGenerationData({}, cleanPrompt.value)
+  const prompt = decorated.promptString
+  return prompt.length > 260 ? `${prompt.slice(0, 260)}…` : prompt
+})
+
+const selectedGenerationEngine = computed(() => {
+  return props.overrides.engine ?? artStore.artForm.engine ?? undefined
+})
+
+const activeServer = computed(() => artStore.activeGenerationServer)
+const needsServer = computed(() => {
+  return !['openai', 'kontext'].includes(String(selectedGenerationEngine.value))
+})
+const needsCheckpoint = computed(() => activeServer.value?.serverType === 'A1111')
+const hasGenerationSetup = computed(() => {
+  if (needsServer.value && !artStore.artForm.serverId) return false
+  if (needsCheckpoint.value && !artStore.selectedCheckpointName) return false
+  return true
+})
+
+const canGenerate = computed(() => {
+  return Boolean(
+    cleanPrompt.value && hasGenerationSetup.value && !artStore.isGenerating,
+  )
+})
+
+const statusLabel = computed(() => {
+  if (!cleanPrompt.value) return 'No prompt yet. The muse is staring at a wall.'
+  if (needsServer.value && !artStore.artForm.serverId)
+    return 'Needs an art server selected.'
+  if (needsCheckpoint.value && !artStore.selectedCheckpointName)
+    return 'Needs an A1111 checkpoint selected.'
+  if (artStore.isGenerating)
+    return 'Pixel goblin currently negotiating with reality.'
+  return 'Ready to generate.'
+})
+
+const message = computed(() => localMessage.value || artStore.generationMessage)
+const messageTone = computed(() =>
+  localMessage.value ? localMessageTone.value : artStore.generationMessageTone,
+)
+
+function getImagePath(image: ArtImage): string | null {
+  const record = image as ArtImage & {
+    imageData?: string | null
+    imagePath?: string | null
+    path?: string | null
+    fileType?: string | null
+  }
+  if (record.imagePath) return record.imagePath
+  if (record.path) return record.path
+  if (record.imageData) {
+    const fileType = record.fileType || 'png'
+    return `data:image/${fileType};base64,${record.imageData}`
+  }
+  return null
+}
+
+function setLocalMessage(tone: 'success' | 'error', text: string) {
+  localMessageTone.value = tone
+  localMessage.value = text
+}
+
+function decoratedOverrides(): Partial<GenerateArtData> {
+  return artFacetDraft.decorateGenerationData(
+    {
+      ...props.overrides,
+      title: props.modelTitle || props.imageRole || props.purpose,
+    } as Record<string, unknown>,
+    cleanPrompt.value,
+  ) as Partial<GenerateArtData>
+}
+
+function syncPromptToArtForm() {
+  if (!cleanPrompt.value) return
+  artStore.setArtForm(decoratedOverrides())
+}
+
+async function generateImage() {
+  syncPromptToArtForm()
+  if (!cleanPrompt.value) {
+    const message = 'Add a prompt before generating.'
+    setLocalMessage('error', message)
+    emit('failed', message)
+    return
+  }
+
+  if (!hasGenerationSetup.value) {
+    const message = needsCheckpoint.value
+      ? 'Select an A1111 checkpoint before generating.'
+      : 'Select an art server before generating.'
+    setLocalMessage('error', message)
+    errorStore.addError(ErrorType.GENERAL_ERROR, message)
+    emit('failed', message)
+    return
+  }
+
+  const result = await artStore.generateCurrentArt(
+    decoratedOverrides() as GenerateArtData,
+  )
+  if (!result.success || !result.data) {
+    const message = result.message || 'Image generation failed.'
+    setLocalMessage('error', message)
+    errorStore.addError(ErrorType.GENERAL_ERROR, message)
+    emit('failed', message)
+    return
+  }
+
+  const imagePath = getImagePath(result.data)
+  generatedImage.value = result.data
+  setLocalMessage('success', result.message || 'Image generated.')
+  emit('update', {
+    prompt: cleanPrompt.value,
+    imagePath,
+    artImageId: result.data.id,
+    artImage: result.data,
+  })
+  emit('generated', result.data)
+}
+
+watch(
+  () => props.prompt,
+  () => syncPromptToArtForm(),
+)
+
+onMounted(async () => {
+  await Promise.all([artStore.prepareArtGenerator(), artFacetDraft.initialize()])
+  syncPromptToArtForm()
+})
+</script>
+
+<style scoped>
+.art-creator-reveal-enter-active {
+  transition:
+    opacity 300ms ease,
+    transform 300ms cubic-bezier(0.34, 1.2, 0.64, 1);
+}
+.art-creator-reveal-leave-active {
+  transition: opacity 180ms ease;
+}
+.art-creator-reveal-enter-from {
+  opacity: 0;
+  transform: translateY(8px) scale(0.98);
+}
+.art-creator-reveal-leave-to {
+  opacity: 0;
+}
+</style>

--- a/components/abandonware/art/lora-picker.vue
+++ b/components/abandonware/art/lora-picker.vue
@@ -1,0 +1,213 @@
+<!--
+  components/art/lora-picker.vue
+
+  A searchable, mature-aware multi-select for LoRA Resources. Drop it into any
+  art surface; it reads Resources from the resourceStore (resourceType LORA /
+  LYCORIS), respects the viewer's showMature consent, and reports the selection
+  back so the parent can drive both generation and provenance:
+
+    <LoraPicker v-model="loraResourceIds" @change="onLoraChange" />
+
+  On change it emits { loraResourceIds, loraName, triggers } where:
+    - loraResourceIds : ids to send as GenerateArtData.loraResourceIds (provenance)
+    - loraName        : the primary LoRA's engine name (GenerateArtData.loraName;
+                        current engines take a single LoRA, so it's the first pick)
+    - triggers        : the selected LoRAs' defaultTrigger/triggerWords, joined,
+                        for the parent to append to the prompt if desired.
+-->
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useResourceStore, type Resource } from '~/stores/resourceStore'
+
+const props = withDefaults(
+  defineProps<{
+    modelValue?: number[]
+    baseFilter?: string | null
+  }>(),
+  { modelValue: () => [], baseFilter: null },
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [ids: number[]]
+  change: [
+    payload: {
+      loraResourceIds: number[]
+      loraName: string | null
+      triggers: string
+    },
+  ]
+}>()
+
+const resourceStore = useResourceStore()
+const query = ref('')
+
+const availableLoras = computed<Resource[]>(() => {
+  const base = props.baseFilter?.toLowerCase() ?? null
+
+  return resourceStore.visibleLoras.filter((resource) =>
+    base
+      ? (resource.generation ?? '').toLowerCase().includes(base) ||
+        (resource.supportedServer ?? '').toLowerCase().includes(base)
+      : true,
+  )
+})
+
+const loras = computed<Resource[]>(() => {
+  const search = query.value.trim().toLowerCase()
+
+  return availableLoras.value
+    .filter((resource) =>
+      search
+        ? [
+            resource.customLabel,
+            resource.name,
+            resource.generation,
+            resource.triggerWords,
+          ]
+            .filter(Boolean)
+            .some((value) => String(value).toLowerCase().includes(search))
+        : true,
+    )
+    .sort((a, b) =>
+      (a.customLabel || a.name || '').localeCompare(
+        b.customLabel || b.name || '',
+      ),
+    )
+})
+
+const availableLoraIds = computed(
+  () => new Set(availableLoras.value.map((resource) => resource.id)),
+)
+
+const selected = computed<Resource[]>(() =>
+  props.modelValue
+    .map((id) => availableLoras.value.find((resource) => resource.id === id))
+    .filter((resource): resource is Resource => Boolean(resource)),
+)
+
+function engineName(resource: Resource): string {
+  return resource.localPath || resource.name || resource.customLabel || ''
+}
+
+function emitChange(ids: number[]): void {
+  emit('update:modelValue', ids)
+
+  const chosen = ids
+    .map((id) => availableLoras.value.find((resource) => resource.id === id))
+    .filter((resource): resource is Resource => Boolean(resource))
+  const primary = chosen.at(0)
+  const triggers = chosen
+    .map((resource) => resource.defaultTrigger || resource.triggerWords || '')
+    .filter(Boolean)
+    .join(', ')
+
+  emit('change', {
+    loraResourceIds: ids,
+    loraName: primary ? engineName(primary) : null,
+    triggers,
+  })
+}
+
+function toggle(resource: Resource): void {
+  const ids = props.modelValue.includes(resource.id)
+    ? props.modelValue.filter((id) => id !== resource.id)
+    : [...props.modelValue, resource.id]
+
+  emitChange(ids)
+}
+
+function isSelected(resource: Resource): boolean {
+  return props.modelValue.includes(resource.id)
+}
+
+watch(
+  [() => props.modelValue, () => resourceStore.hasLoaded, availableLoraIds],
+  () => {
+    if (!resourceStore.hasLoaded) return
+
+    const visibleIds = props.modelValue.filter((id) =>
+      availableLoraIds.value.has(id),
+    )
+
+    if (
+      visibleIds.length !== props.modelValue.length ||
+      visibleIds.some((id, index) => id !== props.modelValue[index])
+    ) {
+      emitChange(visibleIds)
+    }
+  },
+  { immediate: true },
+)
+
+onMounted(async () => {
+  if (!resourceStore.hasLoaded) {
+    await resourceStore.getResources()
+  }
+})
+</script>
+
+<template>
+  <div class="flex flex-col gap-2">
+    <div class="flex items-center gap-2">
+      <span class="text-sm font-medium">LoRAs</span>
+      <span v-if="selected.length" class="badge badge-sm badge-primary">
+        {{ selected.length }}
+      </span>
+    </div>
+
+    <maturity-toggle
+      variant="resource"
+      label="Mature LoRAs"
+      visible-text="Mature image LoRAs are available in this selector."
+      hidden-text="Mature image LoRAs are hidden from this selector."
+    />
+
+    <div v-if="selected.length" class="flex flex-wrap gap-1">
+      <button
+        v-for="resource in selected"
+        :key="resource.id"
+        type="button"
+        class="badge badge-outline gap-1 rounded-xl"
+        :title="resource.triggerWords || ''"
+        @click="toggle(resource)"
+      >
+        {{ resource.customLabel || resource.name }}
+        <span v-if="resource.isMature" class="text-error">·18+</span>
+        ✕
+      </button>
+    </div>
+
+    <input
+      v-model="query"
+      type="text"
+      placeholder="Search LoRAs…"
+      class="input input-bordered input-xs rounded-lg"
+    />
+
+    <ul
+      class="menu menu-xs max-h-56 flex-nowrap overflow-y-auto rounded-lg bg-base-200 p-1"
+    >
+      <li v-if="!loras.length" class="disabled px-2 py-1 text-xs opacity-60">
+        No matching LoRAs.
+      </li>
+      <li v-for="resource in loras" :key="resource.id">
+        <button
+          type="button"
+          class="flex items-center justify-between gap-2"
+          :class="{ 'bg-primary/20': isSelected(resource) }"
+          @click="toggle(resource)"
+        >
+          <span class="truncate">
+            <span :class="{ 'font-semibold': isSelected(resource) }">
+              {{ resource.customLabel || resource.name }}
+            </span>
+            <span v-if="resource.isMature" class="ml-1 text-error">18+</span>
+          </span>
+          <span class="shrink-0 text-[10px] opacity-60">
+            {{ resource.generation || resource.supportedServer }}
+          </span>
+        </button>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/components/abandonware/bots/bot-intros.vue
+++ b/components/abandonware/bots/bot-intros.vue
@@ -1,0 +1,117 @@
+<!-- /components/bots/bot-intros.vue -->
+<template>
+  <div class="flex flex-col gap-4">
+    <div class="flex items-center gap-2">
+      <button
+        type="button"
+        class="btn btn-ghost btn-sm gap-1.5 rounded-xl border border-base-300"
+        :disabled="!canGenerate || isSuggesting"
+        @click="generateIntro"
+      >
+        <span v-if="isSuggesting" class="loading loading-spinner loading-xs" />
+        <Icon v-else name="kind-icon:sparkles" class="h-4 w-4" />
+        Generate from prompt
+      </button>
+
+      <p class="text-xs text-base-content/40">
+        {{ fieldLabel }}
+      </p>
+    </div>
+
+    <div class="flex flex-col gap-2 kr-panel-flat p-4">
+      <div class="flex items-center justify-between">
+        <span
+          class="text-xs font-black uppercase tracking-widest text-primary/70"
+        >
+          {{ fieldLabel }}
+        </span>
+      </div>
+
+      <textarea
+        :value="introText"
+        class="textarea textarea-bordered w-full resize-none rounded-xl bg-base-200 text-sm leading-relaxed focus:border-primary focus:outline-none"
+        rows="4"
+        :placeholder="placeholder"
+        @input="setIntro(($event.target as HTMLTextAreaElement).value)"
+      />
+
+      <button
+        type="button"
+        class="btn btn-ghost btn-xs self-start rounded-xl border border-base-300 text-xs"
+        :disabled="isSuggesting"
+        @click="generateIntro"
+      >
+        <Icon name="kind-icon:sparkles" class="h-3 w-3" />
+        {{ introText.trim() ? 'Refine' : 'Generate' }}
+      </button>
+    </div>
+
+    <p v-if="builder.lastError" class="text-xs text-error">
+      {{ builder.lastError }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useBuilderStore } from '@/stores/builderStore'
+
+const props = withDefaults(
+  defineProps<{
+    field?: 'botIntro' | 'userIntro'
+  }>(),
+  {
+    field: 'botIntro',
+  },
+)
+
+const builder = useBuilderStore()
+
+const isSuggesting = computed(() => {
+  return Boolean(builder.isSuggesting || builder.isSaving)
+})
+
+const introText = computed(() => {
+  const value = builder.sheet[props.field]
+
+  return typeof value === 'string' ? value : ''
+})
+
+const fieldLabel = computed(() => {
+  return props.field === 'userIntro' ? 'User opener' : 'Bot opener'
+})
+
+const placeholder = computed(() => {
+  return props.field === 'userIntro'
+    ? 'The kind of thing a user might say to start the interaction...'
+    : 'Hello! I am here to help you build something interesting...'
+})
+
+const canGenerate = computed(() => {
+  return Boolean(sheetText('prompt').trim() || sheetText('name').trim())
+})
+
+function sheetText(key: string): string {
+  const value = builder.sheet[key]
+
+  return typeof value === 'string' ? value : ''
+}
+
+function setIntro(value: string) {
+  builder.updateSheet({
+    [props.field]: value,
+  })
+}
+
+async function generateIntro() {
+  const result = await builder.callSuggest(
+    props.field,
+    props.field,
+    introText.value,
+  )
+
+  if (!result.success || !result.message) return
+
+  setIntro(result.message)
+}
+</script>

--- a/components/abandonware/bots/bot-modules.vue
+++ b/components/abandonware/bots/bot-modules.vue
@@ -1,0 +1,118 @@
+<!-- /components/bots/bot-modules.vue -->
+<template>
+  <div class="flex flex-col gap-4">
+    <div class="rounded-xl border border-warning/30 bg-warning/8 p-3">
+      <p class="text-xs font-bold text-warning/80">Under Active Development</p>
+      <p class="mt-1 text-xs text-base-content/60">
+        Module support is being built out. Selections are saved now and will
+        activate as each module is implemented.
+      </p>
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <label
+        class="text-xs font-bold uppercase tracking-widest text-base-content/50"
+      >
+        Available Modules
+      </label>
+
+      <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <button
+          v-for="mod in MODULE_PRESETS"
+          :key="mod.value"
+          type="button"
+          class="flex items-start gap-3 rounded-2xl border p-3 text-left transition-all"
+          :class="
+            isActive(mod.value)
+              ? 'border-primary bg-primary/10 text-primary'
+              : 'border-base-300 bg-base-100 text-base-content/70 hover:border-primary/30 hover:bg-primary/5'
+          "
+          @click="toggleModule(mod.value)"
+        >
+          <div
+            class="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded border-2 transition-colors"
+            :class="
+              isActive(mod.value)
+                ? 'border-primary bg-primary'
+                : 'border-base-300'
+            "
+          >
+            <Icon
+              v-if="isActive(mod.value)"
+              name="kind-icon:check"
+              class="h-3 w-3 text-primary-content"
+            />
+          </div>
+
+          <div>
+            <p class="text-xs font-bold leading-tight">{{ mod.label }}</p>
+            <p class="mt-0.5 text-xs leading-snug text-base-content/50">
+              {{ mod.subtext }}
+            </p>
+          </div>
+        </button>
+      </div>
+    </div>
+
+    <div v-if="activeModuleList.length" class="rounded-xl bg-base-200 p-3">
+      <p
+        class="text-xs font-bold uppercase tracking-widest text-base-content/40"
+      >
+        Active modules
+      </p>
+      <p class="mt-1 font-mono text-xs text-base-content/60">
+        {{ modulesText }}
+      </p>
+    </div>
+
+    <p v-else class="text-xs text-base-content/30">
+      No modules selected. This bot runs without additional capabilities.
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useBuilderStore } from '@/stores/builderStore'
+import { MODULE_PRESETS } from '@/stores/helpers/botCards'
+
+const builder = useBuilderStore()
+
+const activeModuleList = computed(() => {
+  const value = builder.sheet.modules
+
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is string => typeof entry === 'string')
+  }
+
+  if (typeof value === 'string') {
+    return value
+      .split('|')
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  }
+
+  return []
+})
+
+const modulesText = computed(() => activeModuleList.value.join('|'))
+
+function writeModules(values: string[]) {
+  builder.updateSheet({
+    modules: values.join('|'),
+  })
+}
+
+function toggleModule(value: string) {
+  const current = activeModuleList.value
+  const next = current.includes(value)
+    ? current.filter((entry) => entry !== value)
+    : [...current, value]
+
+  writeModules(next)
+}
+
+function isActive(value: string): boolean {
+  return activeModuleList.value.includes(value)
+}
+</script>

--- a/components/abandonware/bots/bot-personality.vue
+++ b/components/abandonware/bots/bot-personality.vue
@@ -1,0 +1,121 @@
+<!-- /components/bots/bot-personality.vue -->
+<template>
+  <div class="flex flex-col gap-3">
+    <div v-if="selectedTraits.length" class="flex flex-wrap gap-1.5">
+      <span
+        v-for="trait in selectedTraits"
+        :key="trait"
+        class="inline-flex items-center gap-1 rounded-full bg-primary/15 px-2.5 py-0.5 text-xs font-bold text-primary"
+      >
+        {{ trait }}
+
+        <button
+          type="button"
+          class="hover:text-error"
+          @click="removeTrait(trait)"
+        >
+          <Icon name="kind-icon:x" class="h-3 w-3" />
+        </button>
+      </span>
+
+      <span
+        class="rounded-full bg-base-200 px-2.5 py-0.5 text-xs text-base-content/40"
+      >
+        {{ selectedTraits.length }} selected
+      </span>
+    </div>
+
+    <input
+      v-model="search"
+      type="text"
+      class="input input-bordered input-sm w-full rounded-xl bg-base-100 focus:border-primary"
+      placeholder="Filter traits..."
+    />
+
+    <div class="grid grid-cols-3 gap-1.5 sm:grid-cols-4">
+      <button
+        v-for="trait in filteredTraits"
+        :key="trait.value"
+        type="button"
+        class="rounded-xl border px-2.5 py-2 text-center text-xs font-semibold transition-all"
+        :class="
+          isSelected(trait.value)
+            ? 'border-primary bg-primary/15 text-primary shadow-sm'
+            : 'border-base-300 bg-base-100 text-base-content/70 hover:border-primary/40 hover:text-primary'
+        "
+        @click="toggleTrait(trait.value)"
+      >
+        {{ trait.label }}
+      </button>
+    </div>
+
+    <p class="text-xs text-base-content/30">
+      {{ filteredTraits.length }} traits{{
+        search ? ` matching &quot;${search}&quot;` : ''
+      }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useBuilderStore } from '@/stores/builderStore'
+import { BOT_PERSONALITY_TRAITS } from '@/stores/helpers/botCards'
+
+const builder = useBuilderStore()
+const search = ref('')
+
+const selectedTraits = computed(() => {
+  const value = builder.sheet.personality
+
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is string => typeof entry === 'string')
+  }
+
+  if (typeof value === 'string') {
+    return value
+      .split('|')
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  }
+
+  return []
+})
+
+const filteredTraits = computed(() => {
+  const q = search.value.toLowerCase().trim()
+
+  if (!q) return BOT_PERSONALITY_TRAITS
+
+  return BOT_PERSONALITY_TRAITS.filter((trait) => {
+    return trait.label.toLowerCase().includes(q)
+  })
+})
+
+function writeTraits(values: string[]) {
+  builder.updateSheet({
+    personality: values.join('|'),
+  })
+}
+
+function toggleTrait(value: string) {
+  const current = selectedTraits.value
+  const next = current.includes(value)
+    ? current.filter((entry) => entry !== value)
+    : [...current, value]
+
+  writeTraits(next)
+}
+
+function removeTrait(value: string) {
+  writeTraits(
+    selectedTraits.value.filter((entry) => {
+      return entry !== value
+    }),
+  )
+}
+
+function isSelected(value: string): boolean {
+  return selectedTraits.value.includes(value)
+}
+</script>

--- a/components/abandonware/bots/text-generate.vue
+++ b/components/abandonware/bots/text-generate.vue
@@ -1,0 +1,464 @@
+<!-- /components/chat/text-generate.vue -->
+<template>
+  <section class="flex w-full flex-col gap-3">
+    <div
+      class="grid w-full grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_auto]"
+    >
+      <label class="form-control w-full">
+        <div class="label py-1">
+          <span class="label-text text-xs font-black uppercase tracking-wide">
+            Text Server
+          </span>
+        </div>
+
+        <select
+          v-model="serverChoice"
+          class="select select-bordered w-full rounded-2xl font-semibold"
+          :class="props.compact ? 'select-sm text-sm' : 'min-h-14 text-base'"
+          :disabled="chatStore.isGenerating || !hasServerChoices"
+          @change="handleServerChoiceChange"
+        >
+          <option value="default">
+            {{ defaultServerOptionLabel }}
+          </option>
+
+          <option value="any">Whatever is available</option>
+
+          <option
+            v-for="server in alternateServerOptions"
+            :key="server.id"
+            :value="getSpecificServerValue(server.id)"
+          >
+            {{ getServerDisplayLabel(server) }}
+          </option>
+        </select>
+      </label>
+
+      <button
+        class="btn w-full rounded-2xl font-black transition-all duration-200 sm:w-auto sm:min-w-48"
+        :class="[
+          chatStore.isGenerating
+            ? 'btn-primary cursor-not-allowed opacity-80'
+            : canClick
+              ? 'btn-primary shadow-lg shadow-primary/25 hover:-translate-y-0.5 hover:shadow-primary/40 active:translate-y-0'
+              : 'btn-disabled',
+          props.compact ? 'btn-sm text-sm' : 'min-h-14 text-base',
+        ]"
+        type="button"
+        :disabled="!canClick"
+        @click="handleGenerate"
+      >
+        <span v-if="chatStore.isGenerating" class="flex items-center gap-2">
+          <span class="loading loading-dots loading-sm" />
+          {{ busyLabel }}
+        </span>
+
+        <span v-else class="flex items-center gap-2">
+          <icon :name="icon" class="h-5 w-5" />
+          {{ canAfford ? label : 'Out of mana, top up' }}
+        </span>
+      </button>
+    </div>
+
+    <div
+      class="rounded-2xl border border-base-300 bg-base-200/70 p-3 text-xs font-semibold text-base-content/70"
+    >
+      <div class="flex flex-wrap items-center gap-2">
+        <span class="badge badge-sm rounded-2xl" :class="selectionBadgeClass">
+          {{ selectionBadgeLabel }}
+        </span>
+
+        <span class="truncate">
+          {{ selectionSummary }}
+        </span>
+      </div>
+
+      <p
+        v-if="selectionDetail"
+        class="mt-1 text-[0.7rem] leading-relaxed text-base-content/50"
+      >
+        {{ selectionDetail }}
+      </p>
+    </div>
+
+    <div
+      v-if="showMessage && chatStore.generationMessage"
+      class="flex items-start gap-2 rounded-2xl border p-3 text-sm font-semibold"
+      :class="
+        chatStore.generationMessageTone === 'error'
+          ? 'border-error/40 bg-error/10 text-error'
+          : 'border-success/40 bg-success/10 text-success'
+      "
+    >
+      <icon
+        :name="
+          chatStore.generationMessageTone === 'error'
+            ? 'kind-icon:alert'
+            : 'kind-icon:check'
+        "
+        class="mt-0.5 h-4 w-4 shrink-0"
+      />
+      {{ chatStore.generationMessage }}
+    </div>
+
+    <div
+      v-if="showResult && resultText"
+      class="whitespace-pre-wrap kr-panel-flat p-3 text-sm leading-relaxed"
+    >
+      {{ resultText }}
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import type { Chat, Server } from '~/prisma/generated/prisma/client'
+import { ErrorType, useErrorStore } from '@/stores/errorStore'
+import {
+  useChatStore,
+  type GenerateTextData,
+  type TextServerSelectionMode,
+} from '@/stores/chatStore'
+import { useServerStore } from '@/stores/serverStore'
+import { useUserStore } from '@/stores/userStore'
+import { useManaStore } from '@/stores/manaStore'
+
+type ServerChoice = 'default' | 'any' | `server:${number}`
+
+type GenerateTextDataWithRouting = Partial<GenerateTextData> & {
+  serverSelectionMode?: TextServerSelectionMode
+}
+
+const props = withDefaults(
+  defineProps<{
+    prompt?: string
+    botId?: number | null
+    recipientId?: number | null
+    characterId?: number | null
+    isPublic?: boolean
+    model?: string
+    temperature?: number
+    maxTokens?: number
+    messages?: GenerateTextData['messages']
+    label?: string
+    busyLabel?: string
+    icon?: string
+    compact?: boolean
+    showResult?: boolean
+    showMessage?: boolean
+    clearOnSuccess?: boolean
+    overrides?: Partial<GenerateTextData>
+  }>(),
+  {
+    prompt: '',
+    botId: null,
+    recipientId: null,
+    characterId: null,
+    isPublic: false,
+    model: '',
+    temperature: 0.7,
+    maxTokens: 2048,
+    messages: () => [],
+    label: 'Generate Text',
+    busyLabel: 'Generating…',
+    icon: 'kind-icon:sparkles',
+    compact: false,
+    showResult: true,
+    showMessage: true,
+    clearOnSuccess: true,
+    overrides: () => ({}),
+  },
+)
+
+const emit = defineEmits<{
+  generated: [payload: { chat: Chat; chatId: number; text: string }]
+  failed: [message: string]
+  'update:prompt': [value: string]
+}>()
+
+const chatStore = useChatStore()
+const serverStore = useServerStore()
+const userStore = useUserStore()
+const manaStore = useManaStore()
+const errorStore = useErrorStore()
+
+const serverChoice = ref<ServerChoice>('default')
+const resultText = ref('')
+
+const promptText = computed(() => props.prompt.trim())
+
+const serverOptions = computed<Server[]>(() => {
+  return Array.isArray(chatStore.generationServers)
+    ? [...chatStore.generationServers]
+    : []
+})
+
+const defaultServer = computed<Server | null>(() => {
+  return serverStore.activeTextServer || null
+})
+
+const defaultServerId = computed(() => defaultServer.value?.id ?? null)
+
+const hasServerChoices = computed(() => {
+  return Boolean(defaultServer.value || serverOptions.value.length)
+})
+
+const alternateServerOptions = computed<Server[]>(() => {
+  const defaultId = defaultServerId.value
+
+  return serverOptions.value.filter((server) => {
+    if (!server?.id) return false
+    return server.id !== defaultId
+  })
+})
+
+const selectedSpecificServerId = computed<number | null>(() => {
+  if (!serverChoice.value.startsWith('server:')) return null
+
+  const id = Number(serverChoice.value.replace('server:', ''))
+  return Number.isInteger(id) && id > 0 ? id : null
+})
+
+const selectedSpecificServer = computed<Server | null>(() => {
+  const id = selectedSpecificServerId.value
+  if (!id) return null
+
+  return serverStore.getServerById(id) || null
+})
+
+const displayServer = computed<Server | null>(() => {
+  if (serverChoice.value === 'default') {
+    return defaultServer.value
+  }
+
+  if (serverChoice.value.startsWith('server:')) {
+    return selectedSpecificServer.value
+  }
+
+  return chatStore.activeGenerationServer || defaultServer.value || null
+})
+
+const billingServer = computed<Server | null>(() => {
+  return displayServer.value || chatStore.activeGenerationServer || null
+})
+
+const defaultServerOptionLabel = computed(() => {
+  if (!defaultServer.value) {
+    return 'Default Text Server'
+  }
+
+  return `Default: ${getServerDisplayLabel(defaultServer.value)}`
+})
+
+const selectionBadgeLabel = computed(() => {
+  if (serverChoice.value === 'default') return 'Default'
+  if (serverChoice.value === 'any') return 'Auto'
+  return 'Override'
+})
+
+const selectionBadgeClass = computed(() => {
+  if (serverChoice.value === 'default') return 'badge-primary'
+  if (serverChoice.value === 'any') return 'badge-info'
+  return 'badge-secondary'
+})
+
+const selectionSummary = computed(() => {
+  if (serverChoice.value === 'any') {
+    return 'Whatever compatible text server is available'
+  }
+
+  const server = displayServer.value
+
+  if (!server) {
+    return 'Platform text generation uses mana'
+  }
+
+  return getServerDisplayLabel(server)
+})
+
+const selectionDetail = computed(() => {
+  if (serverChoice.value === 'default') {
+    return defaultServer.value
+      ? 'Uses your preferred text server. Change this in Server Connections.'
+      : 'No preferred text server is currently saved. Platform generation will be used.'
+  }
+
+  if (serverChoice.value === 'any') {
+    return 'The chat store will pick an owned, public, or compatible text server for this request.'
+  }
+
+  return 'Uses this server for this generation only.'
+})
+
+const usesOwnServer = computed(() => {
+  const server = billingServer.value
+
+  if (!server) return false
+  if (!server.isActive) return false
+  if (server.userId && server.userId === userStore.userId) return true
+  if (server.isPublic && !server.isOfficial) return true
+
+  return (
+    server.accessMode === 'BROWSER' ||
+    server.accessMode === 'LOCAL' ||
+    server.accessMode === 'TAILSCALE' ||
+    server.serverType === 'OLLAMA'
+  )
+})
+
+const canAfford = computed(() => {
+  if (manaStore.isFamily) return true
+  if (usesOwnServer.value) return true
+  return manaStore.balance > 0
+})
+
+const canClick = computed(() => {
+  return Boolean(
+    !chatStore.isGenerating &&
+      promptText.value &&
+      canAfford.value &&
+      (hasServerChoices.value || serverChoice.value === 'default'),
+  )
+})
+
+watch(
+  () => chatStore.textForm.serverId,
+  (serverId) => {
+    if (!serverId) {
+      if (serverChoice.value.startsWith('server:')) {
+        serverChoice.value = 'default'
+      }
+
+      return
+    }
+
+    serverChoice.value = getSpecificServerValue(serverId)
+  },
+)
+
+onMounted(async () => {
+  await chatStore.prepareTextGenerator()
+
+  if (chatStore.textForm.serverId) {
+    serverChoice.value = getSpecificServerValue(chatStore.textForm.serverId)
+  }
+})
+
+function getSpecificServerValue(serverId: number): ServerChoice {
+  return `server:${serverId}`
+}
+
+function getServerEngineLabel(server: Server): string {
+  if (server.serverType === 'OPENAI') return 'OpenAI'
+  if (server.serverType === 'ANTHROPIC') return 'Anthropic'
+  if (server.serverType === 'OLLAMA') return 'Ollama'
+
+  return 'Text'
+}
+
+function getServerDisplayLabel(server: Server): string {
+  const title = server.label || server.title || `Server #${server.id}`
+  return `${title} · ${getServerEngineLabel(server)}`
+}
+
+function handleServerChoiceChange() {
+  if (serverChoice.value === 'default') {
+    chatStore.selectGenerationServer(null)
+    return
+  }
+
+  if (serverChoice.value === 'any') {
+    chatStore.selectGenerationServer(null)
+    return
+  }
+
+  const serverId = selectedSpecificServerId.value
+
+  if (!serverId) {
+    chatStore.selectGenerationServer(null)
+    serverChoice.value = 'default'
+    return
+  }
+
+  chatStore.selectGenerationServer(serverId)
+}
+
+function buildGenerationOverrides(): GenerateTextDataWithRouting {
+  const baseOverrides: GenerateTextDataWithRouting = {
+    ...props.overrides,
+    prompt: promptText.value,
+    botId: props.botId,
+    recipientId: props.recipientId ?? props.botId,
+    characterId: props.characterId,
+    isPublic: props.isPublic,
+    model: props.model,
+    temperature: props.temperature,
+    maxTokens: props.maxTokens,
+    messages: props.messages,
+    type: props.botId ? 'ToBot' : 'ToForum',
+  }
+
+  if (serverChoice.value === 'default') {
+    return {
+      ...baseOverrides,
+      serverId: null,
+      serverName: null,
+      serverSelectionMode: 'default',
+    }
+  }
+
+  if (serverChoice.value === 'any') {
+    return {
+      ...baseOverrides,
+      serverId: null,
+      serverName: null,
+      serverSelectionMode: 'any',
+    }
+  }
+
+  const server = selectedSpecificServer.value
+
+  return {
+    ...baseOverrides,
+    serverId: server?.id ?? null,
+    serverName: server
+      ? server.label || server.title || `Server #${server.id}`
+      : null,
+    serverSelectionMode: 'specific',
+  }
+}
+
+async function handleGenerate() {
+  resultText.value = ''
+
+  const result = await chatStore.generateCurrentText(buildGenerationOverrides())
+
+  if (!result.success || !result.data) {
+    const message = result.message || 'Text generation failed.'
+
+    if (/mana|⚡/i.test(message)) {
+      errorStore.addError(
+        ErrorType.INTERACTION_ERROR,
+        `${message} Visit your wallet to top up.`,
+      )
+    } else {
+      errorStore.addError(ErrorType.INTERACTION_ERROR, message)
+    }
+
+    emit('failed', message)
+    return
+  }
+
+  resultText.value = result.data.text
+
+  if (props.clearOnSuccess) {
+    emit('update:prompt', '')
+  }
+
+  emit('generated', {
+    chat: result.data.chat,
+    chatId: result.data.chat.id,
+    text: result.data.text,
+  })
+}
+</script>

--- a/components/abandonware/builder/art-builder.vue
+++ b/components/abandonware/builder/art-builder.vue
@@ -1,0 +1,737 @@
+<!-- /components/builder/art-builder.vue -->
+<template>
+  <section
+    class="flex flex-col gap-4 kr-panel-flat p-4"
+  >
+    <!-- ── Header ──────────────────────────────────────────────────────── -->
+    <header class="rounded-xl border border-base-300 bg-base-200/60 p-3">
+      <div
+        class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between"
+      >
+        <div class="flex items-start gap-3">
+          <span
+            class="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/15 text-primary"
+          >
+            <Icon :name="contextIcon" class="h-5 w-5" />
+          </span>
+          <div class="min-w-0">
+            <p
+              class="text-[0.62rem] font-black uppercase tracking-[0.22em] text-base-content/40"
+            >
+              {{ contextLabel }} Art Creator
+            </p>
+            <h3 class="text-lg font-black text-base-content">{{ title }}</h3>
+            <p class="text-sm text-base-content/60">{{ description }}</p>
+          </div>
+        </div>
+
+        <!-- Mode tab strip -->
+        <div
+          class="flex shrink-0 overflow-hidden rounded-xl border border-base-300 bg-base-100"
+        >
+          <button
+            v-for="tab in modeTabs"
+            :key="tab.value"
+            class="flex items-center gap-1.5 px-3 py-2 text-xs font-black transition"
+            :class="
+              mode === tab.value
+                ? 'bg-primary text-primary-content'
+                : 'text-base-content/60 hover:bg-base-200 hover:text-base-content'
+            "
+            type="button"
+            @click="mode = tab.value"
+          >
+            <Icon :name="tab.icon" class="h-3.5 w-3.5" />
+            {{ tab.label }}
+          </button>
+        </div>
+      </div>
+    </header>
+
+    <!-- ── Mode content ──────────────────────────────────────────────────── -->
+    <main class="rounded-xl border border-base-300 bg-base-200/40 p-4">
+      <!-- Prompt mode -->
+      <section
+        v-if="mode === 'prompt'"
+        class="grid grid-cols-1 gap-4 xl:grid-cols-[1fr_20rem]"
+      >
+        <div class="flex flex-col gap-3">
+          <label class="form-control">
+            <span class="label-text font-bold">Positive Prompt</span>
+            <textarea
+              v-model="localPrompt"
+              class="textarea textarea-bordered min-h-52 rounded-2xl text-base leading-relaxed"
+              :placeholder="promptPlaceholder"
+            />
+          </label>
+
+          <label class="form-control">
+            <span class="label-text font-bold">Negative Prompt</span>
+            <textarea
+              v-model="localNegativePrompt"
+              class="textarea textarea-bordered min-h-24 rounded-2xl text-sm"
+              placeholder="text, watermark, logo, signature, blurry, low quality..."
+            />
+          </label>
+        </div>
+
+        <aside
+          class="flex flex-col gap-2 kr-panel-flat p-4"
+        >
+          <h4
+            class="flex items-center gap-2 text-sm font-black text-base-content"
+          >
+            <Icon name="kind-icon:sparkles" class="h-4 w-4 text-primary" />
+            Prompt Helpers
+          </h4>
+
+          <button
+            class="btn btn-secondary btn-sm rounded-xl"
+            type="button"
+            @click="buildContextPrompt"
+          >
+            <Icon name="kind-icon:wand" class="h-4 w-4" />
+            Build Context Prompt
+          </button>
+
+          <button
+            class="btn btn-ghost btn-sm rounded-xl border border-base-300"
+            type="button"
+            @click="appendNoText"
+          >
+            <Icon name="kind-icon:close" class="h-4 w-4" />
+            No Text / Watermark
+          </button>
+
+          <button
+            class="btn btn-ghost btn-sm rounded-xl border border-base-300"
+            type="button"
+            @click="clearPrompt"
+          >
+            <Icon name="kind-icon:trash" class="h-4 w-4" />
+            Clear Prompt
+          </button>
+
+          <div class="mt-1 rounded-xl border border-base-300 bg-base-200 p-3">
+            <p
+              class="text-[0.58rem] font-black uppercase tracking-widest text-base-content/40"
+            >
+              Context Hint
+            </p>
+            <p class="mt-2 text-sm text-base-content/65 leading-relaxed">
+              {{ contextHint }}
+            </p>
+          </div>
+        </aside>
+      </section>
+
+      <!-- Upload mode -->
+      <section v-else-if="mode === 'upload'" class="flex flex-col gap-3">
+        <div class="flex items-center gap-2">
+          <span
+            class="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/15 text-primary"
+          >
+            <Icon name="kind-icon:save" class="h-4 w-4" />
+          </span>
+          <div>
+            <h4 class="text-sm font-black text-base-content">
+              Upload {{ contextLabel }} Art
+            </h4>
+            <p class="text-xs text-base-content/55">
+              Upload an image and connect it to this builder context.
+            </p>
+          </div>
+        </div>
+        <image-upload />
+      </section>
+
+      <!-- Gallery mode -->
+      <section v-else-if="mode === 'gallery'" class="flex flex-col gap-3">
+        <div class="flex items-center gap-2">
+          <span
+            class="flex h-8 w-8 items-center justify-center rounded-lg bg-secondary/15 text-secondary"
+          >
+            <Icon name="kind-icon:gallery" class="h-4 w-4" />
+          </span>
+          <div>
+            <h4 class="text-sm font-black text-base-content">
+              Select Existing Art
+            </h4>
+            <p class="text-xs text-base-content/55">
+              Pick an existing image for this {{ contextLabel.toLowerCase() }}.
+            </p>
+          </div>
+        </div>
+        <art-gallery />
+      </section>
+
+      <!-- Generate mode -->
+      <section
+        v-else-if="mode === 'generate'"
+        class="grid grid-cols-1 gap-4 xl:grid-cols-[1fr_20rem]"
+      >
+        <div class="kr-panel-flat p-4">
+          <div class="mb-3 flex items-center gap-2">
+            <span
+              class="flex h-8 w-8 items-center justify-center rounded-lg bg-accent/15 text-accent"
+            >
+              <Icon name="kind-icon:wand" class="h-4 w-4" />
+            </span>
+            <div>
+              <h4 class="text-sm font-black text-base-content">
+                Generate {{ contextLabel }} Art
+              </h4>
+              <p class="text-xs text-base-content/55">
+                Sync prompt to art store, then use the generator.
+              </p>
+            </div>
+          </div>
+          <generate-button :overrides="generationOverrides" />
+        </div>
+
+        <aside
+          class="flex flex-col gap-3 kr-panel-flat p-4"
+        >
+          <h4
+            class="flex items-center gap-2 text-sm font-black text-base-content"
+          >
+            <Icon name="kind-icon:settings" class="h-4 w-4 text-primary" />
+            Generator Options
+          </h4>
+
+          <div class="grid grid-cols-2 gap-2">
+            <label class="form-control">
+              <span class="label-text text-xs font-bold">Width</span>
+              <select
+                v-model.number="width"
+                class="select select-bordered select-sm rounded-xl"
+              >
+                <option :value="512">512</option>
+                <option :value="768">768</option>
+                <option :value="1024">1024</option>
+                <option :value="1216">1216</option>
+                <option :value="1344">1344</option>
+              </select>
+            </label>
+            <label class="form-control">
+              <span class="label-text text-xs font-bold">Height</span>
+              <select
+                v-model.number="height"
+                class="select select-bordered select-sm rounded-xl"
+              >
+                <option :value="512">512</option>
+                <option :value="768">768</option>
+                <option :value="1024">1024</option>
+                <option :value="1216">1216</option>
+                <option :value="1344">1344</option>
+              </select>
+            </label>
+            <label class="form-control">
+              <span class="label-text text-xs font-bold">Steps</span>
+              <input
+                v-model.number="steps"
+                class="input input-bordered input-sm rounded-xl"
+                type="number"
+                min="1"
+                max="80"
+              />
+            </label>
+            <label class="form-control">
+              <span class="label-text text-xs font-bold">CFG</span>
+              <input
+                v-model.number="cfg"
+                class="input input-bordered input-sm rounded-xl"
+                type="number"
+                min="1"
+                max="20"
+                step="0.5"
+              />
+            </label>
+          </div>
+
+          <label class="form-control">
+            <span class="label-text text-xs font-bold">Seed</span>
+            <input
+              v-model.number="seed"
+              class="input input-bordered input-sm rounded-xl"
+              type="number"
+            />
+          </label>
+
+          <!-- Aspect ratio quick buttons -->
+          <div class="grid grid-cols-3 gap-1.5">
+            <button
+              class="btn btn-xs rounded-lg"
+              type="button"
+              @click="useSquare"
+            >
+              Square
+            </button>
+            <button
+              class="btn btn-xs rounded-lg"
+              type="button"
+              @click="useLandscape"
+            >
+              Wide
+            </button>
+            <button
+              class="btn btn-xs rounded-lg"
+              type="button"
+              @click="usePortrait"
+            >
+              Tall
+            </button>
+          </div>
+
+          <button
+            class="btn btn-primary btn-sm rounded-xl"
+            type="button"
+            @click="syncToArtStore"
+          >
+            <Icon name="kind-icon:sliders" class="h-4 w-4" />
+            Apply to Art Store
+          </button>
+
+          <div
+            v-if="syncMessage"
+            class="flex items-center gap-2 rounded-xl border border-info/30 bg-info/10 p-2.5 text-xs font-semibold text-info"
+          >
+            <Icon name="kind-icon:check" class="h-3.5 w-3.5 shrink-0" />
+            {{ syncMessage }}
+          </div>
+        </aside>
+      </section>
+    </main>
+
+    <!-- ── Summary strip ──────────────────────────────────────────────── -->
+    <section class="rounded-xl border border-base-300 bg-base-200/40 p-3">
+      <div class="grid grid-cols-2 gap-2 md:grid-cols-4">
+        <article
+          v-for="item in summaryItems"
+          :key="item.key"
+          class="flex items-start gap-2 rounded-xl border border-base-300 bg-base-100 p-2.5"
+        >
+          <div
+            class="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-base-200"
+          >
+            <img
+              v-if="item.image"
+              :src="item.image"
+              :alt="item.label"
+              class="h-full w-full object-cover"
+            />
+            <Icon v-else :name="item.icon" class="h-5 w-5 text-primary" />
+          </div>
+          <div class="min-w-0">
+            <p
+              class="text-[0.58rem] font-black uppercase tracking-widest text-base-content/40"
+            >
+              {{ item.label }}
+            </p>
+            <p
+              class="mt-0.5 line-clamp-2 text-xs font-semibold text-base-content/80"
+            >
+              {{ item.value || 'Not selected yet' }}
+            </p>
+          </div>
+        </article>
+      </div>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useArtStore } from '@/stores/artStore'
+import { handleError } from '@/stores/utils'
+
+type ArtCreatorPurpose =
+  | 'user'
+  | 'dream'
+  | 'character'
+  | 'reward'
+  | 'scenario'
+  | 'builder'
+
+type ArtCreatorMode = 'prompt' | 'upload' | 'gallery' | 'generate'
+
+type ArtStoreLike = {
+  artForm?: Record<string, unknown>
+  form?: Record<string, unknown>
+  selectedArtImage?: {
+    id?: number
+    imagePath?: string | null
+    imageData?: string | null
+    path?: string | null
+  } | null
+  selectedImage?: {
+    id?: number
+    imagePath?: string | null
+    imageData?: string | null
+    path?: string | null
+  } | null
+  selectedArt?: {
+    id?: number
+    imagePath?: string | null
+    path?: string | null
+  } | null
+  updateArtForm?: (patch: Record<string, unknown>) => void
+  setArtForm?: (patch: Record<string, unknown>) => void
+}
+
+const props = withDefaults(
+  defineProps<{
+    purpose: ArtCreatorPurpose
+    title?: string
+    description?: string
+    modelId?: number | null
+    modelTitle?: string
+    prompt?: string
+    negativePrompt?: string
+    imageRole?: string
+  }>(),
+  {
+    title: '',
+    description: '',
+    modelId: null,
+    modelTitle: '',
+    prompt: '',
+    negativePrompt: 'text, watermark, logo, signature, blurry, low quality',
+    imageRole: '',
+  },
+)
+
+const emit = defineEmits<{
+  update: [
+    payload: {
+      purpose: ArtCreatorPurpose
+      modelId: number | null
+      modelTitle: string
+      prompt: string
+      artPrompt: string
+      negativePrompt: string
+      imageRole: string
+      imagePath: string | null
+      artImageId: number | null
+    },
+  ]
+}>()
+const artStore = useArtStore() as unknown as ArtStoreLike
+
+const mode = ref<ArtCreatorMode>('prompt')
+const localPrompt = ref(props.prompt)
+const localNegativePrompt = ref(props.negativePrompt)
+const width = ref(1024)
+const height = ref(1024)
+const steps = ref(28)
+const cfg = ref(3.5)
+const seed = ref(-1)
+const syncMessage = ref('')
+
+const previewImageId = computed(
+  () =>
+    artStore.selectedArtImage?.id ||
+    artStore.selectedImage?.id ||
+    artStore.selectedArt?.id ||
+    null,
+)
+
+const modeTabs = [
+  {
+    value: 'prompt' as ArtCreatorMode,
+    label: 'Prompt',
+    icon: 'kind-icon:prompt',
+  },
+  {
+    value: 'upload' as ArtCreatorMode,
+    label: 'Upload',
+    icon: 'kind-icon:save',
+  },
+  {
+    value: 'gallery' as ArtCreatorMode,
+    label: 'Gallery',
+    icon: 'kind-icon:gallery',
+  },
+  {
+    value: 'generate' as ArtCreatorMode,
+    label: 'Generate',
+    icon: 'kind-icon:wand',
+  },
+]
+
+const generationOverrides = computed(() => ({
+  purpose: props.purpose,
+  modelId: props.modelId,
+  modelTitle: props.modelTitle,
+  imageRole: resolvedImageRole.value,
+  prompt: localPrompt.value,
+  promptString: localPrompt.value,
+  artPrompt: localPrompt.value,
+  negativePrompt: localNegativePrompt.value,
+  width: width.value,
+  height: height.value,
+  steps: steps.value,
+  cfg: cfg.value,
+  seed: seed.value,
+  engine: undefined,
+  transport: undefined,
+  generationRequirement: undefined,
+}))
+
+const contextMap: Record<
+  ArtCreatorPurpose,
+  {
+    label: string
+    icon: string
+    title: string
+    description: string
+    role: string
+    hint: string
+    placeholder: string
+  }
+> = {
+  user: {
+    label: 'User',
+    icon: 'kind-icon:person',
+    title: 'Create User Avatar',
+    description:
+      'Create or select avatar art for the user identity and designer profile.',
+    role: 'avatar',
+    hint: 'Focus on identity, expression, profile readability, and a strong silhouette.',
+    placeholder:
+      'A friendly robot designer avatar with expressive eyes, butterfly accents, cozy sci-fi lighting...',
+  },
+
+  builder: {
+    label: 'Builder',
+    icon: 'kind-icon:hammer',
+    title: 'Create Builder Asset',
+    description:
+      'Create, upload, select, or generate the image asset for this builder sheet.',
+    role: 'builder',
+    hint: 'Focus on a clear reusable asset with strong silhouette, readable composition, and enough visual personality to survive repeated UI use.',
+    placeholder:
+      'A polished reusable game asset with strong silhouette, expressive lighting, clean composition, no text, no watermark...',
+  },
+  dream: {
+    label: 'Dream',
+    icon: 'kind-icon:moon',
+    title: 'Create Dream Art',
+    description:
+      'Create setting, vibe, location, or cover art for the evolved dream world.',
+    role: 'world',
+    hint: 'Prioritize setting, atmosphere, visual rules, and story-rich environmental details.',
+    placeholder:
+      'A dreamlike location with strange architecture, atmospheric lighting, and story hooks...',
+  },
+  character: {
+    label: 'Character',
+    icon: 'kind-icon:mask',
+    title: 'Create Character Art',
+    description:
+      'Create portrait, full-body, or scene art for a playable or chattable character.',
+    role: 'portrait',
+    hint: 'Prioritize personality, pose, clothing, expression, silhouette, and role in the world.',
+    placeholder: 'A character portrait of a charming disaster wizard with...',
+  },
+  reward: {
+    label: 'Reward',
+    icon: 'kind-icon:gift',
+    title: 'Create Reward Art',
+    description: 'Create item, relic, skill, power, curse, or story-key art.',
+    role: 'object',
+    hint: 'Focus on the object or power itself, its texture, symbolism, and story function.',
+    placeholder:
+      'A magical artifact shaped like..., glowing with..., presented as...',
+  },
+  scenario: {
+    label: 'Scenario',
+    icon: 'kind-icon:map',
+    title: 'Create Scenario Art',
+    description:
+      'Create a scene image for a branching adventure choice or narrative moment.',
+    role: 'scene',
+    hint: 'Frame a moment with tension, choice, environment, character stakes, and consequence.',
+    placeholder:
+      'A dramatic story scene where characters must choose between...',
+  },
+}
+
+const context = computed(() => contextMap[props.purpose])
+const contextLabel = computed(() => context.value.label)
+const contextIcon = computed(() => context.value.icon)
+const title = computed(() => props.title || context.value.title)
+const description = computed(
+  () => props.description || context.value.description,
+)
+const contextHint = computed(() => context.value.hint)
+const promptPlaceholder = computed(() => context.value.placeholder)
+const resolvedImageRole = computed(() => props.imageRole || context.value.role)
+
+const previewImage = computed(
+  () =>
+    artStore.selectedArtImage?.imagePath ||
+    artStore.selectedArtImage?.imageData ||
+    artStore.selectedArtImage?.path ||
+    artStore.selectedImage?.imagePath ||
+    artStore.selectedImage?.imageData ||
+    artStore.selectedImage?.path ||
+    artStore.selectedArt?.imagePath ||
+    artStore.selectedArt?.path ||
+    null,
+)
+
+const summaryItems = computed(() => [
+  {
+    key: 'purpose',
+    label: 'Purpose',
+    value: `${contextLabel.value} ${resolvedImageRole.value}`,
+    icon: contextIcon.value,
+  },
+  {
+    key: 'mode',
+    label: 'Mode',
+    value: mode.value,
+    icon:
+      modeTabs.find((t) => t.value === mode.value)?.icon ?? 'kind-icon:prompt',
+  },
+  {
+    key: 'prompt',
+    label: 'Prompt',
+    value: localPrompt.value,
+    icon: 'kind-icon:prompt',
+  },
+  {
+    key: 'preview',
+    label: 'Preview',
+    value: previewImage.value ? 'Image selected' : 'No image selected',
+    image: previewImage.value,
+    icon: 'kind-icon:image',
+  },
+])
+
+function buildContextPrompt() {
+  const modelTitle = props.modelTitle.trim()
+  const base = modelTitle
+    ? `Create original ${resolvedImageRole.value} art for "${modelTitle}".`
+    : `Create original ${resolvedImageRole.value} art for a Kind Robots ${contextLabel.value.toLowerCase()}.`
+  const addition = [
+    base,
+    contextHint.value,
+    'Strong composition, expressive atmosphere, no text, no watermark.',
+  ].join(' ')
+  localPrompt.value = localPrompt.value.trim()
+    ? `${localPrompt.value.trim()}\n\n${addition}`
+    : addition
+  emitUpdate()
+}
+
+function appendNoText() {
+  const additions = ['text', 'watermark', 'logo', 'signature']
+  const existing = localNegativePrompt.value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+  for (const addition of additions) {
+    if (!existing.includes(addition)) existing.push(addition)
+  }
+  localNegativePrompt.value = existing.join(', ')
+  emitUpdate()
+}
+
+function clearPrompt() {
+  localPrompt.value = ''
+  emitUpdate()
+}
+function useSquare() {
+  width.value = 1024
+  height.value = 1024
+}
+function useLandscape() {
+  width.value = 1344
+  height.value = 768
+}
+function usePortrait() {
+  width.value = 768
+  height.value = 1344
+}
+
+function syncToArtStore() {
+  const patch = {
+    purpose: props.purpose,
+    modelId: props.modelId,
+    modelTitle: props.modelTitle,
+    imageRole: resolvedImageRole.value,
+    prompt: localPrompt.value,
+    promptString: localPrompt.value,
+    artPrompt: localPrompt.value,
+    negativePrompt: localNegativePrompt.value,
+    width: width.value,
+    height: height.value,
+    steps: steps.value,
+    cfg: cfg.value,
+    seed: seed.value,
+  }
+  try {
+    if (typeof artStore.updateArtForm === 'function') {
+      artStore.updateArtForm(patch)
+      syncMessage.value = 'Art store options updated.'
+      emitUpdate()
+      return
+    }
+    if (typeof artStore.setArtForm === 'function') {
+      artStore.setArtForm(patch)
+      syncMessage.value = 'Art store form updated.'
+      emitUpdate()
+      return
+    }
+    if (artStore.artForm && typeof artStore.artForm === 'object') {
+      Object.assign(artStore.artForm, patch)
+      syncMessage.value = 'Art form patched directly.'
+      emitUpdate()
+      return
+    }
+    if (artStore.form && typeof artStore.form === 'object') {
+      Object.assign(artStore.form, patch)
+      syncMessage.value = 'Art store form patched directly.'
+      emitUpdate()
+      return
+    }
+    syncMessage.value = 'No writable art form method found.'
+    emitUpdate()
+  } catch (error) {
+    handleError(error, 'syncing art-builder to artStore')
+    syncMessage.value = 'Could not sync options to art store.'
+  }
+}
+
+function emitUpdate() {
+  emit('update', {
+    purpose: props.purpose,
+    modelId: props.modelId,
+    modelTitle: props.modelTitle,
+    prompt: localPrompt.value,
+    artPrompt: localPrompt.value,
+    negativePrompt: localNegativePrompt.value,
+    imageRole: resolvedImageRole.value,
+    imagePath: previewImage.value,
+    artImageId: previewImageId.value,
+  })
+}
+
+watch(
+  () => props.prompt,
+  (value) => {
+    localPrompt.value = value
+  },
+)
+watch(
+  () => props.negativePrompt,
+  (value) => {
+    localNegativePrompt.value = value
+  },
+)
+watch([localPrompt, localNegativePrompt, previewImage], () => {
+  emitUpdate()
+})
+</script>

--- a/components/abandonware/builder/builder-art-input.vue
+++ b/components/abandonware/builder/builder-art-input.vue
@@ -1,0 +1,204 @@
+<!-- /components/builder/builder-art-input.vue -->
+<template>
+  <div class="flex flex-col gap-4">
+    <art-builder
+      :purpose="artPurpose"
+      :title="artTitle"
+      :description="artDescription"
+      :model-id="null"
+      :model-title="modelTitle"
+      :prompt="artPrompt"
+      :image-role="imageRole"
+      @update="handleArtUpdate"
+    />
+
+    <div class="flex flex-wrap gap-2">
+      <button
+        type="button"
+        class="btn btn-sm btn-ghost rounded-xl border border-base-300"
+        :disabled="store.isSuggesting"
+        @click="store.callArtSuggest()"
+      >
+        <span
+          v-if="store.isSuggesting"
+          class="loading loading-spinner loading-xs"
+        />
+        <Icon v-else name="kind-icon:sparkles" class="h-4 w-4" />
+        Refine prompt
+      </button>
+
+      <button
+        type="button"
+        class="btn btn-sm btn-primary rounded-xl"
+        :disabled="!artPrompt.trim()"
+        @click="store.finishCard()"
+      >
+        <Icon name="kind-icon:check" class="h-4 w-4" />
+        Use this asset
+      </button>
+    </div>
+
+    <Transition name="builder-art-preview">
+      <div
+        v-if="imagePath"
+        class="relative overflow-hidden rounded-2xl border border-base-300 bg-base-200"
+      >
+        <img
+          :src="imagePath"
+          :alt="modelTitle"
+          class="max-h-96 w-full object-cover"
+        />
+        <div
+          class="absolute inset-x-0 bottom-0 bg-linear-to-t from-base-100/95 to-transparent p-4"
+        >
+          <p class="font-black text-base-content">{{ modelTitle }}</p>
+          <p class="text-xs text-base-content/60">
+            {{ imageRoleLabel }} attached to builder sheet.
+          </p>
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import ArtDesigner from '@/components/abandonware/builder/art-builder.vue'
+import { useBuilderStore } from '@/stores/builderStore'
+
+type ArtDesignerPurpose =
+  | 'user'
+  | 'dream'
+  | 'character'
+  | 'reward'
+  | 'scenario'
+  | 'builder'
+
+type BuilderArtConfig = {
+  purpose?: ArtDesignerPurpose
+  imageRole?: string
+  title?: string
+  description?: string
+}
+
+type BuilderProjectArtConfig = {
+  key?: string
+  label?: string
+  title?: string
+  modelType?: string
+  artPurpose?: ArtDesignerPurpose
+  artImageRole?: string
+  artTitle?: string
+  artDescription?: string
+}
+
+type BuilderStoreWithArtConfig = ReturnType<typeof useBuilderStore> & {
+  activeArtConfig?: BuilderArtConfig
+}
+
+const store = useBuilderStore() as BuilderStoreWithArtConfig
+
+const activeConfig = computed(
+  () => store.activeConfig as unknown as BuilderProjectArtConfig,
+)
+
+const activeArtConfig = computed<BuilderArtConfig | null>(() => {
+  return store.activeArtConfig ?? null
+})
+
+const artPrompt = computed(() => String(store.sheet.artPrompt ?? ''))
+
+const imagePath = computed(() =>
+  typeof store.sheet.imagePath === 'string' ? store.sheet.imagePath : '',
+)
+
+const modelTitle = computed(() =>
+  String(
+    store.sheet.name ||
+      store.sheet.title ||
+      activeConfig.value.title ||
+      'Builder asset',
+  ),
+)
+
+const artPurpose = computed<ArtDesignerPurpose>(() => {
+  if (activeArtConfig.value?.purpose) return activeArtConfig.value.purpose
+  if (activeConfig.value.artPurpose) return activeConfig.value.artPurpose
+  if (activeConfig.value.key === 'adventure') return 'character'
+  if (activeConfig.value.modelType === 'adventure') return 'character'
+  if (activeConfig.value.modelType === 'character') return 'character'
+  if (activeConfig.value.modelType === 'scenario') return 'scenario'
+  if (activeConfig.value.modelType === 'reward') return 'reward'
+  if (activeConfig.value.modelType === 'dream') return 'dream'
+  return 'builder'
+})
+
+const imageRole = computed(() => {
+  if (activeArtConfig.value?.imageRole) return activeArtConfig.value.imageRole
+  if (activeConfig.value.artImageRole) return activeConfig.value.artImageRole
+  if (artPurpose.value === 'character') return 'avatar'
+  if (artPurpose.value === 'scenario') return 'scene'
+  if (artPurpose.value === 'reward') return 'object'
+  if (artPurpose.value === 'dream') return 'world'
+  return 'builder'
+})
+
+const artTitle = computed(() => {
+  if (activeArtConfig.value?.title) return activeArtConfig.value.title
+  if (activeConfig.value.artTitle) return activeConfig.value.artTitle
+  if (artPurpose.value === 'character') return 'Character Avatar Designer'
+  return `${activeConfig.value.label || activeConfig.value.title || 'Builder'} Art Designer`
+})
+
+const artDescription = computed(() => {
+  if (activeArtConfig.value?.description) {
+    return activeArtConfig.value.description
+  }
+
+  if (activeConfig.value.artDescription) {
+    return activeConfig.value.artDescription
+  }
+
+  if (artPurpose.value === 'character') {
+    return 'Create, upload, select, or generate avatar art for this character.'
+  }
+
+  return 'Create, upload, select, or generate art for this builder sheet.'
+})
+
+const imageRoleLabel = computed(() => {
+  if (imageRole.value === 'avatar') return 'Character avatar'
+  if (imageRole.value === 'portrait') return 'Character portrait'
+  if (imageRole.value === 'scene') return 'Scene image'
+  if (imageRole.value === 'object') return 'Reward image'
+  if (imageRole.value === 'cover') return 'Cover image'
+  if (imageRole.value === 'world') return 'World image'
+  return 'Image asset'
+})
+
+function handleArtUpdate(payload: {
+  prompt?: string
+  artPrompt?: string
+  imagePath?: string | null
+  artImageId?: number | null
+}): void {
+  store.updateArt({
+    artPrompt: payload.artPrompt ?? payload.prompt,
+    imagePath: payload.imagePath,
+    artImageId: payload.artImageId,
+  })
+}
+</script>
+
+<style scoped>
+.builder-art-preview-enter-active,
+.builder-art-preview-leave-active {
+  transition: all 180ms ease;
+}
+
+.builder-art-preview-enter-from,
+.builder-art-preview-leave-to {
+  opacity: 0;
+  transform: translateY(0.5rem);
+}
+</style>

--- a/components/abandonware/builder/builder-card-grid.vue
+++ b/components/abandonware/builder/builder-card-grid.vue
@@ -1,0 +1,62 @@
+<!-- /components/builder/builder-card-grid.vue -->
+<template>
+  <section
+    class="flex h-full min-h-0 flex-1 flex-col overflow-hidden kr-panel-flat"
+  >
+    <div
+      class="flex shrink-0 flex-col gap-2 border-b border-base-300 p-4 sm:flex-row sm:items-end sm:justify-between"
+    >
+      <div class="min-w-0">
+        <p class="text-xs font-black uppercase tracking-widest text-primary/70">
+          Choose a card
+        </p>
+        <h2 class="truncate text-2xl font-black text-base-content">
+          {{ store.activeConfig.title }}
+        </h2>
+        <p class="max-w-3xl text-sm leading-relaxed text-base-content/60">
+          {{ store.splash.tagline }}
+        </p>
+      </div>
+
+      <button
+        type="button"
+        class="btn btn-sm btn-ghost shrink-0 rounded-xl border border-base-300"
+        @click="store.randomCard()"
+      >
+        <Icon name="kind-icon:dice" class="h-4 w-4" />
+        Random card
+      </button>
+    </div>
+
+    <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-4">
+      <div
+        v-if="store.visibleCards.length"
+        class="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5"
+      >
+        <builder-card
+          v-for="card in store.visibleCards"
+          :key="card.key"
+          :card="card"
+        />
+      </div>
+
+      <div
+        v-else
+        class="flex min-h-[60vh] flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-base-300 bg-base-200 p-8 text-center"
+      >
+        <Icon name="kind-icon:check" class="h-12 w-12 text-success" />
+        <h3 class="text-xl font-black text-base-content">Deck complete</h3>
+        <p class="max-w-lg text-sm text-base-content/60">
+          Everything required is filled. The sheet is either ready for final
+          interaction or ready to become a much larger problem.
+        </p>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { useBuilderStore } from '@/stores/builderStore'
+
+const store = useBuilderStore()
+</script>

--- a/components/abandonware/builder/builder-custom-input.vue
+++ b/components/abandonware/builder/builder-custom-input.vue
@@ -1,0 +1,31 @@
+<!-- /components/builder/builder-custom-input.vue -->
+<template>
+  <div v-if="step" class="kr-panel-flat p-4">
+    <label class="form-control">
+      <div class="label pb-1">
+        <span class="label-text font-bold">{{ step.inputLabel || step.title }}</span>
+        <span class="label-text-alt text-base-content/40">{{ step.inputType }}</span>
+      </div>
+      <textarea
+        :value="value"
+        class="textarea textarea-bordered min-h-32 rounded-2xl bg-base-100 leading-relaxed focus:border-primary"
+        :placeholder="step.placeholder || 'This custom input type needs a dedicated component later.'"
+        @input="updateValue"
+      />
+    </label>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useBuilderStore } from '@/stores/builderStore'
+
+const store = useBuilderStore()
+const step = computed(() => store.activeStep)
+const value = computed(() => step.value ? store.stagedValues[step.value.key] ?? '' : '')
+
+function updateValue(event: Event): void {
+  if (!step.value) return
+  store.setStagedValue(step.value.key, (event.target as HTMLTextAreaElement).value)
+}
+</script>

--- a/components/abandonware/builder/builder-input.vue
+++ b/components/abandonware/builder/builder-input.vue
@@ -1,0 +1,19 @@
+<!-- /components/builder/builder-input.vue -->
+<template>
+  <builder-preset-input v-if="inputType === 'preset'" />
+  <builder-text-input v-else-if="inputType === 'text' || inputType === 'long'" />
+  <builder-list-input v-else-if="inputType === 'list'" />
+  <builder-stats-input v-else-if="inputType === 'stats'" />
+  <builder-reward-input v-else-if="inputType === 'reward'" />
+  <builder-art-input v-else-if="inputType === 'art'" />
+  <builder-visibility-input v-else-if="inputType === 'visibility' || inputType === 'toggle'" />
+  <builder-custom-input v-else />
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useBuilderStore } from '@/stores/builderStore'
+
+const store = useBuilderStore()
+const inputType = computed(() => store.activeStep?.inputType ?? 'custom')
+</script>

--- a/components/abandonware/builder/builder-list-input.vue
+++ b/components/abandonware/builder/builder-list-input.vue
@@ -1,0 +1,71 @@
+<!-- /components/builder/builder-list-input.vue -->
+<template>
+  <div v-if="step" class="flex flex-col gap-4">
+    <label class="form-control">
+      <div class="label pb-1">
+        <span class="label-text font-bold">{{ step.inputLabel || step.title }}</span>
+        <span class="label-text-alt text-base-content/40">pipe-separated</span>
+      </div>
+      <input
+        v-model="customValue"
+        type="text"
+        class="input input-bordered rounded-2xl bg-base-100 focus:border-primary"
+        :placeholder="step.placeholder || 'Add a custom option...'
+        "
+        @keydown.enter.prevent="addCustomValue"
+      />
+    </label>
+
+    <div v-if="options.length" class="rounded-2xl border border-base-300 bg-base-200 p-3">
+      <p class="mb-2 text-xs font-black uppercase tracking-widest text-base-content/50">Options</p>
+      <div class="flex max-h-64 flex-wrap gap-2 overflow-y-auto pr-1">
+        <button
+          v-for="option in options"
+          :key="option"
+          type="button"
+          class="btn btn-xs rounded-xl"
+          :class="selected.includes(option) ? 'btn-primary' : 'btn-ghost border border-base-300'"
+          @click="store.selectListOption(step.key, option)"
+        >
+          {{ option }}
+        </button>
+      </div>
+    </div>
+
+    <div v-if="selected.length" class="rounded-2xl border border-primary/30 bg-primary/5 p-3">
+      <p class="mb-2 text-xs font-black uppercase tracking-widest text-primary/70">Selected</p>
+      <div class="flex flex-wrap gap-2">
+        <button
+          v-for="item in selected"
+          :key="item"
+          type="button"
+          class="badge badge-primary gap-1 rounded-xl"
+          @click="store.selectListOption(step.key, item)"
+        >
+          {{ item }}
+          <Icon name="kind-icon:x" class="h-3 w-3" />
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useBuilderStore } from '@/stores/builderStore'
+
+const store = useBuilderStore()
+const customValue = ref('')
+
+const step = computed(() => store.activeStep)
+const options = computed(() => step.value?.listOptions ?? step.value?.choices?.map((choice) => choice.value).filter(Boolean) ?? [])
+const selected = computed(() => step.value ? store.selectedListOptions[step.value.key] ?? [] : [])
+
+function addCustomValue(): void {
+  if (!step.value) return
+  const clean = customValue.value.trim()
+  if (!clean) return
+  store.selectListOption(step.value.key, clean)
+  customValue.value = ''
+}
+</script>

--- a/components/abandonware/builder/builder-manager.vue
+++ b/components/abandonware/builder/builder-manager.vue
@@ -1,0 +1,288 @@
+<!-- /components/builder/builder-manager.vue -->
+<template>
+  <section
+    class="flex h-full min-h-0 max-h-full w-full flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-200"
+  >
+    <header
+      class="flex h-10 shrink-0 items-center gap-2 border-b border-base-300 bg-base-100 px-2 sm:px-3"
+    >
+      <div class="flex min-w-0 flex-1 items-center gap-2">
+        <Icon :name="headerIcon" class="h-4 w-4 shrink-0 text-primary" />
+
+        <div class="min-w-0 flex-1">
+          <div class="flex min-w-0 items-center gap-2">
+            <h2
+              class="truncate text-sm font-black leading-none text-base-content sm:text-base"
+            >
+              {{ title }}
+            </h2>
+
+            <span
+              v-if="subtitle"
+              class="hidden min-w-0 flex-1 truncate text-xs font-semibold text-base-content/45 md:block"
+            >
+              {{ subtitle }}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="showBuilderControls" class="flex shrink-0 items-center gap-1">
+        <button
+          type="button"
+          class="btn btn-xs btn-ghost h-7 min-h-7 rounded-xl px-2 text-base-content/60 hover:text-primary"
+          @click="store.randomCard()"
+        >
+          <Icon name="kind-icon:dice" class="h-3.5 w-3.5" />
+          <span class="hidden sm:inline">Random</span>
+        </button>
+
+        <button
+          type="button"
+          class="btn btn-xs btn-ghost h-7 min-h-7 rounded-xl px-2 text-base-content/60 hover:text-error"
+          @click="showResetConfirm = true"
+        >
+          <Icon name="kind-icon:trash" class="h-3.5 w-3.5" />
+          <span class="hidden sm:inline">Reset</span>
+        </button>
+      </div>
+    </header>
+
+    <Transition name="builder-feedback">
+      <div
+        v-if="store.lastError || store.statusMessage"
+        class="shrink-0 border-b px-3 py-1 text-xs font-semibold"
+        :class="
+          store.lastError
+            ? 'border-error/30 bg-error/10 text-error'
+            : 'border-success/30 bg-success/10 text-success'
+        "
+      >
+        {{ store.lastError || store.statusMessage }}
+      </div>
+    </Transition>
+
+    <main class="flex min-h-0 flex-1 flex-col overflow-hidden p-2 sm:p-3">
+      <template v-if="isBuilderActive">
+        <builder-splash v-if="showSplash" />
+        <builder-step-panel v-else-if="store.activeCard" />
+        <builder-summary v-else-if="store.allComplete" />
+        <builder-card-grid v-else />
+      </template>
+
+      <div
+        v-else
+        class="flex min-h-0 flex-1 flex-col items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-100 p-6 text-center"
+      >
+        <Icon name="kind-icon:blueprint" class="h-12 w-12 text-primary/70" />
+
+        <h3 class="mt-4 text-lg font-black text-base-content">
+          Builder is warming up
+        </h3>
+
+        <p class="mt-2 max-w-md text-sm leading-relaxed text-base-content/60">
+          Pick a builder tab to start shaping a character, bot, reward,
+          scenario, dream, or art project.
+        </p>
+      </div>
+    </main>
+
+    <Teleport to="body">
+      <Transition name="builder-modal-fade">
+        <div
+          v-if="showResetConfirm"
+          class="fixed inset-0 z-30 flex items-center justify-center p-4"
+          @click.self="showResetConfirm = false"
+        >
+          <div class="absolute inset-0 bg-base-300/60 backdrop-blur-sm" />
+
+          <div
+            class="kr-panel relative w-full max-w-sm shadow-xl"
+          >
+            <h3 class="text-lg font-black text-base-content">
+              Clear this builder?
+            </h3>
+
+            <p class="mt-2 text-sm leading-relaxed text-base-content/60">
+              This clears staged answers, completed cards, rewards, stats, and
+              local saved state for this builder. Pure potential. Slightly
+              haunted.
+            </p>
+
+            <div class="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                class="btn btn-sm btn-ghost rounded-xl"
+                @click="showResetConfirm = false"
+              >
+                Keep it
+              </button>
+
+              <button
+                type="button"
+                class="btn btn-sm btn-error rounded-xl"
+                @click="resetBuilder"
+              >
+                Clear everything
+              </button>
+            </div>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { useBuilderStore } from '@/stores/builderStore'
+import { useChannelContentStore } from '@/stores/channelContentStore'
+import { useNavStore } from '@/stores/navStore'
+import { ensureBuildersRegistered } from '@/stores/registerBuilderStore'
+
+const store = useBuilderStore()
+const channelContentStore = useChannelContentStore()
+const navStore = useNavStore()
+const showResetConfirm = ref(false)
+
+await channelContentStore.initialize()
+
+const builderChannel = computed(() =>
+  channelContentStore.getChannel('build'),
+)
+
+const defaultBuilderTab = computed(
+  () => builderChannel.value?.defaultTab || 'character',
+)
+
+const activeTab = computed(() =>
+  channelContentStore.getActiveTab('build') || defaultBuilderTab.value,
+)
+
+const activeTabConfig = computed(() =>
+  channelContentStore.getTab('build', activeTab.value),
+)
+
+const isBuilderActive = computed(() => {
+  return store.activeConfig.modelType !== 'builder' && store.cards.length > 0
+})
+
+const showSplash = computed(() => {
+  return (
+    !store.activeCard &&
+    !store.completedCardList.length &&
+    !store.visibleCards.length
+  )
+})
+
+const showBuilderControls = computed(() => isBuilderActive.value)
+
+const fallbackIcon = computed(() => {
+  if (activeTab.value === 'art') return 'kind-icon:palette'
+  return 'kind-icon:blueprint'
+})
+
+const headerIcon = computed(() => {
+  return activeTabConfig.value?.icon || fallbackIcon.value
+})
+
+const fallbackTitle = computed(() => {
+  if (activeTab.value === 'art') return 'Art Builder'
+  return 'Builder'
+})
+
+const title = computed(() => {
+  const sheetTitle = String(store.sheet.name || store.sheet.title || '').trim()
+
+  return (
+    sheetTitle ||
+    store.activeConfig.title ||
+    store.splash.title ||
+    activeTabConfig.value?.title ||
+    fallbackTitle.value
+  )
+})
+
+const fallbackSubtitle = computed(() => {
+  if (activeTab.value === 'art') {
+    return 'Generate and refine artwork for the builder flow.'
+  }
+
+  return 'Choose a builder card and start shaping the project.'
+})
+
+const subtitle = computed(() => {
+  if (store.activeCard) return store.activeCard.title
+  if (store.allComplete) return 'Ready for final review and interaction.'
+
+  return (
+    store.splash.tagline ||
+    store.activeConfig.label ||
+    activeTabConfig.value?.summary ||
+    activeTabConfig.value?.description ||
+    activeTabConfig.value?.label ||
+    fallbackSubtitle.value
+  )
+})
+
+async function syncBuilder(): Promise<void> {
+  await nextTick()
+
+  if (store.getRegisteredConfig(activeTab.value)) {
+    store.setBuilder(activeTab.value)
+    return
+  }
+
+  if (store.getRegisteredConfig(defaultBuilderTab.value)) {
+    store.setBuilder(defaultBuilderTab.value)
+  }
+}
+
+function resetBuilder(): void {
+  store.resetBuilder(true)
+  showResetConfirm.value = false
+}
+
+watch(activeTab, async () => {
+  await syncBuilder()
+})
+
+watch(
+  () => navStore.getDashboardTab('builder'),
+  (legacyTab) => {
+    const tab = builderChannel.value?.tabs.find(
+      (item) => item.dashboardTab === legacyTab,
+    )
+
+    if (tab && tab.tabKey !== activeTab.value) {
+      channelContentStore.setActiveTab('build', tab.tabKey)
+    }
+  },
+)
+
+onMounted(async () => {
+  ensureBuildersRegistered()
+  store.hydrate()
+  await syncBuilder()
+})
+</script>
+
+<style scoped>
+.builder-feedback-enter-active,
+.builder-feedback-leave-active,
+.builder-modal-fade-enter-active,
+.builder-modal-fade-leave-active {
+  transition: all 180ms ease;
+}
+
+.builder-feedback-enter-from,
+.builder-feedback-leave-to {
+  opacity: 0;
+  transform: translateY(-0.5rem);
+}
+
+.builder-modal-fade-enter-from,
+.builder-modal-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/components/abandonware/builder/builder-preset-input.vue
+++ b/components/abandonware/builder/builder-preset-input.vue
@@ -1,0 +1,169 @@
+<!-- /components/builder/builder-preset-input.vue -->
+<template>
+  <div v-if="step" class="flex min-h-0 flex-col gap-4">
+    <div
+      v-if="step.choices?.length"
+      class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
+    >
+      <button
+        v-for="choice in step.choices"
+        :key="choiceKey(choice)"
+        type="button"
+        class="group relative overflow-hidden rounded-2xl border-2 bg-base-200 text-left transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md"
+        :class="choiceClass(choice)"
+        @click="handleChoice(choice)"
+      >
+        <div class="aspect-4/5 overflow-hidden bg-base-300">
+          <img
+            v-if="choice.image"
+            :src="choice.image"
+            :alt="choice.label"
+            class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+            loading="lazy"
+          />
+
+          <div
+            v-else
+            class="flex h-full w-full items-center justify-center text-primary/60"
+          >
+            <Icon :name="choice.icon || iconName" class="h-14 w-14" />
+          </div>
+        </div>
+
+        <div
+          class="flex min-h-16 items-center justify-center bg-base-100/95 p-3 text-center"
+        >
+          <p
+            class="text-sm font-black leading-tight text-base-content sm:text-base"
+          >
+            {{ choice.label }}
+          </p>
+        </div>
+
+        <div
+          v-if="isSelected(choice)"
+          class="absolute right-2 top-2 rounded-full bg-primary p-1.5 text-primary-content shadow"
+        >
+          <Icon name="kind-icon:check" class="h-4 w-4" />
+        </div>
+      </button>
+    </div>
+
+    <div
+      v-if="expandedListOptions.length"
+      class="rounded-2xl border border-base-300 bg-base-200 p-3"
+    >
+      <p
+        class="mb-2 text-xs font-black uppercase tracking-widest text-base-content/50"
+      >
+        More options
+      </p>
+
+      <div class="flex max-h-60 flex-wrap gap-2 overflow-y-auto pr-1">
+        <button
+          v-for="option in expandedListOptions"
+          :key="option"
+          type="button"
+          class="btn btn-xs rounded-xl"
+          :class="
+            store.activeStepValue === option
+              ? 'btn-primary'
+              : 'btn-ghost border border-base-300'
+          "
+          @click="store.selectPresetChoice(step.key, option)"
+        >
+          {{ option }}
+        </button>
+      </div>
+    </div>
+
+    <label v-if="showCustom || hasCustomChoice" class="form-control">
+      <div class="label pb-1">
+        <span class="label-text font-bold">Custom value</span>
+      </div>
+
+      <input
+        :value="store.stagedValues[step.key] ?? ''"
+        type="text"
+        class="input input-bordered rounded-2xl bg-base-100 focus:border-primary"
+        :placeholder="step.placeholder || 'Write your own...'"
+        @input="
+          store.setStagedValue(
+            step.key,
+            ($event.target as HTMLInputElement).value,
+          )
+        "
+      />
+    </label>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useBuilderStore } from '@/stores/builderStore'
+import type { BuilderChoice } from '@/stores/helpers/builderCards'
+
+const store = useBuilderStore()
+const showCustom = ref(false)
+const expandedListOptions = ref<string[]>([])
+
+const step = computed(() => store.activeStep)
+const iconName = computed(() => store.activeCard?.icon || 'kind-icon:cards')
+
+const selectedValues = computed(() =>
+  step.value ? (store.selectedChoiceValues[step.value.key] ?? []) : [],
+)
+
+const hasCustomChoice = computed(() =>
+  Boolean(step.value?.choices?.some((choice) => choice.opensCustom)),
+)
+
+function choiceKey(choice: BuilderChoice): string {
+  return `${choice.label}-${choice.value || choice.opensCustom || choice.opensList}`
+}
+
+function isSelected(choice: BuilderChoice): boolean {
+  if (!step.value) return false
+  if (step.value.multiSelect) return selectedValues.value.includes(choice.value)
+  return Boolean(choice.value && store.activeStepValue === choice.value)
+}
+
+function choiceClass(choice: BuilderChoice): string {
+  if (isSelected(choice)) {
+    return 'border-primary bg-primary/10 shadow shadow-primary/20'
+  }
+
+  return 'border-base-300 hover:border-primary/60'
+}
+
+function handleChoice(choice: BuilderChoice): void {
+  if (!step.value) return
+
+  if (choice.opensCustom) {
+    showCustom.value = true
+    expandedListOptions.value = []
+    return
+  }
+
+  if (choice.opensList) {
+    expandedListOptions.value = choice.listOptions ?? []
+    showCustom.value = false
+    return
+  }
+
+  store.selectPresetChoice(step.value.key, choice.value)
+
+  store.activeSelectionPreview = {
+    key: choice.value || choice.label,
+    stepKey: step.value.key,
+    label: choice.label,
+    value: choice.value,
+    field: step.value.field,
+    image: choice.image ?? null,
+    icon: choice.icon || iconName.value,
+    description: choice.subtext ?? '',
+    narrative: step.value.narrative,
+    tags: [],
+  }
+}
+</script>

--- a/components/abandonware/builder/builder-reward-input.vue
+++ b/components/abandonware/builder/builder-reward-input.vue
@@ -1,0 +1,354 @@
+<!-- /components/builder/builder-reward-input.vue -->
+<template>
+  <div class="flex flex-col gap-4">
+    <div
+      v-if="slotKey"
+      class="flex items-center justify-between gap-2 rounded-2xl border border-base-300 bg-base-200 p-3"
+    >
+      <div class="min-w-0">
+        <p
+          class="text-xs font-black uppercase tracking-widest text-base-content/50"
+        >
+          Reward slot
+        </p>
+
+        <p class="truncate font-black text-base-content">
+          {{ slotLabel }}
+        </p>
+      </div>
+
+      <button
+        type="button"
+        class="btn btn-sm btn-ghost rounded-xl border border-base-300"
+        :disabled="store.isRewardLoading"
+        @click="rerollOptions"
+      >
+        <Icon
+          :name="store.isRewardLoading ? 'kind-icon:spinner' : 'kind-icon:dice'"
+          class="h-4 w-4"
+          :class="store.isRewardLoading ? 'animate-spin' : ''"
+        />
+        {{ store.isRewardLoading ? 'Drawing…' : 'Reroll options' }}
+      </button>
+    </div>
+
+    <div
+      v-if="store.rewardError"
+      class="rounded-2xl border border-error/30 bg-error/10 p-4 text-sm font-bold text-error"
+    >
+      {{ store.rewardError }}
+    </div>
+
+    <div
+      v-if="store.activeRewardOptions.length"
+      class="grid grid-cols-1 gap-3 sm:grid-cols-2"
+    >
+      <button
+        v-for="reward in store.activeRewardOptions"
+        :key="reward.id"
+        type="button"
+        class="rounded-2xl border-2 bg-base-100 p-4 text-left transition-all hover:-translate-y-0.5 hover:border-primary/60 hover:shadow-md"
+        :class="
+          store.activeSelectedRewardId === reward.id
+            ? 'border-primary bg-primary/10'
+            : 'border-base-300'
+        "
+        @click="selectReward(reward.id)"
+      >
+        <div class="flex items-start gap-3">
+          <div
+            class="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-secondary/10 text-secondary"
+          >
+            <img
+              v-if="rewardImagePath(reward)"
+              :src="rewardImagePath(reward) || ''"
+              :alt="reward.label || 'Reward image'"
+              class="h-full w-full object-cover"
+              loading="lazy"
+              @error="markRewardImageFailed(reward.id)"
+            />
+
+            <Icon v-else :name="rewardIcon(reward)" class="h-6 w-6" />
+          </div>
+
+          <div class="min-w-0 flex-1">
+            <div class="flex min-w-0 flex-wrap items-center gap-2">
+              <p class="min-w-0 truncate font-black text-base-content">
+                {{ reward.label || 'Unnamed reward' }}
+              </p>
+
+              <span
+                v-if="rewardTypeLabel(reward)"
+                class="badge badge-sm rounded-xl border-base-300 bg-base-200 text-[0.65rem] font-black uppercase tracking-widest text-base-content/60"
+              >
+                {{ rewardTypeLabel(reward) }}
+              </span>
+            </div>
+
+            <p
+              v-if="reward.rarity"
+              class="mt-0.5 text-xs font-bold uppercase tracking-widest text-primary/70"
+            >
+              {{ reward.rarity }}
+            </p>
+
+            <p
+              v-if="reward.description"
+              class="mt-2 text-sm leading-relaxed text-base-content/60"
+            >
+              {{ reward.description }}
+            </p>
+          </div>
+        </div>
+      </button>
+    </div>
+
+    <div
+      v-else
+      class="rounded-2xl border border-dashed border-base-300 bg-base-200 p-6 text-center"
+    >
+      <Icon
+        :name="store.isRewardLoading ? 'kind-icon:spinner' : fallbackIcon"
+        class="mx-auto h-10 w-10 text-base-content/25"
+        :class="store.isRewardLoading ? 'animate-spin' : ''"
+      />
+
+      <p class="mt-2 font-black text-base-content">
+        {{
+          store.isRewardLoading
+            ? 'Drawing reward options…'
+            : 'No reward options yet'
+        }}
+      </p>
+
+      <p class="mx-auto mt-1 max-w-md text-sm text-base-content/50">
+        {{ emptyMessage }}
+      </p>
+
+      <button
+        v-if="slotKey && !store.isRewardLoading"
+        type="button"
+        class="btn btn-sm btn-primary mt-4 rounded-xl"
+        @click="rerollOptions"
+      >
+        <Icon name="kind-icon:dice" class="h-4 w-4" />
+        Draw options
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useBuilderStore } from '@/stores/builderStore'
+import type { BuilderRewardOption } from '@/stores/helpers/builderCards'
+import type { RolledReward } from '@/stores/generatorStore'
+
+type RewardImageSource = {
+  image?: string | null
+  imageUrl?: string | null
+  imagePath?: string | null
+  image_path?: string | null
+  artImagePath?: string | null
+  art_image_path?: string | null
+  imageData?: string | null
+  image_data?: string | null
+  artImage?: {
+    imagePath?: string | null
+    path?: string | null
+    imageData?: string | null
+  } | null
+  art?: {
+    imagePath?: string | null
+    path?: string | null
+  } | null
+}
+
+type RewardPayload = {
+  reward?: RolledReward & RewardImageSource
+  image?: string | null
+  imageUrl?: string | null
+  imagePath?: string | null
+  image_path?: string | null
+  artImagePath?: string | null
+  art_image_path?: string | null
+  imageData?: string | null
+  image_data?: string | null
+  rewardType?: string | null
+}
+
+function cleanImagePath(path: string): string {
+  const trimmedPath = path.trim()
+
+  if (!trimmedPath) return ''
+  if (trimmedPath.startsWith('/')) return trimmedPath
+  if (trimmedPath.startsWith('http://')) return trimmedPath
+  if (trimmedPath.startsWith('https://')) return trimmedPath
+  if (trimmedPath.startsWith('data:')) return trimmedPath
+
+  return `/${trimmedPath}`
+}
+
+function rewardImagePath(option: BuilderRewardOption): string | null {
+  if (failedRewardImages.value.has(option.id)) return null
+
+  const payload = optionPayload(option)
+  const reward = payload.reward
+  const optionImageSource = option as BuilderRewardOption & RewardImageSource
+
+  const imagePath =
+    optionImageSource.imagePath ||
+    optionImageSource.imageUrl ||
+    optionImageSource.image ||
+    optionImageSource.image_path ||
+    optionImageSource.artImagePath ||
+    optionImageSource.art_image_path ||
+    optionImageSource.imageData ||
+    optionImageSource.image_data ||
+    optionImageSource.artImage?.imagePath ||
+    optionImageSource.artImage?.path ||
+    optionImageSource.artImage?.imageData ||
+    optionImageSource.art?.imagePath ||
+    optionImageSource.art?.path ||
+    payload.imagePath ||
+    payload.imageUrl ||
+    payload.image ||
+    payload.image_path ||
+    payload.artImagePath ||
+    payload.art_image_path ||
+    payload.imageData ||
+    payload.image_data ||
+    reward?.imagePath ||
+    reward?.imageUrl ||
+    reward?.image ||
+    reward?.image_path ||
+    reward?.artImagePath ||
+    reward?.art_image_path ||
+    reward?.imageData ||
+    reward?.image_data ||
+    reward?.artImage?.imagePath ||
+    reward?.artImage?.path ||
+    reward?.artImage?.imageData ||
+    reward?.art?.imagePath ||
+    reward?.art?.path ||
+    ''
+
+  const cleanedPath = cleanImagePath(String(imagePath))
+
+  return cleanedPath || null
+}
+
+const store = useBuilderStore()
+const failedRewardImages = ref<Set<string>>(new Set())
+
+const slotKey = computed(() => store.activeCard?.rewardSlotKey ?? '')
+
+const slotLabel = computed(() => {
+  if (!slotKey.value) return 'No slot selected'
+
+  return slotKey.value
+    .split('-')
+    .filter(Boolean)
+    .map((part: string) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+})
+
+const fallbackIcon = computed(() => {
+  if (slotKey.value.includes('skill')) return 'kind-icon:sparkles'
+  if (slotKey.value.includes('item')) return 'kind-icon:treasure'
+
+  return 'kind-icon:gift'
+})
+
+const emptyMessage = computed(() => {
+  if (store.isRewardLoading) {
+    return 'Checking your reward pool for matching options.'
+  }
+
+  if (slotKey.value.includes('skill')) {
+    return 'Draw a fresh set of starting skills.'
+  }
+
+  if (slotKey.value.includes('item')) {
+    return 'Draw a fresh set of starting items.'
+  }
+
+  return 'Draw a fresh set for this slot.'
+})
+
+function optionPayload(option: BuilderRewardOption): RewardPayload {
+  if (option.payload && typeof option.payload === 'object') {
+    return option.payload as RewardPayload
+  }
+
+  return {}
+}
+
+function payloadReward(option: BuilderRewardOption): RolledReward | null {
+  const reward = optionPayload(option).reward
+
+  if (reward && typeof reward === 'object') {
+    return reward as RolledReward
+  }
+
+  return null
+}
+
+function markRewardImageFailed(optionId: string): void {
+  failedRewardImages.value = new Set([...failedRewardImages.value, optionId])
+}
+
+function rewardTypeLabel(option: BuilderRewardOption): string {
+  const reward = payloadReward(option)
+  const payload = optionPayload(option)
+  const rewardType = String(
+    reward?.rewardType ?? payload.rewardType ?? '',
+  ).trim()
+
+  return rewardType ? rewardType.toLowerCase() : ''
+}
+
+function rewardIcon(option: BuilderRewardOption): string {
+  const reward = payloadReward(option)
+  const payload = optionPayload(option)
+  const rewardType = String(
+    reward?.rewardType ?? payload.rewardType ?? '',
+  ).toUpperCase()
+
+  if (option.icon) return option.icon
+  if (reward?.icon) return reward.icon
+  if (rewardType === 'SKILL') return 'kind-icon:sparkles'
+  if (rewardType === 'ITEM') return 'kind-icon:treasure'
+  if (rewardType === 'POWER') return 'kind-icon:bolt'
+  if (rewardType === 'PET') return 'kind-icon:heart'
+  if (rewardType === 'MAGIC') return 'kind-icon:wand'
+  if (rewardType === 'FAVOR') return 'kind-icon:star'
+
+  return fallbackIcon.value
+}
+
+function selectReward(optionId: string): void {
+  if (!slotKey.value) return
+  store.selectRewardOption(slotKey.value, optionId)
+}
+
+async function rerollOptions(): Promise<void> {
+  if (!slotKey.value) return
+
+  failedRewardImages.value = new Set()
+  await store.rollRewardOptions(slotKey.value)
+}
+
+watch(
+  slotKey,
+  (nextSlotKey: string) => {
+    failedRewardImages.value = new Set()
+
+    if (!nextSlotKey) return
+    if (store.activeRewardOptions.length) return
+
+    void store.rollRewardOptions(nextSlotKey)
+  },
+  { immediate: true },
+)
+</script>

--- a/components/abandonware/builder/builder-splash.vue
+++ b/components/abandonware/builder/builder-splash.vue
@@ -1,0 +1,174 @@
+<!-- /components/builder/builder-splash.vue -->
+<!--
+  Polished landing page for the card-deck builder.
+  Drop-in replacement — uses the same builderStore API you already have:
+    store.activeConfig.label · store.splash.* · store.cards · store.visibleCards
+    store.selectCard(key) · store.randomCard()
+  Art comes straight from your adventureCards.ts (deckImage / flourish / icon / label).
+-->
+<template>
+  <section
+    class="relative grid min-h-full gap-6 overflow-hidden kr-panel-flat p-5 lg:grid-cols-[minmax(0,1fr)_minmax(280px,440px)] lg:p-8"
+  >
+    <!-- ambient wash: primary in one corner, secondary in the other -->
+    <div
+      class="pointer-events-none absolute inset-0 opacity-80"
+      style="
+        background:
+          radial-gradient(
+            120% 120% at 100% 0%,
+            color-mix(in oklab, var(--color-primary) 10%, transparent),
+            transparent 45%
+          ),
+          radial-gradient(
+            120% 120% at 0% 100%,
+            color-mix(in oklab, var(--color-secondary) 8%, transparent),
+            transparent 45%
+          );
+      "
+    />
+
+    <!-- ── Left: copy ─────────────────────────────────────────────── -->
+    <div class="relative z-10 flex min-w-0 flex-col justify-center gap-5">
+      <div class="flex items-center gap-3">
+        <div
+          class="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary"
+        >
+          <Icon name="kind-icon:sparkles" class="h-7 w-7" />
+        </div>
+        <div class="min-w-0">
+          <p
+            class="text-xs font-black uppercase tracking-[0.22em] text-primary/70"
+          >
+            {{ store.activeConfig.label }}
+          </p>
+          <h1
+            class="builder-display text-4xl font-black leading-[0.92] text-base-content md:text-6xl"
+          >
+            {{ store.splash.title }}
+          </h1>
+        </div>
+      </div>
+
+      <p
+        v-if="store.splash.subtitle"
+        class="text-xl font-bold text-secondary md:text-2xl"
+      >
+        {{ store.splash.subtitle }}
+      </p>
+      <p
+        class="max-w-2xl text-base leading-relaxed text-base-content/65 md:text-lg"
+      >
+        {{ store.splash.description }}
+      </p>
+
+      <div class="flex flex-wrap gap-2.5">
+        <button
+          type="button"
+          class="btn btn-primary gap-2 rounded-2xl px-5 text-base"
+          @click="startBuilder"
+        >
+          <Icon name="kind-icon:play" class="h-4 w-4" />
+          {{ store.splash.ctaLabel || 'Start building' }}
+        </button>
+        <button
+          type="button"
+          class="btn btn-ghost gap-2 rounded-2xl border border-base-300 px-5 text-base"
+          @click="store.randomCard()"
+        >
+          <Icon name="kind-icon:dice" class="h-4 w-4" />
+          {{ store.splash.secondaryLabel || 'Surprise me' }}
+        </button>
+      </div>
+
+      <!-- card-label chips: a quick read of the whole deck -->
+      <div class="mt-1 flex flex-wrap gap-1.5">
+        <span
+          v-for="card in store.cards"
+          :key="card.key"
+          class="inline-flex items-center gap-1.5 rounded-full border border-base-300 bg-base-200 px-2.5 py-1 text-xs font-bold text-base-content/55"
+        >
+          <span class="text-sm leading-none text-primary/70">{{
+            card.flourish
+          }}</span>
+          {{ card.label }}
+        </span>
+      </div>
+    </div>
+
+    <!-- ── Right: fanned deck of real card art ───────────────────── -->
+    <div
+      class="relative z-10 hidden min-h-80 overflow-hidden rounded-2xl lg:block"
+    >
+      <div class="absolute inset-0">
+        <div
+          v-for="(card, i) in fanCards"
+          :key="card.key"
+          class="splash-card absolute overflow-hidden rounded-2xl border border-base-300 bg-base-200 shadow-xl"
+          :style="fanStyle(i)"
+        >
+          <img
+            v-if="card.deckImage"
+            :src="card.deckImage"
+            :alt="card.label"
+            class="h-full w-full object-cover"
+          />
+          <div
+            v-else
+            class="flex h-full w-full items-center justify-center text-7xl text-base-content/15"
+          >
+            {{ card.flourish }}
+          </div>
+          <div
+            class="absolute inset-x-0 bottom-0 flex items-center gap-1.5 bg-linear-to-t from-base-100/90 to-transparent px-3 py-2"
+          >
+            <Icon :name="card.icon" class="h-3.5 w-3.5 text-primary" />
+            <span
+              class="text-xs font-black uppercase tracking-widest text-base-content/80"
+            >
+              {{ card.label }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useBuilderStore } from '@/stores/builderStore'
+
+const store = useBuilderStore()
+
+// First three cards make the fan. Swap for hero cards if you prefer.
+const fanCards = computed(() => (store.cards ?? []).slice(0, 3))
+
+function fanStyle(i: number) {
+  return {
+    inset: '14px',
+    transform: `rotate(${(i - 1) * 5}deg) translate(${(i - 1) * 16}px, ${i * 6}px)`,
+    zIndex: String(3 - i),
+  }
+}
+
+function startBuilder(): void {
+  const first = store.visibleCards[0]
+  if (first) store.selectCard(first.key)
+}
+</script>
+
+<style scoped>
+.builder-display {
+  font-family: 'Bricolage Grotesque', ui-sans-serif, system-ui, sans-serif;
+  letter-spacing: -0.01em;
+}
+
+.splash-card {
+  transition: transform 0.35s cubic-bezier(0.3, 0.7, 0.4, 1);
+}
+.splash-card:hover {
+  transform: rotate(0deg) translate(0, -6px) scale(1.02) !important;
+  z-index: 9 !important;
+}
+</style>

--- a/components/abandonware/builder/builder-stage.vue
+++ b/components/abandonware/builder/builder-stage.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="flex h-full min-h-0 flex-1 flex-col gap-3 overflow-hidden">
+    <art-builder v-if="isArtStage" purpose="builder" />
+
+    <template v-else-if="isBuilderActive">
+      <builder-splash v-if="showSplash" />
+      <builder-step-panel v-else-if="store.activeCard" />
+      <builder-summary v-else-if="store.allComplete" />
+      <builder-card-grid v-else />
+    </template>
+
+    <slot v-else />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useBuilderStore } from '@/stores/builderStore'
+
+const store = useBuilderStore()
+
+const isArtStage = computed(() => store.activeConfig.modelType === 'art')
+
+const isBuilderActive = computed(() => {
+  const t = store.activeConfig.modelType
+  return t !== 'builder' && store.cards.length > 0
+})
+
+const showSplash = computed(() => {
+  return (
+    !store.activeCard &&
+    !store.completedCardList.length &&
+    !store.visibleCards.length
+  )
+})
+</script>

--- a/components/abandonware/builder/builder-stats-input.vue
+++ b/components/abandonware/builder/builder-stats-input.vue
@@ -1,0 +1,63 @@
+<!-- /components/builder/builder-stats-input.vue -->
+<template>
+  <div class="flex flex-col gap-4">
+    <div class="rounded-2xl border border-base-300 bg-base-200 p-3">
+      <p class="mb-2 text-xs font-black uppercase tracking-widest text-base-content/50">Number blocks</p>
+      <div class="grid grid-cols-6 gap-2">
+        <button
+          v-for="block in blocks"
+          :key="block"
+          type="button"
+          class="btn rounded-2xl text-lg font-black"
+          :class="blockClass(block)"
+          @click="store.selectStatBlock(block)"
+        >
+          {{ block }}
+        </button>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+      <button
+        v-for="stat in store.draftStats"
+        :key="stat.key"
+        type="button"
+        class="flex items-center gap-3 rounded-2xl border-2 bg-base-100 p-4 text-left transition-all hover:-translate-y-0.5 hover:border-primary/60 hover:shadow-md"
+        :class="stat.value ? 'border-primary/40' : 'border-base-300'"
+        @click="store.assignStat(stat.key)"
+      >
+        <span class="text-3xl leading-none">{{ stat.display }}</span>
+        <span class="min-w-0 flex-1">
+          <span class="block truncate font-black text-base-content">{{ stat.name }}</span>
+          <span class="text-xs text-base-content/50">{{ stat.key }}</span>
+        </span>
+        <span class="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-lg font-black text-primary">
+          {{ stat.value || '—' }}
+        </span>
+      </button>
+    </div>
+
+    <div class="flex flex-wrap items-center justify-between gap-2 kr-panel-flat p-3">
+      <p class="text-sm font-semibold" :class="store.statAllocationComplete ? 'text-success' : 'text-base-content/50'">
+        {{ store.statAllocationComplete ? 'Stats are allocated.' : 'Assign each number from 1 to 6 once.' }}
+      </p>
+      <button type="button" class="btn btn-sm btn-ghost rounded-xl border border-base-300" @click="store.rollAllStats()">
+        <Icon name="kind-icon:dice" class="h-4 w-4" />
+        Roll all
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useBuilderStore } from '@/stores/builderStore'
+
+const store = useBuilderStore()
+const blocks = [1, 2, 3, 4, 5, 6]
+
+function blockClass(block: number): string {
+  if (store.selectedStatBlock === block) return 'btn-primary'
+  if (store.usedStatValues.includes(block)) return 'btn-ghost border border-success text-success'
+  return 'btn-ghost border border-base-300'
+}
+</script>

--- a/components/abandonware/builder/builder-step-panel.vue
+++ b/components/abandonware/builder/builder-step-panel.vue
@@ -1,0 +1,243 @@
+<!-- /components/builder/builder-step-panel.vue -->
+<template>
+  <article
+    v-if="store.activeCard && store.activeStep"
+    class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
+  >
+    <section
+      class="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden kr-panel-flat"
+    >
+      <template v-if="store.activeSelectionPreview">
+        <div class="flex h-full min-h-0 flex-col overflow-hidden">
+          <section
+            class="grid h-full min-h-0 flex-1 overflow-hidden rounded-2xl border border-primary/30 bg-base-100 shadow-xl lg:grid-cols-[minmax(0,1.08fr)_minmax(20rem,0.92fr)]"
+          >
+            <figure class="relative min-h-0 overflow-hidden bg-base-300">
+              <img
+                v-if="store.activeSelectionPreview.image"
+                :src="store.activeSelectionPreview.image"
+                :alt="store.activeSelectionPreview.label"
+                class="h-full max-h-[42dvh] w-full object-cover sm:max-h-[48dvh] lg:max-h-none lg:object-cover"
+                loading="eager"
+              />
+
+              <div
+                v-else
+                class="flex h-full min-h-64 items-center justify-center bg-base-200 text-primary/60"
+              >
+                <Icon
+                  :name="
+                    store.activeSelectionPreview.icon ||
+                    store.activeCard?.icon ||
+                    'kind-icon:cards'
+                  "
+                  class="h-24 w-24"
+                />
+              </div>
+
+              <div
+                class="pointer-events-none absolute inset-x-0 bottom-0 h-32 bg-linear-to-t from-base-100/90 to-transparent lg:hidden"
+              />
+            </figure>
+
+            <section
+              class="flex min-h-0 flex-col justify-between gap-4 p-4 sm:p-5 lg:p-6"
+            >
+              <div class="min-h-0">
+                <div class="mb-3 flex items-center gap-2">
+                  <span
+                    class="rounded-full bg-primary/15 px-3 py-1 text-xs font-black uppercase tracking-widest text-primary"
+                  >
+                    Choose option
+                  </span>
+
+                  <span
+                    v-if="store.activeCard?.label"
+                    class="hidden rounded-full bg-base-200 px-3 py-1 text-xs font-bold text-base-content/60 sm:inline-flex"
+                  >
+                    {{ store.activeCard.label }}
+                  </span>
+                </div>
+
+                <h2
+                  class="text-4xl font-black leading-none text-base-content sm:text-5xl lg:text-6xl"
+                >
+                  {{ store.activeSelectionPreview.label }}
+                </h2>
+
+                <p
+                  v-if="store.activeSelectionPreview.description"
+                  class="mt-4 max-w-2xl text-base font-semibold leading-relaxed text-base-content/75 sm:text-lg lg:text-xl"
+                >
+                  {{ store.activeSelectionPreview.description }}
+                </p>
+
+                <p
+                  v-if="store.activeSelectionPreview.narrative"
+                  class="mt-4 hidden max-w-2xl text-sm leading-relaxed text-base-content/55 sm:block lg:text-base"
+                >
+                  {{ store.activeSelectionPreview.narrative }}
+                </p>
+              </div>
+
+              <div
+                class="grid shrink-0 grid-cols-2 gap-2 sm:flex sm:flex-wrap sm:items-center"
+              >
+                <button
+                  type="button"
+                  class="btn btn-ghost rounded-2xl border border-base-300"
+                  @click="store.activeSelectionPreview = null"
+                >
+                  <Icon name="kind-icon:back" class="h-4 w-4" />
+                  Back
+                </button>
+
+                <button
+                  type="button"
+                  class="btn btn-primary rounded-2xl sm:min-w-44"
+                  @click="chooseSelectionPreview"
+                >
+                  <Icon name="kind-icon:check" class="h-4 w-4" />
+                  Choose
+                </button>
+              </div>
+            </section>
+          </section>
+        </div>
+      </template>
+
+      <template v-else>
+        <div class="min-h-0 flex-1 overflow-y-auto p-4">
+          <div class="flex min-h-full flex-col gap-4">
+            <div class="flex items-start justify-between gap-3">
+              <div class="min-w-0">
+                <p
+                  class="text-xs font-black uppercase tracking-widest text-primary/70"
+                >
+                  {{ store.activeCard.label }} · Step
+                  {{ store.activeStepIndex + 1 }} of
+                  {{ store.activeCard.steps.length }}
+                </p>
+
+                <h2 class="text-2xl font-black leading-tight text-base-content">
+                  {{ store.activeStep.title }}
+                </h2>
+
+                <p
+                  v-if="store.activeStep.narrative"
+                  class="mt-2 text-sm leading-relaxed text-base-content/65"
+                >
+                  {{ store.activeStep.narrative }}
+                </p>
+              </div>
+
+              <button
+                type="button"
+                class="btn btn-sm btn-ghost shrink-0 rounded-xl"
+                @click="store.cancelCard()"
+              >
+                <Icon name="kind-icon:x" class="h-4 w-4" />
+              </button>
+            </div>
+
+            <div class="flex flex-wrap gap-2">
+              <span
+                v-for="step in store.activeCard.steps"
+                :key="step.key"
+                class="badge rounded-xl"
+                :class="
+                  step.key === store.activeStep.key
+                    ? 'badge-primary'
+                    : 'badge-outline'
+                "
+              >
+                {{ step.title }}
+              </span>
+            </div>
+
+            <builder-input />
+
+            <div class="min-h-4 flex-1" />
+          </div>
+        </div>
+
+        <div class="shrink-0 border-t border-base-300 bg-base-100 p-4">
+          <div class="flex flex-wrap items-center justify-between gap-2">
+            <div class="flex gap-2">
+              <button
+                type="button"
+                class="btn btn-sm rounded-xl"
+                :disabled="store.isFirstStep"
+                @click="store.prevStep()"
+              >
+                <Icon name="kind-icon:arrow-left" class="h-4 w-4" />
+                Back
+              </button>
+
+              <button
+                v-if="!store.isLastStep"
+                type="button"
+                class="btn btn-sm btn-primary rounded-xl"
+                @click="store.nextStep()"
+              >
+                Next
+                <Icon name="kind-icon:arrow-right" class="h-4 w-4" />
+              </button>
+
+              <button
+                v-else
+                type="button"
+                class="btn btn-sm btn-primary rounded-xl"
+                :disabled="!store.canFinish"
+                @click="store.finishCard()"
+              >
+                <Icon name="kind-icon:check" class="h-4 w-4" />
+                Finish card
+              </button>
+            </div>
+
+            <button
+              v-if="canSuggest"
+              type="button"
+              class="btn btn-sm btn-ghost rounded-xl border border-base-300"
+              :disabled="store.isSuggesting"
+              @click="store.callSuggest()"
+            >
+              <span
+                v-if="store.isSuggesting"
+                class="loading loading-spinner loading-xs"
+              />
+              <Icon v-else name="kind-icon:sparkles" class="h-4 w-4" />
+              Suggest
+            </button>
+          </div>
+        </div>
+      </template>
+    </section>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick } from 'vue'
+import { useBuilderStore } from '@/stores/builderStore'
+
+const store = useBuilderStore()
+
+const canSuggest = computed(() => {
+  const step = store.activeStep
+  return Boolean(step?.needsLLM || step?.suggestField || step?.field)
+})
+
+const chooseSelectionPreview = async () => {
+  store.confirmSelectionPreview()
+
+  await nextTick()
+
+  if (store.isLastStep) {
+    store.finishCard()
+    return
+  }
+
+  store.nextStep()
+}
+</script>

--- a/components/abandonware/builder/builder-summary.vue
+++ b/components/abandonware/builder/builder-summary.vue
@@ -1,0 +1,85 @@
+<!-- /components/builder/builder-summary.vue -->
+<template>
+  <section class="flex min-h-full flex-col gap-4 kr-panel-flat p-4">
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <p class="text-xs font-black uppercase tracking-widest text-success/80">Complete</p>
+        <h2 class="text-3xl font-black text-base-content">{{ title }}</h2>
+        <p class="mt-2 max-w-3xl text-sm leading-relaxed text-base-content/60">
+          The required cards are complete. This is the generic final screen, ready for a model-specific interact component when you want the deluxe version.
+        </p>
+      </div>
+
+      <button type="button" class="btn btn-sm btn-primary rounded-xl" @click="store.randomCard()">
+        <Icon name="kind-icon:cards" class="h-4 w-4" />
+        Revisit deck
+      </button>
+    </div>
+
+    <div class="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(280px,420px)]">
+      <div class="rounded-2xl border border-base-300 bg-base-200 p-4">
+        <p class="mb-3 text-xs font-black uppercase tracking-widest text-base-content/50">Sheet data</p>
+        <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          <div
+            v-for="entry in sheetEntries"
+            :key="entry.key"
+            class="rounded-2xl bg-base-100 p-3"
+          >
+            <p class="text-[0.6rem] font-black uppercase tracking-widest text-base-content/35">{{ entry.key }}</p>
+            <p class="mt-1 line-clamp-5 text-sm font-semibold leading-relaxed text-base-content/75">{{ entry.value }}</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="overflow-hidden rounded-2xl border border-base-300 bg-base-200">
+        <div class="relative aspect-4/3 bg-base-300">
+          <img v-if="imagePath" :src="imagePath" :alt="title" class="h-full w-full object-cover" />
+          <div v-else class="flex h-full w-full items-center justify-center">
+            <Icon name="kind-icon:blueprint" class="h-16 w-16 text-base-content/20" />
+          </div>
+          <div class="absolute inset-x-0 bottom-0 bg-linear-to-t from-base-100/95 to-transparent p-4">
+            <p class="font-black text-base-content">{{ title }}</p>
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-3 p-4">
+          <button type="button" class="btn btn-primary rounded-2xl" @click="store.setStatus('Generic builder summary acknowledged.')">
+            <Icon name="kind-icon:check" class="h-4 w-4" />
+            Looks good
+          </button>
+          <button type="button" class="btn btn-ghost rounded-2xl border border-base-300" @click="store.resetBuilder(false)">
+            <Icon name="kind-icon:refresh" class="h-4 w-4" />
+            New local draft
+          </button>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useBuilderStore } from '@/stores/builderStore'
+
+const store = useBuilderStore()
+
+const title = computed(() => String(store.sheet.name || store.sheet.title || store.activeConfig.title || 'Completed Builder'))
+const imagePath = computed(() => typeof store.sheet.imagePath === 'string' ? store.sheet.imagePath : '')
+
+const sheetEntries = computed(() => {
+  return Object.entries(store.sheet)
+    .map(([key, value]) => ({ key, value: stringifyValue(value) }))
+    .filter((entry) => entry.value.trim().length > 0)
+})
+
+function stringifyValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => typeof entry === 'object' ? JSON.stringify(entry) : String(entry))
+      .join(', ')
+  }
+  if (value && typeof value === 'object') return JSON.stringify(value)
+  if (value == null) return ''
+  return String(value)
+}
+</script>

--- a/components/abandonware/builder/builder-text-input.vue
+++ b/components/abandonware/builder/builder-text-input.vue
@@ -1,0 +1,42 @@
+<!-- /components/builder/builder-text-input.vue -->
+<template>
+  <label v-if="step" class="form-control">
+    <div class="label pb-1">
+      <span class="label-text font-bold">{{ step.inputLabel || step.title }}</span>
+      <span class="label-text-alt text-base-content/40">{{ value.length }} chars</span>
+    </div>
+
+    <textarea
+      v-if="step.inputType === 'long'"
+      :value="value"
+      class="textarea textarea-bordered min-h-40 rounded-2xl bg-base-100 leading-relaxed focus:border-primary"
+      :placeholder="step.placeholder || 'Type here...'
+      "
+      @input="updateValue"
+    />
+
+    <input
+      v-else
+      :value="value"
+      type="text"
+      class="input input-bordered rounded-2xl bg-base-100 focus:border-primary"
+      :placeholder="step.placeholder || 'Type here...'
+      "
+      @input="updateValue"
+    />
+  </label>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useBuilderStore } from '@/stores/builderStore'
+
+const store = useBuilderStore()
+const step = computed(() => store.activeStep)
+const value = computed(() => (step.value ? store.stagedValues[step.value.key] ?? '' : ''))
+
+function updateValue(event: Event): void {
+  if (!step.value) return
+  store.setStagedValue(step.value.key, (event.target as HTMLInputElement | HTMLTextAreaElement).value)
+}
+</script>

--- a/components/abandonware/builder/builder-visibility-input.vue
+++ b/components/abandonware/builder/builder-visibility-input.vue
@@ -1,0 +1,32 @@
+<!-- /components/builder/builder-visibility-input.vue -->
+<template>
+  <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+    <button
+      type="button"
+      class="rounded-2xl border-2 bg-base-100 p-4 text-left transition-all hover:border-primary/60"
+      :class="store.sheet.isPublic ? 'border-primary bg-primary/10' : 'border-base-300'"
+      @click="store.updateSheet({ isPublic: !Boolean(store.sheet.isPublic) })"
+    >
+      <Icon name="kind-icon:globe" class="mb-2 h-7 w-7 text-primary" />
+      <p class="font-black text-base-content">Public</p>
+      <p class="text-sm text-base-content/60">Visible to the wider Kind Robots ecosystem.</p>
+    </button>
+
+    <button
+      type="button"
+      class="rounded-2xl border-2 bg-base-100 p-4 text-left transition-all hover:border-warning/60"
+      :class="store.sheet.isMature ? 'border-warning bg-warning/10' : 'border-base-300'"
+      @click="store.updateSheet({ isMature: !Boolean(store.sheet.isMature) })"
+    >
+      <Icon name="kind-icon:warning" class="mb-2 h-7 w-7 text-warning" />
+      <p class="font-black text-base-content">Mature</p>
+      <p class="text-sm text-base-content/60">Marks this model as mature or filtered content.</p>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useBuilderStore } from '@/stores/builderStore'
+
+const store = useBuilderStore()
+</script>

--- a/components/abandonware/butterfly/ami-link-butterflies.vue
+++ b/components/abandonware/butterfly/ami-link-butterflies.vue
@@ -1,0 +1,31 @@
+<!-- /components/content/butterfly/ami-link-butterflies.vue -->
+<template>
+  <div class="space-x-4">
+    <button class="btn btn-primary" @click="handleButtonClick">
+      {{ buttonText }}
+    </button>
+  </div>
+  <AmiSwarm v-if="showAmiSwarm" />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+const router = useRouter() // Import the router
+
+const buttonText = ref('Home of AMIbot')
+const showAmiSwarm = ref(false) // Control display of AmiSwarm
+
+const handleButtonClick = () => {
+  showAmiSwarm.value = !showAmiSwarm.value // Toggle AmiSwarm visibility
+
+  if (showAmiSwarm.value) {
+    buttonText.value = 'No More butterflies?'
+    router.push('/kindrobots/amibot')
+  } else {
+    buttonText.value = 'Release The Butterflies'
+    router.push('/')
+  }
+}
+</script>

--- a/components/abandonware/butterfly/ami-link-iframe.vue
+++ b/components/abandonware/butterfly/ami-link-iframe.vue
@@ -1,0 +1,41 @@
+<!-- /components/content/butterfly/ami-link-iframe.vue -->
+<template>
+  <div class="flex items-center">
+    <SiteLogo />
+    <button v-if="!isLoading" class="ml-4 btn btn-primary" @click="showIframe">
+      AMI's Fundraiser!
+    </button>
+    <div
+      v-if="isLoading"
+      class="fixed inset-0 flex items-center justify-center"
+    >
+      <div
+        class="animate-spin rounded-full h-32 w-32 border-t-2 border-b-2 border-primary-500"
+      />
+    </div>
+    <iframe v-if="iframeVisible" :src="iframeSrc" class="iframe-class" />
+  </div>
+</template>
+
+<script setup lang="ts">
+const isLoading = ref(false)
+const iframeVisible = ref(false)
+const iframeSrc = ref('')
+
+const showIframe = () => {
+  isLoading.value = true
+  setTimeout(() => {
+    iframeSrc.value = 'https://www.againstmalaria.com/amibot'
+    iframeVisible.value = true
+    isLoading.value = false
+  }, 2000)
+}
+</script>
+
+<style>
+.iframe-class {
+  width: 100%;
+  height: 600px;
+  border: none;
+}
+</style>

--- a/components/abandonware/butterfly/ami-link.vue
+++ b/components/abandonware/butterfly/ami-link.vue
@@ -1,0 +1,39 @@
+<!-- /components/content/butterfly/ami-link.vue -->
+<template>
+  <div class="flex justify-center items-center">
+    <img
+      class="justify-center w-32 h-32 object-contain"
+      src="/images/amilogo.webp"
+      alt="Site Logo"
+    />
+    <button
+      v-if="!isLoading"
+      class="ml-4 btn btn-primary"
+      @click="openExternalLink"
+    >
+      AMI's Fundraiser!
+    </button>
+    <div
+      v-if="isLoading"
+      class="fixed inset-0 flex items-center justify-center"
+    >
+      <div
+        class="animate-spin rounded-full h-32 w-32 border-t-2 border-b-2 border-primary-500"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const isLoading = ref(false)
+
+const openExternalLink = () => {
+  isLoading.value = true
+  setTimeout(() => {
+    window.open('https://www.againstmalaria.com/amibot', '_blank')
+    isLoading.value = false
+  }, 2000)
+}
+</script>

--- a/components/abandonware/butterfly/ami-loader.vue
+++ b/components/abandonware/butterfly/ami-loader.vue
@@ -1,0 +1,120 @@
+<!-- /components/content/butterfly/ami-loader.vue -->
+<template>
+  <div
+    class="loading-overlay"
+    :class="{ 'fade-out': fadeOut }"
+    @transitionend="handleTransitionEnd"
+    @click="startFadeOut"
+  >
+    <!-- Bubble Loader - Enlarged and Centered -->
+    <Icon name="kind-icon:bubble-loading" class="bubble-loader" />
+    <!-- Dynamic Loading Message -->
+    <div class="loading-message">{{ currentMessage }}</div>
+
+    <!-- Multiple Butterflies with Animation Delay -->
+    <ami-butterfly
+      v-for="i in butterflyCount"
+      :key="i"
+      :class="{ 'butterfly-fade-out': butterflyFadeOut }"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+import { useLoadStore } from '@/stores/loadStore' // Assuming the path to your loadStore
+
+const { randomLoadMessage } = useLoadStore()
+const currentMessage = ref('Building Kind Robots...')
+
+const butterflyCount = ref(20)
+const fadeOut = ref(false)
+const butterflyFadeOut = ref(false) // New state for butterflies' fade-out
+const pageReady = ref(false)
+
+const startFadeOut = () => {
+  fadeOut.value = true // Fades out the message and overlay
+}
+
+const startButterflyFadeOut = () => {
+  butterflyFadeOut.value = true // Fades out butterflies after additional delay
+}
+
+const updateMessage = () => {
+  currentMessage.value = randomLoadMessage() ?? 'Building Kind Robots...'
+}
+
+let intervalId: NodeJS.Timeout
+onMounted(() => {
+  setTimeout(() => {
+    currentMessage.value = randomLoadMessage() ?? 'Building Kind Robots...'
+    intervalId = setInterval(updateMessage, 2500)
+  }, 100)
+
+  setTimeout(startFadeOut, 1300) // Fade out the message after 2 seconds
+
+  setTimeout(startButterflyFadeOut, 10000) // Butterflies fade out after 5 seconds
+})
+
+onUnmounted(() => {
+  clearInterval(intervalId)
+})
+
+const handleTransitionEnd = () => {
+  if (fadeOut.value) {
+    pageReady.value = true // Marks the page as ready when message fades out
+    // Butterflies will continue to fly until the butterflyFadeOut kicks in.
+  }
+}
+</script>
+
+<style scoped>
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: #111;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  transition: opacity 1s;
+  pointer-events: auto;
+}
+.loading-overlay.fade-out {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.loading-message {
+  color: white;
+  font-size: 32px; /* Increased font size */
+  font-weight: bold;
+  text-align: center;
+  margin-bottom: 20px; /* Space between message and loader */
+}
+
+/* Bubble Loader Styling */
+.bubble-loader {
+  font-size: 80px; /* Large size for the loader icon */
+  color: #fff; /* Ensure it's visible against the background */
+}
+
+/* Fade-out animation for butterflies */
+.butterfly-fade-out {
+  opacity: 0;
+  transition: opacity 1s;
+}
+
+.nuxt-wrapper {
+  opacity: 0;
+  transition: opacity 1s;
+}
+
+.nuxt-wrapper.fade-in {
+  opacity: 1;
+}
+</style>

--- a/components/abandonware/butterfly/base-butterfly.vue
+++ b/components/abandonware/butterfly/base-butterfly.vue
@@ -1,0 +1,91 @@
+<!-- /components/content/butterfly/base-butterfly.vue -->
+<script setup lang="ts">
+import { ref } from 'vue'
+
+export interface Butterfly {
+  wingTopColor: string
+  wingBottomColor: string
+  wingSpeed: number
+}
+
+const randomColor = (): string => {
+  const h = Math.floor(Math.random() * 360)
+  const s = Math.floor(Math.random() * 50 + 50) // keep saturation between 50 and 100
+  const l = Math.floor(Math.random() * 40 + 30) // keep lightness between 30 and 70
+  return `hsl(${h},${s}%,${l}%)`
+}
+
+const butterfly = ref<Butterfly>({
+  wingTopColor: randomColor(),
+  wingBottomColor: randomColor(),
+  wingSpeed: 0.3,
+})
+</script>
+
+<template>
+  <div class="butterfly">
+    <div class="left-wing">
+      <div class="top" :style="{ background: butterfly.wingTopColor }" />
+      <div class="bottom" :style="{ background: butterfly.wingBottomColor }" />
+    </div>
+    <div class="right-wing">
+      <div class="top" :style="{ background: butterfly.wingTopColor }" />
+      <div class="bottom" :style="{ background: butterfly.wingBottomColor }" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.butterfly {
+  width: 100px;
+  height: 100px;
+  position: absolute;
+  pointer-events: none;
+}
+
+.left-wing,
+.right-wing {
+  width: 24px;
+  height: 42px;
+  position: absolute;
+  top: 10px;
+  pointer-events: none;
+}
+
+.left-wing {
+  left: 10px;
+  top: 10px;
+  transform-origin: 24px 50%;
+  animation: flutter-left 0.3s infinite;
+}
+
+.right-wing {
+  left: 34px;
+  transform-origin: 0px 50%;
+  animation: flutter-right 0.3s infinite;
+}
+
+@keyframes flutter-left {
+  0% {
+    transform: rotate3d(0, 1, 0, 20deg);
+  }
+  50% {
+    transform: rotate3d(0, 1, 0, 70deg);
+  }
+  100% {
+    transform: rotate3d(0, 1, 0, 20deg);
+  }
+}
+
+@keyframes flutter-right {
+  0% {
+    transform: rotate3d(0, 1, 0, -20deg);
+  }
+  50% {
+    transform: rotate3d(0, 1, 0, -70deg);
+  }
+  100% {
+    transform: rotate3d(0, 1, 0, -20deg);
+  }
+}
+</style>

--- a/components/abandonware/butterfly/butterfly-back.vue
+++ b/components/abandonware/butterfly/butterfly-back.vue
@@ -1,0 +1,202 @@
+<!-- /components/content/butterfly/butterfly-back.vue -->
+<template>
+  <div class="relative w-full h-full flex items-center justify-center bg-gray-100 p-6">
+    <!-- Card container for the butterfly -->
+    <div class="butterfly-card bg-white shadow-lg rounded-xl p-6 border border-gray-300 relative flex flex-col items-center">
+      <!-- Butterfly demo section for selected butterfly -->
+      <div
+        v-if="selectedButterfly"
+        class="butterfly z-50 mb-6"
+        :style="{
+          transform:
+            'rotate3d(1, 1, 0, ' +
+            selectedButterflyRotation +
+            'deg) scale(' +
+            selectedButterflySize +
+            ')',
+        }"
+      >
+        <div class="left-wing">
+          <div
+            class="top"
+            :style="{ background: selectedButterflyWingTopColor }"
+          ></div>
+          <div
+            class="bottom"
+            :style="{ background: selectedButterflyWingBottomColor }"
+          ></div>
+        </div>
+        <div class="right-wing">
+          <div
+            class="top"
+            :style="{ background: selectedButterflyWingTopColor }"
+          ></div>
+          <div
+            class="bottom"
+            :style="{ background: selectedButterflyWingBottomColor }"
+          ></div>
+        </div>
+      </div>
+
+      <!-- Wing Colors -->
+      <div class="mb-4 w-full max-w-xs">
+        <label for="wingTopColor" class="block mb-2 text-center">Wing Top Color:</label>
+        <input
+          id="wingTopColor"
+          v-model="selectedButterflyWingTopColor"
+          type="color"
+          class="w-full p-2 rounded"
+        />
+      </div>
+
+      <div class="mb-4 w-full max-w-xs">
+        <label for="wingBottomColor" class="block mb-2 text-center"
+          >Wing Bottom Color:</label
+        >
+        <input
+          id="wingBottomColor"
+          v-model="selectedButterflyWingBottomColor"
+          type="color"
+          class="w-full p-2 rounded"
+        />
+      </div>
+
+      <!-- Name and Message Section -->
+      <div v-if="selectedButterfly" class="w-full text-center text-lg text-gray-700 mt-6">
+        <p class="font-bold">{{ selectedButterfly.id }}</p>
+        <p class="italic">{{ selectedButterfly.message }}</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useButterflyStore } from '@/stores/butterflyStore'
+
+// Access the butterfly store
+const butterflyStore = useButterflyStore()
+
+// Computed properties for butterfly settings
+const selectedButterfly = computed(() => butterflyStore.getSelectedButterfly)
+
+const selectedButterflySize = computed({
+  get: () => selectedButterfly.value?.scale || 1,
+  set: (val) => {
+    if (selectedButterfly.value) {
+      selectedButterfly.value.scale = val
+    }
+  },
+})
+
+const selectedButterflyWingTopColor = computed({
+  get: () => selectedButterfly.value?.wingTopColor || '#ffffff',
+  set: (val) => {
+    if (selectedButterfly.value) {
+      selectedButterfly.value.wingTopColor = val
+    }
+  },
+})
+
+const selectedButterflyWingBottomColor = computed({
+  get: () => selectedButterfly.value?.wingBottomColor || '#ffffff',
+  set: (val) => {
+    if (selectedButterfly.value) {
+      selectedButterfly.value.wingBottomColor = val
+    }
+  },
+})
+
+const selectedButterflyRotation = computed({
+  get: () => selectedButterfly.value?.rotation || 0,
+  set: (val) => {
+    if (selectedButterfly.value) {
+      selectedButterfly.value.rotation = val
+    }
+  },
+})
+</script>
+
+<style scoped>
+.butterfly-card {
+  width: 320px;
+  height: 500px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  border-radius: 20px;
+}
+
+.butterfly {
+  width: 120px;
+  height: 120px;
+  position: relative;
+  transform-style: preserve-3d;
+  pointer-events: none;
+}
+
+.left-wing,
+.right-wing {
+  width: 32px;
+  height: 54px;
+  position: absolute;
+  top: 16px;
+  pointer-events: none;
+}
+
+.left-wing {
+  left: 12px;
+  transform-origin: 32px 50%;
+  animation: flutter-left 0.3s infinite;
+}
+
+.right-wing {
+  left: 46px;
+  transform-origin: 0px 50%;
+  animation: flutter-right 0.3s infinite;
+}
+
+.top,
+.bottom {
+  opacity: 0.8;
+  position: absolute;
+}
+
+.top {
+  width: 28px;
+  height: 28px;
+  border-radius: 14px;
+}
+.bottom {
+  top: 20px;
+  width: 32px;
+  height: 32px;
+  border-radius: 16px;
+}
+
+@keyframes flutter-left {
+  0% {
+    transform: rotate3d(0, 1, 0, 20deg);
+  }
+  50% {
+    transform: rotate3d(0, 1, 0, 70deg);
+  }
+  100% {
+    transform: rotate3d(0, 1, 0, 20deg);
+  }
+}
+
+@keyframes flutter-right {
+  0% {
+    transform: rotate3d(0, 1, 0, -20deg);
+  }
+  50% {
+    transform: rotate3d(0, 1, 0, -70deg);
+  }
+  100% {
+    transform: rotate3d(0, 1, 0, -20deg);
+  }
+}
+</style>

--- a/components/abandonware/butterfly/butterfly-canvas.vue
+++ b/components/abandonware/butterfly/butterfly-canvas.vue
@@ -1,0 +1,175 @@
+<!-- /components/content/butterfly/butterfly-canvas.vue -->
+<template>
+  <div
+    ref="containerRef"
+    class="relative h-full min-h-0 w-full overflow-hidden"
+  >
+    <div
+      v-if="!butterfliesExist"
+      class="absolute inset-0 z-10 flex items-center justify-center bg-black/50 p-4"
+    >
+      <p class="text-center text-lg font-semibold text-white">
+        Press the button to start animations
+      </p>
+    </div>
+
+    <canvas
+      ref="canvasRef"
+      class="absolute inset-0 h-full w-full"
+      aria-label="Butterfly animation canvas"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+// /components/content/butterfly/butterfly-canvas.vue
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useButterflyStore } from '@/stores/butterflyStore'
+
+const butterflyStore = useButterflyStore()
+
+const containerRef = ref<HTMLElement | null>(null)
+const canvasRef = ref<HTMLCanvasElement | null>(null)
+const canvasWidth = ref(0)
+const canvasHeight = ref(0)
+const devicePixelRatioValue = ref(1)
+
+let resizeObserver: ResizeObserver | null = null
+let animationFrame: number | null = null
+
+const butterfliesExist = computed(() => {
+  return butterflyStore.butterflies.length > 0
+})
+
+function queueRender() {
+  if (typeof window === 'undefined') return
+
+  if (animationFrame !== null) {
+    cancelAnimationFrame(animationFrame)
+  }
+
+  animationFrame = requestAnimationFrame(() => {
+    animationFrame = null
+    renderButterflies()
+  })
+}
+
+function resizeCanvas() {
+  const container = containerRef.value
+  const canvas = canvasRef.value
+  if (!container || !canvas) return
+
+  const rect = container.getBoundingClientRect()
+  const ratio = window.devicePixelRatio || 1
+
+  canvasWidth.value = Math.max(1, Math.round(rect.width))
+  canvasHeight.value = Math.max(1, Math.round(rect.height))
+  devicePixelRatioValue.value = ratio
+
+  canvas.width = Math.max(1, Math.round(rect.width * ratio))
+  canvas.height = Math.max(1, Math.round(rect.height * ratio))
+  canvas.style.width = `${rect.width}px`
+  canvas.style.height = `${rect.height}px`
+
+  queueRender()
+}
+
+function renderButterflies() {
+  const canvas = canvasRef.value
+  if (!canvas) return
+
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return
+
+  const ratio = devicePixelRatioValue.value
+
+  ctx.setTransform(ratio, 0, 0, ratio, 0, 0)
+  ctx.clearRect(0, 0, canvasWidth.value, canvasHeight.value)
+
+  for (const butterfly of butterflyStore.butterflies) {
+    if (butterfly.isExiting) continue
+
+    const x = Number.isFinite(butterfly.x) ? butterfly.x : canvasWidth.value / 2
+    const y = Number.isFinite(butterfly.y)
+      ? butterfly.y
+      : canvasHeight.value / 2
+    const rotation = Number.isFinite(butterfly.rotation)
+      ? butterfly.rotation
+      : 0
+    const scale = Number.isFinite(butterfly.scale) ? butterfly.scale : 1
+
+    ctx.save()
+    ctx.translate(x, y)
+    ctx.rotate((rotation * Math.PI) / 180)
+    ctx.scale(scale, scale)
+
+    ctx.fillStyle = butterfly.wingTopColor || '#ffffff'
+    ctx.beginPath()
+    ctx.ellipse(-10, -5, 14, 22, -0.45, 0, Math.PI * 2)
+    ctx.fill()
+
+    ctx.beginPath()
+    ctx.ellipse(10, -5, 14, 22, 0.45, 0, Math.PI * 2)
+    ctx.fill()
+
+    ctx.fillStyle =
+      butterfly.wingBottomColor || butterfly.wingTopColor || '#ffffff'
+    ctx.beginPath()
+    ctx.ellipse(-7, 14, 10, 15, 0.35, 0, Math.PI * 2)
+    ctx.fill()
+
+    ctx.beginPath()
+    ctx.ellipse(7, 14, 10, 15, -0.35, 0, Math.PI * 2)
+    ctx.fill()
+
+    ctx.fillStyle = '#111111'
+    ctx.beginPath()
+    ctx.ellipse(0, 4, 4, 20, 0, 0, Math.PI * 2)
+    ctx.fill()
+
+    ctx.restore()
+  }
+}
+
+watch(
+  () => butterflyStore.butterflies,
+  () => {
+    queueRender()
+  },
+  { deep: true },
+)
+
+onMounted(async () => {
+  await nextTick()
+
+  if (containerRef.value) {
+    resizeObserver = new ResizeObserver(() => {
+      resizeCanvas()
+    })
+
+    resizeObserver.observe(containerRef.value)
+  }
+
+  window.addEventListener('resize', resizeCanvas, { passive: true })
+  window.visualViewport?.addEventListener('resize', resizeCanvas, {
+    passive: true,
+  })
+
+  resizeCanvas()
+})
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect()
+  resizeObserver = null
+
+  if (animationFrame !== null) {
+    cancelAnimationFrame(animationFrame)
+    animationFrame = null
+  }
+
+  if (typeof window === 'undefined') return
+
+  window.removeEventListener('resize', resizeCanvas)
+  window.visualViewport?.removeEventListener('resize', resizeCanvas)
+})
+</script>

--- a/components/abandonware/butterfly/butterfly-component.vue
+++ b/components/abandonware/butterfly/butterfly-component.vue
@@ -1,0 +1,103 @@
+<!-- /components/content/butterfly/butterfly-component.vue -->
+<template>
+  <div
+    v-if="hydrated"
+    class="butterfly z-50 absolute"
+    :style="{
+      left: props.butterfly.x + '%',
+      top: props.butterfly.y + '%',
+      transform:
+        'rotate3d(1, 0.5, 0, ' +
+        props.butterfly.rotation +
+        'deg) scale(' +
+        props.butterfly.z +
+        ')',
+      zIndex: props.butterfly.zIndex,
+    }"
+  >
+    <!-- Left Wing -->
+    <div class="left-wing">
+      <div
+        class="top"
+        :style="{ background: props.butterfly.wingTopColor }"
+      ></div>
+      <div
+        class="bottom"
+        :style="{ background: props.butterfly.wingBottomColor }"
+      ></div>
+    </div>
+
+    <!-- Right Wing -->
+    <div class="right-wing">
+      <div
+        class="top"
+        :style="{ background: props.butterfly.wingTopColor }"
+      ></div>
+      <div
+        class="bottom"
+        :style="{ background: props.butterfly.wingBottomColor }"
+      ></div>
+    </div>
+
+    <!-- Conditionally show butterfly's name below -->
+    <div
+      v-if="showName"
+      class="butterfly-name text-center text-xs text-gray-700 w-full absolute"
+      :style="{ top: `${40 * props.butterfly.z + 10}px` }"
+    >
+      {{ props.butterfly.id }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import type { Butterfly } from '@/stores/butterflyStore'
+import { useButterflyStore } from '@/stores/butterflyStore'
+
+const props = defineProps<{ butterfly: Butterfly }>()
+const butterflyStore = useButterflyStore()
+
+const showName = computed(() => butterflyStore.showNames)
+
+const hydrated = ref(false)
+
+onMounted(() => {
+  hydrated.value = true
+})
+</script>
+
+<style scoped>
+.butterfly {
+  position: absolute;
+  width: 40px;
+  height: 40px;
+}
+
+.left-wing,
+.right-wing {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.left-wing .top,
+.right-wing .top {
+  width: 100%;
+  height: 50%;
+  border-radius: 50%;
+}
+
+.left-wing .bottom,
+.right-wing .bottom {
+  width: 100%;
+  height: 50%;
+  border-radius: 50%;
+}
+
+.butterfly-name {
+  position: absolute;
+  top: calc(100% + 10px);
+  width: 100%;
+}
+</style>

--- a/components/abandonware/butterfly/butterfly-demo.vue
+++ b/components/abandonware/butterfly/butterfly-demo.vue
@@ -1,0 +1,177 @@
+<!-- /components/content/butterfly/butterfly-demo.vue -->
+<template>
+  <div
+    class="relative flex h-full w-full items-center justify-center rounded-2xl border border-base-300 bg-base-200 p-4"
+  >
+    <div
+      class="butterfly-card relative flex h-full w-full max-w-md flex-col items-center justify-center kr-panel-flat p-6 text-base-content shadow-lg"
+    >
+      <template v-if="currentButterfly">
+        <div
+          class="butterfly relative z-10 mx-auto"
+          :style="{
+            transform: `rotate3d(1, 1, 0, ${currentButterfly.rotation}deg) scale(${currentButterfly.scale})`,
+          }"
+        >
+          <div class="left-wing">
+            <div
+              class="top"
+              :style="{ background: currentButterfly.wingTopColor }"
+            />
+            <div
+              class="bottom"
+              :style="{ background: currentButterfly.wingBottomColor }"
+            />
+          </div>
+
+          <div class="right-wing">
+            <div
+              class="top"
+              :style="{ background: currentButterfly.wingTopColor }"
+            />
+            <div
+              class="bottom"
+              :style="{ background: currentButterfly.wingBottomColor }"
+            />
+          </div>
+        </div>
+
+        <div class="mt-8 flex w-full flex-col items-center gap-3 text-center">
+          <div
+            class="rounded-2xl border border-base-300 bg-base-200 px-4 py-2 text-sm font-semibold"
+          >
+            {{ currentButterfly.id }}
+          </div>
+
+          <p class="max-w-xs text-sm italic text-base-content/80">
+            {{
+              currentButterfly.message ||
+              'A mysterious butterfly with no comment. Very dramatic.'
+            }}
+          </p>
+
+          <div class="grid w-full grid-cols-2 gap-3 pt-2 text-sm">
+            <div class="rounded-2xl border border-base-300 bg-base-200 p-3">
+              <div class="text-xs uppercase text-base-content/60">Rotation</div>
+              <div class="mt-1 font-semibold">
+                {{ currentButterfly.rotation }}°
+              </div>
+            </div>
+
+            <div class="rounded-2xl border border-base-300 bg-base-200 p-3">
+              <div class="text-xs uppercase text-base-content/60">Scale</div>
+              <div class="mt-1 font-semibold">
+                {{ currentButterfly.scale }}
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <template v-else>
+        <div
+          class="flex h-full w-full flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-base-300 bg-base-200/60 p-6 text-center"
+        >
+          <icon
+            name="kind-icon:butterfly"
+            class="h-12 w-12 text-base-content/40"
+          />
+          <div class="space-y-2">
+            <div class="text-lg font-semibold text-base-content/80">
+              No butterfly selected
+            </div>
+            <p class="max-w-sm text-sm text-base-content/60">
+              Pick a butterfly from the swarm and it will show off here like the
+              tiny diva it is.
+            </p>
+          </div>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// /components/content/butterfly/butterfly-demo.vue
+import { computed } from 'vue'
+import { useButterflyStore } from '@/stores/butterflyStore'
+
+const butterflyStore = useButterflyStore()
+
+const currentButterfly = computed(() => butterflyStore.getSelectedButterfly)
+</script>
+
+<style scoped>
+.butterfly-card {
+  min-height: 22rem;
+}
+
+.butterfly {
+  width: 68px;
+  height: 72px;
+}
+
+@keyframes flutter-left {
+  0% {
+    transform: rotate3d(0, 1, 0, 20deg);
+  }
+  50% {
+    transform: rotate3d(0, 1, 0, 70deg);
+  }
+  100% {
+    transform: rotate3d(0, 1, 0, 20deg);
+  }
+}
+
+@keyframes flutter-right {
+  0% {
+    transform: rotate3d(0, 1, 0, -20deg);
+  }
+  50% {
+    transform: rotate3d(0, 1, 0, -70deg);
+  }
+  100% {
+    transform: rotate3d(0, 1, 0, -20deg);
+  }
+}
+
+.left-wing,
+.right-wing {
+  position: absolute;
+  top: 10px;
+  width: 24px;
+  height: 42px;
+  pointer-events: none;
+}
+
+.left-wing {
+  left: 10px;
+  transform-origin: 24px 50%;
+  animation: flutter-left 0.3s infinite;
+}
+
+.right-wing {
+  left: 34px;
+  transform-origin: 0px 50%;
+  animation: flutter-right 0.3s infinite;
+}
+
+.top,
+.bottom {
+  position: absolute;
+  opacity: 0.78;
+}
+
+.top {
+  width: 20px;
+  height: 20px;
+  border-radius: 9999px;
+}
+
+.bottom {
+  top: 18px;
+  width: 24px;
+  height: 24px;
+  border-radius: 9999px;
+}
+</style>

--- a/components/abandonware/butterfly/butterfly-flip.vue
+++ b/components/abandonware/butterfly/butterfly-flip.vue
@@ -1,0 +1,121 @@
+<!-- /components/content/butterfly/butterfly-flip.vue -->
+<template>
+  <div class="flip-card relative w-full h-full flex flex-col justify-between">
+    <!-- Conditionally apply the flip effect or fade transition -->
+    <div
+      class="flip-card-inner w-full h-full"
+      :class="{ flipped: isFlipped, fadeEffect: !useFlipEffect }"
+    >
+      <div
+        v-if="!isFlipped || !useFlipEffect"
+        class="flip-card-front w-full h-full backface-hidden"
+        :class="{ fade: !useFlipEffect }"
+        :style="{ overflowY: isFlipped ? 'hidden' : 'auto' }"
+      >
+        <slot name="front"></slot>
+      </div>
+      <div
+        v-if="isFlipped || !useFlipEffect"
+        class="flip-card-back w-full h-full backface-hidden transform-back"
+        :class="{ fade: !useFlipEffect }"
+        :style="{ overflowY: isFlipped ? 'auto' : 'hidden' }"
+      >
+        <slot name="back"></slot>
+      </div>
+    </div>
+
+    <!-- Butterfly Icon Toggles - Using Flexbox for Proper Placement -->
+    <div class="w-full flex justify-between items-center mt-2 px-4">
+      <!-- Back to Front Icon -->
+      <div
+        v-if="isFlipped"
+        class="text-2xl bg-yellow-500 rounded-full w-12 h-12 flex items-center justify-center cursor-pointer"
+        @click="setTab('front')"
+      >
+        <Icon name="kind-icon:butterfly" class="text-purple-600 text-3xl" />
+      </div>
+
+      <!-- Front to Back Icon -->
+      <div
+        v-if="!isFlipped"
+        class="text-2xl bg-green-500 rounded-full w-12 h-12 flex items-center justify-center cursor-pointer"
+        @click="setTab('back')"
+      >
+        <Icon name="kind:butterfly" class="text-blue-600 text-3xl" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+// Destructure the prop directly
+const { useFlipEffect } = defineProps({
+  useFlipEffect: {
+    type: Boolean,
+    default: true, // Default to using the flip effect
+  },
+})
+
+// Flip state
+const isFlipped = ref(false)
+
+// Methods to control flipping
+const setTab = (tab) => {
+  isFlipped.value = tab === 'back'
+}
+</script>
+
+<style scoped>
+/* Flip card effect */
+.flip-card {
+  perspective: 1500px; /* Slightly increased perspective for a smoother 3D effect */
+}
+
+.flip-card-inner {
+  transition: transform 0.8s ease-in-out; /* Smoother, slower transition */
+  transform-style: preserve-3d;
+  position: relative; /* Ensure front/back layers are properly positioned */
+}
+
+.flipped {
+  transform: rotateY(180deg);
+}
+
+.flip-card-front,
+.flip-card-back {
+  backface-visibility: hidden; /* Ensure only the front or back is visible */
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  z-index: 1; /* Ensure proper stacking of front and back */
+}
+
+.flip-card-back {
+  transform: rotateY(180deg);
+  z-index: 0; /* Ensure back is behind front before flipping */
+}
+
+/* Fade effect for toggling without 3D flip */
+.fadeEffect .flip-card-inner {
+  transform: none; /* Disable transform for the fade effect */
+}
+
+.fade {
+  transition: opacity 0.5s ease-in-out;
+  opacity: 0;
+}
+
+.flip-card-front.fade,
+.flip-card-back.fade {
+  opacity: 1;
+}
+
+.cursor-pointer:hover {
+  transform: scale(1.1);
+  background-color: #2563eb;
+}
+</style>

--- a/components/abandonware/butterfly/butterfly-front.vue
+++ b/components/abandonware/butterfly/butterfly-front.vue
@@ -1,0 +1,185 @@
+<!-- /components/content/butterfly/butterfly-front.vue -->
+<template>
+  <div class="bg-gray-200 p-1 md:p-4 rounded-lg h-full overflow-y-auto">
+    <h3 class="text-center mb-4">Adjust New Butterfly Presets</h3>
+
+    <!-- Guard: Check if the store and settings are available -->
+    <div v-if="butterflyStoreAvailable">
+      <!-- Size range slider -->
+      <butterfly-slider
+        v-model="newSizeRange"
+        label="Size"
+        :min="0.5"
+        :max="2"
+        :step="0.1"
+        :slider-id="'sizeSlider'"
+        :original-min="originalSizeRange.min"
+        :original-max="originalSizeRange.max"
+      />
+
+      <!-- Speed range slider -->
+      <butterfly-slider
+        v-model="newSpeedRange"
+        label="Speed"
+        :min="0.5"
+        :max="5"
+        :step="0.5"
+        :slider-id="'speedSlider'"
+        :original-min="originalSpeedRange.min"
+        :original-max="originalSpeedRange.max"
+      />
+
+      <!-- Wing Speed slider -->
+      <butterfly-slider
+        v-model="newWingSpeedRange"
+        label="Wing Speed"
+        :min="1"
+        :max="5"
+        :step="1"
+        :slider-id="'wingSpeedSlider'"
+        :original-min="originalWingSpeedRange.min"
+        :original-max="originalWingSpeedRange.max"
+      />
+
+      <!-- Rotation slider -->
+      <butterfly-slider
+        v-model="newRotationRange"
+        label="Rotation"
+        :min="0"
+        :max="360"
+        :step="1"
+        :slider-id="'rotationSlider'"
+        :original-min="originalRotationRange.min"
+        :original-max="originalRotationRange.max"
+      />
+
+      <!-- X Starting Range -->
+      <butterfly-slider
+        v-model="newXRange"
+        label="Starting X Position"
+        :min="0"
+        :max="100"
+        :step="1"
+        :slider-id="'xPositionSlider'"
+        :original-min="originalXRange.min"
+        :original-max="originalXRange.max"
+      />
+
+      <!-- Y Starting Range -->
+      <butterfly-slider
+        v-model="newYRange"
+        label="Starting Y Position"
+        :min="0"
+        :max="100"
+        :step="1"
+        :slider-id="'yPositionSlider'"
+        :original-min="originalYRange.min"
+        :original-max="originalYRange.max"
+      />
+
+      <!-- Color Scheme selection -->
+      <div class="mb-6">
+        <label for="colorScheme" class="block mb-2">Color Scheme:</label>
+        <select v-model="newColorScheme" class="w-full p-2 rounded">
+          <option value="random">Random</option>
+          <option value="complementary">Complementary</option>
+          <option value="analogous">Analogous</option>
+          <option value="same">Same</option>
+          <option value="primary">Primary</option>
+        </select>
+        <div class="text-center mt-2">
+          Selected Color Scheme: {{ newColorScheme }}
+        </div>
+      </div>
+
+      <!-- Butterfly Status selection -->
+      <div class="mb-6">
+        <label for="status" class="block mb-2">Butterfly Status:</label>
+        <select v-model="newStatus" class="w-full p-2 rounded">
+          <option value="random">Random</option>
+          <option value="float">Float</option>
+          <option value="mouse">Mouse</option>
+          <option value="spaz">Spaz</option>
+          <option value="flock">Flock</option>
+          <option value="clear">Clear</option>
+        </select>
+        <div class="text-center mt-2">Selected Status: {{ newStatus }}</div>
+      </div>
+    </div>
+
+    <!-- Fallback Message if Store is Unavailable -->
+    <div v-else class="text-red-500 text-center mt-4">
+      Butterfly settings are unavailable. Please check your data.
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useButterflyStore } from '@/stores/butterflyStore'
+
+// Access the butterfly store
+const butterflyStore = useButterflyStore()
+
+// Guard for store availability
+const butterflyStoreAvailable = computed(
+  () => butterflyStore && butterflyStore.newButterflySettings,
+)
+
+// Access current and original settings for each range
+const newSizeRange = computed({
+  get: () =>
+    butterflyStore?.newButterflySettings?.sizeRange || { min: 0.5, max: 1.5 },
+  set: (val) => butterflyStore?.updateButterflySettings?.({ sizeRange: val }),
+})
+
+const newSpeedRange = computed({
+  get: () =>
+    butterflyStore?.newButterflySettings?.speedRange || { min: 1, max: 3 },
+  set: (val) => butterflyStore?.updateButterflySettings?.({ speedRange: val }),
+})
+
+const newWingSpeedRange = computed({
+  get: () =>
+    butterflyStore?.newButterflySettings?.wingSpeedRange || { min: 1, max: 5 },
+  set: (val) =>
+    butterflyStore?.updateButterflySettings?.({ wingSpeedRange: val }),
+})
+
+const newRotationRange = computed({
+  get: () =>
+    butterflyStore?.newButterflySettings?.rotationRange || { min: 0, max: 360 },
+  set: (val) =>
+    butterflyStore?.updateButterflySettings?.({ rotationRange: val }),
+})
+
+const newXRange = computed({
+  get: () =>
+    butterflyStore?.newButterflySettings?.xRange || { min: 0, max: 100 },
+  set: (val) => butterflyStore?.updateButterflySettings?.({ xRange: val }),
+})
+
+const newYRange = computed({
+  get: () =>
+    butterflyStore?.newButterflySettings?.yRange || { min: 0, max: 100 },
+  set: (val) => butterflyStore?.updateButterflySettings?.({ yRange: val }),
+})
+
+// Original ranges
+const originalSizeRange = computed(() => butterflyStore?.originalButterflySettings?.sizeRange || { min: 0.5, max: 1.5 })
+const originalSpeedRange = computed(() => butterflyStore?.originalButterflySettings?.speedRange || { min: 1, max: 3 })
+const originalWingSpeedRange = computed(() => butterflyStore?.originalButterflySettings?.wingSpeedRange || { min: 1, max: 5 })
+const originalRotationRange = computed(() => butterflyStore?.originalButterflySettings?.rotationRange || { min: 0, max: 360 })
+const originalXRange = computed(() => butterflyStore?.originalButterflySettings?.xRange || { min: 0, max: 100 })
+const originalYRange = computed(() => butterflyStore?.originalButterflySettings?.yRange || { min: 0, max: 100 })
+
+const newColorScheme = computed({
+  get: () => butterflyStore?.newButterflySettings?.colorScheme || 'random',
+  set: (val) => butterflyStore?.updateButterflySettings?.({ colorScheme: val }),
+})
+
+const newStatus = computed({
+  get: () => butterflyStore?.newButterflySettings?.status || 'random',
+  set: (val) => butterflyStore?.updateButterflySettings?.({ status: val }),
+})
+</script>

--- a/components/abandonware/butterfly/butterfly-gallery.vue
+++ b/components/abandonware/butterfly/butterfly-gallery.vue
@@ -1,0 +1,179 @@
+<template>
+  <div class="gallery">
+    <div class="gallery-header">
+      <span class="gallery-title">field guide</span>
+      <span class="gallery-count">{{ caughtCount }} / {{ slots.length }}</span>
+    </div>
+
+    <div class="gallery-grid">
+      <div
+        v-for="slot in slots"
+        :key="slot.rarityNumber"
+        class="gallery-slot"
+        :class="{ caught: !!slot.butterfly }"
+        :title="
+          slot.butterfly
+            ? slot.butterfly.name
+            : `#${String(slot.rarityNumber).padStart(3, '0')} — not yet caught`
+        "
+        @click="slot.butterfly && $emit('inspect', slot.butterfly)"
+      >
+        <template v-if="slot.butterfly">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="32"
+            height="26"
+            viewBox="0 0 36 28"
+            :aria-label="slot.butterfly.name"
+          >
+            <ellipse
+              cx="9"
+              cy="10"
+              rx="9"
+              ry="6"
+              :fill="slot.butterfly.wingTopColor"
+              opacity="0.9"
+            />
+            <ellipse
+              cx="27"
+              cy="10"
+              rx="9"
+              ry="6"
+              :fill="slot.butterfly.wingTopColor"
+              opacity="0.9"
+            />
+            <ellipse
+              cx="8"
+              cy="18"
+              rx="7"
+              ry="5"
+              :fill="slot.butterfly.wingBottomColor"
+              opacity="0.8"
+            />
+            <ellipse
+              cx="28"
+              cy="18"
+              rx="7"
+              ry="5"
+              :fill="slot.butterfly.wingBottomColor"
+              opacity="0.8"
+            />
+            <ellipse
+              cx="18"
+              cy="14"
+              rx="2"
+              ry="6"
+              fill="#2c2c2a"
+              opacity="0.8"
+            />
+          </svg>
+        </template>
+        <template v-else>
+          <span class="slot-num">{{
+            String(slot.rarityNumber).padStart(2, '0')
+          }}</span>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { Butterfly } from '~/stores/helpers/butterflyHelper'
+
+/**
+ * GallerySlot represents one entry in the collectible grid.
+ * butterfly is null until the user catches it (populated from UserButterfly join).
+ */
+export interface GallerySlot {
+  rarityNumber: number
+  butterfly: Butterfly | null
+}
+
+const props = defineProps<{
+  /**
+   * Pass the full ordered slot list — sourced from the DB.
+   * Uncaught slots have butterfly: null.
+   * Derive this in the parent by fetching the user's UserButterfly records
+   * and merging with the full Butterfly roster, ordered by rarityNumber.
+   */
+  slots: GallerySlot[]
+}>()
+
+defineEmits<{
+  /** user clicked a caught butterfly — parent can open detail view */
+  inspect: [butterfly: Butterfly]
+}>()
+
+const caughtCount = computed(
+  () => props.slots.filter((s) => s.butterfly !== null).length,
+)
+</script>
+
+<style scoped>
+.gallery {
+  padding: 12px 16px 16px;
+}
+
+.gallery-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 10px;
+}
+
+.gallery-title {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-secondary, #888);
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+}
+
+.gallery-count {
+  font-size: 12px;
+  color: #1d9e75;
+  font-weight: 500;
+}
+
+.gallery-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.gallery-slot {
+  width: 52px;
+  height: 52px;
+  border-radius: 8px;
+  border: 1.5px dashed #b4b2a9;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    transform 0.15s,
+    border-color 0.15s,
+    background 0.15s;
+  cursor: default;
+}
+
+.gallery-slot.caught {
+  border-style: solid;
+  border-color: #1d9e75;
+  background: rgba(29, 158, 117, 0.06);
+  cursor: pointer;
+}
+
+.gallery-slot.caught:hover {
+  transform: scale(1.12);
+  background: rgba(29, 158, 117, 0.12);
+}
+
+.slot-num {
+  font-size: 10px;
+  color: #b4b2a9;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/components/abandonware/butterfly/butterfly-grid.vue
+++ b/components/abandonware/butterfly/butterfly-grid.vue
@@ -1,0 +1,359 @@
+<template>
+  <section class="rounded-2xl border border-base-300 bg-base-200 p-4 shadow-sm">
+    <div class="flex flex-col gap-4">
+      <div class="flex flex-col gap-1">
+        <h2 class="text-2xl font-bold">Butterfly Orientation Grid</h2>
+        <p class="text-sm opacity-80">
+          Click any card to mark it ugly. This gives you a fast little butterfly lineup.
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 gap-4 lg:grid-cols-4">
+        <label class="kr-panel-flat p-4">
+          <div class="mb-2 font-semibold">Step size</div>
+          <select v-model="stepSize" class="select select-bordered w-full rounded-2xl">
+            <option :value="15">15°</option>
+            <option :value="30">30°</option>
+            <option :value="60">60°</option>
+          </select>
+        </label>
+
+        <label class="kr-panel-flat p-4">
+          <div class="mb-2 font-semibold">Spread</div>
+          <select v-model="spreadMode" class="select select-bordered w-full rounded-2xl">
+            <option value="tight">[-step, 0, step]</option>
+            <option value="wide">[-2step, -step, 0, step, 2step]</option>
+          </select>
+        </label>
+
+        <label class="kr-panel-flat p-4">
+          <div class="mb-2 font-semibold">Scale</div>
+          <input
+            v-model="scale"
+            type="range"
+            min="0.55"
+            max="1.4"
+            step="0.05"
+            class="range range-info"
+          />
+          <div class="mt-2 text-sm font-mono">{{ scale.toFixed(2) }}</div>
+        </label>
+
+        <div class="kr-panel-flat p-4">
+          <div class="mb-2 font-semibold">Grid summary</div>
+          <div class="text-sm">Combos: {{ combinations.length }}</div>
+          <div class="text-sm">Marked ugly: {{ uglyCombos.length }}</div>
+          <div class="mt-3 flex flex-wrap gap-2">
+            <button class="btn btn-sm rounded-2xl" type="button" @click="clearUgly">
+              Clear
+            </button>
+            <button class="btn btn-sm rounded-2xl" type="button" @click="copyUglyCombos">
+              Copy ugly list
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div class="kr-panel-flat p-4">
+        <div class="mb-2 font-semibold">Selected ugly combos</div>
+        <pre class="max-h-56 overflow-auto rounded-2xl bg-base-200 p-3 text-xs font-mono">{{ uglyCombosJson }}</pre>
+      </div>
+
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+        <button
+          v-for="combo in combinations"
+          :key="combo.id"
+          type="button"
+          class="group rounded-2xl border p-4 text-left transition hover:scale-[1.01]"
+          :class="
+            isUgly(combo.id)
+              ? 'border-error bg-error/10'
+              : 'border-base-300 bg-base-100 hover:bg-base-200'
+          "
+          @click="toggleUgly(combo.id)"
+        >
+          <div class="mb-3 flex items-center justify-between gap-2">
+            <div class="text-sm font-semibold">
+              x: {{ combo.x }} | y: {{ combo.y }} | z: {{ combo.z }}
+            </div>
+            <div
+              class="rounded-xl px-2 py-1 text-xs font-bold"
+              :class="isUgly(combo.id) ? 'bg-error text-error-content' : 'bg-base-200'"
+            >
+              {{ isUgly(combo.id) ? 'ugly' : 'ok' }}
+            </div>
+          </div>
+
+          <div
+            class="relative flex min-h-[12rem] items-center justify-center overflow-hidden rounded-2xl border border-base-300 bg-base-200"
+          >
+            <div class="grid-stage">
+              <div class="grid-guides" />
+              <div class="butterfly" :style="getButterflyStyle(combo.x, combo.y, combo.z)">
+                <div class="butterfly-body">
+                  <div class="left-wing">
+                    <div class="top" :style="{ background: wingTopColor }" />
+                    <div class="bottom" :style="{ background: wingBottomColor }" />
+                  </div>
+
+                  <div class="right-wing">
+                    <div class="top" :style="{ background: wingTopColor }" />
+                    <div class="bottom" :style="{ background: wingBottomColor }" />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="mt-3 rounded-2xl bg-base-200 p-2 text-xs font-mono">
+            rotateX({{ combo.x }}deg) rotateY({{ combo.y }}deg) rotateZ({{ combo.z }}deg)
+          </div>
+        </button>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, type CSSProperties } from 'vue'
+
+type StepSize = 15 | 30 | 60
+type SpreadMode = 'tight' | 'wide'
+
+type OrientationCombo = {
+  id: string
+  x: number
+  y: number
+  z: number
+}
+
+type ButterflyStyle = CSSProperties & {
+  '--flutter-duration': string
+}
+
+const stepSize = ref<StepSize>(30)
+const spreadMode = ref<SpreadMode>('tight')
+const scale = ref(1)
+
+const wingTopColor = ref('hsl(320, 80%, 60%)')
+const wingBottomColor = ref('hsl(200, 80%, 60%)')
+
+const uglyIds = ref<string[]>([])
+
+const axisValues = computed<number[]>(() => {
+  const step = stepSize.value
+
+  if (spreadMode.value === 'wide') {
+    return [-2 * step, -step, 0, step, 2 * step]
+  }
+
+  return [-step, 0, step]
+})
+
+const combinations = computed<OrientationCombo[]>(() => {
+  const values = axisValues.value
+  const results: OrientationCombo[] = []
+
+  for (const x of values) {
+    for (const y of values) {
+      for (const z of values) {
+        results.push({
+          id: `${x}:${y}:${z}`,
+          x,
+          y,
+          z,
+        })
+      }
+    }
+  }
+
+  return results
+})
+
+const uglyCombos = computed(() =>
+  combinations.value.filter((combo) => uglyIds.value.includes(combo.id)),
+)
+
+const uglyCombosJson = computed(() =>
+  JSON.stringify(
+    uglyCombos.value.map(({ x, y, z }) => ({ x, y, z })),
+    null,
+    2,
+  ),
+)
+
+function isUgly(id: string) {
+  return uglyIds.value.includes(id)
+}
+
+function toggleUgly(id: string) {
+  if (isUgly(id)) {
+    uglyIds.value = uglyIds.value.filter((entry) => entry !== id)
+    return
+  }
+
+  uglyIds.value = [...uglyIds.value, id]
+}
+
+function clearUgly() {
+  uglyIds.value = []
+}
+
+async function copyUglyCombos() {
+  if (import.meta.server) return
+
+  try {
+    await navigator.clipboard.writeText(uglyCombosJson.value)
+  } catch {
+    console.warn('Could not copy ugly combos.')
+  }
+}
+
+function getButterflyStyle(x: number, y: number, z: number): ButterflyStyle {
+  return {
+    '--flutter-duration': '0.3s',
+    transform: [
+      'translate3d(-50%, -50%, 0)',
+      `rotateX(${x}deg)`,
+      `rotateY(${y}deg)`,
+      `rotateZ(${z}deg)`,
+      `scale(${scale.value})`,
+    ].join(' '),
+  }
+}
+</script>
+
+<style scoped>
+.grid-stage {
+  position: relative;
+  width: 12rem;
+  height: 12rem;
+  perspective: 1000px;
+}
+
+.grid-guides {
+  position: absolute;
+  inset: 0;
+  border-radius: 1rem;
+  background-image:
+    linear-gradient(to right, rgb(255 255 255 / 0.06) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(255 255 255 / 0.06) 1px, transparent 1px);
+  background-size: 1.5rem 1.5rem;
+}
+
+.grid-guides::before,
+.grid-guides::after {
+  content: '';
+  position: absolute;
+  background: rgb(255 255 255 / 0.12);
+}
+
+.grid-guides::before {
+  left: 50%;
+  top: 0;
+  width: 1px;
+  height: 100%;
+  transform: translateX(-50%);
+}
+
+.grid-guides::after {
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 1px;
+  transform: translateY(-50%);
+}
+
+@keyframes flutter-left {
+  0% {
+    transform: rotateY(18deg);
+  }
+
+  50% {
+    transform: rotateY(72deg);
+  }
+
+  100% {
+    transform: rotateY(18deg);
+  }
+}
+
+@keyframes flutter-right {
+  0% {
+    transform: rotateY(-18deg);
+  }
+
+  50% {
+    transform: rotateY(-72deg);
+  }
+
+  100% {
+    transform: rotateY(-18deg);
+  }
+}
+
+.butterfly {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 100px;
+  height: 100px;
+  transform-style: preserve-3d;
+  transform-origin: center;
+  will-change: transform;
+}
+
+.butterfly-body {
+  position: relative;
+  width: 68px;
+  height: 64px;
+  transform-style: preserve-3d;
+}
+
+.left-wing,
+.right-wing {
+  position: absolute;
+  width: 24px;
+  height: 42px;
+  top: 10px;
+  transform-style: preserve-3d;
+  backface-visibility: hidden;
+  will-change: transform;
+}
+
+.left-wing {
+  left: 10px;
+  transform-origin: 24px 50%;
+  animation: flutter-left var(--flutter-duration) infinite ease-in-out;
+}
+
+.right-wing {
+  left: 34px;
+  transform-origin: 0 50%;
+  animation: flutter-right var(--flutter-duration) infinite ease-in-out;
+}
+
+.left-wing .top {
+  right: 0;
+}
+
+.top,
+.bottom {
+  position: absolute;
+  opacity: 0.72;
+  backface-visibility: hidden;
+}
+
+.top {
+  width: 20px;
+  height: 20px;
+  border-radius: 9999px;
+}
+
+.bottom {
+  top: 18px;
+  width: 24px;
+  height: 24px;
+  border-radius: 9999px;
+}
+</style>

--- a/components/abandonware/butterfly/butterfly-guide.vue
+++ b/components/abandonware/butterfly/butterfly-guide.vue
@@ -1,0 +1,402 @@
+<template>
+  <div
+    class="flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-200"
+  >
+    <div
+      v-if="!currentButterfly"
+      class="flex h-full items-center justify-center p-6 text-center text-sm text-base-content/60"
+    >
+      {{ emptyLabel }}
+    </div>
+
+    <div v-else class="flex h-full min-h-0 flex-col overflow-hidden">
+      <div class="border-b border-base-300 p-4">
+        <div class="flex items-start justify-between gap-4">
+          <div class="min-w-0">
+            <div class="truncate text-xl font-bold">
+              {{ currentButterfly.name || currentButterfly.id }}
+            </div>
+
+            <div class="mt-1 flex flex-wrap items-center gap-2">
+              <div class="badge badge-outline badge-sm">
+                {{ currentButterfly.status || 'random' }}
+              </div>
+
+              <div
+                class="badge badge-sm"
+                :class="
+                  currentButterfly.isExiting ? 'badge-warning' : 'badge-success'
+                "
+              >
+                {{ currentButterfly.isExiting ? 'Exiting' : 'Active' }}
+              </div>
+
+              <div v-if="isToggleButterfly" class="badge badge-accent badge-sm">
+                Toggle Butterfly
+              </div>
+
+              <div v-if="canEdit" class="badge badge-secondary badge-sm">
+                Editable
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="min-h-0 flex-1 overflow-y-auto p-4">
+        <div class="grid grid-cols-1 gap-3 xl:grid-cols-2">
+          <div class="kr-panel-flat p-1 xl:col-span-2">
+            <butterfly-demo class="h-64 w-full" />
+          </div>
+          <div class="kr-panel-flat p-3 xl:col-span-2">
+            <div
+              class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
+            >
+              Message
+            </div>
+            <div class="mt-2 text-sm leading-relaxed">
+              {{ currentButterfly.message || 'No butterfly gossip recorded.' }}
+            </div>
+          </div>
+
+          <div class="kr-panel-flat p-3">
+            <div
+              class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
+            >
+              Identity
+            </div>
+
+            <div class="mt-2 grid grid-cols-2 gap-2 text-sm">
+              <div
+                class="col-span-2 rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">ID</div>
+                <div class="break-all font-semibold">
+                  {{ currentButterfly.id }}
+                </div>
+              </div>
+
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Name</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.name || '—' }}
+                </div>
+              </div>
+
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Status</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.status || '—' }}
+                </div>
+              </div>
+
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Art Image</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.artImageId ?? '—' }}
+                </div>
+              </div>
+
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Rarity</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.rarity ?? '—' }}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="kr-panel-flat p-3">
+            <div
+              class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
+            >
+              Ownership
+            </div>
+
+            <div class="mt-2 grid grid-cols-2 gap-2 text-sm">
+              <div
+                class="col-span-2 rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Designer</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.designer || 'Wild-type chaos' }}
+                </div>
+              </div>
+
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Owner ID</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.userId ?? 'Unknown' }}
+                </div>
+              </div>
+
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Editable</div>
+                <div class="font-semibold">{{ canEdit ? 'Yes' : 'No' }}</div>
+              </div>
+            </div>
+          </div>
+
+          <div class="kr-panel-flat p-3">
+            <div
+              class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
+            >
+              Flight Stats
+            </div>
+
+            <div class="mt-2 grid grid-cols-2 gap-2 text-sm">
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Speed</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.speed ?? '—' }}
+                </div>
+              </div>
+
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Wing Speed</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.wingSpeed ?? '—' }}
+                </div>
+              </div>
+
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Scale</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.scale ?? '—' }}
+                </div>
+              </div>
+
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Scale Mod</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.scaleMod ?? '—' }}
+                </div>
+              </div>
+
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Rotation</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.rotation ?? '—' }}
+                </div>
+              </div>
+
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Z Depth</div>
+                <div class="font-semibold">{{ currentButterfly.z ?? '—' }}</div>
+              </div>
+            </div>
+          </div>
+
+          <div class="kr-panel-flat p-3">
+            <div
+              class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
+            >
+              Position
+            </div>
+
+            <div class="mt-2 grid grid-cols-2 gap-2 text-sm">
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">X</div>
+                <div class="font-semibold">{{ currentButterfly.x ?? '—' }}</div>
+              </div>
+
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Y</div>
+                <div class="font-semibold">{{ currentButterfly.y ?? '—' }}</div>
+              </div>
+
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Goal X</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.goal?.x ?? '—' }}
+                </div>
+              </div>
+
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Goal Y</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.goal?.y ?? '—' }}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="kr-panel-flat p-3">
+            <div
+              class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
+            >
+              Rendering
+            </div>
+
+            <div class="mt-2 grid grid-cols-2 gap-2 text-sm">
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Z Index</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.zIndex ?? '—' }}
+                </div>
+              </div>
+
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Base Z Index</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.baseZIndex ?? '—' }}
+                </div>
+              </div>
+
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Top Wing</div>
+                <div class="truncate font-semibold">
+                  {{ currentButterfly.wingTopColor || '—' }}
+                </div>
+              </div>
+
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Bottom Wing</div>
+                <div class="truncate font-semibold">
+                  {{ currentButterfly.wingBottomColor || '—' }}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="kr-panel-flat p-3 xl:col-span-2">
+            <div
+              class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
+            >
+              Internal Motion
+            </div>
+
+            <div class="mt-2 grid grid-cols-2 gap-2 text-sm xl:grid-cols-4">
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Noise Offset X</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.noiseOffsetX ?? '—' }}
+                </div>
+              </div>
+
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Noise Offset Y</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.noiseOffsetY ?? '—' }}
+                </div>
+              </div>
+
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Exiting</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.isExiting ? 'Yes' : 'No' }}
+                </div>
+              </div>
+
+              <div
+                class="rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+              >
+                <div class="text-xs text-base-content/50">Toggle-bound</div>
+                <div class="font-semibold">
+                  {{ isToggleButterfly ? 'Yes' : 'No' }}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="kr-panel-flat p-3 xl:col-span-2">
+            <div
+              class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
+            >
+              Notes
+            </div>
+            <div class="mt-2 text-sm text-base-content/80">
+              Real live butterfly state. No fake résumé energy.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// /components/content/butterfly/butterfly-guide.vue
+import { computed } from 'vue'
+import { useButterflyStore } from '@/stores/butterflyStore'
+import { useUserStore } from '@/stores/userStore'
+
+const props = withDefaults(
+  defineProps<{
+    emptyLabel?: string
+  }>(),
+  {
+    emptyLabel: 'Choose a butterfly to inspect its scandalous little life.',
+  },
+)
+
+const butterflyStore = useButterflyStore()
+const userStore = useUserStore()
+
+const currentButterfly = computed(() => butterflyStore.getSelectedButterfly)
+
+const canEdit = computed(() => {
+  const butterfly = currentButterfly.value
+  if (!butterfly) return false
+
+  const isAdmin = userStore.isAdmin === true || userStore.role === 'ADMIN'
+  const isOwner =
+    butterfly.userId != null &&
+    userStore.userId != null &&
+    butterfly.userId === userStore.userId
+
+  return isAdmin || isOwner
+})
+
+const isToggleButterfly = computed(() => {
+  const butterfly = currentButterfly.value
+  if (!butterfly) return false
+  return butterflyStore.isToggleButterfly(butterfly)
+})
+</script>

--- a/components/abandonware/butterfly/butterfly-lab.vue
+++ b/components/abandonware/butterfly/butterfly-lab.vue
@@ -1,0 +1,342 @@
+<template>
+  <section class="rounded-2xl border border-base-300 bg-base-200 p-4 shadow-sm">
+    <div class="flex flex-col gap-4">
+      <div class="flex flex-col gap-1">
+        <h2 class="text-2xl font-bold">Butterfly Orientation Lab</h2>
+        <p class="text-sm opacity-80">
+          Manually dial X, Y, and Z rotation in step-5 increments and inspect
+          the butterfly.
+        </p>
+      </div>
+
+      <div
+        class="relative flex min-h-96 items-center justify-center overflow-hidden kr-panel-flat"
+      >
+        <div class="orientation-stage">
+          <div class="orientation-guides" />
+          <div class="butterfly" :style="butterflyStyle">
+            <div class="butterfly-body">
+              <div class="left-wing">
+                <div class="top" :style="{ background: wingTopColor }" />
+                <div class="bottom" :style="{ background: wingBottomColor }" />
+              </div>
+
+              <div class="right-wing">
+                <div class="top" :style="{ background: wingTopColor }" />
+                <div class="bottom" :style="{ background: wingBottomColor }" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <label class="kr-panel-flat p-4">
+          <div class="mb-2 flex items-center justify-between">
+            <span class="font-semibold">Rotate X</span>
+            <span class="rounded-xl bg-base-200 px-3 py-1 text-sm font-mono">
+              {{ rotateX }}°
+            </span>
+          </div>
+          <input
+            v-model="rotateX"
+            type="range"
+            min="-180"
+            max="180"
+            step="5"
+            class="range range-primary"
+          />
+        </label>
+
+        <label class="kr-panel-flat p-4">
+          <div class="mb-2 flex items-center justify-between">
+            <span class="font-semibold">Rotate Y</span>
+            <span class="rounded-xl bg-base-200 px-3 py-1 text-sm font-mono">
+              {{ rotateY }}°
+            </span>
+          </div>
+          <input
+            v-model="rotateY"
+            type="range"
+            min="-180"
+            max="180"
+            step="5"
+            class="range range-secondary"
+          />
+        </label>
+
+        <label class="kr-panel-flat p-4">
+          <div class="mb-2 flex items-center justify-between">
+            <span class="font-semibold">Rotate Z</span>
+            <span class="rounded-xl bg-base-200 px-3 py-1 text-sm font-mono">
+              {{ rotateZ }}°
+            </span>
+          </div>
+          <input
+            v-model="rotateZ"
+            type="range"
+            min="-180"
+            max="180"
+            step="5"
+            class="range range-accent"
+          />
+        </label>
+      </div>
+
+      <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <label class="kr-panel-flat p-4">
+          <div class="mb-2 flex items-center justify-between">
+            <span class="font-semibold">Scale</span>
+            <span class="rounded-xl bg-base-200 px-3 py-1 text-sm font-mono">
+              {{ scale.toFixed(2) }}
+            </span>
+          </div>
+          <input
+            v-model="scale"
+            type="range"
+            min="0.4"
+            max="2"
+            step="0.05"
+            class="range range-info"
+          />
+        </label>
+
+        <label class="kr-panel-flat p-4">
+          <div class="mb-2 flex items-center justify-between">
+            <span class="font-semibold">Wing Speed</span>
+            <span class="rounded-xl bg-base-200 px-3 py-1 text-sm font-mono">
+              {{ wingSpeed.toFixed(2) }}s
+            </span>
+          </div>
+          <input
+            v-model="wingSpeed"
+            type="range"
+            min="0.12"
+            max="1"
+            step="0.02"
+            class="range range-warning"
+          />
+        </label>
+      </div>
+
+      <div class="flex flex-wrap gap-2">
+        <button
+          class="btn rounded-2xl"
+          type="button"
+          @click="setPreset(0, 0, 0)"
+        >
+          Reset
+        </button>
+        <button
+          class="btn rounded-2xl"
+          type="button"
+          @click="setPreset(0, 90, 0)"
+        >
+          Side Y 90
+        </button>
+        <button
+          class="btn rounded-2xl"
+          type="button"
+          @click="setPreset(0, -90, 0)"
+        >
+          Side Y -90
+        </button>
+        <button
+          class="btn rounded-2xl"
+          type="button"
+          @click="setPreset(90, 0, 0)"
+        >
+          Top X 90
+        </button>
+        <button
+          class="btn rounded-2xl"
+          type="button"
+          @click="setPreset(0, 0, 90)"
+        >
+          Spin Z 90
+        </button>
+      </div>
+
+      <div class="kr-panel-flat p-4">
+        <div class="mb-2 text-sm font-semibold">Current transform</div>
+        <pre
+          class="overflow-x-auto whitespace-pre-wrap wrap-break-word rounded-2xl bg-base-200 p-3 text-xs font-mono"
+          >{{ transformString }}</pre
+        >
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, type CSSProperties } from 'vue'
+
+type ButterflyStyle = CSSProperties & {
+  '--flutter-duration': string
+}
+
+const rotateX = ref(0)
+const rotateY = ref(0)
+const rotateZ = ref(0)
+const scale = ref(1)
+const wingSpeed = ref(0.3)
+
+const wingTopColor = ref('hsl(320, 80%, 60%)')
+const wingBottomColor = ref('hsl(200, 80%, 60%)')
+
+function setPreset(x: number, y: number, z: number) {
+  rotateX.value = x
+  rotateY.value = y
+  rotateZ.value = z
+}
+
+const transformString = computed(() => {
+  return [
+    'translate3d(-50%, -50%, 0)',
+    `rotateX(${rotateX.value}deg)`,
+    `rotateY(${rotateY.value}deg)`,
+    `rotateZ(${rotateZ.value}deg)`,
+    `scale(${scale.value})`,
+  ].join(' ')
+})
+
+const butterflyStyle = computed<ButterflyStyle>(() => ({
+  '--flutter-duration': `${wingSpeed.value}s`,
+  transform: transformString.value,
+}))
+</script>
+
+<style scoped>
+.orientation-stage {
+  position: relative;
+  width: 20rem;
+  height: 20rem;
+  perspective: 1000px;
+}
+
+.orientation-guides {
+  position: absolute;
+  inset: 0;
+  border-radius: 1rem;
+  background-image:
+    linear-gradient(to right, rgb(255 255 255 / 0.06) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(255 255 255 / 0.06) 1px, transparent 1px);
+  background-size: 2rem 2rem;
+}
+
+.orientation-guides::before,
+.orientation-guides::after {
+  content: '';
+  position: absolute;
+  background: rgb(255 255 255 / 0.12);
+}
+
+.orientation-guides::before {
+  left: 50%;
+  top: 0;
+  width: 1px;
+  height: 100%;
+  transform: translateX(-50%);
+}
+
+.orientation-guides::after {
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 1px;
+  transform: translateY(-50%);
+}
+
+@keyframes flutter-left {
+  0% {
+    transform: rotateY(18deg);
+  }
+
+  50% {
+    transform: rotateY(72deg);
+  }
+
+  100% {
+    transform: rotateY(18deg);
+  }
+}
+
+@keyframes flutter-right {
+  0% {
+    transform: rotateY(-18deg);
+  }
+
+  50% {
+    transform: rotateY(-72deg);
+  }
+
+  100% {
+    transform: rotateY(-18deg);
+  }
+}
+
+.butterfly {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 100px;
+  height: 100px;
+  transform-style: preserve-3d;
+  transform-origin: center;
+  will-change: transform;
+}
+
+.butterfly-body {
+  position: relative;
+  width: 68px;
+  height: 64px;
+  transform-style: preserve-3d;
+}
+
+.left-wing,
+.right-wing {
+  position: absolute;
+  width: 24px;
+  height: 42px;
+  top: 10px;
+  transform-style: preserve-3d;
+  backface-visibility: hidden;
+  will-change: transform;
+}
+
+.left-wing {
+  left: 10px;
+  transform-origin: 24px 50%;
+  animation: flutter-left var(--flutter-duration) infinite ease-in-out;
+}
+
+.right-wing {
+  left: 34px;
+  transform-origin: 0 50%;
+  animation: flutter-right var(--flutter-duration) infinite ease-in-out;
+}
+
+.left-wing .top {
+  right: 0;
+}
+
+.top,
+.bottom {
+  position: absolute;
+  opacity: 0.72;
+  backface-visibility: hidden;
+}
+
+.top {
+  width: 20px;
+  height: 20px;
+  border-radius: 9999px;
+}
+
+.bottom {
+  top: 18px;
+  width: 24px;
+  height: 24px;
+  border-radius: 9999px;
+}
+</style>

--- a/components/abandonware/butterfly/butterfly-loader.vue
+++ b/components/abandonware/butterfly/butterfly-loader.vue
@@ -1,0 +1,116 @@
+<!-- /components/content/butterfly/butterfly-loader.vue -->
+<template>
+  <div
+    v-for="butterfly in butterflies"
+    :key="butterfly.id"
+    class="butterfly"
+    :style="{
+      left: butterfly.x + '%',
+      top: butterfly.y + '%',
+      transform: `rotate3d(1, 0.5, 0, ${butterfly.rotation}deg) scale(${butterfly.scale * butterfly.scaleMod})`,
+    }"
+  >
+    <div class="left-wing">
+      <div class="top" :style="{ background: butterfly.wingTopColor }" />
+      <div class="bottom" :style="{ background: butterfly.wingTopColor }" />
+    </div>
+    <div class="right-wing">
+      <div class="top" :style="{ background: butterfly.wingBottomColor }" />
+      <div class="bottom" :style="{ background: butterfly.wingBottomColor }" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useButterflyStore } from '@/stores/butterflyStore'
+
+const butterflyStore = useButterflyStore()
+const butterflies = computed(() => butterflyStore.getAllButterflies)
+
+onMounted(async () => {
+  if (!butterflyStore.initialized) {
+    await butterflyStore.initialize()
+  }
+})
+</script>
+
+<style scoped>
+@keyframes flutter-left {
+  0% {
+    transform: rotate3d(0, 1, 0, 20deg);
+  }
+  50% {
+    transform: rotate3d(0, 1, 0, 70deg);
+  }
+  100% {
+    transform: rotate3d(0, 1, 0, 20deg);
+  }
+}
+
+@keyframes flutter-right {
+  0% {
+    transform: rotate3d(0, 1, 0, -20deg);
+  }
+  50% {
+    transform: rotate3d(0, 1, 0, -70deg);
+  }
+  100% {
+    transform: rotate3d(0, 1, 0, -20deg);
+  }
+}
+
+.butterfly {
+  width: 100px;
+  height: 100px;
+  position: absolute;
+  transform-style: preserve-3d;
+  transform: rotate3d(1, 0.5, 0, 110deg);
+}
+
+.left-wing,
+.right-wing {
+  width: 24px;
+  height: 42px;
+  position: absolute;
+  top: 10px;
+}
+
+.left-wing {
+  left: 10px;
+  top: 10px;
+  transform-origin: 24px 50%;
+  transform: rotate3d(0, 1, 0, 20deg);
+  animation: flutter-left 0.3s infinite;
+}
+
+.right-wing {
+  left: 34px;
+  transform: rotate3d(0, 1, 0, -20deg);
+  transform-origin: 0px 50%;
+  animation: flutter-right 0.3s infinite;
+}
+
+.left-wing .top {
+  right: 0;
+}
+
+.top,
+.bottom {
+  opacity: 0.7;
+  position: absolute;
+}
+.top {
+  width: 20px;
+  height: 20px;
+  border-radius: 10px;
+}
+
+.bottom {
+  top: 18px;
+  width: 24px;
+  height: 24px;
+  border-radius: 12px;
+}
+</style>
+utils/useRandomColor

--- a/components/abandonware/butterfly/butterfly-mascot.vue
+++ b/components/abandonware/butterfly/butterfly-mascot.vue
@@ -1,0 +1,146 @@
+<!-- /components/content/butterfly/butterfly-mascot.vue -->
+<!-- src/components/ButterflySolo.vue -->
+<template>
+  <div class="butterfly" :style="{ left: x + 'px', top: y + 'px' }">
+    <div class="left-wing">
+      <div class="top" :style="{ background: wingColor }" />
+      <div class="bottom" :style="{ background: wingColor }" />
+    </div>
+    <div class="right-wing">
+      <div class="top" :style="{ background: wingColor }" />
+      <div class="bottom" :style="{ background: wingColor }" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useRandomColor } from '@/utils/useRandomColor'
+
+const props = defineProps<{
+  wingColor?: string
+}>()
+
+const wingColor = props.wingColor || useRandomColor().randomColor.value
+
+const x = ref(0)
+const y = ref(0)
+
+function getRandomSpeed() {
+  return Math.random() * 2 + 0.5
+}
+
+function getRandomDirection() {
+  return Math.random() * 2 * Math.PI
+}
+
+const dx = ref(getRandomSpeed() * Math.cos(getRandomDirection()))
+const dy = ref(getRandomSpeed() * Math.sin(getRandomDirection()))
+
+function updatePosition() {
+  x.value += dx.value
+  y.value += dy.value
+
+  if (x.value < 0 || x.value > window.innerWidth - 100) {
+    dx.value = -dx.value
+  }
+
+  if (y.value < 0 || y.value > window.innerHeight - 100) {
+    dy.value = -dy.value
+  }
+}
+
+function animate() {
+  updatePosition()
+  requestAnimationFrame(animate)
+}
+
+onMounted(() => {
+  updatePosition()
+  animate()
+})
+</script>
+
+<style scoped>
+body {
+  background: #111;
+  pointer-events: none;
+}
+
+@keyframes flutter-left {
+  0% {
+    transform: rotate3d(0, 1, 0, 20deg);
+  }
+  50% {
+    transform: rotate3d(0, 1, 0, 70deg);
+  }
+  100% {
+    transform: rotate3d(0, 1, 0, 20deg);
+  }
+}
+
+@keyframes flutter-right {
+  0% {
+    transform: rotate3d(0, 1, 0, -20deg);
+  }
+  50% {
+    transform: rotate3d(0, 1, 0, -70deg);
+  }
+  100% {
+    transform: rotate3d(0, 1, 0, -20deg);
+  }
+}
+
+.butterfly {
+  width: 100px;
+  height: 100px;
+  position: absolute;
+  transform-style: preserve-3d;
+  transform: rotate3d(1, 0.5, 0, 110deg);
+  pointer-events: none;
+}
+
+.left-wing,
+.right-wing {
+  width: 24px;
+  height: 42px;
+  position: absolute;
+  top: 10px;
+}
+
+.left-wing {
+  left: 10px;
+  top: 10px;
+  transform-origin: 24px 50%;
+  transform: rotate3d(0, 1, 0, 20deg);
+  animation: flutter-left 0.3s infinite;
+}
+
+.right-wing {
+  left: 34px;
+  transform: rotate3d(0, 1, 0, -20deg);
+  transform-origin: 0px 50%;
+  animation: flutter-right 0.3s infinite;
+}
+
+.left-wing .top {
+  right: 0;
+}
+
+.top,
+.bottom {
+  opacity: 0.7;
+  position: absolute;
+}
+.top {
+  width: 20px;
+  height: 20px;
+  border-radius: 10px;
+}
+
+.bottom {
+  top: 18px;
+  width: 24px;
+  height: 24px;
+  border-radius: 12px;
+}
+</style>

--- a/components/abandonware/butterfly/butterfly-modal.vue
+++ b/components/abandonware/butterfly/butterfly-modal.vue
@@ -1,0 +1,457 @@
+<!-- /components/butterfly/butterfly-modal.vue -->
+<template>
+  <!-- ── discovery congratulations ─────────────────────────────────────────── -->
+  <Teleport to="body">
+    <Transition name="modal">
+      <div
+        v-if="butterflyStore.discoveryButterfly"
+        class="modal-backdrop"
+        @click.self="butterflyStore.clearDiscovery()"
+      >
+        <div
+          class="modal-card discovery-card"
+          role="dialog"
+          aria-label="New species discovered"
+          @click.stop
+        >
+          <div class="discovery-glow" aria-hidden="true" />
+
+          <div class="modal-wings" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="96"
+              height="72"
+              viewBox="0 0 36 28"
+            >
+              <ellipse
+                cx="9"
+                cy="10"
+                rx="9"
+                ry="6"
+                :fill="butterflyStore.discoveryButterfly.wingTopColor"
+                opacity="0.95"
+              />
+              <ellipse
+                cx="27"
+                cy="10"
+                rx="9"
+                ry="6"
+                :fill="butterflyStore.discoveryButterfly.wingTopColor"
+                opacity="0.95"
+              />
+              <ellipse
+                cx="8"
+                cy="18"
+                rx="7"
+                ry="5"
+                :fill="butterflyStore.discoveryButterfly.wingBottomColor"
+                opacity="0.88"
+              />
+              <ellipse
+                cx="28"
+                cy="18"
+                rx="7"
+                ry="5"
+                :fill="butterflyStore.discoveryButterfly.wingBottomColor"
+                opacity="0.88"
+              />
+              <ellipse
+                cx="18"
+                cy="14"
+                rx="2"
+                ry="6"
+                fill="#2c2c2a"
+                opacity="0.85"
+              />
+              <line
+                x1="17"
+                y1="8"
+                x2="13"
+                y2="3"
+                stroke="#2c2c2a"
+                stroke-width="0.9"
+              />
+              <line
+                x1="19"
+                y1="8"
+                x2="23"
+                y2="3"
+                stroke="#2c2c2a"
+                stroke-width="0.9"
+              />
+              <circle cx="13" cy="3" r="1" fill="#2c2c2a" />
+              <circle cx="23" cy="3" r="1" fill="#2c2c2a" />
+            </svg>
+          </div>
+
+          <div class="discovery-label">new species discovered</div>
+          <h2 class="modal-name">
+            {{
+              butterflyStore.discoveryButterfly.name ??
+              butterflyStore.discoveryButterfly.id
+            }}
+          </h2>
+          <p class="modal-message">
+            "{{ butterflyStore.discoveryButterfly.message }}"
+          </p>
+          <p class="discovery-body">
+            This butterfly has never been seen before. It's been added to the
+            field guide and your collection.
+          </p>
+
+          <div class="modal-actions">
+            <button
+              class="btn-confirm btn-discovery"
+              @click="butterflyStore.clearDiscovery()"
+            >
+              wonderful
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+
+  <!-- ── standard capture card ─────────────────────────────────────────────── -->
+  <Teleport to="body">
+    <Transition name="modal">
+      <div
+        v-if="butterfly"
+        class="modal-backdrop"
+        @click.self="$emit('cancel')"
+      >
+        <div
+          class="modal-card"
+          role="dialog"
+          :aria-label="`Captured: ${butterfly.name ?? butterfly.id}`"
+          @click.stop
+        >
+          <div class="modal-wings" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="80"
+              height="60"
+              viewBox="0 0 36 28"
+            >
+              <ellipse
+                cx="9"
+                cy="10"
+                rx="9"
+                ry="6"
+                :fill="butterfly.wingTopColor"
+                opacity="0.92"
+              />
+              <ellipse
+                cx="27"
+                cy="10"
+                rx="9"
+                ry="6"
+                :fill="butterfly.wingTopColor"
+                opacity="0.92"
+              />
+              <ellipse
+                cx="8"
+                cy="18"
+                rx="7"
+                ry="5"
+                :fill="butterfly.wingBottomColor"
+                opacity="0.82"
+              />
+              <ellipse
+                cx="28"
+                cy="18"
+                rx="7"
+                ry="5"
+                :fill="butterfly.wingBottomColor"
+                opacity="0.82"
+              />
+              <ellipse
+                cx="18"
+                cy="14"
+                rx="2"
+                ry="6"
+                fill="#2c2c2a"
+                opacity="0.85"
+              />
+              <line
+                x1="17"
+                y1="8"
+                x2="13"
+                y2="3"
+                stroke="#2c2c2a"
+                stroke-width="0.9"
+              />
+              <line
+                x1="19"
+                y1="8"
+                x2="23"
+                y2="3"
+                stroke="#2c2c2a"
+                stroke-width="0.9"
+              />
+              <circle cx="13" cy="3" r="1" fill="#2c2c2a" />
+              <circle cx="23" cy="3" r="1" fill="#2c2c2a" />
+            </svg>
+          </div>
+
+          <div v-if="butterfly.rarity" class="modal-rarity">
+            #{{ String(butterfly.rarity).padStart(3, '0') }}
+          </div>
+
+          <h2 class="modal-name">{{ butterfly.name ?? butterfly.id }}</h2>
+          <p class="modal-message">"{{ butterfly.message }}"</p>
+
+          <div class="modal-stats">
+            <div class="stat">
+              <span class="stat-label">speed</span>
+              <span class="stat-val">{{ butterfly.speed }}×</span>
+            </div>
+            <div class="stat">
+              <span class="stat-label">wing freq</span>
+              <span class="stat-val"
+                >{{ butterfly.wingSpeed.toFixed(2) }} hz</span
+              >
+            </div>
+            <div class="stat">
+              <span class="stat-label">top</span>
+              <span
+                class="stat-swatch"
+                :style="{ background: butterfly.wingTopColor }"
+              />
+            </div>
+            <div class="stat">
+              <span class="stat-label">bottom</span>
+              <span
+                class="stat-swatch"
+                :style="{ background: butterfly.wingBottomColor }"
+              />
+            </div>
+          </div>
+
+          <div class="modal-actions">
+            <button class="btn-confirm" @click="$emit('confirm')">
+              add to gallery
+            </button>
+            <button class="btn-cancel" @click="$emit('cancel')">
+              let it go
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { useButterflyStore } from '~/stores/butterflyStore'
+import type { Butterfly } from '~/stores/helpers/butterflyHelper'
+
+defineProps<{
+  butterfly: Butterfly | null
+}>()
+
+defineEmits<{
+  confirm: []
+  cancel: []
+}>()
+
+const butterflyStore = useButterflyStore()
+</script>
+
+<style scoped>
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(4, 52, 44, 0.18);
+  backdrop-filter: blur(2px);
+  z-index: 9300;
+  cursor: default;
+  pointer-events: all;
+}
+
+.modal-card {
+  position: relative;
+  overflow: hidden;
+  background: var(--color-background-primary, #fff);
+  border-radius: 16px;
+  border: 1px solid #9fe1cb;
+  padding: 24px 28px 20px;
+  min-width: 240px;
+  max-width: 300px;
+  text-align: center;
+  box-shadow: 0 8px 32px rgba(15, 110, 86, 0.12);
+}
+
+/* ── discovery variant ──────────────────────────────────────────────────────── */
+
+.discovery-card {
+  border-color: #fac775;
+  box-shadow: 0 8px 40px rgba(239, 159, 39, 0.2);
+}
+
+.discovery-glow {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse at 50% 25%,
+    rgba(250, 199, 117, 0.22) 0%,
+    transparent 68%
+  );
+  pointer-events: none;
+}
+
+.discovery-label {
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #ba7517;
+  margin-bottom: 6px;
+}
+
+.discovery-body {
+  font-size: 12px;
+  color: var(--color-text-secondary, #666);
+  line-height: 1.6;
+  margin-bottom: 16px;
+}
+
+/* ── shared ─────────────────────────────────────────────────────────────────── */
+
+.modal-wings {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 10px;
+}
+
+.modal-rarity {
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  color: #5dcaa5;
+  margin-bottom: 4px;
+}
+
+.modal-name {
+  font-size: 20px;
+  font-weight: 500;
+  color: var(--color-text-primary, #1a1a18);
+  margin-bottom: 8px;
+  line-height: 1.2;
+}
+
+.modal-message {
+  font-size: 13px;
+  color: var(--color-text-secondary, #666);
+  line-height: 1.55;
+  margin-bottom: 16px;
+  font-style: italic;
+}
+
+.modal-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-bottom: 18px;
+}
+
+.stat {
+  background: var(--color-background-secondary, #f5f5f3);
+  border-radius: 8px;
+  padding: 8px 10px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.stat-label {
+  font-size: 10px;
+  color: var(--color-text-secondary, #888);
+  letter-spacing: 0.04em;
+}
+
+.stat-val {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-primary, #222);
+}
+
+.stat-swatch {
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  display: block;
+}
+
+/* ── actions ────────────────────────────────────────────────────────────────── */
+
+.modal-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.btn-confirm {
+  width: 100%;
+  padding: 9px 12px;
+  border-radius: 8px;
+  border: 1.5px solid #1d9e75;
+  background: transparent;
+  color: #0f6e56;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.btn-confirm:hover {
+  background: #e1f5ee;
+}
+
+.btn-discovery {
+  border-color: #ba7517;
+  color: #854f0b;
+}
+
+.btn-discovery:hover {
+  background: #faeeda;
+}
+
+.btn-cancel {
+  width: 100%;
+  padding: 7px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-tertiary, rgba(0, 0, 0, 0.12));
+  background: transparent;
+  color: var(--color-text-secondary, #888);
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.btn-cancel:hover {
+  background: var(--color-background-secondary, #f5f5f3);
+}
+
+/* ── transitions ────────────────────────────────────────────────────────────── */
+
+.modal-enter-active,
+.modal-leave-active {
+  transition:
+    opacity 0.2s,
+    transform 0.2s;
+}
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+  transform: scale(0.92);
+}
+.modal-enter-active .modal-card,
+.modal-leave-active .modal-card {
+  transition: inherit;
+}
+</style>

--- a/components/abandonware/butterfly/butterfly-net.vue
+++ b/components/abandonware/butterfly/butterfly-net.vue
@@ -1,0 +1,333 @@
+<!-- /components/butterfly/butterfly-net.vue -->
+<template>
+  <button
+    class="net-icon-btn"
+    :class="{ active: butterflyStore.gameOpen }"
+    :aria-label="butterflyStore.gameOpen ? 'Put net down' : 'Pick up butterfly net'"
+    :title="butterflyStore.gameOpen ? 'Put net down' : 'Catch butterflies'"
+    @click.stop="butterflyStore.gameOpen = !butterflyStore.gameOpen"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="30"
+      viewBox="0 0 72 88"
+      class="net-icon-svg"
+      aria-hidden="true"
+    >
+      <line x1="8" y1="76" x2="36" y2="46" stroke-width="5" stroke-linecap="round" class="handle" />
+      <ellipse cx="44" cy="34" rx="24" ry="20" fill="none" stroke-width="3.5" class="hoop" />
+      <g class="mesh" stroke-width="1.2" fill="none" opacity="0.75">
+        <line x1="32" y1="34" x2="30" y2="70" />
+        <line x1="44" y1="34" x2="44" y2="74" />
+        <line x1="56" y1="34" x2="58" y2="70" />
+        <line x1="38" y1="34" x2="37" y2="72" />
+        <line x1="50" y1="34" x2="51" y2="72" />
+        <path d="M22,38 Q44,62 66,38" />
+        <path d="M24,46 Q44,68 64,46" />
+        <path d="M27,54 Q44,72 61,54" />
+        <path d="M31,62 Q44,74 57,62" />
+      </g>
+      <path d="M22,34 Q44,76 66,34" fill="none" stroke-width="2" class="bag-outline" />
+    </svg>
+    <span class="close-x" aria-hidden="true">×</span>
+  </button>
+
+  <Teleport to="body">
+    <Transition name="net-fade">
+      <div v-if="butterflyStore.gameOpen" class="butterfly-overlay">
+        <div v-show="cursorVisible" class="net-cursor" :style="netCursorStyle" aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" width="64" height="78" viewBox="0 0 72 88">
+            <line x1="8" y1="76" x2="36" y2="46" stroke="#7f77dd" stroke-width="5" stroke-linecap="round" />
+            <ellipse cx="44" cy="34" rx="24" ry="20" fill="none" stroke="#1d9e75" stroke-width="3" />
+            <g stroke="#5dcaa5" stroke-width="1.2" fill="none" opacity="0.7">
+              <line x1="32" y1="34" x2="30" y2="70" />
+              <line x1="44" y1="34" x2="44" y2="74" />
+              <line x1="56" y1="34" x2="58" y2="70" />
+              <line x1="38" y1="34" x2="37" y2="72" />
+              <line x1="50" y1="34" x2="51" y2="72" />
+              <path d="M22,38 Q44,62 66,38" />
+              <path d="M24,46 Q44,68 64,46" />
+              <path d="M27,54 Q44,72 61,54" />
+              <path d="M31,62 Q44,74 57,62" />
+            </g>
+            <path d="M22,34 Q44,76 66,34" fill="none" stroke="#0f6e56" stroke-width="1.5" />
+          </svg>
+        </div>
+
+        <Transition name="flash">
+          <div v-if="flashMessage" class="catch-flash">{{ flashMessage }}</div>
+        </Transition>
+
+        <ButterflyModal
+          :butterfly="captureTarget"
+          @confirm="onConfirmCapture"
+          @cancel="onCancel"
+        />
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, onUnmounted, ref, watch } from 'vue'
+import ButterflyModal from './butterfly-modal.vue'
+import { useButterflyStore } from '~/stores/butterflyStore'
+import type { Butterfly } from '~/stores/helpers/butterflyHelper'
+
+const butterflyStore = useButterflyStore()
+
+const mouseX = ref(0)
+const mouseY = ref(0)
+const netX = ref(0)
+const netY = ref(0)
+const cursorVisible = ref(false)
+const captureTarget = ref<Butterfly | null>(null)
+const flashMessage = ref('')
+
+let flashTimer: ReturnType<typeof setTimeout> | null = null
+let rafId: number | null = null
+
+const NET_RADIUS = 48
+
+const netCursorStyle = computed(() => ({
+  left: `${netX.value}px`,
+  top: `${netY.value}px`,
+  transform: 'translate(-44px, -34px)',
+}))
+
+function onDocMouseMove(e: MouseEvent) {
+  mouseX.value = e.clientX
+  mouseY.value = e.clientY
+  cursorVisible.value = true
+}
+
+function onDocMouseLeave() {
+  cursorVisible.value = false
+}
+
+function onDocClick(e: MouseEvent) {
+  if (captureTarget.value) return
+  if (butterflyStore.discoveryButterfly) return
+  if ((e.target as HTMLElement).closest('.net-icon-btn')) return
+
+  for (const butterfly of butterflyStore.butterflies) {
+    if (butterfly.isExiting) continue
+    if (butterflyStore.capturedButterflyIds.has(butterfly.id)) continue
+
+    const butterflyX = (butterfly.x / 100) * window.innerWidth
+    const butterflyY = (butterfly.y / 100) * window.innerHeight
+    const distanceX = butterflyX - netX.value
+    const distanceY = butterflyY - netY.value
+
+    if (Math.sqrt(distanceX * distanceX + distanceY * distanceY) < NET_RADIUS) {
+      captureTarget.value = butterfly
+      e.stopPropagation()
+      return
+    }
+  }
+}
+
+function startNetLag() {
+  function tick() {
+    netX.value += (mouseX.value - netX.value) * 0.18
+    netY.value += (mouseY.value - netY.value) * 0.18
+    rafId = requestAnimationFrame(tick)
+  }
+
+  rafId = requestAnimationFrame(tick)
+}
+
+function stopNetLag() {
+  if (rafId !== null) {
+    cancelAnimationFrame(rafId)
+    rafId = null
+  }
+}
+
+function attachListeners() {
+  document.addEventListener('mousemove', onDocMouseMove)
+  document.addEventListener('mouseleave', onDocMouseLeave)
+  document.addEventListener('click', onDocClick, true)
+  document.documentElement.style.cursor = 'none'
+  startNetLag()
+}
+
+function detachListeners() {
+  document.removeEventListener('mousemove', onDocMouseMove)
+  document.removeEventListener('mouseleave', onDocMouseLeave)
+  document.removeEventListener('click', onDocClick, true)
+  document.documentElement.style.cursor = ''
+  stopNetLag()
+  cursorVisible.value = false
+}
+
+watch(
+  () => butterflyStore.gameOpen,
+  (open) => {
+    if (open) attachListeners()
+    else detachListeners()
+  },
+  { immediate: true },
+)
+
+onUnmounted(detachListeners)
+
+async function onConfirmCapture() {
+  if (!captureTarget.value) return
+
+  const butterfly = captureTarget.value
+  await butterflyStore.recordCapture(butterfly)
+  captureTarget.value = null
+  flashMessage.value = `✓ ${butterfly.name ?? butterfly.id} observed`
+
+  if (flashTimer) clearTimeout(flashTimer)
+  flashTimer = setTimeout(() => {
+    flashMessage.value = ''
+  }, 1800)
+}
+
+function onCancel() {
+  captureTarget.value = null
+}
+</script>
+
+<style scoped>
+.net-icon-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1.5px solid transparent;
+  background: transparent;
+  cursor: pointer;
+  transition:
+    background 0.18s,
+    border-color 0.18s,
+    transform 0.14s;
+}
+
+.net-icon-btn:hover {
+  background: rgba(29, 158, 117, 0.1);
+  border-color: rgba(29, 158, 117, 0.35);
+  transform: scale(1.08);
+}
+
+.net-icon-btn.active {
+  background: rgba(29, 158, 117, 0.14);
+  border-color: #1d9e75;
+}
+
+.net-icon-svg {
+  display: block;
+  transition:
+    opacity 0.18s,
+    transform 0.18s;
+}
+
+.net-icon-btn.active .net-icon-svg {
+  opacity: 0.35;
+  transform: scale(0.85);
+}
+
+.handle {
+  stroke: #7f77dd;
+}
+
+.hoop {
+  stroke: #1d9e75;
+}
+
+.mesh {
+  stroke: #5dcaa5;
+}
+
+.bag-outline {
+  stroke: #0f6e56;
+}
+
+.close-x {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 20px;
+  font-weight: 400;
+  line-height: 1;
+  color: #0f6e56;
+  opacity: 0;
+  transition: opacity 0.18s;
+  pointer-events: none;
+}
+
+.net-icon-btn.active .close-x {
+  opacity: 1;
+}
+
+.butterfly-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+  pointer-events: none;
+}
+
+.net-cursor {
+  position: fixed;
+  pointer-events: none;
+  z-index: 9100;
+  will-change: left, top;
+}
+
+.catch-flash {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(4, 52, 44, 0.85);
+  color: #9fe1cb;
+  font-size: 15px;
+  font-weight: 500;
+  padding: 8px 20px;
+  border-radius: 20px;
+  pointer-events: none;
+  z-index: 9200;
+  white-space: nowrap;
+}
+
+.net-fade-enter-active,
+.net-fade-leave-active,
+.flash-enter-active,
+.flash-leave-active {
+  transition: opacity 0.2s;
+}
+
+.net-fade-enter-from,
+.net-fade-leave-to,
+.flash-enter-from,
+.flash-leave-to {
+  opacity: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .handle {
+    stroke: #afa9ec;
+  }
+
+  .hoop {
+    stroke: #5dcaa5;
+  }
+
+  .mesh {
+    stroke: #9fe1cb;
+  }
+
+  .bag-outline,
+  .close-x {
+    color: #5dcaa5;
+    stroke: #5dcaa5;
+  }
+}
+</style>

--- a/components/abandonware/butterfly/butterfly-sanctuary.vue
+++ b/components/abandonware/butterfly/butterfly-sanctuary.vue
@@ -1,0 +1,610 @@
+<!-- /components/content/butterfly/butterfly-sanctuary.vue -->
+<template>
+  <div class="flex min-h-0 hfull w-full flex-col overflow-hidden bg-base-200">
+    <header
+      class="flex shrink-0 flex-wrap items-center gap-3 border-b border-base-300 bg-base-100 px-4 py-2.5"
+    >
+      <span class="text-base font-semibold tracking-tight">
+        🦋 Butterfly Sanctuary
+      </span>
+
+      <div class="badge badge-outline font-mono text-xs tabular-nums">
+        {{ activeCount }} active
+      </div>
+
+      <div
+        v-if="isSinglePane"
+        class="flex items-center gap-1 rounded-xl border border-base-300 bg-base-200 p-1"
+      >
+        <button
+          type="button"
+          class="btn btn-xs"
+          :class="mobilePanel === 'roster' ? 'btn-primary' : 'btn-ghost'"
+          @click="mobilePanel = 'roster'"
+        >
+          Roster
+        </button>
+        <button
+          type="button"
+          class="btn btn-xs"
+          :class="mobilePanel === 'guide' ? 'btn-primary' : 'btn-ghost'"
+          @click="mobilePanel = 'guide'"
+        >
+          Guide
+        </button>
+      </div>
+
+      <div class="ml-auto flex flex-wrap items-center gap-1.5">
+        <button
+          type="button"
+          class="btn btn-sm"
+          :class="showSwarm ? 'btn-ghost' : 'btn-primary'"
+          @click="butterflyStore.setShowSwarm(!showSwarm)"
+        >
+          {{ showSwarm ? 'Hide Swarm' : 'Show Swarm' }}
+        </button>
+
+        <div class="hidden h-5 w-px bg-base-300 sm:block" />
+
+        <button
+          type="button"
+          class="btn btn-sm btn-ghost"
+          @click="butterflyStore.setShowNames(!showNames)"
+        >
+          {{ showNames ? 'Hide Names' : 'Show Names' }}
+        </button>
+
+        <button
+          type="button"
+          class="btn btn-sm btn-warning"
+          :disabled="activeCount <= 0"
+          @click="clearButterflies"
+        >
+          Clear All
+        </button>
+      </div>
+    </header>
+
+    <div
+      v-if="isSinglePane"
+      class="flex min-h-0 flex-1 flex-col overflow-hidden"
+    >
+      <aside
+        v-show="mobilePanel === 'roster'"
+        class="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden bg-base-100 p-3"
+      >
+        <div class="shrink-0 rounded-xl border border-base-300 bg-base-200 p-3">
+          <div
+            class="mb-2 text-xs font-semibold uppercase tracking-wide text-base-content/50"
+          >
+            Summon
+          </div>
+
+          <div class="grid grid-cols-3 gap-1.5">
+            <button
+              type="button"
+              class="btn btn-sm btn-secondary"
+              @click="removeRandom"
+            >
+              <icon name="kind-icon:minus" class="h-3.5 w-3.5" />
+            </button>
+
+            <button
+              type="button"
+              class="btn btn-sm col-span-2 btn-primary"
+              @click="summon(1)"
+            >
+              <icon name="kind-icon:plus" class="h-3.5 w-3.5" />
+              +1
+            </button>
+
+            <button
+              type="button"
+              class="btn btn-sm btn-ghost"
+              @click="summon(5)"
+            >
+              +5
+            </button>
+
+            <button
+              type="button"
+              class="btn btn-sm btn-ghost"
+              @click="summon(10)"
+            >
+              +10
+            </button>
+
+            <button
+              type="button"
+              class="btn btn-sm btn-ghost"
+              @click="summon(20)"
+            >
+              +20
+            </button>
+          </div>
+        </div>
+
+        <div class="shrink-0 rounded-xl border border-base-300 bg-base-200 p-3">
+          <div class="mb-2 flex items-center justify-between gap-2">
+            <span
+              class="text-xs font-semibold uppercase tracking-wide text-base-content/50"
+            >
+              Selected
+            </span>
+
+            <button
+              v-if="canEditSelected"
+              type="button"
+              class="btn btn-xs btn-accent"
+              @click="editSelectedButterfly"
+            >
+              <icon name="kind-icon:pen" class="h-3 w-3" />
+              Edit
+            </button>
+          </div>
+
+          <template v-if="currentButterfly">
+            <div class="grid grid-cols-2 gap-1.5 text-xs">
+              <div class="col-span-2 rounded-lg bg-base-100 px-2.5 py-1.5">
+                <div class="text-base-content/40">Name</div>
+                <div class="truncate font-semibold">
+                  {{ currentButterfly.name || currentButterfly.id }}
+                </div>
+              </div>
+
+              <div class="rounded-lg bg-base-100 px-2.5 py-1.5">
+                <div class="text-base-content/40">Status</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.status || 'random' }}
+                </div>
+              </div>
+
+              <div class="rounded-lg bg-base-100 px-2.5 py-1.5">
+                <div class="text-base-content/40">Z Index</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.zIndex ?? '—' }}
+                </div>
+              </div>
+
+              <div class="col-span-2 rounded-lg bg-base-100 px-2.5 py-1.5">
+                <div class="text-base-content/40">Position</div>
+                <div class="font-semibold tabular-nums">
+                  {{ currentButterfly.x ?? '—' }},
+                  {{ currentButterfly.y ?? '—' }}
+                </div>
+              </div>
+            </div>
+
+            <button
+              type="button"
+              class="btn btn-outline btn-xs mt-2 w-full"
+              @click="removeSelectedButterfly"
+            >
+              Send Away
+            </button>
+
+            <button
+              type="button"
+              class="btn btn-primary btn-xs mt-2 w-full"
+              @click="mobilePanel = 'guide'"
+            >
+              Open Guide
+            </button>
+          </template>
+
+          <p v-else class="text-xs text-base-content/40">
+            No butterfly selected.
+          </p>
+        </div>
+
+        <div
+          class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-base-300 bg-base-200 p-3"
+        >
+          <div
+            class="mb-2 shrink-0 text-xs font-semibold uppercase tracking-wide text-base-content/50"
+          >
+            Roster
+          </div>
+
+          <div
+            v-if="selectableButterflies.length"
+            class="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto"
+          >
+            <button
+              v-for="butterfly in selectableButterflies"
+              :key="butterfly.id"
+              type="button"
+              class="flex w-full shrink-0 items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-xs transition-colors"
+              :class="
+                selectedButterflyId === butterfly.id
+                  ? 'bg-primary text-primary-content'
+                  : 'bg-base-100 hover:bg-base-300'
+              "
+              @click="selectButterfly(butterfly.id)"
+            >
+              <span class="text-base leading-none">🦋</span>
+              <span class="min-w-0 flex-1 truncate font-medium">
+                {{ butterfly.name || butterfly.id }}
+              </span>
+              <span class="shrink-0 tabular-nums text-[10px] opacity-50">
+                {{ butterfly.x ?? '?' }},{{ butterfly.y ?? '?' }}
+              </span>
+            </button>
+          </div>
+
+          <p v-else class="text-xs text-base-content/40">
+            No butterflies in the swarm.
+          </p>
+        </div>
+      </aside>
+
+      <section
+        v-show="mobilePanel === 'guide'"
+        class="flex min-h-0 flex-1 flex-col overflow-hidden"
+      >
+        <div
+          class="flex shrink-0 items-center justify-between gap-2 border-b border-base-300 px-4 py-2.5"
+        >
+          <span class="truncate text-sm font-semibold">
+            {{
+              currentButterfly?.name || currentButterfly?.id || 'Field Guide'
+            }}
+          </span>
+
+          <div class="flex items-center gap-2">
+            <div
+              v-if="currentButterfly"
+              class="badge shrink-0 text-xs"
+              :class="canEditSelected ? 'badge-secondary' : 'badge-ghost'"
+            >
+              {{ canEditSelected ? 'Editable' : 'Read only' }}
+            </div>
+
+            <button
+              type="button"
+              class="btn btn-xs btn-ghost"
+              @click="mobilePanel = 'roster'"
+            >
+              Back
+            </button>
+          </div>
+        </div>
+
+        <butterfly-guide class="min-h-0 flex-1" :empty-label="emptyLabel" />
+      </section>
+    </div>
+
+    <div
+      v-else
+      class="grid min-h-0 flex-1 overflow-hidden lg:grid-cols-[17rem_1fr] xl:grid-cols-[18rem_1fr]"
+    >
+      <aside
+        class="flex min-h-0 flex-col gap-2 overflow-hidden border-r border-base-300 bg-base-100 p-3"
+      >
+        <div class="shrink-0 rounded-xl border border-base-300 bg-base-200 p-3">
+          <div
+            class="mb-2 text-xs font-semibold uppercase tracking-wide text-base-content/50"
+          >
+            Summon
+          </div>
+
+          <div class="grid grid-cols-3 gap-1.5">
+            <button
+              type="button"
+              class="btn btn-sm btn-secondary"
+              @click="removeRandom"
+            >
+              <icon name="kind-icon:minus" class="h-3.5 w-3.5" />
+            </button>
+
+            <button
+              type="button"
+              class="btn btn-sm col-span-2 btn-primary"
+              @click="summon(1)"
+            >
+              <icon name="kind-icon:plus" class="h-3.5 w-3.5" />
+              +1
+            </button>
+
+            <button
+              type="button"
+              class="btn btn-sm btn-ghost"
+              @click="summon(5)"
+            >
+              +5
+            </button>
+
+            <button
+              type="button"
+              class="btn btn-sm btn-ghost"
+              @click="summon(10)"
+            >
+              +10
+            </button>
+
+            <button
+              type="button"
+              class="btn btn-sm btn-ghost"
+              @click="summon(20)"
+            >
+              +20
+            </button>
+          </div>
+        </div>
+
+        <div class="shrink-0 rounded-xl border border-base-300 bg-base-200 p-3">
+          <div class="mb-2 flex items-center justify-between gap-2">
+            <span
+              class="text-xs font-semibold uppercase tracking-wide text-base-content/50"
+            >
+              Selected
+            </span>
+
+            <button
+              v-if="canEditSelected"
+              type="button"
+              class="btn btn-xs btn-accent"
+              @click="editSelectedButterfly"
+            >
+              <icon name="kind-icon:pen" class="h-3 w-3" />
+              Edit
+            </button>
+          </div>
+
+          <template v-if="currentButterfly">
+            <div class="grid grid-cols-2 gap-1.5 text-xs">
+              <div class="col-span-2 rounded-lg bg-base-100 px-2.5 py-1.5">
+                <div class="text-base-content/40">Name</div>
+                <div class="truncate font-semibold">
+                  {{ currentButterfly.name || currentButterfly.id }}
+                </div>
+              </div>
+
+              <div class="rounded-lg bg-base-100 px-2.5 py-1.5">
+                <div class="text-base-content/40">Status</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.status || 'random' }}
+                </div>
+              </div>
+
+              <div class="rounded-lg bg-base-100 px-2.5 py-1.5">
+                <div class="text-base-content/40">Z Index</div>
+                <div class="font-semibold">
+                  {{ currentButterfly.zIndex ?? '—' }}
+                </div>
+              </div>
+
+              <div class="col-span-2 rounded-lg bg-base-100 px-2.5 py-1.5">
+                <div class="text-base-content/40">Position</div>
+                <div class="font-semibold tabular-nums">
+                  {{ currentButterfly.x ?? '—' }},
+                  {{ currentButterfly.y ?? '—' }}
+                </div>
+              </div>
+            </div>
+
+            <button
+              type="button"
+              class="btn btn-outline btn-xs mt-2 w-full"
+              @click="removeSelectedButterfly"
+            >
+              Send Away
+            </button>
+          </template>
+
+          <p v-else class="text-xs text-base-content/40">
+            No butterfly selected.
+          </p>
+        </div>
+
+        <div
+          class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-base-300 bg-base-200 p-3"
+        >
+          <div
+            class="mb-2 shrink-0 text-xs font-semibold uppercase tracking-wide text-base-content/50"
+          >
+            Roster
+          </div>
+
+          <div
+            v-if="selectableButterflies.length"
+            class="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto"
+          >
+            <button
+              v-for="butterfly in selectableButterflies"
+              :key="butterfly.id"
+              type="button"
+              class="flex w-full shrink-0 items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-xs transition-colors"
+              :class="
+                selectedButterflyId === butterfly.id
+                  ? 'bg-primary text-primary-content'
+                  : 'bg-base-100 hover:bg-base-300'
+              "
+              @click="selectedButterflyId = butterfly.id"
+            >
+              <span class="text-base leading-none">🦋</span>
+              <span class="min-w-0 flex-1 truncate font-medium">
+                {{ butterfly.name || butterfly.id }}
+              </span>
+              <span class="shrink-0 tabular-nums text-[10px] opacity-50">
+                {{ butterfly.x ?? '?' }},{{ butterfly.y ?? '?' }}
+              </span>
+            </button>
+          </div>
+
+          <p v-else class="text-xs text-base-content/40">
+            No butterflies in the swarm.
+          </p>
+        </div>
+      </aside>
+
+      <section class="flex min-h-0 flex-col overflow-hidden">
+        <div
+          class="flex shrink-0 items-center justify-between gap-2 border-b border-base-300 px-4 py-2.5"
+        >
+          <span class="truncate text-sm font-semibold">
+            {{
+              currentButterfly?.name || currentButterfly?.id || 'Field Guide'
+            }}
+          </span>
+
+          <div
+            v-if="currentButterfly"
+            class="badge shrink-0 text-xs"
+            :class="canEditSelected ? 'badge-secondary' : 'badge-ghost'"
+          >
+            {{ canEditSelected ? 'Editable' : 'Read only' }}
+          </div>
+        </div>
+
+        <butterfly-guide class="min-h-0 flex-1" :empty-label="emptyLabel" />
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// /components/content/butterfly/butterfly-sanctuary.vue
+import { computed, onMounted, ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useButterflyStore } from '@/stores/butterflyStore'
+
+import { useUserStore } from '@/stores/userStore'
+
+const butterflyStore = useButterflyStore()
+const userStore = useUserStore()
+
+import { onBeforeUnmount } from 'vue'
+
+const isSinglePane = ref(false)
+let mediaQuery: MediaQueryList | null = null
+
+function syncSinglePane() {
+  if (!mediaQuery) return
+  isSinglePane.value = mediaQuery.matches
+}
+
+onMounted(() => {
+  if (typeof window === 'undefined') return
+
+  mediaQuery = window.matchMedia('(max-width: 1023px)')
+  syncSinglePane()
+  mediaQuery.addEventListener('change', syncSinglePane)
+})
+
+onBeforeUnmount(() => {
+  mediaQuery?.removeEventListener('change', syncSinglePane)
+  mediaQuery = null
+})
+
+const { butterflies, selectedButterflyId, showNames, showSwarm } =
+  storeToRefs(butterflyStore)
+
+const mobilePanel = ref<'roster' | 'guide'>('roster')
+
+const selectableButterflies = computed(() =>
+  butterflies.value.filter((b) => !b.isExiting),
+)
+
+const activeCount = computed(() => selectableButterflies.value.length)
+const currentButterfly = computed(() => butterflyStore.getSelectedButterfly)
+
+const emptyLabel = computed(() => {
+  if (!activeCount.value) return 'No butterflies are active. Summon some!'
+  return 'Select a butterfly from the roster to open its field guide.'
+})
+
+const canEditSelected = computed(() => {
+  const butterfly = currentButterfly.value
+  if (!butterfly) return false
+
+  const isAdmin = userStore.isAdmin === true || userStore.role === 'ADMIN'
+  const isOwner =
+    butterfly.userId != null &&
+    userStore.userId != null &&
+    butterfly.userId === userStore.userId
+
+  return isAdmin || isOwner
+})
+
+watch(
+  () => isSinglePane.value,
+  (singlePane) => {
+    if (!singlePane) {
+      mobilePanel.value = 'roster'
+    }
+  },
+)
+
+onMounted(async () => {
+  if (!butterflyStore.initialized) {
+    await butterflyStore.initialize()
+  }
+
+  await butterflyStore.initGame()
+
+  if (!selectedButterflyId.value && selectableButterflies.value.length > 0) {
+    selectedButterflyId.value = selectableButterflies.value[0]?.id || ''
+  }
+})
+
+async function summon(count: number) {
+  await butterflyStore.addButterflies(count)
+  const newest = selectableButterflies.value.at(-1)
+
+  if (newest) {
+    selectedButterflyId.value = newest.id
+    if (isSinglePane.value) mobilePanel.value = 'guide'
+  }
+}
+
+function selectButterfly(id: string) {
+  selectedButterflyId.value = id
+  if (isSinglePane.value) {
+    mobilePanel.value = 'guide'
+  }
+}
+
+function removeRandom() {
+  butterflyStore.removeRandomButterfly()
+
+  if (currentButterfly.value?.isExiting) {
+    const next = selectableButterflies.value.find(
+      (b) => b.id !== currentButterfly.value?.id,
+    )
+    selectedButterflyId.value = next?.id || ''
+  }
+}
+
+function removeSelectedButterfly() {
+  const butterfly = currentButterfly.value
+  if (!butterfly) return
+
+  butterflyStore.markButterflyForExit(butterfly)
+
+  const next = selectableButterflies.value.find((b) => b.id !== butterfly.id)
+  selectedButterflyId.value = next?.id || ''
+
+  if (isSinglePane.value && !selectedButterflyId.value) {
+    mobilePanel.value = 'roster'
+  }
+}
+
+function clearButterflies() {
+  butterflyStore.clearButterflies()
+  selectedButterflyId.value = ''
+  if (isSinglePane.value) mobilePanel.value = 'roster'
+}
+
+const emit = defineEmits<{
+  edit: [butterflyId: string]
+}>()
+
+function editSelectedButterfly() {
+  const butterfly = currentButterfly.value
+  if (!butterfly || !canEditSelected.value) return
+
+  butterflyStore.setInspected(butterfly)
+  emit('edit', butterfly.id)
+}
+</script>

--- a/components/abandonware/butterfly/butterfly-slider.vue
+++ b/components/abandonware/butterfly/butterfly-slider.vue
@@ -1,0 +1,147 @@
+<!-- /components/content/butterfly/butterfly-slider.vue -->
+<template>
+  <div class="flex flex-col items-center w-full">
+    <!-- Label and Current/Original Min/Max Values -->
+    <label :for="sliderId" class="mb-4 text-lg font-semibold text-gray-700">
+      {{ label }}: {{ minValue }} - {{ maxValue }} <br>
+      <small class="text-sm text-gray-500">Original: {{ originalMin }} - {{ originalMax }}</small> <!-- Display original min/max -->
+    </label>
+
+    <div class="relative w-full">
+      <!-- Grey Slider Track -->
+      <div class="h-2 bg-gray-200 rounded-full"></div>
+
+      <!-- Range Fill Line (colored bg-primary) -->
+      <div
+        class="absolute top-0 h-2 bg-primary rounded-full"
+        :style="{ left: rangeFill.left, width: rangeFill.width }"
+      ></div>
+
+      <!-- Min Knob -->
+      <input
+        v-model="minValue"
+        type="range"
+        :min="props.min"
+        :max="props.max"
+        :step="props.step"
+        class="absolute w-full h-6 appearance-none pointer-events-none"
+        @input="updateMinValue"
+      />
+      <div
+        class="absolute w-6 h-6 bg-white border-2 border-primary rounded-full pointer-events-auto transition-all duration-200"
+        :style="minKnobStyle"
+        @mouseenter="showMinTooltip = true"
+        @mouseleave="showMinTooltip = false"
+      ></div>
+
+      <!-- Min Knob Tooltip on Hover -->
+      <div
+        v-if="showMinTooltip"
+        class="absolute px-2 py-1 text-white bg-gray-700 rounded-md -translate-x-1/2 transform -top-8"
+        :style="minKnobStyle"
+      >
+        {{ minValue }}
+      </div>
+
+      <!-- Max Knob -->
+      <input
+        v-model="maxValue"
+        type="range"
+        :min="props.min"
+        :max="props.max"
+        :step="props.step"
+        class="absolute w-full h-6 appearance-none pointer-events-none"
+        @input="updateMaxValue"
+      />
+      <div
+        class="absolute w-6 h-6 bg-white border-2 border-primary rounded-full pointer-events-auto transition-all duration-200"
+        :style="maxKnobStyle"
+        @mouseenter="showMaxTooltip = true"
+        @mouseleave="showMaxTooltip = false"
+      ></div>
+
+      <!-- Max Knob Tooltip on Hover -->
+      <div
+        v-if="showMaxTooltip"
+        class="absolute px-2 py-1 text-white bg-gray-700 rounded-md -translate-x-1/2 transform -top-8"
+        :style="maxKnobStyle"
+      >
+        {{ maxValue }}
+      </div>
+
+      <!-- Min/Max Value Markers -->
+      <div class="absolute -left-6 top-4 text-gray-600">{{ props.min }}</div>
+      <div class="absolute -right-6 top-4 text-gray-600">{{ props.max }}</div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps({
+  min: { type: Number, required: true },
+  max: { type: Number, required: true },
+  step: { type: Number, default: 1 },
+  modelValue: { type: Object, required: true },
+  label: { type: String, required: true },
+  sliderId: { type: String, default: 'slider' },
+  originalMin: { type: Number, required: true }, // Add original min prop
+  originalMax: { type: Number, required: true }, // Add original max prop
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const minValue = ref(props.modelValue.min)
+const maxValue = ref(props.modelValue.max)
+const showMinTooltip = ref(false)
+const showMaxTooltip = ref(false)
+
+// Update the range-fill style dynamically based on min and max values
+const rangeFill = computed(() => {
+  const totalRange = props.max - props.min
+  const minPercent = ((minValue.value - props.min) / totalRange) * 100
+  const maxPercent = ((maxValue.value - props.min) / totalRange) * 100
+
+  return {
+    left: `${minPercent}%`,
+    width: `${maxPercent - minPercent}%`,
+  }
+})
+
+// Ensure minValue cannot exceed maxValue
+const updateMinValue = () => {
+  if (minValue.value > maxValue.value) {
+    minValue.value = maxValue.value
+  }
+  emit('update:modelValue', { min: minValue.value, max: maxValue.value })
+}
+
+// Ensure maxValue cannot be less than minValue
+const updateMaxValue = () => {
+  if (maxValue.value < minValue.value) {
+    maxValue.value = minValue.value
+  }
+  emit('update:modelValue', { min: minValue.value, max: maxValue.value })
+}
+
+// Position the min and max knobs
+const minKnobStyle = computed(() => {
+  const totalRange = props.max - props.min
+  const left = ((minValue.value - props.min) / totalRange) * 100
+  return { left: `calc(${left}% - 12px)` } // Adjusted for larger knob
+})
+
+const maxKnobStyle = computed(() => {
+  const totalRange = props.max - props.min
+  const left = ((maxValue.value - props.min) / totalRange) * 100
+  return { left: `calc(${left}% - 12px)` } // Adjusted for larger knob
+})
+
+watch(
+  () => props.modelValue,
+  (newVal) => {
+    minValue.value = newVal.min
+    maxValue.value = newVal.max
+  },
+  { immediate: true },
+)
+</script>

--- a/components/abandonware/butterfly/butterfly-swarm.vue
+++ b/components/abandonware/butterfly/butterfly-swarm.vue
@@ -1,0 +1,31 @@
+<!-- /components/content/butterfly/butterfly-swarm.vue -->
+<template>
+  <div>
+    <ButterflySingle
+      v-for="(butterfly, index) in butterflies"
+      :key="'butterfly-' + index"
+      :x="butterfly.x"
+      :y="butterfly.y"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+interface ButterflyPosition {
+  x: number
+  y: number
+}
+
+const butterflies = ref<Array<ButterflyPosition>>([])
+
+onMounted(() => {
+  for (let i = 0; i < 3; i++) {
+    butterflies.value.push({
+      x: Math.random() * window.innerWidth,
+      y: Math.random() * window.innerHeight,
+    })
+  }
+})
+</script>

--- a/components/abandonware/butterfly/single-slider.vue
+++ b/components/abandonware/butterfly/single-slider.vue
@@ -1,0 +1,86 @@
+<!-- /components/content/butterfly/single-slider.vue -->
+<template>
+  <div class="mb-6">
+    <label :for="sliderId" class="block mb-2">{{ label }}:</label>
+    <div class="flex items-center justify-between mb-2">
+      <!-- Displaying current value -->
+      <span>{{ currentValue }}</span>
+
+      <!-- Single range slider -->
+      <div class="relative w-4/5 mx-2">
+        <!-- Range track (static background) -->
+        <div class="range-track"></div>
+
+        <!-- Range fill (dynamic background) -->
+        <div class="range-fill" :style="rangeFill"></div>
+
+        <!-- Slider input -->
+        <input
+          :id="sliderId"
+          v-model="currentValue"
+          type="range"
+          :min="min"
+          :max="max"
+          :step="step"
+          class="w-full slider range range-primary"
+          @input="updateValue"
+        />
+      </div>
+    </div>
+    <div class="text-center">Chosen {{ label }}: {{ currentValue }}</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps({
+  min: { type: Number, required: true },
+  max: { type: Number, required: true },
+  step: { type: Number, default: 1 },
+  modelValue: { type: Number, required: true },
+  label: { type: String, required: true },
+  sliderId: { type: String, default: 'slider' },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const currentValue = ref(props.modelValue)
+
+const rangeFill = computed(() => {
+  const totalRange = props.max - props.min
+  const valuePercent = ((currentValue.value - props.min) / totalRange) * 100
+  return {
+    width: `${valuePercent}%`,
+  }
+})
+
+const updateValue = () => {
+  emit('update:modelValue', currentValue.value)
+}
+
+watch(
+  () => props.modelValue,
+  (newVal) => {
+    currentValue.value = newVal
+  },
+  { immediate: true },
+)
+</script>
+
+<style scoped>
+.range-track {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #e0e0e0;
+}
+
+.range-fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background-color: #3b82f6;
+}
+</style>

--- a/components/abandonware/butterfly/store-butterfly.vue
+++ b/components/abandonware/butterfly/store-butterfly.vue
@@ -1,0 +1,262 @@
+<!-- /components/content/butterfly/store-butterfly.vue -->
+<script setup lang="ts">
+import { onMounted, onUnmounted, reactive } from 'vue'
+import { makeNoise2D } from '~/utils/makeNoise2D'
+
+const hydrated = ref(false)
+
+const randomColor = (): string => {
+  const h = Math.floor(Math.random() * 360)
+  const s = Math.floor(Math.random() * 50 + 50) // keep saturation between 50 and 100
+  const l = Math.floor(Math.random() * 40 + 30) // keep lightness between 30 and 70
+  return `hsl(${h},${s}%,${l}%)`
+}
+
+const analogousColor = (hsl: string): string => {
+  const hslMatch = hsl.match(/\d+/g)
+  if (!hslMatch) {
+    throw new Error('Invalid color format')
+  }
+  const [h = 0, s = 100, l = 50] = hslMatch.map(Number)
+  const newH = (h + 30) % 360
+  return `hsl(${newH},${s}%,${l}%)`
+}
+
+const complementaryColor = (color: string): string => {
+  const [h = '0', s = '100%', l = '50%'] = color
+    .replace('hsl(', '')
+    .replace(')', '')
+    .split(',')
+  const newH = (parseInt(h, 10) + 180) % 360
+  return `hsl(${newH},${s},${l})`
+}
+
+interface Butterfly {
+  wingTopColor: string
+  wingBottomColor: string
+  rotation: number
+  speed: number
+  status: 'random' | 'float' | 'mouse' | 'spaz' | 'flock' | 'clear'
+  goal: { x: number; y: number }
+  hasReachedGoal: boolean
+  wingSpeed: number
+  scale: number
+  countdown: number
+}
+
+interface WindowSize {
+  width: number
+  height: number
+}
+
+const windowSize = reactive<WindowSize>({
+  width: 0,
+  height: 0,
+})
+
+const wingColorType = Math.floor(Math.random() * 3) // 0:same, 1:complementary, 2:analogous
+const primaryColor = randomColor()
+let secondaryColor = primaryColor
+if (wingColorType === 1) {
+  secondaryColor = complementaryColor(primaryColor)
+} else if (wingColorType === 2) {
+  secondaryColor = analogousColor(primaryColor)
+}
+
+const butterfly = reactive<Butterfly>({
+  wingTopColor: primaryColor,
+  wingBottomColor: secondaryColor,
+  rotation: 110, // random initial rotation
+  speed: Math.random() * 2 + 1, // speed between 1 and 3
+  status: 'random',
+  goal: {
+    x: Math.random() * windowSize.width,
+    y: Math.random() * windowSize.height,
+  },
+  hasReachedGoal: false,
+  wingSpeed: Math.floor(Math.random() * 3), // random initial wing speed
+  scale: Math.random() * 0.5 + 0.75, // random initial scale between 0.75 and 1.25
+  countdown: 0,
+})
+
+const noise2D = makeNoise2D(Date.now())
+let t = 0
+
+function updatePosition() {
+  t += 0.01
+  const angle =
+    noise2D(butterfly.goal.x * 0.01, butterfly.goal.y * 0.01 + t) * Math.PI * 2
+  const dx = Math.cos(angle) * butterfly.speed
+  const dy = Math.sin(angle) * butterfly.speed
+
+  butterfly.goal.x += dx
+  butterfly.goal.y += dy
+
+  if (butterfly.goal.x < 0 || butterfly.goal.x > window.innerWidth - 100) {
+    butterfly.goal.x = Math.max(
+      Math.min(butterfly.goal.x, window.innerWidth - 100),
+      0,
+    )
+  }
+
+  if (butterfly.goal.y < 0 || butterfly.goal.y > window.innerHeight - 100) {
+    butterfly.goal.y = Math.max(
+      Math.min(butterfly.goal.y, window.innerHeight - 100),
+      0,
+    )
+  }
+
+  butterfly.scale =
+    0.33 +
+    ((2 -
+      (butterfly.goal.x / window.innerWidth +
+        butterfly.goal.y / window.innerHeight)) /
+      2) *
+      0.67
+
+  butterfly.rotation = dx >= 0 ? 120 : 30
+}
+
+function animate() {
+  updatePosition()
+  requestAnimationFrame(animate)
+}
+
+onMounted(() => {
+  hydrated.value = true
+  windowSize.width = window.innerWidth
+  windowSize.height = window.innerHeight
+
+  window.addEventListener('resize', () => {
+    windowSize.width = window.innerWidth
+    windowSize.height = window.innerHeight
+  })
+
+  animate()
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', () => {
+    windowSize.width = window.innerWidth
+    windowSize.height = window.innerHeight
+  })
+})
+</script>
+
+<template>
+  <div
+    v-if="hydrated"
+    class="butterfly z-50"
+    :style="{
+      left: butterfly.goal.x + 'px',
+      top: butterfly.goal.y + 'px',
+      transform:
+        'rotate3d(1, 0.5, 0, ' +
+        butterfly.rotation +
+        'deg) scale(' +
+        butterfly.scale +
+        ')',
+    }"
+  >
+    <div class="left-wing">
+      <div class="top" :style="{ background: butterfly.wingTopColor }"></div>
+      <div
+        class="bottom"
+        :style="{ background: butterfly.wingBottomColor }"
+      ></div>
+    </div>
+    <div class="right-wing">
+      <div class="top" :style="{ background: butterfly.wingTopColor }"></div>
+      <div
+        class="bottom"
+        :style="{ background: butterfly.wingBottomColor }"
+      ></div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+body {
+  background: #111;
+  pointer-events: none;
+}
+
+@keyframes flutter-left {
+  0% {
+    transform: rotate3d(0, 1, 0, 20deg);
+  }
+  50% {
+    transform: rotate3d(0, 1, 0, 70deg);
+  }
+  100% {
+    transform: rotate3d(0, 1, 0, 20deg);
+  }
+}
+
+@keyframes flutter-right {
+  0% {
+    transform: rotate3d(0, 1, 0, -20deg);
+  }
+  50% {
+    transform: rotate3d(0, 1, 0, -70deg);
+  }
+  100% {
+    transform: rotate3d(0, 1, 0, -20deg);
+  }
+}
+
+.butterfly {
+  width: 100px;
+  height: 100px;
+  position: absolute;
+  transform-style: preserve-3d;
+  transform: rotate3d(1, 0.5, 0, 110deg);
+  pointer-events: none;
+}
+
+.left-wing,
+.right-wing {
+  width: 24px;
+  height: 42px;
+  position: absolute;
+  top: 10px;
+  pointer-events: none;
+}
+
+.left-wing {
+  left: 10px;
+  top: 10px;
+  transform-origin: 24px 50%;
+  transform: rotate3d(0, 1, 0, 20deg);
+  animation: flutter-left 0.3s infinite;
+  pointer-events: none;
+}
+
+.right-wing {
+  left: 34px;
+  transform: rotate3d(0, 1, 0, -20deg);
+  transform-origin: 0px 50%;
+  animation: flutter-right 0.3s infinite;
+  pointer-events: none;
+}
+
+.top,
+.bottom {
+  opacity: 0.7;
+  position: absolute;
+  pointer-events: none;
+}
+
+.top {
+  width: 20px;
+  height: 20px;
+  border-radius: 10px;
+}
+
+.bottom {
+  top: 18px;
+  width: 24px;
+  height: 24px;
+  border-radius: 12px;
+}
+</style>

--- a/components/abandonware/characters/character-sheet.vue
+++ b/components/abandonware/characters/character-sheet.vue
@@ -1,0 +1,889 @@
+<!-- /components/characters/character-sheet.vue -->
+<template>
+  <section
+    class="relative flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-300"
+  >
+    <header
+      class="flex shrink-0 flex-col gap-3 border-b border-base-300 bg-base-200 p-4 lg:flex-row lg:items-start lg:justify-between"
+    >
+      <div class="min-w-0">
+        <p class="text-xs font-bold uppercase tracking-[0.22em] text-primary">
+          Character Sheet
+        </p>
+
+        <h2
+          class="mt-1 flex items-center gap-2 text-2xl font-black text-base-content"
+        >
+          <Icon name="kind-icon:mask" class="h-7 w-7 text-primary" />
+          {{ sheet.name || 'Unnamed Character' }}
+        </h2>
+
+        <p class="mt-1 max-w-3xl text-sm text-base-content/70">
+          {{ sheetSubtitle }}
+        </p>
+      </div>
+
+      <div class="flex flex-wrap gap-2">
+        <button
+          v-if="hasPortrait"
+          class="btn rounded-xl"
+          type="button"
+          @click="showPortrait = !showPortrait"
+        >
+          <Icon
+            :name="showPortrait ? 'kind-icon:blueprint' : 'kind-icon:palette'"
+            class="h-4 w-4"
+          />
+          {{ showPortrait ? 'Show Sheet' : 'Show Portrait' }}
+        </button>
+
+        <button
+          v-if="isBuilderMode && allowArt"
+          class="btn btn-primary rounded-xl"
+          type="button"
+          :disabled="!canCreateArt"
+          @click="emit('select-card', 'art')"
+        >
+          <Icon name="kind-icon:palette" class="h-4 w-4" />
+          {{ hasPortrait ? 'Edit Portrait' : 'Create Portrait' }}
+        </button>
+      </div>
+    </header>
+
+    <Transition name="sheet-fade" mode="out-in">
+      <!-- Portrait view -->
+      <section
+        v-if="showPortrait && hasPortrait"
+        key="portrait"
+        class="relative min-h-0 flex-1 overflow-hidden bg-base-200"
+      >
+        <img
+          v-if="sheet.imagePath"
+          :src="sheet.imagePath"
+          :alt="`${sheet.name || 'Character'} portrait`"
+          class="h-full min-h-128 w-full object-cover"
+        />
+
+        <div
+          v-else
+          class="flex h-full min-h-128 w-full items-center justify-center bg-base-300 p-4 text-center"
+        >
+          <div class="kr-panel-flat p-5">
+            <Icon
+              name="kind-icon:palette"
+              class="mx-auto h-14 w-14 text-primary"
+            />
+            <p class="mt-3 text-sm font-bold text-base-content">
+              Portrait image record attached.
+            </p>
+            <p class="mt-1 text-xs text-base-content/60">
+              No image path was provided, but artImageId exists.
+            </p>
+          </div>
+        </div>
+
+        <div
+          class="absolute inset-x-0 bottom-0 bg-linear-to-t from-base-300 via-base-300/90 to-transparent p-4 pt-28"
+        >
+          <article
+            class="rounded-2xl border border-base-100/20 bg-base-100/85 p-4 shadow-xl backdrop-blur"
+          >
+            <p
+              class="text-xs font-bold uppercase tracking-[0.22em] text-primary"
+            >
+              Portrait Mode
+            </p>
+
+            <h3 class="mt-1 text-3xl font-black text-base-content">
+              {{ sheet.name || 'Unnamed Character' }}
+            </h3>
+
+            <p class="mt-1 text-sm text-base-content/70">
+              {{ identityLine }}
+            </p>
+
+            <div class="mt-3 flex flex-wrap gap-2">
+              <span
+                v-for="badge in badges"
+                :key="badge"
+                class="badge badge-primary badge-outline rounded-xl"
+              >
+                {{ badge }}
+              </span>
+            </div>
+
+            <button
+              class="btn btn-primary mt-4 rounded-xl"
+              type="button"
+              @click="showPortrait = false"
+            >
+              <Icon name="kind-icon:blueprint" class="h-4 w-4" />
+              Return to Sheet
+            </button>
+          </article>
+        </div>
+      </section>
+
+      <!-- Sheet view -->
+      <section v-else key="sheet" class="min-h-0 flex-1 overflow-y-auto p-3">
+        <div class="grid grid-cols-1 gap-3 2xl:grid-cols-[16rem_minmax(0,1fr)]">
+          <!-- Sidebar -->
+          <aside class="flex flex-col gap-3">
+            <!-- Portrait thumbnail -->
+            <article class="kr-panel-flat p-3">
+              <div
+                class="relative flex aspect-square items-center justify-center overflow-hidden rounded-2xl border border-base-300 bg-base-300"
+              >
+                <img
+                  v-if="sheet.imagePath"
+                  :src="sheet.imagePath"
+                  alt="Character portrait"
+                  class="h-full w-full object-cover"
+                />
+
+                <div
+                  v-else
+                  class="flex h-full w-full flex-col items-center justify-center gap-3 p-4 text-center"
+                >
+                  <Icon
+                    name="kind-icon:mask"
+                    class="h-14 w-14 text-primary/70"
+                  />
+                  <p class="text-sm font-bold text-base-content/70">
+                    Portrait Pending
+                  </p>
+                  <p class="text-xs text-base-content/50">
+                    Complete the sheet to unlock portrait creation.
+                  </p>
+                </div>
+              </div>
+            </article>
+
+            <!-- Completion checklist -->
+            <article class="kr-panel-flat p-4">
+              <h3 class="flex items-center gap-2 font-black text-base-content">
+                <Icon name="kind-icon:check" class="h-5 w-5 text-primary" />
+                Completion
+              </h3>
+
+              <div class="mt-3 flex flex-col gap-2">
+                <button
+                  v-for="item in completionItems"
+                  :key="item.key"
+                  class="flex items-center justify-between gap-2 rounded-xl bg-base-200 px-3 py-2 text-left transition hover:bg-primary/10 disabled:hover:bg-base-200"
+                  type="button"
+                  :disabled="!isBuilderMode"
+                  @click="emit('select-card', item.cardKey)"
+                >
+                  <span class="text-sm text-base-content/70">
+                    {{ item.label }}
+                  </span>
+
+                  <Icon
+                    :name="item.done ? 'kind-icon:check' : 'kind-icon:circle'"
+                    :class="
+                      item.done
+                        ? 'h-4 w-4 text-success'
+                        : 'h-4 w-4 text-base-content/30'
+                    "
+                  />
+                </button>
+              </div>
+            </article>
+          </aside>
+
+          <!-- Main content -->
+          <main class="flex min-w-0 flex-col gap-3">
+            <!-- Identity block -->
+            <section class="kr-panel-flat p-4">
+              <div class="flex items-start justify-between gap-3">
+                <div>
+                  <p
+                    class="text-xs font-bold uppercase tracking-[0.18em] text-base-content/50"
+                  >
+                    Identity
+                  </p>
+                  <h3 class="mt-1 text-xl font-black text-base-content">
+                    {{ sheet.name || 'Awaiting Name' }}
+                  </h3>
+                  <p class="mt-1 text-sm text-base-content/70">
+                    {{ identityLine }}
+                  </p>
+                </div>
+
+                <button
+                  v-if="isBuilderMode && hasIdentityContent"
+                  class="btn btn-xs rounded-lg"
+                  type="button"
+                  @click="emit('remove-section', 'identity-group')"
+                >
+                  <Icon name="kind-icon:x" class="h-3 w-3" />
+                  Clear
+                </button>
+              </div>
+
+              <div
+                class="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3"
+              >
+                <sheet-cell
+                  label="Name"
+                  icon="kind-icon:signature"
+                  :value="sheet.name"
+                  placeholder="Name card waiting"
+                  :is-builder-mode="isBuilderMode"
+                  @clear="emit('remove-section', 'name')"
+                />
+
+                <sheet-cell
+                  label="Honorific"
+                  icon="kind-icon:crown"
+                  :value="sheet.honorific"
+                  placeholder="adventurer"
+                  :is-builder-mode="isBuilderMode"
+                  @clear="emit('remove-section', 'name')"
+                />
+
+                <sheet-cell
+                  label="Role"
+                  icon="kind-icon:mask"
+                  :value="sheet.role"
+                  placeholder="Role card waiting"
+                  :is-builder-mode="isBuilderMode"
+                  @clear="emit('remove-section', 'role')"
+                />
+
+                <sheet-cell
+                  label="Species"
+                  icon="kind-icon:species"
+                  :value="sheet.species"
+                  placeholder="Origin card waiting"
+                  :is-builder-mode="isBuilderMode"
+                  @clear="emit('remove-section', 'origin')"
+                />
+
+                <!-- schema: class -->
+                <sheet-cell
+                  label="Class"
+                  icon="kind-icon:sparkles"
+                  :value="sheet.class"
+                  placeholder="Class pending"
+                  :is-builder-mode="isBuilderMode"
+                  @clear="emit('remove-section', 'origin')"
+                />
+
+                <sheet-cell
+                  label="Alignment"
+                  icon="kind-icon:compass"
+                  :value="sheet.alignment"
+                  placeholder="Morally loading"
+                  :is-builder-mode="isBuilderMode"
+                  @clear="emit('remove-section', 'origin')"
+                />
+
+                <!-- schema: gender -->
+                <sheet-cell
+                  label="Gender"
+                  icon="kind-icon:person"
+                  :value="sheet.gender"
+                  placeholder="Identity card waiting"
+                  :is-builder-mode="isBuilderMode"
+                  @clear="emit('remove-section', 'identity')"
+                />
+
+                <sheet-cell
+                  label="Presentation"
+                  icon="kind-icon:eye"
+                  :value="sheet.presentation"
+                  placeholder="Presentation pending"
+                  wide
+                  :is-builder-mode="isBuilderMode"
+                  @clear="emit('remove-section', 'identity')"
+                />
+              </div>
+            </section>
+
+            <!-- Narrative + Stats/Skills columns -->
+            <section
+              class="grid grid-cols-1 gap-3 xl:grid-cols-[minmax(0,1fr)_22rem]"
+            >
+              <!-- Narrative panels -->
+              <div class="flex min-w-0 flex-col gap-3">
+                <sheet-panel
+                  label="Personality"
+                  icon="kind-icon:heart"
+                  :value="sheet.personality"
+                  placeholder="No personality yet. Suspiciously smooth."
+                  :is-builder-mode="isBuilderMode"
+                  @clear="emit('remove-section', 'personality')"
+                />
+
+                <sheet-panel
+                  label="Drive"
+                  icon="kind-icon:target"
+                  :value="sheet.drive"
+                  placeholder="No drive yet. Currently powered by vibes."
+                  :is-builder-mode="isBuilderMode"
+                  @clear="emit('remove-section', 'personality')"
+                />
+
+                <sheet-panel
+                  label="Backstory"
+                  icon="kind-icon:story"
+                  :value="sheet.backstory"
+                  placeholder="No backstory yet. The void is politely waiting."
+                  :is-builder-mode="isBuilderMode"
+                  @clear="emit('remove-section', 'background')"
+                />
+
+                <sheet-panel
+                  label="Achievements"
+                  icon="kind-icon:award"
+                  :value="sheet.achievements"
+                  placeholder="No achievements yet."
+                  :is-builder-mode="isBuilderMode"
+                  @clear="emit('remove-section', 'background')"
+                />
+
+                <sheet-panel
+                  label="Quirks"
+                  icon="kind-icon:bug"
+                  :value="sheet.quirks"
+                  placeholder="No quirks yet. That cannot last."
+                  :is-builder-mode="isBuilderMode"
+                  @clear="emit('remove-section', 'background')"
+                />
+
+                <sheet-panel
+                  label="Art Prompt"
+                  icon="kind-icon:palette"
+                  :value="sheet.artPrompt"
+                  placeholder="Portrait prompt not built yet."
+                  :is-builder-mode="isBuilderMode"
+                  @clear="emit('remove-section', 'art')"
+                />
+              </div>
+
+              <!-- Stats + Skills sidebar -->
+              <aside class="flex flex-col gap-3">
+                <!-- Stat tiers -->
+                <article
+                  class="kr-panel-flat p-4"
+                >
+                  <div class="flex items-center justify-between gap-3">
+                    <h3
+                      class="flex items-center gap-2 font-black text-base-content"
+                    >
+                      <Icon
+                        name="kind-icon:activity"
+                        class="h-5 w-5 text-primary"
+                      />
+                      Stats
+                    </h3>
+
+                    <button
+                      v-if="isBuilderMode && hasStats"
+                      class="btn btn-xs rounded-lg"
+                      type="button"
+                      @click="emit('remove-section', 'stats')"
+                    >
+                      <Icon name="kind-icon:x" class="h-3 w-3" />
+                      Clear
+                    </button>
+                  </div>
+
+                  <div class="mt-3 grid grid-cols-2 gap-2">
+                    <div
+                      v-for="stat in characterStats"
+                      :key="stat.key"
+                      class="rounded-2xl border bg-base-200 p-3 transition"
+                      :class="
+                        stat.value !== 'COMMON'
+                          ? 'border-primary/30'
+                          : 'border-dashed border-base-300 opacity-60'
+                      "
+                    >
+                      <p class="truncate text-sm font-bold text-base-content">
+                        {{ stat.label }}
+                      </p>
+
+                      <p
+                        class="mt-1 text-sm font-black uppercase tracking-wide"
+                        :class="
+                          stat.value !== 'COMMON'
+                            ? 'text-primary'
+                            : 'text-base-content/30'
+                        "
+                      >
+                        {{ stat.value }}
+                      </p>
+                    </div>
+                  </div>
+                </article>
+
+                <!-- Starting Skills (3 skill slots) -->
+                <article
+                  class="kr-panel-flat p-4"
+                >
+                  <h3
+                    class="flex items-center gap-2 font-black text-base-content"
+                  >
+                    <Icon name="kind-icon:bolt" class="h-5 w-5 text-primary" />
+                    Starting Skills
+                  </h3>
+
+                  <div class="mt-3 flex flex-col gap-3">
+                    <article
+                      v-for="slot in rewardSlots"
+                      :key="slot.key"
+                      class="group rounded-2xl border bg-base-200 p-3 transition"
+                      :class="
+                        skillForSlot(slot.key)
+                          ? 'border-base-300'
+                          : 'border-dashed border-base-300 opacity-60'
+                      "
+                    >
+                      <div class="flex gap-3">
+                        <!-- Icon / image -->
+                        <div
+                          class="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-base-300"
+                        >
+                          <img
+                            v-if="skillImagePath(slot.key)"
+                            :src="skillImagePath(slot.key)"
+                            :alt="skillLabel(slot.key)"
+                            class="h-full w-full object-cover"
+                          />
+
+                          <Icon
+                            v-else
+                            :name="skillForSlot(slot.key)?.icon || slot.icon"
+                            class="h-7 w-7 text-primary"
+                          />
+                        </div>
+
+                        <!-- Label + power -->
+                        <div class="min-w-0 flex-1">
+                          <div class="flex items-start justify-between gap-2">
+                            <div class="min-w-0">
+                              <p
+                                class="text-xs font-bold uppercase tracking-[0.16em]"
+                                :class="rarityColor(slot.rarity)"
+                              >
+                                {{ slot.label }}
+                              </p>
+
+                              <p
+                                class="mt-1 font-black"
+                                :class="
+                                  skillForSlot(slot.key)
+                                    ? 'text-base-content'
+                                    : 'italic text-base-content/40'
+                                "
+                              >
+                                {{
+                                  skillForSlot(slot.key)?.label ||
+                                  'Empty skill slot'
+                                }}
+                              </p>
+                            </div>
+
+                            <button
+                              v-if="isBuilderMode && skillForSlot(slot.key)"
+                              class="btn btn-xs rounded-lg opacity-70 transition group-hover:opacity-100"
+                              type="button"
+                              @click="emit('remove-reward', slot.key)"
+                            >
+                              <Icon name="kind-icon:x" class="h-3 w-3" />
+                            </button>
+                          </div>
+
+                          <p
+                            class="mt-2 line-clamp-3 text-sm"
+                            :class="
+                              skillForSlot(slot.key)
+                                ? 'text-base-content/70'
+                                : 'italic text-base-content/40'
+                            "
+                          >
+                            {{
+                              skillForSlot(slot.key)?.power ||
+                              slot.description ||
+                              `${slot.rarity} skill.`
+                            }}
+                          </p>
+                        </div>
+                      </div>
+                    </article>
+                  </div>
+                </article>
+              </aside>
+            </section>
+          </main>
+        </div>
+      </section>
+    </Transition>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, defineComponent, h, ref, resolveComponent } from 'vue'
+import {
+  characterStatFields,
+  type CharacterRewardDraft,
+  type CharacterSheetDraft,
+  type RewardPromptSlot,
+} from '@/stores/helpers/characterHelper'
+
+// ---------------------------------------------------------------------------
+// Props / emits
+// ---------------------------------------------------------------------------
+
+const props = withDefaults(
+  defineProps<{
+    sheet: CharacterSheetDraft
+    rewardSlots: RewardPromptSlot[]
+    isBuilderMode?: boolean
+    canCreateArt?: boolean
+    allowArt?: boolean
+  }>(),
+  {
+    isBuilderMode: false,
+    canCreateArt: false,
+    allowArt: true,
+  },
+)
+
+const emit = defineEmits<{
+  'remove-section': [key: string]
+  'remove-reward': [slotKey: string]
+  'select-card': [key: string]
+}>()
+
+// ---------------------------------------------------------------------------
+// Local state
+// ---------------------------------------------------------------------------
+
+const showPortrait = ref(false)
+
+// ---------------------------------------------------------------------------
+// Computed
+// ---------------------------------------------------------------------------
+
+const hasPortrait = computed(() =>
+  Boolean(props.sheet.imagePath || props.sheet.artImageId),
+)
+
+// Reads the six rarity-tier fields from the sheet (luck, might, wits, etc.)
+// characterStatFields from characterHelper provides { key, label } pairs
+const characterStats = computed(() =>
+  characterStatFields.map((stat) => ({
+    key: stat.key,
+    label: stat.label,
+    value: props.sheet[stat.key] as string,
+  })),
+)
+
+// Stats are "set" when any tier has been raised above COMMON.
+// Allocating 1–6 always produces at least UNCOMMON through MYTHIC,
+// so this is a clean "has this card been played" check.
+const hasStats = computed(() =>
+  characterStats.value.some((stat) => stat.value !== 'COMMON'),
+)
+
+const hasIdentityContent = computed(() =>
+  Boolean(
+    props.sheet.name ||
+    props.sheet.honorific !== 'adventurer' ||
+    props.sheet.role ||
+    props.sheet.species ||
+    props.sheet.class || // schema: class
+    props.sheet.alignment ||
+    props.sheet.gender || // schema: gender
+    props.sheet.presentation,
+  ),
+)
+
+const identityLine = computed(() =>
+  [
+    props.sheet.honorific || 'adventurer',
+    props.sheet.species || 'unknown species',
+    props.sheet.class || 'unclassed', // schema: class
+    props.sheet.role || 'plot-adjacent citizen',
+  ].join(' · '),
+)
+
+const badges = computed(
+  () =>
+    [
+      props.sheet.genre,
+      props.sheet.gender, // schema: gender
+      props.sheet.presentation,
+      props.sheet.alignment,
+    ].filter(Boolean) as string[],
+)
+
+const sheetSubtitle = computed(() => {
+  if (!props.isBuilderMode) return identityLine.value
+  if (props.canCreateArt) {
+    return 'The sheet is complete enough for portrait creation. Save it, paint it, or keep tinkering.'
+  }
+  return 'Choose prompt cards to fill the sheet. Completed sections can be cleared to restore their cards.'
+})
+
+const completionItems = computed(() => [
+  {
+    key: 'role',
+    cardKey: 'role',
+    label: 'Role',
+    done: Boolean(props.sheet.role?.trim()),
+  },
+  {
+    key: 'name',
+    cardKey: 'name',
+    label: 'Name',
+    done: Boolean(props.sheet.name?.trim()),
+  },
+  {
+    key: 'origin',
+    cardKey: 'origin',
+    label: 'Origin',
+    done: Boolean(props.sheet.species?.trim() && props.sheet.class?.trim()), // schema: class
+  },
+  {
+    key: 'identity',
+    cardKey: 'identity',
+    label: 'Identity',
+    done: Boolean(
+      props.sheet.gender?.trim() || props.sheet.presentation?.trim(),
+    ), // schema: gender
+  },
+  {
+    key: 'personality',
+    cardKey: 'personality',
+    label: 'Personality',
+    done: Boolean(props.sheet.personality?.trim()),
+  },
+  {
+    key: 'stats',
+    cardKey: 'stats',
+    label: 'Stats',
+    done: hasStats.value,
+  },
+  {
+    key: 'background',
+    cardKey: 'background',
+    label: 'Backstory',
+    done: Boolean(props.sheet.backstory?.trim()),
+  },
+  {
+    key: 'rewards',
+    cardKey: 'starting-skill',
+    label: 'Starting Rewards',
+    done: props.rewardSlots.every((slot) => Boolean(skillForSlot(slot.key))),
+  },
+  {
+    key: 'portrait',
+    cardKey: 'art',
+    label: 'Portrait',
+    done: Boolean(
+      props.sheet.artPrompt?.trim() ||
+      props.sheet.imagePath ||
+      props.sheet.artImageId,
+    ),
+  },
+])
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function skillImagePath(slotKey: string): string | undefined {
+  return skillForSlot(slotKey)?.imagePath || undefined
+}
+
+function skillLabel(slotKey: string): string {
+  return skillForSlot(slotKey)?.label || 'Character reward'
+}
+
+function skillForSlot(slotKey: string): CharacterRewardDraft | null {
+  return props.sheet.rewards?.find((r) => r.slotKey === slotKey) ?? null
+}
+
+// Returns a text-color class based on rarity tier
+function rarityColor(rarity: string): string {
+  switch (rarity) {
+    case 'MYTHIC':
+      return 'text-warning'
+    case 'LEGENDARY':
+      return 'text-warning/80'
+    case 'EPIC':
+      return 'text-secondary'
+    case 'RARE':
+      return 'text-primary'
+    case 'UNCOMMON':
+      return 'text-success'
+    default:
+      return 'text-base-content/50'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Inline sub-components
+// ---------------------------------------------------------------------------
+
+/**
+ * SheetCell — compact labeled field for the identity grid.
+ * Optionally spans two columns via `wide`.
+ */
+const SheetCell = defineComponent({
+  name: 'SheetCell',
+  props: {
+    label: { type: String, required: true },
+    icon: { type: String, required: true },
+    value: { type: String, default: '' },
+    placeholder: { type: String, required: true },
+    wide: { type: Boolean, default: false },
+    isBuilderMode: { type: Boolean, default: false },
+  },
+  emits: ['clear'],
+  setup(p, { emit: ce }) {
+    const Icon = resolveComponent('Icon')
+
+    return () =>
+      h(
+        'article',
+        {
+          class: [
+            'group rounded-2xl border bg-base-200 p-3 transition',
+            p.value
+              ? 'border-base-300'
+              : 'border-dashed border-base-300 opacity-70',
+            p.wide ? 'md:col-span-2' : '',
+          ],
+        },
+        [
+          h('div', { class: 'flex items-start justify-between gap-2' }, [
+            h('div', { class: 'min-w-0' }, [
+              h(
+                'p',
+                {
+                  class:
+                    'flex items-center gap-2 text-xs font-bold uppercase tracking-[0.16em] text-base-content/50',
+                },
+                [
+                  h(Icon, { name: p.icon, class: 'h-4 w-4 text-primary' }),
+                  p.label,
+                ],
+              ),
+              h(
+                'p',
+                {
+                  class: [
+                    'mt-2 whitespace-pre-wrap text-sm',
+                    p.value
+                      ? 'font-semibold text-base-content'
+                      : 'italic text-base-content/40',
+                  ],
+                },
+                p.value || p.placeholder,
+              ),
+            ]),
+            p.value && p.isBuilderMode
+              ? h(
+                  'button',
+                  {
+                    class:
+                      'btn btn-xs rounded-lg opacity-70 transition group-hover:opacity-100',
+                    type: 'button',
+                    onClick: () => ce('clear'),
+                  },
+                  [h(Icon, { name: 'kind-icon:x', class: 'h-3 w-3' })],
+                )
+              : null,
+          ]),
+        ],
+      )
+  },
+})
+
+/**
+ * SheetPanel — full-width narrative field with heading and prose body.
+ */
+const SheetPanel = defineComponent({
+  name: 'SheetPanel',
+  props: {
+    label: { type: String, required: true },
+    icon: { type: String, required: true },
+    value: { type: String, default: '' },
+    placeholder: { type: String, required: true },
+    isBuilderMode: { type: Boolean, default: false },
+  },
+  emits: ['clear'],
+  setup(p, { emit: ce }) {
+    const Icon = resolveComponent('Icon')
+
+    return () =>
+      h(
+        'article',
+        {
+          class: [
+            'group rounded-2xl border bg-base-100 p-4 transition',
+            p.value
+              ? 'border-base-300'
+              : 'border-dashed border-base-300 opacity-70',
+          ],
+        },
+        [
+          h('div', { class: 'flex items-start justify-between gap-3' }, [
+            h(
+              'h3',
+              { class: 'flex items-center gap-2 font-black text-base-content' },
+              [
+                h(Icon, { name: p.icon, class: 'h-5 w-5 text-primary' }),
+                p.label,
+              ],
+            ),
+            p.value && p.isBuilderMode
+              ? h(
+                  'button',
+                  {
+                    class:
+                      'btn btn-xs rounded-lg opacity-70 transition group-hover:opacity-100',
+                    type: 'button',
+                    onClick: () => ce('clear'),
+                  },
+                  [h(Icon, { name: 'kind-icon:x', class: 'h-3 w-3' }), 'Clear'],
+                )
+              : null,
+          ]),
+          h(
+            'p',
+            {
+              class: [
+                'mt-3 whitespace-pre-wrap text-sm leading-relaxed',
+                p.value
+                  ? 'text-base-content/75'
+                  : 'italic text-base-content/40',
+              ],
+            },
+            p.value || p.placeholder,
+          ),
+        ],
+      )
+  },
+})
+</script>
+
+<style scoped>
+.sheet-fade-enter-active,
+.sheet-fade-leave-active {
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease;
+}
+
+.sheet-fade-enter-from,
+.sheet-fade-leave-to {
+  opacity: 0;
+  transform: translateY(0.5rem) scale(0.99);
+}
+</style>

--- a/components/abandonware/conductor/plan-projects-grid.vue
+++ b/components/abandonware/conductor/plan-projects-grid.vue
@@ -1,0 +1,108 @@
+<!-- /components/conductor/plan-projects-grid.vue -->
+<!--
+  In-page directory of the Plan → Projects sub-items (the third nav level).
+  Sourced directly from the content pages under /plan/projects/, so adding or
+  removing a pitch page is the single source of truth — no separate registry.
+  Nested inside components/pages/conductor-manager.vue (the sole MDC mount for
+  content/conductor.md — see interface-vision/t-017's one-mdc sweep).
+-->
+<template>
+  <section v-if="projects.length" class="mt-6 flex w-full flex-col gap-3">
+    <header class="flex flex-col">
+      <h2 class="text-lg font-black">Projects in progress</h2>
+      <p class="text-sm text-base-content/60">
+        Experiments and pitches still finding their shape.
+      </p>
+    </header>
+
+    <ul class="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+      <li v-for="project in projects" :key="project.path">
+        <NuxtLink
+          :to="project.path"
+          class="flex h-full items-center gap-3 rounded-xl border border-base-300 bg-base-100 p-2 transition-all hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-md"
+        >
+          <span
+            class="relative flex h-11 w-11 shrink-0 overflow-hidden rounded-lg bg-base-200"
+          >
+            <img
+              v-if="project.image"
+              :src="project.image"
+              :alt="project.title"
+              loading="lazy"
+              class="h-full w-full object-cover"
+            />
+            <!--
+              Fallback only. This used to render unconditionally as an
+              `absolute inset-0` overlay, so a project WITH artwork got its
+              image permanently covered by a bg-base-content/15 wash and an
+              icon — the art was loaded, paid for, and then hidden.
+            -->
+            <span
+              v-else
+              class="flex h-full w-full items-center justify-center bg-base-content/15"
+            >
+              <Icon
+                :name="project.icon || 'kind-icon:sparkles'"
+                class="h-5 w-5 text-base-100 drop-shadow"
+              />
+            </span>
+          </span>
+
+          <span class="flex min-w-0 flex-1 flex-col items-start leading-tight">
+            <span class="max-w-full truncate text-sm font-black">
+              {{ project.title }}
+            </span>
+            <span
+              v-if="project.description"
+              class="line-clamp-2 text-xs font-medium text-base-content/60"
+            >
+              {{ project.description }}
+            </span>
+          </span>
+        </NuxtLink>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+type ProjectCard = {
+  path: string
+  title: string
+  description: string
+  icon: string
+  image: string
+}
+
+function resolveImage(value: unknown): string {
+  const raw = typeof value === 'string' ? value.trim() : ''
+  if (!raw) return ''
+  return raw.startsWith('/') || raw.startsWith('http') ? raw : `/images/${raw}`
+}
+
+const { data } = await useAsyncData('plan-projects-grid', () =>
+  queryCollection('content')
+    .where('path', 'LIKE', '/plan/projects/%')
+    .all(),
+)
+
+const projects = computed<ProjectCard[]>(() => {
+  const pages = (data.value ?? []) as unknown as Array<Record<string, unknown>>
+
+  return pages
+    .map((page) => ({
+      path: typeof page.path === 'string' ? page.path : '',
+      title:
+        (typeof page.title === 'string' && page.title) ||
+        (typeof page.path === 'string' ? page.path : ''),
+      description:
+        typeof page.description === 'string' ? page.description : '',
+      icon: typeof page.icon === 'string' ? page.icon : '',
+      image: resolveImage(page.image),
+    }))
+    .filter((project) => project.path)
+    .sort((a, b) => a.title.localeCompare(b.title))
+})
+</script>

--- a/components/abandonware/conductor/project-pitch-board.vue
+++ b/components/abandonware/conductor/project-pitch-board.vue
@@ -1,0 +1,215 @@
+<!-- /components/conductor/project-pitch-board.vue -->
+<!--
+  A lightweight, self-contained drafting board for project proposals / prompts.
+  Entries persist to localStorage keyed by project slug + noun, so a visitor can
+  brainstorm pitches and prompt ideas, edit them, and reorder their thinking
+  without any backend. Used by the coloring-book flagship for "proposed pitches"
+  and "add/edit proposals and prompts".
+-->
+<template>
+  <section class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm">
+    <div class="mb-3 flex items-center gap-2">
+      <Icon :name="icon" class="size-5 text-primary" />
+      <h3
+        class="text-sm font-black uppercase tracking-wide text-base-content/70"
+      >
+        {{ title }}
+      </h3>
+      <span class="badge badge-ghost badge-sm ml-auto rounded-lg">{{
+        items.length
+      }}</span>
+    </div>
+
+    <!-- New entry -->
+    <form class="mb-4 space-y-2" @submit.prevent="add">
+      <input
+        v-model="draftTitle"
+        type="text"
+        :placeholder="`${nounCapitalized} title`"
+        class="input input-bordered input-sm w-full rounded-xl"
+      />
+      <textarea
+        v-model="draftBody"
+        :placeholder="bodyPlaceholder"
+        class="textarea textarea-bordered w-full rounded-xl text-sm leading-relaxed"
+        rows="2"
+      />
+      <div class="flex justify-end">
+        <button
+          type="submit"
+          class="btn btn-primary btn-sm gap-1 rounded-xl"
+          :disabled="!draftTitle.trim() && !draftBody.trim()"
+        >
+          <Icon name="kind-icon:plus" class="size-4" />
+          Add {{ noun }}
+        </button>
+      </div>
+    </form>
+
+    <!-- List -->
+    <div v-if="items.length" class="space-y-2">
+      <article
+        v-for="item in items"
+        :key="item.id"
+        class="rounded-2xl border border-base-300 bg-base-200/60 p-3"
+      >
+        <div v-if="editingId === item.id" class="space-y-2">
+          <input
+            v-model="editTitle"
+            type="text"
+            class="input input-bordered input-sm w-full rounded-xl"
+          />
+          <textarea
+            v-model="editBody"
+            class="textarea textarea-bordered w-full rounded-xl text-sm"
+            rows="3"
+          />
+          <div class="flex justify-end gap-2">
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs rounded-lg"
+              @click="editingId = null"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              class="btn btn-primary btn-xs rounded-lg"
+              @click="saveEdit(item.id)"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+        <div v-else class="flex items-start gap-2">
+          <div class="min-w-0 flex-1">
+            <p v-if="item.title" class="text-sm font-bold text-base-content">
+              {{ item.title }}
+            </p>
+            <p
+              v-if="item.body"
+              class="whitespace-pre-wrap text-sm text-base-content/70"
+            >
+              {{ item.body }}
+            </p>
+          </div>
+          <div class="flex shrink-0 gap-1">
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs rounded-lg"
+              title="Edit"
+              @click="startEdit(item)"
+            >
+              <Icon name="kind-icon:edit" class="size-3.5" />
+            </button>
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs rounded-lg text-base-content/40 hover:text-error"
+              title="Remove"
+              @click="remove(item.id)"
+            >
+              <Icon name="kind-icon:x" class="size-3.5" />
+            </button>
+          </div>
+        </div>
+      </article>
+    </div>
+    <p v-else class="text-sm text-base-content/40">
+      {{ emptyText }}
+    </p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+
+type BoardItem = { id: string; title: string; body: string }
+
+const props = withDefaults(
+  defineProps<{
+    slug: string
+    /** Singular noun for entries, e.g. "proposal" or "prompt". */
+    noun?: string
+    title?: string
+    icon?: string
+    bodyPlaceholder?: string
+    emptyText?: string
+  }>(),
+  {
+    noun: 'proposal',
+    title: 'Proposals',
+    icon: 'kind-icon:sparkles',
+    bodyPlaceholder: 'Describe the idea...',
+    emptyText: 'No entries yet — add the first one.',
+  },
+)
+
+const storageKey = computed(() => `project-board:${props.slug}:${props.noun}`)
+const nounCapitalized = computed(
+  () => props.noun.charAt(0).toUpperCase() + props.noun.slice(1),
+)
+
+const items = ref<BoardItem[]>([])
+const draftTitle = ref('')
+const draftBody = ref('')
+const editingId = ref<string | null>(null)
+const editTitle = ref('')
+const editBody = ref('')
+
+// Stable, no-Date/Random id (those are unavailable in some contexts; a counter
+// plus content hash is deterministic enough for a local draft list).
+let counter = 0
+function nextId(): string {
+  counter += 1
+  return `${props.slug}-${props.noun}-${counter}-${items.value.length}`
+}
+
+function load() {
+  if (typeof window === 'undefined') return
+  try {
+    const raw = window.localStorage.getItem(storageKey.value)
+    items.value = raw ? (JSON.parse(raw) as BoardItem[]) : []
+  } catch {
+    items.value = []
+  }
+}
+function persist() {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(storageKey.value, JSON.stringify(items.value))
+  } catch {
+    /* private mode / quota — drafts stay in-memory */
+  }
+}
+
+watch(items, persist, { deep: true })
+watch(storageKey, load)
+onMounted(load)
+
+function add() {
+  if (!draftTitle.value.trim() && !draftBody.value.trim()) return
+  items.value.unshift({
+    id: nextId(),
+    title: draftTitle.value.trim(),
+    body: draftBody.value.trim(),
+  })
+  draftTitle.value = ''
+  draftBody.value = ''
+}
+function startEdit(item: BoardItem) {
+  editingId.value = item.id
+  editTitle.value = item.title
+  editBody.value = item.body
+}
+function saveEdit(id: string) {
+  const item = items.value.find((i) => i.id === id)
+  if (item) {
+    item.title = editTitle.value.trim()
+    item.body = editBody.value.trim()
+  }
+  editingId.value = null
+}
+function remove(id: string) {
+  items.value = items.value.filter((i) => i.id !== id)
+}
+</script>

--- a/components/abandonware/giftshop/cart-interact.vue
+++ b/components/abandonware/giftshop/cart-interact.vue
@@ -1,0 +1,4 @@
+<!-- /components/giftshop/cart-interact.vue -->
+<template>
+  <shopping-cart />
+</template>

--- a/components/abandonware/giftshop/print-swag.vue
+++ b/components/abandonware/giftshop/print-swag.vue
@@ -1,0 +1,155 @@
+<!-- /components/giftshop/print-swag.vue -->
+<template>
+  <div class="space-y-4">
+    <h3 class="text-lg font-bold">🖼️ Print Your Art</h3>
+
+    <div class="flex justify-center">
+      <img
+        :src="imageUrl"
+        alt="Selected Art"
+        class="rounded-xl border border-base-300 max-h-48 object-contain"
+      />
+    </div>
+
+    <div class="form-control">
+      <label class="label font-semibold">🪄 Choose Product</label>
+      <div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        <button
+          v-for="type in printTypes"
+          :key="type.id"
+          @click="selectedType = type.id"
+          :class="[
+            'btn btn-sm justify-start flex items-center gap-2',
+            selectedType === type.id ? 'btn-accent' : 'btn-outline',
+          ]"
+        >
+          <Icon :name="type.icon" class="text-lg" />
+          {{ type.label }}
+        </button>
+      </div>
+    </div>
+
+    <div class="form-control">
+      <label class="label font-semibold">🛒 Quantity</label>
+      <input
+        v-model.number="quantity"
+        type="number"
+        min="1"
+        max="25"
+        class="input input-bordered w-24"
+      />
+    </div>
+
+    <p v-if="eligibility && !eligibility.eligible" class="text-sm text-error">
+      🚫 Not eligible for print: {{ eligibility.reason }}
+    </p>
+    <p v-if="checkoutError" class="text-sm text-error">{{ checkoutError }}</p>
+
+    <button
+      class="btn btn-primary w-full"
+      :disabled="
+        checkingOut ||
+        !props.artImageId ||
+        (eligibility ? !eligibility.eligible : false)
+      "
+      @click="addToCart"
+    >
+      {{ checkingOut ? 'Redirecting to checkout…' : '➕ Add to Cart' }}
+    </button>
+
+    <button class="btn btn-ghost text-sm underline" @click="emit('close')">
+      Cancel and Close
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+
+const props = defineProps<{ artImageId?: number }>()
+const emit = defineEmits(['close'])
+
+const selectedType = ref('print')
+const quantity = ref(1)
+const checkingOut = ref(false)
+const checkoutError = ref('')
+
+type PrintEligibility = { eligible: boolean; reason: string }
+const eligibility = ref<PrintEligibility | null>(null)
+
+type PodCheckoutResponse = {
+  success: boolean
+  data: { url: string } | null
+  message: string
+}
+
+const printTypes = [
+  { id: 'print', label: 'Art Print', icon: 'kind-icon:print' },
+  { id: 'shirt', label: 'T-Shirt', icon: 'kind-icon:shirt' },
+  { id: 'sticker', label: 'Sticker', icon: 'kind-icon:sticker' },
+  { id: 'mug', label: 'Mug', icon: 'kind-icon:mug' },
+]
+
+const fallbackImage = '/images/art-placeholder.jpg'
+const imageUrl = computed(() =>
+  props.artImageId ? `/api/media/art/${props.artImageId}` : fallbackImage,
+)
+
+watch(
+  () => props.artImageId,
+  async (artImageId) => {
+    eligibility.value = null
+    if (!artImageId) return
+
+    try {
+      const response = await $fetch<
+        { success: boolean; data: PrintEligibility },
+        string
+      >(`/api/art/image/${artImageId}/print-eligibility`)
+      eligibility.value = response.success ? response.data : null
+    } catch {
+      eligibility.value = null
+    }
+  },
+  { immediate: true },
+)
+
+const addToCart = async () => {
+  if (!props.artImageId) {
+    checkoutError.value = 'Select a piece of art from your gallery first.'
+    return
+  }
+
+  checkingOut.value = true
+  checkoutError.value = ''
+
+  try {
+    const response = await $fetch<PodCheckoutResponse, string>(
+      '/api/store/pod-checkout',
+      {
+        method: 'POST',
+        body: {
+          printType: selectedType.value,
+          artImageId: props.artImageId,
+          quantity: quantity.value,
+        },
+      },
+    )
+
+    if (!response.success || !response.data?.url) {
+      checkoutError.value =
+        response.message || 'Checkout failed. Please try again.'
+      return
+    }
+
+    window.location.href = response.data.url
+  } catch (error) {
+    checkoutError.value =
+      error instanceof Error
+        ? error.message
+        : 'Checkout failed. Please try again.'
+  } finally {
+    checkingOut.value = false
+  }
+}
+</script>

--- a/components/abandonware/icons/flip-panel.vue
+++ b/components/abandonware/icons/flip-panel.vue
@@ -1,0 +1,29 @@
+<!-- /components/content/icons/flip-panel.vue -->
+<template>
+  <div
+    class="relative w-full h-full overflow-auto overscroll-y-contain [perspective:1000px]"
+  >
+    <div
+      class="relative w-full h-full transition-transform duration-500 ease-in-out [transform-style:preserve-3d]"
+      :class="{ '[transform:rotateY(180deg)]': flipped }"
+    >
+      <!-- Front Face -->
+      <div
+        class="absolute inset-0 flex flex-col [backface-visibility:hidden] [contain:layout_paint] z-20"
+      >
+        <slot name="front" />
+      </div>
+
+      <!-- Back Face -->
+      <div
+        class="absolute inset-0 flex flex-col [backface-visibility:hidden] [contain:layout_paint] [transform:rotateY(180deg)] z-10"
+      >
+        <slot name="back" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ flipped: boolean }>()
+</script>

--- a/components/abandonware/icons/login-icon.vue
+++ b/components/abandonware/icons/login-icon.vue
@@ -1,0 +1,73 @@
+<!-- /components/content/icons/login-icon.vue -->
+<template>
+  <NuxtLink
+    :to="routeToNavigate"
+    class="flex h-full w-full min-w-0 items-center justify-center overflow-hidden rounded-2xl transition-transform hover:scale-105"
+    :title="navLabel"
+    :aria-label="navLabel"
+  >
+    <div
+      v-if="isLoggedIn"
+      class="relative flex h-full w-full min-w-0 flex-col items-center justify-center overflow-hidden rounded-2xl border border-base-300 bg-base-200 py-0.5 px-0.5"
+    >
+      <!-- Unread message badge -->
+      <span
+        v-if="hasUnread"
+        class="absolute right-1 top-1 z-10 flex h-2.5 w-2.5 items-center justify-center rounded-full bg-error shadow"
+        aria-label="Unread messages"
+      />
+
+      <!-- Avatar -->
+      <div
+        class="flex min-h-0 flex-1 w-full items-center justify-center overflow-hidden"
+      >
+        <user-avatar
+          class="h-full max-h-full aspect-square shrink-0 rounded-full border border-primary/60 object-cover"
+        />
+      </div>
+    </div>
+
+    <!-- Guest state — plain icon, no label needed -->
+    <div
+      v-else
+      class="flex h-full w-full items-center justify-center overflow-hidden"
+    >
+      <Icon name="kind-icon:person" class="h-full w-full" />
+    </div>
+  </NuxtLink>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useUserStore } from '@/stores/userStore'
+import { useChatStore } from '@/stores/chatStore'
+
+const userStore = useUserStore()
+const chatStore = useChatStore()
+
+const isLoggedIn = computed(() => userStore.isLoggedIn)
+
+// Show the user's role in title-case as the label (USER → User, ADMIN → Admin, etc.)
+const roleLabel = computed(() => {
+  const raw = userStore.user?.Role ?? 'USER'
+  return raw.charAt(0).toUpperCase() + raw.slice(1).toLowerCase()
+})
+
+const hasUnread = computed(() =>
+  (chatStore.unreadMessages ?? []).some(
+    (msg) => msg.recipientId === userStore.user?.id,
+  ),
+)
+
+const navLabel = computed(() =>
+  isLoggedIn.value
+    ? `${roleLabel.value}${hasUnread.value ? ' (unread messages)' : ''}`
+    : 'Login?',
+)
+
+const routeToNavigate = computed(() =>
+  isLoggedIn.value ? '/dashboard' : '/login',
+)
+
+defineExpose({ navLabel })
+</script>

--- a/components/abandonware/lora/lora-card.vue
+++ b/components/abandonware/lora/lora-card.vue
@@ -1,0 +1,264 @@
+<!-- /components/lora/lora-card.vue -->
+<!--
+  A single LoRA in the My Library browser. Built on <reactable-card> like
+  <checkpoint-card>, but surfaces the LoRA-specific fields (preview image,
+  base model, trigger words, localPath health) and an Edit affordance instead
+  of a "select" action. Maturity gating mirrors checkpoint-card: when the row
+  is mature and the viewer hasn't opted in, the image and details are hidden.
+-->
+<template>
+  <reactable-card
+    :compact="compact"
+    :show-reaction="canReact"
+    :target-id="reactionTargetId"
+    target-type="resource"
+    reaction-category="RESOURCE"
+    :target-title="loraLabel"
+    :card-class="isHiddenMature ? 'opacity-75' : ''"
+    @select="emitEdit"
+  >
+    <template v-if="showEdit" #actions>
+      <button
+        class="rounded-full bg-base-100 p-2 text-primary shadow transition hover:bg-primary hover:text-primary-content"
+        type="button"
+        title="Edit LoRA"
+        @click.stop="emitEdit"
+      >
+        <Icon name="kind-icon:edit" class="h-4 w-4" />
+      </button>
+    </template>
+
+    <div
+      v-if="showImage"
+      :class="[
+        'relative w-full overflow-hidden rounded-2xl border border-base-300 bg-base-300',
+        imageHeightClass,
+      ]"
+    >
+      <img
+        v-if="imageSource && !isHiddenMature"
+        :src="imageSource"
+        :alt="loraLabel"
+        class="h-full w-full object-cover transition-transform group-hover:scale-105"
+        loading="lazy"
+        @error="imageFailed = true"
+      />
+
+      <div
+        v-else
+        class="flex h-full w-full items-center justify-center bg-base-200"
+      >
+        <div class="flex flex-col items-center gap-2 text-base-content/45">
+          <Icon
+            :name="isHiddenMature ? 'kind-icon:lock' : 'kind-icon:image'"
+            class="h-10 w-10"
+          />
+
+          <span class="text-xs font-bold">
+            {{ isHiddenMature ? 'Mature hidden' : 'No preview' }}
+          </span>
+        </div>
+      </div>
+
+      <div class="absolute left-2 top-2 flex flex-wrap gap-1">
+        <span v-if="baseModel" class="badge badge-secondary badge-sm">
+          {{ baseModel }}
+        </span>
+
+        <span
+          v-if="lora.isMature && showMatureBadge"
+          class="badge badge-warning badge-sm"
+        >
+          Mature
+        </span>
+      </div>
+
+      <div
+        v-if="!hasLocalPath"
+        class="absolute bottom-2 right-2 badge badge-error badge-sm shadow"
+        title="No localPath — this LoRA can't be sent to a render until it is re-scanned."
+      >
+        needs re-scan
+      </div>
+    </div>
+
+    <div class="flex min-w-0 flex-1 flex-col gap-2 text-center">
+      <h3
+        :class="[
+          'font-black leading-tight text-base-content line-clamp-2',
+          compact ? 'text-sm' : 'text-base',
+        ]"
+        :title="loraLabel"
+      >
+        {{ loraLabel }}
+      </h3>
+
+      <p
+        v-if="showDescription && loraDescription && !isHiddenMature"
+        class="line-clamp-2 text-xs text-base-content/60"
+      >
+        {{ loraDescription }}
+      </p>
+
+      <div
+        v-if="showTriggerWords && triggerList.length && !isHiddenMature"
+        class="flex flex-wrap justify-center gap-1"
+      >
+        <span
+          v-for="trigger in triggerList"
+          :key="trigger"
+          class="badge badge-outline badge-xs font-mono"
+        >
+          {{ trigger }}
+        </span>
+      </div>
+
+      <div v-if="showMeta" class="flex flex-wrap justify-center gap-2">
+        <span v-if="hasLocalPath" class="badge badge-ghost badge-sm">
+          {{ loraType }}
+        </span>
+
+        <span v-if="lora.civitaiUrl" class="badge badge-outline badge-sm">
+          Civitai
+        </span>
+
+        <span v-if="lora.hash" class="badge badge-outline badge-sm">
+          hashed
+        </span>
+      </div>
+
+      <button
+        v-if="showEdit"
+        class="btn btn-sm btn-outline mt-auto rounded-xl"
+        type="button"
+        @click.stop="emitEdit"
+      >
+        <Icon name="kind-icon:edit" class="h-4 w-4" />
+        Edit
+      </button>
+    </div>
+  </reactable-card>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { Resource } from '@/stores/resourceStore'
+
+const props = withDefaults(
+  defineProps<{
+    lora: Partial<Resource>
+    showMature?: boolean
+    compact?: boolean
+    showImage?: boolean
+    showDescription?: boolean
+    showTriggerWords?: boolean
+    showMeta?: boolean
+    showMatureBadge?: boolean
+    showReaction?: boolean
+    showEdit?: boolean
+    imageHeightClass?: string
+  }>(),
+  {
+    showMature: false,
+    compact: false,
+    showImage: true,
+    showDescription: true,
+    showTriggerWords: true,
+    showMeta: true,
+    showMatureBadge: true,
+    showReaction: false,
+    showEdit: true,
+    imageHeightClass: 'h-44',
+  },
+)
+
+const emit = defineEmits<{
+  edit: [lora: Partial<Resource>]
+}>()
+
+const imageFailed = ref(false)
+
+function safeText(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+
+  return ''
+}
+
+const isHiddenMature = computed(() => {
+  return Boolean(props.lora.isMature && !props.showMature)
+})
+
+const loraLabel = computed(() => {
+  if (isHiddenMature.value) return 'Hidden LoRA'
+
+  return (
+    safeText(props.lora.customLabel).trim() ||
+    safeText(props.lora.name).trim() ||
+    'Unnamed LoRA'
+  )
+})
+
+const loraDescription = computed(() => {
+  return safeText(props.lora.description).trim()
+})
+
+const baseModel = computed(() => {
+  return (
+    safeText(props.lora.generation).trim() ||
+    safeText(props.lora.supportedServer).trim()
+  )
+})
+
+const loraType = computed(() => {
+  const type = safeText(props.lora.resourceType).trim().toUpperCase()
+  return type === 'LYCORIS' ? 'LyCORIS' : 'LoRA'
+})
+
+const hasLocalPath = computed(() => {
+  return safeText(props.lora.localPath).trim().length > 0
+})
+
+const triggerList = computed(() => {
+  const source =
+    safeText(props.lora.defaultTrigger).trim() ||
+    safeText(props.lora.triggerWords).trim()
+
+  if (!source) return []
+
+  return source
+    .split(',')
+    .map((word) => word.trim())
+    .filter(Boolean)
+    .slice(0, 6)
+})
+
+const imageSource = computed(() => {
+  if (isHiddenMature.value || imageFailed.value) return ''
+
+  return (
+    safeText(props.lora.previewImageUrl).trim() ||
+    safeText(props.lora.imagePath).trim() ||
+    safeText(props.lora.MediaPath).trim() ||
+    ''
+  )
+})
+
+const reactionTargetId = computed(() => {
+  const id = Number(props.lora.id)
+
+  return Number.isInteger(id) && id > 0 ? id : 0
+})
+
+const canReact = computed(() => {
+  return Boolean(props.showReaction && reactionTargetId.value > 0)
+})
+
+function emitEdit() {
+  if (!props.showEdit) return
+
+  emit('edit', props.lora)
+}
+</script>

--- a/components/abandonware/lora/lora-gallery.vue
+++ b/components/abandonware/lora/lora-gallery.vue
@@ -1,0 +1,295 @@
+<!-- /components/lora/lora-gallery.vue -->
+<!--
+  My Library — the owned-LoRA browser. Reads resourceStore.visibleLoras
+  (account maturity already applied), then layers search, base-model +
+  maturity filters, sort, and client-side pagination on top (the library is
+  large, so we never render more than one page of cards at once). Add/edit
+  both route through <add-lora>.
+-->
+<template>
+  <section
+    class="flex h-full min-h-0 w-full flex-col gap-3 rounded-2xl bg-base-300 p-3"
+  >
+    <header
+      class="flex shrink-0 flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3"
+    >
+      <div class="flex items-start justify-between gap-3">
+        <div class="min-w-0">
+          <h2 class="truncate text-lg font-bold text-base-content">
+            My LoRAs
+          </h2>
+          <p class="text-sm text-base-content/60">
+            {{ summaryText }}
+          </p>
+        </div>
+
+        <button
+          class="btn btn-sm btn-primary rounded-xl"
+          type="button"
+          @click="openAdd"
+        >
+          <Icon name="kind-icon:plus" class="h-4 w-4" />
+          Add
+        </button>
+      </div>
+
+      <maturity-toggle
+        variant="resource"
+        label="Mature LoRAs"
+        visible-text="Mature LoRAs are included in your library."
+        hidden-text="Mature LoRAs are hidden from your library."
+      />
+
+      <div class="grid gap-2 md:grid-cols-[1fr_auto_auto_auto]">
+        <input
+          v-model="searchQuery"
+          class="input input-bordered rounded-xl"
+          placeholder="Search name, label, trigger, path"
+        />
+
+        <select
+          v-model="selectedBase"
+          class="select select-bordered rounded-xl"
+        >
+          <option value="all">All bases</option>
+          <option v-for="base in baseOptions" :key="base" :value="base">
+            {{ base }}
+          </option>
+        </select>
+
+        <select
+          v-model="maturityFilter"
+          class="select select-bordered rounded-xl"
+        >
+          <option value="all">All ratings</option>
+          <option value="sfw">SFW only</option>
+          <option value="mature">Mature only</option>
+        </select>
+
+        <select v-model="sortBy" class="select select-bordered rounded-xl">
+          <option value="name">Name A–Z</option>
+          <option value="newest">Newest</option>
+          <option value="base">Base model</option>
+        </select>
+      </div>
+    </header>
+
+    <add-lora
+      v-if="showForm"
+      :lora="editing"
+      @saved="handleSaved"
+      @close="closeForm"
+    />
+
+    <div
+      class="grid gap-3"
+      :class="
+        compact
+          ? 'grid-cols-2 sm:grid-cols-3'
+          : 'grid-cols-2 sm:grid-cols-3 xl:grid-cols-4'
+      "
+    >
+      <lora-card
+        v-for="lora in pageItems"
+        :key="lora.id || lora.name"
+        :lora="lora"
+        :show-mature="showMature"
+        :compact="compact"
+        @edit="openEdit"
+      />
+    </div>
+
+    <div
+      v-if="!filteredLoras.length"
+      class="rounded-2xl border border-dashed border-base-300 bg-base-200 p-6 text-center"
+    >
+      <p class="font-bold">No LoRAs found.</p>
+      <p class="text-sm text-base-content/60">
+        {{
+          resourceStore.isLoading
+            ? 'Loading your library…'
+            : 'Try another filter, or drop a LoRA into Lora/import to auto-add it.'
+        }}
+      </p>
+    </div>
+
+    <footer
+      v-if="pageCount > 1"
+      class="flex shrink-0 items-center justify-center gap-2 pt-1"
+    >
+      <button
+        class="btn btn-sm rounded-xl"
+        type="button"
+        :disabled="page <= 1"
+        @click="page--"
+      >
+        <Icon name="kind-icon:chevron-left" class="h-4 w-4" />
+        Prev
+      </button>
+
+      <span class="text-sm text-base-content/70">
+        Page {{ page }} / {{ pageCount }}
+      </span>
+
+      <button
+        class="btn btn-sm rounded-xl"
+        type="button"
+        :disabled="page >= pageCount"
+        @click="page++"
+      >
+        Next
+        <Icon name="kind-icon:chevron-right" class="h-4 w-4" />
+      </button>
+    </footer>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useResourceStore, type Resource } from '@/stores/resourceStore'
+import { useUserStore } from '@/stores/userStore'
+
+const props = withDefaults(
+  defineProps<{
+    compact?: boolean
+    pageSize?: number
+  }>(),
+  {
+    compact: false,
+    pageSize: 24,
+  },
+)
+
+const resourceStore = useResourceStore()
+const userStore = useUserStore()
+
+const searchQuery = ref('')
+const selectedBase = ref<string>('all')
+const maturityFilter = ref<'all' | 'sfw' | 'mature'>('all')
+const sortBy = ref<'name' | 'newest' | 'base'>('name')
+const page = ref(1)
+
+const showForm = ref(false)
+const editing = ref<Partial<Resource> | null>(null)
+
+const showMature = computed(() => userStore.showMature)
+
+function safeText(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+
+  return ''
+}
+
+function baseOf(lora: Partial<Resource>): string {
+  return (
+    safeText(lora.generation).trim() ||
+    safeText(lora.supportedServer).trim()
+  ).toUpperCase()
+}
+
+const baseOptions = computed(() => {
+  const seen = new Set<string>()
+
+  for (const lora of resourceStore.visibleLoras) {
+    const base = baseOf(lora)
+    if (base) seen.add(base)
+  }
+
+  return Array.from(seen).sort()
+})
+
+const filteredLoras = computed<Partial<Resource>[]>(() => {
+  const query = searchQuery.value.trim().toLowerCase()
+
+  const rows = resourceStore.visibleLoras.filter((lora) => {
+    if (selectedBase.value !== 'all' && baseOf(lora) !== selectedBase.value) {
+      return false
+    }
+
+    if (maturityFilter.value === 'sfw' && lora.isMature) return false
+    if (maturityFilter.value === 'mature' && !lora.isMature) return false
+
+    if (!query) return true
+
+    return [
+      lora.name,
+      lora.customLabel,
+      lora.description,
+      lora.localPath,
+      lora.triggerWords,
+      lora.defaultTrigger,
+      lora.generation,
+      lora.supportedServer,
+    ]
+      .filter(Boolean)
+      .some((value) => String(value).toLowerCase().includes(query))
+  })
+
+  const sorted = [...rows]
+
+  if (sortBy.value === 'name') {
+    sorted.sort((a, b) =>
+      safeText(a.customLabel || a.name).localeCompare(
+        safeText(b.customLabel || b.name),
+      ),
+    )
+  } else if (sortBy.value === 'newest') {
+    sorted.sort((a, b) => Number(b.id ?? 0) - Number(a.id ?? 0))
+  } else if (sortBy.value === 'base') {
+    sorted.sort((a, b) => baseOf(a).localeCompare(baseOf(b)))
+  }
+
+  return sorted
+})
+
+const pageCount = computed(() =>
+  Math.max(1, Math.ceil(filteredLoras.value.length / props.pageSize)),
+)
+
+const pageItems = computed(() => {
+  const start = (page.value - 1) * props.pageSize
+  return filteredLoras.value.slice(start, start + props.pageSize)
+})
+
+const summaryText = computed(() => {
+  const total = resourceStore.visibleLoras.length
+  const shown = filteredLoras.value.length
+
+  if (shown === total) return `${total} LoRA${total === 1 ? '' : 's'}`
+  return `${shown} of ${total} LoRAs`
+})
+
+watch([searchQuery, selectedBase, maturityFilter, sortBy], () => {
+  page.value = 1
+})
+
+watch(pageCount, (count) => {
+  if (page.value > count) page.value = count
+})
+
+function openAdd(): void {
+  editing.value = null
+  showForm.value = true
+}
+
+function openEdit(lora: Partial<Resource>): void {
+  editing.value = lora
+  showForm.value = true
+}
+
+function closeForm(): void {
+  showForm.value = false
+  editing.value = null
+}
+
+function handleSaved(): void {
+  closeForm()
+}
+
+onMounted(() => {
+  resourceStore.loadStore()
+})
+</script>

--- a/components/abandonware/model/model-card.vue
+++ b/components/abandonware/model/model-card.vue
@@ -1,0 +1,244 @@
+<!-- /components/model/model-card.vue -->
+<!--
+  A single checkpoint (base model) in the model browser. Mirrors <lora-card>
+  (reactable-card + preview image + base-model badge + localPath health + Edit),
+  but for CHECKPOINT resources: no trigger words, and it shows the base model /
+  folder rather than a LoRA type. Maturity gating matches lora-card — a mature
+  row is hidden (image + details) when the viewer hasn't opted in.
+-->
+<template>
+  <reactable-card
+    :compact="compact"
+    :show-reaction="canReact"
+    :target-id="reactionTargetId"
+    target-type="resource"
+    reaction-category="RESOURCE"
+    :target-title="modelLabel"
+    :card-class="isHiddenMature ? 'opacity-75' : ''"
+    @select="emitEdit"
+  >
+    <template v-if="showEdit" #actions>
+      <button
+        class="rounded-full bg-base-100 p-2 text-primary shadow transition hover:bg-primary hover:text-primary-content"
+        type="button"
+        title="Edit model"
+        @click.stop="emitEdit"
+      >
+        <Icon name="kind-icon:edit" class="h-4 w-4" />
+      </button>
+    </template>
+
+    <div
+      v-if="showImage"
+      :class="[
+        'relative w-full overflow-hidden rounded-2xl border border-base-300 bg-base-300',
+        imageHeightClass,
+      ]"
+    >
+      <img
+        v-if="imageSource && !isHiddenMature"
+        :src="imageSource"
+        :alt="modelLabel"
+        class="h-full w-full object-cover transition-transform group-hover:scale-105"
+        loading="lazy"
+        @error="imageFailed = true"
+      />
+
+      <div
+        v-else
+        class="flex h-full w-full items-center justify-center bg-base-200"
+      >
+        <div class="flex flex-col items-center gap-2 text-base-content/45">
+          <Icon
+            :name="isHiddenMature ? 'kind-icon:lock' : 'kind-icon:checkpoint'"
+            class="h-10 w-10"
+          />
+
+          <span class="text-xs font-bold">
+            {{ isHiddenMature ? 'Mature hidden' : 'No preview' }}
+          </span>
+        </div>
+      </div>
+
+      <div class="absolute left-2 top-2 flex flex-wrap gap-1">
+        <span v-if="baseModel" class="badge badge-secondary badge-sm">
+          {{ baseModel }}
+        </span>
+
+        <span
+          v-if="model.isMature && showMatureBadge"
+          class="badge badge-warning badge-sm"
+        >
+          Mature
+        </span>
+      </div>
+
+      <div
+        v-if="!hasLocalPath"
+        class="absolute bottom-2 right-2 badge badge-error badge-sm shadow"
+        title="No localPath — this checkpoint can't be sent to a render until it is re-scanned."
+      >
+        needs re-scan
+      </div>
+    </div>
+
+    <div class="flex min-w-0 flex-1 flex-col gap-2 text-center">
+      <h3
+        :class="[
+          'font-black leading-tight text-base-content line-clamp-2',
+          compact ? 'text-sm' : 'text-base',
+        ]"
+        :title="modelLabel"
+      >
+        {{ modelLabel }}
+      </h3>
+
+      <p
+        v-if="showDescription && modelDescription && !isHiddenMature"
+        class="line-clamp-2 text-xs text-base-content/60"
+      >
+        {{ modelDescription }}
+      </p>
+
+      <p
+        v-if="hasLocalPath && !isHiddenMature"
+        class="line-clamp-1 font-mono text-[11px] text-base-content/45"
+        :title="localPathText"
+      >
+        {{ localPathText }}
+      </p>
+
+      <div v-if="showMeta" class="flex flex-wrap justify-center gap-2">
+        <span v-if="model.civitaiUrl" class="badge badge-outline badge-sm">
+          Civitai
+        </span>
+
+        <span v-if="model.hash" class="badge badge-outline badge-sm">
+          hashed
+        </span>
+      </div>
+
+      <button
+        v-if="showEdit"
+        class="btn btn-sm btn-outline mt-auto rounded-xl"
+        type="button"
+        @click.stop="emitEdit"
+      >
+        <Icon name="kind-icon:edit" class="h-4 w-4" />
+        Edit
+      </button>
+    </div>
+  </reactable-card>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { Resource } from '@/stores/resourceStore'
+
+const props = withDefaults(
+  defineProps<{
+    model: Partial<Resource>
+    showMature?: boolean
+    compact?: boolean
+    showImage?: boolean
+    showDescription?: boolean
+    showMeta?: boolean
+    showMatureBadge?: boolean
+    showReaction?: boolean
+    showEdit?: boolean
+    imageHeightClass?: string
+  }>(),
+  {
+    showMature: false,
+    compact: false,
+    showImage: true,
+    showDescription: true,
+    showMeta: true,
+    showMatureBadge: true,
+    showReaction: false,
+    showEdit: true,
+    imageHeightClass: 'h-44',
+  },
+)
+
+const emit = defineEmits<{
+  edit: [model: Partial<Resource>]
+}>()
+
+const imageFailed = ref(false)
+
+function safeText(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+
+  return ''
+}
+
+const isHiddenMature = computed(() => {
+  return Boolean(props.model.isMature && !props.showMature)
+})
+
+const modelLabel = computed(() => {
+  if (isHiddenMature.value) return 'Hidden model'
+
+  return (
+    safeText(props.model.customLabel).trim() ||
+    safeText(props.model.name).trim() ||
+    'Unnamed model'
+  )
+})
+
+const modelDescription = computed(() => {
+  return safeText(props.model.description).trim()
+})
+
+const localPathText = computed(() => {
+  return safeText(props.model.localPath).trim()
+})
+
+// Base model: prefer the checkpoint's folder (the reliable post-repair signal),
+// then the tagged generation / supportedServer.
+const baseModel = computed(() => {
+  const path = localPathText.value.replaceAll('\\', '/').replace(/^\/+/, '')
+  const folder = path.includes('/') ? path.split('/')[0] : ''
+
+  return (
+    folder ||
+    safeText(props.model.generation).trim() ||
+    safeText(props.model.supportedServer).trim()
+  ).toUpperCase()
+})
+
+const hasLocalPath = computed(() => {
+  return localPathText.value.length > 0
+})
+
+const imageSource = computed(() => {
+  if (isHiddenMature.value || imageFailed.value) return ''
+
+  return (
+    safeText(props.model.previewImageUrl).trim() ||
+    safeText(props.model.imagePath).trim() ||
+    safeText(props.model.MediaPath).trim() ||
+    ''
+  )
+})
+
+const reactionTargetId = computed(() => {
+  const id = Number(props.model.id)
+
+  return Number.isInteger(id) && id > 0 ? id : 0
+})
+
+const canReact = computed(() => {
+  return Boolean(props.showReaction && reactionTargetId.value > 0)
+})
+
+function emitEdit() {
+  if (!props.showEdit) return
+
+  emit('edit', props.model)
+}
+</script>

--- a/components/abandonware/model/model-gallery.vue
+++ b/components/abandonware/model/model-gallery.vue
@@ -1,0 +1,295 @@
+<!-- /components/model/model-gallery.vue -->
+<!--
+  Model (checkpoint) browser. Reads resourceStore.visibleCheckpoints (account
+  maturity already applied), then layers search + base-model + maturity filters
+  and sort on top. Cards are grouped by base model; the non-image checkpoints
+  (3D / Audio / Video) render in their own section below a divider. Mirrors
+  <lora-gallery>, but there are only a few dozen checkpoints so it renders them
+  all (no pagination).
+-->
+<template>
+  <section
+    class="flex h-full min-h-0 w-full flex-col gap-3 overflow-y-auto rounded-2xl bg-base-300 p-3"
+  >
+    <header
+      class="sticky top-0 z-10 flex shrink-0 flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3"
+    >
+      <div class="flex items-start justify-between gap-3">
+        <div class="min-w-0">
+          <h2 class="truncate text-lg font-bold text-base-content">
+            Models
+          </h2>
+          <p class="text-sm text-base-content/60">
+            {{ summaryText }}
+          </p>
+        </div>
+
+        <button
+          class="btn btn-sm btn-primary rounded-xl"
+          type="button"
+          @click="openAdd"
+        >
+          <Icon name="kind-icon:plus" class="h-4 w-4" />
+          Add
+        </button>
+      </div>
+
+      <maturity-toggle
+        variant="resource"
+        label="Mature checkpoint models"
+        visible-text="Mature checkpoint models are included in this gallery."
+        hidden-text="Mature checkpoint models are hidden from this gallery."
+      />
+
+      <div class="grid gap-2 md:grid-cols-[1fr_auto_auto_auto]">
+        <input
+          v-model="searchQuery"
+          class="input input-bordered rounded-xl"
+          placeholder="Search name, label, path"
+        />
+
+        <select
+          v-model="selectedBase"
+          class="select select-bordered rounded-xl"
+        >
+          <option value="all">All bases</option>
+          <option v-for="base in baseOptions" :key="base" :value="base">
+            {{ base }}
+          </option>
+        </select>
+
+        <select
+          v-model="maturityFilter"
+          class="select select-bordered rounded-xl"
+        >
+          <option value="all">All ratings</option>
+          <option value="sfw">SFW only</option>
+          <option value="mature">Mature only</option>
+        </select>
+
+        <select v-model="sortBy" class="select select-bordered rounded-xl">
+          <option value="name">Name A–Z</option>
+          <option value="newest">Newest</option>
+        </select>
+      </div>
+    </header>
+
+    <add-model
+      v-if="showForm"
+      :model="editing"
+      @saved="handleSaved"
+      @close="closeForm"
+    />
+
+    <div
+      v-if="!filteredModels.length"
+      class="rounded-2xl border border-dashed border-base-300 bg-base-200 p-6 text-center"
+    >
+      <p class="font-bold">No models found.</p>
+      <p class="text-sm text-base-content/60">
+        {{ resourceStore.isLoading ? 'Loading models…' : 'Try another filter.' }}
+      </p>
+    </div>
+
+    <template v-else>
+      <div
+        v-for="group in imageGroups"
+        :key="`img-${group.base}`"
+        class="flex flex-col gap-2"
+      >
+        <h3
+          class="flex items-center gap-2 px-1 text-sm font-bold text-base-content/80"
+        >
+          <span class="badge badge-secondary badge-sm">{{ group.base }}</span>
+          <span class="text-base-content/45">{{ group.items.length }}</span>
+        </h3>
+
+        <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-4">
+          <model-card
+            v-for="model in group.items"
+            :key="model.id || model.name"
+            :model="model"
+            :show-mature="showMature"
+            @edit="openEdit"
+          />
+        </div>
+      </div>
+
+      <template v-if="nonImageGroups.length">
+        <div class="divider text-xs font-bold uppercase text-base-content/50">
+          Other · non-image models
+        </div>
+
+        <div
+          v-for="group in nonImageGroups"
+          :key="`other-${group.base}`"
+          class="flex flex-col gap-2"
+        >
+          <h3
+            class="flex items-center gap-2 px-1 text-sm font-bold text-base-content/80"
+          >
+            <span class="badge badge-ghost badge-sm">{{ group.base }}</span>
+            <span class="text-base-content/45">{{ group.items.length }}</span>
+          </h3>
+
+          <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-4">
+            <model-card
+              v-for="model in group.items"
+              :key="model.id || model.name"
+              :model="model"
+              :show-mature="showMature"
+              @edit="openEdit"
+            />
+          </div>
+        </div>
+      </template>
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useResourceStore, type Resource } from '@/stores/resourceStore'
+import { useUserStore } from '@/stores/userStore'
+
+const resourceStore = useResourceStore()
+const userStore = useUserStore()
+
+const searchQuery = ref('')
+const selectedBase = ref<string>('all')
+const maturityFilter = ref<'all' | 'sfw' | 'mature'>('all')
+const sortBy = ref<'name' | 'newest'>('name')
+
+const showForm = ref(false)
+const editing = ref<Partial<Resource> | null>(null)
+
+const showMature = computed(() => userStore.showMature)
+
+const NON_IMAGE_BASES = new Set(['3D', 'AUDIO', 'VIDEO'])
+
+function safeText(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+
+  return ''
+}
+
+function baseOf(model: Partial<Resource>): string {
+  const path = safeText(model.localPath)
+    .replaceAll('\\', '/')
+    .replace(/^\/+/, '')
+  const folder = path.includes('/') ? path.split('/')[0] : ''
+
+  return (
+    folder ||
+    safeText(model.generation).trim() ||
+    safeText(model.supportedServer).trim() ||
+    'OTHER'
+  ).toUpperCase()
+}
+
+const baseOptions = computed(() => {
+  const seen = new Set<string>()
+  for (const model of resourceStore.visibleCheckpoints) {
+    seen.add(baseOf(model))
+  }
+
+  return Array.from(seen).sort(
+    (a, b) =>
+      Number(NON_IMAGE_BASES.has(a)) - Number(NON_IMAGE_BASES.has(b)) ||
+      a.localeCompare(b),
+  )
+})
+
+const filteredModels = computed<Partial<Resource>[]>(() => {
+  const query = searchQuery.value.trim().toLowerCase()
+
+  return resourceStore.visibleCheckpoints.filter((model) => {
+    if (selectedBase.value !== 'all' && baseOf(model) !== selectedBase.value) {
+      return false
+    }
+
+    if (maturityFilter.value === 'sfw' && model.isMature) return false
+    if (maturityFilter.value === 'mature' && !model.isMature) return false
+
+    if (!query) return true
+
+    return [model.name, model.customLabel, model.description, model.localPath]
+      .filter(Boolean)
+      .some((value) => String(value).toLowerCase().includes(query))
+  })
+})
+
+type ModelGroup = {
+  base: string
+  isNonImage: boolean
+  items: Partial<Resource>[]
+}
+
+const grouped = computed<ModelGroup[]>(() => {
+  const map = new Map<string, Partial<Resource>[]>()
+  for (const model of filteredModels.value) {
+    const base = baseOf(model)
+    const bucket = map.get(base) ?? map.set(base, []).get(base)!
+    bucket.push(model)
+  }
+
+  const groups: ModelGroup[] = [...map.entries()].map(([base, items]) => ({
+    base,
+    isNonImage: NON_IMAGE_BASES.has(base),
+    items: [...items].sort((a, b) =>
+      sortBy.value === 'newest'
+        ? Number(b.id ?? 0) - Number(a.id ?? 0)
+        : safeText(a.customLabel || a.name).localeCompare(
+            safeText(b.customLabel || b.name),
+          ),
+    ),
+  }))
+
+  return groups.sort(
+    (a, b) =>
+      Number(a.isNonImage) - Number(b.isNonImage) ||
+      a.base.localeCompare(b.base),
+  )
+})
+
+const imageGroups = computed(() =>
+  grouped.value.filter((group) => !group.isNonImage),
+)
+const nonImageGroups = computed(() =>
+  grouped.value.filter((group) => group.isNonImage),
+)
+
+const summaryText = computed(() => {
+  const total = resourceStore.visibleCheckpoints.length
+  const shown = filteredModels.value.length
+
+  if (shown === total) return `${total} model${total === 1 ? '' : 's'}`
+  return `${shown} of ${total} models`
+})
+
+function openAdd(): void {
+  editing.value = null
+  showForm.value = true
+}
+
+function openEdit(model: Partial<Resource>): void {
+  editing.value = model
+  showForm.value = true
+}
+
+function closeForm(): void {
+  showForm.value = false
+  editing.value = null
+}
+
+function handleSaved(): void {
+  closeForm()
+}
+
+onMounted(() => {
+  resourceStore.loadStore()
+})
+</script>

--- a/components/abandonware/navigation/kr-header-actions.vue
+++ b/components/abandonware/navigation/kr-header-actions.vue
@@ -1,0 +1,76 @@
+<!-- /components/abandonware/navigation/kr-header-actions.vue -->
+<!--
+  PARKED 2026-08-11. The mechanism worked; the need went away.
+
+  Its one caller was user-manager.vue, teleporting that page's Refresh and Log
+  Out out of a dead band and into the header row. Then the header collapsed
+  into the account hub, and those two landed in the hub's panel beside the
+  hub's own reload and logout -- Silas: "a refresh option that has the same
+  icon as our full refresh, but I have no idea what it does, and ANOTHER logout
+  button." Removing the duplicates left this with nothing to carry, which
+  verifyComponentReachability flagged.
+
+  Kept rather than deleted because the problem it solves is real and recurring:
+  a page that wants a control in the shared chrome, with its own busy state,
+  where a store of action descriptors cannot go. If that comes up again, this
+  is the shape -- a `defer` Teleport inside ClientOnly, plus a
+  `display: contents` target in the host. Re-adding it means restoring the
+  target too; the hub no longer has one.
+-->
+<!--
+  PUT A PAGE'S OWN CONTROLS IN THE HEADER ROW, not in a band above the content.
+
+  Silas, 2026-08-10, with screenshots of /stories, /facets and /characters:
+  "Same dead band holds refresh and log out on some pages. Fold them into the
+  header row too, so there is no strip between header and content."
+
+  The band was a real element, not a spacing bug: user-manager.vue opened with a
+  full page-width `justify-end` row containing nothing but Refresh and Log Out,
+  so /dashboard, /themes and /achievements each spent a row of vertical space on
+  two buttons and a lot of emptiness. A page renders inside <NuxtPage>, well
+  below workspace-header in the tree, so it has no ordinary way to reach the
+  header row — which left only two bad options, keep the band or delete the
+  controls and lose the capability. This is the third one.
+
+  WHY A TELEPORT RATHER THAN A STORE
+  ----------------------------------
+  The alternative shape is a store of action descriptors that the header
+  renders. That works right up to the first action that needs its own state --
+  user-manager's Log Out shows a spinner and a "Logging out…" label from a local
+  ref -- and then the descriptors grow icon, label, disabled, busy, busyLabel,
+  variant, and the header ends up reimplementing buttons. A teleport moves the
+  page's real button, with its real state, and the header stays a layout.
+
+  CLIENT-ONLY, and that is not a preference. icon-gallery.vue documents what
+  happened the one time this repo SSR'd a teleport: the hydration anchors it
+  emitted into <body> consumed the boot cover's inline <style>, the cover lost
+  `position: fixed`, and a 749px black block shoved the whole shell down the
+  page -- read there as a "122% chrome budget" on /icons for days. Nothing that
+  belongs in this slot needs to exist before hydration; these are account and
+  refresh controls, and the header row is already sized without them.
+
+  `defer` is what makes the target resolvable at all. workspace-header and
+  <NuxtPage> mount in the SAME render cycle, so a plain teleport looks for
+  #kr-header-actions before the header has created it, warns, and renders
+  nothing. `defer` (Vue 3.5+) postpones the lookup until after the cycle, which
+  is exactly the ordering this needs.
+
+  USAGE — wrap the buttons that were in the band, and delete the band:
+
+    <kr-header-actions>
+      <button class="btn btn-ghost btn-sm" @click="refresh">…</button>
+    </kr-header-actions>
+
+  Anything slotted here becomes a direct flex item of the header's control strip
+  (the target is `display: contents`), so it inherits that row's gap and the
+  strip's own compact-button sizing. Keep what you slot to icon-first buttons
+  with a `hidden sm:inline` label; a wide control here starves the tab strip,
+  which is the shrinkable thing in that row.
+-->
+<template>
+  <ClientOnly>
+    <Teleport defer to="#kr-header-actions">
+      <slot />
+    </Teleport>
+  </ClientOnly>
+</template>

--- a/components/abandonware/navigation/notification-bell.vue
+++ b/components/abandonware/navigation/notification-bell.vue
@@ -1,0 +1,121 @@
+<!-- /components/abandonware/navigation/notification-bell.vue -->
+<!--
+  PARKED 2026-08-10. Absorbed by account-hub.vue, not deleted.
+
+  Silas asked for every header icon except the tutorial toggle and the account
+  control to move inside the account control, with "the notification badge ...
+  on the login pic if appropriate, but actual notification stays inside as
+  well". Both halves of this component went there: the unread count now rides
+  the avatar, and the list renders as a section of the hub panel. Its cart
+  button is mounted directly by the hub.
+
+  Nothing in the app reaches this any more, which is what
+  verifyComponentReachability flagged. Parked rather than removed so it stays
+  exhibited in WonderLab and readable as the origin of the hub's notification
+  section -- if that section ever needs to become a standalone control again,
+  this is the shape it had.
+
+  ORIGINAL NOTE
+  -------------
+  Header action cluster: a cart control that appears whenever the local cart has
+  items, plus the logged-in user's notification dropdown. Keeping the cart here
+  makes it visible from every dashboard surface without turning cart state into
+  a notification or requiring each page to remember its own checkout doorway.
+-->
+<template>
+  <div class="flex shrink-0 items-center gap-1 sm:gap-1.5">
+    <cart-button />
+
+    <div
+      v-if="userStore.isLoggedIn && !userStore.isGuest"
+      class="dropdown dropdown-end"
+    >
+      <button
+        tabindex="0"
+        class="btn btn-ghost btn-circle"
+        aria-label="Open notifications"
+        title="Notifications"
+        @click="onOpen"
+      >
+        <div class="indicator">
+          <Icon name="kind-icon:ring" class="h-5 w-5" />
+          <span
+            v-if="notifications.unreadCount"
+            class="badge indicator-item badge-primary badge-xs"
+          >
+            {{
+              notifications.unreadCount > 9 ? '9+' : notifications.unreadCount
+            }}
+          </span>
+        </div>
+      </button>
+
+      <div
+        tabindex="0"
+        class="dropdown-content z-50 mt-2 w-80 kr-panel-flat p-2 shadow-xl"
+      >
+        <div class="flex items-center justify-between px-2 py-1">
+          <span class="font-black">Notifications</span>
+          <button
+            v-if="notifications.unreadCount"
+            class="btn btn-ghost btn-xs"
+            @click="notifications.markAllRead()"
+          >
+            Mark all read
+          </button>
+        </div>
+
+        <div class="max-h-96 overflow-y-auto">
+          <p
+            v-if="!notifications.items.length"
+            class="px-2 py-6 text-center text-sm text-base-content/50"
+          >
+            You're all caught up.
+          </p>
+          <button
+            v-for="n in notifications.items"
+            :key="n.id"
+            class="flex w-full flex-col gap-0.5 rounded-xl px-2 py-2 text-left hover:bg-base-200"
+            :class="{ 'bg-base-200/50': !n.isRead }"
+            @click="onClick(n)"
+          >
+            <span class="flex items-center gap-2 text-sm font-semibold">
+              <span v-if="!n.isRead" class="h-2 w-2 rounded-full bg-primary" />
+              {{ n.title }}
+            </span>
+            <span
+              v-if="n.body"
+              class="line-clamp-2 pl-4 text-xs text-base-content/60"
+              >{{ n.body }}</span
+            >
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useUserStore } from '@/stores/userStore'
+import {
+  useNotificationStore,
+  type AppNotification,
+} from '@/stores/notificationStore'
+
+const userStore = useUserStore()
+const notifications = useNotificationStore()
+
+function onOpen() {
+  notifications.load()
+}
+
+async function onClick(n: AppNotification) {
+  await notifications.markRead(n.id)
+  if (n.linkPath) navigateTo(n.linkPath)
+}
+
+onMounted(() => {
+  if (userStore.isLoggedIn && !userStore.isGuest) notifications.load()
+})
+</script>

--- a/components/abandonware/navigation/page-image.vue
+++ b/components/abandonware/navigation/page-image.vue
@@ -1,0 +1,91 @@
+<template>
+  <div v-if="hydrated" class="relative h-full w-full rounded-2xl">
+    <div class="flip-card h-full w-full rounded-2xl" @click="handleClick">
+      <div
+        class="flip-card-inner rounded-2xl"
+        :class="{ 'is-flipped': flipped }"
+      >
+        <div class="flip-card-front rounded-2xl">
+          <img
+            :src="pageImage"
+            alt="Page"
+            class="h-full w-full rounded-2xl object-cover"
+            draggable="false"
+          />
+        </div>
+
+        <div class="flip-card-back rounded-2xl">
+          <img
+            :src="pageImage"
+            alt="Page"
+            class="h-full w-full rounded-2xl object-cover"
+            draggable="false"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { usePageStore } from '@/stores/pageStore'
+
+const flipped = ref(false)
+const hydrated = ref(false)
+const pageStore = usePageStore()
+
+const fallback = '/images/botcafe.webp'
+
+const pageImage = computed(() => {
+  const img = pageStore.page?.image
+  if (!img) return fallback
+  return img.startsWith('/') ? img : `/images/${img}`
+})
+
+onMounted(() => {
+  hydrated.value = true
+})
+
+const handleClick = () => {
+  flipped.value = !flipped.value
+}
+</script>
+<style scoped>
+.flip-card {
+  width: 100%;
+  height: 100%;
+  perspective: 1000px;
+  cursor: pointer;
+  /* Isolate the stacking context */
+  isolation: isolate;
+}
+
+.flip-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.6s ease-in-out;
+  transform-style: preserve-3d;
+  -webkit-transform-style: preserve-3d; /* Safari */
+}
+
+.flip-card-inner.is-flipped {
+  transform: rotateY(180deg);
+}
+
+.flip-card-front,
+.flip-card-back {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  -webkit-backface-visibility: hidden; /* Safari */
+  backface-visibility: hidden;
+  border-radius: 1rem;
+  /* DO NOT use overflow: hidden here — breaks 3D */
+}
+
+.flip-card-back {
+  transform: rotateY(180deg);
+}
+</style>

--- a/components/abandonware/pages/registration-form.vue
+++ b/components/abandonware/pages/registration-form.vue
@@ -1,0 +1,332 @@
+<!-- /components/content/pages/registration-form.vue -->
+<template>
+  <div class="kr-surface bg-base-300 rounded-2xl p-4 sm:p-8">
+    <div class="kr-scroll flex flex-col items-center">
+      <p class="text-6xl font-bold mb-6 text-center">Kind Robots</p>
+      <div v-if="isLoggedIn" class="text-lg mb-6 text-center">
+        You are already logged in. Would you like to
+        <a href="/dashboard" class="text-info underline hover:text-info-focus">
+          go to the dashboard
+        </a>
+        or
+        <a
+          href="#"
+          class="text-info underline hover:text-info-focus"
+          @click="userStore.logout"
+        >
+          log out </a
+        >?
+      </div>
+      <form
+        class="space-y-6 w-full max-w-md mx-auto"
+        @submit.prevent="register"
+      >
+        <div v-if="step === 1">
+          <!-- Pick a Username Section -->
+          <p class="text-4xl font-bold mb-4 text-center">Pick a</p>
+          <div class="text-primary font-semibold text-5xl text-center mb-2">
+            <adjective-flipper />
+          </div>
+          <h2 class="text-4xl text-center mb-6">username.</h2>
+          <div class="relative mb-6">
+            <input
+              v-model="username"
+              type="text"
+              placeholder="Username"
+              required
+              class="w-full p-4 border rounded-lg text-lg bg-base-200 placeholder-base-content"
+              aria-label="Username"
+              autocomplete="username"
+              @input="checkUsernameAvailability"
+            />
+            <p
+              v-if="usernameWarning"
+              class="absolute text-sm text-warning right-2 bottom-2"
+            >
+              Username already exists
+            </p>
+          </div>
+          <button
+            v-if="username && !usernameWarning"
+            type="button"
+            class="w-full bg-primary text-lg text-base-100 py-2 rounded hover:bg-primary-dark transition duration-300"
+            @click="goToStep(2)"
+          >
+            That's my name!
+          </button>
+        </div>
+
+        <div v-if="step === 2">
+          <!-- Password and Confirmation Section -->
+          <h2 class="text-3xl font-semibold text-primary mb-4 text-center">
+            Welcome, {{ username }}!
+          </h2>
+          <button
+            type="button"
+            class="text-sm text-info underline mb-4 text-center"
+            @click="goToStep(1)"
+          >
+            I want a different username
+          </button>
+          <p class="text-lg mb-2">Optional details:</p>
+          <div class="relative group mb-4">
+            <input
+              v-model="email"
+              type="email"
+              placeholder="Email (optional)"
+              class="w-full p-4 border rounded-lg text-lg bg-base-200 placeholder-base-content"
+              aria-label="Email"
+              autocomplete="email"
+            />
+          </div>
+          <div class="relative group mb-4">
+            <input
+              v-model="password"
+              :type="showPassword ? 'text' : 'password'"
+              placeholder="Password (keep it blank if you prefer)"
+              class="w-full p-4 border rounded-lg text-lg bg-base-200 placeholder-base-content"
+              aria-label="Password"
+              autocomplete="new-password"
+              @input="validatePassword"
+            />
+            <div class="absolute inset-y-0 right-0 flex items-center pr-3">
+              <Icon
+                name="kind-icon:eye"
+                :class="
+                  showPassword
+                    ? 'text-base-300 cursor-pointer hover:text-warning'
+                    : 'text-base-300 cursor-pointer hover:text-success'
+                "
+                title="Show/Hide Password"
+                @click="togglePasswordVisibility"
+              />
+            </div>
+            <p v-if="passwordError" class="text-sm text-warning mt-2">
+              {{ passwordError }}
+            </p>
+          </div>
+
+          <div class="relative group mb-4">
+            <input
+              v-model="confirmPassword"
+              :type="showConfirmPassword ? 'text' : 'password'"
+              placeholder="Confirm Password"
+              class="w-full p-4 border rounded-lg text-lg bg-base-200 placeholder-base-content"
+              aria-label="Confirm Password"
+              autocomplete="new-password"
+              @input="validateConfirmPassword"
+            />
+            <div class="absolute inset-y-0 right-0 flex items-center pr-3">
+              <Icon
+                name="kind-icon:eye"
+                :class="
+                  showConfirmPassword
+                    ? 'text-base-300 cursor-pointer hover:text-warning'
+                    : 'text-base-300 cursor-pointer hover:text-success'
+                "
+                title="Show/Hide Confirm Password"
+                @click="toggleConfirmPasswordVisibility"
+              />
+            </div>
+            <p v-if="confirmPasswordError" class="text-sm text-warning mt-2">
+              {{ confirmPasswordError }}
+            </p>
+          </div>
+
+          <button
+            type="submit"
+            :disabled="!isFormValid || isLoading"
+            class="w-full bg-primary text-lg text-base-100 py-2 rounded hover:bg-primary-dark transition duration-300"
+          >
+            <span v-if="isLoading">Registering...</span>
+            <span v-else>Register</span>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref, computed } from 'vue'
+
+const userStore = useUserStore()
+const errorStore = useErrorStore()
+
+const username = ref('')
+const email = ref('')
+const password = ref('')
+const confirmPassword = ref('')
+const usernameWarning = ref(false)
+const status = ref('')
+const error = ref('')
+const isLoading = ref(false)
+const statusMessage = ref('')
+const confirmPasswordError = ref('')
+
+const showPassword = ref(false)
+const passwordError = ref('')
+const step = ref(1)
+const showConfirmPassword = ref(false)
+const firstPasswordValid = ref(false)
+
+const validatePassword = () => {
+  if (!password.value) {
+    passwordError.value = ''
+    firstPasswordValid.value = false
+    return
+  }
+
+  const minLength = /^.{8,}$/
+  const hasNumber = /\d/
+  const hasLetter = /[a-zA-Z]/
+
+  if (!minLength.test(password.value)) {
+    passwordError.value = 'At least 8 characters'
+    firstPasswordValid.value = false
+  } else if (!hasNumber.test(password.value)) {
+    passwordError.value = 'Include at least one number'
+    firstPasswordValid.value = false
+  } else if (!hasLetter.test(password.value)) {
+    passwordError.value = 'Include at least one letter'
+    firstPasswordValid.value = false
+  } else {
+    passwordError.value = ''
+    firstPasswordValid.value = true
+  }
+}
+
+const validateConfirmPassword = () => {
+  if (password.value && password.value !== confirmPassword.value) {
+    passwordError.value = 'Passwords do not match'
+  } else {
+    passwordError.value = ''
+  }
+}
+
+const welcomeMessage = ref('')
+
+const checkUsernameAvailability = async () => {
+  try {
+    const usernames = await userStore.getUsernames()
+    usernameWarning.value = usernames.includes(username.value)
+    if (usernameWarning.value) {
+      error.value = `Username "${username.value}" already exists.`
+    } else {
+      error.value = ''
+    }
+  } catch (e: unknown) {
+    if (e instanceof Error) {
+      errorStore.setError(
+        ErrorType.UNKNOWN_ERROR,
+        `Error checking username availability: ${e.message}`,
+      )
+    } else {
+      errorStore.setError(
+        ErrorType.UNKNOWN_ERROR,
+        'An unknown error occurred while checking username availability.',
+      )
+    }
+  }
+}
+
+const goToStep = (nextStep: number) => {
+  if (nextStep === 2) {
+    welcomeMessage.value = `Welcome, ${username.value}!`
+  }
+  step.value = nextStep
+}
+
+const isFormValid = computed(() => {
+  return (
+    username.value &&
+    !usernameWarning.value &&
+    (step.value === 1 ||
+      ((!password.value || !passwordError.value) &&
+        password.value === confirmPassword.value))
+  )
+})
+
+const togglePasswordVisibility = () => {
+  showPassword.value = !showPassword.value
+}
+
+const toggleConfirmPasswordVisibility = () => {
+  showConfirmPassword.value = !showConfirmPassword.value
+}
+
+const isLoggedIn = computed(() => userStore.isLoggedIn)
+
+const clearExistingUserData = () => {
+  localStorage.removeItem('api_key')
+  localStorage.removeItem('token')
+}
+const register = async () => {
+  if (!isFormValid.value) return
+
+  isLoading.value = true
+  statusMessage.value = 'Registering user...'
+  try {
+    clearExistingUserData()
+
+    // Register user
+    const registerResponse = await userStore.register({
+      username: username.value,
+    })
+    if (registerResponse.success) {
+      statusMessage.value = 'Welcome to Kind Robots!'
+      status.value = 'Welcome to Kind Robots!'
+
+      // Automatically log the user in
+      try {
+        const credentials = {
+          username: username.value,
+          password: password.value || undefined,
+        }
+        const loginResponse = await userStore.login(credentials)
+        if (!loginResponse.success) {
+          throw new Error(loginResponse.message || 'Login failed')
+        }
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          errorStore.setError(
+            ErrorType.AUTH_ERROR,
+            `Login failed: ${error.message}`,
+          )
+        } else {
+          errorStore.setError(
+            ErrorType.AUTH_ERROR,
+            'An unknown error occurred during login.',
+          )
+        }
+      }
+    } else {
+      status.value = ''
+      error.value = 'Registration failed. Please try again.'
+      errorStore.setError(
+        ErrorType.REGISTRATION_ERROR,
+        'Registration failed. Please try again.',
+      )
+    }
+  } catch (e: unknown) {
+    if (e instanceof Error) {
+      errorStore.setError(
+        ErrorType.REGISTRATION_ERROR,
+        `Registration failed: ${e.message}`,
+      )
+    } else {
+      errorStore.setError(
+        ErrorType.REGISTRATION_ERROR,
+        'An unknown error occurred during registration.',
+      )
+    }
+  }
+  isLoading.value = false
+}
+</script>
+
+<style scoped>
+.bg-primary-dark {
+  background-color: var(--color-primary-dark);
+}
+</style>

--- a/components/abandonware/pages/social-page.vue
+++ b/components/abandonware/pages/social-page.vue
@@ -1,0 +1,8 @@
+<!-- /components/content/pages/social-page.vue -->
+<template>
+  <main class="kr-surface">
+    <div class="kr-scroll">
+      <kofi-link />
+    </div>
+  </main>
+</template>

--- a/components/abandonware/pages/super-form.vue
+++ b/components/abandonware/pages/super-form.vue
@@ -1,0 +1,211 @@
+<!-- /components/pages/super-form.vue -->
+<template>
+  <section
+    class="kr-unbound flex h-full min-h-0 items-center justify-center overflow-y-auto overscroll-contain p-3 sm:p-6"
+  >
+    <div
+      class="w-full max-w-xl kr-panel-flat p-4 shadow-xl sm:p-6"
+    >
+      <header class="mb-6 text-center">
+        <site-logo class="mx-auto mb-4" />
+        <p class="text-3xl font-black text-primary sm:text-4xl">
+          Hair by Superkate!
+        </p>
+        <p class="mt-2 text-sm text-base-content/70">
+          Create and email a client receipt without exposing the mail credentials.
+        </p>
+      </header>
+
+      <form class="grid gap-4" @submit.prevent="submitForm">
+        <label class="form-control">
+          <span class="label-text font-bold">Date</span>
+          <input
+            v-model="form.date"
+            type="date"
+            class="input input-bordered mt-1 w-full"
+            required
+          />
+        </label>
+
+        <label class="form-control">
+          <span class="label-text font-bold">Client name</span>
+          <input
+            v-model="form.clientName"
+            type="text"
+            class="input input-bordered mt-1 w-full"
+            placeholder="Client name"
+            maxlength="120"
+            required
+          />
+        </label>
+
+        <label class="form-control">
+          <span class="label-text font-bold">Services provided</span>
+          <textarea
+            v-model="form.servicesProvided"
+            class="textarea textarea-bordered mt-1 min-h-24 w-full"
+            placeholder="Cut, color, styling..."
+            maxlength="1000"
+          />
+        </label>
+
+        <section
+          class="grid gap-4 rounded-2xl border border-base-300 bg-base-200 p-4 sm:grid-cols-2"
+        >
+          <label class="form-control">
+            <span class="label-text font-bold">Hours</span>
+            <input
+              v-model="form.hours"
+              type="number"
+              class="input input-bordered mt-1 w-full"
+              min="0"
+              max="48"
+              step="0.25"
+            />
+          </label>
+
+          <label class="form-control">
+            <span class="label-text font-bold">Rate per hour</span>
+            <input
+              v-model="form.rate"
+              type="number"
+              class="input input-bordered mt-1 w-full"
+              min="0"
+              max="5000"
+              step="0.01"
+            />
+          </label>
+
+          <label class="form-control sm:col-span-2">
+            <span class="label-text font-bold">Product cost</span>
+            <input
+              v-model="form.productCost"
+              type="number"
+              class="input input-bordered mt-1 w-full"
+              min="0"
+              max="50000"
+              step="0.01"
+            />
+          </label>
+
+          <div
+            class="rounded-2xl border border-primary/30 bg-primary/10 p-4 sm:col-span-2"
+          >
+            <p class="text-sm text-base-content/70">
+              {{ calculationLabel }}
+            </p>
+            <p class="mt-1 text-3xl font-black text-primary">
+              ${{ totalCost.toFixed(2) }}
+            </p>
+          </div>
+        </section>
+
+        <label class="form-control">
+          <span class="label-text font-bold">Client email</span>
+          <input
+            v-model="form.clientEmail"
+            type="email"
+            class="input input-bordered mt-1 w-full"
+            placeholder="client@example.com"
+            required
+          />
+          <span class="mt-1 text-xs text-base-content/60">
+            Studio copies are added securely by the server.
+          </span>
+        </label>
+
+        <div
+          v-if="receiptStore.lastMessage || receiptStore.lastError"
+          class="alert rounded-2xl"
+          :class="receiptStore.lastError ? 'alert-error' : 'alert-success'"
+        >
+          <Icon
+            :name="receiptStore.lastError ? 'kind-icon:warning' : 'kind-icon:check'"
+            class="h-5 w-5"
+          />
+          <span>{{ receiptStore.lastError || receiptStore.lastMessage }}</span>
+        </div>
+
+        <button
+          type="submit"
+          class="btn btn-primary rounded-2xl"
+          :disabled="receiptStore.isSending"
+        >
+          <span
+            v-if="receiptStore.isSending"
+            class="loading loading-spinner loading-sm"
+          />
+          <Icon v-else name="kind-icon:email" class="h-5 w-5" />
+          {{ receiptStore.isSending ? 'Sending...' : 'Send receipt' }}
+        </button>
+      </form>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useSuperkateReceiptStore } from '@/stores/superkateReceiptStore'
+
+type FormData = {
+  date: string
+  clientName: string
+  servicesProvided: string
+  hours: string
+  rate: string
+  productCost: string
+  clientEmail: string
+}
+
+const receiptStore = useSuperkateReceiptStore()
+
+function today(): string {
+  const now = new Date()
+  const offset = now.getTimezoneOffset() * 60_000
+  return new Date(now.getTime() - offset).toISOString().slice(0, 10)
+}
+
+function emptyForm(): FormData {
+  return {
+    date: today(),
+    clientName: '',
+    servicesProvided: '',
+    hours: '',
+    rate: '',
+    productCost: '',
+    clientEmail: '',
+  }
+}
+
+const form = ref<FormData>(emptyForm())
+
+const totalCost = computed(() => {
+  return (
+    Number(form.value.hours || 0) * Number(form.value.rate || 0) +
+    Number(form.value.productCost || 0)
+  )
+})
+
+const calculationLabel = computed(() => {
+  const rate = Number(form.value.rate || 0).toFixed(2)
+  const hours = Number(form.value.hours || 0)
+  const product = Number(form.value.productCost || 0).toFixed(2)
+  return `$${rate} × ${hours} hours + $${product} products`
+})
+
+async function submitForm(): Promise<void> {
+  const result = await receiptStore.sendReceiptEmail({
+    date: form.value.date,
+    clientName: form.value.clientName,
+    servicesProvided: form.value.servicesProvided,
+    hours: Number(form.value.hours || 0),
+    rate: Number(form.value.rate || 0),
+    productCost: Number(form.value.productCost || 0),
+    clientEmail: form.value.clientEmail,
+  })
+
+  if (result.success) {
+    form.value = emptyForm()
+  }
+}
+</script>

--- a/components/abandonware/scenarios/scenario-classification.vue
+++ b/components/abandonware/scenarios/scenario-classification.vue
@@ -1,0 +1,100 @@
+<!-- components/scenarios/scenario-classification.vue -->
+<!-- Tier, group, and difficulty — writes directly to scenarioStore.scenarioForm. -->
+<template>
+  <div class="flex flex-col gap-5">
+    <!-- Tier -->
+    <div class="flex flex-col gap-2">
+      <label
+        class="text-xs font-bold uppercase tracking-widest text-base-content/50"
+        >Tier</label
+      >
+      <div class="flex flex-wrap gap-1.5">
+        <button
+          v-for="t in TIER_PRESETS"
+          :key="t"
+          type="button"
+          class="rounded-full border px-3 py-1 text-xs font-semibold capitalize transition-all"
+          :class="
+            form.tier === t
+              ? 'border-primary bg-primary/15 text-primary'
+              : 'border-base-300 bg-base-200 text-base-content/60 hover:border-primary/40 hover:text-primary'
+          "
+          @click="form.tier = t"
+        >
+          {{ t }}
+        </button>
+      </div>
+      <input
+        v-model="form.tier"
+        type="text"
+        class="input input-bordered input-sm w-full max-w-xs rounded-xl bg-base-100 focus:border-primary"
+        placeholder="or type your own tier..."
+        maxlength="100"
+      />
+    </div>
+
+    <!-- Group -->
+    <div class="flex flex-col gap-2">
+      <label
+        class="text-xs font-bold uppercase tracking-widest text-base-content/50"
+        >Group</label
+      >
+      <input
+        v-model="form.group"
+        type="text"
+        class="input input-bordered input-sm w-full max-w-xs rounded-xl bg-base-100 focus:border-primary"
+        placeholder="dungeon-one, goblin-cave, act-two..."
+        maxlength="200"
+      />
+      <p class="text-xs text-base-content/40">
+        Scenarios with the same group string are linked together.
+      </p>
+    </div>
+
+    <!-- Difficulty -->
+    <div class="flex flex-col gap-2">
+      <label
+        class="text-xs font-bold uppercase tracking-widest text-base-content/50"
+      >
+        Difficulty
+        <span v-if="form.difficulty != null" class="ml-2 text-primary">{{
+          form.difficulty
+        }}</span>
+        <span v-else class="ml-2 text-base-content/30">unset</span>
+      </label>
+      <div class="flex items-center gap-3">
+        <input
+          :value="form.difficulty ?? 5"
+          type="range"
+          min="1"
+          max="10"
+          class="range range-primary range-sm flex-1 max-w-xs"
+          @input="
+            form.difficulty = Number(($event.target as HTMLInputElement).value)
+          "
+        />
+        <button
+          type="button"
+          class="btn btn-ghost btn-xs rounded-xl text-base-content/30"
+          @click="form.difficulty = null"
+        >
+          Clear
+        </button>
+      </div>
+      <div class="flex max-w-xs justify-between text-xs text-base-content/30">
+        <span>1 · Easy</span>
+        <span>5 · Medium</span>
+        <span>10 · Hard</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useScenarioStore } from '@/stores/scenarioStore'
+import { TIER_PRESETS } from '@/stores/helpers/scenarioCards'
+
+const scenarioStore = useScenarioStore()
+const form = computed(() => scenarioStore.scenarioForm)
+</script>

--- a/components/abandonware/scenarios/scenario-intros.vue
+++ b/components/abandonware/scenarios/scenario-intros.vue
@@ -1,0 +1,181 @@
+<!-- /components/scenarios/scenario-intros.vue -->
+<template>
+  <div class="flex flex-col gap-4">
+    <div class="flex items-center gap-2">
+      <button
+        type="button"
+        class="btn btn-ghost btn-sm gap-1.5 rounded-xl border border-base-300"
+        :disabled="!canGenerate || isSuggesting"
+        @click="generateAllIntros"
+      >
+        <span v-if="isSuggesting" class="loading loading-spinner loading-xs" />
+        <Icon v-else name="kind-icon:sparkles" class="h-4 w-4" />
+        Generate all from description
+      </button>
+
+      <p class="text-xs text-base-content/40">
+        {{ introEntries.length }}/5 intros
+      </p>
+    </div>
+
+    <div
+      v-for="(intro, index) in introEntries"
+      :key="index"
+      class="flex flex-col gap-2 kr-panel-flat p-4"
+    >
+      <div class="flex items-center justify-between">
+        <span
+          class="text-xs font-black uppercase tracking-widest text-primary/70"
+        >
+          Intro {{ index + 1 }}
+        </span>
+
+        <button
+          v-if="introEntries.length > 1"
+          type="button"
+          class="text-base-content/30 transition-colors hover:text-error"
+          @click="removeIntro(index)"
+        >
+          <Icon name="kind-icon:x" class="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      <textarea
+        :value="intro"
+        class="textarea textarea-bordered w-full resize-none rounded-xl bg-base-200 text-sm leading-relaxed focus:border-primary focus:outline-none"
+        rows="4"
+        :placeholder="
+          index === 0
+            ? 'TITLE IN CAPS: The situation opens dramatically with...'
+            : `Intro ${index + 1}: Another way into the scenario...`
+        "
+        @input="setIntro(index, ($event.target as HTMLTextAreaElement).value)"
+      />
+
+      <button
+        type="button"
+        class="btn btn-ghost btn-xs self-start rounded-xl border border-base-300 text-xs"
+        :disabled="isSuggesting"
+        @click="refineIntro(index, intro)"
+      >
+        <Icon name="kind-icon:sparkles" class="h-3 w-3" />
+        {{ intro.trim() ? 'Refine' : 'Generate' }}
+      </button>
+    </div>
+
+    <button
+      v-if="introEntries.length < 5"
+      type="button"
+      class="btn btn-ghost btn-sm w-full gap-1.5 rounded-xl border border-dashed border-base-300 hover:border-primary/40"
+      @click="addIntro"
+    >
+      <Icon name="kind-icon:plus" class="h-4 w-4" />
+      Add another intro
+    </button>
+
+    <p v-if="builder.lastError" class="text-xs text-error">
+      {{ builder.lastError }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useBuilderStore } from '@/stores/builderStore'
+
+const builder = useBuilderStore()
+
+const isSuggesting = computed(() => {
+  return Boolean(builder.isSuggesting || builder.isSaving)
+})
+
+const introEntries = computed<string[]>(() => {
+  const value = builder.sheet.intros
+
+  if (Array.isArray(value)) {
+    const entries = value.filter((entry): entry is string => {
+      return typeof entry === 'string'
+    })
+
+    return entries.length ? entries.slice(0, 5) : ['']
+  }
+
+  if (typeof value === 'string') {
+    const entries = value
+      .split('\n---\n')
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+
+    return entries.length ? entries.slice(0, 5) : ['']
+  }
+
+  return ['']
+})
+
+const canGenerate = computed(() => {
+  return Boolean(sheetText('description').trim() || sheetText('title').trim())
+})
+
+function sheetText(key: string): string {
+  const value = builder.sheet[key]
+
+  return typeof value === 'string' ? value : ''
+}
+
+function writeIntros(entries: string[]) {
+  builder.updateSheet({
+    intros: entries.slice(0, 5),
+  })
+}
+
+function setIntro(index: number, value: string) {
+  const entries = [...introEntries.value]
+
+  entries[index] = value
+  writeIntros(entries)
+}
+
+function addIntro() {
+  if (introEntries.value.length >= 5) return
+
+  writeIntros([...introEntries.value, ''])
+}
+
+function removeIntro(index: number) {
+  const entries = introEntries.value.filter((_, entryIndex) => {
+    return entryIndex !== index
+  })
+
+  writeIntros(entries.length ? entries : [''])
+}
+
+async function refineIntro(index: number, current: string) {
+  builder.updateSheet({
+    intros: introEntries.value,
+  })
+
+  const result = await builder.callSuggest('intros', 'intros', current)
+
+  if (!result.success || !result.message) return
+
+  setIntro(index, result.message)
+}
+
+async function generateAllIntros() {
+  const result = await builder.callSuggest(
+    'intros',
+    'intros',
+    introEntries.value.join('\n---\n'),
+  )
+
+  if (!result.success || !result.message) return
+
+  const entries = result.message
+    .split(/\n---\n|\n\d+\.\s+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .slice(0, 5)
+
+  writeIntros(entries.length ? entries : [result.message.trim()])
+}
+</script>

--- a/components/abandonware/servers/chat-test.vue
+++ b/components/abandonware/servers/chat-test.vue
@@ -1,0 +1,934 @@
+<script setup lang="ts">
+import { useUserStore } from '@/stores/userStore'
+// ─── Types ───────────────────────────────────────────────────────────────────
+type Provider = 'anthropic' | 'openai' | 'ollama'
+
+interface ProviderConfig {
+  label: string
+  route: string
+  defaultModel: string
+  models: string[]
+  color: string
+  icon: string
+}
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+const PROVIDERS: Record<Provider, ProviderConfig> = {
+  anthropic: {
+    label: 'Anthropic',
+    route: '/api/chats/anthropic/stream',
+    defaultModel: 'claude-sonnet-4-6',
+    models: [
+      'claude-sonnet-4-6',
+      'claude-opus-4-6',
+      'claude-haiku-4-5-20251001',
+    ],
+    color: '#d4a853',
+    icon: '◈',
+  },
+  openai: {
+    label: 'OpenAI',
+    route: '/api/chats/openai/stream',
+    defaultModel: 'gpt-4o-mini',
+    models: ['gpt-4o-mini', 'gpt-4o', 'gpt-4-turbo'],
+    color: '#4ade80',
+    icon: '◎',
+  },
+  ollama: {
+    label: 'Ollama',
+    route: '/api/chats/ollama/stream',
+    defaultModel: 'llama3.2',
+    models: ['llama3.2', 'llama3.1', 'mistral', 'phi3', 'gemma2'],
+    color: '#60a5fa',
+    icon: '◉',
+  },
+}
+
+// ─── State ────────────────────────────────────────────────────────────────────
+const provider = ref<Provider>('anthropic')
+const model = ref(PROVIDERS.anthropic.defaultModel)
+const prompt = ref('Hello! Tell me a one-sentence joke about robots.')
+const system = ref('')
+const temperature = ref(0.7)
+const maxTokens = ref(512)
+const streamEnabled = ref(true)
+const showPayload = ref(false)
+const showErrors = ref(true)
+const ollamaBaseUrl = ref('http://localhost:11434')
+const userStore = useUserStore()
+
+const isLoading = ref(false)
+const output = ref('')
+const errorMsg = ref('')
+const elapsedMs = ref(0)
+const tokenCount = ref(0)
+const startTime = ref(0)
+let timerInterval: ReturnType<typeof setInterval> | null = null
+
+const cfg = computed(() => PROVIDERS[provider.value])
+
+function getAuthHeaders(): HeadersInit {
+  const token =
+    userStore.token || userStore.user?.token || userStore.apiKey || ''
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+
+  if (token) {
+    headers.Authorization = token.startsWith('Bearer ')
+      ? token
+      : `Bearer ${token}`
+  }
+
+  return headers
+}
+
+// keep model in sync when provider changes
+watch(provider, (p) => {
+  model.value = PROVIDERS[p].defaultModel
+  errorMsg.value = ''
+  output.value = ''
+})
+
+// ─── Payload preview ──────────────────────────────────────────────────────────
+const payloadPreview = computed(() => {
+  const base: Record<string, unknown> = {
+    model: model.value,
+    prompt: prompt.value,
+    stream: streamEnabled.value,
+    temperature: temperature.value,
+    maxTokens: maxTokens.value,
+  }
+  if (system.value) base.system = system.value
+  if (provider.value === 'ollama') base.baseUrl = ollamaBaseUrl.value
+  return JSON.stringify(base, null, 2)
+})
+
+// ─── Stream helpers ───────────────────────────────────────────────────────────
+function countTokens(text: string) {
+  return Math.ceil(text.split(/\s+/).filter(Boolean).length * 1.3)
+}
+
+function startTimer() {
+  startTime.value = Date.now()
+  elapsedMs.value = 0
+  timerInterval = setInterval(() => {
+    elapsedMs.value = Date.now() - startTime.value
+  }, 50)
+}
+
+function stopTimer() {
+  if (timerInterval) clearInterval(timerInterval)
+  elapsedMs.value = Date.now() - startTime.value
+}
+
+function extractDelta(raw: string, prov: Provider): string {
+  try {
+    const parsed = JSON.parse(raw)
+    if (prov === 'anthropic') {
+      if (parsed.type === 'content_block_delta') {
+        return parsed.delta?.text ?? ''
+      }
+      return ''
+    }
+    if (prov === 'openai') {
+      return parsed.choices?.[0]?.delta?.content ?? ''
+    }
+    if (prov === 'ollama') {
+      return parsed.message?.content ?? parsed.response ?? ''
+    }
+  } catch {
+    // ignore parse errors on partial lines
+  }
+  return ''
+}
+
+// ─── Main executor ────────────────────────────────────────────────────────────
+async function run() {
+  if (isLoading.value) return
+  output.value = ''
+  errorMsg.value = ''
+  tokenCount.value = 0
+  isLoading.value = true
+  startTimer()
+
+  const body: Record<string, unknown> = {
+    model: model.value,
+    prompt: prompt.value,
+    stream: streamEnabled.value,
+    temperature: temperature.value,
+    maxTokens: maxTokens.value,
+  }
+  if (system.value) body.system = system.value
+  if (provider.value === 'ollama') body.baseUrl = ollamaBaseUrl.value
+
+  try {
+    const res = await fetch(cfg.value.route, {
+      method: 'POST',
+      headers: getAuthHeaders(),
+      body: JSON.stringify(body),
+    })
+
+    if (!res.ok) {
+      let message = `${res.status} ${res.statusText}`
+
+      try {
+        const contentType = res.headers.get('content-type') || ''
+
+        if (contentType.includes('application/json')) {
+          const data = await res.json()
+          message =
+            data?.message ||
+            data?.statusMessage ||
+            data?.error ||
+            JSON.stringify(data)
+        } else {
+          message = await res.text()
+        }
+      } catch {}
+
+      throw new Error(`HTTP ${res.status}: ${message}`)
+    }
+
+    if (!streamEnabled.value) {
+      // Non-stream: just read JSON
+      const data = await res.json()
+      const text =
+        data?.content?.[0]?.text ??
+        data?.choices?.[0]?.message?.content ??
+        data?.message?.content ??
+        JSON.stringify(data, null, 2)
+      output.value = text
+      tokenCount.value = countTokens(text)
+    } else {
+      // Stream
+      const reader = res.body!.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+
+        const lines = buffer.split('\n')
+        buffer = lines.pop() ?? ''
+
+        for (const line of lines) {
+          const trimmed = line.trim()
+          if (
+            !trimmed ||
+            trimmed === 'data: [DONE]' ||
+            trimmed.startsWith('event:')
+          )
+            continue
+          const jsonStr = trimmed.startsWith('data: ')
+            ? trimmed.slice(6)
+            : trimmed
+          const delta = extractDelta(jsonStr, provider.value)
+          if (delta) {
+            output.value += delta
+            tokenCount.value = countTokens(output.value)
+          }
+        }
+      }
+    }
+  } catch (err) {
+    errorMsg.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    stopTimer()
+    isLoading.value = false
+  }
+}
+
+function copyOutput() {
+  if (typeof window !== 'undefined') {
+    window.navigator.clipboard.writeText(output.value)
+  }
+}
+
+function clear() {
+  output.value = ''
+  errorMsg.value = ''
+  tokenCount.value = 0
+  elapsedMs.value = 0
+}
+</script>
+
+<template>
+  <div class="stream-test">
+    <!-- ── Header ─────────────────────────────────────────────────────────── -->
+    <header class="st-header">
+      <div class="st-header-left">
+        <span class="st-logo">⟨/⟩</span>
+        <div>
+          <h1 class="st-title">Stream Test</h1>
+          <p class="st-subtitle">API Route Diagnostics</p>
+        </div>
+      </div>
+      <div class="st-badge-row">
+        <span class="st-badge" :style="{ '--accent': cfg.color }">
+          {{ cfg.icon }} {{ cfg.label }}
+        </span>
+        <span class="st-badge st-badge-mono">
+          {{ streamEnabled ? '⇶ STREAM' : '⬡ BATCH' }}
+        </span>
+      </div>
+    </header>
+
+    <div class="st-layout">
+      <!-- ── Left panel: controls ─────────────────────────────────────────── -->
+      <aside class="st-sidebar">
+        <!-- Provider select -->
+        <section class="st-section">
+          <label class="st-label">Provider</label>
+          <div class="st-provider-tabs">
+            <button
+              v-for="(pcfg, key) in PROVIDERS"
+              :key="key"
+              class="st-provider-tab"
+              :class="{ active: provider === key }"
+              :style="provider === key ? { '--accent': pcfg.color } : {}"
+              @click="provider = key as Provider"
+            >
+              <span class="st-provider-icon">{{ pcfg.icon }}</span>
+              {{ pcfg.label }}
+            </button>
+          </div>
+        </section>
+
+        <!-- Model -->
+        <section class="st-section">
+          <label class="st-label">Model</label>
+          <select v-model="model" class="st-select">
+            <option v-for="m in cfg.models" :key="m" :value="m">{{ m }}</option>
+          </select>
+        </section>
+
+        <!-- Ollama base URL -->
+        <section v-if="provider === 'ollama'" class="st-section">
+          <label class="st-label">Ollama Base URL</label>
+          <input v-model="ollamaBaseUrl" class="st-input" type="text" />
+        </section>
+
+        <!-- Route display -->
+        <section class="st-section">
+          <label class="st-label">Route</label>
+          <div class="st-route">{{ cfg.route }}</div>
+        </section>
+
+        <hr class="st-divider" />
+
+        <!-- Toggles -->
+        <section class="st-section">
+          <label class="st-label">Options</label>
+          <div class="st-toggles">
+            <label class="st-toggle">
+              <input type="checkbox" v-model="streamEnabled" />
+              <span class="st-toggle-track"
+                ><span class="st-toggle-thumb"
+              /></span>
+              Streaming
+            </label>
+            <label class="st-toggle">
+              <input type="checkbox" v-model="showPayload" />
+              <span class="st-toggle-track"
+                ><span class="st-toggle-thumb"
+              /></span>
+              Show Payload
+            </label>
+            <label class="st-toggle">
+              <input type="checkbox" v-model="showErrors" />
+              <span class="st-toggle-track"
+                ><span class="st-toggle-thumb"
+              /></span>
+              Show Errors
+            </label>
+          </div>
+        </section>
+
+        <hr class="st-divider" />
+
+        <!-- Temperature + Tokens -->
+        <section class="st-section">
+          <label class="st-label"
+            >Temperature <span class="st-val">{{ temperature }}</span></label
+          >
+          <input
+            type="range"
+            min="0"
+            max="2"
+            step="0.05"
+            v-model.number="temperature"
+            class="st-range"
+          />
+        </section>
+        <section class="st-section">
+          <label class="st-label"
+            >Max Tokens <span class="st-val">{{ maxTokens }}</span></label
+          >
+          <input
+            type="range"
+            min="64"
+            max="4096"
+            step="64"
+            v-model.number="maxTokens"
+            class="st-range"
+          />
+        </section>
+      </aside>
+
+      <!-- ── Right panel: prompt + output ──────────────────────────────────── -->
+      <main class="st-main">
+        <!-- System prompt -->
+        <section class="st-section">
+          <label class="st-label"
+            >System Prompt <span class="st-optional">(optional)</span></label
+          >
+          <textarea
+            v-model="system"
+            class="st-textarea st-textarea--sm"
+            placeholder="You are a helpful assistant…"
+          />
+        </section>
+
+        <!-- User prompt -->
+        <section class="st-section">
+          <label class="st-label">User Prompt</label>
+          <textarea
+            v-model="prompt"
+            class="st-textarea"
+            placeholder="Enter your prompt…"
+          />
+        </section>
+
+        <!-- Actions -->
+        <div class="st-actions">
+          <button
+            class="st-btn st-btn--primary"
+            :disabled="isLoading"
+            @click="run"
+          >
+            <span v-if="isLoading" class="st-spinner" />
+            <span v-else>▶ Run</span>
+          </button>
+          <button
+            class="st-btn st-btn--ghost"
+            :disabled="isLoading"
+            @click="clear"
+          >
+            ✕ Clear
+          </button>
+          <div class="st-stats" v-if="elapsedMs > 0">
+            <span>{{ (elapsedMs / 1000).toFixed(2) }}s</span>
+            <span>~{{ tokenCount }} tok</span>
+          </div>
+          <div v-if="isLoading" class="st-live-pill">● LIVE</div>
+        </div>
+
+        <!-- Payload preview -->
+        <Transition name="slide">
+          <section v-if="showPayload" class="st-section">
+            <label class="st-label">Request Payload</label>
+            <pre class="st-code">{{ payloadPreview }}</pre>
+          </section>
+        </Transition>
+
+        <!-- Error panel -->
+        <Transition name="slide">
+          <section v-if="showErrors && errorMsg" class="st-section">
+            <label class="st-label st-label--error">⚠ Error</label>
+            <div class="st-error">{{ errorMsg }}</div>
+          </section>
+        </Transition>
+
+        <!-- Output -->
+        <section class="st-section st-section--grow">
+          <div class="st-output-header">
+            <label class="st-label">Output</label>
+            <button v-if="output" class="st-copy" @click="copyOutput">
+              ⧉ Copy
+            </button>
+          </div>
+          <div class="st-output" :class="{ 'st-output--empty': !output }">
+            <span v-if="!output && !isLoading" class="st-placeholder"
+              >Response will appear here…</span
+            >
+            <span v-else>{{ output }}</span>
+            <span v-if="isLoading" class="st-cursor">▌</span>
+          </div>
+        </section>
+      </main>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* ─── Tokens ──────────────────────────────────────────────────────────────── */
+.stream-test {
+  --bg: #0d0f14;
+  --surface: #13161e;
+  --surface2: #1a1e2a;
+  --border: rgba(255 255 255 / 0.07);
+  --text: #e2e8f0;
+  --muted: #64748b;
+  --accent: #d4a853;
+  --red: #f87171;
+  --green: #4ade80;
+
+  font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 480px;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ─── Header ──────────────────────────────────────────────────────────────── */
+.st-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  flex-shrink: 0;
+}
+.st-header-left {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.st-logo {
+  font-size: 1.5rem;
+  color: var(--accent);
+  font-weight: 700;
+  letter-spacing: -0.05em;
+}
+.st-title {
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin: 0;
+}
+.st-subtitle {
+  font-size: 0.65rem;
+  color: var(--muted);
+  margin: 0;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.st-badge-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+.st-badge {
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.6rem;
+  border-radius: 3px;
+  border: 1px solid var(--accent, var(--border));
+  color: var(--accent, var(--muted));
+  background: transparent;
+}
+.st-badge-mono {
+  color: var(--muted);
+  border-color: var(--border);
+}
+
+/* ─── Layout ──────────────────────────────────────────────────────────────── */
+.st-layout {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  flex: 1;
+  overflow: hidden;
+}
+
+/* ─── Sidebar ─────────────────────────────────────────────────────────────── */
+.st-sidebar {
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  padding: 1.25rem 1rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+/* ─── Main ────────────────────────────────────────────────────────────────── */
+.st-main {
+  padding: 1.25rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* ─── Sections ────────────────────────────────────────────────────────────── */
+.st-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.st-section--grow {
+  flex: 1;
+}
+.st-label {
+  font-size: 0.62rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.st-label--error {
+  color: var(--red);
+}
+.st-optional {
+  opacity: 0.5;
+  text-transform: lowercase;
+  letter-spacing: 0;
+  font-size: 0.6rem;
+}
+.st-val {
+  font-size: 0.75rem;
+  color: var(--accent);
+  text-transform: lowercase;
+  letter-spacing: 0;
+}
+.st-divider {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 0.5rem 0;
+}
+
+/* ─── Provider tabs ───────────────────────────────────────────────────────── */
+.st-provider-tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+.st-provider-tab {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.7rem;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--muted);
+  font-family: inherit;
+  font-size: 0.75rem;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.15s ease;
+}
+.st-provider-tab:hover {
+  background: var(--surface2);
+  color: var(--text);
+}
+.st-provider-tab.active {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
+.st-provider-icon {
+  font-size: 0.9rem;
+}
+
+/* ─── Route display ───────────────────────────────────────────────────────── */
+.st-route {
+  font-size: 0.65rem;
+  color: var(--accent);
+  background: var(--surface2);
+  padding: 0.4rem 0.6rem;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+  word-break: break-all;
+}
+
+/* ─── Form elements ───────────────────────────────────────────────────────── */
+.st-select,
+.st-input {
+  width: 100%;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 0.75rem;
+  padding: 0.45rem 0.6rem;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.st-select:focus,
+.st-input:focus {
+  border-color: var(--accent);
+}
+.st-textarea {
+  width: 100%;
+  min-height: 80px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  padding: 0.6rem 0.75rem;
+  outline: none;
+  resize: vertical;
+  transition: border-color 0.15s;
+  box-sizing: border-box;
+}
+.st-textarea--sm {
+  min-height: 52px;
+}
+.st-textarea:focus {
+  border-color: var(--accent);
+}
+
+.st-range {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
+/* ─── Toggles ─────────────────────────────────────────────────────────────── */
+.st-toggles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.st-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-size: 0.72rem;
+  color: var(--text);
+}
+.st-toggle input {
+  display: none;
+}
+.st-toggle-track {
+  width: 28px;
+  height: 15px;
+  border-radius: 999px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  position: relative;
+  flex-shrink: 0;
+  transition:
+    background 0.2s,
+    border-color 0.2s;
+}
+.st-toggle input:checked ~ .st-toggle-track {
+  background: color-mix(in srgb, var(--accent) 30%, transparent);
+  border-color: var(--accent);
+}
+.st-toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--muted);
+  transition:
+    left 0.2s,
+    background 0.2s;
+}
+.st-toggle input:checked ~ .st-toggle-track .st-toggle-thumb {
+  left: 15px;
+  background: var(--accent);
+}
+
+/* ─── Actions ─────────────────────────────────────────────────────────────── */
+.st-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+.st-btn {
+  font-family: inherit;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  padding: 0.5rem 1.2rem;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  transition: all 0.15s;
+}
+.st-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.st-btn--primary {
+  background: var(--accent);
+  color: #0d0f14;
+  font-weight: 700;
+}
+.st-btn--primary:not(:disabled):hover {
+  background: color-mix(in srgb, var(--accent) 80%, white);
+}
+.st-btn--ghost {
+  background: transparent;
+  color: var(--muted);
+  border-color: var(--border);
+}
+.st-btn--ghost:not(:disabled):hover {
+  color: var(--text);
+  border-color: var(--muted);
+}
+
+.st-stats {
+  display: flex;
+  gap: 0.75rem;
+  font-size: 0.65rem;
+  color: var(--muted);
+  letter-spacing: 0.05em;
+}
+.st-live-pill {
+  font-size: 0.6rem;
+  letter-spacing: 0.12em;
+  color: var(--green);
+  animation: pulse 1s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+
+/* ─── Spinner ─────────────────────────────────────────────────────────────── */
+.st-spinner {
+  width: 10px;
+  height: 10px;
+  border: 2px solid rgba(0 0 0 / 0.2);
+  border-top-color: #0d0f14;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ─── Code / error ────────────────────────────────────────────────────────── */
+.st-code {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.75rem;
+  font-size: 0.7rem;
+  line-height: 1.6;
+  color: var(--green);
+  overflow-x: auto;
+  margin: 0;
+  white-space: pre;
+}
+.st-error {
+  background: color-mix(in srgb, var(--red) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--red) 40%, transparent);
+  border-radius: 4px;
+  padding: 0.75rem;
+  font-size: 0.75rem;
+  color: var(--red);
+  line-height: 1.5;
+}
+
+/* ─── Output ──────────────────────────────────────────────────────────────── */
+.st-output-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.st-copy {
+  font-family: inherit;
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  padding: 0.15rem 0.5rem;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.st-copy:hover {
+  color: var(--text);
+  border-color: var(--muted);
+}
+
+.st-output {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.75rem;
+  font-size: 0.8rem;
+  line-height: 1.7;
+  min-height: 160px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  flex: 1;
+}
+.st-output--empty {
+  border-style: dashed;
+}
+.st-placeholder {
+  color: var(--muted);
+  font-style: italic;
+}
+.st-cursor {
+  display: inline-block;
+  animation: blink 0.8s step-end infinite;
+  color: var(--accent);
+}
+@keyframes blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}
+
+/* ─── Transitions ─────────────────────────────────────────────────────────── */
+.slide-enter-active,
+.slide-leave-active {
+  transition: all 0.2s ease;
+}
+.slide-enter-from,
+.slide-leave-to {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+
+/* ─── Scrollbar ───────────────────────────────────────────────────────────── */
+::-webkit-scrollbar {
+  width: 4px;
+  height: 4px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 2px;
+}
+</style>

--- a/components/abandonware/themes/add-theme.vue
+++ b/components/abandonware/themes/add-theme.vue
@@ -1,0 +1,440 @@
+<!-- /components/content/icons/theme-menu.vue -->
+<template>
+  <div class="theme-menu mx-auto flex max-w-6xl flex-col gap-8 px-4 py-6">
+    <section
+      class="rounded-2xl border border-base-content bg-base-200 p-4 shadow-md"
+    >
+      <div
+        class="flex flex-col gap-3 border-b border-base-300 pb-4 sm:flex-row sm:items-center sm:justify-between"
+      >
+        <div>
+          <h2 class="text-xl font-bold">🎨 Make Your Own Theme</h2>
+          <p class="text-sm text-base-content/70">
+            Build, preview, save, and apply a custom theme without leaving the
+            page.
+          </p>
+        </div>
+
+        <div class="flex flex-wrap items-center gap-3">
+          <label class="label cursor-pointer gap-2">
+            <span class="label-text text-sm">Public</span>
+            <input
+              v-model="themeForm.isPublic"
+              type="checkbox"
+              class="toggle toggle-sm"
+            />
+          </label>
+
+          <label class="label cursor-pointer gap-2">
+            <span class="label-text text-sm">Apply after save</span>
+            <input
+              v-model="applyAfterSave"
+              type="checkbox"
+              class="toggle toggle-sm"
+            />
+          </label>
+        </div>
+      </div>
+
+      <div
+        class="mt-4 grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1.2fr)_minmax(20rem,24rem)]"
+      >
+        <div class="space-y-4">
+          <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <label
+              v-for="color in colorKeys"
+              :key="color"
+              class="flex items-center gap-3 kr-panel-flat px-3 py-3"
+            >
+              <span class="min-w-0 flex-1 truncate text-sm font-medium">
+                {{ themeStore.labelFromKey(color) }}
+              </span>
+
+              <input
+                type="color"
+                :value="themeForm.values?.[color] || '#ffffff'"
+                class="h-10 w-16 cursor-pointer rounded-xl border border-base-300 bg-transparent p-1"
+                @input="onColorInput($event, color)"
+              />
+            </label>
+          </div>
+
+          <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <input
+              v-model="themeForm.name"
+              type="text"
+              placeholder="Theme name"
+              class="input input-bordered w-full bg-base-100 text-center"
+            />
+
+            <input
+              v-model="themeForm.room"
+              type="text"
+              placeholder="Room or vibe"
+              class="input input-bordered w-full bg-base-100 text-center"
+            />
+          </div>
+
+          <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <input
+              v-model="themeForm.tagline"
+              type="text"
+              placeholder="Optional tagline"
+              class="input input-bordered w-full bg-base-100 text-center"
+            />
+
+            <select
+              v-model="themeForm.colorScheme"
+              class="select select-bordered w-full bg-base-100"
+            >
+              <option value="light">light</option>
+              <option value="dark">dark</option>
+            </select>
+          </div>
+
+          <div class="flex flex-wrap gap-3">
+            <button class="btn btn-accent" @click="randomizeTheme">
+              🎲 Randomize
+            </button>
+
+            <button class="btn btn-outline" @click="resetTheme">Reset</button>
+
+            <button
+              class="btn btn-primary"
+              :disabled="isSaving || !trimmedName"
+              @click="saveTheme"
+            >
+              {{
+                isSaving
+                  ? 'Saving…'
+                  : updateMode
+                    ? 'Update Theme'
+                    : 'Save Theme'
+              }}
+            </button>
+
+            <button
+              class="btn btn-secondary"
+              :disabled="isApplyingPreview"
+              @click="applyPreviewTheme"
+            >
+              {{ isApplyingPreview ? 'Applying…' : 'Preview This Theme' }}
+            </button>
+          </div>
+
+          <p
+            v-if="themeError"
+            class="rounded-2xl border border-error bg-error/10 p-3 text-sm text-error whitespace-pre-wrap"
+          >
+            {{ themeError }}
+          </p>
+        </div>
+
+        <div class="min-h-0">
+          <div class="kr-panel-flat p-4 shadow-sm">
+            <div class="mb-3 flex items-center justify-between gap-3">
+              <div>
+                <h3 class="text-lg font-semibold">Live Preview</h3>
+                <p class="text-sm text-base-content/70">
+                  Try the palette before committing to the bit.
+                </p>
+              </div>
+
+              <span class="badge badge-outline">
+                {{ themeForm.colorScheme || 'light' }}
+              </span>
+            </div>
+
+            <div
+              class="rounded-2xl border border-base-300 p-4"
+              :style="previewStyleObject"
+            >
+              <div class="space-y-3">
+                <div>
+                  <div class="text-xl font-bold">
+                    {{ trimmedName || 'Unnamed Theme' }}
+                  </div>
+                  <div class="text-sm opacity-80">
+                    {{
+                      themeForm.tagline ||
+                      'A suspiciously stylish color experiment.'
+                    }}
+                  </div>
+                </div>
+
+                <div class="flex flex-wrap gap-2">
+                  <button class="btn btn-primary btn-sm">Primary</button>
+                  <button class="btn btn-secondary btn-sm">Secondary</button>
+                  <button class="btn btn-accent btn-sm">Accent</button>
+                  <button class="btn btn-info btn-sm">Info</button>
+                  <button class="btn btn-success btn-sm">Success</button>
+                  <button class="btn btn-warning btn-sm">Warning</button>
+                  <button class="btn btn-error btn-sm">Error</button>
+                </div>
+
+                <div class="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                  <div
+                    class="rounded-xl border border-base-300 bg-base-200 p-3"
+                  >
+                    <div class="text-xs uppercase opacity-70">base-100</div>
+                    <div class="text-sm font-semibold">
+                      {{ themeForm.values?.['base-100'] || '#ffffff' }}
+                    </div>
+                  </div>
+
+                  <div
+                    class="rounded-xl border border-base-300 bg-base-200 p-3"
+                  >
+                    <div class="text-xs uppercase opacity-70">primary</div>
+                    <div class="text-sm font-semibold">
+                      {{ themeForm.values?.primary || '#ffffff' }}
+                    </div>
+                  </div>
+
+                  <div
+                    class="rounded-xl border border-base-300 bg-base-200 p-3"
+                  >
+                    <div class="text-xs uppercase opacity-70">accent</div>
+                    <div class="text-sm font-semibold">
+                      {{ themeForm.values?.accent || '#ffffff' }}
+                    </div>
+                  </div>
+                </div>
+
+                <div
+                  class="rounded-xl border border-base-300 bg-base-200 p-3 text-sm"
+                >
+                  This is how your theme might feel in the wild. Slightly
+                  glamorous. Mildly dangerous.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useThemeStore, type Theme } from '@/stores/themeStore'
+import { useAchievementStore } from '@/stores/achievementStore'
+
+const themeStore = useThemeStore()
+const achievementStore = useAchievementStore()
+
+const themeError = ref('')
+const isSaving = ref(false)
+const isApplyingPreview = ref(false)
+
+const themeForm = themeStore.themeForm
+
+onMounted(() => {
+  themeStore.initializeThemeFormIfNeeded()
+})
+
+const colorKeys = computed(() => themeStore.colorKeys)
+
+const applyAfterSave = computed({
+  get: () => themeStore.applyAfterSave,
+  set: (value: boolean) => themeStore.setApplyAfterSave(value),
+})
+
+const updateMode = computed(() => Boolean(themeForm.id))
+
+const trimmedName = computed(() => themeForm.name?.trim() || '')
+
+function getSafeThemeValues(val: unknown): Record<string, string> {
+  return typeof val === 'object' && val !== null && !Array.isArray(val)
+    ? (val as Record<string, string>)
+    : {}
+}
+
+function onColorInput(event: Event, key: string) {
+  const value = (event.target as HTMLInputElement)?.value
+  if (!value) return
+  themeStore.setColorValue(key, value)
+}
+
+function resetTheme() {
+  themeError.value = ''
+  themeStore.resetThemeForm()
+}
+
+function randomizeTheme() {
+  themeError.value = ''
+  themeStore.fillWithRandomTheme()
+}
+
+const previewStyleObject = computed<Record<string, string>>(() => {
+  const values = getSafeThemeValues(themeForm.values)
+  const style: Record<string, string> = {
+    backgroundColor: values['base-100'] || '#ffffff',
+    color: values.neutral || '#111111',
+  }
+
+  for (const [key, value] of Object.entries(values)) {
+    style[`--${convertToDaisyVar(key)}`] = hexToRgb(value)
+  }
+
+  return style
+})
+
+function convertToDaisyVar(key: string) {
+  const map: Record<string, string> = {
+    primary: 'p',
+    secondary: 's',
+    accent: 'a',
+    neutral: 'n',
+    'base-100': 'b1',
+    'base-200': 'b2',
+    'base-300': 'b3',
+    info: 'in',
+    success: 'su',
+    warning: 'wa',
+    error: 'er',
+  }
+
+  return map[key] || key
+}
+
+function hexToRgb(hex: string) {
+  const clean = hex.replace('#', '')
+  const bigint = Number.parseInt(clean, 16)
+  const r = (bigint >> 16) & 255
+  const g = (bigint >> 8) & 255
+  const b = bigint & 255
+  return `${r} ${g} ${b}`
+}
+
+function getPreviewCardStyle(values: Record<string, string>) {
+  const style: Record<string, string> = {}
+
+  for (const [key, value] of Object.entries(values)) {
+    style[`--${convertToDaisyVar(key)}`] = hexToRgb(value)
+  }
+
+  style.padding = '1rem'
+  return style
+}
+
+async function applyBuiltInTheme(theme: string) {
+  const result = await themeStore.setActiveTheme(theme)
+  themeError.value = result.success
+    ? ''
+    : result.message || 'Failed to apply theme'
+
+  if (result.success) {
+    achievementStore.rewardAchievementByCode('theme')
+  }
+}
+
+async function applySharedTheme(theme: Theme) {
+  const result = await themeStore.setActiveTheme({
+    id: theme.id,
+    userId: theme.userId,
+    name: theme.name,
+    prefersDark: theme.prefersDark,
+    colorScheme: theme.colorScheme,
+    isPublic: theme.isPublic,
+    tagline: theme.tagline,
+    room: theme.room || '',
+    values: getSafeThemeValues(theme.values),
+  })
+
+  themeError.value = result.success
+    ? ''
+    : result.message || 'Failed to apply theme'
+
+  if (result.success) {
+    achievementStore.rewardAchievementByCode('theme')
+  }
+}
+
+async function applyPreviewTheme() {
+  if (!trimmedName.value) {
+    themeError.value = 'Give your theme a name first.'
+    return
+  }
+
+  isApplyingPreview.value = true
+  themeError.value = ''
+
+  try {
+    const result = await themeStore.setActiveTheme({
+      id: themeForm.id,
+      userId: themeForm.userId,
+      name: trimmedName.value,
+      prefersDark: themeForm.prefersDark ?? false,
+      colorScheme: themeForm.colorScheme || 'light',
+      isPublic: themeForm.isPublic ?? false,
+      tagline: themeForm.tagline || null,
+      room: themeForm.room || '',
+      values: getSafeThemeValues(themeForm.values),
+    })
+
+    themeError.value = result.success
+      ? ''
+      : result.message || 'Failed to preview theme'
+
+    if (result.success) {
+      achievementStore.rewardAchievementByCode('theme')
+    }
+  } catch (error: unknown) {
+    themeError.value =
+      error instanceof Error ? error.message : 'Failed to preview theme'
+  } finally {
+    isApplyingPreview.value = false
+  }
+}
+
+async function saveTheme() {
+  if (!trimmedName.value) {
+    themeError.value = 'Theme name is required.'
+    return
+  }
+
+  isSaving.value = true
+  themeError.value = ''
+
+  try {
+    themeForm.name = trimmedName.value
+
+    const payload = {
+      id: themeForm.id,
+      userId: themeForm.userId,
+      name: themeForm.name,
+      prefersDark: themeForm.prefersDark ?? false,
+      colorScheme: themeForm.colorScheme || 'light',
+      isPublic: themeForm.isPublic ?? false,
+      tagline: themeForm.tagline || null,
+      room: themeForm.room || '',
+      values: getSafeThemeValues(themeForm.values),
+    }
+
+    if (updateMode.value && themeForm.id) {
+      await themeStore.updateTheme(themeForm.id, payload)
+    } else {
+      await themeStore.addTheme(payload)
+    }
+
+    await themeStore.getThemes(true)
+
+    if (applyAfterSave.value) {
+      const result = await themeStore.setActiveTheme(payload)
+      themeError.value = result.success
+        ? ''
+        : result.message || 'Failed to apply saved theme'
+    }
+
+    achievementStore.rewardAchievementByCode('theme')
+    themeStore.resetThemeForm()
+  } catch (error: unknown) {
+    themeError.value =
+      error instanceof Error ? error.message : 'Theme save failed'
+  } finally {
+    isSaving.value = false
+  }
+}
+</script>

--- a/components/abandonware/themes/theme-card.vue
+++ b/components/abandonware/themes/theme-card.vue
@@ -1,0 +1,393 @@
+<!-- /components/content/themes/theme-card.vue -->
+<template>
+  <reactable-card
+    :selected="selected"
+    :compact="compact"
+    :show-reaction="false"
+    :target-title="themeName"
+    :card-class="cardClass"
+    :data-theme="previewThemeName"
+    @select="applyTheme"
+  >
+    <template #actions>
+      <button
+        v-if="showActions && canEdit"
+        class="rounded-full bg-base-100 p-2 text-warning shadow transition hover:bg-warning hover:text-warning-content"
+        type="button"
+        title="Edit Theme"
+        @click.stop="editTheme"
+      >
+        <Icon name="kind-icon:pencil" class="h-4 w-4" />
+      </button>
+
+      <button
+        v-if="showActions && allowCopy && !isDefaultTheme"
+        class="rounded-full bg-base-100 p-2 text-secondary shadow transition hover:bg-secondary hover:text-secondary-content"
+        type="button"
+        title="Copy Theme Values"
+        @click.stop="copyThemeValues"
+      >
+        <Icon name="kind-icon:copy" class="h-4 w-4" />
+      </button>
+    </template>
+
+    <div class="flex min-h-32 flex-col justify-between kr-panel-flat p-4">
+      <div class="flex items-start justify-between gap-3">
+        <div class="min-w-0">
+          <p
+            class="text-xs font-bold uppercase tracking-wide text-base-content/45"
+          >
+            {{ isDefaultTheme ? 'Default Theme' : 'Shared Theme' }}
+          </p>
+
+          <h2
+            class="mt-1 truncate font-black text-primary"
+            :class="compact ? 'text-lg' : 'text-2xl'"
+            :title="themeName"
+          >
+            {{ themeName }}
+          </h2>
+
+          <p
+            v-if="themeTagline"
+            class="mt-1 line-clamp-2 text-sm text-base-content/65"
+          >
+            {{ themeTagline }}
+          </p>
+        </div>
+
+        <div
+          class="grid h-14 w-14 shrink-0 grid-cols-2 overflow-hidden rounded-2xl border border-base-300"
+        >
+          <span class="bg-primary" />
+          <span class="bg-secondary" />
+          <span class="bg-accent" />
+          <span class="bg-base-300" />
+        </div>
+      </div>
+
+      <div class="mt-4 flex flex-wrap gap-2">
+        <span
+          class="badge badge-sm"
+          :class="isDefaultTheme ? 'badge-primary' : 'badge-secondary'"
+        >
+          {{ isDefaultTheme ? 'DaisyUI' : 'Custom' }}
+        </span>
+
+        <span
+          v-if="!isDefaultTheme"
+          class="badge badge-sm"
+          :class="themeObject?.isPublic ? 'badge-success' : 'badge-warning'"
+        >
+          {{ themeObject?.isPublic ? 'Public' : 'Private' }}
+        </span>
+
+        <span
+          v-if="themeObject?.prefersDark"
+          class="badge badge-sm badge-neutral"
+        >
+          Dark
+        </span>
+
+        <span v-if="selected" class="badge badge-sm badge-accent">
+          Active
+        </span>
+      </div>
+
+      <div v-if="showSwatches" class="mt-4 grid grid-cols-5 gap-2">
+        <div
+          v-for="swatch in swatches"
+          :key="swatch.label"
+          class="flex flex-col items-center gap-1"
+        >
+          <span
+            class="h-8 w-full rounded-xl border border-base-300"
+            :style="{ background: swatch.value }"
+          />
+
+          <span class="max-w-full truncate text-[10px] text-base-content/45">
+            {{ swatch.label }}
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-if="showMeta && !isDefaultTheme"
+      class="grid grid-cols-2 gap-2 kr-panel-flat p-3 text-xs"
+    >
+      <div>
+        <p class="font-bold uppercase text-base-content/45">Room</p>
+        <p class="truncate text-base-content/75">
+          {{ themeObject?.room || 'n/a' }}
+        </p>
+      </div>
+
+      <div>
+        <p class="font-bold uppercase text-base-content/45">Scheme</p>
+        <p class="truncate text-base-content/75">
+          {{ themeObject?.colorScheme || 'light' }}
+        </p>
+      </div>
+
+      <div>
+        <p class="font-bold uppercase text-base-content/45">User</p>
+        <p class="truncate text-base-content/75">
+          {{ themeObject?.userId ?? 'n/a' }}
+        </p>
+      </div>
+
+      <div>
+        <p class="font-bold uppercase text-base-content/45">ID</p>
+        <p class="truncate text-base-content/75">#{{ themeObject?.id }}</p>
+      </div>
+    </div>
+
+    <button
+      v-if="showApplyButton && allowApply"
+      class="btn btn-sm mt-auto rounded-xl"
+      :class="selected ? 'btn-primary text-white' : 'btn-outline'"
+      type="button"
+      @click.stop="applyTheme"
+    >
+      <Icon name="kind-icon:palette" class="h-4 w-4" />
+      {{ selected ? 'Active Theme' : 'Apply Theme' }}
+    </button>
+
+    <div
+      v-if="localMessage"
+      class="rounded-2xl border p-3 text-sm"
+      :class="
+        localTone === 'error'
+          ? 'border-error/40 bg-error/10 text-error'
+          : 'border-success/40 bg-success/10 text-success'
+      "
+    >
+      {{ localMessage }}
+    </div>
+
+    <details v-if="showDebug" class="kr-panel-flat p-2" @click.stop>
+      <summary class="cursor-pointer text-xs font-bold text-base-content/70">
+        Debug
+      </summary>
+
+      <pre class="mt-2 max-h-48 overflow-auto text-xs text-base-content/70">{{
+        JSON.stringify(debugPayload, null, 2)
+      }}</pre>
+    </details>
+  </reactable-card>
+</template>
+
+<script setup lang="ts">
+// /components/content/themes/theme-card.vue
+import { computed, ref } from 'vue'
+import { useThemeStore, type Theme } from '@/stores/themeStore'
+import { useUserStore } from '@/stores/userStore'
+
+const props = withDefaults(
+  defineProps<{
+    theme: string | Theme
+    selected?: boolean
+    compact?: boolean
+    showActions?: boolean
+    showApplyButton?: boolean
+    showSwatches?: boolean
+    showMeta?: boolean
+    showDebug?: boolean
+    allowEdit?: boolean
+    allowCopy?: boolean
+    allowApply?: boolean
+  }>(),
+  {
+    selected: false,
+    compact: false,
+    showActions: true,
+    showApplyButton: true,
+    showSwatches: true,
+    showMeta: true,
+    showDebug: false,
+    allowEdit: true,
+    allowCopy: true,
+    allowApply: true,
+  },
+)
+
+const emit = defineEmits<{
+  applied: [name: string, snapshot: unknown]
+  edit: [theme: Theme]
+  copied: [values: string]
+  error: [message: string]
+}>()
+
+const themeStore = useThemeStore()
+const userStore = useUserStore()
+
+const localMessage = ref('')
+const localTone = ref<'success' | 'error'>('success')
+
+const isDefaultTheme = computed(() => {
+  return typeof props.theme === 'string'
+})
+
+const themeObject = computed<Theme | null>(() => {
+  return typeof props.theme === 'string' ? null : props.theme
+})
+
+const themeName = computed(() => {
+  return typeof props.theme === 'string' ? props.theme : props.theme.name
+})
+
+const previewThemeName = computed(() => {
+  return themeObject.value?.id
+    ? `custom-preview-${themeObject.value.id}`
+    : themeName.value
+})
+
+const themeTagline = computed(() => {
+  if (typeof props.theme === 'string') {
+    return 'Built-in DaisyUI theme.'
+  }
+
+  return props.theme.tagline || props.theme.room || 'Custom Kind Robots theme.'
+})
+
+const canEdit = computed(() => {
+  if (!props.allowEdit || isDefaultTheme.value || !themeObject.value) {
+    return false
+  }
+
+  return userStore.isAdmin || themeObject.value.userId === userStore.userId
+})
+
+const cardClass = computed(() => {
+  return props.selected ? 'ring-2 ring-primary/30' : ''
+})
+
+const themeValues = computed(() => {
+  if (typeof props.theme === 'string') return {}
+  return safeThemeValues(props.theme.values)
+})
+
+const swatches = computed(() => {
+  const values = themeValues.value
+
+  return [
+    {
+      label: 'primary',
+      value: values.primary || 'oklch(var(--p))',
+    },
+    {
+      label: 'secondary',
+      value: values.secondary || 'oklch(var(--s))',
+    },
+    {
+      label: 'accent',
+      value: values.accent || 'oklch(var(--a))',
+    },
+    {
+      label: 'base',
+      value: values['base-100'] || 'oklch(var(--b1))',
+    },
+    {
+      label: 'content',
+      value: values['base-content'] || 'oklch(var(--bc))',
+    },
+  ]
+})
+
+const debugPayload = computed(() => {
+  return {
+    theme: props.theme,
+    themeName: themeName.value,
+    previewThemeName: previewThemeName.value,
+    values: themeValues.value,
+  }
+})
+
+function safeThemeValues(value: unknown): Record<string, string> {
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value)
+
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as Record<string, string>)
+        : {}
+    } catch {
+      return {}
+    }
+  }
+
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, string>)
+    : {}
+}
+
+function toThemeInput(theme: string | Theme) {
+  if (typeof theme === 'string') return theme
+
+  return {
+    name: theme.name,
+    prefersDark: theme.prefersDark,
+    colorScheme: theme.colorScheme,
+    isPublic: theme.isPublic,
+    room: theme.room || '',
+    values: safeThemeValues(theme.values),
+  }
+}
+
+async function applyTheme() {
+  if (!props.allowApply) return
+  localMessage.value = ''
+
+  try {
+    const result = await themeStore.setActiveTheme(toThemeInput(props.theme))
+
+    if (!result.success) {
+      throw new Error(result.message || 'Failed to apply theme.')
+    }
+
+    const snapshot =
+      typeof props.theme === 'string'
+        ? await themeStore.getActiveThemeSnapshot(props.theme)
+        : themeStore.themeForm
+
+    localTone.value = 'success'
+    localMessage.value = 'Theme applied.'
+    emit('applied', themeName.value, snapshot)
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Failed to apply theme.'
+
+    localTone.value = 'error'
+    localMessage.value = message
+    emit('error', message)
+  }
+}
+
+function editTheme() {
+  if (!themeObject.value) return
+
+  themeStore.themeForm = {
+    id: themeObject.value.id,
+    name: themeObject.value.name,
+    prefersDark: themeObject.value.prefersDark,
+    colorScheme: themeObject.value.colorScheme,
+    isPublic: themeObject.value.isPublic,
+    room: themeObject.value.room || '',
+    values: safeThemeValues(themeObject.value.values),
+  }
+
+  localMessage.value = ''
+  emit('edit', themeObject.value)
+}
+
+async function copyThemeValues() {
+  if (!props.allowCopy) return
+  const values = JSON.stringify(themeValues.value, null, 2)
+
+  await navigator.clipboard.writeText(values)
+  localTone.value = 'success'
+  localMessage.value = 'Theme values copied.'
+  emit('copied', values)
+}
+</script>

--- a/components/abandonware/themes/theme-lab.vue
+++ b/components/abandonware/themes/theme-lab.vue
@@ -1,0 +1,257 @@
+<!-- /components/content/themes/theme-lab.vue -->
+<template>
+  <section
+    class="bg-base-200 border border-base-content p-6 rounded-2xl shadow-lg"
+  >
+    <h2 class="text-2xl font-semibold mb-4">Create or Edit Your Theme</h2>
+
+    <!-- Color Inputs -->
+    <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+      <div
+        v-for="color in colorKeys"
+        :key="color"
+        class="relative group w-full h-12 rounded-md overflow-hidden border border-base-content"
+      >
+        <input
+          type="color"
+          :id="`color-${color}`"
+          :value="themeForm.values?.[color] || '#ffffff'"
+          @input="onColorInput($event, color)"
+          class="w-full h-full appearance-none cursor-pointer bg-transparent"
+        />
+
+        <span
+          class="absolute bottom-0 left-0 w-full bg-base-300/80 text-xs text-center text-base-content py-0.5 font-medium capitalize truncate pointer-events-none"
+        >
+          {{ labelFromKey(color) }}
+        </span>
+      </div>
+    </div>
+
+    <button class="btn btn-accent mt-4" @click="fillWithRandomTheme">
+      🎲 Randomize Theme
+    </button>
+
+    <!-- Extra Vars -->
+    <div class="mt-6 grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <label
+        for="prefers-dark"
+        class="flex gap-2 items-center text-sm font-medium"
+      >
+        <input
+          id="prefers-dark"
+          type="checkbox"
+          class="toggle"
+          v-model="themeForm.prefersDark"
+        />
+        <span>Prefers dark mode</span>
+      </label>
+
+      <label
+        v-for="key in extraVars"
+        :key="key"
+        class="flex flex-col gap-1 text-sm font-medium"
+        :for="`input-${key}`"
+      >
+        <span>{{ key.replace('--', '') }}</span>
+
+        <div v-if="isSliderKey(key)" class="w-full">
+          <input
+            type="range"
+            class="range range-sm"
+            :id="`input-${key}`"
+            :min="getSliderMeta(key).min"
+            :max="getSliderMeta(key).max"
+            :step="getSliderMeta(key).step"
+            v-bind="vModelBinding(key)"
+          />
+          <div class="text-xs text-right text-base-content/70">
+            {{ bindValue(key).value }}
+          </div>
+        </div>
+
+        <input
+          v-else
+          type="text"
+          class="input input-bordered w-full h-10"
+          :id="`input-${key}`"
+          placeholder="e.g. 1rem or 0"
+          v-bind="vModelBinding(key)"
+        />
+      </label>
+
+      <input
+        v-model="themeForm.name"
+        id="input-theme-name"
+        placeholder="Theme name"
+        class="input input-bordered text-center"
+      />
+
+      <button @click="saveTheme" class="btn btn-primary">
+        {{ updateMode ? 'Update Theme' : 'Save Theme' }}
+      </button>
+
+      <p
+        v-if="themeError"
+        class="mt-4 p-3 text-sm text-error bg-error/10 border border-error rounded-xl"
+      >
+        {{ themeError }}
+      </p>
+    </div>
+
+    <!-- Toggles -->
+    <div
+      class="form-control col-span-1 sm:col-span-3 flex flex-col sm:flex-row gap-4 items-center mt-6"
+    >
+      <label for="apply-after-save" class="label gap-2">
+        <input
+          id="apply-after-save"
+          type="checkbox"
+          class="toggle"
+          v-model="applyAfterSave"
+        />
+        <span class="label-text">Apply after saving</span>
+      </label>
+
+      <label for="theme-is-public" class="label gap-2">
+        <input
+          id="theme-is-public"
+          type="checkbox"
+          class="toggle"
+          v-model="themeForm.isPublic"
+        />
+        <span class="label-text">Make this theme public</span>
+      </label>
+
+      <label for="use-page-themes" class="label gap-2">
+        <input
+          id="use-page-themes"
+          type="checkbox"
+          class="toggle"
+          v-model="useCustom"
+        />
+        <span class="label-text">Use page themes (showCustom)</span>
+      </label>
+    </div>
+
+    <button class="btn btn-outline mt-4" @click="resetThemeForm">Reset</button>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useThemeStore } from '@/stores/themeStore'
+
+const themeStore = useThemeStore()
+const themeForm = themeStore.themeForm
+const themeError = ref('')
+
+onMounted(() => {
+  themeStore.initializeThemeFormIfNeeded()
+})
+
+const colorKeys = computed(() => themeStore.colorKeys)
+const extraVars = computed(() => themeStore.extraVars)
+const { labelFromKey, isValidColor } = useThemeStore()
+
+const updateMode = computed(() => !!themeForm.id)
+
+const applyAfterSave = computed({
+  get: () => themeStore.applyAfterSave,
+  set: (val: boolean) => themeStore.setApplyAfterSave(val),
+})
+
+const useCustom = computed({
+  get: () => themeStore.showCustom,
+  set: (val: boolean) => themeStore.setShowCustom(val),
+})
+
+watch(
+  () => themeForm.prefersDark,
+  (val) => {
+    themeForm.colorScheme = val ? 'dark' : 'light'
+  },
+)
+
+function bindValue(key: string) {
+  return computed({
+    get: () => themeForm.values?.[key] ?? '',
+    set: (val) => {
+      if (themeForm.values) themeForm.values[key] = val
+    },
+  })
+}
+
+function vModelBinding(key: string) {
+  const model = bindValue(key)
+  return {
+    get modelValue() {
+      return model.value
+    },
+    set modelValue(val: any) {
+      model.value = val
+    },
+  }
+}
+
+function getSliderMeta(key: string) {
+  if (key.includes('radius')) return { min: 0, max: 3, step: 0.05 }
+  if (key.includes('size')) return { min: 0.5, max: 3, step: 0.1 }
+  if (key === '--depth') return { min: 0, max: 3, step: 1 }
+  if (key === '--border') return { min: 0, max: 4, step: 1 }
+  if (key === '--noise') return { min: 0, max: 100, step: 1 }
+  return { min: 0, max: 1, step: 0.1 }
+}
+
+function isSliderKey(key: string) {
+  return (
+    ['--depth', '--noise', '--border'].includes(key) ||
+    key.includes('radius') ||
+    key.includes('size')
+  )
+}
+
+const fillWithRandomTheme = () =>
+  themeStore.fillThemeWithRandomColors(themeForm)
+
+const resetThemeForm = () => themeStore.resetThemeForm()
+
+function onColorInput(e: Event, key: string) {
+  const value = (e.target as HTMLInputElement)?.value
+  if (value) themeStore.setColorValue(key, value)
+}
+
+async function saveTheme() {
+  if (!themeForm.name) return
+  try {
+    const payload = themeStore.buildThemePayload(themeForm)
+
+    if (updateMode.value) {
+      await themeStore.updateTheme(themeForm.id!, payload)
+    } else {
+      await themeStore.addTheme(payload)
+    }
+
+    if (applyAfterSave.value) {
+      const result = await themeStore.setActiveTheme({
+        id: themeForm.id,
+        userId: themeForm.userId,
+        name: themeForm.name,
+        prefersDark: themeForm.prefersDark,
+        colorScheme: themeForm.colorScheme,
+        isPublic: themeForm.isPublic,
+        tagline: themeForm.tagline,
+        room: themeForm.room || '',
+        values: themeForm.values || {},
+      })
+
+      themeError.value = result.success ? '' : result.message || 'Unknown error'
+    }
+
+    themeStore.resetThemeForm()
+  } catch (e) {
+    console.error('Theme save failed', e)
+    themeError.value = 'Theme save failed: ' + String(e)
+  }
+}
+</script>

--- a/components/abandonware/themes/theme-manager.vue
+++ b/components/abandonware/themes/theme-manager.vue
@@ -1,0 +1,221 @@
+<!-- /components/content/themes/theme-manager.vue -->
+<template>
+  <section class="flex h-full min-h-0 flex-col gap-4 overflow-hidden">
+    <div class="flex shrink-0 flex-wrap items-center justify-end gap-2">
+      <span
+        v-if="themeStore.currentTheme"
+        class="flex items-center gap-1.5 rounded-full border border-amber-500 px-2.5 py-1 font-mono text-xs text-amber-500"
+      >
+        <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-amber-500" />
+        {{ themeStore.currentTheme }}
+      </span>
+
+      <span class="badge badge-neutral">{{ allThemeCount }} themes</span>
+
+      <button
+        class="btn btn-ghost btn-sm rounded-xl"
+        type="button"
+        :disabled="isLoadingManager"
+        @click="refreshManagerData"
+      >
+        <span
+          v-if="isLoadingManager"
+          class="loading loading-spinner loading-xs"
+        />
+        <Icon v-else name="kind-icon:refresh" class="size-4" />
+        Refresh
+      </button>
+    </div>
+
+    <div
+      v-if="managerError"
+      class="shrink-0 rounded-2xl border border-error/40 bg-error/10 p-4 text-error"
+    >
+      {{ managerError }}
+    </div>
+
+    <div
+      v-if="isLoadingManager"
+      class="shrink-0 rounded-2xl border border-base-300 bg-base-200 p-4"
+    >
+      <span class="loading loading-spinner loading-sm" />
+      <span class="ml-2">Loading themes...</span>
+    </div>
+
+    <theme-gallery
+      v-if="activeTab === 'gallery'"
+      class="min-h-0 flex-1"
+      @edit="setTab('custom')"
+    />
+
+    <section
+      v-else-if="activeTab === 'custom'"
+      class="flex min-h-0 flex-1 flex-col overflow-hidden kr-panel-flat"
+    >
+      <div
+        class="flex shrink-0 flex-wrap items-center justify-between gap-4 border-b border-base-300 bg-base-200 px-5 py-3"
+      >
+        <div class="flex items-center gap-2.5">
+          <span class="font-mono text-xs uppercase tracking-widest opacity-50">
+            {{ themeStore.themeForm.id ? 'Editing' : 'Creating new theme' }}
+          </span>
+
+          <span
+            v-if="themeStore.themeForm.id && themeStore.themeForm.name"
+            class="text-sm font-bold text-amber-500"
+          >
+            {{ themeStore.themeForm.name }}
+          </span>
+        </div>
+
+        <div class="flex items-center gap-2">
+          <button
+            v-if="themeStore.themeForm.id"
+            class="btn btn-ghost btn-xs rounded-xl"
+            type="button"
+            @click="newTheme"
+          >
+            New theme instead
+          </button>
+
+          <select
+            class="select select-bordered select-sm rounded-xl bg-base-100 focus:border-amber-500"
+            @change="onForgeSelect"
+          >
+            <option value="">Edit existing theme</option>
+
+            <option
+              v-for="theme in themeStore.sharedThemes"
+              :key="theme.id"
+              :value="theme.id"
+            >
+              {{ theme.name }}
+            </option>
+          </select>
+        </div>
+      </div>
+
+      <div class="min-h-0 flex-1 overflow-y-auto">
+        <add-theme :key="forgeKey" />
+      </div>
+    </section>
+
+    <div
+      v-else
+      class="rounded-2xl border border-warning/40 bg-warning/10 p-4 text-warning"
+    >
+      Unknown theme tab: {{ activeTab }}
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useNavStore } from '@/stores/navStore'
+import { useThemeStore, type Theme } from '@/stores/themeStore'
+
+type ThemeTab = 'gallery' | 'custom'
+
+const dashboardKey = 'theme' as const
+const fallbackTab: ThemeTab = 'gallery'
+const validTabs: ThemeTab[] = ['gallery', 'custom']
+
+const navStore = useNavStore()
+const themeStore = useThemeStore()
+
+const isLoadingManager = ref(false)
+const managerError = ref<string | null>(null)
+const forgeKey = ref(0)
+
+const activeTab = computed<ThemeTab>(() => {
+  const selectedTab = navStore.getDashboardTab(dashboardKey)
+
+  return validTabs.includes(selectedTab as ThemeTab)
+    ? (selectedTab as ThemeTab)
+    : fallbackTab
+})
+
+const allThemeCount = computed(() => {
+  return (
+    (themeStore.daisyuiThemes?.length ?? 0) +
+    (themeStore.sharedThemes?.length ?? 0)
+  )
+})
+
+function setTab(tab: ThemeTab) {
+  navStore.setDashboardTab(dashboardKey, tab)
+}
+
+function safeThemeValues(value: unknown): Record<string, string> {
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value)
+
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as Record<string, string>)
+        : {}
+    } catch {
+      return {}
+    }
+  }
+
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, string>)
+    : {}
+}
+
+async function refreshManagerData() {
+  isLoadingManager.value = true
+  managerError.value = null
+
+  try {
+    await themeStore.getThemes()
+  } catch (error) {
+    managerError.value =
+      error instanceof Error ? error.message : 'Failed to refresh themes.'
+  } finally {
+    isLoadingManager.value = false
+  }
+}
+
+function loadThemeIntoForm(theme: Theme) {
+  themeStore.themeForm = {
+    id: theme.id,
+    name: theme.name,
+    prefersDark: theme.prefersDark,
+    colorScheme: theme.colorScheme,
+    isPublic: theme.isPublic,
+    tagline: theme.tagline,
+    room: theme.room ?? '',
+    values: safeThemeValues(theme.values),
+  }
+
+  forgeKey.value++
+}
+
+function newTheme() {
+  themeStore.resetThemeForm()
+  forgeKey.value++
+}
+
+function onForgeSelect(event: Event) {
+  const target = event.target as HTMLSelectElement
+  const id = Number(target.value)
+
+  if (!id) return
+
+  const theme = themeStore.sharedThemes.find((item: Theme) => {
+    return item.id === id
+  })
+
+  if (theme) {
+    loadThemeIntoForm(theme)
+  }
+
+  target.value = ''
+}
+
+onMounted(async () => {
+  await Promise.all([navStore.initialize(), refreshManagerData()])
+})
+</script>

--- a/components/abandonware/user/avatar-image.vue
+++ b/components/abandonware/user/avatar-image.vue
@@ -1,0 +1,161 @@
+<!-- /components/content/story/avatar-image.vue -->
+<template>
+  <div v-if="hydrated" class="relative h-full w-full">
+    <div class="flip-card h-full w-full" @click.stop="handleAvatarClick">
+      <div class="flip-card-inner" :class="{ 'is-flipped': flipped }">
+        <div class="flip-card-front">
+          <img
+            v-if="resolvedImage"
+            :src="resolvedImage"
+            alt="Avatar"
+            class="h-full w-full object-cover shadow-lg hover:shadow-xl"
+            draggable="false"
+            @error="resolvedImage = null"
+          />
+          <div
+            v-else
+            class="flex h-full w-full items-center justify-center bg-base-300"
+          >
+            <Icon name="kind-icon:person" class="h-full w-full text-accent" />
+          </div>
+        </div>
+        <div class="flip-card-back">
+          <img
+            v-if="resolvedImage"
+            :src="resolvedImage"
+            alt="Avatar back"
+            class="h-full w-full object-cover shadow-lg hover:shadow-xl"
+            draggable="false"
+            @error="resolvedImage = null"
+          />
+          <div
+            v-else
+            class="flex h-full w-full items-center justify-center bg-base-300"
+          >
+            <Icon name="kind-icon:person" class="h-full w-full text-accent" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue'
+import { useUserStore } from '@/stores/userStore'
+import { useArtStore } from '@/stores/artStore'
+import { useErrorStore, ErrorType } from '@/stores/errorStore'
+import type { ArtImage } from '~/prisma/generated/prisma/client'
+
+const flipped = ref(false)
+const hydrated = ref(false)
+const resolvedImage = ref<string | null>(null)
+
+const userStore = useUserStore()
+const artStore = useArtStore()
+const errorStore = useErrorStore()
+
+const FALLBACK = '/images/kindart.webp'
+
+function looksLikeBase64(value: string): boolean {
+  const compact = value.replace(/\s+/g, '')
+  return compact.length >= 64 && compact.length % 4 === 0 && /^[A-Za-z0-9+/]+={0,2}$/.test(compact)
+}
+
+function asImageSource(value?: string | null): string {
+  const clean = value?.trim() || ''
+  if (!clean || clean === 'undefined' || clean === 'UNDEFINED') return ''
+  if (clean.startsWith('data:image/')) return clean
+  if (clean.startsWith('http://') || clean.startsWith('https://') || clean.startsWith('/')) return clean
+  if (clean.startsWith('./') || clean.startsWith('images/') || /\.(png|jpe?g|webp|gif|avif|svg)$/i.test(clean)) {
+    return `/${clean.replace(/^\/+/, '').replace(/^\.\//, '')}`
+  }
+  return looksLikeBase64(clean) ? `data:image/png;base64,${clean}` : ''
+}
+
+function imageSourceFromArt(image?: ArtImage | null): string {
+  return (
+    asImageSource(image?.imageData) ||
+    asImageSource(image?.imagePath) ||
+    asImageSource(image?.path) ||
+    asImageSource(image?.thumbnailData)
+  )
+}
+
+async function fetchAvatar() {
+  const user = userStore.user
+  if (!user) {
+    resolvedImage.value = null
+    return
+  }
+
+  if (user.artImageId) {
+    const image = await artStore.getArtImageById(user.artImageId, {
+      includeImageData: true,
+      includeThumbnailData: true,
+    })
+    const source = imageSourceFromArt(image) || asImageSource(user.avatarImage)
+    resolvedImage.value = source && source !== FALLBACK ? source : null
+    return
+  }
+
+  const source = asImageSource(user.avatarImage)
+  resolvedImage.value = source && source !== FALLBACK ? source : null
+}
+
+watch(
+  () => [userStore.user?.id, userStore.user?.artImageId, userStore.user?.avatarImage],
+  () => {
+    void fetchAvatar()
+  },
+)
+
+onMounted(async () => {
+  hydrated.value = true
+  await fetchAvatar()
+})
+
+function handleAvatarClick() {
+  try {
+    flipped.value = !flipped.value
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to toggle'
+    errorStore.setError(ErrorType.INTERACTION_ERROR, message)
+  }
+}
+</script>
+
+<style scoped>
+.flip-card {
+  width: 100%;
+  height: 100%;
+  perspective: 1000px;
+  cursor: pointer;
+}
+
+.flip-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.6s ease-in-out;
+  transform-style: preserve-3d;
+}
+
+.flip-card-inner.is-flipped {
+  transform: rotateY(180deg);
+}
+
+.flip-card-front,
+.flip-card-back {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  backface-visibility: hidden;
+  border-radius: 1rem;
+  overflow: hidden;
+}
+
+.flip-card-back {
+  transform: rotateY(180deg);
+}
+</style>

--- a/components/abandonware/user/chat-card.vue
+++ b/components/abandonware/user/chat-card.vue
@@ -1,0 +1,474 @@
+<!-- /components/content/user/chat-card.vue -->
+<template>
+  <reactable-card
+    :selected="activeSelected"
+    :compact="compact"
+    :show-reaction="showReaction"
+    :target-id="chat.id"
+    target-type="chat"
+    reaction-category="CHAT_EXCHANGE"
+    :target-title="reactionTitle"
+    @select="selectChat"
+  >
+    <template #actions>
+      <button
+        v-if="showActions && canDelete && (activeSelected || compact)"
+        class="rounded-full bg-base-100 p-2 text-error shadow transition hover:bg-error hover:text-error-content"
+        type="button"
+        title="Delete Chat"
+        @click.stop="deleteChat"
+      >
+        <Icon name="kind-icon:trash" class="h-4 w-4" />
+      </button>
+    </template>
+
+    <header class="flex items-start gap-4">
+      <user-avatar
+        v-if="userId"
+        :user-id="userId"
+        class="h-12 w-12 shrink-0 rounded-full border border-base-300"
+      />
+
+      <div
+        v-else
+        class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-base-300 bg-base-100 text-base-content/45"
+      >
+        <Icon name="kind-icon:person" class="h-6 w-6" />
+      </div>
+
+      <div class="min-w-0 flex-1">
+        <div class="flex flex-wrap items-center gap-2">
+          <h2 class="truncate text-lg font-black text-base-content">
+            {{ senderName }}
+          </h2>
+
+          <span class="text-xs font-bold uppercase text-base-content/40">
+            to
+          </span>
+
+          <span class="truncate text-lg font-black text-primary">
+            {{ botName }}
+          </span>
+        </div>
+
+        <p class="mt-1 text-xs text-base-content/50">
+          {{ formattedDate }}
+        </p>
+
+        <div class="mt-2 flex flex-wrap gap-2">
+          <span v-if="chat.type" class="badge badge-outline badge-sm">
+            {{ chat.type }}
+          </span>
+
+          <span v-if="chat.isPublic" class="badge badge-success badge-sm">
+            Public
+          </span>
+
+          <span v-else class="badge badge-warning badge-sm"> Private </span>
+
+          <span v-if="chat.botId" class="badge badge-primary badge-sm">
+            Bot #{{ chat.botId }}
+          </span>
+
+          <span v-if="activeSelected" class="badge badge-accent badge-sm">
+            Selected
+          </span>
+        </div>
+      </div>
+
+      <img
+        v-if="hasBot"
+        :src="botImage || '/images/bot.webp'"
+        :alt="botName"
+        class="h-12 w-12 shrink-0 rounded-full border-2 border-secondary object-cover"
+      />
+    </header>
+
+    <section class="kr-panel-flat p-3">
+      <div class="mb-2 flex items-center justify-between gap-2">
+        <p
+          class="text-xs font-bold uppercase tracking-wide text-base-content/45"
+        >
+          Thread
+        </p>
+
+        <span class="badge badge-ghost badge-sm">
+          {{ threadMessages.length }}
+        </span>
+      </div>
+
+      <div
+        v-if="threadMessages.length"
+        class="flex max-h-72 flex-col gap-2 overflow-y-auto pr-1"
+      >
+        <article
+          v-for="message in threadMessages"
+          :key="message.id"
+          class="flex gap-3 rounded-2xl p-3"
+          :class="messageClass(message)"
+        >
+          <user-avatar
+            v-if="message.userId"
+            :user-id="message.userId"
+            class="h-8 w-8 shrink-0 rounded-full border border-base-300"
+          />
+
+          <div
+            v-else
+            class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-base-300 bg-base-100"
+          >
+            <Icon name="kind-icon:person" class="h-4 w-4" />
+          </div>
+
+          <div class="min-w-0 flex-1">
+            <p class="text-xs font-black">
+              {{ message.sender || senderName }}
+            </p>
+
+            <p class="mt-1 whitespace-pre-wrap text-sm leading-relaxed">
+              {{ message.content }}
+            </p>
+          </div>
+        </article>
+      </div>
+
+      <div
+        v-else
+        class="rounded-2xl border border-base-300 bg-base-200 p-4 text-center text-sm text-base-content/50"
+      >
+        No thread messages found.
+      </div>
+    </section>
+
+    <section class="rounded-2xl border border-accent/30 bg-accent/10 p-4">
+      <div class="mb-3 flex items-center gap-3">
+        <img
+          v-if="hasBot"
+          :src="botImage || '/images/bot.webp'"
+          :alt="botName"
+          class="h-10 w-10 shrink-0 rounded-full border-2 border-secondary object-cover"
+        />
+
+        <div>
+          <p class="text-sm font-black text-base-content">Bot Response</p>
+
+          <p class="text-xs text-base-content/50">
+            {{ botName }}
+          </p>
+        </div>
+      </div>
+
+      <p
+        class="whitespace-pre-wrap text-sm leading-relaxed text-base-content/80"
+      >
+        {{ botResponse }}
+      </p>
+    </section>
+
+    <Transition name="reply-expand">
+      <section v-if="showReply" class="kr-panel-flat p-3">
+        <label class="form-control">
+          <span class="label">
+            <span class="label-text font-bold"> Continue this exchange </span>
+          </span>
+
+          <textarea
+            v-model="replyMessage"
+            class="textarea textarea-bordered min-h-28 w-full resize-none bg-base-200"
+            placeholder="Type your reply here..."
+            :disabled="isReplying"
+            @keydown.enter.exact.prevent="sendReply"
+          />
+        </label>
+
+        <div class="mt-3 flex justify-end gap-2">
+          <button
+            class="btn btn-ghost rounded-xl"
+            type="button"
+            :disabled="isReplying"
+            @click="toggleReply"
+          >
+            Cancel
+          </button>
+
+          <button
+            class="btn btn-primary rounded-xl text-white"
+            type="button"
+            :disabled="isReplying || !replyMessage.trim()"
+            @click="sendReply"
+          >
+            <span
+              v-if="isReplying"
+              class="loading loading-spinner loading-sm"
+            />
+
+            Send Reply
+          </button>
+        </div>
+      </section>
+    </Transition>
+
+    <footer class="flex flex-wrap justify-end gap-2">
+      <button
+        class="btn btn-secondary btn-sm rounded-xl"
+        type="button"
+        @click.stop="toggleReply"
+      >
+        <Icon name="kind-icon:message" class="h-4 w-4" />
+        {{ showReply ? 'Hide Reply' : 'Continue' }}
+      </button>
+    </footer>
+
+    <div
+      v-if="statusMessage"
+      class="rounded-2xl border p-3 text-sm"
+      :class="
+        statusTone === 'error'
+          ? 'border-error/40 bg-error/10 text-error'
+          : 'border-success/40 bg-success/10 text-success'
+      "
+    >
+      {{ statusMessage }}
+    </div>
+  </reactable-card>
+</template>
+
+<script setup lang="ts">
+// /components/content/user/chat-card.vue
+import { computed, ref, watch } from 'vue'
+import { useChatStore, type Chat } from '@/stores/chatStore'
+import { useUserStore } from '@/stores/userStore'
+import { useBotStore } from '@/stores/botStore'
+import { useArtStore } from '@/stores/artStore'
+
+const props = withDefaults(
+  defineProps<{
+    chat: Chat
+    selected?: boolean
+    compact?: boolean
+    showActions?: boolean
+    showReaction?: boolean
+    allowDelete?: boolean
+  }>(),
+  {
+    selected: false,
+    compact: false,
+    showActions: true,
+    showReaction: true,
+    allowDelete: true,
+  },
+)
+
+const chatStore = useChatStore()
+const userStore = useUserStore()
+const botStore = useBotStore()
+const artStore = useArtStore()
+
+const localSelected = ref(false)
+const showReply = ref(false)
+const replyMessage = ref('')
+const userImage = ref<string | undefined>(undefined)
+const botImage = ref<string | undefined>(undefined)
+const isReplying = ref(false)
+const statusMessage = ref('')
+const statusTone = ref<'success' | 'error'>('success')
+
+const chat = computed(() => props.chat)
+
+const activeSelected = computed(() => {
+  return props.selected || localSelected.value
+})
+
+const userId = computed(() => {
+  return chat.value.userId
+})
+
+const hasBot = computed(() => {
+  return Boolean(chat.value.botId)
+})
+
+const canDelete = computed(() => {
+  if (!props.allowDelete) return false
+
+  return userStore.isAdmin || chat.value.userId === userStore.userId
+})
+
+const threadMessages = computed(() => {
+  return chatStore.chats.filter((message) => {
+    return message.originId === chat.value.id || message.id === chat.value.id
+  })
+})
+
+const formattedDate = computed(() => {
+  return chat.value.createdAt
+    ? new Date(chat.value.createdAt).toLocaleString()
+    : 'Unknown Date'
+})
+
+const botResponse = computed(() => {
+  return chat.value.botResponse || 'Awaiting response...'
+})
+
+const senderName = computed(() => {
+  return chat.value.sender || userStore.username || 'User'
+})
+
+const botName = computed(() => {
+  return chat.value.botName || 'Bot'
+})
+
+const reactionTitle = computed(() => {
+  return `${senderName.value} → ${botName.value}`
+})
+
+function setStatus(message: string, tone: 'success' | 'error' = 'success') {
+  statusMessage.value = message
+  statusTone.value = tone
+}
+
+function selectChat() {
+  localSelected.value = true
+}
+
+function messageClass(message: Chat) {
+  const isSender = message.sender === chat.value.sender
+
+  return {
+    'flex-row-reverse bg-primary text-primary-content': isSender,
+    'flex-row bg-base-200 text-base-content': !isSender,
+  }
+}
+
+function toggleReply() {
+  showReply.value = !showReply.value
+}
+
+async function sendReply() {
+  const content = replyMessage.value.trim()
+
+  if (!content || isReplying.value) return
+
+  isReplying.value = true
+  statusMessage.value = ''
+
+  try {
+    const newChat = await chatStore.addChat({
+      content,
+      recipientId: chat.value.recipientId ?? 0,
+      isPublic: chat.value.isPublic,
+      originId: chat.value.originId ?? chat.value.id,
+      previousEntryId: chat.value.id,
+      botId: chat.value.botId ?? 0,
+      botName: chat.value.botName ?? '',
+      type: chat.value.type,
+      characterId: chat.value.characterId,
+    })
+
+    replyMessage.value = ''
+    showReply.value = false
+
+    if (newChat?.id && typeof chatStore.streamResponse === 'function') {
+      await chatStore.streamResponse(newChat.id)
+    }
+
+    setStatus('Reply sent.')
+  } catch (error) {
+    setStatus(
+      error instanceof Error ? error.message : 'Error sending reply.',
+      'error',
+    )
+  } finally {
+    isReplying.value = false
+  }
+}
+
+async function deleteChat() {
+  if (!canDelete.value) return
+
+  try {
+    await chatStore.deleteChat(chat.value.id)
+    setStatus('Chat deleted.')
+  } catch (error) {
+    setStatus(
+      error instanceof Error ? error.message : 'Error deleting chat.',
+      'error',
+    )
+  }
+}
+
+async function loadUserImage() {
+  if (!chat.value.userId || userImage.value) return
+
+  try {
+    const user = await userStore.getUserById(chat.value.userId)
+
+    if (!user) return
+
+    if (user.artImageId) {
+      const [artImage] = await artStore.getArtImagesByIds([user.artImageId])
+      userImage.value = artImage?.imageData || user.avatarImage || undefined
+      return
+    }
+
+    userImage.value = user.avatarImage || undefined
+  } catch (error) {
+    console.error('Error fetching user image:', error)
+  }
+}
+
+async function loadBotImage() {
+  if (!chat.value.botId || botImage.value) return
+
+  try {
+    const bot = await botStore.getBotById(chat.value.botId)
+
+    if (!bot) return
+
+    if (bot.artImageId) {
+      const [artImage] = await artStore.getArtImagesByIds([bot.artImageId])
+      botImage.value = artImage?.imageData || bot.avatarImage || undefined
+      return
+    }
+
+    botImage.value = bot.avatarImage || undefined
+  } catch (error) {
+    console.error('Error fetching bot image:', error)
+  }
+}
+
+watch(
+  () => [chat.value.userId, chat.value.botId],
+  async () => {
+    userImage.value = undefined
+    botImage.value = undefined
+
+    await Promise.all([loadUserImage(), loadBotImage()])
+  },
+  { immediate: true },
+)
+</script>
+
+<style scoped>
+.reply-expand-enter-active,
+.reply-expand-leave-active {
+  overflow: hidden;
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease,
+    max-height 0.2s ease;
+}
+
+.reply-expand-enter-from,
+.reply-expand-leave-to {
+  max-height: 0;
+  opacity: 0;
+  transform: translateY(-0.25rem);
+}
+
+.reply-expand-enter-to,
+.reply-expand-leave-from {
+  max-height: 24rem;
+  opacity: 1;
+  transform: translateY(0);
+}
+</style>

--- a/components/abandonware/user/chat-view.vue
+++ b/components/abandonware/user/chat-view.vue
@@ -1,0 +1,123 @@
+<!-- /components/content/user/chat-view.vue -->
+<template>
+  <div class="p-6 m-4 mx-auto max-w-5xl bg-base-200 rounded-2xl border">
+    <h1 class="text-4xl text-center mb-6">Chat Manager</h1>
+
+    <!-- Chat Input -->
+    <div class="mb-6">
+      <label for="chatContent" class="block text-lg font-medium mb-2"
+        >Enter Message:</label
+      >
+      <input
+        id="chatContent"
+        v-model="chatContent"
+        type="text"
+        class="w-full p-3 rounded-lg border"
+        placeholder="Type your message here..."
+      />
+    </div>
+
+    <!-- Recipient Input -->
+    <div class="mb-6">
+      <label for="recipientId" class="block text-lg font-medium mb-2"
+        >Recipient ID:</label
+      >
+      <input
+        id="recipientId"
+        v-model.number="recipientId"
+        type="number"
+        class="w-full p-3 rounded-lg border"
+        placeholder="Enter recipient ID..."
+      />
+    </div>
+
+    <!-- Submit Button -->
+    <div class="flex justify-center mb-6">
+      <button
+        :disabled="loading || !chatContent.trim() || !recipientId"
+        class="btn btn-primary w-full sm:w-auto transition duration-300 ease-in-out"
+        @click="createChat"
+      >
+        <span v-if="!loading">Create Chat</span>
+        <span
+          v-else
+          class="spinner-border spinner-border-sm"
+          role="status"
+        ></span>
+      </button>
+    </div>
+
+    <!-- Chat Cards -->
+    <div v-if="chats.length" class="grid grid-cols-1 gap-4">
+      <chat-card
+        v-for="chat in chats"
+        :key="chat.id"
+        :chat="chat"
+        class="border p-4 rounded-lg"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useChatStore } from '@/stores/chatStore'
+import { useUserStore } from '@/stores/userStore'
+import { useBotStore } from '@/stores/botStore'
+
+const chatContent = ref('')
+const recipientId = ref<number | null>(null)
+const loading = ref(false)
+const chats = ref<Chat[]>([])
+const chatStore = useChatStore()
+const userStore = useUserStore()
+const botStore = useBotStore()
+
+async function createChat() {
+  if (!chatContent.value.trim() || !recipientId.value) return
+
+  loading.value = true
+
+  try {
+    // Add new chat
+    const newChat = await chatStore.addChat({
+      content: chatContent.value,
+      userId: userStore.userId,
+      botId: botStore.currentBot?.id || null, // Replace with actual botId logic
+      recipientId: recipientId.value,
+      type: 'ToBot',
+      characterId: null,
+    })
+
+    // Stream response for the created chat
+    await chatStore.streamResponse(newChat.id)
+
+    // Add new chat to the displayed chats
+    chats.value.push(newChat)
+  } catch (error) {
+    console.error('Error creating chat:', error)
+  } finally {
+    chatContent.value = ''
+    recipientId.value = null
+    loading.value = false
+  }
+}
+</script>
+
+<style scoped>
+.spinner-border {
+  border-width: 2px;
+  width: 1rem;
+  height: 1rem;
+  border-color: white;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.75s linear infinite;
+}
+
+@keyframes spin {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/components/abandonware/user/login-form.vue
+++ b/components/abandonware/user/login-form.vue
@@ -1,0 +1,190 @@
+<!-- /components/content/user/login-form.vue -->
+<template>
+  <div class="login-form-container" @click.self="closeForm">
+    <div
+      class="login-form p-2 m-1 rounded-2xl bg-base-300 border shadow-lg transition-all duration-300 w-full max-w-md"
+    >
+      <!-- Loading State -->
+      <div v-if="store.loading" class="text-center text-info">
+        <Icon
+          name="kind-icon:bubble-loading"
+          class="animate-spin text-lg mb-2"
+        />
+        <div>Loading, please wait...</div>
+      </div>
+      <!-- Login Form -->
+      <form
+        v-if="!store.isLoggedIn"
+        class="space-y-4 w-full"
+        :autocomplete="stayLoggedIn ? 'on' : 'off'"
+        @submit.prevent="handleLogin"
+      >
+        <div class="mb-2 relative group">
+          <label for="login" class="block text-sm z-30 mb-1">Login:</label>
+          <input
+            id="login"
+            v-model="login"
+            type="text"
+            autocomplete="username"
+            class="w-full p-2 border rounded"
+            required
+          />
+          <div
+            class="absolute right-2 bottom-2 text-xs text-gray-500 group-hover:float-tooltip"
+          >
+            Login
+          </div>
+        </div>
+        <div class="mb-2 relative group">
+          <label for="password" class="block z-30 text-sm mb-1"
+            >Password (optional):</label
+          >
+          <input
+            id="password"
+            v-model="password"
+            type="password"
+            autocomplete="current-password"
+            class="w-full p-2 border rounded"
+          />
+          <div
+            class="absolute right-2 bottom-2 text-xs text-gray-500 group-hover:float-tooltip"
+          >
+            Password (optional)
+          </div>
+        </div>
+
+        <div class="flex items-center justify-between">
+          <div>
+            <input
+              id="stayLoggedIn"
+              v-model="stayLoggedIn"
+              type="checkbox"
+              class="mr-2"
+            />
+            <label for="stayLoggedIn" class="text-sm">Stay Logged in</label>
+          </div>
+          <button type="submit" class="bg-info text-default py-1 px-3 rounded">
+            Login
+          </button>
+        </div>
+        <div class="text-center mt-2">
+          <NuxtLink to="/register" class="text-accent underline"
+            >Register</NuxtLink
+          >
+        </div>
+      </form>
+
+      <!-- Error Message -->
+      <div v-if="errorMessage" class="text-warning mt-2 w-full text-center">
+        {{ errorMessage }}
+        <div v-if="userNotFound">
+          <div class="mt-2">
+            <button class="text-accent underline">
+              <NuxtLink to="/register" class="text-accent underline"
+                >Register</NuxtLink
+              >
+            </button>
+            or
+            <button class="text-accent underline" @click="handleRetryLogin">
+              Try a different login
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useUserStore } from '@/stores/userStore'
+import { useErrorStore, ErrorType } from '@/stores/errorStore'
+
+const store = useUserStore()
+const login = ref('')
+const password = ref('')
+const errorStore = useErrorStore()
+const errorMessage = ref('')
+const userNotFound = ref(false)
+
+// Consolidate stayLoggedIn as a computed property
+const stayLoggedIn = computed({
+  get: () => store.stayLoggedIn,
+  set: (value: boolean) => (store.stayLoggedIn = value),
+})
+
+const emit = defineEmits(['close'])
+
+const closeForm = () => {
+  emit('close')
+}
+
+const handleLogin = async () => {
+  errorMessage.value = ''
+  userNotFound.value = false
+  try {
+    const credentials = {
+      username: login.value,
+      password: password.value || undefined,
+    }
+    const result = await store.login(credentials)
+    if (!result.success) {
+      errorMessage.value = result.message || 'Login failed'
+      userNotFound.value = result.message?.includes('User not found') || false
+    }
+  } catch (error) {
+    errorStore.setError(ErrorType.AUTH_ERROR, error)
+    errorMessage.value = errorStore.message || 'An unexpected error occurred'
+  }
+}
+
+const handleRetryLogin = () => {
+  login.value = ''
+  password.value = ''
+  errorMessage.value = ''
+  userNotFound.value = false
+  errorStore.clearError()
+}
+</script>
+
+<style scoped>
+.login-form-container {
+  position: absolute;
+  top: 100%; /* Positioned right below the header or button */
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 50; /* Ensure it's above other content */
+  width: 100%; /* Full width to cover the area but max width restricts the form size */
+  display: flex;
+  justify-content: center;
+}
+
+.login-form {
+  background-color: var(--bg-base-300);
+}
+
+.group:hover .float-tooltip {
+  visibility: visible;
+  opacity: 1;
+}
+
+.text-accent {
+  transition: color 0.3s ease;
+}
+
+.text-accent:hover {
+  color: var(--text-accent-hover);
+}
+
+/* Styling for the buttons */
+button {
+  transition:
+    background-color 0.3s ease,
+    color 0.3s ease;
+}
+
+button:hover {
+  background-color: var(--bg-button-hover);
+  color: var(--text-button-hover);
+}
+</style>

--- a/components/abandonware/user/user-builder.vue
+++ b/components/abandonware/user/user-builder.vue
@@ -1,0 +1,190 @@
+<!-- /components/users/user-builder.vue -->
+<template>
+  <div class="hidden" aria-hidden="true" />
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import type {
+  BuilderCard,
+  BuilderProjectConfig,
+  BuilderSheet,
+} from '@/stores/helpers/builderCards'
+import { useBuilderStore } from '@/stores/builderStore'
+import { useUserStore } from '@/stores/userStore'
+
+const builder = useBuilderStore()
+const userStore = useUserStore()
+
+const builderKey = 'user'
+const startCard = 'account'
+
+const USER_CARDS: BuilderCard[] = [
+  {
+    key: 'account',
+    label: 'Account',
+    title: 'Sign in or create account',
+    icon: 'kind-icon:login',
+    tagline: 'Builder progress needs a real user.',
+    narrative:
+      'Log in or create an account so your work has somewhere reliable to live.',
+    required: true,
+    restoresFields: [],
+    unlockCondition: 'always',
+    steps: [
+      {
+        key: 'account',
+        title: 'Account',
+        narrative:
+          'Use the account tools to log in or create a profile before building.',
+        inputType: 'custom',
+      },
+    ],
+  },
+  {
+    key: 'designer',
+    label: 'Designer',
+    title: 'Your creative identity',
+    icon: 'kind-icon:signature',
+    tagline: 'Username for access. Designer name for the work.',
+    narrative: 'Choose the public creative byline attached to your creations.',
+    required: false,
+    restoresFields: ['designerName'],
+    unlockCondition: 'always',
+    steps: [
+      {
+        key: 'designerName',
+        title: 'Designer Name',
+        narrative: 'Set the creative name that appears on your work.',
+        inputType: 'text',
+        field: 'designerName',
+        placeholder: 'The Velvet Goblin Atelier',
+        inputLabel: 'Designer Name',
+      },
+    ],
+  },
+  {
+    key: 'settings',
+    label: 'Settings',
+    title: 'Privacy and maturity',
+    icon: 'kind-icon:sliders',
+    tagline: 'Defaults for new creations.',
+    narrative:
+      'Choose visibility and content preferences for future creations.',
+    required: false,
+    restoresFields: ['isPublic', 'showMature'],
+    unlockCondition: 'always',
+    steps: [
+      {
+        key: 'visibility',
+        title: 'Default Visibility',
+        narrative: 'Choose whether new creations start public or private.',
+        inputType: 'visibility',
+        field: 'isPublic',
+      },
+      {
+        key: 'showMature',
+        title: 'Mature Content',
+        narrative: 'Choose whether mature content is visible while building.',
+        inputType: 'toggle',
+        field: 'showMature',
+      },
+    ],
+  },
+]
+
+function sheetText(key: string): string {
+  const value = builder.sheet[key]
+  return typeof value === 'string' ? value : ''
+}
+
+function sheetBoolean(key: string, fallback = false): boolean {
+  const value = builder.sheet[key]
+  return typeof value === 'boolean' ? value : fallback
+}
+
+function defaultUserSheet(): BuilderSheet {
+  return {
+    username: userStore.username ?? '',
+    designerName: userStore.user?.designerName ?? userStore.username ?? '',
+    avatarImage: userStore.user?.avatarImage ?? null,
+    isPublic: true,
+    showMature: userStore.user?.showMature ?? false,
+    userId: userStore.authenticatedUserId,
+  }
+}
+
+async function saveUserBuilder() {
+  builder.clearError()
+
+  try {
+    await userStore.updateUser({
+      designerName: sheetText('designerName'),
+      showMature: sheetBoolean('showMature', false),
+    })
+
+    builder.setStatus('User settings saved.')
+    return {
+      success: true,
+      message: 'User settings saved.',
+      data: userStore.user,
+    }
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Failed to save user settings.'
+    builder.setLastError(error, message)
+    return { success: false, message, data: null }
+  }
+}
+
+function resetUserBuilder() {
+  builder.resetBuilder(true)
+  builder.selectCard(startCard)
+}
+
+const userBuilderConfig: BuilderProjectConfig = {
+  key: builderKey,
+  label: 'User Builder',
+  title: 'User Builder',
+  modelType: 'user',
+  storageKey: 'kindrobots.builder.user.v1',
+  cards: USER_CARDS,
+  splash: {
+    title: 'User Builder',
+    subtitle: 'Set up your account, designer identity, and defaults.',
+    tagline: 'A tiny foyer before the larger nonsense.',
+    description:
+      'Configure the account details and preferences that shape the rest of the workshop.',
+    imagePath: '/images/users/splash.webp',
+    ctaLabel: 'Start Profile',
+    secondaryLabel: 'Review Settings',
+  },
+  defaultSheet: defaultUserSheet,
+  coreCardKeys: ['account'],
+  requiredCardKeys: ['account'],
+  finalCardKey: 'settings',
+  clearFieldDefaults: {
+    avatarImage: null,
+    isPublic: true,
+    showMature: false,
+    userId: null,
+  },
+  persistActiveCard: true,
+  allowCompletedCardsInDeck: true,
+  suggestContext: {
+    builder: 'user',
+    tone: 'Friendly, concise, and onboarding-focused.',
+  },
+  startCardKey: startCard,
+  save: saveUserBuilder,
+  reset: resetUserBuilder,
+}
+
+onMounted(() => {
+  builder.registerBuilder(userBuilderConfig)
+  builder.setBuilder(builderKey, true)
+
+  if (!builder.activeCardKey && builder.visibleCards.length)
+    builder.selectCard(startCard)
+})
+</script>

--- a/components/abandonware/user/user-picture.vue
+++ b/components/abandonware/user/user-picture.vue
@@ -1,0 +1,84 @@
+<!-- /components/content/user/user-picture.vue -->
+<template>
+  <nuxt-link to="/dashboard" class="block">
+    <nuxt-img
+      v-if="avatarImage"
+      :src="avatarImage"
+      class="rounded-full border border-accent object-cover transition-transform duration-300 ease-in-out hover:scale-110 h-8 w-8 md:h-10 md:w-10 lg:h-12 lg:w-12 xl:h-14 xl:w-14"
+      alt="User avatar"
+      @error="avatarImage = fallbackAvatar"
+    />
+    <div
+      v-else
+      class="flex items-center justify-center rounded-full bg-base-300"
+      :style="{ width: `${size}px`, height: `${size}px` }"
+    >
+      <Icon name="kind-icon:person" class="h-full w-full text-accent" />
+    </div>
+  </nuxt-link>
+</template>
+
+<script lang="ts" setup>
+import { ref, watch } from 'vue'
+import { useUserStore } from '@/stores/userStore'
+import { useArtStore } from '@/stores/artStore'
+import type { ArtImage } from '~/prisma/generated/prisma/client'
+
+const userStore = useUserStore()
+const artStore = useArtStore()
+const size = 40
+const fallbackAvatar = '/images/kindart.webp'
+const avatarImage = ref<string | null>(fallbackAvatar)
+
+function looksLikeBase64(value: string): boolean {
+  const compact = value.replace(/\s+/g, '')
+  return compact.length >= 64 && compact.length % 4 === 0 && /^[A-Za-z0-9+/]+={0,2}$/.test(compact)
+}
+
+function asImageSource(value?: string | null): string {
+  const clean = value?.trim() || ''
+  if (!clean || clean === 'undefined' || clean === 'UNDEFINED') return ''
+  if (clean.startsWith('data:image/')) return clean
+  if (clean.startsWith('http://') || clean.startsWith('https://') || clean.startsWith('/')) return clean
+  if (clean.startsWith('./') || clean.startsWith('images/') || /\.(png|jpe?g|webp|gif|avif|svg)$/i.test(clean)) {
+    return `/${clean.replace(/^\/+/, '').replace(/^\.\//, '')}`
+  }
+  return looksLikeBase64(clean) ? `data:image/png;base64,${clean}` : ''
+}
+
+function imageSourceFromArt(image?: ArtImage | null): string {
+  return (
+    asImageSource(image?.thumbnailData) ||
+    asImageSource(image?.imageData) ||
+    asImageSource(image?.imagePath) ||
+    asImageSource(image?.path)
+  )
+}
+
+async function refreshAvatar() {
+  const user = userStore.user
+  if (!user) {
+    avatarImage.value = fallbackAvatar
+    return
+  }
+
+  if (user.artImageId) {
+    const image = await artStore.getArtImageById(user.artImageId, {
+      includeImageData: true,
+      includeThumbnailData: true,
+    })
+    avatarImage.value = imageSourceFromArt(image) || asImageSource(user.avatarImage) || fallbackAvatar
+    return
+  }
+
+  avatarImage.value = asImageSource(user.avatarImage) || fallbackAvatar
+}
+
+watch(
+  () => [userStore.user?.id, userStore.user?.artImageId, userStore.user?.avatarImage],
+  () => {
+    void refreshAvatar()
+  },
+  { immediate: true },
+)
+</script>

--- a/components/abandonware/wishmaster/wishmaster-page.vue
+++ b/components/abandonware/wishmaster/wishmaster-page.vue
@@ -1,0 +1,115 @@
+<!--
+  RETIRED 2026-08-09.
+  Wishmaster was removed from the live product because it duplicated project
+  creation without the infrastructure needed to justify a separate surface.
+  This copy is historical abandonware only and must not be mounted by live nav.
+-->
+<template>
+  <section class="kr-unbound gap-4 rounded-2xl border border-base-300 bg-(--kr-surface-raised) p-4">
+    <header class="flex items-start gap-3">
+      <div class="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-primary/30 bg-primary/10 text-primary">
+        <Icon name="kind-icon:wand" class="size-6" />
+      </div>
+      <div class="min-w-0 flex-1">
+        <p class="text-xs font-bold uppercase tracking-wide text-primary/70">Wishmaster</p>
+        <h2 class="text-2xl font-black leading-tight">Wish dreams</h2>
+        <p class="mt-1 text-sm leading-relaxed text-base-content/70">
+          A wish is a Dream with <code class="rounded bg-base-200 px-1">dreamType: WISH</code> and no project attachment. A project gets the infrastructure; a wish keeps the request lightweight.
+        </p>
+      </div>
+    </header>
+
+    <div class="grid gap-3 md:grid-cols-3">
+      <article class="rounded-2xl border border-base-300 bg-base-200 p-4">
+        <p class="text-xs font-bold uppercase tracking-wide text-base-content/40">Active</p>
+        <p class="mt-2 text-3xl font-black text-primary">{{ activeWishes.length }}</p>
+      </article>
+      <article class="rounded-2xl border border-base-300 bg-base-200 p-4">
+        <p class="text-xs font-bold uppercase tracking-wide text-base-content/40">Total</p>
+        <p class="mt-2 text-3xl font-black text-secondary">{{ wishDreams.length }}</p>
+      </article>
+      <article class="rounded-2xl border border-base-300 bg-base-200 p-4">
+        <p class="text-xs font-bold uppercase tracking-wide text-base-content/40">Inactive</p>
+        <p class="mt-2 text-3xl font-black text-base-content/40">{{ inactiveWishes.length }}</p>
+      </article>
+    </div>
+
+    <form class="space-y-3 rounded-2xl border border-primary/20 bg-primary/5 p-4" @submit.prevent="submitWish">
+      <h3 class="text-xs font-bold uppercase tracking-wide text-primary/70">New Wish</h3>
+      <input v-model="newWishTitle" type="text" placeholder="Request title" class="input input-bordered w-full rounded-xl" :disabled="dreamStore.isSaving" />
+      <textarea v-model="newWishPitch" placeholder="What should Wishmaster help with?" class="textarea textarea-bordered w-full rounded-xl text-sm leading-relaxed" rows="3" :disabled="dreamStore.isSaving" />
+      <div class="flex items-center gap-2">
+        <p v-if="saveMessage" class="text-xs" :class="saveError ? 'text-error' : 'text-success'">{{ saveMessage }}</p>
+        <button type="submit" class="btn btn-primary btn-sm ml-auto rounded-xl" :disabled="!newWishTitle.trim() || dreamStore.isSaving">
+          <Icon name="kind-icon:wand" class="size-4" /> Save
+        </button>
+      </div>
+    </form>
+
+    <div class="space-y-2">
+      <div class="flex items-center justify-between gap-2">
+        <h3 class="text-xs font-bold uppercase tracking-wide text-base-content/50">Recent wish dreams</h3>
+        <span v-if="dreamStore.loading" class="loading loading-spinner loading-xs text-primary" />
+      </div>
+      <article v-for="wish in recentWishes" :key="wish.id" class="kr-panel-flat px-4 py-3">
+        <div class="flex items-start gap-3">
+          <Icon name="kind-icon:sparkles" class="mt-0.5 size-4 shrink-0 text-primary" />
+          <div class="min-w-0 flex-1">
+            <p class="truncate text-sm font-bold">{{ wish.title }}</p>
+            <p v-if="wish.pitch" class="mt-2 line-clamp-2 text-xs leading-relaxed text-base-content/60">{{ wish.pitch }}</p>
+          </div>
+          <span class="badge badge-xs shrink-0" :class="wish.isActive ? 'badge-success' : 'badge-ghost'">{{ wish.isActive ? 'active' : 'inactive' }}</span>
+        </div>
+      </article>
+      <p v-if="!dreamStore.loading && !recentWishes.length" class="rounded-2xl border border-dashed border-base-300 bg-base-200/50 p-6 text-center text-sm text-base-content/50">No wish dreams yet.</p>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useDreamStore } from '@/stores/dreamStore'
+
+const dreamStore = useDreamStore()
+const newWishTitle = ref('')
+const newWishPitch = ref('')
+const saveMessage = ref('')
+const saveError = ref(false)
+
+const wishDreams = computed(() => dreamStore.dreams.filter((dream) => dream.dreamType === 'WISH'))
+const activeWishes = computed(() => wishDreams.value.filter((wish) => wish.isActive))
+const inactiveWishes = computed(() => wishDreams.value.filter((wish) => !wish.isActive))
+const recentWishes = computed(() => wishDreams.value.slice(0, 8))
+
+async function submitWish() {
+  const title = newWishTitle.value.trim()
+  if (!title) return
+  saveMessage.value = ''
+  saveError.value = false
+  const pitch = newWishPitch.value.trim() || title
+  const result = await dreamStore.createDream({
+    title,
+    pitch,
+    description: pitch,
+    flavorText: 'A focused Wishmaster request.',
+    dreamType: 'WISH',
+    icon: 'kind-icon:wand',
+    creationSource: 'HUMAN',
+    isPublic: false,
+    isMature: false,
+    isActive: true,
+  })
+  if (result.success) {
+    newWishTitle.value = ''
+    newWishPitch.value = ''
+    saveMessage.value = 'Wish saved.'
+  } else {
+    saveError.value = true
+    saveMessage.value = result.message || 'Save failed.'
+  }
+}
+
+onMounted(() => {
+  if (!dreamStore.hasLoaded || !wishDreams.value.length) dreamStore.fetchDreams({ showInactive: true, limit: 200 })
+})
+</script>

--- a/components/abandonware/wonderlab-history/README.md
+++ b/components/abandonware/wonderlab-history/README.md
@@ -1,0 +1,13 @@
+# WonderLab archive
+
+WonderLab was retired from the Kind Robots product and runtime in August 2026.
+
+This directory is the exportable historical bundle for artifacts worth keeping after that retirement. It is intentionally outside the live component/runtime graph.
+
+## Temporary exception
+
+The active comment-rewrite project still reads `config/wonderlab-voice-polish-batch-001.json` through `-039.json` as voice evidence. Those 39 files stay in `config/` until that project has finished extracting the historical Component comments. They are the only intentional WonderLab-era corpus dependency left outside this archive.
+
+The Prisma `Component` model/data is likewise preserved temporarily for that rewrite. Runtime Component APIs, museum/admin surfaces, reconciliation tooling, preview fixtures, rollout workflows, and museum-only verifiers are retired and must not return.
+
+Once the comment rewrite no longer needs the corpus or Component rows, the remaining evidence can be copied here for posterity and the Component schema/data can be removed in a separate migration.

--- a/components/abandonware/wonderlab-history/docs/wonderlab-component-retirement-policy.md
+++ b/components/abandonware/wonderlab-history/docs/wonderlab-component-retirement-policy.md
@@ -1,0 +1,137 @@
+# WonderLab component retirement policy
+
+A museum review is a record of what the site **has been**, not a claim about what it currently
+ships. Reviews are therefore never a reason to keep a component file alive.
+
+Silas, 2026-08-03, verbatim:
+
+> "kill them, and just keep the components … the museum reviews are actually literally reviews of
+> what the site has been, not where it is … it's not so we have a reason to cling to outdated
+> components."
+
+This document exists because that question came up as a blocker — two dead components were left in
+the tree on the theory that deleting them would orphan four published reviews. **It would not.** The
+machinery below already handles retirement end to end, and nothing needs to be built.
+
+## Deleting a reviewed component is safe
+
+The museum record is anchored to the database, not the filesystem. Delete the `.vue` file and:
+
+| Thing | What happens |
+|---|---|
+| `Component` row | **Survives.** Reconcile never deletes rows. |
+| Its `Reaction`s (the reviews) | **Survive**, still attached to the same `Component`. |
+| `isDiscovered` | Flips to `false` on the next reconcile run. |
+| `lastSeenAt` | Stops being refreshed, so it dates the disappearance. |
+| `sourceKey` / `sourcePath` | Retained on the row, so historical batch configs still resolve. |
+
+The mechanism is `server/utils/wonderlabComponentReconcile.ts:359-366`: every existing component
+not matched by the current scan, and still marked discovered, gets an `isDiscovered: false` update.
+There is no delete branch. `utils/scripts/verifyComponentCanonicalRuntime.ts:138` asserts that
+branch exists, so it cannot be quietly removed.
+
+### Why published review batches don't break
+
+Configs like `config/wonderlab-voice-polish-batch-011.json` pin each review by `sourceKey`, which
+reads like a filesystem dependency. It isn't. `scripts/preflight-wonderlab-voice-polish-batch.mjs`
+compares that value against the **`Component` row's** `sourceKey` column
+(`sourceLock: actual.sourceKey === revision.sourceKey`), never against a file on disk. The
+corresponding workflow only triggers on changes to itself, its scripts, or
+`config/*wonderlab-voice-polish-batch*.json` — component sources are not in its path filter.
+
+### Generated artifacts regenerate
+
+`public/wonderlab-components.json` and `utils/generated/wonderLabSourceEvidence.ts` both list every
+discovered component, and both are **untracked build artifacts**. They simply stop listing a deleted
+component on the next generation. No contract asserts a fixed entry count.
+
+## The two operations
+
+### Retire — the default
+
+The component is gone and has no successor. This is already fully supported; it is a status change,
+not a new concept.
+
+1. **Move the source file to `components/abandonware/`**, mirroring its original folder
+   (`components/butterfly/butterfly-net.vue` → `components/abandonware/butterfly/butterfly-net.vue`).
+   See "Park, don't delete" below for why this replaced deletion.
+2. Set the `Component`'s status to `RETIRED` with a `statusReason` saying what replaced it or why it
+   went. `ComponentStatus.RETIRED` is a real enum value (`prisma/schema.prisma:2540`), settable from
+   the admin UI at `components/wonderlab/lab-interact.vue:154`, rendered by
+   `components/wonderlab/component-card.vue`, and sorted last in
+   `utils/wonderlab/componentCatalog.ts` (`statusOrder.RETIRED = 6`).
+3. Regenerate the manifest (`npm run components:manifest`). The entry stays, flagged
+   `abandoned: true`, and `isDiscovered` stays **true** — the file genuinely still exists.
+
+The reviews stay on the retired exhibit. That is the point — they document what the site was.
+
+## Park, don't delete
+
+Silas, 2026-08-05, verbatim:
+
+> "if we aren't using a component, it should move to /abandonware. that way it is still reachable by
+> wonderlab, but should not affect built"
+
+Deleting kept the reviews but cost the museum the exhibit itself: `wonderlab-preview-host.vue`
+renders "Component source not found" for a missing file, and no new AI review draft can ever be
+generated for it (`reviewDraftPrompt.ts:209` throws without source evidence). Parking keeps the
+exhibit whole while taking the file out of the app.
+
+### What parking actually removes
+
+| | Parked? |
+|---|---|
+| Nuxt auto-import registration | **Gone** — `nuxt.config.ts` `components[].ignore` lists `abandonware/**/*.vue`, resolved relative to `~/components`. Confirm with: no parked name appears in `.nuxt/components.d.ts`. |
+| `vue-tsc` typechecking | **Gone** — `tsconfig.json` excludes `components/abandonware/**/*`. |
+| WonderLab preview | **Kept** — the museum's `import.meta.glob('@/components/**/*.vue')` still matches. `ignore` governs auto-import, not globs. |
+| Manifest entry + reviews | **Kept**, with `abandoned: true`. |
+| SFC compilation | **Kept.** The glob makes each a lazy chunk rather than main-bundle weight, but Vite still compiles it. Dropping the preview is the only way to zero this, and that costs the exhibit. |
+
+### The known rough edge — accepted, do not spend time on it
+
+A parked component that references *another* parked component loses auto-import resolution for that
+child, so the child renders as an unresolved custom element in the museum preview. This is common in
+the parked clusters (`butterfly/`, `builder/`), which reference each other heavily. The parent's own
+markup still renders; the nested child comes up empty.
+
+Silas, 2026-08-05, verbatim:
+
+> "its ok if museum pieces fail to find other pieces, we can correct that if needed but it's VERY low
+> priority"
+
+So this is not a blocker on parking anything, and it is not worth a preventative sweep. If one
+specific exhibit ever matters enough, give that component an explicit `import` of its child and the
+preview resolves again.
+
+### Finding what to park
+
+`npm run test:component-reachability` traverses from `app.vue`, `error.vue`, `pages/`, `layouts/`,
+and `content/*.md` MDC mounts, and reports every component nothing reaches. A grep cannot answer this
+— a cluster that only cites itself looks referenced from every angle except the one that matters. The
+baseline is a ratchet at **zero**: a PR that orphans a component fails until it parks it.
+
+That check reports rather than judges. Its blind spots are runtime mounts — `<component :is>`, a
+string-addressed registry, a plugin CSS selector — so read the list before acting on it. Three edge
+classes were found and taught to it the hard way, each after a first pass parked something live:
+directory-local `import.meta.glob` registries (all 47 `screenfx/` effects), explicit `.vue` imports
+(`stage-manager`'s three cards, caught by vue-tsc), and Nuxt's `Lazy` prefix
+(`<LazyWorkspaceNarrator>`, six components, caught by `test:narrative-kit`).
+
+### Succeed — only when reviews describe a surface that still exists
+
+Use this only when a component was **renamed or redesigned in place** and its reviews genuinely
+describe the successor's behaviour. Re-point the `Reaction`s at the successor `Component`, then
+retire the original as above.
+
+Do not reach for this to "save" reviews from retirement. A review of a deleted surface belongs on
+the deleted surface.
+
+## What this policy is not
+
+It is not licence to park a component that is still mounted somewhere. Check first — the ordinary
+dead-code checks still apply, and `verifyLayoutContract.ts` resolves every MDC mount in `content/`,
+so a component referenced from a content file will fail CI if you move it.
+
+It is also not a reason to reach for deletion instead. Deleting still behaves exactly as documented
+above — the row and its reviews survive — but it costs the exhibit its preview, and parking costs
+nothing that matters. Park.

--- a/components/abandonware/wonderlab-history/docs/wonderlab-curated-recovery.md
+++ b/components/abandonware/wonderlab-history/docs/wonderlab-curated-recovery.md
@@ -1,0 +1,7 @@
+# WonderLab curated recovery publication
+
+The curated recovery workflow publishes only explicitly listed review drafts that already exist in production and have been manually rewritten in the checked-in manifest.
+
+It does not generate reviews. Each row locks the draft ID, Component ID, first-party reviewer, expected current status, edited comment, rating, and reaction type. A failed or rejected draft must first transition back to `PROPOSED`, then to `APPROVED`, before the existing publication endpoint creates its Reaction.
+
+The workflow stops if any reviewed identity or status has changed. After publication it requires a ready rollout audit with zero duplicate first-party groups, zero unsafe first-party rows, and zero published-draft link mismatches.

--- a/components/abandonware/wonderlab-history/docs/wonderlab-personality-review-rollout.md
+++ b/components/abandonware/wonderlab-history/docs/wonderlab-personality-review-rollout.md
@@ -1,0 +1,153 @@
+# WonderLab personality review rollout
+
+This runbook covers the first production rollout of first-party Bot/Character commentary for Component WonderLab.
+
+## Non-negotiable guardrails
+
+- Human and community Reactions are never deleted, rewritten, or converted.
+- Bot/Character identity can only be assigned by the controlled publication service.
+- Generation creates `PROPOSED` or `FAILED` ReviewDraft rows only.
+- Approval and publication are separate administrator actions.
+- Build, deploy, startup, page load, filtering, and plan previews never generate or publish.
+- A Component/reviewer pair reconciles to one authored Reaction.
+
+## 1. Production deployment and migration
+
+Deploy current `main` through the production Vercel target.
+
+The migration wrapper handles one known historical failure only:
+
+`20260719031500_reaction_first_party_author_expand`
+
+If that exact migration is unfinished, the wrapper verifies and completes its expand-only columns, indexes, and foreign keys, refuses unsafe data, uses Prisma's supported `migrate resolve --applied`, and then runs ordinary `prisma migrate deploy`.
+
+Expected applied migrations:
+
+- `20260719031500_reaction_first_party_author_expand`
+- `20260719033500_review_draft_storage_expand`
+
+Do not manually edit `_prisma_migrations`.
+
+## 2. Run the rollout audit
+
+Open:
+
+`/admin/wonderlab-review-rollout`
+
+The audit must report **Ready** before generating production drafts. In particular:
+
+- both migrations are applied with no unfinished record;
+- `ReviewDraft` exists;
+- both Reaction author columns exist;
+- duplicate authored Component/reviewer groups are zero;
+- dual-author and orphan author rows are zero;
+- published draft/Reaction mismatches are zero.
+
+The audit is read-only.
+
+## 3. Preview reviewer coverage
+
+Open:
+
+`/admin/wonderlab-review-plan`
+
+Start with a small batch:
+
+- 5–10 Components;
+- 1–2 reviewers per Component;
+- `regenerate` off;
+- run **Preview plan** or **Verify dry run** first.
+
+Review the affinity scores and reasons. A second reviewer is selected with Bot/Character diversity when a competitive voice-ready option exists.
+
+Dry run defaults to true and makes no model calls or writes.
+
+## 4. Generate proposed drafts
+
+On the coverage-plan page, explicitly check **Enable model calls for this batch**, then generate.
+
+Batch limits:
+
+- at most 10 Components;
+- at most 20 reviewer slots;
+- sequential model calls;
+- published slots skipped;
+- per-slot errors retained in the result instead of aborting the batch.
+
+Generated output is validated for:
+
+- structured JSON;
+- 20–160 words;
+- integer rating from 1–5;
+- confidence from 0–1;
+- at least one grounded observation;
+- canonical reviewer voice readiness.
+
+Low-confidence output is saved as `FAILED`, not discarded and not published.
+
+## 5. Curate and approve
+
+Open:
+
+`/admin/wonderlab-reviews`
+
+For each draft:
+
+1. Compare generated copy with the reviewer voice and prompt provenance.
+2. Edit the comment, rating, or reaction type as needed.
+3. Save.
+4. Approve only when the copy is useful, grounded, and clearly belongs to that reviewer.
+
+Editing an already approved draft without an explicit status transition returns it to `PROPOSED`.
+
+Representative acceptance cases should include:
+
+- Dotti on a Bot/builder/prompt Component;
+- Catbot on a broadly accessible museum Component;
+- two reviewers evaluating the same exhibit with visibly distinct voices.
+
+## 6. Publish explicitly
+
+Only an `APPROVED` draft can be published.
+
+Publication:
+
+- uses the authenticated administrator as `Reaction.userId` for accountability;
+- stores the Bot or Character in the separate first-party author identity;
+- locks the draft and Component transactionally;
+- updates an existing authored Reaction for the same Component/reviewer;
+- inserts only when no authored Reaction exists;
+- marks the draft `PUBLISHED` and links its Reaction;
+- supersedes stale unpublished attempts for that Component/reviewer;
+- never selects a human Reaction for overwrite.
+
+After publishing a representative set, rerun `/admin/wonderlab-review-rollout`.
+
+## 7. Public verification
+
+Verify on production:
+
+- `/plan/wonderlab`
+- `/play/memory`
+- `/play/screenfx`
+
+In WonderLab, confirm:
+
+- human reviews still display with their user identity;
+- first-party reviews display the Bot/Character name, avatar, role, and first-party label;
+- rating/review counts include the new normal Reactions;
+- no duplicate first-party comments appear after repeated publication;
+- desktop and mobile exhibit layouts remain usable;
+- browser back/forward and URL filters still restore state.
+
+## 8. Rollback and incident handling
+
+If generation quality is poor, stop generating. Existing drafts can remain `PROPOSED`, `FAILED`, or `REJECTED`; none are public.
+
+If a published first-party review is incorrect:
+
+- edit or regenerate a draft;
+- approve it;
+- republish to reconcile the same authored Reaction.
+
+Do not delete human reviews. Do not resolve an unexpected migration failure automatically. The deploy repair is intentionally allowlisted to one known migration and aborts on any unexpected schema or data state.

--- a/components/abandonware/wonderlab-history/docs/wonderlab-production-rollout-status.md
+++ b/components/abandonware/wonderlab-history/docs/wonderlab-production-rollout-status.md
@@ -1,0 +1,41 @@
+# WonderLab production rollout status
+
+This document is a stable entry point for the live Component registry and first-party personality commentary rollout.
+
+## Authoritative live handoff
+
+Read GitHub issue [#531](https://github.com/silasfelinus/kind_robots/issues/531) for the latest automated production commit, deployment, reconciliation plan, audit checks, and exact resume instructions. The guarded workflow overwrites that issue after every read-only audit or apply attempt.
+
+Related tracking:
+
+- [#381](https://github.com/silasfelinus/kind_robots/issues/381) — WonderLab overhaul and acceptance
+- [#472](https://github.com/silasfelinus/kind_robots/issues/472) — first-party personality commentary
+- [#473](https://github.com/silasfelinus/kind_robots/issues/473) — canonical Component identity/status rollout
+
+## Reconciliation safety
+
+The production reconciliation:
+
+- always performs a conflict-checking dry run first;
+- refuses the apply when any canonical identity conflict exists;
+- preserves database-only Components and every Reaction;
+- commits canonical updates and new manifest Components atomically;
+- uses a non-interactive batch transaction, with one `createMany` for all new rows, so a large manifest is not constrained by Prisma's interactive callback timeout;
+- deletes only exact orphaned Cypress Component fixtures with no source identity and no reviews;
+- verifies every manifest source key, path, hash, name, folder, slug, and discovered state after apply;
+- reruns the read-only personality rollout audit and stores JSON evidence as a GitHub Actions artifact.
+
+## Trigger semantics
+
+- `[wonderlab-audit]` runs the reconciliation dry run and personality audit only.
+- `[wonderlab-rollout]` performs the guarded registry apply, exact fixture cleanup, canonical verification, and audit.
+
+Neither trigger generates, approves, or publishes personality review drafts.
+
+## Acceptance after a successful registry apply
+
+1. Generate a small representative draft set, including Dotti and Catbot.
+2. Curate, approve, and explicitly publish only useful, grounded, voice-ready drafts.
+3. Rerun the rollout audit.
+4. Verify `/plan/wonderlab`, `/play/memory`, and `/play/screenfx` on desktop and mobile.
+5. Confirm human reviews remain intact and first-party reviews have no duplicates, unsafe author rows, or draft/Reaction link mismatches.

--- a/components/abandonware/wonderlab-history/docs/wonderlab-production-status-2026-07-19.md
+++ b/components/abandonware/wonderlab-history/docs/wonderlab-production-status-2026-07-19.md
@@ -1,0 +1,7 @@
+# WonderLab production status — 2026-07-19
+
+- Canonical Component runtime merged in PR #552 and verified in production at commit `14bc7c30b8818cf93161721d2b95dbf10c5bd80f`.
+- Production `/api/version` and `/api/components` returned successfully with canonical Component status fields.
+- The final Component contract migration merged in PR #558 as `8fbe7b162f243f5a23ccf37e70f50fedc92cea1c`.
+- TypeScript, repository contracts, and the MariaDB preservation smoke passed before merge.
+- This commit requests the existing read-only WonderLab production audit and records the rollout handoff.

--- a/components/abandonware/wonderlab-history/docs/wonderlab-retirement.md
+++ b/components/abandonware/wonderlab-history/docs/wonderlab-retirement.md
@@ -1,0 +1,11 @@
+# WonderLab retirement
+
+Silas retired WonderLab on 2026-08-11. WonderLab is no longer a product surface, component-retention mechanism, or build-time catalog.
+
+The useful artifact is its first-party voice corpus: 706 polished Bot/Character-authored reactions. Those historical Component reactions and their archived voice-polish manifests remain migration source data until fresh replacement reviews on live Kind Robots objects have been drafted, reviewed, and approved. Do not retarget old Component reactions in place.
+
+New replacement reviews should be paired scenes: two identifiable Bot/Character voices experiencing a real reviewable target together, with setup and payoff. The old text is inspiration for voice and chemistry, not subject matter.
+
+Publishing rewritten reviews is a separate human gate. Infrastructure retirement is approved.
+
+`components/abandonware` is temporarily retained as excluded source for posterity. Its intended final home is outside this repository; no runtime/build mechanism should compile it merely for previews.

--- a/components/abandonware/wonderlab/new-eyeball.vue
+++ b/components/abandonware/wonderlab/new-eyeball.vue
@@ -1,0 +1,148 @@
+<!-- /components/content/weird/new-eyeball.vue -->
+<script setup lang="ts">
+// Imports
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+
+// Initialization
+const eyeballSize = Math.floor(Math.random() * 100) + 50
+const irisSize = eyeballSize * 0.6
+const maxIrisDist = eyeballSize / 2 - irisSize / 2
+const irisColor = ref(generateRandomColor())
+
+const eyeElement = ref<HTMLElement | null>(null)
+const upperEyelidY = ref(0)
+const lowerEyelidY = ref(0)
+const irisX = ref(0)
+const irisY = ref(0)
+let currentBehavior: 'trackMouse' | 'moveRandomly' | '' = ''
+
+// Computed styles
+const eyeballStyle = computed(() => ({
+  width: `${eyeballSize}px`,
+  height: `${eyeballSize}px`,
+}))
+
+const irisStyle = computed(() => ({
+  width: `${irisSize}px`,
+  height: `${irisSize}px`,
+  backgroundColor: irisColor.value,
+  top: `calc(50% + ${irisY.value}px)`,
+  left: `calc(50% + ${irisX.value}px)`,
+  transform: `translate(${irisX.value}px, ${irisY.value}px)`,
+  transition: 'transform 0.5s',
+}))
+
+const upperEyelidStyle = computed(() => ({
+  height: `${upperEyelidY.value}px`,
+  transition: 'height 0.15s',
+}))
+
+const lowerEyelidStyle = computed(() => ({
+  height: `${lowerEyelidY.value}px`,
+  transition: 'height 0.15s',
+}))
+
+// Utility Functions
+function generateRandomColor() {
+  return `rgb(${Math.floor(Math.random() * 256)}, ${Math.floor(Math.random() * 256)}, ${Math.floor(
+    Math.random() * 256,
+  )})`
+}
+
+function setNextBlink() {
+  const randomDuration = Math.random() * 5000 + 2000 // Between 2s to 7s
+  setTimeout(() => {
+    currentBehavior = '' // Reset behavior on blink
+    blink()
+  }, randomDuration)
+}
+
+function moveRandomlyAfterBlink() {
+  if (currentBehavior !== 'moveRandomly') return
+
+  const angle = Math.random() * 2 * Math.PI
+  const distance = Math.random() * maxIrisDist
+  irisX.value = Math.cos(angle) * distance
+  irisY.value = Math.sin(angle) * distance
+
+  setTimeout(moveRandomlyAfterBlink, Math.random() * 2000 + 500) // Randomize movement timing
+}
+
+function blink() {
+  upperEyelidY.value = eyeballSize / 2
+  lowerEyelidY.value = eyeballSize / 2
+  setTimeout(() => {
+    openEye()
+
+    // Determine post-blink behavior
+    currentBehavior = Math.random() < 0.5 ? 'moveRandomly' : 'trackMouse'
+    if (currentBehavior === 'moveRandomly') moveRandomlyAfterBlink()
+
+    setNextBlink()
+  }, 150)
+}
+
+function openEye() {
+  upperEyelidY.value = 0
+  lowerEyelidY.value = 0
+}
+
+function handleMouseMove(event: MouseEvent) {
+  if (currentBehavior !== 'trackMouse') return
+  const rect = eyeElement.value?.getBoundingClientRect()
+  if (!rect) return
+
+  const eyeCenterX = rect.left + rect.width / 2
+  const eyeCenterY = rect.top + rect.height / 2
+  const dx = event.clientX - eyeCenterX
+  const dy = event.clientY - eyeCenterY
+  const dist = Math.min(maxIrisDist, Math.hypot(dx, dy))
+  const angle = Math.atan2(dy, dx)
+  irisX.value = Math.cos(angle) * dist
+  irisY.value = Math.sin(angle) * dist
+}
+
+// Lifecycle Hooks
+onMounted(() => {
+  eyeElement.value = document.querySelector(
+    '.bg-white.rounded-full',
+  ) as HTMLElement | null
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('mousemove', handleMouseMove)
+    setNextBlink()
+  }
+})
+
+onBeforeUnmount(() => {
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('mousemove', handleMouseMove)
+  }
+})
+</script>
+
+<template>
+  <div class="flex h-full min-h-[320px] items-center justify-center">
+    <div
+      class="bg-white rounded-full overflow-hidden shadow relative aspect-w-1 aspect-h-1"
+      :style="eyeballStyle"
+    >
+      <!-- Iris -->
+      <div class="rounded-full absolute" :style="irisStyle">
+        <div
+          class="bg-black rounded-full w-2/5 h-2/5 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
+        />
+      </div>
+      <!-- Eyelids -->
+      <div class="bg-white absolute w-full" :style="upperEyelidStyle" />
+      <div
+        class="bg-white absolute w-full bottom-0"
+        :style="lowerEyelidStyle"
+      />
+    </div>
+  </div>
+</template>
+
+<style>
+/* Add any additional styles here */
+</style>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
   "vueCompilerOptions": {
     "plugins": []
   },
-  "exclude": ["cypress/e2e/**/*"]
+  "exclude": ["cypress/e2e/**/*", "components/abandonware/**/*"]
 }


### PR DESCRIPTION
## Summary

Restores `components/abandonware/` exactly as it existed on `main` immediately before PR #1806 removed it, so Silas can preserve/export the files himself before deleting them later.

The restoration is intentionally narrow:

- reattaches the exact historical subtree (`e1db33773d8d3f9337d98cdfbc67ebfc8906a725`)
- restores the `tsconfig.json` exclusion for `components/abandonware/**/*` so these parked files remain outside TypeScript checking
- leaves the rest of PR #1806's cleanup intact, including archive/artifact pruning and contract tests that now point at live components
- is based on current `main`, including the newer migration-safety work from PR #1807

Nuxt already ignores `abandonware/**/*.vue` for component auto-import, so the restored files remain preserved but dormant.

## Verification

Compared branch against current `main`: only `components/abandonware/**` additions plus the TypeScript exclusion are present. CI must pass on the exact head before merge.