### PR TITLE
text-generation/t-002: shared server-side text provider service

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -551,6 +551,9 @@ jobs:
       - name: Mana-gate on-behalf-of target authorization contract
         run: npm run test:mana-gate-on-behalf-of-target
 
+      - name: Text-provider-service shared mechanics contract
+        run: npm run test:text-provider-service
+
       - name: Animation catalog contract
         run: npm run test:animation-catalog
 

--- a/package.json
+++ b/package.json
@@ -261,6 +261,7 @@
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",
+    "test:text-provider-service": "tsx utils/scripts/verifyTextProviderService.ts",
     "components:manifest": "node utils/scripts/create-component-json.mjs",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",

--- a/server/api/chats/anthropic/stream.post.ts
+++ b/server/api/chats/anthropic/stream.post.ts
@@ -1,14 +1,18 @@
 // /server/api/chats/anthropic/stream.post.ts
-import {
-  createError,
-  defineEventHandler,
-  readBody,
-  setHeader,
-  type H3Event,
-} from 'h3'
-import { getServerEndpoint, resolveServer } from '../../../utils/serverResolver'
+import { createError, defineEventHandler, readBody } from 'h3'
+import { getServerEndpoint } from '../../../utils/serverResolver'
 import { manaGate } from '../../../utils/manaGate'
 import { requireApiUser } from '../../../utils/authGuard'
+import { estimateTextCostUsd } from '../../../utils/manaCost'
+import {
+  assertProviderApiKey,
+  buildChatRefId,
+  getErrorStatusCode,
+  resolveApiKeyPrecedence,
+  resolveOptionalTextServer,
+  sendMeteredStream,
+  setStreamHeaders,
+} from '../../../utils/textProviderService'
 import type { Server } from '~/prisma/generated/prisma/client'
 
 type AnthropicStreamBody = {
@@ -28,12 +32,6 @@ type AnthropicStreamBody = {
   useOwnResource?: boolean
 }
 
-type StreamManaResult = {
-  balance: number
-  charged: number
-  free: boolean
-}
-
 export default defineEventHandler(async (event) => {
   try {
     const body = await readBody<AnthropicStreamBody>(event)
@@ -43,7 +41,7 @@ export default defineEventHandler(async (event) => {
     const model = body.model || 'claude-sonnet-4-6'
     const maxTokens = body.maxTokens ?? 4096
 
-    const server = await resolveOptionalServer({
+    const server = await resolveOptionalTextServer({
       userId: auth.user.id,
       serverId: body.serverId ?? null,
       serverName: body.serverName ?? null,
@@ -51,7 +49,7 @@ export default defineEventHandler(async (event) => {
 
     const gate = await manaGate(event, {
       kind: 'text',
-      estCostUsd: estimateAnthropicTextCostUsd({
+      estCostUsd: estimateTextCostUsd({
         model,
         maxTokens,
       }),
@@ -61,13 +59,17 @@ export default defineEventHandler(async (event) => {
 
     const messages = normalizeMessages(body)
     const endpoint = getAnthropicEndpoint(server)
-    const apiKey = getAnthropicApiKey({
-      serverApiKey: server?.apiKey,
+    const apiKey = resolveApiKeyPrecedence({
       userApiKey: body.userApiKey,
+      serverApiKey: server?.apiKey,
       runtimeApiKey: getRuntimeAnthropicKey(config),
     })
 
-    assertAnthropicApiKey(apiKey)
+    assertProviderApiKey({
+      apiKey,
+      providerLabel: 'Anthropic',
+      expectedPrefix: 'sk-ant-',
+    })
 
     const payload: Record<string, unknown> = {
       model,
@@ -117,12 +119,10 @@ export default defineEventHandler(async (event) => {
 
     setStreamHeaders(event, 'text/event-stream')
 
-    return sendMeteredStream(event, upstream.body, async () => {
-      const refId = body.chatId
-        ? `chat:${body.chatId}`
-        : `anthropic:${Date.now()}`
-
-      const { balance } = await gate.commit(refId)
+    return sendMeteredStream(event, upstream.body, 'anthropic', async () => {
+      const { balance } = await gate.commit(
+        buildChatRefId('anthropic', body.chatId),
+      )
 
       return {
         balance,
@@ -156,23 +156,6 @@ function normalizeMessages(body: AnthropicStreamBody) {
   ]
 }
 
-async function resolveOptionalServer(input: {
-  userId: number
-  serverId?: number | null
-  serverName?: string | null
-}): Promise<Server | null> {
-  if (!input.serverId && !input.serverName) {
-    return null
-  }
-
-  return await resolveServer({
-    userId: input.userId,
-    serverId: input.serverId ?? null,
-    serverName: input.serverName ?? null,
-    capability: 'text',
-  })
-}
-
 function getRuntimeAnthropicKey(config: ReturnType<typeof useRuntimeConfig>) {
   return String(
     config.anthropicApiKey ||
@@ -202,119 +185,4 @@ function getAnthropicEndpoint(server: Server | null) {
   }
 
   return endpoint
-}
-
-function cleanProviderKey(value?: string | null) {
-  return value?.trim().replace(/^Bearer\s+/i, '').trim() || ''
-}
-
-function getAnthropicApiKey(options: {
-  serverApiKey?: string | null
-  userApiKey?: string | null
-  runtimeApiKey?: string | null
-}) {
-  return (
-    cleanProviderKey(options.userApiKey) ||
-    cleanProviderKey(options.serverApiKey) ||
-    cleanProviderKey(options.runtimeApiKey)
-  )
-}
-
-function assertAnthropicApiKey(apiKey: string) {
-  if (!apiKey) {
-    throw createError({
-      statusCode: 500,
-      message: 'No Anthropic API key is configured.',
-    })
-  }
-
-  if (!apiKey.startsWith('sk-ant-')) {
-    throw createError({
-      statusCode: 500,
-      message:
-        'Anthropic provider key is invalid. Expected an Anthropic key starting with "sk-ant-". The app authorization key is probably being used as the provider key.',
-    })
-  }
-}
-
-function setStreamHeaders(event: H3Event, contentType: string) {
-  setHeader(event, 'Content-Type', contentType)
-  setHeader(event, 'Cache-Control', 'no-cache, no-transform')
-  setHeader(event, 'Connection', 'keep-alive')
-  setHeader(event, 'X-Accel-Buffering', 'no')
-}
-
-function sendMeteredStream(
-  event: H3Event,
-  body: ReadableStream<Uint8Array>,
-  onComplete: () => Promise<StreamManaResult>,
-) {
-  const reader = body.getReader()
-  const res = event.node.res
-
-  const pump = async () => {
-    try {
-      while (true) {
-        const { done, value } = await reader.read()
-
-        if (done) break
-
-        res.write(value)
-      }
-
-      const mana = await onComplete()
-
-      res.write(
-        `event: mana\ndata: ${JSON.stringify({
-          mana,
-        })}\n\n`,
-      )
-    } catch (err) {
-      console.error('[anthropic stream pump] error:', err)
-
-      res.write(
-        `event: error\ndata: ${JSON.stringify({
-          message:
-            err instanceof Error ? err.message : 'Streaming response failed.',
-        })}\n\n`,
-      )
-    } finally {
-      res.end()
-    }
-  }
-
-  pump()
-
-  return new Promise(() => {})
-}
-
-function estimateAnthropicTextCostUsd(input: {
-  model: string
-  maxTokens: number
-}): number {
-  const model = input.model.toLowerCase()
-  const maxTokens = Math.max(1, input.maxTokens)
-
-  if (model.includes('opus')) {
-    return (maxTokens / 1_000_000) * 75
-  }
-
-  if (model.includes('sonnet')) {
-    return (maxTokens / 1_000_000) * 15
-  }
-
-  if (model.includes('haiku')) {
-    return (maxTokens / 1_000_000) * 4
-  }
-
-  return (maxTokens / 1_000_000) * 15
-}
-
-function getErrorStatusCode(error: unknown) {
-  return typeof error === 'object' &&
-    error !== null &&
-    'statusCode' in error &&
-    typeof error.statusCode === 'number'
-    ? error.statusCode
-    : 500
 }

--- a/server/api/chats/ollama/stream.post.ts
+++ b/server/api/chats/ollama/stream.post.ts
@@ -1,14 +1,16 @@
 // /server/api/chats/ollama/stream.post.ts
-import {
-  createError,
-  defineEventHandler,
-  readBody,
-  setHeader,
-  type H3Event,
-} from 'h3'
+import { createError, defineEventHandler, readBody } from 'h3'
 import { getServerEndpoint, resolveServer } from '../../../utils/serverResolver'
 import { manaGate } from '../../../utils/manaGate'
 import { requireApiUser } from '../../../utils/authGuard'
+import { estimateTextCostUsd } from '../../../utils/manaCost'
+import {
+  buildChatRefId,
+  buildTextServerAuthHeaders,
+  getErrorStatusCode,
+  sendMeteredStream,
+  setStreamHeaders,
+} from '../../../utils/textProviderService'
 
 type OllamaStreamBody = {
   prompt?: string
@@ -24,12 +26,6 @@ type OllamaStreamBody = {
   serverName?: string | null
   chatId?: number | string | null
   useOwnResource?: boolean
-}
-
-type StreamManaResult = {
-  balance: number
-  charged: number
-  free: boolean
 }
 
 export default defineEventHandler(async (event) => {
@@ -50,7 +46,7 @@ export default defineEventHandler(async (event) => {
 
     const gate = await manaGate(event, {
       kind: 'text',
-      estCostUsd: estimateOllamaTextCostUsd({
+      estCostUsd: estimateTextCostUsd({
         model,
         maxTokens,
       }),
@@ -96,7 +92,7 @@ export default defineEventHandler(async (event) => {
 
     const upstream = await fetch(endpoint, {
       method: 'POST',
-      headers: buildServerHeaders(server),
+      headers: buildTextServerAuthHeaders(server),
       body: JSON.stringify(payload),
     })
 
@@ -111,9 +107,10 @@ export default defineEventHandler(async (event) => {
 
     setStreamHeaders(event, 'application/x-ndjson')
 
-    return sendMeteredStream(event, upstream.body, async () => {
-      const refId = body.chatId ? `chat:${body.chatId}` : `ollama:${Date.now()}`
-      const { balance } = await gate.commit(refId)
+    return sendMeteredStream(event, upstream.body, 'ollama', async () => {
+      const { balance } = await gate.commit(
+        buildChatRefId('ollama', body.chatId),
+      )
 
       return {
         balance,
@@ -156,104 +153,4 @@ function normalizeOllamaChatEndpoint(url: string): string {
   }
 
   return `${cleanUrl}/api/chat`
-}
-
-function buildServerHeaders(server: {
-  apiKey?: string | null
-  apiKeyName?: string | null
-  authType?: string | null
-}): HeadersInit {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-  }
-
-  const token = server.apiKey?.trim()
-
-  if (!token || server.authType === 'NONE') {
-    return headers
-  }
-
-  if (server.authType === 'BEARER') {
-    headers.Authorization = token.startsWith('Bearer ')
-      ? token
-      : `Bearer ${token}`
-
-    return headers
-  }
-
-  if (server.authType === 'HEADER' || server.authType === 'API_KEY') {
-    headers[server.apiKeyName || 'X-API-Key'] = token
-    return headers
-  }
-
-  return headers
-}
-
-function setStreamHeaders(event: H3Event, contentType: string) {
-  setHeader(event, 'Content-Type', contentType)
-  setHeader(event, 'Cache-Control', 'no-cache, no-transform')
-  setHeader(event, 'Connection', 'keep-alive')
-  setHeader(event, 'X-Accel-Buffering', 'no')
-}
-
-function sendMeteredStream(
-  event: H3Event,
-  body: ReadableStream<Uint8Array>,
-  onComplete: () => Promise<StreamManaResult>,
-) {
-  const reader = body.getReader()
-  const res = event.node.res
-
-  const pump = async () => {
-    try {
-      while (true) {
-        const { done, value } = await reader.read()
-
-        if (done) break
-
-        res.write(value)
-      }
-
-      const mana = await onComplete()
-
-      res.write(
-        `event: mana\ndata: ${JSON.stringify({
-          mana,
-        })}\n\n`,
-      )
-    } catch (err) {
-      console.error('[ollama stream pump] error:', err)
-
-      res.write(
-        `event: error\ndata: ${JSON.stringify({
-          message:
-            err instanceof Error ? err.message : 'Streaming response failed.',
-        })}\n\n`,
-      )
-    } finally {
-      res.end()
-    }
-  }
-
-  pump()
-
-  return new Promise(() => {})
-}
-
-function estimateOllamaTextCostUsd(input: {
-  model: string
-  maxTokens: number
-}): number {
-  const maxTokens = Math.max(1, input.maxTokens)
-
-  return (maxTokens / 1_000_000) * 1
-}
-
-function getErrorStatusCode(error: unknown) {
-  return typeof error === 'object' &&
-    error !== null &&
-    'statusCode' in error &&
-    typeof error.statusCode === 'number'
-    ? error.statusCode
-    : 500
 }

--- a/server/api/chats/openai/stream.post.ts
+++ b/server/api/chats/openai/stream.post.ts
@@ -1,14 +1,18 @@
 // /server/api/chats/openai/stream.post.ts
-import {
-  createError,
-  defineEventHandler,
-  readBody,
-  setHeader,
-  type H3Event,
-} from 'h3'
-import { getServerEndpoint, resolveServer } from '../../../utils/serverResolver'
+import { createError, defineEventHandler, readBody } from 'h3'
+import { getServerEndpoint } from '../../../utils/serverResolver'
 import { manaGate } from '../../../utils/manaGate'
 import { requireApiUser } from '../../../utils/authGuard'
+import { estimateTextCostUsd } from '../../../utils/manaCost'
+import {
+  assertProviderApiKey,
+  buildChatRefId,
+  getErrorStatusCode,
+  resolveApiKeyPrecedence,
+  resolveOptionalTextServer,
+  sendMeteredStream,
+  setStreamHeaders,
+} from '../../../utils/textProviderService'
 import type { Server } from '~/prisma/generated/prisma/client'
 
 type OpenAiStreamBody = {
@@ -29,12 +33,6 @@ type OpenAiStreamBody = {
   useOwnResource?: boolean
 }
 
-type StreamManaResult = {
-  balance: number
-  charged: number
-  free: boolean
-}
-
 export default defineEventHandler(async (event) => {
   try {
     const body = await readBody<OpenAiStreamBody>(event)
@@ -44,7 +42,7 @@ export default defineEventHandler(async (event) => {
     const model = body.model || 'gpt-4o-mini'
     const maxTokens = body.maxTokens ?? 2048
 
-    const server = await resolveOptionalServer({
+    const server = await resolveOptionalTextServer({
       userId: auth.user.id,
       serverId: body.serverId ?? null,
       serverName: body.serverName ?? null,
@@ -52,9 +50,10 @@ export default defineEventHandler(async (event) => {
 
     const gate = await manaGate(event, {
       kind: 'text',
-      estCostUsd: estimateOpenAiTextCostUsd({
+      estCostUsd: estimateTextCostUsd({
         model,
         maxTokens,
+        n: body.n,
       }),
       serverId: server?.id ?? body.serverId ?? null,
       useOwnResource: Boolean(body.useOwnResource || body.userApiKey),
@@ -62,16 +61,20 @@ export default defineEventHandler(async (event) => {
 
     const messages = normalizeMessages(body)
     const endpoint = getOpenAiCompatibleEndpoint(server)
-    const apiKey = getOpenAiCompatibleApiKey({
-      server,
-      serverApiKey: server?.apiKey,
+    const apiKey = resolveApiKeyPrecedence({
       userApiKey: body.userApiKey,
+      serverApiKey: server?.apiKey,
       runtimeApiKey: getRuntimeOpenAiKey(config),
     })
 
-    assertOpenAiCompatibleApiKey({
-      server,
+    assertProviderApiKey({
       apiKey,
+      providerLabel: 'OpenAI',
+      // Only the true OpenAI cloud path (no server, or an explicit OPENAI
+      // server) has a guaranteed "sk-" key shape -- a CUSTOM/OpenAI-compatible
+      // server's key convention is whatever that server issues.
+      expectedPrefix:
+        !server || server.serverType === 'OPENAI' ? 'sk-' : undefined,
     })
 
     const payload = {
@@ -120,9 +123,10 @@ export default defineEventHandler(async (event) => {
 
     setStreamHeaders(event, 'text/event-stream')
 
-    return sendMeteredStream(event, upstream.body, async () => {
-      const refId = body.chatId ? `chat:${body.chatId}` : `openai:${Date.now()}`
-      const { balance } = await gate.commit(refId)
+    return sendMeteredStream(event, upstream.body, 'openai', async () => {
+      const { balance } = await gate.commit(
+        buildChatRefId('openai', body.chatId),
+      )
 
       return {
         balance,
@@ -157,23 +161,6 @@ function normalizeMessages(body: OpenAiStreamBody) {
   ]
 }
 
-async function resolveOptionalServer(input: {
-  userId: number
-  serverId?: number | null
-  serverName?: string | null
-}): Promise<Server | null> {
-  if (!input.serverId && !input.serverName) {
-    return null
-  }
-
-  return await resolveServer({
-    userId: input.userId,
-    serverId: input.serverId ?? null,
-    serverName: input.serverName ?? null,
-    capability: 'text',
-  })
-}
-
 function getRuntimeOpenAiKey(config: ReturnType<typeof useRuntimeConfig>) {
   return String(config.openaiApiKey || process.env.OPENAI_API_KEY || '').trim()
 }
@@ -198,127 +185,4 @@ function getOpenAiCompatibleEndpoint(server: Server | null) {
   }
 
   return endpoint
-}
-
-function cleanProviderKey(value?: string | null) {
-  return value?.trim().replace(/^Bearer\s+/i, '').trim() || ''
-}
-
-function getOpenAiCompatibleApiKey(options: {
-  server: Server | null
-  serverApiKey?: string | null
-  userApiKey?: string | null
-  runtimeApiKey?: string | null
-}) {
-  return (
-    cleanProviderKey(options.userApiKey) ||
-    cleanProviderKey(options.serverApiKey) ||
-    cleanProviderKey(options.runtimeApiKey)
-  )
-}
-
-function assertOpenAiCompatibleApiKey(input: {
-  server: Server | null
-  apiKey: string
-}) {
-  const { server, apiKey } = input
-
-  if (!apiKey) {
-    throw createError({
-      statusCode: 500,
-      message: 'No OpenAI-compatible API key is configured.',
-    })
-  }
-
-  const serverType = String(server?.serverType || 'OPENAI')
-
-  if (serverType === 'OPENAI' && !apiKey.startsWith('sk-')) {
-    throw createError({
-      statusCode: 500,
-      message:
-        'OpenAI provider key is invalid. Expected an OpenAI key starting with "sk-". The app authorization key is probably being used as the provider key.',
-    })
-  }
-}
-
-function setStreamHeaders(event: H3Event, contentType: string) {
-  setHeader(event, 'Content-Type', contentType)
-  setHeader(event, 'Cache-Control', 'no-cache, no-transform')
-  setHeader(event, 'Connection', 'keep-alive')
-  setHeader(event, 'X-Accel-Buffering', 'no')
-}
-
-function sendMeteredStream(
-  event: H3Event,
-  body: ReadableStream<Uint8Array>,
-  onComplete: () => Promise<StreamManaResult>,
-) {
-  const reader = body.getReader()
-  const res = event.node.res
-
-  const pump = async () => {
-    try {
-      while (true) {
-        const { done, value } = await reader.read()
-
-        if (done) break
-
-        res.write(value)
-      }
-
-      const mana = await onComplete()
-
-      res.write(
-        `event: mana\ndata: ${JSON.stringify({
-          mana,
-        })}\n\n`,
-      )
-    } catch (err) {
-      console.error('[openai stream pump] error:', err)
-
-      res.write(
-        `event: error\ndata: ${JSON.stringify({
-          message:
-            err instanceof Error ? err.message : 'Streaming response failed.',
-        })}\n\n`,
-      )
-    } finally {
-      res.end()
-    }
-  }
-
-  pump()
-
-  return new Promise(() => {})
-}
-
-function estimateOpenAiTextCostUsd(input: {
-  model: string
-  maxTokens: number
-}): number {
-  const model = input.model.toLowerCase()
-  const maxTokens = Math.max(1, input.maxTokens)
-
-  if (model.includes('gpt-4o-mini')) {
-    return (maxTokens / 1_000_000) * 0.6
-  }
-
-  if (model.includes('gpt-4o')) {
-    return (maxTokens / 1_000_000) * 10
-  }
-
-  if (model.includes('gpt-4')) {
-    return (maxTokens / 1_000_000) * 30
-  }
-
-  return (maxTokens / 1_000_000) * 2
-}
-
-function getErrorStatusCode(error: unknown) {
-  return typeof error === 'object' &&
-    error !== null &&
-    'statusCode' in error &&
-    typeof error.statusCode === 'number'
-    ? error.statusCode
-    : 500
 }

--- a/server/utils/textProviderService.ts
+++ b/server/utils/textProviderService.ts
@@ -1,0 +1,243 @@
+// /server/utils/textProviderService.ts
+//
+// Shared mechanics for the three chat streaming routes
+// (server/api/chats/{openai,anthropic,ollama}/stream.post.ts) -- text-generation/t-002.
+//
+// Each route stayed a ~250-320 line, mostly-duplicated file: the same optional
+// server resolution, the same provider-key precedence, the same SSE/ndjson
+// header setup, the same byte-relay-then-mana-trailer pump, the same error
+// status-code extraction, and three independently-drifted cost estimators
+// (one of which -- the OpenAI route's -- didn't multiply by `n`, undercharging
+// multi-completion requests). This module extracts the provider-agnostic
+// mechanics so the three routes become thin adapters over it; each route keeps
+// only what's genuinely provider-specific (message normalization shape,
+// upstream payload shape, and the provider's own auth-header convention).
+//
+// Behavior is intentionally unchanged for every existing caller: same request
+// URLs, same request/response shapes, same content-types, same two-phase
+// error semantics (pre-stream createError vs. mid-stream `event: error`
+// frame). The one deliberate change is cost estimation -- every route now
+// calls the single shared `estimateTextCostUsd` (./manaCost) instead of a
+// local per-route estimator, per the text-generation BRIEF.md's success
+// criteria ("exactly one cost-estimation code path is used for text
+// generation, not four").
+import { createError, setHeader, type H3Event } from 'h3'
+import type { Server } from '~/prisma/generated/prisma/client'
+
+export type TextStreamManaResult = {
+  balance: number
+  charged: number
+  free: boolean
+}
+
+/**
+ * The three chat routes accept an optional `serverId`/`serverName` -- OpenAI
+ * and Anthropic fall back to the public cloud API when neither is given;
+ * Ollama has no cloud fallback and always resolves a stored `Server` (see
+ * `resolveServer` directly in ollama/stream.post.ts for that required case).
+ *
+ * `serverResolver.ts` (and the Prisma client it pulls in) is imported
+ * dynamically here, not at module scope: this file's pure mechanics
+ * (`resolveApiKeyPrecedence`, `buildTextServerAuthHeaders`, etc.) are
+ * exercised directly by `utils/scripts/verifyTextProviderService.ts`, which
+ * runs under `contract-tests.yml` -- a workflow explicitly documented as
+ * DB-free. A static Prisma-touching import here would break that invariant
+ * for every pure helper in the file, not just this one function.
+ */
+export async function resolveOptionalTextServer(input: {
+  userId: number
+  serverId?: number | null
+  serverName?: string | null
+}): Promise<Server | null> {
+  if (!input.serverId && !input.serverName) {
+    return null
+  }
+
+  const { resolveServer } = await import('./serverResolver')
+
+  return await resolveServer({
+    userId: input.userId,
+    serverId: input.serverId ?? null,
+    serverName: input.serverName ?? null,
+    capability: 'text',
+  })
+}
+
+function cleanProviderKey(value?: string | null): string {
+  return (
+    value
+      ?.trim()
+      .replace(/^Bearer\s+/i, '')
+      .trim() || ''
+  )
+}
+
+/**
+ * Shared provider-key precedence across OpenAI and Anthropic: an explicit
+ * per-request key, then the resolved server's stored key, then the
+ * system/runtime env key. (Ollama servers use `buildServerAuthHeaders`
+ * instead -- their auth shape is generic per `Server.authType`, not a single
+ * provider key.)
+ */
+export function resolveApiKeyPrecedence(options: {
+  userApiKey?: string | null
+  serverApiKey?: string | null
+  runtimeApiKey?: string | null
+}): string {
+  return (
+    cleanProviderKey(options.userApiKey) ||
+    cleanProviderKey(options.serverApiKey) ||
+    cleanProviderKey(options.runtimeApiKey)
+  )
+}
+
+/** Auth-header construction for a stored `Server` profile, generalized from
+ * the Ollama route's `authType`-driven builder (`NONE`/`BEARER`/`HEADER`/
+ * `API_KEY`). Any text-capable server type can reuse this -- it does not
+ * assume Ollama specifically.
+ *
+ * Deliberately named/kept distinct from `serverApi.ts`'s own
+ * `buildServerAuthHeaders` (used by the health-check routes and
+ * `textServer.ts`) rather than merged with it: that one omits
+ * `Content-Type` (its GET-only health callers don't send a body) and adds
+ * `Accept`, a different header contract than the chat routes' original,
+ * preserved-as-is behavior. Unifying the two is a reasonable follow-up but
+ * is out of scope here -- it would change response headers those other
+ * callers currently send. */
+export function buildTextServerAuthHeaders(server: {
+  apiKey?: string | null
+  apiKeyName?: string | null
+  authType?: string | null
+}): HeadersInit {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+
+  const token = server.apiKey?.trim()
+
+  if (!token || server.authType === 'NONE') {
+    return headers
+  }
+
+  if (server.authType === 'BEARER') {
+    headers.Authorization = token.startsWith('Bearer ')
+      ? token
+      : `Bearer ${token}`
+
+    return headers
+  }
+
+  if (server.authType === 'HEADER' || server.authType === 'API_KEY') {
+    headers[server.apiKeyName || 'X-API-Key'] = token
+    return headers
+  }
+
+  return headers
+}
+
+export function setStreamHeaders(event: H3Event, contentType: string): void {
+  setHeader(event, 'Content-Type', contentType)
+  setHeader(event, 'Cache-Control', 'no-cache, no-transform')
+  setHeader(event, 'Connection', 'keep-alive')
+  setHeader(event, 'X-Accel-Buffering', 'no')
+}
+
+/**
+ * Relays the upstream byte stream to the client as-is, then appends the
+ * synthetic `event: mana` trailer frame (or `event: error` if the pump or
+ * `onComplete` -- the mana-gate commit -- throws). Identical across all three
+ * routes today except for the console.error log label, which callers pass in
+ * as `logLabel` so the failure is still attributable to its route.
+ */
+export function sendMeteredStream(
+  event: H3Event,
+  body: ReadableStream<Uint8Array>,
+  logLabel: string,
+  onComplete: () => Promise<TextStreamManaResult>,
+): Promise<never> {
+  const reader = body.getReader()
+  const res = event.node.res
+
+  const pump = async () => {
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+
+        if (done) break
+
+        res.write(value)
+      }
+
+      const mana = await onComplete()
+
+      res.write(
+        `event: mana\ndata: ${JSON.stringify({
+          mana,
+        })}\n\n`,
+      )
+    } catch (err) {
+      console.error(`[${logLabel} stream pump] error:`, err)
+
+      res.write(
+        `event: error\ndata: ${JSON.stringify({
+          message:
+            err instanceof Error ? err.message : 'Streaming response failed.',
+        })}\n\n`,
+      )
+    } finally {
+      res.end()
+    }
+  }
+
+  pump()
+
+  return new Promise(() => {})
+}
+
+export function getErrorStatusCode(error: unknown): number {
+  return typeof error === 'object' &&
+    error !== null &&
+    'statusCode' in error &&
+    typeof error.statusCode === 'number'
+    ? error.statusCode
+    : 500
+}
+
+/** `refId` shape used for the mana-transaction ledger: chat-scoped when a
+ * `chatId` was supplied, otherwise a per-request synthetic id so one-shot
+ * (non-chat) callers still get a distinct, traceable refId. */
+export function buildChatRefId(
+  providerLabel: string,
+  chatId: number | string | null | undefined,
+): string {
+  return chatId ? `chat:${chatId}` : `${providerLabel}:${Date.now()}`
+}
+
+/** Asserts a resolved provider API key is present and looks like the right
+ * provider's key shape, throwing the same 500 + explanatory-hint shape every
+ * route already used when the app's own authorization key gets passed where
+ * a provider key belongs. */
+export function assertProviderApiKey(input: {
+  apiKey: string
+  providerLabel: string
+  expectedPrefix?: string
+}): void {
+  const { apiKey, providerLabel, expectedPrefix } = input
+
+  if (!apiKey) {
+    throw createError({
+      statusCode: 500,
+      message: `No ${providerLabel} API key is configured.`,
+    })
+  }
+
+  if (expectedPrefix && !apiKey.startsWith(expectedPrefix)) {
+    throw createError({
+      statusCode: 500,
+      message:
+        `${providerLabel} provider key is invalid. Expected a ${providerLabel} key ` +
+        `starting with "${expectedPrefix}". The app authorization key is probably ` +
+        'being used as the provider key.',
+    })
+  }
+}

--- a/utils/scripts/verifyTextProviderService.ts
+++ b/utils/scripts/verifyTextProviderService.ts
@@ -1,0 +1,228 @@
+// /utils/scripts/verifyTextProviderService.ts
+//
+// Regression guard for text-generation/t-002: the shared mechanics extracted
+// from the three chat streaming routes (server/api/chats/{openai,anthropic,
+// ollama}/stream.post.ts) into server/utils/textProviderService.ts. Covers
+// the pure, DB-free helpers directly -- provider-key precedence, auth-header
+// construction per Server.authType, the mana refId shape, and error
+// status-code extraction. `resolveOptionalTextServer` (the one function that
+// touches Prisma via serverResolver) is intentionally not exercised here;
+// server resolution itself is already covered by serverResolver's own
+// callers/tests -- this guard is about the mechanics that moved, not
+// re-testing Prisma access.
+import assert from 'node:assert/strict'
+import {
+  assertProviderApiKey,
+  buildChatRefId,
+  buildTextServerAuthHeaders,
+  getErrorStatusCode,
+  resolveApiKeyPrecedence,
+} from '../../server/utils/textProviderService'
+
+let failures = 0
+
+function check(label: string, fn: () => void): void {
+  try {
+    fn()
+    console.log(`ok - ${label}`)
+  } catch (error) {
+    failures += 1
+    console.error(`FAIL - ${label}`)
+    console.error(error instanceof Error ? error.message : error)
+  }
+}
+
+// -- resolveApiKeyPrecedence -------------------------------------------------
+
+check('userApiKey wins over server and runtime keys', () => {
+  assert.equal(
+    resolveApiKeyPrecedence({
+      userApiKey: 'sk-user',
+      serverApiKey: 'sk-server',
+      runtimeApiKey: 'sk-runtime',
+    }),
+    'sk-user',
+  )
+})
+
+check('serverApiKey wins over runtime key when no userApiKey', () => {
+  assert.equal(
+    resolveApiKeyPrecedence({
+      serverApiKey: 'sk-server',
+      runtimeApiKey: 'sk-runtime',
+    }),
+    'sk-server',
+  )
+})
+
+check('runtimeApiKey is the last fallback', () => {
+  assert.equal(
+    resolveApiKeyPrecedence({ runtimeApiKey: 'sk-runtime' }),
+    'sk-runtime',
+  )
+})
+
+check('all-empty precedence resolves to an empty string, not throwing', () => {
+  assert.equal(resolveApiKeyPrecedence({}), '')
+})
+
+check('a "Bearer " prefix on a stored key is stripped', () => {
+  assert.equal(
+    resolveApiKeyPrecedence({ serverApiKey: 'Bearer sk-server' }),
+    'sk-server',
+  )
+})
+
+check('whitespace-only keys are treated as absent', () => {
+  assert.equal(
+    resolveApiKeyPrecedence({
+      userApiKey: '   ',
+      serverApiKey: 'sk-server',
+    }),
+    'sk-server',
+  )
+})
+
+// -- buildTextServerAuthHeaders ----------------------------------------------
+
+check('NONE authType omits Authorization, keeps Content-Type', () => {
+  const headers = buildTextServerAuthHeaders({
+    apiKey: 'secret',
+    authType: 'NONE',
+  }) as Record<string, string>
+
+  assert.equal(headers['Content-Type'], 'application/json')
+  assert.equal('Authorization' in headers, false)
+})
+
+check('no apiKey at all omits Authorization', () => {
+  const headers = buildTextServerAuthHeaders({
+    authType: 'BEARER',
+  }) as Record<string, string>
+
+  assert.equal('Authorization' in headers, false)
+})
+
+check('BEARER authType sets a "Bearer <token>" Authorization header', () => {
+  const headers = buildTextServerAuthHeaders({
+    apiKey: 'secret-token',
+    authType: 'BEARER',
+  }) as Record<string, string>
+
+  assert.equal(headers.Authorization, 'Bearer secret-token')
+})
+
+check(
+  'BEARER authType does not double-prefix an already-prefixed token',
+  () => {
+    const headers = buildTextServerAuthHeaders({
+      apiKey: 'Bearer secret-token',
+      authType: 'BEARER',
+    }) as Record<string, string>
+
+    assert.equal(headers.Authorization, 'Bearer secret-token')
+  },
+)
+
+check('HEADER authType uses the custom apiKeyName', () => {
+  const headers = buildTextServerAuthHeaders({
+    apiKey: 'secret-token',
+    apiKeyName: 'X-Custom-Key',
+    authType: 'HEADER',
+  }) as Record<string, string>
+
+  assert.equal(headers['X-Custom-Key'], 'secret-token')
+})
+
+check('API_KEY authType defaults to X-API-Key when apiKeyName is unset', () => {
+  const headers = buildTextServerAuthHeaders({
+    apiKey: 'secret-token',
+    authType: 'API_KEY',
+  }) as Record<string, string>
+
+  assert.equal(headers['X-API-Key'], 'secret-token')
+})
+
+// -- buildChatRefId -----------------------------------------------------------
+
+check('a chatId produces a chat-scoped refId', () => {
+  assert.equal(buildChatRefId('openai', 42), 'chat:42')
+})
+
+check('no chatId produces a provider-labeled synthetic refId', () => {
+  const refId = buildChatRefId('ollama', null)
+
+  assert.match(refId, /^ollama:\d+$/)
+})
+
+// -- assertProviderApiKey ------------------------------------------------------
+
+check(
+  'missing apiKey throws a 500 with a "no ... key configured" message',
+  () => {
+    assert.throws(
+      () =>
+        assertProviderApiKey({
+          apiKey: '',
+          providerLabel: 'OpenAI',
+        }),
+      (error: unknown) =>
+        error instanceof Error &&
+        (error as { statusCode?: number }).statusCode === 500 &&
+        /no openai api key is configured/i.test(error.message),
+    )
+  },
+)
+
+check('an apiKey matching the expected prefix does not throw', () => {
+  assertProviderApiKey({
+    apiKey: 'sk-real-key',
+    providerLabel: 'OpenAI',
+    expectedPrefix: 'sk-',
+  })
+})
+
+check('an apiKey NOT matching the expected prefix throws a 500', () => {
+  assert.throws(
+    () =>
+      assertProviderApiKey({
+        apiKey: 'app-authorization-key',
+        providerLabel: 'Anthropic',
+        expectedPrefix: 'sk-ant-',
+      }),
+    (error: unknown) =>
+      error instanceof Error &&
+      (error as { statusCode?: number }).statusCode === 500,
+  )
+})
+
+check('no expectedPrefix skips the shape check entirely', () => {
+  assertProviderApiKey({
+    apiKey: 'whatever-a-custom-server-issues',
+    providerLabel: 'OpenAI-compatible',
+  })
+})
+
+// -- getErrorStatusCode --------------------------------------------------------
+
+check(
+  'an error-like object with a numeric statusCode is passed through',
+  () => {
+    assert.equal(getErrorStatusCode({ statusCode: 402 }), 402)
+  },
+)
+
+check('a plain Error without statusCode defaults to 500', () => {
+  assert.equal(getErrorStatusCode(new Error('boom')), 500)
+})
+
+check('a non-object thrown value defaults to 500', () => {
+  assert.equal(getErrorStatusCode('boom'), 500)
+})
+
+if (failures > 0) {
+  console.error(`\n${failures} failure(s).`)
+  process.exitCode = 1
+} else {
+  console.log('\nAll text-provider-service self-tests passed.')
+}


### PR DESCRIPTION
### Task
text-generation/t-002 (conductor): Build a shared server-side text generation provider layer (kind: software)

### What changed / what I produced
- New `server/utils/textProviderService.ts`: extracts the mechanics that were duplicated
  identically across all three chat streaming routes — optional server resolution,
  provider-key precedence (`userApiKey` → `server.apiKey` → runtime env key), per-`authType`
  auth-header building, SSE/ndjson header setup, the byte-relay-then-mana-trailer pump,
  error status-code extraction, and mana `refId` shaping.
- `server/api/chats/{openai,anthropic,ollama}/stream.post.ts` are now thin adapters over
  that shared service, keeping only what's genuinely provider-specific: message
  normalization shape, upstream payload shape, and the provider's own endpoint-resolution
  convention. Net **-367 lines** across the three routes.
- Every route now calls the single already-correct shared `estimateTextCostUsd`
  (`server/utils/manaCost.ts`, which correctly multiplies by `n`) instead of a local,
  drifted per-route estimator — the OpenAI route's local estimator never multiplied by `n`,
  undercharging multi-completion requests. This was the text-generation BRIEF.md's stated
  success criterion: "exactly one cost-estimation code path is used for text generation,
  not four."
- Added `utils/scripts/verifyTextProviderService.ts`, a DB-free self-test (21 checks) for
  the pure helpers: key precedence, per-`authType` header building, refId shape, and error
  status-code extraction. Wired into `.github/workflows/contract-tests.yml`
  (a workflow explicitly documented as DB-free) — `resolveOptionalTextServer`'s one
  Prisma-touching call is dynamically imported specifically so the rest of the module stays
  importable without `DATABASE_URL`.

### How I verified
- `npx eslint` on all touched/new files — clean.
- `npx prettier --check` on all touched/new files — clean.
- `node vue-tsc --noEmit -p tsconfig.json` (project-wide) — clean, no type errors.
- `npx tsx utils/scripts/verifyTextProviderService.ts` with `DATABASE_URL` unset — 21/21
  passing, confirming the new contract-tests.yml step stays genuinely DB-free.
- Read the full diff for each of the three routes against their pre-change version to
  confirm request URLs, request/response shapes, content-types (`text/event-stream` vs
  `application/x-ndjson`), and the two-phase error model (pre-stream `createError` vs.
  mid-stream `event: error` frame) are byte-for-byte unchanged in every branch except the
  cost-estimator call site.
- No live upstream call against a real OpenAI/Anthropic/Ollama endpoint was made (no
  provider credentials in this sandbox) — behavior equivalence was verified by diff-reading
  and the request/payload construction being identical, not by an end-to-end smoke test.

### Stakes
reversible

### Flags for Reviewer
- **New auth-header helper naming**: `buildTextServerAuthHeaders` (new, in
  `textProviderService.ts`) is deliberately a different name/shape than the pre-existing
  `buildServerAuthHeaders` in `server/utils/serverApi.ts` (used by the health-check routes
  and `textServer.ts`). They're not the same function: `serverApi.ts`'s version sets
  `Accept` and omits `Content-Type` (its GET-only health callers send no body);
  the chat routes' original builder always included `Content-Type: application/json`.
  Naming them identically caused a real Nuxt auto-import collision during dev (`nuxi
  prepare` warned "Duplicated imports... ignored") until I renamed mine — flagging this
  because unifying the two into one shared helper is a reasonable follow-up, just out of
  scope for a "no observable behavior change" migration.
- **Cost estimate will shift slightly** for callers that pass an explicit non-default
  `model` string the shared `estimateTextCostUsd` rate table doesn't specifically branch
  on (e.g. a bare `"gpt-4"` model — the old OpenAI-route estimator priced that at
  30/1M tokens; the shared estimator's fallback branch prices it at the gpt-4o-mini rate,
  0.6/1M). This is a real accuracy gap in `manaCost.ts`'s rate table, not something this
  task's scope covers (it only asked to consolidate onto the *existing* shared estimator).
  Worth a follow-up task to audit/extend `estimateTextCostUsd`'s per-model rates.
- Per t-002's explicit scope, I did **not** touch `serverResolver.ts`'s
  `capabilityWhere('text')` (still excludes `OLLAMA` from type-based resolution) — that's
  t-003's assigned scope per the BRIEF.md's migration sequence.

### Kaizen suggestion
Audit `estimateTextCostUsd`'s per-model rate table (`server/utils/manaCost.ts`) against
real provider pricing for model strings outside the `gpt-4o(-mini)`/`claude-{opus,sonnet,
haiku}` families it explicitly branches on (e.g. plain `"gpt-4"`, `"gpt-3.5-turbo"`,
`"o1"`/`"o3"` reasoning models) — several fall through to the conservative
gpt-4o-mini-ish default rate, which is a real (if pre-existing) mana-undercount risk now
that all three chat routes share this one code path instead of three independently-tuned
ones.

### Notes for reviewer
Conductor task: `text-generation/t-002` (set to `status: review` in a companion conductor
PR). Depends on `text-generation/t-001` (BRIEF.md, already merged/done). Per the BRIEF's
implementation sequence, `t-003` (Ollama capability-routing fix + private-server profile
UX) is the next task and builds on this one but does not block it.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvxospWhi9BR7QnDwNockT)_