### PR TITLE
fix(davinci): announce the narrating busy state to assistive tech

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -251,6 +251,12 @@ jobs:
       - name: Da Vinci resolve-panel guard
         run: npm run test:davinci-resolve-panel-guard
 
+      - name: Da Vinci narrating-status guard self-test
+        run: npm run test:davinci-narrating-status-guard-selftest
+
+      - name: Da Vinci narrating-status guard
+        run: npm run test:davinci-narrating-status-guard
+
       - name: Serendipity Voice poll guard self-test
         run: npm run test:serendipity-voice-poll-guard-selftest
 

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -145,12 +145,24 @@
             </div>
           </div>
 
-          <!-- Narrator is composing this chapter -->
+          <!-- Narrator is composing this chapter. role="status"/aria-live
+               match every comparable busy indicator elsewhere in the app
+               (academy-manager.vue, model-builder-manager.vue,
+               model-builder-run-history.vue, narrative-response-composer.vue,
+               kr-chat-window.vue, watchlist-browse.vue,
+               narrative-ingredient-picker.vue) -- this was the one busy state
+               in davinci-page.vue left as a purely visual spinner with no
+               announcement to assistive tech. -->
           <div
             v-if="narrating"
+            role="status"
+            aria-live="polite"
             class="flex flex-col items-center gap-3 rounded-2xl border border-base-300 bg-base-200/40 p-8 text-center"
           >
-            <span class="loading loading-dots loading-lg text-primary/70" />
+            <span
+              class="loading loading-dots loading-lg text-primary/70"
+              aria-hidden="true"
+            />
             <p class="text-xs font-semibold text-base-content/50">
               {{ narratorName || 'The narrator' }} is writing chapter
               {{ chapterIndex }}…

--- a/package.json
+++ b/package.json
@@ -83,6 +83,8 @@
     "test:davinci-narration-error-tone-guard": "tsx utils/scripts/verifyDaVinciNarrationErrorToneGuard.ts",
     "test:davinci-resolve-panel-guard-selftest": "tsx utils/scripts/verifyDaVinciResolvePanelGuard.test.ts",
     "test:davinci-resolve-panel-guard": "tsx utils/scripts/verifyDaVinciResolvePanelGuard.ts",
+    "test:davinci-narrating-status-guard-selftest": "tsx utils/scripts/verifyDaVinciNarratingStatusGuard.test.ts",
+    "test:davinci-narrating-status-guard": "tsx utils/scripts/verifyDaVinciNarratingStatusGuard.ts",
     "test:serendipity-voice-poll-guard-selftest": "tsx utils/scripts/verifySerendipityVoicePollGuard.test.ts",
     "test:serendipity-voice-poll-guard": "tsx utils/scripts/verifySerendipityVoicePollGuard.ts",
     "test:serendipity-voice-cursor-reset-selftest": "tsx utils/scripts/verifySerendipityVoiceCursorReset.test.ts",

--- a/utils/scripts/verifyDaVinciNarratingStatusGuard.test.ts
+++ b/utils/scripts/verifyDaVinciNarratingStatusGuard.test.ts
@@ -1,0 +1,113 @@
+// /utils/scripts/verifyDaVinciNarratingStatusGuard.test.ts
+//
+// Regression test for checkNarratingStatusGuard() in
+// verifyDaVinciNarratingStatusGuard.ts (davinci/t-021 slice 4). Exercises
+// the real check against synthetic component-shaped fixtures covering: the
+// fixed shape (role="status" + aria-live="polite" on the wrapper,
+// aria-hidden="true" on the spinner), a missing-role regression, a
+// missing-aria-live regression, a missing-spinner-aria-hidden regression,
+// and a missing-block regression (the narrating state removed entirely).
+import assert from 'node:assert/strict'
+
+import { checkNarratingStatusGuard } from './verifyDaVinciNarratingStatusGuard.js'
+
+function fixture(wrapperAttrs: string, spinnerAttrs: string): string {
+  return `
+<template>
+  <div
+    v-if="narrating"
+    ${wrapperAttrs}
+    class="flex flex-col items-center gap-3 rounded-2xl border border-base-300 bg-base-200/40 p-8 text-center"
+  >
+    <span
+      class="loading loading-dots loading-lg text-primary/70"
+      ${spinnerAttrs}
+    />
+    <p class="text-xs font-semibold text-base-content/50">
+      {{ narratorName || 'The narrator' }} is writing chapter
+      {{ chapterIndex }}…
+    </p>
+  </div>
+
+  <!-- Narration failed. Per the narration-layer spec a broken chapter
+       surfaces a visible retry rather than a silently fabricated one. -->
+  <div v-else-if="narrationError" class="flex flex-col items-center gap-3">
+    <p>The narrator is having trouble with this chapter.</p>
+  </div>
+</template>
+`
+}
+
+const FIXED = fixture('role="status" aria-live="polite"', 'aria-hidden="true"')
+
+// Pre-fix shape: no accessibility attributes at all.
+const BUGGY = fixture('', '')
+
+// role="status" present but aria-live dropped.
+const NO_ARIA_LIVE = fixture('role="status"', 'aria-hidden="true"')
+
+// Both wrapper attributes present, but the spinner's aria-hidden dropped.
+const NO_SPINNER_ARIA_HIDDEN = fixture('role="status" aria-live="polite"', '')
+
+// The narrating state itself no longer exists.
+const BLOCK_REMOVED = `
+<template>
+  <div v-if="somethingElse" class="flex flex-col items-center gap-3">
+    <p>Unrelated state.</p>
+  </div>
+</template>
+`
+
+function run(): void {
+  const fixedErrors = checkNarratingStatusGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const buggyErrors = checkNarratingStatusGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    3,
+    `expected the buggy fixture to fail all three checks, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(buggyErrors.some((e) => /no longer carries role="status"/.test(e)))
+  assert.ok(
+    buggyErrors.some((e) => /no longer carries aria-live="polite"/.test(e)),
+  )
+  assert.ok(
+    buggyErrors.some((e) => /spinner no longer carries aria-hidden/.test(e)),
+  )
+
+  const noAriaLiveErrors = checkNarratingStatusGuard(NO_ARIA_LIVE)
+  assert.equal(noAriaLiveErrors.length, 1)
+  assert.ok(
+    noAriaLiveErrors.some((e) =>
+      /no longer carries aria-live="polite"/.test(e),
+    ),
+  )
+
+  const noSpinnerAriaHiddenErrors = checkNarratingStatusGuard(
+    NO_SPINNER_ARIA_HIDDEN,
+  )
+  assert.equal(noSpinnerAriaHiddenErrors.length, 1)
+  assert.ok(
+    noSpinnerAriaHiddenErrors.some((e) =>
+      /spinner no longer carries aria-hidden/.test(e),
+    ),
+  )
+
+  const blockRemovedErrors = checkNarratingStatusGuard(BLOCK_REMOVED)
+  assert.equal(blockRemovedErrors.length, 1)
+  assert.ok(blockRemovedErrors.some((e) => /Could not find a/.test(e)))
+
+  console.log(
+    'Da Vinci narrating-status guard self-test passed: buggy fixture fails ' +
+      'all three checks, fixed fixture passes, and the missing-role/' +
+      'missing-aria-live/missing-spinner-aria-hidden/missing-block ' +
+      'regressions all fail individually as expected.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyDaVinciNarratingStatusGuard.ts
+++ b/utils/scripts/verifyDaVinciNarratingStatusGuard.ts
@@ -1,0 +1,138 @@
+// /utils/scripts/verifyDaVinciNarratingStatusGuard.ts
+//
+// Regression guard (davinci/t-021 slice 4) -- the "narrator is writing this
+// chapter" busy block in components/conductor/davinci-page.vue announced
+// nothing to assistive tech: no role="status"/aria-live="polite" on the
+// wrapping element, and no aria-hidden="true" on its loading-dots spinner.
+// Every comparable busy/loading indicator elsewhere in the app follows the
+// same role="status" + aria-live="polite" wrapper + aria-hidden="true"
+// spinner shape (see academy-manager.vue, model-builder-manager.vue,
+// model-builder-run-history.vue, narrative-response-composer.vue,
+// kr-chat-window.vue, watchlist-browse.vue,
+// narrative-ingredient-picker.vue) -- davinci-page.vue's own errorMessage
+// alert (role="alert") already follows an analogous pattern for its own
+// state, so the narrating block was the one outlier left with a purely
+// visual spinner and no textual/AT announcement of the busy state.
+//
+// This asserts the textual shape of the fix stays in place: the div wrapping
+// `v-if="narrating"` carries role="status" and aria-live="polite", and its
+// loading-dots spinner carries aria-hidden="true", deliberately scoped to
+// this one template block, mirroring this project's other narrow textual
+// guards over a general-purpose static analyzer (see
+// verifyDaVinciDimensionToneGuard.ts).
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const COMPONENT_PATH = join(
+  repositoryRoot,
+  'components/conductor/davinci-page.vue',
+)
+
+// Anchored on the `v-if="narrating"` marker rather than any surrounding
+// wording, so this guard reports *which* attribute regressed instead of
+// just "not found" if the block is edited.
+const BLOCK_MARKER = 'v-if="narrating"'
+const NEXT_BLOCK_MARKER = '<!-- Narration failed'
+
+export function extractNarratingBlock(content: string): string | null {
+  const markerIndex = content.indexOf(BLOCK_MARKER)
+  if (markerIndex === -1) return null
+
+  const tagStart = content.lastIndexOf('<div', markerIndex)
+  if (tagStart === -1) return null
+  const tagEnd = content.indexOf('>', markerIndex)
+  if (tagEnd === -1) return null
+
+  const nextBlockIndex = content.indexOf(NEXT_BLOCK_MARKER, tagEnd)
+  const blockEnd = nextBlockIndex === -1 ? content.length : nextBlockIndex
+
+  return content.slice(tagStart, blockEnd)
+}
+
+export function checkNarratingStatusGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const block = extractNarratingBlock(content)
+  if (!block) {
+    errors.push(
+      'Could not find a <div v-if="narrating"> block in ' +
+        'davinci-page.vue -- has the narrating/busy state been ' +
+        'restructured or removed? If so, this guard needs to move with it.',
+    )
+    return errors
+  }
+
+  const openingTagEnd = block.indexOf('>')
+  const openingTag = block.slice(0, openingTagEnd + 1)
+
+  if (!openingTag.includes('role="status"')) {
+    errors.push(
+      "The narrating block's wrapping <div> no longer carries " +
+        'role="status" -- assistive tech gets no signal that the ' +
+        'narrator is composing a chapter, unlike every comparable busy ' +
+        'indicator elsewhere in the app (academy-manager.vue, ' +
+        'model-builder-manager.vue, etc).',
+    )
+  }
+
+  if (!openingTag.includes('aria-live="polite"')) {
+    errors.push(
+      "The narrating block's wrapping <div> no longer carries " +
+        'aria-live="polite" -- a screen reader would not be told when ' +
+        'the "is writing chapter N…" message appears.',
+    )
+  }
+
+  const spinnerIndex = block.indexOf('loading loading-dots')
+  if (spinnerIndex === -1) {
+    errors.push(
+      'Could not find the loading loading-dots spinner inside the ' +
+        'narrating block -- has the spinner markup changed?',
+    )
+  } else {
+    const spinnerTagStart = block.lastIndexOf('<span', spinnerIndex)
+    const spinnerTagEnd = block.indexOf('/>', spinnerIndex)
+    const spinnerTag =
+      spinnerTagStart === -1 || spinnerTagEnd === -1
+        ? ''
+        : block.slice(spinnerTagStart, spinnerTagEnd + 2)
+    if (!spinnerTag.includes('aria-hidden="true"')) {
+      errors.push(
+        "The narrating block's loading-dots spinner no longer carries " +
+          'aria-hidden="true" -- the decorative spinner would be ' +
+          'announced redundantly alongside the role="status" text.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(COMPONENT_PATH, 'utf8')
+  const errors = checkNarratingStatusGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Da Vinci narrating-status guard contract failed in davinci-page.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Da Vinci narrating-status guard contract passed: the "narrator is ' +
+      'writing this chapter" busy state announces itself to assistive ' +
+      'tech via role="status"/aria-live="polite", matching every other ' +
+      'busy/loading indicator convention in the app.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What

davinci/t-021 slice 4 (conductor project) — one concrete, verifiable accessibility gap in `components/conductor/davinci-page.vue`'s "narrator is writing this chapter" busy state, following the same "one bounded gap, not a reskin" convention as the prior three slices (kind_robots #1842, #1854, #1866).

## The gap

The `v-if="narrating"` block renders a `loading loading-dots` spinner plus a text status message, but the wrapping `<div>` carried no `role="status"`/`aria-live="polite"`, and the spinner span carried no `aria-hidden="true"`. Every comparable busy/loading indicator elsewhere in the app follows the same shape — `role="status"` + `aria-live="polite"` on the wrapper, `aria-hidden="true"` on the decorative spinner:

- `components/academy/academy-manager.vue`
- `components/model-builder/model-builder-manager.vue`
- `components/model-builder/model-builder-run-history.vue`
- `components/narrative/narrative-response-composer.vue`
- `components/narrative/kr-chat-window.vue`
- `components/watchlist/watchlist-browse.vue`
- `components/narrative/narrative-ingredient-picker.vue` / `narrative-ingredient-multi-picker.vue`

davinci-page.vue's own `errorMessage` alert already uses `role="alert"` for its own state, so the narrating block was the one busy indicator left purely visual — a screen reader user gets no signal that "the narrator is writing chapter N…" when AI narration is in flight.

## Fix

Added `role="status"` and `aria-live="polite"` to the wrapping `<div v-if="narrating">`, and `aria-hidden="true"` to its `loading loading-dots` spinner, plus an explanatory comment.

## Verification

- New guard (`verifyDaVinciNarratingStatusGuard.ts` + `.test.ts`, following the existing `verifyDaVinciDimensionToneGuard`/`verifyDaVinciNarrationErrorToneGuard`/`verifyDaVinciResolvePanelGuard` convention) + selftest pass
- All three prior davinci guards + selftests still pass
- `test:davinci-narration` (all checks) still passes
- `test:layout-contract` holds, no new violations
- eslint clean on touched files
- `prettier --check` clean on touched/new files (ran `--write` once to normalize the two new files, then re-verified clean)
- `vue-tsc --noEmit` (full project) exits 0
- `git status`-equivalent diff shows exactly the 5 intended files: `components/conductor/davinci-page.vue`, `utils/scripts/verifyDaVinciNarratingStatusGuard.ts`, `utils/scripts/verifyDaVinciNarratingStatusGuard.test.ts`, `package.json`, `.github/workflows/contract-tests.yml`

## Note for reviewer

While auditing this slice I found that kind_robots PR #1866 ("davinci/t-021 slice 3") had already merged on 2026-08-13, but the conductor roadmap task's note was never updated past slice 2 — a documentation-only drift, now being reconciled in a companion conductor PR alongside this one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cv2WDKXEpJUM81HiKCzcH1)_