### PR TITLE
refactor(video): make presets client-owned and restore 12GB LTX path

### DIFF
--- a/pages/play/video-generator.vue
+++ b/pages/play/video-generator.vue
@@ -3,9 +3,8 @@
     <div class="kr-scroll mx-auto max-w-5xl space-y-6 p-6">
       <header class="space-y-1">
         <p class="text-sm opacity-70">
-          Animate a still into a short clip. Pick a first image (and an optional
-          end image), describe the motion, set the length, and queue it to the
-          Comfy studio engine.
+          Animate a still into a short clip. Presets choose sensible studio
+          settings, while every generation control remains editable.
         </p>
       </header>
 
@@ -14,7 +13,6 @@
         account's mana.
       </div>
 
-      <!-- Engine selector -->
       <section class="space-y-2">
         <label class="font-semibold">Engine</label>
         <div class="flex gap-2">
@@ -32,10 +30,17 @@
         <p class="text-xs opacity-60">{{ activeEngine.hint }}</p>
       </section>
 
-      <!-- Generation presets -->
       <section class="space-y-2">
-        <label class="font-semibold">Preset</label>
-        <div class="grid gap-2 sm:grid-cols-3">
+        <div class="flex items-center justify-between gap-3">
+          <label class="font-semibold">Preset</label>
+          <span
+            v-if="videoPresetId === defaultPreset.id"
+            class="badge badge-accent badge-sm"
+          >
+            Studio default
+          </span>
+        </div>
+        <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
           <button
             type="button"
             class="btn h-auto min-h-0 justify-start py-3 text-left"
@@ -45,7 +50,7 @@
             <span class="flex flex-col items-start">
               <span class="font-semibold">Custom</span>
               <span class="text-xs font-normal opacity-70">
-                Keep the manual controls below.
+                Keep the current values and tune them manually.
               </span>
             </span>
           </button>
@@ -57,8 +62,16 @@
             :class="videoPresetId === preset.id ? 'btn-accent' : 'btn-outline'"
             @click="selectVideoPreset(preset.id)"
           >
-            <span class="flex flex-col items-start">
-              <span class="font-semibold">{{ preset.label }}</span>
+            <span class="flex flex-col items-start gap-1">
+              <span class="flex items-center gap-2 font-semibold">
+                {{ preset.label }}
+                <span
+                  v-if="preset.id === defaultPreset.id"
+                  class="badge badge-xs badge-accent"
+                >
+                  default
+                </span>
+              </span>
               <span class="text-xs font-normal opacity-70">
                 {{ preset.description }}
               </span>
@@ -66,19 +79,17 @@
           </button>
         </div>
         <p class="text-xs opacity-60">
-          Presets fill the editable controls below; changing a value still
-          overrides the preset for this render.
+          Presets fill the controls below. Any value can still be changed for
+          this render.
         </p>
       </section>
 
-      <!-- Images -->
       <section class="grid gap-4 md:grid-cols-2">
-        <!-- First image (required) -->
         <div class="space-y-2 rounded-lg border border-base-300 p-3">
           <div class="flex items-center justify-between">
-            <label class="font-semibold"
-              >First image <span class="text-error">*</span></label
-            >
+            <label class="font-semibold">
+              First image <span class="text-error">*</span>
+            </label>
             <button
               type="button"
               class="btn btn-xs btn-outline"
@@ -100,6 +111,7 @@
             <img
               :src="firstImage"
               class="max-h-full max-w-full object-contain"
+              alt="First video frame"
             />
             <button
               type="button"
@@ -115,11 +127,10 @@
           </p>
         </div>
 
-        <!-- Second image (optional) -->
         <div class="space-y-2 rounded-lg border border-base-300 p-3">
-          <label class="font-semibold"
-            >End image <span class="opacity-50">(optional)</span></label
-          >
+          <label class="font-semibold">
+            End image <span class="opacity-50">(optional)</span>
+          </label>
           <input
             type="file"
             accept="image/*"
@@ -133,6 +144,7 @@
             <img
               :src="secondImage"
               class="max-h-full max-w-full object-contain"
+              alt="Last video frame"
             />
             <button
               type="button"
@@ -149,7 +161,6 @@
         </div>
       </section>
 
-      <!-- Prompt -->
       <section class="space-y-2">
         <div class="flex items-center justify-between">
           <label class="font-semibold">Motion prompt</label>
@@ -192,10 +203,9 @@
         :disabled="videoStore.isBusy"
       />
 
-      <!-- Output format -->
       <section class="space-y-2">
         <label class="font-semibold">Output format</label>
-        <div class="flex gap-2">
+        <div class="flex flex-wrap gap-2">
           <button
             v-for="opt in outputFormats"
             :key="opt.value"
@@ -210,7 +220,6 @@
         <p class="text-xs opacity-60">{{ activeOutputFormat.hint }}</p>
       </section>
 
-      <!-- Controls -->
       <section class="grid gap-4 sm:grid-cols-3">
         <div class="space-y-1">
           <label class="text-sm font-semibold">Time (seconds)</label>
@@ -242,20 +251,20 @@
               type="checkbox"
               class="toggle toggle-accent"
             />
-            <span class="text-sm opacity-70">{{
-              loop ? 'Seamless loop' : 'Play once'
-            }}</span>
+            <span class="text-sm opacity-70">
+              {{ loop ? 'Seamless loop' : 'Play once' }}
+            </span>
           </label>
         </div>
       </section>
 
       <details class="text-sm">
         <summary class="cursor-pointer opacity-70">
-          Advanced (size &amp; seed)
+          Advanced quality &amp; size
         </summary>
-        <div class="mt-2 grid gap-4 sm:grid-cols-3">
+        <div class="mt-2 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           <div class="space-y-1">
-            <label class="text-sm">Width</label>
+            <label class="text-sm">Output width</label>
             <input
               v-model.number="width"
               type="number"
@@ -266,7 +275,7 @@
             />
           </div>
           <div class="space-y-1">
-            <label class="text-sm">Height</label>
+            <label class="text-sm">Output height</label>
             <input
               v-model.number="height"
               type="number"
@@ -275,6 +284,18 @@
               step="8"
               class="input input-bordered input-sm w-full"
             />
+          </div>
+          <div class="space-y-1">
+            <label class="text-sm">LTX render scale</label>
+            <select
+              v-model.number="renderScale"
+              class="select select-bordered select-sm w-full"
+              :disabled="engine !== 'ltx'"
+            >
+              <option :value="0.5">50% + latent refine</option>
+              <option :value="0.75">75% + latent refine</option>
+              <option :value="1">100% direct</option>
+            </select>
           </div>
           <div class="space-y-1">
             <label class="text-sm">Seed (blank = random)</label>
@@ -286,13 +307,25 @@
             />
           </div>
         </div>
-        <p class="mt-1 text-xs opacity-50">
-          Estimated frames: {{ estimatedFrames }} ({{ durationSeconds }}s ×
-          {{ fps }}fps)
-        </p>
+        <div class="mt-2 flex flex-wrap gap-x-5 gap-y-1 text-xs opacity-60">
+          <span>Frames: {{ estimatedFrames }}</span>
+          <span>Output: {{ width }}×{{ height }}</span>
+          <span v-if="engine === 'ltx'">
+            First pass: {{ renderWidth }}×{{ renderHeight }}
+          </span>
+        </div>
       </details>
 
-      <!-- Generate -->
+      <div class="alert text-sm" :class="runtimeAlertClass" role="status">
+        <div class="space-y-1">
+          <p class="font-semibold">{{ runtimeTitle }}</p>
+          <p>{{ runtimeMessage }}</p>
+          <p v-if="selectedPreset?.runtimeHint" class="text-xs opacity-75">
+            {{ selectedPreset.runtimeHint }}
+          </p>
+        </div>
+      </div>
+
       <section class="space-y-3">
         <button
           type="button"
@@ -317,11 +350,6 @@
           </span>
         </div>
 
-        <!-- A failed attempt returns the job to the queue rather than ending
-             it, so this rides alongside the spinner: the run is still live,
-             but it has already failed at least once and the user should see
-             why instead of watching a wheel. Suppressed once the run ends,
-             where the fatal alert below says the same thing. -->
         <div
           v-if="videoStore.state.attemptError && videoStore.isBusy"
           class="alert alert-warning text-sm"
@@ -342,7 +370,6 @@
         </div>
       </section>
 
-      <!-- Result -->
       <section v-if="videoStore.state.videoSrc" class="space-y-2">
         <h2 class="font-semibold">Result</h2>
         <img
@@ -378,71 +405,60 @@ import { computed, ref } from 'vue'
 import { useVideoStore } from '@/stores/videoStore'
 import { useUserStore } from '@/stores/userStore'
 import {
+  estimateVideoRuntimeTier,
+  getDefaultVideoPreset,
   getVideoPreset,
   getVideoPresetsForEngine,
+  runtimeTierMessage,
+  videoFrameCount,
   type VideoEngine,
   type VideoOutputFormat,
   type VideoPresetId,
 } from '@/utils/videoPresets'
 
 const LOGO_SRC = '/images/kindlogo_new.webp'
-
-// The launch-gif test case: animate the feminine robot on the right.
 const WINK_PRESET =
   'The feminine kind robot on the right winks one eye and breaks into a warm, playful grin. Subtle head tilt, sparkling eyes, smooth natural motion, charming and friendly. The rest of the logo stays still.'
 
 const videoStore = useVideoStore()
 const userStore = useUserStore()
-
 const isLoggedIn = computed(() => userStore.isLoggedIn)
 
 const engines = [
   {
     value: 'ltx' as const,
     label: 'LTX',
-    hint: 'LTX 2.3 — fast, expressive motion. Great default for short gifs.',
+    hint: 'LTX 2.3 — expressive motion with a 12 GB-aware default and optional full-resolution quality mode.',
   },
   {
     value: 'wan' as const,
     label: 'WAN',
-    hint: 'WAN 2.x — smooth image-to-video, supports first→last frame morphs.',
+    hint: 'WAN 2.x — smooth image-to-video and first→last frame morphs.',
   },
 ]
-
-const engine = ref<VideoEngine>('ltx')
-const videoPresetId = ref<VideoPresetId | ''>('')
-const activeEngine = computed(
-  () => engines.find((e) => e.value === engine.value) ?? engines[0]!,
-)
-const availableVideoPresets = computed(() =>
-  getVideoPresetsForEngine(engine.value),
-)
 
 const outputFormats = [
   {
     value: 'webp' as const,
     label: 'WebP',
-    hint: 'Animated image, loops natively — smallest file, best default for web display (e.g. a randomized loading animation).',
+    hint: 'Animated image, loops natively — smallest file and best default for short web clips.',
   },
   {
     value: 'mp4' as const,
     label: 'MP4',
-    hint: 'Real video container — best for longer or more complex motion, plays with controls.',
+    hint: 'Real video container — best for longer or more complex motion.',
   },
   {
     value: 'webm' as const,
     label: 'WebM',
-    hint: 'Real video container, open codec — similar use case to MP4.',
+    hint: 'Open video container with a similar use case to MP4.',
   },
 ]
 
-const outputFormat = ref<VideoOutputFormat>('webp')
-const activeOutputFormat = computed(
-  () =>
-    outputFormats.find((f) => f.value === outputFormat.value) ??
-    outputFormats[0]!,
-)
-
+const initialPreset = getDefaultVideoPreset('ltx')
+const engine = ref<VideoEngine>('ltx')
+const videoPresetId = ref<VideoPresetId | ''>(initialPreset.id)
+const outputFormat = ref<VideoOutputFormat>(initialPreset.outputFormat)
 const firstImage = ref('')
 const secondImage = ref('')
 const prompt = ref(WINK_PRESET)
@@ -451,53 +467,125 @@ const loraResourceId = ref<number | null>(null)
 const loraStrength = ref(1)
 const isMature = ref(false)
 const isPublic = ref(true)
-const durationSeconds = ref(4)
-const fps = ref(24)
-const loop = ref(true)
-const width = ref<number | null>(null)
-const height = ref<number | null>(null)
+const durationSeconds = ref(initialPreset.durationSeconds)
+const fps = ref(initialPreset.fps)
+const loop = ref(initialPreset.loop)
+const width = ref(initialPreset.width)
+const height = ref(initialPreset.height)
+const renderScale = ref(initialPreset.renderScale)
+const latentUpscaleModel = ref<string | null>(initialPreset.latentUpscaleModel)
+const refineSampler = ref<string | null>(initialPreset.refineSampler)
+const refineSigmas = ref<string | null>(initialPreset.refineSigmas)
 const seedInput = ref<number | string>('')
 
-const estimatedFrames = computed(() =>
-  Math.max(2, Math.round((durationSeconds.value || 0) * (fps.value || 0)) + 1),
+const activeEngine = computed(
+  () => engines.find((item) => item.value === engine.value) ?? engines[0]!,
 )
-
+const activeOutputFormat = computed(
+  () =>
+    outputFormats.find((item) => item.value === outputFormat.value) ??
+    outputFormats[0]!,
+)
+const availableVideoPresets = computed(() =>
+  getVideoPresetsForEngine(engine.value),
+)
+const defaultPreset = computed(() => getDefaultVideoPreset(engine.value))
+const selectedPreset = computed(() => getVideoPreset(videoPresetId.value))
+const estimatedFrames = computed(() =>
+  videoFrameCount(durationSeconds.value || 0, fps.value || 0),
+)
+const renderWidth = computed(() =>
+  Math.max(64, Math.round((width.value * renderScale.value) / 8) * 8),
+)
+const renderHeight = computed(() =>
+  Math.max(64, Math.round((height.value * renderScale.value) / 8) * 8),
+)
+const runtimeTier = computed(() =>
+  estimateVideoRuntimeTier({
+    engine: engine.value,
+    width: width.value,
+    height: height.value,
+    durationSeconds: durationSeconds.value,
+    fps: fps.value,
+    renderScale: engine.value === 'ltx' ? renderScale.value : 1,
+    latentUpscaleModel:
+      engine.value === 'ltx' && renderScale.value < 1
+        ? latentUpscaleModel.value
+        : null,
+  }),
+)
+const runtimeMessage = computed(() => runtimeTierMessage(runtimeTier.value))
+const runtimeTitle = computed(() => {
+  if (runtimeTier.value === 'quick') return 'Quick render profile'
+  if (runtimeTier.value === 'balanced') return '12 GB-friendly render profile'
+  if (runtimeTier.value === 'slow') return 'Slow render warning'
+  return 'Very slow render warning'
+})
+const runtimeAlertClass = computed(() =>
+  runtimeTier.value === 'slow' || runtimeTier.value === 'very-slow'
+    ? 'alert-warning'
+    : 'alert-info',
+)
+const timeoutSeconds = computed(() => {
+  const tierTimeout = {
+    quick: 3_600,
+    balanced: 5_400,
+    slow: 10_800,
+    'very-slow': 14_400,
+  }[runtimeTier.value]
+  return Math.max(selectedPreset.value?.timeoutSeconds ?? 0, tierTimeout)
+})
 const downloadFilename = computed(
   () => `kindrobots-clip.${videoStore.state.fileType || outputFormat.value}`,
 )
-
 const canGenerate = computed(
   () =>
     isLoggedIn.value &&
     !videoStore.isBusy &&
     !!firstImage.value &&
-    !!prompt.value.trim(),
+    !!prompt.value.trim() &&
+    width.value >= 64 &&
+    height.value >= 64 &&
+    durationSeconds.value > 0 &&
+    fps.value > 0,
 )
-
 const generateLabel = computed(() => {
   if (videoStore.state.status === 'queued') return 'Queued…'
   if (videoStore.state.status === 'rendering') return 'Rendering…'
+  if (runtimeTier.value === 'very-slow') {
+    return `Generate ${engine.value.toUpperCase()} clip — very slow`
+  }
+  if (runtimeTier.value === 'slow') {
+    return `Generate ${engine.value.toUpperCase()} clip — slow`
+  }
   return `Generate ${engine.value.toUpperCase()} clip`
 })
 
-function selectEngine(nextEngine: VideoEngine): void {
-  engine.value = nextEngine
-  videoPresetId.value = ''
-}
-
-function selectVideoPreset(nextPresetId: VideoPresetId | ''): void {
-  videoPresetId.value = nextPresetId
-  if (!nextPresetId) return
-
-  const preset = getVideoPreset(nextPresetId)
-  if (!preset || preset.engine !== engine.value) return
-
+function applyPreset(preset: NonNullable<ReturnType<typeof getVideoPreset>>): void {
+  videoPresetId.value = preset.id
   width.value = preset.width
   height.value = preset.height
   durationSeconds.value = preset.durationSeconds
   fps.value = preset.fps
   loop.value = preset.loop
   outputFormat.value = preset.outputFormat
+  renderScale.value = preset.renderScale
+  latentUpscaleModel.value = preset.latentUpscaleModel
+  refineSampler.value = preset.refineSampler
+  refineSigmas.value = preset.refineSigmas
+}
+
+function selectEngine(nextEngine: VideoEngine): void {
+  engine.value = nextEngine
+  applyPreset(getDefaultVideoPreset(nextEngine))
+}
+
+function selectVideoPreset(nextPresetId: VideoPresetId | ''): void {
+  videoPresetId.value = nextPresetId
+  if (!nextPresetId) return
+  const preset = getVideoPreset(nextPresetId)
+  if (!preset || preset.engine !== engine.value) return
+  applyPreset(preset)
 }
 
 function fileToDataUrl(file: File): Promise<string> {
@@ -518,21 +606,14 @@ async function onFileChange(event: Event, slot: 'first' | 'second') {
   else secondImage.value = dataUrl
 }
 
-// Fetch the bundled logo and inline it as a data URL so it enqueues like any
-// uploaded image.
 async function useLogoAsFirst() {
   try {
     const res = await fetch(LOGO_SRC)
     const blob = await res.blob()
-    firstImage.value = await new Promise<string>((resolve, reject) => {
-      const reader = new FileReader()
-      reader.onload = () => resolve(String(reader.result))
-      reader.onerror = () => reject(reader.error)
-      reader.readAsDataURL(blob)
-    })
+    firstImage.value = await fileToDataUrl(
+      new File([blob], 'kindlogo_new.webp', { type: blob.type }),
+    )
   } catch {
-    // Fall back to the path; the enqueue endpoint also accepts data URLs only,
-    // so surface a friendly hint if the fetch failed.
     videoStore.state.error =
       'Could not load the logo image. Try uploading it manually.'
   }
@@ -545,6 +626,10 @@ async function generate() {
     seedInput.value === '' || seedInput.value === null
       ? null
       : Number(seedInput.value)
+  const shouldUpscale =
+    engine.value === 'ltx' &&
+    renderScale.value < 1 &&
+    Boolean(latentUpscaleModel.value)
 
   await videoStore.generate({
     engine: engine.value,
@@ -560,6 +645,11 @@ async function generate() {
     height: height.value,
     seed,
     outputFormat: outputFormat.value,
+    renderScale: engine.value === 'ltx' ? renderScale.value : 1,
+    latentUpscaleModel: shouldUpscale ? latentUpscaleModel.value : null,
+    refineSampler: shouldUpscale ? refineSampler.value : null,
+    refineSigmas: shouldUpscale ? refineSigmas.value : null,
+    timeoutSeconds: timeoutSeconds.value,
     loraResourceIds: loraResourceId.value ? [loraResourceId.value] : undefined,
     loraStrength: loraResourceId.value ? loraStrength.value : undefined,
     isMature: isMature.value,

--- a/server/api/art/enqueue.post.ts
+++ b/server/api/art/enqueue.post.ts
@@ -18,19 +18,11 @@ import {
 import {
   buildLtxImageToVideoWorkflow,
   ltxFrameCount,
-  LTX_DEFAULT_WIDTH,
-  LTX_DEFAULT_HEIGHT,
-  LTX_DEFAULT_DURATION,
-  LTX_DEFAULT_FRAME_RATE,
 } from '../comfy/ltx/utils/imageToVideoWorkflow'
 import { normalizeVideoOutputFormat } from '../comfy/utils/videoOutput'
 import {
   buildWanImageToVideoWorkflow,
   wanFrameCount,
-  WAN_DEFAULT_WIDTH,
-  WAN_DEFAULT_HEIGHT,
-  WAN_DEFAULT_DURATION,
-  WAN_DEFAULT_FRAME_RATE,
 } from '../comfy/wan/utils/imageToVideoWorkflow'
 import { assertArtPromptContract } from '../../utils/artPromptContract'
 import {
@@ -91,7 +83,6 @@ type ArtEnqueueRequest = {
   jsonPrompt?: Record<string, unknown> | unknown[] | null
   loraName?: string | null
   loraStrength?: number | null
-  /** Stacked LoRAs, applied in order. Supersedes the singular pair above. */
   loras?: Array<{
     resourceId?: number | null
     name?: string | null
@@ -114,8 +105,13 @@ type ArtEnqueueRequest = {
   fps?: number | null
   frameRate?: number | null
   loop?: boolean | null
-  // 'webp' (default) | 'mp4' | 'webm' — see server/api/comfy/utils/videoOutput.
   outputFormat?: string | null
+  presetId?: string | null
+  renderScale?: number | null
+  latentUpscaleModel?: string | null
+  refineSampler?: string | null
+  refineSigmas?: string | null
+  timeoutSeconds?: number | null
   workflow?: Record<string, unknown> | null
   entityArt?: EntityArtRequest | null
 }
@@ -141,8 +137,6 @@ const ENGINE_ALIASES: Record<string, EnqueueEngine> = {
   'sdxl-image': 'sdxl-img2img',
 }
 const VIDEO_ENGINES = new Set<EnqueueEngine>(['ltx', 'wan'])
-const DEFAULT_VIDEO_NEGATIVE =
-  'low quality, blurry, distorted, jittery, flickering, watermark, text, logo'
 const GATE_ENGINE: Record<
   EnqueueEngine,
   'comfy' | 'flux' | 'kontext' | 'ltx' | 'wan'
@@ -158,11 +152,8 @@ const GATE_ENGINE: Record<
   wan: 'wan',
 }
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9_-]*$/
-
-// The relay claims work by priority DESC, id ASC. /api/art/queue/[id]/priority
-// caps at 1000; 100 sits above bulk creation (0 and below) without pinning the
-// ceiling, so a genuine emergency can still be pushed past a redo.
 const DEFAULT_ENQUEUE_PRIORITY = 100
+const DEFAULT_ENQUEUE_ENGINE: EnqueueEngine = 'krea2'
 
 function asRecord(value: unknown): JsonRecord {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -195,10 +186,7 @@ function narrativeRequest(
     product !== 'taskmaster' &&
     product !== 'davinci'
   ) {
-    throw createError({
-      statusCode: 400,
-      message: 'Invalid narrative product.',
-    })
+    throw createError({ statusCode: 400, message: 'Invalid narrative product.' })
   }
   if (!sessionId || sessionId.length > 160 || !beatId || beatId.length > 160) {
     throw createError({
@@ -207,10 +195,7 @@ function narrativeRequest(
     })
   }
   if (!allowedMoments.has(moment)) {
-    throw createError({
-      statusCode: 400,
-      message: 'Invalid narrative art moment.',
-    })
+    throw createError({ statusCode: 400, message: 'Invalid narrative art moment.' })
   }
 
   const expectedKey = [product, sessionId, beatId, moment].join(':')
@@ -221,13 +206,7 @@ function narrativeRequest(
     })
   }
 
-  return {
-    product,
-    sessionId,
-    beatId,
-    moment,
-    dedupeKey,
-  }
+  return { product, sessionId, beatId, moment, dedupeKey }
 }
 
 function facetRequest(body: ArtEnqueueRequest | null): {
@@ -244,16 +223,6 @@ function facetRequest(body: ArtEnqueueRequest | null): {
     ).trim(),
   }
 }
-
-// Silas, 2026-08-09: "Nothing should be running a1111. We support it as in
-// users can add an a1111 server, but it's not used by me to build the site. We
-// are 100% comfy at this point ... comfy should generally be the default."
-//
-// So `a1111` stays a VALID engine — a user who has added their own Automatic1111
-// server can still ask for it by name — but it is no longer what you get by
-// saying nothing. An omitted engine now means krea2: Comfy, cfg 1, 8 steps,
-// random seed (server/api/comfy/krea2/utils/workflow.ts).
-const DEFAULT_ENQUEUE_ENGINE: EnqueueEngine = 'krea2'
 
 function normalizeEngine(value: unknown): EnqueueEngine {
   const raw = String(value || DEFAULT_ENQUEUE_ENGINE).toLowerCase()
@@ -342,10 +311,7 @@ export default defineEventHandler(async (event) => {
 
     const bodyWithEntityArt: ArtEnqueueRequest | null =
       entityArt?.sourceImageBase64
-        ? {
-            ...(body ?? {}),
-            sourceImageBase64: entityArt.sourceImageBase64,
-          }
+        ? { ...(body ?? {}), sourceImageBase64: entityArt.sourceImageBase64 }
         : body
 
     if (narrativeContext) {
@@ -410,10 +376,6 @@ export default defineEventHandler(async (event) => {
       facets,
     )
 
-    // Gate the FULL composed prompt — after entity context and Facet direction
-    // are folded in — because that is the string the model actually sees. Facet
-    // artPrompts and entity context are just as capable of smuggling in a
-    // conditional or a format noun as the caller's own text.
     assertArtPromptContract({
       prompt: promptString,
       engine,
@@ -421,13 +383,6 @@ export default defineEventHandler(async (event) => {
       cfg: resolvedBody.cfg ?? null,
     })
 
-    // Everything that reaches this endpoint is interactive or corrective: the
-    // entity art workbench redoing a bad image, a narrative beat a player is
-    // waiting on, a repair pass replacing art that is live and wrong. Bulk
-    // creation (the facet catalog, daily-dream builds) goes through
-    // /api/art/queue from Conductor and sits at 0 or below. Redoing bad art
-    // should outrank making new art, so this defaults to the top of the range
-    // rather than the middle of it. An explicit body.priority still wins.
     const priority = Number.isInteger(resolvedBody.priority)
       ? Number(resolvedBody.priority)
       : DEFAULT_ENQUEUE_PRIORITY
@@ -656,11 +611,6 @@ function buildJobPayload(
     }
   }
 
-  // The named-checkpoint lane. buildDefaultComfyWorkflow has always accepted a
-  // LoRA and a canvas size -- this call site simply never passed them, so a
-  // LoRA chosen in the generator was dropped on the floor and every render came
-  // out at the workflow's built-in dimensions. The sibling lanes (krea2, flux2,
-  // kontext, sdxl-img2img) all forward these; this one now does too.
   const workflow = buildDefaultComfyWorkflow({
     prompt: promptString,
     negativePrompt: body.negativePrompt ?? '',
@@ -690,28 +640,28 @@ function normalizeVideoImage(raw: string, slot: 'first' | 'last'): QueuedImage {
   }
 }
 
-function resolveVideoFrames(
-  engine: EnqueueEngine,
-  body: ArtEnqueueRequest | null | undefined,
+function requireVideoNumber(
+  value: number | null | undefined,
+  field: string,
+  min: number,
+  max: number,
 ): number {
-  const fps = clampNumber(
-    body?.fps ?? body?.frameRate,
-    engine === 'wan' ? WAN_DEFAULT_FRAME_RATE : LTX_DEFAULT_FRAME_RATE,
-    1,
-    60,
-  )
-  const duration = clampNumber(
-    body?.durationSeconds,
-    engine === 'wan' ? WAN_DEFAULT_DURATION : LTX_DEFAULT_DURATION,
-    0.25,
-    30,
-  )
-  return engine === 'wan'
-    ? wanFrameCount(duration, fps)
-    : ltxFrameCount(duration, fps)
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw createError({
+      statusCode: 400,
+      message: `Video generation requires numeric "${field}".`,
+    })
+  }
+  if (value < min || value > max) {
+    throw createError({
+      statusCode: 400,
+      message: `Video "${field}" must be between ${min} and ${max}.`,
+    })
+  }
+  return value
 }
 
-function clampNumber(
+function clampOptionalNumber(
   value: number | null | undefined,
   fallback: number,
   min: number,
@@ -722,40 +672,61 @@ function clampNumber(
   return Math.min(max, Math.max(min, numberValue))
 }
 
+function resolveVideoFrames(
+  engine: EnqueueEngine,
+  body: ArtEnqueueRequest | null | undefined,
+): number {
+  const fps = requireVideoNumber(body?.fps ?? body?.frameRate, 'fps', 1, 60)
+  const duration = requireVideoNumber(
+    body?.durationSeconds,
+    'durationSeconds',
+    0.25,
+    30,
+  )
+  return engine === 'wan'
+    ? wanFrameCount(duration, fps)
+    : ltxFrameCount(duration, fps)
+}
+
 function buildVideoJobPayload(
   engine: 'ltx' | 'wan',
   ctx: { body: ArtEnqueueRequest; promptString: string; save: SaveBlock },
 ): { jobEngine: 'COMFY'; payload: Record<string, unknown> } {
   const { body, promptString, save } = ctx
   const isWan = engine === 'wan'
-  const width = clampNumber(
-    body.width,
-    isWan ? WAN_DEFAULT_WIDTH : LTX_DEFAULT_WIDTH,
-    64,
-    2048,
-  )
-  const height = clampNumber(
-    body.height,
-    isWan ? WAN_DEFAULT_HEIGHT : LTX_DEFAULT_HEIGHT,
-    64,
-    2048,
-  )
-  const frameRate = clampNumber(
-    body.fps ?? body.frameRate,
-    isWan ? WAN_DEFAULT_FRAME_RATE : LTX_DEFAULT_FRAME_RATE,
-    1,
-    60,
-  )
-  const duration = clampNumber(
+  const width = requireVideoNumber(body.width, 'width', 64, 2048)
+  const height = requireVideoNumber(body.height, 'height', 64, 2048)
+  const frameRate = requireVideoNumber(body.fps ?? body.frameRate, 'fps', 1, 60)
+  const duration = requireVideoNumber(
     body.durationSeconds,
-    isWan ? WAN_DEFAULT_DURATION : LTX_DEFAULT_DURATION,
+    'durationSeconds',
     0.25,
     30,
   )
-  const negativePrompt = body.negativePrompt?.trim() || DEFAULT_VIDEO_NEGATIVE
+
+  if (typeof body.loop !== 'boolean') {
+    throw createError({
+      statusCode: 400,
+      message: 'Video generation requires boolean "loop".',
+    })
+  }
+  if (!body.outputFormat?.trim()) {
+    throw createError({
+      statusCode: 400,
+      message: 'Video generation requires "outputFormat".',
+    })
+  }
+  if (body.negativePrompt == null) {
+    throw createError({
+      statusCode: 400,
+      message: 'Video generation requires explicit "negativePrompt" (empty is allowed).',
+    })
+  }
+
+  const negativePrompt = body.negativePrompt.trim()
   const loraName = body.loraName?.trim() || null
   const loraStrength = loraName
-    ? clampNumber(body.loraStrength, 1, -2, 2)
+    ? clampOptionalNumber(body.loraStrength, 1, -2, 2)
     : null
   const images: QueuedImage[] = []
   let firstImageName: string | null = null
@@ -778,11 +749,35 @@ function buildVideoJobPayload(
     })
   }
 
-  const loop = Boolean(body.loop)
+  const loop = body.loop
   const outputFormat = normalizeVideoOutputFormat(body.outputFormat)
   const frames = isWan
     ? wanFrameCount(duration, frameRate)
     : ltxFrameCount(duration, frameRate)
+  const renderScale = isWan
+    ? 1
+    : requireVideoNumber(body.renderScale, 'renderScale', 0.25, 1)
+  const latentUpscaleModel = body.latentUpscaleModel?.trim() || null
+  const refineSampler = body.refineSampler?.trim() || null
+  const refineSigmas = body.refineSigmas?.trim() || null
+  const timeoutSeconds =
+    body.timeoutSeconds == null
+      ? null
+      : requireVideoNumber(body.timeoutSeconds, 'timeoutSeconds', 60, 86_400)
+  const presetId = body.presetId?.trim() || null
+
+  if (
+    !isWan &&
+    renderScale < 1 &&
+    (!latentUpscaleModel || !refineSampler || !refineSigmas)
+  ) {
+    throw createError({
+      statusCode: 400,
+      message:
+        'LTX renderScale below 1 requires latentUpscaleModel, refineSampler, and refineSigmas.',
+    })
+  }
+
   const workflow = isWan
     ? buildWanImageToVideoWorkflow({
         prompt: promptString,
@@ -818,7 +813,14 @@ function buildVideoJobPayload(
         styleLoraName: loraName,
         styleLoraStrength: loraStrength,
         outputFormat,
+        renderScale,
+        latentUpscaleModel,
+        refineSampler,
+        refineSigmas,
       })
+
+  const renderWidth = Math.max(64, Math.round((width * renderScale) / 8) * 8)
+  const renderHeight = Math.max(64, Math.round((height * renderScale) / 8) * 8)
 
   return {
     jobEngine: 'COMFY',
@@ -827,14 +829,20 @@ function buildVideoJobPayload(
       promptString,
       images,
       media: 'video',
+      timeoutSeconds,
       video: {
         model: engine,
+        presetId,
         loop,
         fps: frameRate,
         durationSeconds: duration,
         frames,
         width,
         height,
+        renderScale,
+        renderWidth,
+        renderHeight,
+        latentUpscaleModel,
         hasFirstImage: Boolean(firstImageName),
         hasLastImage: Boolean(lastImageName),
         hasLora: Boolean(loraName),

--- a/server/api/comfy/ltx/utils/imageToVideoWorkflow.ts
+++ b/server/api/comfy/ltx/utils/imageToVideoWorkflow.ts
@@ -1,18 +1,4 @@
 // /server/api/comfy/ltx/utils/imageToVideoWorkflow.ts
-//
-// LTX image-to-video ComfyUI workflow builder for the queue path.
-//
-// Mirrors the loader/sampler stack of the synchronous text2video route
-// (../text2Video.post.ts) — same checkpoint, text encoder, LoRA, VAE, sigmas —
-// but swaps the empty latent for image-conditioned latents so the motion starts
-// from a supplied still. A first image is required; an optional second image is
-// pinned to the final frame (first→last keyframe interpolation) via LTXVAddGuide.
-//
-// The workflow references its input images by NAME only. The enqueue endpoint
-// puts the actual base64 in the ArtJob payload's `images: [{ name, imageData }]`
-// array; the home relay uploads those to Comfy before running the graph, so the
-// LoadImage nodes resolve. This is the same contract the kontext queue path uses.
-
 import {
   buildVideoOutputNodes,
   normalizeVideoOutputFormat,
@@ -31,11 +17,9 @@ export type LtxImageToVideoInput = {
   prompt: string
   negativePrompt: string
   firstImageName: string
-  // When present, pinned to the final frame so the clip morphs first → last.
   lastImageName?: string | null
   width: number
   height: number
-  // Length of the clip in seconds; combined with frameRate to derive frames.
   duration: number
   frameRate: number
   seed?: number | null
@@ -43,9 +27,7 @@ export type LtxImageToVideoInput = {
   cfg?: number | null
   sampler?: string | null
   sigmas?: string | null
-  // Strength for LTX's required distilled acceleration LoRA.
   loraStrength?: number | null
-  // Optional user-selected Resource LoRA, applied after the required LTX LoRA.
   styleLoraName?: string | null
   styleLoraStrength?: number | null
   tileSize?: number | null
@@ -54,10 +36,12 @@ export type LtxImageToVideoInput = {
   temporalOverlap?: number | null
   filenamePrefix?: string | null
   outputFormat?: VideoOutputFormat | string | null
+  renderScale?: number | null
+  latentUpscaleModel?: string | null
+  refineSampler?: string | null
+  refineSigmas?: string | null
 }
 
-// Defaults match the proven text2video route so a queued clip renders with the
-// same look the synchronous path produces.
 export const LTX_DEFAULT_WIDTH = 1280
 export const LTX_DEFAULT_HEIGHT = 720
 export const LTX_DEFAULT_DURATION = 6
@@ -76,13 +60,18 @@ function resolveSeed(seed?: number | null): number {
   if (typeof seed === 'number' && Number.isFinite(seed) && seed >= 0) {
     return Math.floor(seed)
   }
-
   return Math.floor(Math.random() * 2_147_483_647)
 }
 
-// Frame count LTX expects: whole frames across the duration, +1 for the anchor
-// frame — matches the `duration * frameRate + 1` expression the text2video graph
-// computes on-device.
+function clampRenderScale(value?: number | null): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 1
+  return Math.min(1, Math.max(0.25, value))
+}
+
+function scaledDimension(value: number, scale: number): number {
+  return Math.max(64, Math.round((value * scale) / 8) * 8)
+}
+
 export function ltxFrameCount(duration: number, frameRate: number): number {
   const frames = Math.round(duration * frameRate) + 1
   return Math.max(2, frames)
@@ -97,9 +86,26 @@ export function buildLtxImageToVideoWorkflow(
   const frameRate = input.frameRate
   const length = ltxFrameCount(input.duration, frameRate)
   const hasLastFrame = Boolean(input.lastImageName)
+  const renderScale = clampRenderScale(input.renderScale)
+  const renderWidth = scaledDimension(width, renderScale)
+  const renderHeight = scaledDimension(height, renderScale)
+  const wantsUpscale = renderScale < 1
+  const latentUpscaleModel = input.latentUpscaleModel?.trim() || null
+  const refineSampler = input.refineSampler?.trim() || null
+  const refineSigmas = input.refineSigmas?.trim() || null
+
+  if (wantsUpscale && !latentUpscaleModel) {
+    throw new Error(
+      'LTX renderScale below 1 requires latentUpscaleModel so output dimensions remain explicit.',
+    )
+  }
+  if (wantsUpscale && (!refineSampler || !refineSigmas)) {
+    throw new Error(
+      'LTX latent upscale requires refineSampler and refineSigmas for the post-upscale refinement pass.',
+    )
+  }
 
   const workflow: ComfyWorkflow = {
-    // --- Loaders ------------------------------------------------------------
     '317': {
       inputs: { ckpt_name: LTX_CHECKPOINT },
       class_type: 'CheckpointLoaderSimple',
@@ -123,8 +129,6 @@ export function buildLtxImageToVideoWorkflow(
       class_type: 'LoraLoaderModelOnly',
       _meta: { title: 'Load Required LTX Distilled LoRA' },
     },
-
-    // --- Prompt conditioning -----------------------------------------------
     '319': {
       inputs: { value: input.prompt },
       class_type: 'PrimitiveStringMultiline',
@@ -149,9 +153,6 @@ export function buildLtxImageToVideoWorkflow(
       class_type: 'LTXVConditioning',
       _meta: { title: 'LTXVConditioning' },
     },
-
-    // --- Image conditioning (the i2v part) ---------------------------------
-    // First frame: load the still, encode it, and seed the video latent from it.
     img_first: {
       inputs: { image: input.firstImageName },
       class_type: 'LoadImage',
@@ -168,15 +169,14 @@ export function buildLtxImageToVideoWorkflow(
       class_type: 'ImageScale',
       _meta: { title: 'Resize First Image' },
     },
-    // LTXVImgToVideo bakes the start frame into the latent + conditioning.
     ltxv_i2v: {
       inputs: {
         positive: ['307', 0],
         negative: ['307', 1],
         vae: ['317', 2],
         image: ['img_scale', 0],
-        width,
-        height,
+        width: renderWidth,
+        height: renderHeight,
         length,
         batch_size: 1,
         strength: 1,
@@ -189,7 +189,7 @@ export function buildLtxImageToVideoWorkflow(
   let sampledModelRef: [string, number] = ['293', 0]
   const styleLoraName = input.styleLoraName?.trim()
   if (styleLoraName) {
-    workflow['video_lora'] = {
+    workflow.video_lora = {
       inputs: {
         lora_name: styleLoraName,
         strength_model: input.styleLoraStrength ?? 1,
@@ -201,20 +201,17 @@ export function buildLtxImageToVideoWorkflow(
     sampledModelRef = ['video_lora', 0]
   }
 
-  // Node ids that feed the sampler. Default: straight off LTXVImgToVideo.
   let positiveRef: [string, number] = ['ltxv_i2v', 0]
   let negativeRef: [string, number] = ['ltxv_i2v', 1]
   let latentRef: [string, number] = ['ltxv_i2v', 2]
 
   if (hasLastFrame) {
-    // Optional end frame: pin the second still to the final frame index so the
-    // motion resolves onto it. LTXVAddGuide threads through conditioning+latent.
-    workflow['img_last'] = {
+    workflow.img_last = {
       inputs: { image: input.lastImageName as string },
       class_type: 'LoadImage',
       _meta: { title: 'Load Last Image' },
     }
-    workflow['img_last_scale'] = {
+    workflow.img_last_scale = {
       inputs: {
         image: ['img_last', 0],
         upscale_method: 'lanczos',
@@ -225,14 +222,13 @@ export function buildLtxImageToVideoWorkflow(
       class_type: 'ImageScale',
       _meta: { title: 'Resize Last Image' },
     }
-    workflow['ltxv_guide'] = {
+    workflow.ltxv_guide = {
       inputs: {
         positive: ['ltxv_i2v', 0],
         negative: ['ltxv_i2v', 1],
         vae: ['317', 2],
         latent: ['ltxv_i2v', 2],
         image: ['img_last_scale', 0],
-        // -1 targets the final frame of the clip.
         frame_idx: -1,
         strength: 1,
       },
@@ -244,7 +240,6 @@ export function buildLtxImageToVideoWorkflow(
     latentRef = ['ltxv_guide', 2]
   }
 
-  // --- Sampling ------------------------------------------------------------
   workflow['286'] = {
     inputs: { noise_seed: seed },
     class_type: 'RandomNoise',
@@ -282,19 +277,119 @@ export function buildLtxImageToVideoWorkflow(
     _meta: { title: 'SamplerCustomAdvanced' },
   }
 
-  // --- Decode + encode video ----------------------------------------------
+  let finalLatentRef: [string, number] = ['291', 0]
+
+  if (wantsUpscale) {
+    workflow.ltx_crop_guides = {
+      inputs: {
+        positive: positiveRef,
+        negative: negativeRef,
+        latent: ['291', 0],
+      },
+      class_type: 'LTXVCropGuides',
+      _meta: { title: 'LTXV Crop Guides For Upscale' },
+    }
+    workflow.ltx_upscale_model = {
+      inputs: { model_name: latentUpscaleModel as string },
+      class_type: 'LatentUpscaleModelLoader',
+      _meta: { title: 'Load LTX Latent Upscale Model' },
+    }
+    workflow.ltx_upscale = {
+      inputs: {
+        samples: ['291', 0],
+        upscale_model: ['ltx_upscale_model', 0],
+        vae: ['317', 2],
+      },
+      class_type: 'LTXVLatentUpsampler',
+      _meta: { title: 'LTXV Latent Upsampler' },
+    }
+    workflow.ltx_recondition = {
+      inputs: {
+        strength: 1,
+        bypass: false,
+        vae: ['317', 2],
+        image: ['img_scale', 0],
+        latent: ['ltx_upscale', 0],
+      },
+      class_type: 'LTXVImgToVideoInplace',
+      _meta: { title: 'Reapply First Frame After Upscale' },
+    }
+
+    let refinePositiveRef: [string, number] = ['ltx_crop_guides', 0]
+    let refineNegativeRef: [string, number] = ['ltx_crop_guides', 1]
+    let refineLatentRef: [string, number] = ['ltx_recondition', 0]
+
+    if (hasLastFrame) {
+      workflow.ltx_refine_last_guide = {
+        inputs: {
+          positive: refinePositiveRef,
+          negative: refineNegativeRef,
+          vae: ['317', 2],
+          latent: refineLatentRef,
+          image: ['img_last_scale', 0],
+          frame_idx: -1,
+          strength: 1,
+        },
+        class_type: 'LTXVAddGuide',
+        _meta: { title: 'Reapply End Frame After Upscale' },
+      }
+      refinePositiveRef = ['ltx_refine_last_guide', 0]
+      refineNegativeRef = ['ltx_refine_last_guide', 1]
+      refineLatentRef = ['ltx_refine_last_guide', 2]
+    }
+
+    workflow.ltx_refine_noise = {
+      inputs: { noise_seed: (seed + 1) % 2_147_483_647 },
+      class_type: 'RandomNoise',
+      _meta: { title: 'Refinement Noise' },
+    }
+    workflow.ltx_refine_sampler = {
+      inputs: { sampler_name: refineSampler as string },
+      class_type: 'KSamplerSelect',
+      _meta: { title: 'Refinement Sampler' },
+    }
+    workflow.ltx_refine_sigmas = {
+      inputs: { sigmas: refineSigmas as string },
+      class_type: 'ManualSigmas',
+      _meta: { title: 'Refinement Sigmas' },
+    }
+    workflow.ltx_refine_guider = {
+      inputs: {
+        cfg: input.cfg ?? LTX_DEFAULT_CFG,
+        model: sampledModelRef,
+        positive: refinePositiveRef,
+        negative: refineNegativeRef,
+      },
+      class_type: 'CFGGuider',
+      _meta: { title: 'Refinement CFG Guider' },
+    }
+    workflow.ltx_refine_sample = {
+      inputs: {
+        noise: ['ltx_refine_noise', 0],
+        guider: ['ltx_refine_guider', 0],
+        sampler: ['ltx_refine_sampler', 0],
+        sigmas: ['ltx_refine_sigmas', 0],
+        latent_image: refineLatentRef,
+      },
+      class_type: 'SamplerCustomAdvanced',
+      _meta: { title: 'Post-upscale Refinement' },
+    }
+    finalLatentRef = ['ltx_refine_sample', 0]
+  }
+
   workflow['316'] = {
     inputs: {
       tile_size: input.tileSize ?? 768,
       overlap: input.tileOverlap ?? 64,
       temporal_size: input.temporalSize ?? 4096,
       temporal_overlap: input.temporalOverlap ?? 4,
-      samples: ['291', 0],
+      samples: finalLatentRef,
       vae: ['317', 2],
     },
     class_type: 'VAEDecodeTiled',
     _meta: { title: 'VAE Decode Tiled' },
   }
+
   Object.assign(
     workflow,
     buildVideoOutputNodes({

--- a/server/api/video/generate.post.ts
+++ b/server/api/video/generate.post.ts
@@ -1,19 +1,8 @@
 import { createError, defineEventHandler, readBody } from 'h3'
-import {
-  getVideoPreset,
-  type VideoEngine,
-} from '../../../utils/videoPresets'
+import type { VideoEngine } from '../../../utils/videoPresets'
 
 type VideoGenerateRequest = Record<string, unknown> & {
   engine?: string | null
-  presetId?: string | null
-  width?: number | null
-  height?: number | null
-  durationSeconds?: number | null
-  fps?: number | null
-  frameRate?: number | null
-  loop?: boolean | null
-  outputFormat?: string | null
 }
 
 type VideoGenerateResponse = {
@@ -35,36 +24,12 @@ function normalizeEngine(value: unknown): VideoEngine {
 export default defineEventHandler(async (event) => {
   const body = (await readBody(event)) as VideoGenerateRequest | null
   const engine = normalizeEngine(body?.engine)
-  const presetId = body?.presetId?.trim() || null
-  const preset = getVideoPreset(presetId)
-
-  if (presetId && !preset) {
-    throw createError({
-      statusCode: 400,
-      message: `Unknown video preset "${presetId}".`,
-    })
-  }
-  if (preset && preset.engine !== engine) {
-    throw createError({
-      statusCode: 400,
-      message: `Video preset "${preset.id}" requires engine "${preset.engine}".`,
-    })
-  }
-
-  const resolvedBody: VideoGenerateRequest = {
-    ...(body ?? {}),
-    engine,
-    presetId,
-    width: body?.width ?? preset?.width,
-    height: body?.height ?? preset?.height,
-    durationSeconds: body?.durationSeconds ?? preset?.durationSeconds,
-    fps: body?.fps ?? body?.frameRate ?? preset?.fps,
-    loop: body?.loop ?? preset?.loop,
-    outputFormat: body?.outputFormat ?? preset?.outputFormat,
-  }
 
   return event.$fetch<VideoGenerateResponse, string>('/api/art/enqueue', {
     method: 'POST',
-    body: resolvedBody,
+    body: {
+      ...(body ?? {}),
+      engine,
+    },
   })
 })

--- a/stores/videoStore.ts
+++ b/stores/videoStore.ts
@@ -24,18 +24,22 @@ export interface GenerateVideoParams {
   presetId?: VideoPresetId | null
   promptString: string
   negativePrompt?: string
-  // Base64 data URLs (or raw base64). First is required, second optional.
   firstImageBase64: string
   secondImageBase64?: string | null
   durationSeconds: number
   fps: number
   loop: boolean
-  width?: number | null
-  height?: number | null
+  width: number
+  height: number
   seed?: number | null
   loraResourceIds?: number[]
   loraStrength?: number | null
-  outputFormat?: VideoOutputFormat
+  outputFormat: VideoOutputFormat
+  renderScale?: number | null
+  latentUpscaleModel?: string | null
+  refineSampler?: string | null
+  refineSigmas?: string | null
+  timeoutSeconds?: number | null
   isPublic?: boolean
   isMature?: boolean
   designer?: string | null
@@ -47,22 +51,15 @@ type QueuedJob = {
   status: 'PENDING' | 'RUNNING' | 'DONE' | 'FAILED' | 'CANCELLED'
   artImageId?: number | null
   error?: string | null
-  // How many times the relay has taken this job and reported back. The queue
-  // retries a failed job by returning it to PENDING (see
-  // server/api/art/queue/[id]/complete.post.ts), so a job on attempt 2 is
-  // indistinguishable from a fresh one without this.
   attempts?: number | null
 }
 
 const POLL_MS = 5_000
-const TIMEOUT_MS = 20 * 60_000
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-// webp/gif clips are animated *images* (render as <img>, loop natively);
-// mp4/webm are real video containers (render as <video>).
 const IMAGE_CLIP_TYPES = new Set(['webp', 'gif'])
 
 export function isImageClipFileType(
@@ -71,10 +68,6 @@ export function isImageClipFileType(
   return IMAGE_CLIP_TYPES.has((fileType || '').toLowerCase())
 }
 
-// Resolve a finished ArtImage (fileType webp/gif/mp4/webm) into a playable
-// src. Handles inline base64 clips and stored paths, same shape as
-// artImageToSrc but clip-aware (data:video/... , data:image/... , and
-// /video/... or /image/... paths).
 function artImageToVideoSrc(image: ArtImage | null | undefined): string {
   if (!image) return ''
   const fileType = (image.fileType || 'mp4').toLowerCase()
@@ -106,13 +99,6 @@ export const useVideoStore = defineStore('videoStore', () => {
     artImageId: null as number | null,
     message: '',
     error: '',
-    // The error the LAST failed attempt reported, while the queue is still
-    // retrying. Distinct from `error`, which is fatal and ends the run: this
-    // one rides alongside a live spinner, because the job really is still
-    // going. Without it a job that has already failed twice looks exactly like
-    // one that just got queued -- which is how a ComfyUI rejection could spin
-    // a wheel for minutes saying "processing" while the ArtJob row already
-    // held the whole diagnosis (2026-08-19, LTX webp animation).
     attemptError: '',
     attempts: 0,
     loop: true,
@@ -122,7 +108,6 @@ export const useVideoStore = defineStore('videoStore', () => {
     () => state.status === 'queued' || state.status === 'rendering',
   )
 
-  // webp/gif clips render as <img> (loop natively); mp4/webm render as <video>.
   const resultIsImage = computed(() => isImageClipFileType(state.fileType))
 
   function reset(): void {
@@ -148,14 +133,19 @@ export const useVideoStore = defineStore('videoStore', () => {
       durationSeconds: params.durationSeconds,
       fps: params.fps,
       loop: params.loop,
-      width: params.width ?? undefined,
-      height: params.height ?? undefined,
+      width: params.width,
+      height: params.height,
       seed: params.seed ?? undefined,
       loraResourceIds: params.loraResourceIds?.length
         ? params.loraResourceIds
         : undefined,
       loraStrength: params.loraStrength ?? undefined,
-      outputFormat: params.outputFormat ?? undefined,
+      outputFormat: params.outputFormat,
+      renderScale: params.renderScale ?? undefined,
+      latentUpscaleModel: params.latentUpscaleModel ?? undefined,
+      refineSampler: params.refineSampler ?? undefined,
+      refineSigmas: params.refineSigmas ?? undefined,
+      timeoutSeconds: params.timeoutSeconds ?? undefined,
       isPublic: params.isPublic ?? true,
       isMature: params.isMature ?? false,
       designer: params.designer ?? undefined,
@@ -177,9 +167,7 @@ export const useVideoStore = defineStore('videoStore', () => {
   }
 
   async function waitForJob(jobId: number): Promise<QueuedJob> {
-    const startedAt = Date.now()
-
-    while (Date.now() - startedAt < TIMEOUT_MS) {
+    while (true) {
       const res = await performFetch<{ job: QueuedJob }>(
         `/api/art/queue/${jobId}`,
         { method: 'GET' },
@@ -197,11 +185,6 @@ export const useVideoStore = defineStore('videoStore', () => {
         return job
       }
 
-      // A failed attempt returns the job to PENDING with its error recorded,
-      // so `error` on a non-terminal job is the last attempt's failure and the
-      // queue is about to try again. Report it now rather than at the terminal
-      // state -- three attempts is minutes of silence otherwise, and the
-      // failure is usually the same one every time.
       const notice = artJobRetryNotice(job)
       if (notice) {
         state.attempts = notice.attempts
@@ -222,19 +205,6 @@ export const useVideoStore = defineStore('videoStore', () => {
 
       await sleep(POLL_MS)
     }
-
-    // "Still catching up" is only true if nothing has gone wrong yet. A job
-    // that has been failing and retrying for twenty minutes is not catching
-    // up, and telling the user to sit tight sends them back to the same wheel.
-    if (state.attemptError) {
-      throw new Error(
-        `Still retrying after ${state.attempts} failed attempt(s): ${state.attemptError}`,
-      )
-    }
-
-    throw new Error(
-      'The studio engine is still catching up. The job stays queued and its clip will appear once rendering finishes — no need to resubmit.',
-    )
   }
 
   async function loadVideo(artImageId: number): Promise<void> {
@@ -253,8 +223,6 @@ export const useVideoStore = defineStore('videoStore', () => {
     state.fileType = (res.data.fileType || '').toLowerCase()
   }
 
-  // Full orchestration: enqueue → poll → resolve. Sets status/error along the
-  // way so the page can bind directly to the store.
   async function generate(params: GenerateVideoParams): Promise<void> {
     reset()
     state.status = 'queued'

--- a/stores/videoStore.ts
+++ b/stores/videoStore.ts
@@ -127,7 +127,7 @@ export const useVideoStore = defineStore('videoStore', () => {
       engine: params.engine,
       presetId: params.presetId ?? undefined,
       promptString: params.promptString,
-      negativePrompt: params.negativePrompt ?? undefined,
+      negativePrompt: params.negativePrompt ?? '',
       firstImageBase64: params.firstImageBase64,
       secondImageBase64: params.secondImageBase64 ?? undefined,
       durationSeconds: params.durationSeconds,

--- a/utils/videoPresets.ts
+++ b/utils/videoPresets.ts
@@ -1,5 +1,6 @@
 export type VideoEngine = 'ltx' | 'wan'
 export type VideoOutputFormat = 'webp' | 'mp4' | 'webm'
+export type VideoRuntimeTier = 'quick' | 'balanced' | 'slow' | 'very-slow'
 
 export type VideoPresetDefinition = {
   id: string
@@ -12,9 +13,91 @@ export type VideoPresetDefinition = {
   fps: number
   loop: boolean
   outputFormat: VideoOutputFormat
+  renderScale: number
+  latentUpscaleModel: string | null
+  refineSampler: string | null
+  refineSigmas: string | null
+  timeoutSeconds: number
+  runtimeTier: VideoRuntimeTier
+  runtimeHint: string
 }
 
+export type VideoWorkloadInput = {
+  engine: VideoEngine
+  width: number
+  height: number
+  durationSeconds: number
+  fps: number
+  renderScale?: number | null
+  latentUpscaleModel?: string | null
+}
+
+export const LTX_23_SPATIAL_UPSCALER =
+  'ltx-2.3-spatial-upscaler-x2-1.1.safetensors'
+
 export const VIDEO_PRESETS = [
+  {
+    id: 'ltx-12gb-balanced',
+    engine: 'ltx',
+    label: '12 GB Balanced',
+    description:
+      '1280×720 output, 4 seconds at 16 FPS. Diffuses at half resolution, then uses LTX native x2 latent upscale + refinement.',
+    width: 1280,
+    height: 720,
+    durationSeconds: 4,
+    fps: 16,
+    loop: true,
+    outputFormat: 'webp',
+    renderScale: 0.5,
+    latentUpscaleModel: LTX_23_SPATIAL_UPSCALER,
+    refineSampler: 'euler_cfg_pp',
+    refineSigmas: '0.85, 0.7250, 0.4219, 0.0',
+    timeoutSeconds: 5_400,
+    runtimeTier: 'balanced',
+    runtimeHint:
+      'Default for the 12 GB studio card. It trades a little extra refinement work for dramatically lower first-pass VRAM pressure.',
+  },
+  {
+    id: 'ltx-12gb-quick',
+    engine: 'ltx',
+    label: '12 GB Quick',
+    description: '768×432, 3 seconds at 16 FPS. Direct low-resolution render.',
+    width: 768,
+    height: 432,
+    durationSeconds: 3,
+    fps: 16,
+    loop: true,
+    outputFormat: 'webp',
+    renderScale: 1,
+    latentUpscaleModel: null,
+    refineSampler: null,
+    refineSigmas: null,
+    timeoutSeconds: 3_600,
+    runtimeTier: 'quick',
+    runtimeHint:
+      'Fastest practical LTX preset on the 12 GB card. Best for motion tests and iteration.',
+  },
+  {
+    id: 'ltx-full-quality',
+    engine: 'ltx',
+    label: 'Full-res Quality',
+    description:
+      '1280×720, 6 seconds at 25 FPS with direct full-resolution diffusion.',
+    width: 1280,
+    height: 720,
+    durationSeconds: 6,
+    fps: 25,
+    loop: false,
+    outputFormat: 'mp4',
+    renderScale: 1,
+    latentUpscaleModel: null,
+    refineSampler: null,
+    refineSigmas: null,
+    timeoutSeconds: 14_400,
+    runtimeTier: 'very-slow',
+    runtimeHint:
+      'Maximum direct quality, but the 22B model substantially exceeds 12 GB VRAM. Expect a multi-hour render on the studio RTX 3060.',
+  },
   {
     id: 'ltx-startup-webp',
     engine: 'ltx',
@@ -26,6 +109,13 @@ export const VIDEO_PRESETS = [
     fps: 16,
     loop: true,
     outputFormat: 'webp',
+    renderScale: 1,
+    latentUpscaleModel: null,
+    refineSampler: null,
+    refineSigmas: null,
+    timeoutSeconds: 3_600,
+    runtimeTier: 'quick',
+    runtimeHint: 'Short square clip intended for startup/loading animations.',
   },
   {
     id: 'ltx-startup-webm',
@@ -38,6 +128,13 @@ export const VIDEO_PRESETS = [
     fps: 16,
     loop: true,
     outputFormat: 'webm',
+    renderScale: 1,
+    latentUpscaleModel: null,
+    refineSampler: null,
+    refineSigmas: null,
+    timeoutSeconds: 3_600,
+    runtimeTier: 'quick',
+    runtimeHint: 'Short square clip intended for startup/loading animations.',
   },
   {
     id: 'wan-startup-webp',
@@ -50,6 +147,13 @@ export const VIDEO_PRESETS = [
     fps: 16,
     loop: true,
     outputFormat: 'webp',
+    renderScale: 1,
+    latentUpscaleModel: null,
+    refineSampler: null,
+    refineSigmas: null,
+    timeoutSeconds: 5_400,
+    runtimeTier: 'balanced',
+    runtimeHint: 'Conservative WAN startup preset for the local studio card.',
   },
   {
     id: 'wan-startup-webm',
@@ -62,10 +166,22 @@ export const VIDEO_PRESETS = [
     fps: 16,
     loop: true,
     outputFormat: 'webm',
+    renderScale: 1,
+    latentUpscaleModel: null,
+    refineSampler: null,
+    refineSigmas: null,
+    timeoutSeconds: 5_400,
+    runtimeTier: 'balanced',
+    runtimeHint: 'Conservative WAN startup preset for the local studio card.',
   },
 ] as const satisfies readonly VideoPresetDefinition[]
 
 export type VideoPresetId = (typeof VIDEO_PRESETS)[number]['id']
+
+export const DEFAULT_VIDEO_PRESET_BY_ENGINE: Record<VideoEngine, VideoPresetId> = {
+  ltx: 'ltx-12gb-balanced',
+  wan: 'wan-startup-webp',
+}
 
 export function getVideoPreset(
   presetId: string | null | undefined,
@@ -74,8 +190,55 @@ export function getVideoPreset(
   return VIDEO_PRESETS.find((preset) => preset.id === presetId) ?? null
 }
 
+export function getDefaultVideoPreset(
+  engine: VideoEngine,
+): (typeof VIDEO_PRESETS)[number] {
+  return getVideoPreset(DEFAULT_VIDEO_PRESET_BY_ENGINE[engine])!
+}
+
 export function getVideoPresetsForEngine(
   engine: VideoEngine,
 ): readonly (typeof VIDEO_PRESETS)[number][] {
   return VIDEO_PRESETS.filter((preset) => preset.engine === engine)
+}
+
+export function videoFrameCount(durationSeconds: number, fps: number): number {
+  return Math.max(2, Math.round(durationSeconds * fps) + 1)
+}
+
+export function estimateVideoRuntimeTier(
+  input: VideoWorkloadInput,
+): VideoRuntimeTier {
+  const width = Math.max(64, input.width || 0)
+  const height = Math.max(64, input.height || 0)
+  const frames = videoFrameCount(input.durationSeconds || 0, input.fps || 0)
+  const scale = Math.min(1, Math.max(0.25, input.renderScale ?? 1))
+
+  const finalPixelFrames = width * height * frames
+  const firstPassEquivalent = finalPixelFrames * scale * scale
+  const refinementEquivalent =
+    input.engine === 'ltx' && input.latentUpscaleModel && scale < 1
+      ? finalPixelFrames * 0.35
+      : 0
+  const equivalentWork = firstPassEquivalent + refinementEquivalent
+  const balancedBaseline = 1280 * 720 * 65 * (0.25 + 0.35)
+  const ratio = equivalentWork / balancedBaseline
+
+  if (ratio <= 0.7) return 'quick'
+  if (ratio <= 1.5) return 'balanced'
+  if (ratio <= 3) return 'slow'
+  return 'very-slow'
+}
+
+export function runtimeTierMessage(tier: VideoRuntimeTier): string {
+  if (tier === 'quick') {
+    return 'This should be a relatively quick studio render.'
+  }
+  if (tier === 'balanced') {
+    return 'This is tuned for the 12 GB studio card and may still take a while.'
+  }
+  if (tier === 'slow') {
+    return 'This is a heavy render for the 12 GB studio card. Expect a long generation.'
+  }
+  return 'This configuration is intentionally expensive on 12 GB VRAM and can take multiple hours.'
 }


### PR DESCRIPTION
## What this changes

Moves video generation policy back to the front end/store, where it belongs, and restores the low-VRAM LTX 2.3 path we had previously designed for the 12 GB studio GPU.

### Front end / store
- Adds a `12 GB Balanced` LTX default: 1280×720 output, 4s, 16 FPS, half-resolution first pass, native LTX x2 latent upscaler, short refinement pass.
- Keeps `12 GB Quick`, startup presets, and an explicit `Full-res Quality` preset for intentionally long renders.
- Exposes LTX render scale (50/75/100%) in Advanced controls.
- Shows runtime warnings based on actual dimensions, frame count, render scale, and upscale/refinement path.
- Removes the browser's arbitrary 20-minute polling failure; ArtJobs remain durable and the UI keeps following the job until it reaches a terminal state.

### API contract
- `/api/video/generate` no longer imports or applies `videoPresets`; it only normalizes the engine and forwards the explicit request.
- Video ArtJobs now require explicit width, height, duration, FPS, loop, output format, and negative prompt.
- `presetId` is provenance metadata only.
- LTX-specific low-VRAM controls (`renderScale`, latent upscaler, refinement sampler/sigmas) are explicit request fields, not hidden server defaults.
- Runtime timeout expectation is carried in the ArtJob payload for the relay to use as a soft/stall threshold.

### LTX workflow
- Restores the native LTX `LTXVLatentUpsampler` path from the previously proven workflow.
- Reapplies the first frame after upscale and performs the short refinement sampling pass.
- Reapplies an optional final-frame guide after upscale so first→last-frame morphs retain their endpoint.

## Why
ArtJob #9004 demonstrated the failure mode: the queued I2V builder had regressed to direct 1280×720 diffusion through the 22B model on a 12 GB RTX 3060, while the older/proven workflow used half-resolution diffusion plus the LTX spatial upscaler. The server also duplicated front-end preset defaults, and both browser and relay timeout behavior treated long renders as failures instead of distinguishing active work from a stalled job.

Relay-side queue-aware timeout handling is being shipped separately in Conductor so this PR stays focused on product policy and workflow construction.