### PR TITLE
fix(storybook): stop archiving zero-beat phantom sessions into library

### DIFF
--- a/.github/workflows/storybook-library-phantom-session-contract.yml
+++ b/.github/workflows/storybook-library-phantom-session-contract.yml
@@ -1,0 +1,30 @@
+name: Storybook Library Phantom Session Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: storybook-library-phantom-session-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Storybook library phantom session contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify Storybook library phantom-session guard
+        run: node utils/scripts/verifyStorybookLibraryPhantomSessionGuard.mjs

--- a/stores/helpers/storybookLibraryHelper.ts
+++ b/stores/helpers/storybookLibraryHelper.ts
@@ -94,6 +94,19 @@ export function createStorybookLibraryController(bridge: StorybookLibraryBridge)
   }
 
   function upsert(value: StorybookSession): void {
+    // A session with no beats yet is either an opening generation still in
+    // flight or one storybookStore just rolled back to null after the
+    // opening `weaveBeat` call failed (see the beginStory soft-lock fix).
+    // The `watch(bridge.getSession(), ...)` below fires on both the
+    // pre-generation reassignment (session.value = { beats: [], ... }) and
+    // the post-failure rollback (session.value = null, previous = that same
+    // blank session), so without this guard every failed or interrupted
+    // opening generation permanently archives an empty, unopenable
+    // "Untitled story" into the reader's recent-stories library. Skipping a
+    // zero-beat session here is safe for every legitimate caller --
+    // duplicateStory/restartStory/archiveCurrent only ever upsert a session
+    // that has already woven at least its opening beat.
+    if (!value.beats.length) return
     const copy = cloneSession(value)
     library.value = [
       copy,

--- a/utils/scripts/verifyStorybookLibraryPhantomSessionGuard.mjs
+++ b/utils/scripts/verifyStorybookLibraryPhantomSessionGuard.mjs
@@ -1,0 +1,106 @@
+// /utils/scripts/verifyStorybookLibraryPhantomSessionGuard.mjs
+//
+// Regression guard (storybook/t-010, front-end polish). storybookLibraryHelper
+// watches `bridge.getSession()` (deep) and calls `upsert()` on every change --
+// once when a session is (re)assigned and again, with `previous`, whenever it
+// is cleared:
+//
+//   watch(() => bridge.getSession(), (next, previous) => {
+//     if (!initialized.value) return
+//     if (next) upsert(next)
+//     else if (previous) upsert(previous)
+//   }, { deep: true })
+//
+// `beginStory` (and `restartStory`, which calls it) creates a session with
+// `beats: []` *before* the first `weaveBeat` call, then rolls `session.value`
+// back to `null` if that opening generation fails -- a real, reachable path
+// (a transient generateText error, an unparsable response, a moderation
+// rejection). Without a guard in `upsert()` itself, both watcher firings
+// archive that zero-beat session into the reader's recent-stories library:
+// once on the pre-generation reassignment, again (via `previous`) on the
+// post-failure rollback. The result is a permanent, unopenable "Untitled
+// story" phantom sitting in the Story Library -- opening it clones a session
+// with no beats, so the reading view shows an empty transcript forever with
+// no composer and no way to generate anything, and it can push a real story
+// out of the capped MAX_LIBRARY_SESSIONS window over time.
+//
+// This asserts the fix's shape stays in place: `upsert` refuses to persist a
+// session that has no beats yet.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const HELPER_PATH = 'stores/helpers/storybookLibraryHelper.ts'
+const FN_NAME = 'upsert'
+
+function extractFunctionBody(content, name) {
+  const signaturePattern = new RegExp(`^ {2}function ${name}\\s*\\(`, 'm')
+  const match = signaturePattern.exec(content)
+  if (!match) {
+    throw new Error(
+      `Could not find \`  function ${name}(\` in ${HELPER_PATH} -- has it ` +
+        'been renamed, removed, or inlined? If so, this guard (and the ' +
+        'phantom-library-entry bug it protects against) needs to move with it.',
+    )
+  }
+
+  const parenOpen = match.index + match[0].length - 1
+  let parenDepth = 0
+  let i = parenOpen
+  for (; i < content.length; i++) {
+    if (content[i] === '(') parenDepth++
+    else if (content[i] === ')') {
+      parenDepth--
+      if (parenDepth === 0) break
+    }
+  }
+  const braceOpen = content.indexOf('{', i)
+  let braceDepth = 0
+  let j = braceOpen
+  for (; j < content.length; j++) {
+    if (content[j] === '{') braceDepth++
+    else if (content[j] === '}') {
+      braceDepth--
+      if (braceDepth === 0) break
+    }
+  }
+  return content.slice(braceOpen, j + 1)
+}
+
+const content = readFileSync(resolve(process.cwd(), HELPER_PATH), 'utf8')
+const body = extractFunctionBody(content, FN_NAME)
+
+const required = [
+  [
+    'if (!value.beats.length) return',
+    'must refuse to archive a session before it has woven its opening beat',
+  ],
+]
+
+for (const [needle, why] of required) {
+  assert.ok(
+    body.includes(needle),
+    `${FN_NAME}() no longer contains \`${needle}\` -- ${why}, or a failed ` +
+      'or interrupted opening generation permanently archives an empty, ' +
+      'unopenable "Untitled story" into the reader\'s recent-stories library.',
+  )
+}
+
+// The watcher must still route both a fresh session and a just-cleared one
+// through this same guarded upsert() -- otherwise the guard above is dead
+// code that never sees the paths that actually cause the phantom entry.
+const helperContent = content
+assert.ok(
+  /if \(next\) upsert\(next\)/.test(helperContent) &&
+    /else if \(previous\) upsert\(previous\)/.test(helperContent),
+  `${HELPER_PATH} must still route both the next-session and ` +
+    'previous-session (post-clear) cases through upsert() -- otherwise this ' +
+    "guard's fix is not actually reachable from the watcher that caused the bug.",
+)
+
+console.log(
+  'Storybook library phantom-session guard contract passed: upsert() ' +
+    'refuses to archive a zero-beat session, so a failed or interrupted ' +
+    'opening generation can no longer leave a permanent, unopenable entry ' +
+    'in the recent-stories library.',
+)


### PR DESCRIPTION
### Task
storybook/t-010: Polish and upgrade Storybook front-end surface (kind: software)

### What changed / what I produced
- `stores/helpers/storybookLibraryHelper.ts`: `upsert()` now refuses to archive a session that has zero beats.
- New guard `utils/scripts/verifyStorybookLibraryPhantomSessionGuard.mjs` + dedicated workflow `.github/workflows/storybook-library-phantom-session-contract.yml`, following this lane's established narrow-textual-checker + per-guard-workflow convention (matches all 6 prior `verifyStorybook*` guards).

**The bug:** `storybookLibraryHelper` watches the active session (`watch(() => bridge.getSession(), ..., { deep: true })`) and calls `upsert()` on every change, including:
1. `beginStory` reassigns `session.value` to a brand-new `beats: []` session *before* the first `weaveBeat` call — the watcher fires with `next` = that blank session and archives it.
2. If that opening `weaveBeat` call fails (transient `generateText` error, unparsable response, moderation rejection — all real, reachable paths), `beginStory` rolls `session.value` back to `null` so the reader isn't soft-locked. The watcher fires again with `previous` = the same blank session and archives it a second time.

Either firing alone is enough to leave a permanent, unopenable "Untitled story" phantom sitting in the reader's recent-stories library (persisted to `localStorage`, capped at `MAX_LIBRARY_SESSIONS = 20`). Opening it clones a session with no beats, so the reading view shows an empty transcript forever with no composer and no way to generate anything — and over time it can push a real story out of the capped window. This is a new gap, distinct from the opening-generation soft-lock fix (#1835, which rolls back the *active* session correctly) and the answer-composer text-loss fix (#1846) — neither touches the separate library-archival watcher.

**The fix:** guard `upsert()` itself — the single choke point used by the watcher, `archiveCurrent`, `duplicateStory`, and `restartStory` — to skip sessions with `beats.length === 0`. Every legitimate caller only ever archives a session that has already woven its opening beat, so this is safe everywhere and closes both firing paths at the root.

### How I verified
- New guard: passes against the fix; fails against the pre-fix shape (round-tripped via `git stash` on just the helper file, confirmed the assertion error message).
- All 6 pre-existing `verifyStorybook*` guards still pass (no regressions): AnswerInputPreservation, AnswerRollback, BranchState, ObjectEntryLinks, SessionLibrary, Studio.
- `eslint` clean on both touched/new files.
- `prettier --check` clean on the two new files; pre-existing drift on `storybookLibraryHelper.ts` confirmed via `git stash` to predate this change (left untouched, out of scope).
- `vue-tsc --noEmit` repo-wide (`npm run test`) exits clean.
- `git status --porcelain` shows exactly the 3 intended files.

### Stakes
reversible

### Kaizen suggestion
`archiveCurrent()` and the initial `initialize()` upsert both still go through the same now-guarded `upsert()`, so they're covered too — but it might be worth an explicit UI-visible "story not saved yet" cue on the setup screen while the opening beat is generating, so the guard's silence (no library entry appears) doesn't read as "did my click register?" to the reader. Deferred — presentation-layer, out of this fix's scope.

### Notes for reviewer
Recurring `storybook/t-010` bug-hunt cycle (conductor scheduled run). Conductor task set to `status: review` before opening this PR per AGENTS.md step 7; will close back to `ready` (this lane's established "never reaches done" convention) once merged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TPaGKSThAGczCQAN8EPrqs)_