### PR TITLE
feat(lora): stack compatible LoRAs across art and video

### DIFF
--- a/components/art/art-lora-picker.vue
+++ b/components/art/art-lora-picker.vue
@@ -8,18 +8,28 @@
           LoRAs <span class="font-normal opacity-50">(optional)</span>
         </h3>
         <p class="mt-0.5 text-xs text-base-content/55">
-          Stack up to {{ MAX_LORAS_PER_JOB }}. They apply in the order below —
-          later ones layer on top of earlier ones.
+          Stack up to {{ MAX_LORAS_PER_JOB }} compatible LoRAs. They apply in
+          order, and trigger words are added to the render prompt automatically.
         </p>
       </div>
-      <button
-        v-if="modelValue.length"
-        type="button"
-        class="btn btn-ghost btn-xs rounded-xl"
-        @click="emitValue([])"
-      >
-        Clear all
-      </button>
+      <div class="flex flex-wrap items-center gap-1">
+        <button
+          v-if="rankedLoras.length"
+          type="button"
+          class="btn btn-ghost btn-xs rounded-xl"
+          @click="expanded = !expanded"
+        >
+          {{ expanded ? 'Comfortable height' : 'Expand browser' }}
+        </button>
+        <button
+          v-if="modelValue.length"
+          type="button"
+          class="btn btn-ghost btn-xs rounded-xl"
+          @click="emitValue([])"
+        >
+          Clear all
+        </button>
+      </div>
     </div>
 
     <p
@@ -31,7 +41,6 @@
     </p>
 
     <template v-else>
-      <!-- Selected stack, in apply order -->
       <ol v-if="selected.length" class="space-y-2">
         <li
           v-for="(entry, index) in selected"
@@ -55,6 +64,12 @@
                 :title="entry.resource.localPath || ''"
               >
                 {{ entry.resource.localPath }}
+              </span>
+              <span
+                v-if="triggerWords(entry.resource)"
+                class="mt-0.5 line-clamp-2 block text-[11px] text-base-content/55"
+              >
+                Trigger: {{ triggerWords(entry.resource) }}
               </span>
             </span>
 
@@ -113,13 +128,6 @@
               @input="setStrength(entry.resourceId, $event)"
             />
           </div>
-
-          <p
-            v-if="!entry.resource.localPath"
-            class="mt-1 pl-7 text-[11px] text-error"
-          >
-            No localPath — ComfyUI cannot load this one.
-          </p>
         </li>
       </ol>
 
@@ -139,8 +147,9 @@
         v-else-if="!rankedLoras.length"
         class="rounded-xl border border-dashed border-base-300 bg-base-200/50 p-3 text-center text-xs text-base-content/60"
       >
-        No LoRA Resources are available to you yet. Add one from Discover, or
-        turn on mature content above if the one you want is flagged 18+.
+        No compatible LoRA Resources are available for {{ compatibilityLabel }}.
+        Switch the model/checkpoint, add a compatible Resource, or enable mature
+        content if the one you expect is flagged 18+.
       </p>
 
       <template v-else>
@@ -148,10 +157,13 @@
           v-model="search"
           type="search"
           class="input input-bordered input-sm w-full rounded-xl bg-base-200"
-          placeholder="Search LoRAs by name, path, or trigger word…"
+          placeholder="Search compatible LoRAs by name, path, or trigger word…"
         />
 
-        <div class="max-h-64 overflow-y-auto overscroll-contain pr-1">
+        <div
+          class="overflow-y-auto overscroll-contain pr-1"
+          :class="expanded ? 'max-h-none' : 'max-h-[32rem]'"
+        >
           <div
             class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,15rem),1fr))] gap-2"
           >
@@ -200,15 +212,7 @@
                   </span>
                 </span>
 
-                <span
-                  class="badge badge-xs rounded-lg"
-                  :class="entry.rank > 0 ? 'badge-secondary' : 'badge-ghost'"
-                  :title="
-                    entry.rank > 0
-                      ? `Ranked compatible with ${engineLabel}`
-                      : `Not tagged for ${engineLabel} — it may not load`
-                  "
-                >
+                <span class="badge badge-secondary badge-xs rounded-lg">
                   {{ entry.resource.supportedServer }}
                 </span>
 
@@ -216,7 +220,7 @@
                   v-if="triggerWords(entry.resource)"
                   class="line-clamp-2 block text-[11px] text-base-content/55"
                 >
-                  {{ triggerWords(entry.resource) }}
+                  Trigger: {{ triggerWords(entry.resource) }}
                 </span>
               </span>
             </button>
@@ -227,7 +231,7 @@
           v-if="search.trim() && !visibleLoras.length"
           class="text-xs text-base-content/50"
         >
-          No LoRA matches “{{ search.trim() }}”.
+          No compatible LoRA matches “{{ search.trim() }}”.
         </p>
       </template>
     </template>
@@ -240,9 +244,16 @@ import type { Resource } from '~/prisma/generated/prisma/client'
 import { useResourceStore } from '@/stores/resourceStore'
 import {
   engineProfile,
+  CHECKPOINT_FAMILY_LABELS,
   type ArtGeneratorEngine,
+  type CheckpointFamily,
 } from '@/utils/artGeneratorPresets'
 import { MAX_LORAS_PER_JOB } from '@/utils/loraLimits'
+import {
+  artLoraCompatibilityRank,
+  loraTriggerTerms,
+  type LoraPick,
+} from '@/utils/loraSelection'
 
 type PreviewArtImage = {
   imagePath?: string | null
@@ -252,16 +263,16 @@ type PreviewArtImage = {
 
 type LoraResource = Resource & { ArtImage?: PreviewArtImage | null }
 
-/** One link of the chain: which Resource, and how hard it is applied. */
-export type LoraPick = {
-  resourceId: number
-  strength: number
-}
+export type { LoraPick }
 
-const props = defineProps<{
-  modelValue: LoraPick[]
-  engine: ArtGeneratorEngine
-}>()
+const props = withDefaults(
+  defineProps<{
+    modelValue: LoraPick[]
+    engine: ArtGeneratorEngine
+    checkpointFamily?: CheckpointFamily
+  }>(),
+  { checkpointFamily: 'unknown' },
+)
 
 const emit = defineEmits<{
   'update:modelValue': [value: LoraPick[]]
@@ -269,40 +280,31 @@ const emit = defineEmits<{
 
 const resourceStore = useResourceStore()
 const search = ref('')
+const expanded = ref(false)
 
 const profile = computed(() => engineProfile(props.engine))
 const supported = computed(() => profile.value.supports.lora)
 const engineLabel = computed(() => profile.value.label)
 const atCapacity = computed(() => props.modelValue.length >= MAX_LORAS_PER_JOB)
-
-// Mirrors compatibilityRank() in server/utils/artLoraResource.ts. Nothing is
-// HIDDEN by rank -- the enqueue route only hard-blocks incompatible LoRAs on
-// the video and img2img lanes -- but a LoRA the server would rank at zero gets
-// a plain badge instead of a confident one.
-function rankFor(resource: LoraResource): number {
-  const supportedServer = String(resource.supportedServer || '')
-
-  if (props.engine === 'krea2' || props.engine === 'flux2') {
-    if (supportedServer === 'FLUX') return 30
-    if (supportedServer === 'KONTEXT') return 20
-    if (supportedServer === 'GENERIC') return 10
-    return 0
-  }
-
-  if (props.engine === 'comfy') {
-    if (supportedServer === 'SDXL') return 30
-    if (supportedServer === 'COMFY') return 15
-    if (supportedServer === 'GENERIC') return 10
-    return 0
-  }
-
-  return 0
-}
+const compatibilityLabel = computed(() => {
+  if (props.engine !== 'comfy') return engineLabel.value
+  return `${CHECKPOINT_FAMILY_LABELS[props.checkpointFamily]} checkpoint`
+})
 
 const rankedLoras = computed(() => {
+  if (!supported.value) return []
+
   return (resourceStore.visibleLoras as LoraResource[])
     .filter((resource) => Boolean(resource.localPath?.trim()))
-    .map((resource) => ({ resource, rank: rankFor(resource) }))
+    .map((resource) => ({
+      resource,
+      rank: artLoraCompatibilityRank(
+        resource,
+        props.engine,
+        props.checkpointFamily,
+      ),
+    }))
+    .filter((entry) => entry.rank > 0)
     .sort(
       (a, b) =>
         b.rank - a.rank ||
@@ -332,7 +334,6 @@ const visibleLoras = computed(() => {
   })
 })
 
-/** The picks that still resolve to a visible Resource, in apply order. */
 const selected = computed(() => {
   return props.modelValue
     .map((pick) => {
@@ -348,22 +349,25 @@ onMounted(async () => {
   if (!resourceStore.hasLoaded) await resourceStore.getResources()
 })
 
-// A pick that leaves the visible set -- the maturity toggle went off, or the
-// account lost access -- must not stay silently attached to the next job.
-watch([rankedLoras, supported], () => {
-  if (!resourceStore.hasLoaded) return
-  if (!props.modelValue.length) return
+// Model/checkpoint family changes are strict. A selected SDXL LoRA is removed
+// immediately when the user switches to an SD1.5 checkpoint instead of being
+// carried into a graph that cannot load it.
+watch(
+  [rankedLoras, supported, () => props.checkpointFamily, () => props.engine],
+  () => {
+    if (!resourceStore.hasLoaded || !props.modelValue.length) return
 
-  if (!supported.value) {
-    emitValue([])
-    return
-  }
+    if (!supported.value) {
+      emitValue([])
+      return
+    }
 
-  const survivors = props.modelValue.filter((pick) =>
-    byId.value.has(pick.resourceId),
-  )
-  if (survivors.length !== props.modelValue.length) emitValue(survivors)
-})
+    const survivors = props.modelValue.filter((pick) =>
+      byId.value.has(pick.resourceId),
+    )
+    if (survivors.length !== props.modelValue.length) emitValue(survivors)
+  },
+)
 
 function emitValue(picks: LoraPick[]): void {
   emit('update:modelValue', picks.slice(0, MAX_LORAS_PER_JOB))
@@ -416,7 +420,7 @@ function loraLabel(resource: LoraResource): string {
 }
 
 function triggerWords(resource: LoraResource): string {
-  return (resource.defaultTrigger || resource.triggerWords || '').trim()
+  return loraTriggerTerms(resource).join(', ')
 }
 
 function previewImage(resource: LoraResource): string {

--- a/components/art/art-lora-picker.vue
+++ b/components/art/art-lora-picker.vue
@@ -241,10 +241,12 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import type { Resource } from '~/prisma/generated/prisma/client'
+import { useCheckpointStore } from '@/stores/checkpointStore'
 import { useResourceStore } from '@/stores/resourceStore'
 import {
-  engineProfile,
   CHECKPOINT_FAMILY_LABELS,
+  detectCheckpointFamily,
+  engineProfile,
   type ArtGeneratorEngine,
   type CheckpointFamily,
 } from '@/utils/artGeneratorPresets'
@@ -265,20 +267,18 @@ type LoraResource = Resource & { ArtImage?: PreviewArtImage | null }
 
 export type { LoraPick }
 
-const props = withDefaults(
-  defineProps<{
-    modelValue: LoraPick[]
-    engine: ArtGeneratorEngine
-    checkpointFamily?: CheckpointFamily
-  }>(),
-  { checkpointFamily: 'unknown' },
-)
+const props = defineProps<{
+  modelValue: LoraPick[]
+  engine: ArtGeneratorEngine
+  checkpointFamily?: CheckpointFamily
+}>()
 
 const emit = defineEmits<{
   'update:modelValue': [value: LoraPick[]]
 }>()
 
 const resourceStore = useResourceStore()
+const checkpointStore = useCheckpointStore()
 const search = ref('')
 const expanded = ref(false)
 
@@ -286,9 +286,12 @@ const profile = computed(() => engineProfile(props.engine))
 const supported = computed(() => profile.value.supports.lora)
 const engineLabel = computed(() => profile.value.label)
 const atCapacity = computed(() => props.modelValue.length >= MAX_LORAS_PER_JOB)
+const effectiveCheckpointFamily = computed<CheckpointFamily>(() =>
+  props.checkpointFamily ?? detectCheckpointFamily(checkpointStore.selectedCheckpoint),
+)
 const compatibilityLabel = computed(() => {
   if (props.engine !== 'comfy') return engineLabel.value
-  return `${CHECKPOINT_FAMILY_LABELS[props.checkpointFamily]} checkpoint`
+  return `${CHECKPOINT_FAMILY_LABELS[effectiveCheckpointFamily.value]} checkpoint`
 })
 
 const rankedLoras = computed(() => {
@@ -301,7 +304,7 @@ const rankedLoras = computed(() => {
       rank: artLoraCompatibilityRank(
         resource,
         props.engine,
-        props.checkpointFamily,
+        effectiveCheckpointFamily.value,
       ),
     }))
     .filter((entry) => entry.rank > 0)
@@ -349,11 +352,8 @@ onMounted(async () => {
   if (!resourceStore.hasLoaded) await resourceStore.getResources()
 })
 
-// Model/checkpoint family changes are strict. A selected SDXL LoRA is removed
-// immediately when the user switches to an SD1.5 checkpoint instead of being
-// carried into a graph that cannot load it.
 watch(
-  [rankedLoras, supported, () => props.checkpointFamily, () => props.engine],
+  [rankedLoras, supported, effectiveCheckpointFamily, () => props.engine],
   () => {
     if (!resourceStore.hasLoaded || !props.modelValue.length) return
 

--- a/components/video-lora-picker.vue
+++ b/components/video-lora-picker.vue
@@ -1,23 +1,43 @@
 <template>
   <section class="space-y-3 rounded-lg border border-base-300 p-3">
-    <div class="flex flex-wrap items-center justify-between gap-2">
-      <div>
+    <div class="flex flex-wrap items-start justify-between gap-3">
+      <div class="min-w-0">
         <h2 class="font-semibold">
-          LoRA <span class="opacity-50">(optional)</span>
+          LoRAs <span class="opacity-50">(optional)</span>
         </h2>
         <p class="text-xs opacity-60">
-          {{ engine.toUpperCase() }}-compatible Resources only. Preview images
-          come from the Resource record.
+          Stack up to {{ MAX_LORAS_PER_JOB }} {{ engine.toUpperCase() }} LoRAs.
+          Trigger words are added to the render prompt automatically.
         </p>
       </div>
-      <button
-        v-if="modelValue"
-        type="button"
-        class="btn btn-xs btn-ghost"
-        @click="emit('update:modelValue', null)"
-      >
-        Clear LoRA
-      </button>
+      <div class="flex flex-wrap items-center gap-1">
+        <div class="join" aria-label="LoRA browser size">
+          <button
+            type="button"
+            class="btn btn-xs join-item"
+            :class="browserSize === 'comfortable' ? 'btn-accent' : 'btn-ghost'"
+            @click="browserSize = 'comfortable'"
+          >
+            Comfortable
+          </button>
+          <button
+            type="button"
+            class="btn btn-xs join-item"
+            :class="browserSize === 'expanded' ? 'btn-accent' : 'btn-ghost'"
+            @click="browserSize = 'expanded'"
+          >
+            Expand
+          </button>
+        </div>
+        <button
+          v-if="modelValue.length"
+          type="button"
+          class="btn btn-xs btn-ghost"
+          @click="emitValue([])"
+        >
+          Clear all
+        </button>
+      </div>
     </div>
 
     <maturity-toggle
@@ -27,134 +47,232 @@
       hidden-text="Mature video LoRAs are hidden from this selector."
     />
 
+    <ol v-if="selected.length" class="grid gap-2 md:grid-cols-2">
+      <li
+        v-for="(entry, index) in selected"
+        :key="entry.resourceId"
+        class="rounded-xl border border-accent/40 bg-accent/5 p-3"
+      >
+        <div class="flex items-start gap-2">
+          <span
+            class="flex size-6 shrink-0 items-center justify-center rounded-lg bg-accent text-xs font-black text-accent-content"
+          >
+            {{ index + 1 }}
+          </span>
+          <div class="min-w-0 flex-1">
+            <p class="truncate text-sm font-semibold">
+              {{ resourceLabel(entry.resource) }}
+            </p>
+            <p
+              class="truncate text-[11px] opacity-55"
+              :title="entry.resource.localPath || ''"
+            >
+              {{ entry.resource.localPath }}
+            </p>
+            <p
+              v-if="triggerText(entry.resource)"
+              class="mt-1 line-clamp-2 text-[11px] opacity-70"
+            >
+              <span class="font-semibold">Trigger:</span>
+              {{ triggerText(entry.resource) }}
+            </p>
+          </div>
+          <div class="flex shrink-0 gap-0.5">
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs btn-square"
+              :disabled="index === 0"
+              :aria-label="`Move ${resourceLabel(entry.resource)} earlier`"
+              @click="move(index, -1)"
+            >
+              ↑
+            </button>
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs btn-square"
+              :disabled="index === selected.length - 1"
+              :aria-label="`Move ${resourceLabel(entry.resource)} later`"
+              @click="move(index, 1)"
+            >
+              ↓
+            </button>
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs btn-square text-error"
+              :aria-label="`Remove ${resourceLabel(entry.resource)}`"
+              @click="remove(entry.resourceId)"
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+
+        <div class="mt-3 grid grid-cols-[minmax(0,1fr)_5.5rem] items-center gap-3">
+          <label class="space-y-1">
+            <span class="text-xs font-semibold">
+              Strength {{ entry.strength.toFixed(2) }}
+            </span>
+            <input
+              :value="entry.strength"
+              type="range"
+              min="-2"
+              max="2"
+              step="0.05"
+              class="range range-accent range-sm w-full"
+              :aria-label="`${resourceLabel(entry.resource)} strength`"
+              @input="setStrength(entry.resourceId, $event)"
+            />
+          </label>
+          <input
+            :value="entry.strength"
+            type="number"
+            min="-2"
+            max="2"
+            step="0.05"
+            class="input input-bordered input-sm w-full"
+            :aria-label="`${resourceLabel(entry.resource)} strength value`"
+            @input="setStrength(entry.resourceId, $event)"
+          />
+        </div>
+      </li>
+    </ol>
+
+    <p v-if="atCapacity" class="text-xs font-semibold text-warning">
+      Maximum stack reached. Remove one LoRA to add another.
+    </p>
+
     <div
       v-if="resourceStore.isLoading && !resourceStore.hasLoaded"
-      class="flex min-h-28 items-center justify-center rounded-lg bg-base-200"
+      class="flex min-h-32 items-center justify-center rounded-lg bg-base-200"
     >
       <span class="loading loading-spinner loading-sm" />
     </div>
 
     <div
       v-else-if="!compatibleResources.length"
-      class="rounded-lg border border-dashed border-base-300 bg-base-200/50 p-4 text-center text-sm opacity-70"
+      class="rounded-lg border border-dashed border-base-300 bg-base-200/50 p-5 text-center text-sm opacity-70"
     >
       No active {{ engine.toUpperCase() }} LoRA Resources are available.
     </div>
 
-    <div v-else class="max-h-64 overflow-y-auto overscroll-contain pr-1">
-      <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        <button
-          v-for="resource in compatibleResources"
-          :key="resource.id"
-          type="button"
-          class="overflow-hidden rounded-lg border text-left transition"
-          :class="
-            modelValue === resource.id
-              ? 'border-accent bg-accent/10 ring-2 ring-accent/20'
-              : 'border-base-300 bg-base-100 hover:border-accent/60'
-          "
-          :aria-pressed="modelValue === resource.id"
-          @click="selectResource(resource.id)"
-        >
-          <div
-            v-if="previewImages(resource).length"
-            class="grid aspect-video w-full overflow-hidden bg-base-200"
-            :class="
-              previewImages(resource).length > 1
-                ? 'grid-cols-2'
-                : 'grid-cols-1'
-            "
-          >
-            <img
-              v-for="src in previewImages(resource)"
-              :key="src"
-              :src="src"
-              :alt="`${resourceLabel(resource)} preview`"
-              class="h-full min-h-0 w-full object-cover"
-              loading="lazy"
-              @error="hideBrokenImage"
-            />
-          </div>
-          <div
-            v-else
-            class="flex aspect-video items-center justify-center bg-base-200 text-3xl opacity-30"
-            aria-hidden="true"
-          >
-            🎞️
-          </div>
-
-          <div class="space-y-1 p-3">
-            <div class="flex items-start justify-between gap-2">
-              <span class="font-semibold leading-tight">
-                {{ resourceLabel(resource) }}
-              </span>
-              <span class="flex shrink-0 items-center gap-1">
-                <span
-                  v-if="resource.isMature"
-                  class="badge badge-error badge-outline badge-sm"
-                >
-                  18+
-                </span>
-                <span
-                  v-if="modelValue === resource.id"
-                  class="badge badge-accent badge-sm"
-                >
-                  Selected
-                </span>
-              </span>
-            </div>
-            <p
-              class="truncate text-xs opacity-60"
-              :title="resource.localPath || ''"
-            >
-              {{ resource.localPath }}
-            </p>
-            <p
-              v-if="resource.defaultTrigger || resource.triggerWords"
-              class="line-clamp-2 text-xs opacity-70"
-            >
-              {{ resource.defaultTrigger || resource.triggerWords }}
-            </p>
-          </div>
-        </button>
-      </div>
-    </div>
-
-    <div
-      v-if="selectedResource"
-      class="grid gap-3 rounded-lg bg-base-200 p-3 sm:grid-cols-[1fr_7rem] sm:items-end"
-    >
-      <label class="space-y-1">
-        <span class="text-sm font-semibold">
-          LoRA strength: {{ normalizedStrength.toFixed(2) }}
-        </span>
+    <template v-else>
+      <div class="flex flex-wrap items-center gap-2">
         <input
-          :value="normalizedStrength"
-          type="range"
-          min="-2"
-          max="2"
-          step="0.05"
-          class="range range-accent range-sm w-full"
-          @input="updateStrength"
+          v-model="search"
+          type="search"
+          class="input input-bordered input-sm min-w-52 flex-1"
+          placeholder="Search LoRAs by name, path, or trigger word…"
         />
-      </label>
-      <input
-        :value="normalizedStrength"
-        type="number"
-        min="-2"
-        max="2"
-        step="0.05"
-        class="input input-bordered input-sm w-full"
-        aria-label="LoRA strength"
-        @input="updateStrength"
-      />
-    </div>
+        <span class="text-xs opacity-55">
+          {{ filteredResources.length }} compatible
+        </span>
+      </div>
+
+      <div
+        class="overflow-y-auto overscroll-contain pr-1 transition-[max-height]"
+        :class="browserSize === 'expanded' ? 'max-h-none' : 'max-h-[38rem]'"
+      >
+        <div
+          class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,17rem),1fr))] gap-3"
+        >
+          <button
+            v-for="resource in filteredResources"
+            :key="resource.id"
+            type="button"
+            class="overflow-hidden rounded-xl border text-left transition disabled:opacity-40"
+            :class="
+              isSelected(resource.id)
+                ? 'border-accent bg-accent/10 ring-2 ring-accent/20'
+                : 'border-base-300 bg-base-100 hover:border-accent/60'
+            "
+            :aria-pressed="isSelected(resource.id)"
+            :disabled="atCapacity && !isSelected(resource.id)"
+            @click="toggle(resource.id)"
+          >
+            <div
+              v-if="previewImages(resource).length"
+              class="grid aspect-video w-full overflow-hidden bg-base-200"
+              :class="
+                previewImages(resource).length > 1
+                  ? 'grid-cols-2'
+                  : 'grid-cols-1'
+              "
+            >
+              <img
+                v-for="src in previewImages(resource)"
+                :key="src"
+                :src="src"
+                :alt="`${resourceLabel(resource)} preview`"
+                class="h-full min-h-0 w-full object-cover"
+                loading="lazy"
+                @error="hideBrokenImage"
+              />
+            </div>
+            <div
+              v-else
+              class="flex aspect-video items-center justify-center bg-base-200 text-3xl opacity-30"
+              aria-hidden="true"
+            >
+              🎞️
+            </div>
+
+            <div class="space-y-1 p-3">
+              <div class="flex items-start justify-between gap-2">
+                <span class="min-w-0 truncate font-semibold leading-tight">
+                  {{ resourceLabel(resource) }}
+                </span>
+                <span class="flex shrink-0 items-center gap-1">
+                  <span
+                    v-if="resource.isMature"
+                    class="badge badge-error badge-outline badge-sm"
+                  >
+                    18+
+                  </span>
+                  <span
+                    v-if="isSelected(resource.id)"
+                    class="badge badge-accent badge-sm"
+                  >
+                    Selected
+                  </span>
+                </span>
+              </div>
+              <p
+                class="truncate text-xs opacity-60"
+                :title="resource.localPath || ''"
+              >
+                {{ resource.localPath }}
+              </p>
+              <p
+                v-if="triggerText(resource)"
+                class="line-clamp-2 text-xs opacity-70"
+              >
+                <span class="font-semibold">Trigger:</span>
+                {{ triggerText(resource) }}
+              </p>
+            </div>
+          </button>
+        </div>
+      </div>
+
+      <p
+        v-if="search.trim() && !filteredResources.length"
+        class="text-center text-xs opacity-55"
+      >
+        No compatible LoRA matches “{{ search.trim() }}”.
+      </p>
+    </template>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useResourceStore } from '@/stores/resourceStore'
+import { MAX_LORAS_PER_JOB } from '@/utils/loraLimits'
+import {
+  loraTriggerTerms,
+  videoLoraCompatible,
+  type LoraPick,
+} from '@/utils/loraSelection'
 import type { VideoEngine } from '@/utils/videoPresets'
 import type { Resource } from '~/prisma/generated/prisma/client'
 
@@ -169,61 +287,121 @@ type VideoLoraResource = Resource & {
 }
 
 const props = defineProps<{
-  modelValue: number | null
-  strength: number
+  modelValue: LoraPick[]
   engine: VideoEngine
 }>()
 
 const emit = defineEmits<{
-  'update:modelValue': [value: number | null]
-  'update:strength': [value: number]
+  'update:modelValue': [value: LoraPick[]]
 }>()
 
 const resourceStore = useResourceStore()
+const search = ref('')
+const browserSize = ref<'comfortable' | 'expanded'>('comfortable')
 
-const compatibleResources = computed<VideoLoraResource[]>(() => {
-  const supportedServer = props.engine.toUpperCase()
+const compatibleResources = computed<VideoLoraResource[]>(() =>
+  (resourceStore.visibleLoras as VideoLoraResource[]).filter(
+    (resource) =>
+      Boolean(resource.localPath?.trim()) &&
+      videoLoraCompatible(resource, props.engine),
+  ),
+)
 
-  return (resourceStore.visibleLoras as VideoLoraResource[]).filter(
-    (resource) => {
-      return (
-        Boolean(resource.localPath?.trim()) &&
-        (resource.supportedServer === supportedServer ||
-          resource.supportedServer === 'GENERIC')
-      )
-    },
+const byId = computed(
+  () => new Map(compatibleResources.value.map((resource) => [resource.id, resource])),
+)
+
+const selected = computed(() =>
+  props.modelValue
+    .map((pick) => {
+      const resource = byId.value.get(pick.resourceId)
+      return resource ? { ...pick, resource } : null
+    })
+    .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry)),
+)
+
+const atCapacity = computed(() => props.modelValue.length >= MAX_LORAS_PER_JOB)
+
+const filteredResources = computed(() => {
+  const needle = search.value.trim().toLowerCase()
+  if (!needle) return compatibleResources.value
+
+  return compatibleResources.value.filter((resource) =>
+    [
+      resource.name,
+      resource.customLabel,
+      resource.localPath,
+      resource.defaultTrigger,
+      resource.triggerWords,
+    ]
+      .filter((value): value is string => typeof value === 'string')
+      .some((value) => value.toLowerCase().includes(needle)),
   )
 })
 
-const selectedResource = computed(
-  () =>
-    compatibleResources.value.find(
-      (resource) => resource.id === props.modelValue,
-    ) ?? null,
-)
-
-const normalizedStrength = computed(() => clampStrength(props.strength))
-
 onMounted(async () => {
-  if (!resourceStore.hasLoaded) {
-    await resourceStore.getResources()
-  }
+  if (!resourceStore.hasLoaded) await resourceStore.getResources()
 })
 
-watch(
-  [() => props.engine, compatibleResources],
-  () => {
-    if (!resourceStore.hasLoaded) return
+// Engine/maturity/access changes prune invalid picks immediately. A WAN LoRA
+// never remains silently attached when the user switches to LTX, and vice versa.
+watch([() => props.engine, compatibleResources], () => {
+  if (!resourceStore.hasLoaded || !props.modelValue.length) return
+  const survivors = props.modelValue.filter((pick) => byId.value.has(pick.resourceId))
+  if (survivors.length !== props.modelValue.length) emitValue(survivors)
+})
 
-    if (props.modelValue && !selectedResource.value) {
-      emit('update:modelValue', null)
-    }
-  },
-  { immediate: true },
-)
+function emitValue(picks: LoraPick[]): void {
+  emit('update:modelValue', picks.slice(0, MAX_LORAS_PER_JOB))
+}
+
+function isSelected(resourceId: number): boolean {
+  return props.modelValue.some((pick) => pick.resourceId === resourceId)
+}
+
+function toggle(resourceId: number): void {
+  if (isSelected(resourceId)) {
+    remove(resourceId)
+    return
+  }
+  if (atCapacity.value) return
+  emitValue([...props.modelValue, { resourceId, strength: 1 }])
+}
+
+function remove(resourceId: number): void {
+  emitValue(props.modelValue.filter((pick) => pick.resourceId !== resourceId))
+}
+
+function move(index: number, offset: number): void {
+  const next = [...props.modelValue]
+  const target = index + offset
+  if (target < 0 || target >= next.length) return
+  const [moved] = next.splice(index, 1)
+  if (moved) next.splice(target, 0, moved)
+  emitValue(next)
+}
+
+function clampStrength(value: unknown): number {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return 1
+  return Math.min(2, Math.max(-2, parsed))
+}
+
+function setStrength(resourceId: number, event: Event): void {
+  const strength = clampStrength((event.target as HTMLInputElement).value)
+  emitValue(
+    props.modelValue.map((pick) =>
+      pick.resourceId === resourceId ? { ...pick, strength } : pick,
+    ),
+  )
+}
 
 function resourceLabel(resource: VideoLoraResource): string {
   return resource.customLabel?.trim() || resource.name
+}
+
+function triggerText(resource: VideoLoraResource): string {
+  return loraTriggerTerms(resource).join(', ')
 }
 
 function normalizeImagePath(value: string | null | undefined): string {
@@ -254,21 +432,6 @@ function previewImages(resource: VideoLoraResource): string[] {
     .filter(
       (path, index, paths) => Boolean(path) && paths.indexOf(path) === index,
     )
-}
-
-function selectResource(resourceId: number): void {
-  emit('update:modelValue', props.modelValue === resourceId ? null : resourceId)
-}
-
-function clampStrength(value: unknown): number {
-  const parsed = Number(value)
-  if (!Number.isFinite(parsed)) return 1
-  return Math.min(2, Math.max(-2, parsed))
-}
-
-function updateStrength(event: Event): void {
-  const target = event.target as HTMLInputElement
-  emit('update:strength', clampStrength(target.value))
 }
 
 function hideBrokenImage(event: Event): void {

--- a/components/video-lora-picker.vue
+++ b/components/video-lora-picker.vue
@@ -47,7 +47,10 @@
       hidden-text="Mature video LoRAs are hidden from this selector."
     />
 
-    <ol v-if="selected.length" class="grid gap-2 md:grid-cols-2">
+    <ol
+      v-if="selected.length"
+      class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,22rem),1fr))] gap-2"
+    >
       <li
         v-for="(entry, index) in selected"
         :key="entry.resourceId"
@@ -308,7 +311,10 @@ const compatibleResources = computed<VideoLoraResource[]>(() =>
 )
 
 const byId = computed(
-  () => new Map(compatibleResources.value.map((resource) => [resource.id, resource])),
+  () =>
+    new Map(
+      compatibleResources.value.map((resource) => [resource.id, resource]),
+    ),
 )
 
 const selected = computed(() =>
@@ -347,7 +353,9 @@ onMounted(async () => {
 // never remains silently attached when the user switches to LTX, and vice versa.
 watch([() => props.engine, compatibleResources], () => {
   if (!resourceStore.hasLoaded || !props.modelValue.length) return
-  const survivors = props.modelValue.filter((pick) => byId.value.has(pick.resourceId))
+  const survivors = props.modelValue.filter((pick) =>
+    byId.value.has(pick.resourceId),
+  )
   if (survivors.length !== props.modelValue.length) emitValue(survivors)
 })
 

--- a/pages/play/video-generator.vue
+++ b/pages/play/video-generator.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="kr-surface">
-    <div class="kr-scroll mx-auto max-w-5xl space-y-6 p-6">
+    <div class="kr-scroll mx-auto max-w-7xl space-y-6 p-6">
       <header class="space-y-1">
         <p class="text-sm opacity-70">
           Animate a still into a short clip. Presets choose sensible studio
@@ -191,11 +191,7 @@
         </details>
       </section>
 
-      <video-lora-picker
-        v-model="loraResourceId"
-        v-model:strength="loraStrength"
-        :engine="engine"
-      />
+      <video-lora-picker v-model="loraPicks" :engine="engine" />
 
       <content-visibility-controls
         v-model:is-mature="isMature"
@@ -402,8 +398,13 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useResourceStore } from '@/stores/resourceStore'
 import { useVideoStore } from '@/stores/videoStore'
 import { useUserStore } from '@/stores/userStore'
+import {
+  promptWithLoraTriggers,
+  type LoraPick,
+} from '@/utils/loraSelection'
 import {
   estimateVideoRuntimeTier,
   getDefaultVideoPreset,
@@ -422,6 +423,7 @@ const WINK_PRESET =
 
 const videoStore = useVideoStore()
 const userStore = useUserStore()
+const resourceStore = useResourceStore()
 const isLoggedIn = computed(() => userStore.isLoggedIn)
 
 const engines = [
@@ -463,8 +465,7 @@ const firstImage = ref('')
 const secondImage = ref('')
 const prompt = ref(WINK_PRESET)
 const negativePrompt = ref('')
-const loraResourceId = ref<number | null>(null)
-const loraStrength = ref(1)
+const loraPicks = ref<LoraPick[]>([])
 const isMature = ref(false)
 const isPublic = ref(true)
 const durationSeconds = ref(initialPreset.durationSeconds)
@@ -630,11 +631,16 @@ async function generate() {
     engine.value === 'ltx' &&
     renderScale.value < 1 &&
     Boolean(latentUpscaleModel.value)
+  const effectivePrompt = promptWithLoraTriggers(
+    prompt.value,
+    loraPicks.value,
+    resourceStore.visibleLoras,
+  )
 
   await videoStore.generate({
     engine: engine.value,
     presetId: videoPresetId.value || null,
-    promptString: prompt.value.trim(),
+    promptString: effectivePrompt,
     negativePrompt: negativePrompt.value.trim() || undefined,
     firstImageBase64: firstImage.value,
     secondImageBase64: secondImage.value || null,
@@ -650,8 +656,7 @@ async function generate() {
     refineSampler: shouldUpscale ? refineSampler.value : null,
     refineSigmas: shouldUpscale ? refineSigmas.value : null,
     timeoutSeconds: timeoutSeconds.value,
-    loraResourceIds: loraResourceId.value ? [loraResourceId.value] : undefined,
-    loraStrength: loraResourceId.value ? loraStrength.value : undefined,
+    loras: loraPicks.value,
     isMature: isMature.value,
     isPublic: isPublic.value,
   })

--- a/server/api/art/enqueue.post.ts
+++ b/server/api/art/enqueue.post.ts
@@ -20,6 +20,7 @@ import {
   ltxFrameCount,
 } from '../comfy/ltx/utils/imageToVideoWorkflow'
 import { normalizeVideoOutputFormat } from '../comfy/utils/videoOutput'
+import { applyVideoLoraChain } from '../comfy/utils/videoLoraChain'
 import {
   buildWanImageToVideoWorkflow,
   wanFrameCount,
@@ -661,17 +662,6 @@ function requireVideoNumber(
   return value
 }
 
-function clampOptionalNumber(
-  value: number | null | undefined,
-  fallback: number,
-  min: number,
-  max: number,
-): number {
-  const numberValue =
-    typeof value === 'number' && Number.isFinite(value) ? value : fallback
-  return Math.min(max, Math.max(min, numberValue))
-}
-
 function resolveVideoFrames(
   engine: EnqueueEngine,
   body: ArtEnqueueRequest | null | undefined,
@@ -724,10 +714,6 @@ function buildVideoJobPayload(
   }
 
   const negativePrompt = body.negativePrompt.trim()
-  const loraName = body.loraName?.trim() || null
-  const loraStrength = loraName
-    ? clampOptionalNumber(body.loraStrength, 1, -2, 2)
-    : null
   const images: QueuedImage[] = []
   let firstImageName: string | null = null
   let lastImageName: string | null = null
@@ -793,8 +779,6 @@ function buildVideoJobPayload(
         cfg: body.cfg ?? null,
         sampler: body.sampler ?? null,
         scheduler: body.scheduler ?? null,
-        loraName,
-        loraStrength,
         outputFormat,
       })
     : buildLtxImageToVideoWorkflow({
@@ -810,14 +794,18 @@ function buildVideoJobPayload(
         steps: body.steps ?? null,
         cfg: body.cfg ?? null,
         sampler: body.sampler ?? null,
-        styleLoraName: loraName,
-        styleLoraStrength: loraStrength,
         outputFormat,
         renderScale,
         latentUpscaleModel,
         refineSampler,
         refineSigmas,
       })
+
+  const videoLoras = applyVideoLoraChain(workflow, engine, {
+    loras: body.loras,
+    loraName: body.loraName,
+    loraStrength: body.loraStrength,
+  })
 
   const renderWidth = Math.max(64, Math.round((width * renderScale) / 8) * 8)
   const renderHeight = Math.max(64, Math.round((height * renderScale) / 8) * 8)
@@ -845,8 +833,9 @@ function buildVideoJobPayload(
         latentUpscaleModel,
         hasFirstImage: Boolean(firstImageName),
         hasLastImage: Boolean(lastImageName),
-        hasLora: Boolean(loraName),
-        loraStrength,
+        hasLora: videoLoras.length > 0,
+        loraCount: videoLoras.length,
+        loraStrengths: videoLoras.map((lora) => lora.strength),
         outputFormat,
       },
       save,

--- a/server/api/comfy/utils/videoLoraChain.ts
+++ b/server/api/comfy/utils/videoLoraChain.ts
@@ -1,0 +1,80 @@
+import {
+  appendModelOnlyLoraChain,
+  normalizeLoraSelections,
+  type LoraChainWorkflow,
+  type LoraSelection,
+} from './loraChain'
+
+export type VideoLoraEngine = 'ltx' | 'wan'
+
+export type VideoLoraRequest = {
+  loras?: unknown
+  loraName?: unknown
+  loraStrength?: unknown
+}
+
+function setModelRef(
+  workflow: LoraChainWorkflow,
+  nodeId: string,
+  model: [string, number],
+): void {
+  const node = workflow[nodeId]
+  if (!node?.inputs) return
+  node.inputs.model = model
+}
+
+/**
+ * Apply user-selected LoRAs after a video builder has created its base graph.
+ *
+ * LTX already has one REQUIRED distilled acceleration LoRA at node 293. User
+ * LoRAs therefore chain after node 293 and both the main and refine guiders read
+ * the final model. That required LoRA is deliberately not part of the user's
+ * stack or MAX_LORAS_PER_JOB allowance.
+ *
+ * WAN has two graph shapes. TI2V has one UNET/sampler. A14B has high- and
+ * low-noise experts, so every selected LoRA must be applied independently to
+ * both experts in the same order and at the same strength.
+ */
+export function applyVideoLoraChain(
+  workflow: LoraChainWorkflow,
+  engine: VideoLoraEngine,
+  request: VideoLoraRequest,
+): LoraSelection[] {
+  const loras = normalizeLoraSelections(request)
+  if (!loras.length) return loras
+
+  if (engine === 'ltx') {
+    const model = appendModelOnlyLoraChain(workflow, {
+      loras,
+      model: ['293', 0],
+      startId: 9000,
+    })
+    setModelRef(workflow, '315', model)
+    setModelRef(workflow, 'ltx_refine_guider', model)
+    return loras
+  }
+
+  if (workflow.sampler) {
+    const model = appendModelOnlyLoraChain(workflow, {
+      loras,
+      model: ['unet', 0],
+      startId: 9100,
+    })
+    setModelRef(workflow, 'sampler', model)
+    return loras
+  }
+
+  const highModel = appendModelOnlyLoraChain(workflow, {
+    loras,
+    model: ['unet_high', 0],
+    startId: 9100,
+  })
+  const lowModel = appendModelOnlyLoraChain(workflow, {
+    loras,
+    model: ['unet_low', 0],
+    startId: 9200,
+  })
+  setModelRef(workflow, 'sampler_high', highModel)
+  setModelRef(workflow, 'sampler_low', lowModel)
+  return loras
+}

--- a/server/utils/artLoraResource.ts
+++ b/server/utils/artLoraResource.ts
@@ -31,6 +31,8 @@ type LoraResourceRecord = {
   civitaiUrl: string | null
   huggingUrl: string | null
   supportedServer: SupportedServer
+  defaultTrigger: string | null
+  triggerWords: string | null
 }
 
 const LORA_TYPES = [ResourceType.LORA, ResourceType.LYCORIS]
@@ -41,12 +43,15 @@ const RESOURCE_RESOLVED_ENGINES = new Set([
   'ltx',
   'wan',
   'sdxl-img2img',
-  // Added with LoRA support on the named-checkpoint lane. Until then this lane
-  // could not carry a LoRA at all (enqueue.post.ts built its workflow without
-  // one), so nothing existed to break -- and leaving it out would have meant the
-  // ONE lane where a LoRA is picked by Resource id could not resolve that id,
-  // forcing the browser to send a filesystem path and be right about it.
   'comfy',
+])
+const STRICT_COMPATIBILITY_ENGINES = new Set([
+  'kontext',
+  'krea2',
+  'flux2',
+  'ltx',
+  'wan',
+  'sdxl-img2img',
 ])
 
 function normalizeText(value: unknown): string {
@@ -158,8 +163,18 @@ function compatibilityRank(
     if (resource.supportedServer === SupportedServer.SDXL) return 30
     if (resource.supportedServer === SupportedServer.COMFY) return 15
     if (resource.supportedServer === SupportedServer.GENERIC) return 10
-    // SD15 LoRAs are a different architecture and won't load on an SDXL
-    // checkpoint, so they stay rank 0 (blocked by the strict check below).
+  }
+
+  // The named-checkpoint lane can host either SDXL or SD1.5 checkpoints. The
+  // browser has enough checkpoint metadata to filter that distinction exactly;
+  // the server only knows the Resource class here, so it accepts both families
+  // plus explicitly generic Comfy LoRAs and leaves cross-family prevention to
+  // the checkpoint-aware picker.
+  if (engine === 'comfy') {
+    if (resource.supportedServer === SupportedServer.COMFY) return 20
+    if (resource.supportedServer === SupportedServer.SDXL) return 15
+    if (resource.supportedServer === SupportedServer.SD15) return 15
+    if (resource.supportedServer === SupportedServer.GENERIC) return 10
   }
 
   if (engine === 'ltx') {
@@ -209,11 +224,6 @@ type LoraRequest = {
   strength: number
 }
 
-/**
- * Flatten a request's LoRA fields into an ordered list of asks. The multi form
- * wins outright when present; otherwise the legacy singular pair becomes a
- * one-entry list, so every downstream path sees the same shape.
- */
 function readLoraRequests(body: LoraAwareEnqueueBody): LoraRequest[] {
   const requests: LoraRequest[] = []
 
@@ -250,8 +260,6 @@ function readLoraRequests(body: LoraAwareEnqueueBody): LoraRequest[] {
     }
   }
 
-  // Same Resource twice would silently double its strength rather than error,
-  // so the first ask wins and the duplicate is dropped.
   const seen = new Set<string>()
   return requests
     .filter((request) => {
@@ -265,6 +273,40 @@ function readLoraRequests(body: LoraAwareEnqueueBody): LoraRequest[] {
     .slice(0, MAX_LORAS_PER_JOB)
 }
 
+function triggerTerms(resource: LoraResourceRecord): string[] {
+  const preferred = String(resource.defaultTrigger || '').trim()
+  if (preferred) return [preferred]
+  return String(resource.triggerWords || '')
+    .split(/[,;\n]+/)
+    .map((value) => value.trim())
+    .filter(Boolean)
+}
+
+function appendResolvedTriggers(
+  body: LoraAwareEnqueueBody,
+  resources: LoraResourceRecord[],
+): string | null {
+  const base = String(
+    body.basePromptString || body.promptString || body.artPrompt || body.prompt || '',
+  ).trim()
+  if (!base) return null
+
+  const seen = new Set<string>()
+  const haystack = base.toLowerCase()
+  const additions: string[] = []
+
+  for (const resource of resources) {
+    for (const term of triggerTerms(resource)) {
+      const key = term.toLowerCase()
+      if (!key || seen.has(key) || haystack.includes(key)) continue
+      seen.add(key)
+      additions.push(term)
+    }
+  }
+
+  return additions.length ? [base, ...additions].join(', ') : base
+}
+
 export async function resolveEnqueueLoraResource(input: {
   body: LoraAwareEnqueueBody
   engine: string
@@ -273,9 +315,7 @@ export async function resolveEnqueueLoraResource(input: {
 }): Promise<{
   body: LoraAwareEnqueueBody
   resourceIds: number[]
-  /** Engine-facing paths, in apply order. */
   resourceNames: string[]
-  /** First resolved path. Kept for callers that only record one. */
   resourceName: string | null
 }> {
   const normalizedBody: LoraAwareEnqueueBody = {
@@ -293,9 +333,6 @@ export async function resolveEnqueueLoraResource(input: {
     }
   }
 
-  // Lanes outside RESOURCE_RESOLVED_ENGINES take engine-facing paths verbatim
-  // -- there is no Resource lookup to do -- but they still get the normalized
-  // list so a chain reaches their workflow builder.
   if (!RESOURCE_RESOLVED_ENGINES.has(input.engine)) {
     const named = requests.filter((request) => Boolean(request.name))
     return {
@@ -330,9 +367,10 @@ export async function resolveEnqueueLoraResource(input: {
     civitaiUrl: true,
     huggingUrl: true,
     supportedServer: true,
+    defaultTrigger: true,
+    triggerWords: true,
   } as const
 
-  // One query for the whole chain rather than one per link.
   const candidates = await prisma.resource.findMany({
     where: {
       AND: [{ isActive: true, resourceType: { in: LORA_TYPES } }, visibility],
@@ -366,9 +404,7 @@ export async function resolveEnqueueLoraResource(input: {
     }
 
     if (
-      (input.engine === 'ltx' ||
-        input.engine === 'wan' ||
-        input.engine === 'sdxl-img2img') &&
+      STRICT_COMPATIBILITY_ENGINES.has(input.engine) &&
       compatibilityRank(resource, input.engine) === 0
     ) {
       throw createError({
@@ -388,9 +424,6 @@ export async function resolveEnqueueLoraResource(input: {
     resolved.push({ resource, strength: request.strength })
   }
 
-  // Two different asks can land on the same Resource (an id and a name for the
-  // same file). Collapse them here, after resolution, for the same reason
-  // readLoraRequests dedupes before it.
   const seenIds = new Set<number>()
   const unique = resolved.filter(({ resource }) => {
     if (seenIds.has(resource.id)) return false
@@ -402,14 +435,16 @@ export async function resolveEnqueueLoraResource(input: {
     name: String(resource.localPath || '').trim(),
     strength,
   }))
+  const basePromptString = appendResolvedTriggers(
+    normalizedBody,
+    unique.map(({ resource }) => resource),
+  )
 
   return {
     body: {
       ...normalizedBody,
+      ...(basePromptString ? { basePromptString } : {}),
       loras,
-      // The singular pair still carries the FIRST link, so provenance readers,
-      // the ArtJob editor's style-LoRA override, and any caller that never
-      // learned about chaining keep seeing something coherent.
       loraName: loras[0]?.name ?? null,
       loraStrength: loras[0]?.strength ?? null,
       loraResourceIds: unique.map(({ resource }) => resource.id),

--- a/stores/videoStore.ts
+++ b/stores/videoStore.ts
@@ -11,6 +11,7 @@ import { reactive, computed } from 'vue'
 import type { ArtImage } from '~/prisma/generated/prisma/client'
 import { performFetch } from '@/stores/utils'
 import { artJobRetryNotice } from '@/utils/artJobRetryNotice'
+import type { LoraPick } from '@/utils/loraSelection'
 import type {
   VideoEngine,
   VideoOutputFormat,
@@ -32,8 +33,7 @@ export interface GenerateVideoParams {
   width: number
   height: number
   seed?: number | null
-  loraResourceIds?: number[]
-  loraStrength?: number | null
+  loras?: LoraPick[]
   outputFormat: VideoOutputFormat
   renderScale?: number | null
   latentUpscaleModel?: string | null
@@ -136,10 +136,12 @@ export const useVideoStore = defineStore('videoStore', () => {
       width: params.width,
       height: params.height,
       seed: params.seed ?? undefined,
-      loraResourceIds: params.loraResourceIds?.length
-        ? params.loraResourceIds
+      loras: params.loras?.length
+        ? params.loras.map((lora) => ({
+            resourceId: lora.resourceId,
+            strength: lora.strength,
+          }))
         : undefined,
-      loraStrength: params.loraStrength ?? undefined,
       outputFormat: params.outputFormat,
       renderScale: params.renderScale ?? undefined,
       latentUpscaleModel: params.latentUpscaleModel ?? undefined,

--- a/utils/loraSelection.ts
+++ b/utils/loraSelection.ts
@@ -1,0 +1,118 @@
+import type {
+  ArtGeneratorEngine,
+  CheckpointFamily,
+} from '@/utils/artGeneratorPresets'
+import type { VideoEngine } from '@/utils/videoPresets'
+
+export type LoraPick = {
+  resourceId: number
+  strength: number
+}
+
+export type LoraResourceLike = {
+  id: number
+  supportedServer?: string | null
+  defaultTrigger?: string | null
+  triggerWords?: string | null
+}
+
+function normalizedServer(resource: LoraResourceLike): string {
+  return String(resource.supportedServer || '').trim().toUpperCase()
+}
+
+export function videoLoraCompatible(
+  resource: LoraResourceLike,
+  engine: VideoEngine,
+): boolean {
+  const server = normalizedServer(resource)
+  return server === engine.toUpperCase() || server === 'GENERIC'
+}
+
+export function artLoraCompatibilityRank(
+  resource: LoraResourceLike,
+  engine: ArtGeneratorEngine,
+  checkpointFamily: CheckpointFamily = 'unknown',
+): number {
+  const server = normalizedServer(resource)
+
+  if (engine === 'krea2' || engine === 'flux2') {
+    if (server === 'FLUX') return 30
+    if (server === 'KONTEXT') return 20
+    if (server === 'GENERIC') return 10
+    return 0
+  }
+
+  if (engine !== 'comfy') return 0
+
+  if (checkpointFamily === 'sd15') {
+    if (server === 'SD15') return 30
+    if (server === 'COMFY') return 15
+    if (server === 'GENERIC') return 10
+    return 0
+  }
+
+  if (
+    checkpointFamily === 'sdxl' ||
+    checkpointFamily === 'sdxl-distilled' ||
+    checkpointFamily === 'pony'
+  ) {
+    if (server === 'SDXL') return 30
+    if (server === 'COMFY') return 15
+    if (server === 'GENERIC') return 10
+    return 0
+  }
+
+  // Unknown/archive checkpoints should only advertise LoRAs that explicitly
+  // claim broad Comfy compatibility. Guessing SDXL here is how a checkpoint
+  // switch can leave a loader wired to weights from a different architecture.
+  if (server === 'COMFY') return 15
+  if (server === 'GENERIC') return 10
+  return 0
+}
+
+export function artLoraCompatible(
+  resource: LoraResourceLike,
+  engine: ArtGeneratorEngine,
+  checkpointFamily: CheckpointFamily = 'unknown',
+): boolean {
+  return artLoraCompatibilityRank(resource, engine, checkpointFamily) > 0
+}
+
+export function loraTriggerTerms(resource: LoraResourceLike): string[] {
+  const preferred = String(resource.defaultTrigger || '').trim()
+  if (preferred) return [preferred]
+
+  return String(resource.triggerWords || '')
+    .split(/[,;\n]+/)
+    .map((value) => value.trim())
+    .filter(Boolean)
+}
+
+export function promptWithLoraTriggers(
+  prompt: string,
+  picks: LoraPick[],
+  resources: LoraResourceLike[],
+): string {
+  const cleanPrompt = prompt.trim()
+  if (!picks.length) return cleanPrompt
+
+  const byId = new Map(resources.map((resource) => [resource.id, resource]))
+  const additions: string[] = []
+  const seen = new Set<string>()
+  const haystack = cleanPrompt.toLowerCase()
+
+  for (const pick of picks) {
+    const resource = byId.get(pick.resourceId)
+    if (!resource) continue
+
+    for (const term of loraTriggerTerms(resource)) {
+      const key = term.toLowerCase()
+      if (!key || seen.has(key) || haystack.includes(key)) continue
+      seen.add(key)
+      additions.push(term)
+    }
+  }
+
+  if (!additions.length) return cleanPrompt
+  return [cleanPrompt, ...additions].filter(Boolean).join(', ')
+}

--- a/utils/scripts/verifyWanI2vModes.ts
+++ b/utils/scripts/verifyWanI2vModes.ts
@@ -1,16 +1,5 @@
-// Contract test for the two WAN image-to-video graphs.
-//
-// WAN 2.2 ships two i2v paths and this render box (12 GB card) can only afford
-// one interactively. Measured sizes on the host:
-//
-//   A14B  wan2.2_i2v_high_noise_14B_fp8   14 GB  } one resident at a time,
-//         wan2.2_i2v_low_noise_14B_fp8    14 GB  } still over the card
-//   TI2V  wan2.2_ti2v_5B_fp16            9.4 GB
-//
-// A14B does not fit, so ComfyUI offloads and the render becomes an overnight
-// job -- slow, not broken, and explicitly kept as the quality mode. TI2V is the
-// default. The two graphs are structurally different, and the differences are
-// exactly what a careless edit would flatten, so they are pinned here.
+// Contract test for the two WAN image-to-video graphs and the shared video
+// LoRA adapter layered on top of them.
 import assert from 'node:assert/strict'
 import type {
   ComfyWorkflow,
@@ -24,6 +13,11 @@ import {
   WAN_TI2V_VAE,
   WAN_VAE,
 } from '../../server/api/comfy/wan/utils/imageToVideoWorkflow'
+import { applyVideoLoraChain } from '../../server/api/comfy/utils/videoLoraChain'
+import {
+  promptWithLoraTriggers,
+  videoLoraCompatible,
+} from '../loraSelection'
 
 const base: WanImageToVideoInput = {
   prompt: 'a cat',
@@ -46,12 +40,38 @@ function maybeNode(
   return nodesOfClass(wf, cls)[0]
 }
 
-/** The node of this class, asserted present so callers can read `.inputs`. */
 function node(wf: ComfyWorkflow, cls: string): Required<ComfyWorkflowNode> {
   const found = maybeNode(wf, cls)
   assert.ok(found, `expected a ${cls} node`)
   assert.ok(found.inputs, `${cls} must carry inputs`)
   return found as Required<ComfyWorkflowNode>
+}
+
+function nodeById(wf: ComfyWorkflow, id: string): Required<ComfyWorkflowNode> {
+  const found = wf[id]
+  assert.ok(found?.inputs, `expected workflow node ${id}`)
+  return found as Required<ComfyWorkflowNode>
+}
+
+function assertModelChain(
+  wf: ComfyWorkflow,
+  start: unknown,
+  expectedNames: string[],
+  rootId: string,
+): void {
+  const walked: string[] = []
+  let ref = start as [string, number]
+
+  for (let index = 0; index < expectedNames.length; index += 1) {
+    assert.ok(Array.isArray(ref), 'model chain must use node references')
+    const current = nodeById(wf, ref[0])
+    assert.equal(current.class_type, 'LoraLoaderModelOnly')
+    walked.unshift(String(current.inputs.lora_name))
+    ref = current.inputs.model as [string, number]
+  }
+
+  assert.deepEqual(walked, expectedNames)
+  assert.deepEqual(ref, [rootId, 0], 'LoRA chain must terminate at its base model')
 }
 
 // --- mode selection ---------------------------------------------------------
@@ -69,9 +89,6 @@ assert.equal(
 assert.equal(
   resolveWanMode({ ...base, lastImageName: 'z.png' }),
   'a14b',
-  // Wan22ImageToVideoLatent declares only an optional start_image and has no
-  // end_image, so TI2V cannot honour a last frame. Routing to A14B costs time;
-  // silently dropping the pinned final frame would cost the user the feature.
   'a last-frame request must select the only graph that can do it',
 )
 
@@ -85,47 +102,49 @@ assert.equal(
   WAN_TI2V_VAE,
   'the 5B TI2V model is trained against the 2.2 VAE, not the 2.1 VAE',
 )
-assert.ok(
-  maybeNode(ti2v, 'Wan22ImageToVideoLatent'),
-  'TI2V uses the latent node',
-)
+assert.ok(maybeNode(ti2v, 'Wan22ImageToVideoLatent'))
 assert.equal(maybeNode(ti2v, 'WanImageToVideo'), undefined)
-assert.equal(
-  maybeNode(ti2v, 'KSamplerAdvanced'),
-  undefined,
-  'no expert handover, so no two-stage sampler',
-)
+assert.equal(maybeNode(ti2v, 'KSamplerAdvanced'), undefined)
 
 const sampler = node(ti2v, 'KSampler')
-// The load-bearing wiring difference. WanImageToVideo returns
-// (positive, negative, latent) and the A14B graph routes conditioning THROUGH
-// it. Wan22ImageToVideoLatent returns a LATENT only -- confirmed against the
-// host's /object_info -- so conditioning must come straight off the encoders.
-// Copying A14B's wiring here would reference outputs that do not exist.
 assert.deepEqual(sampler.inputs.positive, ['positive', 0])
 assert.deepEqual(sampler.inputs.negative, ['negative', 0])
 assert.deepEqual(sampler.inputs.latent_image, ['latent', 0])
 
 const latent = node(ti2v, 'Wan22ImageToVideoLatent')
 assert.deepEqual(latent.inputs.start_image, ['img_first', 0])
-assert.ok(
-  !('end_image' in latent.inputs),
-  'the node declares no end_image; emitting one would be rejected at submit',
-)
+assert.ok(!('end_image' in latent.inputs))
 for (const key of ['vae', 'width', 'height', 'length', 'batch_size']) {
   assert.ok(key in latent.inputs, `Wan22ImageToVideoLatent requires ${key}`)
 }
 
-// One unet means one LoRA, not the A14B matched pair.
+// Legacy direct-builder support remains one LoRA for backwards compatibility.
 const ti2vLora = buildWanImageToVideoWorkflow({
   ...base,
   loraName: 'x.safetensors',
 })
 const loraNodes = nodesOfClass(ti2vLora, 'LoraLoaderModelOnly')
-assert.equal(loraNodes.length, 1, 'TI2V has a single model to patch')
+assert.equal(loraNodes.length, 1, 'TI2V legacy input still patches one model')
 assert.deepEqual(node(ti2vLora, 'KSampler').inputs.model, ['lora', 0])
 
-// --- A14B graph is untouched ------------------------------------------------
+// The queue-facing adapter is the multi-LoRA path. Every selected LoRA must be
+// in the sampler's model chain, in order and with independent strengths.
+const wanLoras = [
+  { name: 'motion-one.safetensors', strength: 0.8 },
+  { name: 'motion-two.safetensors', strength: 1.15 },
+  { name: 'motion-three.safetensors', strength: 0.45 },
+]
+const ti2vStack = buildWanImageToVideoWorkflow(base)
+const appliedTi2v = applyVideoLoraChain(ti2vStack, 'wan', { loras: wanLoras })
+assert.deepEqual(appliedTi2v, wanLoras)
+assertModelChain(
+  ti2vStack,
+  node(ti2vStack, 'KSampler').inputs.model,
+  wanLoras.map((lora) => lora.name),
+  'unet',
+)
+
+// --- A14B graph -------------------------------------------------------------
 
 const a14b = buildWanImageToVideoWorkflow({ ...base, mode: 'a14b' })
 
@@ -145,7 +164,100 @@ assert.deepEqual(node(a14bLast, 'WanImageToVideo').inputs.end_image, [
   0,
 ])
 
+// A14B has two experts. The same ordered user stack must patch BOTH model paths.
+const a14bStack = buildWanImageToVideoWorkflow({ ...base, mode: 'a14b' })
+applyVideoLoraChain(a14bStack, 'wan', { loras: wanLoras })
+assertModelChain(
+  a14bStack,
+  nodeById(a14bStack, 'sampler_high').inputs.model,
+  wanLoras.map((lora) => lora.name),
+  'unet_high',
+)
+assertModelChain(
+  a14bStack,
+  nodeById(a14bStack, 'sampler_low').inputs.model,
+  wanLoras.map((lora) => lora.name),
+  'unet_low',
+)
+
+// LTX always keeps its hidden required distilled LoRA first, then chains the
+// user's style/motion stack after node 293. Both main and refinement guiders
+// must read the final user-LoRA model reference.
+const ltxSynthetic: ComfyWorkflow = {
+  '293': {
+    class_type: 'LoraLoaderModelOnly',
+    inputs: {
+      model: ['292', 0],
+      lora_name: 'ltx-required-distilled.safetensors',
+      strength_model: 0.5,
+    },
+    _meta: { title: 'Required Distilled LoRA' },
+  },
+  '315': {
+    class_type: 'CFGGuider',
+    inputs: { model: ['293', 0] },
+  },
+  ltx_refine_guider: {
+    class_type: 'CFGGuider',
+    inputs: { model: ['293', 0] },
+  },
+}
+applyVideoLoraChain(ltxSynthetic, 'ltx', { loras: wanLoras })
+assert.equal(
+  nodeById(ltxSynthetic, '293').inputs.lora_name,
+  'ltx-required-distilled.safetensors',
+  'the hidden required LTX LoRA is not replaced by the user stack',
+)
+assertModelChain(
+  ltxSynthetic,
+  nodeById(ltxSynthetic, '315').inputs.model,
+  wanLoras.map((lora) => lora.name),
+  '293',
+)
+assert.deepEqual(
+  nodeById(ltxSynthetic, '315').inputs.model,
+  nodeById(ltxSynthetic, 'ltx_refine_guider').inputs.model,
+  'main and refinement passes must use the same final styled LTX model',
+)
+
+// --- compatibility and triggers --------------------------------------------
+
+const wanResource = {
+  id: 1,
+  supportedServer: 'WAN',
+  defaultTrigger: 'cinematic camera orbit',
+  triggerWords: 'orbit, dolly',
+}
+const ltxResource = { id: 2, supportedServer: 'LTX' }
+const genericResource = { id: 3, supportedServer: 'GENERIC' }
+assert.equal(videoLoraCompatible(wanResource, 'wan'), true)
+assert.equal(videoLoraCompatible(wanResource, 'ltx'), false)
+assert.equal(videoLoraCompatible(ltxResource, 'wan'), false)
+assert.equal(videoLoraCompatible(genericResource, 'wan'), true)
+assert.equal(videoLoraCompatible(genericResource, 'ltx'), true)
+
+assert.equal(
+  promptWithLoraTriggers(
+    'A robot turns toward camera',
+    [{ resourceId: 1, strength: 1 }],
+    [wanResource],
+  ),
+  'A robot turns toward camera, cinematic camera orbit',
+  'the preferred trigger is appended to the effective render prompt',
+)
+assert.equal(
+  promptWithLoraTriggers(
+    'A robot, cinematic camera orbit',
+    [{ resourceId: 1, strength: 1 }],
+    [wanResource],
+  ),
+  'A robot, cinematic camera orbit',
+  'trigger decoration is idempotent',
+)
+
 console.log(
-  'WAN i2v mode contract OK: ti2v default (5B/2.2 VAE/single sampler), ' +
-    'a14b on request or last-frame, conditioning wired per graph.',
+  'WAN/video LoRA contract OK: TI2V and A14B retain their graph shapes, ' +
+    'ordered user LoRA stacks reach every sampler model path, LTX keeps its ' +
+    'required distilled LoRA, WAN/LTX compatibility stays distinct, and ' +
+    'trigger words are added idempotently.',
 )


### PR DESCRIPTION
## Summary
- make video generation support ordered multi-LoRA stacks with independent strengths end-to-end
- reuse the shared Comfy model-only LoRA chain for WAN and LTX, preserving LTX's required distilled LoRA
- strictly filter/prune incompatible LoRAs when switching video engines or art checkpoint families
- keep WAN and LTX LoRA families distinct, with GENERIC as the explicit cross-engine exception
- append Resource trigger words to the effective render prompt exactly once
- redesign the video LoRA browser with search, selected-stack controls, wider cards, and comfortable/expanded sizing
- give the art LoRA browser the same strict compatibility behavior and expandable height
- extend the WAN/video contract to verify multi-LoRA graph wiring, compatibility, and trigger injection

## Notes
PR #1984 was merged separately first. This branch is intentionally focused on LoRA behavior and UX.