### PR TITLE
fix(model-builder): persist item.error to the server so it survives resume (model-builder/t-029)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -515,6 +515,12 @@ jobs:
       - name: Model Builder stage-status JSON-parse guard contract
         run: npm run test:model-builder-stage-status-json-parse-guard
 
+      - name: Model Builder item.error persistence guard self-test
+        run: npm run test:model-builder-error-persistence-guard-selftest
+
+      - name: Model Builder item.error persistence guard contract
+        run: npm run test:model-builder-error-persistence-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/components/model-builder/model-builder-batch-editor.vue
+++ b/components/model-builder/model-builder-batch-editor.vue
@@ -307,10 +307,17 @@ function approvedCount(item: BuildItem): number {
 // "Execute commit" button can fix and commit an item without ever going back
 // through autoBuildItem, which would otherwise leave this reading a failure
 // that's no longer true.
+//
+// item.error is also checked (model-builder/t-029, mirrors model-builder-
+// progress-matrix.vue's identical helper, which both must keep agreeing
+// with): lastAutoBuildOutcome is session-only and never restored on resume,
+// while item.error is the persisted signal that survives it -- see
+// modelBuilderStore.ts's generateItemAsset/generateItemAssetAsync/
+// pollAsyncArtJob/commitItem pushItem calls.
 function autoBuildFailed(item: BuildItem): boolean {
   return (
     item.stages.COMMIT.status !== 'approved' &&
-    item.lastAutoBuildOutcome === 'failed'
+    (item.lastAutoBuildOutcome === 'failed' || Boolean(item.error))
   )
 }
 

--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -274,10 +274,21 @@ const showBatch = computed(() => (selectedGroup.value?.items.length ?? 0) > 1)
 // leave this reading a failure that's no longer true. Mirrors the store's
 // own runProgress.failed and model-builder-batch-editor.vue's identical
 // helper -- all three must agree on what counts as "failed right now".
+//
+// item.error is also checked, not just lastAutoBuildOutcome (model-builder/
+// t-029): lastAutoBuildOutcome is session-only client state -- adaptItem
+// never restores it on resume/reopen/reload, by design, since it means
+// "what this session's auto-build pass just did." item.error is the
+// persisted signal (server column, now actually written -- see
+// generateItemAsset/generateItemAssetAsync/pollAsyncArtJob/commitItem's own
+// pushItem calls in modelBuilderStore.ts) meant to survive exactly that.
+// Without this OR, the warning badge and its tooltip silently disappeared
+// the moment a failed run was reopened from History or the page reloaded,
+// even though the item was still stuck exactly where it failed.
 function autoBuildFailed(item: BuildItem): boolean {
   return (
     item.stages.COMMIT.status !== 'approved' &&
-    item.lastAutoBuildOutcome === 'failed'
+    (item.lastAutoBuildOutcome === 'failed' || Boolean(item.error))
   )
 }
 

--- a/package.json
+++ b/package.json
@@ -248,6 +248,8 @@
     "test:model-builder-field-blob-continuation-guard": "tsx utils/scripts/verifyModelBuilderFieldBlobContinuationGuard.ts",
     "test:model-builder-stage-status-json-parse-guard-selftest": "tsx utils/scripts/verifyModelBuilderStageStatusJsonParseGuard.test.ts",
     "test:model-builder-stage-status-json-parse-guard": "tsx utils/scripts/verifyModelBuilderStageStatusJsonParseGuard.ts",
+    "test:model-builder-error-persistence-guard-selftest": "tsx utils/scripts/verifyModelBuilderErrorPersistenceGuard.test.ts",
+    "test:model-builder-error-persistence-guard": "tsx utils/scripts/verifyModelBuilderErrorPersistenceGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -518,11 +518,16 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     // through autoBuildItem again (e.g. the single-stage "Execute commit"
     // button), which would otherwise leave lastAutoBuildOutcome pointing at
     // a failure that's no longer true. Mirrors model-builder-progress-
-    // matrix.vue's autoBuildFailed, which the same logic must agree with.
+    // matrix.vue's autoBuildFailed, which the same logic must agree with --
+    // including the item.error OR (model-builder/t-029): lastAutoBuildOutcome
+    // is session-only and never restored on resume/reopen/reload, so without
+    // also honoring the persisted item.error signal, this count silently
+    // dropped to 0 for a run reopened from History even when items were
+    // still genuinely stuck failed.
     const failed = state.run.items.filter(
       (item) =>
         item.stages.COMMIT.status !== 'approved' &&
-        item.lastAutoBuildOutcome === 'failed',
+        (item.lastAutoBuildOutcome === 'failed' || Boolean(item.error)),
     ).length
     return { total, committed, failed }
   })
@@ -1192,6 +1197,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       item.error = `${item.generation} generation is not wired into the front-end slice yet.`
       item.stages.GENERATE_ASSETS = { status: 'ready', note: item.error }
       setStatus('error', item.error)
+      pushItem(item, { error: item.error })
       return false
     }
 
@@ -1199,6 +1205,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     if (!prompt) {
       item.error = 'Add a prompt in Fields & Prompts before generating.'
       setStatus('error', item.error)
+      pushItem(item, { error: item.error })
       return false
     }
 
@@ -1264,9 +1271,14 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       finishGenerateAssets(item, { status: 'ready' })
 
       await recordArtifact(item, image, output, prompt, dims, runId)
+      // error: null clears any error a previous failed attempt on this same
+      // item persisted (see the catch block below) -- otherwise a resolved
+      // problem's stale message would resurface on the next resume/reload,
+      // right alongside the freshly-generated candidate.
       pushItem(item, {
         stageStatuses: item.stages,
         artImageId: item.artImageId,
+        error: null,
       })
 
       // Gated by setStatusForRun, not a plain setStatus: the user may have
@@ -1292,6 +1304,21 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       item.error = error instanceof Error ? error.message : 'Generation failed.'
       finishGenerateAssets(item, { status: 'ready', note: item.error })
       setStatusForRun(runId, 'error', item.error)
+      // Bug (model-builder/t-029): item.error is a real, server-writable
+      // `ModelBuildItem.error` column (server/api/model-builder/runs/
+      // index.ts's ItemPatchBody accepts it), and item-panel.vue's error
+      // banner (`v-if="item.error"`) reads it -- but every failure branch in
+      // this file used to only mutate the local reactive item, never push
+      // it. adaptItem always rebuilds from `server.error ?? null` on
+      // resume/reopen/reload (see normalizeStages'/adaptRun's own doc
+      // comments for the identical class of bug with stageStatuses/
+      // sourceSnapshot), so a real, still-unresolved failure -- and the
+      // per-item "failed" badge in model-builder-progress-matrix.vue /
+      // model-builder-batch-editor.vue, which also keys off this item's
+      // error text -- silently vanished the moment the page reloaded or the
+      // run was reopened from History, even though nothing about the item
+      // had actually been fixed.
+      pushItem(item, { error: item.error })
       return false
     } finally {
       // state.generatingItemId is a store-wide singleton (not per-item, unlike
@@ -1363,6 +1390,9 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         item.error = result.message || `Art job ${jobId} did not complete.`
         finishGenerateAssets(item, { status: 'ready', note: item.error })
         setStatusForRun(runId, 'error', item.error)
+        // See generateItemAsset's identical pushItem — this async sibling's
+        // failure was silently local-only for the same reason.
+        pushItem(item, { error: item.error })
         return
       }
 
@@ -1397,9 +1427,11 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       finishGenerateAssets(item, { status: 'ready' })
 
       await recordArtifact(item, image, output, prompt, dims, runId)
+      // error: null — see generateItemAsset's identical success-path clear.
       pushItem(item, {
         stageStatuses: item.stages,
         artImageId: item.artImageId,
+        error: null,
       })
 
       // Gated by setStatusForRun -- see its doc comment (same reasoning as
@@ -1425,6 +1457,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       item.error = `${item.generation} generation is not wired into the front-end slice yet.`
       item.stages.GENERATE_ASSETS = { status: 'ready', note: item.error }
       setStatus('error', item.error)
+      pushItem(item, { error: item.error })
       return false
     }
 
@@ -1432,6 +1465,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     if (!prompt) {
       item.error = 'Add a prompt in Fields & Prompts before generating.'
       setStatus('error', item.error)
+      pushItem(item, { error: item.error })
       return false
     }
 
@@ -1489,6 +1523,9 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       item.queueState = null
       item.artJobId = null
       setStatusForRun(runId, 'error', item.error)
+      // See generateItemAsset's identical pushItem — this enqueue failure
+      // was silently local-only for the same reason.
+      pushItem(item, { error: item.error })
       return false
     }
   }
@@ -1577,6 +1614,14 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         item.targetType = target.type
         item.targetId = target.id
       }
+      // Clears any error a previous failed commit attempt on this item
+      // persisted (see the catch block below) -- the server already durably
+      // committed the target above, so a stale message from an earlier,
+      // now-irrelevant failure must not resurface on the next resume/reload
+      // right next to "Committed → ...". This is the item's only client PATCH
+      // on a successful commit; stageStatuses/targetId/targetType are written
+      // authoritatively by the commit POST itself.
+      pushItem(item, { error: null })
       // Gated by setStatusForRun -- see its doc comment. The commit itself
       // already durably landed server-side regardless; this only suppresses
       // a misleading "committed" toast if the user has since navigated away
@@ -1596,6 +1641,15 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       item.error = error instanceof Error ? error.message : 'Commit failed.'
       finishCommit(item, { status: 'ready', note: item.error })
       setStatusForRun(runId, 'error', item.error)
+      // Bug (model-builder/t-029): see generateItemAsset's identical
+      // pushItem/doc comment -- item.error is a real server column
+      // (ModelBuildItem.error) that this catch block used to only mutate
+      // locally, so a genuine, unresolved commit failure (and the per-item
+      // "failed" badge in model-builder-progress-matrix.vue /
+      // model-builder-batch-editor.vue, which also reads this item's error
+      // text) silently vanished the instant the page reloaded or the run
+      // was reopened from Run History.
+      pushItem(item, { error: item.error })
       return false
     } finally {
       committingItemSingleton.release(item.id)

--- a/utils/scripts/verifyModelBuilderErrorPersistenceGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderErrorPersistenceGuard.test.ts
@@ -1,0 +1,225 @@
+// /utils/scripts/verifyModelBuilderErrorPersistenceGuard.test.ts
+//
+// Regression test for checkErrorPersistenceGuard() in
+// verifyModelBuilderErrorPersistenceGuard.ts (model-builder/t-029).
+// Exercises the real check against synthetic store-shaped fixtures covering:
+// the pre-fix shape (item.error set locally in all four target functions
+// but never pushed to the server), the fixed shape (each function pushes it
+// somewhere -- mirroring the real store's mix of a dedicated
+// `pushItem(item, { error: ... })` call and one piggybacked onto an
+// existing success-path payload alongside other keys), a partially-fixed
+// shape (only some functions fixed), and all four target functions absent.
+import assert from 'node:assert/strict'
+
+import { checkErrorPersistenceGuard } from './verifyModelBuilderErrorPersistenceGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function generateItemAsset(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return false
+    try {
+      const result = await artStore.generateCurrentArt({})
+      pushItem(item, { stageStatuses: item.stages, artImageId: item.artImageId })
+      return true
+    } catch (error) {
+      item.error = error instanceof Error ? error.message : 'Generation failed.'
+      finishGenerateAssets(item, { status: 'ready', note: item.error })
+      return false
+    }
+  }
+
+  async function pollAsyncArtJob(item, jobId, generateData, output, prompt, dims, runId): Promise<void> {
+    const result = await artStore.finalizeQueuedArtImage(job, generateData)
+    if (!result.success || !result.data) {
+      item.error = result.message || 'Art job did not complete.'
+      finishGenerateAssets(item, { status: 'ready', note: item.error })
+      return
+    }
+    pushItem(item, { stageStatuses: item.stages, artImageId: item.artImageId })
+  }
+
+  async function generateItemAssetAsync(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    try {
+      item.artJobId = enqueued.jobId
+      return true
+    } catch (error) {
+      item.error = error instanceof Error ? error.message : 'Failed to queue generation.'
+      finishGenerateAssets(item, { status: 'ready', note: item.error })
+      return false
+    }
+  }
+
+  async function commitItem(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    try {
+      const response = await performFetch('/commit', {})
+      finishCommit(item, { status: 'approved' })
+      return true
+    } catch (error) {
+      item.error = error instanceof Error ? error.message : 'Commit failed.'
+      finishCommit(item, { status: 'ready', note: item.error })
+      return false
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function generateItemAsset(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return false
+    try {
+      const result = await artStore.generateCurrentArt({})
+      pushItem(item, {
+        stageStatuses: item.stages,
+        artImageId: item.artImageId,
+        error: null,
+      })
+      return true
+    } catch (error) {
+      item.error = error instanceof Error ? error.message : 'Generation failed.'
+      finishGenerateAssets(item, { status: 'ready', note: item.error })
+      pushItem(item, { error: item.error })
+      return false
+    }
+  }
+
+  async function pollAsyncArtJob(item, jobId, generateData, output, prompt, dims, runId): Promise<void> {
+    const result = await artStore.finalizeQueuedArtImage(job, generateData)
+    if (!result.success || !result.data) {
+      item.error = result.message || 'Art job did not complete.'
+      finishGenerateAssets(item, { status: 'ready', note: item.error })
+      pushItem(item, { error: item.error })
+      return
+    }
+    pushItem(item, {
+      stageStatuses: item.stages,
+      artImageId: item.artImageId,
+      error: null,
+    })
+  }
+
+  async function generateItemAssetAsync(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    try {
+      item.artJobId = enqueued.jobId
+      return true
+    } catch (error) {
+      item.error = error instanceof Error ? error.message : 'Failed to queue generation.'
+      finishGenerateAssets(item, { status: 'ready', note: item.error })
+      pushItem(item, { error: item.error })
+      return false
+    }
+  }
+
+  async function commitItem(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    try {
+      const response = await performFetch('/commit', {})
+      finishCommit(item, { status: 'approved' })
+      pushItem(item, { error: null })
+      return true
+    } catch (error) {
+      item.error = error instanceof Error ? error.message : 'Commit failed.'
+      finishCommit(item, { status: 'ready', note: item.error })
+      pushItem(item, { error: item.error })
+      return false
+    }
+  }
+`
+
+const PARTIALLY_FIXED_FIXTURE = `
+  async function generateItemAsset(itemId: string): Promise<boolean> {
+    try {
+      pushItem(item, { stageStatuses: item.stages, error: null })
+      return true
+    } catch (error) {
+      item.error = error instanceof Error ? error.message : 'Generation failed.'
+      return false
+    }
+  }
+
+  async function pollAsyncArtJob(item, jobId): Promise<void> {
+    item.error = 'Art job did not complete.'
+  }
+
+  async function generateItemAssetAsync(itemId: string): Promise<boolean> {
+    try {
+      return true
+    } catch (error) {
+      item.error = 'Failed to queue generation.'
+      return false
+    }
+  }
+
+  async function commitItem(itemId: string): Promise<boolean> {
+    try {
+      pushItem(item, { error: null })
+      return true
+    } catch (error) {
+      item.error = 'Commit failed.'
+      pushItem(item, { error: item.error })
+      return false
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkErrorPersistenceGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  4,
+  'expected the pre-fix shape (item.error set but never pushed, in all ' +
+    `four functions) to raise 4 errors, got ${buggyErrors.length}: ` +
+    JSON.stringify(buggyErrors),
+)
+
+const fixedErrors = checkErrorPersistenceGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const partialErrors = checkErrorPersistenceGuard(PARTIALLY_FIXED_FIXTURE)
+assert.equal(
+  partialErrors.length,
+  2,
+  'expected pollAsyncArtJob (never pushes) and generateItemAssetAsync ' +
+    `(never pushes) to be flagged, got ${partialErrors.length}: ` +
+    JSON.stringify(partialErrors),
+)
+assert.ok(partialErrors.some((e) => e.includes('pollAsyncArtJob')))
+assert.ok(partialErrors.some((e) => e.includes('generateItemAssetAsync')))
+
+const missingErrors = checkErrorPersistenceGuard(MISSING_FIXTURE)
+assert.equal(
+  missingErrors.length,
+  4,
+  'expected 4 "function not found" violations when all target functions are absent',
+)
+for (const name of [
+  'generateItemAsset',
+  'generateItemAssetAsync',
+  'pollAsyncArtJob',
+  'commitItem',
+]) {
+  assert.ok(
+    missingErrors.some((e) => e.includes(name)),
+    `expected a violation naming ${name}`,
+  )
+}
+
+console.log(
+  'Model Builder item.error persistence guard checker verified: flags ' +
+    'item.error set-but-never-pushed in each of the four target ' +
+    'functions independently, clears the fixed shape, and flags all four ' +
+    'target functions being absent.',
+)

--- a/utils/scripts/verifyModelBuilderErrorPersistenceGuard.ts
+++ b/utils/scripts/verifyModelBuilderErrorPersistenceGuard.ts
@@ -1,0 +1,115 @@
+// /utils/scripts/verifyModelBuilderErrorPersistenceGuard.ts
+//
+// Regression guard (model-builder/t-029). `ModelBuildItem.error` is a real,
+// client-writable server column (prisma/model-builder.prisma; accepted by
+// ItemPatchBody in server/api/model-builder/runs/index.ts, see `error` in
+// prepareItemUpdate) that item-panel.vue's error banner
+// (`v-if="item.error"`) and model-builder-progress-matrix.vue's / model-
+// builder-batch-editor.vue's per-item "failed" badge both read -- but every
+// failure branch in generateItemAsset, generateItemAssetAsync,
+// pollAsyncArtJob, and commitItem used to only mutate the local reactive
+// `item.error`, never push it to the server. adaptItem always rebuilds a
+// fresh item from `server.error ?? null` on resume/reopen/reload (the same
+// class of bug fixed for stageStatuses/sourceSnapshot by
+// verifyModelBuilderStageStatusJsonParseGuard.ts), so a real, still-
+// unresolved failure -- and the badge that depends on it -- silently
+// vanished the moment the page reloaded or the run was reopened from Run
+// History, even though the item was still stuck exactly where it failed.
+//
+// This walks each target function in modelBuilderStore.ts and requires its
+// body to contain at least one `pushItem(item, { ... error: ... })` call --
+// i.e. that the function actually persists item.error somewhere, on some
+// path, rather than only mutating it locally. Deliberately a presence check
+// (mirroring verifyModelBuilderAutoBuildOutcomePersistenceGuard.ts's own
+// style) rather than proving every single branch pushes -- a future
+// refactor that drops ALL such calls from a function fails loudly; the
+// finer-grained "does every failure branch push" property is exercised by
+// this guard's own self-test fixtures instead.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const TARGET_FUNCTIONS = [
+  'generateItemAsset',
+  'generateItemAssetAsync',
+  'pollAsyncArtJob',
+  'commitItem',
+] as const
+
+// A pushItem(...) call whose object-literal payload includes `error` as a
+// key. Matches both `pushItem(item, { error: ... })` (possibly among other
+// keys, in either order, across lines) and does not require it to be the
+// only field -- generateItemAsset's success path piggybacks `error: null`
+// onto its existing `stageStatuses`/`artImageId` payload rather than firing
+// a second request.
+const PUSHES_ERROR = /pushItem\(\s*item,\s*\{[^}]*\berror\s*:/s
+
+// Checks the fix's exact shape against the full source text of a file
+// containing these function names. Exported so the self-test below can run
+// it against synthetic buggy/fixed fixtures without touching the real store.
+export function checkErrorPersistenceGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+
+  for (const name of TARGET_FUNCTIONS) {
+    const fn = functions.find((f) => f.name === name)
+    if (!fn) {
+      errors.push(
+        `Could not find a function named ${name}() -- has it been renamed, ` +
+          'removed, or inlined? If so, this guard (and the item.error ' +
+          'persistence it protects) needs to move with it.',
+      )
+      continue
+    }
+
+    if (!PUSHES_ERROR.test(fn.body)) {
+      errors.push(
+        `${name}() sets item.error somewhere but never pushes it to the ` +
+          'server (expected a `pushItem(item, { ..., error: ... })` call ' +
+          'in its body). Without it, a genuine failure this function ' +
+          "records is only local reactive state -- item-panel.vue's error " +
+          'banner and the per-item "failed" badge in model-builder-' +
+          'progress-matrix.vue / model-builder-batch-editor.vue both go ' +
+          'silently blank the next time this item resumes, reopens, or ' +
+          'reloads, even though nothing about it was actually fixed.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkErrorPersistenceGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder item.error persistence guard contract failed in ' +
+        'modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder item.error persistence guard contract passed: ' +
+      'generateItemAsset(), generateItemAssetAsync(), pollAsyncArtJob(), ' +
+      'and commitItem() all push item.error to the server, so a real ' +
+      'failure (and the badge/banner reading it) survives resume/reopen/' +
+      'reload instead of only ever existing in local reactive state.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Bug

`ModelBuildItem.error` is a real, client-writable server column (`prisma/model-builder.prisma`; accepted by `ItemPatchBody` in `server/api/model-builder/runs/index.ts`) that `model-builder-item-panel.vue`'s error banner (`v-if="item.error"`) and `model-builder-progress-matrix.vue` / `model-builder-batch-editor.vue`'s per-item "failed" badge both read — but every failure branch in `generateItemAsset`, `generateItemAssetAsync`, `pollAsyncArtJob`, and `commitItem` in `stores/modelBuilderStore.ts` only ever mutated the local reactive item, never pushed it to the server.

`adaptItem` always rebuilds a fresh item from `server.error ?? null` on resume/reopen/reload (the same class of bug fixed for `stageStatuses`/`sourceSnapshot` by `verifyModelBuilderStageStatusJsonParseGuard.ts` last cycle). Combined with `lastAutoBuildOutcome` being intentionally session-only client state (never restored on resume — that part is by design), this meant a real, still-unresolved item failure — and the entire per-item "failed" visibility feature added earlier today — silently vanished the moment the page reloaded or the run was reopened from Run History, even though nothing about the item had actually been fixed. No error, no warning: the item just looked like it had never been attempted.

## Fix

- Each failure branch in `generateItemAsset`/`generateItemAssetAsync`/`pollAsyncArtJob`/`commitItem` now pushes `{ error: <message> }` to the server via the existing `pushItem` mechanism.
- Each success branch that already calls `pushItem` (`generateItemAsset`, `pollAsyncArtJob`) also clears `error: null` in that same payload, so a resolved failure's stale message can't resurface on a later reload.
- `commitItem`'s success path gets its own small `pushItem(item, { error: null })` (it previously had no client PATCH on success at all, since the commit POST itself durably writes stage status/target) so a stale error doesn't sit next to "Committed → …".
- `autoBuildFailed()` in both `model-builder-progress-matrix.vue` and `model-builder-batch-editor.vue`, plus the store's own `runProgress.failed`, now also honor a persisted `item.error` (OR'd with the existing `lastAutoBuildOutcome === 'failed'` check), so the warning badge and failed count survive resume/reopen instead of resetting to zero.

## Guard

New `utils/scripts/verifyModelBuilderErrorPersistenceGuard.ts` (+ `.test.ts` self-test) walks the four target functions and asserts each contains at least one `pushItem(item, { ..., error: ... })` call, mirroring `verifyModelBuilderAutoBuildOutcomePersistenceGuard.ts`'s style. Wired into `package.json` and `.github/workflows/contract-tests.yml`.

## Verified

- All 81 `test:model-builder-*` npm scripts pass (79 pre-existing + 2 new).
- `vue-tsc --noEmit` clean (repo-wide).
- `eslint`/`prettier --check` clean on touched files — 2 pre-existing `no-empty` errors in `modelBuilderStore.ts` and pre-existing prettier formatting drift on lines this change never touches, both confirmed present on `main` before this change (diffed a `prettier --write` pass against the untouched `HEAD` copies of both files to isolate this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoZfLEzPgNHGt1VboS3DG6)_