### PR TITLE
A Facet description is also an art prompt; check it like one

### DIFF
--- a/config/facet-content/batch-0003-material.json
+++ b/config/facet-content/batch-0003-material.json
@@ -79,7 +79,7 @@
       "facetId": 848,
       "title": "Moonstone",
       "taxonomy": "MATERIAL",
-      "description": "Sheens blue when turned, and only when turned. Sits inert on a shelf, which is precisely why it is worn instead."
+      "description": "Sheens blue as it turns and goes flat the moment it stops. Sits inert on a shelf, which is precisely why it is worn instead."
     },
     {
       "facetId": 844,

--- a/utils/scripts/verifyFacetContentQuality.ts
+++ b/utils/scripts/verifyFacetContentQuality.ts
@@ -16,6 +16,7 @@
 // to grow up. The universe respected this. Regenerates everything, including bad
 // decisions." These rules exist to keep 565 new rows from dragging that average
 // down, and every one of them is a thing I caught myself doing while writing.
+import { checkArtPromptContract } from './../../server/utils/artPromptContract'
 import { loadFacetContentBatches } from './publishFacetContent'
 
 const entries = loadFacetContentBatches()
@@ -83,6 +84,45 @@ for (const entry of entries) {
 
   if (entry.flavorText && entry.flavorText.trim().length < 3) {
     violations.push(`${where}: flavorText is present but empty.`)
+  }
+
+  /*
+   * A Facet description is also an ART PROMPT, and that was learned the
+   * expensive way.
+   *
+   * `generate_facet_art.ts` composes each job's prompt out of the Facet's own
+   * title, description, flavor text and examples, and `/api/art/enqueue` gates
+   * the FULL composed string. So an ordinary English phrase in a description
+   * rejects the job -- and because the maintenance run enqueues inside a
+   * serialized session, one bad row fails the ENTIRE run at the last step,
+   * after the catalog work has already committed.
+   *
+   * That is exactly what happened on 2026-08-14 (run 31765805301). MATERIAL
+   * "Moonstone" read "Sheens blue when turned, and only when turned" -- good
+   * prose, and "only when" is a conditional the contract refuses. One of 565
+   * descriptions took down a run covering 714 facets, six minutes in.
+   *
+   * The dream prompts in config/art-coverage were checked against this contract
+   * before anything was spent. These were not, purely because a description did
+   * not look like a prompt. It is one.
+   */
+  const composed = [
+    `Illustrate the Facet concept “${entry.title}”.`,
+    description,
+    entry.flavorText || '',
+  ]
+    .filter(Boolean)
+    .join('\n')
+  for (const violation of checkArtPromptContract({
+    prompt: composed,
+    engine: 'krea2',
+    cfg: 1,
+    steps: 8,
+  })) {
+    violations.push(
+      `${where}: this description would be rejected as an art prompt — ` +
+        `[${violation.rule}] ${violation.detail}`,
+    )
   }
 }
 


### PR DESCRIPTION
**My bug, caught by the run I triggered.** Fixing it and adding the guard that should have existed before I wrote 565 descriptions.

## What failed

[Run 31765805301](https://github.com/silasfelinus/kind_robots/actions/runs/31765805301) failed six minutes in, at the last step:

```
[conditional-instruction] "only when" asks the model to evaluate a condition.
  at generate_facet_art.ts:388
```

The source was `MATERIAL "Moonstone"`, and I wrote it this morning:

> Sheens blue when turned, **and only when turned**. Sits inert on a shelf, which is precisely why it is worn instead.

That is decent prose and an illegal art prompt.

## Why one line took down 714 facets

`generate_facet_art.ts` composes each job's prompt from the Facet's own **title, description, flavor text and examples** — and `/api/art/enqueue` gates the **full composed string**. So an ordinary English phrase sitting in a description rejects the job.

Because the maintenance run enqueues inside a **serialized session**, that single rejection failed the entire run — after the catalog work had already committed. The blast radius of a bad adjective is the whole lane.

I checked the dream prompts in `config/art-coverage` against this exact contract before spending anything, and said so in #1873. I did not check these, purely because a description does not *look* like a prompt. It is one.

## The guard

`verifyFacetContentQuality` now runs `checkArtPromptContract` over every authored description, composed the way `generate_facet_art` composes it:

```
Illustrate the Facet concept “{title}”.
{description}
{flavorText}
```

**Proven** by planting the original Moonstone line back and watching it fail with the identical message the production run produced.

## The fix

Moonstone now reads:

> Sheens blue as it turns and goes flat the moment it stops. Sits inert on a shelf, which is precisely why it is worn instead.

Same meaning, better line.

Its stored `artPrompt` column was cleared too. The failed run had already composed and saved the bad text there, and `buildFacetIdentityPrompt` **prefers `artPrompt` over `description`** — so fixing only the description would have changed nothing and the next run would have failed identically.

## Swept the rest before re-triggering

Ran the contract over **all 714 art-eligible Facets** using the same composition rule:

```
eligible: 714, contract rejections: 0
```

Moonstone was the only one in the entire catalog. The maintenance run is re-triggered.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jx9MRHdNN2ye5mcLPXgx5A)_