### PR TITLE
feat(kind-economy): read-only creator earnings view (t-009)

### DIFF
--- a/components/pages/creator-earnings-page.vue
+++ b/components/pages/creator-earnings-page.vue
@@ -1,0 +1,300 @@
+<template>
+  <div class="kr-unbound kr-container max-w-3xl p-6 space-y-8">
+    <div
+      v-if="userStore.isGuest"
+      class="rounded-2xl border border-accent/30 bg-(--kr-surface) p-6 text-center space-y-3"
+    >
+      <p class="text-base-content/80">
+        Sign in to see what you've earned from things you've made. ✨
+      </p>
+      <NuxtLink to="/login" class="btn btn-accent rounded-xl">
+        Sign in
+      </NuxtLink>
+    </div>
+
+    <template v-else>
+      <p class="text-sm text-base-content/60">
+        What you've earned when someone spent tokens on something you made — a
+        Bot, Character, Facet, Scenario, Pitch, Art, Pack, Reward, or Dream.
+      </p>
+
+      <div
+        class="flex items-start gap-3 rounded-2xl border border-info/30 bg-info/10 p-4 text-sm text-base-content/75"
+      >
+        <Icon name="kind-icon:info" class="mt-0.5 h-5 w-5 shrink-0 text-info" />
+        <p>
+          This page is read-only. There's no payout button here because
+          <strong
+            >the payout threshold and schedule have not been set yet</strong
+          >
+          — creator payouts are still a design-in-progress
+          (kind-economy&nbsp;t-014) and are gated behind Silas's own review
+          before they go live (t-015). Nothing below is a balance you can
+          withdraw today; it's an honest running total of what you've accrued so
+          far.
+        </p>
+      </div>
+
+      <div
+        v-if="earningsStore.loading && !earningsStore.hasLoaded"
+        class="text-sm text-base-content/50"
+      >
+        Loading…
+      </div>
+
+      <div
+        v-else-if="earningsStore.error"
+        class="rounded-2xl border border-error/40 bg-error/5 p-4 text-sm text-error"
+      >
+        {{ earningsStore.error }}
+      </div>
+
+      <template v-else-if="summary">
+        <section
+          class="rounded-2xl border border-primary/20 bg-base-100 shadow-lg p-6 space-y-3"
+        >
+          <div class="flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <h2 class="text-sm text-base-content/60">Total earned</h2>
+              <div class="text-5xl font-extrabold text-primary tabular-nums">
+                {{ formatUsdCents(summary.totalCents) }}
+              </div>
+              <p class="mt-1 text-xs text-base-content/50">
+                {{ summary.interactionCount }}
+                {{
+                  summary.interactionCount === 1
+                    ? 'interaction'
+                    : 'interactions'
+                }}
+              </p>
+            </div>
+            <button
+              class="btn btn-ghost btn-sm rounded-xl"
+              :disabled="earningsStore.loading"
+              @click="earningsStore.fetch()"
+            >
+              Refresh
+            </button>
+          </div>
+
+          <p
+            v-if="summary.selfAttributedTotalCents > 0"
+            class="rounded-xl bg-base-200/70 px-3 py-2 text-xs text-base-content/60"
+          >
+            Plus
+            <strong>{{
+              formatUsdCents(summary.selfAttributedTotalCents)
+            }}</strong>
+            from
+            {{ summary.selfAttributedCount }}
+            self-generated
+            {{
+              summary.selfAttributedCount === 1 ? 'interaction' : 'interactions'
+            }}
+            (you spending on your own creations) —
+            <strong>not included in the total above</strong>. Whether
+            self-generated earnings count toward a payout is still an open
+            policy question (kind-economy&nbsp;t-021); every one of those
+            interactions is still listed below, just labeled.
+          </p>
+        </section>
+
+        <section
+          v-if="isEmpty"
+          class="flex min-h-48 flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-base-300 bg-base-100 p-6 text-center"
+        >
+          <Icon name="kind-icon:coin" class="h-10 w-10 text-base-content/30" />
+          <p class="text-base font-bold text-base-content">
+            Nothing accrued yet.
+          </p>
+          <p class="max-w-sm text-sm text-base-content/55">
+            Nobody has spent tokens on anything you've made yet. Once they do,
+            your share shows up here — nothing to fix, nothing hidden.
+          </p>
+        </section>
+
+        <template v-else>
+          <section class="space-y-3">
+            <h2
+              class="text-sm font-black uppercase tracking-widest text-base-content/50"
+            >
+              By what you made
+            </h2>
+            <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <article
+                v-for="group in summary.byObject"
+                :key="group.key"
+                class="kr-panel-flat space-y-2 p-4"
+              >
+                <div class="flex items-start justify-between gap-2">
+                  <div class="min-w-0">
+                    <p class="truncate text-sm font-black text-base-content">
+                      {{ group.title }}
+                    </p>
+                    <p class="text-xs text-base-content/50">
+                      {{ sourceTypeLabel(group.sourceType) }}
+                    </p>
+                  </div>
+                  <span class="badge badge-outline shrink-0">
+                    {{ group.count }}
+                    {{ group.count === 1 ? 'interaction' : 'interactions' }}
+                  </span>
+                </div>
+
+                <p class="text-xl font-black text-primary tabular-nums">
+                  {{ formatUsdCents(group.totalCents) }}
+                </p>
+                <p
+                  v-if="group.selfAttributedCents > 0"
+                  class="text-xs text-base-content/50"
+                >
+                  +
+                  {{ formatUsdCents(group.selfAttributedCents) }} self-generated
+                  (not counted above)
+                </p>
+
+                <details class="text-xs">
+                  <summary
+                    class="cursor-pointer font-bold text-base-content/60"
+                  >
+                    Show interactions
+                  </summary>
+                  <ul class="mt-2 divide-y divide-base-content/10">
+                    <li
+                      v-for="interaction in group.rows"
+                      :key="interaction.id"
+                      class="flex items-center justify-between gap-2 py-1.5"
+                    >
+                      <span class="flex min-w-0 items-center gap-1.5">
+                        <span class="text-base-content/55">
+                          {{ formatWhen(interaction.createdAt) }}
+                        </span>
+                        <span
+                          v-if="interaction.isSelfAttribution"
+                          class="badge badge-ghost badge-xs"
+                        >
+                          Self-generated
+                        </span>
+                      </span>
+                      <span
+                        class="font-bold tabular-nums"
+                        :class="
+                          interaction.isSelfAttribution
+                            ? 'text-base-content/50'
+                            : 'text-success'
+                        "
+                      >
+                        {{ formatUsdCents(interaction.creatorShareCents) }}
+                      </span>
+                    </li>
+                  </ul>
+                </details>
+              </article>
+            </div>
+          </section>
+
+          <section class="space-y-3">
+            <h2
+              class="text-sm font-black uppercase tracking-widest text-base-content/50"
+            >
+              By period
+            </h2>
+            <ul
+              class="divide-y divide-base-content/10 overflow-x-auto rounded-xl border border-base-content/10"
+            >
+              <li
+                v-for="bucket in summary.byPeriod"
+                :key="bucket.key"
+                class="flex items-center justify-between gap-3 whitespace-nowrap bg-base-100 px-4 py-3"
+              >
+                <span class="text-sm">
+                  {{ periodLabel(bucket) }}
+                </span>
+                <span class="flex items-center gap-3">
+                  <span
+                    v-if="bucket.selfAttributedCents > 0"
+                    class="text-xs text-base-content/45"
+                  >
+                    +
+                    {{ formatUsdCents(bucket.selfAttributedCents) }}
+                    self-generated
+                  </span>
+                  <span class="font-bold tabular-nums text-success">
+                    {{ formatUsdCents(bucket.totalCents) }}
+                  </span>
+                </span>
+              </li>
+            </ul>
+          </section>
+        </template>
+      </template>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useCreatorEarningsStore } from '@/stores/creatorEarningsStore'
+import { useUserStore } from '@/stores/userStore'
+import { formatUsdCents } from '@/utils/formatCurrency'
+import type { CreatorEarningsPeriodBucket } from '@/stores/creatorEarningsStore'
+
+const earningsStore = useCreatorEarningsStore()
+const userStore = useUserStore()
+
+const summary = computed(() => earningsStore.summary)
+
+const isEmpty = computed(
+  () =>
+    !!summary.value &&
+    summary.value.totalCents === 0 &&
+    summary.value.selfAttributedTotalCents === 0 &&
+    summary.value.byObject.length === 0,
+)
+
+const SOURCE_TYPE_LABELS: Record<string, string> = {
+  BOT: 'Bot',
+  CHARACTER: 'Character',
+  FACET: 'Facet',
+  SCENARIO: 'Scenario',
+  PITCH: 'Pitch',
+  ART: 'Art',
+  PACK: 'Pack',
+  REWARD: 'Reward',
+  DREAM: 'Dream',
+}
+
+function sourceTypeLabel(sourceType: string | null): string {
+  if (!sourceType) return 'Unknown source'
+  return SOURCE_TYPE_LABELS[sourceType] ?? sourceType
+}
+
+function formatWhen(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+function periodLabel(bucket: CreatorEarningsPeriodBucket): string {
+  if (bucket.granularity === 'day') {
+    return new Date(`${bucket.key}T00:00:00Z`).toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      timeZone: 'UTC',
+    })
+  }
+  return new Date(`${bucket.key}-01T00:00:00Z`).toLocaleDateString(undefined, {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
+onMounted(() => {
+  earningsStore.fetch()
+})
+</script>

--- a/content/channels/home/creator-earnings.md
+++ b/content/channels/home/creator-earnings.md
@@ -1,0 +1,17 @@
+---
+contentType: tab
+channelKey: home
+tabKey: creator-earnings
+dashboardKey: user
+dashboardTab: profile
+label: Earnings
+title: Creator earnings
+subtitle: What you have earned so far — read only
+description: See your total creator earnings, broken down by what you made and by period, with every interaction behind them.
+icon: kind-icon:coin
+route: /creator-earnings
+sort: 76
+requiredPermission: authenticated
+---
+
+Creator earnings belong in the user's Home channel, right beside Wallet — both are personal balance surfaces for the signed-in user.

--- a/content/creator-earnings.md
+++ b/content/creator-earnings.md
@@ -1,0 +1,23 @@
+---
+title: 'Creator earnings'
+room: 'Creator earnings'
+subtitle: 'What you have earned so far — read only'
+description: See your total creator earnings, broken down by what you made and by period, with every interaction behind them.
+image: splash/dashboard.png
+icon: kind-icon:coin
+tooltip: What you have earned when someone spent tokens on something you made.
+dottiTip: This is honest, not aspirational — no payout button until the payout mechanism is actually designed and approved.
+amiTip: Every cent you have earned, broken down by what made it and when. Nothing to withdraw yet, but nothing hidden either.
+channelKey: home
+tabKey: creator-earnings
+dashboardKey: user
+dashboardTab: profile
+requiredPermission: authenticated
+loadingMessage: Loading your earnings...
+refreshLabel: Refresh earnings
+backgroundMobile: /api/art/backdrop/creator-earnings-mobile
+backgroundTablet: /api/art/backdrop/creator-earnings-tablet
+backgroundDesktop: /api/art/backdrop/creator-earnings-desktop
+---
+
+:creator-earnings-page

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:mana-resource-split": "tsx utils/scripts/verifyManaResourceSplit.test.ts",
     "test:mana-attribution": "tsx utils/scripts/verifyManaAttribution.test.ts",
     "test:revenue-split": "tsx utils/scripts/verifyRevenueSplit.test.ts",
+    "test:creator-earnings": "tsx utils/scripts/verifyCreatorEarnings.test.ts",
     "test:appmaker-slug-candidate-guard": "tsx utils/scripts/verifyAppmakerSlugCandidateGuard.ts",
     "test:appmaker-fleet-description-guard-selftest": "tsx utils/scripts/verifyAppmakerFleetDescriptionGuard.test.ts",
     "test:appmaker-fleet-description-guard": "tsx utils/scripts/verifyAppmakerFleetDescriptionGuard.ts",

--- a/server/api/economy/creator-earnings.get.ts
+++ b/server/api/economy/creator-earnings.get.ts
@@ -1,0 +1,40 @@
+// /server/api/economy/creator-earnings.get.ts
+//
+// kind-economy/t-009: read-only creator earnings view. Returns the
+// authenticated caller's OWN accrued creator-share earnings from the
+// RevenueSplit ledger (t-008) -- total, by object, by period, and the raw
+// interactions behind them. There is no way to request another user's id
+// here (unlike server/api/karma/[id].get.ts's admin-override pattern) --
+// this route only ever answers for the caller, so there is nothing to
+// authorize beyond "is this a real signed-in user".
+//
+// No payout action lives here or anywhere else yet: kind-economy/t-014
+// ("Design the creator payout mechanism") and t-015 ("GATE: enable real
+// creator payouts") are both still open in the roadmap, so this route
+// never implies anything is withdrawable.
+import { defineEventHandler } from 'h3'
+import { requireApiUser } from '../../utils/authGuard'
+import { errorHandler } from '../../utils/error'
+import { getCreatorEarnings } from '../../utils/creatorEarnings'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireApiUser(event)
+    const data = await getCreatorEarnings(auth.user.id)
+
+    return {
+      success: true,
+      message: 'Creator earnings loaded.',
+      statusCode: 200,
+      data,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      message: handled.message || 'Failed to load creator earnings.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/utils/creatorEarnings.ts
+++ b/server/utils/creatorEarnings.ts
@@ -1,0 +1,388 @@
+// /server/utils/creatorEarnings.ts
+//
+// kind-economy/t-009: read-only creator earnings view. Turns a creator's
+// RevenueSplit rows (t-008's immutable ledger) into a total, a by-object
+// breakdown, a by-period breakdown, and the raw interactions behind them.
+// No payout action lives here or anywhere else -- t-014 (design the payout
+// mechanism) and t-015 (GATE: enable real creator payouts) are both still
+// open, so there is nothing to withdraw yet. See ../api/economy/creator-
+// earnings.get.ts for the one route that calls the database-touching half
+// of this file.
+//
+// SELF-ATTRIBUTION (judgment call, kind-economy/t-021 still undecided):
+// isSelfAttribution rows are real ledger rows and are included in `rows`
+// and in each object's `rows` list, always labeled, but they are NEVER
+// folded into any of the "prominent" totals (summary.totalCents, a period
+// bucket's totalCents, or an object group's totalCents) -- those are the
+// numbers a page puts in large type, and this task's instruction is to
+// pick the conservative reading until t-021 settles the policy. Every
+// self-attributed cent is still visible and still summed, just in the
+// separate selfAttributedTotalCents/selfAttributedCents fields, so nothing
+// is hidden -- it is just not implied to be definitely-payable yet.
+//
+// REVERSAL EXCLUSION: RevenueSplit rows are immutable (see the model doc in
+// prisma/schema.prisma) -- a correction is a NEW row whose OWN reversedById
+// points at the id of the row it corrects. There was no prior application
+// code anywhere in this repo that reads reversedById (grepped clean at the
+// time this was written -- t-008 only added the column), so this is the
+// first concrete implementation of the exclusion, not a mirror of an
+// existing one: a row is "effective" (counted) unless some OTHER row's
+// reversedById names it, in which case the correction row supersedes it and
+// is counted in its place. That lookup is intentionally NOT scoped to one
+// creator -- a correction could in principle reassign creatorUserId to
+// someone else -- so supersededIdsFromCorrections must be computed against
+// every row that names one of the candidate ids, not just this creator's
+// own rows.
+import prisma from './prisma'
+import type { ManaAttributionSource } from '~/prisma/generated/prisma/client'
+
+// ---------------------------------------------------------------------------
+// Pure types + logic -- no prisma, no database, unit-testable in isolation
+// (see utils/scripts/verifyCreatorEarnings.test.ts), same discipline as
+// server/utils/revenueSplit.ts and server/utils/manaAttribution.ts.
+// ---------------------------------------------------------------------------
+
+export type CreatorEarningsRow = {
+  id: number
+  createdAt: Date
+  creatorShareCents: number
+  isSelfAttribution: boolean
+  sourceType: string | null
+  sourceId: number | null
+}
+
+export type CreatorEarningsObjectGroup = {
+  key: string
+  sourceType: string | null
+  sourceId: number | null
+  totalCents: number
+  selfAttributedCents: number
+  count: number
+  rows: CreatorEarningsRow[]
+}
+
+export type CreatorEarningsPeriodBucket = {
+  key: string
+  granularity: 'day' | 'month'
+  totalCents: number
+  selfAttributedCents: number
+  count: number
+}
+
+export type CreatorEarningsSummary = {
+  totalCents: number
+  selfAttributedTotalCents: number
+  interactionCount: number
+  selfAttributedCount: number
+  byObject: CreatorEarningsObjectGroup[]
+  byPeriod: CreatorEarningsPeriodBucket[]
+}
+
+/**
+ * Given the ids that some OTHER row's reversedById names, return the set of
+ * ids that are therefore superseded (a correction exists for them). Not
+ * scoped to any one creator -- pass every row in the relevant candidate
+ * pool's correction lookup, not just one creator's own rows.
+ */
+export function supersededIdsFromCorrections(
+  corrections: Array<{ reversedById: number | null }>,
+): Set<number> {
+  const ids = new Set<number>()
+  for (const correction of corrections) {
+    if (correction.reversedById != null) ids.add(correction.reversedById)
+  }
+  return ids
+}
+
+/** Drop any row whose id has been superseded by a later correction row. */
+export function excludeSupersededRows<T extends { id: number }>(
+  rows: T[],
+  supersededIds: ReadonlySet<number>,
+): T[] {
+  return rows.filter((row) => !supersededIds.has(row.id))
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const RECENT_WINDOW_DAYS = 30
+
+/**
+ * PERIOD BUCKETING POLICY (documented judgment call -- no prior convention
+ * existed in this codebase to mirror; the other "stats" routes here bucket
+ * by a pre-stored year/month column, not a derived timestamp window). Daily
+ * buckets for the last 30 days, monthly buckets before that -- recent
+ * activity is where a creator wants day-level resolution, older activity
+ * only needs a coarser rollup.
+ */
+export function bucketKeyForDate(
+  date: Date,
+  now: Date,
+): { key: string; granularity: 'day' | 'month' } {
+  const cutoff = new Date(now.getTime() - RECENT_WINDOW_DAYS * DAY_MS)
+  if (date.getTime() >= cutoff.getTime()) {
+    return { key: date.toISOString().slice(0, 10), granularity: 'day' }
+  }
+  return { key: date.toISOString().slice(0, 7), granularity: 'month' }
+}
+
+function objectGroupKey(
+  sourceType: string | null,
+  sourceId: number | null,
+): string {
+  return `${sourceType ?? 'UNKNOWN'}:${sourceId ?? 'none'}`
+}
+
+/**
+ * Pure summarizer: takes the already-effective (reversal-excluded) rows for
+ * one creator and produces the total/by-object/by-period shape a page
+ * renders. `now` is injectable so the 30-day window is deterministic under
+ * test.
+ */
+export function summarizeCreatorEarnings(
+  rows: CreatorEarningsRow[],
+  now: Date = new Date(),
+): CreatorEarningsSummary {
+  const sorted = [...rows].sort(
+    (a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
+  )
+
+  let totalCents = 0
+  let selfAttributedTotalCents = 0
+  let interactionCount = 0
+  let selfAttributedCount = 0
+
+  const objectMap = new Map<string, CreatorEarningsObjectGroup>()
+  const periodMap = new Map<string, CreatorEarningsPeriodBucket>()
+
+  for (const row of sorted) {
+    const objKey = objectGroupKey(row.sourceType, row.sourceId)
+    let objGroup = objectMap.get(objKey)
+    if (!objGroup) {
+      objGroup = {
+        key: objKey,
+        sourceType: row.sourceType,
+        sourceId: row.sourceId,
+        totalCents: 0,
+        selfAttributedCents: 0,
+        count: 0,
+        rows: [],
+      }
+      objectMap.set(objKey, objGroup)
+    }
+    objGroup.rows.push(row)
+
+    const { key: periodKey, granularity } = bucketKeyForDate(row.createdAt, now)
+    let periodGroup = periodMap.get(periodKey)
+    if (!periodGroup) {
+      periodGroup = {
+        key: periodKey,
+        granularity,
+        totalCents: 0,
+        selfAttributedCents: 0,
+        count: 0,
+      }
+      periodMap.set(periodKey, periodGroup)
+    }
+
+    if (row.isSelfAttribution) {
+      selfAttributedTotalCents += row.creatorShareCents
+      selfAttributedCount += 1
+      objGroup.selfAttributedCents += row.creatorShareCents
+      periodGroup.selfAttributedCents += row.creatorShareCents
+    } else {
+      totalCents += row.creatorShareCents
+      interactionCount += 1
+      objGroup.totalCents += row.creatorShareCents
+      objGroup.count += 1
+      periodGroup.totalCents += row.creatorShareCents
+      periodGroup.count += 1
+    }
+  }
+
+  const byObject = [...objectMap.values()].sort(
+    (a, b) => b.totalCents - a.totalCents,
+  )
+  const byPeriod = [...periodMap.values()].sort((a, b) =>
+    a.key < b.key ? 1 : a.key > b.key ? -1 : 0,
+  )
+
+  return {
+    totalCents,
+    selfAttributedTotalCents,
+    interactionCount,
+    selfAttributedCount,
+    byObject,
+    byPeriod,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Database-touching half. Not covered by the pure unit test (no live
+// database in the verification sandbox) -- see the PR description for what
+// was and was not exercised.
+// ---------------------------------------------------------------------------
+
+export type CreatorEarningsObjectGroupWithTitle = CreatorEarningsObjectGroup & {
+  title: string
+}
+
+export type CreatorEarningsData = {
+  summary: Omit<CreatorEarningsSummary, 'byObject'> & {
+    byObject: CreatorEarningsObjectGroupWithTitle[]
+  }
+  rows: CreatorEarningsRow[]
+}
+
+// One title lookup per ManaAttributionSource value, mirroring the shape of
+// manaAttribution.ts's OWNER_LOOKUP but resolving a display title instead of
+// an owning user id. Kept here rather than added to manaAttribution.ts since
+// that module's contract is specifically "resolve the owner", not "resolve a
+// title" -- a second concern, not a special case of the first.
+const TITLE_LOOKUP: Record<
+  ManaAttributionSource,
+  (id: number) => Promise<string | null>
+> = {
+  BOT: async (id) =>
+    (await prisma.bot.findUnique({ where: { id }, select: { name: true } }))
+      ?.name ?? null,
+  CHARACTER: async (id) =>
+    (
+      await prisma.character.findUnique({
+        where: { id },
+        select: { name: true },
+      })
+    )?.name ?? null,
+  FACET: async (id) =>
+    (
+      await prisma.facet.findUnique({
+        where: { id },
+        select: { title: true },
+      })
+    )?.title ?? null,
+  SCENARIO: async (id) =>
+    (
+      await prisma.scenario.findUnique({
+        where: { id },
+        select: { title: true },
+      })
+    )?.title ?? null,
+  PITCH: async (id) =>
+    (
+      await prisma.pitchSheet.findUnique({
+        where: { id },
+        select: { title: true },
+      })
+    )?.title ?? null,
+  ART: async (id) => {
+    const row = await prisma.artImage.findUnique({
+      where: { id },
+      select: { fileName: true, promptString: true },
+    })
+    if (!row) return null
+    if (row.fileName) return row.fileName
+    if (row.promptString) return row.promptString.slice(0, 60)
+    return null
+  },
+  PACK: async (id) =>
+    (await prisma.pack.findUnique({ where: { id }, select: { title: true } }))
+      ?.title ?? null,
+  REWARD: async (id) =>
+    (await prisma.reward.findUnique({ where: { id }, select: { name: true } }))
+      ?.name ?? null,
+  DREAM: async (id) =>
+    (await prisma.dream.findUnique({ where: { id }, select: { title: true } }))
+      ?.title ?? null,
+}
+
+/**
+ * Resolve a human-readable title for a (sourceType, sourceId) pair. Never
+ * throws -- a lookup failure or a deleted object degrades to a labeled
+ * fallback string, same "enrich, never gate" discipline as
+ * resolveManaAttribution in manaAttribution.ts.
+ */
+export async function resolveObjectTitle(
+  sourceType: string | null,
+  sourceId: number | null,
+): Promise<string> {
+  if (!sourceType || sourceId == null) return 'Unknown source'
+
+  const lookup = TITLE_LOOKUP[sourceType as ManaAttributionSource]
+  if (!lookup) return `${sourceType} #${sourceId}`
+
+  try {
+    const title = await lookup(sourceId)
+    return title || `${sourceType} #${sourceId} (deleted)`
+  } catch (error) {
+    console.warn(
+      '[creatorEarnings] failed to resolve object title',
+      sourceType,
+      sourceId,
+      error,
+    )
+    return `${sourceType} #${sourceId}`
+  }
+}
+
+/**
+ * The one entry point server/api/economy/creator-earnings.get.ts calls.
+ * Fetches this creator's RevenueSplit rows, excludes any that a later
+ * correction has superseded, summarizes them, and resolves a display title
+ * for every distinct object. A creator with no rows gets an honest,
+ * all-zero summary and empty arrays -- never an error.
+ */
+export async function getCreatorEarnings(
+  creatorUserId: number,
+  now: Date = new Date(),
+): Promise<CreatorEarningsData> {
+  const candidateRows = await prisma.revenueSplit.findMany({
+    where: { creatorUserId },
+    select: {
+      id: true,
+      createdAt: true,
+      creatorShareCents: true,
+      isSelfAttribution: true,
+      reversedById: true,
+      ManaTransaction: { select: { sourceType: true, sourceId: true } },
+    },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  if (candidateRows.length === 0) {
+    const emptySummary = summarizeCreatorEarnings([], now)
+    return { summary: { ...emptySummary, byObject: [] }, rows: [] }
+  }
+
+  // Deliberately unscoped by creatorUserId -- see the file-level comment on
+  // why a correction naming one of these ids could in principle belong to
+  // anyone.
+  const corrections = await prisma.revenueSplit.findMany({
+    where: { reversedById: { in: candidateRows.map((row) => row.id) } },
+    select: { reversedById: true },
+  })
+  const supersededIds = supersededIdsFromCorrections(corrections)
+
+  const effectiveRows: CreatorEarningsRow[] = excludeSupersededRows(
+    candidateRows,
+    supersededIds,
+  ).map((row) => ({
+    id: row.id,
+    createdAt: row.createdAt,
+    creatorShareCents: row.creatorShareCents,
+    isSelfAttribution: row.isSelfAttribution,
+    sourceType: row.ManaTransaction?.sourceType ?? null,
+    sourceId: row.ManaTransaction?.sourceId ?? null,
+  }))
+
+  const summary = summarizeCreatorEarnings(effectiveRows, now)
+
+  const byObjectWithTitles = await Promise.all(
+    summary.byObject.map(async (group) => ({
+      ...group,
+      title: await resolveObjectTitle(group.sourceType, group.sourceId),
+    })),
+  )
+
+  return {
+    summary: { ...summary, byObject: byObjectWithTitles },
+    rows: effectiveRows,
+  }
+}

--- a/stores/creatorEarningsStore.ts
+++ b/stores/creatorEarningsStore.ts
@@ -1,0 +1,98 @@
+// /stores/creatorEarningsStore.ts
+//
+// kind-economy/t-009: owns the one read-only fetch behind the creator
+// earnings page (components/pages/creator-earnings-page.vue). Same shape as
+// karmaStore.ts -- components never call APIs directly, per AGENTS.md.
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { useUserStore } from '@/stores/userStore'
+import { performFetch, handleError } from './utils'
+
+export type CreatorEarningsInteraction = {
+  id: number
+  createdAt: string
+  creatorShareCents: number
+  isSelfAttribution: boolean
+  sourceType: string | null
+  sourceId: number | null
+}
+
+export type CreatorEarningsObjectGroup = {
+  key: string
+  sourceType: string | null
+  sourceId: number | null
+  title: string
+  totalCents: number
+  selfAttributedCents: number
+  count: number
+  rows: CreatorEarningsInteraction[]
+}
+
+export type CreatorEarningsPeriodBucket = {
+  key: string
+  granularity: 'day' | 'month'
+  totalCents: number
+  selfAttributedCents: number
+  count: number
+}
+
+export type CreatorEarningsSummary = {
+  totalCents: number
+  selfAttributedTotalCents: number
+  interactionCount: number
+  selfAttributedCount: number
+  byObject: CreatorEarningsObjectGroup[]
+  byPeriod: CreatorEarningsPeriodBucket[]
+}
+
+export type CreatorEarningsData = {
+  summary: CreatorEarningsSummary
+  rows: CreatorEarningsInteraction[]
+}
+
+export const useCreatorEarningsStore = defineStore(
+  'creatorEarningsStore',
+  () => {
+    const userStore = useUserStore()
+
+    const data = ref<CreatorEarningsData | null>(null)
+    const loading = ref(false)
+    const error = ref('')
+
+    const isGuest = computed(() => userStore.isGuest)
+    const hasLoaded = computed(() => data.value !== null)
+    const summary = computed(() => data.value?.summary ?? null)
+
+    async function fetch() {
+      if (userStore.isGuest || !userStore.user?.id) return
+      loading.value = true
+      error.value = ''
+      try {
+        const res = await performFetch<CreatorEarningsData>(
+          '/api/economy/creator-earnings',
+        )
+
+        if (res.success && res.data) {
+          data.value = res.data
+        } else {
+          error.value = res.message || 'Failed to load creator earnings.'
+        }
+      } catch (err) {
+        handleError(err, 'creatorEarningsStore.fetch')
+        error.value = 'Failed to load creator earnings.'
+      } finally {
+        loading.value = false
+      }
+    }
+
+    return {
+      data,
+      summary,
+      loading,
+      error,
+      isGuest,
+      hasLoaded,
+      fetch,
+    }
+  },
+)

--- a/stores/seeds/pageBackdropArtPrompts.ts
+++ b/stores/seeds/pageBackdropArtPrompts.ts
@@ -544,6 +544,12 @@ const PAGES: PageSeed[] = [
       'A counting house of brass scales, coin trays and a ledger under a green-shaded lamp, warm wood. Trustworthy and precise.',
   },
   {
+    page: 'creator-earnings',
+    title: 'Creator Earnings — The Tally Loft',
+    scene:
+      'A tally loft above a workshop floor: shelves of small labelled dishes each holding a handful of glowing tokens, an open ledger book catching lamplight on a slanted desk, taut strings running up from a few dishes to miniature models — a little robot, a book, a mask, a paintbrush — suspended from the rafters overhead. Warm brass fittings, motes of light drifting up from the tokens. Precise and quietly rewarding — a place where what you made is being counted, not yet paid out.',
+  },
+  {
     page: 'watchlist',
     title: 'Watchlist — The Screening Room',
     scene:

--- a/utils/formatCurrency.ts
+++ b/utils/formatCurrency.ts
@@ -1,0 +1,17 @@
+// /utils/formatCurrency.ts
+//
+// No shared cents-to-dollars formatter existed anywhere in this repo (every
+// call site that formats money hand-rolls its own toFixed(2)) -- added here,
+// not in a store or component, because it is stateless and used by both a
+// store-owned page (kind-economy/t-009's creator earnings view) and any
+// future money-adjacent surface. Integer cents in, a "$X.XX" string out --
+// never floats, matching server/utils/revenueSplit.ts's integer-cents-only
+// discipline.
+export function formatUsdCents(cents: number): string {
+  if (!Number.isFinite(cents)) return '$0.00'
+  const sign = cents < 0 ? '-' : ''
+  const abs = Math.abs(cents)
+  const dollars = Math.floor(abs / 100)
+  const remainder = String(abs % 100).padStart(2, '0')
+  return `${sign}$${dollars.toLocaleString('en-US')}.${remainder}`
+}

--- a/utils/scripts/verifyCreatorEarnings.test.ts
+++ b/utils/scripts/verifyCreatorEarnings.test.ts
@@ -1,0 +1,214 @@
+// /utils/scripts/verifyCreatorEarnings.test.ts
+//
+// Regression test for kind-economy/t-009 (the read-only creator earnings
+// view). Exercises server/utils/creatorEarnings.ts's pure calculation core
+// -- no prisma, no database, no Nuxt/H3 runtime -- same discipline as
+// utils/scripts/verifyRevenueSplit.test.ts and
+// utils/scripts/verifyManaAttribution.test.ts.
+//
+// What this does NOT cover (documented, not silently skipped): the actual
+// prisma.revenueSplit.findMany() calls inside getCreatorEarnings() and the
+// TITLE_LOOKUP prisma queries inside resolveObjectTitle() require a real
+// database connection and are not exercised here -- this sandbox has
+// neither a live MariaDB instance nor Docker available to start one.
+import assert from 'node:assert/strict'
+
+import {
+  bucketKeyForDate,
+  excludeSupersededRows,
+  summarizeCreatorEarnings,
+  supersededIdsFromCorrections,
+  type CreatorEarningsRow,
+} from '../../server/utils/creatorEarnings.js'
+
+function row(
+  overrides: Partial<CreatorEarningsRow> & { id: number },
+): CreatorEarningsRow {
+  return {
+    id: overrides.id,
+    createdAt: overrides.createdAt ?? new Date('2026-08-01T00:00:00Z'),
+    creatorShareCents: overrides.creatorShareCents ?? 0,
+    isSelfAttribution: overrides.isSelfAttribution ?? false,
+    sourceType: overrides.sourceType ?? 'BOT',
+    sourceId: overrides.sourceId ?? 1,
+  }
+}
+
+// --- supersededIdsFromCorrections / excludeSupersededRows -----------------
+
+{
+  const supersededIds = supersededIdsFromCorrections([
+    { reversedById: 1 },
+    { reversedById: null },
+    { reversedById: 3 },
+  ])
+  assert.deepEqual([...supersededIds].sort(), [1, 3])
+}
+
+{
+  // A row whose id is named by another row's reversedById is dropped; the
+  // correction row itself (a normal row with its own id) is kept.
+  const rows = [{ id: 1 }, { id: 2 }, { id: 3 }]
+  const superseded = supersededIdsFromCorrections([{ reversedById: 2 }])
+  const effective = excludeSupersededRows(rows, superseded)
+  assert.deepEqual(
+    effective.map((r) => r.id),
+    [1, 3],
+    'row 2 was corrected (some row named it via reversedById) and must be excluded; 1 and 3 were never corrected',
+  )
+}
+
+{
+  // No corrections at all -- everything stays.
+  const rows = [{ id: 1 }, { id: 2 }]
+  const effective = excludeSupersededRows(
+    rows,
+    supersededIdsFromCorrections([]),
+  )
+  assert.deepEqual(
+    effective.map((r) => r.id),
+    [1, 2],
+  )
+}
+
+console.log(
+  '✅ supersededIdsFromCorrections / excludeSupersededRows: reversal exclusion correct',
+)
+
+// --- bucketKeyForDate -------------------------------------------------------
+
+{
+  const now = new Date('2026-08-19T12:00:00Z')
+
+  const today = bucketKeyForDate(new Date('2026-08-19T01:00:00Z'), now)
+  assert.deepEqual(today, { key: '2026-08-19', granularity: 'day' })
+
+  const twentyNineDaysAgo = bucketKeyForDate(
+    new Date('2026-07-21T12:00:00Z'),
+    now,
+  )
+  assert.equal(
+    twentyNineDaysAgo.granularity,
+    'day',
+    'within the 30-day window should still be a daily bucket',
+  )
+
+  const thirtyOneDaysAgo = bucketKeyForDate(
+    new Date('2026-07-19T00:00:00Z'),
+    now,
+  )
+  assert.deepEqual(thirtyOneDaysAgo, { key: '2026-07', granularity: 'month' })
+}
+
+console.log(
+  '✅ bucketKeyForDate: last-30-days daily / older monthly boundary correct',
+)
+
+// --- summarizeCreatorEarnings: totals, self-attribution exclusion ----------
+
+{
+  const now = new Date('2026-08-19T12:00:00Z')
+  const rows: CreatorEarningsRow[] = [
+    row({
+      id: 1,
+      creatorShareCents: 100,
+      isSelfAttribution: false,
+      sourceType: 'BOT',
+      sourceId: 1,
+      createdAt: new Date('2026-08-18T00:00:00Z'),
+    }),
+    row({
+      id: 2,
+      creatorShareCents: 50,
+      isSelfAttribution: true,
+      sourceType: 'BOT',
+      sourceId: 1,
+      createdAt: new Date('2026-08-18T00:00:00Z'),
+    }),
+    row({
+      id: 3,
+      creatorShareCents: 30,
+      isSelfAttribution: false,
+      sourceType: 'CHARACTER',
+      sourceId: 2,
+      createdAt: new Date('2026-06-01T00:00:00Z'),
+    }),
+  ]
+
+  const summary = summarizeCreatorEarnings(rows, now)
+
+  assert.equal(
+    summary.totalCents,
+    130,
+    'the prominent total must be non-self rows only (100 + 30), never including the 50-cent self-attributed row',
+  )
+  assert.equal(summary.selfAttributedTotalCents, 50)
+  assert.equal(summary.interactionCount, 2)
+  assert.equal(summary.selfAttributedCount, 1)
+
+  assert.equal(summary.byObject.length, 2)
+  const botGroup = summary.byObject.find((g) => g.key === 'BOT:1')!
+  assert.equal(
+    botGroup.totalCents,
+    100,
+    'the BOT object group total must exclude its own self-attributed row',
+  )
+  assert.equal(botGroup.selfAttributedCents, 50)
+  assert.equal(
+    botGroup.rows.length,
+    2,
+    'the raw interaction list for an object must include the self-attributed row too, just not counted into the prominent total',
+  )
+
+  const characterGroup = summary.byObject.find((g) => g.key === 'CHARACTER:2')!
+  assert.equal(characterGroup.totalCents, 30)
+
+  // byObject sorted descending by prominent total.
+  assert.deepEqual(
+    summary.byObject.map((g) => g.key),
+    ['BOT:1', 'CHARACTER:2'],
+  )
+
+  assert.equal(
+    summary.byPeriod.length,
+    2,
+    'one bucket for the recent daily row, one for the older monthly row',
+  )
+  const dailyBucket = summary.byPeriod.find((b) => b.granularity === 'day')!
+  assert.equal(dailyBucket.key, '2026-08-18')
+  assert.equal(dailyBucket.totalCents, 100)
+  assert.equal(dailyBucket.selfAttributedCents, 50)
+  const monthlyBucket = summary.byPeriod.find((b) => b.granularity === 'month')!
+  assert.equal(monthlyBucket.key, '2026-06')
+  assert.equal(monthlyBucket.totalCents, 30)
+
+  // byPeriod sorted descending (most recent first).
+  assert.deepEqual(
+    summary.byPeriod.map((b) => b.key),
+    ['2026-08-18', '2026-06'],
+  )
+}
+
+console.log(
+  '✅ summarizeCreatorEarnings: totals, self-attribution exclusion from prominent totals, by-object and by-period grouping all correct',
+)
+
+// --- summarizeCreatorEarnings: zero-earnings creator ------------------------
+
+{
+  const summary = summarizeCreatorEarnings([], new Date('2026-08-19T00:00:00Z'))
+  assert.deepEqual(summary, {
+    totalCents: 0,
+    selfAttributedTotalCents: 0,
+    interactionCount: 0,
+    selfAttributedCount: 0,
+    byObject: [],
+    byPeriod: [],
+  })
+}
+
+console.log(
+  '✅ summarizeCreatorEarnings: a creator with no rows gets an honest all-zero summary, not an error',
+)
+
+console.log('✅ verifyCreatorEarnings: all assertions passed')


### PR DESCRIPTION
### Task
kind-economy/t-009: Creator earnings view — read-only, no payouts (kind: software)

## What

A creator-facing page showing what they have accrued from the `RevenueSplit` ledger (t-008, merged): total, by what they made, by period, and the individual interactions behind each number. Read-only — no payout button, no withdrawal affordance anywhere, and the page states plainly that the payout threshold and schedule have not been set yet, rather than inventing one.

### What changed / what I produced

- **`server/utils/creatorEarnings.ts`** (new) — pure, dependency-free summarizer (`summarizeCreatorEarnings`, `bucketKeyForDate`, `supersededIdsFromCorrections`, `excludeSupersededRows`) plus the prisma-backed `getCreatorEarnings()` / `resolveObjectTitle()` wrapper that the route calls.
- **`server/api/economy/creator-earnings.get.ts`** (new) — `requireApiUser`-gated GET route. No id parameter accepted at all — it only ever answers for the caller, unlike `server/api/karma/[id].get.ts`'s admin-override pattern, since there's no legitimate reason for one user to read another's earnings breakdown here.
- **`stores/creatorEarningsStore.ts`** (new) — owns the fetch (components never call APIs directly, per AGENTS.md), same shape as `karmaStore.ts`.
- **`components/pages/creator-earnings-page.vue`** (new) — the page itself, structurally mirroring `components/pages/wallet-page.vue` (root `kr-unbound kr-container`, `kr-panel-flat` cards, no page-owned `<h1>` — the shell renders the title).
- **`content/creator-earnings.md`** + **`content/channels/home/creator-earnings.md`** (new) — registers the page as a tab in the *existing* `home`/`user`/`profile` dashboard channel, right beside Wallet (`sort: 76`, Wallet is 75) — no new top-level route, per AGENTS.md's "prefer an existing dashboard channel" guidance.
- **`utils/formatCurrency.ts`** (new) — `formatUsdCents()`. No shared cents→dollars formatter existed anywhere in the repo before this.
- **`utils/scripts/verifyCreatorEarnings.test.ts`** (new) — DB-free unit test for the pure summarizer, same discipline as `verifyRevenueSplit.test.ts`. Registered as `npm run test:creator-earnings`.
- **`package.json`** — the one new test script line.

## Judgment calls (flagging for the Reviewer, per this repo's convention for money-adjacent features)

1. **Self-attribution (t-021 still undecided)**: `isSelfAttribution` rows are real ledger rows — they're always visible, always labeled "Self-generated," and always summed into their own `selfAttributedTotalCents`/`selfAttributedCents` fields — but they are **never** folded into any prominent total (the headline total, a period bucket's total, or an object group's total). Picked the conservative reading the task asked for. Nothing is hidden; it's just not implied to be definitely-payable until t-021 settles.
2. **Reversal exclusion (`reversedById`)**: I grepped this repo clean before writing this — there is **no prior application code anywhere** that reads `RevenueSplit.reversedById` or `ManaTransaction.reversedById` (t-008 only added the column; nothing consumes it yet). So this is the first concrete implementation, built directly from the schema's documented semantics: a correction row's *own* `reversedById` names the id of the row it supersedes. `supersededIdsFromCorrections()` is deliberately **not** scoped to one creator — a correction could in principle reassign `creatorUserId` to someone else — so it queries every row that names one of the candidate ids, not just this creator's own rows. Worth a second pair of eyes since there's no existing precedent to compare against.
3. **Period bucketing**: daily buckets for the last 30 days, monthly before that. No existing dashboard in this repo derives buckets from a raw timestamp — the two closest precedents (`media-entries/stats.get.ts`, `art/queue/stats.get.ts`) both group by a pre-stored `year`/`month` column, not a computed window. Picked a sensible default per the task's own suggestion and documented it in the code; easy one-line change if a different window is preferred.
4. **Payout threshold/timeline copy**: verified against `projects/kind-economy/roadmap.yaml` — t-013 and t-015 are both `gate_human: true`/`needs-human`/`approved_by_human: false`, and t-014 ("Design the creator payout mechanism") is still `status: ready`, not done. So there genuinely is no threshold or timeline to state — the page says so explicitly ("the payout threshold and schedule have not been set yet... gated behind Silas's own review before they go live") instead of inventing a number.
5. **`User.earnedTokens`** exists in the schema (t-006) but is not wired up by any crediting logic yet — confirmed by grepping `manaGate.ts`'s `commit()`: it writes a `RevenueSplit` row but never touches `earnedTokens`. So this page deliberately queries the `RevenueSplit` ledger directly (sum of `creatorShareCents`) rather than that column, matching the task's own instruction for what counts as "accrued."

## How I verified

- ✅ `node --max-old-space-size=8192 ./node_modules/vue-tsc/bin/vue-tsc.js --noEmit -p tsconfig.json` — clean, exit 0, full repo.
- ✅ `npx eslint` on every new/touched file — clean.
- ✅ `npx prettier --check` on every new/touched file — clean.
- ✅ `npm run test:creator-earnings` (new) — all assertions pass: reversal exclusion, self-attribution split, by-object/by-period grouping, zero-earnings honesty.
- ✅ `npm run test:revenue-split` and `npm run test:mana-attribution` — no regression in the neighboring t-007/t-008 tests.
- ✅ `npx tsx utils/scripts/verifyLayoutContract.ts` — caught and fixed one real violation (the page rendered its own `<h1>`; the shell already owns the page title) before landing; holds clean now with zero new violations.
- ✅ Hand-validated both new content frontmatter files against `content.config.ts`'s actual zod schemas (`pageSchema`/`channelSchema`) in a throwaway script — both parse successfully.
- ❌ **Not verified** (no live DB, no browser in this sandbox): the actual `prisma.revenueSplit.findMany()` query against real data, and live responsive rendering at phone/tablet/desktop widths. I verified responsiveness only via CSS/breakpoint reasoning — `grid-cols-1 sm:grid-cols-2` for the by-object cards, a single-column stacking list for by-period, `<details>` for the raw interaction list so a long history doesn't force scroll depth on mobile — and by structurally mirroring `wallet-page.vue`, which is a live, currently-shipped page using the identical `kr-unbound kr-container` + `kr-panel-flat` pattern at the same `max-w-3xl` width. No screenshots exist from this sandbox; the `responsive-layout-audit` workflow can confirm real geometry post-merge+deploy per AGENTS.md.

### Stakes
reversible

### Flags for Reviewer

- This touches money-adjacent UI (what a creator is told they've earned), so **I'm leaving this PR unmerged even though the roadmap task carries no `gate_human` flag** — same judgment call the t-008 PR (#1962) made for its migration. Please give the reversal-exclusion logic in `creatorEarnings.ts` in particular a careful read, since (per point 2 above) there's no existing application-code precedent for it to compare against — I built it straight from the schema's doc comments, not from a working example.
- I did not touch `components/user/user-dashboard.vue`. I considered adding a 4th tile to its existing karma/mana/achievements 3-column grid, but decided the tab-registration route (identical mechanism to how Wallet is already discoverable) was lower-risk than changing an already-shipped, already-tested responsive grid's column count. Happy to add the dashboard tile too if you'd prefer tighter discoverability.
- Object titles for `ART` sources fall back to a truncated `promptString` (or `fileName`) since `ArtImage` has no title/name field — worth checking that reads sensibly once there's real data.

### Kaizen suggestion
`server/utils/creatorEarnings.ts`'s reversal-exclusion query (`corrections = revenueSplit.findMany({ where: { reversedById: { in: [...] } } })`) has no supporting index on `reversedById` — fine at today's scale, but worth a `@@index([reversedById])` on `RevenueSplit` once real correction volume exists, so this doesn't become a full-table scan on the ledger's most privacy/money-sensitive table.

### Notes for reviewer
No live database or browser available in this sandbox — see "How I verified" above for the precise line between what was checked and what was reasoned about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxmsnPFyRMtbaJHGuinXHa

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxmsnPFyRMtbaJHGuinXHa)_