### PR TITLE
fix(model-builder): source Dream-type choices from canonical dreamHelper (model-builder/t-029 cycle 34)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -437,6 +437,12 @@ jobs:
       - name: Model Builder commit text-truncation guard contract
         run: npm run test:model-builder-commit-text-truncation-guard
 
+      - name: Model Builder Dream-type choices guard checker self-test
+        run: npm run test:model-builder-dream-type-choices-guard-selftest
+
+      - name: Model Builder Dream-type choices guard contract
+        run: npm run test:model-builder-dream-type-choices-guard
+
       - name: Model Builder commit stale-snapshot guard checker self-test
         run: npm run test:model-builder-commit-stale-snapshot-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -231,6 +231,8 @@
     "test:model-builder-commit-name-field-guard": "tsx utils/scripts/verifyModelBuilderCommitNameFieldGuard.ts",
     "test:model-builder-commit-text-truncation-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitTextTruncationGuard.test.ts",
     "test:model-builder-commit-text-truncation-guard": "tsx utils/scripts/verifyModelBuilderCommitTextTruncationGuard.ts",
+    "test:model-builder-dream-type-choices-guard-selftest": "tsx utils/scripts/verifyModelBuilderDreamTypeChoicesGuard.test.ts",
+    "test:model-builder-dream-type-choices-guard": "tsx utils/scripts/verifyModelBuilderDreamTypeChoicesGuard.ts",
     "test:model-builder-commit-stale-snapshot-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.test.ts",
     "test:model-builder-commit-stale-snapshot-guard": "tsx utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.ts",
     "test:model-builder-commit-target-persistence-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitTargetPersistenceGuard.test.ts",

--- a/stores/helpers/modelBuilderFields.ts
+++ b/stores/helpers/modelBuilderFields.ts
@@ -6,6 +6,7 @@
 // *Cards). Used to auto-fill the FIELDS stage and to ground AI drafting so a
 // created record comes out complete and specific (a Reward gets a real
 // type/rarity/effect) instead of a generic sentence.
+import { CREATABLE_DREAM_TYPES } from '@/stores/helpers/dreamHelper'
 import type { SourceTypeKey } from '@/stores/helpers/modelBuilderRecipes'
 import { DAISY_CARD_THEMES } from '@/utils/entityTheme'
 
@@ -22,16 +23,15 @@ export interface ModelFieldSpec {
 const RARITY = ['COMMON', 'UNCOMMON', 'RARE', 'EPIC', 'LEGENDARY', 'MYTHIC']
 const REWARD_TYPES = ['ITEM', 'PET', 'SKILL', 'POWER', 'MAGIC', 'FAVOR']
 const BOT_TYPES = ['CHATBOT', 'PROMPTBOT', 'ARTBOT']
-const DREAM_TYPES = [
-  'ART',
-  'BRAINSTORM',
-  'CHARACTER',
-  'REWARD',
-  'SCENARIO',
-  'LOCATION',
-  'PITCH',
-  'WISH',
-]
+// Sourced from dreamHelper.ts's CREATABLE_DREAM_TYPES (model-builder/t-029,
+// cycle 34) rather than a hand-duplicated literal list -- a prior
+// hand-duplicated copy here silently omitted PROMPTBOT and NARRATOR, both
+// real, user-creatable DreamType values dreamHelper.ts already treats as
+// normal. Currently zero live impact (Dream is not a CREATE_TARGETS output,
+// so this choices list only backs an as-yet-unreachable dreamType field
+// spec) but importing the canonical list instead of re-typing it removes the
+// drift class entirely rather than just patching this one instance of it.
+const DREAM_TYPES: string[] = [...CREATABLE_DREAM_TYPES]
 
 // Facet.kind is a compatibility column. Model Builder accepts the authoritative
 // FacetProfile taxonomy and the commit route derives kind internally.

--- a/utils/scripts/verifyModelBuilderDreamTypeChoicesGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderDreamTypeChoicesGuard.test.ts
@@ -1,0 +1,77 @@
+// /utils/scripts/verifyModelBuilderDreamTypeChoicesGuard.test.ts
+//
+// Regression test for verifyModelBuilderDreamTypeChoicesGuard.ts
+// (model-builder/t-029, cycle 34). Exercises findDreamTypeChoicesProblem
+// against synthetic modelBuilderFields.ts fixtures covering: the pre-fix
+// hand-typed literal (missing both the import and the spread assignment),
+// the fixed shape (import + spread present), and two partial-drift shapes
+// (import present but assignment reverted to a literal; assignment present
+// but the import removed/renamed) that a careless future edit could produce.
+import assert from 'node:assert/strict'
+
+import { findDreamTypeChoicesProblem } from './verifyModelBuilderDreamTypeChoicesGuard.js'
+
+const PRE_FIX_HARDCODED = `
+const DREAM_TYPES = [
+  'ART',
+  'BRAINSTORM',
+  'CHARACTER',
+  'REWARD',
+  'SCENARIO',
+  'LOCATION',
+  'PITCH',
+  'WISH',
+]
+`
+
+const preFixProblem = findDreamTypeChoicesProblem(PRE_FIX_HARDCODED)
+assert.ok(
+  preFixProblem,
+  'expected the pre-fix hand-typed literal to be flagged',
+)
+assert.equal(preFixProblem!.missingImport, true)
+assert.equal(preFixProblem!.missingSpreadAssignment, true)
+
+const FIXED = `
+import { CREATABLE_DREAM_TYPES } from '@/stores/helpers/dreamHelper'
+
+const DREAM_TYPES: string[] = [...CREATABLE_DREAM_TYPES]
+`
+
+assert.equal(
+  findDreamTypeChoicesProblem(FIXED),
+  null,
+  'expected the fixed import + spread shape to pass',
+)
+
+const MISSING_IMPORT_ONLY = `
+const DREAM_TYPES: string[] = [...CREATABLE_DREAM_TYPES]
+`
+
+const missingImportProblem = findDreamTypeChoicesProblem(MISSING_IMPORT_ONLY)
+assert.ok(
+  missingImportProblem,
+  'expected a spread assignment with no matching import to be flagged',
+)
+assert.equal(missingImportProblem!.missingImport, true)
+assert.equal(missingImportProblem!.missingSpreadAssignment, false)
+
+const REVERTED_ASSIGNMENT_ONLY = `
+import { CREATABLE_DREAM_TYPES } from '@/stores/helpers/dreamHelper'
+
+const DREAM_TYPES = ['ART', 'BRAINSTORM']
+`
+
+const revertedProblem = findDreamTypeChoicesProblem(REVERTED_ASSIGNMENT_ONLY)
+assert.ok(
+  revertedProblem,
+  'expected an import with a reverted hand-typed assignment to be flagged',
+)
+assert.equal(revertedProblem!.missingImport, false)
+assert.equal(revertedProblem!.missingSpreadAssignment, true)
+
+console.log(
+  'Model Builder Dream-type choices guard checker verified: passes the ' +
+    'import + spread-from-canonical shape, flags the pre-fix hand-typed ' +
+    'literal, and flags either half missing independently.',
+)

--- a/utils/scripts/verifyModelBuilderDreamTypeChoicesGuard.ts
+++ b/utils/scripts/verifyModelBuilderDreamTypeChoicesGuard.ts
@@ -1,0 +1,99 @@
+// /utils/scripts/verifyModelBuilderDreamTypeChoicesGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 34). modelBuilderFields.ts's
+// MODEL_FIELDS.Dream.dreamType field spec offers a `choices` list for the
+// Dream model's dreamType enum. Before this fix that list was a hand-typed
+// literal array that had drifted from dreamHelper.ts's canonical
+// CREATABLE_DREAM_TYPES (itself `as const satisfies readonly
+// PrismaDreamType[]`, i.e. checked against the real Prisma DreamType enum):
+// it was missing PROMPTBOT and NARRATOR, two DreamType values dreamHelper.ts
+// already treats as normal, user-creatable dream types.
+//
+// Currently zero live impact -- Dream is never a CREATE_TARGETS output (see
+// verifyModelBuilderLinkCoverage.ts), so this choices list only backs an
+// as-yet-unreachable field spec -- but the fix removes the drift class
+// itself: modelBuilderFields.ts's local DREAM_TYPES now spreads
+// dreamHelper.ts's canonical CREATABLE_DREAM_TYPES instead of re-typing the
+// enum values, so the two can no longer independently drift.
+//
+// This guard fails if modelBuilderFields.ts ever goes back to a
+// hand-typed/hardcoded DREAM_TYPES literal instead of sourcing it from
+// dreamHelper.ts -- i.e. it protects the *shape* of the fix, not just a
+// point-in-time value comparison (a value-set comparison would pass even for
+// a second hand-duplicated list that happens to still match today, right up
+// until the next time either list is edited alone).
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const MODEL_BUILDER_FIELDS_PATH = join(
+  repositoryRoot,
+  'stores/helpers/modelBuilderFields.ts',
+)
+
+const IMPORT_PATTERN =
+  /import\s*\{\s*CREATABLE_DREAM_TYPES\s*\}\s*from\s*['"]@\/stores\/helpers\/dreamHelper['"]/
+const ASSIGNMENT_PATTERN =
+  /const DREAM_TYPES(?:\s*:[^=]*)?=\s*\[\s*\.\.\.CREATABLE_DREAM_TYPES\s*\]/
+
+export interface DreamTypeChoicesProblem {
+  missingImport: boolean
+  missingSpreadAssignment: boolean
+}
+
+// null when modelBuilderFields.ts both imports the canonical
+// CREATABLE_DREAM_TYPES from dreamHelper.ts and assigns its local
+// DREAM_TYPES as a spread of it; a problem object otherwise.
+export function findDreamTypeChoicesProblem(
+  fieldsFileContent: string,
+): DreamTypeChoicesProblem | null {
+  const missingImport = !IMPORT_PATTERN.test(fieldsFileContent)
+  const missingSpreadAssignment = !ASSIGNMENT_PATTERN.test(fieldsFileContent)
+  if (!missingImport && !missingSpreadAssignment) return null
+  return { missingImport, missingSpreadAssignment }
+}
+
+function main(): void {
+  const fieldsFileContent = readFileSync(MODEL_BUILDER_FIELDS_PATH, 'utf8')
+  const problem = findDreamTypeChoicesProblem(fieldsFileContent)
+
+  if (problem) {
+    process.exitCode = 1
+    console.error(
+      'Model Builder Dream-type choices contract failed: ' +
+        "modelBuilderFields.ts's local DREAM_TYPES is no longer sourced from " +
+        "dreamHelper.ts's canonical CREATABLE_DREAM_TYPES.",
+    )
+    if (problem.missingImport) {
+      console.error(
+        '- expected `import { CREATABLE_DREAM_TYPES } from ' +
+          "'@/stores/helpers/dreamHelper'` in modelBuilderFields.ts",
+      )
+    }
+    if (problem.missingSpreadAssignment) {
+      console.error(
+        '- expected `const DREAM_TYPES = [...CREATABLE_DREAM_TYPES]` (or with a ' +
+          'type annotation) in modelBuilderFields.ts',
+      )
+    }
+    console.error(
+      'A hand-typed literal list here can silently drift from the real ' +
+        'Prisma DreamType enum -- see cycle 34 (PROMPTBOT/NARRATOR were ' +
+        'missing) for exactly this failure mode.',
+    )
+    return
+  }
+
+  console.log(
+    "Model Builder Dream-type choices contract passed: modelBuilderFields.ts's " +
+      "DREAM_TYPES is sourced from dreamHelper.ts's canonical " +
+      'CREATABLE_DREAM_TYPES, not a hand-typed literal.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What

`modelBuilderFields.ts`'s `MODEL_FIELDS.Dream.dreamType` field spec offered a hand-typed `DREAM_TYPES` literal that had drifted from `dreamHelper.ts`'s canonical `CREATABLE_DREAM_TYPES` (itself `as const satisfies readonly PrismaDreamType[]`, i.e. checked against the real Prisma `DreamType` enum): it was missing `PROMPTBOT` and `NARRATOR`, both real, user-creatable dream types `dreamHelper.ts` already treats as normal.

This closes conductor `model-builder/t-029` cycle 34, following up on cycle 33's suggested lead.

## Impact

Currently zero live impact — `Dream` is never a `CREATE_TARGETS` output (confirmed by tracing `CREATE_TARGETS` in `modelBuilderFields.ts` and `Dream`'s `recipes: ['art-upgrade', 'relationship-expansion']` in `modelBuilderRecipes.ts`, neither of which route through `MODEL_FIELDS.Dream`), so this choices list only backs an as-yet-unreachable field spec. Worth fixing now, before Dream becomes a reachable CREATE/UPDATE target in a future cycle.

## Changes

- **`stores/helpers/modelBuilderFields.ts`** — local `DREAM_TYPES` now spreads `dreamHelper.ts`'s canonical `CREATABLE_DREAM_TYPES` import instead of re-typing the enum values, removing the drift class rather than just patching this one instance of it.
- **`utils/scripts/verifyModelBuilderDreamTypeChoicesGuard.ts` + `.test.ts`** (new) — regression guard that fails if `modelBuilderFields.ts` ever reverts to a hand-typed/hardcoded `DREAM_TYPES` literal instead of sourcing it from `dreamHelper.ts`.
- **`package.json` + `contract-tests.yml`** — wired the new guard's selftest + contract into CI.

## Verification

- New guard selftest + contract pass
- All 125 `test:model-builder-*` npm scripts pass (no regressions)
- `vue-tsc --noEmit` clean repo-wide
- `eslint`/`prettier --check` clean on touched files
- `git status --porcelain` shows exactly the 5 intended files


---
_Generated by [Claude Code](https://claude.ai/code/session_01X5pbL7qJjZEDesCMLjkwaC)_