### PR TITLE
ui(artjob): collapse non-output queue cards

### DIFF
--- a/components/art/artjob-queue-card.vue
+++ b/components/art/artjob-queue-card.vue
@@ -4,6 +4,7 @@
     class="flex min-w-0 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-200/30"
   >
     <div
+      v-if="job.status === 'DONE'"
       class="relative flex aspect-[4/3] min-h-52 w-full items-center justify-center overflow-hidden bg-base-100"
     >
       <a
@@ -91,6 +92,34 @@
     </div>
 
     <div class="flex min-w-0 flex-1 flex-col gap-3 p-3">
+      <div
+        v-if="job.status !== 'DONE'"
+        class="flex flex-wrap items-center justify-between gap-2"
+      >
+        <div class="flex flex-wrap gap-1">
+          <span class="badge badge-neutral badge-sm rounded-2xl font-mono">
+            #{{ job.id }}
+          </span>
+          <span
+            class="badge badge-sm rounded-2xl"
+            :class="jobStatusClass(job.status)"
+          >
+            {{ job.status }}
+          </span>
+        </div>
+        <div class="flex flex-wrap justify-end gap-1">
+          <span class="badge badge-outline badge-sm rounded-2xl">
+            {{ job.engine }}
+          </span>
+          <span
+            v-if="job.priority > 0"
+            class="badge badge-accent badge-sm rounded-2xl"
+          >
+            Priority {{ job.priority }}
+          </span>
+        </div>
+      </div>
+
       <div class="min-w-0">
         <div class="flex flex-wrap items-start justify-between gap-2">
           <div class="min-w-0 flex-1">


### PR DESCRIPTION
## What changed

- Remove the large 4:3 preview area from ArtJob cards unless the job is `DONE`.
- Keep job id, status, engine, and priority visible in a compact header for pending, running, failed, and cancelled jobs.
- Leave completed-job output previews and protected/mature preview behavior unchanged.

## Why

Pending, running, and failed jobs do not have a useful output image to preview, but the shared card reserved a `min-h-52` 4:3 block for them anyway. That consumed most of the queue viewport with placeholders instead of job information.

## Validation

- Reviewed the exact one-file diff against current `main`; branch is one commit ahead and zero behind.
- GitHub CI is the validation path for this connector-only change; local clone was unavailable in this session because the sandbox could not resolve github.com.