### PR TITLE
feat(davinci): visually distinguish negative dimensions in the life-run stat grid (t-021)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -221,6 +221,12 @@ jobs:
       - name: Da Vinci narration bounds contract
         run: npm run test:davinci-narration
 
+      - name: Da Vinci dimension-tone guard self-test
+        run: npm run test:davinci-dimension-tone-guard-selftest
+
+      - name: Da Vinci dimension-tone guard
+        run: npm run test:davinci-dimension-tone-guard
+
       - name: Pack manifest validator self-test
         run: npm run test:pack-manifest
 

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -129,11 +129,7 @@
               v-for="dim in DAVINCI_DIMENSIONS"
               :key="dim"
               class="flex flex-col items-center gap-0.5 rounded-xl border p-2 text-center"
-              :class="
-                (statMap[dim] ?? 0) >= 1
-                  ? 'border-success/40 bg-success/10'
-                  : 'border-base-300 bg-base-200/40'
-              "
+              :class="dimensionPillClass(statMap[dim] ?? 0)"
               :title="`${DIMENSION_LABELS[dim]}: ${statMap[dim] ?? 0}`"
             >
               <span
@@ -141,7 +137,11 @@
               >
                 {{ DIMENSION_LABELS[dim] }}
               </span>
-              <span class="text-xs font-black">{{ statMap[dim] ?? 0 }}</span>
+              <span
+                class="text-xs font-black"
+                :class="dimensionValueClass(statMap[dim] ?? 0)"
+                >{{ statMap[dim] ?? 0 }}</span
+              >
             </div>
           </div>
 
@@ -174,6 +174,7 @@
               <button
                 type="button"
                 class="btn btn-primary btn-sm gap-1.5 rounded-xl"
+                :disabled="narrating"
                 @click="narrateChapter()"
               >
                 <Icon name="kind-icon:refresh" class="size-4" />
@@ -675,6 +676,27 @@ function victoryBadgeClass(type: LifeEndingData['victoryType']) {
     default:
       return 'badge-warning'
   }
+}
+
+// The dimension grid previously only distinguished "has any positive value"
+// (success green) from everything else, including dimensions the player has
+// actively driven negative (health: -2 in "The Collapse", wealth: -1 in "The
+// Spark", etc. — several curated chapters have negative-effect choices by
+// design). A negative dimension looked identical to an untouched, neutral
+// one, so a player watching their stats had no visual signal that a choice
+// had cost them something until they read the small numeral. Three-way tone
+// now matches the shared status-tint formula (border-{status}/40 +
+// bg-{status}/10) already used for success here and for .kr-note elsewhere.
+function dimensionPillClass(value: number): string {
+  if (value >= 1) return 'border-success/40 bg-success/10'
+  if (value < 0) return 'border-error/40 bg-error/10'
+  return 'border-base-300 bg-base-200/40'
+}
+
+function dimensionValueClass(value: number): string {
+  if (value >= 1) return 'text-success'
+  if (value < 0) return 'text-error'
+  return ''
 }
 
 // Best-effort: the illustration is decorative, so a failed attach never

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "seed:davinci:verify": "tsx utils/scripts/verifyDaVinciSeed.ts",
     "seed:davinci:playloop-verify": "tsx utils/scripts/verifyDaVinciPlayLoop.ts",
     "test:davinci-narration": "tsx utils/scripts/verifyDaVinciNarration.ts",
+    "test:davinci-dimension-tone-guard-selftest": "tsx utils/scripts/verifyDaVinciDimensionToneGuard.test.ts",
+    "test:davinci-dimension-tone-guard": "tsx utils/scripts/verifyDaVinciDimensionToneGuard.ts",
     "test:achievement-store": "tsx utils/scripts/verifyAchievementStoreFetchSafety.ts",
     "test:achievement-catalog": "tsx utils/scripts/verifyDatabaseRetry.ts && tsx utils/scripts/verifyAchievementArtJobDedupe.ts && tsx utils/scripts/verifyAchievementCatalog.ts",
     "seed:achievements": "tsx scripts/seed_achievements.ts",

--- a/utils/scripts/verifyDaVinciDimensionToneGuard.test.ts
+++ b/utils/scripts/verifyDaVinciDimensionToneGuard.test.ts
@@ -1,0 +1,132 @@
+// /utils/scripts/verifyDaVinciDimensionToneGuard.test.ts
+//
+// Regression test for checkDimensionToneGuard() in
+// verifyDaVinciDimensionToneGuard.ts (davinci/t-021). Exercises the real
+// check against synthetic component-shaped fixtures covering: the pre-fix
+// shape (template inlines a two-way ternary, no negative tone anywhere), the
+// fixed shape (template calls the extracted helpers, both branch on
+// `value < 0` into an error tone), and a partial regression (helpers exist
+// and are called, but one of them lost its negative branch).
+import assert from 'node:assert/strict'
+
+import { checkDimensionToneGuard } from './verifyDaVinciDimensionToneGuard.js'
+
+function fixture(opts: {
+  templateUsesPillHelper: boolean
+  templateUsesValueHelper: boolean
+  pillBody: string
+  valueBody: string
+}): string {
+  return `
+<template>
+  <div
+    class="flex flex-col items-center gap-0.5 rounded-xl border p-2 text-center"
+    :class="${
+      opts.templateUsesPillHelper
+        ? 'dimensionPillClass(statMap[dim] ?? 0)'
+        : "(statMap[dim] ?? 0) >= 1 ? 'border-success/40 bg-success/10' : 'border-base-300 bg-base-200/40'"
+    }"
+  >
+    <span
+      class="text-xs font-black"
+      :class="${
+        opts.templateUsesValueHelper
+          ? 'dimensionValueClass(statMap[dim] ?? 0)'
+          : "''"
+      }"
+      >{{ statMap[dim] ?? 0 }}</span
+    >
+  </div>
+</template>
+<script setup lang="ts">
+function dimensionPillClass(value: number): string {
+  ${opts.pillBody}
+}
+
+function dimensionValueClass(value: number): string {
+  ${opts.valueBody}
+}
+</script>
+`
+}
+
+const FIXED = fixture({
+  templateUsesPillHelper: true,
+  templateUsesValueHelper: true,
+  pillBody: `
+    if (value >= 1) return 'border-success/40 bg-success/10'
+    if (value < 0) return 'border-error/40 bg-error/10'
+    return 'border-base-300 bg-base-200/40'
+  `,
+  valueBody: `
+    if (value >= 1) return 'text-success'
+    if (value < 0) return 'text-error'
+    return ''
+  `,
+})
+
+// Pre-fix shape: template never calls either helper (inlined two-way
+// ternary instead), and neither helper exists at all.
+const BUGGY = `
+<template>
+  <div
+    :class="(statMap[dim] ?? 0) >= 1 ? 'border-success/40 bg-success/10' : 'border-base-300 bg-base-200/40'"
+  >
+    <span class="text-xs font-black">{{ statMap[dim] ?? 0 }}</span>
+  </div>
+</template>
+`
+
+// Partial regression: both helpers exist and are wired up in the template,
+// but dimensionValueClass lost its negative branch (e.g. reverted to always
+// returning '').
+const PARTIALLY_REGRESSED = fixture({
+  templateUsesPillHelper: true,
+  templateUsesValueHelper: true,
+  pillBody: `
+    if (value >= 1) return 'border-success/40 bg-success/10'
+    if (value < 0) return 'border-error/40 bg-error/10'
+    return 'border-base-300 bg-base-200/40'
+  `,
+  valueBody: `
+    if (value >= 1) return 'text-success'
+    return ''
+  `,
+})
+
+function run(): void {
+  const fixedErrors = checkDimensionToneGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const buggyErrors = checkDimensionToneGuard(BUGGY)
+  assert.ok(
+    buggyErrors.length >= 2,
+    `expected the pre-fix fixture (no helper calls, no helpers) to fail ` +
+      `on both the template wiring and the missing functions, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(buggyErrors.some((e) => /no longer binds/.test(e)))
+  assert.ok(buggyErrors.some((e) => /Could not find a function named/.test(e)))
+
+  const regressedErrors = checkDimensionToneGuard(PARTIALLY_REGRESSED)
+  assert.equal(
+    regressedErrors.length,
+    2,
+    'expected a fixture where dimensionValueClass lost its negative branch ' +
+      'and its error-tone reference entirely to fail on both checks for ' +
+      `that function, got: ${JSON.stringify(regressedErrors)}`,
+  )
+  assert.ok(regressedErrors.every((e) => e.startsWith('dimensionValueClass()')))
+  assert.ok(regressedErrors.some((e) => /no longer branches/.test(e)))
+  assert.ok(regressedErrors.some((e) => /error\/danger tone/.test(e)))
+
+  console.log(
+    'Da Vinci dimension-tone guard self-test passed: buggy fixture fails, ' +
+      'fixed fixture passes, a partially-regressed fixture fails.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyDaVinciDimensionToneGuard.ts
+++ b/utils/scripts/verifyDaVinciDimensionToneGuard.ts
@@ -1,0 +1,129 @@
+// /utils/scripts/verifyDaVinciDimensionToneGuard.ts
+//
+// Regression guard (davinci/t-021) -- the dimension grid in
+// components/conductor/davinci-page.vue previously only distinguished "has
+// any positive value" (success green, border-success/40 bg-success/10) from
+// everything else, including dimensions the player has actively driven
+// negative. Several curated chapters have negative-effect choices by design
+// ("The Collapse" costs health: -2, "The Spark" costs health: -1, etc.), so a
+// dimension a player has actively damaged looked pixel-identical to one
+// they've never touched -- same neutral border-base-300/bg-base-200/40 tone,
+// distinguishable only by reading the small numeral inside.
+//
+// Fixed by giving the pill a real three-way tone: positive keeps the
+// existing success styling, negative gets the error equivalent
+// (border-error/40 bg-error/10, matching the same status-tint formula used
+// throughout the app), and everything else keeps the neutral tone. Extracted
+// into dimensionPillClass()/dimensionValueClass() rather than inlining a
+// second ternary branch in the template, so the tone rule lives in one place.
+//
+// This asserts the textual shape of that fix stays in place: the template
+// calls dimensionPillClass()/dimensionValueClass() for the dimension pill
+// (not a hand-inlined `>= 1 ? success : neutral` ternary that silently drops
+// the negative case again), and both functions actually branch on `value < 0`
+// into the error tone -- deliberately scoped to this one template/behavior,
+// mirroring this project's other narrow textual guards over a general-purpose
+// static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const COMPONENT_PATH = join(
+  repositoryRoot,
+  'components/conductor/davinci-page.vue',
+)
+
+function extractFunctionSource(content: string, name: string): string | null {
+  const signature = new RegExp(`^function ${name}\\([^)]*\\)[^{]*\\{`, 'm')
+  const match = signature.exec(content)
+  if (!match) return null
+
+  const braceOpen = match.index + match[0].length - 1
+  let depth = 0
+  let i = braceOpen
+  for (; i < content.length; i++) {
+    if (content[i] === '{') depth++
+    else if (content[i] === '}') {
+      depth--
+      if (depth === 0) break
+    }
+  }
+  if (depth !== 0) return null
+  return content.slice(braceOpen, i + 1)
+}
+
+export function checkDimensionToneGuard(content: string): string[] {
+  const errors: string[] = []
+
+  if (!content.includes(':class="dimensionPillClass(statMap[dim] ?? 0)"')) {
+    errors.push(
+      'The dimension grid pill no longer binds :class to ' +
+        'dimensionPillClass(statMap[dim] ?? 0) -- has it been reverted to ' +
+        'an inline ternary that only checks for a positive value, dropping ' +
+        'the negative-dimension tone again?',
+    )
+  }
+
+  if (!content.includes(':class="dimensionValueClass(statMap[dim] ?? 0)"')) {
+    errors.push(
+      "The dimension grid pill's numeral span no longer binds :class to " +
+        'dimensionValueClass(statMap[dim] ?? 0) -- the negative-value text ' +
+        'color signal has been dropped.',
+    )
+  }
+
+  for (const name of ['dimensionPillClass', 'dimensionValueClass']) {
+    const body = extractFunctionSource(content, name)
+    if (!body) {
+      errors.push(
+        `Could not find a function named ${name}() -- has it been renamed, ` +
+          'removed, or inlined back into the template? If so, this guard ' +
+          '(and the negative-dimension visibility bug it protects against) ' +
+          'needs to move with it.',
+      )
+      continue
+    }
+    if (!/value\s*<\s*0/.test(body)) {
+      errors.push(
+        `${name}() no longer branches on \`value < 0\` -- negative ` +
+          'dimensions will fall through to the neutral tone again, ' +
+          'identical to an untouched dimension.',
+      )
+    }
+    if (!/error/i.test(body)) {
+      errors.push(
+        `${name}() no longer references an error/danger tone for negative ` +
+          'values.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(COMPONENT_PATH, 'utf8')
+  const errors = checkDimensionToneGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Da Vinci dimension-tone guard contract failed in davinci-page.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Da Vinci dimension-tone guard contract passed: the dimension grid ' +
+      'gives negative values a distinct error tone instead of falling back ' +
+      'to the neutral/untouched styling.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
conductor davinci/t-021: Da Vinci visual style and interaction polish pass. First slice — the dimension grid's negative-value visibility gap.

### What changed / what I produced
- The life-run dimension grid (`components/conductor/davinci-page.vue`) previously only distinguished "has any positive value" (success green) from everything else, including dimensions the player has actively driven negative — several curated chapters have negative-effect choices by design (`health: -2` in "The Collapse", `wealth: -1` in "The Spark", etc.). A negative dimension looked pixel-identical to an untouched, neutral one, distinguishable only by reading the small numeral.
- Gives the pill a real three-way tone via two extracted helpers (`dimensionPillClass`/`dimensionValueClass`): positive keeps the existing success styling, negative gets the error equivalent (`border-error/40 bg-error/10`, matching the same status-tint formula already used for success and for `.kr-note` elsewhere), everything else stays neutral.
- Adds `:disabled="narrating"` to the narration-retry ("Try again") button for defense-in-depth against a double-click race — every other async-triggering button in this component already guards on `submitting`/`narrating`, this one was the exception.
- Added `utils/scripts/verifyDaVinciDimensionToneGuard.ts` (+ `.test.ts` self-test) as a narrow textual regression guard, following this project's established narrow-textual-checker convention (see `verifyModelBuilderDraftStatusScopeGuard.ts`), wired into `package.json` and `contract-tests.yml`.

### How I verified
- New guard self-test + contract both pass.
- Existing `test:davinci-narration` suite passes (unaffected — server-side).
- `eslint` clean on all changed files.
- `prettier --check` clean on all changed files.
- `vue-tsc --noEmit` repo-wide: exit 0.
- `test:layout-contract`: holds, no new violations (davinci-page.vue was already contract-clean before this change and stays clean).
- `git status --porcelain` showed exactly the 5 intended files.

### Stakes
reversible

### Flags for Reviewer
- This is one bounded slice of t-021's broader "visual style and interaction polish pass" scope (Interface Vision sequence: states work → kr-* consistency → visually intentional). The layout-contract's 8 machine-checked rules were already 100% clean for this file going in, and the DESIGN-BRIEF explicitly warns against forcing bespoke crafted UI onto shared `.kr-panel`-style classes ("not a `.kr-panel` crusade") — so I scoped this pass to a concrete, verifiable functional/visual gap rather than a cosmetic reskin.
- I did not attempt the "playtest 2-3 full runs" style verification (that's t-024's scope, and headless Chromium can't reach any HTTPS host through this sandbox's proxy per AGENTS.md) — verification here is static (types/lint/guard/contract), which is what's actually checkable for a template class-binding change.
- Left the conductor `davinci/t-021` task at `status: review` — will flip to `done` once this merges.

### Kaizen suggestion
The other three "large centered card" states in this same file (logged-out, narrating, ending) share a consistent hand-rolled `rounded-2xl border ... p-6 text-center` pattern that isn't itself a violation of anything, but could become its own shared `.kr-card-empty`-style primitive if the same shape keeps recurring across other product pages — worth checking during a future interface-vision sweep rather than introducing a new primitive here for one file.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2gsRy8DuVJS9vm3KpfT5X)_