### PR TITLE
fix(model-builder): announce source loading state to assistive tech (model-builder/t-029 cycle 16)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -611,6 +611,12 @@ jobs:
       - name: Model Builder step-content focus guard contract
         run: npm run test:model-builder-step-content-focus-guard
 
+      - name: Model Builder source loading announcement guard self-test
+        run: npm run test:model-builder-source-loading-announcement-guard-selftest
+
+      - name: Model Builder source loading announcement guard contract
+        run: npm run test:model-builder-source-loading-announcement-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -71,8 +71,11 @@
       <div
         v-else-if="store.loadingSources"
         class="flex h-full min-h-32 items-center justify-center gap-2 text-sm text-base-content/60"
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
       >
-        <span class="loading loading-dots loading-md" />
+        <span class="loading loading-dots loading-md" aria-hidden="true" />
         Loading {{ activeType?.plural.toLowerCase() }}…
       </div>
 

--- a/package.json
+++ b/package.json
@@ -280,6 +280,8 @@
     "test:model-builder-history-close-focus-guard": "tsx utils/scripts/verifyModelBuilderHistoryCloseFocusGuard.ts",
     "test:model-builder-step-content-focus-guard-selftest": "tsx utils/scripts/verifyModelBuilderStepContentFocusGuard.test.ts",
     "test:model-builder-step-content-focus-guard": "tsx utils/scripts/verifyModelBuilderStepContentFocusGuard.ts",
+    "test:model-builder-source-loading-announcement-guard-selftest": "tsx utils/scripts/verifyModelBuilderSourceLoadingAnnouncementGuard.test.ts",
+    "test:model-builder-source-loading-announcement-guard": "tsx utils/scripts/verifyModelBuilderSourceLoadingAnnouncementGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/utils/scripts/verifyModelBuilderSourceLoadingAnnouncementGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderSourceLoadingAnnouncementGuard.test.ts
@@ -1,0 +1,87 @@
+// /utils/scripts/verifyModelBuilderSourceLoadingAnnouncementGuard.test.ts
+//
+// Regression test for checkSourceLoadingAnnouncementGuard() in
+// verifyModelBuilderSourceLoadingAnnouncementGuard.ts (model-builder/t-029,
+// cycle 16). Exercises the check against synthetic component-shaped
+// fixtures covering: the fixed shape (all four attributes present), the
+// pre-fix shape (none of the four attributes), a partially-regressed shape
+// (only some attributes present), and a missing-block regression (the
+// loadingSources branch removed entirely).
+import assert from 'node:assert/strict'
+
+import { checkSourceLoadingAnnouncementGuard } from './verifyModelBuilderSourceLoadingAnnouncementGuard.js'
+
+function fixture(openingTagExtra: string, spanExtra: string): string {
+  return `
+<template>
+  <div
+    v-else-if="store.loadingSources"
+    ${openingTagExtra}
+    class="flex h-full min-h-32 items-center justify-center gap-2 text-sm text-base-content/60"
+  >
+    <span class="loading loading-dots loading-md" ${spanExtra} />
+    Loading {{ activeType?.plural.toLowerCase() }}…
+  </div>
+</template>
+`
+}
+
+const FIXED = fixture(
+  'role="status" aria-live="polite" aria-busy="true"',
+  'aria-hidden="true"',
+)
+const BUGGY = fixture('', '')
+const PARTIAL = fixture('role="status"', '')
+const BLOCK_REMOVED = `
+<template>
+  <div v-else class="flex h-full min-h-32">Nothing here.</div>
+</template>
+`
+
+function run(): void {
+  // Fixed fixture passes.
+  const fixedErrors = checkSourceLoadingAnnouncementGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  // Pre-fix (no attributes at all) fails all four checks.
+  const buggyErrors = checkSourceLoadingAnnouncementGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    4,
+    `expected the fully-buggy fixture to fail all four checks, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(buggyErrors.some((e) => /role="status"/.test(e)))
+  assert.ok(buggyErrors.some((e) => /aria-live="polite"/.test(e)))
+  assert.ok(buggyErrors.some((e) => /aria-busy="true"/.test(e)))
+  assert.ok(buggyErrors.some((e) => /spinner span/.test(e)))
+
+  // Partial regression (role="status" present, the rest missing) fails
+  // exactly the three still-missing checks.
+  const partialErrors = checkSourceLoadingAnnouncementGuard(PARTIAL)
+  assert.equal(
+    partialErrors.length,
+    3,
+    `expected the partial fixture to fail three checks, got: ${JSON.stringify(partialErrors)}`,
+  )
+  assert.ok(
+    !partialErrors.some((e) => /no longer carries role="status"/.test(e)),
+  )
+
+  // Block removed entirely fails with a single "could not find" error.
+  const removedErrors = checkSourceLoadingAnnouncementGuard(BLOCK_REMOVED)
+  assert.equal(removedErrors.length, 1)
+  assert.ok(removedErrors.some((e) => /Could not find a/.test(e)))
+
+  console.log(
+    'Model Builder source loading announcement guard self-test passed: ' +
+      'buggy fixtures fail, the fixed fixture passes, a partial ' +
+      'regression fails only the still-missing checks, and a ' +
+      'missing-block regression fails with a clear message.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderSourceLoadingAnnouncementGuard.ts
+++ b/utils/scripts/verifyModelBuilderSourceLoadingAnnouncementGuard.ts
@@ -1,0 +1,155 @@
+// /utils/scripts/verifyModelBuilderSourceLoadingAnnouncementGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 16) -- the source-picker's own
+// `store.loadingSources` block (step 1 of the wizard, the very first screen a
+// build run starts on) rendered its "Loading {type}…" state as a purely
+// visual spinner-plus-text <div>, with no role/aria-live semantics at all.
+// Two sibling loading states in this same feature already establish the
+// correct pattern for exactly this shape -- a transient "please wait" block
+// swapped in via v-if/v-else-if while data is fetched:
+//
+// 1. model-builder-run-history.vue's `store.loadingRuns` block --
+//    role="status" aria-live="polite" aria-busy="true" on the container,
+//    aria-hidden="true" on the decorative spinner span.
+// 2. model-builder-manager.vue's `resumingRun` block -- the identical
+//    role="status" aria-live="polite" shape (plus aria-busy="true" on the
+//    ancestor <section> covering the whole surface while it restores).
+//
+// The source-picker's own error-toned sibling in the same v-if/v-else-if
+// chain (`store.sourcesError`) already carries role="alert" (cycle 11,
+// verifyModelBuilderErrorCalloutRoleGuard.ts) -- but the loading state one
+// branch above it was never given the equivalent role="status" treatment.
+// Without it, a screen-reader user who picks a source type hears nothing at
+// all until the records finish loading (or errors), unlike every other
+// "fetching, please wait" surface in this same feature.
+//
+// Fixed by adding role="status" aria-live="polite" aria-busy="true" to the
+// loadingSources container and aria-hidden="true" to its spinner span. This
+// asserts the textual shape of that fix stays in place -- deliberately
+// scoped to this one template block, mirroring this project's other narrow
+// textual guards over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const SOURCE_PICKER_PATH = join(
+  repositoryRoot,
+  'components/model-builder/model-builder-source-picker.vue',
+)
+
+const LOADING_MARKER = 'v-else-if="store.loadingSources"'
+
+// Anchored on the block's distinguishing v-else-if marker rather than any
+// surrounding wording, so this guard reports *how* the block regressed
+// (missing attributes vs. missing entirely) instead of just "not found".
+function extractOpeningTag(content: string, marker: string): string | null {
+  const markerIndex = content.indexOf(marker)
+  if (markerIndex === -1) return null
+
+  const tagStart = content.lastIndexOf('<', markerIndex)
+  if (tagStart === -1) return null
+  const tagEnd = content.indexOf('>', markerIndex)
+  if (tagEnd === -1) return null
+
+  return content.slice(tagStart, tagEnd + 1)
+}
+
+// The spinner span is the first `<span ...>` after the container's opening
+// tag, up to the container's own closing `</div>`.
+function extractSpinnerSpan(content: string, marker: string): string | null {
+  const markerIndex = content.indexOf(marker)
+  if (markerIndex === -1) return null
+
+  const containerEnd = content.indexOf('</div>', markerIndex)
+  if (containerEnd === -1) return null
+
+  const spanStart = content.indexOf('<span', markerIndex)
+  if (spanStart === -1 || spanStart > containerEnd) return null
+  const spanTagEnd = content.indexOf('>', spanStart)
+  if (spanTagEnd === -1 || spanTagEnd > containerEnd) return null
+
+  return content.slice(spanStart, spanTagEnd + 1)
+}
+
+export function checkSourceLoadingAnnouncementGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const openingTag = extractOpeningTag(content, LOADING_MARKER)
+  if (!openingTag) {
+    errors.push(
+      `Could not find a \`${LOADING_MARKER}\` block in ` +
+        'model-builder-source-picker.vue -- has the loadingSources state ' +
+        'been renamed, removed, or restructured? If so, this guard needs ' +
+        'to move with it.',
+    )
+    return errors
+  }
+
+  if (!openingTag.includes('role="status"')) {
+    errors.push(
+      'The model-builder-source-picker.vue loadingSources block no ' +
+        'longer carries role="status" -- assistive tech gets no signal ' +
+        "that sources are loading, unlike this same feature's own " +
+        'model-builder-run-history.vue loadingRuns block and ' +
+        'model-builder-manager.vue resumingRun block.',
+    )
+  }
+  if (!openingTag.includes('aria-live="polite"')) {
+    errors.push(
+      'The model-builder-source-picker.vue loadingSources block no ' +
+        'longer carries aria-live="polite" -- a screen reader will not ' +
+        'announce this state change at all.',
+    )
+  }
+  if (!openingTag.includes('aria-busy="true"')) {
+    errors.push(
+      'The model-builder-source-picker.vue loadingSources block no ' +
+        'longer carries aria-busy="true", unlike the identically-shaped ' +
+        'model-builder-run-history.vue loadingRuns block.',
+    )
+  }
+
+  const spinnerSpan = extractSpinnerSpan(content, LOADING_MARKER)
+  if (!spinnerSpan) {
+    errors.push(
+      'Could not find the decorative spinner <span> inside the ' +
+        'loadingSources block in model-builder-source-picker.vue -- has it ' +
+        'been renamed, removed, or restructured? If so, this guard needs ' +
+        'to move with it.',
+    )
+  } else if (!spinnerSpan.includes('aria-hidden="true"')) {
+    errors.push(
+      'The model-builder-source-picker.vue loadingSources spinner span no ' +
+        'longer carries aria-hidden="true" -- assistive tech will try to ' +
+        'read the decorative spinner icon itself.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(SOURCE_PICKER_PATH, 'utf8')
+  const errors = checkSourceLoadingAnnouncementGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder source loading announcement guard contract failed:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder source loading announcement guard contract passed: the ' +
+      'loadingSources block still announces itself to assistive tech.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What

`model-builder-source-picker.vue`'s `store.loadingSources` block — the very first screen a build run starts on — rendered its "Loading {type}…" spinner as a purely visual `<div>`, with no role/aria-live semantics at all. A screen-reader user who picked a source type heard nothing until the records finished loading or errored.

Two sibling loading states in this same feature already establish the correct pattern for exactly this shape:
- `model-builder-run-history.vue`'s `loadingRuns` block (`role="status" aria-live="polite" aria-busy="true"`)
- `model-builder-manager.vue`'s `resumingRun` block (the same `role="status" aria-live="polite"` shape)

The source-picker's own error-toned sibling in the same `v-if`/`v-else-if` chain (`sourcesError`) already carries `role="alert"` (cycle 11), but the loading branch one step above it was never given the equivalent `role="status"` treatment.

## Fix

Added `role="status" aria-live="polite" aria-busy="true"` to the `loadingSources` container and `aria-hidden="true"` to its decorative spinner span, matching the established pattern exactly.

## Guard

Added `utils/scripts/verifyModelBuilderSourceLoadingAnnouncementGuard.ts` (+ self-test), wired into `package.json` and `contract-tests.yml`, mirroring the existing Model Builder guards (e.g. `verifyModelBuilderErrorCalloutRoleGuard.ts`).

## Verification

- `npm run test:model-builder-source-loading-announcement-guard-selftest` — passes
- `npm run test:model-builder-source-loading-announcement-guard` — passes
- Confirmed the guard fails against the pre-fix markup via `git stash` (exit 1, all four checks reported) and passes post-fix (exit 0)
- `vue-tsc --noEmit` — clean
- `eslint` + `prettier --check` on touched files — clean
- Re-ran the existing model-builder guards (`error-callout-role`, `history-close-focus`, `step-content-focus`) — all still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QcWvCzQ8KLhJeELEapwsb1)_