### PR TITLE
fix(model-builder): pre-fill batch field values from group's shared value (model-builder/t-029, cycle 19)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -467,6 +467,12 @@ jobs:
       - name: Model Builder batch-editor key guard contract
         run: npm run test:model-builder-batch-editor-key-guard
 
+      - name: Model Builder batch-editor pre-fill guard checker self-test
+        run: npm run test:model-builder-batch-prefill-guard-selftest
+
+      - name: Model Builder batch-editor pre-fill guard contract
+        run: npm run test:model-builder-batch-prefill-guard
+
       - name: Model Builder ASSET_ONLY approval guard checker self-test
         run: npm run test:model-builder-asset-only-approval-guard-selftest
 

--- a/components/model-builder/model-builder-batch-editor.vue
+++ b/components/model-builder/model-builder-batch-editor.vue
@@ -208,10 +208,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive, ref } from 'vue'
+import { computed, onMounted, reactive, ref } from 'vue'
 import { useModelBuilderStore } from '@/stores/modelBuilderStore'
 import type { BuildItem, DraftField } from '@/stores/modelBuilderStore'
-import { fieldSpecFor } from '@/stores/helpers/modelBuilderFields'
+import {
+  fieldSpecFor,
+  readFieldLine,
+} from '@/stores/helpers/modelBuilderFields'
 
 const props = defineProps<{ outputKey: string }>()
 const emit = defineEmits<{ (e: 'select-item', itemId: string): void }>()
@@ -275,6 +278,36 @@ const autoBuildGroupTitle = computed(() =>
 
 const onlyEmpty = ref(false)
 const batchValues = reactive<Record<string, string>>({})
+
+// Pre-populate "Set a field on all N" with the group's existing shared value
+// (model-builder/t-029, cycle 19 -- suggested lead from cycle 18): every
+// item's fieldsDraft already carries a "key: value" blob (seeded by
+// defaultFieldsTemplate, drafted by AI, or previously set by this very
+// panel), but readFieldLine -- the helper written to read exactly that --
+// was never called here, so this panel always started blank even when every
+// item in the group already agreed on a value. Only pre-fills a field when
+// EVERY item holds the identical non-empty value; any disagreement
+// (including one item that was individually edited away from the rest)
+// leaves the input blank, same as before this fix, so a stale majority
+// value is never silently offered over a real per-item difference. Runs
+// once on mount only -- this component remounts on outputKey change (see
+// model-builder-progress-matrix.vue's `:key="selectedItem.outputKey"` and
+// verifyModelBuilderBatchEditorKeyGuard.ts), so there's no stale-group case
+// to re-derive for, and re-running after the user starts editing would
+// clobber an in-progress edit with the original shared value.
+onMounted(() => {
+  const currentGroup = group.value
+  if (!currentGroup) return
+  for (const field of fields.value) {
+    const values = currentGroup.items.map((item) =>
+      readFieldLine(item.fieldsDraft, field.key, currentGroup.targetModel),
+    )
+    const [first, ...rest] = values
+    if (first && rest.every((value) => value === first)) {
+      batchValues[field.key] = first
+    }
+  }
+})
 
 function batchFieldId(key: string): string {
   return `model-builder-batch-${props.outputKey}-${key}`

--- a/package.json
+++ b/package.json
@@ -239,6 +239,8 @@
     "test:model-builder-stale-asset-approval-guard": "tsx utils/scripts/verifyModelBuilderStaleAssetApprovalGuard.ts",
     "test:model-builder-batch-editor-key-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchEditorKeyGuard.test.ts",
     "test:model-builder-batch-editor-key-guard": "tsx utils/scripts/verifyModelBuilderBatchEditorKeyGuard.ts",
+    "test:model-builder-batch-prefill-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchPrefillGuard.test.ts",
+    "test:model-builder-batch-prefill-guard": "tsx utils/scripts/verifyModelBuilderBatchPrefillGuard.ts",
     "test:model-builder-asset-only-approval-guard-selftest": "tsx utils/scripts/verifyModelBuilderAssetOnlyApprovalGuard.test.ts",
     "test:model-builder-asset-only-approval-guard": "tsx utils/scripts/verifyModelBuilderAssetOnlyApprovalGuard.ts",
     "test:model-builder-auto-build-approval-race-guard-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildApprovalRaceGuard.test.ts",

--- a/utils/scripts/verifyModelBuilderBatchPrefillGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderBatchPrefillGuard.test.ts
@@ -1,0 +1,128 @@
+// /utils/scripts/verifyModelBuilderBatchPrefillGuard.test.ts
+//
+// Regression test for checkBatchPrefillGuard() in
+// verifyModelBuilderBatchPrefillGuard.ts (model-builder/t-029, cycle 19).
+// Exercises the real check against synthetic script-shaped fixtures
+// covering: the pre-fix shape (no `onMounted`/`readFieldLine` at all --
+// batchValues starts and stays blank), the fixed shape, an `onMounted`
+// block present but missing the `readFieldLine` call, and one present but
+// missing the actual seed write.
+import assert from 'node:assert/strict'
+
+import { checkBatchPrefillGuard } from './verifyModelBuilderBatchPrefillGuard.js'
+
+const BUGGY_FIXTURE = `
+<script setup lang="ts">
+import { computed, reactive, ref } from 'vue'
+import { fieldSpecFor } from '@/stores/helpers/modelBuilderFields'
+
+const onlyEmpty = ref(false)
+const batchValues = reactive<Record<string, string>>({})
+
+function batchFieldId(key: string): string {
+  return \`model-builder-batch-\${key}\`
+}
+</script>
+`
+
+const FIXED_FIXTURE = `
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue'
+import { fieldSpecFor, readFieldLine } from '@/stores/helpers/modelBuilderFields'
+
+const onlyEmpty = ref(false)
+const batchValues = reactive<Record<string, string>>({})
+
+onMounted(() => {
+  const currentGroup = group.value
+  if (!currentGroup) return
+  for (const field of fields.value) {
+    const values = currentGroup.items.map((item) =>
+      readFieldLine(item.fieldsDraft, field.key, currentGroup.targetModel),
+    )
+    const [first, ...rest] = values
+    if (first && rest.every((value) => value === first)) {
+      batchValues[field.key] = first
+    }
+  }
+})
+
+function batchFieldId(key: string): string {
+  return \`model-builder-batch-\${key}\`
+}
+</script>
+`
+
+const MISSING_READ_FIXTURE = `
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue'
+import { fieldSpecFor, readFieldLine } from '@/stores/helpers/modelBuilderFields'
+
+const batchValues = reactive<Record<string, string>>({})
+
+onMounted(() => {
+  batchValues.name = 'placeholder'
+})
+</script>
+`
+
+const MISSING_SEED_FIXTURE = `
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue'
+import { fieldSpecFor, readFieldLine } from '@/stores/helpers/modelBuilderFields'
+
+const batchValues = reactive<Record<string, string>>({})
+
+onMounted(() => {
+  const currentGroup = group.value
+  if (!currentGroup) return
+  for (const field of fields.value) {
+    const values = currentGroup.items.map((item) =>
+      readFieldLine(item.fieldsDraft, field.key, currentGroup.targetModel),
+    )
+    console.log(values)
+  }
+})
+</script>
+`
+
+const buggyErrors = checkBatchPrefillGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  1,
+  `expected the pre-fix shape to raise 1 error, got ${buggyErrors.length}: ` +
+    `${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(buggyErrors[0]!.includes('readFieldLine'))
+
+const fixedErrors = checkBatchPrefillGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingReadErrors = checkBatchPrefillGuard(MISSING_READ_FIXTURE)
+assert.equal(
+  missingReadErrors.length,
+  2,
+  'expected the missing-readFieldLine-call shape to raise 2 errors ' +
+    `(no read call, no seed write), got ${missingReadErrors.length}: ` +
+    `${JSON.stringify(missingReadErrors)}`,
+)
+
+const missingSeedErrors = checkBatchPrefillGuard(MISSING_SEED_FIXTURE)
+assert.equal(
+  missingSeedErrors.length,
+  1,
+  'expected the missing-seed-write shape to raise 1 error, got ' +
+    `${missingSeedErrors.length}: ${JSON.stringify(missingSeedErrors)}`,
+)
+assert.ok(missingSeedErrors[0]!.includes('batchValues[field.key] = first'))
+
+console.log(
+  'Model Builder batch-editor pre-fill guard checker verified: flags the ' +
+    'pre-fix shape (no onMounted pre-fill at all), clears the fixed shape, ' +
+    'and flags an onMounted block missing either the readFieldLine call or ' +
+    'the actual seed write.',
+)

--- a/utils/scripts/verifyModelBuilderBatchPrefillGuard.ts
+++ b/utils/scripts/verifyModelBuilderBatchPrefillGuard.ts
@@ -1,0 +1,115 @@
+// /utils/scripts/verifyModelBuilderBatchPrefillGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 19) -- model-builder-batch-
+// editor.vue's "Set a field on all N" panel binds each control directly to
+// `batchValues[field.key]`, a plain `reactive<Record<string, string>>({})`
+// that starts empty. Every item in the group already carries a
+// "key: value" fieldsDraft blob (seeded by defaultFieldsTemplate, drafted
+// by AI, or previously set by this very panel via a prior batchSetField
+// pass), and stores/helpers/modelBuilderFields.ts's readFieldLine() exists
+// specifically to read one field's value back out of that blob -- but
+// nothing in this component called it, so the panel always started blank
+// even when every item in the group already agreed on a value, forcing the
+// user to retype a value that was already true of all N items.
+//
+// Fixed by an onMounted() hook that reads each field's value across every
+// item in the group via readFieldLine and, only when all of them agree on
+// an identical non-empty value, seeds batchValues[field.key] with it.
+//
+// This asserts the textual shape of that fix stays in place: an
+// `onMounted` block in model-builder-batch-editor.vue that calls
+// `readFieldLine(` to seed `batchValues[`, deliberately scoped to this one
+// bug shape, mirroring this project's other narrow textual guards over a
+// general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const BATCH_EDITOR_PATH = join(
+  repositoryRoot,
+  'components/model-builder/model-builder-batch-editor.vue',
+)
+
+const IMPORT_NEEDLE = 'readFieldLine'
+const MOUNT_NEEDLE = 'onMounted('
+const READ_CALL_NEEDLE = 'readFieldLine('
+const SEED_NEEDLE = 'batchValues[field.key] = first'
+
+// Checks the fix's exact shape against the full source text of
+// model-builder-batch-editor.vue. Exported so the self-test below can run
+// it against synthetic buggy/fixed fixtures without touching the real
+// component file.
+export function checkBatchPrefillGuard(content: string): string[] {
+  const errors: string[] = []
+
+  if (!content.includes(IMPORT_NEEDLE)) {
+    errors.push(
+      'model-builder-batch-editor.vue no longer references ' +
+        '`readFieldLine` -- without it the batch-edit panel cannot read ' +
+        "each item's existing field value, so it has no way to pre-fill " +
+        '"Set a field on all N" with a value every item already shares.',
+    )
+    return errors
+  }
+
+  const mountIndex = content.indexOf(MOUNT_NEEDLE)
+  if (mountIndex === -1) {
+    errors.push(
+      'model-builder-batch-editor.vue has no `onMounted(` block -- the ' +
+        'shared-value pre-fill for "Set a field on all N" ran once on ' +
+        'mount; without that hook the panel goes back to always starting ' +
+        'blank even when every item in the group already agrees on a value.',
+    )
+    return errors
+  }
+
+  const mountBody = content.slice(mountIndex)
+
+  if (!mountBody.includes(READ_CALL_NEEDLE)) {
+    errors.push(
+      "model-builder-batch-editor.vue's `onMounted` block does not call " +
+        "`readFieldLine(` -- it can no longer read each item's existing " +
+        'field value out of its fieldsDraft blob, so the pre-fill has ' +
+        'nothing to derive a shared value from.',
+    )
+  }
+
+  if (!mountBody.includes(SEED_NEEDLE)) {
+    errors.push(
+      "model-builder-batch-editor.vue's `onMounted` block no longer " +
+        `writes \`${SEED_NEEDLE}\` -- without seeding batchValues from the ` +
+        'derived shared value, "Set a field on all N" starts blank again ' +
+        'even when every item in the group already agrees on a value.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(BATCH_EDITOR_PATH, 'utf8')
+  const errors = checkBatchPrefillGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder batch-editor pre-fill guard contract failed for ' +
+        'model-builder-batch-editor.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder batch-editor pre-fill guard contract passed: ' +
+      '"Set a field on all N" still pre-fills from each field\'s existing ' +
+      'shared value across the group on mount.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What

`model-builder-batch-editor.vue`'s "Set a field on all N" panel binds each control directly to `batchValues[field.key]`, a plain `reactive<Record<string, string>>({})` that always starts empty. Every item in a quantity/expansion group already carries a `"key: value"` `fieldsDraft` blob (seeded by `defaultFieldsTemplate`, drafted by AI, or previously set by an earlier `batchSetField` pass), and `readFieldLine()` in `stores/helpers/modelBuilderFields.ts` exists specifically to read a field's value back out of that blob — but nothing in this component called it, so the panel always started blank even when every item in the group already agreed on a value, forcing the user to retype a value that was already true of all N items.

This closes out the suggested lead from model-builder/t-029's cycle 18.

## Changes

- `components/model-builder/model-builder-batch-editor.vue` — an `onMounted()` hook reads each field's value across every item in the group via `readFieldLine` and, only when **all** items hold an identical non-empty value, seeds `batchValues[field.key]` with it. Any disagreement (including one item that was individually edited away from the rest) leaves the input blank, same as before — a stale majority value is never silently applied over a real per-item difference. Runs once on mount only: this component already remounts on `outputKey` change (`:key="selectedItem.outputKey"` in `model-builder-progress-matrix.vue`, guarded by `verifyModelBuilderBatchEditorKeyGuard.ts`), so there's no stale-group case to re-derive for, and re-running after the user starts editing would clobber an in-progress edit.
- `utils/scripts/verifyModelBuilderBatchPrefillGuard.ts` + `.test.ts` (new) — narrow textual regression guard mirroring this project's other `verifyModelBuilder*Guard` checks, wired into `package.json` and `contract-tests.yml`.

## Verification

- New guard self-test passes (buggy/fixed/missing-read/missing-seed fixtures all behave as expected)
- New guard passes against the real fixed file
- Sibling `model-builder-batch-editor-key-guard` and `model-builder-field-blob-continuation-guard` (self-test + contract) still pass unaffected
- `eslint` clean on touched files
- `prettier --check` clean on touched files (ran `--write` once; confirmed via a `git stash` round-trip that the pre-`--write` state had no pre-existing formatting drift — the warnings were introduced by this change's own formatting, not latent)
- `vue-tsc --noEmit` repo-wide clean
- `git status --porcelain` shows exactly the 5 intended files

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJD4BRXJsmtacvDnfRrCiT)_