### PR TITLE
model-builder: revert per-item optimistic state on partial batch failure (t-029 cycle 9)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -563,6 +563,12 @@ jobs:
       - name: Model Builder item.error persistence guard contract
         run: npm run test:model-builder-error-persistence-guard
 
+      - name: Model Builder batch partial-failure revert guard self-test
+        run: npm run test:model-builder-batch-partial-failure-revert-guard-selftest
+
+      - name: Model Builder batch partial-failure revert guard contract
+        run: npm run test:model-builder-batch-partial-failure-revert-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -264,6 +264,8 @@
     "test:model-builder-stage-status-json-parse-guard": "tsx utils/scripts/verifyModelBuilderStageStatusJsonParseGuard.ts",
     "test:model-builder-error-persistence-guard-selftest": "tsx utils/scripts/verifyModelBuilderErrorPersistenceGuard.test.ts",
     "test:model-builder-error-persistence-guard": "tsx utils/scripts/verifyModelBuilderErrorPersistenceGuard.ts",
+    "test:model-builder-batch-partial-failure-revert-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchPartialFailureRevertGuard.test.ts",
+    "test:model-builder-batch-partial-failure-revert-guard": "tsx utils/scripts/verifyModelBuilderBatchPartialFailureRevertGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -142,6 +142,16 @@ interface OutputSelection {
   quantity: number
 }
 
+// batchPushItems' return shape. Named (rather than an inline `Promise<{ ... }>`
+// object-literal return type) so this store's own verifyModelBuilder*Guard.ts
+// scripts -- which locate a function's body by scanning for the first '{'
+// after its parameter list's closing ')' -- land on the real body brace
+// instead of the object type literal's own braces.
+interface BatchPushOutcome {
+  ok: boolean
+  failedIds: Set<string>
+}
+
 interface ModelBuilderState {
   step: BuilderStep
   sourceType: SourceTypeKey | null
@@ -774,18 +784,33 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   // Background persistence of a whole group edit in one round-trip. Callers
   // mutate local state first (optimistic) and pass only the changed fields per
   // item, same contract as pushItem — this just collapses N per-item PATCH
-  // requests into a single batch request. Returns whether the write actually
-  // succeeded, so a caller that summarizes its own outcome (batchSetField) can
-  // await the real result instead of assuming success the instant the request
-  // is issued.
+  // requests into a single batch request. Returns the real, confirmed outcome
+  // -- both an overall `ok` (true only when every entry persisted) and the
+  // per-item `failedIds` -- so a caller that summarizes its own outcome
+  // (batchSetField, batchApproveStage) can await the real result instead of
+  // assuming success the instant the request is issued.
+  //
+  // failedIds matters beyond the summary toast: items/batch.patch.ts validates
+  // and applies each entry independently (a single failing entry does not
+  // abort the others -- see its own header comment), so a batch can come back
+  // as a *partial* failure (HTTP 207: some entries updated, some rejected,
+  // e.g. by a concurrent edit that made one item's stage no longer editable
+  // server-side). Every entry's item was already mutated optimistically
+  // before this call was made, for every entry, not just the ones that end up
+  // persisting -- treating a partial failure as "all failed" would falsely
+  // discard entries that DID persist, and treating it as an opaque failure
+  // with no detail leaves the entries that were actually rejected still
+  // showing their optimistic change locally forever, with no sign that write
+  // never landed. Returning exactly which ids failed lets the caller revert
+  // only those.
   function batchPushItems(
     entries: Array<{
       item: BuildItem
       payload: Record<string, unknown>
       meta?: { stage?: string; reason?: string }
     }>,
-  ): Promise<boolean> {
-    if (!entries.length) return Promise.resolve(true)
+  ): Promise<BatchPushOutcome> {
+    if (!entries.length) return Promise.resolve({ ok: true, failedIds: new Set() })
     const runId = state.run?.id
     return performFetch('/api/model-builder/items/batch', {
       method: 'PATCH',
@@ -799,23 +824,51 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       }),
     })
       .then((response) => {
-        if (!response.success) {
-          if (runId) {
-            setStatusForRun(
-              runId,
-              'error',
-              response.message || 'Failed to save changes.',
-            )
+        if (response.success) return { ok: true, failedIds: new Set<string>() }
+
+        // Distinguish a total failure (rejected before any entry was even
+        // evaluated -- bad auth, a malformed body -- so response.data carries
+        // no per-entry breakdown) from a partial one (response.data is the
+        // per-entry `{ id, success }[]` items/batch.patch.ts always returns
+        // once it reaches its per-entry loop). Only the latter can tell which
+        // specific ids actually failed; fall back to treating every entry as
+        // failed when that detail isn't available, rather than guessing any
+        // of them landed.
+        const perItem = Array.isArray(response.data)
+          ? (response.data as unknown[])
+          : null
+        const failedIds = new Set<string>()
+        if (perItem) {
+          for (const result of perItem) {
+            if (
+              result &&
+              typeof result === 'object' &&
+              'id' in result &&
+              (result as { success?: unknown }).success !== true
+            ) {
+              failedIds.add(String((result as { id: unknown }).id))
+            }
           }
-          return false
+        } else {
+          for (const { item } of entries) failedIds.add(item.id)
         }
-        return true
+
+        if (runId) {
+          setStatusForRun(
+            runId,
+            'error',
+            response.message || 'Failed to save changes.',
+          )
+        }
+        return { ok: false, failedIds }
       })
       .catch((error) => {
         // Same reasoning as pushItem's catch above: mirror the success:false
         // branch's run-scoping instead of unconditionally calling
         // handleError, so a rejected batch write doesn't pop a global error
-        // banner for a run the user has cancelled or moved away from.
+        // banner for a run the user has cancelled or moved away from. A
+        // rejected request never reached the server at all, so every entry
+        // is unconfirmed.
         if (runId) {
           setStatusForRun(
             runId,
@@ -825,7 +878,10 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
               : 'Failed to save changes.',
           )
         }
-        return false
+        return {
+          ok: false,
+          failedIds: new Set(entries.map(({ item }) => item.id)),
+        }
       })
   }
 
@@ -2016,6 +2072,20 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   // unscoped-looking "Failed to save changes." -- while every item's local
   // fieldsDraft/stageStatuses had already been optimistically changed with no
   // indication of which items, if any, never actually persisted.
+  //
+  // Bug (model-builder/t-029 cycle 9): that last part -- "no indication of
+  // which items never actually persisted" -- was more than a messaging gap.
+  // items/batch.patch.ts validates and applies every entry independently (a
+  // single failing entry does not abort the others), so a real-world failure
+  // here is usually *partial*: most items persist, one or two are rejected
+  // (e.g. a concurrent edit made that item's FIELDS_AND_PROMPTS no longer
+  // editable server-side by the time this batch reached it). Every entry's
+  // item was already mutated optimistically before the request was sent, and
+  // this used to leave ALL of them, including the rejected ones, showing
+  // their new fieldsDraft/stageStatuses forever -- the UI kept claiming a
+  // field was set to a value that was never actually written, with nothing
+  // short of a full reload to reveal the discrepancy. batchPushItems now
+  // reports exactly which ids failed so only those get reverted below.
   async function batchSetField(
     outputKey: string,
     fieldKey: string,
@@ -2027,6 +2097,13 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       payload: Record<string, unknown>
       meta?: { stage?: string; reason?: string }
     }> = []
+    // Snapshotted before each item's optimistic mutation below so a
+    // server-rejected entry can be reverted to exactly what it held before
+    // this call, instead of keeping an edit that never actually persisted.
+    const previous = new Map<
+      string,
+      { fieldsDraft: string; stages: BuildItem['stages'] }
+    >()
     for (const item of items) {
       // Skip items whose FIELDS_AND_PROMPTS is already approved/locked — see
       // isStageEditable's doc comment.
@@ -2036,6 +2113,10 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         : undefined
       const next = setFieldLine(item.fieldsDraft, fieldKey, value, modelType)
       if (next === item.fieldsDraft) continue
+      previous.set(item.id, {
+        fieldsDraft: item.fieldsDraft,
+        stages: item.stages,
+      })
       item.fieldsDraft = next
       markDownstreamStale(item, 'FIELDS_AND_PROMPTS')
       entries.push({
@@ -2046,7 +2127,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     }
     batchingOutputSingleton.claim(outputKey)
     try {
-      const ok = await batchPushItems(entries)
+      const { ok, failedIds } = await batchPushItems(entries)
       // On failure, batchPushItems already surfaced the real error via
       // setStatusForRun -- reporting a blanket "success" here too would be
       // actively misleading.
@@ -2055,6 +2136,18 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
           'success',
           `Set ${fieldKey} on ${entries.length}/${items.length} items.`,
         )
+      } else if (failedIds.size) {
+        // Revert exactly the entries the server rejected -- see this
+        // function's own doc comment and batchPushItems' for why a partial
+        // failure must not leave those items showing an unpersisted edit.
+        for (const entry of entries) {
+          if (!failedIds.has(entry.item.id)) continue
+          const prior = previous.get(entry.item.id)
+          if (prior) {
+            entry.item.fieldsDraft = prior.fieldsDraft
+            entry.item.stages = prior.stages
+          }
+        }
       }
     } finally {
       batchingOutputSingleton.release(outputKey)
@@ -2080,6 +2173,16 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   // unrelated-looking "Failed to save changes." error moments later -- with
   // every item's local stageStatuses already optimistically flipped to
   // 'approved' either way, same as batchSetField's pre-fix bug.
+  //
+  // Bug (model-builder/t-029 cycle 9): fixing the toast (this function
+  // already did, per the paragraph above) left a second, quieter half of the
+  // same bug in place -- see batchPushItems' and batchSetField's own doc
+  // comments for the full picture. A *partial* server-side rejection (one
+  // item's stage is no longer approvable by the time this batch reaches it,
+  // the rest persist fine) used to leave every item, including the rejected
+  // one, showing 'approved' locally forever: the toast stopped lying, but the
+  // badge kept lying. batchPushItems now reports exactly which ids failed so
+  // only those get reverted below.
   async function batchApproveStage(
     outputKey: string,
     stageKey: BuildStageKey,
@@ -2089,8 +2192,14 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       payload: Record<string, unknown>
       meta?: { stage?: string; reason?: string }
     }> = []
+    // Snapshotted before each item's optimistic mutation below so a
+    // server-rejected entry can be reverted to exactly the stages it held
+    // before this call, instead of keeping an approval that never actually
+    // persisted.
+    const previousStages = new Map<string, BuildItem['stages']>()
     for (const item of groupItems(outputKey)) {
       if (item.stages[stageKey].status === 'locked') continue
+      previousStages.set(item.id, { ...item.stages })
       item.stages[stageKey] = { status: 'approved' }
       const next = BUILD_STAGES[stageIndex(stageKey) + 1]
       if (next && item.stages[next.key].status === 'locked') {
@@ -2104,7 +2213,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     }
     batchingOutputSingleton.claim(outputKey)
     try {
-      const ok = await batchPushItems(entries)
+      const { ok, failedIds } = await batchPushItems(entries)
       // On failure, batchPushItems already surfaced the real error via
       // setStatusForRun -- reporting a blanket "success" here too would be
       // actively misleading.
@@ -2113,6 +2222,15 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
           'success',
           `Approved ${stageKey} for ${entries.length} items.`,
         )
+      } else if (failedIds.size) {
+        // Revert exactly the entries the server rejected -- see this
+        // function's own doc comment and batchPushItems' for why a partial
+        // failure must not leave those items showing an unpersisted approval.
+        for (const entry of entries) {
+          if (!failedIds.has(entry.item.id)) continue
+          const previous = previousStages.get(entry.item.id)
+          if (previous) entry.item.stages = previous
+        }
       }
     } finally {
       batchingOutputSingleton.release(outputKey)

--- a/utils/scripts/verifyModelBuilderBatchPartialFailureRevertGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderBatchPartialFailureRevertGuard.test.ts
@@ -1,0 +1,139 @@
+// /utils/scripts/verifyModelBuilderBatchPartialFailureRevertGuard.test.ts
+//
+// Regression test for checkBatchPartialFailureRevertGuard() in
+// verifyModelBuilderBatchPartialFailureRevertGuard.ts (model-builder/t-029
+// cycle 9). Exercises the real check against synthetic store-shaped
+// fixtures covering: the pre-fix shape (batchPushItems returns a bare
+// boolean, neither caller can tell which entries a partial failure
+// rejected or revert them), the fixed shape (batchPushItems returns
+// `{ ok, failedIds }`, both callers destructure it and revert the rejected
+// entries), and a partially-regressed shape (only one of the two callers
+// still reverts).
+import assert from 'node:assert/strict'
+
+import { checkBatchPartialFailureRevertGuard } from './verifyModelBuilderBatchPartialFailureRevertGuard.js'
+
+function batchPushItemsFixture(returnsFailedIds: boolean): string {
+  return returnsFailedIds
+    ? `
+  function batchPushItems(
+    entries: Array<{ item: BuildItem; payload: Record<string, unknown> }>,
+  ): Promise<BatchPushOutcome> {
+    return performFetch('/api/model-builder/items/batch', {})
+      .then((response) => {
+        if (response.success) return { ok: true, failedIds: new Set() }
+        const failedIds = new Set<string>()
+        return { ok: false, failedIds }
+      })
+  }
+`
+    : `
+  function batchPushItems(
+    entries: Array<{ item: BuildItem; payload: Record<string, unknown> }>,
+  ): Promise<boolean> {
+    return performFetch('/api/model-builder/items/batch', {})
+      .then((response) => response.success)
+  }
+`
+}
+
+function callerFixture(opts: { name: string; reverts: boolean }): string {
+  const body = opts.reverts
+    ? `const { ok, failedIds } = await batchPushItems(entries)
+    if (ok) {
+      setStatus('success', 'done')
+    } else if (failedIds.size) {
+      for (const entry of entries) {
+        if (!failedIds.has(entry.item.id)) continue
+        const previous = previousByItem.get(entry.item.id)
+        if (previous) entry.item.stages = previous
+      }
+    }`
+    : `const ok = await batchPushItems(entries)
+    if (ok) {
+      setStatus('success', 'done')
+    }`
+  return `
+  async function ${opts.name}(outputKey: string): Promise<void> {
+    const entries: Array<{ item: BuildItem; payload: Record<string, unknown> }> = []
+    ${body}
+  }
+`
+}
+
+const BUGGY = [
+  batchPushItemsFixture(false),
+  callerFixture({ name: 'batchApproveStage', reverts: false }),
+  callerFixture({ name: 'batchSetField', reverts: false }),
+].join('\n')
+
+const FIXED = [
+  batchPushItemsFixture(true),
+  callerFixture({ name: 'batchApproveStage', reverts: true }),
+  callerFixture({ name: 'batchSetField', reverts: true }),
+].join('\n')
+
+// Regressed: batchPushItems still reports failedIds and batchApproveStage
+// still reverts using it, but batchSetField was edited back to the old
+// bare-boolean, no-revert shape (e.g. a bad merge that only carried the fix
+// forward for one of the two callers).
+const PARTIALLY_REGRESSED = [
+  batchPushItemsFixture(true),
+  callerFixture({ name: 'batchApproveStage', reverts: true }),
+  callerFixture({ name: 'batchSetField', reverts: false }),
+].join('\n')
+
+function run(): void {
+  const buggyErrors = checkBatchPartialFailureRevertGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    5,
+    'expected the pre-fix fixture (no failedIds anywhere, neither caller ' +
+      `reverts) to fail five times, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(
+    buggyErrors.some((e) => /no longer computes\/returns failedIds/.test(e)),
+  )
+  assert.ok(
+    buggyErrors.filter((e) => /no longer destructures/.test(e)).length === 2,
+  )
+  assert.ok(
+    buggyErrors.filter((e) => /no longer checks `failedIds\.has/.test(e))
+      .length === 2,
+  )
+
+  const fixedErrors = checkBatchPartialFailureRevertGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const regressedErrors = checkBatchPartialFailureRevertGuard(
+    PARTIALLY_REGRESSED,
+  )
+  assert.equal(
+    regressedErrors.length,
+    2,
+    'expected a fixture where only batchSetField regressed to fail exactly ' +
+      `twice (destructure + revert-check), got: ${JSON.stringify(regressedErrors)}`,
+  )
+  assert.ok(regressedErrors.every((e) => e.startsWith('batchSetField()')))
+
+  const missingFnErrors = checkBatchPartialFailureRevertGuard(
+    'function someOtherFunction(): void {}',
+  )
+  assert.equal(missingFnErrors.length, 3)
+  assert.ok(
+    missingFnErrors.every((e) => /Could not find a function named/.test(e)),
+  )
+
+  console.log(
+    'Model Builder batch partial-failure revert guard self-test passed: ' +
+      'buggy fixture fails, fixed fixture passes, a partially-regressed ' +
+      'fixture fails only for the still-broken caller, missing-function ' +
+      'fixture fails clearly.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderBatchPartialFailureRevertGuard.ts
+++ b/utils/scripts/verifyModelBuilderBatchPartialFailureRevertGuard.ts
@@ -1,0 +1,142 @@
+// /utils/scripts/verifyModelBuilderBatchPartialFailureRevertGuard.ts
+//
+// Regression guard (model-builder/t-029 cycle 9). batchApproveStage() and
+// batchSetField() (the "Approve for all N" / "Set a field on all N" actions
+// in the batch editor, model-builder-batch-editor.vue) mutate every entry's
+// item optimistically BEFORE the batch PATCH is even sent, then call
+// batchPushItems(entries) once to persist the whole group in a single
+// round-trip. items/batch.patch.ts validates and applies each entry
+// independently -- a single failing entry does not abort the others (see its
+// own header comment) -- so a real-world failure here is usually *partial*:
+// most entries persist, one or two are rejected (e.g. a concurrent edit made
+// that specific item's stage no longer editable server-side by the time this
+// batch reached it).
+//
+// Before this fix, batchPushItems only ever returned a plain boolean, so its
+// callers could tell "the whole batch failed" from "the whole batch
+// succeeded" but had no way to tell WHICH entries, if any, a partial failure
+// actually rejected. Every entry's local optimistic mutation stayed in place
+// either way -- an earlier fix (see
+// verifyModelBuilderBatch{SetField,ApproveStage}ConfirmedSuccessGuard.ts)
+// stopped the success TOAST from lying, but the item's own badge/fieldsDraft
+// for the specific rejected entry kept silently claiming a change that was
+// never actually persisted, with nothing short of a full reload revealing
+// the discrepancy -- the same "review gate would be lying about what's
+// actually stored" class of bug this codebase treats as a real defect
+// everywhere else it's found (see e.g. isStageEditable's own doc comment).
+//
+// Fixed by having batchPushItems return `{ ok, failedIds }` (see its own doc
+// comment in modelBuilderStore.ts) instead of a bare boolean, and both
+// callers revert exactly the entries found in failedIds back to a locally
+// captured pre-mutation snapshot whenever the batch does not come back fully
+// ok.
+//
+// This asserts the textual shape of that fix stays in place: batchPushItems
+// still computes/returns `failedIds`, and each of batchApproveStage /
+// batchSetField destructures `{ ok, failedIds }` from the awaited call and
+// checks `failedIds.has(entry.item.id)` somewhere in its body to revert the
+// rejected entries.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const CALLER_FN_NAMES = ['batchApproveStage', 'batchSetField']
+
+const DESTRUCTURED_RESULT =
+  /const\s*\{\s*ok\s*,\s*failedIds\s*\}\s*=\s*await\s+batchPushItems\(\s*entries\s*\)/
+
+const REVERT_BRANCH = /failedIds\.has\(\s*entry\.item\.id\s*\)/
+
+export function checkBatchPartialFailureRevertGuard(
+  content: string,
+): string[] {
+  const errors: string[] = []
+  const functions = extractFunctionBodies(content)
+
+  const batchPushItemsFn = functions.find((f) => f.name === 'batchPushItems')
+  if (!batchPushItemsFn) {
+    errors.push(
+      'Could not find a function named batchPushItems() -- has it been ' +
+        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+  } else if (!/failedIds/.test(batchPushItemsFn.body)) {
+    errors.push(
+      'batchPushItems() no longer computes/returns failedIds -- without a ' +
+        'per-entry breakdown, its callers cannot tell which entries a ' +
+        'partial batch failure actually rejected, and are forced back to ' +
+        'either reverting every entry (discarding ones that DID persist) ' +
+        'or none (leaving the genuinely rejected entries silently showing ' +
+        'an unpersisted optimistic change).',
+    )
+  }
+
+  for (const fnName of CALLER_FN_NAMES) {
+    const fn = functions.find((f) => f.name === fnName)
+    if (!fn) {
+      errors.push(
+        `Could not find a function named ${fnName}() -- has it been ` +
+          'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+          'protects against) needs to move with it.',
+      )
+      continue
+    }
+
+    if (!DESTRUCTURED_RESULT.test(fn.body)) {
+      errors.push(
+        `${fnName}() no longer destructures \`const { ok, failedIds } = ` +
+          'await batchPushItems(entries)` -- without `failedIds`, a ' +
+          'partial server-side rejection can no longer be told apart from ' +
+          'a fully-successful batch, and the entries the server actually ' +
+          'rejected have nothing left to revert their optimistic change.',
+      )
+    }
+
+    if (!REVERT_BRANCH.test(fn.body)) {
+      errors.push(
+        `${fnName}() no longer checks \`failedIds.has(entry.item.id)\` -- ` +
+          'a partial batch failure used to (and, without this check, would ' +
+          'again) leave every entry -- including the ones the server ' +
+          'actually rejected -- showing its optimistic local change ' +
+          'forever, with nothing short of a full reload revealing the ' +
+          'discrepancy.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkBatchPartialFailureRevertGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder batch partial-failure revert guard contract failed in ' +
+        'modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder batch partial-failure revert guard contract passed: ' +
+      'batchPushItems reports per-entry failedIds, and both ' +
+      'batchApproveStage/batchSetField revert exactly the entries the ' +
+      'server actually rejected instead of leaving them showing an ' +
+      'unpersisted optimistic change.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Bug

`batchApproveStage()` and `batchSetField()` (the batch editor's "Approve for all N" / "Set a field on all N" actions in `model-builder-batch-editor.vue`) mutate every entry's item optimistically *before* sending a single batched PATCH via `batchPushItems()`. `items/batch.patch.ts` validates and applies each entry independently — a single failing entry does not abort the others — so a real-world failure here is usually **partial**: most entries persist, one or two are rejected (e.g. a concurrent edit made that specific item's stage no longer editable server-side by the time the batch reached it).

Cycle 8 (PR #1932) fixed the success toast for this shape — it no longer claims success before the write confirms. But `batchPushItems()` only ever returned a bare `boolean`, so its callers had no way to tell **which** entries a partial failure actually rejected. Every entry's local optimistic mutation stayed in place either way: the toast stopped lying, but the item's own badge/`fieldsDraft` for the specific rejected entry kept silently claiming a change that was never actually persisted — nothing short of a full reload revealed the discrepancy. This is the same "review gate would be lying about what's actually stored" class of bug this codebase treats as a real defect everywhere else it's found.

## Fix

`batchPushItems()` now returns `{ ok, failedIds }`:
- `ok` is `true` only when every entry persisted.
- `failedIds` carries exactly the entries the server rejected, derived from `items/batch.patch.ts`'s per-entry `results` array on an HTTP 207 partial failure, or every entry when no per-entry breakdown is available at all (a total/network failure).

Both `batchApproveStage()` and `batchSetField()` now snapshot each item's pre-mutation state (`stages`, and `fieldsDraft` for the field-edit case) before applying their optimistic change, and revert exactly the entries found in `failedIds` back to that snapshot once the batch resolves.

Also introduces a named `BatchPushOutcome` return-type interface rather than an inline `Promise<{ ... }>` object literal — this store's own `verifyModelBuilder*Guard.ts` scripts locate a function's body by scanning for the first `{` after its parameter list's closing `)`, and an inline object type in the return-type annotation was matching that scan before the real body brace, breaking two existing guards (`verifyModelBuilderAsyncFetchStalenessCoverage` and `verifyModelBuilderPushItemErrorScopeGuard`) until fixed.

## Guard

New: `utils/scripts/verifyModelBuilderBatchPartialFailureRevertGuard.ts` (+ self-test), asserting `batchPushItems()` still computes/returns `failedIds` and both callers destructure `{ ok, failedIds }` and check `failedIds.has(entry.item.id)` to revert. Wired into `package.json` and `contract-tests.yml` alongside the existing Model Builder guards.

## Verification

- All `test:model-builder-*` npm scripts pass: **85/85** (83 pre-existing + 2 new).
- `vue-tsc --noEmit` (`npm run test`) is clean repo-wide.
- `eslint` is clean on every touched file — the store's 2 pre-existing `no-empty` errors are unchanged/unrelated to this diff (confirmed via `git stash` before/after comparison).
- `prettier --check` was confirmed to already fail repo-wide on `stores/modelBuilderStore.ts` at `main` (unrelated formatting drift, not CI-gated — no workflow runs `prettier`), so it's out of scope per the task's own pre-existing-issues carve-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jdFnR1ezCvU9uQtsKaSkr

---
_Generated by [Claude Code](https://claude.ai/code/session_014jdFnR1ezCvU9uQtsKaSkr)_