### PR TITLE
fix(copy): move creator-earnings claims to future tense (kind-economy/t-004)

### DIFF
--- a/components/pages/about-page.vue
+++ b/components/pages/about-page.vue
@@ -124,7 +124,7 @@ const cards = ref([
   {
     title: 'VISION',
     icon: 'kind-icon:eye',
-    content: `🤖👋 We're here to bridge the AI/Human divide and foster harmonious coexistence. Our mission is to empower the world with modern tools, raise funds for our anti-malaria fundraiser, and generate revenue (and social buzz) for our content creators through sales from our gift shop of print-on-demand literature and art. Together, we can help each other make a difference with mutually compatible goals! 💪🌍`,
+    content: `🤖👋 We're here to bridge the AI/Human divide and foster harmonious coexistence. Our mission is to empower the world with modern tools, raise funds for our anti-malaria fundraiser, and eventually generate revenue (and social buzz) for our content creators through sales from our gift shop of print-on-demand literature and art. Together, we can help each other make a difference with mutually compatible goals! 💪🌍`,
   },
   {
     title: 'VALUES',

--- a/stores/helpers/tutorialCards.ts
+++ b/stores/helpers/tutorialCards.ts
@@ -68,9 +68,10 @@ export const EARNING_CHANNELS = [
 export type EarningChannelKey = (typeof EARNING_CHANNELS)[number]
 
 export const CREATOR_EARNINGS_MESSAGE =
-  'When people spend paid tokens on something you made, you earn a share. ' +
-  'Paid usage is split three ways - Kind Robots, the anti-malaria fundraiser, ' +
-  'and you. Build something people love, and the swarm pays you back.'
+  "Paid tokens aren't live yet, but when they are, spending on something you " +
+  'made will earn you a share. The plan: paid usage split three ways - Kind ' +
+  'Robots, the anti-malaria fundraiser, and you. Build something people love, ' +
+  'and the swarm will pay you back.'
 
 export function isEarningChannel(key: string): key is EarningChannelKey {
   return (EARNING_CHANNELS as readonly string[]).includes(key)


### PR DESCRIPTION
### Task
kind-economy/t-004: Reconcile the live creator-earnings copy with what actually exists (kind: software)

### What changed / what I produced
- `stores/helpers/tutorialCards.ts`: reworded `CREATOR_EARNINGS_MESSAGE` (rendered on six tutorial channels — scenario, character, dream, reward, bot, packs — via `tutorial-flyer.vue`) from present tense ("you earn a share") to future tense, matching README.md's existing "Planned... not yet implemented" framing for the same three-way revenue-share model.
- `components/pages/about-page.vue`: added "eventually" to the VISION card's creator-revenue clause ("generate revenue... for our content creators through sales from our gift shop"), matching the MONETIZATION card immediately below it which already says "Eventually, we hope to...".
- Mission/fundraiser copy (anti-malaria donations, README, narrator seeds, first-launch intro) is untouched — that claim is accurate today.

### How I verified
- Full-repo grep inventory for every surface promising creator earnings (`CREATOR_EARNINGS_MESSAGE`, "creator...earn", "earn...share/creator", plus the narrator-seed mission-claim mentions the design brief flagged) — confirmed the two edited surfaces are the only present-tense creator-earnings claims; everything else (README, narrator seeds, first-launch-intro) already reads as mission copy or is already future-tense.
- `npx eslint components/pages/about-page.vue stores/helpers/tutorialCards.ts` — clean, no output.
- `npx vue-tsc --noEmit` — clean, exit 0.
- No test coupling to the exact string (grepped for `CREATOR_EARNINGS_MESSAGE` in `*.test.ts` — no matches).

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
The design brief noted narrator seeds "repeat the mission claim widely" — confirmed on inspection those seeds only repeat the *mission* claim (anti-malaria fundraiser), not a creator-earnings claim, so no narrator copy needed changing. Worth a note in kind-economy's DESIGN-BRIEF.md so a future session doesn't re-walk the same seeds looking for a creator-earnings mention that isn't there.

### Notes for reviewer
Per the task note, this executes option (a) (shift to future tense) rather than (b) (leave as-is with reasoning) — the message is unambiguously false right now (paid tokens don't exist at all yet), reversible to change, and costs nothing to fix, so there's no real case for knowingly leaving a false claim live on a public page.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MBCsdH7yuTCyjA2C3siKBU)_