### PR TITLE
fix(model-builder): scope batch-group completion toasts to their own run (t-029 cycle 13)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -485,6 +485,12 @@ jobs:
       - name: Model Builder draftText status-scope guard contract
         run: npm run test:model-builder-draft-status-scope-guard
 
+      - name: Model Builder batch-group status-scope guard checker self-test
+        run: npm run test:model-builder-batch-group-status-scope-guard-selftest
+
+      - name: Model Builder batch-group status-scope guard contract
+        run: npm run test:model-builder-batch-group-status-scope-guard
+
       - name: Model Builder batchSetField confirmed-success guard checker self-test
         run: npm run test:model-builder-batch-set-field-confirmed-success-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -238,6 +238,8 @@
     "test:model-builder-pushitem-error-scope-guard": "tsx utils/scripts/verifyModelBuilderPushItemErrorScopeGuard.ts",
     "test:model-builder-draft-status-scope-guard-selftest": "tsx utils/scripts/verifyModelBuilderDraftStatusScopeGuard.test.ts",
     "test:model-builder-draft-status-scope-guard": "tsx utils/scripts/verifyModelBuilderDraftStatusScopeGuard.ts",
+    "test:model-builder-batch-group-status-scope-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchGroupStatusScopeGuard.test.ts",
+    "test:model-builder-batch-group-status-scope-guard": "tsx utils/scripts/verifyModelBuilderBatchGroupStatusScopeGuard.ts",
     "test:model-builder-batch-set-field-confirmed-success-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.test.ts",
     "test:model-builder-batch-set-field-confirmed-success-guard": "tsx utils/scripts/verifyModelBuilderBatchSetFieldConfirmedSuccessGuard.ts",
     "test:model-builder-batch-approve-stage-confirmed-success-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchApproveStageConfirmedSuccessGuard.test.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -2090,6 +2090,24 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   ): Promise<void> {
     const items = groupItems(outputKey)
     if (!items.length) return
+    // Bug (model-builder/t-029 cycle 13): unlike every single-item async
+    // entry point that spans a real network round-trip (draftText itself --
+    // see verifyModelBuilderDraftStatusScopeGuard's doc comment --
+    // generateItemAsset, generateItemAssetAsync, commitItem, pushItem,
+    // batchPushItems) and unlike this function's own whole-run sibling
+    // autoBuildRun, this loop's final completion toast was a bare, unscoped
+    // setStatus, with no runId capture at all. batchDraftField awaits
+    // draftText once per item in the group -- easily seconds of real work
+    // for a multi-item quantity group -- long enough for the user to switch
+    // to (or start) a different run via History before it finishes. Every
+    // per-item draftText call already scopes ITS OWN status messages
+    // correctly via setStatusForRun, so no per-item toast leaks -- but this
+    // function's own summary ran unconditionally after the loop regardless
+    // of which run was on screen by then, popping a misleading "Drafted
+    // X/N items." banner over whatever OTHER run the user has since
+    // switched to, about a group that isn't even part of what's on screen.
+    // Captured up front, mirroring autoBuildRun's own runId capture.
+    const runId = state.run?.id
     const stageKey = stageForDraftField(field)
     batchingOutputSingleton.claim(outputKey)
     clearStatus()
@@ -2125,10 +2143,13 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         else failed++
       }
       const label = field === 'artPrompt' ? 'prompt' : field
-      setStatus(
-        failed ? 'error' : 'success',
-        `Drafted ${label} for ${drafted}/${items.length} items.`,
-      )
+      if (runId) {
+        setStatusForRun(
+          runId,
+          failed ? 'error' : 'success',
+          `Drafted ${label} for ${drafted}/${items.length} items.`,
+        )
+      }
     } finally {
       batchingOutputSingleton.release(outputKey)
     }
@@ -2168,6 +2189,18 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     fieldKey: string,
     value: string,
   ): Promise<void> {
+    // Bug (model-builder/t-029 cycle 13): captured up front, mirroring
+    // draftText/generateItemAsset/commitItem/pushItem/batchPushItems (see
+    // verifyModelBuilderDraftStatusScopeGuard's doc comment for the full
+    // shape of this bug class). batchPushItems below is a real network
+    // round-trip the user can switch runs during via History; batchPushItems
+    // itself already scopes its own failure toast through setStatusForRun,
+    // but this function's own success toast was a bare, unscoped setStatus
+    // with no runId at all -- so a batch field-set that resolves after the
+    // user has switched to (or started) a different run pops a misleading
+    // "Set ... on N/M items." success banner over whatever OTHER run is now
+    // on screen, about a group that isn't even part of what's on screen.
+    const runId = state.run?.id
     const items = groupItems(outputKey)
     const entries: Array<{
       item: BuildItem
@@ -2209,10 +2242,13 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       // setStatusForRun -- reporting a blanket "success" here too would be
       // actively misleading.
       if (ok) {
-        setStatus(
-          'success',
-          `Set ${fieldKey} on ${entries.length}/${items.length} items.`,
-        )
+        if (runId) {
+          setStatusForRun(
+            runId,
+            'success',
+            `Set ${fieldKey} on ${entries.length}/${items.length} items.`,
+          )
+        }
       } else if (failedIds.size) {
         // Revert exactly the entries the server rejected -- see this
         // function's own doc comment and batchPushItems' for why a partial
@@ -2264,6 +2300,12 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     outputKey: string,
     stageKey: BuildStageKey,
   ): Promise<void> {
+    // Bug (model-builder/t-029 cycle 13): captured up front, same as
+    // batchSetField's identical fix (see its own doc comment) -- the
+    // batchPushItems() await below is a real network round-trip the user can
+    // switch runs during via History, and this function's success toast was
+    // a bare, unscoped setStatus with no runId at all.
+    const runId = state.run?.id
     const entries: Array<{
       item: BuildItem
       payload: Record<string, unknown>
@@ -2295,10 +2337,13 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       // setStatusForRun -- reporting a blanket "success" here too would be
       // actively misleading.
       if (ok) {
-        setStatus(
-          'success',
-          `Approved ${stageKey} for ${entries.length} items.`,
-        )
+        if (runId) {
+          setStatusForRun(
+            runId,
+            'success',
+            `Approved ${stageKey} for ${entries.length} items.`,
+          )
+        }
       } else if (failedIds.size) {
         // Revert exactly the entries the server rejected -- see this
         // function's own doc comment and batchPushItems' for why a partial
@@ -2319,6 +2364,26 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   async function batchAutoBuild(outputKey: string): Promise<void> {
     const items = groupItems(outputKey)
     if (!items.length) return
+    // Bug (model-builder/t-029 cycle 13): captured up front, exactly
+    // mirroring autoBuildRun's own runId capture and its doc comment just
+    // below (same file) -- autoBuildRun already guards both its per-item
+    // loop and its final summary against the user switching to (or
+    // starting) a different run via History mid-pass, but this function,
+    // despite looping the same way over the same multi-step autoBuildItem()
+    // calls for potentially many items in a group, never captured a runId
+    // at all: its final summary was a bare, unscoped setStatus that ran
+    // unconditionally regardless of which run was on screen by the time the
+    // group finished. A "Auto-build group" pass on Run A left running while
+    // the user opens History and switches to Run B pops this stale
+    // completion toast -- "Auto-built X/N in this group (Y failed...)" --
+    // over Run B's banner once Run A's abandoned pass finally finishes,
+    // about a group that isn't even part of what's on screen. `items.length`
+    // being non-zero already implies state.run was non-null when
+    // groupItems() read it, but that's not visible to the type checker
+    // through the intervening function call, so this stays optional
+    // (mirroring batchDraftField/batchSetField/batchApproveStage's own
+    // identical `state.run?.id` capture) rather than a non-null assertion.
+    const runId = state.run?.id
     batchingOutputSingleton.claim(outputKey)
     clearStatus()
     let committed = 0
@@ -2326,6 +2391,12 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     let failed = 0
     try {
       for (const item of items) {
+        // See autoBuildRun's identical guard: stop walking this group the
+        // instant the user has switched away from the run it belongs to,
+        // rather than continuing to await autoBuildItem() calls that can
+        // now only fail fast (findItem() won't find this item in whatever
+        // OTHER run is now active).
+        if (state.run?.id !== runId) return
         if (item.stages.COMMIT.status === 'approved') {
           committed++
           // See autoBuildRun's identical branch: keep the badge from
@@ -2355,10 +2426,12 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       const failedNote = failed
         ? ` (${failed} failed — see the item's own error for details)`
         : ''
-      setStatus(
-        failed ? 'error' : 'success',
-        `Auto-built ${committed}/${items.length} in this group${failedNote}${skippedNote}.`,
-      )
+      if (state.run?.id === runId) {
+        setStatus(
+          failed ? 'error' : 'success',
+          `Auto-built ${committed}/${items.length} in this group${failedNote}${skippedNote}.`,
+        )
+      }
     } finally {
       batchingOutputSingleton.release(outputKey)
     }

--- a/utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.test.ts
@@ -2,11 +2,15 @@
 //
 // Regression test for checkAutoBuildFailedSummaryGuard() in
 // verifyModelBuilderAutoBuildFailedSummaryGuard.ts (model-builder/t-029,
-// extended cycle 12 to also cover batchDraftField()). Exercises the real
+// extended cycle 12 to also cover batchDraftField(), extended cycle 13 for
+// the setStatusForRun(runId, tone, message) call shape). Exercises the real
 // check against synthetic store-shaped fixtures covering: the pre-fix shape
 // (failed outcomes never tallied, tone always 'success'), the fixed shape
-// (all three functions), a shape that tallies `failed` but never reflects it
-// in the tone, and all target functions being absent entirely.
+// (all three functions, with batchDraftField using the real
+// setStatusForRun(runId, ...) shape it was migrated to in cycle 13), a shape
+// that tallies `failed` but never reflects it in the tone (both the bare
+// setStatus and the setStatusForRun call shapes), and all target functions
+// being absent entirely.
 import assert from 'node:assert/strict'
 
 import { checkAutoBuildFailedSummaryGuard } from './verifyModelBuilderAutoBuildFailedSummaryGuard.js'
@@ -113,6 +117,7 @@ const FIXED_FIXTURE = `
 
   async function batchDraftField(outputKey: string, field: DraftField): Promise<void> {
     const items = groupItems(outputKey)
+    const runId = state.run?.id
     let drafted = 0
     let failed = 0
     try {
@@ -121,10 +126,13 @@ const FIXED_FIXTURE = `
         if (ok) drafted++
         else failed++
       }
-      setStatus(
-        failed ? 'error' : 'success',
-        \`Drafted \${field} for \${drafted}/\${items.length} items.\`,
-      )
+      if (runId) {
+        setStatusForRun(
+          runId,
+          failed ? 'error' : 'success',
+          \`Drafted \${field} for \${drafted}/\${items.length} items.\`,
+        )
+      }
     } finally {
       batchingOutputSingleton.release(outputKey)
     }
@@ -176,6 +184,7 @@ const TALLIED_BUT_TONE_IGNORED_FIXTURE = `
 
   async function batchDraftField(outputKey: string, field: DraftField): Promise<void> {
     const items = groupItems(outputKey)
+    const runId = state.run?.id
     let drafted = 0
     let failed = 0
     try {
@@ -184,10 +193,13 @@ const TALLIED_BUT_TONE_IGNORED_FIXTURE = `
         if (ok) drafted++
         else failed++
       }
-      setStatus(
-        'success',
-        \`Drafted \${field} for \${drafted}/\${items.length} items.\`,
-      )
+      if (runId) {
+        setStatusForRun(
+          runId,
+          'success',
+          \`Drafted \${field} for \${drafted}/\${items.length} items.\`,
+        )
+      }
     } finally {
       batchingOutputSingleton.release(outputKey)
     }

--- a/utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.ts
@@ -29,6 +29,16 @@
 // draftText already set per failed item via setStatusForRun. Folded into
 // this same generic guard rather than a new file since the guard was already
 // written to check an arbitrary list of TARGET_FUNCTIONS for this one shape.
+//
+// Extended again (model-builder/t-029 cycle 13, see
+// verifyModelBuilderBatchGroupStatusScopeGuard's own doc comment for the
+// full bug): batchDraftField's own final summary call changed shape from
+// the bare `setStatus(tone, message)` this guard originally expected to
+// `setStatusForRun(runId, tone, message)` -- a *different*, orthogonal fix
+// (scoping the toast to the run it belongs to) that this guard's regex
+// wasn't written to recognize. The tone-reflects-failure check below now
+// accepts either call shape, reading the tone argument from whichever
+// position it actually falls in.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -78,13 +88,22 @@ export function checkAutoBuildFailedSummaryGuard(content: string): string[] {
       continue
     }
 
-    const finalSetStatusMatch = fn.body.match(
-      /setStatus\(\s*([\s\S]*?),\s*`[^`]*`\s*,?\s*\)/,
+    // Prefer the run-scoped shape (setStatusForRun(runId, tone, message)) --
+    // its tone argument is the second parameter, after runId -- and fall
+    // back to the plain setStatus(tone, message) shape for a function that
+    // hasn't been migrated to run-scoping. Either is an acceptable home for
+    // the final summary; this guard only cares whether ITS tone reflects a
+    // tallied failure.
+    const finalSetStatusForRunMatch = fn.body.match(
+      /setStatusForRun\(\s*[^,]+,\s*([\s\S]*?),\s*`[^`]*`\s*,?\s*\)/,
     )
+    const finalSetStatusMatch =
+      finalSetStatusForRunMatch ??
+      fn.body.match(/setStatus\(\s*([\s\S]*?),\s*`[^`]*`\s*,?\s*\)/)
     if (!finalSetStatusMatch) {
       errors.push(
-        `${name}() does not appear to call setStatus(...) with its final ` +
-          'summary message.',
+        `${name}() does not appear to call setStatus(...)/setStatusForRun(...) ` +
+          'with its final summary message.',
       )
       continue
     }

--- a/utils/scripts/verifyModelBuilderBatchGroupStatusScopeGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderBatchGroupStatusScopeGuard.test.ts
@@ -1,0 +1,139 @@
+// /utils/scripts/verifyModelBuilderBatchGroupStatusScopeGuard.test.ts
+//
+// Regression test for checkBatchGroupStatusScopeGuard() in
+// verifyModelBuilderBatchGroupStatusScopeGuard.ts (model-builder/t-029
+// cycle 13). Exercises the real check against synthetic store-shaped
+// fixtures covering: the pre-fix shape (no captured runId, a bare
+// setStatus() completion toast) and the fixed shape (runId captured up
+// front, routed through setStatusForRun(runId, ...)) for each of the four
+// batch-group functions -- plus batchAutoBuild's own extra "wrapped in an
+// explicit state.run?.id === runId guard" shape, mirroring autoBuildRun.
+import assert from 'node:assert/strict'
+
+import { checkBatchGroupStatusScopeGuard } from './verifyModelBuilderBatchGroupStatusScopeGuard.js'
+
+function simpleFixture(name: string, buggy: boolean): string {
+  const runIdLine = buggy ? '' : 'const runId = state.run?.id'
+  const completion = buggy
+    ? "setStatus('success', 'done')"
+    : "if (runId) { setStatusForRun(runId, 'success', 'done') }"
+  return `
+  async function ${name}(outputKey: string): Promise<void> {
+    const items = groupItems(outputKey)
+    if (!items.length) return
+    ${runIdLine}
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      const { ok } = await batchPushItems([])
+      if (ok) {
+        ${completion}
+      }
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+}
+
+function autoBuildFixture(buggy: boolean): string {
+  const runIdLine = buggy ? '' : 'const runId = state.run?.id'
+  const completion = buggy
+    ? "setStatus('success', 'done')"
+    : "if (state.run?.id === runId) {\n        setStatus('success', 'done')\n      }"
+  return `
+  async function batchAutoBuild(outputKey: string): Promise<void> {
+    const items = groupItems(outputKey)
+    if (!items.length) return
+    ${runIdLine}
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      for (const item of items) {
+        if (state.run?.id !== runId) return
+        const outcome = await autoBuildItem(item.id)
+      }
+      ${completion}
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+}
+
+const BUGGY = [
+  simpleFixture('batchDraftField', true),
+  simpleFixture('batchSetField', true),
+  simpleFixture('batchApproveStage', true),
+  autoBuildFixture(true),
+].join('\n')
+
+const FIXED = [
+  simpleFixture('batchDraftField', false),
+  simpleFixture('batchSetField', false),
+  simpleFixture('batchApproveStage', false),
+  autoBuildFixture(false),
+].join('\n')
+
+function run(): void {
+  const buggyErrors = checkBatchGroupStatusScopeGuard(BUGGY)
+  // Each of the 4 functions should fail twice: no runId capture, and a bare
+  // unscoped setStatus().
+  assert.equal(
+    buggyErrors.length,
+    8,
+    `expected the pre-fix fixture (4 functions x 2 problems each) to fail ` +
+      `8 times, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(buggyErrors.some((e) => /batchDraftField.*capture/.test(e)))
+  assert.ok(buggyErrors.some((e) => /batchSetField.*capture/.test(e)))
+  assert.ok(buggyErrors.some((e) => /batchApproveStage.*capture/.test(e)))
+  assert.ok(buggyErrors.some((e) => /batchAutoBuild.*capture/.test(e)))
+  assert.ok(buggyErrors.some((e) => /batchDraftField.*1 time\(s\)/.test(e)))
+  assert.ok(buggyErrors.some((e) => /batchAutoBuild.*1 time\(s\)/.test(e)))
+
+  const fixedErrors = checkBatchGroupStatusScopeGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  // Regressed: runId captured everywhere, but batchSetField's own
+  // completion call site reverted to the bare setStatus().
+  const partiallyRegressed = [
+    simpleFixture('batchDraftField', false),
+    simpleFixture('batchSetField', true).replace(
+      // put back the runId capture that simpleFixture(name, true) omits,
+      // while keeping the buggy bare setStatus() completion call.
+      'const items = groupItems(outputKey)\n    if (!items.length) return\n    ',
+      'const items = groupItems(outputKey)\n    if (!items.length) return\n    const runId = state.run?.id\n    ',
+    ),
+    simpleFixture('batchApproveStage', false),
+    autoBuildFixture(false),
+  ].join('\n')
+  const regressedErrors = checkBatchGroupStatusScopeGuard(partiallyRegressed)
+  assert.equal(
+    regressedErrors.length,
+    1,
+    'expected only batchSetField to fail (bare setStatus, runId present) ' +
+      `got: ${JSON.stringify(regressedErrors)}`,
+  )
+  assert.ok(/batchSetField/.test(regressedErrors[0]!))
+  assert.ok(/1 time\(s\)/.test(regressedErrors[0]!))
+
+  const missingFnErrors = checkBatchGroupStatusScopeGuard(
+    'function someOtherFunction(): void {}',
+  )
+  assert.equal(missingFnErrors.length, 4)
+  for (const error of missingFnErrors) {
+    assert.ok(/Could not find a function named/.test(error))
+  }
+
+  console.log(
+    'Model Builder batch-group status-scope guard self-test passed: buggy ' +
+      'fixture fails for all four functions, fixed fixture passes, a ' +
+      'partially-regressed fixture fails only for the regressed function, ' +
+      'missing-function fixture fails clearly for all four.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderBatchGroupStatusScopeGuard.ts
+++ b/utils/scripts/verifyModelBuilderBatchGroupStatusScopeGuard.ts
@@ -1,0 +1,151 @@
+// /utils/scripts/verifyModelBuilderBatchGroupStatusScopeGuard.ts
+//
+// Regression guard (model-builder/t-029 cycle 13). draftText was fixed
+// (model-builder/t-029, see verifyModelBuilderDraftStatusScopeGuard's own
+// doc comment) to capture `const runId = state.run.id` up front and route
+// every status message it surfaces through setStatusForRun(runId, ...) --
+// because it spans a real network round-trip long enough for the user to
+// switch to (or start) a DIFFERENT run via History before the response
+// lands, and a bare, unscoped setStatus() would then pop a misleading toast
+// over whatever OTHER run is now on screen. autoBuildRun (the whole-run
+// auto-build entry point) already followed that same discipline from the
+// start: it captures its own runId and gates both its per-item loop and its
+// final summary on `state.run?.id === runId`.
+//
+// The four "act on every item in one quantity/expansion output group at
+// once" entry points -- batchDraftField, batchSetField, batchApproveStage,
+// batchAutoBuild -- never got this treatment. Each awaits at least one real
+// network round-trip per group (draftText per item, a single batchPushItems
+// call, or autoBuildItem per item), so each is exactly as exposed to the
+// same run-switch race, but every one of them reported its own completion
+// toast through the bare, unscoped setStatus() with no runId captured
+// anywhere in the function. Concrete repro (pre-fix): open a run with a
+// quantity output group (e.g. "expand-characters" x5), click "Auto-build
+// group", then -- while it's still working through the group -- open Run
+// History and open a different run. Minutes later, while looking at the
+// OTHER run, a stale "Auto-built X/N in this group (Y failed...)" banner
+// pops up over it, about a group that isn't even part of what's on screen.
+// Identical shape for batchDraftField's "Drafted X/N items.", batchSetField's
+// "Set KEY on X/M items.", and batchApproveStage's "Approved STAGE for X
+// items." toasts.
+//
+// This asserts the textual shape of the fix stays in place for all four
+// functions: each contains `const runId = state.run?.id` (or `state.run.id`
+// on a path where the type checker sees state.run as already narrowed
+// non-null), and every one of that function's own completion-toast call
+// sites reads `setStatusForRun(runId` or is wrapped in an explicit
+// `state.run?.id === runId` check -- never a bare `setStatus(` outside of
+// that guard. Deliberately scoped to these four functions/this one bug,
+// mirroring verifyModelBuilderDraftStatusScopeGuard's own narrow, textual
+// approach over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAMES = [
+  'batchDraftField',
+  'batchSetField',
+  'batchApproveStage',
+  'batchAutoBuild',
+] as const
+
+const RUN_ID_CAPTURE = /const\s+runId\s*=\s*state\.run\??\.id/
+
+// A bare `setStatus(` call -- i.e. not `setStatusForRun(` -- that is NOT
+// immediately preceded (on the same or an earlier line, ignoring
+// whitespace/newlines) by an opening `state.run?.id === runId) {` guard.
+// Rather than trying to fully parse nesting, this narrow check mirrors
+// verifyModelBuilderDraftStatusScopeGuard's own approach: strip every
+// `setStatusForRun(` occurrence first (so its embedded `setStatus` prefix
+// can't false-match), strip every guarded bare call (the
+// `state.run?.id === runId) {\n...setStatus(` shape batchAutoBuild uses),
+// then anything left starting with `setStatus(` is a genuine unscoped call.
+function findUnguardedBareSetStatusCalls(body: string): number {
+  let scrubbed = body.replace(/setStatusForRun\(/g, '')
+  // Remove the one sanctioned guarded shape: an `if (state.run?.id ===
+  // runId)` block whose body calls the bare setStatus(. Non-greedy across
+  // newlines so this only eats up to the next closing brace, not the rest
+  // of the function.
+  scrubbed = scrubbed.replace(
+    /if\s*\(\s*state\.run\?\.id\s*===\s*runId\s*\)\s*\{[\s\S]*?setStatus\([\s\S]*?\n\s*\}/,
+    '',
+  )
+  const matches = scrubbed.match(/\bsetStatus\(/g)
+  return matches ? matches.length : 0
+}
+
+export function checkBatchGroupStatusScopeGuard(content: string): string[] {
+  const errors: string[] = []
+  const functions = extractFunctionBodies(content)
+
+  for (const name of FN_NAMES) {
+    const fn = functions.find((f) => f.name === name)
+    if (!fn) {
+      errors.push(
+        `Could not find a function named ${name}() -- has it been ` +
+          'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+          'protects against) needs to move with it.',
+      )
+      continue
+    }
+
+    if (!RUN_ID_CAPTURE.test(fn.body)) {
+      errors.push(
+        `${name}() no longer captures a runId (\`const runId = state.run?.id\`` +
+          " or `state.run.id`) up front -- without it, this function's own " +
+          'completion toast can never be scoped to the run it was acting on, ' +
+          'and a group action that finishes after the user has switched runs ' +
+          'via History will surface a misleading toast in whatever run is ' +
+          'now on screen.',
+      )
+    }
+
+    const bareCount = findUnguardedBareSetStatusCalls(fn.body)
+    if (bareCount > 0) {
+      errors.push(
+        `${name}() still calls the bare, unscoped setStatus(...) ` +
+          `${bareCount} time(s) outside of a \`state.run?.id === runId\` ` +
+          "guard -- this function's own completion toast must go through " +
+          'setStatusForRun(runId, ...) (or be wrapped in that same runId ' +
+          'check), mirroring draftText/generateItemAsset/commitItem/' +
+          'pushItem/batchPushItems/autoBuildRun.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkBatchGroupStatusScopeGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder batch-group status-scope guard contract failed in ' +
+        'modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder batch-group status-scope guard contract passed: ' +
+      'batchDraftField/batchSetField/batchApproveStage/batchAutoBuild each ' +
+      'capture their own runId and route their completion toast through ' +
+      'setStatusForRun(runId, ...) (or an equivalent state.run?.id === ' +
+      'runId guard).',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Bug

`batchDraftField`/`batchSetField`/`batchApproveStage`/`batchAutoBuild` each spend at least one real network round-trip acting on every item in a quantity/expansion output group (`draftText` per item, a single `batchPushItems` call, or `autoBuildItem` per item) — long enough for the user to switch to (or start) a different run via History before the call finishes.

Every single-item async entry point in this file (`draftText`, `generateItemAsset`, `generateItemAssetAsync`, `commitItem`, `pushItem`, `batchPushItems`) and the whole-run `autoBuildRun` already guard against this: each captures `runId` up front and routes its status messages through `setStatusForRun(runId, ...)`, which no-ops unless `state.run` still matches that run. These four batch-group functions never got that treatment — each reported its own completion toast through the bare, unscoped `setStatus()`, with no `runId` captured anywhere in the function.

**Concrete repro (pre-fix):** open a run with a quantity output group (e.g. `expand-characters` x5), click "Auto-build group", then — while it's still working through the group — open Run History and open a different run. Minutes later, while looking at the other run, a stale "Auto-built X/N in this group (Y failed...)" banner pops up over it, about a group that isn't even part of what's on screen. Identical shape for `batchDraftField`'s "Drafted X/N items.", `batchSetField`'s "Set KEY on X/M items.", and `batchApproveStage`'s "Approved STAGE for X items." toasts.

## Fix

- Capture `runId` up front in all four functions and route their completion toast through `setStatusForRun(runId, ...)`.
- `batchAutoBuild` also gains the same mid-loop "stop walking an abandoned run" early-return its sibling `autoBuildRun` already has.
- Updates `verifyModelBuilderAutoBuildFailedSummaryGuard.ts` (+ self-test) to recognize the `setStatusForRun(runId, tone, message)` call shape `batchDraftField`'s final summary now uses, alongside the bare `setStatus(tone, message)` shape it originally expected — an orthogonal, pre-existing guard whose textual match broke against this fix's shape change.
- Adds a new guard, `verifyModelBuilderBatchGroupStatusScopeGuard.ts` (+ self-test), asserting all four functions keep capturing a `runId` and keep routing their completion toast through `setStatusForRun` (or an equivalent `state.run?.id === runId` guard) — wired into `package.json` and `contract-tests.yml` the way sibling guards are.

## Verification

- `vue-tsc --noEmit`: clean repo-wide
- `eslint`/`prettier --check`: clean on touched files (two pre-existing `no-empty` errors in `modelBuilderStore.ts` at lines 240/247 predate this change — confirmed via `git stash` comparison against the unmodified file)
- All 91 `test:model-builder-*` scripts pass, including the two new/updated guards and their self-tests
- git-stash round trip: `verifyModelBuilderBatchGroupStatusScopeGuard` fails with 8 errors (2 per function) against the pre-fix store, passes clean post-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wSx2kDrm4xXxBS2e12zVA

---
_Generated by [Claude Code](https://claude.ai/code/session_014wSx2kDrm4xXxBS2e12zVA)_