### PR TITLE
fix(model-builder): merge stageStatuses changes onto fresh reads in PATCH routes (model-builder/t-029)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -359,6 +359,12 @@ jobs:
       - name: Model Builder commit stale-snapshot guard contract
         run: npm run test:model-builder-commit-stale-snapshot-guard
 
+      - name: Model Builder PATCH stale stage-status guard checker self-test
+        run: npm run test:model-builder-patch-stale-stage-status-guard-selftest
+
+      - name: Model Builder PATCH stale stage-status guard contract
+        run: npm run test:model-builder-patch-stale-stage-status-guard
+
       - name: Model Builder resetAll guard checker self-test
         run: npm run test:model-builder-reset-all-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -196,6 +196,8 @@
     "test:model-builder-commit-name-field-guard": "tsx utils/scripts/verifyModelBuilderCommitNameFieldGuard.ts",
     "test:model-builder-commit-stale-snapshot-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.test.ts",
     "test:model-builder-commit-stale-snapshot-guard": "tsx utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.ts",
+    "test:model-builder-patch-stale-stage-status-guard-selftest": "tsx utils/scripts/verifyModelBuilderPatchStaleStageStatusGuard.test.ts",
+    "test:model-builder-patch-stale-stage-status-guard": "tsx utils/scripts/verifyModelBuilderPatchStaleStageStatusGuard.ts",
     "test:model-builder-reset-all-guard-selftest": "tsx utils/scripts/verifyModelBuilderResetAllGuard.test.ts",
     "test:model-builder-reset-all-guard": "tsx utils/scripts/verifyModelBuilderResetAllGuard.ts",
     "test:model-builder-reset-run-guard-selftest": "tsx utils/scripts/verifyModelBuilderResetRunGuard.test.ts",

--- a/server/api/model-builder/items/[id].patch.ts
+++ b/server/api/model-builder/items/[id].patch.ts
@@ -8,6 +8,7 @@ import {
   assertRunAccess,
   assertRunWritable,
   getItemId,
+  mergeStageStatusChanges,
   prepareItemUpdate,
   type ItemPatchBody,
 } from '../runs/index'
@@ -44,7 +45,7 @@ export default defineEventHandler(async (event) => {
     if (body.artImageId !== undefined) {
       await assertArtImageAttachable(body.artImageId, auth.user.id, auth.isAdmin)
     }
-    const { data, revision } = prepareItemUpdate(
+    const { data, revision, stageStatusChanges } = prepareItemUpdate(
       existing,
       body,
       auth.user.username ?? String(auth.user.id),
@@ -55,6 +56,23 @@ export default defineEventHandler(async (event) => {
         await tx.modelBuildRevision.create({
           data: { itemId: id, ...revision },
         })
+      }
+      // Re-read stageStatuses immediately before the write rather than
+      // trusting the request-start `existing` snapshot: another request
+      // (a concurrent single-item PATCH, batch PATCH, or commit) can change
+      // OTHER stage keys in the window between that read and this write.
+      // stageStatusChanges only carries the keys THIS request actually
+      // intends to change (see prepareItemUpdate/diffStageStatusChanges),
+      // merged onto whatever is live right now — never onto the stale copy.
+      if (stageStatusChanges) {
+        const fresh = await tx.modelBuildItem.findUnique({
+          where: { id },
+          select: { stageStatuses: true },
+        })
+        data.stageStatuses = mergeStageStatusChanges(
+          fresh?.stageStatuses,
+          stageStatusChanges,
+        )
       }
       return tx.modelBuildItem.update({
         where: { id },

--- a/server/api/model-builder/items/batch.patch.ts
+++ b/server/api/model-builder/items/batch.patch.ts
@@ -13,6 +13,7 @@ import { requireApiUser } from '~/server/utils/authGuard'
 import {
   assertRunAccess,
   assertRunWritable,
+  mergeStageStatusChanges,
   prepareItemUpdate,
   type ItemPatchBody,
 } from '../runs/index'
@@ -62,6 +63,9 @@ export default defineEventHandler(async (event) => {
       id: number
       data: Prisma.ModelBuildItemUncheckedUpdateInput
       revision: ReturnType<typeof prepareItemUpdate>['revision']
+      stageStatusChanges: ReturnType<
+        typeof prepareItemUpdate
+      >['stageStatusChanges']
     }> = []
 
     for (const entry of entries) {
@@ -106,8 +110,12 @@ export default defineEventHandler(async (event) => {
 
         const { id: _omit, ...fields } = entry
         void _omit
-        const { data, revision } = prepareItemUpdate(existing, fields, actor)
-        applied.push({ id, data, revision })
+        const { data, revision, stageStatusChanges } = prepareItemUpdate(
+          existing,
+          fields,
+          actor,
+        )
+        applied.push({ id, data, revision, stageStatusChanges })
         results.push({ id, success: true, message: 'Queued.', statusCode: 200 })
       } catch (error: unknown) {
         const handled = errorHandler(error)
@@ -124,11 +132,29 @@ export default defineEventHandler(async (event) => {
     if (applied.length) {
       const updatedById = await prisma.$transaction(async (tx) => {
         const byId = new Map<number, unknown>()
-        for (const { id, data, revision } of applied) {
+        for (const { id, data, revision, stageStatusChanges } of applied) {
           if (revision) {
             await tx.modelBuildRevision.create({
               data: { itemId: id, ...revision },
             })
+          }
+          // Re-read stageStatuses immediately before this entry's own write —
+          // see the identical merge in items/[id].patch.ts for why. The gap
+          // this closes is larger here than the single-item route: every
+          // entry above already did its own findUnique + attachability await
+          // before this transaction even started, so a same-item concurrent
+          // write (e.g. an async art job's pushItem landing mid-batch) has a
+          // real window to land in between this batch's `existing` reads and
+          // its actual writes.
+          if (stageStatusChanges) {
+            const fresh = await tx.modelBuildItem.findUnique({
+              where: { id },
+              select: { stageStatuses: true },
+            })
+            data.stageStatuses = mergeStageStatusChanges(
+              fresh?.stageStatuses,
+              stageStatusChanges,
+            )
           }
           const item = await tx.modelBuildItem.update({
             where: { id },

--- a/server/api/model-builder/runs/index.ts
+++ b/server/api/model-builder/runs/index.ts
@@ -172,6 +172,65 @@ export type PreparedItemUpdate = {
     previousPayload: string
     nextPayload: string
   } | null
+  // Present only when the request's stageStatuses differs from the item as it
+  // stood when this request was validated (`existing`) — the specific stage
+  // keys that changed, not the whole blob. `data` deliberately does NOT carry
+  // a `stageStatuses` write: the caller must merge these keys onto a *fresh*
+  // read of the item immediately before its own transaction write (see
+  // mergeStageStatusChanges below) rather than writing this object directly,
+  // or a concurrent write to a stage this request never touched gets clobbered.
+  stageStatusChanges: Record<string, unknown> | null
+}
+
+// The client always sends item.stages in full — every stage key, including
+// ones this particular action didn't touch — because that's simply what its
+// local reactive state looks like at click time (mirrors every other
+// stageStatuses payload in modelBuilderStore.ts: pushItem, batchPushItems,
+// recordArtifact's callers). Writing that whole blob straight to the DB
+// column (the pre-fix behavior here) silently discards any OTHER stage key
+// a concurrent request changed in the window between this request's
+// `existing` read and its own eventual write — the exact class of bug
+// commit.post.ts's stageStatuses merge (see its own header comment) already
+// fixes for the COMMIT key specifically. Generalizes the same fix to every
+// PATCH-driven stage-status write: diff the request against its own
+// `existing` snapshot to find which keys it actually intends to change, then
+// (in the caller, right before the real write) merge only those keys onto
+// whatever is currently in the DB — never the stale `existing` copy.
+export function diffStageStatusChanges(
+  existingRaw: unknown,
+  requestedRaw: string,
+): Record<string, unknown> | null {
+  const existingStages = parseStoredJson<Record<string, unknown>>(
+    existingRaw,
+    {},
+  )
+  const requestedStages = parseStoredJson<Record<string, unknown>>(
+    requestedRaw,
+    {},
+  )
+  const changes: Record<string, unknown> = {}
+  for (const key of Object.keys(requestedStages)) {
+    if (
+      JSON.stringify(requestedStages[key]) !==
+      JSON.stringify(existingStages[key])
+    ) {
+      changes[key] = requestedStages[key]
+    }
+  }
+  return Object.keys(changes).length ? changes : null
+}
+
+// Applies a stage-status diff (from diffStageStatusChanges) onto a freshly
+// read stageStatuses value. Callers must fetch `currentRaw` immediately
+// before the write this feeds, not reuse any earlier-in-the-request snapshot
+// — see PreparedItemUpdate.stageStatusChanges' doc comment for why.
+export function mergeStageStatusChanges(
+  currentRaw: unknown,
+  changes: Record<string, unknown> | null,
+): string | undefined {
+  if (!changes) return undefined
+  const current = parseStoredJson<Record<string, unknown>>(currentRaw, {})
+  return JSON.stringify({ ...current, ...changes })
 }
 
 // A stage's content is only safe to overwrite while it is workable — ready,
@@ -235,9 +294,18 @@ export function prepareItemUpdate(
 ): PreparedItemUpdate {
   const data: Prisma.ModelBuildItemUncheckedUpdateInput = {}
 
+  let stageStatusChanges: Record<string, unknown> | null = null
   if (body.stageStatuses !== undefined && body.stageStatuses !== null) {
     const stageStatuses = normalizeJson(body.stageStatuses)
-    if (typeof stageStatuses === 'string') data.stageStatuses = stageStatuses
+    // Deliberately not assigned straight onto `data.stageStatuses` here — see
+    // PreparedItemUpdate.stageStatusChanges' doc comment. The caller merges
+    // these changed keys onto a fresh read at write time instead.
+    if (typeof stageStatuses === 'string') {
+      stageStatusChanges = diffStageStatusChanges(
+        existing.stageStatuses,
+        stageStatuses,
+      )
+    }
   }
   if (body.pitch !== undefined) {
     assertContentStageEditable(existing.stageStatuses, 'PITCH', 'Pitch')
@@ -284,7 +352,7 @@ export function prepareItemUpdate(
     body.promptDraft !== undefined ||
     body.relationshipDraft !== undefined
 
-  if (!contentChanged) return { data, revision: null }
+  if (!contentChanged) return { data, revision: null, stageStatusChanges }
 
   const stageLabel =
     typeof body.stage === 'string' ? body.stage.slice(0, 48) : 'EDIT'
@@ -298,11 +366,20 @@ export function prepareItemUpdate(
     stageStatuses: existing.stageStatuses,
     relationshipDraft: existing.relationshipDraft,
   })
+  // Audit-record only, not the live write — mergeStageStatusChanges applied
+  // against this same request's own `existing` snapshot documents what this
+  // request intended to change, same base as previousPayload above. The
+  // actual DB write (see mergeStageStatusChanges call sites in the PATCH
+  // routes) merges stageStatusChanges onto a fresh read at write time
+  // instead, which is deliberately allowed to differ from this record when a
+  // concurrent request also touched stageStatuses in between.
   const nextPayload = JSON.stringify({
     pitch: data.pitch ?? existing.pitch,
     fieldsDraft: data.fieldsDraft ?? existing.fieldsDraft,
     promptDraft: data.promptDraft ?? existing.promptDraft,
-    stageStatuses: data.stageStatuses ?? existing.stageStatuses,
+    stageStatuses:
+      mergeStageStatusChanges(existing.stageStatuses, stageStatusChanges) ??
+      existing.stageStatuses,
     relationshipDraft: data.relationshipDraft ?? existing.relationshipDraft,
   })
 
@@ -315,5 +392,6 @@ export function prepareItemUpdate(
       previousPayload,
       nextPayload,
     },
+    stageStatusChanges,
   }
 }

--- a/utils/scripts/verifyModelBuilderPatchStaleStageStatusGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderPatchStaleStageStatusGuard.test.ts
@@ -1,0 +1,150 @@
+// /utils/scripts/verifyModelBuilderPatchStaleStageStatusGuard.test.ts
+//
+// Regression test for verifyModelBuilderPatchStaleStageStatusGuard.ts
+// (model-builder/t-029). Exercises the real checks against synthetic
+// runs/index.ts- and PATCH-route-shaped fixtures covering: the pre-fix
+// shape (blind wholesale stageStatuses overwrite / missing fresh-merge), the
+// fixed shape (diff + fresh-read + merge), and a missing-anchor fixture.
+import assert from 'node:assert/strict'
+
+import {
+  checkPatchRouteFreshMerge,
+  checkRunsIndexNoBlindOverwrite,
+} from './verifyModelBuilderPatchStaleStageStatusGuard.js'
+
+const BUGGY_RUNS_INDEX = `
+  if (body.stageStatuses !== undefined && body.stageStatuses !== null) {
+    const stageStatuses = normalizeJson(body.stageStatuses)
+    if (typeof stageStatuses === 'string') data.stageStatuses = stageStatuses
+  }
+`
+
+const FIXED_RUNS_INDEX = `
+  let stageStatusChanges: Record<string, unknown> | null = null
+  if (body.stageStatuses !== undefined && body.stageStatuses !== null) {
+    const stageStatuses = normalizeJson(body.stageStatuses)
+    if (typeof stageStatuses === 'string') {
+      stageStatusChanges = diffStageStatusChanges(
+        existing.stageStatuses,
+        stageStatuses,
+      )
+    }
+  }
+
+  export function diffStageStatusChanges(a: unknown, b: string) {
+    return null
+  }
+
+  export function mergeStageStatusChanges(a: unknown, b: unknown) {
+    return undefined
+  }
+`
+
+const BUGGY_PATCH_ROUTE = `
+    const { data, revision } = prepareItemUpdate(existing, body, actor)
+    const item = await prisma.$transaction(async (tx) => {
+      return tx.modelBuildItem.update({
+        where: { id },
+        data,
+        include: itemInclude,
+      })
+    })
+`
+
+const FIXED_PATCH_ROUTE = `
+    const { data, revision, stageStatusChanges } = prepareItemUpdate(existing, body, actor)
+    const item = await prisma.$transaction(async (tx) => {
+      if (stageStatusChanges) {
+        const fresh = await tx.modelBuildItem.findUnique({
+          where: { id },
+          select: { stageStatuses: true },
+        })
+        data.stageStatuses = mergeStageStatusChanges(
+          fresh?.stageStatuses,
+          stageStatusChanges,
+        )
+      }
+      return tx.modelBuildItem.update({
+        where: { id },
+        data,
+        include: itemInclude,
+      })
+    })
+`
+
+const MISSING_FRESH_READ_PATCH_ROUTE = `
+    const { data, revision, stageStatusChanges } = prepareItemUpdate(existing, body, actor)
+    if (stageStatusChanges) {
+      data.stageStatuses = mergeStageStatusChanges(
+        existing.stageStatuses,
+        stageStatusChanges,
+      )
+    }
+    const item = await prisma.$transaction(async (tx) => {
+      return tx.modelBuildItem.update({
+        where: { id },
+        data,
+        include: itemInclude,
+      })
+    })
+`
+
+function run(): void {
+  const buggyRunsIndexErrors = checkRunsIndexNoBlindOverwrite(BUGGY_RUNS_INDEX)
+  assert.equal(
+    buggyRunsIndexErrors.length,
+    3,
+    'expected the buggy runs/index.ts fixture to fail for the blind ' +
+      `overwrite and both missing exports, got: ${JSON.stringify(buggyRunsIndexErrors)}`,
+  )
+  assert.match(buggyRunsIndexErrors[0]!, /still contains/)
+  assert.match(buggyRunsIndexErrors[1]!, /diffStageStatusChanges/)
+  assert.match(buggyRunsIndexErrors[2]!, /mergeStageStatusChanges/)
+
+  const fixedRunsIndexErrors = checkRunsIndexNoBlindOverwrite(FIXED_RUNS_INDEX)
+  assert.deepEqual(
+    fixedRunsIndexErrors,
+    [],
+    `expected the fixed runs/index.ts fixture to pass, got: ${JSON.stringify(fixedRunsIndexErrors)}`,
+  )
+
+  const buggyRouteErrors = checkPatchRouteFreshMerge(
+    BUGGY_PATCH_ROUTE,
+    'fixture-route.ts',
+  )
+  assert.equal(
+    buggyRouteErrors.length,
+    1,
+    `expected the buggy PATCH route fixture to fail once, got: ${JSON.stringify(buggyRouteErrors)}`,
+  )
+  assert.match(buggyRouteErrors[0]!, /does not call/)
+
+  const fixedRouteErrors = checkPatchRouteFreshMerge(
+    FIXED_PATCH_ROUTE,
+    'fixture-route.ts',
+  )
+  assert.deepEqual(
+    fixedRouteErrors,
+    [],
+    `expected the fixed PATCH route fixture to pass, got: ${JSON.stringify(fixedRouteErrors)}`,
+  )
+
+  const missingFreshReadErrors = checkPatchRouteFreshMerge(
+    MISSING_FRESH_READ_PATCH_ROUTE,
+    'fixture-route.ts',
+  )
+  assert.equal(
+    missingFreshReadErrors.length,
+    1,
+    'expected the missing-fresh-read fixture (merges onto `existing`, not a ' +
+      `fresh findUnique) to fail once, got: ${JSON.stringify(missingFreshReadErrors)}`,
+  )
+  assert.match(missingFreshReadErrors[0]!, /no nearby/)
+
+  console.log(
+    'Model Builder PATCH stale stage-status guard self-test passed: buggy ' +
+      'fixtures fail with the expected messages, fixed fixtures pass.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderPatchStaleStageStatusGuard.ts
+++ b/utils/scripts/verifyModelBuilderPatchStaleStageStatusGuard.ts
@@ -1,0 +1,180 @@
+// /utils/scripts/verifyModelBuilderPatchStaleStageStatusGuard.ts
+//
+// Regression guard (model-builder/t-029, kaizen) -- prepareItemUpdate() in
+// server/api/model-builder/runs/index.ts is the shared body behind both
+// items/[id].patch.ts and items/batch.patch.ts. modelBuilderStore.ts always
+// sends the item's ENTIRE local `stages` object as body.stageStatuses on
+// every write (pushItem, batchPushItems' per-entry payloads, recordArtifact's
+// callers -- it's simply what the client's own reactive state looks like at
+// click time), never just the one stage key an action actually changed.
+//
+// Before this fix, prepareItemUpdate wrote that whole blob straight to the
+// `stageStatuses` column (`data.stageStatuses = stageStatuses`). Any OTHER
+// stage key a concurrent request changed in the window between THIS
+// request's `existing` read and its own eventual write got silently
+// discarded. items/[id]/commit.post.ts already had (and still has) an
+// almost identical bug fixed for its own COMMIT-only write -- see
+// verifyModelBuilderCommitStaleSnapshotGuard.ts -- but that fix never
+// extended to the PATCH / batch-PATCH routes, which write stageStatuses far
+// more often and (for batch.patch.ts especially) hold a much wider window:
+// every entry in a batch does its own findUnique + assertArtImageAttachable
+// round trip *before* the shared transaction even starts, so a same-item
+// concurrent write (e.g. an async art job's pollAsyncArtJob -> pushItem
+// landing mid-batch) has real room to land in between.
+//
+// Concrete repro: a user opens a quantity group and clicks "Set field on
+// group" (batchSetField), which snapshots every item's local `.stages` and
+// sends them as part of a single batch PATCH. Meanwhile one item in that
+// same group has an async art job (generateItemAssetAsync) that finishes
+// mid-batch-request and PATCHes its own item with a freshly-'ready'
+// GENERATE_ASSETS status. If that single PATCH commits before the batch's
+// shared transaction reaches that item, the batch's write -- built from its
+// pre-request snapshot -- silently reverts GENERATE_ASSETS back to whatever
+// it was when the batch was sent, discarding the just-finished render's
+// status with no error, no re-review trigger, no toast.
+//
+// Fixed the same way commit.post.ts was: diff the request's stageStatuses
+// against its own `existing` snapshot to find which keys it actually
+// intends to change (diffStageStatusChanges), then re-read the item's live
+// stageStatuses immediately before each write and merge only those changed
+// keys onto it (mergeStageStatusChanges) -- never write the stale blob
+// wholesale.
+//
+// This asserts the textual shape of the fix stays in place:
+//   1. prepareItemUpdate() no longer contains a direct
+//      `data.stageStatuses = stageStatuses` assignment.
+//   2. Both items/[id].patch.ts and items/batch.patch.ts call
+//      mergeStageStatusChanges(...) with a value sourced from a `findUnique`
+//      call, immediately assigned to `data.stageStatuses`, before their
+//      respective `tx.modelBuildItem.update(...)` write.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const RUNS_INDEX_PATH = join(
+  repositoryRoot,
+  'server/api/model-builder/runs/index.ts',
+)
+const SINGLE_PATCH_PATH = join(
+  repositoryRoot,
+  'server/api/model-builder/items/[id].patch.ts',
+)
+const BATCH_PATCH_PATH = join(
+  repositoryRoot,
+  'server/api/model-builder/items/batch.patch.ts',
+)
+
+const BLIND_OVERWRITE = 'data.stageStatuses = stageStatuses'
+const MERGE_ASSIGNMENT = 'data.stageStatuses = mergeStageStatusChanges('
+
+// Checks runs/index.ts: prepareItemUpdate must no longer contain the blind
+// wholesale-overwrite assignment.
+export function checkRunsIndexNoBlindOverwrite(content: string): string[] {
+  const errors: string[] = []
+  if (content.includes(BLIND_OVERWRITE)) {
+    errors.push(
+      `runs/index.ts still contains \`${BLIND_OVERWRITE}\` -- prepareItemUpdate() ` +
+        'appears to write the request-start stageStatuses blob wholesale again, ' +
+        'reintroducing the stale-overwrite bug this guard exists to catch.',
+    )
+  }
+  if (!content.includes('export function diffStageStatusChanges')) {
+    errors.push(
+      'runs/index.ts no longer exports diffStageStatusChanges() -- has the ' +
+        'stageStatuses-diff fix been renamed or removed?',
+    )
+  }
+  if (!content.includes('export function mergeStageStatusChanges')) {
+    errors.push(
+      'runs/index.ts no longer exports mergeStageStatusChanges() -- has the ' +
+        'stageStatuses-merge fix been renamed or removed?',
+    )
+  }
+  return errors
+}
+
+// Checks a PATCH route file: it must call mergeStageStatusChanges with a
+// value read via a fresh `findUnique` (not the request-start snapshot),
+// immediately before a `tx.modelBuildItem.update(` write.
+export function checkPatchRouteFreshMerge(
+  content: string,
+  label: string,
+): string[] {
+  const errors: string[] = []
+
+  const mergeIndex = content.indexOf(MERGE_ASSIGNMENT)
+  if (mergeIndex === -1) {
+    errors.push(
+      `${label} does not call \`${MERGE_ASSIGNMENT}...)\` -- it appears to ` +
+        'write stageStatuses without merging onto a fresh read, reintroducing ' +
+        'the stale-overwrite bug this guard exists to catch.',
+    )
+    return errors
+  }
+
+  // A `findUnique` selecting stageStatuses must appear shortly before the
+  // merge call (the fresh read this merge is supposed to be based on).
+  const precedingSlice = content.slice(
+    Math.max(0, mergeIndex - 400),
+    mergeIndex,
+  )
+  if (
+    !precedingSlice.includes('findUnique') ||
+    !precedingSlice.includes('stageStatuses: true')
+  ) {
+    errors.push(
+      `${label} calls mergeStageStatusChanges(...) but no nearby ` +
+        '`findUnique({ ... select: { stageStatuses: true } })` precedes it -- ' +
+        'the merge must be based on a value read immediately before the ' +
+        'write, not an older snapshot.',
+    )
+  }
+
+  // The merge assignment must itself land before the actual DB write it
+  // feeds, not after.
+  const updateIndex = content.indexOf('tx.modelBuildItem.update({', mergeIndex)
+  if (updateIndex === -1) {
+    errors.push(
+      `${label} calls mergeStageStatusChanges(...) but no ` +
+        '`tx.modelBuildItem.update({` write follows it -- the merged value ' +
+        "doesn't appear to feed an actual write.",
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const runsIndexContent = readFileSync(RUNS_INDEX_PATH, 'utf8')
+  const singlePatchContent = readFileSync(SINGLE_PATCH_PATH, 'utf8')
+  const batchPatchContent = readFileSync(BATCH_PATCH_PATH, 'utf8')
+
+  const errors = [
+    ...checkRunsIndexNoBlindOverwrite(runsIndexContent),
+    ...checkPatchRouteFreshMerge(singlePatchContent, 'items/[id].patch.ts'),
+    ...checkPatchRouteFreshMerge(batchPatchContent, 'items/batch.patch.ts'),
+  ]
+
+  if (errors.length) {
+    console.error(
+      'Model Builder PATCH stale stage-status guard contract failed:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder PATCH stale stage-status guard contract passed: ' +
+      'prepareItemUpdate() diffs requested stageStatuses against its own ' +
+      'request-start snapshot, and both PATCH routes merge only the changed ' +
+      'keys onto a freshly re-read value immediately before each write.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What

Both `items/[id].patch.ts` and `items/batch.patch.ts` wrote the client's full `stageStatuses` blob straight to the DB column via `prepareItemUpdate()`. The client always sends the item's entire local `.stages` object on every write (it's just what its reactive state looks like at click time), so any *other* stage key a concurrent request changed in the window between this request's `existing` read and its own write got silently clobbered back to the stale snapshot — the same class of bug already fixed once in `commit.post.ts` for its COMMIT-only write, but never generalized to the PATCH/batch-PATCH paths.

Most exploitable in `items/batch.patch.ts`: every entry in a batch does its own `findUnique` + `assertArtImageAttachable` round trip before the shared transaction even starts, so a same-item concurrent single-item PATCH (e.g. an async art job's `pollAsyncArtJob` → `pushItem` finishing mid-batch) has real room to land and then get silently reverted.

## Fix

Diff the request's `stageStatuses` against its own `existing` snapshot (`diffStageStatusChanges`) to find which keys it actually intends to change, then re-read the item's live `stageStatuses` immediately before each write and merge only those changed keys onto it (`mergeStageStatusChanges`) — never write the stale blob wholesale. Mirrors the existing `commit.post.ts` fix, generalized from one hardcoded key to arbitrary changed keys.

Added `verifyModelBuilderPatchStaleStageStatusGuard.ts` + `.test.ts` following the established narrow-textual-checker convention, wired into `package.json` and `contract-tests.yml`.

## Verification

- New guard + self-test pass
- All 69 `test:model-builder-*` npm scripts pass (no regression)
- `vue-tsc --noEmit` exits 0 repo-wide
- eslint clean on touched files
- `prettier --check` clean (`items/[id].patch.ts`'s pre-existing formatting drift, present on `main` before this change, is untouched by this diff's added lines)
- `git status --porcelain` showed exactly the 7 intended files

Part of the recurring `model-builder/t-029` bug-hunt cycle (conductor roadmap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGB5dMF5Pb23nm45pJuB5a)_