### PR TITLE
fix(storybook): add the missing Location "start a story" CTA (storybook/t-010 cycle 20)

### DIFF
--- a/.github/workflows/storybook-location-deep-link-contract.yml
+++ b/.github/workflows/storybook-location-deep-link-contract.yml
@@ -1,0 +1,30 @@
+name: Storybook Location Deep Link Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: storybook-location-deep-link-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Storybook location deep link contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify Storybook location deep link guard
+        run: node utils/scripts/verifyStorybookLocationDeepLinkGuard.mjs

--- a/components/dreams/dream-narration.vue
+++ b/components/dreams/dream-narration.vue
@@ -16,6 +16,17 @@
 
         <div class="flex shrink-0 flex-wrap gap-2">
           <button
+            v-if="locationStorySlug"
+            type="button"
+            class="btn btn-primary btn-sm rounded-xl"
+            title="Start a Storybook story seeded with this Location"
+            @click="startStoryWithLocation"
+          >
+            <Icon name="kind-icon:book-open" class="h-4 w-4" />
+            <span class="hidden sm:inline">Start a story with this</span>
+          </button>
+
+          <button
             type="button"
             class="btn btn-ghost btn-sm rounded-xl"
             @click="backToGallery"
@@ -179,6 +190,29 @@ const dreamTitle = computed(
   () => dreamStore.selectedDream?.title || 'No Dream Selected',
 )
 const selectedSummary = computed(() => dreamStore.selectedDreamSummary)
+
+/**
+ * Storybook's seedFromQuery() already reads ?location= into
+ * draft.locationSlug (components/conductor/storybook-page.vue), but unlike
+ * Character, Reward, Scenario and Facet -- each a first-class model with its
+ * own detail surface and "Start a story with this" CTA -- a LOCATION Dream
+ * has no dedicated component of its own. Its only detail surface is this
+ * generic dream-narration workspace, so that is where the matching CTA has
+ * to live. Gated to dreamType === 'LOCATION' so every other Dream type
+ * (ART, BRAINSTORM, PITCH, WISH, ...) -- none of which Storybook's
+ * seedFromQuery() has a query key for -- keeps rendering none of this.
+ */
+const locationStorySlug = computed(() => {
+  const dream = dreamStore.selectedDream
+  if (!dream || dream.dreamType !== 'LOCATION') return ''
+  return dream.slug || ''
+})
+
+function startStoryWithLocation(): void {
+  const slug = locationStorySlug.value
+  if (!slug) return
+  void navigateTo({ path: '/storybook', query: { location: slug } })
+}
 
 watch(
   () => dreamStore.selectedDream?.id,

--- a/utils/scripts/verifyStorybookLocationDeepLinkGuard.mjs
+++ b/utils/scripts/verifyStorybookLocationDeepLinkGuard.mjs
@@ -1,0 +1,127 @@
+// /utils/scripts/verifyStorybookLocationDeepLinkGuard.mjs
+//
+// Regression guard (storybook/t-010 cycle 20). Cycle 19 left a kaizen lead:
+// Facet, Reward, Character and Scenario detail surfaces each carry a "Start
+// a story with this" CTA that navigates to /storybook with the object's slug
+// in the matching query key (facet/reward/character/scenario), and
+// storybook-page.vue's seedFromQuery() reads all five supported keys --
+// including `?location=` -- into its setup draft. But Location has no
+// first-class model or dedicated component of its own (unlike the other
+// four): a LOCATION Dream's only detail surface is the generic
+// dream-narration.vue workspace (opened from dream-gallery / dream-interact),
+// and that workspace had no CTA at all. `?location=` was a dead query key --
+// nothing in the app ever produced it -- so a reader browsing a LOCATION
+// Dream had no way to jump into Storybook with that location pre-seeded,
+// unlike readers browsing a Character, Reward, Scenario, or Facet.
+//
+// This closes the gap the same way character-manager.vue,
+// reward-encounter.vue, facet-profile.vue and scenario-manager.vue do it:
+// dream-narration.vue now renders a "Start a story with this" button (only
+// when the selected Dream's dreamType is LOCATION and it has a slug) that
+// navigates to /storybook with `query: { location: slug }`.
+//
+// This guard is deliberately narrow, matching verifyStorybookObjectEntryLinks
+// and verifyStorybookCharacterDeepLinkGuard's convention: it checks the CTA's
+// click handler exists, sends the real Dream slug under the `location` query
+// key, is gated on dreamType === 'LOCATION', and that seedFromQuery() still
+// consumes `?location=` into `draft.locationSlug`. It does not assert button
+// classes, icon names, or layout -- a restyle of the CTA must not fail this.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { extractTsFunctionBody } from './lib/extractTsFunctionBody.mjs'
+
+const NARRATION_PATH = 'components/dreams/dream-narration.vue'
+const PAGE_PATH = 'components/conductor/storybook-page.vue'
+
+function source(path) {
+  return readFileSync(resolve(process.cwd(), path), 'utf8')
+}
+
+const narrationContent = source(NARRATION_PATH)
+
+// The template must render the CTA gated on a computed that only resolves
+// for LOCATION dreams, and wire its click to the handler.
+assert.ok(
+  narrationContent.includes('v-if="locationStorySlug"') &&
+    narrationContent.includes('@click="startStoryWithLocation"'),
+  `${NARRATION_PATH} must render a "Start a story with this" CTA gated on ` +
+    '`locationStorySlug` and wired to `startStoryWithLocation` -- has the ' +
+    'CTA been renamed, removed, or restructured?',
+)
+
+// locationStorySlug must only resolve for dreamType === 'LOCATION' -- if this
+// gate is lost, every other Dream type (ART, BRAINSTORM, PITCH, WISH, ...)
+// would grow a CTA that points Storybook at a query key seedFromQuery()
+// cannot use for them.
+const locationStorySlugMatch =
+  /const locationStorySlug = computed\(\(\) => \{([\s\S]*?)\n\}\)/.exec(
+    narrationContent,
+  )
+assert.ok(
+  locationStorySlugMatch,
+  `Could not find \`const locationStorySlug = computed\` in ${NARRATION_PATH} ` +
+    '-- has it been renamed, removed, or restructured? If so, this guard ' +
+    'needs to move with it.',
+)
+const locationStorySlugBody = locationStorySlugMatch[1]
+assert.ok(
+  /dream\.dreamType !== 'LOCATION'/.test(locationStorySlugBody),
+  `\`locationStorySlug\` in ${NARRATION_PATH} must bail out for any Dream ` +
+    "whose dreamType isn't LOCATION -- otherwise every Dream type gains a " +
+    '"Start a story with this" CTA even though seedFromQuery() only has a ' +
+    'query key for LOCATION dreams.',
+)
+assert.ok(
+  /return dream\.slug \|\| ''/.test(locationStorySlugBody),
+  `\`locationStorySlug\` in ${NARRATION_PATH} must resolve to the real ` +
+    '`dream.slug` -- a synthetic or missing slug would not match what ' +
+    "storybook-page.vue's `locationOptions` keys against.",
+)
+
+// The handler itself must send the real slug under the `location` query key,
+// matching what seedFromQuery() reads.
+const startStoryBody = extractTsFunctionBody(
+  narrationContent,
+  'startStoryWithLocation',
+  {
+    path: NARRATION_PATH,
+    notFoundHint:
+      'has it been renamed, removed, or inlined? If so, this guard needs ' +
+      'to move with it.',
+  },
+)
+assert.ok(
+  /const slug = locationStorySlug\.value/.test(startStoryBody) &&
+    /query:\s*\{\s*location:\s*slug\s*\}/.test(startStoryBody),
+  `startStoryWithLocation() in ${NARRATION_PATH} must navigate to ` +
+    "'/storybook' with `query: { location: slug }`, sourced from " +
+    '`locationStorySlug.value` -- otherwise it no longer agrees with what ' +
+    "storybook-page.vue's seedFromQuery() and locationOptions expect.",
+)
+
+// The receiving half of the contract: seedFromQuery() must still forward the
+// raw ?location= query value into draft.locationSlug -- the CTA above is
+// dead unless this still wires the query into the field Storybook actually
+// reads for its setup draft.
+const pageContent = source(PAGE_PATH)
+const seedFromQueryBody = extractTsFunctionBody(pageContent, 'seedFromQuery', {
+  path: PAGE_PATH,
+  notFoundHint:
+    'has it been renamed, removed, or inlined? If so, this guard needs to ' +
+    'move with it.',
+})
+assert.ok(
+  /draft\.locationSlug = location/.test(seedFromQueryBody) &&
+    /const location = single\(route\.query\.location\)/.test(seedFromQueryBody),
+  `seedFromQuery() in ${PAGE_PATH} must still read \`route.query.location\` ` +
+    'into `draft.locationSlug` -- otherwise the new Location CTA in ' +
+    `${NARRATION_PATH} has nothing to seed.`,
+)
+
+console.log(
+  'Storybook location-deep-link guard contract passed: dream-narration.vue ' +
+    'renders a "Start a story with this" CTA for LOCATION Dreams that sends ' +
+    "the real Dream slug as ?location=, and storybook-page.vue's " +
+    'seedFromQuery() still consumes it into the setup draft.',
+)


### PR DESCRIPTION
## Bug

Facet, Reward, Character and Scenario detail surfaces (`facet-profile.vue`, `reward-encounter.vue`, `character-manager.vue`, `scenario-manager.vue`) each carry a "Start a story with this" CTA that navigates to `/storybook` with the object's slug in a matching query key. `storybook-page.vue`'s `seedFromQuery()` reads all five supported keys — `scenario`, `location`, `character`, `facet`, `reward` — into its setup draft.

Location is the odd one out: it has no first-class Prisma model or dedicated component of its own — a "Location" is just a `Dream` row with `dreamType: 'LOCATION'` (see `prisma/schema.prisma`'s `DreamType` enum, and `locationOptions` in `storybook-page.vue`, which filters `dreamStore.dreams` by `dreamType === 'LOCATION'`, unlike scenario/character/reward which come from their own dedicated stores). A LOCATION Dream's only detail surface is the generic `dream-narration.vue` workspace, and that workspace had no CTA at all. `?location=` was therefore a dead query key — nothing in the app ever produced it — so a reader browsing a LOCATION Dream had no way to jump into Storybook with that location pre-seeded, unlike readers browsing a Character, Reward, Scenario, or Facet.

## Fix

Add the same CTA to `dream-narration.vue`'s header, gated on a new `locationStorySlug` computed that only resolves when the selected Dream's `dreamType === 'LOCATION'` (so no other Dream type — ART, BRAINSTORM, PITCH, WISH, ...) grows a CTA pointing Storybook at a query key `seedFromQuery()` has no use for. `startStoryWithLocation()` navigates to `/storybook` with `query: { location: slug }`, using the real `dream.slug`, matching what `locationOptions` in `storybook-page.vue` keys against.

## Guard

New `utils/scripts/verifyStorybookLocationDeepLinkGuard.mjs`, following the exact convention of `verifyStorybookObjectEntryLinks.mjs` and `verifyStorybookCharacterDeepLinkGuard.mjs`. It asserts both ends of the contract:
- the CTA in `dream-narration.vue` exists, is gated on `dreamType === 'LOCATION'`, and sends the real Dream slug under `?location=`
- `seedFromQuery()` in `storybook-page.vue` still reads `route.query.location` into `draft.locationSlug`

Wired into a new per-guard workflow `.github/workflows/storybook-location-deep-link-contract.yml`, matching every other `verifyStorybook*` guard's own dedicated workflow (none of these guards are wired into `package.json` scripts — confirmed by grep — so none was added here either, to match the established convention exactly).

## Verification

- Stash round-trip: guard fails pre-fix (`AssertionError` — CTA not found) and passes post-fix. ✅
- All 17 prior `verifyStorybook*` guards (16 `.mjs` + 1 `.ts`) still pass — no regression. ✅
- `eslint` clean on touched files (fixed one `no-useless-escape`). ✅
- `prettier --check` clean on touched files. ✅
- `vue-tsc --noEmit` clean repo-wide. ✅
- `git status --porcelain` shows exactly the 3 intended files changed. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_011UZRAso7uR292yLAxtehDv)_