### PR TITLE
fix(storybook): carry in-flight/failed art forward on duplicateStory (storybook/t-010)

### DIFF
--- a/.github/workflows/storybook-duplicate-art-carryover-contract.yml
+++ b/.github/workflows/storybook-duplicate-art-carryover-contract.yml
@@ -1,0 +1,30 @@
+name: Storybook Duplicate Art Carryover Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: storybook-duplicate-art-carryover-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Storybook duplicate art carryover contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify Storybook duplicate art carryover guard
+        run: node utils/scripts/verifyStorybookDuplicateArtCarryoverGuard.mjs

--- a/stores/helpers/storybookLibraryHelper.ts
+++ b/stores/helpers/storybookLibraryHelper.ts
@@ -219,14 +219,36 @@ export function createStorybookLibraryController(bridge: StorybookLibraryBridge)
     const beats = duplicate.beats.map((beat) => {
       const beatId = makeId()
       beatIds.set(beat.id, beatId)
+      // Only 'queueing' (enqueue()'s synchronous pre-submit state, no jobId
+      // assigned yet) has to be dropped to `undefined` here -- every other
+      // status is safe to carry forward rekeyed to the duplicate's own ids.
+      // This used to drop every non-'done' status, which silently and
+      // permanently lost a duplicate's illustration state for a beat whose
+      // art was still 'queued'/'rendering' or had previously 'failed': the
+      // Duplicate button is enabled the moment isWeaving() goes false, long
+      // before that beat's background art job resolves, so this is routine
+      // to hit, not an edge case. NarrativeArtStatus renders nothing at all
+      // when `art` is unset (`v-if="art"`) and retryBeatArt() requires a
+      // truthy `beat.art`, so the duplicate was left with no image, no busy
+      // indicator, and no retry affordance for that beat, forever.
+      // 'queued'/'rendering'/'failed'/'cancelled' all already carry a real
+      // `jobId` (or are terminal with none pending), so rekeying their ids is
+      // safe: resume() polls purely by jobId with no re-submission, and
+      // retry() always submits a fresh job scoped to whatever ids are
+      // present. 'queueing' is the one case with no jobId yet -- the real
+      // gap between the optimistic status write and the resolved POST -- so
+      // rekeying it would send the duplicate's later recovery GET query
+      // looking for a job filed under the ORIGINAL's ids and find nothing,
+      // falling through to `submit()` and billing a second illustration for
+      // one beat. Dropping it here, as before, keeps that window safe.
       const art =
-        beat.art?.status === 'done'
+        beat.art && beat.art.status !== 'queueing'
           ? {
               ...beat.art,
               sessionId,
               beatId,
               dedupeKey: [beat.art.product, sessionId, beatId, beat.art.moment].join(':'),
-              jobId: undefined,
+              jobId: beat.art.status === 'done' ? undefined : beat.art.jobId,
               updatedAt: createdAt,
             }
           : undefined

--- a/utils/scripts/verifyStorybookDuplicateArtCarryoverGuard.mjs
+++ b/utils/scripts/verifyStorybookDuplicateArtCarryoverGuard.mjs
@@ -1,0 +1,77 @@
+// /utils/scripts/verifyStorybookDuplicateArtCarryoverGuard.mjs
+//
+// Regression guard (storybook/t-010, front-end polish). `remapDuplicate()` in
+// storybookLibraryHelper.ts is what `duplicateStory()` uses to build the copy
+// that becomes the new active session -- and the "Duplicate" button that
+// calls it is enabled the moment `isWeaving()` goes false, long before that
+// story's most recent beat's background illustration job actually resolves
+// (art generation runs independently of `isWeaving`). Duplicating while a
+// beat's art was still 'queued'/'rendering', or had previously 'failed', used
+// to drop that beat's `art` straight to `undefined` on the copy -- only a
+// `status === 'done'` illustration was carried forward. `NarrativeArtStatus`
+// renders nothing at all when `art` is unset (`v-if="art"`), and
+// `retryBeatArt()` requires a truthy `beat.art` to do anything, so the
+// duplicate was left with no image, no busy indicator, and no retry
+// affordance for that beat -- permanently, with no way for the reader to ever
+// get an illustration there again.
+//
+// The fix carries the art state forward (rekeyed to the duplicate's own
+// session/beat ids) for every status except 'queueing' -- the one gap with no
+// `jobId` assigned yet, where rekeying would send a later recovery GET
+// looking for a job filed under the ORIGINAL's ids, find nothing, and fall
+// through to submitting a second real job for one beat. This asserts that
+// shape stays in place: `remapDuplicate()` still special-cases only
+// 'queueing' for the drop, and still rekeys everything else's identity
+// fields rather than blanket-dropping any non-'done' status.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { extractTsFunctionBody } from './lib/extractTsFunctionBody.mjs'
+
+const HELPER_PATH = 'stores/helpers/storybookLibraryHelper.ts'
+const FN_NAME = 'remapDuplicate'
+
+const content = readFileSync(resolve(process.cwd(), HELPER_PATH), 'utf8')
+const body = extractTsFunctionBody(content, FN_NAME, {
+  path: HELPER_PATH,
+  notFoundHint:
+    'has remapDuplicate() been renamed, removed, or inlined? If so, this ' +
+    'guard (and the duplicate-art-loss bug it protects against) needs to ' +
+    'move with it.',
+})
+
+assert.ok(
+  !body.includes("beat.art?.status === 'done'"),
+  `${FN_NAME}() must not gate art carryover on \`beat.art?.status === 'done'\` ` +
+    "alone -- that blanket-drops every 'queued'/'rendering'/'failed'/" +
+    "'cancelled' illustration on the duplicate, permanently and with no " +
+    'retry path.',
+)
+
+assert.ok(
+  body.includes("beat.art && beat.art.status !== 'queueing'"),
+  `${FN_NAME}() no longer guards art carryover with ` +
+    "`beat.art && beat.art.status !== 'queueing'` -- without this exact " +
+    'condition, either a real illustration gets dropped again (too strict), ' +
+    "or the unresolved 'queueing' gap (no jobId assigned yet) gets rekeyed " +
+    'and risks a second real submission once the original job actually ' +
+    'resolves under ids the duplicate no longer matches (too loose).',
+)
+
+assert.ok(
+  body.includes(
+    "jobId: beat.art.status === 'done' ? undefined : beat.art.jobId",
+  ),
+  `${FN_NAME}() must preserve a carried-over illustration's real \`jobId\` ` +
+    "for every non-'done' status -- clearing it would make resume() treat " +
+    "an already-submitted 'queued'/'rendering' job as needing recovery, " +
+    'risking the exact double-submission this guard exists to prevent.',
+)
+
+console.log(
+  'Storybook duplicate-art-carryover guard contract passed: remapDuplicate() ' +
+    'still carries a queued, rendering, failed, or cancelled illustration ' +
+    'forward onto the duplicate (rekeyed, jobId intact) instead of silently ' +
+    'and permanently dropping it, while still refusing to rekey the one ' +
+    "genuinely unsafe 'queueing' (no jobId yet) window.",
+)

--- a/utils/scripts/verifyStorybookSessionLibrary.mjs
+++ b/utils/scripts/verifyStorybookSessionLibrary.mjs
@@ -34,8 +34,13 @@ includesAll(helperPath, [
   'const beatIds = new Map<string, string>()',
   'const beatId = makeId()',
   "dedupeKey: [beat.art.product, sessionId, beatId, beat.art.moment].join(':')",
-  'jobId: undefined',
-  "beat.art?.status === 'done'",
+  // storybook/t-010 (verifyStorybookDuplicateArtCarryoverGuard): a duplicate
+  // used to carry forward only a `status === 'done'` illustration, silently
+  // and permanently dropping any queued/rendering/failed one instead. The
+  // fixed shape carries every status except the unresolved 'queueing' gap
+  // forward, clearing `jobId` only once an illustration is actually done.
+  "jobId: beat.art.status === 'done' ? undefined : beat.art.jobId",
+  "beat.art && beat.art.status !== 'queueing'",
   'branchHistory: duplicate.branchHistory.map',
   'consequences: duplicate.consequences.map',
   'inventory: duplicate.inventory.map',


### PR DESCRIPTION
### Task
storybook/t-010: Polish and upgrade Storybook front-end surface (kind: software) — recurring bug-hunt cycle 16.

### What changed / what I produced
- **Bug**: `remapDuplicate()` in `stores/helpers/storybookLibraryHelper.ts` (used by `duplicateStory()`) only carried a beat's illustration forward onto the duplicate when its status was `'done'`. The "Duplicate" button in `storybook-library-page.vue` is enabled the moment `isWeaving()` goes false — well before that beat's background art job actually resolves (art generation runs independently of `isWeaving`) — so duplicating a story while its most recent illustration was still `'queued'`/`'rendering'`, or had previously `'failed'`/`'cancelled'`, silently and permanently dropped that beat's `art` to `undefined` on the copy. `NarrativeArtStatus` renders nothing at all when `art` is unset (`v-if="art"`), and `retryBeatArt()` requires a truthy `beat.art` to do anything — so the duplicate ended up with no image, no busy indicator, and no retry affordance for that beat, forever. The original session was unaffected (its own art job keeps polling normally); only the duplicate's copy of that beat lost the reference.
- **Fix**: carry the art state forward (rekeyed to the duplicate's own session/beat ids, matching the existing `'done'` handling) for every status except `'queueing'` — the one gap with no `jobId` assigned yet (the real window between the optimistic status write and the resolved POST). Rekeying `'queueing'` would send the duplicate's later recovery GET looking for a job filed under the ORIGINAL's ids, find nothing, and fall through to submitting a second real job for one beat — so that one case is still dropped, exactly as before, to keep the window safe. `jobId` is cleared only once a status is `'done'` (no longer needs polling); every other carried-over status keeps its real `jobId` so `resume()` polls the existing job directly with no re-submission risk, and a failed/cancelled illustration now correctly exposes its retry button on the duplicate.
- Added the 15th `verifyStorybook*` guard: `utils/scripts/verifyStorybookDuplicateArtCarryoverGuard.mjs` + `.github/workflows/storybook-duplicate-art-carryover-contract.yml`, matching the established per-guard-workflow convention exactly (no `package.json` wiring — none of the 14 prior guards are wired there either; each runs directly via its own workflow).
- Updated `utils/scripts/verifyStorybookSessionLibrary.mjs`'s literal-shape assertions (`jobId: undefined` / `beat.art?.status === 'done'`), which had locked in the old buggy code shape verbatim, to assert the corrected shape instead.

### How I verified
- Fresh read of `stores/storybookStore.ts`, `stores/helpers/storybookLibraryHelper.ts`, `stores/helpers/narrativeArtJobsHelper.ts`, `utils/narrativeArtJobs.ts`, `components/conductor/storybook-page.vue`, `components/pages/storybook-library-page.vue`, `components/narrative/narrative-art-status.vue`.
- Cross-checked all 14 existing `verifyStorybook*` guards' doc comments before picking this bug — none cover `remapDuplicate()`/`duplicateStory()` art handling.
- New guard: confirmed it **fails on pre-fix code** (git-stash round-trip: `AssertionError` on the `'done'`-only gate) and **passes post-fix**.
- All 14 pre-existing `verifyStorybook*` guards still pass (no regression) — including `verifyStorybookSessionLibrary.mjs` after updating its shape assertions.
- `eslint` clean on all touched/new files (one pre-existing `no-unused-vars` on an unrelated line of `verifyStorybookSessionLibrary.mjs` confirmed via git-stash to predate this change; left untouched, out of scope).
- `prettier --check` clean on the new guard file; the two pre-existing files I touched already had unrelated formatting drift, confirmed via git-stash to predate this change — left untouched per the repo's own documented lesson about not running a blanket `--write`.
- `vue-tsc --noEmit` repo-wide: clean, no output.
- `git status --porcelain` showed exactly the 4 intended files.

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
`updateBeatArt()` in `storybookStore.ts` looks up the target beat via `session.value?.beats.find(...)`, implicitly assuming `session.value` still refers to the session that originally requested the art. If a reader switches sessions (duplicates, opens another library story, restarts) while a *different* beat's art job is still in flight, that job's eventual `update()` callback silently no-ops against whichever session happens to be active by then, rather than updating the session it actually belongs to. In every case traced so far this self-heals on next open (via `resumeNarrativeArtJobs()`'s recovery/poll path re-fetching real server state), so no data loss was found — but it costs a background poll timer that runs to completion writing into the void, and it's a shape worth a dedicated future cycle's attention if a case is found where it doesn't self-heal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB3pAMRV3GdWHZwxiSVpdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01JB3pAMRV3GdWHZwxiSVpdC)_