### PR TITLE
Stop globally initializing console progression

### DIFF
--- a/components/admin/kind-loader.vue
+++ b/components/admin/kind-loader.vue
@@ -118,8 +118,7 @@ async function runWave(
 /*
  * Global boot is deliberately conservative. Feature stores initialize from
  * their own surfaces instead of making every visitor download/fetch the whole
- * application. ConsoleStore is intentionally global: its browser-console
- * journey is a product feature for attentive developers, not debug debris.
+ * application.
  */
 async function initializeStores() {
   try {
@@ -135,14 +134,12 @@ async function initializeStores() {
       { useUserStore },
       { usePageStore },
       { useNavStore },
-      { useConsoleStore },
       { useAchievementStore },
       { useThemeStore },
     ] = await Promise.all([
       import('@/stores/userStore'),
       import('@/stores/pageStore'),
       import('@/stores/navStore'),
-      import('@/stores/consoleStore'),
       import('@/stores/achievementStore'),
       import('@/stores/themeStore'),
     ])
@@ -159,7 +156,6 @@ async function initializeStores() {
     await runWave('identity + chrome', [
       usePageStore().initialize?.(),
       useNavStore().initialize?.(),
-      useConsoleStore().initialize?.(),
       achievementStore.initialize?.(),
       // Apply the current/local theme at boot. The shared theme catalog belongs
       // to the Themes surface and should not be fetched for every page visit.
@@ -176,10 +172,11 @@ async function initializeStores() {
 
     /*
      * Servers, checkpoints, art, chat, builders, facets/randomizer, prompts,
-     * rewards, scenarios, characters and the remaining feature stores all
-     * initialize from the surfaces that consume them. Historically boot woke
-     * these systems speculatively, including a 1,000-facet randomizer catalog,
-     * even when the visitor never opened those features.
+     * rewards, scenarios, characters, console progression and the remaining
+     * feature stores all initialize from the surfaces that consume them.
+     * Historically boot woke these systems speculatively, including a 1,000-
+     * facet randomizer catalog, even when the visitor never opened those
+     * features.
      */
   } catch (error) {
     errorStore.setError(

--- a/utils/scripts/verifyBootAchievementBudget.mjs
+++ b/utils/scripts/verifyBootAchievementBudget.mjs
@@ -14,6 +14,11 @@ assert.doesNotMatch(
   /achievementStore\.fetchAchievementRecords\s*\(/,
   'global boot must not fetch all remote achievement records',
 )
+assert.doesNotMatch(
+  loader,
+  /useConsoleStore|consoleStore\.initialize/,
+  'global boot must not initialize console progression',
+)
 assert.match(
   loader,
   /achievementStore\.initialize\?\.\(\)/,
@@ -40,4 +45,4 @@ assert.match(
   'ID-based awards must retain their lazy single-achievement fallback',
 )
 
-console.log('Boot achievement budget contract passed: mount hydrates local state; remote catalogs stay lazy.')
+console.log('Boot achievement budget contract passed: mount stays shell-focused; remote catalogs and console progression stay lazy.')


### PR DESCRIPTION
## Root cause

Issue #1757 identified `consoleStore` as feature state that was still being initialized by the global loader even though repository search shows no live consumer outside `kind-loader.vue`. Its initialization hydrates local progression/messages, emits a random console message, and increments XP for every app mount, which is feature behavior rather than shell boot responsibility.

## What changed

- remove `consoleStore` from `kind-loader.vue`'s global dynamic imports and startup wave
- update the loader contract comment so console progression is explicitly surface-local
- extend the existing boot-budget contract to reject reintroducing `useConsoleStore` or `consoleStore.initialize()` into global boot

## Scope

This is one bounded slice of #1757. It does not delete the console store or change its behavior when deliberately consumed later.

## Safety

No schema, production data, credentials, billing, or outward-facing content changes.

Progresses #1757