### PR TITLE
ci(docker): tighten publish-container timeout to surface hangs (t-043)

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -26,7 +26,15 @@ jobs:
   build-and-publish:
     name: Build production image
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Not a required status check for merge -- this only validates the image still
+    # builds (and, on push to main, publishes it). Typical duration is ~9 minutes;
+    # 30 minutes let a genuine hang run silently in the background well past when
+    # merge already fired on the required checks (kaizen from model-builder/t-029,
+    # kind_robots PR #1882, 2026-08-14: every required check on #1882 was green by
+    # 06:04:19Z but this job was still running past its typical duration when the
+    # merge fired at 06:04:54Z). Tightened so a hang surfaces as a clear CI failure
+    # instead of dangling -- still generous headroom over the ~9-minute norm.
+    timeout-minutes: 15
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

The "Build production image" job (`publish-container.yml`) is not a required status check for merge, but it's consistently the slowest and least predictable check on PRs that touch `Dockerfile`/`package.json`/`package-lock.json`/`prisma/**`.

Kaizen from model-builder/t-029 (kind_robots PR #1882, 2026-08-14): every required check on #1882 was green by 06:04:19Z, but this job was still running past its typical ~9-minute duration when the merge fired at 06:04:54Z.

## Change

Reduce `timeout-minutes` from 30 to 15 so a genuine hang surfaces as a clear CI failure instead of dangling silently in the background well past merge time — still generous headroom over the observed ~9-minute norm.

## Ref

conductor/model-builder/t-043

---
_Generated by [Claude Code](https://claude.ai/code/session_016GijubRko9i2XkfZ4jqcdn)_