### PR TITLE
fix(storybook): scope destructive-action confirm arms to the active session (storybook/t-010 cycle 17)

### DIFF
--- a/.github/workflows/storybook-confirm-arm-scope-contract.yml
+++ b/.github/workflows/storybook-confirm-arm-scope-contract.yml
@@ -1,0 +1,30 @@
+name: Storybook Confirm Arm Scope Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: storybook-confirm-arm-scope-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Storybook confirm arm scope contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify Storybook confirm-arm session-scope guard
+        run: node utils/scripts/verifyStorybookConfirmArmScopeGuard.mjs

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -670,7 +670,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useCharacterStore } from '@/stores/characterStore'
 import { useDreamStore } from '@/stores/dreamStore'
 import { useFacetStore } from '@/stores/facetStore'
@@ -704,6 +704,22 @@ const setupStep = ref(0)
 const furthestStep = ref(0)
 const answerInput = ref('')
 const newStoryArmed = ref(false)
+
+// A "Discard this tale?" arm is a confirmation for THIS session, not a
+// standing state. storybook-library-page.vue can swap the active session out
+// from under it -- opening a different story, duplicating, or restarting all
+// change `store.session.id` without this component's own startAnother() ever
+// running. Without this reset, the next session renders straight into the
+// armed, warning-colored button (never the plain "New story" one), so a
+// single click that looks like a first press instead discards that session
+// immediately, with no confirmation ever given for the story actually on
+// screen.
+watch(
+  () => store.session?.id ?? null,
+  () => {
+    newStoryArmed.value = false
+  },
+)
 
 /*
  * Beats persist as one record per scene (narration plus the reader's reply);

--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -286,6 +286,15 @@ function formatStoryDate(value: string): string {
 watch(
   () => storyStore.session?.id ?? null,
   (sessionId) => {
+    // A "Restart from the beginning?" arm is a confirmation for THIS session,
+    // not a standing state. Opening a different story, duplicating,
+    // restarting, or starting a new one all swap the active session out from
+    // under an armed-but-unconfirmed button -- without this reset, the next
+    // session renders straight into the armed, warning-colored button (never
+    // the plain "Restart" one), so a single click that looks like a first
+    // press instead fires the destructive restart immediately, with no
+    // confirmation ever given for the story actually on screen.
+    restartArmed.value = false
     if (sessionId !== queryStoryId()) updateStoryQuery(sessionId)
   },
 )

--- a/utils/scripts/verifyStorybookConfirmArmScopeGuard.mjs
+++ b/utils/scripts/verifyStorybookConfirmArmScopeGuard.mjs
@@ -1,0 +1,126 @@
+// /utils/scripts/verifyStorybookConfirmArmScopeGuard.mjs
+//
+// Regression guard (storybook/t-010, front-end polish). Two destructive
+// actions -- "New story" (storybook-page.vue) and "Restart" (storybook-
+// library-page.vue) -- use an arm-then-confirm pattern: one click swaps the
+// button to a warning-colored "Discard this tale?" / "Restart from the
+// beginning?" confirmation, and only a SECOND click on that same control
+// fires the destructive action (`startAnother()` / `restartCurrent()`).
+//
+// Both `newStoryArmed` and `restartArmed` are plain component-local refs with
+// no concept of which session they were armed for. Several ordinary actions
+// swap `store.session` out from under an armed-but-unconfirmed button without
+// ever running the confirm handler that resets it:
+//   - storybook-library-page.vue's "New story" button (`startNewStory()`)
+//     while storybook-page.vue's own "New story" control is armed.
+//   - Opening a different story, duplicating the current one, or restarting
+//     successfully, all from storybook-library-page.vue, while its OWN
+//     "Restart" control is armed.
+// `v-if="store.session"` / `v-if="storyStore.session"` keeps the toolbar
+// visible across every one of those transitions (a session still exists --
+// just a different one), so the armed button renders straight into the next
+// session: a single click that looks like the plain, first-press "New
+// story"/"Restart" affordance (in a reader's memory of what that region
+// usually shows) instead fires the destructive action immediately, with no
+// fresh confirmation ever given for the story actually on screen.
+//
+// This asserts the fix's shape stays in place: both components reset their
+// arm ref to `false` inside a `watch()` on the active session's id, so ANY
+// session-identity change -- regardless of which action caused it -- clears
+// a stale arm before the reader can land on it.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+function source(path) {
+  return readFileSync(resolve(process.cwd(), path), 'utf8')
+}
+
+// Pulls the full `watch(...)` call starting at a literal anchor found inside
+// it, by paren-depth matching forward from the `watch(` that precedes the
+// anchor. Anchors below are written to start with `watch(` itself so the
+// opening paren's position is unambiguous.
+function extractWatchCall(content, anchor, { path } = {}) {
+  const anchorIndex = content.indexOf(anchor)
+  assert.ok(
+    anchorIndex >= 0,
+    `Could not find \`${anchor}\` in ${path} -- has this watcher been ` +
+      'renamed, removed, or restructured? If so, this guard (and the ' +
+      'stale-arm bug it protects against) needs to move with it.',
+  )
+  const openParen = anchorIndex + anchor.indexOf('(')
+  let depth = 0
+  let i = openParen
+  for (; i < content.length; i++) {
+    if (content[i] === '(') depth++
+    else if (content[i] === ')') {
+      depth--
+      if (depth === 0) break
+    }
+  }
+  return content.slice(openParen, i + 1)
+}
+
+const LIBRARY_PAGE_PATH = 'components/pages/storybook-library-page.vue'
+const STUDIO_PAGE_PATH = 'components/conductor/storybook-page.vue'
+
+const libraryPage = source(LIBRARY_PAGE_PATH)
+const studioPage = source(STUDIO_PAGE_PATH)
+
+// --- storybook-library-page.vue: restartArmed scoped to session id ---
+
+const restartWatch = extractWatchCall(
+  libraryPage,
+  'watch(\n  () => storyStore.session?.id ?? null,\n  (sessionId) => {',
+  { path: LIBRARY_PAGE_PATH },
+)
+
+assert.ok(
+  restartWatch.includes('restartArmed.value = false'),
+  `The session-id watcher in ${LIBRARY_PAGE_PATH} no longer resets ` +
+    '`restartArmed.value = false` -- without it, an armed "Restart from ' +
+    'the beginning?" button survives opening a different story, ' +
+    'duplicating, or restarting, and stays primed to fire on the next ' +
+    'session with a single, unconfirmed click.',
+)
+
+const restartResetIndex = restartWatch.indexOf('restartArmed.value = false')
+const restartQueryIndex = restartWatch.indexOf(
+  'if (sessionId !== queryStoryId()) updateStoryQuery(sessionId)',
+)
+assert.ok(
+  restartResetIndex >= 0 && restartQueryIndex > restartResetIndex,
+  `${LIBRARY_PAGE_PATH}'s session-id watcher must reset \`restartArmed\` ` +
+    'unconditionally on every session change (ahead of the `?story=` sync), ' +
+    'not only on the branch that also happens to touch the query string.',
+)
+
+// --- storybook-page.vue: newStoryArmed scoped to session id ---
+
+assert.ok(
+  /import\s*\{[^}]*\bwatch\b[^}]*\}\s*from\s*'vue'/.test(studioPage),
+  `${STUDIO_PAGE_PATH} must import \`watch\` from 'vue' to scope ` +
+    '`newStoryArmed` to the active session.',
+)
+
+const newStoryWatch = extractWatchCall(
+  studioPage,
+  'watch(\n  () => store.session?.id ?? null,\n  () => {',
+  { path: STUDIO_PAGE_PATH },
+)
+
+assert.ok(
+  newStoryWatch.includes('newStoryArmed.value = false'),
+  `The session-id watcher in ${STUDIO_PAGE_PATH} no longer resets ` +
+    '`newStoryArmed.value = false` -- without it, an armed "Discard this ' +
+    'tale?" button survives storybook-library-page.vue swapping the active ' +
+    'session (open/duplicate/restart), and stays primed to fire on the ' +
+    'next session with a single, unconfirmed click.',
+)
+
+console.log(
+  'Storybook confirm-arm session-scope guard contract passed: both ' +
+    '`newStoryArmed` and `restartArmed` reset whenever the active session ' +
+    "id changes, so a stale confirmation can't survive onto a different " +
+    'story.',
+)


### PR DESCRIPTION
## Bug

Two arm-then-confirm destructive controls had no concept of which session they were armed for:

- `storybook-page.vue`'s **"New story"** button (`newStoryArmed`): first click swaps it to a warning-colored "Discard this tale?" confirm button; a second click calls `startAnother()`, which resets `newStoryArmed`.
- `storybook-library-page.vue`'s **"Restart"** button (`restartArmed`): same arm-then-confirm shape, confirmed via `restartCurrent()`.

Several ordinary actions swap the active session out from under an armed-but-unconfirmed button *without* ever running the confirm handler that resets it:

- Clicking `storybook-library-page.vue`'s own "New story" button while `storybook-page.vue`'s "New story" control is armed.
- Opening a different story, duplicating the current one, or restarting successfully — all from `storybook-library-page.vue` — while its own "Restart" control is armed.

`v-if="store.session"` keeps the toolbar visible across every one of these transitions (a session still exists — just a different one), so the armed button renders straight into the next session: a single click that looks like the plain, first-press affordance instead fires the destructive action immediately, with **no fresh confirmation ever given for the story actually on screen**.

## Fix

Both components now reset their arm ref inside a `watch()` on the active session's id, so *any* session-identity change — regardless of which action caused it — clears a stale arm before the reader can land on it:

```ts
// storybook-library-page.vue
watch(
  () => storyStore.session?.id ?? null,
  (sessionId) => {
    restartArmed.value = false
    if (sessionId !== queryStoryId()) updateStoryQuery(sessionId)
  },
)
```

```ts
// storybook-page.vue
watch(
  () => store.session?.id ?? null,
  () => {
    newStoryArmed.value = false
  },
)
```

## Guard

Added the 16th `verifyStorybook*` guard, `utils/scripts/verifyStorybookConfirmArmScopeGuard.mjs`, plus a matching dedicated workflow `storybook-confirm-arm-scope-contract.yml`, following the established per-guard-workflow convention. The guard asserts both session-id watchers reset their respective arm ref.

## Verification

- New guard fails pre-fix / passes post-fix (git-stash round-trip on the two touched `.vue` files).
- All 15 pre-existing `verifyStorybook*` guards still pass — no regression.
- `eslint` clean on touched files.
- `prettier --check` clean on the two new files (pre-existing, unrelated formatting drift on both touched `.vue` files confirmed via git-stash to predate this change; left untouched).
- `vue-tsc --noEmit` repo-wide clean.
- `git status --porcelain` showed exactly the 4 intended files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PTxNioPRp2FU9mwDn2bp6t

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTxNioPRp2FU9mwDn2bp6t)_