### PR TITLE
fix: pollOnce() can resurrect connected state after stop() mid-flight (alexa-integration/t-015)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -227,6 +227,12 @@ jobs:
       - name: Da Vinci dimension-tone guard
         run: npm run test:davinci-dimension-tone-guard
 
+      - name: Serendipity Voice poll guard self-test
+        run: npm run test:serendipity-voice-poll-guard-selftest
+
+      - name: Serendipity Voice poll guard
+        run: npm run test:serendipity-voice-poll-guard
+
       - name: Pack manifest validator self-test
         run: npm run test:pack-manifest
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "test:davinci-narration": "tsx utils/scripts/verifyDaVinciNarration.ts",
     "test:davinci-dimension-tone-guard-selftest": "tsx utils/scripts/verifyDaVinciDimensionToneGuard.test.ts",
     "test:davinci-dimension-tone-guard": "tsx utils/scripts/verifyDaVinciDimensionToneGuard.ts",
+    "test:serendipity-voice-poll-guard-selftest": "tsx utils/scripts/verifySerendipityVoicePollGuard.test.ts",
+    "test:serendipity-voice-poll-guard": "tsx utils/scripts/verifySerendipityVoicePollGuard.ts",
     "test:achievement-store": "tsx utils/scripts/verifyAchievementStoreFetchSafety.ts",
     "test:achievement-catalog": "tsx utils/scripts/verifyDatabaseRetry.ts && tsx utils/scripts/verifyAchievementArtJobDedupe.ts && tsx utils/scripts/verifyAchievementCatalog.ts",
     "seed:achievements": "tsx scripts/seed_achievements.ts",

--- a/stores/serendipityVoiceStore.ts
+++ b/stores/serendipityVoiceStore.ts
@@ -260,6 +260,17 @@ export const useSerendipityVoiceStore = defineStore(
           ),
         ])
 
+        // stop() (explicit Disconnect, or onBeforeUnmount) may have run while
+        // the fetches above were in flight -- e.g. triggered from
+        // sendVoiceText()'s trailing `await pollOnce()`. Once the caller has
+        // declared itself stopped, applying a stale response would silently
+        // resurrect `connected` (with no interval left to ever poll again)
+        // and could apply a voice command to global stores after the page
+        // that was listening has already gone away. Bail before touching any
+        // state; the fetches themselves already completed so nothing is left
+        // dangling.
+        if (!polling.value) return
+
         if (!commandsRes.ok || !messagesRes.ok) {
           throw new Error(
             `Relay responded ${commandsRes.status}/${messagesRes.status}`,

--- a/utils/scripts/verifySerendipityVoicePollGuard.test.ts
+++ b/utils/scripts/verifySerendipityVoicePollGuard.test.ts
@@ -1,0 +1,122 @@
+// /utils/scripts/verifySerendipityVoicePollGuard.test.ts
+//
+// Regression test for checkSerendipityVoicePollGuard() in
+// verifySerendipityVoicePollGuard.ts (alexa-integration/t-015). Exercises
+// the real check against synthetic store-shaped fixtures covering: the
+// pre-fix shape (no polling.value re-check at all), the fixed shape (the
+// re-check sits between the Promise.all fetch and `connected.value = true`),
+// a misplaced-guard regression (the check exists but too early, before the
+// fetches even start -- which would not catch a stop() that happens while
+// the fetches are in flight), and a missing-function fixture.
+import assert from 'node:assert/strict'
+
+import { checkSerendipityVoicePollGuard } from './verifySerendipityVoicePollGuard.js'
+
+function fixture(opts: { stoppedGuard: string }): string {
+  return `
+    async function pollOnce(): Promise<void> {
+      if (!isClient()) return
+      if (pollInFlight.value) return
+      pollInFlight.value = true
+
+      try {
+        const [commandsRes, messagesRes] = await Promise.all([
+          fetch(\`\${relayBaseUrl.value}/api/commands?since=\${commandCursor.value}\`),
+          fetch(\`\${relayBaseUrl.value}/api/messages?since=\${messageCursor.value}\`),
+        ])
+
+        ${opts.stoppedGuard}
+
+        if (!commandsRes.ok || !messagesRes.ok) {
+          throw new Error('Relay error')
+        }
+
+        for (const message of messagesData.messages) messages.value.push(message)
+        messageCursor.value = messagesData.cursor
+
+        for (const command of commandsData.commands) applyCommand(command)
+        commandCursor.value = commandsData.cursor
+
+        connected.value = true
+        lastError.value = null
+      } catch (error) {
+        connected.value = false
+        lastError.value = error instanceof Error ? error.message : 'Relay poll failed'
+      } finally {
+        pollInFlight.value = false
+      }
+    }
+  `
+}
+
+const FIXED = fixture({ stoppedGuard: 'if (!polling.value) return' })
+
+// Pre-fix: no re-check of polling.value anywhere -- a poll whose fetches
+// resolve after stop() ran will still apply the response.
+const BUGGY = fixture({ stoppedGuard: '' })
+
+// Misplaced regression: the guard exists, but before the try block up near
+// the top-of-function re-entrancy guards instead of after the fetches
+// resolve. Only the trailing "" from stoppedGuard's slot is used here, and
+// the guard is inserted before pollInFlight.value = true instead -- this
+// fixture builds that shape directly rather than via the helper above.
+const GUARD_TOO_EARLY = `
+    async function pollOnce(): Promise<void> {
+      if (!isClient()) return
+      if (pollInFlight.value) return
+      if (!polling.value) return
+      pollInFlight.value = true
+
+      try {
+        const [commandsRes, messagesRes] = await Promise.all([
+          fetch(\`\${relayBaseUrl.value}/api/commands?since=\${commandCursor.value}\`),
+          fetch(\`\${relayBaseUrl.value}/api/messages?since=\${messageCursor.value}\`),
+        ])
+
+        connected.value = true
+      } catch (error) {
+        connected.value = false
+      } finally {
+        pollInFlight.value = false
+      }
+    }
+  `
+
+function run(): void {
+  const fixedErrors = checkSerendipityVoicePollGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const buggyErrors = checkSerendipityVoicePollGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    1,
+    `expected the pre-fix fixture (no polling.value re-check) to fail once, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(/no longer contains/.test(buggyErrors[0]!))
+
+  const tooEarlyErrors = checkSerendipityVoicePollGuard(GUARD_TOO_EARLY)
+  assert.equal(
+    tooEarlyErrors.length,
+    1,
+    `expected a guard placed before the fetches to fail once, got: ${JSON.stringify(tooEarlyErrors)}`,
+  )
+  assert.ok(/not between/.test(tooEarlyErrors[0]!))
+
+  const missingFnErrors = checkSerendipityVoicePollGuard(
+    'function someOtherFunction(): void {}',
+  )
+  assert.equal(missingFnErrors.length, 1)
+  assert.ok(/Could not find a function named/.test(missingFnErrors[0]!))
+
+  console.log(
+    'Serendipity Voice poll guard self-test passed: buggy fixture fails, ' +
+      'fixed fixture passes, a too-early-guard fixture fails, missing-' +
+      'function fixture fails clearly.',
+  )
+}
+
+run()

--- a/utils/scripts/verifySerendipityVoicePollGuard.ts
+++ b/utils/scripts/verifySerendipityVoicePollGuard.ts
@@ -1,0 +1,145 @@
+// /utils/scripts/verifySerendipityVoicePollGuard.ts
+//
+// Regression guard (alexa-integration/t-015) -- pollOnce() in
+// stores/serendipityVoiceStore.ts already guards against overlapping polls
+// via pollInFlight (fixed 2026-07-29, kind_robots PR #1127), but that guard
+// only prevents two polls from racing each other. It never checked whether
+// the caller had, in the meantime, called stop() -- the authoritative
+// "I am no longer polling the relay" action, fired both from the explicit
+// Disconnect button and from onBeforeUnmount on both voice-lab-page.vue and
+// serendipity-page.vue.
+//
+// Failure scenario this protects against: sendVoiceText() awaits its POST
+// to /api/handle, then calls `await pollOnce()` to fetch the resulting
+// commands/messages. If stop() runs (Disconnect click, or the user
+// navigating away and unmounting the component) while that trailing
+// pollOnce()'s own fetches are still in flight, the poll had no way to know
+// the caller had disconnected -- it would go on to unconditionally set
+// `connected.value = true` and apply any pending commands (which can toggle
+// global animation effects or change the app theme) even though `stop()`
+// already set `polling.value = false` and cleared the poll interval. The UI
+// would end up self-contradictory (a green "Relay connected" badge next to
+// a "Connect" button) and permanently unable to poll again until the user
+// manually reconnected, and a voice command could still land on global
+// stores after the page that was supposedly listening had already gone.
+//
+// Fixed by re-checking `polling.value` immediately after the commands/
+// messages fetches resolve, before any of their results are applied to
+// store state -- late enough to catch a stop() that happened mid-flight,
+// early enough that nothing has been mutated yet.
+//
+// This asserts the textual shape of that fix stays in place: pollOnce()'s
+// body contains a `if (!polling.value) return` guard positioned after the
+// `Promise.all([...])` fetch call and before the `connected.value = true`
+// assignment -- deliberately scoped to this one function/bug, mirroring
+// this project's other narrow textual guards over a general-purpose static
+// analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/serendipityVoiceStore.ts')
+
+function extractFunctionSource(content: string, name: string): string | null {
+  const signature = new RegExp(
+    `^\\s*(?:async\\s+)?function ${name}\\([^)]*\\)[^{]*\\{`,
+    'm',
+  )
+  const match = signature.exec(content)
+  if (!match) return null
+
+  const braceOpen = match.index + match[0].length - 1
+  let depth = 0
+  let i = braceOpen
+  for (; i < content.length; i++) {
+    if (content[i] === '{') depth++
+    else if (content[i] === '}') {
+      depth--
+      if (depth === 0) break
+    }
+  }
+  if (depth !== 0) return null
+  return content.slice(braceOpen, i + 1)
+}
+
+export function checkSerendipityVoicePollGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const body = extractFunctionSource(content, 'pollOnce')
+  if (!body) {
+    errors.push(
+      'Could not find a function named pollOnce() -- has it been renamed, ' +
+        'removed, or restructured? If so, this guard (and the stale-poll-' +
+        'after-stop bug it protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  const promiseAllIndex = body.search(/Promise\.all\(/)
+  const stoppedGuardMatch = body.match(
+    /if\s*\(\s*!polling\.value\s*\)\s*return/,
+  )
+  const connectedTrueIndex = body.search(/connected\.value\s*=\s*true/)
+
+  if (promiseAllIndex === -1) {
+    errors.push(
+      'pollOnce() no longer calls Promise.all([...]) for its commands/' +
+        'messages fetch -- has the relay-polling shape changed? This guard ' +
+        'assumes that structure to locate the mid-flight disconnect race.',
+    )
+  }
+
+  if (!stoppedGuardMatch) {
+    errors.push(
+      'pollOnce() no longer contains `if (!polling.value) return` -- ' +
+        'without it, a poll whose fetches resolve after stop() has already ' +
+        'run (explicit Disconnect, or unmount) will resurrect ' +
+        '`connected.value` and can still apply a voice command to global ' +
+        'stores after the caller declared itself stopped.',
+    )
+  } else if (
+    promiseAllIndex !== -1 &&
+    connectedTrueIndex !== -1 &&
+    !(
+      stoppedGuardMatch.index! > promiseAllIndex &&
+      stoppedGuardMatch.index! < connectedTrueIndex
+    )
+  ) {
+    errors.push(
+      'pollOnce() contains `if (!polling.value) return`, but not between ' +
+        'the Promise.all([...]) fetch and `connected.value = true` -- it ' +
+        'must sit right after the fetches resolve (late enough to catch a ' +
+        'stop() that happened mid-flight) and before any state is applied ' +
+        '(early enough that nothing has been mutated yet).',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkSerendipityVoicePollGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Serendipity Voice poll guard contract failed in ' +
+        'serendipityVoiceStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Serendipity Voice poll guard contract passed: pollOnce() bails before ' +
+      'applying a response that resolved after stop() already ran.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Summary

Bug-hunt slice on `alexa-integration/t-015` (Voice Lab front-end polish, conductor roadmap). `pollOnce()`'s existing `pollInFlight` guard (PR #1127) only prevents two polls from racing each other — it never checked whether `stop()` had run while its own fetch was still in flight.

## The bug

`sendVoiceText()` awaits its POST to `/api/handle`, then calls `await pollOnce()`. If the user clicks Disconnect, or navigates away (unmounting the component, which fires `stop()` via `onBeforeUnmount`), while that trailing poll's `commands`/`messages` fetches are still resolving, `pollOnce()` had no way to know — it would go on to unconditionally set `connected.value = true` and apply any pending commands (which can toggle global animation effects or change the app theme), even though `stop()` had already set `polling.value = false` and cleared the poll interval.

Net effect: the UI ends up self-contradictory (a green "Relay connected" badge next to a "Connect" button), permanently stuck until the user manually reconnects (the interval is gone), and a voice command can still land on global stores after the page that was supposedly listening had already gone.

## Fix

Re-check `polling.value` immediately after the `Promise.all([...])` fetch resolves, before any of its results are applied to store state — late enough to catch a `stop()` that happened mid-flight, early enough that nothing has been mutated yet.

## Verification

- Added `verifySerendipityVoicePollGuard.ts` + `.test.ts`, following this project's narrow-textual-checker convention (mirrors `verifyDaVinciDimensionToneGuard.ts`), wired into `package.json` and `contract-tests.yml`.
- New guard + selftest pass.
- `eslint` clean on all changed/new files.
- `prettier --check` clean.
- `vue-tsc --noEmit` repo-wide: exit 0.
- `git status --porcelain` shows exactly the 5 intended files.

## Flags for Reviewer

- Reversible, scoped, no schema/API changes — client-only store fix plus a new regression guard.
- Rebased onto current `main` (post PR #1845) immediately before opening this PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6b4owWdafj5QveiPkJpjF)_