### PR TITLE
davinci/t-021 slice 7: group the dimension grid's ten stat pills for assistive tech

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -278,6 +278,12 @@ jobs:
       - name: Da Vinci choice-list guard
         run: npm run test:davinci-choice-list-guard
 
+      - name: Da Vinci dimension-group guard self-test
+        run: npm run test:davinci-dimension-group-guard-selftest
+
+      - name: Da Vinci dimension-group guard
+        run: npm run test:davinci-dimension-group-guard
+
       - name: Serendipity Voice poll guard self-test
         run: npm run test:serendipity-voice-poll-guard-selftest
 

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -137,7 +137,22 @@
             </button>
           </div>
 
-          <div class="grid grid-cols-5 gap-2 sm:grid-cols-10">
+          <!-- Ten individually-meaningful stat pills with no wrapping
+               role/aria-label tying them together as one set -- the same gap
+               kr-choice-list.vue's own doc comment (and this file's own
+               choice-list fix, slice 6) was written to close for the chapter
+               choices, now present here instead. Matches the established
+               convention for exactly this shape (a grid/row of individually
+               meaningful items grouped by role="group" + aria-label) already
+               used by kr-choice-list.vue itself, narrative-role-assigner.vue's
+               protagonist/antagonist lists, brainstorm-manager.vue's
+               direction/shape rows, and this project's own sibling
+               storybook-page.vue setup-progress nav. -->
+          <div
+            class="grid grid-cols-5 gap-2 sm:grid-cols-10"
+            role="group"
+            aria-label="Life dimensions"
+          >
             <div
               v-for="dim in DAVINCI_DIMENSIONS"
               :key="dim"

--- a/package.json
+++ b/package.json
@@ -91,6 +91,8 @@
     "test:davinci-resuming-status-guard": "tsx utils/scripts/verifyDaVinciResumingStatusGuard.ts",
     "test:davinci-choice-list-guard-selftest": "tsx utils/scripts/verifyDaVinciChoiceListGuard.test.ts",
     "test:davinci-choice-list-guard": "tsx utils/scripts/verifyDaVinciChoiceListGuard.ts",
+    "test:davinci-dimension-group-guard-selftest": "tsx utils/scripts/verifyDaVinciDimensionGroupGuard.test.ts",
+    "test:davinci-dimension-group-guard": "tsx utils/scripts/verifyDaVinciDimensionGroupGuard.ts",
     "test:serendipity-voice-poll-guard-selftest": "tsx utils/scripts/verifySerendipityVoicePollGuard.test.ts",
     "test:serendipity-voice-poll-guard": "tsx utils/scripts/verifySerendipityVoicePollGuard.ts",
     "test:serendipity-voice-cursor-reset-selftest": "tsx utils/scripts/verifySerendipityVoiceCursorReset.test.ts",

--- a/utils/scripts/verifyDaVinciDimensionGroupGuard.test.ts
+++ b/utils/scripts/verifyDaVinciDimensionGroupGuard.test.ts
@@ -1,0 +1,92 @@
+// /utils/scripts/verifyDaVinciDimensionGroupGuard.test.ts
+//
+// Regression test for checkDimensionGroupGuard() in
+// verifyDaVinciDimensionGroupGuard.ts (davinci/t-021 slice 7). Exercises the
+// real check against synthetic component-shaped fixtures covering: the
+// fixed shape (role="group" + aria-label="Life dimensions"), a
+// reverted-to-ungrouped regression, a group-with-no-label regression, and a
+// missing-region regression (the dimension grid removed entirely).
+import assert from 'node:assert/strict'
+
+import { checkDimensionGroupGuard } from './verifyDaVinciDimensionGroupGuard.js'
+
+function fixture(gridAttrs: string): string {
+  return `
+<template>
+  <div v-else-if="phase === 'playing' && run">
+    <div class="grid grid-cols-5 gap-2 sm:grid-cols-10" ${gridAttrs}>
+      <div
+        v-for="dim in DAVINCI_DIMENSIONS"
+        :key="dim"
+        :title="\`\${DIMENSION_LABELS[dim]}: \${statMap[dim] ?? 0}\`"
+      >
+        {{ DIMENSION_LABELS[dim] }}
+      </div>
+    </div>
+  </div>
+</template>
+`
+}
+
+const FIXED = fixture('role="group" aria-label="Life dimensions"')
+
+// Pre-fix shape: the grid container carries neither role nor aria-label.
+const UNGROUPED = fixture('')
+
+// role="group" present but the accessible name got dropped.
+const NO_LABEL = fixture('role="group"')
+
+// The dimension grid itself no longer exists at all.
+const REGION_REMOVED = `
+<template>
+  <div v-if="phase === 'ending'">
+    <p>This life has ended.</p>
+  </div>
+</template>
+`
+
+function run(): void {
+  const fixedErrors = checkDimensionGroupGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const ungroupedErrors = checkDimensionGroupGuard(UNGROUPED)
+  assert.equal(
+    ungroupedErrors.length,
+    2,
+    `expected the ungrouped fixture to fail both checks, got: ${JSON.stringify(ungroupedErrors)}`,
+  )
+  assert.ok(ungroupedErrors.some((e) => /no longer has role="group"/.test(e)))
+  assert.ok(
+    ungroupedErrors.some((e) =>
+      /no longer has aria-label="Life dimensions"/.test(e),
+    ),
+  )
+
+  const noLabelErrors = checkDimensionGroupGuard(NO_LABEL)
+  assert.equal(noLabelErrors.length, 1)
+  assert.ok(
+    noLabelErrors.some((e) =>
+      /no longer has aria-label="Life dimensions"/.test(e),
+    ),
+  )
+
+  const removedErrors = checkDimensionGroupGuard(REGION_REMOVED)
+  assert.equal(removedErrors.length, 1)
+  assert.ok(
+    removedErrors.some((e) =>
+      /Could not find the `v-for="dim in DAVINCI_DIMENSIONS"` marker/.test(e),
+    ),
+  )
+
+  console.log(
+    'Da Vinci dimension-group guard self-test passed: ungrouped, ' +
+      'no-label, and missing-region regressions all fail; the fixed ' +
+      'fixture passes.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyDaVinciDimensionGroupGuard.ts
+++ b/utils/scripts/verifyDaVinciDimensionGroupGuard.ts
@@ -1,0 +1,112 @@
+// /utils/scripts/verifyDaVinciDimensionGroupGuard.ts
+//
+// Regression guard (davinci/t-021 slice 7) -- the ten-pill dimension grid in
+// components/conductor/davinci-page.vue rendered each stat as an
+// individually meaningful pill (label + value, plus a hover-only :title),
+// but the grid container itself carried no role/aria-label tying the ten
+// pills together as one set. That is the exact gap kr-choice-list.vue's own
+// doc comment -- and this file's own slice-6 fix -- closed for the chapter
+// choices ("no role="group"/aria-label tying the options together as one
+// choice set"), just left open here for the dimension grid instead. The
+// same "group of individually meaningful items" shape gets role="group" +
+// aria-label elsewhere in the app: kr-choice-list.vue itself,
+// narrative-role-assigner.vue's protagonist/antagonist lists,
+// brainstorm-manager.vue's direction/shape rows, and this project's own
+// sibling storybook-page.vue setup-progress nav (aria-label="Story setup
+// progress").
+//
+// Fixed by giving the grid container role="group" and
+// aria-label="Life dimensions".
+//
+// This asserts the textual shape of that fix stays in place -- deliberately
+// scoped to this one template region over a general-purpose static
+// analyzer, mirroring this project's other narrow textual guards (see
+// verifyDaVinciDimensionToneGuard.ts, verifyDaVinciChoiceListGuard.ts).
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const COMPONENT_PATH = join(
+  repositoryRoot,
+  'components/conductor/davinci-page.vue',
+)
+
+// Anchored on the `v-for="dim in DAVINCI_DIMENSIONS"` pill loop, which sits
+// immediately inside the grid container in both the old and new markup, so
+// this guard can report *how* the grid regressed (missing entirely vs.
+// still present but ungrouped) instead of just "not found".
+const PILL_LOOP_MARKER = 'v-for="dim in DAVINCI_DIMENSIONS"'
+
+function extractDimensionGridRegion(content: string): string | null {
+  const loopIndex = content.indexOf(PILL_LOOP_MARKER)
+  if (loopIndex === -1) return null
+
+  // The grid container's opening tag sits some distance *before* the loop
+  // marker (the v-for lives on the pill div, one level in), and the pills'
+  // own attributes sit some distance after it. Slicing a window around the
+  // marker comfortably covers the grid container's opening tag on both
+  // sides without needing a real HTML parser for a narrow textual check.
+  const start = Math.max(0, loopIndex - 400)
+  const end = Math.min(content.length, loopIndex + 400)
+  return content.slice(start, end)
+}
+
+export function checkDimensionGroupGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const region = extractDimensionGridRegion(content)
+  if (!region) {
+    errors.push(
+      `Could not find the \`${PILL_LOOP_MARKER}\` marker in ` +
+        'davinci-page.vue -- has the dimension grid been restructured or ' +
+        'removed? If so, this guard needs to move with it.',
+    )
+    return errors
+  }
+
+  if (!region.includes('role="group"')) {
+    errors.push(
+      'The dimension grid container no longer has role="group" -- the ' +
+        'ten stat pills are no longer tied together as one named set for ' +
+        'assistive tech, the exact regression this guard exists to catch.',
+    )
+  }
+
+  if (!region.includes('aria-label="Life dimensions"')) {
+    errors.push(
+      'The dimension grid container no longer has ' +
+        'aria-label="Life dimensions" -- the group has lost its accessible ' +
+        'name.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(COMPONENT_PATH, 'utf8')
+  const errors = checkDimensionGroupGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Da Vinci dimension-group guard contract failed in davinci-page.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Da Vinci dimension-group guard contract passed: the dimension grid ' +
+      'still ties its ten stat pills together with role="group" + ' +
+      'aria-label="Life dimensions" instead of exposing them as ten ' +
+      'unrelated items.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Gap found

`components/conductor/davinci-page.vue`'s dimension grid renders ten individually-meaningful stat pills (dimension label + value, each with a hover-only `:title` tooltip), but the grid **container** carried no `role`/`aria-label` tying the ten pills together as one named set.

This is the exact same gap slice 6 fixed for the chapter choices — kr-choice-list.vue's own doc comment: *"no role="group"/aria-label tying the options together as one choice set"* — just left open here for the dimension grid instead.

Confirmed as a genuine outlier by checking the established convention for this shape (a grid/row of individually meaningful items grouped by `role="group"` + `aria-label`) elsewhere in the app:
- `components/narrative/kr-choice-list.vue` — `role="group"` + `:aria-label="label"`
- `components/narrative/narrative-role-assigner.vue` — `role="group" aria-label="Protagonist(s)"` / `"Antagonist(s)"`
- `components/brainstorm/brainstorm-manager.vue` — `role="group" aria-label="Creative direction"` / `"Batch shape"`
- This project's own sibling `components/conductor/storybook-page.vue` setup-progress nav — `aria-label="Story setup progress"`

`davinci-page.vue`'s dimension grid (`components/conductor/davinci-page.vue:140`) was the one comparable grid with no group semantics at all.

## Fix

Added `role="group"` and `aria-label="Life dimensions"` to the dimension grid's container `<div>`.

## New guard

`utils/scripts/verifyDaVinciDimensionGroupGuard.ts` + `.test.ts`, following the exact pattern of the five existing `verifyDaVinci*Guard.ts` files (anchors on the `v-for="dim in DAVINCI_DIMENSIONS"` marker, checks the surrounding region for `role="group"` and `aria-label="Life dimensions"`). Wired into:
- `package.json`: `test:davinci-dimension-group-guard-selftest`, `test:davinci-dimension-group-guard`
- `.github/workflows/contract-tests.yml`: both steps added after the existing `Da Vinci choice-list guard` steps

## Verification performed

- New guard self-test passes (fixed/ungrouped/no-label/missing-region fixtures).
- Guard fails against the pre-fix component (verified via `git stash` on just the `.vue` file) and passes post-fix (fix restored afterward).
- All 6 prior davinci guards + selftests still pass: dimension-tone, narration-error-tone, resolve-panel, narrating-status, resuming-status, choice-list.
- `npm run test:davinci-narration` passes (12/12 checks).
- `npm run test:layout-contract` holds — no new violations (an unrelated pre-existing baseline improvement of -14 entries in other components showed up, untouched by this PR).
- `eslint` clean on touched files.
- `prettier --check` clean on touched files (ran `--write` once on the new `.test.ts` to normalize, then re-checked clean).
- `npx vue-tsc --noEmit` exits 0 repo-wide.
- `git status --porcelain` shows exactly the 5 intended files: the guard `.ts`/`.test.ts`, `davinci-page.vue`, `package.json`, `contract-tests.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018eXC6MeygzoN3UbsWAetN1

---
_Generated by [Claude Code](https://claude.ai/code/session_018eXC6MeygzoN3UbsWAetN1)_