### PR TITLE
fix(model-builder): parse JSON-string stageStatuses/sourceSnapshot on resume (model-builder/t-029)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -509,6 +509,12 @@ jobs:
       - name: Model Builder field-blob continuation guard contract
         run: npm run test:model-builder-field-blob-continuation-guard
 
+      - name: Model Builder stage-status JSON-parse guard self-test
+        run: npm run test:model-builder-stage-status-json-parse-guard-selftest
+
+      - name: Model Builder stage-status JSON-parse guard contract
+        run: npm run test:model-builder-stage-status-json-parse-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -246,6 +246,8 @@
     "test:model-builder-auto-build-outcome-persistence-guard": "tsx utils/scripts/verifyModelBuilderAutoBuildOutcomePersistenceGuard.ts",
     "test:model-builder-field-blob-continuation-guard-selftest": "tsx utils/scripts/verifyModelBuilderFieldBlobContinuationGuard.test.ts",
     "test:model-builder-field-blob-continuation-guard": "tsx utils/scripts/verifyModelBuilderFieldBlobContinuationGuard.ts",
+    "test:model-builder-stage-status-json-parse-guard-selftest": "tsx utils/scripts/verifyModelBuilderStageStatusJsonParseGuard.test.ts",
+    "test:model-builder-stage-status-json-parse-guard": "tsx utils/scripts/verifyModelBuilderStageStatusJsonParseGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -274,12 +274,49 @@ function freshStages(): Record<BuildStageKey, StageState> {
   return stages
 }
 
+// ModelBuildItem.stageStatuses and ModelBuildRun.sourceSnapshot are both
+// plain `String @db.LongText` columns, not native Prisma Json columns (see
+// utils/scripts/verifyNoPrismaJsonCast.ts) -- every server route writes them
+// with JSON.stringify and reads them back with parseStoredJson (server/api/
+// model-builder/runs/index.ts). A value that has round-tripped through any
+// /api/model-builder/* GET/POST response is therefore always a JSON *string*
+// on the client, never an already-parsed object. Parse defensively: accept a
+// string (the real shape) or an object (defensive only -- nothing produces
+// this today), and fall back to null/default on anything else, including
+// malformed JSON.
+function parseJsonValue(raw: unknown): unknown {
+  if (typeof raw !== 'string') return raw
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
 // Coerce a persisted stageStatuses JSON blob back into a complete stage map,
 // filling any missing gate with a locked default.
+//
+// Bug (found by inspection, model-builder/t-029): this used to gate on
+// `typeof raw === 'object'` alone, which is never true for `raw` sourced from
+// the server (see parseJsonValue's comment above) -- so every call from
+// adaptItem below silently discarded the real stageStatuses and returned the
+// fresh-item default (PITCH ready, everything else locked) instead. This
+// stayed invisible for the run that actually did the approving: approveStage/
+// pushItem/etc. all mutate the SAME long-lived state.run object in place, so
+// optimistic local state kept showing the right thing right up until the
+// object was rebuilt from a fresh server read. Concrete repro (pre-fix):
+// approve PITCH, refresh the page (or close the tab and reopen the same run
+// from Run History) -- resumeRun()/openRun()/fetchRuns() all re-fetch and
+// rebuild via adaptItem, and the just-approved PITCH stage (along with any
+// other approved or even fully committed stage) silently reverted to
+// 'ready'/'locked' in the UI, while the item's own targetId/targetType/
+// artImageId (typed columns, unaffected by this bug) still correctly showed
+// "Committed" -- a self-contradicting item panel with no error ever raised.
 function normalizeStages(raw: unknown): Record<BuildStageKey, StageState> {
   const stages = freshStages()
-  if (raw && typeof raw === 'object') {
-    const source = raw as Record<string, StageState>
+  const parsed = parseJsonValue(raw)
+  if (parsed && typeof parsed === 'object') {
+    const source = parsed as Record<string, StageState>
     for (const stage of BUILD_STAGES) {
       const value = source[stage.key]
       if (value && typeof value.status === 'string') {
@@ -348,10 +385,22 @@ function adaptRun(server: ServerRun): BuildRun {
     sourceType: server.sourceType as SourceTypeKey,
     sourceId: server.sourceId,
     sourceLabel: server.sourceLabel ?? '',
-    sourceSnapshot:
-      server.sourceSnapshot && typeof server.sourceSnapshot === 'object'
-        ? (server.sourceSnapshot as Record<string, unknown>)
-        : null,
+    // See parseJsonValue's doc comment: server.sourceSnapshot is a JSON
+    // string, not an already-parsed object, on every response from the
+    // server. model-builder-progress-matrix.vue's `source` computed falls
+    // back to store.selectedSource specifically so this snapshot "survives
+    // resume" (its own comment) -- but store.selectedSource is only ever set
+    // by an in-session selectSource() call and is never restored on
+    // resume/reopen, so before this fix the fallback masked the break only
+    // for the run that had just been created; resuming a run (or opening one
+    // from Run History) always showed a blank "Source context" card, with no
+    // error, for a value the run's own creation had genuinely captured.
+    sourceSnapshot: (() => {
+      const parsed = parseJsonValue(server.sourceSnapshot)
+      return parsed && typeof parsed === 'object'
+        ? (parsed as Record<string, unknown>)
+        : null
+    })(),
     recipeKey: server.recipeKey as RecipeKey,
     items: Array.isArray(server.Items) ? server.Items.map(adaptItem) : [],
   }

--- a/utils/scripts/verifyModelBuilderStageStatusJsonParseGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderStageStatusJsonParseGuard.test.ts
@@ -1,0 +1,245 @@
+// /utils/scripts/verifyModelBuilderStageStatusJsonParseGuard.test.ts
+//
+// Regression test for checkStageStatusJsonParseGuard() in
+// verifyModelBuilderStageStatusJsonParseGuard.ts (model-builder/t-029).
+// Exercises the real check against synthetic modelBuilderStore.ts-shaped
+// fixtures covering: the pre-fix shape (both call sites gate on
+// `typeof === 'object'` against the still-serialized raw value -- the exact
+// bug found by manual read-through), the fixed shape (both routed through
+// parseJsonValue() first), partial fixtures (only one of the two call sites
+// fixed), and a missing-helper fixture.
+//
+// Also exercises the real parseJsonValue()-shaped logic behaviorally against
+// the JSON-string-not-object data shape the server actually returns, so the
+// bug this guard protects against is demonstrated directly, not just its
+// textual signature.
+import assert from 'node:assert/strict'
+
+import {
+  checkStageStatusJsonParseGuard,
+  extractFunctionBody,
+} from './verifyModelBuilderStageStatusJsonParseGuard.js'
+
+const BUGGY_FIXTURE = `
+function parseJsonValue(raw: unknown): unknown {
+  if (typeof raw !== 'string') return raw
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+function normalizeStages(raw: unknown): Record<BuildStageKey, StageState> {
+  const stages = freshStages()
+  if (raw && typeof raw === 'object') {
+    const source = raw as Record<string, StageState>
+    for (const stage of BUILD_STAGES) {
+      const value = source[stage.key]
+      if (value && typeof value.status === 'string') {
+        stages[stage.key] = { status: value.status, note: value.note }
+      }
+    }
+  }
+  return stages
+}
+
+function adaptRun(server: ServerRun): BuildRun {
+  return {
+    id: String(server.id),
+    sourceSnapshot:
+      server.sourceSnapshot && typeof server.sourceSnapshot === 'object'
+        ? (server.sourceSnapshot as Record<string, unknown>)
+        : null,
+    recipeKey: server.recipeKey as RecipeKey,
+    items: [],
+  }
+}
+`
+
+const FIXED_FIXTURE = `
+function parseJsonValue(raw: unknown): unknown {
+  if (typeof raw !== 'string') return raw
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+function normalizeStages(raw: unknown): Record<BuildStageKey, StageState> {
+  const stages = freshStages()
+  const parsed = parseJsonValue(raw)
+  if (parsed && typeof parsed === 'object') {
+    const source = parsed as Record<string, StageState>
+    for (const stage of BUILD_STAGES) {
+      const value = source[stage.key]
+      if (value && typeof value.status === 'string') {
+        stages[stage.key] = { status: value.status, note: value.note }
+      }
+    }
+  }
+  return stages
+}
+
+function adaptRun(server: ServerRun): BuildRun {
+  return {
+    id: String(server.id),
+    sourceSnapshot: (() => {
+      const parsed = parseJsonValue(server.sourceSnapshot)
+      return parsed && typeof parsed === 'object'
+        ? (parsed as Record<string, unknown>)
+        : null
+    })(),
+    recipeKey: server.recipeKey as RecipeKey,
+    items: [],
+  }
+}
+`
+
+const NORMALIZE_STAGES_ONLY_FIXTURE = `
+function parseJsonValue(raw: unknown): unknown {
+  if (typeof raw !== 'string') return raw
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+function normalizeStages(raw: unknown): Record<BuildStageKey, StageState> {
+  const stages = freshStages()
+  const parsed = parseJsonValue(raw)
+  if (parsed && typeof parsed === 'object') {
+    const source = parsed as Record<string, StageState>
+    for (const stage of BUILD_STAGES) {
+      const value = source[stage.key]
+      if (value && typeof value.status === 'string') {
+        stages[stage.key] = { status: value.status, note: value.note }
+      }
+    }
+  }
+  return stages
+}
+
+function adaptRun(server: ServerRun): BuildRun {
+  return {
+    id: String(server.id),
+    sourceSnapshot:
+      server.sourceSnapshot && typeof server.sourceSnapshot === 'object'
+        ? (server.sourceSnapshot as Record<string, unknown>)
+        : null,
+    recipeKey: server.recipeKey as RecipeKey,
+    items: [],
+  }
+}
+`
+
+const MISSING_HELPER_FIXTURE = `
+function normalizeStages(raw: unknown): Record<BuildStageKey, StageState> {
+  const stages = freshStages()
+  if (raw && typeof raw === 'object') {
+    return stages
+  }
+  return stages
+}
+`
+
+function run(): void {
+  const buggyErrors = checkStageStatusJsonParseGuard(BUGGY_FIXTURE)
+  assert.equal(
+    buggyErrors.length,
+    2,
+    'expected the buggy fixture (both call sites un-fixed) to fail twice, ' +
+      `got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.match(buggyErrors[0]!, /normalizeStages/)
+  assert.match(buggyErrors[1]!, /adaptRun/)
+
+  const fixedErrors = checkStageStatusJsonParseGuard(FIXED_FIXTURE)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const partialErrors = checkStageStatusJsonParseGuard(
+    NORMALIZE_STAGES_ONLY_FIXTURE,
+  )
+  assert.equal(
+    partialErrors.length,
+    1,
+    'expected the partial fixture (normalizeStages fixed, adaptRun still ' +
+      `buggy) to fail exactly once, got: ${JSON.stringify(partialErrors)}`,
+  )
+  assert.match(partialErrors[0]!, /adaptRun/)
+
+  const missingHelperErrors = checkStageStatusJsonParseGuard(
+    MISSING_HELPER_FIXTURE,
+  )
+  assert.equal(
+    missingHelperErrors.length,
+    1,
+    'expected a fixture with no parseJsonValue() helper to fail with a ' +
+      `"could not find" error, got: ${JSON.stringify(missingHelperErrors)}`,
+  )
+  assert.match(missingHelperErrors[0]!, /Could not find/)
+
+  // Behavioral demonstration of the actual bug: the server always returns
+  // these fields as JSON strings (ModelBuildItem.stageStatuses /
+  // ModelBuildRun.sourceSnapshot are `String @db.LongText`, not native Json
+  // columns), never as already-parsed objects. The pre-fix
+  // `typeof raw === 'object'` check is false for a string, so it always fell
+  // through to the default/null branch; the fix must actually parse first.
+  const serialized = JSON.stringify({
+    PITCH: { status: 'approved' },
+    FIELDS_AND_PROMPTS: { status: 'ready' },
+  })
+  assert.equal(
+    typeof serialized,
+    'string',
+    'sanity: JSON.stringify always produces a string',
+  )
+  const buggyCheck = Boolean(serialized && typeof serialized === 'object')
+  assert.equal(
+    buggyCheck,
+    false,
+    'sanity: the pre-fix `typeof === object` check is false for the ' +
+      "server's actual (string) shape -- this is the root cause the fix " +
+      'above addresses',
+  )
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(serialized)
+  } catch {
+    parsed = null
+  }
+  const fixedCheck = Boolean(parsed && typeof parsed === 'object')
+  assert.equal(
+    fixedCheck,
+    true,
+    'sanity: parsing the string first before the object check recovers the ' +
+      'real data',
+  )
+
+  // extractFunctionBody itself: confirm it finds a nested-brace function body
+  // correctly (both normalizeStages and adaptRun contain nested `{ }` blocks
+  // that a naive "first closing brace" scan would truncate early on).
+  const body = extractFunctionBody(FIXED_FIXTURE, 'function normalizeStages(')
+  assert.ok(body, 'expected extractFunctionBody to find normalizeStages')
+  assert.match(body!, /return stages/)
+  assert.equal(
+    extractFunctionBody(FIXED_FIXTURE, 'function doesNotExist('),
+    null,
+    'expected extractFunctionBody to return null for a missing anchor',
+  )
+
+  console.log(
+    'Model Builder stage-status JSON-parse guard self-test passed: buggy ' +
+      'fixture fails twice, fixed fixture passes, partial fixtures fail ' +
+      'once each, missing-helper fixture fails clearly, and the underlying ' +
+      "JSON-string-vs-object behavior matches the server's actual shape.",
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderStageStatusJsonParseGuard.ts
+++ b/utils/scripts/verifyModelBuilderStageStatusJsonParseGuard.ts
@@ -1,0 +1,145 @@
+// /utils/scripts/verifyModelBuilderStageStatusJsonParseGuard.ts
+//
+// Regression guard (model-builder/t-029) -- ModelBuildItem.stageStatuses and
+// ModelBuildRun.sourceSnapshot are both plain `String @db.LongText` columns
+// (see utils/scripts/verifyNoPrismaJsonCast.ts), not native Prisma Json
+// columns. Every /api/model-builder/* route writes them with JSON.stringify
+// and reads them back with parseStoredJson (server/api/model-builder/runs/
+// index.ts) -- so any value that has round-tripped through a GET/POST
+// response is a JSON *string* on the client, never an already-parsed object.
+//
+// stores/modelBuilderStore.ts's normalizeStages() and adaptRun()'s
+// sourceSnapshot handling used to gate on `typeof raw === 'object'` alone,
+// which is never true for server-sourced data -- so normalizeStages always
+// silently discarded the real stageStatuses and returned the fresh-item
+// default (PITCH ready, everything else locked), and sourceSnapshot always
+// came back null. This stayed invisible for the run that actually did the
+// approving/promoting/committing: approveStage/pushItem/etc. all mutate the
+// SAME long-lived state.run object in place, so optimistic local state kept
+// showing the right thing right up until the object was rebuilt from a fresh
+// server read (resumeRun() on page load, openRun() for a run not already
+// cached in state.runs, fetchRuns() populating the History list). Concrete
+// repro (pre-fix): approve PITCH, refresh the page (or reopen the same run
+// from Run History) -- the just-approved stage (or even a fully committed
+// one) silently reverted to 'ready'/'locked' in the UI, while the item's own
+// targetId/targetType/artImageId (typed columns, unaffected) still correctly
+// showed "Committed" -- a self-contradicting item panel with no error raised.
+//
+// Fixed by routing both through a shared parseJsonValue() helper that
+// JSON.parses a string before the object check, instead of checking the
+// object-ness of the raw (still-serialized) value directly.
+//
+// This asserts the textual shape of that fix stays in place.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const PARSE_HELPER_ANCHOR = 'function parseJsonValue('
+const NORMALIZE_STAGES_ANCHOR = 'function normalizeStages('
+const ADAPT_RUN_ANCHOR = 'function adaptRun('
+
+// Extracts a `function name(...) { ... }` body via brace matching from the
+// first `{` after the anchor, so the check is robust to reformatting inside
+// the function.
+export function extractFunctionBody(
+  content: string,
+  anchor: string,
+): string | null {
+  const anchorIndex = content.indexOf(anchor)
+  if (anchorIndex === -1) return null
+
+  const braceOpen = content.indexOf('{', anchorIndex)
+  if (braceOpen === -1) return null
+
+  let depth = 0
+  let i = braceOpen
+  for (; i < content.length; i++) {
+    if (content[i] === '{') depth++
+    else if (content[i] === '}') {
+      depth--
+      if (depth === 0) break
+    }
+  }
+  if (depth !== 0) return null
+
+  return content.slice(braceOpen, i + 1)
+}
+
+export function checkStageStatusJsonParseGuard(content: string): string[] {
+  const errors: string[] = []
+
+  if (!content.includes(PARSE_HELPER_ANCHOR)) {
+    errors.push(
+      `Could not find \`${PARSE_HELPER_ANCHOR}\` in stores/modelBuilderStore.ts -- ` +
+        'has the shared JSON-string-or-object parse helper been renamed, removed, ' +
+        'or restructured? If so, this guard (and the bug it protects against) ' +
+        'needs to move with it.',
+    )
+    return errors
+  }
+
+  const normalizeStagesBody = extractFunctionBody(
+    content,
+    NORMALIZE_STAGES_ANCHOR,
+  )
+  if (normalizeStagesBody === null) {
+    errors.push(
+      `Could not find \`${NORMALIZE_STAGES_ANCHOR}\` in stores/modelBuilderStore.ts.`,
+    )
+  } else if (!normalizeStagesBody.includes('parseJsonValue(raw)')) {
+    errors.push(
+      'normalizeStages() no longer routes its `raw` argument through ' +
+        'parseJsonValue() before checking whether it is an object -- server-sourced ' +
+        'stageStatuses is always a JSON string, so this would silently discard every ' +
+        "item's real stage progress on the next resume/reopen/refresh and fall back " +
+        'to the fresh-item default (PITCH ready, everything else locked).',
+    )
+  }
+
+  const adaptRunBody = extractFunctionBody(content, ADAPT_RUN_ANCHOR)
+  if (adaptRunBody === null) {
+    errors.push(
+      `Could not find \`${ADAPT_RUN_ANCHOR}\` in stores/modelBuilderStore.ts.`,
+    )
+  } else if (!adaptRunBody.includes('parseJsonValue(server.sourceSnapshot)')) {
+    errors.push(
+      'adaptRun() no longer routes server.sourceSnapshot through parseJsonValue() ' +
+        'before checking whether it is an object -- server-sourced sourceSnapshot is ' +
+        'always a JSON string, so this would silently come back null on every ' +
+        "resume/reopen/refresh, even though the run's own creation genuinely " +
+        'captured it.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkStageStatusJsonParseGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder stage-status JSON-parse guard contract failed for ' +
+        'stores/modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder stage-status JSON-parse guard contract passed: ' +
+      'normalizeStages()/adaptRun() parse server-sourced JSON-string fields ' +
+      'before checking their shape.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
Recurring task: model-builder/t-029 "Polish and upgrade Model Builder front-end surface".

## Bug

`ModelBuildItem.stageStatuses` and `ModelBuildRun.sourceSnapshot` are both plain `String @db.LongText` columns, not native Prisma `Json` columns (see `utils/scripts/verifyNoPrismaJsonCast.ts`). Every `/api/model-builder/*` route writes them with `JSON.stringify` and reads them back server-side with `parseStoredJson`. Any value that has round-tripped through a GET/POST response is therefore a JSON *string* on the client, never an already-parsed object.

`stores/modelBuilderStore.ts`'s `normalizeStages()` and `adaptRun()`'s `sourceSnapshot` handling both gated on `typeof raw === 'object'` alone, which is never true for server-sourced data:

- `normalizeStages()` silently discarded every item's real stage progress and returned the fresh-item default (`PITCH` ready, everything else locked) instead.
- `adaptRun()` silently returned `null` for `sourceSnapshot`.

## Why it was invisible

`state.run` is a single long-lived reactive object. `approveStage`/`pushItem`/etc. all mutate it in place, so optimistic local state kept showing the right thing right up until the object was rebuilt from a fresh server read.

**Concrete repro (pre-fix):** approve a stage — or fully commit an item — then refresh the page, or close the tab and reopen the same run from Run History. `resumeRun()`/`openRun()`/`fetchRuns()` all re-fetch and rebuild via `adaptItem`/`adaptRun`, and the just-approved (or committed) stage silently reverts to `'ready'`/`'locked'` in the UI — while the item's own `targetId`/`targetType`/`artImageId` (typed columns, unaffected by this bug) still correctly show "Committed → X #Y". Self-contradicting item panel, no error ever raised.

Separately, the "Source context" card (image + description) in `model-builder-progress-matrix.vue` always came back blank on resume/reopen, even though `sourceSnapshot` was genuinely captured at run creation — its own code comment says the snapshot is meant to "survive resume," but it never did once state.run left the current tab's memory.

## Fix

Added a shared `parseJsonValue()` helper that `JSON.parse`s a string before the object-shape check, and routed both `normalizeStages()` and `adaptRun()`'s `sourceSnapshot` handling through it.

## How this was found

Per this task's context, prior cycles today (PRs #1901–#1905) heavily audited `server/api/model-builder/**`, `stores/modelBuilderStore.ts`'s commit/race-condition surface, and the batch/auto-build UI. This cycle instead read the genuinely unexplored front-end files with fresh eyes: `model-builder-item-panel.vue`, `model-builder-recipe-selector.vue`, `model-builder-source-picker.vue`, `model-builder-run-history.vue`, and `model-builder-manager.vue`. Tracing `progress-matrix.vue`'s `source` computed and its own "snapshot survives resume" comment back to `adaptRun`/`normalizeStages` surfaced this.

## Regression guard

Added `utils/scripts/verifyModelBuilderStageStatusJsonParseGuard.ts` (+ self-test), wired into `package.json` and `.github/workflows/contract-tests.yml`, following the existing narrow textual-guard convention (matches `verifyModelBuilderCommitNameFieldGuard.ts`'s shape).

## Verification

- `npm run test:model-builder-stage-status-json-parse-guard` and its `-selftest` — pass
- All 79 existing `test:model-builder-*` npm scripts — pass, no regressions
- `npx vue-tsc --noEmit` — clean
- `eslint`/`prettier` on touched files — clean (two pre-existing `no-empty` lint errors in `modelBuilderStore.ts` predate this change, confirmed against `HEAD` before editing)
- `git status --porcelain` — only the 5 intended files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015sW9pPza1ih83A5xge9Drg)_