### PR TITLE
model-builder/t-029 cycle 25: stop Auto-build-all and group batch ops from racing

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -491,6 +491,12 @@ jobs:
       - name: Model Builder auto-build asset-only message guard contract
         run: npm run test:model-builder-auto-build-asset-only-message-guard
 
+      - name: Model Builder auto-build/batch mutual-exclusion guard checker self-test
+        run: npm run test:model-builder-auto-build-batch-exclusion-guard-selftest
+
+      - name: Model Builder auto-build/batch mutual-exclusion guard contract
+        run: npm run test:model-builder-auto-build-batch-exclusion-guard
+
       - name: Model Builder ASSET_ONLY approval guard checker self-test
         run: npm run test:model-builder-asset-only-approval-guard-selftest
 

--- a/components/model-builder/model-builder-batch-editor.vue
+++ b/components/model-builder/model-builder-batch-editor.vue
@@ -51,7 +51,7 @@
         <button
           type="button"
           class="btn btn-xs rounded-lg"
-          :disabled="anyBatching"
+          :disabled="anyBatching || store.autoBuilding"
           @click="draftAll('pitch')"
         >
           <Icon name="kind-icon:sparkles" class="h-3.5 w-3.5" />
@@ -61,7 +61,7 @@
           v-if="!isAsset"
           type="button"
           class="btn btn-xs rounded-lg"
-          :disabled="anyBatching"
+          :disabled="anyBatching || store.autoBuilding"
           @click="draftAll('fields')"
         >
           <Icon name="kind-icon:sparkles" class="h-3.5 w-3.5" />
@@ -71,7 +71,7 @@
           v-if="wantArt"
           type="button"
           class="btn btn-xs rounded-lg"
-          :disabled="anyBatching"
+          :disabled="anyBatching || store.autoBuilding"
           @click="draftAll('artPrompt')"
         >
           <Icon name="kind-icon:sparkles" class="h-3.5 w-3.5" />
@@ -80,7 +80,7 @@
         <button
           type="button"
           class="btn btn-xs btn-ghost rounded-lg"
-          :disabled="anyBatching"
+          :disabled="anyBatching || store.autoBuilding"
           @click="
             store.batchApproveStage(group.outputKey, 'FIELDS_AND_PROMPTS')
           "
@@ -91,7 +91,7 @@
         <button
           type="button"
           class="btn btn-xs btn-primary rounded-lg"
-          :disabled="anyBatching"
+          :disabled="anyBatching || store.autoBuilding"
           :title="autoBuildGroupTitle"
           @click="store.batchAutoBuild(group.outputKey)"
         >
@@ -154,7 +154,9 @@
           <button
             type="button"
             class="btn btn-xs rounded-lg"
-            :disabled="anyBatching || !batchValues[field.key]"
+            :disabled="
+              anyBatching || store.autoBuilding || !batchValues[field.key]
+            "
             :aria-label="`Apply ${field.label} to all ${group.items.length} items`"
             @click="applyField(field.key)"
           >
@@ -251,6 +253,26 @@ const batching = computed(() => store.batchingOutputKey === props.outputKey)
 // `batching` above stays narrow on purpose -- it only drives this group's
 // own header spinner.
 const anyBatching = computed(() => store.batchingOutputKey !== null)
+
+// Bug (model-builder/t-029, cycle 25): every `:disabled` above used to check
+// only `anyBatching` -- ANY group's batch operation -- never
+// `store.autoBuilding`, the SEPARATE store-wide flag model-builder-progress-
+// matrix.vue's "Auto-build all" sets. Clicking "Auto-build all" while this
+// group's own batch controls were still enabled let the user start a
+// second, fully concurrent walk over the same run's items: autoBuildRun's
+// per-item loop and a batch action here (e.g. "Auto-build group" on a
+// DIFFERENT group, or even this same one) both drive items through
+// draftText/generateItemAsset/commitItem, so two items in the same run
+// could end up mid-generate/mid-commit at the same instant via two
+// independent orchestration passes -- the same race class `anyBatching`
+// itself exists to prevent for two batch operations, just never extended to
+// this sibling whole-run entry point. See modelBuilderStore.ts's
+// isRunOperationInFlight doc comment. Added inline (`anyBatching ||
+// store.autoBuilding`) at each `:disabled` rather than folded into
+// `anyBatching`'s own definition so
+// verifyModelBuilderBatchAnyInFlightGuard.ts's existing exact-text check on
+// that computed's definition (a DIFFERENT, already-shipped regression
+// guard) keeps passing unchanged.
 const isAsset = computed(() => group.value?.action === 'ASSET_ONLY')
 const wantArt = computed(
   () => store.includeArt && group.value?.generation === 'image',

--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -24,7 +24,7 @@
         <button
           type="button"
           class="btn btn-xs btn-primary rounded-xl"
-          :disabled="store.autoBuilding"
+          :disabled="autoBuildAllDisabled"
           :title="autoBuildAllTitle"
           @click="store.autoBuildRun()"
         >
@@ -200,13 +200,31 @@ const busyCount = computed(
     run.value?.items.filter((item) => store.isItemManualActionInFlight(item.id))
       .length ?? 0,
 )
-const autoBuildAllTitle = computed(() =>
-  busyCount.value
-    ? `${busyCount.value} item${busyCount.value === 1 ? '' : 's'} in this run ` +
-      `${busyCount.value === 1 ? 'has' : 'have'} a manual action in progress ` +
-      'right now and will be skipped this pass -- retry after it finishes.'
-    : 'Draft, generate, and commit every item automatically',
+// Bug (model-builder/t-029, cycle 25): this button only ever disabled on
+// store.autoBuilding (a second whole-run auto-build), never on
+// store.batchingOutputKey -- so a group batch operation running from
+// model-builder-batch-editor.vue (Draft pitches/fields/prompts, Approve
+// fields, or Auto-build group) left this button clickable, letting the user
+// start a second, fully concurrent walk over the same run's items. See
+// modelBuilderStore.ts's isRunOperationInFlight doc comment for the full
+// race this caused.
+const batchInProgress = computed(() => store.batchingOutputKey !== null)
+const autoBuildAllDisabled = computed(
+  () => store.autoBuilding || batchInProgress.value,
 )
+const autoBuildAllTitle = computed(() => {
+  if (batchInProgress.value) {
+    return (
+      'A batch group operation is already running for this run -- wait ' +
+      'for it to finish before Auto-build all.'
+    )
+  }
+  return busyCount.value
+    ? `${busyCount.value} item${busyCount.value === 1 ? '' : 's'} in this run ` +
+        `${busyCount.value === 1 ? 'has' : 'have'} a manual action in progress ` +
+        'right now and will be skipped this pass -- retry after it finishes.'
+    : 'Draft, generate, and commit every item automatically'
+})
 
 // The source record we're building from — snapshot survives resume; fall back to
 // the freshly-picked record.

--- a/package.json
+++ b/package.json
@@ -247,6 +247,8 @@
     "test:model-builder-batch-prefill-guard": "tsx utils/scripts/verifyModelBuilderBatchPrefillGuard.ts",
     "test:model-builder-auto-build-asset-only-message-guard-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildAssetOnlyMessageGuard.test.ts",
     "test:model-builder-auto-build-asset-only-message-guard": "tsx utils/scripts/verifyModelBuilderAutoBuildAssetOnlyMessageGuard.ts",
+    "test:model-builder-auto-build-batch-exclusion-guard-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildBatchExclusionGuard.test.ts",
+    "test:model-builder-auto-build-batch-exclusion-guard": "tsx utils/scripts/verifyModelBuilderAutoBuildBatchExclusionGuard.ts",
     "test:model-builder-asset-only-approval-guard-selftest": "tsx utils/scripts/verifyModelBuilderAssetOnlyApprovalGuard.test.ts",
     "test:model-builder-asset-only-approval-guard": "tsx utils/scripts/verifyModelBuilderAssetOnlyApprovalGuard.ts",
     "test:model-builder-auto-build-approval-race-guard-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildApprovalRaceGuard.test.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1840,6 +1840,33 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     )
   }
 
+  // Bug (model-builder/t-029, cycle 25): autoBuildRun (whole-run) and the
+  // batch group operations below (batchDraftField/batchSetField/
+  // batchApproveStage/batchAutoBuild) each track their own "in flight" flag
+  // -- state.autoBuilding vs state.batchingOutputKey -- and neither checked
+  // the other before this fix, at either the store-function level or the UI
+  // button level (model-builder-progress-matrix.vue's "Auto-build all" only
+  // disabled on store.autoBuilding; model-builder-batch-editor.vue's
+  // anyBatching only disabled on store.batchingOutputKey). A user could
+  // click "Auto-build all" while a group's "Auto-build group" (or any other
+  // batch action) was still running for that same run, or the reverse, and
+  // both entry points loop over the run's items sequentially, awaiting each
+  // item's own draftText/generateItemAsset/commitItem calls in turn --
+  // starting two of these loops at once lets them interleave, so two
+  // different items in the SAME run can end up mid-generate/mid-commit at
+  // the same instant via two independent orchestration passes. That's
+  // exactly the race class isItemManualActionInFlight and every batch
+  // button's own anyBatching gate exist to prevent for a single item or a
+  // single group -- it just never got extended to cover these two sibling
+  // whole-run/group entry points recognizing each other. (autoBuildItem's
+  // own autoBuildingItemSingleton only protects the exact same item id from
+  // double-processing at a given instant, and only weakly -- see
+  // createOwnedSingleton's doc comment -- it does nothing for two
+  // *different* items being driven by two concurrent loops.)
+  function isRunOperationInFlight(): boolean {
+    return state.autoBuilding || state.batchingOutputKey !== null
+  }
+
   // Run one item through every gate automatically with sensible defaults: draft
   // what's empty, generate art only when wanted, and commit. "Create directly"
   // for CREATE/UPDATE items when art is off. Returns the outcome so batch/run
@@ -1986,7 +2013,10 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
 
   // Auto-build every not-yet-committed item in the run, in order.
   async function autoBuildRun(): Promise<void> {
-    if (!state.run || state.autoBuilding) return
+    // See isRunOperationInFlight's doc comment (model-builder/t-029, cycle
+    // 25) -- a group batch operation already running for this run must
+    // block a whole-run auto-build too, not just a second whole-run one.
+    if (!state.run || isRunOperationInFlight()) return
     state.autoBuilding = true
     clearStatus()
 
@@ -2112,6 +2142,10 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   ): Promise<void> {
     const items = groupItems(outputKey)
     if (!items.length) return
+    // See isRunOperationInFlight's doc comment (model-builder/t-029, cycle
+    // 25) -- a whole-run auto-build already in progress must block a group
+    // batch operation too, not just a second group batch operation.
+    if (state.autoBuilding) return
     // Bug (model-builder/t-029 cycle 13): unlike every single-item async
     // entry point that spans a real network round-trip (draftText itself --
     // see verifyModelBuilderDraftStatusScopeGuard's doc comment --
@@ -2211,6 +2245,10 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     fieldKey: string,
     value: string,
   ): Promise<void> {
+    // See isRunOperationInFlight's doc comment (model-builder/t-029, cycle
+    // 25) -- a whole-run auto-build already in progress must block a group
+    // batch operation too, not just a second group batch operation.
+    if (state.autoBuilding) return
     // Bug (model-builder/t-029 cycle 13): captured up front, mirroring
     // draftText/generateItemAsset/commitItem/pushItem/batchPushItems (see
     // verifyModelBuilderDraftStatusScopeGuard's doc comment for the full
@@ -2322,6 +2360,10 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     outputKey: string,
     stageKey: BuildStageKey,
   ): Promise<void> {
+    // See isRunOperationInFlight's doc comment (model-builder/t-029, cycle
+    // 25) -- a whole-run auto-build already in progress must block a group
+    // batch operation too, not just a second group batch operation.
+    if (state.autoBuilding) return
     // Bug (model-builder/t-029 cycle 13): captured up front, same as
     // batchSetField's identical fix (see its own doc comment) -- the
     // batchPushItems() await below is a real network round-trip the user can
@@ -2386,6 +2428,10 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   async function batchAutoBuild(outputKey: string): Promise<void> {
     const items = groupItems(outputKey)
     if (!items.length) return
+    // See isRunOperationInFlight's doc comment (model-builder/t-029, cycle
+    // 25) -- a whole-run auto-build already in progress must block a group
+    // batch operation too, not just a second group batch operation.
+    if (state.autoBuilding) return
     // Bug (model-builder/t-029 cycle 13): captured up front, exactly
     // mirroring autoBuildRun's own runId capture and its doc comment just
     // below (same file) -- autoBuildRun already guards both its per-item

--- a/utils/scripts/verifyModelBuilderAutoBuildBatchExclusionGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildBatchExclusionGuard.test.ts
@@ -1,0 +1,286 @@
+// /utils/scripts/verifyModelBuilderAutoBuildBatchExclusionGuard.test.ts
+//
+// Regression test for checkAutoBuildBatchExclusionGuard() in
+// verifyModelBuilderAutoBuildBatchExclusionGuard.ts (model-builder/t-029,
+// cycle 25). Exercises the real check against synthetic store-shaped
+// fixtures covering: the pre-fix shape (isRunOperationInFlight only checks
+// its own flag, autoBuildRun never calls it, no batch function checks
+// state.autoBuilding), the fixed shape (all five functions), a partial fix
+// that leaves one batch function behind, and all five target functions
+// being absent entirely.
+import assert from 'node:assert/strict'
+
+import { checkAutoBuildBatchExclusionGuard } from './verifyModelBuilderAutoBuildBatchExclusionGuard.js'
+
+const BUGGY_FIXTURE = `
+  function isRunOperationInFlight(): boolean {
+    return state.autoBuilding
+  }
+
+  async function autoBuildRun(): Promise<void> {
+    if (!state.run || state.autoBuilding) return
+    state.autoBuilding = true
+    try {
+      // ...
+    } finally {
+      state.autoBuilding = false
+    }
+  }
+
+  async function batchDraftField(
+    outputKey: string,
+    field: DraftField,
+  ): Promise<void> {
+    const items = groupItems(outputKey)
+    if (!items.length) return
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchSetField(
+    outputKey: string,
+    fieldKey: string,
+    value: string,
+  ): Promise<void> {
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchApproveStage(
+    outputKey: string,
+    stageKey: BuildStageKey,
+  ): Promise<void> {
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchAutoBuild(outputKey: string): Promise<void> {
+    const items = groupItems(outputKey)
+    if (!items.length) return
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  function isRunOperationInFlight(): boolean {
+    return state.autoBuilding || state.batchingOutputKey !== null
+  }
+
+  async function autoBuildRun(): Promise<void> {
+    if (!state.run || isRunOperationInFlight()) return
+    state.autoBuilding = true
+    try {
+      // ...
+    } finally {
+      state.autoBuilding = false
+    }
+  }
+
+  async function batchDraftField(
+    outputKey: string,
+    field: DraftField,
+  ): Promise<void> {
+    const items = groupItems(outputKey)
+    if (!items.length) return
+    if (state.autoBuilding) return
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchSetField(
+    outputKey: string,
+    fieldKey: string,
+    value: string,
+  ): Promise<void> {
+    if (state.autoBuilding) return
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchApproveStage(
+    outputKey: string,
+    stageKey: BuildStageKey,
+  ): Promise<void> {
+    if (state.autoBuilding) return
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchAutoBuild(outputKey: string): Promise<void> {
+    const items = groupItems(outputKey)
+    if (!items.length) return
+    if (state.autoBuilding) return
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+
+const PARTIAL_FIX_FIXTURE = `
+  function isRunOperationInFlight(): boolean {
+    return state.autoBuilding || state.batchingOutputKey !== null
+  }
+
+  async function autoBuildRun(): Promise<void> {
+    if (!state.run || isRunOperationInFlight()) return
+    state.autoBuilding = true
+    try {
+      // ...
+    } finally {
+      state.autoBuilding = false
+    }
+  }
+
+  async function batchDraftField(
+    outputKey: string,
+    field: DraftField,
+  ): Promise<void> {
+    const items = groupItems(outputKey)
+    if (!items.length) return
+    if (state.autoBuilding) return
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchSetField(
+    outputKey: string,
+    fieldKey: string,
+    value: string,
+  ): Promise<void> {
+    if (state.autoBuilding) return
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchApproveStage(
+    outputKey: string,
+    stageKey: BuildStageKey,
+  ): Promise<void> {
+    if (state.autoBuilding) return
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchAutoBuild(outputKey: string): Promise<void> {
+    const items = groupItems(outputKey)
+    if (!items.length) return
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkAutoBuildBatchExclusionGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  6,
+  'expected the pre-fix shape to raise 1 "helper missing batchingOutputKey ' +
+    'check" error, 1 "autoBuildRun doesn\'t call the helper" error, and 4 ' +
+    `per-batch-function violations, got ${buggyErrors.length}: ` +
+    JSON.stringify(buggyErrors),
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes('batchingOutputKey !== null')),
+  'expected an error calling out the helper missing its ' +
+    'state.batchingOutputKey !== null check',
+)
+assert.ok(buggyErrors.some((e) => e.startsWith('autoBuildRun()')))
+for (const name of [
+  'batchDraftField',
+  'batchSetField',
+  'batchApproveStage',
+  'batchAutoBuild',
+]) {
+  assert.ok(
+    buggyErrors.some((e) => e.startsWith(`${name}()`)),
+    `expected an error for ${name}() not bailing out on state.autoBuilding`,
+  )
+}
+
+const fixedErrors = checkAutoBuildBatchExclusionGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const partialErrors = checkAutoBuildBatchExclusionGuard(PARTIAL_FIX_FIXTURE)
+assert.equal(
+  partialErrors.length,
+  1,
+  'expected the partial-fix shape (batchAutoBuild left behind) to raise ' +
+    `exactly 1 error, got ${partialErrors.length}: ${JSON.stringify(partialErrors)}`,
+)
+assert.ok(partialErrors[0]!.startsWith('batchAutoBuild()'))
+
+const missingErrors = checkAutoBuildBatchExclusionGuard(MISSING_FIXTURE)
+assert.equal(
+  missingErrors.length,
+  6,
+  'expected 6 "function not found" violations when all five target ' +
+    `functions are absent, got ${missingErrors.length}: ${JSON.stringify(missingErrors)}`,
+)
+
+console.log(
+  'Model Builder auto-build/batch mutual-exclusion guard checker verified: ' +
+    'flags a helper that only checks its own flag, flags autoBuildRun not ' +
+    'calling the helper, flags a batch function missing its ' +
+    'state.autoBuilding bail-out, clears the fixed shape, flags a partial ' +
+    'fix that leaves one batch function behind, and flags all five target ' +
+    'functions being absent.',
+)

--- a/utils/scripts/verifyModelBuilderAutoBuildBatchExclusionGuard.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildBatchExclusionGuard.ts
@@ -1,0 +1,160 @@
+// /utils/scripts/verifyModelBuilderAutoBuildBatchExclusionGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 25) -- autoBuildRun()
+// (whole-run "Auto-build all") and the four group batch operations
+// (batchDraftField/batchSetField/batchApproveStage/batchAutoBuild, driven by
+// model-builder-batch-editor.vue's "Draft pitches/fields/prompts", "Approve
+// fields", and "Auto-build group" buttons) each track their own
+// store-wide "in flight" flag -- state.autoBuilding vs
+// state.batchingOutputKey -- and neither checked the other before this fix,
+// at either the store-function level or the UI button level
+// (model-builder-progress-matrix.vue's "Auto-build all" button only
+// disabled on store.autoBuilding; model-builder-batch-editor.vue's action
+// buttons only disabled on anyBatching, itself scoped to
+// store.batchingOutputKey).
+//
+// A user could click "Auto-build all" while a group's batch operation was
+// still running for that same run (or the reverse: start a batch action
+// while "Auto-build all" was already walking the run), and both entry
+// points loop sequentially over the run's items, awaiting each item's own
+// draftText/generateItemAsset/commitItem calls in turn. Starting two of
+// these loops at once lets them interleave: two *different* items in the
+// same run can end up mid-draft/mid-generate/mid-commit at the same instant
+// via two independent orchestration passes -- exactly the race class
+// isItemManualActionInFlight and anyBatching's own gate already exist to
+// prevent for a single item or two group batch operations, just never
+// extended to these two sibling whole-run/group entry points recognizing
+// each other. (autoBuildItem's own autoBuildingItemSingleton only protects
+// the exact same item id from double-processing at a given instant, and
+// only weakly -- see createOwnedSingleton's own doc comment -- it does
+// nothing for two *different* items being driven by two concurrent loops.)
+//
+// Fixed with a shared isRunOperationInFlight() helper
+// (`state.autoBuilding || state.batchingOutputKey !== null`), used in
+// autoBuildRun()'s own entry guard, plus an explicit
+// `if (state.autoBuilding) return` added to each of the four batch
+// functions (kept as a separate literal check rather than reusing the
+// helper there, since a batch function checking its OWN flag too would
+// change existing same-flag re-entrancy semantics that are out of scope for
+// this fix). This guard asserts both halves of that fix stay in place:
+// if a future refactor drops either side, the two orchestration loops can
+// run concurrently again with no error and no warning until a user
+// happens to trigger both from the UI at once.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const BATCH_FUNCTIONS = [
+  'batchDraftField',
+  'batchSetField',
+  'batchApproveStage',
+  'batchAutoBuild',
+] as const
+
+// Checks the fix's exact shape against the full source text of a file
+// containing isRunOperationInFlight/autoBuildRun/batchXxx-named functions.
+// Exported (rather than only exercised via main()) so the self-test below
+// can run it against synthetic buggy/fixed fixtures without touching the
+// real store file.
+export function checkAutoBuildBatchExclusionGuard(content: string): string[] {
+  const errors: string[] = []
+  const functions = extractFunctionBodies(content)
+
+  const helperFn = functions.find((f) => f.name === 'isRunOperationInFlight')
+  if (!helperFn) {
+    errors.push(
+      'Could not find a function named isRunOperationInFlight() -- has it ' +
+        'been renamed, removed, or inlined? If so, this guard (and the ' +
+        'shared whole-run/batch mutual-exclusion check it protects) needs ' +
+        'to move with it.',
+    )
+  } else {
+    if (!/state\.autoBuilding/.test(helperFn.body)) {
+      errors.push(
+        'isRunOperationInFlight() does not check state.autoBuilding -- a ' +
+          'group batch operation could start while a whole-run auto-build ' +
+          'is still in progress.',
+      )
+    }
+    if (!/state\.batchingOutputKey\s*!==\s*null/.test(helperFn.body)) {
+      errors.push(
+        'isRunOperationInFlight() does not check ' +
+          'state.batchingOutputKey !== null -- a whole-run auto-build ' +
+          'could start while a group batch operation is still in progress.',
+      )
+    }
+  }
+
+  const runFn = functions.find((f) => f.name === 'autoBuildRun')
+  if (!runFn) {
+    errors.push(
+      'Could not find a function named autoBuildRun() -- has it been ' +
+        'renamed, removed, or inlined? If so, this guard (and the fix it ' +
+        'protects) needs to move with it.',
+    )
+  } else if (!/isRunOperationInFlight\(\)/.test(runFn.body)) {
+    errors.push(
+      'autoBuildRun() does not check isRunOperationInFlight() in its ' +
+        'entry guard -- a group batch operation already running for this ' +
+        'run (batchDraftField/batchSetField/batchApproveStage/' +
+        'batchAutoBuild) no longer blocks "Auto-build all" from starting ' +
+        "a second, fully concurrent walk over the same run's items.",
+    )
+  }
+
+  for (const name of BATCH_FUNCTIONS) {
+    const fn = functions.find((f) => f.name === name)
+    if (!fn) {
+      errors.push(
+        `Could not find a function named ${name}() -- has it been ` +
+          'renamed, removed, or inlined? If so, this guard (and the fix ' +
+          'it protects) needs to move with it.',
+      )
+      continue
+    }
+    if (!/if\s*\(\s*state\.autoBuilding\s*\)\s*return/.test(fn.body)) {
+      errors.push(
+        `${name}() does not bail out early when state.autoBuilding is ` +
+          'true (expected something like `if (state.autoBuilding) ' +
+          'return`) -- a whole-run "Auto-build all" already in progress ' +
+          `no longer blocks ${name}() from starting a second, fully ` +
+          "concurrent walk over the same run's items.",
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkAutoBuildBatchExclusionGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder auto-build/batch mutual-exclusion guard contract ' +
+        'failed in modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder auto-build/batch mutual-exclusion guard contract ' +
+      'passed: autoBuildRun() refuses to start while a group batch ' +
+      'operation is in flight, and every group batch operation refuses to ' +
+      'start while a whole-run auto-build is in flight.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Cycle 25 investigation

Cycle 24's suggested leads: (a) re-audit whether `titleField` really is already fully covered by `verifyModelBuilderSourceFieldGuard.ts` for all 7 `SOURCE_TYPES`, or (b) the batch-editor/run-history component pairing under concurrent multi-tab use.

**Lead (a) is genuinely exhausted.** Re-read `verifyModelBuilderSourceFieldGuard.ts`'s `findSourceFieldProblems()` directly: it loops over both `titleField` and `subtitleField` unconditionally for every `SOURCE_TYPES` entry. Cycle 23's claim holds — no further work there.

**Lead (b): investigated `model-builder-batch-editor.vue`/`model-builder-run-history.vue` and the store's batch/cancel/resume paths in depth.** Nearly every cross-tab and cross-run race in this area (cancel-during-poll, stale selections on reopen, partial-batch-failure revert, run-scoped status toasts, etc.) is already covered by 19+ prior cycles' guards. One genuine gap remained, found by tracing the two store-wide "operation in flight" flags: `state.autoBuilding` (whole-run "Auto-build all", `autoBuildRun()`) and `state.batchingOutputKey` (any group batch op — `batchDraftField`/`batchSetField`/`batchApproveStage`/`batchAutoBuild`, driven by `model-builder-batch-editor.vue`).

**The bug:** these two flags never checked each other, at either the store-function level or the UI button level:
- `autoBuildRun()`'s entry guard was `if (!state.run || state.autoBuilding) return` — no check of `state.batchingOutputKey`.
- None of the four batch functions checked `state.autoBuilding` before claiming `batchingOutputSingleton`.
- `model-builder-progress-matrix.vue`'s "Auto-build all" button was `:disabled="store.autoBuilding"` only.
- `model-builder-batch-editor.vue`'s `anyBatching` computed (gating every action button) was `store.batchingOutputKey !== null` only.

A user could click "Auto-build all" while a group's batch action was still running for the same run (or the reverse), starting **two independent sequential loops over the same run's items that can interleave** — each awaits its own `draftText`/`generateItemAsset`/`commitItem` calls per item in turn, so two *different* items in the same run could end up mid-draft/mid-generate/mid-commit at the same instant via two concurrent orchestration passes. `autoBuildItem`'s own `autoBuildingItemSingleton` only protects the exact same item id from double-processing at a given instant (and only weakly, per its own doc comment) — it does nothing for two different items being driven by two concurrent loops. This is the same race class `isItemManualActionInFlight` and `anyBatching` itself already exist to prevent for a single item / two batch ops — it just never got extended to these two sibling whole-run/group entry points recognizing each other.

## Fix

- Added `isRunOperationInFlight()` to `modelBuilderStore.ts` (`state.autoBuilding || state.batchingOutputKey !== null`), used in `autoBuildRun()`'s entry guard.
- Added an explicit `if (state.autoBuilding) return` to each of the four batch functions.
- Updated `model-builder-progress-matrix.vue`'s "Auto-build all" button to also disable (with an explanatory title) when a batch group operation is running.
- Updated `model-builder-batch-editor.vue`'s six action buttons to also disable when `store.autoBuilding` is true — added inline (`anyBatching || store.autoBuilding`) at each `:disabled` rather than folded into `anyBatching`'s own definition, so the already-shipped `verifyModelBuilderBatchAnyInFlightGuard.ts` (which does an exact-text check on `anyBatching`'s definition) keeps passing unchanged.

## New regression guard

`utils/scripts/verifyModelBuilderAutoBuildBatchExclusionGuard.ts` (+ `.test.ts`), following the established guard pattern (`extractFunctionBodies` + regex checks on function bodies), asserts: `isRunOperationInFlight()` checks both flags, `autoBuildRun()` calls it, and each of the four batch functions bails out on `state.autoBuilding`. Wired into `package.json` (`test:model-builder-auto-build-batch-exclusion-guard[-selftest]`) and `.github/workflows/contract-tests.yml`.

## Verification performed

- New guard self-test and contract check pass against real fixtures and the real store file.
- The existing `verifyModelBuilderBatchAnyInFlightGuard.ts` (which this change touches adjacent code to) still passes unchanged, confirming its exact-text check on `anyBatching`'s definition wasn't disturbed.
- All 109 `test:model-builder-*` npm scripts pass (107 pre-existing + 2 new).
- `npx vue-tsc --noEmit` repo-wide: clean.
- `eslint` on all touched files: clean (the two pre-existing `no-empty` lint errors in `modelBuilderStore.ts` confirmed via `git stash` to predate this change).
- `prettier --check` on all touched files: clean. `modelBuilderStore.ts` and `model-builder-progress-matrix.vue` carry pre-existing whole-file formatting drift (confirmed via `git stash`); confirmed via a scratch `prettier --write` diff against each file that none of the lines I added appear in the drift diff, i.e. my additions are already prettier-compliant and the pre-existing drift is untouched.
- `git status --porcelain` shows only the 7 intended files.

## Flags for reviewer

None — this is a client-side/store-only concurrency guard fix; no schema or server route changes.

## Kaizen suggestion for cycle 26

The codebase remains heavily fortified after 25 cycles (109 narrow `verifyModelBuilder*Guard.ts` regression scripts). Worth a fresh read of `server/api/model-builder/items/[id]/commit.post.ts` and `server/api/model-builder/items/[id]/artifacts.post.ts` end-to-end — these haven't had a dedicated cycle since roughly cycle 20, and this cycle's investigation stayed mostly client-side.

model-builder/t-029, cycle 25

---
_Generated by [Claude Code](https://claude.ai/code/session_012x37DjF2SbHLS856AXyb3L)_