### PR TITLE
fix(mermaids): persist writing desk copy site-wide

### DIFF
--- a/components/pages/mermaids-page.vue
+++ b/components/pages/mermaids-page.vue
@@ -24,8 +24,24 @@
           </button>
         </div>
         <p class="text-xs text-base-content/60">
-          {{ editing ? `${saveStatus} · autosaved on this device` : 'Edit controls hidden' }}
+          {{ visitorPreview ? 'Edit controls hidden' : saveStatus }}
         </p>
+      </div>
+
+      <div
+        v-if="userStore.isAdmin && lastError && !loaded"
+        class="alert alert-error mb-4"
+        role="alert"
+      >
+        <Icon name="kind-icon:warning" class="h-5 w-5" />
+        <span class="flex-1">{{ lastError }}</span>
+        <button
+          type="button"
+          class="btn btn-sm"
+          @click="mermaidsStore.loadDraft(true)"
+        >
+          Retry load
+        </button>
       </div>
 
       <header
@@ -211,9 +227,11 @@ import { useUserStore } from '@/stores/userStore'
 
 const mermaidsStore = useMermaidsStore()
 const userStore = useUserStore()
-const { draft, saveStatus } = storeToRefs(mermaidsStore)
+const { draft, loaded, lastError, saveStatus } = storeToRefs(mermaidsStore)
 const visitorPreview = ref(false)
-const editing = computed(() => userStore.isAdmin && !visitorPreview.value)
+const editing = computed(
+  () => userStore.isAdmin && loaded.value && !visitorPreview.value,
+)
 
-onMounted(() => mermaidsStore.loadDraft())
+onMounted(() => void mermaidsStore.loadDraft())
 </script>

--- a/prisma/migrations/20260817000500_project_page_content/migration.sql
+++ b/prisma/migrations/20260817000500_project_page_content/migration.sql
@@ -1,0 +1,15 @@
+-- Expand-only durable storage for editable Project-owned page copy.
+CREATE TABLE `ProjectPageContent` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `projectId` INTEGER NOT NULL,
+    `pageKey` VARCHAR(128) NOT NULL,
+    `content` LONGTEXT NOT NULL,
+    `updatedById` INTEGER NULL,
+
+    UNIQUE INDEX `ProjectPageContent_projectId_pageKey_key`(`projectId`, `pageKey`),
+    INDEX `ProjectPageContent_projectId_idx`(`projectId`),
+    INDEX `ProjectPageContent_updatedById_idx`(`updatedById`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/project-page-content.prisma
+++ b/prisma/project-page-content.prisma
@@ -1,0 +1,19 @@
+/// Durable editable presentation copy for Project-owned pages. `projectId` and
+/// `updatedById` intentionally remain ownership/audit scalars rather than adding
+/// more back-relations to the already-large Project/User models. API routes
+/// validate the Project and authenticated editor before reading or writing.
+/// Structured page payloads are serialized JSON in LongText, matching the repo's
+/// existing durable payload convention.
+model ProjectPageContent {
+  id          Int       @id @default(autoincrement())
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime? @default(now()) @updatedAt
+  projectId   Int
+  pageKey     String    @db.VarChar(128)
+  content     String    @db.LongText
+  updatedById Int?
+
+  @@unique([projectId, pageKey])
+  @@index([projectId])
+  @@index([updatedById])
+}

--- a/server/api/admin/project-page-content/[project].get.ts
+++ b/server/api/admin/project-page-content/[project].get.ts
@@ -1,0 +1,55 @@
+import {
+  createError,
+  defineEventHandler,
+  getQuery,
+  getRouterParam,
+} from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireAdminApiUser } from '~/server/utils/authGuard'
+import {
+  normalizeProjectPageKey,
+  resolveProjectPageProject,
+} from '~/server/utils/projectPageContent'
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireAdminApiUser(event)
+
+    const projectKey = getRouterParam(event, 'project')?.trim()
+    if (!projectKey) {
+      throw createError({ statusCode: 400, message: 'Project key is required.' })
+    }
+
+    const pageKey = normalizeProjectPageKey(getQuery(event).page)
+    const project = await resolveProjectPageProject(projectKey)
+    const page = await prisma.projectPageContent.findUnique({
+      where: {
+        projectId_pageKey: {
+          projectId: project.id,
+          pageKey,
+        },
+      },
+    })
+
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      message: page ? 'Project page content fetched.' : 'Project page has no saved content yet.',
+      data: {
+        projectId: project.id,
+        projectKey: project.conductorSlug || project.slug || String(project.id),
+        pageKey,
+        content: page?.content ?? null,
+        updatedAt: page?.updatedAt?.toISOString() ?? null,
+        updatedById: page?.updatedById ?? null,
+      },
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/admin/project-page-content/[project].put.ts
+++ b/server/api/admin/project-page-content/[project].put.ts
@@ -1,0 +1,74 @@
+import {
+  createError,
+  defineEventHandler,
+  getQuery,
+  getRouterParam,
+  readBody,
+} from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireAdminApiUser } from '~/server/utils/authGuard'
+import {
+  normalizeProjectPageContent,
+  normalizeProjectPageKey,
+  resolveProjectPageProject,
+} from '~/server/utils/projectPageContent'
+
+type ProjectPageContentBody = {
+  content?: unknown
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireAdminApiUser(event)
+
+    const projectKey = getRouterParam(event, 'project')?.trim()
+    if (!projectKey) {
+      throw createError({ statusCode: 400, message: 'Project key is required.' })
+    }
+
+    const pageKey = normalizeProjectPageKey(getQuery(event).page)
+    const body = await readBody<ProjectPageContentBody>(event)
+    const content = normalizeProjectPageContent(body?.content)
+    const project = await resolveProjectPageProject(projectKey)
+
+    const page = await prisma.projectPageContent.upsert({
+      where: {
+        projectId_pageKey: {
+          projectId: project.id,
+          pageKey,
+        },
+      },
+      create: {
+        projectId: project.id,
+        pageKey,
+        content,
+        updatedById: auth.user.id,
+      },
+      update: {
+        content,
+        updatedById: auth.user.id,
+      },
+    })
+
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      message: 'Project page content saved.',
+      data: {
+        projectId: project.id,
+        projectKey: project.conductorSlug || project.slug || String(project.id),
+        pageKey,
+        content: page.content,
+        updatedAt: page.updatedAt?.toISOString() ?? null,
+        updatedById: page.updatedById ?? null,
+      },
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+    return { ...handled, statusCode }
+  }
+})

--- a/server/utils/projectPageContent.ts
+++ b/server/utils/projectPageContent.ts
@@ -1,0 +1,59 @@
+import { createError } from 'h3'
+import prisma from '~/server/utils/prisma'
+
+const PAGE_KEY_PATTERN = /^[a-z0-9][a-z0-9-]{0,127}$/
+export const MAX_PROJECT_PAGE_CONTENT_CHARS = 250_000
+
+export function normalizeProjectPageKey(value: unknown): string {
+  const pageKey = typeof value === 'string' ? value.trim().toLowerCase() : ''
+  if (!PAGE_KEY_PATTERN.test(pageKey)) {
+    throw createError({
+      statusCode: 400,
+      message: 'Page key must be 1-128 lowercase letters, numbers, or hyphens.',
+    })
+  }
+  return pageKey
+}
+
+export function normalizeProjectPageContent(value: unknown): string {
+  if (typeof value !== 'string') {
+    throw createError({
+      statusCode: 400,
+      message: 'Project page content must be serialized text.',
+    })
+  }
+  if (value.length > MAX_PROJECT_PAGE_CONTENT_CHARS) {
+    throw createError({
+      statusCode: 413,
+      message: 'Project page content is too large.',
+    })
+  }
+  return value
+}
+
+export async function resolveProjectPageProject(projectKey: string) {
+  const normalized = projectKey.trim()
+  if (!normalized) {
+    throw createError({ statusCode: 400, message: 'Project key is required.' })
+  }
+
+  const id = Number(normalized)
+  const project = await prisma.project.findFirst({
+    where:
+      Number.isInteger(id) && id > 0
+        ? { id }
+        : { OR: [{ slug: normalized }, { conductorSlug: normalized }] },
+    select: {
+      id: true,
+      title: true,
+      slug: true,
+      conductorSlug: true,
+    },
+  })
+
+  if (!project) {
+    throw createError({ statusCode: 404, message: 'Project not found.' })
+  }
+
+  return project
+}

--- a/stores/mermaidsStore.ts
+++ b/stores/mermaidsStore.ts
@@ -1,8 +1,12 @@
 import { computed, ref, watch } from 'vue'
 import { defineStore } from 'pinia'
 import { useUserStore } from '@/stores/userStore'
+import { performFetch } from '@/stores/utils'
 
-const STORAGE_KEY = 'kindrobots:mermaids-page-draft:v1'
+const LEGACY_STORAGE_KEY = 'kindrobots:mermaids-page-draft:v1'
+const PROJECT_KEY = 'mermaids-of-venice'
+const PAGE_KEY = 'landing'
+const CONTENT_ENDPOINT = `/api/admin/project-page-content/${PROJECT_KEY}?page=${PAGE_KEY}`
 const SAVE_DELAY_MS = 450
 
 export type MermaidsPageDraft = {
@@ -16,6 +20,15 @@ export type MermaidsPageDraft = {
   personalNote: string
   aiNoteHeading: string
   aiNote: string
+}
+
+type ProjectPageContentResponse = {
+  projectId: number
+  projectKey: string
+  pageKey: string
+  content: string | null
+  updatedAt: string | null
+  updatedById: number | null
 }
 
 export const MERMAIDS_PAGE_DEFAULTS: Readonly<MermaidsPageDraft> = {
@@ -53,49 +66,140 @@ function normalizeDraft(value: unknown): MermaidsPageDraft {
   return defaults
 }
 
+function parseDraft(serialized: string): MermaidsPageDraft {
+  return normalizeDraft(JSON.parse(serialized))
+}
+
+function readLegacyDraft(): MermaidsPageDraft | null {
+  if (!import.meta.client) return null
+  try {
+    const serialized = window.localStorage.getItem(LEGACY_STORAGE_KEY)
+    return serialized ? parseDraft(serialized) : null
+  } catch {
+    return null
+  }
+}
+
+function removeLegacyDraft(): void {
+  if (!import.meta.client) return
+  try {
+    window.localStorage.removeItem(LEGACY_STORAGE_KEY)
+  } catch {
+    // A browser refusing localStorage cleanup is harmless once the server copy exists.
+  }
+}
+
 export const useMermaidsStore = defineStore('mermaidsStore', () => {
   const userStore = useUserStore()
   const draft = ref<MermaidsPageDraft>(freshDefaults())
   const loaded = ref(false)
+  const loading = ref(false)
   const saving = ref(false)
   const savedAt = ref<Date | null>(null)
   const lastError = ref<string | null>(null)
   let saveTimer: ReturnType<typeof setTimeout> | null = null
 
   const saveStatus = computed(() => {
+    if (loading.value) return 'Loading site copy…'
     if (lastError.value) return lastError.value
-    if (saving.value) return 'Saving draft…'
-    if (savedAt.value) return `Saved ${savedAt.value.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`
-    return 'Draft not saved yet'
+    if (saving.value) return 'Saving to site…'
+    if (savedAt.value) {
+      return `Saved site-wide ${savedAt.value.toLocaleTimeString([], {
+        hour: 'numeric',
+        minute: '2-digit',
+      })}`
+    }
+    if (loaded.value) return 'Site copy ready'
+    return 'Waiting for site copy…'
   })
 
-  function loadDraft(): void {
-    if (loaded.value || !import.meta.client) return
+  async function persistDraft(): Promise<boolean> {
+    if (!import.meta.client || !userStore.isAdmin || !loaded.value) return false
 
-    lastError.value = null
+    saving.value = true
     try {
-      const stored = window.localStorage.getItem(STORAGE_KEY)
-      if (stored) draft.value = normalizeDraft(JSON.parse(stored))
-      loaded.value = true
+      const response = await performFetch<ProjectPageContentResponse>(
+        CONTENT_ENDPOINT,
+        {
+          method: 'PUT',
+          cache: 'no-store',
+          body: JSON.stringify({ content: JSON.stringify(draft.value) }),
+        },
+      )
+
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Could not save the Mermaids page.')
+      }
+
+      savedAt.value = response.data.updatedAt
+        ? new Date(response.data.updatedAt)
+        : new Date()
+      lastError.value = null
+      removeLegacyDraft()
+      return true
     } catch (error) {
-      loaded.value = true
       lastError.value =
-        error instanceof Error ? error.message : 'Could not load the Mermaids draft.'
+        error instanceof Error
+          ? `Save failed: ${error.message}`
+          : 'Save failed: could not update the Mermaids page.'
+      return false
+    } finally {
+      saving.value = false
     }
   }
 
-  function saveDraft(): void {
-    if (!import.meta.client || !userStore.isAdmin) return
+  async function loadDraft(force = false): Promise<void> {
+    if ((!force && loaded.value) || loading.value || !import.meta.client) return
+    if (!userStore.isAdmin) return
+
+    loading.value = true
+    lastError.value = null
+    if (saveTimer) {
+      clearTimeout(saveTimer)
+      saveTimer = null
+    }
 
     try {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(draft.value))
-      savedAt.value = new Date()
-      lastError.value = null
+      const response = await performFetch<ProjectPageContentResponse>(
+        CONTENT_ENDPOINT,
+        { cache: 'no-store' },
+      )
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Could not load the Mermaids page.')
+      }
+
+      if (response.data.content) {
+        try {
+          draft.value = parseDraft(response.data.content)
+        } catch {
+          throw new Error('The saved Mermaids page copy is not valid JSON.')
+        }
+        loaded.value = true
+        savedAt.value = response.data.updatedAt
+          ? new Date(response.data.updatedAt)
+          : null
+        removeLegacyDraft()
+        return
+      }
+
+      // PR #1920 briefly stored the writing desk only in this browser. If that
+      // draft exists and no server copy exists yet, promote it once so the user
+      // does not lose work during the migration to durable site content.
+      const legacyDraft = readLegacyDraft()
+      draft.value = legacyDraft ?? freshDefaults()
+      loaded.value = true
+
+      if (legacyDraft) {
+        await persistDraft()
+      }
     } catch (error) {
+      loaded.value = false
       lastError.value =
-        error instanceof Error ? error.message : 'Could not save the Mermaids draft.'
+        error instanceof Error
+          ? `Load failed: ${error.message}`
+          : 'Load failed: could not fetch the Mermaids page.'
     } finally {
-      saving.value = false
+      loading.value = false
     }
   }
 
@@ -103,26 +207,32 @@ export const useMermaidsStore = defineStore('mermaidsStore', () => {
     if (!loaded.value || !import.meta.client || !userStore.isAdmin) return
     if (saveTimer) clearTimeout(saveTimer)
     saving.value = true
-    saveTimer = setTimeout(saveDraft, SAVE_DELAY_MS)
+    saveTimer = setTimeout(() => {
+      saveTimer = null
+      void persistDraft()
+    }, SAVE_DELAY_MS)
   }
 
   function resetDraft(): void {
-    if (!userStore.isAdmin) return
+    if (!userStore.isAdmin || !loaded.value) return
     draft.value = freshDefaults()
-    scheduleSave()
   }
 
-  watch(draft, scheduleSave, { deep: true })
+  // Synchronous flush keeps server hydration from being mistaken for a user
+  // edit: loadDraft assigns draft while `loaded` is still false, so only actual
+  // post-load edits enter the autosave debounce.
+  watch(draft, scheduleSave, { deep: true, flush: 'sync' })
 
   return {
     draft,
     loaded,
+    loading,
     saving,
     savedAt,
     lastError,
     saveStatus,
     loadDraft,
-    saveDraft,
+    saveDraft: persistDraft,
     resetDraft,
   }
 })


### PR DESCRIPTION
## Why
PR #1920 made the Mermaids writing desk editable, but its first persistence implementation was browser-local. That does not meet the intended contract: edits need to follow the admin across devices and be the canonical copy rendered by the site.

## What changed
- add reusable `ProjectPageContent` durable storage as a separate Prisma schema model
- add an expand-only migration creating the page-content table
- add admin-authenticated GET/PUT APIs scoped by Project + page key
- switch `mermaidsStore` from local-only autosave to authenticated server autosave
- keep the old localStorage key only as a one-time migration source when no server copy exists, then remove it after successful server persistence
- prevent writing controls from appearing until canonical site copy has loaded
- report site-wide save state and provide a retry path on load failure

## Scope / safety
- no destructive database operations
- no reset or data replacement
- no secrets, billing, DNS, or external publishing changes
- `/mermaids` remains admin-only; Visitor preview remains presentation-only
- the no-AI-background and cover-only visual behavior from #1920 is unchanged

## Verification requested from CI
- Prisma multi-file schema generation/validation
- TypeScript/Vue typecheck
- contract/layout tests
- migration/build checks