### PR TITLE
fix(storybook): stop redundant openStory() from double-billing in-flight art (storybook/t-010)

### DIFF
--- a/.github/workflows/storybook-library-mount-reopen-contract.yml
+++ b/.github/workflows/storybook-library-mount-reopen-contract.yml
@@ -1,0 +1,30 @@
+name: Storybook Library Mount Reopen Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: storybook-library-mount-reopen-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Storybook library mount reopen contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify Storybook library mount reopen guard
+        run: node utils/scripts/verifyStorybookLibraryMountReopenGuard.mjs

--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -277,7 +277,24 @@ onMounted(() => {
   storyStore.restoreFromLocalStorage()
   storyStore.initializeLibrary()
   const directId = queryStoryId()
-  if (directId) storyStore.openStory(directId)
+  // Only call openStory() when it would actually SWITCH sessions. On a plain
+  // reload mid-story, restoreFromLocalStorage() above already restored the
+  // live session, and updateStoryQuery() keeps ?story= in sync with it while
+  // playing -- so directId equals storyStore.session.id on every ordinary
+  // refresh, not just some rare cross-story navigation. Calling openStory()
+  // anyway re-clones the just-restored session and, critically, invokes
+  // resumeNarrativeArtJobs() a SECOND time on top of the one
+  // restoreFromLocalStorage() already performed. For any beat whose art job
+  // enqueue never reached the server before the reload (status still
+  // 'queueing', no jobId yet -- a real window between the optimistic status
+  // update and the resolved POST), both resume() calls independently find no
+  // existing job and independently submit one, generating and billing two
+  // illustrations for a single beat. The watcher below already guards the
+  // same call this way (`value === storyStore.session?.id`); mount just
+  // never matched it.
+  if (directId && directId !== storyStore.session?.id) {
+    storyStore.openStory(directId)
+  }
   libraryOpen.value = !storyStore.session && storyStore.recentStories.length > 0
   if (storyStore.session && !directId) updateStoryQuery(storyStore.session.id)
 })

--- a/utils/scripts/verifyStorybookLibraryMountReopenGuard.mjs
+++ b/utils/scripts/verifyStorybookLibraryMountReopenGuard.mjs
@@ -1,0 +1,102 @@
+// /utils/scripts/verifyStorybookLibraryMountReopenGuard.mjs
+//
+// Regression guard (storybook/t-010, front-end polish). storybook-library-page.vue
+// keeps `?story=<id>` in sync with the active session while playing: every time
+// `storyStore.session?.id` changes, a watcher writes it into the route query via
+// `updateStoryQuery()`. That means on ANY ordinary page reload mid-story -- not
+// a rare case, the normal one -- `route.query.story` already equals the id of
+// the session `restoreFromLocalStorage()` is about to restore from
+// STORAGE_KEY.
+//
+// `onMounted()` used to call `storyStore.openStory(directId)` unconditionally
+// whenever a `?story=` query param was present, with no check for whether it
+// already matched the session `restoreFromLocalStorage()` just restored. Since
+// that is true on every normal reload with an active story, `openStory()` ran
+// redundantly every time: it re-clones the just-restored session into a new
+// object and, critically, calls `resumeNarrativeArtJobs()` a SECOND time on
+// top of the one `restoreFromLocalStorage()` already performed.
+//
+// For a beat whose illustration was still `queued`/`rendering`, that just
+// doubles a status poll. But for a beat whose art enqueue never reached the
+// server before the reload -- status still `queueing`, no `jobId` yet, the
+// real window between the optimistic local update and the resolved POST --
+// `resume()` routes through `recoverOrSubmit()`, which GETs for an existing
+// job and, finding none, submits a fresh one. Two concurrent
+// `resumeNarrativeArtJobs()` calls for the same beat independently repeat that
+// GET-then-submit sequence, so both can find nothing and both submit --
+// generating and billing two illustrations for one beat instead of one.
+//
+// The reactive counterpart just below in the same file (the
+// `route.query.story` watcher) already guards this exact call with
+// `value === storyStore.session?.id`; only the mount-time call lacked it. This
+// asserts mount uses the same guard, so opening only actually happens when it
+// would switch sessions.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const PAGE_PATH = 'components/pages/storybook-library-page.vue'
+
+function extractOnMountedBody(content) {
+  const signature = /onMounted\(\(\)\s*=>\s*\{/
+  const match = signature.exec(content)
+  if (!match) {
+    throw new Error(
+      `Could not find \`onMounted(() => {\` in ${PAGE_PATH} -- has it been ` +
+        'renamed, removed, or restructured? If so, this guard (and the ' +
+        'redundant-reopen bug it protects against) needs to move with it.',
+    )
+  }
+  const braceOpen = match.index + match[0].length - 1
+  let braceDepth = 0
+  let i = braceOpen
+  for (; i < content.length; i++) {
+    if (content[i] === '{') braceDepth++
+    else if (content[i] === '}') {
+      braceDepth--
+      if (braceDepth === 0) break
+    }
+  }
+  return content.slice(braceOpen, i + 1)
+}
+
+const content = readFileSync(resolve(process.cwd(), PAGE_PATH), 'utf8')
+const body = extractOnMountedBody(content)
+
+assert.ok(
+  /if\s*\(\s*directId\s*&&\s*directId\s*!==\s*storyStore\.session\?\.id\s*\)/.test(
+    body,
+  ),
+  `onMounted() in ${PAGE_PATH} must only call storyStore.openStory(directId) ` +
+    'when directId differs from the session restoreFromLocalStorage() just ' +
+    'restored -- otherwise every ordinary reload mid-story (where ?story= ' +
+    "already matches the restored session, since the page's own watcher " +
+    'keeps them in sync while playing) calls openStory() redundantly, ' +
+    'double-invoking resumeNarrativeArtJobs() and risking two billed art ' +
+    'jobs for one beat whose enqueue POST was still in flight at reload.',
+)
+
+assert.ok(
+  /storyStore\.openStory\(directId\)/.test(body),
+  `onMounted() in ${PAGE_PATH} no longer calls storyStore.openStory(directId) ` +
+    'at all -- has direct-link story opening moved elsewhere? If so, this ' +
+    'guard needs to move with it.',
+)
+
+// The reactive counterpart must keep the same guard shape it already had --
+// otherwise this fix only covers the mount path while a future edit could
+// reintroduce the redundant call on the reactive one.
+assert.ok(
+  /value === storyStore\.session\?\.id/.test(content),
+  `${PAGE_PATH} must still guard the route.query.story watcher's ` +
+    'storyStore.openStory() call against re-opening the already-active ' +
+    'session, matching the guard mount now uses.',
+)
+
+console.log(
+  'Storybook library mount-reopen guard contract passed: onMounted() only ' +
+    'opens a story from ?story= when it would actually switch sessions, so ' +
+    'an ordinary reload mid-story no longer double-invokes ' +
+    'resumeNarrativeArtJobs() and risks double-billing an in-flight ' +
+    "beat's illustration.",
+)


### PR DESCRIPTION
## Bug

`storybook-library-page.vue` keeps `?story=<id>` in sync with the active session while playing: a watcher writes `session.value.id` into the route query on every change. That means on **any ordinary reload mid-story** — the normal case, not a rare one — `route.query.story` already equals the id of the session `restoreFromLocalStorage()` is about to restore from localStorage.

`onMounted()` called `storyStore.openStory(directId)` unconditionally whenever a `?story=` query param was present, with no check for whether it already matched the session `restoreFromLocalStorage()` just restored. Since that's true on every normal reload with an active story, `openStory()` ran redundantly every time: it re-clones the just-restored session and, critically, calls `resumeNarrativeArtJobs()` a **second time** on top of the one `restoreFromLocalStorage()` already performed.

For a beat still `queued`/`rendering`, that only doubles a status poll — wasteful but harmless. But for a beat whose art enqueue never reached the server before the reload (status still `queueing`, no `jobId` yet — a real window between the optimistic local `update()` and the resolved POST to the art-generation endpoint), `resume()` routes through `recoverOrSubmit()`, which GETs for an existing job by `dedupeKey` and, finding none, submits a fresh one. Two concurrent `resumeNarrativeArtJobs()` calls for the same beat independently repeat that GET-then-submit sequence, so both can find nothing and both submit — **generating and billing two illustrations for one beat instead of one**.

Notably, the reactive counterpart just below in the same file (the `route.query.story` watcher) *already* guards this exact call with `value === storyStore.session?.id`. Only the mount-time call lacked the equivalent guard — an inconsistency between two code paths doing the same thing, which is what made this stand out during the read.

## Fix

`components/pages/storybook-library-page.vue`: only call `openStory(directId)` on mount when it would actually switch sessions (`directId !== storyStore.session?.id`), matching the guard the watcher already uses.

## New guard

`utils/scripts/verifyStorybookLibraryMountReopenGuard.mjs` (the 12th `verifyStorybook*` guard) asserts:
- `onMounted()` guards its `openStory(directId)` call with `directId !== storyStore.session?.id`.
- The reactive watcher keeps its matching `value === storyStore.session?.id` guard, so a future edit can't silently reintroduce the redundant call on that path either.

Wired into a dedicated `.github/workflows/storybook-library-mount-reopen-contract.yml` lane, matching the structure of the existing 11 per-guard storybook workflows. (None of the 11 existing storybook guards are wired into `package.json` scripts — they're invoked directly from their workflow file — so this one follows that same precedent rather than the more generic convention.)

## Verification performed

- New guard **fails** on the pre-fix code and **passes** post-fix (git-stash round trip).
- All 11 pre-existing `verifyStorybook*` guards still pass — no regression.
- `eslint` clean on touched/new files.
- `prettier --check` clean on the new files; the touched `.vue` file has **pre-existing** formatting debt on `main` outside the touched hunk (confirmed via `git checkout -- <file>` + `prettier --check` on the untouched original) — the added `onMounted()` lines are byte-identical to what `prettier --write` alone produces for that region, so nothing new was introduced. Left the pre-existing debt untouched to keep this diff minimal and scoped.
- `vue-tsc --noEmit` is clean repo-wide (via `npm run test`).
- `git status --porcelain` shows exactly the 3 intended files.

## Latent observations for a future cycle (not fixed here, no confirmed reachable repro)

- `storybookLibraryHelper.ts`'s `restartInput()` forwards `bible.cast`/`location`/`facets`/`rewards`/`scenario` by reference rather than a deep clone. When restarting an **archived** (not currently active) story, the new session's bible ends up sharing array/object references with the library snapshot. Traced every consumer and found nothing that mutates these ingredient objects in place (only reads) — Vue reactivity is scoped to the top-level `session` ref, which restart always reassigns wholesale, not the ingredient objects within it — so this is inert today, but a future edit that mutates an ingredient in place (e.g. a per-story annotation feature) would silently corrupt the archived library entry too.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vt6rWAN9F1Qm6kjocUcoi1)_