### PR TITLE
media-watchlist/t-006: surface the rewatch count in the watchlist UI

### DIFF
--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -527,6 +527,15 @@
               >
                 <Icon name="kind-icon:star" class="size-3" />{{ entry.rating }}
               </span>
+              <span
+                v-if="entry.rewatch && entry.rewatch >= 2"
+                class="badge badge-ghost badge-sm gap-0.5 rounded-lg"
+                :title="`Watched ${entry.rewatch}x`"
+              >
+                <Icon name="kind-icon:history" class="size-3" />{{
+                  entry.rewatch
+                }}x
+              </span>
               <span class="badge badge-ghost badge-sm rounded-lg">{{
                 entry.mediaType
               }}</span>

--- a/components/watchlist/watchlist-entry-detail.vue
+++ b/components/watchlist/watchlist-entry-detail.vue
@@ -50,6 +50,12 @@
         </dt>
         <dd>{{ entry.year }}</dd>
       </div>
+      <div v-if="rewatchLabel">
+        <dt class="text-xs font-semibold uppercase text-base-content/45">
+          Rewatch
+        </dt>
+        <dd>{{ rewatchLabel }}</dd>
+      </div>
       <div class="col-span-2">
         <dt class="text-xs font-semibold uppercase text-base-content/45">
           Rating
@@ -225,6 +231,7 @@ export type MediaEntryDetail = {
   review: string | null
   reviewPublic: boolean
   rating: number | null
+  rewatch: number | null
   externalId: string | null
   externalUrl: string | null
 }
@@ -304,6 +311,21 @@ const consumedLabel = computed(() => {
     { month: 'long' },
   )
   return props.entry.watchedDay ? `${month} ${props.entry.watchedDay}` : month
+})
+
+// `rewatch` is the total watch count the source marked for this entry (e.g.
+// "x2" -> 2); it only exists on rows where the source explicitly noted a
+// repeat viewing, so 1 never appears here (see BROWSE-UX.md schema note).
+const rewatchLabel = computed(() => {
+  const count = props.entry.rewatch
+  if (!count || count < 2) return ''
+  const suffix =
+    count % 10 === 2 && count % 100 !== 12
+      ? 'nd'
+      : count % 10 === 3 && count % 100 !== 13
+        ? 'rd'
+        : 'th'
+  return `${count}${suffix} viewing`
 })
 
 let autoSaveTimer: ReturnType<typeof setTimeout> | undefined


### PR DESCRIPTION
### Task
media-watchlist/t-006: BROWSE-UX.md re-audit slice — surface `rewatch` in the UI (kind: content, but this slice is ordinary reversible software)

### What changed / what I produced
- `MediaEntryDetail.rewatch: number | null` — the field was already returned by `GET /api/media-entries` (no `select` clause, so `findMany` returns all scalars) and already exported in CSV, but was missing from the frontend type entirely, so it never reached the UI.
- `watchlist-entry-detail.vue`: shows an ordinal "Nth viewing" label next to Year, same conditional `dl` row pattern as the existing Rating field.
- `watchlist-browse.vue`: small ghost badge (`history` icon + "Nx") on the entry card next to the existing rating badge, shown only when `rewatch >= 2`.

No API/schema changes — purely surfacing data the backend already returns. `rewatch` stays read-only (matches its "set during enrichment/import" schema comment, unlike the user-editable `rating`).

### How I verified
- `eslint` on both changed files: clean
- `prettier --check` on both changed files: clean
- Full-project `vue-tsc --noEmit`: 0 errors
- `git diff --stat` against `main`: exactly the 2 intended files, 31 insertions, 0 deletions

### Stakes
reversible

### Flags for Reviewer
- The real corpus's source data (`media_list.md`) doesn't currently contain any explicit rewatch markers, so `rewatch` is null for every existing row today — this change makes the field visible for any future import/entry that does set it, rather than fixing a currently-visible bug. Low risk, additive-only.

### Kaizen suggestion
BROWSE-UX.md's spec is now fully implemented end-to-end (search, all filters, all sort modes, stats view incl. year-over-year, CSV export, review editor with auto-save/publish, related entries, external links, rating, and now rewatch). A future cycle should treat this task's "step (4) further evolution" as exhausted against the current spec, and either retire the recurring pattern for this project or write a fresh BROWSE-UX-v2 addendum before continuing to pick it up.

### Notes for reviewer
Conductor task media-watchlist/t-006 stays `status: ready` after this merges, per this project's established "polish and upgrade" recurring-task convention (kept ready across many prior cycles rather than reaching `done`).

---
_Generated by [Claude Code](https://claude.ai/code/session_017wfD91NNpkxCY8dH87mvWF)_