### PR TITLE
model-builder/t-029 cycle 24: fix stale selectedSource/selections on run reopen

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -467,6 +467,12 @@ jobs:
       - name: Model Builder stale-asset approval guard contract
         run: npm run test:model-builder-stale-asset-approval-guard
 
+      - name: Model Builder stale-selection-on-reopen guard checker self-test
+        run: npm run test:model-builder-stale-selection-on-reopen-guard-selftest
+
+      - name: Model Builder stale-selection-on-reopen guard contract
+        run: npm run test:model-builder-stale-selection-on-reopen-guard
+
       - name: Model Builder batch-editor key guard checker self-test
         run: npm run test:model-builder-batch-editor-key-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -239,6 +239,8 @@
     "test:model-builder-reset-run-guard": "tsx utils/scripts/verifyModelBuilderResetRunGuard.ts",
     "test:model-builder-stale-asset-approval-guard-selftest": "tsx utils/scripts/verifyModelBuilderStaleAssetApprovalGuard.test.ts",
     "test:model-builder-stale-asset-approval-guard": "tsx utils/scripts/verifyModelBuilderStaleAssetApprovalGuard.ts",
+    "test:model-builder-stale-selection-on-reopen-guard-selftest": "tsx utils/scripts/verifyModelBuilderStaleSelectionOnReopenGuard.test.ts",
+    "test:model-builder-stale-selection-on-reopen-guard": "tsx utils/scripts/verifyModelBuilderStaleSelectionOnReopenGuard.ts",
     "test:model-builder-batch-editor-key-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchEditorKeyGuard.test.ts",
     "test:model-builder-batch-editor-key-guard": "tsx utils/scripts/verifyModelBuilderBatchEditorKeyGuard.ts",
     "test:model-builder-batch-prefill-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchPrefillGuard.test.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -2517,6 +2517,32 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
           state.run = adaptRun(data)
           state.sourceType = data.sourceType as SourceTypeKey
           state.recipeKey = data.recipeKey as RecipeKey
+          // state.selectedSource/state.selections are never restored here --
+          // only selectSource()/selectRecipe() populate them, and this branch
+          // adopts a *different* run's sourceType/recipeKey without going
+          // through either (model-builder/t-029 cycle 24). Leaving a stale
+          // selectedSource/selections combo from an earlier in-session
+          // selectSource() call in place (rather than clearing it) is the
+          // actual bug: the header's "Recipe" crumb is enabled by
+          // `Boolean(store.selectedSource)` alone, so a stale non-null
+          // selectedSource makes it clickable, and model-builder-recipe-
+          // selector.vue would then render this *new* recipeKey's outputs
+          // against the *old* selections object -- their output keys don't
+          // overlap across recipes, so every checkbox reads unchecked while
+          // the footer's "N outputs selected" count still reflects the old
+          // recipe's leftover `on` entries, and `canStartRun` (which only
+          // checks selectedSource/recipeKey/selectedOutputCount, not whether
+          // the outputs it's counting actually belong to the current recipe)
+          // reads true -- so "Start build run" renders enabled and silently
+          // no-ops when clicked, since startRun()'s own selections lookup by
+          // the new recipe's output keys finds nothing and its itemsPayload
+          // ends up empty. Clearing both here keeps the crumb correctly
+          // disabled until the user makes a real in-session source/recipe
+          // choice again, exactly matching adaptRun's own comment that
+          // selectedSource "is only ever set by an in-session selectSource()
+          // call and is never restored on resume/reopen".
+          state.selectedSource = null
+          state.selections = {}
           state.step = 'run'
           setActiveRunId(data.id)
         }
@@ -2602,6 +2628,13 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       state.run = cached
       state.sourceType = cached.sourceType
       state.recipeKey = cached.recipeKey
+      // See the matching reset in resumeRun()'s "adopt a different run"
+      // branch (model-builder/t-029 cycle 24) for why selectedSource/
+      // selections must be cleared, not left stale, whenever sourceType/
+      // recipeKey are adopted from a run instead of selectSource()/
+      // selectRecipe() -- opening a run from History is exactly that path.
+      state.selectedSource = null
+      state.selections = {}
       state.step = 'run'
       setActiveRunId(Number(runId))
       return
@@ -2616,6 +2649,9 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         state.run = adaptRun(response.data)
         state.sourceType = state.run.sourceType
         state.recipeKey = state.run.recipeKey
+        // See the comment on the cached branch above.
+        state.selectedSource = null
+        state.selections = {}
         state.step = 'run'
         setActiveRunId(response.data.id)
       } else if (!response.success) {

--- a/utils/scripts/verifyModelBuilderStaleSelectionOnReopenGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderStaleSelectionOnReopenGuard.test.ts
@@ -1,0 +1,167 @@
+// /utils/scripts/verifyModelBuilderStaleSelectionOnReopenGuard.test.ts
+//
+// Regression test for checkStaleSelectionOnReopenGuard() in
+// verifyModelBuilderStaleSelectionOnReopenGuard.ts (model-builder/t-029,
+// cycle 24). Exercises the real check against synthetic store-shaped
+// fixtures covering: the pre-fix shape (all three adopt-a-different-run
+// branches leave state.selectedSource/state.selections untouched -- the
+// exact bug found by manual read-through of resumeRun()/openRun()), the
+// fixed shape (all three reset both fields before `state.step = 'run'`),
+// and each anchor missing entirely (function renamed/restructured).
+import assert from 'node:assert/strict'
+
+import { checkStaleSelectionOnReopenGuard } from './verifyModelBuilderStaleSelectionOnReopenGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function resumeRun(): Promise<void> {
+    try {
+      if (data) {
+        if (state.run?.id === String(data.id)) {
+          state.step = 'run'
+          setActiveRunId(data.id)
+        } else {
+          state.run = adaptRun(data)
+          state.sourceType = data.sourceType as SourceTypeKey
+          state.recipeKey = data.recipeKey as RecipeKey
+          state.step = 'run'
+          setActiveRunId(data.id)
+        }
+      }
+    } catch {}
+  }
+
+  async function openRun(runId: string): Promise<void> {
+    if (state.run?.id === runId) {
+      state.step = 'run'
+      return
+    }
+
+    const cached = state.runs.find((entry) => entry.id === runId)
+    if (cached) {
+      state.run = cached
+      state.sourceType = cached.sourceType
+      state.recipeKey = cached.recipeKey
+      state.step = 'run'
+      setActiveRunId(Number(runId))
+      return
+    }
+
+    try {
+      const response = await performFetch<ServerRun>(
+        \`/api/model-builder/runs/\${runId}\`,
+      )
+      if (response.success && response.data) {
+        state.run = adaptRun(response.data)
+        state.sourceType = state.run.sourceType
+        state.recipeKey = state.run.recipeKey
+        state.step = 'run'
+        setActiveRunId(response.data.id)
+      }
+    } catch (error) {}
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function resumeRun(): Promise<void> {
+    try {
+      if (data) {
+        if (state.run?.id === String(data.id)) {
+          state.step = 'run'
+          setActiveRunId(data.id)
+        } else {
+          state.run = adaptRun(data)
+          state.sourceType = data.sourceType as SourceTypeKey
+          state.recipeKey = data.recipeKey as RecipeKey
+          state.selectedSource = null
+          state.selections = {}
+          state.step = 'run'
+          setActiveRunId(data.id)
+        }
+      }
+    } catch {}
+  }
+
+  async function openRun(runId: string): Promise<void> {
+    if (state.run?.id === runId) {
+      state.step = 'run'
+      return
+    }
+
+    const cached = state.runs.find((entry) => entry.id === runId)
+    if (cached) {
+      state.run = cached
+      state.sourceType = cached.sourceType
+      state.recipeKey = cached.recipeKey
+      state.selectedSource = null
+      state.selections = {}
+      state.step = 'run'
+      setActiveRunId(Number(runId))
+      return
+    }
+
+    try {
+      const response = await performFetch<ServerRun>(
+        \`/api/model-builder/runs/\${runId}\`,
+      )
+      if (response.success && response.data) {
+        state.run = adaptRun(response.data)
+        state.sourceType = state.run.sourceType
+        state.recipeKey = state.run.recipeKey
+        state.selectedSource = null
+        state.selections = {}
+        state.step = 'run'
+        setActiveRunId(response.data.id)
+      }
+    } catch (error) {}
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkStaleSelectionOnReopenGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  6,
+  'expected the pre-fix shape to raise 2 errors (selectedSource + ' +
+    `selections) for each of the 3 branches (6 total), got ${buggyErrors.length}: ` +
+    `${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors.filter((e) => e.includes('state.selectedSource = null'))
+    .length === 3,
+  'expected a selectedSource-reset violation for each of the 3 branches',
+)
+assert.ok(
+  buggyErrors.filter((e) => e.includes('state.selections = {}')).length === 3,
+  'expected a selections-reset violation for each of the 3 branches',
+)
+
+const fixedErrors = checkStaleSelectionOnReopenGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingErrors = checkStaleSelectionOnReopenGuard(MISSING_FIXTURE)
+assert.equal(
+  missingErrors.length,
+  3,
+  'expected one "anchor not found" violation per branch when resumeRun/' +
+    'openRun are both absent',
+)
+for (const error of missingErrors) {
+  assert.ok(error.includes('Could not find'))
+}
+
+console.log(
+  'Model Builder stale-selection-on-reopen guard checker verified: flags ' +
+    'the pre-fix shape (all 3 branches leaving selectedSource/selections ' +
+    'stale), clears the fixed shape, and flags all 3 anchors being absent.',
+)

--- a/utils/scripts/verifyModelBuilderStaleSelectionOnReopenGuard.ts
+++ b/utils/scripts/verifyModelBuilderStaleSelectionOnReopenGuard.ts
@@ -1,0 +1,159 @@
+// /utils/scripts/verifyModelBuilderStaleSelectionOnReopenGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 24) -- resumeRun() and
+// openRun() each have a branch that adopts a *different* run's sourceType
+// and recipeKey directly (`state.sourceType = data.sourceType`, `state.
+// recipeKey = data.recipeKey`, etc.), bypassing selectSource()/
+// selectRecipe() entirely. Neither branch touched state.selectedSource or
+// state.selections, so both were left holding whatever an earlier
+// in-session selectSource()/selectRecipe() call had put there -- stale, not
+// merely absent.
+//
+// That staleness is user-visible and functional, not cosmetic: the header
+// crumb nav's "Recipe" step is enabled by `Boolean(store.selectedSource)`
+// alone (model-builder-manager.vue's `crumbs` computed), so a stale non-null
+// selectedSource left the crumb clickable after opening/resuming a
+// different run. Clicking it renders model-builder-recipe-selector.vue
+// against the *new* recipeKey's outputs (via getOutputsForRecipe) but the
+// *old* selections object -- output keys don't overlap across recipes in
+// OUTPUT_CATALOG, so every checkbox reads unchecked while
+// store.selectedOutputCount (which just counts `.on` entries in
+// state.selections, unscoped to the current recipe) still reports the old
+// recipe's leftover selections, and store.sourceLabel(store.selectedSource)
+// shows the OLD source's name/title paired with the NEW sourceType. Worse,
+// store.canStartRun only checks selectedSource/recipeKey/
+// selectedOutputCount>0, not whether those "on" selections' keys actually
+// belong to the current recipe -- so "Start build run" renders enabled and
+// silently no-ops when clicked, since startRun()'s own per-output
+// `state.selections[output.key]` lookup finds nothing for the new recipe's
+// keys and its itemsPayload ends up empty (`if (!itemsPayload.length)
+// return`, with no error/status message).
+//
+// Fixed by clearing both `state.selectedSource = null` and
+// `state.selections = {}` in all three "adopt a different run" branches
+// (resumeRun's else branch, and both of openRun's cached/fetched branches),
+// matching adaptRun's own existing comment that selectedSource "is only
+// ever set by an in-session selectSource() call and is never restored on
+// resume/reopen" -- the bug was that it could still be *wrong*, not just
+// missing. The "requested run is already the active one" early-return
+// branches in both functions are deliberately untouched: they don't adopt a
+// different run, so the current selectedSource/selections are still valid.
+//
+// This asserts the textual shape of that fix stays in place: each of the
+// three adopt-a-different-run anchor lines is followed, before the next
+// `state.step = 'run'`, by both `state.selectedSource = null` and
+// `state.selections = {}`.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const SELECTED_SOURCE_RESET = 'state.selectedSource = null'
+const SELECTIONS_RESET = 'state.selections = {}'
+const STEP_RUN = "state.step = 'run'"
+
+interface Branch {
+  name: string
+  anchor: string
+}
+
+const BRANCHES: Branch[] = [
+  {
+    name: "resumeRun()'s adopt-a-different-run branch (the `else` of `if (state.run?.id === String(data.id))`)",
+    anchor: 'state.recipeKey = data.recipeKey as RecipeKey',
+  },
+  {
+    name: "openRun()'s cached-run branch (`const cached = state.runs.find(...)`)",
+    anchor: 'state.recipeKey = cached.recipeKey',
+  },
+  {
+    name: "openRun()'s network-fetch branch (`response.success && response.data`)",
+    anchor: 'state.recipeKey = state.run.recipeKey',
+  },
+]
+
+// Checks the fix's exact shape against the full source text of a file
+// shaped like modelBuilderStore.ts. Exported so the self-test below can run
+// it against synthetic buggy/fixed fixtures without touching the real store
+// file.
+export function checkStaleSelectionOnReopenGuard(content: string): string[] {
+  const errors: string[] = []
+
+  for (const branch of BRANCHES) {
+    const anchorIndex = content.indexOf(branch.anchor)
+    if (anchorIndex === -1) {
+      errors.push(
+        `Could not find \`${branch.anchor}\` in modelBuilderStore.ts -- ` +
+          `has ${branch.name} been renamed or restructured? If so, this ` +
+          'guard needs to move with it.',
+      )
+      continue
+    }
+
+    const stepRunIndex = content.indexOf(STEP_RUN, anchorIndex)
+    const windowEnd = stepRunIndex === -1 ? content.length : stepRunIndex
+    const window = content.slice(anchorIndex, windowEnd)
+
+    if (!window.includes(SELECTED_SOURCE_RESET)) {
+      errors.push(
+        `${branch.name} no longer resets \`${SELECTED_SOURCE_RESET}\` ` +
+          "before setting the step to 'run' -- without this, a source " +
+          'picked earlier in the session (via selectSource()) stays ' +
+          "attached after this branch adopts a different run's " +
+          'sourceType/recipeKey, leaving the header\'s "Recipe" crumb ' +
+          '(enabled by `Boolean(store.selectedSource)` alone) clickable ' +
+          'into a mismatched recipe-selector screen: wrong source label, ' +
+          'wrong selected-output count, and a "Start build run" button ' +
+          'that renders enabled but silently no-ops when clicked.',
+      )
+    }
+
+    if (!window.includes(SELECTIONS_RESET)) {
+      errors.push(
+        `${branch.name} no longer resets \`${SELECTIONS_RESET}\` before ` +
+          "setting the step to 'run' -- without this, an earlier " +
+          "recipe's output selections stay in state.selections after " +
+          "this branch adopts a different run's recipeKey. Since output " +
+          'keys never overlap across recipes in OUTPUT_CATALOG, every ' +
+          'checkbox on a later visit to the recipe step would read ' +
+          'unchecked while store.selectedOutputCount still counts the ' +
+          "old recipe's leftover `on` entries -- letting canStartRun " +
+          'read true for a selection set that maps to zero real items.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkStaleSelectionOnReopenGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder stale-selection-on-reopen guard contract failed for ' +
+        'modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder stale-selection-on-reopen guard contract passed: ' +
+      'resumeRun() and openRun() both clear selectedSource/selections in ' +
+      'every branch that adopts a different run, so a stale in-session ' +
+      'source/recipe selection can never make the "Recipe" crumb or ' +
+      '"Start build run" button misleadingly clickable after opening or ' +
+      'resuming an unrelated run.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Cycle 24 investigation

Cycle 23's lead: `model-builder-recipe-selector.vue` is the least-guarded Model Builder component, worth a dedicated pass on `store.selectRecipe()`'s interaction with `getOutputsForRecipe`/`getRecipesForSource`, and whether switching recipes mid-selection correctly discards old output selections in every case, including recipes sharing output keys.

**`selectRecipe()` itself is fine.** It always fully replaces `state.selections` with a freshly-built object from `getOutputsForRecipe(key, state.sourceType)` — never merges. A literal recipe-chip click always correctly discards old selections, including for the hypothetical "shared output key" case (moot today: every output key in `OUTPUT_CATALOG` is unique to exactly one recipe).

**The real staleness gap was elsewhere: `resumeRun()` and `openRun()`.** Both have a branch that adopts a *different* run's `sourceType`/`recipeKey` directly (`state.sourceType = data.sourceType`, etc.), bypassing `selectSource()`/`selectRecipe()` entirely. Neither branch touched `state.selectedSource` or `state.selections`, leaving them holding whatever an earlier in-session `selectSource()` call had put there — **stale, not merely absent**.

This is functional, not cosmetic:
- The header crumb nav's "Recipe" step is enabled by `Boolean(store.selectedSource)` alone, so a stale non-null `selectedSource` left it clickable after opening/resuming a different run.
- Clicking it renders `model-builder-recipe-selector.vue` against the **new** recipe's outputs but the **old** selections object. Output keys never overlap across recipes, so every checkbox reads unchecked while `selectedOutputCount` still counts the old recipe's leftover `on` entries, and the "Building from X" label shows the OLD source's name paired with the NEW sourceType.
- `canStartRun` only checks `selectedSource && recipeKey && selectedOutputCount > 0`, not whether those selections' keys belong to the current recipe — so **"Start build run" renders enabled and silently no-ops when clicked** (`startRun()`'s per-output lookup finds nothing for the new recipe's keys, `itemsPayload` ends up empty, and it returns with no error/status message).

This is exactly the same known fragility a prior cycle already flagged in `adaptRun`'s own comment ("`store.selectedSource` is only ever set by an in-session `selectSource()` call and is never restored on resume/reopen") and partially fixed in `model-builder-progress-matrix.vue` (falls back to `run.sourceSnapshot`) — but the recipe-selector/crumb-nav consequence of the same gap was missed.

## Fix

Clear both `state.selectedSource = null` and `state.selections = {}` in all three "adopt a different run" branches: `resumeRun()`'s `else` branch, and both of `openRun()`'s cached/network-fetch branches. The "requested run is already active" early-return branches in both functions are untouched — they don't adopt a different run, so the current selection state is still valid there.

## New regression guard

`utils/scripts/verifyModelBuilderStaleSelectionOnReopenGuard.ts` (+ `.test.ts`), following the established guard pattern, asserts both resets stay present in all three branches. Wired into `package.json` (`test:model-builder-stale-selection-on-reopen-guard[-selftest]`) and `.github/workflows/contract-tests.yml`.

## Verification performed

- New guard self-test and contract check pass against real fixtures and the real store file.
- All 107 `test:model-builder-*` npm scripts pass (106 pre-existing + 1 new).
- `npx vue-tsc --noEmit` repo-wide: clean.
- `eslint`/`prettier --check` on all touched files: clean (the two pre-existing `no-empty` lint errors and one pre-existing prettier warning in `modelBuilderStore.ts` predate this change — confirmed via `git stash`).
- `git status --porcelain` shows only the intended files.

model-builder/t-029, cycle 24


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUKpzkRKsgAana8jrC1ekS)_