### PR TITLE
fix: restrict Mermaids of Venice to admins

### DIFF
--- a/content/channels/sanctuary/mermaids.md
+++ b/content/channels/sanctuary/mermaids.md
@@ -11,6 +11,7 @@ description: Explore the Mermaids of Venice project, its world, art, and externa
 icon: kind-icon:mermaid
 route: /mermaids
 sort: 20
+requiredRole: ADMIN
 ---
 
 A public-facing creative project living in the community and mission wing.


### PR DESCRIPTION
## Summary
- restrict the Mermaids of Venice navigation/content route to `ADMIN`
- preserve its existing Sanctuary grouping and dashboard placement

## Root cause
`/mermaids` is served through the generic content/navigation access layer. Its Sanctuary tab had no role requirement, so it inherited public access.

## Verification
- scoped to `content/channels/sanctuary/mermaids.md`
- relies on the existing `requiredRole` schema and navigation route guard
