### PR TITLE
storybook: fix unconfirmed single-click "New story" discard on the library page (storybook/t-010 cycle 24)

### DIFF
--- a/.github/workflows/storybook-library-new-story-confirm-contract.yml
+++ b/.github/workflows/storybook-library-new-story-confirm-contract.yml
@@ -1,0 +1,30 @@
+name: Storybook Library New Story Confirm Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: storybook-library-new-story-confirm-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Storybook library New story confirm contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify Storybook library "New story" confirm guard
+        run: node utils/scripts/verifyStorybookLibraryNewStoryConfirmGuard.mjs

--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -68,12 +68,23 @@
           </button>
 
           <button
+            v-if="!newStoryArmed"
             type="button"
             class="btn btn-primary btn-sm rounded-xl"
             :disabled="storyStore.isWeaving"
-            @click="startNewStory"
+            @click="newStoryArmed = true"
           >
             <Icon name="kind-icon:plus" class="size-4" /> New story
+          </button>
+          <button
+            v-else
+            type="button"
+            class="btn btn-warning btn-sm rounded-xl"
+            :disabled="storyStore.isWeaving"
+            @click="startNewStory"
+            @blur="newStoryArmed = false"
+          >
+            <Icon name="kind-icon:alert" class="size-4" /> Discard this tale?
           </button>
         </template>
       </div>
@@ -177,6 +188,7 @@ const router = useRouter()
 
 const libraryOpen = ref(false)
 const restartArmed = ref(false)
+const newStoryArmed = ref(false)
 
 // storybook-page.vue's seedFromQuery() (child, mounted first) treats these as
 // one-shot: it consumes them into the setup draft, then strips them with its
@@ -266,6 +278,7 @@ function downloadStory(
 
 function startNewStory(): void {
   if (storyStore.isWeaving) return
+  newStoryArmed.value = false
   storyStore.archiveCurrent()
   storyStore.resetSession()
   libraryOpen.value = false
@@ -286,15 +299,17 @@ function formatStoryDate(value: string): string {
 watch(
   () => storyStore.session?.id ?? null,
   (sessionId) => {
-    // A "Restart from the beginning?" arm is a confirmation for THIS session,
-    // not a standing state. Opening a different story, duplicating,
-    // restarting, or starting a new one all swap the active session out from
-    // under an armed-but-unconfirmed button -- without this reset, the next
-    // session renders straight into the armed, warning-colored button (never
-    // the plain "Restart" one), so a single click that looks like a first
-    // press instead fires the destructive restart immediately, with no
-    // confirmation ever given for the story actually on screen.
+    // A "Restart from the beginning?" / "Discard this tale?" arm is a
+    // confirmation for THIS session, not a standing state. Opening a
+    // different story, duplicating, restarting, or starting a new one all
+    // swap the active session out from under an armed-but-unconfirmed
+    // button -- without this reset, the next session renders straight into
+    // the armed, warning-colored button (never the plain "Restart"/"New
+    // story" one), so a single click that looks like a first press instead
+    // fires the destructive action immediately, with no confirmation ever
+    // given for the story actually on screen.
     restartArmed.value = false
+    newStoryArmed.value = false
     if (sessionId !== queryStoryId()) updateStoryQuery(sessionId)
   },
 )

--- a/utils/scripts/verifyStorybookLibraryNewStoryConfirmGuard.mjs
+++ b/utils/scripts/verifyStorybookLibraryNewStoryConfirmGuard.mjs
@@ -110,7 +110,7 @@ assert.ok(
     'has it been renamed or restructured?',
 )
 assert.ok(
-  startNewStoryMatch[1].includes('newStoryArmed.value = false'),
+  (startNewStoryMatch?.[1] ?? '').includes('newStoryArmed.value = false'),
   `${LIBRARY_PAGE_PATH}'s startNewStory() must reset ` +
     "`newStoryArmed.value = false` (matching restartCurrent()'s own " +
     'reset of `restartArmed`), so the button returns to its unarmed state ' +

--- a/utils/scripts/verifyStorybookLibraryNewStoryConfirmGuard.mjs
+++ b/utils/scripts/verifyStorybookLibraryNewStoryConfirmGuard.mjs
@@ -1,0 +1,144 @@
+// /utils/scripts/verifyStorybookLibraryNewStoryConfirmGuard.mjs
+//
+// Regression guard (storybook/t-010, front-end polish, cycle 24). Every other
+// destructive control in storybook-library-page.vue's persistent header --
+// its own "Restart" button, and storybook-page.vue's own "New story" button
+// (see verifyStorybookConfirmArmScopeGuard.mjs) -- uses an arm-then-confirm
+// pattern: one click swaps the button to a warning-colored confirmation, and
+// only a SECOND click on that same control fires the destructive action.
+//
+// storybook-library-page.vue's OWN "New story" button (`startNewStory()`) had
+// no such guard at all: it fired immediately on a single click, ending the
+// active session with zero confirmation, right next to a "Restart" button
+// that requires two clicks for what is an equally disruptive action (both
+// archive the outgoing session to the library first via
+// upsert()/archiveCurrent(), so this was never about data loss -- it was
+// about an unconfirmed, single-click destructive action sitting beside its
+// own two-click sibling in the same header, and inconsistent with
+// storybook-page.vue's own "New story" button, which the very comment in
+// that file's code explains exists specifically "so an in-progress or
+// finished tale can't be discarded by a single stray click"). The prior
+// arm-scope guard's own commentary even names storybook-library-page.vue's
+// "New story" button as a HAZARD to other components' armed state, without
+// ever noticing this button had no arm state of its own to go stale.
+//
+// Fix: startNewStory() now sits behind the same v-if="!newStoryArmed" /
+// v-else two-button pattern as "Restart", with its own `newStoryArmed` ref
+// reset inside the same session-id watcher that already resets
+// `restartArmed` -- so an armed-but-unconfirmed "Discard this tale?" can't
+// survive a session-identity change either, extending the exact fix
+// verifyStorybookConfirmArmScopeGuard.mjs already protects to this third
+// control.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+function source(path) {
+  return readFileSync(resolve(process.cwd(), path), 'utf8')
+}
+
+function extractWatchCall(content, anchor, { path } = {}) {
+  const anchorIndex = content.indexOf(anchor)
+  assert.ok(
+    anchorIndex >= 0,
+    `Could not find \`${anchor}\` in ${path} -- has this watcher been ` +
+      'renamed, removed, or restructured? If so, this guard (and the ' +
+      'stale-arm bug it protects against) needs to move with it.',
+  )
+  const openParen = anchorIndex + anchor.indexOf('(')
+  let depth = 0
+  let i = openParen
+  for (; i < content.length; i++) {
+    if (content[i] === '(') depth++
+    else if (content[i] === ')') {
+      depth--
+      if (depth === 0) break
+    }
+  }
+  return content.slice(openParen, i + 1)
+}
+
+const LIBRARY_PAGE_PATH = 'components/pages/storybook-library-page.vue'
+const libraryPage = source(LIBRARY_PAGE_PATH)
+
+// --- the ref exists ---
+
+assert.ok(
+  /const\s+newStoryArmed\s*=\s*ref\(false\)/.test(libraryPage),
+  `${LIBRARY_PAGE_PATH} must declare \`const newStoryArmed = ref(false)\` -- ` +
+    'the arm state for its own "New story" confirmation.',
+)
+
+// --- the template renders the two-button arm-then-confirm pair ---
+
+const armedButtonIndex = libraryPage.indexOf('v-if="!newStoryArmed"')
+assert.ok(
+  armedButtonIndex >= 0,
+  `${LIBRARY_PAGE_PATH}'s "New story" button must be gated behind ` +
+    '`v-if="!newStoryArmed"` -- without it, the button has no first-press ' +
+    'state distinct from its destructive, confirmed state.',
+)
+
+const confirmButtonSlice = libraryPage.slice(
+  armedButtonIndex,
+  armedButtonIndex + 1200,
+)
+assert.ok(
+  /@click="newStoryArmed = true"/.test(confirmButtonSlice),
+  `${LIBRARY_PAGE_PATH}'s unarmed "New story" button must arm on click ` +
+    '(`newStoryArmed = true`) rather than firing `startNewStory()` directly ' +
+    '-- a single accidental click must not end the active session.',
+)
+assert.ok(
+  /v-else[\s\S]{0,300}@click="startNewStory"[\s\S]{0,120}@blur="newStoryArmed = false"/.test(
+    confirmButtonSlice,
+  ),
+  `${LIBRARY_PAGE_PATH} must render a \`v-else\` confirmation button that ` +
+    'calls `startNewStory()` on click and resets `newStoryArmed` on blur, ' +
+    'matching the "Restart" button\'s established two-click pattern right ' +
+    'beside it.',
+)
+
+// --- startNewStory() resets its own arm on every call ---
+
+const startNewStoryMatch = libraryPage.match(
+  /function startNewStory\(\)[^{]*\{([\s\S]*?)\n\}/,
+)
+assert.ok(
+  startNewStoryMatch,
+  `Could not find \`function startNewStory()\` in ${LIBRARY_PAGE_PATH} -- ` +
+    'has it been renamed or restructured?',
+)
+assert.ok(
+  startNewStoryMatch[1].includes('newStoryArmed.value = false'),
+  `${LIBRARY_PAGE_PATH}'s startNewStory() must reset ` +
+    "`newStoryArmed.value = false` (matching restartCurrent()'s own " +
+    'reset of `restartArmed`), so the button returns to its unarmed state ' +
+    'once the action has fired.',
+)
+
+// --- the session-id watcher resets newStoryArmed too, alongside restartArmed ---
+
+const sessionWatch = extractWatchCall(
+  libraryPage,
+  'watch(\n  () => storyStore.session?.id ?? null,\n  (sessionId) => {',
+  { path: LIBRARY_PAGE_PATH },
+)
+
+assert.ok(
+  sessionWatch.includes('restartArmed.value = false') &&
+    sessionWatch.includes('newStoryArmed.value = false'),
+  `${LIBRARY_PAGE_PATH}'s session-id watcher must reset BOTH ` +
+    '`restartArmed.value = false` and `newStoryArmed.value = false` -- ' +
+    'without the latter, an armed "Discard this tale?" button survives ' +
+    'opening a different story, duplicating, or restarting, and stays ' +
+    'primed to fire on the next session with a single, unconfirmed click.',
+)
+
+console.log(
+  'Storybook library "New story" confirm guard contract passed: the ' +
+    'library page\'s own "New story" control now requires the same ' +
+    'arm-then-confirm two-click pattern as its "Restart" sibling and ' +
+    "storybook-page.vue's own control, and its arm resets whenever the " +
+    'active session id changes.',
+)


### PR DESCRIPTION
## What

`storybook-library-page.vue`'s own **"New story"** button, in its persistent header, fired `startNewStory()` immediately on a single click — no confirmation at all. Right beside it, in the same header, the **"Restart"** button requires an arm-then-confirm two-click pattern (`restartArmed`) specifically to prevent an in-progress or finished tale from being discarded by a single stray click. `storybook-page.vue`'s own **"New story"** button (a separate control, also visible during an active session) already uses the identical two-click pattern for exactly the same reason — its own code comment says so explicitly.

So the same destructive action ("start over, ending the current session") had two entry points on screen at once: one gated behind two clicks, one firing on the first. The existing `verifyStorybookConfirmArmScopeGuard.mjs` (cycle 17, PR #1953) even names `storybook-library-page.vue`'s `startNewStory()` as a *hazard* to the other two arm states going stale — without ever noticing this button had no arm state of its own to go stale in the first place.

Neither button risks true data loss (`startNewStory()`/`restartCurrent()` both archive the outgoing session to the library first), but an accidental single click still abruptly ends the active reading session with zero confirmation, discarding scroll position/context and forcing the reader back into the library to reopen it.

## Fix

`storybook-library-page.vue`'s "New story" button now sits behind the same `v-if="!newStoryArmed"` / `v-else` two-button pattern as "Restart":
- First click arms it (`newStoryArmed = true`), swapping to a warning-colored "Discard this tale?" confirmation.
- Second click on that same control fires `startNewStory()`.
- `newStoryArmed` resets on blur, inside `startNewStory()` itself, and inside the same session-id `watch()` that already resets `restartArmed` — so an armed-but-unconfirmed "Discard this tale?" can't survive a session-identity change (opening a different story, duplicating, or restarting) either.

## Guard

Added the 19th `verifyStorybook*` guard, `verifyStorybookLibraryNewStoryConfirmGuard.mjs`, plus its own dedicated `storybook-library-new-story-confirm-contract.yml` workflow, matching the established per-guard-workflow convention.

## Verification

- New guard fails pre-fix / passes post-fix (git-stash round-trip confirmed).
- All 18 pre-existing `verifyStorybook*` guards pass (17 `.mjs` via `node`, 1 `.ts` via `npx tsx`) — no regression.
- `eslint` clean on touched/new files.
- `prettier --check` clean on the two new files (pre-existing, unrelated formatting drift on `storybook-library-page.vue` confirmed via git-stash to predate this change, left untouched).
- `vue-tsc --noEmit` repo-wide clean.
- `git status --porcelain` shows exactly the 3 intended files.

## Flags for Reviewer

- `stakes: reversible`, `kind: software` per `projects/storybook/roadmap.yaml`'s t-010 — standard merge-when-green flow, no human gate.
- Recurring bug-hunt task (storybook/t-010), cycle 24 of an ongoing series; conductor-side roadmap/TALKBACK/LEARNING close-out is handled by the dispatching conductor session, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MJvPmiD75hGwS41MoFGDBh)_