### PR TITLE
davinci: fix narration-error callout background opacity drift

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -227,6 +227,12 @@ jobs:
       - name: Da Vinci dimension-tone guard
         run: npm run test:davinci-dimension-tone-guard
 
+      - name: Da Vinci narration-error tone guard self-test
+        run: npm run test:davinci-narration-error-tone-guard-selftest
+
+      - name: Da Vinci narration-error tone guard
+        run: npm run test:davinci-narration-error-tone-guard
+
       - name: Serendipity Voice poll guard self-test
         run: npm run test:serendipity-voice-poll-guard-selftest
 

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -163,7 +163,7 @@
                instead of a transparent fallback. -->
           <div
             v-else-if="narrationError"
-            class="flex flex-col items-center gap-3 rounded-2xl border border-warning/40 bg-warning/5 p-6 text-center"
+            class="flex flex-col items-center gap-3 rounded-2xl border border-warning/40 bg-warning/10 p-6 text-center"
           >
             <Icon name="kind-icon:warning" class="size-8 text-warning/70" />
             <p class="text-sm text-base-content/70">

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "test:davinci-narration": "tsx utils/scripts/verifyDaVinciNarration.ts",
     "test:davinci-dimension-tone-guard-selftest": "tsx utils/scripts/verifyDaVinciDimensionToneGuard.test.ts",
     "test:davinci-dimension-tone-guard": "tsx utils/scripts/verifyDaVinciDimensionToneGuard.ts",
+    "test:davinci-narration-error-tone-guard-selftest": "tsx utils/scripts/verifyDaVinciNarrationErrorToneGuard.test.ts",
+    "test:davinci-narration-error-tone-guard": "tsx utils/scripts/verifyDaVinciNarrationErrorToneGuard.ts",
     "test:serendipity-voice-poll-guard-selftest": "tsx utils/scripts/verifySerendipityVoicePollGuard.test.ts",
     "test:serendipity-voice-poll-guard": "tsx utils/scripts/verifySerendipityVoicePollGuard.ts",
     "test:achievement-store": "tsx utils/scripts/verifyAchievementStoreFetchSafety.ts",

--- a/utils/scripts/verifyDaVinciNarrationErrorToneGuard.test.ts
+++ b/utils/scripts/verifyDaVinciNarrationErrorToneGuard.test.ts
@@ -1,0 +1,85 @@
+// /utils/scripts/verifyDaVinciNarrationErrorToneGuard.test.ts
+//
+// Regression test for checkNarrationErrorToneGuard() in
+// verifyDaVinciNarrationErrorToneGuard.ts (davinci/t-021 slice 2). Exercises
+// the real check against synthetic component-shaped fixtures covering: the
+// fixed shape (bg-warning/10), the pre-fix shape (bg-warning/5, half the
+// canonical opacity), a missing-background regression, and a missing-block
+// regression (the narration-error callout removed entirely).
+import assert from 'node:assert/strict'
+
+import { checkNarrationErrorToneGuard } from './verifyDaVinciNarrationErrorToneGuard.js'
+
+function fixture(classAttr: string): string {
+  return `
+<template>
+  <div
+    v-else-if="narrationError"
+    class="${classAttr}"
+  >
+    <Icon name="kind-icon:warning" class="size-8 text-warning/70" />
+    <p class="text-sm text-base-content/70">
+      The narrator is having trouble with this chapter.
+    </p>
+  </div>
+</template>
+`
+}
+
+const FIXED = fixture(
+  'flex flex-col items-center gap-3 rounded-2xl border border-warning/40 bg-warning/10 p-6 text-center',
+)
+
+// Pre-fix shape: bg-warning/5 is half the documented canonical opacity.
+const BUGGY = fixture(
+  'flex flex-col items-center gap-3 rounded-2xl border border-warning/40 bg-warning/5 p-6 text-center',
+)
+
+// Background tint dropped entirely.
+const NO_BACKGROUND = fixture(
+  'flex flex-col items-center gap-3 rounded-2xl border border-warning/40 p-6 text-center',
+)
+
+// The narration-error block itself no longer exists.
+const BLOCK_REMOVED = `
+<template>
+  <div v-else class="flex flex-col items-center gap-3">
+    <p>Something went wrong.</p>
+  </div>
+</template>
+`
+
+function run(): void {
+  const fixedErrors = checkNarrationErrorToneGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const buggyErrors = checkNarrationErrorToneGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    1,
+    `expected the bg-warning/5 fixture to fail exactly one check, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(buggyErrors.some((e) => /bg-warning\/5 instead of/.test(e)))
+
+  const noBackgroundErrors = checkNarrationErrorToneGuard(NO_BACKGROUND)
+  assert.equal(noBackgroundErrors.length, 1)
+  assert.ok(
+    noBackgroundErrors.some((e) => /no longer sets a bg-warning/.test(e)),
+  )
+
+  const blockRemovedErrors = checkNarrationErrorToneGuard(BLOCK_REMOVED)
+  assert.equal(blockRemovedErrors.length, 1)
+  assert.ok(blockRemovedErrors.some((e) => /Could not find a/.test(e)))
+
+  console.log(
+    'Da Vinci narration-error tone guard self-test passed: buggy fixture ' +
+      'fails, fixed fixture passes, missing-background and missing-block ' +
+      'regressions both fail.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyDaVinciNarrationErrorToneGuard.ts
+++ b/utils/scripts/verifyDaVinciNarrationErrorToneGuard.ts
@@ -1,0 +1,109 @@
+// /utils/scripts/verifyDaVinciNarrationErrorToneGuard.ts
+//
+// Regression guard (davinci/t-021 slice 2) -- the narration-error callout in
+// components/conductor/davinci-page.vue used `border-warning/40 bg-warning/5`,
+// half the documented canonical opacity for a warning status callout
+// (assets/css/tailwind.css's .kr-note-warning formula, and every other
+// border-warning/40 callout in the app, use bg-warning/10). The border
+// opacity was already correct, which made the drift easy to miss on a
+// visual skim -- only the background was half-strength, giving this one
+// callout a visibly fainter tint than every sibling warning callout
+// elsewhere in the app.
+//
+// Fixed by bringing the background opacity token in line with the
+// canonical border-warning/40 + bg-warning/10 pair. This asserts the
+// textual shape of that fix stays in place: the narration-error block still
+// pairs border-warning/40 with bg-warning/10, not bg-warning/5 or any other
+// opacity -- deliberately scoped to this one template class string, mirroring
+// this project's other narrow textual guards over a general-purpose static
+// analyzer (see verifyDaVinciDimensionToneGuard.ts).
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const COMPONENT_PATH = join(
+  repositoryRoot,
+  'components/conductor/davinci-page.vue',
+)
+
+function extractNarrationErrorBlock(content: string): string | null {
+  const marker = content.indexOf('v-else-if="narrationError"')
+  if (marker === -1) return null
+
+  // Walk backward to the start of this element's opening tag, and forward
+  // to the end of the opening tag, so we isolate just the tag's attributes
+  // (in particular its class string) rather than the whole block's body.
+  const tagStart = content.lastIndexOf('<div', marker)
+  if (tagStart === -1) return null
+  const tagEnd = content.indexOf('>', marker)
+  if (tagEnd === -1) return null
+
+  return content.slice(tagStart, tagEnd + 1)
+}
+
+export function checkNarrationErrorToneGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const openingTag = extractNarrationErrorBlock(content)
+  if (!openingTag) {
+    errors.push(
+      'Could not find a `v-else-if="narrationError"` block in ' +
+        'davinci-page.vue -- has the narration-error callout been renamed, ' +
+        'removed, or restructured? If so, this guard needs to move with it.',
+    )
+    return errors
+  }
+
+  if (!openingTag.includes('border-warning/40')) {
+    errors.push(
+      'The narration-error callout no longer uses border-warning/40 -- ' +
+        'has its border tone been changed?',
+    )
+  }
+
+  if (!openingTag.includes('bg-warning/10')) {
+    if (/bg-warning\/\d+/.test(openingTag)) {
+      const found = openingTag.match(/bg-warning\/\d+/)?.[0]
+      errors.push(
+        `The narration-error callout uses ${found} instead of the ` +
+          'canonical bg-warning/10 -- this is the exact opacity-drift bug ' +
+          '(half-strength background tint vs. every other border-warning/40 ' +
+          'callout in the app) this guard exists to catch.',
+      )
+    } else {
+      errors.push(
+        'The narration-error callout no longer sets a bg-warning/* ' +
+          'background tint at all.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(COMPONENT_PATH, 'utf8')
+  const errors = checkNarrationErrorToneGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Da Vinci narration-error tone guard contract failed in davinci-page.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Da Vinci narration-error tone guard contract passed: the narration-error ' +
+      'callout pairs border-warning/40 with the canonical bg-warning/10, ' +
+      'matching every other warning callout in the app.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
Slice 2 of `davinci/t-021` (Da Vinci visual style and interaction polish pass — Interface Vision sequence, conductor scheduled Agent run). Slice 1 (#1842) fixed the dimension-tone pill; this slice found one more concrete, verifiable gap rather than a blanket reskin.

## The gap

`components/conductor/davinci-page.vue`'s narration-error callout used:

```
border-warning/40 bg-warning/5
```

`assets/css/tailwind.css`'s `.kr-note-warning` primitive documents the canonical status-tint formula as `border-{status}/40 + bg-{status}/10`, specifically to prevent drifting opacities like this. Every other `border-warning/40` callout in the app (`snapshot-mode-banner.vue`, `stage-manager.vue`, `scenario-relationship-gallery.vue`, `kr-manager.vue`, `mermaids-pdf-purchase.vue`, `coloring-book-cover-studio.vue`, `coloring-canvas.vue`, `coloring-book-studio.vue`, `artjob-failed-page-requeue.vue`, `stylist-relay-status.vue`, `artjob-queue-browser.vue`, `conductor-page.vue`) uses `bg-warning/10`. This one callout was the sole outlier, giving it a visibly fainter tint than every sibling warning callout.

## The fix

- `bg-warning/5` → `bg-warning/10` in the narration-error callout's class string.
- Added `verifyDaVinciNarrationErrorToneGuard.ts` + `.test.ts`, following this project's narrow-textual-checker convention (modeled on `verifyDaVinciDimensionToneGuard.ts`).
- Wired two `package.json` scripts + two steps into `.github/workflows/contract-tests.yml`, alongside the existing dimension-tone guard steps.

## Verification

- New guard + self-test pass
- `test:davinci-dimension-tone-guard(-selftest)` still pass
- `test:davinci-narration` (all 26 checks) still passes
- `test:layout-contract` holds — no new violations
- eslint clean on touched files
- prettier clean on touched files
- `vue-tsc --noEmit` repo-wide exit 0
- `git status --porcelain` showed exactly the 5 intended files

---
_Generated by [Claude Code](https://claude.ai/code/session_01VwbaMfEnbz12TXh7j12hBe)_