### PR TITLE
fix(art): cap consecutive queue-status poll failures instead of retrying forever (model-builder/t-029 cycle 37)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -449,6 +449,12 @@ jobs:
       - name: Model Builder async poll-failure guard contract
         run: npm run test:model-builder-async-poll-failure-guard
 
+      - name: Art queue poll-failure guard checker self-test
+        run: npm run test:art-queue-poll-failure-guard-selftest
+
+      - name: Art queue poll-failure guard contract
+        run: npm run test:art-queue-poll-failure-guard
+
       - name: Model Builder Dream-type choices guard checker self-test
         run: npm run test:model-builder-dream-type-choices-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -235,6 +235,8 @@
     "test:model-builder-commit-name-width-guard": "tsx utils/scripts/verifyModelBuilderCommitNameWidthGuard.ts",
     "test:model-builder-async-poll-failure-guard-selftest": "tsx utils/scripts/verifyModelBuilderAsyncPollFailureGuard.test.ts",
     "test:model-builder-async-poll-failure-guard": "tsx utils/scripts/verifyModelBuilderAsyncPollFailureGuard.ts",
+    "test:art-queue-poll-failure-guard-selftest": "tsx utils/scripts/verifyArtQueuePollFailureGuard.test.ts",
+    "test:art-queue-poll-failure-guard": "tsx utils/scripts/verifyArtQueuePollFailureGuard.ts",
     "test:model-builder-dream-type-choices-guard-selftest": "tsx utils/scripts/verifyModelBuilderDreamTypeChoicesGuard.test.ts",
     "test:model-builder-dream-type-choices-guard": "tsx utils/scripts/verifyModelBuilderDreamTypeChoicesGuard.ts",
     "test:model-builder-commit-stale-snapshot-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.test.ts",

--- a/stores/artStore.ts
+++ b/stores/artStore.ts
@@ -1690,7 +1690,23 @@ export const useArtStore = defineStore('artStore', () => {
     return response.data.jobId
   }
 
+  // getArtJobStatus's own fetch (mirrored inline here rather than reused, so
+  // this loop controls its own retry/timeout budget) returns a null job for
+  // BOTH "job not started yet" and "the status fetch itself failed"
+  // (performFetch never throws -- a network blip, an expired session's 401,
+  // the store-wide circuit breaker being open, or a genuine 404 all collapse
+  // to the same null). Before this fix, that null fell through to the same
+  // "keep polling" branch as a genuine PENDING/RUNNING status with no retry
+  // cap and no timeout, so a *persistent* fetch failure (e.g. the user's JWT
+  // expiring mid-render) looped forever every ART_QUEUE_POLL_MS -- this
+  // await never resolved or rejected, so generateArt's own try/catch never
+  // ran and the caller was left awaiting indefinitely with nothing surfaced.
+  // Caps consecutive failed status checks before giving up, matching the
+  // sibling fix already applied to modelBuilderStore.ts's pollAsyncArtJob.
+  const MAX_CONSECUTIVE_QUEUE_POLL_FAILURES = 6 // ~30s of failed status checks
+
   async function waitForQueuedArtJob(jobId: number): Promise<QueuedArtJob> {
+    let consecutivePollFailures = 0
     while (true) {
       const response = await performFetch<{ job: QueuedArtJob }>(
         `/api/art/queue/${jobId}`,
@@ -1708,6 +1724,14 @@ export const useArtStore = defineStore('artStore', () => {
       }
       if (job?.status === 'PENDING' || job?.status === 'RUNNING') {
         state.queueState = job.status === 'RUNNING' ? 'rendering' : 'queued'
+        consecutivePollFailures = 0
+      } else {
+        consecutivePollFailures += 1
+        if (consecutivePollFailures >= MAX_CONSECUTIVE_QUEUE_POLL_FAILURES) {
+          throw new Error(
+            `Lost track of art job ${jobId} after ${consecutivePollFailures} failed status checks.`,
+          )
+        }
       }
       await queueSleep(ART_QUEUE_POLL_MS)
     }

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1517,9 +1517,13 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
 
   // --- GENERATE_ASSETS (async): queue via ArtJob, poll per item -------------
   //
-  // generateItemAsset above blocks the whole call on the render (up to
-  // ART_QUEUE_TIMEOUT_MS). This is the "normal" async path from the roadmap
-  // note: enqueue, store the jobId on the item, poll independently so
+  // generateItemAsset above blocks the whole call on the render via
+  // artStore's waitForQueuedArtJob, which gives up after
+  // MAX_CONSECUTIVE_QUEUE_POLL_FAILURES consecutive failed status checks but
+  // otherwise polls for as long as the job stays PENDING/RUNNING -- there is
+  // no separate overall wall-clock timeout constant. This is the "normal"
+  // async path from the roadmap note: enqueue, store the jobId on the item,
+  // poll independently so
   // multiple items can be in flight at once with their own queued/rendering
   // state, and promote the image once the job finishes. Keeps
   // generateItemAsset as the synchronous "art first, interactively" option.

--- a/utils/scripts/verifyArtQueuePollFailureGuard.test.ts
+++ b/utils/scripts/verifyArtQueuePollFailureGuard.test.ts
@@ -1,0 +1,153 @@
+// /utils/scripts/verifyArtQueuePollFailureGuard.test.ts
+//
+// Regression test for checkArtQueuePollFailureGuard() in
+// verifyArtQueuePollFailureGuard.ts (model-builder/t-029, cycle 37).
+// Exercises the real check against synthetic waitForQueuedArtJob-shaped
+// fixtures: the pre-fix shape (a null/failed status fetch falls through to
+// the same unbounded retry as a genuine PENDING/RUNNING status), the fixed
+// shape (bounded consecutive-failure counter with a real throw), and partial
+// fixtures missing one piece of the fix each.
+import assert from 'node:assert/strict'
+
+import {
+  checkArtQueuePollFailureGuard,
+  extractWaitForQueuedArtJobBody,
+} from './verifyArtQueuePollFailureGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function waitForQueuedArtJob(jobId: number): Promise<QueuedArtJob> {
+    while (true) {
+      const response = await performFetch<{ job: QueuedArtJob }>(
+        \`/api/art/queue/\${jobId}\`,
+        { method: 'GET' },
+        2,
+        20_000,
+      )
+      const job = response.success ? response.data?.job : null
+      if (
+        job?.status === 'DONE' ||
+        job?.status === 'FAILED' ||
+        job?.status === 'CANCELLED'
+      ) {
+        return job
+      }
+      if (job?.status === 'PENDING' || job?.status === 'RUNNING') {
+        state.queueState = job.status === 'RUNNING' ? 'rendering' : 'queued'
+      }
+      await queueSleep(ART_QUEUE_POLL_MS)
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function waitForQueuedArtJob(jobId: number): Promise<QueuedArtJob> {
+    let consecutivePollFailures = 0
+    while (true) {
+      const response = await performFetch<{ job: QueuedArtJob }>(
+        \`/api/art/queue/\${jobId}\`,
+        { method: 'GET' },
+        2,
+        20_000,
+      )
+      const job = response.success ? response.data?.job : null
+      if (
+        job?.status === 'DONE' ||
+        job?.status === 'FAILED' ||
+        job?.status === 'CANCELLED'
+      ) {
+        return job
+      }
+      if (job?.status === 'PENDING' || job?.status === 'RUNNING') {
+        state.queueState = job.status === 'RUNNING' ? 'rendering' : 'queued'
+        consecutivePollFailures = 0
+      } else {
+        consecutivePollFailures += 1
+        if (consecutivePollFailures >= MAX_CONSECUTIVE_QUEUE_POLL_FAILURES) {
+          throw new Error(
+            \`Lost track of art job \${jobId} after \${consecutivePollFailures} failed status checks.\`,
+          )
+        }
+      }
+      await queueSleep(ART_QUEUE_POLL_MS)
+    }
+  }
+`
+
+const MISSING_THROW_FIXTURE = `
+  async function waitForQueuedArtJob(jobId: number): Promise<QueuedArtJob> {
+    let consecutivePollFailures = 0
+    while (true) {
+      const job = await pollOnce(jobId)
+      if (job?.status === 'PENDING' || job?.status === 'RUNNING') {
+        consecutivePollFailures = 0
+      } else {
+        consecutivePollFailures += 1
+        if (consecutivePollFailures >= MAX_CONSECUTIVE_QUEUE_POLL_FAILURES) {
+          return job
+        }
+      }
+      await queueSleep(ART_QUEUE_POLL_MS)
+    }
+  }
+`
+
+function run(): void {
+  // --- extraction sanity ---
+  assert.equal(extractWaitForQueuedArtJobBody('no such function here'), null)
+  assert.ok(
+    extractWaitForQueuedArtJobBody(FIXED_FIXTURE)?.startsWith(
+      'async function waitForQueuedArtJob(',
+    ),
+  )
+
+  // --- buggy fixture: no counter, no threshold, no throw ---
+  const buggyErrors = checkArtQueuePollFailureGuard(BUGGY_FIXTURE)
+  assert.ok(
+    buggyErrors.some((e) => e.includes('consecutive-failure counter')),
+    `expected the buggy fixture to flag the missing counter, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(
+    buggyErrors.some((e) => e.includes('MAX_CONSECUTIVE_QUEUE_POLL_FAILURES')),
+    `expected the buggy fixture to flag the missing threshold, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(
+    buggyErrors.some((e) => e.includes('throw new Error')),
+    `expected the buggy fixture to flag the missing throw, got: ${JSON.stringify(buggyErrors)}`,
+  )
+
+  // --- fixed fixture: passes clean ---
+  const fixedErrors = checkArtQueuePollFailureGuard(FIXED_FIXTURE)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  // --- partial fixture: counter exists but never actually throws ---
+  const missingThrowErrors = checkArtQueuePollFailureGuard(
+    MISSING_THROW_FIXTURE,
+  )
+  assert.ok(
+    missingThrowErrors.length > 0,
+    'expected the missing-throw fixture (counter present, but the failure ' +
+      'branch never throws) to fail',
+  )
+  assert.ok(
+    missingThrowErrors.some((e) => e.includes('throw new Error')),
+    `expected a throw-related error, got: ${JSON.stringify(missingThrowErrors)}`,
+  )
+
+  // --- missing-anchor fixture ---
+  const missingAnchorErrors = checkArtQueuePollFailureGuard('const x = 1')
+  assert.equal(missingAnchorErrors.length, 1)
+  assert.match(missingAnchorErrors[0]!, /Could not find/)
+
+  console.log(
+    'Art queue poll-failure guard self-test passed: buggy fixture fails on ' +
+      'the missing counter/threshold/throw, fixed fixture passes, a ' +
+      'never-throws partial fixture fails, missing-anchor fixture fails ' +
+      'clearly.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyArtQueuePollFailureGuard.ts
+++ b/utils/scripts/verifyArtQueuePollFailureGuard.ts
@@ -1,0 +1,192 @@
+// /utils/scripts/verifyArtQueuePollFailureGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 37). stores/artStore.ts's
+// waitForQueuedArtJob() polls a queued art job's status every
+// ART_QUEUE_POLL_MS via a direct performFetch call, which resolves to a null
+// job for BOTH "the job hasn't started yet" and "the status fetch itself
+// failed" -- performFetch never throws; a network blip, an expired
+// session's 401, the store-wide circuit breaker being open, or a genuine 404
+// all collapse to the same null.
+//
+// Before this fix, the loop only special-cased a terminal status
+// (DONE/FAILED/CANCELLED, which returns) and a genuine PENDING/RUNNING
+// status (which just sets state.queueState) -- any other outcome, including
+// a null job from a persistently failing fetch, fell straight through to
+// `await queueSleep(...)` and looped again with no retry cap and no
+// timeout. Concrete failure: this function backs enqueueAndRenderArtImage,
+// the actual synchronous rendering path behind generateArt/
+// generateCurrentArt/generateItemAsset -- a persistent status-fetch failure
+// (e.g. the user's JWT expiring mid-render) left the awaited promise never
+// resolving or rejecting, so generateArt's own try/catch never ran, nothing
+// was ever surfaced to the user, and the whole call sat hung indefinitely.
+// Same defect class as pollAsyncArtJob in modelBuilderStore.ts (cycle 36),
+// just in the shared art store's own synchronous-wait sibling instead of
+// model-builder's async poll loop.
+//
+// Fixed by counting consecutive non-terminal, non-PENDING/RUNNING outcomes
+// (i.e. a null/failed status fetch) separately from genuine PENDING/RUNNING
+// statuses and, past a bounded threshold
+// (MAX_CONSECUTIVE_QUEUE_POLL_FAILURES), throwing instead of looping
+// forever -- the thrown error propagates through enqueueAndRenderArtImage
+// into generateArt's existing catch block, the same error-surfacing path a
+// genuine FAILED job already uses.
+//
+// This checks waitForQueuedArtJob's source text for: (1) a per-call failure
+// counter, (2) the counter being compared against a threshold constant, and
+// (3) a `throw` reachable from the failure branch (proof the loop can
+// actually exit on persistent failure, not just retry forever).
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/artStore.ts')
+
+const FUNCTION_ANCHOR = 'async function waitForQueuedArtJob('
+
+/**
+ * Extracts waitForQueuedArtJob's full function body (from its `async
+ * function` anchor through the balancing closing brace), so the checks
+ * below are robust to reformatting/comment changes elsewhere in the file.
+ * Mirrors extractPollAsyncArtJobBody's brace-balancing approach
+ * (verifyModelBuilderAsyncPollFailureGuard.ts), including skipping over
+ * string/template literals so a `${jobId}`-style interpolation in the real
+ * fix's error message can't desync the brace-depth count.
+ */
+export function extractWaitForQueuedArtJobBody(content: string): string | null {
+  const anchorIndex = content.indexOf(FUNCTION_ANCHOR)
+  if (anchorIndex === -1) return null
+
+  const paramsOpen = anchorIndex + FUNCTION_ANCHOR.length - 1 // the '(' itself
+  let parenDepth = 0
+  let paramsClose = -1
+  for (let i = paramsOpen; i < content.length; i++) {
+    if (content[i] === '(') parenDepth++
+    else if (content[i] === ')') {
+      parenDepth--
+      if (parenDepth === 0) {
+        paramsClose = i
+        break
+      }
+    }
+  }
+  if (paramsClose === -1) return null
+
+  const bodyOpen = content.indexOf('{', paramsClose)
+  if (bodyOpen === -1) return null
+
+  let depth = 0
+  let i = bodyOpen
+  for (; i < content.length; i++) {
+    const char = content[i]
+
+    if (char === "'" || char === '"' || char === '`') {
+      i += 1
+      while (i < content.length && content[i] !== char) {
+        if (content[i] === '\\') i += 1
+        i += 1
+      }
+      continue
+    }
+
+    if (char === '{') depth++
+    else if (char === '}') {
+      depth--
+      if (depth === 0) break
+    }
+  }
+  if (depth !== 0) return null
+
+  return content.slice(anchorIndex, i + 1)
+}
+
+export function checkArtQueuePollFailureGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const body = extractWaitForQueuedArtJobBody(content)
+  if (body === null) {
+    errors.push(
+      `Could not find \`${FUNCTION_ANCHOR}\` in artStore.ts -- has ` +
+        'waitForQueuedArtJob been renamed, removed, or restructured? If so, ' +
+        'this guard (and the infinite-retry bug it protects against) needs ' +
+        'to move with it.',
+    )
+    return errors
+  }
+
+  const counterDeclared = /let\s+consecutivePollFailures\s*=\s*0/.test(body)
+  if (!counterDeclared) {
+    errors.push(
+      'waitForQueuedArtJob no longer declares a consecutive-failure counter ' +
+        '(expected `let consecutivePollFailures = 0`) -- without one, a ' +
+        'persistent status-fetch failure has no way to be distinguished ' +
+        'from a transient one.',
+    )
+  }
+
+  if (!/consecutivePollFailures\s*\+=\s*1/.test(body)) {
+    errors.push(
+      'waitForQueuedArtJob never increments consecutivePollFailures -- the ' +
+        'failure count would never advance, so the threshold check below it ' +
+        'could never trigger.',
+    )
+  }
+
+  const zeroAssignmentCount = (
+    body.match(/consecutivePollFailures\s*=\s*0/g) ?? []
+  ).length
+  if (zeroAssignmentCount < 2) {
+    errors.push(
+      'waitForQueuedArtJob never resets consecutivePollFailures back to 0 on ' +
+        'a genuine PENDING/RUNNING status (only the initial declaration was ' +
+        'found) -- a transient blip followed by recovery would keep counting ' +
+        'toward the threshold instead of clearing.',
+    )
+  }
+
+  if (!/MAX_CONSECUTIVE_QUEUE_POLL_FAILURES/.test(body)) {
+    errors.push(
+      'waitForQueuedArtJob does not reference ' +
+        'MAX_CONSECUTIVE_QUEUE_POLL_FAILURES -- there is no bounded ' +
+        'threshold past which a persistent status-fetch failure stops being ' +
+        'retried.',
+    )
+  }
+
+  if (!/throw new Error/.test(body)) {
+    errors.push(
+      'waitForQueuedArtJob has no `throw new Error` reachable from the ' +
+        'failure-handling branch -- there is no path by which persistent ' +
+        'status-fetch failures actually exit the poll loop; it would retry ' +
+        'forever regardless of any counter.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkArtQueuePollFailureGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Art queue poll-failure guard contract failed for stores/artStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Art queue poll-failure guard contract passed: waitForQueuedArtJob caps ' +
+      'consecutive status-fetch failures and throws instead of retrying ' +
+      'forever.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What

`stores/artStore.ts`'s `waitForQueuedArtJob()` polls a queued art job's status every `ART_QUEUE_POLL_MS`. A failed/null status fetch (network blip, expired session, circuit breaker open, genuine 404) fell through the same branch as a real `PENDING`/`RUNNING` status with no retry cap and no timeout — a *persistent* failure left the awaited promise never resolving or rejecting, so `generateArt`'s own try/catch never ran and the whole synchronous generation path (`generateItemAsset` → `generateCurrentArt` → `generateArt` → `enqueueAndRenderArtImage`) hung indefinitely with nothing surfaced to the user.

Same defect class as `pollAsyncArtJob` in `modelBuilderStore.ts` (t-029 cycle 36), just in the shared art store's synchronous-wait sibling instead of Model Builder's async poll loop — and more consequential, since `waitForQueuedArtJob` backs every synchronous art-generation call site in the app, not just Model Builder.

## Changes

- **`stores/artStore.ts`** — `waitForQueuedArtJob` now counts consecutive non-terminal, non-`PENDING`/`RUNNING` outcomes separately from genuine `PENDING`/`RUNNING` statuses and throws past `MAX_CONSECUTIVE_QUEUE_POLL_FAILURES` (6, ~30s) instead of looping forever. The thrown error propagates through `enqueueAndRenderArtImage` into `generateArt`'s existing catch block, the same error-surfacing path a genuine `FAILED` job already uses.
- **`stores/modelBuilderStore.ts`** — updated a stale comment referencing the removed `ART_QUEUE_TIMEOUT_MS` constant to describe the actual current behavior (no separate overall timeout; bounded only by consecutive failed status checks).
- **`utils/scripts/verifyArtQueuePollFailureGuard.ts` + `.test.ts`** (new) — regression guard checking `waitForQueuedArtJob`'s source for a failure counter, a threshold reference, a reset on recovery, and a reachable `throw`. Wired into `package.json`/`contract-tests.yml`.

## Verification

- New guard self-test + real-file pass
- All 129 `test:model-builder-*` npm scripts pass (sibling suite, confirms no regression from the `modelBuilderStore.ts` comment edit)
- `vue-tsc --noEmit` clean
- `eslint`/`prettier --check` clean on touched files (pre-existing, unrelated `no-empty`/unused-var findings in both store files confirmed present on `main` before this change via `git stash` diff — left untouched per scope discipline)
- `verifyCaptureGroupGuards.ts origin/main` clean (no new `.match()`/`.exec()` call sites)
- `git status --porcelain` scoped to exactly the 6 intended files

Closes conductor `model-builder/t-029` cycle 37.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CwnNLTcFtPJhncVGvMrRf3)_