### PR TITLE
feat(davinci): integrate contextual art throughout the playable run (t-020)

### DIFF
--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -196,6 +196,12 @@
             <h4 v-if="currentChapter.title" class="text-base font-black">
               {{ currentChapter.title }}
             </h4>
+            <NarrativeArtStatus
+              v-if="currentChapterArt"
+              :art="currentChapterArt"
+              :label="`Illustration for chapter ${chapterIndex}`"
+              @retry="retryCurrentChapterArt"
+            />
             <p
               class="whitespace-pre-line text-sm leading-relaxed text-base-content/75"
             >
@@ -265,6 +271,13 @@
             {{ endingData.victoryType }}
           </span>
           <h4 class="text-xl font-black">{{ endingData.title }}</h4>
+          <NarrativeArtStatus
+            v-if="endingArt"
+            class="w-full max-w-md"
+            :art="endingArt"
+            :label="`Illustration for how ${run?.protagonistName || 'this life'} ended`"
+            @retry="retryEndingArt"
+          />
           <p class="max-w-md text-sm text-base-content/70">
             {{ endingData.summary }}
           </p>
@@ -317,6 +330,8 @@ import { performFetch } from '@/stores/utils'
 import { useUserStore } from '@/stores/userStore'
 import type { ProjectFrontConfig } from '@/components/conductor/projectFront'
 import { useAchievementStore } from '@/stores/achievementStore'
+import { createNarrativeArtJobsController } from '@/stores/helpers/narrativeArtJobsHelper'
+import type { NarrativeArtJobState } from '@/utils/narrativeArtJobs'
 
 // Mirrors server/utils/davinci.ts DAVINCI_DIMENSIONS — bit order is a
 // display concern here (the server owns the real resolve math), but keeping
@@ -509,6 +524,16 @@ interface LifeEndingData {
   summary: string
   victoryType: 'VICTORY' | 'FAILURE' | 'MIXED' | 'SECRET'
 }
+// Mirrors the LifeRunArt row shape server/utils/davinci.ts's getLifeRunForUser
+// returns, joined with just enough ArtImage to resolve a display path.
+interface LifeRunArtRow {
+  id: number
+  chapter: number | null
+  sceneType: string
+  prompt: string
+  artImageId: number
+  ArtImage: { imagePath: string | null; path: string | null } | null
+}
 interface LifeRunRecord {
   id: number
   title: string
@@ -518,6 +543,7 @@ interface LifeRunRecord {
   Stats: LifeStatRow[]
   Choices: LifeChoiceRow[]
   Ending: LifeEndingData | null
+  Art?: LifeRunArtRow[]
 }
 interface ChoiceResponseData {
   stats: LifeStatRow[]
@@ -581,6 +607,19 @@ const narrationError = ref('')
 const narratorName = ref('')
 const aiChapter = ref<ActiveChapter | null>(null)
 
+// Contextual in-run art (davinci/t-020). The narrator proposes an artPrompt
+// per chapter and the resolve screen synthesizes one for the ending; both are
+// requested through the same shared /api/art/enqueue narrativeContext
+// pipeline Storybook and Taskmaster already use (product: 'davinci'), then
+// persisted as a LifeRunArt row once the queued job resolves to a real
+// ArtImage — see server/utils/davinci.ts's attachLifeRunArt. Reading/choosing
+// never blocks on this: chapterArt/endingArt render a pending/skeleton state
+// via <NarrativeArtStatus> until the illustration is ready.
+const narrativeArtJobs = createNarrativeArtJobsController()
+const chapterArt = ref<Record<number, NarrativeArtJobState>>({})
+const endingArt = ref<NarrativeArtJobState | null>(null)
+const lastArtPrompt = ref<string | null>(null)
+
 const chapterIndex = computed(() => playedCount.value + 1)
 
 const curatedChapter = computed<ActiveChapter | null>(() => {
@@ -603,6 +642,22 @@ const canEndRun = computed(
   () => playedCount.value >= MIN_CHAPTERS_BEFORE_ENDING,
 )
 
+const currentChapterArt = computed<NarrativeArtJobState | undefined>(
+  () => chapterArt.value[chapterIndex.value],
+)
+
+function retryCurrentChapterArt() {
+  const chapter = chapterIndex.value
+  const art = chapterArt.value[chapter]
+  if (!art) return
+  narrativeArtJobs.retry(art, (next) => updateChapterArt(chapter, next))
+}
+
+function retryEndingArt() {
+  if (!endingArt.value) return
+  narrativeArtJobs.retry(endingArt.value, updateEndingArt)
+}
+
 function statsToMap(stats: LifeStatRow[]): Record<string, number> {
   const map: Record<string, number> = {}
   for (const stat of stats) map[stat.key] = stat.value
@@ -622,6 +677,119 @@ function victoryBadgeClass(type: LifeEndingData['victoryType']) {
   }
 }
 
+// Best-effort: the illustration is decorative, so a failed attach never
+// surfaces an error to the player — the run keeps working either way.
+async function persistLifeRunArt(
+  chapter: number | null,
+  sceneType: 'THRESHOLD' | 'ENDING',
+  prompt: string,
+  artImageId: number,
+) {
+  if (!run.value) return
+  await performFetch(`/api/davinci/runs/${run.value.id}/art`, {
+    method: 'POST',
+    body: JSON.stringify({ chapter, sceneType, prompt, artImageId }),
+  }).catch(() => null)
+}
+
+function updateChapterArt(chapter: number, art: NarrativeArtJobState) {
+  const wasDone = chapterArt.value[chapter]?.status === 'done'
+  chapterArt.value = { ...chapterArt.value, [chapter]: art }
+  if (!wasDone && art.status === 'done' && art.artImageId) {
+    void persistLifeRunArt(
+      chapter,
+      'THRESHOLD',
+      art.promptString,
+      art.artImageId,
+    )
+  }
+}
+
+function updateEndingArt(art: NarrativeArtJobState) {
+  const wasDone = endingArt.value?.status === 'done'
+  endingArt.value = art
+  if (!wasDone && art.status === 'done' && art.artImageId) {
+    void persistLifeRunArt(null, 'ENDING', art.promptString, art.artImageId)
+  }
+}
+
+// Chapter-transition art (sceneType THRESHOLD): requested once per chapter,
+// the moment the narrator proposes a non-null artPrompt for it. Skipped for
+// chapters that already have art (a resumed run's hydrated rows, or a
+// duplicate narrate() call for the same chapter).
+function requestChapterArt(chapter: number, artPrompt: string) {
+  if (!run.value || chapterArt.value[chapter]) return
+  void narrativeArtJobs.enqueue(
+    {
+      product: 'davinci',
+      sessionId: `davinci-run-${run.value.id}`,
+      beatId: `chapter-${chapter}`,
+      moment: 'chapter',
+      narrative: artPrompt,
+      title: run.value.protagonistName || run.value.title,
+    },
+    (art) => updateChapterArt(chapter, art),
+  )
+}
+
+// Ending art (sceneType ENDING): a personalized illustration of this specific
+// run's outcome, distinct from the shared per-outcomeKey ending art seeded by
+// scripts/generate_davinci_endings.py. Prefers the narrator's last proposed
+// artPrompt (the freshest visual detail for how this life was trending);
+// falls back to a synthesized prompt from the ending itself when no chapter
+// ever proposed one (e.g. the curated fallback pool, which has no narrator).
+function requestEndingArt() {
+  if (!run.value || !endingData.value || endingArt.value) return
+  const ending = endingData.value
+  const artPrompt =
+    lastArtPrompt.value ||
+    `The moment this life resolved: ${ending.title} — ${ending.summary}`
+  void narrativeArtJobs.enqueue(
+    {
+      product: 'davinci',
+      sessionId: `davinci-run-${run.value.id}`,
+      beatId: `ending-${run.value.id}`,
+      moment: 'finale',
+      narrative: artPrompt,
+      title: run.value.protagonistName || run.value.title,
+      objective: ending.title,
+    },
+    updateEndingArt,
+  )
+}
+
+// Rehydrates already-attached LifeRunArt rows into displayable, terminal
+// ('done') job states — no polling needed, the image is already resolved.
+function hydrateArtFromRun(data: LifeRunRecord) {
+  chapterArt.value = {}
+  endingArt.value = null
+  const timestamp = new Date().toISOString()
+  for (const row of data.Art ?? []) {
+    const imagePath = row.ArtImage?.imagePath || row.ArtImage?.path || null
+    const state: NarrativeArtJobState = {
+      dedupeKey: `davinci:${data.id}:${row.sceneType}:${row.chapter ?? 'ending'}:${row.id}`,
+      product: 'davinci',
+      sessionId: `davinci-run-${data.id}`,
+      beatId: row.chapter ? `chapter-${row.chapter}` : `ending-${data.id}`,
+      moment: row.sceneType === 'ENDING' ? 'finale' : 'chapter',
+      surface: 'scene-landscape',
+      profileKey: 'davinci-narrative-krea4',
+      promptString: row.prompt,
+      status: 'done',
+      artImageId: row.artImageId,
+      imagePath,
+      error: null,
+      requestedAt: timestamp,
+      updatedAt: timestamp,
+    }
+    if (row.sceneType === 'ENDING') {
+      endingArt.value = state
+    } else if (row.chapter) {
+      chapterArt.value[row.chapter] = state
+    }
+  }
+}
+
 async function resumeRun(id: number) {
   phase.value = 'loading'
   const response = await performFetch<LifeRunRecord>(`/api/davinci/runs/${id}`)
@@ -634,10 +802,12 @@ async function resumeRun(id: number) {
   run.value = response.data
   statMap.value = statsToMap(response.data.Stats || [])
   playedCount.value = response.data.Choices?.length ?? 0
+  hydrateArtFromRun(response.data)
 
   if (response.data.status === 'COMPLETE' && response.data.Ending) {
     endingData.value = response.data.Ending
     phase.value = 'ending'
+    requestEndingArt()
   } else {
     phase.value = 'playing'
     if (narrationMode.value === 'ai') await narrateChapter()
@@ -709,6 +879,11 @@ async function narrateChapter() {
       effects: choice.effects,
     })),
     milestoneCandidate: response.data.milestoneCandidate,
+  }
+
+  if (response.data.artPrompt) {
+    lastArtPrompt.value = response.data.artPrompt
+    requestChapterArt(response.data.chapter, response.data.artPrompt)
   }
 }
 
@@ -790,6 +965,9 @@ function playAgain() {
   narrationMode.value = 'ai'
   narrationError.value = ''
   aiChapter.value = null
+  chapterArt.value = {}
+  endingArt.value = null
+  lastArtPrompt.value = null
   phase.value = 'start'
 }
 
@@ -870,8 +1048,9 @@ const config: ProjectFrontConfig = {
       'Life-run schema (runs, choices, stats, endings, achievements)',
       'Da Vinci API surface',
       'Playable run UI',
+      'Contextual chapter and ending art',
     ],
-    next: ['Achievement gallery', 'Generated art per chapter'],
+    next: ['Achievement gallery'],
   },
 }
 </script>

--- a/server/api/art/enqueue.post.ts
+++ b/server/api/art/enqueue.post.ts
@@ -60,7 +60,7 @@ type EnqueueEngine =
 type JsonRecord = Record<string, unknown>
 
 type NarrativeEnqueueContext = {
-  product: 'storybook' | 'taskmaster'
+  product: 'storybook' | 'taskmaster' | 'davinci'
   sessionId: string
   beatId: string
   moment: string
@@ -184,7 +184,11 @@ function narrativeRequest(
     'finale',
   ])
 
-  if (product !== 'storybook' && product !== 'taskmaster') {
+  if (
+    product !== 'storybook' &&
+    product !== 'taskmaster' &&
+    product !== 'davinci'
+  ) {
     throw createError({
       statusCode: 400,
       message: 'Invalid narrative product.',

--- a/server/api/art/queue/narrative.get.ts
+++ b/server/api/art/queue/narrative.get.ts
@@ -5,7 +5,7 @@ import { errorHandler } from '../../../utils/error'
 import { requireMachineUser } from '../../../utils/authGuard'
 
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9_-]*$/
-const ALLOWED_PRODUCTS = new Set(['storybook', 'taskmaster'])
+const ALLOWED_PRODUCTS = new Set(['storybook', 'taskmaster', 'davinci'])
 const ALLOWED_MOMENTS = new Set([
   'opening',
   'chapter',

--- a/server/api/davinci/runs/[id]/art.post.ts
+++ b/server/api/davinci/runs/[id]/art.post.ts
@@ -1,0 +1,57 @@
+// /server/api/davinci/runs/[id]/art.post.ts
+//
+// Attaches a resolved illustration to a Da Vinci life run as a LifeRunArt row.
+// The narrator only *proposes* an artPrompt (server/utils/davinciNarration.ts);
+// the client requests art for that prompt through the same shared
+// /api/art/enqueue narrativeContext pipeline Storybook and Taskmaster already
+// use (product: 'davinci'), then — once that job resolves to a real ArtImage —
+// calls this route to persist the (lifeRunId, chapter, sceneType, prompt,
+// artImageId) row. Only the run's owner may attach art to it.
+
+import { defineEventHandler, readBody, createError } from 'h3'
+import { errorHandler } from '../../../../utils/error'
+import { requireApiUser } from '../../../../utils/authGuard'
+import { attachLifeRunArt } from '../../../../utils/davinci'
+
+export default defineEventHandler(async (event) => {
+  let response
+
+  try {
+    const { user } = await requireApiUser(event)
+
+    const lifeRunId = Number(event.context.params?.id)
+    if (!Number.isInteger(lifeRunId) || lifeRunId <= 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'LifeRun ID must be a positive integer.',
+      })
+    }
+
+    const body = await readBody(event)
+
+    const data = await attachLifeRunArt(lifeRunId, user.id, {
+      chapter: body?.chapter ?? null,
+      sceneType: body?.sceneType,
+      prompt: body?.prompt,
+      artImageId: body?.artImageId,
+    })
+
+    response = {
+      success: true,
+      message: `Art attached to run ${lifeRunId}.`,
+      data,
+      statusCode: 201,
+    }
+    event.node.res.statusCode = 201
+  } catch (error) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+    response = {
+      success: false,
+      message: handledError.message || 'Failed to attach art to life run.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+
+  return response
+})

--- a/server/utils/davinci.ts
+++ b/server/utils/davinci.ts
@@ -9,6 +9,7 @@
 // '1' = pass. Do not reorder without migrating the seeded endings.
 
 import prisma from './prisma'
+import { LifeArtSceneType } from '~/prisma/generated/prisma/client'
 import {
   DAVINCI_DIMENSIONS,
   resolveOutcomeKey,
@@ -457,7 +458,9 @@ export async function recordLifeChoice(
   })
 }
 
-// Loads a run with its stats, choices, and (if resolved) ending — for resume.
+// Loads a run with its stats, choices, contextual art, and (if resolved)
+// ending — for resume. Art is included so a resumed run redisplays chapter
+// and ending illustrations already attached, without a second round trip.
 export async function getLifeRunForUser(lifeRunId: number, userId: number) {
   const run = await prisma.lifeRun.findUnique({
     where: { id: lifeRunId },
@@ -465,6 +468,17 @@ export async function getLifeRunForUser(lifeRunId: number, userId: number) {
       Stats: { orderBy: { key: 'asc' } },
       Choices: { orderBy: [{ chapter: 'asc' }, { id: 'asc' }] },
       Ending: true,
+      Art: {
+        orderBy: [{ chapter: 'asc' }, { id: 'asc' }],
+        select: {
+          id: true,
+          chapter: true,
+          sceneType: true,
+          prompt: true,
+          artImageId: true,
+          ArtImage: { select: { imagePath: true, path: true } },
+        },
+      },
     },
   })
   if (!run) throw withStatusCode(`LifeRun ${lifeRunId} does not exist.`, 404)
@@ -475,4 +489,80 @@ export async function getLifeRunForUser(lifeRunId: number, userId: number) {
     )
   }
   return run
+}
+
+export interface AttachLifeRunArtInput {
+  chapter?: number | null
+  sceneType: string
+  prompt: string
+  artImageId: number
+}
+
+// Persists a LifeRunArt row once a queued illustration for this run resolves
+// to a real ArtImage. The narrator only ever *proposes* an artPrompt (see
+// server/utils/davinciNarration.ts); this is the one place that turns a
+// resolved image into durable contextual art, reusing the shared
+// enqueue/entityArt art pipeline's output rather than a parallel store.
+// Idempotent per (lifeRunId, chapter, sceneType): a resumed run that recovers
+// or retries the same art job updates the existing row instead of duplicating
+// it, since LifeRunArt has no unique constraint on that triple.
+export async function attachLifeRunArt(
+  lifeRunId: number,
+  userId: number,
+  input: AttachLifeRunArtInput,
+) {
+  const validSceneTypes = Object.values(LifeArtSceneType) as string[]
+  if (!validSceneTypes.includes(input.sceneType)) {
+    throw withStatusCode(
+      `sceneType must be one of ${validSceneTypes.join(', ')}.`,
+      400,
+    )
+  }
+  const sceneType = input.sceneType as LifeArtSceneType
+  const chapter =
+    input.chapter === null || input.chapter === undefined
+      ? null
+      : Number(input.chapter)
+  if (chapter !== null && (!Number.isInteger(chapter) || chapter <= 0)) {
+    throw withStatusCode('chapter must be a positive integer or null.', 400)
+  }
+  const prompt = input.prompt?.trim()
+  if (!prompt) throw withStatusCode('prompt is required.', 400)
+  const artImageId = Number(input.artImageId)
+  if (!Number.isInteger(artImageId) || artImageId <= 0) {
+    throw withStatusCode('artImageId must be a positive integer.', 400)
+  }
+
+  const run = await prisma.lifeRun.findUnique({ where: { id: lifeRunId } })
+  if (!run) throw withStatusCode(`LifeRun ${lifeRunId} does not exist.`, 404)
+  if (run.userId !== userId) {
+    throw withStatusCode(
+      'LifeRun does not belong to the authenticated user.',
+      403,
+    )
+  }
+
+  const artImage = await prisma.artImage.findUnique({
+    where: { id: artImageId },
+  })
+  if (!artImage) {
+    throw withStatusCode(`ArtImage ${artImageId} does not exist.`, 404)
+  }
+
+  const existing = await prisma.lifeRunArt.findFirst({
+    where: { lifeRunId, chapter, sceneType },
+  })
+
+  if (existing) {
+    return prisma.lifeRunArt.update({
+      where: { id: existing.id },
+      data: { artImageId, prompt },
+      include: { ArtImage: { select: { imagePath: true, path: true } } },
+    })
+  }
+
+  return prisma.lifeRunArt.create({
+    data: { lifeRunId, chapter, sceneType, prompt, artImageId },
+    include: { ArtImage: { select: { imagePath: true, path: true } } },
+  })
 }

--- a/stores/artStore.ts
+++ b/stores/artStore.ts
@@ -109,7 +109,7 @@ export type QueuedArtJob = {
 }
 
 export type NarrativeArtEnqueueContext = {
-  product: 'storybook' | 'taskmaster'
+  product: 'storybook' | 'taskmaster' | 'davinci'
   sessionId: string
   beatId: string
   moment: string

--- a/utils/narrativeArtProfiles.ts
+++ b/utils/narrativeArtProfiles.ts
@@ -1,11 +1,12 @@
 // /utils/narrativeArtProfiles.ts
 //
-// Storybook creates stories. Taskmaster uses stories to finish tasks.
-// Neither experience asks the user to configure image-generation internals.
-// Product code selects one of these centralized profiles and derives the prompt
-// from narrative state, Facets, characters, locations, and the target surface.
+// Storybook creates stories. Taskmaster uses stories to finish tasks. Da Vinci
+// narrates a branching life. None of these experiences ask the user to
+// configure image-generation internals. Product code selects one of these
+// centralized profiles and derives the prompt from narrative state, Facets,
+// characters, locations, and the target surface.
 
-export type NarrativeProduct = 'storybook' | 'taskmaster'
+export type NarrativeProduct = 'storybook' | 'taskmaster' | 'davinci'
 
 export type NarrativeArtMoment =
   | 'opening'
@@ -75,6 +76,22 @@ export const NARRATIVE_ART_PROFILES: Record<
     defaultSurface: 'scene-landscape',
     styleDirective:
       'adventurous quest-board illustration, clear objective-focused composition, playful stakes, practical visual readability, polished storybook finish',
+    negativePrompt: SHARED_NEGATIVE_PROMPT,
+  },
+  davinci: {
+    key: 'davinci-narrative-krea4',
+    product: 'davinci',
+    engine: 'krea2',
+    steps: 4,
+    cfg: 1,
+    sampler: 'euler',
+    scheduler: 'simple',
+    denoise: 1,
+    designer: 'davinci-auto-narrator',
+    projectSlug: 'davinci',
+    defaultSurface: 'scene-landscape',
+    styleDirective:
+      'painterly single-life biographical illustration, one Renaissance-workshop-inflected scene, expressive protagonist, coherent visual continuity across the same life',
     negativePrompt: SHARED_NEGATIVE_PROMPT,
   },
 }


### PR DESCRIPTION
## Task

Conductor `davinci/t-020`: "Integrate contextual art throughout the playable Da Vinci run." The narrator (`server/utils/davinciNarration.ts`) already proposed a per-chapter `artPrompt`, but `LifeRunArt` had zero server or component call sites consuming it — confirmed via `grep -rn "LifeRunArt" server/ components/ stores/` before starting, which found only the schema model, the `ArtImage` relation, and t-018's read-only coverage endpoint.

## What changed

Reused the shared narrative-art request pipeline Storybook and Taskmaster already use (`/api/art/enqueue`'s `narrativeContext`, `stores/helpers/narrativeArtJobsHelper.ts`, `<NarrativeArtStatus>`) instead of inventing a parallel store, and wired it to persist into the existing `LifeRunArt` model — no schema change needed, it already had every field.

- **`utils/narrativeArtProfiles.ts`**: added a `'davinci'` `NarrativeProduct` + profile (krea2, life-sim style directive).
- **`server/api/art/enqueue.post.ts`**, **`server/api/art/queue/narrative.get.ts`**, **`stores/artStore.ts`**: extended the existing `product: 'storybook' | 'taskmaster'` union/allowlist to include `'davinci'`. Da Vinci art rides the same interactive-priority lane (`DEFAULT_ENQUEUE_PRIORITY = 100`) every other entity/narrative art request uses — it does **not** touch the reserved priority-200 dream-cycle tier.
- **`server/utils/davinci.ts`**: added `attachLifeRunArt()` — persists a `LifeRunArt` row (idempotent per `lifeRunId`+`chapter`+`sceneType`, since the table has no unique constraint on that triple) once a queued illustration resolves to a real `ArtImage`. Extended `getLifeRunForUser()` to include `Art` so a resumed run redisplays already-attached art without a second round trip.
- **`server/api/davinci/runs/[id]/art.post.ts`** (new): owner-gated route wrapping `attachLifeRunArt`.
- **`components/conductor/davinci-page.vue`**: requests art through the shared `narrativeArtJobsHelper` controller —
  - `sceneType: THRESHOLD` for each narrated chapter transition, keyed directly off the narrator's own `artPrompt` cadence (one request per narrated chapter, nothing new invented on top of it).
  - `sceneType: ENDING` for a personalized illustration of *this run's specific outcome* — distinct from the shared per-outcomeKey ending art the seed importer already seeds onto `Milestone`/`LifeEnding`. Falls back to a prompt synthesized from the ending title/summary when no chapter ever proposed an `artPrompt` (e.g. the curated fallback pool has no narrator).
  - Renders via `<NarrativeArtStatus>` for pending/queued/rendering/failed/done states, so reading and choosing never block on art generation.
  - Resumed runs hydrate already-attached `LifeRunArt` rows directly into displayable terminal states (no re-polling needed).

## How I verified

- `npx vue-tsc --noEmit` (full project via `npm run test`): 0 errors.
- `npx eslint` on every changed/added file: clean. Two files (`server/utils/davinci.ts`, `stores/artStore.ts`) have pre-existing unrelated errors (an already-unused `DAVINCI_DIMENSIONS` import; an empty block, a dynamic-delete, two other unused vars) — confirmed via `git stash` diff against this branch's base that all of them predate this change.
- `npx prettier --check` on every changed/added file: clean except confirmed pre-existing drift in `narrative.get.ts`, `artStore.ts`, `narrativeArtProfiles.ts`, `davinci.ts` — verified via `git stash` that the exact same drift exists on the base commit, and that none of it falls in lines this PR touches.
- `npm run test:davinci-narration`: 35/35 checks pass (unaffected — `davinciNarration.ts` itself is untouched).
- Live browser smoke test of the full in-run art flow (enqueue → relay → resolve → attach → display) is deferred — no reachable `DATABASE_URL` in this sandbox, a standing documented limitation for every davinci/animation-manager/model-builder task in this codebase's history.

## Stakes

Reversible. Additive-only: new product union member, new route, new function, new template branches gated behind data that doesn't exist until art is actually requested. No schema migration, no production data, no live ArtJobs created by this change itself.

## Flags for reviewer

- `attachLifeRunArt`'s idempotency is a `findFirst` + update-or-create rather than a DB-level unique constraint (the schema has none on `lifeRunId`+`chapter`+`sceneType`). Fine for this write pattern's concurrency profile (one player, one run, sequential chapters) but worth knowing if this ever gets a genuinely concurrent writer.
- Chose `THRESHOLD` for per-chapter art and `ENDING` for the final ending, reading `LifeArtSceneType`'s existing enum semantics (`MOMENT, DREAM, CHARACTER, CHOICE, THRESHOLD, ENDING, ICON, HERO`) rather than adding new values — a chapter reveal is literally "crossing a threshold" into the next stage of the life. Did not add a separate `MOMENT`-tagged request per choice, since the narrator's `artPrompt` cadence is already once-per-chapter, not once-per-choice.
- A page reload mid-render of an in-flight (not-yet-attached) chapter illustration loses that one request's live client-side polling, since only *attached* (already-resolved) art is persisted/hydrated on resume — the run itself never blocks either way, but that one chapter may end up without art. Documented as a known, intentionally deferred nuance rather than added complexity (would need a second localStorage-backed pending-job ledger to fully close).

Conductor task reference: `davinci/t-020`


---
_Generated by [Claude Code](https://claude.ai/code/session_0129wPyrkbQAeCeowMbnZzra)_