### PR TITLE
fix(alexa-integration): don't clobber manual fx placement on redundant on/off/toggle (t-015)

### DIFF
--- a/stores/serendipityVoiceStore.ts
+++ b/stores/serendipityVoiceStore.ts
@@ -281,22 +281,33 @@ export const useSerendipityVoiceStore = defineStore(
       }
 
       const active = animationStore.isScreenEffectActive(effectId)
-      if (command.action === 'on' && !active)
+      let stateChanged = false
+      if (command.action === 'on' && !active) {
         animationStore.toggleScreenEffect(effectId)
-      else if (command.action === 'off' && active)
+        stateChanged = true
+      } else if (command.action === 'off' && active) {
         animationStore.toggleScreenEffect(effectId)
-      else if (command.action === 'toggle')
+        stateChanged = true
+      } else if (command.action === 'toggle') {
         animationStore.toggleScreenEffect(effectId)
+        stateChanged = true
+      }
 
-      // Gate on the effect's actual resulting state, not the literal action
-      // string -- a 'toggle' that flips an active effect off ends up just
-      // as inactive as a literal 'off', and forcing its fx region to front
-      // placement anyway would bring a now-empty region to the front for
-      // no reason. Only the literal 'off' case was excluded before; only
-      // bring the region forward when the effect is actually visible
-      // afterward.
+      // Gate on whether this command actually changed the effect's active
+      // state, not just its resulting state. Gating on resulting state
+      // alone (isNowActive) still forced the region to 'front' on a
+      // redundant "turn X on" while X was already on -- e.g. after a user
+      // manually placed that region 'behind' via the Coverage Zones panel
+      // (screen-fx.vue's per-region setSurfacePlacement() control), a
+      // repeated "on" voice command for an effect already active there
+      // would silently re-home the whole region to 'front' with no user
+      // intent to move it. A 'toggle' that flips an active effect off ends
+      // up just as inactive as a literal 'off', and forcing its fx region
+      // to front placement anyway would bring a now-empty region to the
+      // front for no reason -- so also require the effect to actually be
+      // active afterward.
       const isNowActive = animationStore.isScreenEffectActive(effectId)
-      if (isNowActive) {
+      if (stateChanged && isNowActive) {
         animationStore.setSurfacePlacement(
           normalizeRegion(command.surface),
           'front',

--- a/utils/scripts/verifySerendipityVoiceActionGuard.test.ts
+++ b/utils/scripts/verifySerendipityVoiceActionGuard.test.ts
@@ -14,6 +14,7 @@ import {
   checkSerendipityVoiceActionGuard,
   checkSerendipityVoiceArtAckGuard,
   checkSerendipityVoiceErrorReportingGuard,
+  checkSerendipityVoiceRedundantOnSurfacePlacementGuard,
   checkSerendipityVoiceToggleOffSurfacePlacementGuard,
 } from './verifySerendipityVoiceActionGuard.js'
 
@@ -524,6 +525,138 @@ function runToggleOffSurfacePlacementSelfTest(): void {
   )
 }
 
+// --- Fixtures for checkSerendipityVoiceRedundantOnSurfacePlacementGuard()
+// (t-015, 2026-08-20 cycle) ---
+// Distinct from the toggle-off fixtures above: those exercise the gate's
+// *condition* (literal action string vs. resulting state); these exercise
+// whether the gate also requires an actual state *transition*, not just a
+// resulting state that happens to already hold.
+
+function redundantOnPlacementFixture(opts: {
+  toggleBranches: string
+  placementGate: string
+}): string {
+  return `
+    function applyCommand(command: VoiceBusCommand): void {
+      if (command.target !== 'animation') {
+        pushLocalMessage('system', \`Ignored unsupported command target: \${command.target}\`)
+        return
+      }
+
+      const effectId = resolveEffectId(command)
+      if (!effectId) {
+        return
+      }
+
+      const active = animationStore.isScreenEffectActive(effectId)
+      let stateChanged = false
+      ${opts.toggleBranches}
+
+      const isNowActive = animationStore.isScreenEffectActive(effectId)
+      ${opts.placementGate}
+    }
+  `
+}
+
+// Fixed: every on/off/toggle branch tracks whether it actually toggled the
+// effect, and the placement gate requires both that transition and the
+// resulting active state.
+const TOGGLE_BRANCHES_STATE_TRACKED = `if (command.action === 'on' && !active) {
+        animationStore.toggleScreenEffect(effectId)
+        stateChanged = true
+      } else if (command.action === 'off' && active) {
+        animationStore.toggleScreenEffect(effectId)
+        stateChanged = true
+      } else if (command.action === 'toggle') {
+        animationStore.toggleScreenEffect(effectId)
+        stateChanged = true
+      }`
+
+const PLACEMENT_GATE_STATE_CHANGE_FIXED = `if (stateChanged && isNowActive) {
+        animationStore.setSurfacePlacement(normalizeRegion(command.surface), 'front')
+      }`
+
+// Pre-fix (t-020's shape, before this t-015 2026-08-20 extension): no branch
+// tracks a transition at all, and the gate keys only off the resulting
+// active state -- so a redundant "turn X on" while X is already active (and
+// manually placed 'behind' via screen-fx.vue's Coverage Zones panel) still
+// forces the region to 'front' even though nothing changed.
+const TOGGLE_BRANCHES_NO_TRACKING = `if (command.action === 'on' && !active) animationStore.toggleScreenEffect(effectId)
+      else if (command.action === 'off' && active) animationStore.toggleScreenEffect(effectId)
+      else if (command.action === 'toggle') animationStore.toggleScreenEffect(effectId)`
+
+const PLACEMENT_GATE_ISNOWACTIVE_ONLY = `if (isNowActive) {
+        animationStore.setSurfacePlacement(normalizeRegion(command.surface), 'front')
+      }`
+
+const REDUNDANT_ON_PLACEMENT_FIXED = redundantOnPlacementFixture({
+  toggleBranches: TOGGLE_BRANCHES_STATE_TRACKED,
+  placementGate: PLACEMENT_GATE_STATE_CHANGE_FIXED,
+})
+
+const REDUNDANT_ON_PLACEMENT_BUGGY = redundantOnPlacementFixture({
+  toggleBranches: TOGGLE_BRANCHES_NO_TRACKING,
+  placementGate: PLACEMENT_GATE_ISNOWACTIVE_ONLY,
+})
+
+// Partial regression: stateChanged is tracked (so the tracking check
+// passes), but the gate was never updated to actually use it -- a plausible
+// half-applied edit that would silently reintroduce the same bug.
+const REDUNDANT_ON_PLACEMENT_PARTIAL_REGRESSION = redundantOnPlacementFixture({
+  toggleBranches: TOGGLE_BRANCHES_STATE_TRACKED,
+  placementGate: PLACEMENT_GATE_ISNOWACTIVE_ONLY,
+})
+
+function runRedundantOnSurfacePlacementSelfTest(): void {
+  const fixedErrors = checkSerendipityVoiceRedundantOnSurfacePlacementGuard(
+    REDUNDANT_ON_PLACEMENT_FIXED,
+  )
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed redundant-on fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const buggyErrors = checkSerendipityVoiceRedundantOnSurfacePlacementGuard(
+    REDUNDANT_ON_PLACEMENT_BUGGY,
+  )
+  assert.equal(
+    buggyErrors.length,
+    2,
+    `expected the untracked pre-fix fixture to fail twice (no tracking + no gate use), got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(
+    buggyErrors.some((e) => /no longer sets a `stateChanged = true`/.test(e)),
+  )
+  assert.ok(
+    buggyErrors.some((e) => /no longer gates setSurfacePlacement/.test(e)),
+  )
+
+  const partialErrors = checkSerendipityVoiceRedundantOnSurfacePlacementGuard(
+    REDUNDANT_ON_PLACEMENT_PARTIAL_REGRESSION,
+  )
+  assert.equal(
+    partialErrors.length,
+    1,
+    `expected the tracked-but-unused fixture to fail once, got: ${JSON.stringify(partialErrors)}`,
+  )
+  assert.ok(/no longer gates setSurfacePlacement/.test(partialErrors[0]!))
+
+  const missingFnErrors = checkSerendipityVoiceRedundantOnSurfacePlacementGuard(
+    'function someOtherFunction(): void {}',
+  )
+  assert.equal(missingFnErrors.length, 1)
+  assert.ok(/Could not find a function named/.test(missingFnErrors[0]!))
+
+  console.log(
+    'Serendipity Voice redundant-on surface-placement guard self-test ' +
+      'passed: the untracked pre-fix fixture fails on both the missing ' +
+      'tracking and the missing gate use, a tracked-but-unused-gate partial ' +
+      'regression fails once, the fixed fixture passes, and a ' +
+      'missing-function fixture fails clearly.',
+  )
+}
+
 function run(): void {
   const fixedErrors = checkSerendipityVoiceActionGuard(FIXED)
   assert.deepEqual(
@@ -580,3 +713,4 @@ run()
 runErrorReportingSelfTest()
 runArtAckSelfTest()
 runToggleOffSurfacePlacementSelfTest()
+runRedundantOnSurfacePlacementSelfTest()

--- a/utils/scripts/verifySerendipityVoiceActionGuard.ts
+++ b/utils/scripts/verifySerendipityVoiceActionGuard.ts
@@ -77,6 +77,27 @@
 // isScreenEffectActive(effectId) *after* the on/off/toggle branch runs and
 // gating setSurfacePlacement() on that resulting boolean instead of the
 // action string, so 'toggle'-to-off is treated the same as literal 'off'.
+//
+// Extended a fifth time (alexa-integration/t-015, 2026-08-20 cycle) with
+// checkSerendipityVoiceRedundantOnSurfacePlacementGuard() below -- the
+// t-021 cycle's own kaizen lead, left as an open question rather than a
+// confirmed bug: "applyCommand()'s 'on' branch always runs
+// setSurfacePlacement(region, 'front') regardless of whether the effect was
+// already active and already placed 'behind' from an earlier command...
+// worth confirming this is intentional... vs. investigating whether a
+// 'behind'-placement command path exists that this would fight against."
+// It does: components/screenfx/screen-fx.vue's "Coverage zones" panel lets a
+// user manually set any region's placement to 'behind' via
+// animationStore.setSurfacePlacement() directly, independent of voice
+// commands. Confirmed the bug: gating setSurfacePlacement() on the effect's
+// resulting active state alone (isNowActive, the t-020 fix above) still
+// forced 'front' on a redundant "turn X on" while X was already active --
+// the command caused no actual state transition, so it had no reason to
+// touch placement at all. Fixed by tracking whether the on/off/toggle
+// branch actually toggled the effect (stateChanged) and requiring both
+// stateChanged and isNowActive before calling setSurfacePlacement(), so an
+// idempotent repeat of an already-applied action no longer clobbers a
+// user's manual 'behind' placement for that region.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -528,7 +549,7 @@ export function checkSerendipityVoiceToggleOffSurfacePlacementGuard(
   }
 
   const toggleBranchIndex = commandBody.search(
-    /else if\s*\(\s*command\.action\s*===\s*'toggle'\s*\)\s*\n?\s*animationStore\.toggleScreenEffect\(effectId\)/,
+    /else if\s*\(\s*command\.action\s*===\s*'toggle'\s*\)\s*\{?\s*\n?\s*animationStore\.toggleScreenEffect\(effectId\)/,
   )
   if (toggleBranchIndex === -1) {
     errors.push(
@@ -587,9 +608,14 @@ export function checkSerendipityVoiceToggleOffSurfacePlacementGuard(
         'reintroducing the toggle-to-off false-front-placement bug.',
     )
   } else {
+    // Accepts either `if (isNowActive) {` (this check's own original
+    // shape) or `if (stateChanged && isNowActive) {` (the t-015 2026-08-20
+    // extension below, checkSerendipityVoiceRedundantOnSurfacePlacementGuard,
+    // which further requires an actual state transition) -- either way,
+    // isNowActive must still be part of what drives the gate.
     const placementGuardIndex = searchAfter(
       commandBody,
-      /if\s*\(\s*isNowActive\s*\)\s*\{/,
+      /if\s*\(\s*(?:stateChanged\s*&&\s*)?isNowActive\s*\)\s*\{/,
       recheckIndex,
     )
     if (
@@ -598,12 +624,98 @@ export function checkSerendipityVoiceToggleOffSurfacePlacementGuard(
     ) {
       errors.push(
         'applyCommand() re-checks isScreenEffectActive(effectId) but does ' +
-          'not gate setSurfacePlacement() on `if (isNowActive)` right ' +
-          'before the call -- the rechecked state must actually drive the ' +
-          'gate, not just sit unused alongside the old literal-action ' +
-          'check.',
+          'not gate setSurfacePlacement() on `if (isNowActive)` (optionally ' +
+          'combined with `stateChanged &&`) right before the call -- the ' +
+          'rechecked state must actually drive the gate, not just sit ' +
+          'unused alongside the old literal-action check.',
       )
     }
+  }
+
+  return errors
+}
+
+// Checks the "redundant on/off/toggle still forces placement" gap -- see
+// the file-header addendum above (alexa-integration/t-015, 2026-08-20
+// cycle) for what this protects against. Distinct from the guard above:
+// that one covers the placement gate keying off the wrong *condition*
+// (literal action string vs. resulting state); this one covers the gate
+// still firing on a command that caused no state *transition* at all.
+export function checkSerendipityVoiceRedundantOnSurfacePlacementGuard(
+  content: string,
+): string[] {
+  const errors: string[] = []
+
+  const commandBody = extractFunctionSource(content, 'applyCommand')
+  if (!commandBody) {
+    errors.push(
+      'Could not find a function named applyCommand() -- has it been ' +
+        'renamed, removed, or restructured? If so, this guard (and the ' +
+        'redundant-action surface-placement contract it protects) needs ' +
+        'to move with it.',
+    )
+    return errors
+  }
+
+  const onBranchIndex = commandBody.search(
+    /if\s*\(\s*command\.action\s*===\s*'on'\s*&&\s*!active\s*\)\s*\{?/,
+  )
+  if (onBranchIndex === -1) {
+    errors.push(
+      "applyCommand() no longer contains the `if (command.action === 'on' " +
+        '&& !active)` branch -- has the on/off/toggle dispatch shape ' +
+        'changed? This guard assumes that structure to locate the ' +
+        'state-change tracking it protects.',
+    )
+    return errors
+  }
+
+  const placementCallIndex = searchAfter(
+    commandBody,
+    /animationStore\.setSurfacePlacement\(/,
+    onBranchIndex,
+  )
+  if (placementCallIndex === -1) {
+    errors.push(
+      'applyCommand() no longer calls animationStore.setSurfacePlacement() ' +
+        'after the on/off/toggle branch -- has the fx-region-placement step ' +
+        'been removed or restructured? This guard assumes that call exists ' +
+        'so it can check what gates it.',
+    )
+    return errors
+  }
+
+  const gateWindow = commandBody.slice(onBranchIndex, placementCallIndex)
+
+  if (!/stateChanged\s*=\s*true/.test(gateWindow)) {
+    errors.push(
+      'applyCommand() no longer sets a `stateChanged = true` flag inside ' +
+        'the on/off/toggle branches -- without tracking whether this ' +
+        'command actually toggled the effect, the placement gate cannot ' +
+        'tell a real state transition apart from a redundant repeat of an ' +
+        'already-applied action.',
+    )
+  }
+
+  const placementGateIndex = commandBody.search(
+    /if\s*\(\s*stateChanged\s*&&\s*isNowActive\s*\)\s*\{/,
+  )
+  if (placementGateIndex === -1) {
+    errors.push(
+      'applyCommand() no longer gates setSurfacePlacement() on ' +
+        '`if (stateChanged && isNowActive)` -- gating on isNowActive alone ' +
+        "still forces the fx region to 'front' on a redundant \"turn X " +
+        'on" while X was already active there, silently clobbering a ' +
+        "region a user manually placed 'behind' via the Coverage Zones " +
+        'panel (screen-fx.vue) even though the command caused no actual ' +
+        'state change.',
+    )
+  } else if (placementGateIndex >= placementCallIndex) {
+    errors.push(
+      'applyCommand() contains the `stateChanged && isNowActive` gate, but ' +
+        'not immediately before the setSurfacePlacement() call it must ' +
+        'guard -- it needs to directly gate that call.',
+    )
   }
 
   return errors
@@ -616,11 +728,14 @@ function main(): void {
   const artAckErrors = checkSerendipityVoiceArtAckGuard(content)
   const toggleOffPlacementErrors =
     checkSerendipityVoiceToggleOffSurfacePlacementGuard(content)
+  const redundantOnPlacementErrors =
+    checkSerendipityVoiceRedundantOnSurfacePlacementGuard(content)
   const errors = [
     ...actionErrors,
     ...errorReportingErrors,
     ...artAckErrors,
     ...toggleOffPlacementErrors,
+    ...redundantOnPlacementErrors,
   ]
 
   if (errors.length) {
@@ -640,10 +755,13 @@ function main(): void {
       'false "applied" message, the unmatched-effect/unknown-theme ' +
       'no-match branches still report failure (not a false success) before ' +
       "returning, applyArtCommand()'s success path still acknowledges back " +
-      'through the relay like every other successful command target, and ' +
+      'through the relay like every other successful command target, ' +
       "applyCommand()'s surface-placement gate keys off the effect's " +
       'actual resulting active state rather than the literal action ' +
-      'string, so a toggle-to-off is treated the same as a literal off.',
+      'string, so a toggle-to-off is treated the same as a literal off, ' +
+      'and that gate also requires an actual state transition, so a ' +
+      'redundant repeat of an already-applied on/off/toggle no longer ' +
+      "clobbers a region's manually-set placement.",
   )
 }
 


### PR DESCRIPTION
## What

`applyCommand()`'s on/off/toggle branch gated its `setSurfacePlacement(region, 'front')` call on the effect's resulting active state alone (`isNowActive`). That still forced the region to `'front'` on a redundant "turn X on" while X was already active there -- silently overriding a placement a user set manually via `screen-fx.vue`'s Coverage Zones panel (`setSurfacePlacement()` called directly from that UI, independent of any voice command), even though the voice command caused no actual state change.

This closes conductor `alexa-integration/t-015`'s own kaizen lead from the prior cycle, which had left the question open ("worth confirming this is intentional... vs. investigating whether a 'behind'-placement command path exists that this would fight against"). It does exist -- `components/screenfx/screen-fx.vue`'s Coverage Zones panel.

## Changes

- `stores/serendipityVoiceStore.ts`: `applyCommand()` now tracks whether the on/off/toggle branch actually toggled the effect (`stateChanged`) and requires both `stateChanged` and `isNowActive` before calling `setSurfacePlacement()`, so an idempotent repeat of an already-applied action no longer touches placement.
- `utils/scripts/verifySerendipityVoiceActionGuard.ts`: extended with a fifth check, `checkSerendipityVoiceRedundantOnSurfacePlacementGuard()`, following the established t-020/t-021/2026-08-18/2026-08-19-cycle convention of extending the same guard file. Also loosened two existing regexes (toggle-branch shape, placement-gate shape) so they tolerate the new braces/`stateChanged &&` prefix without weakening what they check.
- `utils/scripts/verifySerendipityVoiceActionGuard.test.ts`: matching self-test with fixed / untracked-buggy / tracked-but-unused-gate / missing-function fixtures.

## Verification

- New self-test: `npm run test:serendipity-voice-action-guard-selftest` -- all 5 guard self-tests pass, including the new one (untracked pre-fix fixture fails twice, tracked-but-unused-gate partial regression fails once, fixed fixture passes, missing-function fixture fails clearly).
- `npm run test:serendipity-voice-action-guard` passes against the real fixed store.
- Sibling contract tests re-run to confirm no regression: `test:serendipity-voice-poll-guard(-selftest)`, `test:serendipity-voice-cursor-reset(-selftest)`.
- `vue-tsc --noEmit` clean repo-wide.
- `eslint`/`prettier --check` clean on all three changed files.
- `git status --porcelain` shows exactly the 3 intended files.

## Stakes
reversible

## Notes for reviewer
Traced the "does a 'behind'-placement path exist" question fully: `setSurfacePlacement()` has exactly two callers in the codebase -- `applyCommand()` (fixed here) and `screen-fx.vue`'s Coverage Zones UI (per-region placement toggle, unrelated to voice). `toggleSurface()`/`setSurface()` in `animationStore.ts` are currently unused dead exports, not a second live path.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Ye99NwEZeRiZ3SkqtRWXK)_