### PR TITLE
fix(storybook): stop double-resuming art jobs on Resume of the active story (storybook/t-010)

### DIFF
--- a/.github/workflows/storybook-active-story-resume-contract.yml
+++ b/.github/workflows/storybook-active-story-resume-contract.yml
@@ -1,0 +1,34 @@
+name: Storybook Active Story Resume Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: storybook-active-story-resume-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Storybook active story resume contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Verify Storybook active story resume guard
+        run: npx tsx utils/scripts/verifyStorybookActiveStoryResumeGuard.ts

--- a/stores/helpers/storybookLibraryHelper.ts
+++ b/stores/helpers/storybookLibraryHelper.ts
@@ -189,6 +189,23 @@ export function createStorybookLibraryController(bridge: StorybookLibraryBridge)
     const current = bridge.getSession()
     const found = current?.id === sessionId ? current : findStory(sessionId)
     if (!found) return false
+    // Already the active session -- stop here rather than re-cloning and
+    // calling resumeNarrativeArtJobs() again. storybook-library-page.vue's
+    // onMounted() and its route.query.story watcher both already guard their
+    // own calls into this function with an `=== storyStore.session?.id`
+    // check for exactly this reason, but this function is the one place
+    // every caller funnels through -- including the "Resume"/"Open" button
+    // on the CURRENT story's own card in the Recent Stories panel, which is
+    // visible and clickable while that story is actively playing (upsert()
+    // archives the live session into the library on every mutation). That
+    // click had no such guard and reached this same fall-through: a second
+    // resumeNarrativeArtJobs() call for a beat whose art enqueue is still in
+    // the narrow status:'queueing'/no-jobId window (the real gap between the
+    // optimistic status write and the resolved POST) independently finds no
+    // existing job and independently submits one, billing two illustrations
+    // for a single beat. Guarding here protects every caller at once instead
+    // of relying on each new one to remember to check first.
+    if (current?.id === sessionId) return true
     bridge.setSession(cloneSession(found))
     bridge.resumeNarrativeArtJobs()
     return true

--- a/utils/scripts/verifyStorybookActiveStoryResumeGuard.ts
+++ b/utils/scripts/verifyStorybookActiveStoryResumeGuard.ts
@@ -1,0 +1,148 @@
+// /utils/scripts/verifyStorybookActiveStoryResumeGuard.ts
+//
+// Regression guard (storybook/t-010, front-end polish). storybook-library-page.vue
+// shows the CURRENT story's own card in the "Recent stories" panel while it is
+// actively playing -- storybookLibraryHelper.ts's `upsert()` archives the live
+// session into the library on every mutation via its deep watcher, so the
+// active story is always present (usually first, being the most recently
+// updated). Its card renders the same "Resume"/"Open" button every other
+// story's card does, wired straight to `storyStore.openStory(story.id)`.
+//
+// openStory() in storybookLibraryHelper.ts used to fall through unconditionally
+// once it found a matching session -- cloning it fresh via `bridge.setSession()`
+// and calling `bridge.resumeNarrativeArtJobs()` again, even when the requested
+// id was already the live, active session. That is exactly the redundant-resume
+// bug verifyStorybookLibraryMountReopenGuard.mjs already fixed for two other
+// entry points into this same function (storybook-library-page.vue's
+// onMounted() and its route.query.story watcher, both of which guard their own
+// call with `=== storyStore.session?.id` before ever calling openStory()) --
+// but that fix lived at the CALL SITES, not inside openStory() itself, so the
+// "Resume" button on the current story's own card -- a third, independent
+// caller with no such guard -- still reached the unprotected fall-through.
+//
+// For a beat whose art enqueue is still mid-flight (status 'queueing', no
+// jobId yet -- the real window between the optimistic local status write and
+// the resolved POST), two independent resumeNarrativeArtJobs() calls each
+// find no existing job via recoverOrSubmit() and each submit one, billing two
+// illustrations for a single beat.
+//
+// This exercises openStory() directly against a fake bridge (no Nuxt/Pinia
+// runtime needed -- storybookLibraryHelper.ts's only non-type dependency is
+// Vue's core reactivity) and asserts that requesting the id already loaded as
+// the live session is a no-op: no re-clone, no second resume.
+import assert from 'node:assert/strict'
+import { createStorybookLibraryController } from '../../stores/helpers/storybookLibraryHelper'
+import type { StorybookSession } from '../../stores/storybookStore'
+
+function emptyStateDelta() {
+  return {
+    consequences: [],
+    relationshipShifts: [],
+    inventoryAdd: [],
+    inventoryRemove: [],
+  }
+}
+
+function activeSession(id: string): StorybookSession {
+  return {
+    id,
+    userId: 1,
+    bible: {
+      title: 'The Clockwork Orchard',
+      premise: 'A premise.',
+      narratorStyle: 'cinematic',
+      structure: 'chaptered',
+      cast: [],
+      facets: [],
+      rewards: [],
+      createdAt: '2026-08-17T00:00:00.000Z',
+    },
+    beats: [
+      {
+        id: 'beat-1',
+        sessionId: id,
+        narrative: 'The orchard hums at midnight.',
+        question: 'What do you touch first?',
+        stateDelta: emptyStateDelta(),
+        createdAt: '2026-08-17T00:00:00.000Z',
+      },
+    ],
+    branchHistory: [],
+    consequences: [],
+    inventory: [],
+    stateVersion: 1,
+    status: 'active',
+    createdAt: '2026-08-17T00:00:00.000Z',
+    updatedAt: '2026-08-17T00:00:00.000Z',
+  }
+}
+
+let current: StorybookSession | null = activeSession('story-active')
+let setSessionCalls = 0
+let resumeCalls = 0
+
+const bridge = {
+  getSession: () => current,
+  setSession: (next: StorybookSession) => {
+    setSessionCalls += 1
+    current = next
+  },
+  isWeaving: () => false,
+  resumeNarrativeArtJobs: () => {
+    resumeCalls += 1
+  },
+  beginStory: async () => false,
+  authenticatedUserId: () => 1,
+}
+
+const { openStory } = createStorybookLibraryController(bridge)
+
+// Simulates clicking "Resume" on the current story's own card in the Recent
+// Stories panel while it is the live, active session.
+const result = openStory('story-active')
+
+assert.equal(
+  result,
+  true,
+  'openStory() should still report success when the requested id is already ' +
+    'the active session, even though it now does nothing further.',
+)
+assert.equal(
+  setSessionCalls,
+  0,
+  'openStory() re-cloned and re-set the already-active session -- clicking ' +
+    '"Resume" on the current story\'s own card must be a no-op, not a fresh ' +
+    'setSession() call.',
+)
+assert.equal(
+  resumeCalls,
+  0,
+  'openStory() called resumeNarrativeArtJobs() a second time for the ' +
+    'already-active session -- for a beat whose art enqueue is still ' +
+    "mid-flight (status 'queueing', no jobId yet), this independently " +
+    'submits a second illustration job for the same beat, billing twice.',
+)
+
+// A genuinely different id must still open normally (found via the live
+// session only when ids match; anything else needs the library, which this
+// guard does not populate, so a mismatched id here is expected to no-op
+// rather than throw).
+setSessionCalls = 0
+resumeCalls = 0
+const missResult = openStory('story-does-not-exist')
+assert.equal(
+  missResult,
+  false,
+  'openStory() must still fail for an id that is neither the active session ' +
+    'nor in the library.',
+)
+assert.equal(setSessionCalls, 0)
+assert.equal(resumeCalls, 0)
+
+console.log(
+  'Storybook active-story resume guard contract passed: openStory() no-ops ' +
+    'when the requested id is already the live active session, so the ' +
+    '"Resume" button on the current story\'s own Recent Stories card can no ' +
+    'longer double-invoke resumeNarrativeArtJobs() and double-bill an ' +
+    "in-flight beat's illustration.",
+)


### PR DESCRIPTION
## Bug

`storyStore.openStory()` (implemented in `stores/helpers/storybookLibraryHelper.ts`) always re-cloned the found session into the store and called `resumeNarrativeArtJobs()` again, even when the requested session id was already the live, active session.

Two of the three real callers already guard against exactly this case, but at the *call site* rather than inside `openStory()` itself:

- `components/pages/storybook-library-page.vue`'s `onMounted()` — guarded by `directId !== storyStore.session?.id` (fixed in an earlier t-010 cycle, see `verifyStorybookLibraryMountReopenGuard.mjs`)
- its `route.query.story` watcher — guarded by `value === storyStore.session?.id`

The third caller has no such guard: the **"Resume"/"Open" button on the current story's own card** in the "Recent stories" panel (`components/pages/storybook-library-page.vue` template, wired to the page's local `openStory(sessionId)` → `storyStore.openStory(sessionId)`). That card is visible and clickable *while the story is actively playing*, because `upsert()` in the same helper archives the live session into the library on every mutation via a deep watcher — so the in-progress story is always present in the "Recent stories" list, usually first (most recently updated). Clicking "Resume" on it falls straight through `openStory()`'s unconditional `bridge.setSession(cloneSession(found)); bridge.resumeNarrativeArtJobs()`.

**Mechanism / repro:** for a beat whose art enqueue is still mid-flight (`status: 'queueing'`, no `jobId` yet — the real window between the optimistic local status write and the resolved `POST /api/art/queue`), a second `resumeNarrativeArtJobs()` call independently routes through `recoverOrSubmit()`, finds no existing job (since the first submit hasn't landed yet), and independently submits a new one — billing **two illustrations for a single beat**.

Proved with a throwaway behavioral script driving `createStorybookLibraryController()` against a fake bridge (no Nuxt/Pinia needed — the helper's only runtime dependency is Vue core reactivity): calling `openStory(currentSessionId)` on a session already returned by `bridge.getSession()` produced `setSessionCalls: 1, resumeCalls: 1` pre-fix, `0, 0` post-fix.

## Fix

`openStory()` in `stores/helpers/storybookLibraryHelper.ts` now returns early (`return true`, no-op) when the requested id already matches the live session's id — *before* re-cloning or resuming anything. This is the single choke point every caller funnels through, so it protects mount, the query watcher, and the "Resume" button (and any future caller) at once, rather than relying on each new call site to remember the same check.

## New guard

`utils/scripts/verifyStorybookActiveStoryResumeGuard.ts` — drives `openStory()` directly against a fake bridge and asserts that requesting the id already loaded as the active session triggers zero `setSession()`/`resumeNarrativeArtJobs()` calls (and that a genuinely unknown id still correctly no-ops as `false`). Wired into `.github/workflows/storybook-active-story-resume-contract.yml` (`npm ci --ignore-scripts` + `npx tsx utils/scripts/verifyStorybookActiveStoryResumeGuard.ts`), matching the sibling `narrative-art-milestone-contract.yml` convention for a `.ts` guard that needs the real Vue runtime.

## Verification

- New guard: fails on pre-fix code via `git stash` round-trip, passes post-fix — confirmed.
- All 12 pre-existing `verifyStorybook*` guards: pass, no regression.
- `npx vue-tsc --noEmit`: clean.
- `npx eslint` on touched files: clean.
- `npx prettier --check` on the two new files: clean. (`stores/helpers/storybookLibraryHelper.ts` has pre-existing formatting drift predating this change — confirmed via `git stash` that `prettier --check` already fails on it at `main`'s tip — left untouched to keep this diff minimal and scoped to the bug fix.)
- `git status --porcelain`: only the three intended files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DJsgrFD3zGJGS1FKJJVM7x)_