### PR TITLE
feat(davinci): render chapter choices through shared kr-choice-list (davinci/t-021)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -269,6 +269,12 @@ jobs:
       - name: Da Vinci resuming-status guard
         run: npm run test:davinci-resuming-status-guard
 
+      - name: Da Vinci choice-list guard self-test
+        run: npm run test:davinci-choice-list-guard-selftest
+
+      - name: Da Vinci choice-list guard
+        run: npm run test:davinci-choice-list-guard
+
       - name: Serendipity Voice poll guard self-test
         run: npm run test:serendipity-voice-poll-guard-selftest
 

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -233,18 +233,30 @@
             >
               {{ currentChapter.narrative }}
             </p>
-            <div class="flex flex-col gap-2">
-              <button
-                v-for="choice in currentChapter.choices"
-                :key="choice.label"
-                type="button"
-                class="btn btn-outline btn-sm h-auto min-h-8 justify-start whitespace-normal rounded-xl py-1.5 text-left normal-case"
-                :disabled="submitting"
-                @click="chooseOption(choice)"
-              >
-                {{ choice.label }}
-              </button>
-            </div>
+            <!-- Was a hand-rolled v-for of plain btn-outline buttons -- the
+                 fourth duplicate of exactly the pick-one-option list
+                 kr-choice-list.vue was built to unify (its own doc comment:
+                 "replaces at least three separate implementations of the
+                 same idea"). The duplication cost real accessibility
+                 coverage: no role="group"/aria-label tying the options
+                 together as one choice set, and none of the
+                 focus-visible/motion-reduce/disabled:pointer-events-none
+                 guards every other narrative surface's choice list gets for
+                 free (kr-narrator-stage, workspace-narrator,
+                 narrative-response-composer, kr-chat-window,
+                 scenario-story, taskmaster-page). show-index left false to
+                 match every current live caller and this page's own
+                 existing plain-button look, rather than also opting into
+                 the numbered "storybook gesture" badge as an unrelated
+                 visual change in the same pass. -->
+            <kr-choice-list
+              layout="stack"
+              label="Choices for this chapter"
+              :choices="currentChapterChoices"
+              :disabled="submitting"
+              :show-index="false"
+              @select="chooseOptionByKey"
+            />
             <p
               v-if="currentChapter.milestoneCandidate"
               class="text-[0.65rem] italic text-base-content/40"
@@ -369,6 +381,7 @@ import type { ProjectFrontConfig } from '@/components/conductor/projectFront'
 import { useAchievementStore } from '@/stores/achievementStore'
 import { createNarrativeArtJobsController } from '@/stores/helpers/narrativeArtJobsHelper'
 import type { NarrativeArtJobState } from '@/utils/narrativeArtJobs'
+import type { NarrativeChoice } from '@/components/narrative/kr-choice-list.vue'
 
 // Mirrors server/utils/davinci.ts DAVINCI_DIMENSIONS — bit order is a
 // display concern here (the server owns the real resolve math), but keeping
@@ -962,6 +975,25 @@ function useCuratedChapters() {
   narrationMode.value = 'curated'
   narrationError.value = ''
   aiChapter.value = null
+}
+
+// Adapter for kr-choice-list, which speaks {key,label,hint,icon} rather
+// than this project's own LifeChoiceOption shape. Chapter choice labels are
+// already relied on as a unique key (the original hand-rolled v-for used
+// `choice.label` as its :key too), so reusing that as the NarrativeChoice
+// key needs no extra id plumbing.
+const currentChapterChoices = computed<NarrativeChoice[]>(() =>
+  (currentChapter.value?.choices ?? []).map((choice) => ({
+    key: choice.label,
+    label: choice.label,
+  })),
+)
+
+function chooseOptionByKey(choice: NarrativeChoice) {
+  const original = currentChapter.value?.choices.find(
+    (candidate) => candidate.label === choice.key,
+  )
+  if (original) void chooseOption(original)
 }
 
 async function chooseOption(choice: LifeChoiceOption) {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,8 @@
     "test:davinci-narrating-status-guard": "tsx utils/scripts/verifyDaVinciNarratingStatusGuard.ts",
     "test:davinci-resuming-status-guard-selftest": "tsx utils/scripts/verifyDaVinciResumingStatusGuard.test.ts",
     "test:davinci-resuming-status-guard": "tsx utils/scripts/verifyDaVinciResumingStatusGuard.ts",
+    "test:davinci-choice-list-guard-selftest": "tsx utils/scripts/verifyDaVinciChoiceListGuard.test.ts",
+    "test:davinci-choice-list-guard": "tsx utils/scripts/verifyDaVinciChoiceListGuard.ts",
     "test:serendipity-voice-poll-guard-selftest": "tsx utils/scripts/verifySerendipityVoicePollGuard.test.ts",
     "test:serendipity-voice-poll-guard": "tsx utils/scripts/verifySerendipityVoicePollGuard.ts",
     "test:serendipity-voice-cursor-reset-selftest": "tsx utils/scripts/verifySerendipityVoiceCursorReset.test.ts",

--- a/utils/scripts/verifyDaVinciChoiceListGuard.test.ts
+++ b/utils/scripts/verifyDaVinciChoiceListGuard.test.ts
@@ -1,0 +1,92 @@
+// /utils/scripts/verifyDaVinciChoiceListGuard.test.ts
+//
+// Regression test for checkChoiceListGuard() in
+// verifyDaVinciChoiceListGuard.ts (davinci/t-021 slice 6). Exercises the
+// real check against synthetic component-shaped fixtures covering: the
+// fixed shape (kr-choice-list with @select), a reverted-to-hand-rolled-loop
+// regression, a kr-choice-list-with-no-handler regression, and a
+// missing-region regression (the currentChapter block removed entirely).
+import assert from 'node:assert/strict'
+
+import { checkChoiceListGuard } from './verifyDaVinciChoiceListGuard.js'
+
+function fixture(choiceMarkup: string): string {
+  return `
+<template>
+  <div v-else-if="currentChapter">
+    <p>{{ currentChapter.narrative }}</p>
+    ${choiceMarkup}
+  </div>
+</template>
+`
+}
+
+const FIXED = fixture(
+  '<kr-choice-list layout="stack" :choices="currentChapterChoices" @select="chooseOptionByKey" />',
+)
+
+// Pre-fix shape: a hand-rolled v-for of plain buttons instead of the shared
+// component.
+const HAND_ROLLED_LOOP = fixture(`
+  <div class="flex flex-col gap-2">
+    <button v-for="choice in currentChapter.choices" :key="choice.label" @click="chooseOption(choice)">
+      {{ choice.label }}
+    </button>
+  </div>
+`)
+
+// kr-choice-list present but its @select handler dropped.
+const NO_SELECT_HANDLER = fixture(
+  '<kr-choice-list layout="stack" :choices="currentChapterChoices" />',
+)
+
+// The currentChapter block itself -- and its narrative marker -- no longer
+// exists at all.
+const REGION_REMOVED = `
+<template>
+  <div v-if="phase === 'ending'">
+    <p>This life has ended.</p>
+  </div>
+</template>
+`
+
+function run(): void {
+  const fixedErrors = checkChoiceListGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const loopErrors = checkChoiceListGuard(HAND_ROLLED_LOOP)
+  assert.equal(
+    loopErrors.length,
+    1,
+    `expected the hand-rolled-loop fixture to fail exactly one check, got: ${JSON.stringify(loopErrors)}`,
+  )
+  assert.ok(
+    loopErrors.some((e) =>
+      /no longer render(s)? through <kr-choice-list>/.test(e),
+    ),
+  )
+
+  const noHandlerErrors = checkChoiceListGuard(NO_SELECT_HANDLER)
+  assert.equal(noHandlerErrors.length, 1)
+  assert.ok(noHandlerErrors.some((e) => /has no @select handler/.test(e)))
+
+  const removedErrors = checkChoiceListGuard(REGION_REMOVED)
+  assert.equal(removedErrors.length, 1)
+  assert.ok(
+    removedErrors.some((e) =>
+      /Could not find the `\{\{ currentChapter\.narrative \}\}` marker/.test(e),
+    ),
+  )
+
+  console.log(
+    'Da Vinci choice-list guard self-test passed: hand-rolled-loop, ' +
+      'no-select-handler, and missing-region regressions all fail; the ' +
+      'fixed fixture passes.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyDaVinciChoiceListGuard.ts
+++ b/utils/scripts/verifyDaVinciChoiceListGuard.ts
@@ -1,0 +1,106 @@
+// /utils/scripts/verifyDaVinciChoiceListGuard.ts
+//
+// Regression guard (davinci/t-021 slice 6) -- the "playing" chapter's choice
+// buttons in components/conductor/davinci-page.vue used to be a hand-rolled
+// `v-for` of plain `btn-outline` buttons: the fourth separate implementation
+// of exactly the pick-one-option list kr-choice-list.vue's own doc comment
+// says it exists to unify ("replaces at least three separate
+// implementations of the same idea"). The duplicate had no
+// role="group"/aria-label tying the buttons together as one choice set, and
+// none of the focus-visible/motion-reduce/disabled:pointer-events-none
+// guards every other narrative choice list gets for free.
+//
+// Fixed by rendering <kr-choice-list> instead, matching kr-narrator-stage,
+// workspace-narrator, narrative-response-composer, kr-chat-window,
+// scenario-story, and taskmaster-page. This asserts the textual shape of
+// that fix stays in place -- the chapter choices still go through
+// kr-choice-list rather than a hand-rolled button loop -- deliberately
+// scoped to this one template region over a general-purpose static
+// analyzer, mirroring this project's other narrow textual guards (see
+// verifyDaVinciDimensionToneGuard.ts, verifyDaVinciResolvePanelGuard.ts).
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const COMPONENT_PATH = join(
+  repositoryRoot,
+  'components/conductor/davinci-page.vue',
+)
+
+// Anchored on the currentChapter block's narrative paragraph, which sits
+// immediately above the choice list in both the old and new markup, so this
+// guard can report *how* the choice region regressed (missing entirely vs.
+// reverted to a hand-rolled loop) instead of just "not found".
+const NARRATIVE_MARKER = '{{ currentChapter.narrative }}'
+
+function extractChoiceRegion(content: string): string | null {
+  const narrativeIndex = content.indexOf(NARRATIVE_MARKER)
+  if (narrativeIndex === -1) return null
+
+  // The next closing }} after milestoneCandidate (or the section's closing
+  // </div> if that paragraph is absent) bounds the region reliably enough
+  // for a narrow textual check; slicing ~2000 chars past the narrative
+  // marker comfortably covers the choice list markup either shape produces.
+  return content.slice(narrativeIndex, narrativeIndex + 2000)
+}
+
+export function checkChoiceListGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const region = extractChoiceRegion(content)
+  if (!region) {
+    errors.push(
+      `Could not find the \`${NARRATIVE_MARKER}\` marker in ` +
+        'davinci-page.vue -- has the currentChapter block been ' +
+        'restructured or removed? If so, this guard needs to move with it.',
+    )
+    return errors
+  }
+
+  if (!region.includes('<kr-choice-list')) {
+    errors.push(
+      'The chapter choices no longer render through <kr-choice-list> -- ' +
+        'this is the exact regression this guard exists to catch: a ' +
+        'hand-rolled v-for of plain buttons loses the shared role="group"/' +
+        'aria-label choice-set semantics and the focus-visible/' +
+        'motion-reduce/disabled:pointer-events-none guards every other ' +
+        'narrative choice list gets for free.',
+    )
+  }
+
+  if (region.includes('<kr-choice-list') && !region.includes('@select=')) {
+    errors.push(
+      'The <kr-choice-list> in the chapter-choice region has no @select ' +
+        'handler -- picking an option would no longer do anything.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(COMPONENT_PATH, 'utf8')
+  const errors = checkChoiceListGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Da Vinci choice-list guard contract failed in davinci-page.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Da Vinci choice-list guard contract passed: chapter choices still ' +
+      'render through the shared <kr-choice-list> primitive rather than a ' +
+      'hand-rolled button loop.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
davinci/t-021: Da Vinci visual style and interaction polish pass — slice 6 (kind: software)

### What changed / what I produced
- `components/conductor/davinci-page.vue`'s "playing" phase chapter-choice buttons were a hand-rolled `v-for` of plain `btn-outline` buttons — the fourth separate implementation of exactly the pick-one-option list `kr-choice-list.vue` was built to unify (its own doc comment: "replaces at least three separate implementations of the same idea"). The duplication cost real accessibility coverage: no `role="group"`/`aria-label` tying the choice buttons together as one set, and none of the `focus-visible`/`motion-reduce`/`disabled:pointer-events-none` guards every other narrative choice list in the app gets for free (`kr-narrator-stage`, `workspace-narrator`, `narrative-response-composer`, `kr-chat-window`, `scenario-story`, `taskmaster-page`).
- Replaced it with the shared `kr-choice-list` component, with a small adapter (`currentChapterChoices` computed + `chooseOptionByKey`) mapping this project's `LifeChoiceOption` shape to `kr-choice-list`'s `{key,label}` `NarrativeChoice` contract. `choice.label` was already relied on as a unique key by the original `v-for`, so no new id plumbing was needed. `show-index` left `false` to match every current live caller of `kr-choice-list` and this page's existing plain-button look, rather than also opting into the numbered "storybook gesture" badge as an unrelated visual change in the same pass.
- Added `verifyDaVinciChoiceListGuard.ts` + selftest following this project's established narrow-textual-guard convention, wired into `package.json` and `contract-tests.yml` alongside the five existing davinci guards.

### How I verified
- New guard + selftest pass (`npm run test:davinci-choice-list-guard[-selftest]`).
- All five existing davinci guards + selftests still pass (dimension-tone, narration-error-tone, resolve-panel, narrating-status, resuming-status).
- `npm run test:davinci-narration` (26 checks) still passes.
- `npm run test:layout-contract` holds — no new violations.
- `vue-tsc --noEmit` (full project) — 0 errors.
- `eslint` clean on all touched files; `prettier --check` clean (after one `--write` pass on the new test file).
- `git status --porcelain` shows exactly the 5 intended files: `components/conductor/davinci-page.vue`, `utils/scripts/verifyDaVinciChoiceListGuard.ts`, `utils/scripts/verifyDaVinciChoiceListGuard.test.ts`, `package.json`, `.github/workflows/contract-tests.yml`.

### Stakes
reversible

### Flags for Reviewer
- `show-index` was deliberately left `false` (plain buttons, no numbered badges) to match every other live `kr-choice-list` caller today, even though the component's own doc comment frames numbered badges as "the storybook gesture" it was designed for. Worth a second look if a future slice wants the numbered look specifically for davinci's chapter choices.
- This is slice 6 of an ongoing multi-slice davinci/t-021 polish task (conductor roadmap). Remaining scope per the task note: the broader "visually intentional" pass across the rest of the file, plus phone/tablet/desktop rendered-preview verification.

### Kaizen suggestion
A repo-wide sweep for other hand-rolled "pick one of N buttons" loops that predate `kr-choice-list.vue` (2026-08-02) and never got migrated — this was the fourth known duplicate, davinci's was a fifth/undiscovered one until this slice.

### Notes for reviewer
Conductor task davinci/t-021 is set to `status: review` for this slice; will re-arm to `status: ready` (not `done`) after merge per this task's established multi-slice convention, since the broader remaining scope isn't finished.
