### PR TITLE
feat(brainstorm): add Scenario entry point into brainstorm variations (brainstorm/t-027)

### DIFF
--- a/.github/workflows/brainstorm-object-entry-links-contract.yml
+++ b/.github/workflows/brainstorm-object-entry-links-contract.yml
@@ -7,6 +7,7 @@ on:
       - '.github/workflows/brainstorm-object-entry-links-contract.yml'
       - 'components/brainstorm/**'
       - 'components/characters/character-manager.vue'
+      - 'components/scenarios/scenario-manager.vue'
       - 'utils/scripts/verifyBrainstormObjectEntryLinks.mjs'
   pull_request:
     branches: [main]
@@ -14,6 +15,7 @@ on:
       - '.github/workflows/brainstorm-object-entry-links-contract.yml'
       - 'components/brainstorm/**'
       - 'components/characters/character-manager.vue'
+      - 'components/scenarios/scenario-manager.vue'
       - 'utils/scripts/verifyBrainstormObjectEntryLinks.mjs'
   workflow_dispatch:
 
@@ -26,7 +28,7 @@ concurrency:
 
 jobs:
   contract:
-    name: Character -> Brainstorm object-entry contract
+    name: Character/Scenario -> Brainstorm object-entry contract
     runs-on: ubuntu-latest
     timeout-minutes: 5
 

--- a/components/scenarios/scenario-manager.vue
+++ b/components/scenarios/scenario-manager.vue
@@ -25,6 +25,15 @@
             <Icon name="kind-icon:book-open" class="size-4" />
             <span class="hidden sm:inline">Start a story with this</span>
           </button>
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm rounded-xl"
+            title="Brainstorm variations grounded in this Scenario"
+            @click="startBrainstormWithScenario"
+          >
+            <Icon name="kind-icon:brain" class="size-4" />
+            <span class="hidden sm:inline">Brainstorm variations</span>
+          </button>
         </div>
         <scenario-interact class="h-full min-h-0 flex-1 overflow-hidden" />
       </div>
@@ -116,6 +125,19 @@ function startStoryWithScenario(): void {
   const slug = scenarioStore.selectedScenario?.slug
   if (!slug) return
   void navigateTo({ path: '/storybook', query: { scenario: slug } })
+}
+
+function startBrainstormWithScenario(): void {
+  const scenario = scenarioStore.selectedScenario
+  if (!scenario?.id) return
+  void navigateTo({
+    path: '/brainstorm',
+    query: {
+      source: 'scenario',
+      sourceId: String(scenario.id),
+      intent: `Generate premise, plot-twist, and setting variations for "${scenario.title || 'this Scenario'}" that preserve its canonical tone.`,
+    },
+  })
 }
 
 async function loadManagerData(force = false) {

--- a/utils/scripts/verifyBrainstormObjectEntryLinks.mjs
+++ b/utils/scripts/verifyBrainstormObjectEntryLinks.mjs
@@ -29,6 +29,7 @@ function includesAll(path, values) {
 }
 
 const characterManagerPath = 'components/characters/character-manager.vue'
+const scenarioManagerPath = 'components/scenarios/scenario-manager.vue'
 const brainstormManagerPath = 'components/brainstorm/brainstorm-manager.vue'
 
 includesAll(characterManagerPath, [
@@ -37,6 +38,17 @@ includesAll(characterManagerPath, [
   "path: '/brainstorm'",
   "source: 'character'",
   'sourceId: String(character.id)',
+])
+
+// brainstorm/t-027: Scenario is the second surface to wire into the same
+// seedFromQuery() contract -- its BRAINSTORM_SOURCE_ADAPTERS entry already
+// existed (brainstorm/t-014) with no UI entry point driving traffic to it.
+includesAll(scenarioManagerPath, [
+  'startBrainstormWithScenario',
+  '@click="startBrainstormWithScenario"',
+  "path: '/brainstorm'",
+  "source: 'scenario'",
+  'sourceId: String(scenario.id)',
 ])
 
 includesAll(brainstormManagerPath, [


### PR DESCRIPTION
### Task
brainstorm/t-027: Evaluate Brainstorm entry points for Prompt/Reward/Scenario/Project/art surfaces (kind: software)

### What changed / what I produced
- `scenario-manager.vue`: added a "Brainstorm variations" button in the Scenario detail panel (right next to the existing "Start a story with this" button), mirroring `character-manager.vue`'s `startBrainstormWithCharacter` pattern exactly — navigates to `/brainstorm?source=scenario&sourceId=<id>&intent=<text>`. Scenario's `BRAINSTORM_SOURCE_ADAPTERS` entry (brainstorm/t-014) already existed with no UI entry point driving traffic to it; this closes that gap, the cheapest of the remaining surfaces per the task's own note.
- `verifyBrainstormObjectEntryLinks.mjs`: extended the existing textual contract guard with a Scenario block. No new `brainstorm-manager.vue` assertions needed since `seedFromQuery()` is already generic over `modelType`.
- `brainstorm-object-entry-links-contract.yml`: added `components/scenarios/scenario-manager.vue` to the workflow's path filters so future changes to it actually trigger this contract check (it only watched `character-manager.vue` before).

Prompt/Reward/Project were evaluated per the task's broader scope:
- **Reward** (`reward-manager.vue` / `reward-interact.vue`) and **Project** (`conductor-page.vue`) both have a clear existing detail-panel home a similar button could slot into in a future slice.
- **Prompt** has no standalone detail/CRUD surface yet (`selectedPrompt` is only referenced incidentally elsewhere) — no natural place to attach a button until one exists.

Left both as follow-up rather than forcing a button onto an ill-fitting surface, per this task's own "one focused entry point per surface where it adds real value, not a button on every card" scoping.

### How I verified
- `node utils/scripts/verifyBrainstormObjectEntryLinks.mjs` — passes (new Scenario assertions included)
- `npm run test:brainstorm-source-adapters` — passes, no regression
- `npm run test:brainstorm-source-context` — passes, no regression
- `npx eslint` on the 2 touched JS/Vue files — clean
- `npx prettier --check` on all 3 touched files — clean
- `npx vue-tsc --noEmit` repo-wide — clean, exit 0
- `git status --porcelain` shows exactly the 3 intended files

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Reward (`reward-manager.vue`) is the next-cheapest surface: it already has a detail/activity view (`reward-encounter.vue`) via `isInteractMode`, it just needs a `v-if="rewardStore.selectedReward"` gating div added at the manager level (Character/Scenario both already have one) before a button can slot in the same way.


---
_Generated by [Claude Code](https://claude.ai/code/session_014yyGPYUd4fwEHUKj541HV5)_