### PR TITLE
fix(video): cap consecutive queue-status poll failures instead of retrying forever (model-builder/t-029 cycle 38)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -455,6 +455,12 @@ jobs:
       - name: Art queue poll-failure guard contract
         run: npm run test:art-queue-poll-failure-guard
 
+      - name: Video job poll-failure guard checker self-test
+        run: npm run test:video-job-poll-failure-guard-selftest
+
+      - name: Video job poll-failure guard contract
+        run: npm run test:video-job-poll-failure-guard
+
       - name: Model Builder Dream-type choices guard checker self-test
         run: npm run test:model-builder-dream-type-choices-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -237,6 +237,8 @@
     "test:model-builder-async-poll-failure-guard": "tsx utils/scripts/verifyModelBuilderAsyncPollFailureGuard.ts",
     "test:art-queue-poll-failure-guard-selftest": "tsx utils/scripts/verifyArtQueuePollFailureGuard.test.ts",
     "test:art-queue-poll-failure-guard": "tsx utils/scripts/verifyArtQueuePollFailureGuard.ts",
+    "test:video-job-poll-failure-guard-selftest": "tsx utils/scripts/verifyVideoJobPollFailureGuard.test.ts",
+    "test:video-job-poll-failure-guard": "tsx utils/scripts/verifyVideoJobPollFailureGuard.ts",
     "test:model-builder-dream-type-choices-guard-selftest": "tsx utils/scripts/verifyModelBuilderDreamTypeChoicesGuard.test.ts",
     "test:model-builder-dream-type-choices-guard": "tsx utils/scripts/verifyModelBuilderDreamTypeChoicesGuard.ts",
     "test:model-builder-commit-stale-snapshot-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitStaleSnapshotGuard.test.ts",

--- a/stores/videoStore.ts
+++ b/stores/videoStore.ts
@@ -168,7 +168,23 @@ export const useVideoStore = defineStore('videoStore', () => {
     return res.data.jobId
   }
 
+  // `res.success` is false for BOTH "job not started yet" and "the status
+  // fetch itself failed" (performFetch never throws -- a network blip, an
+  // expired session's 401, the store-wide circuit breaker being open, or a
+  // genuine 404 all collapse to the same `job: null`). Before this fix, that
+  // null fell through to the same "keep polling" path as a genuine
+  // PENDING/RUNNING status with no retry cap and no timeout, so a
+  // *persistent* fetch failure (e.g. the user's JWT expiring mid-render)
+  // looped forever every POLL_MS -- this await never resolved or rejected,
+  // so generate()'s own try/catch never ran and the caller was left awaiting
+  // indefinitely with nothing surfaced. Caps consecutive failed status
+  // checks before giving up, mirroring the sibling fix already applied to
+  // artStore.ts's waitForQueuedArtJob and modelBuilderStore.ts's
+  // pollAsyncArtJob.
+  const MAX_CONSECUTIVE_POLL_FAILURES = 6 // ~30s of failed status checks
+
   async function waitForJob(jobId: number): Promise<QueuedJob> {
+    let consecutivePollFailures = 0
     while (true) {
       const res = await performFetch<{ job: QueuedJob }>(
         `/api/art/queue/${jobId}`,
@@ -185,6 +201,17 @@ export const useVideoStore = defineStore('videoStore', () => {
         job?.status === 'CANCELLED'
       ) {
         return job
+      }
+
+      if (job?.status === 'RUNNING' || job?.status === 'PENDING') {
+        consecutivePollFailures = 0
+      } else {
+        consecutivePollFailures += 1
+        if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
+          throw new Error(
+            `Lost track of video job ${jobId} after ${consecutivePollFailures} failed status checks.`,
+          )
+        }
       }
 
       const notice = artJobRetryNotice(job)

--- a/utils/scripts/verifyVideoJobPollFailureGuard.test.ts
+++ b/utils/scripts/verifyVideoJobPollFailureGuard.test.ts
@@ -1,0 +1,168 @@
+// /utils/scripts/verifyVideoJobPollFailureGuard.test.ts
+//
+// Regression test for checkVideoJobPollFailureGuard() in
+// verifyVideoJobPollFailureGuard.ts (model-builder/t-029, cycle 38).
+// Exercises the real check against synthetic waitForJob-shaped fixtures: the
+// pre-fix shape (a null/failed status fetch falls through to the same
+// unbounded retry as a genuine PENDING/RUNNING status), the fixed shape
+// (bounded consecutive-failure counter with a real throw), and partial
+// fixtures missing one piece of the fix each.
+import assert from 'node:assert/strict'
+
+import {
+  checkVideoJobPollFailureGuard,
+  extractWaitForJobBody,
+} from './verifyVideoJobPollFailureGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function waitForJob(jobId: number): Promise<QueuedJob> {
+    while (true) {
+      const res = await performFetch<{ job: QueuedJob }>(
+        \`/api/art/queue/\${jobId}\`,
+        { method: 'GET' },
+        2,
+        20_000,
+      )
+
+      const job = res.success ? res.data?.job : null
+
+      if (
+        job?.status === 'DONE' ||
+        job?.status === 'FAILED' ||
+        job?.status === 'CANCELLED'
+      ) {
+        return job
+      }
+
+      if (job?.status === 'RUNNING') {
+        state.status = 'rendering'
+      } else if (job?.status === 'PENDING') {
+        state.status = 'queued'
+      }
+
+      await sleep(POLL_MS)
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function waitForJob(jobId: number): Promise<QueuedJob> {
+    let consecutivePollFailures = 0
+    while (true) {
+      const res = await performFetch<{ job: QueuedJob }>(
+        \`/api/art/queue/\${jobId}\`,
+        { method: 'GET' },
+        2,
+        20_000,
+      )
+
+      const job = res.success ? res.data?.job : null
+
+      if (
+        job?.status === 'DONE' ||
+        job?.status === 'FAILED' ||
+        job?.status === 'CANCELLED'
+      ) {
+        return job
+      }
+
+      if (job?.status === 'RUNNING' || job?.status === 'PENDING') {
+        consecutivePollFailures = 0
+      } else {
+        consecutivePollFailures += 1
+        if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
+          throw new Error(
+            \`Lost track of video job \${jobId} after \${consecutivePollFailures} failed status checks.\`,
+          )
+        }
+      }
+
+      if (job?.status === 'RUNNING') {
+        state.status = 'rendering'
+      } else if (job?.status === 'PENDING') {
+        state.status = 'queued'
+      }
+
+      await sleep(POLL_MS)
+    }
+  }
+`
+
+const MISSING_THROW_FIXTURE = `
+  async function waitForJob(jobId: number): Promise<QueuedJob> {
+    let consecutivePollFailures = 0
+    while (true) {
+      const job = await pollOnce(jobId)
+      if (job?.status === 'PENDING' || job?.status === 'RUNNING') {
+        consecutivePollFailures = 0
+      } else {
+        consecutivePollFailures += 1
+        if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
+          return job
+        }
+      }
+      await sleep(POLL_MS)
+    }
+  }
+`
+
+function run(): void {
+  // --- extraction sanity ---
+  assert.equal(extractWaitForJobBody('no such function here'), null)
+  assert.ok(
+    extractWaitForJobBody(FIXED_FIXTURE)?.startsWith(
+      'async function waitForJob(',
+    ),
+  )
+
+  // --- buggy fixture: no counter, no threshold, no throw ---
+  const buggyErrors = checkVideoJobPollFailureGuard(BUGGY_FIXTURE)
+  assert.ok(
+    buggyErrors.some((e) => e.includes('consecutive-failure counter')),
+    `expected the buggy fixture to flag the missing counter, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(
+    buggyErrors.some((e) => e.includes('MAX_CONSECUTIVE_POLL_FAILURES')),
+    `expected the buggy fixture to flag the missing threshold, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(
+    buggyErrors.some((e) => e.includes('throw new Error')),
+    `expected the buggy fixture to flag the missing throw, got: ${JSON.stringify(buggyErrors)}`,
+  )
+
+  // --- fixed fixture: passes clean ---
+  const fixedErrors = checkVideoJobPollFailureGuard(FIXED_FIXTURE)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  // --- partial fixture: counter exists but never actually throws ---
+  const missingThrowErrors = checkVideoJobPollFailureGuard(
+    MISSING_THROW_FIXTURE,
+  )
+  assert.ok(
+    missingThrowErrors.length > 0,
+    'expected the missing-throw fixture (counter present, but the failure ' +
+      'branch never throws) to fail',
+  )
+  assert.ok(
+    missingThrowErrors.some((e) => e.includes('throw new Error')),
+    `expected a throw-related error, got: ${JSON.stringify(missingThrowErrors)}`,
+  )
+
+  // --- missing-anchor fixture ---
+  const missingAnchorErrors = checkVideoJobPollFailureGuard('const x = 1')
+  assert.equal(missingAnchorErrors.length, 1)
+  assert.match(missingAnchorErrors[0]!, /Could not find/)
+
+  console.log(
+    'Video job poll-failure guard self-test passed: buggy fixture fails on ' +
+      'the missing counter/threshold/throw, fixed fixture passes, a ' +
+      'never-throws partial fixture fails, missing-anchor fixture fails ' +
+      'clearly.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyVideoJobPollFailureGuard.ts
+++ b/utils/scripts/verifyVideoJobPollFailureGuard.ts
@@ -1,0 +1,188 @@
+// /utils/scripts/verifyVideoJobPollFailureGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 38). stores/videoStore.ts's
+// waitForJob() polls a queued video job's status every POLL_MS via a direct
+// performFetch call, which resolves to a null job for BOTH "the job hasn't
+// started yet" and "the status fetch itself failed" -- performFetch never
+// throws; a network blip, an expired session's 401, the store-wide circuit
+// breaker being open, or a genuine 404 all collapse to the same null.
+//
+// Before this fix, the loop only special-cased a terminal status
+// (DONE/FAILED/CANCELLED, which returns) and a genuine PENDING/RUNNING
+// status (which just updated state.status/state.message) -- any other
+// outcome, including a null job from a persistently failing fetch, fell
+// straight through to `await sleep(POLL_MS)` and looped again with no retry
+// cap and no timeout. Concrete failure: this function backs generate(), the
+// video-generator page's only entry point -- a persistent status-fetch
+// failure (e.g. the user's JWT expiring mid-render) left the awaited promise
+// never resolving or rejecting, so generate's own try/catch never ran,
+// nothing was ever surfaced to the user, and state.status sat stuck at
+// 'queued'/'rendering' forever. Same defect class as pollAsyncArtJob
+// (modelBuilderStore.ts, cycle 36) and waitForQueuedArtJob (artStore.ts,
+// cycle 37), just in the video store's own poll loop.
+//
+// Fixed by counting consecutive non-terminal, non-PENDING/RUNNING outcomes
+// (i.e. a null/failed status fetch) separately from genuine PENDING/RUNNING
+// statuses and, past a bounded threshold (MAX_CONSECUTIVE_POLL_FAILURES),
+// throwing instead of looping forever -- the thrown error propagates into
+// generate's existing catch block, the same error-surfacing path a genuine
+// FAILED job already uses.
+//
+// This checks waitForJob's source text for: (1) a per-call failure counter,
+// (2) the counter being compared against a threshold constant, and (3) a
+// `throw` reachable from the failure branch (proof the loop can actually
+// exit on persistent failure, not just retry forever).
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/videoStore.ts')
+
+const FUNCTION_ANCHOR = 'async function waitForJob('
+
+/**
+ * Extracts waitForJob's full function body (from its `async function`
+ * anchor through the balancing closing brace), so the checks below are
+ * robust to reformatting/comment changes elsewhere in the file. Mirrors
+ * extractWaitForQueuedArtJobBody's brace-balancing approach
+ * (verifyArtQueuePollFailureGuard.ts), including skipping over
+ * string/template literals so a `${jobId}`-style interpolation in the real
+ * fix's error message can't desync the brace-depth count.
+ */
+export function extractWaitForJobBody(content: string): string | null {
+  const anchorIndex = content.indexOf(FUNCTION_ANCHOR)
+  if (anchorIndex === -1) return null
+
+  const paramsOpen = anchorIndex + FUNCTION_ANCHOR.length - 1 // the '(' itself
+  let parenDepth = 0
+  let paramsClose = -1
+  for (let i = paramsOpen; i < content.length; i++) {
+    if (content[i] === '(') parenDepth++
+    else if (content[i] === ')') {
+      parenDepth--
+      if (parenDepth === 0) {
+        paramsClose = i
+        break
+      }
+    }
+  }
+  if (paramsClose === -1) return null
+
+  const bodyOpen = content.indexOf('{', paramsClose)
+  if (bodyOpen === -1) return null
+
+  let depth = 0
+  let i = bodyOpen
+  for (; i < content.length; i++) {
+    const char = content[i]
+
+    if (char === "'" || char === '"' || char === '`') {
+      i += 1
+      while (i < content.length && content[i] !== char) {
+        if (content[i] === '\\') i += 1
+        i += 1
+      }
+      continue
+    }
+
+    if (char === '{') depth++
+    else if (char === '}') {
+      depth--
+      if (depth === 0) break
+    }
+  }
+  if (depth !== 0) return null
+
+  return content.slice(anchorIndex, i + 1)
+}
+
+export function checkVideoJobPollFailureGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const body = extractWaitForJobBody(content)
+  if (body === null) {
+    errors.push(
+      `Could not find \`${FUNCTION_ANCHOR}\` in videoStore.ts -- has ` +
+        'waitForJob been renamed, removed, or restructured? If so, this ' +
+        'guard (and the infinite-retry bug it protects against) needs to ' +
+        'move with it.',
+    )
+    return errors
+  }
+
+  const counterDeclared = /let\s+consecutivePollFailures\s*=\s*0/.test(body)
+  if (!counterDeclared) {
+    errors.push(
+      'waitForJob no longer declares a consecutive-failure counter ' +
+        '(expected `let consecutivePollFailures = 0`) -- without one, a ' +
+        'persistent status-fetch failure has no way to be distinguished ' +
+        'from a transient one.',
+    )
+  }
+
+  if (!/consecutivePollFailures\s*\+=\s*1/.test(body)) {
+    errors.push(
+      'waitForJob never increments consecutivePollFailures -- the failure ' +
+        'count would never advance, so the threshold check below it could ' +
+        'never trigger.',
+    )
+  }
+
+  const zeroAssignmentCount = (
+    body.match(/consecutivePollFailures\s*=\s*0/g) ?? []
+  ).length
+  if (zeroAssignmentCount < 2) {
+    errors.push(
+      'waitForJob never resets consecutivePollFailures back to 0 on a ' +
+        'genuine PENDING/RUNNING status (only the initial declaration was ' +
+        'found) -- a transient blip followed by recovery would keep ' +
+        'counting toward the threshold instead of clearing.',
+    )
+  }
+
+  if (!/MAX_CONSECUTIVE_POLL_FAILURES/.test(body)) {
+    errors.push(
+      'waitForJob does not reference MAX_CONSECUTIVE_POLL_FAILURES -- ' +
+        'there is no bounded threshold past which a persistent ' +
+        'status-fetch failure stops being retried.',
+    )
+  }
+
+  if (!/throw new Error/.test(body)) {
+    errors.push(
+      'waitForJob has no `throw new Error` reachable from the ' +
+        'failure-handling branch -- there is no path by which persistent ' +
+        'status-fetch failures actually exit the poll loop; it would retry ' +
+        'forever regardless of any counter.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkVideoJobPollFailureGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Video job poll-failure guard contract failed for stores/videoStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Video job poll-failure guard contract passed: waitForJob caps ' +
+      'consecutive status-fetch failures and throws instead of retrying ' +
+      'forever.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
model-builder/t-029 (recurring): Polish and upgrade Model Builder front-end surface — cycle 38.

### What changed / what I produced
- `stores/videoStore.ts`'s `waitForJob()` polled `/api/art/queue/:id` in an unbounded `while (true)` loop. A failed status fetch (network blip, expired session, circuit breaker open, genuine 404) resolves to `job: null`, which fell through the same branch as a real `PENDING`/`RUNNING` status with no retry cap and no timeout — a persistent failure left `generate()`'s awaited promise never resolving or rejecting, so its own `try`/`catch` never ran and `state.status` sat stuck at `'queued'`/`'rendering'` forever with nothing surfaced to the user.
- Same defect class already fixed in `modelBuilderStore.ts`'s `pollAsyncArtJob` (cycle 36) and `artStore.ts`'s `waitForQueuedArtJob` (cycle 37). This mirrors that fix: counts consecutive non-terminal, non-`PENDING`/`RUNNING` outcomes separately from genuine `PENDING`/`RUNNING` statuses and throws past `MAX_CONSECUTIVE_POLL_FAILURES` (6, ~30s) instead of looping forever.
- Added `utils/scripts/verifyVideoJobPollFailureGuard.ts` + `.test.ts` (mirroring the sibling guards' brace-balancing extraction approach), wired into `package.json`/`contract-tests.yml`.
- Investigated `stores/resourceGalleryStore.ts`'s `waitForPreview` (the other candidate lead from cycle 37's note): it is **already safe** — a bounded `for` loop (120 attempts × 2.5s) that returns `null` immediately on a failed fetch rather than continuing to poll. No fix needed there.

### How I verified
- New guard self-test + real-file pass (`test:video-job-poll-failure-guard-selftest`, `test:video-job-poll-failure-guard`)
- Sibling `test:video-retry-notice-selftest` / `test:video-retry-notice` pass (confirms no regression from touching the code adjacent to `artJobRetryNotice` usage)
- `vue-tsc --noEmit` clean repo-wide
- `eslint` / `prettier --check` clean on touched files
- `git status --porcelain` scoped to exactly the 5 intended files

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
`stores/artStore.ts` and `stores/modelBuilderStore.ts` both had this defect and are now fixed; `stores/videoStore.ts` is now fixed too. `stores/resourceGalleryStore.ts` was checked and is already safe. Worth a final pass over any other store with a raw `performFetch`-based poll loop (grep for `while (true)` + `performFetch` across `stores/`) to confirm no fourth sibling remains before considering this defect class closed app-wide.

### Notes for reviewer
None.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBWQWPxXpquWXPht9FzDeo)_