### PR TITLE
ci: disable retired Vercel Git deployments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ covers only what is true about *this codebase*. Don't restate coordination rules
 ## Stack
 
 Nuxt 4, Vue 3, TypeScript (ES modules), Nitro/h3, Pinia, Tailwind + DaisyUI, Prisma,
-MariaDB. Deployed on Vercel.
+MariaDB. Production is served at `https://kindrobots.org` through the current container/self-hosted deployment path. Vercel is retired infrastructure: its deployment status is not authoritative for this repo and must not block review or merge decisions.
 
 ## Code conventions
 
@@ -54,7 +54,7 @@ MariaDB. Deployed on Vercel.
   `art/storefront-featured.get.ts`).
 - `errorHandler()` (`server/utils/error.ts`) returns `{ success, message, statusCode }`.
   Route handlers funnel failures through it rather than throwing raw errors — it already
-  classifies Prisma, auth, and transient-database errors, and keeps 4xx out of Vercel's
+  classifies Prisma, auth, and transient-database errors, and keeps 4xx out of production
   error clusters.
 - Match the idiom of the file you're editing. Keep diffs small and reviewable.
 - When returning code in chat, return complete copy-paste-ready files or sections — never

--- a/vercel.json
+++ b/vercel.json
@@ -16,11 +16,6 @@
     }
   ],
   "git": {
-    "deploymentEnabled": {
-      "claude/*": true,
-      "agent/*": false,
-      "worker/*": false,
-      "conductor/*": false
-    }
+    "deploymentEnabled": false
   }
 }


### PR DESCRIPTION
Kind Robots production moved to `https://kindrobots.org` and the repository now publishes its production container through GitHub Actions, but the old Vercel project is still Git-connected and has been posting `Vercel: failure — Account is blocked` on every PR.

That external status was the reason otherwise-green PRs #1816, #1818, #1819, and #1821 were parked today. Their GitHub Actions were all green; Vercel was the only systemic red signal.

Vercel's documented repository-side switch for disabling automatic Git deployments is `git.deploymentEnabled: false`. This PR replaces the old branch-specific Vercel deployment map with that global disable. The remaining Vercel config is retained only as inert legacy/manual-deploy configuration; no production routing is changed.

The stronger cleanup is disconnecting the Git repository from the retired Vercel project (`vercel git disconnect`), but the connected Vercel tools in this session expose read/observability rather than that account mutation. This repo-side disable prevents automatic Vercel Git deployments without touching billing, DNS, or current production.