### PR TITLE
Brainstorm: ground Character-aware sessions in real canonical traits

### DIFF
--- a/.github/workflows/brainstorm-generation-contract.yml
+++ b/.github/workflows/brainstorm-generation-contract.yml
@@ -11,6 +11,7 @@ on:
       - 'server/api/suggest.post.ts'
       - 'types/brainstorm.ts'
       - 'utils/scripts/verifyBrainstormGeneration.ts'
+      - 'utils/scripts/verifyBrainstormSourceContext.ts'
   pull_request:
     branches: [main]
     paths:
@@ -21,6 +22,7 @@ on:
       - 'server/api/suggest.post.ts'
       - 'types/brainstorm.ts'
       - 'utils/scripts/verifyBrainstormGeneration.ts'
+      - 'utils/scripts/verifyBrainstormSourceContext.ts'
   workflow_dispatch:
 
 permissions:
@@ -51,3 +53,6 @@ jobs:
 
       - name: Verify Brainstorm generation contract
         run: npx tsx utils/scripts/verifyBrainstormGeneration.ts
+
+      - name: Verify Brainstorm source context contract
+        run: npx tsx utils/scripts/verifyBrainstormSourceContext.ts

--- a/.github/workflows/brainstorm-object-entry-links-contract.yml
+++ b/.github/workflows/brainstorm-object-entry-links-contract.yml
@@ -1,0 +1,43 @@
+name: Brainstorm Object-Entry Links Contract
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/brainstorm-object-entry-links-contract.yml'
+      - 'components/brainstorm/**'
+      - 'components/characters/character-manager.vue'
+      - 'utils/scripts/verifyBrainstormObjectEntryLinks.mjs'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/brainstorm-object-entry-links-contract.yml'
+      - 'components/brainstorm/**'
+      - 'components/characters/character-manager.vue'
+      - 'utils/scripts/verifyBrainstormObjectEntryLinks.mjs'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: brainstorm-object-entry-links-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: Character -> Brainstorm object-entry contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify Brainstorm object-entry links
+        run: node utils/scripts/verifyBrainstormObjectEntryLinks.mjs

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -713,6 +713,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import {
   BRAINSTORM_MAX_RESULTS,
@@ -811,6 +812,8 @@ const starterPremises = [
   },
 ] as const
 
+const route = useRoute()
+const router = useRouter()
 const store = useBrainstormStore()
 const {
   premise,
@@ -998,8 +1001,54 @@ const persistenceErrorHeading = computed(() => {
   return 'Saved work hit a snag'
 })
 
+/*
+ * ARRIVING WITH A SOURCE ALREADY CHOSEN (brainstorm/t-013).
+ *
+ * Mirrors storybook-page.vue's seedFromQuery(): a source object elsewhere in
+ * the app (today, a Character's "Brainstorm variations" button) can launch
+ * straight into a grounded session instead of making the user find and pick
+ * it again in the "Ground it in a Kind Robots object" panel. Generic over
+ * modelType -- any adapter registered in brainstormSourceAdapters.ts works
+ * here, not just Character, so a future Dream/Scenario/Reward entry point
+ * (brainstorm/t-014, t-019) needs no change to this function.
+ *
+ * Seeds on top of the restored session (called after initializeSession), and
+ * clears the consumed query keys immediately so a reload/bookmark/share
+ * doesn't silently re-seed after the user has moved the session on.
+ */
+function seedFromQuery(): void {
+  const single = (value: unknown): string | null => {
+    const raw = Array.isArray(value) ? value[0] : value
+    return typeof raw === 'string' && raw ? raw : null
+  }
+
+  const modelType = single(route.query.source)
+  const rawId = single(route.query.sourceId)
+  const id = rawId ? Number(rawId) : NaN
+  const intent = single(route.query.intent)
+
+  if (modelType && Number.isInteger(id) && id > 0) {
+    store.setSource({ modelType, id, ...(intent ? { intent } : {}) })
+  }
+
+  // Prefill the premise from intent only when the composer is still empty --
+  // never clobber a premise the user (or the restored session) already has.
+  if (intent && !premise.value.trim()) {
+    store.setPremise(intent)
+  }
+
+  const consumed = ['source', 'sourceId', 'intent']
+  if (!consumed.some((key) => route.query[key])) return
+
+  const query = Object.fromEntries(
+    Object.entries(route.query).filter(([key]) => !consumed.includes(key)),
+  )
+  void router.replace({ query })
+}
+
 onMounted(() => {
   store.initializeSession()
+  seedFromQuery()
 })
 
 function returnTypeSelected(id: BrainstormReturnTypeId): boolean {

--- a/components/characters/character-manager.vue
+++ b/components/characters/character-manager.vue
@@ -22,6 +22,15 @@
             <Icon name="kind-icon:book-open" class="size-4" />
             <span class="hidden sm:inline">Start a story with this</span>
           </button>
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm rounded-xl"
+            title="Brainstorm variations grounded in this Character"
+            @click="startBrainstormWithCharacter"
+          >
+            <Icon name="kind-icon:brain" class="size-4" />
+            <span class="hidden sm:inline">Brainstorm variations</span>
+          </button>
         </div>
         <character-interact class="h-full min-h-0 flex-1 overflow-hidden" />
       </div>
@@ -94,6 +103,19 @@ function startStoryWithCharacter(): void {
   const slug = characterStore.selectedCharacter?.slug
   if (!slug) return
   void navigateTo({ path: '/storybook', query: { character: slug } })
+}
+
+function startBrainstormWithCharacter(): void {
+  const character = characterStore.selectedCharacter
+  if (!character?.id) return
+  void navigateTo({
+    path: '/brainstorm',
+    query: {
+      source: 'character',
+      sourceId: String(character.id),
+      intent: `Generate art-prompt, situation, and dialogue-hook variations for ${character.name || 'this Character'} that preserve their canonical traits.`,
+    },
+  })
 }
 
 async function refreshManagerData() {

--- a/server/api/brainstorm/generate.post.ts
+++ b/server/api/brainstorm/generate.post.ts
@@ -37,6 +37,7 @@ import type {
 } from '../../utils/suggest/suggestTypes'
 import { parseBrainstormProviderOutput } from '../../utils/brainstorm/brainstormParser'
 import { buildBrainstormPrompts } from '../../utils/brainstorm/brainstormPrompt'
+import { resolveBrainstormSourceContext } from '../../utils/brainstorm/brainstormSourceContext'
 import {
   brainstormProviderApiKey,
   callBrainstormProvider,
@@ -325,7 +326,14 @@ export default defineEventHandler(async (event) => {
     })
 
     const config = useRuntimeConfig()
-    const { systemPrompt, userPrompt } = buildBrainstormPrompts(request)
+    const sourceContext = await resolveBrainstormSourceContext(
+      request.source,
+      viewer,
+    )
+    const { systemPrompt, userPrompt } = buildBrainstormPrompts(
+      request,
+      sourceContext,
+    )
 
     console.log('[brainstorm:generate]', {
       provider,
@@ -335,6 +343,7 @@ export default defineEventHandler(async (event) => {
       mode: request.mode,
       batchShape: request.batchShape,
       returnTypes: request.returnTypes,
+      grounded: Boolean(sourceContext),
       replacement: Boolean(request.replaceCandidateId),
       branch: Boolean(request.parentCandidateId),
     })

--- a/server/utils/brainstorm/brainstormPrompt.ts
+++ b/server/utils/brainstorm/brainstormPrompt.ts
@@ -120,6 +120,7 @@ function assortmentInstructions(
 
 export function buildBrainstormPrompts(
   request: BrainstormGenerateRequest,
+  sourceContext?: string | null,
 ): BrainstormPrompts {
   const systemPrompt = [
     'You are Brainstorm, a creative divergence engine for humans.',
@@ -155,6 +156,14 @@ export function buildBrainstormPrompts(
     `Premise: ${request.premise.trim()}`,
     `Generate exactly ${request.count} distinct candidate${request.count === 1 ? '' : 's'}.`,
   ]
+
+  if (sourceContext?.trim()) {
+    lines.push(
+      '',
+      'Grounded in this Kind Robots object. Preserve these canonical traits -- do not contradict them, rename the subject, or drift it into a generic archetype:',
+      sourceContext.trim(),
+    )
+  }
 
   if (request.constraints?.trim()) {
     lines.push(`Constraints: ${request.constraints.trim()}`)

--- a/server/utils/brainstorm/brainstormSourceContext.ts
+++ b/server/utils/brainstorm/brainstormSourceContext.ts
@@ -1,0 +1,79 @@
+// /server/utils/brainstorm/brainstormSourceContext.ts
+//
+// conductor brainstorm/t-013: Character-aware brainstorming.
+//
+// BrainstormSourceRef (types/brainstorm.ts) only ever carried
+// `{ modelType, id?, slug?, intent? }` through the request/session, and
+// buildBrainstormPrompts never read it -- a Character-grounded session
+// generated exactly the same premise-only ideas as a freeform one (the
+// picker just showed what you'd picked). This resolves a ref into a compact,
+// privacy-checked trait summary the prompt can actually use.
+//
+// Only Character is wired today. Dream and further entity types are
+// brainstorm/t-014's scope ("Ship Dream-aware brainstorming and expand
+// adapter coverage") -- add a resolver to SOURCE_CONTEXT_RESOLVERS below and
+// resolveBrainstormSourceContext picks it up with no other change needed,
+// same "just another registry entry" shape as
+// stores/helpers/brainstormSourceAdapters.ts.
+//
+// The pure trait-formatting logic lives in brainstormSourceContextKit.ts (no
+// Prisma/canView imports, unit-testable with plain tsx) and is re-exported
+// here alongside the fetch+authorize half, mirroring the
+// brainstormSourceAdapterKit.ts / brainstormSourceAdapters.ts split.
+import prisma from '../prisma'
+import { canView } from '../contentAccess'
+import type { AuthUser } from '../authUser'
+import type { BrainstormSourceRef } from '../../../types/brainstorm'
+import { formatCharacterContext } from './brainstormSourceContextKit'
+
+async function characterContext(
+  id: number,
+  viewer: AuthUser | null,
+): Promise<string | null> {
+  const character = await prisma.character.findUnique({ where: { id } })
+  if (!character) return null
+  // Same authorization the character.get route itself applies -- a ref the
+  // requesting user cannot view must never leak that Character's traits into
+  // a generation prompt just because they happened to know its id.
+  if (!(await canView(character, null, viewer))) return null
+
+  return formatCharacterContext(character)
+}
+
+type BrainstormSourceContextResolver = (
+  id: number,
+  viewer: AuthUser | null,
+) => Promise<string | null>
+
+const SOURCE_CONTEXT_RESOLVERS: Record<
+  string,
+  BrainstormSourceContextResolver
+> = {
+  character: characterContext,
+}
+
+/**
+ * Resolve a BrainstormSourceRef into prompt-ready context text, or null when
+ * there's nothing to ground (no source, unregistered modelType, not found,
+ * or not viewable). Grounding is an enhancement, not a hard requirement -- a
+ * lookup failure degrades to an ungrounded but still-successful generation,
+ * never a failed request.
+ */
+export async function resolveBrainstormSourceContext(
+  source: BrainstormSourceRef | null | undefined,
+  viewer: AuthUser | null,
+): Promise<string | null> {
+  if (!source?.modelType || !source.id) return null
+  const resolver = SOURCE_CONTEXT_RESOLVERS[source.modelType.toLowerCase()]
+  if (!resolver) return null
+
+  try {
+    return await resolver(source.id, viewer)
+  } catch (error) {
+    console.warn(
+      '[brainstorm:sourceContext] failed to resolve source context',
+      error,
+    )
+    return null
+  }
+}

--- a/server/utils/brainstorm/brainstormSourceContextKit.ts
+++ b/server/utils/brainstorm/brainstormSourceContextKit.ts
@@ -1,0 +1,69 @@
+// /server/utils/brainstorm/brainstormSourceContextKit.ts
+//
+// The pure half of brainstormSourceContext.ts's Character-grounding logic --
+// no Prisma/canView/Nuxt alias imports, so it can be exercised directly by
+// utils/scripts/verifyBrainstormSourceContext.ts with plain tsx, the same
+// split brainstormSourceAdapterKit.ts uses for the client-side adapter
+// registry (no Pinia imports there either, for the identical reason).
+
+/** The Character fields formatCharacterContext actually reads. */
+export type CharacterContextRow = {
+  name: string
+  honorific?: string | null
+  title?: string | null
+  role?: string | null
+  class?: string | null
+  species?: string | null
+  gender?: string | null
+  alignment?: string | null
+  genre?: string | null
+  personality?: string | null
+  voice?: string | null
+  drive?: string | null
+  quirks?: string | null
+  backstory?: string | null
+}
+
+const MAX_CONTEXT_LENGTH = 2_000
+
+function joinFacts(...parts: Array<string | null | undefined | false>): string {
+  return parts
+    .filter((part): part is string => Boolean(part && part.trim()))
+    .map((part) => part.trim())
+    .join(' | ')
+}
+
+/**
+ * Compose a Character row into a compact trait summary for the prompt.
+ * Bounded to MAX_CONTEXT_LENGTH so one verbose Character cannot blow out the
+ * prompt/cost budget.
+ */
+export function formatCharacterContext(character: CharacterContextRow): string {
+  const identity = joinFacts(
+    character.honorific,
+    character.title,
+    character.role,
+  )
+  const traits = joinFacts(
+    character.class && `class: ${character.class}`,
+    character.species && `species: ${character.species}`,
+    character.gender && `gender: ${character.gender}`,
+    character.alignment && `alignment: ${character.alignment}`,
+    character.genre && `genre: ${character.genre}`,
+  )
+  const voice = joinFacts(
+    character.personality && `personality: ${character.personality}`,
+    character.voice && `voice: ${character.voice}`,
+    character.drive && `drive: ${character.drive}`,
+    character.quirks && `quirks: ${character.quirks}`,
+  )
+
+  const lines = [
+    `Character: ${character.name}${identity ? ` (${identity})` : ''}.`,
+    traits && `Traits: ${traits}.`,
+    voice && `Voice: ${voice}.`,
+    character.backstory && `Backstory: ${character.backstory}`,
+  ].filter((line): line is string => Boolean(line))
+
+  return lines.join('\n').slice(0, MAX_CONTEXT_LENGTH)
+}

--- a/utils/scripts/verifyBrainstormGeneration.ts
+++ b/utils/scripts/verifyBrainstormGeneration.ts
@@ -258,6 +258,41 @@ assert.match(replacement.userPrompt, /Replacement task:/)
 assert.match(replacement.userPrompt, /Dark humor ×1/)
 assert.match(replacement.userPrompt, /Too familiar\. Find a stranger mechanism\./)
 
+const ungrounded = buildBrainstormPrompts({
+  premise: 'Invent art-prompt variations for this character',
+  count: 4,
+  mode: 'freeform',
+  source: { modelType: 'character', id: 42 },
+})
+assert.doesNotMatch(
+  ungrounded.userPrompt,
+  /Grounded in this Kind Robots object/,
+  'a source ref alone (no resolved context) must not add a grounding block',
+)
+
+const grounded = buildBrainstormPrompts(
+  {
+    premise: 'Invent art-prompt variations for this character',
+    count: 4,
+    mode: 'freeform',
+    source: { modelType: 'character', id: 42 },
+  },
+  'Character: Ami (honorific: butterfly guide). Traits: species: butterfly-person. Voice: personality: cheerful and curious.',
+)
+assert.match(grounded.userPrompt, /Grounded in this Kind Robots object/)
+assert.match(grounded.userPrompt, /Ami \(honorific: butterfly guide\)/)
+assert.match(grounded.userPrompt, /do not contradict them, rename the subject/)
+
+const groundedBlank = buildBrainstormPrompts(
+  { premise: 'Invent something', count: 2, source: null },
+  '   ',
+)
+assert.doesNotMatch(
+  groundedBlank.userPrompt,
+  /Grounded in this Kind Robots object/,
+  'blank/whitespace-only context must not add an empty grounding block',
+)
+
 const branch = buildBrainstormPrompts({
   premise: 'Invent stage deaths for a cartoonish improv game',
   count: 1,
@@ -331,6 +366,16 @@ assert.match(endpoint, /normalizedReturnTypes\(body\.returnTypes, batchShape, co
 assert.match(endpoint, /manaGate\(event/)
 assert.match(endpoint, /parseBrainstormProviderOutput\(raw, request\.count, request\)/)
 assert.match(endpoint, /errorHandler\(error\)/)
+assert.match(
+  endpoint,
+  /resolveBrainstormSourceContext\(\s*\n?\s*request\.source,\s*\n?\s*viewer,?\s*\n?\s*\)/,
+  'the source ref must be resolved server-side (with the authenticated viewer, for the canView check) before prompts are built',
+)
+assert.match(
+  endpoint,
+  /buildBrainstormPrompts\(\s*\n?\s*request,\s*\n?\s*sourceContext,?\s*\n?\s*\)/,
+  'the resolved source context must actually reach buildBrainstormPrompts',
+)
 assert.doesNotMatch(endpoint, /body\.server\?\.baseUrl/)
 assert.doesNotMatch(endpoint, /body\.server\?\.endpointPath/)
 

--- a/utils/scripts/verifyBrainstormObjectEntryLinks.mjs
+++ b/utils/scripts/verifyBrainstormObjectEntryLinks.mjs
@@ -1,0 +1,56 @@
+// /utils/scripts/verifyBrainstormObjectEntryLinks.mjs
+//
+// conductor brainstorm/t-013: Character-aware brainstorming and a reusable
+// deep-link/query-state contract. Mirrors
+// verifyStorybookObjectEntryLinks.mjs's shape and rationale: nothing
+// directly asserted that a Character surface can actually launch a
+// Brainstorm session grounded in that Character, only that the pieces
+// existed separately. This contract closes that gap for Brainstorm the same
+// way PR #1706's kaizen closed it for Storybook.
+//
+// Deliberately narrow: it checks that the CTA's click handler exists and
+// performs the navigation with the object's id/intent threaded through the
+// right query keys, and that Brainstorm's own seedFromQuery() still consumes
+// those keys. It does NOT assert button classes, icon names, or layout -- a
+// restyle of the CTA must not fail this check.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+function source(path) {
+  return readFileSync(resolve(process.cwd(), path), 'utf8')
+}
+
+function includesAll(path, values) {
+  const contents = source(path)
+  for (const value of values) {
+    assert.ok(contents.includes(value), `${path} must include ${value}`)
+  }
+}
+
+const characterManagerPath = 'components/characters/character-manager.vue'
+const brainstormManagerPath = 'components/brainstorm/brainstorm-manager.vue'
+
+includesAll(characterManagerPath, [
+  'startBrainstormWithCharacter',
+  '@click="startBrainstormWithCharacter"',
+  "path: '/brainstorm'",
+  "source: 'character'",
+  'sourceId: String(character.id)',
+])
+
+includesAll(brainstormManagerPath, [
+  'function seedFromQuery',
+  'seedFromQuery()',
+  'route.query.source',
+  'route.query.sourceId',
+  'route.query.intent',
+  'store.setSource(',
+  'store.setPremise(intent)',
+])
+
+console.log(
+  'Brainstorm object-entry links contract passed: Character can launch a ' +
+    'Brainstorm session grounded in itself, and Brainstorm still seeds its ' +
+    'source and premise from the source/sourceId/intent query keys.',
+)

--- a/utils/scripts/verifyBrainstormSourceContext.ts
+++ b/utils/scripts/verifyBrainstormSourceContext.ts
@@ -1,0 +1,90 @@
+// /utils/scripts/verifyBrainstormSourceContext.ts
+//
+// conductor brainstorm/t-013: Character-aware brainstorming.
+//
+// formatCharacterContext lives in brainstormSourceContextKit.ts, which is
+// deliberately Prisma/Nuxt-alias-free, so it can be exercised directly here
+// without a live database -- resolving the same "this sandbox has no
+// reachable DATABASE_URL" constraint documented repeatedly across this
+// repo's other verify scripts (verifyBrainstormSourceAdapters.test.ts's own
+// header comment). The fetch+canView half of brainstormSourceContext.ts
+// (resolveBrainstormSourceContext) needs a live Nuxt/Prisma runtime and is
+// exercised only via the fragile source-string checks below, same pattern
+// as the adapter test.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { formatCharacterContext } from '../../server/utils/brainstorm/brainstormSourceContextKit'
+
+const full = formatCharacterContext({
+  name: 'Ami',
+  honorific: 'butterfly guide',
+  title: null,
+  role: null,
+  class: 'Wayfinder',
+  species: 'butterfly-person',
+  gender: null,
+  alignment: null,
+  genre: null,
+  personality: 'cheerful and curious',
+  voice: 'speaks in short, warm sentences',
+  drive: 'wants everyone to feel welcome',
+  quirks: 'hums when thinking',
+  backstory: 'Found the Nexus as a lost seed and never left.',
+})
+assert.match(full, /^Character: Ami \(butterfly guide\)\./)
+assert.match(full, /Traits: class: Wayfinder \| species: butterfly-person\./)
+assert.match(
+  full,
+  /Voice: personality: cheerful and curious \| voice: speaks in short, warm sentences \| drive: wants everyone to feel welcome \| quirks: hums when thinking\./,
+)
+assert.match(full, /Backstory: Found the Nexus as a lost seed and never left\./)
+
+const sparse = formatCharacterContext({ name: 'Squiddy Coltrane' })
+assert.equal(
+  sparse,
+  'Character: Squiddy Coltrane.',
+  'a Character with no optional fields must still produce a usable one-line summary, no empty "Traits:"/"Voice:" labels',
+)
+assert.doesNotMatch(sparse, /Traits:|Voice:|Backstory:/)
+
+const longBackstory = formatCharacterContext({
+  name: 'Overlong',
+  backstory: 'x'.repeat(5_000),
+})
+assert.ok(
+  longBackstory.length <= 2_000,
+  'the composed context must stay bounded so one Character cannot blow out the prompt budget',
+)
+
+const partial = formatCharacterContext({
+  name: 'Old Komodo',
+  honorific: null,
+  title: 'Keeper of the Slow Fire',
+  species: 'komodo dragon',
+})
+assert.match(partial, /^Character: Old Komodo \(Keeper of the Slow Fire\)\./)
+assert.match(partial, /Traits: species: komodo dragon\./)
+assert.doesNotMatch(partial, /Voice:|Backstory:/)
+
+// The fetch+canView dispatch half needs a live database -- assert its
+// contract directly against the source, same pattern
+// verifyBrainstormSourceAdapters.test.ts uses for the client-side registry.
+const contextSource = readFileSync(
+  resolve(process.cwd(), 'server/utils/brainstorm/brainstormSourceContext.ts'),
+  'utf8',
+)
+assert.ok(
+  contextSource.includes('await canView(character, null, viewer)'),
+  'characterContext must revalidate view authorization on every resolve, not trust that the caller already checked it',
+)
+assert.ok(
+  contextSource.includes('character: characterContext'),
+  'the resolver registry must register a character entry',
+)
+assert.ok(
+  /catch \(error\) \{[\s\S]*?return null/.test(contextSource),
+  'resolveBrainstormSourceContext must degrade to null on any resolver failure, never throw and fail the whole generation request',
+)
+
+console.log('Brainstorm source context contract passed.')


### PR DESCRIPTION
### Task
conductor brainstorm/t-013: Ship Character-aware brainstorming and art-prompt variations (kind: software)

### What changed / what I produced
A `BrainstormSourceRef` could already be picked in the "Ground it in a Kind Robots object" UI and persisted with a session (brainstorm/t-012), but `buildBrainstormPrompts` never actually read it — a Character-grounded session generated exactly the same premise-only ideas as a freeform one. This closes that gap and adds the reusable deep-link contract the task calls for:

- `server/utils/brainstorm/brainstormSourceContext(Kit).ts` (new): resolves a source ref into a compact, privacy-checked (`canView`) trait summary server-side. Split into a pure kit (trait formatting, unit-testable with plain `tsx`, no Prisma/Nuxt-alias imports) and the fetch+authorize half — mirrors `brainstormSourceAdapterKit.ts`/`brainstormSourceAdapters.ts`'s existing split. Only Character is wired; Dream is brainstorm/t-014's explicit scope and slots into the same one-entry resolver registry with no other change needed.
- `brainstormPrompt.ts` / `generate.post.ts`: `buildBrainstormPrompts` now accepts the resolved context and folds it into the user prompt as a "Grounded in this Kind Robots object" block. A resolve failure (not found, not viewable, DB hiccup) degrades to an ungrounded but still-successful generation — never a failed request.
- `brainstorm-manager.vue`: reusable deep-link/query-state contract (`source`/`sourceId`/`intent` query keys) so any surface can launch Brainstorm with the source pre-linked and the premise pre-filled, mirroring `storybook-page.vue`'s `seedFromQuery()` convention. Generic over `modelType`, not Character-specific — Dream/Scenario/Reward entry points can reuse it unchanged.
- `character-manager.vue`: first entry point using the contract above — a "Brainstorm variations" button next to the existing "Start a story with this".

### How I verified
- `npx tsx utils/scripts/verifyBrainstormGeneration.ts` — pass (added grounded/ungrounded/blank-context assertions + endpoint wiring regex checks)
- `npx tsx utils/scripts/verifyBrainstormSourceContext.ts` — pass (new, pure `formatCharacterContext` unit tests + resolver-registry source checks)
- `node utils/scripts/verifyBrainstormObjectEntryLinks.mjs` — pass (new, mirrors `verifyStorybookObjectEntryLinks.mjs`)
- `node utils/scripts/verifyBrainstormWorkbench.mjs`, `npx tsx utils/scripts/verifyBrainstormSourceAdapters.test.ts`, `node utils/scripts/verifyStorybookObjectEntryLinks.mjs` — all still pass (no regression)
- `eslint` clean on all touched/new files
- `prettier --check` clean on all new files (the 4 touched pre-existing files carry prettier drift confirmed via `git stash` to predate this change)
- `DATABASE_URL=... npx vue-tsc --noEmit` — exit 0, repo-wide
- `git status --porcelain` shows exactly the 11 intended files

### Stakes
reversible

### Flags for Reviewer
- Scope is deliberately Character-only per t-013's own text ("Output is text only in this task"); Dream-aware grounding is t-014's task, not folded in here even though the resolver registry would make it trivial to add.
- "Art-prompt variations" is delivered via the existing `count`/`returnTypes`/`mode` machinery plus the new deep-link `intent` prefill (e.g. Character's button seeds an intent like "Generate art-prompt, situation, and dialogue-hook variations…") rather than inventing a new taxonomy of return-type lenses — the existing lenses (dark-humor, practical, left-field, etc.) already vary creative approach; grounding makes them actually respect the Character.

### Kaizen suggestion
`character-card.vue` (the grid/list card, distinct from `character-manager.vue`'s detail panel) has no "Brainstorm variations" entry point yet — only the manager's selected-character panel does. Worth adding there too once the pattern proves out, so users don't have to open a Character before brainstorming around it.

### Notes for reviewer
Companion conductor task: `brainstorm/t-013` in `silasfelinus/conductor`, claimed this session (`20260813T1800Z-sched-conductor-brainstorm-t013`) and will be closed to `done` after this PR merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzrPkNS3HxoN49htRZPfjA)_