### PR TITLE
fix(model-builder): restore focus when a step changes from inside its own content (t-029 cycle 15)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -605,6 +605,12 @@ jobs:
       - name: Model Builder history-close focus guard contract
         run: npm run test:model-builder-history-close-focus-guard
 
+      - name: Model Builder step-content focus guard self-test
+        run: npm run test:model-builder-step-content-focus-guard-selftest
+
+      - name: Model Builder step-content focus guard contract
+        run: npm run test:model-builder-step-content-focus-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/components/model-builder/model-builder-manager.vue
+++ b/components/model-builder/model-builder-manager.vue
@@ -80,7 +80,12 @@
       </div>
     </Transition>
 
-    <main class="flex min-h-0 flex-1 flex-col overflow-y-auto p-2 sm:p-3">
+    <main
+      ref="mainContent"
+      tabindex="-1"
+      aria-label="Model Builder step content"
+      class="flex min-h-0 flex-1 flex-col overflow-y-auto p-2 sm:p-3"
+    >
       <div
         v-if="resumingRun"
         class="flex min-h-32 flex-1 items-center justify-center gap-2 text-sm text-base-content/60"
@@ -111,6 +116,7 @@ const store = useModelBuilderStore()
 const showHistory = ref(false)
 const resumingRun = ref(true)
 const historyToggleButton = ref<HTMLButtonElement | null>(null)
+const mainContent = ref<HTMLElement | null>(null)
 
 const crumbs = computed(() => [
   { step: 'source' as const, label: 'Source', enabled: true },
@@ -150,6 +156,46 @@ watch(showHistory, (isOpen) => {
     historyToggleButton.value?.focus()
   })
 })
+
+// The same focus-loss shape as the watcher above, one level down: several
+// buttons *inside* the current step's own component change store.step,
+// unmounting that whole component (and the clicked button with it) via the
+// v-if/v-else-if chain above -- model-builder-progress-matrix.vue's "New
+// run" (store.resetRun()), model-builder-recipe-selector.vue's "Change
+// source" (store.goToStep('source')), and model-builder-source-picker.vue's
+// record buttons (store.selectSource()) all mutate step synchronously, with
+// nothing moving focus anywhere afterward, so the browser drops it to
+// <body> exactly like the history-panel case. The header's own crumb nav
+// buttons also change store.step, but they live in <header>, which never
+// unmounts across a step change -- a crumb click keeps focus right where it
+// already correctly was, and must stay untouched, so this can't just watch
+// store.step unconditionally the way the showHistory watch above does.
+// Checking `mainContent.value?.contains(document.activeElement)` at watch
+// time (before Vue patches the DOM for the new step, so activeElement is
+// still whatever was focused at the moment of the click that changed step)
+// tells the two shapes apart: true only when the control that changed the
+// step was itself inside <main> -- the step content about to be replaced --
+// never for a crumb click, which lives outside it. <main> carries
+// tabindex="-1" so it can receive focus programmatically without joining
+// the normal Tab order, and it never unmounts across any step or the
+// history-panel toggle, so it's always a safe landing spot.
+//
+// This can fire in the same tick as the showHistory watch above (e.g.
+// "New run" inside model-builder-run-history.vue calls store.resetRun()
+// then emits `close`, changing both step and showHistory at once) -- both
+// watchers' nextTick callbacks then run in registration order, so this one
+// (registered second) wins and focus lands on the newly-shown step's
+// content, which is the more useful outcome of the two when the step
+// itself actually changed.
+watch(
+  () => store.step,
+  () => {
+    if (!mainContent.value?.contains(document.activeElement)) return
+    nextTick(() => {
+      mainContent.value?.focus()
+    })
+  },
+)
 </script>
 
 <style scoped>

--- a/package.json
+++ b/package.json
@@ -278,6 +278,8 @@
     "test:model-builder-error-callout-role-guard": "tsx utils/scripts/verifyModelBuilderErrorCalloutRoleGuard.ts",
     "test:model-builder-history-close-focus-guard-selftest": "tsx utils/scripts/verifyModelBuilderHistoryCloseFocusGuard.test.ts",
     "test:model-builder-history-close-focus-guard": "tsx utils/scripts/verifyModelBuilderHistoryCloseFocusGuard.ts",
+    "test:model-builder-step-content-focus-guard-selftest": "tsx utils/scripts/verifyModelBuilderStepContentFocusGuard.test.ts",
+    "test:model-builder-step-content-focus-guard": "tsx utils/scripts/verifyModelBuilderStepContentFocusGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/utils/scripts/verifyModelBuilderStepContentFocusGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderStepContentFocusGuard.test.ts
@@ -1,0 +1,184 @@
+// /utils/scripts/verifyModelBuilderStepContentFocusGuard.test.ts
+//
+// Regression test for checkStepContentFocusGuard() in
+// verifyModelBuilderStepContentFocusGuard.ts (model-builder/t-029, cycle
+// 15). Exercises the check against synthetic component-shaped fixtures
+// covering: the fixed shape (ref + tabindex + watch + contains-check +
+// focus call all present), each piece of the pre-fix shape missing
+// individually, and a missing-<main> regression (the wrapper removed
+// entirely).
+import assert from 'node:assert/strict'
+
+import { checkStepContentFocusGuard } from './verifyModelBuilderStepContentFocusGuard.js'
+
+function fixture(options: {
+  refAttr?: boolean
+  tabindexAttr?: boolean
+  watchCall?: boolean
+  containsCheck?: boolean
+  focusCall?: boolean
+  mainPresent?: boolean
+}): string {
+  const {
+    refAttr = true,
+    tabindexAttr = true,
+    watchCall = true,
+    containsCheck = true,
+    focusCall = true,
+    mainPresent = true,
+  } = options
+
+  const main = mainPresent
+    ? `
+      <main
+        ${refAttr ? 'ref="mainContent"' : ''}
+        ${tabindexAttr ? 'tabindex="-1"' : ''}
+        aria-label="Model Builder step content"
+      >
+        <template v-else />
+      </main>`
+    : ''
+
+  const watchBody = containsCheck
+    ? `if (!mainContent.value?.contains(document.activeElement)) return
+    nextTick(() => {
+      ${focusCall ? 'mainContent.value?.focus()' : 'doNothing()'}
+    })`
+    : `nextTick(() => {
+      ${focusCall ? 'mainContent.value?.focus()' : 'doNothing()'}
+    })`
+
+  const script = `
+<script setup lang="ts">
+import { nextTick, ref${watchCall ? ', watch' : ''} } from 'vue'
+const mainContent = ref(null)
+${
+  watchCall
+    ? `watch(
+  () => store.step,
+  () => {
+    ${watchBody}
+  },
+)`
+    : ''
+}
+</script>`
+
+  return `
+<template>
+  <section>${main}</section>
+</template>
+${script}
+`
+}
+
+const FIXED = fixture({})
+const MISSING_REF = fixture({ refAttr: false })
+const MISSING_TABINDEX = fixture({ tabindexAttr: false })
+const MISSING_WATCH = fixture({ watchCall: false })
+const MISSING_CONTAINS_CHECK = fixture({ containsCheck: false })
+const MISSING_FOCUS_CALL = fixture({ focusCall: false })
+const MAIN_REMOVED = fixture({ mainPresent: false })
+
+function run(): void {
+  // Fixed fixture passes with no errors.
+  const fixedErrors = checkStepContentFocusGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  // Missing `ref="mainContent"` fails exactly one check.
+  const missingRefErrors = checkStepContentFocusGuard(MISSING_REF)
+  assert.equal(
+    missingRefErrors.length,
+    1,
+    `expected the missing-ref fixture to fail exactly one check, got: ${JSON.stringify(missingRefErrors)}`,
+  )
+  assert.ok(
+    missingRefErrors.some((e) =>
+      /no longer carries `ref="mainContent"`/.test(e),
+    ),
+    `expected a "no longer carries" ref error, got: ${JSON.stringify(missingRefErrors)}`,
+  )
+
+  // Missing `tabindex="-1"` fails exactly one check.
+  const missingTabindexErrors = checkStepContentFocusGuard(MISSING_TABINDEX)
+  assert.equal(
+    missingTabindexErrors.length,
+    1,
+    `expected the missing-tabindex fixture to fail exactly one check, got: ${JSON.stringify(missingTabindexErrors)}`,
+  )
+  assert.ok(
+    missingTabindexErrors.some((e) =>
+      /no longer carries `tabindex="-1"`/.test(e),
+    ),
+    `expected a "no longer carries" tabindex error, got: ${JSON.stringify(missingTabindexErrors)}`,
+  )
+
+  // Missing the `watch(() => store.step, ...)` call fails every downstream
+  // check too -- dropping the watch block in this fixture takes its inline
+  // contains-check and .focus() call with it, same as a real regression
+  // that deletes the whole watcher in one edit.
+  const missingWatchErrors = checkStepContentFocusGuard(MISSING_WATCH)
+  assert.equal(
+    missingWatchErrors.length,
+    3,
+    `expected the missing-watch fixture to fail all three downstream checks, got: ${JSON.stringify(missingWatchErrors)}`,
+  )
+  assert.ok(
+    missingWatchErrors.some((e) => /no longer watches/.test(e)),
+    `expected a "no longer watches" error, got: ${JSON.stringify(missingWatchErrors)}`,
+  )
+  assert.ok(
+    missingWatchErrors.some((e) => /no longer checks/.test(e)),
+    `expected a "no longer checks" error, got: ${JSON.stringify(missingWatchErrors)}`,
+  )
+  assert.ok(
+    missingWatchErrors.some((e) => /no longer calls/.test(e)),
+    `expected a "no longer calls" error, got: ${JSON.stringify(missingWatchErrors)}`,
+  )
+
+  // Missing the `.contains(document.activeElement)` check (watch present,
+  // but unconditional) fails exactly one check.
+  const missingContainsErrors = checkStepContentFocusGuard(
+    MISSING_CONTAINS_CHECK,
+  )
+  assert.equal(
+    missingContainsErrors.length,
+    1,
+    `expected the missing-contains-check fixture to fail exactly one check, got: ${JSON.stringify(missingContainsErrors)}`,
+  )
+  assert.ok(
+    missingContainsErrors.some((e) => /no longer checks/.test(e)),
+    `expected a "no longer checks" error, got: ${JSON.stringify(missingContainsErrors)}`,
+  )
+
+  // Missing the actual `.focus()` call (watch and contains-check present
+  // but inert) fails exactly one check.
+  const missingFocusErrors = checkStepContentFocusGuard(MISSING_FOCUS_CALL)
+  assert.equal(
+    missingFocusErrors.length,
+    1,
+    `expected the missing-focus-call fixture to fail exactly one check, got: ${JSON.stringify(missingFocusErrors)}`,
+  )
+  assert.ok(
+    missingFocusErrors.some((e) => /no longer calls/.test(e)),
+    `expected a "no longer calls" error, got: ${JSON.stringify(missingFocusErrors)}`,
+  )
+
+  // <main> removed entirely fails with a "could not find" error.
+  const mainRemovedErrors = checkStepContentFocusGuard(MAIN_REMOVED)
+  assert.equal(mainRemovedErrors.length, 1)
+  assert.ok(mainRemovedErrors.some((e) => /Could not find/.test(e)))
+
+  console.log(
+    'Model Builder step-content focus guard self-test passed: the fixed ' +
+      'fixture passes, each individually-broken fixture fails the right ' +
+      'checks, and a fully-removed <main> wrapper fails with a "could not ' +
+      'find" error.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderStepContentFocusGuard.ts
+++ b/utils/scripts/verifyModelBuilderStepContentFocusGuard.ts
@@ -1,0 +1,153 @@
+// /utils/scripts/verifyModelBuilderStepContentFocusGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 15) -- model-builder-manager.vue
+// swaps its <main> content between the three wizard steps
+// (model-builder-source-picker.vue, model-builder-recipe-selector.vue,
+// model-builder-progress-matrix.vue) with a v-if/v-else-if chain. Several
+// buttons *inside* the currently-displayed step change `store.step`, which
+// unmounts that whole step component -- and the very button that was just
+// clicked -- to mount the next one: model-builder-progress-matrix.vue's
+// "New run" (store.resetRun()), model-builder-recipe-selector.vue's
+// "Change source" (store.goToStep('source')), and
+// model-builder-source-picker.vue's source-record buttons
+// (store.selectSource()). Before this fix, nothing ever moved focus
+// anywhere on that transition, so the browser dropped it to <body> --
+// exactly the same shape cycle 14 fixed for the run-history toggle (see
+// verifyModelBuilderHistoryCloseFocusGuard.ts), just one level down: a
+// button inside the swapped-out content, rather than a button inside a
+// swapped-out panel.
+//
+// The header's own crumb nav buttons also change `store.step`, but they
+// live in <header>, which never unmounts across a step change, so a crumb
+// click correctly keeps focus right where it already was -- that case must
+// stay untouched, which is why the fix cannot just watch `store.step`
+// unconditionally the way cycle 14's `watch(showHistory, ...)` does.
+//
+// Fixed by giving <main> a template ref (`ref="mainContent"`) and
+// `tabindex="-1"` so it can receive focus programmatically, plus a
+// `watch(() => store.step, ...)` that checks
+// `mainContent.value?.contains(document.activeElement)` (true only when the
+// control that changed the step was itself inside <main>) before calling
+// `nextTick()` then `mainContent.value?.focus()`.
+//
+// This asserts the textual shape of that fix stays in place: <main> carries
+// both the template ref and tabindex="-1", and the script block wires a
+// `watch(() => store.step, ...)` callback that checks
+// `mainContent.value?.contains(document.activeElement)` and calls
+// `mainContent.value?.focus()` -- deliberately scoped to this one bug
+// shape, mirroring this project's other narrow textual guards over a
+// general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const MANAGER_PATH = join(
+  repositoryRoot,
+  'components/model-builder/model-builder-manager.vue',
+)
+
+const MAIN_MARKER = '<main'
+const REF_ATTR = 'ref="mainContent"'
+const TABINDEX_ATTR = 'tabindex="-1"'
+const WATCH_CALL = 'watch(\n  () => store.step'
+const CONTAINS_CHECK = 'mainContent.value?.contains(document.activeElement)'
+const FOCUS_CALL = 'mainContent.value?.focus()'
+
+// Checks the fix's exact shape against the full source text of
+// model-builder-manager.vue. Exported so the self-test below can run it
+// against synthetic buggy/fixed fixtures without touching the real
+// component file.
+export function checkStepContentFocusGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const mainIndex = content.indexOf(MAIN_MARKER)
+  if (mainIndex === -1) {
+    errors.push(
+      'Could not find a `<main` element in model-builder-manager.vue -- ' +
+        'has the step content wrapper been renamed or restructured? If so, ' +
+        'this guard needs to move with it.',
+    )
+    return errors
+  }
+
+  const tagEnd = content.indexOf('>', mainIndex)
+  const tag = tagEnd === -1 ? '' : content.slice(mainIndex, tagEnd + 1)
+
+  if (!tag.includes(REF_ATTR)) {
+    errors.push(
+      `The <main> step content wrapper no longer carries \`${REF_ATTR}\` -- ` +
+        'without a template ref to it, focus can no longer be restored to ' +
+        'it when a button inside the current step (New run, Change source, ' +
+        'a source record) unmounts itself along with the step it belongs ' +
+        'to, and keyboard/screen-reader focus silently drops to <body>.',
+    )
+  }
+
+  if (!tag.includes(TABINDEX_ATTR)) {
+    errors.push(
+      `The <main> step content wrapper no longer carries \`${TABINDEX_ATTR}\` -- ` +
+        'a <main> element is not focusable by default, so calling ' +
+        '.focus() on it silently does nothing without this attribute.',
+    )
+  }
+
+  if (!content.includes(WATCH_CALL)) {
+    errors.push(
+      'model-builder-manager.vue no longer watches `store.step` -- the ' +
+        'step-content focus restoration only runs on that transition; ' +
+        'without the watch, a step change triggered from inside the ' +
+        'current step drops focus to <body> with nothing to bring it back.',
+    )
+  }
+
+  if (!content.includes(CONTAINS_CHECK)) {
+    errors.push(
+      `model-builder-manager.vue no longer checks \`${CONTAINS_CHECK}\` -- ` +
+        'without this check the watcher cannot tell a step change caused ' +
+        'by a button inside the step content (needs refocusing) apart ' +
+        'from one caused by a persistent header crumb click (already ' +
+        'correctly focused, must stay untouched), so the fix either does ' +
+        'nothing or wrongly steals focus away from the header on every ' +
+        'crumb click.',
+    )
+  }
+
+  if (!content.includes(FOCUS_CALL)) {
+    errors.push(
+      `model-builder-manager.vue no longer calls \`${FOCUS_CALL}\` -- the ` +
+        'store.step watcher exists but no longer actually refocuses <main>, ' +
+        'so the fix is present in shape only.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(MANAGER_PATH, 'utf8')
+  const errors = checkStepContentFocusGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder step-content focus guard contract failed for ' +
+        'model-builder-manager.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder step-content focus guard contract passed: a step ' +
+      "change triggered from inside the current step's own content " +
+      'restores focus to <main> instead of dropping it to <body>, without ' +
+      "interfering with the header crumb nav's own already-correct focus.",
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What

`model-builder-manager.vue` swaps its `<main>` content between the three wizard steps (`model-builder-source-picker.vue`, `model-builder-recipe-selector.vue`, `model-builder-progress-matrix.vue`) with a plain `v-if`/`v-else-if` chain. Several buttons *inside* the currently-displayed step change `store.step`, which unmounts that whole step component — and the very button that was just clicked — to mount the next one:

- `model-builder-progress-matrix.vue`'s "New run" (`store.resetRun()`)
- `model-builder-recipe-selector.vue`'s "Change source" (`store.goToStep('source')`)
- `model-builder-source-picker.vue`'s source-record buttons (`store.selectSource()`)

Nothing ever moved focus anywhere on that transition, so the browser dropped it to `<body>` — keyboard/screen-reader users lost their place entirely and had to tab in again from the very top of the page. This is exactly the same shape cycle 14 (#1950) fixed for the run-history toggle, just one level down: a button inside the swapped-out **step content**, rather than a button inside a swapped-out **panel**.

**Concrete repro:** open Model Builder → pick a source → pick a recipe → tab to "Change source" → press Enter. Focus is now on `<body>`; the next Tab press starts from the very top of the page instead of continuing from the newly-shown source picker.

The header's own crumb nav buttons (`1. Source` / `2. Recipe` / `3. Run`) also change `store.step`, but they live in `<header>`, which never unmounts across a step change — a crumb click already correctly kept focus right where it was. That case had to stay untouched, which is why the fix can't just watch `store.step` unconditionally the way cycle 14's `watch(showHistory, ...)` does.

## Fix

Gave `<main>` a template ref (`ref="mainContent"`) and `tabindex="-1"` so it can receive focus programmatically, plus a `watch(() => store.step, ...)` that checks `mainContent.value?.contains(document.activeElement)` — true only when the control that changed the step was itself inside `<main>` (checked before Vue patches the DOM for the new step) — before calling `nextTick()` then `mainContent.value?.focus()`. This distinguishes the two shapes: a crumb click (control lives outside `<main>`, skip) from a step-content button (control lives inside `<main>`, refocus it once the new step renders).

When this watcher and cycle 14's `showHistory` watcher both fire in the same tick (e.g. "New run" inside `model-builder-run-history.vue` changes both `step` and `showHistory` at once), they resolve deterministically by registration order — this one, registered second, wins, landing focus on the newly-shown step's content rather than back on the history toggle button, which is the more useful outcome when the step itself actually changed.

## Guard

Added `utils/scripts/verifyModelBuilderStepContentFocusGuard.ts` + `.test.ts` (narrow textual guard, mirrors `verifyModelBuilderHistoryCloseFocusGuard.ts`), wired into `package.json` and `.github/workflows/contract-tests.yml` alongside this feature's other `test:model-builder-*` entries.

## Verification

- `vue-tsc --noEmit`: clean repo-wide
- `eslint` / `prettier --check`: clean on touched files
- All 95 `test:model-builder-*` npm scripts pass (93 prior + 2 new)
- git-stash round trip: new guard fails against the pre-fix component (all 5 checks), passes post-fix

## Context

model-builder/t-029 cycle 15. Audited the four components cycle 14 flagged as the next lead (`model-builder-batch-editor.vue`, `model-builder-progress-matrix.vue`, `model-builder-recipe-selector.vue`, `model-builder-source-picker.vue`) plus a fresh read of `modelBuilderStore.ts` — the store and those four components are exceptionally hardened at this point (every race/staleness scenario I traced already has an explicit, documented guard). The genuine, concrete, reproducible gap found was this focus-restoration bug in the manager shell, one level down from cycle 14's own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019W7uQeKUXYTTNUwGaB1wYK

---
_Generated by [Claude Code](https://claude.ai/code/session_019W7uQeKUXYTTNUwGaB1wYK)_