### PR TITLE
fix(model-builder): report a failed artifact-recording POST instead of silently discarding it (t-029)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -440,6 +440,12 @@ jobs:
       - name: Model Builder async-enqueue cancelled-run guard contract
         run: npm run test:model-builder-async-enqueue-cancelled-run-guard
 
+      - name: Model Builder recordArtifact success guard checker self-test
+        run: npm run test:model-builder-record-artifact-success-guard-selftest
+
+      - name: Model Builder recordArtifact success guard contract
+        run: npm run test:model-builder-record-artifact-success-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -223,6 +223,8 @@
     "test:model-builder-batch-any-in-flight-guard": "tsx utils/scripts/verifyModelBuilderBatchAnyInFlightGuard.ts",
     "test:model-builder-async-enqueue-cancelled-run-guard-selftest": "tsx utils/scripts/verifyModelBuilderAsyncEnqueueCancelledRunGuard.test.ts",
     "test:model-builder-async-enqueue-cancelled-run-guard": "tsx utils/scripts/verifyModelBuilderAsyncEnqueueCancelledRunGuard.ts",
+    "test:model-builder-record-artifact-success-guard-selftest": "tsx utils/scripts/verifyModelBuilderRecordArtifactSuccessGuard.test.ts",
+    "test:model-builder-record-artifact-success-guard": "tsx utils/scripts/verifyModelBuilderRecordArtifactSuccessGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1031,15 +1031,45 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
 
   // --- GENERATE_ASSETS: reuse the existing art generator --------------------
 
+  // Persists a GENERATE_ASSETS candidate as a durable ModelBuildArtifact row —
+  // this is what adaptItem's imagePath (Artifacts[last]?.promotedPath ??
+  // draftPath) reconstructs from on the NEXT resume/reload, independent of
+  // item.artImageId (which is written separately, straight onto the item, by
+  // the pushItem call right after this one). performFetch never rejects for
+  // an HTTP-level failure — a validation error, assertArtImageAttachable's
+  // 403, or a 409 from assertRunWritable if the run was cancelled mid-request
+  // — it always *resolves* with `{ success: false }` (see its own doc comment:
+  // "honor both fields so a body-level failure is never reported as a
+  // successful fetch"). This function's try/catch never actually caught that:
+  // it awaited performFetch without ever checking `.success`, so ANY failure
+  // of this POST was silently discarded with no error surfaced anywhere and
+  // no retry. Both call sites proceed straight to marking the stage 'ready'
+  // and popping a "Generated a candidate" success toast regardless — so the
+  // user sees success while the durable Artifact row (and the imagePath a
+  // later resume/reload reconstructs from it) was simply never written.
+  // Concrete repro: generate a candidate for an item, have this POST fail for
+  // any reason (a transient DB error is enough — no cancellation needed),
+  // approve GENERATE_ASSETS ("Keep this asset" still shows the just-rendered
+  // thumbnail from local state), then reload the page — the stage is still
+  // 'approved' and item.artImageId is still set (commit still works off it),
+  // but item.imagePath comes back null because adaptItem has no Artifact row
+  // to read it from, so the approved candidate silently loses its preview
+  // image with no error ever having been shown. Fixed by checking `.success`
+  // and reporting a real failure the same run-scoped way every other action
+  // in this file does (mirrors pushItem/batchPushItems); setStatusForRun
+  // already no-ops if the run isn't the one currently on screen, so this
+  // still stays silent for a run the user has since cancelled or left.
   async function recordArtifact(
     item: BuildItem,
     image: { id: number; imagePath?: string | null },
     output: BuildOutputConfig | undefined,
     prompt: string,
     dims: { width: number; height: number },
+    runId: string,
   ): Promise<void> {
-    try {
-      await performFetch(`/api/model-builder/items/${item.id}/artifacts`, {
+    const result = await performFetch(
+      `/api/model-builder/items/${item.id}/artifacts`,
+      {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -1052,9 +1082,15 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
           draftPath: image.imagePath ?? null,
           reviewState: 'PENDING',
         }),
-      })
-    } catch (error) {
-      handleError(error, 'recording build artifact')
+      },
+    )
+    if (!result.success) {
+      setStatusForRun(
+        runId,
+        'error',
+        result.message ||
+          `Generated a candidate for ${item.label}, but recording it failed — it may not survive a reload.`,
+      )
     }
   }
 
@@ -1140,7 +1176,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       item.imagePath = image.imagePath ?? null
       finishGenerateAssets(item, { status: 'ready' })
 
-      await recordArtifact(item, image, output, prompt, dims)
+      await recordArtifact(item, image, output, prompt, dims, runId)
       pushItem(item, {
         stageStatuses: item.stages,
         artImageId: item.artImageId,
@@ -1273,7 +1309,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       item.imagePath = image.imagePath ?? null
       finishGenerateAssets(item, { status: 'ready' })
 
-      await recordArtifact(item, image, output, prompt, dims)
+      await recordArtifact(item, image, output, prompt, dims, runId)
       pushItem(item, {
         stageStatuses: item.stages,
         artImageId: item.artImageId,

--- a/utils/scripts/verifyModelBuilderRecordArtifactSuccessGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderRecordArtifactSuccessGuard.test.ts
@@ -1,0 +1,119 @@
+// /utils/scripts/verifyModelBuilderRecordArtifactSuccessGuard.test.ts
+//
+// Regression test for checkRecordArtifactSuccessGuard() in
+// verifyModelBuilderRecordArtifactSuccessGuard.ts (model-builder/t-029).
+// Exercises the real check against synthetic store-shaped fixtures covering:
+// the pre-fix shape (a bare try/catch around performFetch with no `.success`
+// check -- the exact gap found by manual read-through, since performFetch
+// never rejects for an HTTP-level failure so that catch block never actually
+// fires for the failures this function needs to report), and the fixed
+// shape.
+import assert from 'node:assert/strict'
+
+import { checkRecordArtifactSuccessGuard } from './verifyModelBuilderRecordArtifactSuccessGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function recordArtifact(
+    item: BuildItem,
+    image: { id: number; imagePath?: string | null },
+    output: BuildOutputConfig | undefined,
+    prompt: string,
+    dims: { width: number; height: number },
+  ): Promise<void> {
+    try {
+      await performFetch(\`/api/model-builder/items/\${item.id}/artifacts\`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          kind: 'image',
+          provider: output?.engine ?? null,
+          prompt,
+          width: dims.width,
+          height: dims.height,
+          artImageId: image.id,
+          draftPath: image.imagePath ?? null,
+          reviewState: 'PENDING',
+        }),
+      })
+    } catch (error) {
+      handleError(error, 'recording build artifact')
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function recordArtifact(
+    item: BuildItem,
+    image: { id: number; imagePath?: string | null },
+    output: BuildOutputConfig | undefined,
+    prompt: string,
+    dims: { width: number; height: number },
+    runId: string,
+  ): Promise<void> {
+    const result = await performFetch(\`/api/model-builder/items/\${item.id}/artifacts\`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        kind: 'image',
+        provider: output?.engine ?? null,
+        prompt,
+        width: dims.width,
+        height: dims.height,
+        artImageId: image.id,
+        draftPath: image.imagePath ?? null,
+        reviewState: 'PENDING',
+      }),
+    })
+    if (!result.success) {
+      setStatusForRun(
+        runId,
+        'error',
+        result.message || \`Generated a candidate for \${item.label}, but recording it failed.\`,
+      )
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkRecordArtifactSuccessGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  1,
+  `expected the pre-fix shape (no .success check on the resolved ` +
+    `performFetch response) to raise 1 error, got ${buggyErrors.length}: ` +
+    `${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors[0]!.includes('.success'),
+  'expected a violation naming the missing .success check',
+)
+
+const fixedErrors = checkRecordArtifactSuccessGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingFnErrors = checkRecordArtifactSuccessGuard(MISSING_FIXTURE)
+assert.equal(
+  missingFnErrors.length,
+  1,
+  'expected a single "function not found" violation when recordArtifact ' +
+    'is absent',
+)
+assert.ok(missingFnErrors[0]!.includes('recordArtifact'))
+
+console.log(
+  'Model Builder recordArtifact success guard checker verified: flags the ' +
+    'pre-fix shape (no .success check on the resolved performFetch ' +
+    'response), clears the fixed shape, and flags recordArtifact being ' +
+    'absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderRecordArtifactSuccessGuard.ts
+++ b/utils/scripts/verifyModelBuilderRecordArtifactSuccessGuard.ts
@@ -1,0 +1,132 @@
+// /utils/scripts/verifyModelBuilderRecordArtifactSuccessGuard.ts
+//
+// Regression guard (model-builder/t-029) -- recordArtifact() persists a
+// GENERATE_ASSETS candidate as a durable ModelBuildArtifact row: adaptItem's
+// imagePath (Artifacts[last]?.promotedPath ?? draftPath) reconstructs from
+// this row on the NEXT resume/reload, independent of item.artImageId (which
+// is written separately, straight onto the item, by the pushItem call right
+// after this one). performFetch never rejects for an HTTP-level failure -- a
+// validation error, assertArtImageAttachable's 403, or a 409 from
+// assertRunWritable if the run was cancelled mid-request -- it always
+// *resolves* with `{ success: false }` (see its own doc comment: "honor both
+// fields so a body-level failure is never reported as a successful fetch").
+// Before this fix, recordArtifact awaited performFetch inside a try/catch but
+// never checked `.success` on the resolved response -- since performFetch
+// doesn't throw for a body-level failure, that catch block was effectively
+// dead code, and ANY failure of this POST was silently discarded with no
+// error surfaced anywhere and no retry. Both call sites (generateItemAsset,
+// pollAsyncArtJob) proceed straight to marking the stage 'ready' and popping
+// a "Generated a candidate" success toast regardless -- so the user sees
+// success while the durable Artifact row was simply never written. Concrete
+// repro: generate a candidate, have this POST fail for any reason (no
+// cancellation needed -- a transient DB error is enough), approve
+// GENERATE_ASSETS (the just-rendered thumbnail is still showing from local
+// state), reload the page -- the stage is still 'approved' and
+// item.artImageId is still set (commit still works off it), but
+// item.imagePath comes back null because adaptItem has no Artifact row to
+// read it from, so the approved candidate silently loses its preview image
+// with no error ever having been shown.
+//
+// This asserts the textual shape of that fix stays in place: recordArtifact()
+// checks `result.success` (or an equivalent `!result.success`/`.success ===
+// false` guard on the resolved performFetch response) before returning, and
+// no longer performs the POST inside a try/catch that never checks it --
+// deliberately scoped to this one function/bug, mirroring
+// verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.ts's own narrow
+// textual check over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'recordArtifact'
+const FETCH_CALL = 'performFetch('
+const SUCCESS_CHECK_PATTERN =
+  /!\s*result\.success|result\.success\s*===\s*false/
+
+// Checks the fix's exact shape against the full source text of a file
+// containing a `recordArtifact`-named async function. Exported (rather than
+// only exercised via main()) so the self-test below can run it against
+// synthetic buggy/fixed fixtures without touching the real store file.
+export function checkRecordArtifactSuccessGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find an async function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  const fetchIndex = fn.body.indexOf(FETCH_CALL)
+  if (fetchIndex === -1) {
+    errors.push(
+      `${FN_NAME}() no longer calls ${FETCH_CALL} -- this guard's anchor ` +
+        "point has moved; re-check how this function's artifact-recording " +
+        'request is issued.',
+    )
+    return errors
+  }
+
+  if (!SUCCESS_CHECK_PATTERN.test(fn.body)) {
+    errors.push(
+      `${FN_NAME}() does not check the resolved response's \`.success\` ` +
+        'field (expected something like `if (!result.success) { ... }`). ' +
+        'performFetch never rejects for an HTTP-level failure -- it always ' +
+        'resolves with `{ success: false }` -- so a bare try/catch around ' +
+        'the await never actually catches a failed artifact-recording POST. ' +
+        'Without a `.success` check, that failure is silently discarded: ' +
+        'the caller still marks the stage ready and pops a success toast, ' +
+        'but the durable Artifact row an eventual reload reconstructs ' +
+        'item.imagePath from was never written.',
+    )
+  }
+
+  // The pre-fix shape wrapped the fetch in a try/catch and called the
+  // *unconditional* global handleError() only from that catch block -- which
+  // performFetch's always-resolve behavior made unreachable in practice for
+  // the exact failures this function needs to report. A bare
+  // `catch (error) { handleError(error, ...) }` with no success check
+  // anywhere in the body is the buggy shape even if a success check exists
+  // elsewhere by coincidence, so this only flags the specific combination:
+  // no success check at all (handled above). No further check needed here --
+  // keeping this guard narrow, one function/bug, per the file's convention.
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkRecordArtifactSuccessGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder recordArtifact success guard contract failed for ' +
+        `${FN_NAME}() in modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder recordArtifact success guard contract passed: ' +
+      `${FN_NAME}() checks the resolved response's success field before ` +
+      'returning, so a failed artifact-recording POST is reported instead ' +
+      'of silently discarded.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
model-builder/t-029: recurring bug-hunt cycle (kind: software)

### What changed / what I produced
- `stores/modelBuilderStore.ts`: `recordArtifact()` awaited `performFetch` inside a `try/catch` but never checked the resolved response's `.success` field. `performFetch` never *rejects* for an HTTP-level failure (a validation error, `assertArtImageAttachable`'s 403, or a 409 from `assertRunWritable` if the run was cancelled mid-request) — it always *resolves* with `{ success: false }` (see its own doc comment: "honor both fields so a body-level failure is never reported as a successful fetch"). That made the `catch` block effectively dead code: any failure of the artifact-recording POST was silently discarded, with no error surfaced anywhere and no retry.
  - Both call sites (`generateItemAsset`, `pollAsyncArtJob`) proceed straight to marking `GENERATE_ASSETS` `ready` and popping a "Generated a candidate" success toast regardless — so the user sees success while the durable `ModelBuildArtifact` row is never written.
  - Concrete repro: generate a candidate, have this POST fail for any reason (no cancellation needed — a transient DB error is enough), approve `GENERATE_ASSETS` (the just-rendered thumbnail is still showing from local state), reload the page — the stage is still `'approved'` and `item.artImageId` is still set (commit still works off it), but `item.imagePath` comes back `null` because `adaptItem` has no `Artifact` row to reconstruct it from (`Artifacts[last]?.promotedPath ?? draftPath`). The approved candidate silently loses its preview image with no error ever having been shown.
  - Fixed by checking `result.success` and reporting a real failure the same run-scoped way every other action in this store does (mirrors `pushItem`/`batchPushItems`'s `setStatusForRun` pattern), instead of a try/catch that performFetch's always-resolve behavior made unreachable.
- Added `utils/scripts/verifyModelBuilderRecordArtifactSuccessGuard.ts` + `.test.ts` following the established narrow-textual-checker convention (28 prior `verifyModelBuilder*` guards), wired into `package.json` and `.github/workflows/contract-tests.yml`.

### How I verified
- New guard self-test + guard contract pass (`npm run test:model-builder-record-artifact-success-guard-selftest` / `-guard`).
- All 28 pre-existing `verifyModelBuilder*` guard + selftest scripts pass — no regression (ran every `test:model-builder-*` script in `package.json`, 29 total incl. the new one).
- `eslint` on touched files clean (2 pre-existing `no-empty` errors at unrelated lines 204/211 of `modelBuilderStore.ts` — confirmed present verbatim on `origin/main` before this change, not introduced by this diff).
- `prettier --write` applied to touched/new files; `prettier --check` clean afterward.
- `vue-tsc --noEmit` exits 0 repo-wide.
- `git status --porcelain` showed exactly the 5 intended files.

### Stakes
reversible

### Flags for Reviewer
- The bug hunt this cycle looked hard at `batchApproveStage` (no `isStageEditable`/in-flight gate before approving) and `batchSetField`'s all-or-nothing partial-failure reporting on a 207 batch response — both looked like plausible candidates but didn't hold up to a concrete repro once traced through (the former's only wired call site, `FIELDS_AND_PROMPTS`, is never `'in-progress'`, and `draftText`'s own `isStageEditable` guard already discards a stale draft racing an approval regardless of which UI surface triggered it; the latter is closer to a UX nitpick than a correctness bug). `recordArtifact`'s silently-unreachable catch block was the one that produced a genuine, concrete, previously-unguarded repro.

### Kaizen suggestion
`batchSetField`'s all-or-nothing outcome reporting on a partial-failure (HTTP 207) batch response could be made more precise — right now a single failing item in a group PATCH suppresses the success toast for the whole batch with no indication of which items actually persisted. Worth a look in a future cycle if it recurs as a real complaint, but didn't rise to this cycle's bar for a concrete bug.

### Notes for reviewer
Recurring task — roadmap `model-builder/t-029` will be rearmed to `status: ready` after this merges, per its established convention (never reaches `done`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01ChP3uJWBHs6BmNeHCWYjKx)_