### PR TITLE
fix(serendipity-voice): skip front placement when a toggle turns an effect off (alexa-integration/t-015)

### DIFF
--- a/stores/serendipityVoiceStore.ts
+++ b/stores/serendipityVoiceStore.ts
@@ -288,7 +288,15 @@ export const useSerendipityVoiceStore = defineStore(
       else if (command.action === 'toggle')
         animationStore.toggleScreenEffect(effectId)
 
-      if (command.action !== 'off') {
+      // Gate on the effect's actual resulting state, not the literal action
+      // string -- a 'toggle' that flips an active effect off ends up just
+      // as inactive as a literal 'off', and forcing its fx region to front
+      // placement anyway would bring a now-empty region to the front for
+      // no reason. Only the literal 'off' case was excluded before; only
+      // bring the region forward when the effect is actually visible
+      // afterward.
+      const isNowActive = animationStore.isScreenEffectActive(effectId)
+      if (isNowActive) {
         animationStore.setSurfacePlacement(
           normalizeRegion(command.surface),
           'front',

--- a/utils/scripts/verifySerendipityVoiceActionGuard.test.ts
+++ b/utils/scripts/verifySerendipityVoiceActionGuard.test.ts
@@ -14,6 +14,7 @@ import {
   checkSerendipityVoiceActionGuard,
   checkSerendipityVoiceArtAckGuard,
   checkSerendipityVoiceErrorReportingGuard,
+  checkSerendipityVoiceToggleOffSurfacePlacementGuard,
 } from './verifySerendipityVoiceActionGuard.js'
 
 const ANIMATION_ACTION_GUARD = `if (
@@ -407,6 +408,122 @@ function runArtAckSelfTest(): void {
   )
 }
 
+// --- Fixtures for checkSerendipityVoiceToggleOffSurfacePlacementGuard()
+// (t-015, 2026-08-19 cycle) ---
+// Distinct from every fixture above: this exercises the surface-placement
+// gate that follows the on/off/toggle branch, not action/target mismatches,
+// false no-match successes, or a missing acknowledgement.
+
+function togglePlacementFixture(opts: {
+  toggleBranch: string
+  placementGate: string
+}): string {
+  return `
+    function applyCommand(command: VoiceBusCommand): void {
+      if (command.target !== 'animation') {
+        pushLocalMessage('system', \`Ignored unsupported command target: \${command.target}\`)
+        return
+      }
+
+      const effectId = resolveEffectId(command)
+      if (!effectId) {
+        return
+      }
+
+      const active = animationStore.isScreenEffectActive(effectId)
+      if (command.action === 'on' && !active) animationStore.toggleScreenEffect(effectId)
+      else if (command.action === 'off' && active) animationStore.toggleScreenEffect(effectId)
+      ${opts.toggleBranch}
+
+      ${opts.placementGate}
+    }
+  `
+}
+
+const TOGGLE_BRANCH_FIXED = `else if (command.action === 'toggle')
+        animationStore.toggleScreenEffect(effectId)`
+
+// Pre-fix (alexa-integration/t-015's original 2026-08-18 cycle shape): gates
+// setSurfacePlacement() on the literal action string, so a 'toggle' that
+// flips an active effect off still forces its fx region to front placement.
+const PLACEMENT_GATE_BUGGY_LITERAL_OFF = `if (command.action !== 'off') {
+        animationStore.setSurfacePlacement(normalizeRegion(command.surface), 'front')
+      }`
+
+// Fixed: gates on the effect's actual resulting state instead.
+const PLACEMENT_GATE_FIXED = `const isNowActive = animationStore.isScreenEffectActive(effectId)
+      if (isNowActive) {
+        animationStore.setSurfacePlacement(normalizeRegion(command.surface), 'front')
+      }`
+
+// Hypothetical future regression: the re-check is dropped entirely and
+// setSurfacePlacement() runs unconditionally -- no literal-action check
+// either, just a different way to reintroduce the same false-front-placement
+// bug (and worse, for the literal 'off' case too).
+const PLACEMENT_GATE_UNCONDITIONAL = `animationStore.setSurfacePlacement(normalizeRegion(command.surface), 'front')`
+
+const TOGGLE_PLACEMENT_FIXED = togglePlacementFixture({
+  toggleBranch: TOGGLE_BRANCH_FIXED,
+  placementGate: PLACEMENT_GATE_FIXED,
+})
+
+const TOGGLE_PLACEMENT_BUGGY = togglePlacementFixture({
+  toggleBranch: TOGGLE_BRANCH_FIXED,
+  placementGate: PLACEMENT_GATE_BUGGY_LITERAL_OFF,
+})
+
+const TOGGLE_PLACEMENT_UNCONDITIONAL = togglePlacementFixture({
+  toggleBranch: TOGGLE_BRANCH_FIXED,
+  placementGate: PLACEMENT_GATE_UNCONDITIONAL,
+})
+
+function runToggleOffSurfacePlacementSelfTest(): void {
+  const fixedErrors = checkSerendipityVoiceToggleOffSurfacePlacementGuard(
+    TOGGLE_PLACEMENT_FIXED,
+  )
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed toggle-placement fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const buggyErrors = checkSerendipityVoiceToggleOffSurfacePlacementGuard(
+    TOGGLE_PLACEMENT_BUGGY,
+  )
+  assert.equal(
+    buggyErrors.length,
+    2,
+    `expected the literal-'off' buggy fixture to fail twice (buggy gate + missing recheck), got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(buggyErrors.some((e) => /still gates setSurfacePlacement/.test(e)))
+  assert.ok(buggyErrors.some((e) => /no longer re-checks/.test(e)))
+
+  const unconditionalErrors =
+    checkSerendipityVoiceToggleOffSurfacePlacementGuard(
+      TOGGLE_PLACEMENT_UNCONDITIONAL,
+    )
+  assert.equal(
+    unconditionalErrors.length,
+    1,
+    `expected the unconditional-placement fixture to fail once, got: ${JSON.stringify(unconditionalErrors)}`,
+  )
+  assert.ok(/no longer re-checks/.test(unconditionalErrors[0]!))
+
+  const missingFnErrors = checkSerendipityVoiceToggleOffSurfacePlacementGuard(
+    'function someOtherFunction(): void {}',
+  )
+  assert.equal(missingFnErrors.length, 1)
+  assert.ok(/Could not find a function named/.test(missingFnErrors[0]!))
+
+  console.log(
+    'Serendipity Voice toggle-off surface-placement guard self-test ' +
+      'passed: the literal-action buggy fixture fails on both the gate and ' +
+      'the missing recheck, an unconditional-placement regression fails on ' +
+      'the missing recheck, the fixed fixture passes, and a ' +
+      'missing-function fixture fails clearly.',
+  )
+}
+
 function run(): void {
   const fixedErrors = checkSerendipityVoiceActionGuard(FIXED)
   assert.deepEqual(
@@ -462,3 +579,4 @@ function run(): void {
 run()
 runErrorReportingSelfTest()
 runArtAckSelfTest()
+runToggleOffSurfacePlacementSelfTest()

--- a/utils/scripts/verifySerendipityVoiceActionGuard.ts
+++ b/utils/scripts/verifySerendipityVoiceActionGuard.ts
@@ -63,6 +63,20 @@
 // acknowledgement back through the relay. Fixed by calling postAck() the
 // same way the other three success paths do; this guard keeps a future edit
 // from silently dropping that call again.
+//
+// Extended a fourth time (alexa-integration/t-015, 2026-08-19 cycle) with
+// checkSerendipityVoiceToggleOffSurfacePlacementGuard() below -- a kaizen
+// lead filed by the prior cycle. applyCommand()'s animation branch gated its
+// setSurfacePlacement(region, 'front') call on `command.action !== 'off'`,
+// i.e. the literal spoken action string, not on whether the effect actually
+// ended up active. A 'toggle' command that flipped an already-active effect
+// off ends up exactly as inactive as a literal 'off' does, but the literal
+// check let it fall through and still force that fx region to front
+// placement -- bringing a now-empty region to the front for no reason,
+// something the literal-'off' path never did. Fixed by re-checking
+// isScreenEffectActive(effectId) *after* the on/off/toggle branch runs and
+// gating setSurfacePlacement() on that resulting boolean instead of the
+// action string, so 'toggle'-to-off is treated the same as literal 'off'.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -490,12 +504,124 @@ export function checkSerendipityVoiceArtAckGuard(content: string): string[] {
   return errors
 }
 
+// Checks the "toggle-to-off still forces front placement" gap -- see the
+// file-header addendum above (alexa-integration/t-015, 2026-08-19 cycle) for
+// what this protects against. Distinct from every guard above: those cover
+// mismatched actions, false no-match successes, and a missing
+// acknowledgement; this one covers a surface-placement side effect that
+// fires on the wrong condition (the literal action string) instead of the
+// effect's actual resulting active state.
+export function checkSerendipityVoiceToggleOffSurfacePlacementGuard(
+  content: string,
+): string[] {
+  const errors: string[] = []
+
+  const commandBody = extractFunctionSource(content, 'applyCommand')
+  if (!commandBody) {
+    errors.push(
+      'Could not find a function named applyCommand() -- has it been ' +
+        'renamed, removed, or restructured? If so, this guard (and the ' +
+        'toggle-to-off surface-placement contract it protects) needs to ' +
+        'move with it.',
+    )
+    return errors
+  }
+
+  const toggleBranchIndex = commandBody.search(
+    /else if\s*\(\s*command\.action\s*===\s*'toggle'\s*\)\s*\n?\s*animationStore\.toggleScreenEffect\(effectId\)/,
+  )
+  if (toggleBranchIndex === -1) {
+    errors.push(
+      'applyCommand() no longer contains the `else if (command.action === ' +
+        "'toggle') animationStore.toggleScreenEffect(effectId)` branch -- " +
+        'has the on/off/toggle dispatch shape changed? This guard assumes ' +
+        'that structure to locate the surface-placement gate that follows ' +
+        'it.',
+    )
+    return errors
+  }
+
+  const placementCallIndex = searchAfter(
+    commandBody,
+    /animationStore\.setSurfacePlacement\(/,
+    toggleBranchIndex,
+  )
+  if (placementCallIndex === -1) {
+    errors.push(
+      'applyCommand() no longer calls animationStore.setSurfacePlacement() ' +
+        'after the on/off/toggle branch -- has the fx-region-placement step ' +
+        'been removed or restructured? This guard assumes that call exists ' +
+        'so it can check what gates it.',
+    )
+    return errors
+  }
+
+  const gateWindow = commandBody.slice(toggleBranchIndex, placementCallIndex)
+
+  const buggyLiteralOffGate =
+    /if\s*\(\s*command\.action\s*!==\s*'off'\s*\)\s*\{/.test(gateWindow)
+  if (buggyLiteralOffGate) {
+    errors.push(
+      'applyCommand() still gates setSurfacePlacement() on ' +
+        "`command.action !== 'off'` -- the literal action string, not the " +
+        "effect's actual resulting state. A 'toggle' command that flips an " +
+        'already-active effect off ends up exactly as inactive as a ' +
+        "literal 'off' does, but this gate lets it fall through and still " +
+        'force that fx region to front placement, bringing a now-empty ' +
+        'region to the front for no reason.',
+    )
+  }
+
+  const recheckIndex = searchAfter(
+    commandBody,
+    /animationStore\.isScreenEffectActive\(effectId\)/,
+    toggleBranchIndex,
+  )
+  if (recheckIndex === -1 || recheckIndex >= placementCallIndex) {
+    errors.push(
+      'applyCommand() no longer re-checks ' +
+        'animationStore.isScreenEffectActive(effectId) after the ' +
+        'on/off/toggle branch and before setSurfacePlacement() -- without ' +
+        "re-checking the effect's actual resulting state, the placement " +
+        'gate has nothing but the literal action string to key off of, ' +
+        'reintroducing the toggle-to-off false-front-placement bug.',
+    )
+  } else {
+    const placementGuardIndex = searchAfter(
+      commandBody,
+      /if\s*\(\s*isNowActive\s*\)\s*\{/,
+      recheckIndex,
+    )
+    if (
+      placementGuardIndex === -1 ||
+      placementGuardIndex >= placementCallIndex
+    ) {
+      errors.push(
+        'applyCommand() re-checks isScreenEffectActive(effectId) but does ' +
+          'not gate setSurfacePlacement() on `if (isNowActive)` right ' +
+          'before the call -- the rechecked state must actually drive the ' +
+          'gate, not just sit unused alongside the old literal-action ' +
+          'check.',
+      )
+    }
+  }
+
+  return errors
+}
+
 function main(): void {
   const content = readFileSync(STORE_PATH, 'utf8')
   const actionErrors = checkSerendipityVoiceActionGuard(content)
   const errorReportingErrors = checkSerendipityVoiceErrorReportingGuard(content)
   const artAckErrors = checkSerendipityVoiceArtAckGuard(content)
-  const errors = [...actionErrors, ...errorReportingErrors, ...artAckErrors]
+  const toggleOffPlacementErrors =
+    checkSerendipityVoiceToggleOffSurfacePlacementGuard(content)
+  const errors = [
+    ...actionErrors,
+    ...errorReportingErrors,
+    ...artAckErrors,
+    ...toggleOffPlacementErrors,
+  ]
 
   if (errors.length) {
     console.error(
@@ -513,8 +639,11 @@ function main(): void {
       "that don't apply to their target instead of silently reporting a " +
       'false "applied" message, the unmatched-effect/unknown-theme ' +
       'no-match branches still report failure (not a false success) before ' +
-      "returning, and applyArtCommand()'s success path still acknowledges " +
-      'back through the relay like every other successful command target.',
+      "returning, applyArtCommand()'s success path still acknowledges back " +
+      'through the relay like every other successful command target, and ' +
+      "applyCommand()'s surface-placement gate keys off the effect's " +
+      'actual resulting active state rather than the literal action ' +
+      'string, so a toggle-to-off is treated the same as a literal off.',
   )
 }
 


### PR DESCRIPTION
### Task
alexa-integration/t-015: Polish and upgrade Voice Lab front-end surface (kind: software)

### What changed / what I produced
Investigated and fixed the kaizen lead filed by the prior 2026-08-18 cycle
(confirmed real by reading the live code first): `applyCommand()`'s animation
branch in `stores/serendipityVoiceStore.ts` gated its
`animationStore.setSurfacePlacement(region, 'front')` call on
`command.action !== 'off'` — the literal spoken action string, not the
effect's actual resulting state. A `'toggle'` command that flipped an
already-active effect *off* ends up exactly as inactive as a literal `'off'`
does, but the literal check let it fall through and still force that fx
region to front placement — bringing a now-empty region to the front for no
reason, something the literal-`'off'` path never did.

- `stores/serendipityVoiceStore.ts`: re-check
  `animationStore.isScreenEffectActive(effectId)` *after* the on/off/toggle
  branch runs (`isNowActive`), and gate `setSurfacePlacement()` on that
  resulting boolean instead of the action string, so a toggle-to-off is now
  treated the same as a literal off.
- `utils/scripts/verifySerendipityVoiceActionGuard.ts`: extended with a
  fourth check, `checkSerendipityVoiceToggleOffSurfacePlacementGuard()`,
  following the t-020/t-021/2026-08-18-cycle convention of extending the
  same guard file with a new `checkX()` — locates the on/off/toggle branch,
  flags the old literal `command.action !== 'off'` gating pattern if
  present, and requires a re-check of `isScreenEffectActive(effectId)` that
  actually drives the `setSurfacePlacement()` gate.
- `utils/scripts/verifySerendipityVoiceActionGuard.test.ts`: matching
  self-test with fixed / literal-action-buggy / unconditional-regression /
  missing-function fixtures.

### How I verified
- **New check fails pre-fix / passes post-fix (git-stash round-trip):**
  `git stash push -- stores/serendipityVoiceStore.ts` (guard file changes
  kept), ran `npx tsx utils/scripts/verifySerendipityVoiceActionGuard.ts`
  against the pre-fix store — failed with exactly the two expected errors
  (buggy literal-`'off'` gate + missing re-check), exit 1. `git stash pop`
  restored the fix; re-ran the same check — passed clean, exit 0.
- **All pre-existing checks + selftest still pass:** `npx tsx
  utils/scripts/verifySerendipityVoiceActionGuard.test.ts` — all four
  self-tests (action-guard, error-reporting, art-ack, and the new
  toggle-off-surface-placement one) pass.
- **eslint clean:** `npx eslint stores/serendipityVoiceStore.ts
  utils/scripts/verifySerendipityVoiceActionGuard.ts
  utils/scripts/verifySerendipityVoiceActionGuard.test.ts` — no output, exit 0.
- **prettier clean:** `npx prettier --check` on the same three files passes
  (ran `--write` once after the initial edits to normalize formatting, then
  re-verified `--check` passes and both the guard check and selftest still
  pass after reformatting).
- **vue-tsc repo-wide:** `npm run test` (`nuxi prepare` + `vue-tsc --noEmit`
  over the whole project) completed clean, exit 0.
- **Diff scope:** `git status --porcelain` shows exactly the three intended
  files: `stores/serendipityVoiceStore.ts`,
  `utils/scripts/verifySerendipityVoiceActionGuard.ts`,
  `utils/scripts/verifySerendipityVoiceActionGuard.test.ts`.

### Stakes
reversible

### Flags for Reviewer
- None — the lead was investigated fresh against the live code before
  changing anything, confirmed real, and fixed minimally.

### Kaizen suggestion
`applyCommand()`'s `'on'` branch has the mirror-image gap worth a fresh look:
it only calls `toggleScreenEffect()` when `!active` (skips redundant
toggling, correct), but always still runs `setSurfacePlacement(..., 'front')`
regardless of whether the effect was already active and already at `'front'`
vs. `'behind'`/`'off'` from an earlier command — i.e. a repeated "turn X on"
while X is already on and placed `'behind'` will silently re-home it to
`'front'`. Worth confirming intentional vs. investigating a `'behind'`
placement command path that this bug would then also fight against.

### Notes for reviewer
Read `projects/alexa-integration/roadmap.yaml` task t-015's note for the
full cycle history and the guard-file extension convention this follows
(t-015 original cycle → t-020 → t-021 → t-015 2026-08-18 cycle → this
2026-08-19 cycle).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZxtRVqs6U8LD1cwhZzLbc)_