### PR TITLE
feat(brainstorm): reusable source-object context adapter (t-012)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -227,6 +227,9 @@ jobs:
       - name: Pitch detector accuracy contract
         run: npm run test:pitch-detector-accuracy
 
+      - name: Brainstorm source adapter contract
+        run: npm run test:brainstorm-source-adapters
+
       - name: mysql:// URL parser contract
         run: npm run test:parse-mysql-url
 

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -249,6 +249,127 @@
 
       <details
         class="mt-4 rounded-2xl border border-base-content/10 bg-base-200/45 p-3"
+        data-testid="brainstorm-source"
+      >
+        <summary class="cursor-pointer select-none text-sm font-bold text-base-content/75">
+          Ground it in a Kind Robots object
+          <span v-if="source" class="ml-2 font-normal text-success">linked</span>
+        </summary>
+
+        <p class="mt-3 max-w-3xl text-xs leading-5 text-base-content/55">
+          Pick a Character or Dream to brainstorm around. It rides along with the session and every candidate, but never changes what the model can see beyond what you'd normally share.
+        </p>
+
+        <div
+          v-if="resolvedSource"
+          class="mt-3 flex items-center gap-3 rounded-2xl border border-primary/25 bg-primary/5 p-3"
+          data-testid="brainstorm-source-selected"
+        >
+          <img
+            v-if="resolvedSource.thumbnailUrl"
+            :src="resolvedSource.thumbnailUrl"
+            :alt="resolvedSource.title"
+            class="h-12 w-12 shrink-0 rounded-xl object-cover"
+          />
+          <div
+            v-else
+            class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-base-300 text-lg"
+            aria-hidden="true"
+          >
+            🧩
+          </div>
+          <div class="min-w-0 flex-1">
+            <p class="truncate text-sm font-black text-base-content">
+              {{ resolvedSource.title }}
+            </p>
+            <p class="truncate text-xs text-base-content/55">
+              {{ resolvedSource.subtitle || resolvedSource.modelType }}
+            </p>
+          </div>
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs rounded-xl text-error"
+            data-testid="brainstorm-source-remove"
+            @click="clearSource"
+          >
+            <Icon name="kind-icon:x" class="h-3.5 w-3.5" />
+            Remove
+          </button>
+        </div>
+        <p v-else-if="isResolvingSource" class="mt-3 text-xs text-base-content/50">
+          Loading selected source…
+        </p>
+
+        <div class="mt-4 grid grid-cols-[auto_minmax(0,1fr)_auto] items-end gap-2">
+          <label class="form-control">
+            <span class="label py-1"
+              ><span class="label-text text-xs font-bold uppercase tracking-[0.12em] text-base-content/55"
+                >Type</span
+              ></span
+            >
+            <select
+              v-model="sourceModelType"
+              class="select select-bordered select-sm rounded-xl bg-base-100"
+              data-testid="brainstorm-source-type"
+            >
+              <option v-for="adapter in sourceAdapters" :key="adapter.modelType" :value="adapter.modelType">
+                {{ adapter.label }}
+              </option>
+            </select>
+          </label>
+          <label class="form-control">
+            <span class="label py-1"
+              ><span class="label-text text-xs font-bold uppercase tracking-[0.12em] text-base-content/55"
+                >Search</span
+              ></span
+            >
+            <input
+              v-model="sourceQuery"
+              type="search"
+              class="input input-bordered input-sm rounded-xl bg-base-100"
+              placeholder="Search by name…"
+              data-testid="brainstorm-source-query"
+              @keydown.enter.prevent="runSourceSearch"
+            />
+          </label>
+          <button
+            type="button"
+            class="btn btn-sm rounded-xl"
+            :disabled="isSearchingSource"
+            data-testid="brainstorm-source-search"
+            @click="runSourceSearch"
+          >
+            <span v-if="isSearchingSource" class="loading loading-spinner loading-xs" aria-hidden="true" />
+            Search
+          </button>
+        </div>
+
+        <ul
+          v-if="sourceSearchResults.length"
+          class="mt-3 grid gap-2"
+          data-testid="brainstorm-source-results"
+        >
+          <li v-for="option in sourceSearchResults" :key="`${option.modelType}-${option.id}`">
+            <button
+              type="button"
+              class="w-full rounded-xl border border-base-content/10 bg-base-100 p-2 text-left text-sm hover:border-primary/40"
+              @click="pickSource(option)"
+            >
+              <span class="font-bold">{{ option.title }}</span>
+              <span v-if="option.subtitle" class="ml-2 text-xs text-base-content/50">{{ option.subtitle }}</span>
+            </button>
+          </li>
+        </ul>
+        <p
+          v-else-if="!isSearchingSource && sourceQuery"
+          class="mt-3 text-xs text-base-content/45"
+        >
+          No {{ sourceModelType }} matched "{{ sourceQuery }}".
+        </p>
+      </details>
+
+      <details
+        class="mt-4 rounded-2xl border border-base-content/10 bg-base-200/45 p-3"
         data-testid="brainstorm-saved-work"
       >
         <summary class="cursor-pointer select-none text-sm font-bold text-base-content/75">
@@ -591,7 +712,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import {
   BRAINSTORM_MAX_RESULTS,
@@ -602,6 +723,15 @@ import type {
   BrainstormReturnTypeId,
 } from '@/types/brainstorm'
 import { useBrainstormStore } from '@/stores/brainstormStore'
+import {
+  listBrainstormSourceAdapters,
+  resolveBrainstormSource,
+  searchBrainstormSources,
+} from '@/stores/helpers/brainstormSourceAdapters'
+import type {
+  BrainstormSourceDisplay,
+  BrainstormSourceOption,
+} from '@/stores/helpers/brainstormSourceAdapters'
 
 const creativeDirections = [
   {
@@ -710,6 +840,7 @@ const {
   isPersisting,
   canSaveSession,
   suggestedSessionName,
+  source,
 } = storeToRefs(store)
 
 const pendingCandidateAction = ref<{
@@ -747,6 +878,55 @@ const sessionNameModel = computed({
   get: () => sessionName.value,
   set: (value: string) => store.setSessionName(value),
 })
+
+// Source object (brainstorm/t-012): ground the premise in an existing Kind
+// Robots entity via the adapter registry in brainstormSourceAdapters.ts.
+const sourceAdapters = listBrainstormSourceAdapters()
+const sourceModelType = ref(sourceAdapters[0]?.modelType ?? 'character')
+const sourceQuery = ref('')
+const sourceSearchResults = ref<BrainstormSourceOption[]>([])
+const isSearchingSource = ref(false)
+const resolvedSource = ref<BrainstormSourceDisplay | null>(null)
+const isResolvingSource = ref(false)
+
+watch(
+  source,
+  async (ref) => {
+    if (!ref) {
+      resolvedSource.value = null
+      return
+    }
+    isResolvingSource.value = true
+    try {
+      resolvedSource.value = await resolveBrainstormSource(ref)
+    } finally {
+      isResolvingSource.value = false
+    }
+  },
+  { immediate: true },
+)
+
+async function runSourceSearch() {
+  isSearchingSource.value = true
+  try {
+    sourceSearchResults.value = await searchBrainstormSources(
+      sourceModelType.value,
+      sourceQuery.value,
+    )
+  } finally {
+    isSearchingSource.value = false
+  }
+}
+
+function pickSource(option: BrainstormSourceOption) {
+  store.setSource({ modelType: option.modelType, id: option.id })
+  sourceSearchResults.value = []
+  sourceQuery.value = ''
+}
+
+function clearSource() {
+  store.setSource(null)
+}
 
 const activeCreativeDirection = computed(
   () => creativeDirections.find((direction) => direction.id === mode.value) || creativeDirections[0],

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -889,18 +889,29 @@ const isSearchingSource = ref(false)
 const resolvedSource = ref<BrainstormSourceDisplay | null>(null)
 const isResolvingSource = ref(false)
 
+// Request-identity token: an overlapping earlier resolve (e.g. two rapid
+// source changes) must not overwrite a later selection or resurrect a
+// removed source once it finally settles (reviewer finding on PR #1820).
+let sourceResolveToken = 0
+
 watch(
   source,
   async (ref) => {
+    const token = ++sourceResolveToken
     if (!ref) {
       resolvedSource.value = null
+      isResolvingSource.value = false
       return
     }
     isResolvingSource.value = true
     try {
-      resolvedSource.value = await resolveBrainstormSource(ref)
+      const resolved = await resolveBrainstormSource(ref)
+      if (token !== sourceResolveToken) return
+      resolvedSource.value = resolved
     } finally {
-      isResolvingSource.value = false
+      if (token === sourceResolveToken) {
+        isResolvingSource.value = false
+      }
     }
   },
   { immediate: true },

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -917,15 +917,26 @@ watch(
   { immediate: true },
 )
 
+// Request-identity token: an overlapping earlier search (e.g. the user
+// changes the type or edits the query while a prior search is still in
+// flight) must not overwrite a newer search's results or clear the loading
+// flag out from under it (follow-up reviewer finding on PR #1820).
+let sourceSearchToken = 0
+
 async function runSourceSearch() {
+  const token = ++sourceSearchToken
   isSearchingSource.value = true
   try {
-    sourceSearchResults.value = await searchBrainstormSources(
+    const results = await searchBrainstormSources(
       sourceModelType.value,
       sourceQuery.value,
     )
+    if (token !== sourceSearchToken) return
+    sourceSearchResults.value = results
   } finally {
-    isSearchingSource.value = false
+    if (token === sourceSearchToken) {
+      isSearchingSource.value = false
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "test:conductor-progress-parity": "tsx utils/scripts/verifyConductorProgressParity.ts",
     "test:pack-manifest": "tsx utils/scripts/verifyPackManifest.test.ts",
     "test:pitch-detector-accuracy": "tsx utils/scripts/verifyPitchDetectorAccuracy.test.ts",
+    "test:brainstorm-source-adapters": "tsx utils/scripts/verifyBrainstormSourceAdapters.test.ts",
     "test:pack-scaffold-extraction": "tsx utils/scripts/verifyPackScaffoldExtraction.test.ts",
     "test:parse-mysql-url": "tsx utils/scripts/verifyParseMysqlUrl.ts",
     "test:newsfeed-aggregation": "tsx utils/scripts/verifyNewsfeedAggregation.ts",

--- a/stores/helpers/brainstormSourceAdapterKit.ts
+++ b/stores/helpers/brainstormSourceAdapterKit.ts
@@ -1,0 +1,105 @@
+// /stores/helpers/brainstormSourceAdapterKit.ts
+//
+// conductor brainstorm/t-012: the store-agnostic half of the source-object
+// adapter contract -- types plus the resolve/search dispatch and fallback
+// logic. Deliberately has NO imports of Pinia stores (characterStore,
+// dreamStore, ...), so it can be unit-tested with plain `tsx`/node, outside
+// a Nuxt/Vite runtime. Per-entity adapters (which DO need live stores) live
+// in brainstormSourceAdapters.ts and import this kit rather than the other
+// way around.
+import type { BrainstormSourceRef } from '@/types/brainstorm'
+
+/** A lightweight row for a source picker's search results. */
+export interface BrainstormSourceOption {
+  modelType: string
+  id: number
+  title: string
+  subtitle?: string
+}
+
+/** The resolved, display-ready shape of a selected source object. */
+export interface BrainstormSourceDisplay extends BrainstormSourceOption {
+  thumbnailUrl: string | null
+}
+
+export interface BrainstormSourceAdapter {
+  /** Canonical modelType key. Matches BrainstormSourceRef.modelType (case-insensitive). */
+  modelType: string
+  /** Human label for the picker UI ("Character", "Dream"). */
+  label: string
+  /** Resolve a ref into a display-ready summary, or null if it can't be found. */
+  resolve: (ref: BrainstormSourceRef) => Promise<BrainstormSourceDisplay | null>
+  /** Search this entity type for the picker. An empty query returns known/recent rows. */
+  search: (query: string) => Promise<BrainstormSourceOption[]>
+}
+
+export type BrainstormSourceAdapterRegistry = Record<
+  string,
+  BrainstormSourceAdapter
+>
+
+/** Case-insensitive matching helper shared by every adapter's search(). */
+export function matchesQuery(
+  haystack: Array<string | null | undefined>,
+  query: string,
+): boolean {
+  const needle = query.trim().toLowerCase()
+  if (!needle) return true
+  return haystack.some((part) => (part || '').toLowerCase().includes(needle))
+}
+
+export function getBrainstormSourceAdapter(
+  modelType: string | null | undefined,
+  registry: BrainstormSourceAdapterRegistry,
+): BrainstormSourceAdapter | null {
+  if (!modelType) return null
+  return registry[modelType.toLowerCase()] || null
+}
+
+/**
+ * Resolve a BrainstormSourceRef into a display-ready summary.
+ *
+ * Falls back to a generic display built from the ref itself (never null for
+ * a non-null ref) when the modelType has no registered adapter yet, or when
+ * a registered adapter's lookup misses -- e.g. the row was deleted since the
+ * ref was captured. The UI can always show *something* and let the user
+ * remove it, rather than the source silently vanishing without explanation.
+ */
+export async function resolveBrainstormSource(
+  ref: BrainstormSourceRef | null | undefined,
+  registry: BrainstormSourceAdapterRegistry,
+): Promise<BrainstormSourceDisplay | null> {
+  if (!ref) return null
+
+  const adapter = getBrainstormSourceAdapter(ref.modelType, registry)
+  if (adapter) {
+    try {
+      const resolved = await adapter.resolve(ref)
+      if (resolved) return resolved
+    } catch {
+      // Fall through to the generic fallback below -- a lookup error should
+      // not make the selected source disappear from the UI.
+    }
+  }
+
+  return {
+    modelType: ref.modelType,
+    id: ref.id ?? 0,
+    title: ref.slug || `${ref.modelType} #${ref.id ?? '?'}`,
+    subtitle: adapter
+      ? 'No longer available'
+      : `Unsupported source type "${ref.modelType}"`,
+    thumbnailUrl: null,
+  }
+}
+
+/** Search a registered entity type for the source picker. Empty array for an unregistered modelType. */
+export async function searchBrainstormSources(
+  modelType: string,
+  query: string,
+  registry: BrainstormSourceAdapterRegistry,
+): Promise<BrainstormSourceOption[]> {
+  const adapter = getBrainstormSourceAdapter(modelType, registry)
+  if (!adapter) return []
+  return adapter.search(query)
+}

--- a/stores/helpers/brainstormSourceAdapterKit.ts
+++ b/stores/helpers/brainstormSourceAdapterKit.ts
@@ -48,6 +48,20 @@ export function matchesQuery(
   return haystack.some((part) => (part || '').toLowerCase().includes(needle))
 }
 
+/**
+ * Return rows only when the caller can prove the fetch just completed
+ * successfully. Some entity stores intentionally fall back to cached rows when
+ * their remote fetch fails; source pickers must not reuse that offline behavior
+ * because cached private rows may predate an auth transition.
+ */
+export async function fetchFreshSourceRows<T>(
+  fetchRows: () => Promise<T[]>,
+  didFetchFail: () => boolean,
+): Promise<T[]> {
+  const rows = await fetchRows()
+  return didFetchFail() ? [] : rows
+}
+
 export function getBrainstormSourceAdapter(
   modelType: string | null | undefined,
   registry: BrainstormSourceAdapterRegistry,

--- a/stores/helpers/brainstormSourceAdapters.ts
+++ b/stores/helpers/brainstormSourceAdapters.ts
@@ -49,7 +49,12 @@ const characterAdapter: BrainstormSourceAdapter = {
   async resolve(ref) {
     if (!ref.id) return null
     const store = useCharacterStore()
-    const character = await store.fetchCharacterById(ref.id)
+    // force=true: a cached/localStorage Character can predate an auth
+    // transition. The server route enforces canView on every request, so a
+    // fresh fetch is the actual authorization check -- serving the cached
+    // row here would let a stale reference expose a Character the current
+    // session is no longer allowed to view (reviewer finding on PR #1820).
+    const character = await store.fetchCharacterById(ref.id, true)
     if (!character) return null
 
     return {

--- a/stores/helpers/brainstormSourceAdapters.ts
+++ b/stores/helpers/brainstormSourceAdapters.ts
@@ -26,6 +26,7 @@ import { useCharacterStore } from '@/stores/characterStore'
 import { useDreamStore } from '@/stores/dreamStore'
 import { resolveArtImageSrc } from '@/utils/artImageSrc'
 import {
+  fetchFreshSourceRows,
   getBrainstormSourceAdapter as getAdapterFromRegistry,
   matchesQuery,
   resolveBrainstormSource as resolveFromRegistry,
@@ -70,14 +71,16 @@ const characterAdapter: BrainstormSourceAdapter = {
   },
   async search(query) {
     const store = useCharacterStore()
-    // force=true: fetchCharacters() short-circuits to whatever is already
-    // cached/persisted once hasLoaded is true, same staleness the resolve()
-    // fix above addresses -- listing candidates from a pre-auth-transition
-    // cache would surface Character rows the current session may no longer
-    // be authorized to view (reviewer finding on PR #1820).
-    await store.fetchCharacters(true)
+    // fetchCharacters(true) intentionally preserves cached rows on network
+    // failure for offline-friendly Character surfaces. The Brainstorm picker
+    // has a stricter privacy contract: if fresh authorization cannot be
+    // confirmed, return zero candidates instead of searching that cache.
+    const freshCharacters = await fetchFreshSourceRows(
+      () => store.fetchCharacters(true),
+      () => Boolean(store.error),
+    )
 
-    return store.characters
+    return freshCharacters
       .filter((character) =>
         matchesQuery(
           [
@@ -121,9 +124,15 @@ const dreamAdapter: BrainstormSourceAdapter = {
   },
   async search(query) {
     const store = useDreamStore()
-    await store.fetchDreams()
+    // fetchDreams() already returns [] when the remote request fails, but use
+    // the same explicit fresh-result contract as Character search so this
+    // adapter can never fall back to store.dreams after a failed revalidation.
+    const freshDreams = await fetchFreshSourceRows(
+      () => store.fetchDreams(),
+      () => Boolean(store.error),
+    )
 
-    return store.dreams
+    return freshDreams
       .filter((dream) =>
         matchesQuery([dream.title, dream.pitch, dream.description], query),
       )

--- a/stores/helpers/brainstormSourceAdapters.ts
+++ b/stores/helpers/brainstormSourceAdapters.ts
@@ -1,0 +1,160 @@
+// /stores/helpers/brainstormSourceAdapters.ts
+//
+// conductor brainstorm/t-012: reusable source-object context adapter.
+//
+// A BrainstormSourceRef (types/brainstorm.ts) only carries
+// `{ modelType, id?, slug?, intent? }` -- enough to persist and replay a
+// session, but not enough to show the user *what* they picked or let them
+// find it in the first place. This registry maps a modelType to a small,
+// inspectable adapter that knows how to:
+//   (a) resolve a ref into a display-ready summary, reusing each entity's
+//       own Pinia store (fetchCharacterById, fetchDreamById, ...) rather
+//       than a bespoke brainstorm-specific endpoint, and
+//   (b) search that entity type for a picker UI.
+//
+// Start with Character and Dream -- the two entity types Brainstorm already
+// has typed hooks into (BrainstormSourceRef.modelType is a free string, but
+// these two are the only ones with real adapters so far). Scenario, Reward,
+// Bot, Project, and Prompt can each register a BrainstormSourceAdapter the
+// same way, with no new API surface and no bespoke endpoint -- just another
+// entry in BRAINSTORM_SOURCE_ADAPTERS backed by that entity's existing store.
+//
+// The store-agnostic dispatch/fallback logic lives in
+// brainstormSourceAdapterKit.ts (no Pinia imports, unit-testable with plain
+// tsx) and is re-exported here bound to the real registry below.
+import { useCharacterStore } from '@/stores/characterStore'
+import { useDreamStore } from '@/stores/dreamStore'
+import { resolveArtImageSrc } from '@/utils/artImageSrc'
+import {
+  getBrainstormSourceAdapter as getAdapterFromRegistry,
+  matchesQuery,
+  resolveBrainstormSource as resolveFromRegistry,
+  searchBrainstormSources as searchFromRegistry,
+} from '@/stores/helpers/brainstormSourceAdapterKit'
+import type { BrainstormSourceAdapter } from '@/stores/helpers/brainstormSourceAdapterKit'
+import type { BrainstormSourceRef } from '@/types/brainstorm'
+
+export type {
+  BrainstormSourceAdapter,
+  BrainstormSourceAdapterRegistry,
+  BrainstormSourceDisplay,
+  BrainstormSourceOption,
+} from '@/stores/helpers/brainstormSourceAdapterKit'
+
+const SEARCH_RESULT_LIMIT = 20
+
+const characterAdapter: BrainstormSourceAdapter = {
+  modelType: 'character',
+  label: 'Character',
+  async resolve(ref) {
+    if (!ref.id) return null
+    const store = useCharacterStore()
+    const character = await store.fetchCharacterById(ref.id)
+    if (!character) return null
+
+    return {
+      modelType: 'character',
+      id: character.id,
+      title: character.name || `Character #${character.id}`,
+      subtitle:
+        [character.honorific, character.class, character.species]
+          .filter(Boolean)
+          .join(' · ') || undefined,
+      thumbnailUrl: character.imagePath || null,
+    }
+  },
+  async search(query) {
+    const store = useCharacterStore()
+    await store.fetchCharacters()
+
+    return store.characters
+      .filter((character) =>
+        matchesQuery(
+          [
+            character.name,
+            character.honorific,
+            character.class,
+            character.species,
+          ],
+          query,
+        ),
+      )
+      .slice(0, SEARCH_RESULT_LIMIT)
+      .map((character) => ({
+        modelType: 'character',
+        id: character.id,
+        title: character.name || `Character #${character.id}`,
+        subtitle: character.honorific || character.class || undefined,
+      }))
+  },
+}
+
+const dreamAdapter: BrainstormSourceAdapter = {
+  modelType: 'dream',
+  label: 'Dream',
+  async resolve(ref) {
+    if (!ref.id) return null
+    const store = useDreamStore()
+    const dream = await store.fetchDreamById(ref.id)
+    if (!dream) return null
+
+    return {
+      modelType: 'dream',
+      id: dream.id,
+      title: dream.title || `Dream #${dream.id}`,
+      subtitle:
+        dream.pitch || dream.description || dream.flavorText || undefined,
+      thumbnailUrl: dream.ArtImage
+        ? resolveArtImageSrc(dream.ArtImage) || null
+        : null,
+    }
+  },
+  async search(query) {
+    const store = useDreamStore()
+    await store.fetchDreams()
+
+    return store.dreams
+      .filter((dream) =>
+        matchesQuery([dream.title, dream.pitch, dream.description], query),
+      )
+      .slice(0, SEARCH_RESULT_LIMIT)
+      .map((dream) => ({
+        modelType: 'dream',
+        id: dream.id,
+        title: dream.title || `Dream #${dream.id}`,
+        subtitle: dream.pitch || dream.description || undefined,
+      }))
+  },
+}
+
+/** The adapter registry. Keys are lowercase modelType strings. */
+export const BRAINSTORM_SOURCE_ADAPTERS: Record<
+  string,
+  BrainstormSourceAdapter
+> = {
+  character: characterAdapter,
+  dream: dreamAdapter,
+}
+
+export function listBrainstormSourceAdapters(): BrainstormSourceAdapter[] {
+  return Object.values(BRAINSTORM_SOURCE_ADAPTERS)
+}
+
+export function getBrainstormSourceAdapter(
+  modelType: string | null | undefined,
+): BrainstormSourceAdapter | null {
+  return getAdapterFromRegistry(modelType, BRAINSTORM_SOURCE_ADAPTERS)
+}
+
+export async function resolveBrainstormSource(
+  ref: BrainstormSourceRef | null | undefined,
+) {
+  return resolveFromRegistry(ref, BRAINSTORM_SOURCE_ADAPTERS)
+}
+
+export async function searchBrainstormSources(
+  modelType: string,
+  query: string,
+) {
+  return searchFromRegistry(modelType, query, BRAINSTORM_SOURCE_ADAPTERS)
+}

--- a/stores/helpers/brainstormSourceAdapters.ts
+++ b/stores/helpers/brainstormSourceAdapters.ts
@@ -70,7 +70,12 @@ const characterAdapter: BrainstormSourceAdapter = {
   },
   async search(query) {
     const store = useCharacterStore()
-    await store.fetchCharacters()
+    // force=true: fetchCharacters() short-circuits to whatever is already
+    // cached/persisted once hasLoaded is true, same staleness the resolve()
+    // fix above addresses -- listing candidates from a pre-auth-transition
+    // cache would surface Character rows the current session may no longer
+    // be authorized to view (reviewer finding on PR #1820).
+    await store.fetchCharacters(true)
 
     return store.characters
       .filter((character) =>

--- a/utils/scripts/verifyBrainstormSourceAdapters.test.ts
+++ b/utils/scripts/verifyBrainstormSourceAdapters.test.ts
@@ -155,6 +155,17 @@ async function main() {
       'so a stale cached row cannot bypass canView after an auth transition.',
   )
 
+  // The same staleness class applies to search: characterStore.fetchCharacters()
+  // short-circuits to whatever is already cached once hasLoaded is true, so an
+  // unforced call after an auth transition can list Character rows the current
+  // session is no longer authorized to view (follow-up reviewer finding on PR
+  // #1820, third review pass).
+  assert.ok(
+    adapterSource.includes('store.fetchCharacters(true)'),
+    'characterAdapter.search must force a fresh Character list fetch ' +
+      '(force=true) so the picker cannot surface pre-auth-transition cached rows.',
+  )
+
   // The source watcher in brainstorm-manager.vue must guard against a
   // slower, superseded resolve overwriting a later selection or resurrecting
   // a removed source -- request-identity/token invalidation, not just a

--- a/utils/scripts/verifyBrainstormSourceAdapters.test.ts
+++ b/utils/scripts/verifyBrainstormSourceAdapters.test.ts
@@ -180,12 +180,42 @@ async function main() {
       'so a superseded in-flight resolve cannot leave the loading flag stuck.',
   )
 
+  // runSourceSearch must carry the same request-identity discipline as the
+  // resolve watcher: a slower, superseded search (e.g. the user changed the
+  // type or edited the query again before the first search returned) must
+  // not overwrite a newer search's results or clear isSearchingSource while
+  // the newer search is still in flight (follow-up reviewer finding on PR
+  // #1820, second review pass).
+  assert.ok(
+    managerSource.includes('let sourceSearchToken = 0'),
+    'brainstorm-manager.vue must track a request-identity token for ' +
+      'runSourceSearch, distinct from sourceResolveToken.',
+  )
+  assert.ok(
+    /const token = \+\+sourceSearchToken/.test(managerSource),
+    'runSourceSearch must mint a fresh token for each call.',
+  )
+  assert.ok(
+    /if \(token !== sourceSearchToken\) return\s*\n\s*sourceSearchResults\.value = results/.test(
+      managerSource,
+    ),
+    'A stale search (token mismatch) must not overwrite sourceSearchResults.',
+  )
+  assert.ok(
+    /if \(token === sourceSearchToken\) \{\s*\n\s*isSearchingSource\.value = false/.test(
+      managerSource,
+    ),
+    'A stale search must not clear isSearchingSource out from under a newer, ' +
+      'still-in-flight search.',
+  )
+
   console.log(
     'Brainstorm source adapter registry verified: case-insensitive lookup, ' +
       'successful resolve passthrough, missing-row and unregistered-modelType ' +
       'fallbacks, thrown-adapter recovery, search dispatch/filtering, the ' +
       "Character adapter force-revalidate contract, and the source watcher's " +
-      'request-identity invalidation contract (brainstorm/t-012).',
+      "and runSourceSearch's request-identity invalidation contracts " +
+      '(brainstorm/t-012).',
   )
 }
 

--- a/utils/scripts/verifyBrainstormSourceAdapters.test.ts
+++ b/utils/scripts/verifyBrainstormSourceAdapters.test.ts
@@ -7,6 +7,7 @@
 // runtime, which this test intentionally never touches; the kit module has
 // no such dependency, which is exactly why the split exists.
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 
 import {
   getBrainstormSourceAdapter,
@@ -136,11 +137,55 @@ async function main() {
   )
   assert.deepEqual(unregistered, [])
 
+  // Real character adapter must revalidate authorization on every resolve,
+  // not serve a cached/localStorage row: a persisted BrainstormSourceRef can
+  // outlive an auth transition, and the server route's canView check only
+  // runs on the live /api/characters/:id fetch, not the cached-store lookup.
+  // Exercising this against the live Pinia store needs a Nuxt runtime this
+  // sandbox doesn't have (documented repeatedly for this repo), so this
+  // asserts the source contract directly -- same pattern as
+  // verifyAchievementStoreFetchSafety.ts (reviewer finding on PR #1820).
+  const adapterSource = readFileSync(
+    'stores/helpers/brainstormSourceAdapters.ts',
+    'utf8',
+  )
+  assert.ok(
+    adapterSource.includes('store.fetchCharacterById(ref.id, true)'),
+    'characterAdapter.resolve must force a fresh Character fetch (force=true) ' +
+      'so a stale cached row cannot bypass canView after an auth transition.',
+  )
+
+  // The source watcher in brainstorm-manager.vue must guard against a
+  // slower, superseded resolve overwriting a later selection or resurrecting
+  // a removed source -- request-identity/token invalidation, not just a
+  // loading flag.
+  const managerSource = readFileSync(
+    'components/brainstorm/brainstorm-manager.vue',
+    'utf8',
+  )
+  assert.ok(
+    managerSource.includes('let sourceResolveToken = 0'),
+    'brainstorm-manager.vue must track a request-identity token for the ' +
+      'source resolve watcher.',
+  )
+  assert.ok(
+    managerSource.includes('if (token !== sourceResolveToken) return'),
+    'A stale resolve (token mismatch) must not overwrite resolvedSource.',
+  )
+  assert.ok(
+    /if\s*\(!ref\)\s*\{\s*resolvedSource\.value = null\s*\n\s*isResolvingSource\.value = false/.test(
+      managerSource,
+    ),
+    'Clearing the source (ref becomes null) must reset isResolvingSource too, ' +
+      'so a superseded in-flight resolve cannot leave the loading flag stuck.',
+  )
+
   console.log(
     'Brainstorm source adapter registry verified: case-insensitive lookup, ' +
       'successful resolve passthrough, missing-row and unregistered-modelType ' +
-      'fallbacks, thrown-adapter recovery, and search dispatch/filtering ' +
-      '(brainstorm/t-012).',
+      'fallbacks, thrown-adapter recovery, search dispatch/filtering, the ' +
+      "Character adapter force-revalidate contract, and the source watcher's " +
+      'request-identity invalidation contract (brainstorm/t-012).',
   )
 }
 

--- a/utils/scripts/verifyBrainstormSourceAdapters.test.ts
+++ b/utils/scripts/verifyBrainstormSourceAdapters.test.ts
@@ -1,0 +1,150 @@
+// /utils/scripts/verifyBrainstormSourceAdapters.test.ts
+//
+// Regression guard for conductor brainstorm/t-012's adapter dispatch/fallback
+// logic (stores/helpers/brainstormSourceAdapterKit.ts). Exercises it in
+// isolation via injected fake adapters -- the real character/dream adapters
+// (brainstormSourceAdapters.ts) call Pinia stores that need a live Nuxt
+// runtime, which this test intentionally never touches; the kit module has
+// no such dependency, which is exactly why the split exists.
+import assert from 'node:assert/strict'
+
+import {
+  getBrainstormSourceAdapter,
+  resolveBrainstormSource,
+  searchBrainstormSources,
+  type BrainstormSourceAdapter,
+} from '../../stores/helpers/brainstormSourceAdapterKit.js'
+
+const fakeCharacterAdapter: BrainstormSourceAdapter = {
+  modelType: 'character',
+  label: 'Character',
+  async resolve(ref) {
+    if (ref.id === 1) {
+      return {
+        modelType: 'character',
+        id: 1,
+        title: 'Captain Marrow',
+        subtitle: 'Rogue · Human',
+        thumbnailUrl: '/images/marrow.webp',
+      }
+    }
+    return null // simulates a deleted/missing row
+  },
+  async search(query) {
+    const rows = [{ id: 1, title: 'Captain Marrow', subtitle: 'Rogue' }]
+    return rows
+      .filter((row) => row.title.toLowerCase().includes(query.toLowerCase()))
+      .map((row) => ({ modelType: 'character', ...row }))
+  },
+}
+
+const throwingAdapter: BrainstormSourceAdapter = {
+  modelType: 'scenario',
+  label: 'Scenario',
+  async resolve() {
+    throw new Error('network exploded')
+  },
+  async search() {
+    return []
+  },
+}
+
+const registry = {
+  character: fakeCharacterAdapter,
+  scenario: throwingAdapter,
+}
+
+async function main() {
+  // Registered modelType, case-insensitive lookup.
+  assert.equal(
+    getBrainstormSourceAdapter('character', registry),
+    fakeCharacterAdapter,
+  )
+  assert.equal(
+    getBrainstormSourceAdapter('CHARACTER', registry),
+    fakeCharacterAdapter,
+  )
+  assert.equal(getBrainstormSourceAdapter('dream', registry), null)
+  assert.equal(getBrainstormSourceAdapter(null, registry), null)
+
+  // null ref resolves to null, not a fallback object.
+  assert.equal(await resolveBrainstormSource(null, registry), null)
+
+  // Registered adapter, successful resolve passes through untouched.
+  const resolved = await resolveBrainstormSource(
+    { modelType: 'character', id: 1 },
+    registry,
+  )
+  assert.deepEqual(resolved, {
+    modelType: 'character',
+    id: 1,
+    title: 'Captain Marrow',
+    subtitle: 'Rogue · Human',
+    thumbnailUrl: '/images/marrow.webp',
+  })
+
+  // Registered adapter, resolve misses (deleted row) -- generic fallback,
+  // distinguishable "no longer available" subtitle, never null.
+  const missing = await resolveBrainstormSource(
+    { modelType: 'character', id: 999, slug: 'ghost-captain' },
+    registry,
+  )
+  assert.ok(missing)
+  assert.equal(missing?.title, 'ghost-captain')
+  assert.equal(missing?.subtitle, 'No longer available')
+  assert.equal(missing?.thumbnailUrl, null)
+
+  // Registered adapter that throws -- caught, same fallback shape, no crash.
+  const errored = await resolveBrainstormSource(
+    { modelType: 'scenario', id: 5 },
+    registry,
+  )
+  assert.ok(errored)
+  assert.equal(errored?.title, 'scenario #5')
+  assert.equal(errored?.subtitle, 'No longer available')
+
+  // Unregistered modelType -- fallback built purely from the ref, distinct
+  // subtitle from the "adapter exists but missed" case above.
+  const unsupported = await resolveBrainstormSource(
+    { modelType: 'bot', id: 3 },
+    registry,
+  )
+  assert.ok(unsupported)
+  assert.equal(unsupported?.title, 'bot #3')
+  assert.equal(unsupported?.subtitle, 'Unsupported source type "bot"')
+
+  // Fallback title prefers slug over the "#id" shape when both are present.
+  const withSlug = await resolveBrainstormSource(
+    { modelType: 'bot', id: 3, slug: 'the-narrator' },
+    registry,
+  )
+  assert.equal(withSlug?.title, 'the-narrator')
+
+  // Search delegates to the matched adapter and filters correctly.
+  const hits = await searchBrainstormSources('character', 'marrow', registry)
+  assert.equal(hits.length, 1)
+  assert.equal(hits[0]?.title, 'Captain Marrow')
+
+  const misses = await searchBrainstormSources('character', 'nobody', registry)
+  assert.equal(misses.length, 0)
+
+  // Search against an unregistered modelType returns empty, not an error.
+  const unregistered = await searchBrainstormSources(
+    'reward',
+    'anything',
+    registry,
+  )
+  assert.deepEqual(unregistered, [])
+
+  console.log(
+    'Brainstorm source adapter registry verified: case-insensitive lookup, ' +
+      'successful resolve passthrough, missing-row and unregistered-modelType ' +
+      'fallbacks, thrown-adapter recovery, and search dispatch/filtering ' +
+      '(brainstorm/t-012).',
+  )
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/utils/scripts/verifyBrainstormSourceAdapters.test.ts
+++ b/utils/scripts/verifyBrainstormSourceAdapters.test.ts
@@ -10,6 +10,7 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 
 import {
+  fetchFreshSourceRows,
   getBrainstormSourceAdapter,
   resolveBrainstormSource,
   searchBrainstormSources,
@@ -137,6 +138,27 @@ async function main() {
   )
   assert.deepEqual(unregistered, [])
 
+  // Source search must fail closed when a fresh authorization/list fetch
+  // fails, even if the underlying store deliberately hands back cached rows
+  // for offline-friendly surfaces. This simulates a cached private row from a
+  // prior auth context plus a failed forced fetch: the picker must expose zero
+  // candidates. A successful fresh fetch may return the same row normally.
+  const cachedPrivateRows = [{ id: 99, title: 'Private Before Logout' }]
+  assert.deepEqual(
+    await fetchFreshSourceRows(
+      async () => cachedPrivateRows,
+      () => true,
+    ),
+    [],
+  )
+  assert.deepEqual(
+    await fetchFreshSourceRows(
+      async () => cachedPrivateRows,
+      () => false,
+    ),
+    cachedPrivateRows,
+  )
+
   // Real character adapter must revalidate authorization on every resolve,
   // not serve a cached/localStorage row: a persisted BrainstormSourceRef can
   // outlive an auth transition, and the server route's canView check only
@@ -155,15 +177,25 @@ async function main() {
       'so a stale cached row cannot bypass canView after an auth transition.',
   )
 
-  // The same staleness class applies to search: characterStore.fetchCharacters()
-  // short-circuits to whatever is already cached once hasLoaded is true, so an
-  // unforced call after an auth transition can list Character rows the current
-  // session is no longer authorized to view (follow-up reviewer finding on PR
-  // #1820, third review pass).
+  // Character and Dream search must both feed their fresh remote result through
+  // the fail-closed helper, and neither may search the store's cached list after
+  // revalidation fails. Character also still forces the remote list fetch.
   assert.ok(
-    adapterSource.includes('store.fetchCharacters(true)'),
-    'characterAdapter.search must force a fresh Character list fetch ' +
-      '(force=true) so the picker cannot surface pre-auth-transition cached rows.',
+    adapterSource.includes('() => store.fetchCharacters(true)') &&
+      adapterSource.includes('return freshCharacters'),
+    'characterAdapter.search must force a fresh Character list fetch and search ' +
+      'only the fail-closed fresh result.',
+  )
+  assert.ok(
+    adapterSource.includes('() => store.fetchDreams()') &&
+      adapterSource.includes('return freshDreams'),
+    'dreamAdapter.search must search only the fail-closed fresh result rather ' +
+      'than store.dreams after a failed remote fetch.',
+  )
+  assert.ok(
+    !adapterSource.includes('return store.characters') &&
+      !adapterSource.includes('return store.dreams'),
+    'Brainstorm source search must never return cached Character or Dream lists directly.',
   )
 
   // The source watcher in brainstorm-manager.vue must guard against a
@@ -224,9 +256,9 @@ async function main() {
     'Brainstorm source adapter registry verified: case-insensitive lookup, ' +
       'successful resolve passthrough, missing-row and unregistered-modelType ' +
       'fallbacks, thrown-adapter recovery, search dispatch/filtering, the ' +
-      "Character adapter force-revalidate contract, and the source watcher's " +
-      "and runSourceSearch's request-identity invalidation contracts " +
-      '(brainstorm/t-012).',
+      'Character adapter force-revalidate contract, fail-closed fresh source ' +
+      "searches, and the source watcher's and runSourceSearch's request-identity " +
+      'invalidation contracts (brainstorm/t-012).',
   )
 }
 


### PR DESCRIPTION
## conductor brainstorm/t-012

Define an explicit, inspectable adapter contract for grounding a Brainstorm session in an existing Kind Robots entity, starting with Character and Dream, designed so Scenario, Reward, Bot, Project, and Prompt can follow without bespoke endpoints.

## What changed

- `stores/helpers/brainstormSourceAdapterKit.ts`: store-agnostic types plus the resolve/search dispatch and fallback logic (no Pinia imports, so it's unit-testable with plain `tsx` outside a Nuxt/Vite runtime).
- `stores/helpers/brainstormSourceAdapters.ts`: the real adapter registry. Character and Dream adapters reuse each entity's existing store (`fetchCharacterById`/`fetchDreamById`) rather than a bespoke endpoint.
- `components/brainstorm/brainstorm-manager.vue`: a "Ground it in a Kind Robots object" panel — type + search picker, a card showing the resolved title/subtitle/thumbnail once selected, and a Remove button that clears the store's existing `source` field. `BrainstormSourceRef` already flowed through generation requests via t-005/t-006; this task was the missing display/picker layer, not new store plumbing.
- `utils/scripts/verifyBrainstormSourceAdapters.test.ts` (+ `package.json`/`contract-tests.yml` wiring): case-insensitive lookup, successful resolve passthrough, missing-row and unregistered-modelType fallbacks (distinct messages), thrown-adapter recovery, and search dispatch, all via injected fake adapters.

## Verification

- `vue-tsc --noEmit` (both scoped and full `npm run test`): clean.
- `eslint` on changed files: clean.
- `prettier --check` on the two new `stores/helpers/*.ts` files and the new test: clean. Kept `brainstorm-manager.vue`'s pre-existing formatting outside the lines this change touches — confirmed via `git stash` that its prettier drift predates this change (same pattern noted for `modelBuilderStore.ts`/`package.json` in recent model-builder work).
- `npm run test:brainstorm-source-adapters`: passes.
- Existing brainstorm contracts unaffected: `verifyBrainstormWorkbench.mjs` and `verifyBrainstormStoreContract.mjs` both still pass.
- `npm run test:workflow-paths`, `verifyCaptureGroupGuards.ts origin/main`: clean.
- `git diff --stat`: exactly 3 modified + 3 new files.

## Not done in this pass (kept in scope per the task's own text)

- No live/preview visual check — kind-robots.vercel.app and its Vercel preview deploys are both down for this whole session (`kind-robots/t-064`, account-level "Deployment Disabled"/"Account is blocked", unrelated to this change). Verified via vue-tsc/eslint/unit tests only; a follow-up session should spot-check the new picker once the outage clears.
- No entry point outside `brainstorm-manager.vue` sets a source yet (e.g. a "Brainstorm about this Character" deep link from a Character page) — out of scope for "define the adapter contract," left for whichever future task wants that specific entry point.

## Safety

No schema, production data, credentials, or outward-facing content changes.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019y3ZZwjhyWw3Uq1c5jRkWQ)_