### PR TITLE
fix(header): cap channel-select width so it can't starve tab-select

### DIFF
--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -72,7 +72,27 @@
       <div
         class="flex h-10 min-h-10 min-w-0 flex-1 items-stretch rounded-xl border border-base-300 bg-base-100 shadow-sm sm:h-11 sm:min-h-11 xl:h-14 xl:min-h-14"
       >
-        <channel-select seamless class="min-w-0 shrink" />
+        <!--
+          CAPPED, not just shrinkable. `shrink` alone only says channel-select
+          MAY give up room -- it says nothing about how MUCH, and tab-select's
+          `flex-1` starts from a 0% basis (see tab-select.vue), so under the
+          flexbox shrink algorithm a zero-basis sibling absorbs none of an
+          overflow: channel-select keeps its full preferred width and
+          tab-select is left with whatever is left over, down to nothing.
+
+          Confirmed on kindrobots.org's phone audit (responsive-layout-audit,
+          2026-08-12 through 2026-08-14, 30+ consecutive scheduled failures):
+          "Sanctuary" -- at 9 characters the longest of the five channel
+          labels (Home/Plan/Play/Admin/Sanctuary) -- rendered in full while
+          every Sanctuary tab (About, Cart, Giving, Mermaids, Privacy) was
+          crushed to a 32px sliver right next to it. `max-w-[45%]` is a
+          ceiling, not a width: the four short labels already sit well under
+          it and are unaffected; only a label that would otherwise claim more
+          than its fair share of the shell gets truncated first, which is
+          what guarantees tab-select a usable floor instead of whatever crumb
+          is left.
+        -->
+        <channel-select seamless class="min-w-0 shrink max-w-[45%]" />
 
         <div
           v-if="resolvedChannel && resolvedTabs.length"


### PR DESCRIPTION
### Task
conductor (scheduled sweep, no roadmap task -- diagnosed a red scheduled CI workflow): fix `Responsive Layout Audit` failing repeatedly on `main`  (kind: software)

### What changed / what I produced
- `components/navigation/workspace-header.vue`: added `max-w-[45%]` to `channel-select`'s fallthrough classes in the header shell.
- Root cause: `tab-select` is `flex-1` with a `0%` flex-basis (see `tab-select.vue`). Under the CSS flexbox shrink algorithm, a zero-basis flex item absorbs none of an overflow, so `channel-select` (basis: content, `shrink`) always kept its full preferred width and `tab-select` got whatever was left over -- down to a ~19-32px sliver on phone viewports when the channel label was long enough.
- "Sanctuary" (9 chars) is the longest of the site's five channel labels (Home/Plan/Play/Admin/Sanctuary) and was the trigger: every Sanctuary-channel tab (About, Cart, Giving, Mermaids, Privacy, plus the bare `/sanctuary` route) crushed its own tab label on phone width.
- `max-w-[45%]` is a ceiling, not a width -- the four short labels already sit comfortably under it at every viewport and are visually unaffected; only a label that would otherwise claim more than its fair share of the shell truncates first, guaranteeing `tab-select` a usable floor.

### How I verified
- Diagnosed via GitHub Actions: `responsive-layout-audit.yml` has failed on every scheduled run against `main` since at least 2026-08-12 (30+ consecutive failures, still failing as of this PR), consistently reporting the same "14 route/viewport combination(s) with layout defects."
- Downloaded the audit's own screenshot artifact from the most recent failed run and visually confirmed the crush on `/about`, `/sanctuary` (channel-select's full "Sanctuary" label squeezing tab-select's label to "A…") and, separately, an unrelated back-button-driven crush on guest-gated routes (see Flags below).
- `npx eslint components/navigation/workspace-header.vue` clean.
- `npx prettier --check components/navigation/workspace-header.vue` clean.
- `npx vue-tsc --noEmit` (repo-wide) exit 0, no new errors.
- `npm run test:layout-contract` holds -- no new violations.
- `git status --porcelain` shows exactly the one intended file changed.

### Stakes
reversible

### Flags for Reviewer
- This fixes 6 of the 14 failing route/viewport combinations (all six Sanctuary-channel routes: `/about`, `/cart`, `/giving`, `/mermaids`, `/privacy`, `/sanctuary`). It will **not** turn the `audit` check fully green by itself. The remaining 8 have two separate, still-unexplained causes I could not root-cause without live devtools/network inspection (this sandbox's headless Chromium can't reach the proxy for interactive debugging, and the audit only runs in CI):
  1. **An unexpected back button** (`navStore.canGoBack` true) appears on several guest-gated routes during the audit's fresh crawl (`/achievements`, `/chats`, `/appmaker`, `/conductor-app`, `/plan/voice-lab`, `/plan/watchlist`, `/auth/google`), stealing ~40-46px from the header row on top of the Sanctuary-style squeeze. `middleware/navigation-access.global.ts` is the strongest lead (it does a deferred, client-only `navigateTo(..., {replace:true})` to `/login` for unauthenticated users on account-gated routes, on an `app:mounted` hook) but I could not confirm it's the actual trigger, and the audit's own screenshots show the *original* page content still rendering (not `/login`) at capture time, so the exact mechanism is unresolved.
  2. `/bots` fails independently on an unrelated element: `CRUSHED <div> "NarratorAllPrompt BotAll statusesR" w=5 .min-w-0 flex-1` -- not part of the header at all, not investigated.
- I'm filing a conductor follow-up task with this full writeup so the next cycle (or Silas) doesn't have to re-derive the diagnosis. Recommend re-running `responsive-layout-audit.yml` after this merges to confirm the Sanctuary-route count drops from 14 to 8 defects, then picking up the back-button mystery separately.

### Kaizen suggestion
`utils/scripts/auditResponsiveLayout.mjs`'s CRUSHED check only flags elements that are themselves flex items with non-zero `flexGrow`/non-`auto` `flexBasis` (see the `flexible` check). A sibling like `channel-select`'s label span (no `flex-1`) can be squeezed to a sliver too and never gets flagged -- worth a follow-up to also catch a *non-growing* flex item that's been shrunk below a usable width, not just a growing one, so a fix elsewhere can't silently "solve" one crush by creating another the audit is blind to.

### Notes for reviewer
Screenshots referenced above came from artifact `responsive-audit-31840575701` (run [31840575701](https://github.com/silasfelinus/kind_robots/actions/runs/31840575701)).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LwDCmjHnYuqpAy5Xp2ZkC8)_