### PR TITLE
fix(model-builder): scope generateItemAssetAsync's enqueue failure to cancelledRunIds (t-029)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -434,6 +434,12 @@ jobs:
       - name: Model Builder batch any-in-flight guard contract
         run: npm run test:model-builder-batch-any-in-flight-guard
 
+      - name: Model Builder async-enqueue cancelled-run guard checker self-test
+        run: npm run test:model-builder-async-enqueue-cancelled-run-guard-selftest
+
+      - name: Model Builder async-enqueue cancelled-run guard contract
+        run: npm run test:model-builder-async-enqueue-cancelled-run-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -221,6 +221,8 @@
     "test:model-builder-confirmed-outcome-guard": "tsx utils/scripts/verifyModelBuilderConfirmedOutcomeGuard.ts",
     "test:model-builder-batch-any-in-flight-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchAnyInFlightGuard.test.ts",
     "test:model-builder-batch-any-in-flight-guard": "tsx utils/scripts/verifyModelBuilderBatchAnyInFlightGuard.ts",
+    "test:model-builder-async-enqueue-cancelled-run-guard-selftest": "tsx utils/scripts/verifyModelBuilderAsyncEnqueueCancelledRunGuard.test.ts",
+    "test:model-builder-async-enqueue-cancelled-run-guard": "tsx utils/scripts/verifyModelBuilderAsyncEnqueueCancelledRunGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1349,6 +1349,16 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       )
       return true
     } catch (error) {
+      // Mirror generateItemAsset's identical guard, missing here until now:
+      // prepareArtGenerator/enqueueCurrentArt is a network round-trip the
+      // user can cancel this exact run during. Without this check, an
+      // enqueue that fails after cancellation still calls the global
+      // handleError() (an app-wide error banner, per its own doc comment --
+      // not scoped to any run) and rewrites the detached item's stage for a
+      // run the user already told the app to abandon, instead of quietly
+      // no-opping the way its synchronous sibling does.
+      if (cancelledRunIds.has(runId)) return false
+
       handleError(error, 'queueing model builder asset')
       item.error =
         error instanceof Error ? error.message : 'Failed to queue generation.'

--- a/utils/scripts/verifyModelBuilderAsyncEnqueueCancelledRunGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderAsyncEnqueueCancelledRunGuard.test.ts
@@ -1,0 +1,128 @@
+// /utils/scripts/verifyModelBuilderAsyncEnqueueCancelledRunGuard.test.ts
+//
+// Regression test for checkAsyncEnqueueCancelledRunGuard() in
+// verifyModelBuilderAsyncEnqueueCancelledRunGuard.ts (model-builder/t-029).
+// Exercises the real check against synthetic store-shaped fixtures covering:
+// the pre-fix shape (no cancelledRunIds check before the catch block's
+// handleError call -- the exact gap found by manual read-through, comparing
+// generateItemAssetAsync against its synchronous sibling generateItemAsset),
+// and the fixed shape.
+import assert from 'node:assert/strict'
+
+import { checkAsyncEnqueueCancelledRunGuard } from './verifyModelBuilderAsyncEnqueueCancelledRunGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function generateItemAssetAsync(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return false
+    const runId = state.run.id
+
+    item.error = null
+    item.queueState = 'queued'
+    item.stages.GENERATE_ASSETS = { status: 'in-progress', note: 'queued' }
+    clearStatus()
+
+    try {
+      await artStore.prepareArtGenerator()
+
+      const enqueued = await artStore.enqueueCurrentArt({ promptString: prompt })
+
+      if (!enqueued.success || !enqueued.jobId || !enqueued.data) {
+        throw new Error(enqueued.message || 'Failed to queue generation.')
+      }
+
+      item.artJobId = enqueued.jobId
+      void pollAsyncArtJob(item, enqueued.jobId, enqueued.data, output, prompt, dims, runId)
+      return true
+    } catch (error) {
+      handleError(error, 'queueing model builder asset')
+      item.error = error instanceof Error ? error.message : 'Failed to queue generation.'
+      finishGenerateAssets(item, { status: 'ready', note: item.error })
+      item.queueState = null
+      item.artJobId = null
+      setStatusForRun(runId, 'error', item.error)
+      return false
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function generateItemAssetAsync(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return false
+    const runId = state.run.id
+
+    item.error = null
+    item.queueState = 'queued'
+    item.stages.GENERATE_ASSETS = { status: 'in-progress', note: 'queued' }
+    clearStatus()
+
+    try {
+      await artStore.prepareArtGenerator()
+
+      const enqueued = await artStore.enqueueCurrentArt({ promptString: prompt })
+
+      if (!enqueued.success || !enqueued.jobId || !enqueued.data) {
+        throw new Error(enqueued.message || 'Failed to queue generation.')
+      }
+
+      item.artJobId = enqueued.jobId
+      void pollAsyncArtJob(item, enqueued.jobId, enqueued.data, output, prompt, dims, runId)
+      return true
+    } catch (error) {
+      if (cancelledRunIds.has(runId)) return false
+
+      handleError(error, 'queueing model builder asset')
+      item.error = error instanceof Error ? error.message : 'Failed to queue generation.'
+      finishGenerateAssets(item, { status: 'ready', note: item.error })
+      item.queueState = null
+      item.artJobId = null
+      setStatusForRun(runId, 'error', item.error)
+      return false
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkAsyncEnqueueCancelledRunGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  1,
+  `expected the pre-fix shape (missing cancelledRunIds check before ` +
+    `handleError) to raise 1 error, got ${buggyErrors.length}: ` +
+    `${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors[0]!.includes('cancelledRunIds'),
+  'expected a violation naming the missing cancelledRunIds check',
+)
+
+const fixedErrors = checkAsyncEnqueueCancelledRunGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingFnErrors = checkAsyncEnqueueCancelledRunGuard(MISSING_FIXTURE)
+assert.equal(
+  missingFnErrors.length,
+  1,
+  'expected a single "function not found" violation when ' +
+    'generateItemAssetAsync is absent',
+)
+assert.ok(missingFnErrors[0]!.includes('generateItemAssetAsync'))
+
+console.log(
+  'Model Builder async-enqueue cancelled-run guard checker verified: flags ' +
+    'the pre-fix shape (missing cancelledRunIds check before the catch ' +
+    "block's handleError call), clears the fixed shape, and flags " +
+    'generateItemAssetAsync being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderAsyncEnqueueCancelledRunGuard.ts
+++ b/utils/scripts/verifyModelBuilderAsyncEnqueueCancelledRunGuard.ts
@@ -1,0 +1,114 @@
+// /utils/scripts/verifyModelBuilderAsyncEnqueueCancelledRunGuard.ts
+//
+// Regression guard (model-builder/t-029) -- generateItemAssetAsync()'s catch
+// block (covering `artStore.prepareArtGenerator()` / `artStore.enqueueCurrentArt()`,
+// both network round-trips) called the global handleError() unconditionally and
+// unconditionally rewrote the item's GENERATE_ASSETS stage/queueState, with no
+// check against cancelledRunIds. Its synchronous sibling generateItemAsset --
+// literally the previous function in this same file -- already guards its own
+// catch block with `if (cancelledRunIds.has(runId)) return false` as the very
+// first line, precisely so a render/enqueue that fails after the user has
+// cancelled this exact run (via the History panel's cancelRun()) doesn't pop a
+// stray, app-wide error banner or touch a now-detached item for a run the user
+// already told the app to abandon. generateItemAssetAsync never got the same
+// treatment: click "Queue generation in background", cancel the run while
+// prepareArtGenerator/enqueueCurrentArt is still in flight, then have that
+// enqueue independently fail (network hiccup, guest-promotion failure, quota) --
+// handleError() fires a global "An error occurred while queueing model builder
+// asset: ..." toast regardless of the cancellation, unlike every other
+// cancellable async entry point in this store (generateItemAsset,
+// pollAsyncArtJob, commitItem all check cancelledRunIds before their own
+// handleError/toast).
+//
+// This asserts the textual shape of the fix stays in place: a
+// `cancelledRunIds.has(runId)` check appears in generateItemAssetAsync's body
+// strictly before its `handleError(error, 'queueing model builder asset')`
+// call -- deliberately scoped to this one function/bug, mirroring
+// verifyModelBuilderCommitCancelledRunGuard.ts's and
+// verifyModelBuilderCancelledRunGuard.ts's own narrow textual checks over a
+// general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'generateItemAssetAsync'
+const HANDLE_ERROR_CALL = "handleError(error, 'queueing model builder asset')"
+const GUARD = 'cancelledRunIds.has(runId)'
+
+// Checks the fix's exact shape against the full source text of a file
+// containing a `generateItemAssetAsync`-named async function. Exported
+// (rather than only exercised via main()) so the self-test below can run it
+// against synthetic buggy/fixed fixtures without touching the real store
+// file.
+export function checkAsyncEnqueueCancelledRunGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find an async function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  const handleErrorIndex = fn.body.indexOf(HANDLE_ERROR_CALL)
+  if (handleErrorIndex === -1) {
+    errors.push(
+      `${FN_NAME}() no longer calls ${HANDLE_ERROR_CALL} -- this guard's ` +
+        "anchor point has moved; re-check how this function's enqueue " +
+        'failure is reported.',
+    )
+    return errors
+  }
+
+  const guardIndex = fn.body.indexOf(GUARD)
+  if (guardIndex === -1 || guardIndex >= handleErrorIndex) {
+    errors.push(
+      `${FN_NAME}() does not check \`${GUARD}\` before its ` +
+        `${HANDLE_ERROR_CALL} call. prepareArtGenerator/enqueueCurrentArt is ` +
+        'a network round-trip the user can cancel this run during; without ' +
+        'this check, an enqueue that fails after cancellation still pops a ' +
+        'global, unscoped error banner and rewrites the detached item for a ' +
+        'run the user already told the app to abandon -- unlike this ' +
+        "function's own synchronous sibling generateItemAsset, which guards " +
+        'its identical catch block the same way.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkAsyncEnqueueCancelledRunGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder async-enqueue cancelled-run guard contract failed for ' +
+        `${FN_NAME}() in modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder async-enqueue cancelled-run guard contract passed: ' +
+      `${FN_NAME}() checks cancelledRunIds before reporting an enqueue ` +
+      'failure, matching its synchronous sibling generateItemAsset.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Bug

`generateItemAssetAsync()`'s catch block (covering `artStore.prepareArtGenerator()` /
`artStore.enqueueCurrentArt()`, both network round-trips) called the global
`handleError()` unconditionally and unconditionally rewrote the item's
GENERATE_ASSETS stage/queueState, with **no check against `cancelledRunIds`**.

Its synchronous sibling `generateItemAsset` — literally the previous function
in the same file — already guards its own catch block with
`if (cancelledRunIds.has(runId)) return false` as the very first line,
precisely so a render that fails after the user has cancelled this exact run
(via the History panel's `cancelRun()`) doesn't pop a stray, app-wide error
banner or touch a now-detached item for a run the user already told the app
to abandon. `pollAsyncArtJob` and `commitItem` both carry the same guard in
their own catch/error paths.

`generateItemAssetAsync` never got the same treatment. Concretely: click
"Queue generation in background" on an item, cancel that run while
`prepareArtGenerator`/`enqueueCurrentArt` is still in flight, then have that
enqueue independently fail (network hiccup, guest-promotion failure, quota,
etc.) — `handleError()` fires a global "An error occurred while queueing
model builder asset: ..." toast regardless of the cancellation, unlike every
other cancellable async entry point in this store.

## Fix

Added the same `if (cancelledRunIds.has(runId)) return false` guard as the
first line of `generateItemAssetAsync`'s catch block, mirroring
`generateItemAsset` exactly (`stores/modelBuilderStore.ts`).

## Guard

Added `utils/scripts/verifyModelBuilderAsyncEnqueueCancelledRunGuard.ts` +
its self-test (`.test.ts`), modeled on the existing narrow-textual-guard
convention (`verifyModelBuilderCommitCancelledRunGuard.ts` /
`verifyModelBuilderCancelledRunGuard.ts`): it asserts a
`cancelledRunIds.has(runId)` check appears in `generateItemAssetAsync`'s body
strictly before its `handleError(error, 'queueing model builder asset')`
call. Wired into `package.json` and `.github/workflows/contract-tests.yml`.

## Verification

- `npx tsx utils/scripts/verifyModelBuilderAsyncEnqueueCancelledRunGuard.test.ts` — pass
- `npx tsx utils/scripts/verifyModelBuilderAsyncEnqueueCancelledRunGuard.ts` — pass
- All 28 pre-existing `verifyModelBuilder*` guards + their self-tests — all pass, no regressions
- `npx eslint stores/modelBuilderStore.ts utils/scripts/verifyModelBuilderAsyncEnqueueCancelledRunGuard.ts utils/scripts/verifyModelBuilderAsyncEnqueueCancelledRunGuard.test.ts` — clean (the store file's 2 pre-existing `no-empty` warnings on unrelated `safeSet`/`safeRemove` lines predate this change, confirmed via `git show origin/main`)
- `npx prettier --check` on all touched files — clean
- `npm run test` (`vue-tsc --noEmit`) — clean, exit 0, no errors
- `git status --porcelain` / `git diff origin/main --stat` — exactly the 5 intended files, no stray changes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQnYcVgwTNuo8sHgNXPH3W)_