### PR TITLE
fix(serendipity-voice): reset command/message cursors on relay reconnect (t-015)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -257,6 +257,12 @@ jobs:
       - name: Serendipity Voice poll guard
         run: npm run test:serendipity-voice-poll-guard
 
+      - name: Serendipity Voice cursor-reset guard self-test
+        run: npm run test:serendipity-voice-cursor-reset-selftest
+
+      - name: Serendipity Voice cursor-reset guard
+        run: npm run test:serendipity-voice-cursor-reset
+
       - name: Pack manifest validator self-test
         run: npm run test:pack-manifest
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,8 @@
     "test:davinci-resolve-panel-guard": "tsx utils/scripts/verifyDaVinciResolvePanelGuard.ts",
     "test:serendipity-voice-poll-guard-selftest": "tsx utils/scripts/verifySerendipityVoicePollGuard.test.ts",
     "test:serendipity-voice-poll-guard": "tsx utils/scripts/verifySerendipityVoicePollGuard.ts",
+    "test:serendipity-voice-cursor-reset-selftest": "tsx utils/scripts/verifySerendipityVoiceCursorReset.test.ts",
+    "test:serendipity-voice-cursor-reset": "tsx utils/scripts/verifySerendipityVoiceCursorReset.ts",
     "test:achievement-store": "tsx utils/scripts/verifyAchievementStoreFetchSafety.ts",
     "test:achievement-catalog": "tsx utils/scripts/verifyDatabaseRetry.ts && tsx utils/scripts/verifyAchievementArtJobDedupe.ts && tsx utils/scripts/verifyAchievementCatalog.ts",
     "seed:achievements": "tsx scripts/seed_achievements.ts",

--- a/stores/serendipityVoiceStore.ts
+++ b/stores/serendipityVoiceStore.ts
@@ -90,7 +90,16 @@ export const useSerendipityVoiceStore = defineStore(
     }
 
     function setRelayBaseUrl(url: string): void {
-      relayBaseUrl.value = url.trim().replace(/\/+$/, '') || DEFAULT_RELAY_URL
+      const next = url.trim().replace(/\/+$/, '') || DEFAULT_RELAY_URL
+      // A different relay instance never shares the old one's command/message
+      // id space -- keeping a stale cursor here means every future /api/commands
+      // and /api/messages poll sends `since=<a value the new relay may never
+      // reach>`, so the server-side filter silently drops everything forever.
+      if (next !== relayBaseUrl.value) {
+        commandCursor.value = 0
+        messageCursor.value = 0
+      }
+      relayBaseUrl.value = next
       if (isClient())
         window.localStorage.setItem(RELAY_URL_KEY, relayBaseUrl.value)
     }
@@ -307,6 +316,15 @@ export const useSerendipityVoiceStore = defineStore(
     function start(): void {
       if (!isClient() || polling.value) return
       loadRelayUrl()
+      // The relay is documented as an in-memory dev seam (see header comment)
+      // that is expected to be restarted often -- a restart resets its
+      // command/message log back to id 0. Reset the cursors on every fresh
+      // connect so a relay restart between sessions can't leave the client
+      // holding a cursor value the new relay session will never reach, which
+      // would otherwise make every future command/message poll come back
+      // silently empty (connected with no error, but nothing ever arrives).
+      commandCursor.value = 0
+      messageCursor.value = 0
       polling.value = true
       void pollOnce()
       pollTimer.value = setInterval(() => void pollOnce(), POLL_INTERVAL_MS)

--- a/utils/scripts/verifySerendipityVoiceCursorReset.test.ts
+++ b/utils/scripts/verifySerendipityVoiceCursorReset.test.ts
@@ -1,0 +1,101 @@
+// /utils/scripts/verifySerendipityVoiceCursorReset.test.ts
+//
+// Regression test for checkSerendipityVoiceCursorReset() in
+// verifySerendipityVoiceCursorReset.ts (alexa-integration/t-015). Exercises
+// the real check against synthetic store-shaped fixtures covering: the
+// fixed shape (both setRelayBaseUrl() and start() reset the cursors), the
+// pre-fix shape (neither resets), a partial-fix shape (only one of the two
+// resets), and missing-function fixtures.
+import assert from 'node:assert/strict'
+
+import { checkSerendipityVoiceCursorReset } from './verifySerendipityVoiceCursorReset.js'
+
+function fixture(opts: { relayReset: string; startReset: string }): string {
+  return `
+    function setRelayBaseUrl(url: string): void {
+      const next = url.trim().replace(/\\/+$/, '') || DEFAULT_RELAY_URL
+      if (next !== relayBaseUrl.value) {
+        ${opts.relayReset}
+      }
+      relayBaseUrl.value = next
+      if (isClient())
+        window.localStorage.setItem(RELAY_URL_KEY, relayBaseUrl.value)
+    }
+
+    function start(): void {
+      if (!isClient() || polling.value) return
+      loadRelayUrl()
+      ${opts.startReset}
+      polling.value = true
+      void pollOnce()
+      pollTimer.value = setInterval(() => void pollOnce(), POLL_INTERVAL_MS)
+    }
+  `
+}
+
+const RESET = 'commandCursor.value = 0\n        messageCursor.value = 0'
+
+const FIXED = fixture({ relayReset: RESET, startReset: RESET })
+
+// Pre-fix: neither function resets the cursors -- a relay restart or URL
+// switch leaves the client polling with a stale `since` value forever.
+const BUGGY = fixture({ relayReset: '', startReset: '' })
+
+// Partial fix: only setRelayBaseUrl() resets -- a same-URL relay restart
+// (the scenario the file's own header comment calls the normal case) still
+// reproduces the bug because start() never resets on reconnect.
+const PARTIAL_ONLY_RELAY = fixture({ relayReset: RESET, startReset: '' })
+
+// Partial fix: only start() resets -- a relay URL switch without a
+// disconnect/reconnect cycle still reproduces the bug.
+const PARTIAL_ONLY_START = fixture({ relayReset: '', startReset: RESET })
+
+function run(): void {
+  const fixedErrors = checkSerendipityVoiceCursorReset(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const buggyErrors = checkSerendipityVoiceCursorReset(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    2,
+    `expected the pre-fix fixture (neither function resets) to fail twice, got: ${JSON.stringify(buggyErrors)}`,
+  )
+
+  const partialRelayErrors =
+    checkSerendipityVoiceCursorReset(PARTIAL_ONLY_RELAY)
+  assert.equal(
+    partialRelayErrors.length,
+    1,
+    `expected the relay-only partial fix to fail once (start() still missing), got: ${JSON.stringify(partialRelayErrors)}`,
+  )
+  assert.ok(/start\(\) no longer resets/.test(partialRelayErrors[0]!))
+
+  const partialStartErrors =
+    checkSerendipityVoiceCursorReset(PARTIAL_ONLY_START)
+  assert.equal(
+    partialStartErrors.length,
+    1,
+    `expected the start-only partial fix to fail once (setRelayBaseUrl() still missing), got: ${JSON.stringify(partialStartErrors)}`,
+  )
+  assert.ok(/setRelayBaseUrl\(\) no longer resets/.test(partialStartErrors[0]!))
+
+  const missingFnErrors = checkSerendipityVoiceCursorReset(
+    'function someOtherFunction(): void {}',
+  )
+  assert.equal(missingFnErrors.length, 2)
+  assert.ok(
+    missingFnErrors.every((e) => /Could not find a function named/.test(e)),
+  )
+
+  console.log(
+    'Serendipity Voice cursor-reset self-test passed: buggy fixture fails ' +
+      'twice, both partial fixes fail once each on the missing side, fixed ' +
+      'fixture passes, missing-function fixture fails clearly.',
+  )
+}
+
+run()

--- a/utils/scripts/verifySerendipityVoiceCursorReset.ts
+++ b/utils/scripts/verifySerendipityVoiceCursorReset.ts
@@ -1,0 +1,133 @@
+// /utils/scripts/verifySerendipityVoiceCursorReset.ts
+//
+// Regression guard (alexa-integration/t-015) -- commandCursor/messageCursor
+// in stores/serendipityVoiceStore.ts are monotonically-advancing "since"
+// pointers into the relay's command/message log. The relay is explicitly
+// documented (top-of-file comment) as "an in-memory dev seam on localhost",
+// meaning it is expected to be restarted often -- a restart resets its
+// command/message log, and their id space, back to 0.
+//
+// Failure scenario this protects against: the store is a long-lived Pinia
+// singleton whose cursor state survives across a relay restart at the same
+// URL, or a Relay URL switch to a different relay instance (saveRelay() in
+// serendipity-page.vue). If the cursors are never reset, the next poll sends
+// `since=<a value the new/restarted relay's fresh log may never reach>` --
+// the server-side filter then drops every future command/message, silently.
+// The fetches still succeed (`connected.value = true`, no lastError), so the
+// UI shows "Relay connected" while every subsequent voice command and chat
+// message is swallowed with no visible sign anything is wrong.
+//
+// Fixed by resetting both cursors to 0: (a) in setRelayBaseUrl() whenever the
+// URL actually changes, and (b) in start() on every fresh connect, since a
+// same-URL relay restart between sessions is exactly the scenario the file's
+// own header comment calls out as expected/normal for this dev tool.
+//
+// This asserts the textual shape of that fix stays in place: both
+// setRelayBaseUrl() and start() contain a `commandCursor.value = 0` /
+// `messageCursor.value = 0` reset -- deliberately scoped to this one
+// bug/fix, mirroring this project's other narrow textual guards over a
+// general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/serendipityVoiceStore.ts')
+
+function extractFunctionSource(content: string, name: string): string | null {
+  const signature = new RegExp(
+    `^\\s*(?:async\\s+)?function ${name}\\([^)]*\\)[^{]*\\{`,
+    'm',
+  )
+  const match = signature.exec(content)
+  if (!match) return null
+
+  const braceOpen = match.index + match[0].length - 1
+  let depth = 0
+  let i = braceOpen
+  for (; i < content.length; i++) {
+    if (content[i] === '{') depth++
+    else if (content[i] === '}') {
+      depth--
+      if (depth === 0) break
+    }
+  }
+  if (depth !== 0) return null
+  return content.slice(braceOpen, i + 1)
+}
+
+function hasCursorReset(body: string): boolean {
+  return (
+    /commandCursor\.value\s*=\s*0/.test(body) &&
+    /messageCursor\.value\s*=\s*0/.test(body)
+  )
+}
+
+export function checkSerendipityVoiceCursorReset(content: string): string[] {
+  const errors: string[] = []
+
+  const setRelayBaseUrlBody = extractFunctionSource(content, 'setRelayBaseUrl')
+  if (!setRelayBaseUrlBody) {
+    errors.push(
+      'Could not find a function named setRelayBaseUrl() -- has it been ' +
+        'renamed, removed, or restructured? If so, this guard (and the ' +
+        'stale-cursor-after-relay-switch bug it protects against) needs to ' +
+        'move with it.',
+    )
+  } else if (!hasCursorReset(setRelayBaseUrlBody)) {
+    errors.push(
+      'setRelayBaseUrl() no longer resets commandCursor/messageCursor to 0 ' +
+        'when the relay URL changes -- without it, switching to a ' +
+        'different relay instance keeps the old cursor, and the server-side ' +
+        '`since` filter can silently drop every future command/message ' +
+        'because the new relay may never reach that id.',
+    )
+  }
+
+  const startBody = extractFunctionSource(content, 'start')
+  if (!startBody) {
+    errors.push(
+      'Could not find a function named start() -- has it been renamed, ' +
+        'removed, or restructured? If so, this guard needs to move with it.',
+    )
+  } else if (!hasCursorReset(startBody)) {
+    errors.push(
+      'start() no longer resets commandCursor/messageCursor to 0 on ' +
+        'connect -- without it, restarting the relay (documented as an ' +
+        'in-memory dev seam expected to restart often) while the app stays ' +
+        "open leaves the client holding a cursor the restarted relay's " +
+        'fresh log may never reach, silently dropping every future poll ' +
+        'result.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkSerendipityVoiceCursorReset(content)
+
+  if (errors.length) {
+    console.error(
+      'Serendipity Voice cursor-reset contract failed in ' +
+        'serendipityVoiceStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Serendipity Voice cursor-reset contract passed: setRelayBaseUrl() and ' +
+      'start() both reset the command/message cursors so a relay restart ' +
+      'or URL switch cannot leave the client polling with a stale `since` ' +
+      'value.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
alexa-integration/t-015: Polish and upgrade Voice Lab front-end surface (kind: software) — step (4) follow-on, a third review-and-fix cycle on `stores/serendipityVoiceStore.ts`.

### What changed / what I produced
- **Bug found and fixed**: `commandCursor`/`messageCursor` in `serendipityVoiceStore.ts` are monotonically-advancing "since" pointers into the relay's in-memory command/message log. The relay is documented (top-of-file comment) as an in-memory dev seam expected to restart often — a restart, or switching the Relay URL to a different instance, resets its log back to id `0`. Nothing ever reset the client's cursors, so the next poll after a restart/URL-switch sends `since=<a value the new/restarted relay's fresh log may never reach>`. The server-side filter then silently drops every future command/message forever, while the fetches still succeed (`connected.value = true`, no `lastError`) — so the UI shows "Relay connected" with no visible sign that voice commands and chat messages are being swallowed.
- Fixed by resetting both cursors to `0`: in `setRelayBaseUrl()` when the URL actually changes, and in `start()` on every fresh connect (a same-URL relay restart between sessions is exactly the scenario the file's own header comment calls normal).
- Added `utils/scripts/verifySerendipityVoiceCursorReset.ts` + `.test.ts`, a narrow textual regression guard following this project's existing convention (mirrors `verifySerendipityVoicePollGuard.ts`, which guards the two previously-fixed races in this same file: PR #1127 and PR #1847). Wired into `package.json` and `contract-tests.yml` alongside the sibling poll-guard checks.

### How I verified
- `npm run test:serendipity-voice-cursor-reset-selftest` / `test:serendipity-voice-cursor-reset` — new guard + self-test both pass.
- `npm run test:serendipity-voice-poll-guard-selftest` / `test:serendipity-voice-poll-guard` — pre-existing sibling guard still passes (unaffected).
- `eslint` clean on all 5 changed files.
- `prettier --check` clean on all 5 changed files.
- `vue-tsc --noEmit` (full repo) exit 0.
- `git status` shows exactly the 5 intended files changed.

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
The relay's dev-seam nature (in-memory, restarts often) is exactly the kind of assumption that's easy to violate from a long-lived Pinia store — worth a one-line note in `serendipityVoiceStore.ts`'s own header comment listing "resets on restart" as an explicit invariant callers of `start()`/`setRelayBaseUrl()` must handle, so the next person adding relay-facing state (not just cursors) remembers to reset it too.

### Notes for reviewer
This is the third review-and-fix cycle on this file (see PR #1127, PR #1847) — found via a fresh, from-scratch Explore-agent read of the current code excluding both previously-fixed issues, not a re-report of either.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CsApeWkCBqzmx8z4D1xjup)_