### PR TITLE
fix(server): default admin uptime dashboard to all server types (text-generation/t-007)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -557,6 +557,9 @@ jobs:
       - name: Server capability routing contract
         run: npm run test:server-capability-routing
 
+      - name: Server uptime default-scope contract
+        run: npm run test:server-uptime-default-scope
+
       - name: Animation catalog contract
         run: npm run test:animation-catalog
 

--- a/package.json
+++ b/package.json
@@ -263,6 +263,7 @@
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",
     "test:text-provider-service": "tsx utils/scripts/verifyTextProviderService.ts",
     "test:server-capability-routing": "tsx utils/scripts/verifyServerCapabilityRouting.ts",
+    "test:server-uptime-default-scope": "tsx utils/scripts/verifyServerUptimeDefaultScope.ts",
     "components:manifest": "node utils/scripts/create-component-json.mjs",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",

--- a/server/api/server/uptime.get.ts
+++ b/server/api/server/uptime.get.ts
@@ -1,26 +1,24 @@
 // /server/api/server/uptime.get.ts
 //
-// Admin uptime report for art-generation servers. Aggregates the
+// Admin uptime report for art- and text-generation servers. Aggregates the
 // ServerHealthCheck time-series into per-server uptime % + a recent sample
 // series (for sparklines) over a configurable window. Powers the Uptime panel
 // of the ArtJob admin dashboard.
 //
-// Query: ?window=<hours> (default 24, max 720) ?serverType=COMFY|A1111
+// Defaults to every server type in getUptimeDefaultServerTypes()
+// (A1111/COMFY/OPENAI/ANTHROPIC/OLLAMA/CUSTOM, text-generation/t-007) so a
+// text-capable server's health is visible without a manual override.
+// Query: ?window=<hours> (default 24, max 720)
+//        ?serverType=A1111|COMFY|OPENAI|ANTHROPIC|OLLAMA|CUSTOM
 //        ?samples=<n> (recent samples per server, default 60, max 500)
 import { defineEventHandler, getQuery } from 'h3'
 import type { Prisma, ServerType } from '~/prisma/generated/prisma/client'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { requireAdminApiUser } from '../../utils/authGuard'
+import { getUptimeDefaultServerTypes } from '../../utils/serverUptimeScope'
 
-const SERVER_TYPES = new Set<ServerType>([
-  'A1111',
-  'COMFY',
-  'OPENAI',
-  'ANTHROPIC',
-  'OLLAMA',
-  'CUSTOM',
-])
+const SERVER_TYPES = new Set<ServerType>(getUptimeDefaultServerTypes())
 
 export default defineEventHandler(async (event) => {
   try {
@@ -32,7 +30,7 @@ export default defineEventHandler(async (event) => {
     const since = new Date(Date.now() - windowHours * 3_600_000)
 
     const serverWhere: Prisma.ServerWhereInput = {
-      serverType: { in: ['A1111', 'COMFY'] },
+      serverType: { in: getUptimeDefaultServerTypes() },
     }
 
     const requestedType = String(query.serverType || '').toUpperCase()

--- a/server/utils/serverUptimeScope.ts
+++ b/server/utils/serverUptimeScope.ts
@@ -1,0 +1,31 @@
+// /server/utils/serverUptimeScope.ts
+//
+// Pure, DB-free default scope for the admin uptime dashboard
+// (server/api/server/uptime.get.ts). Split out so it can be unit-tested
+// without a Prisma connection (see
+// utils/scripts/verifyServerUptimeDefaultScope.ts) the same way
+// serverCapabilities.ts is -- importing uptime.get.ts directly would
+// transitively pull in ../../utils/prisma, which throws at module-load time
+// without a DATABASE_URL (the "Contract verifiers" CI job intentionally
+// never sets one for its DB-free static checks).
+import type { ServerType } from '~/prisma/generated/prisma/client'
+
+// Every server type the uptime dashboard should surface by default. Before
+// text-generation/t-007, the default where-clause only covered A1111/COMFY
+// (the original art/GPU servers this panel was built for) -- a text-capable
+// server (OPENAI/ANTHROPIC/OLLAMA/CUSTOM) was only visible via a manual
+// ?serverType= override that nothing in the UI ever surfaced, so it had no
+// uptime/latency visibility in practice once text-generation/t-003 made
+// those server types real and resolvable.
+export const UPTIME_DEFAULT_SERVER_TYPES: ServerType[] = [
+  'A1111',
+  'COMFY',
+  'OPENAI',
+  'ANTHROPIC',
+  'OLLAMA',
+  'CUSTOM',
+]
+
+export function getUptimeDefaultServerTypes(): ServerType[] {
+  return UPTIME_DEFAULT_SERVER_TYPES
+}

--- a/utils/scripts/verifyServerUptimeDefaultScope.ts
+++ b/utils/scripts/verifyServerUptimeDefaultScope.ts
@@ -1,0 +1,61 @@
+// /utils/scripts/verifyServerUptimeDefaultScope.ts
+//
+// Regression guard for text-generation/t-007: server/utils/
+// serverUptimeScope.ts's getUptimeDefaultServerTypes() decides which
+// Server.serverType values server/api/server/uptime.get.ts includes by
+// default (before any ?serverType= override). Before this fix, the default
+// where-clause was hardcoded to ['A1111', 'COMFY'] only -- once
+// text-generation/t-003 made OPENAI/ANTHROPIC/OLLAMA/CUSTOM real,
+// resolvable text servers, they still had no uptime/latency visibility on
+// the admin dashboard unless an operator manually passed
+// ?serverType=OLLAMA (etc.), which nothing in the UI surfaces. Imported
+// directly here (not via uptime.get.ts) because that route transitively
+// pulls in ../../utils/prisma, which throws at module-load time without a
+// DATABASE_URL -- this CI job intentionally has none set.
+import assert from 'node:assert/strict'
+import { getUptimeDefaultServerTypes } from '../../server/utils/serverUptimeScope'
+
+let failures = 0
+
+function check(label: string, fn: () => void): void {
+  try {
+    fn()
+    console.log(`ok - ${label}`)
+  } catch (error) {
+    failures += 1
+    console.error(`FAIL - ${label}`)
+    console.error(error instanceof Error ? error.message : error)
+  }
+}
+
+const types = getUptimeDefaultServerTypes()
+
+check('default scope includes the original art/GPU server types', () => {
+  assert.ok(types.includes('A1111'))
+  assert.ok(types.includes('COMFY'))
+})
+
+check('default scope includes every text-capable server type', () => {
+  assert.ok(types.includes('OPENAI'))
+  assert.ok(types.includes('ANTHROPIC'))
+  assert.ok(types.includes('OLLAMA'))
+  assert.ok(types.includes('CUSTOM'))
+})
+
+check('default scope has no duplicate entries', () => {
+  assert.equal(types.length, new Set(types).size)
+})
+
+check('default scope is exactly the six known server types', () => {
+  assert.deepEqual(
+    [...types].sort(),
+    ['A1111', 'ANTHROPIC', 'COMFY', 'CUSTOM', 'OLLAMA', 'OPENAI'].sort(),
+  )
+})
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed.`)
+  process.exit(1)
+} else {
+  console.log(`\nAll checks passed.`)
+}


### PR DESCRIPTION
### Task
text-generation/t-007: Extend the admin server-uptime dashboard to cover text-capable servers (kind: software)

Kaizen from t-001's research / surfaced again during t-003's review: `server/api/server/uptime.get.ts` restricted its default `serverType` where-clause to `A1111`/`COMFY` only (overridable via `?serverType=` but not surfaced anywhere in the UI). Once t-003 made `OPENAI`/`ANTHROPIC`/`OLLAMA`/`CUSTOM` real, resolvable text-server types, they still had no uptime/latency visibility on the admin dashboard by default.

### What changed
- Extracted the default server-type scope into a pure, exported `getUptimeDefaultServerTypes()` (`server/utils/serverUptimeScope.ts`) — same DB-free pattern as `serverCapabilities.ts`'s `getCapabilityServerTypes()` from t-003 — and pointed `uptime.get.ts`'s default `serverWhere` at it instead of a hardcoded two-type array.
- Default scope now covers all six known server types: `A1111`, `COMFY`, `OPENAI`, `ANTHROPIC`, `OLLAMA`, `CUSTOM`. The `?serverType=` override behavior is unchanged.
- Added `utils/scripts/verifyServerUptimeDefaultScope.ts`, a DB-free contract test (4 checks: art/GPU types present, all text-capable types present, no duplicates, exact expected set). Wired into `package.json` (`test:server-uptime-default-scope`) and `.github/workflows/contract-tests.yml` alongside the sibling `server-capability-routing` check from t-003.
- Updated the route's header comment to describe the new default and the full `?serverType=` option list.

### How I verified
- New guard: `npm run test:server-uptime-default-scope` — 4/4 checks pass.
- Regression: `npm run test:server-capability-routing` (t-003's sibling contract) — 9/9 checks pass, unaffected.
- `vue-tsc --noEmit` (full project): 0 errors.
- `eslint` on changed files: clean.
- `prettier --check` on changed files: clean.
- `git status --porcelain`: exactly the 5 intended files.

### Stakes
reversible

### Notes for reviewer
Conductor roadmap: `text-generation/t-007` set to `status: review` via a small companion conductor PR (silasfelinus/conductor#2360).

The consuming front-end (`stores/artJobStore.ts`'s uptime fetch) never passes an explicit `serverType`, so this default-scope fix alone satisfies the acceptance criteria without any UI changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYq12ftfiCJLymR2Toigsq)_