### PR TITLE
fix(davinci): stop the resolve panel stacking under a narration-error retry

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -236,6 +236,12 @@ jobs:
       - name: Da Vinci narration-error tone guard
         run: npm run test:davinci-narration-error-tone-guard
 
+      - name: Da Vinci resolve-panel guard self-test
+        run: npm run test:davinci-resolve-panel-guard-selftest
+
+      - name: Da Vinci resolve-panel guard
+        run: npm run test:davinci-resolve-panel-guard
+
       - name: Serendipity Voice poll guard self-test
         run: npm run test:serendipity-voice-poll-guard-selftest
 

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -231,9 +231,19 @@
 
           <!-- The run may be ended any time after chapter 3 (narration-layer
                spec): enough chapters for a meaningful spread of dimensions.
-               The narrator never decides when a life ends — the player does. -->
+               The narrator never decides when a life ends — the player does.
+               Excluded while narrationError is set: narrateChapter() clears
+               aiChapter (making currentChapter null) *before* the request
+               that then fails, so without the narrationError exclusion
+               `!currentChapter` reads true during a narration failure too —
+               stacking this "See your ending" panel underneath the
+               narration-error retry panel with the misleading "Your
+               chapters are told" copy, even at chapter 1 with zero recorded
+               choices. -->
           <div
-            v-if="!narrating && (canEndRun || !currentChapter)"
+            v-if="
+              !narrating && !narrationError && (canEndRun || !currentChapter)
+            "
             class="flex flex-col items-center gap-3 rounded-2xl border border-primary/30 bg-primary/5 p-6 text-center"
           >
             <Icon name="kind-icon:trophy" class="size-8 text-primary/70" />

--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
     "test:davinci-dimension-tone-guard": "tsx utils/scripts/verifyDaVinciDimensionToneGuard.ts",
     "test:davinci-narration-error-tone-guard-selftest": "tsx utils/scripts/verifyDaVinciNarrationErrorToneGuard.test.ts",
     "test:davinci-narration-error-tone-guard": "tsx utils/scripts/verifyDaVinciNarrationErrorToneGuard.ts",
+    "test:davinci-resolve-panel-guard-selftest": "tsx utils/scripts/verifyDaVinciResolvePanelGuard.test.ts",
+    "test:davinci-resolve-panel-guard": "tsx utils/scripts/verifyDaVinciResolvePanelGuard.ts",
     "test:serendipity-voice-poll-guard-selftest": "tsx utils/scripts/verifySerendipityVoicePollGuard.test.ts",
     "test:serendipity-voice-poll-guard": "tsx utils/scripts/verifySerendipityVoicePollGuard.ts",
     "test:achievement-store": "tsx utils/scripts/verifyAchievementStoreFetchSafety.ts",

--- a/utils/scripts/verifyDaVinciResolvePanelGuard.test.ts
+++ b/utils/scripts/verifyDaVinciResolvePanelGuard.test.ts
@@ -1,0 +1,98 @@
+// /utils/scripts/verifyDaVinciResolvePanelGuard.test.ts
+//
+// Regression test for checkResolvePanelGuard() in
+// verifyDaVinciResolvePanelGuard.ts (davinci/t-021 slice 3). Exercises the
+// real check against synthetic component-shaped fixtures covering: the
+// fixed shape (narrationError excluded), the pre-fix shape (narrationError
+// not excluded, letting the resolve panel stack under the narration-error
+// panel), a narrating-not-excluded regression, a canEndRun-dropped
+// regression, and a missing-condition regression (the resolve panel
+// removed/restructured entirely).
+import assert from 'node:assert/strict'
+
+import { checkResolvePanelGuard } from './verifyDaVinciResolvePanelGuard.js'
+
+function fixture(condition: string): string {
+  return `
+<template>
+  <div
+    v-if="${condition}"
+    class="flex flex-col items-center gap-3 rounded-2xl border border-primary/30 bg-primary/5 p-6 text-center"
+  >
+    <button type="button" @click="resolveLife">See your ending</button>
+  </div>
+</template>
+`
+}
+
+const FIXED = fixture(
+  '!narrating && !narrationError && (canEndRun || !currentChapter)',
+)
+
+// Pre-fix shape: narrationError not excluded, so the panel renders stacked
+// under the narration-error retry panel whenever currentChapter is null
+// (which is always true while narrationError is set).
+const BUGGY = fixture('!narrating && (canEndRun || !currentChapter)')
+
+// narrating no longer excluded.
+const NARRATING_NOT_EXCLUDED = fixture(
+  '!narrationError && (canEndRun || !currentChapter)',
+)
+
+// canEndRun dropped entirely.
+const CAN_END_RUN_DROPPED = fixture(
+  '!narrating && !narrationError && !currentChapter',
+)
+
+// The resolve panel itself -- and its resolveLife button -- no longer
+// exists at all.
+const CONDITION_REMOVED = `
+<template>
+  <div v-if="phase === 'ending'">
+    <p>This life has ended.</p>
+  </div>
+</template>
+`
+
+function run(): void {
+  const fixedErrors = checkResolvePanelGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const buggyErrors = checkResolvePanelGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    1,
+    `expected the pre-fix fixture to fail exactly one check, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(
+    buggyErrors.some((e) => /no longer excludes `narrationError`/.test(e)),
+  )
+
+  const narratingErrors = checkResolvePanelGuard(NARRATING_NOT_EXCLUDED)
+  assert.equal(narratingErrors.length, 1)
+  assert.ok(
+    narratingErrors.some((e) => /no longer excludes `narrating`/.test(e)),
+  )
+
+  const canEndRunErrors = checkResolvePanelGuard(CAN_END_RUN_DROPPED)
+  assert.equal(canEndRunErrors.length, 1)
+  assert.ok(
+    canEndRunErrors.some((e) => /no longer references `canEndRun`/.test(e)),
+  )
+
+  const removedErrors = checkResolvePanelGuard(CONDITION_REMOVED)
+  assert.equal(removedErrors.length, 1)
+  assert.ok(removedErrors.some((e) => /Could not find a `<div v-if=/.test(e)))
+
+  console.log(
+    'Da Vinci resolve-panel guard self-test passed: buggy fixture fails, ' +
+      'fixed fixture passes, narrating-not-excluded, canEndRun-dropped, and ' +
+      'missing-condition regressions all fail.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyDaVinciResolvePanelGuard.ts
+++ b/utils/scripts/verifyDaVinciResolvePanelGuard.ts
@@ -1,0 +1,134 @@
+// /utils/scripts/verifyDaVinciResolvePanelGuard.ts
+//
+// Regression guard (davinci/t-021 slice 3) -- the "See your ending" resolve
+// panel in components/conductor/davinci-page.vue is a standalone `v-if`, not
+// part of the `v-if`/`v-else-if` chain above it that switches between the
+// narrating / narrationError / currentChapter states. Its condition was
+// `!narrating && (canEndRun || !currentChapter)`.
+//
+// narrateChapter() clears `aiChapter` (making the `currentChapter` computed
+// null) *before* sending the request that can then fail, and only
+// repopulates it on success. So while a narration failure is being shown --
+// `narrating` is false and `narrationError` is set -- `currentChapter` is
+// also null, which made `!currentChapter` true. The resolve panel rendered
+// stacked underneath the narration-error retry panel, offering "See your
+// ending" with the misleading copy "Your chapters are told. It's time to
+// see how this life resolves" at the same time as "Try again" / "Play the
+// written chapters instead" -- even at chapter 1 with zero recorded choices.
+//
+// Fixed by excluding narrationError from the resolve panel's condition:
+// `!narrating && !narrationError && (canEndRun || !currentChapter)`. This
+// asserts the textual shape of that fix stays in place: the resolve panel's
+// `v-if` condition still excludes narrationError, deliberately scoped to
+// this one template condition, mirroring this project's other narrow
+// textual guards over a general-purpose static analyzer (see
+// verifyDaVinciDimensionToneGuard.ts).
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const COMPONENT_PATH = join(
+  repositoryRoot,
+  'components/conductor/davinci-page.vue',
+)
+
+// Anchored on the resolveLife button's click handler rather than any
+// particular wording of the condition itself, so this guard can still
+// report *which* part of the condition regressed instead of just "not
+// found" when e.g. canEndRun is dropped from it.
+const CLICK_MARKER = '@click="resolveLife"'
+
+function extractResolvePanelCondition(content: string): string | null {
+  const clickIndex = content.indexOf(CLICK_MARKER)
+  if (clickIndex === -1) return null
+
+  const tagStart = content.lastIndexOf('<div', clickIndex)
+  if (tagStart === -1) return null
+  const tagEnd = content.indexOf('>', tagStart)
+  if (tagEnd === -1) return null
+  const openingTag = content.slice(tagStart, tagEnd + 1)
+
+  const attrPrefix = 'v-if="'
+  const attrStart = openingTag.indexOf(attrPrefix)
+  if (attrStart === -1) return null
+
+  const valueStart = attrStart + attrPrefix.length
+  const valueEnd = openingTag.indexOf('"', valueStart)
+  if (valueEnd === -1) return null
+
+  return openingTag.slice(valueStart, valueEnd)
+}
+
+export function checkResolvePanelGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const condition = extractResolvePanelCondition(content)
+  if (!condition) {
+    errors.push(
+      'Could not find a `<div v-if="...">` wrapping a ' +
+        `\`${CLICK_MARKER}\` button in davinci-page.vue -- has the ` +
+        'resolve/ending panel been restructured or removed? If so, this ' +
+        'guard needs to move with it.',
+    )
+    return errors
+  }
+
+  if (!condition.includes('!narrationError')) {
+    errors.push(
+      "The resolve/ending panel's v-if condition no longer excludes " +
+        '`narrationError` -- this is the exact bug this guard exists to ' +
+        'catch: narrateChapter() clears aiChapter (making currentChapter ' +
+        'null) before a request that then fails, so without this exclusion ' +
+        '`!currentChapter` is also true during a narration failure and the ' +
+        '"See your ending" panel renders stacked underneath the ' +
+        'narration-error retry panel with a misleading "chapters are told" ' +
+        'message -- even at chapter 1 with zero recorded choices.',
+    )
+  }
+
+  if (!condition.includes('!narrating')) {
+    errors.push(
+      "The resolve/ending panel's v-if condition no longer excludes " +
+        '`narrating` -- the panel could render while the narrator is still ' +
+        'composing the current chapter.',
+    )
+  }
+
+  if (!condition.includes('canEndRun')) {
+    errors.push(
+      "The resolve/ending panel's v-if condition no longer references " +
+        '`canEndRun` -- has the "end any time after chapter 3" rule been ' +
+        'dropped?',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(COMPONENT_PATH, 'utf8')
+  const errors = checkResolvePanelGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Da Vinci resolve-panel guard contract failed in davinci-page.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Da Vinci resolve-panel guard contract passed: the "See your ending" ' +
+      'panel stays excluded while a narration error is being shown, so it ' +
+      "never stacks underneath the narration-error retry panel's " +
+      'contradictory "chapters are told" copy.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What

davinci/t-021 slice 3 (conductor project) — one concrete, verifiable interaction bug in `components/conductor/davinci-page.vue`'s resolve panel, following the same "one bounded gap, not a reskin" convention as the prior two slices (kind_robots #1842, #1854).

## The bug

The "See your ending" resolve panel is a standalone `v-if`, not part of the `v-if`/`v-else-if` chain that switches between the narrating / narrationError / currentChapter states above it:

```
v-if="!narrating && (canEndRun || !currentChapter)"
```

`narrateChapter()` sets `aiChapter.value = null` *before* sending the request, and only repopulates it on success — on failure it sets `narrationError` and returns, leaving `aiChapter` (and thus the `currentChapter` computed) null. So while a narration failure is being shown (`narrating` false, `narrationError` set), `currentChapter` is also null, making `!currentChapter` true. Result: the resolve panel rendered stacked underneath the narration-error retry panel, showing "See your ending" with "Your chapters are told. It's time to see how this life resolves" at the same time as "Try again" / "Play the written chapters instead" — even at chapter 1 with zero recorded choices. Two contradictory calls-to-action any time AI narration fails.

## Fix

Excluded `narrationError` from the condition: `!narrating && !narrationError && (canEndRun || !currentChapter)`, plus an explanatory comment.

## Verification

- New guard (`verifyDaVinciResolvePanelGuard.ts` + `.test.ts`, following the existing `verifyDaVinciDimensionToneGuard`/`verifyDaVinciNarrationErrorToneGuard` convention) + selftest pass
- Both prior davinci guards + selftests still pass
- `test:davinci-narration` still passes
- `test:layout-contract` holds, no new violations
- eslint clean on touched/new files
- prettier clean on touched/new files
- `vue-tsc --noEmit` (full project) exits 0
- `git status --porcelain` shows exactly the 5 intended files

---
_Generated by [Claude Code](https://claude.ai/code/session_01BiB3VJXxmc9dwFMba2rnAk)_