### PR TITLE
feat(brainstorm): wire selected-candidate art generation through ArtJobs (t-016)

### DIFF
--- a/components/brainstorm/brainstorm-candidate-card.vue
+++ b/components/brainstorm/brainstorm-candidate-card.vue
@@ -34,6 +34,27 @@
           >
             edited
           </span>
+          <label
+            v-if="candidate.status === 'kept'"
+            class="flex cursor-pointer items-center gap-1.5 rounded-full bg-secondary/10 px-2.5 py-1 text-[0.68rem] font-bold text-secondary"
+            data-testid="brainstorm-art-select"
+          >
+            <input
+              type="checkbox"
+              class="checkbox checkbox-xs checkbox-secondary"
+              :checked="selectedForArt"
+              :disabled="disabled || artBusy"
+              @change="emit('toggleArtSelection')"
+            />
+            Select for art
+          </label>
+          <span
+            v-if="artBusy"
+            class="flex items-center gap-1 rounded-full bg-secondary/10 px-2.5 py-1 text-[0.68rem] font-bold text-secondary"
+          >
+            <span class="loading loading-spinner loading-xs" />
+            Generating art…
+          </span>
         </div>
 
         <template v-if="editing">
@@ -107,6 +128,28 @@
       >
         {{ candidate.text }}
       </p>
+    </div>
+
+    <div
+      v-if="artImageIds.length"
+      class="mt-3 flex flex-wrap gap-2"
+      data-testid="brainstorm-candidate-art"
+    >
+      <a
+        v-for="imageId in artImageIds"
+        :key="imageId"
+        :href="`/api/art/images/${imageId}/file`"
+        target="_blank"
+        rel="noopener"
+        class="block size-16 shrink-0 overflow-hidden rounded-lg border border-base-300"
+      >
+        <img
+          :src="`/api/art/images/${imageId}/file`"
+          :alt="`Generated art for ${candidate.title || 'this candidate'}`"
+          class="size-full object-cover"
+          loading="lazy"
+        />
+      </a>
     </div>
 
     <details
@@ -281,7 +324,8 @@ const props = defineProps<{
   parentCandidate?: BrainstormCandidate | null
   disabled?: boolean
   busy?: boolean
-  busyAction?: 'regenerate' | 'branch' | null
+  busyAction?: 'regenerate' | 'branch' | 'art' | null
+  selectedForArt?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -294,6 +338,7 @@ const emit = defineEmits<{
   restoreRevision: [revisionIndex: number]
   edit: [patch: { title: string; text: string }]
   feedback: [value: string]
+  toggleArtSelection: []
 }>()
 
 const editing = ref(false)
@@ -339,6 +384,11 @@ const statusBadgeClass = computed(() => {
   if (props.candidate.status === 'rejected') return 'bg-error/12 text-error'
   return 'bg-primary/10 text-primary'
 })
+
+const artBusy = computed(
+  () => Boolean(props.busy) && props.busyAction === 'art',
+)
+const artImageIds = computed(() => props.candidate.meta.art?.imageIds ?? [])
 
 const returnType = computed(() =>
   BRAINSTORM_RETURN_TYPES.find(

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -684,6 +684,76 @@
     </div>
 
     <div
+      v-if="keptCandidates.length"
+      class="kr-panel-flat flex flex-wrap items-center justify-between gap-3 border border-secondary/20 bg-secondary/5 p-3"
+      data-testid="brainstorm-art-batch"
+    >
+      <div class="min-w-0">
+        <p
+          class="text-xs font-black uppercase tracking-[0.14em] text-secondary/80"
+        >
+          Generate art
+        </p>
+        <p class="mt-1 text-sm text-base-content/65">
+          {{ selectedForArtCount }} of {{ keptCandidates.length }} kept idea{{
+            keptCandidates.length === 1 ? '' : 's'
+          }}
+          selected · Krea 2
+        </p>
+      </div>
+      <div class="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          class="btn btn-ghost btn-sm"
+          :disabled="!selectedForArtCount || isGeneratingArt"
+          @click="store.clearArtSelection()"
+        >
+          Clear selection
+        </button>
+        <button
+          type="button"
+          class="btn btn-secondary btn-sm gap-1.5"
+          :disabled="!selectedForArtCount || isGeneratingArt"
+          data-testid="brainstorm-generate-art"
+          @click="generateArt"
+        >
+          <span
+            v-if="isGeneratingArt"
+            class="loading loading-spinner loading-xs"
+          />
+          <Icon v-else name="kind-icon:sparkles" class="h-4 w-4" />
+          {{
+            isGeneratingArt
+              ? artProgressLabel
+              : `Generate art for ${selectedForArtCount} selected`
+          }}
+        </button>
+      </div>
+    </div>
+
+    <div
+      v-if="artGenerationError"
+      class="alert border border-error/25 bg-error/10 text-base-content"
+      role="alert"
+      data-testid="brainstorm-art-error"
+    >
+      <span aria-hidden="true">⚠</span>
+      <div class="min-w-0 flex-1">
+        <p class="font-black">Art generation hit a snag</p>
+        <p class="mt-1 break-words text-sm opacity-80">
+          {{ artGenerationError.message }}
+        </p>
+      </div>
+      <button
+        type="button"
+        class="btn btn-ghost btn-sm"
+        @click="store.clearArtGenerationError()"
+      >
+        Dismiss
+      </button>
+    </div>
+
+    <div
       v-if="activeCandidates.length"
       class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,20rem),1fr))] items-start gap-4"
       data-testid="brainstorm-candidates"
@@ -694,8 +764,9 @@
         :candidate="candidate"
         :parent-candidate="parentCandidateFor(candidate)"
         :disabled="isGenerating"
-        :busy="generationTargetId === candidate.id"
+        :busy="isCandidateBusy(candidate.id)"
         :busy-action="candidateBusyAction(candidate.id)"
+        :selected-for-art="store.isSelectedForArt(candidate.id)"
         @keep="keepCandidate(candidate.id)"
         @reject="rejectCandidate(candidate.id)"
         @reset="resetCandidate(candidate.id)"
@@ -705,6 +776,7 @@
         @restore-revision="restoreRevision(candidate.id, $event)"
         @regenerate="regenerate(candidate.id)"
         @branch="branch(candidate.id)"
+        @toggle-art-selection="store.toggleArtSelection(candidate.id)"
       />
     </div>
 
@@ -891,6 +963,11 @@ const {
   canSaveSession,
   suggestedSessionName,
   source,
+  selectedForArtCandidates,
+  artGenerationState,
+  artGenerationError,
+  artGenerationProgress,
+  artGeneratingCandidateIds,
 } = storeToRefs(store)
 
 const pendingCandidateAction = ref<{
@@ -1026,6 +1103,21 @@ const selectedKeptCandidates = computed(() =>
 
 const skeletonCount = computed(() => Math.min(resultCount.value, 6))
 
+// brainstorm/t-016: batch art generation from explicitly selected kept
+// candidates.
+const isGeneratingArt = computed(
+  () => artGenerationState.value === 'generating',
+)
+const selectedForArtCount = computed(
+  () => selectedForArtCandidates.value.length,
+)
+const artProgressLabel = computed(() => {
+  const progress = artGenerationProgress.value
+  return progress
+    ? `Generating ${progress.completed}/${progress.total}…`
+    : 'Generating…'
+})
+
 const errorHeading = computed(() => {
   switch (generationError.value?.kind) {
     case 'auth':
@@ -1151,10 +1243,20 @@ function applyStarter(starter: (typeof starterPremises)[number]): void {
   )
 }
 
-function candidateBusyAction(candidateId: string): 'regenerate' | 'branch' | null {
-  return pendingCandidateAction.value?.id === candidateId
-    ? pendingCandidateAction.value.action
-    : null
+function candidateBusyAction(
+  candidateId: string,
+): 'regenerate' | 'branch' | 'art' | null {
+  if (pendingCandidateAction.value?.id === candidateId) {
+    return pendingCandidateAction.value.action
+  }
+  return artGeneratingCandidateIds.value.includes(candidateId) ? 'art' : null
+}
+
+function isCandidateBusy(candidateId: string): boolean {
+  return (
+    generationTargetId.value === candidateId ||
+    artGeneratingCandidateIds.value.includes(candidateId)
+  )
 }
 
 function parentCandidateFor(candidate: BrainstormCandidate): BrainstormCandidate | null {
@@ -1301,5 +1403,10 @@ async function branch(candidateId: string): Promise<void> {
   } finally {
     pendingCandidateAction.value = null
   }
+}
+
+async function generateArt(): Promise<void> {
+  if (isGeneratingArt.value || !selectedForArtCount.value) return
+  await store.generateArtForSelected()
 }
 </script>

--- a/server/api/art/enqueue.post.ts
+++ b/server/api/art/enqueue.post.ts
@@ -60,6 +60,24 @@ type NarrativeEnqueueContext = {
   dedupeKey: string
 }
 
+// brainstorm/t-016: kept separate from NarrativeEnqueueContext rather than
+// widening its product union -- that shape's beatId/moment/dedupeKey exist
+// for narrative-beat dedup (see narrativeRequest below), which Brainstorm
+// candidates have no equivalent of. This is provenance-only: it never gates
+// or deduplicates the request, it just gets tagged onto the ArtJob payload
+// (mirrors how entityArt/narrativeContext do the same) so the job stays
+// traceable back to its BrainstormSession/candidate/source.
+type BrainstormEnqueueContext = {
+  product: 'brainstorm'
+  candidateId: string
+  sessionId: number | null
+  source?: {
+    modelType: string
+    id?: number | null
+    slug?: string | null
+  } | null
+}
+
 type ArtEnqueueRequest = {
   engine?: string | null
   promptString?: string | null
@@ -99,6 +117,7 @@ type ArtEnqueueRequest = {
   projectSlug?: string | null
   priority?: number | null
   narrativeContext?: NarrativeEnqueueContext | null
+  brainstormContext?: BrainstormEnqueueContext | null
   sourceImageBase64?: string | null
   firstImageBase64?: string | null
   secondImageBase64?: string | null
@@ -210,6 +229,41 @@ function narrativeRequest(
   return { product, sessionId, beatId, moment, dedupeKey }
 }
 
+function brainstormRequest(
+  body: ArtEnqueueRequest | null,
+): BrainstormEnqueueContext | null {
+  const raw = asRecord(body?.brainstormContext)
+  if (!Object.keys(raw).length) return null
+
+  const candidateId = String(raw.candidateId || '').trim()
+  if (!candidateId || candidateId.length > 200) {
+    throw createError({
+      statusCode: 400,
+      message: 'Invalid Brainstorm candidate id.',
+    })
+  }
+
+  const rawSessionId = Number(raw.sessionId)
+  const sessionId =
+    Number.isInteger(rawSessionId) && rawSessionId > 0 ? rawSessionId : null
+
+  const rawSource = asRecord(raw.source)
+  const sourceModelType = String(rawSource.modelType || '').trim()
+  const source = sourceModelType
+    ? {
+        modelType: sourceModelType.slice(0, 80),
+        ...(Number.isInteger(Number(rawSource.id)) && Number(rawSource.id) > 0
+          ? { id: Number(rawSource.id) }
+          : {}),
+        ...(typeof rawSource.slug === 'string' && rawSource.slug.trim()
+          ? { slug: rawSource.slug.trim().slice(0, 160) }
+          : {}),
+      }
+    : null
+
+  return { product: 'brainstorm', candidateId, sessionId, source }
+}
+
 function facetRequest(body: ArtEnqueueRequest | null): {
   facetIds: number[]
   basePromptString: string
@@ -269,6 +323,7 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 400, message: 'Invalid projectSlug.' })
     }
     const narrativeContext = narrativeRequest(body)
+    const brainstormContext = brainstormRequest(body)
 
     const videoFrames = VIDEO_ENGINES.has(engine)
       ? resolveVideoFrames(engine, body)
@@ -395,6 +450,7 @@ export default defineEventHandler(async (event) => {
     })
     applyArtFacetsToPayload(payload, contextualBasePrompt, facets)
     if (narrativeContext) payload.narrativeContext = narrativeContext
+    if (brainstormContext) payload.brainstormContext = brainstormContext
     if (entityArt) payload.entityArt = entityArt.metadata
 
     const provenanceResources = {

--- a/stores/artStore.ts
+++ b/stores/artStore.ts
@@ -114,6 +114,26 @@ export type NarrativeArtEnqueueContext = {
   dedupeKey: string
 }
 
+// brainstorm/t-016: a separate, narrower context shape rather than widening
+// NarrativeArtEnqueueContext's product union -- that type's beatId/moment/
+// dedupeKey fields exist for narrative-beat dedup (Storybook/Taskmaster/
+// Da Vinci), which Brainstorm has no equivalent of: every "Generate art"
+// click is an explicit, distinct user action, not something that needs
+// idempotent re-triggering protection. sessionId is the durable saved
+// BrainstormSession id (null until the working session has been saved at
+// least once) and source mirrors BrainstormSourceRef, kept structurally
+// separate so this file doesn't need to import types/brainstorm.ts.
+export type BrainstormArtEnqueueContext = {
+  product: 'brainstorm'
+  candidateId: string
+  sessionId: number | null
+  source?: {
+    modelType: string
+    id?: number | null
+    slug?: string | null
+  } | null
+}
+
 export type ArtLoraSelection = {
   resourceId?: number | null
   name?: string | null
@@ -157,6 +177,7 @@ export interface GenerateArtData {
   serverName?: string | null
   projectSlug?: string | null
   narrativeContext?: NarrativeArtEnqueueContext | null
+  brainstormContext?: BrainstormArtEnqueueContext | null
 
   engine?: ArtImageGenerationEngine
   transport?: ArtImageGenerationTransport
@@ -1789,6 +1810,10 @@ export const useArtStore = defineStore('artStore', () => {
       projectSlug: artData?.projectSlug ?? state.artForm.projectSlug ?? null,
       narrativeContext:
         artData?.narrativeContext ?? state.artForm.narrativeContext ?? null,
+      brainstormContext:
+        artData?.brainstormContext ??
+        state.artForm.brainstormContext ??
+        null,
       generationRequirement:
         artData?.generationRequirement ?? state.artForm.generationRequirement,
       engine,

--- a/stores/brainstormStore.ts
+++ b/stores/brainstormStore.ts
@@ -1,5 +1,6 @@
 import { computed, ref, watch } from 'vue'
 import { defineStore } from 'pinia'
+import { useArtStore } from '@/stores/artStore'
 import { useServerStore } from '@/stores/serverStore'
 import { performFetch } from '@/stores/utils'
 import {
@@ -7,6 +8,7 @@ import {
   applyCandidateRegeneration,
   applyCandidateRevisionRestore,
   applyCandidateStatus,
+  buildBrainstormArtPrompt,
   classifyError,
   cleanExamples,
   cleanMultilineText,
@@ -22,6 +24,8 @@ import {
   normalizeStoredBatch,
   normalizeStoredCandidate,
   nowIso,
+  recordCandidateArtImage,
+  recordCandidateArtJob,
   RETURN_TYPE_IDS,
 } from '@/stores/helpers/brainstormCandidateLifecycle'
 import {
@@ -110,6 +114,20 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
   const generationTargetId = ref<string | null>(null)
   const lastGeneratedAt = ref<string | null>(null)
 
+  // brainstorm/t-016: explicit selected-candidate art generation. Selection
+  // is deliberately kept out of BrainstormCandidate/meta -- it is a
+  // this-session UI concern (which kept candidates to render art for right
+  // now), not durable creative state worth persisting through save/load the
+  // way meta.art (the resulting job/image linkage) is.
+  const artSelectionIds = ref<string[]>([])
+  const artGenerationState = ref<'idle' | 'generating'>('idle')
+  const artGenerationError = ref<BrainstormError | null>(null)
+  const artGenerationProgress = ref<{
+    total: number
+    completed: number
+  } | null>(null)
+  const artGeneratingCandidateIds = ref<string[]>([])
+
   const savedSessionId = ref<number | null>(null)
   const sessionName = ref('')
   const savedSessions = ref<BrainstormSavedSessionSummary[]>([])
@@ -156,6 +174,17 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
   const rejectedCandidates = computed(() =>
     activeCandidates.value.filter(
       (candidate) => candidate.status === 'rejected',
+    ),
+  )
+
+  // brainstorm/t-016: selection is restricted to kept candidates -- the ones
+  // the user has already curated -- both here and in toggleArtSelection, so
+  // stale/orphaned selection ids (a candidate later un-kept, edited into
+  // rejection, or removed) simply drop out of this list without needing
+  // explicit pruning of artSelectionIds itself.
+  const selectedForArtCandidates = computed(() =>
+    keptCandidates.value.filter((candidate) =>
+      artSelectionIds.value.includes(candidate.id),
     ),
   )
 
@@ -829,6 +858,182 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
     return Boolean(appendBranchCandidate(candidate, generated[0]))
   }
 
+  function isSelectedForArt(candidateId: string): boolean {
+    return artSelectionIds.value.includes(candidateId)
+  }
+
+  // Selection is restricted to kept candidates (see selectedForArtCandidates'
+  // comment) -- a non-kept id is refused here rather than merely filtered
+  // later, so a candidate that was never kept can never even enter the list.
+  function toggleArtSelection(candidateId: string): boolean {
+    const candidate = findCandidate(candidateId)
+    if (!candidate || candidate.status !== 'kept') return false
+
+    const index = artSelectionIds.value.indexOf(candidateId)
+    if (index >= 0) artSelectionIds.value.splice(index, 1)
+    else artSelectionIds.value.push(candidateId)
+    return true
+  }
+
+  function clearArtSelection(): void {
+    artSelectionIds.value = []
+  }
+
+  function clearArtGenerationError(): void {
+    artGenerationError.value = null
+  }
+
+  function isGeneratingArtFor(candidateId: string): boolean {
+    return artGeneratingCandidateIds.value.includes(candidateId)
+  }
+
+  const ART_JOB_POLL_MS = 5_000
+
+  function artQueueSleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+  }
+
+  /**
+   * Enqueues one ArtJob for `candidate` through the normal
+   * POST /api/art/enqueue pipeline (via artStore.enqueueArtGeneration, so
+   * mana gating/server resolution/checkpoint defaults all go through the
+   * same path every other product uses), records the returned job id onto
+   * candidate.meta.art.jobIds immediately, then polls until the job resolves
+   * and records the resulting image id onto meta.art.imageIds. Mirrors
+   * modelBuilderStore.ts's generateItemAssetAsync/pollAsyncArtJob split
+   * (enqueue returns fast, a separate poll loop resolves the image) but
+   * without that store's run-cancellation apparatus -- Brainstorm has no
+   * equivalent of a model-builder "run" to cancel out from under a job, so a
+   * plain per-candidate async task awaited via Promise.all is sufficient.
+   */
+  async function generateArtForCandidate(
+    candidate: BrainstormCandidate,
+  ): Promise<{ success: boolean; message?: string }> {
+    const artStore = useArtStore()
+    artGeneratingCandidateIds.value = [
+      ...artGeneratingCandidateIds.value,
+      candidate.id,
+    ]
+    try {
+      const prompt = buildBrainstormArtPrompt(candidate, outputDomain.value)
+      const enqueued = await artStore.enqueueArtGeneration({
+        promptString: prompt,
+        engine: 'krea2',
+        isPublic: false,
+        isMature: false,
+        brainstormContext: {
+          product: 'brainstorm',
+          candidateId: candidate.id,
+          sessionId: savedSessionId.value,
+          source: candidate.meta.source ?? source.value ?? null,
+        },
+      })
+
+      if (!enqueued.success || !enqueued.jobId) {
+        return {
+          success: false,
+          message:
+            enqueued.message ||
+            `"${candidate.title || candidate.text.slice(0, 40)}" failed to queue.`,
+        }
+      }
+
+      recordCandidateArtJob(candidate, enqueued.jobId)
+
+      while (true) {
+        const job = await artStore.getArtJobStatus(enqueued.jobId)
+        if (!job || job.status === 'PENDING' || job.status === 'RUNNING') {
+          await artQueueSleep(ART_JOB_POLL_MS)
+          continue
+        }
+        if (job.status !== 'DONE' || !job.artImageId) {
+          return {
+            success: false,
+            message:
+              job.error ||
+              `ArtJob ${enqueued.jobId} ended as ${job.status.toLowerCase()}.`,
+          }
+        }
+        recordCandidateArtImage(candidate, job.artImageId)
+        return { success: true }
+      }
+    } catch (error) {
+      return {
+        success: false,
+        message:
+          error instanceof Error ? error.message : 'Art generation failed.',
+      }
+    } finally {
+      artGeneratingCandidateIds.value = artGeneratingCandidateIds.value.filter(
+        (id) => id !== candidate.id,
+      )
+    }
+  }
+
+  /**
+   * The explicit, user-initiated batch action: one ArtJob per currently
+   * selected (kept + toggled) candidate, run concurrently. Per brainstorm/
+   * t-016's note, this is intentionally the only way art generation fires --
+   * nothing here runs automatically off text generation, keep/reject, or
+   * session load.
+   */
+  async function generateArtForSelected(): Promise<boolean> {
+    const targets = selectedForArtCandidates.value
+    if (!targets.length || artGenerationState.value === 'generating') {
+      return false
+    }
+
+    clearArtGenerationError()
+    artGenerationState.value = 'generating'
+    artGenerationProgress.value = { total: targets.length, completed: 0 }
+
+    const failures: string[] = []
+    let succeeded = 0
+
+    await Promise.all(
+      targets.map(async (candidate) => {
+        const result = await generateArtForCandidate(candidate)
+        if (result.success) succeeded += 1
+        else if (result.message) failures.push(result.message)
+        if (artGenerationProgress.value) {
+          artGenerationProgress.value = {
+            ...artGenerationProgress.value,
+            completed: artGenerationProgress.value.completed + 1,
+          }
+        }
+      }),
+    )
+
+    artGenerationState.value = 'idle'
+    artGenerationProgress.value = null
+    clearArtSelection()
+
+    if (failures.length) {
+      const firstFailure = failures[0] ?? 'Art generation failed.'
+      artGenerationError.value = {
+        kind: 'provider',
+        message:
+          failures.length === targets.length
+            ? firstFailure
+            : `${failures.length} of ${targets.length} art jobs failed. ${firstFailure}`,
+        status: null,
+      }
+    }
+
+    // Durable persistence (brainstorm/t-016): the local session snapshot
+    // already picks up meta.art via the existing deep watch -> persistSession
+    // -> localStorage autosave (candidates are mutated in place above, not
+    // replaced). Once a session has been saved to the server at least once,
+    // also push the new job/image linkage there so it survives a reload from
+    // a different browser/device, not just this one's localStorage. Fire and
+    // forget: a save failure here surfaces through the existing persistence
+    // error banner, and should not turn a successful art generation into a
+    // reported failure.
+    if (savedSessionId.value) void saveCurrentSession()
+
+    return succeeded > 0
+  }
+
   function upsertSavedSummary(summary: BrainstormSavedSessionSummary): void {
     const index = savedSessions.value.findIndex(
       (entry) => entry.id === summary.id,
@@ -1017,6 +1222,11 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
     generationError,
     generationTargetId,
     lastGeneratedAt,
+    artSelectionIds,
+    artGenerationState,
+    artGenerationError,
+    artGenerationProgress,
+    artGeneratingCandidateIds,
     savedSessionId,
     sessionName,
     savedSessions,
@@ -1030,6 +1240,7 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
     allKeptCandidates,
     rejectedCandidates,
     pendingCandidates,
+    selectedForArtCandidates,
     minimumMixResults,
     isGenerating,
     isPersisting,
@@ -1065,6 +1276,12 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
     generateBatch,
     regenerateCandidate,
     branchCandidate,
+    isSelectedForArt,
+    toggleArtSelection,
+    clearArtSelection,
+    clearArtGenerationError,
+    isGeneratingArtFor,
+    generateArtForSelected,
     loadSavedSessions,
     saveCurrentSession,
     openSavedSession,

--- a/stores/helpers/brainstormCandidateLifecycle.ts
+++ b/stores/helpers/brainstormCandidateLifecycle.ts
@@ -17,6 +17,10 @@
 // brainstormStore.ts imports everything it still needs from here; nothing
 // about its own behavior changes, only where the pure half of it lives.
 import {
+  artContextRules,
+  artSlotFraming,
+} from '../../utils/entityArtPromptFraming'
+import {
   BRAINSTORM_DEFAULT_OUTPUT_DOMAIN,
   BRAINSTORM_DEFAULT_RESULTS,
   BRAINSTORM_MAX_RESULTS,
@@ -29,6 +33,7 @@ import type {
   BrainstormBatchShape,
   BrainstormBranchOrigin,
   BrainstormCandidate,
+  BrainstormCandidateArtMeta,
   BrainstormCandidateRevision,
   BrainstormCandidateStatus,
   BrainstormErrorKind,
@@ -165,6 +170,107 @@ export function normalizeGeneratedCandidates(
   return candidates.length === expectedCount ? candidates : null
 }
 
+function normalizePositiveIntArray(value: unknown): number[] {
+  if (!Array.isArray(value)) return []
+  const seen = new Set<number>()
+  const result: number[] = []
+  for (const raw of value) {
+    const id = Number(raw)
+    if (Number.isInteger(id) && id > 0 && !seen.has(id)) {
+      seen.add(id)
+      result.push(id)
+    }
+  }
+  return result
+}
+
+/**
+ * brainstorm/t-016: a candidate's linkage to its generated ArtJobs/ArtImages
+ * (BrainstormCandidateArtMeta) round-trips through the *server* save path
+ * generically -- brainstormPersistence.ts's normalizeCandidate keeps the
+ * whole `meta` object as-is. It does NOT round-trip through this module's
+ * own normalizeStoredCandidate (the browser localStorage autosave path)
+ * without this explicit normalizer, since that function otherwise only lifts
+ * out the specific sub-fields it knows about (source/returnType/branchOrigin)
+ * and drops everything else -- silently wiping meta.art on a page reload
+ * before the user explicitly saves the session to the server.
+ */
+export function normalizeCandidateArtMeta(
+  value: unknown,
+): BrainstormCandidateArtMeta | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined
+  }
+  const record = value as Record<string, unknown>
+  const jobIds = normalizePositiveIntArray(record.jobIds)
+  const imageIds = normalizePositiveIntArray(record.imageIds)
+  if (!jobIds.length && !imageIds.length) return undefined
+  return { jobIds, imageIds }
+}
+
+/** Appends a newly queued ArtJob id to a candidate's art tracking, in place. */
+export function recordCandidateArtJob(
+  candidate: BrainstormCandidate,
+  jobId: number,
+): void {
+  if (!Number.isInteger(jobId) || jobId <= 0) return
+  const art = candidate.meta.art ?? { jobIds: [], imageIds: [] }
+  if (!art.jobIds.includes(jobId)) art.jobIds = [...art.jobIds, jobId]
+  candidate.meta.art = art
+}
+
+/** Appends a resolved ArtImage id to a candidate's art tracking, in place. */
+export function recordCandidateArtImage(
+  candidate: BrainstormCandidate,
+  imageId: number,
+): void {
+  if (!Number.isInteger(imageId) || imageId <= 0) return
+  const art = candidate.meta.art ?? { jobIds: [], imageIds: [] }
+  if (!art.imageIds.includes(imageId)) art.imageIds = [...art.imageIds, imageId]
+  candidate.meta.art = art
+}
+
+/**
+ * brainstorm/t-016: frames a candidate's title/text as an image-generation
+ * prompt, following the house convention set by
+ * server/utils/entityArt.ts's buildEntityArtPrompt -- primary direction
+ * first, then a geometry-only (not format-noun) composition instruction via
+ * artSlotFraming, then the shared trailing rules via artContextRules. Unlike
+ * the entity version there is no fixed slot size (Brainstorm art isn't
+ * filling a UI card/hero/icon), so artSlotFraming is called with no
+ * width/height, which it already treats as "a single balanced composition".
+ *
+ * When outputDomain is 'art-prompts' the candidate's own text was generated
+ * BY Brainstorm specifically as a ready-to-use image prompt (see
+ * BRAINSTORM_OUTPUT_DOMAINS's description in types/brainstorm.ts) -- wrapping
+ * it in more framing language would dilute a prompt that is already
+ * purpose-built, so only the optional title is folded in.
+ */
+export function buildBrainstormArtPrompt(
+  candidate: { title: string; text: string },
+  outputDomain: BrainstormOutputDomainId,
+): string {
+  const heading = candidate.title
+    ? `${candidate.title}: ${candidate.text}`
+    : candidate.text
+  const trimmedHeading = heading.trim()
+
+  if (outputDomain === 'art-prompts') {
+    return trimmedHeading.slice(0, 4000)
+  }
+
+  const prompt = [
+    trimmedHeading,
+    '',
+    `Compose this as ${artSlotFraming({ label: '', width: 0, height: 0 })} illustrating the idea above.`,
+    ...artContextRules('idea'),
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  return prompt.slice(0, 4000)
+}
+
 export function normalizeSourceRef(value: unknown): BrainstormSourceRef | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null
 
@@ -282,6 +388,7 @@ export function normalizeStoredCandidate(
   const source = normalizeSourceRef(meta.source)
   const returnType = normalizeReturnTypeId(meta.returnType)
   const branchOrigin = normalizeBranchOrigin(meta.branchOrigin)
+  const art = normalizeCandidateArtMeta(meta.art)
 
   return {
     id,
@@ -308,6 +415,7 @@ export function normalizeStoredCandidate(
       source,
       returnType,
       branchOrigin,
+      ...(art ? { art } : {}),
     },
   }
 }


### PR DESCRIPTION
## What changed

Wires explicit selected-candidate art generation to the normal `POST /api/art/enqueue` pipeline for Brainstorm, defaulting to Krea 2, per conductor `brainstorm/t-016`.

- **`brainstorm-candidate-card.vue`** — a "Select for art" checkbox, and thumbnail display of any generated images (`meta.art.imageIds`).
- **`brainstorm-manager.vue`** — an explicit "Generate art" batch button with a clear `N of M kept ideas selected · Krea 2` count preview, plus a dismissible error banner.
- **`brainstormStore.ts`** — selection state (`artSelectionIds`) and `generateArtForSelected()`, which enqueues one ArtJob per selected candidate via `artStore.enqueueArtGeneration` (krea2 engine), polls each job, and records job/image ids onto `candidate.meta.art.{jobIds,imageIds}` in place. Auto-saves the session afterward if it already has a durable `savedSessionId`, so the linkage survives a reload from another device, not just this browser's localStorage.
- **`brainstormCandidateLifecycle.ts`** — `buildBrainstormArtPrompt` (frames a candidate's title/text as an image prompt using the same house convention as `buildEntityArtPrompt`; candidates from the `art-prompts` output domain pass through mostly as-is since they're already ready-to-use image prompts), `recordCandidateArtJob`/`recordCandidateArtImage`, and `normalizeCandidateArtMeta`.
- **`artStore.ts`** — a new `BrainstormArtEnqueueContext` type threaded through `GenerateArtData`/`buildGenerateArtData`.
- **`enqueue.post.ts`** — accepts and validates `brainstormContext`, tagging it onto the ArtJob payload for traceability (session id, candidate id, source ref), alongside the existing `narrativeContext`/`entityArt` conventions.

## Key design decisions

**Selection mechanism**: an explicit per-candidate checkbox, restricted to `kept` candidates only (not `pending`/`rejected`). Rationale: "selected candidates" per the task note should mean deliberately curated ones, and a batch can have far more kept ideas than the user wants art for right now — a separate selection layer on top of `kept` avoids generating art for everything kept by default while still keeping the affordance one click away. Selection state lives in the store (`artSelectionIds`), not in `BrainstormCandidate`/`meta` — it's a this-session UI concern, not durable creative state, unlike `meta.art` itself.

**Prompt framing**: candidate title+text is wrapped with the same geometry-only composition framing and trailing rules `server/utils/entityArt.ts`'s `buildEntityArtPrompt` already uses for entity art (no fixed slot size, since Brainstorm art isn't filling a UI card/hero/icon — `artSlotFraming` falls back to "a single balanced composition"). When the candidate came from the `art-prompts` output domain (t-015), its text is already a purpose-built image-generation prompt, so it's passed through with only the title folded in rather than adding more framing on top of framing.

**Metadata linkage**: `meta.art.{jobIds,imageIds}` on the candidate (the already-scaffolded route) rather than the generic `entityArt`/`EntityArtImage` system — Brainstorm candidates aren't Prisma-backed the way bots/characters/etc. are, so the simpler route fit better. For job traceability I added a new `BrainstormArtEnqueueContext`/`brainstormContext` (client type in `artStore.ts`, server type in `enqueue.post.ts`) rather than widening `NarrativeArtEnqueueContext`'s product union — that type's `beatId`/`moment`/`dedupeKey` exist for narrative-beat idempotency dedup (Storybook/Taskmaster/Da Vinci), which Brainstorm has no equivalent of: every "Generate art" click is an explicit, distinct action, not something needing re-trigger protection.

**Bug fixed along the way**: `normalizeStoredCandidate` (the client-side localStorage-autosave round-trip) was rebuilding `meta` from only `source`/`returnType`/`branchOrigin`, silently dropping `meta.art` on every page reload before the user explicitly saved to the server — even though the *server* save path (`brainstormPersistence.ts`) already preserved the whole `meta` object generically. Added `normalizeCandidateArtMeta` and wired it in so both paths round-trip identically.

## Verification

- `npx vue-tsc --noEmit` — clean (full project). Found and fixed one real type error (`string | undefined` narrowing in the failure-message branch of `generateArtForSelected`).
- `npx eslint` on all 6 changed files — clean. The 4 errors `artStore.ts` reports are pre-existing (confirmed via `git stash` against `HEAD`, same 4 errors at shifted line numbers).
- `npx prettier --check` — every line I added or changed is prettier-clean (verified by round-tripping each file through `prettier --write` and confirming zero diff against my working copy for anything my task touched). 4 of the 6 files carry pre-existing whole-file prettier drift *outside* my diff (confirmed the same way — `HEAD` versions already fail `--check`) — left untouched rather than reformatted wholesale, matching the precedent already set in `cbd28d5` for `modelBuilderStore.ts`.
- All 6 Brainstorm contract scripts pass: `verifyBrainstormStoreContract.mjs`, `verifyBrainstormCandidateLifecycle.test.ts`, `verifyBrainstormWorkbench.mjs`, `verifyBrainstormPersistence.ts`, `verifyBrainstormObjectEntryLinks.mjs`, `verifyBrainstormSourceAdapters.test.ts`.
- `verifyLayoutContract.ts` — holds, no new violations (the touched components already used the intrinsic `grid-cols-[repeat(auto-fit,minmax(...))]` pattern; I didn't add any new grid).
- No Prisma changes: `BrainstormCandidate.meta` is already a generic `String? @db.LongText` column — confirmed it round-trips `art.jobIds`/`art.imageIds` through both the server save path and (after the fix above) the client localStorage path.
- `git diff --stat` — scoped to exactly 6 files, 569 insertions / 6 deletions, nothing unrelated.

## Flags for review

- Engine is hardcoded to `krea2` (no engine picker in the UI) — the task note allows "unless the user deliberately chooses another supported option," and since no such option is currently offered, this trivially satisfies "default to Krea 2." Happy to add an engine picker in a follow-up if wanted.
- Batch generation runs all selected candidates concurrently via `Promise.all` (not sequential/queued) — each is an independent ArtJob so this seemed fine, but flagging in case a different concurrency posture is preferred for mana-gating UX.
- Generated art here is treated as pre-authorized internal generation per the repo's standing rule (`isPublic: false`, `isMature: false`) — no external publication path exists for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELRnyRK45Jf695ZxQppFrK)_