### PR TITLE
fix(model-builder): guard fetchRuns() against a stale out-of-order response (t-029)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -446,6 +446,12 @@ jobs:
       - name: Model Builder recordArtifact success guard contract
         run: npm run test:model-builder-record-artifact-success-guard
 
+      - name: Model Builder fetchRuns staleness guard checker self-test
+        run: npm run test:model-builder-fetch-runs-staleness-guard-selftest
+
+      - name: Model Builder fetchRuns staleness guard contract
+        run: npm run test:model-builder-fetch-runs-staleness-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -226,6 +226,8 @@
     "test:model-builder-async-enqueue-cancelled-run-guard": "tsx utils/scripts/verifyModelBuilderAsyncEnqueueCancelledRunGuard.ts",
     "test:model-builder-record-artifact-success-guard-selftest": "tsx utils/scripts/verifyModelBuilderRecordArtifactSuccessGuard.test.ts",
     "test:model-builder-record-artifact-success-guard": "tsx utils/scripts/verifyModelBuilderRecordArtifactSuccessGuard.ts",
+    "test:model-builder-fetch-runs-staleness-guard-selftest": "tsx utils/scripts/verifyModelBuilderFetchRunsStalenessGuard.test.ts",
+    "test:model-builder-fetch-runs-staleness-guard": "tsx utils/scripts/verifyModelBuilderFetchRunsStalenessGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1958,21 +1958,40 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
 
   // --- run history ----------------------------------------------------------
 
+  // fetchRuns() re-fires on every mount of model-builder-run-history.vue
+  // (onMounted) and on its "Refresh" button — unlike loadSources(), which
+  // guards the identical class of race with `requestedType`, this had no
+  // request-scoping at all. Toggling History closed then open again (a
+  // normal double-click, not exotic timing) starts a second call while the
+  // first is still in flight; nothing here stopped the FIRST call's response
+  // from landing after the second's and unconditionally overwriting
+  // state.runs with its older snapshot — silently resurrecting a run the
+  // user cancelled in between (cancelRun's own `state.runs = state.runs.
+  // filter(...)` gets clobbered), losing one created in between, or just
+  // flipping loadingRuns back to false while the newer, still-in-flight call
+  // is the one that should own that spinner. Captured a request ticket, same
+  // pattern as loadSources' requestedType, so a stale response is discarded
+  // instead of applied.
+  let fetchRunsRequestId = 0
+
   async function fetchRuns(): Promise<void> {
+    const requestId = ++fetchRunsRequestId
     state.loadingRuns = true
     try {
       const response = await performFetch<ServerRun[]>(
         '/api/model-builder/runs?take=50',
       )
+      if (fetchRunsRequestId !== requestId) return
       if (response.success && Array.isArray(response.data)) {
         state.runs = response.data.map(adaptRun)
       } else if (!response.success) {
         setStatus('error', response.message || 'Failed to load run history.')
       }
     } catch (error) {
+      if (fetchRunsRequestId !== requestId) return
       handleError(error, 'loading run history')
     } finally {
-      state.loadingRuns = false
+      if (fetchRunsRequestId === requestId) state.loadingRuns = false
     }
   }
 

--- a/utils/scripts/verifyModelBuilderFetchRunsStalenessGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderFetchRunsStalenessGuard.test.ts
@@ -1,0 +1,129 @@
+// /utils/scripts/verifyModelBuilderFetchRunsStalenessGuard.test.ts
+//
+// Regression test for checkFetchRunsStalenessGuard() in
+// verifyModelBuilderFetchRunsStalenessGuard.ts (model-builder/t-029).
+// Exercises the real check against synthetic store-shaped fixtures covering:
+// the pre-fix shape (no request ticket at all -- the exact gap found by
+// manual read-through), the fixed shape (a monotonic ticket gating both the
+// success and catch branches, plus the `finally`), a partially-fixed shape
+// (ticket declared and captured, but only the success branch checks it --
+// the catch branch can still apply a stale error), and fetchRuns being
+// absent entirely.
+import assert from 'node:assert/strict'
+
+import { checkFetchRunsStalenessGuard } from './verifyModelBuilderFetchRunsStalenessGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function fetchRuns(): Promise<void> {
+    state.loadingRuns = true
+    try {
+      const response = await performFetch<ServerRun[]>(
+        '/api/model-builder/runs?take=50',
+      )
+      if (response.success && Array.isArray(response.data)) {
+        state.runs = response.data.map(adaptRun)
+      } else if (!response.success) {
+        setStatus('error', response.message || 'Failed to load run history.')
+      }
+    } catch (error) {
+      handleError(error, 'loading run history')
+    } finally {
+      state.loadingRuns = false
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  let fetchRunsRequestId = 0
+
+  async function fetchRuns(): Promise<void> {
+    const requestId = ++fetchRunsRequestId
+    state.loadingRuns = true
+    try {
+      const response = await performFetch<ServerRun[]>(
+        '/api/model-builder/runs?take=50',
+      )
+      if (fetchRunsRequestId !== requestId) return
+      if (response.success && Array.isArray(response.data)) {
+        state.runs = response.data.map(adaptRun)
+      } else if (!response.success) {
+        setStatus('error', response.message || 'Failed to load run history.')
+      }
+    } catch (error) {
+      if (fetchRunsRequestId !== requestId) return
+      handleError(error, 'loading run history')
+    } finally {
+      if (fetchRunsRequestId === requestId) state.loadingRuns = false
+    }
+  }
+`
+
+const PARTIAL_FIXTURE = `
+  let fetchRunsRequestId = 0
+
+  async function fetchRuns(): Promise<void> {
+    const requestId = ++fetchRunsRequestId
+    state.loadingRuns = true
+    try {
+      const response = await performFetch<ServerRun[]>(
+        '/api/model-builder/runs?take=50',
+      )
+      if (fetchRunsRequestId !== requestId) return
+      if (response.success && Array.isArray(response.data)) {
+        state.runs = response.data.map(adaptRun)
+      } else if (!response.success) {
+        setStatus('error', response.message || 'Failed to load run history.')
+      }
+    } catch (error) {
+      handleError(error, 'loading run history')
+    } finally {
+      if (fetchRunsRequestId === requestId) state.loadingRuns = false
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkFetchRunsStalenessGuard(BUGGY_FIXTURE)
+assert.ok(
+  buggyErrors.some((e) => e.includes('fetchRunsRequestId = 0')),
+  `expected the pre-fix shape to flag the missing request ticket, got: ${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors.some((e) =>
+    e.includes('checks `fetchRunsRequestId !== requestId` only 0 time(s)'),
+  ),
+  `expected the pre-fix shape to flag zero stale-response checks, got: ${JSON.stringify(buggyErrors)}`,
+)
+
+const fixedErrors = checkFetchRunsStalenessGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const partialErrors = checkFetchRunsStalenessGuard(PARTIAL_FIXTURE)
+assert.ok(
+  partialErrors.some((e) => e.includes('only 1 time(s)')),
+  `expected the partial fix (catch branch not scoped) to flag only 1 stale-response check, got: ${JSON.stringify(partialErrors)}`,
+)
+
+const missingFnErrors = checkFetchRunsStalenessGuard(MISSING_FIXTURE)
+assert.ok(
+  missingFnErrors.some((e) => e.includes('fetchRuns')),
+  'expected a "function not found" violation when fetchRuns is absent',
+)
+
+console.log(
+  'Model Builder fetchRuns staleness guard checker verified: flags the ' +
+    'pre-fix shape (no request ticket), clears the fixed shape (ticket ' +
+    'gating success/catch/finally), flags a partial fix (catch branch not ' +
+    'scoped), and flags fetchRuns being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderFetchRunsStalenessGuard.ts
+++ b/utils/scripts/verifyModelBuilderFetchRunsStalenessGuard.ts
@@ -1,0 +1,130 @@
+// /utils/scripts/verifyModelBuilderFetchRunsStalenessGuard.ts
+//
+// Regression guard (model-builder/t-029) -- fetchRuns() re-fires on every
+// mount of model-builder-run-history.vue (onMounted) and on its "Refresh"
+// button. loadSources() in this same file guards the identical class of bug
+// -- an async list-fetch whose response can land out of order -- by
+// capturing `requestedType` up front and discarding any response that
+// arrives after state has moved on. fetchRuns() had no equivalent: it
+// unconditionally applied whatever response landed most recently in wall-
+// clock time, not whichever was actually the most recently REQUESTED.
+//
+// Concrete repro: open the History panel (fetchRuns call A starts), close it
+// (an ordinary click -- model-builder-manager.vue's `showHistory` toggle
+// unmounts the panel but does not cancel the in-flight request), reopen it
+// (fetchRuns call B starts, mounts a fresh instance). If call B's response
+// lands first (plausible network variance -- nothing orders these two
+// requests), the panel correctly renders the current list. If call A's
+// slower response then lands, it unconditionally overwrites state.runs with
+// its older snapshot: a run cancelled in the interim reappears (clobbering
+// cancelRun's own `state.runs = state.runs.filter(...)`), a run created in
+// the interim vanishes, and `state.loadingRuns` can flip back to false while
+// a *third*, still-in-flight call is the one that should own the spinner.
+//
+// Fixed by a monotonic request ticket (`fetchRunsRequestId`), the same
+// pattern as loadSources' requestedType: capture it as `requestId` at the
+// top of the call, and bail out of the success/catch branches (and skip
+// clearing loadingRuns in `finally`) if a newer call has since started.
+//
+// This asserts the textual shape of that fix stays in place -- deliberately
+// scoped to this one function/bug, mirroring
+// verifyModelBuilderResetAllGuard.ts's preference for explicit, narrow
+// textual checks over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'fetchRuns'
+const TICKET_VAR = 'fetchRunsRequestId'
+
+const REQUIRED_BODY_STATEMENTS = [
+  `const requestId = ++${TICKET_VAR}`,
+  `if (${TICKET_VAR} !== requestId) return`,
+  `if (${TICKET_VAR} === requestId) state.loadingRuns = false`,
+]
+
+// Checks the fix's exact shape against the full source text of a file
+// containing a `fetchRuns`-named function. Exported (rather than only
+// exercised via main()) so the self-test below can run it against synthetic
+// buggy/fixed fixtures without touching the real store file.
+export function checkFetchRunsStalenessGuard(content: string): string[] {
+  const errors: string[] = []
+
+  if (!new RegExp(`let ${TICKET_VAR}\\s*=\\s*0`).test(content)) {
+    errors.push(
+      `Could not find \`let ${TICKET_VAR} = 0\` -- fetchRuns() needs a ` +
+        'closure-scoped request ticket to tell a stale response apart from ' +
+        'the latest one, the same pattern loadSources() already uses via ' +
+        '`requestedType`.',
+    )
+  }
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find a function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the race it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  const staleChecks = (
+    fn.body.match(new RegExp(`${TICKET_VAR} !== requestId`, 'g')) ?? []
+  ).length
+  if (staleChecks < 2) {
+    errors.push(
+      `${FN_NAME}() checks \`${TICKET_VAR} !== requestId\` only ` +
+        `${staleChecks} time(s) -- both the success branch (after the ` +
+        'await) and the catch branch must bail out on a stale response, or ' +
+        'an older, slower call can still overwrite state.runs with outdated ' +
+        'data after a newer call already rendered the current list.',
+    )
+  }
+
+  for (const statement of REQUIRED_BODY_STATEMENTS) {
+    if (!fn.body.includes(statement)) {
+      errors.push(
+        `${FN_NAME}() no longer contains \`${statement}\`. Without every ` +
+          'one of these, a stale (out-of-order) response can silently ' +
+          'overwrite state.runs or state.loadingRuns with data from a ' +
+          'call that is no longer the most recently issued one.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkFetchRunsStalenessGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder fetchRuns staleness guard contract failed for ' +
+        `${FN_NAME}() in modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Model Builder fetchRuns staleness guard contract passed: ${FN_NAME}() ` +
+      'discards any response that lands after a newer call has already ' +
+      'started, mirroring loadSources() own requestedType guard.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Bug

`fetchRuns()` in `stores/modelBuilderStore.ts` populates the Run History panel's list. It re-fires on every mount of `model-builder-run-history.vue` (`onMounted`) and on its "Refresh" button, but had **no request-scoping at all** — unlike `loadSources()` in the same file, which already guards the identical class of bug (an async list-fetch whose response can land out of order) via a captured `requestedType`.

**Concrete repro:**
1. Open History (fetchRuns call A starts, slow).
2. Close the panel — an ordinary click; `model-builder-manager.vue`'s `showHistory` toggle unmounts the panel but does **not** cancel the in-flight request.
3. Reopen it (fetchRuns call B starts, fast, from a freshly-mounted instance).
4. Call B's response lands first → the panel correctly shows the current list.
5. Call A's slower response then lands and **unconditionally overwrites `state.runs`** with its older snapshot: a run cancelled in the interim reappears (clobbering `cancelRun()`'s own `state.runs = state.runs.filter(...)`), a run created in the interim vanishes, and `state.loadingRuns` can flip back to `false` while a third, still-in-flight call is the one that should actually own the spinner.

## Fix

Added a monotonic request ticket (`fetchRunsRequestId`), the exact pattern `loadSources()` already uses via `requestedType`: capture it as `requestId` at the top of the call, bail out of both the success and catch branches if a newer call has since started, and only clear `loadingRuns` in `finally` if this is still the latest request.

```ts
let fetchRunsRequestId = 0

async function fetchRuns(): Promise<void> {
  const requestId = ++fetchRunsRequestId
  state.loadingRuns = true
  try {
    const response = await performFetch<ServerRun[]>('/api/model-builder/runs?take=50')
    if (fetchRunsRequestId !== requestId) return
    if (response.success && Array.isArray(response.data)) {
      state.runs = response.data.map(adaptRun)
    } else if (!response.success) {
      setStatus('error', response.message || 'Failed to load run history.')
    }
  } catch (error) {
    if (fetchRunsRequestId !== requestId) return
    handleError(error, 'loading run history')
  } finally {
    if (fetchRunsRequestId === requestId) state.loadingRuns = false
  }
}
```

## Guard

Added `utils/scripts/verifyModelBuilderFetchRunsStalenessGuard.ts` (+ `.test.ts`), following this repo's narrow-textual-checker convention (mirrors `verifyModelBuilderResetAllGuard.ts`): asserts the `fetchRunsRequestId` ticket exists and that `fetchRuns()` checks it in both the success and catch branches plus the `finally`. Wired into `package.json` (`test:model-builder-fetch-runs-staleness-guard[-selftest]`) and `.github/workflows/contract-tests.yml`, placed alongside the `recordArtifact` success guard entry (the most recently added guard in that file).

## Verification

- New guard + self-test: pass (`npm run test:model-builder-fetch-runs-staleness-guard[-selftest]`)
- All 61 pre-existing `verifyModelBuilder*` guard/self-test scripts (63 total including the new pair): all pass, no regressions
- `eslint` on touched files: 2 pre-existing `no-empty` errors in `modelBuilderStore.ts` (unrelated `safeSet`/`safeRemove` catch blocks, lines 204/211) — confirmed present on `origin/main` before this change via `git stash`; nothing new introduced
- `prettier --check` on the two new files: clean after `--write`; `modelBuilderStore.ts`'s pre-existing formatting drift (present on `main` before this change, confirmed via `git stash`) is untouched by this diff — verified the added lines are not part of what `prettier --write` would reformat
- `vue-tsc --noEmit` repo-wide (`npm run test`): exits 0, no type errors
- `git status --porcelain`: only the 5 intended files (`stores/modelBuilderStore.ts`, `package.json`, `.github/workflows/contract-tests.yml`, and the two new guard files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfJv2km3HCagSdtr4zebqq)_