### PR TITLE
feat(model-builder): report batchApproveStage success only once the batch write confirms (model-builder/t-029 cycle 8)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -470,6 +470,12 @@ jobs:
       - name: Model Builder batchSetField confirmed-success guard contract
         run: npm run test:model-builder-batch-set-field-confirmed-success-guard
 
+      - name: Model Builder batchApproveStage confirmed-success guard checker self-test
+        run: npm run test:model-builder-batch-approve-stage-confirmed-success-guard-selftest
+
+      - name: Model Builder batchApproveStage confirmed-success guard contract
+        run: npm run test:model-builder-batch-approve-stage-confirmed-success-guard
+
       - name: Model Builder confirmed-outcome-before-toast meta-guard checker self-test
         run: npm run test:model-builder-confirmed-outcome-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -233,6 +233,8 @@
     "test:model-builder-draft-status-scope-guard": "tsx utils/scripts/verifyModelBuilderDraftStatusScopeGuard.ts",
     "test:model-builder-batch-set-field-confirmed-success-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.test.ts",
     "test:model-builder-batch-set-field-confirmed-success-guard": "tsx utils/scripts/verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.ts",
+    "test:model-builder-batch-approve-stage-confirmed-success-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchApproveStageConfirmedSuccessGuard.test.ts",
+    "test:model-builder-batch-approve-stage-confirmed-success-guard": "tsx utils/scripts/verifyModelBuilderBatchApproveStageConfirmedSuccessGuard.ts",
     "test:model-builder-confirmed-outcome-guard-selftest": "tsx utils/scripts/verifyModelBuilderConfirmedOutcomeGuard.test.ts",
     "test:model-builder-confirmed-outcome-guard": "tsx utils/scripts/verifyModelBuilderConfirmedOutcomeGuard.ts",
     "test:model-builder-batch-any-in-flight-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchAnyInFlightGuard.test.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -2061,15 +2061,62 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     }
   }
 
-  // Approve a stage for every (unlocked) item in a group at once.
-  function batchApproveStage(outputKey: string, stageKey: BuildStageKey): void {
-    let approved = 0
+  // Approve a stage for every (unlocked) item in a group at once. Persists
+  // the whole group in a single batch request rather than N per-item
+  // PATCHes, and reports success only once that request actually confirms it
+  // -- mirrors batchSetField (see its own doc comment for the identical
+  // race). The pre-fix shape called the single-item approveStage (whose own
+  // pushItem is a fire-and-forget background PATCH) in a loop and
+  // unconditionally showed an "Approved N items." success toast the instant
+  // the loop finished, before any of those N background writes had actually
+  // resolved. That's fine for a fire-and-forget action reporting on
+  // separately-confirmed local work (e.g. generateItemAsset's toast reports
+  // the *render* succeeding, with pushItem persisting it alongside) -- but
+  // "approved" has no meaning other than "persisted": there's no separate
+  // local accomplishment being confirmed the way a rendered asset is. A
+  // concurrent run cancellation (or any other server-side rejection, e.g.
+  // assertRunWritable) during that loop could pop a false "Approved N
+  // items." success toast, immediately followed by pushItem's own
+  // unrelated-looking "Failed to save changes." error moments later -- with
+  // every item's local stageStatuses already optimistically flipped to
+  // 'approved' either way, same as batchSetField's pre-fix bug.
+  async function batchApproveStage(
+    outputKey: string,
+    stageKey: BuildStageKey,
+  ): Promise<void> {
+    const entries: Array<{
+      item: BuildItem
+      payload: Record<string, unknown>
+      meta?: { stage?: string; reason?: string }
+    }> = []
     for (const item of groupItems(outputKey)) {
       if (item.stages[stageKey].status === 'locked') continue
-      approveStage(item.id, stageKey)
-      approved++
+      item.stages[stageKey] = { status: 'approved' }
+      const next = BUILD_STAGES[stageIndex(stageKey) + 1]
+      if (next && item.stages[next.key].status === 'locked') {
+        item.stages[next.key] = { status: 'ready' }
+      }
+      entries.push({
+        item,
+        payload: { stageStatuses: item.stages },
+        meta: { stage: stageKey },
+      })
     }
-    setStatus('success', `Approved ${stageKey} for ${approved} items.`)
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      const ok = await batchPushItems(entries)
+      // On failure, batchPushItems already surfaced the real error via
+      // setStatusForRun -- reporting a blanket "success" here too would be
+      // actively misleading.
+      if (ok) {
+        setStatus(
+          'success',
+          `Approved ${stageKey} for ${entries.length} items.`,
+        )
+      }
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
   }
 
   // Auto-build (draft → generate → commit with defaults) every not-yet-committed

--- a/utils/scripts/verifyModelBuilderBatchApproveStageConfirmedSuccessGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderBatchApproveStageConfirmedSuccessGuard.test.ts
@@ -1,0 +1,147 @@
+// /utils/scripts/verifyModelBuilderBatchApproveStageConfirmedSuccessGuard.test.ts
+//
+// Regression test for checkBatchApproveStageConfirmedSuccessGuard() in
+// verifyModelBuilderBatchApproveStageConfirmedSuccessGuard.ts
+// (model-builder/t-029). Exercises the real check against synthetic
+// store-shaped fixtures covering: the original pre-fix shape (sync
+// function, loops a bare un-awaited approveStage(...) call, unconditional
+// success toast), a batchSetField-style pre-fix shape (fires
+// batchPushItems(entries) without awaiting it), and the fixed shape (async
+// function, collects entries, awaits the real result, success toast gated
+// on it).
+import assert from 'node:assert/strict'
+
+import { checkBatchApproveStageConfirmedSuccessGuard } from './verifyModelBuilderBatchApproveStageConfirmedSuccessGuard.js'
+
+const ORIGINAL_BUGGY = `
+  function batchApproveStage(outputKey: string, stageKey: BuildStageKey): void {
+    let approved = 0
+    for (const item of groupItems(outputKey)) {
+      if (item.stages[stageKey].status === 'locked') continue
+      approveStage(item.id, stageKey)
+      approved++
+    }
+    setStatus('success', \`Approved \${stageKey} for \${approved} items.\`)
+  }
+`
+
+const UNAWAITED_BATCH_PUSH_BUGGY = `
+  function batchApproveStage(
+    outputKey: string,
+    stageKey: BuildStageKey,
+  ): void {
+    const entries: Array<{
+      item: BuildItem
+      payload: Record<string, unknown>
+      meta?: { stage?: string; reason?: string }
+    }> = []
+    for (const item of groupItems(outputKey)) {
+      if (item.stages[stageKey].status === 'locked') continue
+      item.stages[stageKey] = { status: 'approved' }
+      entries.push({
+        item,
+        payload: { stageStatuses: item.stages },
+        meta: { stage: stageKey },
+      })
+    }
+    batchPushItems(entries)
+    setStatus(
+      'success',
+      \`Approved \${stageKey} for \${entries.length} items.\`,
+    )
+  }
+`
+
+const FIXED = `
+  async function batchApproveStage(
+    outputKey: string,
+    stageKey: BuildStageKey,
+  ): Promise<void> {
+    const entries: Array<{
+      item: BuildItem
+      payload: Record<string, unknown>
+      meta?: { stage?: string; reason?: string }
+    }> = []
+    for (const item of groupItems(outputKey)) {
+      if (item.stages[stageKey].status === 'locked') continue
+      item.stages[stageKey] = { status: 'approved' }
+      const next = BUILD_STAGES[stageIndex(stageKey) + 1]
+      if (next && item.stages[next.key].status === 'locked') {
+        item.stages[next.key] = { status: 'ready' }
+      }
+      entries.push({
+        item,
+        payload: { stageStatuses: item.stages },
+        meta: { stage: stageKey },
+      })
+    }
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      const ok = await batchPushItems(entries)
+      if (ok) {
+        setStatus(
+          'success',
+          \`Approved \${stageKey} for \${entries.length} items.\`,
+        )
+      }
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+
+function run(): void {
+  const originalBuggyErrors =
+    checkBatchApproveStageConfirmedSuccessGuard(ORIGINAL_BUGGY)
+  assert.equal(
+    originalBuggyErrors.length,
+    3,
+    'expected the original pre-fix fixture (sync, looped bare ' +
+      `approveStage(...), unconditional success) to fail three times, got: ${JSON.stringify(originalBuggyErrors)}`,
+  )
+  assert.ok(originalBuggyErrors.some((e) => /declared `async`/.test(e)))
+  assert.ok(originalBuggyErrors.some((e) => /no longer awaits/.test(e)))
+  assert.ok(
+    originalBuggyErrors.some((e) =>
+      /regressed to the original pre-fix shape/.test(e),
+    ),
+  )
+
+  const unawaitedBatchPushErrors = checkBatchApproveStageConfirmedSuccessGuard(
+    UNAWAITED_BATCH_PUSH_BUGGY,
+  )
+  assert.equal(
+    unawaitedBatchPushErrors.length,
+    3,
+    'expected the batchSetField-style pre-fix fixture (sync, unawaited ' +
+      `batchPushItems call, unconditional success) to fail three times, got: ${JSON.stringify(unawaitedBatchPushErrors)}`,
+  )
+  assert.ok(unawaitedBatchPushErrors.some((e) => /declared `async`/.test(e)))
+  assert.ok(unawaitedBatchPushErrors.some((e) => /no longer awaits/.test(e)))
+  assert.ok(
+    unawaitedBatchPushErrors.some((e) =>
+      /without awaiting it and unconditionally/.test(e),
+    ),
+  )
+
+  const fixedErrors = checkBatchApproveStageConfirmedSuccessGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const missingFnErrors = checkBatchApproveStageConfirmedSuccessGuard(
+    'function someOtherFunction(): void {}',
+  )
+  assert.equal(missingFnErrors.length, 1)
+  assert.ok(/Could not find a function named/.test(missingFnErrors[0]!))
+
+  console.log(
+    'Model Builder batchApproveStage confirmed-success guard self-test ' +
+      'passed: both pre-fix fixture shapes fail with the right errors, the ' +
+      'fixed fixture passes, missing-function fixture fails clearly.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderBatchApproveStageConfirmedSuccessGuard.ts
+++ b/utils/scripts/verifyModelBuilderBatchApproveStageConfirmedSuccessGuard.ts
@@ -1,0 +1,149 @@
+// /utils/scripts/verifyModelBuilderBatchApproveStageConfirmedSuccessGuard.ts
+//
+// Regression guard (model-builder/t-029) -- batchApproveStage() is the
+// "Approve fields for all N" action in the batch editor
+// (model-builder-batch-editor.vue). It's the same shape of bug the
+// confirmed-outcome-before-toast meta-guard (verifyModelBuilderConfirmedOutcomeGuard.ts,
+// t-042) deliberately does NOT catch: that meta-guard excludes any `void`
+// -returning helper (pushItem, approveStage, ...) on the theory that a
+// caller reporting success right after firing one is usually reporting on
+// separately-confirmed local work (e.g. generateItemAsset's toast reports
+// the *render* succeeding, with pushItem persisting it alongside as a
+// best-effort background write). batchApproveStage doesn't fit that
+// exception: "approved" has no meaning other than "persisted" -- there's no
+// separate local accomplishment being confirmed the way a rendered asset is.
+//
+// The pre-fix shape called the single-item approveStage (whose own pushItem
+// is a fire-and-forget background PATCH) in a loop and *unconditionally*
+// showed an `Approved ${stageKey} for ${approved} items.` success toast the
+// instant the loop finished, before any of those N background writes had
+// resolved. Concretely: approve a stage on a group of 10 items while the run
+// gets cancelled in another tab (or any other server-side rejection, e.g.
+// assertRunWritable) mid-loop -- the UI immediately shows "Approved
+// FIELDS_AND_PROMPTS for 10 items." in success (green) tone, then each
+// pushItem's own unrelated-looking "Failed to save changes." error toast
+// silently overwrites it moments later, one at a time, with no indication of
+// which item(s) never actually persisted. Every item's local stageStatuses
+// had already been optimistically flipped to 'approved' either way.
+//
+// Fixed exactly like its sibling batchSetField
+// (verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.ts): collect entries
+// and post them in a single batchPushItems(entries) call, make
+// batchApproveStage `async`, await that real result, and only show the
+// success toast when it's actually true -- mirroring
+// batchDraftField/batchAutoBuild/batchSetField's own await-then-report
+// shape. On failure, batchPushItems' existing run-scoped setStatusForRun(...)
+// call is the only message shown, instead of a false success immediately
+// followed by a generic failure.
+//
+// This asserts the textual shape of that fix stays in place: batchApproveStage()
+// is declared `async`, its body awaits `batchPushItems(entries)`, and the
+// success toast is gated behind that awaited result rather than firing
+// unconditionally right after an un-awaited `batchPushItems(entries)` call
+// (or, regressing back to the original bug shape, right after a bare loop of
+// un-awaited `approveStage(...)` calls).
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'batchApproveStage'
+
+// The pre-fix shape: batchPushItems(entries) fired without `await`, followed
+// (with nothing gating it) by the success toast.
+const UNAWAITED_FIRE_AND_FORGET =
+  /(?<!await\s)batchPushItems\(entries\)\s*\n\s*setStatus\(\s*\n?\s*'success'/
+
+// The original pre-fix shape: a bare, un-awaited `approveStage(...)` call
+// inside a loop, with an unconditional success toast right after the loop.
+const LOOPED_FIRE_AND_FORGET_APPROVE = /^[ \t]*approveStage\(/m
+
+export function checkBatchApproveStageConfirmedSuccessGuard(
+  content: string,
+): string[] {
+  const errors: string[] = []
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+
+  if (!fn) {
+    errors.push(
+      `Could not find a function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  if (!fn.isAsync) {
+    errors.push(
+      `${FN_NAME}() is no longer declared \`async\` -- without it, it ` +
+        "can't await batchPushItems' real result before reporting its own " +
+        'success/failure toast.',
+    )
+  }
+
+  if (!/await\s+batchPushItems\(\s*entries\s*\)/.test(fn.body)) {
+    errors.push(
+      `${FN_NAME}() no longer awaits \`batchPushItems(entries)\` -- ` +
+        'without awaiting the real result, any success message it shows ' +
+        'is just an assumption made the instant the request was issued, ' +
+        "not a confirmed outcome (mirrors batchSetField's own " +
+        'await-then-report shape).',
+    )
+  }
+
+  if (UNAWAITED_FIRE_AND_FORGET.test(fn.body)) {
+    errors.push(
+      `${FN_NAME}() still fires batchPushItems(entries) without awaiting ` +
+        'it and unconditionally reports a success toast right after -- a ' +
+        'partial or total server-side failure will still show that false ' +
+        "success message before batchPushItems' own error toast silently " +
+        'overwrites it moments later.',
+    )
+  }
+
+  if (LOOPED_FIRE_AND_FORGET_APPROVE.test(fn.body)) {
+    errors.push(
+      `${FN_NAME}() has regressed to the original pre-fix shape -- a bare ` +
+        'call to the single-item approveStage(...) (whose own pushItem is ' +
+        'fire-and-forget) inside its loop, rather than collecting entries ' +
+        'and awaiting a single batchPushItems(entries) call. approveStage ' +
+        "is fine for item-panel.vue's single-item flow (no aggregate " +
+        'success message to falsely confirm), but reintroducing it here ' +
+        'brings back the exact race this guard exists to catch.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkBatchApproveStageConfirmedSuccessGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder batchApproveStage confirmed-success guard contract ' +
+        'failed in modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder batchApproveStage confirmed-success guard contract ' +
+      "passed: batchApproveStage awaits batchPushItems' real result and " +
+      'only reports success once the write actually confirms it.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What

`batchApproveStage()` (the "Approve fields for all N" action in `model-builder-batch-editor.vue`) reported an unconditional `Approved ${stageKey} for ${approved} items.` success toast the instant its loop finished — before any of the N background PATCH requests it triggered had actually resolved.

Fixed the same way `batchSetField` was fixed earlier in t-029: collect the group's changed items into `entries`, persist them in a single `batchPushItems(entries)` call, `await` the real result, and only show the success toast once that write is actually confirmed. `batchApproveStage` is now `async` and claims/releases `batchingOutputSingleton` like every other batch action, so the group's buttons correctly disable while it's in flight too.

## Why

`batchApproveStage` called the single-item `approveStage()` (whose own `pushItem` is a fire-and-forget background PATCH) in a loop, then unconditionally showed a success toast right after:

```ts
function batchApproveStage(outputKey: string, stageKey: BuildStageKey): void {
  let approved = 0
  for (const item of groupItems(outputKey)) {
    if (item.stages[stageKey].status === 'locked') continue
    approveStage(item.id, stageKey)
    approved++
  }
  setStatus('success', `Approved ${stageKey} for ${approved} items.`)
}
```

This is the exact bug class `batchSetField` had before its own fix (see its doc comment) — but it wasn't caught by the existing `verifyModelBuilderConfirmedOutcomeGuard.ts` meta-guard (t-042), because that guard deliberately excludes `void`-returning helpers like `pushItem`/`approveStage` on the theory that a caller reporting success right after firing one of those is usually reporting on *separately-confirmed local work* (e.g. `generateItemAsset`'s toast reports the render succeeding, with `pushItem` persisting it alongside as a best-effort background write). `batchApproveStage` doesn't fit that exception: "approved" has no meaning other than "persisted" — there is no separate local accomplishment being confirmed the way a rendered asset is.

Concretely: approve a stage on a group of 10 items while the run gets cancelled in another tab (or any other server-side rejection, e.g. `assertRunWritable`) mid-loop. The UI immediately shows "Approved FIELDS_AND_PROMPTS for 10 items." in success (green) tone, then each `pushItem`'s own unrelated-looking "Failed to save changes." error toast silently overwrites it moments later, one at a time, with no indication of which item(s) never actually persisted. Every item's local `stageStatuses` had already been optimistically flipped to `'approved'` either way.

## Fix

- `batchApproveStage` in `stores/modelBuilderStore.ts` is now `async`. It builds an `entries` array (mirroring `batchSetField`'s shape exactly), persists the whole group in one `batchPushItems(entries)` call, and only reports success once that call resolves `true`. On failure, `batchPushItems`' existing run-scoped `setStatusForRun(...)` call is the only message shown, instead of a false success immediately followed by a generic failure.
- Added `utils/scripts/verifyModelBuilderBatchApproveStageConfirmedSuccessGuard.ts` (+ self-test), following the exact convention of the prior model-builder guards (e.g. `verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.ts`). It asserts `batchApproveStage` stays `async`, awaits `batchPushItems(entries)`, and never regresses to either pre-fix shape (the original bare-`approveStage`-in-a-loop shape, or a `batchSetField`-style unawaited-`batchPushItems` shape).
- Wired the new guard + self-test into `package.json` (`test:model-builder-batch-approve-stage-confirmed-success-guard[-selftest]`) and `.github/workflows/contract-tests.yml`, next to the sibling `batchSetField` guard steps.

## Verification

- Investigated cycle 7's suggested lead (`draftText()`'s failure path never persisting `item.error`) first — found it had already been closed by a separate task, `model-builder/t-029`'s sibling `model-builder/t-045` (kind_robots#1909, merged same day), so no work was needed there. Moved on to a genuinely unexplored function (`batchApproveStage`) per the task's fallback instruction.
- `npm run test:model-builder-*` (83 scripts, up from the prior 81 — 2 new): **83/83 pass**.
- `npx vue-tsc --noEmit`: clean, repo-wide, no output.
- `npx eslint` on touched files: 2 pre-existing `no-empty` findings in `stores/modelBuilderStore.ts` at lines 230/237 (unrelated to this change, well outside the touched region), confirmed present on `main` before this change via `git stash`. No new eslint errors.
- `npx prettier --check` on touched files: the new guard/test files and `package.json`/`contract-tests.yml` are clean; `stores/modelBuilderStore.ts` shows the same pre-existing formatting drift confirmed present on `main` before this change (unrelated hunks elsewhere in the file, verified with `git stash` + diff — none inside the touched `batchApproveStage` region).
- Diff is scoped to exactly the 5 files above; no unrelated files touched; no force-push (this branch's only push was its first).


---
_Generated by [Claude Code](https://claude.ai/code/session_01B46qu86HmThwFU3gzZKVth)_