### PR TITLE
feat(brainstorm): persist candidate art status, verify delivery, resume in-flight jobs (t-017)

### DIFF
--- a/components/brainstorm/brainstorm-candidate-card.vue
+++ b/components/brainstorm/brainstorm-candidate-card.vue
@@ -152,13 +152,26 @@
       </a>
     </div>
 
+    <p
+      v-if="artFailed"
+      class="kr-note kr-note-error mt-3 text-xs"
+      data-testid="brainstorm-candidate-art-error"
+    >
+      Art generation failed{{ artError ? `: ${artError}` : '.' }} Select for art
+      and try again.
+    </p>
+
     <details
       v-if="candidate.meta.branchOrigin"
       class="mt-4 rounded-2xl border border-secondary/15 bg-secondary/5 p-3"
       data-testid="brainstorm-branch-lineage"
     >
-      <summary class="cursor-pointer select-none text-xs font-black uppercase tracking-[0.12em] text-secondary/80">
-        Branch lineage · parent v{{ candidate.meta.branchOrigin.revisionIndex + 1 }}
+      <summary
+        class="cursor-pointer select-none text-xs font-black uppercase tracking-[0.12em] text-secondary/80"
+      >
+        Branch lineage · parent v{{
+          candidate.meta.branchOrigin.revisionIndex + 1
+        }}
       </summary>
       <div class="mt-3 text-xs leading-5 text-base-content/65">
         <div class="flex flex-wrap items-center gap-2">
@@ -172,9 +185,13 @@
           >
             Jump to parent
           </a>
-          <span v-else class="text-base-content/40">Parent no longer in this batch</span>
+          <span v-else class="text-base-content/40"
+            >Parent no longer in this batch</span
+          >
         </div>
-        <p class="mt-2 max-h-24 overflow-auto whitespace-pre-wrap break-words rounded-xl bg-base-100/75 p-2">
+        <p
+          class="mt-2 max-h-24 overflow-auto whitespace-pre-wrap break-words rounded-xl bg-base-100/75 p-2"
+        >
           {{ candidate.meta.branchOrigin.text }}
         </p>
       </div>
@@ -185,7 +202,9 @@
       class="mt-4 rounded-2xl border border-base-content/10 bg-base-200/35 p-3"
       data-testid="brainstorm-revision-history"
     >
-      <summary class="cursor-pointer select-none text-xs font-black uppercase tracking-[0.12em] text-base-content/60">
+      <summary
+        class="cursor-pointer select-none text-xs font-black uppercase tracking-[0.12em] text-base-content/60"
+      >
         History · {{ candidate.revisions.length }} versions
       </summary>
       <div class="mt-3 flex flex-col gap-2">
@@ -195,14 +214,23 @@
           class="rounded-xl border border-base-content/8 bg-base-100/80 p-3"
         >
           <div class="flex flex-wrap items-center gap-2 text-[0.7rem]">
-            <span class="font-black text-base-content/75">v{{ entry.index + 1 }}</span>
-            <span class="rounded-full bg-base-200 px-2 py-0.5 font-bold text-base-content/55">
+            <span class="font-black text-base-content/75"
+              >v{{ entry.index + 1 }}</span
+            >
+            <span
+              class="rounded-full bg-base-200 px-2 py-0.5 font-bold text-base-content/55"
+            >
               {{ revisionReasonLabel(entry.revision.reason) }}
             </span>
-            <span v-if="revisionReturnTypeLabel(entry.revision.returnType)" class="text-accent">
+            <span
+              v-if="revisionReturnTypeLabel(entry.revision.returnType)"
+              class="text-accent"
+            >
               {{ revisionReturnTypeLabel(entry.revision.returnType) }}
             </span>
-            <span class="text-base-content/35">{{ formatRevisionTime(entry.revision.createdAt) }}</span>
+            <span class="text-base-content/35">{{
+              formatRevisionTime(entry.revision.createdAt)
+            }}</span>
             <span
               v-if="entry.current"
               class="ml-auto rounded-full bg-primary/10 px-2 py-0.5 font-black text-primary"
@@ -210,10 +238,15 @@
               current
             </span>
           </div>
-          <p v-if="entry.revision.title" class="mt-2 text-xs font-black text-base-content/75">
+          <p
+            v-if="entry.revision.title"
+            class="mt-2 text-xs font-black text-base-content/75"
+          >
             {{ entry.revision.title }}
           </p>
-          <p class="mt-1 max-h-20 overflow-auto whitespace-pre-wrap break-words text-xs leading-5 text-base-content/60">
+          <p
+            class="mt-1 max-h-20 overflow-auto whitespace-pre-wrap break-words text-xs leading-5 text-base-content/60"
+          >
             {{ entry.revision.text }}
           </p>
           <div v-if="!entry.current" class="mt-2 flex justify-end">
@@ -229,7 +262,8 @@
         </div>
       </div>
       <p class="mt-2 text-[0.7rem] leading-5 text-base-content/40">
-        Restoring is non-destructive. The restored text becomes a new version instead of deleting later work.
+        Restoring is non-destructive. The restored text becomes a new version
+        instead of deleting later work.
       </p>
     </details>
 
@@ -254,7 +288,9 @@
       />
     </div>
 
-    <footer class="mt-4 flex flex-wrap items-center gap-2 border-t border-base-content/8 pt-4">
+    <footer
+      class="mt-4 flex flex-wrap items-center gap-2 border-t border-base-content/8 pt-4"
+    >
       <button
         type="button"
         class="btn btn-sm"
@@ -292,7 +328,10 @@
           :disabled="disabled"
           @click="regenerate"
         >
-          <span v-if="busy && busyAction === 'regenerate'" class="loading loading-spinner loading-xs" />
+          <span
+            v-if="busy && busyAction === 'regenerate'"
+            class="loading loading-spinner loading-xs"
+          />
           Regenerate
         </button>
         <button
@@ -301,7 +340,10 @@
           :disabled="disabled"
           @click="branch"
         >
-          <span v-if="busy && busyAction === 'branch'" class="loading loading-spinner loading-xs" />
+          <span
+            v-if="busy && busyAction === 'branch'"
+            class="loading loading-spinner loading-xs"
+          />
           More like this
         </button>
       </div>
@@ -389,6 +431,16 @@ const artBusy = computed(
   () => Boolean(props.busy) && props.busyAction === 'art',
 )
 const artImageIds = computed(() => props.candidate.meta.art?.imageIds ?? [])
+// brainstorm/t-017: meta.art.status/error persist past a page reload, unlike
+// artBusy (this session's own in-flight generation flag) -- so a failed
+// attempt from an earlier session stays visible instead of silently looking
+// identical to "art never requested." Only surfaced once nothing in *this*
+// session is actively generating, so a live retry's spinner takes priority
+// over the stale error it's in the middle of replacing.
+const artFailed = computed(
+  () => !artBusy.value && props.candidate.meta.art?.status === 'failed',
+)
+const artError = computed(() => props.candidate.meta.art?.error || null)
 
 const returnType = computed(() =>
   BRAINSTORM_RETURN_TYPES.find(
@@ -396,7 +448,9 @@ const returnType = computed(() =>
   ),
 )
 const returnTypeLabel = computed(() => returnType.value?.label || '')
-const returnTypeDescription = computed(() => returnType.value?.description || '')
+const returnTypeDescription = computed(
+  () => returnType.value?.description || '',
+)
 
 const revisionEntries = computed(() =>
   props.candidate.revisions
@@ -427,10 +481,15 @@ function revisionReturnTypeLabel(
   returnTypeId: BrainstormReturnTypeId | null | undefined,
 ): string {
   if (!returnTypeId) return ''
-  return BRAINSTORM_RETURN_TYPES.find((entry) => entry.id === returnTypeId)?.label || ''
+  return (
+    BRAINSTORM_RETURN_TYPES.find((entry) => entry.id === returnTypeId)?.label ||
+    ''
+  )
 }
 
-function formatRevisionTime(value: BrainstormCandidateRevision['createdAt']): string {
+function formatRevisionTime(
+  value: BrainstormCandidateRevision['createdAt'],
+): string {
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return ''
   return new Intl.DateTimeFormat(undefined, {

--- a/stores/brainstormStore.ts
+++ b/stores/brainstormStore.ts
@@ -1,6 +1,7 @@
 import { computed, ref, watch } from 'vue'
 import { defineStore } from 'pinia'
 import { useArtStore } from '@/stores/artStore'
+import type { GenerateArtData } from '@/stores/artStore'
 import { useServerStore } from '@/stores/serverStore'
 import { performFetch } from '@/stores/utils'
 import {
@@ -23,7 +24,9 @@ import {
   normalizeSourceRef,
   normalizeStoredBatch,
   normalizeStoredCandidate,
+  markCandidateArtProcessing,
   nowIso,
+  recordCandidateArtFailure,
   recordCandidateArtImage,
   recordCandidateArtJob,
   RETURN_TYPE_IDS,
@@ -905,6 +908,23 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
    * without that store's run-cancellation apparatus -- Brainstorm has no
    * equivalent of a model-builder "run" to cancel out from under a job, so a
    * plain per-candidate async task awaited via Promise.all is sufficient.
+   *
+   * brainstorm/t-017: two follow-ons on top of the above.
+   *   1. Retry-safe resume -- if this candidate's meta.art already carries a
+   *      `queued`/`processing` status (an earlier attempt's poll loop never
+   *      saw a terminal status, e.g. a page reload interrupted it), reuse
+   *      that job's id instead of enqueueing a duplicate ArtJob for the same
+   *      candidate. Only a genuinely new attempt (no art yet, or the last one
+   *      ended `delivered`/`failed`) enqueues fresh.
+   *   2. Verified delivery -- a DONE status with an artImageId attached is
+   *      not itself proof the image exists and loads. Route the terminal job
+   *      through artStore.finalizeQueuedArtImage the same way
+   *      modelBuilderStore.ts's pollAsyncArtJob does: it re-fetches the
+   *      ArtImage record (so a DONE job whose image row never actually
+   *      landed surfaces as a failure here, not a silently-broken thumbnail
+   *      later) and attaches it through the same collection semantics every
+   *      other art-generation surface uses, rather than Brainstorm inventing
+   *      its own image storage.
    */
   async function generateArtForCandidate(
     candidate: BrainstormCandidate,
@@ -916,53 +936,74 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
     ]
     try {
       const prompt = buildBrainstormArtPrompt(candidate, outputDomain.value)
-      const enqueued = await artStore.enqueueArtGeneration({
-        promptString: prompt,
-        engine: 'krea2',
-        isPublic: false,
-        isMature: false,
-        brainstormContext: {
-          product: 'brainstorm',
-          candidateId: candidate.id,
-          sessionId: savedSessionId.value,
-          source: candidate.meta.source ?? source.value ?? null,
-        },
-      })
+      const existingArt = candidate.meta.art
+      const resumableJobId =
+        existingArt?.status === 'queued' || existingArt?.status === 'processing'
+          ? (existingArt.jobIds[existingArt.jobIds.length - 1] ?? null)
+          : null
 
-      if (!enqueued.success || !enqueued.jobId) {
-        return {
-          success: false,
-          message:
+      let jobId: number
+      let generateData: GenerateArtData = { promptString: prompt }
+
+      if (resumableJobId != null) {
+        jobId = resumableJobId
+      } else {
+        const enqueued = await artStore.enqueueArtGeneration({
+          promptString: prompt,
+          engine: 'krea2',
+          isPublic: false,
+          isMature: false,
+          brainstormContext: {
+            product: 'brainstorm',
+            candidateId: candidate.id,
+            sessionId: savedSessionId.value,
+            source: candidate.meta.source ?? source.value ?? null,
+          },
+        })
+
+        if (!enqueued.success || !enqueued.jobId) {
+          const message =
             enqueued.message ||
-            `"${candidate.title || candidate.text.slice(0, 40)}" failed to queue.`,
+            `"${candidate.title || candidate.text.slice(0, 40)}" failed to queue.`
+          recordCandidateArtFailure(candidate, message)
+          return { success: false, message }
         }
+
+        recordCandidateArtJob(candidate, enqueued.jobId)
+        jobId = enqueued.jobId
+        if (enqueued.data) generateData = enqueued.data
       }
 
-      recordCandidateArtJob(candidate, enqueued.jobId)
-
       while (true) {
-        const job = await artStore.getArtJobStatus(enqueued.jobId)
-        if (!job || job.status === 'PENDING' || job.status === 'RUNNING') {
+        const job = await artStore.getArtJobStatus(jobId)
+        if (!job || job.status === 'PENDING') {
           await artQueueSleep(ART_JOB_POLL_MS)
           continue
         }
-        if (job.status !== 'DONE' || !job.artImageId) {
-          return {
-            success: false,
-            message:
-              job.error ||
-              `ArtJob ${enqueued.jobId} ended as ${job.status.toLowerCase()}.`,
-          }
+        if (job.status === 'RUNNING') {
+          markCandidateArtProcessing(candidate)
+          await artQueueSleep(ART_JOB_POLL_MS)
+          continue
         }
-        recordCandidateArtImage(candidate, job.artImageId)
+
+        const finalized = await artStore.finalizeQueuedArtImage(
+          job,
+          generateData,
+        )
+        if (!finalized.success || !finalized.data) {
+          const message =
+            finalized.message || `ArtJob ${jobId} did not complete.`
+          recordCandidateArtFailure(candidate, message)
+          return { success: false, message }
+        }
+        recordCandidateArtImage(candidate, finalized.data.id)
         return { success: true }
       }
     } catch (error) {
-      return {
-        success: false,
-        message:
-          error instanceof Error ? error.message : 'Art generation failed.',
-      }
+      const message =
+        error instanceof Error ? error.message : 'Art generation failed.'
+      recordCandidateArtFailure(candidate, message)
+      return { success: false, message }
     } finally {
       artGeneratingCandidateIds.value = artGeneratingCandidateIds.value.filter(
         (id) => id !== candidate.id,

--- a/stores/helpers/brainstormCandidateLifecycle.ts
+++ b/stores/helpers/brainstormCandidateLifecycle.ts
@@ -34,6 +34,7 @@ import type {
   BrainstormBranchOrigin,
   BrainstormCandidate,
   BrainstormCandidateArtMeta,
+  BrainstormCandidateArtStatus,
   BrainstormCandidateRevision,
   BrainstormCandidateStatus,
   BrainstormErrorKind,
@@ -195,6 +196,22 @@ function normalizePositiveIntArray(value: unknown): number[] {
  * and drops everything else -- silently wiping meta.art on a page reload
  * before the user explicitly saves the session to the server.
  */
+const ART_STATUS_VALUES: BrainstormCandidateArtStatus[] = [
+  'queued',
+  'processing',
+  'delivered',
+  'failed',
+]
+
+function normalizeArtStatus(
+  value: unknown,
+): BrainstormCandidateArtStatus | undefined {
+  return typeof value === 'string' &&
+    (ART_STATUS_VALUES as string[]).includes(value)
+    ? (value as BrainstormCandidateArtStatus)
+    : undefined
+}
+
 export function normalizeCandidateArtMeta(
   value: unknown,
 ): BrainstormCandidateArtMeta | undefined {
@@ -204,11 +221,20 @@ export function normalizeCandidateArtMeta(
   const record = value as Record<string, unknown>
   const jobIds = normalizePositiveIntArray(record.jobIds)
   const imageIds = normalizePositiveIntArray(record.imageIds)
-  if (!jobIds.length && !imageIds.length) return undefined
-  return { jobIds, imageIds }
+  const status = normalizeArtStatus(record.status)
+  const error = typeof record.error === 'string' ? record.error : undefined
+  if (!jobIds.length && !imageIds.length && !status && !error) {
+    return undefined
+  }
+  return { jobIds, imageIds, status, error }
 }
 
-/** Appends a newly queued ArtJob id to a candidate's art tracking, in place. */
+/**
+ * Appends a newly queued ArtJob id to a candidate's art tracking, in place,
+ * and marks the candidate `queued` -- the state a page reload should see
+ * while polling has not yet observed the job as RUNNING (brainstorm/t-017).
+ * Clears any error left over from a prior failed attempt.
+ */
 export function recordCandidateArtJob(
   candidate: BrainstormCandidate,
   jobId: number,
@@ -216,10 +242,31 @@ export function recordCandidateArtJob(
   if (!Number.isInteger(jobId) || jobId <= 0) return
   const art = candidate.meta.art ?? { jobIds: [], imageIds: [] }
   if (!art.jobIds.includes(jobId)) art.jobIds = [...art.jobIds, jobId]
+  art.status = 'queued'
+  art.error = undefined
   candidate.meta.art = art
 }
 
-/** Appends a resolved ArtImage id to a candidate's art tracking, in place. */
+/**
+ * Marks a candidate's art tracking as actively rendering (the job moved from
+ * PENDING to RUNNING). Distinct from `queued` so a resumed poll after a page
+ * reload can tell the two apart even though neither has a delivered image
+ * yet (brainstorm/t-017).
+ */
+export function markCandidateArtProcessing(
+  candidate: BrainstormCandidate,
+): void {
+  const art = candidate.meta.art
+  if (!art) return
+  art.status = 'processing'
+  candidate.meta.art = art
+}
+
+/**
+ * Appends a resolved, verified ArtImage id to a candidate's art tracking, in
+ * place, and marks it `delivered`. Clears any error left over from a prior
+ * failed attempt on this same candidate.
+ */
 export function recordCandidateArtImage(
   candidate: BrainstormCandidate,
   imageId: number,
@@ -227,6 +274,24 @@ export function recordCandidateArtImage(
   if (!Number.isInteger(imageId) || imageId <= 0) return
   const art = candidate.meta.art ?? { jobIds: [], imageIds: [] }
   if (!art.imageIds.includes(imageId)) art.imageIds = [...art.imageIds, imageId]
+  art.status = 'delivered'
+  art.error = undefined
+  candidate.meta.art = art
+}
+
+/**
+ * Records that the most recent art generation attempt for this candidate
+ * ended in failure, in place. Keeps `jobIds`/`imageIds` untouched (a prior
+ * delivered image, if any, is not a failure) so the card can keep showing
+ * whatever art already delivered alongside the new error (brainstorm/t-017).
+ */
+export function recordCandidateArtFailure(
+  candidate: BrainstormCandidate,
+  message: string,
+): void {
+  const art = candidate.meta.art ?? { jobIds: [], imageIds: [] }
+  art.status = 'failed'
+  art.error = message
   candidate.meta.art = art
 }
 

--- a/types/brainstorm.ts
+++ b/types/brainstorm.ts
@@ -16,7 +16,8 @@ export const BRAINSTORM_OUTPUT_DOMAINS = [
   {
     id: 'ideas',
     label: 'Ideas',
-    description: 'General creative divergence: concepts, jokes, plans, and premises.',
+    description:
+      'General creative divergence: concepts, jokes, plans, and premises.',
   },
   {
     id: 'art-prompts',
@@ -26,53 +27,64 @@ export const BRAINSTORM_OUTPUT_DOMAINS = [
   },
 ] as const
 
-export type BrainstormOutputDomainId = (typeof BRAINSTORM_OUTPUT_DOMAINS)[number]['id']
-export const BRAINSTORM_DEFAULT_OUTPUT_DOMAIN: BrainstormOutputDomainId = 'ideas'
+export type BrainstormOutputDomainId =
+  (typeof BRAINSTORM_OUTPUT_DOMAINS)[number]['id']
+export const BRAINSTORM_DEFAULT_OUTPUT_DOMAIN: BrainstormOutputDomainId =
+  'ideas'
 
 export const BRAINSTORM_RETURN_TYPES = [
   {
     id: 'dark-humor',
     label: 'Dark humor',
-    description: 'Gallows humor, irony, cartoon peril, and darker comic premises where allowed.',
+    description:
+      'Gallows humor, irony, cartoon peril, and darker comic premises where allowed.',
   },
   {
     id: 'pun',
     label: 'Pun / wordplay',
-    description: 'Language-driven ideas with an actual premise, not just a word swapped into a title.',
+    description:
+      'Language-driven ideas with an actual premise, not just a word swapped into a title.',
   },
   {
     id: 'dad-joke',
     label: 'Dad joke',
-    description: 'Earnest groaners, literal misunderstandings, and proudly obvious comic machinery.',
+    description:
+      'Earnest groaners, literal misunderstandings, and proudly obvious comic machinery.',
   },
   {
     id: 'dry-observation',
     label: 'Dry observation',
-    description: 'Underplayed, deadpan, or sharply observed responses that trust the premise.',
+    description:
+      'Underplayed, deadpan, or sharply observed responses that trust the premise.',
   },
   {
     id: 'absurd-escalation',
     label: 'Absurd escalation',
-    description: 'Take one coherent mechanism farther until the consequences become delightfully unreasonable.',
+    description:
+      'Take one coherent mechanism farther until the consequences become delightfully unreasonable.',
   },
   {
     id: 'practical',
     label: 'Practical',
-    description: 'Useful, buildable, or actionable answers that still avoid the obvious first draft.',
+    description:
+      'Useful, buildable, or actionable answers that still avoid the obvious first draft.',
   },
   {
     id: 'inversion',
     label: 'Inversion',
-    description: 'Reverse a role, assumption, incentive, cause, or expected outcome.',
+    description:
+      'Reverse a role, assumption, incentive, cause, or expected outcome.',
   },
   {
     id: 'left-field',
     label: 'Left field',
-    description: 'A surprising but premise-connected angle that changes the mechanism rather than adding random nouns.',
+    description:
+      'A surprising but premise-connected angle that changes the mechanism rather than adding random nouns.',
   },
 ] as const
 
-export type BrainstormReturnTypeId = (typeof BRAINSTORM_RETURN_TYPES)[number]['id']
+export type BrainstormReturnTypeId =
+  (typeof BRAINSTORM_RETURN_TYPES)[number]['id']
 export type BrainstormBatchShape = 'focused' | 'assortment'
 
 export type BrainstormReturnTypeRequest = {
@@ -83,24 +95,13 @@ export type BrainstormReturnTypeRequest = {
 export type BrainstormCandidateStatus = 'pending' | 'kept' | 'rejected'
 
 export type BrainstormRevisionReason =
-  | 'generated'
-  | 'edited'
-  | 'regenerated'
-  | 'branched'
-  | 'restored'
+  'generated' | 'edited' | 'regenerated' | 'branched' | 'restored'
 
 export type BrainstormGenerationState =
-  | 'idle'
-  | 'generating'
-  | 'success'
-  | 'error'
+  'idle' | 'generating' | 'success' | 'error'
 
 export type BrainstormPersistenceState =
-  | 'idle'
-  | 'loading'
-  | 'saving'
-  | 'success'
-  | 'error'
+  'idle' | 'loading' | 'saving' | 'success' | 'error'
 
 export type BrainstormErrorKind =
   | 'validation'
@@ -133,9 +134,19 @@ export type BrainstormBranchOrigin = {
   text: string
 }
 
+// status/error persist the outcome of the most recent art generation attempt
+// on the candidate itself (not just in-memory store state), so a page reload
+// mid-generation can tell "still queued, resume polling" apart from "the last
+// attempt failed" instead of silently looking identical to "never started"
+// (brainstorm/t-017).
+export type BrainstormCandidateArtStatus =
+  'queued' | 'processing' | 'delivered' | 'failed'
+
 export type BrainstormCandidateArtMeta = {
   jobIds: number[]
   imageIds: number[]
+  status?: BrainstormCandidateArtStatus
+  error?: string | null
 }
 
 export type BrainstormCandidateMeta = {


### PR DESCRIPTION
conductor brainstorm/t-017: "Add candidate art results and retry-safe delivery states."

**What was missing:** `BrainstormCandidateArtMeta` only tracked `jobIds`/`imageIds`. A failed art-generation attempt left no persisted trace — the card's only failure signal was the transient, session-local `artBusy` flag, so a reload made a failed attempt look identical to "never tried." A retry after a reload also always enqueued a brand-new ArtJob even if the previous one might still be running server-side, and a `DONE` job's `artImageId` was trusted without ever confirming the image record actually resolves.

**What this does:**
- `BrainstormCandidateArtMeta` gains `status: 'queued'|'processing'|'delivered'|'failed'` and `error`, persisted on the candidate (round-trips through both the server save path and the local-storage autosave normalizer, matching t-016's existing `meta.art` convention).
- `generateArtForCandidate` checks for a resumable in-flight job (`status` `queued`/`processing`) before enqueueing — reuses that job id instead of duplicating the ArtJob.
- A terminal job now goes through `artStore.finalizeQueuedArtImage` (mirrors `modelBuilderStore.ts`'s `pollAsyncArtJob` → `finalizeQueuedArtImage`), which re-fetches the `ArtImage` row and routes it through the same collection-attachment semantics every other art surface uses, rather than trusting `job.artImageId` blind or inventing Brainstorm-specific storage.
- `brainstorm-candidate-card.vue` shows a persisted failure (`kr-note kr-note-error`) once nothing in the current session is actively regenerating, so a failure from an earlier session/reload stays visible instead of vanishing.

**Verified:**
- `eslint` clean on all 4 changed files
- `prettier --check` clean
- `vue-tsc --noEmit` (repo-wide) exit 0
- `npm run test:brainstorm-candidate-lifecycle` passed
- `node utils/scripts/verifyBrainstormStoreContract.mjs` passed
- `node utils/scripts/verifyBrainstormWorkbench.mjs` passed
- `git status --porcelain` shows exactly the 4 intended files

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrL5YWiYDdCDQEWkZGhxXk)_