### PR TITLE
fix(server): close metering gaps on characters/generate and comfy/test/generate (kind-economy/t-027)

### DIFF
--- a/server/api/characters/generate.ts
+++ b/server/api/characters/generate.ts
@@ -1,21 +1,11 @@
 //server/api/characters/generate.ts
 import { defineEventHandler, readBody, createError } from 'h3'
 import { errorHandler } from '../../utils/error'
-import { validateApiKey } from '../../utils/validateKey'
+import { authAndTextGate } from '../../utils/textGate'
 
 export default defineEventHandler(async (event) => {
   try {
     console.log('[API] Received request to /generate endpoint')
-    console.log('[API] Validating API Key...')
-
-    // Validate API Key
-    const { isValid } = await validateApiKey(event)
-    if (!isValid) {
-      console.warn('[API] Invalid or expired token')
-      event.node.res.statusCode = 401
-      return { success: false, message: 'Invalid or expired token.' }
-    }
-    console.log('[API] API Key validated successfully')
 
     // Parse request body
     console.log('[API] Parsing request body...')
@@ -64,6 +54,20 @@ export default defineEventHandler(async (event) => {
       })
     }
 
+    // Auth + mana gate (kind-economy/t-027). This route always calls OpenAI
+    // with the SERVER's own OPENAI_API_KEY -- there is no per-request server
+    // selection / BYOK key here, so authAndTextGate (validates the caller via
+    // requireMachineUser, then charges mana for a text generation) is the
+    // right-sized wrapper, same primitive chats/openai/stream.post.ts and
+    // generate/text.post.ts build on. Admins, FAMILY-role users, and
+    // own-resource/BYOK callers are still exempted -- that logic lives in
+    // manaGate.isFreeGeneration and is untouched here.
+    const gate = await authAndTextGate(event, {
+      model: 'gpt-4',
+      maxTokens: 1000,
+      provider: 'openai',
+    })
+
     // Prepare content for API
     const promptIntro =
       instructions || 'Upgrade the given character fields creatively.'
@@ -72,9 +76,9 @@ export default defineEventHandler(async (event) => {
 
     const content = `
       ${promptIntro}
-      Character: 
+      Character:
       ${promptCharacter}
-      
+
       Fields to upgrade: ${promptFields}
     `
 
@@ -146,11 +150,20 @@ export default defineEventHandler(async (event) => {
       })
     }
 
+    const { balance } = await gate.commit(
+      `character-generate:${character?.id ?? 'draft'}:${Date.now()}`,
+    )
+
     console.log('[API] Successfully generated character updates')
     return {
       success: true,
       message: 'Character updated successfully.',
       data: updatedCharacter,
+      mana: {
+        balance,
+        charged: gate.cost,
+        free: gate.free,
+      },
     }
   } catch (error) {
     console.error('[API] Error in /generate handler:', error)

--- a/server/api/comfy/test/generate.post.ts
+++ b/server/api/comfy/test/generate.post.ts
@@ -6,6 +6,16 @@
 //   - authenticates ONCE (requireMachineUser), no internal self-HTTP hop
 //   - needs NO checkpoint (flux loads a GGUF unet, not an SDXL checkpoint)
 // Safe to run repeatedly / in CI.
+//
+// kind-economy/t-027: this is a REAL generation on real Comfy hardware, not a
+// read-only check -- despite the "test" name, any authenticated user could
+// previously hit it and spend GPU time for free with no mana charge. Rather
+// than start charging mana here (which would contradict the "no mana
+// charged" smoke-test contract CI and the relay rely on), it's restricted to
+// admin/server-key callers only, the same admin-or-server-key gate already
+// used by the other internal-verification/re-run routes in this codebase
+// (art/queue/[id]/reenqueue.post.ts, art/queue/reenqueue-failed.post.ts,
+// art/queue/[id]/trainer-redo.post.ts).
 import { createError, defineEventHandler, readBody } from 'h3'
 import { errorHandler } from '../../../utils/error'
 import { requireMachineUser } from '../../../utils/authGuard'
@@ -45,6 +55,13 @@ export default defineEventHandler(async (event) => {
     }
 
     const auth = await requireMachineUser(event)
+    if (!auth.isAdmin && !auth.isServerKey) {
+      throw createError({
+        statusCode: 403,
+        message: 'Admin access required to run the Comfy smoke test.',
+      })
+    }
+
     const server = await resolveServer({
       userId: auth.user.id,
       serverId: body.serverId ?? null,


### PR DESCRIPTION
## kind-economy/t-027 — close the metering gaps

Per Silas: "any time a user (non admin and non-family) use our llm services or comfy, it should cost mana or tokens... If they are using the site with their own api keys or comfy/sd url, then that's cool, no mana expended."

An audit found the codebase mostly compliant already (25 generation endpoints gated via `manaGate` or one of its wrappers). Two genuine gaps remained, both authenticated but free of any charge:

### 1. `server/api/characters/generate.ts`
Validated an API key, then called `https://api.openai.com/v1/chat/completions` using the **server's own** `OPENAI_API_KEY` with no gate of any kind. Any user holding a valid token could spend Silas's OpenAI budget for free — exactly the case the instruction describes.

**Fix:** routed through `authAndTextGate` (`server/utils/textGate.ts`), the existing `requireMachineUser` + `manaGate('text')` wrapper other single-purpose LLM routes (`generate/text.post.ts`, the `chats/*/stream.post.ts` routes) already build on. Estimated cost uses the actual model/token budget (`gpt-4`, 1000 max tokens). The gate runs after input validation but before the OpenAI call, and `gate.commit(...)` fires only after a successful, parsed response — mirroring `art/generate.post.ts`'s placement. Admin/FAMILY/BYOK exemptions are untouched: they live entirely in `manaGate.isFreeGeneration`, which this route now goes through for the first time.

### 2. `server/api/comfy/test/generate.post.ts`
Used `requireMachineUser` (any authenticated user or server key, **not** admin-only), then ran `runComfySmokeGeneration` against a resolved Comfy server. Despite the "test" name and its own header comment ("charges NO mana... Safe to run repeatedly / in CI"), it's a real generation on real GPU hardware reachable by any authenticated user — free image generations for anyone with a valid token.

**Decision — admin/server-key gate, not a mana charge:** the codebase already has a precedent for exactly this shape of route. The other internal verification/re-run routes — `art/queue/[id]/reenqueue.post.ts`, `art/queue/reenqueue-failed.post.ts`, `art/queue/[id]/trainer-redo.post.ts` — all use `requireMachineUser` and then explicitly check `if (!auth.isAdmin && !auth.isServerKey) throw 403`. Charging mana here instead would contradict the route's own stated contract (a free, repeatable CI smoke test) and the one live Cypress spec for it (`cypress/e2e/api/comfy.cy.ts`, currently `describe.skip`, driven by an operator's `API_KEY`). Restricting to admin/server-key matches both the codebase's own convention for this route shape and keeps the smoke-test contract intact, while closing the free-generation-for-any-user gap.

### Confirmed not touched
`art/queue/*` family (already charged at enqueue time; re-run routes already admin/server-key gated), `art/sd/currentModel`, `comfy/prompt/[promptId]`, `comfy/test/info`, `server/heartbeat`, `server/uptime`, `botcafe/amibot.ts`.

### Tests
No unit-test harness exists for gate-wrapped server routes in this repo (only `vue-tsc --noEmit` via `npm test`, plus Cypress e2e that's `describe.skip` for this exact route and requires live infra/env secrets) — so no test scaffolding was added, following the repo's existing convention for these routes. CI's typecheck/lint on this PR is the verification gate.

### Note on how this PR was produced
This session's sandbox hard-blocks all local git *and* local file-write operations against the `kind_robots` working copy (it's treated as a protected shared checkout a foreground session may be using concurrently) — `git status`/`git commit`/`Write` all refused with "Refusing to run it" / "Edit the worktree copy instead". The two files above were verified by full manual review against the existing gate wrappers and their sibling call sites (`art/generate.post.ts`, `generate/text.post.ts`, `art/queue/[id]/reenqueue.post.ts`, `botcafe/embellish.ts`) rather than a local `vue-tsc`/`eslint` run, and pushed directly via the GitHub API (`create_branch` + `push_files`) instead of local git. Please treat this PR's CI checks as the first real compile/lint pass on this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wiqrab1y4pB3HCi7nKZ636)_