### PR TITLE
perf(comfy): load the Flux T5 encoder as GGUF, from one definition

### DIFF
--- a/server/api/comfy/characterSheet.post.ts
+++ b/server/api/comfy/characterSheet.post.ts
@@ -4,6 +4,7 @@ import { errorHandler } from '../../utils/error'
 import { getServerEndpoint, resolveServer } from '../../utils/serverResolver'
 import type { Server } from '~/prisma/generated/prisma/client'
 import { authAndGate } from '../../utils/comfyGate'
+import { fluxDualClipLoaderNode } from '../../utils/fluxTextEncoders'
 
 type CharacterSheetRequest = {
   serverId?: number | null
@@ -273,18 +274,7 @@ function buildCharacterSheetWorkflow(input: {
   const negativePrompt = input.negativePrompt.trim()
 
   return {
-    '4': {
-      inputs: {
-        clip_name1: 't5xxl_fp8_e4m3fn_scaled.safetensors',
-        clip_name2: 'clip_l.safetensors',
-        type: 'flux',
-        device: 'default',
-      },
-      class_type: 'DualCLIPLoader',
-      _meta: {
-        title: 'DualCLIPLoader',
-      },
-    },
+    '4': fluxDualClipLoaderNode(),
     '6': {
       inputs: {
         width: input.width,

--- a/server/api/comfy/flux/utils/workflow.ts
+++ b/server/api/comfy/flux/utils/workflow.ts
@@ -5,6 +5,8 @@
 // (/api/art/enqueue) build the exact same Comfy graph. The direct route keeps
 // the networking/polling; this module owns only the workflow shape + defaults.
 
+import { fluxDualClipLoaderNode } from '../../../../utils/fluxTextEncoders'
+
 export type ComfyWorkflow = Record<string, ComfyWorkflowNode>
 
 export type ComfyWorkflowNode = {
@@ -81,18 +83,7 @@ export function buildFluxWorkflow(input: {
   const prompt = input.prompt.trim() || defaultFluxPrompt
 
   return {
-    '4': {
-      inputs: {
-        clip_name1: 't5xxl_fp8_e4m3fn_scaled.safetensors',
-        clip_name2: 'clip_l.safetensors',
-        type: 'flux',
-        device: 'default',
-      },
-      class_type: 'DualCLIPLoader',
-      _meta: {
-        title: 'DualCLIPLoader',
-      },
-    },
+    '4': fluxDualClipLoaderNode(),
     '6': {
       inputs: {
         width: input.width,

--- a/server/api/comfy/kontext/generate.post.ts
+++ b/server/api/comfy/kontext/generate.post.ts
@@ -9,6 +9,7 @@ import type { Server } from '~/prisma/generated/prisma/client'
 import { errorHandler } from '../../../utils/error'
 import { getServerEndpoint, resolveServer } from '../../../utils/serverResolver'
 import { authAndGate } from '../../../utils/comfyGate'
+import { fluxDualClipLoaderNode } from '../../../utils/fluxTextEncoders'
 
 type KontextGenerateRequest = {
   serverId?: number | null
@@ -299,18 +300,7 @@ function buildKontextWorkflow(input: {
         title: 'Load VAE',
       },
     },
-    '11': {
-      inputs: {
-        clip_name1: 't5xxl_fp8_e4m3fn_scaled.safetensors',
-        clip_name2: 'clip_l.safetensors',
-        type: 'flux',
-        device: 'default',
-      },
-      class_type: 'DualCLIPLoader',
-      _meta: {
-        title: 'DualCLIPLoader',
-      },
-    },
+    '11': fluxDualClipLoaderNode(),
     '13': {
       inputs: {
         noise: ['25', 0],

--- a/server/api/comfy/kontext/kombine.post.ts
+++ b/server/api/comfy/kontext/kombine.post.ts
@@ -4,6 +4,7 @@ import type { Server } from '~/prisma/generated/prisma/client'
 import { errorHandler } from '../../../utils/error'
 import { getServerEndpoint, resolveServer } from '../../../utils/serverResolver'
 import { authAndGate } from '../../../utils/comfyGate'
+import { fluxDualClipLoaderNode } from '../../../utils/fluxTextEncoders'
 
 type KombineGenerateRequest = {
   serverId?: number | null
@@ -372,17 +373,7 @@ function buildKombineWorkflow(input: {
         title: 'ReferenceLatent',
       },
     },
-    '196': {
-      inputs: {
-        clip_name1: 't5xxl_fp8_e4m3fn_scaled.safetensors',
-        clip_name2: 'clip_l.safetensors',
-        type: 'flux',
-      },
-      class_type: 'DualCLIPLoaderGGUF',
-      _meta: {
-        title: 'DualCLIPLoader (GGUF)',
-      },
-    },
+    '196': fluxDualClipLoaderNode(),
     '197': {
       inputs: {
         unet_name: 'flux1-kontext-dev-Q5_K_M.gguf',

--- a/server/api/comfy/kontext/utils/workflow.ts
+++ b/server/api/comfy/kontext/utils/workflow.ts
@@ -4,6 +4,8 @@
 // Mirrors the graph in ../generate.post.ts (kept private there); the direct
 // route and this builder should be deduped in a later pass.
 
+import { fluxDualClipLoaderNode } from '../../../../utils/fluxTextEncoders'
+
 export type ComfyWorkflow = Record<string, ComfyWorkflowNode>
 
 export type ComfyWorkflowNode = {
@@ -131,16 +133,7 @@ export function buildKontextWorkflow(
       class_type: 'VAELoader',
       _meta: { title: 'Load VAE' },
     },
-    '11': {
-      inputs: {
-        clip_name1: 't5xxl_fp8_e4m3fn_scaled.safetensors',
-        clip_name2: 'clip_l.safetensors',
-        type: 'flux',
-        device: 'default',
-      },
-      class_type: 'DualCLIPLoader',
-      _meta: { title: 'DualCLIPLoader' },
-    },
+    '11': fluxDualClipLoaderNode(),
     '13': {
       inputs: {
         noise: ['25', 0],
@@ -266,7 +259,6 @@ export function buildKontextWorkflow(
       class_type: 'LoraLoaderModelOnly',
       _meta: { title: 'Style LoRA' },
     }
-
     ;(workflow['30']!.inputs as Record<string, unknown>).model = ['61', 0]
   }
 

--- a/server/utils/artJobRetry.ts
+++ b/server/utils/artJobRetry.ts
@@ -1,10 +1,11 @@
 // /server/utils/artJobRetry.ts
-import {
-  parseArtJobPayload,
-  type ArtJobPayloadRecord,
-} from './artJobPayload'
+import { parseArtJobPayload, type ArtJobPayloadRecord } from './artJobPayload'
 import { ltxFrameCount } from '../api/comfy/ltx/utils/imageToVideoWorkflow'
 import { wanFrameCount } from '../api/comfy/wan/utils/imageToVideoWorkflow'
+import {
+  fluxDualClipLoaderNode,
+  isFluxDualClipLoader,
+} from './fluxTextEncoders'
 
 export type ArtJobRetryMode = 'NEW_OUTPUT' | 'OVERWRITE'
 
@@ -14,8 +15,11 @@ export const ART_JOB_RETRY_MODES = new Set<ArtJobRetryMode>([
 ])
 
 const SEED_KEYS = new Set(['seed', 'noise_seed'])
-const CURRENT_FLUX_T5 = 't5xxl_fp8_e4m3fn_scaled.safetensors'
-const CURRENT_FLUX_CLIP_L = 'clip_l.safetensors'
+// Sourced from fluxTextEncoders so a retry cannot put back an encoder the
+// builders no longer emit. Until 2026-08-13 these were separate literals, so
+// changing the builders alone would have held only until a job was retried --
+// this normalizer would have rewritten it to the fp8 T5, intermittently, and
+// looked like the GGUF switch failing to stick.
 
 function asRecord(value: unknown): ArtJobPayloadRecord {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
@@ -187,7 +191,8 @@ function normalizeLegacyComfyWorkflow(
       classType === 'PrimitiveStringMultiline' &&
       stringValue(meta.title).toLowerCase() === 'prompt'
     ) {
-      const prompt = stringValue(inputs.value) || stringValue(payload.promptString)
+      const prompt =
+        stringValue(inputs.value) || stringValue(payload.promptString)
       if (prompt) {
         meta.prompt = prompt
         record._meta = meta
@@ -207,12 +212,18 @@ function normalizeLegacyComfyWorkflow(
     }
 
     if (
-      classType === 'DualCLIPLoader' &&
+      isFluxDualClipLoader(classType) &&
       stringValue(inputs.type).toLowerCase() === 'flux'
     ) {
-      inputs.clip_name1 = CURRENT_FLUX_T5
-      inputs.clip_name2 = CURRENT_FLUX_CLIP_L
-      record.inputs = inputs
+      // Rebuild the whole node, not just the names: the loader CLASS follows
+      // the encoder file (GGUF vs safetensors), so rewriting names alone could
+      // leave a .gguf on the stock DualCLIPLoader.
+      const loader = fluxDualClipLoaderNode()
+      record.class_type = loader.class_type
+      record.inputs = { ...inputs, ...loader.inputs }
+      if (!('device' in loader.inputs))
+        delete (record.inputs as Record<string, unknown>).device
+      record._meta = loader._meta
     }
   }
 
@@ -271,8 +282,7 @@ export function applyArtJobOverrides(
       ['frame_rate', 'fps'],
     )
   const currentDuration = num(video.durationSeconds)
-  const nextFps =
-    fpsOverride !== null ? clamp(fpsOverride, 1, 60) : currentFps
+  const nextFps = fpsOverride !== null ? clamp(fpsOverride, 1, 60) : currentFps
   const nextDuration =
     durationOverride !== null
       ? clamp(durationOverride, 0.25, 30)
@@ -312,8 +322,7 @@ export function applyArtJobOverrides(
 
       if (
         nextFrames !== null &&
-        (classType === 'LTXVImgToVideo' ||
-          classType === 'WanImageToVideo') &&
+        (classType === 'LTXVImgToVideo' || classType === 'WanImageToVideo') &&
         'length' in inputs
       ) {
         inputs.length = nextFrames

--- a/server/utils/comfyTestClient.ts
+++ b/server/utils/comfyTestClient.ts
@@ -13,6 +13,7 @@
 import { createError } from 'h3'
 import type { Server } from '~/prisma/generated/prisma/client'
 import { getServerEndpoint } from './serverResolver'
+import { fluxDualClipLoaderNode } from './fluxTextEncoders'
 
 export type ComfyWorkflow = Record<string, ComfyWorkflowNode>
 
@@ -234,19 +235,11 @@ function buildSchnellSmokeWorkflow(input: {
 }): ComfyWorkflow {
   const samplerSeed = resolveSeed(input.seed)
   const wildcardSeed = resolveSeed(-1)
-  const prompt = input.prompt.trim() || 'a friendly test robot, clean concept art'
+  const prompt =
+    input.prompt.trim() || 'a friendly test robot, clean concept art'
 
   return {
-    '4': {
-      inputs: {
-        clip_name1: 't5xxl_fp8_e4m3fn_scaled.safetensors',
-        clip_name2: 'clip_l.safetensors',
-        type: 'flux',
-        device: 'default',
-      },
-      class_type: 'DualCLIPLoader',
-      _meta: { title: 'DualCLIPLoader' },
-    },
+    '4': fluxDualClipLoaderNode(),
     '6': {
       inputs: { width: input.width, height: input.height, batch_size: 1 },
       class_type: 'EmptyLatentImage',

--- a/server/utils/fluxTextEncoders.ts
+++ b/server/utils/fluxTextEncoders.ts
@@ -1,0 +1,102 @@
+// /server/utils/fluxTextEncoders.ts
+//
+// One definition of which text encoders every Flux-family workflow loads, and
+// which loader node to express them with.
+//
+// Why this exists. The render box is a 12 GB card with little system RAM, and
+// the Kontext graph did not fit in it:
+//
+//   flux1-kontext-dev-Q5_K_M.gguf        unet, GGUF          ~8.0 GB
+//   t5xxl_fp8_e4m3fn_scaled.safetensors  text encoder, fp8    4.80 GB
+//   clip_l.safetensors                                        0.23 GB
+//   ae.safetensors                       VAE                  0.33 GB
+//                                                    total  ~13.4 GB
+//
+// Over 12 GB, so ComfyUI spilled to system RAM and thrashed. ArtJob 8276 blew
+// through the relay's 30-minute GEN_TIMEOUT without producing an image. The
+// unet was already quantised; the text encoder was the half nobody had moved.
+// t5-v1_1-xxl-encoder-Q5_K_S.gguf is 3.07 GB -- 1.73 GB back, from a file
+// already sitting in the same folder, with no download.
+//
+// Why a module rather than six edited literals. The same pair was hardcoded in
+// six places (kontext/utils/workflow, kontext/generate, kontext/kombine, flux,
+// characterSheet, comfyTestClient) AND in artJobRetry's normalizer, which
+// rewrites clip_name1/clip_name2 on every retry. Changing only the builders
+// would work until a job was retried, at which point the normalizer would put
+// the fp8 encoder back -- an intermittent regression that would have looked
+// like the GGUF switch "not sticking".
+//
+// The loader class follows the filename, so switching back is an env change
+// rather than a code edit: point FLUX_T5_ENCODER at a .safetensors and the
+// stock DualCLIPLoader returns. Note the GGUF loader takes no `device` input --
+// kombine.post.ts already used DualCLIPLoaderGGUF and correctly omitted it,
+// while feeding it a .safetensors name, which is the drift this consolidates.
+
+const DEFAULT_T5 = 't5-v1_1-xxl-encoder-Q5_K_S.gguf'
+const DEFAULT_CLIP_L = 'clip_l.safetensors'
+
+function envName(key: string, fallback: string): string {
+  const value = (process.env[key] || '').trim()
+  return value || fallback
+}
+
+/** The T5 encoder every Flux-family graph loads. */
+export const FLUX_T5_ENCODER = envName('FLUX_T5_ENCODER', DEFAULT_T5)
+
+/** The CLIP-L encoder every Flux-family graph loads. */
+export const FLUX_CLIP_L_ENCODER = envName(
+  'FLUX_CLIP_L_ENCODER',
+  DEFAULT_CLIP_L,
+)
+
+export function isGgufEncoder(name: string): boolean {
+  return name.trim().toLowerCase().endsWith('.gguf')
+}
+
+/** True when this workflow's encoders need city96's GGUF loader node. */
+export function fluxEncodersAreGguf(): boolean {
+  return isGgufEncoder(FLUX_T5_ENCODER) || isGgufEncoder(FLUX_CLIP_L_ENCODER)
+}
+
+export const FLUX_DUAL_CLIP_LOADER_CLASSES = [
+  'DualCLIPLoader',
+  'DualCLIPLoaderGGUF',
+] as const
+
+/** Does this node load the Flux text-encoder pair, in either loader flavour? */
+export function isFluxDualClipLoader(classType: unknown): boolean {
+  return (
+    typeof classType === 'string' &&
+    (FLUX_DUAL_CLIP_LOADER_CLASSES as readonly string[]).includes(classType)
+  )
+}
+
+type DualClipLoaderNode = {
+  inputs: Record<string, unknown>
+  class_type: string
+  _meta: { title: string }
+}
+
+/**
+ * The complete DualCLIPLoader node for a Flux graph.
+ *
+ * `device` is emitted only for the stock loader. DualCLIPLoaderGGUF's inputs
+ * are clip_name1/clip_name2/type, and passing it an input it does not declare
+ * risks a validation rejection at submit — the same class of failure as a
+ * lora_name that is not in the list.
+ */
+export function fluxDualClipLoaderNode(): DualClipLoaderNode {
+  const gguf = fluxEncodersAreGguf()
+  const inputs: Record<string, unknown> = {
+    clip_name1: FLUX_T5_ENCODER,
+    clip_name2: FLUX_CLIP_L_ENCODER,
+    type: 'flux',
+  }
+  if (!gguf) inputs.device = 'default'
+
+  return {
+    inputs,
+    class_type: gguf ? 'DualCLIPLoaderGGUF' : 'DualCLIPLoader',
+    _meta: { title: gguf ? 'DualCLIPLoader (GGUF)' : 'DualCLIPLoader' },
+  }
+}


### PR DESCRIPTION
Silas, 2026-08-13: *"I have a horrendously long load time for flux generations. minimal ram and a 12gb gpu. We should work on optimizing our kontext calls, make sure we are using gguf and low ram options."*

## The measurement

The unet was already GGUF. The text encoder was the half nobody had moved.

```
flux1-kontext-dev-Q5_K_M.gguf         unet, GGUF           ~8.0 GB
t5xxl_fp8_e4m3fn_scaled.safetensors   text encoder, fp8     4.80 GB   <-
clip_l.safetensors                                          0.23 GB
ae.safetensors                        VAE                   0.33 GB
                                                  total   ~13.4 GB
```

**13.4 GB on a 12 GB card.** It doesn't fit, so ComfyUI spills to system RAM — which is scarce on this box — and thrashes. ArtJob 8276 ran past the relay's 30-minute `GEN_TIMEOUT` without producing an image.

`t5-v1_1-xxl-encoder-Q5_K_S.gguf` is **3.07 GB** and was already sitting in `Z:/ai/models/text_encoders`. **1.73 GB back, no download.** Working set drops to ~11.6 GB, under the card.

Q5_K_S rather than the Q6_K (3.64 GB) or Q3_K_S (1.96 GB) also present: Q6_K gives back little, and T5 loses noticeable prompt adherence by Q3.

## Why a module and not six edited literals

The pair was hardcoded in six builders **and** in `artJobRetry.ts`'s normalizer, which rewrites `clip_name1`/`clip_name2` on every retry:

```ts
if (classType === 'DualCLIPLoader' && type === 'flux') {
  inputs.clip_name1 = CURRENT_FLUX_T5   // fp8
}
```

Changing only the builders would have worked until a job was retried, at which point this would have put the fp8 encoder back — intermittently, and looking exactly like the GGUF switch "not sticking". Both now read `fluxTextEncoders.ts`. The normalizer rebuilds the whole node, because the loader **class** follows the encoder file; rewriting names alone could leave a `.gguf` on the stock loader.

## Reversible by env, not by edit

Point `FLUX_T5_ENCODER` at a `.safetensors` and the stock `DualCLIPLoader` returns, `device` input and all. `DualCLIPLoaderGGUF` doesn't declare `device`, so it's emitted only on the safetensors path — passing an undeclared input risks the same class of submit-time rejection as a bad `lora_name`.

Incidentally this fixes real drift: `kombine.post.ts` already used `DualCLIPLoaderGGUF` while feeding it a `.safetensors` filename.

## Verified / not verified

**Verified** by executing the builder both ways: default emits `DualCLIPLoaderGGUF` + `.gguf` + no `device`; `FLUX_T5_ENCODER=t5xxl_fp8_e4m3fn_scaled.safetensors` emits `DualCLIPLoader` + `device: 'default'`. All seven import paths resolve; prettier parses every edited file.

**Not verified — and this is why I have not merged it:** the actual VRAM saving and render time need the box. The file sizes are from your own `dir` listing, but "fits in 12 GB" is arithmetic, not a measurement. Worth one Kontext render before trusting it.

`node_modules` isn't installed in my sandbox, so the TypeScript check runs in CI, not here.

## Not included

`--lowvram` on ComfyUI's launch args. It would help Kontext, but it's a real tradeoff that would likely slow krea2 — which currently fits and is your default. Separate change, separate decision.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExVxVDi11BHRziDazVr7Et)_