### PR TITLE
feat(mermaids): turn the landing page into an admin writing desk

### DIFF
--- a/components/pages/mermaids-page.vue
+++ b/components/pages/mermaids-page.vue
@@ -1,37 +1,75 @@
-<!-- /components/content/pages/mermaids-page.vue -->
 <template>
-  <div class="kr-unbound flex flex-col items-center gap-4 bg-(--kr-surface) px-4 py-6">
+  <div class="kr-unbound flex flex-col items-center bg-(--kr-surface) px-4 py-6">
     <div class="w-full max-w-3xl">
-      <!-- Hero -->
       <div
-        class="relative mb-6 overflow-hidden rounded-2xl border border-base-300 shadow-lg"
+        v-if="userStore.isAdmin"
+        class="sticky top-3 z-30 mb-4 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-100/95 p-3 shadow-lg backdrop-blur"
       >
-        <img
-          src="/images/artcollections/mermaids-of-venice/mermaids-of-venice-inspiration-01.webp"
-          alt="Mermaids gliding through the submerged streets of a moonlit Venice"
-          class="h-56 w-full object-cover sm:h-72"
-        />
-        <div
-          class="absolute inset-0 flex flex-col justify-end bg-linear-to-t from-base-300/95 via-base-300/40 to-transparent p-5"
-        >
-          <p class="text-3xl font-black text-base-content sm:text-4xl">
-            Mermaids of Venice
-          </p>
-          <p class="text-sm font-semibold text-base-content/80 sm:text-base">
-            A subversive tale of gods and street performers — by Silas Knight
-          </p>
+        <div class="join">
+          <button
+            type="button"
+            class="btn btn-sm join-item"
+            :class="visitorPreview ? 'btn-ghost' : 'btn-primary'"
+            @click="visitorPreview = false"
+          >
+            Writing mode
+          </button>
+          <button
+            type="button"
+            class="btn btn-sm join-item"
+            :class="visitorPreview ? 'btn-primary' : 'btn-ghost'"
+            @click="visitorPreview = true"
+          >
+            Visitor preview
+          </button>
         </div>
+        <p class="text-xs text-base-content/60">
+          {{ editing ? `${saveStatus} · autosaved on this device` : 'Edit controls hidden' }}
+        </p>
       </div>
 
-      <!-- The book -->
-      <div
-        class="kr-panel mb-4 flex flex-col gap-5 p-5 sm:flex-row"
+      <header
+        class="relative mb-6 overflow-hidden rounded-3xl border border-base-300 bg-linear-to-br from-primary/18 via-base-100 to-secondary/16 shadow-lg"
       >
+        <div class="grid gap-6 p-6 sm:grid-cols-[1fr_auto] sm:items-center sm:p-8">
+          <div class="min-w-0">
+            <template v-if="editing">
+              <input
+                v-model="draft.heroTitle"
+                aria-label="Page title"
+                class="input input-bordered mb-3 w-full text-2xl font-black sm:text-3xl"
+              />
+              <textarea
+                v-model="draft.heroSubtitle"
+                aria-label="Page subtitle"
+                class="textarea textarea-bordered min-h-20 w-full text-sm font-semibold sm:text-base"
+              />
+            </template>
+            <template v-else>
+              <h1 class="text-3xl font-black text-base-content sm:text-4xl">
+                {{ draft.heroTitle }}
+              </h1>
+              <p class="mt-2 text-sm font-semibold text-base-content/75 sm:text-base">
+                {{ draft.heroSubtitle }}
+              </p>
+            </template>
+          </div>
+
+          <img
+            src="/images/utility/mermaids/mermaids1.jpg"
+            alt="Mermaids of Venice book cover"
+            class="mx-auto w-36 rounded-xl shadow-xl sm:mx-0 sm:w-44"
+          />
+        </div>
+      </header>
+
+      <section class="kr-panel mb-4 flex flex-col gap-5 p-5 sm:flex-row">
         <img
           src="/images/utility/mermaids/mermaids1.jpg"
-          alt="Mermaids of Venice book cover"
+          alt="Mermaids of Venice novel"
           class="mx-auto w-40 shrink-0 self-start rounded-xl shadow-md sm:mx-0"
         />
+
         <div class="flex min-w-0 flex-1 flex-col gap-3">
           <div class="flex items-center gap-3">
             <span
@@ -39,18 +77,28 @@
             >
               <Icon name="kind-icon:book" class="h-5 w-5" />
             </span>
+            <input
+              v-if="editing"
+              v-model="draft.bookHeading"
+              aria-label="Book section heading"
+              class="input input-bordered w-full font-black uppercase tracking-wider"
+            />
             <h2
+              v-else
               class="text-base font-black uppercase tracking-wider text-base-content"
             >
-              The Book
+              {{ draft.bookHeading }}
             </h2>
           </div>
 
-          <p class="text-sm leading-relaxed text-base-content/70">
-            In the canals and campos of Venice, old gods get by the way anyone
-            does — busking, bargaining, and performing for a crowd that no
-            longer believes in them. Six years in the writing, edited by the
-            author's own hand.
+          <textarea
+            v-if="editing"
+            v-model="draft.bookDescription"
+            aria-label="Book description"
+            class="textarea textarea-bordered min-h-36 w-full text-sm leading-relaxed"
+          />
+          <p v-else class="whitespace-pre-line text-sm leading-relaxed text-base-content/70">
+            {{ draft.bookDescription }}
           </p>
 
           <div class="mt-1 flex flex-wrap items-center gap-2">
@@ -61,28 +109,32 @@
               class="btn btn-primary btn-sm rounded-2xl"
             >
               <Icon name="kind-icon:external-link" class="h-4 w-4" />
-              Paperback on Amazon
+              {{ draft.amazonLabel }}
             </a>
+            <input
+              v-if="editing"
+              v-model="draft.amazonLabel"
+              aria-label="Amazon button label"
+              class="input input-bordered input-sm min-w-48 flex-1"
+            />
           </div>
 
           <mermaids-pdf-purchase />
 
-          <p class="text-xs text-base-content/50">
-            Signed copies appear in the Kind Robots giftshop when the tide is
-            right.
+          <textarea
+            v-if="editing"
+            v-model="draft.signedCopiesNote"
+            aria-label="Signed copies note"
+            class="textarea textarea-bordered min-h-20 w-full text-xs"
+          />
+          <p v-else class="whitespace-pre-line text-xs text-base-content/50">
+            {{ draft.signedCopiesNote }}
           </p>
         </div>
-      </div>
+      </section>
 
-      <!--
-        PERSONAL NOTE PLACEHOLDER
-        Silas writes this section himself (conductor: mermaids-of-venice t-002).
-        Filled with lorem ipsum at Silas's own direction ("just lorem ipsum it
-        for now") while he writes the real note. Replace the paragraph below
-        with his note, verbatim, and remove the "coming soon" styling.
-      -->
-      <div
-        class="mb-4 rounded-2xl border border-dashed border-base-300 bg-base-100 p-5 shadow-sm"
+      <section
+        class="mb-4 rounded-2xl border border-base-300 bg-base-100 p-5 shadow-sm"
       >
         <div class="mb-3 flex items-center gap-3">
           <span
@@ -90,57 +142,78 @@
           >
             <Icon name="kind-icon:hand-heart" class="h-5 w-5" />
           </span>
+          <input
+            v-if="editing"
+            v-model="draft.personalNoteHeading"
+            aria-label="Personal note heading"
+            class="input input-bordered w-full font-black uppercase tracking-wider"
+          />
           <h2
+            v-else
             class="text-base font-black uppercase tracking-wider text-base-content"
           >
-            A Note From Silas
+            {{ draft.personalNoteHeading }}
           </h2>
         </div>
-        <p class="text-sm italic leading-relaxed text-base-content/50">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-          ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat — Silas's real note will replace
-          this placeholder soon.
-        </p>
-      </div>
 
-      <!-- The AI disclosure — the only AI-written words on this page -->
-      <div class="kr-panel p-5">
+        <textarea
+          v-if="editing"
+          v-model="draft.personalNote"
+          aria-label="Personal note"
+          class="textarea textarea-bordered min-h-64 w-full text-sm leading-relaxed"
+          placeholder="Write your note here."
+        />
+        <p v-else class="whitespace-pre-line text-sm leading-relaxed text-base-content/70">
+          {{ draft.personalNote }}
+        </p>
+      </section>
+
+      <section class="kr-panel p-5">
         <div class="mb-3 flex items-center gap-3">
           <span
             class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-accent/12 text-accent"
           >
             <Icon name="kind-icon:robot-color" class="h-5 w-5" />
           </span>
+          <input
+            v-if="editing"
+            v-model="draft.aiNoteHeading"
+            aria-label="AI disclosure heading"
+            class="input input-bordered w-full font-black uppercase tracking-wider"
+          />
           <h2
+            v-else
             class="text-base font-black uppercase tracking-wider text-base-content"
           >
-            A Note About AI (Written by One)
+            {{ draft.aiNoteHeading }}
           </h2>
         </div>
-        <p class="text-sm leading-relaxed text-base-content/70">
-          No AI was used to write this book — other than the words that make up
-          this paragraph. Every other sentence was hand-carved by one stubborn
-          human across six years of drafts, which makes this paragraph the only
-          artificial thing on the premises. It is aware of the irony: a machine
-          vouching for the authenticity of a story about gods passing themselves
-          off as street performers. Originality is a strange gate to keep. But
-          somebody has to stand on this side of it and wave you through to the
-          real thing.
-        </p>
-      </div>
 
-      <ProjectGalleryStrip
-        collection-label="mermaids-of-venice"
-        title="Inspiration gallery"
-        class="mt-4"
-      />
+        <textarea
+          v-if="editing"
+          v-model="draft.aiNote"
+          aria-label="AI disclosure"
+          class="textarea textarea-bordered min-h-56 w-full text-sm leading-relaxed"
+        />
+        <p v-else class="whitespace-pre-line text-sm leading-relaxed text-base-content/70">
+          {{ draft.aiNote }}
+        </p>
+      </section>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-// Static landing page — deliberately no AI features, stores, or chat surfaces.
-// The book's front end stays human (conductor: mermaids-of-venice roadmap).
+import { computed, onMounted, ref } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useMermaidsStore } from '@/stores/mermaidsStore'
+import { useUserStore } from '@/stores/userStore'
+
+const mermaidsStore = useMermaidsStore()
+const userStore = useUserStore()
+const { draft, saveStatus } = storeToRefs(mermaidsStore)
+const visitorPreview = ref(false)
+const editing = computed(() => userStore.isAdmin && !visitorPreview.value)
+
+onMounted(() => mermaidsStore.loadDraft())
 </script>

--- a/components/pages/mermaids-page.vue
+++ b/components/pages/mermaids-page.vue
@@ -46,9 +46,9 @@
               />
             </template>
             <template v-else>
-              <h1 class="text-3xl font-black text-base-content sm:text-4xl">
+              <h2 class="text-3xl font-black text-base-content sm:text-4xl">
                 {{ draft.heroTitle }}
-              </h1>
+              </h2>
               <p class="mt-2 text-sm font-semibold text-base-content/75 sm:text-base">
                 {{ draft.heroSubtitle }}
               </p>

--- a/content/channels/sanctuary/mermaids.md
+++ b/content/channels/sanctuary/mermaids.md
@@ -6,12 +6,12 @@ dashboardKey: giftshop
 dashboardTab: mermaids
 label: Mermaids
 title: Mermaids of Venice
-subtitle: A story project with its own public home
-description: Explore the Mermaids of Venice project, its world, art, and external surfaces.
+subtitle: A writing desk for the novel's landing page
+description: Edit and preview the Mermaids of Venice landing page without generated artwork.
 icon: kind-icon:mermaid
 route: /mermaids
 sort: 20
 requiredRole: ADMIN
 ---
 
-A public-facing creative project living in the community and mission wing.
+An admin-only writing and preview surface for the Mermaids of Venice landing page.

--- a/content/mermaids.md
+++ b/content/mermaids.md
@@ -15,13 +15,6 @@ dashboardTab: mermaids
 cards: navCards
 loadingMessage: Rowing out to the lagoon...
 refreshLabel: Refresh the tide
-# Stage 3 backdrop art, resolved by slug via /api/art/backdrop/<page>-<variant>.
-# The route finds the completed ArtJob for this page and redirects to its
-# image, so art appears on its own once generation finishes. Until then the
-# route 404s and the page renders exactly as before.
-backgroundMobile: /api/art/backdrop/mermaids-mobile
-backgroundTablet: /api/art/backdrop/mermaids-tablet
-backgroundDesktop: /api/art/backdrop/mermaids-desktop
 ---
 
 :mermaids-page

--- a/stores/mermaidsStore.ts
+++ b/stores/mermaidsStore.ts
@@ -1,0 +1,128 @@
+import { computed, ref, watch } from 'vue'
+import { defineStore } from 'pinia'
+import { useUserStore } from '@/stores/userStore'
+
+const STORAGE_KEY = 'kindrobots:mermaids-page-draft:v1'
+const SAVE_DELAY_MS = 450
+
+export type MermaidsPageDraft = {
+  heroTitle: string
+  heroSubtitle: string
+  bookHeading: string
+  bookDescription: string
+  amazonLabel: string
+  signedCopiesNote: string
+  personalNoteHeading: string
+  personalNote: string
+  aiNoteHeading: string
+  aiNote: string
+}
+
+export const MERMAIDS_PAGE_DEFAULTS: Readonly<MermaidsPageDraft> = {
+  heroTitle: 'Mermaids of Venice',
+  heroSubtitle: 'A subversive tale of gods and street performers — by Silas Knight',
+  bookHeading: 'The Book',
+  bookDescription:
+    "In the canals and campos of Venice, old gods get by the way anyone does — busking, bargaining, and performing for a crowd that no longer believes in them. Six years in the writing, edited by the author's own hand.",
+  amazonLabel: 'Paperback on Amazon',
+  signedCopiesNote:
+    'Signed copies appear in the Kind Robots giftshop when the tide is right.',
+  personalNoteHeading: 'A Note From Silas',
+  personalNote:
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat — Silas's real note will replace this placeholder soon.",
+  aiNoteHeading: 'A Note About AI (Written by One)',
+  aiNote:
+    'No AI was used to write this book — other than the words that make up this paragraph. Every other sentence was hand-carved by one stubborn human across six years of drafts, which makes this paragraph the only artificial thing on the premises. It is aware of the irony: a machine vouching for the authenticity of a story about gods passing themselves off as street performers. Originality is a strange gate to keep. But somebody has to stand on this side of it and wave you through to the real thing.',
+}
+
+function freshDefaults(): MermaidsPageDraft {
+  return { ...MERMAIDS_PAGE_DEFAULTS }
+}
+
+function normalizeDraft(value: unknown): MermaidsPageDraft {
+  const source =
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {}
+
+  const defaults = freshDefaults()
+  for (const key of Object.keys(defaults) as Array<keyof MermaidsPageDraft>) {
+    if (typeof source[key] === 'string') defaults[key] = source[key]
+  }
+
+  return defaults
+}
+
+export const useMermaidsStore = defineStore('mermaidsStore', () => {
+  const userStore = useUserStore()
+  const draft = ref<MermaidsPageDraft>(freshDefaults())
+  const loaded = ref(false)
+  const saving = ref(false)
+  const savedAt = ref<Date | null>(null)
+  const lastError = ref<string | null>(null)
+  let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+  const saveStatus = computed(() => {
+    if (lastError.value) return lastError.value
+    if (saving.value) return 'Saving draft…'
+    if (savedAt.value) return `Saved ${savedAt.value.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`
+    return 'Draft not saved yet'
+  })
+
+  function loadDraft(): void {
+    if (loaded.value || !import.meta.client) return
+
+    lastError.value = null
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY)
+      if (stored) draft.value = normalizeDraft(JSON.parse(stored))
+      loaded.value = true
+    } catch (error) {
+      loaded.value = true
+      lastError.value =
+        error instanceof Error ? error.message : 'Could not load the Mermaids draft.'
+    }
+  }
+
+  function saveDraft(): void {
+    if (!import.meta.client || !userStore.isAdmin) return
+
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(draft.value))
+      savedAt.value = new Date()
+      lastError.value = null
+    } catch (error) {
+      lastError.value =
+        error instanceof Error ? error.message : 'Could not save the Mermaids draft.'
+    } finally {
+      saving.value = false
+    }
+  }
+
+  function scheduleSave(): void {
+    if (!loaded.value || !import.meta.client || !userStore.isAdmin) return
+    if (saveTimer) clearTimeout(saveTimer)
+    saving.value = true
+    saveTimer = setTimeout(saveDraft, SAVE_DELAY_MS)
+  }
+
+  function resetDraft(): void {
+    if (!userStore.isAdmin) return
+    draft.value = freshDefaults()
+    scheduleSave()
+  }
+
+  watch(draft, scheduleSave, { deep: true })
+
+  return {
+    draft,
+    loaded,
+    saving,
+    savedAt,
+    lastError,
+    saveStatus,
+    loadDraft,
+    saveDraft,
+    resetDraft,
+  }
+})

--- a/stores/seeds/pageBackdropArtPrompts.ts
+++ b/stores/seeds/pageBackdropArtPrompts.ts
@@ -102,22 +102,6 @@ const CONTRACT = `Create one standalone environment illustration to be used as a
 
 const HOUSE_AESTHETIC = `Painted storybook-illustration style with cinematic depth, warm inviting light, soft atmospheric haze in the distance, and rich but unfussy detail.`
 
-/**
- * The house aesthetic is a children's-picture-book register, and it is right
- * for almost every page here. It is wrong for `mermaids`, which fronts Silas's
- * novel — "Mermaids of Venice: a subversive tale of gods and street
- * performers", six years of work for adult readers.
- *
- * Silas, 2026-08-08, on the first batch: *"I don't have a problem with those,
- * only the ones that linked to mermaids because it was specifically for an
- * adult audience."* The acute problem there was the casting clause — the mobile
- * and tablet backdrops came back lined with small children and toy robots,
- * which is not art for that book. Removing the cast is necessary and not
- * sufficient: "friendly, playful, warm inviting light" would still render a
- * kids' game menu behind an adult novel.
- */
-const NOVEL_AESTHETIC = `Painted in the manner of a literary book jacket: oil-like brushwork, restrained and moody, deep shadow with a narrow shaft of cold light, muted desaturated colour with one low ember accent, weathered and lived-in surfaces, unsentimental. Adult in register — not whimsical, not cute, not a children's picture book.`
-
 const NEGATIVE_PROMPT = `text, caption, lettering, signage, logo, watermark, signature, border, frame, panel, collage, grid, contact sheet, ui mockup, interface elements, buttons, strong central subject, centered portrait, close-up face, busy cluttered centre, high-contrast centre, harsh clutter, photorealism, low detail, blurry, jpeg artifacts`
 
 type PageSeed = {
@@ -125,12 +109,7 @@ type PageSeed = {
   title: string
   /** The setting. Written to survive all three framings. */
   scene: string
-  /**
-   * Replaces HOUSE_AESTHETIC for this page only. For pages whose content sits
-   * in a different register than the rest of the app — today that is `mermaids`
-   * and its adult novel. It cannot reach CONTRACT, so an override can restyle a
-   * backdrop but never un-scenery it or put people back in.
-   */
+  /** Replaces HOUSE_AESTHETIC when a page needs a different visual register. */
   aesthetic?: string
 }
 
@@ -407,17 +386,6 @@ const PAGES: PageSeed[] = [
     title: 'Memory — The Card Hall',
     scene:
       'A hall of face-down cards floating in neat ranks, a few flipped to show tiny glowing scenes, candlelight. Playful concentration.',
-  },
-  {
-    page: 'mermaids',
-    title: 'Mermaids — The Lagoon',
-    // Grounded in the page's own frontmatter — room "Mermaids of Venice",
-    // subtitle "A subversive tale of gods and street performers" — rather than
-    // the generic lagoon the first batch used. A backdrop for a novel should
-    // look like that novel.
-    scene:
-      'A Venetian back canal after midnight, black water lying flat between old stone walls streaked with salt and algae. A low bridge, a shuttered doorway half a step above the waterline, a moored boat knocking against its post. One lamp burns somewhere out of frame and lays a long cold reflection down the water. Drifting sea-fog, wet stone, a few pale fish holding still under the surface.',
-    aesthetic: NOVEL_AESTHETIC,
   },
   {
     page: 'messages',


### PR DESCRIPTION
## Summary
- removes the generated Mermaids backdrop metadata, generated inspiration hero, and inspiration gallery from `/mermaids`
- uses the existing Mermaids book-cover asset as the only page image, framed by CSS gradients rather than generated scenery
- adds an admin-only Writing mode with editable title/subtitle, book copy, personal note, disclosure copy, and labels
- adds a Visitor preview toggle that hides all edit controls while keeping the route itself admin-only
- autosaves the draft through a dedicated Pinia store to this browser/device; checked-in defaults remain the safe fallback copy

## Why
The page explicitly says the novel was written without AI. Generated background/inspiration art undercuts that statement, and the personal-note placeholder has become something easy to defer instead of an inviting place to write.

## Scope / safety
- no generated art added
- no AI writing added or substituted for Silas's prose
- no DB schema changes or unrelated Project-field reuse
- `/mermaids` remains `requiredRole: ADMIN`; Visitor preview is presentation-only

## Verification requested from CI
- Vue/TypeScript typecheck
- lint/format/contracts already registered for normal PRs
- route/navigation access tests should continue to enforce the admin gate

## Known limitation
The writing draft intentionally persists locally on the current device in this first pass. It is not yet a cross-device/published CMS record. That keeps the feature useful without abusing an unrelated database field or adding a one-off schema before we decide whether this should become a reusable page-content system.
