### PR TITLE
fix(model-builder): stop SHORT_TEXT_MAX being dead code for prose fields (t-029 cycle 33)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -431,6 +431,12 @@ jobs:
       - name: Model Builder commit name/title field guard contract
         run: npm run test:model-builder-commit-name-field-guard
 
+      - name: Model Builder commit text-truncation guard checker self-test
+        run: npm run test:model-builder-commit-text-truncation-guard-selftest
+
+      - name: Model Builder commit text-truncation guard contract
+        run: npm run test:model-builder-commit-text-truncation-guard
+
       - name: Model Builder commit stale-snapshot guard checker self-test
         run: npm run test:model-builder-commit-stale-snapshot-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -229,6 +229,8 @@
     "test:model-builder-open-run-identity-guard": "tsx utils/scripts/verifyModelBuilderOpenRunIdentityGuard.ts",
     "test:model-builder-commit-name-field-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitNameFieldGuard.test.ts",
     "test:model-builder-commit-name-field-guard": "tsx utils/scripts/verifyModelBuilderCommitNameFieldGuard.ts",
+    "test:model-builder-commit-text-truncation-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitTextTruncationGuard.test.ts",
+    "test:model-builder-commit-text-truncation-guard": "tsx utils/scripts/verifyModelBuilderCommitTextTruncationGuard.ts",
     "test:model-builder-commit-stale-snapshot-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.test.ts",
     "test:model-builder-commit-stale-snapshot-guard": "tsx utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.ts",
     "test:model-builder-commit-target-persistence-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitTargetPersistenceGuard.test.ts",

--- a/server/api/model-builder/items/[id]/commit.post.ts
+++ b/server/api/model-builder/items/[id]/commit.post.ts
@@ -56,9 +56,34 @@ function isSourceType(value: string): value is SourceType {
 
 const LONG_TEXT_MAX = 20000
 const DEFAULT_TEXT_MAX = 256
+// Explicit per-field caps for columns narrower than LONG_TEXT_MAX/
+// DEFAULT_TEXT_MAX -- checked first in pickText below regardless of a
+// field's `prose`/LONG_TEXT_FIELDS classification (model-builder/t-029,
+// cycle 33): every one of these fields maps to a bounded VarChar column in
+// prisma/schema.prisma, so its cap here must match that column's declared
+// width, not the prose-text default of 20000 chars.
 const SHORT_TEXT_MAX: Partial<Record<SourceType, Record<string, number>>> = {
   Character: { class: 764, species: 764 },
-  Bot: { subtitle: 764 },
+  // description/personality/botIntro/userIntro/prompt: Bot.description and
+  // Bot.personality are VarChar(764); Bot.botIntro is VarChar(3000) and
+  // NOT NULL; Bot.userIntro and Bot.prompt are VarChar(764) and NOT NULL.
+  // All five are marked `prose: true` (or, for personality, simply lacked
+  // any override) in MODEL_FIELDS.Bot, which -- before this fix -- let
+  // pickText's isLongText branch return LONG_TEXT_MAX (20000) unconditionally
+  // for the four prose ones, or the generic DEFAULT_TEXT_MAX (256) for
+  // personality, both silently ignoring the real column width. Committing an
+  // AI-drafted or user-typed value past these caps risked either a silent
+  // MySQL truncation or a "Data too long for column" write failure on the
+  // three NOT NULL columns -- for a live, reachable path: Bot is a real
+  // CREATE target via the expand-narrator-bot/expand-manager-bot outputs.
+  Bot: {
+    subtitle: 764,
+    description: 764,
+    personality: 764,
+    botIntro: 3000,
+    userIntro: 764,
+    prompt: 764,
+  },
   Reward: { flavorText: 512, collection: 764 },
   Dream: { flavorText: 512 },
 }
@@ -135,9 +160,21 @@ function pickText(
   const isLongText =
     fieldSpecFor(type).find((field) => field.key === key)?.prose ||
     LONG_TEXT_FIELDS[type]?.has(key)
-  const maxLen = isLongText
-    ? LONG_TEXT_MAX
-    : (SHORT_TEXT_MAX[type]?.[key] ?? DEFAULT_TEXT_MAX)
+  // SHORT_TEXT_MAX is checked FIRST, unconditionally -- not only when
+  // `!isLongText` (model-builder/t-029, cycle 33). Before this fix, a field
+  // marked `prose: true` (or listed in LONG_TEXT_FIELDS) always took the
+  // isLongText branch and got LONG_TEXT_MAX (20000) regardless of any
+  // SHORT_TEXT_MAX entry for it, silently making that entry dead code. That
+  // exact gap left Reward.flavorText and Dream.flavorText -- both real
+  // VarChar(512) columns, both marked prose: true, both already listed in
+  // SHORT_TEXT_MAX at 512 -- free to accept up to 20000 characters at
+  // commit time, risking a silent MySQL truncation or a "Data too long for
+  // column" write failure. An explicit SHORT_TEXT_MAX entry is a narrower,
+  // more specific fact about the real schema column than the generic
+  // prose/long-text classification, so it must win regardless of that flag.
+  const maxLen =
+    SHORT_TEXT_MAX[type]?.[key] ??
+    (isLongText ? LONG_TEXT_MAX : DEFAULT_TEXT_MAX)
   return trimmed.length > maxLen ? trimmed.slice(0, maxLen) : trimmed
 }
 

--- a/utils/scripts/verifyModelBuilderCommitTextTruncationGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderCommitTextTruncationGuard.test.ts
@@ -1,0 +1,255 @@
+// /utils/scripts/verifyModelBuilderCommitTextTruncationGuard.test.ts
+//
+// Regression test for verifyModelBuilderCommitTextTruncationGuard.ts
+// (model-builder/t-029, cycle 33). Exercises the real checks against
+// synthetic schema/fields/commit-route fixtures covering: the pre-fix
+// buggy maxLen precedence (isLongText gated ahead of SHORT_TEXT_MAX), the
+// fixed precedence, a long-text-classified field with a bounded VarChar
+// column and no SHORT_TEXT_MAX override (Bot's pre-fix
+// description/botIntro/userIntro/prompt), the fixed shape with matching
+// overrides, and a drifted override value that no longer matches the
+// schema's declared width.
+import assert from 'node:assert/strict'
+
+import {
+  extractLongTextFields,
+  extractMaxLenExpression,
+  extractProseFields,
+  extractShortTextMax,
+  extractVarCharWidths,
+  findTruncationProblems,
+  maxLenPrefersShortTextMax,
+} from './verifyModelBuilderCommitTextTruncationGuard.js'
+
+const SCHEMA_FIXTURE = `
+model Bot {
+  id          Int     @id @default(autoincrement())
+  name        String  @db.VarChar(256)
+  subtitle    String? @db.VarChar(764)
+  description String? @db.VarChar(764)
+  botIntro    String  @db.VarChar(3000)
+  personality String? @db.Text
+}
+
+model Reward {
+  id         Int     @id @default(autoincrement())
+  name       String  @db.VarChar(256)
+  flavorText String? @db.VarChar(512)
+  effect     String? @db.Text
+}
+`
+
+const FIELDS_FIXTURE_BOT_UNCLASSIFIED = `
+export const MODEL_FIELDS: Record<string, ModelFieldSpec[]> = {
+  Bot: [
+    { key: 'name', label: 'Name', required: true },
+    { key: 'subtitle', label: 'Subtitle' },
+    { key: 'description', label: 'Description', prose: true },
+    { key: 'botIntro', label: 'Bot intro', prose: true },
+    { key: 'personality', label: 'Personality', prose: true },
+  ],
+  Reward: [
+    { key: 'name', label: 'Name', required: true },
+    { key: 'flavorText', label: 'Flavor text', prose: true },
+    { key: 'effect', label: 'Effect', prose: true },
+  ],
+}
+`
+
+// --- extractProseFields / extractVarCharWidths -----------------------------
+
+const proseFields = extractProseFields(FIELDS_FIXTURE_BOT_UNCLASSIFIED)
+assert.deepEqual(
+  proseFields.Bot,
+  ['description', 'botIntro', 'personality'],
+  `expected Bot's prose keys parsed in order, got: ${JSON.stringify(proseFields.Bot)}`,
+)
+assert.deepEqual(
+  proseFields.Reward,
+  ['flavorText', 'effect'],
+  `expected Reward's prose keys parsed in order, got: ${JSON.stringify(proseFields.Reward)}`,
+)
+
+const botWidths = extractVarCharWidths(SCHEMA_FIXTURE, 'Bot')
+assert.equal(botWidths.description, 764)
+assert.equal(botWidths.botIntro, 3000)
+assert.equal(
+  botWidths.personality,
+  undefined,
+  'expected Bot.personality (a Text column) to have no bounded width',
+)
+
+assert.throws(
+  () => extractVarCharWidths(SCHEMA_FIXTURE, 'Character'),
+  /Could not find model Character/,
+  'expected a missing model to throw a descriptive error',
+)
+
+// --- extractMaxLenExpression / maxLenPrefersShortTextMax --------------------
+
+const BUGGY_MAXLEN_ROUTE = `
+function pickText() {
+  const isLongText = true
+  const maxLen = isLongText
+    ? LONG_TEXT_MAX
+    : (SHORT_TEXT_MAX[type]?.[key] ?? DEFAULT_TEXT_MAX)
+  return trimmed.length > maxLen ? trimmed.slice(0, maxLen) : trimmed
+}
+`
+
+const FIXED_MAXLEN_ROUTE = `
+function pickText() {
+  const isLongText = true
+  const maxLen =
+    SHORT_TEXT_MAX[type]?.[key] ?? (isLongText ? LONG_TEXT_MAX : DEFAULT_TEXT_MAX)
+  return trimmed.length > maxLen ? trimmed.slice(0, maxLen) : trimmed
+}
+`
+
+const buggyExpr = extractMaxLenExpression(BUGGY_MAXLEN_ROUTE)
+assert.ok(buggyExpr, 'expected the buggy maxLen expression to be found')
+assert.equal(
+  maxLenPrefersShortTextMax(buggyExpr!),
+  false,
+  'expected the pre-fix isLongText-first shape to fail the precedence check',
+)
+
+const fixedExpr = extractMaxLenExpression(FIXED_MAXLEN_ROUTE)
+assert.ok(fixedExpr, 'expected the fixed maxLen expression to be found')
+assert.equal(
+  maxLenPrefersShortTextMax(fixedExpr!),
+  true,
+  'expected the fixed SHORT_TEXT_MAX-first shape to pass the precedence check',
+)
+
+assert.equal(
+  extractMaxLenExpression('no maxLen assignment here'),
+  null,
+  'expected a missing maxLen assignment to return null rather than throw',
+)
+
+// --- extractShortTextMax / extractLongTextFields ----------------------------
+
+const COMMIT_ROUTE_FIXTURE = `
+const LONG_TEXT_MAX = 20000
+const DEFAULT_TEXT_MAX = 256
+const SHORT_TEXT_MAX: Partial<Record<SourceType, Record<string, number>>> = {
+  Bot: { subtitle: 764 },
+  Reward: { flavorText: 512 },
+}
+const LONG_TEXT_FIELDS: Partial<Record<SourceType, Set<string>>> = {
+  Dream: new Set(['examples']),
+}
+`
+
+const shortTextMax = extractShortTextMax(COMMIT_ROUTE_FIXTURE)
+assert.deepEqual(shortTextMax, {
+  Bot: { subtitle: 764 },
+  Reward: { flavorText: 512 },
+})
+
+const longTextFields = extractLongTextFields(COMMIT_ROUTE_FIXTURE)
+assert.deepEqual(longTextFields, { Dream: ['examples'] })
+
+// --- findTruncationProblems --------------------------------------------------
+
+// Pre-fix shape: Bot.description/botIntro are prose-classified real
+// VarChar(764)/VarChar(3000) columns with no SHORT_TEXT_MAX entry at all;
+// Reward.flavorText is prose-classified and real (VarChar(512)) but its
+// override is present and correct.
+const PARTIALLY_BUGGY_ROUTE = `
+const SHORT_TEXT_MAX: Partial<Record<SourceType, Record<string, number>>> = {
+  Reward: { flavorText: 512 },
+}
+const LONG_TEXT_FIELDS: Partial<Record<SourceType, Set<string>>> = {
+}
+`
+
+const partiallyBuggyProblems = findTruncationProblems(
+  SCHEMA_FIXTURE,
+  FIELDS_FIXTURE_BOT_UNCLASSIFIED,
+  PARTIALLY_BUGGY_ROUTE,
+)
+assert.equal(
+  partiallyBuggyProblems.length,
+  2,
+  `expected Bot.description and Bot.botIntro to be flagged (missing override), ` +
+    `got ${partiallyBuggyProblems.length}: ${JSON.stringify(partiallyBuggyProblems)}`,
+)
+assert.ok(
+  partiallyBuggyProblems.some(
+    (p) =>
+      p.model === 'Bot' && p.field === 'description' && p.schemaWidth === 764,
+  ),
+)
+assert.ok(
+  partiallyBuggyProblems.some(
+    (p) =>
+      p.model === 'Bot' && p.field === 'botIntro' && p.schemaWidth === 3000,
+  ),
+)
+assert.ok(
+  !partiallyBuggyProblems.some((p) => p.field === 'personality'),
+  'expected Bot.personality (a Text column, no bounded width) not to be flagged',
+)
+assert.ok(
+  !partiallyBuggyProblems.some((p) => p.field === 'flavorText'),
+  'expected Reward.flavorText (already correctly overridden) not to be flagged',
+)
+
+// Fixed shape: every long-text-classified bounded VarChar field has a
+// matching override.
+const FIXED_ROUTE = `
+const SHORT_TEXT_MAX: Partial<Record<SourceType, Record<string, number>>> = {
+  Bot: { description: 764, botIntro: 3000 },
+  Reward: { flavorText: 512 },
+}
+const LONG_TEXT_FIELDS: Partial<Record<SourceType, Set<string>>> = {
+}
+`
+
+const fixedProblems = findTruncationProblems(
+  SCHEMA_FIXTURE,
+  FIELDS_FIXTURE_BOT_UNCLASSIFIED,
+  FIXED_ROUTE,
+)
+assert.equal(
+  fixedProblems.length,
+  0,
+  `expected the fixed shape to raise no problems, got: ${JSON.stringify(fixedProblems)}`,
+)
+
+// A drifted override (schema width changed since the override was written)
+// must still be flagged even though an entry exists.
+const DRIFTED_ROUTE = `
+const SHORT_TEXT_MAX: Partial<Record<SourceType, Record<string, number>>> = {
+  Bot: { description: 256, botIntro: 3000 },
+  Reward: { flavorText: 512 },
+}
+const LONG_TEXT_FIELDS: Partial<Record<SourceType, Set<string>>> = {
+}
+`
+
+const driftedProblems = findTruncationProblems(
+  SCHEMA_FIXTURE,
+  FIELDS_FIXTURE_BOT_UNCLASSIFIED,
+  DRIFTED_ROUTE,
+)
+assert.equal(
+  driftedProblems.length,
+  1,
+  `expected the drifted description override to be flagged, got ${driftedProblems.length}: ` +
+    JSON.stringify(driftedProblems),
+)
+assert.equal(driftedProblems[0]!.field, 'description')
+assert.equal(driftedProblems[0]!.shortTextMaxValue, 256)
+assert.equal(driftedProblems[0]!.schemaWidth, 764)
+
+console.log(
+  'Model Builder commit text-truncation guard checker verified: parses ' +
+    "MODEL_FIELDS' prose keys and schema VarChar widths, flags the pre-fix " +
+    'isLongText-first maxLen precedence and the fixed SHORT_TEXT_MAX-first ' +
+    'shape correctly, flags a long-text-classified bounded column with a ' +
+    'missing or drifted SHORT_TEXT_MAX override, and clears Text columns ' +
+    'and already-correct overrides.',
+)

--- a/utils/scripts/verifyModelBuilderCommitTextTruncationGuard.ts
+++ b/utils/scripts/verifyModelBuilderCommitTextTruncationGuard.ts
@@ -163,7 +163,8 @@ export function extractProseFields(
       const obj = fieldMatch[0]
       if (!/prose:\s*true/.test(obj)) continue
       const keyMatch = obj.match(/key:\s*'(\w+)'/)
-      if (keyMatch) proseKeys.push(keyMatch[1]!)
+      if (!keyMatch) continue
+      proseKeys.push(keyMatch[1]!)
     }
     result[match[1]!] = proseKeys
   })
@@ -174,7 +175,8 @@ export function extractProseFields(
 
 function findModelBlock(schema: string, modelName: string): string | null {
   const match = schema.match(new RegExp(`^model\\s+${modelName}\\s*\\{`, 'm'))
-  if (!match || match.index === undefined) return null
+  if (!match) return null
+  if (match.index === undefined) return null
   const start = match.index + match[0].length
   const end = schema.indexOf('\n}', start)
   if (end === -1) return null
@@ -198,7 +200,8 @@ export function extractVarCharWidths(
   const widths: Record<string, number> = {}
   for (const line of block.split('\n')) {
     const match = line.match(/^\s*(\w+)\s+\S+.*@db\.VarChar\((\d+)\)/)
-    if (match) widths[match[1]!] = Number(match[2]!)
+    if (!match) continue
+    widths[match[1]!] = Number(match[2]!)
   }
   return widths
 }

--- a/utils/scripts/verifyModelBuilderCommitTextTruncationGuard.ts
+++ b/utils/scripts/verifyModelBuilderCommitTextTruncationGuard.ts
@@ -1,0 +1,335 @@
+// /utils/scripts/verifyModelBuilderCommitTextTruncationGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 33). commit.post.ts's
+// pickText() decides how many characters of a FIELDS_AND_PROMPTS value to
+// keep before writing it to the DB: LONG_TEXT_MAX (20000) for fields marked
+// `prose: true` in MODEL_FIELDS (modelBuilderFields.ts) or listed in
+// LONG_TEXT_FIELDS, DEFAULT_TEXT_MAX (256) otherwise, or an explicit
+// SHORT_TEXT_MAX[type][key] override for a column narrower than either
+// default.
+//
+// Before this fix, that choice was `isLongText ? LONG_TEXT_MAX :
+// (SHORT_TEXT_MAX[type]?.[key] ?? DEFAULT_TEXT_MAX)` -- so ANY field marked
+// prose/long-text took LONG_TEXT_MAX *unconditionally*, silently ignoring a
+// SHORT_TEXT_MAX entry for that same field. That made the SHORT_TEXT_MAX
+// entries already in place for Reward.flavorText and Dream.flavorText (both
+// real `VarChar(512)` columns, both marked `prose: true`) pure dead code:
+// pickText would still let up to 20000 characters through to a 512-char
+// column, risking a silent MySQL truncation or a "Data too long for column"
+// write failure. The same gap left Bot.description/botIntro/userIntro/
+// prompt -- VarChar(764)/VarChar(3000) columns, three of them NOT NULL --
+// with no SHORT_TEXT_MAX entry at all, on a live, reachable path: Bot is a
+// real CREATE target via the expand-narrator-bot/expand-manager-bot outputs.
+//
+// This walks prisma/schema.prisma, modelBuilderFields.ts's MODEL_FIELDS, and
+// commit.post.ts's SHORT_TEXT_MAX/LONG_TEXT_FIELDS maps, and fails if:
+//   1. pickText's maxLen expression no longer checks SHORT_TEXT_MAX ahead of
+//      (independent of) the prose/long-text classification, or
+//   2. any field MODEL_FIELDS classifies as long-text (prose: true, or
+//      listed in LONG_TEXT_FIELDS) maps to a real, bounded `@db.VarChar(n)`
+//      schema column with no matching SHORT_TEXT_MAX[type][key] === n entry.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const SCHEMA_PATH = join(repositoryRoot, 'prisma/schema.prisma')
+const MODEL_BUILDER_FIELDS_PATH = join(
+  repositoryRoot,
+  'stores/helpers/modelBuilderFields.ts',
+)
+const COMMIT_ROUTE_PATH = join(
+  repositoryRoot,
+  'server/api/model-builder/items/[id]/commit.post.ts',
+)
+
+// --- pickText's maxLen precedence -------------------------------------------
+
+const MAXLEN_ANCHOR = 'const maxLen ='
+const RETURN_ANCHOR = 'return trimmed.length > maxLen'
+
+// Extracts the `const maxLen = ...` expression (up to the following `return`
+// statement) so the precedence check is robust to reformatting/comments
+// around it, the same paren/anchor-matching approach used by
+// verifyModelBuilderCommitNameFieldGuard.ts's extractNameAssignment.
+export function extractMaxLenExpression(
+  commitRouteContent: string,
+): string | null {
+  const start = commitRouteContent.indexOf(MAXLEN_ANCHOR)
+  if (start === -1) return null
+  const end = commitRouteContent.indexOf(RETURN_ANCHOR, start)
+  if (end === -1) return null
+  return commitRouteContent
+    .slice(start + MAXLEN_ANCHOR.length, end)
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+// True if the expression gives SHORT_TEXT_MAX[type]?.[key] first priority,
+// independent of isLongText -- i.e. `SHORT_TEXT_MAX[type]?.[key] ?? ...`.
+// The pre-fix shape instead gated on isLongText first
+// (`isLongText ? LONG_TEXT_MAX : (SHORT_TEXT_MAX...`), which this correctly
+// rejects.
+export function maxLenPrefersShortTextMax(expression: string): boolean {
+  return /^SHORT_TEXT_MAX\[type\]\?\.\[key\]\s*\?\?/.test(expression)
+}
+
+// --- SHORT_TEXT_MAX / LONG_TEXT_FIELDS extraction ---------------------------
+
+// Finds the `const NAME: Partial<Record<SourceType, ...>> = { ... }` object
+// literal's raw inner body text.
+function extractOuterMapBody(content: string, constName: string): string {
+  const match = content.match(
+    new RegExp(`const ${constName}:[^=]*=\\s*\\{([\\s\\S]*?)\\n\\}\\n`),
+  )
+  if (!match) {
+    throw new Error(
+      `Could not find \`const ${constName}\` object literal in commit.post.ts` +
+        ' -- has its shape changed?',
+    )
+  }
+  return match[1]!
+}
+
+// SHORT_TEXT_MAX's per-model values are `Model: { field: n, ... }` object
+// literals.
+export function extractShortTextMax(
+  commitRouteContent: string,
+): Record<string, Record<string, number>> {
+  const body = extractOuterMapBody(commitRouteContent, 'SHORT_TEXT_MAX')
+  const result: Record<string, Record<string, number>> = {}
+  for (const m of body.matchAll(/(\w+):\s*\{([^{}]*)\}/g)) {
+    const fields: Record<string, number> = {}
+    for (const fieldMatch of m[2]!.matchAll(/(\w+):\s*(\d+)/g)) {
+      fields[fieldMatch[1]!] = Number(fieldMatch[2]!)
+    }
+    result[m[1]!] = fields
+  }
+  return result
+}
+
+// LONG_TEXT_FIELDS' per-model values are `Model: new Set([...])` calls, not
+// object literals -- a distinct shape from SHORT_TEXT_MAX's, so this parses
+// the body directly rather than sharing SHORT_TEXT_MAX's brace-chunking.
+export function extractLongTextFields(
+  commitRouteContent: string,
+): Record<string, string[]> {
+  const body = extractOuterMapBody(commitRouteContent, 'LONG_TEXT_FIELDS')
+  const result: Record<string, string[]> = {}
+  for (const m of body.matchAll(/(\w+):\s*new Set\(\[([^\]]*)\]\)/g)) {
+    result[m[1]!] = [...m[2]!.matchAll(/'(\w+)'/g)].map((n) => n[1]!)
+  }
+  return result
+}
+
+// --- MODEL_FIELDS prose extraction ------------------------------------------
+
+// Every field key marked `prose: true` per top-level MODEL_FIELDS model
+// (modelBuilderFields.ts), independent of field order within each model's
+// array and of array order between models.
+export function extractProseFields(
+  fieldsFileContent: string,
+): Record<string, string[]> {
+  const outerMatch = fieldsFileContent.match(
+    /export const MODEL_FIELDS: Record<string, ModelFieldSpec\[\]> = \{([\s\S]*?)\n\}\n/,
+  )
+  if (!outerMatch) {
+    throw new Error(
+      'Could not find MODEL_FIELDS object literal in modelBuilderFields.ts ' +
+        '-- has its shape changed?',
+    )
+  }
+  const body = outerMatch[1]!
+  const modelKeyMatches = [...body.matchAll(/^\s*(\w+):\s*\[/gm)]
+  if (!modelKeyMatches.length) {
+    throw new Error(
+      'Found MODEL_FIELDS but no per-model array entries inside it -- has ' +
+        'its shape changed?',
+    )
+  }
+
+  const result: Record<string, string[]> = {}
+  modelKeyMatches.forEach((match, index) => {
+    const start = match.index!
+    const end =
+      index + 1 < modelKeyMatches.length
+        ? modelKeyMatches[index + 1]!.index!
+        : body.length
+    const chunk = body.slice(start, end)
+    const proseKeys: string[] = []
+    for (const fieldMatch of chunk.matchAll(/\{[^{}]*\}/g)) {
+      const obj = fieldMatch[0]
+      if (!/prose:\s*true/.test(obj)) continue
+      const keyMatch = obj.match(/key:\s*'(\w+)'/)
+      if (keyMatch) proseKeys.push(keyMatch[1]!)
+    }
+    result[match[1]!] = proseKeys
+  })
+  return result
+}
+
+// --- schema VarChar width extraction -----------------------------------------
+
+function findModelBlock(schema: string, modelName: string): string | null {
+  const match = schema.match(new RegExp(`^model\\s+${modelName}\\s*\\{`, 'm'))
+  if (!match || match.index === undefined) return null
+  const start = match.index + match[0].length
+  const end = schema.indexOf('\n}', start)
+  if (end === -1) return null
+  return schema.slice(start, end)
+}
+
+// Field name -> declared `@db.VarChar(n)` width, for scalar columns on
+// `modelName`. A field with no such annotation (Text/LongText/no explicit
+// length) is omitted -- it has no bounded width for SHORT_TEXT_MAX to match.
+export function extractVarCharWidths(
+  schema: string,
+  modelName: string,
+): Record<string, number> {
+  const block = findModelBlock(schema, modelName)
+  if (!block) {
+    throw new Error(
+      `Could not find model ${modelName} in prisma/schema.prisma -- has it ` +
+        'been renamed?',
+    )
+  }
+  const widths: Record<string, number> = {}
+  for (const line of block.split('\n')) {
+    const match = line.match(/^\s*(\w+)\s+\S+.*@db\.VarChar\((\d+)\)/)
+    if (match) widths[match[1]!] = Number(match[2]!)
+  }
+  return widths
+}
+
+// --- combined check -----------------------------------------------------------
+
+export interface TruncationProblem {
+  model: string
+  field: string
+  schemaWidth: number
+  shortTextMaxValue: number | undefined
+}
+
+// For every model/field MODEL_FIELDS classifies as long-text (prose: true,
+// or listed in LONG_TEXT_FIELDS) that maps to a real, bounded VarChar schema
+// column, SHORT_TEXT_MAX[model][field] must exist and equal that column's
+// width -- otherwise pickText lets more characters through than the column
+// can actually hold.
+export function findTruncationProblems(
+  schema: string,
+  fieldsFileContent: string,
+  commitRouteContent: string,
+): TruncationProblem[] {
+  const proseFields = extractProseFields(fieldsFileContent)
+  const longTextFields = extractLongTextFields(commitRouteContent)
+  const shortTextMax = extractShortTextMax(commitRouteContent)
+
+  const problems: TruncationProblem[] = []
+
+  const models = new Set([
+    ...Object.keys(proseFields),
+    ...Object.keys(longTextFields),
+  ])
+
+  for (const model of models) {
+    const longTextKeys = new Set([
+      ...(proseFields[model] ?? []),
+      ...(longTextFields[model] ?? []),
+    ])
+    if (!longTextKeys.size) continue
+
+    const widths = extractVarCharWidths(schema, model)
+    for (const field of longTextKeys) {
+      const schemaWidth = widths[field]
+      if (schemaWidth === undefined) continue // Text/LongText -- unbounded enough
+
+      const override = shortTextMax[model]?.[field]
+      if (override !== schemaWidth) {
+        problems.push({
+          model,
+          field,
+          schemaWidth,
+          shortTextMaxValue: override,
+        })
+      }
+    }
+  }
+
+  return problems
+}
+
+function main(): void {
+  const schema = readFileSync(SCHEMA_PATH, 'utf8')
+  const fieldsFileContent = readFileSync(MODEL_BUILDER_FIELDS_PATH, 'utf8')
+  const commitRouteContent = readFileSync(COMMIT_ROUTE_PATH, 'utf8')
+
+  let failed = false
+
+  const maxLenExpr = extractMaxLenExpression(commitRouteContent)
+  if (maxLenExpr === null) {
+    failed = true
+    console.error(
+      "Could not find pickText's `const maxLen = ...` assignment in " +
+        'commit.post.ts -- has it been renamed, removed, or restructured? ' +
+        'If so, this guard (and the truncation bug it protects against) ' +
+        'needs to move with it.',
+    )
+  } else if (!maxLenPrefersShortTextMax(maxLenExpr)) {
+    failed = true
+    console.error(
+      "Model Builder commit text-truncation contract failed: pickText's " +
+        '`maxLen` no longer checks SHORT_TEXT_MAX[type]?.[key] first, ' +
+        'independent of the prose/long-text classification. A field marked ' +
+        '`prose: true` (or listed in LONG_TEXT_FIELDS) would silently take ' +
+        'LONG_TEXT_MAX (20000 chars) even when a narrower SHORT_TEXT_MAX ' +
+        'entry exists for it, making that entry dead code. ' +
+        `Got: \`${maxLenExpr}\``,
+    )
+  }
+
+  const problems = findTruncationProblems(
+    schema,
+    fieldsFileContent,
+    commitRouteContent,
+  )
+  if (problems.length) {
+    failed = true
+    console.error(
+      `Model Builder commit text-truncation contract failed: ${problems.length} ` +
+        'long-text field(s) map to a bounded VarChar schema column with no ' +
+        'matching SHORT_TEXT_MAX override:',
+    )
+    for (const problem of problems) {
+      const found =
+        problem.shortTextMaxValue === undefined
+          ? 'no SHORT_TEXT_MAX entry'
+          : `SHORT_TEXT_MAX = ${problem.shortTextMaxValue}`
+      console.error(
+        `- ${problem.model}.${problem.field} is @db.VarChar(${problem.schemaWidth}) ` +
+          `in prisma/schema.prisma but is classified as long-text in ` +
+          `modelBuilderFields.ts/commit.post.ts, and ${found} -- pickText ` +
+          `will let more characters through than the column can hold, ` +
+          'risking a silent truncation or a "Data too long for column" ' +
+          'write failure.',
+      )
+    }
+  }
+
+  if (failed) {
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder commit text-truncation contract passed: pickText checks ' +
+      'SHORT_TEXT_MAX ahead of the prose/long-text classification, and ' +
+      'every long-text-classified field with a bounded VarChar schema ' +
+      'column has a matching SHORT_TEXT_MAX override.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What changed

Cycle 33's suggested lead (a line-by-line pass of `CREATE_TARGETS`/`defaultFieldsTemplate` in `stores/helpers/modelBuilderFields.ts` / `modelBuilderRecipes.ts` against the Prisma schema) turned out to be clean — see "Investigated but not a bug" below. The pivot found a real, live bug in the neighboring commit path instead:

`server/api/model-builder/items/[id]/commit.post.ts`'s `pickText()` decides how many characters of a FIELDS_AND_PROMPTS value survive before being written to the DB. Its `maxLen` computation gated on `isLongText` **first**:

```ts
const maxLen = isLongText
  ? LONG_TEXT_MAX
  : (SHORT_TEXT_MAX[type]?.[key] ?? DEFAULT_TEXT_MAX)
```

Any field marked `prose: true` in `MODEL_FIELDS` (or listed in `LONG_TEXT_FIELDS`) always took the `isLongText` branch and got `LONG_TEXT_MAX` (20000 chars) **unconditionally** — silently ignoring any `SHORT_TEXT_MAX` override for that same field. That made the existing `SHORT_TEXT_MAX` entries for `Reward.flavorText` and `Dream.flavorText` (both real `VarChar(512)` columns, both marked `prose: true`) pure dead code: `pickText` would still let up to 20000 characters through to a 512-char column.

The same gap left `Bot.description`/`botIntro`/`userIntro`/`prompt` — real `VarChar(764)`/`VarChar(3000)` columns, three of them `NOT NULL` — with **no** `SHORT_TEXT_MAX` entry at all, on a live, reachable path: `Bot` is a real CREATE target via the `expand-narrator-bot`/`expand-manager-bot` relationship-expansion outputs. An AI-drafted or user-typed value past these widths risks a silent MySQL truncation or a "Data too long for column" write failure on a required column.

### Fix
1. `pickText`'s `maxLen` now checks `SHORT_TEXT_MAX[type]?.[key]` **first**, independent of the prose/long-text classification, falling back to `isLongText ? LONG_TEXT_MAX : DEFAULT_TEXT_MAX` only when no explicit override exists.
2. Added the missing `SHORT_TEXT_MAX.Bot` entries matching the real schema column widths: `description`/`personality`: 764, `botIntro`: 3000, `userIntro`/`prompt`: 764.

### New regression guard
Added `utils/scripts/verifyModelBuilderCommitTextTruncationGuard.ts` (+ `.test.ts`), following this repo's existing `verifyModelBuilder*Guard.ts` static-analysis pattern:
- Asserts `pickText`'s `maxLen` expression gives `SHORT_TEXT_MAX` precedence over the prose/long-text classification (catches a regression back to the original bug shape).
- Walks `prisma/schema.prisma`, `MODEL_FIELDS`, and `SHORT_TEXT_MAX`/`LONG_TEXT_FIELDS`, and fails if any field classified as long-text maps to a bounded `@db.VarChar(n)` schema column without a matching `SHORT_TEXT_MAX` entry equal to `n` (catches both a missing override and a drifted one).

Wired into `package.json` (`test:model-builder-commit-text-truncation-guard[-selftest]`) and `.github/workflows/contract-tests.yml`.

## Investigated but not a bug

Traced `CREATE_TARGETS`, `resolveTargetModel`, and `defaultFieldsTemplate` end to end against `prisma/schema.prisma`:
- All 6 `CREATE_TARGETS` entries (`expand-characters`→Character, `expand-rewards`/`expand-signature-rewards`→Reward, `expand-scenarios`→Scenario, `expand-narrator-bot`/`expand-manager-bot`→Bot) resolve to models that exist with matching fields.
- `resolveTargetModel`'s dispatch (`CREATE_TARGETS[outputKey] ?? sourceType`) never falls through to a nonexistent model, and every CREATE output key has an entry.
- Cross-checked every `MODEL_FIELDS` field (Character/Bot/Reward/Dream/Scenario/Project/Facet) against its Prisma column: names, enum choice sets (`RARITY`, `RewardType`), and required/default fields all match — this is where the real bug above was found instead, in the truncation-length side of that same cross-check.
- Did separately notice `DREAM_TYPES` in `modelBuilderFields.ts` (used for `Dream.dreamType` choices) is missing `PROMPTBOT`/`NARRATOR`, which the canonical `stores/helpers/dreamHelper.ts`'s `CREATABLE_DREAM_TYPES` includes — but `Dream` is never actually reachable as a CREATE or UPDATE target through the Model Builder's current recipe wiring (its only recipes are `art-upgrade`, ASSET_ONLY-only, and `relationship-expansion`, which only *creates other* models from a Dream source), so this has zero live user-facing impact today. Flagging for a future cycle rather than fixing now, since it's currently dead code.

## Verification
- `npx tsx utils/scripts/verifyModelBuilderCommitTextTruncationGuard.test.ts` — new self-test, passes
- `npx tsx utils/scripts/verifyModelBuilderCommitTextTruncationGuard.ts` — new guard against real repo files, passes
- All 123 `test:model-builder-*` npm scripts run individually — all pass
- `npx vue-tsc --noEmit` (repo-wide) — clean, exit 0
- `npx eslint` on touched files — clean
- `npx prettier --check` on touched files — clean
- `git status --porcelain` shows only the intended files: `.github/workflows/contract-tests.yml`, `package.json`, `server/api/model-builder/items/[id]/commit.post.ts`, and the two new guard files

Closes conductor task model-builder/t-029 cycle 33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016G9vsQVTXxAYEkboUg9SHi

---
_Generated by [Claude Code](https://claude.ai/code/session_016G9vsQVTXxAYEkboUg9SHi)_