### PR TITLE
model-builder: revert single-item optimistic mutation on failed PATCH (t-029 cycle 10)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -575,6 +575,12 @@ jobs:
       - name: Model Builder batch partial-failure revert guard contract
         run: npm run test:model-builder-batch-partial-failure-revert-guard
 
+      - name: Model Builder single-item revert guard self-test
+        run: npm run test:model-builder-single-item-revert-guard-selftest
+
+      - name: Model Builder single-item revert guard contract
+        run: npm run test:model-builder-single-item-revert-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -268,6 +268,8 @@
     "test:model-builder-error-persistence-guard": "tsx utils/scripts/verifyModelBuilderErrorPersistenceGuard.ts",
     "test:model-builder-batch-partial-failure-revert-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchPartialFailureRevertGuard.test.ts",
     "test:model-builder-batch-partial-failure-revert-guard": "tsx utils/scripts/verifyModelBuilderBatchPartialFailureRevertGuard.ts",
+    "test:model-builder-single-item-revert-guard-selftest": "tsx utils/scripts/verifyModelBuilderSingleItemRevertGuard.test.ts",
+    "test:model-builder-single-item-revert-guard": "tsx utils/scripts/verifyModelBuilderSingleItemRevertGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -742,10 +742,25 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   // Background persistence of a single item. Callers mutate local state first
   // (optimistic) and pass only the changed fields; a draft change also carries
   // stage metadata so the server records a revision.
+  //
+  // onFailure (model-builder/t-029 cycle 10): invoked once, synchronously,
+  // when the PATCH genuinely fails -- either a `{success:false}` response or
+  // a rejected promise -- so the caller can revert exactly the optimistic
+  // mutation it made before this call, mirroring batchApproveStage/
+  // batchSetField's own pre-mutation-snapshot pattern (cycle 9) at
+  // single-item scope. Before this, a failed single-item PATCH already
+  // surfaced an error toast via setStatusForRun below, but the item itself
+  // (approved badge, edited pitch/fields/prompt text, stage statuses) kept
+  // showing the unpersisted optimistic change until a full reload rebuilt it
+  // from the server's real (unchanged) state -- the same "review gate lying
+  // about what's actually stored" class of bug this codebase treats as real
+  // everywhere else it's found. onFailure is optional and additive: callers
+  // that don't pass one keep today's toast-only behavior unchanged.
   function pushItem(
     item: BuildItem,
     payload: Record<string, unknown>,
     meta?: { stage?: string; reason?: string },
+    onFailure?: () => void,
   ): void {
     const runId = state.run?.id
     performFetch(`/api/model-builder/items/${item.id}`, {
@@ -754,12 +769,15 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       body: JSON.stringify({ ...payload, ...meta }),
     })
       .then((response) => {
-        if (!response.success && runId) {
-          setStatusForRun(
-            runId,
-            'error',
-            response.message || 'Failed to save changes.',
-          )
+        if (!response.success) {
+          onFailure?.()
+          if (runId) {
+            setStatusForRun(
+              runId,
+              'error',
+              response.message || 'Failed to save changes.',
+            )
+          }
         }
       })
       .catch((error) => {
@@ -769,6 +787,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         // elsewhere shouldn't pop a global error banner for a run that's no
         // longer on screen. setStatusForRun already no-ops unless state.run
         // still matches the run this write belonged to.
+        onFailure?.()
         if (runId) {
           setStatusForRun(
             runId,
@@ -947,12 +966,19 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   function approveStage(itemId: string, stageKey: BuildStageKey): void {
     const item = findItem(itemId)
     if (!item) return
+    // Snapshotted before the optimistic mutation below so a failed PATCH can
+    // revert to exactly what this item held before this call, instead of
+    // leaving an approval that was never actually persisted (see pushItem's
+    // onFailure doc comment).
+    const previousStages = { ...item.stages }
     item.stages[stageKey] = { status: 'approved' }
     const next = BUILD_STAGES[stageIndex(stageKey) + 1]
     if (next && item.stages[next.key].status === 'locked') {
       item.stages[next.key] = { status: 'ready' }
     }
-    pushItem(item, { stageStatuses: item.stages }, { stage: stageKey })
+    pushItem(item, { stageStatuses: item.stages }, { stage: stageKey }, () => {
+      item.stages = previousStages
+    })
   }
 
   function rejectStage(
@@ -962,18 +988,24 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   ): void {
     const item = findItem(itemId)
     if (!item) return
+    const previousStages = { ...item.stages }
     item.stages[stageKey] = { status: 'rejected', note }
     markDownstreamStale(item, stageKey)
-    pushItem(item, { stageStatuses: item.stages }, { stage: stageKey })
+    pushItem(item, { stageStatuses: item.stages }, { stage: stageKey }, () => {
+      item.stages = previousStages
+    })
   }
 
   // Reopen a stale/approved stage for editing and invalidate downstream.
   function reopenStage(itemId: string, stageKey: BuildStageKey): void {
     const item = findItem(itemId)
     if (!item) return
+    const previousStages = { ...item.stages }
     item.stages[stageKey] = { status: 'ready' }
     markDownstreamStale(item, stageKey)
-    pushItem(item, { stageStatuses: item.stages }, { stage: stageKey })
+    pushItem(item, { stageStatuses: item.stages }, { stage: stageKey }, () => {
+      item.stages = previousStages
+    })
   }
 
   // error: null (both locally and in the pushed payload) on all three setters
@@ -991,6 +1023,12 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   function updatePitch(itemId: string, value: string): void {
     const item = findItem(itemId)
     if (!item) return
+    // Snapshotted before the optimistic mutation below so a failed PATCH can
+    // revert to exactly what this item held before this call (see pushItem's
+    // onFailure doc comment).
+    const previousPitch = item.pitch
+    const previousError = item.error
+    const previousStages = { ...item.stages }
     item.pitch = value
     item.error = null
     markDownstreamStale(item, 'PITCH')
@@ -998,12 +1036,20 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       item,
       { stageStatuses: item.stages, pitch: item.pitch, error: null },
       { stage: 'PITCH', reason: 'edited pitch' },
+      () => {
+        item.pitch = previousPitch
+        item.error = previousError
+        item.stages = previousStages
+      },
     )
   }
 
   function updateFields(itemId: string, value: string): void {
     const item = findItem(itemId)
     if (!item) return
+    const previousFieldsDraft = item.fieldsDraft
+    const previousError = item.error
+    const previousStages = { ...item.stages }
     item.fieldsDraft = value
     item.error = null
     markDownstreamStale(item, 'FIELDS_AND_PROMPTS')
@@ -1015,12 +1061,20 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         error: null,
       },
       { stage: 'FIELDS_AND_PROMPTS', reason: 'edited fields' },
+      () => {
+        item.fieldsDraft = previousFieldsDraft
+        item.error = previousError
+        item.stages = previousStages
+      },
     )
   }
 
   function updatePrompt(itemId: string, value: string): void {
     const item = findItem(itemId)
     if (!item) return
+    const previousPromptDraft = item.promptDraft
+    const previousError = item.error
+    const previousStages = { ...item.stages }
     item.promptDraft = value
     item.error = null
     markDownstreamStale(item, 'FIELDS_AND_PROMPTS')
@@ -1032,6 +1086,11 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         error: null,
       },
       { stage: 'FIELDS_AND_PROMPTS', reason: 'edited prompt' },
+      () => {
+        item.promptDraft = previousPromptDraft
+        item.error = previousError
+        item.stages = previousStages
+      },
     )
   }
 

--- a/utils/scripts/verifyModelBuilderSingleItemRevertGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderSingleItemRevertGuard.test.ts
@@ -1,0 +1,197 @@
+// /utils/scripts/verifyModelBuilderSingleItemRevertGuard.test.ts
+//
+// Regression test for checkSingleItemRevertGuard() in
+// verifyModelBuilderSingleItemRevertGuard.ts (model-builder/t-029 cycle 10).
+// Exercises the real check against synthetic store-shaped fixtures covering:
+// the pre-fix shape (pushItem has no onFailure param/calls, none of the six
+// single-item mutators snapshot or revert), the fixed shape (all six do), and
+// a partially-regressed shape (only one mutator lost its revert).
+import assert from 'node:assert/strict'
+
+import { checkSingleItemRevertGuard } from './verifyModelBuilderSingleItemRevertGuard.js'
+
+function pushItemFixture(hasOnFailure: boolean): string {
+  return hasOnFailure
+    ? `
+  function pushItem(
+    item: BuildItem,
+    payload: Record<string, unknown>,
+    meta?: { stage?: string; reason?: string },
+    onFailure?: () => void,
+  ): void {
+    performFetch('/api/model-builder/items/' + item.id, {})
+      .then((response) => {
+        if (!response.success) {
+          onFailure?.()
+          if (runId) setStatusForRun(runId, 'error', response.message)
+        }
+      })
+      .catch((error) => {
+        onFailure?.()
+        if (runId) setStatusForRun(runId, 'error', 'failed')
+      })
+  }
+`
+    : `
+  function pushItem(
+    item: BuildItem,
+    payload: Record<string, unknown>,
+    meta?: { stage?: string; reason?: string },
+  ): void {
+    performFetch('/api/model-builder/items/' + item.id, {})
+      .then((response) => {
+        if (!response.success && runId) {
+          setStatusForRun(runId, 'error', response.message)
+        }
+      })
+      .catch((error) => {
+        if (runId) setStatusForRun(runId, 'error', 'failed')
+      })
+  }
+`
+}
+
+function stageCallerFixture(opts: { name: string; reverts: boolean }): string {
+  const body = opts.reverts
+    ? `
+    const previousStages = { ...item.stages }
+    item.stages[stageKey] = { status: 'approved' }
+    pushItem(item, { stageStatuses: item.stages }, { stage: stageKey }, () => {
+      item.stages = previousStages
+    })`
+    : `
+    item.stages[stageKey] = { status: 'approved' }
+    pushItem(item, { stageStatuses: item.stages }, { stage: stageKey })`
+  return `
+  function ${opts.name}(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    ${body}
+  }
+`
+}
+
+function textCallerFixture(opts: {
+  name: string
+  field: string
+  reverts: boolean
+}): string {
+  const body = opts.reverts
+    ? `
+    const previous${cap(opts.field)} = item.${opts.field}
+    item.${opts.field} = value
+    pushItem(item, { ${opts.field}: item.${opts.field} }, { stage: 'PITCH' }, () => {
+      item.${opts.field} = previous${cap(opts.field)}
+    })`
+    : `
+    item.${opts.field} = value
+    pushItem(item, { ${opts.field}: item.${opts.field} }, { stage: 'PITCH' })`
+  return `
+  function ${opts.name}(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    ${body}
+  }
+`
+}
+
+function cap(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+function allCallers(reverts: boolean): string {
+  return [
+    stageCallerFixture({ name: 'approveStage', reverts }),
+    stageCallerFixture({ name: 'rejectStage', reverts }),
+    stageCallerFixture({ name: 'reopenStage', reverts }),
+    textCallerFixture({ name: 'updatePitch', field: 'pitch', reverts }),
+    textCallerFixture({
+      name: 'updateFields',
+      field: 'fieldsDraft',
+      reverts,
+    }),
+    textCallerFixture({
+      name: 'updatePrompt',
+      field: 'promptDraft',
+      reverts,
+    }),
+  ].join('\n')
+}
+
+const BUGGY = [pushItemFixture(false), allCallers(false)].join('\n')
+const FIXED = [pushItemFixture(true), allCallers(true)].join('\n')
+
+// Regressed: pushItem still supports onFailure and five of the six mutators
+// still revert, but updatePitch was edited back to the old no-snapshot,
+// no-revert shape (e.g. a bad merge that only carried the fix forward
+// partially).
+const PARTIALLY_REGRESSED = [
+  pushItemFixture(true),
+  stageCallerFixture({ name: 'approveStage', reverts: true }),
+  stageCallerFixture({ name: 'rejectStage', reverts: true }),
+  stageCallerFixture({ name: 'reopenStage', reverts: true }),
+  textCallerFixture({ name: 'updatePitch', field: 'pitch', reverts: false }),
+  textCallerFixture({
+    name: 'updateFields',
+    field: 'fieldsDraft',
+    reverts: true,
+  }),
+  textCallerFixture({
+    name: 'updatePrompt',
+    field: 'promptDraft',
+    reverts: true,
+  }),
+].join('\n')
+
+function run(): void {
+  const buggyErrors = checkSingleItemRevertGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    14,
+    'expected the pre-fix fixture (no onFailure anywhere, no mutator ' +
+      `reverts) to fail 14 times (2 for pushItem + 2 for each of 6 ` +
+      `callers), got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(buggyErrors.some((e) => /no longer declares an `onFailure/.test(e)))
+  assert.ok(buggyErrors.some((e) => /no longer invokes onFailure\(\)/.test(e)))
+  assert.ok(
+    buggyErrors.filter((e) => /no longer snapshots/.test(e)).length === 6,
+  )
+  assert.ok(
+    buggyErrors.filter((e) => /no longer passes a revert closure/.test(e))
+      .length === 6,
+  )
+
+  const fixedErrors = checkSingleItemRevertGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const regressedErrors = checkSingleItemRevertGuard(PARTIALLY_REGRESSED)
+  assert.equal(
+    regressedErrors.length,
+    2,
+    'expected a fixture where only updatePitch regressed to fail exactly ' +
+      `twice (snapshot + revert-check), got: ${JSON.stringify(regressedErrors)}`,
+  )
+  assert.ok(regressedErrors.every((e) => e.startsWith('updatePitch()')))
+
+  const missingFnErrors = checkSingleItemRevertGuard(
+    'function someOtherFunction(): void {}',
+  )
+  assert.equal(missingFnErrors.length, 7)
+  assert.ok(
+    missingFnErrors.every((e) => /Could not find a function named/.test(e)),
+  )
+
+  console.log(
+    'Model Builder single-item revert-on-failure guard self-test passed: ' +
+      'buggy fixture fails, fixed fixture passes, a partially-regressed ' +
+      'fixture fails only for the still-broken mutator, missing-function ' +
+      'fixture fails clearly.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderSingleItemRevertGuard.ts
+++ b/utils/scripts/verifyModelBuilderSingleItemRevertGuard.ts
@@ -1,0 +1,164 @@
+// /utils/scripts/verifyModelBuilderSingleItemRevertGuard.ts
+//
+// Regression guard (model-builder/t-029 cycle 10). Cycle 9 gave
+// batchPushItems() a `{ ok, failedIds }` result so batchApproveStage() /
+// batchSetField() could revert exactly the group entries a partial batch
+// failure rejected (see verifyModelBuilderBatchPartialFailureRevertGuard.ts),
+// and left as its suggested next lead: pushItem() -- the single-item
+// background PATCH used by approveStage/rejectStage/reopenStage/updatePitch/
+// updateFields/updatePrompt -- has the identical fire-and-forget,
+// no-local-revert-on-failure shape. A failed single-item PATCH already
+// surfaced an error toast via setStatusForRun, but the item itself (approved
+// badge, edited pitch/fields/prompt text, stage statuses) kept showing the
+// unpersisted optimistic change until a full reload rebuilt it from the
+// server's real (unchanged) state -- the same "review gate lying about what's
+// actually stored" class of bug this codebase treats as real everywhere else
+// it's found (batch scope, item.error persistence, stageStatuses JSON
+// parsing, ...).
+//
+// Fixed by giving pushItem() an optional `onFailure?: () => void` callback,
+// invoked from both its `.then` success:false branch and its `.catch` branch
+// (mirroring where it already calls setStatusForRun), and having each of the
+// six single-item mutators snapshot the fields it's about to change and pass
+// a revert closure as pushItem's 4th argument.
+//
+// This asserts the textual shape of that fix stays in place: pushItem()
+// declares an `onFailure` parameter and invokes it (`onFailure?.()` or
+// `onFailure()`) from both its response-handling branches, and each of the
+// six callers below both snapshots its own pre-mutation state and passes an
+// arrow-function 4th argument to its own pushItem(...) call that reassigns
+// at least one of the snapshotted fields back.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+// extractFunctionBodies only captures a function's body (between its outer
+// braces), not its parameter list, so the onFailure *parameter* has to be
+// checked against the raw signature text instead of fn.body. Captures
+// everything between pushItem('s opening paren and the `): void {` that
+// closes its parameter list -- non-greedy, so it stops at the first such
+// close rather than a later unrelated one -- and requires an `onFailure`
+// parameter somewhere in that captured list.
+const PUSHITEM_SIGNATURE = /function pushItem\(([\s\S]*?)\)\s*:\s*void\s*\{/
+const ONFAILURE_PARAM = /onFailure\s*\?\s*:\s*\(\s*\)\s*=>\s*void/
+const ONFAILURE_CALL = /onFailure\s*\?\.?\s*\(\s*\)/
+
+// Each single-item mutator: the field(s) it snapshots before mutating, and
+// the field it must restore inside the 4th-argument revert closure passed to
+// its own pushItem(...) call.
+const CALLER_FIELDS: Record<string, string> = {
+  approveStage: 'stages',
+  rejectStage: 'stages',
+  reopenStage: 'stages',
+  updatePitch: 'pitch',
+  updateFields: 'fieldsDraft',
+  updatePrompt: 'promptDraft',
+}
+
+export function checkSingleItemRevertGuard(content: string): string[] {
+  const errors: string[] = []
+  const functions = extractFunctionBodies(content)
+
+  const pushItemFn = functions.find((f) => f.name === 'pushItem')
+  if (!pushItemFn) {
+    errors.push(
+      'Could not find a function named pushItem() -- has it been renamed, ' +
+        'removed, or inlined? If so, this guard (and the bug it protects ' +
+        'against) needs to move with it.',
+    )
+  } else {
+    const signatureMatch = PUSHITEM_SIGNATURE.exec(content)
+    if (!signatureMatch || !ONFAILURE_PARAM.test(signatureMatch[1]!)) {
+      errors.push(
+        'pushItem() no longer declares an `onFailure?: () => void` ' +
+          'parameter -- without it, none of its callers have a way to ' +
+          'revert their optimistic local mutation when the PATCH actually ' +
+          'fails.',
+      )
+    }
+    const onFailureCalls = pushItemFn.body.match(
+      new RegExp(ONFAILURE_CALL, 'g'),
+    )
+    if (!onFailureCalls || onFailureCalls.length < 2) {
+      errors.push(
+        'pushItem() no longer invokes onFailure() from both its `.then` ' +
+          'success:false branch and its `.catch` branch -- a failure ' +
+          'reached through only one of the two paths would silently skip ' +
+          "the caller's revert.",
+      )
+    }
+  }
+
+  for (const [fnName, field] of Object.entries(CALLER_FIELDS)) {
+    const fn = functions.find((f) => f.name === fnName)
+    if (!fn) {
+      errors.push(
+        `Could not find a function named ${fnName}() -- has it been ` +
+          'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+          'protects against) needs to move with it.',
+      )
+      continue
+    }
+
+    const snapshotPattern = new RegExp(
+      `const\\s+previous\\w*\\s*=\\s*(\\{\\s*\\.\\.\\.item\\.${field}\\s*\\}|item\\.${field})`,
+    )
+    if (!snapshotPattern.test(fn.body)) {
+      errors.push(
+        `${fnName}() no longer snapshots item.${field} into a \`previous*\` ` +
+          'const before mutating it -- without a pre-mutation snapshot, a ' +
+          'failed PATCH has nothing correct to revert to.',
+      )
+    }
+
+    // The revert closure must be pushItem's 4th argument and must reassign
+    // the snapshotted field back onto the item.
+    const revertPattern = new RegExp(
+      `pushItem\\([\\s\\S]*?,\\s*\\(\\)\\s*=>\\s*\\{[\\s\\S]*?item\\.${field}\\s*=\\s*previous\\w*[\\s\\S]*?\\}\\s*,?\\s*\\)`,
+    )
+    if (!revertPattern.test(fn.body)) {
+      errors.push(
+        `${fnName}() no longer passes a revert closure as pushItem()'s 4th ` +
+          `argument that restores item.${field} from its snapshot -- a ` +
+          'failed PATCH would leave this item showing an unpersisted ' +
+          'optimistic change until a full reload.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkSingleItemRevertGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder single-item revert-on-failure guard contract failed ' +
+        'in modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder single-item revert-on-failure guard contract passed: ' +
+      'pushItem() supports an onFailure callback invoked on both failure ' +
+      'paths, and approveStage/rejectStage/reopenStage/updatePitch/' +
+      'updateFields/updatePrompt each snapshot and revert their own ' +
+      'optimistic mutation when the PATCH actually fails.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}

--- a/utils/scripts/verifyModelBuilderSingleItemRevertGuard.ts
+++ b/utils/scripts/verifyModelBuilderSingleItemRevertGuard.ts
@@ -75,7 +75,7 @@ export function checkSingleItemRevertGuard(content: string): string[] {
     )
   } else {
     const signatureMatch = PUSHITEM_SIGNATURE.exec(content)
-    if (!signatureMatch || !ONFAILURE_PARAM.test(signatureMatch[1]!)) {
+    if (!ONFAILURE_PARAM.test(signatureMatch?.[1] ?? '')) {
       errors.push(
         'pushItem() no longer declares an `onFailure?: () => void` ' +
           'parameter -- without it, none of its callers have a way to ' +


### PR DESCRIPTION
## Bug

Cycle 9 (PR #1941) fixed `batchApproveStage()`/`batchSetField()` so a partial batch-PATCH failure only reverts the specific entries the server rejected, and left as its suggested lead: `pushItem()` — the single-item background PATCH used by `approveStage`/`rejectStage`/`reopenStage`/`updatePitch`/`updateFields`/`updatePrompt` — has the identical fire-and-forget, no-local-revert-on-failure shape.

A failed single-item PATCH already surfaced an error toast via `setStatusForRun`, but the item itself (approved badge, edited pitch/fields/prompt text, stage statuses) kept showing the unpersisted optimistic change until a full reload rebuilt it from the server's real (unchanged) state — the same "review gate lying about what's actually stored" class of bug this codebase treats as real everywhere else it's found (batch scope, `item.error` persistence, `stageStatuses` JSON parsing, ...).

## Fix

`pushItem()` now takes an optional `onFailure?: () => void` 4th argument, invoked from both its `.then` success:false branch and its `.catch` branch (mirroring where it already calls `setStatusForRun`). Each of the six single-item mutators now snapshots the field(s) it's about to change before mutating and passes a revert closure so a genuine PATCH failure restores exactly what the item held before the call:

- `approveStage`/`rejectStage`/`reopenStage` snapshot and revert `item.stages`
- `updatePitch`/`updateFields`/`updatePrompt` snapshot and revert their own text field plus `item.error` and `item.stages` (`markDownstreamStale` already mutates stages as part of the same optimistic change)

`pushItem`'s `onFailure` is optional and purely additive — the other call sites (`generateItemAsset`, `pollAsyncArtJob`, `commitItem`, etc.) that only pass 3 arguments are unaffected.

New guard `utils/scripts/verifyModelBuilderSingleItemRevertGuard.ts` + self-test, wired into `package.json`/`contract-tests.yml`, asserting `pushItem` declares/calls `onFailure` on both failure paths and each of the six mutators snapshots and reverts its own field.

## Verified

- All 87 `test:model-builder-*` npm scripts pass (85 pre-existing + 2 new)
- `vue-tsc --noEmit` (`npm test`) clean, exit 0, repo-wide
- `eslint` clean on touched files (2 pre-existing `no-empty` errors in `safeSet`/`safeRemove`, confirmed present on `main` before this change via `git stash`, far from the touched lines)
- `prettier --check` clean on the two new guard files; `modelBuilderStore.ts` already fails `prettier --check` on `main` before this change (confirmed via `git stash`) and prettier is not CI-gated, consistent with prior cycles' documented carve-out

Tracked in conductor `model-builder/t-029` (recurring polish task, cycle 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFxc8DenYDND6QxJKQDyGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFxc8DenYDND6QxJKQDyGv)_