### PR TITLE
Fix the facet-catalog-maintenance failure, drop the MOOD pick it exposed, and give dream locations art

### DIFF
--- a/.github/workflows/facet-catalog-contract.yml
+++ b/.github/workflows/facet-catalog-contract.yml
@@ -59,6 +59,12 @@ jobs:
       - name: Verify final Facet catalog directives
         run: npx tsx utils/scripts/verifyFacetCatalogDirectives.ts
 
+      # Curation creates MOOD rows; the directives step asserts none remain.
+      # Without this the disagreement only surfaces sixteen minutes into a
+      # production maintenance run, after the delete step has already committed.
+      - name: Verify curated MOOD definitions have a migration
+        run: npx tsx utils/scripts/verifyFacetCurationMoodPolicy.ts
+
       - name: Verify retired Facet cleanup and artwork queue
         run: npx tsx utils/scripts/verifyFacetCatalogMaintenance.ts
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "audit:fitness": "tsx utils/scripts/auditObjectFitness.ts",
     "test:migrate-on-deploy": "tsx utils/scripts/verifyMigrateOnDeploy.ts",
     "test:facet-aliases": "tsx utils/scripts/verifyFacetAliases.ts",
-    "test:facet-catalog": "prisma validate && tsx utils/scripts/verifyFacetCatalogCutover.ts && tsx utils/scripts/verifyFacetCanonicalMerges.ts && tsx utils/scripts/verifyDailyDreamFacets.ts",
+    "test:facet-catalog": "prisma validate && tsx utils/scripts/verifyFacetCatalogCutover.ts && tsx utils/scripts/verifyFacetCanonicalMerges.ts && tsx utils/scripts/verifyDailyDreamFacets.ts && tsx utils/scripts/verifyFacetCurationMoodPolicy.ts",
     "test:facet-closure": "tsx utils/scripts/verifyFacetClosure.ts",
     "test:facet-gallery": "tsx utils/scripts/verifyFacetGallery.ts",
     "test:layout-contract": "tsx utils/scripts/verifyLayoutContract.ts",

--- a/server/api/challenges/variants.post.ts
+++ b/server/api/challenges/variants.post.ts
@@ -39,7 +39,8 @@ const FACET_PLACEHOLDERS: Record<string, FacetTaxonomy[]> = {
   quirk: ['QUIRK'],
   theme: ['THEME'],
   style: ['STYLE'],
-  mood: ['MOOD'],
+  // MOOD is empty by policy; narrative tone lives in THEME. See randomStore.
+  mood: ['THEME'],
   setting: ['SETTING'],
   core: ['CORE'],
   artdirection: ['ART_DIRECTION', 'PROMPT_ENHANCEMENT'],

--- a/server/utils/dailyDreamFacetBlueprint.ts
+++ b/server/utils/dailyDreamFacetBlueprint.ts
@@ -56,10 +56,30 @@ export type DailyDreamNarratorBlueprint = {
   facets: DailyDreamFacetUse[]
 }
 
+/**
+ * A location has no `mood`.
+ *
+ * It used to. The field was fed by `one('MOOD')`, and the facet catalog no
+ * longer has a MOOD taxonomy to draw from -- `applyFacetCatalogDirectives`
+ * migrates narrative tone to THEME and then asserts zero MOOD profiles remain.
+ * So the pick had been silently returning null and every location was already
+ * being built with `mood: ''` before this field was removed; dropping it
+ * changes the type, not the output.
+ *
+ * ART_DIRECTION is not the substitute it looks like. Its eight `art-atmosphere`
+ * rows (Serene, Melancholy, Ominous, Dreamlike...) are all
+ * `isRandomizable: false`, so a randomizable pick from that taxonomy returns art
+ * SUBJECTS instead -- a location's atmosphere would come out as "Landscape".
+ *
+ * Silas, 2026-08-13: "a mood is not a hard set thing anyway, it's like hard
+ * setting a character with emotion. As my clown teacher said: every character
+ * can experience every emotion." A place is the same. The Dream's THEME already
+ * carries tone for the whole piece; pinning a second, different one per location
+ * was fixing something that reads better unfixed.
+ */
 export type DailyDreamLocationBlueprint = {
   name: string
   setting: string
-  mood: string
   description: string
   facets: DailyDreamFacetUse[]
 }
@@ -268,11 +288,11 @@ export async function buildDailyDreamFacetBlueprint(options: {
 
   const genre = one('GENRE')
   const theme = one('THEME')
-  const mood = one('MOOD')
   const setting = one('SETTING')
   const style = one('STYLE')
   const color = one('COLOR')
-  const dreamEntries = [genre, theme, mood, setting, style, color].filter(
+  // No MOOD pick: the taxonomy is empty by policy. See DailyDreamLocationBlueprint.
+  const dreamEntries = [genre, theme, setting, style, color].filter(
     (entry): entry is FacetCatalogEntry => Boolean(entry),
   )
   const dreamValues = dreamEntries.map(value)
@@ -311,19 +331,15 @@ export async function buildDailyDreamFacetBlueprint(options: {
   // Two locations so a Dream spans more than one place (spec: 2 locations).
   const locationEntries = weightedMany(pool('SETTING'), 2, random)
   const locations: DailyDreamLocationBlueprint[] = locationEntries.map(
-    (entry, index) => {
-      const locationMood = index === 0 ? mood : one('MOOD')
+    (entry) => {
       const settingValue = value(entry) || 'A place that should not exist'
-      const moodValue = value(locationMood)
       return {
         name: settingValue,
         setting: settingValue,
-        mood: moodValue,
-        description: `${settingValue}${moodValue ? `, ${moodValue.toLowerCase()}` : ''} — one of the two places this Dream unfolds.`,
-        facets: [
-          use(entry, 'location'),
-          use(locationMood, 'locationMood'),
-        ].filter((item): item is DailyDreamFacetUse => Boolean(item)),
+        description: `${settingValue} — one of the two places this Dream unfolds.`,
+        facets: [use(entry, 'location')].filter(
+          (item): item is DailyDreamFacetUse => Boolean(item),
+        ),
       }
     },
   )

--- a/stores/randomStore.ts
+++ b/stores/randomStore.ts
@@ -43,7 +43,11 @@ const RANDOM_KEY_TAXONOMIES: Record<string, FacetTaxonomy[]> = {
   theme: ['THEME'],
   style: ['STYLE'],
   palette: ['COLOR'],
-  mood: ['MOOD'],
+  // MOOD is empty by policy -- the directives migrate narrative tone to THEME
+  // and assert no MOOD profiles remain. A `{mood}` placeholder pointed at the
+  // old taxonomy resolves to nothing at all, so it reads THEME, which is where
+  // those rows now live.
+  mood: ['THEME'],
   setting: ['SETTING'],
   core: ['CORE'],
   artDirection: ['ART_DIRECTION', 'PROMPT_ENHANCEMENT'],

--- a/utils/scripts/publishDreamLocations.ts
+++ b/utils/scripts/publishDreamLocations.ts
@@ -20,6 +20,28 @@
 // Nothing here deletes or unpublishes. If a location turns out to be wrong the
 // repair is to unpublish that one row by hand, which is a smaller and more
 // reversible operation than anything this script could do on its own.
+//
+// ART -- the gap this lane shipped with
+// ------------------------------------
+// The first run created sixteen LOCATION Dreams and queued art for none of
+// them. Nothing failed and nothing warned; every new world simply arrived with
+// `artPrompt: null, artImageId: null, imagePath: null` and stayed that way,
+// which is why Silas saw no spike in the art queue and asked (2026-08-13):
+// "did the new objects, such as locations, get artjobs queued? We should have
+// an artjob for each new object."
+//
+// He should not have had to ask. A creation lane that leaves its objects
+// pictureless is not finished, so this script now enqueues art for every
+// location that has none -- newly created OR adopted, which makes the same code
+// path the backfill for the sixteen already out there.
+//
+// Art costs mana and GPU time, so it is opt-in per run:
+//
+//   KR_API_BASE=https://kindrobots.org KR_API_TOKEN=... \
+//     npx tsx utils/scripts/publishDreamLocations.ts --queue-art
+//
+// Without --queue-art the script still counts the art-less locations and says
+// so on the way out. The one thing it will not do again is finish quietly.
 import { readFileSync, readdirSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
 import prisma from '@/server/utils/prisma'
@@ -54,9 +76,76 @@ async function serial<T extends readonly (() => Promise<unknown>)[]>(
 }
 
 const DRY_RUN = process.argv.includes('--dry-run')
+const QUEUE_ART = process.argv.includes('--queue-art')
 const OWNER_USER_ID = 1
 const EXPECTED_RELEASE_GATE = 'GPT-5.6 Sol'
 const dir = join(process.cwd(), 'config', 'dream-locations')
+
+// dream.imagePath is the primary slot in ENTITY_FIELDS -- 512x768, the same
+// portrait shape every other Dream card renders at.
+const DREAM_ART = { field: 'imagePath', width: 512, height: 768 } as const
+
+/**
+ * A location's art prompt, built from what the location already says.
+ *
+ * Deliberately not invented: title, then flavor text, then description, joined
+ * and truncated. `buildEntityArtPrompt` on the server enriches whatever it
+ * receives, so this only has to supply the world's own creative seed. A
+ * location with nothing to say gets no job rather than a generic one.
+ */
+function artPromptFor(location: DreamLocation): string {
+  const seen = new Set<string>()
+  const prompt = [location.title, location.flavorText, location.description]
+    .map((value) => (typeof value === 'string' ? value.trim() : ''))
+    .filter((value) => value && !seen.has(value) && seen.add(value))
+    .join('. ')
+  return prompt.length >= 3 ? prompt.slice(0, 900) : ''
+}
+
+async function enqueueLocationArt(
+  base: string,
+  token: string,
+  dreamId: number,
+  prompt: string,
+): Promise<number> {
+  const response = await fetch(`${base.replace(/\/$/, '')}/api/art/enqueue`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      engine: 'krea2',
+      promptString: prompt,
+      width: DREAM_ART.width,
+      height: DREAM_ART.height,
+      isPublic: true,
+      isMature: false,
+      designer: LOCATION_DESIGNER,
+      projectSlug: 'dream-locations',
+      entityArt: {
+        entityType: 'dream',
+        entityId: dreamId,
+        field: DREAM_ART.field,
+        preserveOriginal: true,
+        mode: 'recreate',
+      },
+    }),
+  })
+
+  const body = (await response.json().catch(() => null)) as {
+    success?: boolean
+    message?: string
+    data?: { jobId?: number }
+  } | null
+
+  if (!response.ok || !body?.success || !body.data?.jobId) {
+    throw new Error(
+      `Dream #${dreamId}: HTTP ${response.status} ${body?.message || 'enqueue failed'}`,
+    )
+  }
+  return Number(body.data.jobId)
+}
 
 function loadLocations(): DreamLocation[] {
   if (!existsSync(dir)) throw new Error(`No batch directory at ${dir}.`)
@@ -99,7 +188,9 @@ async function main() {
   const [existingDreams, scenarios, owner] = await serial([
     // Whole tables, filtered in memory -- a large IN list hung another lane's
     // dry run for fourteen minutes through ProxySQL.
-    () => prisma.dream.findMany({ select: { id: true, slug: true, title: true } }),
+    () => prisma.dream.findMany({
+      select: { id: true, slug: true, title: true, imagePath: true },
+    }),
     () => prisma.scenario.findMany({
       select: { id: true, title: true, isPublic: true, isActive: true },
     }),
@@ -157,12 +248,21 @@ async function main() {
     return
   }
 
+  const artBase = process.env.KR_API_BASE || ''
+  const artToken = process.env.KR_API_TOKEN || ''
+  if (QUEUE_ART && (!artBase || !artToken)) {
+    throw new Error('--queue-art requires KR_API_BASE and KR_API_TOKEN.')
+  }
+
   let created = 0
   let adopted = 0
   let linked = 0
+  let artQueued = 0
+  const artless: string[] = []
 
   for (const location of locations) {
-    let dreamId = bySlug.get(location.slug)?.id
+    const existing = bySlug.get(location.slug)
+    let dreamId = existing?.id
     if (dreamId) {
       adopted += 1
     } else {
@@ -195,16 +295,49 @@ async function main() {
       linked += 1
     }
 
+    // A location the run just created has no art by definition; an adopted one
+    // may still be carrying the gap this lane shipped with.
+    let jobId: number | null = null
+    if (!existing?.imagePath) {
+      const prompt = artPromptFor(location)
+      if (!prompt) {
+        console.log(
+          'LOCATION_ART_SKIPPED',
+          JSON.stringify({ slug: location.slug, reason: 'no prompt source' }),
+        )
+      } else if (QUEUE_ART) {
+        jobId = await enqueueLocationArt(artBase, artToken, dreamId, prompt)
+        artQueued += 1
+      } else {
+        artless.push(location.slug)
+      }
+    }
+
     console.log(
       'LOCATION_DONE',
-      JSON.stringify({ slug: location.slug, dreamId, scenarios: location.scenarioIds.length }),
+      JSON.stringify({
+        slug: location.slug,
+        dreamId,
+        scenarios: location.scenarioIds.length,
+        artJobId: jobId,
+      }),
     )
   }
 
   console.log(
     'LOCATIONS_COMPLETE',
-    JSON.stringify({ created, adopted, linked }),
+    JSON.stringify({ created, adopted, linked, artQueued }),
   )
+
+  // Never finish quietly on art-less worlds again -- that silence is the whole
+  // reason the first sixteen went out pictureless.
+  if (artless.length) {
+    console.warn(
+      `\n${artless.length} location(s) have no art and none was queued: ` +
+        `${artless.join(', ')}\n` +
+        'Re-run with KR_API_BASE, KR_API_TOKEN and --queue-art to give them one.',
+    )
+  }
 }
 
 await main()

--- a/utils/scripts/verifyDailyDreamFacets.ts
+++ b/utils/scripts/verifyDailyDreamFacets.ts
@@ -103,6 +103,13 @@ async function main(): Promise<void> {
     "use(rewardTypeFacet, 'rewardType')",
   )
 
+  // The blueprint must not draw from MOOD. applyFacetCatalogDirectives migrates
+  // narrative tone to THEME and then asserts no MOOD profiles remain, so a pick
+  // from that taxonomy silently returns null -- which is how every daily dream
+  // came to be built with an empty atmosphere and nobody noticed. Re-adding the
+  // pick would restore the silence, not the facet.
+  forbidText(files.blueprint, text.blueprint, "one('MOOD')")
+
   requireText(files.endpoint, text.endpoint, 'validDateKey(dateKey)')
   requireText(files.endpoint, text.endpoint, 'rewardType: reward.rewardType')
   requireText(files.endpoint, text.endpoint, 'tx.dreamFacet.createMany')

--- a/utils/scripts/verifyFacetCurationMoodPolicy.ts
+++ b/utils/scripts/verifyFacetCurationMoodPolicy.ts
@@ -1,0 +1,112 @@
+// /utils/scripts/verifyFacetCurationMoodPolicy.ts
+//
+// Every curated MOOD definition must be one the directives step knows how to
+// migrate. Offline; no database.
+//
+//   npx tsx utils/scripts/verifyFacetCurationMoodPolicy.ts
+//
+// WHY
+// ---
+// The facet maintenance run is a serialized sequence, and two of its steps
+// disagree about MOOD unless somebody keeps them in sync by hand:
+//
+//   curateFacetCatalog        applies FACET_CURATION_BATCHES, upserting each
+//                             definition's taxonomy verbatim -- so a mood()
+//                             definition CREATES a MOOD profile.
+//
+//   applyFacetCatalogDirectives  reclassifies the four slugs in its
+//                             NARRATIVE_TONES constant to THEME, then asserts
+//                             `Expected zero MOOD profiles`.
+//
+// A MOOD definition that is not in NARRATIVE_TONES therefore survives its own
+// migration and fails the post-condition. The failure is expensive out of all
+// proportion to the mistake: it surfaces sixteen minutes into a production run
+// that has already merged duplicates and DELETED historical shell rows, so the
+// exit code reads like a rollback when nothing rolled back at all.
+//
+// That happened on 2026-08-13 (run 31703186995). A genre-vocabulary batch added
+// mood('elegiac-wonder') -- correct instinct, wrong taxonomy, since the catalog
+// policy is "art atmosphere is ART_DIRECTION, story tone is THEME" -- and a
+// second one, mood('borrowed-light-bittersweet'), was already queued to fail
+// the same way on the following run.
+//
+// This check is deliberately a PAIRING rule rather than a ban. The two
+// legitimate mood() definitions (emotionally-intimate, tender) are declared
+// MOOD and migrated to THEME by the directives on purpose; outlawing MOOD
+// outright would force a rewrite of a working arrangement. What must never
+// happen again is a MOOD definition with nothing to migrate it.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { FACET_CURATION_BATCHES } from './../../utils/seeds/facetCatalogCuration'
+
+const root = process.cwd()
+const directivePath = join(
+  root,
+  'utils/scripts/applyFacetCatalogDirectives.ts',
+)
+const directive = readFileSync(directivePath, 'utf8')
+
+/**
+ * The NARRATIVE_TONES array, read out of the directive source.
+ *
+ * Parsed from text rather than imported because applyFacetCatalogDirectives
+ * opens a Prisma client and runs `main()` on import -- importing it here would
+ * try to reach production from a contract test.
+ */
+function narrativeToneSlugs(): Set<string> {
+  const block = directive.match(
+    /const NARRATIVE_TONES = \[([\s\S]*?)\] as const/,
+  )?.[1]
+  assert.ok(
+    block,
+    'Could not find the NARRATIVE_TONES array in applyFacetCatalogDirectives.ts. ' +
+      'If it was renamed, update this contract rather than deleting it.',
+  )
+  const slugs = [...block.matchAll(/'([^']+)'/g)].map((match) => match[1] || '')
+  assert.ok(
+    slugs.length > 0,
+    'NARRATIVE_TONES parsed as empty; the regex above no longer matches the source.',
+  )
+  return new Set(slugs)
+}
+
+/** The post-condition this whole check exists to protect. */
+assert.ok(
+  directive.includes("where: { taxonomy: 'MOOD' }") &&
+    directive.includes('Expected zero MOOD profiles'),
+  'applyFacetCatalogDirectives no longer asserts zero MOOD profiles. If that ' +
+    'policy was deliberately dropped, this contract should be dropped with it.',
+)
+
+const tones = narrativeToneSlugs()
+const violations: string[] = []
+let moodDefinitions = 0
+
+for (const batch of FACET_CURATION_BATCHES) {
+  for (const definition of batch.ensures) {
+    if (definition.taxonomy !== 'MOOD') continue
+    moodDefinitions += 1
+    if (!tones.has(definition.slug)) {
+      violations.push(
+        `${batch.id}: mood('${definition.slug}', '${definition.title}') is not in ` +
+          `NARRATIVE_TONES, so nothing will migrate it and the maintenance run ` +
+          `will fail its zero-MOOD post-condition. Use theme() if this is story ` +
+          `tone, or add the slug to NARRATIVE_TONES if it genuinely needs the ` +
+          `narrative-tone group and weight.`,
+      )
+    }
+  }
+}
+
+if (violations.length) {
+  console.error(`Facet curation MOOD policy FAILED (${violations.length}):`)
+  for (const violation of violations) console.error(`  - ${violation}`)
+  process.exit(1)
+}
+
+console.log(
+  `Facet curation MOOD policy verified: ${moodDefinitions} MOOD definition(s) ` +
+    `across ${FACET_CURATION_BATCHES.length} batch(es), all covered by the ` +
+    `${tones.size} slug(s) in NARRATIVE_TONES.`,
+)

--- a/utils/seeds/facetCatalogCuration.ts
+++ b/utils/seeds/facetCatalogCuration.ts
@@ -80,6 +80,26 @@ const theme = (
   aliases,
 })
 
+/**
+ * MOOD, which the catalog policy has abolished. Use with care.
+ *
+ * applyFacetCatalogDirectives ends the maintenance run with a hard
+ * post-condition: zero MOOD profiles may remain. Curation runs BEFORE it in the
+ * same serialized session, so a mood() definition here creates a row that the
+ * later step must then migrate -- and it only migrates the four slugs listed in
+ * its NARRATIVE_TONES constant. Anything else survives, the count comes back
+ * non-zero, and the whole run exits 1 sixteen minutes in.
+ *
+ * That is exactly what happened on 2026-08-13 (run 31703186995): a genre-
+ * vocabulary batch added mood('elegiac-wonder'), which is not a narrative tone
+ * the directives know about, and the run failed on "Expected zero MOOD
+ * profiles, found 1." Note that the throw comes AFTER the deletion step, so the
+ * historical shells were removed and only the exit code looked like a rollback.
+ *
+ * So: a mood() definition is only valid if its slug is also in NARRATIVE_TONES.
+ * verifyFacetCurationMoodPolicy.ts enforces that pairing at commit time. If you
+ * are reaching for this to classify how a story FEELS, you want theme().
+ */
 const mood = (
   slug: string,
   title: string,
@@ -591,7 +611,12 @@ export const FACET_CURATION_BATCHES = [
 
       // --- not genres at all; they are what the story is ABOUT or how it feels
       theme('animal-interiority', 'Animal Interiority'),
-      mood('elegiac-wonder', 'Elegiac Wonder'),
+      // THEME, not MOOD. The catalog policy is "no global MOOD Facets remain;
+      // art atmosphere is ART_DIRECTION, story tone is THEME", and
+      // applyFacetCatalogDirectives enforces it with a hard post-condition.
+      // This arrived as a free-text GENRE string -- how a story feels -- so
+      // THEME is where it belongs. See the note on the mood() helper.
+      theme('elegiac-wonder', 'Elegiac Wonder'),
     ],
     transforms: [],
     weights: [],
@@ -636,7 +661,10 @@ export const FACET_CURATION_BATCHES = [
       // word all three are specialisations of.
       genre('dystopia', 'Dystopia'),
 
-      mood('borrowed-light-bittersweet', 'Borrowed-Light Bittersweet'),
+      // THEME for the same reason as elegiac-wonder above. This one had not
+      // been applied yet, so it never reached production -- but it was queued
+      // to fail the identical zero-MOOD post-condition on the next run.
+      theme('borrowed-light-bittersweet', 'Borrowed-Light Bittersweet'),
     ],
     transforms: [],
     weights: [],


### PR DESCRIPTION
Closes the open question in #1849. Three commits, each a thing that was quietly broken and nobody was told.

## 1. What actually failed

Run [31703186995](https://github.com/silasfelinus/kind_robots/actions/runs/31703186995) exited 1 on:

```
Error: Expected zero MOOD profiles, found 1.
    at main (utils/scripts/applyFacetCatalogDirectives.ts:1077:11)
```

Two steps of the same serialized session disagree about MOOD:

| step | what it does |
|---|---|
| `curateFacetCatalog` | upserts each curation definition's taxonomy **verbatim** — so a `mood()` definition **creates** a MOOD profile |
| `applyFacetCatalogDirectives` | reclassifies the four slugs in `NARRATIVE_TONES` to THEME, then asserts **no MOOD profiles remain** |

A MOOD definition outside that list survives its own migration and fails the post-condition.

**I introduced two of them** in the fitness pass:

- `elegiac-wonder` — applied, live in production as taxonomy MOOD, facet **2068**. This is the row that failed the run.
- `borrowed-light-bittersweet` — in the second batch, **never applied**, and queued to fail the identical assertion on the next run.

Both arrived as free-text GENRE strings the catalog couldn't resolve — *how a story feels*, not how a picture looks — so both are THEME. The policy is stated in the directives themselves: art atmosphere is ART_DIRECTION, story tone is THEME. `curateFacetCatalog` upserts with `update: { taxonomy }`, so correcting the definition migrates the existing row rather than orphaning it.

### Two corrections to #1849

The issue reasoned about this failure and got both parts backwards:

- **"since the failing step *deletes* rows, failing means nothing was deleted."** The throw is *after* `deleteHistoricalShells()`. The thirteen shells were removed and committed; only the exit code looks like a rollback.
- **"Worth confirming it did not leave a transaction open."** It didn't. The log shows `Released database lock kind-robots:facet-catalog-maintenance: yes` before the error, so this was never a candidate for the CI hang it was filed under.

For the record, the CI hang in #1849 also wasn't connection exhaustion — it was `poolProfile: 'long-lived'` holding the event loop open after `main()` resolved. Fixed by `await prisma.$disconnect()` in every publisher.

### The guard

`utils/scripts/verifyFacetCurationMoodPolicy.ts` — offline, no database.

It's a **pairing rule, not a ban**: a `mood()` definition is valid iff its slug is in `NARRATIVE_TONES`. The two legitimate ones (`emotionally-intimate`, `tender`) are declared MOOD and migrated on purpose, and outlawing the taxonomy would force a rewrite of something that works. What must not recur is a MOOD definition with nothing to migrate it — discovered sixteen minutes into a production run that has already deleted rows.

It reads `NARRATIVE_TONES` out of the directive **source text** rather than importing it, because `applyFacetCatalogDirectives` opens a Prisma client and runs `main()` on import. It also asserts the zero-MOOD post-condition still exists, so the check can't quietly become vacuous.

**Proven to fail on three planted violations.** Wired into `npm run test:facet-catalog` and the `facet-catalog-contract` workflow.

## 2. The daily dream loses its mood, on purpose

The first commit flagged this and left it for a decision. Silas made it:

> if we don't have mood anymore, then it's superfluous to include. if there isn't a reasonable substitute, we can drop. It feels like a mood is not a hard set thing anyway, it's like hard setting a character with emotion. As my clown teacher said: every character can experience every emotion.

`dailyDreamFacetBlueprint` picked `one('MOOD')` for the Dream and again for **each location's atmosphere**. With MOOD abolished that pool is empty, so the pick has been returning null and every daily dream was already being built with `mood: ''` and a location description missing its clause. **Removing the field changes the type, not the output.**

ART_DIRECTION was the obvious substitute and doesn't work. Its eight `art-atmosphere` rows are all `isRandomizable: false, randomWeight: 0`, so a randomizable pick from that taxonomy returns art **subjects**:

```
art-subject     Avatar, Abstract, Creature, Group, Landscape, Person, Object, Scene   randomizable ✓
art-atmosphere  Serene, Joyful, Melancholy, Ominous, Grand Scale, Whimsical, Tense,
                Dreamlike                                                             randomizable ✗
```

A location's atmosphere would come out as *Landscape*. So the slot is dropped rather than refilled — the Dream's THEME already carries tone for the whole piece.

`verifyDailyDreamFacets` now **forbids** `one('MOOD')` in the blueprint, so re-adding the pick restores the silence rather than the facet. Proven by planting it.

Two placeholder maps pointed at the same dead taxonomy — `stores/randomStore.ts` and the challenge variant pools in `server/api/challenges/variants.post.ts`. Both now read `THEME`, which is where those rows actually went, so a `{mood}` placeholder resolves to something again.

## 3. Dream locations were shipping without art

Silas asked whether the new objects got ArtJobs. They did not — not one.

`publishDreamLocations` created sixteen LOCATION Dreams and queued art for none of them. Nothing failed and nothing warned; every world arrived with `artPrompt`, `artImageId` and `imagePath` all null and stayed that way. That is exactly why the queue never spiked.

**Verified against production before changing anything, with the queue walked in full rather than sampled.** `/api/art/queue` pages on `page` + `pageSize` (max 200) and **ignores `take`/`skip` entirely** — an earlier scan had only seen the first 20 of 74 PENDING jobs and its negative result meant nothing. Walked properly:

```
PENDING  74   RUNNING  3   FAILED  0
  73 PENDING + 2 RUNNING   facet-catalog
   1 PENDING + 1 RUNNING   ai-art-academy
```

None reference any of the sixteen locations, and `ArtJob` carries no dream-linkage column at all.

The lane now enqueues `dream/imagePath` art through `/api/art/enqueue` for every location that has none — newly created **or adopted**, which makes the same code path the backfill for the sixteen already out there. Prompts come from the location's own title, flavor text and description; a location with nothing to say gets no job rather than a generic one.

Art costs mana and GPU time, so the enqueue is opt-in per run behind `--queue-art` plus `KR_API_BASE`/`KR_API_TOKEN`. Without it the script still counts the art-less locations and names them on the way out. The one thing it will not do again is finish quietly.

## Verification

- `npm run test:facet-catalog` — all five contracts pass
- `npx tsx utils/scripts/verifyDailyDreamFacets.ts` — passes; fails correctly when `one('MOOD')` is planted back
- `npx tsx utils/scripts/verifyFacetCurationMoodPolicy.ts` — passes; fails correctly on all three planted violations
- `npx vue-tsc --noEmit` — clean
- `npx eslint` on the changed runtime files — one pre-existing `no-dynamic-delete` error in `randomStore.ts`, unchanged by this PR (same error at line 240 before, 244 after)
- **No production write in this diff.** The facet correction reaches row 2068 on the next `facet-catalog-maintenance` run; the location art backfill needs an explicit `--queue-art` invocation.