### PR TITLE
fix(storybook): harden cloneSession/openStory library sourcing (storybook/t-010)

### DIFF
--- a/.github/workflows/storybook-library-session-consistency-contract.yml
+++ b/.github/workflows/storybook-library-session-consistency-contract.yml
@@ -1,0 +1,30 @@
+name: Storybook Library Session Consistency Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: storybook-library-session-consistency-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Storybook library session consistency contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify Storybook library session consistency guard
+        run: node utils/scripts/verifyStorybookLibrarySessionConsistencyGuard.mjs

--- a/stores/helpers/storybookLibraryHelper.ts
+++ b/stores/helpers/storybookLibraryHelper.ts
@@ -4,6 +4,7 @@ import type {
   StorybookBible,
   StorybookSession,
   StorybookStartInput,
+  StorybookStateDelta,
 } from '@/stores/storybookStore'
 
 export type StorybookLibraryExport = {
@@ -25,6 +26,19 @@ function makeId(): string {
     : `storybook-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
 }
 
+// Mirrors storybookStore.ts's own emptyStateDelta() -- duplicated locally
+// rather than imported, the same way nowIso()/makeId() above are, since this
+// helper module is what storybookStore.ts imports and a reverse import would
+// be circular.
+function emptyStateDelta(): StorybookStateDelta {
+  return {
+    consequences: [],
+    relationshipShifts: [],
+    inventoryAdd: [],
+    inventoryRemove: [],
+  }
+}
+
 function cloneSession(value: StorybookSession): StorybookSession {
   const copy = JSON.parse(JSON.stringify(value)) as StorybookSession
   return {
@@ -33,7 +47,17 @@ function cloneSession(value: StorybookSession): StorybookSession {
       ...copy.bible,
       rewards: Array.isArray(copy.bible?.rewards) ? copy.bible.rewards : [],
     },
-    beats: Array.isArray(copy.beats) ? copy.beats : [],
+    // Every library read/write funnels through this one function -- backfill
+    // a beat missing `stateDelta` the same way storybookStore.ts's own
+    // normalizeRestoredSession() already does on the localStorage-restore
+    // path, so a session saved before this field existed (or by a future
+    // schema change) can't reach a consumer as `undefined.consequences`.
+    beats: Array.isArray(copy.beats)
+      ? copy.beats.map((beat) => ({
+          ...beat,
+          stateDelta: beat.stateDelta ?? emptyStateDelta(),
+        }))
+      : [],
     branchHistory: Array.isArray(copy.branchHistory) ? copy.branchHistory : [],
     consequences: Array.isArray(copy.consequences) ? copy.consequences : [],
     inventory: Array.isArray(copy.inventory) ? copy.inventory : [],
@@ -153,8 +177,18 @@ export function createStorybookLibraryController(bridge: StorybookLibraryBridge)
   }
 
   function openStory(sessionId: string): boolean {
-    const found = findStory(sessionId)
-    if (!found || bridge.isWeaving()) return false
+    if (bridge.isWeaving()) return false
+    // Prefer the live in-memory session over the archived library snapshot
+    // when the requested id is already the active one -- the same sourcing
+    // duplicateStory()/restartStory() below use. No reachable window was
+    // found where the archive actually lags the live session (the library's
+    // deep watcher archives every mutation via a microtask that always
+    // flushes before the next click can be dispatched), but this keeps all
+    // three sibling functions sourcing identically rather than leaving
+    // openStory() as the one exception.
+    const current = bridge.getSession()
+    const found = current?.id === sessionId ? current : findStory(sessionId)
+    if (!found) return false
     bridge.setSession(cloneSession(found))
     bridge.resumeNarrativeArtJobs()
     return true

--- a/utils/scripts/verifyStorybookLibrarySessionConsistencyGuard.mjs
+++ b/utils/scripts/verifyStorybookLibrarySessionConsistencyGuard.mjs
@@ -1,0 +1,85 @@
+// /utils/scripts/verifyStorybookLibrarySessionConsistencyGuard.mjs
+//
+// Hardening guard (storybook/t-010). The previous t-010 bug-hunt cycle left
+// two latent, not-concrete-enough-to-fix observations about
+// storybookLibraryHelper.ts open for a future cycle. Neither had a
+// constructed live repro after tracing every reachable call path, but both
+// close a code-shape gap that matches a bug class this task has fixed for
+// real before, so this cycle applied them proactively and pins the shape:
+//
+//   1. cloneSession() is the single choke point every library read/write
+//      passes a session through (library.initialize(), openStory(),
+//      duplicateStory()/remapDuplicate(), restartStory(), buildExport()),
+//      but unlike normalizeRestoredSession() (storybookStore.ts's own
+//      restore-path normalizer), it never backfilled a beat missing
+//      `stateDelta`. The only current consumer
+//      (narrativeArtMilestones.ts's hasMeaningfulStateDelta(), via the
+//      milestone-art plugin) never actually reaches an affected beat today
+//      -- its seen-beats gating only ever scans a freshly-generated beat,
+//      which always has a valid stateDelta from parseGeneratedBeat() -- but
+//      a session saved before this field existed, or by a future schema
+//      change, would crash the first consumer that reads
+//      `beat.stateDelta.consequences` off a library-sourced session.
+//
+//   2. openStory() unconditionally sourced from the archived library
+//      snapshot (`findStory(sessionId)`), while its two siblings --
+//      duplicateStory() and restartStory() -- both prefer the live
+//      in-memory session when its id matches the request
+//      (`current?.id === sessionId ? current : findStory(sessionId)`). No
+//      reachable data-loss window was found (the library's deep watcher
+//      archives every session mutation via a microtask that always flushes
+//      before the browser can dispatch the next click), but the asymmetry
+//      was still a latent trap for the next edit to assume all three
+//      source identically.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { extractTsFunctionBody } from './lib/extractTsFunctionBody.mjs'
+
+const HELPER_PATH = 'stores/helpers/storybookLibraryHelper.ts'
+
+function extractFunctionBody(content, name) {
+  return extractTsFunctionBody(content, name, {
+    path: HELPER_PATH,
+    notFoundHint:
+      'has it been renamed, removed, or inlined? If so, this guard needs to move with it.',
+  })
+}
+
+const content = readFileSync(resolve(process.cwd(), HELPER_PATH), 'utf8')
+
+const cloneSessionBody = extractFunctionBody(content, 'cloneSession')
+
+assert.ok(
+  /stateDelta:\s*beat\.stateDelta\s*\?\?\s*emptyStateDelta\(\)/.test(
+    cloneSessionBody,
+  ),
+  `cloneSession() in ${HELPER_PATH} must backfill a beat missing ` +
+    '`stateDelta` with `emptyStateDelta()` -- the same fallback ' +
+    'normalizeRestoredSession() applies on the localStorage-restore path in ' +
+    'storybookStore.ts -- otherwise a beat saved before this field existed ' +
+    '(or missing it for any other reason) reaches the first consumer that ' +
+    'reads `beat.stateDelta.consequences` off a library-sourced session as ' +
+    '`undefined.consequences`.',
+)
+
+const openStoryBody = extractFunctionBody(content, 'openStory')
+
+assert.ok(
+  /const current = bridge\.getSession\(\)/.test(openStoryBody) &&
+    /current\?\.id === sessionId\s*\?\s*current\s*:\s*findStory\(sessionId\)/.test(
+      openStoryBody,
+    ),
+  `openStory() in ${HELPER_PATH} must prefer the live in-memory session ` +
+    'over the archived library snapshot when the requested id matches the ' +
+    'current session -- the same sourcing duplicateStory() and ' +
+    'restartStory() already use -- so opening the currently-active story ' +
+    'can never step backwards to a stale archived copy.',
+)
+
+console.log(
+  'Storybook library session-consistency guard contract passed: ' +
+    'cloneSession() backfills a missing stateDelta and openStory() sources ' +
+    "from the live session when ids match, matching duplicateStory()'s and " +
+    "restartStory()'s existing pattern.",
+)


### PR DESCRIPTION
Recurring storybook/t-010 bug-hunt cycle. Resolves the two latent observations left open by the previous cycle (2026-08-15T0858Z) as proactive hardening — neither yielded a concrete live repro after tracing every reachable call path, but both close a code-shape gap matching a bug class this task has fixed for real before (kind_robots #1892, #1861).

## What changed

**1. `cloneSession()` now backfills a missing `stateDelta`.**

`cloneSession()` in `stores/helpers/storybookLibraryHelper.ts` is the single choke point every library read/write passes a session through (`library.initialize()`, `openStory()`, `duplicateStory()`/`remapDuplicate()`, `restartStory()`, `buildExport()`), but unlike `normalizeRestoredSession()` (`storybookStore.ts`'s own restore-path normalizer), it never applied the `beat.stateDelta ?? emptyStateDelta()` fallback. No live consumer currently hits this — the only reader, `narrativeArtMilestones.ts`'s `hasMeaningfulStateDelta()` via the milestone-art plugin, only ever scans freshly-generated beats (which always have a valid `stateDelta` from `parseGeneratedBeat()`) thanks to its seen-beats gating — but a session saved before this field existed, or by a future schema change, would crash the first consumer that reads `beat.stateDelta.consequences` off a library-sourced session. Now applies the same fallback.

**2. `openStory()` now prefers the live in-memory session when ids match.**

`openStory()` unconditionally sourced from the archived library snapshot (`findStory(sessionId)`), while its two siblings — `duplicateStory()` and `restartStory()` — both prefer the live in-memory session when its id matches the request (`current?.id === sessionId ? current : findStory(sessionId)`). Traced every reachable call path (click-driven mutations, page-load restore, the object-entry/library-page route watchers): found no window where the archive actually lags the live session, because the library's deep watcher archives every session mutation via a Vue-scheduler microtask that always fully flushes before the browser can dispatch the next click event. Still, the asymmetry was a latent trap for the next edit that assumes all three functions source identically. Now matches the established pattern.

## Guard added

`utils/scripts/verifyStorybookLibrarySessionConsistencyGuard.mjs` + dedicated `.github/workflows/storybook-library-session-consistency-contract.yml`, matching the existing per-guard-workflow lane convention (10th `verifyStorybook*` guard).

## Verification

- New guard fails against the pre-fix shape and passes against the fix (git-stash round-trip)
- All 9 pre-existing `verifyStorybook*` guards still pass (no regressions)
- `eslint` clean on touched files
- `prettier --check` clean on the two new files (pre-existing `storybookLibraryHelper.ts` formatting drift confirmed via git-stash to predate this change, matching prior cycles' notes on this same file)
- `vue-tsc --noEmit` repo-wide exit 0
- `git status --porcelain` shows exactly the 3 intended files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_016PRqcZ8xqdovTgAxguP3kL)_