### PR TITLE
fix(model-builder): resolve Facet UPDATE commit race via facetProfile.upsert (model-builder/t-029)

### DIFF
--- a/server/api/model-builder/items/[id]/commit.post.ts
+++ b/server/api/model-builder/items/[id]/commit.post.ts
@@ -410,22 +410,44 @@ async function syncFacetProfileUpdate(
     throw createError({ statusCode: 404, message: `Facet #${id} not found.` })
 
   const requestedTaxonomy = facetFields(fields).taxonomy
-  const fallbackTaxonomy = normalizeFacetTaxonomy(
-    existingProfile?.taxonomy,
-    'OTHER',
-  )
-  const taxonomy = requestedTaxonomy ?? fallbackTaxonomy
 
+  // Two UPDATE-type build runs can target the same existing Facet at once
+  // (nothing serializes runs by sourceId -- see runs/index.post.ts). If both
+  // reach COMMIT while `existingProfile` is still null for both reads, a
+  // plain create-if-missing here lets the second transaction's
+  // facetProfile.create() throw a `facetId` unique-constraint violation,
+  // which aborts this *entire* commit transaction -- rolling back the
+  // sibling tx.facet.update() above along with it, and surfacing as an
+  // opaque 500 to whichever request loses the race. facetProfile.upsert()
+  // resolves the create-vs-update decision atomically at the database (a
+  // single INSERT ... ON DUPLICATE KEY UPDATE on MySQL), so the loser
+  // applies its own intended taxonomy as an update instead of crashing.
   if (!existingProfile) {
-    const profile = buildFacetProfileCreateData(
+    const taxonomy = requestedTaxonomy ?? 'OTHER'
+    const createData = buildFacetProfileCreateData(
       { taxonomy },
       { title: facet.title, taxonomy },
     )
-    await tx.facetProfile.create({ data: { facetId: id, ...profile } })
-  } else if (requestedTaxonomy) {
+    await tx.facetProfile.upsert({
+      where: { facetId: id },
+      create: { facetId: id, ...createData },
+      update: requestedTaxonomy
+        ? buildFacetProfileUpdateData(
+            { taxonomy: requestedTaxonomy },
+            { title: facet.title, taxonomy },
+          )
+        : {},
+    })
+    return
+  }
+
+  if (requestedTaxonomy) {
     const profile = buildFacetProfileUpdateData(
       { taxonomy: requestedTaxonomy },
-      { title: facet.title, taxonomy: fallbackTaxonomy },
+      {
+        title: facet.title,
+        taxonomy: normalizeFacetTaxonomy(existingProfile.taxonomy, 'OTHER'),
+      },
     )
     await tx.facetProfile.update({ where: { facetId: id }, data: profile })
   }

--- a/utils/scripts/verifyModelBuilderFacetSync.ts
+++ b/utils/scripts/verifyModelBuilderFacetSync.ts
@@ -59,6 +59,13 @@ async function main(): Promise<void> {
   requireText(files.commit, text.commit, 'syncFacetProfileUpdate(tx, id, fields)')
   forbidText(files.commit, text.commit, 'import type { FacetKind')
   forbidText(files.commit, text.commit, "pickChoice<FacetKind>(fields, 'Facet', 'kind')")
+  /* t-029: two UPDATE-type build runs can target the same existing Facet at
+     once (nothing serializes runs by sourceId). A plain create-if-missing on
+     FacetProfile races on its `facetId` unique key and aborts the whole
+     commit transaction for the loser. facetProfile.upsert() resolves
+     create-vs-update atomically at the database instead of crashing. */
+  requireText(files.commit, text.commit, 'await tx.facetProfile.upsert({')
+  forbidText(files.commit, text.commit, 'await tx.facetProfile.create({ data: { facetId: id')
 
   requireText(files.characterSync, text.characterSync, "backstory: ['BACKSTORY']")
   requireText(files.characterSync, text.characterSync, "quirks: ['QUIRK']")


### PR DESCRIPTION
### Task
model-builder/t-029: Recurring bug-hunt cycle (kind: software)

### What changed / what I produced
- `server/api/model-builder/items/[id]/commit.post.ts`: `syncFacetProfileUpdate()` now uses `tx.facetProfile.upsert()` instead of a check-then-act `findUnique` → `create`/`update` branch for the "existing Facet has no FacetProfile row yet" case.
- `utils/scripts/verifyModelBuilderFacetSync.ts` (already wired into `.github/workflows/facet-catalog-contract.yml`): added a `requireText`/`forbidText` pair asserting the upsert shape stays in place and the retired create-if-missing shape doesn't return.

### The bug
Two UPDATE-type build runs can target the same existing Facet at once — nothing serializes `ModelBuildRun`s by `sourceId` (see `runs/index.post.ts`; the only per-item guard is the item's own `idempotencyKey` claim, which doesn't prevent two *different* items/runs from targeting the same source). If both commits reach `syncFacetProfileUpdate()` while `existingProfile` is still `null` for both reads, the old create-if-missing branch let the second transaction's `facetProfile.create()` throw a `facetId` unique-constraint violation (`FacetProfile.facetId` is the `@id`). That aborts the *entire* commit transaction — rolling back the sibling `tx.facet.update()` in the same transaction along with it — and surfaces as an opaque 500 to whichever request loses the race, with the item's `idempotencyKey` reset for a retry that then succeeds silently (since `existingProfile` is found on the second attempt).

### How I verified
- All 67 `test:model-builder-*` npm scripts pass (no regression).
- `npx tsx utils/scripts/verifyModelBuilderFacetSync.ts` passes with the extended assertions.
- `vue-tsc --noEmit` exits 0 repo-wide.
- `eslint` clean on both touched files.
- `prettier --check` clean except `verifyModelBuilderFacetSync.ts`'s pre-existing formatting drift — confirmed present on `origin/main` before this change (`git stash` + re-check), untouched by this diff's added lines, so left as-is per this project's established convention of not reformatting unrelated lines.
- `git status --porcelain` showed exactly the 2 intended files.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
This was reachable specifically because `ModelBuildRun` creation never checks for an existing ACTIVE run against the same `(sourceType, sourceId)` pair. A future cycle could consider whether `runs/index.post.ts` should surface a warning (not a hard block — legitimate concurrent edits by an admin+owner, or two tabs, should still be possible) when a new run is created against a source that already has an ACTIVE run, so users get an earlier signal than a race at commit time.

### Notes for reviewer
Recurring `model-builder/t-029` bug-hunt cycle (conductor scheduled Agent run, session `sched-conductor-mb-t029-20260815T172813Z`). This cycle read the three files the prior cycle's note flagged as unexplored ground (`characterFacetSync.ts`, `botFacetSync.ts`, `facetProfileInput.ts`) plus their only call site (`commit.post.ts`). Both facet-sync helpers are pure, purely-additive `deleteMany`+`createMany` writes keyed on composite unique constraints (`characterId+facetId+fieldKey`, `botId+facetId+fieldKey`) — no crash-prone race there. The one genuinely novel, previously-unaudited race was `syncFacetProfileUpdate()`'s single-column-PK check-then-act, which this PR fixes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QfJBwq1Gdm3XTu89AzmkBa)_