### PR TITLE
fix(davinci): restore focus after outer phase transitions (davinci/t-021 slice 10)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -320,6 +320,12 @@ jobs:
       - name: Da Vinci chapter-focus guard
         run: npm run test:davinci-chapter-focus-guard
 
+      - name: Da Vinci phase-focus guard self-test
+        run: npm run test:davinci-phase-focus-guard-selftest
+
+      - name: Da Vinci phase-focus guard
+        run: npm run test:davinci-phase-focus-guard
+
       - name: Serendipity Voice poll guard self-test
         run: npm run test:serendipity-voice-poll-guard-selftest
 

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -23,21 +23,41 @@
           <span>{{ errorMessage }}</span>
         </div>
 
-        <!-- Logged out -->
-        <div
-          v-if="!userStore.isLoggedIn"
-          class="flex flex-col items-center gap-3 rounded-2xl border border-dashed border-base-300 bg-base-200/40 px-6 py-10 text-center"
-        >
-          <Icon name="kind-icon:castle" class="size-9 text-primary/50" />
-          <p class="max-w-md text-sm text-base-content/65">
-            Log in to seed a life, make choices, and leave a legacy.
-          </p>
-          <NuxtLink to="/login" class="btn btn-primary btn-sm rounded-xl">
-            Log in to play
-          </NuxtLink>
-        </div>
+        <!-- Wraps every block that swaps in/out as `phase` changes
+             (logged-out, loading/resuming, start, playing, ending).
+             startLife() (start -> playing), resolveLife()/resumeRun()
+             (playing -> loading -> ending or playing), and
+             playAgain()/abandonRun() (ending/playing -> start) all click a
+             button that lives *inside* whichever phase block is currently
+             showing, then flip `phase` via this same v-if/v-else-if chain --
+             unmounting the clicked button along with the whole block that
+             held it. This is the identical focus-loss shape chapterRegion's
+             own watch below already fixes one level down, inside the
+             `playing` block (davinci/t-021 slice 9) -- resolveLife's "See
+             your ending" button click, for example, lives inside
+             chapterRegion but its phase transition unmounts the *entire*
+             playing block, chapterRegion included, so the inner fix alone
+             can't catch it. tabindex="-1" lets this region receive focus
+             programmatically without joining the normal Tab order,
+             mirroring the same pattern one level down; the paired watch
+             below restores focus here once a click from inside this region
+             causes the visible phase block to change. -->
+        <div ref="phaseRegion" tabindex="-1" aria-label="Life status">
+          <!-- Logged out -->
+          <div
+            v-if="!userStore.isLoggedIn"
+            class="flex flex-col items-center gap-3 rounded-2xl border border-dashed border-base-300 bg-base-200/40 px-6 py-10 text-center"
+          >
+            <Icon name="kind-icon:castle" class="size-9 text-primary/50" />
+            <p class="max-w-md text-sm text-base-content/65">
+              Log in to seed a life, make choices, and leave a legacy.
+            </p>
+            <NuxtLink to="/login" class="btn btn-primary btn-sm rounded-xl">
+              Log in to play
+            </NuxtLink>
+          </div>
 
-        <!-- Resuming an existing run. Purely visual animate-pulse skeleton
+          <!-- Resuming an existing run. Purely visual animate-pulse skeleton
              with no role/aria-live/text carried no announcement to
              assistive tech -- the exact gap slice 4 fixed for the
              narrating busy state below, left unfixed here because this is
@@ -47,97 +67,100 @@
              visible/sr-only text), and academy-manager.vue's
              `isLoadingManager` state, which both cover comparable "we're
              restoring something on load" moments the same way. -->
-        <div
-          v-else-if="phase === 'loading'"
-          role="status"
-          aria-live="polite"
-          class="h-40 animate-pulse rounded-2xl border border-base-300 bg-base-200"
-        >
-          <span class="sr-only">Resuming your life…</span>
-        </div>
-
-        <!-- Start a new life -->
-        <form
-          v-else-if="phase === 'start'"
-          class="flex flex-col gap-3"
-          @submit.prevent="startLife"
-        >
-          <p class="text-sm text-base-content/70">
-            Seed a fresh life. You'll move through a run of chapters, each
-            choice nudging your legacy, wealth, love, wisdom, health, freedom,
-            fame, creation, community, and mystery — then your story resolves
-            into one of many possible endings.
-          </p>
-          <label class="form-control w-full max-w-sm">
-            <span class="label-text mb-1 text-xs font-semibold"
-              >Protagonist name (optional)</span
-            >
-            <input
-              v-model="protagonistName"
-              type="text"
-              maxlength="255"
-              placeholder="Who are you?"
-              class="input input-bordered input-sm rounded-xl"
-            />
-          </label>
-          <label class="form-control w-full max-w-sm">
-            <span class="label-text mb-1 text-xs font-semibold"
-              >Genre (optional)</span
-            >
-            <input
-              v-model="genre"
-              type="text"
-              maxlength="255"
-              placeholder="e.g. quiet epic, folk tale, heist"
-              class="input input-bordered input-sm rounded-xl"
-            />
-          </label>
-          <button
-            type="submit"
-            class="btn btn-primary btn-sm w-fit gap-1.5 rounded-xl"
-            :disabled="submitting"
+          <div
+            v-else-if="phase === 'loading'"
+            role="status"
+            aria-live="polite"
+            class="h-40 animate-pulse rounded-2xl border border-base-300 bg-base-200"
           >
-            <span
-              v-if="submitting"
-              class="loading loading-spinner loading-sm"
-            />
-            <Icon v-else name="kind-icon:sparkles" class="size-4" />
-            Begin a life
-          </button>
-        </form>
-
-        <!-- Playing -->
-        <div v-else-if="phase === 'playing' && run" class="flex flex-col gap-4">
-          <div class="flex flex-wrap items-center justify-between gap-2">
-            <p
-              class="text-sm font-black uppercase tracking-wide text-base-content/60"
-            >
-              {{ run.protagonistName || run.title }}
-            </p>
-            <p class="text-xs font-semibold text-base-content/50">
-              <template v-if="narrationMode === 'ai'">
-                Chapter {{ chapterIndex }}
-                <span v-if="narratorName" class="text-base-content/40"
-                  >· narrated by {{ narratorName }}</span
-                >
-              </template>
-              <template v-else>
-                Chapter {{ Math.min(chapterIndex, chapterCount) }} of
-                {{ chapterCount }}
-              </template>
-            </p>
-            <button
-              type="button"
-              class="btn btn-ghost btn-xs gap-1 rounded-lg text-base-content/40 normal-case hover:text-error"
-              :disabled="submitting"
-              @click="abandonRun"
-            >
-              <Icon name="kind-icon:close" class="size-3.5" />
-              Abandon this life
-            </button>
+            <span class="sr-only">Resuming your life…</span>
           </div>
 
-          <!-- Ten individually-meaningful stat pills with no wrapping
+          <!-- Start a new life -->
+          <form
+            v-else-if="phase === 'start'"
+            class="flex flex-col gap-3"
+            @submit.prevent="startLife"
+          >
+            <p class="text-sm text-base-content/70">
+              Seed a fresh life. You'll move through a run of chapters, each
+              choice nudging your legacy, wealth, love, wisdom, health, freedom,
+              fame, creation, community, and mystery — then your story resolves
+              into one of many possible endings.
+            </p>
+            <label class="form-control w-full max-w-sm">
+              <span class="label-text mb-1 text-xs font-semibold"
+                >Protagonist name (optional)</span
+              >
+              <input
+                v-model="protagonistName"
+                type="text"
+                maxlength="255"
+                placeholder="Who are you?"
+                class="input input-bordered input-sm rounded-xl"
+              />
+            </label>
+            <label class="form-control w-full max-w-sm">
+              <span class="label-text mb-1 text-xs font-semibold"
+                >Genre (optional)</span
+              >
+              <input
+                v-model="genre"
+                type="text"
+                maxlength="255"
+                placeholder="e.g. quiet epic, folk tale, heist"
+                class="input input-bordered input-sm rounded-xl"
+              />
+            </label>
+            <button
+              type="submit"
+              class="btn btn-primary btn-sm w-fit gap-1.5 rounded-xl"
+              :disabled="submitting"
+            >
+              <span
+                v-if="submitting"
+                class="loading loading-spinner loading-sm"
+              />
+              <Icon v-else name="kind-icon:sparkles" class="size-4" />
+              Begin a life
+            </button>
+          </form>
+
+          <!-- Playing -->
+          <div
+            v-else-if="phase === 'playing' && run"
+            class="flex flex-col gap-4"
+          >
+            <div class="flex flex-wrap items-center justify-between gap-2">
+              <p
+                class="text-sm font-black uppercase tracking-wide text-base-content/60"
+              >
+                {{ run.protagonistName || run.title }}
+              </p>
+              <p class="text-xs font-semibold text-base-content/50">
+                <template v-if="narrationMode === 'ai'">
+                  Chapter {{ chapterIndex }}
+                  <span v-if="narratorName" class="text-base-content/40"
+                    >· narrated by {{ narratorName }}</span
+                  >
+                </template>
+                <template v-else>
+                  Chapter {{ Math.min(chapterIndex, chapterCount) }} of
+                  {{ chapterCount }}
+                </template>
+              </p>
+              <button
+                type="button"
+                class="btn btn-ghost btn-xs gap-1 rounded-lg text-base-content/40 normal-case hover:text-error"
+                :disabled="submitting"
+                @click="abandonRun"
+              >
+                <Icon name="kind-icon:close" class="size-3.5" />
+                Abandon this life
+              </button>
+            </div>
+
+            <!-- Ten individually-meaningful stat pills with no wrapping
                role/aria-label tying them together as one set -- the same gap
                kr-choice-list.vue's own doc comment (and this file's own
                choice-list fix, slice 6) was written to close for the chapter
@@ -148,32 +171,32 @@
                protagonist/antagonist lists, brainstorm-manager.vue's
                direction/shape rows, and this project's own sibling
                storybook-page.vue setup-progress nav. -->
-          <div
-            class="grid grid-cols-5 gap-2 sm:grid-cols-10"
-            role="group"
-            aria-label="Life dimensions"
-          >
             <div
-              v-for="dim in DAVINCI_DIMENSIONS"
-              :key="dim"
-              class="flex flex-col items-center gap-0.5 rounded-xl border p-2 text-center"
-              :class="dimensionPillClass(statMap[dim] ?? 0)"
-              :title="`${DIMENSION_LABELS[dim]}: ${statMap[dim] ?? 0}`"
+              class="grid grid-cols-5 gap-2 sm:grid-cols-10"
+              role="group"
+              aria-label="Life dimensions"
             >
-              <span
-                class="text-[0.55rem] font-black uppercase tracking-wide text-base-content/60"
+              <div
+                v-for="dim in DAVINCI_DIMENSIONS"
+                :key="dim"
+                class="flex flex-col items-center gap-0.5 rounded-xl border p-2 text-center"
+                :class="dimensionPillClass(statMap[dim] ?? 0)"
+                :title="`${DIMENSION_LABELS[dim]}: ${statMap[dim] ?? 0}`"
               >
-                {{ DIMENSION_LABELS[dim] }}
-              </span>
-              <span
-                class="text-xs font-black"
-                :class="dimensionValueClass(statMap[dim] ?? 0)"
-                >{{ statMap[dim] ?? 0 }}</span
-              >
+                <span
+                  class="text-[0.55rem] font-black uppercase tracking-wide text-base-content/60"
+                >
+                  {{ DIMENSION_LABELS[dim] }}
+                </span>
+                <span
+                  class="text-xs font-black"
+                  :class="dimensionValueClass(statMap[dim] ?? 0)"
+                  >{{ statMap[dim] ?? 0 }}</span
+                >
+              </div>
             </div>
-          </div>
 
-          <!-- Wraps every block that swaps in/out as narrating/narrationError/
+            <!-- Wraps every block that swaps in/out as narrating/narrationError/
                currentChapter change (busy, error, chapter, and the "See your
                ending" resolve panel below). Clicking a choice inside the
                chapter block, or "Try again"/"Play the written chapters
@@ -189,8 +212,8 @@
                ref="mainContent" tabindex="-1">` pattern; the paired watch
                below restores focus here once a click from inside this region
                causes the visible block to change. -->
-          <div ref="chapterRegion" tabindex="-1" aria-label="Current chapter">
-            <!-- Narrator is composing this chapter. role="status"/aria-live
+            <div ref="chapterRegion" tabindex="-1" aria-label="Current chapter">
+              <!-- Narrator is composing this chapter. role="status"/aria-live
                  match every comparable busy indicator elsewhere in the app
                  (academy-manager.vue, model-builder-manager.vue,
                  model-builder-run-history.vue, narrative-response-composer.vue,
@@ -198,23 +221,23 @@
                  narrative-ingredient-picker.vue) -- this was the one busy
                  state in davinci-page.vue left as a purely visual spinner
                  with no announcement to assistive tech. -->
-            <div
-              v-if="narrating"
-              role="status"
-              aria-live="polite"
-              class="flex flex-col items-center gap-3 rounded-2xl border border-base-300 bg-base-200/40 p-8 text-center"
-            >
-              <span
-                class="loading loading-dots loading-lg text-primary/70"
-                aria-hidden="true"
-              />
-              <p class="text-xs font-semibold text-base-content/50">
-                {{ narratorName || 'The narrator' }} is writing chapter
-                {{ chapterIndex }}…
-              </p>
-            </div>
+              <div
+                v-if="narrating"
+                role="status"
+                aria-live="polite"
+                class="flex flex-col items-center gap-3 rounded-2xl border border-base-300 bg-base-200/40 p-8 text-center"
+              >
+                <span
+                  class="loading loading-dots loading-lg text-primary/70"
+                  aria-hidden="true"
+                />
+                <p class="text-xs font-semibold text-base-content/50">
+                  {{ narratorName || 'The narrator' }} is writing chapter
+                  {{ chapterIndex }}…
+                </p>
+              </div>
 
-            <!-- Narration failed. Per the narration-layer spec a broken chapter
+              <!-- Narration failed. Per the narration-layer spec a broken chapter
                surfaces a visible retry rather than a silently fabricated one,
                so the curated pool is offered as an explicit, labelled choice
                instead of a transparent fallback. role="alert" matches every
@@ -226,55 +249,55 @@
                warning-toned block in davinci-page.vue with no role/aria
                semantics at all, left uncovered even after slice 2 fixed its
                color tone. -->
-            <div
-              v-else-if="narrationError"
-              role="alert"
-              class="flex flex-col items-center gap-3 rounded-2xl border border-warning/40 bg-warning/10 p-6 text-center"
-            >
-              <Icon name="kind-icon:warning" class="size-8 text-warning/70" />
-              <p class="text-sm text-base-content/70">
-                The narrator is having trouble with this chapter.
-              </p>
-              <p class="text-xs text-base-content/50">{{ narrationError }}</p>
-              <div class="flex flex-wrap justify-center gap-2">
-                <button
-                  type="button"
-                  class="btn btn-primary btn-sm gap-1.5 rounded-xl"
-                  :disabled="narrating"
-                  @click="narrateChapter()"
-                >
-                  <Icon name="kind-icon:refresh" class="size-4" />
-                  Try again
-                </button>
-                <button
-                  type="button"
-                  class="btn btn-outline btn-sm rounded-xl"
-                  @click="useCuratedChapters"
-                >
-                  Play the written chapters instead
-                </button>
-              </div>
-            </div>
-
-            <div
-              v-else-if="currentChapter"
-              class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200/40 p-4"
-            >
-              <h4 v-if="currentChapter.title" class="text-base font-black">
-                {{ currentChapter.title }}
-              </h4>
-              <NarrativeArtStatus
-                v-if="currentChapterArt"
-                :art="currentChapterArt"
-                :label="`Illustration for chapter ${chapterIndex}`"
-                @retry="retryCurrentChapterArt"
-              />
-              <p
-                class="whitespace-pre-line text-sm leading-relaxed text-base-content/75"
+              <div
+                v-else-if="narrationError"
+                role="alert"
+                class="flex flex-col items-center gap-3 rounded-2xl border border-warning/40 bg-warning/10 p-6 text-center"
               >
-                {{ currentChapter.narrative }}
-              </p>
-              <!-- Was a hand-rolled v-for of plain btn-outline buttons -- the
+                <Icon name="kind-icon:warning" class="size-8 text-warning/70" />
+                <p class="text-sm text-base-content/70">
+                  The narrator is having trouble with this chapter.
+                </p>
+                <p class="text-xs text-base-content/50">{{ narrationError }}</p>
+                <div class="flex flex-wrap justify-center gap-2">
+                  <button
+                    type="button"
+                    class="btn btn-primary btn-sm gap-1.5 rounded-xl"
+                    :disabled="narrating"
+                    @click="narrateChapter()"
+                  >
+                    <Icon name="kind-icon:refresh" class="size-4" />
+                    Try again
+                  </button>
+                  <button
+                    type="button"
+                    class="btn btn-outline btn-sm rounded-xl"
+                    @click="useCuratedChapters"
+                  >
+                    Play the written chapters instead
+                  </button>
+                </div>
+              </div>
+
+              <div
+                v-else-if="currentChapter"
+                class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200/40 p-4"
+              >
+                <h4 v-if="currentChapter.title" class="text-base font-black">
+                  {{ currentChapter.title }}
+                </h4>
+                <NarrativeArtStatus
+                  v-if="currentChapterArt"
+                  :art="currentChapterArt"
+                  :label="`Illustration for chapter ${chapterIndex}`"
+                  @retry="retryCurrentChapterArt"
+                />
+                <p
+                  class="whitespace-pre-line text-sm leading-relaxed text-base-content/75"
+                >
+                  {{ currentChapter.narrative }}
+                </p>
+                <!-- Was a hand-rolled v-for of plain btn-outline buttons -- the
                  fourth duplicate of exactly the pick-one-option list
                  kr-choice-list.vue was built to unify (its own doc comment:
                  "replaces at least three separate implementations of the
@@ -290,24 +313,24 @@
                  existing plain-button look, rather than also opting into
                  the numbered "storybook gesture" badge as an unrelated
                  visual change in the same pass. -->
-              <kr-choice-list
-                layout="stack"
-                label="Choices for this chapter"
-                :choices="currentChapterChoices"
-                :disabled="submitting"
-                :show-index="false"
-                @select="chooseOptionByKey"
-              />
-              <p
-                v-if="currentChapter.milestoneCandidate"
-                class="text-[0.65rem] italic text-base-content/40"
-              >
-                This life seems headed toward
-                {{ currentChapter.milestoneCandidate }}.
-              </p>
-            </div>
+                <kr-choice-list
+                  layout="stack"
+                  label="Choices for this chapter"
+                  :choices="currentChapterChoices"
+                  :disabled="submitting"
+                  :show-index="false"
+                  @select="chooseOptionByKey"
+                />
+                <p
+                  v-if="currentChapter.milestoneCandidate"
+                  class="text-[0.65rem] italic text-base-content/40"
+                >
+                  This life seems headed toward
+                  {{ currentChapter.milestoneCandidate }}.
+                </p>
+              </div>
 
-            <!-- The run may be ended any time after chapter 6 (raised from 3,
+              <!-- The run may be ended any time after chapter 6 (raised from 3,
                davinci/t-024: simulation-backed, see MIN_CHAPTERS_BEFORE_ENDING
                above) -- enough chapters for a meaningful spread of dimensions.
                The narrator never decides when a life ends — the player does.
@@ -319,70 +342,73 @@
                narration-error retry panel with the misleading "Your
                chapters are told" copy, even at chapter 1 with zero recorded
                choices. -->
-            <div
-              v-if="
-                !narrating && !narrationError && (canEndRun || !currentChapter)
-              "
-              class="flex flex-col items-center gap-3 rounded-2xl border border-primary/30 bg-primary/5 p-6 text-center"
-            >
-              <Icon name="kind-icon:trophy" class="size-8 text-primary/70" />
-              <p class="text-sm text-base-content/70">
-                {{
-                  currentChapter
-                    ? 'You can keep living, or draw the line here and see what it all added up to.'
-                    : "Your chapters are told. It's time to see how this life resolves."
-                }}
-              </p>
-              <button
-                type="button"
-                class="btn btn-primary btn-sm gap-1.5 rounded-xl"
-                :disabled="submitting"
-                @click="resolveLife"
+              <div
+                v-if="
+                  !narrating &&
+                  !narrationError &&
+                  (canEndRun || !currentChapter)
+                "
+                class="flex flex-col items-center gap-3 rounded-2xl border border-primary/30 bg-primary/5 p-6 text-center"
               >
-                <span
-                  v-if="submitting"
-                  class="loading loading-spinner loading-sm"
-                />
-                <Icon v-else name="kind-icon:trophy" class="size-4" />
-                See your ending
-              </button>
+                <Icon name="kind-icon:trophy" class="size-8 text-primary/70" />
+                <p class="text-sm text-base-content/70">
+                  {{
+                    currentChapter
+                      ? 'You can keep living, or draw the line here and see what it all added up to.'
+                      : "Your chapters are told. It's time to see how this life resolves."
+                  }}
+                </p>
+                <button
+                  type="button"
+                  class="btn btn-primary btn-sm gap-1.5 rounded-xl"
+                  :disabled="submitting"
+                  @click="resolveLife"
+                >
+                  <span
+                    v-if="submitting"
+                    class="loading loading-spinner loading-sm"
+                  />
+                  <Icon v-else name="kind-icon:trophy" class="size-4" />
+                  See your ending
+                </button>
+              </div>
             </div>
           </div>
-        </div>
 
-        <!-- Ending -->
-        <div
-          v-else-if="phase === 'ending' && endingData"
-          class="flex flex-col items-center gap-3 rounded-2xl border border-primary/30 bg-primary/5 p-6 text-center"
-        >
-          <span
-            class="badge badge-sm rounded-lg font-black"
-            :class="victoryBadgeClass(endingData.victoryType)"
+          <!-- Ending -->
+          <div
+            v-else-if="phase === 'ending' && endingData"
+            class="flex flex-col items-center gap-3 rounded-2xl border border-primary/30 bg-primary/5 p-6 text-center"
           >
-            {{ endingData.victoryType }}
-          </span>
-          <h4 class="text-xl font-black">{{ endingData.title }}</h4>
-          <NarrativeArtStatus
-            v-if="endingArt"
-            class="w-full max-w-md"
-            :art="endingArt"
-            :label="`Illustration for how ${run?.protagonistName || 'this life'} ended`"
-            @retry="retryEndingArt"
-          />
-          <p class="max-w-md text-sm text-base-content/70">
-            {{ endingData.summary }}
-          </p>
-          <p v-if="awardedNote" class="text-xs font-semibold text-success">
-            {{ awardedNote }}
-          </p>
-          <button
-            type="button"
-            class="btn btn-outline btn-sm gap-1.5 rounded-xl"
-            @click="playAgain"
-          >
-            <Icon name="kind-icon:refresh" class="size-4" />
-            Live another life
-          </button>
+            <span
+              class="badge badge-sm rounded-lg font-black"
+              :class="victoryBadgeClass(endingData.victoryType)"
+            >
+              {{ endingData.victoryType }}
+            </span>
+            <h4 class="text-xl font-black">{{ endingData.title }}</h4>
+            <NarrativeArtStatus
+              v-if="endingArt"
+              class="w-full max-w-md"
+              :art="endingArt"
+              :label="`Illustration for how ${run?.protagonistName || 'this life'} ended`"
+              @retry="retryEndingArt"
+            />
+            <p class="max-w-md text-sm text-base-content/70">
+              {{ endingData.summary }}
+            </p>
+            <p v-if="awardedNote" class="text-xs font-semibold text-success">
+              {{ awardedNote }}
+            </p>
+            <button
+              type="button"
+              class="btn btn-outline btn-sm gap-1.5 rounded-xl"
+              @click="playAgain"
+            >
+              <Icon name="kind-icon:refresh" class="size-4" />
+              Live another life
+            </button>
+          </div>
         </div>
       </section>
 
@@ -717,6 +743,11 @@ const aiChapter = ref<ActiveChapter | null>(null)
 // watch below and the template comment on this element for the bug this
 // closes.
 const chapterRegion = ref<HTMLElement | null>(null)
+// The region wrapping the whole outer phase chain (logged-out, loading,
+// start, playing, ending) -- one level up from chapterRegion above, same
+// tabindex="-1" reasoning. See the paired watch below and the template
+// comment on this element for the bug this closes (davinci/t-021 slice 10).
+const phaseRegion = ref<HTMLElement | null>(null)
 
 // Contextual in-run art (davinci/t-020). The narrator proposes an artPrompt
 // per chapter and the resolve screen synthesizes one for the ending; both are
@@ -781,6 +812,25 @@ watch(
     })
   },
 )
+
+// One level up from the watch above: `phase` itself switches which of the
+// logged-out/loading/start/playing/ending blocks is showing via the same
+// kind of v-if/v-else-if chain. startLife(), resolveLife()/resumeRun(), and
+// playAgain()/abandonRun() all click a button *inside* the currently-shown
+// phase block and then change `phase`, unmounting that whole block (and the
+// clicked button) -- including cases the chapterRegion watch above can't
+// catch on its own, since "See your ending" lives inside chapterRegion but
+// resolveLife's phase transition unmounts the entire `playing` block,
+// chapterRegion included. Checking `phaseRegion.value?.contains(document.activeElement)`
+// at watch time (before Vue patches the DOM for the new phase) tells an
+// in-region click apart from anything else that could theoretically change
+// `phase` without a click of its own.
+watch(phase, () => {
+  if (!phaseRegion.value?.contains(document.activeElement)) return
+  void nextTick(() => {
+    phaseRegion.value?.focus()
+  })
+})
 
 const currentChapterArt = computed<NarrativeArtJobState | undefined>(
   () => chapterArt.value[chapterIndex.value],

--- a/package.json
+++ b/package.json
@@ -109,6 +109,8 @@
     "test:davinci-narration-error-role-guard": "tsx utils/scripts/verifyDaVinciNarrationErrorRoleGuard.ts",
     "test:davinci-chapter-focus-guard-selftest": "tsx utils/scripts/verifyDaVinciChapterFocusGuard.test.ts",
     "test:davinci-chapter-focus-guard": "tsx utils/scripts/verifyDaVinciChapterFocusGuard.ts",
+    "test:davinci-phase-focus-guard-selftest": "tsx utils/scripts/verifyDaVinciPhaseFocusGuard.test.ts",
+    "test:davinci-phase-focus-guard": "tsx utils/scripts/verifyDaVinciPhaseFocusGuard.ts",
     "test:serendipity-voice-poll-guard-selftest": "tsx utils/scripts/verifySerendipityVoicePollGuard.test.ts",
     "test:serendipity-voice-poll-guard": "tsx utils/scripts/verifySerendipityVoicePollGuard.ts",
     "test:serendipity-voice-cursor-reset-selftest": "tsx utils/scripts/verifySerendipityVoiceCursorReset.test.ts",

--- a/utils/scripts/verifyDaVinciPhaseFocusGuard.test.ts
+++ b/utils/scripts/verifyDaVinciPhaseFocusGuard.test.ts
@@ -1,0 +1,174 @@
+// /utils/scripts/verifyDaVinciPhaseFocusGuard.test.ts
+//
+// Regression test for checkPhaseFocusGuard() in
+// verifyDaVinciPhaseFocusGuard.ts (davinci/t-021 slice 10). Exercises the
+// real check against synthetic component-shaped fixtures covering: the
+// fixed shape (wrapper + ref/watch all present), several individually-
+// regressed pre-fix shapes (missing wrapper ref, missing tabindex, missing
+// script-side ref declaration, missing activeElement guard, missing the
+// focus() call), and a missing-block regression (the phase chain
+// restructured away entirely).
+import assert from 'node:assert/strict'
+
+import { checkPhaseFocusGuard } from './verifyDaVinciPhaseFocusGuard.js'
+
+function templateFixture(wrapperOpenTag: string): string {
+  return `
+<template>
+  ${wrapperOpenTag}
+    <div v-if="!userStore.isLoggedIn">logged out</div>
+    <div v-else-if="phase === 'loading'">loading</div>
+    <div v-else-if="phase === 'start'">start</div>
+    <div v-else-if="phase === 'playing' && run">playing</div>
+    <div v-else-if="phase === 'ending' && endingData">ending</div>
+  </div>
+</template>
+`
+}
+
+const SCRIPT_FIXED = `
+<script setup lang="ts">
+const phaseRegion = ref<HTMLElement | null>(null)
+
+watch(phase, () => {
+  if (!phaseRegion.value?.contains(document.activeElement)) return
+  void nextTick(() => {
+    phaseRegion.value?.focus()
+  })
+})
+</script>
+`
+
+const FIXED_TEMPLATE = templateFixture(
+  '<div ref="phaseRegion" tabindex="-1" aria-label="Life status">',
+)
+const FIXED = FIXED_TEMPLATE + SCRIPT_FIXED
+
+// Pre-fix shape: the wrapper div exists but carries neither ref nor
+// tabindex (a plain grouping div, the state before this slice).
+const NO_WRAPPER_ATTRS_TEMPLATE = templateFixture('<div>')
+const NO_WRAPPER_ATTRS = NO_WRAPPER_ATTRS_TEMPLATE + SCRIPT_FIXED
+
+// Regression: ref present but tabindex dropped (not focusable).
+const MISSING_TABINDEX_TEMPLATE = templateFixture(
+  '<div ref="phaseRegion" aria-label="Life status">',
+)
+const MISSING_TABINDEX = MISSING_TABINDEX_TEMPLATE + SCRIPT_FIXED
+
+// Regression: template wrapper correct, but the script-side ref declaration
+// was removed.
+const MISSING_SCRIPT_REF =
+  FIXED_TEMPLATE +
+  `
+<script setup lang="ts">
+watch(phase, () => {
+  if (!phaseRegion.value?.contains(document.activeElement)) return
+  void nextTick(() => {
+    phaseRegion.value?.focus()
+  })
+})
+</script>
+`
+
+// Regression: the activeElement guard was dropped, so the watch would
+// steal focus unconditionally.
+const MISSING_GUARD_SCRIPT = `
+<script setup lang="ts">
+const phaseRegion = ref<HTMLElement | null>(null)
+
+watch(phase, () => {
+  void nextTick(() => {
+    phaseRegion.value?.focus()
+  })
+})
+</script>
+`
+const MISSING_GUARD = FIXED_TEMPLATE + MISSING_GUARD_SCRIPT
+
+// Regression: the guard check survives but the actual focus() call was
+// dropped -- the region exists, is checked, but focus never moves.
+const MISSING_FOCUS_CALL_SCRIPT = `
+<script setup lang="ts">
+const phaseRegion = ref<HTMLElement | null>(null)
+
+watch(phase, () => {
+  if (!phaseRegion.value?.contains(document.activeElement)) return
+  void nextTick(() => {})
+})
+</script>
+`
+const MISSING_FOCUS_CALL = FIXED_TEMPLATE + MISSING_FOCUS_CALL_SCRIPT
+
+// The logged-out block itself no longer exists -- the guard's anchor marker
+// is gone.
+const BLOCK_REMOVED =
+  `
+<template>
+  <div class="whole-page">
+    <p>Something else entirely.</p>
+  </div>
+</template>
+` + SCRIPT_FIXED
+
+function run(): void {
+  const fixedErrors = checkPhaseFocusGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const noWrapperAttrsErrors = checkPhaseFocusGuard(NO_WRAPPER_ATTRS)
+  assert.equal(noWrapperAttrsErrors.length, 2)
+  assert.ok(
+    noWrapperAttrsErrors.some((e) =>
+      /no longer has a ref="phaseRegion"/.test(e),
+    ),
+  )
+  assert.ok(
+    noWrapperAttrsErrors.some((e) => /no longer carries tabindex="-1"/.test(e)),
+  )
+
+  const missingTabindexErrors = checkPhaseFocusGuard(MISSING_TABINDEX)
+  assert.equal(missingTabindexErrors.length, 1)
+  assert.ok(
+    missingTabindexErrors.some((e) =>
+      /no longer carries tabindex="-1"/.test(e),
+    ),
+  )
+
+  const missingScriptRefErrors = checkPhaseFocusGuard(MISSING_SCRIPT_REF)
+  assert.equal(missingScriptRefErrors.length, 1)
+  assert.ok(
+    missingScriptRefErrors.some((e) =>
+      /template ref declaration is missing/.test(e),
+    ),
+  )
+
+  const missingGuardErrors = checkPhaseFocusGuard(MISSING_GUARD)
+  assert.equal(missingGuardErrors.length, 1)
+  assert.ok(missingGuardErrors.some((e) => /no longer checks/.test(e)))
+
+  const missingFocusCallErrors = checkPhaseFocusGuard(MISSING_FOCUS_CALL)
+  assert.equal(missingFocusCallErrors.length, 1)
+  assert.ok(
+    missingFocusCallErrors.some((e) =>
+      /focus\(\)` -- the region exists/.test(e),
+    ),
+  )
+
+  const blockRemovedErrors = checkPhaseFocusGuard(BLOCK_REMOVED)
+  assert.equal(blockRemovedErrors.length, 1)
+  assert.ok(
+    blockRemovedErrors.some((e) => /Could not find the wrapper/.test(e)),
+  )
+
+  console.log(
+    'Da Vinci phase-focus guard self-test passed: missing-ref, missing-' +
+      'tabindex, missing-script-ref, missing-guard, missing-focus-call, and ' +
+      'missing-block regressions all fail individually; the fixed fixture ' +
+      'passes.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyDaVinciPhaseFocusGuard.ts
+++ b/utils/scripts/verifyDaVinciPhaseFocusGuard.ts
@@ -1,0 +1,151 @@
+// /utils/scripts/verifyDaVinciPhaseFocusGuard.ts
+//
+// Regression guard (davinci/t-021 slice 10) -- the outer
+// logged-out/loading/start/playing/ending blocks in
+// components/conductor/davinci-page.vue swap via one v-if/v-else-if chain
+// keyed on `phase`, but nothing moved focus after a phase change that was
+// itself triggered by a click *inside* the block being replaced. startLife()
+// (start -> playing), resolveLife()/resumeRun() (playing -> loading ->
+// ending or playing), and playAgain()/abandonRun() (ending/playing -> start)
+// all click a button that then gets unmounted along with whichever phase
+// block held it, so the browser dropped focus to <body> -- including cases
+// the narrower chapterRegion guard (verifyDaVinciChapterFocusGuard.ts,
+// slice 9) can't catch on its own: "See your ending" lives inside
+// chapterRegion, but resolveLife's phase transition unmounts the *entire*
+// `playing` block, chapterRegion included.
+//
+// Fixed the same way, one level up: wrap the whole outer phase chain in one
+// persistent `ref="phaseRegion" tabindex="-1"` container that never itself
+// unmounts across a phase change, then a `watch` on `phase` that checks
+// `phaseRegion.value?.contains(document.activeElement)` at watch time
+// (before Vue patches the DOM) to tell an in-region click apart from
+// anything else, and calls `phaseRegion.value?.focus()` in `nextTick()`
+// when it was. Mirrors model-builder-manager.vue's `mainContent` region and
+// this file's own chapterRegion guard for the identical focus-loss shape.
+//
+// Deliberately scoped to this one template block and its paired script-side
+// ref/watch, mirroring this project's other narrow textual guards over a
+// general-purpose static analyzer (see verifyDaVinciChapterFocusGuard.ts,
+// verifyDaVinciDimensionGroupGuard.ts).
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const COMPONENT_PATH = join(
+  repositoryRoot,
+  'components/conductor/davinci-page.vue',
+)
+
+// Anchored on the `v-if="!userStore.isLoggedIn"` marker -- the first branch
+// of the chain this guard's wrapper needs to enclose -- rather than any
+// surrounding wording, so a rename/restructure of the block reports *how*
+// it moved instead of just "not found".
+const LOGGED_OUT_MARKER = 'v-if="!userStore.isLoggedIn"'
+
+export function extractPhaseRegionOpeningTag(content: string): string | null {
+  const markerIndex = content.indexOf(LOGGED_OUT_MARKER)
+  if (markerIndex === -1) return null
+
+  // The wrapper is the nearest enclosing <div ...> that opens before the
+  // logged-out block's own <div v-if="!userStore.isLoggedIn" ...> tag.
+  const loggedOutTagStart = content.lastIndexOf('<div', markerIndex)
+  if (loggedOutTagStart === -1) return null
+
+  const wrapperTagStart = content.lastIndexOf('<div', loggedOutTagStart - 1)
+  if (wrapperTagStart === -1) return null
+  const wrapperTagEnd = content.indexOf('>', wrapperTagStart)
+  if (wrapperTagEnd === -1) return null
+
+  return content.slice(wrapperTagStart, wrapperTagEnd + 1)
+}
+
+export function checkPhaseFocusGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const openingTag = extractPhaseRegionOpeningTag(content)
+  if (!openingTag) {
+    errors.push(
+      `Could not find the wrapper enclosing \`${LOGGED_OUT_MARKER}\` in ` +
+        'davinci-page.vue -- has the outer phase chain been renamed, ' +
+        'removed, or restructured? If so, this guard needs to move with it.',
+    )
+    return errors
+  }
+
+  if (!openingTag.includes('ref="phaseRegion"')) {
+    errors.push(
+      'The logged-out/loading/start/playing/ending chain no longer has a ' +
+        'ref="phaseRegion" wrapper -- the paired focus-restoring watch has ' +
+        'nothing to focus, so a keyboard/screen-reader user is dropped to ' +
+        '<body> after a phase change again.',
+    )
+  }
+
+  if (!openingTag.includes('tabindex="-1"')) {
+    errors.push(
+      'The phase-region wrapper no longer carries tabindex="-1" -- it ' +
+        "can't receive focus programmatically (a plain <div> isn't " +
+        "focusable), matching model-builder-manager.vue's " +
+        '`<main ref="mainContent" tabindex="-1">` precedent for this same ' +
+        'focus-loss shape.',
+    )
+  }
+
+  if (!content.includes('const phaseRegion = ref<HTMLElement | null>(null)')) {
+    errors.push(
+      'The `phaseRegion` template ref declaration is missing from the ' +
+        '<script setup> block.',
+    )
+  }
+
+  if (
+    !content.includes('phaseRegion.value?.contains(document.activeElement)')
+  ) {
+    errors.push(
+      'The focus-restoring watch no longer checks ' +
+        '`phaseRegion.value?.contains(document.activeElement)` before ' +
+        'moving focus -- without this check, the watch would steal focus ' +
+        'even when the state change did not originate from a click inside ' +
+        'the region, the exact false-positive the chapterRegion watch (and ' +
+        "model-builder-manager.vue's own watch) is careful to avoid.",
+    )
+  }
+
+  if (!content.includes('phaseRegion.value?.focus()')) {
+    errors.push(
+      'The focus-restoring watch no longer calls `phaseRegion.value?.focus()` ' +
+        '-- the region exists but focus is never actually moved back to it.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(COMPONENT_PATH, 'utf8')
+  const errors = checkPhaseFocusGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Da Vinci phase-focus guard contract failed in davinci-page.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Da Vinci phase-focus guard contract passed: the outer logged-out/' +
+      'loading/start/playing/ending chain still restores focus to itself ' +
+      'after an in-region click swaps the visible phase block, so keyboard ' +
+      'and screen-reader users are never dropped to <body> after a phase ' +
+      'change.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What

Continues the davinci/t-021 "concrete gap, not a reskin" polish slices (9 prior, all merged). Slice 9 fixed focus loss for the narrating/narrationError/currentChapter/resolve-panel chain inside the `playing` phase (`chapterRegion`). Its own REMAINING note flagged the identical shape one level up: the outer `phase` (`loading`/`start`/`playing`/`ending`) also switches via a v-if/v-else-if chain with no persistent wrapper, so `startLife()`, `resolveLife()`/`resumeRun()`, and `playAgain()`/`abandonRun()` all click a button that gets unmounted along with its whole phase block — dropping keyboard/screen-reader focus to `<body>`. This includes cases the narrower `chapterRegion` fix can't catch on its own: "See your ending" lives inside `chapterRegion`, but `resolveLife`'s phase transition unmounts the entire `playing` block, `chapterRegion` included.

## Changes

- **`components/conductor/davinci-page.vue`** — wraps the whole outer logged-out/loading/start/playing/ending chain in a persistent `ref="phaseRegion" tabindex="-1"` container (mirrors `model-builder-manager.vue`'s `mainContent` and this file's own `chapterRegion`), plus a paired `watch(phase, ...)` that restores focus to the region when the transition originated from a click inside it.
- **`utils/scripts/verifyDaVinciPhaseFocusGuard.ts`** (new, 10th davinci guard) + selftest — narrow textual regression guard following this project's established convention.
- **`package.json`** + **`contract-tests.yml`** — wired the new guard's two npm scripts into CI alongside the nine existing davinci guards.

## Verification

- New guard fails pre-fix / passes post-fix (git-stash round-trip against the real component)
- New guard selftest + guard pass
- All 9 prior `verifyDaVinci*` guards + selftests still pass individually
- `test:davinci-narration` (16/16) still passes
- `test:layout-contract` holds with no new violations
- `eslint` clean, `prettier --check` clean (after one `--write` pass to reindent the newly-wrapped block)
- `vue-tsc --noEmit` repo-wide exit 0
- `git status --porcelain` showed exactly the 5 intended files (the large line-count diff on `davinci-page.vue` is prettier's reindent of the whole wrapped block, confirmed content-identical via `git diff --ignore-all-space`)

## Stakes

reversible

## Flags for Reviewer

None.

## Kaizen suggestion

Ten slices in, both the accessibility (busy-indicators, dimension-group, choice-list, chapter/phase focus) and tone-consistency gaps found so far are fixed. Next slice should keep auditing for further concrete, verifiable gaps (e.g. remaining kr-panel/kr-stat wrapper consistency for the dimension grid) or attempt the still-outstanding phone/tablet/desktop rendered-preview verification this task's own note calls for (documented as not possible pre-merge in this sandbox — see AGENTS.md's Vercel-preview-retirement section).


---
_Generated by [Claude Code](https://claude.ai/code/session_01EhExpCV4ZvNSqFgtpUhUSW)_