### PR TITLE
fix(conductor-app): correct stale channelKey fallback (conductor-app/t-013)

### DIFF
--- a/components/conductor/conductor-app-page.vue
+++ b/components/conductor/conductor-app-page.vue
@@ -1,6 +1,10 @@
 <!-- /components/conductor/conductor-app-page.vue -->
 <template>
-  <project-front-page class="kr-surface" slug="conductor-app" :fallback="config">
+  <project-front-page
+    class="kr-surface"
+    slug="conductor-app"
+    :fallback="config"
+  >
     <template #interactive>
       <section
         class="flex flex-col items-start gap-3 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
@@ -75,7 +79,7 @@ const nextTasks = computed(() =>
 const config: ProjectFrontConfig = {
   slug: 'conductor-app',
   title: 'Conductor App',
-  channelKey: 'conductor',
+  channelKey: 'plan',
   tabKey: 'conductor-app',
   icon: 'kind-icon:external-link',
   tagline: 'Steer the swarm from your pocket.',


### PR DESCRIPTION
### Task
conductor/conductor-app/t-013: Polish and upgrade Conductor App front-end surface (kind: software)

### What changed / what I produced
- `components/conductor/conductor-app-page.vue`'s fallback `config.channelKey` was `'conductor'` — not a real nav channel (valid ones are `home`/`play`/`plan`/`admin`). Corrected to `'plan'`, matching `content/channels/plan/conductor-app.md`, `utils/projectPlacements.ts`, and conductor's `project-overrides.yaml` (all already agree on `plan`/`conductor-app`).
- Also applied Prettier's pre-existing formatting fix to the same file (template attribute wrapping) while touching it — unrelated to the value change, just picked up by `--write`.

### How I verified
- `npx eslint components/conductor/conductor-app-page.vue` — clean
- `npx prettier --check` → found pre-existing drift, fixed with `--write`, re-verified clean
- `npm run test` (full-project `vue-tsc --noEmit` via `nuxi prepare`) — exit 0
- `npx tsx utils/scripts/verifyLayoutContract.ts` — holds, no new violations
- Confirmed via `curl` that both queued art assets for this project are now live at the CDN (`media.acrocatranch.com/images/dashboard-tabs/conductor/conductor-app.webp` and `.../tutorials/conductor/conductor-app.webp`, both 200) — closes out the remaining open step of conductor-app/t-013.

### Stakes
reversible

### Flags for Reviewer
- This field (`ProjectFrontConfig.channelKey`/`tabKey`) is currently unused by `project-front-page.vue`'s render logic (`view` computed doesn't read it) — so this fix has no visible runtime effect today. Fixing it anyway for correctness/consistency in case a future consumer (breadcrumbs, "back to channel" link) reads it.

### Kaizen suggestion
`ProjectFrontConfig.channelKey`/`tabKey` being declared-but-unused is itself worth a look — either wire it into the shell (e.g. a "back to <channel>" link) or drop the unused fields so a future fallback config can't go stale silently the way this one did.

### Notes for reviewer
Companion conductor-repo task (conductor-app/t-013) will be closed to `done` in the same session — art (step 1), tutorial section (step 2), and placement fields (step 3) were all independently verified complete; this PR closes the remaining minor correctness gap found while re-auditing step 3.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J4nKjJKMiKP1GmRWemj3r9)_