### PR TITLE
fix(model-builder): exclude busy items from batch stage-status writes (t-029 cycle 30)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -725,6 +725,12 @@ jobs:
       - name: Model Builder contract-tests coverage guard contract
         run: npm run test:model-builder-contract-tests-coverage-guard
 
+      - name: Model Builder batch busy-item exclusion guard self-test
+        run: npm run test:model-builder-batch-busy-item-exclusion-guard-selftest
+
+      - name: Model Builder batch busy-item exclusion guard contract
+        run: npm run test:model-builder-batch-busy-item-exclusion-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -319,6 +319,8 @@
     "test:model-builder-source-field-guard": "tsx utils/scripts/verifyModelBuilderSourceFieldGuard.ts",
     "test:model-builder-contract-tests-coverage-guard-selftest": "tsx utils/scripts/verifyModelBuilderContractTestsCoverageGuard.test.ts",
     "test:model-builder-contract-tests-coverage-guard": "tsx utils/scripts/verifyModelBuilderContractTestsCoverageGuard.ts",
+    "test:model-builder-batch-busy-item-exclusion-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchBusyItemExclusionGuard.test.ts",
+    "test:model-builder-batch-busy-item-exclusion-guard": "tsx utils/scripts/verifyModelBuilderBatchBusyItemExclusionGuard.ts",
     "test:storybook-active-story-resume-guard": "npx tsx utils/scripts/verifyStorybookActiveStoryResumeGuard.ts",
     "test:storybook-answer-input-preservation-guard": "node utils/scripts/verifyStorybookAnswerInputPreservationGuard.mjs",
     "test:storybook-answer-rollback-guard": "node utils/scripts/verifyStorybookAnswerRollbackGuard.mjs",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -2237,6 +2237,43 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         // Skip items whose stage is already approved/locked — see
         // isStageEditable's doc comment.
         if (!isStageEditable(item, stageKey)) continue
+        // Bug (model-builder/t-029, cycle 30): a per-item manual action
+        // already in flight for this exact item was not excluded here --
+        // most concretely commitItem(), which sets
+        // item.stages.COMMIT = { status: 'in-progress' } locally *before*
+        // its own await and never itself persists that transient marker (it
+        // relies entirely on the server's own commit.post.ts write to
+        // resolve it; see finishCommit's doc comment). draftText below
+        // routes a successful draft through updatePitch/updateFields/
+        // updatePrompt, and every one of those calls pushItem with
+        // `stageStatuses: item.stages` -- the item's FULL current stage map,
+        // including whatever OTHER stage's transient 'in-progress' marker
+        // happens to be set at that instant. The server's diff-then-merge
+        // stage-status logic (diffStageStatusChanges/mergeStageStatusChanges
+        // in server/api/model-builder/runs/index.ts) can't tell a
+        // genuinely-intended change apart from a stale local-only marker
+        // leaking through, so it gets diffed against the server's real value
+        // and, if different, persisted -- if this write's own transaction
+        // happens to land AFTER commit.post.ts's dedicated fresh-read/merge
+        // final write (cycle 27), it silently reverts a just-committed
+        // item's COMMIT status from 'approved' back to a permanently-stuck
+        // 'in-progress' that nothing will ever resolve, even though
+        // targetType/targetId (written durably and separately, also cycle
+        // 27) still correctly point at the committed record -- the same
+        // "review gate lying about what's actually stored" class of bug this
+        // codebase treats as real everywhere else. model-builder-progress-
+        // matrix.vue renders model-builder-batch-editor.vue and model-
+        // builder-item-panel.vue side by side for the SAME selected item's
+        // group, so this is reachable in a single tab with no clock race:
+        // select an item, click "Execute commit" in the item panel, then
+        // immediately click "Draft pitches" (or any other batch action) in
+        // the batch editor for that same group while the commit POST is
+        // still in flight. Skip any item a manual single-item action already
+        // owns, mirroring autoBuildItem's own identical guard for the exact
+        // same reason. batchSetField/batchApproveStage carry the identical
+        // fix for the same reason -- see their own shorter cross-reference
+        // comments.
+        if (isItemManualActionInFlight(item.id)) continue
         const current =
           field === 'pitch'
             ? item.pitch
@@ -2328,6 +2365,13 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       // Skip items whose FIELDS_AND_PROMPTS is already approved/locked — see
       // isStageEditable's doc comment.
       if (!isStageEditable(item, 'FIELDS_AND_PROMPTS')) continue
+      // Bug (model-builder/t-029, cycle 30): skip an item a manual
+      // single-item action (most concretely commitItem()) already owns --
+      // see batchDraftField's identical check for the full shape of this
+      // race (a stale local-only 'in-progress' marker for another stage
+      // leaking into this call's `stageStatuses: item.stages` payload and
+      // potentially clobbering the server's real, just-written status).
+      if (isItemManualActionInFlight(item.id)) continue
       const modelType = state.run
         ? resolveTargetModel(item.action, item.outputKey, state.run.sourceType)
         : undefined
@@ -2432,6 +2476,19 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     const previousStages = new Map<string, BuildItem['stages']>()
     for (const item of groupItems(outputKey)) {
       if (item.stages[stageKey].status === 'locked') continue
+      // Bug (model-builder/t-029, cycle 30): skip an item a manual
+      // single-item action (most concretely commitItem()) already owns --
+      // see batchDraftField's identical check for the full shape of this
+      // race (a stale local-only 'in-progress' marker for another stage
+      // leaking into this call's `stageStatuses: item.stages` payload and
+      // potentially clobbering the server's real, just-written status). This
+      // matters even more here than in batchSetField/batchDraftField: this
+      // function writes `stageStatuses: item.stages` for EVERY unlocked
+      // item regardless of whether stageKey's own status actually changes,
+      // so a committing item's stray 'in-progress' COMMIT marker would
+      // otherwise be forwarded even when this batch call has nothing genuine
+      // to persist for that item at all.
+      if (isItemManualActionInFlight(item.id)) continue
       previousStages.set(item.id, { ...item.stages })
       item.stages[stageKey] = { status: 'approved' }
       const next = BUILD_STAGES[stageIndex(stageKey) + 1]

--- a/utils/scripts/verifyModelBuilderBatchBusyItemExclusionGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderBatchBusyItemExclusionGuard.test.ts
@@ -1,0 +1,242 @@
+// /utils/scripts/verifyModelBuilderBatchBusyItemExclusionGuard.test.ts
+//
+// Regression test for checkBatchBusyItemExclusionGuard() in
+// verifyModelBuilderBatchBusyItemExclusionGuard.ts (model-builder/t-029,
+// cycle 30). Exercises the real check against synthetic store-shaped
+// fixtures covering: the pre-fix shape (none of the three functions skip a
+// busy item), the fixed shape (all three), a partial fix that leaves one
+// function behind, and all three target functions being absent entirely.
+import assert from 'node:assert/strict'
+
+import { checkBatchBusyItemExclusionGuard } from './verifyModelBuilderBatchBusyItemExclusionGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function batchDraftField(
+    outputKey: string,
+    field: DraftField,
+    opts?: { onlyEmpty?: boolean },
+  ): Promise<void> {
+    const items = groupItems(outputKey)
+    if (!items.length) return
+    if (state.autoBuilding) return
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      for (const item of items) {
+        if (!isStageEditable(item, stageKey)) continue
+        const ok = await draftText(item.id, field)
+      }
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchSetField(
+    outputKey: string,
+    fieldKey: string,
+    value: string,
+  ): Promise<void> {
+    if (state.autoBuilding) return
+    const items = groupItems(outputKey)
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      for (const item of items) {
+        if (!isStageEditable(item, 'FIELDS_AND_PROMPTS')) continue
+        entries.push({ item, payload: { stageStatuses: item.stages } })
+      }
+      const { ok, failedIds } = await batchPushItems(entries)
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchApproveStage(
+    outputKey: string,
+    stageKey: BuildStageKey,
+  ): Promise<void> {
+    if (state.autoBuilding) return
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      for (const item of groupItems(outputKey)) {
+        if (item.stages[stageKey].status === 'locked') continue
+        entries.push({ item, payload: { stageStatuses: item.stages } })
+      }
+      const { ok, failedIds } = await batchPushItems(entries)
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function batchDraftField(
+    outputKey: string,
+    field: DraftField,
+    opts?: { onlyEmpty?: boolean },
+  ): Promise<void> {
+    const items = groupItems(outputKey)
+    if (!items.length) return
+    if (state.autoBuilding) return
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      for (const item of items) {
+        if (!isStageEditable(item, stageKey)) continue
+        if (isItemManualActionInFlight(item.id)) continue
+        const ok = await draftText(item.id, field)
+      }
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchSetField(
+    outputKey: string,
+    fieldKey: string,
+    value: string,
+  ): Promise<void> {
+    if (state.autoBuilding) return
+    const items = groupItems(outputKey)
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      for (const item of items) {
+        if (!isStageEditable(item, 'FIELDS_AND_PROMPTS')) continue
+        if (isItemManualActionInFlight(item.id)) continue
+        entries.push({ item, payload: { stageStatuses: item.stages } })
+      }
+      const { ok, failedIds } = await batchPushItems(entries)
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchApproveStage(
+    outputKey: string,
+    stageKey: BuildStageKey,
+  ): Promise<void> {
+    if (state.autoBuilding) return
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      for (const item of groupItems(outputKey)) {
+        if (item.stages[stageKey].status === 'locked') continue
+        if (isItemManualActionInFlight(item.id)) continue
+        entries.push({ item, payload: { stageStatuses: item.stages } })
+      }
+      const { ok, failedIds } = await batchPushItems(entries)
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+
+const PARTIAL_FIX_FIXTURE = `
+  async function batchDraftField(
+    outputKey: string,
+    field: DraftField,
+    opts?: { onlyEmpty?: boolean },
+  ): Promise<void> {
+    const items = groupItems(outputKey)
+    if (!items.length) return
+    if (state.autoBuilding) return
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      for (const item of items) {
+        if (!isStageEditable(item, stageKey)) continue
+        if (isItemManualActionInFlight(item.id)) continue
+        const ok = await draftText(item.id, field)
+      }
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchSetField(
+    outputKey: string,
+    fieldKey: string,
+    value: string,
+  ): Promise<void> {
+    if (state.autoBuilding) return
+    const items = groupItems(outputKey)
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      for (const item of items) {
+        if (!isStageEditable(item, 'FIELDS_AND_PROMPTS')) continue
+        if (isItemManualActionInFlight(item.id)) continue
+        entries.push({ item, payload: { stageStatuses: item.stages } })
+      }
+      const { ok, failedIds } = await batchPushItems(entries)
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchApproveStage(
+    outputKey: string,
+    stageKey: BuildStageKey,
+  ): Promise<void> {
+    if (state.autoBuilding) return
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      for (const item of groupItems(outputKey)) {
+        if (item.stages[stageKey].status === 'locked') continue
+        entries.push({ item, payload: { stageStatuses: item.stages } })
+      }
+      const { ok, failedIds } = await batchPushItems(entries)
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkBatchBusyItemExclusionGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  3,
+  'expected the pre-fix shape to raise exactly 3 per-function violations ' +
+    `(one per batch function), got ${buggyErrors.length}: ` +
+    JSON.stringify(buggyErrors),
+)
+for (const name of ['batchDraftField', 'batchSetField', 'batchApproveStage']) {
+  assert.ok(
+    buggyErrors.some((e) => e.startsWith(`${name}()`)),
+    `expected an error for ${name}() not skipping a busy item`,
+  )
+}
+
+const fixedErrors = checkBatchBusyItemExclusionGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const partialErrors = checkBatchBusyItemExclusionGuard(PARTIAL_FIX_FIXTURE)
+assert.equal(
+  partialErrors.length,
+  1,
+  'expected the partial-fix shape (batchApproveStage left behind) to ' +
+    `raise exactly 1 error, got ${partialErrors.length}: ` +
+    JSON.stringify(partialErrors),
+)
+assert.ok(partialErrors[0]!.startsWith('batchApproveStage()'))
+
+const missingErrors = checkBatchBusyItemExclusionGuard(MISSING_FIXTURE)
+assert.equal(
+  missingErrors.length,
+  3,
+  'expected 3 "function not found" violations when all three target ' +
+    `functions are absent, got ${missingErrors.length}: ${JSON.stringify(missingErrors)}`,
+)
+
+console.log(
+  'Model Builder batch busy-item exclusion guard checker verified: flags ' +
+    'each batch function missing its isItemManualActionInFlight skip, ' +
+    'clears the fixed shape, flags a partial fix that leaves one function ' +
+    'behind, and flags all three target functions being absent.',
+)

--- a/utils/scripts/verifyModelBuilderBatchBusyItemExclusionGuard.ts
+++ b/utils/scripts/verifyModelBuilderBatchBusyItemExclusionGuard.ts
@@ -1,0 +1,124 @@
+// /utils/scripts/verifyModelBuilderBatchBusyItemExclusionGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 30) -- batchDraftField(),
+// batchSetField(), and batchApproveStage() each loop over a quantity
+// group's items and, for every item they touch, push that item's FULL
+// current `item.stages` blob to the server as part of the write (directly
+// as `payload: { stageStatuses: item.stages }` in batchApproveStage/
+// batchSetField, or indirectly via draftText -> updatePitch/updateFields/
+// updatePrompt -> pushItem in batchDraftField). None of the three checked
+// whether the SAME item already had a manual single-item action in flight
+// before this fix.
+//
+// That matters because two single-item actions set a stage to a purely
+// client-local 'in-progress' marker *before* their own await, and never
+// themselves persist it: commitItem() sets item.stages.COMMIT =
+// { status: 'in-progress' } and relies entirely on the server's own
+// commit.post.ts write to resolve it later; generateItemAsset/
+// generateItemAssetAsync do the identical thing for GENERATE_ASSETS. If one
+// of the three batch functions above snapshots and pushes that item's
+// stageStatuses while such a marker is set, the server's diff-then-merge
+// stage-status logic (diffStageStatusChanges/mergeStageStatusChanges in
+// server/api/model-builder/runs/index.ts) has no way to tell that stray
+// local marker apart from a genuinely intended change -- it diffs the whole
+// blob against its own last-known value and persists whatever differs. If
+// that batch write's transaction happens to land AFTER the single-item
+// action's own dedicated final write, it silently clobbers the correct
+// final status (e.g. reverting a just-committed item's COMMIT status from
+// 'approved' back to a permanently-stuck 'in-progress' that nothing will
+// ever resolve) -- the same "review gate lying about what's actually
+// stored" class of bug this codebase treats as real everywhere else.
+//
+// This is reachable in a single browser tab with no clock race required:
+// model-builder-progress-matrix.vue renders model-builder-batch-editor.vue
+// and model-builder-item-panel.vue side by side for the SAME selected
+// item's group, so a user can click "Execute commit" in the item panel and
+// then immediately click a batch-editor button for that same group while
+// the commit POST is still in flight.
+//
+// Fixed by adding an `if (isItemManualActionInFlight(item.id)) continue`
+// skip to all three loops, mirroring autoBuildItem's own identical guard
+// for the exact same reason. This guard asserts that skip stays present in
+// all three functions: if a future refactor drops it from any of them, this
+// exact race reopens silently.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const BATCH_FUNCTIONS = [
+  'batchDraftField',
+  'batchSetField',
+  'batchApproveStage',
+] as const
+
+const BUSY_CHECK_PATTERN =
+  /if\s*\(\s*isItemManualActionInFlight\(\s*item\.id\s*\)\s*\)\s*continue/
+
+// Checks the fix's exact shape against the full source text of a file
+// containing batchDraftField/batchSetField/batchApproveStage-named
+// functions. Exported (rather than only exercised via main()) so the
+// self-test below can run it against synthetic buggy/fixed fixtures without
+// touching the real store file.
+export function checkBatchBusyItemExclusionGuard(content: string): string[] {
+  const errors: string[] = []
+  const functions = extractFunctionBodies(content)
+
+  for (const name of BATCH_FUNCTIONS) {
+    const fn = functions.find((f) => f.name === name)
+    if (!fn) {
+      errors.push(
+        `Could not find a function named ${name}() -- has it been ` +
+          'renamed, removed, or inlined? If so, this guard (and the fix ' +
+          'it protects) needs to move with it.',
+      )
+      continue
+    }
+    if (!BUSY_CHECK_PATTERN.test(fn.body)) {
+      errors.push(
+        `${name}() does not skip an item that already has a manual ` +
+          'single-item action in flight (expected something like ' +
+          '`if (isItemManualActionInFlight(item.id)) continue`) -- a ' +
+          'concurrent commitItem()/generateItemAsset() for the same item ' +
+          "can leak that action's transient, never-persisted " +
+          `in-progress stage marker into ${name}()'s own ` +
+          'stageStatuses write, and a later-landing write can silently ' +
+          "clobber the manual action's real, just-persisted result.",
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkBatchBusyItemExclusionGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder batch busy-item exclusion guard contract failed in ' +
+        'modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder batch busy-item exclusion guard contract passed: ' +
+      'batchDraftField(), batchSetField(), and batchApproveStage() all ' +
+      'skip an item that already has a manual single-item action in ' +
+      'flight.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Bug

`batchDraftField()`, `batchSetField()`, and `batchApproveStage()` (the three group batch operations in `stores/modelBuilderStore.ts` driven by `model-builder-batch-editor.vue`'s "Draft pitches/fields/prompts", "Approve fields", and "Set field" controls) each push an item's **full current `item.stages` blob** to the server for every item they touch — directly as `payload: { stageStatuses: item.stages }` (`batchSetField`/`batchApproveStage`), or indirectly via `draftText -> updatePitch/updateFields/updatePrompt -> pushItem` (`batchDraftField`). None of the three checked whether that same item already had a manual single-item action in flight.

That matters because two single-item actions set a stage to a purely client-local `'in-progress'` marker *before* their own `await`, and never persist it themselves:
- `commitItem()` sets `item.stages.COMMIT = { status: 'in-progress' }` and relies entirely on `commit.post.ts`'s own write to resolve it later (see `finishCommit`'s doc comment).
- `generateItemAsset`/`generateItemAssetAsync` do the identical thing for `GENERATE_ASSETS`.

If one of the three batch functions snapshots and pushes an item's `stageStatuses` while such a marker is set, the server's diff-then-merge stage-status logic (`diffStageStatusChanges`/`mergeStageStatusChanges` in `server/api/model-builder/runs/index.ts`) has no way to tell that stray local marker apart from a genuinely intended change — it diffs the whole blob against its own last-known value and persists whatever differs. If the batch write's transaction happens to land **after** `commit.post.ts`'s own dedicated fresh-read/merge final write (cycle 27's fix), it silently reverts a just-committed item's `COMMIT` status from `'approved'` back to a permanently-stuck `'in-progress'` that nothing will ever resolve — even though `targetType`/`targetId` (written durably and separately, also cycle 27) still correctly point at the committed record. Same "review gate lying about what's actually stored" class of bug this codebase treats as real everywhere else.

**Reachable in a single browser tab, no clock race needed**: `model-builder-progress-matrix.vue` renders `model-builder-batch-editor.vue` and `model-builder-item-panel.vue` side by side for the *same* selected item's group. Select an item, click "Execute commit" in the item panel, then immediately click any batch-editor action ("Draft pitches", "Approve fields", "Apply" a field) for that same group while the commit POST is still in flight.

## Fix

Added an `if (isItemManualActionInFlight(item.id)) continue` skip to the per-item loops in `batchDraftField`, `batchSetField`, and `batchApproveStage` — mirroring `autoBuildItem()`'s own identical guard, which already exists for the exact same reason. (`batchAutoBuild` was already safe: it delegates to `autoBuildItem()`, which already has this check.)

## Guard

Added `utils/scripts/verifyModelBuilderBatchBusyItemExclusionGuard.ts` + `.test.ts` — a static-shape guard asserting all three batch functions keep the `isItemManualActionInFlight` skip. Wired into `package.json` (`test:model-builder-batch-busy-item-exclusion-guard[-selftest]`) and `.github/workflows/contract-tests.yml`.

## Verification

- New guard's selftest passes (buggy/fixed/partial-fix/missing-function fixtures all behave as expected)
- New guard passes against the real fixed file
- All 119 `test:model-builder-*` npm scripts pass (117 pre-existing + 2 new), including `verifyModelBuilderContractTestsCoverageGuard` (confirms the new scripts are correctly wired into CI, not just present)
- `vue-tsc --noEmit` repo-wide clean
- eslint clean on touched files (two pre-existing `no-empty` errors in `modelBuilderStore.ts` confirmed via `git stash` to predate this change)
- prettier clean on the two new files (`modelBuilderStore.ts`'s pre-existing whole-file prettier drift also confirmed via `git stash` to predate this change)
- `git status --porcelain` scoped to exactly the 5 intended files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cyc2yMvNhYvRBV6Y8kkbbm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cyc2yMvNhYvRBV6Y8kkbbm)_