### PR TITLE
fix(model-builder): gate artifact creation on GENERATE_ASSETS stage editability (t-029 cycle 28)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -707,6 +707,12 @@ jobs:
       - name: Model Builder item-patch stage guard contract
         run: npm run test:model-builder-item-patch-stage-guard
 
+      - name: Model Builder artifact-stage guard self-test
+        run: npm run test:model-builder-artifact-stage-guard-selftest
+
+      - name: Model Builder artifact-stage guard contract
+        run: npm run test:model-builder-artifact-stage-guard
+
       - name: Model Builder contract-tests coverage guard self-test
         run: npm run test:model-builder-contract-tests-coverage-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -221,6 +221,8 @@
     "test:model-builder-auto-build-draft-gate": "tsx utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts",
     "test:model-builder-item-patch-stage-guard-selftest": "tsx utils/scripts/verifyModelBuilderItemPatchStageGuard.test.ts",
     "test:model-builder-item-patch-stage-guard": "tsx utils/scripts/verifyModelBuilderItemPatchStageGuard.ts",
+    "test:model-builder-artifact-stage-guard-selftest": "tsx utils/scripts/verifyModelBuilderArtifactStageGuard.test.ts",
+    "test:model-builder-artifact-stage-guard": "tsx utils/scripts/verifyModelBuilderArtifactStageGuard.ts",
     "test:model-builder-run-writable-guard-selftest": "tsx utils/scripts/verifyModelBuilderRunWritableGuard.test.ts",
     "test:model-builder-run-writable-guard": "tsx utils/scripts/verifyModelBuilderRunWritableGuard.ts",
     "test:model-builder-open-run-identity-guard-selftest": "tsx utils/scripts/verifyModelBuilderOpenRunIdentityGuard.test.ts",

--- a/server/api/model-builder/items/[id]/artifacts.post.ts
+++ b/server/api/model-builder/items/[id]/artifacts.post.ts
@@ -5,6 +5,7 @@ import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
 import {
+  assertContentStageEditable,
   assertRunAccess,
   assertRunWritable,
   getItemId,
@@ -64,6 +65,36 @@ export default defineEventHandler(async (event) => {
     }
     assertRunAccess(item.Run, auth.user)
     assertRunWritable(item.Run)
+    // Every other GENERATE_ASSETS write goes through prepareItemUpdate's
+    // assertContentStageEditable(..., 'GENERATE_ASSETS', ...) gate (items/
+    // [id].patch.ts and items/batch.patch.ts, for body.artImageId) -- this
+    // route never did (model-builder/t-029 cycle 28), even though it's the
+    // one that actually persists each generated candidate as a durable
+    // ModelBuildArtifact row. modelBuilderStore.ts's generateItemAsset/
+    // pollAsyncArtJob only check their OWN in-memory item.stages.
+    // GENERATE_ASSETS before calling this route (verifyModelBuilder
+    // ApprovedAssetGuard.ts) -- a second browser tab (or a slow in-flight
+    // render that resolves after a *different* tab already approved the
+    // stage) has stale local state that still reads 'ready'/'in-progress',
+    // so it sails past that client-side check and lands here regardless of
+    // the item's actual server-side stage. The follow-up pushItem PATCH that
+    // sets item.artImageId IS correctly rejected by the item-patch-stage
+    // guard once the stage is 'approved' -- so item.artImageId itself never
+    // gets corrupted -- but this route already created the orphaned
+    // ModelBuildArtifact row for the stale render by then. adaptItem's
+    // imagePath reads Artifacts[Artifacts.length - 1]?.promotedPath ??
+    // draftPath (stores/modelBuilderStore.ts), i.e. whichever artifact row
+    // was created LAST, with no relation at all to which one artImageId
+    // actually points at -- so on the next resume/reload the item's
+    // displayed candidate silently becomes the orphaned, never-reviewed
+    // render instead of the one actually approved and committed, with the
+    // stage badge still reading 'approved'. Gating here the same way every
+    // sibling GENERATE_ASSETS write already is closes it at the source.
+    assertContentStageEditable(
+      item.stageStatuses,
+      'GENERATE_ASSETS',
+      'Art image',
+    )
 
     const body = await readBody<ArtifactBody>(event)
     if (typeof body.kind !== 'string' || !body.kind.trim()) {
@@ -73,34 +104,56 @@ export default defineEventHandler(async (event) => {
       })
     }
     await assertArtImageAttachable(body.artImageId, auth.user.id, auth.isAdmin)
+    // Narrowed to a plain local before entering the transaction closure below
+    // -- TS's control-flow narrowing of body.kind (from the typeof check
+    // above) does not carry into a nested async arrow function.
+    const kind = body.kind.slice(0, 64)
 
-    const artifact = await prisma.modelBuildArtifact.create({
-      data: {
-        itemId,
-        kind: body.kind.slice(0, 64),
-        provider: str(body.provider, 64),
-        model: str(body.model, 191),
-        seed: str(body.seed, 64),
-        prompt: str(body.prompt, 20000),
-        negativePrompt: str(body.negativePrompt, 20000),
-        width: int(body.width),
-        height: int(body.height),
-        workflow:
-          body.workflow && typeof body.workflow === 'object'
-            ? JSON.stringify(body.workflow)
-            : undefined,
-        format: str(body.format, 32),
-        artImageId: normalizeNullableId(body.artImageId) ?? null,
-        draftPath: str(body.draftPath, 20000),
-        promotedPath: str(body.promotedPath, 20000),
-        reviewState: reviewStates.has(body.reviewState as ModelBuildReviewState)
-          ? (body.reviewState as ModelBuildReviewState)
-          : 'PENDING',
-        usageInfo:
-          body.usageInfo && typeof body.usageInfo === 'object'
-            ? JSON.stringify(body.usageInfo)
-            : undefined,
-      },
+    const artifact = await prisma.$transaction(async (tx) => {
+      // Re-read stageStatuses immediately before the write, same reasoning
+      // as items/[id].patch.ts's identical re-check: the eager check above
+      // only ever saw the request-start `item` snapshot, read before
+      // readBody/assertArtImageAttachable's own awaits -- a concurrent
+      // approveStage landing in that window is invisible to it otherwise.
+      const fresh = await tx.modelBuildItem.findUnique({
+        where: { id: itemId },
+        select: { stageStatuses: true },
+      })
+      assertContentStageEditable(
+        fresh?.stageStatuses,
+        'GENERATE_ASSETS',
+        'Art image',
+      )
+      return tx.modelBuildArtifact.create({
+        data: {
+          itemId,
+          kind,
+          provider: str(body.provider, 64),
+          model: str(body.model, 191),
+          seed: str(body.seed, 64),
+          prompt: str(body.prompt, 20000),
+          negativePrompt: str(body.negativePrompt, 20000),
+          width: int(body.width),
+          height: int(body.height),
+          workflow:
+            body.workflow && typeof body.workflow === 'object'
+              ? JSON.stringify(body.workflow)
+              : undefined,
+          format: str(body.format, 32),
+          artImageId: normalizeNullableId(body.artImageId) ?? null,
+          draftPath: str(body.draftPath, 20000),
+          promotedPath: str(body.promotedPath, 20000),
+          reviewState: reviewStates.has(
+            body.reviewState as ModelBuildReviewState,
+          )
+            ? (body.reviewState as ModelBuildReviewState)
+            : 'PENDING',
+          usageInfo:
+            body.usageInfo && typeof body.usageInfo === 'object'
+              ? JSON.stringify(body.usageInfo)
+              : undefined,
+        },
+      })
     })
 
     event.node.res.statusCode = 201

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1424,6 +1424,18 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         return false
       }
 
+      // Snapshotted before the optimistic mutation below (mirrors approveStage/
+      // rejectStage/reopenStage) so a PATCH rejected by the server-side
+      // GENERATE_ASSETS stage gate can revert local state instead of leaving
+      // it silently diverged. That rejection is reachable here specifically:
+      // the 'approved' check just above only sees THIS tab's own in-memory
+      // stage, so a different tab approving the stage in the gap between that
+      // check and this PATCH landing (or an artifacts.post.ts write already
+      // rejected the same way, model-builder/t-029 cycle 28) still slips past
+      // it locally, even though the server correctly rejects the PATCH.
+      const previousArtImageId = item.artImageId
+      const previousImagePath = item.imagePath
+      const previousStages = { ...item.stages }
       const image = result.data as { id: number; imagePath?: string | null }
       item.artImageId = image.id
       item.imagePath = image.imagePath ?? null
@@ -1434,11 +1446,20 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       // item persisted (see the catch block below) -- otherwise a resolved
       // problem's stale message would resurface on the next resume/reload,
       // right alongside the freshly-generated candidate.
-      pushItem(item, {
-        stageStatuses: item.stages,
-        artImageId: item.artImageId,
-        error: null,
-      })
+      pushItem(
+        item,
+        {
+          stageStatuses: item.stages,
+          artImageId: item.artImageId,
+          error: null,
+        },
+        undefined,
+        () => {
+          item.artImageId = previousArtImageId
+          item.imagePath = previousImagePath
+          item.stages = previousStages
+        },
+      )
 
       // Gated by setStatusForRun, not a plain setStatus: the user may have
       // navigated away to (or started) a different run via resetRun/resetAll/
@@ -1580,6 +1601,11 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         return
       }
 
+      // Snapshotted for the same revert-on-rejected-PATCH reason as
+      // generateItemAsset's identical snapshot just above its own mutation.
+      const previousArtImageId = item.artImageId
+      const previousImagePath = item.imagePath
+      const previousStages = { ...item.stages }
       const image = result.data as { id: number; imagePath?: string | null }
       item.artImageId = image.id
       item.imagePath = image.imagePath ?? null
@@ -1587,11 +1613,20 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
 
       await recordArtifact(item, image, output, prompt, dims, runId)
       // error: null — see generateItemAsset's identical success-path clear.
-      pushItem(item, {
-        stageStatuses: item.stages,
-        artImageId: item.artImageId,
-        error: null,
-      })
+      pushItem(
+        item,
+        {
+          stageStatuses: item.stages,
+          artImageId: item.artImageId,
+          error: null,
+        },
+        undefined,
+        () => {
+          item.artImageId = previousArtImageId
+          item.imagePath = previousImagePath
+          item.stages = previousStages
+        },
+      )
 
       // Gated by setStatusForRun -- see its doc comment (same reasoning as
       // generateItemAsset's identical success-path gate above it).

--- a/utils/scripts/verifyModelBuilderArtifactStageGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderArtifactStageGuard.test.ts
@@ -1,0 +1,148 @@
+// /utils/scripts/verifyModelBuilderArtifactStageGuard.test.ts
+//
+// Regression test for checkArtifactStageGuard() in
+// verifyModelBuilderArtifactStageGuard.ts (model-builder/t-029 cycle 28).
+// Exercises the real check against synthetic artifacts.post.ts-shaped
+// fixtures covering: the pre-fix shape (no stage gate at all, a bare
+// `prisma.modelBuildArtifact.create`), a partial fix (only the eager check,
+// no fresh-read re-check inside a transaction -- still leaves the TOCTOU gap
+// open), and the fully fixed shape.
+import assert from 'node:assert/strict'
+
+import { checkArtifactStageGuard } from './verifyModelBuilderArtifactStageGuard.js'
+
+const BUGGY_FIXTURE = `
+    assertRunAccess(item.Run, auth.user)
+    assertRunWritable(item.Run)
+
+    const body = await readBody<ArtifactBody>(event)
+    if (typeof body.kind !== 'string' || !body.kind.trim()) {
+      throw createError({ statusCode: 400, message: 'Artifact "kind" is required.' })
+    }
+    await assertArtImageAttachable(body.artImageId, auth.user.id, auth.isAdmin)
+
+    const artifact = await prisma.modelBuildArtifact.create({
+      data: {
+        itemId,
+        kind: body.kind.slice(0, 64),
+      },
+    })
+`
+
+const PARTIAL_FIXTURE = `
+    assertRunAccess(item.Run, auth.user)
+    assertRunWritable(item.Run)
+    assertContentStageEditable(
+      item.stageStatuses,
+      'GENERATE_ASSETS',
+      'Art image',
+    )
+
+    const body = await readBody<ArtifactBody>(event)
+    await assertArtImageAttachable(body.artImageId, auth.user.id, auth.isAdmin)
+
+    const artifact = await prisma.modelBuildArtifact.create({
+      data: {
+        itemId,
+        kind: body.kind!.slice(0, 64),
+      },
+    })
+`
+
+const FIXED_FIXTURE = `
+    assertRunAccess(item.Run, auth.user)
+    assertRunWritable(item.Run)
+    assertContentStageEditable(
+      item.stageStatuses,
+      'GENERATE_ASSETS',
+      'Art image',
+    )
+
+    const body = await readBody<ArtifactBody>(event)
+    await assertArtImageAttachable(body.artImageId, auth.user.id, auth.isAdmin)
+
+    const artifact = await prisma.$transaction(async (tx) => {
+      const fresh = await tx.modelBuildItem.findUnique({
+        where: { id: itemId },
+        select: { stageStatuses: true },
+      })
+      assertContentStageEditable(
+        fresh?.stageStatuses,
+        'GENERATE_ASSETS',
+        'Art image',
+      )
+      return tx.modelBuildArtifact.create({
+        data: {
+          itemId,
+          kind: body.kind!.slice(0, 64),
+        },
+      })
+    })
+`
+
+function run(): void {
+  const buggyErrors = checkArtifactStageGuard(BUGGY_FIXTURE)
+  assert.equal(
+    buggyErrors.length,
+    3,
+    'expected the buggy fixture (no gate at all, bare create outside any ' +
+      `transaction) to fail three ways, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.match(buggyErrors[0]!, /0 time\(s\), expected at least 2/)
+  assert.match(
+    buggyErrors[1]!,
+    /does not wrap a `tx\.modelBuildItem\.findUnique`/,
+  )
+  assert.match(
+    buggyErrors[2]!,
+    /still calls `prisma\.modelBuildArtifact\.create`/,
+  )
+
+  const partialErrors = checkArtifactStageGuard(PARTIAL_FIXTURE)
+  assert.equal(
+    partialErrors.length,
+    3,
+    'expected the partial fixture (eager check only, no transaction ' +
+      're-check, bare create) to fail three ways, got: ' +
+      JSON.stringify(partialErrors),
+  )
+  assert.match(partialErrors[0]!, /1 time\(s\), expected at least 2/)
+  assert.match(
+    partialErrors[1]!,
+    /does not wrap a `tx\.modelBuildItem\.findUnique`/,
+  )
+  assert.match(
+    partialErrors[2]!,
+    /still calls `prisma\.modelBuildArtifact\.create`/,
+  )
+
+  const fixedErrors = checkArtifactStageGuard(FIXED_FIXTURE)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  // A regression that reintroduces a bare, ungated create alongside the
+  // transaction (e.g. a stray leftover call) must still fail even though
+  // both assertContentStageEditable calls are present.
+  const bareCreateAlongsideFixed = `${FIXED_FIXTURE}\n    const stray = await prisma.modelBuildArtifact.create({ data: { itemId } })\n`
+  const strayErrors = checkArtifactStageGuard(bareCreateAlongsideFixed)
+  assert.equal(
+    strayErrors.length,
+    1,
+    `expected exactly the bare-create error, got: ${JSON.stringify(strayErrors)}`,
+  )
+  assert.match(
+    strayErrors[0]!,
+    /still calls `prisma\.modelBuildArtifact\.create`/,
+  )
+
+  console.log(
+    'Model Builder artifact-stage guard self-test passed: buggy fixture ' +
+      'fails three ways, partial fixture fails three ways, fixed fixture ' +
+      'passes, a stray bare create alongside the fix still fails.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderArtifactStageGuard.ts
+++ b/utils/scripts/verifyModelBuilderArtifactStageGuard.ts
@@ -1,0 +1,138 @@
+// /utils/scripts/verifyModelBuilderArtifactStageGuard.ts
+//
+// Regression guard (model-builder/t-029 cycle 28) -- every other write that
+// touches an item's GENERATE_ASSETS content goes through prepareItemUpdate's
+// assertContentStageEditable(..., 'GENERATE_ASSETS', ...) gate (items/
+// [id].patch.ts and items/batch.patch.ts, for body.artImageId, both re-
+// checked against a fresh read immediately before the write -- see
+// verifyModelBuilderItemPatchStageGuard.ts / verifyModelBuilderContentStage
+// FreshnessGuard.ts). items/[id]/artifacts.post.ts never did, even though
+// it's the route that actually persists each generated candidate as a
+// durable ModelBuildArtifact row.
+//
+// modelBuilderStore.ts's generateItemAsset/pollAsyncArtJob only check their
+// OWN in-memory item.stages.GENERATE_ASSETS before calling this route
+// (verifyModelBuilderApprovedAssetGuard.ts) -- a second browser tab, or a
+// slow in-flight render that resolves after a *different* tab already
+// approved the stage, has stale local state that still reads
+// 'ready'/'in-progress', so it sails past that client-side check regardless
+// of the item's actual server-side stage. The follow-up PATCH that sets
+// item.artImageId is correctly rejected once the stage is 'approved' (that
+// field IS gated), so item.artImageId itself never gets corrupted -- but
+// this route already created the orphaned ModelBuildArtifact row for the
+// stale render by then. adaptItem's imagePath reads
+// Artifacts[Artifacts.length - 1]?.promotedPath ?? draftPath (stores/
+// modelBuilderStore.ts) -- whichever artifact row was created LAST, with no
+// relation to which one artImageId actually points at -- so on the next
+// resume/reload the item's displayed candidate silently becomes the
+// orphaned, never-reviewed render instead of the one actually approved and
+// committed, with the stage badge still reading 'approved'.
+//
+// Fixed by gating this route the same way every sibling GENERATE_ASSETS
+// write already is: an eager assertContentStageEditable check against the
+// request-start item read, and a second check against a fresh read inside
+// the same prisma.$transaction that creates the artifact row, so a
+// concurrent approveStage landing in between can't slip through either.
+//
+// This asserts the textual shape of that fix stays in place: two
+// assertContentStageEditable(..., 'GENERATE_ASSETS', 'Art image') calls, and
+// the artifact create happens via `tx.modelBuildArtifact.create` inside a
+// `prisma.$transaction` block that also re-reads stageStatuses -- not a bare
+// `prisma.modelBuildArtifact.create` outside any gate, which is the exact
+// shape a future "simplification" could easily reintroduce.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const ROUTE_PATH = join(
+  repositoryRoot,
+  'server/api/model-builder/items/[id]/artifacts.post.ts',
+)
+
+const GATE_CALL = 'assertContentStageEditable('
+const GATE_ARGS_RE =
+  /assertContentStageEditable\(\s*[\w.?]+,\s*\n?\s*'GENERATE_ASSETS',\s*\n?\s*'Art image',?\s*\n?\s*\)/g
+
+export function checkArtifactStageGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const gateMatches = content.match(GATE_ARGS_RE) ?? []
+  if (gateMatches.length < 2) {
+    errors.push(
+      `artifacts.post.ts calls assertContentStageEditable(..., ` +
+        `'GENERATE_ASSETS', 'Art image') ${gateMatches.length} time(s), ` +
+        'expected at least 2 -- one eager check against the request-start ' +
+        'item read, one re-check against a fresh read immediately before ' +
+        'the write. Without both, a stale second tab (or a render that ' +
+        'resolves after a concurrent approval) can create an orphaned ' +
+        'ModelBuildArtifact row for an item whose GENERATE_ASSETS stage is ' +
+        'already approved -- adaptItem then reconstructs imagePath from ' +
+        'that orphaned row on the next resume/reload instead of the ' +
+        'actually-approved one.',
+    )
+  }
+
+  const transactionIndex = content.indexOf('prisma.$transaction')
+  const freshReadIndex = content.indexOf('tx.modelBuildItem.findUnique')
+  const createIndex = content.indexOf('tx.modelBuildArtifact.create')
+  const bareCreateIndex = content.indexOf('prisma.modelBuildArtifact.create')
+
+  if (transactionIndex === -1 || freshReadIndex === -1 || createIndex === -1) {
+    errors.push(
+      'artifacts.post.ts does not wrap a `tx.modelBuildItem.findUnique` ' +
+        '(fresh stageStatuses re-read) and a `tx.modelBuildArtifact.create` ' +
+        'inside `prisma.$transaction` -- the artifact create must happen ' +
+        'in the same transaction as the fresh stage re-check, or the ' +
+        'TOCTOU gap the re-check exists to close reopens.',
+    )
+  } else if (!(
+    transactionIndex < freshReadIndex && freshReadIndex < createIndex
+  )) {
+    errors.push(
+      'artifacts.post.ts has `prisma.$transaction`, `tx.modelBuildItem.' +
+        'findUnique`, and `tx.modelBuildArtifact.create`, but not in that ' +
+        'order -- the fresh stageStatuses read must happen before the ' +
+        'artifact create, both inside the transaction.',
+    )
+  }
+
+  if (bareCreateIndex !== -1) {
+    errors.push(
+      'artifacts.post.ts still calls `prisma.modelBuildArtifact.create` ' +
+        'directly (outside `tx.`) -- this is the exact ungated shape the ' +
+        'fix was meant to replace.',
+    )
+  }
+
+  void GATE_CALL
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(ROUTE_PATH, 'utf8')
+  const errors = checkArtifactStageGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder artifact-stage guard contract failed for ' +
+        'server/api/model-builder/items/[id]/artifacts.post.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder artifact-stage guard contract passed: artifacts.post.ts ' +
+      'gates ModelBuildArtifact creation on GENERATE_ASSETS stage ' +
+      'editability, eagerly and against a fresh read inside the write ' +
+      'transaction.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
conductor/model-builder/t-029 cycle 28: Polish and upgrade Model Builder front-end surface (kind: software)

### What changed / what I produced
- `server/api/model-builder/items/[id]/artifacts.post.ts` never checked whether an item's GENERATE_ASSETS stage was actually editable server-side before creating a durable `ModelBuildArtifact` row — every sibling GENERATE_ASSETS write (`body.artImageId` via `items/[id].patch.ts` / `items/batch.patch.ts`) already gates through `assertContentStageEditable`, but this route didn't.
- `modelBuilderStore.ts`'s `generateItemAsset`/`pollAsyncArtJob` only check their own in-memory `item.stages.GENERATE_ASSETS` before POSTing here. A second browser tab (or a slow in-flight render that resolves after a *different* tab already approved the stage) has stale local state that sails past that client-side check regardless of the item's real server-side stage. The follow-up PATCH setting `item.artImageId` is correctly rejected once the stage is `'approved'`, so `item.artImageId` itself never gets corrupted — but the artifacts route had already created an orphaned `ModelBuildArtifact` row for the stale render.
- `adaptItem`'s `imagePath` reads `Artifacts[Artifacts.length - 1]?.promotedPath ?? draftPath` — whichever artifact row was created **last**, unrelated to which one `artImageId` actually points at — so on the next resume/reload the item's displayed candidate silently became the orphaned, never-reviewed render instead of the actually-approved/committed one, while the stage badge kept reading `'approved'`.
- Fixed by gating this route the same way every sibling GENERATE_ASSETS write already is: an eager `assertContentStageEditable` check plus a fresh-read re-check inside the same `prisma.$transaction` that creates the artifact row.
- Also fixed the client-side half of the same race: `generateItemAsset`'s and `pollAsyncArtJob`'s `pushItem` calls for the `artImageId` PATCH didn't pass an `onFailure` revert, so a stale tab whose PATCH the server correctly rejects was still left showing the new (unapproved) image and stage locally with no way back to the true approved state short of a reload.
- Added `utils/scripts/verifyModelBuilderArtifactStageGuard.ts` + `.test.ts` (follows the existing `verifyModelBuilder*Guard.ts` pattern), wired into `package.json` and `contract-tests.yml`.

### How I verified
- New guard's selftest + real-check both pass.
- All 115 `test:model-builder-*` npm scripts pass (113 pre-existing + 2 new).
- `vue-tsc --noEmit` repo-wide clean.
- eslint clean on touched files (two pre-existing `no-empty` errors in `modelBuilderStore.ts` confirmed via `git stash` to predate this change).
- prettier clean on touched files (the file's pre-existing whole-file formatting drift also confirmed via `git stash`; this change's own added lines were checked against the file's established style, not standalone prettier's preference).
- `git status --porcelain` scoped to exactly the 6 intended files.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
No new lead surfaced for cycle 29 yet from this investigation — next cycle should do a fresh bug-hunt read of a not-recently-focused surface (e.g. `runs/[id].patch.ts`'s cancel/resume interaction with an in-flight async ArtJob, which hasn't had the same dedicated scrutiny as the item-level routes).

### Notes for reviewer
Part of the standing conductor `model-builder/t-029` recurring polish task (cycle 28 of an ongoing series).


---
_Generated by [Claude Code](https://claude.ai/code/session_014apz1R5cLJyiVxbPHi1gGK)_