### PR TITLE
model-builder: at-a-glance per-item batch/auto-build status indicator

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -497,6 +497,12 @@ jobs:
       - name: Model Builder auto-build failed-summary guard contract
         run: npm run test:model-builder-auto-build-failed-summary-guard
 
+      - name: Model Builder auto-build outcome-persistence guard checker self-test
+        run: npm run test:model-builder-auto-build-outcome-persistence-guard-selftest
+
+      - name: Model Builder auto-build outcome-persistence guard contract
+        run: npm run test:model-builder-auto-build-outcome-persistence-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/components/model-builder/model-builder-batch-editor.vue
+++ b/components/model-builder/model-builder-batch-editor.vue
@@ -182,7 +182,15 @@
           >
             {{ item.label }}
           </span>
-          <span class="badge badge-xs" :class="commitBadge(item)">
+          <span
+            class="badge badge-xs"
+            :class="commitBadge(item)"
+            :title="
+              autoBuildFailed(item)
+                ? (item.error ?? 'Auto-build failed for this item.')
+                : undefined
+            "
+          >
             {{ itemStageSummary(item) }}
           </span>
           <button
@@ -292,15 +300,29 @@ function approvedCount(item: BuildItem): number {
   ).length
 }
 
+// A failed auto-build reverts its stage back to 'ready' (see autoBuildItem's
+// per-stage branches in modelBuilderStore.ts) -- indistinguishable from an
+// item that was simply never attempted, unless lastAutoBuildOutcome is also
+// checked. Committed always wins over a stale 'failed': the single-item
+// "Execute commit" button can fix and commit an item without ever going back
+// through autoBuildItem, which would otherwise leave this reading a failure
+// that's no longer true.
+function autoBuildFailed(item: BuildItem): boolean {
+  return (
+    item.stages.COMMIT.status !== 'approved' &&
+    item.lastAutoBuildOutcome === 'failed'
+  )
+}
+
 function itemStageSummary(item: BuildItem): string {
-  return item.stages.COMMIT.status === 'approved'
-    ? 'committed'
-    : `${approvedCount(item)}/4`
+  if (item.stages.COMMIT.status === 'approved') return 'committed'
+  if (autoBuildFailed(item)) return 'failed'
+  return `${approvedCount(item)}/4`
 }
 
 function commitBadge(item: BuildItem): string {
-  return item.stages.COMMIT.status === 'approved'
-    ? 'badge-success'
-    : 'badge-ghost'
+  if (item.stages.COMMIT.status === 'approved') return 'badge-success'
+  if (autoBuildFailed(item)) return 'badge-error'
+  return 'badge-ghost'
 }
 </script>

--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -5,9 +5,19 @@
       <div>
         <h3 class="text-base font-black text-base-content">3. Build run</h3>
         <p class="mt-1 text-xs text-base-content/60">
-          <span class="font-bold text-base-content">{{ run?.sourceLabel }}</span>
-          · {{ recipeLabel }} ·
-          {{ store.runProgress.committed }}/{{ store.runProgress.total }} committed
+          <span class="font-bold text-base-content">{{
+            run?.sourceLabel
+          }}</span>
+          · {{ recipeLabel }} · {{ store.runProgress.committed }}/{{
+            store.runProgress.total
+          }}
+          committed
+          <span
+            v-if="store.runProgress.failed"
+            class="font-semibold text-error"
+          >
+            · {{ store.runProgress.failed }} failed
+          </span>
         </p>
       </div>
       <div class="flex shrink-0 items-center gap-1">
@@ -101,12 +111,23 @@
             <td class="max-w-[10rem] p-0 text-xs font-semibold">
               <button
                 type="button"
-                class="w-full truncate rounded-lg px-3 py-2 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-primary"
+                class="flex w-full items-center gap-1 truncate rounded-lg px-3 py-2 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-primary"
                 :aria-pressed="item.id === selectedItemId"
-                :aria-label="`Select ${item.label}`"
+                :aria-label="
+                  autoBuildFailed(item)
+                    ? `Select ${item.label} — auto-build failed for this item`
+                    : `Select ${item.label}`
+                "
                 @click.stop="selectedItemId = item.id"
               >
-                {{ item.label }}
+                <Icon
+                  v-if="autoBuildFailed(item)"
+                  name="kind-icon:warning"
+                  class="h-3 w-3 shrink-0 text-error"
+                  :title="item.error ?? 'Auto-build failed for this item.'"
+                  aria-hidden="true"
+                />
+                <span class="truncate">{{ item.label }}</span>
               </button>
             </td>
             <td
@@ -160,7 +181,7 @@
 import { computed, ref } from 'vue'
 import { useModelBuilderStore } from '@/stores/modelBuilderStore'
 import { BUILD_STAGES, getRecipe } from '@/stores/helpers/modelBuilderRecipes'
-import type { StageStatus } from '@/stores/modelBuilderStore'
+import type { BuildItem, StageStatus } from '@/stores/modelBuilderStore'
 
 const store = useModelBuilderStore()
 const stages = BUILD_STAGES
@@ -243,6 +264,22 @@ const selectedGroup = computed(() =>
   ),
 )
 const showBatch = computed(() => (selectedGroup.value?.items.length ?? 0) > 1)
+
+// A failed auto-build reverts its stage back to 'ready' (see autoBuildItem's
+// per-stage branches in modelBuilderStore.ts) -- indistinguishable in the
+// matrix below from an item that was simply never attempted, unless
+// lastAutoBuildOutcome is also checked. Committed always wins over a stale
+// 'failed': the single-item "Execute commit" button can fix and commit an
+// item without ever going back through autoBuildItem, which would otherwise
+// leave this reading a failure that's no longer true. Mirrors the store's
+// own runProgress.failed and model-builder-batch-editor.vue's identical
+// helper -- all three must agree on what counts as "failed right now".
+function autoBuildFailed(item: BuildItem): boolean {
+  return (
+    item.stages.COMMIT.status !== 'approved' &&
+    item.lastAutoBuildOutcome === 'failed'
+  )
+}
 
 function statusClass(status: StageStatus): string {
   switch (status) {

--- a/package.json
+++ b/package.json
@@ -242,6 +242,8 @@
     "test:model-builder-commit-asset-attachable-guard": "tsx utils/scripts/verifyModelBuilderCommitAssetAttachableGuard.ts",
     "test:model-builder-auto-build-failed-summary-guard-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.test.ts",
     "test:model-builder-auto-build-failed-summary-guard": "tsx utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.ts",
+    "test:model-builder-auto-build-outcome-persistence-guard-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildOutcomePersistenceGuard.test.ts",
+    "test:model-builder-auto-build-outcome-persistence-guard": "tsx utils/scripts/verifyModelBuilderAutoBuildOutcomePersistenceGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -52,6 +52,21 @@ export type StageStatus =
   | 'rejected' // user rejected — needs a redo
   | 'stale' // an upstream edit invalidated this stage
 
+// 'skipped' means auto-build never attempted the item this call because
+// another in-flight action (itself or a manual single-stage action) owns
+// it right now -- the item is still buildable, just not yet. 'failed'
+// means auto-build attempted a stage and it did not succeed (or the item
+// isn't eligible, e.g. asset-only with art off). Exported (and mirrored onto
+// BuildItem.lastAutoBuildOutcome below) so both the aggregate tallies in
+// autoBuildRun/batchAutoBuild AND the per-item UI (model-builder-progress-
+// matrix.vue) can tell a busy-but-fine item apart from a broken one, and a
+// broken item apart from one that simply hasn't been attempted yet (t-029:
+// previously this was only visible per-item inside item.error, which several
+// of autoBuildItem's own 'failed' branches — an empty AI draft, a stage gone
+// stale mid-run, an ineligible asset-only item — never set, and a run-wide
+// scan had no per-item signal at all short of opening each item's panel).
+export type AutoBuildOutcome = 'committed' | 'skipped' | 'failed'
+
 export interface StageState {
   status: StageStatus
   note?: string
@@ -86,6 +101,17 @@ export interface BuildItem {
   targetType: string | null
   targetId: number | null
   error: string | null
+  // Outcome of this item's most recent pass through autoBuildRun() or
+  // batchAutoBuild() (not the single-item "Auto" button in
+  // model-builder-item-panel.vue -- that button's own panel already shows
+  // the failure directly, so it doesn't need to write here too). null before
+  // any run/batch has touched this item. Ephemeral -- not persisted
+  // server-side, like queueState/artJobId; a page refresh drops it, which is
+  // fine since it only describes "what just happened in this session's last
+  // pass," not durable item state. UI should prefer the item's own current
+  // stage status (e.g. COMMIT approved) over a stale 'failed' here when the
+  // two disagree — see model-builder-progress-matrix.vue's autoBuildFailed.
+  lastAutoBuildOutcome: AutoBuildOutcome | null
 }
 
 export interface BuildRun {
@@ -311,6 +337,7 @@ function adaptItem(server: ServerItem): BuildItem {
     targetType: server.targetType ?? null,
     targetId: server.targetId ?? null,
     error: server.error ?? null,
+    lastAutoBuildOutcome: null,
   }
 }
 
@@ -432,12 +459,23 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   )
 
   const runProgress = computed(() => {
-    if (!state.run) return { total: 0, committed: 0 }
+    if (!state.run) return { total: 0, committed: 0, failed: 0 }
     const total = state.run.items.length
     const committed = state.run.items.filter(
       (item) => item.stages.COMMIT.status === 'approved',
     ).length
-    return { total, committed }
+    // Committed always wins over a stale 'failed' outcome — an item can
+    // fail once, then get fixed and committed by hand without ever going
+    // through autoBuildItem again (e.g. the single-stage "Execute commit"
+    // button), which would otherwise leave lastAutoBuildOutcome pointing at
+    // a failure that's no longer true. Mirrors model-builder-progress-
+    // matrix.vue's autoBuildFailed, which the same logic must agree with.
+    const failed = state.run.items.filter(
+      (item) =>
+        item.stages.COMMIT.status !== 'approved' &&
+        item.lastAutoBuildOutcome === 'failed',
+    ).length
+    return { total, committed, failed }
   })
 
   function setStatus(tone: 'success' | 'error', message: string): void {
@@ -1521,14 +1559,9 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     state.includeArt = typeof value === 'boolean' ? value : !state.includeArt
   }
 
-  // 'skipped' means auto-build never attempted the item this call because
-  // another in-flight action (itself or a manual single-stage action) owns
-  // it right now -- the item is still buildable, just not yet. 'failed'
-  // means auto-build attempted a stage and it did not succeed (or the item
-  // isn't eligible, e.g. asset-only with art off). Callers that tally
-  // progress across many items (autoBuildRun, batchAutoBuild) need this
-  // distinction so a busy-but-fine item doesn't read the same as a broken one.
-  type AutoBuildOutcome = 'committed' | 'skipped' | 'failed'
+  // AutoBuildOutcome is declared near StageStatus (top of file) and exported
+  // — autoBuildRun/batchAutoBuild below now also mirror it per-item onto
+  // BuildItem.lastAutoBuildOutcome, not just tally it into their own summary.
 
   // Mirrors model-builder-item-panel.vue's per-item isManualActionInFlight
   // computed (generating / queued / committing / drafting any field) so a
@@ -1693,9 +1726,23 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         if (state.run?.id !== runId) return
         if (item.stages.COMMIT.status === 'approved') {
           committed++
+          // Already committed before this pass touched it -- not routed
+          // through autoBuildItem, so it wouldn't otherwise get a fresh
+          // 'committed' outcome and could keep showing a stale 'failed'
+          // badge from an earlier attempt.
+          item.lastAutoBuildOutcome = 'committed'
           continue
         }
         const outcome = await autoBuildItem(item.id)
+        // Mirrored onto the item itself (not just tallied into this run's
+        // aggregate counters) so model-builder-progress-matrix.vue's
+        // per-item badge has something to read after the run finishes --
+        // previously the only per-item failure signal was item.error, which
+        // several of autoBuildItem's own 'failed' branches (an empty AI
+        // draft, a stage gone stale mid-run, an ineligible asset-only item)
+        // never set, and there was no per-item signal at all short of
+        // opening each item's own panel (t-029).
+        item.lastAutoBuildOutcome = outcome
         if (outcome === 'committed') committed++
         else if (outcome === 'skipped') skipped++
         else failed++
@@ -1889,9 +1936,17 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       for (const item of items) {
         if (item.stages.COMMIT.status === 'approved') {
           committed++
+          // See autoBuildRun's identical branch: keep the badge from
+          // showing a stale 'failed' for an item already committed before
+          // this pass reached it.
+          item.lastAutoBuildOutcome = 'committed'
           continue
         }
         const outcome = await autoBuildItem(item.id)
+        // See autoBuildRun's identical line -- mirrors the outcome onto the
+        // item itself for model-builder-progress-matrix.vue's per-item
+        // badge and model-builder-batch-editor.vue's own per-item badge.
+        item.lastAutoBuildOutcome = outcome
         if (outcome === 'committed') committed++
         else if (outcome === 'skipped') skipped++
         else failed++

--- a/utils/scripts/verifyModelBuilderAutoBuildOutcomePersistenceGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildOutcomePersistenceGuard.test.ts
@@ -1,0 +1,204 @@
+// /utils/scripts/verifyModelBuilderAutoBuildOutcomePersistenceGuard.test.ts
+//
+// Regression test for checkAutoBuildOutcomePersistenceGuard() in
+// verifyModelBuilderAutoBuildOutcomePersistenceGuard.ts (model-builder/t-029).
+// Exercises the real check against synthetic store-shaped fixtures covering:
+// the pre-fix shape (outcome tallied but never mirrored onto the item,
+// pre-committed items never marked either), the fixed shape (both
+// functions), a shape that persists the attempted outcome but forgets the
+// pre-committed branch, and both target functions being absent entirely.
+import assert from 'node:assert/strict'
+
+import { checkAutoBuildOutcomePersistenceGuard } from './verifyModelBuilderAutoBuildOutcomePersistenceGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function autoBuildRun(): Promise<void> {
+    const items = [...state.run.items]
+    let committed = 0
+    let skipped = 0
+    let failed = 0
+    try {
+      for (const item of items) {
+        if (item.stages.COMMIT.status === 'approved') {
+          committed++
+          continue
+        }
+        const outcome = await autoBuildItem(item.id)
+        if (outcome === 'committed') committed++
+        else if (outcome === 'skipped') skipped++
+        else failed++
+      }
+    } finally {
+      state.autoBuilding = false
+    }
+  }
+
+  async function batchAutoBuild(outputKey: string): Promise<void> {
+    const items = groupItems(outputKey)
+    let committed = 0
+    let skipped = 0
+    let failed = 0
+    try {
+      for (const item of items) {
+        if (item.stages.COMMIT.status === 'approved') {
+          committed++
+          continue
+        }
+        const outcome = await autoBuildItem(item.id)
+        if (outcome === 'committed') committed++
+        else if (outcome === 'skipped') skipped++
+        else failed++
+      }
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function autoBuildRun(): Promise<void> {
+    const items = [...state.run.items]
+    let committed = 0
+    let skipped = 0
+    let failed = 0
+    try {
+      for (const item of items) {
+        if (item.stages.COMMIT.status === 'approved') {
+          committed++
+          item.lastAutoBuildOutcome = 'committed'
+          continue
+        }
+        const outcome = await autoBuildItem(item.id)
+        item.lastAutoBuildOutcome = outcome
+        if (outcome === 'committed') committed++
+        else if (outcome === 'skipped') skipped++
+        else failed++
+      }
+    } finally {
+      state.autoBuilding = false
+    }
+  }
+
+  async function batchAutoBuild(outputKey: string): Promise<void> {
+    const items = groupItems(outputKey)
+    let committed = 0
+    let skipped = 0
+    let failed = 0
+    try {
+      for (const item of items) {
+        if (item.stages.COMMIT.status === 'approved') {
+          committed++
+          item.lastAutoBuildOutcome = 'committed'
+          continue
+        }
+        const outcome = await autoBuildItem(item.id)
+        item.lastAutoBuildOutcome = outcome
+        if (outcome === 'committed') committed++
+        else if (outcome === 'skipped') skipped++
+        else failed++
+      }
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+
+const MISSING_PRECOMMITTED_FIXTURE = `
+  async function autoBuildRun(): Promise<void> {
+    const items = [...state.run.items]
+    let committed = 0
+    let skipped = 0
+    let failed = 0
+    try {
+      for (const item of items) {
+        if (item.stages.COMMIT.status === 'approved') {
+          committed++
+          continue
+        }
+        const outcome = await autoBuildItem(item.id)
+        item.lastAutoBuildOutcome = outcome
+        if (outcome === 'committed') committed++
+        else if (outcome === 'skipped') skipped++
+        else failed++
+      }
+    } finally {
+      state.autoBuilding = false
+    }
+  }
+
+  async function batchAutoBuild(outputKey: string): Promise<void> {
+    const items = groupItems(outputKey)
+    let committed = 0
+    let skipped = 0
+    let failed = 0
+    try {
+      for (const item of items) {
+        if (item.stages.COMMIT.status === 'approved') {
+          committed++
+          continue
+        }
+        const outcome = await autoBuildItem(item.id)
+        item.lastAutoBuildOutcome = outcome
+        if (outcome === 'committed') committed++
+        else if (outcome === 'skipped') skipped++
+        else failed++
+      }
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkAutoBuildOutcomePersistenceGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  4,
+  'expected the pre-fix shape (neither assignment present, in either ' +
+    `function) to raise 4 errors, got ${buggyErrors.length}: ` +
+    JSON.stringify(buggyErrors),
+)
+
+const fixedErrors = checkAutoBuildOutcomePersistenceGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingPrecommittedErrors = checkAutoBuildOutcomePersistenceGuard(
+  MISSING_PRECOMMITTED_FIXTURE,
+)
+assert.equal(
+  missingPrecommittedErrors.length,
+  2,
+  'expected the "attempted outcome persisted, pre-committed branch not" ' +
+    `shape to raise 2 errors, got ${missingPrecommittedErrors.length}: ` +
+    JSON.stringify(missingPrecommittedErrors),
+)
+assert.ok(
+  missingPrecommittedErrors.every((e) => e.includes('already committed')),
+)
+
+const missingErrors = checkAutoBuildOutcomePersistenceGuard(MISSING_FIXTURE)
+assert.equal(
+  missingErrors.length,
+  2,
+  'expected 2 "function not found" violations when both target functions are absent',
+)
+assert.ok(missingErrors[0]!.includes('autoBuildRun'))
+assert.ok(missingErrors[1]!.includes('batchAutoBuild'))
+
+console.log(
+  'Model Builder auto-build outcome-persistence guard checker verified: ' +
+    'flags a non-persisted attempted outcome, flags a missing pre-committed ' +
+    'branch assignment, clears the fixed shape, and flags both target ' +
+    'functions being absent.',
+)

--- a/utils/scripts/verifyModelBuilderAutoBuildOutcomePersistenceGuard.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildOutcomePersistenceGuard.ts
@@ -1,0 +1,111 @@
+// /utils/scripts/verifyModelBuilderAutoBuildOutcomePersistenceGuard.ts
+//
+// Regression guard (model-builder/t-029) -- autoBuildRun()/batchAutoBuild()
+// tally autoBuildItem()'s AutoBuildOutcome into run-wide committed/skipped/
+// failed counters (see verifyModelBuilderAutoBuildFailedSummaryGuard.ts), but
+// that summary only ever reached the UI as one aggregate toast at the end of
+// a run/group. There was no per-item signal at all short of opening each
+// item's own panel -- a large auto-build run with a handful of failures
+// among dozens of successes looked identical, at a glance, to a run that
+// fully succeeded, unless you clicked into every item to check.
+//
+// The fix has both loops mirror each item's outcome onto its own
+// `item.lastAutoBuildOutcome` field (both for the outcome autoBuildItem()
+// returns, and for the "already committed before this pass reached it"
+// branch that skips calling autoBuildItem() at all) so
+// model-builder-progress-matrix.vue and model-builder-batch-editor.vue can
+// render a per-item badge without their own parallel bookkeeping. This
+// guard checks both assignments stay in place in both functions: if a
+// future refactor drops either, the aggregate counters keep working (the
+// guard above stays green) while the per-item UI silently goes stale/blank
+// again.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const TARGET_FUNCTIONS = ['autoBuildRun', 'batchAutoBuild'] as const
+
+// Checks the fix's exact shape against the full source text of a file
+// containing `autoBuildRun`/`batchAutoBuild`-named functions. Exported
+// (rather than only exercised via main()) so the self-test below can run it
+// against synthetic buggy/fixed fixtures without touching the real store file.
+export function checkAutoBuildOutcomePersistenceGuard(
+  content: string,
+): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+
+  for (const name of TARGET_FUNCTIONS) {
+    const fn = functions.find((f) => f.name === name)
+    if (!fn) {
+      errors.push(
+        `Could not find a function named ${name}() -- has it been renamed, ` +
+          'removed, or inlined? If so, this guard (and the per-item outcome ' +
+          'persistence it protects) needs to move with it.',
+      )
+      continue
+    }
+
+    const persistsAttemptedOutcome =
+      /item\.lastAutoBuildOutcome\s*=\s*outcome\b/.test(fn.body)
+    if (!persistsAttemptedOutcome) {
+      errors.push(
+        `${name}() does not assign the outcome of autoBuildItem() onto ` +
+          "the item's own `lastAutoBuildOutcome` field (expected something " +
+          'like `item.lastAutoBuildOutcome = outcome`). Without it, ' +
+          "model-builder-progress-matrix.vue's and model-builder-batch-" +
+          "editor.vue's per-item failed/committed badges have no per-item " +
+          'signal to read once this run/batch finishes.',
+      )
+    }
+
+    const persistsPreCommittedOutcome =
+      /stages\.COMMIT\.status === 'approved'\)\s*\{[\s\S]{0,600}?item\.lastAutoBuildOutcome\s*=\s*'committed'/.test(
+        fn.body,
+      )
+    if (!persistsPreCommittedOutcome) {
+      errors.push(
+        `${name}()'s "already committed before this pass" branch does not ` +
+          "set item.lastAutoBuildOutcome = 'committed'. Without it, an " +
+          'item committed before this run/batch reached it can keep ' +
+          "showing a stale 'failed' badge from an earlier attempt, since " +
+          'that branch `continue`s without ever calling autoBuildItem().',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkAutoBuildOutcomePersistenceGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder auto-build outcome-persistence guard contract failed ' +
+        'in modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder auto-build outcome-persistence guard contract passed: ' +
+      'autoBuildRun() and batchAutoBuild() both mirror per-item outcomes ' +
+      '(attempted and pre-committed) onto item.lastAutoBuildOutcome.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Context

Fourth cycle of `model-builder/t-029` "Polish and upgrade Model Builder front-end surface" today. Three earlier cycles fixed real backend bugs, including `autoBuildRun()`/`batchAutoBuild()` silently reporting `success` even when items had genuinely `failed` (now tallies `failed` and shows an `error` tone banner). That fix flagged a concrete front-end gap: the failure state is only visible if you click into that specific item's own panel — there's no at-a-glance indicator across the whole run while it's in progress or after it completes. This PR closes that gap.

## What changed

**Store (`stores/modelBuilderStore.ts`)** — found the store genuinely didn't expose enough per-item detail: `item.error` is only set by two of `autoBuildItem()`'s several `'failed'` branches (generate/commit failures); an empty AI draft, a stage gone stale mid-run, and an ineligible asset-only item all return `'failed'` without ever touching `item.error`. So a per-item badge built purely on `item.error` would miss most failure causes.

- Added `BuildItem.lastAutoBuildOutcome: AutoBuildOutcome | null`, mirrored by `autoBuildRun()`/`batchAutoBuild()` onto each item as they process it (including the "already committed before this pass reached it" branch, which previously left no trace at all).
- Extended `runProgress` with a `failed` count. Committed always wins over a stale `'failed'`, since an item can be fixed and committed by hand (e.g. the single-item "Execute commit" button) without ever going back through `autoBuildItem`.
- `AutoBuildOutcome` moved next to `StageStatus` and exported, since it's now part of the public `BuildItem` shape, not just an internal tally type.

This is the smallest change that unblocks the UI — persistence happens only in the two batch/run loops (not the single-item "Auto" button, whose own panel already shows the failure directly).

**UI (`components/model-builder/`)**
- `model-builder-progress-matrix.vue` (the whole-run overview grid): failed count added to the run summary line, plus a warning icon on any item row whose last auto-build attempt failed, with the item's error as a tooltip.
- `model-builder-batch-editor.vue` (the per-group batch editor, used by `batchAutoBuild`): the existing per-item badge now reads `failed` (`badge-error`) instead of falling back to the bare `N/4` stage count.

Both compute "failed" identically: `COMMIT` not yet approved AND `lastAutoBuildOutcome === 'failed'`.

**Regression guard**: `utils/scripts/verifyModelBuilderAutoBuildOutcomePersistenceGuard.ts` (+ self-test), wired into `package.json` and `contract-tests.yml`, following this repo's existing `verifyModelBuilder*Guard.ts`/`.test.ts` convention. Checks that `autoBuildRun()`/`batchAutoBuild()` keep mirroring the outcome onto `item.lastAutoBuildOutcome` in both the attempted and pre-committed branches, so a future refactor can't silently regress the per-item UI while the existing aggregate-summary guard stays green.

## Scope

Display/UI only — no store business logic altered beyond exposing the per-item status the UI needs, per the task's guidance.

## Verification

- All 75 `test:model-builder-*` npm scripts pass (73 pre-existing + 2 new).
- `vue-tsc --noEmit` exits 0 repo-wide.
- `eslint`/`prettier --check` clean on every touched file **except** two pre-existing issues in `stores/modelBuilderStore.ts` unrelated to this diff (confirmed present in `main` before this change, at the same code, just different line numbers): two `no-empty` `catch {}` blocks (a pervasive pattern already used in 10+ other store files repo-wide) and some pre-existing `prettier` formatting drift elsewhere in the same file/component (verified line-by-line that none of it overlaps my added lines). Left both out of scope rather than drive-by-fixing unrelated pre-existing debt.
- `git status --porcelain` confirmed to show exactly the 7 intended files before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01V11Gay32gXRGDe88rsWJmr)_