### PR TITLE
feat(brainstorm): ground generation on Dream and Scenario sources (brainstorm/t-014)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -314,6 +314,9 @@ jobs:
       - name: Brainstorm source adapter contract
         run: npm run test:brainstorm-source-adapters
 
+      - name: Brainstorm source context contract
+        run: npm run test:brainstorm-source-context
+
       - name: mysql:// URL parser contract
         run: npm run test:parse-mysql-url
 

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "test:pack-manifest": "tsx utils/scripts/verifyPackManifest.test.ts",
     "test:pitch-detector-accuracy": "tsx utils/scripts/verifyPitchDetectorAccuracy.test.ts",
     "test:brainstorm-source-adapters": "tsx utils/scripts/verifyBrainstormSourceAdapters.test.ts",
+    "test:brainstorm-source-context": "tsx utils/scripts/verifyBrainstormSourceContext.ts",
     "test:pack-scaffold-extraction": "tsx utils/scripts/verifyPackScaffoldExtraction.test.ts",
     "test:parse-mysql-url": "tsx utils/scripts/verifyParseMysqlUrl.ts",
     "test:newsfeed-aggregation": "tsx utils/scripts/verifyNewsfeedAggregation.ts",

--- a/server/utils/brainstorm/brainstormSourceContext.ts
+++ b/server/utils/brainstorm/brainstormSourceContext.ts
@@ -9,9 +9,10 @@
 // picker just showed what you'd picked). This resolves a ref into a compact,
 // privacy-checked trait summary the prompt can actually use.
 //
-// Only Character is wired today. Dream and further entity types are
-// brainstorm/t-014's scope ("Ship Dream-aware brainstorming and expand
-// adapter coverage") -- add a resolver to SOURCE_CONTEXT_RESOLVERS below and
+// conductor brainstorm/t-014: added dreamContext and scenarioContext,
+// following the identical fetch-minimal-select -> canView -> formatXContext
+// shape as characterContext below. Reward, Bot, Project, and Prompt remain
+// documented candidates for the next entity type -- add a resolver here and
 // resolveBrainstormSourceContext picks it up with no other change needed,
 // same "just another registry entry" shape as
 // stores/helpers/brainstormSourceAdapters.ts.
@@ -24,7 +25,11 @@ import prisma from '../prisma'
 import { canView } from '../contentAccess'
 import type { AuthUser } from '../authUser'
 import type { BrainstormSourceRef } from '../../../types/brainstorm'
-import { formatCharacterContext } from './brainstormSourceContextKit'
+import {
+  formatCharacterContext,
+  formatDreamContext,
+  formatScenarioContext,
+} from './brainstormSourceContextKit'
 
 async function characterContext(
   id: number,
@@ -40,6 +45,79 @@ async function characterContext(
   return formatCharacterContext(character)
 }
 
+async function dreamContext(
+  id: number,
+  viewer: AuthUser | null,
+): Promise<string | null> {
+  const dream = await prisma.dream.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      title: true,
+      dreamType: true,
+      description: true,
+      pitch: true,
+      flavorText: true,
+      artPrompt: true,
+      isPublic: true,
+      userId: true,
+      packId: true,
+      Characters: { select: { name: true }, take: 6 },
+      Rewards: { select: { name: true, rewardType: true }, take: 6 },
+      Scenarios: {
+        select: {
+          title: true,
+          description: true,
+          locations: true,
+          tier: true,
+          difficulty: true,
+        },
+        take: 6,
+      },
+    },
+  })
+  if (!dream) return null
+  // Same authorization the dreams/:id.get route's assertDreamAccess applies
+  // for the "view" action (owner, admin, or isPublic) -- a ref the requesting
+  // user cannot view must never leak Dream/Scenario/Reward/Character details
+  // into a generation prompt just because they happened to know its id. The
+  // route's additional PACK-grant fallback (digital-storefront/t-004) is not
+  // replicated here -- a PACK-only-gated Dream simply degrades to ungrounded
+  // generation, never a leak.
+  if (!(await canView(dream, null, viewer))) return null
+
+  return formatDreamContext(dream)
+}
+
+async function scenarioContext(
+  id: number,
+  viewer: AuthUser | null,
+): Promise<string | null> {
+  const scenario = await prisma.scenario.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      locations: true,
+      tier: true,
+      difficulty: true,
+      genres: true,
+      isPublic: true,
+      userId: true,
+      Characters: { select: { name: true }, take: 6 },
+    },
+  })
+  if (!scenario) return null
+  // The scenarios/:id.get route itself applies no record-level view check
+  // today (only its linked Facets are visibility-filtered) -- revalidate
+  // independently here rather than inherit that gap, matching every other
+  // resolver in this registry.
+  if (!(await canView(scenario, null, viewer))) return null
+
+  return formatScenarioContext(scenario)
+}
+
 type BrainstormSourceContextResolver = (
   id: number,
   viewer: AuthUser | null,
@@ -50,6 +128,8 @@ const SOURCE_CONTEXT_RESOLVERS: Record<
   BrainstormSourceContextResolver
 > = {
   character: characterContext,
+  dream: dreamContext,
+  scenario: scenarioContext,
 }
 
 /**

--- a/server/utils/brainstorm/brainstormSourceContextKit.ts
+++ b/server/utils/brainstorm/brainstormSourceContextKit.ts
@@ -1,10 +1,19 @@
 // /server/utils/brainstorm/brainstormSourceContextKit.ts
 //
-// The pure half of brainstormSourceContext.ts's Character-grounding logic --
+// The pure half of brainstormSourceContext.ts's entity-grounding logic --
 // no Prisma/canView/Nuxt alias imports, so it can be exercised directly by
 // utils/scripts/verifyBrainstormSourceContext.ts with plain tsx, the same
 // split brainstormSourceAdapterKit.ts uses for the client-side adapter
 // registry (no Pinia imports there either, for the identical reason).
+//
+// conductor brainstorm/t-014: added formatDreamContext and
+// formatScenarioContext alongside the original formatCharacterContext
+// (brainstorm/t-013), same shape -- a plain row type plus a joinFacts-based
+// composer bounded to MAX_CONTEXT_LENGTH. To ground a further entity type
+// (Reward, Bot, Project, Prompt are the documented remaining candidates —
+// see brainstormSourceContext.ts), add its row type and formatXContext here,
+// then a matching fetch+canView resolver in brainstormSourceContext.ts's
+// SOURCE_CONTEXT_RESOLVERS -- no other change needed.
 
 /** The Character fields formatCharacterContext actually reads. */
 export type CharacterContextRow = {
@@ -63,6 +72,134 @@ export function formatCharacterContext(character: CharacterContextRow): string {
     traits && `Traits: ${traits}.`,
     voice && `Voice: ${voice}.`,
     character.backstory && `Backstory: ${character.backstory}`,
+  ].filter((line): line is string => Boolean(line))
+
+  return lines.join('\n').slice(0, MAX_CONTEXT_LENGTH)
+}
+
+/** A Scenario row as linked from a Dream, or fetched directly for its own context. */
+export type DreamScenarioRow = {
+  title: string
+  description?: string | null
+  locations?: string | null
+  tier?: string | null
+  difficulty?: number | null
+}
+
+/** A Reward row as linked from a Dream. */
+export type DreamRewardRow = {
+  name: string
+  rewardType: string
+}
+
+/** A Character row as linked from a Dream. */
+export type DreamCharacterRow = {
+  name: string
+}
+
+/** The Dream fields formatDreamContext actually reads. */
+export type DreamContextRow = {
+  title: string
+  dreamType: string
+  description?: string | null
+  pitch?: string | null
+  flavorText?: string | null
+  artPrompt?: string | null
+  Characters?: DreamCharacterRow[]
+  Rewards?: DreamRewardRow[]
+  Scenarios?: DreamScenarioRow[]
+}
+
+const MAX_LINKED_ROWS = 6
+
+/** Compose one Scenario's tier/difficulty/locations/description into one line. */
+function formatScenarioLine(scenario: DreamScenarioRow): string {
+  const meta = joinFacts(
+    scenario.tier && `tier: ${scenario.tier}`,
+    typeof scenario.difficulty === 'number' &&
+      `difficulty: ${scenario.difficulty}`,
+  )
+  const heading = [
+    scenario.title,
+    scenario.locations && `@ ${scenario.locations}`,
+    meta && `(${meta})`,
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join(' ')
+  return joinFacts(heading, scenario.description)
+}
+
+/**
+ * Compose a Dream row into a compact, multi-facet summary for the prompt:
+ * the title/type, its premise and sensory atmosphere, its visual concept,
+ * and the locations/encounters/threats/rewards/characters carried by its
+ * linked Scenarios, Rewards, and Characters. Bounded to MAX_CONTEXT_LENGTH
+ * so one richly-linked Dream cannot blow out the prompt/cost budget.
+ */
+export function formatDreamContext(dream: DreamContextRow): string {
+  const premise = joinFacts(dream.pitch, dream.description)
+  const characters = (dream.Characters || [])
+    .map((character) => character.name)
+    .filter(Boolean)
+    .slice(0, MAX_LINKED_ROWS)
+    .join(', ')
+  const rewards = (dream.Rewards || [])
+    .map((reward) => `${reward.name} (${reward.rewardType.toLowerCase()})`)
+    .slice(0, MAX_LINKED_ROWS)
+    .join(', ')
+  const scenarioLines = (dream.Scenarios || [])
+    .slice(0, MAX_LINKED_ROWS)
+    .map(formatScenarioLine)
+    .filter(Boolean)
+
+  const lines = [
+    `Dream: ${dream.title} (${dream.dreamType.toLowerCase()}).`,
+    // Premise/sensory detail/visual concept are freeform prose (like
+    // Character.backstory below) and are not given a forced trailing
+    // period -- the source text supplies its own punctuation.
+    premise && `Premise: ${premise}`,
+    dream.flavorText && `Sensory detail: ${dream.flavorText}`,
+    dream.artPrompt && `Visual concept: ${dream.artPrompt}`,
+    // Characters/Rewards are joined fragments (like Traits/Voice above),
+    // so a forced trailing period is correct here.
+    characters && `Characters: ${characters}.`,
+    rewards && `Rewards: ${rewards}.`,
+    scenarioLines.length &&
+      `Locations, encounters and threats: ${scenarioLines.join(' / ')}`,
+  ].filter((line): line is string => Boolean(line))
+
+  return lines.join('\n').slice(0, MAX_CONTEXT_LENGTH)
+}
+
+/** The Scenario fields formatScenarioContext actually reads. */
+export type ScenarioContextRow = DreamScenarioRow & {
+  genres?: string | null
+  Characters?: DreamCharacterRow[]
+}
+
+/**
+ * Compose a Scenario row into a compact encounter summary for the prompt:
+ * the location/tier/difficulty heading, its genre, its description, and any
+ * linked Characters. Bounded to MAX_CONTEXT_LENGTH like every other
+ * formatXContext helper.
+ */
+export function formatScenarioContext(scenario: ScenarioContextRow): string {
+  const characters = (scenario.Characters || [])
+    .map((character) => character.name)
+    .filter(Boolean)
+    .slice(0, MAX_LINKED_ROWS)
+    .join(', ')
+
+  // formatScenarioLine ends in freeform description prose when one is
+  // present (already self-punctuated, like Character.backstory) but in a
+  // bare title/fragment when it's not -- only the fragment case gets a
+  // forced trailing period.
+  const heading = `Scenario: ${formatScenarioLine(scenario)}`
+
+  const lines = [
+    scenario.description ? heading : `${heading}.`,
+    scenario.genres && `Genre: ${scenario.genres}.`,
+    characters && `Characters: ${characters}.`,
   ].filter((line): line is string => Boolean(line))
 
   return lines.join('\n').slice(0, MAX_CONTEXT_LENGTH)

--- a/stores/helpers/brainstormSourceAdapters.ts
+++ b/stores/helpers/brainstormSourceAdapters.ts
@@ -12,18 +12,19 @@
 //       than a bespoke brainstorm-specific endpoint, and
 //   (b) search that entity type for a picker UI.
 //
-// Start with Character and Dream -- the two entity types Brainstorm already
-// has typed hooks into (BrainstormSourceRef.modelType is a free string, but
-// these two are the only ones with real adapters so far). Scenario, Reward,
-// Bot, Project, and Prompt can each register a BrainstormSourceAdapter the
-// same way, with no new API surface and no bespoke endpoint -- just another
-// entry in BRAINSTORM_SOURCE_ADAPTERS backed by that entity's existing store.
+// Started with Character and Dream (BrainstormSourceRef.modelType is a free
+// string; these were the first two with real adapters). Scenario joined them
+// in brainstorm/t-014. Reward, Bot, Project, and Prompt can each register a
+// BrainstormSourceAdapter the same way, with no new API surface and no
+// bespoke endpoint -- just another entry in BRAINSTORM_SOURCE_ADAPTERS
+// backed by that entity's existing store.
 //
 // The store-agnostic dispatch/fallback logic lives in
 // brainstormSourceAdapterKit.ts (no Pinia imports, unit-testable with plain
 // tsx) and is re-exported here bound to the real registry below.
 import { useCharacterStore } from '@/stores/characterStore'
 import { useDreamStore } from '@/stores/dreamStore'
+import { useScenarioStore } from '@/stores/scenarioStore'
 import { resolveArtImageSrc } from '@/utils/artImageSrc'
 import {
   fetchFreshSourceRows,
@@ -146,6 +147,51 @@ const dreamAdapter: BrainstormSourceAdapter = {
   },
 }
 
+const scenarioAdapter: BrainstormSourceAdapter = {
+  modelType: 'scenario',
+  label: 'Scenario',
+  async resolve(ref) {
+    if (!ref.id) return null
+    const store = useScenarioStore()
+    // force=true for the same reason characterAdapter forces its fetch: a
+    // cached/localStorage Scenario can predate an auth transition.
+    const scenario = await store.fetchScenarioById(ref.id, true)
+    if (!scenario) return null
+
+    return {
+      modelType: 'scenario',
+      id: scenario.id,
+      title: scenario.title || `Scenario #${scenario.id}`,
+      subtitle: scenario.locations || scenario.tier || undefined,
+      thumbnailUrl: scenario.imagePath || null,
+    }
+  },
+  async search(query) {
+    const store = useScenarioStore()
+    // Same fail-closed contract as characterAdapter/dreamAdapter: a failed
+    // fresh fetch must never fall back to searching a possibly-stale cache.
+    const freshScenarios = await fetchFreshSourceRows(
+      () => store.fetchScenarios(true),
+      () => Boolean(store.lastError),
+    )
+
+    return freshScenarios
+      .filter((scenario) =>
+        matchesQuery(
+          [scenario.title, scenario.locations, scenario.tier, scenario.group],
+          query,
+        ),
+      )
+      .slice(0, SEARCH_RESULT_LIMIT)
+      .map((scenario) => ({
+        modelType: 'scenario',
+        id: scenario.id,
+        title: scenario.title || `Scenario #${scenario.id}`,
+        subtitle: scenario.locations || undefined,
+      }))
+  },
+}
+
 /** The adapter registry. Keys are lowercase modelType strings. */
 export const BRAINSTORM_SOURCE_ADAPTERS: Record<
   string,
@@ -153,6 +199,7 @@ export const BRAINSTORM_SOURCE_ADAPTERS: Record<
 > = {
   character: characterAdapter,
   dream: dreamAdapter,
+  scenario: scenarioAdapter,
 }
 
 export function listBrainstormSourceAdapters(): BrainstormSourceAdapter[] {

--- a/utils/scripts/verifyBrainstormSourceAdapters.test.ts
+++ b/utils/scripts/verifyBrainstormSourceAdapters.test.ts
@@ -2,10 +2,11 @@
 //
 // Regression guard for conductor brainstorm/t-012's adapter dispatch/fallback
 // logic (stores/helpers/brainstormSourceAdapterKit.ts). Exercises it in
-// isolation via injected fake adapters -- the real character/dream adapters
-// (brainstormSourceAdapters.ts) call Pinia stores that need a live Nuxt
-// runtime, which this test intentionally never touches; the kit module has
-// no such dependency, which is exactly why the split exists.
+// isolation via injected fake adapters -- the real character/dream/scenario
+// adapters (brainstormSourceAdapters.ts, the last added in brainstorm/t-014)
+// call Pinia stores that need a live Nuxt runtime, which this test
+// intentionally never touches; the kit module has no such dependency, which
+// is exactly why the split exists.
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 
@@ -198,6 +199,30 @@ async function main() {
     'Brainstorm source search must never return cached Character or Dream lists directly.',
   )
 
+  // conductor brainstorm/t-014: Scenario as the second lightweight adapter
+  // added beyond Character/Dream. Same force-revalidate and fail-closed
+  // search discipline applies -- a cached/localStorage Scenario can predate
+  // an auth transition exactly like a cached Character or Dream can.
+  assert.ok(
+    adapterSource.includes('scenario: scenarioAdapter'),
+    'the client-side adapter registry must register a scenario entry',
+  )
+  assert.ok(
+    adapterSource.includes('store.fetchScenarioById(ref.id, true)'),
+    'scenarioAdapter.resolve must force a fresh Scenario fetch (force=true) ' +
+      'so a stale cached row cannot bypass canView after an auth transition.',
+  )
+  assert.ok(
+    adapterSource.includes('() => store.fetchScenarios(true)') &&
+      adapterSource.includes('return freshScenarios'),
+    'scenarioAdapter.search must force a fresh Scenario list fetch and search ' +
+      'only the fail-closed fresh result.',
+  )
+  assert.ok(
+    !adapterSource.includes('return store.scenarios'),
+    'Brainstorm source search must never return the cached Scenario list directly.',
+  )
+
   // The source watcher in brainstorm-manager.vue must guard against a
   // slower, superseded resolve overwriting a later selection or resurrecting
   // a removed source -- request-identity/token invalidation, not just a
@@ -256,9 +281,9 @@ async function main() {
     'Brainstorm source adapter registry verified: case-insensitive lookup, ' +
       'successful resolve passthrough, missing-row and unregistered-modelType ' +
       'fallbacks, thrown-adapter recovery, search dispatch/filtering, the ' +
-      'Character adapter force-revalidate contract, fail-closed fresh source ' +
-      "searches, and the source watcher's and runSourceSearch's request-identity " +
-      'invalidation contracts (brainstorm/t-012).',
+      'Character/Scenario adapter force-revalidate contracts, fail-closed fresh ' +
+      "source searches, and the source watcher's and runSourceSearch's " +
+      'request-identity invalidation contracts (brainstorm/t-012, t-014).',
   )
 }
 

--- a/utils/scripts/verifyBrainstormSourceContext.ts
+++ b/utils/scripts/verifyBrainstormSourceContext.ts
@@ -14,7 +14,11 @@
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { formatCharacterContext } from '../../server/utils/brainstorm/brainstormSourceContextKit'
+import {
+  formatCharacterContext,
+  formatDreamContext,
+  formatScenarioContext,
+} from '../../server/utils/brainstorm/brainstormSourceContextKit'
 
 const full = formatCharacterContext({
   name: 'Ami',
@@ -67,6 +71,100 @@ assert.match(partial, /^Character: Old Komodo \(Keeper of the Slow Fire\)\./)
 assert.match(partial, /Traits: species: komodo dragon\./)
 assert.doesNotMatch(partial, /Voice:|Backstory:/)
 
+// conductor brainstorm/t-014: Dream-aware brainstorming.
+const dreamFull = formatDreamContext({
+  title: 'The Hollow Lantern Market',
+  dreamType: 'LOCATION',
+  description: 'A night market that only opens when someone is lost.',
+  pitch: 'A market of second chances for the truly lost.',
+  flavorText: 'Smells of rain-warm lanterns and someone else’s home cooking.',
+  artPrompt: 'glowing paper lanterns over wet cobblestones, warm gold light',
+  Characters: [{ name: 'Wick the Lampkeeper' }, { name: 'Old Marrow' }],
+  Rewards: [{ name: 'Borrowed Ember', rewardType: 'ITEM' }],
+  Scenarios: [
+    {
+      title: 'The Vanishing Stall',
+      description: 'A stall that sells exactly what you fear losing next.',
+      locations: 'the market’s furthest, quietest row',
+      tier: 'uncanny',
+      difficulty: 2,
+    },
+  ],
+})
+assert.match(dreamFull, /^Dream: The Hollow Lantern Market \(location\)\./)
+assert.match(
+  dreamFull,
+  /Premise: A market of second chances for the truly lost\. \| A night market that only opens when someone is lost\./,
+)
+assert.match(
+  dreamFull,
+  /Sensory detail: Smells of rain-warm lanterns and someone else’s home cooking\./,
+)
+assert.ok(
+  dreamFull.includes(
+    'Visual concept: glowing paper lanterns over wet cobblestones, warm gold light',
+  ),
+  'artPrompt (freeform prose, no forced trailing period) must surface as a Visual concept line',
+)
+assert.match(dreamFull, /Characters: Wick the Lampkeeper, Old Marrow\./)
+assert.match(dreamFull, /Rewards: Borrowed Ember \(item\)\./)
+assert.ok(
+  dreamFull.includes(
+    'Locations, encounters and threats: The Vanishing Stall @ the market’s furthest, quietest row (tier: uncanny | difficulty: 2) | A stall that sells exactly what you fear losing next.',
+  ),
+  'the Scenarios linked to a Dream must surface as a combined locations/encounters/threats line',
+)
+
+const dreamSparse = formatDreamContext({
+  title: 'Untitled Wish',
+  dreamType: 'WISH',
+})
+assert.equal(
+  dreamSparse,
+  'Dream: Untitled Wish (wish).',
+  'a Dream with no optional fields or links must still produce a usable one-line summary',
+)
+assert.doesNotMatch(
+  dreamSparse,
+  /Premise:|Sensory detail:|Visual concept:|Characters:|Rewards:|Locations,/,
+)
+
+const dreamOverlong = formatDreamContext({
+  title: 'Overlong',
+  dreamType: 'PITCH',
+  description: 'x'.repeat(5_000),
+})
+assert.ok(
+  dreamOverlong.length <= 2_000,
+  'the composed Dream context must stay bounded so one richly-linked Dream cannot blow out the prompt budget',
+)
+
+// conductor brainstorm/t-014: Scenario as a second lightweight adapter.
+const scenarioFull = formatScenarioContext({
+  title: 'The Vanishing Stall',
+  description: 'A stall that sells exactly what you fear losing next.',
+  locations: 'the market’s furthest, quietest row',
+  tier: 'uncanny',
+  difficulty: 2,
+  genres: 'urban fantasy, mystery',
+  Characters: [{ name: 'Old Marrow' }],
+})
+assert.ok(
+  scenarioFull.startsWith(
+    'Scenario: The Vanishing Stall @ the market’s furthest, quietest row (tier: uncanny | difficulty: 2) | A stall that sells exactly what you fear losing next.',
+  ),
+  'formatScenarioContext must lead with the same location/tier/difficulty/description line formatDreamContext composes for a linked Scenario',
+)
+assert.match(scenarioFull, /Genre: urban fantasy, mystery\./)
+assert.match(scenarioFull, /Characters: Old Marrow\./)
+
+const scenarioSparse = formatScenarioContext({ title: 'Bare Room' })
+assert.equal(
+  scenarioSparse,
+  'Scenario: Bare Room.',
+  'a Scenario with no optional fields must still produce a usable one-line summary',
+)
+
 // The fetch+canView dispatch half needs a live database -- assert its
 // contract directly against the source, same pattern
 // verifyBrainstormSourceAdapters.test.ts uses for the client-side registry.
@@ -79,12 +177,30 @@ assert.ok(
   'characterContext must revalidate view authorization on every resolve, not trust that the caller already checked it',
 )
 assert.ok(
+  contextSource.includes('await canView(dream, null, viewer)'),
+  'dreamContext must revalidate view authorization on every resolve, not trust that the caller already checked it',
+)
+assert.ok(
+  contextSource.includes('await canView(scenario, null, viewer)'),
+  'scenarioContext must revalidate view authorization on every resolve, even though the scenarios/:id.get route itself applies no record-level check today',
+)
+assert.ok(
   contextSource.includes('character: characterContext'),
   'the resolver registry must register a character entry',
+)
+assert.ok(
+  contextSource.includes('dream: dreamContext'),
+  'the resolver registry must register a dream entry',
+)
+assert.ok(
+  contextSource.includes('scenario: scenarioContext'),
+  'the resolver registry must register a scenario entry',
 )
 assert.ok(
   /catch \(error\) \{[\s\S]*?return null/.test(contextSource),
   'resolveBrainstormSourceContext must degrade to null on any resolver failure, never throw and fail the whole generation request',
 )
 
-console.log('Brainstorm source context contract passed.')
+console.log(
+  'Brainstorm source context contract passed: Character, Dream, and Scenario grounding (brainstorm/t-013, t-014).',
+)


### PR DESCRIPTION
## What

Closes conductor `brainstorm/t-014` ("Ship Dream-aware brainstorming and expand adapter coverage"). Extends the Character-only source-context grounding from `brainstorm/t-013` — until now, picking a Dream (or any non-Character) as a Brainstorm source showed the picker's label but generated exactly the same premise-only ideas as a freeform session (`resolveBrainstormSourceContext` had no registered resolver for it).

## Changes

- **`server/utils/brainstorm/brainstormSourceContextKit.ts`** — added `formatDreamContext` (title/type, premise, sensory detail, visual concept, linked characters, linked rewards, and the locations/encounters/threats carried by linked Scenarios) and `formatScenarioContext`, alongside the existing `formatCharacterContext`. Same `joinFacts`-based, `MAX_CONTEXT_LENGTH`-bounded shape; freeform prose fields (premise/sensory/visual) skip the forced trailing period the fragment-list fields (characters/rewards) get, matching the existing `Character.backstory` convention.
- **`server/utils/brainstorm/brainstormSourceContext.ts`** — added `dreamContext` and `scenarioContext` resolvers to `SOURCE_CONTEXT_RESOLVERS`: minimal-select Prisma fetch + `canView` revalidation, same privacy contract as `characterContext` (a ref the requesting user cannot view must never leak into a generation prompt). Noted two deliberate simplifications in comments: Dream's PACK-grant fallback (digital-storefront/t-004) isn't replicated (a PACK-only-gated Dream just degrades to ungrounded generation, never a leak), and `scenarioContext` revalidates independently even though the `scenarios/:id.get` route itself applies no record-level view check today.
- **`stores/helpers/brainstormSourceAdapters.ts`** — added a `Scenario` picker adapter (the task's "at least one additional lightweight entity adapter"), with the same force-revalidate (`fetchScenarioById(id, true)`) and fail-closed search (`fetchFreshSourceRows`) discipline as Character/Dream. Reward, Bot, Project, and Prompt remain the documented next candidates for both the picker and the context resolver — comments updated to reflect what's done vs. what's left.
- **Tests**: extended `verifyBrainstormSourceContext.ts` (Dream/Scenario formatting + resolver-registry contract checks) and `verifyBrainstormSourceAdapters.test.ts` (Scenario adapter force-revalidate/fail-closed-search contract). Wired `verifyBrainstormSourceContext.ts` into `package.json`/`contract-tests.yml` — it existed since t-013 but was never actually run in CI; fixed that gap since this PR substantially extends it.

## Verification

- `eslint`/`prettier --check` clean on all changed files
- `vue-tsc --noEmit` clean repo-wide
- `npm run test:brainstorm-source-context` — new Dream/Scenario formatting assertions + resolver contract checks, all passing
- `npm run test:brainstorm-source-adapters` — Scenario adapter contract added, all passing (existing Character/Dream assertions unaffected)
- `git diff --stat` shows exactly the 7 intended files

## Flags for reviewer

- Wiring `test:brainstorm-source-context` into CI for the first time means this PR's CI run is also the first real signal on whether that script's existing (pre-t-014) Character assertions pass under the actual CI environment — I ran it locally against a provisioned `node_modules`/Prisma client and it's clean, but flagging the "first CI run of an existing script" shape in case anything sandbox-specific slipped through.
- Reward, Bot, Project, and Prompt are intentionally left unwired (both picker and context) — same "documented next candidate" pattern the file comments already used before this PR, just updated to reflect Dream/Scenario now being done.

### Kaizen suggestion
`applyArtCommand`-style single-purpose action helpers aside, a natural next Brainstorm improvement: wire a `Reward` context resolver + picker adapter next (same shape as Scenario here), since Reward is the next entity already namechecked in both files' "documented candidates" comments and has no privacy-sensitive relations to reason about beyond `canView` itself.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K68ikYmGiPnde2yKW88jEY)_