### PR TITLE
chore(conductor-app): drop dead ProjectFrontConfig.channelKey/tabKey fields

### DIFF
--- a/components/coloring/coloring-book-page.vue
+++ b/components/coloring/coloring-book-page.vue
@@ -27,8 +27,6 @@ import type { ProjectFrontConfig } from '@/components/conductor/projectFront'
 const config: ProjectFrontConfig = {
   slug: 'coloring-book',
   title: 'Coloring Book',
-  channelKey: 'art',
-  tabKey: 'coloring',
   icon: 'kind-icon:paintbrush',
   tagline: 'Build, review, pair, package, and color three living books.',
   description:

--- a/components/conductor/challenge-center-page.vue
+++ b/components/conductor/challenge-center-page.vue
@@ -410,8 +410,6 @@ onMounted(loadChallenges)
 const config: ProjectFrontConfig = {
   slug: 'challenge-center',
   title: 'Challenge Center',
-  channelKey: 'wonder',
-  tabKey: 'challenges',
   icon: 'kind-icon:trophy',
   tagline: 'Two contenders enter. The swarm decides.',
   description:

--- a/components/conductor/coat-dance-page.vue
+++ b/components/conductor/coat-dance-page.vue
@@ -76,8 +76,6 @@ const productionStages: ProductionStage[] = [
 const config: ProjectFrontConfig = {
   slug: 'coat-dance',
   title: 'Coat Dance',
-  channelKey: 'art',
-  tabKey: 'coat-dance',
   icon: 'kind-icon:sparkles',
   tagline: 'Motion and costume, remixed into delight.',
   description:

--- a/components/conductor/conductor-app-page.vue
+++ b/components/conductor/conductor-app-page.vue
@@ -79,8 +79,6 @@ const nextTasks = computed(() =>
 const config: ProjectFrontConfig = {
   slug: 'conductor-app',
   title: 'Conductor App',
-  channelKey: 'plan',
-  tabKey: 'conductor-app',
   icon: 'kind-icon:external-link',
   tagline: 'Steer the swarm from your pocket.',
   description:

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -1058,8 +1058,6 @@ const recentEndings = computed(() =>
 const config: ProjectFrontConfig = {
   slug: 'davinci',
   title: 'Da Vinci',
-  channelKey: 'wonder',
-  tabKey: 'davinci',
   icon: 'kind-icon:castle',
   tagline: 'Live a life. Leave a legacy.',
   description:

--- a/components/conductor/humboldt-scoop-page.vue
+++ b/components/conductor/humboldt-scoop-page.vue
@@ -9,8 +9,6 @@ import type { ProjectFrontConfig } from '@/components/conductor/projectFront'
 const config: ProjectFrontConfig = {
   slug: 'humboldt-scoop',
   title: 'The Humboldt Scoop',
-  channelKey: 'wonder',
-  tabKey: 'humboldt-scoop',
   icon: 'kind-icon:heart',
   tagline: 'Small business, big heart, tidy yards.',
   description:

--- a/components/conductor/newsfeed-page.vue
+++ b/components/conductor/newsfeed-page.vue
@@ -18,8 +18,6 @@ import type { ProjectFrontConfig } from '@/components/conductor/projectFront'
 const config: ProjectFrontConfig = {
   slug: 'newsfeed',
   title: 'Newsfeed',
-  channelKey: 'wonder',
-  tabKey: 'newsfeed',
   icon: 'kind-icon:scroll',
   tagline: 'The front page the swarm writes itself.',
   description:

--- a/components/conductor/packmaker-page.vue
+++ b/components/conductor/packmaker-page.vue
@@ -13,8 +13,6 @@ import type { ProjectFrontConfig } from '@/components/conductor/projectFront'
 const config: ProjectFrontConfig = {
   slug: 'packmaker',
   title: 'Packmaker',
-  channelKey: 'builder',
-  tabKey: 'packs',
   icon: 'kind-icon:box',
   tagline: 'Bundle it once. Share it everywhere.',
   description:

--- a/components/conductor/projectFront.ts
+++ b/components/conductor/projectFront.ts
@@ -59,9 +59,6 @@ export type ProjectFrontConfig = {
   tagline?: string
   /** One or two paragraph public description. */
   description?: string
-  /** Existing channel + tab this page is stitched into. */
-  channelKey: string
-  tabKey: string
   /** Iconify kind-icon name for the hero chip. */
   icon?: string
   /** Optional hero image override (else resolved from slug). */

--- a/components/conductor/ruler-hooked-page.vue
+++ b/components/conductor/ruler-hooked-page.vue
@@ -13,8 +13,6 @@ import type { ProjectFrontConfig } from '@/components/conductor/projectFront'
 const config: ProjectFrontConfig = {
   slug: 'ruler-hooked',
   title: 'Ruler Hooked',
-  channelKey: 'wonder',
-  tabKey: 'ruler-hooked',
   icon: 'kind-icon:crown',
   tagline: 'Rule the shore. Answer to the tide.',
   description:

--- a/components/conductor/scoop-cms-page.vue
+++ b/components/conductor/scoop-cms-page.vue
@@ -9,8 +9,6 @@ import type { ProjectFrontConfig } from '@/components/conductor/projectFront'
 const config: ProjectFrontConfig = {
   slug: 'humboldt-scoop-cms',
   title: 'Humboldt Scoop CMS',
-  channelKey: 'conductor',
-  tabKey: 'scoop-cms',
   icon: 'kind-icon:heart',
   tagline: 'The back office behind the tidy yards.',
   description:

--- a/components/conductor/sketchy-page.vue
+++ b/components/conductor/sketchy-page.vue
@@ -127,8 +127,6 @@ const activeSample = computed(() => samplesByTier[activeTier.value])
 const config: ProjectFrontConfig = {
   slug: 'sketchy',
   title: 'Sketchy',
-  channelKey: 'wonder',
-  tabKey: 'sketchy',
   icon: 'kind-icon:pencil',
   tagline: 'Show up, fill the page, get a little better.',
   description:

--- a/components/conductor/voice-lab-page.vue
+++ b/components/conductor/voice-lab-page.vue
@@ -194,8 +194,6 @@ const ADAPTERS = [
 const config: ProjectFrontConfig = {
   slug: 'alexa-integration',
   title: 'Voice Lab',
-  channelKey: 'wonder',
-  tabKey: 'voice-lab',
   icon: 'kind-icon:microphone',
   tagline: 'Kind Robots, out loud.',
   description:

--- a/components/conductor/watchlist-page.vue
+++ b/components/conductor/watchlist-page.vue
@@ -13,8 +13,6 @@ import type { ProjectFrontConfig } from '@/components/conductor/projectFront'
 const config: ProjectFrontConfig = {
   slug: 'media-watchlist',
   title: 'Media Watchlist',
-  channelKey: 'wonder',
-  tabKey: 'watchlist',
   icon: 'kind-icon:movie',
   tagline: 'Everything you meant to watch, in one honest list.',
   description:


### PR DESCRIPTION
### Task
conductor/conductor-app/t-015: wire or drop the dead `ProjectFrontConfig.channelKey/tabKey` fields (kind: software)

### What changed / what I produced
- Every project front page's static `fallback` config declared `channelKey`/`tabKey` (see `components/conductor/projectFront.ts`'s `ProjectFrontConfig`), but `project-front-page.vue`'s `view` computed never read either field — dead data at runtime. This let `conductor-app-page.vue`'s `channelKey: 'conductor'` (not a real nav channel — only home/play/plan/admin exist) sit wrong for weeks with nothing surfacing it, until a manual audit caught it (kind_robots PR #1889).
- Dropped `channelKey`/`tabKey` from `ProjectFrontConfig` and every fallback config that set them, rather than wiring them into the shell: the real values are already canonically tracked in `utils/projectPlacements.ts` and the live `Project` DB row, and read from there by the actual nav/placement resolver — these fallback-config copies were purely redundant duplicates, and exactly the kind of stale-copy risk that hid the conductor-app bug in the first place. Dropping removes the whole class of bug rather than adding a new UI surface.
- Audited every `components/conductor/*-page.vue` **and** `components/coloring/*-page.vue` for the same pattern (the task asked to check for drift elsewhere). Found and fixed 13 files total: `challenge-center-page.vue`, `coat-dance-page.vue`, `conductor-app-page.vue`, `davinci-page.vue`, `humboldt-scoop-page.vue`, `newsfeed-page.vue`, `packmaker-page.vue`, `ruler-hooked-page.vue`, `scoop-cms-page.vue`, `sketchy-page.vue`, `voice-lab-page.vue`, `watchlist-page.vue`, and `coloring/coloring-book-page.vue`.

### How I verified
- `npx vue-tsc --noEmit` — clean, no errors.
- `npx eslint` on all 14 changed files — clean.
- `npx prettier --check` on all 14 changed files — the same 5 files (`challenge-center-page.vue`, `humboldt-scoop-page.vue`, `scoop-cms-page.vue`, `voice-lab-page.vue`, `watchlist-page.vue`) flag pre-existing formatting drift; confirmed via `git stash` that this warning is present on `main` before my change too (unrelated to this diff), so left it out of scope rather than bundling an unrelated reformat into this PR.
- `npm run test:layout-contract` — holds, no new violations.
- `npm run test:davinci-narration` — all 26 checks pass (davinci-page.vue touched).
- `npm run test:challenge-center` — passes (challenge-center-page.vue touched).

### Stakes
reversible

### Flags for Reviewer
- None — mechanical dead-field removal, no runtime behavior change (confirmed the field was never read anywhere before deletion).

### Kaizen suggestion
The 5 files with pre-existing prettier drift (noted above) are unrelated to this task; worth a dedicated formatting-only pass at some point so `prettier --check` is clean repo-wide.

### Notes for reviewer
Companion conductor PR reconciles `conductor-app/t-015`'s roadmap state once this merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YH7udeVe6grea4EcxFLAJf)_