### PR TITLE
test(storybook): guard restartInput() against future dropped bible fields (storybook/t-021)

### DIFF
--- a/.github/workflows/storybook-restart-input-completeness-contract.yml
+++ b/.github/workflows/storybook-restart-input-completeness-contract.yml
@@ -1,0 +1,30 @@
+name: Storybook Restart Input Completeness Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: storybook-restart-input-completeness-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Storybook restart input completeness contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify Storybook restart input completeness guard
+        run: node utils/scripts/verifyStorybookRestartInputCompletenessGuard.mjs

--- a/utils/scripts/verifyStorybookRestartInputCompletenessGuard.mjs
+++ b/utils/scripts/verifyStorybookRestartInputCompletenessGuard.mjs
@@ -1,0 +1,146 @@
+// /utils/scripts/verifyStorybookRestartInputCompletenessGuard.mjs
+//
+// Regression guard (storybook/t-021, kaizen from t-010's restart-scenario-frame
+// fix, kind_robots PR #1892). `restartInput()` in storybookLibraryHelper.ts
+// rebuilds a fresh `StorybookStartInput` from a story's `StorybookBible` when
+// the reader restarts it, and `buildBible()` in storybookStore.ts is the only
+// place that turns a `StorybookStartInput` back into the new session's
+// `StorybookBible`. Every field `buildBible()` reads off `input` has to
+// survive that round trip, or a restarted story silently loses it with no
+// type error and no runtime error -- exactly what happened to `scenario`
+// before #1892 fixed that one field by hand.
+//
+// Rather than re-litigating field-by-field forever, this asserts the general
+// shape: every `input.<field>` that `buildBible()` actually reads must appear
+// as a key in the object `restartInput()` returns. It does not check the
+// reverse direction (an extra key in `restartInput()`'s return with no
+// matching `buildBible()` read is harmless, just unused) and it does not
+// check runtime values -- only that the next optional field added to
+// `StorybookBible`/`StorybookStartInput` and read by `buildBible()` cannot be
+// silently forgotten in `restartInput()` the way `scenario` was.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const STORE_PATH = 'stores/storybookStore.ts'
+const HELPER_PATH = 'stores/helpers/storybookLibraryHelper.ts'
+
+function extractFunctionBody(content, name, path) {
+  const signaturePattern = new RegExp(`^\\s*function ${name}\\s*\\(`, 'm')
+  const match = signaturePattern.exec(content)
+  if (!match) {
+    throw new Error(
+      `Could not find \`function ${name}(\` in ${path} -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the ' +
+        'dropped-field bug it protects against) needs to move with it.',
+    )
+  }
+
+  const parenOpen = match.index + match[0].length - 1
+  let parenDepth = 0
+  let i = parenOpen
+  for (; i < content.length; i++) {
+    if (content[i] === '(') parenDepth++
+    else if (content[i] === ')') {
+      parenDepth--
+      if (parenDepth === 0) break
+    }
+  }
+  const braceOpen = content.indexOf('{', i)
+  let braceDepth = 0
+  let j = braceOpen
+  for (; j < content.length; j++) {
+    if (content[j] === '{') braceDepth++
+    else if (content[j] === '}') {
+      braceDepth--
+      if (braceDepth === 0) break
+    }
+  }
+  return content.slice(braceOpen, j + 1)
+}
+
+// Fields buildBible() actually consumes off `input` -- every `input.<field>`
+// reference in its body, deduplicated. Covers both direct reads
+// (`input.narratorStyle`) and reads inside a chained/nested expression
+// (`input.title?.trim()`, `derivedTitle(input.premise)`).
+function extractInputFieldsRead(body) {
+  const fields = new Set()
+  for (const match of body.matchAll(/\binput\.([a-zA-Z_$][\w$]*)/g)) {
+    fields.add(match[1])
+  }
+  return fields
+}
+
+// Top-level keys of the object literal `restartInput()` returns. The
+// function body is just `return { key: value, ... }` with no nested object
+// literals, so a line-based `key:` scan across the object's own brace span
+// is enough -- no need for a full expression parser.
+function extractReturnedObjectKeys(body) {
+  const returnMatch = /return\s*\{/.exec(body)
+  if (!returnMatch) {
+    throw new Error(
+      `restartInput()'s body in ${HELPER_PATH} no longer returns an object ` +
+        'literal directly -- this guard cannot verify field coverage ' +
+        'against a shape it cannot see.',
+    )
+  }
+  const braceOpen = returnMatch.index + returnMatch[0].length - 1
+  let braceDepth = 0
+  let k = braceOpen
+  for (; k < body.length; k++) {
+    if (body[k] === '{') braceDepth++
+    else if (body[k] === '}') {
+      braceDepth--
+      if (braceDepth === 0) break
+    }
+  }
+  const objectLiteral = body.slice(braceOpen + 1, k)
+  const keys = new Set()
+  for (const match of objectLiteral.matchAll(/^\s*([a-zA-Z_$][\w$]*)\s*:/gm)) {
+    keys.add(match[1])
+  }
+  return keys
+}
+
+const storeContent = readFileSync(resolve(process.cwd(), STORE_PATH), 'utf8')
+const helperContent = readFileSync(resolve(process.cwd(), HELPER_PATH), 'utf8')
+
+const buildBibleBody = extractFunctionBody(
+  storeContent,
+  'buildBible',
+  STORE_PATH,
+)
+const restartInputBody = extractFunctionBody(
+  helperContent,
+  'restartInput',
+  HELPER_PATH,
+)
+
+const consumedFields = extractInputFieldsRead(buildBibleBody)
+const forwardedKeys = extractReturnedObjectKeys(restartInputBody)
+
+assert.ok(
+  consumedFields.size > 0,
+  `Found zero \`input.<field>\` reads in buildBible()'s body in ${STORE_PATH} ` +
+    "-- the extraction regex likely no longer matches this function's " +
+    'shape, which would make this guard vacuously pass.',
+)
+
+const missing = [...consumedFields].filter((field) => !forwardedKeys.has(field))
+
+assert.deepEqual(
+  missing,
+  [],
+  `restartInput() in ${HELPER_PATH} does not forward field(s) ` +
+    `[${missing.join(', ')}] that buildBible() reads from StorybookStartInput ` +
+    `-- restarting a story will silently drop ${missing.length === 1 ? 'this field' : 'these fields'} ` +
+    'with no type error and no runtime error (the same bug class #1892 fixed ' +
+    'for `scenario`). Add the missing key(s) to the object restartInput() returns.',
+)
+
+console.log(
+  'Storybook restart-input-completeness guard contract passed: ' +
+    `restartInput() forwards all ${consumedFields.size} StorybookStartInput ` +
+    "field(s) buildBible() reads, so a restarted story can't silently lose " +
+    'one the way `scenario` did before #1892.',
+)


### PR DESCRIPTION
### Task
storybook/t-021: Add a completeness guard so `restartInput()` forwards every `StorybookBible` field `buildBible()` consumes  (kind: software)

### What changed / what I produced
- New guard `utils/scripts/verifyStorybookRestartInputCompletenessGuard.mjs`: extracts every `input.<field>` read inside `buildBible()` (stores/storybookStore.ts) and every top-level key of the object `restartInput()` returns (stores/helpers/storybookLibraryHelper.ts), then asserts the latter is a superset of the former.
- New CI workflow `storybook-restart-input-completeness-contract.yml`, matching the existing 8 `verifyStorybook*` contract workflows' shape exactly.

### Why
Kaizen from t-010 (PR #1892): `restartInput()` silently dropped `scenario` from the rebuilt `StorybookStartInput` on story restart — it type-checked cleanly because `scenario` is optional on both types, and nothing in CI caught it. #1892 fixed that one field by hand; this guard makes the *next* optional bible field added and forgotten in `restartInput()` fail CI instead of silently repeating the same bug class.

### How I verified
- `node utils/scripts/verifyStorybookRestartInputCompletenessGuard.mjs` passes against current `main`.
- Fail path confirmed via git-stash: temporarily removed `scenario: bible.scenario` from `restartInput()`'s return — guard fails with a clear message naming the missing field; restored, guard passes again.
- All 8 pre-existing `verifyStorybook*` guards still pass (no regression).
- `npx eslint` and `npx prettier --check` clean on both new files.
- `npx vue-tsc --noEmit` repo-wide: clean.
- `git status --porcelain` showed exactly the 2 intended new files.

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
Several `verifyStorybook*.mjs` guards (this one included) hand-roll a brace-matching `extractFunctionBody` helper independently. Worth factoring into a small shared `utils/scripts/lib/extractTsFunctionBody.mjs` the next time a new guard needs it, so the parsing logic has one place to fix if it ever needs to handle a shape it currently doesn't (e.g. arrow-function guards, which none of the 9 current ones are).

### Notes for reviewer
Conductor task: storybook/t-021 (status: review). Will merge this PR once CI is green and close the conductor task out in the same session.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTr7G2XBh3apgmgKmewVuV)_