### PR TITLE
fix(davinci): announce the resuming-run skeleton to assistive tech (davinci/t-021)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -257,6 +257,12 @@ jobs:
       - name: Da Vinci narrating-status guard
         run: npm run test:davinci-narrating-status-guard
 
+      - name: Da Vinci resuming-status guard self-test
+        run: npm run test:davinci-resuming-status-guard-selftest
+
+      - name: Da Vinci resuming-status guard
+        run: npm run test:davinci-resuming-status-guard
+
       - name: Serendipity Voice poll guard self-test
         run: npm run test:serendipity-voice-poll-guard-selftest
 

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -37,11 +37,24 @@
           </NuxtLink>
         </div>
 
-        <!-- Resuming an existing run -->
+        <!-- Resuming an existing run. Purely visual animate-pulse skeleton
+             with no role/aria-live/text carried no announcement to
+             assistive tech -- the exact gap slice 4 fixed for the
+             narrating busy state below, left unfixed here because this is
+             a different busy state (page-load resume, not chapter
+             narration). Matches model-builder-manager.vue's identical
+             `resumingRun` state (role="status" + aria-live="polite" +
+             visible/sr-only text), and academy-manager.vue's
+             `isLoadingManager` state, which both cover comparable "we're
+             restoring something on load" moments the same way. -->
         <div
           v-else-if="phase === 'loading'"
+          role="status"
+          aria-live="polite"
           class="h-40 animate-pulse rounded-2xl border border-base-300 bg-base-200"
-        />
+        >
+          <span class="sr-only">Resuming your life…</span>
+        </div>
 
         <!-- Start a new life -->
         <form

--- a/package.json
+++ b/package.json
@@ -85,6 +85,8 @@
     "test:davinci-resolve-panel-guard": "tsx utils/scripts/verifyDaVinciResolvePanelGuard.ts",
     "test:davinci-narrating-status-guard-selftest": "tsx utils/scripts/verifyDaVinciNarratingStatusGuard.test.ts",
     "test:davinci-narrating-status-guard": "tsx utils/scripts/verifyDaVinciNarratingStatusGuard.ts",
+    "test:davinci-resuming-status-guard-selftest": "tsx utils/scripts/verifyDaVinciResumingStatusGuard.test.ts",
+    "test:davinci-resuming-status-guard": "tsx utils/scripts/verifyDaVinciResumingStatusGuard.ts",
     "test:serendipity-voice-poll-guard-selftest": "tsx utils/scripts/verifySerendipityVoicePollGuard.test.ts",
     "test:serendipity-voice-poll-guard": "tsx utils/scripts/verifySerendipityVoicePollGuard.ts",
     "test:serendipity-voice-cursor-reset-selftest": "tsx utils/scripts/verifySerendipityVoiceCursorReset.test.ts",

--- a/utils/scripts/verifyDaVinciResumingStatusGuard.test.ts
+++ b/utils/scripts/verifyDaVinciResumingStatusGuard.test.ts
@@ -1,0 +1,113 @@
+// /utils/scripts/verifyDaVinciResumingStatusGuard.test.ts
+//
+// Regression test for checkResumingStatusGuard() in
+// verifyDaVinciResumingStatusGuard.ts (davinci/t-021 slice 5). Exercises the
+// real check against synthetic component-shaped fixtures covering: the
+// fixed shape (role="status" + aria-live="polite" on the wrapper, plus an
+// sr-only text node), a missing-role regression, a missing-aria-live
+// regression, a missing-text regression (role/aria-live present but the
+// skeleton stays empty), and a missing-block regression (the resuming state
+// removed entirely).
+import assert from 'node:assert/strict'
+
+import { checkResumingStatusGuard } from './verifyDaVinciResumingStatusGuard.js'
+
+function fixture(wrapperAttrs: string, innerText: string): string {
+  return `
+<template>
+  <div
+    v-else-if="phase === 'loading'"
+    ${wrapperAttrs}
+    class="h-40 animate-pulse rounded-2xl border border-base-300 bg-base-200"
+  >
+    ${innerText}
+  </div>
+
+  <!-- Start a new life -->
+  <form v-else-if="phase === 'start'" class="flex flex-col gap-3">
+    <p>Seed a fresh life.</p>
+  </form>
+</template>
+`
+}
+
+const FIXED = fixture(
+  'role="status" aria-live="polite"',
+  '<span class="sr-only">Resuming your life…</span>',
+)
+
+// Pre-fix shape: no accessibility attributes and no text content at all.
+const BUGGY = fixture('', '')
+
+// role="status" present but aria-live dropped.
+const NO_ARIA_LIVE = fixture(
+  'role="status"',
+  '<span class="sr-only">Resuming your life…</span>',
+)
+
+// Both wrapper attributes present, but the skeleton stays textless.
+const NO_TEXT = fixture('role="status" aria-live="polite"', '')
+
+// The resuming state itself no longer exists.
+const BLOCK_REMOVED = `
+<template>
+  <div v-else-if="somethingElse" class="flex flex-col items-center gap-3">
+    <p>Unrelated state.</p>
+  </div>
+
+  <!-- Start a new life -->
+  <form v-else-if="phase === 'start'" class="flex flex-col gap-3">
+    <p>Seed a fresh life.</p>
+  </form>
+</template>
+`
+
+function run(): void {
+  const fixedErrors = checkResumingStatusGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const buggyErrors = checkResumingStatusGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    3,
+    `expected the buggy fixture to fail all three checks, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(buggyErrors.some((e) => /no longer carries role="status"/.test(e)))
+  assert.ok(
+    buggyErrors.some((e) => /no longer carries aria-live="polite"/.test(e)),
+  )
+  assert.ok(
+    buggyErrors.some((e) => /no longer contains any text content/.test(e)),
+  )
+
+  const noAriaLiveErrors = checkResumingStatusGuard(NO_ARIA_LIVE)
+  assert.equal(noAriaLiveErrors.length, 1)
+  assert.ok(
+    noAriaLiveErrors.some((e) =>
+      /no longer carries aria-live="polite"/.test(e),
+    ),
+  )
+
+  const noTextErrors = checkResumingStatusGuard(NO_TEXT)
+  assert.equal(noTextErrors.length, 1)
+  assert.ok(
+    noTextErrors.some((e) => /no longer contains any text content/.test(e)),
+  )
+
+  const blockRemovedErrors = checkResumingStatusGuard(BLOCK_REMOVED)
+  assert.equal(blockRemovedErrors.length, 1)
+  assert.ok(blockRemovedErrors.some((e) => /Could not find a/.test(e)))
+
+  console.log(
+    'Da Vinci resuming-status guard self-test passed: buggy fixture fails ' +
+      'all three checks, fixed fixture passes, and the missing-role/' +
+      'missing-aria-live/missing-text/missing-block regressions all fail ' +
+      'individually as expected.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyDaVinciResumingStatusGuard.ts
+++ b/utils/scripts/verifyDaVinciResumingStatusGuard.ts
@@ -1,0 +1,129 @@
+// /utils/scripts/verifyDaVinciResumingStatusGuard.ts
+//
+// Regression guard (davinci/t-021 slice 5) -- the "Resuming an existing run"
+// skeleton in components/conductor/davinci-page.vue (rendered while
+// `phase === 'loading'`, on every page load that finds a stored run id in
+// localStorage) was a purely visual `animate-pulse` div: no role="status",
+// no aria-live, and no text content at all. Assistive tech got zero signal
+// that anything was happening during that load. This is the same shape of
+// gap davinci/t-021 slice 4 fixed for the narrating/busy spinner
+// (verifyDaVinciNarratingStatusGuard.ts) -- a different busy state in the
+// same file was left uncovered. Every comparable "restoring something on
+// page load" state elsewhere in the app announces itself the same way: see
+// model-builder-manager.vue's `resumingRun` block (role="status" +
+// aria-live="polite" + visible text) and academy-manager.vue's
+// `isLoadingManager` block (role="status" + aria-live="polite" +
+// aria-busy="true" + visible text).
+//
+// This asserts the textual shape of the fix stays in place: the div
+// wrapping `v-else-if="phase === 'loading'"` carries role="status" and
+// aria-live="polite", and contains a text node (sr-only or otherwise) so a
+// screen reader actually has something to announce -- an empty role="status"
+// element announces nothing. Deliberately scoped to this one template
+// block, mirroring this project's other narrow textual guards over a
+// general-purpose static analyzer (see verifyDaVinciDimensionToneGuard.ts).
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const COMPONENT_PATH = join(
+  repositoryRoot,
+  'components/conductor/davinci-page.vue',
+)
+
+// Anchored on the `phase === 'loading'` marker rather than any surrounding
+// wording, so this guard reports *which* attribute regressed instead of
+// just "not found" if the block is edited.
+const BLOCK_MARKER = "phase === 'loading'"
+const NEXT_BLOCK_MARKER = '<!-- Start a new life'
+
+export function extractResumingBlock(content: string): string | null {
+  const markerIndex = content.indexOf(BLOCK_MARKER)
+  if (markerIndex === -1) return null
+
+  const tagStart = content.lastIndexOf('<div', markerIndex)
+  if (tagStart === -1) return null
+  const openingTagEnd = content.indexOf('>', markerIndex)
+  if (openingTagEnd === -1) return null
+
+  const nextBlockIndex = content.indexOf(NEXT_BLOCK_MARKER, openingTagEnd)
+  const blockEnd = nextBlockIndex === -1 ? content.length : nextBlockIndex
+
+  return content.slice(tagStart, blockEnd)
+}
+
+export function checkResumingStatusGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const block = extractResumingBlock(content)
+  if (!block) {
+    errors.push(
+      'Could not find a <div v-else-if="phase === \'loading\'"> block in ' +
+        'davinci-page.vue -- has the resuming/loading state been ' +
+        'restructured or removed? If so, this guard needs to move with it.',
+    )
+    return errors
+  }
+
+  const openingTagEnd = block.indexOf('>')
+  const openingTag = block.slice(0, openingTagEnd + 1)
+
+  if (!openingTag.includes('role="status"')) {
+    errors.push(
+      "The resuming block's wrapping <div> no longer carries " +
+        'role="status" -- assistive tech gets no signal that an existing ' +
+        'run is being restored on page load, unlike every comparable ' +
+        '"restoring on load" state elsewhere in the app ' +
+        "(model-builder-manager.vue's resumingRun, " +
+        "academy-manager.vue's isLoadingManager).",
+    )
+  }
+
+  if (!openingTag.includes('aria-live="polite"')) {
+    errors.push(
+      "The resuming block's wrapping <div> no longer carries " +
+        'aria-live="polite" -- a screen reader would not be told when ' +
+        'this state appears.',
+    )
+  }
+
+  const afterOpeningTag = block.slice(openingTagEnd + 1)
+  if (!/\S/.test(afterOpeningTag.replace(/<[^>]*>/g, ''))) {
+    errors.push(
+      'The resuming block no longer contains any text content -- an ' +
+        'empty role="status" element announces nothing to assistive ' +
+        'tech, so the skeleton needs a visible or sr-only text node (e.g. ' +
+        '`<span class="sr-only">Resuming your life…</span>`).',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(COMPONENT_PATH, 'utf8')
+  const errors = checkResumingStatusGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Da Vinci resuming-status guard contract failed in davinci-page.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Da Vinci resuming-status guard contract passed: the "Resuming an ' +
+      'existing run" skeleton announces itself to assistive tech via ' +
+      'role="status"/aria-live="polite" plus a real text node, matching ' +
+      'every other "restoring on page load" convention in the app.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## davinci/t-021 — Slice 5

Recurring Da Vinci visual style / interaction polish pass. This is slice 5, following the established convention from slices 1-4 (dimension-tone pills, narration-error tone fix, resolve-panel exclusion, narrating-status aria pattern).

### Convention compared against
`role="status"` + `aria-live="polite"` wrapper + `aria-hidden="true"` spinner (or a real text node) for busy/loading states — used consistently across `academy-manager.vue` (`isLoadingManager`), `model-builder-manager.vue` (`resumingRun`), `model-builder-run-history.vue`, `narrative-response-composer.vue`, `kr-chat-window.vue`, `watchlist-browse.vue`, `narrative-ingredient-picker.vue`, and by `davinci-page.vue`'s own `narrating` busy state (fixed in slice 4).

### Gap found
`davinci-page.vue`'s **"Resuming an existing run"** skeleton — rendered while `phase === 'loading'`, i.e. on every page load where a stored run id is found in `localStorage` — was a purely visual `animate-pulse` `<div>` with **no `role`, no `aria-live`, and no text content at all**. This is the exact same category of gap slice 4 fixed for the `narrating` state, just on a *different* busy state in the same file that was missed. `model-builder-manager.vue`'s `resumingRun` block covers the literally identical semantic moment ("restoring a run on load") with `role="status"` + `aria-live="polite"` + visible text, confirming this is a real, established convention this file should also follow.

### Fix
Added `role="status"` and `aria-live="polite"` to the wrapping div, plus an `sr-only` `"Resuming your life…"` text node (an empty `role="status"` element announces nothing to assistive tech, so a text node was required, not just the attributes).

### Guard added
`utils/scripts/verifyDaVinciResumingStatusGuard.ts` + `verifyDaVinciResumingStatusGuard.test.ts`, following the exact pattern of the 4 existing guards (`verifyDaVinciNarratingStatusGuard.ts` et al.) — a narrow textual check anchored on the `phase === 'loading'` marker, asserting `role="status"`, `aria-live="polite"`, and non-empty text content survive future edits. Wired into `package.json` (`test:davinci-resuming-status-guard[-selftest]`) and `.github/workflows/contract-tests.yml` alongside the existing four.

### Verification (all run against this branch)
- `npm run test:davinci-resuming-status-guard-selftest` — **pass**
- `npm run test:davinci-resuming-status-guard` — **pass**
- `npm run test:davinci-dimension-tone-guard-selftest` / `test:davinci-dimension-tone-guard` — **pass** (slice 1, unaffected)
- `npm run test:davinci-narration-error-tone-guard-selftest` / `test:davinci-narration-error-tone-guard` — **pass** (slice 2, unaffected)
- `npm run test:davinci-resolve-panel-guard-selftest` / `test:davinci-resolve-panel-guard` — **pass** (slice 3, unaffected)
- `npm run test:davinci-narrating-status-guard-selftest` / `test:davinci-narrating-status-guard` — **pass** (slice 4, unaffected)
- `npm run test:davinci-narration` — **pass** (all 26 checks)
- `npm run test:layout-contract` — **holds, no new violations** (an unrelated pre-existing `viewport-grid` baseline improvement note appeared, not caused by this change and not touched)
- `npx eslint components/conductor/davinci-page.vue utils/scripts/verifyDaVinciResumingStatusGuard.ts utils/scripts/verifyDaVinciResumingStatusGuard.test.ts` — **clean, no output**
- `npx prettier --check` on all touched files — **clean**
- `npx vue-tsc --noEmit` (repo-wide) — **exit 0, no output**
- `git status --porcelain` — exactly the 5 intended files: `.github/workflows/contract-tests.yml`, `components/conductor/davinci-page.vue`, `package.json`, `utils/scripts/verifyDaVinciResumingStatusGuard.ts` (new), `utils/scripts/verifyDaVinciResumingStatusGuard.test.ts` (new)

### Production preview check
Per repo convention (self-hosted, no Vercel previews): did a lightweight direct-HTTPS check against the **currently-deployed `main`** (this PR isn't merged yet, so this checks the pre-fix state, not the fix itself):
- `curl https://kindrobots.org/conductor` → HTTP 200, SSR markup mentions "Da Vinci"/davinci project card.
- `curl https://kindrobots.org/play/davinci` → HTTP 200, SSR markup includes `davinci-page.vue`'s logged-out interactive branch ("Live a life", "Log in to play", "Begin a life").
- This was an **anonymous, unauthenticated curl**, so the `phase === 'loading'` resuming-run branch this PR touches is not reachable in that SSR snapshot (it only renders for a logged-in user with a stored run id in `localStorage`, a client-side, post-hydration condition). This confirms the route mounts and SSRs correctly but is **not** a pixel-level or authenticated verification of the specific fixed markup — noting that plainly rather than claiming more than was checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHocZvJJDfMadJ91BEDkSw)_