### PR TITLE
model-builder: fix batchDraftField's false-success toast on draft failure (t-029 cycle 12)

### DIFF
--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -2094,6 +2094,20 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     batchingOutputSingleton.claim(outputKey)
     clearStatus()
     let drafted = 0
+    // Bug (model-builder/t-029 cycle 12): unlike every sibling batch entry
+    // point (batchAutoBuild/autoBuildRun tally a `failed` outcome and flip
+    // tone to 'error' -- see verifyModelBuilderAutoBuildFailedSummaryGuard's
+    // doc comment; batchSetField/batchApproveStage rely on batchPushItems'
+    // own error toast when `ok` is false), this loop only ever counted
+    // `drafted` and then unconditionally reported tone 'success' once it
+    // finished -- even when EVERY item in the group failed to draft (e.g.
+    // the text server is down). draftText already sets a real 'error'
+    // status via setStatusForRun on each failed item, but this function's
+    // own final setStatus call ran after the loop and clobbered that with a
+    // green "Drafted 0/N items." banner, exactly the same clobbered-error
+    // shape the auto-build guard above exists to prevent. Track failures and
+    // switch tone the same way autoBuildRun/batchAutoBuild do.
+    let failed = 0
     try {
       for (const item of items) {
         // Skip items whose stage is already approved/locked — see
@@ -2108,9 +2122,13 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         if (opts?.onlyEmpty && current.trim()) continue
         const ok = await draftText(item.id, field)
         if (ok) drafted++
+        else failed++
       }
       const label = field === 'artPrompt' ? 'prompt' : field
-      setStatus('success', `Drafted ${label} for ${drafted}/${items.length} items.`)
+      setStatus(
+        failed ? 'error' : 'success',
+        `Drafted ${label} for ${drafted}/${items.length} items.`,
+      )
     } finally {
       batchingOutputSingleton.release(outputKey)
     }

--- a/utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.test.ts
@@ -1,11 +1,12 @@
 // /utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.test.ts
 //
 // Regression test for checkAutoBuildFailedSummaryGuard() in
-// verifyModelBuilderAutoBuildFailedSummaryGuard.ts (model-builder/t-029).
-// Exercises the real check against synthetic store-shaped fixtures covering:
-// the pre-fix shape (failed outcomes never tallied, tone always 'success'),
-// the fixed shape (both functions), a shape that tallies `failed` but never
-// reflects it in the tone, and both target functions being absent entirely.
+// verifyModelBuilderAutoBuildFailedSummaryGuard.ts (model-builder/t-029,
+// extended cycle 12 to also cover batchDraftField()). Exercises the real
+// check against synthetic store-shaped fixtures covering: the pre-fix shape
+// (failed outcomes never tallied, tone always 'success'), the fixed shape
+// (all three functions), a shape that tallies `failed` but never reflects it
+// in the tone, and all target functions being absent entirely.
 import assert from 'node:assert/strict'
 
 import { checkAutoBuildFailedSummaryGuard } from './verifyModelBuilderAutoBuildFailedSummaryGuard.js'
@@ -43,6 +44,23 @@ const BUGGY_FIXTURE = `
       setStatus(
         'success',
         \`Auto-built \${committed}/\${items.length} in this group.\`,
+      )
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchDraftField(outputKey: string, field: DraftField): Promise<void> {
+    const items = groupItems(outputKey)
+    let drafted = 0
+    try {
+      for (const item of items) {
+        const ok = await draftText(item.id, field)
+        if (ok) drafted++
+      }
+      setStatus(
+        'success',
+        \`Drafted \${field} for \${drafted}/\${items.length} items.\`,
       )
     } finally {
       batchingOutputSingleton.release(outputKey)
@@ -92,6 +110,25 @@ const FIXED_FIXTURE = `
       batchingOutputSingleton.release(outputKey)
     }
   }
+
+  async function batchDraftField(outputKey: string, field: DraftField): Promise<void> {
+    const items = groupItems(outputKey)
+    let drafted = 0
+    let failed = 0
+    try {
+      for (const item of items) {
+        const ok = await draftText(item.id, field)
+        if (ok) drafted++
+        else failed++
+      }
+      setStatus(
+        failed ? 'error' : 'success',
+        \`Drafted \${field} for \${drafted}/\${items.length} items.\`,
+      )
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
 `
 
 const TALLIED_BUT_TONE_IGNORED_FIXTURE = `
@@ -136,6 +173,25 @@ const TALLIED_BUT_TONE_IGNORED_FIXTURE = `
       batchingOutputSingleton.release(outputKey)
     }
   }
+
+  async function batchDraftField(outputKey: string, field: DraftField): Promise<void> {
+    const items = groupItems(outputKey)
+    let drafted = 0
+    let failed = 0
+    try {
+      for (const item of items) {
+        const ok = await draftText(item.id, field)
+        if (ok) drafted++
+        else failed++
+      }
+      setStatus(
+        'success',
+        \`Drafted \${field} for \${drafted}/\${items.length} items.\`,
+      )
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
 `
 
 const MISSING_FIXTURE = `
@@ -149,9 +205,9 @@ const MISSING_FIXTURE = `
 const buggyErrors = checkAutoBuildFailedSummaryGuard(BUGGY_FIXTURE)
 assert.equal(
   buggyErrors.length,
-  2,
-  'expected the pre-fix shape (failed never tallied in either function) to ' +
-    `raise 2 errors, got ${buggyErrors.length}: ${JSON.stringify(buggyErrors)}`,
+  3,
+  'expected the pre-fix shape (failed never tallied in any of the three ' +
+    `functions) to raise 3 errors, got ${buggyErrors.length}: ${JSON.stringify(buggyErrors)}`,
 )
 assert.ok(buggyErrors.every((e) => e.includes('failed++')))
 
@@ -167,9 +223,9 @@ const talliedButIgnoredErrors = checkAutoBuildFailedSummaryGuard(
 )
 assert.equal(
   talliedButIgnoredErrors.length,
-  2,
+  3,
   'expected the "tallied but tone still hardcoded success" shape to raise ' +
-    `2 errors, got ${talliedButIgnoredErrors.length}: ` +
+    `3 errors, got ${talliedButIgnoredErrors.length}: ` +
     JSON.stringify(talliedButIgnoredErrors),
 )
 assert.ok(
@@ -179,14 +235,16 @@ assert.ok(
 const missingErrors = checkAutoBuildFailedSummaryGuard(MISSING_FIXTURE)
 assert.equal(
   missingErrors.length,
-  2,
-  'expected 2 "function not found" violations when both target functions are absent',
+  3,
+  'expected 3 "function not found" violations when all target functions are absent',
 )
 assert.ok(missingErrors[0]!.includes('autoBuildRun'))
 assert.ok(missingErrors[1]!.includes('batchAutoBuild'))
+assert.ok(missingErrors[2]!.includes('batchDraftField'))
 
 console.log(
   'Model Builder auto-build failed-summary guard checker verified: flags ' +
     'untallied failures, flags a tallied-but-ignored tone, clears the fixed ' +
-    'shape, and flags both target functions being absent.',
+    'shape, and flags all three target functions being absent -- including ' +
+    'batchDraftField, added cycle 12.',
 )

--- a/utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.ts
@@ -20,6 +20,15 @@
 // exact surfaces that walk an item through every stage — including COMMIT —
 // without a human reviewing each step, so a failure there most needs to be
 // reported accurately.
+//
+// Extended (model-builder/t-029 cycle 12) to cover batchDraftField() too --
+// the exact same clobbered-tone shape, just with `drafted`/`failed` in place
+// of `committed`/`skipped`/`failed`: a fully- or partially-failed AI drafting
+// pass across a group (e.g. the text server is down) still reported a plain
+// green "Drafted 0/N items." banner, clobbering the real 'error' status
+// draftText already set per failed item via setStatusForRun. Folded into
+// this same generic guard rather than a new file since the guard was already
+// written to check an arbitrary list of TARGET_FUNCTIONS for this one shape.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -31,12 +40,17 @@ const repositoryRoot = resolve(scriptDirectory, '../..')
 
 const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
 
-const TARGET_FUNCTIONS = ['autoBuildRun', 'batchAutoBuild'] as const
+const TARGET_FUNCTIONS = [
+  'autoBuildRun',
+  'batchAutoBuild',
+  'batchDraftField',
+] as const
 
 // Checks the fix's exact shape against the full source text of a file
-// containing `autoBuildRun`/`batchAutoBuild`-named functions. Exported
-// (rather than only exercised via main()) so the self-test below can run it
-// against synthetic buggy/fixed fixtures without touching the real store file.
+// containing `autoBuildRun`/`batchAutoBuild`/`batchDraftField`-named
+// functions. Exported (rather than only exercised via main()) so the
+// self-test below can run it against synthetic buggy/fixed fixtures without
+// touching the real store file.
 export function checkAutoBuildFailedSummaryGuard(content: string): string[] {
   const errors: string[] = []
 
@@ -56,10 +70,10 @@ export function checkAutoBuildFailedSummaryGuard(content: string): string[] {
     const tracksFailed = /\bfailed\s*\+\+/.test(fn.body)
     if (!tracksFailed) {
       errors.push(
-        `${name}() does not tally a 'failed' outcome from autoBuildItem() ` +
-          'into its own counter (expected a `failed++` alongside `committed++`' +
-          ' / `skipped++`). Without it, a rejected commit is invisible in ' +
-          "this function's final summary.",
+        `${name}() does not tally a 'failed' outcome into its own counter ` +
+          '(expected a `failed++` alongside its other outcome counters). ' +
+          "Without it, a real failure is invisible in this function's " +
+          'final summary.',
       )
       continue
     }
@@ -107,8 +121,9 @@ function main(): void {
 
   console.log(
     'Model Builder auto-build failed-summary guard contract passed: ' +
-      'autoBuildRun() and batchAutoBuild() both tally failed outcomes and ' +
-      'report them (with an error tone) in their final summary.',
+      'autoBuildRun(), batchAutoBuild(), and batchDraftField() all tally ' +
+      'failed outcomes and report them (with an error tone) in their ' +
+      'final summary.',
   )
 }
 


### PR DESCRIPTION
## Summary

Cycle 11's suggested lead (audit `model-builder-recipe-selector.vue` and `model-builder-run-history.vue` for missing `role="alert"`/`role="status"` accessibility semantics) turned out to be a dead end: `model-builder-run-history.vue` already has `role="status"` + `aria-live="polite"` on its loading state, and `model-builder-recipe-selector.vue` has no error/warning-toned callout of its own — it delegates all error reporting to `model-builder-manager.vue`'s `statusMessage` banner, which is already correctly fixed. `model-builder-batch-editor.vue`'s only error-adjacent element is a small per-item status badge with a tooltip `title`, not a persistent callout comparable to the already-fixed item-panel/source-picker blocks, so it wasn't a fit either.

A fresh read of `stores/modelBuilderStore.ts` turned up a real, distinct bug instead: **`batchDraftField()`** (the "Draft pitches / Draft fields / Draft prompts" group buttons in `model-builder-batch-editor.vue`) tallies a `drafted` counter across its per-item loop, but then **unconditionally** calls `setStatus('success', ...)` once the loop finishes — even when *every* item in the group failed to draft (e.g. the text server is down). `draftText()` already sets a real `'error'` status via `setStatusForRun` on each failed item, but `batchDraftField`'s own final `setStatus` call runs after the loop and clobbers that with a misleading green "Drafted 0/N items." banner.

This is exactly the same clobbered-tone bug class that `verifyModelBuilderAutoBuildFailedSummaryGuard.ts` already exists to catch for `autoBuildRun()`/`batchAutoBuild()` — `batchDraftField` was simply never added to that guard's `TARGET_FUNCTIONS` list, so this sibling instance of the bug went undetected.

## Fix

- `stores/modelBuilderStore.ts`: `batchDraftField()` now tallies a `failed` counter alongside `drafted`, and its final `setStatus` call switches tone to `'error'` when `failed > 0` — mirroring `autoBuildRun`/`batchAutoBuild` exactly.
- `utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.ts`: extended `TARGET_FUNCTIONS` to include `batchDraftField` (reusing the existing generic guard rather than adding a new file, since it was already written to check an arbitrary list of target functions for this one shape). Updated doc comments accordingly.
- `utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.test.ts`: added `batchDraftField` fixtures to the buggy/fixed/tallied-but-ignored/missing test cases; error-count assertions bumped from 2 to 3.

No new npm script or CI wiring was needed — both `test:model-builder-auto-build-failed-summary-guard(-selftest)` scripts already existed and are already wired into `contract-tests.yml`.

## Verification

- `npm run test:model-builder-auto-build-failed-summary-guard-selftest` — passes (checker correctly flags buggy/tallied-but-ignored fixtures, clears the fixed fixture, flags all 3 target functions absent)
- `npm run test:model-builder-auto-build-failed-summary-guard` — passes against the real store
- Git-stash-style round trip: reverted `stores/modelBuilderStore.ts` to pre-fix, re-ran the guard — it correctly **failed** with `batchDraftField() does not tally a 'failed' outcome...`; restored the fix, guard passes again
- All 89 `test:model-builder-*` npm scripts pass
- `npm run test` (`vue-tsc --noEmit`, repo-wide) — passes clean, exit 0
- `eslint` on the 3 touched files — 2 pre-existing errors in `modelBuilderStore.ts` (`safeSet`/`safeRemove` empty `catch {}` blocks), untouched by this diff and present before it
- `prettier --check` — both guard files clean; `modelBuilderStore.ts` has pre-existing formatting drift elsewhere in the file (confirmed unrelated: this diff's own added lines match `prettier`'s output byte-for-byte)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUSLAs87K2qErj8wEPPXQD)_