### PR TITLE
fix(model-builder): match FIELDS_AND_PROMPTS field keys case-insensitively (model-builder/t-029, cycle 18)

### DIFF
--- a/stores/helpers/modelBuilderFields.ts
+++ b/stores/helpers/modelBuilderFields.ts
@@ -255,22 +255,50 @@ export interface FieldLine {
 // raining." as the second sentence of a backstory) can't be mistaken for a
 // new field. When `modelType` is omitted, any non-empty key before the first
 // colon counts (the old, fully-generic behavior).
+//
+// Matched case-insensitively against the spec (model-builder/t-029, cycle
+// 18): MODEL_FIELDS' own keys are lowerCamelCase ('name', 'rewardType', ...),
+// but nothing about the FIELDS_AND_PROMPTS textarea tells a user typing a
+// field by hand to match that exact casing -- every other place the same key
+// surfaces (field.label in the batch editor, e.g. "Name", "Class") is
+// capitalized, which is exactly what someone free-typing "Name: Aria" would
+// reach for. Before this fix, "Name:" failed the case-sensitive knownKeys
+// check, so it wasn't a recognized field start -- and since it's typically
+// also the FIRST line of the blob, `previous` in parseFieldLines' loop below
+// is still unset, so the line (and often every line after it, cascading the
+// same miss) was silently dropped rather than merely mis-parsed. A record
+// committed from such a blob came out with blank/default fields and no error
+// anywhere -- the exact "silent data loss" class this file's continuation
+// fix (see parseFieldLines' own doc comment) already exists to prevent, just
+// reached through a case mismatch instead of a missing colon. Returning the
+// canonical spec-cased key (not the user's raw casing) keeps every
+// downstream consumer -- commit.post.ts's own `.toLowerCase()` lookups,
+// which already tolerated this, and readFieldLine/setFieldLine's direct
+// `line.key === key` comparisons against a caller-supplied canonical key,
+// which did not -- working consistently regardless of how the field was
+// originally typed.
 function isFieldStart(
   line: string,
-  knownKeys: Set<string> | null,
+  knownKeys: Map<string, string> | null,
 ): { key: string; rest: string } | null {
   const idx = line.indexOf(':')
   if (idx === -1) return null
-  const key = line.slice(0, idx).trim()
-  if (!key) return null
-  if (knownKeys && !knownKeys.has(key)) return null
-  return { key, rest: line.slice(idx + 1).trim() }
+  const rawKey = line.slice(0, idx).trim()
+  if (!rawKey) return null
+  if (knownKeys) {
+    const canonicalKey = knownKeys.get(rawKey.toLowerCase())
+    if (!canonicalKey) return null
+    return { key: canonicalKey, rest: line.slice(idx + 1).trim() }
+  }
+  return { key: rawKey, rest: line.slice(idx + 1).trim() }
 }
 
-function knownKeysFor(modelType?: string): Set<string> | null {
+function knownKeysFor(modelType?: string): Map<string, string> | null {
   if (!modelType) return null
   const spec = fieldSpecFor(modelType)
-  return spec.length ? new Set(spec.map((field) => field.key)) : null
+  return spec.length
+    ? new Map(spec.map((field) => [field.key.toLowerCase(), field.key]))
+    : null
 }
 
 // Splits a FIELDS_AND_PROMPTS blob ("key: value" lines, one per field) into

--- a/utils/scripts/verifyModelBuilderFieldBlobContinuationGuard.ts
+++ b/utils/scripts/verifyModelBuilderFieldBlobContinuationGuard.ts
@@ -35,6 +35,23 @@
 // would be. A light textual check is kept alongside it for the one thing
 // behavioral testing can't see -- whether commit.post.ts still delegates to
 // the shared splitter instead of re-inlining its own copy.
+//
+// Extended (model-builder/t-029, cycle 18) to cover a second way this same
+// pair of functions silently dropped user content: field-key matching was
+// case-sensitive against MODEL_FIELDS' lowerCamelCase keys ('name', 'class',
+// 'rewardType', ...), but nothing in the FIELDS_AND_PROMPTS textarea tells a
+// user typing a field by hand to match that exact casing -- every other
+// place the same key surfaces (field.label in the batch editor, e.g. "Name",
+// "Class") is capitalized. "Name: Aria" typed by hand failed the
+// case-sensitive check, so it wasn't recognized as a field start -- and
+// being typically the FIRST line, there was no `previous` field yet to
+// append it to as a continuation, so it (and everything cascading after it)
+// was dropped outright, same as the original continuation bug this guard
+// already protects, just reached through a case mismatch instead of a
+// missing colon. Fixed by matching knownKeys case-insensitively and emitting
+// the canonical spec-cased key, so parseFieldLines/readFieldLine/
+// setFieldLine and commit.post.ts's own `.toLowerCase()` field lookups all
+// agree regardless of how the field was originally typed.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -148,6 +165,66 @@ export function checkFieldBlobContinuation(): string[] {
     )
   }
 
+  // A user typing field keys with natural capitalization ("Name:", "Class:",
+  // "Personality:") -- rather than MODEL_FIELDS' own lowerCamelCase keys --
+  // must still be recognized, not silently dropped. This is the exact same
+  // "typed by hand into a free-text textarea with no format enforcement"
+  // path as the multi-line/stray-colon cases above, just varying case
+  // instead of structure.
+  const mixedCase =
+    'Name: Aria Nightshade\nClass: Warrior\nPersonality: stoic, guarded'
+  const mixedParsed = parseFieldLines(mixedCase, 'Character')
+  const mixedByKey = new Map(mixedParsed.map((line) => [line.key, line.value]))
+  if (mixedByKey.get('name') !== 'Aria Nightshade') {
+    errors.push(
+      'parseFieldLines() drops or misparses a field typed with natural ' +
+        'capitalization ("Name:" against the spec key "name") -- expected ' +
+        `"name" to equal "Aria Nightshade", got ${JSON.stringify(mixedParsed)}.`,
+    )
+  }
+  if (mixedByKey.get('class') !== 'Warrior') {
+    errors.push(
+      'parseFieldLines() drops or misparses "Class:" against the spec key ' +
+        `"class" -- got ${JSON.stringify(mixedParsed)}.`,
+    )
+  }
+  if (mixedByKey.get('personality') !== 'stoic, guarded') {
+    errors.push(
+      'parseFieldLines() drops or misparses "Personality:" against the ' +
+        `spec key "personality" -- got ${JSON.stringify(mixedParsed)}.`,
+    )
+  }
+
+  // readFieldLine/setFieldLine take a canonical key from the caller (e.g.
+  // batchSetField's field.key) -- they must still find a field the user
+  // typed in a different case, not treat it as absent and append a
+  // duplicate.
+  const mixedCaseReadBack = readFieldLine(mixedCase, 'name', 'Character')
+  if (mixedCaseReadBack !== 'Aria Nightshade') {
+    errors.push(
+      'readFieldLine() does not find "Name:" when asked for the canonical ' +
+        `key "name" -- got ${JSON.stringify(mixedCaseReadBack)}.`,
+    )
+  }
+  const mixedCaseReplaced = setFieldLine(
+    mixedCase,
+    'name',
+    'Corvin Ashwood',
+    'Character',
+  )
+  const mixedCaseReplacedParsed = parseFieldLines(
+    mixedCaseReplaced,
+    'Character',
+  )
+  if (
+    mixedCaseReplacedParsed.filter((line) => line.key === 'name').length !== 1
+  ) {
+    errors.push(
+      'setFieldLine() appended a duplicate "name" field instead of ' +
+        `replacing the one typed as "Name:" -- got ${JSON.stringify(mixedCaseReplacedParsed)}.`,
+    )
+  }
+
   return errors
 }
 
@@ -193,9 +270,11 @@ function main(): void {
 
   console.log(
     'Model Builder field-blob continuation guard passed: multi-line prose ' +
-      'values in the FIELDS_AND_PROMPTS blob survive parseFieldLines/' +
-      'readFieldLine/setFieldLine round-trips, and commit.post.ts delegates ' +
-      'to the shared splitter instead of a hand-rolled duplicate.',
+      'values and naturally-capitalized field keys ("Name:" against the ' +
+      'spec key "name") in the FIELDS_AND_PROMPTS blob survive ' +
+      'parseFieldLines/readFieldLine/setFieldLine round-trips, and ' +
+      'commit.post.ts delegates to the shared splitter instead of a ' +
+      'hand-rolled duplicate.',
   )
 }
 


### PR DESCRIPTION
## Cycle 18 — Model Builder polish (model-builder/t-029)

### Investigated cycle 17's suggested lead — not a live bug

Cycle 17 suggested auditing `assertArtImageAttachable` for the same
"checked-once-outside-the-transaction, never revalidated at write time"
shape it had just fixed for content-stage editability.

I confirmed the shape exists: `items/[id].patch.ts` and
`items/batch.patch.ts` both call `assertArtImageAttachable` exactly once,
before `prisma.$transaction`, using `body.artImageId`/`auth.user.id` — and
never re-check it inside the transaction.

But it isn't exploitable, and I found it was already deliberately handled
this way:

- `relations.ts`'s own header comment says the guard exists because "an
  item's `artImageId` is **later promoted** onto the run's owner-verified
  source record" — i.e. the risk is entirely at the promotion point, not
  the attach point.
- `commit.post.ts`'s `ASSET_ONLY` branch already re-calls
  `assertArtImageAttachable` immediately before `promoteAsset()` — the
  exact write that actually matters — and
  `verifyModelBuilderCommitAssetAttachableGuard.ts` documents this fix in
  detail (concrete repro included) and asserts the shape stays in place.
- The `ModelBuildItem` row the PATCH routes write to is never visible to
  anyone but its owner/admin (`assertRunAccess` gates every read and write
  route), and the PATCH response's `itemInclude` never resolves the
  `ArtImage` relation — so a stale attach-time check on the PATCH route
  can't leak a private image's content or metadata to anyone the item's
  owner couldn't already show it to. There's nothing downstream of the
  PATCH write itself that depends on the attach-time check still holding,
  other than commit — which re-checks.

So this matches the task's own "not a real bug" criteria (already
re-validated at the point that matters). No fix made for this.

### Bug found and fixed instead: case-sensitive field-key matching silently drops FIELDS_AND_PROMPTS content

`parseFieldLines()`/`setFieldLine()` in
`stores/helpers/modelBuilderFields.ts` recognize a `"key: value"` line as
a field start only when `key` **exactly** matches a `MODEL_FIELDS` spec key
— all of which are lowerCamelCase (`name`, `class`, `rewardType`, ...).
Nothing in the FIELDS_AND_PROMPTS textarea tells a user typing a field by
hand to match that exact casing — every other place the same key surfaces
(`field.label` in the batch editor: "Name", "Class", "Personality") is
capitalized, which is exactly what a person free-typing `Name: Aria` would
reach for.

Repro (unpatched):
```ts
parseFieldLines('Name: Aria Nightshade\nClass: Warrior\nPersonality: stoic', 'Character')
// => []  (every line silently dropped)
```

Because a case-mismatched key isn't recognized as a field start, and it's
typically the *first* line of the blob, there's no `previous` field yet
for the parser's continuation-line fallback to append it to — so the line
(and everything cascading after it) is dropped outright, with **no error
anywhere**. `commit.post.ts` parses this exact same blob into the typed
columns it writes to the database on commit, so a record could be created
with blank/default fields despite the user having filled in a full blob —
the same "silent data loss" class the existing
`verifyModelBuilderFieldBlobContinuationGuard.ts` fix already protects
against (PR #1905), just reached through a case mismatch instead of a
missing colon/multi-line value.

**Fix:** match known field keys case-insensitively and emit the canonical
spec-cased key, so `parseFieldLines`/`readFieldLine`/`setFieldLine` and
`commit.post.ts`'s own `.toLowerCase()` field lookups all agree regardless
of how the field was originally typed. The no-`modelType` generic path
(used with no known-key set) is unchanged.

### Guard / tests

- Extended `verifyModelBuilderFieldBlobContinuationGuard.ts`'s existing
  behavioral check (`checkFieldBlobContinuation`) with a mixed-case
  fixture (`Name:`/`Class:`/`Personality:` against `Character`'s spec) —
  covering `parseFieldLines`, `readFieldLine`, and `setFieldLine`'s
  replace-in-place behavior.
- **Git-stash round trip**: stashed the `modelBuilderFields.ts` fix (kept
  the extended guard), ran the self-test — failed with 4 clear assertion
  errors describing exactly the bug above. Unstashed — self-test and guard
  both pass again.

### Checks run

- `npm run test:model-builder-field-blob-continuation-guard-selftest` — pass
- `npm run test:model-builder-field-blob-continuation-guard` — pass
- `npm run test:model-builder-commit-name-field-guard-selftest` — pass (adjacent guard touching the same field-parsing surface)
- `npm run test:model-builder-commit-name-field-guard` — pass
- `npm run test:model-builder-link-coverage` — pass
- `npx eslint` on both touched files — clean
- `npx prettier --check` on both touched files — clean (one file needed `--write`, applied)
- `npm run test` (`vue-tsc --noEmit`, full project) — pass, exit 0, no type errors

### Suggested lead for cycle 19

`readFieldLine()` (same file, `stores/helpers/modelBuilderFields.ts`) is
currently unused in production code — only `setFieldLine` and
`parseFieldLines` have real call sites (`batchSetField` /
`commit.post.ts`). Worth checking whether the FIELDS_AND_PROMPTS UI (or a
future single-field editor) *should* be using `readFieldLine` to
pre-populate the batch editor's per-field inputs (`model-builder-batch-
editor.vue`'s `batchValues`) from the group's existing blob, rather than
always starting blank — right now `batchValues` is a bare `reactive<Record
<string, string>>({})` with no initialization from `group.value.items`,
so "Set a field on all N" always starts every input empty even when every
item in the group already shares the same value for that field, which is
a small but real UX gap (and worth double-checking there isn't a matching
silent-overwrite risk if the field actually differs across items in the
group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
