### PR TITLE
feat(server): SSRF/timeout/redirect/cancellation hardening for text-server dialing (text-generation/t-005)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -563,6 +563,9 @@ jobs:
       - name: Text-generation dispatch contract
         run: npm run test:text-generation-dispatch
 
+      - name: Network safety (SSRF boundary) contract
+        run: npm run test:network-safety
+
       - name: Animation catalog contract
         run: npm run test:animation-catalog
 

--- a/package.json
+++ b/package.json
@@ -265,6 +265,7 @@
     "test:server-capability-routing": "tsx utils/scripts/verifyServerCapabilityRouting.ts",
     "test:server-uptime-default-scope": "tsx utils/scripts/verifyServerUptimeDefaultScope.ts",
     "test:text-generation-dispatch": "tsx utils/scripts/verifyTextGenerationDispatch.ts",
+    "test:network-safety": "tsx utils/scripts/verifyNetworkSafety.ts",
     "components:manifest": "node utils/scripts/create-component-json.mjs",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",

--- a/server/api/chats/anthropic/stream.post.ts
+++ b/server/api/chats/anthropic/stream.post.ts
@@ -4,6 +4,7 @@ import { getServerEndpoint } from '../../../utils/serverResolver'
 import { manaGate } from '../../../utils/manaGate'
 import { requireApiUser } from '../../../utils/authGuard'
 import { estimateTextCostUsd } from '../../../utils/manaCost'
+import { safeFetch } from '../../../utils/safeFetch'
 import {
   assertProviderApiKey,
   buildChatRefId,
@@ -35,6 +36,10 @@ type AnthropicStreamBody = {
 }
 
 export default defineEventHandler(async (event) => {
+  // text-generation/t-005 -- see generate/text.post.ts's identical comment.
+  const abortController = new AbortController()
+  event.node.req.on('close', () => abortController.abort())
+
   try {
     const body = await readBody<AnthropicStreamBody>(event)
     const config = useRuntimeConfig()
@@ -100,11 +105,15 @@ export default defineEventHandler(async (event) => {
       bodyHasUserApiKey: Boolean(body.userApiKey),
     })
 
-    const upstream = await fetch(endpoint, {
-      method: 'POST',
-      headers: buildCloudProviderAuthHeaders('anthropic', apiKey),
-      body: JSON.stringify(payload),
-    })
+    const upstream = await safeFetch(
+      endpoint,
+      {
+        method: 'POST',
+        headers: buildCloudProviderAuthHeaders('anthropic', apiKey),
+        body: JSON.stringify(payload),
+      },
+      { signal: abortController.signal },
+    )
 
     if (!upstream.ok || !upstream.body) {
       const errText = await upstream.text().catch(() => '')
@@ -117,17 +126,23 @@ export default defineEventHandler(async (event) => {
 
     setStreamHeaders(event, 'text/event-stream')
 
-    return sendMeteredStream(event, upstream.body, 'anthropic', async () => {
-      const { balance } = await gate.commit(
-        buildChatRefId('anthropic', body.chatId),
-      )
+    return sendMeteredStream(
+      event,
+      upstream.body,
+      'anthropic',
+      async () => {
+        const { balance } = await gate.commit(
+          buildChatRefId('anthropic', body.chatId),
+        )
 
-      return {
-        balance,
-        charged: gate.cost,
-        free: gate.free,
-      }
-    })
+        return {
+          balance,
+          charged: gate.cost,
+          free: gate.free,
+        }
+      },
+      { abortController },
+    )
   } catch (error) {
     const statusCode = getErrorStatusCode(error)
     const message = error instanceof Error ? error.message : 'Unknown error'

--- a/server/api/chats/ollama/stream.post.ts
+++ b/server/api/chats/ollama/stream.post.ts
@@ -4,6 +4,7 @@ import { getServerEndpoint, resolveServer } from '../../../utils/serverResolver'
 import { manaGate } from '../../../utils/manaGate'
 import { requireApiUser } from '../../../utils/authGuard'
 import { estimateTextCostUsd } from '../../../utils/manaCost'
+import { safeFetch } from '../../../utils/safeFetch'
 import {
   buildChatRefId,
   buildTextServerAuthHeaders,
@@ -29,6 +30,10 @@ type OllamaStreamBody = {
 }
 
 export default defineEventHandler(async (event) => {
+  // text-generation/t-005 -- see generate/text.post.ts's identical comment.
+  const abortController = new AbortController()
+  event.node.req.on('close', () => abortController.abort())
+
   try {
     const body = await readBody<OllamaStreamBody>(event)
     const config = useRuntimeConfig()
@@ -57,6 +62,13 @@ export default defineEventHandler(async (event) => {
     const resolvedEndpoint = getServerEndpoint(server)
     const fallbackBaseUrl = String(config.ollamaBaseUrl || '').trim()
     const baseUrl = resolvedEndpoint || fallbackBaseUrl
+    // text-generation/t-005 -- `resolvedEndpoint` comes from a DB-stored
+    // `Server.baseUrl`, settable by any authenticated user (see
+    // networkSafety.ts's module doc), so loopback stays blocked for it.
+    // `fallbackBaseUrl` is `config.ollamaBaseUrl`, an operator-set env var
+    // (nuxt.config.ts defaults it to `http://localhost:11434`) -- not
+    // attacker-influenced, so loopback is allowed only on this path.
+    const usingOperatorFallback = !resolvedEndpoint
 
     if (!baseUrl) {
       throw createError({
@@ -90,11 +102,15 @@ export default defineEventHandler(async (event) => {
       free: gate.free,
     })
 
-    const upstream = await fetch(endpoint, {
-      method: 'POST',
-      headers: buildTextServerAuthHeaders(server),
-      body: JSON.stringify(payload),
-    })
+    const upstream = await safeFetch(
+      endpoint,
+      {
+        method: 'POST',
+        headers: buildTextServerAuthHeaders(server),
+        body: JSON.stringify(payload),
+      },
+      { signal: abortController.signal, allowLoopback: usingOperatorFallback },
+    )
 
     if (!upstream.ok || !upstream.body) {
       const errText = await upstream.text().catch(() => '')
@@ -107,17 +123,23 @@ export default defineEventHandler(async (event) => {
 
     setStreamHeaders(event, 'application/x-ndjson')
 
-    return sendMeteredStream(event, upstream.body, 'ollama', async () => {
-      const { balance } = await gate.commit(
-        buildChatRefId('ollama', body.chatId),
-      )
+    return sendMeteredStream(
+      event,
+      upstream.body,
+      'ollama',
+      async () => {
+        const { balance } = await gate.commit(
+          buildChatRefId('ollama', body.chatId),
+        )
 
-      return {
-        balance,
-        charged: gate.cost,
-        free: gate.free,
-      }
-    })
+        return {
+          balance,
+          charged: gate.cost,
+          free: gate.free,
+        }
+      },
+      { abortController },
+    )
   } catch (error) {
     const statusCode = getErrorStatusCode(error)
     const message = error instanceof Error ? error.message : 'Unknown error'

--- a/server/api/chats/openai/stream.post.ts
+++ b/server/api/chats/openai/stream.post.ts
@@ -4,6 +4,7 @@ import { getServerEndpoint } from '../../../utils/serverResolver'
 import { manaGate } from '../../../utils/manaGate'
 import { requireApiUser } from '../../../utils/authGuard'
 import { estimateTextCostUsd } from '../../../utils/manaCost'
+import { safeFetch } from '../../../utils/safeFetch'
 import {
   assertProviderApiKey,
   buildChatRefId,
@@ -36,6 +37,10 @@ type OpenAiStreamBody = {
 }
 
 export default defineEventHandler(async (event) => {
+  // text-generation/t-005 -- see generate/text.post.ts's identical comment.
+  const abortController = new AbortController()
+  event.node.req.on('close', () => abortController.abort())
+
   try {
     const body = await readBody<OpenAiStreamBody>(event)
     const config = useRuntimeConfig()
@@ -103,11 +108,15 @@ export default defineEventHandler(async (event) => {
       bodyHasUserApiKey: Boolean(body.userApiKey),
     })
 
-    const upstream = await fetch(endpoint, {
-      method: 'POST',
-      headers: buildCloudProviderAuthHeaders('openai', apiKey),
-      body: JSON.stringify(payload),
-    })
+    const upstream = await safeFetch(
+      endpoint,
+      {
+        method: 'POST',
+        headers: buildCloudProviderAuthHeaders('openai', apiKey),
+        body: JSON.stringify(payload),
+      },
+      { signal: abortController.signal },
+    )
 
     if (!upstream.ok || !upstream.body) {
       const errText = await upstream.text().catch(() => '')
@@ -120,17 +129,23 @@ export default defineEventHandler(async (event) => {
 
     setStreamHeaders(event, 'text/event-stream')
 
-    return sendMeteredStream(event, upstream.body, 'openai', async () => {
-      const { balance } = await gate.commit(
-        buildChatRefId('openai', body.chatId),
-      )
+    return sendMeteredStream(
+      event,
+      upstream.body,
+      'openai',
+      async () => {
+        const { balance } = await gate.commit(
+          buildChatRefId('openai', body.chatId),
+        )
 
-      return {
-        balance,
-        charged: gate.cost,
-        free: gate.free,
-      }
-    })
+        return {
+          balance,
+          charged: gate.cost,
+          free: gate.free,
+        }
+      },
+      { abortController },
+    )
   } catch (error) {
     const statusCode = getErrorStatusCode(error)
     const message = error instanceof Error ? error.message : 'Unknown error'

--- a/server/api/generate/text.post.ts
+++ b/server/api/generate/text.post.ts
@@ -15,6 +15,7 @@ import { createError, defineEventHandler, readBody } from 'h3'
 import { manaGate } from '../../utils/manaGate'
 import { requireApiUser } from '../../utils/authGuard'
 import { estimateTextCostUsd } from '../../utils/manaCost'
+import { safeFetch } from '../../utils/safeFetch'
 import {
   assertProviderApiKey,
   buildChatRefId,
@@ -23,6 +24,7 @@ import {
   getErrorStatusCode,
   getRuntimeAnthropicKey,
   getRuntimeOpenAiKey,
+  readJsonWithSizeCap,
   resolveApiKeyPrecedence,
   sendMeteredStream,
   setStreamHeaders,
@@ -65,6 +67,15 @@ type GenerateTextBody = {
 }
 
 export default defineEventHandler(async (event) => {
+  // text-generation/t-005 -- tied to `safeFetch`'s `signal` option so a
+  // client that disconnects (navigates away, clicks "stop") tears down the
+  // in-flight upstream request instead of running/billing to completion
+  // unread. `sendMeteredStream` also registers its own `close` listener on
+  // this same controller for the streaming branch below; both calling
+  // `.abort()` is harmless (idempotent).
+  const abortController = new AbortController()
+  event.node.req.on('close', () => abortController.abort())
+
   try {
     const body = await readBody<GenerateTextBody>(event)
     const config = useRuntimeConfig()
@@ -141,11 +152,15 @@ export default defineEventHandler(async (event) => {
       providerKeyLength: apiKeyLength,
     })
 
-    const upstream = await fetch(endpoint, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(payload),
-    })
+    const upstream = await safeFetch(
+      endpoint,
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+      },
+      { signal: abortController.signal },
+    )
 
     if (!upstream.ok || (stream && !upstream.body)) {
       const errText = await upstream.text().catch(() => '')
@@ -164,14 +179,20 @@ export default defineEventHandler(async (event) => {
         provider === 'ollama' ? 'application/x-ndjson' : 'text/event-stream',
       )
 
-      return sendMeteredStream(event, upstream.body!, provider, async () => {
-        const { balance } = await gate.commit(refId)
+      return sendMeteredStream(
+        event,
+        upstream.body!,
+        provider,
+        async () => {
+          const { balance } = await gate.commit(refId)
 
-        return { balance, charged: gate.cost, free: gate.free }
-      })
+          return { balance, charged: gate.cost, free: gate.free }
+        },
+        { abortController },
+      )
     }
 
-    const raw = await upstream.json()
+    const raw = await readJsonWithSizeCap(upstream)
     const normalized = parseGenerationResponse(provider, raw)
     const { balance } = await gate.commit(refId)
 

--- a/server/utils/networkSafety.ts
+++ b/server/utils/networkSafety.ts
@@ -1,0 +1,385 @@
+// /server/utils/networkSafety.ts
+//
+// text-generation/t-005 -- outbound-URL safety checks for every route that
+// dials a stored `Server.baseUrl` (or a cloud-provider endpoint derived from
+// one). A `Server` row can be created by ANY authenticated user (POST
+// /api/server only requires `requireAuthUser`, not an admin/owner check --
+// see server/api/server/index.post.ts's `serverCreateFields`/
+// `buildServerCreateData` -- `baseUrl` itself is not privilege-gated), so a
+// stored `baseUrl` is attacker-reachable input, not merely admin input. This
+// module is defense-in-depth on top of the existing visibility/ownership
+// gate `resolveServer` already enforces (see serverResolver.ts) -- it closes
+// the network-layer gap BRIEF.md documents: "any stored Server row with a
+// baseUrl is dialed as-is; there is no explicit block on cloud-metadata,
+// link-local, or otherwise unsafe destinations."
+//
+// Deliberately narrower than "block every RFC1918-private address": this
+// app's own self-hosted-server story explicitly includes home-LAN
+// (`192.168.x.x`/`10.x.x.x`) and Tailscale (`100.64.0.0/10` CGNAT range,
+// `ServerAccessMode.TAILSCALE` in the Prisma schema) targets as first-class,
+// intended destinations -- blocking those ranges outright would break the
+// exact feature this project exists to harden. Only metadata/link-local/
+// unspecified targets (plus loopback, gated by `allowLoopback` below) are
+// blocked; see BRIEF.md's "Private-server SSRF boundary (t-005)" section
+// for the exact scope this implements.
+//
+// Loopback (127.0.0.0/8, ::1, literal "localhost") is a narrower case: it's
+// blocked by default (a malicious ordinary user pointing a `Server.baseUrl`
+// at 127.0.0.1 to reach this process's own internal-only services is a
+// classic SSRF pivot), but `nuxt.config.ts`'s own `ollamaBaseUrl` default is
+// `http://localhost:11434` -- an operator-set env var, not user input, and
+// the documented zero-config self-hosted-Ollama experience. Every check
+// below takes an `allowLoopback` flag (default `false`) so call sites can
+// distinguish "validating a DB-stored, user-settable baseUrl" (leave it
+// false) from "validating an operator-configured fallback endpoint" (pass
+// `true`) without weakening the DB-input path.
+import dns from 'node:dns'
+import net from 'node:net'
+
+export type UrlValidationResult =
+  { ok: true; url: URL } | { ok: false; reason: string }
+
+export type HostValidationResult =
+  { ok: true; addresses: string[] } | { ok: false; reason: string }
+
+export type SafetyCheckOptions = {
+  /** Allow loopback (127.0.0.0/8, ::1, "localhost") through. Never allows
+   * cloud-metadata/link-local/unspecified addresses regardless of this
+   * flag -- those have no legitimate use as any kind of configured
+   * destination. */
+  allowLoopback?: boolean
+}
+
+export const ALLOWED_URL_SCHEMES = new Set(['http:', 'https:'])
+
+export const DEFAULT_OUTBOUND_CONNECT_TIMEOUT_MS = 15_000
+export const DEFAULT_IDLE_TIMEOUT_MS = 30_000
+export const DEFAULT_MAX_RESPONSE_BYTES = 25 * 1024 * 1024 // 25MB
+export const DEFAULT_MAX_REDIRECTS = 3
+
+/** Hostname literals with no legitimate use as a configured server target,
+ * regardless of what they resolve to (or even if they don't resolve at
+ * all -- some of these are conventionally routed by a local resolver/hosts
+ * file rather than real DNS, e.g. cloud metadata hostnames). */
+const BLOCKED_METADATA_HOSTNAME_LITERALS = new Set([
+  'metadata',
+  'metadata.google.internal',
+])
+
+const LOOPBACK_HOSTNAME_LITERALS = new Set(['localhost'])
+
+export function isBlockedHostnameLiteral(
+  hostname: string,
+  options: SafetyCheckOptions = {},
+): boolean {
+  const host = hostname.trim().toLowerCase().replace(/\.$/, '')
+
+  if (BLOCKED_METADATA_HOSTNAME_LITERALS.has(host)) return true
+
+  if (options.allowLoopback) return false
+
+  if (LOOPBACK_HOSTNAME_LITERALS.has(host)) return true
+  if (host.endsWith('.localhost')) return true
+
+  return false
+}
+
+/** Single-address, non-link-local metadata endpoints that don't fall inside
+ * the 169.254.0.0/16 or fe80::/10 blocks below but are still pure
+ * cloud-metadata targets: Alibaba Cloud (100.100.100.200) and AWS's IPv6
+ * metadata address (fd00:ec2::254). Never affected by `allowLoopback`. */
+const BLOCKED_METADATA_SINGLE_IPS = new Set([
+  '100.100.100.200',
+  'fd00:ec2::254',
+])
+
+export function isPrivateOrReservedIpv4(
+  ip: string,
+  options: SafetyCheckOptions = {},
+): boolean {
+  const parts = ip.split('.').map((part) => Number(part))
+
+  if (
+    parts.length !== 4 ||
+    parts.some((p) => !Number.isInteger(p) || p < 0 || p > 255)
+  ) {
+    return false
+  }
+
+  const [a, b] = parts
+
+  if (a === 0) return true // "this network" / unspecified, 0.0.0.0/8
+  if (a === 169 && b === 254) return true // link-local incl. cloud metadata, 169.254.0.0/16
+  if (a === 127) return !options.allowLoopback // loopback, 127.0.0.0/8
+
+  return false
+}
+
+type Ipv6Groups = readonly [
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+]
+
+/** Expands a (possibly `::`-compressed, possibly IPv4-mapped) IPv6 address
+ * literal into its 8 canonical 16-bit groups. Returns null if `ip` isn't a
+ * parseable IPv6 literal. */
+function expandIpv6Groups(ip: string): Ipv6Groups | null {
+  const address = ip.split('%')[0] ?? ip // strip zone id, e.g. fe80::1%eth0
+  if (!address.includes(':')) return null
+
+  let head = address
+  let v4Octets: [number, number, number, number] | null = null
+
+  const lastColon = address.lastIndexOf(':')
+  const tail = address.slice(lastColon + 1)
+
+  if (tail.includes('.')) {
+    const octets = tail.split('.').map((o) => Number(o))
+    if (
+      octets.length !== 4 ||
+      octets.some((o) => !Number.isInteger(o) || o < 0 || o > 255)
+    ) {
+      return null
+    }
+    v4Octets = octets as [number, number, number, number]
+    head = address.slice(0, lastColon + 1)
+  }
+
+  const halves = head.split('::')
+  if (halves.length > 2) return null
+
+  const left = halves[0] ? halves[0].split(':').filter(Boolean) : []
+  const right =
+    halves.length === 2 && halves[1] ? halves[1].split(':').filter(Boolean) : []
+
+  let groupStrings: string[]
+
+  if (halves.length === 2) {
+    const v4GroupCount = v4Octets ? 2 : 0
+    const missing = 8 - left.length - right.length - v4GroupCount
+    if (missing < 0) return null
+    groupStrings = [...left, ...Array(missing).fill('0'), ...right]
+  } else {
+    // Full (non-"::"-compressed) form. `head` already excludes the trailing
+    // dotted-quad (sliced off above) and its trailing colon is dropped by
+    // `filter(Boolean)`, so this is every remaining hex group as-is.
+    groupStrings = head.split(':').filter(Boolean)
+  }
+
+  const groups = groupStrings.map((g) => parseInt(g, 16))
+
+  if (v4Octets) {
+    groups.push((v4Octets[0] << 8) | v4Octets[1])
+    groups.push((v4Octets[2] << 8) | v4Octets[3])
+  }
+
+  if (
+    groups.length !== 8 ||
+    groups.some((g) => !Number.isInteger(g) || g < 0 || g > 0xffff)
+  ) {
+    return null
+  }
+
+  return groups as unknown as Ipv6Groups
+}
+
+export function isPrivateOrReservedIpv6(
+  ip: string,
+  options: SafetyCheckOptions = {},
+): boolean {
+  const groups = expandIpv6Groups(ip)
+  if (!groups) return false
+
+  const allZero = groups.every((g) => g === 0)
+  if (allZero) return true // :: unspecified
+
+  const isLoopback = groups.slice(0, 7).every((g) => g === 0) && groups[7] === 1
+  if (isLoopback) return !options.allowLoopback // ::1
+
+  const [g0] = groups
+
+  if ((g0 & 0xffc0) === 0xfe80) return true // fe80::/10 link-local
+  if ((g0 & 0xff00) === 0xff00) return true // ff00::/8 multicast
+
+  // ::ffff:0:0/96 IPv4-mapped -- validate the embedded IPv4 address instead.
+  const isV4Mapped =
+    groups[0] === 0 &&
+    groups[1] === 0 &&
+    groups[2] === 0 &&
+    groups[3] === 0 &&
+    groups[4] === 0 &&
+    groups[5] === 0xffff
+
+  if (isV4Mapped) {
+    const embedded = [
+      (groups[6] >> 8) & 0xff,
+      groups[6] & 0xff,
+      (groups[7] >> 8) & 0xff,
+      groups[7] & 0xff,
+    ].join('.')
+
+    return isPrivateOrReservedIpv4(embedded, options)
+  }
+
+  return false
+}
+
+export function isBlockedIpLiteral(
+  ip: string,
+  options: SafetyCheckOptions = {},
+): boolean {
+  if (BLOCKED_METADATA_SINGLE_IPS.has(ip.toLowerCase())) return true
+
+  const family = net.isIP(ip)
+
+  if (family === 4) return isPrivateOrReservedIpv4(ip, options)
+  if (family === 6) return isPrivateOrReservedIpv6(ip, options)
+
+  return false
+}
+
+/** Pure, synchronous validation: scheme allowlist, blocked hostname
+ * literals, and (if the hostname is itself an IP literal) the blocked-range
+ * check. Does not touch the network -- a hostname that needs DNS resolution
+ * to know if it's safe passes this stage and must go through
+ * `resolveAndValidateHost` before being dialed. */
+export function validateUrlSyntax(
+  rawUrl: string,
+  options: SafetyCheckOptions = {},
+): UrlValidationResult {
+  let url: URL
+
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    return { ok: false, reason: `"${rawUrl}" is not a valid URL.` }
+  }
+
+  if (!ALLOWED_URL_SCHEMES.has(url.protocol)) {
+    return {
+      ok: false,
+      reason: `URL scheme "${url.protocol}" is not allowed (only http/https).`,
+    }
+  }
+
+  const hostname = url.hostname.replace(/^\[|\]$/g, '') // strip IPv6 brackets
+
+  if (!hostname) {
+    return { ok: false, reason: 'URL has no hostname.' }
+  }
+
+  if (isBlockedHostnameLiteral(hostname, options)) {
+    return {
+      ok: false,
+      reason: `Hostname "${hostname}" is not an allowed destination.`,
+    }
+  }
+
+  if (net.isIP(hostname) && isBlockedIpLiteral(hostname, options)) {
+    return {
+      ok: false,
+      reason: `"${hostname}" resolves to a blocked (metadata/link-local) address.`,
+    }
+  }
+
+  return { ok: true, url }
+}
+
+/** Resolves a non-literal-IP hostname and validates every returned address.
+ * Closes the "hostname under attacker DNS control resolves to a metadata IP"
+ * gap that `validateUrlSyntax` alone can't catch. Real DNS I/O -- not called
+ * from the DB-free contract test. */
+export async function resolveAndValidateHost(
+  hostname: string,
+  options: SafetyCheckOptions = {},
+): Promise<HostValidationResult> {
+  if (net.isIP(hostname)) {
+    return isBlockedIpLiteral(hostname, options)
+      ? {
+          ok: false,
+          reason: `"${hostname}" resolves to a blocked (metadata/link-local) address.`,
+        }
+      : { ok: true, addresses: [hostname] }
+  }
+
+  let records: dns.LookupAddress[]
+
+  try {
+    records = await dns.promises.lookup(hostname, { all: true, verbatim: true })
+  } catch (error) {
+    return {
+      ok: false,
+      reason: `Could not resolve hostname "${hostname}": ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    }
+  }
+
+  if (records.length === 0) {
+    return {
+      ok: false,
+      reason: `Hostname "${hostname}" did not resolve to any address.`,
+    }
+  }
+
+  const blocked = records.find((record) =>
+    isBlockedIpLiteral(record.address, options),
+  )
+
+  if (blocked) {
+    return {
+      ok: false,
+      reason: `Hostname "${hostname}" resolves to a blocked address (${blocked.address}).`,
+    }
+  }
+
+  return { ok: true, addresses: records.map((r) => r.address) }
+}
+
+/** Full validation of an outbound URL: syntax/scheme/hostname-literal
+ * checks, then (for a non-IP-literal hostname) DNS resolution against the
+ * same blocked ranges. This is the single function every fetch call site in
+ * the text-generation path should validate through before dialing. */
+export async function validateOutboundUrl(
+  rawUrl: string,
+  options: SafetyCheckOptions = {},
+): Promise<UrlValidationResult> {
+  const syntaxResult = validateUrlSyntax(rawUrl, options)
+  if (!syntaxResult.ok) return syntaxResult
+
+  const hostname = syntaxResult.url.hostname.replace(/^\[|\]$/g, '')
+
+  if (net.isIP(hostname)) {
+    return syntaxResult // already fully validated by validateUrlSyntax
+  }
+
+  const hostResult = await resolveAndValidateHost(hostname, options)
+
+  if (!hostResult.ok) {
+    return { ok: false, reason: hostResult.reason }
+  }
+
+  return syntaxResult
+}
+
+/** Resolves a `Location` header against the URL that produced it. Returns
+ * null if the header is missing or unparseable (caller treats that as a
+ * hard failure, not "no redirect"). */
+export function resolveRedirectLocation(
+  from: URL,
+  location: string | null,
+): URL | null {
+  if (!location) return null
+
+  try {
+    return new URL(location, from)
+  } catch {
+    return null
+  }
+}

--- a/server/utils/safeFetch.ts
+++ b/server/utils/safeFetch.ts
@@ -1,0 +1,151 @@
+// /server/utils/safeFetch.ts
+//
+// text-generation/t-005 -- outbound-request wrapper for every route that
+// dials a stored Server.baseUrl (or a cloud-provider endpoint derived from
+// one). Validates the destination (networkSafety.ts) before dialing and
+// again on every redirect hop -- plain `fetch` follows redirects
+// automatically with no re-validation, which would let an otherwise-allowed
+// destination hand back a 302 to a blocked one and bypass the check
+// entirely -- and enforces one connect-timeout budget across the whole call
+// (validation + every hop), not a fresh clock per hop, so a malicious/
+// misbehaving upstream can't multiply the attacker-controlled stall time by
+// chaining redirects that each take just under the timeout.
+//
+// Response-body size/idle-read enforcement is NOT this module's job: it
+// lives in textProviderService.ts (`sendMeteredStream` for streaming
+// responses, `readJsonWithSizeCap` for one-shot JSON), since those already
+// own the only two places a response body is actually consumed.
+import { createError } from 'h3'
+import {
+  DEFAULT_MAX_REDIRECTS,
+  DEFAULT_OUTBOUND_CONNECT_TIMEOUT_MS,
+  resolveRedirectLocation,
+  validateOutboundUrl,
+} from './networkSafety'
+
+export type SafeFetchOptions = {
+  connectTimeoutMs?: number
+  maxRedirects?: number
+  /** External abort signal (e.g. tied to the client disconnecting) merged
+   * with this call's own connect-timeout controller via `AbortSignal.any`. */
+  signal?: AbortSignal
+  /** Passed through to `validateOutboundUrl` on every hop -- see
+   * `networkSafety.ts`'s module doc for when this is safe to set (an
+   * operator-configured endpoint, not a DB-stored/user-settable one). */
+  allowLoopback?: boolean
+}
+
+/**
+ * Validates `rawUrl` (and every redirect hop it leads to) against
+ * `networkSafety.ts`'s blocked-destination rules, then performs the fetch
+ * with a connect timeout and a capped, re-validated manual redirect chain.
+ * Throws an h3 `createError` (400 for a rejected destination/scheme, 502 for
+ * an exhausted redirect budget or unusable Location header, 504 for a
+ * timeout) rather than returning a rejected Response, so every call site's
+ * existing try/catch → `getErrorStatusCode` handling picks it up unchanged.
+ */
+export async function safeFetch(
+  rawUrl: string,
+  init: RequestInit,
+  options: SafeFetchOptions = {},
+): Promise<Response> {
+  const connectTimeoutMs =
+    options.connectTimeoutMs ?? DEFAULT_OUTBOUND_CONNECT_TIMEOUT_MS
+  const maxRedirects = options.maxRedirects ?? DEFAULT_MAX_REDIRECTS
+  const safetyOptions = { allowLoopback: options.allowLoopback ?? false }
+
+  const validated = await validateOutboundUrl(rawUrl, safetyOptions)
+
+  if (!validated.ok) {
+    throw createError({
+      statusCode: 400,
+      message: `Blocked outbound request: ${validated.reason}`,
+    })
+  }
+
+  const timeoutController = new AbortController()
+  const timer = setTimeout(() => timeoutController.abort(), connectTimeoutMs)
+  const signal = options.signal
+    ? AbortSignal.any([timeoutController.signal, options.signal])
+    : timeoutController.signal
+
+  try {
+    let currentUrl = validated.url
+    let currentInit: RequestInit = { ...init, redirect: 'manual', signal }
+    let redirectsLeft = maxRedirects
+
+    for (;;) {
+      let response: Response
+
+      try {
+        response = await fetch(currentUrl, currentInit)
+      } catch (error) {
+        if (timeoutController.signal.aborted) {
+          throw createError({
+            statusCode: 504,
+            message: `Request to ${currentUrl.hostname} timed out after ${connectTimeoutMs}ms.`,
+          })
+        }
+
+        throw error
+      }
+
+      const isRedirect =
+        response.status >= 300 &&
+        response.status < 400 &&
+        response.headers.has('location')
+
+      if (!isRedirect) {
+        return response
+      }
+
+      if (redirectsLeft <= 0) {
+        throw createError({
+          statusCode: 502,
+          message: `Too many redirects (max ${maxRedirects}) while fetching ${rawUrl}.`,
+        })
+      }
+
+      const location = response.headers.get('location')
+      const nextUrl = resolveRedirectLocation(currentUrl, location)
+
+      if (!nextUrl) {
+        throw createError({
+          statusCode: 502,
+          message: `Redirect from ${currentUrl.href} carried an unusable Location header.`,
+        })
+      }
+
+      const nextValidated = await validateOutboundUrl(
+        nextUrl.href,
+        safetyOptions,
+      )
+
+      if (!nextValidated.ok) {
+        throw createError({
+          statusCode: 400,
+          message: `Blocked redirect destination: ${nextValidated.reason}`,
+        })
+      }
+
+      // 301/302/303 downgrade a non-GET/HEAD method to GET and drop the body
+      // (matches `fetch`'s own `redirect: 'follow'` semantics); 307/308
+      // preserve method and body as-is.
+      const downgradeToGet =
+        (response.status === 301 ||
+          response.status === 302 ||
+          response.status === 303) &&
+        currentInit.method != null &&
+        currentInit.method !== 'GET' &&
+        currentInit.method !== 'HEAD'
+
+      currentUrl = nextValidated.url
+      currentInit = downgradeToGet
+        ? { ...currentInit, method: 'GET', body: undefined }
+        : currentInit
+      redirectsLeft -= 1
+    }
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/server/utils/textProviderService.ts
+++ b/server/utils/textProviderService.ts
@@ -21,8 +21,13 @@
 // local per-route estimator, per the text-generation BRIEF.md's success
 // criteria ("exactly one cost-estimation code path is used for text
 // generation, not four").
+import { Buffer } from 'node:buffer'
 import { createError, setHeader, type H3Event } from 'h3'
 import type { Server } from '~/prisma/generated/prisma/client'
+import {
+  DEFAULT_IDLE_TIMEOUT_MS,
+  DEFAULT_MAX_RESPONSE_BYTES,
+} from './networkSafety'
 
 export type TextStreamManaResult = {
   balance: number
@@ -197,28 +202,95 @@ export function setStreamHeaders(event: H3Event, contentType: string): void {
   setHeader(event, 'X-Accel-Buffering', 'no')
 }
 
+export type SendMeteredStreamOptions = {
+  /** Total bytes relayed before the pump aborts the upstream stream and
+   * surfaces an `event: error` frame -- caps how much an upstream server
+   * (private/self-hosted, so not necessarily well-behaved) can make this
+   * process buffer/relay for one request. */
+  maxBytes?: number
+  /** Aborts the pump if no chunk arrives from upstream within this window --
+   * an upstream that accepts the connection but never sends (or stalls
+   * mid-stream) would otherwise hold the response open indefinitely. */
+  idleTimeoutMs?: number
+  /** Aborted when the pump gives up for any reason (idle timeout, size cap,
+   * client disconnect) so the upstream connection this controller's signal
+   * was given to (see `safeFetch`'s `signal` option) actually tears down
+   * instead of continuing to run/bill on the provider side unread. */
+  abortController?: AbortController
+}
+
+async function readChunkWithTimeout(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  idleTimeoutMs: number,
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  let timer: ReturnType<typeof setTimeout>
+
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () =>
+        reject(
+          new Error(`Upstream response idle for over ${idleTimeoutMs}ms.`),
+        ),
+      idleTimeoutMs,
+    )
+  })
+
+  try {
+    return await Promise.race([reader.read(), timeout])
+  } finally {
+    clearTimeout(timer!)
+  }
+}
+
 /**
  * Relays the upstream byte stream to the client as-is, then appends the
  * synthetic `event: mana` trailer frame (or `event: error` if the pump or
  * `onComplete` -- the mana-gate commit -- throws). Identical across all three
  * routes today except for the console.error log label, which callers pass in
  * as `logLabel` so the failure is still attributable to its route.
+ *
+ * Enforces a response-size cap and a per-chunk idle timeout (text-generation
+ * /t-005), and tears down the upstream request if the client disconnects
+ * mid-stream (`event.node.req`'s `close` event) rather than continuing to
+ * relay/bill for a response nobody is reading.
  */
 export function sendMeteredStream(
   event: H3Event,
   body: ReadableStream<Uint8Array>,
   logLabel: string,
   onComplete: () => Promise<TextStreamManaResult>,
+  options: SendMeteredStreamOptions = {},
 ): Promise<never> {
   const reader = body.getReader()
   const res = event.node.res
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_RESPONSE_BYTES
+  const idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS
+  let bytesReceived = 0
+
+  const onClientDisconnect = () => {
+    options.abortController?.abort()
+    reader.cancel().catch(() => {})
+  }
+
+  event.node.req.on('close', onClientDisconnect)
 
   const pump = async () => {
     try {
       while (true) {
-        const { done, value } = await reader.read()
+        const { done, value } = await readChunkWithTimeout(
+          reader,
+          idleTimeoutMs,
+        )
 
         if (done) break
+
+        bytesReceived += value.byteLength
+
+        if (bytesReceived > maxBytes) {
+          throw new Error(
+            `Upstream ${logLabel} response exceeded ${maxBytes} bytes; aborted.`,
+          )
+        }
 
         res.write(value)
       }
@@ -232,6 +304,8 @@ export function sendMeteredStream(
       )
     } catch (err) {
       console.error(`[${logLabel} stream pump] error:`, err)
+      options.abortController?.abort()
+      reader.cancel().catch(() => {})
 
       res.write(
         `event: error\ndata: ${JSON.stringify({
@@ -240,6 +314,7 @@ export function sendMeteredStream(
         })}\n\n`,
       )
     } finally {
+      event.node.req.off('close', onClientDisconnect)
       res.end()
     }
   }
@@ -247,6 +322,48 @@ export function sendMeteredStream(
   pump()
 
   return new Promise(() => {})
+}
+
+/**
+ * Reads a one-shot (non-streaming) upstream JSON response with the same
+ * response-size cap `sendMeteredStream` enforces for streaming responses --
+ * `response.json()` alone has no size limit and would happily buffer an
+ * unbounded body before parsing.
+ */
+export async function readJsonWithSizeCap(
+  response: Response,
+  maxBytes: number = DEFAULT_MAX_RESPONSE_BYTES,
+): Promise<unknown> {
+  if (!response.body) {
+    return response.json()
+  }
+
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let total = 0
+
+  while (true) {
+    const { done, value } = await reader.read()
+
+    if (done) break
+
+    total += value.byteLength
+
+    if (total > maxBytes) {
+      await reader.cancel().catch(() => {})
+
+      throw createError({
+        statusCode: 502,
+        message: `Upstream response exceeded ${maxBytes} bytes.`,
+      })
+    }
+
+    chunks.push(value)
+  }
+
+  const combined = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)))
+
+  return JSON.parse(combined.toString('utf-8'))
 }
 
 export function getErrorStatusCode(error: unknown): number {

--- a/utils/scripts/verifyNetworkSafety.ts
+++ b/utils/scripts/verifyNetworkSafety.ts
@@ -1,0 +1,287 @@
+// /utils/scripts/verifyNetworkSafety.ts
+//
+// Regression guard for text-generation/t-005: the outbound-URL safety
+// checks (server/utils/networkSafety.ts) that block cloud-metadata/
+// link-local (and, unless explicitly allowed, loopback) destinations before
+// a stored Server.baseUrl -- or any endpoint derived from one -- is dialed.
+// Entirely DB-free and covers only the pure/synchronous surface
+// (`isPrivateOrReservedIpv4`, `isPrivateOrReservedIpv6`, `isBlockedIpLiteral`,
+// `isBlockedHostnameLiteral`, `validateUrlSyntax`, `resolveRedirectLocation`)
+// -- `resolveAndValidateHost`/`validateOutboundUrl`'s DNS-resolution branch
+// does real network I/O and is deliberately not exercised here, matching
+// this repo's DB-free/no-network contract-test convention.
+import assert from 'node:assert/strict'
+import {
+  isBlockedHostnameLiteral,
+  isBlockedIpLiteral,
+  isPrivateOrReservedIpv4,
+  isPrivateOrReservedIpv6,
+  resolveRedirectLocation,
+  validateUrlSyntax,
+} from '../../server/utils/networkSafety'
+
+let failures = 0
+
+function check(label: string, fn: () => void): void {
+  try {
+    fn()
+    console.log(`ok - ${label}`)
+  } catch (error) {
+    failures += 1
+    console.error(`FAIL - ${label}`)
+    console.error(error instanceof Error ? error.message : error)
+  }
+}
+
+// -- isPrivateOrReservedIpv4 --------------------------------------------------
+
+check('blocks 169.254.169.254 (AWS/GCP/Azure/DO/Oracle cloud metadata)', () => {
+  assert.equal(isPrivateOrReservedIpv4('169.254.169.254'), true)
+})
+
+check('blocks the whole 169.254.0.0/16 link-local range', () => {
+  assert.equal(isPrivateOrReservedIpv4('169.254.1.1'), true)
+  assert.equal(isPrivateOrReservedIpv4('169.254.255.255'), true)
+})
+
+check('blocks 0.0.0.0/8', () => {
+  assert.equal(isPrivateOrReservedIpv4('0.0.0.0'), true)
+  assert.equal(isPrivateOrReservedIpv4('0.1.2.3'), true)
+})
+
+check('blocks loopback 127.0.0.0/8 by default', () => {
+  assert.equal(isPrivateOrReservedIpv4('127.0.0.1'), true)
+  assert.equal(isPrivateOrReservedIpv4('127.1.2.3'), true)
+})
+
+check(
+  'allows loopback when allowLoopback is set (operator-configured endpoints only)',
+  () => {
+    assert.equal(
+      isPrivateOrReservedIpv4('127.0.0.1', { allowLoopback: true }),
+      false,
+    )
+  },
+)
+
+check('never allows metadata/link-local through allowLoopback', () => {
+  assert.equal(
+    isPrivateOrReservedIpv4('169.254.169.254', { allowLoopback: true }),
+    true,
+  )
+})
+
+check(
+  'does NOT block RFC1918 private ranges (home-LAN self-hosted servers)',
+  () => {
+    assert.equal(isPrivateOrReservedIpv4('10.0.0.5'), false)
+    assert.equal(isPrivateOrReservedIpv4('172.16.0.1'), false)
+    assert.equal(isPrivateOrReservedIpv4('172.31.255.254'), false)
+    assert.equal(isPrivateOrReservedIpv4('192.168.1.50'), false)
+  },
+)
+
+check(
+  'does NOT block 100.64.0.0/10 (Tailscale CGNAT range -- ServerAccessMode.TAILSCALE)',
+  () => {
+    assert.equal(isPrivateOrReservedIpv4('100.64.0.1'), false)
+    assert.equal(isPrivateOrReservedIpv4('100.100.100.1'), false)
+    assert.equal(isPrivateOrReservedIpv4('100.127.255.254'), false)
+  },
+)
+
+check(
+  'blocks the single-IP Alibaba Cloud metadata address even though it is in the CGNAT range',
+  () => {
+    assert.equal(isBlockedIpLiteral('100.100.100.200'), true)
+  },
+)
+
+check('does NOT block real public addresses', () => {
+  assert.equal(isPrivateOrReservedIpv4('8.8.8.8'), false)
+  assert.equal(isPrivateOrReservedIpv4('1.1.1.1'), false)
+})
+
+check(
+  'rejects malformed IPv4-shaped strings instead of misclassifying them',
+  () => {
+    assert.equal(isPrivateOrReservedIpv4('999.1.1.1'), false)
+    assert.equal(isPrivateOrReservedIpv4('1.2.3'), false)
+  },
+)
+
+// -- isPrivateOrReservedIpv6 --------------------------------------------------
+
+check('blocks ::1 loopback by default, allows it with allowLoopback', () => {
+  assert.equal(isPrivateOrReservedIpv6('::1'), true)
+  assert.equal(isPrivateOrReservedIpv6('::1', { allowLoopback: true }), false)
+})
+
+check('blocks :: unspecified regardless of allowLoopback', () => {
+  assert.equal(isPrivateOrReservedIpv6('::'), true)
+  assert.equal(isPrivateOrReservedIpv6('::', { allowLoopback: true }), true)
+})
+
+check('blocks fe80::/10 link-local', () => {
+  assert.equal(isPrivateOrReservedIpv6('fe80::1'), true)
+  assert.equal(isPrivateOrReservedIpv6('fe80::abcd:1234:5678:9abc'), true)
+})
+
+check('blocks ff00::/8 multicast', () => {
+  assert.equal(isPrivateOrReservedIpv6('ff02::1'), true)
+})
+
+check('blocks AWS IPv6 metadata address fd00:ec2::254', () => {
+  assert.equal(isBlockedIpLiteral('fd00:ec2::254'), true)
+})
+
+check(
+  'resolves IPv4-mapped IPv6 addresses and validates the embedded IPv4',
+  () => {
+    assert.equal(isPrivateOrReservedIpv6('::ffff:127.0.0.1'), true)
+    assert.equal(isPrivateOrReservedIpv6('::ffff:169.254.169.254'), true)
+    assert.equal(isPrivateOrReservedIpv6('::ffff:8.8.8.8'), false)
+  },
+)
+
+check('does NOT block Tailscale ULA addresses (fd7a:115c:a1e0::/48)', () => {
+  assert.equal(isPrivateOrReservedIpv6('fd7a:115c:a1e0::1'), false)
+})
+
+check('does NOT block ordinary public IPv6 addresses', () => {
+  assert.equal(isPrivateOrReservedIpv6('2606:4700:4700::1111'), false)
+})
+
+check('rejects non-IPv6 strings without throwing', () => {
+  assert.equal(isPrivateOrReservedIpv6('not-an-ip'), false)
+})
+
+// -- isBlockedHostnameLiteral --------------------------------------------------
+
+check(
+  'blocks "localhost" and "*.localhost" by default, allows with allowLoopback',
+  () => {
+    assert.equal(isBlockedHostnameLiteral('localhost'), true)
+    assert.equal(isBlockedHostnameLiteral('foo.localhost'), true)
+    assert.equal(
+      isBlockedHostnameLiteral('localhost', { allowLoopback: true }),
+      false,
+    )
+  },
+)
+
+check(
+  'blocks known cloud-metadata hostnames regardless of allowLoopback',
+  () => {
+    assert.equal(isBlockedHostnameLiteral('metadata.google.internal'), true)
+    assert.equal(
+      isBlockedHostnameLiteral('metadata.google.internal', {
+        allowLoopback: true,
+      }),
+      true,
+    )
+    assert.equal(isBlockedHostnameLiteral('metadata'), true)
+  },
+)
+
+check('does NOT block an ordinary or Tailscale MagicDNS hostname', () => {
+  assert.equal(isBlockedHostnameLiteral('myollama.tailnet-name.ts.net'), false)
+  assert.equal(isBlockedHostnameLiteral('ollama.home.arpa'), false)
+})
+
+// -- validateUrlSyntax --------------------------------------------------------
+
+check('rejects non-http/https schemes', () => {
+  const result = validateUrlSyntax('ftp://example.com/')
+  assert.equal(result.ok, false)
+})
+
+check('rejects file: scheme (classic SSRF-via-scheme-confusion vector)', () => {
+  const result = validateUrlSyntax('file:///etc/passwd')
+  assert.equal(result.ok, false)
+})
+
+check('rejects an unparseable URL', () => {
+  const result = validateUrlSyntax('not a url')
+  assert.equal(result.ok, false)
+})
+
+check('rejects a literal cloud-metadata IP target', () => {
+  const result = validateUrlSyntax('http://169.254.169.254/latest/meta-data/')
+  assert.equal(result.ok, false)
+})
+
+check('rejects a bracketed IPv6 loopback target by default', () => {
+  const result = validateUrlSyntax('http://[::1]:8080/')
+  assert.equal(result.ok, false)
+})
+
+check('accepts a home-LAN http target', () => {
+  const result = validateUrlSyntax('http://192.168.1.50:11434/api/chat')
+  assert.equal(result.ok, true)
+})
+
+check('accepts a Tailscale CGNAT http target', () => {
+  const result = validateUrlSyntax('http://100.101.102.103:11434/api/chat')
+  assert.equal(result.ok, true)
+})
+
+check('accepts the well-known cloud API https targets', () => {
+  assert.equal(
+    validateUrlSyntax('https://api.openai.com/v1/chat/completions').ok,
+    true,
+  )
+  assert.equal(
+    validateUrlSyntax('https://api.anthropic.com/v1/messages').ok,
+    true,
+  )
+})
+
+check('accepts a loopback target only when allowLoopback is set', () => {
+  assert.equal(validateUrlSyntax('http://localhost:11434/api/chat').ok, false)
+  assert.equal(
+    validateUrlSyntax('http://localhost:11434/api/chat', {
+      allowLoopback: true,
+    }).ok,
+    true,
+  )
+  assert.equal(validateUrlSyntax('http://127.0.0.1:11434/api/chat').ok, false)
+  assert.equal(
+    validateUrlSyntax('http://127.0.0.1:11434/api/chat', {
+      allowLoopback: true,
+    }).ok,
+    true,
+  )
+})
+
+// -- resolveRedirectLocation ---------------------------------------------------
+
+check('resolves a relative Location against the originating URL', () => {
+  const from = new URL('http://192.168.1.50:11434/api/chat')
+  const next = resolveRedirectLocation(from, '/v2/api/chat')
+  assert.ok(next)
+  assert.equal(next?.href, 'http://192.168.1.50:11434/v2/api/chat')
+})
+
+check('resolves an absolute Location as-is', () => {
+  const from = new URL('http://192.168.1.50:11434/api/chat')
+  const next = resolveRedirectLocation(
+    from,
+    'http://169.254.169.254/latest/meta-data/',
+  )
+  assert.ok(next)
+  assert.equal(next?.hostname, '169.254.169.254')
+})
+
+check('returns null for a missing or unusable Location header', () => {
+  const from = new URL('http://192.168.1.50:11434/api/chat')
+  assert.equal(resolveRedirectLocation(from, null), null)
+  assert.equal(resolveRedirectLocation(from, ''), null)
+})
+
+if (failures > 0) {
+  console.error(`\n${failures} failure(s).`)
+  process.exitCode = 1
+} else {
+  console.log('\nAll network-safety self-tests passed.')
+}


### PR DESCRIPTION
## What

Every route that dials a stored `Server.baseUrl` (or a cloud-provider endpoint derived from one) previously trusted it as-is: no scheme allowlist, no block on cloud-metadata/link-local destinations, automatic redirect-following with no re-validation, no connect/idle timeout, no response-size cap, and no cancellation when the client disconnects mid-stream. A `Server` row can be created by **any authenticated user** (`POST /api/server` only requires `requireAuthUser`, not an owner/admin check), so this was attacker-reachable input, not just admin-configured input.

This closes conductor `text-generation/t-005` — a `gate_human: true` security-boundary task.

## Changes

- **`server/utils/networkSafety.ts` (new)** — pure destination-validation helpers: scheme allowlist (http/https only), blocked hostname literals and IPv4/IPv6 ranges (cloud metadata, link-local, unspecified; loopback gated behind an explicit `allowLoopback` flag), plus async DNS-resolution validation so a hostname under attacker DNS control can't rebind to a blocked address.
  - Deliberately does **not** block RFC1918/Tailscale-CGNAT ranges — this app's own self-hosted-server story (`ServerAccessMode.TAILSCALE`) makes home-LAN/Tailscale targets a first-class intended destination, not something to harden away.
- **`server/utils/safeFetch.ts` (new)** — validates the destination before dialing and again on every redirect hop (`redirect: 'manual'` + a manually re-validated, capped chain, with correct 301/302/303 method-downgrade semantics), one connect-timeout budget spanning the whole call (not a fresh clock per hop).
- **`server/utils/textProviderService.ts`** — `sendMeteredStream` now enforces a response-size cap and a per-chunk idle timeout, and tears down the upstream request when the client disconnects (`event.node.req` `'close'`). Added `readJsonWithSizeCap` for the one-shot (non-streaming) path, which previously had no bound on `response.json()`.
- Wired into `generate/text.post.ts` and the three legacy chat routes (`chats/{openai,anthropic,ollama}/stream.post.ts`): `fetch` → `safeFetch`, `upstream.json()` → `readJsonWithSizeCap`, an `AbortController` tied to client disconnect threaded through both.
- `ollama/stream.post.ts`'s env-configured fallback endpoint (`config.ollamaBaseUrl`, defaulting to `http://localhost:11434` in `nuxt.config.ts` — the documented zero-config self-hosted default, not user input) is the **only** call site passing `allowLoopback: true`; every DB-resolved `Server.baseUrl` stays fully blocked on loopback.
- **`utils/scripts/verifyNetworkSafety.ts`** + `package.json` + `contract-tests.yml` — 35 DB-free assertions covering the blocked/allowed ranges (including the Tailscale-CGNAT and home-LAN negative cases), scheme rejection, loopback gating, and redirect-location resolution.

## Verification

- `vue-tsc --noEmit` clean repo-wide
- `eslint`/`prettier --check` clean
- New contract test: 35/35 passing
- Sibling contract tests re-run to confirm no regression: `text-provider-service`, `text-generation-dispatch`, `server-capability-routing`, `server-uptime-default-scope`
- `git status --porcelain` shows exactly the 10 intended files

No live private-server integration test was possible in this sandbox (no real Ollama/OpenAI-compatible endpoint reachable) — covered by the DB-free unit suite instead.

## Flags for reviewer

This is a **security boundary change**. Per the roadmap task's own gate (`gate_human: true`, `stakes: reversible`), the conductor task stays at `status: needs-human` regardless of this PR's CI outcome — it needs Silas's explicit review before the roadmap task itself is marked done, even though the code change is ordinary reversible software.


---
_Generated by [Claude Code](https://claude.ai/code/session_019VoaV6rw31SkfB6noWmRZG)_