### PR TITLE
fix(gallery): stop kr-gallery toolbar slot from crushing to zero width

### DIFF
--- a/components/gallery/kr-gallery.vue
+++ b/components/gallery/kr-gallery.vue
@@ -55,7 +55,23 @@
       v-if="modes.length || $slots.toolbar || pageCount > 1"
       class="sticky top-0 z-20 -mx-1 flex shrink-0 flex-wrap items-center gap-1 bg-(--kr-surface-sunken) px-1 py-1 backdrop-blur"
     >
-      <div v-if="$slots.toolbar" class="min-w-0 flex-1">
+      <!--
+        interface-vision/t-117: this was `min-w-0 flex-1` (flex-basis 0%), the
+        same shape as #1890's channel-select/tab-select bug. flex-wrap decides
+        whether an item fits the current line using its HYPOTHETICAL main
+        size, which for a flex-basis:0 item is always 0 -- so the browser
+        never sees this slot as "too big" and never wraps it to its own line.
+        Instead every pixel the toolbar's own filters (type toggle, status
+        select, search box) couldn't fit landed on this div via min-w-0,
+        which crushed it to a few px wide on /bots once the pager (`shrink-0`,
+        so it never gives ground) and the mode buttons were also on the line.
+        `flex-auto` (basis: auto) makes the hypothetical size the slot's real
+        content width, so when it doesn't fit next to the pager/modes it
+        wraps to a second line -- which `flex-wrap` on the bar above already
+        intended -- instead of being squeezed in place. min-w-0 stays so it
+        can still shrink normally on lines where it fits.
+      -->
+      <div v-if="$slots.toolbar" class="min-w-0 flex-auto">
         <slot name="toolbar" />
       </div>
 


### PR DESCRIPTION
## What

`interface-vision/t-117`'s remaining `/bots` phone-layout defect from `responsive-layout-audit.yml` (`CRUSHED <div> "NarratorAllPrompt BotAll statusesR" w=5 .min-w-0 flex-1`) is the same bug class as #1890's channel-select/tab-select crush.

`components/gallery/kr-gallery.vue`'s sticky toolbar bar packs the `#toolbar` slot (bot type toggle + status select + search box) alongside a `shrink-0` pager and mode-toggle buttons that never give ground. The slot wrapper was `min-w-0 flex-1` — `flex-1` is `flex-basis: 0%`, and flex-wrap's line-breaking decision uses each item's *hypothetical* main size to decide whether it fits the current line. For a `flex-basis: 0` item that hypothetical size is always 0, so the browser never sees the slot as "too big to fit" and never wraps it to its own line — instead `min-w-0` (which removes the normal min-content floor) let it absorb the entire overflow and get crushed to a few px wide on `/bots` at phone width.

## Fix

Switch the slot wrapper to `flex-auto` (`flex-basis: auto`), so its hypothetical size is its real content width. When it doesn't fit next to the pager/mode buttons it now wraps to a second line — which the bar's own `flex-wrap` already intended — instead of being squeezed in place. `min-w-0` stays so it can still shrink normally on lines where everything does fit.

This is a shared component, so the fix applies to every gallery using kr-gallery's `#toolbar` slot, not just `/bots`.

## Verification

- `npx prettier --check components/gallery/kr-gallery.vue` — passes.
- No live-browser verification possible from this sandbox (proxy cannot reach `kindrobots.org`, per `AGENTS.md`'s "What 'visual verification' actually means here"). Confirmation should come from the next scheduled `responsive-layout-audit.yml` run against production, same as #1890.
- The other half of `interface-vision/t-117` (an unexpected back-button on 7 guest-gated routes) is **not** addressed here — still needs live devtools per the task note, out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DLxVvuotbp8bNPSLXR5D8e)_