### PR TITLE
fix(model-builder): harden runs/[id].patch.ts against writes to CANCELLED runs (model-builder/t-029)

### DIFF
--- a/server/api/model-builder/runs/[id].patch.ts
+++ b/server/api/model-builder/runs/[id].patch.ts
@@ -9,6 +9,7 @@ import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
 import {
   assertRunAccess,
+  assertRunWritable,
   getRunId,
   modelBuildStatuses,
   normalizeJson,
@@ -30,13 +31,23 @@ export default defineEventHandler(async (event) => {
 
     const existing = await prisma.modelBuildRun.findUnique({
       where: { id },
-      select: { id: true, userId: true },
+      select: { id: true, userId: true, status: true },
     })
     if (!existing) {
       event.node.res.statusCode = 404
       return { success: false, message: 'Build run not found.', statusCode: 404 }
     }
+    // Defense-in-depth (model-builder/t-029 kaizen, deferred twice before this
+    // cycle): the client only ever sends {status: 'CANCELLED'} through this
+    // route today, which is why a missing check here was never a *live*
+    // exploit -- but this is the run's own status route, the natural place a
+    // future "resume" feature would land a status write, and every other
+    // write-capable model-builder route already refuses once the run is
+    // CANCELLED. Checking existing.status (read before this update, not the
+    // value the client is trying to set) means the CANCEL action itself still
+    // succeeds -- it only blocks writes to a run that is *already* CANCELLED.
     assertRunAccess(existing, auth.user)
+    assertRunWritable(existing)
 
     const body = await readBody<RunPatchBody>(event)
     const data: Prisma.ModelBuildRunUncheckedUpdateInput = {}

--- a/utils/scripts/verifyModelBuilderRunWritableGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderRunWritableGuard.test.ts
@@ -1,16 +1,18 @@
 // /utils/scripts/verifyModelBuilderRunWritableGuard.test.ts
 //
 // Regression test for checkRunWritableGuard() in
-// verifyModelBuilderRunWritableGuard.ts (model-builder/t-039). Exercises the
-// real check against synthetic route-shaped fixtures covering: the pre-fix
-// shape (assertRunAccess present, assertRunWritable missing entirely -- the
-// exact gap PR #1239 closed), the fixed shape (assertRunWritable immediately
+// verifyModelBuilderRunWritableGuard.ts (model-builder/t-039, extended by a
+// later t-029 cycle to also cover runs/[id].patch.ts). Exercises the real
+// check against synthetic route-shaped fixtures covering: the pre-fix shape
+// (assertRunAccess present, assertRunWritable missing entirely -- the exact
+// gap PR #1239 closed), the fixed shape (assertRunWritable immediately
 // follows assertRunAccess for the same run reference), a reordered shape
 // (assertRunWritable present but before assertRunAccess, which this guard
 // still flags since the anchor is "immediately after"), and assertRunAccess
-// itself being absent entirely. Runs each fixture against two different
-// runVar shapes (existing.Run and item.Run) to confirm the dot-escaping in
-// the generated regex works for either.
+// itself being absent entirely. Runs each fixture against three different
+// runVar shapes (existing.Run, item.Run, and bare existing -- runs/[id].patch.ts
+// reads the run's own status directly, not through a relation) to confirm
+// the dot-escaping in the generated regex works for all of them.
 import assert from 'node:assert/strict'
 
 import { checkRunWritableGuard } from './verifyModelBuilderRunWritableGuard.js'
@@ -23,6 +25,11 @@ const EXISTING_ROUTE = {
 const ITEM_ROUTE = {
   relativePath: 'server/api/model-builder/items/[id]/commit.post.ts',
   runVar: 'item.Run',
+}
+
+const RUN_ROUTE = {
+  relativePath: 'server/api/model-builder/runs/[id].patch.ts',
+  runVar: 'existing',
 }
 
 function buggyFixture(runVar: string): string {
@@ -86,7 +93,7 @@ export default defineEventHandler(async (event) => {
 })
 `
 
-for (const route of [EXISTING_ROUTE, ITEM_ROUTE]) {
+for (const route of [EXISTING_ROUTE, ITEM_ROUTE, RUN_ROUTE]) {
   const buggyErrors = checkRunWritableGuard(buggyFixture(route.runVar), route)
   assert.equal(
     buggyErrors.length,
@@ -136,5 +143,5 @@ console.log(
     'shape (assertRunAccess present, assertRunWritable missing), a ' +
     'reordered shape (assertRunWritable before assertRunAccess), clears the ' +
     'fully-fixed shape, and flags assertRunAccess being absent entirely -- ' +
-    'for both existing.Run and item.Run runVar shapes.',
+    'for existing.Run, item.Run, and bare existing runVar shapes.',
 )

--- a/utils/scripts/verifyModelBuilderRunWritableGuard.ts
+++ b/utils/scripts/verifyModelBuilderRunWritableGuard.ts
@@ -21,7 +21,15 @@
 // assertRunWritable() call from any one of the four routes with nothing
 // failing except a live end-to-end test this sandbox can't run.
 //
-// This asserts the textual shape stays in place: each of the four routes
+// runs/[id].patch.ts (the run's own status route) was deliberately left out
+// of that original set -- the client only ever sends {status: 'CANCELLED'}
+// through it, so the gap was never live-reachable via the UI -- but two
+// later t-029 bug-hunt cycles flagged the omission as worth closing anyway
+// for defense-in-depth, since it's the one write-capable model-builder route
+// that *doesn't* refuse further writes to an already-CANCELLED run. Closed
+// as a deliberate kaizen rather than deferring a third time.
+//
+// This asserts the textual shape stays in place: each of the five routes
 // calls assertRunWritable(<run>) immediately after assertRunAccess(<run>,
 // auth.user) for the same run reference -- deliberately scoped to this one
 // bug shape, mirroring verifyModelBuilderItemPatchStageGuard.ts's and
@@ -67,6 +75,10 @@ const ROUTES: RouteCheck[] = [
   {
     relativePath: 'server/api/model-builder/items/[id]/commit.post.ts',
     runVar: 'item.Run',
+  },
+  {
+    relativePath: 'server/api/model-builder/runs/[id].patch.ts',
+    runVar: 'existing',
   },
 ]
 
@@ -147,11 +159,12 @@ function main(): void {
   }
 
   console.log(
-    'Model Builder required guard contracts passed: all four write-capable ' +
-      'item routes refuse writes to CANCELLED runs, async completion cannot ' +
-      'persist after run cancellation, finished renders cannot replace ' +
-      'already-approved assets, and item PATCH writes cannot bypass ' +
-      'server-stored stage review gates.',
+    'Model Builder required guard contracts passed: all five write-capable ' +
+      'routes (four item routes plus the run status route) refuse writes to ' +
+      'CANCELLED runs, async completion cannot persist after run ' +
+      'cancellation, finished renders cannot replace already-approved ' +
+      'assets, and item PATCH writes cannot bypass server-stored stage ' +
+      'review gates.',
   )
 }
 


### PR DESCRIPTION
### Task
model-builder/t-029: Recurring bug-hunt cycle (kind: software) — kaizen from two prior cycles

### What changed / what I produced
- `server/api/model-builder/runs/[id].patch.ts` now selects `status` alongside `id`/`userId` and calls `assertRunWritable(existing)` immediately after `assertRunAccess(existing, auth.user)`, matching the pattern every other write-capable model-builder route already follows (`items/[id].patch.ts`, `items/batch.patch.ts`, `items/[id]/artifacts.post.ts`, `items/[id]/commit.post.ts`).
- Not a live exploit today — the client only ever sends `{status: 'CANCELLED'}` through this route — but it was the one write-capable model-builder route that didn't share the "refuse further writes once CANCELLED" invariant, and a future "resume" feature would naturally land its status write here. Two prior `model-builder/t-029` cycles flagged this and deferred it; this cycle closes it.
- Checking the pre-update `existing.status` (not the value the client is trying to set) means the CANCEL action itself still succeeds — it only blocks writes to a run that is *already* CANCELLED.
- Extended `utils/scripts/verifyModelBuilderRunWritableGuard.ts` / `.test.ts` (rather than adding a new guard file) to cover this fifth route/runVar shape (`existing`, not `existing.Run`/`item.Run`).

### How I verified
- Extended guard self-test + guard pass (`npm run test:model-builder-run-writable-guard-selftest` / `test:model-builder-run-writable-guard`).
- All 69 `test:model-builder-*` npm scripts pass — no regression.
- `vue-tsc --noEmit` exits 0 repo-wide.
- `eslint` clean on the 3 touched files.
- `prettier --check` clean except `runs/[id].patch.ts`'s pre-existing formatting drift, confirmed present on `origin/main` before this change (via `git stash`), untouched by this diff's added lines.
- `git status --porcelain` shows exactly the 3 intended files.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
`runs/[id].patch.ts`'s `RunPatchBody` type doesn't validate `status` transitions beyond membership in `modelBuildStatuses` — e.g. nothing stops a client from flipping `DRAFT` → `COMPLETED` directly, skipping `ACTIVE`. Worth a future cycle checking whether the store/UI ever relies on that ordering being enforced server-side, or whether it's intentionally permissive.

### Notes for reviewer
This is the model-builder/t-029 recurring roadmap task in `silasfelinus/conductor` (claimed this cycle, closed via `close_task.py` after merge).


---
_Generated by [Claude Code](https://claude.ai/code/session_01KSRsxQ1joWTb1vUcZKc7SH)_