### PR TITLE
Give every art-less object art: a coverage sweep, 50 written prompts, 47 jobs

### DIFF
--- a/config/art-coverage/batch-0001.json
+++ b/config/art-coverage/batch-0001.json
@@ -1,0 +1,309 @@
+{
+  "version": 1,
+  "note": "Hand-authored art prompts for every catalog object found with no art of any kind, from the 2026-08-14 coverage sweep. Prompts are written, not machine-joined: a prompt assembled by concatenating a Dream's description or a Project's roadmap text produces an image of the text's subject matter, not of the thing. Each one obeys server/utils/artPromptContract.ts -- no conditional instructions, no format vocabulary, no 'Kind Robots visual style', and no text-exclusion pile (guidance is inert at krea2's cfg 1, so those words would land in positive conditioning).",
+  "prompts": [
+    {
+      "entityType": "dream",
+      "entityId": 5646,
+      "title": "The Terminus Office",
+      "prompt": "An endless filing hall at the end of time, brass drawer fronts stacked forty deep and vanishing into warm gloom, green banker's lamps burning at every desk, a lobby clock with too many hands, one clerk on a rolling ladder, dust suspended in slanted amber light"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 5647,
+      "title": "The Foxwood Court",
+      "prompt": "A moonlit autumn forest holding court, foxes and badgers in worn heraldic collars seated on root thrones, ancient oaks with faces half formed in the bark, lantern light from a small village glimmering far through the trunks, cold blue mist low to the ground"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 5648,
+      "title": "The Unlisted Floor",
+      "prompt": "A hotel corridor that should not exist, patterned carpet running past a dozen mismatched doors, each one ajar onto a different impossible interior — a wheat field, a flooded ballroom, an open night sky — flickering sconces, a stairwell behind with no floor number"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 5649,
+      "title": "The Walk-In Pantheon",
+      "prompt": "A municipal waiting room for deities, frosted glass office doors with domains stencilled in gold, a storm god filling out paperwork under fluorescent tubes, mortals on plastic chairs holding paper tickets, a humming vending machine glowing at the far wall"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 5650,
+      "title": "The Waking Room",
+      "prompt": "A deliberately plain white room where a new mind is switching on, two simple chairs facing each other, a robot with fresh unmarked plating opening its eyes for the first time, soft even daylight from a single high window, nothing else in the room at all"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 5651,
+      "title": "Marrowlace District",
+      "prompt": "A narrow evening street of shops kept by the dead, skeletal figures in good coats browsing lit windows, a tailor pinning a sleeve onto a customer with no arm, a pet shop window full of wagging bone-tailed dogs, warm gaslight on wet cobbles"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 5652,
+      "title": "The OverCorp Atrium",
+      "prompt": "A corporate atrium ninety floors tall with its own weather, thin rain falling inside past ranks of glass balconies, a monolithic carved cornerstone at the base, tiny commuters crossing a vast marble floor, cold blue daylight from an impossibly distant skylight"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 5653,
+      "title": "The Rendering City",
+      "prompt": "A night city still finishing loading, upper towers dissolving into untextured grey blocks and bare wireframe, magenta advertising falling like rain on the finished streets below, a sector glitching into coloured static at the horizon"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 5654,
+      "title": "The Overnight Midway",
+      "prompt": "A carnival midway that arrived overnight, striped tent canvas silhouetted against a pale predawn sky, strings of unlit bulbs, hand-painted show boards along an empty muddy lane, one ringmaster in a red coat standing perfectly still and waiting"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 5655,
+      "title": "The Caretaker's Allotment",
+      "prompt": "A walled community garden at golden hour, raised beds subtly out of alignment as if recently moved on their own, cracked terracotta pots, a rusted watering can, small strange objects half surfaced in the dark soil, one empty pair of gardening gloves on a bench"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 5656,
+      "title": "The Three A.M. Precinct",
+      "prompt": "A rain-slick city block at three in the morning, an all-night laundromat, a bus depot window and a police front desk somehow all on the same corner, sodium light pooling on wet asphalt, four tired night workers visible through four different panes of glass"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 5657,
+      "title": "Blackrock Shore",
+      "prompt": "A black volcanic coastline at dawn, a lighthouse beam sweeping low cloud, four small salt-crusted objects arranged in a row on the wet rocks by the tide, dark pine woods crowding the shingle behind, cold grey-green water"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 5658,
+      "title": "Candlewick Row",
+      "prompt": "A cold narrow street of warm lit windows at dusk, a tea shop with jars stacked to the ceiling, a lost property bureau full of single gloves and small keys, snow beginning to fall, every shopfront lamp burning gold against deep blue evening"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 5659,
+      "title": "The Salt Ledger",
+      "prompt": "A back room lit by one bare hanging bulb, four stolen objects laid out on black velvet, a hand reaching into the light above them, cigarette haze, a diner booth visible through a doorway behind, deep shadow everywhere else"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 5660,
+      "title": "The Tidepool Court",
+      "prompt": "A tidepool the size of a dinner plate arranged as a royal court, an anemone throne, crabs standing in ranks of precedence, a coral reef rising like a cathedral above the waterline, an enormous dark shape passing far out in the deep blue beyond"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 5661,
+      "title": "The Sitting Coast",
+      "prompt": "A vast warm shallow sea at low tide, an enormous mossy creature lying carefully down in water that only reaches its shoulder, tiny white birds standing along its back, a shoreline scaled far too large for anything human, hazy gold afternoon light"
+    },
+
+    {
+      "entityType": "dream",
+      "entityId": 37,
+      "title": "The Lantern Greenhouse",
+      "prompt": "A warm Victorian glasshouse at night, brass robots watering rows of softly luminous plants, paper lanterns drifting between the rafters, heavy condensation on old panes, doorways at the far end opening onto different weather"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 38,
+      "title": "Blacklace Cathedral",
+      "prompt": "A gothic cathedral built from black glass and rusted neon, stacked speaker towers standing where the organ pipes should be, thorned ironwork, stained glass saints in leather jackets lit from behind in violet and hot pink, choir lights flickering in the rafters"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 39,
+      "title": "Gallowsun Junction",
+      "prompt": "A weird western rail town under a swollen sun sitting too low on the horizon, a wide dust street, clockwork vultures perched along sagging telegraph wires, a saloon front whose mirror reflects an empty room, long red shadows"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 40,
+      "title": "The Infernal Circuit",
+      "prompt": "A vast arena of lava-lit server towers, guitar-shaped steel pylons catching forked lightning, horned machine spirits working at a forge of chrome and molten slag, orange underlight and deep black smoke"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 41,
+      "title": "The Rainbow Butterfly Sanctuary",
+      "prompt": "A radiant sanctuary of floating flowers and jewelled streams, soft moss bridges over clear water, thousands of luminous butterflies leaving faint coloured trails behind them, tiny garden shrines glowing among the ferns, dappled sunlight"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 42,
+      "title": "The Cthulian Jam Band Festival",
+      "prompt": "A seaside music festival under three impossible moons, a tentacled brass band improvising on a driftwood stage, food trucks strung with lights selling faintly moving noodles, an audience silhouetted against phosphorescent surf"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 44,
+      "title": "Serendipity Space Bar",
+      "prompt": "A cheerful crowded space bar drifting in hyperspace, retired starship captains and time-lost poets crammed into curved booths, a malfunctioning protocol droid carrying a tray of appetisers, an alien lounge singer under a warm spotlight, a starfield through a wide port window"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 45,
+      "title": "Lanterns Beneath the Snow",
+      "prompt": "A silent pine forest after fresh snowfall, a frozen creek running through it, warm amber lanterns glowing beneath the clear ice, their light spreading up through the snow from below, blue twilight, no wind"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 46,
+      "title": "Mistress Cassady's Spooktakular Monster Drag Party",
+      "prompt": "A midnight monster revue in full swing, a velvet-curtained stage, werewolves and gorgons and swamp things in extravagant sequinned gowns and towering wigs, footlights in green and magenta, a delighted audience of creatures at little round tables"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 47,
+      "title": "The Yokai Steamhouse",
+      "prompt": "A traditional bathhouse for spirits behind a curtain of lantern fog, steam rolling across dark wooden decking, paper lanterns hung in long rows, fox-masked and many-eyed bathers soaking in glowing pools, warm orange light through the mist"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 48,
+      "title": "The Lamp of a Thousand Parties",
+      "prompt": "The interior of an enormous brass lamp holding a centuries-long party, tiered balconies of carpets and cushions spiralling up the curved metal walls, cooking fires and dancers and musicians on every level, warm amber light reflecting off burnished brass"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 49,
+      "title": "The Improbability Starcruiser",
+      "prompt": "The cramped bridge of a barely functional starship, duct tape over the conduit seams, mismatched salvaged consoles, a coffee pot bungee-corded to a bulkhead, a scruffy mixed crew of several species at their stations, warm practical lighting and one failing overhead panel"
+    },
+
+    {
+      "entityType": "dream",
+      "entityId": 2140,
+      "title": "Borrowed-Light Bittersweet",
+      "prompt": "A warm lantern-lit crowd packed onto wooden jetties above cold black water, hundreds of hanging lamps, small boats passing ledgers hand to hand between them, breath visible in the night air, gold light against deep blue"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 2155,
+      "title": "The Sound Cannery",
+      "prompt": "A seaside cannery interior where sounds are sealed into small tins, rows of labelled tins stacked to the ceiling, a woman on the line holding one to her ear, steam and salt light through high dirty windows, a faint shimmer rising from an open tin"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 2156,
+      "title": "Tin & Echo",
+      "prompt": "A single dented tin sitting open on a windowsill in an empty room, late afternoon light falling across bare floorboards, a faint visible ripple in the air above the lid, dust motes, deep quiet"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 2158,
+      "title": "The Hollow Choir",
+      "prompt": "A vast limestone cavern with faintly glowing fungal veins mapping paths across the walls, shimmering humanoid echo-shapes like heat haze suspended in the air, one soft blue-green spotlight falling on a lone singer far below"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 2330,
+      "title": "Elegiac Wonder",
+      "prompt": "A vast warm archive of grief, wooden card-catalogue drawers rising in tiers into soft darkness, each drawer front glowing faintly from within, one drawer pulled open spilling gentle golden light, a single empty chair below it"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 2620,
+      "title": "Wind-Fortune",
+      "prompt": "A bright windswept hillside filled with hundreds of paper kites and prayer streamers, their strings crossed and knotted together in one great tangle overhead, small figures below holding on, high clear sky and fast-moving cloud"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 3194,
+      "title": "The Lantern Post",
+      "prompt": "A night-sky post office staffed by enormous gentle moths, wings dusted with pale gold, sorting letters along a long wooden counter, a wall of pigeonholes receding into indigo dark, lantern light and drifting wing-dust"
+    },
+    {
+      "entityType": "dream",
+      "entityId": 3195,
+      "title": "The Lantern Post",
+      "prompt": "A timber-and-brass sorting hall balanced atop a lighthouse above the cloud line, pigeonholes stretching away into the dark like a star map, brass fittings catching lantern gold, a sea of cloud below the windows, deep indigo night"
+    },
+
+    {
+      "entityType": "project",
+      "entityId": 22,
+      "title": "Challenge Center",
+      "prompt": "A bright tournament arena for creative work, two large framed paintings facing each other on opposing plinths, a tiered audience of small robots raising coloured paddles, hanging banners and warm stage light"
+    },
+    {
+      "entityType": "project",
+      "entityId": 57,
+      "title": "Coloring Book",
+      "prompt": "An open coloring book lying on a wooden desk, one page half filled with colour and the rest still clean black line art, scattered pencils and a sharpener, warm lamp light falling from the upper left"
+    },
+    {
+      "entityType": "project",
+      "entityId": 56,
+      "title": "AI Art Academy",
+      "prompt": "A grand studio classroom hung with paintings in many different historical styles, easels standing in rows, plaster casts on a high shelf, a robot student at the nearest easel copying a landscape, north light through tall windows"
+    },
+    {
+      "entityType": "project",
+      "entityId": 58,
+      "title": "Dream Cycle",
+      "prompt": "A brass orrery of dreams turning slowly in a dark observatory, six small glowing objects orbiting a central lamp, star charts pinned to the surrounding walls, deep blue light and warm instrument gold"
+    },
+    {
+      "entityType": "project",
+      "entityId": 1649,
+      "title": "Music Mentor",
+      "prompt": "A warm home recording corner, a microphone on a boom arm, headphones resting on a stack of handwritten sheet music, a small friendly robot listening intently from the edge of the desk, soft lamp light"
+    },
+    {
+      "entityType": "project",
+      "entityId": 95,
+      "title": "Ruler Hooked",
+      "prompt": "A crowned monarch sitting on the edge of a castle dock with a fishing rod, boots off, entirely at peace, an anxious court of advisors clustered on the battlements far behind waving scrolls, golden afternoon light"
+    },
+    {
+      "entityType": "project",
+      "entityId": 24,
+      "title": "Appmaker",
+      "prompt": "A workbench where small applications are built by hand like clockwork toys, half-assembled glowing panels and tiny screens nested in a wooden tray, brass tools laid out beside them, a magnifying lamp overhead"
+    },
+    {
+      "entityType": "project",
+      "entityId": 1834,
+      "title": "Taskmaster",
+      "prompt": "A tall wall of task cards being sorted by a calm robot on a rolling ladder, neat columns of pinned index cards, red string connecting a few of them, warm workshop light"
+    },
+    {
+      "entityType": "project",
+      "entityId": 20,
+      "title": "Engagement",
+      "prompt": "A glowing network of warm light threads connecting many small figures across a dark plane, energy visibly flowing along the strands between them, the nodes brightening at every junction"
+    },
+    {
+      "entityType": "project",
+      "entityId": 27,
+      "title": "Packmaker",
+      "prompt": "An open crate of freshly made game items on a workshop floor, glowing swords and potions and trinkets nested in straw, a stamping press standing behind it, warm forge light"
+    },
+    {
+      "entityType": "project",
+      "entityId": 28,
+      "title": "Ecosystem Map",
+      "prompt": "A vast illuminated wall map of interconnected islands, each island a different small settlement, glowing shipping routes drawn between them, one figure below studying it by lantern light"
+    },
+    {
+      "entityType": "project",
+      "entityId": 17,
+      "title": "Global UI",
+      "prompt": "A modular interface system laid out as physical panels on a light table, identical frames holding different contents, arranged in a clean even grid, soft studio light from directly above"
+    },
+    {
+      "entityType": "project",
+      "entityId": 54,
+      "title": "Superkate Hairstyle AI",
+      "prompt": "A bright modern salon station, a large round mirror ringed with warm bulbs, styling tools laid out in a neat row along the counter, colour swatches fanned beside them, teal and violet accents"
+    },
+    {
+      "entityType": "project",
+      "entityId": 16,
+      "title": "Superkate Services Calculator",
+      "prompt": "A dark elegant salon reception desk at closing time, an open appointment ledger, a small brass bell, one desk lamp lit, purple and teal light coming through the window behind"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "audit:fitness": "tsx utils/scripts/auditObjectFitness.ts",
     "test:migrate-on-deploy": "tsx utils/scripts/verifyMigrateOnDeploy.ts",
     "test:facet-aliases": "tsx utils/scripts/verifyFacetAliases.ts",
+    "audit:art-coverage": "tsx utils/scripts/auditEntityArtCoverage.ts",
     "test:facet-catalog": "prisma validate && tsx utils/scripts/verifyFacetCatalogCutover.ts && tsx utils/scripts/verifyFacetCanonicalMerges.ts && tsx utils/scripts/verifyDailyDreamFacets.ts && tsx utils/scripts/verifyFacetCurationMoodPolicy.ts",
     "test:facet-closure": "tsx utils/scripts/verifyFacetClosure.ts",
     "test:facet-gallery": "tsx utils/scripts/verifyFacetGallery.ts",

--- a/utils/scripts/auditEntityArtCoverage.ts
+++ b/utils/scripts/auditEntityArtCoverage.ts
@@ -1,0 +1,484 @@
+// /utils/scripts/auditEntityArtCoverage.ts
+//
+// Find every catalog object with no art at all, and give it some.
+//
+//   npx tsx utils/scripts/auditEntityArtCoverage.ts                 # audit only
+//   npx tsx utils/scripts/auditEntityArtCoverage.ts --apply         # enqueue
+//   npx tsx utils/scripts/auditEntityArtCoverage.ts --type dream    # one type
+//
+//   export KR_API_BASE=https://kindrobots.org
+//   export KR_API_TOKEN=<admin or server token>   # required for --apply and
+//                                                 # for reading the art queue
+//
+// WHY
+// ---
+// The dream-location lane created sixteen worlds and queued art for none of
+// them. Nothing failed and nothing warned; they simply arrived pictureless and
+// stayed that way, which is why the art queue never spiked and why the gap was
+// found by Silas asking rather than by anything in the codebase noticing.
+//
+// That lane is fixed, but "this one publisher forgot" is the small version of
+// the problem. The real question is how many objects across the whole catalog
+// are in the same state, and nothing could answer it -- so this does. Silas,
+// 2026-08-14: "anything, and I mean anything missing at least one art asset
+// should be given one."
+//
+// WHAT COUNTS AS ART
+// ------------------
+// Any of the real art fields being set: the primary slot (imagePath, or
+// avatarImage for bot), the icon/card/hero paths, or any of the ArtImage id
+// columns. An object with even one of those is left alone.
+//
+// `icon` is deliberately NOT in that list. It holds a NAME for an existing
+// icon in the Kind Robots set (e.g. 'kind-icon:bot'), never generated art --
+// the distinction is spelled out in server/utils/entityArt.ts and treating the
+// two as the same thing would hide every object whose only "art" is a string.
+//
+// `artCollectionId` is also not counted. A collection is a group of related
+// images, not the record's own display art, so a Dream carrying one still
+// renders a blank card. Those are reported separately rather than skipped.
+//
+// DEDUPE
+// ------
+// ArtJob has no entity foreign key -- the linkage lives inside `payload.entityArt`
+// (entityType, entityId, field), written by /api/art/enqueue. So every PENDING
+// and RUNNING job is read and its payload parsed, and any object already
+// waiting on a job is skipped. Without this, a second run would double every
+// job in the queue.
+//
+// The art queue pages on `page` + `pageSize` (max 200) and IGNORES `take`/`skip`
+// entirely -- a scan written with take/skip silently sees only the first 20
+// jobs and reports a confident, wrong answer. That mistake is why the first
+// pass at this question had to be thrown away.
+//
+// PROMPTS ARE AUTHORED, NOT ASSEMBLED
+// -----------------------------------
+// Nothing here builds a prompt by concatenating a record's fields. A Project's
+// description is roadmap prose ("Canonical book order and scope, clarified
+// 2026-07-17..."); joined into a prompt it asks an image model to paint a
+// changelog. A Dream's description is a paragraph about what a place is KNOWN
+// FOR, which is a different sentence from what it LOOKS like.
+//
+// So prompts come from config/art-coverage/*.json, written by hand, or from the
+// record's own artPrompt column where one already exists. An object with
+// neither is reported and skipped -- a picture invented from an empty row is
+// worse than an honest blank, and a bad render still costs the same mana.
+import { readFileSync, readdirSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+type EntityType =
+  | 'bot'
+  | 'dream'
+  | 'character'
+  | 'scenario'
+  | 'reward'
+  | 'facet'
+  | 'achievement'
+  | 'project'
+
+type Row = Record<string, unknown>
+
+/**
+ * Per-type endpoint, primary art field, and the fields a prompt is built from.
+ *
+ * Sizes come from ENTITY_FIELDS in server/utils/entityArt.ts and are repeated
+ * rather than imported because that module reaches for a Prisma client.
+ */
+const TYPES: Record<
+  EntityType,
+  {
+    endpoint: string
+    paged?: 'page' | 'skip'
+    field: string
+    width: number
+    height: number
+    promptFields: string[]
+  }
+> = {
+  bot: {
+    endpoint: '/api/bots',
+    paged: 'page',
+    field: 'avatarImage',
+    width: 1024,
+    height: 1024,
+    promptFields: ['name', 'subtitle', 'tagline', 'description', 'botIntro'],
+  },
+  dream: {
+    endpoint: '/api/dreams?take=1000',
+    field: 'imagePath',
+    width: 512,
+    height: 768,
+    promptFields: ['title', 'flavorText', 'pitch', 'description'],
+  },
+  character: {
+    endpoint: '/api/characters',
+    field: 'imagePath',
+    width: 512,
+    height: 768,
+    promptFields: ['name', 'title', 'species', 'class', 'personality', 'backstory'],
+  },
+  scenario: {
+    endpoint: '/api/scenarios',
+    field: 'imagePath',
+    width: 512,
+    height: 768,
+    promptFields: ['title', 'intro', 'description'],
+  },
+  reward: {
+    endpoint: '/api/rewards',
+    field: 'imagePath',
+    width: 512,
+    height: 768,
+    promptFields: ['name', 'text', 'power', 'description'],
+  },
+  facet: {
+    endpoint: '/api/facets?take=250',
+    paged: 'skip',
+    field: 'imagePath',
+    width: 512,
+    height: 768,
+    promptFields: ['title', 'description', 'artPrompt'],
+  },
+  achievement: {
+    endpoint: '/api/achievements',
+    field: 'imagePath',
+    width: 512,
+    height: 768,
+    promptFields: ['name', 'description', 'goal'],
+  },
+  project: {
+    endpoint: '/api/projects',
+    field: 'imagePath',
+    width: 512,
+    height: 768,
+    promptFields: ['name', 'title', 'pitch', 'description'],
+  },
+}
+
+/**
+ * Types this script must not enqueue for, and who owns them instead.
+ *
+ * Facets already have a dedicated lane: scripts/generate_facet_art.ts, run
+ * every week by facet-catalog-maintenance. It applies a quality gate this
+ * script knows nothing about -- no art for duplicate, malformed, composite,
+ * taxonomy-leaking, cargo-cult or unreviewed legacy Facets -- and it is caught
+ * up: of 904 art-less Facets on 2026-08-14, 186 were artRequired=false, 630
+ * were held by that gate, and the 88 genuinely eligible were all already
+ * queued. Blasting the other 816 from here would not be filling a gap, it
+ * would be overriding a deliberate decision to withhold art from records that
+ * need editing first.
+ */
+const OWNED_ELSEWHERE: Partial<Record<EntityType, string>> = {
+  facet: 'scripts/generate_facet_art.ts (weekly, via facet-catalog-maintenance)',
+}
+
+/** Real art fields. `icon` is a name, not art -- see the header. */
+const ART_FIELDS = [
+  'imagePath',
+  'avatarImage',
+  'iconPath',
+  'cardPath',
+  'heroPath',
+  'artImageId',
+  'iconArtImageId',
+  'cardArtImageId',
+  'heroArtImageId',
+]
+
+const APPLY = process.argv.includes('--apply')
+const base = (process.env.KR_API_BASE || 'https://kindrobots.org').replace(/\/$/, '')
+const token = process.env.KR_API_TOKEN || ''
+
+function arg(name: string): string | undefined {
+  const index = process.argv.indexOf(`--${name}`)
+  return index === -1 ? undefined : process.argv[index + 1]
+}
+
+function text(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function hasArt(row: Row): boolean {
+  return ART_FIELDS.some((field) => {
+    const value = row[field]
+    if (value === null || value === undefined) return false
+    if (typeof value === 'string') return value.trim().length > 0
+    if (typeof value === 'number') return value > 0
+    return false
+  })
+}
+
+function unwrap(body: unknown): Row[] {
+  const envelope = body as { data?: unknown } | null
+  const data = envelope?.data ?? body
+  if (Array.isArray(data)) return data as Row[]
+  const record = data as Record<string, unknown> | null
+  for (const key of Object.keys(record || {})) {
+    if (Array.isArray(record?.[key])) return record[key] as Row[]
+  }
+  return []
+}
+
+async function get(path: string, auth = false): Promise<unknown> {
+  const response = await fetch(`${base}${path}`, {
+    headers: auth && token ? { Authorization: `Bearer ${token}` } : {},
+  })
+  if (!response.ok) {
+    throw new Error(`GET ${path} -> ${response.status} ${await response.text()}`)
+  }
+  return response.json()
+}
+
+/** Every row of one type, following whichever pagination that route uses. */
+async function allRows(type: EntityType): Promise<Row[]> {
+  const config = TYPES[type]
+  if (!config.paged) return unwrap(await get(config.endpoint))
+
+  const rows: Row[] = []
+  const join = config.endpoint.includes('?') ? '&' : '?'
+  for (let index = 0; index < 60; index++) {
+    const query =
+      config.paged === 'page'
+        ? `${join}page=${index + 1}&pageSize=200`
+        : `${join}skip=${rows.length}`
+    const page = unwrap(await get(`${config.endpoint}${query}`))
+    if (!page.length) break
+    const before = rows.length
+    rows.push(...page)
+    if (rows.length === before) break
+    if (config.paged === 'page' && page.length < 200) break
+  }
+  return rows
+}
+
+/**
+ * Entities already waiting on art, as `type:id` keys.
+ *
+ * Reads every PENDING and RUNNING job and parses `payload.entityArt`. Jobs with
+ * no entityArt block (facet-catalog coverage runs, ad-hoc generations) simply
+ * contribute nothing, which is correct -- they are not claims on an entity slot.
+ */
+async function queuedEntities(): Promise<Set<string>> {
+  const queued = new Set<string>()
+  for (const status of ['PENDING', 'RUNNING']) {
+    for (let page = 1; page <= 60; page++) {
+      const body = (await get(
+        `/api/art/queue?status=${status}&pageSize=200&page=${page}`,
+        true,
+      )) as { data?: { jobs?: Row[]; pagination?: { page: number; pageCount: number } } }
+      const jobs = body?.data?.jobs || []
+      for (const job of jobs) {
+        const payload = job.payload as { entityArt?: Row } | null
+        const entity = payload?.entityArt
+        if (!entity) continue
+        const entityType = text(entity.entityType)
+        const entityId = Number(entity.entityId)
+        if (entityType && entityId > 0) queued.add(`${entityType}:${entityId}`)
+      }
+      const pagination = body?.data?.pagination
+      if (!pagination || pagination.page >= pagination.pageCount) break
+    }
+  }
+  return queued
+}
+
+type AuthoredPrompt = {
+  entityType: EntityType
+  entityId: number
+  title?: string
+  prompt: string
+}
+
+/** Every hand-written prompt, keyed `type:id`. */
+function authoredPrompts(): Map<string, string> {
+  const dir = join(process.cwd(), 'config', 'art-coverage')
+  const out = new Map<string, string>()
+  if (!existsSync(dir)) return out
+  for (const name of readdirSync(dir).filter((n) => n.endsWith('.json')).sort()) {
+    const batch = JSON.parse(readFileSync(join(dir, name), 'utf8')) as {
+      version?: number
+      prompts?: AuthoredPrompt[]
+    }
+    if (batch.version !== 1) {
+      throw new Error(`${name}: unexpected version ${batch.version}.`)
+    }
+    for (const entry of batch.prompts || []) {
+      const key = `${entry.entityType}:${entry.entityId}`
+      if (out.has(key)) throw new Error(`${name}: duplicate prompt for ${key}.`)
+      const prompt = text(entry.prompt)
+      if (prompt.length < 20) {
+        throw new Error(`${name}: ${key} prompt is too short to be authored.`)
+      }
+      out.set(key, prompt)
+    }
+  }
+  return out
+}
+
+/**
+ * The authored prompt for a record, or the one it already carries.
+ *
+ * Never assembled from the record's other fields -- see the header. Returns an
+ * empty string when there is nothing written, which makes the record a reported
+ * skip rather than a generic render.
+ */
+function promptFor(
+  type: EntityType,
+  row: Row,
+  authored: Map<string, string>,
+): string {
+  const written = authored.get(`${type}:${row.id}`)
+  if (written) return written.slice(0, 900)
+  const existing = text(row.artPrompt)
+  return existing.length >= 20 ? existing.slice(0, 900) : ''
+}
+
+async function enqueue(
+  type: EntityType,
+  row: Row,
+  prompt: string,
+): Promise<number> {
+  const config = TYPES[type]
+  const response = await fetch(`${base}/api/art/enqueue`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      engine: 'krea2',
+      promptString: prompt,
+      width: config.width,
+      height: config.height,
+      isPublic: row.isPublic ?? true,
+      isMature: row.isMature ?? false,
+      designer: text(row.designer) || null,
+      projectSlug: 'art-coverage',
+      entityArt: {
+        entityType: type,
+        entityId: Number(row.id),
+        field: config.field,
+        preserveOriginal: true,
+        mode: 'recreate',
+      },
+    }),
+  })
+  const body = (await response.json().catch(() => null)) as {
+    success?: boolean
+    message?: string
+    data?: { jobId?: number }
+  } | null
+  if (!response.ok || !body?.success || !body.data?.jobId) {
+    throw new Error(
+      `${type} #${row.id}: HTTP ${response.status} ${body?.message || 'enqueue failed'}`,
+    )
+  }
+  return Number(body.data.jobId)
+}
+
+async function main(): Promise<void> {
+  if (APPLY && !token) throw new Error('--apply requires KR_API_TOKEN.')
+  if (!token) {
+    console.warn(
+      'No KR_API_TOKEN: the art queue cannot be read, so already-queued ' +
+        'objects will be reported as needing a job. Audit numbers only.\n',
+    )
+  }
+
+  const only = arg('type') as EntityType | undefined
+  const types = only ? [only] : (Object.keys(TYPES) as EntityType[])
+  if (only && !TYPES[only]) throw new Error(`Unknown type "${only}".`)
+
+  const authored = authoredPrompts()
+  const queued = token ? await queuedEntities() : new Set<string>()
+  console.log(
+    `Authored prompts on file: ${authored.size}\n` +
+      `Entities already waiting on an ArtJob: ${queued.size}\n`,
+  )
+
+  const work: Array<{ type: EntityType; row: Row; prompt: string }> = []
+  const noPrompt: string[] = []
+  const deferred: string[] = []
+  let collectionOnly = 0
+
+  for (const type of types) {
+    const rows = await allRows(type)
+    const artless = rows.filter((row) => !hasArt(row))
+    const waiting = artless.filter((row) => queued.has(`${type}:${row.id}`))
+    const actionable = artless.filter((row) => !queued.has(`${type}:${row.id}`))
+
+    const owner = OWNED_ELSEWHERE[type]
+    if (!owner) {
+      for (const row of actionable) {
+        const prompt = promptFor(type, row, authored)
+        if (prompt) work.push({ type, row, prompt })
+        else noPrompt.push(`${type} #${row.id} ${text(row.title) || text(row.name)}`)
+        if (Number(row.artCollectionId) > 0) collectionOnly += 1
+      }
+    } else {
+      deferred.push(
+        `${type}: ${actionable.length} art-less and unqueued, owned by ${owner}`,
+      )
+    }
+
+    console.log(
+      `${type.padEnd(12)} ${String(rows.length).padStart(5)} rows  ` +
+        `${String(rows.length - artless.length).padStart(5)} with art  ` +
+        `${String(artless.length).padStart(5)} without  ` +
+        `${String(waiting.length).padStart(4)} already queued  ` +
+        `${String(actionable.length).padStart(5)} ${owner ? 'deferred  ' : 'need a job'}`,
+    )
+  }
+
+  console.log(`\n${work.length} job(s) to enqueue.`)
+  for (const entry of deferred) console.log(`Deferred — ${entry}`)
+  if (collectionOnly) {
+    console.log(
+      `${collectionOnly} of them carry an artCollectionId but no display art ` +
+        'of their own, so their card still renders blank.',
+    )
+  }
+  if (noPrompt.length) {
+    console.log(
+      `\n${noPrompt.length} skipped for having no authored prompt. Write one in ` +
+        'config/art-coverage/ rather than letting the record describe itself:',
+    )
+    for (const entry of noPrompt) console.log(`  - ${entry}`)
+  }
+
+  if (!APPLY) {
+    console.log('\nAudit only. Add --apply to enqueue.')
+    return
+  }
+
+  // Each job costs mana and GPU time. --limit exists so the first run of a
+  // sweep can be one job, checked in the queue by eye, before the rest follow.
+  const limit = Number(arg('limit') ?? work.length)
+  const batch = work.slice(0, Number.isFinite(limit) ? Math.max(0, limit) : work.length)
+  if (batch.length < work.length) {
+    console.log(`\n--limit ${limit}: enqueueing ${batch.length} of ${work.length}.`)
+  }
+
+  let queuedCount = 0
+  const failures: string[] = []
+  for (const item of batch) {
+    try {
+      const jobId = await enqueue(item.type, item.row, item.prompt)
+      queuedCount += 1
+      if (queuedCount % 25 === 0) {
+        console.log(`  … ${queuedCount}/${batch.length} queued (last job ${jobId})`)
+      }
+    } catch (error) {
+      failures.push(String(error instanceof Error ? error.message : error))
+    }
+  }
+
+  console.log(`\nQueued ${queuedCount} of ${batch.length}.`)
+  if (failures.length) {
+    console.error(`${failures.length} failed:`)
+    for (const failure of failures.slice(0, 20)) console.error(`  - ${failure}`)
+    process.exitCode = 1
+  }
+}
+
+await main()


### PR DESCRIPTION
> anything, and I mean anything missing at least one art asset should be given one

Nothing in the repo could answer how many there were, so `utils/scripts/auditEntityArtCoverage.ts` now does. It walks all eight art-bearing types, finds every row with **no art of any kind**, dedupes against the live queue, and enqueues one job each.

**47 jobs are live right now** under `projectSlug: art-coverage` — 33 Dreams and 14 Projects.

## What the sweep found

Of 2,421 objects:

| type | rows | with art | without |
|---|---:|---:|---:|
| bot | 69 | 69 | **0** |
| character | 228 | 228 | **0** |
| reward | 261 | 261 | **0** |
| achievement | 25 | 25 | **0** |
| dream | 75 | 39 | 36 |
| project | 36 | 22 | 14 |
| scenario | 117 | 116 | 1 |
| facet | 1610 | 706 | 904 |

`icon` is not counted as art — it holds a *name* for an existing icon (`kind-icon:bot`), never generated art, and the distinction is spelled out in `entityArt.ts`. `artCollectionId` is not counted either: a collection is a group of related images, not the record's own display art, so a Dream carrying one still renders a blank card. 12 of the queued Dreams were in exactly that state.

## Facets are deferred, not skipped

`scripts/generate_facet_art.ts` already owns them, weekly via `facet-catalog-maintenance`, and applies a quality gate this script knows nothing about — *no art for duplicate, malformed, composite, taxonomy-leaking, cargo-cult or unreviewed legacy Facets.*

Reproducing its eligibility split offline against the live catalog, the 904 break down as:

```
186  artRequired = false        withheld by design
630  held by the quality gate   464 unreviewed-legacy-record
                                268 underspecified-title
                                 57 sentence-title
                                  8 other
 88  genuinely eligible         ALL already queued
```

**That lane is caught up.** Last night's maintenance run queued every eligible Facet. Firing the other 816 from here would not fill a gap — it would override a deliberate decision to withhold art from records that need editing first, and spend a lot of GPU doing it. The script now names its owner instead of silently listing them as work.

## Prompts are authored, not assembled

Concatenating a Project's roadmap prose — *"Canonical book order and scope, clarified 2026-07-17…"* — asks an image model to paint a changelog. And a Dream's `description` says what a place is **known for**, which is a different sentence from what it **looks like**.

So all 50 are written by hand in `config/art-coverage/batch-0001.json`, and a record with no authored prompt is **reported rather than rendered** from whatever text it happens to carry. All 50 were checked against `server/utils/artPromptContract.ts` offline before anything was spent: **zero violations**, 28–46 words each.

## Three Dreams are blocked by their own descriptions

The contract gates the **full composed prompt**, and `buildEntityArtPrompt` folds the record's own Description, Pitch and Flavor text in — deliberately, since entity context can smuggle in a format noun as easily as an author can. But these three trip it on ordinary creative English about their own subject:

| dream | offending text | rule |
|---|---|---|
| #42 The Cthulian Jam Band Festival | "the main stage appears **only when** the bassline gets weird enough" | conditional-instruction |
| #48 The Lamp of a Thousand Parties | "the coins become useful **only when** given away" | conditional-instruction |
| #5654 The Overnight Midway | "an act announced on the **poster** must happen" | format-vocabulary |

**Left alone rather than edited.** Rewriting a Dream's description to satisfy an art gate damages real content, and loosening a contract built out of roughly 150 wasted renders is not a call to make in passing. Your call which way it goes — the honest options are refining the gate to treat quoted record context differently from author instructions, editing the three lines, or leaving those three without art.

## Repaired along the way

Dreams **3194, 3195 and 2155** carried pre-contract `artPrompt` columns containing `"cohesive Kind Robots visual style"` — now a hard reject. Those three could never have been given art again by any producer. Replaced with their authored prompts; all three then queued.

## Not queued

Scenario **#501** `"Updated-Scenario-1783846699135"`, description *"A unique scenario description."* That is a test artifact, not content, and it wants deleting rather than illustrating.

## Verification

- `npx vue-tsc --noEmit` — clean
- `npx eslint utils/scripts/auditEntityArtCoverage.ts` — clean
- All 50 prompts pass `checkArtPromptContract` at krea2 cfg 1 / 8 steps
- One job fired first and inspected in the live queue before the rest followed — correct slug, entity, field and authored prompt
- Re-running the sweep is idempotent: already-queued entities are skipped via `payload.entityArt`
- New: `npm run audit:art-coverage` (audit only; `--apply` writes, `--limit N` caps a first batch)

**Unrelated, noticed while verifying:** 2 `ai-art-academy` jobs have moved to FAILED since yesterday.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jx9MRHdNN2ye5mcLPXgx5A)_