### PR TITLE
test(brainstorm): deterministic fixtures for candidate lifecycle (brainstorm/t-021)

### DIFF
--- a/.github/workflows/brainstorm-store-contract.yml
+++ b/.github/workflows/brainstorm-store-contract.yml
@@ -6,15 +6,19 @@ on:
     paths:
       - '.github/workflows/brainstorm-store-contract.yml'
       - 'stores/brainstormStore.ts'
+      - 'stores/helpers/brainstormCandidateLifecycle.ts'
       - 'types/brainstorm.ts'
       - 'utils/scripts/verifyBrainstormStoreContract.mjs'
+      - 'utils/scripts/verifyBrainstormCandidateLifecycle.test.ts'
   pull_request:
     branches: [main]
     paths:
       - '.github/workflows/brainstorm-store-contract.yml'
       - 'stores/brainstormStore.ts'
+      - 'stores/helpers/brainstormCandidateLifecycle.ts'
       - 'types/brainstorm.ts'
       - 'utils/scripts/verifyBrainstormStoreContract.mjs'
+      - 'utils/scripts/verifyBrainstormCandidateLifecycle.test.ts'
   workflow_dispatch:
 
 permissions:
@@ -41,3 +45,9 @@ jobs:
 
       - name: Verify Brainstorm store contract
         run: node utils/scripts/verifyBrainstormStoreContract.mjs
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Verify Brainstorm candidate lifecycle contract
+        run: npx tsx utils/scripts/verifyBrainstormCandidateLifecycle.test.ts

--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "test:pitch-detector-accuracy": "tsx utils/scripts/verifyPitchDetectorAccuracy.test.ts",
     "test:brainstorm-source-adapters": "tsx utils/scripts/verifyBrainstormSourceAdapters.test.ts",
     "test:brainstorm-source-context": "tsx utils/scripts/verifyBrainstormSourceContext.ts",
+    "test:brainstorm-candidate-lifecycle": "tsx utils/scripts/verifyBrainstormCandidateLifecycle.test.ts",
     "test:pack-scaffold-extraction": "tsx utils/scripts/verifyPackScaffoldExtraction.test.ts",
     "test:parse-mysql-url": "tsx utils/scripts/verifyParseMysqlUrl.ts",
     "test:newsfeed-aggregation": "tsx utils/scripts/verifyNewsfeedAggregation.ts",

--- a/stores/brainstormStore.ts
+++ b/stores/brainstormStore.ts
@@ -3,22 +3,40 @@ import { defineStore } from 'pinia'
 import { useServerStore } from '@/stores/serverStore'
 import { performFetch } from '@/stores/utils'
 import {
+  applyCandidateEdit,
+  applyCandidateRegeneration,
+  applyCandidateRevisionRestore,
+  applyCandidateStatus,
+  classifyError,
+  cleanExamples,
+  cleanMultilineText,
+  cleanText,
+  clampResultCount,
+  computeBranchOrigin,
+  normalizeBatchShape,
+  normalizeGeneratedCandidates,
+  normalizeOutputDomain,
+  normalizeReturnTypeId,
+  normalizeReturnTypes,
+  normalizeSourceRef,
+  normalizeStoredBatch,
+  normalizeStoredCandidate,
+  nowIso,
+  RETURN_TYPE_IDS,
+} from '@/stores/helpers/brainstormCandidateLifecycle'
+import {
   BRAINSTORM_DEFAULT_OUTPUT_DOMAIN,
   BRAINSTORM_DEFAULT_RESULTS,
   BRAINSTORM_MAX_RESULTS,
   BRAINSTORM_MIN_RESULTS,
-  BRAINSTORM_OUTPUT_DOMAINS,
-  BRAINSTORM_RETURN_TYPES,
 } from '@/types/brainstorm'
 import type {
   BrainstormBatch,
   BrainstormBatchShape,
-  BrainstormBranchOrigin,
   BrainstormCandidate,
   BrainstormCandidateRevision,
   BrainstormCandidateStatus,
   BrainstormError,
-  BrainstormErrorKind,
   BrainstormGenerateData,
   BrainstormGeneratedCandidate,
   BrainstormGeneratePayload,
@@ -38,20 +56,21 @@ import type {
   BrainstormSourceRef,
 } from '@/types/brainstorm'
 
+// conductor brainstorm/t-021: the pure normalization and candidate
+// state-transition logic that used to live in this file (nowIso through
+// computeBranchOrigin) now lives in
+// stores/helpers/brainstormCandidateLifecycle.ts, imported above, so it can
+// be exercised by a plain-Node test without pulling in Pinia/useServerStore.
+// See that file's header comment for why. Nothing below this point changed
+// behavior; only where the pure half of it is defined.
+
 const STORAGE_KEY = 'kindrobots:brainstorm-session:v1'
 const SAVED_LINK_STORAGE_KEY = 'kindrobots:brainstorm-saved-link:v1'
 const STORAGE_VERSION = 1 as const
 const GENERATION_TIMEOUT_MS = 60_000
 const PERSISTENCE_TIMEOUT_MS = 30_000
-const RETURN_TYPE_IDS = new Set<BrainstormReturnTypeId>(
-  BRAINSTORM_RETURN_TYPES.map((entry) => entry.id),
-)
 
 let localIdSequence = 0
-
-function nowIso(): string {
-  return new Date().toISOString()
-}
 
 function createLocalId(prefix: 'batch' | 'candidate'): string {
   localIdSequence += 1
@@ -59,278 +78,14 @@ function createLocalId(prefix: 'batch' | 'candidate'): string {
   return `${prefix}-${uuid || `${Date.now()}-${localIdSequence}`}`
 }
 
-function cleanText(value: unknown): string {
-  return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : ''
-}
-
-function cleanMultilineText(value: unknown): string {
-  return typeof value === 'string' ? value.trim() : ''
-}
-
-function cleanExamples(values: unknown): string[] {
-  if (!Array.isArray(values)) return []
-
-  return values
-    .map((value) => cleanMultilineText(value))
-    .filter((value, index, all) => value && all.indexOf(value) === index)
-    .slice(0, 20)
-}
-
-function clampResultCount(value: unknown): number {
-  const parsed = Number(value)
-  if (!Number.isFinite(parsed)) return BRAINSTORM_DEFAULT_RESULTS
-  return Math.min(
-    BRAINSTORM_MAX_RESULTS,
-    Math.max(BRAINSTORM_MIN_RESULTS, Math.round(parsed)),
-  )
-}
-
-function normalizeBatchShape(value: unknown): BrainstormBatchShape {
-  return value === 'assortment' ? 'assortment' : 'focused'
-}
-
-const OUTPUT_DOMAIN_IDS = new Set(
-  BRAINSTORM_OUTPUT_DOMAINS.map((entry) => entry.id),
-)
-
-function normalizeOutputDomain(value: unknown): BrainstormOutputDomainId {
-  const id = cleanText(value) as BrainstormOutputDomainId
-  return OUTPUT_DOMAIN_IDS.has(id) ? id : BRAINSTORM_DEFAULT_OUTPUT_DOMAIN
-}
-
-function normalizeReturnTypeId(value: unknown): BrainstormReturnTypeId | null {
-  const id = cleanText(value) as BrainstormReturnTypeId
-  return RETURN_TYPE_IDS.has(id) ? id : null
-}
-
-function normalizeReturnTypes(value: unknown): BrainstormReturnTypeRequest[] {
-  if (!Array.isArray(value)) return []
-
-  const result: BrainstormReturnTypeRequest[] = []
-  const seen = new Set<BrainstormReturnTypeId>()
-
-  for (const raw of value) {
-    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue
-    const record = raw as Record<string, unknown>
-    const id = normalizeReturnTypeId(record.id)
-    if (!id || seen.has(id)) continue
-
-    const parsedCount = Number(record.count)
-    const count =
-      Number.isInteger(parsedCount) && parsedCount > 0
-        ? Math.min(BRAINSTORM_MAX_RESULTS, parsedCount)
-        : undefined
-
-    result.push({ id, ...(count ? { count } : {}) })
-    seen.add(id)
-  }
-
-  return result
-}
-
-function minimumResultCountForMix(entries: BrainstormReturnTypeRequest[]): number {
+function minimumResultCountForMix(
+  entries: BrainstormReturnTypeRequest[],
+): number {
   if (!entries.length) return BRAINSTORM_MIN_RESULTS
   return Math.min(
     BRAINSTORM_MAX_RESULTS,
     entries.reduce((total, entry) => total + (entry.count ?? 1), 0),
   )
-}
-
-function normalizeGeneratedCandidates(
-  value: unknown,
-  expectedCount: number,
-): BrainstormGeneratedCandidate[] | null {
-  if (!Array.isArray(value)) return null
-
-  const candidates: BrainstormGeneratedCandidate[] = []
-  const seen = new Set<string>()
-
-  for (const raw of value) {
-    if (!raw || typeof raw !== 'object') return null
-
-    const record = raw as Record<string, unknown>
-    const text = cleanMultilineText(record.text)
-    const title = cleanText(record.title)
-    const returnType = normalizeReturnTypeId(record.returnType)
-
-    if (!text) return null
-
-    const duplicateKey = text.toLocaleLowerCase().replace(/\s+/g, ' ').trim()
-    if (seen.has(duplicateKey)) return null
-    seen.add(duplicateKey)
-
-    candidates.push({
-      text,
-      ...(title ? { title } : {}),
-      ...(returnType ? { returnType } : {}),
-    })
-  }
-
-  return candidates.length === expectedCount ? candidates : null
-}
-
-function normalizeSourceRef(value: unknown): BrainstormSourceRef | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
-
-  const record = value as Record<string, unknown>
-  const modelType = cleanText(record.modelType)
-  const id = Number(record.id)
-  const slug = cleanText(record.slug)
-  const intent = cleanMultilineText(record.intent)
-
-  if (!modelType) return null
-
-  return {
-    modelType,
-    ...(Number.isInteger(id) && id > 0 ? { id } : {}),
-    ...(slug ? { slug } : {}),
-    ...(intent ? { intent } : {}),
-  }
-}
-
-function normalizeRevision(value: unknown): BrainstormCandidateRevision | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
-
-  const record = value as Record<string, unknown>
-  const text = cleanMultilineText(record.text)
-  const title = cleanText(record.title)
-  const createdAt = cleanText(record.createdAt)
-  const reason = record.reason
-  const returnType = normalizeReturnTypeId(record.returnType)
-
-  if (
-    !text ||
-    !createdAt ||
-    !['generated', 'edited', 'regenerated', 'branched', 'restored'].includes(String(reason))
-  ) {
-    return null
-  }
-
-  return {
-    text,
-    createdAt,
-    reason: reason as BrainstormCandidateRevision['reason'],
-    ...(title ? { title } : {}),
-    returnType,
-  }
-}
-
-function normalizeBranchOrigin(value: unknown): BrainstormBranchOrigin | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
-  const record = value as Record<string, unknown>
-  const candidateId = cleanText(record.candidateId)
-  const revisionIndex = Number(record.revisionIndex)
-  const title = cleanText(record.title)
-  const text = cleanMultilineText(record.text)
-
-  if (!candidateId || !text || !Number.isInteger(revisionIndex) || revisionIndex < 0) {
-    return null
-  }
-
-  return {
-    candidateId,
-    revisionIndex,
-    ...(title ? { title } : {}),
-    text,
-  }
-}
-
-function normalizeStoredCandidate(value: unknown): BrainstormCandidate | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
-
-  const record = value as Record<string, unknown>
-  const id = cleanText(record.id)
-  const batchId = cleanText(record.batchId)
-  const text = cleanMultilineText(record.text)
-  const title = cleanText(record.title)
-  const feedback = cleanMultilineText(record.feedback)
-  const parentId = cleanText(record.parentId)
-  const status = record.status
-
-  if (
-    !id ||
-    !batchId ||
-    !text ||
-    !['pending', 'kept', 'rejected'].includes(String(status))
-  ) {
-    return null
-  }
-
-  const revisions = Array.isArray(record.revisions)
-    ? record.revisions
-        .map((revision) => normalizeRevision(revision))
-        .filter((revision): revision is BrainstormCandidateRevision => Boolean(revision))
-    : []
-
-  const meta =
-    record.meta && typeof record.meta === 'object' && !Array.isArray(record.meta)
-      ? (record.meta as Record<string, unknown>)
-      : {}
-  const source = normalizeSourceRef(meta.source)
-  const returnType = normalizeReturnTypeId(meta.returnType)
-  const branchOrigin = normalizeBranchOrigin(meta.branchOrigin)
-
-  return {
-    id,
-    batchId,
-    title,
-    text,
-    status: status as BrainstormCandidateStatus,
-    feedback,
-    edited: record.edited === true,
-    parentId: parentId || null,
-    revisions:
-      revisions.length > 0
-        ? revisions
-        : [{ title, text, createdAt: nowIso(), reason: 'generated', returnType }],
-    meta: {
-      source,
-      returnType,
-      branchOrigin,
-    },
-  }
-}
-
-function normalizeStoredBatch(value: unknown): BrainstormBatch | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
-
-  const record = value as Record<string, unknown>
-  const id = cleanText(record.id)
-  const createdAt = cleanText(record.createdAt)
-  const premise = cleanMultilineText(record.premise)
-  const candidateIds = Array.isArray(record.candidateIds)
-    ? record.candidateIds.map((value) => cleanText(value)).filter(Boolean)
-    : []
-
-  if (!id || !createdAt || !premise || candidateIds.length === 0) return null
-
-  const requestRecord =
-    record.request && typeof record.request === 'object'
-      ? (record.request as Record<string, unknown>)
-      : {}
-
-  const request: BrainstormGenerateRequest = {
-    premise: cleanMultilineText(requestRecord.premise) || premise,
-    count: clampResultCount(requestRecord.count),
-    constraints: cleanMultilineText(requestRecord.constraints),
-    examples: cleanExamples(requestRecord.examples),
-    mode: cleanText(requestRecord.mode) || 'freeform',
-    outputDomain: normalizeOutputDomain(requestRecord.outputDomain),
-    batchShape: normalizeBatchShape(requestRecord.batchShape),
-    returnTypes: normalizeReturnTypes(requestRecord.returnTypes),
-    source: normalizeSourceRef(requestRecord.source),
-  }
-
-  return { id, createdAt, premise, request, candidateIds }
-}
-
-function classifyError(status: number | undefined): BrainstormErrorKind {
-  if (status === 401) return 'auth'
-  if (status === 402) return 'mana'
-  if (status === 408) return 'network'
-  if (status === 404 || status === 503) return 'server'
-  if (status && status >= 500) return 'provider'
-  return 'network'
 }
 
 export const useBrainstormStore = defineStore('brainstormStore', () => {
@@ -339,7 +94,9 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
   const constraints = ref('')
   const examples = ref<string[]>([])
   const mode = ref('freeform')
-  const outputDomain = ref<BrainstormOutputDomainId>(BRAINSTORM_DEFAULT_OUTPUT_DOMAIN)
+  const outputDomain = ref<BrainstormOutputDomainId>(
+    BRAINSTORM_DEFAULT_OUTPUT_DOMAIN,
+  )
   const batchShape = ref<BrainstormBatchShape>('focused')
   const returnTypes = ref<BrainstormReturnTypeRequest[]>([])
   const source = ref<BrainstormSourceRef | null>(null)
@@ -380,7 +137,9 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
 
     return batch.candidateIds
       .map((candidateId) => byId.get(candidateId))
-      .filter((candidate): candidate is BrainstormCandidate => Boolean(candidate))
+      .filter((candidate): candidate is BrainstormCandidate =>
+        Boolean(candidate),
+      )
   })
 
   const keptCandidates = computed(() =>
@@ -395,11 +154,15 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
   )
 
   const rejectedCandidates = computed(() =>
-    activeCandidates.value.filter((candidate) => candidate.status === 'rejected'),
+    activeCandidates.value.filter(
+      (candidate) => candidate.status === 'rejected',
+    ),
   )
 
   const pendingCandidates = computed(() =>
-    activeCandidates.value.filter((candidate) => candidate.status === 'pending'),
+    activeCandidates.value.filter(
+      (candidate) => candidate.status === 'pending',
+    ),
   )
 
   const minimumMixResults = computed(() =>
@@ -408,11 +171,11 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
       : BRAINSTORM_MIN_RESULTS,
   )
 
-  const isGenerating = computed(
-    () => generationState.value === 'generating',
-  )
+  const isGenerating = computed(() => generationState.value === 'generating')
   const isPersisting = computed(
-    () => persistenceState.value === 'loading' || persistenceState.value === 'saving',
+    () =>
+      persistenceState.value === 'loading' ||
+      persistenceState.value === 'saving',
   )
 
   const canGenerate = computed(
@@ -423,7 +186,10 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
   )
 
   const canSaveSession = computed(
-    () => Boolean(premise.value.trim()) && Boolean(sessionName.value.trim()) && !isPersisting.value,
+    () =>
+      Boolean(premise.value.trim()) &&
+      Boolean(sessionName.value.trim()) &&
+      !isPersisting.value,
   )
 
   const suggestedSessionName = computed(() => {
@@ -469,7 +235,10 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
       if (savedSessionId.value && sessionName.value.trim()) {
         localStorage.setItem(
           SAVED_LINK_STORAGE_KEY,
-          JSON.stringify({ id: savedSessionId.value, name: sessionName.value.trim() }),
+          JSON.stringify({
+            id: savedSessionId.value,
+            name: sessionName.value.trim(),
+          }),
         )
       } else {
         localStorage.removeItem(SAVED_LINK_STORAGE_KEY)
@@ -487,7 +256,9 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
       const restoredCandidates = Array.isArray(parsed.candidates)
         ? parsed.candidates
             .map((candidate) => normalizeStoredCandidate(candidate))
-            .filter((candidate): candidate is BrainstormCandidate => Boolean(candidate))
+            .filter((candidate): candidate is BrainstormCandidate =>
+              Boolean(candidate),
+            )
         : []
       const restoredCandidateIds = new Set(
         restoredCandidates.map((candidate) => candidate.id),
@@ -515,7 +286,10 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
           : BRAINSTORM_MIN_RESULTS
 
       premise.value = cleanMultilineText(parsed.premise)
-      resultCount.value = Math.max(clampResultCount(parsed.resultCount), restoredMinimum)
+      resultCount.value = Math.max(
+        clampResultCount(parsed.resultCount),
+        restoredMinimum,
+      )
       constraints.value = cleanMultilineText(parsed.constraints)
       examples.value = cleanExamples(parsed.examples)
       mode.value = cleanText(parsed.mode) || 'freeform'
@@ -622,7 +396,10 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
     ensureMixFits()
   }
 
-  function setReturnTypeCount(id: BrainstormReturnTypeId, value: number | null): void {
+  function setReturnTypeCount(
+    id: BrainstormReturnTypeId,
+    value: number | null,
+  ): void {
     const entry = returnTypes.value.find((candidate) => candidate.id === id)
     if (!entry) return
 
@@ -706,8 +483,7 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
     const candidate = findCandidate(candidateId)
     if (!candidate) return false
 
-    candidate.status = status
-    if (status === 'kept') candidate.feedback = ''
+    applyCandidateStatus(candidate, status)
     return true
   }
 
@@ -737,25 +513,7 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
     const candidate = findCandidate(candidateId)
     if (!candidate) return false
 
-    const nextTitle =
-      patch.title === undefined ? candidate.title : cleanText(patch.title)
-    const nextText =
-      patch.text === undefined ? candidate.text : cleanMultilineText(patch.text)
-
-    if (!nextText) return false
-    if (nextTitle === candidate.title && nextText === candidate.text) return true
-
-    candidate.title = nextTitle
-    candidate.text = nextText
-    candidate.edited = true
-    candidate.revisions.push({
-      ...(nextTitle ? { title: nextTitle } : {}),
-      text: nextText,
-      createdAt: nowIso(),
-      reason: 'edited',
-      returnType: candidate.meta.returnType ?? null,
-    })
-    return true
+    return applyCandidateEdit(candidate, patch)
   }
 
   function restoreCandidateRevision(
@@ -764,37 +522,8 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
   ): boolean {
     const candidate = findCandidate(candidateId)
     if (!candidate) return false
-    if (!Number.isInteger(revisionIndex) || revisionIndex < 0) return false
 
-    const revision = candidate.revisions[revisionIndex]
-    if (!revision) return false
-
-    const nextTitle = cleanText(revision.title)
-    const nextText = cleanMultilineText(revision.text)
-    if (!nextText) return false
-
-    const nextReturnType =
-      normalizeReturnTypeId(revision.returnType) ?? candidate.meta.returnType ?? null
-    if (
-      nextTitle === candidate.title &&
-      nextText === candidate.text &&
-      nextReturnType === (candidate.meta.returnType ?? null)
-    ) {
-      return true
-    }
-
-    candidate.title = nextTitle
-    candidate.text = nextText
-    candidate.meta.returnType = nextReturnType
-    candidate.edited = true
-    candidate.revisions.push({
-      ...(nextTitle ? { title: nextTitle } : {}),
-      text: nextText,
-      createdAt: nowIso(),
-      reason: 'restored',
-      returnType: nextReturnType,
-    })
-    return true
+    return applyCandidateRevisionRestore(candidate, revisionIndex)
   }
 
   function removeCandidate(candidateId: string): boolean {
@@ -807,7 +536,9 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
     for (const batch of batches.value) {
       batch.candidateIds = batch.candidateIds.filter((id) => id !== candidateId)
     }
-    batches.value = batches.value.filter((batch) => batch.candidateIds.length > 0)
+    batches.value = batches.value.filter(
+      (batch) => batch.candidateIds.length > 0,
+    )
 
     if (
       activeBatchId.value &&
@@ -886,26 +617,7 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
     const candidate = findCandidate(candidateId)
     if (!candidate) return false
 
-    const title = cleanText(generated.title)
-    const text = cleanMultilineText(generated.text)
-    if (!text) return false
-
-    const returnType =
-      normalizeReturnTypeId(generated.returnType) ?? candidate.meta.returnType ?? null
-    candidate.title = title
-    candidate.text = text
-    candidate.status = 'pending'
-    candidate.feedback = ''
-    candidate.edited = false
-    candidate.meta.returnType = returnType
-    candidate.revisions.push({
-      ...(title ? { title } : {}),
-      text,
-      createdAt: nowIso(),
-      reason: 'regenerated',
-      returnType,
-    })
-    return true
+    return applyCandidateRegeneration(candidate, generated)
   }
 
   function appendBranchCandidate(
@@ -921,13 +633,9 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
       'branched',
       parent.id,
     )
-    if (!child.meta.returnType) child.meta.returnType = parent.meta.returnType ?? null
-    child.meta.branchOrigin = {
-      candidateId: parent.id,
-      revisionIndex: Math.max(0, parent.revisions.length - 1),
-      ...(parent.title ? { title: parent.title } : {}),
-      text: parent.text,
-    }
+    if (!child.meta.returnType)
+      child.meta.returnType = parent.meta.returnType ?? null
+    child.meta.branchOrigin = computeBranchOrigin(parent)
     candidates.value.push(child)
 
     const parentIndex = batch.candidateIds.indexOf(parent.id)
@@ -960,7 +668,8 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
       mode: cleanText(mode.value) || 'freeform',
       outputDomain: outputDomain.value,
       batchShape: shape,
-      returnTypes: shape === 'assortment' ? normalizeReturnTypes(returnTypes.value) : [],
+      returnTypes:
+        shape === 'assortment' ? normalizeReturnTypes(returnTypes.value) : [],
       source: source.value,
     }
   }
@@ -978,7 +687,9 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
 
     return {
       premise:
-        originalRequest?.premise || cleanMultilineText(premise.value) || candidate.text,
+        originalRequest?.premise ||
+        cleanMultilineText(premise.value) ||
+        candidate.text,
       count: 1,
       constraints:
         originalRequest?.constraints || cleanMultilineText(constraints.value),
@@ -1119,7 +830,9 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
   }
 
   function upsertSavedSummary(summary: BrainstormSavedSessionSummary): void {
-    const index = savedSessions.value.findIndex((entry) => entry.id === summary.id)
+    const index = savedSessions.value.findIndex(
+      (entry) => entry.id === summary.id,
+    )
     if (index >= 0) savedSessions.value.splice(index, 1, summary)
     else savedSessions.value.unshift(summary)
     savedSessions.value.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
@@ -1221,7 +934,10 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
 
     const saved = result.data.session
     if (!restoreSession(JSON.stringify(saved.snapshot))) {
-      setPersistenceFailure(500, 'The saved Brainstorm session could not be restored safely.')
+      setPersistenceFailure(
+        500,
+        'The saved Brainstorm session could not be restored safely.',
+      )
       return false
     }
 

--- a/stores/helpers/brainstormCandidateLifecycle.ts
+++ b/stores/helpers/brainstormCandidateLifecycle.ts
@@ -23,7 +23,7 @@ import {
   BRAINSTORM_MIN_RESULTS,
   BRAINSTORM_OUTPUT_DOMAINS,
   BRAINSTORM_RETURN_TYPES,
-} from '@/types/brainstorm'
+} from '../../types/brainstorm'
 import type {
   BrainstormBatch,
   BrainstormBatchShape,
@@ -38,7 +38,7 @@ import type {
   BrainstormReturnTypeId,
   BrainstormReturnTypeRequest,
   BrainstormSourceRef,
-} from '@/types/brainstorm'
+} from '../../types/brainstorm'
 
 export function nowIso(): string {
   return new Date().toISOString()

--- a/stores/helpers/brainstormCandidateLifecycle.ts
+++ b/stores/helpers/brainstormCandidateLifecycle.ts
@@ -1,0 +1,474 @@
+// /stores/helpers/brainstormCandidateLifecycle.ts
+//
+// Pure BrainstormCandidate normalization and state-transition logic, split
+// out of stores/brainstormStore.ts (conductor brainstorm/t-021) so it can be
+// exercised directly in a plain Node test -- the same reason
+// brainstormSourceAdapterKit.ts/brainstormSourceContextKit.ts are split from
+// their store-facing callers. brainstormStore.ts itself is unreachable from
+// a bare `tsx` process: it imports useServerStore -> userStore ->
+// achievementStore, and achievementStore.ts calls `import.meta.glob(...)` at
+// module load time, a Vite-only feature with no meaning under plain Node.
+// None of the functions below need Pinia, a store instance, or a browser
+// runtime -- they take plain data in and return plain data (or mutate one
+// passed-in BrainstormCandidate) out, so moving them here costs nothing and
+// is what actually makes verifyBrainstormCandidateLifecycle.test.ts able to
+// import and call them for real instead of grepping the store source.
+//
+// brainstormStore.ts imports everything it still needs from here; nothing
+// about its own behavior changes, only where the pure half of it lives.
+import {
+  BRAINSTORM_DEFAULT_OUTPUT_DOMAIN,
+  BRAINSTORM_DEFAULT_RESULTS,
+  BRAINSTORM_MAX_RESULTS,
+  BRAINSTORM_MIN_RESULTS,
+  BRAINSTORM_OUTPUT_DOMAINS,
+  BRAINSTORM_RETURN_TYPES,
+} from '@/types/brainstorm'
+import type {
+  BrainstormBatch,
+  BrainstormBatchShape,
+  BrainstormBranchOrigin,
+  BrainstormCandidate,
+  BrainstormCandidateRevision,
+  BrainstormCandidateStatus,
+  BrainstormErrorKind,
+  BrainstormGenerateRequest,
+  BrainstormGeneratedCandidate,
+  BrainstormOutputDomainId,
+  BrainstormReturnTypeId,
+  BrainstormReturnTypeRequest,
+  BrainstormSourceRef,
+} from '@/types/brainstorm'
+
+export function nowIso(): string {
+  return new Date().toISOString()
+}
+
+export function cleanText(value: unknown): string {
+  return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : ''
+}
+
+export function cleanMultilineText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+export function cleanExamples(values: unknown): string[] {
+  if (!Array.isArray(values)) return []
+
+  return values
+    .map((value) => cleanMultilineText(value))
+    .filter((value, index, all) => value && all.indexOf(value) === index)
+    .slice(0, 20)
+}
+
+export function clampResultCount(value: unknown): number {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return BRAINSTORM_DEFAULT_RESULTS
+  return Math.min(
+    BRAINSTORM_MAX_RESULTS,
+    Math.max(BRAINSTORM_MIN_RESULTS, Math.round(parsed)),
+  )
+}
+
+export function normalizeBatchShape(value: unknown): BrainstormBatchShape {
+  return value === 'assortment' ? 'assortment' : 'focused'
+}
+
+const OUTPUT_DOMAIN_IDS = new Set(
+  BRAINSTORM_OUTPUT_DOMAINS.map((entry) => entry.id),
+)
+
+export function normalizeOutputDomain(
+  value: unknown,
+): BrainstormOutputDomainId {
+  const id = cleanText(value) as BrainstormOutputDomainId
+  return OUTPUT_DOMAIN_IDS.has(id) ? id : BRAINSTORM_DEFAULT_OUTPUT_DOMAIN
+}
+
+export const RETURN_TYPE_IDS = new Set<BrainstormReturnTypeId>(
+  BRAINSTORM_RETURN_TYPES.map((entry) => entry.id),
+)
+
+export function normalizeReturnTypeId(
+  value: unknown,
+): BrainstormReturnTypeId | null {
+  const id = cleanText(value) as BrainstormReturnTypeId
+  return RETURN_TYPE_IDS.has(id) ? id : null
+}
+
+export function normalizeReturnTypes(
+  value: unknown,
+): BrainstormReturnTypeRequest[] {
+  if (!Array.isArray(value)) return []
+
+  const result: BrainstormReturnTypeRequest[] = []
+  const seen = new Set<BrainstormReturnTypeId>()
+
+  for (const raw of value) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue
+    const record = raw as Record<string, unknown>
+    const id = normalizeReturnTypeId(record.id)
+    if (!id || seen.has(id)) continue
+
+    const parsedCount = Number(record.count)
+    const count =
+      Number.isInteger(parsedCount) && parsedCount > 0
+        ? Math.min(BRAINSTORM_MAX_RESULTS, parsedCount)
+        : undefined
+
+    result.push({ id, ...(count ? { count } : {}) })
+    seen.add(id)
+  }
+
+  return result
+}
+
+/**
+ * The store's own exact-duplicate sanity check on a generation API response,
+ * run client-side before candidates are created from it. Distinct from the
+ * server-side parser's near-duplicate (Jaccard-similarity) check in
+ * server/utils/brainstorm/brainstormParser.ts -- that one tolerates a
+ * reworded restatement; this one only catches an identical (modulo
+ * whitespace/case) response, which would indicate the provider echoed the
+ * same idea twice rather than a legitimately similar one.
+ */
+export function normalizeGeneratedCandidates(
+  value: unknown,
+  expectedCount: number,
+): BrainstormGeneratedCandidate[] | null {
+  if (!Array.isArray(value)) return null
+
+  const candidates: BrainstormGeneratedCandidate[] = []
+  const seen = new Set<string>()
+
+  for (const raw of value) {
+    if (!raw || typeof raw !== 'object') return null
+
+    const record = raw as Record<string, unknown>
+    const text = cleanMultilineText(record.text)
+    const title = cleanText(record.title)
+    const returnType = normalizeReturnTypeId(record.returnType)
+
+    if (!text) return null
+
+    const duplicateKey = text.toLocaleLowerCase().replace(/\s+/g, ' ').trim()
+    if (seen.has(duplicateKey)) return null
+    seen.add(duplicateKey)
+
+    candidates.push({
+      text,
+      ...(title ? { title } : {}),
+      ...(returnType ? { returnType } : {}),
+    })
+  }
+
+  return candidates.length === expectedCount ? candidates : null
+}
+
+export function normalizeSourceRef(value: unknown): BrainstormSourceRef | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+
+  const record = value as Record<string, unknown>
+  const modelType = cleanText(record.modelType)
+  const id = Number(record.id)
+  const slug = cleanText(record.slug)
+  const intent = cleanMultilineText(record.intent)
+
+  if (!modelType) return null
+
+  return {
+    modelType,
+    ...(Number.isInteger(id) && id > 0 ? { id } : {}),
+    ...(slug ? { slug } : {}),
+    ...(intent ? { intent } : {}),
+  }
+}
+
+export function normalizeRevision(
+  value: unknown,
+): BrainstormCandidateRevision | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+
+  const record = value as Record<string, unknown>
+  const text = cleanMultilineText(record.text)
+  const title = cleanText(record.title)
+  const createdAt = cleanText(record.createdAt)
+  const reason = record.reason
+  const returnType = normalizeReturnTypeId(record.returnType)
+
+  if (
+    !text ||
+    !createdAt ||
+    !['generated', 'edited', 'regenerated', 'branched', 'restored'].includes(
+      String(reason),
+    )
+  ) {
+    return null
+  }
+
+  return {
+    text,
+    createdAt,
+    reason: reason as BrainstormCandidateRevision['reason'],
+    ...(title ? { title } : {}),
+    returnType,
+  }
+}
+
+export function normalizeBranchOrigin(
+  value: unknown,
+): BrainstormBranchOrigin | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  const candidateId = cleanText(record.candidateId)
+  const revisionIndex = Number(record.revisionIndex)
+  const title = cleanText(record.title)
+  const text = cleanMultilineText(record.text)
+
+  if (
+    !candidateId ||
+    !text ||
+    !Number.isInteger(revisionIndex) ||
+    revisionIndex < 0
+  ) {
+    return null
+  }
+
+  return {
+    candidateId,
+    revisionIndex,
+    ...(title ? { title } : {}),
+    text,
+  }
+}
+
+export function normalizeStoredCandidate(
+  value: unknown,
+): BrainstormCandidate | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+
+  const record = value as Record<string, unknown>
+  const id = cleanText(record.id)
+  const batchId = cleanText(record.batchId)
+  const text = cleanMultilineText(record.text)
+  const title = cleanText(record.title)
+  const feedback = cleanMultilineText(record.feedback)
+  const parentId = cleanText(record.parentId)
+  const status = record.status
+
+  if (
+    !id ||
+    !batchId ||
+    !text ||
+    !['pending', 'kept', 'rejected'].includes(String(status))
+  ) {
+    return null
+  }
+
+  const revisions = Array.isArray(record.revisions)
+    ? record.revisions
+        .map((revision) => normalizeRevision(revision))
+        .filter((revision): revision is BrainstormCandidateRevision =>
+          Boolean(revision),
+        )
+    : []
+
+  const meta =
+    record.meta &&
+    typeof record.meta === 'object' &&
+    !Array.isArray(record.meta)
+      ? (record.meta as Record<string, unknown>)
+      : {}
+  const source = normalizeSourceRef(meta.source)
+  const returnType = normalizeReturnTypeId(meta.returnType)
+  const branchOrigin = normalizeBranchOrigin(meta.branchOrigin)
+
+  return {
+    id,
+    batchId,
+    title,
+    text,
+    status: status as BrainstormCandidateStatus,
+    feedback,
+    edited: record.edited === true,
+    parentId: parentId || null,
+    revisions:
+      revisions.length > 0
+        ? revisions
+        : [
+            {
+              title,
+              text,
+              createdAt: nowIso(),
+              reason: 'generated',
+              returnType,
+            },
+          ],
+    meta: {
+      source,
+      returnType,
+      branchOrigin,
+    },
+  }
+}
+
+export function normalizeStoredBatch(value: unknown): BrainstormBatch | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+
+  const record = value as Record<string, unknown>
+  const id = cleanText(record.id)
+  const createdAt = cleanText(record.createdAt)
+  const premise = cleanMultilineText(record.premise)
+  const candidateIds = Array.isArray(record.candidateIds)
+    ? record.candidateIds.map((value) => cleanText(value)).filter(Boolean)
+    : []
+
+  if (!id || !createdAt || !premise || candidateIds.length === 0) return null
+
+  const requestRecord =
+    record.request && typeof record.request === 'object'
+      ? (record.request as Record<string, unknown>)
+      : {}
+
+  const request: BrainstormGenerateRequest = {
+    premise: cleanMultilineText(requestRecord.premise) || premise,
+    count: clampResultCount(requestRecord.count),
+    constraints: cleanMultilineText(requestRecord.constraints),
+    examples: cleanExamples(requestRecord.examples),
+    mode: cleanText(requestRecord.mode) || 'freeform',
+    outputDomain: normalizeOutputDomain(requestRecord.outputDomain),
+    batchShape: normalizeBatchShape(requestRecord.batchShape),
+    returnTypes: normalizeReturnTypes(requestRecord.returnTypes),
+    source: normalizeSourceRef(requestRecord.source),
+  }
+
+  return { id, createdAt, premise, request, candidateIds }
+}
+
+export function classifyError(status: number | undefined): BrainstormErrorKind {
+  if (status === 401) return 'auth'
+  if (status === 402) return 'mana'
+  if (status === 408) return 'network'
+  if (status === 404 || status === 503) return 'server'
+  if (status && status >= 500) return 'provider'
+  return 'network'
+}
+
+/*
+ * Candidate state-transition logic. Each function mutates a single
+ * BrainstormCandidate and has no dependency on candidates.value or any other
+ * store-scoped ref, so the store's own action functions are thin
+ * findCandidate-then-delegate wrappers around these.
+ */
+
+export function applyCandidateStatus(
+  candidate: BrainstormCandidate,
+  status: BrainstormCandidateStatus,
+): void {
+  candidate.status = status
+  if (status === 'kept') candidate.feedback = ''
+}
+
+export function applyCandidateEdit(
+  candidate: BrainstormCandidate,
+  patch: { title?: string; text?: string },
+): boolean {
+  const nextTitle =
+    patch.title === undefined ? candidate.title : cleanText(patch.title)
+  const nextText =
+    patch.text === undefined ? candidate.text : cleanMultilineText(patch.text)
+
+  if (!nextText) return false
+  if (nextTitle === candidate.title && nextText === candidate.text) return true
+
+  candidate.title = nextTitle
+  candidate.text = nextText
+  candidate.edited = true
+  candidate.revisions.push({
+    ...(nextTitle ? { title: nextTitle } : {}),
+    text: nextText,
+    createdAt: nowIso(),
+    reason: 'edited',
+    returnType: candidate.meta.returnType ?? null,
+  })
+  return true
+}
+
+export function applyCandidateRevisionRestore(
+  candidate: BrainstormCandidate,
+  revisionIndex: number,
+): boolean {
+  if (!Number.isInteger(revisionIndex) || revisionIndex < 0) return false
+
+  const revision = candidate.revisions[revisionIndex]
+  if (!revision) return false
+
+  const nextTitle = cleanText(revision.title)
+  const nextText = cleanMultilineText(revision.text)
+  if (!nextText) return false
+
+  const nextReturnType =
+    normalizeReturnTypeId(revision.returnType) ??
+    candidate.meta.returnType ??
+    null
+  if (
+    nextTitle === candidate.title &&
+    nextText === candidate.text &&
+    nextReturnType === (candidate.meta.returnType ?? null)
+  ) {
+    return true
+  }
+
+  candidate.title = nextTitle
+  candidate.text = nextText
+  candidate.meta.returnType = nextReturnType
+  candidate.edited = true
+  candidate.revisions.push({
+    ...(nextTitle ? { title: nextTitle } : {}),
+    text: nextText,
+    createdAt: nowIso(),
+    reason: 'restored',
+    returnType: nextReturnType,
+  })
+  return true
+}
+
+export function applyCandidateRegeneration(
+  candidate: BrainstormCandidate,
+  generated: BrainstormGeneratedCandidate,
+): boolean {
+  const title = cleanText(generated.title)
+  const text = cleanMultilineText(generated.text)
+  if (!text) return false
+
+  const returnType =
+    normalizeReturnTypeId(generated.returnType) ??
+    candidate.meta.returnType ??
+    null
+  candidate.title = title
+  candidate.text = text
+  candidate.status = 'pending'
+  candidate.feedback = ''
+  candidate.edited = false
+  candidate.meta.returnType = returnType
+  candidate.revisions.push({
+    ...(title ? { title } : {}),
+    text,
+    createdAt: nowIso(),
+    reason: 'regenerated',
+    returnType,
+  })
+  return true
+}
+
+/** The exact parent-revision lineage a branch's child candidate is stamped with. */
+export function computeBranchOrigin(
+  parent: BrainstormCandidate,
+): BrainstormBranchOrigin {
+  return {
+    candidateId: parent.id,
+    revisionIndex: Math.max(0, parent.revisions.length - 1),
+    ...(parent.title ? { title: parent.title } : {}),
+    text: parent.text,
+  }
+}

--- a/utils/scripts/verifyBrainstormCandidateLifecycle.test.ts
+++ b/utils/scripts/verifyBrainstormCandidateLifecycle.test.ts
@@ -1,0 +1,585 @@
+// /utils/scripts/verifyBrainstormCandidateLifecycle.test.ts
+//
+// conductor brainstorm/t-021: deterministic fixtures around candidate state
+// transitions, regeneration lineage, and save/reopen restore -- the areas
+// this project's existing Brainstorm coverage left as source-text shape
+// checks only (verifyBrainstormStoreContract.mjs's requireText assertions
+// confirm a string like "reason: 'regenerated'" appears somewhere in the
+// file; it never actually calls the code and checks what happens).
+//
+// stores/brainstormStore.ts's candidate-transition logic (setCandidateStatus,
+// editCandidate, restoreCandidateRevision, replaceCandidateWithGenerated,
+// appendBranchCandidate's branch-origin stamp) previously lived only inside
+// the store's Pinia setup closure, coupled to candidates.value -- and
+// brainstormStore.ts itself cannot be imported from a plain `tsx` process:
+// it pulls in useServerStore -> userStore -> achievementStore, and
+// achievementStore.ts calls the Vite-only `import.meta.glob(...)` at module
+// load time. This task moved the pure normalizers and the candidate
+// mutation logic (applyCandidateStatus/applyCandidateEdit/
+// applyCandidateRevisionRestore/applyCandidateRegeneration/
+// computeBranchOrigin) into stores/helpers/brainstormCandidateLifecycle.ts,
+// which has no such dependency -- the same split already used for
+// brainstormSourceAdapterKit.ts/brainstormSourceContextKit.ts, and for the
+// same reason. brainstormStore.ts imports them back and its own action
+// functions are now thin findCandidate-then-delegate wrappers; that wiring
+// is still covered by verifyBrainstormStoreContract.mjs. This file is what
+// actually calls the logic and checks what happens -- same "test real
+// logic, not shape" standard verifyBrainstormGeneration.ts already holds
+// the parser to.
+//
+// Save/reopen is split two ways in this codebase: the SERVER-side
+// persistence round-trip (brainstormSessionData/normalizeBrainstormSession
+// SaveRequest/storedBrainstormSession) already has deep coverage in
+// verifyBrainstormPersistence.ts. The CLIENT-side restore path -- what
+// normalizeStoredCandidate/normalizeStoredBatch turn a GET/localStorage
+// payload back into -- had none; that gap is closed below.
+import assert from 'node:assert/strict'
+import {
+  applyCandidateEdit,
+  applyCandidateRegeneration,
+  applyCandidateRevisionRestore,
+  applyCandidateStatus,
+  classifyError,
+  computeBranchOrigin,
+  normalizeBranchOrigin,
+  normalizeGeneratedCandidates,
+  normalizeRevision,
+  normalizeStoredBatch,
+  normalizeStoredCandidate,
+} from '../../stores/helpers/brainstormCandidateLifecycle'
+import type { BrainstormCandidate } from '../../types/brainstorm'
+
+function baseCandidate(
+  overrides: Partial<BrainstormCandidate> = {},
+): BrainstormCandidate {
+  return {
+    id: 'candidate-1',
+    batchId: 'batch-1',
+    title: 'Glass Choir',
+    text: 'A choir performs with sugar-glass mouths that shatter on the high notes.',
+    status: 'pending',
+    feedback: '',
+    edited: false,
+    parentId: null,
+    revisions: [
+      {
+        title: 'Glass Choir',
+        text: 'A choir performs with sugar-glass mouths that shatter on the high notes.',
+        createdAt: '2026-08-10T12:00:00.000Z',
+        reason: 'generated',
+        returnType: null,
+      },
+    ],
+    meta: { source: null, returnType: null, branchOrigin: null },
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// applyCandidateStatus -- keep/reject/reset transitions
+// ---------------------------------------------------------------------------
+
+{
+  const candidate = baseCandidate({ feedback: 'too safe' })
+  applyCandidateStatus(candidate, 'kept')
+  assert.equal(candidate.status, 'kept')
+  assert.equal(
+    candidate.feedback,
+    '',
+    'keeping a candidate must clear stale reject feedback',
+  )
+}
+
+{
+  const candidate = baseCandidate({ feedback: 'too safe' })
+  applyCandidateStatus(candidate, 'rejected')
+  assert.equal(candidate.status, 'rejected')
+  assert.equal(
+    candidate.feedback,
+    'too safe',
+    'rejecting must NOT clear feedback -- it is the reason the reviewer is recording',
+  )
+}
+
+{
+  const candidate = baseCandidate({ status: 'rejected', feedback: 'too safe' })
+  applyCandidateStatus(candidate, 'pending')
+  assert.equal(candidate.status, 'pending')
+  assert.equal(
+    candidate.feedback,
+    'too safe',
+    'resetting to pending must preserve feedback -- only kept clears it',
+  )
+}
+
+// ---------------------------------------------------------------------------
+// applyCandidateEdit -- revision push on real change, no-op skip, rejection
+// ---------------------------------------------------------------------------
+
+{
+  const candidate = baseCandidate()
+  const ok = applyCandidateEdit(candidate, {
+    text: 'A choir of glass mouths shatters on cue.',
+  })
+  assert.equal(ok, true)
+  assert.equal(candidate.text, 'A choir of glass mouths shatters on cue.')
+  assert.equal(
+    candidate.title,
+    'Glass Choir',
+    'an undefined title in the patch must leave the existing title alone',
+  )
+  assert.equal(candidate.edited, true)
+  assert.equal(candidate.revisions.length, 2)
+  assert.equal(candidate.revisions[1]?.reason, 'edited')
+  assert.equal(
+    candidate.revisions[1]?.text,
+    'A choir of glass mouths shatters on cue.',
+  )
+}
+
+{
+  // Re-submitting the exact same title/text (e.g. a form re-save with no
+  // actual change) must not fabricate a revision entry.
+  const candidate = baseCandidate()
+  const ok = applyCandidateEdit(candidate, {
+    title: 'Glass Choir',
+    text: candidate.text,
+  })
+  assert.equal(ok, true)
+  assert.equal(
+    candidate.revisions.length,
+    1,
+    'a no-op edit must not push a new revision',
+  )
+  assert.equal(candidate.edited, false)
+}
+
+{
+  const candidate = baseCandidate()
+  const ok = applyCandidateEdit(candidate, { text: '   ' })
+  assert.equal(ok, false, 'blanking the text entirely must be rejected')
+  assert.equal(
+    candidate.text,
+    baseCandidate().text,
+    'a rejected edit must leave the candidate untouched',
+  )
+  assert.equal(candidate.revisions.length, 1)
+}
+
+// ---------------------------------------------------------------------------
+// applyCandidateRevisionRestore -- exact restoration, no-op skip, bad index
+// ---------------------------------------------------------------------------
+
+{
+  const candidate = baseCandidate({
+    title: 'Current Title',
+    text: 'Current text after an edit.',
+    meta: { source: null, returnType: 'dark-humor', branchOrigin: null },
+    revisions: [
+      {
+        title: 'Glass Choir',
+        text: 'A choir performs with sugar-glass mouths that shatter on the high notes.',
+        createdAt: '2026-08-10T12:00:00.000Z',
+        reason: 'generated',
+        returnType: 'pun',
+      },
+      {
+        title: 'Current Title',
+        text: 'Current text after an edit.',
+        createdAt: '2026-08-10T12:05:00.000Z',
+        reason: 'edited',
+        returnType: 'dark-humor',
+      },
+    ],
+  })
+
+  const ok = applyCandidateRevisionRestore(candidate, 0)
+  assert.equal(ok, true)
+  assert.equal(candidate.title, 'Glass Choir')
+  assert.equal(
+    candidate.text,
+    'A choir performs with sugar-glass mouths that shatter on the high notes.',
+  )
+  assert.equal(
+    candidate.meta.returnType,
+    'pun',
+    'restoring a revision must restore its returnType too',
+  )
+  assert.equal(candidate.edited, true)
+  assert.equal(
+    candidate.revisions.length,
+    3,
+    'a restore is itself recorded as a new revision, not a rewind',
+  )
+  assert.equal(candidate.revisions[2]?.reason, 'restored')
+  assert.equal(candidate.revisions[2]?.text, candidate.text)
+}
+
+{
+  // Restoring the revision that already matches current state must not
+  // fabricate a duplicate "restored" entry.
+  const candidate = baseCandidate()
+  const before = candidate.revisions.length
+  const ok = applyCandidateRevisionRestore(candidate, 0)
+  assert.equal(ok, true)
+  assert.equal(
+    candidate.revisions.length,
+    before,
+    'restoring the already-current revision must be a no-op',
+  )
+}
+
+for (const badIndex of [-1, 1, 99, 1.5]) {
+  const candidate = baseCandidate()
+  const ok = applyCandidateRevisionRestore(candidate, badIndex)
+  assert.equal(ok, false, `revisionIndex ${badIndex} must be rejected`)
+  assert.equal(candidate.revisions.length, 1)
+}
+
+// ---------------------------------------------------------------------------
+// applyCandidateRegeneration -- clears review state, records lineage
+// ---------------------------------------------------------------------------
+
+{
+  const candidate = baseCandidate({
+    status: 'kept',
+    feedback: 'liked it but try darker',
+    edited: true,
+  })
+  const ok = applyCandidateRegeneration(candidate, {
+    title: 'Borrowed Shadows',
+    text: 'People rent better shadows for important social occasions.',
+    returnType: 'dry-observation',
+  })
+  assert.equal(ok, true)
+  assert.equal(candidate.title, 'Borrowed Shadows')
+  assert.equal(
+    candidate.text,
+    'People rent better shadows for important social occasions.',
+  )
+  assert.equal(
+    candidate.status,
+    'pending',
+    'regenerating must reopen the candidate for review',
+  )
+  assert.equal(
+    candidate.feedback,
+    '',
+    'regenerating must clear the feedback that prompted it',
+  )
+  assert.equal(
+    candidate.edited,
+    false,
+    'a freshly regenerated candidate is not a hand edit',
+  )
+  assert.equal(candidate.meta.returnType, 'dry-observation')
+  assert.equal(candidate.revisions.length, 2)
+  assert.equal(candidate.revisions[1]?.reason, 'regenerated')
+}
+
+{
+  const candidate = baseCandidate()
+  const ok = applyCandidateRegeneration(candidate, { text: '' })
+  assert.equal(ok, false, 'an empty regenerated text must be rejected')
+  assert.equal(candidate.revisions.length, 1)
+}
+
+{
+  // A regeneration response with no returnType must fall back to the
+  // candidate's existing one rather than clearing it.
+  const candidate = baseCandidate({
+    meta: { source: null, returnType: 'inversion', branchOrigin: null },
+  })
+  applyCandidateRegeneration(candidate, {
+    text: 'A fresh mechanism with no declared lens.',
+  })
+  assert.equal(candidate.meta.returnType, 'inversion')
+}
+
+// ---------------------------------------------------------------------------
+// computeBranchOrigin -- exact parent-revision lineage stamp
+// ---------------------------------------------------------------------------
+
+{
+  const parent = baseCandidate({
+    id: 'parent-1',
+    title: 'Useful Idea',
+    text: 'A character is slowly laminated during an argument.',
+    revisions: [
+      baseCandidate().revisions[0]!,
+      { text: 'edit 1', createdAt: 't1', reason: 'edited', returnType: null },
+      { text: 'edit 2', createdAt: 't2', reason: 'edited', returnType: null },
+    ],
+  })
+  const origin = computeBranchOrigin(parent)
+  assert.deepEqual(origin, {
+    candidateId: 'parent-1',
+    revisionIndex: 2,
+    title: 'Useful Idea',
+    text: 'A character is slowly laminated during an argument.',
+  })
+}
+
+{
+  // A single-revision parent must clamp to index 0, never negative.
+  const parent = baseCandidate({ id: 'parent-2' })
+  const origin = computeBranchOrigin(parent)
+  assert.equal(origin.revisionIndex, 0)
+}
+
+{
+  const parent = baseCandidate({ id: 'parent-3', title: '' })
+  const origin = computeBranchOrigin(parent)
+  assert.ok(
+    !('title' in origin),
+    'an empty parent title must not appear as an empty-string key',
+  )
+}
+
+// ---------------------------------------------------------------------------
+// classifyError -- status -> error-kind mapping
+// ---------------------------------------------------------------------------
+
+assert.equal(classifyError(401), 'auth')
+assert.equal(classifyError(402), 'mana')
+assert.equal(classifyError(408), 'network')
+assert.equal(classifyError(404), 'server')
+assert.equal(classifyError(503), 'server')
+assert.equal(classifyError(500), 'provider')
+assert.equal(classifyError(529), 'provider')
+assert.equal(
+  classifyError(undefined),
+  'network',
+  'no status at all falls back to network, not provider',
+)
+assert.equal(classifyError(0), 'network')
+
+// ---------------------------------------------------------------------------
+// normalizeGeneratedCandidates -- the STORE's own exact-duplicate client-side
+// sanity check on a generation response, distinct from the server-side
+// parser's near-duplicate (Jaccard) check already covered in
+// verifyBrainstormGeneration.ts. This one had zero prior coverage.
+// ---------------------------------------------------------------------------
+
+{
+  const result = normalizeGeneratedCandidates(
+    [
+      { title: 'A', text: 'First distinct idea.' },
+      { title: 'B', text: 'Second distinct idea.' },
+    ],
+    2,
+  )
+  assert.equal(result?.length, 2)
+}
+
+assert.equal(
+  normalizeGeneratedCandidates(
+    [{ text: 'Same idea.' }, { text: '  same   idea.  ' }],
+    2,
+  ),
+  null,
+  'whitespace/case-normalized exact duplicates must be rejected',
+)
+
+assert.equal(
+  normalizeGeneratedCandidates([{ text: 'Only one.' }], 2),
+  null,
+  'a short response must be rejected even if every entry is otherwise valid',
+)
+
+assert.equal(
+  normalizeGeneratedCandidates('not-an-array', 1),
+  null,
+  'a non-array payload must be rejected outright',
+)
+
+assert.equal(
+  normalizeGeneratedCandidates([{ title: 'No text field' }], 1),
+  null,
+  'an entry with no usable text must reject the whole batch',
+)
+
+// ---------------------------------------------------------------------------
+// Client-side save/reopen restore -- normalizeStoredCandidate /
+// normalizeStoredBatch round-tripping a realistic session payload, the way
+// openSavedSession()/restoreSession() consume a GET or localStorage read.
+// ---------------------------------------------------------------------------
+
+{
+  const stored = {
+    id: 'candidate-9',
+    batchId: 'batch-9',
+    title: 'Compliance Vanilla',
+    text: 'Vanilla served with a forty-page terms-of-service agreement nobody reads.',
+    status: 'kept',
+    feedback: '',
+    edited: true,
+    parentId: 'candidate-1',
+    revisions: [
+      {
+        title: 'Compliance Vanilla',
+        text: 'Vanilla served with paperwork.',
+        createdAt: '2026-08-10T12:00:00.000Z',
+        reason: 'branched',
+        returnType: 'dry-observation',
+      },
+      {
+        title: 'Compliance Vanilla',
+        text: 'Vanilla served with a forty-page terms-of-service agreement nobody reads.',
+        createdAt: '2026-08-10T12:05:00.000Z',
+        reason: 'edited',
+        returnType: 'dry-observation',
+      },
+    ],
+    meta: {
+      source: {
+        modelType: 'Character',
+        id: 42,
+        intent: 'art prompt variations',
+      },
+      returnType: 'dry-observation',
+      branchOrigin: {
+        candidateId: 'candidate-1',
+        revisionIndex: 0,
+        title: 'Glass Choir',
+        text: 'A choir performs with sugar-glass mouths that shatter on the high notes.',
+      },
+    },
+  }
+
+  // JSON round trip -- exactly what a GET response or a JSON.parse(localStorage...) read is.
+  const restored = normalizeStoredCandidate(JSON.parse(JSON.stringify(stored)))
+  assert.ok(restored)
+  assert.equal(restored?.id, 'candidate-9')
+  assert.equal(restored?.parentId, 'candidate-1')
+  assert.equal(restored?.status, 'kept')
+  assert.equal(restored?.revisions.length, 2)
+  assert.equal(restored?.revisions[0]?.reason, 'branched')
+  assert.equal(restored?.revisions[1]?.reason, 'edited')
+  assert.equal(restored?.meta.source?.modelType, 'Character')
+  assert.equal(restored?.meta.source?.id, 42)
+  assert.equal(restored?.meta.branchOrigin?.candidateId, 'candidate-1')
+  assert.equal(restored?.meta.branchOrigin?.revisionIndex, 0)
+}
+
+{
+  // A candidate with no stored revisions (older/malformed payload) must
+  // synthesize one from its current title/text/status rather than restoring
+  // with an empty lineage.
+  const restored = normalizeStoredCandidate({
+    id: 'candidate-10',
+    batchId: 'batch-9',
+    title: 'Bare',
+    text: 'No history was ever recorded for this one.',
+    status: 'pending',
+    revisions: [],
+  })
+  assert.ok(restored)
+  assert.equal(restored?.revisions.length, 1)
+  assert.equal(restored?.revisions[0]?.reason, 'generated')
+  assert.equal(
+    restored?.revisions[0]?.text,
+    'No history was ever recorded for this one.',
+  )
+}
+
+for (const bad of [
+  { id: '', batchId: 'b', text: 't', status: 'pending' },
+  { id: 'c', batchId: '', text: 't', status: 'pending' },
+  { id: 'c', batchId: 'b', text: '', status: 'pending' },
+  { id: 'c', batchId: 'b', text: 't', status: 'archived' },
+  null,
+  'a string',
+]) {
+  assert.equal(
+    normalizeStoredCandidate(bad),
+    null,
+    `malformed candidate payload must be rejected: ${JSON.stringify(bad)}`,
+  )
+}
+
+{
+  const batch = normalizeStoredBatch({
+    id: 'batch-9',
+    createdAt: '2026-08-10T12:00:00.000Z',
+    premise: 'Invent terrible ice cream flavors',
+    candidateIds: ['candidate-9', 'candidate-10'],
+    request: {
+      premise: 'Invent terrible ice cream flavors',
+      count: 4,
+      mode: 'darker-funnier',
+      outputDomain: 'art-prompts',
+      batchShape: 'assortment',
+      returnTypes: [{ id: 'dark-humor', count: 2 }],
+    },
+  })
+  assert.ok(batch)
+  assert.equal(batch?.candidateIds.length, 2)
+  assert.equal(batch?.request.mode, 'darker-funnier')
+  assert.equal(batch?.request.outputDomain, 'art-prompts')
+  assert.equal(batch?.request.batchShape, 'assortment')
+  assert.equal(batch?.request.returnTypes?.[0]?.id, 'dark-humor')
+}
+
+assert.equal(
+  normalizeStoredBatch({
+    id: 'batch-empty',
+    createdAt: '2026-08-10T12:00:00.000Z',
+    premise: 'Invent something',
+    candidateIds: [],
+  }),
+  null,
+  'a batch with no surviving candidate ids must be rejected, not restored empty',
+)
+
+{
+  // A malformed/missing request object must fall back to safe defaults
+  // rather than restoring undefined into the generation composer.
+  const batch = normalizeStoredBatch({
+    id: 'batch-legacy',
+    createdAt: '2026-08-10T12:00:00.000Z',
+    premise: 'Invent something',
+    candidateIds: ['candidate-1'],
+  })
+  assert.ok(batch)
+  assert.equal(batch?.request.mode, 'freeform')
+  assert.equal(batch?.request.outputDomain, 'ideas')
+  assert.equal(batch?.request.batchShape, 'focused')
+  assert.deepEqual(batch?.request.returnTypes, [])
+}
+
+// ---------------------------------------------------------------------------
+// normalizeRevision / normalizeBranchOrigin -- invalid-input rejection
+// ---------------------------------------------------------------------------
+
+assert.equal(
+  normalizeRevision({
+    text: 'ok',
+    createdAt: 't',
+    reason: 'not-a-real-reason',
+  }),
+  null,
+  'an unrecognized revision reason must be rejected',
+)
+assert.equal(
+  normalizeRevision({ text: '', createdAt: 't', reason: 'edited' }),
+  null,
+  'a revision with no text must be rejected',
+)
+assert.ok(normalizeRevision({ text: 'ok', createdAt: 't', reason: 'restored' }))
+
+assert.equal(
+  normalizeBranchOrigin({ candidateId: 'c', revisionIndex: -1, text: 't' }),
+  null,
+  'a negative revisionIndex must be rejected',
+)
+assert.equal(
+  normalizeBranchOrigin({ candidateId: '', revisionIndex: 0, text: 't' }),
+  null,
+  'a branch origin with no candidateId must be rejected',
+)
+assert.ok(
+  normalizeBranchOrigin({ candidateId: 'c', revisionIndex: 0, text: 't' }),
+)
+
+console.log('Brainstorm candidate lifecycle contract passed.')

--- a/utils/scripts/verifyBrainstormStoreContract.mjs
+++ b/utils/scripts/verifyBrainstormStoreContract.mjs
@@ -4,9 +4,14 @@ import { resolve } from 'node:path'
 const root = process.cwd()
 const storePath = resolve(root, 'stores/brainstormStore.ts')
 const typesPath = resolve(root, 'types/brainstorm.ts')
+const lifecyclePath = resolve(
+  root,
+  'stores/helpers/brainstormCandidateLifecycle.ts',
+)
 
 const store = readFileSync(storePath, 'utf8')
 const types = readFileSync(typesPath, 'utf8')
+const lifecycle = readFileSync(lifecyclePath, 'utf8')
 
 const failures = []
 
@@ -21,33 +26,140 @@ function forbidText(source, needle, label) {
 requireText(store, "defineStore('brainstormStore'", 'dedicated Pinia owner')
 requireText(store, "'/api/brainstorm/generate'", 'canonical generation route')
 requireText(store, 'useServerStore()', 'shared server-store reuse')
-requireText(store, 'serverStore.activeTextServer', 'active text server selection')
-requireText(store, 'performFetch<BrainstormGenerateData>', 'standard generation API client')
-requireText(store, 'localStorage.setItem(STORAGE_KEY', 'store-owned local draft persistence')
+requireText(
+  store,
+  'serverStore.activeTextServer',
+  'active text server selection',
+)
+requireText(
+  store,
+  'performFetch<BrainstormGenerateData>',
+  'standard generation API client',
+)
+requireText(
+  store,
+  'localStorage.setItem(STORAGE_KEY',
+  'store-owned local draft persistence',
+)
 requireText(store, 'SAVED_LINK_STORAGE_KEY', 'durable session linkage')
-requireText(store, 'localStorage.setItem(\n          SAVED_LINK_STORAGE_KEY', 'store-owned durable linkage persistence')
-requireText(store, "'/api/brainstorm/sessions'", 'durable session collection route')
-requireText(store, '`/api/brainstorm/sessions/${id}`', 'durable session item route')
+requireText(
+  store,
+  'localStorage.setItem(\n          SAVED_LINK_STORAGE_KEY',
+  'store-owned durable linkage persistence',
+)
+requireText(
+  store,
+  "'/api/brainstorm/sessions'",
+  'durable session collection route',
+)
+requireText(
+  store,
+  '`/api/brainstorm/sessions/${id}`',
+  'durable session item route',
+)
 requireText(store, 'loadSavedSessions()', 'saved-session listing action')
 requireText(store, 'saveCurrentSession()', 'saved-session create/update action')
-requireText(store, 'openSavedSession(id: number)', 'saved-session reopen action')
+requireText(
+  store,
+  'openSavedSession(id: number)',
+  'saved-session reopen action',
+)
 requireText(store, 'detachSavedSession()', 'save-as-new action')
-requireText(store, 'restoreSession(JSON.stringify(saved.snapshot))', 'shared safe restore contract')
-requireText(store, 'normalizeGeneratedCandidates(', 'structured candidate validation')
+requireText(
+  store,
+  'restoreSession(JSON.stringify(saved.snapshot))',
+  'shared safe restore contract',
+)
+requireText(
+  store,
+  'normalizeGeneratedCandidates(',
+  'structured candidate validation',
+)
 requireText(store, 'replaceCandidateWithGenerated(', 'slot regeneration')
 requireText(store, 'appendBranchCandidate(', 'candidate branching')
-requireText(store, 'restoreCandidateRevision(', 'non-destructive revision restore')
-requireText(store, "reason: 'edited'", 'edit revision history')
-requireText(store, "reason: 'regenerated'", 'regeneration revision history')
-requireText(store, "reason: 'restored'", 'restore revision history')
+requireText(
+  store,
+  'restoreCandidateRevision(',
+  'non-destructive revision restore',
+)
 requireText(store, "'branched'", 'branch revision history')
-requireText(store, 'branchOrigin = normalizeBranchOrigin', 'restored branch-origin snapshots')
-requireText(store, 'child.meta.branchOrigin = {', 'branch provenance snapshot')
-requireText(store, 'revisionIndex: Math.max(0, parent.revisions.length - 1)', 'exact parent revision lineage')
-requireText(store, 'const batches = ref<BrainstormBatch[]>([])', 'batch history')
-requireText(store, 'const activeBatchId = ref<string | null>(null)', 'active batch identity')
-requireText(store, 'const savedSessionId = ref<number | null>(null)', 'durable session identity')
-requireText(store, 'const savedSessions = ref<BrainstormSavedSessionSummary[]>([])', 'saved-session summaries')
+requireText(
+  store,
+  'child.meta.branchOrigin = computeBranchOrigin(parent)',
+  'branch provenance snapshot',
+)
+requireText(
+  store,
+  'const batches = ref<BrainstormBatch[]>([])',
+  'batch history',
+)
+requireText(
+  store,
+  'const activeBatchId = ref<string | null>(null)',
+  'active batch identity',
+)
+requireText(
+  store,
+  'const savedSessionId = ref<number | null>(null)',
+  'durable session identity',
+)
+requireText(
+  store,
+  'const savedSessions = ref<BrainstormSavedSessionSummary[]>([])',
+  'saved-session summaries',
+)
+
+// conductor brainstorm/t-021: the pure normalizers and candidate
+// state-transition logic moved out of this file into
+// stores/helpers/brainstormCandidateLifecycle.ts (see that file's header
+// comment for why -- brainstormStore.ts itself cannot be imported from a
+// plain `tsx` process). The store must still visibly source its behavior
+// from there, and the moved logic's own shape is checked against the file
+// it actually lives in now; real behavioral coverage of what it DOES lives
+// in verifyBrainstormCandidateLifecycle.test.ts, not here.
+requireText(
+  store,
+  "} from '@/stores/helpers/brainstormCandidateLifecycle'",
+  'candidate lifecycle logic sourced from the testable helper module',
+)
+requireText(lifecycle, "reason: 'edited'", 'edit revision history')
+requireText(lifecycle, "reason: 'regenerated'", 'regeneration revision history')
+requireText(lifecycle, "reason: 'restored'", 'restore revision history')
+requireText(
+  lifecycle,
+  'branchOrigin = normalizeBranchOrigin',
+  'restored branch-origin snapshots',
+)
+requireText(
+  lifecycle,
+  'revisionIndex: Math.max(0, parent.revisions.length - 1)',
+  'exact parent revision lineage',
+)
+requireText(
+  lifecycle,
+  'export function computeBranchOrigin(',
+  'branch-lineage logic testable without a live store',
+)
+requireText(
+  lifecycle,
+  'export function applyCandidateStatus(',
+  'candidate status transitions testable without a live store',
+)
+requireText(
+  lifecycle,
+  'export function applyCandidateEdit(',
+  'candidate edit transitions testable without a live store',
+)
+requireText(
+  lifecycle,
+  'export function applyCandidateRevisionRestore(',
+  'revision-restore lineage testable without a live store',
+)
+requireText(
+  lifecycle,
+  'export function applyCandidateRegeneration(',
+  'regeneration lineage testable without a live store',
+)
 
 forbidText(store, '/api/botcafe/brainstorm', 'legacy Dream endpoint')
 forbidText(store, 'useDreamStore', 'Dream state ownership')
@@ -61,14 +173,30 @@ requireText(types, 'BrainstormCandidateRevision', 'revision contract')
 requireText(types, "| 'restored'", 'restored revision reason')
 requireText(types, 'BrainstormBranchOrigin', 'branch origin contract')
 requireText(types, 'revisionIndex: number', 'branch revision identity')
-requireText(types, 'branchOrigin?: BrainstormBranchOrigin | null', 'candidate branch metadata')
+requireText(
+  types,
+  'branchOrigin?: BrainstormBranchOrigin | null',
+  'candidate branch metadata',
+)
 requireText(types, 'batchId: string', 'candidate batch membership')
 requireText(types, 'parentId?: string | null', 'candidate lineage')
-requireText(types, 'referenceCandidate?: BrainstormReferenceCandidate | null', 'regeneration context')
+requireText(
+  types,
+  'referenceCandidate?: BrainstormReferenceCandidate | null',
+  'regeneration context',
+)
 requireText(types, 'BrainstormServerSnapshot', 'safe server snapshot')
 requireText(types, 'BrainstormSessionSnapshot', 'ephemeral session contract')
-requireText(types, 'BrainstormSavedSessionSummary', 'saved-session summary contract')
-requireText(types, 'BrainstormSessionSaveRequest', 'saved-session write contract')
+requireText(
+  types,
+  'BrainstormSavedSessionSummary',
+  'saved-session summary contract',
+)
+requireText(
+  types,
+  'BrainstormSessionSaveRequest',
+  'saved-session write contract',
+)
 requireText(types, 'BrainstormPersistenceState', 'persistence state contract')
 requireText(types, 'BRAINSTORM_MAX_RESULTS = 24', 'result-count ceiling')
 


### PR DESCRIPTION
## What

Closes conductor `brainstorm/t-021`: "Add Brainstorm-specific tests, telemetry-free quality fixtures, and duplicate checks." Adds real deterministic fixtures for the areas the project's existing Brainstorm coverage left as source-text shape checks only — candidate state transitions, regeneration lineage, and client-side save/reopen restore.

## Why a refactor came with it

`stores/brainstormStore.ts`'s candidate-transition logic (`setCandidateStatus`, `editCandidate`, `restoreCandidateRevision`, `replaceCandidateWithGenerated`, `appendBranchCandidate`'s branch-origin stamp) and its pure normalizers previously lived only inside the store's Pinia setup closure / module scope — but the file itself can't be imported from a plain `tsx` process: it pulls in `useServerStore -> userStore -> achievementStore`, and `achievementStore.ts` calls the Vite-only `import.meta.glob(...)` at module load time.

This PR splits the pure logic into `stores/helpers/brainstormCandidateLifecycle.ts` — the same split already used for `brainstormSourceAdapterKit.ts`/`brainstormSourceContextKit.ts`, and for the same reason (see that file's own header comment). `brainstormStore.ts` imports everything back; its own action functions are now thin `findCandidate`-then-delegate wrappers. **Behavior is unchanged** — this is a pure extraction, not a logic change.

## New test coverage

`utils/scripts/verifyBrainstormCandidateLifecycle.test.ts` — real function calls with before/after assertions, not grep:

- **Candidate state transitions**: keep clears feedback, reject/reset preserve it.
- **Edit lineage**: revision pushed on real change, no-op skipped, empty-text rejected.
- **Revision restore**: exact field restoration (including `returnType`), no-op skip, invalid-index rejection.
- **Regeneration lineage**: status/feedback/edited reset on regenerate, `returnType` fallback preserved.
- **Branch-origin computation**: exact parent revision index/title/text stamp.
- **Error classification**: full status-code mapping.
- **The store's own exact-duplicate check** (`normalizeGeneratedCandidates`, distinct from the server-side parser's near-duplicate check) — previously untested entirely.
- **Client-side save/reopen restore** (`normalizeStoredCandidate`/`normalizeStoredBatch`) round-tripping a realistic session payload through JSON — the client half of save/reopen; the server half already has deep coverage in `verifyBrainstormPersistence.ts`.

`verifyBrainstormStoreContract.mjs`'s internal-detail assertions (e.g. `"reason: 'edited'"`) now check the new helper file, since that's where the logic lives; its call-site/wiring checks stay against the store. Wired the new test into `brainstorm-store-contract.yml`.

## Verification

- `npm run test:brainstorm-candidate-lifecycle` (new) — passes
- `node utils/scripts/verifyBrainstormStoreContract.mjs` — passes
- `npx tsx utils/scripts/verifyBrainstormGeneration.ts` — passes (no regression)
- `npx tsx utils/scripts/verifyBrainstormPersistence.ts` — passes (no regression)
- `npx tsx utils/scripts/verifyBrainstormSourceContext.ts` — passes (no regression)
- `npx tsx utils/scripts/verifyBrainstormSourceAdapters.test.ts` — passes (no regression)
- `node utils/scripts/verifyBrainstormWorkbench.mjs` / `verifyBrainstormObjectEntryLinks.mjs` — pass (no regression)
- `npm run test` (repo-wide `vue-tsc --noEmit`) — clean
- `eslint` on all touched files — clean
- `prettier --check` on all touched files — clean
- `git status --porcelain` shows exactly the 6 intended files

## Flags for reviewer

Object-context privacy and route-behavior/parser-validation/duplicate-suppression coverage were already solid (`verifyBrainstormSourceContext.ts`, `verifyBrainstormGeneration.ts`) — deliberately not duplicated here; this PR targets the gap.

---
_Generated by [Claude Code](https://claude.ai/code/session_011azHbLCKEqpdJjoAPURMuA)_