### PR TITLE
fix(appmaker): check the conductor apps/ folder for slug collisions too (appmaker/t-012)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -245,6 +245,12 @@ jobs:
       - name: AppMaker fleet-description guard
         run: npm run test:appmaker-fleet-description-guard
 
+      - name: AppMaker scaffold-collision guard self-test
+        run: npm run test:appmaker-scaffold-collision-guard-selftest
+
+      - name: AppMaker scaffold-collision guard
+        run: npm run test:appmaker-scaffold-collision-guard
+
       - name: Da Vinci narration bounds contract
         run: npm run test:davinci-narration
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "test:appmaker-slug-candidate-guard": "tsx utils/scripts/verifyAppmakerSlugCandidateGuard.ts",
     "test:appmaker-fleet-description-guard-selftest": "tsx utils/scripts/verifyAppmakerFleetDescriptionGuard.test.ts",
     "test:appmaker-fleet-description-guard": "tsx utils/scripts/verifyAppmakerFleetDescriptionGuard.ts",
+    "test:appmaker-scaffold-collision-guard-selftest": "tsx utils/scripts/verifyAppmakerScaffoldCollisionGuard.test.ts",
+    "test:appmaker-scaffold-collision-guard": "tsx utils/scripts/verifyAppmakerScaffoldCollisionGuard.ts",
     "test:comment-prefix": "tsx utils/scripts/verifyPartialPublishPrefix.ts",
     "test:comment-quality": "tsx utils/scripts/verifyCommentDraftQuality.ts",
     "test:population-quality": "tsx utils/scripts/verifyPopulationDraftQuality.ts",

--- a/server/api/appmaker/scaffold-request.post.ts
+++ b/server/api/appmaker/scaffold-request.post.ts
@@ -8,6 +8,7 @@ import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
 import { enforceProjectCap } from '@/server/utils/projectCap'
 import { userIsAdmin, userRoles } from '@/server/utils/authUser'
+import { conductorList } from '~/server/utils/conductor-github'
 
 const SLUG_RE = /^[a-z][a-z0-9-]{1,40}$/
 
@@ -56,11 +57,14 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const slug = body.slug?.trim() ? body.slug.trim().toLowerCase() : slugify(title)
+    const slug = body.slug?.trim()
+      ? body.slug.trim().toLowerCase()
+      : slugify(title)
     if (!SLUG_RE.test(slug)) {
       throw createError({
         statusCode: 400,
-        message: 'slug must be kebab-case: start with a letter, then letters/digits/hyphens.',
+        message:
+          'slug must be kebab-case: start with a letter, then letters/digits/hyphens.',
       })
     }
 
@@ -71,7 +75,7 @@ export default defineEventHandler(async (event) => {
         message: 'description must be 1000 characters or fewer.',
       })
     }
-    const [existingProject, existingDream] = await Promise.all([
+    const [existingProject, existingDream, scaffoldedApps] = await Promise.all([
       prisma.project.findFirst({
         where: { OR: [{ slug }, { conductorSlug: slug }] },
         select: { id: true },
@@ -80,10 +84,30 @@ export default defineEventHandler(async (event) => {
         where: { slug },
         select: { id: true },
       }),
+      conductorList('apps'),
     ])
 
-    if (existingProject || existingDream) {
-      throw createError({ statusCode: 409, message: `Slug '${slug}' is already taken.` })
+    // apps.get.ts treats a `dir` entry under conductor's apps/ folder as the
+    // source of truth for "already scaffolded". Several apps (e.g.
+    // apps/storybook, apps/wishmaster) were scaffolded directly by an agent
+    // before this self-serve flow existed and never got a matching Project
+    // row, so the existingProject/existingDream checks above miss them
+    // entirely. Without this, a request for a colliding slug would succeed
+    // here (201, Todo filed), but the Worker cycle's
+    // `scripts/new_app.py <slug>` invocation refuses to run over an
+    // existing apps/<slug>/ folder and fails -- silently, since nothing
+    // ever reports that failure back through this endpoint or the AppMaker
+    // UI, leaving the user's Project row (and one of their
+    // FREE_PROJECT_LIMIT slots) permanently orphaned.
+    const alreadyScaffolded = (scaffoldedApps ?? []).some(
+      (entry) => entry.type === 'dir' && entry.name === slug,
+    )
+
+    if (existingProject || existingDream || alreadyScaffolded) {
+      throw createError({
+        statusCode: 409,
+        message: `Slug '${slug}' is already taken.`,
+      })
     }
 
     const isAdmin = userIsAdmin(user)

--- a/utils/scripts/verifyAppmakerScaffoldCollisionGuard.test.ts
+++ b/utils/scripts/verifyAppmakerScaffoldCollisionGuard.test.ts
@@ -1,0 +1,164 @@
+// /utils/scripts/verifyAppmakerScaffoldCollisionGuard.test.ts
+//
+// Regression test for checkScaffoldCollisionGuard() in
+// verifyAppmakerScaffoldCollisionGuard.ts (appmaker/t-012). Exercises the
+// real check against synthetic route-shaped fixtures covering: the fixed
+// shape (candidate slug checked against Project, Dream, AND the conductor
+// apps/ folder listing), the pre-fix shape (only Project/Dream checked,
+// conductorList never imported/called), and partial regressions (the
+// conductorList call and dir-entry filter survive, but the result is no
+// longer folded into the "already taken" throw).
+import assert from 'node:assert/strict'
+
+import { checkScaffoldCollisionGuard } from './verifyAppmakerScaffoldCollisionGuard.js'
+
+function fixture(body: string): string {
+  return `
+import { conductorList } from '~/server/utils/conductor-github'
+
+export default defineEventHandler(async (event) => {
+  try {
+${body}
+  } catch (error) {
+    if (error instanceof H3Error) throw error
+    return errorHandler(error)
+  }
+})
+`
+}
+
+const FIXED = fixture(`
+    const [existingProject, existingDream, scaffoldedApps] = await Promise.all([
+      prisma.project.findFirst({
+        where: { OR: [{ slug }, { conductorSlug: slug }] },
+        select: { id: true },
+      }),
+      prisma.dream.findUnique({
+        where: { slug },
+        select: { id: true },
+      }),
+      conductorList('apps'),
+    ])
+
+    const alreadyScaffolded = (scaffoldedApps ?? []).some(
+      (entry) => entry.type === 'dir' && entry.name === slug,
+    )
+
+    if (existingProject || existingDream || alreadyScaffolded) {
+      throw createError({ statusCode: 409, message: \`Slug '\${slug}' is already taken.\` })
+    }
+`)
+
+// Pre-fix shape: no import, no conductorList call, slug uniqueness checked
+// only against Project/Dream.
+const BUGGY = `
+export default defineEventHandler(async (event) => {
+  try {
+    const [existingProject, existingDream] = await Promise.all([
+      prisma.project.findFirst({
+        where: { OR: [{ slug }, { conductorSlug: slug }] },
+        select: { id: true },
+      }),
+      prisma.dream.findUnique({
+        where: { slug },
+        select: { id: true },
+      }),
+    ])
+
+    if (existingProject || existingDream) {
+      throw createError({ statusCode: 409, message: \`Slug '\${slug}' is already taken.\` })
+    }
+  } catch (error) {
+    if (error instanceof H3Error) throw error
+    return errorHandler(error)
+  }
+})
+`
+
+// Partial regression: conductorList is still imported and called, and the
+// dir-entry filter still exists, but `alreadyScaffolded` was dropped back
+// out of the "already taken" condition -- so it's computed but has no
+// effect, same bug in practice.
+const PARTIALLY_REGRESSED = fixture(`
+    const [existingProject, existingDream, scaffoldedApps] = await Promise.all([
+      prisma.project.findFirst({
+        where: { OR: [{ slug }, { conductorSlug: slug }] },
+        select: { id: true },
+      }),
+      prisma.dream.findUnique({
+        where: { slug },
+        select: { id: true },
+      }),
+      conductorList('apps'),
+    ])
+
+    const alreadyScaffolded = (scaffoldedApps ?? []).some(
+      (entry) => entry.type === 'dir' && entry.name === slug,
+    )
+
+    if (existingProject || existingDream) {
+      throw createError({ statusCode: 409, message: \`Slug '\${slug}' is already taken.\` })
+    }
+`)
+
+function run(): void {
+  const fixedErrors = checkScaffoldCollisionGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const buggyErrors = checkScaffoldCollisionGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    4,
+    'expected the pre-fix fixture (no import, no conductorList call, no ' +
+      'dir-entry filter, no folded condition) to fail all four checks, got: ' +
+      `${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(
+    buggyErrors.some((e) => /no longer imports `conductorList`/.test(e)),
+  )
+  assert.ok(
+    buggyErrors.some((e) => /no longer calls conductorList\('apps'\)/.test(e)),
+  )
+  assert.ok(
+    buggyErrors.some((e) =>
+      /no longer filters conductorList\('apps'\) entries/.test(e),
+    ),
+  )
+  assert.ok(
+    buggyErrors.some((e) => /no longer checks `existingProject \|\|/.test(e)),
+  )
+
+  const regressedErrors = checkScaffoldCollisionGuard(PARTIALLY_REGRESSED)
+  assert.equal(
+    regressedErrors.length,
+    1,
+    'expected a fixture where alreadyScaffolded is computed but not folded ' +
+      `into the throw to fail only that assertion, got: ${JSON.stringify(regressedErrors)}`,
+  )
+  assert.ok(
+    regressedErrors.some((e) =>
+      /no longer checks `existingProject \|\| existingDream \|\| alreadyScaffolded`/.test(
+        e,
+      ),
+    ),
+  )
+
+  const missingHandler = checkScaffoldCollisionGuard(
+    "import { conductorList } from '~/server/utils/conductor-github'\nconst somethingElse = 1\n",
+  )
+  assert.equal(missingHandler.length, 1)
+  assert.ok(missingHandler.some((e) => /Could not find/.test(e)))
+
+  console.log(
+    'AppMaker scaffold-collision guard self-test passed: buggy fixture ' +
+      'fails all checks, fixed fixture passes, a partially-regressed ' +
+      'fixture fails only the folded-condition check, and a missing ' +
+      'handler is detected.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyAppmakerScaffoldCollisionGuard.ts
+++ b/utils/scripts/verifyAppmakerScaffoldCollisionGuard.ts
@@ -1,0 +1,146 @@
+// /utils/scripts/verifyAppmakerScaffoldCollisionGuard.ts
+//
+// Regression guard (appmaker/t-012) -- server/api/appmaker/scaffold-request.post.ts's
+// slug-collision check only queried the kind_robots Prisma `Project` and
+// `Dream` tables (existingProject / existingDream), never the conductor
+// repo's apps/ folder listing that apps.get.ts itself treats as the real
+// source of truth for "already scaffolded" (`conductorList('apps')`,
+// filtered to `type === 'dir'`). Several apps were scaffolded directly by an
+// agent before this self-serve flow existed (apps/storybook, apps/wishmaster,
+// apps/sketchy, ...) and never got a matching Project row.
+//
+// That gap let a user request a slug colliding with one of those folders:
+// the request succeeded here (201, Todo filed, one of their
+// FREE_PROJECT_LIMIT slots consumed), but the Worker cycle's
+// `scripts/new_app.py <slug>` invocation refuses to run over an existing
+// apps/<slug>/ folder and fails -- with nothing ever surfacing that failure
+// back through this endpoint or the AppMaker UI. The user's Project row (and
+// project-cap slot) is silently orphaned forever.
+//
+// Fixed by also listing the conductor apps/ folder via conductorList('apps')
+// alongside the existing Project/Dream lookups, and folding a `type ===
+// 'dir'` match on the candidate slug into the same "already taken" 409.
+//
+// This asserts the textual shape of that fix stays in place: the handler
+// still calls conductorList('apps'), still filters its `dir` entries by
+// name against the candidate slug, and still folds that result into the
+// same conditional that throws the "already taken" 409 -- not a bare
+// `if (existingProject || existingDream)` that silently accepts a slug
+// belonging to a pre-existing, unregistered apps/ folder again.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const ROUTE_PATH = join(
+  repositoryRoot,
+  'server/api/appmaker/scaffold-request.post.ts',
+)
+
+function extractHandlerSource(content: string): string | null {
+  const signature = /export default defineEventHandler\(async \(event\) => \{/
+  const match = signature.exec(content)
+  if (!match) return null
+
+  const braceOpen = match.index + match[0].length - 1
+  let depth = 0
+  let i = braceOpen
+  for (; i < content.length; i++) {
+    if (content[i] === '{') depth++
+    else if (content[i] === '}') {
+      depth--
+      if (depth === 0) break
+    }
+  }
+  if (depth !== 0) return null
+  return content.slice(braceOpen, i + 1)
+}
+
+export function checkScaffoldCollisionGuard(content: string): string[] {
+  const errors: string[] = []
+
+  if (
+    !/import\s*\{\s*conductorList\s*\}\s*from\s*['"][^'"]*conductor-github['"]/.test(
+      content,
+    )
+  ) {
+    errors.push(
+      'scaffold-request.post.ts no longer imports `conductorList` from ' +
+        'conductor-github -- has the apps/ folder collision check been ' +
+        'dropped, leaving slug uniqueness checked only against the Project ' +
+        'and Dream tables?',
+    )
+  }
+
+  const body = extractHandlerSource(content)
+  if (!body) {
+    errors.push(
+      'Could not find `export default defineEventHandler(async (event) => ' +
+        '{ ... })` in scaffold-request.post.ts -- has it been renamed, ' +
+        'removed, or restructured? If so, this guard (and the scaffold-' +
+        'folder collision bug it protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  if (!/conductorList\(\s*['"]apps['"]\s*\)/.test(body)) {
+    errors.push(
+      "The handler no longer calls conductorList('apps') -- the " +
+        "candidate slug is no longer checked against the conductor repo's " +
+        'actual apps/ folder listing, so a slug matching a pre-existing, ' +
+        'unregistered apps/<slug>/ folder will silently pass validation ' +
+        'and file a Todo that scripts/new_app.py is guaranteed to fail on.',
+    )
+  }
+
+  if (!/entry\.type === 'dir' && entry\.name === slug/.test(body)) {
+    errors.push(
+      "The handler no longer filters conductorList('apps') entries by " +
+        "`entry.type === 'dir' && entry.name === slug` -- has the " +
+        'collision match against the scaffolded-folder listing been ' +
+        'weakened or dropped?',
+    )
+  }
+
+  if (
+    !/if\s*\(\s*existingProject\s*\|\|\s*existingDream\s*\|\|\s*alreadyScaffolded\s*\)/.test(
+      body,
+    )
+  ) {
+    errors.push(
+      'The "already taken" 409 no longer checks `existingProject || ' +
+        'existingDream || alreadyScaffolded` together -- the apps/ folder ' +
+        'collision result is no longer folded into the slug-taken check, ' +
+        'so it has no effect even if it is still computed.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(ROUTE_PATH, 'utf8')
+  const errors = checkScaffoldCollisionGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'AppMaker scaffold-collision guard contract failed in ' +
+        'scaffold-request.post.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'AppMaker scaffold-collision guard contract passed: a slug matching an ' +
+      'already-scaffolded (but unregistered) apps/ folder is rejected ' +
+      'instead of silently filing a Todo doomed to fail.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
appmaker/t-012: Polish and upgrade AppMaker front-end surface (kind: software, recurring)

### What changed / what I produced
Fresh-read `components/pages/appmaker-page.vue`, `stores/conductorStore.ts`, `server/api/appmaker/apps.get.ts`, `server/api/appmaker/scaffold-request.post.ts`, and `server/utils/projectCap.ts`, excluding the four already-fixed items (refreshToken sequencing, fetchProjects force in-flight sharing, slug-candidate validation, fleet computed description fallback) and the already-filed appmaker/t-014 (out of scope, untouched).

Found a real gap in `scaffold-request.post.ts`'s "is this slug already taken?" check: it only queried the kind_robots `Project` and `Dream` tables. `apps.get.ts`'s own `scaffolded` list treats the conductor repo's `apps/` folder listing (`conductorList('apps')`, filtered to `type === 'dir'`) as the actual source of truth for "already scaffolded" — and several apps (`apps/storybook`, `apps/wishmaster`, `apps/sketchy`, `apps/conductor`, `apps/kind-robots`, ...) were scaffolded directly by an agent before this self-serve flow existed, so they never got a matching `Project` row.

That gap let a user request one of those already-taken slugs: the request succeeded (`201`, `Todo` filed, one of their `FREE_PROJECT_LIMIT` slots consumed), but the Worker cycle's `scripts/new_app.py <slug>` invocation refuses to run over an existing `apps/<slug>/` folder (confirmed by reading conductor's `scripts/new_app.py`: `if (ROOT / "apps" / slug).exists(): fail(...)`) and fails — silently, since nothing ever surfaces that failure back through this endpoint or the AppMaker UI. The user's `Project` row is orphaned permanently, eating a project-cap slot for no reason, and the "Being built" badge for that request never resolves.

- `server/api/appmaker/scaffold-request.post.ts`: also list conductor's `apps/` folder via `conductorList('apps')` alongside the existing `Project`/`Dream` lookups, and fold a `dir`-entry name match into the same "already taken" 409 (`existingProject || existingDream || alreadyScaffolded`).
- `utils/scripts/verifyAppmakerScaffoldCollisionGuard.ts`: new guard mirroring the project's other narrow textual `verifyAppmaker*` guards — asserts the `conductorList` import, the `conductorList('apps')` call, the `dir`-entry/slug filter, and that the result is folded into the "already taken" throw.
- `utils/scripts/verifyAppmakerScaffoldCollisionGuard.test.ts`: matching self-test with fixed / pre-fix (no import/call/filter) / partially-regressed (computed but not folded into the throw) / missing-handler fixtures.
- `package.json` + `.github/workflows/contract-tests.yml`: wired the new guard + self-test in alongside the existing `appmaker-slug-candidate-guard` and `appmaker-fleet-description-guard` steps.

### How I verified
- **New guard self-test passes:** `npm run test:appmaker-scaffold-collision-guard-selftest` — buggy fixture fails all 4 checks, fixed fixture passes clean, a partially-regressed fixture (computed but not folded into the throw) fails only that one check, missing-handler fixture detected.
- **New guard passes against the real fixed file:** `npm run test:appmaker-scaffold-collision-guard`.
- **Pre-existing appmaker guards still pass, unaffected:** `npm run test:appmaker-slug-candidate-guard-selftest`, `test:appmaker-slug-candidate-guard`, `test:appmaker-fleet-description-guard-selftest`, `test:appmaker-fleet-description-guard` — all pass.
- **eslint clean:** `npx eslint server/api/appmaker/scaffold-request.post.ts utils/scripts/verifyAppmakerScaffoldCollisionGuard.ts utils/scripts/verifyAppmakerScaffoldCollisionGuard.test.ts` — no output, exit 0.
- **prettier clean:** `npx prettier --check` on the same three files plus `package.json`/`contract-tests.yml` — passes (ran `--write` once after the initial edits; confirmed via a `git stash` round-trip that `scaffold-request.post.ts` had pre-existing, unrelated formatting drift predating this change, harmless to normalize).
- **vue-tsc repo-wide:** `npm run test` (`nuxi prepare` + `vue-tsc --noEmit` over the whole project) completed clean, 0 `error TS` occurrences, exit 0.
- **Diff scope:** `git status --porcelain` shows exactly the 5 intended files: `server/api/appmaker/scaffold-request.post.ts`, `utils/scripts/verifyAppmakerScaffoldCollisionGuard.ts`, `utils/scripts/verifyAppmakerScaffoldCollisionGuard.test.ts`, `package.json`, `.github/workflows/contract-tests.yml`.

### Stakes
reversible

### Flags for Reviewer
- None — the collision check is additive (a strict superset of the prior check: same 409 status/message, one more source consulted), doesn't touch the happy path for any slug that isn't already scaffolded, and the fix mirrors `apps.get.ts`'s own existing `conductorList('apps')` + `type === 'dir'` pattern exactly.

### Kaizen suggestion
`server/api/appmaker/github/create-app.post.ts` (the external-repo GitHub-integration flow, appmaker/t-009) has the identical `existingProject`/`existingDream` pattern without the `apps/` folder check either — not fixed here since it has no wired-up front-end UI yet (grepped `components/`/`pages/` for `appmaker/github` — no matches) and t-012's scope this cycle was the reachable self-serve form. Worth applying the same fix once that flow gets a UI. Separately, `apps.get.ts`'s pending-Todo query (`SCAFFOLD_TITLE_RE`, matching `"Scaffold new app '"`) also doesn't match `create-app.post.ts`'s `"Scaffold external app '...' via AppMaker GitHub integration"` Todo title, so a pending external-repo request would never show up under "Being built" even once that UI exists — same "unreachable yet" reasoning applies.

### Notes for reviewer
Read `projects/appmaker/roadmap.yaml` task t-012's note for the full cycle history (2026-08-16 fleet-description fix → 2026-08-18 no-new-bug audit + t-014 filed → this 2026-08-19 cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYZF59LWAX8LqRnQ2eJr9E

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYZF59LWAX8LqRnQ2eJr9E)_