### PR TITLE
fix(model-builder): re-check assertArtImageAttachable before ASSET_ONLY promotion (model-builder/t-029)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -485,6 +485,12 @@ jobs:
       - name: Model Builder async-fetch staleness coverage contract
         run: npm run test:model-builder-async-fetch-staleness-coverage
 
+      - name: Model Builder commit asset-attachable guard checker self-test
+        run: npm run test:model-builder-commit-asset-attachable-guard-selftest
+
+      - name: Model Builder commit asset-attachable guard contract
+        run: npm run test:model-builder-commit-asset-attachable-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -238,6 +238,8 @@
     "test:model-builder-open-run-request-guard": "tsx utils/scripts/verifyModelBuilderOpenRunRequestGuard.ts",
     "test:model-builder-async-fetch-staleness-coverage-selftest": "tsx utils/scripts/verifyModelBuilderAsyncFetchStalenessCoverage.test.ts",
     "test:model-builder-async-fetch-staleness-coverage": "tsx utils/scripts/verifyModelBuilderAsyncFetchStalenessCoverage.ts",
+    "test:model-builder-commit-asset-attachable-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitAssetAttachableGuard.test.ts",
+    "test:model-builder-commit-asset-attachable-guard": "tsx utils/scripts/verifyModelBuilderCommitAssetAttachableGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/server/api/model-builder/items/[id]/commit.post.ts
+++ b/server/api/model-builder/items/[id]/commit.post.ts
@@ -16,6 +16,7 @@ import {
   getItemId,
   parseStoredJson,
 } from '../../runs/index'
+import { assertArtImageAttachable } from '../../relations'
 import {
   CREATE_TARGETS,
   fieldSpecFor,
@@ -893,6 +894,25 @@ export default defineEventHandler(async (event) => {
     let target: CommitTarget
     try {
       if (plan.action === 'ASSET_ONLY') {
+        // assertArtImageAttachable was already checked once, when this
+        // artImageId was first attached to the item (items/[id].patch.ts,
+        // items/batch.patch.ts) — but an item can sit approved for an
+        // arbitrary stretch between that attach and this COMMIT (nothing
+        // requires committing right away). If the ArtImage's owner flips it
+        // private (or an admin/owner action changes who may attach it) in
+        // that window, the earlier check no longer reflects reality, and
+        // promoteAsset below writes the FK onto the source record's
+        // canonical art link regardless — exactly the "surfaces a private
+        // ArtImage through another record's canonical art" outcome
+        // relations.ts's own header comment says this guard exists to
+        // prevent. Re-checking here, immediately before the privileged
+        // write, closes that gap the same way this route already re-reads
+        // stageStatuses immediately before its own final write below.
+        await assertArtImageAttachable(
+          plan.value,
+          auth.user.id,
+          syncOptions.isAdmin,
+        )
         await promoteAsset(sourceType, sourceId, plan.value)
         target = { type: sourceType, id: sourceId, created: false }
       } else if (plan.action === 'UPDATE') {

--- a/utils/scripts/verifyModelBuilderCommitAssetAttachableGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderCommitAssetAttachableGuard.test.ts
@@ -1,0 +1,130 @@
+// /utils/scripts/verifyModelBuilderCommitAssetAttachableGuard.test.ts
+//
+// Regression test for checkCommitAssetAttachableGuard() in
+// verifyModelBuilderCommitAssetAttachableGuard.ts. Exercises the real check
+// against synthetic route-shaped fixtures covering: the pre-fix shape (the
+// import present, promoteAsset() called with no preceding
+// assertArtImageAttachable call -- the exact gap this fix closed), the fixed
+// shape (assertArtImageAttachable(...) called immediately before
+// promoteAsset(...)), the import missing entirely, and promoteAsset() itself
+// missing (route restructured beyond what this narrow checker can follow).
+import assert from 'node:assert/strict'
+
+import { checkCommitAssetAttachableGuard } from './verifyModelBuilderCommitAssetAttachableGuard.js'
+
+const IMPORT_LINE = "import { assertArtImageAttachable } from '../../relations'"
+
+function buggyFixture(): string {
+  return `
+${IMPORT_LINE}
+
+export default defineEventHandler(async (event) => {
+  try {
+    let target
+    try {
+      if (plan.action === 'ASSET_ONLY') {
+        await promoteAsset(sourceType, sourceId, plan.value)
+        target = { type: sourceType, id: sourceId, created: false }
+      }
+    } catch (writeError) {
+      throw writeError
+    }
+    return { success: true }
+  } catch (error) {
+    return errorHandler(error)
+  }
+})
+`
+}
+
+function fixedFixture(): string {
+  return `
+${IMPORT_LINE}
+
+export default defineEventHandler(async (event) => {
+  try {
+    let target
+    try {
+      if (plan.action === 'ASSET_ONLY') {
+        await assertArtImageAttachable(
+          plan.value,
+          auth.user.id,
+          syncOptions.isAdmin,
+        )
+        await promoteAsset(sourceType, sourceId, plan.value)
+        target = { type: sourceType, id: sourceId, created: false }
+      }
+    } catch (writeError) {
+      throw writeError
+    }
+    return { success: true }
+  } catch (error) {
+    return errorHandler(error)
+  }
+})
+`
+}
+
+function missingImportFixture(): string {
+  return fixedFixture().replace(`${IMPORT_LINE}\n\n`, '')
+}
+
+function missingPromoteFixture(): string {
+  return `
+${IMPORT_LINE}
+
+export default defineEventHandler(async (event) => {
+  try {
+    return { success: true }
+  } catch (error) {
+    return errorHandler(error)
+  }
+})
+`
+}
+
+const buggyErrors = checkCommitAssetAttachableGuard(buggyFixture())
+assert.equal(
+  buggyErrors.length,
+  1,
+  `expected the pre-fix shape (promoteAsset present, no preceding ` +
+    `assertArtImageAttachable call) to raise 1 error, got ${buggyErrors.length}: ` +
+    JSON.stringify(buggyErrors),
+)
+assert.ok(buggyErrors[0]!.includes('assertArtImageAttachable'))
+
+const fixedErrors = checkCommitAssetAttachableGuard(fixedFixture())
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingImportErrors = checkCommitAssetAttachableGuard(
+  missingImportFixture(),
+)
+assert.equal(
+  missingImportErrors.length,
+  1,
+  `expected the import line being absent to raise 1 error, got ` +
+    `${missingImportErrors.length}: ${JSON.stringify(missingImportErrors)}`,
+)
+assert.ok(missingImportErrors[0]!.includes(IMPORT_LINE))
+
+const missingPromoteErrors = checkCommitAssetAttachableGuard(
+  missingPromoteFixture(),
+)
+assert.equal(
+  missingPromoteErrors.length,
+  1,
+  `expected promoteAsset() being absent to raise 1 error, got ` +
+    `${missingPromoteErrors.length}: ${JSON.stringify(missingPromoteErrors)}`,
+)
+assert.ok(missingPromoteErrors[0]!.includes('promoteAsset'))
+
+console.log(
+  'Model Builder commit asset-attachable guard checker verified: flags the ' +
+    'pre-fix shape (promoteAsset present, no preceding assertArtImageAttachable ' +
+    'call), clears the fully-fixed shape, and flags the import or the ' +
+    'promoteAsset call being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderCommitAssetAttachableGuard.ts
+++ b/utils/scripts/verifyModelBuilderCommitAssetAttachableGuard.ts
@@ -1,0 +1,129 @@
+// /utils/scripts/verifyModelBuilderCommitAssetAttachableGuard.ts
+//
+// Regression guard (model-builder/t-029, kaizen) -- relations.ts's
+// assertArtImageAttachable() exists specifically because an item's
+// artImageId is later promoted onto the run's owner-verified source record
+// (see its own header comment: "An item's artImageId is later promoted onto
+// the run's owner-verified source record ... an unchecked FK lets a user pin
+// another user's PRIVATE ArtImage onto their own record and surface it
+// through that record's canonical art link"). Every route that lets a
+// caller SET an item's artImageId already calls it at write time
+// (items/[id].patch.ts, items/batch.patch.ts, items/[id]/artifacts.post.ts)
+// -- but until this fix, items/[id]/commit.post.ts's ASSET_ONLY branch never
+// called it at all. It promoted whatever artImageId the item already carried
+// straight onto the source record via promoteAsset(), trusting the
+// attach-time check alone.
+//
+// Concrete repro: user B's Character (id 42) build item is set to a PUBLIC
+// ArtImage (id 500, owned by user A) via PATCH /items/:id --
+// assertArtImageAttachable passes since it's public at that moment. The item
+// sits at GENERATE_ASSETS approved for a while (nothing forces an immediate
+// commit). User A then flips ArtImage 500 private via PATCH
+// /api/art/image/500 (their own image, their own call). User B commits the
+// item: commit.post.ts's ASSET_ONLY branch calls promoteAsset(), which does
+// `prisma.character.update({ where: { id: 42 }, data: { artImageId: 500 } })`
+// unconditionally -- no re-check -- writing user A's now-private ArtImage
+// onto user B's Character's canonical art link. If that Character is public,
+// user A's private image becomes reachable through it, exactly the outcome
+// the guard's own header comment says it exists to prevent.
+//
+// Fixed by calling assertArtImageAttachable(plan.value, auth.user.id,
+// syncOptions.isAdmin) immediately before promoteAsset() in the ASSET_ONLY
+// branch, re-validating against the ArtImage's CURRENT ownership/visibility
+// at the moment of the actual privileged write rather than trusting the
+// attach-time check alone -- mirrors this same route's existing
+// re-read-immediately-before-the-write idiom (see
+// verifyModelBuilderCommitStaleSnapshotGuard.ts for stageStatuses).
+//
+// This asserts the textual shape of the fix stays in place: commit.post.ts
+// imports assertArtImageAttachable from '../../relations', and calls it with
+// a preceding `assertArtImageAttachable(` occurrence shortly before its
+// `await promoteAsset(sourceType, sourceId, plan.value)` call.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const ROUTE_PATH = join(
+  repositoryRoot,
+  'server/api/model-builder/items/[id]/commit.post.ts',
+)
+
+const IMPORT_LINE = "import { assertArtImageAttachable } from '../../relations'"
+const PROMOTE_CALL = 'await promoteAsset(sourceType, sourceId, plan.value)'
+const ATTACHABLE_CALL = 'assertArtImageAttachable('
+
+// Checks the fix's exact shape against the full source text of a file
+// containing commit.post.ts's ASSET_ONLY commit branch. Exported (rather
+// than only exercised via main()) so the self-test below can run it against
+// synthetic buggy/fixed fixtures without touching the real route file.
+export function checkCommitAssetAttachableGuard(content: string): string[] {
+  const errors: string[] = []
+
+  if (!content.includes(IMPORT_LINE)) {
+    errors.push(
+      `commit.post.ts no longer contains \`${IMPORT_LINE}\` -- has ` +
+        'assertArtImageAttachable stopped being imported, or moved to a ' +
+        'different import shape? Either way this guard needs to move with it.',
+    )
+  }
+
+  const promoteIndex = content.indexOf(PROMOTE_CALL)
+  if (promoteIndex === -1) {
+    errors.push(
+      `commit.post.ts no longer contains \`${PROMOTE_CALL}\` -- has the ` +
+        'ASSET_ONLY promotion call been renamed or restructured? If so, this ' +
+        'guard (and the bug it protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  const precedingSlice = content.slice(
+    Math.max(0, promoteIndex - 600),
+    promoteIndex,
+  )
+  if (!precedingSlice.includes(ATTACHABLE_CALL)) {
+    errors.push(
+      'commit.post.ts calls promoteAsset() in its ASSET_ONLY branch without ' +
+        "a preceding assertArtImageAttachable(...) call -- the ArtImage's " +
+        'ownership/visibility is only checked once, when it was first ' +
+        'attached to the item (items/[id].patch.ts / items/batch.patch.ts), ' +
+        "not again at the moment it's actually promoted onto the source " +
+        'record. An item can sit approved for an arbitrary stretch between ' +
+        'attach and commit; if the ArtImage is made private in that window, ' +
+        'the stale attach-time check no longer reflects reality and a ' +
+        "private ArtImage gets promoted onto another user's canonical " +
+        'record with no re-check.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(ROUTE_PATH, 'utf8')
+  const errors = checkCommitAssetAttachableGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder commit asset-attachable guard contract failed for ' +
+        'server/api/model-builder/items/[id]/commit.post.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder commit asset-attachable guard contract passed: the ' +
+      'ASSET_ONLY commit branch re-checks assertArtImageAttachable ' +
+      'immediately before promoting the ArtImage onto the source record, ' +
+      "instead of trusting the item's attach-time check alone.",
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
Recurring model-builder/t-029 bug-hunt cycle.

## The bug

`server/api/model-builder/relations.ts`'s `assertArtImageAttachable()` exists specifically because an item's `artImageId` is later *promoted* onto the run's owner-verified source record — its own header comment says so: "An item's artImageId is later promoted onto the run's owner-verified source record ... an unchecked FK lets a user pin another user's PRIVATE ArtImage onto their own record and surface it through that record's canonical art link."

Every route that lets a caller **set** an item's `artImageId` already calls this guard at write time (`items/[id].patch.ts`, `items/batch.patch.ts`, `items/[id]/artifacts.post.ts`) — but `items/[id]/commit.post.ts`'s `ASSET_ONLY` branch never called it at all. It called `promoteAsset()` directly, trusting the attach-time check alone.

**Concrete failure scenario:** user B's Character (id 42) build item has its `artImageId` set to a PUBLIC ArtImage (id 500, owned by user A) via `PATCH /items/:id` — `assertArtImageAttachable` passes since it's public at that moment. The item sits at `GENERATE_ASSETS` approved for a while (nothing forces an immediate commit — that's an explicit design point of the resumable build-run model). User A then flips ArtImage 500 private via `PATCH /api/art/image/500` (their own image, their own call — unrelated to this build). User B commits the item: the `ASSET_ONLY` branch calls `promoteAsset()`, which does `prisma.character.update({ where: { id: 42 }, data: { artImageId: 500 } })` unconditionally, writing user A's now-private ArtImage onto user B's Character's canonical art link with no re-check. If that Character is public, user A's private image becomes reachable through it — exactly the outcome the guard's own doc comment says it exists to prevent.

## The fix

Call `assertArtImageAttachable(plan.value, auth.user.id, syncOptions.isAdmin)` immediately before `promoteAsset()` in the `ASSET_ONLY` branch, re-validating against the ArtImage's *current* ownership/visibility at the moment of the actual privileged write, rather than trusting the attach-time check alone. Mirrors this same route's existing re-read-immediately-before-the-write idiom (see `verifyModelBuilderCommitStaleSnapshotGuard.ts` for the analogous `stageStatuses` fix). On failure it's caught by the existing `catch (writeError)` block, which already releases the idempotency-key claim and rethrows — self-healing on retry, same as every other write failure on this route.

## Regression guard

Added `utils/scripts/verifyModelBuilderCommitAssetAttachableGuard.ts` + `.test.ts` following the established narrow-textual-checker convention (confirms the import is present and `assertArtImageAttachable(` appears shortly before the `promoteAsset(sourceType, sourceId, plan.value)` call). Wired into `package.json`'s `test:model-builder-*` group and `.github/workflows/contract-tests.yml`, in the same position as the most recently wired guard.

## Verification

- New guard + its self-test pass
- All 71 `test:model-builder-*` npm scripts pass (69 pre-existing + 2 new — no regression)
- `vue-tsc --noEmit` exits 0 repo-wide
- `eslint` clean on touched files
- `prettier --check` clean on touched files
- `git status --porcelain` shows exactly the 5 intended files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1z6xSbShEHc4f17VzDbb

---
_Generated by [Claude Code](https://claude.ai/code/session_01TS1z6xSbShEHc4f17VzDbb)_