### PR TITLE
fix(model-builder): guard async-enqueue success path against a cancelled run (t-029 cycle 29)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -587,6 +587,12 @@ jobs:
       - name: Model Builder async-enqueue cancelled-run guard contract
         run: npm run test:model-builder-async-enqueue-cancelled-run-guard
 
+      - name: Model Builder async-enqueue success cancelled-run guard checker self-test
+        run: npm run test:model-builder-async-enqueue-success-cancelled-run-guard-selftest
+
+      - name: Model Builder async-enqueue success cancelled-run guard contract
+        run: npm run test:model-builder-async-enqueue-success-cancelled-run-guard
+
       - name: Model Builder recordArtifact success guard checker self-test
         run: npm run test:model-builder-record-artifact-success-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -281,6 +281,8 @@
     "test:model-builder-batch-any-in-flight-guard": "tsx utils/scripts/verifyModelBuilderBatchAnyInFlightGuard.ts",
     "test:model-builder-async-enqueue-cancelled-run-guard-selftest": "tsx utils/scripts/verifyModelBuilderAsyncEnqueueCancelledRunGuard.test.ts",
     "test:model-builder-async-enqueue-cancelled-run-guard": "tsx utils/scripts/verifyModelBuilderAsyncEnqueueCancelledRunGuard.ts",
+    "test:model-builder-async-enqueue-success-cancelled-run-guard-selftest": "tsx utils/scripts/verifyModelBuilderAsyncEnqueueSuccessCancelledRunGuard.test.ts",
+    "test:model-builder-async-enqueue-success-cancelled-run-guard": "tsx utils/scripts/verifyModelBuilderAsyncEnqueueSuccessCancelledRunGuard.ts",
     "test:model-builder-record-artifact-success-guard-selftest": "tsx utils/scripts/verifyModelBuilderRecordArtifactSuccessGuard.test.ts",
     "test:model-builder-record-artifact-success-guard": "tsx utils/scripts/verifyModelBuilderRecordArtifactSuccessGuard.ts",
     "test:model-builder-fetch-runs-staleness-guard-selftest": "tsx utils/scripts/verifyModelBuilderFetchRunsStalenessGuard.test.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1688,6 +1688,21 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         throw new Error(enqueued.message || 'Failed to queue generation.')
       }
 
+      // enqueueCurrentArt is the same class of network round-trip the catch
+      // block below already guards (its own comment: "missing here until
+      // now") -- but that guard only covers the *failure* path. The user can
+      // just as easily cancel this exact run while the enqueue is in flight
+      // and have it come back successfully: without this check, this
+      // function would unconditionally arm item.artJobId with the new jobId
+      // and start pollAsyncArtJob for an item cancelRun() already cleared
+      // (or never saw, if the run wasn't the active one) -- re-arming a poll
+      // for a run the user just told us to abandon. pollAsyncArtJob's own
+      // cancelledRunIds check (model-builder/t-029) does stop it from ever
+      // persisting a candidate, but only after minutes of pointless 5s
+      // polling against a detached item nothing displays. Mirrors
+      // generateItemAsset's identical guard on its own network round-trip.
+      if (cancelledRunIds.has(runId)) return false
+
       item.artJobId = enqueued.jobId
       void pollAsyncArtJob(
         item,

--- a/utils/scripts/verifyModelBuilderAsyncEnqueueSuccessCancelledRunGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderAsyncEnqueueSuccessCancelledRunGuard.test.ts
@@ -1,0 +1,134 @@
+// /utils/scripts/verifyModelBuilderAsyncEnqueueSuccessCancelledRunGuard.test.ts
+//
+// Regression test for checkAsyncEnqueueSuccessCancelledRunGuard() in
+// verifyModelBuilderAsyncEnqueueSuccessCancelledRunGuard.ts (model-builder/
+// t-029 cycle 29). Exercises the real check against synthetic store-shaped
+// fixtures covering: the pre-fix shape (no cancelledRunIds check before the
+// success path's `item.artJobId = enqueued.jobId` poll-arming assignment --
+// the exact gap found by manual read-through, comparing
+// generateItemAssetAsync's success path against its own catch block and its
+// synchronous sibling generateItemAsset), and the fixed shape.
+import assert from 'node:assert/strict'
+
+import { checkAsyncEnqueueSuccessCancelledRunGuard } from './verifyModelBuilderAsyncEnqueueSuccessCancelledRunGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function generateItemAssetAsync(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return false
+    const runId = state.run.id
+
+    item.error = null
+    item.queueState = 'queued'
+    item.stages.GENERATE_ASSETS = { status: 'in-progress', note: 'queued' }
+    clearStatus()
+
+    try {
+      await artStore.prepareArtGenerator()
+
+      const enqueued = await artStore.enqueueCurrentArt({ promptString: prompt })
+
+      if (!enqueued.success || !enqueued.jobId || !enqueued.data) {
+        throw new Error(enqueued.message || 'Failed to queue generation.')
+      }
+
+      item.artJobId = enqueued.jobId
+      void pollAsyncArtJob(item, enqueued.jobId, enqueued.data, output, prompt, dims, runId)
+      return true
+    } catch (error) {
+      if (cancelledRunIds.has(runId)) return false
+
+      handleError(error, 'queueing model builder asset')
+      item.error = error instanceof Error ? error.message : 'Failed to queue generation.'
+      finishGenerateAssets(item, { status: 'ready', note: item.error })
+      item.queueState = null
+      item.artJobId = null
+      setStatusForRun(runId, 'error', item.error)
+      return false
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function generateItemAssetAsync(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return false
+    const runId = state.run.id
+
+    item.error = null
+    item.queueState = 'queued'
+    item.stages.GENERATE_ASSETS = { status: 'in-progress', note: 'queued' }
+    clearStatus()
+
+    try {
+      await artStore.prepareArtGenerator()
+
+      const enqueued = await artStore.enqueueCurrentArt({ promptString: prompt })
+
+      if (!enqueued.success || !enqueued.jobId || !enqueued.data) {
+        throw new Error(enqueued.message || 'Failed to queue generation.')
+      }
+
+      if (cancelledRunIds.has(runId)) return false
+
+      item.artJobId = enqueued.jobId
+      void pollAsyncArtJob(item, enqueued.jobId, enqueued.data, output, prompt, dims, runId)
+      return true
+    } catch (error) {
+      if (cancelledRunIds.has(runId)) return false
+
+      handleError(error, 'queueing model builder asset')
+      item.error = error instanceof Error ? error.message : 'Failed to queue generation.'
+      finishGenerateAssets(item, { status: 'ready', note: item.error })
+      item.queueState = null
+      item.artJobId = null
+      setStatusForRun(runId, 'error', item.error)
+      return false
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkAsyncEnqueueSuccessCancelledRunGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  1,
+  `expected the pre-fix shape (missing cancelledRunIds check before the ` +
+    `poll-arming assignment) to raise 1 error, got ${buggyErrors.length}: ` +
+    `${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors[0]!.includes('cancelledRunIds'),
+  'expected a violation naming the missing cancelledRunIds check',
+)
+
+const fixedErrors = checkAsyncEnqueueSuccessCancelledRunGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingFnErrors =
+  checkAsyncEnqueueSuccessCancelledRunGuard(MISSING_FIXTURE)
+assert.equal(
+  missingFnErrors.length,
+  1,
+  'expected a single "function not found" violation when ' +
+    'generateItemAssetAsync is absent',
+)
+assert.ok(missingFnErrors[0]!.includes('generateItemAssetAsync'))
+
+console.log(
+  'Model Builder async-enqueue success cancelled-run guard checker ' +
+    'verified: flags the pre-fix shape (missing cancelledRunIds check ' +
+    'before the poll-arming assignment), clears the fixed shape, and flags ' +
+    'generateItemAssetAsync being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderAsyncEnqueueSuccessCancelledRunGuard.ts
+++ b/utils/scripts/verifyModelBuilderAsyncEnqueueSuccessCancelledRunGuard.ts
@@ -1,0 +1,119 @@
+// /utils/scripts/verifyModelBuilderAsyncEnqueueSuccessCancelledRunGuard.ts
+//
+// Regression guard (model-builder/t-029 cycle 29) -- generateItemAssetAsync()'s
+// SUCCESS path (after `artStore.enqueueCurrentArt()` resolves with a real job)
+// unconditionally armed `item.artJobId = enqueued.jobId` and started
+// `pollAsyncArtJob` with no check against cancelledRunIds. Its own catch block
+// already guards the failure path this exact same way (see
+// verifyModelBuilderAsyncEnqueueCancelledRunGuard.ts), and its synchronous
+// sibling generateItemAsset guards its equivalent success path too (`if
+// (cancelledRunIds.has(runId)) return false` immediately after
+// `artStore.generateCurrentArt()` resolves, before touching the result) --
+// generateItemAssetAsync's success branch never got the same treatment.
+//
+// enqueueCurrentArt is a network round-trip the user can cancel this exact run
+// during (click "Queue generation in background", then hit Cancel on the run
+// before the enqueue POST resolves). Without this check, a successful enqueue
+// that lands after cancellation still arms item.artJobId and starts a fresh
+// pollAsyncArtJob loop for an item cancelRun() already detached (or never saw,
+// if this run wasn't the active one) -- re-arming a 5s poll loop for a run the
+// user already told the app to abandon. pollAsyncArtJob's own cancelledRunIds
+// check does stop it from ever persisting a candidate once the job resolves,
+// but only after minutes of pointless polling against a run nothing displays
+// any more.
+//
+// This asserts the textual shape of the fix stays in place: a
+// `cancelledRunIds.has(runId)` check appears in generateItemAssetAsync's body
+// strictly before the `item.artJobId = enqueued.jobId` assignment that arms
+// the poll -- deliberately scoped to this one function/bug, mirroring
+// verifyModelBuilderAsyncEnqueueCancelledRunGuard.ts's own narrow textual
+// check over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'generateItemAssetAsync'
+const ARM_POLL_ASSIGNMENT = 'item.artJobId = enqueued.jobId'
+const GUARD = 'cancelledRunIds.has(runId)'
+
+// Checks the fix's exact shape against the full source text of a file
+// containing a `generateItemAssetAsync`-named async function. Exported
+// (rather than only exercised via main()) so the self-test below can run it
+// against synthetic buggy/fixed fixtures without touching the real store
+// file.
+export function checkAsyncEnqueueSuccessCancelledRunGuard(
+  content: string,
+): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find an async function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  const armPollIndex = fn.body.indexOf(ARM_POLL_ASSIGNMENT)
+  if (armPollIndex === -1) {
+    errors.push(
+      `${FN_NAME}() no longer contains \`${ARM_POLL_ASSIGNMENT}\` -- this ` +
+        "guard's anchor point has moved; re-check how this function arms " +
+        'its async poll after a successful enqueue.',
+    )
+    return errors
+  }
+
+  const guardIndex = fn.body.indexOf(GUARD)
+  if (guardIndex === -1 || guardIndex >= armPollIndex) {
+    errors.push(
+      `${FN_NAME}() does not check \`${GUARD}\` before its ` +
+        `${ARM_POLL_ASSIGNMENT} assignment. enqueueCurrentArt is a network ` +
+        'round-trip the user can cancel this run during; without this ' +
+        'check, a successful enqueue that lands after cancellation still ' +
+        'arms item.artJobId and starts a fresh pollAsyncArtJob loop for a ' +
+        'run the user already told the app to abandon -- unlike this ' +
+        "function's own catch block, and its synchronous sibling " +
+        'generateItemAsset, which both guard their equivalent path the ' +
+        'same way.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkAsyncEnqueueSuccessCancelledRunGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder async-enqueue success cancelled-run guard contract ' +
+        `failed for ${FN_NAME}() in modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder async-enqueue success cancelled-run guard contract ' +
+      `passed: ${FN_NAME}() checks cancelledRunIds before arming its async ` +
+      'poll on a successful enqueue, matching its own catch block and its ' +
+      'synchronous sibling generateItemAsset.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
conductor/model-builder/t-029 cycle 29: Polish and upgrade Model Builder front-end surface (kind: software)

### What changed / what I produced
- `generateItemAssetAsync()`'s **success** path (after `artStore.enqueueCurrentArt()` resolves with a real job) unconditionally armed `item.artJobId = enqueued.jobId` and started `pollAsyncArtJob` with no check against `cancelledRunIds`.
- This function's own **catch** block already guards its equivalent failure path this exact same way (fixed in an earlier cycle — see `verifyModelBuilderAsyncEnqueueCancelledRunGuard.ts`), and its synchronous sibling `generateItemAsset` guards its equivalent success path too (`if (cancelledRunIds.has(runId)) return false` immediately after `artStore.generateCurrentArt()` resolves, before touching the result). The async success branch never got the same treatment.
- `enqueueCurrentArt` is a network round-trip the user can cancel this exact run during: click "Queue generation in background", then hit Cancel on the run before the enqueue POST resolves. Without this check, a successful enqueue that lands after cancellation still arms `item.artJobId` and starts a fresh `pollAsyncArtJob` loop for an item `cancelRun()` already detached (or never saw, if this wasn't the active run) — re-arming a 5s poll loop for a run the user already told the app to abandon. `pollAsyncArtJob`'s own `cancelledRunIds` check does stop it from ever persisting a candidate once the job resolves, but only after minutes of pointless polling against a run nothing displays any more.
- Fixed by adding the same `cancelledRunIds.has(runId)` guard right after the enqueue succeeds, before arming the poll — mirroring the catch block and the synchronous sibling exactly.
- Added `utils/scripts/verifyModelBuilderAsyncEnqueueSuccessCancelledRunGuard.ts` + `.test.ts` (follows the existing `verifyModelBuilder*Guard.ts` pattern), wired into `package.json` and `contract-tests.yml`.

### How I verified
- New guard's selftest + real-check both pass.
- All 117 `test:model-builder-*` npm scripts pass (115 pre-existing + 2 new), including the `contract-tests-coverage` meta-guard (confirms the new scripts are correctly wired into CI).
- `vue-tsc --noEmit` repo-wide clean.
- eslint clean on touched files (two pre-existing `no-empty` errors in `modelBuilderStore.ts` confirmed via `git stash` to predate this change).
- prettier clean on touched files (the store file's pre-existing whole-file formatting drift confirmed via `git stash` to predate this change; the two new files are prettier-clean).
- `git status --porcelain` scoped to exactly the 5 intended files.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Next cycle should do a fresh bug-hunt read of `commitItem`'s interaction with a concurrent `batchPushItems` call on the same item — hasn't had the same dedicated scrutiny as the single-item generate/patch paths this and the last few cycles focused on.

### Notes for reviewer
Part of the standing conductor `model-builder/t-029` recurring polish task (cycle 29 of an ongoing series).

---
_Generated by [Claude Code](https://claude.ai/code/session_0154wsnLQuBvY2GT9K1X9wXA)_