### PR TITLE
feat(model-builder): add meta-guard for confirmed-outcome-before-toast

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -410,6 +410,12 @@ jobs:
       - name: Model Builder batchSetField confirmed-success guard contract
         run: npm run test:model-builder-batch-set-field-confirmed-success-guard
 
+      - name: Model Builder confirmed-outcome-before-toast meta-guard checker self-test
+        run: npm run test:model-builder-confirmed-outcome-guard-selftest
+
+      - name: Model Builder confirmed-outcome-before-toast meta-guard contract
+        run: npm run test:model-builder-confirmed-outcome-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -212,6 +212,8 @@
     "test:model-builder-draft-status-scope-guard": "tsx utils/scripts/verifyModelBuilderDraftStatusScopeGuard.ts",
     "test:model-builder-batch-set-field-confirmed-success-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.test.ts",
     "test:model-builder-batch-set-field-confirmed-success-guard": "tsx utils/scripts/verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.ts",
+    "test:model-builder-confirmed-outcome-guard-selftest": "tsx utils/scripts/verifyModelBuilderConfirmedOutcomeGuard.test.ts",
+    "test:model-builder-confirmed-outcome-guard": "tsx utils/scripts/verifyModelBuilderConfirmedOutcomeGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/utils/scripts/verifyModelBuilderConfirmedOutcomeGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderConfirmedOutcomeGuard.test.ts
@@ -1,0 +1,174 @@
+// /utils/scripts/verifyModelBuilderConfirmedOutcomeGuard.test.ts
+//
+// Regression test for checkConfirmedOutcomeGuard()/findPromiseReturningHelpers()
+// in verifyModelBuilderConfirmedOutcomeGuard.ts (model-builder/t-042).
+// Exercises the real check against synthetic store-shaped fixtures: a
+// helper's own Promise<...>-vs-void signature detection, the pre-fix
+// batchSetField shape (bare unawaited call, unconditional success toast),
+// the fixed shape (awaited + gated), the intentional `void`-marked
+// fire-and-forget shape (generateItemAssetAsync/pollAsyncArtJob), and the
+// established "fire a void-returning helper, then toast on separately-
+// confirmed work" shape (generateItemAsset/pushItem) that must never be
+// flagged.
+import assert from 'node:assert/strict'
+
+import {
+  checkConfirmedOutcomeGuard,
+  findPromiseReturningHelpers,
+} from './verifyModelBuilderConfirmedOutcomeGuard.js'
+
+function run(): void {
+  // --- findPromiseReturningHelpers -----------------------------------------
+
+  const helpers = findPromiseReturningHelpers(`
+  function pushItem(item: BuildItem): void {
+    performFetch('/x')
+  }
+
+  function batchPushItems(entries: unknown[]): Promise<boolean> {
+    return performFetch('/x').then(() => true)
+  }
+
+  async function draftText(itemId: string): Promise<boolean> {
+    return true
+  }
+
+  function groupItems(outputKey: string): BuildItem[] {
+    return []
+  }
+`)
+  const helperNames = helpers.map((h) => h.name).sort()
+  assert.deepEqual(
+    helperNames,
+    ['batchPushItems', 'draftText'],
+    `expected only the Promise-returning helpers, got: ${JSON.stringify(helperNames)}`,
+  )
+  assert.ok(
+    !helperNames.includes('pushItem'),
+    'pushItem returns void and must not be treated as a confirmed-outcome helper',
+  )
+  assert.ok(
+    !helperNames.includes('groupItems'),
+    'groupItems returns a plain array (no Promise) and must not be flagged',
+  )
+
+  // --- checkConfirmedOutcomeGuard -------------------------------------------
+
+  const BUGGY = `
+  function batchPushItems(entries: unknown[]): Promise<boolean> {
+    return performFetch('/x').then(() => true)
+  }
+
+  function batchSetField(outputKey: string, fieldKey: string): void {
+    const entries = groupItems(outputKey)
+    batchPushItems(entries)
+    setStatus(
+      'success',
+      \`Set \${fieldKey} on \${entries.length} items.\`,
+    )
+  }
+`
+  const buggyErrors = checkConfirmedOutcomeGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    1,
+    `expected the bare-unawaited-call fixture to fail once, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(/batchSetField\(\) line/.test(buggyErrors[0]!))
+  assert.ok(/without `await`/.test(buggyErrors[0]!))
+
+  const FIXED = `
+  function batchPushItems(entries: unknown[]): Promise<boolean> {
+    return performFetch('/x').then(() => true)
+  }
+
+  async function batchSetField(outputKey: string, fieldKey: string): Promise<void> {
+    const entries = groupItems(outputKey)
+    const ok = await batchPushItems(entries)
+    if (ok) {
+      setStatus(
+        'success',
+        \`Set \${fieldKey} on \${entries.length} items.\`,
+      )
+    }
+  }
+`
+  assert.deepEqual(
+    checkConfirmedOutcomeGuard(FIXED),
+    [],
+    'an awaited, result-gated call must not be flagged',
+  )
+
+  const VOID_MARKED = `
+  async function pollAsyncArtJob(item: BuildItem): Promise<void> {
+    setStatusForRun(item.runId, 'success', 'Generated a candidate.')
+  }
+
+  async function generateItemAssetAsync(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    void pollAsyncArtJob(item)
+    return true
+  }
+`
+  assert.deepEqual(
+    checkConfirmedOutcomeGuard(VOID_MARKED),
+    [],
+    'an explicitly `void`-marked fire-and-forget call must not be flagged, ' +
+      "and a helper's OWN internal, already-gated success toast must not " +
+      'be confused with its caller firing it unawaited',
+  )
+
+  const VOID_RETURNING_HELPER_FIRE_AND_FORGET = `
+  function pushItem(item: BuildItem): void {
+    performFetch('/x')
+  }
+
+  async function generateItemAsset(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    await artStore.generateCurrentArt({})
+    pushItem(item)
+    setStatusForRun(
+      item.runId,
+      'success',
+      \`Generated a candidate for \${item.label}.\`,
+    )
+    return true
+  }
+`
+  assert.deepEqual(
+    checkConfirmedOutcomeGuard(VOID_RETURNING_HELPER_FIRE_AND_FORGET),
+    [],
+    'firing a void-returning (non-Promise) helper before a toast reporting ' +
+      'separately-awaited, already-confirmed work is the established ' +
+      'correct pattern and must not be flagged',
+  )
+
+  const TOAST_BEFORE_BARE_CALL = `
+  function batchPushItems(entries: unknown[]): Promise<boolean> {
+    return performFetch('/x').then(() => true)
+  }
+
+  async function mixedOrder(outputKey: string): Promise<void> {
+    setStatus('success', 'Unrelated earlier success.')
+    const entries = groupItems(outputKey)
+    batchPushItems(entries)
+  }
+`
+  assert.deepEqual(
+    checkConfirmedOutcomeGuard(TOAST_BEFORE_BARE_CALL),
+    [],
+    'a success toast that occurs BEFORE the bare call is not describing ' +
+      "that call's outcome and must not be flagged",
+  )
+
+  console.log(
+    'Model Builder confirmed-outcome-before-toast meta-guard self-test ' +
+      'passed: Promise-vs-void helper detection is correct, the bare-' +
+      'unawaited-call shape fails, the awaited+gated shape passes, `void`-' +
+      'marked fire-and-forget passes, firing a void-returning helper ' +
+      'before a toast on separately-confirmed work passes, and toast-' +
+      'before-call ordering is not flagged.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderConfirmedOutcomeGuard.ts
+++ b/utils/scripts/verifyModelBuilderConfirmedOutcomeGuard.ts
@@ -1,0 +1,201 @@
+// /utils/scripts/verifyModelBuilderConfirmedOutcomeGuard.ts
+//
+// Meta-guard (model-builder/t-042, kaizen from t-029). Three separate t-029
+// bug-hunt cycles found the same shape of defect in modelBuilderStore.ts: a
+// store action calls one of the store's own Promise-returning helpers
+// (pushItem's batch sibling batchPushItems, specifically -- see PR #1859)
+// without awaiting it, then unconditionally shows a `setStatus`/
+// `setStatusForRun` success toast the instant the request is *issued*
+// rather than once it actually *confirms*. Each cycle so far added one
+// narrow verifyModelBuilder*Guard.ts per fixed function
+// (verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.ts). This guard
+// instead walks the whole file's action surface at once, so the next new
+// batch/draft/push-style action added to the store gets this property
+// checked automatically instead of needing its own bespoke guard
+// discovered a cycle later.
+//
+// What counts as "the store's own Promise-returning helpers" is computed
+// from the file itself, not hardcoded: any top-level function declared
+// `async function NAME(...)`, or a non-async `function NAME(...):
+// Promise<...>` (batchPushItems' own shape -- see its doc comment: "Returns
+// whether the write actually succeeded, so a caller that summarizes its own
+// outcome ... can await the real result instead of assuming success the
+// instant the request is issued"). A function with a plain `void` return
+// (pushItem, approveStage, ...) is deliberately excluded: this store's own
+// idiom is that those ARE meant to be fired-and-forgotten in the background
+// (their own internal `.then`/`.catch` already scope their failure toast via
+// setStatusForRun), and a caller reporting success based on locally-known,
+// already-confirmed state right after firing one (e.g. generateItemAsset's
+// "Generated a candidate" toast, reporting the *render* succeeding, with
+// pushItem firing the background persist alongside it) is the established,
+// correct pattern -- not the bug this guards against.
+//
+// For every top-level function in the store that contains a 'success'-toned
+// setStatus(...)/setStatusForRun(...) call anywhere in its body, this
+// asserts: no *bare* (i.e. a stand-alone expression-statement, not awaited,
+// not assigned, not returned, and not explicitly marked with the `void`
+// operator to declare an intentional fire-and-forget -- see
+// generateItemAssetAsync's `void pollAsyncArtJob(...)`) call to one of the
+// store's own Promise-returning helpers appears anywhere before that
+// success toast in the same function body. Deliberately scoped to this
+// store's own textual idiom over a general-purpose static analyzer, per
+// this codebase's established narrow-textual-guard convention.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const SIGNATURE_PATTERN = /^ {2}(async )?function (\w+)\s*\(/gm
+
+export interface PromiseHelper {
+  name: string
+  isAsync: boolean
+}
+
+// Every top-level `function NAME(` (this store's setup-function convention,
+// mirroring extractFunctionBodies' own signature pattern) that either is
+// declared `async` or whose parameter list is followed by a `: Promise<`
+// return-type annotation before its body's opening brace.
+export function findPromiseReturningHelpers(content: string): PromiseHelper[] {
+  const helpers: PromiseHelper[] = []
+
+  for (const match of content.matchAll(SIGNATURE_PATTERN)) {
+    const isAsync = Boolean(match[1])
+    const name = match[2]!
+    const parenOpen = match.index + match[0].length - 1
+
+    let parenDepth = 0
+    let i = parenOpen
+    for (; i < content.length; i++) {
+      if (content[i] === '(') parenDepth++
+      else if (content[i] === ')') {
+        parenDepth--
+        if (parenDepth === 0) break
+      }
+    }
+    if (parenDepth !== 0) continue
+
+    const braceOpen = content.indexOf('{', i)
+    if (braceOpen === -1) continue
+
+    // The text between the parameter list's closing ')' and the body's
+    // opening '{' is the return-type annotation, if any (e.g.
+    // `): Promise<boolean> {`).
+    const returnType = content.slice(i + 1, braceOpen)
+
+    if (isAsync || /:\s*Promise</.test(returnType)) {
+      helpers.push({ name, isAsync })
+    }
+  }
+
+  return helpers
+}
+
+// True if a 'success'-toned setStatus(...) or setStatusForRun(...) call
+// appears anywhere in `body`. Both functions take the tone as a string
+// literal argument ('success' | 'error'); matching the literal is enough --
+// this codebase's own message strings are always template literals, never
+// bare 'success'/'error' quoted strings, so there's no realistic collision.
+function hasSuccessToast(body: string): boolean {
+  return /\bsetStatus(?:ForRun)?\([^)]*?'success'/s.test(body)
+}
+
+export interface ConfirmedOutcomeViolation {
+  functionName: string
+  helperName: string
+  line: number
+}
+
+// A "bare" call to `helperName(` -- a stand-alone expression statement, not
+// `await helperName(`, not `const x = helperName(`/`return helperName(`,
+// and not explicitly fire-and-forgotten via the `void` operator. Anchored
+// to the start of a line (after indentation) so an assignment, return, or
+// await -- which all put a different token before the call on the same
+// line -- never match.
+function findBareCalls(body: string, helperName: string): number[] {
+  const pattern = new RegExp(`^[ \\t]*${helperName}\\(`, 'gm')
+  return [...body.matchAll(pattern)].map((m) => m.index)
+}
+
+export function checkConfirmedOutcomeGuard(content: string): string[] {
+  const errors: string[] = []
+  const helpers = findPromiseReturningHelpers(content)
+  const functions = extractFunctionBodies(content)
+
+  for (const fn of functions) {
+    if (!hasSuccessToast(fn.body)) continue
+
+    // A function may legitimately call itself recursively or reference its
+    // own name in a comment; only other helpers matter for the "did this
+    // function fire-and-forget something it's about to claim succeeded"
+    // check.
+    for (const helper of helpers) {
+      if (helper.name === fn.name) continue
+
+      const bareOffsets = findBareCalls(fn.body, helper.name)
+      if (!bareOffsets.length) continue
+
+      // Only the toast(s) that occur AFTER the bare call are in scope --
+      // a success toast for a fully separate, earlier branch of the same
+      // function isn't describing this call's outcome.
+      const successToastPattern = /\bsetStatus(?:ForRun)?\([^)]*?'success'/gs
+      const toastOffsets = [...fn.body.matchAll(successToastPattern)].map(
+        (m) => m.index,
+      )
+
+      const earliestBare = Math.min(...bareOffsets)
+      const violatingToast = toastOffsets.find((t) => t > earliestBare)
+      if (violatingToast === undefined) continue
+
+      const absoluteOffset = fn.bodyStart + earliestBare
+      const line = content.slice(0, absoluteOffset).split('\n').length
+
+      errors.push(
+        `${fn.name}() line ${line}: calls ${helper.name}(...) without ` +
+          '`await`, `return`, an assignment, or an explicit `void` marker, ' +
+          "then shows a 'success' status toast later in the same function " +
+          `-- the toast fires the instant ${helper.name}(...) is issued, ` +
+          'not once it actually confirms. Either `await` the call and gate ' +
+          'the toast on its real result (see batchSetField), or mark it ' +
+          '`void ' +
+          `${helper.name}(...)\` if it's meant to keep running in the ` +
+          'background and the toast is reporting on separately-confirmed ' +
+          'work instead (see generateItemAssetAsync/pollAsyncArtJob).',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkConfirmedOutcomeGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder confirmed-outcome-before-toast meta-guard failed in ' +
+        'modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder confirmed-outcome-before-toast meta-guard passed: every ' +
+      "store action with a 'success' status toast either has no bare, " +
+      "unhandled call to one of the store's own Promise-returning helpers " +
+      'ahead of it, or that call is explicitly `void`-marked as intentional.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What

Adds `verifyModelBuilderConfirmedOutcomeGuard.ts`, a meta-guard for `stores/modelBuilderStore.ts` requested by conductor `model-builder/t-042` (kaizen from `t-029`).

## Why

Three separate `t-029` bug-hunt cycles found the same shape of defect in the store: an action calls one of the store's own Promise-returning helpers (e.g. `batchPushItems`) without awaiting it, then unconditionally shows a `setStatus`/`setStatusForRun` success toast the instant the request is *issued* rather than once it actually *confirms* (most recently `batchSetField`, PR #1859). Each cycle so far added one narrow `verifyModelBuilder*Guard.ts` per fixed function. This guard instead walks the whole file's action surface at once, so the next new batch/draft/push-style action added to the store gets this property checked automatically instead of needing its own bespoke guard discovered a cycle later.

## How

- Computes the set of "the store's own Promise-returning helpers" directly from each function's signature — `async function NAME(...)`, or a non-async `function NAME(...): Promise<...>` (`batchPushItems`' own shape). A plain `void`-returning function (`pushItem`, `approveStage`, ...) is deliberately excluded — the store's established idiom is that those are meant to be fired-and-forgotten in the background (their own `.then`/`.catch` already scope their own failure toast via `setStatusForRun`).
- For every top-level function containing a `'success'`-toned status toast, flags any **bare** call (not `await`ed, not assigned, not `return`ed, and not explicitly `void`-marked) to one of those helpers occurring earlier in the same function body.
- The explicit `void` operator is treated as an intentional, correct fire-and-forget marker (matches `generateItemAssetAsync`'s existing `void pollAsyncArtJob(...)` idiom), so legitimate patterns aren't flagged.

## Verification

- New self-test (`verifyModelBuilderConfirmedOutcomeGuard.test.ts`) covers: Promise-vs-void helper signature detection, the pre-fix buggy shape (bare unawaited call + unconditional toast), the fixed awaited+gated shape, the intentional `void`-marked fire-and-forget shape, firing a void-returning helper before a toast on separately-confirmed work (the established `generateItemAsset`/`pushItem` pattern — verified this does **not** false-positive), and toast-before-call ordering.
- Guard runs clean against the real `stores/modelBuilderStore.ts` (0 violations).
- All 24 pre-existing `verifyModelBuilder*` guards + self-tests pass — no regression.
- `eslint` clean on the new files; `prettier --check` clean.
- `vue-tsc --noEmit` repo-wide exits clean.
- `git status --porcelain` shows exactly the 4 intended files (the two new guard files, `package.json` npm-script wiring, `contract-tests.yml` CI step wiring).

Tracked by conductor `model-builder/t-042`.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfmYHbXF4D8F4YdhVTpxrX)_