### PR TITLE
fix(model-builder): refuse to reopen an already-cancelled run (t-029 cycle 32)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -611,6 +611,12 @@ jobs:
       - name: Model Builder openRun request guard contract
         run: npm run test:model-builder-open-run-request-guard
 
+      - name: Model Builder openRun cancelled-run guard checker self-test
+        run: npm run test:model-builder-open-run-cancelled-guard-selftest
+
+      - name: Model Builder openRun cancelled-run guard contract
+        run: npm run test:model-builder-open-run-cancelled-guard
+
       - name: Model Builder async-fetch staleness coverage checker self-test
         run: npm run test:model-builder-async-fetch-staleness-coverage-selftest
 

--- a/package.json
+++ b/package.json
@@ -289,6 +289,8 @@
     "test:model-builder-fetch-runs-staleness-guard": "tsx utils/scripts/verifyModelBuilderFetchRunsStalenessGuard.ts",
     "test:model-builder-open-run-request-guard-selftest": "tsx utils/scripts/verifyModelBuilderOpenRunRequestGuard.test.ts",
     "test:model-builder-open-run-request-guard": "tsx utils/scripts/verifyModelBuilderOpenRunRequestGuard.ts",
+    "test:model-builder-open-run-cancelled-guard-selftest": "tsx utils/scripts/verifyModelBuilderOpenRunCancelledGuard.test.ts",
+    "test:model-builder-open-run-cancelled-guard": "tsx utils/scripts/verifyModelBuilderOpenRunCancelledGuard.ts",
     "test:model-builder-async-fetch-staleness-coverage-selftest": "tsx utils/scripts/verifyModelBuilderAsyncFetchStalenessCoverage.test.ts",
     "test:model-builder-async-fetch-staleness-coverage": "tsx utils/scripts/verifyModelBuilderAsyncFetchStalenessCoverage.ts",
     "test:model-builder-commit-asset-attachable-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitAssetAttachableGuard.test.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -117,6 +117,12 @@ export interface BuildItem {
 export interface BuildRun {
   id: string
   createdAt: string
+  // Server-authoritative run status (DRAFT/ACTIVE/COMPLETED/CANCELLED). Kept
+  // on every cached BuildRun (not just the freshly-fetched ServerRun it came
+  // from) so openRun() can tell a run in state.runs is already CANCELLED
+  // without a network round trip -- see openRun's own doc comment for why
+  // that check matters.
+  status: string
   sourceType: SourceTypeKey
   sourceId: number
   sourceLabel: string
@@ -392,6 +398,7 @@ function adaptRun(server: ServerRun): BuildRun {
   return {
     id: String(server.id),
     createdAt: server.createdAt,
+    status: server.status ?? 'ACTIVE',
     sourceType: server.sourceType as SourceTypeKey,
     sourceId: server.sourceId,
     sourceLabel: server.sourceLabel ?? '',
@@ -2762,6 +2769,31 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   // catch branches.
   let openRunRequestId = 0
 
+  // Bug (model-builder/t-029 cycle 32): unlike resumeRun() -- which explicitly
+  // checks `status !== 'CANCELLED'` on its remembered-run-id fetch and forgets
+  // the id when it fails, specifically "so we don't keep resuming a dead run
+  // into a read-only 409 trap" (see resumeRun's own comment) -- openRun() had
+  // no equivalent check on either of its paths. A CANCELLED run is normally
+  // excluded from state.runs (fetchRuns()'s default query filters
+  // `status: { not: 'CANCELLED' } }`), but that list goes stale the moment a
+  // run is cancelled from *elsewhere* -- another browser tab, another device,
+  // or simply a concurrent fetchRuns()/cancelRun() in this same tab that
+  // finishes after the click. The cached branch then reopened that stale
+  // CANCELLED entry directly with no status check at all (state.runs didn't
+  // even retain a status field to check), and the network-fetch fallback
+  // branch fetched the live record -- which DOES carry the real status -- and
+  // still ignored it. Either path leaves state.run pointing at a run that
+  // *looks* like a normal, fully interactive run: every stage-mutating action
+  // optimistically updates local state, then the background PATCH/POST 409s
+  // server-side on assertRunWritable's cancelled check, exactly the "read-only
+  // 409 trap" resumeRun's own fix was written to avoid.
+  //
+  // Fixed by carrying `status` on every cached BuildRun (see adaptRun) so the
+  // cached branch can skip a stale CANCELLED entry instead of opening it, and
+  // by treating the fetch fallback's own response the same way resumeRun
+  // treats its remembered-id fetch: a CANCELLED result is refused, the stale
+  // entry (if any) is dropped from state.runs, and an error is surfaced
+  // instead of silently opening a dead run.
   async function openRun(runId: string): Promise<void> {
     const requestId = ++openRunRequestId
 
@@ -2777,7 +2809,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     }
 
     const cached = state.runs.find((entry) => entry.id === runId)
-    if (cached) {
+    if (cached && cached.status !== 'CANCELLED') {
       state.run = cached
       state.sourceType = cached.sourceType
       state.recipeKey = cached.recipeKey
@@ -2799,6 +2831,17 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       )
       if (openRunRequestId !== requestId) return
       if (response.success && response.data) {
+        if (response.data.status === 'CANCELLED') {
+          // See this function's own doc comment. Drop the stale entry (if
+          // this run was the `cached` one above, it's CANCELLED and must not
+          // linger in state.runs either) instead of opening a dead run.
+          state.runs = state.runs.filter((entry) => entry.id !== runId)
+          setStatus(
+            'error',
+            'This run was cancelled and can no longer be opened.',
+          )
+          return
+        }
         state.run = adaptRun(response.data)
         state.sourceType = state.run.sourceType
         state.recipeKey = state.run.recipeKey

--- a/utils/scripts/verifyModelBuilderOpenRunCancelledGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderOpenRunCancelledGuard.test.ts
@@ -1,0 +1,203 @@
+// /utils/scripts/verifyModelBuilderOpenRunCancelledGuard.test.ts
+//
+// Regression test for checkOpenRunCancelledGuard() in
+// verifyModelBuilderOpenRunCancelledGuard.ts (model-builder/t-029 cycle 32).
+// Exercises the real check against synthetic store-shaped fixtures covering:
+// the pre-fix shape (cached branch opens any cached run regardless of
+// status, fetch fallback adopts any successful response regardless of
+// status -- the exact bug found by manual read-through), and the fixed
+// shape (both paths check status and the fetch fallback drops a stale
+// state.runs entry when the fetched run turns out CANCELLED).
+import assert from 'node:assert/strict'
+
+import { checkOpenRunCancelledGuard } from './verifyModelBuilderOpenRunCancelledGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function openRun(runId: string): Promise<void> {
+    const requestId = ++openRunRequestId
+
+    if (state.run?.id === runId) {
+      state.step = 'run'
+      return
+    }
+
+    const cached = state.runs.find((entry) => entry.id === runId)
+    if (cached) {
+      state.run = cached
+      state.sourceType = cached.sourceType
+      state.recipeKey = cached.recipeKey
+      state.selectedSource = null
+      state.selections = {}
+      state.step = 'run'
+      setActiveRunId(Number(runId))
+      return
+    }
+
+    try {
+      const response = await performFetch<ServerRun>(
+        \`/api/model-builder/runs/\${runId}\`,
+      )
+      if (openRunRequestId !== requestId) return
+      if (response.success && response.data) {
+        state.run = adaptRun(response.data)
+        state.sourceType = state.run.sourceType
+        state.recipeKey = state.run.recipeKey
+        state.selectedSource = null
+        state.selections = {}
+        state.step = 'run'
+        setActiveRunId(response.data.id)
+      } else if (!response.success) {
+        setStatus('error', response.message || 'Failed to open run.')
+      }
+    } catch (error) {
+      if (openRunRequestId !== requestId) return
+      handleError(error, 'opening build run')
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function openRun(runId: string): Promise<void> {
+    const requestId = ++openRunRequestId
+
+    if (state.run?.id === runId) {
+      state.step = 'run'
+      return
+    }
+
+    const cached = state.runs.find((entry) => entry.id === runId)
+    if (cached && cached.status !== 'CANCELLED') {
+      state.run = cached
+      state.sourceType = cached.sourceType
+      state.recipeKey = cached.recipeKey
+      state.selectedSource = null
+      state.selections = {}
+      state.step = 'run'
+      setActiveRunId(Number(runId))
+      return
+    }
+
+    try {
+      const response = await performFetch<ServerRun>(
+        \`/api/model-builder/runs/\${runId}\`,
+      )
+      if (openRunRequestId !== requestId) return
+      if (response.success && response.data) {
+        if (response.data.status === 'CANCELLED') {
+          state.runs = state.runs.filter((entry) => entry.id !== runId)
+          setStatus('error', 'This run was cancelled and can no longer be opened.')
+          return
+        }
+        state.run = adaptRun(response.data)
+        state.sourceType = state.run.sourceType
+        state.recipeKey = state.run.recipeKey
+        state.selectedSource = null
+        state.selections = {}
+        state.step = 'run'
+        setActiveRunId(response.data.id)
+      } else if (!response.success) {
+        setStatus('error', response.message || 'Failed to open run.')
+      }
+    } catch (error) {
+      if (openRunRequestId !== requestId) return
+      handleError(error, 'opening build run')
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkOpenRunCancelledGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  3,
+  'expected the pre-fix shape (missing cached-status check, missing ' +
+    'fetch-status check, missing stale-entry drop) to raise 3 errors, got ' +
+    `${buggyErrors.length}: ${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes("cached.status !== 'CANCELLED'")),
+  'expected a violation for the missing cached-branch status check',
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes("response.data.status === 'CANCELLED'")),
+  'expected a violation for the missing fetch-fallback status check',
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes('state.runs = state.runs.filter')),
+  'expected a violation for the missing stale-entry drop',
+)
+
+const fixedErrors = checkOpenRunCancelledGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingFnErrors = checkOpenRunCancelledGuard(MISSING_FIXTURE)
+assert.equal(
+  missingFnErrors.length,
+  1,
+  'expected a single "function not found" violation when openRun is absent',
+)
+assert.ok(missingFnErrors[0]!.includes('openRun'))
+
+// A fixture where the fetch-status check exists but runs AFTER the adopt
+// statement must still fail -- the check has to gate the assignment, not
+// just appear somewhere in the function body.
+const CHECK_TOO_LATE_FIXTURE = `
+  async function openRun(runId: string): Promise<void> {
+    const requestId = ++openRunRequestId
+
+    if (state.run?.id === runId) {
+      state.step = 'run'
+      return
+    }
+
+    const cached = state.runs.find((entry) => entry.id === runId)
+    if (cached && cached.status !== 'CANCELLED') {
+      state.run = cached
+      state.step = 'run'
+      setActiveRunId(Number(runId))
+      return
+    }
+
+    try {
+      const response = await performFetch<ServerRun>(
+        \`/api/model-builder/runs/\${runId}\`,
+      )
+      if (openRunRequestId !== requestId) return
+      if (response.success && response.data) {
+        state.run = adaptRun(response.data)
+        if (response.data.status === 'CANCELLED') {
+          state.runs = state.runs.filter((entry) => entry.id !== runId)
+        }
+        state.step = 'run'
+        setActiveRunId(response.data.id)
+      }
+    } catch (error) {
+      if (openRunRequestId !== requestId) return
+      handleError(error, 'opening build run')
+    }
+  }
+`
+const tooLateErrors = checkOpenRunCancelledGuard(CHECK_TOO_LATE_FIXTURE)
+assert.ok(
+  tooLateErrors.some((e) => e.includes('AFTER already assigning')),
+  `expected a violation for a status check that runs after the adopt ` +
+    `statement, got: ${JSON.stringify(tooLateErrors)}`,
+)
+
+console.log(
+  'Model Builder open-run-cancelled guard checker verified: flags the ' +
+    'pre-fix shape (missing cached-status check, missing fetch-status ' +
+    'check, missing stale-entry drop), flags a status check that runs too ' +
+    'late, clears the fixed shape, and flags openRun being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderOpenRunCancelledGuard.ts
+++ b/utils/scripts/verifyModelBuilderOpenRunCancelledGuard.ts
@@ -1,0 +1,133 @@
+// /utils/scripts/verifyModelBuilderOpenRunCancelledGuard.ts
+//
+// Regression guard (model-builder/t-029 cycle 32) -- openRun(runId) had no
+// equivalent of resumeRun()'s "don't resume a dead run" check (see
+// verifyModelBuilderResumeCancelledRunGuard.ts for that sibling fix).
+// fetchRuns()'s default query excludes CANCELLED runs, so state.runs is
+// *usually* clean, but that list goes stale the instant a run is cancelled
+// from elsewhere -- another browser tab, another device, or just a
+// concurrent fetchRuns()/cancelRun() finishing after the click. Before this
+// fix, openRun()'s cached branch reopened a stale CANCELLED entry from
+// state.runs with no status check at all, and its network-fetch fallback
+// fetched the live (status-accurate) record and still ignored the status.
+// Either path leaves state.run pointing at a run that looks fully
+// interactive -- every stage-mutating action optimistically updates local
+// state, then the background PATCH/POST 409s server-side on
+// assertRunWritable's cancelled check -- the exact "read-only 409 trap"
+// resumeRun's own fix exists to avoid.
+//
+// Fixed by carrying `status` on every cached BuildRun (adaptRun) so the
+// cached branch can refuse a stale CANCELLED entry, and by checking
+// `response.data.status === 'CANCELLED'` on the fetch fallback the same way
+// resumeRun checks its own remembered-id fetch, dropping the stale entry
+// from state.runs and surfacing an error instead of opening a dead run.
+//
+// This asserts the textual shape of that fix stays in place: openRun()'s
+// cached-branch guard includes `cached.status !== 'CANCELLED'`, and its
+// fetch-fallback branch checks `response.data.status === 'CANCELLED'` before
+// the `state.run = adaptRun(response.data)` assignment. Deliberately scoped
+// to this one function/bug, mirroring
+// verifyModelBuilderResumeCancelledRunGuard.ts's own narrow textual check
+// over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'openRun'
+const CACHED_CHECK = "cached.status !== 'CANCELLED'"
+const FETCH_CHECK = "response.data.status === 'CANCELLED'"
+const ADOPT_STATEMENT = 'state.run = adaptRun(response.data)'
+const DROP_STALE_ENTRY =
+  'state.runs = state.runs.filter((entry) => entry.id !== runId)'
+
+// Checks the fix's exact shape against the full source text of a file
+// containing an `openRun`-named function. Exported (rather than only
+// exercised via main()) so the self-test below can run it against synthetic
+// buggy/fixed fixtures without touching the real store file.
+export function checkOpenRunCancelledGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find an async function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  if (!fn.body.includes(CACHED_CHECK)) {
+    errors.push(
+      `${FN_NAME}()'s cached-run branch does not check \`${CACHED_CHECK}\` ` +
+        '-- without this, a stale CANCELLED entry left in state.runs by a ' +
+        'run cancelled from elsewhere (another tab/device, or a concurrent ' +
+        'fetchRuns()) gets reopened directly with no status check, leading ' +
+        "to the same read-only 409 trap resumeRun()'s own cancelled-run " +
+        'check exists to avoid.',
+    )
+  }
+
+  const fetchCheckIndex = fn.body.indexOf(FETCH_CHECK)
+  const adoptIndex = fn.body.indexOf(ADOPT_STATEMENT)
+  if (fetchCheckIndex === -1) {
+    errors.push(
+      `${FN_NAME}()'s network-fetch fallback does not check ` +
+        `\`${FETCH_CHECK}\` before adopting the response -- ` +
+        'GET /api/model-builder/runs/:id has no status filter, so a ' +
+        'CANCELLED run fetched this way would otherwise be opened as if it ' +
+        'were still live.',
+    )
+  } else if (adoptIndex !== -1 && fetchCheckIndex >= adoptIndex) {
+    errors.push(
+      `${FN_NAME}() checks \`${FETCH_CHECK}\` AFTER already assigning ` +
+        `\`${ADOPT_STATEMENT}\` -- the check must run before state.run is ` +
+        'set, or a CANCELLED response still gets adopted first.',
+    )
+  }
+
+  if (!fn.body.includes(DROP_STALE_ENTRY)) {
+    errors.push(
+      `${FN_NAME}() does not drop the stale entry from state.runs ` +
+        `(expected \`${DROP_STALE_ENTRY}\`) when the fetch reveals the run ` +
+        'is CANCELLED -- without this, the same dead entry stays cached and ' +
+        'a later click can still hit the cached branch instead of ' +
+        're-checking.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkOpenRunCancelledGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder open-run-cancelled guard contract failed for ' +
+        `${FN_NAME}() in modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder open-run-cancelled guard contract passed: ' +
+      `${FN_NAME}() refuses a stale cached or freshly-fetched CANCELLED ` +
+      'run instead of silently reopening it.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What changed

`openRun()` in `stores/modelBuilderStore.ts` had no equivalent of `resumeRun()`'s "don't resume a dead run" check.

`resumeRun()` explicitly checks `status !== 'CANCELLED'` on its remembered-run-id fetch and forgets the id when it fails — its own comment says this is "so we don't keep resuming a dead run into a read-only 409 trap." `openRun()` had no equivalent guard on either of its two paths:

- **Cached branch** (`state.runs.find(...)`): opened any cached entry with no status check at all — `BuildRun` didn't even carry a `status` field to check. `fetchRuns()`'s default query excludes `CANCELLED` runs, so `state.runs` is *usually* clean, but it goes stale the instant a run is cancelled from elsewhere: another browser tab, another device, or a concurrent `fetchRuns()`/`cancelRun()` finishing after the click.
- **Network-fetch fallback** (`GET /api/model-builder/runs/:id`, which has no status filter): fetched the live, status-accurate record and still ignored it.

Either path left `state.run` pointing at a run that looks fully interactive — every stage-mutating action optimistically updates local state, then the background PATCH/POST 409s server-side on `assertRunWritable`'s cancelled check — the exact "read-only 409 trap" `resumeRun()`'s own fix exists to avoid.

### Fix
- Added `status` to `BuildRun`/`adaptRun` so every cached run carries its server-authoritative status.
- `openRun()`'s cached branch now refuses a cached entry whose `status === 'CANCELLED'`.
- `openRun()`'s fetch fallback now checks `response.data.status === 'CANCELLED'` before adopting the response; on a cancelled run it drops the stale `state.runs` entry and surfaces an error instead of opening a dead run.

### Also checked (cycle 32's suggested lead)
Whether any other Model Builder component reads a source record's raw fields the fragile way `model-builder-source-picker.vue`'s `subtitle()` used to before cycle 31's fix (`Scenario.difficulty` being a Prisma `Int`). Grepped for other `SOURCE_TYPES`/`titleField`/`subtitleField` consumers — found none. `sourceLabel()` in `modelBuilderStore.ts` only ever reads `titleField`, and every `titleField` in `SOURCE_TYPES` is a Prisma string column (`title`/`name`), so it isn't exposed to the same non-string-value bug. No fix needed there; confirmed non-issue.

Also read `server/api/model-builder/runs/index.post.ts`, `runs/index.get.ts`, and `runs/[id].get.ts` line by line against their callers — no bug found there; the run-creation/list/reopen server routes themselves are solid. The bug turned out to be in the client-side `openRun()` reopen path instead.

## Test coverage

Added `utils/scripts/verifyModelBuilderOpenRunCancelledGuard.ts` + its `.test.ts`, following this task's established regression-guard convention (mirrors `verifyModelBuilderResumeCancelledRunGuard.ts` for its sibling function `resumeRun`). Wired into `package.json` (`test:model-builder-open-run-cancelled-guard[-selftest]`) and `.github/workflows/contract-tests.yml`, verified against `verifyModelBuilderContractTestsCoverageGuard.ts`.

## Verification

- `vue-tsc --noEmit`: clean (no errors)
- `eslint` on touched files: only 2 pre-existing, unrelated errors (empty catch blocks in `safeSet`/`safeRemove`, predating this change — confirmed via `git stash` diff against `origin/main`)
- `prettier --check` on new/touched files: clean
- All **121** `test:model-builder-*` npm scripts pass, including the 2 new ones
- `git status --porcelain` shows only the intended files

Closes conductor task `model-builder/t-029` cycle 32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016G9vsQVTXxAYEkboUg9SHi

---
_Generated by [Claude Code](https://claude.ai/code/session_016G9vsQVTXxAYEkboUg9SHi)_