### PR TITLE
Run-scope Model Builder pushItem/batchPushItems exception path (t-041)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -368,6 +368,12 @@ jobs:
       - name: Model Builder cancel-run poll guard contract
         run: npm run test:model-builder-cancel-run-poll-guard
 
+      - name: Model Builder pushItem error-scope guard checker self-test
+        run: npm run test:model-builder-pushitem-error-scope-guard-selftest
+
+      - name: Model Builder pushItem error-scope guard contract
+        run: npm run test:model-builder-pushitem-error-scope-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -194,6 +194,8 @@
     "test:model-builder-resume-run-identity-guard": "tsx utils/scripts/verifyModelBuilderResumeRunIdentityGuard.ts",
     "test:model-builder-cancel-run-poll-guard-selftest": "tsx utils/scripts/verifyModelBuilderCancelRunPollGuard.test.ts",
     "test:model-builder-cancel-run-poll-guard": "tsx utils/scripts/verifyModelBuilderCancelRunPollGuard.ts",
+    "test:model-builder-pushitem-error-scope-guard-selftest": "tsx utils/scripts/verifyModelBuilderPushItemErrorScopeGuard.test.ts",
+    "test:model-builder-pushitem-error-scope-guard": "tsx utils/scripts/verifyModelBuilderPushItemErrorScopeGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -660,7 +660,23 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
           )
         }
       })
-      .catch((error) => handleError(error, 'saving build item'))
+      .catch((error) => {
+        // Mirror the success:false branch above rather than unconditionally
+        // calling handleError: a PATCH that rejects (network error, etc.)
+        // after its run was cancelled or the user has since navigated
+        // elsewhere shouldn't pop a global error banner for a run that's no
+        // longer on screen. setStatusForRun already no-ops unless state.run
+        // still matches the run this write belonged to.
+        if (runId) {
+          setStatusForRun(
+            runId,
+            'error',
+            error instanceof Error
+              ? error.message
+              : 'Failed to save changes.',
+          )
+        }
+      })
   }
 
   // Background persistence of a whole group edit in one round-trip. Callers
@@ -696,7 +712,21 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
           )
         }
       })
-      .catch((error) => handleError(error, 'saving build items'))
+      .catch((error) => {
+        // Same reasoning as pushItem's catch above: mirror the success:false
+        // branch's run-scoping instead of unconditionally calling
+        // handleError, so a rejected batch write doesn't pop a global error
+        // banner for a run the user has cancelled or moved away from.
+        if (runId) {
+          setStatusForRun(
+            runId,
+            'error',
+            error instanceof Error
+              ? error.message
+              : 'Failed to save changes.',
+          )
+        }
+      })
   }
 
   // A stage's content is only safe to overwrite while it is workable — ready,

--- a/utils/scripts/verifyModelBuilderPushItemErrorScopeGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderPushItemErrorScopeGuard.test.ts
@@ -1,0 +1,154 @@
+// /utils/scripts/verifyModelBuilderPushItemErrorScopeGuard.test.ts
+//
+// Regression test for checkPushItemErrorScopeGuard() in
+// verifyModelBuilderPushItemErrorScopeGuard.ts (model-builder/t-041).
+// Exercises the real check against synthetic store-shaped fixtures covering:
+// the pre-fix shape (`.catch((error) => handleError(...))`, unconditional),
+// and the fixed shape (catch block gated on `if (runId)`, routed through
+// setStatusForRun instead of handleError).
+import assert from 'node:assert/strict'
+
+import { checkPushItemErrorScopeGuard } from './verifyModelBuilderPushItemErrorScopeGuard.js'
+
+function fixture(catchBody: string): string {
+  return `
+  function pushItem(
+    item: BuildItem,
+    payload: Record<string, unknown>,
+    meta?: { stage?: string; reason?: string },
+  ): void {
+    const runId = state.run?.id
+    performFetch(\`/api/model-builder/items/\${item.id}\`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...payload, ...meta }),
+    })
+      .then((response) => {
+        if (!response.success && runId) {
+          setStatusForRun(
+            runId,
+            'error',
+            response.message || 'Failed to save changes.',
+          )
+        }
+      })
+      ${catchBody}
+  }
+
+  function batchPushItems(
+    entries: Array<{
+      item: BuildItem
+      payload: Record<string, unknown>
+      meta?: { stage?: string; reason?: string }
+    }>,
+  ): void {
+    if (!entries.length) return
+    const runId = state.run?.id
+    performFetch('/api/model-builder/items/batch', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        items: entries.map(({ item, payload, meta }) => ({
+          id: item.id,
+          ...payload,
+          ...meta,
+        })),
+      }),
+    })
+      .then((response) => {
+        if (!response.success && runId) {
+          setStatusForRun(
+            runId,
+            'error',
+            response.message || 'Failed to save changes.',
+          )
+        }
+      })
+      ${catchBody}
+  }
+`
+}
+
+const BUGGY_CATCH = ".catch((error) => handleError(error, 'saving build item'))"
+
+const FIXED_CATCH = `.catch((error) => {
+        if (runId) {
+          setStatusForRun(
+            runId,
+            'error',
+            error instanceof Error
+              ? error.message
+              : 'Failed to save changes.',
+          )
+        }
+      })`
+
+const REGRESSED_CATCH = `.catch((error) => {
+        if (runId) {
+          setStatusForRun(runId, 'error', 'Failed to save changes.')
+        }
+        handleError(error, 'saving build item')
+      })`
+
+const UNGATED_CATCH = `.catch((error) => {
+        setStatusForRun(runId, 'error', 'Failed to save changes.')
+      })`
+
+function run(): void {
+  const buggyErrors = checkPushItemErrorScopeGuard(fixture(BUGGY_CATCH))
+  assert.equal(
+    buggyErrors.length,
+    2,
+    'expected the buggy fixture (single-expression catch calling ' +
+      'handleError unconditionally, no block for either function) to fail ' +
+      `once per function, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(buggyErrors.every((e) => /no longer has a/.test(e)))
+
+  const fixedErrors = checkPushItemErrorScopeGuard(fixture(FIXED_CATCH))
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const regressedErrors = checkPushItemErrorScopeGuard(fixture(REGRESSED_CATCH))
+  assert.equal(
+    regressedErrors.length,
+    2,
+    'expected a fixture that gates setStatusForRun but ALSO still calls ' +
+      `handleError() unconditionally to fail once per function, got: ${JSON.stringify(regressedErrors)}`,
+  )
+  assert.ok(regressedErrors.every((e) => /handleError\(\) again/.test(e)))
+
+  const ungatedErrors = checkPushItemErrorScopeGuard(fixture(UNGATED_CATCH))
+  assert.equal(
+    ungatedErrors.length,
+    2,
+    'expected a fixture that drops the `if (runId)` gate to fail once per ' +
+      `function, got: ${JSON.stringify(ungatedErrors)}`,
+  )
+  assert.ok(ungatedErrors.every((e) => /gates on `if \(runId\)`/.test(e)))
+
+  const missingFnErrors = checkPushItemErrorScopeGuard(
+    'function someOtherFunction(): void {}',
+  )
+  assert.equal(
+    missingFnErrors.length,
+    2,
+    'expected a fixture with neither pushItem() nor batchPushItems() to ' +
+      'fail with two "could not find" errors',
+  )
+  assert.ok(
+    missingFnErrors.every((e) => /Could not find a function named/.test(e)),
+  )
+
+  console.log(
+    'Model Builder pushItem/batchPushItems error-scope guard self-test ' +
+      'passed: buggy fixture fails, fixed fixture passes, a regressed ' +
+      '(handleError re-added) fixture fails, an ungated fixture fails, ' +
+      'missing-function fixture fails clearly.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderPushItemErrorScopeGuard.ts
+++ b/utils/scripts/verifyModelBuilderPushItemErrorScopeGuard.ts
@@ -1,0 +1,143 @@
+// /utils/scripts/verifyModelBuilderPushItemErrorScopeGuard.ts
+//
+// Regression guard (model-builder/t-041, kaizen from t-029's run-history
+// cancellation-race fix, kind_robots PR #1825) -- pushItem()/batchPushItems()
+// persist a single item (or a batch) in the background after the caller has
+// already applied an optimistic local update. Their `.then` branch already
+// run-scopes a `{success: false}` response: it only surfaces a status toast
+// via setStatusForRun(runId, ...), which itself no-ops unless
+// `state.run?.id === runId` -- so a background write that resolves
+// unsuccessfully for a run the user has since cancelled (state.run reset to
+// null by cancelRun) or navigated away from (state.run pointing at a
+// different run) never surfaces anything.
+//
+// The `.catch` branch had no equivalent scoping: a PATCH that *rejects*
+// (network error, timeout, etc.) rather than resolving with
+// `{success: false}` called the global handleError() unconditionally,
+// popping an app-wide error banner for a run that may no longer be the one
+// on screen -- the same class of "action still fires after the user's
+// context changed" issue t-029 fixed for the synchronous run-history UI
+// path. Fixed by mirroring the `.then` branch's own gate: the catch handler
+// now checks `runId` and routes through setStatusForRun instead of calling
+// handleError at all.
+//
+// This asserts the textual shape of that fix stays in place for both
+// functions: neither's `.catch` block calls handleError(), and both gate a
+// setStatusForRun(...) call behind an `if (runId)` check.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAMES = ['pushItem', 'batchPushItems']
+const CATCH_OPEN = '.catch((error) => {'
+
+// Slices the `.catch((error) => { ... })` block out of a function body via
+// brace-matching, starting from CATCH_OPEN's own opening '{'. Returns null
+// if the function's catch handler isn't (or is no longer) an arrow function
+// block -- e.g. reverted to the single-expression `.catch((error) =>
+// handleError(...))` shape this guard exists to catch.
+function extractCatchBlock(body: string): string | null {
+  const catchIndex = body.indexOf(CATCH_OPEN)
+  if (catchIndex === -1) return null
+
+  const braceOpen = catchIndex + CATCH_OPEN.length - 1
+  let depth = 0
+  for (let i = braceOpen; i < body.length; i++) {
+    if (body[i] === '{') depth++
+    else if (body[i] === '}') {
+      depth--
+      if (depth === 0) return body.slice(braceOpen, i + 1)
+    }
+  }
+  return null
+}
+
+export function checkPushItemErrorScopeGuard(content: string): string[] {
+  const errors: string[] = []
+  const functions = extractFunctionBodies(content)
+
+  for (const fnName of FN_NAMES) {
+    const fn = functions.find((f) => f.name === fnName)
+    if (!fn) {
+      errors.push(
+        `Could not find a function named ${fnName}() -- has it been ` +
+          'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+          'protects against) needs to move with it.',
+      )
+      continue
+    }
+
+    const catchBlock = extractCatchBlock(fn.body)
+    if (!catchBlock) {
+      errors.push(
+        `${fnName}() no longer has a \`${CATCH_OPEN}\` block -- this ` +
+          "guard's anchor point has moved (reverted to a single-expression " +
+          'catch, or restructured entirely). Re-check how it handles a ' +
+          'rejected background write.',
+      )
+      continue
+    }
+
+    if (catchBlock.includes('handleError(')) {
+      errors.push(
+        `${fnName}()'s catch block calls handleError() again -- this pops ` +
+          'a global error banner unconditionally, including for a run the ' +
+          "user has since cancelled or navigated away from. Route it " +
+          "through setStatusForRun(runId, ...) instead, mirroring the " +
+          "same function's own `.then` success:false branch.",
+      )
+    }
+
+    if (!/if\s*\(\s*runId\s*\)/.test(catchBlock)) {
+      errors.push(
+        `${fnName}()'s catch block no longer gates on \`if (runId)\` -- ` +
+          'without it, a rejected write can surface a status update for a ' +
+          "run that isn't the caller's own (or none at all).",
+      )
+    }
+
+    if (!catchBlock.includes('setStatusForRun(')) {
+      errors.push(
+        `${fnName}()'s catch block no longer calls setStatusForRun() -- ` +
+          "it should surface the failure the same way the function's own " +
+          '`.then` success:false branch does, not via a different, ' +
+          'unscoped mechanism.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkPushItemErrorScopeGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder pushItem/batchPushItems error-scope guard contract ' +
+        'failed in modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder pushItem/batchPushItems error-scope guard contract ' +
+      'passed: both catch a rejected write without calling the global ' +
+      'handleError(), scoping the failure through setStatusForRun(runId, ' +
+      '...) instead, same as their own `.then` success:false branch.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
model-builder/t-041: Run-scope the background pushItem/batchPushItems network-exception catch path (kind: software)

### What changed / what I produced
- Kaizen from t-029 (kind_robots PR #1825, run-history cancellation-race fix). `pushItem()`/`batchPushItems()`'s `.then` branch already run-gates a `{success:false}` response via `setStatusForRun(runId, ...)`, which no-ops unless `state.run` still matches the run this write belonged to. Their `.catch` branch had no equivalent gate: a PATCH that *rejects* (network error, timeout, etc.) called the global `handleError()` unconditionally, popping an app-wide error banner for a run the user has since cancelled or navigated away from.
- Fixed both catch handlers to mirror the success:false branch's own gate — route the rejection through `setStatusForRun(runId, ...)` instead of the unscoped global `handleError()`.
- Added `utils/scripts/verifyModelBuilderPushItemErrorScopeGuard.ts` (+ `.test.ts` self-test) following this file's established static-guard convention (mirrors `verifyModelBuilderCancelRunPollGuard.ts`), wired into `package.json` and `contract-tests.yml`.

### How I verified
- `npx vue-tsc --noEmit` — clean.
- `npm run test:lint-ratchet` — 339 problems across 24 rules (−53), no rule got worse.
- New guard self-test + contract both pass; proven against the pre-fix source (fails with "no longer has a `.catch((error) => {` block") and the fixed source (passes) by running the check function directly against `git show HEAD:stores/modelBuilderStore.ts` before this change existed.
- `npm run test:model-builder-cancel-run-poll-guard(-selftest)` — unaffected, still green (adjacent t-029 guard).

### Stakes
reversible

### Flags for Reviewer
- None — this is a self-contained store-only change with no schema/API/UI surface change.

### Kaizen suggestion
`generateItemAsset`'s own catch calls `handleError()` unconditionally once past its `cancelledRunIds` check (i.e. for any error on a still-active, non-cancelled run) — worth checking whether that should also route through `setStatusForRun` for consistency, or whether the synchronous generate path genuinely wants the stronger global-banner treatment since it's a user-initiated action rather than a background auto-save.

### Notes for reviewer
Conductor: model-builder/t-041 (soft `ready` → `review`, no `gate_human`/`soft_gate` set — plain reversible software task).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHACPYrGQSuDcZqv542mN7)_