### PR TITLE
fix(storybook): stop the seed-query race from resurrecting one-shot ingredient params (storybook/t-010)

### DIFF
--- a/.github/workflows/storybook-seed-query-race-contract.yml
+++ b/.github/workflows/storybook-seed-query-race-contract.yml
@@ -1,0 +1,30 @@
+name: Storybook Seed Query Race Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: storybook-seed-query-race-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Storybook seed query race contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify Storybook seed query race guard
+        run: node utils/scripts/verifyStorybookSeedQueryRaceGuard.mjs

--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -178,12 +178,37 @@ const router = useRouter()
 const libraryOpen = ref(false)
 const restartArmed = ref(false)
 
+// storybook-page.vue's seedFromQuery() (child, mounted first) treats these as
+// one-shot: it consumes them into the setup draft, then strips them with its
+// own router.replace() so a reload, bookmark, or share never silently re-adds
+// the ingredient. That replace() races this component's own onMounted
+// (parent, mounted second, same synchronous tick) whenever it also calls
+// updateStoryQuery() -- e.g. arriving at `/storybook?character=<slug>` while
+// a previous session is still active in localStorage, exactly the case
+// seedFromQuery's own comment describes ("a link never destroys a story
+// someone was already assembling"). Neither router.replace() has resolved
+// when the second one is built, so updateStoryQuery()'s `{ ...route.query }`
+// still carries the stale, not-yet-stripped ingredient key, and its
+// navigation -- issued after seedFromQuery's -- wins: the ingredient key
+// resurfaces in the URL alongside `story=`, undoing the one-shot consumption
+// seedFromQuery just performed. Stripping these keys here too, on every query
+// rewrite this component makes, closes the race regardless of ordering.
+const SEED_QUERY_KEYS = new Set([
+  'scenario',
+  'location',
+  'character',
+  'facet',
+  'reward',
+])
+
 function queryStoryId(): string | null {
   return typeof route.query.story === 'string' ? route.query.story : null
 }
 
 function updateStoryQuery(sessionId: string | null): void {
-  const query = { ...route.query }
+  const query = Object.fromEntries(
+    Object.entries(route.query).filter(([key]) => !SEED_QUERY_KEYS.has(key)),
+  )
   if (sessionId) query.story = sessionId
   else delete query.story
   void router.replace({ query })

--- a/utils/scripts/verifyStorybookSeedQueryRaceGuard.mjs
+++ b/utils/scripts/verifyStorybookSeedQueryRaceGuard.mjs
@@ -1,0 +1,130 @@
+// /utils/scripts/verifyStorybookSeedQueryRaceGuard.mjs
+//
+// Regression guard (storybook/t-010, front-end polish). storybook-page.vue's
+// seedFromQuery() treats `?scenario=`, `?location=`, `?character=`, `?facet=`
+// and `?reward=` as one-shot: it consumes the value into the setup draft,
+// then strips it with its own `router.replace()` -- "The query is cleared
+// immediately so a reload, bookmark or share does not silently re-add the
+// ingredient after the author removed it."
+//
+// content/storybook.md mounts `:storybook-library-page`, which renders
+// `<StorybookPage />` as a child, so BOTH components' onMounted() hooks run
+// on the same page load -- the child's (seedFromQuery's replace) first, then
+// the parent's (storybook-library-page.vue's own onMounted), same
+// synchronous tick, no await between them.
+//
+// storybook-library-page.vue's onMounted() calls its own updateStoryQuery()
+// whenever a session is already active and the URL has no `?story=` yet
+// (`storyStore.session && !directId`) -- exactly the case seedFromQuery's own
+// comment describes: arriving at a deep link such as
+// `/storybook?character=<slug>` (character-manager.vue's
+// startStoryWithCharacter() sends exactly this, with no `story` param and no
+// clearing of any existing session) while a previous story is still active in
+// localStorage.
+//
+// router.replace() resolves asynchronously -- the reactive `route.query`
+// object is not updated until the navigation's guard pipeline finishes, which
+// happens after this synchronous onMounted chain returns. So when
+// updateStoryQuery() builds its target query from `{ ...route.query }`, it
+// still sees the stale, not-yet-stripped ingredient key, and re-includes it
+// alongside `story=<id>`. Its navigation is issued after seedFromQuery's and
+// wins, so the ingredient key resurfaces in the URL -- undoing the one-shot
+// consumption seedFromQuery just performed. On the next reload, bookmark, or
+// share of that URL, seedFromQuery() fires again and silently re-adds a stale
+// ingredient the reader has already moved past into whatever story is being
+// set up at that point.
+//
+// This asserts the fix's shape stays in place: storybook-library-page.vue
+// strips the same one-shot ingredient keys from `route.query` every time it
+// rewrites the query, so its own navigation can never resurrect one
+// regardless of ordering against seedFromQuery's.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { extractTsFunctionBody } from './lib/extractTsFunctionBody.mjs'
+
+const PAGE_PATH = 'components/pages/storybook-library-page.vue'
+const COMPONENT_PATH = 'components/conductor/storybook-page.vue'
+const FN_NAME = 'updateStoryQuery'
+
+const pageContent = readFileSync(resolve(process.cwd(), PAGE_PATH), 'utf8')
+const componentContent = readFileSync(
+  resolve(process.cwd(), COMPONENT_PATH),
+  'utf8',
+)
+
+const body = extractTsFunctionBody(pageContent, FN_NAME, {
+  path: PAGE_PATH,
+  notFoundHint:
+    'has it been renamed, removed, or inlined? If so, this guard (and the ' +
+    'seed-query race it protects against) needs to move with it.',
+})
+
+// The one-shot keys seedFromQuery() consumes in storybook-page.vue. Extracted
+// from its own source rather than hard-coded twice, so a future ingredient
+// added to seedFromQuery() without updating this list fails loudly here
+// instead of silently reopening the race for just that key.
+const seedKeyPattern =
+  /route\.query\.(scenario|location|character|facet|reward)\b/g
+const seedKeysInComponent = new Set(
+  Array.from(componentContent.matchAll(seedKeyPattern), (m) => m[1]),
+)
+assert.ok(
+  seedKeysInComponent.size >= 5,
+  `Expected seedFromQuery() in ${COMPONENT_PATH} to read at least 5 one-shot ` +
+    'route.query ingredient keys -- has it changed shape? This guard reads ' +
+    'that list directly off seedFromQuery() to stay in sync.',
+)
+
+assert.ok(
+  body.includes('SEED_QUERY_KEYS'),
+  `${FN_NAME}() in ${PAGE_PATH} no longer references SEED_QUERY_KEYS -- ` +
+    'it must strip every one-shot ingredient key from route.query on every ' +
+    'query rewrite this component makes, or its own navigation can win a ' +
+    "race against seedFromQuery()'s stripping replace() and resurrect a " +
+    'key that was supposed to be consumed once.',
+)
+
+const constDeclarationMatch = pageContent.match(
+  /const SEED_QUERY_KEYS\s*=\s*(?:new Set\()?\s*\[([^\]]*)\]/,
+)
+assert.ok(
+  constDeclarationMatch,
+  `Could not find \`const SEED_QUERY_KEYS = [...]\` in ${PAGE_PATH}.`,
+)
+const declaredKeys = new Set(
+  Array.from(
+    constDeclarationMatch[1].matchAll(/'([^']+)'|"([^"]+)"/g),
+    (m) => m[1] ?? m[2],
+  ),
+)
+
+for (const key of seedKeysInComponent) {
+  assert.ok(
+    declaredKeys.has(key),
+    `SEED_QUERY_KEYS in ${PAGE_PATH} is missing '${key}', which ` +
+      `seedFromQuery() in ${COMPONENT_PATH} treats as a one-shot ingredient ` +
+      'key -- updateStoryQuery() can still resurrect this specific key if ' +
+      'it wins the mount-order race against seedFromQuery().',
+  )
+}
+
+// The strip must run before the query is handed to router.replace(), not
+// after -- a `delete` placed after the `void router.replace(...)` call would
+// parse and reference SEED_QUERY_KEYS but do nothing for the navigation that
+// matters.
+const replaceIndex = body.indexOf('router.replace(')
+const stripIndex = body.indexOf('SEED_QUERY_KEYS')
+assert.ok(
+  replaceIndex === -1 || (stripIndex !== -1 && stripIndex < replaceIndex),
+  `${FN_NAME}() in ${PAGE_PATH} must strip SEED_QUERY_KEYS from the target ` +
+    'query object before calling router.replace(), not after.',
+)
+
+console.log(
+  'Storybook seed-query race guard contract passed: ' +
+    `${FN_NAME}() strips every one-shot ingredient key seedFromQuery() ` +
+    'consumes before rewriting route.query, so it can no longer win a ' +
+    "mount-order race and resurrect a key seedFromQuery()'s own replace() " +
+    'just stripped.',
+)

--- a/utils/scripts/verifyStorybookSeedQueryRaceGuard.mjs
+++ b/utils/scripts/verifyStorybookSeedQueryRaceGuard.mjs
@@ -92,9 +92,14 @@ assert.ok(
   constDeclarationMatch,
   `Could not find \`const SEED_QUERY_KEYS = [...]\` in ${PAGE_PATH}.`,
 )
+// Index via optional chaining (with a nullish fallback) even though the
+// assert.ok above already guarantees constDeclarationMatch is truthy here --
+// this repo's capture-group-guards contract requires every capture-group
+// index to be syntactically guarded at the point of use, not just asserted
+// earlier in the file.
 const declaredKeys = new Set(
   Array.from(
-    constDeclarationMatch[1].matchAll(/'([^']+)'|"([^"]+)"/g),
+    constDeclarationMatch?.[1]?.matchAll(/'([^']+)'|"([^"]+)"/g) ?? [],
     (m) => m[1] ?? m[2],
   ),
 )


### PR DESCRIPTION
## Bug

`storybook-page.vue`'s `seedFromQuery()` treats `?scenario=`, `?location=`, `?character=`, `?facet=` and `?reward=` as **one-shot**: it consumes the value into the setup draft, then strips it with its own `router.replace()` — "The query is cleared immediately so a reload, bookmark or share does not silently re-add the ingredient after the author removed it."

`content/storybook.md` mounts `:storybook-library-page`, which renders `<StorybookPage />` as a child, so **both** components' `onMounted()` hooks run on the same page load — the child's (`seedFromQuery`'s replace) first, then the parent's (`storybook-library-page.vue`'s own `onMounted`), same synchronous tick, no `await` between them.

`storybook-library-page.vue`'s `onMounted()` calls its own `updateStoryQuery()` whenever a session is already active and the URL has no `?story=` yet (`storyStore.session && !directId`) — exactly the case `seedFromQuery`'s own comment anticipates: arriving at a deep link such as `/storybook?character=<slug>` (`character-manager.vue`'s `startStoryWithCharacter()` sends exactly this, with no `story` param and no clearing of any existing session) while a previous story is still active in localStorage.

`router.replace()` resolves **asynchronously** — the reactive `route.query` object isn't updated until the navigation's guard pipeline finishes, which happens after this synchronous `onMounted` chain returns. So when `updateStoryQuery()` builds its target query from `{ ...route.query }`, it still sees the stale, not-yet-stripped ingredient key and re-includes it alongside `story=`. Its navigation is issued *after* `seedFromQuery`'s and wins, so the ingredient key resurfaces in the URL — undoing the one-shot consumption `seedFromQuery` just performed. On the next reload, bookmark, or share of that URL, `seedFromQuery()` fires again and silently re-adds a stale ingredient the reader has already moved past into whatever story is being set up at that point.

None of the 13 existing `verifyStorybook*` guards cover this — they address double art-job billing, answer/restart rollback, restart field-completeness, library-source consistency, and the character-slug matching bug, but not this router-replace race for the one-shot deep-link query cleanup.

## Fix

`updateStoryQuery()` in `components/pages/storybook-library-page.vue` now strips a `SEED_QUERY_KEYS` set (the same five ingredient keys `seedFromQuery()` consumes) from `route.query` on **every** query rewrite it makes, so its own navigation can never resurrect one regardless of ordering against `seedFromQuery()`'s.

## New guard

`utils/scripts/verifyStorybookSeedQueryRaceGuard.mjs`, wired via `.github/workflows/storybook-seed-query-race-contract.yml` (mirrors the existing `storybook-*-contract.yml` structure exactly). It asserts `updateStoryQuery()` strips `SEED_QUERY_KEYS` — derived from `seedFromQuery()`'s own five ingredient-key reads, so a future ingredient added there without updating this list fails loudly — before calling `router.replace()`.

(Note: none of the 13 prior storybook guards are wired into `package.json` — all 13 are invoked directly via `node`/`npx tsx` from their workflow's `run:` step. This PR follows that same actual convention rather than adding a `package.json` entry.)

## Verification

- **Standalone behavioral repro** (independent of Vue/router, simulating the real async-replace race) confirmed the bug pre-fix (`character=` resurfaces in the final URL alongside `story=`) and the fix post-fix (`character=` stays stripped).
- New guard **fails on pre-fix code, passes on post-fix code** — verified via `git stash` / `git stash pop` round-trip.
- All **13 pre-existing `verifyStorybook*` guards still pass** (12 `.mjs` + 1 `.ts`), no regression.
- `eslint` clean on changed/new files.
- `prettier --check` clean on the new files. The touched `.vue` file has **pre-existing** template-wrapping drift on `main` unrelated to this change (confirmed via `git show HEAD:... | prettier --check`, and by isolating a full-file `prettier --write` diff, which reformats only pre-existing template lines >80 chars and never touches the added script lines) — left untouched to keep this diff scoped to the actual fix.
- `vue-tsc --noEmit -p tsconfig.json` repo-wide (`npm run test`): clean.
- `git status --porcelain` showed exactly the three intended files before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139jcN3agcqM6CWqtFwvQhx

---
_Generated by [Claude Code](https://claude.ai/code/session_0139jcN3agcqM6CWqtFwvQhx)_