### PR TITLE
Fix migration drift false positives after retries and squash

### DIFF
--- a/server/utils/migrationDrift.ts
+++ b/server/utils/migrationDrift.ts
@@ -46,18 +46,21 @@ export type MigrationDriftReport = {
    */
   pending: string[]
   /**
-   * Recorded in `_prisma_migrations` but never finished, or rolled back. A
-   * subset of the same problem with a different remedy -- see
-   * scripts/repair-known-prisma-migrations.mjs, which the deploy wrapper runs.
+   * Recorded in `_prisma_migrations` but never successfully completed. Prisma
+   * can retain an older failed/rolled-back attempt next to a later successful
+   * attempt with the same migration name; that recovered migration is healthy.
    */
   failed: string[]
   /**
    * Applied to the database but absent from this build. Harmless to queries
-   * (the columns exist, this code just doesn't use them) but it means the
+   * (the columns exist, this code just doesn't use them) but it can mean the
    * running image is older than the schema -- worth knowing during a rollback.
+   * Pre-squash history intentionally replaced by the current squash is omitted.
    */
   ahead: string[]
 }
+
+const SQUASH_MIGRATION = '00000000000000_squashed'
 
 function isApplied(row: AppliedMigrationRow): boolean {
   const finished = row.finished_at
@@ -79,25 +82,49 @@ export function compareMigrations(
   applied: readonly AppliedMigrationRow[],
 ): MigrationDriftReport {
   const appliedNames = new Set<string>()
-  const failed: string[] = []
+  const failedAttemptNames = new Set<string>()
 
   for (const row of applied) {
     const name = (row?.migration_name || '').trim()
     if (!name) continue
     if (isApplied(row)) {
       appliedNames.add(name)
-    } else if (!failed.includes(name)) {
-      failed.push(name)
+    } else {
+      failedAttemptNames.add(name)
     }
   }
+
+  // Prisma keeps historical attempts. Once any row for a migration name has
+  // completed successfully, an older failed/rolled-back row is history rather
+  // than current drift.
+  const failed = [...failedAttemptNames]
+    .filter((name) => !appliedNames.has(name))
+    .sort()
 
   const diskNames = onDisk.map((name) => name.trim()).filter(Boolean)
   const diskSet = new Set(diskNames)
 
+  let ahead = [...appliedNames].filter((name) => !diskSet.has(name))
+
+  // A production database can legitimately retain every pre-squash migration
+  // row after the current build replaces that history with one squashed marker.
+  // If both sides agree that the squash itself was applied, only absent applied
+  // migrations at or after the first post-squash migration can represent a
+  // genuinely newer schema (for example, a rollback to an older image).
+  if (diskSet.has(SQUASH_MIGRATION) && appliedNames.has(SQUASH_MIGRATION)) {
+    const firstPostSquash = diskNames
+      .filter((name) => name !== SQUASH_MIGRATION)
+      .sort()[0]
+
+    if (firstPostSquash) {
+      ahead = ahead.filter((name) => name >= firstPostSquash)
+    }
+  }
+
   return {
     pending: diskNames.filter((name) => !appliedNames.has(name)).sort(),
-    failed: failed.sort(),
-    ahead: [...appliedNames].filter((name) => !diskSet.has(name)).sort(),
+    failed,
+    ahead: ahead.sort(),
   }
 }
 
@@ -124,8 +151,8 @@ export function describeMigrationDrift(report: MigrationDriftReport): string {
 
   if (report.failed.length) {
     parts.push(
-      `${report.failed.length} migration(s) are recorded as started but not ` +
-        `finished (or were rolled back): ${report.failed.join(', ')}.`,
+      `${report.failed.length} migration(s) are recorded without any ` +
+        `successful completion: ${report.failed.join(', ')}.`,
     )
   }
 

--- a/utils/scripts/verifyMigrationDriftCheck.ts
+++ b/utils/scripts/verifyMigrationDriftCheck.ts
@@ -108,6 +108,25 @@ export function checkDriftBehaviour(): string[] {
     assert.deepEqual(report.failed, ['20260819120000_b'])
   })
 
+  check('a later successful retry clears an older failed attempt', () => {
+    // Prisma stores retry attempts as separate rows with the same name. The
+    // Alexandria database has several old rolled-back rows followed by a later
+    // successful row; those recovered migrations must not keep warning forever.
+    const report = compareMigrations(
+      ['20260819120000_b'],
+      [
+        applied('20260819120000_b', {
+          finished_at: null,
+          rolled_back_at: new Date('2026-08-19T00:30:00Z'),
+        }),
+        applied('20260819120000_b'),
+      ],
+    )
+    assert.deepEqual(report.pending, [])
+    assert.deepEqual(report.failed, [])
+    assert.equal(hasMigrationDrift(report), false)
+  })
+
   check('a database ahead of the build is reported separately', () => {
     // Rollback shape: the schema has moved on, this image has not. Queries
     // still work, so it must not read as the dangerous direction.
@@ -122,6 +141,39 @@ export function checkDriftBehaviour(): string[] {
       false,
       'being behind the database is not a runtime hazard and must not read as one',
     )
+  })
+
+  check('pre-squash migration history is not reported as database-ahead drift', () => {
+    const report = compareMigrations(
+      [
+        '00000000000000_squashed',
+        '20260717103700_first_post_squash',
+        '20260819120000_current',
+      ],
+      [
+        applied('00000000000000_baseline'),
+        applied('20260714210000_last_legacy'),
+        applied('00000000000000_squashed'),
+        applied('20260717103700_first_post_squash'),
+        applied('20260819120000_current'),
+      ],
+    )
+    assert.deepEqual(report.pending, [])
+    assert.deepEqual(report.failed, [])
+    assert.deepEqual(report.ahead, [])
+  })
+
+  check('a genuinely newer post-squash migration is still reported as ahead', () => {
+    const report = compareMigrations(
+      ['00000000000000_squashed', '20260717103700_current'],
+      [
+        applied('00000000000000_baseline'),
+        applied('00000000000000_squashed'),
+        applied('20260717103700_current'),
+        applied('20260820000000_future'),
+      ],
+    )
+    assert.deepEqual(report.ahead, ['20260820000000_future'])
   })
 
   check('an empty database reports every migration as pending', () => {


### PR DESCRIPTION
Fixes the boot-time migration drift checker so recovered Prisma retries and intentionally retained pre-squash history do not produce false alarms.

Changes:
- Treat a migration as successfully applied if any row for that migration name completed successfully, even when older failed/rolled-back attempts remain in `_prisma_migrations`.
- When the current squash marker is present and applied, ignore absent applied migration records older than the first post-squash migration.
- Continue reporting genuinely newer post-squash migrations as database-ahead drift.
- Add behavioural coverage for the exact retry and squash-history shapes observed on Alexandria after the 2026-08-20 recovery.

The dangerous direction, migrations present in the image but not successfully applied to the database, remains unchanged.