### PR TITLE
fix(model-builder): correct wrong subtitleField names for Bot and Facet (model-builder/t-029, cycle 22)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -659,6 +659,12 @@ jobs:
       - name: Model Builder source loading announcement guard contract
         run: npm run test:model-builder-source-loading-announcement-guard
 
+      - name: Model Builder source-field guard self-test
+        run: npm run test:model-builder-source-field-guard-selftest
+
+      - name: Model Builder source-field guard contract
+        run: npm run test:model-builder-source-field-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -303,6 +303,8 @@
     "test:model-builder-step-content-focus-guard": "tsx utils/scripts/verifyModelBuilderStepContentFocusGuard.ts",
     "test:model-builder-source-loading-announcement-guard-selftest": "tsx utils/scripts/verifyModelBuilderSourceLoadingAnnouncementGuard.test.ts",
     "test:model-builder-source-loading-announcement-guard": "tsx utils/scripts/verifyModelBuilderSourceLoadingAnnouncementGuard.ts",
+    "test:model-builder-source-field-guard-selftest": "tsx utils/scripts/verifyModelBuilderSourceFieldGuard.test.ts",
+    "test:model-builder-source-field-guard": "tsx utils/scripts/verifyModelBuilderSourceFieldGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",

--- a/stores/helpers/modelBuilderRecipes.ts
+++ b/stores/helpers/modelBuilderRecipes.ts
@@ -157,7 +157,13 @@ export const SOURCE_TYPES: SourceTypeConfig[] = [
     icon: 'kind-icon:robot',
     endpoint: '/api/bots',
     titleField: 'name',
-    subtitleField: 'botType',
+    // 'BotType' (capital B) -- matches Bot.BotType in prisma/schema.prisma.
+    // A lowercase 'botType' silently resolves to undefined on every record
+    // (model-builder/t-029 cycle 22): subtitle() in model-builder-source-
+    // picker.vue does a plain `record[field]` lookup with no type check
+    // against the schema, so a case mismatch renders a permanently blank
+    // Grid/List subtitle line instead of erroring anywhere.
+    subtitleField: 'BotType',
     defaultRecipe: 'character-deck',
     recipes: ['character-deck', 'art-upgrade'],
     blurb: 'Character deck with expressions, transitions, and an art upgrade.',
@@ -173,7 +179,13 @@ export const SOURCE_TYPES: SourceTypeConfig[] = [
     icon: 'kind-icon:gem',
     endpoint: '/api/facets',
     titleField: 'title',
-    subtitleField: 'kind',
+    // 'taxonomy', not 'kind' -- Facet.kind was dropped from the schema in
+    // t-072 (see server/utils/facetAssignments.ts); /api/facets now returns
+    // a hydrated FacetSummary with a computed `taxonomy` field instead. The
+    // stale 'kind' silently resolved to undefined on every record
+    // (model-builder/t-029 cycle 22), same failure mode as Bot's
+    // subtitleField above -- a permanently blank Grid/List subtitle line.
+    subtitleField: 'taxonomy',
     defaultRecipe: 'art-upgrade',
     recipes: ['art-upgrade'],
     blurb: 'Art upgrade only — Facets are reusable tags/attributes, not a relationship-expansion source.',

--- a/utils/scripts/verifyModelBuilderSourceFieldGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderSourceFieldGuard.test.ts
@@ -1,0 +1,199 @@
+// /utils/scripts/verifyModelBuilderSourceFieldGuard.test.ts
+//
+// Regression test for findSourceFieldProblems() and its helpers in
+// verifyModelBuilderSourceFieldGuard.ts (model-builder/t-029, cycle 22).
+// Exercises the real checks against synthetic schema/recipes/facet-summary
+// fixtures covering: the pre-fix shape (Bot's wrong-case 'botType', Facet's
+// dropped 'kind' column), the fixed shape, a titleField typo, and a
+// hydrated-summary field that's legitimately absent from the raw Facet
+// model but present on FacetSummary's own computed additions.
+import assert from 'node:assert/strict'
+
+import {
+  extractFacetSummaryExtraFields,
+  extractScalarFieldNames,
+  extractSourceFieldEntries,
+  findSourceFieldProblems,
+} from './verifyModelBuilderSourceFieldGuard.js'
+
+const SCHEMA_FIXTURE = `
+model Bot {
+  id       Int     @id @default(autoincrement())
+  name     String  @db.VarChar(256)
+  BotType  String  @db.VarChar(764)
+  imagePath String? @db.VarChar(764)
+  ArtImage ArtImage? @relation(fields: [artImageId], references: [id])
+  Chats    Chat[]
+}
+
+model Facet {
+  id        Int     @id @default(autoincrement())
+  title     String  @db.VarChar(255)
+  imagePath String? @db.Text
+  User      User?   @relation(fields: [userId], references: [id])
+}
+`
+
+const FACET_ASSIGNMENTS_FIXTURE = `
+export type FacetSummary = Pick<
+  Facet,
+  | 'id'
+  | 'title'
+  | 'imagePath'
+> & {
+  aliases: string[]
+  taxonomy: FacetTaxonomy
+  sortOrder: number
+}
+`
+
+const BUGGY_RECIPES_FIXTURE = `
+export const SOURCE_TYPES: SourceTypeConfig[] = [
+  {
+    key: 'Bot',
+    label: 'Bot',
+    titleField: 'name',
+    subtitleField: 'botType',
+    defaultRecipe: 'character-deck',
+  },
+  {
+    key: 'Facet',
+    label: 'Facet',
+    titleField: 'title',
+    subtitleField: 'kind',
+    defaultRecipe: 'art-upgrade',
+  },
+]
+`
+
+const FIXED_RECIPES_FIXTURE = `
+export const SOURCE_TYPES: SourceTypeConfig[] = [
+  {
+    key: 'Bot',
+    label: 'Bot',
+    titleField: 'name',
+    subtitleField: 'BotType',
+    defaultRecipe: 'character-deck',
+  },
+  {
+    key: 'Facet',
+    label: 'Facet',
+    titleField: 'title',
+    subtitleField: 'taxonomy',
+    defaultRecipe: 'art-upgrade',
+  },
+]
+`
+
+const TITLE_FIELD_TYPO_FIXTURE = `
+export const SOURCE_TYPES: SourceTypeConfig[] = [
+  {
+    key: 'Bot',
+    label: 'Bot',
+    titleField: 'nam',
+    subtitleField: 'BotType',
+    defaultRecipe: 'character-deck',
+  },
+]
+`
+
+// --- extractScalarFieldNames -----------------------------------------------
+
+const botFields = extractScalarFieldNames(SCHEMA_FIXTURE, 'Bot')
+assert.ok(botFields.includes('BotType'), 'expected Bot.BotType to be found')
+assert.ok(botFields.includes('imagePath'), 'expected Bot.imagePath to be found')
+assert.ok(
+  !botFields.includes('ArtImage'),
+  'expected the single relation field ArtImage to be excluded',
+)
+assert.ok(
+  !botFields.includes('Chats'),
+  'expected the list relation field Chats to be excluded',
+)
+
+assert.throws(
+  () => extractScalarFieldNames(SCHEMA_FIXTURE, 'Reward'),
+  /Could not find model Reward/,
+  'expected a missing model to throw a descriptive error',
+)
+
+// --- extractFacetSummaryExtraFields -----------------------------------------
+
+const facetExtras = extractFacetSummaryExtraFields(FACET_ASSIGNMENTS_FIXTURE)
+assert.deepEqual(
+  facetExtras,
+  ['aliases', 'taxonomy', 'sortOrder'],
+  `expected exactly the hydrated FacetSummary additions, got: ${JSON.stringify(facetExtras)}`,
+)
+
+// --- extractSourceFieldEntries ----------------------------------------------
+
+const entries = extractSourceFieldEntries(FIXED_RECIPES_FIXTURE)
+assert.deepEqual(
+  entries,
+  [
+    { key: 'Bot', titleField: 'name', subtitleField: 'BotType' },
+    { key: 'Facet', titleField: 'title', subtitleField: 'taxonomy' },
+  ],
+  `expected both SOURCE_TYPES entries parsed independent of order, got: ${JSON.stringify(entries)}`,
+)
+
+// --- findSourceFieldProblems -------------------------------------------------
+
+const buggyProblems = findSourceFieldProblems(
+  SCHEMA_FIXTURE,
+  BUGGY_RECIPES_FIXTURE,
+  FACET_ASSIGNMENTS_FIXTURE,
+)
+assert.equal(
+  buggyProblems.length,
+  2,
+  `expected the pre-fix shape (Bot's wrong-case 'botType', Facet's dropped ` +
+    `'kind') to raise 2 problems, got ${buggyProblems.length}: ` +
+    `${JSON.stringify(buggyProblems)}`,
+)
+assert.ok(
+  buggyProblems.some(
+    (p) =>
+      p.key === 'Bot' && p.which === 'subtitleField' && p.field === 'botType',
+  ),
+)
+assert.ok(
+  buggyProblems.some(
+    (p) =>
+      p.key === 'Facet' && p.which === 'subtitleField' && p.field === 'kind',
+  ),
+)
+
+const fixedProblems = findSourceFieldProblems(
+  SCHEMA_FIXTURE,
+  FIXED_RECIPES_FIXTURE,
+  FACET_ASSIGNMENTS_FIXTURE,
+)
+assert.equal(
+  fixedProblems.length,
+  0,
+  `expected the fixed shape to raise no problems, got: ${JSON.stringify(fixedProblems)}`,
+)
+
+const titleTypoProblems = findSourceFieldProblems(
+  SCHEMA_FIXTURE,
+  TITLE_FIELD_TYPO_FIXTURE,
+  FACET_ASSIGNMENTS_FIXTURE,
+)
+assert.equal(
+  titleTypoProblems.length,
+  1,
+  `expected a titleField typo to raise 1 problem, got ${titleTypoProblems.length}: ` +
+    `${JSON.stringify(titleTypoProblems)}`,
+)
+assert.equal(titleTypoProblems[0]!.which, 'titleField')
+assert.equal(titleTypoProblems[0]!.field, 'nam')
+
+console.log(
+  'Model Builder source-field guard checker verified: finds Bot.BotType ' +
+    'and Facet.imagePath as real scalar fields, excludes relation fields, ' +
+    "parses FacetSummary's hydrated additions, flags the pre-fix " +
+    'wrong-case/dropped-column shape, clears the fixed shape, and flags a ' +
+    'titleField typo.',
+)

--- a/utils/scripts/verifyModelBuilderSourceFieldGuard.ts
+++ b/utils/scripts/verifyModelBuilderSourceFieldGuard.ts
@@ -1,0 +1,245 @@
+// /utils/scripts/verifyModelBuilderSourceFieldGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 22) -- SOURCE_TYPES in
+// stores/helpers/modelBuilderRecipes.ts names a titleField/subtitleField per
+// source type: the record property model-builder-source-picker.vue reads
+// for a record's display name (store.sourceLabel) and secondary Grid/List
+// line (its own subtitle()). Both are plain `record[field]` lookups with no
+// compile-time link to the Prisma schema or to what the source type's list
+// endpoint actually returns -- a typo or a stale field name left behind by a
+// schema rename fails completely silently: `record[field]` is simply
+// `undefined`, sourceLabel() falls back to `#<id>` and subtitle() falls back
+// to '', with no error or console warning anywhere. The subtitle line for
+// every record of that source type just never renders.
+//
+// Found by inspection: Bot's subtitleField was 'botType', but the Prisma
+// field is `BotType` (capital B -- see Bot.BotType in prisma/schema.prisma)
+// -- every Bot record's Grid/List subtitle was blank. Facet's subtitleField
+// was 'kind' -- Facet.kind was dropped from the schema in t-072 (see
+// server/utils/facetAssignments.ts's own comment), and /api/facets has
+// returned a hydrated `taxonomy` field instead ever since -- so every Facet
+// record's subtitle had been silently blank since that migration landed,
+// long before this recurring task's watch began.
+//
+// This walks prisma/schema.prisma for the schema-backed source types (every
+// key except Facet, whose list endpoint returns a computed FacetSummary, not
+// a raw Facet row) and asserts titleField/subtitleField are real scalar
+// fields on that Prisma model. Facet is checked against its actual response
+// shape instead: the raw scalar Facet fields plus hydrateFacetSummaries' own
+// computed additions, parsed from the FacetSummary type in
+// server/utils/facetAssignments.ts so a future summary-shape change keeps
+// this guard honest without a hand-maintained duplicate field list.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const SCHEMA_PATH = join(repositoryRoot, 'prisma/schema.prisma')
+const MODEL_BUILDER_RECIPES_PATH = join(
+  repositoryRoot,
+  'stores/helpers/modelBuilderRecipes.ts',
+)
+const FACET_ASSIGNMENTS_PATH = join(
+  repositoryRoot,
+  'server/utils/facetAssignments.ts',
+)
+
+// Facet's list endpoint hydrates a computed summary rather than returning a
+// raw Facet row -- see FACET_ASSIGNMENTS_PATH's FacetSummary type.
+const HYDRATED_SUMMARY_SOURCE_TYPES = new Set(['Facet'])
+
+export interface SourceFieldEntry {
+  key: string
+  titleField: string
+  subtitleField?: string
+}
+
+// Every entry object literal in SOURCE_TYPES (modelBuilderRecipes.ts),
+// independent of field order within the object and of array order -- split
+// on each `key: 'X'` occurrence so every chunk holds exactly one source
+// type's config through to (but not including) the next one's key.
+export function extractSourceFieldEntries(
+  recipesFileContent: string,
+): SourceFieldEntry[] {
+  const arrayMatch = recipesFileContent.match(
+    /export const SOURCE_TYPES: SourceTypeConfig\[\] = \[([\s\S]*?)\n\]/,
+  )
+  if (!arrayMatch) {
+    throw new Error(
+      'Could not find SOURCE_TYPES array literal in modelBuilderRecipes.ts ' +
+        '-- has its shape changed?',
+    )
+  }
+  const body = arrayMatch[1]!
+  const keyMatches = [...body.matchAll(/key:\s*'(\w+)'/g)]
+  if (!keyMatches.length) {
+    throw new Error(
+      'Found the SOURCE_TYPES array literal but no key: entries inside it ' +
+        '-- has its shape changed?',
+    )
+  }
+
+  return keyMatches.map((match, index) => {
+    const start = match.index!
+    const end =
+      index + 1 < keyMatches.length
+        ? keyMatches[index + 1]!.index!
+        : body.length
+    const chunk = body.slice(start, end)
+    const titleField = chunk.match(/titleField:\s*'(\w+)'/)?.[1]
+    const subtitleField = chunk.match(/subtitleField:\s*'(\w+)'/)?.[1]
+    if (!titleField) {
+      throw new Error(
+        `SOURCE_TYPES entry '${match[1]}' has no titleField -- has its ` +
+          'shape changed?',
+      )
+    }
+    return { key: match[1]!, titleField, subtitleField }
+  })
+}
+
+function findModelBlock(schema: string, modelName: string): string | null {
+  const match = schema.match(new RegExp(`^model\\s+${modelName}\\s*\\{`, 'm'))
+  if (!match) return null
+  if (match.index === undefined) return null
+  const start = match.index + match[0].length
+  const end = schema.indexOf('\n}', start)
+  if (end === -1) return null
+  return schema.slice(start, end)
+}
+
+// Scalar column names declared directly on a Prisma model -- excludes
+// relation fields (list relations end in `[]`; single relations carry
+// `@relation`), which `prisma.<model>.findMany()` never returns without an
+// explicit `include`/`select`, and excludes `@@`-prefixed block attributes
+// and comment lines, which never match the leading `\w+` at all.
+export function extractScalarFieldNames(
+  schemaContent: string,
+  modelName: string,
+): string[] {
+  const block = findModelBlock(schemaContent, modelName)
+  if (!block) {
+    throw new Error(
+      `Could not find model ${modelName} in prisma/schema.prisma -- has it ` +
+        'been renamed?',
+    )
+  }
+  const names: string[] = []
+  for (const line of block.split('\n')) {
+    const match = line.match(/^\s*(\w+)\s+([\w[\].?]+)(.*)$/)
+    if (!match) continue
+    const [, fieldName, type, rest] = match
+    if (!fieldName || !type) continue
+    if (type.endsWith('[]')) continue // list relation
+    if (rest && rest.includes('@relation')) continue // single relation object
+    names.push(fieldName)
+  }
+  return names
+}
+
+// The computed fields hydrateFacetSummaries adds on top of the raw scalar
+// Facet columns -- parsed from FacetSummary's own `& { ... }` type literal
+// so a future summary-shape change (a field renamed or removed) keeps this
+// guard honest without a hand-maintained duplicate list.
+export function extractFacetSummaryExtraFields(
+  facetAssignmentsContent: string,
+): string[] {
+  const match = facetAssignmentsContent.match(
+    /export type FacetSummary = Pick<[\s\S]*?>\s*&\s*\{([\s\S]*?)\n\}/,
+  )
+  if (!match) {
+    throw new Error(
+      'Could not find the FacetSummary type literal in ' +
+        'server/utils/facetAssignments.ts -- has its shape changed?',
+    )
+  }
+  const names: string[] = []
+  for (const line of match[1]!.split('\n')) {
+    const fieldMatch = line.match(/^\s*(\w+)\s*:/)
+    const name = fieldMatch?.[1]
+    if (name) names.push(name)
+  }
+  return names
+}
+
+export interface SourceFieldProblem {
+  key: string
+  field: string
+  which: 'titleField' | 'subtitleField'
+}
+
+export function findSourceFieldProblems(
+  schemaContent: string,
+  recipesFileContent: string,
+  facetAssignmentsContent: string,
+): SourceFieldProblem[] {
+  const entries = extractSourceFieldEntries(recipesFileContent)
+  const facetExtraFields = extractFacetSummaryExtraFields(
+    facetAssignmentsContent,
+  )
+  const problems: SourceFieldProblem[] = []
+
+  for (const entry of entries) {
+    const scalarFields = extractScalarFieldNames(schemaContent, entry.key)
+    const allowedFields = HYDRATED_SUMMARY_SOURCE_TYPES.has(entry.key)
+      ? [...scalarFields, ...facetExtraFields]
+      : scalarFields
+
+    const checks: Array<['titleField' | 'subtitleField', string | undefined]> =
+      [
+        ['titleField', entry.titleField],
+        ['subtitleField', entry.subtitleField],
+      ]
+    for (const [which, field] of checks) {
+      if (field && !allowedFields.includes(field)) {
+        problems.push({ key: entry.key, field, which })
+      }
+    }
+  }
+
+  return problems
+}
+
+function main(): void {
+  const schemaContent = readFileSync(SCHEMA_PATH, 'utf8')
+  const recipesFileContent = readFileSync(MODEL_BUILDER_RECIPES_PATH, 'utf8')
+  const facetAssignmentsContent = readFileSync(FACET_ASSIGNMENTS_PATH, 'utf8')
+
+  const problems = findSourceFieldProblems(
+    schemaContent,
+    recipesFileContent,
+    facetAssignmentsContent,
+  )
+
+  if (problems.length) {
+    console.error(
+      `Model Builder source-field contract failed: ${problems.length} ` +
+        'SOURCE_TYPES entry(s) in stores/helpers/modelBuilderRecipes.ts ' +
+        "name a field that doesn't exist on what their list endpoint " +
+        'actually returns:',
+    )
+    for (const problem of problems) {
+      console.error(
+        `- ${problem.key}.${problem.which} = '${problem.field}' is not a ` +
+          `real property of what /api/${problem.key.toLowerCase()}... ` +
+          `returns -- model-builder-source-picker.vue's ` +
+          `${problem.which === 'titleField' ? 'store.sourceLabel()' : 'subtitle()'} ` +
+          `will silently render blank for every ${problem.key} record.`,
+      )
+    }
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder source-field contract passed: every SOURCE_TYPES ' +
+      'titleField/subtitleField names a real property of what its source ' +
+      "type's list endpoint actually returns.",
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## model-builder/t-029, cycle 22

Cycle 21's note suggested a fresh read of recipe-selector or source-picker. This cycle read both, plus their store/server call paths end to end, and found a genuine display bug in `model-builder-source-picker.vue`.

### Bug

`subtitle()` in `model-builder-source-picker.vue` does a plain `record[field]` lookup, using `SOURCE_TYPES[key].subtitleField` from `stores/helpers/modelBuilderRecipes.ts`, with no compile-time link to the Prisma schema or to what the source type's list endpoint actually returns. Two of the seven source types named a field that doesn't exist:

- **Bot**: `subtitleField` was `'botType'` (lowercase b), but the Prisma field is `BotType` (capital B — `Bot.BotType` in `prisma/schema.prisma`).
- **Facet**: `subtitleField` was `'kind'` — `Facet.kind` was dropped from the schema in t-072 (see `server/utils/facetAssignments.ts`'s own comment); `/api/facets` has returned a hydrated `taxonomy` field instead ever since.

Both mismatches fail completely silently: `record[field]` is simply `undefined`, so `subtitle()` falls back to `''` with no error anywhere. Every Bot and Facet record's secondary line in the source-picker's Grid and List views has been permanently blank — Facet's since the t-072 migration, well before this recurring task's watch began.

### Fix

Corrected both field names (`BotType`, `taxonomy`) with inline comments explaining the mismatch.

### Regression guard

Added `utils/scripts/verifyModelBuilderSourceFieldGuard.ts` (+ `.test.ts`), following the existing `verifyModelBuilder*Guard` pattern. It walks `prisma/schema.prisma` for the schema-backed source types and asserts every `SOURCE_TYPES` `titleField`/`subtitleField` is a real scalar field on that model. Facet is checked against its actual hydrated `FacetSummary` shape (parsed from `server/utils/facetAssignments.ts`) instead of the raw `Facet` model, since its list endpoint returns a computed summary, not a raw row. Confirmed the guard fails against the pre-fix field names and passes after the fix.

Wired into `package.json` (`test:model-builder-source-field-guard[-selftest]`) and `contract-tests.yml`, alongside the other model-builder guards.

### Verification

- New guard self-test: pass
- New guard contract: pass (and confirmed it fails against the original `'botType'`/`'kind'` values)
- All 105 existing `test:model-builder-*` npm scripts: pass
- `vue-tsc --noEmit` (repo-wide): clean
- `eslint` on touched files: clean
- `prettier --check` on the two new guard files: clean (the touched lines in `modelBuilderRecipes.ts` match the file's pre-existing, already-non-prettier-compliant baseline style — confirmed the file failed `prettier --check` before this change too, so this PR doesn't reformat unrelated code)
- `git status --porcelain`: only the intended 5 files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELbt1pPtPAnPKdDTaueSEm)_