### PR TITLE
fix(appmaker): close apps/-folder collision gap in the external-repo create flow (t-012)

### DIFF
--- a/server/api/appmaker/github/create-app.post.ts
+++ b/server/api/appmaker/github/create-app.post.ts
@@ -11,6 +11,7 @@ import { requireApiUser } from '@/server/utils/authGuard'
 import { enforceProjectCap } from '@/server/utils/projectCap'
 import { listInstallationRepositories } from '@/server/utils/appmakerGithub'
 import { userIsAdmin, userRoles } from '@/server/utils/authUser'
+import { conductorList } from '~/server/utils/conductor-github'
 
 const SLUG_RE = /^[a-z][a-z0-9-]{1,40}$/
 
@@ -120,8 +121,8 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const [existingProject, existingDream, existingAppRepo] = await Promise.all(
-      [
+    const [existingProject, existingDream, existingAppRepo, scaffoldedApps] =
+      await Promise.all([
         prisma.project.findFirst({
           where: { OR: [{ slug }, { conductorSlug: slug }] },
           select: { id: true },
@@ -131,10 +132,30 @@ export default defineEventHandler(async (event) => {
           where: { slug_userId: { slug, userId: user.id } },
           select: { id: true },
         }),
-      ],
+        conductorList('apps'),
+      ])
+
+    // Mirrors scaffold-request.post.ts's collision guard (appmaker/t-012):
+    // apps.get.ts treats a `dir` entry under conductor's apps/ folder as the
+    // real source of truth for "already scaffolded", but several apps (e.g.
+    // apps/storybook, apps/wishmaster) were scaffolded directly by an agent
+    // before either self-serve flow existed and never got a matching Project
+    // row. Without this check, a user could register this same slug through
+    // the external-repo flow -- existingProject/existingDream/existingAppRepo
+    // would all miss it (no Project, Dream, or AppRepo row exists for an
+    // agent-scaffolded monorepo app), so the request would succeed and create
+    // a Project that permanently collides with the existing apps/<slug>/
+    // folder's own identity.
+    const alreadyScaffolded = (scaffoldedApps ?? []).some(
+      (entry) => entry.type === 'dir' && entry.name === slug,
     )
 
-    if (existingProject || existingDream || existingAppRepo) {
+    if (
+      existingProject ||
+      existingDream ||
+      existingAppRepo ||
+      alreadyScaffolded
+    ) {
       throw createError({
         statusCode: 409,
         message: `Slug '${slug}' is already taken.`,

--- a/utils/scripts/verifyAppmakerScaffoldCollisionGuard.test.ts
+++ b/utils/scripts/verifyAppmakerScaffoldCollisionGuard.test.ts
@@ -2,15 +2,20 @@
 //
 // Regression test for checkScaffoldCollisionGuard() in
 // verifyAppmakerScaffoldCollisionGuard.ts (appmaker/t-012). Exercises the
-// real check against synthetic route-shaped fixtures covering: the fixed
-// shape (candidate slug checked against Project, Dream, AND the conductor
-// apps/ folder listing), the pre-fix shape (only Project/Dream checked,
-// conductorList never imported/called), and partial regressions (the
+// real check against synthetic route-shaped fixtures for BOTH covered
+// routes -- scaffold-request.post.ts's `existingProject || existingDream ||
+// alreadyScaffolded` shape and create-app.post.ts's `existingProject ||
+// existingDream || existingAppRepo || alreadyScaffolded` shape -- covering:
+// the fixed shape, the pre-fix shape (only Prisma tables checked,
+// conductorList never imported/called), and a partial regression (the
 // conductorList call and dir-entry filter survive, but the result is no
 // longer folded into the "already taken" throw).
 import assert from 'node:assert/strict'
 
-import { checkScaffoldCollisionGuard } from './verifyAppmakerScaffoldCollisionGuard.js'
+import {
+  checkScaffoldCollisionGuard,
+  SCAFFOLD_COLLISION_ROUTES,
+} from './verifyAppmakerScaffoldCollisionGuard.js'
 
 function fixture(body: string): string {
   return `
@@ -27,7 +32,14 @@ ${body}
 `
 }
 
-const FIXED = fixture(`
+const SCAFFOLD_REQUEST_ROUTE = SCAFFOLD_COLLISION_ROUTES.find(
+  (r) => r.label === 'scaffold-request.post.ts',
+)!
+const CREATE_APP_ROUTE = SCAFFOLD_COLLISION_ROUTES.find(
+  (r) => r.label === 'create-app.post.ts',
+)!
+
+const SCAFFOLD_REQUEST_FIXED = fixture(`
     const [existingProject, existingDream, scaffoldedApps] = await Promise.all([
       prisma.project.findFirst({
         where: { OR: [{ slug }, { conductorSlug: slug }] },
@@ -51,7 +63,7 @@ const FIXED = fixture(`
 
 // Pre-fix shape: no import, no conductorList call, slug uniqueness checked
 // only against Project/Dream.
-const BUGGY = `
+const SCAFFOLD_REQUEST_BUGGY = `
 export default defineEventHandler(async (event) => {
   try {
     const [existingProject, existingDream] = await Promise.all([
@@ -79,7 +91,7 @@ export default defineEventHandler(async (event) => {
 // dir-entry filter still exists, but `alreadyScaffolded` was dropped back
 // out of the "already taken" condition -- so it's computed but has no
 // effect, same bug in practice.
-const PARTIALLY_REGRESSED = fixture(`
+const SCAFFOLD_REQUEST_PARTIALLY_REGRESSED = fixture(`
     const [existingProject, existingDream, scaffoldedApps] = await Promise.all([
       prisma.project.findFirst({
         where: { OR: [{ slug }, { conductorSlug: slug }] },
@@ -101,21 +113,79 @@ const PARTIALLY_REGRESSED = fixture(`
     }
 `)
 
+const CREATE_APP_FIXED = fixture(`
+    const [existingProject, existingDream, existingAppRepo, scaffoldedApps] = await Promise.all([
+      prisma.project.findFirst({
+        where: { OR: [{ slug }, { conductorSlug: slug }] },
+        select: { id: true },
+      }),
+      prisma.dream.findUnique({ where: { slug }, select: { id: true } }),
+      prisma.appRepo.findUnique({
+        where: { slug_userId: { slug, userId: user.id } },
+        select: { id: true },
+      }),
+      conductorList('apps'),
+    ])
+
+    const alreadyScaffolded = (scaffoldedApps ?? []).some(
+      (entry) => entry.type === 'dir' && entry.name === slug,
+    )
+
+    if (existingProject || existingDream || existingAppRepo || alreadyScaffolded) {
+      throw createError({ statusCode: 409, message: \`Slug '\${slug}' is already taken.\` })
+    }
+`)
+
+// Pre-fix shape for create-app.post.ts: the actual state this repo shipped
+// before this cycle's fix -- Project/Dream/AppRepo checked, apps/ folder
+// never consulted.
+const CREATE_APP_BUGGY = `
+export default defineEventHandler(async (event) => {
+  try {
+    const [existingProject, existingDream, existingAppRepo] = await Promise.all([
+      prisma.project.findFirst({
+        where: { OR: [{ slug }, { conductorSlug: slug }] },
+        select: { id: true },
+      }),
+      prisma.dream.findUnique({ where: { slug }, select: { id: true } }),
+      prisma.appRepo.findUnique({
+        where: { slug_userId: { slug, userId: user.id } },
+        select: { id: true },
+      }),
+    ])
+
+    if (existingProject || existingDream || existingAppRepo) {
+      throw createError({ statusCode: 409, message: \`Slug '\${slug}' is already taken.\` })
+    }
+  } catch (error) {
+    if (error instanceof H3Error) throw error
+    return errorHandler(error)
+  }
+})
+`
+
 function run(): void {
-  const fixedErrors = checkScaffoldCollisionGuard(FIXED)
+  // scaffold-request.post.ts shape
+  const fixedErrors = checkScaffoldCollisionGuard(
+    SCAFFOLD_REQUEST_FIXED,
+    SCAFFOLD_REQUEST_ROUTE.alreadyTakenPattern,
+  )
   assert.deepEqual(
     fixedErrors,
     [],
-    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+    `expected the fixed scaffold-request fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
   )
 
-  const buggyErrors = checkScaffoldCollisionGuard(BUGGY)
+  const buggyErrors = checkScaffoldCollisionGuard(
+    SCAFFOLD_REQUEST_BUGGY,
+    SCAFFOLD_REQUEST_ROUTE.alreadyTakenPattern,
+  )
   assert.equal(
     buggyErrors.length,
     4,
-    'expected the pre-fix fixture (no import, no conductorList call, no ' +
-      'dir-entry filter, no folded condition) to fail all four checks, got: ' +
-      `${JSON.stringify(buggyErrors)}`,
+    'expected the pre-fix scaffold-request fixture (no import, no ' +
+      'conductorList call, no dir-entry filter, no folded condition) to ' +
+      `fail all four checks, got: ${JSON.stringify(buggyErrors)}`,
   )
   assert.ok(
     buggyErrors.some((e) => /no longer imports `conductorList`/.test(e)),
@@ -129,35 +199,59 @@ function run(): void {
     ),
   )
   assert.ok(
-    buggyErrors.some((e) => /no longer checks `existingProject \|\|/.test(e)),
+    buggyErrors.some((e) => /no longer folds `alreadyScaffolded`/.test(e)),
   )
 
-  const regressedErrors = checkScaffoldCollisionGuard(PARTIALLY_REGRESSED)
+  const regressedErrors = checkScaffoldCollisionGuard(
+    SCAFFOLD_REQUEST_PARTIALLY_REGRESSED,
+    SCAFFOLD_REQUEST_ROUTE.alreadyTakenPattern,
+  )
   assert.equal(
     regressedErrors.length,
     1,
-    'expected a fixture where alreadyScaffolded is computed but not folded ' +
-      `into the throw to fail only that assertion, got: ${JSON.stringify(regressedErrors)}`,
+    'expected a scaffold-request fixture where alreadyScaffolded is ' +
+      'computed but not folded into the throw to fail only that ' +
+      `assertion, got: ${JSON.stringify(regressedErrors)}`,
   )
   assert.ok(
-    regressedErrors.some((e) =>
-      /no longer checks `existingProject \|\| existingDream \|\| alreadyScaffolded`/.test(
-        e,
-      ),
-    ),
+    regressedErrors.some((e) => /no longer folds `alreadyScaffolded`/.test(e)),
   )
 
   const missingHandler = checkScaffoldCollisionGuard(
     "import { conductorList } from '~/server/utils/conductor-github'\nconst somethingElse = 1\n",
+    SCAFFOLD_REQUEST_ROUTE.alreadyTakenPattern,
   )
   assert.equal(missingHandler.length, 1)
   assert.ok(missingHandler.some((e) => /Could not find/.test(e)))
 
+  // create-app.post.ts shape (appmaker/t-009's external-repo flow, fixed
+  // this cycle to close the same collision gap)
+  const createAppFixedErrors = checkScaffoldCollisionGuard(
+    CREATE_APP_FIXED,
+    CREATE_APP_ROUTE.alreadyTakenPattern,
+  )
+  assert.deepEqual(
+    createAppFixedErrors,
+    [],
+    `expected the fixed create-app fixture to pass, got: ${JSON.stringify(createAppFixedErrors)}`,
+  )
+
+  const createAppBuggyErrors = checkScaffoldCollisionGuard(
+    CREATE_APP_BUGGY,
+    CREATE_APP_ROUTE.alreadyTakenPattern,
+  )
+  assert.equal(
+    createAppBuggyErrors.length,
+    4,
+    'expected the pre-fix create-app fixture to fail all four checks, got: ' +
+      `${JSON.stringify(createAppBuggyErrors)}`,
+  )
+
   console.log(
-    'AppMaker scaffold-collision guard self-test passed: buggy fixture ' +
-      'fails all checks, fixed fixture passes, a partially-regressed ' +
-      'fixture fails only the folded-condition check, and a missing ' +
-      'handler is detected.',
+    'AppMaker scaffold-collision guard self-test passed: both covered ' +
+      'routes (scaffold-request.post.ts, create-app.post.ts) fail on their ' +
+      "buggy fixture, pass on their fixed fixture, and scaffold-request's " +
+      'partially-regressed fixture fails only the folded-condition check.',
   )
 }
 

--- a/utils/scripts/verifyAppmakerScaffoldCollisionGuard.ts
+++ b/utils/scripts/verifyAppmakerScaffoldCollisionGuard.ts
@@ -1,32 +1,38 @@
 // /utils/scripts/verifyAppmakerScaffoldCollisionGuard.ts
 //
-// Regression guard (appmaker/t-012) -- server/api/appmaker/scaffold-request.post.ts's
-// slug-collision check only queried the kind_robots Prisma `Project` and
-// `Dream` tables (existingProject / existingDream), never the conductor
-// repo's apps/ folder listing that apps.get.ts itself treats as the real
-// source of truth for "already scaffolded" (`conductorList('apps')`,
-// filtered to `type === 'dir'`). Several apps were scaffolded directly by an
-// agent before this self-serve flow existed (apps/storybook, apps/wishmaster,
-// apps/sketchy, ...) and never got a matching Project row.
+// Regression guard (appmaker/t-012) -- both of AppMaker's self-serve app
+// creation routes originally checked slug uniqueness only against the
+// kind_robots Prisma `Project`/`Dream` tables (and, for the external-repo
+// flow, `AppRepo`), never the conductor repo's apps/ folder listing that
+// apps.get.ts itself treats as the real source of truth for "already
+// scaffolded" (`conductorList('apps')`, filtered to `type === 'dir'`).
+// Several apps were scaffolded directly by an agent before either self-serve
+// flow existed (apps/storybook, apps/wishmaster, apps/sketchy, ...) and never
+// got a matching Project row.
 //
 // That gap let a user request a slug colliding with one of those folders:
-// the request succeeded here (201, Todo filed, one of their
-// FREE_PROJECT_LIMIT slots consumed), but the Worker cycle's
-// `scripts/new_app.py <slug>` invocation refuses to run over an existing
-// apps/<slug>/ folder and fails -- with nothing ever surfacing that failure
-// back through this endpoint or the AppMaker UI. The user's Project row (and
-// project-cap slot) is silently orphaned forever.
+// - scaffold-request.post.ts: the request succeeded (201, Todo filed, one of
+//   their FREE_PROJECT_LIMIT slots consumed), but the Worker cycle's
+//   `scripts/new_app.py <slug>` invocation refuses to run over an existing
+//   apps/<slug>/ folder and fails -- with nothing ever surfacing that
+//   failure back through this endpoint or the AppMaker UI. The user's
+//   Project row (and project-cap slot) is silently orphaned forever.
+// - create-app.post.ts: the request would succeed and create a Project +
+//   AppRepo that permanently collides with the existing apps/<slug>/
+//   folder's own identity, since no Project/Dream/AppRepo row exists for an
+//   agent-scaffolded monorepo app to catch the collision.
 //
-// Fixed by also listing the conductor apps/ folder via conductorList('apps')
-// alongside the existing Project/Dream lookups, and folding a `type ===
-// 'dir'` match on the candidate slug into the same "already taken" 409.
+// Fixed in both handlers by also listing the conductor apps/ folder via
+// conductorList('apps') alongside the existing Prisma lookups, and folding a
+// `type === 'dir'` match on the candidate slug into each handler's own
+// "already taken" 409.
 //
-// This asserts the textual shape of that fix stays in place: the handler
-// still calls conductorList('apps'), still filters its `dir` entries by
-// name against the candidate slug, and still folds that result into the
-// same conditional that throws the "already taken" 409 -- not a bare
-// `if (existingProject || existingDream)` that silently accepts a slug
-// belonging to a pre-existing, unregistered apps/ folder again.
+// This asserts the textual shape of that fix stays in place in both route
+// files: each still calls conductorList('apps'), still filters its `dir`
+// entries by name against the candidate slug, and still folds that result
+// into its own "already taken" condition -- not a bare check that silently
+// accepts a slug belonging to a pre-existing, unregistered apps/ folder
+// again.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -34,10 +40,34 @@ import { fileURLToPath } from 'node:url'
 const scriptDirectory = dirname(fileURLToPath(import.meta.url))
 const repositoryRoot = resolve(scriptDirectory, '../..')
 
-const ROUTE_PATH = join(
-  repositoryRoot,
-  'server/api/appmaker/scaffold-request.post.ts',
-)
+interface RouteConfig {
+  label: string
+  path: string
+  // The full "already taken" condition expected in the fixed handler, e.g.
+  // `existingProject || existingDream || alreadyScaffolded`.
+  alreadyTakenPattern: RegExp
+}
+
+// Default pattern for checkScaffoldCollisionGuard()'s optional second
+// argument -- pulled out as its own constant (rather than indexing into
+// SCAFFOLD_COLLISION_ROUTES[0]) so a default-parameter initializer can't trip
+// TypeScript's noUncheckedIndexedAccess-style "possibly undefined" check.
+const SCAFFOLD_REQUEST_ALREADY_TAKEN_PATTERN =
+  /if\s*\(\s*existingProject\s*\|\|\s*existingDream\s*\|\|\s*alreadyScaffolded\s*\)/
+
+export const SCAFFOLD_COLLISION_ROUTES: RouteConfig[] = [
+  {
+    label: 'scaffold-request.post.ts',
+    path: join(repositoryRoot, 'server/api/appmaker/scaffold-request.post.ts'),
+    alreadyTakenPattern: SCAFFOLD_REQUEST_ALREADY_TAKEN_PATTERN,
+  },
+  {
+    label: 'create-app.post.ts',
+    path: join(repositoryRoot, 'server/api/appmaker/github/create-app.post.ts'),
+    alreadyTakenPattern:
+      /if\s*\(\s*existingProject\s*\|\|\s*existingDream\s*\|\|\s*existingAppRepo\s*\|\|\s*alreadyScaffolded\s*\)/,
+  },
+]
 
 function extractHandlerSource(content: string): string | null {
   const signature = /export default defineEventHandler\(async \(event\) => \{/
@@ -58,7 +88,10 @@ function extractHandlerSource(content: string): string | null {
   return content.slice(braceOpen, i + 1)
 }
 
-export function checkScaffoldCollisionGuard(content: string): string[] {
+export function checkScaffoldCollisionGuard(
+  content: string,
+  alreadyTakenPattern: RegExp = SCAFFOLD_REQUEST_ALREADY_TAKEN_PATTERN,
+): string[] {
   const errors: string[] = []
 
   if (
@@ -67,10 +100,9 @@ export function checkScaffoldCollisionGuard(content: string): string[] {
     )
   ) {
     errors.push(
-      'scaffold-request.post.ts no longer imports `conductorList` from ' +
-        'conductor-github -- has the apps/ folder collision check been ' +
-        'dropped, leaving slug uniqueness checked only against the Project ' +
-        'and Dream tables?',
+      'no longer imports `conductorList` from conductor-github -- has the ' +
+        'apps/ folder collision check been dropped, leaving slug uniqueness ' +
+        'checked only against the Prisma tables?',
     )
   }
 
@@ -78,42 +110,37 @@ export function checkScaffoldCollisionGuard(content: string): string[] {
   if (!body) {
     errors.push(
       'Could not find `export default defineEventHandler(async (event) => ' +
-        '{ ... })` in scaffold-request.post.ts -- has it been renamed, ' +
-        'removed, or restructured? If so, this guard (and the scaffold-' +
-        'folder collision bug it protects against) needs to move with it.',
+        '{ ... })` -- has it been renamed, removed, or restructured? If so, ' +
+        'this guard (and the scaffold-folder collision bug it protects ' +
+        'against) needs to move with it.',
     )
     return errors
   }
 
   if (!/conductorList\(\s*['"]apps['"]\s*\)/.test(body)) {
     errors.push(
-      "The handler no longer calls conductorList('apps') -- the " +
-        "candidate slug is no longer checked against the conductor repo's " +
-        'actual apps/ folder listing, so a slug matching a pre-existing, ' +
-        'unregistered apps/<slug>/ folder will silently pass validation ' +
-        'and file a Todo that scripts/new_app.py is guaranteed to fail on.',
+      "the handler no longer calls conductorList('apps') -- the candidate " +
+        "slug is no longer checked against the conductor repo's actual " +
+        'apps/ folder listing, so a slug matching a pre-existing, ' +
+        'unregistered apps/<slug>/ folder will silently pass validation.',
     )
   }
 
   if (!/entry\.type === 'dir' && entry\.name === slug/.test(body)) {
     errors.push(
-      "The handler no longer filters conductorList('apps') entries by " +
+      "the handler no longer filters conductorList('apps') entries by " +
         "`entry.type === 'dir' && entry.name === slug` -- has the " +
         'collision match against the scaffolded-folder listing been ' +
         'weakened or dropped?',
     )
   }
 
-  if (
-    !/if\s*\(\s*existingProject\s*\|\|\s*existingDream\s*\|\|\s*alreadyScaffolded\s*\)/.test(
-      body,
-    )
-  ) {
+  if (!alreadyTakenPattern.test(body)) {
     errors.push(
-      'The "already taken" 409 no longer checks `existingProject || ' +
-        'existingDream || alreadyScaffolded` together -- the apps/ folder ' +
-        'collision result is no longer folded into the slug-taken check, ' +
-        'so it has no effect even if it is still computed.',
+      'the "already taken" 409 no longer folds `alreadyScaffolded` into ' +
+        'its condition alongside the existing Prisma lookups -- the apps/ ' +
+        'folder collision result is no longer checked even if it is still ' +
+        'computed.',
     )
   }
 
@@ -121,24 +148,31 @@ export function checkScaffoldCollisionGuard(content: string): string[] {
 }
 
 function main(): void {
-  const content = readFileSync(ROUTE_PATH, 'utf8')
-  const errors = checkScaffoldCollisionGuard(content)
+  let anyFailed = false
 
-  if (errors.length) {
-    console.error(
-      'AppMaker scaffold-collision guard contract failed in ' +
-        'scaffold-request.post.ts:',
+  for (const route of SCAFFOLD_COLLISION_ROUTES) {
+    const content = readFileSync(route.path, 'utf8')
+    const errors = checkScaffoldCollisionGuard(
+      content,
+      route.alreadyTakenPattern,
     )
-    for (const error of errors) console.error(`- ${error}`)
-    process.exitCode = 1
-    return
+
+    if (errors.length) {
+      anyFailed = true
+      console.error(
+        `AppMaker scaffold-collision guard contract failed in ${route.label}:`,
+      )
+      for (const error of errors) console.error(`- ${error}`)
+    } else {
+      console.log(
+        `AppMaker scaffold-collision guard contract passed for ${route.label}: ` +
+          'a slug matching an already-scaffolded (but unregistered) apps/ ' +
+          'folder is rejected instead of silently accepted.',
+      )
+    }
   }
 
-  console.log(
-    'AppMaker scaffold-collision guard contract passed: a slug matching an ' +
-      'already-scaffolded (but unregistered) apps/ folder is rejected ' +
-      'instead of silently filing a Todo doomed to fail.',
-  )
+  if (anyFailed) process.exitCode = 1
 }
 
 if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {


### PR DESCRIPTION
## What

`server/api/appmaker/github/create-app.post.ts`'s slug-uniqueness check only queried the `Project`/`Dream`/`AppRepo` Prisma tables, never the conductor repo's `apps/` folder listing that `apps.get.ts` itself treats as the real source of truth for "already scaffolded" (`conductorList('apps')`, filtered to `type === 'dir'`).

Several apps (`apps/storybook`, `apps/wishmaster`, `apps/sketchy`, ...) were scaffolded directly by an agent before either self-serve flow existed and never got a matching `Project` row. That let a user register one of those slugs through the external-repo GitHub-integration flow — the request would succeed (201) and create a `Project`/`AppRepo` that permanently collides with the existing `apps/<slug>/` folder's identity, since nothing in the existing checks would catch it.

This mirrors the identical bug already fixed in `scaffold-request.post.ts` (the monorepo self-serve flow) under `appmaker/t-012` — this PR closes the same gap in the sibling external-repo flow, which was explicitly flagged as a known-but-deferred gap in that task's own progress notes.

## Fix

- `create-app.post.ts`: also list conductor's `apps/` folder via `conductorList('apps')` alongside the existing Prisma lookups, and fold a `type === 'dir'` name match on the candidate slug into the existing "already taken" 409.
- Generalized `utils/scripts/verifyAppmakerScaffoldCollisionGuard.ts` to assert the fixed shape across **both** routes (`scaffold-request.post.ts` and `create-app.post.ts`) instead of just the first, and extended its self-test with `create-app.post.ts`'s buggy/fixed fixtures.

## Verification

- `npm run test:appmaker-scaffold-collision-guard-selftest` — passes (both routes' buggy/fixed/regressed fixtures behave as expected)
- `npm run test:appmaker-scaffold-collision-guard` — passes for both routes against the real files
- `npm run test:appmaker-slug-candidate-guard{,-selftest}` and `test:appmaker-fleet-description-guard{,-selftest}` — unaffected, still pass
- ESLint clean, Prettier clean on touched files
- Full-project `vue-tsc --noEmit` — exit 0
- `git diff --stat` scoped to exactly the 3 intended files

Note: this external-repo flow has no wired-up front-end UI yet (confirmed via grep), so this is a defense-in-depth fix on a currently API-only-reachable endpoint, not a user-visible regression fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_017YhmT7ro8mGRuGVTzgLTK5)_