### PR TITLE
Backfill Academy failureMode for 11 lessons + coverage contract (ai-art-academy/t-071)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -170,6 +170,9 @@ jobs:
       - name: Academy style gallery disclosure contract
         run: npm run test:academy-style-gallery-disclosure
 
+      - name: Academy failureMode coverage contract
+        run: npm run test:academy-failuremode-coverage
+
       - name: Navigation route access contract
         run: npx tsx utils/scripts/verifyNavigationRouteAccess.ts
 

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "test:academy-starter-manifest": "tsx utils/scripts/verifyAcademyStarterManifest.ts",
     "test:academy-examples-manifest": "tsx utils/scripts/verifyAcademyExamplesManifest.ts",
     "test:academy-style-gallery-disclosure": "tsx utils/scripts/verifyAcademyStyleGalleryDisclosure.ts",
+    "test:academy-failuremode-coverage": "tsx utils/scripts/verifyAcademyFailureModeCoverage.ts",
     "test:workflow-paths": "tsx utils/scripts/verifyWorkflowPaths.ts",
     "test:workflow-pipefail": "tsx utils/scripts/verifyWorkflowPipefail.ts",
     "test:nightly-workflows": "node utils/scripts/verify-nightly-workflows.mjs",

--- a/stores/seeds/academyStyles.ts
+++ b/stores/seeds/academyStyles.ts
@@ -256,6 +256,8 @@ export const academyStyles: AcademyStyle[] = [
         note: 'Known for austere winter and river scenes; his handscroll format shows the same monumental idiom unrolling horizontally rather than in a single vertical view.',
       },
     ],
+    failureMode:
+      "Often keeps the source photo's naturalistic lighting and cast shadows instead of flat monochrome ink tonality, and leaves the subject at its original scale rather than dwarfed by a towering peak — lean on the remix template's explicit 'no cast shadows' and 'tiny travelers dwarfed by scale' to keep the mountain's cosmological hierarchy intact.",
     remix: {
       mode: 'prompt',
       template:
@@ -407,6 +409,8 @@ export const academyStyles: AcademyStyle[] = [
         note: "Director of Shah Ismail's Tabriz workshop and first project director of the Shahnameh of Shah Tahmasp, known for dense, imaginative compositions.",
       },
     ],
+    failureMode:
+      "Easily reverts to Western linear perspective and cast shadows, since most training data assumes them by default — lean on the remix template's explicit 'no Western perspective or cast shadow' and push the dense floral or geometric border to keep the miniature's flat, ornamental logic intact.",
     remix: {
       mode: 'prompt',
       template:
@@ -1886,6 +1890,8 @@ export const academyStyles: AcademyStyle[] = [
         note: "The movement's central figure and this lesson's sole verified generation-style anchor; Dwight Tryon, Ralph Albert Blakelock, and J. Francis Murphy are also commonly cited Tonalists but have no rights-verified example work in this curriculum yet.",
       },
     ],
+    failureMode:
+      "Likely stays too crisp and multi-toned, reading as a slightly muted photo rather than a unified single-tone glaze; lean on the remix template's explicit 'single dominant harmony' and 'blurred edges toward near-silhouette' to push it past Hudson River School's sharp detail and toward Tonalism's soft, remembered quality.",
     remix: {
       mode: 'prompt',
       template:
@@ -1926,6 +1932,8 @@ export const academyStyles: AcademyStyle[] = [
         note: "Extended Barbizon's plein-air practice along the rivers of northern France, working increasingly from a studio boat; among the most direct influences cited by the early Impressionists.",
       },
     ],
+    failureMode:
+      "Risks drifting toward Impressionism's broken, high-key color instead of Barbizon's more tonally unified, controlled brushwork, or toward an idealized academic finish instead of humble direct observation; lean on the remix template's explicit 'muted, earthy palette' and 'no academic or mythological staging' to keep the plain, dignified rural subject intact.",
     remix: {
       mode: 'prompt',
       template:
@@ -1966,6 +1974,8 @@ export const academyStyles: AcademyStyle[] = [
         note: 'Painted calm inland lake and shoreline scenes (Lake George, Newport) with the same smooth, light-precise handling.',
       },
     ],
+    failureMode:
+      "Easily keeps visible brushwork or a dramatic sky like Hudson River School, or blurs into Tonalism's soft near-silhouette mood, instead of Luminism's own smooth, almost-invisible finish and mirror-still water; lean on the remix template's explicit 'extremely smooth, near-invisible brushwork' and 'hushed and motionless' phrasing to hold the distinction between all three American landscape lessons.",
     remix: {
       mode: 'prompt',
       template:
@@ -2006,6 +2016,8 @@ export const academyStyles: AcademyStyle[] = [
         note: 'Brought a narrative, often melancholic sensibility to bush-settler subjects, frequently in a looser, more textured brushwork than Roberts or Streeton.',
       },
     ],
+    failureMode:
+      "Can collapse into generic French Impressionist color and brushwork, losing the specific high-key blue-and-gold Australian light and dusty bush subject; lean on the remix template's explicit 'harsh direct Australian sunlight' and 'dusty ochre-and-olive bush' phrasing, and discuss the movement's settler-nationalist framing honestly rather than teaching the light alone — the same treatment this curriculum gives Hudson River School's Manifest Destiny undertone.",
     remix: {
       mode: 'prompt',
       template:
@@ -2046,6 +2058,8 @@ export const academyStyles: AcademyStyle[] = [
         note: "Softened the mode's austerity in the second half of the century with tender, warmly lit devotional scenes and genre paintings of Seville's street children.",
       },
     ],
+    failureMode:
+      "Risks tipping into Italian Baroque's swirling theatrical motion or Dutch Baroque's cozy domestic warmth instead of Spanish Golden Age's frozen, austere gravity; lean on the remix template's explicit 'single strong light source against a near-black ground' and 'minimal ornament' to keep the stillness and restraint.",
     remix: {
       mode: 'prompt',
       template:
@@ -2086,6 +2100,8 @@ export const academyStyles: AcademyStyle[] = [
         note: "A leading pupil of Raphael who carried Roman Mannerism's crowded, elegant figure groups into large-scale religious painting.",
       },
     ],
+    failureMode:
+      "Likely under-cooks toward a generic High Renaissance portrait instead of committing to Mannerism's deliberate elongation and artifice; lean on the remix template's explicit 'elongated figures in artificial, twisting poses' and 'cool porcelain-smooth skin' phrasing to push past Renaissance naturalism rather than settle for it.",
     remix: {
       mode: 'prompt',
       template:
@@ -2116,6 +2132,8 @@ export const academyStyles: AcademyStyle[] = [
         note: 'The earliest Ethiopian icon painter identifiable by name and the presumed source of a recognizable workshop style; named for historical context only, since this lesson\'s example works are catalogued as "Follower of Fre Seyon" or anonymous rather than by his own verified hand.',
       },
     ],
+    failureMode:
+      'Can collapse into a generic Byzantine Mosaic look since both share hieratic frontality and flat symbolic color; lean on the remix template\'s explicit wide-open frontal "reversal gaze" eyes and the red-ochre/gold/blue-green palette to keep Ethiopian icon painting visually distinct from its Byzantine source tradition.',
     remix: {
       mode: 'prompt',
       template:
@@ -2156,6 +2174,8 @@ export const academyStyles: AcademyStyle[] = [
         note: "Hōitsu's leading pupil, whose sharper, more graphic botanical forms mark the tradition's latest phase taught here.",
       },
     ],
+    failureMode:
+      "Likely collapses into a generic Ukiyo-e print look or a flat gold-leaf decorative filter, skipping the tarashikomi pooled-ink technique that makes Rinpa distinct; lean on the remix template's explicit 'pooled ink-and-color edges' and 'asymmetrical cropped arrangement' phrasing to keep the brushed, one-of-a-kind quality Ukiyo-e's woodblock printmaking doesn't have.",
     remix: {
       mode: 'prompt',
       template:
@@ -2186,6 +2206,8 @@ export const academyStyles: AcademyStyle[] = [
         note: 'The Kishangarh school\'s most celebrated later painter, credited with the "Bani Thani" portrait type; named for historical context only, since this lesson\'s Kishangarh example work predates his documented activity.',
       },
     ],
+    failureMode:
+      "Risks drifting toward Mughal Miniature's naturalistic modeling and atmospheric depth instead of Rajput's flat saturated color fields; lean on the remix template's explicit 'flat fields of intensely saturated red, yellow, and blue' and 'architecture and landscape flattened into decorative pattern' phrasing to keep the two Indian court traditions visually distinct.",
     remix: {
       mode: 'prompt',
       template:

--- a/utils/scripts/verifyAcademyFailureModeCoverage.ts
+++ b/utils/scripts/verifyAcademyFailureModeCoverage.ts
@@ -1,0 +1,74 @@
+// utils/scripts/verifyAcademyFailureModeCoverage.ts
+//
+// ai-art-academy/t-071: historical t-025 backfilled a bespoke `failureMode`
+// ("what tends to go wrong" note for the Try It beat) for every movement that
+// existed when it closed, but the curriculum has since expanded and nothing
+// re-checked the denominator. academy-style-detail.vue falls back to a
+// generic mode-level note for any style without one, so a gap is silent in
+// the UI (the Try It beat still renders) and easy to lose track of as new
+// styles are added. This is a lightweight coverage contract, not a schema
+// check: it reports the bespoke-vs-fallback split and fails only when a
+// style has no `failureMode` and isn't listed in the exceptions below with a
+// documented reason — so a newly-added style surfaces explicitly instead of
+// silently shrinking the coverage percentage.
+//
+// Run: npm run test:academy-failuremode-coverage
+
+import { academyStyles } from '../../stores/seeds/academyStyles'
+
+// Slugs intentionally left on the generic mode-level fallback, with why.
+// Empty today (t-071 brought coverage to 47/47) — add an entry here only
+// with a documented policy reason, never to silence a routine gap.
+const DOCUMENTED_FALLBACK_EXCEPTIONS: Record<string, string> = {}
+
+function main(): void {
+  const missing: string[] = []
+  const undocumentedExceptions: string[] = []
+
+  for (const style of academyStyles) {
+    const hasFailureMode =
+      typeof style.failureMode === 'string' && style.failureMode.trim() !== ''
+    if (!hasFailureMode) missing.push(style.slug)
+  }
+
+  for (const slug of Object.keys(DOCUMENTED_FALLBACK_EXCEPTIONS)) {
+    if (!missing.includes(slug)) {
+      undocumentedExceptions.push(
+        `${slug}: listed in DOCUMENTED_FALLBACK_EXCEPTIONS but already has a failureMode — remove the stale exception entry`,
+      )
+    }
+  }
+
+  const trulyMissing = missing.filter(
+    (slug) => !(slug in DOCUMENTED_FALLBACK_EXCEPTIONS),
+  )
+
+  const total = academyStyles.length
+  const covered = total - missing.length
+  const pct = total === 0 ? 100 : Math.round((covered / total) * 100)
+
+  if (trulyMissing.length || undocumentedExceptions.length) {
+    console.error(
+      `Academy failureMode coverage contract failed (${covered}/${total} styles, ${pct}% bespoke):`,
+    )
+    for (const slug of trulyMissing) {
+      console.error(
+        `- ${slug}: no failureMode set and not in DOCUMENTED_FALLBACK_EXCEPTIONS. Add a bespoke ` +
+          '"what tends to go wrong" note grounded in this lesson\'s remix template, or add a ' +
+          'documented exception if the generic fallback is the deliberate choice.',
+      )
+    }
+    for (const message of undocumentedExceptions) console.error(`- ${message}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Academy failureMode coverage contract passed: ${covered}/${total} styles (${pct}%) have a bespoke failureMode` +
+      (Object.keys(DOCUMENTED_FALLBACK_EXCEPTIONS).length
+        ? `; ${Object.keys(DOCUMENTED_FALLBACK_EXCEPTIONS).length} documented exception(s) rely on the generic mode-level fallback.`
+        : '.'),
+  )
+}
+
+main()


### PR DESCRIPTION
### Task
ai-art-academy/t-071: Backfill per-style Try It failure-mode guidance for every current Academy lesson (kind: software)

### What changed / what I produced
- Re-measured `stores/seeds/academyStyles.ts`: 47 canonical style entries, 36 had a bespoke `failureMode`, leaving 11 on the generic mode-level fallback (`academy-style-detail.vue` falls back gracefully, so nothing was broken — this is a curriculum-quality gap, not a missing feature).
- Added a grounded, style-specific `failureMode` to each of the 11: `song-dynasty-landscape`, `persian-miniature`, `tonalism`, `barbizon-school`, `american-luminism`, `heidelberg-school`, `spanish-golden-age`, `mannerism`, `ethiopian-icon-painting`, `rinpa-school`, `rajput-painting`. Each follows the established convention: names the likely AI-remix failure, points at the exact remix-template phrasing to lean on, and — where the lesson's own `keyIdeas` already draws the contrast — distinguishes it from a confusable sibling lesson (Rinpa vs. Ukiyo-e, Rajput vs. Mughal Miniature, Ethiopian icon painting vs. Byzantine Mosaic, American Luminism vs. Hudson River School/Tonalism, etc.).
- Added `utils/scripts/verifyAcademyFailureModeCoverage.ts`: a lightweight coverage contract (not a schema check) that reports the bespoke-vs-fallback split and fails only when a style has no `failureMode` and isn't listed in a documented exceptions map — so a future curriculum expansion surfaces the gap explicitly instead of silently shrinking coverage, per the task's acceptance criterion (4). Wired into `package.json` (`test:academy-failuremode-coverage`) and `.github/workflows/contract-tests.yml` alongside the other Academy contracts.
- Coverage is now 47/47 (100%).

### How I verified
- `npm run test:academy-failuremode-coverage` — passes (47/47).
- `npm run test:academy-examples-manifest` — still passes (confirms the sibling t-070 denominator/contract wasn't disturbed).
- `npx eslint stores/seeds/academyStyles.ts utils/scripts/verifyAcademyFailureModeCoverage.ts` — clean.
- `npx prettier --check` on all touched files — clean.
- `npx vue-tsc --noEmit` — clean, no errors.
- `git status --porcelain` / `git diff --stat` scoped to exactly the 4 intended files.

### Stakes
reversible

### Flags for Reviewer
- Per the task note, Example Works coverage is deliberately out of scope here (tracked separately as ai-art-academy/t-070); this PR only touches `failureMode`.
- `DOCUMENTED_FALLBACK_EXCEPTIONS` in the new guard is intentionally empty today — it exists so a future style can be deliberately exempted with a written reason instead of the check being loosened silently.

### Kaizen suggestion
ai-art-academy/t-070 (Example Works backfill for 27 lessons) is a much larger, rights-clearance-heavy content task — worth decomposing into smaller per-movement-cohort tasks rather than attempting all 27 in one pass, the same way t-013/t-025 originally shipped incrementally.

### Notes for reviewer
Conductor roadmap task ai-art-academy/t-071 claimed and moved to `status: review` in the companion conductor PR from this session.


---
_Generated by [Claude Code](https://claude.ai/code/session_018NSLf5Nh2cjNpB6TznAEhF)_