### PR TITLE
fix(model-builder): scope draftText status toasts to their own run (t-029)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -377,6 +377,12 @@ jobs:
       - name: Model Builder pushItem error-scope guard contract
         run: npm run test:model-builder-pushitem-error-scope-guard
 
+      - name: Model Builder draftText status-scope guard checker self-test
+        run: npm run test:model-builder-draft-status-scope-guard-selftest
+
+      - name: Model Builder draftText status-scope guard contract
+        run: npm run test:model-builder-draft-status-scope-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -196,6 +196,8 @@
     "test:model-builder-cancel-run-poll-guard": "tsx utils/scripts/verifyModelBuilderCancelRunPollGuard.ts",
     "test:model-builder-pushitem-error-scope-guard-selftest": "tsx utils/scripts/verifyModelBuilderPushItemErrorScopeGuard.test.ts",
     "test:model-builder-pushitem-error-scope-guard": "tsx utils/scripts/verifyModelBuilderPushItemErrorScopeGuard.ts",
+    "test:model-builder-draft-status-scope-guard-selftest": "tsx utils/scripts/verifyModelBuilderDraftStatusScopeGuard.test.ts",
+    "test:model-builder-draft-status-scope-guard": "tsx utils/scripts/verifyModelBuilderDraftStatusScopeGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -875,6 +875,18 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     const item = findItem(itemId)
     if (!item || !state.run) return false
 
+    // Captured up front so every status message this call ever surfaces --
+    // success, the two mid-flight discard cases, and the catch block -- is
+    // scoped to the run it was drafting for, mirroring generateItemAsset/
+    // pollAsyncArtJob/commitItem/pushItem/batchPushItems (see
+    // setStatusForRun's own doc comment). draftText spans a real network
+    // round-trip; without this, a draft started against this run but landing
+    // after the user has since navigated to (or started) a DIFFERENT run via
+    // resetRun/resetAll/openRun pops a misleading "Drafted ..." success (or
+    // "was edited/approved while drafting" discard) toast in that other
+    // run's banner, about an item that isn't even part of what's on screen.
+    const runId = state.run.id
+
     const targetModel = resolveTargetModel(
       item.action,
       item.outputKey,
@@ -958,7 +970,8 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
             ? item.fieldsDraft
             : item.promptDraft
       if (liveValue !== current) {
-        setStatus(
+        setStatusForRun(
+          runId,
           'error',
           `${item.label} was edited while drafting — draft discarded to avoid overwriting your changes.`,
         )
@@ -977,7 +990,8 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       // called from behind the UI's editable gate, which is true for a
       // synchronous @change edit but not for this async draft's completion).
       if (!isStageEditable(item, stageForDraftField(field))) {
-        setStatus(
+        setStatusForRun(
+          runId,
           'error',
           `${item.label} was approved while drafting — draft discarded to avoid overwriting the approved content.`,
         )
@@ -990,7 +1004,8 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       else if (field === 'fields') updateFields(itemId, value)
       else updatePrompt(itemId, value)
 
-      setStatus(
+      setStatusForRun(
+        runId,
         'success',
         `Drafted ${field === 'artPrompt' ? 'prompt' : field} for ${item.label}.`,
       )
@@ -999,7 +1014,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       handleError(error, 'drafting model builder text')
       const message =
         error instanceof Error ? error.message : 'Draft request failed.'
-      setStatus('error', message)
+      setStatusForRun(runId, 'error', message)
       return false
     } finally {
       draftingFieldSingleton.release(draftKey)

--- a/utils/scripts/verifyModelBuilderDraftStatusScopeGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderDraftStatusScopeGuard.test.ts
@@ -1,0 +1,142 @@
+// /utils/scripts/verifyModelBuilderDraftStatusScopeGuard.test.ts
+//
+// Regression test for checkDraftStatusScopeGuard() in
+// verifyModelBuilderDraftStatusScopeGuard.ts (model-builder/t-029).
+// Exercises the real check against synthetic store-shaped fixtures covering:
+// the pre-fix shape (no captured runId, all four status messages routed
+// through the bare, unscoped setStatus()), and the fixed shape (runId
+// captured up front, every message routed through
+// setStatusForRun(runId, ...)).
+import assert from 'node:assert/strict'
+
+import { checkDraftStatusScopeGuard } from './verifyModelBuilderDraftStatusScopeGuard.js'
+
+function fixture(opts: {
+  captureRunId: boolean
+  editedCall: string
+  approvedCall: string
+  successCall: string
+  catchCall: string
+}): string {
+  return `
+  async function draftText(
+    itemId: string,
+    field: DraftField,
+    instruction?: string,
+  ): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return false
+
+    ${opts.captureRunId ? 'const runId = state.run.id' : ''}
+
+    const current = field === 'pitch' ? item.pitch : item.fieldsDraft
+
+    const draftKey = { itemId, field }
+    draftingFieldSingleton.claim(draftKey)
+    clearStatus()
+
+    try {
+      const result = await performFetch('/api/suggest', {}, 2, 60_000)
+
+      if (!result.success || !result.data?.value) {
+        throw new Error(result.message || 'The model returned nothing useful.')
+      }
+
+      const value = result.data.value.trim()
+
+      const liveValue = field === 'pitch' ? item.pitch : item.fieldsDraft
+      if (liveValue !== current) {
+        ${opts.editedCall}
+        return false
+      }
+
+      if (!isStageEditable(item, stageForDraftField(field))) {
+        ${opts.approvedCall}
+        return false
+      }
+
+      if (field === 'pitch') updatePitch(itemId, value)
+      else if (field === 'fields') updateFields(itemId, value)
+      else updatePrompt(itemId, value)
+
+      ${opts.successCall}
+      return true
+    } catch (error) {
+      handleError(error, 'drafting model builder text')
+      const message = error instanceof Error ? error.message : 'Draft request failed.'
+      ${opts.catchCall}
+      return false
+    } finally {
+      draftingFieldSingleton.release(draftKey)
+    }
+  }
+`
+}
+
+const BUGGY = fixture({
+  captureRunId: false,
+  editedCall: "setStatus('error', 'edited while drafting')",
+  approvedCall: "setStatus('error', 'approved while drafting')",
+  successCall: "setStatus('success', 'Drafted ' + field)",
+  catchCall: "setStatus('error', message)",
+})
+
+const FIXED = fixture({
+  captureRunId: true,
+  editedCall: "setStatusForRun(runId, 'error', 'edited while drafting')",
+  approvedCall: "setStatusForRun(runId, 'error', 'approved while drafting')",
+  successCall: "setStatusForRun(runId, 'success', 'Drafted ' + field)",
+  catchCall: "setStatusForRun(runId, 'error', message)",
+})
+
+// Regressed: runId is captured (so that check passes) but one call site
+// (the success path) was reverted back to the bare setStatus().
+const PARTIALLY_REGRESSED = fixture({
+  captureRunId: true,
+  editedCall: "setStatusForRun(runId, 'error', 'edited while drafting')",
+  approvedCall: "setStatusForRun(runId, 'error', 'approved while drafting')",
+  successCall: "setStatus('success', 'Drafted ' + field)",
+  catchCall: "setStatusForRun(runId, 'error', message)",
+})
+
+function run(): void {
+  const buggyErrors = checkDraftStatusScopeGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    2,
+    `expected the pre-fix fixture (no runId, all four calls bare) to fail ` +
+      `twice, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(buggyErrors.some((e) => /capture/.test(e)))
+  assert.ok(buggyErrors.some((e) => /4 time\(s\)/.test(e)))
+
+  const fixedErrors = checkDraftStatusScopeGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const regressedErrors = checkDraftStatusScopeGuard(PARTIALLY_REGRESSED)
+  assert.equal(
+    regressedErrors.length,
+    1,
+    'expected a fixture with runId captured but one call site reverted to ' +
+      `bare setStatus() to fail once, got: ${JSON.stringify(regressedErrors)}`,
+  )
+  assert.ok(/1 time\(s\)/.test(regressedErrors[0]!))
+
+  const missingFnErrors = checkDraftStatusScopeGuard(
+    'function someOtherFunction(): void {}',
+  )
+  assert.equal(missingFnErrors.length, 1)
+  assert.ok(/Could not find a function named/.test(missingFnErrors[0]!))
+
+  console.log(
+    'Model Builder draftText status-scope guard self-test passed: buggy ' +
+      'fixture fails, fixed fixture passes, a partially-regressed fixture ' +
+      'fails, missing-function fixture fails clearly.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderDraftStatusScopeGuard.ts
+++ b/utils/scripts/verifyModelBuilderDraftStatusScopeGuard.ts
@@ -1,0 +1,115 @@
+// /utils/scripts/verifyModelBuilderDraftStatusScopeGuard.ts
+//
+// Regression guard (model-builder/t-029) -- draftText() is the single async
+// primitive behind every AI-drafting entry point in the store: the item
+// panel's per-field "Draft with AI" buttons, autoBuildItem()'s draft steps,
+// and batchDraftField()'s per-item loop. It spans a real network round-trip
+// (`/api/suggest`, up to a 60s timeout), long enough for the user to
+// navigate away from the run it was drafting for via resetRun()/resetAll()/
+// openRun() before the response lands. Every OTHER async model-builder
+// action that can outlive a run switch this way -- generateItemAsset,
+// pollAsyncArtJob, commitItem, pushItem, batchPushItems -- captures its own
+// `runId` up front and routes every status message it can ever surface
+// through setStatusForRun(runId, ...), which no-ops unless
+// `state.run?.id === runId` (see setStatusForRun's own doc comment).
+// draftText was the one async entry point that never got this treatment: it
+// called the plain, unscoped setStatus() for its success message and both
+// of its own mid-flight discard cases (a hand-edit or an approval landing
+// while the draft was in flight), plus its catch block's failure message.
+// Before this fix, a draft started against Run A but resolving after the
+// user had switched to (or started) a different Run B popped a misleading
+// "Drafted ... for ..." success (or "was edited/approved while drafting"
+// discard, or a bare failure) toast in Run B's banner, about an item that
+// isn't even part of what's on screen -- the exact failure mode
+// setStatusForRun exists to prevent, just missing at this one call site.
+//
+// Fixed by capturing `const runId = state.run.id` at the top of draftText
+// (immediately after its own `if (!item || !state.run) return false` guard)
+// and routing all four of its status messages through
+// setStatusForRun(runId, ...) instead of the bare setStatus(...).
+//
+// This asserts the textual shape of that fix stays in place: draftText's
+// body contains `const runId = state.run.id`, and no bare `setStatus(` call
+// (i.e. not `setStatusForRun(`) remains anywhere in its body -- deliberately
+// scoped to this one function/bug, mirroring this project's other narrow
+// textual guards over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'draftText'
+
+// `setStatus(` but not `setStatusForRun(` -- a trailing `(` after the plain
+// name means the call wasn't routed through the run-scoped wrapper.
+const BARE_SET_STATUS = /\bsetStatus\(/g
+
+export function checkDraftStatusScopeGuard(content: string): string[] {
+  const errors: string[] = []
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+
+  if (!fn) {
+    errors.push(
+      `Could not find a function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  if (!/const\s+runId\s*=\s*state\.run\.id/.test(fn.body)) {
+    errors.push(
+      `${FN_NAME}() no longer captures \`const runId = state.run.id\` up ` +
+        "front -- without it, none of this function's status messages can " +
+        'be scoped to the run they were drafting for, and a draft that ' +
+        'resolves after the user has switched runs will surface a ' +
+        'misleading toast in whatever run is now on screen.',
+    )
+  }
+
+  const bareMatches = fn.body.match(BARE_SET_STATUS)
+  if (bareMatches) {
+    errors.push(
+      `${FN_NAME}() still calls the bare, unscoped setStatus(...) ` +
+        `${bareMatches.length} time(s) -- every status message this ` +
+        'function surfaces (success, either mid-flight discard case, and ' +
+        'the catch block) must go through setStatusForRun(runId, ...) ' +
+        'instead, mirroring generateItemAsset/pollAsyncArtJob/commitItem/' +
+        'pushItem/batchPushItems.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkDraftStatusScopeGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder draftText status-scope guard contract failed in ' +
+        'modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder draftText status-scope guard contract passed: draftText ' +
+      'captures its own runId and every status message it surfaces is ' +
+      'scoped through setStatusForRun(runId, ...).',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What

`draftText()` in `stores/modelBuilderStore.ts` — the single async primitive behind every AI-drafting entry point in Model Builder (the item panel's per-field "Draft with AI" buttons, `autoBuildItem()`'s draft steps, and `batchDraftField()`'s per-item loop) — spans a real network round-trip to `/api/suggest` (up to a 60s timeout), long enough for the user to navigate away from the run it was drafting for via `resetRun()`/`resetAll()`/`openRun()` before the response lands.

Every *other* async model-builder action that can outlive a run switch this way (`generateItemAsset`, `pollAsyncArtJob`, `commitItem`, `pushItem`, `batchPushItems`) captures its own `runId` up front and routes every status message through `setStatusForRun(runId, ...)`, which no-ops unless `state.run?.id === runId` — this is exactly what stops a slow background action from popping a misleading toast in a *different* run's banner once the user has moved on. `draftText` was the one async entry point that never got this treatment: it called the plain, unscoped `setStatus()` for its success message, both of its own mid-flight discard cases (a hand-edit or an approval landing while the draft was in flight), and its catch block's failure message.

**Before this fix:** start a draft against Run A, then switch to (or start) Run B before the draft response lands — the eventual "Drafted ... for ..." success (or "was edited/approved while drafting" discard, or a bare failure) toast pops in Run B's banner, about an item that isn't even part of what's on screen.

**Fix:** capture `const runId = state.run.id` at the top of `draftText` and route all four of its status messages through `setStatusForRun(runId, ...)` instead of the bare `setStatus(...)`.

## Regression guard

Adds `utils/scripts/verifyModelBuilderDraftStatusScopeGuard.ts` (+ `.test.ts`), following this project's established narrow-textual-checker convention (a self-test that proves the checker fails against the pre-fix shape and passes against the fixed shape). Wired into:
- `package.json`: `test:model-builder-draft-status-scope-guard[-selftest]`
- `.github/workflows/contract-tests.yml`: the required Contract Tests job

## Flags for Reviewer

- This is a **model-builder/t-029 recurring-task cycle** (Worker side of conductor's long-running Model Builder polish task). The conductor roadmap task is already claimed/tracked by another process — this PR is the code-side deliverable only.
- **Bug found:** `draftText()`'s status messages (success + 2 discard cases + failure) were not scoped to the run they started against, unlike every sibling async model-builder action (`generateItemAsset`/`pollAsyncArtJob`/`commitItem`/`pushItem`/`batchPushItems`), all of which already use the `setStatusForRun(runId, ...)` pattern for exactly this reason. Confirmed via full read of `stores/modelBuilderStore.ts`, all Model Builder Vue components, and all `server/api/model-builder/**` routes, cross-checked against the ~35 prior cycles' guard files to confirm this bug class wasn't already covered.
- **Verification performed (all green):**
  - New guard self-test (`test:model-builder-draft-status-scope-guard-selftest`) — pass
  - New guard contract (`test:model-builder-draft-status-scope-guard`) — pass
  - All 24 pre-existing `verifyModelBuilder*` guard scripts (self-tests + contracts) — all pass, no regressions
  - `npx eslint` on changed/new files — clean (2 pre-existing `no-empty` errors in `modelBuilderStore.ts` confirmed via `git stash` to predate this change, unrelated to the diff)
  - `npx prettier --check` on changed/new files — new files clean after `--write`; pre-existing drift in `stores/modelBuilderStore.ts`/`package.json` confirmed via `git stash` to predate this change; this PR's own diff lines match the surrounding style exactly
  - `npx vue-tsc --noEmit` (repo-wide) — exit 0, no errors
  - `git status --porcelain` — only the 5 intended files touched (no incidental Prisma/generated drift)

## Files changed
- `stores/modelBuilderStore.ts` — the fix
- `utils/scripts/verifyModelBuilderDraftStatusScopeGuard.ts` (new) — the guard
- `utils/scripts/verifyModelBuilderDraftStatusScopeGuard.test.ts` (new) — the guard's self-test
- `package.json` — wire the two new npm scripts
- `.github/workflows/contract-tests.yml` — wire the guard into the required Contract Tests job


---
_Generated by [Claude Code](https://claude.ai/code/session_01LpYnEx9BqkoiLdN6V3gu5y)_