### PR TITLE
Open Newsfeed to Home users

### DIFF
--- a/content/channels/home/newsfeed.md
+++ b/content/channels/home/newsfeed.md
@@ -11,7 +11,6 @@ description: Explore an experimental feed for collecting, shaping, and reviewing
 icon: kind-icon:news
 route: /plan/newsfeed
 sort: 70
-requiredRole: ADMIN
 ---
 
 A prototype feed where information is invited to arrive with context.


### PR DESCRIPTION
## What changed

- Remove the explicit `requiredRole: ADMIN` gate from the Home Newsfeed tab.
- Keep Newsfeed in the Home channel with the same route and dashboard adapter.

## Why

Newsfeed is a normal Home surface, not an admin-only tool.

## Verification

- Diff is exactly one deleted frontmatter line in `content/channels/home/newsfeed.md`.
- Branch is current with `main`.
- All 17 GitHub Actions workflow runs completed successfully, including Contract Tests and TypeScript Type Check.