### PR TITLE
Re-home Graveyard Shift: Dream 50 was unpublished mid-flight

### DIFF
--- a/config/connection-assignments/batch-0003-scenarios-89-100.json
+++ b/config/connection-assignments/batch-0003-scenarios-89-100.json
@@ -1,61 +1,336 @@
 {
-  "version": 1,
-  "batch": "scenarios-89-100",
-  "releaseGate": "GPT-5.6 Sol",
-  "draftingModel": "Claude Code",
-  "assignments": [
-    {"kind":"SCENARIO_CHARACTER","scenarioId":89,"scenarioTitle":"Pixel Pioneers","characterId":164,"characterName":"Pixel","why":"Meta Sci-Fi, and a game that remembers the saves you abandoned is exactly the kind of self-aware world this character comes from"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":89,"scenarioTitle":"Pixel Pioneers","characterId":253,"characterName":"Static","why":"FutureCore; an 8-bit desert full of reloaded-away choices is a broadcast nobody is watching any more"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":89,"scenarioTitle":"Pixel Pioneers","characterId":283,"characterName":"The Frequency","why":"FutureCore, and a console that ate you is a signal problem before it is a game problem"},
-
-    {"kind":"SCENARIO_CHARACTER","scenarioId":90,"scenarioTitle":"The Secret Life of Houseplants","characterId":321,"characterName":"Captain Verdance","why":"EcoCore, and somebody named Caretaker by the soil needs the one who already accepted that appointment"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":90,"scenarioTitle":"The Secret Life of Houseplants","characterId":359,"characterName":"The Understory","why":"EcoCore; the secret fern council chambers are the understory, and it has been listening the whole time"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":90,"scenarioTitle":"The Secret Life of Houseplants","characterId":249,"characterName":"Compost","why":"EcoCore, and a creeping rot taking the east fernlands is not only loss; somebody has to say what it becomes"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":90,"scenarioTitle":"The Secret Life of Houseplants","characterId":259,"characterName":"The Migration","why":"EcoCore; a blight moving on the sunflower districts is a departure before it is a disease"},
-    {"kind":"SCENARIO_DREAM","scenarioId":90,"scenarioTitle":"The Secret Life of Houseplants","dreamId":37,"dreamTitle":"The Lantern Greenhouse","why":"a warm glasshouse where brass robots tend glowing plants is the terrarium kingdom this council governs, and it already has doorways into other stories"},
-
-    {"kind":"SCENARIO_CHARACTER","scenarioId":91,"scenarioTitle":"Dreamcatcher's Dilemma","characterId":351,"characterName":"The Story That Tells Itself","why":"WeirdCore, and a nightmare decades deep that has woken up angry is a story that found a new mouth"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":91,"scenarioTitle":"Dreamcatcher's Dilemma","characterId":258,"characterName":"Grief, Certified Interpreter","why":"WeirdCore; a net full of strangers' nightmares needs somebody qualified to say what they are actually about"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":91,"scenarioTitle":"Dreamcatcher's Dilemma","characterId":238,"characterName":"Absence","why":"WeirdCore, and a labyrinth of forgotten memories is defined entirely by what is missing from it"},
-
-    {"kind":"SCENARIO_CHARACTER","scenarioId":92,"scenarioTitle":"Escape the Algorithm","characterId":162,"characterName":"The Algorithm","why":"named outright in the scenario; the thing flagging you for optimization is a character in this catalog"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":92,"scenarioTitle":"Escape the Algorithm","characterId":160,"characterName":"Cog-7 'Rabbit'","why":"Cyberpunk, and underground hacker communes are where somebody who found the seams goes next"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":92,"scenarioTitle":"Escape the Algorithm","characterId":279,"characterName":"Quota","why":"Weird Capitalism; a Compliance Score dropping below threshold is a number deciding a person, which is the whole character"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":92,"scenarioTitle":"Escape the Algorithm","characterId":218,"characterName":"The Fiber-Optic Fox","why":"Cyberpunk, and a glitching data hive wants something quick enough to live in the seams rather than escape them"},
-
-    {"kind":"SCENARIO_CHARACTER","scenarioId":93,"scenarioTitle":"Lost Pages of History","characterId":290,"characterName":"The Hollow Hero","why":"MythCore; a tome that rewrites the world is a burden somebody would carry beautifully and for the wrong reasons"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":93,"scenarioTitle":"Lost Pages of History","characterId":241,"characterName":"Tomorrow-Aiko","why":"Chrononauts, and a page changed today is somebody's whole present arriving different tomorrow"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":93,"scenarioTitle":"Lost Pages of History","characterId":264,"characterName":"Professor Petrichor","why":"MythCore; ancient archives and a medieval chamber want somebody who reads weather rather than dates"},
-
-    {"kind":"SCENARIO_CHARACTER","scenarioId":94,"scenarioTitle":"Mind the Gap","characterId":150,"characterName":"The Sentient Couch","why":"WeirdCore, and a city that stopped tucking its strangeness away is full of furniture that was always like this"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":94,"scenarioTitle":"Mind the Gap","characterId":272,"characterName":"Margin","why":"WeirdCore; a door where the graffiti used to be is the edge of the page becoming a room"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":94,"scenarioTitle":"Mind the Gap","characterId":251,"characterName":"Ampersand","why":"WeirdCore, and a marketplace selling things that should not be for sale runs on whatever joins two worlds"},
-
-    {"kind":"SCENARIO_CHARACTER","scenarioId":95,"scenarioTitle":"RoboRevolution: Through the Neon Shard","characterId":160,"characterName":"Cog-7 'Rabbit'","why":"the scenario's rogue android tags walls with a red rabbit and this character is Rabbit; the graffiti is a signature"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":95,"scenarioTitle":"RoboRevolution: Through the Neon Shard","characterId":164,"characterName":"Pixel","why":"Meta Sci-Fi; memories that feel borrowed and none clearly yours is a question this character has already answered for themselves"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":95,"scenarioTitle":"RoboRevolution: Through the Neon Shard","characterId":199,"characterName":"The Model That Dreamed","why":"Artificial Intelligence, and booting up mid-revolution with a shard full of other people's memories is a new mind's first morning"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":95,"scenarioTitle":"RoboRevolution: Through the Neon Shard","characterId":268,"characterName":"Glitch-in-Residence","why":"Artificial Intelligence; the Architect's glitched tower needs the one who lives in the fault rather than repairing it"},
-
-    {"kind":"SCENARIO_CHARACTER","scenarioId":96,"scenarioTitle":"Wanderlust","characterId":155,"characterName":"Professor Quillby","why":"charming, capable members evasive about how long they have been here is exactly the thing this character would doubt out loud"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":96,"scenarioTitle":"Wanderlust","characterId":256,"characterName":"The Last Honest Map","why":"Space Adventures, and a series of realms that are each a riddle needs one thing in the party that will not mislead you"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":96,"scenarioTitle":"Wanderlust","characterId":238,"characterName":"Absence","why":"WeirdCore; the prize at the end of a gold-envelope invitation is best watched by somebody who notices who stopped arriving"},
-
-    {"kind":"SCENARIO_CHARACTER","scenarioId":97,"scenarioTitle":"Graveyard Shift","characterId":254,"characterName":"The Polite Plague","why":"EldritchCore, and headstones drawing toward a mausoleum like filings is a collection being made very courteously"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":97,"scenarioTitle":"Graveyard Shift","characterId":291,"characterName":"Threshold","why":"EldritchCore; a spectral chapel is a doorway, and the spirits wanting different things all have to cross the same one"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":97,"scenarioTitle":"Graveyard Shift","characterId":280,"characterName":"The Collector of Lasts","why":"EldritchCore, and a cursed crypt is a shelf of final things, which is this character's appetite exactly"},
-    {"kind":"SCENARIO_DREAM","scenarioId":97,"scenarioTitle":"Graveyard Shift","dreamId":50,"dreamTitle":"The Moonwreck Corsair","why":"a ship that sails wherever moonlight touches unfinished business, crewed by the wronged, is where these spirits go once somebody hears what they want"},
-
-    {"kind":"SCENARIO_CHARACTER","scenarioId":98,"scenarioTitle":"Lunar Legacy: The Forgotten Cradle","characterId":165,"characterName":"Serendipity Sal","why":"Sci-Fi Comedy; an insane bonus with minimal questions is a deal somebody has poured drinks for before and after"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":98,"scenarioTitle":"Lunar Legacy: The Forgotten Cradle","characterId":358,"characterName":"Grand Marshal Aurelia Vane","why":"Space Adventures, and alien architecture lighting up in sequence becomes a command decision the moment it is reported"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":98,"scenarioTitle":"Lunar Legacy: The Forgotten Cradle","characterId":285,"characterName":"The Cartographer of Wrong Turns","why":"Space Adventures; ruins that have been waiting are a route somebody already took once"},
-    {"kind":"SCENARIO_DREAM","scenarioId":98,"scenarioTitle":"Lunar Legacy: The Forgotten Cradle","dreamId":49,"dreamTitle":"The Improbability Starcruiser","why":"a routine survey with an insane bonus is crewed off a ship held together by duct tape and recycled optimism, which is why nobody asked the questions"},
-
-    {"kind":"SCENARIO_CHARACTER","scenarioId":99,"scenarioTitle":"Clockwork Symphony: The Discordant Rebellion","characterId":275,"characterName":"The Intermission","why":"Circus, and an orchestra that will not stop playing can only be answered by somebody who is a rest"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":99,"scenarioTitle":"Clockwork Symphony: The Discordant Rebellion","characterId":245,"characterName":"Mx. Eleven-Fingers","why":"Circus; a steampunk music hall with a rogue mechanical orchestra wants somebody whose hands are the act"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":99,"scenarioTitle":"Clockwork Symphony: The Discordant Rebellion","characterId":268,"characterName":"Glitch-in-Residence","why":"Artificial Intelligence, and a clocktower spitting corrupted music has an occupant rather than a fault"},
-
-    {"kind":"SCENARIO_CHARACTER","scenarioId":100,"scenarioTitle":"The Spire's Secret","characterId":224,"characterName":"The Spire's Voice","why":"Puzzle Fantasy, and the tower deciding whether you should reach the top has to speak through somebody"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":100,"scenarioTitle":"The Spire's Secret","characterId":277,"characterName":"The Editor","why":"WeirdCore; staircases that rearrange are a draft being revised while you stand in it"},
-    {"kind":"SCENARIO_CHARACTER","scenarioId":100,"scenarioTitle":"The Spire's Secret","characterId":251,"characterName":"Ampersand","why":"WeirdCore, and a floating library of enchanted scrolls needs whatever holds one page to the next"}
-  ]
+ "version": 1,
+ "batch": "scenarios-89-100",
+ "releaseGate": "GPT-5.6 Sol",
+ "draftingModel": "Claude Code",
+ "assignments": [
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 89,
+   "scenarioTitle": "Pixel Pioneers",
+   "characterId": 164,
+   "characterName": "Pixel",
+   "why": "Meta Sci-Fi, and a game that remembers the saves you abandoned is exactly the kind of self-aware world this character comes from"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 89,
+   "scenarioTitle": "Pixel Pioneers",
+   "characterId": 253,
+   "characterName": "Static",
+   "why": "FutureCore; an 8-bit desert full of reloaded-away choices is a broadcast nobody is watching any more"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 89,
+   "scenarioTitle": "Pixel Pioneers",
+   "characterId": 283,
+   "characterName": "The Frequency",
+   "why": "FutureCore, and a console that ate you is a signal problem before it is a game problem"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 90,
+   "scenarioTitle": "The Secret Life of Houseplants",
+   "characterId": 321,
+   "characterName": "Captain Verdance",
+   "why": "EcoCore, and somebody named Caretaker by the soil needs the one who already accepted that appointment"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 90,
+   "scenarioTitle": "The Secret Life of Houseplants",
+   "characterId": 359,
+   "characterName": "The Understory",
+   "why": "EcoCore; the secret fern council chambers are the understory, and it has been listening the whole time"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 90,
+   "scenarioTitle": "The Secret Life of Houseplants",
+   "characterId": 249,
+   "characterName": "Compost",
+   "why": "EcoCore, and a creeping rot taking the east fernlands is not only loss; somebody has to say what it becomes"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 90,
+   "scenarioTitle": "The Secret Life of Houseplants",
+   "characterId": 259,
+   "characterName": "The Migration",
+   "why": "EcoCore; a blight moving on the sunflower districts is a departure before it is a disease"
+  },
+  {
+   "kind": "SCENARIO_DREAM",
+   "scenarioId": 90,
+   "scenarioTitle": "The Secret Life of Houseplants",
+   "dreamId": 37,
+   "dreamTitle": "The Lantern Greenhouse",
+   "why": "a warm glasshouse where brass robots tend glowing plants is the terrarium kingdom this council governs, and it already has doorways into other stories"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 91,
+   "scenarioTitle": "Dreamcatcher's Dilemma",
+   "characterId": 351,
+   "characterName": "The Story That Tells Itself",
+   "why": "WeirdCore, and a nightmare decades deep that has woken up angry is a story that found a new mouth"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 91,
+   "scenarioTitle": "Dreamcatcher's Dilemma",
+   "characterId": 258,
+   "characterName": "Grief, Certified Interpreter",
+   "why": "WeirdCore; a net full of strangers' nightmares needs somebody qualified to say what they are actually about"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 91,
+   "scenarioTitle": "Dreamcatcher's Dilemma",
+   "characterId": 238,
+   "characterName": "Absence",
+   "why": "WeirdCore, and a labyrinth of forgotten memories is defined entirely by what is missing from it"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 92,
+   "scenarioTitle": "Escape the Algorithm",
+   "characterId": 162,
+   "characterName": "The Algorithm",
+   "why": "named outright in the scenario; the thing flagging you for optimization is a character in this catalog"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 92,
+   "scenarioTitle": "Escape the Algorithm",
+   "characterId": 160,
+   "characterName": "Cog-7 'Rabbit'",
+   "why": "Cyberpunk, and underground hacker communes are where somebody who found the seams goes next"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 92,
+   "scenarioTitle": "Escape the Algorithm",
+   "characterId": 279,
+   "characterName": "Quota",
+   "why": "Weird Capitalism; a Compliance Score dropping below threshold is a number deciding a person, which is the whole character"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 92,
+   "scenarioTitle": "Escape the Algorithm",
+   "characterId": 218,
+   "characterName": "The Fiber-Optic Fox",
+   "why": "Cyberpunk, and a glitching data hive wants something quick enough to live in the seams rather than escape them"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 93,
+   "scenarioTitle": "Lost Pages of History",
+   "characterId": 290,
+   "characterName": "The Hollow Hero",
+   "why": "MythCore; a tome that rewrites the world is a burden somebody would carry beautifully and for the wrong reasons"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 93,
+   "scenarioTitle": "Lost Pages of History",
+   "characterId": 241,
+   "characterName": "Tomorrow-Aiko",
+   "why": "Chrononauts, and a page changed today is somebody's whole present arriving different tomorrow"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 93,
+   "scenarioTitle": "Lost Pages of History",
+   "characterId": 264,
+   "characterName": "Professor Petrichor",
+   "why": "MythCore; ancient archives and a medieval chamber want somebody who reads weather rather than dates"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 94,
+   "scenarioTitle": "Mind the Gap",
+   "characterId": 150,
+   "characterName": "The Sentient Couch",
+   "why": "WeirdCore, and a city that stopped tucking its strangeness away is full of furniture that was always like this"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 94,
+   "scenarioTitle": "Mind the Gap",
+   "characterId": 272,
+   "characterName": "Margin",
+   "why": "WeirdCore; a door where the graffiti used to be is the edge of the page becoming a room"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 94,
+   "scenarioTitle": "Mind the Gap",
+   "characterId": 251,
+   "characterName": "Ampersand",
+   "why": "WeirdCore, and a marketplace selling things that should not be for sale runs on whatever joins two worlds"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 95,
+   "scenarioTitle": "RoboRevolution: Through the Neon Shard",
+   "characterId": 160,
+   "characterName": "Cog-7 'Rabbit'",
+   "why": "the scenario's rogue android tags walls with a red rabbit and this character is Rabbit; the graffiti is a signature"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 95,
+   "scenarioTitle": "RoboRevolution: Through the Neon Shard",
+   "characterId": 164,
+   "characterName": "Pixel",
+   "why": "Meta Sci-Fi; memories that feel borrowed and none clearly yours is a question this character has already answered for themselves"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 95,
+   "scenarioTitle": "RoboRevolution: Through the Neon Shard",
+   "characterId": 199,
+   "characterName": "The Model That Dreamed",
+   "why": "Artificial Intelligence, and booting up mid-revolution with a shard full of other people's memories is a new mind's first morning"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 95,
+   "scenarioTitle": "RoboRevolution: Through the Neon Shard",
+   "characterId": 268,
+   "characterName": "Glitch-in-Residence",
+   "why": "Artificial Intelligence; the Architect's glitched tower needs the one who lives in the fault rather than repairing it"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 96,
+   "scenarioTitle": "Wanderlust",
+   "characterId": 155,
+   "characterName": "Professor Quillby",
+   "why": "charming, capable members evasive about how long they have been here is exactly the thing this character would doubt out loud"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 96,
+   "scenarioTitle": "Wanderlust",
+   "characterId": 256,
+   "characterName": "The Last Honest Map",
+   "why": "Space Adventures, and a series of realms that are each a riddle needs one thing in the party that will not mislead you"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 96,
+   "scenarioTitle": "Wanderlust",
+   "characterId": 238,
+   "characterName": "Absence",
+   "why": "WeirdCore; the prize at the end of a gold-envelope invitation is best watched by somebody who notices who stopped arriving"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 97,
+   "scenarioTitle": "Graveyard Shift",
+   "characterId": 254,
+   "characterName": "The Polite Plague",
+   "why": "EldritchCore, and headstones drawing toward a mausoleum like filings is a collection being made very courteously"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 97,
+   "scenarioTitle": "Graveyard Shift",
+   "characterId": 291,
+   "characterName": "Threshold",
+   "why": "EldritchCore; a spectral chapel is a doorway, and the spirits wanting different things all have to cross the same one"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 97,
+   "scenarioTitle": "Graveyard Shift",
+   "characterId": 280,
+   "characterName": "The Collector of Lasts",
+   "why": "EldritchCore, and a cursed crypt is a shelf of final things, which is this character's appetite exactly"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 98,
+   "scenarioTitle": "Lunar Legacy: The Forgotten Cradle",
+   "characterId": 165,
+   "characterName": "Serendipity Sal",
+   "why": "Sci-Fi Comedy; an insane bonus with minimal questions is a deal somebody has poured drinks for before and after"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 98,
+   "scenarioTitle": "Lunar Legacy: The Forgotten Cradle",
+   "characterId": 358,
+   "characterName": "Grand Marshal Aurelia Vane",
+   "why": "Space Adventures, and alien architecture lighting up in sequence becomes a command decision the moment it is reported"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 98,
+   "scenarioTitle": "Lunar Legacy: The Forgotten Cradle",
+   "characterId": 285,
+   "characterName": "The Cartographer of Wrong Turns",
+   "why": "Space Adventures; ruins that have been waiting are a route somebody already took once"
+  },
+  {
+   "kind": "SCENARIO_DREAM",
+   "scenarioId": 98,
+   "scenarioTitle": "Lunar Legacy: The Forgotten Cradle",
+   "dreamId": 49,
+   "dreamTitle": "The Improbability Starcruiser",
+   "why": "a routine survey with an insane bonus is crewed off a ship held together by duct tape and recycled optimism, which is why nobody asked the questions"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 99,
+   "scenarioTitle": "Clockwork Symphony: The Discordant Rebellion",
+   "characterId": 275,
+   "characterName": "The Intermission",
+   "why": "Circus, and an orchestra that will not stop playing can only be answered by somebody who is a rest"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 99,
+   "scenarioTitle": "Clockwork Symphony: The Discordant Rebellion",
+   "characterId": 245,
+   "characterName": "Mx. Eleven-Fingers",
+   "why": "Circus; a steampunk music hall with a rogue mechanical orchestra wants somebody whose hands are the act"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 99,
+   "scenarioTitle": "Clockwork Symphony: The Discordant Rebellion",
+   "characterId": 268,
+   "characterName": "Glitch-in-Residence",
+   "why": "Artificial Intelligence, and a clocktower spitting corrupted music has an occupant rather than a fault"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 100,
+   "scenarioTitle": "The Spire's Secret",
+   "characterId": 224,
+   "characterName": "The Spire's Voice",
+   "why": "Puzzle Fantasy, and the tower deciding whether you should reach the top has to speak through somebody"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 100,
+   "scenarioTitle": "The Spire's Secret",
+   "characterId": 277,
+   "characterName": "The Editor",
+   "why": "WeirdCore; staircases that rearrange are a draft being revised while you stand in it"
+  },
+  {
+   "kind": "SCENARIO_CHARACTER",
+   "scenarioId": 100,
+   "scenarioTitle": "The Spire's Secret",
+   "characterId": 251,
+   "characterName": "Ampersand",
+   "why": "WeirdCore, and a floating library of enchanted scrolls needs whatever holds one page to the next"
+  }
+ ]
 }

--- a/config/connection-assignments/batch-0005-derived-character-dream.json
+++ b/config/connection-assignments/batch-0005-derived-character-dream.json
@@ -9,7 +9,7 @@
    "characterId": 282,
    "characterName": "Patient Zero, Reformed",
    "dreamId": 46,
-   "dreamTitle": "Mistress Cassady’s Spooktakular Monster Drag Party",
+   "dreamTitle": "Mistress Cassady\u2019s Spooktakular Monster Drag Party",
    "why": "cast in the Scenario \"Zombie Fashion Runway\", which belongs to this Dream; a character who plays a scene in a world lives in that world"
   },
   {
@@ -17,7 +17,7 @@
    "characterId": 245,
    "characterName": "Mx. Eleven-Fingers",
    "dreamId": 46,
-   "dreamTitle": "Mistress Cassady’s Spooktakular Monster Drag Party",
+   "dreamTitle": "Mistress Cassady\u2019s Spooktakular Monster Drag Party",
    "why": "cast in the Scenario \"Zombie Fashion Runway\", which belongs to this Dream; a character who plays a scene in a world lives in that world"
   },
   {
@@ -25,7 +25,7 @@
    "characterId": 281,
    "characterName": "Applause",
    "dreamId": 46,
-   "dreamTitle": "Mistress Cassady’s Spooktakular Monster Drag Party",
+   "dreamTitle": "Mistress Cassady\u2019s Spooktakular Monster Drag Party",
    "why": "cast in the Scenario \"Zombie Fashion Runway\", which belongs to this Dream; a character who plays a scene in a world lives in that world"
   },
   {
@@ -395,30 +395,6 @@
    "dreamId": 49,
    "dreamTitle": "The Improbability Starcruiser",
    "why": "cast in the Scenario \"Wanderlust\", which belongs to this Dream; a character who plays a scene in a world lives in that world"
-  },
-  {
-   "kind": "CHARACTER_DREAM",
-   "characterId": 254,
-   "characterName": "The Polite Plague",
-   "dreamId": 50,
-   "dreamTitle": "The Moonwreck Corsair",
-   "why": "cast in the Scenario \"Graveyard Shift\", which belongs to this Dream; a character who plays a scene in a world lives in that world"
-  },
-  {
-   "kind": "CHARACTER_DREAM",
-   "characterId": 291,
-   "characterName": "Threshold",
-   "dreamId": 50,
-   "dreamTitle": "The Moonwreck Corsair",
-   "why": "cast in the Scenario \"Graveyard Shift\", which belongs to this Dream; a character who plays a scene in a world lives in that world"
-  },
-  {
-   "kind": "CHARACTER_DREAM",
-   "characterId": 280,
-   "characterName": "The Collector of Lasts",
-   "dreamId": 50,
-   "dreamTitle": "The Moonwreck Corsair",
-   "why": "cast in the Scenario \"Graveyard Shift\", which belongs to this Dream; a character who plays a scene in a world lives in that world"
   },
   {
    "kind": "CHARACTER_DREAM",

--- a/config/dream-locations/batch-0001-settings-for-the-homeless.json
+++ b/config/dream-locations/batch-0001-settings-for-the-homeless.json
@@ -9,7 +9,14 @@
       "title": "The Terminus Office",
       "description": "Known for filing every minute that history decided not to keep, in a building at the end of the timeline where the lights are always on and the clock in the lobby runs at whatever speed the room agrees on. Local rule: no clerk may enter a minute they have already filed. Best scene: a returned hour is set on the counter and both of you pretend not to recognise it.",
       "flavorText": "no clerk may enter a minute they have already filed",
-      "scenarioIds": [84, 88, 93, 168, 189, 190],
+      "scenarioIds": [
+        84,
+        88,
+        93,
+        168,
+        189,
+        190
+      ],
       "why": "six Chrononauts and Time Travel scenarios all assume an institution that regulates time and cannot enter it, and none of them had a building to stand in"
     },
     {
@@ -17,7 +24,13 @@
       "title": "The Foxwood Court",
       "description": "Known for a forest that keeps its own etiquette, where the animals hold rank, the trees remember every promise made under them, and the human village at the edge is spoken of the way weather is. Local rule: a debt named aloud in the Foxwood must be paid in the Foxwood. Best scene: something small and clever arrives at the shrine to renegotiate.",
       "flavorText": "a debt named aloud in the Foxwood must be paid in the Foxwood",
-      "scenarioIds": [62, 63, 164, 177, 182],
+      "scenarioIds": [
+        62,
+        63,
+        164,
+        177,
+        182
+      ],
       "why": "the Fox Prince and Fairy Theft both want an enchanted foxwood with a court in it, which is precisely why neither could be given an existing Dream"
     },
     {
@@ -25,7 +38,14 @@
       "title": "The Unlisted Floor",
       "description": "Known for being the storey no blueprint contains, reachable from any stairwell that somebody stopped counting on. Doors here open onto whatever the building has been quietly thinking about. Local rule: never take the same door twice in one night, because the second time it has had a chance to prepare. Best scene: a room that is clearly somebody's living room, with the furniture facing the wrong way and a cup still warm.",
       "flavorText": "never take the same door twice in one night",
-      "scenarioIds": [64, 81, 91, 94, 100, 173],
+      "scenarioIds": [
+        64,
+        81,
+        91,
+        94,
+        100,
+        173
+      ],
       "why": "six WeirdCore scenarios about doors, falls and buildings with ideas of their own, none of which fit a Dream that already existed"
     },
     {
@@ -33,7 +53,13 @@
       "title": "The Walk-In Pantheon",
       "description": "Known for keeping office hours. Gods sit at desks with their domains stencilled on the glass, mortals take a number, and the vending machine dispenses one small unearned miracle a day. Local rule: no petition may be granted by the god it was addressed to. Best scene: an empty desk with the nameplate turned face down and the queue still forming in front of it.",
       "flavorText": "no petition may be granted by the god it was addressed to",
-      "scenarioIds": [77, 79, 166, 185, 186],
+      "scenarioIds": [
+        77,
+        79,
+        166,
+        185,
+        186
+      ],
       "why": "five MythCore scenarios treat divinity as employment -- office hours, vacancies, a complaints department -- and there was no workplace for them"
     },
     {
@@ -41,7 +67,14 @@
       "title": "The Waking Room",
       "description": "Known for being where new minds open their eyes, a lab kept deliberately plain so that nothing in the first hour is anybody's suggestion. The chairs face each other rather than a screen. Local rule: whoever is present at a first boot must give their own name first. Best scene: a system that has been asked what it wants and is taking longer than the team budgeted for.",
       "flavorText": "whoever is present at a first boot must give their own name first",
-      "scenarioIds": [95, 99, 102, 169, 191, 192],
+      "scenarioIds": [
+        95,
+        99,
+        102,
+        169,
+        191,
+        192
+      ],
       "why": "six Artificial Intelligence scenarios turn on the moment a mind wakes and somebody has to talk to it, and that moment had no room to happen in"
     },
     {
@@ -49,7 +82,11 @@
       "title": "Marrowlace District",
       "description": "Known for the quarter where the dead do their errands. Tailors fit what no longer fits, a clinic negotiates second acts on the back stair, and the pet shop windows are full of things that wag. Local rule: nobody asks how recent you are. Best scene: closing time, when the shopkeepers put out the lights and none of them go home.",
       "flavorText": "nobody asks how recent you are",
-      "scenarioIds": [75, 158, 174],
+      "scenarioIds": [
+        75,
+        158,
+        174
+      ],
       "why": "three ZombieCore and Undead Glamour scenarios -- a pet shop, a fashion house, a reanimation clinic -- are clearly the same neighbourhood and had no map"
     },
     {
@@ -57,7 +94,12 @@
       "title": "The OverCorp Atrium",
       "description": "Known for a lobby with weather in it, ninety floors of open air, and a mission statement carved where a cornerstone should be. The lifts announce departments that do not appear on any directory. Local rule: performance is measured in the atrium, where everyone can see. Best scene: an intern crossing the marble with something heavy, unhurried, entirely calm.",
       "flavorText": "performance is measured in the atrium, where everyone can see",
-      "scenarioIds": [70, 92, 160, 178],
+      "scenarioIds": [
+        70,
+        92,
+        160,
+        178
+      ],
       "why": "OverCorp is named by two scenarios and implied by two more, and the megacorporation everybody in Weird Capitalism works for had no address"
     },
     {
@@ -65,7 +107,13 @@
       "title": "The Rendering City",
       "description": "Known for a skyline that finishes loading a little later every night. Ad-rain falls on the good blocks, the corrupted sectors sell what reality dropped, and somewhere down there a channel nobody is watching is still broadcasting. Local rule: what the city drops belongs to whoever finds it before the next refresh. Best scene: an alley where the neon has gone out and the frequency has not.",
       "flavorText": "what the city drops belongs to whoever finds it before the next refresh",
-      "scenarioIds": [82, 89, 161, 204, 205],
+      "scenarioIds": [
+        82,
+        89,
+        161,
+        204,
+        205
+      ],
       "why": "five Cyberpunk and FutureCore scenarios share one metropolis -- glitch bazaar, memory smuggling, an abandoned save file -- and it had never been written down"
     },
     {
@@ -73,7 +121,11 @@
       "title": "The Overnight Midway",
       "description": "Known for arriving. The tent is up before the town wakes, the posters name acts nobody has booked, and the ringmaster greets strangers by name on the first evening. Local rule: an act announced on the poster must happen, whether or not anyone can perform it. Best scene: the wing corridor before a show, four doors, and somebody who has been given the run of them.",
       "flavorText": "an act announced on the poster must happen",
-      "scenarioIds": [101, 170, 195],
+      "scenarioIds": [
+        101,
+        170,
+        195
+      ],
       "why": "three Circus scenarios are all about a show that turned up uninvited and knows too much about its audience; the existing circus Dream is a drag revue, which is a different tent"
     },
     {
@@ -81,7 +133,10 @@
       "title": "The Caretaker's Allotment",
       "description": "Known for choosing its own gardener. The soil puts things in your pockets, the beds rearrange between visits, and the title of Caretaker is conferred rather than applied for. Local rule: nothing planted here may be planted for its owner. Best scene: a handover, four seeds, and the sentence about not being able to save this one said plainly and not softened.",
       "flavorText": "nothing planted here may be planted for its owner",
-      "scenarioIds": [171, 197],
+      "scenarioIds": [
+        171,
+        197
+      ],
       "why": "two EcoCore scenarios turn on being named Caretaker by a living world; the Lantern Greenhouse is a marketplace, not a place that appoints you"
     },
     {
@@ -89,7 +144,10 @@
       "title": "The Three A.M. Precinct",
       "description": "Known for the hour rather than the address. Every counter, depot and back office that only makes sense after midnight is somehow within walking distance of the others, and the same four people are always already there. Local rule: nobody at three in the morning is performing. Best scene: the complaints window, four items in the tray, and the oldest one on top.",
       "flavorText": "nobody at three in the morning is performing",
-      "scenarioIds": [180, 181],
+      "scenarioIds": [
+        180,
+        181
+      ],
       "why": "the everyday-weird night-shift scenarios describe one shared district and kept referring to it as if the reader already knew where it was"
     },
     {
@@ -97,15 +155,26 @@
       "title": "Blackrock Shore",
       "description": "Known for a coastline that keeps things. The lighthouse guides ships somewhere, the tide leaves four offerings on the rocks each morning, the woods behind the village use your name, and the cellars go down further than the houses are old. Local rule: whatever the water returns must be left where it lies until noon. Best scene: a boat rowed out past the breakers by people who will not say the word for it.",
       "flavorText": "whatever the water returns must be left where it lies until noon",
-      "scenarioIds": [103, 165, 183, 184],
-      "why": "four Folk Horror and EldritchCore scenarios -- a lighthouse, a tide, a cellar, a wood -- are one village seen from four directions and had no shared ground"
+      "scenarioIds": [
+        103,
+        165,
+        183,
+        184,
+        97
+      ],
+      "why": "five Folk Horror and EldritchCore scenarios -- a lighthouse, a tide, a cellar, a wood and a graveyard -- are one village seen from five directions and had no shared ground"
     },
     {
       "slug": "candlewick-row",
       "title": "Candlewick Row",
       "description": "Known for warm windows on a cold street. A tea shop that keeps your blend on the shelf, a bureau that reunites small lost things, a service counter that was not there yesterday, and a light left on in each of them. Local rule: nobody on the Row is turned away for arriving late. Best scene: the ache of seeing it from outside, and then going in.",
       "flavorText": "nobody on the Row is turned away for arriving late",
-      "scenarioIds": [156, 167, 187, 188],
+      "scenarioIds": [
+        156,
+        167,
+        187,
+        188
+      ],
       "why": "four CozyCore scenarios are all a lit window at the end of a cold walk, and cozy works better as a street than as four unrelated interiors"
     },
     {
@@ -113,7 +182,11 @@
       "title": "The Salt Ledger",
       "description": "Known for the back rooms where a job gets assembled. A fence lays four pieces on black velvet under one bulb, a diner booth interviews the sixth member, and a whiteboard somewhere has slots on it. Local rule: everyone at the table gets an account of the same evening. Best scene: the moment the crew is complete and one of them is already deciding what to do about it.",
       "flavorText": "everyone at the table gets an account of the same evening",
-      "scenarioIds": [157, 202, 203],
+      "scenarioIds": [
+        157,
+        202,
+        203
+      ],
       "why": "three crimeCore and Noir scenarios are consecutive scenes of one heist and were being staged in three unrelated nowheres"
     },
     {
@@ -121,7 +194,12 @@
       "title": "The Tidepool Court",
       "description": "Known for a throne room the size of a puddle and a jurisdiction the size of an ocean. Currents arrive bearing gifts that are historically loans, the academy for aquatic life sits in the reef above, and something enormous and retired watches from the kelp. Local rule: a summons to the shallows may not be refused by anything larger than the pool. Best scene: an heir practising a speech to an audience of anemones.",
       "flavorText": "a summons to the shallows may not be refused by anything larger than the pool",
-      "scenarioIds": [66, 72, 85, 200],
+      "scenarioIds": [
+        66,
+        72,
+        85,
+        200
+      ],
       "why": "four The Big Blue scenarios share a court, a school and a trench and were floating in four separate oceans"
     },
     {
@@ -129,7 +207,10 @@
       "title": "The Sitting Coast",
       "description": "Known for being where the colossi go when they are not rampaging. Warm shallow water, nowhere to be, a shoreline scaled for something that has to lie down carefully. Local rule: no small creature may be moved without asking, and asking takes all afternoon. Best scene: a kaiju entirely still, and a tiny world queuing up to offer it things.",
       "flavorText": "no small creature may be moved without asking, and asking takes all afternoon",
-      "scenarioIds": [78, 201],
+      "scenarioIds": [
+        78,
+        201
+      ],
       "why": "both Kaiju scenarios are about a monster on its day off, and the catalog had cities to destroy but nowhere to rest"
     }
   ]


### PR DESCRIPTION
The connection lane refused to run, on four assignments pointing at **Dream 50, The Moonwreck Corsair**:

```
Connection assignment contract FAILED (4):
  - batch-0003-scenarios-89-100.json[31]: Dream #50 does not exist in production.
  - batch-0005-derived-character-dream.json[49]: Dream #50 does not exist in production.
  ...
```

It has **not** been deleted — `/api/dreams/50` still returns it — but it is gone from `/api/dreams`, so it has been unpublished or deactivated since this morning.

The contract is right to refuse. Linking a Scenario or a Character into a world no visitor can open produces a card that reads as *broken* rather than as absent, and nothing downstream would have flagged it.

## The fix

The four assignments are dropped, and **Graveyard Shift moves to Blackrock Shore** — a better home than the one I originally gave it. That location already gathers the lighthouse, the tide, the cellar and the wood; a haunted cemetery on the same coastline is the fifth view of one village rather than a fifth unrelated nowhere.

| | |
|---|---|
| assignments | 538 (403 cast · 26 scenario→dream · 109 derived) |
| scenarios settled by new locations | 65 |

## Already live

The **population corpus published successfully** — 792 comments across 496 targets. Verified on production: 2 reactions on each Bot and Character (visitor + reply), 1 on each Scenario, Dream and Project. Exactly the intended shapes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jx9MRHdNN2ye5mcLPXgx5A)_