### PR TITLE
docs(ops): make the migration lane reproducible and its runbook runnable

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,4 +1,7 @@
 # Infrastructure runbooks
 
+- [Migration credential boundary](./migration-credential-boundary.md) — how schema changes reach production, and the `kindrobot_migrate` lane
+- [Coding-agent database lane](./agent-database-lane.md) — the read/write-only `kindrobot_agent` identity
 - [ProxySQL connection capacity](./proxysql-connection-capacity.md)
+- [Connection-capacity investigation](./connection-capacity-investigation.md) — the 2026-08-04 frontend-session exhaustion
 - [Payment environment configuration](./payment-environment.md)

--- a/docs/runbooks/migration-credential-boundary.md
+++ b/docs/runbooks/migration-credential-boundary.md
@@ -40,14 +40,21 @@ CI or production jobs that execute migrations must provide `MIGRATION_DATABASE_U
 Migrate from the image you are about to serve, then Force Update:
 
 ```bash
+cd /mnt/user/appdata/kind_robots
+set -a; . /mnt/user/pc/kindrobots-db-migrate/kindrobots-db-migrate.env; set +a
+
 docker pull ghcr.io/silasfelinus/kind_robots:latest
 
 docker run --rm --network cafepurr \
   --env-file /mnt/user/appdata/kind_robots/.env \
-  -e MIGRATION_DATABASE_URL='<kindrobot_migrate URL>' \
+  -e MIGRATION_DATABASE_URL \
   ghcr.io/silasfelinus/kind_robots:latest \
   node scripts/prisma-migrate-deploy.mjs
 ```
+
+Every line above is meant to be pasted as-is. There are deliberately **no placeholders** to substitute: `MIGRATION_DATABASE_URL` arrives from the sourced handoff file, and `-e MIGRATION_DATABASE_URL` with no `=value` passes it from the current shell, keeping the credential out of the command line and out of shell history. An earlier revision of this page printed a `mysql://kindrobot_migrate:PASSWORD@HOST:5544/DBNAME` template here; it was pasted verbatim more than once, and `P1001: Can't reach database server at HOST:5544` is what that looks like.
+
+No `git pull` is required for any of this. The image carries its own `prisma/migrations`, `scripts/` and `prisma.config.ts`; the checkout is used only for `.env`.
 
 Pull first. Migrating from `:latest` and then Force Updating to `:latest` is what keeps the schema and the code that will serve it the same build.
 
@@ -59,18 +66,75 @@ Pull first. Migrating from `:latest` and then Force Updating to `:latest` is wha
 
 Set `MIGRATION_DATABASE_URL` to the `kindrobot_migrate` credential in the deploying shell. It is deliberately **not** read from the application env file.
 
-This keeps the boundary rather than bending it. The rule is that schema-write capability must not sit in the *long-running* application container; a container whose entire lifetime is the migration is the same shape as a CI job. Do not move `MIGRATION_DATABASE_URL` into the `kind-robots` service to simplify the file — that hands a permanently-running web process the ability to drop tables, and `utils/scripts/verifyMigrateOnDeploy.ts` fails the build if you do.
+This keeps the boundary rather than bending it. The rule is that schema-write capability must not sit in the _long-running_ application container; a container whose entire lifetime is the migration is the same shape as a CI job. Do not move `MIGRATION_DATABASE_URL` into the `kind-robots` service to simplify the file — that hands a permanently-running web process the ability to drop tables, and `utils/scripts/verifyMigrateOnDeploy.ts` fails the build if you do.
 
 That contract also pins the runtime image carrying `prisma/`, `scripts/` and `prisma.config.ts`. The image originally shipped only `.output`, `node_modules` and `package.json`, which is why migrations could not run from it at all and had to be run by hand from a repo checkout on the host — against whatever revision that checkout happened to be on. An image-slimming pass that drops them would silently reintroduce that.
 
-### Running a migration by hand
+### Where the credential comes from
 
-Still supported, from a repo checkout with dependencies installed:
+`MIGRATION_DATABASE_URL` is written by `scripts/provision-migrate-db-lane.sh` to a mode-600 handoff file, by default:
 
-```bash
-MIGRATION_DATABASE_URL='mysql://kindrobot_migrate:PASSWORD@HOST:5544/DBNAME' \
-DATABASE_SSL_CA_BASE64="$(grep -m1 '^DATABASE_SSL_CA_BASE64=' .env | cut -d= -f2-)" \
-npx prisma migrate status     # read-only; lists what is pending
+```text
+/mnt/user/pc/kindrobots-db-migrate/kindrobots-db-migrate.env
 ```
 
-Then swap `npx prisma migrate status` for `node scripts/prisma-migrate-deploy.mjs` to apply. Pass a plain `mysql://` URL with no SSL parameters — the wrapper writes the CA to a temporary file and appends `sslcert`/`sslaccept=strict` itself, then removes it.
+Source that in the deploying shell (`set -a; . <file>; set +a`) rather than retyping a URL. If the file does not exist, or the credential in it no longer authenticates, run the provisioner — it creates or reconciles the lane in **both** MariaDB and ProxySQL and verifies authentication end to end:
+
+```bash
+bash scripts/provision-migrate-db-lane.sh            # dry run
+bash scripts/provision-migrate-db-lane.sh --apply
+```
+
+### Reading what is pending
+
+`prisma migrate status` **cannot be used against this lane directly.** `prisma.config.ts` passes `MIGRATION_DATABASE_URL` through as the datasource URL and adds no SSL parameters; nothing reads `DATABASE_SSL_CA_BASE64` except `scripts/prisma-migrate-deploy.mjs`, which writes the CA to a temp file and appends `sslcert`/`sslaccept=strict` itself. `kindrobot_migrate` has `use_ssl=1` in ProxySQL, so a plain `npx prisma migrate status` connects without TLS and is rejected — surfacing as **P1000 "Authentication failed"**, which reads exactly like a wrong password and is not one. (2026-08-19: an hour was lost to this.)
+
+Read the history directly instead — no TLS plumbing, no Prisma:
+
+```bash
+set -a; . /mnt/user/pc/kindrobots-db-migrate/kindrobots-db-migrate.env; set +a
+
+docker run --rm --network cafepurr -e MYSQL_PWD="$MIGRATE_DB_PASSWORD" mariadb:11.4 \
+  mariadb -h "$PUBLIC_PROXYSQL_HOST" -P "$PUBLIC_PROXYSQL_PORT" -u "$MIGRATE_DB_USER" \
+  --ssl -D "$DATABASE_NAME" --batch --raw --skip-column-names \
+  -e "SELECT migration_name FROM _prisma_migrations WHERE finished_at IS NOT NULL AND rolled_back_at IS NULL;" \
+  | sort > /tmp/applied.txt
+
+docker run --rm ghcr.io/silasfelinus/kind_robots:latest sh -lc 'ls -1 /app/prisma/migrations' \
+  | grep -v migration_lock | sort > /tmp/ondisk.txt
+
+comm -23 /tmp/ondisk.txt /tmp/applied.txt    # what a deploy would run
+```
+
+Take the on-disk list from the **image**, not from a repo checkout on the host: the image is what will actually run, and the checkout is at whatever revision it happens to be.
+
+Two things to look for in that output:
+
+- **`00000000000000_squashed` listed as pending** — the database predates the squash and was never baselined. Do not run deploy; it would try to re-create the whole schema. Record the baseline with `prisma migrate resolve --applied 00000000000000_squashed` (which needs the same TLS treatment as `status`, so run it through the image with `sslcert`/`sslaccept` set on the URL) and re-check.
+- **Applied migrations absent from the image** — expected for a database older than the squash; `migrate deploy` ignores them.
+
+If you do want Prisma's own view, replicate what the wrapper does to the URL:
+
+```bash
+docker run --rm --network cafepurr --env-file .env -e MIGRATION_DATABASE_URL \
+  ghcr.io/silasfelinus/kind_robots:latest sh -lc '
+    printf %s "$DATABASE_SSL_CA_BASE64" | tr -d "[:space:]" | base64 -d > /tmp/ca.pem
+    export MIGRATION_DATABASE_URL="${MIGRATION_DATABASE_URL}?sslcert=/tmp/ca.pem&sslaccept=strict"
+    npx prisma migrate status
+  '
+```
+
+### Running a migration by hand
+
+Still supported, from a repo checkout with dependencies installed. Pass a plain `mysql://` URL with no SSL parameters — the wrapper adds them:
+
+```bash
+set -a; . /mnt/user/pc/kindrobots-db-migrate/kindrobots-db-migrate.env; set +a
+DATABASE_SSL_CA_BASE64="$(grep -m1 '^DATABASE_SSL_CA_BASE64=' .env | cut -d= -f2- | tr -d '\042\047')" \
+  node scripts/prisma-migrate-deploy.mjs
+```
+
+Two shell hazards, both of which have cost real time here:
+
+- **Do not `source` the application `.env`.** Its values are unquoted and contain characters bash will execute; `set -a; . ./.env` produces `command not found` lines made of your secrets. Read individual keys with `grep`/`cut` as above, or let `docker run --env-file` parse the file (docker does not use a shell).
+- **Do not put an interactive `read` in a block you paste.** When several lines are pasted at once, `read` consumes the _next pasted line_ as its input rather than waiting for you to type. Put passwords in a mode-600 file and read them from there.

--- a/scripts/provision-migrate-db-lane.sh
+++ b/scripts/provision-migrate-db-lane.sh
@@ -1,0 +1,426 @@
+#!/usr/bin/env bash
+# Provision (or reconcile) the dedicated ProxySQL/MariaDB migration lane.
+# Run on Alexandria from the Kind Robots repository.
+#
+# Dry run (default):
+#   bash scripts/provision-migrate-db-lane.sh
+#
+# Apply:
+#   bash scripts/provision-migrate-db-lane.sh --apply
+#
+# Optional overrides:
+#   PROXYSQL_CONTAINER=proxysql
+#   MARIADB_CONTAINER=mariadb-kindrobots2
+#   APP_DB_USER=kindrobot
+#   MIGRATE_DB_USER=kindrobot_migrate
+#   PRODUCTION_HOSTGROUP=10
+#   MIGRATE_HOSTGROUP=30
+#   MIGRATE_FRONTEND_MAX=8
+#   MIGRATE_BACKEND_MAX=4
+#   PUBLIC_PROXYSQL_HOST=acrocatranch.com
+#   PUBLIC_PROXYSQL_PORT=5544
+#   OUTPUT_FILE=/mnt/user/pc/kindrobots-db-migrate/kindrobots-db-migrate.env
+#   MIGRATE_DB_PASSWORD=...            # reuse an existing password instead of generating
+#   ROTATE_PASSWORD=1                  # generate a new password even if one is known
+#   STRICT_PRIVILEGES=1                # REVOKE first, then grant only the set below
+#
+# This is the sibling of provision-agent-db-lane.sh and the exact inverse of it
+# in one respect: the agent lane must NOT be able to change schema, and this one
+# must. Everything else -- dry run first, credential handoff file, verification
+# through ProxySQL, never printing the password -- is deliberately the same.
+#
+# WHY THIS EXISTS
+# ---------------
+# 2026-08-19: a deploy shipped code expecting `User.tokens` while the database
+# was three releases behind, and the migration could not be run because nobody
+# had a working `kindrobot_migrate` password. The lane itself turned out to be
+# fully provisioned in ProxySQL (hostgroup 30, active, correct schema) -- it was
+# only the credential that had gone missing. `kindrobot_agent` had a script that
+# creates and reconciles it idempotently; this lane did not, which is most
+# likely why this is the lane that drifted. Recovering it by hand took four
+# rounds of ProxySQL and MariaDB spelunking. This script is that recovery,
+# written down.
+#
+# PRIVILEGES
+# ----------
+# Additive by default: the migration user is granted the schema-change set on
+# the application schema, and nothing is revoked. That is deliberate -- this
+# runs against production, and silently narrowing an already-working migration
+# identity is a worse failure than leaving it broader than necessary. Pass
+# STRICT_PRIVILEGES=1 to revoke first and land exactly the set below, which is
+# what you want when reconciling a lane you believe has accumulated extra
+# grants. Either way the script verifies afterwards that every privilege a
+# Prisma migration needs is present.
+
+set -Eeuo pipefail
+
+MODE='dry-run'
+if [[ "${1:-}" == '--apply' ]]; then
+  MODE='apply'
+elif [[ -n "${1:-}" ]]; then
+  printf 'Usage: %s [--apply]\n' "$0" >&2
+  exit 2
+fi
+
+PROXYSQL_CONTAINER="${PROXYSQL_CONTAINER:-proxysql}"
+MARIADB_CONTAINER="${MARIADB_CONTAINER:-mariadb-kindrobots2}"
+APP_DB_USER="${APP_DB_USER:-kindrobot}"
+MIGRATE_DB_USER="${MIGRATE_DB_USER:-kindrobot_migrate}"
+PRODUCTION_HOSTGROUP="${PRODUCTION_HOSTGROUP:-10}"
+MIGRATE_HOSTGROUP="${MIGRATE_HOSTGROUP:-30}"
+MIGRATE_FRONTEND_MAX="${MIGRATE_FRONTEND_MAX:-8}"
+MIGRATE_BACKEND_MAX="${MIGRATE_BACKEND_MAX:-4}"
+PUBLIC_PROXYSQL_HOST="${PUBLIC_PROXYSQL_HOST:-acrocatranch.com}"
+PUBLIC_PROXYSQL_PORT="${PUBLIC_PROXYSQL_PORT:-5544}"
+OUTPUT_FILE="${OUTPUT_FILE:-/mnt/user/pc/kindrobots-db-migrate/kindrobots-db-migrate.env}"
+ROTATE_PASSWORD="${ROTATE_PASSWORD:-0}"
+STRICT_PRIVILEGES="${STRICT_PRIVILEGES:-0}"
+
+# Everything `prisma migrate deploy` can need on one schema. Kept explicit
+# rather than `ALL PRIVILEGES` so the verification below can assert it, and so
+# a reader can see exactly what a migration is allowed to do.
+MIGRATE_PRIVILEGES='SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, ALTER, INDEX, REFERENCES, CREATE TEMPORARY TABLES, LOCK TABLES, CREATE VIEW, SHOW VIEW, TRIGGER, EXECUTE, CREATE ROUTINE, ALTER ROUTINE'
+# The subset the verification insists on afterwards. A migration that cannot
+# CREATE/ALTER/DROP/INDEX is not a migration lane.
+REQUIRED_PRIVILEGES="'SELECT','INSERT','UPDATE','DELETE','CREATE','DROP','ALTER','INDEX','REFERENCES'"
+REQUIRED_PRIVILEGE_COUNT=9
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+info() {
+  printf '%s\n' "$*"
+}
+
+command -v docker >/dev/null 2>&1 || fail 'docker is required on the Unraid host'
+command -v openssl >/dev/null 2>&1 || fail 'openssl is required to generate credentials'
+
+for container in "$PROXYSQL_CONTAINER" "$MARIADB_CONTAINER"; do
+  running="$(docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null || true)"
+  [[ "$running" == 'true' ]] || fail "container $container is not running"
+done
+
+for value in "$APP_DB_USER" "$MIGRATE_DB_USER"; do
+  [[ "$value" =~ ^[A-Za-z0-9_.@-]+$ ]] || fail "unsupported database username: $value"
+done
+
+[[ "$APP_DB_USER" != "$MIGRATE_DB_USER" ]] || fail \
+  'The migration user must differ from the production application user; that separation is the whole point of docs/runbooks/migration-credential-boundary.md'
+
+for value in "$PRODUCTION_HOSTGROUP" "$MIGRATE_HOSTGROUP" "$MIGRATE_FRONTEND_MAX" \
+  "$MIGRATE_BACKEND_MAX" "$PUBLIC_PROXYSQL_PORT"; do
+  [[ "$value" =~ ^[0-9]+$ ]] || fail "expected an integer, got: $value"
+done
+
+[[ "$PRODUCTION_HOSTGROUP" != "$MIGRATE_HOSTGROUP" ]] || fail 'Migration hostgroup must differ from production'
+[[ "$MIGRATE_FRONTEND_MAX" -ge 1 ]] || fail 'Migration frontend max must be at least 1'
+[[ "$MIGRATE_BACKEND_MAX" -ge 1 ]] || fail 'Migration backend max must be at least 1'
+
+container_env_value() {
+  local container="$1"
+  local key="$2"
+  docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$container" 2>/dev/null \
+    | sed -n "s/^${key}=//p" \
+    | head -n 1
+}
+
+find_proxysql_admin_credentials() {
+  local credentials
+  credentials="$(
+    docker exec "$PROXYSQL_CONTAINER" sh -lc '
+      for file in /etc/proxysql.cnf /etc/proxysql/proxysql.cnf /var/lib/proxysql/proxysql.cnf; do
+        if [ -r "$file" ]; then
+          sed -nE '\''s/^[[:space:]]*admin_credentials[[:space:]]*=[[:space:]]*"([^";]+)(;[^"]*)?".*/\1/p'\'' "$file"
+          exit 0
+        fi
+      done
+    ' 2>/dev/null || true
+  )"
+
+  [[ -n "$credentials" ]] || return 1
+  PROXYSQL_ADMIN_USER="${credentials%%:*}"
+  PROXYSQL_ADMIN_PASSWORD="${credentials#*:}"
+  [[ -n "$PROXYSQL_ADMIN_USER" && -n "$PROXYSQL_ADMIN_PASSWORD" ]]
+}
+
+PROXYSQL_ADMIN_USER="${PROXYSQL_ADMIN_USER:-}"
+PROXYSQL_ADMIN_PASSWORD="${PROXYSQL_ADMIN_PASSWORD:-}"
+if [[ -z "$PROXYSQL_ADMIN_USER" || -z "$PROXYSQL_ADMIN_PASSWORD" ]]; then
+  find_proxysql_admin_credentials || fail \
+    'could not read ProxySQL admin_credentials; set PROXYSQL_ADMIN_USER and PROXYSQL_ADMIN_PASSWORD'
+fi
+
+MARIADB_ROOT_PASSWORD="${MARIADB_ROOT_PASSWORD:-}"
+if [[ -z "$MARIADB_ROOT_PASSWORD" ]]; then
+  MARIADB_ROOT_PASSWORD="$(container_env_value "$MARIADB_CONTAINER" MARIADB_ROOT_PASSWORD)"
+fi
+if [[ -z "$MARIADB_ROOT_PASSWORD" ]]; then
+  MARIADB_ROOT_PASSWORD="$(container_env_value "$MARIADB_CONTAINER" MYSQL_ROOT_PASSWORD)"
+fi
+
+proxysql_query() {
+  local sql="$1"
+  docker exec \
+    -e MYSQL_PWD="$PROXYSQL_ADMIN_PASSWORD" \
+    -e KR_SQL="$sql" \
+    -e KR_ADMIN_USER="$PROXYSQL_ADMIN_USER" \
+    "$PROXYSQL_CONTAINER" sh -lc '
+      client="$(command -v mariadb || command -v mysql || true)"
+      [ -n "$client" ] || exit 127
+      "$client" --protocol=tcp -h127.0.0.1 -P6032 -u"$KR_ADMIN_USER" --batch --skip-column-names --raw -e "$KR_SQL"
+    '
+}
+
+mariadb_query() {
+  local sql="$1"
+  if [[ -n "$MARIADB_ROOT_PASSWORD" ]]; then
+    docker exec \
+      -e MYSQL_PWD="$MARIADB_ROOT_PASSWORD" \
+      -e KR_SQL="$sql" \
+      "$MARIADB_CONTAINER" sh -lc '
+        client="$(command -v mariadb || command -v mysql || true)"
+        [ -n "$client" ] || exit 127
+        "$client" --protocol=socket -uroot --batch --skip-column-names --raw -e "$KR_SQL"
+      '
+  else
+    docker exec \
+      -e KR_SQL="$sql" \
+      "$MARIADB_CONTAINER" sh -lc '
+        client="$(command -v mariadb || command -v mysql || true)"
+        [ -n "$client" ] || exit 127
+        "$client" --protocol=socket -uroot --batch --skip-column-names --raw -e "$KR_SQL"
+      ' || fail 'root login failed; set MARIADB_ROOT_PASSWORD for provisioning'
+  fi
+}
+
+load_saved_credentials() {
+  [[ -f "$OUTPUT_FILE" ]] || return 0
+  local mode
+  mode="$(stat -c '%a' "$OUTPUT_FILE" 2>/dev/null || true)"
+  [[ "$mode" == '600' || "$mode" == '400' ]] || fail \
+    "refusing to source $OUTPUT_FILE because its mode is ${mode:-unknown}; chmod 600 first"
+  # shellcheck disable=SC1090
+  source "$OUTPUT_FILE"
+}
+
+load_saved_credentials
+MIGRATE_DB_PASSWORD="${MIGRATE_DB_PASSWORD:-}"
+# An `[[ ... ]] && x=y` one-liner returns non-zero when the test fails, which
+# under `set -e` exits the script -- the opposite of "leave it alone".
+if [[ "$ROTATE_PASSWORD" == '1' ]]; then
+  MIGRATE_DB_PASSWORD=''
+fi
+
+# Routing comes from the production user's live row rather than from constants,
+# so the migration lane can never end up pointed at a schema or an SSL setting
+# the application does not itself use.
+prod_user_row="$(proxysql_query "
+SELECT default_schema, use_ssl
+FROM runtime_mysql_users
+WHERE username='${APP_DB_USER}' AND frontend=1
+LIMIT 1;
+")"
+[[ -n "$prod_user_row" ]] || fail "ProxySQL runtime user ${APP_DB_USER} was not found"
+
+IFS=$'\t' read -r DATABASE_NAME PROD_USE_SSL <<<"$prod_user_row"
+[[ "$DATABASE_NAME" =~ ^[A-Za-z0-9_]+$ ]] || fail "unsupported database name: $DATABASE_NAME"
+[[ "$PROD_USE_SSL" =~ ^[01]$ ]] || fail "unexpected use_ssl value for ${APP_DB_USER}: $PROD_USE_SSL"
+
+prod_backend_count="$(proxysql_query "SELECT COUNT(*) FROM mysql_servers WHERE hostgroup_id=${PRODUCTION_HOSTGROUP};")"
+[[ "$prod_backend_count" -gt 0 ]] || fail "production hostgroup ${PRODUCTION_HOSTGROUP} has no backend servers"
+
+foreign_rows="$(proxysql_query "
+SELECT COUNT(*)
+FROM mysql_servers AS target
+WHERE target.hostgroup_id=${MIGRATE_HOSTGROUP}
+  AND NOT EXISTS (
+    SELECT 1
+    FROM mysql_servers AS prod
+    WHERE prod.hostgroup_id=${PRODUCTION_HOSTGROUP}
+      AND prod.hostname=target.hostname
+      AND prod.port=target.port
+  );
+")"
+[[ "$foreign_rows" == '0' ]] || fail \
+  "hostgroup ${MIGRATE_HOSTGROUP} already contains backend rows unrelated to production hostgroup ${PRODUCTION_HOSTGROUP}"
+
+migrate_backend_count="$(proxysql_query "SELECT COUNT(*) FROM mysql_servers WHERE hostgroup_id=${MIGRATE_HOSTGROUP};")"
+migrate_user_exists="$(mariadb_query "SELECT COUNT(*) FROM mysql.user WHERE User='${MIGRATE_DB_USER}' AND Host='%';")"
+
+if [[ "$migrate_user_exists" != '0' && -z "$MIGRATE_DB_PASSWORD" ]]; then
+  info "NOTE: MariaDB user ${MIGRATE_DB_USER}@% already exists and no password is known."
+  info '      A new one will be generated and set on BOTH MariaDB and ProxySQL.'
+  info "      Anything still holding the old password stops working -- that is the"
+  info '      intended recovery when the credential has been lost. Set'
+  info '      MIGRATE_DB_PASSWORD to keep the existing one instead.'
+fi
+
+[[ -n "$MIGRATE_DB_PASSWORD" ]] || MIGRATE_DB_PASSWORD="$(openssl rand -hex 24)"
+[[ "$MIGRATE_DB_PASSWORD" =~ ^[A-Za-z0-9]+$ ]] || fail \
+  'Migration password must contain only letters and digits: it is embedded in a URL and in SQL, and every escaping layer it crosses is a place to lose an hour'
+
+migrate_url="mysql://${MIGRATE_DB_USER}:${MIGRATE_DB_PASSWORD}@${PUBLIC_PROXYSQL_HOST}:${PUBLIC_PROXYSQL_PORT}/${DATABASE_NAME}"
+
+info 'Kind Robots migration database lane'
+info "Mode: ${MODE}"
+info "Database: ${DATABASE_NAME}"
+info "Production lane: user=${APP_DB_USER} hostgroup=${PRODUCTION_HOSTGROUP} backends=${prod_backend_count}"
+info "Migration lane: user=${MIGRATE_DB_USER} frontendMax=${MIGRATE_FRONTEND_MAX} hostgroup=${MIGRATE_HOSTGROUP} backendMax/server=${MIGRATE_BACKEND_MAX}"
+info "Migration hostgroup backends currently present: ${migrate_backend_count} (will be reconciled to ${prod_backend_count})"
+info "MariaDB user exists: $([[ "$migrate_user_exists" == '0' ]] && echo no || echo yes)"
+info "Privileges: ${MIGRATE_PRIVILEGES}"
+info "Revoke before granting: $([[ "$STRICT_PRIVILEGES" == '1' ]] && echo yes || echo 'no (additive)')"
+info 'Passwords and URLs are intentionally not printed.'
+
+if [[ "$MODE" != 'apply' ]]; then
+  info ''
+  info 'Dry run complete. Re-run with --apply to provision the migration lane.'
+  exit 0
+fi
+
+output_dir="$(dirname "$OUTPUT_FILE")"
+mkdir -p "$output_dir"
+chmod 700 "$output_dir"
+snapshot_file="${OUTPUT_FILE%.env}-before-$(date -u +%Y%m%dT%H%M%SZ).txt"
+{
+  printf 'ProxySQL migration user (password omitted)\n'
+  proxysql_query "SELECT username,active,use_ssl,default_hostgroup,default_schema,schema_locked,transaction_persistent,frontend,backend,max_connections FROM mysql_users WHERE username='${MIGRATE_DB_USER}';"
+  printf '\nProxySQL target servers\n'
+  proxysql_query "SELECT hostgroup_id,hostname,port,status,weight,max_connections,use_ssl,comment FROM mysql_servers WHERE hostgroup_id=${MIGRATE_HOSTGROUP} ORDER BY hostname,port;"
+  printf '\nMariaDB migration grants before change\n'
+  mariadb_query "SHOW GRANTS FOR '${MIGRATE_DB_USER}'@'%';" 2>/dev/null || true
+} >"$snapshot_file"
+chmod 600 "$snapshot_file"
+
+# --- MariaDB ---------------------------------------------------------------
+# IDENTIFIED VIA mysql_native_password is not a style choice: ProxySQL cannot
+# authenticate to the backend with MariaDB's newer default plugin, and the
+# resulting failure surfaces as a plain "Access denied" that looks exactly like
+# a wrong password.
+if [[ "$STRICT_PRIVILEGES" == '1' ]]; then
+  mariadb_query "REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${MIGRATE_DB_USER}'@'%';" >/dev/null 2>&1 || true
+fi
+
+mariadb_query "
+CREATE USER IF NOT EXISTS '${MIGRATE_DB_USER}'@'%' IDENTIFIED VIA mysql_native_password USING PASSWORD('${MIGRATE_DB_PASSWORD}');
+ALTER USER '${MIGRATE_DB_USER}'@'%' IDENTIFIED VIA mysql_native_password USING PASSWORD('${MIGRATE_DB_PASSWORD}');
+GRANT USAGE ON *.* TO '${MIGRATE_DB_USER}'@'%' WITH MAX_USER_CONNECTIONS ${MIGRATE_FRONTEND_MAX};
+GRANT ${MIGRATE_PRIVILEGES} ON \`${DATABASE_NAME}\`.* TO '${MIGRATE_DB_USER}'@'%';
+FLUSH PRIVILEGES;
+" >/dev/null
+
+# --- ProxySQL --------------------------------------------------------------
+proxysql_query "
+INSERT INTO mysql_servers (hostgroup_id,hostname,port,gtid_port,status,weight,compression,max_connections,max_replication_lag,use_ssl,max_latency_ms,comment)
+SELECT ${MIGRATE_HOSTGROUP},prod.hostname,prod.port,prod.gtid_port,prod.status,prod.weight,prod.compression,${MIGRATE_BACKEND_MAX},prod.max_replication_lag,prod.use_ssl,prod.max_latency_ms,'kind robots migration lane'
+  FROM mysql_servers AS prod
+ WHERE prod.hostgroup_id=${PRODUCTION_HOSTGROUP}
+   AND NOT EXISTS (
+     SELECT 1 FROM mysql_servers AS existing
+      WHERE existing.hostgroup_id=${MIGRATE_HOSTGROUP}
+        AND existing.hostname=prod.hostname
+        AND existing.port=prod.port
+   );
+
+UPDATE mysql_servers SET max_connections=${MIGRATE_BACKEND_MAX} WHERE hostgroup_id=${MIGRATE_HOSTGROUP};
+
+UPDATE mysql_users
+   SET password=MYSQL_NATIVE_PASSWORD('${MIGRATE_DB_PASSWORD}'),
+       active=1,
+       use_ssl=${PROD_USE_SSL},
+       default_hostgroup=${MIGRATE_HOSTGROUP},
+       default_schema='${DATABASE_NAME}',
+       schema_locked=1,
+       transaction_persistent=1,
+       fast_forward=0,
+       backend=1,
+       frontend=1,
+       max_connections=${MIGRATE_FRONTEND_MAX}
+ WHERE username='${MIGRATE_DB_USER}';
+
+INSERT INTO mysql_users (
+  username,password,active,use_ssl,default_hostgroup,default_schema,
+  schema_locked,transaction_persistent,fast_forward,backend,frontend,max_connections
+)
+SELECT '${MIGRATE_DB_USER}',MYSQL_NATIVE_PASSWORD('${MIGRATE_DB_PASSWORD}'),1,${PROD_USE_SSL},
+       ${MIGRATE_HOSTGROUP},'${DATABASE_NAME}',1,1,0,1,1,${MIGRATE_FRONTEND_MAX}
+WHERE NOT EXISTS (SELECT 1 FROM mysql_users WHERE username='${MIGRATE_DB_USER}');
+
+LOAD MYSQL SERVERS TO RUNTIME;
+SAVE MYSQL SERVERS TO DISK;
+LOAD MYSQL USERS TO RUNTIME;
+SAVE MYSQL USERS TO DISK;
+" >/dev/null
+
+# --- verify ----------------------------------------------------------------
+runtime_migrate="$(proxysql_query "SELECT default_hostgroup,max_connections FROM runtime_mysql_users WHERE username='${MIGRATE_DB_USER}' AND frontend=1 LIMIT 1;")"
+[[ "$runtime_migrate" == "${MIGRATE_HOSTGROUP}"$'\t'"${MIGRATE_FRONTEND_MAX}" ]] || fail \
+  "Migration runtime user verification failed: ${runtime_migrate:-missing}"
+
+migrate_server_count="$(proxysql_query "SELECT COUNT(*) FROM runtime_mysql_servers WHERE hostgroup_id=${MIGRATE_HOSTGROUP};")"
+[[ "$migrate_server_count" == "$prod_backend_count" ]] || fail \
+  "Migration hostgroup verification failed: expected ${prod_backend_count} backend row(s), got ${migrate_server_count}"
+
+granted_privileges="$(mariadb_query "
+SELECT COUNT(*)
+FROM information_schema.SCHEMA_PRIVILEGES
+WHERE GRANTEE=CONCAT(CHAR(39),'${MIGRATE_DB_USER}',CHAR(39),'@',CHAR(39),'%',CHAR(39))
+  AND TABLE_SCHEMA='${DATABASE_NAME}'
+  AND PRIVILEGE_TYPE IN (${REQUIRED_PRIVILEGES});
+")"
+[[ "$granted_privileges" == "$REQUIRED_PRIVILEGE_COUNT" ]] || fail \
+  "Migration user is missing schema-change privileges on ${DATABASE_NAME}: expected ${REQUIRED_PRIVILEGE_COUNT}, found ${granted_privileges}"
+
+# A migration identity has no business holding global privileges. Scoped
+# schema-change rights are the point; server-wide ones are a different blast
+# radius entirely.
+global_privileges="$(mariadb_query "
+SELECT COUNT(*)
+FROM information_schema.USER_PRIVILEGES
+WHERE GRANTEE=CONCAT(CHAR(39),'${MIGRATE_DB_USER}',CHAR(39),'@',CHAR(39),'%',CHAR(39))
+  AND PRIVILEGE_TYPE <> 'USAGE';
+")"
+[[ "$global_privileges" == '0' ]] || fail \
+  "Migration user unexpectedly holds ${global_privileges} server-wide privilege(s); it should be scoped to ${DATABASE_NAME}"
+
+# Authentication through ProxySQL, without printing the URL or the password.
+docker exec \
+  -e MYSQL_PWD="$MIGRATE_DB_PASSWORD" \
+  -e KR_MIGRATE_USER="$MIGRATE_DB_USER" \
+  -e KR_MIGRATE_DB="$DATABASE_NAME" \
+  "$PROXYSQL_CONTAINER" sh -lc '
+    client="$(command -v mariadb || command -v mysql || true)"
+    [ -n "$client" ] || exit 127
+    "$client" --protocol=tcp -h127.0.0.1 -P6033 -u"$KR_MIGRATE_USER" "$KR_MIGRATE_DB" --batch --skip-column-names -e "SELECT 1;" >/dev/null
+  ' || fail 'Migration authentication through ProxySQL failed'
+
+umask 077
+cat >"$OUTPUT_FILE" <<EOF
+# Kind Robots migration credentials generated $(date -u +%Y-%m-%dT%H:%M:%SZ)
+# Keep this file private. Source it in the deploying shell; it is deliberately
+# NOT part of the application env file (docs/runbooks/migration-credential-boundary.md).
+MIGRATE_DB_USER=${MIGRATE_DB_USER}
+MIGRATE_DB_PASSWORD=${MIGRATE_DB_PASSWORD}
+DATABASE_NAME=${DATABASE_NAME}
+PUBLIC_PROXYSQL_HOST=${PUBLIC_PROXYSQL_HOST}
+PUBLIC_PROXYSQL_PORT=${PUBLIC_PROXYSQL_PORT}
+MIGRATION_DATABASE_URL=${migrate_url}
+EOF
+chmod 600 "$OUTPUT_FILE"
+
+info ''
+info 'Provisioning succeeded.'
+info "Credential handoff file: $OUTPUT_FILE (mode 600; contents not printed)"
+info "Pre-change snapshot: $snapshot_file"
+info "Migration user ${MIGRATE_DB_USER} is isolated to hostgroup ${MIGRATE_HOSTGROUP}."
+info "Schema-change privileges verified on ${DATABASE_NAME}; no server-wide privileges."
+info 'ProxySQL authentication verified.'
+info ''
+info 'Next, from the repository on this host:'
+info "  set -a; . ${OUTPUT_FILE}; set +a"
+info '  docker pull ghcr.io/silasfelinus/kind_robots:latest'
+info '  docker run --rm --network cafepurr --env-file .env -e MIGRATION_DATABASE_URL \'
+info '    ghcr.io/silasfelinus/kind_robots:latest node scripts/prisma-migrate-deploy.mjs'
+info 'Then Force Update the container so the code and the schema match.'


### PR DESCRIPTION
Fallout from today's `User.tokens` incident. The database was three releases behind and the migration couldn't be run because nobody had a working `kindrobot_migrate` password. Recovering it took four rounds of ProxySQL and MariaDB spelunking; most of that was avoidable.

The lane turned out to be **fully provisioned in ProxySQL all along** — hostgroup 30, active, correct schema and SSL. Only the credential had gone missing. `kindrobot_agent` has `provision-agent-db-lane.sh` to create and reconcile it idempotently; this lane had nothing, which is plausibly why it's the one that drifted.

## `scripts/provision-migrate-db-lane.sh`

The sibling of the agent-lane script, and its exact inverse in one respect: the agent lane must **not** be able to change schema, and this one must. Everything else is deliberately the same shape — dry run by default, credential handoff file, verification through ProxySQL, password never printed.

- Routing is **cloned from the live production user's row** (schema, `use_ssl`), not from constants — so the migration lane can't end up pointed at a schema the app doesn't use.
- `LOAD MYSQL USERS TO RUNTIME` **and** `SAVE ... TO DISK`. Without the save, the user vanishes on the next ProxySQL restart, which is one of the ways a lane silently disappears.
- `IDENTIFIED VIA mysql_native_password` — ProxySQL can't authenticate to the backend with MariaDB's newer default, and that failure surfaces as a plain "Access denied" that reads exactly like a wrong password.
- Privileges are **additive by default**. This runs against production, and silently narrowing an already-working migration identity is a worse failure than leaving it broader than needed. `STRICT_PRIVILEGES=1` revokes first when you're deliberately reconciling.
- Verifies afterwards that the schema-change privileges are present *and* that the user holds no server-wide privileges.
- Generates alphanumeric-only passwords — it crosses a URL, SQL, a shell and an env file, and every escaping layer is somewhere to lose an hour.

## Runbook fixes

Both of these actively misled today.

**1. The deploy section printed a placeholder as if it were runnable:**

```
-e MIGRATION_DATABASE_URL='<kindrobot_migrate URL>'   ← and earlier, a literal
mysql://kindrobot_migrate:PASSWORD@HOST:5544/DBNAME
```

It was pasted verbatim more than once. `P1001: Can't reach database server at HOST:5544` is what that looks like. Now a no-placeholder recipe that sources the handoff file and passes `-e MIGRATION_DATABASE_URL` with no `=value`, keeping the credential out of the command line and shell history — plus an explicit note that **no `git pull` is needed**, since the image carries its own `prisma/migrations` and `scripts/`.

**2. "Running a migration by hand" told you to run `npx prisma migrate status` with `DATABASE_SSL_CA_BASE64` set.** That cannot work. `prisma.config.ts` passes the URL straight through:

```ts
datasource: { url: migrationDatabaseUrl || env('DATABASE_URL') }
```

Nothing reads `DATABASE_SSL_CA_BASE64` except `scripts/prisma-migrate-deploy.mjs`, which writes the CA to a temp file and sets `sslcert`/`sslaccept=strict` itself. Against a `use_ssl=1` ProxySQL user, a bare `migrate status` connects without TLS and is rejected as **P1000 "Authentication failed"** — indistinguishable from a wrong password, and it cost an hour today. Replaced with a direct `_prisma_migrations` read, the squashed-baseline trap to check for before applying, and the `sslcert`-augmented command for Prisma's own view.

Also documented the two shell hazards this incident hit: never `source` the application `.env` (unquoted values execute as commands — `set -a; . ./.env` produced `command not found` lines made of secrets), and never put an interactive `read` in a block you paste (it consumes the next pasted line as its input).

`docs/runbooks/README.md` indexed two of five runbooks; now indexes all five.

## Verification

- `bash -n` clean; `prettier@3.9.6` clean on both docs.
- `verifyMigrateOnDeploy`, `verifyMigrationCredentialBoundary`, and `verifyMigrationDriftCheck` all pass.
- The provisioner is **not** executed here — it mutates production ProxySQL and MariaDB, and this environment has neither. Its SQL and control flow mirror `provision-agent-db-lane.sh`, which is in service, and the recovery it encodes was performed by hand today and verified working end to end. It defaults to a dry run for exactly this reason: run `bash scripts/provision-migrate-db-lane.sh` and read the plan before `--apply`.

Two bugs found in my own first draft and fixed before pushing: an `[[ … ]] && x=y` one-liner that would exit under `set -e` when the test failed, and a correlated subquery that relied on ambiguous same-table name resolution.

---
_Generated by [Claude Code](https://claude.ai/code/session_0143kXoZMz1kv9naqHoCCeAH)_