### PR TITLE
feat(academy): rebuild the Academy around gallery-first exploration

### DIFF
--- a/components/academy/academy-remix.vue
+++ b/components/academy/academy-remix.vue
@@ -42,6 +42,7 @@
           :show-close="false"
           :show-remix-button="false"
           :allow-mark-viewed="false"
+          compact
         />
 
         <div

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -234,8 +234,8 @@
               class="group grid min-h-32 grid-cols-[72px_minmax(0,1fr)] overflow-hidden rounded-2xl border border-base-300 bg-base-200/35"
             >
               <div class="flex items-center justify-center border-r border-base-300 bg-base-200">
-                <div class="flex h-12 w-12 items-center justify-center rounded-full bg-base-100 shadow-inner">
-                  <Icon name="kind-icon:user" class="h-6 w-6 text-base-content/30" aria-hidden="true" />
+                <div class="flex h-12 w-12 items-center justify-center rounded-full bg-base-100 text-xl font-black text-base-content/30 shadow-inner" aria-hidden="true">
+                  {{ artist.name.slice(0, 1) }}
                 </div>
               </div>
               <div class="flex min-w-0 flex-col justify-center p-3">
@@ -249,10 +249,6 @@
               </div>
             </div>
           </div>
-
-          <p class="mt-4 rounded-2xl border border-dashed border-base-300 px-3 py-2 text-xs leading-relaxed text-base-content/50">
-            Artist portrait slots are now part of this visual section; the next asset pass can replace the neutral portrait frames with verified public-domain portraits without redesigning the lesson again.
-          </p>
         </section>
       </div>
 

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -153,9 +153,7 @@
         </p>
       </div>
 
-      <div
-        class="grid auto-rows-[170px] gap-3 sm:grid-cols-2 sm:auto-rows-[220px] lg:grid-cols-3"
-      >
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,15rem),1fr))] auto-rows-[220px] gap-3">
         <a
           v-for="(work, index) in lesson.exampleWorks"
           :key="work.imageSrc"
@@ -163,7 +161,7 @@
           target="_blank"
           rel="noopener noreferrer"
           class="group relative overflow-hidden rounded-2xl border border-base-300 bg-base-200 shadow-sm"
-          :class="index === 0 && lesson.exampleWorks.length > 1 ? 'sm:row-span-2 lg:col-span-2' : ''"
+          :class="index === 0 && lesson.exampleWorks.length > 1 ? 'row-span-2' : ''"
           :title="`${work.workTitle} — public-domain source page`"
         >
           <img
@@ -190,7 +188,7 @@
 
     <div
       v-if="!compact"
-      class="grid gap-5 xl:grid-cols-[minmax(0,1.15fr)_minmax(360px,0.85fr)] xl:items-start"
+      class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,24rem),1fr))] items-start gap-5"
     >
       <div class="flex min-w-0 flex-col gap-5">
         <section class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm sm:p-6">
@@ -370,10 +368,6 @@ const isViewed = computed(() => {
   return academyStore.viewedLessons.includes(props.lesson.slug)
 })
 
-// Per-style failure-mode text (ai-art-academy/t-025, backfilled from
-// conductor's docs/teaching-notes.md §3). Falls back to the original
-// mode-level generic note for any style not yet backfilled (e.g. a
-// newly-added movement whose teaching notes haven't landed here yet).
 const tryItFailureLabel = computed(() => 'Watch for:')
 
 const tryItFailureFallbackNote = computed(() => {

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -1,27 +1,94 @@
 <!-- /components/academy/academy-style-detail.vue -->
 <template>
-  <article class="flex flex-col gap-4 kr-panel-flat p-4">
-    <header class="flex flex-wrap items-start justify-between gap-2">
-      <div class="flex min-w-0 flex-col gap-1">
+  <article class="mx-auto flex w-full max-w-[1500px] flex-col gap-5">
+    <section
+      v-if="lesson.previewImageSrc"
+      class="relative min-h-[320px] overflow-hidden rounded-3xl border border-base-300 bg-base-300 shadow-xl sm:min-h-[400px] lg:min-h-[480px]"
+    >
+      <img
+        :src="lesson.previewImageSrc"
+        :alt="`${lesson.name} visual style study`"
+        class="absolute inset-0 h-full w-full object-cover"
+      />
+      <div class="absolute inset-0 bg-linear-to-t from-black/90 via-black/25 to-black/10" />
+
+      <button
+        v-if="showClose"
+        type="button"
+        class="btn btn-circle btn-sm absolute right-4 top-4 z-10 border-white/30 bg-black/35 text-white backdrop-blur hover:bg-black/55"
+        title="Close lesson"
+        aria-label="Close lesson"
+        @click="emit('close')"
+      >
+        <Icon name="mdi:close" class="h-4 w-4" />
+      </button>
+
+      <div class="absolute inset-x-0 bottom-0 flex flex-col gap-4 p-5 text-white sm:p-7 lg:p-9">
         <div class="flex flex-wrap items-center gap-2">
-          <span class="text-2xl leading-none" aria-hidden="true">🏛️</span>
-          <h3 class="text-lg font-black text-base-content">
-            {{ lesson.name }}
-          </h3>
-          <span class="badge badge-primary badge-sm font-bold">
+          <span class="badge border-0 bg-primary text-primary-content font-bold">
             {{ lesson.era }}
           </span>
+          <span class="badge border-white/25 bg-black/30 text-white backdrop-blur">
+            {{ lesson.region }}
+          </span>
+          <span
+            v-if="isViewed"
+            class="badge border-0 bg-success text-success-content font-bold"
+          >
+            <Icon name="kind-icon:check" class="mr-1 h-3.5 w-3.5" />
+            Explored
+          </span>
+        </div>
+
+        <div class="max-w-4xl">
+          <p class="mb-2 text-xs font-black uppercase tracking-[0.18em] text-white/65">
+            Enter the movement
+          </p>
+          <h3 class="text-3xl font-black leading-none drop-shadow sm:text-4xl lg:text-5xl">
+            {{ lesson.name }}
+          </h3>
+          <p class="mt-3 line-clamp-3 max-w-3xl text-sm leading-relaxed text-white/85 sm:text-base">
+            {{ lesson.keyIdeas }}
+          </p>
+        </div>
+
+        <div v-if="showRemixButton" class="flex flex-wrap gap-2">
+          <button
+            type="button"
+            class="btn btn-primary rounded-2xl border-0 font-black shadow-lg shadow-black/30"
+            @click="emit('remix', lesson.slug)"
+          >
+            <Icon name="kind-icon:magic" class="h-5 w-5" />
+            Remix in {{ lesson.name }}
+          </button>
+          <a
+            v-if="lesson.exampleWorks?.[0]"
+            :href="lesson.exampleWorks[0].sourceUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="btn rounded-2xl border-white/30 bg-black/35 text-white backdrop-blur hover:bg-black/55"
+          >
+            <Icon name="kind-icon:gallery" class="h-4 w-4" />
+            View a real work
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <header
+      v-else
+      class="flex flex-wrap items-start justify-between gap-3 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
+    >
+      <div class="flex min-w-0 flex-col gap-2">
+        <div class="flex flex-wrap items-center gap-2">
+          <h3 class="text-2xl font-black text-base-content">{{ lesson.name }}</h3>
+          <span class="badge badge-primary badge-sm font-bold">{{ lesson.era }}</span>
           <span class="badge badge-ghost badge-sm">{{ lesson.region }}</span>
         </div>
-        <p
-          v-if="isViewed"
-          class="flex items-center gap-1 text-xs font-semibold text-success"
-        >
-          <Icon name="kind-icon:check" class="h-3.5 w-3.5" />
-          Lesson explored
+        <p class="max-w-3xl text-sm leading-relaxed text-base-content/75">
+          {{ lesson.keyIdeas }}
         </p>
       </div>
-
       <button
         v-if="showClose"
         type="button"
@@ -34,158 +101,196 @@
       </button>
     </header>
 
-    <p class="text-sm leading-relaxed text-base-content/80">
-      {{ lesson.keyIdeas }}
-    </p>
-
-    <div class="rounded-xl border border-base-300 bg-base-200/60 p-3">
-      <p
-        class="mb-2 flex items-center gap-1.5 text-xs font-black uppercase tracking-wide text-base-content/60"
-      >
-        <Icon name="kind-icon:search" class="h-3.5 w-3.5" />
-        How to spot it
-      </p>
-      <ul class="flex flex-col gap-1.5">
-        <li
-          v-for="cue in lesson.recognitionCues"
-          :key="cue"
-          class="flex items-start gap-2 text-sm text-base-content/80"
-        >
-          <span class="mt-1 h-1.5 w-1.5 shrink-0 rounded-full bg-primary" />
-          {{ cue }}
-        </li>
-      </ul>
-    </div>
-
-    <div class="flex flex-col gap-2">
-      <p
-        class="flex items-center gap-1.5 text-xs font-black uppercase tracking-wide text-base-content/60"
-      >
-        <Icon name="kind-icon:user" class="h-3.5 w-3.5" />
-        Meet the masters
-      </p>
-      <div class="grid gap-2 sm:grid-cols-2">
-        <div
-          v-for="artist in lesson.artists"
-          :key="artist.name"
-          class="rounded-xl border border-base-300 bg-base-200/40 px-3 py-2"
-        >
-          <p class="text-sm font-bold text-base-content">
-            {{ artist.name }}
-            <span class="ml-1 text-xs font-normal text-base-content/50">
-              {{ artist.years }}
-            </span>
+    <section
+      v-if="lesson.exampleWorks?.length"
+      class="rounded-3xl border border-base-300 bg-base-100 p-4 shadow-sm sm:p-5"
+    >
+      <div class="mb-4 flex flex-wrap items-end justify-between gap-2">
+        <div>
+          <p class="flex items-center gap-1.5 text-xs font-black uppercase tracking-[0.16em] text-primary">
+            <Icon name="kind-icon:gallery" class="h-4 w-4" />
+            Gallery wall
           </p>
-          <p class="text-xs leading-relaxed text-base-content/70">
-            {{ artist.note }}
-          </p>
+          <h4 class="mt-1 text-xl font-black text-base-content">Look before you read</h4>
         </div>
+        <p class="max-w-xl text-xs leading-relaxed text-base-content/55">
+          These are real historical works with provenance links. Open any image to visit its source collection.
+        </p>
       </div>
-    </div>
 
-    <div v-if="lesson.exampleWorks?.length" class="flex flex-col gap-2">
-      <p
-        class="flex items-center gap-1.5 text-xs font-black uppercase tracking-wide text-base-content/60"
+      <div
+        class="grid auto-rows-[170px] gap-3 sm:grid-cols-2 sm:auto-rows-[220px] lg:grid-cols-3"
       >
-        <Icon name="kind-icon:gallery" class="h-3.5 w-3.5" />
-        Example works
-      </p>
-      <div class="grid gap-2 sm:grid-cols-2">
         <a
-          v-for="work in lesson.exampleWorks"
+          v-for="(work, index) in lesson.exampleWorks"
           :key="work.imageSrc"
           :href="work.sourceUrl"
           target="_blank"
           rel="noopener noreferrer"
-          class="group relative overflow-hidden rounded-xl border border-base-300 bg-base-200/40"
+          class="group relative overflow-hidden rounded-2xl border border-base-300 bg-base-200 shadow-sm"
+          :class="index === 0 && lesson.exampleWorks.length > 1 ? 'sm:row-span-2 lg:col-span-2' : ''"
           :title="`${work.workTitle} — public-domain source page`"
         >
           <img
             :src="work.imageSrc"
             :alt="`${work.workTitle} by ${work.artist}`"
             loading="lazy"
-            class="aspect-[4/3] w-full object-cover transition-transform duration-300 group-hover:scale-105"
+            class="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
           />
-          <div
-            class="absolute inset-x-0 bottom-0 bg-linear-to-t from-base-300/90 to-transparent px-2 pb-1.5 pt-6"
-          >
-            <p class="truncate text-xs font-bold text-base-content">
+          <div class="absolute inset-0 bg-linear-to-t from-black/85 via-black/5 to-transparent" />
+          <div class="absolute inset-x-0 bottom-0 p-3 text-white sm:p-4">
+            <p class="text-sm font-black leading-tight drop-shadow sm:text-base">
               {{ work.workTitle }}
             </p>
-            <p class="truncate text-[0.65rem] text-base-content/70">
-              {{ work.artist }} · {{ work.year }} · {{ work.collection }}
+            <p class="mt-1 text-xs text-white/75">
+              {{ work.artist }} · {{ work.year }}
+            </p>
+            <p class="mt-0.5 truncate text-[0.65rem] text-white/55">
+              {{ work.collection }}
             </p>
           </div>
         </a>
       </div>
-    </div>
+    </section>
 
-    <div class="rounded-xl border border-base-300 bg-base-200/60 p-3">
-      <p
-        class="mb-2 flex items-center gap-1.5 text-xs font-black uppercase tracking-wide text-base-content/60"
-      >
-        <Icon name="kind-icon:flask" class="h-3.5 w-3.5" />
-        Try it
-      </p>
-      <p class="mb-2 text-sm leading-relaxed text-base-content/80">
-        {{ lesson.remix.template }}
-      </p>
-      <p class="mb-1 text-xs font-bold text-base-content/70">What to expect</p>
-      <p class="mb-2 text-xs leading-relaxed text-base-content/60">
-        The remix should keep hold of the cues above — especially
-        {{ lesson.recognitionCues[0]?.toLowerCase() }}. If it just looks like a
-        generic old painting, the style didn't fully take.
-      </p>
-      <p class="mb-1 text-xs font-bold text-base-content/70">
-        {{ tryItFailureLabel }}
-      </p>
-      <p class="mb-2 text-xs leading-relaxed text-base-content/60">
-        {{ tryItFailureNote }}
-      </p>
-      <p
-        class="flex items-start gap-1.5 text-xs leading-relaxed text-base-content/60"
-      >
-        <Icon
-          name="kind-icon:refresh"
-          class="mt-0.5 h-3.5 w-3.5 shrink-0 text-base-content/40"
-        />
-        Not quite right? Try a different starter image, tweak the instruction
-        above, or adjust the style strength — then remix again.
-      </p>
-    </div>
+    <div class="grid gap-5 xl:grid-cols-[minmax(0,1.15fr)_minmax(360px,0.85fr)] xl:items-start">
+      <div class="flex min-w-0 flex-col gap-5">
+        <section class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm sm:p-6">
+          <p class="flex items-center gap-1.5 text-xs font-black uppercase tracking-[0.16em] text-primary">
+            <Icon name="kind-icon:search" class="h-4 w-4" />
+            How to spot it
+          </p>
+          <h4 class="mt-2 text-xl font-black text-base-content">Train your eye</h4>
+          <div class="mt-4 grid gap-3 sm:grid-cols-2">
+            <div
+              v-for="(cue, index) in lesson.recognitionCues"
+              :key="cue"
+              class="flex items-start gap-3 rounded-2xl border border-base-300 bg-base-200/45 p-3"
+            >
+              <span
+                class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-black text-primary"
+              >
+                {{ index + 1 }}
+              </span>
+              <p class="text-sm leading-relaxed text-base-content/78">{{ cue }}</p>
+            </div>
+          </div>
+        </section>
 
-    <div class="rounded-xl border border-base-300 bg-base-200/60 p-3">
-      <p
-        class="mb-2 flex items-center gap-1.5 text-xs font-black uppercase tracking-wide text-base-content/60"
-      >
-        <Icon name="kind-icon:chat" class="h-3.5 w-3.5" />
-        Reflect
-      </p>
-      <ul class="flex flex-col gap-1.5">
-        <li
-          v-for="prompt in reflectPrompts"
-          :key="prompt"
-          class="flex items-start gap-2 text-sm text-base-content/80"
-        >
-          <Icon
-            name="kind-icon:question"
-            class="mt-0.5 h-3.5 w-3.5 shrink-0 text-base-content/40"
-          />
-          {{ prompt }}
-        </li>
-      </ul>
-    </div>
+        <section class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm sm:p-6">
+          <div class="flex flex-wrap items-end justify-between gap-2">
+            <div>
+              <p class="flex items-center gap-1.5 text-xs font-black uppercase tracking-[0.16em] text-secondary">
+                <Icon name="kind-icon:user" class="h-4 w-4" />
+                Meet the masters
+              </p>
+              <h4 class="mt-2 text-xl font-black text-base-content">People behind the movement</h4>
+            </div>
+            <span class="text-xs text-base-content/45">
+              {{ lesson.artists.length }} featured {{ lesson.artists.length === 1 ? 'artist' : 'artists' }}
+            </span>
+          </div>
 
-    <footer v-if="showRemixButton" class="flex flex-wrap items-center gap-2">
-      <button
-        type="button"
-        class="btn btn-primary flex-1 rounded-2xl font-black shadow-lg shadow-primary/20 hover:-translate-y-0.5 hover:shadow-primary/30 active:translate-y-0"
-        @click="emit('remix', lesson.slug)"
-      >
-        <Icon name="kind-icon:magic" class="h-5 w-5" />
-        Remix an image in {{ lesson.name }}
-      </button>
-    </footer>
+          <div class="mt-4 grid gap-3 sm:grid-cols-2">
+            <div
+              v-for="artist in lesson.artists"
+              :key="artist.name"
+              class="group grid min-h-32 grid-cols-[72px_minmax(0,1fr)] overflow-hidden rounded-2xl border border-base-300 bg-base-200/35"
+            >
+              <div class="flex items-center justify-center border-r border-base-300 bg-base-200">
+                <div class="flex h-12 w-12 items-center justify-center rounded-full bg-base-100 shadow-inner">
+                  <Icon name="kind-icon:user" class="h-6 w-6 text-base-content/30" aria-hidden="true" />
+                </div>
+              </div>
+              <div class="flex min-w-0 flex-col justify-center p-3">
+                <p class="text-base font-black leading-tight text-base-content">
+                  {{ artist.name }}
+                </p>
+                <p class="mt-0.5 text-xs font-semibold text-primary/80">{{ artist.years }}</p>
+                <p class="mt-2 line-clamp-3 text-xs leading-relaxed text-base-content/65">
+                  {{ artist.note }}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <p class="mt-4 rounded-2xl border border-dashed border-base-300 px-3 py-2 text-xs leading-relaxed text-base-content/50">
+            Artist portrait slots are now part of this visual section; the next asset pass can replace the neutral portrait frames with verified public-domain portraits without redesigning the lesson again.
+          </p>
+        </section>
+      </div>
+
+      <aside class="flex min-w-0 flex-col gap-5 xl:sticky xl:top-3">
+        <section class="overflow-hidden rounded-3xl border border-primary/25 bg-primary/5 shadow-sm">
+          <div class="border-b border-primary/15 bg-primary/10 p-5">
+            <p class="flex items-center gap-1.5 text-xs font-black uppercase tracking-[0.16em] text-primary">
+              <Icon name="kind-icon:flask" class="h-4 w-4" />
+              Try it
+            </p>
+            <h4 class="mt-2 text-2xl font-black leading-tight text-base-content">
+              Turn the lesson into an image
+            </h4>
+          </div>
+
+          <div class="flex flex-col gap-4 p-5">
+            <div>
+              <p class="text-xs font-black uppercase tracking-wide text-base-content/45">Remix instruction</p>
+              <p class="mt-1 text-sm leading-relaxed text-base-content/80">
+                {{ lesson.remix.template }}
+              </p>
+            </div>
+
+            <div class="rounded-2xl bg-base-100/70 p-3">
+              <p class="text-xs font-bold text-base-content/70">What to expect</p>
+              <p class="mt-1 text-xs leading-relaxed text-base-content/60">
+                The remix should keep hold of the cues above, especially
+                {{ lesson.recognitionCues[0]?.toLowerCase() }}. If it just looks like a generic old painting, the style did not fully take.
+              </p>
+            </div>
+
+            <div class="rounded-2xl bg-base-100/70 p-3">
+              <p class="text-xs font-bold text-base-content/70">{{ tryItFailureLabel }}</p>
+              <p class="mt-1 text-xs leading-relaxed text-base-content/60">
+                {{ tryItFailureNote }}
+              </p>
+            </div>
+
+            <p class="flex items-start gap-2 text-xs leading-relaxed text-base-content/55">
+              <Icon name="kind-icon:refresh" class="mt-0.5 h-4 w-4 shrink-0" />
+              Not quite right? Try a different source image, tweak the instruction, or adjust the style strength and remix again.
+            </p>
+
+            <button
+              v-if="showRemixButton"
+              type="button"
+              class="btn btn-primary w-full rounded-2xl font-black shadow-lg shadow-primary/20"
+              @click="emit('remix', lesson.slug)"
+            >
+              <Icon name="kind-icon:magic" class="h-5 w-5" />
+              Open Remix Studio
+            </button>
+          </div>
+        </section>
+
+        <section class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm">
+          <p class="flex items-center gap-1.5 text-xs font-black uppercase tracking-[0.16em] text-base-content/45">
+            <Icon name="kind-icon:chat" class="h-4 w-4" />
+            Reflect
+          </p>
+          <h4 class="mt-2 text-lg font-black text-base-content">Look again after you remix</h4>
+          <ul class="mt-3 flex flex-col gap-2">
+            <li
+              v-for="prompt in reflectPrompts"
+              :key="prompt"
+              class="flex items-start gap-2 rounded-xl bg-base-200/45 p-3 text-sm leading-relaxed text-base-content/75"
+            >
+              <Icon name="kind-icon:question" class="mt-0.5 h-4 w-4 shrink-0 text-primary/60" />
+              {{ prompt }}
+            </li>
+          </ul>
+        </section>
+      </aside>
+    </div>
   </article>
 </template>
 

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -1,8 +1,43 @@
 <!-- /components/academy/academy-style-detail.vue -->
 <template>
-  <article class="mx-auto flex w-full max-w-[1500px] flex-col gap-5">
+  <article
+    class="mx-auto flex w-full flex-col gap-5"
+    :class="compact ? 'max-w-none' : 'max-w-[1500px]'"
+  >
     <section
-      v-if="lesson.previewImageSrc"
+      v-if="compact"
+      class="overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-sm"
+    >
+      <div v-if="lesson.previewImageSrc" class="relative aspect-[16/9] overflow-hidden bg-base-200">
+        <img
+          :src="lesson.previewImageSrc"
+          :alt="`${lesson.name} visual style study`"
+          class="h-full w-full object-cover"
+        />
+        <div class="absolute inset-0 bg-linear-to-t from-black/80 via-transparent to-transparent" />
+        <div class="absolute inset-x-0 bottom-0 p-4 text-white">
+          <p class="text-lg font-black leading-tight">{{ lesson.name }}</p>
+          <p class="mt-1 text-xs text-white/70">{{ lesson.era }} · {{ lesson.region }}</p>
+        </div>
+      </div>
+      <div class="flex flex-col gap-3 p-4">
+        <p class="line-clamp-4 text-sm leading-relaxed text-base-content/70">
+          {{ lesson.keyIdeas }}
+        </p>
+        <div class="flex flex-wrap gap-1.5">
+          <span
+            v-for="cue in lesson.recognitionCues.slice(0, 3)"
+            :key="cue"
+            class="badge badge-ghost h-auto max-w-full whitespace-normal py-1 text-left text-[0.65rem] leading-snug"
+          >
+            {{ cue }}
+          </span>
+        </div>
+      </div>
+    </section>
+
+    <section
+      v-else-if="lesson.previewImageSrc"
       class="relative min-h-[320px] overflow-hidden rounded-3xl border border-base-300 bg-base-300 shadow-xl sm:min-h-[400px] lg:min-h-[480px]"
     >
       <img
@@ -102,7 +137,7 @@
     </header>
 
     <section
-      v-if="lesson.exampleWorks?.length"
+      v-if="!compact && lesson.exampleWorks?.length"
       class="rounded-3xl border border-base-300 bg-base-100 p-4 shadow-sm sm:p-5"
     >
       <div class="mb-4 flex flex-wrap items-end justify-between gap-2">
@@ -153,7 +188,10 @@
       </div>
     </section>
 
-    <div class="grid gap-5 xl:grid-cols-[minmax(0,1.15fr)_minmax(360px,0.85fr)] xl:items-start">
+    <div
+      v-if="!compact"
+      class="grid gap-5 xl:grid-cols-[minmax(0,1.15fr)_minmax(360px,0.85fr)] xl:items-start"
+    >
       <div class="flex min-w-0 flex-col gap-5">
         <section class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm sm:p-6">
           <p class="flex items-center gap-1.5 text-xs font-black uppercase tracking-[0.16em] text-primary">
@@ -297,14 +335,10 @@
 <script setup lang="ts">
 // Reused in three contexts, each passing a different showClose/showRemixButton
 // subset — check all three before changing a prop's default or meaning:
-//   - academy-timeline.vue: default props (close+remix shown), expanded list item
+//   - academy-timeline.vue: default props (close+remix shown), expanded gallery item
 //   - academy-styles-browser.vue: default props (close+remix shown), grid detail panel
-//   - academy-remix.vue: showClose=false, showRemixButton=false, allowMarkViewed=false
-//     — read-only style summary in the Remix Studio sidebar, where remixing is
-//     already the page's primary action (a stray showRemixButton no-op button
-//     here was PR #301's bug); allowMarkViewed=false stops incidental style
-//     preview clicks from inflating the Timeline/Gallery "explored" progress,
-//     which is meant to reflect deliberate lesson-reading, not style browsing
+//   - academy-remix.vue: compact=true, showClose=false, showRemixButton=false,
+//     allowMarkViewed=false — image-led read-only style summary beside Remix Studio
 import { computed, onMounted } from 'vue'
 import { useAcademyStore } from '@/stores/academyStore'
 import type { AcademyStyle } from '@/stores/seeds/academyStyles'
@@ -315,11 +349,13 @@ const props = withDefaults(
     showClose?: boolean
     showRemixButton?: boolean
     allowMarkViewed?: boolean
+    compact?: boolean
   }>(),
   {
     showClose: true,
     showRemixButton: true,
     allowMarkViewed: true,
+    compact: false,
   },
 )
 

--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -9,9 +9,7 @@
           <Icon name="kind-icon:palette" class="h-4 w-4" aria-hidden="true" />
           Browse the collection
         </p>
-        <h2 class="mt-2 text-2xl font-black text-base-content sm:text-3xl">
-          Style Gallery
-        </h2>
+        <h2 class="mt-2 text-2xl font-black text-base-content sm:text-3xl">Style Gallery</h2>
         <p class="mt-1 text-sm leading-relaxed text-base-content/65">
           Start with the image. Open whatever catches your eye, learn how to recognize it, then remix your own source in that visual language.
         </p>
@@ -19,11 +17,7 @@
 
       <div class="flex w-full flex-col gap-2 lg:w-auto lg:items-end">
         <div class="flex flex-wrap items-center gap-2">
-          <div
-            class="join"
-            role="group"
-            aria-label="Filter Academy lessons by progress"
-          >
+          <div class="join" role="group" aria-label="Filter Academy lessons by progress">
             <button
               v-for="option in lessonFilterOptions"
               :key="option.value"
@@ -39,14 +33,8 @@
           </div>
 
           <div class="flex min-w-0 flex-1 items-center gap-2 lg:flex-none">
-            <label
-              class="input input-bordered input-sm flex min-w-0 flex-1 items-center gap-1.5 bg-base-100 lg:w-72"
-            >
-              <Icon
-                name="kind-icon:search"
-                class="h-3.5 w-3.5 shrink-0 text-base-content/40"
-                aria-hidden="true"
-              />
+            <label class="input input-bordered input-sm flex min-w-0 flex-1 items-center gap-1.5 bg-base-100 lg:w-72">
+              <Icon name="kind-icon:search" class="h-3.5 w-3.5 shrink-0 text-base-content/40" aria-hidden="true" />
               <input
                 ref="searchInputRef"
                 v-model="searchQuery"
@@ -75,10 +63,8 @@
       </div>
     </header>
 
-    <div
-      class="grid gap-3 rounded-3xl border border-base-300 bg-base-100 p-4 shadow-sm sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center sm:p-5"
-    >
-      <div class="min-w-0">
+    <div class="flex flex-wrap items-center gap-3 rounded-3xl border border-base-300 bg-base-100 p-4 shadow-sm sm:p-5">
+      <div class="min-w-[min(100%,20rem)] flex-1">
         <div class="flex items-center justify-between gap-3">
           <div>
             <p class="text-sm font-black text-base-content">{{ progressHeadline }}</p>
@@ -117,24 +103,16 @@
       />
     </div>
 
-    <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
+    <div class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,13rem),1fr))] gap-3">
       <button
         v-for="style in filteredStyles"
         :key="style.slug"
         :ref="(el) => setGridRef(style.slug, el)"
         type="button"
         class="group relative aspect-[4/5] min-w-0 overflow-hidden rounded-3xl border-2 bg-base-200 text-left shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-        :class="
-          expandedSlug === style.slug
-            ? 'border-primary shadow-lg shadow-primary/20'
-            : 'border-base-300 hover:border-primary/55'
-        "
+        :class="expandedSlug === style.slug ? 'border-primary shadow-lg shadow-primary/20' : 'border-base-300 hover:border-primary/55'"
         :aria-expanded="expandedSlug === style.slug"
-        :aria-controls="
-          expandedSlug === style.slug
-            ? `academy-style-detail-${style.slug}`
-            : undefined
-        "
+        :aria-controls="expandedSlug === style.slug ? `academy-style-detail-${style.slug}` : undefined"
         @click="expandedSlug = expandedSlug === style.slug ? null : style.slug"
       >
         <img
@@ -169,19 +147,13 @@
           <p class="text-base font-black leading-tight text-white drop-shadow sm:text-lg">
             {{ style.name }}
           </p>
-          <p class="mt-1 truncate text-[0.68rem] font-semibold text-white/65">
-            {{ style.region }}
-          </p>
+          <p class="mt-1 truncate text-[0.68rem] font-semibold text-white/65">{{ style.region }}</p>
           <p class="mt-2 line-clamp-2 text-xs leading-relaxed text-white/78">
             {{ style.recognitionCues[0] }}
           </p>
           <div class="mt-3 flex items-center gap-1 text-[0.68rem] font-black uppercase tracking-wide text-white/90">
             Open lesson
-            <Icon
-              name="kind-icon:arrow-right"
-              class="h-3.5 w-3.5 transition-transform group-hover:translate-x-1"
-              aria-hidden="true"
-            />
+            <Icon name="kind-icon:arrow-right" class="h-3.5 w-3.5 transition-transform group-hover:translate-x-1" aria-hidden="true" />
           </div>
         </div>
       </button>
@@ -191,11 +163,7 @@
       v-if="!filteredStyles.length"
       class="flex min-h-40 flex-col items-center justify-center rounded-3xl border border-base-300 bg-base-100 px-4 text-center shadow-sm"
     >
-      <Icon
-        :name="emptyStateIcon"
-        class="h-8 w-8 text-base-content/20"
-        aria-hidden="true"
-      />
+      <Icon :name="emptyStateIcon" class="h-8 w-8 text-base-content/20" aria-hidden="true" />
       <p class="mt-2 text-sm text-base-content/45">{{ emptyStateMessage }}</p>
       <button
         v-if="searchQuery || lessonFilter !== 'all'"
@@ -313,11 +281,7 @@ const expandedStyle = computed<AcademyStyle | null>(() => {
 })
 
 const nextLesson = computed<AcademyStyle | null>(() => {
-  return (
-    academyStore.timeline.find(
-      (style) => !academyStore.viewedLessons.includes(style.slug),
-    ) ?? null
-  )
+  return academyStore.timeline.find((style) => !academyStore.viewedLessons.includes(style.slug)) ?? null
 })
 
 const progressPercent = computed(() => {
@@ -334,12 +298,8 @@ const progressHeadline = computed(() => {
 })
 
 const progressMessage = computed(() => {
-  if (!academyStore.timeline.length) {
-    return 'The Academy is gathering its lesson collection.'
-  }
-  if (!nextLesson.value) {
-    return 'You explored every lesson. Revisit any movement whenever inspiration gets suspiciously quiet.'
-  }
+  if (!academyStore.timeline.length) return 'The Academy is gathering its lesson collection.'
+  if (!nextLesson.value) return 'You explored every lesson. Revisit any movement whenever inspiration gets suspiciously quiet.'
   return `Up next: ${nextLesson.value.name} · ${nextLesson.value.era}`
 })
 
@@ -390,11 +350,9 @@ const emptyStateMessage = computed(() => {
   if (lessonFilter.value === 'new' && !searchQuery.value) {
     return 'You explored every lesson. Art history officially fears you now.'
   }
-
   if (lessonFilter.value === 'explored' && !searchQuery.value) {
     return 'No explored lessons yet. Open one and your progress will appear here.'
   }
-
   return `No styles match “${searchQuery.value}”. Try a broader search or reset the filters.`
 })
 </script>

--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -118,7 +118,7 @@
         <img
           v-if="style.previewImageSrc"
           :src="style.previewImageSrc"
-          :alt="`${style.name} style preview`"
+          alt=""
           loading="lazy"
           class="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
         />

--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -1,112 +1,99 @@
 <!-- /components/academy/academy-styles-browser.vue -->
 <template>
-  <section class="flex flex-col gap-4">
+  <section class="mx-auto flex w-full max-w-[1600px] flex-col gap-4">
     <header
-      class="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-base-300 bg-base-200 p-4"
+      class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-4 shadow-sm sm:p-5 lg:flex-row lg:items-end lg:justify-between"
     >
-      <div class="flex min-w-0 flex-col gap-1">
-        <h2
-          class="flex items-center gap-2 text-base font-black text-base-content"
-        >
-          <Icon
-            name="kind-icon:palette"
-            class="h-5 w-5 text-primary"
-            aria-hidden="true"
-          />
+      <div class="min-w-0 max-w-2xl">
+        <p class="flex items-center gap-1.5 text-xs font-black uppercase tracking-[0.16em] text-primary">
+          <Icon name="kind-icon:palette" class="h-4 w-4" aria-hidden="true" />
+          Browse the collection
+        </p>
+        <h2 class="mt-2 text-2xl font-black text-base-content sm:text-3xl">
           Style Gallery
         </h2>
-        <p class="text-sm text-base-content/70">
-          Every style the Academy teaches. Open a lesson, learn to spot it, then
-          remix your own image in it.
+        <p class="mt-1 text-sm leading-relaxed text-base-content/65">
+          Start with the image. Open whatever catches your eye, learn how to recognize it, then remix your own source in that visual language.
         </p>
       </div>
 
-      <div class="flex w-full flex-col gap-2 sm:w-auto sm:items-end">
-        <div
-          class="join"
-          role="group"
-          aria-label="Filter Academy lessons by progress"
-        >
-          <button
-            v-for="option in lessonFilterOptions"
-            :key="option.value"
-            type="button"
-            class="btn btn-sm join-item"
-            :class="lessonFilter === option.value ? 'btn-primary' : 'btn-ghost'"
-            :aria-pressed="lessonFilter === option.value"
-            @click="lessonFilter = option.value"
+      <div class="flex w-full flex-col gap-2 lg:w-auto lg:items-end">
+        <div class="flex flex-wrap items-center gap-2">
+          <div
+            class="join"
+            role="group"
+            aria-label="Filter Academy lessons by progress"
           >
-            <Icon :name="option.icon" class="h-3.5 w-3.5" aria-hidden="true" />
-            {{ option.label }}
-          </button>
+            <button
+              v-for="option in lessonFilterOptions"
+              :key="option.value"
+              type="button"
+              class="btn btn-sm join-item"
+              :class="lessonFilter === option.value ? 'btn-primary' : 'btn-ghost'"
+              :aria-pressed="lessonFilter === option.value"
+              @click="lessonFilter = option.value"
+            >
+              <Icon :name="option.icon" class="h-3.5 w-3.5" aria-hidden="true" />
+              {{ option.label }}
+            </button>
+          </div>
+
+          <div class="flex min-w-0 flex-1 items-center gap-2 lg:flex-none">
+            <label
+              class="input input-bordered input-sm flex min-w-0 flex-1 items-center gap-1.5 bg-base-100 lg:w-72"
+            >
+              <Icon
+                name="kind-icon:search"
+                class="h-3.5 w-3.5 shrink-0 text-base-content/40"
+                aria-hidden="true"
+              />
+              <input
+                ref="searchInputRef"
+                v-model="searchQuery"
+                type="search"
+                class="min-w-0 flex-1 bg-transparent"
+                placeholder="Search styles, artists, eras…"
+                aria-label="Search Academy styles"
+              />
+            </label>
+            <button
+              v-if="searchQuery"
+              type="button"
+              class="btn btn-circle btn-ghost btn-sm shrink-0"
+              aria-label="Clear style search"
+              title="Clear search"
+              @click="clearSearch"
+            >
+              <Icon name="mdi:close" class="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
         </div>
 
-        <div class="flex w-full items-center gap-2 sm:w-auto">
-          <label
-            class="input input-bordered input-sm flex min-w-0 flex-1 items-center gap-1.5 bg-base-100 sm:w-64"
-          >
-            <Icon
-              name="kind-icon:search"
-              class="h-3.5 w-3.5 shrink-0 text-base-content/40"
-              aria-hidden="true"
-            />
-            <input
-              ref="searchInputRef"
-              v-model="searchQuery"
-              type="search"
-              class="min-w-0 flex-1 bg-transparent"
-              placeholder="Search styles…"
-              aria-label="Search Academy styles"
-            />
-          </label>
-          <button
-            v-if="searchQuery"
-            type="button"
-            class="btn btn-circle btn-ghost btn-sm shrink-0"
-            aria-label="Clear style search"
-            title="Clear search"
-            @click="clearSearch"
-          >
-            <Icon name="mdi:close" class="h-4 w-4" aria-hidden="true" />
-          </button>
-        </div>
-
-        <p
-          class="text-xs font-semibold text-base-content/50"
-          aria-live="polite"
-        >
+        <p class="text-xs font-semibold text-base-content/50" aria-live="polite">
           {{ resultSummary }}
         </p>
       </div>
     </header>
 
     <div
-      class="flex flex-col gap-3 kr-panel-flat p-4 sm:flex-row sm:items-center sm:justify-between"
+      class="grid gap-3 rounded-3xl border border-base-300 bg-base-100 p-4 shadow-sm sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center sm:p-5"
     >
-      <div class="min-w-0 flex-1">
+      <div class="min-w-0">
         <div class="flex items-center justify-between gap-3">
-          <p class="text-sm font-bold text-base-content">
-            {{ progressHeadline }}
-          </p>
-          <span class="text-xs font-semibold text-base-content/50">
-            {{ progressPercent }}%
-          </span>
+          <div>
+            <p class="text-sm font-black text-base-content">{{ progressHeadline }}</p>
+            <p class="mt-0.5 text-xs text-base-content/55">{{ progressMessage }}</p>
+          </div>
+          <span class="text-sm font-black text-primary">{{ progressPercent }}%</span>
         </div>
         <progress
-          class="progress progress-primary mt-2 w-full"
+          class="progress progress-primary mt-3 w-full"
           :value="academyStore.viewedLessons.length"
           :max="academyStore.timeline.length || 1"
           :aria-label="`${academyStore.viewedLessons.length} of ${academyStore.timeline.length} Academy lessons explored`"
         />
-        <p class="mt-1 text-xs text-base-content/60">
-          {{ progressMessage }}
-        </p>
       </div>
-      <button
-        type="button"
-        class="btn btn-primary btn-sm shrink-0"
-        @click="openNextLesson"
-      >
+      <button type="button" class="btn btn-primary btn-sm rounded-2xl" @click="openNextLesson">
         <Icon
           :name="nextLesson ? 'kind-icon:arrow-right' : 'kind-icon:refresh'"
           class="h-4 w-4"
@@ -120,6 +107,7 @@
       v-if="expandedStyle"
       :id="`academy-style-detail-${expandedStyle.slug}`"
       ref="detailPanelRef"
+      class="py-1"
     >
       <academy-style-detail
         :key="expandedStyle.slug"
@@ -129,22 +117,17 @@
       />
     </div>
 
-    <div
-      class="grid gap-3"
-      style="
-        grid-template-columns: repeat(auto-fill, minmax(min(240px, 100%), 1fr));
-      "
-    >
+    <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
       <button
         v-for="style in filteredStyles"
         :key="style.slug"
         :ref="(el) => setGridRef(style.slug, el)"
         type="button"
-        class="group flex flex-col gap-2 rounded-2xl border-2 p-4 text-left transition-all duration-150"
+        class="group relative aspect-[4/5] min-w-0 overflow-hidden rounded-3xl border-2 bg-base-200 text-left shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
         :class="
           expandedSlug === style.slug
-            ? 'border-primary shadow-md shadow-primary/20'
-            : 'border-base-300 bg-base-100 hover:border-primary/50 hover:shadow-sm'
+            ? 'border-primary shadow-lg shadow-primary/20'
+            : 'border-base-300 hover:border-primary/55'
         "
         :aria-expanded="expandedSlug === style.slug"
         :aria-controls="
@@ -154,65 +137,66 @@
         "
         @click="expandedSlug = expandedSlug === style.slug ? null : style.slug"
       >
-        <div
+        <img
           v-if="style.previewImageSrc"
-          class="relative -mx-4 -mt-4 w-[calc(100%+2rem)] overflow-hidden rounded-t-xl"
-          style="aspect-ratio: 16 / 9"
+          :src="style.previewImageSrc"
+          :alt="`${style.name} style preview`"
+          loading="lazy"
+          class="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+        />
+        <div v-else class="absolute inset-0 flex items-center justify-center bg-base-200">
+          <Icon name="kind-icon:gallery" class="h-10 w-10 text-base-content/20" />
+        </div>
+
+        <div class="absolute inset-0 bg-linear-to-t from-black/90 via-black/10 to-black/10" />
+
+        <div class="absolute left-2.5 top-2.5 flex max-w-[calc(100%-3rem)] flex-wrap gap-1">
+          <span class="badge border-0 bg-black/45 text-[0.6rem] font-bold text-white backdrop-blur">
+            {{ style.era }}
+          </span>
+        </div>
+
+        <div
+          v-if="academyStore.viewedLessons.includes(style.slug)"
+          class="absolute right-2.5 top-2.5 flex h-7 w-7 items-center justify-center rounded-full bg-success text-success-content shadow-md"
+          title="Lesson explored"
         >
-          <img
-            :src="style.previewImageSrc"
-            alt=""
-            loading="lazy"
-            class="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
-          />
-          <template v-if="academyStore.viewedLessons.includes(style.slug)">
-            <Icon
-              name="kind-icon:check"
-              class="absolute right-1.5 top-1.5 h-4 w-4 rounded-full bg-base-100/80 p-0.5 text-success"
-              aria-hidden="true"
-            />
-            <span class="sr-only">Lesson explored</span>
-          </template>
+          <Icon name="kind-icon:check" class="h-3.5 w-3.5" aria-hidden="true" />
+          <span class="sr-only">Lesson explored</span>
         </div>
-        <div v-else class="flex items-center justify-between gap-2">
-          <span class="text-2xl leading-none" aria-hidden="true">🏛️</span>
-          <template v-if="academyStore.viewedLessons.includes(style.slug)">
-            <Icon
-              name="kind-icon:check"
-              class="h-4 w-4 text-success"
-              aria-hidden="true"
-            />
-            <span class="sr-only">Lesson explored</span>
-          </template>
-        </div>
-        <div class="flex flex-col">
-          <span
-            class="text-sm font-black text-base-content group-hover:text-primary"
-          >
+
+        <div class="absolute inset-x-0 bottom-0 p-3 sm:p-4">
+          <p class="text-base font-black leading-tight text-white drop-shadow sm:text-lg">
             {{ style.name }}
-          </span>
-          <span class="text-xs text-base-content/50">
-            {{ style.era }} · {{ style.region }}
-          </span>
+          </p>
+          <p class="mt-1 truncate text-[0.68rem] font-semibold text-white/65">
+            {{ style.region }}
+          </p>
+          <p class="mt-2 line-clamp-2 text-xs leading-relaxed text-white/78">
+            {{ style.recognitionCues[0] }}
+          </p>
+          <div class="mt-3 flex items-center gap-1 text-[0.68rem] font-black uppercase tracking-wide text-white/90">
+            Open lesson
+            <Icon
+              name="kind-icon:arrow-right"
+              class="h-3.5 w-3.5 transition-transform group-hover:translate-x-1"
+              aria-hidden="true"
+            />
+          </div>
         </div>
-        <p class="line-clamp-2 text-xs leading-relaxed text-base-content/60">
-          {{ style.keyIdeas }}
-        </p>
       </button>
     </div>
 
     <div
       v-if="!filteredStyles.length"
-      class="flex min-h-28 flex-col items-center justify-center rounded-2xl border border-base-300 bg-base-200/60 px-4 text-center"
+      class="flex min-h-40 flex-col items-center justify-center rounded-3xl border border-base-300 bg-base-100 px-4 text-center shadow-sm"
     >
       <Icon
         :name="emptyStateIcon"
         class="h-8 w-8 text-base-content/20"
         aria-hidden="true"
       />
-      <p class="mt-1 text-xs text-base-content/40">
-        {{ emptyStateMessage }}
-      </p>
+      <p class="mt-2 text-sm text-base-content/45">{{ emptyStateMessage }}</p>
       <button
         v-if="searchQuery || lessonFilter !== 'all'"
         type="button"
@@ -265,19 +249,13 @@ const lessonFilterOptions: Array<{
 watch(expandedSlug, (slug) => {
   if (!slug) return
   nextTick(() => {
-    detailPanelRef.value?.scrollIntoView({
-      behavior: 'smooth',
-      block: 'nearest',
-    })
+    detailPanelRef.value?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
   })
 })
 
 const gridRefs = new Map<string, HTMLButtonElement>()
 
-function setGridRef(
-  slug: string,
-  el: Element | ComponentPublicInstance | null,
-) {
+function setGridRef(slug: string, el: Element | ComponentPublicInstance | null) {
   if (el instanceof HTMLButtonElement) {
     gridRefs.set(slug, el)
   } else {
@@ -308,8 +286,7 @@ function resetFilters() {
 function openNextLesson() {
   searchQuery.value = ''
   lessonFilter.value = 'all'
-  expandedSlug.value =
-    nextLesson.value?.slug ?? academyStore.timeline[0]?.slug ?? null
+  expandedSlug.value = nextLesson.value?.slug ?? academyStore.timeline[0]?.slug ?? null
 }
 
 function onKeydown(event: KeyboardEvent) {
@@ -332,10 +309,7 @@ onBeforeUnmount(() => {
 
 const expandedStyle = computed<AcademyStyle | null>(() => {
   if (!expandedSlug.value) return null
-  return (
-    academyStore.styles.find((style) => style.slug === expandedSlug.value) ??
-    null
-  )
+  return academyStore.styles.find((style) => style.slug === expandedSlug.value) ?? null
 })
 
 const nextLesson = computed<AcademyStyle | null>(() => {

--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -95,7 +95,7 @@
             <img
               v-if="style.previewImageSrc"
               :src="style.previewImageSrc"
-              :alt="`${style.name} style preview`"
+              alt=""
               loading="lazy"
               class="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
             />

--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -2,7 +2,7 @@
 <template>
   <section class="mx-auto flex w-full max-w-[1600px] flex-col gap-5">
     <header
-      class="grid overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-sm lg:grid-cols-[minmax(0,0.9fr)_minmax(420px,1.1fr)]"
+      class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,30rem),1fr))] overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-sm"
     >
       <div class="flex flex-col justify-center gap-4 p-5 sm:p-7">
         <div class="flex items-center gap-2 text-primary">
@@ -69,24 +69,18 @@
           Each image opens into a lesson, gallery wall, and remix path.
         </p>
       </div>
-      <p class="text-xs font-semibold text-base-content/45">
-        Earliest → latest
-      </p>
+      <p class="text-xs font-semibold text-base-content/45">Earliest → latest</p>
     </div>
 
     <ol
-      class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4"
+      class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,18rem),1fr))] gap-4"
       aria-label="Art history timeline lessons"
     >
       <li
         v-for="(style, index) in academyStore.timeline"
         :key="style.slug"
         class="min-w-0"
-        :class="
-          expandedSlug === style.slug
-            ? 'col-span-full'
-            : timelineCardSpan(index)
-        "
+        :class="expandedSlug === style.slug ? 'col-span-full' : ''"
       >
         <button
           v-if="expandedSlug !== style.slug"
@@ -189,10 +183,6 @@ const heroStyles = computed(() => {
     (style): style is NonNullable<typeof style> => Boolean(style),
   )
 })
-
-function timelineCardSpan(index: number) {
-  return index % 11 === 0 ? 'xl:col-span-2' : ''
-}
 
 function timelineImageAspect(index: number) {
   if (index % 11 === 0) return 'aspect-[16/9]'

--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -1,96 +1,157 @@
 <!-- /components/academy/academy-timeline.vue -->
 <template>
-  <section class="flex flex-col gap-4">
+  <section class="mx-auto flex w-full max-w-[1600px] flex-col gap-5">
     <header
-      class="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-base-300 bg-base-200 p-4"
+      class="grid overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-sm lg:grid-cols-[minmax(0,0.9fr)_minmax(420px,1.1fr)]"
     >
-      <div class="flex flex-col gap-1">
-        <h2
-          class="flex items-center gap-2 text-base font-black text-base-content"
-        >
-          <Icon name="kind-icon:map" class="h-5 w-5 text-primary" />
-          The Art History Timeline
-        </h2>
-        <p class="text-sm text-base-content/70">
-          Thirty-three centuries of style, all public domain, all remixable.
-          Pick an era and see what the masters were up to.
-        </p>
+      <div class="flex flex-col justify-center gap-4 p-5 sm:p-7">
+        <div class="flex items-center gap-2 text-primary">
+          <Icon name="kind-icon:map" class="h-5 w-5" aria-hidden="true" />
+          <span class="text-xs font-black uppercase tracking-[0.18em]">
+            Art history, room by room
+          </span>
+        </div>
+        <div class="max-w-2xl">
+          <h2 class="text-2xl font-black leading-tight text-base-content sm:text-3xl">
+            The Art History Timeline
+          </h2>
+          <p class="mt-2 text-sm leading-relaxed text-base-content/70 sm:text-base">
+            Start with the pictures. Move through thirty-three centuries of style,
+            open whatever catches your eye, then turn what you learn into a remix.
+          </p>
+        </div>
+        <div class="flex flex-wrap items-center gap-2 text-xs font-semibold">
+          <span class="badge badge-primary badge-outline">
+            {{ academyStore.lessonsViewedCount }}/{{ academyStore.timeline.length }} explored
+          </span>
+          <span class="badge badge-secondary badge-outline">
+            {{ academyStore.stylesRemixedCount }} styles remixed
+          </span>
+        </div>
       </div>
+
       <div
-        class="flex items-center gap-2 text-xs font-semibold text-base-content/60"
+        class="grid min-h-52 grid-cols-3 border-t border-base-300 bg-base-200 lg:min-h-64 lg:border-l lg:border-t-0"
+        aria-hidden="true"
       >
-        <span class="badge badge-ghost badge-sm">
-          {{ academyStore.lessonsViewedCount }}/{{
-            academyStore.timeline.length
-          }}
-          lessons explored
-        </span>
-        <span class="badge badge-ghost badge-sm">
-          {{ academyStore.stylesRemixedCount }} styles remixed
-        </span>
+        <div
+          v-for="(style, index) in heroStyles"
+          :key="style.slug"
+          class="relative overflow-hidden"
+          :class="index === 1 ? 'border-x border-base-300' : ''"
+        >
+          <img
+            v-if="style.previewImageSrc"
+            :src="style.previewImageSrc"
+            alt=""
+            class="h-full w-full object-cover"
+            :class="index === 1 ? 'scale-110' : ''"
+          />
+          <div v-else class="flex h-full items-center justify-center bg-base-200">
+            <Icon name="kind-icon:gallery" class="h-10 w-10 text-base-content/20" />
+          </div>
+          <div class="absolute inset-0 bg-linear-to-t from-base-content/65 via-transparent to-transparent" />
+          <p
+            class="absolute inset-x-2 bottom-2 line-clamp-2 text-xs font-black leading-tight text-base-100 drop-shadow"
+          >
+            {{ style.name }}
+          </p>
+        </div>
       </div>
     </header>
 
-    <ol class="relative flex flex-col gap-3 pl-6">
-      <div
-        class="absolute bottom-4 left-2 top-4 w-0.5 rounded-full bg-linear-to-b from-primary/60 via-secondary/40 to-primary/10"
-      />
+    <div class="flex flex-wrap items-end justify-between gap-3 px-1">
+      <div>
+        <p class="text-xs font-black uppercase tracking-[0.16em] text-base-content/45">
+          Chronological gallery
+        </p>
+        <p class="mt-1 text-sm text-base-content/65">
+          Each image opens into a lesson, gallery wall, and remix path.
+        </p>
+      </div>
+      <p class="text-xs font-semibold text-base-content/45">
+        Earliest → latest
+      </p>
+    </div>
 
+    <ol
+      class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4"
+      aria-label="Art history timeline lessons"
+    >
       <li
-        v-for="style in academyStore.timeline"
+        v-for="(style, index) in academyStore.timeline"
         :key="style.slug"
-        class="relative"
+        class="min-w-0"
+        :class="
+          expandedSlug === style.slug
+            ? 'col-span-full'
+            : timelineCardSpan(index)
+        "
       >
-        <span
-          class="absolute -left-[1.35rem] top-5 h-3 w-3 rounded-full border-2 transition-colors"
-          :class="
-            expandedSlug === style.slug
-              ? 'border-primary bg-primary'
-              : academyStore.viewedLessons.includes(style.slug)
-                ? 'border-primary bg-base-100'
-                : 'border-base-300 bg-base-100'
-          "
-        />
-
         <button
           v-if="expandedSlug !== style.slug"
           :ref="(el) => setToggleRef(style.slug, el)"
           type="button"
-          class="group flex w-full flex-wrap items-center gap-3 kr-panel-flat px-4 py-3 text-left transition-all hover:border-primary/50 hover:shadow-sm"
+          class="group flex h-full w-full flex-col overflow-hidden rounded-3xl border border-base-300 bg-base-100 text-left shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
           aria-expanded="false"
           :aria-controls="`academy-style-detail-${style.slug}`"
           @click="expandedSlug = style.slug"
         >
-          <span class="text-xl leading-none" aria-hidden="true">🏛️</span>
-          <span class="flex min-w-0 flex-1 flex-col">
-            <span class="flex flex-wrap items-baseline gap-2">
-              <span
-                class="text-sm font-black text-base-content group-hover:text-primary"
-              >
-                {{ style.name }}
-              </span>
-              <span class="text-xs text-base-content/50">{{ style.era }}</span>
-            </span>
-            <span class="truncate text-xs text-base-content/60">
-              {{ style.recognitionCues[0] }}
-            </span>
-          </span>
-          <template v-if="academyStore.viewedLessons.includes(style.slug)">
-            <Icon
-              name="kind-icon:check"
-              class="h-4 w-4 shrink-0 text-success"
-              aria-hidden="true"
+          <div class="relative w-full overflow-hidden bg-base-200" :class="timelineImageAspect(index)">
+            <img
+              v-if="style.previewImageSrc"
+              :src="style.previewImageSrc"
+              :alt="`${style.name} style preview`"
+              loading="lazy"
+              class="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
             />
-            <span class="sr-only">Lesson explored</span>
-          </template>
-          <Icon
-            name="mdi:chevron-down"
-            class="h-4 w-4 shrink-0 text-base-content/40 group-hover:text-primary"
-            aria-hidden="true"
-          />
+            <div v-else class="flex h-full items-center justify-center">
+              <Icon name="kind-icon:gallery" class="h-10 w-10 text-base-content/20" />
+            </div>
+
+            <div class="absolute inset-0 bg-linear-to-t from-black/80 via-black/10 to-black/10" />
+
+            <div class="absolute left-3 top-3 flex flex-wrap gap-1.5">
+              <span class="badge border-0 bg-base-100/90 text-[0.65rem] font-bold text-base-content shadow-sm backdrop-blur">
+                {{ style.era }}
+              </span>
+              <span class="badge border-0 bg-base-100/80 text-[0.65rem] text-base-content/75 shadow-sm backdrop-blur">
+                {{ style.region }}
+              </span>
+            </div>
+
+            <div
+              v-if="academyStore.viewedLessons.includes(style.slug)"
+              class="absolute right-3 top-3 flex h-8 w-8 items-center justify-center rounded-full bg-success text-success-content shadow-md"
+              title="Lesson explored"
+            >
+              <Icon name="kind-icon:check" class="h-4 w-4" aria-hidden="true" />
+              <span class="sr-only">Lesson explored</span>
+            </div>
+
+            <div class="absolute inset-x-0 bottom-0 p-4">
+              <p class="text-lg font-black leading-tight text-white drop-shadow sm:text-xl">
+                {{ style.name }}
+              </p>
+            </div>
+          </div>
+
+          <div class="flex flex-1 flex-col gap-3 p-4">
+            <p class="line-clamp-2 text-sm leading-relaxed text-base-content/70">
+              {{ style.recognitionCues[0] }}
+            </p>
+            <div class="mt-auto flex items-center justify-between gap-3 text-xs font-bold text-primary">
+              <span>Enter the gallery</span>
+              <Icon
+                name="kind-icon:arrow-right"
+                class="h-4 w-4 transition-transform group-hover:translate-x-1"
+                aria-hidden="true"
+              />
+            </div>
+          </div>
         </button>
 
-        <div v-else :id="`academy-style-detail-${style.slug}`">
+        <div v-else :id="`academy-style-detail-${style.slug}`" class="py-1">
           <academy-style-detail
             :lesson="style"
             @close="closeLesson(style.slug)"
@@ -104,6 +165,7 @@
 
 <script setup lang="ts">
 import {
+  computed,
   nextTick,
   onBeforeUnmount,
   onMounted,
@@ -117,8 +179,26 @@ const emit = defineEmits<{
 }>()
 
 const academyStore = useAcademyStore()
-
 const expandedSlug = ref<string | null>(null)
+
+const heroStyles = computed(() => {
+  const timeline = academyStore.timeline
+  if (timeline.length <= 3) return timeline
+  const middle = Math.floor(timeline.length / 2)
+  return [timeline[0], timeline[middle], timeline[timeline.length - 1]].filter(
+    (style): style is NonNullable<typeof style> => Boolean(style),
+  )
+})
+
+function timelineCardSpan(index: number) {
+  return index % 11 === 0 ? 'xl:col-span-2' : ''
+}
+
+function timelineImageAspect(index: number) {
+  if (index % 11 === 0) return 'aspect-[16/9]'
+  if (index % 5 === 0) return 'aspect-square'
+  return 'aspect-[4/3]'
+}
 
 // Collapsing an expanded lesson unmounts its close button (v-if/v-else swap
 // with the toggle button), so the browser drops focus to <body> with no


### PR DESCRIPTION
## Why

The Academy content and remix path exist, but the current presentation is still text-first: Timeline renders as accordion rows, Style Gallery treats images as thumbnails attached to text cards, and expanded lessons turn wide screens into long horizontal prose bands. Silas's current visual direction is gallery -> interact, using the Bot Gallery as a useful density/reference point.

## What changed

- Rebuilt **Timeline** as a chronological, image-led gallery using the existing 47 Academy preview images.
  - image hero at the section entrance
  - varied artwork proportions for visual rhythm
  - movement name/era/region over the art
  - exploration/remix progress stays visible
- Reworked **Style Gallery** into tall artwork-first cards closer to the Bot Gallery visual hierarchy.
- Rebuilt **academy-style-detail** as an exhibit rather than an accordion body:
  - large visual movement hero
  - real historical example works promoted into a gallery wall
  - scannable recognition-cue cards
  - masters grouped as a dedicated visual section
  - Try It + Reflect moved into a compact interaction rail
  - Remix CTA appears at the visual entry point and inside the interaction rail
- Added a **compact lesson presentation** for Remix Studio so the richer lesson layout does not overwhelm the generation workspace.
- Made the new shared-component grids intrinsically responsive with `auto-fit`/`minmax`, so they respond to their actual host width rather than viewport breakpoints.

## Deliberately not faked in this PR

Artist portraits. The new lesson layout gives `Meet the masters` an intentional portrait-card shape, but the registry does not currently carry verified portrait assets. This PR leaves neutral initial frames rather than generating fake likenesses or hotlinking unreviewed images. Conductor #2399 now tracks the rights-checked portrait + gallery-density asset pass.

Likewise, lessons added after the original 21-style cohort still need their historical Example Works backfill (Conductor #2381). This layout makes those real assets much more valuable when they land, but does not pretend they already exist.

## Acceptance focus

- Academy discovery is image-first on Timeline and Styles.
- Expanded lessons no longer render as full-width prose strips.
- Existing preview/example image paths are reused; no new media delivery contract is introduced.
- Lesson -> Remix Studio behavior remains intact.
- Remix Studio uses a compact style summary.
- Keyboard close/focus behavior remains intact for Timeline/Style Gallery.
- Shared grids remain compliant with the repository layout contract.

## Related

- #1927 restored Academy browser-facing media delivery.
- Conductor #2380 tracks current-production media + end-to-end remix acceptance.
- Conductor #2381 tracks the 26 lessons currently lacking Example Works.
- Conductor #2382 tracks per-style Try It guidance drift.
- Conductor #2399 tracks rights-checked artist portraits and a 2-4-work gallery-density target.