### PR TITLE
fix(model-builder): render Scenario's numeric subtitleField (t-029 cycle 31)

### DIFF
--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -264,11 +264,27 @@ const activeType = computed(() =>
   store.sourceType ? getSourceType(store.sourceType) : undefined,
 )
 
+// Bug (model-builder/t-029, cycle 31): this only ever rendered a string
+// value, but not every SOURCE_TYPES subtitleField is a string column --
+// Scenario's is 'difficulty' (Prisma `Int?`, see prisma/schema.prisma),
+// which transports over JSON as a genuine number, not a string. The field
+// exists and is exactly what was intended (cycle 22's own
+// verifyModelBuilderSourceFieldGuard.ts only checks that the named field is
+// a real property, never its type), so `typeof value === 'string'` silently
+// discarded it -- every Scenario record's Grid/List secondary line has been
+// permanently blank since Scenario was added as a source type, the same
+// user-visible failure mode cycle 22 fixed for Bot/Facet, just reached
+// through a type mismatch instead of a stale/miscased field name. Rendering
+// finite numbers too (Prisma enum columns like Dream.dreamType/
+// Reward.rewardType already worked here -- they transport as plain JSON
+// strings) fixes Scenario without touching which field it points at.
 function subtitle(record: SourceRecord): string {
   const field = activeType.value?.subtitleField
   if (!field) return ''
   const value = record[field]
-  return typeof value === 'string' ? value : ''
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  return ''
 }
 
 // Resolve a record's existing art for the source thumbnail, checking the common

--- a/utils/scripts/verifyModelBuilderSourceFieldGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderSourceFieldGuard.test.ts
@@ -7,13 +7,22 @@
 // dropped 'kind' column), the fixed shape, a titleField typo, and a
 // hydrated-summary field that's legitimately absent from the raw Facet
 // model but present on FacetSummary's own computed additions.
+//
+// Cycle 31 adds coverage for findSourceFieldTypeProblems() and its two new
+// helpers (extractScalarFieldTypes, extractEnumNames): a field can exist
+// (pass every check above) yet still be unrenderable, e.g. Scenario's real
+// subtitleField 'difficulty' is a Prisma `Int?` column that model-builder-
+// source-picker.vue's pre-fix subtitle() silently discarded.
 import assert from 'node:assert/strict'
 
 import {
+  extractEnumNames,
   extractFacetSummaryExtraFields,
   extractScalarFieldNames,
+  extractScalarFieldTypes,
   extractSourceFieldEntries,
   findSourceFieldProblems,
+  findSourceFieldTypeProblems,
 } from './verifyModelBuilderSourceFieldGuard.js'
 
 const SCHEMA_FIXTURE = `
@@ -31,6 +40,19 @@ model Facet {
   title     String  @db.VarChar(255)
   imagePath String? @db.Text
   User      User?   @relation(fields: [userId], references: [id])
+}
+
+model Scenario {
+  id         Int      @id @default(autoincrement())
+  title      String   @db.VarChar(255)
+  difficulty Int?
+  isActive   Boolean  @default(true)
+  outputType ScenarioType @default(STORY)
+}
+
+enum ScenarioType {
+  STORY
+  QUEST
 }
 `
 
@@ -93,6 +115,62 @@ export const SOURCE_TYPES: SourceTypeConfig[] = [
     titleField: 'nam',
     subtitleField: 'BotType',
     defaultRecipe: 'character-deck',
+  },
+]
+`
+
+// The real, live shape (model-builder/t-029, cycle 31): 'difficulty' is a
+// real Scenario column (findSourceFieldProblems sees no problem here), an
+// `Int?`, not a String -- must clear the type check now that subtitle()
+// renders finite numbers too.
+const SCENARIO_TYPE_INT_RECIPES_FIXTURE = `
+export const SOURCE_TYPES: SourceTypeConfig[] = [
+  {
+    key: 'Scenario',
+    label: 'Scenario',
+    titleField: 'title',
+    subtitleField: 'difficulty',
+    defaultRecipe: 'art-upgrade',
+  },
+]
+`
+
+// A String subtitleField clears the type check.
+const SCENARIO_TYPE_FIXED_RECIPES_FIXTURE = `
+export const SOURCE_TYPES: SourceTypeConfig[] = [
+  {
+    key: 'Scenario',
+    label: 'Scenario',
+    titleField: 'title',
+    subtitleField: 'title',
+    defaultRecipe: 'art-upgrade',
+  },
+]
+`
+
+// A genuinely non-renderable column (Boolean) must still be flagged.
+const SCENARIO_BOOLEAN_RECIPES_FIXTURE = `
+export const SOURCE_TYPES: SourceTypeConfig[] = [
+  {
+    key: 'Scenario',
+    label: 'Scenario',
+    titleField: 'title',
+    subtitleField: 'isActive',
+    defaultRecipe: 'art-upgrade',
+  },
+]
+`
+
+// A Prisma enum column (transports as a JSON string) must clear the check,
+// same as a real String column.
+const SCENARIO_ENUM_RECIPES_FIXTURE = `
+export const SOURCE_TYPES: SourceTypeConfig[] = [
+  {
+    key: 'Scenario',
+    label: 'Scenario',
+    titleField: 'title',
+    subtitleField: 'outputType',
+    defaultRecipe: 'art-upgrade',
   },
 ]
 `
@@ -190,10 +268,104 @@ assert.equal(
 assert.equal(titleTypoProblems[0]!.which, 'titleField')
 assert.equal(titleTypoProblems[0]!.field, 'nam')
 
+// --- extractScalarFieldTypes / extractEnumNames -----------------------------
+
+const scenarioTypes = extractScalarFieldTypes(SCHEMA_FIXTURE, 'Scenario')
+assert.equal(scenarioTypes.title, 'String')
+assert.equal(scenarioTypes.difficulty, 'Int')
+assert.equal(scenarioTypes.isActive, 'Boolean')
+assert.equal(scenarioTypes.outputType, 'ScenarioType')
+
+const enumNames = extractEnumNames(SCHEMA_FIXTURE)
+assert.ok(
+  enumNames.has('ScenarioType'),
+  `expected ScenarioType to be recognized as an enum, got: ${JSON.stringify([...enumNames])}`,
+)
+
+// --- findSourceFieldTypeProblems ---------------------------------------------
+
+// Int is renderable (model-builder-source-picker.vue's subtitle() was fixed
+// this same cycle to also stringify finite numbers) -- Scenario's real
+// subtitleField 'difficulty' must clear the type check post-fix, exactly
+// matching the live SOURCE_TYPES config this guard runs against in CI.
+const scenarioIntProblems = findSourceFieldTypeProblems(
+  SCHEMA_FIXTURE,
+  SCENARIO_TYPE_INT_RECIPES_FIXTURE,
+)
+assert.equal(
+  scenarioIntProblems.length,
+  0,
+  "expected Scenario's Int subtitleField 'difficulty' to raise no type " +
+    `problems now that the renderer handles numbers, got ` +
+    `${scenarioIntProblems.length}: ${JSON.stringify(scenarioIntProblems)}`,
+)
+
+const scenarioStringProblems = findSourceFieldTypeProblems(
+  SCHEMA_FIXTURE,
+  SCENARIO_TYPE_FIXED_RECIPES_FIXTURE,
+)
+assert.equal(
+  scenarioStringProblems.length,
+  0,
+  `expected a String subtitleField to raise no type problems, got: ` +
+    JSON.stringify(scenarioStringProblems),
+)
+
+const scenarioBooleanProblems = findSourceFieldTypeProblems(
+  SCHEMA_FIXTURE,
+  SCENARIO_BOOLEAN_RECIPES_FIXTURE,
+)
+assert.equal(
+  scenarioBooleanProblems.length,
+  1,
+  'expected a Boolean subtitleField to raise 1 type problem, got ' +
+    `${scenarioBooleanProblems.length}: ${JSON.stringify(scenarioBooleanProblems)}`,
+)
+assert.equal(scenarioBooleanProblems[0]!.fieldType, 'Boolean')
+
+const scenarioEnumProblems = findSourceFieldTypeProblems(
+  SCHEMA_FIXTURE,
+  SCENARIO_ENUM_RECIPES_FIXTURE,
+)
+assert.equal(
+  scenarioEnumProblems.length,
+  0,
+  'expected an enum subtitleField (transports as a string) to raise no ' +
+    `type problems, got: ${JSON.stringify(scenarioEnumProblems)}`,
+)
+
+// A field that doesn't exist at all is findSourceFieldProblems' job, not
+// this one's -- must not double-report the same root cause.
+const titleTypoTypeProblems = findSourceFieldTypeProblems(
+  SCHEMA_FIXTURE,
+  TITLE_FIELD_TYPO_FIXTURE,
+)
+assert.equal(
+  titleTypoTypeProblems.length,
+  0,
+  'expected a nonexistent field to raise 0 type problems (existence is ' +
+    `findSourceFieldProblems' job), got: ${JSON.stringify(titleTypoTypeProblems)}`,
+)
+
+// Facet is skipped entirely (hydrated summary, no raw schema column to
+// type-check) -- must not throw even though the fixture Facet model has no
+// 'kind'/'taxonomy' field at all.
+const facetTypeProblems = findSourceFieldTypeProblems(
+  SCHEMA_FIXTURE,
+  FIXED_RECIPES_FIXTURE,
+)
+assert.equal(
+  facetTypeProblems.length,
+  0,
+  `expected Facet to be skipped by the type check, got: ${JSON.stringify(facetTypeProblems)}`,
+)
+
 console.log(
   'Model Builder source-field guard checker verified: finds Bot.BotType ' +
     'and Facet.imagePath as real scalar fields, excludes relation fields, ' +
     "parses FacetSummary's hydrated additions, flags the pre-fix " +
-    'wrong-case/dropped-column shape, clears the fixed shape, and flags a ' +
-    'titleField typo.',
+    'wrong-case/dropped-column shape, clears the fixed shape, flags a ' +
+    'titleField typo, and (cycle 31) flags a real field whose Prisma type ' +
+    "(Boolean) the renderer can't turn into text while clearing " +
+    'renderable String/Int/enum-typed fields and skipping Facet entirely.',
 )

--- a/utils/scripts/verifyModelBuilderSourceFieldGuard.ts
+++ b/utils/scripts/verifyModelBuilderSourceFieldGuard.ts
@@ -29,6 +29,21 @@
 // computed additions, parsed from the FacetSummary type in
 // server/utils/facetAssignments.ts so a future summary-shape change keeps
 // this guard honest without a hand-maintained duplicate field list.
+//
+// Extended cycle 31 with a second, narrower check (findSourceFieldTypeProblems):
+// a field can be real (pass everything above) yet still render permanently
+// blank if its Prisma type isn't one sourceLabel()/subtitle() can turn into
+// text -- found by inspection: Scenario's subtitleField is 'difficulty',
+// which is a real column (`difficulty Int?`), but both renderers only ever
+// checked `typeof value === 'string'`, so the JS number every Scenario
+// record's difficulty transports as was silently discarded -- the same
+// user-visible "permanently blank Grid/List subtitle" outcome as the
+// wrong-name bugs above, just reached through a type mismatch on an
+// otherwise-correct field name instead. Fixed both model-builder-source-
+// picker.vue's subtitle() (now also renders finite numbers) and added this
+// second check so a future SOURCE_TYPES entry pointed at a column whose
+// runtime value the renderer still can't handle (Boolean/DateTime/Json/
+// BigInt/Bytes/Decimal) fails the same way a nonexistent field already does.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -49,6 +64,19 @@ const FACET_ASSIGNMENTS_PATH = join(
 // Facet's list endpoint hydrates a computed summary rather than returning a
 // raw Facet row -- see FACET_ASSIGNMENTS_PATH's FacetSummary type.
 const HYDRATED_SUMMARY_SOURCE_TYPES = new Set(['Facet'])
+
+// Base Prisma scalar types model-builder-source-picker.vue's sourceLabel()/
+// subtitle() can actually turn into visible text (cycle 31): both do a plain
+// `typeof value === 'string' | 'number'` check on the JSON-transported
+// value. String is the obvious case; Int/Float genuinely round-trip as JS
+// numbers. Everything else Prisma can declare on a scalar column --
+// Boolean, DateTime, Json, BigInt, Bytes, Decimal -- is a real column
+// findSourceFieldProblems above happily accepts (it exists!) but whose
+// runtime value that pair of typeof checks silently discards. Prisma enum
+// types are handled separately in findSourceFieldTypeProblems below (they
+// transport as strings, but aren't named here since enum names vary and
+// live in the schema's own `enum` blocks, not this fixed base-type list).
+const RENDERABLE_SCALAR_TYPES = new Set(['String', 'Int', 'Float'])
 
 export interface SourceFieldEntry {
   key: string
@@ -139,6 +167,47 @@ export function extractScalarFieldNames(
   return names
 }
 
+// Field name -> declared Prisma type (nullable `?` stripped) for the same
+// scalar columns extractScalarFieldNames above finds -- added cycle 31 to
+// support findSourceFieldTypeProblems below, which needs to know not just
+// THAT a named field exists but WHAT type it is.
+export function extractScalarFieldTypes(
+  schemaContent: string,
+  modelName: string,
+): Record<string, string> {
+  const block = findModelBlock(schemaContent, modelName)
+  if (!block) {
+    throw new Error(
+      `Could not find model ${modelName} in prisma/schema.prisma -- has it ` +
+        'been renamed?',
+    )
+  }
+  const types: Record<string, string> = {}
+  for (const line of block.split('\n')) {
+    const match = line.match(/^\s*(\w+)\s+([\w[\].?]+)(.*)$/)
+    if (!match) continue
+    const [, fieldName, rawType, rest] = match
+    if (!fieldName || !rawType) continue
+    if (rawType.endsWith('[]')) continue // list relation
+    if (rest && rest.includes('@relation')) continue // single relation object
+    types[fieldName] = rawType.replace(/\?$/, '')
+  }
+  return types
+}
+
+// Every `enum X { ... }` name declared in the schema. A Prisma enum column
+// (e.g. Dream.dreamType: DreamType, Reward.rewardType: RewardType) still
+// transports as a plain JSON string at runtime -- the enum only constrains
+// which strings are valid -- so it renders in model-builder-source-picker.vue
+// exactly as well as a real String column does.
+export function extractEnumNames(schemaContent: string): Set<string> {
+  const names = new Set<string>()
+  for (const match of schemaContent.matchAll(/^enum\s+(\w+)\s*\{/gm)) {
+    names.add(match[1]!)
+  }
+  return names
+}
+
 // The computed fields hydrateFacetSummaries adds on top of the raw scalar
 // Facet columns -- parsed from FacetSummary's own `& { ... }` type literal
 // so a future summary-shape change (a field renamed or removed) keeps this
@@ -202,6 +271,59 @@ export function findSourceFieldProblems(
   return problems
 }
 
+export interface SourceFieldTypeProblem {
+  key: string
+  field: string
+  which: 'titleField' | 'subtitleField'
+  fieldType: string
+}
+
+// Complements findSourceFieldProblems above: that function only asks "does
+// this field exist?" -- it happily accepts Scenario's subtitleField:
+// 'difficulty' since Scenario.difficulty is a real column
+// (prisma/schema.prisma: `difficulty Int?`). This asks the second question
+// (model-builder/t-029, cycle 31): "is the renderer that reads it able to
+// turn its runtime value into visible text?" A field that exists but is
+// e.g. Boolean/DateTime/Json/BigInt/Bytes/Decimal passes the existence
+// check yet still renders permanently blank, exactly like a missing field
+// does -- see model-builder-source-picker.vue's subtitle()/store.sourceLabel().
+// Skips HYDRATED_SUMMARY_SOURCE_TYPES (Facet): its list endpoint returns a
+// computed FacetSummary, not raw Prisma columns, so there's no schema column
+// type to check here -- findSourceFieldProblems' allowedFields check (which
+// already covers FacetSummary's computed fields) is all that applies to it.
+export function findSourceFieldTypeProblems(
+  schemaContent: string,
+  recipesFileContent: string,
+): SourceFieldTypeProblem[] {
+  const entries = extractSourceFieldEntries(recipesFileContent)
+  const enumNames = extractEnumNames(schemaContent)
+  const problems: SourceFieldTypeProblem[] = []
+
+  for (const entry of entries) {
+    if (HYDRATED_SUMMARY_SOURCE_TYPES.has(entry.key)) continue
+    const fieldTypes = extractScalarFieldTypes(schemaContent, entry.key)
+
+    const checks: Array<['titleField' | 'subtitleField', string | undefined]> =
+      [
+        ['titleField', entry.titleField],
+        ['subtitleField', entry.subtitleField],
+      ]
+    for (const [which, field] of checks) {
+      if (!field) continue
+      const fieldType = fieldTypes[field]
+      // A field that doesn't exist at all is findSourceFieldProblems' job to
+      // report, not this one's -- avoid a redundant/misleading second
+      // problem for the exact same root cause.
+      if (!fieldType) continue
+      if (RENDERABLE_SCALAR_TYPES.has(fieldType) || enumNames.has(fieldType))
+        continue
+      problems.push({ key: entry.key, field, which, fieldType })
+    }
+  }
+
+  return problems
+}
+
 function main(): void {
   const schemaContent = readFileSync(SCHEMA_PATH, 'utf8')
   const recipesFileContent = readFileSync(MODEL_BUILDER_RECIPES_PATH, 'utf8')
@@ -211,6 +333,11 @@ function main(): void {
     schemaContent,
     recipesFileContent,
     facetAssignmentsContent,
+  )
+
+  const typeProblems = findSourceFieldTypeProblems(
+    schemaContent,
+    recipesFileContent,
   )
 
   if (problems.length) {
@@ -233,10 +360,30 @@ function main(): void {
     return
   }
 
+  if (typeProblems.length) {
+    console.error(
+      `Model Builder source-field contract failed: ${typeProblems.length} ` +
+        'SOURCE_TYPES entry(s) in stores/helpers/modelBuilderRecipes.ts ' +
+        'name a field that exists but whose Prisma type ' +
+        "model-builder-source-picker.vue's renderer can't turn into text:",
+    )
+    for (const problem of typeProblems) {
+      console.error(
+        `- ${problem.key}.${problem.which} = '${problem.field}' is a ` +
+          `${problem.fieldType} column -- model-builder-source-picker.vue's ` +
+          `${problem.which === 'titleField' ? 'store.sourceLabel()' : 'subtitle()'} ` +
+          `only renders String/Int/Float/enum values, so this will silently ` +
+          `render blank for every ${problem.key} record.`,
+      )
+    }
+    process.exitCode = 1
+    return
+  }
+
   console.log(
     'Model Builder source-field contract passed: every SOURCE_TYPES ' +
-      'titleField/subtitleField names a real property of what its source ' +
-      "type's list endpoint actually returns.",
+      'titleField/subtitleField names a real, renderable property of what ' +
+      "its source type's list endpoint actually returns.",
   )
 }
 


### PR DESCRIPTION
## What

`model-builder-source-picker.vue`'s `subtitle()` only ever rendered a
`string` value (`typeof value === 'string' ? value : ''`). Scenario's
configured `subtitleField` is `'difficulty'`, a real Prisma `Int?` column —
it exists (so cycle 22's `verifyModelBuilderSourceFieldGuard.ts` saw no
problem), but transports over JSON as a number, not a string, so the check
silently discarded it. **Every Scenario record's Grid/List secondary line
has been permanently blank** since Scenario was added as a source type —
the same user-visible failure mode cycle 22 fixed for Bot/Facet, just
reached through a type mismatch on an otherwise-correct field name instead
of a wrong one.

## Fix

- `subtitle()` now also stringifies finite numbers (Prisma enum columns
  like `Dream.dreamType`/`Reward.rewardType` already worked here — enums
  transport as plain JSON strings).
- Extended `verifyModelBuilderSourceFieldGuard.ts` (rather than adding a new
  guard file — mirrors cycle 21's precedent of extending an existing guard
  covering the same contract) with `findSourceFieldTypeProblems()` plus two
  helpers (`extractScalarFieldTypes`, `extractEnumNames`): it now also
  asserts every `SOURCE_TYPES` `titleField`/`subtitleField` resolves to a
  Prisma type the renderer can actually turn into text (String/Int/Float, or
  an enum), catching a future field pointed at a genuinely unrenderable type
  (Boolean/DateTime/Json/BigInt/Bytes/Decimal) the same way the existing
  check already catches a nonexistent field.
- Extended the guard's test file with matching fixtures/assertions.
  Already wired into `package.json`/`contract-tests.yml` (no new script
  names needed since this extends an already-wired guard).

## Investigated first (no bug found, no code change)

Cycle 30's suggested lead: whether `updatePitch`/`updateFields`/
`updatePrompt`/`approveStage`/`rejectStage`/`reopenStage` need a defensive
`isItemManualActionInFlight` gate the way the cycle-30 batch functions now
have. Traced every UI entry point in `model-builder-item-panel.vue` against
the actual stage-progression prerequisites and the server's diff-then-merge
`stageStatuses` write. Confirmed this is **not** currently live/reachable
through the shipped UI in a single tab: by the time COMMIT is clickable,
PITCH/FIELDS_AND_PROMPTS/GENERATE_ASSETS are already `approved`, and their
only interactive controls (the Edit/reopen buttons) are correctly gated on
`isCommitting`; their textareas are separately disabled via `isEditable()`
once approved. `rejectStage` has no UI call site at all. The one loose gap
found (PITCH/FIELDS Edit only checks `isCommitting`, not
`isGenerating`/`isQueued`) traces through `markDownstreamStale` +
`finishGenerateAssets`/`finishCommit`'s existing in-progress guards to the
intended "reopening upstream stales the render" cascade, not corruption.

## Verification

- New/extended guard selftest passes (Int now clears, Boolean still flags,
  enum clears, nonexistent field stays `findSourceFieldProblems`' job).
- Guard passes against the real repo files.
- All 119 `test:model-builder-*` npm scripts pass (including the
  contract-tests-coverage meta-guard).
- `npm run test` (`vue-tsc --noEmit`, repo-wide) clean.
- `eslint` clean on touched files.
- `prettier --check` on touched files: the two guard files are clean;
  `model-builder-source-picker.vue` has pre-existing whole-file formatting
  drift confirmed via `git stash` to predate this change (diffed
  prettier's own `--write` output — none of it touches the added
  `subtitle()` block).
- `git status --porcelain` scoped to exactly the 3 intended files.

model-builder/t-029, cycle 31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01YGiXiBT6VfqrmtrH9wZPQb)_