### PR TITLE
fix(video): report a failing clip job while the queue retries it

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -266,6 +266,12 @@ jobs:
       - name: Da Vinci resolve-panel guard
         run: npm run test:davinci-resolve-panel-guard
 
+      - name: Video retry-notice guard self-test
+        run: npm run test:video-retry-notice-selftest
+
+      - name: Video retry-notice guard
+        run: npm run test:video-retry-notice
+
       - name: Da Vinci narrating-status guard self-test
         run: npm run test:davinci-narrating-status-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "test:prompt-variants": "tsx utils/scripts/verifyPromptVariants.ts",
     "test:challenge-center": "tsx utils/scripts/verifyChallengeCenter.ts",
     "test:relay-agent-registry": "tsx utils/scripts/verifyRelayAgentRegistry.ts",
+    "test:video-retry-notice-selftest": "tsx utils/scripts/verifyVideoRetryNotice.test.ts",
+    "test:video-retry-notice": "tsx utils/scripts/verifyVideoRetryNotice.ts",
     "test:seed-challenges": "tsx scripts/seed_challenges.ts",
     "test:seed-contenders": "tsx scripts/seed_contenders.ts",
     "dev": "nuxt dev --host",

--- a/pages/play/video-generator.vue
+++ b/pages/play/video-generator.vue
@@ -317,6 +317,22 @@
           </span>
         </div>
 
+        <!-- A failed attempt returns the job to the queue rather than ending
+             it, so this rides alongside the spinner: the run is still live,
+             but it has already failed at least once and the user should see
+             why instead of watching a wheel. Suppressed once the run ends,
+             where the fatal alert below says the same thing. -->
+        <div
+          v-if="videoStore.state.attemptError && videoStore.isBusy"
+          class="alert alert-warning text-sm"
+          role="status"
+        >
+          <span>
+            Attempt {{ videoStore.state.attempts }} failed, retrying:
+            {{ videoStore.state.attemptError }}
+          </span>
+        </div>
+
         <div
           v-if="videoStore.state.error"
           class="alert alert-error text-sm"

--- a/stores/videoStore.ts
+++ b/stores/videoStore.ts
@@ -10,6 +10,7 @@ import { defineStore } from 'pinia'
 import { reactive, computed } from 'vue'
 import type { ArtImage } from '~/prisma/generated/prisma/client'
 import { performFetch } from '@/stores/utils'
+import { artJobRetryNotice } from '@/utils/artJobRetryNotice'
 import type {
   VideoEngine,
   VideoOutputFormat,
@@ -46,6 +47,11 @@ type QueuedJob = {
   status: 'PENDING' | 'RUNNING' | 'DONE' | 'FAILED' | 'CANCELLED'
   artImageId?: number | null
   error?: string | null
+  // How many times the relay has taken this job and reported back. The queue
+  // retries a failed job by returning it to PENDING (see
+  // server/api/art/queue/[id]/complete.post.ts), so a job on attempt 2 is
+  // indistinguishable from a fresh one without this.
+  attempts?: number | null
 }
 
 const POLL_MS = 5_000
@@ -59,7 +65,9 @@ function sleep(ms: number): Promise<void> {
 // mp4/webm are real video containers (render as <video>).
 const IMAGE_CLIP_TYPES = new Set(['webp', 'gif'])
 
-export function isImageClipFileType(fileType: string | null | undefined): boolean {
+export function isImageClipFileType(
+  fileType: string | null | undefined,
+): boolean {
   return IMAGE_CLIP_TYPES.has((fileType || '').toLowerCase())
 }
 
@@ -98,6 +106,15 @@ export const useVideoStore = defineStore('videoStore', () => {
     artImageId: null as number | null,
     message: '',
     error: '',
+    // The error the LAST failed attempt reported, while the queue is still
+    // retrying. Distinct from `error`, which is fatal and ends the run: this
+    // one rides alongside a live spinner, because the job really is still
+    // going. Without it a job that has already failed twice looks exactly like
+    // one that just got queued -- which is how a ComfyUI rejection could spin
+    // a wheel for minutes saying "processing" while the ArtJob row already
+    // held the whole diagnosis (2026-08-19, LTX webp animation).
+    attemptError: '',
+    attempts: 0,
     loop: true,
   })
 
@@ -116,6 +133,8 @@ export const useVideoStore = defineStore('videoStore', () => {
     state.artImageId = null
     state.message = ''
     state.error = ''
+    state.attemptError = ''
+    state.attempts = 0
   }
 
   async function enqueue(params: GenerateVideoParams): Promise<number> {
@@ -178,15 +197,39 @@ export const useVideoStore = defineStore('videoStore', () => {
         return job
       }
 
+      // A failed attempt returns the job to PENDING with its error recorded,
+      // so `error` on a non-terminal job is the last attempt's failure and the
+      // queue is about to try again. Report it now rather than at the terminal
+      // state -- three attempts is minutes of silence otherwise, and the
+      // failure is usually the same one every time.
+      const notice = artJobRetryNotice(job)
+      if (notice) {
+        state.attempts = notice.attempts
+        state.attemptError = notice.error
+      }
+
       if (job?.status === 'RUNNING') {
         state.status = 'rendering'
-        state.message = 'The studio engine is rendering your clip…'
+        state.message = state.attemptError
+          ? `Retrying after attempt ${state.attempts} failed — rendering…`
+          : 'The studio engine is rendering your clip…'
       } else if (job?.status === 'PENDING') {
         state.status = 'queued'
-        state.message = 'Queued — waiting for the studio engine to pick it up…'
+        state.message = state.attemptError
+          ? `Attempt ${state.attempts} failed — waiting for the studio engine to retry…`
+          : 'Queued — waiting for the studio engine to pick it up…'
       }
 
       await sleep(POLL_MS)
+    }
+
+    // "Still catching up" is only true if nothing has gone wrong yet. A job
+    // that has been failing and retrying for twenty minutes is not catching
+    // up, and telling the user to sit tight sends them back to the same wheel.
+    if (state.attemptError) {
+      throw new Error(
+        `Still retrying after ${state.attempts} failed attempt(s): ${state.attemptError}`,
+      )
     }
 
     throw new Error(

--- a/utils/artJobRetryNotice.ts
+++ b/utils/artJobRetryNotice.ts
@@ -1,0 +1,65 @@
+// /utils/artJobRetryNotice.ts
+//
+// A queued ArtJob that fails does NOT stop. server/api/art/queue/[id]/complete.post.ts
+// records the error and returns the job to PENDING until `attempts` reaches
+// MAX_ATTEMPTS, only then flipping it to FAILED. So between the first failure
+// and the last one, the job carries a full diagnosis in its `error` column
+// while still looking, to any poller watching `status` alone, exactly like a
+// job that was queued a second ago.
+//
+// Every enqueue → poll → resolve store in the app read `error` only once the
+// job reached a terminal state, which made those retries silent. 2026-08-19:
+// an LTX webp animation was rejected by ComfyUI on submission
+// (`value_not_in_list` on a checkpoint name), retried the whole way to
+// exhaustion, and the page showed a spinner reading "processing" the entire
+// time -- while the exact error sat in the ArtJob row from the first attempt
+// onward.
+//
+// This is deliberately framework-free (no pinia, no fetch, no Vue) so both the
+// stores and a plain `tsx` guard can use it.
+
+export type RetryNoticeJobStatus =
+  'PENDING' | 'RUNNING' | 'DONE' | 'FAILED' | 'CANCELLED'
+
+export type RetryNoticeJob = {
+  status: RetryNoticeJobStatus
+  error?: string | null
+  attempts?: number | null
+}
+
+export type ArtJobRetryNotice = {
+  attempts: number
+  error: string
+}
+
+const TERMINAL_STATUSES = new Set<RetryNoticeJobStatus>([
+  'DONE',
+  'FAILED',
+  'CANCELLED',
+])
+
+/**
+ * The failure a still-running job has already hit, or null when there is
+ * nothing to report yet.
+ *
+ * Terminal jobs return null on purpose: a FAILED/CANCELLED job is fatal and
+ * its caller raises the error itself, and a DONE job has had `error` cleared
+ * by the completion route. This is only about the in-between -- a job that has
+ * failed at least once and is going to be tried again.
+ */
+export function artJobRetryNotice(
+  job: RetryNoticeJob | null | undefined,
+): ArtJobRetryNotice | null {
+  if (!job || TERMINAL_STATUSES.has(job.status)) return null
+
+  const error = (job.error || '').trim()
+  if (!error) return null
+
+  // `attempts` counts completed tries. A non-terminal job carrying an error
+  // but no attempt count is not something to report as a retry -- without a
+  // number to show, "attempt 0 failed" reads worse than saying nothing.
+  const attempts = typeof job.attempts === 'number' ? job.attempts : 0
+  if (attempts < 1) return null
+
+  return { attempts, error }
+}

--- a/utils/scripts/verifyVideoRetryNotice.test.ts
+++ b/utils/scripts/verifyVideoRetryNotice.test.ts
@@ -1,0 +1,127 @@
+// /utils/scripts/verifyVideoRetryNotice.test.ts
+//
+// Regression test for the textual halves of verifyVideoRetryNotice.ts. The
+// behavioural half (checkRetryNoticeBehaviour) runs the real artJobRetryNotice
+// against real inputs and needs no fixture, so it is exercised directly; the
+// two source checkers are fed pre-fix and post-fix shapes to prove they fail
+// on the shape that actually shipped the bug rather than on nothing.
+import assert from 'node:assert/strict'
+
+import {
+  checkPageWiring,
+  checkRetryNoticeBehaviour,
+  checkStoreWiring,
+} from './verifyVideoRetryNotice.js'
+
+// The store as it looked while the bug was live: it polls, it distinguishes
+// queued from rendering, and it never looks at `error` until the job is
+// terminal.
+const STORE_BEFORE = `
+type QueuedJob = {
+  id: number
+  status: 'PENDING' | 'RUNNING' | 'DONE' | 'FAILED' | 'CANCELLED'
+  artImageId?: number | null
+  error?: string | null
+}
+
+      if (job?.status === 'RUNNING') {
+        state.status = 'rendering'
+        state.message = 'The studio engine is rendering your clip…'
+      } else if (job?.status === 'PENDING') {
+        state.status = 'queued'
+        state.message = 'Queued — waiting for the studio engine to pick it up…'
+      }
+`
+
+const STORE_AFTER = `
+type QueuedJob = {
+  id: number
+  status: 'PENDING' | 'RUNNING' | 'DONE' | 'FAILED' | 'CANCELLED'
+  artImageId?: number | null
+  error?: string | null
+  attempts?: number | null
+}
+
+      const notice = artJobRetryNotice(job)
+      if (notice) {
+        state.attempts = notice.attempts
+        state.attemptError = notice.error
+      }
+`
+
+function page(attrs: string): string {
+  return `
+<template>
+        <div
+          v-if="videoStore.state.attemptError && videoStore.isBusy"
+          ${attrs}
+        >
+          <span>
+            Attempt {{ videoStore.state.attempts }} failed, retrying:
+            {{ videoStore.state.attemptError }}
+          </span>
+        </div>
+</template>
+`
+}
+
+const PAGE_AFTER = page(
+  'class="alert alert-warning text-sm"\n          role="status"',
+)
+const PAGE_NO_NOTICE = `
+<template>
+        <div v-if="videoStore.state.error" class="alert alert-error" role="alert">
+          {{ videoStore.state.error }}
+        </div>
+</template>
+`
+
+function run(): void {
+  // Behaviour: the real decision function, real inputs, no fixtures.
+  const behaviourErrors = checkRetryNoticeBehaviour()
+  assert.deepEqual(
+    behaviourErrors,
+    [],
+    `artJobRetryNotice misbehaved: ${behaviourErrors.join('; ')}`,
+  )
+
+  // Store: the pre-fix source must fail, and on the specific grounds that it
+  // never consults artJobRetryNotice.
+  const storeBeforeErrors = checkStoreWiring(STORE_BEFORE)
+  assert.ok(
+    storeBeforeErrors.length >= 3,
+    'the pre-fix store should fail the notice, state, and attempts checks',
+  )
+  assert.ok(storeBeforeErrors.some((e) => /artJobRetryNotice/.test(e)))
+  assert.ok(storeBeforeErrors.some((e) => /state\.attemptError/.test(e)))
+  assert.ok(storeBeforeErrors.some((e) => /QueuedJob type/.test(e)))
+
+  assert.deepEqual(checkStoreWiring(STORE_AFTER), [])
+
+  // Page: no notice block at all is the pre-fix shape.
+  const pageMissingErrors = checkPageWiring(PAGE_NO_NOTICE)
+  assert.equal(pageMissingErrors.length, 1)
+  assert.ok(pageMissingErrors.some((e) => /no longer renders/.test(e)))
+
+  assert.deepEqual(checkPageWiring(PAGE_AFTER), [])
+
+  // Each rendering requirement must fail on its own, so a partial regression
+  // is not masked by the others passing.
+  const noRoleErrors = checkPageWiring(page('class="alert alert-warning"'))
+  assert.equal(noRoleErrors.length, 1)
+  assert.ok(noRoleErrors.some((e) => /role="status"/.test(e)))
+
+  const noWarningErrors = checkPageWiring(
+    page('class="alert alert-error"\n          role="status"'),
+  )
+  assert.equal(noWarningErrors.length, 1)
+  assert.ok(noWarningErrors.some((e) => /styled as a warning/.test(e)))
+
+  console.log(
+    'Video retry-notice guard self-test passed: artJobRetryNotice behaves ' +
+      'on real inputs, the pre-fix store and page fixtures fail, and the ' +
+      'missing-role and missing-warning regressions each fail on their own.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyVideoRetryNotice.ts
+++ b/utils/scripts/verifyVideoRetryNotice.ts
@@ -1,0 +1,210 @@
+// /utils/scripts/verifyVideoRetryNotice.ts
+//
+// Regression guard -- a failing video job used to spin a "processing" wheel in
+// total silence.
+//
+// server/api/art/queue/[id]/complete.post.ts returns a failed job to PENDING
+// with its error recorded, retrying until `attempts` hits MAX_ATTEMPTS. Both
+// stores that poll that endpoint read `error` only after the job reached a
+// terminal state, so every retry in between looked identical to a freshly
+// queued job. 2026-08-19: an LTX webp animation was rejected by ComfyUI at
+// submission time (`value_not_in_list` on `ckpt_name`), burned its whole retry
+// budget, and the page said "Queued — waiting for the studio engine to pick it
+// up…" the entire time, while the ArtJob row had carried the exact ComfyUI
+// rejection since the first attempt.
+//
+// Two halves, both asserted here because either alone leaves the bug:
+//   1. artJobRetryNotice() decides correctly WHEN there is a failure to report
+//      (behavioural -- run against real inputs, not grepped).
+//   2. videoStore + the video-generator page actually route that decision to
+//      the screen (textual, in the narrow style of this project's other
+//      template guards -- see verifyDaVinciNarratingStatusGuard.ts).
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { artJobRetryNotice } from '../artJobRetryNotice'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/videoStore.ts')
+const PAGE_PATH = join(repositoryRoot, 'pages/play/video-generator.vue')
+
+export function checkRetryNoticeBehaviour(): string[] {
+  const errors: string[] = []
+
+  const check = (label: string, run: () => void): void => {
+    try {
+      run()
+    } catch (error) {
+      errors.push(
+        `${label}: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+  }
+
+  check('a retrying job reports its last failure', () => {
+    const notice = artJobRetryNotice({
+      status: 'PENDING',
+      attempts: 1,
+      error: 'ComfyUI /prompt returned HTTP 400: ckpt_name not in list',
+    })
+    // Plain throws rather than assert.ok() for the null check: TypeScript only
+    // narrows through an assertion signature when the callee is declared with
+    // an explicit type annotation, which an imported `assert` is not.
+    if (!notice)
+      throw new Error('a PENDING job that already failed reported nothing')
+    assert.equal(notice.attempts, 1)
+    assert.match(notice.error, /HTTP 400/)
+  })
+
+  check('a job re-claimed after a failure still reports it', () => {
+    // The relay picks the job back up, so it reads RUNNING while still
+    // carrying the previous attempt's error. That is the longest stretch of
+    // the retry cycle and the one the spinner covered up.
+    const notice = artJobRetryNotice({
+      status: 'RUNNING',
+      attempts: 2,
+      error: 'ComfyUI POST /prompt failed',
+    })
+    if (!notice)
+      throw new Error('a RUNNING job carrying an error reported nothing')
+    assert.equal(notice.attempts, 2)
+  })
+
+  check('a healthy queued job reports nothing', () => {
+    assert.equal(artJobRetryNotice({ status: 'PENDING', attempts: 0 }), null)
+    assert.equal(
+      artJobRetryNotice({ status: 'RUNNING', attempts: 1, error: null }),
+      null,
+    )
+    assert.equal(artJobRetryNotice(null), null)
+  })
+
+  check('terminal jobs are left to the fatal path', () => {
+    // FAILED/CANCELLED raise through the caller's own error handling, and DONE
+    // has had `error` cleared. A notice here would double-report or, worse,
+    // show a warning next to a finished clip.
+    for (const status of ['FAILED', 'CANCELLED', 'DONE'] as const) {
+      assert.equal(
+        artJobRetryNotice({ status, attempts: 3, error: 'boom' }),
+        null,
+        `${status} should not produce a retry notice`,
+      )
+    }
+  })
+
+  check('an error with no attempt count is not reported', () => {
+    assert.equal(
+      artJobRetryNotice({ status: 'PENDING', error: 'boom' }),
+      null,
+      'without an attempt count there is no honest number to show',
+    )
+  })
+
+  check('whitespace-only errors are not reported', () => {
+    assert.equal(
+      artJobRetryNotice({ status: 'PENDING', attempts: 1, error: '   ' }),
+      null,
+    )
+  })
+
+  return errors
+}
+
+export function checkStoreWiring(content: string): string[] {
+  const errors: string[] = []
+
+  if (!content.includes('artJobRetryNotice')) {
+    errors.push(
+      'videoStore no longer calls artJobRetryNotice() -- its poll loop is ' +
+        'back to reading `error` only at the terminal state, which is the ' +
+        'silent-spinner bug.',
+    )
+  }
+
+  for (const field of ['attemptError', 'attempts']) {
+    if (!content.includes(`state.${field} =`)) {
+      errors.push(
+        `videoStore no longer assigns state.${field} -- the page has ` +
+          'nothing to render while the queue retries.',
+      )
+    }
+  }
+
+  // The store's `attempts` field must include the ArtJob column, or the poll
+  // loop silently reads undefined and never reports a thing.
+  if (!/attempts\??:/.test(content)) {
+    errors.push(
+      "videoStore's QueuedJob type no longer declares `attempts` -- the " +
+        'retry count would be dropped from the polled payload.',
+    )
+  }
+
+  return errors
+}
+
+export function checkPageWiring(content: string): string[] {
+  const errors: string[] = []
+
+  if (!content.includes('videoStore.state.attemptError')) {
+    errors.push(
+      'video-generator.vue no longer renders videoStore.state.attemptError ' +
+        '-- a job that has already failed shows only the spinner again.',
+    )
+    return errors
+  }
+
+  const index = content.indexOf('videoStore.state.attemptError')
+  const blockStart = content.lastIndexOf('<div', index)
+  const blockEnd = content.indexOf('</div>', index)
+  const block =
+    blockStart === -1 || blockEnd === -1
+      ? ''
+      : content.slice(blockStart, blockEnd)
+
+  if (!block.includes('role="status"')) {
+    errors.push(
+      'The retry notice no longer carries role="status" -- it appears while ' +
+        'the run is still live, so assistive tech gets no announcement, ' +
+        "matching this app's busy-state convention.",
+    )
+  }
+
+  if (!block.includes('alert-warning')) {
+    errors.push(
+      'The retry notice is no longer styled as a warning -- it must read as ' +
+        'distinct from the fatal alert-error block, since the job is still ' +
+        'running.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const errors = [
+    ...checkRetryNoticeBehaviour(),
+    ...checkStoreWiring(readFileSync(STORE_PATH, 'utf8')),
+    ...checkPageWiring(readFileSync(PAGE_PATH, 'utf8')),
+  ]
+
+  if (errors.length) {
+    console.error('Video retry-notice contract failed:')
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Video retry-notice contract passed: a queued clip that has already ' +
+      'failed an attempt reports the failure while it retries, instead of ' +
+      'spinning a wheel that says "processing".',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What happened

A webp animation failed on submission (ComfyUI rejected `ckpt_name` with `value_not_in_list`) and the page showed a spinner reading "Queued — waiting for the studio engine to pick it up…" the entire time. The user only learned it had failed by reading the relay's console.

## Why the page said nothing

A failed ArtJob does not stop. `server/api/art/queue/[id]/complete.post.ts:498` records the error and returns the job to **PENDING** until `attempts` reaches `MAX_ATTEMPTS` (3), only then flipping it to `FAILED`:

```ts
status: exhausted ? 'FAILED' : 'PENDING',
error: message,
```

`videoStore.waitForJob` read `error` only once the job reached a terminal state, so a job on attempt 2 was indistinguishable from one queued a second ago. With `COMFY_RECOVERY_SECONDS` at 120s on the relay, that's several minutes of confident-looking "processing" while the ArtJob row had held the full ComfyUI rejection since the first attempt.

## Changes

- **`utils/artJobRetryNotice.ts`** — framework-free decision for when a non-terminal job carries a failure worth reporting. Terminal jobs deliberately return null: `FAILED`/`CANCELLED` raise through the caller's own fatal path and `DONE` has had `error` cleared, so a notice there would double-report or park a warning next to a finished clip.
- **`stores/videoStore.ts`** — adds `attempts` to the polled job type (it was being dropped), exposes `state.attemptError`/`state.attempts`, and folds the retry state into the status line. The 20-minute client timeout no longer claims the engine is "still catching up" when the job has actually been failing — it reports the failure instead.
- **`pages/play/video-generator.vue`** — renders the notice as an `alert-warning` with `role="status"` beside the live spinner, visually distinct from the fatal `alert-error` block, and suppressed once the run ends so the two never say the same thing twice.
- **`utils/scripts/verifyVideoRetryNotice.ts`** + self-test, wired into `contract-tests.yml`.

## Verification

- Guard and self-test pass; the self-test feeds both source checkers the **pre-fix** store and page shapes and asserts they fail, and that the missing-`role` and missing-warning regressions each fail on their own.
- Behavioural half runs the real `artJobRetryNotice` against real inputs (retrying PENDING, re-claimed RUNNING, healthy queued, all three terminal states, error-without-attempt-count, whitespace-only error).
- `tsc --noEmit --strict` (ESNext/bundler, matching `tsconfig.json`) clean on the new files; `prettier@3.9.6` (the lockfile version) clean on every changed file.

Not run: the full `npm test` (`nuxi prepare` + `vue-tsc`) — `node_modules` isn't installed in this environment and this session has a fixed disk allowance. The typecheck above covers the new TypeScript; the store/page edits are small and typed.

## Note on `stores/artStore.ts`

It has the same blind spot at its own poll loop (`waitForQueuedArtJob`, ~line 2183) and would benefit from the same helper — left out because its consumers (`generate-button.vue`, `stylist-restyle.vue`) each need a rendering decision that isn't mine to make unprompted. Happy to follow up.

---
_Generated by [Claude Code](https://claude.ai/code/session_0143kXoZMz1kv9naqHoCCeAH)_