### PR TITLE
fix(model-builder): cap consecutive async-art-job poll failures instead of retrying forever (t-029 cycle 36)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -443,6 +443,12 @@ jobs:
       - name: Model Builder commit name-width guard contract
         run: npm run test:model-builder-commit-name-width-guard
 
+      - name: Model Builder async poll-failure guard checker self-test
+        run: npm run test:model-builder-async-poll-failure-guard-selftest
+
+      - name: Model Builder async poll-failure guard contract
+        run: npm run test:model-builder-async-poll-failure-guard
+
       - name: Model Builder Dream-type choices guard checker self-test
         run: npm run test:model-builder-dream-type-choices-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -233,6 +233,8 @@
     "test:model-builder-commit-text-truncation-guard": "tsx utils/scripts/verifyModelBuilderCommitTextTruncationGuard.ts",
     "test:model-builder-commit-name-width-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitNameWidthGuard.test.ts",
     "test:model-builder-commit-name-width-guard": "tsx utils/scripts/verifyModelBuilderCommitNameWidthGuard.ts",
+    "test:model-builder-async-poll-failure-guard-selftest": "tsx utils/scripts/verifyModelBuilderAsyncPollFailureGuard.test.ts",
+    "test:model-builder-async-poll-failure-guard": "tsx utils/scripts/verifyModelBuilderAsyncPollFailureGuard.ts",
     "test:model-builder-dream-type-choices-guard-selftest": "tsx utils/scripts/verifyModelBuilderDreamTypeChoicesGuard.test.ts",
     "test:model-builder-dream-type-choices-guard": "tsx utils/scripts/verifyModelBuilderDreamTypeChoicesGuard.ts",
     "test:model-builder-commit-stale-snapshot-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.test.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1525,6 +1525,19 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   // generateItemAsset as the synchronous "art first, interactively" option.
 
   const ASYNC_ART_POLL_MS = 5_000
+  // getArtJobStatus returns null for BOTH "job not started yet" and "the
+  // status fetch itself failed" (performFetch never throws -- a network
+  // blip, an expired session's 401, the store-wide circuit breaker being
+  // open, or a genuine 404 all collapse to the same null). Before this fix,
+  // pollAsyncArtJob treated every null identically to a real PENDING status,
+  // so a *persistent* fetch failure (e.g. the user's JWT expiring mid-render)
+  // looped forever every ASYNC_ART_POLL_MS with no retry cap, no timeout, and
+  // no error ever surfaced -- the item sat at "queued" indefinitely with
+  // nothing to tell the user (or the server) anything was wrong, even if the
+  // underlying ArtJob had long since finished. This caps consecutive fetch
+  // failures before falling through to the same error-recovery path already
+  // used a few lines below for a genuine terminal job failure.
+  const MAX_CONSECUTIVE_POLL_FAILURES = 6 // ~30s of failed status checks
 
   async function pollAsyncArtJob(
     item: BuildItem,
@@ -1536,6 +1549,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     runId: string,
   ): Promise<void> {
     const artStore = useArtStore()
+    let consecutivePollFailures = 0
 
     // If another call re-queues this item (or the item is dropped from the
     // run), item.artJobId will no longer match — stop, the newer poll (or
@@ -1545,8 +1559,33 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
 
       if (item.artJobId !== jobId) return
 
-      if (!job || job.status === 'PENDING' || job.status === 'RUNNING') {
-        item.queueState = job?.status === 'RUNNING' ? 'rendering' : 'queued'
+      if (!job) {
+        consecutivePollFailures += 1
+        if (consecutivePollFailures < MAX_CONSECUTIVE_POLL_FAILURES) {
+          item.queueState = 'queued'
+          finishGenerateAssets(item, {
+            status: 'in-progress',
+            note: item.queueState,
+          })
+          await new Promise((resolve) => setTimeout(resolve, ASYNC_ART_POLL_MS))
+          continue
+        }
+        // Too many consecutive failed status checks to keep treating this as
+        // "still queued" -- fall through to the same terminal-failure
+        // handling used below for a genuine DONE/FAILED job, so the item
+        // doesn't sit stuck at "queued" forever with no error surfaced.
+        item.artJobId = null
+        item.queueState = null
+        item.error = `Lost track of art job ${jobId} after ${consecutivePollFailures} failed status checks.`
+        finishGenerateAssets(item, { status: 'ready', note: item.error })
+        setStatusForRun(runId, 'error', item.error)
+        pushItem(item, { error: item.error })
+        return
+      }
+      consecutivePollFailures = 0
+
+      if (job.status === 'PENDING' || job.status === 'RUNNING') {
+        item.queueState = job.status === 'RUNNING' ? 'rendering' : 'queued'
         finishGenerateAssets(item, {
           status: 'in-progress',
           note: item.queueState,

--- a/utils/scripts/verifyModelBuilderAsyncPollFailureGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderAsyncPollFailureGuard.test.ts
@@ -1,0 +1,178 @@
+// /utils/scripts/verifyModelBuilderAsyncPollFailureGuard.test.ts
+//
+// Regression test for checkAsyncPollFailureGuard() in
+// verifyModelBuilderAsyncPollFailureGuard.ts (model-builder/t-029, cycle 36).
+// Exercises the real check against synthetic pollAsyncArtJob-shaped fixtures:
+// the pre-fix shape (unbounded `!job` retry, the exact bug found by the
+// read-only bug-hunt pass), the fixed shape (bounded consecutive-failure
+// counter with a real exit), and partial fixtures missing one piece of the
+// fix each.
+import assert from 'node:assert/strict'
+
+import {
+  checkAsyncPollFailureGuard,
+  extractPollAsyncArtJobBody,
+} from './verifyModelBuilderAsyncPollFailureGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function pollAsyncArtJob(
+    item: BuildItem,
+    jobId: number,
+    runId: string,
+  ): Promise<void> {
+    const artStore = useArtStore()
+
+    while (item.artJobId === jobId) {
+      const job: QueuedArtJob | null = await artStore.getArtJobStatus(jobId)
+
+      if (item.artJobId !== jobId) return
+
+      if (!job || job.status === 'PENDING' || job.status === 'RUNNING') {
+        item.queueState = job?.status === 'RUNNING' ? 'rendering' : 'queued'
+        finishGenerateAssets(item, {
+          status: 'in-progress',
+          note: item.queueState,
+        })
+        await new Promise((resolve) => setTimeout(resolve, ASYNC_ART_POLL_MS))
+        continue
+      }
+
+      item.artJobId = null
+      item.queueState = null
+      return
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function pollAsyncArtJob(
+    item: BuildItem,
+    jobId: number,
+    runId: string,
+  ): Promise<void> {
+    const artStore = useArtStore()
+    let consecutivePollFailures = 0
+
+    while (item.artJobId === jobId) {
+      const job: QueuedArtJob | null = await artStore.getArtJobStatus(jobId)
+
+      if (item.artJobId !== jobId) return
+
+      if (!job) {
+        consecutivePollFailures += 1
+        if (consecutivePollFailures < MAX_CONSECUTIVE_POLL_FAILURES) {
+          item.queueState = 'queued'
+          finishGenerateAssets(item, {
+            status: 'in-progress',
+            note: item.queueState,
+          })
+          await new Promise((resolve) => setTimeout(resolve, ASYNC_ART_POLL_MS))
+          continue
+        }
+        item.artJobId = null
+        item.queueState = null
+        item.error = \`Lost track of art job \${jobId}.\`
+        finishGenerateAssets(item, { status: 'ready', note: item.error })
+        setStatusForRun(runId, 'error', item.error)
+        pushItem(item, { error: item.error })
+        return
+      }
+      consecutivePollFailures = 0
+
+      if (job.status === 'PENDING' || job.status === 'RUNNING') {
+        item.queueState = job.status === 'RUNNING' ? 'rendering' : 'queued'
+        finishGenerateAssets(item, {
+          status: 'in-progress',
+          note: item.queueState,
+        })
+        await new Promise((resolve) => setTimeout(resolve, ASYNC_ART_POLL_MS))
+        continue
+      }
+
+      item.artJobId = null
+      item.queueState = null
+      return
+    }
+  }
+`
+
+const MISSING_RETURN_FIXTURE = `
+  async function pollAsyncArtJob(
+    item: BuildItem,
+    jobId: number,
+    runId: string,
+  ): Promise<void> {
+    const artStore = useArtStore()
+    let consecutivePollFailures = 0
+
+    while (item.artJobId === jobId) {
+      const job: QueuedArtJob | null = await artStore.getArtJobStatus(jobId)
+
+      if (!job) {
+        consecutivePollFailures += 1
+        if (consecutivePollFailures < MAX_CONSECUTIVE_POLL_FAILURES) {
+          continue
+        }
+        item.artJobId = null
+      }
+      consecutivePollFailures = 0
+    }
+  }
+`
+
+function run(): void {
+  // --- extraction sanity ---
+  assert.equal(extractPollAsyncArtJobBody('no such function here'), null)
+  assert.ok(
+    extractPollAsyncArtJobBody(FIXED_FIXTURE)?.startsWith(
+      'async function pollAsyncArtJob(',
+    ),
+  )
+
+  // --- buggy fixture: unbounded retry, no counter, no threshold ---
+  const buggyErrors = checkAsyncPollFailureGuard(BUGGY_FIXTURE)
+  assert.ok(
+    buggyErrors.some((e) => e.includes('retry forever')),
+    `expected the buggy fixture to flag the unbounded-retry shape, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(
+    buggyErrors.some((e) => e.includes('consecutivePollFailures')),
+    `expected the buggy fixture to flag the missing counter, got: ${JSON.stringify(buggyErrors)}`,
+  )
+
+  // --- fixed fixture: passes clean ---
+  const fixedErrors = checkAsyncPollFailureGuard(FIXED_FIXTURE)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  // --- partial fixture: counter exists but never actually exits the loop ---
+  const missingReturnErrors = checkAsyncPollFailureGuard(MISSING_RETURN_FIXTURE)
+  assert.ok(
+    missingReturnErrors.length > 0,
+    'expected the missing-return fixture (counter present, but the failure ' +
+      'block never returns) to fail',
+  )
+  assert.ok(
+    missingReturnErrors.some(
+      (e) =>
+        e.includes('return') || e.includes('MAX_CONSECUTIVE_POLL_FAILURES'),
+    ),
+    `expected a return/threshold-related error, got: ${JSON.stringify(missingReturnErrors)}`,
+  )
+
+  // --- missing-anchor fixture ---
+  const missingAnchorErrors = checkAsyncPollFailureGuard('const x = 1')
+  assert.equal(missingAnchorErrors.length, 1)
+  assert.match(missingAnchorErrors[0]!, /Could not find/)
+
+  console.log(
+    'Model Builder async poll-failure guard self-test passed: buggy fixture ' +
+      'fails on the unbounded-retry shape, fixed fixture passes, a ' +
+      'never-exits partial fixture fails, missing-anchor fixture fails clearly.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderAsyncPollFailureGuard.ts
+++ b/utils/scripts/verifyModelBuilderAsyncPollFailureGuard.ts
@@ -1,0 +1,207 @@
+// /utils/scripts/verifyModelBuilderAsyncPollFailureGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 36). stores/modelBuilderStore.ts's
+// pollAsyncArtJob() polls an async art job's status every ASYNC_ART_POLL_MS via
+// artStore.getArtJobStatus(), which returns `null` for BOTH "the job hasn't
+// started yet" and "the status fetch itself failed" -- performFetch
+// (stores/utils.ts) never throws; a network blip, an expired session's 401, the
+// store-wide circuit breaker being open, or a genuine 404 all collapse to the
+// same `null`.
+//
+// Before this fix, the loop's condition was
+// `if (!job || job.status === 'PENDING' || job.status === 'RUNNING')` --
+// treating every null identically to a real PENDING status. A *persistent*
+// fetch failure (e.g. the user's JWT expiring mid-render) therefore looped
+// forever every ASYNC_ART_POLL_MS with no retry cap, no timeout, and no error
+// ever surfaced to the user or the server, even if the underlying ArtJob had
+// long since finished server-side. Concrete failure: the item sits at
+// "queued" indefinitely; item.error never gets set; GENERATE_ASSETS can never
+// reach ready/approved; nothing tells the user or pushes anything to the
+// server -- exactly the class of silently-local-only failure this file's
+// synchronous sibling generateItemAsset() already guards against (its own
+// catch block sets item.error, calls finishGenerateAssets, and pushItem's a
+// server-visible error).
+//
+// Fixed by counting consecutive `!job` failures separately from genuine
+// PENDING/RUNNING statuses and, past a bounded threshold
+// (MAX_CONSECUTIVE_POLL_FAILURES), falling through to the same
+// terminal-failure handling already used a few lines below for a genuine
+// DONE/FAILED job (set item.error, finishGenerateAssets 'ready', setStatusForRun
+// 'error', pushItem the error) instead of looping forever.
+//
+// This checks pollAsyncArtJob's source text for: (1) a per-call failure
+// counter, (2) the counter being compared against a threshold constant, and
+// (3) a `return` reachable from the `!job` branch (proof the loop can
+// actually exit on persistent failure, not just `continue` forever) -- and
+// fails if the pre-fix combined `!job || job.status === 'PENDING' ...`
+// condition (which retries `!job` unconditionally, forever) has come back.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FUNCTION_ANCHOR = 'async function pollAsyncArtJob('
+const PRE_FIX_UNBOUNDED_RETRY =
+  "if (!job || job.status === 'PENDING' || job.status === 'RUNNING')"
+
+/**
+ * Extracts pollAsyncArtJob's full function body (from its `async function`
+ * anchor through the balancing closing brace), so the checks below are
+ * robust to reformatting/comment changes elsewhere in the file.
+ */
+export function extractPollAsyncArtJobBody(content: string): string | null {
+  const anchorIndex = content.indexOf(FUNCTION_ANCHOR)
+  if (anchorIndex === -1) return null
+
+  // The naive `content.indexOf('{', anchorIndex)` finds whichever `{` comes
+  // first -- which, for a multi-line parameter list, is an object-type
+  // parameter's brace (e.g. `dims: { width: number; height: number }`), not
+  // the function body's own opening brace. Balance the parameter list's
+  // parens first, then look for the body's `{` only after they close.
+  const paramsOpen = anchorIndex + FUNCTION_ANCHOR.length - 1 // the '(' itself
+  let parenDepth = 0
+  let paramsClose = -1
+  for (let i = paramsOpen; i < content.length; i++) {
+    if (content[i] === '(') parenDepth++
+    else if (content[i] === ')') {
+      parenDepth--
+      if (parenDepth === 0) {
+        paramsClose = i
+        break
+      }
+    }
+  }
+  if (paramsClose === -1) return null
+
+  const bodyOpen = content.indexOf('{', paramsClose)
+  if (bodyOpen === -1) return null
+
+  // Skips over string/template literals so a `${expr}` interpolation's own
+  // braces (e.g. the real fix's ``Lost track of art job ${jobId}...`` error
+  // message) can't desync the brace-depth count -- the same class of bug
+  // verifyCaptureGroupGuards.ts's afterCaptureCallClose already guards
+  // against for regex literals.
+  let depth = 0
+  let i = bodyOpen
+  for (; i < content.length; i++) {
+    const char = content[i]
+
+    if (char === "'" || char === '"' || char === '`') {
+      i += 1
+      while (i < content.length && content[i] !== char) {
+        if (content[i] === '\\') i += 1
+        i += 1
+      }
+      continue
+    }
+
+    if (char === '{') depth++
+    else if (char === '}') {
+      depth--
+      if (depth === 0) break
+    }
+  }
+  if (depth !== 0) return null
+
+  return content.slice(anchorIndex, i + 1)
+}
+
+export function checkAsyncPollFailureGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const body = extractPollAsyncArtJobBody(content)
+  if (body === null) {
+    errors.push(
+      `Could not find \`${FUNCTION_ANCHOR}\` in modelBuilderStore.ts -- has ` +
+        'pollAsyncArtJob been renamed, removed, or restructured? If so, this ' +
+        'guard (and the infinite-retry bug it protects against) needs to move ' +
+        'with it.',
+    )
+    return errors
+  }
+
+  if (body.includes(PRE_FIX_UNBOUNDED_RETRY)) {
+    errors.push(
+      'pollAsyncArtJob has reverted to treating `!job` identically to a real ' +
+        'PENDING/RUNNING status in one combined condition -- a persistent ' +
+        'status-fetch failure (expired session, network blip, circuit ' +
+        'breaker open) would once again retry forever with no error ever ' +
+        'surfaced.',
+    )
+  }
+
+  const counterDeclared = /let\s+consecutivePollFailures\s*=\s*0/.test(body)
+  if (!counterDeclared) {
+    errors.push(
+      'pollAsyncArtJob no longer declares a consecutive-failure counter ' +
+        '(expected `let consecutivePollFailures = 0`) -- without one, a ' +
+        'persistent `!job` status-fetch failure has no way to be ' +
+        'distinguished from a transient one.',
+    )
+  }
+
+  const failureBlockMatch = body.match(/if \(!job\) \{([\s\S]*?)\n {6}\}\n/)
+  if (!failureBlockMatch) {
+    errors.push(
+      'Could not find a standalone `if (!job) { ... }` block in ' +
+        'pollAsyncArtJob -- the `!job` (status-fetch-failed) case must be ' +
+        'handled separately from genuine PENDING/RUNNING statuses so it can ' +
+        'be capped independently.',
+    )
+  } else {
+    const failureBlock = failureBlockMatch[1]!
+    if (!/consecutivePollFailures\s*\+=\s*1/.test(failureBlock)) {
+      errors.push(
+        'The `if (!job) { ... }` block does not increment ' +
+          'consecutivePollFailures -- the failure count would never advance, ' +
+          'so the threshold check below it could never trigger.',
+      )
+    }
+    if (!/MAX_CONSECUTIVE_POLL_FAILURES/.test(failureBlock)) {
+      errors.push(
+        'The `if (!job) { ... }` block does not reference ' +
+          'MAX_CONSECUTIVE_POLL_FAILURES -- there is no bounded threshold ' +
+          'past which a persistent status-fetch failure stops being treated ' +
+          'as "still queued."',
+      )
+    }
+    if (!/\breturn\b/.test(failureBlock)) {
+      errors.push(
+        'The `if (!job) { ... }` block has no `return` -- there is no path ' +
+          'by which persistent status-fetch failures actually exit the poll ' +
+          'loop; it would retry forever regardless of any counter.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkAsyncPollFailureGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder async poll-failure guard contract failed for ' +
+        'stores/modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder async poll-failure guard contract passed: pollAsyncArtJob ' +
+      'caps consecutive status-fetch failures and surfaces an error instead ' +
+      'of retrying forever.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Task
model-builder/t-029 (recurring, cycle 36): "Polish and upgrade Model Builder front-end surface" — this cycle's fresh bug-hunt pass over the `linkSourceToTarget`/facet-sync path and the asset-generation polling loop's error surfacing to the client (cycle 35's suggested lead).

## What changed / what I produced
`stores/modelBuilderStore.ts`'s `pollAsyncArtJob()` polls an async art job's status every `ASYNC_ART_POLL_MS` via `artStore.getArtJobStatus(jobId)`, which returns `null` for **both** "the job hasn't started yet" and "the status fetch itself failed" — `performFetch` (`stores/utils.ts`) never throws; a network blip, an expired session's 401, the store-wide circuit breaker being open, or a genuine 404 all collapse to the same `null`.

The loop's condition was `if (!job || job.status === 'PENDING' || job.status === 'RUNNING')` — treating every `null` identically to a real `PENDING` status, with no retry cap and no timeout.

**Concrete failure:** a user starts an async art render; their JWT expires (or the network drops, or the circuit breaker opens) partway through. Every subsequent status fetch now fails, `getArtJobStatus` returns `null` forever, and `pollAsyncArtJob` loops every 5s indefinitely — the item sits stuck at "queued," `item.error` never gets set, nothing is ever pushed to the server, and `GENERATE_ASSETS` can never reach `ready`/`approved`, even if the underlying ArtJob actually finished successfully server-side ages ago. Contrast with this function's synchronous sibling `generateItemAsset()`, whose failed request throws, is caught, sets `item.error`, and pushes the error to the server — exactly the recovery this async path was missing.

- Added a `consecutivePollFailures` counter, incremented only on `!job` (not on genuine `PENDING`/`RUNNING`), reset once a real status comes back.
- Past `MAX_CONSECUTIVE_POLL_FAILURES` (6, ~30s), falls through to the same terminal-failure handling already used a few lines below for a genuine `DONE`/`FAILED` job: sets `item.error`, `finishGenerateAssets(item, { status: 'ready', note: item.error })`, `setStatusForRun(runId, 'error', ...)`, `pushItem(item, { error: item.error })`.
- Added `utils/scripts/verifyModelBuilderAsyncPollFailureGuard.ts` + `.test.ts`: checks `pollAsyncArtJob`'s source for the counter, the threshold check, and a reachable `return` in the `!job` branch, and fails if the pre-fix unbounded-retry condition reappears. Wired into `package.json`/`contract-tests.yml`.

## How I verified
- New guard self-test + real-file run: both pass (caught and fixed two bugs in the guard's own brace-balancing extractor along the way — a template-literal `${...}` desyncing brace depth, and an object-type parameter like `dims: { width: number; height: number }` being mistaken for the function body's opening brace — before trusting it against the real file).
- All 129 `test:model-builder-*` npm scripts pass (127 prior + 2 new).
- `vue-tsc --noEmit`: clean, repo-wide.
- `eslint` / `prettier --check`: clean on all touched files. (Note: `stores/modelBuilderStore.ts` as a whole has pre-existing, unrelated `prettier --check`/`eslint` findings — confirmed present on `origin/main` before this change — left untouched per scope discipline; my diff is scoped to exactly the intended 41 inserted/2 removed lines.)
- `verifyCaptureGroupGuards.ts origin/main`: clean.
- `git status --porcelain`: exactly the 5 intended files.

## Stakes
reversible

## Flags for Reviewer
`stores/modelBuilderStore.ts` fails a whole-file `prettier --check`/has 2 pre-existing `eslint no-empty` findings unrelated to this change (confirmed present on `main` already) — noted here rather than silently expanding this PR's diff to fix unrelated drift.

## Kaizen suggestion
`stores/modelBuilderStore.ts:1521`'s comment references `ART_QUEUE_TIMEOUT_MS`, a constant that no longer exists anywhere in the codebase (a verify script even asserts its absence) — stale/misleading documentation, worth a follow-up cleanup task. Also worth considering: a repo-wide `prettier --write` + `eslint --fix` pass on `modelBuilderStore.ts` as its own small, isolated task, now that this cycle surfaced how far it's drifted from both tools' current output.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvKeWJZVTp1ed4zyFWQEgf)_