### PR TITLE
brainstorm/t-018: soft persona flourish from the live Brainbot record

### DIFF
--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -13,8 +13,17 @@
         <div class="min-w-[min(100%,28rem)] flex-1">
           <div
             class="mb-2 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs font-black uppercase tracking-[0.16em] text-primary"
+            data-testid="brainstorm-persona-badge"
           >
-            <span aria-hidden="true">🧠</span>
+            <img
+              v-if="persona?.avatarImage && !personaAvatarFailed"
+              :src="persona.avatarImage"
+              :alt="persona.name"
+              class="h-4 w-4 rounded-full object-cover"
+              loading="lazy"
+              @error="personaAvatarFailed = true"
+            />
+            <span v-else aria-hidden="true">🧠</span>
             Brainstorm
           </div>
           <h2 class="text-2xl font-black tracking-tight text-base-content sm:text-3xl">
@@ -23,6 +32,13 @@
           <p class="mt-2 max-w-3xl text-sm leading-6 text-base-content/65">
             Give Brainstorm a premise, problem, joke setup, art target, or half-formed thought.
             It will propose a batch. You keep the sparks and bully the beige ones into doing better.
+          </p>
+          <p
+            v-if="persona?.tagline"
+            class="mt-1 text-xs italic text-base-content/45"
+            data-testid="brainstorm-persona-tagline"
+          >
+            {{ persona.tagline }}
           </p>
         </div>
 
@@ -761,6 +777,8 @@ import type {
   BrainstormSourceDisplay,
   BrainstormSourceOption,
 } from '@/stores/helpers/brainstormSourceAdapters'
+import { useBotStore } from '@/stores/botStore'
+import type { Bot } from '~/prisma/generated/prisma/client'
 
 const creativeDirections = [
   {
@@ -1078,9 +1096,37 @@ function seedFromQuery(): void {
   void router.replace({ query })
 }
 
+// Purely decorative persona flourish (brainstorm/t-018): the historical
+// Brainstorm bot persona survives in the live Bot table (slug
+// "brainstorm-bot") with modern generated avatar/tagline art. Showing it here
+// is soft flavor only -- generation never reads `persona` and works
+// identically whether this bot exists, is renamed, or fails to load.
+const botStore = useBotStore()
+const persona = ref<Bot | null>(null)
+const personaAvatarFailed = ref(false)
+
+async function loadBrainstormPersona(): Promise<void> {
+  try {
+    const bots = await botStore.fetchBots()
+    persona.value =
+      bots.find(
+        (bot) =>
+          bot.slug === 'brainstorm-bot' &&
+          bot.isPublic !== false &&
+          bot.isActive !== false &&
+          !bot.underConstruction,
+      ) ?? null
+  } catch {
+    // Decorative only -- a failed/blocked bot fetch must never affect the
+    // generation workbench, so it silently falls back to no persona flair.
+    persona.value = null
+  }
+}
+
 onMounted(() => {
   store.initializeSession()
   seedFromQuery()
+  void loadBrainstormPersona()
 })
 
 function returnTypeSelected(id: BrainstormReturnTypeId): boolean {


### PR DESCRIPTION
### Task
brainstorm/t-018: Recover and modernize the Brainstorm bot/persona from repository evidence (kind: software)

### What changed / what I produced
- Audited historical Brainstorm persona evidence: `stores/seeds/seedBots.ts` has a `Brainb0t` dev-seed record with `avatarImage: '/images/avatars/brain1.webp'` — that exact path was never committed as a repo file (`public/images/**` is gitignored) and the seed script's schema (no `slug`/`tagline`/`narrativeVoice`/art-image ids) is stale relative to the live `Bot` table, so it isn't what actually populated production.
- Confirmed via `git log --all --diff-filter=A -- '*brain1*'` that `brain1.webp` was never a real committed asset. It IS live at `https://kindrobots.org/images/avatars/brain1.webp` (HTTP 200, real 1000x1000 WebP) — presumably a legacy generated asset outside git, but it's not wired to anything in current code.
- `content/brainstorm.md` already carries live, recognizable persona copy that was never lost: `tooltip: "Welcome to Brainstorm's lair!..."`, `amiTip` ("he's a brain in a jar"), `dottiTip` ("Brainstorm is my first robot, even before AMI!"), `icon: kind-icon:brain` (backed by `assets/icons/brain.svg`, still registered in `stores/seeds/validIcons.ts`). These render live via `workspace-header.vue`/`channel-select.vue`.
- Found a fully modern, live Bot record already in production: `GET /api/bots` returns id 4, `name: "Brainbot"`, `slug: "brainstorm-bot"`, `tagline: "Fresh angles, fewer beige rectangles."`, `narrativeVoice`, generated `avatarImage`/card/hero/icon art (`cardArtImageId`/`heroArtImageId`/`iconArtImageId`), `isPublic: true`, `isActive: true`. It has zero UI surface today — `bot-gallery.vue` is not mounted by any content route.
- Confirmed the functional generation path has no bot-ID coupling at all: `server/api/brainstorm/generate.post.ts` and everything under `server/utils/brainstorm/` (`brainstormProvider.ts`, `brainstormPrompt.ts`, `brainstormParser.ts`, `brainstormPersistence.ts`, `brainstormSourceContext*.ts`) contain zero references to `botId`/`Brainbot`/`brainstorm-bot`.
- Added a small, soft, reversible persona flourish to `components/brainstorm/brainstorm-manager.vue`: on mount, softly fetches bots via the existing `useBotStore().fetchBots()` (same cached call used elsewhere on the site) and looks up the live `brainstorm-bot` record. If found, the header's "🧠 Brainstorm" badge shows its avatar instead of the emoji, and its tagline renders under the headline copy. On any failure (fetch error, missing record, broken image, renamed/removed bot) it silently falls back to the current plain emoji badge — `persona` is never read by the generation code path.

### How I verified
- `npx vue-tsc --noEmit` — clean (exit 0)
- `npx eslint components/brainstorm/brainstorm-manager.vue` — clean (exit 0)
- `npx prettier --check components/brainstorm/brainstorm-manager.vue` — flags pre-existing whole-file drift (confirmed identical warning on `main` *before* this diff via `git stash`); diffed `prettier --write` output against my change and none of the newly added lines needed reformatting, matching the documented precedent in brainstorm/t-011's note.
- `node utils/scripts/verifyBrainstormWorkbench.mjs` — "Brainstorm workbench contract passed."
- `node utils/scripts/verifyBrainstormStoreContract.mjs` — "Brainstorm store contract passed."
- `curl https://kindrobots.org/images/avatars/brain1.webp` — HTTP 200 (legacy asset still live but unused by current code)
- `curl https://kindrobots.org/api/bots` — confirmed live `Brainbot` record (id 4, slug `brainstorm-bot`) with the fields referenced above
- Manually audited `server/api/brainstorm/generate.post.ts` and every file in `server/utils/brainstorm/` for `botId` — no hard dependency on any single bot exists in the generation path (task requirement satisfied, no code change needed for this part).

### Stakes
reversible

### Flags for Reviewer
- This does not restore the old `brain1.webp` image or the stale `seedBots.ts` record — it reuses the live, already-generated `Brainbot` Bot record instead, which is materially better (real art, tagline, voice) and requires no schema/migration/seed change.
- The `Brainbot` PROMPTBOT record has no other live surface on the site (`bot-gallery.vue` unmounted). This PR does not add one — that's out of scope for t-018, which only asks for Brainstorm-specific persona flavor. Giving `Brainbot`/other PROMPTBOTs a general gallery surface would be a separate, larger task if wanted.
- I did not touch `content/brainstorm.md`'s `image: splash/brainstorm.png` field — that path has never existed as a file in this repo (checked via git history) and isn't read by any renderer I could find (`grep` for `frontmatter.image` usage only hit unrelated content pages). It looks like unused/dead frontmatter, not related to this task's persona scope; flagging rather than touching since removing frontmatter fields is a separate cleanup.

### Kaizen suggestion
Mount `bot-gallery.vue` (or an equivalent lightweight surface) somewhere reachable so the 69 live Bot records — including fully-authored ones like `Brainbot` with generated art and voice — aren't invisible data. Several bots (AMIbot, Rapbot, Brainbot, etc.) already have complete personas and art sitting unused.

### Notes for reviewer
No schema, migration, or generation-endpoint changes. Single-file, additive, decorative-only diff (47 insertions, 1 deletion) in `components/brainstorm/brainstorm-manager.vue`.


---
_Generated by [Claude Code](https://claude.ai/code/session_0141DKz3L8CZSuFvcsbXKN3S)_