### PR TITLE
fix(model-builder): cancelRun must clear artJobId on every copy of the run

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -359,6 +359,12 @@ jobs:
       - name: Model Builder resume-run identity guard contract
         run: npm run test:model-builder-resume-run-identity-guard
 
+      - name: Model Builder cancel-run poll guard checker self-test
+        run: npm run test:model-builder-cancel-run-poll-guard-selftest
+
+      - name: Model Builder cancel-run poll guard contract
+        run: npm run test:model-builder-cancel-run-poll-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -187,6 +187,8 @@
     "test:model-builder-auto-build-queued-guard": "tsx utils/scripts/verifyModelBuilderAutoBuildQueuedGuard.ts",
     "test:model-builder-resume-run-identity-guard-selftest": "tsx utils/scripts/verifyModelBuilderResumeRunIdentityGuard.test.ts",
     "test:model-builder-resume-run-identity-guard": "tsx utils/scripts/verifyModelBuilderResumeRunIdentityGuard.ts",
+    "test:model-builder-cancel-run-poll-guard-selftest": "tsx utils/scripts/verifyModelBuilderCancelRunPollGuard.test.ts",
+    "test:model-builder-cancel-run-poll-guard": "tsx utils/scripts/verifyModelBuilderCancelRunPollGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1921,12 +1921,25 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       // artifacts onto items that belong to a run the user just cancelled —
       // and popping a misleading "Generated a candidate" success toast for
       // work they said they no longer want.
-      const cancelledRun =
-        state.runs.find((entry) => entry.id === runId) ??
-        (state.run?.id === runId ? state.run : null)
-      cancelledRun?.items.forEach((item) => {
-        item.artJobId = null
-        item.queueState = null
+      //
+      // adaptRun/adaptItem never memoize, so state.runs (populated
+      // independently by fetchRuns(), e.g. when the History panel mounts)
+      // and state.run (the currently open run) can each hold a distinct
+      // object instance for the same run id. pollAsyncArtJob's closure
+      // references whichever item object was live in state.run at the time
+      // generateItemAssetAsync queued the job — clearing only ONE of the two
+      // copies (the old `??` picked at most one) can null the state.runs
+      // duplicate while leaving state.run's original untouched, orphaning
+      // the poll instead of stopping it. Clear both copies whenever present.
+      const cancelledRuns = [
+        state.runs.find((entry) => entry.id === runId),
+        state.run?.id === runId ? state.run : null,
+      ].filter((entry): entry is BuildRun => entry != null)
+      cancelledRuns.forEach((run) => {
+        run.items.forEach((item) => {
+          item.artJobId = null
+          item.queueState = null
+        })
       })
       state.runs = state.runs.filter((entry) => entry.id !== runId)
       if (state.run?.id === runId) resetRun()

--- a/utils/scripts/verifyModelBuilderCancelRunPollGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderCancelRunPollGuard.test.ts
@@ -1,0 +1,117 @@
+// /utils/scripts/verifyModelBuilderCancelRunPollGuard.test.ts
+//
+// Regression test for checkCancelRunPollGuard() in
+// verifyModelBuilderCancelRunPollGuard.ts (model-builder/t-029). Exercises
+// the real check against synthetic store-shaped fixtures covering: the
+// pre-fix shape (`??` picks at most one of the state.runs / state.run
+// copies of the cancelled run before nulling artJobId/queueState -- the
+// exact bug found by an Explore-agent code trace), and the fixed shape
+// (both copies are looked up independently and cleared).
+import assert from 'node:assert/strict'
+
+import { checkCancelRunPollGuard } from './verifyModelBuilderCancelRunPollGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function cancelRun(runId: string): Promise<void> {
+    try {
+      const response = await performFetch(
+        \`/api/model-builder/runs/\${runId}\`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'CANCELLED' }),
+        },
+      )
+      if (!response.success) {
+        setStatus('error', response.message || 'Failed to cancel run.')
+        return
+      }
+      cancelledRunIds.add(runId)
+      const cancelledRun =
+        state.runs.find((entry) => entry.id === runId) ??
+        (state.run?.id === runId ? state.run : null)
+      cancelledRun?.items.forEach((item) => {
+        item.artJobId = null
+        item.queueState = null
+      })
+      state.runs = state.runs.filter((entry) => entry.id !== runId)
+      if (state.run?.id === runId) resetRun()
+      setStatus('success', 'Run cancelled.')
+    } catch (error) {
+      handleError(error, 'cancelling build run')
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function cancelRun(runId: string): Promise<void> {
+    try {
+      const response = await performFetch(
+        \`/api/model-builder/runs/\${runId}\`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'CANCELLED' }),
+        },
+      )
+      if (!response.success) {
+        setStatus('error', response.message || 'Failed to cancel run.')
+        return
+      }
+      cancelledRunIds.add(runId)
+      const cancelledRuns = [
+        state.runs.find((entry) => entry.id === runId),
+        state.run?.id === runId ? state.run : null,
+      ].filter((entry): entry is BuildRun => entry != null)
+      cancelledRuns.forEach((run) => {
+        run.items.forEach((item) => {
+          item.artJobId = null
+          item.queueState = null
+        })
+      })
+      state.runs = state.runs.filter((entry) => entry.id !== runId)
+      if (state.run?.id === runId) resetRun()
+      setStatus('success', 'Run cancelled.')
+    } catch (error) {
+      handleError(error, 'cancelling build run')
+    }
+  }
+`
+
+function run(): void {
+  const buggyErrors = checkCancelRunPollGuard(BUGGY_FIXTURE)
+  assert.equal(
+    buggyErrors.length,
+    1,
+    'expected the buggy fixture (?? picking a single copy) to fail exactly ' +
+      `once, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.match(buggyErrors[0]!, /picks at most one/)
+
+  const fixedErrors = checkCancelRunPollGuard(FIXED_FIXTURE)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const missingFnErrors = checkCancelRunPollGuard(
+    'async function someOtherFunction(): Promise<void> {}',
+  )
+  assert.equal(
+    missingFnErrors.length,
+    1,
+    'expected a fixture with no cancelRun() to fail with a "could not find" error',
+  )
+  assert.match(
+    missingFnErrors[0]!,
+    /Could not find an async function named cancelRun/,
+  )
+
+  console.log(
+    'Model Builder cancel-run poll guard self-test passed: buggy fixture ' +
+      'fails, fixed fixture passes, missing-function fixture fails clearly.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderCancelRunPollGuard.ts
+++ b/utils/scripts/verifyModelBuilderCancelRunPollGuard.ts
@@ -1,0 +1,108 @@
+// /utils/scripts/verifyModelBuilderCancelRunPollGuard.ts
+//
+// Regression guard (model-builder/t-029, kaizen) -- cancelRun()'s
+// poll-stopping step picked at most ONE of state.runs' and state.run's
+// object instances for a cancelled run id via `??`, then nulled
+// artJobId/queueState only on that one. adaptRun/adaptItem never memoize,
+// so state.runs (populated independently by fetchRuns(), e.g. when the
+// History panel mounts) and state.run (the currently open run) can each
+// hold a *different* object instance for the same run id at the same time.
+// pollAsyncArtJob's while loop holds a closure reference to whichever item
+// object was live in state.run when generateItemAssetAsync queued the job
+// -- so if `??` picked the state.runs copy (because both existed), the poll
+// keeps running against state.run's untouched original, defeating the
+// "clearing artJobId makes the loop exit at its next check" mechanism the
+// surrounding comment describes. Concretely: queue an async render, open
+// the History panel (populates state.runs), cancel that same run from
+// there -- the poll silently keeps hitting the ArtJob-status endpoint every
+// ASYNC_ART_POLL_MS for as long as the render takes, well past cancellation.
+//
+// Fixed by clearing artJobId/queueState on every matching copy found across
+// both state.runs and state.run, not just whichever `??` happened to pick.
+//
+// This asserts the textual shape of that fix stays in place: cancelRun's
+// body no longer uses `??` to select a single cancelledRun between
+// state.runs and state.run, and instead nulls items on each copy that
+// exists.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'cancelRun'
+const SINGLE_PICK_PATTERN =
+  /\?\?\s*\(\s*state\.run\?\.id\s*===\s*runId\s*\?\s*state\.run\s*:\s*null\s*\)/
+const RUNS_LOOKUP =
+  /state\.runs\.find\(\s*\(entry\)\s*=>\s*entry\.id\s*===\s*runId\s*\)/
+const RUN_LOOKUP = /state\.run\?\.id\s*===\s*runId\s*\?\s*state\.run\s*:\s*null/
+
+export function checkCancelRunPollGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find an async function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  if (SINGLE_PICK_PATTERN.test(fn.body)) {
+    errors.push(
+      `${FN_NAME}() picks at most one of the state.runs / state.run ` +
+        'copies of the cancelled run via `??` before nulling artJobId/' +
+        'queueState. adaptRun/adaptItem never memoize, so these can be ' +
+        'distinct object instances for the same run id -- clearing only ' +
+        "one leaves pollAsyncArtJob's closure over the other copy's item " +
+        'orphaned and polling indefinitely after cancellation.',
+    )
+    return errors
+  }
+
+  const hasRunsLookup = RUNS_LOOKUP.test(fn.body)
+  const hasRunLookup = RUN_LOOKUP.test(fn.body)
+  if (!hasRunsLookup || !hasRunLookup) {
+    errors.push(
+      `${FN_NAME}() no longer looks up the cancelled run independently in ` +
+        "both state.runs and state.run -- this guard's anchor points have " +
+        'moved; re-check how the poll-stopping copies are resolved.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkCancelRunPollGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder cancel-run poll guard contract failed for ' +
+        `${FN_NAME}() in modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder cancel-run poll guard contract passed: ' +
+      `${FN_NAME}() clears artJobId/queueState on every matching copy of ` +
+      'the cancelled run across state.runs and state.run, not just ' +
+      'whichever one a `??` pick happened to select.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Root cause

`cancelRun()`'s poll-stopping step picked at most one of `state.runs`' and `state.run`'s object instances for the cancelled run id via `??`, then nulled `artJobId`/`queueState` only on that one.

`adaptRun`/`adaptItem` never memoize, so `state.runs` (populated independently by `fetchRuns()`, e.g. when the History panel mounts) and `state.run` (the currently open run) can each hold a **distinct object instance** for the same run id at the same time. `pollAsyncArtJob`'s while loop holds a closure reference to whichever item object was live in `state.run` when `generateItemAssetAsync` queued the job — so when both copies existed and `??` picked the `state.runs` one, the poll kept running against `state.run`'s untouched original, defeating the "clearing `artJobId` makes the loop exit at its next check" mechanism the surrounding comment describes.

## Failure scenario

1. Queue an item's art generation in the background (`generateItemAssetAsync`) — sets `artJobId`/`queueState` on the item inside `state.run` and starts `pollAsyncArtJob` holding a reference to that exact item object.
2. Open the History panel while the job is still pending/running — `model-builder-run-history.vue`'s `fetchRuns()` populates `state.runs` with a fresh, differently-identified copy of every run, including the active one.
3. Cancel that same run from the History list — `cancelRun` finds the `state.runs` copy first via `??` and nulls its items' `artJobId`/`queueState`; the live item inside `state.run` is never touched.
4. The orphaned `pollAsyncArtJob` while-loop keeps polling the ArtJob-status endpoint every `ASYNC_ART_POLL_MS` (5s) for as long as the render takes, well past the user's cancellation. `cancelledRunIds` still correctly prevents the eventual terminal response from persisting a candidate or popping a toast, so this doesn't corrupt data — but it silently defeats the immediate-stop mechanism and leaks background polling for an abandoned run.

## Fix

Clear `artJobId`/`queueState` on every matching copy found across both `state.runs` and `state.run`, not just whichever one `??` happened to select.

## What changed

- `stores/modelBuilderStore.ts`: `cancelRun()`'s poll-stopping step now looks up and clears both copies independently.
- `utils/scripts/verifyModelBuilderCancelRunPollGuard.ts` (+ `.test.ts`): new regression guard, wired into `package.json`/`contract-tests.yml`, mirroring the existing `verifyModelBuilderResumeRunIdentityGuard.ts` pattern.

Found via an Explore subagent given the full accumulated model-builder/t-029 exclusion list and a directive to read the actual store code directly; confirmed by reading `modelBuilderStore.ts` (`adaptRun`/`adaptItem`'s lack of memoization, `fetchRuns()`'s independent population of `state.runs`, `pollAsyncArtJob`'s closure) before editing.

## Verification

- `vue-tsc --noEmit`: clean.
- `eslint` on changed files: clean (2 pre-existing `no-empty` errors in `modelBuilderStore.ts` confirmed via `git stash` to predate this change, same lines).
- `prettier --check` on new files: clean (pre-existing drift on `modelBuilderStore.ts`/`package.json` confirmed via `git stash` to predate this change).
- All 47 `test:model-builder-*` guard + selftest scripts pass, including the 2 new ones.
- `verifyCaptureGroupGuards.ts origin/main`: clean.
- `npm run test:workflow-paths`: clean.
- `git diff --stat`: exactly 5 files.

## Safety

No schema, production data, credentials, or outward-facing content changes.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRTfVFGvwaMvEMXe7Soj8G)_