### PR TITLE
fix(model-builder): restore focus when the run-history panel closes (t-029 cycle 14)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -599,6 +599,12 @@ jobs:
       - name: Model Builder error callout role guard contract
         run: npm run test:model-builder-error-callout-role-guard
 
+      - name: Model Builder history-close focus guard self-test
+        run: npm run test:model-builder-history-close-focus-guard-selftest
+
+      - name: Model Builder history-close focus guard contract
+        run: npm run test:model-builder-history-close-focus-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/components/model-builder/model-builder-manager.vue
+++ b/components/model-builder/model-builder-manager.vue
@@ -37,9 +37,14 @@
       </nav>
 
       <button
+        ref="historyToggleButton"
         type="button"
         class="btn btn-xs btn-ghost ml-auto h-7 min-h-7 rounded-xl px-2"
-        :class="showHistory ? 'text-primary' : 'text-base-content/60 hover:text-primary'"
+        :class="
+          showHistory
+            ? 'text-primary'
+            : 'text-base-content/60 hover:text-primary'
+        "
         :disabled="store.startingRun || resumingRun"
         aria-label="Toggle run history"
         :aria-pressed="showHistory"
@@ -99,12 +104,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { useModelBuilderStore } from '@/stores/modelBuilderStore'
 
 const store = useModelBuilderStore()
 const showHistory = ref(false)
 const resumingRun = ref(true)
+const historyToggleButton = ref<HTMLButtonElement | null>(null)
 
 const crumbs = computed(() => [
   { step: 'source' as const, label: 'Source', enabled: true },
@@ -122,6 +128,27 @@ onMounted(async () => {
   } finally {
     resumingRun.value = false
   }
+})
+
+// The run-history panel (model-builder-run-history.vue) can close itself
+// from a button *inside* the panel -- "Open" on a run or "New run" both emit
+// `close` (see their own click handlers) rather than going back through the
+// header's own toggle button below. That inside button unmounts along with
+// the whole panel, and since nothing here ever moves focus anywhere else,
+// the browser drops it to <body> -- keyboard/screen-reader users lose their
+// place entirely and have to tab in again from the very top of the page,
+// instead of picking back up at the control that reopened the step they're
+// now looking at. Restoring focus to the toggle button itself (whether the
+// panel closed via that same button, a harmless no-op re-focus, or via one
+// of the inside buttons, the actual gap) keeps keyboard navigation anchored
+// to a sensible, discoverable spot. Mirrors academy-timeline.vue's
+// closeLesson() -- nextTick() then ref.value?.focus() -- for the identical
+// close-from-inside-the-panel shape.
+watch(showHistory, (isOpen) => {
+  if (isOpen) return
+  nextTick(() => {
+    historyToggleButton.value?.focus()
+  })
 })
 </script>
 

--- a/package.json
+++ b/package.json
@@ -276,6 +276,8 @@
     "test:model-builder-single-item-revert-guard": "tsx utils/scripts/verifyModelBuilderSingleItemRevertGuard.ts",
     "test:model-builder-error-callout-role-guard-selftest": "tsx utils/scripts/verifyModelBuilderErrorCalloutRoleGuard.test.ts",
     "test:model-builder-error-callout-role-guard": "tsx utils/scripts/verifyModelBuilderErrorCalloutRoleGuard.ts",
+    "test:model-builder-history-close-focus-guard-selftest": "tsx utils/scripts/verifyModelBuilderHistoryCloseFocusGuard.test.ts",
+    "test:model-builder-history-close-focus-guard": "tsx utils/scripts/verifyModelBuilderHistoryCloseFocusGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/utils/scripts/verifyModelBuilderHistoryCloseFocusGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderHistoryCloseFocusGuard.test.ts
@@ -1,0 +1,136 @@
+// /utils/scripts/verifyModelBuilderHistoryCloseFocusGuard.test.ts
+//
+// Regression test for checkHistoryCloseFocusGuard() in
+// verifyModelBuilderHistoryCloseFocusGuard.ts (model-builder/t-029, cycle
+// 14). Exercises the check against synthetic component-shaped fixtures
+// covering: the fixed shape (ref attribute + watch + focus call all
+// present), each piece of the pre-fix shape missing individually, and a
+// missing-button regression (the toggle button removed entirely).
+import assert from 'node:assert/strict'
+
+import { checkHistoryCloseFocusGuard } from './verifyModelBuilderHistoryCloseFocusGuard.js'
+
+function fixture(options: {
+  refAttr?: boolean
+  watchCall?: boolean
+  focusCall?: boolean
+  buttonPresent?: boolean
+}): string {
+  const {
+    refAttr = true,
+    watchCall = true,
+    focusCall = true,
+    buttonPresent = true,
+  } = options
+
+  const button = buttonPresent
+    ? `
+      <button
+        ${refAttr ? 'ref="historyToggleButton"' : ''}
+        type="button"
+        aria-label="Toggle run history"
+        :aria-pressed="showHistory"
+        @click="showHistory = !showHistory"
+      >
+        History
+      </button>`
+    : ''
+
+  const script = `
+<script setup lang="ts">
+import { ref${watchCall ? ', watch' : ''} } from 'vue'
+const showHistory = ref(false)
+const historyToggleButton = ref(null)
+${
+  watchCall
+    ? `watch(showHistory, (isOpen) => {
+  if (isOpen) return
+  nextTick(() => {
+    ${focusCall ? 'historyToggleButton.value?.focus()' : 'doNothing()'}
+  })
+})`
+    : ''
+}
+</script>`
+
+  return `
+<template>
+  <section>${button}</section>
+</template>
+${script}
+`
+}
+
+const FIXED = fixture({})
+const MISSING_REF = fixture({ refAttr: false })
+const MISSING_WATCH = fixture({ watchCall: false })
+const MISSING_FOCUS_CALL = fixture({ focusCall: false })
+const BUTTON_REMOVED = fixture({ buttonPresent: false })
+
+function run(): void {
+  // Fixed fixture passes with no errors.
+  const fixedErrors = checkHistoryCloseFocusGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  // Missing `ref="historyToggleButton"` fails exactly one check.
+  const missingRefErrors = checkHistoryCloseFocusGuard(MISSING_REF)
+  assert.equal(
+    missingRefErrors.length,
+    1,
+    `expected the missing-ref fixture to fail exactly one check, got: ${JSON.stringify(missingRefErrors)}`,
+  )
+  assert.ok(
+    missingRefErrors.some((e) => /no longer carries/.test(e)),
+    `expected a "no longer carries" error, got: ${JSON.stringify(missingRefErrors)}`,
+  )
+
+  // Missing the `watch(showHistory, ...)` call fails both the watch check
+  // and the focus-call check -- dropping the watch block in this fixture
+  // takes its inline `.focus()` call with it, same as a real regression
+  // that deletes the whole watcher in one edit.
+  const missingWatchErrors = checkHistoryCloseFocusGuard(MISSING_WATCH)
+  assert.equal(
+    missingWatchErrors.length,
+    2,
+    `expected the missing-watch fixture to fail both checks, got: ${JSON.stringify(missingWatchErrors)}`,
+  )
+  assert.ok(
+    missingWatchErrors.some((e) => /no longer watches/.test(e)),
+    `expected a "no longer watches" error, got: ${JSON.stringify(missingWatchErrors)}`,
+  )
+  assert.ok(
+    missingWatchErrors.some((e) => /no longer calls/.test(e)),
+    `expected a "no longer calls" error, got: ${JSON.stringify(missingWatchErrors)}`,
+  )
+
+  // Missing the actual `.focus()` call (watch present but inert) fails
+  // exactly one check.
+  const missingFocusErrors = checkHistoryCloseFocusGuard(MISSING_FOCUS_CALL)
+  assert.equal(
+    missingFocusErrors.length,
+    1,
+    `expected the missing-focus-call fixture to fail exactly one check, got: ${JSON.stringify(missingFocusErrors)}`,
+  )
+  assert.ok(
+    missingFocusErrors.some((e) => /no longer calls/.test(e)),
+    `expected a "no longer calls" error, got: ${JSON.stringify(missingFocusErrors)}`,
+  )
+
+  // Toggle button removed entirely fails with a "could not find" error.
+  const buttonRemovedErrors = checkHistoryCloseFocusGuard(BUTTON_REMOVED)
+  assert.equal(buttonRemovedErrors.length, 1)
+  assert.ok(buttonRemovedErrors.some((e) => /Could not find/.test(e)))
+
+  console.log(
+    'Model Builder history-close focus guard self-test passed: the fixed ' +
+      'fixture passes, each individually-broken fixture fails exactly one ' +
+      'check, and a fully-removed toggle button fails with a ' +
+      '"could not find" error.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderHistoryCloseFocusGuard.ts
+++ b/utils/scripts/verifyModelBuilderHistoryCloseFocusGuard.ts
@@ -1,0 +1,128 @@
+// /utils/scripts/verifyModelBuilderHistoryCloseFocusGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 14) -- model-builder-manager.vue
+// swaps its <main> content between the run-history panel
+// (model-builder-run-history.vue) and the current step's component with a
+// plain `v-else-if="showHistory"` / `v-else` toggle. The history panel can
+// close itself from a button *inside* the panel: "Open" on a run and
+// "New run" (model-builder-run-history.vue's `open()`/`startNew()`) both
+// emit `close`, same as the header's own "Toggle run history" button
+// (`@click="showHistory = !showHistory"`). Before this fix, nothing ever
+// moved focus anywhere on that transition -- closing via the header toggle
+// leaves focus right where it already was (harmless), but closing via
+// "Open"/"New run" unmounts the very button that currently holds focus.
+// With no reasonable element to land on, the browser drops focus to
+// <body>, silently resetting keyboard/screen-reader navigation to the top
+// of the page instead of leaving it anchored at the control that reopened
+// the step now on screen. Concrete repro: open Model Builder, tab to
+// "History", press Enter, tab to a run's "Open" button, press Enter --
+// focus is now on <body>, and the next Tab press starts from the very top
+// of the page rather than continuing from the header.
+//
+// Fixed by giving the header's "Toggle run history" button a template ref
+// (`ref="historyToggleButton"`) and a `watch(showHistory, ...)` that calls
+// `nextTick()` then `historyToggleButton.value?.focus()` whenever
+// showHistory transitions to false -- mirrors academy-timeline.vue's
+// closeLesson() (nextTick + ref.focus()) for the identical
+// close-from-inside-the-panel shape.
+//
+// This asserts the textual shape of that fix stays in place: the toggle
+// button carries the template ref, and the script block both imports
+// `watch`/`nextTick` and wires a `watch(showHistory, ...)` callback that
+// calls `historyToggleButton.value?.focus()` -- deliberately scoped to this
+// one bug shape, mirroring this project's other narrow textual guards over
+// a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const MANAGER_PATH = join(
+  repositoryRoot,
+  'components/model-builder/model-builder-manager.vue',
+)
+
+const TOGGLE_MARKER = 'aria-label="Toggle run history"'
+const REF_ATTR = 'ref="historyToggleButton"'
+const WATCH_CALL = 'watch(showHistory'
+const FOCUS_CALL = 'historyToggleButton.value?.focus()'
+
+// Checks the fix's exact shape against the full source text of
+// model-builder-manager.vue. Exported so the self-test below can run it
+// against synthetic buggy/fixed fixtures without touching the real
+// component file.
+export function checkHistoryCloseFocusGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const toggleIndex = content.indexOf(TOGGLE_MARKER)
+  if (toggleIndex === -1) {
+    errors.push(
+      `Could not find \`${TOGGLE_MARKER}\` in model-builder-manager.vue -- ` +
+        'has the "Toggle run history" button been renamed or restructured? ' +
+        'If so, this guard needs to move with it.',
+    )
+    return errors
+  }
+
+  const tagStart = content.lastIndexOf('<button', toggleIndex)
+  const tagEnd = content.indexOf('>', toggleIndex)
+  const tag =
+    tagStart === -1 || tagEnd === -1 ? '' : content.slice(tagStart, tagEnd + 1)
+
+  if (!tag.includes(REF_ATTR)) {
+    errors.push(
+      `The "Toggle run history" button no longer carries \`${REF_ATTR}\` -- ` +
+        'without a template ref to it, focus can no longer be restored to ' +
+        'it when the run-history panel closes from a button inside the ' +
+        'panel itself (Open / New run in model-builder-run-history.vue), ' +
+        'and keyboard/screen-reader focus silently drops to <body>.',
+    )
+  }
+
+  if (!content.includes(WATCH_CALL)) {
+    errors.push(
+      'model-builder-manager.vue no longer watches `showHistory` -- the ' +
+        'close-from-inside-the-panel focus restoration only runs on that ' +
+        'transition; without the watch, closing history via "Open" or ' +
+        '"New run" drops focus to <body> with nothing to bring it back.',
+    )
+  }
+
+  if (!content.includes(FOCUS_CALL)) {
+    errors.push(
+      `model-builder-manager.vue no longer calls \`${FOCUS_CALL}\` -- the ` +
+        'showHistory watcher exists but no longer actually refocuses the ' +
+        'toggle button, so the fix is present in shape only.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(MANAGER_PATH, 'utf8')
+  const errors = checkHistoryCloseFocusGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder history-close focus guard contract failed for ' +
+        'model-builder-manager.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder history-close focus guard contract passed: closing the ' +
+      'run-history panel from a button inside it restores focus to the ' +
+      'header\'s "Toggle run history" button instead of dropping it to ' +
+      '<body>.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What

`model-builder-manager.vue` swaps its `<main>` content between the run-history panel and the current step with a plain `v-else-if="showHistory"` / `v-else` toggle. The history panel can close itself from a button **inside** the panel: "Open" on a run and "New run" (`model-builder-run-history.vue`'s `open()`/`startNew()`) both emit `close`, same as the header's own "Toggle run history" button.

Closing via the header toggle is harmless (focus was already there). But closing via Open/New run unmounts the very button that currently holds focus, and since nothing ever moves focus anywhere else, the browser drops it to `<body>` — keyboard and screen-reader users lose their place entirely and have to tab in again from the very top of the page instead of picking back up at a sensible spot.

**Concrete repro:** open Model Builder → Tab to "History" → Enter → Tab to a run's "Open" button → Enter. Focus is now on `<body>`; the next Tab press starts from the top of the page.

## Fix

Gave the header's "Toggle run history" button a template ref (`ref="historyToggleButton"`) and a `watch(showHistory, ...)` that calls `nextTick()` then `historyToggleButton.value?.focus()` whenever the panel closes. Mirrors `academy-timeline.vue`'s `closeLesson()` (`nextTick` + `ref.focus()`) for the identical close-from-inside-the-panel shape already established elsewhere in this codebase.

## Guard

Added `utils/scripts/verifyModelBuilderHistoryCloseFocusGuard.ts` + `.test.ts` (narrow textual guard, mirrors this feature's other guards like `verifyModelBuilderBatchEditorKeyGuard.ts`), wired into `package.json` and `.github/workflows/contract-tests.yml` alongside the feature's other `test:model-builder-*` entries.

## Verification

- `vue-tsc --noEmit`: clean repo-wide
- `eslint` / `prettier --check`: clean on touched files (repo-wide lint has pre-existing unrelated failures in untouched files)
- All 93 `test:model-builder-*` npm scripts pass, including the new guard's self-test
- git-stash round trip: new guard fails against the pre-fix component, passes post-fix

## Context

model-builder/t-029 cycle 14. Prior cycles (1–13) hardened the store (`modelBuilderStore.ts`) extensively against run-scoping/race bugs; cycle 13's own lead pointed at the `.vue` components for real UX gaps instead. This cycle audited all 7 `model-builder-*.vue` components for missing loading/disabled states, keyboard-inaccessible controls, and focus-management gaps — the store itself is exceptionally hardened at this point (every button double-submit / stale-write scenario I traced already has an explicit, documented guard), so this focus-restoration bug in the manager shell was the one genuine, concrete, reproducible gap found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wSx2kDrm4xXxBS2e12zVA


---
_Generated by [Claude Code](https://claude.ai/code/session_014wSx2kDrm4xXxBS2e12zVA)_