### PR TITLE
fix(storybook): restore Scenario frame when restarting a story (storybook/t-010)

### DIFF
--- a/.github/workflows/storybook-restart-scenario-frame-contract.yml
+++ b/.github/workflows/storybook-restart-scenario-frame-contract.yml
@@ -1,0 +1,30 @@
+name: Storybook Restart Scenario Frame Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: storybook-restart-scenario-frame-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Storybook restart scenario frame contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify Storybook restart scenario frame guard
+        run: node utils/scripts/verifyStorybookRestartScenarioFrameGuard.mjs

--- a/stores/helpers/storybookLibraryHelper.ts
+++ b/stores/helpers/storybookLibraryHelper.ts
@@ -60,6 +60,15 @@ function restartInput(bible: StorybookBible) {
     location: bible.location,
     facets: bible.facets,
     rewards: bible.rewards,
+    // A Scenario-framed story ("the plot thread ... every other ingredient
+    // bends it", storybookStore.ts) must restart with the same frame it
+    // began with. `scenario` is optional on StorybookStartInput, so leaving
+    // it off here type-checked fine while silently downgrading every
+    // restarted Scenario story into a freeform one: `beginStory` builds a
+    // fresh bible from exactly this object, and `undefined` there means the
+    // new bible.scenario is unset and the reader's chosen frame is gone with
+    // no error surfaced anywhere.
+    scenario: bible.scenario,
     notes: bible.notes,
   }
 }

--- a/utils/scripts/verifyStorybookRestartScenarioFrameGuard.mjs
+++ b/utils/scripts/verifyStorybookRestartScenarioFrameGuard.mjs
@@ -1,0 +1,90 @@
+// /utils/scripts/verifyStorybookRestartScenarioFrameGuard.mjs
+//
+// Regression guard (storybook/t-010, front-end polish). A story can be
+// framed on a Scenario -- "the plot thread ... the cast, setting and Facets
+// below reshape how it plays out rather than being decoration on it"
+// (storybookStore.ts biblePrompt()). `restartStory()` in
+// storybookLibraryHelper.ts rebuilds a fresh `StorybookStartInput` from the
+// old bible via `restartInput(bible)` and passes it straight to
+// `bridge.beginStory()`, which builds the new session's bible from exactly
+// that object (buildBible() sets `scenario: input.scenario`).
+//
+// `scenario` is optional on both `StorybookBible` and `StorybookStartInput`,
+// so a `restartInput()` that simply forgot to carry it over type-checked
+// cleanly while silently downgrading every restarted Scenario story into a
+// freeform one: the new bible's `scenario` is `undefined`, `biblePrompt()`
+// then never emits the "Plot thread" section, and the reader gets a
+// differently-framed story with no error, warning, or indication that their
+// chosen frame was dropped.
+//
+// This asserts the fix's shape stays in place: `restartInput()` still
+// forwards the source bible's `scenario` into the object it returns.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const HELPER_PATH = 'stores/helpers/storybookLibraryHelper.ts'
+const FN_NAME = 'restartInput'
+
+function extractFunctionBody(content, name) {
+  const signaturePattern = new RegExp(`^function ${name}\\s*\\(`, 'm')
+  const match = signaturePattern.exec(content)
+  if (!match) {
+    throw new Error(
+      `Could not find \`function ${name}(\` in ${HELPER_PATH} -- has it ` +
+        'been renamed, removed, or inlined? If so, this guard (and the ' +
+        'dropped-Scenario-on-restart bug it protects against) needs to move ' +
+        'with it.',
+    )
+  }
+
+  const parenOpen = match.index + match[0].length - 1
+  let parenDepth = 0
+  let i = parenOpen
+  for (; i < content.length; i++) {
+    if (content[i] === '(') parenDepth++
+    else if (content[i] === ')') {
+      parenDepth--
+      if (parenDepth === 0) break
+    }
+  }
+  const braceOpen = content.indexOf('{', i)
+  let braceDepth = 0
+  let j = braceOpen
+  for (; j < content.length; j++) {
+    if (content[j] === '{') braceDepth++
+    else if (content[j] === '}') {
+      braceDepth--
+      if (braceDepth === 0) break
+    }
+  }
+  return content.slice(braceOpen, j + 1)
+}
+
+const content = readFileSync(resolve(process.cwd(), HELPER_PATH), 'utf8')
+const body = extractFunctionBody(content, FN_NAME)
+
+assert.ok(
+  /scenario:\s*bible\.scenario/.test(body),
+  `${FN_NAME}() no longer contains \`scenario: bible.scenario\` -- it must ` +
+    "forward the source story's Scenario frame into the restarted story's " +
+    'input, or restarting a Scenario-framed story silently downgrades it ' +
+    'into a freeform one with no error surfaced to the reader.',
+)
+
+// restartStory() must still route this object straight into beginStory()
+// unmodified -- otherwise the fix above is dead code that never reaches the
+// call that actually builds the new session's bible.
+assert.ok(
+  /await bridge\.beginStory\(restartInput\(source\.bible\)\)/.test(content),
+  `${HELPER_PATH} must still pass \`restartInput(source.bible)\` directly ` +
+    "into bridge.beginStory() -- otherwise this guard's fix is not " +
+    'actually reachable from restartStory().',
+)
+
+console.log(
+  'Storybook restart-scenario-frame guard contract passed: restartInput() ' +
+    "still forwards the source story's Scenario into the restarted story, " +
+    'so restarting a Scenario-framed story keeps its plot-thread frame ' +
+    'instead of silently becoming a freeform story.',
+)


### PR DESCRIPTION
### Task
storybook/t-010: Polish and upgrade Storybook front-end surface (recurring bug-hunt cycle) (kind: software)

### What changed / what I produced
- **Bug**: `restartInput()` in `stores/helpers/storybookLibraryHelper.ts` rebuilds a `StorybookStartInput` from the source story's `StorybookBible` for `restartStory()`, but never forwarded the bible's `scenario` field. `scenario` is optional on both `StorybookBible` and `StorybookStartInput`, so this type-checked fine while silently dropping it. `restartStory()` passes this object straight into `beginStory()`, which builds the new session's bible directly from it (`buildBible()`: `scenario: input.scenario`) — so the new bible's `scenario` ends up `undefined`. A Scenario is meant to be the story's frame ("the plot thread ... every other ingredient bends it", per `storybookStore.ts`'s own comments quoting Silas), and `biblePrompt()` only emits the "Plot thread" section of the generation prompt when `bible.scenario` is set. Net effect: restarting a Scenario-framed story from the Story Library's "Restart from the beginning?" button silently turns it into a freeform story with a different narrative frame, with zero error, warning, or indication to the reader that their chosen Scenario was dropped. `duplicateStory()` was unaffected (it deep-clones the whole bible via `cloneSession()`), so this was restart-path-specific.
- **Fix**: `restartInput()` now forwards `scenario: bible.scenario`, matching every other bible field the function already carries over.
- Adds `utils/scripts/verifyStorybookRestartScenarioFrameGuard.mjs`, following the existing `verifyStorybook*.mjs` guard convention (source-text assertion against the fixed function, plus a check that `restartStory()` still routes through it unmodified).
- Adds `.github/workflows/storybook-restart-scenario-frame-contract.yml`, mirroring the other per-guard workflow files exactly.

### How I verified
- New guard fail/pass round-trip: `git stash`'d the fix, ran the new guard — it failed with the expected assertion message (`scenario: bible.scenario` missing); `git stash pop`'d and re-ran — it passed.
- Ran all 8 pre-existing `verifyStorybook*.mjs` guards after the fix — all pass, no regressions.
- `npx eslint` on the two touched/added source files — clean.
- `npx prettier --check` on the two new files — clean. The one pre-existing formatting nit in `storybookLibraryHelper.ts` (a few lines exceeding the print width elsewhere in the file) predates this change — confirmed by running `prettier --check` against the unmodified `origin/main` copy of the file, which fails identically; my diff doesn't touch those lines.
- `npx vue-tsc --noEmit` repo-wide — exit 0.
- `git status --porcelain` shows exactly the 3 intended files (1 modified, 2 new).

### Stakes
reversible

### Kaizen suggestion
`restartInput()` and `remapDuplicate()`/`cloneSession()` now both need to independently agree on "every StorybookBible field that should survive a session-derived operation." A future cycle could add a small compile-time or runtime completeness check (e.g. a guard that asserts `restartInput()`'s returned keys are a superset of every field `StorybookStartInput` actually forwards into `buildBible()`) so a next-added-optional-bible-field doesn't silently repeat this exact class of bug in whichever transform function forgets it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ERzdBurpFFNnT9UygWnZpf)_