### PR TITLE
docs(storybook): document why answerCurrentBeat's guard is unreachable (t-020)

### DIFF
--- a/stores/storybookStore.ts
+++ b/stores/storybookStore.ts
@@ -801,6 +801,25 @@ export const useStorybookStore = defineStore('storybookStore', () => {
     const active = session.value
     const beat = currentBeat.value
     const clean = answerText.trim()
+    // Audited (storybook/t-020, kaizen from t-010/#1846): every branch here is
+    // structurally unreachable through the composer, so a silent `false` never
+    // reaches a reader with no explanation.
+    //   !active / !beat  -- narrative-response-composer only renders behind
+    //     `v-if="store.session && !store.isComplete"`, and `session.value` and
+    //     its first beat are both written inside the same synchronous span as
+    //     `isWeaving.value = true` (beginStory -> weaveBeat), so there is no
+    //     paint where the composer is visible, enabled, and beat-less.
+    //   !clean -- the composer's own submit() already trims and rejects an
+    //     empty/whitespace-only value before ever emitting `submit`.
+    //   beat.answer / isWeaving.value -- both flip inside the same synchronous
+    //     block that starts weaveBeat, before any `await`. The composer's
+    //     `disabled`/`loading` props mirror those two flags, and the HTML spec
+    //     drains Vue's reactive (microtask) render queue before the next click
+    //     or keydown task can run submit() again, so a double-submit is
+    //     rejected by the composer itself, not by this guard.
+    // If a future change moves session/beat creation off this synchronous
+    // path, or adds another caller that skips the composer, this guard can
+    // become reachable again -- give it a user-facing message at that point.
     if (!active || !beat || beat.answer || !clean || isWeaving.value)
       return false
 


### PR DESCRIPTION
Conductor task: `storybook/t-020` (kaizen from t-010, PR #1846).

`answerCurrentBeat`'s early guard (`!active || !beat || beat.answer || !clean || isWeaving.value`) returns `false` silently with no user-facing signal. The task asked whether any branch is actually reachable through the UI in a way that leaves the reader with no feedback.

Traced every branch against `narrative-response-composer.vue` and the store:

- `!active` / `!beat` — the composer only renders behind `v-if="store.session && !store.isComplete"`, and `session.value`/its first beat are both written inside the same synchronous span as `isWeaving.value = true` (`beginStory` → `weaveBeat`), so there's no paint where the composer is visible, enabled, and beat-less.
- `!clean` — the composer's own `submit()` already trims and rejects an empty/whitespace-only value before ever emitting `submit`.
- `beat.answer` / `isWeaving.value` (double-submit) — both flip inside the same synchronous block that starts `weaveBeat`, before any `await`. The composer's `disabled`/`loading` props mirror those flags, and the HTML spec drains Vue's microtask render queue before the next click or keydown task can run `submit()` again, so a double-submit is rejected by the composer itself.

Conclusion: not reachable through normal UI flow today, so no new user-facing message is added. Left a comment recording the analysis and the condition that would make it reachable again, per the task's own "if not reachable through normal UI flow, close this out with that finding recorded" instruction.

**Verification**
- `eslint stores/storybookStore.ts` clean on the touched lines (2 pre-existing unrelated errors at lines 364/639 confirmed via `git stash` to predate this change)
- `prettier --check` clean on the touched lines (this file's pre-existing formatting drift at the `STORYBOOK_MODES` array also confirmed via `git stash` to predate this change and left untouched)
- `vue-tsc --noEmit` repo-wide: exit 0
- `verifyStorybookAnswerInputPreservationGuard.mjs` and `verifyStorybookAnswerRollbackGuard.mjs` (existing regression guards for this function): both still pass
- `git status --porcelain` shows exactly the one intended file

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2wJBVsFJH9J47TJGmyyZ8)_