### PR TITLE
fix(model-builder): coverage guard for the async-fetch staleness pattern (t-044)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -458,6 +458,12 @@ jobs:
       - name: Model Builder openRun request guard contract
         run: npm run test:model-builder-open-run-request-guard
 
+      - name: Model Builder async-fetch staleness coverage checker self-test
+        run: npm run test:model-builder-async-fetch-staleness-coverage-selftest
+
+      - name: Model Builder async-fetch staleness coverage contract
+        run: npm run test:model-builder-async-fetch-staleness-coverage
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -230,6 +230,8 @@
     "test:model-builder-fetch-runs-staleness-guard": "tsx utils/scripts/verifyModelBuilderFetchRunsStalenessGuard.ts",
     "test:model-builder-open-run-request-guard-selftest": "tsx utils/scripts/verifyModelBuilderOpenRunRequestGuard.test.ts",
     "test:model-builder-open-run-request-guard": "tsx utils/scripts/verifyModelBuilderOpenRunRequestGuard.ts",
+    "test:model-builder-async-fetch-staleness-coverage-selftest": "tsx utils/scripts/verifyModelBuilderAsyncFetchStalenessCoverage.test.ts",
+    "test:model-builder-async-fetch-staleness-coverage": "tsx utils/scripts/verifyModelBuilderAsyncFetchStalenessCoverage.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/utils/scripts/verifyModelBuilderAsyncFetchStalenessCoverage.test.ts
+++ b/utils/scripts/verifyModelBuilderAsyncFetchStalenessCoverage.test.ts
@@ -1,0 +1,232 @@
+// /utils/scripts/verifyModelBuilderAsyncFetchStalenessCoverage.test.ts
+//
+// Regression test for checkAsyncFetchStalenessCoverage() in
+// verifyModelBuilderAsyncFetchStalenessCoverage.ts (model-builder/t-044).
+// Exercises the real check against synthetic store-shaped fixtures covering:
+// an unregistered new performFetch( call site, a registered function whose
+// marker has been deleted (protection silently regressed), a registered
+// function that no longer exists (renamed/removed), a registered function
+// whose performFetch( call is gone (should be de-registered), a 'write-only'
+// entry that has started assigning `state.*` from `.data` (classification
+// gone stale), and the clean/covered shape raising nothing.
+import assert from 'node:assert/strict'
+
+import {
+  AUDITED_ASYNC_FETCH_FUNCTIONS,
+  checkAsyncFetchStalenessCoverage,
+} from './verifyModelBuilderAsyncFetchStalenessCoverage.js'
+
+// A minimal fixture containing every currently-registered function, each
+// shaped just enough to satisfy its own registry marker -- this is the
+// "everything covered, nothing changed" baseline the other fixtures perturb.
+const COVERED_FIXTURE = `
+  async function loadSources(): Promise<void> {
+    const requestedType = state.sourceType
+    try {
+      const response = await performFetch<SourceRecord[]>(config.endpoint)
+      if (state.sourceType !== requestedType) return
+      state.sources = response.data
+    } catch (error) {
+      if (state.sourceType !== requestedType) return
+    }
+  }
+
+  async function startRun(): Promise<void> {
+    if (state.startingRun) return
+    state.startingRun = true
+    try {
+      const response = await performFetch<ServerRun>('/api/model-builder/runs', {})
+      state.run = adaptRun(response.data)
+    } finally {
+      state.startingRun = false
+    }
+  }
+
+  function pushItem(item, payload) {
+    performFetch(\`/api/model-builder/items/\${item.id}\`, {}).then((response) => {
+      if (!response.success) setStatusForRun(runId, 'error', response.message)
+    })
+  }
+
+  function batchPushItems(entries) {
+    return performFetch('/api/model-builder/items/batch', {}).then((response) => {
+      if (!response.success) return false
+      return true
+    })
+  }
+
+  async function draftText(itemId, field) {
+    const current = item.pitch
+    try {
+      const result = await performFetch<{ value: string }>('/api/suggest', {})
+      const liveValue = item.pitch
+      if (liveValue !== current) return false
+      updatePitch(itemId, result.data.value)
+    } catch (error) {}
+  }
+
+  async function recordArtifact(item, image) {
+    const result = await performFetch(\`/api/model-builder/items/\${item.id}/artifacts\`, {})
+    if (!result.success) {
+      setStatusForRun(runId, 'error', result.message)
+    }
+  }
+
+  async function commitItem(itemId): Promise<boolean> {
+    const runId = state.run.id
+    try {
+      const response = await performFetch<{ target?: CommitTarget }>(\`/api/model-builder/items/\${itemId}/commit\`, {})
+      if (cancelledRunIds.has(runId)) return false
+      item.targetType = response.data.target.type
+    } catch (error) {
+      if (cancelledRunIds.has(runId)) return false
+    }
+  }
+
+  async function resumeRun(): Promise<void> {
+    try {
+      const response = await performFetch<ServerRun>(\`/api/model-builder/runs/\${remembered}\`)
+      const data = response.data
+      if (state.run?.id === String(data.id)) {
+        state.step = 'run'
+      } else {
+        state.run = adaptRun(data)
+      }
+    } catch {}
+  }
+
+  let fetchRunsRequestId = 0
+  async function fetchRuns(): Promise<void> {
+    const requestId = ++fetchRunsRequestId
+    try {
+      const response = await performFetch<ServerRun[]>('/api/model-builder/runs?take=50')
+      if (fetchRunsRequestId !== requestId) return
+      state.runs = response.data
+    } catch (error) {
+      if (fetchRunsRequestId !== requestId) return
+    }
+  }
+
+  let openRunRequestId = 0
+  async function openRun(runId: string): Promise<void> {
+    const requestId = ++openRunRequestId
+    try {
+      const response = await performFetch<ServerRun>(\`/api/model-builder/runs/\${runId}\`)
+      if (openRunRequestId !== requestId) return
+      state.run = adaptRun(response.data)
+    } catch (error) {
+      if (openRunRequestId !== requestId) return
+    }
+  }
+
+  async function cancelRun(runId: string): Promise<void> {
+    const response = await performFetch(\`/api/model-builder/runs/\${runId}\`, {})
+    if (!response.success) {
+      setStatus('error', response.message)
+      return
+    }
+    state.runs = state.runs.filter((entry) => entry.id !== runId)
+  }
+`
+
+const covered = checkAsyncFetchStalenessCoverage(COVERED_FIXTURE)
+assert.equal(
+  covered.length,
+  0,
+  `expected the fully-covered fixture to raise no errors, got: ${JSON.stringify(covered)}`,
+)
+
+// Every registered function should actually appear in the baseline fixture --
+// guards this test file itself against silently drifting from the real
+// registry (e.g. a new entry added to the script but never added here).
+for (const name of Object.keys(AUDITED_ASYNC_FETCH_FUNCTIONS)) {
+  assert.ok(
+    new RegExp(`function ${name}\\(`).test(COVERED_FIXTURE),
+    `COVERED_FIXTURE is missing a fixture for registered function ${name}() -- add one so this test file stays in sync with the real registry`,
+  )
+}
+
+const NEW_UNREGISTERED_FIXTURE =
+  COVERED_FIXTURE +
+  `
+  async function loadTemplates(): Promise<void> {
+    const response = await performFetch<Template[]>('/api/model-builder/templates')
+    state.templates = response.data
+  }
+`
+const newCallSiteErrors = checkAsyncFetchStalenessCoverage(
+  NEW_UNREGISTERED_FIXTURE,
+)
+assert.ok(
+  newCallSiteErrors.some(
+    (e) => e.includes('loadTemplates') && e.includes('no entry in'),
+  ),
+  `expected a new, unregistered performFetch( call site to be flagged, got: ${JSON.stringify(newCallSiteErrors)}`,
+)
+
+const MARKER_DELETED_FIXTURE = COVERED_FIXTURE.replace(
+  'if (cancelledRunIds.has(runId)) return false\n      item.targetType',
+  'item.targetType',
+).replace(
+  '    } catch (error) {\n      if (cancelledRunIds.has(runId)) return false\n    }\n  }\n\n  async function resumeRun',
+  '    } catch (error) {\n    }\n  }\n\n  async function resumeRun',
+)
+const markerDeletedErrors = checkAsyncFetchStalenessCoverage(
+  MARKER_DELETED_FIXTURE,
+)
+assert.ok(
+  markerDeletedErrors.some(
+    (e) => e.includes('commitItem') && e.includes('no longer present'),
+  ),
+  `expected commitItem's deleted cancelledRunIds marker to be flagged, got: ${JSON.stringify(markerDeletedErrors)}`,
+)
+
+const RENAMED_FIXTURE = COVERED_FIXTURE.replace(
+  'async function commitItem(itemId): Promise<boolean> {',
+  'async function commitBuildItem(itemId): Promise<boolean> {',
+)
+const renamedErrors = checkAsyncFetchStalenessCoverage(RENAMED_FIXTURE)
+assert.ok(
+  renamedErrors.some((e) => e.includes('commitItem') && e.includes('renamed')),
+  `expected a renamed registered function to be flagged as missing, got: ${JSON.stringify(renamedErrors)}`,
+)
+
+const FETCH_REMOVED_FIXTURE = COVERED_FIXTURE.replace(
+  'const response = await performFetch<{ target?: CommitTarget }>(`/api/model-builder/items/${itemId}/commit`, {})\n      if (cancelledRunIds.has(runId)) return false\n      item.targetType = response.data.target.type',
+  'const response = await someOtherHelper(itemId)\n      item.targetType = response.data.target.type',
+)
+const fetchRemovedErrors = checkAsyncFetchStalenessCoverage(
+  FETCH_REMOVED_FIXTURE,
+)
+assert.ok(
+  fetchRemovedErrors.some(
+    (e) =>
+      e.includes('commitItem') &&
+      e.includes('no longer contains a performFetch'),
+  ),
+  `expected a registered function whose performFetch( call was removed to be flagged, got: ${JSON.stringify(fetchRemovedErrors)}`,
+)
+
+const WRITE_ONLY_GONE_STALE_FIXTURE = COVERED_FIXTURE.replace(
+  "if (!result.success) {\n      setStatusForRun(runId, 'error', result.message)\n    }\n  }\n\n  async function commitItem",
+  "if (!result.success) {\n      setStatusForRun(runId, 'error', result.message)\n    }\n    state.lastArtifactPath = result.data.path\n  }\n\n  async function commitItem",
+)
+const writeOnlyStaleErrors = checkAsyncFetchStalenessCoverage(
+  WRITE_ONLY_GONE_STALE_FIXTURE,
+)
+assert.ok(
+  writeOnlyStaleErrors.some(
+    (e) =>
+      e.includes('recordArtifact') && e.includes("classified 'write-only'"),
+  ),
+  `expected a 'write-only' function now assigning state from .data to be flagged, got: ${JSON.stringify(writeOnlyStaleErrors)}`,
+)
+
+console.log(
+  'Model Builder async-fetch staleness coverage checker verified: passes on ' +
+    'the fully-covered fixture, flags a new unregistered performFetch( call ' +
+    "site, flags a registered function's marker being deleted, flags a " +
+    "registered function being renamed away, flags a registered function's " +
+    "performFetch( call being removed, and flags a 'write-only' function " +
+    'that has started assigning state from a response body.',
+)

--- a/utils/scripts/verifyModelBuilderAsyncFetchStalenessCoverage.ts
+++ b/utils/scripts/verifyModelBuilderAsyncFetchStalenessCoverage.ts
@@ -1,0 +1,317 @@
+// /utils/scripts/verifyModelBuilderAsyncFetchStalenessCoverage.ts
+//
+// Coverage guard (model-builder/t-044, kaizen from t-029 / kind_robots PR
+// #1882). The monotonic request-ticket pattern (fetchRunsRequestId, then
+// openRunRequestId) has been hand-applied to modelBuilderStore.ts across
+// three separate bug-hunt cycles, each time found by a fresh manual
+// read-through rather than any automated check -- see
+// verifyModelBuilderFetchRunsStalenessGuard.ts,
+// verifyModelBuilderOpenRunRequestGuard.ts, and loadSources' own
+// `requestedType` fix that predates both.
+//
+// A literal "every performFetch call site must use a monotonic counter"
+// requirement turns out to be the WRONG generalization once every call site
+// is actually read (this guard's own research pass, 2026-08-14): the store
+// uses several genuinely different, independently-correct staleness idioms
+// depending on what the function does with the response:
+//   - ticket-counter: fetchRuns/openRun -- an incrementing counter, re-entrant
+//     calls are expected and the newest one must win.
+//   - capture-compare: loadSources/draftText -- a value snapshotted at the
+//     top of the call (state.sourceType, the field's live text) is compared
+//     against its live equivalent before applying the response, instead of a
+//     separate counter variable.
+//   - cancelled-run-check: commitItem -- `cancelledRunIds.has(runId)`, since
+//     the thing that can go stale here is "the run was cancelled," not "a
+//     newer call of the same kind superseded this one."
+//   - identity-check: resumeRun -- compares the fetched run's id against
+//     state.run's current id before deciding to replace vs. no-op, so an
+//     in-flight async poll's object reference is never orphaned.
+//   - serialized-lock: startRun -- a boolean (state.startingRun) blocks a
+//     second call from ever starting while the first is in flight, so no two
+//     calls can race in the first place; nothing to compare on response.
+//   - write-only: pushItem/batchPushItems/recordArtifact/cancelRun -- the
+//     response is only ever consulted for `.success`/`.message`; nothing
+//     from `.data` is written into shared state, so an out-of-order response
+//     has nothing to corrupt.
+//
+// So this guard does NOT re-demand the ticket-counter shape everywhere --
+// the individual guards above already assert that exact shape for the two
+// functions where it's the right fix, and would themselves fail if it
+// regressed. What NONE of the individual guards do is notice a brand new
+// performFetch call site showing up somewhere else in the file with no
+// staleness idiom recorded for it at all -- exactly how every one of the
+// existing guards came to exist (a fresh manual read-through, not a CI
+// signal). This is that missing signal: it enumerates every function that
+// calls performFetch(, requires each to appear in the registry below with a
+// classified guardKind, and fails loudly on anything unregistered so the
+// next bug-hunt cycle has to make and record a real decision about it
+// instead of it silently shipping unaudited. It also spot-checks each
+// registered entry's `marker` substring is still present, so a refactor that
+// quietly deletes the actual protection (while leaving the registry entry
+// behind) still fails instead of passing on stale metadata.
+//
+// Deliberately scoped to modelBuilderStore.ts's own top-level `function`
+// declarations (via extractFunctionBodies, the same 2-space-indent
+// convention every other verifyModelBuilder* guard relies on) and to literal
+// `performFetch(` call sites within them. Functions that reach the same bug
+// class indirectly through a delegated call (generateItemAsset/
+// pollAsyncArtJob/generateItemAssetAsync calling artStore methods rather than
+// performFetch directly) are out of scope here -- they already have their
+// own dedicated guards (verifyModelBuilderCancelledRunGuard.ts,
+// verifyModelBuilderAsyncEnqueueCancelledRunGuard.ts, etc.), the same
+// per-bug-found pattern this guard's registry continues for direct
+// performFetch call sites specifically.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+// Matches both a plain call (`performFetch(`) and a generic one
+// (`performFetch<ServerRun>(`) -- most call sites in this store use an
+// explicit type argument.
+const FETCH_CALL = /performFetch[<(]/
+
+export type StalenessGuardKind =
+  | 'ticket-counter'
+  | 'capture-compare'
+  | 'cancelled-run-check'
+  | 'identity-check'
+  | 'serialized-lock'
+  | 'write-only'
+
+export interface AuditedFetchFunction {
+  guardKind: StalenessGuardKind
+  // A substring that must still be present in the function's body for the
+  // recorded classification to still hold. Not a full re-implementation of
+  // the dedicated guard (where one already exists) -- just enough to notice
+  // if the protection itself has been deleted out from under the registry.
+  marker: string
+  rationale: string
+}
+
+// Every function in modelBuilderStore.ts known (as of this audit) to call
+// performFetch(, and how it's protected against an out-of-order response.
+// A new performFetch call site not listed here fails the build -- see file
+// header. Keep entries in the order they appear in the store.
+export const AUDITED_ASYNC_FETCH_FUNCTIONS: Record<
+  string,
+  AuditedFetchFunction
+> = {
+  loadSources: {
+    guardKind: 'capture-compare',
+    marker: 'state.sourceType !== requestedType',
+    rationale:
+      'Captures state.sourceType as requestedType before the fetch and ' +
+      're-checks it in both the success and catch branches (and finally) ' +
+      'before touching state.sources/state.sourcesError/state.loadingSources ' +
+      '-- a rapid tab switch cannot let a slower, now-irrelevant response ' +
+      'overwrite the currently selected tab.',
+  },
+  startRun: {
+    guardKind: 'serialized-lock',
+    marker: 'state.startingRun',
+    rationale:
+      'Entry is gated on `state.startingRun` and it is only cleared in the ' +
+      'finally block, so a second startRun() cannot begin while the first ' +
+      'is still in flight -- there is no concurrent call for a response to ' +
+      'race against.',
+  },
+  pushItem: {
+    guardKind: 'write-only',
+    marker: 'performFetch(',
+    rationale:
+      'Fire-and-forget PATCH; the response is only ever read for ' +
+      '`.success`/`.message` (to report a failure via the run-scoped ' +
+      'setStatusForRun), never applied to shared state, so an out-of-order ' +
+      'response has nothing to corrupt.',
+  },
+  batchPushItems: {
+    guardKind: 'write-only',
+    marker: 'performFetch(',
+    rationale:
+      'Same shape as pushItem, batched: response consulted only for ' +
+      '`.success`/`.message`, never written into state.',
+  },
+  draftText: {
+    guardKind: 'capture-compare',
+    marker: 'liveValue !== current',
+    rationale:
+      "Captures the field's current value up front and, before applying " +
+      'the AI draft, re-checks both that the live value is unchanged ' +
+      '(liveValue !== current) and that the stage is still editable ' +
+      '(isStageEditable) -- a manual edit or an approval that landed while ' +
+      'the draft was in flight wins instead of being silently overwritten.',
+  },
+  recordArtifact: {
+    guardKind: 'write-only',
+    marker: 'if (!result.success)',
+    rationale:
+      'POST is only ever consulted for `.success` (to report a failure via ' +
+      'setStatusForRun); no response field is written into shared state, so ' +
+      'there is nothing an out-of-order response could corrupt.',
+  },
+  commitItem: {
+    guardKind: 'cancelled-run-check',
+    marker: 'cancelledRunIds.has(runId)',
+    rationale:
+      'The commit POST durably lands server-side regardless of ordering; ' +
+      'the guard exists to stop a completion that lands after the user ' +
+      'cancelled this exact run from re-attaching a detached item or ' +
+      'popping a misleading "committed" toast, checked in both the success ' +
+      'and catch branches.',
+  },
+  resumeRun: {
+    guardKind: 'identity-check',
+    marker: 'state.run?.id === String(data.id)',
+    rationale:
+      'Before replacing state.run with the fetched run, compares the ' +
+      "fetched run's id against the currently active run's id -- resuming " +
+      'the run that is already active must not swap in a fresh object, or ' +
+      "an in-flight pollAsyncArtJob's reference to the live item would be " +
+      'silently orphaned.',
+  },
+  fetchRuns: {
+    guardKind: 'ticket-counter',
+    marker: 'fetchRunsRequestId !== requestId',
+    rationale:
+      'Monotonic request ticket; fully asserted by its own dedicated guard, ' +
+      'verifyModelBuilderFetchRunsStalenessGuard.ts. This entry only exists ' +
+      "so this file's coverage sweep recognizes fetchRuns as already " +
+      'audited rather than flagging it as a new, unclassified call site.',
+  },
+  openRun: {
+    guardKind: 'ticket-counter',
+    marker: 'openRunRequestId !== requestId',
+    rationale:
+      'Monotonic request ticket; fully asserted by its own dedicated guard, ' +
+      'verifyModelBuilderOpenRunRequestGuard.ts (plus ' +
+      'verifyModelBuilderOpenRunIdentityGuard.ts for the identity side). ' +
+      'Same as fetchRuns above, this entry exists for coverage recognition.',
+  },
+  cancelRun: {
+    guardKind: 'write-only',
+    marker: 'if (!response.success)',
+    rationale:
+      'The PATCH response is only consulted for `.success`/`.message`; the ' +
+      'subsequent state mutations (state.runs filter, resetRun, ' +
+      'cancelledRunIds.add) are all driven by the runId parameter the ' +
+      'caller already had, not by anything in the response body, so an ' +
+      'out-of-order response has nothing to corrupt.',
+  },
+}
+
+// A function is "write-only" only if it never assigns a `state.*` field
+// directly from the fetch response's `.data` -- a real, checkable structural
+// claim, not just a label. If a later edit starts doing that inside a
+// function still classified 'write-only', this catches the classification
+// going stale instead of silently trusting the registry text.
+const STATE_FROM_RESPONSE_DATA = /state\.[\w.[\]'"]+\s*=[^;\n]*\.data\b/
+
+export function checkAsyncFetchStalenessCoverage(content: string): string[] {
+  const errors: string[] = []
+  const functions = extractFunctionBodies(content)
+  const byName = new Map(functions.map((f) => [f.name, f]))
+
+  const foundFetchFunctions = functions.filter((f) => FETCH_CALL.test(f.body))
+
+  // 1. Every function that calls performFetch( must be registered.
+  for (const fn of foundFetchFunctions) {
+    if (!(fn.name in AUDITED_ASYNC_FETCH_FUNCTIONS)) {
+      errors.push(
+        `${fn.name}() calls performFetch( but has no entry in ` +
+          'AUDITED_ASYNC_FETCH_FUNCTIONS -- this is a new async-fetch call ' +
+          'site with no recorded staleness classification. Read it fresh ' +
+          '(does it apply the response to shared state after an await? can ' +
+          'two calls race?) and add a registry entry with the guardKind it ' +
+          'actually uses (see the guardKind union and existing entries for ' +
+          'the shapes already in use) before merging -- do not default to ' +
+          "assuming it's safe.",
+      )
+    }
+  }
+
+  // 2. Every registered function must still exist and still call
+  // performFetch( -- catches a rename/removal the registry wasn't updated
+  // for, mirroring every other verifyModelBuilder* guard's "has it moved?"
+  // check.
+  for (const [name, entry] of Object.entries(AUDITED_ASYNC_FETCH_FUNCTIONS)) {
+    const fn = byName.get(name)
+    if (!fn) {
+      errors.push(
+        `AUDITED_ASYNC_FETCH_FUNCTIONS has an entry for ${name}(), but no ` +
+          'function by that name was found in modelBuilderStore.ts -- has ' +
+          'it been renamed, removed, or inlined? If so, this registry entry ' +
+          '(and the staleness protection it documents) needs to move with ' +
+          'it, or be removed if the call site is genuinely gone.',
+      )
+      continue
+    }
+    if (!FETCH_CALL.test(fn.body)) {
+      errors.push(
+        `AUDITED_ASYNC_FETCH_FUNCTIONS has an entry for ${name}(), but its ` +
+          'body no longer contains a performFetch( call -- remove the ' +
+          'registry entry, or if the fetch moved to a helper it calls, ' +
+          'confirm the helper (not this function) is the real call site and ' +
+          'register that instead.',
+      )
+      continue
+    }
+    if (!fn.body.includes(entry.marker)) {
+      errors.push(
+        `${name}()'s recorded staleness-guard marker (${JSON.stringify(entry.marker)}, ` +
+          `guardKind: '${entry.guardKind}') is no longer present in its body ` +
+          '-- the protection this registry entry documents may have been ' +
+          'removed or rewritten. Re-audit this function for the out-of-order ' +
+          'response race and update the registry entry (marker and/or ' +
+          'guardKind) to match what is actually there now.',
+      )
+    }
+    if (
+      entry.guardKind === 'write-only' &&
+      STATE_FROM_RESPONSE_DATA.test(fn.body)
+    ) {
+      errors.push(
+        `${name}() is classified 'write-only' (never applies the fetch ` +
+          "response's .data to shared state), but its body now contains a " +
+          'state assignment sourced from `.data` -- this classification is ' +
+          'stale. Re-audit for an out-of-order response race and reclassify ' +
+          "(likely 'ticket-counter', 'capture-compare', or 'identity-check' " +
+          'depending on what it does with the response).',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkAsyncFetchStalenessCoverage(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder async-fetch staleness coverage contract failed for ' +
+        'modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder async-fetch staleness coverage contract passed: every ' +
+      `performFetch( call site (${Object.keys(AUDITED_ASYNC_FETCH_FUNCTIONS).length} ` +
+      'functions) has a recorded staleness classification, and each ' +
+      "classification's marker is still present in the store.",
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
model-builder/t-044: Build a coverage guard for the async-fetch staleness pattern itself, instead of rediscovering it function-by-function each cycle (kind: software)

### What changed / what I produced
- Added `utils/scripts/verifyModelBuilderAsyncFetchStalenessCoverage.ts`: enumerates every `performFetch(`/`performFetch<T>(` call site in `stores/modelBuilderStore.ts` and requires each to carry a recorded staleness-guard classification in an explicit registry (`AUDITED_ASYNC_FETCH_FUNCTIONS`). A new, unaudited call site now fails CI instead of silently shipping — the actual gap this task was filed to close.
- Reading every call site first (rather than assuming the ticket-counter shape from `fetchRuns`/`openRun` is universally required) found the store actually uses **six** distinct, independently-correct staleness idioms depending on what the function does with the response: `ticket-counter`, `capture-compare`, `cancelled-run-check`, `identity-check`, `serialized-lock`, `write-only`. These are documented in the guard's header comment and in each registry entry's `rationale`. The guard does **not** re-demand the ticket-counter shape everywhere (that would false-flag ~8 already-correct, already-audited functions) — it only requires every call site be classified, and spot-checks each classification's `marker` substring is still present so a refactor that quietly deletes the actual protection still fails the build.
- Added `utils/scripts/verifyModelBuilderAsyncFetchStalenessCoverage.test.ts` following the established narrow-textual-checker + self-test convention, covering: the fully-covered baseline (no errors), a new unregistered `performFetch(` call site, a registered function's marker being deleted, a registered function being renamed away, a registered function's `performFetch(` call being removed, and a `'write-only'`-classified function that starts assigning `state.*` from `.data` (classification gone stale).
- Wired both into `package.json` (`test:model-builder-async-fetch-staleness-coverage[-selftest]`) and `.github/workflows/contract-tests.yml`, immediately after the `openRun` request guard entries.

### How I verified
- New guard + self-test pass (`npm run test:model-builder-async-fetch-staleness-coverage[-selftest]`).
- All 67 existing `test:model-builder-*` guard/self-test scripts pass — no regression.
- `eslint` clean on the two new files.
- `prettier --check` clean on all four touched/new files.
- `vue-tsc --noEmit` exits 0 repo-wide.
- `git status --porcelain` showed exactly the 4 intended files.

### Stakes
reversible

### Flags for Reviewer
- This guard is deliberately scoped to *direct* `performFetch(` call sites in `modelBuilderStore.ts`. Functions that reach the same bug class indirectly via a delegated call (`generateItemAsset`/`pollAsyncArtJob`/`generateItemAssetAsync` calling `artStore` methods rather than `performFetch` themselves) are out of scope here — they already have their own dedicated guards (`verifyModelBuilderCancelledRunGuard.ts`, `verifyModelBuilderAsyncEnqueueCancelledRunGuard.ts`). Noted explicitly in the file header so this isn't mistaken for full coverage of the bug class, only of this one call shape.
- The `write-only` classification's structural check (no `state.* = ...data` assignment) is a real, checkable claim, not just a label — see `STATE_FROM_RESPONSE_DATA` regex and its dedicated self-test case.

### Kaizen suggestion
Filed from the conductor side already (this is the kaizen task being closed by this PR); no new kaizen filed from here — the point of this task was to stop needing one.

### Notes for reviewer
n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPyz5yfuijSaTjVdFyJ49e)_