### PR TITLE
alexa-integration/t-015: ack successful art drafts back through the relay

### DIFF
--- a/stores/serendipityVoiceStore.ts
+++ b/stores/serendipityVoiceStore.ts
@@ -203,6 +203,11 @@ export const useSerendipityVoiceStore = defineStore(
       }
 
       // Draft only: surface the request for review. Never generate or publish.
+      // Every other successful command target (clear, animation on/off/
+      // toggle, theme set) sends postAck() so the voice side gets a spoken
+      // confirmation -- a successful art draft did not, leaving a spoken
+      // "generate art of X" request with no acknowledgement at all even
+      // though it landed. Ack it the same way the other targets do.
       const request: VoiceArtRequest = {
         id: command.id,
         prompt: command.prompt ?? command.spokenText,
@@ -215,6 +220,9 @@ export const useSerendipityVoiceStore = defineStore(
       artRequests.value.push(request)
       lastAppliedText.value = `art draft: ${request.prompt}`
       pushLocalMessage('system', `Art draft received: ${request.prompt}`)
+      void postAck(
+        `Serendipity view: art draft received for "${request.prompt}".`,
+      )
     }
 
     function applyCommand(command: VoiceBusCommand): void {

--- a/utils/scripts/verifySerendipityVoiceActionGuard.test.ts
+++ b/utils/scripts/verifySerendipityVoiceActionGuard.test.ts
@@ -12,6 +12,7 @@ import assert from 'node:assert/strict'
 
 import {
   checkSerendipityVoiceActionGuard,
+  checkSerendipityVoiceArtAckGuard,
   checkSerendipityVoiceErrorReportingGuard,
 } from './verifySerendipityVoiceActionGuard.js'
 
@@ -354,6 +355,58 @@ function runErrorReportingSelfTest(): void {
   )
 }
 
+// --- Fixtures for checkSerendipityVoiceArtAckGuard() (t-015, 2026-08-18) ---
+// Distinct from all fixtures above: this exercises the "success path never
+// acknowledges" gap on applyArtCommand(), not action/target mismatches or
+// false-success no-match branches.
+
+function artAckFixture(successAck: string): string {
+  return `
+    function applyArtCommand(command: VoiceBusCommand): void {
+      if (command.action !== 'draft') {
+        pushLocalMessage('system', \`Ignored unsupported art action: \${command.action}\`)
+        return
+      }
+
+      const request = { id: command.id, prompt: command.prompt ?? command.spokenText, at: command.at }
+      artRequests.value.push(request)
+      lastAppliedText.value = \`art draft: \${request.prompt}\`
+      pushLocalMessage('system', \`Art draft received: \${request.prompt}\`)
+      ${successAck}
+    }
+  `
+}
+
+const ART_ACK_FIXED = artAckFixture(
+  'void postAck(`Serendipity view: art draft received for "${request.prompt}".`)',
+)
+const ART_ACK_MISSING = artAckFixture('')
+
+function runArtAckSelfTest(): void {
+  const fixedErrors = checkSerendipityVoiceArtAckGuard(ART_ACK_FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed art-ack fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const missingErrors = checkSerendipityVoiceArtAckGuard(ART_ACK_MISSING)
+  assert.equal(missingErrors.length, 1)
+  assert.ok(/no longer calls postAck\(\)/.test(missingErrors[0]!))
+
+  const missingFnErrors = checkSerendipityVoiceArtAckGuard(
+    'function someOtherFunction(): void {}',
+  )
+  assert.equal(missingFnErrors.length, 1)
+  assert.ok(/Could not find a function named/.test(missingFnErrors[0]!))
+
+  console.log(
+    'Serendipity Voice art-ack guard self-test passed: a successful art ' +
+      'draft that never calls postAck() fails, the fixed fixture passes, ' +
+      'and a missing-function fixture fails clearly.',
+  )
+}
+
 function run(): void {
   const fixedErrors = checkSerendipityVoiceActionGuard(FIXED)
   assert.deepEqual(
@@ -408,3 +461,4 @@ function run(): void {
 
 run()
 runErrorReportingSelfTest()
+runArtAckSelfTest()

--- a/utils/scripts/verifySerendipityVoiceActionGuard.ts
+++ b/utils/scripts/verifySerendipityVoiceActionGuard.ts
@@ -51,6 +51,18 @@
 // the lastError/pushLocalMessage report, or the postAck() gating cannot
 // reintroduce a false "Applied"/"is now X" acknowledgement the way t-015's
 // and t-020's bugs did for the mismatched-action case.
+//
+// Extended again (alexa-integration/t-015, 2026-08-18 cycle) with a third,
+// distinct contract: checkSerendipityVoiceArtAckGuard() below. The two
+// contracts above are both about *false* acknowledgements. This one is the
+// opposite gap: a *missing* one. Every other successful command target
+// (clear, animation on/off/toggle, theme set) calls postAck() so the voice
+// side gets a spoken confirmation; applyArtCommand()'s success path pushed
+// the draft and a local feed message but never called postAck() at all, so
+// a spoken "generate art of X" request that fully succeeded still got no
+// acknowledgement back through the relay. Fixed by calling postAck() the
+// same way the other three success paths do; this guard keeps a future edit
+// from silently dropping that call again.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -434,11 +446,56 @@ export function checkSerendipityVoiceErrorReportingGuard(
   return errors
 }
 
+// Checks the "successful command, but no voice acknowledgement" gap --
+// see the file-header addendum above (alexa-integration/t-015, 2026-08-18
+// cycle) for what this protects against. Distinct from both guards above:
+// those catch a *false* postAck(); this one catches a *missing* one on
+// applyArtCommand()'s only success path.
+export function checkSerendipityVoiceArtAckGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const artBody = extractFunctionSource(content, 'applyArtCommand')
+  if (!artBody) {
+    errors.push(
+      'Could not find a function named applyArtCommand() -- has it been ' +
+        'renamed, removed, or restructured? If so, this guard (and the ' +
+        'missing-acknowledgement contract it protects) needs to move with ' +
+        'it.',
+    )
+    return errors
+  }
+
+  const pushIndex = artBody.search(/artRequests\.value\.push\(request\)/)
+  if (pushIndex === -1) {
+    errors.push(
+      'applyArtCommand() no longer contains `artRequests.value.push(' +
+        'request)` -- has the draft-recording shape changed? This guard ' +
+        'assumes that structure to locate the success path.',
+    )
+    return errors
+  }
+
+  const postAckIndex = searchAfter(artBody, /postAck\(/, pushIndex)
+  if (postAckIndex === -1) {
+    errors.push(
+      "applyArtCommand()'s success path no longer calls postAck() -- " +
+        'every other successful command target (clear, animation on/off/' +
+        'toggle, theme set) acknowledges back through the relay so the ' +
+        'voice side can confirm; a successful art draft must too, or a ' +
+        'spoken "generate art of X" request that fully succeeded gets no ' +
+        'acknowledgement at all.',
+    )
+  }
+
+  return errors
+}
+
 function main(): void {
   const content = readFileSync(STORE_PATH, 'utf8')
   const actionErrors = checkSerendipityVoiceActionGuard(content)
   const errorReportingErrors = checkSerendipityVoiceErrorReportingGuard(content)
-  const errors = [...actionErrors, ...errorReportingErrors]
+  const artAckErrors = checkSerendipityVoiceArtAckGuard(content)
+  const errors = [...actionErrors, ...errorReportingErrors, ...artAckErrors]
 
   if (errors.length) {
     console.error(
@@ -454,9 +511,10 @@ function main(): void {
     'Serendipity Voice action guard contract passed: applyCommand(), ' +
       'applyThemeCommand(), and applyArtCommand() all reject action values ' +
       "that don't apply to their target instead of silently reporting a " +
-      'false "applied" message, and the unmatched-effect/unknown-theme ' +
+      'false "applied" message, the unmatched-effect/unknown-theme ' +
       'no-match branches still report failure (not a false success) before ' +
-      'returning.',
+      "returning, and applyArtCommand()'s success path still acknowledges " +
+      'back through the relay like every other successful command target.',
   )
 }
 


### PR DESCRIPTION
### Task
alexa-integration/t-015: Polish and upgrade Voice Lab front-end surface (kind: software)

### What changed / what I produced
- `stores/serendipityVoiceStore.ts`: `applyArtCommand()`'s success path now calls `postAck()`, matching every other successful command target (clear, animation on/off/toggle, theme set). Before this fix, a spoken "generate art of X" request that fully succeeded (pushed to `artRequests`, logged to the local feed) sent no acknowledgement back through the relay at all — the Echo/relay side had no way to confirm the request landed.
- `utils/scripts/verifySerendipityVoiceActionGuard.ts`: added a third guard, `checkSerendipityVoiceArtAckGuard()`, following the existing convention from t-020/t-021 (extending the same file rather than adding a new one), protecting this fix against a future regression.
- `utils/scripts/verifySerendipityVoiceActionGuard.test.ts`: added `runArtAckSelfTest()` with fixed/missing/missing-function fixtures for the new guard.

### How I verified
- `npm run test:serendipity-voice-action-guard-selftest` and `npm run test:serendipity-voice-action-guard` — both green, including the new art-ack checks.
- Both sibling guards (`test:serendipity-voice-poll-guard(-selftest)`, `test:serendipity-voice-cursor-reset(-selftest)`) still pass.
- `npx eslint` on all 3 changed files — clean.
- `npx prettier --check` on all 3 changed files — clean (after one `--write` pass to match project style).
- Full-project `npm run test` (`vue-tsc --noEmit`) — clean, no errors.
- `git status --porcelain` confirmed the diff is scoped to exactly these 3 files.

### Stakes
reversible

### Flags for Reviewer
- This is the same recurring-audit shape this task has followed for several cycles now (t-016 → t-021): read the store fresh, exclude the already-fixed issues, find one more distinct gap. This cycle's gap is a *missing* acknowledgement (as opposed to t-015/t-020's *false* acknowledgements, and t-021's error-reporting gaps) — a new failure class for this file, not a repeat.
- I also considered a related smaller issue in `applyCommand()`: when `action === 'toggle'` turns an animation effect *off*, `setSurfacePlacement(region, 'front')` still runs unconditionally (only the literal `'off'` action skips it). This is a minor placement inconsistency, not a false-success report like the others, so I left it out of scope for this pass — noting it here in case it's worth its own follow-up.
- Step (1) of this task (dashboard-tab/tutorial art) remains blocked on the render backlog, per the prior cycle's note — unrelated to this fix.

### Kaizen suggestion
Extend `applyCommand()`'s animation branch so a `toggle` that turns an effect *off* skips `setSurfacePlacement(region, 'front')` the same way the literal `'off'` action does — right now only `action === 'off'` is excluded, so a toggle-to-off still forces that fx region to "front" placement even though no effect is active there anymore.

### Notes for reviewer
Rearmed alexa-integration/t-015 to `ready` in conductor after this cycle (recurring-audit convention, same as t-016/t-020's cycles) — no further scope found on this pass beyond the one fix above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EJiq2ZuRbfrsKvyd7H6WTH)_