### PR TITLE
fix(model-builder): guard openRun() against a stale out-of-order response (t-029)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -452,6 +452,12 @@ jobs:
       - name: Model Builder fetchRuns staleness guard contract
         run: npm run test:model-builder-fetch-runs-staleness-guard
 
+      - name: Model Builder openRun request guard checker self-test
+        run: npm run test:model-builder-open-run-request-guard-selftest
+
+      - name: Model Builder openRun request guard contract
+        run: npm run test:model-builder-open-run-request-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -228,6 +228,8 @@
     "test:model-builder-record-artifact-success-guard": "tsx utils/scripts/verifyModelBuilderRecordArtifactSuccessGuard.ts",
     "test:model-builder-fetch-runs-staleness-guard-selftest": "tsx utils/scripts/verifyModelBuilderFetchRunsStalenessGuard.test.ts",
     "test:model-builder-fetch-runs-staleness-guard": "tsx utils/scripts/verifyModelBuilderFetchRunsStalenessGuard.ts",
+    "test:model-builder-open-run-request-guard-selftest": "tsx utils/scripts/verifyModelBuilderOpenRunRequestGuard.test.ts",
+    "test:model-builder-open-run-request-guard": "tsx utils/scripts/verifyModelBuilderOpenRunRequestGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1995,7 +1995,27 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     }
   }
 
+  // openRun's fallback fetch (below) had no request-scoping at all -- unlike
+  // fetchRuns() and loadSources(), which each guard this identical class of
+  // bug (an async list/record fetch whose response can land out of order) by
+  // capturing a ticket up front and discarding any response that arrives
+  // after state has moved on. The run-history "Open" button has no in-flight
+  // guard of its own (only cancellingRunId disables it), so a user can click
+  // Open on run A -- not yet in state.runs, so this falls through to the
+  // network fetch -- then, before it resolves, click Open on run B. If B is
+  // already cached (or becomes the active run) it resolves synchronously, but
+  // A's slower response can still land afterward and unconditionally
+  // overwrite state.run with the WRONG run -- silently discarding the user's
+  // actual last click. Fixed with the same monotonic-ticket pattern as
+  // fetchRunsRequestId: captured at the very top of every call (so a newer
+  // call -- sync or async -- always invalidates an older call's pending
+  // fetch), and checked before applying the response in both the success and
+  // catch branches.
+  let openRunRequestId = 0
+
   async function openRun(runId: string): Promise<void> {
+    const requestId = ++openRunRequestId
+
     // Reopening the run that's already active must not swap in a fresh object:
     // fetchRuns()/the fallback fetch below both rebuild items via adaptRun/adaptItem,
     // which reset the client-only artJobId/queueState fields to null. Replacing
@@ -2021,6 +2041,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       const response = await performFetch<ServerRun>(
         `/api/model-builder/runs/${runId}`,
       )
+      if (openRunRequestId !== requestId) return
       if (response.success && response.data) {
         state.run = adaptRun(response.data)
         state.sourceType = state.run.sourceType
@@ -2031,6 +2052,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         setStatus('error', response.message || 'Failed to open run.')
       }
     } catch (error) {
+      if (openRunRequestId !== requestId) return
       handleError(error, 'opening build run')
     }
   }

--- a/utils/scripts/verifyModelBuilderOpenRunRequestGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderOpenRunRequestGuard.test.ts
@@ -1,0 +1,183 @@
+// /utils/scripts/verifyModelBuilderOpenRunRequestGuard.test.ts
+//
+// Regression test for checkOpenRunRequestGuard() in
+// verifyModelBuilderOpenRunRequestGuard.ts (model-builder/t-029). Exercises
+// the real check against synthetic store-shaped fixtures covering: the
+// pre-fix shape (no request ticket at all -- the exact gap found by manual
+// read-through), the fixed shape (a monotonic ticket captured up front and
+// gating both the success and catch branches), a partially-fixed shape
+// (ticket declared and captured, but only the success branch checks it -- the
+// catch branch can still apply a stale error), and openRun being absent
+// entirely.
+import assert from 'node:assert/strict'
+
+import { checkOpenRunRequestGuard } from './verifyModelBuilderOpenRunRequestGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function openRun(runId: string): Promise<void> {
+    if (state.run?.id === runId) {
+      state.step = 'run'
+      return
+    }
+
+    const cached = state.runs.find((entry) => entry.id === runId)
+    if (cached) {
+      state.run = cached
+      state.sourceType = cached.sourceType
+      state.recipeKey = cached.recipeKey
+      state.step = 'run'
+      setActiveRunId(Number(runId))
+      return
+    }
+
+    try {
+      const response = await performFetch<ServerRun>(
+        \`/api/model-builder/runs/\${runId}\`,
+      )
+      if (response.success && response.data) {
+        state.run = adaptRun(response.data)
+        state.sourceType = state.run.sourceType
+        state.recipeKey = state.run.recipeKey
+        state.step = 'run'
+        setActiveRunId(response.data.id)
+      } else if (!response.success) {
+        setStatus('error', response.message || 'Failed to open run.')
+      }
+    } catch (error) {
+      handleError(error, 'opening build run')
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  let openRunRequestId = 0
+
+  async function openRun(runId: string): Promise<void> {
+    const requestId = ++openRunRequestId
+
+    if (state.run?.id === runId) {
+      state.step = 'run'
+      return
+    }
+
+    const cached = state.runs.find((entry) => entry.id === runId)
+    if (cached) {
+      state.run = cached
+      state.sourceType = cached.sourceType
+      state.recipeKey = cached.recipeKey
+      state.step = 'run'
+      setActiveRunId(Number(runId))
+      return
+    }
+
+    try {
+      const response = await performFetch<ServerRun>(
+        \`/api/model-builder/runs/\${runId}\`,
+      )
+      if (openRunRequestId !== requestId) return
+      if (response.success && response.data) {
+        state.run = adaptRun(response.data)
+        state.sourceType = state.run.sourceType
+        state.recipeKey = state.run.recipeKey
+        state.step = 'run'
+        setActiveRunId(response.data.id)
+      } else if (!response.success) {
+        setStatus('error', response.message || 'Failed to open run.')
+      }
+    } catch (error) {
+      if (openRunRequestId !== requestId) return
+      handleError(error, 'opening build run')
+    }
+  }
+`
+
+const PARTIAL_FIXTURE = `
+  let openRunRequestId = 0
+
+  async function openRun(runId: string): Promise<void> {
+    const requestId = ++openRunRequestId
+
+    if (state.run?.id === runId) {
+      state.step = 'run'
+      return
+    }
+
+    const cached = state.runs.find((entry) => entry.id === runId)
+    if (cached) {
+      state.run = cached
+      state.sourceType = cached.sourceType
+      state.recipeKey = cached.recipeKey
+      state.step = 'run'
+      setActiveRunId(Number(runId))
+      return
+    }
+
+    try {
+      const response = await performFetch<ServerRun>(
+        \`/api/model-builder/runs/\${runId}\`,
+      )
+      if (openRunRequestId !== requestId) return
+      if (response.success && response.data) {
+        state.run = adaptRun(response.data)
+        state.sourceType = state.run.sourceType
+        state.recipeKey = state.run.recipeKey
+        state.step = 'run'
+        setActiveRunId(response.data.id)
+      } else if (!response.success) {
+        setStatus('error', response.message || 'Failed to open run.')
+      }
+    } catch (error) {
+      handleError(error, 'opening build run')
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkOpenRunRequestGuard(BUGGY_FIXTURE)
+assert.ok(
+  buggyErrors.some((e) => e.includes('openRunRequestId = 0')),
+  `expected the pre-fix shape to flag the missing request ticket, got: ${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors.some((e) =>
+    e.includes('checks `openRunRequestId !== requestId` only 0 time(s)'),
+  ),
+  `expected the pre-fix shape to flag zero stale-response checks, got: ${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes('does not capture')),
+  `expected the pre-fix shape to flag the missing ticket capture, got: ${JSON.stringify(buggyErrors)}`,
+)
+
+const fixedErrors = checkOpenRunRequestGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const partialErrors = checkOpenRunRequestGuard(PARTIAL_FIXTURE)
+assert.ok(
+  partialErrors.some((e) => e.includes('only 1 time(s)')),
+  `expected the partial fix (catch branch not scoped) to flag only 1 stale-response check, got: ${JSON.stringify(partialErrors)}`,
+)
+
+const missingFnErrors = checkOpenRunRequestGuard(MISSING_FIXTURE)
+assert.ok(
+  missingFnErrors.some((e) => e.includes('openRun')),
+  'expected a "function not found" violation when openRun is absent',
+)
+
+console.log(
+  'Model Builder openRun request guard checker verified: flags the pre-fix ' +
+    'shape (no request ticket), clears the fixed shape (ticket captured up ' +
+    'front and gating success/catch), flags a partial fix (catch branch not ' +
+    'scoped), and flags openRun being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderOpenRunRequestGuard.ts
+++ b/utils/scripts/verifyModelBuilderOpenRunRequestGuard.ts
@@ -1,0 +1,137 @@
+// /utils/scripts/verifyModelBuilderOpenRunRequestGuard.ts
+//
+// Regression guard (model-builder/t-029) -- openRun(runId)'s fallback network
+// fetch (taken when the requested run is neither already active nor cached in
+// state.runs) had no request-scoping at all. fetchRuns() and loadSources() in
+// this same file each guard the identical class of bug -- an async
+// list/record fetch whose response can land out of order -- by capturing a
+// ticket up front and discarding any response that arrives after state has
+// moved on. openRun() had no equivalent for its own fetch branch.
+//
+// Concrete repro: the run-history panel's "Open" button has no in-flight
+// guard of its own (only cancellingRunId disables it -- see
+// model-builder-run-history.vue). Click Open on run A while it is not yet in
+// state.runs (falls through to the network fetch), then -- before that
+// response lands -- click Open on run B. If B resolves synchronously (already
+// cached, or becomes the newly-active run) the UI correctly shows B. If A's
+// slower fetch then resolves, it unconditionally overwrote state.run with
+// run A's data -- silently discarding the user's actual last click and
+// leaving the Model Builder showing the wrong run with no error surfaced.
+//
+// Fixed by a monotonic request ticket (`openRunRequestId`), the same pattern
+// as fetchRunsRequestId: captured as `requestId` at the very top of every
+// call (so a newer call -- whether it resolves synchronously or via fetch --
+// always invalidates an older call's still-pending fetch), and checked before
+// applying the response in both the success and catch branches.
+//
+// This asserts the textual shape of that fix stays in place -- deliberately
+// scoped to this one function/bug, mirroring
+// verifyModelBuilderFetchRunsStalenessGuard.ts's identical pattern for its
+// sibling function.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'openRun'
+const TICKET_VAR = 'openRunRequestId'
+
+const REQUIRED_BODY_STATEMENTS = [
+  `const requestId = ++${TICKET_VAR}`,
+  `if (${TICKET_VAR} !== requestId) return`,
+]
+
+// Checks the fix's exact shape against the full source text of a file
+// containing an `openRun`-named function. Exported (rather than only
+// exercised via main()) so the self-test below can run it against synthetic
+// buggy/fixed fixtures without touching the real store file.
+export function checkOpenRunRequestGuard(content: string): string[] {
+  const errors: string[] = []
+
+  if (!new RegExp(`let ${TICKET_VAR}\\s*=\\s*0`).test(content)) {
+    errors.push(
+      `Could not find \`let ${TICKET_VAR} = 0\` -- openRun() needs a ` +
+        'closure-scoped request ticket to tell a stale fallback-fetch ' +
+        'response apart from the latest one, the same pattern ' +
+        'fetchRunsRequestId already uses for fetchRuns().',
+    )
+  }
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find a function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the race it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  const staleChecks = (
+    fn.body.match(new RegExp(`${TICKET_VAR} !== requestId`, 'g')) ?? []
+  ).length
+  if (staleChecks < 2) {
+    errors.push(
+      `${FN_NAME}() checks \`${TICKET_VAR} !== requestId\` only ` +
+        `${staleChecks} time(s) -- both the success branch (after the ` +
+        'await) and the catch branch must bail out on a stale response, or ' +
+        'an older, slower Open click can still overwrite state.run with a ' +
+        'different run after a newer click already resolved.',
+    )
+  }
+
+  if (!fn.body.trimStart().startsWith(`const requestId = ++${TICKET_VAR}`)) {
+    errors.push(
+      `${FN_NAME}() does not capture \`const requestId = ++${TICKET_VAR}\` ` +
+        'as its first statement. The ticket must be captured before the ' +
+        'identity check / cache lookup so that ANY newer call -- whether it ' +
+        "resolves synchronously or via fetch -- invalidates an older call's " +
+        'still-pending fetch.',
+    )
+  }
+
+  for (const statement of REQUIRED_BODY_STATEMENTS) {
+    if (!fn.body.includes(statement)) {
+      errors.push(
+        `${FN_NAME}() no longer contains \`${statement}\`. Without every ` +
+          'one of these, a stale (out-of-order) response from the fallback ' +
+          'fetch can silently overwrite state.run with data from a run the ' +
+          'user is no longer trying to open.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkOpenRunRequestGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder openRun request guard contract failed for ' +
+        `${FN_NAME}() in modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Model Builder openRun request guard contract passed: ${FN_NAME}() ` +
+      'discards any fallback-fetch response that lands after a newer call ' +
+      "has already started, mirroring fetchRuns()' own requestId guard.",
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What changed

Recurring bug-hunt cycle for `model-builder/t-029`. Found one new bug (not one of the two already fixed in prior cycles: e148178's artifact-POST error reporting, or 4367d56/#1880's `fetchRuns()` staleness guard).

**Bug:** `openRun(runId)` in `stores/modelBuilderStore.ts` has a fallback network-fetch branch (used when the requested run is neither already the active run nor already cached in `state.runs`) with no request-scoping at all — unlike `fetchRuns()` and `loadSources()` in the same file, which each guard this identical class of bug (an async list/record fetch whose response can land out of order) via a monotonic request ticket.

**Concrete repro:** the run-history panel's "Open" button (`model-builder-run-history.vue`) has no in-flight guard of its own — only `cancellingRunId` disables it. Click Open on run A while it isn't yet in `state.runs` (so `openRun` falls through to the network fetch), then — before that response lands — click Open on run B. If B resolves synchronously (already cached, or is already the active run) the UI correctly shows B. If A's slower fetch then resolves, it unconditionally overwrote `state.run` with run A's data — silently discarding the user's actual last click and leaving Model Builder showing the wrong run, with no error surfaced anywhere.

**Fix:** the same monotonic-ticket pattern `fetchRunsRequestId` already uses — `openRunRequestId`, captured as `requestId` at the very top of *every* call to `openRun` (so a newer call, whether it resolves synchronously via the identity/cache branches or asynchronously via fetch, always invalidates an older call's still-pending fetch), and checked before applying the response in both the success and catch branches.

**New guard:** `utils/scripts/verifyModelBuilderOpenRunRequestGuard.ts` + `.test.ts`, following the established `verifyModelBuilder*` narrow-textual-checker convention (mirrors `verifyModelBuilderFetchRunsStalenessGuard.ts` almost exactly, adapted for `openRun`/`openRunRequestId`). Wired into `package.json` (`test:model-builder-open-run-request-guard[-selftest]`) and `.github/workflows/contract-tests.yml` the same way as the ~30 other existing guards.

## Files changed
- `stores/modelBuilderStore.ts` — the fix (22 lines added, nothing else touched)
- `utils/scripts/verifyModelBuilderOpenRunRequestGuard.ts` (new)
- `utils/scripts/verifyModelBuilderOpenRunRequestGuard.test.ts` (new)
- `package.json` — two new script entries
- `.github/workflows/contract-tests.yml` — two new CI steps

## Verification
- Ran all 65 `test:model-builder-*` npm scripts (32 existing guard/self-test pairs + `link-coverage` + the 2 new ones) — **all 65 passed**, no regressions.
- New guard + self-test individually: `npm run test:model-builder-open-run-request-guard-selftest` and `npm run test:model-builder-open-run-request-guard` — both pass.
- `npx eslint stores/modelBuilderStore.ts utils/scripts/verifyModelBuilderOpenRunRequestGuard.ts utils/scripts/verifyModelBuilderOpenRunRequestGuard.test.ts` — 2 pre-existing `no-empty` errors on `stores/modelBuilderStore.ts` lines 204/211 (unrelated `safeSet`/`safeRemove` catch blocks), verified byte-for-byte identical on origin/main before this change (via `git stash` diff) — no new lint errors introduced; the two new files are fully clean.
- `npx prettier --check` on the two new files, `package.json`, and the workflow file — clean. `stores/modelBuilderStore.ts` as a whole already fails `prettier --check` on origin/main (pre-existing repo-wide formatting drift, confirmed via `git stash`) — verified my added lines introduce zero new drift by diffing a full `prettier`-formatted copy of the file against my change and confirming no diff falls within the added `openRun`/`openRunRequestId` lines.
- `npm run test` (`vue-tsc --noEmit -p tsconfig.json`, repo-wide) — exit 0, no errors.
- `git status --porcelain` — exactly the 5 intended files.

## Stakes
Reversible. Client-side-only store logic change plus a new narrow regression-guard script pair; no schema/migration/API surface change, no data mutation risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NpU4KRBaujHnH4nEAqGsAs)_