### PR TITLE
fix(model-builder): surface failed auto-build outcomes accurately (model-builder/t-029)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -491,6 +491,12 @@ jobs:
       - name: Model Builder commit asset-attachable guard contract
         run: npm run test:model-builder-commit-asset-attachable-guard
 
+      - name: Model Builder auto-build failed-summary guard checker self-test
+        run: npm run test:model-builder-auto-build-failed-summary-guard-selftest
+
+      - name: Model Builder auto-build failed-summary guard contract
+        run: npm run test:model-builder-auto-build-failed-summary-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -240,6 +240,8 @@
     "test:model-builder-async-fetch-staleness-coverage": "tsx utils/scripts/verifyModelBuilderAsyncFetchStalenessCoverage.ts",
     "test:model-builder-commit-asset-attachable-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitAssetAttachableGuard.test.ts",
     "test:model-builder-commit-asset-attachable-guard": "tsx utils/scripts/verifyModelBuilderCommitAssetAttachableGuard.ts",
+    "test:model-builder-auto-build-failed-summary-guard-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.test.ts",
+    "test:model-builder-auto-build-failed-summary-guard": "tsx utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1687,6 +1687,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     const items = [...state.run.items]
     let committed = 0
     let skipped = 0
+    let failed = 0
     try {
       for (const item of items) {
         if (state.run?.id !== runId) return
@@ -1697,14 +1698,30 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         const outcome = await autoBuildItem(item.id)
         if (outcome === 'committed') committed++
         else if (outcome === 'skipped') skipped++
+        else failed++
       }
       if (state.run?.id === runId) {
+        // A 'failed' outcome (a rejected commit — e.g. the ASSET_ONLY
+        // attachability re-check in commit.post.ts firing because the
+        // ArtImage's owner changed its visibility mid-run — a draft that
+        // came back empty, or any other real error autoBuildItem's own
+        // per-stage branches surface) is neither 'committed' nor 'skipped',
+        // so committed + skipped alone can undercount items.length with no
+        // explanation. Unconditionally reporting 'success' here (the
+        // pre-fix behavior) papered over that gap twice over: the count
+        // silently didn't add up, and this final call clobbers whatever
+        // 'error' tone an earlier failed item in this same loop already set
+        // via setStatus/setStatusForRun, replacing it with a misleading
+        // green banner. Surface failures in both the tone and the count.
         const skippedNote = skipped
           ? ` (${skipped} skipped — manual action in progress, retry after it finishes)`
           : ''
+        const failedNote = failed
+          ? ` (${failed} failed — see the item's own error for details)`
+          : ''
         setStatus(
-          'success',
-          `Auto-build finished: ${committed}/${items.length} committed${skippedNote}.`,
+          failed ? 'error' : 'success',
+          `Auto-build finished: ${committed}/${items.length} committed${failedNote}${skippedNote}.`,
         )
       }
     } finally {
@@ -1867,6 +1884,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     clearStatus()
     let committed = 0
     let skipped = 0
+    let failed = 0
     try {
       for (const item of items) {
         if (item.stages.COMMIT.status === 'approved') {
@@ -1876,13 +1894,23 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         const outcome = await autoBuildItem(item.id)
         if (outcome === 'committed') committed++
         else if (outcome === 'skipped') skipped++
+        else failed++
       }
+      // Same gap as autoBuildRun's identical summary (see its doc comment):
+      // a 'failed' outcome is neither committed nor skipped, so it must be
+      // counted and reflected in the tone here too, or a rejected commit
+      // (e.g. the ASSET_ONLY attachability re-check) inside this group
+      // reports as an unconditional green "success" with an unexplained gap
+      // between committed+skipped and items.length.
       const skippedNote = skipped
         ? ` (${skipped} skipped — manual action in progress, retry after it finishes)`
         : ''
+      const failedNote = failed
+        ? ` (${failed} failed — see the item's own error for details)`
+        : ''
       setStatus(
-        'success',
-        `Auto-built ${committed}/${items.length} in this group${skippedNote}.`,
+        failed ? 'error' : 'success',
+        `Auto-built ${committed}/${items.length} in this group${failedNote}${skippedNote}.`,
       )
     } finally {
       batchingOutputSingleton.release(outputKey)

--- a/utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.test.ts
@@ -1,0 +1,192 @@
+// /utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.test.ts
+//
+// Regression test for checkAutoBuildFailedSummaryGuard() in
+// verifyModelBuilderAutoBuildFailedSummaryGuard.ts (model-builder/t-029).
+// Exercises the real check against synthetic store-shaped fixtures covering:
+// the pre-fix shape (failed outcomes never tallied, tone always 'success'),
+// the fixed shape (both functions), a shape that tallies `failed` but never
+// reflects it in the tone, and both target functions being absent entirely.
+import assert from 'node:assert/strict'
+
+import { checkAutoBuildFailedSummaryGuard } from './verifyModelBuilderAutoBuildFailedSummaryGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function autoBuildRun(): Promise<void> {
+    const items = [...state.run.items]
+    let committed = 0
+    let skipped = 0
+    try {
+      for (const item of items) {
+        const outcome = await autoBuildItem(item.id)
+        if (outcome === 'committed') committed++
+        else if (outcome === 'skipped') skipped++
+      }
+      setStatus(
+        'success',
+        \`Auto-build finished: \${committed}/\${items.length} committed.\`,
+      )
+    } finally {
+      state.autoBuilding = false
+    }
+  }
+
+  async function batchAutoBuild(outputKey: string): Promise<void> {
+    const items = groupItems(outputKey)
+    let committed = 0
+    let skipped = 0
+    try {
+      for (const item of items) {
+        const outcome = await autoBuildItem(item.id)
+        if (outcome === 'committed') committed++
+        else if (outcome === 'skipped') skipped++
+      }
+      setStatus(
+        'success',
+        \`Auto-built \${committed}/\${items.length} in this group.\`,
+      )
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function autoBuildRun(): Promise<void> {
+    const items = [...state.run.items]
+    let committed = 0
+    let skipped = 0
+    let failed = 0
+    try {
+      for (const item of items) {
+        const outcome = await autoBuildItem(item.id)
+        if (outcome === 'committed') committed++
+        else if (outcome === 'skipped') skipped++
+        else failed++
+      }
+      setStatus(
+        failed ? 'error' : 'success',
+        \`Auto-build finished: \${committed}/\${items.length} committed.\`,
+      )
+    } finally {
+      state.autoBuilding = false
+    }
+  }
+
+  async function batchAutoBuild(outputKey: string): Promise<void> {
+    const items = groupItems(outputKey)
+    let committed = 0
+    let skipped = 0
+    let failed = 0
+    try {
+      for (const item of items) {
+        const outcome = await autoBuildItem(item.id)
+        if (outcome === 'committed') committed++
+        else if (outcome === 'skipped') skipped++
+        else failed++
+      }
+      setStatus(
+        failed ? 'error' : 'success',
+        \`Auto-built \${committed}/\${items.length} in this group.\`,
+      )
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+
+const TALLIED_BUT_TONE_IGNORED_FIXTURE = `
+  async function autoBuildRun(): Promise<void> {
+    const items = [...state.run.items]
+    let committed = 0
+    let skipped = 0
+    let failed = 0
+    try {
+      for (const item of items) {
+        const outcome = await autoBuildItem(item.id)
+        if (outcome === 'committed') committed++
+        else if (outcome === 'skipped') skipped++
+        else failed++
+      }
+      setStatus(
+        'success',
+        \`Auto-build finished: \${committed}/\${items.length} committed.\`,
+      )
+    } finally {
+      state.autoBuilding = false
+    }
+  }
+
+  async function batchAutoBuild(outputKey: string): Promise<void> {
+    const items = groupItems(outputKey)
+    let committed = 0
+    let skipped = 0
+    let failed = 0
+    try {
+      for (const item of items) {
+        const outcome = await autoBuildItem(item.id)
+        if (outcome === 'committed') committed++
+        else if (outcome === 'skipped') skipped++
+        else failed++
+      }
+      setStatus(
+        'success',
+        \`Auto-built \${committed}/\${items.length} in this group.\`,
+      )
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkAutoBuildFailedSummaryGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  2,
+  'expected the pre-fix shape (failed never tallied in either function) to ' +
+    `raise 2 errors, got ${buggyErrors.length}: ${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(buggyErrors.every((e) => e.includes('failed++')))
+
+const fixedErrors = checkAutoBuildFailedSummaryGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const talliedButIgnoredErrors = checkAutoBuildFailedSummaryGuard(
+  TALLIED_BUT_TONE_IGNORED_FIXTURE,
+)
+assert.equal(
+  talliedButIgnoredErrors.length,
+  2,
+  'expected the "tallied but tone still hardcoded success" shape to raise ' +
+    `2 errors, got ${talliedButIgnoredErrors.length}: ` +
+    JSON.stringify(talliedButIgnoredErrors),
+)
+assert.ok(
+  talliedButIgnoredErrors.every((e) => e.includes('does not switch tone')),
+)
+
+const missingErrors = checkAutoBuildFailedSummaryGuard(MISSING_FIXTURE)
+assert.equal(
+  missingErrors.length,
+  2,
+  'expected 2 "function not found" violations when both target functions are absent',
+)
+assert.ok(missingErrors[0]!.includes('autoBuildRun'))
+assert.ok(missingErrors[1]!.includes('batchAutoBuild'))
+
+console.log(
+  'Model Builder auto-build failed-summary guard checker verified: flags ' +
+    'untallied failures, flags a tallied-but-ignored tone, clears the fixed ' +
+    'shape, and flags both target functions being absent.',
+)

--- a/utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.ts
@@ -1,0 +1,117 @@
+// /utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.ts
+//
+// Regression guard (model-builder/t-029) -- autoBuildRun()/batchAutoBuild()'s
+// per-item loop tallies autoBuildItem()'s AutoBuildOutcome into `committed`
+// and `skipped` counters only, then unconditionally reports tone 'success'
+// with a "committed/total" count once the loop finishes. A 'failed' outcome
+// (a rejected commit -- e.g. the ASSET_ONLY branch's assertArtImageAttachable
+// re-check in commit.post.ts firing because the ArtImage's owner changed its
+// visibility mid-run -- an AI draft that came back empty, or any other real
+// error autoBuildItem's own per-stage branches surface) is neither
+// 'committed' nor 'skipped', so it silently vanished from both the count
+// (committed + skipped < items.length with no explanation) and the tone: the
+// final unconditional setStatus('success', ...) call also clobbers whatever
+// 'error' status an earlier failed item in the same loop already set via
+// setStatus/setStatusForRun, replacing it with a misleading green banner.
+//
+// This directly matters for the newly-added commit-time re-check: an
+// ASSET_ONLY item's attachability can now legitimately fail at COMMIT even
+// after every earlier gate passed, and auto-build/batch-auto-build are the
+// exact surfaces that walk an item through every stage — including COMMIT —
+// without a human reviewing each step, so a failure there most needs to be
+// reported accurately.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const TARGET_FUNCTIONS = ['autoBuildRun', 'batchAutoBuild'] as const
+
+// Checks the fix's exact shape against the full source text of a file
+// containing `autoBuildRun`/`batchAutoBuild`-named functions. Exported
+// (rather than only exercised via main()) so the self-test below can run it
+// against synthetic buggy/fixed fixtures without touching the real store file.
+export function checkAutoBuildFailedSummaryGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+
+  for (const name of TARGET_FUNCTIONS) {
+    const fn = functions.find((f) => f.name === name)
+    if (!fn) {
+      errors.push(
+        `Could not find a function named ${name}() -- has it been renamed, ` +
+          'removed, or inlined? If so, this guard (and the bug it protects ' +
+          'against) needs to move with it.',
+      )
+      continue
+    }
+
+    const tracksFailed = /\bfailed\s*\+\+/.test(fn.body)
+    if (!tracksFailed) {
+      errors.push(
+        `${name}() does not tally a 'failed' outcome from autoBuildItem() ` +
+          'into its own counter (expected a `failed++` alongside `committed++`' +
+          ' / `skipped++`). Without it, a rejected commit is invisible in ' +
+          "this function's final summary.",
+      )
+      continue
+    }
+
+    const finalSetStatusMatch = fn.body.match(
+      /setStatus\(\s*([\s\S]*?),\s*`[^`]*`\s*,?\s*\)/,
+    )
+    if (!finalSetStatusMatch) {
+      errors.push(
+        `${name}() does not appear to call setStatus(...) with its final ` +
+          'summary message.',
+      )
+      continue
+    }
+    const toneExpression = finalSetStatusMatch[1]!
+    const toneReflectsFailure =
+      /failed\s*\?\s*'error'\s*:\s*'success'/.test(toneExpression) ||
+      (/failed/.test(toneExpression) && /'error'/.test(toneExpression))
+    if (!toneReflectsFailure) {
+      errors.push(
+        `${name}()'s final setStatus(...) call does not switch tone to ` +
+          "'error' when failed > 0 -- it will report a plain 'success' " +
+          'banner even when a real commit/draft/generate failure occurred ' +
+          'in this run/group.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkAutoBuildFailedSummaryGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder auto-build failed-summary guard contract failed in ' +
+        'modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder auto-build failed-summary guard contract passed: ' +
+      'autoBuildRun() and batchAutoBuild() both tally failed outcomes and ' +
+      'report them (with an error tone) in their final summary.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What

`autoBuildRun()`/`batchAutoBuild()` in `stores/modelBuilderStore.ts` tallied `autoBuildItem()`'s `AutoBuildOutcome` into `committed`/`skipped` counters only. A `'failed'` outcome was neither committed nor skipped, so it silently vanished from the summary:

- `committed + skipped` could undercount `items.length` with no explanation.
- The final unconditional `setStatus('success', ...)` call clobbered whatever `'error'` tone an earlier failed item in the same loop had already set (via `setStatus`/`setStatusForRun`), replacing it with a misleading green "success" banner.

## Why this matters now

This directly follows up on the previous model-builder/t-029 cycle (#1902), which added a commit-time `assertArtImageAttachable` re-check to the ASSET_ONLY branch of `commit.post.ts`. That re-check can now legitimately reject a commit (e.g. the ArtImage's owner flipped it private mid-run). Auto-build and batch-auto-build are exactly the surfaces that walk an item through every stage — including COMMIT — without a human reviewing each step, so a rejection there is the case that most needs to be reported accurately, and previously wasn't.

## Fix

Tally a `failed` counter alongside `committed`/`skipped` in both `autoBuildRun()` and `batchAutoBuild()`, and switch the final `setStatus(...)` tone to `'error'` (with a failed-count note) whenever `failed > 0`.

## Guard

Added `utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.ts` + `.test.ts` following the established narrow-textual-checker convention (see the ~35 other `verifyModelBuilder*` guards), wired into `package.json`'s `test:model-builder-*` group and `.github/workflows/contract-tests.yml`.

## Verification

- New guard + self-test pass.
- All 73 `test:model-builder-*` npm scripts pass (71 pre-existing + 2 new, no regression).
- `vue-tsc --noEmit` exits 0 repo-wide.
- eslint clean on touched files (2 pre-existing `no-empty` errors at unrelated lines 204/211 confirmed present verbatim on `origin/main` before this change).
- `prettier --check` clean on the new files; `modelBuilderStore.ts`'s pre-existing formatting drift (present on `main` before this change) confirmed untouched by this diff's added lines via a full-file prettier diff.
- `git status --porcelain` showed exactly the 5 intended files.

Refs model-builder/t-029.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8WSQC14H8YgLHSP9WXvp8)_