### PR TITLE
fix(art-queue): let the priority endpoint reach below zero

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -46,6 +46,9 @@ jobs:
       - name: ArtJob sampler repair contract
         run: npm run test:artjob-sampler-repair
 
+      - name: ArtJob priority bounds contract
+        run: npm run test:artjob-priority-bounds
+
       - name: Comfy-only generation contract
         run: npm run test:comfy-only-generation
 

--- a/package.json
+++ b/package.json
@@ -224,7 +224,8 @@
     "dedupe:generated-art": "tsx utils/scripts/dedupeGeneratedArtImages.ts",
     "test:no-shadowed-content-routes": "tsx utils/scripts/verifyNoShadowedContentRoutes.ts",
     "flag:mature-resources": "tsx utils/scripts/flagMatureResources.ts",
-    "test:mature-terms": "tsx utils/scripts/flagMatureResources.ts --self-test"
+    "test:mature-terms": "tsx utils/scripts/flagMatureResources.ts --self-test",
+    "test:artjob-priority-bounds": "tsx utils/scripts/verifyArtJobPriorityBounds.ts"
   },
   "devDependencies": {
     "@nuxt/eslint": "^1.1.0",

--- a/server/api/art/queue/[id]/priority.post.ts
+++ b/server/api/art/queue/[id]/priority.post.ts
@@ -1,19 +1,23 @@
 // /server/api/art/queue/[id]/priority.post.ts
 //
 // Admin action: change the priority of a pending ArtJob. The relay already
-// claims runnable work by priority DESC, id ASC, so raising a job here moves it
-// ahead of normal-priority work without rewriting timestamps or duplicating it.
+// claims runnable work by priority DESC, id ASC, so setting a job here moves it
+// ahead of — or behind — other work without rewriting timestamps or duplicating
+// it. The accepted range and its rationale live in utils/artJobPriority.ts;
+// notably the floor is negative, because the bulk lanes queue below 0 and a
+// demotion has to be able to reach them.
 import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
 import prisma from '../../../../utils/prisma'
 import { errorHandler } from '../../../../utils/error'
 import { requireMachineUser } from '../../../../utils/authGuard'
+import {
+  describeArtJobPriorityChange,
+  parseArtJobPriority,
+} from '~/utils/artJobPriority'
 
 type PriorityBody = {
   priority?: number | null
 }
-
-const MIN_PRIORITY = 0
-const MAX_PRIORITY = 1000
 
 export default defineEventHandler(async (event) => {
   try {
@@ -32,19 +36,16 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 400, message: 'Invalid job id.' })
     }
 
-    const body = (await readBody(event).catch(() => null)) as PriorityBody | null
-    const priority = Number(body?.priority)
+    const body = (await readBody(event).catch(
+      () => null,
+    )) as PriorityBody | null
+    const parsed = parseArtJobPriority(body?.priority)
 
-    if (
-      !Number.isInteger(priority) ||
-      priority < MIN_PRIORITY ||
-      priority > MAX_PRIORITY
-    ) {
-      throw createError({
-        statusCode: 400,
-        message: `Priority must be an integer from ${MIN_PRIORITY} to ${MAX_PRIORITY}.`,
-      })
+    if (!parsed.ok) {
+      throw createError({ statusCode: 400, message: parsed.message })
     }
+
+    const priority = parsed.priority
 
     const job = await prisma.artJob.findUnique({ where: { id } })
 
@@ -66,10 +67,7 @@ export default defineEventHandler(async (event) => {
 
     return {
       success: true,
-      message:
-        priority > 0
-          ? `Job ${id} moved ahead with priority ${priority}.`
-          : `Job ${id} returned to normal priority.`,
+      message: describeArtJobPriorityChange(id, priority),
       data: { job: updated },
       statusCode: 200,
     }

--- a/stores/artJobPriorityStore.ts
+++ b/stores/artJobPriorityStore.ts
@@ -3,8 +3,13 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { performFetch } from '@/stores/utils'
 import { useArtJobStore, type ArtJobRecord } from '@/stores/artJobStore'
-
-const FRONT_OF_QUEUE_PRIORITY = 100
+// Shared with the endpoint that validates them (utils/artJobPriority.ts) so the
+// dashboard cannot offer a value the API rejects.
+import {
+  BACK_OF_QUEUE_PRIORITY,
+  FRONT_OF_QUEUE_PRIORITY,
+  NORMAL_QUEUE_PRIORITY,
+} from '@/utils/artJobPriority'
 
 export const useArtJobPriorityStore = defineStore('artJobPriorityStore', () => {
   const prioritizingJobIds = ref<number[]>([])
@@ -46,7 +51,13 @@ export const useArtJobPriorityStore = defineStore('artJobPriorityStore', () => {
   }
 
   function returnToNormal(id: number): Promise<boolean> {
-    return setPriority(id, 0)
+    return setPriority(id, NORMAL_QUEUE_PRIORITY)
+  }
+
+  // Below every bulk lane in use, so a demoted job loses to the existing
+  // backlog instead of landing in the middle of it.
+  function sendToBack(id: number): Promise<boolean> {
+    return setPriority(id, BACK_OF_QUEUE_PRIORITY)
   }
 
   return {
@@ -55,5 +66,6 @@ export const useArtJobPriorityStore = defineStore('artJobPriorityStore', () => {
     setPriority,
     moveToFront,
     returnToNormal,
+    sendToBack,
   }
 })

--- a/utils/artJobPriority.ts
+++ b/utils/artJobPriority.ts
@@ -1,0 +1,111 @@
+// /utils/artJobPriority.ts
+//
+// The accepted range for an ArtJob's `priority`, and the parse that guards the
+// admin priority endpoint.
+//
+// Why this range is not 0..1000. The relay claims work by `priority DESC, id
+// ASC`, so priority is the only lever that reorders the queue. Producers already
+// write negative priorities on purpose: the bulk lanes that enter through
+// /api/art/queue (the Facet catalog, daily-dream builds) sit at 0 or below, and
+// on 2026-08-13 the live PENDING backlog held 389 jobs at -15 and 34 at -20,
+// while /api/art/enqueue's interactive work defaults to 100. That is a working
+// design — bulk coverage should lose to a human waiting on a redo.
+//
+// The admin endpoint, however, clamped its input to a 0 floor. So every value
+// the bulk lanes actually use was unreachable through the one API that exists to
+// change priority: an operator could promote a job but could never put one back
+// behind the backlog, or demote a job that had jumped the queue. Asked on
+// 2026-08-13 to move two flux jobs (priority 0) behind 424 krea2 jobs (-15/-20),
+// there was no legal request that expressed it — the only API-reachable route
+// was raising all 424 of the others instead. The floor, not the queue, was the
+// problem.
+//
+// The range is symmetric so that "as far back as anything gets queued" is as
+// expressible as "front of the queue". It is deliberately wider than any lane in
+// use, so a new producer picking a sensible negative tier does not have to come
+// back and widen a constant.
+//
+// This module holds no database import on purpose. `priority.post.ts` pulls in
+// prisma, and prisma.ts throws at import time when DATABASE_URL is unset, so
+// anything living there is unreachable from the DB-free contract-tests workflow
+// that gates every PR — the same reason artJobQueueSettings.ts was split out of
+// artJobQueueCoverage.ts. See utils/scripts/verifyArtJobPriorityBounds.ts.
+//
+// It lives in root `utils/` rather than `server/utils/` because the dashboard
+// store needs the same constants at runtime, and the only existing client
+// imports from `server/` are type-only (erased at build). Root `utils/` is the
+// side-neutral home both can value-import — the same shape as
+// utils/artFacetPrompt.ts, which stores/artFacetDraftStore.ts imports.
+
+export const MIN_ART_JOB_PRIORITY = -1000
+export const MAX_ART_JOB_PRIORITY = 1000
+
+/** Front of the queue: outranks the interactive default (100). */
+export const FRONT_OF_QUEUE_PRIORITY = 100
+
+/** Normal tier — what `returnToNormal` restores a job to. */
+export const NORMAL_QUEUE_PRIORITY = 0
+
+/**
+ * Back of the queue: below every bulk lane in use (-15/-20 as of 2026-08-13),
+ * so a job sent here loses to the existing backlog rather than landing in the
+ * middle of it.
+ */
+export const BACK_OF_QUEUE_PRIORITY = -100
+
+export type ArtJobPriorityParse =
+  | { ok: true; priority: number }
+  | { ok: false; message: string }
+
+/**
+ * Validate a caller-supplied priority. Rejects non-integers and anything outside
+ * the accepted range, so the endpoint never writes a value the queue's ordering
+ * cannot express.
+ *
+ * Non-numeric input is rejected rather than coerced. The previous validation ran
+ * a bare `Number(body?.priority)`, and `Number(null)`, `Number('')` and
+ * `Number([])` are all 0 — so a missing or malformed body silently set priority
+ * 0 instead of failing. That was survivable while 0 was also the floor. Now that
+ * negative values are legal, "the body didn't parse" and "put this job at the
+ * normal tier" are genuinely different requests, and a malformed body that reads
+ * as a demotion is a queue reorder nobody asked for.
+ */
+export function parseArtJobPriority(value: unknown): ArtJobPriorityParse {
+  const rejected: ArtJobPriorityParse = {
+    ok: false,
+    message: `Priority must be an integer from ${MIN_ART_JOB_PRIORITY} to ${MAX_ART_JOB_PRIORITY}.`,
+  }
+
+  const numeric =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string' && value.trim() !== ''
+        ? Number(value)
+        : Number.NaN
+
+  const priority = numeric
+
+  if (!Number.isInteger(priority)) {
+    return rejected
+  }
+
+  if (priority < MIN_ART_JOB_PRIORITY || priority > MAX_ART_JOB_PRIORITY) {
+    return rejected
+  }
+
+  return { ok: true, priority }
+}
+
+/** Human-readable confirmation for a completed priority change. */
+export function describeArtJobPriorityChange(
+  id: number,
+  priority: number,
+): string {
+  if (priority > NORMAL_QUEUE_PRIORITY) {
+    return `Job ${id} moved ahead with priority ${priority}.`
+  }
+  if (priority < NORMAL_QUEUE_PRIORITY) {
+    return `Job ${id} moved back with priority ${priority}.`
+  }
+  return `Job ${id} returned to normal priority.`
+}

--- a/utils/scripts/verifyArtJobPriorityBounds.ts
+++ b/utils/scripts/verifyArtJobPriorityBounds.ts
@@ -1,0 +1,196 @@
+// Contract test for utils/artJobPriority.ts and the admin endpoint that is the
+// only API-reachable way to reorder the render queue.
+//
+// The bug this file exists for, in full: the relay claims work by `priority
+// DESC, id ASC`, and producers deliberately queue below zero — /api/art/queue's
+// bulk lanes (Facet catalog, daily-dream builds) sit at 0 or under, while
+// /api/art/enqueue's interactive work defaults to 100. On 2026-08-13 the live
+// PENDING backlog was 389 jobs at -15 and 34 at -20. But the admin priority
+// endpoint validated against `MIN_PRIORITY = 0`, so every value those lanes
+// actually use was rejected: an operator could promote a job and could never
+// demote one. Asked that day to move two flux jobs (priority 0) behind 424 krea2
+// jobs (-15/-20), no legal request expressed it — the only API-reachable route
+// was raising all 424 of the others instead.
+//
+// The floor is now negative and the endpoint delegates to the shared parse. The
+// checks below pin both halves: the range must still admit the tiers in real
+// use, and the endpoint must not drift back to a hand-rolled bound.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import {
+  BACK_OF_QUEUE_PRIORITY,
+  FRONT_OF_QUEUE_PRIORITY,
+  MAX_ART_JOB_PRIORITY,
+  MIN_ART_JOB_PRIORITY,
+  NORMAL_QUEUE_PRIORITY,
+  describeArtJobPriorityChange,
+  parseArtJobPriority,
+} from '../artJobPriority'
+
+const failures: string[] = []
+
+function check(name: string, run: () => void): void {
+  try {
+    run()
+  } catch (error) {
+    failures.push(
+      `${name}: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+}
+
+// --- The regression itself -------------------------------------------------
+
+check('negative priorities are accepted', () => {
+  for (const priority of [-1, -15, -20, -100, MIN_ART_JOB_PRIORITY]) {
+    const parsed = parseArtJobPriority(priority)
+    assert.deepEqual(
+      parsed,
+      { ok: true, priority },
+      `priority ${priority} must be accepted — bulk lanes queue below zero`,
+    )
+  }
+})
+
+check('the floor reaches past every bulk lane in use', () => {
+  // -15 and -20 were the live PENDING tiers on 2026-08-13; the back-of-queue
+  // constant has to sit below them or "send to back" lands mid-backlog.
+  assert.ok(
+    BACK_OF_QUEUE_PRIORITY < -20,
+    `BACK_OF_QUEUE_PRIORITY (${BACK_OF_QUEUE_PRIORITY}) must be below the -20 bulk lane`,
+  )
+  assert.ok(
+    MIN_ART_JOB_PRIORITY < BACK_OF_QUEUE_PRIORITY,
+    'the accepted floor must be reachable past the back-of-queue constant',
+  )
+})
+
+check('the range is symmetric and ordered', () => {
+  assert.equal(MIN_ART_JOB_PRIORITY, -MAX_ART_JOB_PRIORITY)
+  assert.ok(MIN_ART_JOB_PRIORITY < NORMAL_QUEUE_PRIORITY)
+  assert.ok(NORMAL_QUEUE_PRIORITY < FRONT_OF_QUEUE_PRIORITY)
+  assert.ok(FRONT_OF_QUEUE_PRIORITY <= MAX_ART_JOB_PRIORITY)
+})
+
+// --- Everything the old validation got right, still rejected ---------------
+
+check('out-of-range values are rejected', () => {
+  for (const priority of [
+    MIN_ART_JOB_PRIORITY - 1,
+    MAX_ART_JOB_PRIORITY + 1,
+    -100000,
+    100000,
+  ]) {
+    const parsed = parseArtJobPriority(priority)
+    assert.equal(parsed.ok, false, `priority ${priority} must be rejected`)
+  }
+})
+
+check('non-integers and junk are rejected', () => {
+  for (const value of [
+    1.5,
+    -1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    'front',
+    {},
+    true,
+  ]) {
+    const parsed = parseArtJobPriority(value)
+    assert.equal(
+      parsed.ok,
+      false,
+      `${JSON.stringify(value) ?? String(value)} must be rejected`,
+    )
+  }
+})
+
+check('a missing or malformed body is not coerced to 0', () => {
+  // `Number(null)`, `Number('')` and `Number([])` are all 0. The old bare
+  // `Number(body?.priority)` therefore turned an unparseable request into a
+  // silent write of priority 0 — a real demotion now that the floor is negative.
+  for (const value of [null, undefined, '', '   ', []]) {
+    const parsed = parseArtJobPriority(value)
+    assert.equal(
+      parsed.ok,
+      false,
+      `${JSON.stringify(value) ?? String(value)} must be rejected, not read as priority 0`,
+    )
+  }
+})
+
+check('numeric strings still parse, for tolerant clients', () => {
+  assert.deepEqual(parseArtJobPriority('-20'), { ok: true, priority: -20 })
+  assert.deepEqual(parseArtJobPriority('100'), { ok: true, priority: 100 })
+})
+
+check('the rejection message states the real range', () => {
+  const parsed = parseArtJobPriority('nope')
+  assert.equal(parsed.ok, false)
+  if (parsed.ok) return
+  assert.match(parsed.message, new RegExp(String(MIN_ART_JOB_PRIORITY)))
+  assert.match(parsed.message, new RegExp(String(MAX_ART_JOB_PRIORITY)))
+})
+
+// --- Confirmation copy distinguishes a demotion from a reset ----------------
+
+check('a demotion does not report as "returned to normal"', () => {
+  assert.match(describeArtJobPriorityChange(7, -20), /moved back/)
+  assert.match(
+    describeArtJobPriorityChange(7, FRONT_OF_QUEUE_PRIORITY),
+    /ahead/,
+  )
+  assert.match(
+    describeArtJobPriorityChange(7, NORMAL_QUEUE_PRIORITY),
+    /normal priority/,
+  )
+})
+
+// --- The endpoint must keep delegating -------------------------------------
+
+const ENDPOINT = 'server/api/art/queue/[id]/priority.post.ts'
+
+check('the endpoint delegates to the shared parse', () => {
+  const source = readFileSync(ENDPOINT, 'utf8')
+
+  assert.match(
+    source,
+    /parseArtJobPriority/,
+    `${ENDPOINT} must validate through parseArtJobPriority`,
+  )
+  assert.doesNotMatch(
+    source,
+    /const\s+MIN_PRIORITY\s*=/,
+    `${ENDPOINT} must not re-declare its own floor — that is the bug this test pins`,
+  )
+  assert.doesNotMatch(
+    source,
+    /const\s+MAX_PRIORITY\s*=/,
+    `${ENDPOINT} must not re-declare its own ceiling`,
+  )
+})
+
+check('the priority store offers a demotion path', () => {
+  const source = readFileSync('stores/artJobPriorityStore.ts', 'utf8')
+
+  assert.match(
+    source,
+    /sendToBack/,
+    'the dashboard store must expose a demotion action now that the API allows one',
+  )
+  assert.doesNotMatch(
+    source,
+    /const\s+FRONT_OF_QUEUE_PRIORITY\s*=/,
+    'the store must import the shared constants, not fork its own copy',
+  )
+})
+
+// --- Report ----------------------------------------------------------------
+
+if (failures.length) {
+  console.error(`ArtJob priority bounds contract FAILED (${failures.length}):`)
+  for (const failure of failures) console.error(`  - ${failure}`)
+  process.exit(1)
+}
+
+console.log('ArtJob priority bounds contract passed.')


### PR DESCRIPTION
## What

`POST /api/art/queue/[id]/priority` validated against `MIN_PRIORITY = 0`. The floor is now `-1000`, the bounds and their parse move to a shared `utils/artJobPriority.ts`, and the dashboard store gains a matching `sendToBack()`.

## Why

The relay claims work by `priority DESC, id ASC`, so priority is the only lever that reorders the queue. Producers already write negative priorities **on purpose** — `/api/art/queue`'s bulk lanes (Facet catalog, daily-dream builds) sit at 0 or below, while `/api/art/enqueue`'s interactive work defaults to 100. That's a working design: bulk coverage should lose to a human waiting on a redo.

But every value those bulk lanes actually use was unreachable through the one API that exists to change priority. An operator could promote a job and could never demote one, or put a promoted job back behind the backlog.

This surfaced concretely on 2026-08-13. The live PENDING backlog held **389 jobs at -15 and 34 at -20**. Asked to move two flux jobs (priority 0) behind 424 krea2 jobs, there was no legal request that expressed it — the only API-reachable route was raising all 424 of the others instead. The floor, not the queue, was the problem.

## Notes for review

- **Range is symmetric** (`-1000..1000`) so "as far back as anything gets queued" is as expressible as "front of the queue", and deliberately wider than any lane in use.
- **`BACK_OF_QUEUE_PRIORITY = -100`** sits below the -15/-20 bulk lanes, so a demoted job loses to the existing backlog rather than landing in the middle of it. The contract test pins this relationship.
- **Module placement.** It lives in root `utils/` rather than `server/utils/` because the store needs the constants at runtime and the only existing client imports from `server/` are type-only (erased at build). Root `utils/` is the side-neutral home both can value-import — same shape as `utils/artFacetPrompt.ts`, which `stores/artFacetDraftStore.ts` imports. It also stays free of prisma so the DB-free contract-tests workflow can reach it, the same split as `artJobQueueSettings.ts` out of `artJobQueueCoverage.ts`.
- **One behavior change beyond the floor.** The old validation ran a bare `Number(body?.priority)`, and `Number(null)`, `Number('')` and `Number([])` are all `0` — so a missing or malformed body silently wrote priority 0 instead of failing. That was survivable while 0 was also the floor. Now that negative values are legal, "the body didn't parse" and "put this job at the normal tier" are genuinely different requests, and a malformed body that reads as a demotion is a queue reorder nobody asked for. Non-numeric input is now rejected; numeric strings still parse.
- No migration — `ArtJob.priority` is already a plain `Int @default(0)` with no DB-level constraint.

## Verification

`npm run test:artjob-priority-bounds` passes locally and is wired into `contract-tests.yml`. It covers the regression (negative values accepted, floor reaches past every lane in use), everything the old validation correctly rejected (out-of-range, non-integers), the no-longer-coerced malformed body, and two source-level guards so the endpoint can't drift back to a hand-rolled bound and the store can't fork its own copy of the constants.

Not verified: no UI surfaces `sendToBack()` yet — this adds the store action alongside the existing `moveToFront`/`returnToNormal`, but wiring a button into the ArtJob dashboard is left for whoever wants it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExVxVDi11BHRziDazVr7Et)_