### PR TITLE
Model Builder: batchSetField no longer claims success before the server confirms it

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -404,6 +404,12 @@ jobs:
       - name: Model Builder draftText status-scope guard contract
         run: npm run test:model-builder-draft-status-scope-guard
 
+      - name: Model Builder batchSetField confirmed-success guard checker self-test
+        run: npm run test:model-builder-batch-set-field-confirmed-success-guard-selftest
+
+      - name: Model Builder batchSetField confirmed-success guard contract
+        run: npm run test:model-builder-batch-set-field-confirmed-success-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -210,6 +210,8 @@
     "test:model-builder-pushitem-error-scope-guard": "tsx utils/scripts/verifyModelBuilderPushItemErrorScopeGuard.ts",
     "test:model-builder-draft-status-scope-guard-selftest": "tsx utils/scripts/verifyModelBuilderDraftStatusScopeGuard.test.ts",
     "test:model-builder-draft-status-scope-guard": "tsx utils/scripts/verifyModelBuilderDraftStatusScopeGuard.ts",
+    "test:model-builder-batch-set-field-confirmed-success-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.test.ts",
+    "test:model-builder-batch-set-field-confirmed-success-guard": "tsx utils/scripts/verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -682,17 +682,20 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   // Background persistence of a whole group edit in one round-trip. Callers
   // mutate local state first (optimistic) and pass only the changed fields per
   // item, same contract as pushItem — this just collapses N per-item PATCH
-  // requests into a single batch request.
+  // requests into a single batch request. Returns whether the write actually
+  // succeeded, so a caller that summarizes its own outcome (batchSetField) can
+  // await the real result instead of assuming success the instant the request
+  // is issued.
   function batchPushItems(
     entries: Array<{
       item: BuildItem
       payload: Record<string, unknown>
       meta?: { stage?: string; reason?: string }
     }>,
-  ): void {
-    if (!entries.length) return
+  ): Promise<boolean> {
+    if (!entries.length) return Promise.resolve(true)
     const runId = state.run?.id
-    performFetch('/api/model-builder/items/batch', {
+    return performFetch('/api/model-builder/items/batch', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -704,13 +707,17 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       }),
     })
       .then((response) => {
-        if (!response.success && runId) {
-          setStatusForRun(
-            runId,
-            'error',
-            response.message || 'Failed to save changes.',
-          )
+        if (!response.success) {
+          if (runId) {
+            setStatusForRun(
+              runId,
+              'error',
+              response.message || 'Failed to save changes.',
+            )
+          }
+          return false
         }
+        return true
       })
       .catch((error) => {
         // Same reasoning as pushItem's catch above: mirror the success:false
@@ -726,6 +733,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
               : 'Failed to save changes.',
           )
         }
+        return false
       })
   }
 
@@ -1739,12 +1747,23 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   // Set one model field to the same value on every item in a group (e.g. rarity =
   // RARE across 10 rewards). Only rewrites items whose value actually changes.
   // Persists the whole group in a single batch request rather than one PATCH
-  // per changed item.
-  function batchSetField(
+  // per changed item. Reports success only once that request actually
+  // confirms it -- unlike every other batch entry point (batchDraftField,
+  // batchAutoBuild), this used to call batchPushItems(entries) without
+  // awaiting it and then unconditionally show a "Set ... on N/M items."
+  // success toast the instant the request was issued, before the server had
+  // even responded. A partial or total failure (e.g. a concurrent edit on
+  // another tab making one item no longer stage-editable server-side, or a
+  // network error) still popped that same misleading success banner, then
+  // moments later silently overwrote it with batchPushItems' own generic,
+  // unscoped-looking "Failed to save changes." -- while every item's local
+  // fieldsDraft/stageStatuses had already been optimistically changed with no
+  // indication of which items, if any, never actually persisted.
+  async function batchSetField(
     outputKey: string,
     fieldKey: string,
     value: string,
-  ): void {
+  ): Promise<void> {
     const items = groupItems(outputKey)
     const entries: Array<{
       item: BuildItem
@@ -1765,11 +1784,21 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         meta: { stage: 'FIELDS_AND_PROMPTS', reason: 'edited fields' },
       })
     }
-    batchPushItems(entries)
-    setStatus(
-      'success',
-      `Set ${fieldKey} on ${entries.length}/${items.length} items.`,
-    )
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      const ok = await batchPushItems(entries)
+      // On failure, batchPushItems already surfaced the real error via
+      // setStatusForRun -- reporting a blanket "success" here too would be
+      // actively misleading.
+      if (ok) {
+        setStatus(
+          'success',
+          `Set ${fieldKey} on ${entries.length}/${items.length} items.`,
+        )
+      }
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
   }
 
   // Approve a stage for every (unlocked) item in a group at once.

--- a/utils/scripts/verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.test.ts
@@ -1,0 +1,130 @@
+// /utils/scripts/verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.test.ts
+//
+// Regression test for checkBatchSetFieldConfirmedSuccessGuard() in
+// verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.ts
+// (model-builder/t-029). Exercises the real check against synthetic
+// store-shaped fixtures covering: the pre-fix shape (sync function, fires
+// batchPushItems(entries) without awaiting it, unconditional success toast
+// right after) and the fixed shape (async function, awaits the real result,
+// success toast gated on it).
+import assert from 'node:assert/strict'
+
+import { checkBatchSetFieldConfirmedSuccessGuard } from './verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.js'
+
+function fixture(opts: { async: boolean; body: string }): string {
+  return `
+  ${opts.async ? 'async ' : ''}function batchSetField(
+    outputKey: string,
+    fieldKey: string,
+    value: string,
+  ): ${opts.async ? 'Promise<void>' : 'void'} {
+    const items = groupItems(outputKey)
+    const entries: Array<{
+      item: BuildItem
+      payload: Record<string, unknown>
+      meta?: { stage?: string; reason?: string }
+    }> = []
+    for (const item of items) {
+      if (!isStageEditable(item, 'FIELDS_AND_PROMPTS')) continue
+      const next = setFieldLine(item.fieldsDraft, fieldKey, value)
+      if (next === item.fieldsDraft) continue
+      item.fieldsDraft = next
+      markDownstreamStale(item, 'FIELDS_AND_PROMPTS')
+      entries.push({
+        item,
+        payload: { stageStatuses: item.stages, fieldsDraft: item.fieldsDraft },
+        meta: { stage: 'FIELDS_AND_PROMPTS', reason: 'edited fields' },
+      })
+    }
+    ${opts.body}
+  }
+`
+}
+
+const BUGGY = fixture({
+  async: false,
+  body: `batchPushItems(entries)
+    setStatus(
+      'success',
+      \`Set \${fieldKey} on \${entries.length}/\${items.length} items.\`,
+    )`,
+})
+
+const FIXED = fixture({
+  async: true,
+  body: `batchingOutputSingleton.claim(outputKey)
+    try {
+      const ok = await batchPushItems(entries)
+      if (ok) {
+        setStatus(
+          'success',
+          \`Set \${fieldKey} on \${entries.length}/\${items.length} items.\`,
+        )
+      }
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }`,
+})
+
+// Regressed: the function is async and does await batchPushItems elsewhere
+// (satisfying that check), but the success toast still fires unconditionally
+// right after a *second*, un-awaited fire-and-forget call -- e.g. a bad
+// merge that left both an awaited call (for a different purpose) and the old
+// un-awaited-plus-unconditional-toast shape in place.
+const PARTIALLY_REGRESSED = fixture({
+  async: true,
+  body: `if (items.length > entries.length) {
+      await batchPushItems(entries)
+    }
+    batchPushItems(entries)
+    setStatus(
+      'success',
+      \`Set \${fieldKey} on \${entries.length}/\${items.length} items.\`,
+    )`,
+})
+
+function run(): void {
+  const buggyErrors = checkBatchSetFieldConfirmedSuccessGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    3,
+    'expected the pre-fix fixture (sync, unawaited call, unconditional ' +
+      `success) to fail three times, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(buggyErrors.some((e) => /declared `async`/.test(e)))
+  assert.ok(buggyErrors.some((e) => /no longer awaits/.test(e)))
+  assert.ok(
+    buggyErrors.some((e) => /without awaiting it and unconditionally/.test(e)),
+  )
+
+  const fixedErrors = checkBatchSetFieldConfirmedSuccessGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const regressedErrors =
+    checkBatchSetFieldConfirmedSuccessGuard(PARTIALLY_REGRESSED)
+  assert.equal(
+    regressedErrors.length,
+    1,
+    'expected a fixture that awaits a call but still fires an unawaited ' +
+      `fire-and-forget call with an unconditional toast to fail once, got: ${JSON.stringify(regressedErrors)}`,
+  )
+  assert.ok(/without awaiting it and unconditionally/.test(regressedErrors[0]!))
+
+  const missingFnErrors = checkBatchSetFieldConfirmedSuccessGuard(
+    'function someOtherFunction(): void {}',
+  )
+  assert.equal(missingFnErrors.length, 1)
+  assert.ok(/Could not find a function named/.test(missingFnErrors[0]!))
+
+  console.log(
+    'Model Builder batchSetField confirmed-success guard self-test passed: ' +
+      'buggy fixture fails, fixed fixture passes, a partially-regressed ' +
+      'fixture fails, missing-function fixture fails clearly.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.ts
+++ b/utils/scripts/verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.ts
@@ -1,0 +1,130 @@
+// /utils/scripts/verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.ts
+//
+// Regression guard (model-builder/t-029) -- batchSetField() is the "Set a
+// field on all N" action in the batch editor (model-builder-batch-editor.vue).
+// Every other batch entry point that summarizes its own outcome --
+// batchDraftField (awaits draftText per item, tallies real `ok` results) and
+// batchAutoBuild (awaits autoBuildItem per item, tallies real outcomes) --
+// reports its status message only after its async work actually resolves.
+// batchSetField was the exception: it called batchPushItems(entries) without
+// awaiting it, then *unconditionally* showed a
+// `Set ${fieldKey} on ${entries.length}/${items.length} items.` success
+// toast the instant the request was fired, before the server had even
+// responded.
+//
+// Concretely: apply a field to a group of 10 items where one item's
+// FIELDS_AND_PROMPTS stage was independently approved a moment earlier
+// (another tab, or a concurrent autoBuildItem/approveStage call) --
+// batchSetField's own client-side isStageEditable check doesn't see that
+// yet, so all 10 entries get queued and posted in one batch request. The UI
+// immediately shows "Set rarity on 10/10 items." in success (green) tone.
+// The server's batch route (items/batch.patch.ts) correctly rejects that one
+// entry (assertContentStageEditable) and returns `success: false` (207,
+// partial failure) -- batchPushItems' own `.then` branch then fires a
+// *second*, unrelated-looking toast: a generic "Failed to save changes."
+// error, silently overwriting the false "success" one moments later, with no
+// indication of which item(s) never actually persisted. Every item's local
+// fieldsDraft/stageStatuses had already been optimistically mutated either
+// way.
+//
+// Fixed by making batchPushItems return Promise<boolean> (the real,
+// confirmed outcome) and batchSetField `async`, awaiting that result and
+// only showing the success toast when it's actually true -- mirroring
+// batchDraftField/batchAutoBuild's own await-then-report shape. On failure,
+// batchPushItems' existing run-scoped setStatusForRun(...) call is the only
+// message shown, instead of a false success immediately followed by a
+// generic failure.
+//
+// This asserts the textual shape of that fix stays in place: batchSetField()
+// is declared `async`, its body awaits `batchPushItems(entries)`, and the
+// success toast is gated behind that awaited result rather than firing
+// unconditionally right after an un-awaited `batchPushItems(entries)` call.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'batchSetField'
+
+// The pre-fix shape: batchPushItems(entries) fired without `await`, followed
+// (with nothing gating it) by the success toast.
+const UNAWAITED_FIRE_AND_FORGET =
+  /(?<!await\s)batchPushItems\(entries\)\s*\n\s*setStatus\(\s*\n?\s*'success'/
+
+export function checkBatchSetFieldConfirmedSuccessGuard(
+  content: string,
+): string[] {
+  const errors: string[] = []
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+
+  if (!fn) {
+    errors.push(
+      `Could not find a function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  if (!fn.isAsync) {
+    errors.push(
+      `${FN_NAME}() is no longer declared \`async\` -- without it, it ` +
+        "can't await batchPushItems' real result before reporting its own " +
+        'success/failure toast.',
+    )
+  }
+
+  if (!/await\s+batchPushItems\(\s*entries\s*\)/.test(fn.body)) {
+    errors.push(
+      `${FN_NAME}() no longer awaits \`batchPushItems(entries)\` -- ` +
+        'without awaiting the real result, any success message it shows ' +
+        'is just an assumption made the instant the request was issued, ' +
+        "not a confirmed outcome (mirrors batchDraftField/batchAutoBuild's " +
+        'own await-then-report shape).',
+    )
+  }
+
+  if (UNAWAITED_FIRE_AND_FORGET.test(fn.body)) {
+    errors.push(
+      `${FN_NAME}() still fires batchPushItems(entries) without awaiting ` +
+        'it and unconditionally reports a success toast right after -- a ' +
+        'partial or total server-side failure will still show that false ' +
+        "success message before batchPushItems' own error toast silently " +
+        'overwrites it moments later.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkBatchSetFieldConfirmedSuccessGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder batchSetField confirmed-success guard contract ' +
+        'failed in modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder batchSetField confirmed-success guard contract passed: ' +
+      "batchSetField awaits batchPushItems' real result and only reports " +
+      'success once the write actually confirms it.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Bug

`batchSetField` (the batch editor's "Set a field on all N" action, `stores/modelBuilderStore.ts`) called `batchPushItems(entries)` without awaiting it, then **unconditionally** showed a `Set ${fieldKey} on N/M items.` success toast the instant the request was issued — before the server had even responded. Every other batch entry point that summarizes its own outcome (`batchDraftField`, `batchAutoBuild`) awaits its async work first and reports the real result; `batchSetField` was the one exception.

### Concrete failure scenario

Batch-set a field (e.g. rarity) across a group of items where one item's `FIELDS_AND_PROMPTS` stage was independently approved a moment earlier — another browser tab, or a concurrent `autoBuildItem`/`approveStage` call. `batchSetField`'s own client-side `isStageEditable` check doesn't see that yet, so all entries (including the now-approved one) get queued and posted together in one batch PATCH.

1. The UI immediately shows a green **"Set rarity on 10/10 items."** success toast.
2. The server (`items/batch.patch.ts`) correctly rejects that one entry via `assertContentStageEditable` and returns `success: false` (HTTP 207, partial failure).
3. `batchPushItems`' own `.then` branch then fires a *second*, unrelated-looking toast: a generic **"Failed to save changes."** error, silently overwriting the false success one moments later — with no indication of which item(s) never actually persisted.
4. Meanwhile every item's local `fieldsDraft`/`stageStatuses` had already been optimistically mutated regardless of the real outcome, so the UI and the database are now out of sync for that one item with no visible cue.

## Fix

- `batchPushItems` now returns `Promise<boolean>` (the confirmed outcome) instead of being fully fire-and-forget.
- `batchSetField` is now `async`, awaits that result, and only shows the success toast once the write actually confirms it. On failure, `batchPushItems`' existing run-scoped `setStatusForRun(...)` call is the only message shown (no more false-success-then-generic-failure double toast).
- `batchSetField` now also claims/releases the existing `batchingOutputSingleton` around the await, matching `batchDraftField`/`batchAutoBuild`'s own in-flight indicator (the "Apply" button and friends now correctly show busy/disabled state while the write is actually in flight, which they didn't before).

Minimal, narrowly-scoped diff — only `batchPushItems` and `batchSetField` in `stores/modelBuilderStore.ts` changed.

## New regression guard

`utils/scripts/verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.ts` (+ `.test.ts`), following this repo's existing `verifyModelBuilder*` convention exactly: a textual-shape check over `modelBuilderStore.ts` via `extractFunctionBodies`, asserting `batchSetField` is `async`, awaits `batchPushItems(entries)`, and no longer has the pre-fix "fire without awaiting, then unconditional success toast" shape. Confirmed it fails against the pre-fix code and passes against the fix. Wired into `package.json` (`test:model-builder-batch-set-field-confirmed-success-guard[-selftest]`) and `.github/workflows/contract-tests.yml`, right after the sibling `draft-status-scope-guard` steps.

## Verification

- `npx tsx utils/scripts/verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.test.ts` — pass (self-test: buggy fixture fails 3x, fixed fixture passes, partially-regressed fixture fails once, missing-function fixture fails clearly)
- `npx tsx utils/scripts/verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.ts` — pass against the real store
- Ran the guard against the pre-fix `origin/main` copy of the store directly — confirmed it fails with all 3 expected errors (proves it actually pins the regression, not just self-consistent fixtures)
- All 26 pre-existing `verifyModelBuilder*.ts` guards — pass, no regressions
- All 26 pre-existing `verifyModelBuilder*.test.ts` self-tests — pass
- `npx eslint stores/modelBuilderStore.ts utils/scripts/verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.ts utils/scripts/verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.test.ts` — the 2 errors reported in `modelBuilderStore.ts` (`no-empty` on `safeSet`/`safeRemove`'s catch blocks) are pre-existing, confirmed via `git stash` to predate this change; the new guard files are eslint-clean
- `npx prettier --check` on the two new guard files — clean (formatted with `--write`). `modelBuilderStore.ts` has pre-existing repo-wide prettier drift confirmed via `git stash` to predate this change (unrelated formatting-version mismatch spanning the whole file) — left untouched per scope
- `npx vue-tsc --noEmit` (repo-wide) — exits clean, no output
- `git status --porcelain` — diff is exactly the 5 intended files (`stores/modelBuilderStore.ts`, the 2 new guard files, `package.json`, `.github/workflows/contract-tests.yml`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZd3wF5mz8kHHow8hbFtKU)_