### PR TITLE
feat(wan): default image-to-video to the 5B TI2V model that fits the card

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Comfy-only generation contract
         run: npm run test:comfy-only-generation
 
+      - name: WAN image-to-video mode contract
+        run: npm run test:wan-i2v-modes
+
       - name: Channel content contract
         run: npm run test:channel-content
 

--- a/package.json
+++ b/package.json
@@ -247,7 +247,8 @@
     "test:no-shadowed-content-routes": "tsx utils/scripts/verifyNoShadowedContentRoutes.ts",
     "flag:mature-resources": "tsx utils/scripts/flagMatureResources.ts",
     "test:mature-terms": "tsx utils/scripts/flagMatureResources.ts --self-test",
-    "test:artjob-priority-bounds": "tsx utils/scripts/verifyArtJobPriorityBounds.ts"
+    "test:artjob-priority-bounds": "tsx utils/scripts/verifyArtJobPriorityBounds.ts",
+    "test:wan-i2v-modes": "tsx utils/scripts/verifyWanI2vModes.ts"
   },
   "devDependencies": {
     "@nuxt/eslint": "^1.1.0",

--- a/server/api/comfy/wan/utils/imageToVideoWorkflow.ts
+++ b/server/api/comfy/wan/utils/imageToVideoWorkflow.ts
@@ -50,7 +50,11 @@ export type WanImageToVideoInput = {
   loraStrength?: number | null
   // Fraction of the total steps handled by the high-noise expert before the
   // low-noise expert takes over (0–1). Defaults to WAN_DEFAULT_BOUNDARY.
+  // Ignored in ti2v mode, which has no second expert to hand over to.
   boundary?: number | null
+  // 'ti2v' (default) fits the card; 'a14b' is the slower high-quality pair.
+  // Omitted, a last-frame request selects 'a14b' -- see resolveWanMode.
+  mode?: WanImageToVideoMode | null
   filenamePrefix?: string | null
   outputFormat?: VideoOutputFormat | string | null
 }
@@ -106,6 +110,49 @@ export function wanClipLoaderNode() {
 }
 export const WAN_VAE = 'wan_2.1_vae.safetensors'
 
+// WAN 2.2 ships two image-to-video paths, and this box can only afford one of
+// them interactively. Measured on the render host (12 GB card):
+//
+//   A14B  wan2.2_i2v_high_noise_14B_fp8   14 GB  } one resident at a time,
+//         wan2.2_i2v_low_noise_14B_fp8    14 GB  } still over the card
+//   TI2V  wan2.2_ti2v_5B_fp16            9.4 GB
+//
+// A14B does not fit in VRAM, so ComfyUI offloads to system RAM and the render
+// becomes an overnight job. It completes, and Silas rates the quality highly --
+// it is a batch mode, not a broken one, and is kept exactly as it was.
+//
+// TI2V-5B is WAN's own answer for consumer cards and is what a caller should
+// get by default. It is a different graph, not a different filename: one unet
+// instead of the high/low expert pair, no boundary split, the 2.2 VAE rather
+// than the 2.1 VAE, and Wan22ImageToVideoLatent in place of WanImageToVideo.
+export const WAN_TI2V_UNET = 'wan2.2_ti2v_5B_fp16.safetensors'
+
+// The 5B TI2V model uses the 2.2 VAE. The A14B pair uses the 2.1 VAE -- these
+// are not interchangeable, which is why both files exist on the box.
+export const WAN_TI2V_VAE = 'wan2.2_vae.safetensors'
+
+export type WanImageToVideoMode = 'ti2v' | 'a14b'
+
+export const WAN_DEFAULT_MODE: WanImageToVideoMode =
+  (process.env.WAN_I2V_MODE || '').trim() === 'a14b' ? 'a14b' : 'ti2v'
+
+/**
+ * Which graph to build.
+ *
+ * An explicit mode wins. Otherwise a request that pins the final frame selects
+ * A14B automatically: Wan22ImageToVideoLatent declares only an optional
+ * `start_image` and has no `end_image` input, so first-last-frame is a
+ * capability TI2V structurally does not have. Silently dropping the last frame
+ * would be worse than spending the extra time.
+ */
+export function resolveWanMode(
+  input: Pick<WanImageToVideoInput, 'mode' | 'lastImageName'>,
+): WanImageToVideoMode {
+  if (input.mode === 'a14b' || input.mode === 'ti2v') return input.mode
+  if (input.lastImageName?.trim()) return 'a14b'
+  return WAN_DEFAULT_MODE
+}
+
 function resolveSeed(seed?: number | null): number {
   if (typeof seed === 'number' && Number.isFinite(seed) && seed >= 0) {
     return Math.floor(seed)
@@ -143,6 +190,20 @@ export function buildWanImageToVideoWorkflow(
   const scheduler = input.scheduler ?? WAN_DEFAULT_SCHEDULER
   const split = boundaryStep(steps, input.boundary ?? WAN_DEFAULT_BOUNDARY)
   const hasLastFrame = Boolean(input.lastImageName)
+
+  if (resolveWanMode(input) === 'ti2v') {
+    return buildWanTi2vWorkflow(input, {
+      seed,
+      width,
+      height,
+      frameRate,
+      length,
+      steps,
+      cfg,
+      samplerName,
+      scheduler,
+    })
+  }
 
   const workflow: ComfyWorkflow = {
     // --- Loaders ------------------------------------------------------------
@@ -288,6 +349,144 @@ export function buildWanImageToVideoWorkflow(
     class_type: 'VAEDecode',
     _meta: { title: 'VAE Decode' },
   }
+  Object.assign(
+    workflow,
+    buildVideoOutputNodes({
+      format: normalizeVideoOutputFormat(input.outputFormat),
+      imagesRef: ['decode', 0],
+      fps: frameRate,
+      filenamePrefix:
+        input.filenamePrefix ?? 'video/kindrobots_wan_image2video',
+    }),
+  )
+
+  return workflow
+}
+
+type WanDerived = {
+  seed: number
+  width: number
+  height: number
+  frameRate: number
+  length: number
+  steps: number
+  cfg: number
+  samplerName: string
+  scheduler: string
+}
+
+/**
+ * WAN 2.2 TI2V-5B: one 9.4 GB unet that fits the card, against the A14B pair's
+ * 14 GB-at-a-time that does not.
+ *
+ * Structurally different from the A14B graph, not just differently named:
+ *
+ *   - one UNETLoader, so one optional LoRA rather than a matched pair
+ *   - one KSampler, because there is no second expert to hand a partially
+ *     denoised latent to -- `boundary` has no meaning here
+ *   - the 2.2 VAE, which is what the 5B model was trained against
+ *   - Wan22ImageToVideoLatent, whose signature (confirmed against the render
+ *     host's /object_info) is vae/width/height/length/batch_size with an
+ *     OPTIONAL start_image, returning a LATENT and nothing else
+ *
+ * That last point is the one worth reading twice. WanImageToVideo returns
+ * (positive, negative, latent) and the A14B graph wires conditioning THROUGH
+ * it. Wan22ImageToVideoLatent returns a latent only, so conditioning runs
+ * straight from CLIPTextEncode into the sampler. Copying the A14B wiring here
+ * would reference outputs that do not exist.
+ *
+ * It also has no end_image input, which is why resolveWanMode sends any
+ * last-frame request to A14B rather than quietly dropping the last frame.
+ */
+function buildWanTi2vWorkflow(
+  input: WanImageToVideoInput,
+  derived: WanDerived,
+): ComfyWorkflow {
+  const { seed, width, height, frameRate, length, steps, cfg } = derived
+  const { samplerName, scheduler } = derived
+
+  const workflow: ComfyWorkflow = {
+    unet: {
+      inputs: { unet_name: WAN_TI2V_UNET, weight_dtype: 'default' },
+      class_type: 'UNETLoader',
+      _meta: { title: 'Load Diffusion Model (TI2V 5B)' },
+    },
+    clip: wanClipLoaderNode(),
+    vae: {
+      inputs: { vae_name: WAN_TI2V_VAE },
+      class_type: 'VAELoader',
+      _meta: { title: 'Load VAE (WAN 2.2)' },
+    },
+    positive: {
+      inputs: { text: input.prompt, clip: ['clip', 0] },
+      class_type: 'CLIPTextEncode',
+      _meta: { title: 'CLIP Text Encode Positive' },
+    },
+    negative: {
+      inputs: { text: input.negativePrompt, clip: ['clip', 0] },
+      class_type: 'CLIPTextEncode',
+      _meta: { title: 'CLIP Text Encode Negative' },
+    },
+    img_first: {
+      inputs: { image: input.firstImageName },
+      class_type: 'LoadImage',
+      _meta: { title: 'Load First Image' },
+    },
+  }
+
+  let modelRef: [string, number] = ['unet', 0]
+  const loraName = input.loraName?.trim()
+  if (loraName) {
+    workflow['lora'] = {
+      inputs: {
+        lora_name: loraName,
+        strength_model: input.loraStrength ?? 1,
+        model: modelRef,
+      },
+      class_type: 'LoraLoaderModelOnly',
+      _meta: { title: 'Load Selected WAN LoRA' },
+    }
+    modelRef = ['lora', 0]
+  }
+
+  workflow['latent'] = {
+    inputs: {
+      vae: ['vae', 0],
+      width,
+      height,
+      length,
+      batch_size: 1,
+      start_image: ['img_first', 0],
+    },
+    class_type: 'Wan22ImageToVideoLatent',
+    _meta: { title: 'WAN 2.2 Image To Video Latent' },
+  }
+
+  workflow['sampler'] = {
+    inputs: {
+      seed,
+      steps,
+      cfg,
+      sampler_name: samplerName,
+      scheduler,
+      denoise: 1,
+      model: modelRef,
+      // Straight from the encoders: this graph's latent node emits no
+      // conditioning to route through.
+      positive: ['positive', 0],
+      negative: ['negative', 0],
+      latent_image: ['latent', 0],
+    },
+    class_type: 'KSampler',
+    _meta: { title: 'KSampler (TI2V)' },
+  }
+
+  workflow['decode'] = {
+    inputs: { samples: ['sampler', 0], vae: ['vae', 0] },
+    class_type: 'VAEDecode',
+    _meta: { title: 'VAE Decode' },
+  }
+
   Object.assign(
     workflow,
     buildVideoOutputNodes({

--- a/utils/scripts/verifyWanI2vModes.ts
+++ b/utils/scripts/verifyWanI2vModes.ts
@@ -12,6 +12,11 @@
 // default. The two graphs are structurally different, and the differences are
 // exactly what a careless edit would flatten, so they are pinned here.
 import assert from 'node:assert/strict'
+import type {
+  ComfyWorkflow,
+  ComfyWorkflowNode,
+  WanImageToVideoInput,
+} from '../../server/api/comfy/wan/utils/imageToVideoWorkflow'
 import {
   buildWanImageToVideoWorkflow,
   resolveWanMode,
@@ -20,7 +25,7 @@ import {
   WAN_VAE,
 } from '../../server/api/comfy/wan/utils/imageToVideoWorkflow'
 
-const base = {
+const base: WanImageToVideoInput = {
   prompt: 'a cat',
   negativePrompt: 'blurry',
   firstImageName: 'a.png',
@@ -28,10 +33,26 @@ const base = {
   height: 480,
   duration: 5,
   frameRate: 16,
-} as Parameters<typeof buildWanImageToVideoWorkflow>[0]
+}
 
-const node = (wf: Record<string, any>, cls: string) =>
-  Object.values(wf).find((n: any) => n?.class_type === cls) as any
+function nodesOfClass(wf: ComfyWorkflow, cls: string): ComfyWorkflowNode[] {
+  return Object.values(wf).filter((n) => n?.class_type === cls)
+}
+
+function maybeNode(
+  wf: ComfyWorkflow,
+  cls: string,
+): ComfyWorkflowNode | undefined {
+  return nodesOfClass(wf, cls)[0]
+}
+
+/** The node of this class, asserted present so callers can read `.inputs`. */
+function node(wf: ComfyWorkflow, cls: string): Required<ComfyWorkflowNode> {
+  const found = maybeNode(wf, cls)
+  assert.ok(found, `expected a ${cls} node`)
+  assert.ok(found.inputs, `${cls} must carry inputs`)
+  return found as Required<ComfyWorkflowNode>
+}
 
 // --- mode selection ---------------------------------------------------------
 
@@ -56,7 +77,7 @@ assert.equal(
 
 // --- TI2V graph -------------------------------------------------------------
 
-const ti2v = buildWanImageToVideoWorkflow(base) as Record<string, any>
+const ti2v = buildWanImageToVideoWorkflow(base)
 
 assert.equal(node(ti2v, 'UNETLoader').inputs.unet_name, WAN_TI2V_UNET)
 assert.equal(
@@ -64,16 +85,18 @@ assert.equal(
   WAN_TI2V_VAE,
   'the 5B TI2V model is trained against the 2.2 VAE, not the 2.1 VAE',
 )
-assert.ok(node(ti2v, 'Wan22ImageToVideoLatent'), 'TI2V uses the latent node')
-assert.equal(node(ti2v, 'WanImageToVideo'), undefined)
+assert.ok(
+  maybeNode(ti2v, 'Wan22ImageToVideoLatent'),
+  'TI2V uses the latent node',
+)
+assert.equal(maybeNode(ti2v, 'WanImageToVideo'), undefined)
 assert.equal(
-  node(ti2v, 'KSamplerAdvanced'),
+  maybeNode(ti2v, 'KSamplerAdvanced'),
   undefined,
   'no expert handover, so no two-stage sampler',
 )
 
 const sampler = node(ti2v, 'KSampler')
-assert.ok(sampler, 'TI2V samples in one pass')
 // The load-bearing wiring difference. WanImageToVideo returns
 // (positive, negative, latent) and the A14B graph routes conditioning THROUGH
 // it. Wan22ImageToVideoLatent returns a LATENT only -- confirmed against the
@@ -97,35 +120,26 @@ for (const key of ['vae', 'width', 'height', 'length', 'batch_size']) {
 const ti2vLora = buildWanImageToVideoWorkflow({
   ...base,
   loraName: 'x.safetensors',
-}) as Record<string, any>
-const loraNodes = Object.values(ti2vLora).filter(
-  (n: any) => n?.class_type === 'LoraLoaderModelOnly',
-)
+})
+const loraNodes = nodesOfClass(ti2vLora, 'LoraLoaderModelOnly')
 assert.equal(loraNodes.length, 1, 'TI2V has a single model to patch')
 assert.deepEqual(node(ti2vLora, 'KSampler').inputs.model, ['lora', 0])
 
 // --- A14B graph is untouched ------------------------------------------------
 
-const a14b = buildWanImageToVideoWorkflow({
-  ...base,
-  mode: 'a14b',
-}) as Record<string, any>
+const a14b = buildWanImageToVideoWorkflow({ ...base, mode: 'a14b' })
 
-const unets = Object.values(a14b).filter(
-  (n: any) => n?.class_type === 'UNETLoader',
-)
+const unets = nodesOfClass(a14b, 'UNETLoader')
 assert.equal(unets.length, 2, 'the quality mode keeps both experts')
 assert.equal(node(a14b, 'VAELoader').inputs.vae_name, WAN_VAE)
-assert.ok(node(a14b, 'WanImageToVideo'))
-const advanced = Object.values(a14b).filter(
-  (n: any) => n?.class_type === 'KSamplerAdvanced',
-)
+assert.ok(maybeNode(a14b, 'WanImageToVideo'))
+const advanced = nodesOfClass(a14b, 'KSamplerAdvanced')
 assert.equal(advanced.length, 2, 'high-noise then low-noise')
 
 const a14bLast = buildWanImageToVideoWorkflow({
   ...base,
   lastImageName: 'z.png',
-}) as Record<string, any>
+})
 assert.deepEqual(node(a14bLast, 'WanImageToVideo').inputs.end_image, [
   'img_last',
   0,

--- a/utils/scripts/verifyWanI2vModes.ts
+++ b/utils/scripts/verifyWanI2vModes.ts
@@ -1,0 +1,137 @@
+// Contract test for the two WAN image-to-video graphs.
+//
+// WAN 2.2 ships two i2v paths and this render box (12 GB card) can only afford
+// one interactively. Measured sizes on the host:
+//
+//   A14B  wan2.2_i2v_high_noise_14B_fp8   14 GB  } one resident at a time,
+//         wan2.2_i2v_low_noise_14B_fp8    14 GB  } still over the card
+//   TI2V  wan2.2_ti2v_5B_fp16            9.4 GB
+//
+// A14B does not fit, so ComfyUI offloads and the render becomes an overnight
+// job -- slow, not broken, and explicitly kept as the quality mode. TI2V is the
+// default. The two graphs are structurally different, and the differences are
+// exactly what a careless edit would flatten, so they are pinned here.
+import assert from 'node:assert/strict'
+import {
+  buildWanImageToVideoWorkflow,
+  resolveWanMode,
+  WAN_TI2V_UNET,
+  WAN_TI2V_VAE,
+  WAN_VAE,
+} from '../../server/api/comfy/wan/utils/imageToVideoWorkflow'
+
+const base = {
+  prompt: 'a cat',
+  negativePrompt: 'blurry',
+  firstImageName: 'a.png',
+  width: 832,
+  height: 480,
+  duration: 5,
+  frameRate: 16,
+} as Parameters<typeof buildWanImageToVideoWorkflow>[0]
+
+const node = (wf: Record<string, any>, cls: string) =>
+  Object.values(wf).find((n: any) => n?.class_type === cls) as any
+
+// --- mode selection ---------------------------------------------------------
+
+assert.equal(
+  resolveWanMode(base),
+  'ti2v',
+  'TI2V is the default: it fits the card',
+)
+assert.equal(
+  resolveWanMode({ ...base, mode: 'a14b' }),
+  'a14b',
+  'an explicit mode always wins',
+)
+assert.equal(
+  resolveWanMode({ ...base, lastImageName: 'z.png' }),
+  'a14b',
+  // Wan22ImageToVideoLatent declares only an optional start_image and has no
+  // end_image, so TI2V cannot honour a last frame. Routing to A14B costs time;
+  // silently dropping the pinned final frame would cost the user the feature.
+  'a last-frame request must select the only graph that can do it',
+)
+
+// --- TI2V graph -------------------------------------------------------------
+
+const ti2v = buildWanImageToVideoWorkflow(base) as Record<string, any>
+
+assert.equal(node(ti2v, 'UNETLoader').inputs.unet_name, WAN_TI2V_UNET)
+assert.equal(
+  node(ti2v, 'VAELoader').inputs.vae_name,
+  WAN_TI2V_VAE,
+  'the 5B TI2V model is trained against the 2.2 VAE, not the 2.1 VAE',
+)
+assert.ok(node(ti2v, 'Wan22ImageToVideoLatent'), 'TI2V uses the latent node')
+assert.equal(node(ti2v, 'WanImageToVideo'), undefined)
+assert.equal(
+  node(ti2v, 'KSamplerAdvanced'),
+  undefined,
+  'no expert handover, so no two-stage sampler',
+)
+
+const sampler = node(ti2v, 'KSampler')
+assert.ok(sampler, 'TI2V samples in one pass')
+// The load-bearing wiring difference. WanImageToVideo returns
+// (positive, negative, latent) and the A14B graph routes conditioning THROUGH
+// it. Wan22ImageToVideoLatent returns a LATENT only -- confirmed against the
+// host's /object_info -- so conditioning must come straight off the encoders.
+// Copying A14B's wiring here would reference outputs that do not exist.
+assert.deepEqual(sampler.inputs.positive, ['positive', 0])
+assert.deepEqual(sampler.inputs.negative, ['negative', 0])
+assert.deepEqual(sampler.inputs.latent_image, ['latent', 0])
+
+const latent = node(ti2v, 'Wan22ImageToVideoLatent')
+assert.deepEqual(latent.inputs.start_image, ['img_first', 0])
+assert.ok(
+  !('end_image' in latent.inputs),
+  'the node declares no end_image; emitting one would be rejected at submit',
+)
+for (const key of ['vae', 'width', 'height', 'length', 'batch_size']) {
+  assert.ok(key in latent.inputs, `Wan22ImageToVideoLatent requires ${key}`)
+}
+
+// One unet means one LoRA, not the A14B matched pair.
+const ti2vLora = buildWanImageToVideoWorkflow({
+  ...base,
+  loraName: 'x.safetensors',
+}) as Record<string, any>
+const loraNodes = Object.values(ti2vLora).filter(
+  (n: any) => n?.class_type === 'LoraLoaderModelOnly',
+)
+assert.equal(loraNodes.length, 1, 'TI2V has a single model to patch')
+assert.deepEqual(node(ti2vLora, 'KSampler').inputs.model, ['lora', 0])
+
+// --- A14B graph is untouched ------------------------------------------------
+
+const a14b = buildWanImageToVideoWorkflow({
+  ...base,
+  mode: 'a14b',
+}) as Record<string, any>
+
+const unets = Object.values(a14b).filter(
+  (n: any) => n?.class_type === 'UNETLoader',
+)
+assert.equal(unets.length, 2, 'the quality mode keeps both experts')
+assert.equal(node(a14b, 'VAELoader').inputs.vae_name, WAN_VAE)
+assert.ok(node(a14b, 'WanImageToVideo'))
+const advanced = Object.values(a14b).filter(
+  (n: any) => n?.class_type === 'KSamplerAdvanced',
+)
+assert.equal(advanced.length, 2, 'high-noise then low-noise')
+
+const a14bLast = buildWanImageToVideoWorkflow({
+  ...base,
+  lastImageName: 'z.png',
+}) as Record<string, any>
+assert.deepEqual(node(a14bLast, 'WanImageToVideo').inputs.end_image, [
+  'img_last',
+  0,
+])
+
+console.log(
+  'WAN i2v mode contract OK: ti2v default (5B/2.2 VAE/single sampler), ' +
+    'a14b on request or last-frame, conditioning wired per graph.',
+)


### PR DESCRIPTION
Silas: *"The high low pass should stick as a high quality option, it does work and works great. It just shouldn't be the default, and we want one that fits our system better."*

## Measured on the render host

```
A14B  wan2.2_i2v_high_noise_14B_fp8   14 GB  } one resident at a time,
      wan2.2_i2v_low_noise_14B_fp8    14 GB  } still over the 12 GB card
TI2V  wan2.2_ti2v_5B_fp16            9.4 GB
```

A14B doesn't fit in VRAM, so ComfyUI offloads to system RAM and the render becomes an overnight job. **Slow is not broken** — it's kept exactly as it was, now reachable as `mode: 'a14b'` or `WAN_I2V_MODE=a14b`.

TI2V-5B is WAN's own answer for consumer cards and is now the default.

## It's a different graph, not a different filename

- one `UNETLoader`, so one optional LoRA rather than a matched pair
- one `KSampler` — there's no second expert to hand a partially denoised latent to, so `boundary` is meaningless in this mode
- the **2.2 VAE**, which the 5B model was trained against. The 2.1 VAE stays with A14B; they aren't interchangeable, which is why both files are on the box — and this file's own comment already said exactly that
- `Wan22ImageToVideoLatent` instead of `WanImageToVideo`

## The trap in that last point

`WanImageToVideo` returns `(positive, negative, latent)`, and the A14B graph routes conditioning **through** it. I captured the real signature from your `/object_info` rather than assuming:

```
required: vae, width, height, length, batch_size
optional: start_image
output:   LATENT          ← only
```

`Wan22ImageToVideoLatent` returns a latent and nothing else, so conditioning runs straight from `CLIPTextEncode` into the sampler. Copying A14B's wiring would have referenced outputs that don't exist — and that's the mistake I'd have made from memory. Worth the extra round trip, given tonight already produced two failures of exactly this kind (a `lora_name` absent from ComfyUI's list, and `DualCLIPLoaderGGUF` not declaring `device`).

## The capability that forced a design decision

The same capture showed **no `end_image` input** — TI2V structurally cannot pin a final frame. So `resolveWanMode` routes any last-frame request to A14B. Spending the extra time is better than silently dropping the feature the caller asked for.

Resolution order: explicit `mode` → last-frame present → `WAN_I2V_MODE` → `ti2v`.

## Tests

`verifyWanI2vModes` pins both graphs and is **verified to fail** on the two mistakes actually available here:

| injected regression | caught by |
|---|---|
| TI2V wired to the 2.1 VAE | `the 5B TI2V model is trained against the 2.2 VAE` |
| conditioning copied from A14B refs | deep-equal on `sampler.positive` |

Wired into `contract-tests.yml`. `verifyComfyOnlyGeneration` still passes.

## Not verified

Whether TI2V actually fits once video latents and activations are counted — 9.4 GB unet + 1.4 GB VAE is ~10.8 GB before those. If it still spills, `umt5-xxl-encoder-Q3_K_M.gguf` (2.9 GB vs 3.9 GB) buys another gigabyte, and ComfyUI can unload the encoder after conditioning. First real i2v render is the measurement.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExVxVDi11BHRziDazVr7Et)_