### PR TITLE
Fix /art to open on generation and expose Gallery

### DIFF
--- a/components/art/art-studio.vue
+++ b/components/art/art-studio.vue
@@ -1,0 +1,51 @@
+<template>
+  <section class="flex h-full min-h-0 w-full flex-col overflow-hidden">
+    <nav
+      class="mb-2 flex shrink-0 items-center gap-2 kr-panel-flat p-2"
+      aria-label="Art studio views"
+    >
+      <button
+        type="button"
+        class="btn btn-sm rounded-xl"
+        :class="activeTab === 'generate' ? 'btn-primary' : 'btn-ghost'"
+        :aria-pressed="activeTab === 'generate'"
+        @click="selectPrimaryTab('generate')"
+      >
+        <Icon name="kind-icon:sparkles" class="h-4 w-4" />
+        Generate
+      </button>
+
+      <button
+        type="button"
+        class="btn btn-sm rounded-xl"
+        :class="activeTab === 'gallery' ? 'btn-primary' : 'btn-ghost'"
+        :aria-pressed="activeTab === 'gallery'"
+        @click="selectPrimaryTab('gallery')"
+      >
+        <Icon name="kind-icon:gallery" class="h-4 w-4" />
+        Gallery
+      </button>
+
+      <p class="ml-1 hidden text-xs text-base-content/55 md:block">
+        Make something new, or browse what you already made.
+      </p>
+    </nav>
+
+    <art-manager class="min-h-0 flex-1" />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useNavStore } from '@/stores/navStore'
+
+type ArtPrimaryTab = 'generate' | 'gallery'
+
+const navStore = useNavStore()
+
+const activeTab = computed(() => navStore.getDashboardTab('art'))
+
+function selectPrimaryTab(tab: ArtPrimaryTab): void {
+  navStore.setDashboardTab('art', tab, 'art studio primary navigation')
+}
+</script>

--- a/content/art.md
+++ b/content/art.md
@@ -1,24 +1,24 @@
 ---
 title: 'Art'
-room: 'Art Gallery'
-subtitle: 'Your personal art space'
-description: 'This is your space to make and share art created with modellers. Thanks for being a part of the Kind Community!'
+room: 'Art Studio'
+subtitle: 'Create, browse, collect, and remix images'
+description: 'Generate new images first, then browse, organize, and reuse them from your gallery.'
 image: 'background/artgallery.webp'
 icon: splash/aartgallerybout.png
-tooltip: This is a collection of user art.
+tooltip: Create new art or browse your gallery.
 dottiTip: People keep asking if AI art is 'real' art. I never know what to say.
 amiTip: "If it makes you stop and look, have a conversation, or feel something new, I’d say it does its job!"
 sort: highlight
 channelKey: play
 tabKey: art
 dashboardKey: art
-dashboardTab: gallery
+dashboardTab: generate
 cards: artCards
-loadingMessage: Loading art gallery...
+loadingMessage: Loading art studio...
 refreshLabel: Refresh Art
 backgroundMobile: /api/art/backdrop/art-mobile
 backgroundTablet: /api/art/backdrop/art-tablet
 backgroundDesktop: /api/art/backdrop/art-desktop
 ---
 
-:art-manager
+:art-studio

--- a/content/channels/play/art.md
+++ b/content/channels/play/art.md
@@ -3,14 +3,14 @@ contentType: tab
 channelKey: play
 tabKey: art
 dashboardKey: art
-dashboardTab: gallery
+dashboardTab: generate
 label: Art
 title: Art Studio
 subtitle: Generate, browse, collect, and remix images
-description: Create new art, explore the gallery, inspect details, collect favorites, and reuse images in other creations.
+description: Create new art first, then explore the gallery, inspect details, collect favorites, and reuse images in other creations.
 icon: kind-icon:image
 route: /art
 sort: 20
 ---
 
-The Art manager holds generation and gallery tools together, without a second Build doorway.
+The Art studio keeps generation and gallery tools together, with generation as the front door.


### PR DESCRIPTION
## What
- make `/art` enter the Art dashboard on `generate` instead of `gallery`
- align the Play-channel Art metadata with that same generation-first behavior
- add a compact, persistent Generate / Gallery switch above the existing Art manager
- update `/art` copy from gallery-only language to Art Studio language

## Why
The canonical Art dashboard config and `art-manager.vue` both already define `generate` as the default, but `content/art.md` and `content/channels/play/art.md` explicitly overrode that with `dashboardTab: gallery`. `navStore.setDashboardShellFromContent()` then persisted that stale override, so the gallery won every time. The global Play tab picker only exposes the single `Art` channel tab, not the Art manager's internal dashboard views, leaving no obvious path back to Generate.

## Impact
`/art` now presents image generation front and center. Gallery remains one click away, and Generate remains one click away from Gallery. Existing advanced Art manager tabs and generation/gallery implementations are unchanged.

## Verification
- exact branch diff is limited to 3 files: one small Art Studio navigation wrapper plus the two Art content metadata files
- no API, database, generation pipeline, or ArtJob behavior changed
- CI required before merge