### PR TITLE
fix(appmaker): flag a title that slugifies to nothing as a slug error

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -221,6 +221,12 @@ jobs:
       - name: Conductor roadmap progress parity contract
         run: npm run test:conductor-progress-parity
 
+      - name: AppMaker slug-candidate guard self-test
+        run: npm run test:appmaker-slug-candidate-guard-selftest
+
+      - name: AppMaker slug-candidate guard
+        run: npm run test:appmaker-slug-candidate-guard
+
       - name: Da Vinci narration bounds contract
         run: npm run test:davinci-narration
 

--- a/components/pages/appmaker-page.vue
+++ b/components/pages/appmaker-page.vue
@@ -209,7 +209,21 @@ const slugPreview = computed(() =>
 
 const slugError = computed(() => {
   const candidate = form.slug.trim().toLowerCase() || slugPreview.value
-  if (!candidate || SLUG_RE.test(candidate)) return ''
+  // An empty candidate is only "not yet an error" while the title itself is
+  // still empty (the Create button is separately disabled by !form.title in
+  // that case). Once the title is non-empty but reduces to nothing after
+  // slugify (e.g. "###", "---", pure emoji/punctuation) — and the slug field
+  // is also empty — there is no usable slug to submit. Treating that as "no
+  // error" let the Create button stay enabled and every SLUG_RE.test('')
+  // guard below fall through silently, so submission always reached the
+  // server just to bounce off its mirrored SLUG_RE check instead of being
+  // caught here as intended.
+  if (!candidate) {
+    return form.title.trim()
+      ? 'Enter a slug — the title has no letters or digits to build one from.'
+      : ''
+  }
+  if (SLUG_RE.test(candidate)) return ''
   return 'Slug must be kebab-case: start with a letter, then letters/digits/hyphens.'
 })
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "test:comments": "npm run test:comment-migration && npm run test:comment-signals && npm run test:comment-calibration",
     "test:comment-authors": "tsx utils/scripts/verifyCommentBackfillAuthors.ts",
     "test:app-base-url": "tsx utils/scripts/verifyAppBaseUrl.ts",
+    "test:appmaker-slug-candidate-guard-selftest": "tsx utils/scripts/verifyAppmakerSlugCandidateGuard.test.ts",
+    "test:appmaker-slug-candidate-guard": "tsx utils/scripts/verifyAppmakerSlugCandidateGuard.ts",
     "test:comment-prefix": "tsx utils/scripts/verifyPartialPublishPrefix.ts",
     "test:comment-quality": "tsx utils/scripts/verifyCommentDraftQuality.ts",
     "test:population-quality": "tsx utils/scripts/verifyPopulationDraftQuality.ts",

--- a/utils/scripts/verifyAppmakerSlugCandidateGuard.test.ts
+++ b/utils/scripts/verifyAppmakerSlugCandidateGuard.test.ts
@@ -1,0 +1,109 @@
+// /utils/scripts/verifyAppmakerSlugCandidateGuard.test.ts
+//
+// Regression test for checkSlugCandidateGuard() in
+// verifyAppmakerSlugCandidateGuard.ts (appmaker/t-004). Exercises the real
+// check against synthetic component-shaped fixtures covering: the fixed
+// shape (empty-candidate branch conditioned on form.title.trim()), the
+// pre-fix shape (bare `if (!candidate || SLUG_RE.test(candidate)) return
+// ''` with no title check at all), and a partial regression (the
+// !candidate branch still exists but no longer references form.title).
+import assert from 'node:assert/strict'
+
+import { checkSlugCandidateGuard } from './verifyAppmakerSlugCandidateGuard.js'
+
+function fixture(slugErrorBody: string): string {
+  return `
+<script setup lang="ts">
+const slugPreview = computed(() =>
+  form.title
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40),
+)
+
+const slugError = computed(() => {
+${slugErrorBody}
+})
+
+const fleet = computed(() => [])
+</script>
+`
+}
+
+const FIXED = fixture(`
+  const candidate = form.slug.trim().toLowerCase() || slugPreview.value
+  if (!candidate) {
+    return form.title.trim()
+      ? 'Enter a slug — the title has no letters or digits to build one from.'
+      : ''
+  }
+  if (SLUG_RE.test(candidate)) return ''
+  return 'Slug must be kebab-case: start with a letter, then letters/digits/hyphens.'
+`)
+
+// Pre-fix shape: a single combined check, empty candidate always passes
+// regardless of the title.
+const BUGGY = fixture(`
+  const candidate = form.slug.trim().toLowerCase() || slugPreview.value
+  if (!candidate || SLUG_RE.test(candidate)) return ''
+  return 'Slug must be kebab-case: start with a letter, then letters/digits/hyphens.'
+`)
+
+// Partial regression: the !candidate branch survived as its own `if`, but
+// it no longer consults form.title, so it still always returns ''.
+const PARTIALLY_REGRESSED = fixture(`
+  const candidate = form.slug.trim().toLowerCase() || slugPreview.value
+  if (!candidate) {
+    return ''
+  }
+  if (SLUG_RE.test(candidate)) return ''
+  return 'Slug must be kebab-case: start with a letter, then letters/digits/hyphens.'
+`)
+
+function run(): void {
+  const fixedErrors = checkSlugCandidateGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const buggyErrors = checkSlugCandidateGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    2,
+    `expected the pre-fix fixture (no separate !candidate branch, no title ` +
+      `check) to fail both checks, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(buggyErrors.some((e) => /no longer branches separately/.test(e)))
+  assert.ok(
+    buggyErrors.some((e) => /no longer checks form\.title\.trim/.test(e)),
+  )
+
+  const regressedErrors = checkSlugCandidateGuard(PARTIALLY_REGRESSED)
+  assert.equal(
+    regressedErrors.length,
+    1,
+    'expected a fixture with a bare !candidate branch that never checks ' +
+      `form.title to fail only the title-check assertion, got: ${JSON.stringify(regressedErrors)}`,
+  )
+  assert.ok(
+    regressedErrors.some((e) => /no longer checks form\.title\.trim/.test(e)),
+  )
+
+  const missingFunction = checkSlugCandidateGuard(
+    '<script setup lang="ts">\nconst somethingElse = 1\n</script>\n',
+  )
+  assert.equal(missingFunction.length, 1)
+  assert.ok(missingFunction.some((e) => /Could not find/.test(e)))
+
+  console.log(
+    'AppMaker slug-candidate guard self-test passed: buggy fixture fails, ' +
+      'fixed fixture passes, a partially-regressed fixture fails, and a ' +
+      'missing slugError() is detected.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyAppmakerSlugCandidateGuard.ts
+++ b/utils/scripts/verifyAppmakerSlugCandidateGuard.ts
@@ -1,0 +1,120 @@
+// /utils/scripts/verifyAppmakerSlugCandidateGuard.ts
+//
+// Regression guard (appmaker/t-004) -- slugError() in
+// components/pages/appmaker-page.vue mirrors the server's SLUG_RE so an
+// obviously-invalid slug is caught client-side with an inline error and a
+// disabled Create button, instead of round-tripping to the server just to
+// bounce off the same regex there. That mirroring had a gap: when both the
+// slug field and the title-derived slugPreview reduce to an empty string
+// (e.g. a title of "###", "---", or pure emoji/punctuation, with the slug
+// field left blank), `candidate` was `''`, and `!candidate` short-circuited
+// to "no error" unconditionally -- even though the title itself was
+// non-empty and the Create button's separate `!form.title.trim()` guard was
+// therefore already satisfied. The button stayed enabled, the user could
+// click Create, and the request was guaranteed to fail server-side with a
+// 400 from scaffold-request.post.ts's own SLUG_RE check -- exactly the
+// round trip the client-side mirror exists to avoid.
+//
+// Fixed by making the empty-candidate branch conditional on the title: an
+// empty candidate is only a non-error while the title is *also* empty (the
+// button's title guard covers that case); once the title is non-empty but
+// yields no usable slug, slugError() now returns an explicit message and the
+// Create button stays disabled.
+//
+// This asserts the textual shape of that fix stays in place: slugError()
+// branches on `form.title.trim()` inside its empty-candidate handling
+// (not a bare `if (!candidate) return ''` that silently accepts an
+// untitled-derived empty slug again), scoped narrowly to this one function,
+// mirroring this project's other narrow textual guards over a
+// general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const COMPONENT_PATH = join(
+  repositoryRoot,
+  'components/pages/appmaker-page.vue',
+)
+
+function extractFunctionSource(content: string, name: string): string | null {
+  const signature = new RegExp(`const ${name} = computed\\(\\(\\) => \\{`, 'm')
+  const match = signature.exec(content)
+  if (!match) return null
+
+  const braceOpen = match.index + match[0].length - 1
+  let depth = 0
+  let i = braceOpen
+  for (; i < content.length; i++) {
+    if (content[i] === '{') depth++
+    else if (content[i] === '}') {
+      depth--
+      if (depth === 0) break
+    }
+  }
+  if (depth !== 0) return null
+  return content.slice(braceOpen, i + 1)
+}
+
+export function checkSlugCandidateGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const body = extractFunctionSource(content, 'slugError')
+  if (!body) {
+    errors.push(
+      'Could not find `const slugError = computed(() => { ... })` in ' +
+        'appmaker-page.vue -- has it been renamed, removed, or restructured? ' +
+        'If so, this guard (and the empty-slug-candidate bug it protects ' +
+        'against) needs to move with it.',
+    )
+    return errors
+  }
+
+  if (!/if\s*\(\s*!candidate\s*\)\s*\{/.test(body)) {
+    errors.push(
+      'slugError() no longer branches separately on `if (!candidate)` -- ' +
+        'has the empty-candidate case been collapsed back into a single ' +
+        "`if (!candidate || SLUG_RE.test(candidate)) return ''` that treats " +
+        'an empty candidate as always valid, regardless of whether the ' +
+        'title actually produced one?',
+    )
+  }
+
+  if (!/form\.title\.trim\(\)/.test(body)) {
+    errors.push(
+      'slugError() no longer checks form.title.trim() inside its ' +
+        'empty-candidate handling -- an empty candidate from a non-empty, ' +
+        'unslugifiable title (e.g. "###") will silently pass validation ' +
+        'again and let the Create button stay enabled for a guaranteed ' +
+        'server-side 400.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(COMPONENT_PATH, 'utf8')
+  const errors = checkSlugCandidateGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'AppMaker slug-candidate guard contract failed in appmaker-page.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'AppMaker slug-candidate guard contract passed: a non-empty title that ' +
+      'slugifies to nothing is flagged as an error instead of silently ' +
+      'passing validation.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
Recurring appmaker/t-012 bug-hunt cycle (conductor scheduled Agent run). Found a real gap distinct from the prior fixes in this task (refresh-token sequencing, force-fetch in-flight sharing, client-side slug validation).

## The bug

`components/pages/appmaker-page.vue`'s `slugError` computed mirrors the server's `SLUG_RE` so a bad slug is caught before the round trip. It builds `candidate = form.slug.trim().toLowerCase() || slugPreview.value`, then does:

```
if (!candidate || SLUG_RE.test(candidate)) return ''
```

When the title is non-empty but slugifies to nothing — e.g. `"###"`, `"---"`, or pure emoji/punctuation, with the slug field left blank — `candidate` is `''`, and the `!candidate` branch treats that as *valid* regardless of whether the title actually produced a usable slug. The Create button is otherwise only gated on `creating`, `!form.title.trim()`, and `!!slugError`, so it stayed enabled and clicking it always produced a guaranteed server-side 400 from `server/api/appmaker/scaffold-request.post.ts`'s identical `SLUG_RE` check — exactly the round trip the client-side mirror was added to avoid.

## The fix

The empty-candidate branch is now conditioned on `form.title.trim()`: an empty candidate is a non-error only while the title is also empty (already covered by the button's separate `!form.title` guard). Once the title is non-empty but yields no usable slug, `slugError` returns an explicit message and the Create button stays disabled.

## Guard

`utils/scripts/verifyAppmakerSlugCandidateGuard.ts` + `.test.ts`, modeled on `verifyDaVinciDimensionToneGuard.ts`. Wired into `package.json` and `.github/workflows/contract-tests.yml`.

## Verification

- New guard + self-test pass
- `npx eslint` on touched files — clean
- `npx prettier --check` on touched files — clean
- `npm run test` (`vue-tsc --noEmit`) — clean
- `git status --porcelain` showed exactly the 5 intended files

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8sVMBUvN9HMBLDsxAk1vh)_