### PR TITLE
fix(model-builder): persist item.error on draftText() failure too (model-builder/t-045)

### DIFF
--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -920,14 +920,27 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     pushItem(item, { stageStatuses: item.stages }, { stage: stageKey })
   }
 
+  // error: null (both locally and in the pushed payload) on all three setters
+  // below (model-builder/t-029 cycle 7 left this out of updatePitch/
+  // updateFields/updatePrompt deliberately to keep that fix surgical --
+  // model-builder/t-045 revisits it). markDownstreamStale already invalidates
+  // every downstream stage's approval the moment any of these fire, so a
+  // prior item.error -- whether from a failed AI draft (draftText's own
+  // catch block routes its success back through these same setters, see
+  // below), a failed GENERATE_ASSETS render, or a failed COMMIT -- describes
+  // a stage that no longer reflects what's now stored and has to be redone
+  // anyway. Clearing here uniformly (manual edit or AI draft alike) also
+  // avoids a confusing asymmetry where an AI-redrafted fix clears the item's
+  // error banner but retyping the identical fix by hand does not.
   function updatePitch(itemId: string, value: string): void {
     const item = findItem(itemId)
     if (!item) return
     item.pitch = value
+    item.error = null
     markDownstreamStale(item, 'PITCH')
     pushItem(
       item,
-      { stageStatuses: item.stages, pitch: item.pitch },
+      { stageStatuses: item.stages, pitch: item.pitch, error: null },
       { stage: 'PITCH', reason: 'edited pitch' },
     )
   }
@@ -936,10 +949,15 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     const item = findItem(itemId)
     if (!item) return
     item.fieldsDraft = value
+    item.error = null
     markDownstreamStale(item, 'FIELDS_AND_PROMPTS')
     pushItem(
       item,
-      { stageStatuses: item.stages, fieldsDraft: item.fieldsDraft },
+      {
+        stageStatuses: item.stages,
+        fieldsDraft: item.fieldsDraft,
+        error: null,
+      },
       { stage: 'FIELDS_AND_PROMPTS', reason: 'edited fields' },
     )
   }
@@ -948,10 +966,15 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     const item = findItem(itemId)
     if (!item) return
     item.promptDraft = value
+    item.error = null
     markDownstreamStale(item, 'FIELDS_AND_PROMPTS')
     pushItem(
       item,
-      { stageStatuses: item.stages, promptDraft: item.promptDraft },
+      {
+        stageStatuses: item.stages,
+        promptDraft: item.promptDraft,
+        error: null,
+      },
       { stage: 'FIELDS_AND_PROMPTS', reason: 'edited prompt' },
     )
   }
@@ -1114,7 +1137,28 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       handleError(error, 'drafting model builder text')
       const message =
         error instanceof Error ? error.message : 'Draft request failed.'
+      // Bug (model-builder/t-045): draftText is autoBuildItem's very first
+      // step (PITCH, then FIELDS_AND_PROMPTS) and so is the most-likely-to-
+      // fire failure path of the whole run, but unlike generateItemAsset/
+      // generateItemAssetAsync/pollAsyncArtJob/commitItem (fixed for this in
+      // model-builder/t-029 cycle 7 -- see
+      // verifyModelBuilderErrorPersistenceGuard.ts's doc comment) it never
+      // touched item.error at all, only this transient setStatusForRun
+      // toast. adaptItem always rebuilds a fresh item from `server.error ??
+      // null` on resume/reopen/reload, so an empty/failed AI draft had no
+      // trace left anywhere -- not the item-panel.vue error banner, not the
+      // per-item "failed" badge in model-builder-progress-matrix.vue /
+      // model-builder-batch-editor.vue -- the instant the toast dismissed,
+      // even though the item was still stuck exactly where it failed. The
+      // two mid-flight discard branches above (edited/approved while
+      // drafting) deliberately do NOT set item.error, mirroring
+      // generateItemAsset's/pollAsyncArtJob's own "already approved" race
+      // guards, which don't push item.error either -- those are the draft
+      // request succeeding but being correctly discarded, not a genuine
+      // unresolved failure.
+      item.error = message
       setStatusForRun(runId, 'error', message)
+      pushItem(item, { error: item.error })
       return false
     } finally {
       draftingFieldSingleton.release(draftKey)

--- a/utils/scripts/verifyModelBuilderErrorPersistenceGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderErrorPersistenceGuard.test.ts
@@ -1,14 +1,15 @@
 // /utils/scripts/verifyModelBuilderErrorPersistenceGuard.test.ts
 //
 // Regression test for checkErrorPersistenceGuard() in
-// verifyModelBuilderErrorPersistenceGuard.ts (model-builder/t-029).
-// Exercises the real check against synthetic store-shaped fixtures covering:
-// the pre-fix shape (item.error set locally in all four target functions
-// but never pushed to the server), the fixed shape (each function pushes it
-// somewhere -- mirroring the real store's mix of a dedicated
+// verifyModelBuilderErrorPersistenceGuard.ts (model-builder/t-029;
+// draftText added to TARGET_FUNCTIONS in model-builder/t-045). Exercises the
+// real check against synthetic store-shaped fixtures covering: the pre-fix
+// shape (item.error set locally in all five target functions but never
+// pushed to the server), the fixed shape (each function pushes it somewhere
+// -- mirroring the real store's mix of a dedicated
 // `pushItem(item, { error: ... })` call and one piggybacked onto an
 // existing success-path payload alongside other keys), a partially-fixed
-// shape (only some functions fixed), and all four target functions absent.
+// shape (only some functions fixed), and all five target functions absent.
 import assert from 'node:assert/strict'
 
 import { checkErrorPersistenceGuard } from './verifyModelBuilderErrorPersistenceGuard.js'
@@ -59,6 +60,20 @@ const BUGGY_FIXTURE = `
     } catch (error) {
       item.error = error instanceof Error ? error.message : 'Commit failed.'
       finishCommit(item, { status: 'ready', note: item.error })
+      return false
+    }
+  }
+
+  async function draftText(itemId: string, field: DraftField): Promise<boolean> {
+    const item = findItem(itemId)
+    try {
+      const result = await performFetch('/api/suggest', {})
+      updatePitch(itemId, result.data.value)
+      return true
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Draft request failed.'
+      item.error = message
+      setStatusForRun(runId, 'error', message)
       return false
     }
   }
@@ -126,6 +141,21 @@ const FIXED_FIXTURE = `
       return false
     }
   }
+
+  async function draftText(itemId: string, field: DraftField): Promise<boolean> {
+    const item = findItem(itemId)
+    try {
+      const result = await performFetch('/api/suggest', {})
+      updatePitch(itemId, result.data.value)
+      return true
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Draft request failed.'
+      item.error = message
+      setStatusForRun(runId, 'error', message)
+      pushItem(item, { error: item.error })
+      return false
+    }
+  }
 `
 
 const PARTIALLY_FIXED_FIXTURE = `
@@ -162,6 +192,17 @@ const PARTIALLY_FIXED_FIXTURE = `
       return false
     }
   }
+
+  async function draftText(itemId: string, field: DraftField): Promise<boolean> {
+    try {
+      updatePitch(itemId, 'value')
+      return true
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Draft request failed.'
+      item.error = message
+      return false
+    }
+  }
 `
 
 const MISSING_FIXTURE = `
@@ -175,9 +216,9 @@ const MISSING_FIXTURE = `
 const buggyErrors = checkErrorPersistenceGuard(BUGGY_FIXTURE)
 assert.equal(
   buggyErrors.length,
-  4,
+  5,
   'expected the pre-fix shape (item.error set but never pushed, in all ' +
-    `four functions) to raise 4 errors, got ${buggyErrors.length}: ` +
+    `five functions) to raise 5 errors, got ${buggyErrors.length}: ` +
     JSON.stringify(buggyErrors),
 )
 
@@ -191,25 +232,27 @@ assert.equal(
 const partialErrors = checkErrorPersistenceGuard(PARTIALLY_FIXED_FIXTURE)
 assert.equal(
   partialErrors.length,
-  2,
-  'expected pollAsyncArtJob (never pushes) and generateItemAssetAsync ' +
-    `(never pushes) to be flagged, got ${partialErrors.length}: ` +
+  3,
+  'expected pollAsyncArtJob (never pushes), generateItemAssetAsync (never ' +
+    `pushes), and draftText (never pushes) to be flagged, got ${partialErrors.length}: ` +
     JSON.stringify(partialErrors),
 )
 assert.ok(partialErrors.some((e) => e.includes('pollAsyncArtJob')))
 assert.ok(partialErrors.some((e) => e.includes('generateItemAssetAsync')))
+assert.ok(partialErrors.some((e) => e.includes('draftText')))
 
 const missingErrors = checkErrorPersistenceGuard(MISSING_FIXTURE)
 assert.equal(
   missingErrors.length,
-  4,
-  'expected 4 "function not found" violations when all target functions are absent',
+  5,
+  'expected 5 "function not found" violations when all target functions are absent',
 )
 for (const name of [
   'generateItemAsset',
   'generateItemAssetAsync',
   'pollAsyncArtJob',
   'commitItem',
+  'draftText',
 ]) {
   assert.ok(
     missingErrors.some((e) => e.includes(name)),
@@ -219,7 +262,7 @@ for (const name of [
 
 console.log(
   'Model Builder item.error persistence guard checker verified: flags ' +
-    'item.error set-but-never-pushed in each of the four target ' +
-    'functions independently, clears the fixed shape, and flags all four ' +
+    'item.error set-but-never-pushed in each of the five target ' +
+    'functions independently, clears the fixed shape, and flags all five ' +
     'target functions being absent.',
 )

--- a/utils/scripts/verifyModelBuilderErrorPersistenceGuard.ts
+++ b/utils/scripts/verifyModelBuilderErrorPersistenceGuard.ts
@@ -25,6 +25,13 @@
 // refactor that drops ALL such calls from a function fails loudly; the
 // finer-grained "does every failure branch push" property is exercised by
 // this guard's own self-test fixtures instead.
+//
+// model-builder/t-045 added draftText to TARGET_FUNCTIONS: it's
+// autoBuildItem's very first step and so the most-likely-to-fire failure
+// path of a whole run, but was left out of the original t-029 cycle 7 sweep
+// entirely -- it only ever surfaced a transient setStatusForRun toast, never
+// touching item.error at all, so an empty/failed AI draft left no trace once
+// the toast dismissed.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -41,6 +48,7 @@ const TARGET_FUNCTIONS = [
   'generateItemAssetAsync',
   'pollAsyncArtJob',
   'commitItem',
+  'draftText',
 ] as const
 
 // A pushItem(...) call whose object-literal payload includes `error` as a
@@ -104,9 +112,10 @@ function main(): void {
   console.log(
     'Model Builder item.error persistence guard contract passed: ' +
       'generateItemAsset(), generateItemAssetAsync(), pollAsyncArtJob(), ' +
-      'and commitItem() all push item.error to the server, so a real ' +
-      'failure (and the badge/banner reading it) survives resume/reopen/' +
-      'reload instead of only ever existing in local reactive state.',
+      'commitItem(), and draftText() all push item.error to the server, ' +
+      'so a real failure (and the badge/banner reading it) survives ' +
+      'resume/reopen/reload instead of only ever existing in local ' +
+      'reactive state.',
   )
 }
 


### PR DESCRIPTION
## Bug

`item.error` (`stores/modelBuilderStore.ts`) is a real, server-writable `ModelBuildItem.error` column that `item-panel.vue`'s error banner and the per-item "failed" badge in `model-builder-progress-matrix.vue` / `model-builder-batch-editor.vue` both read. model-builder/t-029 cycle 7 (#1908) persisted it on every `generateItemAsset`/`generateItemAssetAsync`/`pollAsyncArtJob`/`commitItem` failure branch, clearing it on success.

`draftText()` — the AI-drafting function for pitch/fields/artPrompt, and `autoBuildItem`'s very first step — was left out of that sweep. It's the most-likely-to-fire failure path of an auto-build run (an empty/failed AI draft is often the very first thing attempted), but it only ever surfaced a transient toast via `setStatusForRun`. Since `adaptItem` always rebuilds a fresh item from `server.error ?? null` on resume/reopen/reload, a genuine draft failure left no trace anywhere the instant the toast dismissed.

## Fix

- `draftText()`'s catch block (genuine failure: network error, or "the model returned nothing useful") now sets `item.error` and pushes it via `pushItem`, mirroring the other four functions.
  - The two mid-flight *discard* branches inside `draftText` (field was edited, or its stage was approved, while the draft was in flight) deliberately do **not** set `item.error` — this mirrors `generateItemAsset`'s/`pollAsyncArtJob`'s own "already approved" race guards, which also don't push `item.error`. Those are the draft request succeeding but being correctly discarded, not an unresolved failure.
- `updatePitch`/`updateFields`/`updatePrompt` (shared by manual edits and `draftText`'s own success path, since it routes drafted content through these exact setters) now also clear `item.error` locally and in the pushed payload.
  - This was left out of cycle 7 deliberately to keep that fix surgical. Revisiting it now: `draftText`'s success path funnels through these setters, so this is the natural place for a successful re-draft (after a prior failed attempt) to actually clear the stale error. Extending it uniformly to manual edits too avoids a confusing asymmetry where an AI-redrafted fix clears the error banner but retyping the identical fix by hand does not. `markDownstreamStale` already invalidates every downstream stage's approval the moment any of these fire, so a prior `item.error` (from a failed draft, art render, or commit) describes a stage that has to be redone anyway.
- Extended the existing `verifyModelBuilderErrorPersistenceGuard.ts` guard's `TARGET_FUNCTIONS` to include `draftText` (and updated its self-test fixtures/assertions to match), rather than adding a new guard file — same contract, same `npm run test:model-builder-error-persistence-guard{,-selftest}` scripts already wired into `contract-tests.yml`, so no workflow changes were needed.

## Verification

- All 81 `test:model-builder-*` npm scripts pass, including the extended `test:model-builder-error-persistence-guard` and its `-selftest`.
- `vue-tsc --noEmit -p tsconfig.json` is clean.
- `eslint` on the touched files reports only the two pre-existing `no-empty` findings in `modelBuilderStore.ts` (confirmed present on `main` before this change via `git stash` — unrelated to this diff).
- `prettier --check` passes on both touched guard/test files. `modelBuilderStore.ts` itself has pre-existing formatting drift unrelated to the lines touched here (confirmed on `main` before this change too); running `prettier --write` on a scratch copy produced no changes anywhere near the new code, so the added lines are already Prettier-clean.
- `git status --porcelain` confirms the diff touches only `stores/modelBuilderStore.ts`, `utils/scripts/verifyModelBuilderErrorPersistenceGuard.ts`, and `utils/scripts/verifyModelBuilderErrorPersistenceGuard.test.ts`.


---
_Generated by [Claude Code](https://claude.ai/code/session_014Vh9rzNApebooJyRdm6oJW)_