### PR TITLE
fix(storybook): preserve reader's answer text on a failed weaveBeat submit (t-010)

### DIFF
--- a/.github/workflows/storybook-answer-input-preservation-contract.yml
+++ b/.github/workflows/storybook-answer-input-preservation-contract.yml
@@ -1,0 +1,30 @@
+name: Storybook Answer Input Preservation Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: storybook-answer-input-preservation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Storybook answer-input-preservation contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify Storybook answer input preservation
+        run: node utils/scripts/verifyStorybookAnswerInputPreservationGuard.mjs

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -944,7 +944,16 @@ async function beginStory() {
 
 async function submitAnswer(value: string) {
   answerInput.value = ''
-  await store.answerCurrentBeat(value)
+  const wove = await store.answerCurrentBeat(value)
+  // answerCurrentBeat's own rollback (see verifyStorybookAnswerRollbackGuard)
+  // restores store consistency on a failed weaveBeat call, but it can't
+  // restore the composer's local text -- without this, the reader's answer
+  // is optimistically cleared above and then silently lost, forcing them to
+  // recall and retype it from scratch on retry. weaveBeat always sets
+  // errorMessage on a real failure, so checking it (not just `!wove`) avoids
+  // repopulating the box when answerCurrentBeat's own no-op guard rejected
+  // the submission before ever calling weaveBeat.
+  if (!wove && store.errorMessage) answerInput.value = value
 }
 
 function startAnother() {

--- a/utils/scripts/verifyStorybookAnswerInputPreservationGuard.mjs
+++ b/utils/scripts/verifyStorybookAnswerInputPreservationGuard.mjs
@@ -1,0 +1,93 @@
+// /utils/scripts/verifyStorybookAnswerInputPreservationGuard.mjs
+//
+// Regression guard (storybook/t-010, front-end polish). `submitAnswer` in
+// components/conductor/storybook-page.vue optimistically clears the
+// composer's `answerInput` ref before awaiting `store.answerCurrentBeat()`.
+// `NarrativeResponseComposer` is a fully controlled component (its textarea
+// binds `:value="modelValue"` with no local text state), so `answerInput` is
+// the only place the reader's typed answer lives once submitted.
+//
+// `answerCurrentBeat`'s own rollback (see verifyStorybookAnswerRollbackGuard)
+// restores STORE consistency when the follow-up `weaveBeat` call fails --
+// but it has no way to restore the composer's local text. Without a matching
+// UI-level restore, a reader whose submission hits a transient generateText
+// failure sees the textarea silently go blank and has to recall and retype
+// their entire answer, with no indication their submission was lost rather
+// than accepted.
+//
+// This asserts the fix's shape stays in place: `submitAnswer` captures
+// `answerCurrentBeat`'s outcome and, on failure, restores `answerInput` to
+// the submitted value.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const COMPONENT_PATH = 'components/conductor/storybook-page.vue'
+const FN_NAME = 'submitAnswer'
+
+function extractFunctionBody(content, name) {
+  const signaturePattern = new RegExp(`^async function ${name}\\s*\\(`, 'm')
+  const match = signaturePattern.exec(content)
+  if (!match) {
+    throw new Error(
+      `Could not find \`async function ${name}(\` in ${COMPONENT_PATH} -- ` +
+        'has it been renamed, removed, or inlined? If so, this guard (and ' +
+        'the lost-answer bug it protects against) needs to move with it.',
+    )
+  }
+
+  const parenOpen = match.index + match[0].length - 1
+  let parenDepth = 0
+  let i = parenOpen
+  for (; i < content.length; i++) {
+    if (content[i] === '(') parenDepth++
+    else if (content[i] === ')') {
+      parenDepth--
+      if (parenDepth === 0) break
+    }
+  }
+  const braceOpen = content.indexOf('{', i)
+  let braceDepth = 0
+  let j = braceOpen
+  for (; j < content.length; j++) {
+    if (content[j] === '{') braceDepth++
+    else if (content[j] === '}') {
+      braceDepth--
+      if (braceDepth === 0) break
+    }
+  }
+  return content.slice(braceOpen, j + 1)
+}
+
+const content = readFileSync(resolve(process.cwd(), COMPONENT_PATH), 'utf8')
+const body = extractFunctionBody(content, FN_NAME)
+
+const required = [
+  [
+    'const wove = await store.answerCurrentBeat(',
+    "must capture answerCurrentBeat's outcome instead of discarding it",
+  ],
+  [
+    '!wove && store.errorMessage',
+    'must branch on a real weaveBeat failure (errorMessage set), not just a falsy return',
+  ],
+  [
+    'answerInput.value = value',
+    'must restore the submitted text into answerInput on failure so the reader does not have to retype it',
+  ],
+]
+
+for (const [needle, why] of required) {
+  assert.ok(
+    body.includes(needle),
+    `${FN_NAME}() no longer contains \`${needle}\` -- ${why}, or a failed ` +
+      "submission silently clears the reader's typed answer with no way " +
+      'to recover it.',
+  )
+}
+
+console.log(
+  `Storybook answer-input-preservation guard contract passed: ${FN_NAME}() ` +
+    'restores the composer text on a failed submission instead of ' +
+    'silently discarding it.',
+)


### PR DESCRIPTION
### Task
storybook/t-010: Polish and upgrade Storybook front-end surface (kind: software)

### What changed / what I produced
`submitAnswer()` in `components/conductor/storybook-page.vue` optimistically clears the composer's `answerInput` before awaiting `store.answerCurrentBeat()`. `NarrativeResponseComposer` is a fully controlled component (its textarea binds `:value="modelValue"` with no local text state), so `answerInput` is the only place the reader's typed answer lives once submitted.

`answerCurrentBeat`'s own rollback (see `verifyStorybookAnswerRollbackGuard.mjs`) restores STORE consistency when the follow-up `weaveBeat` call fails, but it can't restore the composer's local text. Before this fix, a reader whose submission hit a transient `generateText` failure saw the textarea silently go blank and had to recall and retype their entire answer, with no indication their submission was lost rather than accepted — worse the longer/more thoughtful the answer was.

**Fix:** capture `answerCurrentBeat`'s outcome, and on a real `weaveBeat` failure (signaled by `store.errorMessage`, which `weaveBeat` always sets on failure), restore `answerInput` to the submitted value instead of leaving it empty.

- `components/conductor/storybook-page.vue` — the fix
- `utils/scripts/verifyStorybookAnswerInputPreservationGuard.mjs` (new) — regression guard, following this project's established narrow-textual-checker convention (mirrors `verifyStorybookAnswerRollbackGuard`'s extraction-and-assert style)
- `.github/workflows/storybook-answer-input-preservation-contract.yml` (new) — wires the guard in, cloned from the existing per-guard `storybook-*-contract.yml` template (this lane doesn't use `package.json` npm scripts for its guards — confirmed against all five existing ones)

### How I verified
- New guard passes against the fix; confirmed it correctly *fails* against the pre-fix shape by round-tripping the file content in-process before restoring the fix
- All 5 pre-existing `verifyStorybook*` guards still pass — no regressions
- `npx eslint` on changed/new files — clean
- `npx prettier --check` — new guard + workflow file clean; pre-existing drift on `storybook-page.vue` confirmed via `git stash` to predate this change
- `npx vue-tsc --noEmit` (repo-wide) — exit 0, no errors
- `git status --porcelain` — only the 3 intended files touched

### Stakes
reversible

### Flags for Reviewer
- This is a **storybook/t-010 open-ended polish-lane cycle** (conductor's recurring front-end-surface task for this project). The conductor roadmap task is claimed/tracked separately — this PR is the code-side deliverable.
- **Bug found:** confirmed via a full read of `stores/storybookStore.ts`, `components/conductor/storybook-page.vue`, `components/narrative/narrative-response-composer.vue`, and all 5 existing `verifyStorybook*` guards to confirm this exact gap (UI-level input loss on a failed submit, distinct from the store-level rollback the existing guard already covers) wasn't already covered by any of them.

### Kaizen suggestion
`answerCurrentBeat`'s early no-op guard (`!active || !beat || beat.answer || !clean || isWeaving.value`) returns `false` silently with no user-facing signal at all — distinct from this PR's scope (a real `weaveBeat` failure) but worth a future look at whether any of those branches are reachable through the UI in a way that leaves the reader without feedback.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGkr9JjR8cgQPYFhqH4GPB)_