### PR TITLE
fix(model-builder): re-validate content-stage editability against a fresh read (model-builder/t-029)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -425,6 +425,12 @@ jobs:
       - name: Model Builder PATCH stale stage-status guard contract
         run: npm run test:model-builder-patch-stale-stage-status-guard
 
+      - name: Model Builder content-stage freshness guard checker self-test
+        run: npm run test:model-builder-content-stage-freshness-guard-selftest
+
+      - name: Model Builder content-stage freshness guard contract
+        run: npm run test:model-builder-content-stage-freshness-guard
+
       - name: Model Builder resetAll guard checker self-test
         run: npm run test:model-builder-reset-all-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -224,6 +224,8 @@
     "test:model-builder-commit-stale-snapshot-guard": "tsx utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.ts",
     "test:model-builder-patch-stale-stage-status-guard-selftest": "tsx utils/scripts/verifyModelBuilderPatchStaleStageStatusGuard.test.ts",
     "test:model-builder-patch-stale-stage-status-guard": "tsx utils/scripts/verifyModelBuilderPatchStaleStageStatusGuard.ts",
+    "test:model-builder-content-stage-freshness-guard-selftest": "tsx utils/scripts/verifyModelBuilderContentStageFreshnessGuard.test.ts",
+    "test:model-builder-content-stage-freshness-guard": "tsx utils/scripts/verifyModelBuilderContentStageFreshnessGuard.ts",
     "test:model-builder-reset-all-guard-selftest": "tsx utils/scripts/verifyModelBuilderResetAllGuard.test.ts",
     "test:model-builder-reset-all-guard": "tsx utils/scripts/verifyModelBuilderResetAllGuard.ts",
     "test:model-builder-reset-run-guard-selftest": "tsx utils/scripts/verifyModelBuilderResetRunGuard.test.ts",

--- a/server/api/model-builder/items/[id].patch.ts
+++ b/server/api/model-builder/items/[id].patch.ts
@@ -5,6 +5,7 @@ import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
 import {
+  assertContentStageEditable,
   assertRunAccess,
   assertRunWritable,
   getItemId,
@@ -45,18 +46,14 @@ export default defineEventHandler(async (event) => {
     if (body.artImageId !== undefined) {
       await assertArtImageAttachable(body.artImageId, auth.user.id, auth.isAdmin)
     }
-    const { data, revision, stageStatusChanges } = prepareItemUpdate(
-      existing,
-      body,
-      auth.user.username ?? String(auth.user.id),
-    )
+    const { data, revision, stageStatusChanges, contentStageChecks } =
+      prepareItemUpdate(
+        existing,
+        body,
+        auth.user.username ?? String(auth.user.id),
+      )
 
     const item = await prisma.$transaction(async (tx) => {
-      if (revision) {
-        await tx.modelBuildRevision.create({
-          data: { itemId: id, ...revision },
-        })
-      }
       // Re-read stageStatuses immediately before the write rather than
       // trusting the request-start `existing` snapshot: another request
       // (a concurrent single-item PATCH, batch PATCH, or commit) can change
@@ -64,11 +61,32 @@ export default defineEventHandler(async (event) => {
       // stageStatusChanges only carries the keys THIS request actually
       // intends to change (see prepareItemUpdate/diffStageStatusChanges),
       // merged onto whatever is live right now — never onto the stale copy.
-      if (stageStatusChanges) {
-        const fresh = await tx.modelBuildItem.findUnique({
-          where: { id },
-          select: { stageStatuses: true },
+      //
+      // contentStageChecks re-runs prepareItemUpdate's own gate a second
+      // time against this same fresh read (model-builder/t-029): that first
+      // check only ever saw `existing`, read once at request start, before
+      // readBody/artImageId validation even ran, let alone this transaction
+      // opening. A concurrent approveStage (which writes only stageStatuses,
+      // never content) landing in that window is invisible to the eager
+      // check — this closes it, throwing (and rolling back the transaction)
+      // if the stage this request is about to write into is no longer
+      // ready/stale/rejected by the time the write actually happens.
+      const fresh =
+        stageStatusChanges || contentStageChecks.length
+          ? await tx.modelBuildItem.findUnique({
+              where: { id },
+              select: { stageStatuses: true },
+            })
+          : null
+      for (const { stageKey, fieldLabel } of contentStageChecks) {
+        assertContentStageEditable(fresh?.stageStatuses, stageKey, fieldLabel)
+      }
+      if (revision) {
+        await tx.modelBuildRevision.create({
+          data: { itemId: id, ...revision },
         })
+      }
+      if (stageStatusChanges) {
         data.stageStatuses = mergeStageStatusChanges(
           fresh?.stageStatuses,
           stageStatusChanges,

--- a/server/api/model-builder/items/batch.patch.ts
+++ b/server/api/model-builder/items/batch.patch.ts
@@ -11,6 +11,7 @@ import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
 import {
+  assertContentStageEditable,
   assertRunAccess,
   assertRunWritable,
   mergeStageStatusChanges,
@@ -66,6 +67,9 @@ export default defineEventHandler(async (event) => {
       stageStatusChanges: ReturnType<
         typeof prepareItemUpdate
       >['stageStatusChanges']
+      contentStageChecks: ReturnType<
+        typeof prepareItemUpdate
+      >['contentStageChecks']
     }> = []
 
     for (const entry of entries) {
@@ -110,12 +114,15 @@ export default defineEventHandler(async (event) => {
 
         const { id: _omit, ...fields } = entry
         void _omit
-        const { data, revision, stageStatusChanges } = prepareItemUpdate(
-          existing,
-          fields,
-          actor,
-        )
-        applied.push({ id, data, revision, stageStatusChanges })
+        const { data, revision, stageStatusChanges, contentStageChecks } =
+          prepareItemUpdate(existing, fields, actor)
+        applied.push({
+          id,
+          data,
+          revision,
+          stageStatusChanges,
+          contentStageChecks,
+        })
         results.push({ id, success: true, message: 'Queued.', statusCode: 200 })
       } catch (error: unknown) {
         const handled = errorHandler(error)
@@ -132,12 +139,13 @@ export default defineEventHandler(async (event) => {
     if (applied.length) {
       const updatedById = await prisma.$transaction(async (tx) => {
         const byId = new Map<number, unknown>()
-        for (const { id, data, revision, stageStatusChanges } of applied) {
-          if (revision) {
-            await tx.modelBuildRevision.create({
-              data: { itemId: id, ...revision },
-            })
-          }
+        for (const {
+          id,
+          data,
+          revision,
+          stageStatusChanges,
+          contentStageChecks,
+        } of applied) {
           // Re-read stageStatuses immediately before this entry's own write —
           // see the identical merge in items/[id].patch.ts for why. The gap
           // this closes is larger here than the single-item route: every
@@ -146,11 +154,48 @@ export default defineEventHandler(async (event) => {
           // write (e.g. an async art job's pushItem landing mid-batch) has a
           // real window to land in between this batch's `existing` reads and
           // its actual writes.
-          if (stageStatusChanges) {
-            const fresh = await tx.modelBuildItem.findUnique({
-              where: { id },
-              select: { stageStatuses: true },
+          const fresh =
+            stageStatusChanges || contentStageChecks.length
+              ? await tx.modelBuildItem.findUnique({
+                  where: { id },
+                  select: { stageStatuses: true },
+                })
+              : null
+
+          // Re-run prepareItemUpdate's content-editable gate against that
+          // same fresh read (model-builder/t-029) — its own eager check only
+          // ever saw the per-entry `existing` read taken before this shared
+          // transaction opened, so a concurrent approveStage for this same
+          // item landing in between is invisible to it. Caught per-entry
+          // (rather than left to abort the whole transaction) so one item's
+          // stage having moved on doesn't revert every other entry in the
+          // same batch — matching this route's own "single failing entry
+          // does not abort the others" contract.
+          try {
+            for (const { stageKey, fieldLabel } of contentStageChecks) {
+              assertContentStageEditable(
+                fresh?.stageStatuses,
+                stageKey,
+                fieldLabel,
+              )
+            }
+          } catch (error: unknown) {
+            const handled = errorHandler(error)
+            const result = results.find((entry) => entry.id === id)
+            if (result) {
+              result.success = false
+              result.message = handled.message || `Failed to update item ${id}.`
+              result.statusCode = handled.statusCode || 500
+            }
+            continue
+          }
+
+          if (revision) {
+            await tx.modelBuildRevision.create({
+              data: { itemId: id, ...revision },
             })
+          }
+          if (stageStatusChanges) {
             data.stageStatuses = mergeStageStatusChanges(
               fresh?.stageStatuses,
               stageStatusChanges,

--- a/server/api/model-builder/runs/index.ts
+++ b/server/api/model-builder/runs/index.ts
@@ -180,6 +180,20 @@ export type PreparedItemUpdate = {
   // mergeStageStatusChanges below) rather than writing this object directly,
   // or a concurrent write to a stage this request never touched gets clobbered.
   stageStatusChanges: Record<string, unknown> | null
+  // Every assertContentStageEditable(existing.stageStatuses, ...) call this
+  // invocation performed, so the caller can re-run the identical check a
+  // second time against a value read immediately before the write (model-
+  // builder/t-029): the check above only ever sees `existing`, a single
+  // findUnique done once at request start, before readBody/artImageId
+  // validation/the transaction even open. A concurrent request that changes
+  // this same stage's status (most plainly: approveStage, which writes only
+  // stageStatuses, never pitch/fieldsDraft/promptDraft/artImageId) can land
+  // in the window between that read and this request's own write — the
+  // eager check above then okays a content write against a status that is
+  // no longer current, silently overwriting an approved stage's content
+  // while its badge keeps showing 'approved', exactly the outcome this gate
+  // exists to prevent. Empty when this request touched no gated field.
+  contentStageChecks: Array<{ stageKey: ContentStageKey; fieldLabel: string }>
 }
 
 // The client always sends item.stages in full — every stage key, including
@@ -257,9 +271,16 @@ export function mergeStageStatusChanges(
 // 'approved' for the old, actually-reviewed image.
 const CONTENT_STAGE_EDITABLE_STATUSES = new Set(['ready', 'stale', 'rejected'])
 
-function assertContentStageEditable(
+export type ContentStageKey = 'PITCH' | 'FIELDS_AND_PROMPTS' | 'GENERATE_ASSETS'
+
+// Exported so callers can re-run this exact check a second time, against a
+// freshly-read stageStatuses value immediately before their write — see
+// PreparedItemUpdate.contentStageChecks' doc comment for why the single
+// check performed inside prepareItemUpdate below (against the request-start
+// `existing` snapshot) is not sufficient on its own.
+export function assertContentStageEditable(
   stageStatuses: unknown,
-  stageKey: 'PITCH' | 'FIELDS_AND_PROMPTS' | 'GENERATE_ASSETS',
+  stageKey: ContentStageKey,
   fieldLabel: string,
 ): void {
   const stages = parseStoredJson<Record<string, { status?: string }>>(
@@ -293,6 +314,7 @@ export function prepareItemUpdate(
   actor: string,
 ): PreparedItemUpdate {
   const data: Prisma.ModelBuildItemUncheckedUpdateInput = {}
+  const contentStageChecks: PreparedItemUpdate['contentStageChecks'] = []
 
   let stageStatusChanges: Record<string, unknown> | null = null
   if (body.stageStatuses !== undefined && body.stageStatuses !== null) {
@@ -309,6 +331,7 @@ export function prepareItemUpdate(
   }
   if (body.pitch !== undefined) {
     assertContentStageEditable(existing.stageStatuses, 'PITCH', 'Pitch')
+    contentStageChecks.push({ stageKey: 'PITCH', fieldLabel: 'Pitch' })
     data.pitch = normalizeText(body.pitch)
   }
   if (body.fieldsDraft !== undefined) {
@@ -317,6 +340,10 @@ export function prepareItemUpdate(
       'FIELDS_AND_PROMPTS',
       'Fields',
     )
+    contentStageChecks.push({
+      stageKey: 'FIELDS_AND_PROMPTS',
+      fieldLabel: 'Fields',
+    })
     data.fieldsDraft = normalizeText(body.fieldsDraft)
   }
   if (body.promptDraft !== undefined) {
@@ -325,6 +352,10 @@ export function prepareItemUpdate(
       'FIELDS_AND_PROMPTS',
       'Prompt',
     )
+    contentStageChecks.push({
+      stageKey: 'FIELDS_AND_PROMPTS',
+      fieldLabel: 'Prompt',
+    })
     data.promptDraft = normalizeText(body.promptDraft)
   }
   const relationshipDraft = normalizeJson(body.relationshipDraft)
@@ -339,6 +370,10 @@ export function prepareItemUpdate(
       'GENERATE_ASSETS',
       'Art image',
     )
+    contentStageChecks.push({
+      stageKey: 'GENERATE_ASSETS',
+      fieldLabel: 'Art image',
+    })
     data.artImageId = normalizeNullableId(body.artImageId)
   }
   if (body.targetType !== undefined)
@@ -352,7 +387,8 @@ export function prepareItemUpdate(
     body.promptDraft !== undefined ||
     body.relationshipDraft !== undefined
 
-  if (!contentChanged) return { data, revision: null, stageStatusChanges }
+  if (!contentChanged)
+    return { data, revision: null, stageStatusChanges, contentStageChecks }
 
   const stageLabel =
     typeof body.stage === 'string' ? body.stage.slice(0, 48) : 'EDIT'
@@ -393,5 +429,6 @@ export function prepareItemUpdate(
       nextPayload,
     },
     stageStatusChanges,
+    contentStageChecks,
   }
 }

--- a/utils/scripts/verifyModelBuilderContentStageFreshnessGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderContentStageFreshnessGuard.test.ts
@@ -1,0 +1,194 @@
+// /utils/scripts/verifyModelBuilderContentStageFreshnessGuard.test.ts
+//
+// Regression test for verifyModelBuilderContentStageFreshnessGuard.ts
+// (model-builder/t-029, cycle 17). Exercises the real checks against
+// synthetic runs/index.ts- and PATCH-route-shaped fixtures covering: the
+// pre-fix shape (eager check only, against `existing`, never replayed at
+// write time), the fixed shape (re-checked inside the transaction against a
+// fresh `findUnique` read), and a still-stale-inside-the-transaction
+// fixture (the subtle near-miss -- calls assertContentStageEditable a
+// second time, but still passes `existing` instead of the fresh value).
+import assert from 'node:assert/strict'
+
+import {
+  checkPatchRouteFreshContentCheck,
+  checkRunsIndexExportsFreshnessPieces,
+} from './verifyModelBuilderContentStageFreshnessGuard.js'
+
+const BUGGY_RUNS_INDEX = `
+  function assertContentStageEditable(stageStatuses, stageKey, fieldLabel) {
+    // ...
+  }
+
+  export function prepareItemUpdate(existing, body, actor) {
+    const data = {}
+    if (body.pitch !== undefined) {
+      assertContentStageEditable(existing.stageStatuses, 'PITCH', 'Pitch')
+      data.pitch = normalizeText(body.pitch)
+    }
+    return { data, revision: null, stageStatusChanges: null }
+  }
+`
+
+const FIXED_RUNS_INDEX = `
+  export function assertContentStageEditable(stageStatuses, stageKey, fieldLabel) {
+    // ...
+  }
+
+  export function prepareItemUpdate(existing, body, actor) {
+    const data = {}
+    const contentStageChecks: PreparedItemUpdate['contentStageChecks'] = []
+    if (body.pitch !== undefined) {
+      assertContentStageEditable(existing.stageStatuses, 'PITCH', 'Pitch')
+      contentStageChecks.push({ stageKey: 'PITCH', fieldLabel: 'Pitch' })
+      data.pitch = normalizeText(body.pitch)
+    }
+    if (body.fieldsDraft !== undefined) {
+      assertContentStageEditable(existing.stageStatuses, 'FIELDS_AND_PROMPTS', 'Fields')
+      contentStageChecks.push({ stageKey: 'FIELDS_AND_PROMPTS', fieldLabel: 'Fields' })
+      data.fieldsDraft = normalizeText(body.fieldsDraft)
+    }
+    if (body.promptDraft !== undefined) {
+      assertContentStageEditable(existing.stageStatuses, 'FIELDS_AND_PROMPTS', 'Prompt')
+      contentStageChecks.push({ stageKey: 'FIELDS_AND_PROMPTS', fieldLabel: 'Prompt' })
+      data.promptDraft = normalizeText(body.promptDraft)
+    }
+    if (body.artImageId !== undefined) {
+      assertContentStageEditable(existing.stageStatuses, 'GENERATE_ASSETS', 'Art image')
+      contentStageChecks.push({ stageKey: 'GENERATE_ASSETS', fieldLabel: 'Art image' })
+      data.artImageId = normalizeNullableId(body.artImageId)
+    }
+    return { data, revision: null, stageStatusChanges: null, contentStageChecks }
+  }
+`
+
+const BUGGY_PATCH_ROUTE = `
+    const { data, revision, stageStatusChanges, contentStageChecks } =
+      prepareItemUpdate(existing, body, actor)
+    const item = await prisma.$transaction(async (tx) => {
+      if (revision) {
+        await tx.modelBuildRevision.create({ data: { itemId: id, ...revision } })
+      }
+      if (stageStatusChanges) {
+        const fresh = await tx.modelBuildItem.findUnique({
+          where: { id },
+          select: { stageStatuses: true },
+        })
+        data.stageStatuses = mergeStageStatusChanges(fresh?.stageStatuses, stageStatusChanges)
+      }
+      return tx.modelBuildItem.update({ where: { id }, data, include: itemInclude })
+    })
+`
+
+const FIXED_PATCH_ROUTE = `
+    const { data, revision, stageStatusChanges, contentStageChecks } =
+      prepareItemUpdate(existing, body, actor)
+    const item = await prisma.$transaction(async (tx) => {
+      const fresh =
+        stageStatusChanges || contentStageChecks.length
+          ? await tx.modelBuildItem.findUnique({
+              where: { id },
+              select: { stageStatuses: true },
+            })
+          : null
+      for (const { stageKey, fieldLabel } of contentStageChecks) {
+        assertContentStageEditable(fresh?.stageStatuses, stageKey, fieldLabel)
+      }
+      if (revision) {
+        await tx.modelBuildRevision.create({ data: { itemId: id, ...revision } })
+      }
+      if (stageStatusChanges) {
+        data.stageStatuses = mergeStageStatusChanges(fresh?.stageStatuses, stageStatusChanges)
+      }
+      return tx.modelBuildItem.update({ where: { id }, data, include: itemInclude })
+    })
+`
+
+// The subtle near-miss: assertContentStageEditable IS called a second time,
+// inside the transaction -- but still against `existing`, not the fresh
+// read. This would satisfy a check that only asked "is it called twice?"
+// without also inspecting what each call was actually passed.
+const STILL_STALE_PATCH_ROUTE = `
+    const { data, revision, stageStatusChanges, contentStageChecks } =
+      prepareItemUpdate(existing, body, actor)
+    const item = await prisma.$transaction(async (tx) => {
+      const fresh = await tx.modelBuildItem.findUnique({
+        where: { id },
+        select: { stageStatuses: true },
+      })
+      for (const { stageKey, fieldLabel } of contentStageChecks) {
+        assertContentStageEditable(existing.stageStatuses, stageKey, fieldLabel)
+      }
+      if (stageStatusChanges) {
+        data.stageStatuses = mergeStageStatusChanges(fresh?.stageStatuses, stageStatusChanges)
+      }
+      return tx.modelBuildItem.update({ where: { id }, data, include: itemInclude })
+    })
+`
+
+function run(): void {
+  const buggyRunsIndexErrors =
+    checkRunsIndexExportsFreshnessPieces(BUGGY_RUNS_INDEX)
+  assert.equal(
+    buggyRunsIndexErrors.length,
+    3,
+    'expected the buggy runs/index.ts fixture (private helper, no ' +
+      `accumulator, no pushes) to fail three times, got: ${JSON.stringify(buggyRunsIndexErrors)}`,
+  )
+  assert.match(buggyRunsIndexErrors[0]!, /no longer exports/)
+  assert.match(buggyRunsIndexErrors[1]!, /no longer initializes/)
+  assert.match(
+    buggyRunsIndexErrors[2]!,
+    /only pushes onto contentStageChecks 0/,
+  )
+
+  const fixedRunsIndexErrors =
+    checkRunsIndexExportsFreshnessPieces(FIXED_RUNS_INDEX)
+  assert.deepEqual(
+    fixedRunsIndexErrors,
+    [],
+    `expected the fixed runs/index.ts fixture to pass, got: ${JSON.stringify(fixedRunsIndexErrors)}`,
+  )
+
+  const buggyRouteErrors = checkPatchRouteFreshContentCheck(
+    BUGGY_PATCH_ROUTE,
+    'fixture-route.ts',
+  )
+  assert.equal(
+    buggyRouteErrors.length,
+    1,
+    `expected the buggy PATCH route fixture (no re-check at all) to fail ` +
+      `once, got: ${JSON.stringify(buggyRouteErrors)}`,
+  )
+  assert.match(buggyRouteErrors[0]!, /never calls assertContentStageEditable/)
+
+  const fixedRouteErrors = checkPatchRouteFreshContentCheck(
+    FIXED_PATCH_ROUTE,
+    'fixture-route.ts',
+  )
+  assert.deepEqual(
+    fixedRouteErrors,
+    [],
+    `expected the fixed PATCH route fixture to pass, got: ${JSON.stringify(fixedRouteErrors)}`,
+  )
+
+  const stillStaleErrors = checkPatchRouteFreshContentCheck(
+    STILL_STALE_PATCH_ROUTE,
+    'fixture-route.ts',
+  )
+  assert.equal(
+    stillStaleErrors.length,
+    1,
+    'expected the still-stale fixture (re-checked, but against `existing`) ' +
+      `to fail once, got: ${JSON.stringify(stillStaleErrors)}`,
+  )
+  assert.match(stillStaleErrors[0]!, /references `existing`/)
+
+  console.log(
+    'Model Builder content-stage freshness guard self-test passed: buggy ' +
+      'and still-stale fixtures fail with the expected messages, fixed ' +
+      'fixtures pass.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderContentStageFreshnessGuard.ts
+++ b/utils/scripts/verifyModelBuilderContentStageFreshnessGuard.ts
@@ -1,0 +1,221 @@
+// /utils/scripts/verifyModelBuilderContentStageFreshnessGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 17) -- runs/index.ts's
+// assertContentStageEditable() gate (added by an earlier cycle, see
+// verifyModelBuilderItemPatchStageGuard.ts) refuses to write body.pitch /
+// body.fieldsDraft / body.promptDraft / body.artImageId onto an item whose
+// owning stage (PITCH / FIELDS_AND_PROMPTS / GENERATE_ASSETS) is not
+// ready/stale/rejected -- but until this fix, that check ran exactly once,
+// against `existing`, a single findUnique read done at the very top of the
+// request handler, before readBody, artImageId attachability validation, or
+// the transaction even opened. A sibling cycle (kind_robots PR #1900)
+// already hardened the neighboring stageStatuses *merge* to re-read
+// immediately before its write; this check -- the *gate that decides
+// whether the content write is even allowed at all* -- was never given the
+// same treatment.
+//
+// Concrete repro: an item's PITCH stage is 'ready'. Two concurrent PATCH
+// /items/:id requests target it -- request A is approveStage('PITCH') (sends
+// only { stageStatuses: {...PITCH: approved...} }, no content field, exactly
+// what modelBuilderStore.ts's approveStage() sends); request B is
+// updatePitch(itemId, 'edited text') (sends { stageStatuses: <B's own,
+// still-'ready' local snapshot>, pitch: 'edited text', error: null }, exactly
+// what updatePitch() sends). Both requests' own `existing` findUnique read
+// PITCH as 'ready'. A's transaction commits first, writing PITCH: 'approved'.
+// B's assertContentStageEditable call already ran (synchronously, before
+// either transaction opened) against B's now-stale `existing.stageStatuses`
+// showing 'ready' -- it passed. B's own diffStageStatusChanges found no
+// difference between its local 'ready' and its own stale existing-read
+// 'ready', so stageStatusChanges is null and B's write never touches
+// stageStatuses at all. B's transaction then applies data.pitch = 'edited
+// text' unconditionally. Final DB state: PITCH stays 'approved' (from A),
+// but item.pitch is silently overwritten with B's edit -- the approved
+// badge lies about what's actually stored, exactly the outcome
+// assertContentStageEditable exists to prevent, just reached through its own
+// staleness rather than its absence.
+//
+// Fixed by re-running assertContentStageEditable a second time, against a
+// value read via findUnique immediately before the actual write, for every
+// content field a request intends to change (contentStageChecks, threaded
+// through PreparedItemUpdate) -- both in items/[id].patch.ts and, per-entry
+// so one item's staleness doesn't abort the rest of an unrelated batch, in
+// items/batch.patch.ts.
+//
+// This asserts the textual shape of that fix stays in place:
+//   1. runs/index.ts exports assertContentStageEditable (so route files can
+//      call it a second time) and PreparedItemUpdate's contentStageChecks
+//      field is actually populated by prepareItemUpdate.
+//   2. Both items/[id].patch.ts and items/batch.patch.ts call
+//      assertContentStageEditable a second time, inside their transaction,
+//      with a value sourced from a `findUnique` -- not `existing` -- as the
+//      first argument.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const RUNS_INDEX_PATH = join(
+  repositoryRoot,
+  'server/api/model-builder/runs/index.ts',
+)
+const SINGLE_PATCH_PATH = join(
+  repositoryRoot,
+  'server/api/model-builder/items/[id].patch.ts',
+)
+const BATCH_PATCH_PATH = join(
+  repositoryRoot,
+  'server/api/model-builder/items/batch.patch.ts',
+)
+
+// Checks runs/index.ts: assertContentStageEditable must be exported, and
+// prepareItemUpdate must actually populate contentStageChecks (not just
+// declare the field and leave it always empty).
+export function checkRunsIndexExportsFreshnessPieces(
+  content: string,
+): string[] {
+  const errors: string[] = []
+
+  if (!content.includes('export function assertContentStageEditable')) {
+    errors.push(
+      'runs/index.ts no longer exports assertContentStageEditable() -- ' +
+        'route files can no longer re-run this gate a second time against a ' +
+        'fresh read, reintroducing the staleness bug this guard exists to catch.',
+    )
+  }
+
+  if (
+    !content.includes(
+      "contentStageChecks: PreparedItemUpdate['contentStageChecks'] = []",
+    )
+  ) {
+    errors.push(
+      'prepareItemUpdate() no longer initializes a contentStageChecks ' +
+        'accumulator -- has the fix been renamed, removed, or reworked?',
+    )
+  }
+
+  const pushCount = (content.match(/contentStageChecks\.push\(/g) ?? []).length
+  if (pushCount < 4) {
+    errors.push(
+      `prepareItemUpdate() only pushes onto contentStageChecks ${pushCount} ` +
+        'time(s) -- expected 4 (pitch, fieldsDraft, promptDraft, artImageId), ' +
+        "one per gated field. A missing push means that field's eager check " +
+        "is no longer replayed at write time, silently reopening this field's " +
+        'own staleness window.',
+    )
+  }
+
+  return errors
+}
+
+// Checks a PATCH route file: it must call assertContentStageEditable with a
+// value sourced from a fresh read (never `existing`), inside its
+// transaction, before the item write it protects.
+export function checkPatchRouteFreshContentCheck(
+  content: string,
+  label: string,
+): string[] {
+  const errors: string[] = []
+
+  // Every call to assertContentStageEditable(...) in this file -- there may
+  // be more than one in batch.patch.ts's per-entry loop shape, but each
+  // must pass a non-`existing` first argument.
+  const callPattern = /assertContentStageEditable\(\s*([^,]+),/g
+  const calls = [...content.matchAll(callPattern)]
+
+  if (calls.length === 0) {
+    errors.push(
+      `${label} never calls assertContentStageEditable(...) -- the write-time ` +
+        're-validation this guard exists to enforce is missing entirely.',
+    )
+    return errors
+  }
+
+  for (const call of calls) {
+    const firstArg = call[1]!.trim()
+    if (/\bexisting\b/.test(firstArg)) {
+      errors.push(
+        `${label} calls assertContentStageEditable(${firstArg}, ...) -- its ` +
+          'first argument references `existing`, the request-start snapshot, ' +
+          'instead of a value read fresh (via findUnique) immediately before ' +
+          'the write it gates. This is the exact staleness bug this guard ' +
+          'exists to catch: a concurrent approveStage landing in between is ' +
+          'invisible to a check run against `existing`.',
+      )
+    }
+  }
+
+  // At least one of those calls must sit inside a transaction callback
+  // (`prisma.$transaction(async (tx) => {`), not only in the pre-transaction
+  // eager check inside prepareItemUpdate (which this file merely calls, and
+  // whose own internal `existing`-based call is expected and fine).
+  const txIndex = content.indexOf('prisma.$transaction(async (tx)')
+  const hasCallAfterTx = calls.some((call) => call.index! > txIndex)
+  if (txIndex === -1 || !hasCallAfterTx) {
+    errors.push(
+      `${label} does not call assertContentStageEditable(...) inside its ` +
+        '`prisma.$transaction(async (tx) => { ... })` callback -- the write-time ' +
+        're-check must run immediately before the write, inside the same ' +
+        'transaction, not only once eagerly at request start.',
+    )
+  }
+
+  // A `findUnique` selecting stageStatuses must precede that in-transaction
+  // call (the fresh read it's meant to validate against).
+  if (hasCallAfterTx) {
+    const inTxCall = calls.find((call) => call.index! > txIndex)!
+    const beforeCall = content.slice(0, inTxCall.index)
+    const findUniqueIndex = beforeCall.lastIndexOf('findUnique')
+    const stageTrueIndex = beforeCall.lastIndexOf('stageStatuses: true')
+    if (findUniqueIndex === -1 || stageTrueIndex < findUniqueIndex) {
+      errors.push(
+        `${label}'s in-transaction assertContentStageEditable(...) call has no ` +
+          '`findUnique({ ... select: { stageStatuses: true } })` preceding it -- ' +
+          'there is no fresh value for it to actually validate against.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const runsIndexContent = readFileSync(RUNS_INDEX_PATH, 'utf8')
+  const singlePatchContent = readFileSync(SINGLE_PATCH_PATH, 'utf8')
+  const batchPatchContent = readFileSync(BATCH_PATCH_PATH, 'utf8')
+
+  const errors = [
+    ...checkRunsIndexExportsFreshnessPieces(runsIndexContent),
+    ...checkPatchRouteFreshContentCheck(
+      singlePatchContent,
+      'items/[id].patch.ts',
+    ),
+    ...checkPatchRouteFreshContentCheck(
+      batchPatchContent,
+      'items/batch.patch.ts',
+    ),
+  ]
+
+  if (errors.length) {
+    console.error(
+      'Model Builder content-stage freshness guard contract failed:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder content-stage freshness guard contract passed: ' +
+      'assertContentStageEditable() is re-run against a freshly re-read ' +
+      'stageStatuses value, inside the write transaction, immediately before ' +
+      'every content field write it gates -- in both items/[id].patch.ts and ' +
+      'items/batch.patch.ts.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}

--- a/utils/scripts/verifyModelBuilderPatchStaleStageStatusGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderPatchStaleStageStatusGuard.test.ts
@@ -89,6 +89,76 @@ const MISSING_FRESH_READ_PATCH_ROUTE = `
     })
 `
 
+// Mirrors the real fix's shape (model-builder/t-029, cycle 17): a good deal
+// of unrelated-looking code (the contentStageChecks re-validation loop, plus
+// a conditional revision write) now legitimately sits between the fresh
+// findUnique read and the merge assignment it feeds. The old fixed-400-char
+// window would have failed this genuinely-correct shape; the check must
+// pass it.
+const FIXED_PATCH_ROUTE_WITH_CONTENT_CHECKS = `
+    const { data, revision, stageStatusChanges, contentStageChecks } =
+      prepareItemUpdate(existing, body, actor)
+    const item = await prisma.$transaction(async (tx) => {
+      const fresh =
+        stageStatusChanges || contentStageChecks.length
+          ? await tx.modelBuildItem.findUnique({
+              where: { id },
+              select: { stageStatuses: true },
+            })
+          : null
+      for (const { stageKey, fieldLabel } of contentStageChecks) {
+        assertContentStageEditable(fresh?.stageStatuses, stageKey, fieldLabel)
+      }
+      if (revision) {
+        await tx.modelBuildRevision.create({
+          data: { itemId: id, ...revision },
+        })
+      }
+      if (stageStatusChanges) {
+        data.stageStatuses = mergeStageStatusChanges(
+          fresh?.stageStatuses,
+          stageStatusChanges,
+        )
+      }
+      return tx.modelBuildItem.update({
+        where: { id },
+        data,
+        include: itemInclude,
+      })
+    })
+`
+
+// The inverse defect this widened check must still catch: another write
+// landing BETWEEN the fresh read and the merge that consumes it -- the read
+// would no longer be "immediately before the write" once something else
+// writes to the item first, reopening exactly the staleness window this
+// whole guard exists to close. Distance-independent, so this can only be
+// caught by checking write-vs-read-vs-merge ordering explicitly, not a
+// character window.
+const WRITE_BETWEEN_READ_AND_MERGE_PATCH_ROUTE = `
+    const { data, revision, stageStatusChanges } = prepareItemUpdate(existing, body, actor)
+    const item = await prisma.$transaction(async (tx) => {
+      const fresh = await tx.modelBuildItem.findUnique({
+        where: { id },
+        select: { stageStatuses: true },
+      })
+      await tx.modelBuildItem.update({
+        where: { id },
+        data: { touchedAt: new Date() },
+        include: itemInclude,
+      })
+      data.stageStatuses = mergeStageStatusChanges(
+        fresh?.stageStatuses,
+        stageStatusChanges,
+      )
+      return tx.modelBuildItem.update({
+        where: { id },
+        data,
+        include: itemInclude,
+      })
+    })
+`
+
 function run(): void {
   const buggyRunsIndexErrors = checkRunsIndexNoBlindOverwrite(BUGGY_RUNS_INDEX)
   assert.equal(
@@ -135,11 +205,45 @@ function run(): void {
   )
   assert.equal(
     missingFreshReadErrors.length,
-    1,
+    2,
     'expected the missing-fresh-read fixture (merges onto `existing`, not a ' +
-      `fresh findUnique) to fail once, got: ${JSON.stringify(missingFreshReadErrors)}`,
+      'fresh findUnique) to fail twice -- once for referencing `existing` ' +
+      `directly, once for no findUnique preceding it -- got: ${JSON.stringify(missingFreshReadErrors)}`,
   )
-  assert.match(missingFreshReadErrors[0]!, /no nearby/)
+  assert.match(missingFreshReadErrors[0]!, /references `existing`/)
+  assert.match(missingFreshReadErrors[1]!, /no `findUnique/)
+
+  // The widened, distance-independent check must still pass the real fix's
+  // actual shape -- a good deal of legitimate validation code (the
+  // contentStageChecks loop, a conditional revision write) between the
+  // fresh read and the merge, which the old fixed-400-char window did not
+  // survive.
+  const withContentChecksErrors = checkPatchRouteFreshMerge(
+    FIXED_PATCH_ROUTE_WITH_CONTENT_CHECKS,
+    'fixture-route.ts',
+  )
+  assert.deepEqual(
+    withContentChecksErrors,
+    [],
+    'expected the fixed-with-content-checks fixture (fresh read separated ' +
+      'from its merge by legitimate validation code) to pass, got: ' +
+      JSON.stringify(withContentChecksErrors),
+  )
+
+  // The inverse ordering defect: a write landing BETWEEN the fresh read and
+  // the merge that consumes it must still fail, distance-independent window
+  // or not.
+  const writeBetweenErrors = checkPatchRouteFreshMerge(
+    WRITE_BETWEEN_READ_AND_MERGE_PATCH_ROUTE,
+    'fixture-route.ts',
+  )
+  assert.equal(
+    writeBetweenErrors.length,
+    1,
+    'expected the write-between-read-and-merge fixture to fail once, got: ' +
+      JSON.stringify(writeBetweenErrors),
+  )
+  assert.match(writeBetweenErrors[0]!, /before its own stageStatuses/)
 
   console.log(
     'Model Builder PATCH stale stage-status guard self-test passed: buggy ' +

--- a/utils/scripts/verifyModelBuilderPatchStaleStageStatusGuard.ts
+++ b/utils/scripts/verifyModelBuilderPatchStaleStageStatusGuard.ts
@@ -98,7 +98,23 @@ export function checkRunsIndexNoBlindOverwrite(content: string): string[] {
 
 // Checks a PATCH route file: it must call mergeStageStatusChanges with a
 // value read via a fresh `findUnique` (not the request-start snapshot),
-// immediately before a `tx.modelBuildItem.update(` write.
+// before a `tx.modelBuildItem.update(` write.
+//
+// Not a fixed character-distance window (model-builder/t-029, cycle 17):
+// the earlier version of this check required `findUnique` and
+// `stageStatuses: true` to appear within 400 characters before the merge
+// assignment, which was true when this fix first landed but broke the
+// moment legitimate per-write validation grew that gap -- e.g. the
+// contentStageChecks re-validation this same cycle added between the fresh
+// read and the merge, to close the sibling staleness bug in
+// assertContentStageEditable (see verifyModelBuilderItemPatchStageGuard.ts).
+// Checked instead as three distance-independent invariants: (1) the merge's
+// own first argument text isn't `existing.stageStatuses` (the literal
+// regression signal), (2) a `findUnique(...)` selecting `stageStatuses:
+// true` appears anywhere before the merge, and (3) no
+// `tx.modelBuildItem.update(` write happens between that read and the
+// merge -- i.e. the read genuinely precedes this write, however much
+// validation now sits in between.
 export function checkPatchRouteFreshMerge(
   content: string,
   label: string,
@@ -115,22 +131,38 @@ export function checkPatchRouteFreshMerge(
     return errors
   }
 
-  // A `findUnique` selecting stageStatuses must appear shortly before the
-  // merge call (the fresh read this merge is supposed to be based on).
-  const precedingSlice = content.slice(
-    Math.max(0, mergeIndex - 400),
-    mergeIndex,
-  )
-  if (
-    !precedingSlice.includes('findUnique') ||
-    !precedingSlice.includes('stageStatuses: true')
-  ) {
+  const argStart = mergeIndex + MERGE_ASSIGNMENT.length
+  const argEnd = content.indexOf(',', argStart)
+  const firstArg = content
+    .slice(argStart, argEnd === -1 ? argStart + 120 : argEnd)
+    .trim()
+  if (/\bexisting\b/.test(firstArg)) {
     errors.push(
-      `${label} calls mergeStageStatusChanges(...) but no nearby ` +
+      `${label} calls mergeStageStatusChanges(${firstArg}, ...) -- its first ` +
+        'argument references `existing`, the stale request-start snapshot, ' +
+        'instead of a value read fresh immediately before this write.',
+    )
+  }
+
+  const beforeMerge = content.slice(0, mergeIndex)
+  const findUniqueIndex = beforeMerge.lastIndexOf('findUnique')
+  const stageTrueIndex = beforeMerge.lastIndexOf('stageStatuses: true')
+  if (findUniqueIndex === -1 || stageTrueIndex < findUniqueIndex) {
+    errors.push(
+      `${label} calls mergeStageStatusChanges(...) but no ` +
         '`findUnique({ ... select: { stageStatuses: true } })` precedes it -- ' +
         'the merge must be based on a value read immediately before the ' +
         'write, not an older snapshot.',
     )
+  } else {
+    const lastWriteIndex = beforeMerge.lastIndexOf('tx.modelBuildItem.update(')
+    if (lastWriteIndex > findUniqueIndex) {
+      errors.push(
+        `${label} writes the item (tx.modelBuildItem.update(...)) before ` +
+          'its own stageStatuses fresh-read/merge -- the read (and merge) ' +
+          'must happen before any write, not after.',
+      )
+    }
   }
 
   // The merge assignment must itself land before the actual DB write it


### PR DESCRIPTION
## Bug (model-builder/t-029, cycle 17)

`prepareItemUpdate()`'s `assertContentStageEditable` gate (guards `pitch` / `fieldsDraft` / `promptDraft` / `artImageId` against being written while their owning stage is already `approved` or still `locked`) checked only `existing` — a single `findUnique` read taken once at the very top of the PATCH request handler, before `readBody`, artImageId attachability validation, or the transaction even opened. A sibling cycle (#1900) already hardened the neighboring `stageStatuses` *merge* to re-read immediately before its write; this gate — which decides whether the content write is even allowed at all — never got the same treatment.

**Concrete repro:** item X's PITCH stage is `ready`. Two concurrent `PATCH /items/:id` requests land — request A is `approveStage('PITCH')` (sends only `{ stageStatuses: {...PITCH: approved...} }`, exactly what `modelBuilderStore.ts`'s `approveStage()` sends, no content field); request B is `updatePitch(itemId, 'edited text')` (sends `{ stageStatuses: <B's own, still-'ready' local snapshot>, pitch: 'edited text' }`). Both requests' own `existing` read sees PITCH as `ready`. A's transaction commits first, writing PITCH: `approved`. B's `assertContentStageEditable` already ran (synchronously, before either transaction opened) against B's now-stale `existing.stageStatuses` — it passed. B's own stageStatuses diff finds no change (its local `ready` matches what it itself read), so B's write never touches `stageStatuses` at all — only `data.pitch`. Final DB state: PITCH stays `approved` (from A), but `item.pitch` is silently overwritten by B, with the approved badge lying about what's actually stored — exactly the outcome this gate exists to prevent, reached through its own staleness rather than its absence.

## Fix

Threaded `contentStageChecks` through `PreparedItemUpdate` (records which gated fields a request touched) and re-run `assertContentStageEditable` a second time, inside the write transaction, against a value read via `findUnique` immediately before the write — in both `items/[id].patch.ts` and, per-entry so one item's staleness doesn't abort an unrelated sibling entry, `items/batch.patch.ts`.

Also widens `verifyModelBuilderPatchStaleStageStatusGuard.ts`'s fixed 400-character proximity window to a distance-independent check (first-arg identity + read-before-write ordering), since the `contentStageChecks` re-validation this fix adds legitimately grows the gap between the fresh read and the `stageStatuses` merge assignment beyond that old window (the old window would have false-failed this genuinely-correct shape).

## Guard

Added `verifyModelBuilderContentStageFreshnessGuard.ts` + `.test.ts`, wired into `package.json` and `contract-tests.yml`. Verified via git-stash round trip: the new guard fails with 5 errors against the pre-fix code and passes post-fix.

## Verification

- All 99 existing `test:model-builder-*` guard scripts pass, no regression
- `vue-tsc --noEmit` clean repo-wide
- `eslint` clean on touched files
- `prettier --check` reports only one pre-existing drift line (confirmed present on `origin/main` before this change, left untouched) — diffed against `origin/main` to keep the change minimally scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELnzCQHq4SsNrDZzW2pXK8


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELnzCQHq4SsNrDZzW2pXK8)_