### PR TITLE
model-builder: add role="alert" to item-panel and source-picker error callouts (t-029 cycle 11)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -581,6 +581,12 @@ jobs:
       - name: Model Builder single-item revert guard contract
         run: npm run test:model-builder-single-item-revert-guard
 
+      - name: Model Builder error callout role guard self-test
+        run: npm run test:model-builder-error-callout-role-guard-selftest
+
+      - name: Model Builder error callout role guard contract
+        run: npm run test:model-builder-error-callout-role-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -25,6 +25,7 @@
 
     <p
       v-if="item.error"
+      role="alert"
       class="rounded-lg bg-error/10 px-2 py-1 text-xs font-semibold text-error"
     >
       {{ item.error }}

--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -78,6 +78,7 @@
 
       <div
         v-else-if="store.sourcesError"
+        role="alert"
         class="flex h-full min-h-32 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-error/30 bg-error/5 p-6 text-center text-sm text-error"
       >
         <Icon name="kind-icon:warning" class="h-6 w-6" />

--- a/package.json
+++ b/package.json
@@ -270,6 +270,8 @@
     "test:model-builder-batch-partial-failure-revert-guard": "tsx utils/scripts/verifyModelBuilderBatchPartialFailureRevertGuard.ts",
     "test:model-builder-single-item-revert-guard-selftest": "tsx utils/scripts/verifyModelBuilderSingleItemRevertGuard.test.ts",
     "test:model-builder-single-item-revert-guard": "tsx utils/scripts/verifyModelBuilderSingleItemRevertGuard.ts",
+    "test:model-builder-error-callout-role-guard-selftest": "tsx utils/scripts/verifyModelBuilderErrorCalloutRoleGuard.test.ts",
+    "test:model-builder-error-callout-role-guard": "tsx utils/scripts/verifyModelBuilderErrorCalloutRoleGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/utils/scripts/verifyModelBuilderErrorCalloutRoleGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderErrorCalloutRoleGuard.test.ts
@@ -1,0 +1,123 @@
+// /utils/scripts/verifyModelBuilderErrorCalloutRoleGuard.test.ts
+//
+// Regression test for checkItemPanelErrorRoleGuard() and
+// checkSourcePickerErrorRoleGuard() in
+// verifyModelBuilderErrorCalloutRoleGuard.ts (model-builder/t-029, cycle
+// 11). Exercises both checks against synthetic component-shaped fixtures
+// covering: the fixed shape (role="alert" present), the pre-fix shape (no
+// role attribute at all), and a missing-block regression (the callout
+// removed entirely).
+import assert from 'node:assert/strict'
+
+import {
+  checkItemPanelErrorRoleGuard,
+  checkSourcePickerErrorRoleGuard,
+} from './verifyModelBuilderErrorCalloutRoleGuard.js'
+
+function itemPanelFixture(openingTagExtra: string): string {
+  return `
+<template>
+  <p
+    v-if="item.error"
+    ${openingTagExtra}
+    class="rounded-lg bg-error/10 px-2 py-1 text-xs font-semibold text-error"
+  >
+    {{ item.error }}
+  </p>
+</template>
+`
+}
+
+function sourcePickerFixture(openingTagExtra: string): string {
+  return `
+<template>
+  <div
+    v-else-if="store.sourcesError"
+    ${openingTagExtra}
+    class="flex h-full min-h-32 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-error/30 bg-error/5 p-6 text-center text-sm text-error"
+  >
+    <Icon name="kind-icon:warning" class="h-6 w-6" />
+    {{ store.sourcesError }}
+    <button type="button" @click="store.loadSources()">Retry</button>
+  </div>
+</template>
+`
+}
+
+const ITEM_PANEL_FIXED = itemPanelFixture('role="alert"')
+const ITEM_PANEL_BUGGY = itemPanelFixture('')
+const ITEM_PANEL_BLOCK_REMOVED = `
+<template>
+  <p v-if="item.warning">{{ item.warning }}</p>
+</template>
+`
+
+const SOURCE_PICKER_FIXED = sourcePickerFixture('role="alert"')
+const SOURCE_PICKER_BUGGY = sourcePickerFixture('')
+const SOURCE_PICKER_BLOCK_REMOVED = `
+<template>
+  <div v-else class="flex h-full min-h-32">Nothing here.</div>
+</template>
+`
+
+function run(): void {
+  // item-panel: fixed fixture passes.
+  const itemFixedErrors = checkItemPanelErrorRoleGuard(ITEM_PANEL_FIXED)
+  assert.deepEqual(
+    itemFixedErrors,
+    [],
+    `expected the fixed item-panel fixture to pass, got: ${JSON.stringify(itemFixedErrors)}`,
+  )
+
+  // item-panel: pre-fix (no role) fails exactly one check.
+  const itemBuggyErrors = checkItemPanelErrorRoleGuard(ITEM_PANEL_BUGGY)
+  assert.equal(
+    itemBuggyErrors.length,
+    1,
+    `expected the missing-role item-panel fixture to fail exactly one check, got: ${JSON.stringify(itemBuggyErrors)}`,
+  )
+  assert.ok(
+    itemBuggyErrors.some((e) => /no longer carries role="alert"/.test(e)),
+  )
+
+  // item-panel: block removed entirely fails with a "could not find" error.
+  const itemRemovedErrors = checkItemPanelErrorRoleGuard(
+    ITEM_PANEL_BLOCK_REMOVED,
+  )
+  assert.equal(itemRemovedErrors.length, 1)
+  assert.ok(itemRemovedErrors.some((e) => /Could not find a/.test(e)))
+
+  // source-picker: fixed fixture passes.
+  const sourceFixedErrors = checkSourcePickerErrorRoleGuard(SOURCE_PICKER_FIXED)
+  assert.deepEqual(
+    sourceFixedErrors,
+    [],
+    `expected the fixed source-picker fixture to pass, got: ${JSON.stringify(sourceFixedErrors)}`,
+  )
+
+  // source-picker: pre-fix (no role) fails exactly one check.
+  const sourceBuggyErrors = checkSourcePickerErrorRoleGuard(SOURCE_PICKER_BUGGY)
+  assert.equal(
+    sourceBuggyErrors.length,
+    1,
+    `expected the missing-role source-picker fixture to fail exactly one check, got: ${JSON.stringify(sourceBuggyErrors)}`,
+  )
+  assert.ok(
+    sourceBuggyErrors.some((e) => /no longer carries role="alert"/.test(e)),
+  )
+
+  // source-picker: block removed entirely fails with a "could not find" error.
+  const sourceRemovedErrors = checkSourcePickerErrorRoleGuard(
+    SOURCE_PICKER_BLOCK_REMOVED,
+  )
+  assert.equal(sourceRemovedErrors.length, 1)
+  assert.ok(sourceRemovedErrors.some((e) => /Could not find a/.test(e)))
+
+  console.log(
+    'Model Builder error callout role guard self-test passed: buggy ' +
+      'fixtures fail, fixed fixtures pass, missing-block regressions fail ' +
+      'for both the item-panel and source-picker checks.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderErrorCalloutRoleGuard.ts
+++ b/utils/scripts/verifyModelBuilderErrorCalloutRoleGuard.ts
@@ -1,0 +1,146 @@
+// /utils/scripts/verifyModelBuilderErrorCalloutRoleGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 11) -- two persistent
+// error-toned callouts in the Model Builder front end had no role/aria
+// semantics at all, unlike every other warning/error-toned block in this
+// same feature and the app at large:
+//
+// 1. model-builder-item-panel.vue's `item.error` banner (`v-if="item.error"`)
+//    -- the per-item failure message surfaced by cycle 7's error-persistence
+//    fix (verifyModelBuilderErrorPersistenceGuard.ts). A real, unresolved
+//    failure rendered as a purely visual red-tinted <p>, announcing nothing
+//    to assistive tech.
+// 2. model-builder-source-picker.vue's `store.sourcesError` callout
+//    (`v-else-if="store.sourcesError"`) -- a tinted-callout-plus-retry-button
+//    block, structurally identical to academy-manager.vue's `managerError`
+//    block and this same feature's own model-builder-manager.vue
+//    `statusMessage` banner, both of which already carry role="alert"/
+//    role="status" correctly.
+//
+// This exact gap (an error callout with no role) was just closed the same
+// day for davinci-page.vue's narration-error callout (PR #1944,
+// verifyDaVinciNarrationErrorRoleGuard.ts) -- this guard follows that one's
+// narrow-textual-checker shape, extended to cover both Model Builder blocks
+// in one guard since they're the same fix applied to two sibling components.
+//
+// Fixed by adding role="alert" to both blocks. This asserts the textual
+// shape of that fix stays in place -- deliberately scoped to these two
+// template blocks, mirroring this project's other narrow textual guards
+// over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const ITEM_PANEL_PATH = join(
+  repositoryRoot,
+  'components/model-builder/model-builder-item-panel.vue',
+)
+const SOURCE_PICKER_PATH = join(
+  repositoryRoot,
+  'components/model-builder/model-builder-source-picker.vue',
+)
+
+const ITEM_ERROR_MARKER = 'v-if="item.error"'
+const SOURCES_ERROR_MARKER = 'v-else-if="store.sourcesError"'
+
+// Anchored on each block's distinguishing v-if/v-else-if marker rather than
+// any surrounding wording, so this guard reports *how* a block regressed
+// (missing role vs. missing entirely) instead of just "not found".
+function extractOpeningTag(content: string, marker: string): string | null {
+  const markerIndex = content.indexOf(marker)
+  if (markerIndex === -1) return null
+
+  const tagStart = content.lastIndexOf('<', markerIndex)
+  if (tagStart === -1) return null
+  const tagEnd = content.indexOf('>', markerIndex)
+  if (tagEnd === -1) return null
+
+  return content.slice(tagStart, tagEnd + 1)
+}
+
+export function checkItemPanelErrorRoleGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const openingTag = extractOpeningTag(content, ITEM_ERROR_MARKER)
+  if (!openingTag) {
+    errors.push(
+      `Could not find a \`${ITEM_ERROR_MARKER}\` block in ` +
+        'model-builder-item-panel.vue -- has the item.error banner been ' +
+        'renamed, removed, or restructured? If so, this guard needs to ' +
+        'move with it.',
+    )
+    return errors
+  }
+
+  if (!openingTag.includes('role="alert"')) {
+    errors.push(
+      'The model-builder-item-panel.vue item.error banner no longer ' +
+        'carries role="alert" -- assistive tech gets no signal that this ' +
+        "item's build failed, unlike every comparable warning/error-toned " +
+        "block elsewhere in the app (this feature's own " +
+        'model-builder-manager.vue statusMessage banner, ' +
+        "davinci-page.vue's narration-error callout, " +
+        "academy-manager.vue's managerError block).",
+    )
+  }
+
+  return errors
+}
+
+export function checkSourcePickerErrorRoleGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const openingTag = extractOpeningTag(content, SOURCES_ERROR_MARKER)
+  if (!openingTag) {
+    errors.push(
+      `Could not find a \`${SOURCES_ERROR_MARKER}\` block in ` +
+        'model-builder-source-picker.vue -- has the sourcesError callout ' +
+        'been renamed, removed, or restructured? If so, this guard needs ' +
+        'to move with it.',
+    )
+    return errors
+  }
+
+  if (!openingTag.includes('role="alert"')) {
+    errors.push(
+      'The model-builder-source-picker.vue sourcesError callout no ' +
+        'longer carries role="alert" -- assistive tech gets no signal ' +
+        'that loading sources failed, unlike the structurally identical ' +
+        'tinted-callout-plus-retry-button academy-manager.vue ' +
+        "managerError block and this feature's own " +
+        'model-builder-manager.vue statusMessage banner.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const itemPanelContent = readFileSync(ITEM_PANEL_PATH, 'utf8')
+  const sourcePickerContent = readFileSync(SOURCE_PICKER_PATH, 'utf8')
+
+  const errors = [
+    ...checkItemPanelErrorRoleGuard(itemPanelContent),
+    ...checkSourcePickerErrorRoleGuard(sourcePickerContent),
+  ]
+
+  if (errors.length) {
+    console.error('Model Builder error callout role guard contract failed:')
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder error callout role guard contract passed: both the ' +
+      'item-panel item.error banner and the source-picker sourcesError ' +
+      'callout still carry role="alert".',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Bug

Two persistent error-toned callouts in the Model Builder front end had no role/aria semantics at all, unlike every other warning/error-toned callout in this feature and the app at large:

- `model-builder-item-panel.vue`'s `item.error` banner (`v-if="item.error"`) — the per-item failure message surfaced by cycle 7's error-persistence fix (`verifyModelBuilderErrorPersistenceGuard.ts`). A real, unresolved build failure rendered as a purely visual red-tinted `<p>`, announcing nothing to assistive tech.
- `model-builder-source-picker.vue`'s `store.sourcesError` callout (`v-else-if="store.sourcesError"`) — a tinted-callout-plus-retry-button block, structurally identical to `academy-manager.vue`'s `managerError` block and this same feature's own `model-builder-manager.vue` `statusMessage` banner, both of which already carry `role="alert"`/`role="status"` correctly.

This exact gap (an error callout with no role) was just closed the same day for `davinci-page.vue`'s narration-error callout (PR #1944, `verifyDaVinciNarrationErrorRoleGuard.ts`) — this fix follows that precedent, applied to the two Model Builder callouts that never got the same treatment.

## Fix

Added `role="alert"` to both blocks.

New guard `utils/scripts/verifyModelBuilderErrorCalloutRoleGuard.ts` + self-test, wired into `package.json`/`contract-tests.yml`, covering both callouts in one guard since it's the same fix applied to two sibling components.

## Verified

- All 89 `test:model-builder-*` npm scripts pass (87 pre-existing + 2 new)
- `vue-tsc --noEmit` (`npm test`) clean, exit 0, repo-wide
- `eslint` clean on all touched files
- `prettier --check` clean on the two new guard files; the two touched `.vue` files already fail `prettier --check` on `main` before this change (confirmed via `git stash`), matching prior cycles' documented carve-out — prettier is not CI-gated
- Guard fails pre-fix / passes post-fix via git-stash round-trip on both touched components
- `git status --porcelain` shows exactly the 6 intended files

Tracked in conductor `model-builder/t-029` (recurring polish task, cycle 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NJTpqbbbwoc7PvEQEE1Yq

---
_Generated by [Claude Code](https://claude.ai/code/session_011NJTpqbbbwoc7PvEQEE1Yq)_