### PR TITLE
fix(model-builder): stop silently truncating multi-line prose fields on commit

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -503,6 +503,12 @@ jobs:
       - name: Model Builder auto-build outcome-persistence guard contract
         run: npm run test:model-builder-auto-build-outcome-persistence-guard
 
+      - name: Model Builder field-blob continuation guard self-test
+        run: npm run test:model-builder-field-blob-continuation-guard-selftest
+
+      - name: Model Builder field-blob continuation guard contract
+        run: npm run test:model-builder-field-blob-continuation-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -244,6 +244,8 @@
     "test:model-builder-auto-build-failed-summary-guard": "tsx utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.ts",
     "test:model-builder-auto-build-outcome-persistence-guard-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildOutcomePersistenceGuard.test.ts",
     "test:model-builder-auto-build-outcome-persistence-guard": "tsx utils/scripts/verifyModelBuilderAutoBuildOutcomePersistenceGuard.ts",
+    "test:model-builder-field-blob-continuation-guard-selftest": "tsx utils/scripts/verifyModelBuilderFieldBlobContinuationGuard.test.ts",
+    "test:model-builder-field-blob-continuation-guard": "tsx utils/scripts/verifyModelBuilderFieldBlobContinuationGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/server/api/model-builder/items/[id]/commit.post.ts
+++ b/server/api/model-builder/items/[id]/commit.post.ts
@@ -20,6 +20,7 @@ import { assertArtImageAttachable } from '../../relations'
 import {
   CREATE_TARGETS,
   fieldSpecFor,
+  parseFieldLines as splitFieldBlob,
 } from '~/stores/helpers/modelBuilderFields'
 import { BUILD_STAGES } from '~/stores/helpers/modelBuilderRecipes'
 import { syncCharacterFacetsInTransaction } from '~/server/utils/characterFacetSync'
@@ -70,17 +71,24 @@ const NUMERIC_FIELDS: Partial<Record<SourceType, Set<string>>> = {
   Scenario: new Set(['difficulty']),
 }
 
+// Delegates the actual line-splitting to the shared, schema-aware splitter
+// in modelBuilderFields.ts (used by the client too) rather than maintaining
+// a second hand-written copy of the same "key: value" parsing here -- two
+// copies of this exact logic previously drifted in lockstep only by luck,
+// and neither one preserved a multi-line prose value past its first line
+// (see parseFieldLines' doc comment there for the full story). modelType is
+// the item's own resolved target model (CREATE_TARGETS[outputKey] for
+// CREATE, the run's sourceType for UPDATE/ASSET_ONLY) so a stray colon
+// inside prose text isn't mistaken for a new field boundary.
 function parseFieldLines(
   raw: string | null | undefined,
+  modelType: SourceType,
 ): Record<string, string> {
   const map: Record<string, string> = {}
   if (!raw) return map
-  for (const line of raw.split('\n')) {
-    const idx = line.indexOf(':')
-    if (idx === -1) continue
-    const key = line.slice(0, idx).trim().toLowerCase()
-    const value = line.slice(idx + 1).trim()
-    if (key && value) map[key] = value
+  for (const { key, value } of splitFieldBlob(raw, modelType)) {
+    const normalizedKey = key.toLowerCase()
+    if (normalizedKey && value) map[normalizedKey] = value
   }
   return map
 }
@@ -759,7 +767,15 @@ export default defineEventHandler(async (event) => {
     }
     const sourceId = item.Run.sourceId
     const text = (item.pitch || item.fieldsDraft || '').trim()
-    const fieldMap = parseFieldLines(item.fieldsDraft)
+    // ASSET_ONLY/UPDATE write onto the run's own source record; CREATE writes
+    // a different, mapped target model instead (see the `plan` branches
+    // below). Resolved here too so the FIELDS_AND_PROMPTS blob is split
+    // against the model it's actually destined for.
+    const fieldModelType: SourceType =
+      item.action === 'CREATE'
+        ? (CREATE_TARGETS[item.outputKey] ?? sourceType)
+        : sourceType
+    const fieldMap = parseFieldLines(item.fieldsDraft, fieldModelType)
     // Every CREATE target's field spec declares a required 'name' or 'title'
     // line (see MODEL_FIELDS in modelBuilderFields.ts) that the batch editor
     // and per-item panel both surface as the record's actual name/title. Honor

--- a/stores/helpers/modelBuilderFields.ts
+++ b/stores/helpers/modelBuilderFields.ts
@@ -249,33 +249,107 @@ export interface FieldLine {
   value: string
 }
 
-export function parseFieldLines(blob: string): FieldLine[] {
-  return blob
-    .split('\n')
-    .map((line): FieldLine | null => {
-      const idx = line.indexOf(':')
-      if (idx === -1) return null
-      const key = line.slice(0, idx).trim()
-      if (!key) return null
-      return { key, value: line.slice(idx + 1).trim() }
-    })
-    .filter((line): line is FieldLine => line !== null)
+// Whether `line` opens a new "key: value" field. When `modelType` is given,
+// only a key present in that model's own field spec counts as a field start
+// -- so a stray colon inside a multi-line prose value (e.g. "Note: it was
+// raining." as the second sentence of a backstory) can't be mistaken for a
+// new field. When `modelType` is omitted, any non-empty key before the first
+// colon counts (the old, fully-generic behavior).
+function isFieldStart(
+  line: string,
+  knownKeys: Set<string> | null,
+): { key: string; rest: string } | null {
+  const idx = line.indexOf(':')
+  if (idx === -1) return null
+  const key = line.slice(0, idx).trim()
+  if (!key) return null
+  if (knownKeys && !knownKeys.has(key)) return null
+  return { key, rest: line.slice(idx + 1).trim() }
 }
 
-export function readFieldLine(blob: string, key: string): string {
-  return parseFieldLines(blob).find((line) => line.key === key)?.value ?? ''
+function knownKeysFor(modelType?: string): Set<string> | null {
+  if (!modelType) return null
+  const spec = fieldSpecFor(modelType)
+  return spec.length ? new Set(spec.map((field) => field.key)) : null
 }
 
-export function setFieldLine(blob: string, key: string, value: string): string {
-  const lines = blob.split('\n')
+// Splits a FIELDS_AND_PROMPTS blob ("key: value" lines, one per field) into
+// structured lines. A line that doesn't open a recognized field is treated
+// as a continuation of the previous field's value rather than being dropped.
+//
+// This matters because several fields are declared `prose: true` (backstory,
+// personality, quirks, description, effect, flavorText, botIntro, userIntro,
+// prompt, pitch, goal, intros -- see MODEL_FIELDS above) specifically to
+// allow long, multi-paragraph text (commit.post.ts's own pickText() allows
+// up to 20000 chars for these). A user typing a paragraph break, or an AI
+// draft that wraps onto a second line, previously had every line after the
+// first silently discarded on the very next parse -- including at COMMIT
+// time (server/api/model-builder/items/[id]/commit.post.ts parses this same
+// blob into the typed columns it writes), so the committed record ended up
+// permanently missing everything past the first line with no error shown.
+// The commit preview panel shows the raw, un-parsed blob (correct, full
+// text) right up until the moment of commit, which made the truncation
+// invisible until after the record already existed.
+export function parseFieldLines(blob: string, modelType?: string): FieldLine[] {
+  const knownKeys = knownKeysFor(modelType)
+  const lines: FieldLine[] = []
+  for (const rawLine of blob.split('\n')) {
+    const start = isFieldStart(rawLine, knownKeys)
+    if (start) {
+      lines.push({ key: start.key, value: start.rest })
+      continue
+    }
+    const previous = lines[lines.length - 1]
+    if (!previous) continue
+    const continuation = rawLine.trim()
+    if (!continuation) continue
+    previous.value = previous.value
+      ? `${previous.value}\n${continuation}`
+      : continuation
+  }
+  return lines
+}
+
+export function readFieldLine(
+  blob: string,
+  key: string,
+  modelType?: string,
+): string {
+  return (
+    parseFieldLines(blob, modelType).find((line) => line.key === key)?.value ??
+    ''
+  )
+}
+
+export function setFieldLine(
+  blob: string,
+  key: string,
+  value: string,
+  modelType?: string,
+): string {
+  const knownKeys = knownKeysFor(modelType)
+  const rawLines = blob.split('\n')
+  const next: string[] = []
   let found = false
-  const next = lines.map((line) => {
-    const idx = line.indexOf(':')
-    if (idx === -1) return line
-    if (line.slice(0, idx).trim() !== key) return line
-    found = true
-    return `${key}: ${value}`
-  })
+  let i = 0
+  while (i < rawLines.length) {
+    const line = rawLines[i]!
+    const start = isFieldStart(line, knownKeys)
+    if (start && start.key === key) {
+      found = true
+      next.push(`${key}: ${value}`)
+      i += 1
+      // Also consume this field's own existing continuation lines, or the
+      // old value's trailing paragraphs would bleed in right after the
+      // replacement.
+      while (i < rawLines.length && !isFieldStart(rawLines[i]!, knownKeys)) {
+        i += 1
+      }
+      continue
+    }
+    next.push(line)
+    i += 1
+  }
   if (!found) {
     const last = next[next.length - 1]
     if (last !== undefined && last.trim() === '') next.pop()

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1884,7 +1884,10 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       // Skip items whose FIELDS_AND_PROMPTS is already approved/locked — see
       // isStageEditable's doc comment.
       if (!isStageEditable(item, 'FIELDS_AND_PROMPTS')) continue
-      const next = setFieldLine(item.fieldsDraft, fieldKey, value)
+      const modelType = state.run
+        ? resolveTargetModel(item.action, item.outputKey, state.run.sourceType)
+        : undefined
+      const next = setFieldLine(item.fieldsDraft, fieldKey, value, modelType)
       if (next === item.fieldsDraft) continue
       item.fieldsDraft = next
       markDownstreamStale(item, 'FIELDS_AND_PROMPTS')

--- a/utils/scripts/verifyModelBuilderFieldBlobContinuationGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderFieldBlobContinuationGuard.test.ts
@@ -1,0 +1,115 @@
+// /utils/scripts/verifyModelBuilderFieldBlobContinuationGuard.test.ts
+//
+// Self-test for verifyModelBuilderFieldBlobContinuationGuard.ts
+// (model-builder/t-029). Two halves, matching the guard's own split:
+//
+// 1. checkFieldBlobContinuation() is behavioral -- it imports and directly
+//    exercises the real parseFieldLines/readFieldLine/setFieldLine from
+//    stores/helpers/modelBuilderFields.ts, so this half of the self-test
+//    just asserts it currently passes clean against the real, fixed
+//    implementation (there is no separate "buggy fixture" to run it
+//    against -- the function under test *is* the fix).
+// 2. checkCommitDelegatesToSharedSplitter() is textual, so it's exercised
+//    against synthetic buggy/fixed source fixtures the same way every
+//    sibling Model Builder guard's self-test does.
+import assert from 'node:assert/strict'
+
+import {
+  checkCommitDelegatesToSharedSplitter,
+  checkFieldBlobContinuation,
+} from './verifyModelBuilderFieldBlobContinuationGuard.js'
+
+const FIXED_FIXTURE = `
+import {
+  CREATE_TARGETS,
+  fieldSpecFor,
+  parseFieldLines as splitFieldBlob,
+} from '~/stores/helpers/modelBuilderFields'
+
+function parseFieldLines(raw, modelType) {
+  const map = {}
+  for (const { key, value } of splitFieldBlob(raw, modelType)) {
+    map[key.toLowerCase()] = value
+  }
+  return map
+}
+`
+
+const BUGGY_FIXTURE_NO_IMPORT = `
+import { CREATE_TARGETS, fieldSpecFor } from '~/stores/helpers/modelBuilderFields'
+
+function parseFieldLines(raw) {
+  const map = {}
+  for (const line of raw.split('\\n')) {
+    const idx = line.indexOf(':')
+    if (idx === -1) continue
+    map[line.slice(0, idx).trim().toLowerCase()] = line.slice(idx + 1).trim()
+  }
+  return map
+}
+`
+
+const BUGGY_FIXTURE_UNUSED_IMPORT = `
+import {
+  CREATE_TARGETS,
+  fieldSpecFor,
+  parseFieldLines as splitFieldBlob,
+} from '~/stores/helpers/modelBuilderFields'
+
+function parseFieldLines(raw) {
+  const map = {}
+  for (const line of raw.split('\\n')) {
+    const idx = line.indexOf(':')
+    if (idx === -1) continue
+    map[line.slice(0, idx).trim().toLowerCase()] = line.slice(idx + 1).trim()
+  }
+  return map
+}
+`
+
+function run(): void {
+  const behaviorErrors = checkFieldBlobContinuation()
+  assert.deepEqual(
+    behaviorErrors,
+    [],
+    'expected the real parseFieldLines/readFieldLine/setFieldLine to pass ' +
+      `the multi-line continuation checks, got: ${JSON.stringify(behaviorErrors)}`,
+  )
+
+  const fixedErrors = checkCommitDelegatesToSharedSplitter(FIXED_FIXTURE)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const noImportErrors = checkCommitDelegatesToSharedSplitter(
+    BUGGY_FIXTURE_NO_IMPORT,
+  )
+  assert.equal(
+    noImportErrors.length,
+    2,
+    'expected the fixture with no splitFieldBlob import (a reintroduced ' +
+      `hand-rolled parser) to fail twice, got: ${JSON.stringify(noImportErrors)}`,
+  )
+
+  const unusedImportErrors = checkCommitDelegatesToSharedSplitter(
+    BUGGY_FIXTURE_UNUSED_IMPORT,
+  )
+  assert.equal(
+    unusedImportErrors.length,
+    1,
+    'expected the fixture that imports but never calls splitFieldBlob to ' +
+      `fail once, got: ${JSON.stringify(unusedImportErrors)}`,
+  )
+  assert.match(unusedImportErrors[0]!, /never calls it/)
+
+  console.log(
+    'Model Builder field-blob continuation guard self-test passed: real ' +
+      'parseFieldLines/readFieldLine/setFieldLine preserve multi-line ' +
+      'prose, and the delegation checker correctly flags a reintroduced ' +
+      'hand-rolled parser or an unused splitFieldBlob import.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderFieldBlobContinuationGuard.ts
+++ b/utils/scripts/verifyModelBuilderFieldBlobContinuationGuard.ts
@@ -1,0 +1,204 @@
+// /utils/scripts/verifyModelBuilderFieldBlobContinuationGuard.ts
+//
+// Regression guard (model-builder/t-029, kaizen) -- the FIELDS_AND_PROMPTS
+// blob format is "key: value" lines, one per field, but several fields are
+// declared `prose: true` in MODEL_FIELDS (modelBuilderFields.ts) --
+// backstory, personality, quirks, description, effect, flavorText, botIntro,
+// userIntro, prompt, pitch, goal, intros -- specifically to allow long,
+// multi-paragraph text (commit.post.ts's own pickText() allows up to 20000
+// chars for these). parseFieldLines()/setFieldLine() previously dropped any
+// line that didn't itself contain a colon, so a paragraph break typed by a
+// user (or wrapped onto a second line by an AI draft) silently discarded
+// everything after the first line of that field's value -- including at
+// COMMIT time, since commit.post.ts parsed this exact same blob into the
+// typed columns it actually writes to the database. The commit preview
+// panel shows the raw, un-parsed blob (correct, full text) right up until
+// the moment of commit, so the truncation was invisible until after the
+// record already existed with silently-missing content -- no error, no
+// warning, just a shorter backstory/description/etc. than what was
+// approved.
+//
+// Fixed by treating a line that doesn't open a recognized field (checked
+// against the target model's own MODEL_FIELDS keys, when known) as a
+// continuation of the previous field's value instead of dropping it.
+// commit.post.ts's own hand-rolled duplicate of this exact parsing logic
+// was removed in the same change -- it now delegates to the shared,
+// schema-aware splitter in modelBuilderFields.ts (the same module the
+// client uses) rather than maintaining two copies that can silently drift
+// out of sync with each other.
+//
+// Unlike most sibling Model Builder guards, this one is intentionally
+// behavioral rather than purely textual: parseFieldLines/readFieldLine/
+// setFieldLine are pure, freestanding functions with no DB/HTTP dependency,
+// so importing and directly exercising the real implementation is strictly
+// stronger regression protection than pattern-matching its source text
+// would be. A light textual check is kept alongside it for the one thing
+// behavioral testing can't see -- whether commit.post.ts still delegates to
+// the shared splitter instead of re-inlining its own copy.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  parseFieldLines,
+  readFieldLine,
+  setFieldLine,
+} from '@/stores/helpers/modelBuilderFields'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const COMMIT_ROUTE_PATH = join(
+  repositoryRoot,
+  'server/api/model-builder/items/[id]/commit.post.ts',
+)
+
+// Exercises the real parseFieldLines/readFieldLine/setFieldLine against
+// multi-line fixtures. Exported so the self-test can assert it currently
+// passes against the real, fixed implementation.
+export function checkFieldBlobContinuation(): string[] {
+  const errors: string[] = []
+
+  const multiline =
+    'name: Elandra\n' +
+    'backstory: Elandra grew up in the northern peaks.\n' +
+    'She lost her family in a rockslide and vowed to become strong.\n' +
+    'personality: stoic, guarded, secretly kind'
+
+  const expectedBackstory =
+    'Elandra grew up in the northern peaks.\n' +
+    'She lost her family in a rockslide and vowed to become strong.'
+
+  const parsed = parseFieldLines(multiline, 'Character')
+  const backstory = parsed.find((line) => line.key === 'backstory')?.value
+  if (backstory !== expectedBackstory) {
+    errors.push(
+      'parseFieldLines() no longer preserves a multi-line prose value -- ' +
+        `expected backstory to equal ${JSON.stringify(expectedBackstory)}, ` +
+        `got ${JSON.stringify(backstory)}. A continuation line (no colon, ` +
+        'or no recognized field key) must be appended to the previous ' +
+        "field's value, not dropped.",
+    )
+  }
+
+  const personality = parsed.find((line) => line.key === 'personality')?.value
+  if (personality !== 'stoic, guarded, secretly kind') {
+    errors.push(
+      'parseFieldLines() misparsed the field immediately after a ' +
+        'multi-line value -- expected personality to equal ' +
+        `"stoic, guarded, secretly kind", got ${JSON.stringify(personality)}.`,
+    )
+  }
+
+  const readBack = readFieldLine(multiline, 'backstory', 'Character')
+  if (readBack !== expectedBackstory) {
+    errors.push(
+      'readFieldLine() does not return the full multi-line value for ' +
+        `"backstory" -- got ${JSON.stringify(readBack)}.`,
+    )
+  }
+
+  // A stray colon inside a continuation line (e.g. a clock time mid-
+  // sentence) must not be mistaken for a new field when the target model's
+  // known keys are given.
+  const withStrayColon =
+    'backstory: She arrived at dawn.\nIt was 3:00 in the morning.'
+  const strayParsed = parseFieldLines(withStrayColon, 'Character')
+  if (strayParsed.length !== 1 || strayParsed[0]?.key !== 'backstory') {
+    errors.push(
+      'parseFieldLines() treats a stray colon inside a continuation line ' +
+        '(e.g. a clock time) as a new field when a modelType is given -- ' +
+        `got ${JSON.stringify(strayParsed)}.`,
+    )
+  } else if (
+    strayParsed[0]?.value !==
+    'She arrived at dawn.\nIt was 3:00 in the morning.'
+  ) {
+    errors.push(
+      'parseFieldLines() dropped or mangled a continuation line containing ' +
+        `a stray colon -- got ${JSON.stringify(strayParsed[0]?.value)}.`,
+    )
+  }
+
+  // setFieldLine() replacing a field that currently holds a multi-line
+  // value must consume the old value's continuation lines too, not leave
+  // them behind as orphaned text after the replacement.
+  const replaced = setFieldLine(
+    multiline,
+    'backstory',
+    'A short new bio.',
+    'Character',
+  )
+  const replacedParsed = parseFieldLines(replaced, 'Character')
+  const replacedBackstory = replacedParsed.find(
+    (line) => line.key === 'backstory',
+  )?.value
+  if (replacedBackstory !== 'A short new bio.') {
+    errors.push(
+      "setFieldLine() left the old multi-line backstory's continuation " +
+        `lines behind after replacing it -- got ${JSON.stringify(replacedBackstory)}.`,
+    )
+  }
+  const replacedPersonality = replacedParsed.find(
+    (line) => line.key === 'personality',
+  )?.value
+  if (replacedPersonality !== 'stoic, guarded, secretly kind') {
+    errors.push(
+      'setFieldLine() corrupted a sibling field while replacing backstory ' +
+        `-- got ${JSON.stringify(replacedPersonality)}.`,
+    )
+  }
+
+  return errors
+}
+
+// Light textual check: commit.post.ts must delegate to the shared splitter
+// rather than re-inlining its own hand-rolled "key: value" parser -- the
+// exact duplication that let this bug diverge undetected between the two
+// copies in the first place. Exported so the self-test can run it against
+// synthetic buggy/fixed fixtures without touching the real route file.
+export function checkCommitDelegatesToSharedSplitter(
+  content: string,
+): string[] {
+  const errors: string[] = []
+  if (!content.includes('parseFieldLines as splitFieldBlob')) {
+    errors.push(
+      'commit.post.ts no longer imports the shared parseFieldLines splitter ' +
+        'from stores/helpers/modelBuilderFields.ts as `splitFieldBlob` -- has ' +
+        'a hand-rolled duplicate parser been reintroduced? That is the exact ' +
+        'drift risk this guard exists to catch.',
+    )
+  }
+  if (!content.includes('splitFieldBlob(')) {
+    errors.push(
+      'commit.post.ts imports splitFieldBlob but never calls it -- the ' +
+        'FIELDS_AND_PROMPTS blob must be parsed via the shared, schema-aware ' +
+        'splitter, not a local reimplementation.',
+    )
+  }
+  return errors
+}
+
+function main(): void {
+  const errors = checkFieldBlobContinuation()
+
+  const commitContent = readFileSync(COMMIT_ROUTE_PATH, 'utf8')
+  errors.push(...checkCommitDelegatesToSharedSplitter(commitContent))
+
+  if (errors.length) {
+    console.error('Model Builder field-blob continuation guard failed:')
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder field-blob continuation guard passed: multi-line prose ' +
+      'values in the FIELDS_AND_PROMPTS blob survive parseFieldLines/' +
+      'readFieldLine/setFieldLine round-trips, and commit.post.ts delegates ' +
+      'to the shared splitter instead of a hand-rolled duplicate.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What

The FIELDS_AND_PROMPTS blob format is "key: value" lines, one per field. Several fields (backstory, personality, quirks, description, effect, flavorText, botIntro, userIntro, prompt, pitch, goal, intros) are declared `prose: true` in `MODEL_FIELDS` specifically to allow long, multi-paragraph text — `commit.post.ts`'s own `pickText()` already allows up to 20000 chars for them.

But `parseFieldLines()`/`setFieldLine()` dropped any line that didn't itself contain a colon, so a paragraph break typed by a user (or wrapped onto a second line by an AI draft) silently discarded **everything after the first line** of that field's value — including at COMMIT time, since `commit.post.ts` parses this exact same blob into the typed columns it writes to the database. The commit preview panel shows the raw, un-parsed blob (correct, full text) right up until the moment of commit, so the truncation was invisible until after the record already existed with silently-missing content — no error, no warning, just a shorter backstory/description/etc. than what was approved.

## Fix

- `parseFieldLines()`/`readFieldLine()`/`setFieldLine()` (`stores/helpers/modelBuilderFields.ts`) now treat a line that doesn't open a recognized field as a continuation of the previous field's value instead of dropping it. When a `modelType` is passed, only a key present in that model's own field spec counts as a new field boundary, so a stray colon inside prose (e.g. "It was 3:00 in the morning." mid-paragraph) isn't mistaken for a new field.
- Removed `commit.post.ts`'s hand-rolled duplicate of this exact parsing logic — it now delegates to the shared, schema-aware splitter in `modelBuilderFields.ts` (the same module the client already uses) instead of maintaining two copies that can silently drift out of sync with each other.
- `batchSetField` in the store now threads the resolved target model through to `setFieldLine` too, for consistency (its own call sites only ever pass single-line choice values today, so this is defensive rather than fixing a live bug there).

## Tests

Added `verifyModelBuilderFieldBlobContinuationGuard.ts` + `.test.ts`, following this project's `verifyModelBuilder*Guard` convention. Unlike most sibling guards (which pattern-match route-file source text because the routes they guard need a live DB/HTTP context), this one is behavioral: `parseFieldLines`/`readFieldLine`/`setFieldLine` are pure, freestanding functions, so it imports and directly exercises the real implementation — multi-line prose round-trips, a stray-colon-in-prose disambiguation check, and a `setFieldLine` replace-with-multiline-value check. A light textual check confirms `commit.post.ts` still delegates to the shared splitter rather than re-inlining its own copy. Wired into `package.json` and `contract-tests.yml`.

## Verification

- All 77 `test:model-builder-*` npm scripts pass (75 pre-existing + 2 new)
- `vue-tsc --noEmit` exits 0 repo-wide
- `eslint`/`prettier --check` clean on all touched files (the 2 pre-existing `no-empty` errors and pre-existing prettier drift in `modelBuilderStore.ts` confirmed present on `main` before this change via `git stash`)

model-builder/t-029

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MrrJDUAzVXQo19eRZsnQaS)_