### PR TITLE
fix(model-builder): persist commit target before the slower stageStatuses write (t-029 cycle 27)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -437,6 +437,12 @@ jobs:
       - name: Model Builder commit stale-snapshot guard contract
         run: npm run test:model-builder-commit-stale-snapshot-guard
 
+      - name: Model Builder commit target-persistence guard checker self-test
+        run: npm run test:model-builder-commit-target-persistence-guard-selftest
+
+      - name: Model Builder commit target-persistence guard contract
+        run: npm run test:model-builder-commit-target-persistence-guard
+
       - name: Model Builder PATCH stale stage-status guard checker self-test
         run: npm run test:model-builder-patch-stale-stage-status-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -229,6 +229,8 @@
     "test:model-builder-commit-name-field-guard": "tsx utils/scripts/verifyModelBuilderCommitNameFieldGuard.ts",
     "test:model-builder-commit-stale-snapshot-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.test.ts",
     "test:model-builder-commit-stale-snapshot-guard": "tsx utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.ts",
+    "test:model-builder-commit-target-persistence-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitTargetPersistenceGuard.test.ts",
+    "test:model-builder-commit-target-persistence-guard": "tsx utils/scripts/verifyModelBuilderCommitTargetPersistenceGuard.ts",
     "test:model-builder-patch-stale-stage-status-guard-selftest": "tsx utils/scripts/verifyModelBuilderPatchStaleStageStatusGuard.test.ts",
     "test:model-builder-patch-stale-stage-status-guard": "tsx utils/scripts/verifyModelBuilderPatchStaleStageStatusGuard.ts",
     "test:model-builder-content-stage-freshness-guard-selftest": "tsx utils/scripts/verifyModelBuilderContentStageFreshnessGuard.test.ts",

--- a/server/api/model-builder/items/[id]/commit.post.ts
+++ b/server/api/model-builder/items/[id]/commit.post.ts
@@ -979,6 +979,31 @@ export default defineEventHandler(async (event) => {
       throw writeError
     }
 
+    // Durably persist targetType/targetId in their own minimal write
+    // immediately after the primary write succeeds, separate from the
+    // slower stageStatuses re-read/merge/write below. Without this, a
+    // failure in that later step (e.g. a DB blip) would leave the item
+    // permanently claimed -- idempotencyKey is already set above, and must
+    // stay set so a retry can't redo the primary write and duplicate it --
+    // but with targetType/targetId still null, orphaning the record this
+    // commit already produced: every future "already committed" response
+    // (both branches above) would report `target: null` forever with no
+    // way to recover it. This write's own failure isn't caught/reset either,
+    // for the same reason -- the primary write already happened and must
+    // not be repeated.
+    target = await prisma.modelBuildItem
+      .update({
+        where: { id },
+        data: { targetType: target.type, targetId: target.id },
+        select: { targetType: true, targetId: true },
+      })
+      .then((row) => ({
+        type: row.targetType as SourceType,
+        id: row.targetId as number,
+        created: target.created,
+        linked: target.linked,
+      }))
+
     // Re-read stageStatuses immediately before this final write rather than
     // reusing the request-start `item` snapshot: the write above (promote /
     // update / create+link) can be a slow, multi-step transaction, and
@@ -987,6 +1012,8 @@ export default defineEventHandler(async (event) => {
     // stageStatuses blob from a stale snapshot would silently clobber that
     // concurrent edit -- restoring stages to 'approved' that the user just
     // reopened -- so merge the COMMIT key into the current DB value instead.
+    // targetType/targetId are already durably persisted above, so this write
+    // only needs to carry stageStatuses.
     const latest = await prisma.modelBuildItem.findUnique({
       where: { id },
       select: { stageStatuses: true },
@@ -1003,8 +1030,6 @@ export default defineEventHandler(async (event) => {
     const updated = await prisma.modelBuildItem.update({
       where: { id },
       data: {
-        targetType: target.type,
-        targetId: target.id,
         stageStatuses: JSON.stringify(stages),
       },
       include: {

--- a/utils/scripts/verifyModelBuilderCommitTargetPersistenceGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderCommitTargetPersistenceGuard.test.ts
@@ -1,0 +1,124 @@
+// /utils/scripts/verifyModelBuilderCommitTargetPersistenceGuard.test.ts
+//
+// Regression test for checkCommitTargetPersistenceGuard() in
+// verifyModelBuilderCommitTargetPersistenceGuard.ts (model-builder/t-029
+// cycle 27). Exercises the real check against synthetic commit.post.ts-shaped
+// fixtures covering: the pre-fix shape (targetType/targetId only written
+// inside the final combined stageStatuses update), the fixed shape (an early,
+// separate write persists target before the final update, which then only
+// carries stageStatuses), and a missing-anchor fixture.
+import assert from 'node:assert/strict'
+
+import {
+  checkCommitTargetPersistenceGuard,
+  splitAroundFinalUpdate,
+} from './verifyModelBuilderCommitTargetPersistenceGuard.js'
+
+const BUGGY_FIXTURE = `
+    const latest = await prisma.modelBuildItem.findUnique({
+      where: { id },
+      select: { stageStatuses: true },
+    })
+    const stages = parseStoredJson<Record<string, unknown>>(
+      latest?.stageStatuses ?? item.stageStatuses,
+      {},
+    )
+    stages.COMMIT = {
+      status: 'approved',
+      note: \`Committed → \${target.type} #\${target.id}\`,
+    }
+
+    const updated = await prisma.modelBuildItem.update({
+      where: { id },
+      data: {
+        targetType: target.type,
+        targetId: target.id,
+        stageStatuses: JSON.stringify(stages),
+      },
+      include: {
+        Artifacts: { orderBy: { id: 'asc' } },
+      },
+    })
+`
+
+const FIXED_FIXTURE = `
+    target = await prisma.modelBuildItem
+      .update({
+        where: { id },
+        data: { targetType: target.type, targetId: target.id },
+        select: { targetType: true, targetId: true },
+      })
+      .then((row) => ({
+        type: row.targetType as SourceType,
+        id: row.targetId as number,
+        created: target.created,
+        linked: target.linked,
+      }))
+
+    const latest = await prisma.modelBuildItem.findUnique({
+      where: { id },
+      select: { stageStatuses: true },
+    })
+    const stages = parseStoredJson<Record<string, unknown>>(
+      latest?.stageStatuses ?? item.stageStatuses,
+      {},
+    )
+    stages.COMMIT = {
+      status: 'approved',
+      note: \`Committed → \${target.type} #\${target.id}\`,
+    }
+
+    const updated = await prisma.modelBuildItem.update({
+      where: { id },
+      data: {
+        stageStatuses: JSON.stringify(stages),
+      },
+      include: {
+        Artifacts: { orderBy: { id: 'asc' } },
+      },
+    })
+`
+
+function run(): void {
+  const buggyErrors = checkCommitTargetPersistenceGuard(BUGGY_FIXTURE)
+  assert.equal(
+    buggyErrors.length,
+    2,
+    'expected the buggy fixture (target only in the combined final write) ' +
+      `to fail twice, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.match(buggyErrors[0]!, /does not durably persist targetType\/targetId/)
+  assert.match(buggyErrors[1]!, /exact combined-write shape/)
+
+  const fixedErrors = checkCommitTargetPersistenceGuard(FIXED_FIXTURE)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const missingAnchorErrors = checkCommitTargetPersistenceGuard(
+    'const somethingElse = 1',
+  )
+  assert.equal(
+    missingAnchorErrors.length,
+    1,
+    'expected a fixture with no `stages.COMMIT = {` / final update anchor ' +
+      'to fail with a "could not locate" error',
+  )
+  assert.match(missingAnchorErrors[0]!, /Could not locate/)
+
+  assert.notEqual(
+    splitAroundFinalUpdate(FIXED_FIXTURE),
+    null,
+    'expected splitAroundFinalUpdate to find both anchors in the fixed fixture',
+  )
+
+  console.log(
+    'Model Builder commit target-persistence guard self-test passed: buggy ' +
+      'fixture fails twice, fixed fixture passes, missing-anchor fixture ' +
+      'fails clearly.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderCommitTargetPersistenceGuard.ts
+++ b/utils/scripts/verifyModelBuilderCommitTargetPersistenceGuard.ts
@@ -1,0 +1,151 @@
+// /utils/scripts/verifyModelBuilderCommitTargetPersistenceGuard.ts
+//
+// Regression guard (model-builder/t-029 cycle 27, kaizen from cycle 26's
+// note) -- items/[id]/commit.post.ts claims the item (idempotencyKey set to
+// `commit:${id}`) before doing the actual write (promoteAsset / updateText /
+// createRecord+linkSourceToTarget), then -- on success -- re-reads
+// stageStatuses and writes targetType/targetId together with the merged
+// stageStatuses blob in a single final `prisma.modelBuildItem.update()`.
+//
+// That final write is not the primary write: it's a slower read-modify-write
+// (a `findUnique` immediately followed by an `update`) that can fail on its
+// own (a DB blip, a connection hiccup) *after* the primary write already
+// succeeded. When it does, idempotencyKey correctly stays set -- resetting it
+// would let a retry redo the primary write and duplicate the record -- but
+// with the old single-combined-write shape, targetType/targetId never got
+// persisted either, since they lived in that same doomed write. The item was
+// then permanently claimed with its target unrecoverable: every future
+// "already committed" response (both early-return branches above, which
+// report `target: item.targetType && item.targetId ? {...} : null`) would
+// report `target: null` forever, orphaning the record the commit actually
+// produced.
+//
+// Fixed by durably persisting targetType/targetId in their own minimal write
+// immediately after the primary write succeeds, separate from the slower
+// stageStatuses re-read/merge/write -- so a later failure in that second step
+// can no longer orphan the target record.
+//
+// This asserts the textual shape of that fix stays in place: a
+// `prisma.modelBuildItem.update()` call that writes `targetType`/`targetId`
+// appears before the final stageStatuses write, and that final write no
+// longer carries `targetType`/`targetId` itself (the one thing a future edit
+// could easily "simplify" back into a single combined write, silently
+// reintroducing the bug).
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const ROUTE_PATH = join(
+  repositoryRoot,
+  'server/api/model-builder/items/[id]/commit.post.ts',
+)
+
+const STAGE_ASSIGNMENT = 'stages.COMMIT = {'
+const FINAL_UPDATE_ANCHOR =
+  'const updated = await prisma.modelBuildItem.update({'
+
+// Splits the source at the final `const updated = ...update({` call (the
+// stageStatuses write) so the "target persisted before this point" and "not
+// re-carried in this final write" checks can each look at the right half.
+// Exported so the self-test can exercise it directly against synthetic
+// fixtures without touching the real route file.
+export function splitAroundFinalUpdate(
+  content: string,
+): { before: string; finalUpdateBlock: string } | null {
+  const stageIndex = content.indexOf(STAGE_ASSIGNMENT)
+  if (stageIndex === -1) return null
+
+  const finalUpdateIndex = content.indexOf(FINAL_UPDATE_ANCHOR, stageIndex)
+  if (finalUpdateIndex === -1) return null
+
+  // The final update's `data: { ... }` object is what we need to inspect;
+  // grab a generous slice starting at the anchor through the next top-level
+  // closing of the update() call. Looking for the first `include:` or the
+  // literal `})` that ends the `data: {...}` block keeps this robust to
+  // reordering of fields inside `data`.
+  const closeIndex = content.indexOf('\n    })', finalUpdateIndex)
+  const finalUpdateBlock = content.slice(
+    finalUpdateIndex,
+    closeIndex === -1 ? finalUpdateIndex + 400 : closeIndex,
+  )
+
+  return { before: content.slice(0, finalUpdateIndex), finalUpdateBlock }
+}
+
+export function checkCommitTargetPersistenceGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const split = splitAroundFinalUpdate(content)
+  if (split === null) {
+    errors.push(
+      'Could not locate both `stages.COMMIT = {` and the final ' +
+        '`const updated = await prisma.modelBuildItem.update({` write in ' +
+        'commit.post.ts -- has the final write been renamed, removed, or ' +
+        'restructured? If so, this guard (and the bug it protects against) ' +
+        'needs to move with it.',
+    )
+    return errors
+  }
+
+  const { before, finalUpdateBlock } = split
+
+  const persistsTargetEarly =
+    before.includes('modelBuildItem') &&
+    before.includes('data: { targetType: target.type, targetId: target.id }')
+
+  if (!persistsTargetEarly) {
+    errors.push(
+      'commit.post.ts does not durably persist targetType/targetId in ' +
+        'their own write immediately after the primary write succeeds -- it ' +
+        'appears the only place target gets written is the final ' +
+        'stageStatuses update. If that later read-modify-write fails on its ' +
+        'own (after the primary write already succeeded and ' +
+        'idempotencyKey is already set and must stay set), the item is left ' +
+        'permanently claimed with its target unrecoverable -- every future ' +
+        '"already committed" response would report `target: null` forever.',
+    )
+  }
+
+  if (
+    finalUpdateBlock.includes('targetType: target.type') ||
+    finalUpdateBlock.includes('targetId: target.id')
+  ) {
+    errors.push(
+      "commit.post.ts's final stageStatuses write still carries " +
+        'targetType/targetId in the same `data: {...}` object -- this is ' +
+        'the exact combined-write shape the fix was meant to split apart. ' +
+        'If that final write fails, target is lost along with it.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(ROUTE_PATH, 'utf8')
+  const errors = checkCommitTargetPersistenceGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder commit target-persistence guard contract failed for ' +
+        'server/api/model-builder/items/[id]/commit.post.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder commit target-persistence guard contract passed: ' +
+      'targetType/targetId are durably persisted in their own write ' +
+      'immediately after the primary write succeeds, separate from the ' +
+      'final stageStatuses read-modify-write.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What

`server/api/model-builder/items/[id]/commit.post.ts`'s final write bundled `targetType`/`targetId` together with a re-read/merge of `stageStatuses` in one combined `prisma.modelBuildItem.update()` call. That final write is a slower read-modify-write (`findUnique` immediately followed by `update`) than the primary write (`promoteAsset`/`updateText`/`createRecord`+`linkSourceToTarget`), and can fail on its own (a DB blip, connection hiccup) *after* the primary write already succeeded.

When it does, `idempotencyKey` correctly stays set — resetting it would let a retry redo the primary write and duplicate the record — but with the old combined-write shape, `targetType`/`targetId` never got persisted either, since they lived in that same doomed write. The item was then left permanently claimed with its target unrecoverable: every future "already committed" response (both early-return branches in the route) would report `target: null` forever, orphaning the record the commit actually produced.

This closes conductor `model-builder/t-029` cycle 27 (the lead cycle 26 left for cycle 27).

## Change

- Durably persist `targetType`/`targetId` in their own minimal write immediately after the primary write succeeds, separate from the slower `stageStatuses` re-read/merge/write. A later failure in that second step can no longer orphan the target record.
- Added `utils/scripts/verifyModelBuilderCommitTargetPersistenceGuard.ts` + `.test.ts` asserting the split-write shape stays in place (the final write no longer carries `targetType`/`targetId`, and an earlier separate write does), wired into `package.json` and `contract-tests.yml`.

## Verification

- New guard's selftest + real-check both pass
- All 113 `test:model-builder-*` npm scripts pass (111 pre-existing + 2 new, including the `contract-tests-coverage` meta-guard added in cycle 26, confirming this PR's new scripts are correctly wired into CI)
- `vue-tsc --noEmit` repo-wide clean
- `eslint`/`prettier --check` clean on touched files
- `git status --porcelain` scoped to exactly the 5 intended files

## Flags for reviewer

Purely additive/defensive — no behavior change on the success path, only on an existing (rare) partial-failure path. `stakes: reversible`, `gate_human: false`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyhMVeVA1hsSMMmccknB25)_