### PR TITLE
model-builder/t-029: guard resumeRun() against orphaning an in-flight poll on remount

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -353,6 +353,12 @@ jobs:
       - name: Model Builder auto-build queued-item guard contract
         run: npm run test:model-builder-auto-build-queued-guard
 
+      - name: Model Builder resume-run identity guard checker self-test
+        run: npm run test:model-builder-resume-run-identity-guard-selftest
+
+      - name: Model Builder resume-run identity guard contract
+        run: npm run test:model-builder-resume-run-identity-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -185,6 +185,8 @@
     "test:model-builder-resume-cancelled-run-guard": "tsx utils/scripts/verifyModelBuilderResumeCancelledRunGuard.ts",
     "test:model-builder-auto-build-queued-guard-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildQueuedGuard.test.ts",
     "test:model-builder-auto-build-queued-guard": "tsx utils/scripts/verifyModelBuilderAutoBuildQueuedGuard.ts",
+    "test:model-builder-resume-run-identity-guard-selftest": "tsx utils/scripts/verifyModelBuilderResumeRunIdentityGuard.test.ts",
+    "test:model-builder-resume-run-identity-guard": "tsx utils/scripts/verifyModelBuilderResumeRunIdentityGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1811,11 +1811,25 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       }
 
       if (data) {
-        state.run = adaptRun(data)
-        state.sourceType = data.sourceType as SourceTypeKey
-        state.recipeKey = data.recipeKey as RecipeKey
-        state.step = 'run'
-        setActiveRunId(data.id)
+        // Resuming the run that's already active must not swap in a fresh object:
+        // adaptRun/adaptItem reset the client-only artJobId/queueState fields to
+        // null, and a component remount (e.g. navigating away from and back to
+        // the Model Builder page) re-runs resumeRun() unconditionally. Replacing
+        // state.run here would orphan pollAsyncArtJob's reference to the live item
+        // object mid-poll, making an in-flight async generation silently vanish
+        // from the UI even though it's still running (and completes against the
+        // now-detached object) — the same failure mode openRun() already guards
+        // against for its own reopen path.
+        if (state.run?.id === String(data.id)) {
+          state.step = 'run'
+          setActiveRunId(data.id)
+        } else {
+          state.run = adaptRun(data)
+          state.sourceType = data.sourceType as SourceTypeKey
+          state.recipeKey = data.recipeKey as RecipeKey
+          state.step = 'run'
+          setActiveRunId(data.id)
+        }
       }
     } catch {
       // Not signed in, or no runs yet — start fresh at the source picker.

--- a/utils/scripts/verifyModelBuilderResumeRunIdentityGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderResumeRunIdentityGuard.test.ts
@@ -1,0 +1,143 @@
+// /utils/scripts/verifyModelBuilderResumeRunIdentityGuard.test.ts
+//
+// Regression test for checkResumeRunIdentityGuard() in
+// verifyModelBuilderResumeRunIdentityGuard.ts (model-builder/t-029).
+// Exercises the real check against synthetic store-shaped fixtures
+// covering: the pre-fix shape (resumeRun replaces state.run
+// unconditionally once it resolves `data`, even for the already-active
+// run -- the exact bug found by manual read-through), and the fixed shape
+// (an identity check against state.run?.id short-circuits before that
+// reassignment).
+import assert from 'node:assert/strict'
+
+import { checkResumeRunIdentityGuard } from './verifyModelBuilderResumeRunIdentityGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function resumeRun(): Promise<void> {
+    try {
+      const remembered = safeGet(runIdKey)
+      let data: ServerRun | undefined
+
+      if (remembered) {
+        const response = await performFetch<ServerRun>(
+          \`/api/model-builder/runs/\${remembered}\`,
+        )
+        if (
+          response.success &&
+          response.data &&
+          response.data.status !== 'CANCELLED'
+        ) {
+          data = response.data
+        } else if (response.success && response.data) {
+          safeRemove(runIdKey)
+        }
+      }
+
+      if (!data) {
+        const response = await performFetch<ServerRun[]>(
+          '/api/model-builder/runs?take=1',
+        )
+        if (response.success && Array.isArray(response.data) && response.data.length) {
+          data = response.data[0]
+        }
+      }
+
+      if (data) {
+        state.run = adaptRun(data)
+        state.sourceType = data.sourceType as SourceTypeKey
+        state.recipeKey = data.recipeKey as RecipeKey
+        state.step = 'run'
+        setActiveRunId(data.id)
+      }
+    } catch {
+      // Not signed in, or no runs yet -- start fresh at the source picker.
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function resumeRun(): Promise<void> {
+    try {
+      const remembered = safeGet(runIdKey)
+      let data: ServerRun | undefined
+
+      if (remembered) {
+        const response = await performFetch<ServerRun>(
+          \`/api/model-builder/runs/\${remembered}\`,
+        )
+        if (
+          response.success &&
+          response.data &&
+          response.data.status !== 'CANCELLED'
+        ) {
+          data = response.data
+        } else if (response.success && response.data) {
+          safeRemove(runIdKey)
+        }
+      }
+
+      if (!data) {
+        const response = await performFetch<ServerRun[]>(
+          '/api/model-builder/runs?take=1',
+        )
+        if (response.success && Array.isArray(response.data) && response.data.length) {
+          data = response.data[0]
+        }
+      }
+
+      if (data) {
+        if (state.run?.id === String(data.id)) {
+          state.step = 'run'
+          setActiveRunId(data.id)
+        } else {
+          state.run = adaptRun(data)
+          state.sourceType = data.sourceType as SourceTypeKey
+          state.recipeKey = data.recipeKey as RecipeKey
+          state.step = 'run'
+          setActiveRunId(data.id)
+        }
+      }
+    } catch {
+      // Not signed in, or no runs yet -- start fresh at the source picker.
+    }
+  }
+`
+
+function run(): void {
+  const buggyErrors = checkResumeRunIdentityGuard(BUGGY_FIXTURE)
+  assert.equal(
+    buggyErrors.length,
+    1,
+    'expected the buggy fixture (no identity guard before the adaptRun ' +
+      `reassignment) to fail exactly once, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.match(buggyErrors[0]!, /state\.run\?\.id === String\(data\.id\)/)
+
+  const fixedErrors = checkResumeRunIdentityGuard(FIXED_FIXTURE)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const missingFnErrors = checkResumeRunIdentityGuard(
+    'async function someOtherFunction(): Promise<void> {}',
+  )
+  assert.equal(
+    missingFnErrors.length,
+    1,
+    'expected a fixture with no resumeRun() to fail with a "could not find" error',
+  )
+  assert.match(
+    missingFnErrors[0]!,
+    /Could not find an async function named resumeRun/,
+  )
+
+  console.log(
+    'Model Builder resume-run identity guard self-test passed: buggy ' +
+      'fixture fails, fixed fixture passes, missing-function fixture fails ' +
+      'clearly.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderResumeRunIdentityGuard.ts
+++ b/utils/scripts/verifyModelBuilderResumeRunIdentityGuard.ts
@@ -1,0 +1,117 @@
+// /utils/scripts/verifyModelBuilderResumeRunIdentityGuard.ts
+//
+// Regression guard (model-builder/t-029, kaizen) -- resumeRun() always
+// replaced state.run with a *different* object once it resolved the run to
+// resume, even when that run was already the active one. resumeRun() is
+// called unconditionally on every mount of model-builder-manager.vue, and
+// rebuilds BuildRun/BuildItem objects via adaptRun/adaptItem, which reset
+// the client-only artJobId and queueState fields to null (the server never
+// returns them -- see the BuildItem.artJobId doc comment). pollAsyncArtJob
+// captures a reference to the specific BuildItem object it was called with
+// and polls against that object only, independent of whatever object
+// state.run currently points to. So: user queues an async generate on an
+// item, navigates away from and back to the Model Builder page (a normal
+// SPA remount), and resumeRun() swaps in a freshly-adapted object for the
+// same already-active run, orphaning the in-flight poll. The UI now shows
+// the item as idle (no queued/rendering indicator, buttons re-enabled)
+// while the original job is still running in the background, inviting a
+// second concurrent generation and leaving the eventual first result to
+// land invisibly on the orphaned object -- the same failure mode openRun()
+// already guards against for its own reopen path (see
+// verifyModelBuilderOpenRunIdentityGuard.ts).
+//
+// Fixed by checking state.run's identity against the resolved run's id
+// immediately before the `state.run = adaptRun(` assignment: if they match,
+// keep the live object in place (only update step/activeRunId) instead of
+// replacing it.
+//
+// This asserts the textual shape of that fix stays in place: resumeRun's
+// body checks `state.run?.id === String(data.id)` (or an equivalent
+// identity check against the resolved run's id) strictly before the
+// `state.run = adaptRun(` assignment that would otherwise unconditionally
+// replace state.run.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'resumeRun'
+const REPLACE_ASSIGNMENT = 'state.run = adaptRun('
+const IDENTITY_GUARD = /state\.run\?\.id\s*===\s*String\(data\.id\)/
+
+// Checks the fix's exact shape against the full source text of a file
+// containing a `resumeRun`-named async function. Exported (rather than only
+// exercised via main()) so the self-test below can run it against synthetic
+// buggy/fixed fixtures without touching the real store file.
+export function checkResumeRunIdentityGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find an async function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  const replaceIndex = fn.body.indexOf(REPLACE_ASSIGNMENT)
+  if (replaceIndex === -1) {
+    errors.push(
+      `${FN_NAME}() no longer calls ${REPLACE_ASSIGNMENT} -- this guard's ` +
+        'anchor point has moved; re-check where the run-object replacement ' +
+        'now happens.',
+    )
+    return errors
+  }
+
+  const guardMatch = IDENTITY_GUARD.exec(fn.body)
+  if (!guardMatch || guardMatch.index >= replaceIndex) {
+    errors.push(
+      `${FN_NAME}() does not check \`state.run?.id === String(data.id)\` ` +
+        `before its ${REPLACE_ASSIGNMENT} assignment. Without this guard, ` +
+        'resuming the run that is already active (e.g. on a component ' +
+        'remount) swaps state.run for a freshly-adapted object ' +
+        '(artJobId/queueState reset to null), orphaning any pollAsyncArtJob ' +
+        "poll still bound to the item's live object -- an in-flight async " +
+        'generation silently vanishes from the UI even though it is still ' +
+        'running.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkResumeRunIdentityGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder resume-run identity guard contract failed for ' +
+        `${FN_NAME}() in modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder resume-run identity guard contract passed: ' +
+      `${FN_NAME}() keeps the live state.run object in place when the ` +
+      'resolved run is already active, before the adaptRun reassignment ' +
+      'that would otherwise replace it.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
model-builder/t-029: Polish and upgrade Model Builder front-end surface (kind: software, recurring)

### What changed / what I produced
- `resumeRun()` in `stores/modelBuilderStore.ts` unconditionally replaced `state.run` via `adaptRun()` once it resolved which run to resume — even when that run was already the active one. `model-builder-manager.vue` calls `resumeRun()` unconditionally on every mount, so a normal SPA navigation away from and back to Model Builder while an async "Queue generation in background" render was still in flight would swap `state.run` for a freshly-adapted object (`adaptItem` always resets `artJobId`/`queueState` to `null`), orphaning `pollAsyncArtJob`'s reference to the live item. The item then shows as idle with Generate/Queue re-enabled while the original job is still rendering server-side, inviting a duplicate concurrent render — and the orphaned poll's eventual completion mutates a detached object nothing in the UI references anymore.
- `openRun()` already guards against this exact failure mode when reopening an already-active run (`state.run?.id === runId`, short-circuit before any replacement). `resumeRun()` had no equivalent check. Fixed by adding the same identity guard immediately before the `state.run = adaptRun(...)` assignment.
- Added `utils/scripts/verifyModelBuilderResumeRunIdentityGuard.ts` (+ `.test.ts` selftest), wired into `package.json`/`contract-tests.yml`, mirroring the existing `verifyModelBuilderOpenRunIdentityGuard.ts` pattern.

### How I verified
- Read `stores/modelBuilderStore.ts` directly (`adaptItem`'s `artJobId`/`queueState` reset, `openRun`'s existing guard) before editing, to confirm this is a real bug and not a re-discovery of an already-fixed class.
- `npx vue-tsc --noEmit`: 0 errors repo-wide.
- `npx eslint` on changed/new files: 2 pre-existing `no-empty` errors in `modelBuilderStore.ts` (lines unchanged by this diff), confirmed via `git stash` to predate this change.
- `npx prettier --check` on changed/new files: pre-existing drift on `modelBuilderStore.ts`/`package.json`, confirmed via `git stash` to predate this change; new files are prettier-clean.
- All 45 `test:model-builder-*` guard + selftest scripts pass, including the 2 new ones.
- `npx tsx utils/scripts/verifyCaptureGroupGuards.ts origin/main`: clean.
- `npm run test:workflow-paths`: green (69 workflow files, 686 path references checked).
- `git diff --stat`: exactly 5 files.

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
`resumeRun()` and `openRun()` now duplicate the same identity-guard shape almost verbatim (and `checkOpenRunIdentityGuard`/`checkResumeRunIdentityGuard` are near-duplicate checker scripts). A future pass could factor the guard itself into a small shared helper (e.g. `adoptRunIfChanged(data)`) that both call sites use, reducing the chance a third call site (if one is ever added) forgets the guard entirely.

### Notes for reviewer
Found via an Explore subagent given an explicit exclusion list of every model-builder/t-029 bug class fixed earlier the same day (2026-08-12), continuing that day's recurring bug-hunt cycle.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXwaN2Q9WKuZbmX423u9nX)_