### PR TITLE
chore: gitignore .claude/ harness worktree state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ kindblank_*.sql
 /public/wonderlab-components.json
 /utils/generated/wonderLabSourceEvidence.ts
 /config/comment-backfill-live-batches.json
+
+# Claude Code harness state (background-agent worktree isolation, etc.) -- never repo content
+.claude/


### PR DESCRIPTION
### What changed
- Added `.claude/` to `.gitignore`.

### Why
The Claude Code agent harness's `isolation: 'worktree'` mechanism creates `.claude/worktrees/` in the repo root while a background agent is active (observed this session during a model-builder/t-029 bug-hunt sub-agent run). It's transient working-copy state, not repo content, and flagged the working tree as dirty after the agent's worktree was released. Ignoring it avoids that noise in future sessions.

### Stakes
reversible — one-line `.gitignore` addition, no code/behavior change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NpU4KRBaujHnH4nEAqGsAs)_