### PR TITLE
docs: document and provision payment environment configuration (kind-economy/t-012)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,121 @@
+# kind_robots runtime environment
+#
+# Copy this file to `.env` next to docker-compose.yml on the deploy host and
+# fill in real values. `.env*` is gitignored -- never commit a real value.
+# `docker-compose.yml` points both the `migrate` and `kind-robots` services at
+# `${KIND_ROBOTS_ENV_FILE:-.env}`, so this one file is the whole runtime
+# configuration surface for a `docker compose pull && docker compose up -d`
+# deploy.
+#
+# See docs/runbooks/payment-environment.md for the detailed writeup of the
+# payment/Printful variables below (what each is for, which routes read it,
+# and how each route behaves when it's missing). See
+# docs/runbooks/migration-credential-boundary.md for MIGRATION_DATABASE_URL.
+
+# ---------------------------------------------------------------------------
+# Database
+# ---------------------------------------------------------------------------
+
+# Ordinary application database connection. Prisma Client, app runtime,
+# `prisma generate`/`studio`/`db pull`. NOT schema-write capable on its own --
+# see docs/runbooks/migration-credential-boundary.md.
+DATABASE_URL=mysql://user:password@host:3306/kindrobots
+
+# Elevated, schema-write-capable connection. Deliberately NOT read by the
+# long-running `kind-robots` service (only the one-shot `migrate` service in
+# docker-compose.yml) -- see docs/runbooks/migration-credential-boundary.md
+# for why this boundary matters and must not be collapsed.
+MIGRATION_DATABASE_URL=mysql://kindrobot_migrate:password@host:3306/kindrobots
+
+# ---------------------------------------------------------------------------
+# Payments -- Stripe (see docs/runbooks/payment-environment.md)
+# ---------------------------------------------------------------------------
+
+# Stripe API secret key. Read directly via process.env by every route under
+# server/api/stripe/ and the two Checkout-Session-creating routes under
+# server/api/store/ -- NOT wired through nuxt.config.ts's runtimeConfig like
+# the app's other integrations. Every route fails closed with a structured
+# 500 (not a raw Stripe SDK error) when this is unset.
+STRIPE_SECRET_KEY=sk_live_your_stripe_secret_key_here
+
+# Stripe webhook signing secret, verifies the Stripe-Signature header on
+# inbound webhook deliveries. Read only by server/api/stripe/webhook.post.ts.
+# Fails closed with a structured 500 when unset.
+STRIPE_WEBHOOK_SECRET=whsec_your_webhook_signing_secret_here
+
+# Stripe Price ID for the paid membership subscription. Read only by
+# server/api/stripe/subscribe.post.ts. Fails closed with a structured 500
+# when unset (digital-storefront/t-039 fixed this route to match every other
+# Stripe route's error shape instead of a bare non-null assertion).
+STRIPE_PRICE_ID=price_your_subscription_price_id_here
+
+# Base URL used to build Stripe Checkout success_url/cancel_url redirects
+# (subscribe/checkout/topup/pod-checkout/product-checkout routes). NOTE: this
+# is a *different* variable from APP_BASE_URL below -- see
+# docs/runbooks/payment-environment.md's "BASE_URL" section. No trailing
+# slash.
+BASE_URL=https://kindrobots.org
+
+# ---------------------------------------------------------------------------
+# Payments -- Printful print-on-demand (see docs/runbooks/payment-environment.md)
+# ---------------------------------------------------------------------------
+
+# Printful Private Token / OAuth2 Bearer token. Read only by
+# server/utils/podVendorClient.ts. Unset is a deliberate no-op today (no
+# Printful account provisioned yet, digital-storefront/t-015) -- callers skip
+# submission entirely rather than erroring on every checkout.
+PRINTFUL_API_KEY=your_printful_private_token_here
+
+# Printful store id sent as the X-PF-Store-Id header on order submission.
+# Read only by server/utils/podVendorClient.ts. Optional: if unset, the
+# header is simply omitted from the request.
+PRINTFUL_STORE_ID=your_printful_store_id_here
+
+# ---------------------------------------------------------------------------
+# Other integrations (all wired through nuxt.config.ts's runtimeConfig --
+# listed tersely here since that file is the authoritative reference for
+# what each is used for)
+# ---------------------------------------------------------------------------
+
+OPENAI_API_KEY=sk-your_openai_api_key_here
+ANTHROPIC_API_KEY=sk-ant-your_anthropic_api_key_here
+OLLAMA_BASE_URL=http://localhost:11434
+
+GITHUB_ID=your_github_oauth_app_client_id_here
+GITHUB_SECRET=your_github_oauth_app_client_secret_here
+GITHUB_TOKEN=your_github_token_here
+
+# AppMaker GitHub App (appmaker/t-007/t-008, see GITHUB-APP-DESIGN.md)
+APPMAKER_GH_APP_ID=your_appmaker_github_app_id_here
+APPMAKER_GH_APP_KEY=your_appmaker_github_app_private_key_here
+APPMAKER_GH_WEBHOOK_SECRET=your_appmaker_github_webhook_secret_here
+
+GOOGLE_ID=your_google_oauth_client_id_here
+GOOGLE_SECRET=your_google_oauth_client_secret_here
+# Read directly via process.env (not runtimeConfig) by
+# server/api/auth/google/index.ts and callback.ts.
+GOOGLE_REDIRECT_URI=https://kindrobots.org/api/auth/google/callback
+
+AUTH_SECRET=your_auth_secret_here
+JWT_SECRET=your_jwt_secret_here
+SERVER_SECRET_KEY=your_server_secret_key_here
+
+# Brevo (Sendinblue) transactional email + newsletter contact sync
+BREVO_API_KEY=your_brevo_api_key_here
+BREVO_SENDER_EMAIL=hello@kindrobots.org
+BREVO_SENDER_NAME=Kind Robots
+BREVO_NEWSLETTER_LIST_ID=your_brevo_newsletter_list_id_here
+
+# Public app base URL (distinct from BASE_URL above -- see
+# docs/runbooks/payment-environment.md)
+APP_BASE_URL=https://kindrobots.org
+
+# ---------------------------------------------------------------------------
+# Docker Compose host settings (not read by the app itself -- consumed by
+# docker-compose.yml's variable substitution; documented here since they
+# live in the same .env file)
+# ---------------------------------------------------------------------------
+
+# KIND_ROBOTS_IMAGE=ghcr.io/silasfelinus/kind_robots:latest
+# KIND_ROBOTS_PORT=3009
+# KIND_ROBOTS_MEDIA_PATH=/mnt/user/pc/kindrobots/images

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ prisma/migrations_old/*.sql
 kindblank_*.sql
 .vercel
 .env*
+!.env.example
 /public/images/**
 !/public/images/.gitkeep
 /public/wonderlab-components.json

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,3 +1,4 @@
 # Infrastructure runbooks
 
 - [ProxySQL connection capacity](./proxysql-connection-capacity.md)
+- [Payment environment configuration](./payment-environment.md)

--- a/docs/runbooks/payment-environment.md
+++ b/docs/runbooks/payment-environment.md
@@ -1,0 +1,154 @@
+# Payment environment configuration
+
+kind_robots deploys as a self-hosted Docker Compose stack, not a PaaS.
+`docker-compose.yml` gives both the `migrate` and `kind-robots` services
+`env_file: ${KIND_ROBOTS_ENV_FILE:-.env}`, so every runtime secret — payment
+secrets included — comes from a single `.env` file that lives beside
+`docker-compose.yml` on the host. `.env*` is gitignored; nothing in it ever
+reaches the repo. A committed template with placeholder values lives at
+[`.env.example`](../../.env.example) — copy it to `.env` on the host and fill
+in real values.
+
+Deploying is `docker compose pull && docker compose up -d` (or, on the
+production host, the two-step Force-Update path documented in
+[migration-credential-boundary.md](./migration-credential-boundary.md) —
+either way, both paths read the same `.env`).
+
+## An inconsistency worth knowing about
+
+Every other integration's secret (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
+`GITHUB_TOKEN`, `BREVO_API_KEY`, …) is wired through `nuxt.config.ts`'s
+`runtimeConfig` block, which reads `process.env` once at startup and exposes
+the result via `useRuntimeConfig()`. **Stripe and Printful are not.** Every
+Stripe route and `server/utils/podVendorClient.ts` reads
+`process.env.STRIPE_*` / `process.env.PRINTFUL_*` directly, at request time,
+with no entry in `runtimeConfig` at all.
+
+This works — Nitro server routes can read `process.env` directly — but it
+means these five variables are undiscoverable from `nuxt.config.ts` and were,
+until this document, tribal knowledge recoverable only by grepping
+`process.env.STRIPE` / `process.env.PRINTFUL`. This doc and `.env.example`
+are the fix for the *discoverability* gap. The `runtimeConfig` inconsistency
+itself is left as-is — refactoring Stripe/Printful onto `runtimeConfig` is a
+separate, larger change or refactor task, not a doc-provisioning one, and is
+out of scope here.
+
+## Payment variables
+
+### `STRIPE_SECRET_KEY`
+
+- **For:** Stripe API secret key. Constructs the `Stripe` client used to
+  create Checkout Sessions, look up sessions, create/cancel subscriptions,
+  and verify webhook signatures.
+- **Read by:** every route under `server/api/stripe/` and both routes under
+  `server/api/store/` that create a Checkout Session:
+  - `server/api/stripe/checkout.post.ts`
+  - `server/api/stripe/subscribe.post.ts`
+  - `server/api/stripe/webhook.post.ts`
+  - `server/api/stripe/checkout-status.get.ts`
+  - `server/api/stripe/cancel-subscription.post.ts`
+  - `server/api/stripe/topup.post.ts`
+  - `server/api/store/pod-checkout.post.ts` (orphaned/unreachable route, see
+    its file header — kept for a possible future POD SKU flow)
+  - `server/api/store/product-checkout.post.ts`
+- **Missing-value behavior:** every one of the routes above guards this in a
+  local `getStripeClient()` helper and fails closed with a structured error
+  before ever calling the Stripe SDK — no bare non-null assertion, no raw
+  Stripe SDK error surfaces to the caller. Two equivalent shapes exist:
+  - `subscribe.post.ts` throws a plain `Error` with a `.statusCode = 500`
+    property attached.
+  - Every other route (`checkout.post.ts`, `webhook.post.ts`,
+    `checkout-status.get.ts`, `cancel-subscription.post.ts`, `topup.post.ts`,
+    `pod-checkout.post.ts`, `product-checkout.post.ts`) throws h3's
+    `createError({ statusCode: 500, message: 'Stripe secret key is not
+    configured' })`.
+
+  Both shapes are caught by each route's own top-level `try/catch`, passed
+  through `server/utils/error.ts`'s `errorHandler()`, and returned to the
+  caller as a structured `{ success: false, message, statusCode: 500 }`
+  response (webhook's outer catch defaults the fallback status to 400, but
+  since `createError` always sets `statusCode: 500` here, that fallback is
+  never actually hit for this particular failure). **No gap found**:
+  digital-storefront/t-039 fixed `subscribe.post.ts`'s previous bare
+  `process.env.STRIPE_SECRET_KEY!` non-null assertion specifically so it would
+  match this pattern, and as of this audit every other Stripe/store route
+  already matched it independently — there was nothing left to fix.
+
+### `STRIPE_WEBHOOK_SECRET`
+
+- **For:** verifies the `Stripe-Signature` header on inbound webhook
+  deliveries (`stripe.webhooks.constructEvent`), so `webhook.post.ts` only
+  acts on events that genuinely came from Stripe.
+- **Read by:** `server/api/stripe/webhook.post.ts` only.
+- **Missing-value behavior:** guarded explicitly before signature
+  verification — `createError({ statusCode: 500, message: 'Stripe webhook
+  secret is not configured' })`, caught by the route's own `try/catch` and
+  returned as a structured `{ success: false, message }` response. No gap.
+
+### `STRIPE_PRICE_ID`
+
+- **For:** the Stripe Price ID for the paid membership subscription line
+  item.
+- **Read by:** `server/api/stripe/subscribe.post.ts` only, via a
+  `getSubscriptionPriceId()` helper.
+- **Missing-value behavior:** guarded and fails closed the same way as
+  `STRIPE_SECRET_KEY` above (`Error` with `.statusCode = 500`, structured
+  response). This guard is itself the digital-storefront/t-039 fix — the
+  route used to pass a bare `process.env.STRIPE_PRICE_ID!` straight into
+  `line_items`, which let an unset value fall through as the literal string
+  `"undefined"` to Stripe's API and come back as an opaque `No such price:
+  'undefined'` error instead of the app's own structured 500. No further gap.
+
+### `PRINTFUL_API_KEY`
+
+- **For:** Printful Private Token / OAuth2 Bearer token, authenticating
+  print-on-demand order submission to Printful's Sync-Order API.
+- **Read by:** `server/utils/podVendorClient.ts` (`isConfigured()`,
+  `submitPodOrder()`, `isPodVendorConfigured()`).
+- **Missing-value behavior:** **not an error path — a deliberate no-op.**
+  No Printful account/API key has been provisioned yet
+  (digital-storefront/t-015, still `needs-human`). `isPodVendorConfigured()`
+  returns `false` when unset, and callers (the webhook's PrintJob creation)
+  use that to skip attempting submission entirely rather than throwing on
+  every checkout. If a caller invokes `submitPodOrder()` directly without
+  checking first, it throws `PodVendorNotConfiguredError` (a clear, typed
+  error, not a raw fetch failure) — see the doc comment at the top of
+  `podVendorClient.ts`.
+
+### `PRINTFUL_STORE_ID`
+
+- **For:** the Printful store id passed as the `X-PF-Store-Id` header on the
+  Sync-Order create call.
+- **Read by:** `server/utils/podVendorClient.ts` (`submitPodOrder()`) only.
+- **Missing-value behavior:** soft — if unset, the `X-PF-Store-Id` header is
+  simply omitted (`...(storeId ? { 'X-PF-Store-Id': storeId } : {})`) and the
+  request proceeds. Only matters once `PRINTFUL_API_KEY` is also set and a
+  real submission is attempted; Printful's own API would reject/misroute the
+  request without it, not this codebase.
+
+## Related, non-payment-secret variable worth flagging: `BASE_URL`
+
+Every Stripe route that creates a Checkout Session builds its
+`success_url`/`cancel_url` from `process.env.BASE_URL` directly (e.g.
+`` `${process.env.BASE_URL}/sanctuary?subscription=success` ``) — see
+`checkout.post.ts`, `subscribe.post.ts`, `topup.post.ts`,
+`pod-checkout.post.ts`, `product-checkout.post.ts`. This is a **different**
+env var from `APP_BASE_URL`, which is the one wired through
+`runtimeConfig.public.appBaseUrl` and used everywhere else in the app
+(email links, narrator/export scripts, etc. — see
+`utils/scripts/verifyAppBaseUrl.ts`). `BASE_URL` has no guard and no
+`runtimeConfig` entry: if unset, the redirect URLs Stripe receives become the
+literal string `"undefined/sanctuary?subscription=success"`, which Stripe's
+API will reject as an invalid URL, surfacing as a generic Stripe SDK error
+caught by the route's existing `try/catch` rather than the codebase's own
+structured "not configured" guard. It is included in `.env.example` for that
+reason, but reconciling it with `APP_BASE_URL` (either by reusing
+`APP_BASE_URL` in the Stripe routes or by giving `BASE_URL` its own explicit
+guard) is left for a future task — out of scope here.
+
+## Where the values themselves come from
+
+Real values are Silas's — Stripe dashboard (API keys, webhook signing
+secret, price id) and, once provisioned, a Printful account. No real value
+for any of the above has ever been in this repo; do not add one. Set them in
+the `.env` file on the deploy host only.


### PR DESCRIPTION
## What

kind_robots deploys as a self-hosted Docker Compose stack. Both `migrate` and
`kind-robots` services read `env_file: ${KIND_ROBOTS_ENV_FILE:-.env}`, so every
runtime secret comes from one `.env` beside `docker-compose.yml` on the host,
and `.env*` is gitignored — there was no `.env.example` and the payment
secrets were only discoverable by grepping `process.env`. This PR fixes the
discoverability gap:

- **`docs/runbooks/payment-environment.md`** — full writeup of every
  payment-related env var actually read at runtime.
- **`.env.example`** (repo root, placeholder values only) — the payment/
  Printful set documented in detail, plus `DATABASE_URL` /
  `MIGRATION_DATABASE_URL` and every var already covered by
  `nuxt.config.ts`'s `runtimeConfig`, listed tersely.
- **`docs/runbooks/README.md`** — links the new runbook.
- **`.gitignore`** — adds `!.env.example` so the template survives the
  existing `.env*` ignore rule.

No refactor of the Stripe/Printful env-reading pattern — documented as a
known inconsistency instead (see below), per task scope.

## Variables found and documented

| Variable | Read by | Missing-value behavior |
|---|---|---|
| `STRIPE_SECRET_KEY` | every route under `server/api/stripe/`, plus `server/api/store/pod-checkout.post.ts` and `product-checkout.post.ts` | Fails closed with a structured 500 in every route (either a custom `Error` with `.statusCode`, or h3's `createError`), caught by each route's own `try/catch` and returned through `errorHandler()` as `{ success: false, message, statusCode: 500 }`. |
| `STRIPE_WEBHOOK_SECRET` | `server/api/stripe/webhook.post.ts` | Same structured-500 guard, verified before signature verification. |
| `STRIPE_PRICE_ID` | `server/api/stripe/subscribe.post.ts` | Same structured-500 guard. |
| `PRINTFUL_API_KEY` | `server/utils/podVendorClient.ts` | Deliberate no-op when unset (no Printful account provisioned yet) — `isPodVendorConfigured()` returns `false` and callers skip submission; a direct `submitPodOrder()` call throws a typed `PodVendorNotConfiguredError`. |
| `PRINTFUL_STORE_ID` | `server/utils/podVendorClient.ts` | Soft — `X-PF-Store-Id` header is simply omitted if unset. |
| `BASE_URL` (flagged, not a "payment secret" per se) | every Stripe/store checkout route, for building `success_url`/`cancel_url` | No guard — distinct from `APP_BASE_URL` (the one wired through `runtimeConfig`). Documented as a related gap, left unfixed per task scope. |

### On the "does every route match the fixed pattern" question

digital-storefront/t-039 fixed `subscribe.post.ts`'s bare
`process.env.STRIPE_PRICE_ID!` non-null assertion to return a structured 500
like its siblings. I re-verified every other Stripe/store route
(`checkout.post.ts`, `webhook.post.ts`, `checkout-status.get.ts`,
`cancel-subscription.post.ts`, `topup.post.ts`, `pod-checkout.post.ts`,
`product-checkout.post.ts`) against that same shape — **all of them already
matched independently**, via h3's `createError({ statusCode: 500, ... })`
guarded in each route's own `getStripeClient()`. No gap found, nothing to fix.

### The `runtimeConfig` inconsistency

Every other integration secret (`OPENAI_API_KEY`, `GITHUB_TOKEN`,
`BREVO_API_KEY`, …) is wired through `nuxt.config.ts`'s `runtimeConfig`.
Stripe and Printful are not — they read `process.env` directly at request
time. This works (Nitro server routes can do that), but it's the reason these
vars were undiscoverable. Documented, not refactored, per task scope.

## Verification

- No real secret value was ever written, echoed, or committed — `.env.example`
  contains only placeholders (`sk_live_your_stripe_secret_key_here`,
  `whsec_your_webhook_signing_secret_here`, etc.). Verified by re-fetching the
  pushed file content before opening this PR.
- Diff is scoped to the two new docs/env files plus the two small existing
  files they had to touch (`docs/runbooks/README.md` link,
  `.gitignore` exception) — no source code changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wiqrab1y4pB3HCi7nKZ636)_