### PR TITLE
davinci: add role="alert" to the narration-error callout (t-021 slice 8)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -284,6 +284,12 @@ jobs:
       - name: Da Vinci dimension-group guard
         run: npm run test:davinci-dimension-group-guard
 
+      - name: Da Vinci narration-error role guard self-test
+        run: npm run test:davinci-narration-error-role-guard-selftest
+
+      - name: Da Vinci narration-error role guard
+        run: npm run test:davinci-narration-error-role-guard
+
       - name: Serendipity Voice poll guard self-test
         run: npm run test:serendipity-voice-poll-guard-selftest
 

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -200,9 +200,18 @@
           <!-- Narration failed. Per the narration-layer spec a broken chapter
                surfaces a visible retry rather than a silently fabricated one,
                so the curated pool is offered as an explicit, labelled choice
-               instead of a transparent fallback. -->
+               instead of a transparent fallback. role="alert" matches every
+               other warning/error-toned callout with a retry action in the
+               app -- academy-manager.vue's kr-note-error block is the
+               closest structural match (same tinted-callout + retry-button
+               shape, same role="alert"), and this file's own errorMessage
+               callout above already carries it. This was the one
+               warning-toned block in davinci-page.vue with no role/aria
+               semantics at all, left uncovered even after slice 2 fixed its
+               color tone. -->
           <div
             v-else-if="narrationError"
+            role="alert"
             class="flex flex-col items-center gap-3 rounded-2xl border border-warning/40 bg-warning/10 p-6 text-center"
           >
             <Icon name="kind-icon:warning" class="size-8 text-warning/70" />

--- a/package.json
+++ b/package.json
@@ -93,6 +93,8 @@
     "test:davinci-choice-list-guard": "tsx utils/scripts/verifyDaVinciChoiceListGuard.ts",
     "test:davinci-dimension-group-guard-selftest": "tsx utils/scripts/verifyDaVinciDimensionGroupGuard.test.ts",
     "test:davinci-dimension-group-guard": "tsx utils/scripts/verifyDaVinciDimensionGroupGuard.ts",
+    "test:davinci-narration-error-role-guard-selftest": "tsx utils/scripts/verifyDaVinciNarrationErrorRoleGuard.test.ts",
+    "test:davinci-narration-error-role-guard": "tsx utils/scripts/verifyDaVinciNarrationErrorRoleGuard.ts",
     "test:serendipity-voice-poll-guard-selftest": "tsx utils/scripts/verifySerendipityVoicePollGuard.test.ts",
     "test:serendipity-voice-poll-guard": "tsx utils/scripts/verifySerendipityVoicePollGuard.ts",
     "test:serendipity-voice-cursor-reset-selftest": "tsx utils/scripts/verifySerendipityVoiceCursorReset.test.ts",

--- a/utils/scripts/verifyDaVinciNarrationErrorRoleGuard.test.ts
+++ b/utils/scripts/verifyDaVinciNarrationErrorRoleGuard.test.ts
@@ -1,0 +1,70 @@
+// /utils/scripts/verifyDaVinciNarrationErrorRoleGuard.test.ts
+//
+// Regression test for checkNarrationErrorRoleGuard() in
+// verifyDaVinciNarrationErrorRoleGuard.ts (davinci/t-021 slice 8). Exercises
+// the real check against synthetic component-shaped fixtures covering: the
+// fixed shape (role="alert" present), the pre-fix shape (no role attribute
+// at all), and a missing-block regression (the narration-error callout
+// removed entirely).
+import assert from 'node:assert/strict'
+
+import { checkNarrationErrorRoleGuard } from './verifyDaVinciNarrationErrorRoleGuard.js'
+
+function fixture(openingTagExtra: string): string {
+  return `
+<template>
+  <div
+    v-else-if="narrationError"
+    ${openingTagExtra}
+    class="flex flex-col items-center gap-3 rounded-2xl border border-warning/40 bg-warning/10 p-6 text-center"
+  >
+    <Icon name="kind-icon:warning" class="size-8 text-warning/70" />
+    <p class="text-sm text-base-content/70">
+      The narrator is having trouble with this chapter.
+    </p>
+  </div>
+</template>
+`
+}
+
+const FIXED = fixture('role="alert"')
+
+// Pre-fix shape: no role attribute at all.
+const BUGGY = fixture('')
+
+// The narration-error block itself no longer exists.
+const BLOCK_REMOVED = `
+<template>
+  <div v-else class="flex flex-col items-center gap-3">
+    <p>Something went wrong.</p>
+  </div>
+</template>
+`
+
+function run(): void {
+  const fixedErrors = checkNarrationErrorRoleGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const buggyErrors = checkNarrationErrorRoleGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    1,
+    `expected the missing-role fixture to fail exactly one check, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(buggyErrors.some((e) => /no longer carries role="alert"/.test(e)))
+
+  const blockRemovedErrors = checkNarrationErrorRoleGuard(BLOCK_REMOVED)
+  assert.equal(blockRemovedErrors.length, 1)
+  assert.ok(blockRemovedErrors.some((e) => /Could not find a/.test(e)))
+
+  console.log(
+    'Da Vinci narration-error role guard self-test passed: buggy fixture ' +
+      'fails, fixed fixture passes, missing-block regression fails.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyDaVinciNarrationErrorRoleGuard.ts
+++ b/utils/scripts/verifyDaVinciNarrationErrorRoleGuard.ts
@@ -1,0 +1,108 @@
+// /utils/scripts/verifyDaVinciNarrationErrorRoleGuard.ts
+//
+// Regression guard (davinci/t-021 slice 8) -- the narration-error callout in
+// components/conductor/davinci-page.vue (`v-else-if="narrationError"`) had
+// no role or aria-live semantics at all: a purely visual warning-tinted
+// block with an icon, message, and two action buttons (retry / switch to
+// the curated pool), announcing nothing to assistive tech when a narration
+// failure occurred. Slice 2 already fixed this exact block's color-tone
+// opacity drift (verifyDaVinciNarrationErrorToneGuard.ts) without touching
+// its missing semantics -- this closes the gap that fix left behind.
+//
+// Every other warning/error-toned callout in the app carries role="alert",
+// including this same file's own top-of-page errorMessage callout
+// (`v-if="errorMessage"`, a few lines above this block) and, as the closest
+// structural match, academy-manager.vue's `managerError` block: the same
+// tinted-callout-plus-retry-button shape, also role="alert". Also confirmed
+// on narrative-ingredient-picker.vue's and
+// narrative-ingredient-multi-picker.vue's error blocks, coloring-book-studio
+// .vue's alert-error, and challenge-center-page.vue's alert-warning.
+//
+// Fixed by adding role="alert" to the narrationError div. This asserts the
+// textual shape of that fix stays in place -- deliberately scoped to this
+// one template block, mirroring this project's other narrow textual guards
+// over a general-purpose static analyzer (see
+// verifyDaVinciNarrationErrorToneGuard.ts, verifyDaVinciNarratingStatusGuard.ts).
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const COMPONENT_PATH = join(
+  repositoryRoot,
+  'components/conductor/davinci-page.vue',
+)
+
+// Anchored on the `v-else-if="narrationError"` marker rather than any
+// surrounding wording, so this guard reports *how* the block regressed
+// (missing role vs. missing entirely) instead of just "not found".
+const BLOCK_MARKER = 'v-else-if="narrationError"'
+
+export function extractNarrationErrorOpeningTag(
+  content: string,
+): string | null {
+  const markerIndex = content.indexOf(BLOCK_MARKER)
+  if (markerIndex === -1) return null
+
+  const tagStart = content.lastIndexOf('<div', markerIndex)
+  if (tagStart === -1) return null
+  const tagEnd = content.indexOf('>', markerIndex)
+  if (tagEnd === -1) return null
+
+  return content.slice(tagStart, tagEnd + 1)
+}
+
+export function checkNarrationErrorRoleGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const openingTag = extractNarrationErrorOpeningTag(content)
+  if (!openingTag) {
+    errors.push(
+      `Could not find a \`${BLOCK_MARKER}\` block in davinci-page.vue -- ` +
+        'has the narration-error callout been renamed, removed, or ' +
+        'restructured? If so, this guard needs to move with it.',
+    )
+    return errors
+  }
+
+  if (!openingTag.includes('role="alert"')) {
+    errors.push(
+      'The narration-error callout no longer carries role="alert" -- ' +
+        'assistive tech gets no signal that narration failed, unlike this ' +
+        "file's own errorMessage callout and every comparable warning/" +
+        "error-toned block elsewhere in the app (academy-manager.vue's " +
+        "managerError block, narrative-ingredient-picker.vue's and " +
+        "-multi-picker.vue's error blocks, coloring-book-studio.vue's " +
+        "alert-error, challenge-center-page.vue's alert-warning).",
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(COMPONENT_PATH, 'utf8')
+  const errors = checkNarrationErrorRoleGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Da Vinci narration-error role guard contract failed in davinci-page.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Da Vinci narration-error role guard contract passed: the narration-error ' +
+      'callout still carries role="alert", matching this file\'s own ' +
+      'errorMessage callout and every other warning/error-toned block in ' +
+      'the app.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
davinci/t-021: Da Vinci visual style and interaction polish pass — slice 8 (kind: software)

### What changed / what I produced
- Audited `components/conductor/davinci-page.vue` against all 7 prior slices' guards (grepped and read every existing `verifyDaVinci*` guard first) and the house style ("not a `.kr-panel` crusade" — one concrete, verifiable gap, not a reskin).
- Found: the narration-error callout (`v-else-if="narrationError"`, the panel shown when a chapter fails to narrate) had no `role` or `aria-live` semantics at all — a purely visual warning-tinted block with an icon, message, and two action buttons (retry / switch to the curated pool). Slice 2 already fixed this exact block's color-tone opacity drift (`verifyDaVinciNarrationErrorToneGuard.ts`) without touching its missing ARIA semantics, so this closes the gap that fix left behind.
- Every other warning/error-toned callout in the app carries `role="alert"`, including this same file's own top-of-page `errorMessage` callout a few lines above, and, as the closest structural match, `academy-manager.vue`'s `managerError` block (same tinted-callout + retry-button shape, also `role="alert"`). Also confirmed on `narrative-ingredient-picker.vue`'s and `-multi-picker.vue`'s error blocks, `coloring-book-studio.vue`'s `alert-error`, and `challenge-center-page.vue`'s `alert-warning`.
- Fixed by adding `role="alert"` to the div.
- Added `verifyDaVinciNarrationErrorRoleGuard.ts` + `.test.ts` following this project's established narrow-textual-checker convention, wired into `package.json` and `.github/workflows/contract-tests.yml` alongside the seven existing davinci guards.
- Considered the task note's other candidate direction (the outstanding phone/tablet/desktop rendered-preview verification) but confirmed via `AGENTS.md`'s documented Vercel-preview-retirement section that real pixel-level pre-merge verification is not possible in this sandbox (no PR preview since the Vercel migration, headless Chromium fails through the proxy against every host) — this is unchanged from every prior slice's precedent, so continued the concrete-gap audit instead.

### How I verified
- New guard + selftest pass.
- Guard fails pre-fix / passes post-fix via a `git stash` round-trip against the real component.
- All seven prior `verifyDaVinci*` guards + selftests still pass.
- `npm run test:davinci-narration` still passes (12/12).
- `npm run test:layout-contract` holds with no new violations (one pre-existing baseline improvement unrelated to this change, elsewhere in the app).
- `eslint` clean on every changed/added file.
- `prettier --check` clean (after one `--write` pass to normalize the two new files).
- `vue-tsc --noEmit` repo-wide: 0 errors.
- `git status --porcelain` shows exactly the 5 intended files: `components/conductor/davinci-page.vue`, `utils/scripts/verifyDaVinciNarrationErrorRoleGuard.ts`, `utils/scripts/verifyDaVinciNarrationErrorRoleGuard.test.ts`, `package.json`, `.github/workflows/contract-tests.yml`.

### Stakes
reversible

### Flags for Reviewer
- This session's sandbox isolated Bash/Edit git operations to my own worktree (a different repo, `conductor`), so I could not edit `/home/user/kind_robots` directly. Worked around it by cloning `kind_robots` fresh into my own worktree, doing all edits/verification there, and pushing normally from that clone — no shared-checkout state was touched.

### Kaizen suggestion
None of this file's remaining hand-rolled outer `<section>` wrappers deviate from an established sibling convention (checked `.kr-panel`'s `rounded-2xl`/`p-6` formula against davinci's `rounded-3xl`/`p-5` — that exact shape is also used correctly by `project-deliverables-panel.vue`, so it's a legitimate existing pattern, not a gap). The next slice should keep auditing for a similarly concrete, narrow gap rather than reaching for a reskin.

### Notes for reviewer
None.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JB3pAMRV3GdWHZwxiSVpdC)_