### PR TITLE
fix(model-builder): gate relationshipDraft edits behind FIELDS_AND_PROMPTS stage (model-builder/t-029, cycle 21)

### DIFF
--- a/server/api/model-builder/runs/index.ts
+++ b/server/api/model-builder/runs/index.ts
@@ -358,6 +358,17 @@ export function prepareItemUpdate(
     })
     data.promptDraft = normalizeText(body.promptDraft)
   }
+  if (body.relationshipDraft !== undefined) {
+    assertContentStageEditable(
+      existing.stageStatuses,
+      'FIELDS_AND_PROMPTS',
+      'Relationships',
+    )
+    contentStageChecks.push({
+      stageKey: 'FIELDS_AND_PROMPTS',
+      fieldLabel: 'Relationships',
+    })
+  }
   const relationshipDraft = normalizeJson(body.relationshipDraft)
   if (relationshipDraft !== undefined)
     data.relationshipDraft = relationshipDraft

--- a/utils/scripts/verifyModelBuilderItemPatchStageGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderItemPatchStageGuard.test.ts
@@ -1,11 +1,12 @@
 // /utils/scripts/verifyModelBuilderItemPatchStageGuard.test.ts
 //
 // Regression test for checkItemPatchStageGuard() in
-// verifyModelBuilderItemPatchStageGuard.ts (model-builder/t-029). Exercises
-// the real check against synthetic route-shaped fixtures covering: the
-// pre-fix shape (no assertContentStageEditable calls -- the exact bug found
-// by manual read-through), the fixed shape (a guard call ahead of each
-// content-field assignment, including artImageId/GENERATE_ASSETS), a
+// verifyModelBuilderItemPatchStageGuard.ts (model-builder/t-029, cycle 21
+// adds relationshipDraft). Exercises the real check against synthetic
+// route-shaped fixtures covering: the pre-fix shape (no
+// assertContentStageEditable calls -- the exact bug found by manual
+// read-through), the fixed shape (a guard call ahead of each content-field
+// assignment, including relationshipDraft and artImageId/GENERATE_ASSETS), a
 // partially-fixed shape (only PITCH guarded), and the function being absent
 // entirely.
 import assert from 'node:assert/strict'
@@ -29,6 +30,9 @@ export function prepareItemUpdate(
     data.fieldsDraft = normalizeText(body.fieldsDraft)
   if (body.promptDraft !== undefined)
     data.promptDraft = normalizeText(body.promptDraft)
+  const relationshipDraft = normalizeJson(body.relationshipDraft)
+  if (relationshipDraft !== undefined)
+    data.relationshipDraft = relationshipDraft
   if (body.artImageId !== undefined)
     data.artImageId = normalizeNullableId(body.artImageId)
 
@@ -68,6 +72,16 @@ export function prepareItemUpdate(
     )
     data.promptDraft = normalizeText(body.promptDraft)
   }
+  if (body.relationshipDraft !== undefined) {
+    assertContentStageEditable(
+      existing.stageStatuses,
+      'FIELDS_AND_PROMPTS',
+      'Relationships',
+    )
+  }
+  const relationshipDraft = normalizeJson(body.relationshipDraft)
+  if (relationshipDraft !== undefined)
+    data.relationshipDraft = relationshipDraft
   if (body.artImageId !== undefined) {
     assertContentStageEditable(
       existing.stageStatuses,
@@ -97,6 +111,9 @@ export function prepareItemUpdate(
     data.fieldsDraft = normalizeText(body.fieldsDraft)
   if (body.promptDraft !== undefined)
     data.promptDraft = normalizeText(body.promptDraft)
+  const relationshipDraft = normalizeJson(body.relationshipDraft)
+  if (relationshipDraft !== undefined)
+    data.relationshipDraft = relationshipDraft
   if (body.artImageId !== undefined)
     data.artImageId = normalizeNullableId(body.artImageId)
 
@@ -113,14 +130,15 @@ export function getRunId(event: H3Event): number {
 const buggyErrors = checkItemPatchStageGuard(BUGGY_FIXTURE)
 assert.equal(
   buggyErrors.length,
-  4,
-  `expected the pre-fix shape (no guard calls at all) to raise 4 errors ` +
-    `(pitch, fieldsDraft, promptDraft, artImageId), got ${buggyErrors.length}: ` +
+  5,
+  `expected the pre-fix shape (no guard calls at all) to raise 5 errors ` +
+    `(pitch, fieldsDraft, promptDraft, relationshipDraft, artImageId), got ${buggyErrors.length}: ` +
     JSON.stringify(buggyErrors),
 )
 assert.ok(buggyErrors.some((e) => e.includes("'PITCH'")))
 assert.ok(buggyErrors.some((e) => e.includes('body.fieldsDraft')))
 assert.ok(buggyErrors.some((e) => e.includes('body.promptDraft')))
+assert.ok(buggyErrors.some((e) => e.includes('data.relationshipDraft')))
 assert.ok(buggyErrors.some((e) => e.includes('body.artImageId')))
 assert.ok(buggyErrors.some((e) => e.includes("'GENERATE_ASSETS'")))
 
@@ -134,14 +152,15 @@ assert.equal(
 const partialErrors = checkItemPatchStageGuard(PARTIAL_FIXTURE)
 assert.equal(
   partialErrors.length,
-  3,
+  4,
   `expected the partially-fixed shape (PITCH guarded, FIELDS_AND_PROMPTS ` +
-    `and GENERATE_ASSETS not) to raise 3 errors, got ${partialErrors.length}: ` +
+    `and GENERATE_ASSETS not) to raise 4 errors, got ${partialErrors.length}: ` +
     JSON.stringify(partialErrors),
 )
 assert.ok(
   partialErrors.some((e) => e.includes('body.fieldsDraft')) &&
-    partialErrors.some((e) => e.includes('body.promptDraft')),
+    partialErrors.some((e) => e.includes('body.promptDraft')) &&
+    partialErrors.some((e) => e.includes('data.relationshipDraft')),
 )
 assert.ok(partialErrors.some((e) => e.includes('body.artImageId')))
 assert.ok(!partialErrors.some((e) => e.includes("'PITCH'")))
@@ -156,7 +175,8 @@ assert.ok(missingFnErrors[0]!.includes('prepareItemUpdate'))
 
 console.log(
   'Model Builder item-patch stage guard checker verified: flags the pre-fix ' +
-    'shape (no server-side stage gate on content edits), a partially-fixed ' +
-    'shape (only PITCH guarded), clears the fully-fixed shape, and flags ' +
-    'prepareItemUpdate being absent entirely.',
+    'shape (no server-side stage gate on content edits, including ' +
+    'relationshipDraft), a partially-fixed shape (only PITCH guarded), ' +
+    'clears the fully-fixed shape, and flags prepareItemUpdate being absent ' +
+    'entirely.',
 )

--- a/utils/scripts/verifyModelBuilderItemPatchStageGuard.ts
+++ b/utils/scripts/verifyModelBuilderItemPatchStageGuard.ts
@@ -28,15 +28,27 @@
 // (verifyModelBuilderApprovedAssetGuard.ts's generateItemAsset/
 // pollAsyncArtJob checks) only ever run inside the store, never here.
 //
+// relationshipDraft (model-builder/t-029 cycle 21) had the identical gap:
+// unlike pitch/fieldsDraft/promptDraft/artImageId, it was applied
+// unconditionally with no assertContentStageEditable call at all -- dead in
+// practice today (no client code sends body.relationshipDraft, confirmed via
+// grep across modelBuilderStore.ts and every model-builder .vue component),
+// but a defense-in-depth gap on a real, writable DB column that the moment
+// any future feature starts sending it would silently reopen the same
+// already-'approved'-content-overwrite hole this file exists to guard
+// against. Gated it under FIELDS_AND_PROMPTS, same bucket as fieldsDraft/
+// promptDraft, since it sits in the schema alongside them.
+//
 // This asserts the textual shape of the fix stays in place: prepareItemUpdate
 // calls assertContentStageEditable(existing.stageStatuses, 'PITCH', ...)
 // before assigning data.pitch, assertContentStageEditable(existing.
-// stageStatuses, 'FIELDS_AND_PROMPTS', ...) before assigning both
-// data.fieldsDraft and data.promptDraft, and assertContentStageEditable(
-// existing.stageStatuses, 'GENERATE_ASSETS', ...) before assigning
-// data.artImageId -- deliberately scoped to this one function/bug shape,
-// mirroring verifyModelBuilderCommitCancelledRunGuard.ts's preference for
-// explicit, narrow textual checks over a general-purpose static analyzer.
+// stageStatuses, 'FIELDS_AND_PROMPTS', ...) before assigning each of
+// data.fieldsDraft, data.promptDraft, and data.relationshipDraft, and
+// assertContentStageEditable(existing.stageStatuses, 'GENERATE_ASSETS', ...)
+// before assigning data.artImageId -- deliberately scoped to this one
+// function/bug shape, mirroring verifyModelBuilderCommitCancelledRunGuard.ts's
+// preference for explicit, narrow textual checks over a general-purpose
+// static analyzer.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -72,6 +84,11 @@ const GATES: GateCheck[] = [
   {
     field: 'promptDraft',
     assignment: 'data.promptDraft = normalizeText(body.promptDraft)',
+    stageKey: 'FIELDS_AND_PROMPTS',
+  },
+  {
+    field: 'relationshipDraft',
+    assignment: 'data.relationshipDraft = relationshipDraft',
     stageKey: 'FIELDS_AND_PROMPTS',
   },
   {
@@ -189,9 +206,9 @@ function main(): void {
 
   console.log(
     `Model Builder item-patch stage guard contract passed: ${FN_NAME}() ` +
-      'refuses to overwrite pitch/fieldsDraft/promptDraft/artImageId while ' +
-      "their stage is not ready/stale/rejected, per the item's server-stored " +
-      'stage status.',
+      'refuses to overwrite pitch/fieldsDraft/promptDraft/relationshipDraft/' +
+      'artImageId while their stage is not ready/stale/rejected, per the ' +
+      "item's server-stored stage status.",
   )
 }
 


### PR DESCRIPTION
## What

Every other content field `prepareItemUpdate()` writes (`pitch`, `fieldsDraft`, `promptDraft`, `artImageId`) refuses to overwrite an already-`approved`/`locked` stage's content via `assertContentStageEditable()`. `relationshipDraft` was the one gap: it was applied unconditionally, with no server-side stage check at all — the same "review gate would be lying about what's actually stored" hole this file's other four fields are already guarded against (model-builder/t-029 cycles 19/20).

This closes the lead flagged by cycle 20's TALKBACK note.

## Changes

- `server/api/model-builder/runs/index.ts`: `prepareItemUpdate()` now calls `assertContentStageEditable(existing.stageStatuses, 'FIELDS_AND_PROMPTS', 'Relationships')` before applying `body.relationshipDraft`, same bucket as `fieldsDraft`/`promptDraft` since it sits alongside them in the schema.
- `utils/scripts/verifyModelBuilderItemPatchStageGuard.ts` (+ its selftest): extended the existing static-shape guard to cover `relationshipDraft` the same way it already covers the other four fields.

## How I verified

- New/updated guard selftest passes (buggy fixture now expects 5 errors incl. relationshipDraft, partial fixture 4, fixed fixture 0)
- Guard passes against the real fixed route file
- Sibling guard selftests re-run unaffected: `model-builder-completion-gate`, `model-builder-cancelled-run-guard`, `model-builder-approved-asset-guard`
- `vue-tsc --noEmit` repo-wide clean
- `eslint` clean on touched files
- `prettier --check` clean on touched files (after a `--write` pass on the guard script's own formatting)
- `git status --porcelain` shows exactly the 3 intended files

## Stakes

reversible

## Flags for Reviewer

`relationshipDraft` has no live client call site today (confirmed via grep across `modelBuilderStore.ts` and every model-builder `.vue` component) — this is defense-in-depth on an unused-but-writable DB column, not a fix for an observed live bug.

## Kaizen suggestion

None new this cycle — 21 cycles in, the item-patch/commit/batch-editor/run-lifecycle surface area is thoroughly covered by narrow `verifyModelBuilder*Guard.ts` regression checks; the next worthwhile investigation is probably a fresh read of a component this recurring task hasn't focused on yet (e.g. the recipe-selector or source-picker UI) rather than re-auditing `prepareItemUpdate()` again.

---
_Generated by [Claude Code](https://claude.ai/code/session_01St3zq1citgfq6xvPGBHVs5)_