### PR TITLE
fix(serendipity-voice): reject unsupported animation actions instead of faking success (alexa-integration/t-015)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -275,6 +275,12 @@ jobs:
       - name: Serendipity Voice cursor-reset guard
         run: npm run test:serendipity-voice-cursor-reset
 
+      - name: Serendipity Voice action guard self-test
+        run: npm run test:serendipity-voice-action-guard-selftest
+
+      - name: Serendipity Voice action guard
+        run: npm run test:serendipity-voice-action-guard
+
       - name: Pack manifest validator self-test
         run: npm run test:pack-manifest
 

--- a/package.json
+++ b/package.json
@@ -91,6 +91,8 @@
     "test:serendipity-voice-poll-guard": "tsx utils/scripts/verifySerendipityVoicePollGuard.ts",
     "test:serendipity-voice-cursor-reset-selftest": "tsx utils/scripts/verifySerendipityVoiceCursorReset.test.ts",
     "test:serendipity-voice-cursor-reset": "tsx utils/scripts/verifySerendipityVoiceCursorReset.ts",
+    "test:serendipity-voice-action-guard-selftest": "tsx utils/scripts/verifySerendipityVoiceActionGuard.test.ts",
+    "test:serendipity-voice-action-guard": "tsx utils/scripts/verifySerendipityVoiceActionGuard.ts",
     "test:achievement-store": "tsx utils/scripts/verifyAchievementStoreFetchSafety.ts",
     "test:achievement-catalog": "tsx utils/scripts/verifyDatabaseRetry.ts && tsx utils/scripts/verifyAchievementArtJobDedupe.ts && tsx utils/scripts/verifyAchievementCatalog.ts",
     "seed:achievements": "tsx scripts/seed_achievements.ts",

--- a/stores/serendipityVoiceStore.ts
+++ b/stores/serendipityVoiceStore.ts
@@ -216,6 +216,26 @@ export const useSerendipityVoiceStore = defineStore(
         return
       }
 
+      // 'set' and 'draft' are only meaningful for the theme/art targets
+      // (VoiceBusCommand's action union is shared across all targets). An
+      // animation command carrying one of them falls outside every branch
+      // below -- without this guard it would resolve an effect id, skip the
+      // on/off/toggle toggle entirely (nothing actually changes), then still
+      // fall through to the unconditional setSurfacePlacement() call and the
+      // default-to-"on" verb, reporting a false "Applied: <effect> on." to
+      // the feed and the voice ack even though no effect state changed.
+      if (
+        command.action !== 'on' &&
+        command.action !== 'off' &&
+        command.action !== 'toggle'
+      ) {
+        pushLocalMessage(
+          'system',
+          `Ignored unsupported animation action: ${command.action}`,
+        )
+        return
+      }
+
       const effectId = resolveEffectId(command)
       if (!effectId) {
         const message = `Could not match animation "${command.effect ?? command.effectId ?? 'unknown'}".`

--- a/utils/scripts/verifySerendipityVoiceActionGuard.test.ts
+++ b/utils/scripts/verifySerendipityVoiceActionGuard.test.ts
@@ -1,0 +1,138 @@
+// /utils/scripts/verifySerendipityVoiceActionGuard.test.ts
+//
+// Regression test for checkSerendipityVoiceActionGuard() in
+// verifySerendipityVoiceActionGuard.ts (alexa-integration/t-015). Exercises
+// the real check against synthetic applyCommand()-shaped fixtures covering:
+// the pre-fix shape (no action guard at all), the fixed shape (the guard
+// sits between the 'clear' handling and resolveEffectId()), a misplaced-
+// guard regression (the check exists but after resolveEffectId() has
+// already run, too late to stop the animationStore lookup from proceeding
+// on an unsupported action), and a missing-function fixture.
+import assert from 'node:assert/strict'
+
+import { checkSerendipityVoiceActionGuard } from './verifySerendipityVoiceActionGuard.js'
+
+function fixture(opts: { actionGuard: string }): string {
+  return `
+    function applyCommand(command: VoiceBusCommand): void {
+      if (command.target === 'theme') {
+        applyThemeCommand(command)
+        return
+      }
+
+      if (command.target === 'art') {
+        applyArtCommand(command)
+        return
+      }
+
+      if (command.target !== 'animation') {
+        pushLocalMessage('system', \`Ignored unsupported command target: \${command.target}\`)
+        return
+      }
+
+      if (command.action === 'clear') {
+        animationStore.clearScreenEffects()
+        lastAppliedText.value = 'Cleared all animations'
+        pushLocalMessage('system', 'Applied: cleared all animations.')
+        void postAck('Serendipity view: cleared all animations.')
+        return
+      }
+
+      ${opts.actionGuard}
+
+      const effectId = resolveEffectId(command)
+      if (!effectId) {
+        return
+      }
+
+      const active = animationStore.isScreenEffectActive(effectId)
+      if (command.action === 'on' && !active) animationStore.toggleScreenEffect(effectId)
+      else if (command.action === 'off' && active) animationStore.toggleScreenEffect(effectId)
+      else if (command.action === 'toggle') animationStore.toggleScreenEffect(effectId)
+
+      if (command.action !== 'off') {
+        animationStore.setSurfacePlacement(normalizeRegion(command.surface), 'front')
+      }
+    }
+  `
+}
+
+const ACTION_GUARD = `if (
+        command.action !== 'on' &&
+        command.action !== 'off' &&
+        command.action !== 'toggle'
+      ) {
+        pushLocalMessage('system', \`Ignored unsupported animation action: \${command.action}\`)
+        return
+      }`
+
+const FIXED = fixture({ actionGuard: ACTION_GUARD })
+
+// Pre-fix: no action guard at all -- a command with action 'set' or 'draft'
+// targeting 'animation' falls through to a false "applied" message.
+const BUGGY = fixture({ actionGuard: '' })
+
+// Misplaced regression: the guard exists, but after resolveEffectId() and
+// the animationStore lookups have already run instead of before them.
+const GUARD_TOO_LATE = `
+    function applyCommand(command: VoiceBusCommand): void {
+      if (command.target !== 'animation') {
+        pushLocalMessage('system', \`Ignored unsupported command target: \${command.target}\`)
+        return
+      }
+
+      if (command.action === 'clear') {
+        animationStore.clearScreenEffects()
+        return
+      }
+
+      const effectId = resolveEffectId(command)
+      if (!effectId) {
+        return
+      }
+
+      ${ACTION_GUARD}
+
+      const active = animationStore.isScreenEffectActive(effectId)
+      if (command.action === 'on' && !active) animationStore.toggleScreenEffect(effectId)
+    }
+  `
+
+function run(): void {
+  const fixedErrors = checkSerendipityVoiceActionGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const buggyErrors = checkSerendipityVoiceActionGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    1,
+    `expected the pre-fix fixture (no action guard) to fail once, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(/no longer rejects command\.action values/.test(buggyErrors[0]!))
+
+  const tooLateErrors = checkSerendipityVoiceActionGuard(GUARD_TOO_LATE)
+  assert.equal(
+    tooLateErrors.length,
+    1,
+    `expected a guard placed after resolveEffectId() to fail once, got: ${JSON.stringify(tooLateErrors)}`,
+  )
+  assert.ok(/not between/.test(tooLateErrors[0]!))
+
+  const missingFnErrors = checkSerendipityVoiceActionGuard(
+    'function someOtherFunction(): void {}',
+  )
+  assert.equal(missingFnErrors.length, 1)
+  assert.ok(/Could not find a function named/.test(missingFnErrors[0]!))
+
+  console.log(
+    'Serendipity Voice action guard self-test passed: buggy fixture fails, ' +
+      'fixed fixture passes, a too-late-guard fixture fails, missing-' +
+      'function fixture fails clearly.',
+  )
+}
+
+run()

--- a/utils/scripts/verifySerendipityVoiceActionGuard.ts
+++ b/utils/scripts/verifySerendipityVoiceActionGuard.ts
@@ -1,0 +1,149 @@
+// /utils/scripts/verifySerendipityVoiceActionGuard.ts
+//
+// Regression guard (alexa-integration/t-015) -- applyCommand() in
+// stores/serendipityVoiceStore.ts branches on `command.target`, and for an
+// unsupported target it explicitly pushes an "Ignored unsupported command
+// target" message instead of pretending anything happened. But
+// VoiceBusCommand's `action` field ('on' | 'off' | 'toggle' | 'clear' |
+// 'set' | 'draft') is shared across every target, even though 'set' and
+// 'draft' are only meaningful for the theme/art targets. Before the fix,
+// target === 'animation' had no equivalent guard for `action`: a command
+// with action 'set' or 'draft' would resolve an effect id, skip every
+// on/off/toggle branch (so no effect state actually changed), then still
+// fall through to the unconditional setSurfacePlacement() call and the
+// verb ternary's default of "on" -- reporting a false "Applied: <effect>
+// on." to the message feed and the voice ack even though nothing toggled.
+//
+// Fixed by rejecting any target === 'animation' command whose action isn't
+// 'on' | 'off' | 'toggle' (action 'clear' is handled, and returns, earlier)
+// with the same "ignored, not applied" shape already used for unsupported
+// targets, before resolveEffectId() or any animationStore mutation runs.
+//
+// This asserts the textual shape of that fix stays in place: applyCommand()
+// contains a guard rejecting action values outside 'on'/'off'/'toggle'
+// (after the 'clear' handling, before resolveEffectId() is called) that
+// pushes a message and returns rather than falling through --
+// deliberately scoped to this one function/bug, mirroring this project's
+// other narrow textual guards over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/serendipityVoiceStore.ts')
+
+function extractFunctionSource(content: string, name: string): string | null {
+  const signature = new RegExp(
+    `^\\s*(?:async\\s+)?function ${name}\\([^)]*\\)[^{]*\\{`,
+    'm',
+  )
+  const match = signature.exec(content)
+  if (!match) return null
+
+  const braceOpen = match.index + match[0].length - 1
+  let depth = 0
+  let i = braceOpen
+  for (; i < content.length; i++) {
+    if (content[i] === '{') depth++
+    else if (content[i] === '}') {
+      depth--
+      if (depth === 0) break
+    }
+  }
+  if (depth !== 0) return null
+  return content.slice(braceOpen, i + 1)
+}
+
+export function checkSerendipityVoiceActionGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const body = extractFunctionSource(content, 'applyCommand')
+  if (!body) {
+    errors.push(
+      'Could not find a function named applyCommand() -- has it been ' +
+        'renamed, removed, or restructured? If so, this guard (and the ' +
+        'false-success-on-unsupported-animation-action bug it protects ' +
+        'against) needs to move with it.',
+    )
+    return errors
+  }
+
+  const clearIndex = body.search(/command\.action\s*===\s*'clear'/)
+  const resolveIndex = body.search(/resolveEffectId\(command\)/)
+  const actionGuardMatch = body.match(
+    /command\.action\s*!==\s*'on'\s*&&\s*command\.action\s*!==\s*'off'\s*&&\s*command\.action\s*!==\s*'toggle'/,
+  )
+
+  if (clearIndex === -1) {
+    errors.push(
+      "applyCommand() no longer handles command.action === 'clear' -- has " +
+        'the animation-command dispatch shape changed? This guard assumes ' +
+        'that structure to locate the unsupported-action check.',
+    )
+  }
+
+  if (resolveIndex === -1) {
+    errors.push(
+      'applyCommand() no longer calls resolveEffectId(command) -- has the ' +
+        'animation-command dispatch shape changed? This guard assumes that ' +
+        'structure to locate the unsupported-action check.',
+    )
+  }
+
+  if (!actionGuardMatch) {
+    errors.push(
+      'applyCommand() no longer rejects command.action values outside ' +
+        "'on' / 'off' / 'toggle' before applying an animation command -- " +
+        "without it, a command with action 'set' or 'draft' targeting " +
+        "'animation' resolves an effect id, skips every on/off/toggle " +
+        'branch (so nothing actually changes), then still falls through to ' +
+        'setSurfacePlacement() and a default "on" verb, reporting a false ' +
+        '"Applied: <effect> on." to the feed and the voice ack even though ' +
+        'no effect state changed.',
+    )
+  } else if (
+    clearIndex !== -1 &&
+    resolveIndex !== -1 &&
+    !(
+      actionGuardMatch.index! > clearIndex &&
+      actionGuardMatch.index! < resolveIndex
+    )
+  ) {
+    errors.push(
+      'applyCommand() contains the action-guard check, but not between ' +
+        "the 'clear' handling and resolveEffectId(command) -- it must run " +
+        'before any effect id is resolved or animationStore is touched, so ' +
+        'an unsupported action never has a chance to fall through to a ' +
+        'false "applied" message.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkSerendipityVoiceActionGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Serendipity Voice action guard contract failed in ' +
+        'serendipityVoiceStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Serendipity Voice action guard contract passed: applyCommand() ' +
+      'rejects unsupported animation actions instead of silently reporting ' +
+      'a false "applied" message.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
alexa-integration/t-015 — Polish and upgrade Voice Lab front-end surface (recurring). Fresh read-through of `serendipityVoiceStore.ts`, `voice-lab-page.vue`, and `serendipity-page.vue` looking for a bug/gap distinct from the prior poll-overlap (#1127), stale-poll-after-stop (#1847), and cursor-reset (#1888) fixes.

### What changed
- `stores/serendipityVoiceStore.ts`: `applyCommand()` now rejects animation commands whose `action` isn't `on`/`off`/`toggle` (e.g. `set`/`draft` — valid for other command targets like `theme`/`art`, but meaningless for `animation`) by reporting them as ignored, mirroring the existing unsupported-*target* handling. Previously such a command fell through every `on`/`off`/`toggle` branch untouched, still hit the unconditional `setSurfacePlacement()` call, and posted a false `"Applied: <effect> on."` message/ack even though the effect's actual on/off state never changed.
- Added `utils/scripts/verifySerendipityVoiceActionGuard.ts` + `.test.ts` as a regression guard, following the existing `verifySerendipityVoicePollGuard.ts` / `verifySerendipityVoiceCursorReset.ts` convention.
- Wired the new guard + its self-test into `package.json` scripts and `.github/workflows/contract-tests.yml`.

### How I verified
- New guard self-test and guard both pass (exit 0): buggy fixture fails, fixed fixture passes, too-late-guard fixture fails, missing-function fixture fails clearly.
- Existing poll-guard and cursor-reset guards still pass (no regression).
- `eslint` clean on touched files; `prettier --check` clean.
- Full-project `vue-tsc --noEmit` clean.
- `git status --porcelain` showed only the 5 intended files changed.

### Stakes
reversible

### Notes for reviewer
Scoped narrowly to this one bug; did not touch the already-fixed pollInFlight/stale-poll/cursor-reset logic or the known-blocked dashboard-tab art generation item (render backlog still unhealthy).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUP3ksbM9N1CCkN8hs9kdv)_