### PR TITLE
Fix Model Card Lazy Boundary workflow path filter

### DIFF
--- a/.github/workflows/model-card-lazy-boundary.yml
+++ b/.github/workflows/model-card-lazy-boundary.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - 'stores/helpers/modelCards.ts'
       - 'stores/pageStore.ts'
-      - 'pages/[...slug].vue'
+      - 'pages/**'
       - 'utils/scripts/verifyModelCardLazyBoundary.mjs'
       - '.github/workflows/model-card-lazy-boundary.yml'
   workflow_dispatch:


### PR DESCRIPTION
### Task
PR-medic: restore the broken Model Card Lazy Boundary workflow on current `main`.

### What changed / what I produced
- Replace the dynamic Nuxt route's bracketed path-filter pattern with the conservative `pages/**` filter.
- Keep the verifier itself unchanged, so this broadens when the guard may run rather than weakening what it checks.

### How I verified
- Live `main` workflow runs fail before any job is created (`jobs: []`).
- GitHub registers the broken workflow under its filename instead of its declared `name`, consistent with a workflow-definition failure rather than a verifier assertion.
- This PR must prove the repair by producing a real `Model Card Lazy Boundary` job on this exact head and passing the repository's attached checks before merge.

### Stakes
reversible

### Flags for Reviewer
- Root failure is in workflow parsing/filter registration, not the Node verifier; the exact offending construct is the bracketed `pages/[...slug].vue` path filter, introduced with the workflow in #1785.

### Kaizen suggestion
Add a workflow-definition lint/contract that catches malformed Actions path filters before they reach `main`.