### PR TITLE
fix(model-builder): stop telling users to enable art for outputs with no generator

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -473,6 +473,12 @@ jobs:
       - name: Model Builder batch-editor pre-fill guard contract
         run: npm run test:model-builder-batch-prefill-guard
 
+      - name: Model Builder auto-build asset-only message guard checker self-test
+        run: npm run test:model-builder-auto-build-asset-only-message-guard-selftest
+
+      - name: Model Builder auto-build asset-only message guard contract
+        run: npm run test:model-builder-auto-build-asset-only-message-guard
+
       - name: Model Builder ASSET_ONLY approval guard checker self-test
         run: npm run test:model-builder-asset-only-approval-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -241,6 +241,8 @@
     "test:model-builder-batch-editor-key-guard": "tsx utils/scripts/verifyModelBuilderBatchEditorKeyGuard.ts",
     "test:model-builder-batch-prefill-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchPrefillGuard.test.ts",
     "test:model-builder-batch-prefill-guard": "tsx utils/scripts/verifyModelBuilderBatchPrefillGuard.ts",
+    "test:model-builder-auto-build-asset-only-message-guard-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildAssetOnlyMessageGuard.test.ts",
+    "test:model-builder-auto-build-asset-only-message-guard": "tsx utils/scripts/verifyModelBuilderAutoBuildAssetOnlyMessageGuard.ts",
     "test:model-builder-asset-only-approval-guard-selftest": "tsx utils/scripts/verifyModelBuilderAssetOnlyApprovalGuard.test.ts",
     "test:model-builder-asset-only-approval-guard": "tsx utils/scripts/verifyModelBuilderAssetOnlyApprovalGuard.ts",
     "test:model-builder-auto-build-approval-race-guard-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildApprovalRaceGuard.test.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1871,11 +1871,33 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     const wantArt = state.includeArt && item.generation === 'image'
 
     // An ASSET_ONLY item is nothing but its art — can't auto-build without it.
+    //
+    // Bug (model-builder/t-029, cycle 20): wantArt requires BOTH
+    // state.includeArt AND item.generation === 'image', so this branch fires
+    // for two genuinely different reasons that need two different messages.
+    // When generation IS 'image' and only includeArt is off, "enable art" is
+    // real, actionable advice — toggle it on the recipe step and retry. But
+    // several ASSET_ONLY outputs use a generation kind this front-end slice
+    // has never wired a generator for at all: 'plan' (photo-shoot-plan,
+    // video-shot-list, commercial-treatment, launch-plan — the last one
+    // defaultOn: true, so every default Marketing Deck run creates one) and
+    // 'three-d' (three-d-reference, reward-3d) — see model-builder-item-
+    // panel.vue's own GENERATE_ASSETS section, which shows exactly this
+    // explanation in place of a generate button. For those items,
+    // item.generation is never 'image', so wantArt can never become true no
+    // matter what includeArt is set to — "enable art" describes an action
+    // that cannot possibly fix the item. Clicking Auto on one (or letting
+    // Auto-build all/group reach it) before this fix left the user with a
+    // wrong, unhelpful instruction and no clue the generation kind itself is
+    // simply unimplemented yet, rather than something they mis-configured.
     if (isAsset && !wantArt) {
-      setStatus(
-        'error',
-        `${item.label} is asset-only — enable art to auto-build it.`,
-      )
+      const message =
+        item.generation === 'image'
+          ? `${item.label} is asset-only — enable art to auto-build it.`
+          : `${item.label}: ${item.generation} generation is not yet wired ` +
+            `into this front-end slice, so it can't be auto-built or ` +
+            `committed yet.`
+      setStatus('error', message)
       return 'failed'
     }
 

--- a/utils/scripts/verifyModelBuilderAutoBuildAssetOnlyMessageGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildAssetOnlyMessageGuard.test.ts
@@ -1,0 +1,151 @@
+// /utils/scripts/verifyModelBuilderAutoBuildAssetOnlyMessageGuard.test.ts
+//
+// Regression test for checkAutoBuildAssetOnlyMessageGuard() in
+// verifyModelBuilderAutoBuildAssetOnlyMessageGuard.ts (model-builder/t-029,
+// cycle 20). Exercises the real check against synthetic store-shaped
+// fixtures covering: the pre-fix shape (one "enable art" message for both
+// causes), the fixed shape, a shape that branches on generation but still
+// reuses "enable art" text in the non-image branch, and a shape missing the
+// function entirely.
+import assert from 'node:assert/strict'
+
+import { checkAutoBuildAssetOnlyMessageGuard } from './verifyModelBuilderAutoBuildAssetOnlyMessageGuard.js'
+
+const BUGGY_FIXTURE = `
+export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
+  async function autoBuildItem(itemId: string): Promise<AutoBuildOutcome> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return 'failed'
+
+    const isAsset = item.action === 'ASSET_ONLY'
+    const wantArt = state.includeArt && item.generation === 'image'
+
+    // An ASSET_ONLY item is nothing but its art — can't auto-build without it.
+    if (isAsset && !wantArt) {
+      setStatus(
+        'error',
+        \`\${item.label} is asset-only — enable art to auto-build it.\`,
+      )
+      return 'failed'
+    }
+
+    return 'committed'
+  }
+
+  return { autoBuildItem }
+})
+`
+
+const FIXED_FIXTURE = `
+export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
+  async function autoBuildItem(itemId: string): Promise<AutoBuildOutcome> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return 'failed'
+
+    const isAsset = item.action === 'ASSET_ONLY'
+    const wantArt = state.includeArt && item.generation === 'image'
+
+    if (isAsset && !wantArt) {
+      const message =
+        item.generation === 'image'
+          ? \`\${item.label} is asset-only — enable art to auto-build it.\`
+          : \`\${item.label}: \${item.generation} generation is not yet wired \` +
+            \`into this front-end slice, so it can't be auto-built or \` +
+            \`committed yet.\`
+      setStatus('error', message)
+      return 'failed'
+    }
+
+    return 'committed'
+  }
+
+  return { autoBuildItem }
+})
+`
+
+const STILL_MENTIONS_ENABLE_ART_FIXTURE = `
+export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
+  async function autoBuildItem(itemId: string): Promise<AutoBuildOutcome> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return 'failed'
+
+    const isAsset = item.action === 'ASSET_ONLY'
+    const wantArt = state.includeArt && item.generation === 'image'
+
+    if (isAsset && !wantArt) {
+      const message =
+        item.generation === 'image'
+          ? \`\${item.label} is asset-only — enable art to auto-build it.\`
+          : \`\${item.label} generation is not yet wired into this front-end \` +
+            \`slice — enable art to auto-build it.\`
+      setStatus('error', message)
+      return 'failed'
+    }
+
+    return 'committed'
+  }
+
+  return { autoBuildItem }
+})
+`
+
+const MISSING_FUNCTION_FIXTURE = `
+export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
+  function commitItem(itemId: string): Promise<boolean> {
+    return Promise.resolve(true)
+  }
+
+  return { commitItem }
+})
+`
+
+const buggyErrors = checkAutoBuildAssetOnlyMessageGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  2,
+  `expected the pre-fix shape (single message, no generation branch, no ` +
+    `distinct non-image message) to raise 2 errors, got ${buggyErrors.length}: ` +
+    `${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(buggyErrors.some((error) => error.includes("generation === 'image'")))
+assert.ok(
+  buggyErrors.some((error) => error.includes('not wired into the front-end')),
+)
+
+const fixedErrors = checkAutoBuildAssetOnlyMessageGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const stillMentionsEnableArtErrors = checkAutoBuildAssetOnlyMessageGuard(
+  STILL_MENTIONS_ENABLE_ART_FIXTURE,
+)
+assert.equal(
+  stillMentionsEnableArtErrors.length,
+  1,
+  'expected the shape that branches correctly but still says "enable art" ' +
+    `in the non-image message to raise 1 error, got ` +
+    `${stillMentionsEnableArtErrors.length}: ` +
+    `${JSON.stringify(stillMentionsEnableArtErrors)}`,
+)
+assert.ok(stillMentionsEnableArtErrors[0]!.includes('cannot fix'))
+
+const missingFunctionErrors = checkAutoBuildAssetOnlyMessageGuard(
+  MISSING_FUNCTION_FIXTURE,
+)
+assert.equal(
+  missingFunctionErrors.length,
+  1,
+  `expected the missing-function shape to raise 1 error, got ` +
+    `${missingFunctionErrors.length}: ${JSON.stringify(missingFunctionErrors)}`,
+)
+assert.ok(missingFunctionErrors[0]!.includes('autoBuildItem'))
+
+console.log(
+  'Model Builder auto-build asset-only message guard checker verified: ' +
+    'flags the pre-fix single-message shape, clears the fixed shape, flags ' +
+    'a shape that branches but still gives misleading "enable art" advice ' +
+    'in the non-image case, and flags a missing autoBuildItem() function.',
+)

--- a/utils/scripts/verifyModelBuilderAutoBuildAssetOnlyMessageGuard.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildAssetOnlyMessageGuard.ts
@@ -1,0 +1,157 @@
+// /utils/scripts/verifyModelBuilderAutoBuildAssetOnlyMessageGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 20) -- autoBuildItem()'s
+// "an ASSET_ONLY item is nothing but its art" guard fires whenever
+// `isAsset && !wantArt`, and `wantArt` is defined as
+// `state.includeArt && item.generation === 'image'`. That single boolean
+// collapses two genuinely different situations into one message:
+//
+//   1. generation === 'image' but state.includeArt is off -- "enable art
+//      to auto-build it" is real, actionable advice: toggle Include Art on
+//      the recipe step and retry.
+//   2. generation !== 'image' (the OUTPUT_CATALOG entries with generation
+//      'plan' or 'three-d' -- photo-shoot-plan, video-shot-list,
+//      commercial-treatment, launch-plan [defaultOn: true, so every default
+//      Marketing Deck run creates one], three-d-reference, reward-3d) --
+//      wantArt can NEVER become true for these no matter what includeArt is
+//      set to, since generation is never 'image'. "Enable art" describes an
+//      action that cannot possibly fix the item -- these generation kinds
+//      simply have no generator wired into this front-end slice at all (see
+//      model-builder-item-panel.vue's own GENERATE_ASSETS section, which
+//      shows exactly that explanation instead of a generate button for
+//      them).
+//
+// Before this fix, autoBuildItem() reported the same "enable art" message
+// for both cases -- a real user clicking Auto on launch-plan (or any other
+// plan/three-d ASSET_ONLY item) got a wrong, unhelpful instruction with no
+// indication the generation kind itself is simply unimplemented rather than
+// something they mis-configured.
+//
+// This asserts the textual shape of the fix stays in place: autoBuildItem()
+// branches on `item.generation === 'image'` before choosing its failure
+// message, and the non-image branch's message does not contain the
+// misleading "enable art" phrasing.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'autoBuildItem'
+
+// Checks the fix's exact shape against the full source text of a file
+// containing an `autoBuildItem`-named function. Exported (rather than only
+// exercised via main()) so the self-test below can run it against synthetic
+// buggy/fixed fixtures without touching the real store file.
+export function checkAutoBuildAssetOnlyMessageGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find a function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  const guardBlockMatch = fn.body.match(
+    /if\s*\(\s*isAsset\s*&&\s*!wantArt\s*\)\s*\{([\s\S]*?)\n {4}\}/,
+  )
+  if (!guardBlockMatch) {
+    errors.push(
+      `${FN_NAME}() no longer contains an \`if (isAsset && !wantArt)\` ` +
+        "block -- this guard's anchor point has moved; re-check where the " +
+        'asset-only-without-art failure is reported.',
+    )
+    return errors
+  }
+  const guardBlock = guardBlockMatch[1]!
+
+  const branchesOnGeneration = /item\.generation\s*===\s*'image'/.test(
+    guardBlock,
+  )
+  if (!branchesOnGeneration) {
+    errors.push(
+      `${FN_NAME}()'s \`isAsset && !wantArt\` block does not branch on ` +
+        "`item.generation === 'image'` -- it reports one message for " +
+        'both "art is off" (fixable by enabling Include Art) and ' +
+        '"this generation kind has no generator at all" (not fixable by ' +
+        'enabling art, since wantArt can never become true for it), which ' +
+        'is misleading for the second case.',
+    )
+  }
+
+  const mentionsEnableArt = /enable art/.test(guardBlock)
+  if (!mentionsEnableArt) {
+    errors.push(
+      `${FN_NAME}()'s \`isAsset && !wantArt\` block no longer mentions ` +
+        '"enable art" at all -- the image-generation, includeArt-is-off ' +
+        'case (where that advice IS actionable) appears to have lost its ' +
+        'message entirely.',
+    )
+  }
+
+  // The non-image (else) branch's message can legitimately be built from
+  // several concatenated template-literal fragments (` + `), so this can't
+  // just grab a single backtick pair -- it captures everything from the
+  // ternary's own `:` through the next `setStatus(` call, regardless of how
+  // many literals/pluses sit in between.
+  const nonImageBranchMatch = guardBlock.match(
+    /item\.generation === 'image'[\s\S]*?\?[\s\S]*?:([\s\S]*?)(?=\n\s*setStatus\()/,
+  )
+  const nonImageBranchText = nonImageBranchMatch?.[1] ?? ''
+  const hasDistinctNonImageMessage = /generation is not yet wired/.test(
+    nonImageBranchText,
+  )
+  if (!hasDistinctNonImageMessage) {
+    errors.push(
+      `${FN_NAME}()'s \`isAsset && !wantArt\` block does not have a ` +
+        'distinct message explaining that this generation kind is not ' +
+        'wired into the front-end slice yet -- the non-image branch must ' +
+        'not just reuse the "enable art" text (see this guard\'s own file ' +
+        "header for why that's actively wrong for plan/three-d outputs).",
+    )
+  } else if (/enable art/.test(nonImageBranchText)) {
+    errors.push(
+      `${FN_NAME}()'s non-image failure message still mentions "enable ` +
+        'art" -- that advice cannot fix a generation kind with no ' +
+        'generator wired at all, regardless of includeArt.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkAutoBuildAssetOnlyMessageGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder auto-build asset-only message guard contract failed ' +
+        `for ${FN_NAME}() in stores/modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder auto-build asset-only message guard contract passed: ' +
+      `${FN_NAME}() reports a distinct, accurate message for ASSET_ONLY ` +
+      "items whose generation kind isn't wired in at all, instead of the " +
+      'misleading "enable art" advice.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What

Cycle 20 of the recurring Model Builder polish task (model-builder/t-029). Fixes a misleading auto-build error message for ASSET_ONLY outputs whose generation kind isn't wired into the front-end yet.

## Changes

- `stores/modelBuilderStore.ts`: `autoBuildItem()`'s `isAsset && !wantArt` guard used to report a single message — `"X is asset-only — enable art to auto-build it."` — for two genuinely different situations, since `wantArt = state.includeArt && item.generation === 'image'`:
  1. `generation === 'image'` but `state.includeArt` is off — "enable art" is real, actionable advice here.
  2. `generation !== 'image'` (the catalog's `'plan'`/`'three-d'` outputs — `photo-shoot-plan`, `video-shot-list`, `commercial-treatment`, `launch-plan` [**defaultOn: true**, so every default Marketing Deck run creates one], `three-d-reference`, `reward-3d`) — `wantArt` can *never* become true for these regardless of `includeArt`, since no generator is wired for those kinds at all (mirrors `model-builder-item-panel.vue`'s own "not yet wired into this front-end slice" explanation for the same items). "Enable art" describes an action that cannot possibly fix them.

  Before this fix, a real user clicking "Auto" on `launch-plan` (or any other plan/three-d ASSET_ONLY item) got a wrong, unhelpful instruction with no indication the generation kind itself is simply unimplemented. Now the message branches on `item.generation === 'image'` and gives an accurate explanation for the unimplemented-generation case instead.
- `utils/scripts/verifyModelBuilderAutoBuildAssetOnlyMessageGuard.ts` + `.test.ts`: new narrow regression guard (follows the existing `verifyModelBuilder*Guard.ts` pattern) asserting `autoBuildItem()` keeps branching on `generation === 'image'` and that the non-image message doesn't regress to the misleading "enable art" text.
- `package.json` / `.github/workflows/contract-tests.yml`: wired the new guard's self-test and contract check in alongside the sibling Model Builder guards.

## Verification

- `npx tsx utils/scripts/verifyModelBuilderAutoBuildAssetOnlyMessageGuard.test.ts` — new guard's self-test (buggy/fixed/partially-fixed/missing-function fixtures) passes.
- `npx tsx utils/scripts/verifyModelBuilderAutoBuildAssetOnlyMessageGuard.ts` — new guard passes against the real fixed `modelBuilderStore.ts`.
- Ran all 103 `test:model-builder-*` npm scripts (every sibling Model Builder guard's self-test + contract check) — all pass unaffected.
- `npx eslint stores/modelBuilderStore.ts utils/scripts/verifyModelBuilderAutoBuildAssetOnlyMessageGuard.ts utils/scripts/verifyModelBuilderAutoBuildAssetOnlyMessageGuard.test.ts` — clean on the new files; the two `no-empty` errors reported in `modelBuilderStore.ts` are pre-existing (verified via `git stash`, present before this change, well outside the diff).
- `npx prettier --check` on the two new files — clean. `modelBuilderStore.ts` reports pre-existing formatting drift across the whole file (also verified via `git stash` to predate this change); diffed prettier's own reformatted output against the added block specifically and it is byte-for-byte identical, confirming the new code itself is prettier-compliant.
- `npm test` (`vue-tsc --noEmit` repo-wide) — clean.
- `git status --porcelain` — only the 5 intended files touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FAj47v7GLVaKnGb82v7WFB)_