### PR TITLE
fix(appmaker): surface real project descriptions on fleet cards (appmaker/t-012)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -230,6 +230,12 @@ jobs:
       - name: AppMaker slug-candidate guard
         run: npm run test:appmaker-slug-candidate-guard
 
+      - name: AppMaker fleet-description guard self-test
+        run: npm run test:appmaker-fleet-description-guard-selftest
+
+      - name: AppMaker fleet-description guard
+        run: npm run test:appmaker-fleet-description-guard
+
       - name: Da Vinci narration bounds contract
         run: npm run test:davinci-narration
 

--- a/components/pages/appmaker-page.vue
+++ b/components/pages/appmaker-page.vue
@@ -233,10 +233,26 @@ const fleet = computed<FleetApp[]>(() =>
       (candidate) => candidate.slug === slug,
     )
     const tasks = project?.tasks ?? []
+    // scripts/new_app.py seeds every scaffolded app's roadmap.yaml with
+    // milestones/tasks up front, so `tasks.length === 0` is essentially
+    // never true for a real, registry-tracked app — it only happens in the
+    // brief/degraded window before conductorStore has this project's data
+    // at all. That made the old `tasks.length === 0 ? 'Freshly
+    // scaffolded.' : ''` check backwards in practice: every successfully
+    // tracked app showed a permanently blank description, and the "Freshly
+    // scaffolded." message only ever appeared when the project lookup
+    // *failed*. Prefer the project's real one-line description (`goal`,
+    // falling back to `notesFromSilas` — new_app.py always seeds the
+    // latter, even if just its "Define what this app is before building."
+    // placeholder) so the card shows something meaningful once the app is
+    // actually tracked, and reserve "Freshly scaffolded." for when there is
+    // truly no project data yet.
+    const description = project?.goal || project?.notesFromSilas || ''
     return {
       slug,
       title: project?.name || titleize(slug),
-      description: tasks.length === 0 ? 'Freshly scaffolded.' : '',
+      description:
+        description || (tasks.length === 0 ? 'Freshly scaffolded.' : ''),
       taskDone: tasks.filter((task) => task.status === 'done').length,
       taskTotal: tasks.length,
       needsHuman: tasks.filter((task) => task.status === 'needs-human').length,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "test:app-base-url": "tsx utils/scripts/verifyAppBaseUrl.ts",
     "test:appmaker-slug-candidate-guard-selftest": "tsx utils/scripts/verifyAppmakerSlugCandidateGuard.test.ts",
     "test:appmaker-slug-candidate-guard": "tsx utils/scripts/verifyAppmakerSlugCandidateGuard.ts",
+    "test:appmaker-fleet-description-guard-selftest": "tsx utils/scripts/verifyAppmakerFleetDescriptionGuard.test.ts",
+    "test:appmaker-fleet-description-guard": "tsx utils/scripts/verifyAppmakerFleetDescriptionGuard.ts",
     "test:comment-prefix": "tsx utils/scripts/verifyPartialPublishPrefix.ts",
     "test:comment-quality": "tsx utils/scripts/verifyCommentDraftQuality.ts",
     "test:population-quality": "tsx utils/scripts/verifyPopulationDraftQuality.ts",

--- a/utils/scripts/verifyAppmakerFleetDescriptionGuard.test.ts
+++ b/utils/scripts/verifyAppmakerFleetDescriptionGuard.test.ts
@@ -1,0 +1,133 @@
+// /utils/scripts/verifyAppmakerFleetDescriptionGuard.test.ts
+//
+// Regression test for checkFleetDescriptionGuard() in
+// verifyAppmakerFleetDescriptionGuard.ts (appmaker/t-012). Exercises the
+// real check against synthetic component-shaped fixtures covering: the
+// fixed shape (description prefers goal, then notesFromSilas, then the
+// empty-task literal), the pre-fix shape (description only ever the
+// empty-task literal), and partial regressions (only one of the two real
+// fields dropped).
+import assert from 'node:assert/strict'
+
+import { checkFleetDescriptionGuard } from './verifyAppmakerFleetDescriptionGuard.js'
+
+function fixture(fleetBody: string): string {
+  return `
+<script setup lang="ts">
+const slugError = computed(() => '')
+
+const fleet = computed<FleetApp[]>(() =>
+${fleetBody}
+)
+</script>
+`
+}
+
+const FIXED = fixture(`
+  scaffolded.value.map((slug) => {
+    const project = conductorStore.projects.find(
+      (candidate) => candidate.slug === slug,
+    )
+    const tasks = project?.tasks ?? []
+    const description =
+      project?.goal || project?.notesFromSilas || ''
+    return {
+      slug,
+      title: project?.name || titleize(slug),
+      description: description || (tasks.length === 0 ? 'Freshly scaffolded.' : ''),
+      taskDone: tasks.filter((task) => task.status === 'done').length,
+      taskTotal: tasks.length,
+      needsHuman: tasks.filter((task) => task.status === 'needs-human').length,
+    }
+  }),
+`)
+
+// Pre-fix shape: description is only ever the empty-task literal, never a
+// real project field.
+const BUGGY = fixture(`
+  scaffolded.value.map((slug) => {
+    const project = conductorStore.projects.find(
+      (candidate) => candidate.slug === slug,
+    )
+    const tasks = project?.tasks ?? []
+    return {
+      slug,
+      title: project?.name || titleize(slug),
+      description: tasks.length === 0 ? 'Freshly scaffolded.' : '',
+      taskDone: tasks.filter((task) => task.status === 'done').length,
+      taskTotal: tasks.length,
+      needsHuman: tasks.filter((task) => task.status === 'needs-human').length,
+    }
+  }),
+`)
+
+// Partial regression: goal survived but the notesFromSilas fallback (the
+// only field new_app.py actually seeds on a freshly scaffolded app) was
+// dropped.
+const PARTIALLY_REGRESSED = fixture(`
+  scaffolded.value.map((slug) => {
+    const project = conductorStore.projects.find(
+      (candidate) => candidate.slug === slug,
+    )
+    const tasks = project?.tasks ?? []
+    const description = project?.goal || ''
+    return {
+      slug,
+      title: project?.name || titleize(slug),
+      description: description || (tasks.length === 0 ? 'Freshly scaffolded.' : ''),
+      taskDone: tasks.filter((task) => task.status === 'done').length,
+      taskTotal: tasks.length,
+      needsHuman: tasks.filter((task) => task.status === 'needs-human').length,
+    }
+  }),
+`)
+
+function run(): void {
+  const fixedErrors = checkFleetDescriptionGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const buggyErrors = checkFleetDescriptionGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    2,
+    `expected the pre-fix fixture (no goal, no notesFromSilas) to fail both ` +
+      `real-field checks, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(
+    buggyErrors.some((e) => /no longer reads `project\?\.goal`/.test(e)),
+  )
+  assert.ok(
+    buggyErrors.some((e) => /no longer falls back to.*notesFromSilas/.test(e)),
+  )
+
+  const regressedErrors = checkFleetDescriptionGuard(PARTIALLY_REGRESSED)
+  assert.equal(
+    regressedErrors.length,
+    1,
+    'expected a fixture missing only the notesFromSilas fallback to fail ' +
+      `only that assertion, got: ${JSON.stringify(regressedErrors)}`,
+  )
+  assert.ok(
+    regressedErrors.some((e) =>
+      /no longer falls back to.*notesFromSilas/.test(e),
+    ),
+  )
+
+  const missingFunction = checkFleetDescriptionGuard(
+    '<script setup lang="ts">\nconst somethingElse = 1\n</script>\n',
+  )
+  assert.equal(missingFunction.length, 1)
+  assert.ok(missingFunction.some((e) => /Could not find/.test(e)))
+
+  console.log(
+    'AppMaker fleet-description guard self-test passed: buggy fixture ' +
+      'fails, fixed fixture passes, a partially-regressed fixture fails, ' +
+      'and a missing fleet computed is detected.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyAppmakerFleetDescriptionGuard.ts
+++ b/utils/scripts/verifyAppmakerFleetDescriptionGuard.ts
@@ -1,0 +1,128 @@
+// /utils/scripts/verifyAppmakerFleetDescriptionGuard.ts
+//
+// Regression guard (appmaker/t-012) -- the `fleet` computed in
+// components/pages/appmaker-page.vue used to derive each fleet card's
+// `description` solely from `tasks.length === 0 ? 'Freshly scaffolded.' :
+// ''`. scripts/new_app.py (the conductor-side scaffolder) always seeds a
+// freshly scaffolded app's roadmap.yaml with three milestones/tasks up
+// front, so `tasks.length === 0` is essentially never true for a real,
+// registry-tracked app -- it only happened in the transient/degraded
+// window where conductorStore had no matching project entry at all. In
+// practice that made the check backwards: every successfully tracked app
+// showed a permanently blank card description, while "Freshly scaffolded."
+// only ever surfaced when the project *lookup failed*, which reads like a
+// data problem rather than a success state.
+//
+// Fixed by preferring the project's real one-line description --
+// `project?.goal`, falling back to `project?.notesFromSilas` (new_app.py
+// always seeds the latter, even if just its own placeholder text) -- and
+// only falling through to the empty-task literal when there is truly no
+// description available.
+//
+// This asserts the textual shape of that fix stays in place: the `fleet`
+// computed still reads `project?.goal` and `project?.notesFromSilas` before
+// falling back to the empty-task literal, scoped narrowly to this one
+// function, mirroring this project's other narrow textual guards over a
+// general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const COMPONENT_PATH = join(
+  repositoryRoot,
+  'components/pages/appmaker-page.vue',
+)
+
+function extractFunctionSource(content: string, name: string): string | null {
+  const signature = new RegExp(
+    `const ${name} = computed<[^>]*>\\(\\(\\) =>`,
+    'm',
+  )
+  const match = signature.exec(content)
+  if (!match) return null
+
+  const parenOpen = content.indexOf('(', match.index + match[0].length - 2)
+  const braceOpen = content.indexOf('{', parenOpen)
+  if (braceOpen === -1) return null
+
+  let depth = 0
+  let i = braceOpen
+  for (; i < content.length; i++) {
+    if (content[i] === '{') depth++
+    else if (content[i] === '}') {
+      depth--
+      if (depth === 0) break
+    }
+  }
+  if (depth !== 0) return null
+  return content.slice(braceOpen, i + 1)
+}
+
+export function checkFleetDescriptionGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const body = extractFunctionSource(content, 'fleet')
+  if (!body) {
+    errors.push(
+      'Could not find `const fleet = computed<...>(() => { ... })` in ' +
+        'appmaker-page.vue -- has it been renamed, removed, or restructured? ' +
+        'If so, this guard (and the blank-description bug it protects ' +
+        'against) needs to move with it.',
+    )
+    return errors
+  }
+
+  if (!/project\?\.\s*goal/.test(body)) {
+    errors.push(
+      "fleet's description no longer reads `project?.goal` -- has the " +
+        'real one-line project description been dropped again in favor of ' +
+        'just the empty-task literal?',
+    )
+  }
+
+  if (!/project\?\.\s*notesFromSilas/.test(body)) {
+    errors.push(
+      "fleet's description no longer falls back to " +
+        '`project?.notesFromSilas` -- freshly scaffolded apps (which only ' +
+        'ever get notesFromSilas seeded, never goal) will show a blank ' +
+        "description again instead of new_app.py's placeholder text.",
+    )
+  }
+
+  if (!/tasks\.length === 0 \? 'Freshly scaffolded\.' : ''/.test(body)) {
+    errors.push(
+      'fleet no longer falls back to the "Freshly scaffolded." literal ' +
+        'when there is truly no description and no tasks yet -- has that ' +
+        'transient/degraded-lookup case been dropped?',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(COMPONENT_PATH, 'utf8')
+  const errors = checkFleetDescriptionGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'AppMaker fleet-description guard contract failed in appmaker-page.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'AppMaker fleet-description guard contract passed: fleet cards prefer ' +
+      'a real project goal/notesFromSilas description over a permanently ' +
+      'blank field once an app is registry-tracked.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
appmaker/t-012 — recurring "Polish and upgrade AppMaker front-end surface" pass.

### What changed
`components/pages/appmaker-page.vue`'s `fleet` computed derived each card's `description` solely from `tasks.length === 0 ? 'Freshly scaffolded.' : ''`. Since `scripts/new_app.py` always seeds a scaffolded app's roadmap with 3 tasks up front, `tasks.length === 0` is essentially never true for a real, registry-tracked app — the check was backwards in practice: every successfully tracked app showed a permanently blank description, and "Freshly scaffolded." only surfaced when the project lookup itself failed. Now the card prefers the project's real one-line description (`goal`, falling back to `notesFromSilas`, which `new_app.py` always seeds even as a placeholder), and only falls back to the old literal when there's truly no project data yet. Added `utils/scripts/verifyAppmakerFleetDescriptionGuard.ts` + `.test.ts` (mirrors `verifyAppmakerSlugCandidateGuard.ts`'s pattern) and wired both into `contract-tests.yml`.

### How I verified
- New guard self-test and guard both pass against the real file
- Existing `test:appmaker-slug-candidate-guard*` still pass, untouched
- `eslint` clean on touched files
- `prettier --check` clean on touched files
- `vue-tsc --noEmit` clean across the full project
- `git status --porcelain` shows only the 5 intended files changed

### Stakes
reversible

### Notes for reviewer
No changes to the previously-fixed refreshToken sequencing, `fetchProjects(force)` in-flight sharing, or slug-candidate validation — those were left as-is per the task brief. Did not touch the known-blocked art-generation or Placements-backfill items.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUP3ksbM9N1CCkN8hs9kdv)_