### PR TITLE
ruler-hooked/t-015: installable/offline PWA wrapper for the Ruler Hooked route

### DIFF
--- a/components/conductor/ruler-hooked-page.vue
+++ b/components/conductor/ruler-hooked-page.vue
@@ -2,6 +2,42 @@
 <template>
   <project-front-page class="kr-surface" slug="ruler-hooked" :fallback="config">
     <template #interactive>
+      <!--
+        ruler-hooked/t-015: explicit "install this app" affordance. `$pwa` is
+        the shared @vite-pwa/nuxt injection (client-only plugin, hence
+        ClientOnly here) -- see nuxt.config.ts's pwa.client.installPrompt
+        comment for why this needed a config flag flip before `$pwa` would
+        ever populate showInstallPrompt/install rather than staying inert.
+        This is the only route in the app currently wired to it; the flag
+        itself is global so any other route could add the same banner later.
+      -->
+      <ClientOnly>
+        <div
+          v-if="pwa?.showInstallPrompt"
+          class="alert mb-3 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-primary/40 bg-primary/10 py-2 text-sm"
+        >
+          <span
+            >Install Ruler Hooked to play offline, without browser chrome.</span
+          >
+          <div class="flex gap-2">
+            <button
+              type="button"
+              class="btn btn-primary btn-sm"
+              @click="pwa?.install()"
+            >
+              Install
+            </button>
+            <button
+              type="button"
+              class="btn btn-ghost btn-sm"
+              @click="pwa?.cancelInstall()"
+            >
+              Not now
+            </button>
+          </div>
+        </div>
+      </ClientOnly>
+
       <RulerHookedGame />
     </template>
   </project-front-page>
@@ -9,6 +45,8 @@
 
 <script setup lang="ts">
 import type { ProjectFrontConfig } from '@/components/conductor/projectFront'
+
+const { $pwa: pwa } = useNuxtApp()
 
 const config: ProjectFrontConfig = {
   slug: 'ruler-hooked',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -206,6 +206,19 @@ export default defineNuxtConfig({
   // and precache only the small, stable install chrome.
   pwa: {
     registerType: 'autoUpdate',
+    // ruler-hooked/t-015: `installPrompt` gates the entire custom-install-flow
+    // block in @vite-pwa/nuxt's client plugin (dist/runtime/plugins/
+    // pwa.client.js) -- without it set, `beforeinstallprompt` is never
+    // listened for and `$pwa.showInstallPrompt` / `$pwa.install()` are
+    // permanently inert no-ops, regardless of the VitePwaManifest fix from
+    // ai-art-academy/t-062+t-063. Turning it on is what makes the shared
+    // `usePWA()` composable's install affordance usable anywhere in the app;
+    // ruler-hooked-page.vue is the first (and so far only) place that wires
+    // up UI for it. String value names the localStorage key the module uses
+    // to remember a user's "don't ask again" dismissal.
+    client: {
+      installPrompt: 'kr-pwa-install-dismissed',
+    },
     manifest: {
       name: 'Kind Robots',
       short_name: 'Kind Robots',
@@ -235,6 +248,35 @@ export default defineNuxtConfig({
         'favicon.ico',
       ],
       navigateFallback: null,
+      // ruler-hooked/t-015: the game already plays fully offline once loaded
+      // (its state lives in localStorage, see components/ruler-hooked) --
+      // the gap was the *document* itself not surviving an offline reload.
+      // Nitro doesn't put long-lived cache headers on SSR HTML the way it
+      // does on hashed build output, so a hard reload with no network fails
+      // even after a first visit. Cache just this one route's rendered
+      // document (network-first, so a return visit still gets fresh content
+      // when online) rather than widening the install-chrome-only precache
+      // policy above -- see that budget note for why the rest of the site
+      // stays install-only. This does not attempt to cover client-side SPA
+      // navigation *into* the route from elsewhere while offline, only a
+      // full reload/open of a URL that has been fully loaded before.
+      runtimeCaching: [
+        {
+          urlPattern: /^https?:\/\/[^/]+\/plan\/projects\/ruler-hooked\/?$/,
+          handler: 'NetworkFirst',
+          options: {
+            cacheName: 'ruler-hooked-document',
+            networkTimeoutSeconds: 3,
+            expiration: {
+              maxEntries: 1,
+              maxAgeSeconds: 60 * 60 * 24 * 30,
+            },
+            cacheableResponse: {
+              statuses: [0, 200],
+            },
+          },
+        },
+      ],
     },
   },
 


### PR DESCRIPTION
## What

Installable/offline PWA wrapper for the Ruler Hooked route (`/plan/projects/ruler-hooked`), per `projects/ruler-hooked/roadmap.yaml` t-015 in the conductor repo.

## Convention audit: reused, didn't invent one

kind_robots already has a shared, site-wide PWA convention: `@vite-pwa/nuxt` (added for ai-art-academy/t-062, t-063, t-066). It's deliberately **install-chrome-only** — one shared `manifest.webmanifest` + service worker that precaches only icons/favicon/manifest, not route JS/CSS, because most pages are SSR/API-driven and a full precache would just make every install/update download the whole product. There's even a dedicated CI guard for this policy: `utils/scripts/verifyPwaPrecacheBudget.ts`, run by `.github/workflows/pwa-precache-budget.yml` whenever `nuxt.config.ts` changes.

This PR **extends** that shared convention with two narrow, `nuxt.config.ts`-scoped additions rather than building a ruler-hooked-specific manifest/SW:

1. **`pwa.client.installPrompt`** — Turned out the shared `usePWA()`/`$pwa` composable's custom install flow (`showInstallPrompt`, `install()`, `cancelInstall()`) was a permanently inert no-op site-wide: `@vite-pwa/nuxt`'s client plugin only attaches the `beforeinstallprompt` listener and populates those fields when this config flag is set, and it was never set — even after the earlier `VitePwaManifest` link fix (see the comment in `app.vue` about `beforeinstallprompt` never firing). Setting it is what makes an install affordance *possible* anywhere in the app. I only wired up UI for it on the ruler-hooked route (see below); this flag being global is a side effect of it living in the shared module config, not a claim that every route now has an install button.
2. **`pwa.workbox.runtimeCaching`** — one `NetworkFirst` route scoped by regex to exactly `/plan/projects/ruler-hooked`'s document. Ruler Hooked's actual game state already lives in `localStorage` and plays fully offline once loaded (see `components/ruler-hooked/ruler-hooked-game.vue`'s header comment) — that part was already true before this PR. The gap this closes is narrower: Nitro doesn't give SSR HTML the long-lived, immutable cache headers it gives hashed `_nuxt/*` build assets, so a **hard reload** of the route with the network off failed even after a first visit, because the document itself wasn't cached anywhere. This adds exactly one cache entry (`maxEntries: 1`) for that one route's document — it does not touch `globPatterns` (still icons/manifest only, verified by the unchanged, still-passing `verifyPwaPrecacheBudget.ts`) and does not attempt to cover client-side SPA navigation *into* the route from elsewhere while offline (that would need caching Nuxt Content's data-fetch path too, which I left out — see Follow-up scope below).

3. **`components/conductor/ruler-hooked-page.vue`** — an explicit "Install" / "Not now" banner, `ClientOnly`-wrapped, driven by the shared `$pwa` injection (`showInstallPrompt`, `install()`, `cancelInstall()`). This is the only route in the app currently wired up to show this UI.

## Verified

- Production build (`npm run build`) succeeds.
- Inspected the emitted output directly:
  - `manifest.webmanifest` — present, unchanged (`name: "Kind Robots"`, icons, `display: standalone`).
  - `sw.js` — its `precacheAndRoute([...])` list is unchanged (icons/favicon/manifest/build-meta only, no route JS/CSS), and it now also carries a `registerRoute(/^https?:\/\/[^/]+\/plan\/projects\/ruler-hooked\/?$/, new NetworkFirst({cacheName:"ruler-hooked-document", networkTimeoutSeconds:3, plugins:[ExpirationPlugin({maxEntries:1,...}), CacheableResponsePlugin({statuses:[0,200]})]}), "GET")` call.
  - The `kr-pwa-install-dismissed` localStorage key I configured shows up baked into the built client bundle, confirming `installPrompt` actually reached the runtime module.
- `vue-tsc --noEmit` (`npm run test`) — passes, zero errors.
- `eslint` on both changed files — zero errors. Full-repo `eslint .` has a large pre-existing baseline (339 problems) unrelated to this change (confirmed identical on `main` via `git stash`); the repo's actual CI gate is a ratchet (`utils/scripts/verifyLintRatchet.ts` / `.github/workflows/...`), which I ran directly and it holds (`339 problem(s) ... (-53)`, "no rule got worse").
- `prettier --write` applied to both changed files. Note: `nuxt.config.ts` still fails a plain `prettier --check .` on one *pre-existing, unrelated* line (the `apple-touch-icon` `link:` entry) — confirmed via `git stash` that this already fails identically on `main` before my change, and `prettier --check` isn't wired into any CI workflow in this repo, so I left that line as-is rather than bundling an unrelated formatting fix into this diff.
- `utils/scripts/verifyPwaPrecacheBudget.ts` — passes directly, and will also run in CI via `.github/workflows/pwa-precache-budget.yml` since it triggers on `nuxt.config.ts` changes.

## Explicitly NOT verified (no real browser in this sandbox)

- An actual `beforeinstallprompt` event firing and a real native install-prompt dialog appearing.
- A real "load once online, disable network in devtools, reload" check in an actual browser.

These are the two things called out in the task ("Verify an actual install prompt fires and the route loads with network disabled after first visit") that this sandbox genuinely cannot exercise — I'm flagging that honestly rather than claiming browser-level verification I didn't do. Everything upstream of that (config reaching the built manifest/SW correctly, the composable's install-prompt code path being reachable instead of dead) is verified as described above.

## Follow-up scope deliberately left out

- A site-wide PWA conversion (this stays install-chrome-only everywhere except this one route's document).
- Caching Nuxt Content's data-fetch path, so a *client-side SPA navigation* into `/plan/projects/ruler-hooked` from elsewhere while offline would also work (only a full page load/reload of the URL is covered).
- Install-prompt UI on any other route (the `installPrompt` config flag is now on globally, but no other page renders a button for it yet).

## Files changed
- `nuxt.config.ts`
- `components/conductor/ruler-hooked-page.vue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqpZanbduX63Dcq6WL9NwD)_