### PR TITLE
fix(model-builder): autoBuildItem must treat a queued async art job as busy

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -347,6 +347,12 @@ jobs:
       - name: Model Builder resume-cancelled-run guard contract
         run: npm run test:model-builder-resume-cancelled-run-guard
 
+      - name: Model Builder auto-build queued-item guard checker self-test
+        run: npm run test:model-builder-auto-build-queued-guard-selftest
+
+      - name: Model Builder auto-build queued-item guard contract
+        run: npm run test:model-builder-auto-build-queued-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -183,6 +183,8 @@
     "test:model-builder-auto-build-approval-race-guard": "tsx utils/scripts/verifyModelBuilderAutoBuildApprovalRaceGuard.ts",
     "test:model-builder-resume-cancelled-run-guard-selftest": "tsx utils/scripts/verifyModelBuilderResumeCancelledRunGuard.test.ts",
     "test:model-builder-resume-cancelled-run-guard": "tsx utils/scripts/verifyModelBuilderResumeCancelledRunGuard.ts",
+    "test:model-builder-auto-build-queued-guard-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildQueuedGuard.test.ts",
+    "test:model-builder-auto-build-queued-guard": "tsx utils/scripts/verifyModelBuilderAutoBuildQueuedGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1461,12 +1461,15 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     // otherwise Auto walks straight into the same stage and fires a second,
     // concurrent request (generateItemAsset's own approved-stage guard only
     // catches the case where the first call already resolved to approved; it
-    // does nothing while both calls are still racing mid-flight).
-    if (
-      state.generatingItemId === item.id ||
-      state.committingItemId === item.id ||
-      draftingField.value?.itemId === item.id
-    ) {
+    // does nothing while both calls are still racing mid-flight). This must
+    // also check item.queueState (mirrors isItemManualActionInFlight above)
+    // -- otherwise an item with an async art job already queued/rendering
+    // via "Queue generation in background" isn't recognized as busy here,
+    // and Auto-build group/all (unlike the single-item Auto button, which
+    // does gate on isQueued) walks straight into GENERATE_ASSETS and fires a
+    // second, synchronous generateItemAsset() call for the same item while
+    // the first is still in flight.
+    if (isItemManualActionInFlight(item.id)) {
       return 'skipped'
     }
 

--- a/utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts
@@ -111,10 +111,22 @@ export function checkAutoBuildDraftGate(content: string): string[] {
     )
   }
 
-  const manualActionGuard =
+  // Accepts either the original inline three-condition check, or a call to
+  // the shared isItemManualActionInFlight(item.id) helper (added later, same
+  // task, to also cover item.queueState -- see
+  // verifyModelBuilderAutoBuildQueuedGuard.ts for that half of the contract).
+  // Both shapes return 'skipped' when a manual single-stage action is
+  // already in flight for this item; which one is in place is not this
+  // guard's concern, only that one of them is.
+  const manualActionGuardInline =
     /state\.generatingItemId\s*===\s*item\.id[\s\S]{0,200}state\.committingItemId\s*===\s*item\.id[\s\S]{0,200}draftingField\.value\?\.itemId\s*===\s*item\.id[\s\S]{0,80}return 'skipped'/.exec(
       fn.body,
     )
+  const manualActionGuardShared =
+    /isItemManualActionInFlight\(item\.id\)[\s\S]{0,80}return 'skipped'/.exec(
+      fn.body,
+    )
+  const manualActionGuard = manualActionGuardInline ?? manualActionGuardShared
   if (
     claimIndex < 0 ||
     !manualActionGuard ||
@@ -123,8 +135,9 @@ export function checkAutoBuildDraftGate(content: string): string[] {
     errors.push(
       `${FN_NAME}() must return 'skipped' when a manual single-stage action ` +
         '(state.generatingItemId, state.committingItemId, or ' +
-        "draftingField.value's itemId already matching item.id) is in " +
-        'flight for this item, before claiming autoBuildingItemSingleton. ' +
+        "draftingField.value's itemId already matching item.id -- directly " +
+        'or via the shared isItemManualActionInFlight(item.id) helper) is ' +
+        'in flight for this item, before claiming autoBuildingItemSingleton. ' +
         'Without that guard, clicking Auto while a manual "Generate ' +
         'candidate" / "Draft with AI" / "Execute commit" is still running ' +
         'fires a second, concurrent request for the same stage -- for ' +

--- a/utils/scripts/verifyModelBuilderAutoBuildQueuedGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildQueuedGuard.test.ts
@@ -1,0 +1,151 @@
+// /utils/scripts/verifyModelBuilderAutoBuildQueuedGuard.test.ts
+//
+// Regression test for checkAutoBuildQueuedGuard() in
+// verifyModelBuilderAutoBuildQueuedGuard.ts (model-builder/t-029). Exercises
+// the real check against synthetic store-shaped fixtures covering: the
+// pre-fix shape (guard checks only the three singletons, never
+// item.queueState -- the exact bug found by manual read-through), the fixed
+// shape via the shared isItemManualActionInFlight() helper, a fixed shape
+// that checks item.queueState inline instead, and autoBuildItem being absent
+// entirely.
+import assert from 'node:assert/strict'
+
+import { checkAutoBuildQueuedGuard } from './verifyModelBuilderAutoBuildQueuedGuard.js'
+
+const BUGGY_FIXTURE = `
+  function isItemManualActionInFlight(itemId: string): boolean {
+    const item = findItem(itemId)
+    return (
+      state.generatingItemId === itemId ||
+      Boolean(item?.queueState) ||
+      state.committingItemId === itemId ||
+      draftingField.value?.itemId === itemId
+    )
+  }
+
+  async function autoBuildItem(itemId: string): Promise<AutoBuildOutcome> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return 'failed'
+
+    if (state.autoBuildingItemId === item.id) return 'skipped'
+
+    if (
+      state.generatingItemId === item.id ||
+      state.committingItemId === item.id ||
+      draftingField.value?.itemId === item.id
+    ) {
+      return 'skipped'
+    }
+
+    autoBuildingItemSingleton.claim(item.id)
+    try {
+      return 'committed'
+    } finally {
+      autoBuildingItemSingleton.release(item.id)
+    }
+  }
+`
+
+const FIXED_FIXTURE_SHARED_HELPER = `
+  function isItemManualActionInFlight(itemId: string): boolean {
+    const item = findItem(itemId)
+    return (
+      state.generatingItemId === itemId ||
+      Boolean(item?.queueState) ||
+      state.committingItemId === itemId ||
+      draftingField.value?.itemId === itemId
+    )
+  }
+
+  async function autoBuildItem(itemId: string): Promise<AutoBuildOutcome> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return 'failed'
+
+    if (state.autoBuildingItemId === item.id) return 'skipped'
+
+    if (isItemManualActionInFlight(item.id)) {
+      return 'skipped'
+    }
+
+    autoBuildingItemSingleton.claim(item.id)
+    try {
+      return 'committed'
+    } finally {
+      autoBuildingItemSingleton.release(item.id)
+    }
+  }
+`
+
+const FIXED_FIXTURE_INLINE = `
+  async function autoBuildItem(itemId: string): Promise<AutoBuildOutcome> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return 'failed'
+
+    if (state.autoBuildingItemId === item.id) return 'skipped'
+
+    if (
+      state.generatingItemId === item.id ||
+      Boolean(item.queueState) ||
+      state.committingItemId === item.id ||
+      draftingField.value?.itemId === item.id
+    ) {
+      return 'skipped'
+    }
+
+    autoBuildingItemSingleton.claim(item.id)
+    try {
+      return 'committed'
+    } finally {
+      autoBuildingItemSingleton.release(item.id)
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkAutoBuildQueuedGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  1,
+  'expected the pre-fix shape (queueState never checked inside ' +
+    `autoBuildItem) to raise 1 error, got ${buggyErrors.length}: ` +
+    JSON.stringify(buggyErrors),
+)
+assert.ok(buggyErrors[0]!.includes('item.queueState'))
+
+const fixedSharedErrors = checkAutoBuildQueuedGuard(FIXED_FIXTURE_SHARED_HELPER)
+assert.equal(
+  fixedSharedErrors.length,
+  0,
+  'expected the shared-helper fixed shape to raise no errors, got: ' +
+    JSON.stringify(fixedSharedErrors),
+)
+
+const fixedInlineErrors = checkAutoBuildQueuedGuard(FIXED_FIXTURE_INLINE)
+assert.equal(
+  fixedInlineErrors.length,
+  0,
+  'expected the inline-check fixed shape to raise no errors, got: ' +
+    JSON.stringify(fixedInlineErrors),
+)
+
+const missingFnErrors = checkAutoBuildQueuedGuard(MISSING_FIXTURE)
+assert.equal(
+  missingFnErrors.length,
+  1,
+  'expected a single "function not found" violation when autoBuildItem is absent',
+)
+assert.ok(missingFnErrors[0]!.includes('autoBuildItem'))
+
+console.log(
+  'Model Builder auto-build queued-item guard checker verified: flags an ' +
+    'in-flight bail-out that never checks item.queueState, clears both the ' +
+    'shared-helper and inline-check fixed shapes, and flags autoBuildItem ' +
+    'being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderAutoBuildQueuedGuard.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildQueuedGuard.ts
@@ -1,0 +1,98 @@
+// /utils/scripts/verifyModelBuilderAutoBuildQueuedGuard.ts
+//
+// Regression guard (model-builder/t-029) -- autoBuildItem()'s in-flight
+// bail-out checked only state.generatingItemId / state.committingItemId /
+// draftingField.value?.itemId, never item.queueState. queueState is what
+// generateItemAssetAsync()/pollAsyncArtJob() (the "Queue generation in
+// background" path) set on the item while an async art job is
+// queued/rendering -- a store-wide singleton is never touched for that path,
+// so autoBuildItem's own guard didn't recognize the item as busy.
+//
+// isItemManualActionInFlight() (defined just above autoBuildItem, added for
+// t-038's "N busy" pre-flight signal) already checks Boolean(item?.queueState)
+// alongside the same three singletons -- autoBuildItem's inline guard simply
+// didn't reuse it. Before this fix: queue an item's art generation in the
+// background from model-builder-item-panel.vue, then click "Auto-build
+// group" (model-builder-batch-editor.vue) or "Auto-build all"
+// (model-builder-progress-matrix.vue) before it finishes -- both buttons are
+// gated only by their own batching/autoBuilding flag, not busyCount. Auto
+// walks straight into GENERATE_ASSETS and fires a second, synchronous
+// generateItemAsset() call for the same item while the async one is still
+// rendering; whichever response lands last silently overwrites
+// item.artImageId/imagePath with no re-review, and the render is paid for
+// twice. (The single-item Auto button in model-builder-item-panel.vue does
+// not have this hole -- it already gates on isQueued before calling Auto.)
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'autoBuildItem'
+
+// Checks the fix's exact shape against the full source text of a file
+// containing an `autoBuildItem`-named async function. Exported (rather than
+// only exercised via main()) so the self-test below can run it against
+// synthetic buggy/fixed fixtures without touching the real store file.
+export function checkAutoBuildQueuedGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find an async function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  const usesSharedHelper = /isItemManualActionInFlight\(item\.id\)/.test(
+    fn.body,
+  )
+  const checksQueueStateInline = /item\.queueState/.test(fn.body)
+
+  if (!usesSharedHelper && !checksQueueStateInline) {
+    errors.push(
+      `${FN_NAME}()'s in-flight bail-out does not check item.queueState ` +
+        '(directly, or via calling isItemManualActionInFlight(item.id)). ' +
+        'Without it, an item with an async art job already queued/rendering ' +
+        'via "Queue generation in background" is not recognized as busy, ' +
+        'and Auto-build group/all can fire a second, concurrent ' +
+        'generateItemAsset() call for the same item.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkAutoBuildQueuedGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder auto-build queued-item guard contract failed for ' +
+        `${FN_NAME}() in modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder auto-build queued-item guard contract passed: ' +
+      `${FN_NAME}() recognizes an item with a queued/rendering async art ` +
+      'job as busy before walking into GENERATE_ASSETS.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Root cause

`autoBuildItem()`'s in-flight bail-out checked only `state.generatingItemId`, `state.committingItemId`, and `draftingField.value?.itemId` — never `item.queueState`, which is what `generateItemAssetAsync()`/`pollAsyncArtJob()` (the "Queue generation in background" path) set on the item while an async render is queued/rendering. A store-wide singleton is never touched for that path, so `autoBuildItem`'s own guard didn't recognize the item as busy.

`isItemManualActionInFlight()` (defined just above `autoBuildItem`, added for t-038's "N busy" pre-flight signal) already checks `Boolean(item?.queueState)` alongside the same three singletons — `autoBuildItem`'s inline guard simply didn't reuse it.

## Failure scenario

Queue an item's art generation in the background from `model-builder-item-panel.vue`, then click "Auto-build group" (`model-builder-batch-editor.vue`) or "Auto-build all" (`model-builder-progress-matrix.vue`) before it finishes — both buttons are gated only by their own `batching`/`autoBuilding` flag, not `busyCount`. Auto walks straight into `GENERATE_ASSETS` and fires a second, synchronous `generateItemAsset()` call for the same item while the async one is still rendering; whichever response lands last silently overwrites `item.artImageId`/`imagePath` with no re-review, and the render is paid for twice. (The single-item Auto button in `model-builder-item-panel.vue` does not have this hole — it already gates on `isQueued` before calling Auto.)

## Fix

Reuse `isItemManualActionInFlight(item.id)` instead of duplicating the singleton checks inline.

## What changed

- `stores/modelBuilderStore.ts`: `autoBuildItem()`'s manual-action guard now calls the shared `isItemManualActionInFlight(item.id)` helper.
- `utils/scripts/verifyModelBuilderAutoBuildQueuedGuard.ts` (+ `.test.ts`): new regression guard, wired into `package.json`/`contract-tests.yml`.
- `utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts`: updated its own manual-action-guard check to accept either the original inline shape or a call to the shared helper, since both now legitimately appear in the codebase.

Found via an Explore subagent given an explicit exclusion list of every model-builder/t-029 bug class fixed earlier today; confirmed by reading `stores/modelBuilderStore.ts` directly before editing.

## Verification

- `vue-tsc --noEmit` (via `npm run test`): clean.
- `eslint` on changed files: clean (2 pre-existing `no-empty` errors in `modelBuilderStore.ts` confirmed via `git stash` to predate this change).
- `prettier --check`: clean on new files; pre-existing drift on `modelBuilderStore.ts`/`package.json` confirmed via `git stash` to predate this change.
- All `test:model-builder-*` guard + selftest scripts (43 total, including the 2 new ones): pass.
- `verifyCaptureGroupGuards.ts origin/main`: clean.
- `npm run test:workflow-paths`: clean.
- `git diff --stat`: exactly 6 files.

## Safety

No schema, production data, credentials, or outward-facing content changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RNzBLa2fq6rsRamDmUYvVK)_