### PR TITLE
refactor(storybook): share extractFunctionBody across verifyStorybook* guards (storybook/t-022)

### DIFF
--- a/utils/scripts/lib/extractTsFunctionBody.mjs
+++ b/utils/scripts/lib/extractTsFunctionBody.mjs
@@ -1,0 +1,55 @@
+// /utils/scripts/lib/extractTsFunctionBody.mjs
+//
+// Shared brace-matching helper for the verifyStorybook* regression guards
+// (and anything else that needs to pull a named function's body out of a
+// TypeScript/Vue `<script setup>` source file by plain text, without pulling
+// in a full parser). Originally hand-rolled, byte-for-byte identical except
+// for the exact signature regex, in verifyStorybookAnswerInputPreservationGuard,
+// verifyStorybookRestartScenarioFrameGuard, and
+// verifyStorybookRestartInputCompletenessGuard (storybook/t-022, kaizen from
+// t-021's kind_robots PR #1893).
+//
+// Handles both signature shapes seen across those guards: a plain
+// `function name(` and an `async function name(`, with or without leading
+// indentation (e.g. a function nested inside a `defineStore()` setup body).
+// It intentionally does NOT match `export function name(` or arrow/const
+// function forms -- none of the guarded functions use those shapes, and
+// broadening the match risks silently matching the wrong declaration.
+export function extractTsFunctionBody(
+  content,
+  name,
+  { path, notFoundHint } = {},
+) {
+  const signaturePattern = new RegExp(
+    `^\\s*(?:async\\s+)?function\\s+${name}\\s*\\(`,
+    'm',
+  )
+  const match = signaturePattern.exec(content)
+  if (!match) {
+    const location = path ? ` in ${path}` : ''
+    const hint = notFoundHint ? ` -- ${notFoundHint}` : ''
+    throw new Error(`Could not find \`function ${name}(\`${location}${hint}`)
+  }
+
+  const parenOpen = match.index + match[0].length - 1
+  let parenDepth = 0
+  let i = parenOpen
+  for (; i < content.length; i++) {
+    if (content[i] === '(') parenDepth++
+    else if (content[i] === ')') {
+      parenDepth--
+      if (parenDepth === 0) break
+    }
+  }
+  const braceOpen = content.indexOf('{', i)
+  let braceDepth = 0
+  let j = braceOpen
+  for (; j < content.length; j++) {
+    if (content[j] === '{') braceDepth++
+    else if (content[j] === '}') {
+      braceDepth--
+      if (braceDepth === 0) break
+    }
+  }
+  return content.slice(braceOpen, j + 1)
+}

--- a/utils/scripts/verifyStorybookAnswerInputPreservationGuard.mjs
+++ b/utils/scripts/verifyStorybookAnswerInputPreservationGuard.mjs
@@ -21,46 +21,18 @@
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { extractTsFunctionBody } from './lib/extractTsFunctionBody.mjs'
 
 const COMPONENT_PATH = 'components/conductor/storybook-page.vue'
 const FN_NAME = 'submitAnswer'
 
-function extractFunctionBody(content, name) {
-  const signaturePattern = new RegExp(`^async function ${name}\\s*\\(`, 'm')
-  const match = signaturePattern.exec(content)
-  if (!match) {
-    throw new Error(
-      `Could not find \`async function ${name}(\` in ${COMPONENT_PATH} -- ` +
-        'has it been renamed, removed, or inlined? If so, this guard (and ' +
-        'the lost-answer bug it protects against) needs to move with it.',
-    )
-  }
-
-  const parenOpen = match.index + match[0].length - 1
-  let parenDepth = 0
-  let i = parenOpen
-  for (; i < content.length; i++) {
-    if (content[i] === '(') parenDepth++
-    else if (content[i] === ')') {
-      parenDepth--
-      if (parenDepth === 0) break
-    }
-  }
-  const braceOpen = content.indexOf('{', i)
-  let braceDepth = 0
-  let j = braceOpen
-  for (; j < content.length; j++) {
-    if (content[j] === '{') braceDepth++
-    else if (content[j] === '}') {
-      braceDepth--
-      if (braceDepth === 0) break
-    }
-  }
-  return content.slice(braceOpen, j + 1)
-}
-
 const content = readFileSync(resolve(process.cwd(), COMPONENT_PATH), 'utf8')
-const body = extractFunctionBody(content, FN_NAME)
+const body = extractTsFunctionBody(content, FN_NAME, {
+  path: COMPONENT_PATH,
+  notFoundHint:
+    'has it been renamed, removed, or inlined? If so, this guard (and the ' +
+    'lost-answer bug it protects against) needs to move with it.',
+})
 
 const required = [
   [

--- a/utils/scripts/verifyStorybookRestartInputCompletenessGuard.mjs
+++ b/utils/scripts/verifyStorybookRestartInputCompletenessGuard.mjs
@@ -21,42 +21,18 @@
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { extractTsFunctionBody } from './lib/extractTsFunctionBody.mjs'
 
 const STORE_PATH = 'stores/storybookStore.ts'
 const HELPER_PATH = 'stores/helpers/storybookLibraryHelper.ts'
 
 function extractFunctionBody(content, name, path) {
-  const signaturePattern = new RegExp(`^\\s*function ${name}\\s*\\(`, 'm')
-  const match = signaturePattern.exec(content)
-  if (!match) {
-    throw new Error(
-      `Could not find \`function ${name}(\` in ${path} -- has it been ` +
-        'renamed, removed, or inlined? If so, this guard (and the ' +
-        'dropped-field bug it protects against) needs to move with it.',
-    )
-  }
-
-  const parenOpen = match.index + match[0].length - 1
-  let parenDepth = 0
-  let i = parenOpen
-  for (; i < content.length; i++) {
-    if (content[i] === '(') parenDepth++
-    else if (content[i] === ')') {
-      parenDepth--
-      if (parenDepth === 0) break
-    }
-  }
-  const braceOpen = content.indexOf('{', i)
-  let braceDepth = 0
-  let j = braceOpen
-  for (; j < content.length; j++) {
-    if (content[j] === '{') braceDepth++
-    else if (content[j] === '}') {
-      braceDepth--
-      if (braceDepth === 0) break
-    }
-  }
-  return content.slice(braceOpen, j + 1)
+  return extractTsFunctionBody(content, name, {
+    path,
+    notFoundHint:
+      'has it been renamed, removed, or inlined? If so, this guard (and ' +
+      'the dropped-field bug it protects against) needs to move with it.',
+  })
 }
 
 // Fields buildBible() actually consumes off `input` -- every `input.<field>`

--- a/utils/scripts/verifyStorybookRestartScenarioFrameGuard.mjs
+++ b/utils/scripts/verifyStorybookRestartScenarioFrameGuard.mjs
@@ -22,47 +22,19 @@
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { extractTsFunctionBody } from './lib/extractTsFunctionBody.mjs'
 
 const HELPER_PATH = 'stores/helpers/storybookLibraryHelper.ts'
 const FN_NAME = 'restartInput'
 
-function extractFunctionBody(content, name) {
-  const signaturePattern = new RegExp(`^function ${name}\\s*\\(`, 'm')
-  const match = signaturePattern.exec(content)
-  if (!match) {
-    throw new Error(
-      `Could not find \`function ${name}(\` in ${HELPER_PATH} -- has it ` +
-        'been renamed, removed, or inlined? If so, this guard (and the ' +
-        'dropped-Scenario-on-restart bug it protects against) needs to move ' +
-        'with it.',
-    )
-  }
-
-  const parenOpen = match.index + match[0].length - 1
-  let parenDepth = 0
-  let i = parenOpen
-  for (; i < content.length; i++) {
-    if (content[i] === '(') parenDepth++
-    else if (content[i] === ')') {
-      parenDepth--
-      if (parenDepth === 0) break
-    }
-  }
-  const braceOpen = content.indexOf('{', i)
-  let braceDepth = 0
-  let j = braceOpen
-  for (; j < content.length; j++) {
-    if (content[j] === '{') braceDepth++
-    else if (content[j] === '}') {
-      braceDepth--
-      if (braceDepth === 0) break
-    }
-  }
-  return content.slice(braceOpen, j + 1)
-}
-
 const content = readFileSync(resolve(process.cwd(), HELPER_PATH), 'utf8')
-const body = extractFunctionBody(content, FN_NAME)
+const body = extractTsFunctionBody(content, FN_NAME, {
+  path: HELPER_PATH,
+  notFoundHint:
+    'has it been renamed, removed, or inlined? If so, this guard (and the ' +
+    'dropped-Scenario-on-restart bug it protects against) needs to move ' +
+    'with it.',
+})
 
 assert.ok(
   /scenario:\s*bible\.scenario/.test(body),


### PR DESCRIPTION
## Summary
- `verifyStorybookAnswerInputPreservationGuard`, `verifyStorybookRestartScenarioFrameGuard`, and `verifyStorybookRestartInputCompletenessGuard` each hand-rolled an identical brace-matching `extractFunctionBody(content, name)` helper, differing only in the signature regex (`async function name(` vs plain `function name(`, and one variant allowing leading indentation for a function nested inside a `defineStore()` setup body).
- Factored one shared implementation into `utils/scripts/lib/extractTsFunctionBody.mjs`, whose signature regex covers both shapes seen across the guards (optional `async`, optional leading whitespace), and accepts an optional `path`/`notFoundHint` so each guard keeps its own specific error text.
- Updated all three guards to import the shared helper instead of keeping their own copy.

Kaizen from `storybook/t-021` (PR #1893).

## Test plan
- All 9 `verifyStorybook*.mjs` guards still pass (no regression).
- Each of the three touched guards still fails correctly on its own documented regression case, verified via git-stash round-trip:
  - dropping the restored `answerInput.value = value` assignment
  - dropping the forwarded `scenario` field (scenario-frame guard)
  - dropping the same field again (completeness guard)
- `eslint` and `prettier --check` clean on all touched files.
- `vue-tsc --noEmit` clean repo-wide.
- `git status --porcelain` shows exactly the 4 intended files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TubuYEABt7h2a2jFAU6oaj)_