### PR TITLE
fix(model-builder): cap Scenario.title to its real 191-char column width (t-029 cycle 35)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -437,6 +437,12 @@ jobs:
       - name: Model Builder commit text-truncation guard contract
         run: npm run test:model-builder-commit-text-truncation-guard
 
+      - name: Model Builder commit name-width guard checker self-test
+        run: npm run test:model-builder-commit-name-width-guard-selftest
+
+      - name: Model Builder commit name-width guard contract
+        run: npm run test:model-builder-commit-name-width-guard
+
       - name: Model Builder Dream-type choices guard checker self-test
         run: npm run test:model-builder-dream-type-choices-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -231,6 +231,8 @@
     "test:model-builder-commit-name-field-guard": "tsx utils/scripts/verifyModelBuilderCommitNameFieldGuard.ts",
     "test:model-builder-commit-text-truncation-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitTextTruncationGuard.test.ts",
     "test:model-builder-commit-text-truncation-guard": "tsx utils/scripts/verifyModelBuilderCommitTextTruncationGuard.ts",
+    "test:model-builder-commit-name-width-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitNameWidthGuard.test.ts",
+    "test:model-builder-commit-name-width-guard": "tsx utils/scripts/verifyModelBuilderCommitNameWidthGuard.ts",
     "test:model-builder-dream-type-choices-guard-selftest": "tsx utils/scripts/verifyModelBuilderDreamTypeChoicesGuard.test.ts",
     "test:model-builder-dream-type-choices-guard": "tsx utils/scripts/verifyModelBuilderDreamTypeChoicesGuard.ts",
     "test:model-builder-commit-stale-snapshot-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.test.ts",

--- a/server/api/model-builder/items/[id]/commit.post.ts
+++ b/server/api/model-builder/items/[id]/commit.post.ts
@@ -95,6 +95,29 @@ const LONG_TEXT_FIELDS: Partial<Record<SourceType, Set<string>>> = {
 const NUMERIC_FIELDS: Partial<Record<SourceType, Set<string>>> = {
   Scenario: new Set(['difficulty']),
 }
+// name/title column widths per live CREATE target (prisma/schema.prisma).
+// The record name/title is never `prose`-classified in MODEL_FIELDS, so it
+// falls outside pickText/SHORT_TEXT_MAX entirely -- this file previously
+// applied one flat 255-char cap to every target regardless of its actual
+// column width. That overshoots Scenario.title, which is `String` with no
+// `@db.VarChar` override and therefore Prisma's MySQL default of
+// VARCHAR(191) NOT NULL (confirmed in
+// prisma/migrations/00000000000000_squashed/migration.sql). A Scenario
+// title of 192-255 chars -- reachable via the batch editor's "Set a field
+// on all N" or the per-item fieldsDraft textarea, neither of which has a
+// maxlength -- passed the old cap untouched and failed the whole commit
+// transaction at INSERT time ("Data too long for column 'title'" in MySQL
+// strict mode, or a silent truncation otherwise): the same drift class
+// SHORT_TEXT_MAX exists to prevent (cycle 33), just reached through a field
+// that classification never covers. Character/Reward/Bot.name are all
+// VARCHAR(256), so 255 remains correct for them; 255 stays the fallback for
+// any future CREATE_TARGETS entry not listed here.
+const NAME_MAX: Partial<Record<SourceType, number>> = {
+  Character: 256,
+  Reward: 256,
+  Bot: 256,
+  Scenario: 191,
+}
 
 // Delegates the actual line-splitting to the shared, schema-aware splitter
 // in modelBuilderFields.ts (used by the client too) rather than maintaining
@@ -818,14 +841,15 @@ export default defineEventHandler(async (event) => {
     // and per-item panel both surface as the record's actual name/title. Honor
     // whatever the user (or AI drafter) put there before falling back to the
     // pitch's first line -- otherwise a deliberately-typed name is silently
-    // discarded in favor of pitch text on commit.
+    // discarded in favor of pitch text on commit. The cap is per-target width
+    // (NAME_MAX) rather than one flat number -- see NAME_MAX's comment.
     const name = (
       fieldMap.name ||
       fieldMap.title ||
       item.pitch?.split('\n')[0]?.trim() ||
       item.label ||
       'Untitled'
-    ).slice(0, 255)
+    ).slice(0, NAME_MAX[fieldModelType] ?? 255)
 
     if (item.idempotencyKey) {
       return {

--- a/utils/scripts/verifyModelBuilderCommitNameWidthGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderCommitNameWidthGuard.test.ts
@@ -1,0 +1,168 @@
+// /utils/scripts/verifyModelBuilderCommitNameWidthGuard.test.ts
+//
+// Regression test for the pure functions in
+// verifyModelBuilderCommitNameWidthGuard.ts (model-builder/t-029, cycle 35).
+// Exercises extraction/comparison logic against synthetic fixtures rather
+// than the real repo files, so it stays fast and independent of future edits
+// to the real schema/route/fields files (same convention as
+// verifyModelBuilderCommitTextTruncationGuard.test.ts).
+import assert from 'node:assert/strict'
+
+import {
+  extractCreateTargetModels,
+  extractIdentifierWidth,
+  extractNameMax,
+  findNameWidthProblems,
+  nameCapUsesNameMax,
+} from './verifyModelBuilderCommitNameWidthGuard.js'
+
+const FIELDS_FIXTURE = `
+export const CREATE_TARGETS: Record<string, SourceTypeKey> = {
+  'expand-characters': 'Character',
+  'expand-signature-rewards': 'Reward',
+  'expand-rewards': 'Reward',
+  'expand-scenarios': 'Scenario',
+  'expand-manager-bot': 'Bot',
+  'expand-narrator-bot': 'Bot',
+}
+`
+
+const SCHEMA_FIXTURE = `
+model Bot {
+  id                   Int                    @id @default(autoincrement())
+  name                 String                 @db.VarChar(256)
+}
+
+model Character {
+  id                   Int                    @id @default(autoincrement())
+  name                 String                 @db.VarChar(256)
+}
+
+model Reward {
+  id             Int           @id @default(autoincrement())
+  name           String        @db.VarChar(256)
+}
+
+model Scenario {
+  id                   Int                   @id @default(autoincrement())
+  title                String
+  description          String                @db.Text
+}
+`
+
+const FIXED_COMMIT_FIXTURE = `
+const NAME_MAX: Partial<Record<SourceType, number>> = {
+  Character: 256,
+  Reward: 256,
+  Bot: 256,
+  Scenario: 191,
+}
+    ).slice(0, NAME_MAX[fieldModelType] ?? 255)
+`
+
+const BUGGY_COMMIT_FIXTURE = `
+const NAME_MAX: Partial<Record<SourceType, number>> = {
+  Character: 256,
+  Reward: 256,
+  Bot: 256,
+  Scenario: 191,
+}
+    ).slice(0, 255)
+`
+
+const MISSING_ENTRY_COMMIT_FIXTURE = `
+const NAME_MAX: Partial<Record<SourceType, number>> = {
+  Character: 256,
+  Reward: 256,
+  Bot: 256,
+}
+    ).slice(0, NAME_MAX[fieldModelType] ?? 255)
+`
+
+function run(): void {
+  // --- extraction sanity ---
+  const models = extractCreateTargetModels(FIELDS_FIXTURE)
+  assert.deepEqual(
+    [...models].sort(),
+    ['Bot', 'Character', 'Reward', 'Scenario'],
+    `expected exactly the four live CREATE targets, got: ${JSON.stringify(models)}`,
+  )
+
+  const nameMax = extractNameMax(FIXED_COMMIT_FIXTURE)
+  assert.deepEqual(nameMax, {
+    Character: 256,
+    Reward: 256,
+    Bot: 256,
+    Scenario: 191,
+  })
+
+  assert.equal(extractIdentifierWidth(SCHEMA_FIXTURE, 'Character'), 256)
+  assert.equal(extractIdentifierWidth(SCHEMA_FIXTURE, 'Bot'), 256)
+  assert.equal(extractIdentifierWidth(SCHEMA_FIXTURE, 'Reward'), 256)
+  // Scenario.title has no @db.VarChar override -> Prisma's implicit MySQL
+  // default of 191.
+  assert.equal(extractIdentifierWidth(SCHEMA_FIXTURE, 'Scenario'), 191)
+
+  // --- cap-shape check ---
+  assert.equal(nameCapUsesNameMax(FIXED_COMMIT_FIXTURE), true)
+  assert.equal(
+    nameCapUsesNameMax(BUGGY_COMMIT_FIXTURE),
+    false,
+    'a bare `.slice(0, 255)` with no NAME_MAX lookup should fail this check',
+  )
+
+  // --- combined check: fixed fixture passes ---
+  const fixedProblems = findNameWidthProblems(
+    SCHEMA_FIXTURE,
+    FIELDS_FIXTURE,
+    FIXED_COMMIT_FIXTURE,
+  )
+  assert.deepEqual(
+    fixedProblems,
+    [],
+    `expected the fixed fixture to have no problems, got: ${JSON.stringify(fixedProblems)}`,
+  )
+
+  // --- combined check: pre-fix bug (flat 255 for Scenario) is caught ---
+  // Reuses FIXED_COMMIT_FIXTURE's NAME_MAX (which is already correct) but
+  // simulates the pre-fix world by checking a NAME_MAX that still claims 255
+  // for Scenario, the exact real bug this guard exists to catch.
+  const PRE_FIX_COMMIT_FIXTURE = FIXED_COMMIT_FIXTURE.replace(
+    'Scenario: 191,',
+    'Scenario: 255,',
+  )
+  const preFixProblems = findNameWidthProblems(
+    SCHEMA_FIXTURE,
+    FIELDS_FIXTURE,
+    PRE_FIX_COMMIT_FIXTURE,
+  )
+  assert.equal(
+    preFixProblems.length,
+    1,
+    `expected exactly one problem (Scenario), got: ${JSON.stringify(preFixProblems)}`,
+  )
+  assert.equal(preFixProblems[0]!.model, 'Scenario')
+  assert.equal(preFixProblems[0]!.schemaWidth, 191)
+  assert.equal(preFixProblems[0]!.nameMaxValue, 255)
+
+  // --- combined check: a live target missing from NAME_MAX entirely ---
+  const missingEntryProblems = findNameWidthProblems(
+    SCHEMA_FIXTURE,
+    FIELDS_FIXTURE,
+    MISSING_ENTRY_COMMIT_FIXTURE,
+  )
+  assert.equal(
+    missingEntryProblems.length,
+    1,
+    `expected exactly one problem (Scenario missing), got: ${JSON.stringify(missingEntryProblems)}`,
+  )
+  assert.equal(missingEntryProblems[0]!.model, 'Scenario')
+  assert.equal(missingEntryProblems[0]!.nameMaxValue, undefined)
+
+  console.log(
+    'Model Builder commit name-width guard self-test passed: extraction, ' +
+      'cap-shape, and combined-problem checks all behave as expected.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderCommitNameWidthGuard.ts
+++ b/utils/scripts/verifyModelBuilderCommitNameWidthGuard.ts
@@ -1,0 +1,264 @@
+// /utils/scripts/verifyModelBuilderCommitNameWidthGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 35). commit.post.ts's CREATE
+// path computes the new record's name/title once, then applies a single
+// length cap before writing it:
+//   const name = ( ... ).slice(0, NAME_MAX[fieldModelType] ?? 255)
+//
+// Before this fix, that cap was a flat `.slice(0, 255)` regardless of the
+// actual CREATE target. That overshoots Scenario.title, which is `String`
+// with no `@db.VarChar` override in prisma/schema.prisma and therefore
+// Prisma's MySQL default column width of VARCHAR(191) NOT NULL. A Scenario
+// title of 192-255 characters -- reachable via the batch editor's "Set a
+// field on all N" or the per-item fieldsDraft textarea, neither of which has
+// a maxlength -- passed the old flat cap untouched and failed the whole
+// commit transaction at INSERT time ("Data too long for column 'title'" in
+// MySQL strict mode, or a silent truncation otherwise). This is the same
+// drift class verifyModelBuilderCommitTextTruncationGuard.ts already
+// protects against for prose/long-text fields, just for the record
+// name/title, which is never `prose`-classified in MODEL_FIELDS and so falls
+// entirely outside that guard's scope.
+//
+// This walks prisma/schema.prisma, modelBuilderFields.ts's live
+// CREATE_TARGETS map, and commit.post.ts's NAME_MAX map, and fails if any
+// live CREATE target's NAME_MAX entry doesn't match its actual identifier
+// column's real width (explicit `@db.VarChar(n)`, or Prisma's implicit
+// MySQL default of 191 for an unannotated `String` column) -- or if a live
+// CREATE target has no NAME_MAX entry at all, silently falling back to the
+// 255 default regardless of whether that's correct.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const SCHEMA_PATH = join(repositoryRoot, 'prisma/schema.prisma')
+const MODEL_BUILDER_FIELDS_PATH = join(
+  repositoryRoot,
+  'stores/helpers/modelBuilderFields.ts',
+)
+const COMMIT_ROUTE_PATH = join(
+  repositoryRoot,
+  'server/api/model-builder/items/[id]/commit.post.ts',
+)
+
+// Prisma's implicit column width for an unannotated MySQL `String` field
+// (no `@db.VarChar(n)`/`@db.Text`/`@db.LongText` override).
+const IMPLICIT_MYSQL_VARCHAR_WIDTH = 191
+
+// Which identifier field (per createRecord's switch in commit.post.ts) each
+// SourceType writes name/title into. Deliberately explicit rather than
+// inferred from the schema/fields file -- createRecord's own field choice
+// (`name` vs `title`) is the actual fact being checked against, so hardcoding
+// it here mirrors commit.post.ts's own switch instead of guessing.
+const IDENTIFIER_FIELD: Record<string, 'name' | 'title'> = {
+  Character: 'name',
+  Bot: 'name',
+  Reward: 'name',
+  Scenario: 'title',
+  Dream: 'title',
+  Project: 'title',
+  Facet: 'title',
+}
+
+// --- CREATE_TARGETS extraction (which SourceTypes are live CREATE targets) --
+
+// `CREATE_TARGETS: Record<string, SourceTypeKey> = { 'output-key': 'Model', ... }`
+export function extractCreateTargetModels(fieldsFileContent: string): string[] {
+  const match = fieldsFileContent.match(
+    /export const CREATE_TARGETS: Record<string, SourceTypeKey> = \{([\s\S]*?)\n\}\n/,
+  )
+  if (!match) {
+    throw new Error(
+      'Could not find CREATE_TARGETS object literal in ' +
+        'modelBuilderFields.ts -- has its shape changed?',
+    )
+  }
+  const models = new Set<string>()
+  for (const m of match[1]!.matchAll(/:\s*'(\w+)'/g)) {
+    models.add(m[1]!)
+  }
+  return [...models]
+}
+
+// --- NAME_MAX extraction -----------------------------------------------------
+
+// `const NAME_MAX: Partial<Record<SourceType, number>> = { Model: n, ... }`
+export function extractNameMax(
+  commitRouteContent: string,
+): Record<string, number> {
+  const match = commitRouteContent.match(
+    /const NAME_MAX: Partial<Record<SourceType, number>> = \{([\s\S]*?)\n\}\n/,
+  )
+  if (!match) {
+    throw new Error(
+      'Could not find NAME_MAX object literal in commit.post.ts -- has it ' +
+        'been renamed, removed, or restructured? If so, this guard (and the ' +
+        'name/title truncation bug it protects against) needs to move with it.',
+    )
+  }
+  const result: Record<string, number> = {}
+  for (const m of match[1]!.matchAll(/(\w+):\s*(\d+)/g)) {
+    result[m[1]!] = Number(m[2]!)
+  }
+  return result
+}
+
+// True if `.slice(0, NAME_MAX[fieldModelType] ?? 255)` (or an equivalent
+// direct lookup on the resolved CREATE target type) still gates the name
+// assignment's cap -- i.e. the cap wasn't silently reverted back to a bare
+// `.slice(0, 255)` with no per-target lookup at all.
+export function nameCapUsesNameMax(commitRouteContent: string): boolean {
+  return /\.slice\(0, NAME_MAX\[\w+\] \?\? 255\)/.test(commitRouteContent)
+}
+
+// --- schema identifier-column width extraction -------------------------------
+
+function findModelBlock(schema: string, modelName: string): string | null {
+  const match = schema.match(new RegExp(`^model\\s+${modelName}\\s*\\{`, 'm'))
+  if (!match) return null
+  if (match.index === undefined) return null
+  const start = match.index + match[0].length
+  const end = schema.indexOf('\n}', start)
+  if (end === -1) return null
+  return schema.slice(start, end)
+}
+
+// The real column width for `model`'s identifier field (name or title, per
+// IDENTIFIER_FIELD): an explicit `@db.VarChar(n)` if present, otherwise
+// Prisma's implicit MySQL default (191) for a plain `String`/`String?`
+// column, or `undefined` if the field is unbounded (`@db.Text`/
+// `@db.LongText`) or not found at all.
+export function extractIdentifierWidth(
+  schema: string,
+  model: string,
+): number | undefined {
+  const field = IDENTIFIER_FIELD[model]
+  if (!field) {
+    throw new Error(
+      `No IDENTIFIER_FIELD entry for "${model}" -- this guard's hardcoded ` +
+        'name/title mapping needs a new entry before it can check this ' +
+        'CREATE target.',
+    )
+  }
+  const block = findModelBlock(schema, model)
+  if (!block) {
+    throw new Error(
+      `Could not find model ${model} in prisma/schema.prisma -- has it ` +
+        'been renamed?',
+    )
+  }
+  const line = block
+    .split('\n')
+    .find((l) => new RegExp(`^\\s*${field}\\s+String`).test(l))
+  if (!line) return undefined
+
+  const explicit = line.match(/@db\.VarChar\((\d+)\)/)
+  if (!explicit) {
+    if (/@db\.(Text|LongText)/.test(line)) return undefined // unbounded
+    return IMPLICIT_MYSQL_VARCHAR_WIDTH
+  }
+  return Number(explicit[1])
+}
+
+// --- combined check -----------------------------------------------------------
+
+export interface NameWidthProblem {
+  model: string
+  field: 'name' | 'title'
+  schemaWidth: number | undefined
+  nameMaxValue: number | undefined
+}
+
+// For every live CREATE_TARGETS model, NAME_MAX[model] must exist and equal
+// its identifier column's real schema width -- otherwise the flat 255
+// fallback either overshoots a narrower column (write failure/silent
+// truncation) or, in principle, undershoots a wider one (needlessly loses
+// characters the column could hold).
+export function findNameWidthProblems(
+  schema: string,
+  fieldsFileContent: string,
+  commitRouteContent: string,
+): NameWidthProblem[] {
+  const liveModels = extractCreateTargetModels(fieldsFileContent)
+  const nameMax = extractNameMax(commitRouteContent)
+
+  const problems: NameWidthProblem[] = []
+  for (const model of liveModels) {
+    const schemaWidth = extractIdentifierWidth(schema, model)
+    if (schemaWidth === undefined) continue // unbounded column, nothing to cap correctly against
+
+    const nameMaxValue = nameMax[model]
+    if (nameMaxValue !== schemaWidth) {
+      problems.push({
+        model,
+        field: IDENTIFIER_FIELD[model]!,
+        schemaWidth,
+        nameMaxValue,
+      })
+    }
+  }
+  return problems
+}
+
+function main(): void {
+  const schema = readFileSync(SCHEMA_PATH, 'utf8')
+  const fieldsFileContent = readFileSync(MODEL_BUILDER_FIELDS_PATH, 'utf8')
+  const commitRouteContent = readFileSync(COMMIT_ROUTE_PATH, 'utf8')
+
+  let failed = false
+
+  if (!nameCapUsesNameMax(commitRouteContent)) {
+    failed = true
+    console.error(
+      'Model Builder commit name-width contract failed: the name/title ' +
+        'cap no longer applies `NAME_MAX[fieldModelType] ?? 255` (or an ' +
+        'equivalent per-target lookup) -- has it reverted to a flat ' +
+        '`.slice(0, 255)` for every CREATE target regardless of its real ' +
+        'column width?',
+    )
+  }
+
+  const problems = findNameWidthProblems(
+    schema,
+    fieldsFileContent,
+    commitRouteContent,
+  )
+  if (problems.length) {
+    failed = true
+    console.error(
+      `Model Builder commit name-width contract failed: ${problems.length} ` +
+        'live CREATE target(s) have a NAME_MAX entry that does not match ' +
+        "their identifier column's real schema width:",
+    )
+    for (const problem of problems) {
+      const found =
+        problem.nameMaxValue === undefined
+          ? 'no NAME_MAX entry (falls back to 255)'
+          : `NAME_MAX = ${problem.nameMaxValue}`
+      console.error(
+        `- ${problem.model}.${problem.field} is ${problem.schemaWidth} ` +
+          `characters wide in prisma/schema.prisma, but commit.post.ts has ` +
+          `${found} -- a mismatch here risks a "Data too long for column" ` +
+          'write failure (cap too wide) or needlessly truncates a value the ' +
+          'column could actually hold (cap too narrow).',
+      )
+    }
+  }
+
+  if (failed) {
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder commit name-width contract passed: every live CREATE ' +
+      "target's NAME_MAX entry matches its identifier column's real schema " +
+      'width.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Task
model-builder/t-029 (recurring, cycle 35): "Polish and upgrade Model Builder front-end surface" — this cycle's fresh bug-hunt pass, per the recurring task's own fallback convention, over the batch editor/autoBuildRun path and asset-generation stage.

## What changed / what I produced
`server/api/model-builder/items/[id]/commit.post.ts`'s CREATE-name computation applied one flat `.slice(0, 255)` cap to every CREATE target's name/title, regardless of the actual target's schema column width:

- `Character.name`, `Reward.name`, `Bot.name` are all `VARCHAR(256)` — 255 is safe.
- `Scenario.title` is `String` with **no** `@db.VarChar` override, so it takes Prisma's implicit MySQL default of `VARCHAR(191) NOT NULL` (confirmed in `prisma/migrations/00000000000000_squashed/migration.sql`) — **255 overshoots this by 64 characters.**

Concrete failure: a user (or the AI drafter) types/batch-sets a Scenario title 192–255 characters long via the batch editor's "Set a field on all N" or the per-item `fieldsDraft` textarea (neither has a `maxlength`), approves every stage, and hits commit. `commit.post.ts` writes the uncapped title into a 191-char column, failing the whole transaction at INSERT time in MySQL strict mode ("Data too long for column 'title'"), or silently truncating it otherwise — the same drift class `SHORT_TEXT_MAX`/`pickText` already guards for prose fields (cycle 33), just reached through the name/title field, which is never `prose`-classified and so falls outside that guard's scope entirely.

- Added `NAME_MAX: Partial<Record<SourceType, number>>` (`Character/Reward/Bot: 256`, `Scenario: 191`) and applied it via the already-resolved `fieldModelType` at the point the name/title is capped, instead of a flat `255`.
- Added `utils/scripts/verifyModelBuilderCommitNameWidthGuard.ts` + `.test.ts`: walks `prisma/schema.prisma`, `modelBuilderFields.ts`'s live `CREATE_TARGETS`, and `commit.post.ts`'s `NAME_MAX` map, and fails if any live CREATE target's `NAME_MAX` entry doesn't match its identifier column's real width (explicit `@db.VarChar(n)`, or Prisma's implicit 191 default), or if a live target has no entry at all. Wired into `package.json`/`contract-tests.yml`.

## How I verified
- New guard self-test + real-file run: both pass.
- Re-ran the existing `verifyModelBuilderCommitNameFieldGuard` and `verifyModelBuilderCommitTextTruncationGuard` self-tests/contracts (my edit's minimal diff deliberately preserves the `const name = (` anchor those checks are keyed on) — no regression.
- All 127 `test:model-builder-*` npm scripts pass (125 prior + 2 new).
- `vue-tsc --noEmit`: clean, repo-wide.
- `eslint` / `prettier --check`: clean on all touched files.
- `git status --porcelain`: exactly the 5 intended files.

## Stakes
reversible

## Flags for Reviewer
None.

## Kaizen suggestion
No new bug-hunt lead surfaced beyond this one during this cycle's sweep of the batch/autoBuildRun path (heavily hardened already — cancellation races, stale-snapshot guards, stage-approval sequencing all checked and found solid). Next cycle: a fresh pass over a not-yet-audited area, e.g. the `linkSourceToTarget`/facet-sync path in the same file, or the asset-generation polling loop's error surfacing to the client.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvKeWJZVTp1ed4zyFWQEgf)_