### PR TITLE
Keep Vercel deploy seed inside the guarded DB pool

### DIFF
--- a/scripts/seed_kr_logo_art_image.ts
+++ b/scripts/seed_kr_logo_art_image.ts
@@ -40,12 +40,17 @@
 import 'dotenv/config'
 import { fileURLToPath } from 'node:url'
 import { PrismaClient } from '../prisma/generated/prisma/client'
-import { PrismaMariaDb } from '@prisma/adapter-mariadb'
+import { createDatabaseAdapter } from '../server/utils/databaseAdapterConfig'
 
 function createSeedPrismaClient(): PrismaClient {
   const databaseUrl = process.env.DATABASE_URL
   if (!databaseUrl) throw new Error('DATABASE_URL is missing')
-  return new PrismaClient({ adapter: new PrismaMariaDb(databaseUrl) })
+
+  // This seed runs during Vercel production builds. Reuse the application's
+  // single adapter factory so it inherits the serverless connection cap,
+  // minimumIdle=0, ProxySQL TLS settings, and text-protocol policy instead of
+  // silently creating @prisma/adapter-mariadb's default 10-connection pool.
+  return new PrismaClient({ adapter: createDatabaseAdapter(databaseUrl) })
 }
 
 // fileName is the idempotency key: ArtImage has no unique slug column, so a


### PR DESCRIPTION
Fixes the current production-build connection-capacity regression found while clearing #1581.

Root cause: `scripts/seed_kr_logo_art_image.ts` constructed `PrismaMariaDb` directly from `DATABASE_URL`, bypassing `createDatabaseAdapter()`. During the current production deployment this created the connector default `limit=10` pool and failed with P2039 / database code 45028 (`pool connections: active=0 idle=0 limit=10`).

This change routes the seed through the same centralized adapter factory as the application, so Vercel builds inherit the serverless pool cap, `minimumIdle=0`, ProxySQL TLS configuration, and text-protocol policy.

No schema or data-shape change. The seed remains idempotent and its existing bounded deploy retry behavior is unchanged.

Issue: #1581