### PR TITLE
The Dream list caps at 48 — every tool here was validating a truncated catalog

### DIFF
--- a/utils/comments/fitnessLoader.ts
+++ b/utils/comments/fitnessLoader.ts
@@ -21,6 +21,25 @@ export type LoadedInventory = Inventory & {
   dreamFacetIds: Map<number, number[]>
 }
 
+/**
+ * The Dream list endpoint, asked for all of them.
+ *
+ * `/api/dreams` defaults to a `take` of 48 and there are 75. Every tool in this
+ * lane fetched the bare path and therefore validated against a truncated
+ * catalog, which produced one real false positive: the connection contract
+ * refused four assignments with "Dream #50 does not exist in production" when
+ * Dream 50 was simply row 49.
+ *
+ * That failure was fail-closed and got caught. The dangerous one was silent:
+ * verifyDreamLocations checks new slugs and titles against this list, so a new
+ * location colliding with an existing Dream past row 48 would have been created
+ * as a duplicate world. (Checked after the fact -- none of the sixteen
+ * collided.)
+ *
+ * Characters, Scenarios and Bots return everything by default; only Dreams cap.
+ */
+const ALL_DREAMS = '/api/dreams?take=1000'
+
 export function createFetcher(baseUrl: string) {
   return async function get<T>(path: string): Promise<T> {
     for (let attempt = 0; attempt < 4; attempt += 1) {
@@ -80,7 +99,7 @@ export async function loadFitnessInventory(
 
   const [characters, dreamList, scenarios] = await Promise.all([
     get<CharacterRow[]>('/api/characters'),
-    get<DreamRow[]>('/api/dreams'),
+    get<DreamRow[]>(ALL_DREAMS),
     get<ScenarioRow[]>('/api/scenarios'),
   ])
 

--- a/utils/scripts/verifyConnectionAssignments.ts
+++ b/utils/scripts/verifyConnectionAssignments.ts
@@ -22,6 +22,25 @@ import {
 } from '@/utils/comments/connectionAssignments'
 import { createFetcher } from '@/utils/comments/fitnessLoader'
 
+/**
+ * The Dream list endpoint, asked for all of them.
+ *
+ * `/api/dreams` defaults to a `take` of 48 and there are 75. Every tool in this
+ * lane fetched the bare path and therefore validated against a truncated
+ * catalog, which produced one real false positive: the connection contract
+ * refused four assignments with "Dream #50 does not exist in production" when
+ * Dream 50 was simply row 49.
+ *
+ * That failure was fail-closed and got caught. The dangerous one was silent:
+ * verifyDreamLocations checks new slugs and titles against this list, so a new
+ * location colliding with an existing Dream past row 48 would have been created
+ * as a duplicate world. (Checked after the fact -- none of the sixteen
+ * collided.)
+ *
+ * Characters, Scenarios and Bots return everything by default; only Dreams cap.
+ */
+const ALL_DREAMS = '/api/dreams?take=1000'
+
 function arg(name: string, fallback = ''): string {
   const hit = process.argv.find((value) => value.startsWith(`--${name}=`))
   return hit ? hit.slice(name.length + 3) : fallback
@@ -58,7 +77,7 @@ async function main() {
       '/api/characters',
     ),
     get<Array<{ id: number; title: string; isPublic?: boolean; isActive?: boolean }>>(
-      '/api/dreams',
+      ALL_DREAMS,
     ),
     get<
       Array<{

--- a/utils/scripts/verifyDreamLocations.ts
+++ b/utils/scripts/verifyDreamLocations.ts
@@ -26,6 +26,25 @@ import {
 } from '@/utils/comments/dreamLocations'
 import { createFetcher } from '@/utils/comments/fitnessLoader'
 
+/**
+ * The Dream list endpoint, asked for all of them.
+ *
+ * `/api/dreams` defaults to a `take` of 48 and there are 75. Every tool in this
+ * lane fetched the bare path and therefore validated against a truncated
+ * catalog, which produced one real false positive: the connection contract
+ * refused four assignments with "Dream #50 does not exist in production" when
+ * Dream 50 was simply row 49.
+ *
+ * That failure was fail-closed and got caught. The dangerous one was silent:
+ * verifyDreamLocations checks new slugs and titles against this list, so a new
+ * location colliding with an existing Dream past row 48 would have been created
+ * as a duplicate world. (Checked after the fact -- none of the sixteen
+ * collided.)
+ *
+ * Characters, Scenarios and Bots return everything by default; only Dreams cap.
+ */
+const ALL_DREAMS = '/api/dreams?take=1000'
+
 function arg(name: string, fallback = ''): string {
   const hit = process.argv.find((value) => value.startsWith(`--${name}=`))
   return hit ? hit.slice(name.length + 3) : fallback
@@ -76,7 +95,7 @@ async function main() {
 
   const get = createFetcher(baseUrl)
   const [dreams, scenarios] = await Promise.all([
-    get<Array<{ id: number; title: string; slug?: string | null }>>('/api/dreams'),
+    get<Array<{ id: number; title: string; slug?: string | null }>>(ALL_DREAMS),
     get<
       Array<{
         id: number
@@ -121,9 +140,11 @@ async function main() {
       if (!slugLooksValid(location.slug || '')) {
         fail(`${at}: slug is not kebab-case.`)
       }
-      if (liveSlugs.has(String(location.slug).toLowerCase())) {
-        fail(`${at}: slug already exists in production.`)
-      }
+      // A slug that already exists is this location, already created. The
+      // publisher adopts by slug rather than recreating, so a re-run is safe --
+      // and a contract that refuses what the publisher handles correctly just
+      // makes the lane un-rerunnable after its first success.
+      const alreadyCreated = liveSlugs.has(String(location.slug).toLowerCase())
       const previousSlug = seenSlugs.get(location.slug)
       if (previousSlug) fail(`${at}: slug duplicates ${previousSlug}.`)
       else seenSlugs.set(location.slug, at)
@@ -131,7 +152,7 @@ async function main() {
       const titleKey = String(location.title || '').trim().toLowerCase()
       if (!titleKey) fail(`${at}: no title.`)
       const clash = liveTitles.get(titleKey)
-      if (clash) {
+      if (clash && !alreadyCreated) {
         fail(`${at}: title "${location.title}" is already Dream #${clash.id}.`)
       }
 
@@ -174,9 +195,13 @@ async function main() {
         if (scenario.isPublic === false || scenario.isActive === false) {
           fail(`${at}: Scenario #${scenarioId} is not public/active.`)
         }
-        if ((scenario.Dreams || []).length) {
+        // Belonging to THIS location is the lane having already run. Belonging
+        // to a different one is the double-homing this check exists to stop.
+        const homes = scenario.Dreams || []
+        const elsewhere = homes.filter((d) => d.title !== location.title)
+        if (elsewhere.length) {
           fail(
-            `${at}: Scenario #${scenarioId} "${scenario.title}" already belongs to ${(scenario.Dreams || []).map((d) => d.title).join(', ')}.`,
+            `${at}: Scenario #${scenarioId} "${scenario.title}" already belongs to ${elsewhere.map((d) => d.title).join(', ')}.`,
           )
         }
         const pending = pendingDreams.get(scenarioId)


### PR DESCRIPTION
`/api/dreams` defaults to a `take` of **48**, and there are **75**. Characters, Scenarios and Bots return everything by default — only Dreams cap. Every tool in this lane fetched the bare path.

That produced one visible failure and one invisible risk.

## Visible — and I misread it

The connection contract refused four assignments with *"Dream #50 does not exist in production."* Dream 50 exists and is public. It was **row 49**.

I diagnosed that as a Dream unpublished mid-flight and re-homed Graveyard Shift on a false premise. The re-home stands — Blackrock Shore genuinely is the better home, and it is already live — but the reasoning in #1853 was wrong and this corrects the record.

## Invisible, and the one that mattered

`verifyDreamLocations` checks new slugs and titles against **this same capped list**. A new location colliding with an existing Dream past row 48 would have been created as a **duplicate world** instead of refused.

Checked after the fact: none of the sixteen collided. But that was luck, not the contract.

## Also: the contract now agrees with its own publisher

`publishDreamLocations` adopts an existing slug rather than recreating it, so a re-run is safe. The contract refused one outright — which made the lane **un-rerunnable the moment it succeeded**. It now treats *"this scenario already belongs to THIS location"* as satisfied, while still refusing a scenario homed somewhere else, which is the double-homing the check exists for.

## All four lanes are live

| | before | after |
|---|---|---|
| Comments | 961 | **1,753** (+792) |
| Scenarios with a cast | 0 of 116 | **115 of 117** (103 with 2+) |
| Scenarios with a home | 25 | **116 of 117** |
| Dreams | 59 | **75** (+16 new locations) |
| Nexus thoroughfares | — | Serendipity 1 → 5 comments |


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jx9MRHdNN2ye5mcLPXgx5A)_