### PR TITLE
feat(ops): warn at boot when the database is missing this build's migrations

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -266,6 +266,12 @@ jobs:
       - name: Da Vinci resolve-panel guard
         run: npm run test:davinci-resolve-panel-guard
 
+      - name: Migration drift check self-test
+        run: npm run test:migration-drift-check-selftest
+
+      - name: Migration drift check contract
+        run: npm run test:migration-drift-check
+
       - name: Video retry-notice guard self-test
         run: npm run test:video-retry-notice-selftest
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "test:relay-agent-registry": "tsx utils/scripts/verifyRelayAgentRegistry.ts",
     "test:video-retry-notice-selftest": "tsx utils/scripts/verifyVideoRetryNotice.test.ts",
     "test:video-retry-notice": "tsx utils/scripts/verifyVideoRetryNotice.ts",
+    "test:migration-drift-check-selftest": "tsx utils/scripts/verifyMigrationDriftCheck.test.ts",
+    "test:migration-drift-check": "tsx utils/scripts/verifyMigrationDriftCheck.ts",
     "test:seed-challenges": "tsx scripts/seed_challenges.ts",
     "test:seed-contenders": "tsx scripts/seed_contenders.ts",
     "dev": "nuxt dev --host",

--- a/server/plugins/01-migration-drift-check.ts
+++ b/server/plugins/01-migration-drift-check.ts
@@ -1,0 +1,91 @@
+// /server/plugins/01-migration-drift-check.ts
+//
+// Say at boot whether this build's migrations are actually in the database.
+// See server/utils/migrationDrift.ts for why CI cannot answer this and why the
+// Alexandria deploy path makes it a live hazard rather than a hypothetical.
+//
+// WARNS, NEVER BLOCKS. Refusing to serve on pending migrations would convert a
+// partial outage (the routes touching new columns) into a total one, and would
+// do it during exactly the window where someone is mid-deploy and least wants
+// the site to disappear. Every failure path here -- no prisma/ directory, no
+// `_prisma_migrations` table on a fresh database, a database that is simply
+// down -- is swallowed after a note. A diagnostic that can take the site down
+// is worse than the error it diagnoses.
+import { readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import prisma from '../utils/prisma'
+import {
+  compareMigrations,
+  describeMigrationDrift,
+  hasMigrationDrift,
+  type AppliedMigrationRow,
+} from '../utils/migrationDrift'
+
+// The runtime image carries prisma/ at /app -- utils/scripts/verifyMigrateOnDeploy.ts
+// is the contract that keeps it there, since an image-slimming pass would
+// otherwise drop it and silently disable both this check and migrate-on-deploy.
+function migrationsOnDisk(): string[] {
+  const directory = join(process.cwd(), 'prisma', 'migrations')
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort()
+}
+
+async function appliedMigrations(): Promise<AppliedMigrationRow[]> {
+  // A plain read of Prisma's own bookkeeping table. This stays in the ordinary
+  // application lane on purpose: it needs to know what was migrated, never to
+  // migrate anything, so it must not want the elevated credential that
+  // docs/runbooks/migration-credential-boundary.md keeps out of this process.
+  return prisma.$queryRaw<AppliedMigrationRow[]>`
+    SELECT migration_name, finished_at, rolled_back_at
+    FROM _prisma_migrations
+  `
+}
+
+export default defineNitroPlugin(() => {
+  // Detached from boot: nothing downstream waits on this, and a slow or
+  // unreachable database must delay serving no more than it already does.
+  void (async () => {
+    let onDisk: string[]
+    try {
+      onDisk = migrationsOnDisk()
+    } catch (error) {
+      console.warn(
+        '[migration-drift] could not read prisma/migrations; skipping the ' +
+          'check. The runtime image is supposed to carry it -- see ' +
+          'utils/scripts/verifyMigrateOnDeploy.ts.',
+        error,
+      )
+      return
+    }
+
+    if (!onDisk.length) return
+
+    let applied: AppliedMigrationRow[]
+    try {
+      applied = await appliedMigrations()
+    } catch (error) {
+      // A fresh database has no _prisma_migrations table yet, and a database
+      // that is down is already being reported by everything else. Neither is
+      // this check's business to escalate.
+      console.warn(
+        '[migration-drift] could not read _prisma_migrations; skipping the ' +
+          'check (fresh database, or the database is unreachable).',
+        error,
+      )
+      return
+    }
+
+    const report = compareMigrations(onDisk, applied)
+
+    if (hasMigrationDrift(report)) {
+      console.error('[migration-drift]', describeMigrationDrift(report))
+      return
+    }
+
+    if (report.ahead.length) {
+      console.warn('[migration-drift]', describeMigrationDrift(report))
+    }
+  })()
+})

--- a/server/utils/migrationDrift.ts
+++ b/server/utils/migrationDrift.ts
@@ -1,0 +1,148 @@
+// /server/utils/migrationDrift.ts
+//
+// Does the database this process is talking to actually have the schema this
+// build expects?
+//
+// Nothing in CI can answer that. Every migration check in .github/workflows is
+// structural -- verifyMigrateOnDeploy.ts asserts the runtime image carries
+// prisma/ and scripts/ and that compose's one-shot service runs the wrapper;
+// verifyMigrationCredentialBoundary.mjs asserts the elevated credential stays
+// out of the app lane. None of them connect to a production database, by
+// design: CI has no credential for one. They prove the machinery for migrating
+// is intact, never that a migration was run.
+//
+// On Alexandria that gap is not theoretical. docker-compose.yml gates the app
+// behind a `migrate` service (`condition: service_completed_successfully`), but
+// docs/runbooks/migration-credential-boundary.md is explicit that the gate
+// "only fires on `docker compose up`, which is not how this host deploys" --
+// there it is pull + Force Update, with the migration as a separate manual
+// step. Code and schema therefore ship independently, and doing only the first
+// is silent until a query touches a column that isn't there.
+//
+// 2026-08-19: PR #1956 added `User.tokens`, `User.earnedTokens` and
+// `ManaTransaction.resource` (migration 20260819120000_split_mana_tokens_resource,
+// merged 01:11). The container was updated; the migration was not run. First
+// symptom was a raw Prisma error in a user-facing response:
+//
+//   The column `User.tokens` does not exist in the current database.
+//
+// This module turns that into one line at boot naming the pending migration.
+// It is framework-free (no Prisma import, no Nitro, no fs) so the comparison
+// can be tested against real inputs without a database.
+
+/** One row of Prisma's own `_prisma_migrations` bookkeeping table. */
+export type AppliedMigrationRow = {
+  migration_name: string
+  // Set when the migration ran to completion. Null means it started and did
+  // not finish -- Prisma leaves the row behind as the record of that.
+  finished_at?: Date | string | null
+  rolled_back_at?: Date | string | null
+}
+
+export type MigrationDriftReport = {
+  /**
+   * On disk in this build, not successfully applied to the database. This is
+   * the dangerous direction: the code expects columns the database lacks.
+   */
+  pending: string[]
+  /**
+   * Recorded in `_prisma_migrations` but never finished, or rolled back. A
+   * subset of the same problem with a different remedy -- see
+   * scripts/repair-known-prisma-migrations.mjs, which the deploy wrapper runs.
+   */
+  failed: string[]
+  /**
+   * Applied to the database but absent from this build. Harmless to queries
+   * (the columns exist, this code just doesn't use them) but it means the
+   * running image is older than the schema -- worth knowing during a rollback.
+   */
+  ahead: string[]
+}
+
+function isApplied(row: AppliedMigrationRow): boolean {
+  const finished = row.finished_at
+  const rolledBack = row.rolled_back_at
+  if (finished === null || finished === undefined) return false
+  if (rolledBack !== null && rolledBack !== undefined) return false
+  return true
+}
+
+/**
+ * Compare the migrations this build carries against what the database records.
+ *
+ * `onDisk` is the directory names under prisma/migrations, which sort
+ * chronologically by their timestamp prefix; the report preserves that order so
+ * the first pending entry is the oldest thing missing.
+ */
+export function compareMigrations(
+  onDisk: readonly string[],
+  applied: readonly AppliedMigrationRow[],
+): MigrationDriftReport {
+  const appliedNames = new Set<string>()
+  const failed: string[] = []
+
+  for (const row of applied) {
+    const name = (row?.migration_name || '').trim()
+    if (!name) continue
+    if (isApplied(row)) {
+      appliedNames.add(name)
+    } else if (!failed.includes(name)) {
+      failed.push(name)
+    }
+  }
+
+  const diskNames = onDisk.map((name) => name.trim()).filter(Boolean)
+  const diskSet = new Set(diskNames)
+
+  return {
+    pending: diskNames.filter((name) => !appliedNames.has(name)).sort(),
+    failed: failed.sort(),
+    ahead: [...appliedNames].filter((name) => !diskSet.has(name)).sort(),
+  }
+}
+
+export function hasMigrationDrift(report: MigrationDriftReport): boolean {
+  return report.pending.length > 0 || report.failed.length > 0
+}
+
+/**
+ * The boot log line. Written here rather than in the plugin so its wording is
+ * covered by the same test as the comparison -- a check nobody can act on is
+ * the failure mode this whole module exists to prevent, and "drift detected"
+ * with no migration name and no command is exactly that.
+ */
+export function describeMigrationDrift(report: MigrationDriftReport): string {
+  const parts: string[] = []
+
+  if (report.pending.length) {
+    parts.push(
+      `${report.pending.length} migration(s) in this build have NOT been ` +
+        `applied to the database: ${report.pending.join(', ')}. Queries ` +
+        'touching their columns will fail at runtime.',
+    )
+  }
+
+  if (report.failed.length) {
+    parts.push(
+      `${report.failed.length} migration(s) are recorded as started but not ` +
+        `finished (or were rolled back): ${report.failed.join(', ')}.`,
+    )
+  }
+
+  if (report.ahead.length) {
+    parts.push(
+      `The database has ${report.ahead.length} migration(s) this build does ` +
+        `not carry: ${report.ahead.join(', ')} -- it is running older code ` +
+        'than the schema.',
+    )
+  }
+
+  parts.push(
+    'Apply with: docker run --rm --network cafepurr --env-file <app .env> ' +
+      "-e MIGRATION_DATABASE_URL='<kindrobot_migrate URL>' " +
+      '<the image you are serving> node scripts/prisma-migrate-deploy.mjs ' +
+      '(see docs/runbooks/migration-credential-boundary.md).',
+  )
+
+  return parts.join(' ')
+}

--- a/utils/scripts/verifyMigrationDriftCheck.test.ts
+++ b/utils/scripts/verifyMigrationDriftCheck.test.ts
@@ -1,0 +1,109 @@
+// /utils/scripts/verifyMigrationDriftCheck.test.ts
+//
+// Self-test for verifyMigrationDriftCheck.ts. The behavioural half runs the
+// real comparison against real inputs, so it is exercised directly; the plugin
+// checker is fed a would-block-boot fixture to prove it actually catches the
+// regression it exists for, rather than passing on anything.
+import assert from 'node:assert/strict'
+
+import {
+  checkDriftBehaviour,
+  checkPluginCannotBlockBoot,
+} from './verifyMigrationDriftCheck.js'
+
+const PLUGIN_SAFE = `
+export default defineNitroPlugin(() => {
+  void (async () => {
+    let onDisk
+    try {
+      onDisk = migrationsOnDisk()
+    } catch (error) {
+      console.warn('[migration-drift] skipping', error)
+      return
+    }
+    let applied
+    try {
+      applied = await appliedMigrations()
+    } catch (error) {
+      console.warn('[migration-drift] skipping', error)
+      return
+    }
+    console.error('[migration-drift]', describeMigrationDrift(compareMigrations(onDisk, applied)))
+  })()
+})
+`
+
+// The tempting version: fail fast so nobody can miss it. It also means a
+// pending migration takes the whole site down instead of the routes that
+// touch the new columns.
+const PLUGIN_THROWS = PLUGIN_SAFE.replace(
+  "console.error('[migration-drift]',",
+  "throw new Error('pending migrations: ' + String(",
+)
+
+// Both guards removed: a fresh database with no _prisma_migrations table
+// would take an unhandled rejection through boot.
+const PLUGIN_UNGUARDED = `
+export default defineNitroPlugin(() => {
+  void (async () => {
+    const onDisk = migrationsOnDisk()
+    const applied = await appliedMigrations()
+    console.error('[migration-drift]', compareMigrations(onDisk, applied))
+  })()
+})
+`
+
+function run(): void {
+  const behaviourErrors = checkDriftBehaviour()
+  assert.deepEqual(
+    behaviourErrors,
+    [],
+    `drift comparison misbehaved: ${behaviourErrors.join('; ')}`,
+  )
+
+  assert.deepEqual(
+    checkPluginCannotBlockBoot(PLUGIN_SAFE),
+    [],
+    'the warn-only plugin shape must pass',
+  )
+
+  const throwErrors = checkPluginCannotBlockBoot(PLUGIN_THROWS)
+  assert.ok(
+    throwErrors.some((e) => /throws/.test(e)),
+    'a plugin that throws on drift must be rejected',
+  )
+
+  const unguardedErrors = checkPluginCannotBlockBoot(PLUGIN_UNGUARDED)
+  assert.ok(
+    unguardedErrors.some((e) => /no longer guards both/.test(e)),
+    'a plugin with no try/catch around either read must be rejected',
+  )
+
+  // The credential-lane check must actually fire on a real read, not merely on
+  // a plugin that happens to mention the variable in a comment.
+  const elevatedErrors = checkPluginCannotBlockBoot(
+    PLUGIN_SAFE.replace(
+      'let onDisk',
+      'const url = process.env.MIGRATION_DATABASE_URL\n    let onDisk',
+    ),
+  )
+  assert.ok(
+    elevatedErrors.some((e) => /reads MIGRATION_DATABASE_URL/.test(e)),
+    'a plugin reaching for the elevated migration credential must be rejected',
+  )
+  assert.deepEqual(
+    checkPluginCannotBlockBoot(
+      `${PLUGIN_SAFE}\n// MIGRATION_DATABASE_URL is deliberately not read here.`,
+    ),
+    [],
+    'naming the credential in a comment must stay allowed',
+  )
+
+  console.log(
+    'Migration drift check self-test passed: the real comparison behaves, ' +
+      'the warn-only plugin shape passes, and both the throws-on-drift and ' +
+      'unguarded-reads regressions are caught.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyMigrationDriftCheck.ts
+++ b/utils/scripts/verifyMigrationDriftCheck.ts
@@ -1,0 +1,213 @@
+// /utils/scripts/verifyMigrationDriftCheck.ts
+//
+// Contract for the boot-time migration drift check.
+//
+// 2026-08-19: PR #1956 added `User.tokens` (migration
+// 20260819120000_split_mana_tokens_resource). The Alexandria container was
+// updated to the new image; the migration was never run against the database.
+// The first symptom was a raw Prisma error in a user-facing response --
+// "The column `User.tokens` does not exist in the current database" -- and
+// nothing in the app had noticed the mismatch at boot, when it was already
+// knowable.
+//
+// CI cannot catch that class at all: every migration check in .github/workflows
+// is structural and none of them connect to a production database. So this
+// contract holds the runtime check to the two properties that make it useful:
+//
+//   1. It computes drift correctly (behavioural, real inputs).
+//   2. It cannot take the site down. A boot check that throws on pending
+//      migrations turns a partial outage into a total one, during a deploy.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  compareMigrations,
+  describeMigrationDrift,
+  hasMigrationDrift,
+} from '../../server/utils/migrationDrift'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const PLUGIN_PATH = join(
+  repositoryRoot,
+  'server/plugins/01-migration-drift-check.ts',
+)
+
+function applied(name: string, overrides = {}) {
+  return {
+    migration_name: name,
+    finished_at: new Date('2026-08-19T00:00:00Z'),
+    rolled_back_at: null,
+    ...overrides,
+  }
+}
+
+export function checkDriftBehaviour(): string[] {
+  const errors: string[] = []
+
+  const check = (label: string, run: () => void): void => {
+    try {
+      run()
+    } catch (error) {
+      errors.push(
+        `${label}: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+  }
+
+  check('the real incident is detected', () => {
+    // The exact shape of 2026-08-19: the build carries the token-split
+    // migration, the database stops one migration earlier.
+    const report = compareMigrations(
+      [
+        '20260818190000_add_brainstorm_output_domain',
+        '20260819120000_split_mana_tokens_resource',
+      ],
+      [applied('20260818190000_add_brainstorm_output_domain')],
+    )
+    assert.deepEqual(report.pending, [
+      '20260819120000_split_mana_tokens_resource',
+    ])
+    assert.equal(hasMigrationDrift(report), true)
+  })
+
+  check('a fully migrated database is quiet', () => {
+    const report = compareMigrations(
+      ['20260818190000_a', '20260819120000_b'],
+      [applied('20260818190000_a'), applied('20260819120000_b')],
+    )
+    assert.deepEqual(report, { pending: [], failed: [], ahead: [] })
+    assert.equal(hasMigrationDrift(report), false)
+  })
+
+  check('a started-but-unfinished migration is not counted as applied', () => {
+    // Prisma leaves the row behind with finished_at NULL. Treating that as
+    // applied is how a half-run migration reads as a healthy deploy.
+    const report = compareMigrations(
+      ['20260819120000_b'],
+      [applied('20260819120000_b', { finished_at: null })],
+    )
+    assert.deepEqual(report.pending, ['20260819120000_b'])
+    assert.deepEqual(report.failed, ['20260819120000_b'])
+    assert.equal(hasMigrationDrift(report), true)
+  })
+
+  check('a rolled-back migration is not counted as applied', () => {
+    const report = compareMigrations(
+      ['20260819120000_b'],
+      [
+        applied('20260819120000_b', {
+          rolled_back_at: new Date('2026-08-19T01:00:00Z'),
+        }),
+      ],
+    )
+    assert.deepEqual(report.pending, ['20260819120000_b'])
+    assert.deepEqual(report.failed, ['20260819120000_b'])
+  })
+
+  check('a database ahead of the build is reported separately', () => {
+    // Rollback shape: the schema has moved on, this image has not. Queries
+    // still work, so it must not read as the dangerous direction.
+    const report = compareMigrations(
+      ['20260818190000_a'],
+      [applied('20260818190000_a'), applied('20260819120000_b')],
+    )
+    assert.deepEqual(report.pending, [])
+    assert.deepEqual(report.ahead, ['20260819120000_b'])
+    assert.equal(
+      hasMigrationDrift(report),
+      false,
+      'being behind the database is not a runtime hazard and must not read as one',
+    )
+  })
+
+  check('an empty database reports every migration as pending', () => {
+    const report = compareMigrations(
+      ['20260818190000_a', '20260819120000_b'],
+      [],
+    )
+    assert.deepEqual(report.pending, ['20260818190000_a', '20260819120000_b'])
+  })
+
+  check('the message names the migration and the remedy', () => {
+    // A drift warning nobody can act on is the failure this whole check
+    // exists to prevent, so the wording is part of the contract.
+    const message = describeMigrationDrift(
+      compareMigrations(['20260819120000_split_mana_tokens_resource'], []),
+    )
+    assert.match(message, /20260819120000_split_mana_tokens_resource/)
+    assert.match(message, /prisma-migrate-deploy\.mjs/)
+    assert.match(message, /migration-credential-boundary\.md/)
+  })
+
+  return errors
+}
+
+export function checkPluginCannotBlockBoot(content: string): string[] {
+  const errors: string[] = []
+
+  // `throw` anywhere in the plugin body, or an un-caught await, is the
+  // difference between "one loud line" and "the site does not come up".
+  if (/\bthrow\b/.test(content)) {
+    errors.push(
+      'The drift plugin throws. It must only warn: refusing to serve on a ' +
+        'pending migration turns a partial outage into a total one, in the ' +
+        'middle of a deploy.',
+    )
+  }
+
+  for (const guarded of ['migrationsOnDisk', 'appliedMigrations']) {
+    if (!content.includes(`${guarded}(`)) {
+      errors.push(`The drift plugin no longer calls ${guarded}().`)
+    }
+  }
+
+  // Two try/catch blocks: one for the filesystem read, one for the query.
+  const catches = content.match(/\}\s*catch\s*\(/g) || []
+  if (catches.length < 2) {
+    errors.push(
+      'The drift plugin no longer guards both the prisma/migrations read and ' +
+        'the _prisma_migrations query. A fresh database (no bookkeeping ' +
+        'table) or a slimmed image (no prisma/ directory) must not break boot.',
+    )
+  }
+
+  // The plugin may name the elevated credential in a comment; it must never
+  // read one. This check lives in the ordinary application lane because it
+  // needs to know what was migrated, never to migrate.
+  if (/process\.env\.MIGRATION_DATABASE_URL/.test(content)) {
+    errors.push(
+      'The drift plugin reads MIGRATION_DATABASE_URL. It only needs to read ' +
+        'what was migrated, never to migrate -- see ' +
+        'docs/runbooks/migration-credential-boundary.md.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const errors = [
+    ...checkDriftBehaviour(),
+    ...checkPluginCannotBlockBoot(readFileSync(PLUGIN_PATH, 'utf8')),
+  ]
+
+  if (errors.length) {
+    console.error('Migration drift check contract failed:')
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Migration drift check contract passed: a build whose migrations are not ' +
+      'in the database says so at boot, names them, and cannot refuse to serve.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Why CI didn't catch the `User.tokens` error

It can't. Every migration-related check in `.github/workflows` is **structural**:

| Check | What it asserts |
|---|---|
| `verifyMigrateOnDeploy.ts` | the runtime image carries `prisma/`, `scripts/`, `prisma.config.ts`; compose's one-shot service runs the wrapper, not raw `migrate deploy`; `MIGRATION_DATABASE_URL` stays out of the app service |
| `verifyMigrationCredentialBoundary.mjs` | the elevated credential never reaches the ordinary lane |
| `verify-known-migration-repair.mjs` | the repair path never `UPDATE`s `_prisma_migrations` |
| `facet-alias-smoke.yml` | a throwaway MariaDB + fixture SQL, not the real migration chain |
| `publish-container.yml` | *"this only validates the image still builds (and, on push to main, publishes it)"* — no deploy, no migration |

Nothing runs `migrate deploy`, `migrate status`, or `migrate diff` against any real database. That's correct — CI has no production credential and shouldn't. But it means CI proves the *machinery* for migrating is intact, never that a migration **ran**.

On Alexandria that's not theoretical. `docker-compose.yml` gates the app behind a `migrate` service (`condition: service_completed_successfully`), but `docs/runbooks/migration-credential-boundary.md` is explicit:

> …that gate is real — but it only fires on `docker compose up`, which is **not** how this host deploys.

There it's pull + Force Update, with migration as a separate manual step. Code and schema ship independently, and doing only the first is silent until a query touches a column that isn't there. On 2026-08-19 #1956 added `User.tokens`; the container was updated, the migration wasn't run, and the first symptom was a raw Prisma error in a user-facing response.

## What this adds

- **`server/utils/migrationDrift.ts`** — framework-free comparison of the migrations this build carries against `_prisma_migrations`. Three distinct outcomes, because they mean different things:
  - `pending` — on disk, not applied. Code ahead of schema: **the dangerous direction**.
  - `failed` — recorded as started but never finished, or rolled back. Same symptom, different remedy (the deploy wrapper's repair path).
  - `ahead` — applied but absent from this build. The rollback shape: queries still work, the image is just older than the schema. Deliberately **not** counted as drift.
- **`server/plugins/01-migration-drift-check.ts`** — reads both at boot, logs one line naming the migrations *and the command to fix them*.
- **`verifyMigrationDriftCheck`** guard + self-test, wired into `contract-tests.yml`.

## Warns, never blocks

Refusing to serve on a pending migration would turn a partial outage (the routes touching new columns) into a total one, during exactly the window when someone is mid-deploy. Every failure path — no `prisma/` directory, no `_prisma_migrations` table on a fresh database, database unreachable — is swallowed after a note. A diagnostic that can take the site down is worse than the error it diagnoses.

The guard enforces this: it fails if the plugin ever `throw`s, drops either `try`/`catch`, or reaches for `process.env.MIGRATION_DATABASE_URL` (this check reads in the ordinary application lane — it needs to know what was migrated, never to migrate).

## Verification

- Self-test feeds the checker a **throws-on-drift** plugin and an **unguarded-reads** plugin and asserts each is rejected, plus a real `process.env.MIGRATION_DATABASE_URL` read, plus the comment-only mention that must stay allowed.
- Behavioural half runs the real comparison over: the exact 2026-08-19 shape, a fully-migrated database, `finished_at` NULL, `rolled_back_at` set, a database ahead of the build, and an empty database.
- Message wording is under test — it must name the migration, `prisma-migrate-deploy.mjs`, and the runbook. A drift warning nobody can act on is the failure this exists to prevent.
- `tsc --noEmit --strict` (ESNext/bundler) and `prettier@3.9.6` clean.

## Still not covered

This catches *"migration merged, never run."* It does **not** catch *"field added to `schema.prisma`, migration never written"* — nothing fails today if you add a column to the schema and skip the migration; `prisma generate` produces a client for a schema no migration builds, and you get the identical runtime error. That one **is** CI-checkable without production access:

```
prisma migrate diff --from-migrations prisma/migrations \
  --to-schema-datamodel prisma --shadow-database-url <throwaway> --exit-code
```

`prisma.config.ts` already plumbs `SHADOW_DATABASE_URL`, and `facet-alias-smoke.yml` already shows the throwaway-MariaDB pattern. Not included here — say the word.

---
_Generated by [Claude Code](https://claude.ai/code/session_0143kXoZMz1kv9naqHoCCeAH)_