### PR TITLE
fix(academy): restore media delivery for previews and remix starters

### DIFF
--- a/server/routes/images/[...path].get.ts
+++ b/server/routes/images/[...path].get.ts
@@ -23,6 +23,51 @@ const CONTENT_TYPES: Record<string, string> = {
   '.webp': 'image/webp',
 }
 
+const DEFAULT_MEDIA_ORIGIN = 'https://media.acrocatranch.com'
+const REMOTE_FALLBACK_PREFIXES = ['academy/', 'dashboard-tabs/academy/']
+const REMOTE_FALLBACK_TIMEOUT_MS = 15_000
+
+function remoteFallbackUrl(relativePath: string): string | null {
+  if (!REMOTE_FALLBACK_PREFIXES.some((prefix) => relativePath.startsWith(prefix))) {
+    return null
+  }
+
+  const mediaOrigin = (
+    process.env.MEDIA_ORIGIN?.trim() || DEFAULT_MEDIA_ORIGIN
+  ).replace(/\/+$/, '')
+  const encodedPath = relativePath
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/')
+
+  return `${mediaOrigin}/images/${encodedPath}`
+}
+
+async function fetchRemoteFallback(relativePath: string): Promise<Response | null> {
+  const url = remoteFallbackUrl(relativePath)
+  if (!url) return null
+
+  try {
+    const response = await fetch(url, {
+      redirect: 'follow',
+      signal: AbortSignal.timeout(REMOTE_FALLBACK_TIMEOUT_MS),
+    })
+    if (!response.ok) return null
+
+    const headers = new Headers(response.headers)
+    headers.set('Cache-Control', 'public, max-age=3600')
+    headers.set('X-Content-Type-Options', 'nosniff')
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    })
+  } catch {
+    return null
+  }
+}
+
 export default defineEventHandler(async (event) => {
   const rawPath = getRouterParam(event, 'path') || ''
 
@@ -50,6 +95,9 @@ export default defineEventHandler(async (event) => {
   try {
     fileStat = await stat(filePath)
   } catch {
+    const fallbackResponse = await fetchRemoteFallback(relativePath)
+    if (fallbackResponse) return fallbackResponse
+
     throw createError({ statusCode: 404, statusMessage: 'Image not found' })
   }
 


### PR DESCRIPTION
## What broke

The Academy front end stores style previews, example works, and starter images as same-origin `/images/academy/...` URLs. After the self-hosted image-storage cutover, `server/routes/images/[...path].get.ts` serves only `IMAGES_PATH` (or repo `public/images` when unset). The Academy media itself is still maintained and verified on the canonical media origin (`https://media.acrocatranch.com` by default), so a self-host whose persistent image root was not seeded with those historical Academy assets returns 404s.

That makes two roadmap promises look missing at once: the Timeline/Styles UI loses its artwork, and Remix Studio's Starter source cannot fetch its manifest/images even though the remix UI and CTA wiring are present.

## Fix

- Keep local persistent image storage first, unchanged.
- On a local miss, fall back to the established `MEDIA_ORIGIN` only for Academy-owned media namespaces:
  - `academy/**`
  - `dashboard-tabs/academy/**`
- Proxy the remote bytes through the existing same-origin `/images/...` route instead of redirecting the browser. This matters because Remix Studio fetches starter images into blobs; a redirect would introduce a cross-origin CORS dependency.
- Preserve cache and nosniff response headers.
- Leave every non-Academy `/images/**` miss as the existing 404.

## Why this is the seam, not a duplicate feature

`/academy` mounts `academy-manager`; its canonical dashboard already exposes Timeline, Styles, Remix Studio, and Style Lab. Lesson/style CTAs already select a style and navigate to Remix, and `academy-remix` already embeds `art-styler` with Upload, Gallery, and Starters. The missing media bridge was making completed pieces present as an incomplete product.

## Verification requested from CI / deployment

- TypeScript / Nuxt checks
- Contract verifiers
- Deployment/build checks
- After deployment: `/academy` should render style/example images, Remix Studio → Starters should load the manifest and thumbnails, and selecting a starter should produce a usable source image.

## Roadmap reconciliation

The current Academy roadmap's implementation tasks are greener than the live product acceptance. The follow-up bookkeeping should explicitly treat current-production media reachability and the lesson → remix flow as ship-milestone acceptance, not merely seed/manifest existence.