### PR TITLE
fix(model-builder): prevent two quantity groups from batch-processing concurrently

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -416,6 +416,12 @@ jobs:
       - name: Model Builder confirmed-outcome-before-toast meta-guard contract
         run: npm run test:model-builder-confirmed-outcome-guard
 
+      - name: Model Builder batch any-in-flight guard checker self-test
+        run: npm run test:model-builder-batch-any-in-flight-guard-selftest
+
+      - name: Model Builder batch any-in-flight guard contract
+        run: npm run test:model-builder-batch-any-in-flight-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/components/model-builder/model-builder-batch-editor.vue
+++ b/components/model-builder/model-builder-batch-editor.vue
@@ -51,7 +51,7 @@
         <button
           type="button"
           class="btn btn-xs rounded-lg"
-          :disabled="batching"
+          :disabled="anyBatching"
           @click="draftAll('pitch')"
         >
           <Icon name="kind-icon:sparkles" class="h-3.5 w-3.5" />
@@ -61,7 +61,7 @@
           v-if="!isAsset"
           type="button"
           class="btn btn-xs rounded-lg"
-          :disabled="batching"
+          :disabled="anyBatching"
           @click="draftAll('fields')"
         >
           <Icon name="kind-icon:sparkles" class="h-3.5 w-3.5" />
@@ -71,7 +71,7 @@
           v-if="wantArt"
           type="button"
           class="btn btn-xs rounded-lg"
-          :disabled="batching"
+          :disabled="anyBatching"
           @click="draftAll('artPrompt')"
         >
           <Icon name="kind-icon:sparkles" class="h-3.5 w-3.5" />
@@ -80,7 +80,7 @@
         <button
           type="button"
           class="btn btn-xs btn-ghost rounded-lg"
-          :disabled="batching"
+          :disabled="anyBatching"
           @click="
             store.batchApproveStage(group.outputKey, 'FIELDS_AND_PROMPTS')
           "
@@ -91,7 +91,7 @@
         <button
           type="button"
           class="btn btn-xs btn-primary rounded-lg"
-          :disabled="batching"
+          :disabled="anyBatching"
           :title="autoBuildGroupTitle"
           @click="store.batchAutoBuild(group.outputKey)"
         >
@@ -154,7 +154,7 @@
           <button
             type="button"
             class="btn btn-xs rounded-lg"
-            :disabled="batching || !batchValues[field.key]"
+            :disabled="anyBatching || !batchValues[field.key]"
             :aria-label="`Apply ${field.label} to all ${group.items.length} items`"
             @click="applyField(field.key)"
           >
@@ -214,6 +214,32 @@ const group = computed(() =>
   store.itemGroups.find((entry) => entry.outputKey === props.outputKey),
 )
 const batching = computed(() => store.batchingOutputKey === props.outputKey)
+
+// batchingOutputSingleton (modelBuilderStore.ts) is a single store-wide slot,
+// not one per group -- see createOwnedSingleton's own doc comment: claiming
+// it is an unconditional overwrite, so it's only reliable as "who owns the
+// spinner right now," never as a lock that blocks a second claim. This
+// component is keyed by outputKey (progress-matrix.vue's
+// `:key="selectedItem.outputKey"`, from t-029's earlier batch-editor-key
+// fix), and row clicks that change the selected item/group are never
+// disabled -- so switching to a different quantity group while this group's
+// batchDraftField/batchSetField/batchAutoBuild is still running unmounts
+// this instance and mounts a fresh one for the new group, whose own
+// `batching` (scoped to ITS OWN outputKey) reads false even though the old
+// group's operation is still in flight. Every action button used to gate
+// only on that narrow `batching`, so the new group's buttons stayed
+// clickable and could kick off a second, fully concurrent batch operation --
+// racing draftText's shared draftingField singleton, defeating
+// batchDraftField's "sequentially, so we don't hammer the text server"
+// design, and letting the two operations' unscoped setStatus() completion
+// toasts silently clobber each other. Mirrors item-panel.vue's
+// isAnyDraftInFlight (gates every field's controls on ANY draft being in
+// flight, not just the matching one) -- gate every action button here on
+// ANY batch operation being in flight anywhere in the run, not just this
+// group, so a second one can't start until the first actually finishes.
+// `batching` above stays narrow on purpose -- it only drives this group's
+// own header spinner.
+const anyBatching = computed(() => store.batchingOutputKey !== null)
 const isAsset = computed(() => group.value?.action === 'ASSET_ONLY')
 const wantArt = computed(
   () => store.includeArt && group.value?.generation === 'image',

--- a/package.json
+++ b/package.json
@@ -214,6 +214,8 @@
     "test:model-builder-batch-set-field-confirmed-success-guard": "tsx utils/scripts/verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.ts",
     "test:model-builder-confirmed-outcome-guard-selftest": "tsx utils/scripts/verifyModelBuilderConfirmedOutcomeGuard.test.ts",
     "test:model-builder-confirmed-outcome-guard": "tsx utils/scripts/verifyModelBuilderConfirmedOutcomeGuard.ts",
+    "test:model-builder-batch-any-in-flight-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchAnyInFlightGuard.test.ts",
+    "test:model-builder-batch-any-in-flight-guard": "tsx utils/scripts/verifyModelBuilderBatchAnyInFlightGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/utils/scripts/verifyModelBuilderBatchAnyInFlightGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderBatchAnyInFlightGuard.test.ts
@@ -1,0 +1,110 @@
+// /utils/scripts/verifyModelBuilderBatchAnyInFlightGuard.test.ts
+//
+// Regression test for checkBatchAnyInFlightGuard() in
+// verifyModelBuilderBatchAnyInFlightGuard.ts (model-builder/t-029).
+// Exercises the real check against synthetic script-block-shaped fixtures
+// covering: the pre-fix shape (every button gates on the narrow per-group
+// `batching` -- the exact bug found by manual read-through), the fixed
+// shape, a partial fix (anyBatching defined but one button still left on
+// the narrow `batching`), and the anyBatching computed being absent
+// entirely.
+import assert from 'node:assert/strict'
+
+import { checkBatchAnyInFlightGuard } from './verifyModelBuilderBatchAnyInFlightGuard.js'
+
+const BUGGY_FIXTURE = `
+<template>
+  <button :disabled="batching" @click="draftAll('pitch')">Draft pitches</button>
+  <button :disabled="batching" @click="draftAll('fields')">Draft fields</button>
+  <button :disabled="batching" @click="store.batchApproveStage(group.outputKey, 'FIELDS_AND_PROMPTS')">Approve fields</button>
+  <button :disabled="batching" @click="store.batchAutoBuild(group.outputKey)">Auto-build group</button>
+  <button :disabled="batching || !batchValues[field.key]" @click="applyField(field.key)">Apply</button>
+</template>
+<script setup lang="ts">
+const batching = computed(() => store.batchingOutputKey === props.outputKey)
+</script>
+`
+
+const FIXED_FIXTURE = `
+<template>
+  <button :disabled="anyBatching" @click="draftAll('pitch')">Draft pitches</button>
+  <button :disabled="anyBatching" @click="draftAll('fields')">Draft fields</button>
+  <button :disabled="anyBatching" @click="store.batchApproveStage(group.outputKey, 'FIELDS_AND_PROMPTS')">Approve fields</button>
+  <button :disabled="anyBatching" @click="store.batchAutoBuild(group.outputKey)">Auto-build group</button>
+  <button :disabled="anyBatching || !batchValues[field.key]" @click="applyField(field.key)">Apply</button>
+</template>
+<script setup lang="ts">
+const batching = computed(() => store.batchingOutputKey === props.outputKey)
+const anyBatching = computed(() => store.batchingOutputKey !== null)
+</script>
+`
+
+const PARTIAL_FIX_FIXTURE = `
+<template>
+  <button :disabled="anyBatching" @click="draftAll('pitch')">Draft pitches</button>
+  <button :disabled="anyBatching" @click="draftAll('fields')">Draft fields</button>
+  <button :disabled="anyBatching" @click="store.batchApproveStage(group.outputKey, 'FIELDS_AND_PROMPTS')">Approve fields</button>
+  <button :disabled="anyBatching" @click="store.batchAutoBuild(group.outputKey)">Auto-build group</button>
+  <button :disabled="batching || !batchValues[field.key]" @click="applyField(field.key)">Apply</button>
+</template>
+<script setup lang="ts">
+const batching = computed(() => store.batchingOutputKey === props.outputKey)
+const anyBatching = computed(() => store.batchingOutputKey !== null)
+</script>
+`
+
+const MISSING_FIXTURE = `
+<template>
+  <button :disabled="batching" @click="draftAll('pitch')">Draft pitches</button>
+</template>
+<script setup lang="ts">
+const batching = computed(() => store.batchingOutputKey === props.outputKey)
+</script>
+`
+
+const buggyErrors = checkBatchAnyInFlightGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  6,
+  'expected the pre-fix shape to raise 1 "missing anyBatching" error plus ' +
+    `5 per-button violations (one per :disabled="...batching..." ` +
+    `attribute), got ${buggyErrors.length}: ${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(buggyErrors[0]!.includes(ANY_BATCHING_MISSING_SNIPPET()))
+
+const fixedErrors = checkBatchAnyInFlightGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const partialErrors = checkBatchAnyInFlightGuard(PARTIAL_FIX_FIXTURE)
+assert.equal(
+  partialErrors.length,
+  1,
+  'expected the partial-fix shape (Apply button left on the narrow ' +
+    `batching) to raise exactly 1 error, got ${partialErrors.length}: ` +
+    `${JSON.stringify(partialErrors)}`,
+)
+assert.ok(partialErrors[0]!.includes('batching || !batchValues[field.key]'))
+
+const missingErrors = checkBatchAnyInFlightGuard(MISSING_FIXTURE)
+assert.equal(
+  missingErrors.length,
+  2,
+  'expected the anyBatching-computed-absent shape to raise the ' +
+    `"missing anyBatching" error plus 1 per-button violation, got ` +
+    `${missingErrors.length}: ${JSON.stringify(missingErrors)}`,
+)
+
+function ANY_BATCHING_MISSING_SNIPPET(): string {
+  return 'Could not find `const anyBatching = computed(() => store.batchingOutputKey !== null)`'
+}
+
+console.log(
+  'Model Builder batch any-in-flight guard checker verified: flags the ' +
+    'pre-fix shape (every button gates on the narrow per-group `batching`), ' +
+    'clears the fixed shape, flags a partial fix that leaves one button ' +
+    'behind, and flags the anyBatching computed being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderBatchAnyInFlightGuard.ts
+++ b/utils/scripts/verifyModelBuilderBatchAnyInFlightGuard.ts
@@ -1,0 +1,122 @@
+// /utils/scripts/verifyModelBuilderBatchAnyInFlightGuard.ts
+//
+// Regression guard (model-builder/t-029) -- model-builder-batch-editor.vue's
+// action buttons (Draft pitches/fields/prompts, Approve fields, Auto-build
+// group, Apply-a-field) used to gate only on `batching`, a computed scoped to
+// THIS component instance's own `props.outputKey`
+// (`store.batchingOutputKey === props.outputKey`). batchingOutputSingleton
+// (modelBuilderStore.ts) is a single store-wide slot, not one per group --
+// claiming it is an unconditional overwrite (createOwnedSingleton's own doc
+// comment), so it only reliably tracks the MOST RECENTLY STARTED batch
+// operation's owner, never "is a batch operation running at all."
+// model-builder-progress-matrix.vue mounts this component keyed by
+// `selectedItem.outputKey` (t-029's earlier batch-editor-key fix) and never
+// disables the row clicks that change the selected item/group. So switching
+// to a different quantity group while this group's batchDraftField/
+// batchSetField/batchAutoBuild is still running unmounts this instance and
+// mounts a fresh one for the new group, whose own `batching` reads false
+// even though the old group's operation is still in flight -- every action
+// button stayed clickable, letting the user start a second, fully
+// concurrent batch operation. That races draftText's shared draftingField
+// singleton, defeats batchDraftField's "sequentially, so we don't hammer the
+// text server" design, and lets the two operations' unscoped setStatus()
+// completion toasts silently clobber each other.
+//
+// Fixed by adding `anyBatching = computed(() => store.batchingOutputKey !==
+// null)` and gating every action button's `:disabled` on it instead of the
+// narrow `batching` (which stays only for this group's own header spinner)
+// -- mirrors item-panel.vue's isAnyDraftInFlight (gates every field's
+// controls on ANY draft being in flight, not just the matching one).
+//
+// This asserts the textual shape of that fix stays in place: an
+// `anyBatching` computed keyed off `store.batchingOutputKey !== null`, and
+// every action-button `:disabled` attribute in the file using it (never the
+// bare `batching` alone) -- deliberately scoped to this one bug shape,
+// mirroring this project's other narrow textual guards over a general-
+// purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const BATCH_EDITOR_PATH = join(
+  repositoryRoot,
+  'components/model-builder/model-builder-batch-editor.vue',
+)
+
+const ANY_BATCHING_DEF =
+  'const anyBatching = computed(() => store.batchingOutputKey !== null)'
+
+// Every `:disabled="..."` attribute in the file that references the batching
+// state must use `anyBatching`, not the narrow per-group `batching` alone.
+// Case-insensitive so this matches both the narrow `batching` and
+// `anyBatching` itself (whose own substring is "Batching", capital B).
+const DISABLED_ATTR_PATTERN = /:disabled="([^"]*batching[^"]*)"/gi
+
+export function checkBatchAnyInFlightGuard(content: string): string[] {
+  const errors: string[] = []
+
+  if (!content.includes(ANY_BATCHING_DEF)) {
+    errors.push(
+      `Could not find \`${ANY_BATCHING_DEF}\` in model-builder-batch-editor.vue ` +
+        '-- without a store-wide "is ANY batch operation in flight" computed, ' +
+        "a button's :disabled can only key off this group's own narrow " +
+        '`batching`, which reads false the instant a different quantity ' +
+        "group's batch operation becomes the singleton's current owner, even " +
+        "though THIS group's own operation may still be running.",
+    )
+  }
+
+  const matches = [...content.matchAll(DISABLED_ATTR_PATTERN)]
+  if (matches.length === 0) {
+    errors.push(
+      'Could not find any `:disabled="...batching..."` attribute in ' +
+        'model-builder-batch-editor.vue -- has the batching gate been ' +
+        'renamed or restructured? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+  }
+
+  for (const match of matches) {
+    const expression = match[1] ?? ''
+    if (!expression.includes('anyBatching')) {
+      errors.push(
+        `Found \`:disabled="${expression}"\` gating on the narrow, ` +
+          'per-group `batching` computed instead of `anyBatching` -- this ' +
+          "button stays clickable while a DIFFERENT quantity group's batch " +
+          'operation is still running, letting two batch operations run ' +
+          'concurrently.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(BATCH_EDITOR_PATH, 'utf8')
+  const errors = checkBatchAnyInFlightGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder batch any-in-flight guard contract failed for ' +
+        'model-builder-batch-editor.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder batch any-in-flight guard contract passed: every action ' +
+      "button gates on anyBatching (ANY group's batch operation in flight), " +
+      'so switching quantity groups can no longer start a second, concurrent ' +
+      'batch operation while the first is still running.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
Recurring model-builder/t-029 bug-hunt cycle.

## Bug

`model-builder-batch-editor.vue`'s action buttons (Draft pitches/fields/prompts, Approve fields, Auto-build group, Apply-a-field) gated only on `batching`, a computed scoped to the component's own `outputKey` (`store.batchingOutputKey === props.outputKey`). `batchingOutputSingleton` is a single store-wide slot, not one per group — claiming it is an unconditional overwrite, so it only reliably tracks the most-recently-started batch operation's owner, never "is a batch operation running at all."

`model-builder-progress-matrix.vue` mounts the batch editor keyed by `selectedItem.outputKey` (an earlier t-029 fix) and never disables the row clicks that change the selected item/group. So switching to a different quantity group while this group's `batchDraftField`/`batchSetField`/`batchAutoBuild` is still running unmounts this instance and mounts a fresh one for the new group, whose own `batching` reads false even though the old group's operation is still in flight — every action button stayed clickable, letting the user start a second, fully concurrent batch operation. That races `draftText`'s shared `draftingField` singleton, defeats `batchDraftField`'s "sequentially, so we don't hammer the text server" design, and lets the two operations' unscoped `setStatus()` completion toasts silently clobber each other.

## Fix

Added `anyBatching = computed(() => store.batchingOutputKey !== null)` and gated every action button's `:disabled` on it instead of the narrow `batching` (which stays only for this group's own header spinner) — mirrors `item-panel.vue`'s `isAnyDraftInFlight` (gates every field's controls on ANY draft being in flight, not just the matching one).

Added `verifyModelBuilderBatchAnyInFlightGuard.ts` + `.test.ts` following the established narrow-textual-checker convention, wired into `package.json` and `contract-tests.yml`.

## Verification

- New guard self-test + guard pass.
- All 26 pre-existing `verifyModelBuilder*` guards + self-tests pass (no regression).
- `eslint` clean on touched files.
- `prettier --check` clean on all touched/new files.
- `vue-tsc --noEmit -p tsconfig.json` exits 0 repo-wide.
- `git status --porcelain` shows exactly the 5 intended files.

## Flags for Reviewer

None — front-end/store + test-only change, no schema change, reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPaGKSThAGczCQAN8EPrqs)_