### PR TITLE
fix(davinci): restore focus to the chapter region after a choice (t-021 slice 9)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -308,6 +308,12 @@ jobs:
       - name: Da Vinci narration-error role guard
         run: npm run test:davinci-narration-error-role-guard
 
+      - name: Da Vinci chapter-focus guard self-test
+        run: npm run test:davinci-chapter-focus-guard-selftest
+
+      - name: Da Vinci chapter-focus guard
+        run: npm run test:davinci-chapter-focus-guard
+
       - name: Serendipity Voice poll guard self-test
         run: npm run test:serendipity-voice-poll-guard-selftest
 

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -173,31 +173,48 @@
             </div>
           </div>
 
-          <!-- Narrator is composing this chapter. role="status"/aria-live
-               match every comparable busy indicator elsewhere in the app
-               (academy-manager.vue, model-builder-manager.vue,
-               model-builder-run-history.vue, narrative-response-composer.vue,
-               kr-chat-window.vue, watchlist-browse.vue,
-               narrative-ingredient-picker.vue) -- this was the one busy state
-               in davinci-page.vue left as a purely visual spinner with no
-               announcement to assistive tech. -->
-          <div
-            v-if="narrating"
-            role="status"
-            aria-live="polite"
-            class="flex flex-col items-center gap-3 rounded-2xl border border-base-300 bg-base-200/40 p-8 text-center"
-          >
-            <span
-              class="loading loading-dots loading-lg text-primary/70"
-              aria-hidden="true"
-            />
-            <p class="text-xs font-semibold text-base-content/50">
-              {{ narratorName || 'The narrator' }} is writing chapter
-              {{ chapterIndex }}…
-            </p>
-          </div>
+          <!-- Wraps every block that swaps in/out as narrating/narrationError/
+               currentChapter change (busy, error, chapter, and the "See your
+               ending" resolve panel below). Clicking a choice inside the
+               chapter block, or "Try again"/"Play the written chapters
+               instead" inside the error block, unmounts whichever block held
+               the clicked button via this v-if/v-else-if chain -- the exact
+               focus-loss shape model-builder-manager.vue's own `mainContent`
+               region already documents and fixes ("several buttons *inside*
+               the current step's own component change store.step, unmounting
+               that whole component ... with nothing moving focus anywhere
+               afterward, so the browser drops it to <body>"). tabindex="-1"
+               lets this region receive focus programmatically without
+               joining the normal Tab order, mirroring that same `<main
+               ref="mainContent" tabindex="-1">` pattern; the paired watch
+               below restores focus here once a click from inside this region
+               causes the visible block to change. -->
+          <div ref="chapterRegion" tabindex="-1" aria-label="Current chapter">
+            <!-- Narrator is composing this chapter. role="status"/aria-live
+                 match every comparable busy indicator elsewhere in the app
+                 (academy-manager.vue, model-builder-manager.vue,
+                 model-builder-run-history.vue, narrative-response-composer.vue,
+                 kr-chat-window.vue, watchlist-browse.vue,
+                 narrative-ingredient-picker.vue) -- this was the one busy
+                 state in davinci-page.vue left as a purely visual spinner
+                 with no announcement to assistive tech. -->
+            <div
+              v-if="narrating"
+              role="status"
+              aria-live="polite"
+              class="flex flex-col items-center gap-3 rounded-2xl border border-base-300 bg-base-200/40 p-8 text-center"
+            >
+              <span
+                class="loading loading-dots loading-lg text-primary/70"
+                aria-hidden="true"
+              />
+              <p class="text-xs font-semibold text-base-content/50">
+                {{ narratorName || 'The narrator' }} is writing chapter
+                {{ chapterIndex }}…
+              </p>
+            </div>
 
-          <!-- Narration failed. Per the narration-layer spec a broken chapter
+            <!-- Narration failed. Per the narration-layer spec a broken chapter
                surfaces a visible retry rather than a silently fabricated one,
                so the curated pool is offered as an explicit, labelled choice
                instead of a transparent fallback. role="alert" matches every
@@ -209,55 +226,55 @@
                warning-toned block in davinci-page.vue with no role/aria
                semantics at all, left uncovered even after slice 2 fixed its
                color tone. -->
-          <div
-            v-else-if="narrationError"
-            role="alert"
-            class="flex flex-col items-center gap-3 rounded-2xl border border-warning/40 bg-warning/10 p-6 text-center"
-          >
-            <Icon name="kind-icon:warning" class="size-8 text-warning/70" />
-            <p class="text-sm text-base-content/70">
-              The narrator is having trouble with this chapter.
-            </p>
-            <p class="text-xs text-base-content/50">{{ narrationError }}</p>
-            <div class="flex flex-wrap justify-center gap-2">
-              <button
-                type="button"
-                class="btn btn-primary btn-sm gap-1.5 rounded-xl"
-                :disabled="narrating"
-                @click="narrateChapter()"
-              >
-                <Icon name="kind-icon:refresh" class="size-4" />
-                Try again
-              </button>
-              <button
-                type="button"
-                class="btn btn-outline btn-sm rounded-xl"
-                @click="useCuratedChapters"
-              >
-                Play the written chapters instead
-              </button>
-            </div>
-          </div>
-
-          <div
-            v-else-if="currentChapter"
-            class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200/40 p-4"
-          >
-            <h4 v-if="currentChapter.title" class="text-base font-black">
-              {{ currentChapter.title }}
-            </h4>
-            <NarrativeArtStatus
-              v-if="currentChapterArt"
-              :art="currentChapterArt"
-              :label="`Illustration for chapter ${chapterIndex}`"
-              @retry="retryCurrentChapterArt"
-            />
-            <p
-              class="whitespace-pre-line text-sm leading-relaxed text-base-content/75"
+            <div
+              v-else-if="narrationError"
+              role="alert"
+              class="flex flex-col items-center gap-3 rounded-2xl border border-warning/40 bg-warning/10 p-6 text-center"
             >
-              {{ currentChapter.narrative }}
-            </p>
-            <!-- Was a hand-rolled v-for of plain btn-outline buttons -- the
+              <Icon name="kind-icon:warning" class="size-8 text-warning/70" />
+              <p class="text-sm text-base-content/70">
+                The narrator is having trouble with this chapter.
+              </p>
+              <p class="text-xs text-base-content/50">{{ narrationError }}</p>
+              <div class="flex flex-wrap justify-center gap-2">
+                <button
+                  type="button"
+                  class="btn btn-primary btn-sm gap-1.5 rounded-xl"
+                  :disabled="narrating"
+                  @click="narrateChapter()"
+                >
+                  <Icon name="kind-icon:refresh" class="size-4" />
+                  Try again
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-outline btn-sm rounded-xl"
+                  @click="useCuratedChapters"
+                >
+                  Play the written chapters instead
+                </button>
+              </div>
+            </div>
+
+            <div
+              v-else-if="currentChapter"
+              class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200/40 p-4"
+            >
+              <h4 v-if="currentChapter.title" class="text-base font-black">
+                {{ currentChapter.title }}
+              </h4>
+              <NarrativeArtStatus
+                v-if="currentChapterArt"
+                :art="currentChapterArt"
+                :label="`Illustration for chapter ${chapterIndex}`"
+                @retry="retryCurrentChapterArt"
+              />
+              <p
+                class="whitespace-pre-line text-sm leading-relaxed text-base-content/75"
+              >
+                {{ currentChapter.narrative }}
+              </p>
+              <!-- Was a hand-rolled v-for of plain btn-outline buttons -- the
                  fourth duplicate of exactly the pick-one-option list
                  kr-choice-list.vue was built to unify (its own doc comment:
                  "replaces at least three separate implementations of the
@@ -273,24 +290,24 @@
                  existing plain-button look, rather than also opting into
                  the numbered "storybook gesture" badge as an unrelated
                  visual change in the same pass. -->
-            <kr-choice-list
-              layout="stack"
-              label="Choices for this chapter"
-              :choices="currentChapterChoices"
-              :disabled="submitting"
-              :show-index="false"
-              @select="chooseOptionByKey"
-            />
-            <p
-              v-if="currentChapter.milestoneCandidate"
-              class="text-[0.65rem] italic text-base-content/40"
-            >
-              This life seems headed toward
-              {{ currentChapter.milestoneCandidate }}.
-            </p>
-          </div>
+              <kr-choice-list
+                layout="stack"
+                label="Choices for this chapter"
+                :choices="currentChapterChoices"
+                :disabled="submitting"
+                :show-index="false"
+                @select="chooseOptionByKey"
+              />
+              <p
+                v-if="currentChapter.milestoneCandidate"
+                class="text-[0.65rem] italic text-base-content/40"
+              >
+                This life seems headed toward
+                {{ currentChapter.milestoneCandidate }}.
+              </p>
+            </div>
 
-          <!-- The run may be ended any time after chapter 6 (raised from 3,
+            <!-- The run may be ended any time after chapter 6 (raised from 3,
                davinci/t-024: simulation-backed, see MIN_CHAPTERS_BEFORE_ENDING
                above) -- enough chapters for a meaningful spread of dimensions.
                The narrator never decides when a life ends — the player does.
@@ -302,33 +319,34 @@
                narration-error retry panel with the misleading "Your
                chapters are told" copy, even at chapter 1 with zero recorded
                choices. -->
-          <div
-            v-if="
-              !narrating && !narrationError && (canEndRun || !currentChapter)
-            "
-            class="flex flex-col items-center gap-3 rounded-2xl border border-primary/30 bg-primary/5 p-6 text-center"
-          >
-            <Icon name="kind-icon:trophy" class="size-8 text-primary/70" />
-            <p class="text-sm text-base-content/70">
-              {{
-                currentChapter
-                  ? 'You can keep living, or draw the line here and see what it all added up to.'
-                  : "Your chapters are told. It's time to see how this life resolves."
-              }}
-            </p>
-            <button
-              type="button"
-              class="btn btn-primary btn-sm gap-1.5 rounded-xl"
-              :disabled="submitting"
-              @click="resolveLife"
+            <div
+              v-if="
+                !narrating && !narrationError && (canEndRun || !currentChapter)
+              "
+              class="flex flex-col items-center gap-3 rounded-2xl border border-primary/30 bg-primary/5 p-6 text-center"
             >
-              <span
-                v-if="submitting"
-                class="loading loading-spinner loading-sm"
-              />
-              <Icon v-else name="kind-icon:trophy" class="size-4" />
-              See your ending
-            </button>
+              <Icon name="kind-icon:trophy" class="size-8 text-primary/70" />
+              <p class="text-sm text-base-content/70">
+                {{
+                  currentChapter
+                    ? 'You can keep living, or draw the line here and see what it all added up to.'
+                    : "Your chapters are told. It's time to see how this life resolves."
+                }}
+              </p>
+              <button
+                type="button"
+                class="btn btn-primary btn-sm gap-1.5 rounded-xl"
+                :disabled="submitting"
+                @click="resolveLife"
+              >
+                <span
+                  v-if="submitting"
+                  class="loading loading-spinner loading-sm"
+                />
+                <Icon v-else name="kind-icon:trophy" class="size-4" />
+                See your ending
+              </button>
+            </div>
           </div>
         </div>
 
@@ -398,7 +416,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { performFetch } from '@/stores/utils'
 import { useUserStore } from '@/stores/userStore'
 import type { ProjectFrontConfig } from '@/components/conductor/projectFront'
@@ -693,6 +711,12 @@ const narrating = ref(false)
 const narrationError = ref('')
 const narratorName = ref('')
 const aiChapter = ref<ActiveChapter | null>(null)
+// The region wrapping the narrating/narrationError/currentChapter/resolve
+// blocks (template) -- tabindex="-1" so it can receive focus
+// programmatically without joining the normal Tab order. See the paired
+// watch below and the template comment on this element for the bug this
+// closes.
+const chapterRegion = ref<HTMLElement | null>(null)
 
 // Contextual in-run art (davinci/t-020). The narrator proposes an artPrompt
 // per chapter and the resolve screen synthesizes one for the ending; both are
@@ -727,6 +751,35 @@ const currentChapter = computed<ActiveChapter | null>(() =>
 
 const canEndRun = computed(
   () => playedCount.value >= MIN_CHAPTERS_BEFORE_ENDING,
+)
+
+// Mirrors model-builder-manager.vue's `mainContent`/`store.step` watcher:
+// choosing an option, retrying a failed narration, or switching to the
+// curated pool all click a button that lives *inside* one of the
+// narrating/narrationError/currentChapter blocks above and then flip which
+// of those blocks is showing via the v-if/v-else-if chain, unmounting the
+// clicked button along with the block that held it. Nothing moved focus
+// afterward, so it fell back to <body> -- a keyboard or screen-reader user
+// had to re-discover the new chapter (or the busy/error state) from the top
+// of the page after every single choice, the core interaction loop of this
+// whole product. Checking `chapterRegion.value?.contains(document.activeElement)`
+// at watch time (before Vue patches the DOM, so activeElement is still
+// whatever was focused at the moment of the click) tells an in-region click
+// apart from anything else that could theoretically change these three refs
+// (e.g. a future caller flipping narrationMode) without moving focus itself.
+watch(
+  () =>
+    [
+      narrating.value,
+      narrationError.value,
+      Boolean(currentChapter.value),
+    ] as const,
+  () => {
+    if (!chapterRegion.value?.contains(document.activeElement)) return
+    void nextTick(() => {
+      chapterRegion.value?.focus()
+    })
+  },
 )
 
 const currentChapterArt = computed<NarrativeArtJobState | undefined>(

--- a/package.json
+++ b/package.json
@@ -105,6 +105,8 @@
     "test:davinci-dimension-group-guard": "tsx utils/scripts/verifyDaVinciDimensionGroupGuard.ts",
     "test:davinci-narration-error-role-guard-selftest": "tsx utils/scripts/verifyDaVinciNarrationErrorRoleGuard.test.ts",
     "test:davinci-narration-error-role-guard": "tsx utils/scripts/verifyDaVinciNarrationErrorRoleGuard.ts",
+    "test:davinci-chapter-focus-guard-selftest": "tsx utils/scripts/verifyDaVinciChapterFocusGuard.test.ts",
+    "test:davinci-chapter-focus-guard": "tsx utils/scripts/verifyDaVinciChapterFocusGuard.ts",
     "test:serendipity-voice-poll-guard-selftest": "tsx utils/scripts/verifySerendipityVoicePollGuard.test.ts",
     "test:serendipity-voice-poll-guard": "tsx utils/scripts/verifySerendipityVoicePollGuard.ts",
     "test:serendipity-voice-cursor-reset-selftest": "tsx utils/scripts/verifySerendipityVoiceCursorReset.test.ts",

--- a/utils/scripts/verifyDaVinciChapterFocusGuard.test.ts
+++ b/utils/scripts/verifyDaVinciChapterFocusGuard.test.ts
@@ -1,0 +1,190 @@
+// /utils/scripts/verifyDaVinciChapterFocusGuard.test.ts
+//
+// Regression test for checkChapterFocusGuard() in
+// verifyDaVinciChapterFocusGuard.ts (davinci/t-021 slice 9). Exercises the
+// real check against synthetic component-shaped fixtures covering: the
+// fixed shape (wrapper + ref/watch all present), several individually-
+// regressed pre-fix shapes (missing wrapper ref, missing tabindex, missing
+// script-side ref declaration, missing activeElement guard, missing the
+// focus() call), and a missing-block regression (the chapter region
+// restructured away entirely).
+import assert from 'node:assert/strict'
+
+import { checkChapterFocusGuard } from './verifyDaVinciChapterFocusGuard.js'
+
+function templateFixture(wrapperOpenTag: string): string {
+  return `
+<template>
+  ${wrapperOpenTag}
+    <div
+      v-if="narrating"
+      role="status"
+      aria-live="polite"
+    >
+      narrating…
+    </div>
+    <div v-else-if="narrationError" role="alert">error</div>
+    <div v-else-if="currentChapter">chapter</div>
+  </div>
+</template>
+`
+}
+
+const SCRIPT_FIXED = `
+<script setup lang="ts">
+const chapterRegion = ref<HTMLElement | null>(null)
+
+watch(
+  () => [narrating.value, narrationError.value, Boolean(currentChapter.value)] as const,
+  () => {
+    if (!chapterRegion.value?.contains(document.activeElement)) return
+    void nextTick(() => {
+      chapterRegion.value?.focus()
+    })
+  },
+)
+</script>
+`
+
+const FIXED_TEMPLATE = templateFixture(
+  '<div ref="chapterRegion" tabindex="-1" aria-label="Current chapter">',
+)
+const FIXED = FIXED_TEMPLATE + SCRIPT_FIXED
+
+// Pre-fix shape: the wrapper div exists but carries neither ref nor
+// tabindex (a plain grouping div, the state before this slice).
+const NO_WRAPPER_ATTRS_TEMPLATE = templateFixture('<div>')
+const NO_WRAPPER_ATTRS = NO_WRAPPER_ATTRS_TEMPLATE + SCRIPT_FIXED
+
+// Regression: ref present but tabindex dropped (not focusable).
+const MISSING_TABINDEX_TEMPLATE = templateFixture(
+  '<div ref="chapterRegion" aria-label="Current chapter">',
+)
+const MISSING_TABINDEX = MISSING_TABINDEX_TEMPLATE + SCRIPT_FIXED
+
+// Regression: template wrapper correct, but the script-side ref declaration
+// was removed.
+const MISSING_SCRIPT_REF =
+  FIXED_TEMPLATE +
+  `
+<script setup lang="ts">
+watch(
+  () => [narrating.value, narrationError.value, Boolean(currentChapter.value)] as const,
+  () => {
+    if (!chapterRegion.value?.contains(document.activeElement)) return
+    void nextTick(() => {
+      chapterRegion.value?.focus()
+    })
+  },
+)
+</script>
+`
+
+// Regression: the activeElement guard was dropped, so the watch would
+// steal focus unconditionally.
+const MISSING_GUARD_SCRIPT = `
+<script setup lang="ts">
+const chapterRegion = ref<HTMLElement | null>(null)
+
+watch(
+  () => [narrating.value, narrationError.value, Boolean(currentChapter.value)] as const,
+  () => {
+    void nextTick(() => {
+      chapterRegion.value?.focus()
+    })
+  },
+)
+</script>
+`
+const MISSING_GUARD = FIXED_TEMPLATE + MISSING_GUARD_SCRIPT
+
+// Regression: the guard check survives but the actual focus() call was
+// dropped -- the region exists, is checked, but focus never moves.
+const MISSING_FOCUS_CALL_SCRIPT = `
+<script setup lang="ts">
+const chapterRegion = ref<HTMLElement | null>(null)
+
+watch(
+  () => [narrating.value, narrationError.value, Boolean(currentChapter.value)] as const,
+  () => {
+    if (!chapterRegion.value?.contains(document.activeElement)) return
+    void nextTick(() => {})
+  },
+)
+</script>
+`
+const MISSING_FOCUS_CALL = FIXED_TEMPLATE + MISSING_FOCUS_CALL_SCRIPT
+
+// The narrating block itself no longer exists -- the guard's anchor marker
+// is gone.
+const BLOCK_REMOVED =
+  `
+<template>
+  <div class="playing">
+    <p>Something else entirely.</p>
+  </div>
+</template>
+` + SCRIPT_FIXED
+
+function run(): void {
+  const fixedErrors = checkChapterFocusGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const noWrapperAttrsErrors = checkChapterFocusGuard(NO_WRAPPER_ATTRS)
+  assert.equal(noWrapperAttrsErrors.length, 2)
+  assert.ok(
+    noWrapperAttrsErrors.some((e) =>
+      /no longer has a ref="chapterRegion"/.test(e),
+    ),
+  )
+  assert.ok(
+    noWrapperAttrsErrors.some((e) => /no longer carries tabindex="-1"/.test(e)),
+  )
+
+  const missingTabindexErrors = checkChapterFocusGuard(MISSING_TABINDEX)
+  assert.equal(missingTabindexErrors.length, 1)
+  assert.ok(
+    missingTabindexErrors.some((e) =>
+      /no longer carries tabindex="-1"/.test(e),
+    ),
+  )
+
+  const missingScriptRefErrors = checkChapterFocusGuard(MISSING_SCRIPT_REF)
+  assert.equal(missingScriptRefErrors.length, 1)
+  assert.ok(
+    missingScriptRefErrors.some((e) =>
+      /template ref declaration is missing/.test(e),
+    ),
+  )
+
+  const missingGuardErrors = checkChapterFocusGuard(MISSING_GUARD)
+  assert.equal(missingGuardErrors.length, 1)
+  assert.ok(missingGuardErrors.some((e) => /no longer checks/.test(e)))
+
+  const missingFocusCallErrors = checkChapterFocusGuard(MISSING_FOCUS_CALL)
+  assert.equal(missingFocusCallErrors.length, 1)
+  assert.ok(
+    missingFocusCallErrors.some((e) =>
+      /focus\(\)` -- the region exists/.test(e),
+    ),
+  )
+
+  const blockRemovedErrors = checkChapterFocusGuard(BLOCK_REMOVED)
+  assert.equal(blockRemovedErrors.length, 1)
+  assert.ok(
+    blockRemovedErrors.some((e) => /Could not find the wrapper/.test(e)),
+  )
+
+  console.log(
+    'Da Vinci chapter-focus guard self-test passed: missing-ref, missing-' +
+      'tabindex, missing-script-ref, missing-guard, missing-focus-call, and ' +
+      'missing-block regressions all fail individually; the fixed fixture ' +
+      'passes.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyDaVinciChapterFocusGuard.ts
+++ b/utils/scripts/verifyDaVinciChapterFocusGuard.ts
@@ -1,0 +1,156 @@
+// /utils/scripts/verifyDaVinciChapterFocusGuard.ts
+//
+// Regression guard (davinci/t-021 slice 9) -- the narrating/narrationError/
+// currentChapter/resolve-panel blocks in components/conductor/davinci-page.vue
+// swap in and out via one v-if/v-else-if chain, but nothing moved focus
+// after a swap that was itself triggered by a click *inside* the region
+// being replaced. Choosing an option (kr-choice-list -> chooseOptionByKey ->
+// chooseOption -> narrateChapter), clicking "Try again", and clicking "Play
+// the written chapters instead" all click a button that then gets unmounted
+// along with whichever block held it, so the browser dropped focus to
+// <body> -- a keyboard or screen-reader user had to re-discover the new
+// chapter (or the busy/error state) from the top of the page after every
+// single choice, the core interaction loop of this whole product.
+//
+// This is the exact focus-loss shape model-builder-manager.vue's own
+// `mainContent` region already documents and fixes: "several buttons
+// *inside* the current step's own component change store.step, unmounting
+// that whole component ... with nothing moving focus anywhere afterward, so
+// the browser drops it to <body>." Fixed the same way: wrap the swapping
+// blocks in one persistent `ref="chapterRegion" tabindex="-1"` container
+// that never itself unmounts across the swap, then a `watch` on the trio of
+// refs the v-if chain switches on that checks
+// `chapterRegion.value?.contains(document.activeElement)` at watch time
+// (before Vue patches the DOM) to tell an in-region click apart from
+// anything else, and calls `chapterRegion.value?.focus()` in `nextTick()`
+// when it was.
+//
+// Deliberately scoped to this one template block and its paired script-side
+// ref/watch, mirroring this project's other narrow textual guards over a
+// general-purpose static analyzer (see verifyDaVinciNarrationErrorRoleGuard.ts,
+// verifyDaVinciDimensionGroupGuard.ts).
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const COMPONENT_PATH = join(
+  repositoryRoot,
+  'components/conductor/davinci-page.vue',
+)
+
+// Anchored on the `v-if="narrating"` marker -- the first branch of the chain
+// this guard's wrapper needs to enclose -- rather than any surrounding
+// wording, so a rename/restructure of the block reports *how* it moved
+// instead of just "not found".
+const NARRATING_MARKER = 'v-if="narrating"'
+
+export function extractChapterRegionOpeningTag(content: string): string | null {
+  const markerIndex = content.indexOf(NARRATING_MARKER)
+  if (markerIndex === -1) return null
+
+  // The wrapper is the nearest enclosing <div ...> that opens before the
+  // narrating block's own <div v-if="narrating" ...> tag.
+  const narratingTagStart = content.lastIndexOf('<div', markerIndex)
+  if (narratingTagStart === -1) return null
+
+  const wrapperTagStart = content.lastIndexOf('<div', narratingTagStart - 1)
+  if (wrapperTagStart === -1) return null
+  const wrapperTagEnd = content.indexOf('>', wrapperTagStart)
+  if (wrapperTagEnd === -1) return null
+
+  return content.slice(wrapperTagStart, wrapperTagEnd + 1)
+}
+
+export function checkChapterFocusGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const openingTag = extractChapterRegionOpeningTag(content)
+  if (!openingTag) {
+    errors.push(
+      `Could not find the wrapper enclosing \`${NARRATING_MARKER}\` in ` +
+        'davinci-page.vue -- has the chapter region been renamed, removed, ' +
+        'or restructured? If so, this guard needs to move with it.',
+    )
+    return errors
+  }
+
+  if (!openingTag.includes('ref="chapterRegion"')) {
+    errors.push(
+      'The narrating/narrationError/currentChapter/resolve-panel chain no ' +
+        'longer has a ref="chapterRegion" wrapper -- the paired focus-' +
+        'restoring watch has nothing to focus, so a keyboard/screen-reader ' +
+        'user is dropped to <body> after every choice again.',
+    )
+  }
+
+  if (!openingTag.includes('tabindex="-1"')) {
+    errors.push(
+      'The chapter-region wrapper no longer carries tabindex="-1" -- it ' +
+        "can't receive focus programmatically (a plain <div> isn't " +
+        "focusable), matching model-builder-manager.vue's " +
+        '`<main ref="mainContent" tabindex="-1">` precedent for this same ' +
+        'focus-loss shape.',
+    )
+  }
+
+  if (
+    !content.includes('const chapterRegion = ref<HTMLElement | null>(null)')
+  ) {
+    errors.push(
+      'The `chapterRegion` template ref declaration is missing from the ' +
+        '<script setup> block.',
+    )
+  }
+
+  if (
+    !content.includes('chapterRegion.value?.contains(document.activeElement)')
+  ) {
+    errors.push(
+      'The focus-restoring watch no longer checks ' +
+        '`chapterRegion.value?.contains(document.activeElement)` before ' +
+        'moving focus -- without this check, the watch would steal focus ' +
+        'even when the state change did not originate from a click inside ' +
+        'the region (e.g. a future caller flipping narrationMode), the ' +
+        "exact false-positive model-builder-manager.vue's own watch is " +
+        'careful to avoid.',
+    )
+  }
+
+  if (!content.includes('chapterRegion.value?.focus()')) {
+    errors.push(
+      'The focus-restoring watch no longer calls `chapterRegion.value?.focus()` ' +
+        '-- the region exists but focus is never actually moved back to it.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(COMPONENT_PATH, 'utf8')
+  const errors = checkChapterFocusGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Da Vinci chapter-focus guard contract failed in davinci-page.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Da Vinci chapter-focus guard contract passed: the narrating/' +
+      'narrationError/currentChapter/resolve-panel chain still restores ' +
+      'focus to itself after an in-region click swaps the visible block, ' +
+      'so keyboard and screen-reader users are never dropped to <body> ' +
+      'after a choice.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
davinci/t-021: Da Vinci visual style and interaction polish pass — slice 9 (kind: software)

### What changed / what I produced
- `components/conductor/davinci-page.vue`'s narrating/narrationError/currentChapter/resolve-panel blocks swap in and out via one `v-if`/`v-else-if` chain. Choosing an option (`kr-choice-list` → `chooseOptionByKey` → `chooseOption` → `narrateChapter`), clicking "Try again", and clicking "Play the written chapters instead" all click a button that lives *inside* one of these blocks, and the click then flips which block is showing — unmounting the clicked button along with the whole block that held it. Nothing moved focus afterward, so the browser dropped it to `<body>`: a keyboard or screen-reader user had to re-discover the new chapter (or the busy/error state) from the top of the page after every single choice — the core interaction loop of this whole product.
- This is the exact focus-loss shape `model-builder-manager.vue`'s own `mainContent` region already documents and fixes: *"several buttons inside the current step's own component change store.step, unmounting that whole component ... with nothing moving focus anywhere afterward, so the browser drops it to `<body>`."* Confirmed the precedent is real (`components/model-builder/model-builder-manager.vue:84-85` — `<main ref="mainContent" tabindex="-1">`, with a paired `watch(() => store.step, ...)` doing the same `contains(document.activeElement)` check) before reusing its shape here.
- Fixed the same way: wrapped the narrating/narrationError/currentChapter/resolve-panel chain in one persistent `<div ref="chapterRegion" tabindex="-1" aria-label="Current chapter">` container that never itself unmounts across the swap, then added a `watch` on `[narrating, narrationError, Boolean(currentChapter)]` — the trio the `v-if` chain switches on — that checks `chapterRegion.value?.contains(document.activeElement)` at watch time (before Vue patches the DOM, so `activeElement` is still whatever was focused at the moment of the click) to tell an in-region click apart from anything else that could theoretically flip those refs, and calls `chapterRegion.value?.focus()` in `nextTick()` only when it was.
- Added the 9th guard, `verifyDaVinciChapterFocusGuard.ts` + `.test.ts`, following this project's established narrow-textual-checker convention, wired into `package.json` and `.github/workflows/contract-tests.yml` alongside the eight existing davinci guards.

### How I verified
- New guard fails pre-fix / passes post-fix, confirmed via a `git checkout <parent-commit> -- components/conductor/davinci-page.vue` round-trip against the real component (not just the guard's own synthetic fixtures) — pre-fix run reported all 5 expected errors (missing wrapper ref, missing tabindex, missing script-side ref, missing activeElement guard, missing focus() call); restored, guard then passed.
- New guard's own self-test passes (missing-ref, missing-tabindex, missing-script-ref, missing-guard, missing-focus-call, and missing-block regressions all fail individually; fixed fixture passes).
- All 8 prior `verifyDaVinci*` guards + selftests still pass: dimension-tone, narration-error-tone, resolve-panel, narrating-status, resuming-status, choice-list, dimension-group, narration-error-role.
- `npm run test:davinci-narration` still passes (12/12 checks).
- `npm run test:layout-contract` holds, no new violations.
- `eslint` clean on all touched/new files (`davinci-page.vue`, both new `.ts` files) — zero warnings/errors.
- `prettier --check` clean on the new files; also re-checked clean on the touched files (`davinci-page.vue`, `package.json`, `contract-tests.yml`) — no pre-existing drift to account for.
- `vue-tsc --noEmit` repo-wide: exit 0.
- `git status --porcelain` after all verification work showed exactly the 5 intended files: `components/conductor/davinci-page.vue`, `utils/scripts/verifyDaVinciChapterFocusGuard.ts`, `utils/scripts/verifyDaVinciChapterFocusGuard.test.ts`, `package.json`, `.github/workflows/contract-tests.yml`.

### Stakes
reversible

### Flags for Reviewer
- This PR picks up a commit (`006bc8978`) pushed by a prior background agent run that died mid-session (connection lost) before opening the PR or verifying. I did not redo the implementation — I cloned the branch fresh, read the actual diff line-by-line against the commit message's claims (confirmed the v-if/v-else-if unmount-on-click shape is real, confirmed the model-builder-manager.vue precedent is real and matches), then ran the full verification pass myself before opening this PR.
- Watcher-timing note for review: Vue's default `watch()` flush is `'pre'`, which runs before the render effect that actually patches the DOM for the new `v-if` branch — so `document.activeElement` inside the watch callback is still the button that was just clicked (which is about to be unmounted), not `<body>`. This is the same timing model-builder-manager.vue's existing watch already relies on, not something this slice introduces.

### Kaizen suggestion
No further busy/loading-indicator or focus-management gaps found in `davinci-page.vue`'s remaining hand-rolled state — the accessibility sweep (busy-indicator ARIA, dimension-group, choice-list semantics, narration-error role, and now focus restoration) looks complete across slices 4-9. The next slice should look at a different concrete-gap category: candidates are (a) whether the dimension-grid stat pills and section wrappers match `kr-panel`/`kr-stat` structural conventions used elsewhere (flagged as worth checking in slice 7's note but never followed up), or (b) whether `resolveLife`'s submit path has the same button-inside-swapped-region focus-loss shape this slice just fixed for the chapter blocks (worth a quick read of the resolve/ending screen this page transitions to, which is out of this slice's scope).

### Notes for reviewer
Conductor task davinci/t-021 stays owned by the foreground conductor session for status/roadmap bookkeeping — this kind_robots PR is the code side only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZxtRVqs6U8LD1cwhZzLbc)_