### PR TITLE
feat(economy): mission-remittance reconciliation check (kind-economy/t-016)

### DIFF
--- a/components/pages/mission-accrual-page.vue
+++ b/components/pages/mission-accrual-page.vue
@@ -107,6 +107,14 @@
           </article>
         </section>
 
+        <section
+          class="rounded-2xl border p-4 text-sm"
+          :class="reconciliationBannerClass"
+        >
+          <p class="font-bold">{{ reconciliationHeadline }}</p>
+          <p class="mt-1 text-xs opacity-80">{{ reconciliationDetail }}</p>
+        </section>
+
         <section class="space-y-3">
           <div class="flex items-center justify-between">
             <h2
@@ -234,6 +242,45 @@ const data = computed(() => store.data)
 const externalDonationCents = EXTERNAL_DIRECT_DONATION_CENTS
 const externalDonationAsOf = EXTERNAL_DIRECT_DONATION_AS_OF
 const externalDonationUrl = EXTERNAL_DIRECT_DONATION_URL
+
+// Reconciliation banner -- kind-economy/t-016. Mirrors
+// server/utils/missionAccrual.ts's checkMissionRemittanceReconciliation:
+// reconciled (outstanding == 0), under-remitted (promise broken, still
+// owed), or over-remitted (likely a duplicate/double remittance).
+const reconciliation = computed(() => data.value?.reconciliation ?? null)
+
+const reconciliationBannerClass = computed(() => {
+  switch (reconciliation.value?.status) {
+    case 'under-remitted':
+      return 'border-warning/40 bg-warning/10 text-base-content/85'
+    case 'over-remitted':
+      return 'border-error/40 bg-error/10 text-base-content/85'
+    default:
+      return 'border-success/30 bg-success/10 text-base-content/85'
+  }
+})
+
+const reconciliationHeadline = computed(() => {
+  const r = reconciliation.value
+  if (!r || r.status === 'reconciled') {
+    return '✅ Reconciled — outstanding is $0.00.'
+  }
+  if (r.status === 'under-remitted') {
+    return `⚠️ Under-remitted by ${formatUsdCents(r.shortfallCents)}.`
+  }
+  return `⚠️ Over-remitted by ${formatUsdCents(r.overageCents)}.`
+})
+
+const reconciliationDetail = computed(() => {
+  const r = reconciliation.value
+  if (!r || r.status === 'reconciled') {
+    return 'The last logged remittance covered exactly what had accrued at the time. Nothing owed right now.'
+  }
+  if (r.status === 'under-remitted') {
+    return 'The mission share promised to the fundraiser has not fully gone out yet. Send the outstanding amount and log it to bring this back to zero.'
+  }
+  return 'More has been logged as remitted than has accrued. Check for a duplicate remittance entry (same donation logged twice) or a typo’d amount before assuming this is correct.'
+})
 
 const form = reactive({
   amountUsd: '',

--- a/server/utils/missionAccrual.ts
+++ b/server/utils/missionAccrual.ts
@@ -98,6 +98,43 @@ export function summarizeMissionAccrual(
 }
 
 // ---------------------------------------------------------------------------
+// Reconciliation check -- pure, unit-testable (kind-economy/t-016)
+//
+// Because every remittance is meant to bring the running outstanding
+// balance back to exactly zero (there is no per-period bucketing on
+// MissionRemittance rows -- see the runbook at
+// conductor/projects/kind-economy/docs/mission-remittance-runbook.md), the
+// two failure modes the task asks for collapse onto the sign of
+// outstandingCents immediately after a remittance is logged:
+//   outstanding == 0  -> reconciled: this remittance covered exactly what
+//                        had accrued, no more, no less.
+//   outstanding  > 0  -> under-remitted: the remittance was smaller than
+//                        what had accrued -- the "a third of what you pay
+//                        buys nets" promise is broken for the shortfall.
+//   outstanding  < 0  -> over-remitted: the remittance exceeded what had
+//                        accrued -- most likely a duplicate/double
+//                        remittance for a period already covered, or a
+//                        typo'd amount. The money is gone twice from
+//                        Silas's perspective even though the ledger still
+//                        balances honestly (it just balances negative).
+// ---------------------------------------------------------------------------
+
+export type MissionRemittanceReconciliation =
+  | { status: 'reconciled' }
+  | { status: 'under-remitted'; shortfallCents: number }
+  | { status: 'over-remitted'; overageCents: number }
+
+export function checkMissionRemittanceReconciliation(
+  outstandingCents: number,
+): MissionRemittanceReconciliation {
+  if (outstandingCents === 0) return { status: 'reconciled' }
+  if (outstandingCents > 0) {
+    return { status: 'under-remitted', shortfallCents: outstandingCents }
+  }
+  return { status: 'over-remitted', overageCents: -outstandingCents }
+}
+
+// ---------------------------------------------------------------------------
 // Remittance validation -- pure, unit-testable
 // ---------------------------------------------------------------------------
 
@@ -166,6 +203,7 @@ export type MissionAccrualData = {
   remittances: MissionRemittanceRow[]
   remittedTotalCents: number
   outstandingCents: number
+  reconciliation: MissionRemittanceReconciliation
 }
 
 /**
@@ -231,12 +269,14 @@ export async function getMissionAccrualData(
     (sum, row) => sum + row.amountCents,
     0,
   )
+  const outstandingCents = accrual.totalCents - remittedTotalCents
 
   return {
     accrual,
     remittances,
     remittedTotalCents,
-    outstandingCents: accrual.totalCents - remittedTotalCents,
+    outstandingCents,
+    reconciliation: checkMissionRemittanceReconciliation(outstandingCents),
   }
 }
 

--- a/stores/missionAccrualStore.ts
+++ b/stores/missionAccrualStore.ts
@@ -33,11 +33,17 @@ export type MissionRemittanceRow = {
   reference: string | null
 }
 
+export type MissionRemittanceReconciliation =
+  | { status: 'reconciled' }
+  | { status: 'under-remitted'; shortfallCents: number }
+  | { status: 'over-remitted'; overageCents: number }
+
 export type MissionAccrualData = {
   accrual: MissionAccrualSummary
   remittances: MissionRemittanceRow[]
   remittedTotalCents: number
   outstandingCents: number
+  reconciliation: MissionRemittanceReconciliation
 }
 
 export type LogRemittanceInput = {

--- a/utils/scripts/verifyMissionAccrual.test.ts
+++ b/utils/scripts/verifyMissionAccrual.test.ts
@@ -17,6 +17,7 @@ import assert from 'node:assert/strict'
 import {
   summarizeMissionAccrual,
   validateMissionRemittanceInput,
+  checkMissionRemittanceReconciliation,
   type MissionAccrualRow,
 } from '../../server/utils/missionAccrual.js'
 import {
@@ -224,6 +225,35 @@ for (const badNote of ['', '   ', null, undefined]) {
 
 console.log(
   '✅ validateMissionRemittanceInput: accepts clean input, trims/limits reference, rejects non-positive/non-integer amounts and empty notes',
+)
+
+// --- checkMissionRemittanceReconciliation (kind-economy/t-016) -------------
+// The two failure modes the task asks for: remitting less than accrued
+// (the promise is broken) and double-remitting the same period (the money
+// is gone twice). Both collapse onto the sign of outstandingCents.
+
+{
+  assert.deepEqual(checkMissionRemittanceReconciliation(0), {
+    status: 'reconciled',
+  })
+}
+
+{
+  assert.deepEqual(checkMissionRemittanceReconciliation(1250), {
+    status: 'under-remitted',
+    shortfallCents: 1250,
+  })
+}
+
+{
+  assert.deepEqual(checkMissionRemittanceReconciliation(-500), {
+    status: 'over-remitted',
+    overageCents: 500,
+  })
+}
+
+console.log(
+  '✅ checkMissionRemittanceReconciliation: reconciled at zero, flags under-remitted (positive outstanding) and over-remitted/possible-double-remit (negative outstanding) with the correct magnitude',
 )
 
 console.log('✅ verifyMissionAccrual: all assertions passed')


### PR DESCRIPTION
## What

`kind-economy/t-016` asks for a runbook (in conductor) plus reconciliation *tooling*
for the mission-share remittance process built in `t-010` (#1964) — catching the two
failure modes that matter: remitting less than accrued (the promise is broken) and
double-remitting the same period (the money is gone twice). No transfer is automated;
Silas still sends the money manually and logs it via the existing dashboard form.

## Changes

- **`server/utils/missionAccrual.ts`** — new pure function
  `checkMissionRemittanceReconciliation(outstandingCents)`. Because every remittance
  is meant to bring the running `outstanding = accrued − remitted` balance back to
  exactly zero, both failure modes collapse onto the sign of `outstandingCents`
  immediately after a remittance is logged:
  - `== 0` → `reconciled`
  - `> 0` → `under-remitted` (`shortfallCents`) — less went out than had accrued
  - `< 0` → `over-remitted` (`overageCents`) — more was logged than had accrued,
    most likely a duplicate log entry
  Wired into `getMissionAccrualData()`'s return as `reconciliation`.
- **`stores/missionAccrualStore.ts`** — mirrors the new `MissionRemittanceReconciliation`
  type and the `reconciliation` field on `MissionAccrualData`.
- **`components/pages/mission-accrual-page.vue`** — a reconciliation banner (green/
  reconciled, amber/under-remitted, red/over-remitted) that appears after the stat
  cards, refreshing automatically whenever the dashboard reloads (including right
  after logging a remittance).
- **`utils/scripts/verifyMissionAccrual.test.ts`** — three new assertions covering
  reconciled / under-remitted / over-remitted, with correct shortfall/overage
  magnitude.

No schema change — `MissionRemittance` doesn't need a "for period X" field for this
check to work; see the companion runbook for why.

## Companion doc

The operational runbook (cadence, who initiates, where the amount comes from, where
the receipt is filed, how to act on each reconciliation state) is in the conductor
repo: `projects/kind-economy/docs/mission-remittance-runbook.md` (conductor PR, same
session).

## Verification

- `npm run test:mission-accrual` — 6/6 assertions pass (3 pre-existing + 3 new)
- Sibling contract tests re-run to confirm no regression: `test:revenue-split`,
  `test:creator-earnings`
- `vue-tsc --noEmit` clean repo-wide
- `eslint` / `prettier --check` clean on all 4 touched files
- `git status --porcelain` shows exactly the 4 intended files

## Stakes

reversible — pure bookkeeping/UI addition, no money moves, no schema change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1eHXYMrt9eySRQj88UU7n)_