### PR TITLE
feat(art-queue): group recentFailed by normalized error signature (ai-art-academy/t-073)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -49,6 +49,9 @@ jobs:
       - name: ArtJob priority bounds contract
         run: npm run test:artjob-priority-bounds
 
+      - name: Art failure-signature grouping contract
+        run: npm run test:art-failure-signature
+
       - name: Comfy-only generation contract
         run: npm run test:comfy-only-generation
 

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "test:art-asset-suggest": "tsx utils/scripts/verifyArtAssetSuggest.ts",
     "test:artjob-bulk-scope": "tsx utils/scripts/verifyArtJobBulkScope.ts && tsx utils/scripts/verifyArtJobBulkCancel.ts",
     "test:artjob-lora-override": "tsx utils/scripts/verifyArtJobLoraOverride.ts",
+    "test:art-failure-signature": "tsx utils/scripts/verifyArtFailureSignature.test.ts",
     "test:comfy-model-paths": "tsx utils/scripts/verifyComfyModelPaths.ts",
     "test:channel-content": "tsx utils/scripts/verifyChannelContent.ts",
     "test:gallery-adoption": "tsx utils/scripts/verifyGalleryAdoption.ts",

--- a/server/api/art/queue/stats.get.ts
+++ b/server/api/art/queue/stats.get.ts
@@ -13,6 +13,7 @@ import { defineEventHandler, getQuery } from 'h3'
 import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
 import { requireAdminApiUser } from '../../../utils/authGuard'
+import { groupArtFailuresBySignature } from '../../../utils/artFailureSignature'
 
 // Mirror claim.post.ts STALE_CLAIM_MINUTES: a RUNNING job whose claim is older
 // than this is considered stuck (its relay likely died mid-render).
@@ -34,7 +35,9 @@ export default defineEventHandler(async (event) => {
     const query = getQuery(event)
     const windowHours = Math.min(Math.max(Number(query.window) || 24, 1), 720)
     const summaryOnly = ['1', 'true', 'yes'].includes(
-      String(query.summary || '').trim().toLowerCase(),
+      String(query.summary || '')
+        .trim()
+        .toLowerCase(),
     )
     const since = new Date(Date.now() - windowHours * 3_600_000)
     const staleBefore = new Date(Date.now() - STALE_CLAIM_MINUTES * 60_000)
@@ -78,6 +81,11 @@ export default defineEventHandler(async (event) => {
           staleRunningCount,
           staleRunning: [],
           recentFailed: [],
+          // Additive summary layer (ai-art-academy/t-073): empty here since
+          // recentFailed itself is empty in summary mode -- same shape as
+          // the full mode below so consumers don't need a mode-specific
+          // branch to read it.
+          failuresBySignature: [],
           imagesCreatedInWindow: 0,
           imagesByServer: [],
         },
@@ -166,6 +174,12 @@ export default defineEventHandler(async (event) => {
         staleRunningCount: staleRunning.length,
         staleRunning,
         recentFailed,
+        // Additive summary layer (ai-art-academy/t-073): the same
+        // `recentFailed` sample above, grouped by normalized error
+        // signature and then by projectSlug, so "is MY project's queue
+        // clean" is a glance instead of a manual scan of the raw array.
+        // `recentFailed` itself is untouched -- raw detail stays available.
+        failuresBySignature: groupArtFailuresBySignature(recentFailed),
         imagesCreatedInWindow: imagesInWindow,
         imagesByServer: imagesByServer.map((group) => ({
           serverName: group.serverName,

--- a/server/utils/artFailureSignature.ts
+++ b/server/utils/artFailureSignature.ts
@@ -1,0 +1,169 @@
+// /server/utils/artFailureSignature.ts
+//
+// Normalizes an ArtJob.error string into a small, stable set of known
+// failure signatures, and groups a batch of failed-job records by that
+// signature (and, within each signature, by projectSlug).
+//
+// Why this exists (ai-art-academy/t-073): GET /api/art/queue/stats'
+// `recentFailed` is a flat list of raw error strings. Two consumers had
+// independently converged on the same workaround -- manually reading that
+// raw list to answer "is my project's queue actually healthy, or is this
+// just an already-tracked issue on a different project?":
+//   - a human/agent verifying a render by eye (ai-art-academy/t-069's
+//     close-out, which had to rule out t-068's facet-catalog/dream-cycle
+//     CLIPTextEncode failures before trusting its own clean job)
+//   - `scripts/recheck_render_queue.py`'s own `summarize_failures()`, whose
+//     substring match on "workflow error" collapsed t-068's specific
+//     `hostbuf_file_reader_read failed` CLIPTextEncode signature into the
+//     same generic "workflow error" bucket as any other unrelated node
+//     failure -- exactly the loss of detail this module fixes.
+//
+// Pure, dependency-free logic (no prisma, no H3) so it can be unit-tested
+// directly and reused by any consumer (this repo's stats endpoint today;
+// conductor's recheck_render_queue.py mirrors the same signature set in
+// Python since it runs outside this repo's runtime).
+
+export type ArtFailureSignatureId =
+  | 'connection-refused'
+  | 'lora-not-in-list'
+  | 'hostbuf-file-reader-read'
+  | 'charmap-codec'
+  | 'workflow-error-other'
+  | 'no-error-text'
+  | 'other'
+
+export interface ArtFailureSignatureMatch {
+  /** Stable, machine-readable key -- safe to use as a grouping/sort key. */
+  signature: ArtFailureSignatureId
+  /** Short human-readable description of what this signature means. */
+  label: string
+}
+
+interface KnownSignature {
+  id: ArtFailureSignatureId
+  label: string
+  test: (error: string) => boolean
+}
+
+// Order matters: more specific patterns are checked before the generic
+// "workflow error" catch-all, so a known node-level failure (e.g.
+// hostbuf_file_reader_read) is never swallowed by the broader substring
+// match the way recheck_render_queue.py's original summarize_failures() did.
+const KNOWN_SIGNATURES: KnownSignature[] = [
+  {
+    id: 'connection-refused',
+    label: 'ComfyUI unreachable (connection refused)',
+    test: (error) =>
+      /actively refused/i.test(error) ||
+      /\b10061\b/.test(error) ||
+      /ConnectionRefused/i.test(error),
+  },
+  {
+    id: 'lora-not-in-list',
+    label: 'LoRA name not in list (asset-name resolution)',
+    test: (error) => /lora_name/i.test(error) && /not in \(?list/i.test(error),
+  },
+  {
+    id: 'hostbuf-file-reader-read',
+    label: 'hostbuf_file_reader_read failed (CLIPTextEncode node)',
+    test: (error) => /hostbuf_file_reader_read/i.test(error),
+  },
+  {
+    id: 'charmap-codec',
+    label: "'charmap' codec encoding crash (non-ASCII log line)",
+    test: (error) => /'charmap' codec/i.test(error),
+  },
+  {
+    id: 'workflow-error-other',
+    label: 'ComfyUI workflow error (other/unspecified node)',
+    test: (error) => /workflow error/i.test(error),
+  },
+]
+
+/**
+ * Classify a single raw ArtJob.error string into a known signature, or an
+ * `other` fallback carrying a truncated, id/path-stripped snippet of the raw
+ * text (so distinct-but-unrecognized errors don't all collapse into one
+ * bucket, while still remaining a bounded, stable-ish grouping key).
+ */
+export function classifyArtFailureSignature(
+  error: string | null | undefined,
+): ArtFailureSignatureMatch {
+  const text = String(error ?? '').trim()
+  if (!text) {
+    return { signature: 'no-error-text', label: '(no error text)' }
+  }
+
+  for (const known of KNOWN_SIGNATURES) {
+    if (known.test(text)) {
+      return { signature: known.id, label: known.label }
+    }
+  }
+
+  // Fallback: strip common job-specific/variable substrings (numeric ids,
+  // file paths, quoted asset names) so near-identical unrecognized errors
+  // still collapse together instead of each producing its own bucket.
+  const normalized = text
+    .replace(/\b\d{3,}\b/g, '#') // job/node/line-ish numeric ids
+    .replace(/(['"])(?:(?!\1).)*\1/g, '<name>') // quoted names/paths
+    .replace(/[\\/][\w.-]+(?:[\\/][\w.-]+)+/g, '<path>') // file paths
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 120)
+
+  return { signature: 'other', label: normalized || '(unrecognized error)' }
+}
+
+export interface ArtFailureGroupProjectCount {
+  projectSlug: string | null
+  count: number
+}
+
+export interface ArtFailureSignatureGroup {
+  signature: ArtFailureSignatureId
+  label: string
+  count: number
+  projectSlugs: ArtFailureGroupProjectCount[]
+}
+
+/**
+ * Group a batch of failed-job records (as returned by the recentFailed
+ * query -- anything carrying `error` and `projectSlug`) by normalized error
+ * signature, and within each signature by projectSlug. Sorted by count
+ * descending (signature, then projectSlug within it) so the most impactful
+ * failure pattern for the busiest project surfaces first.
+ */
+export function groupArtFailuresBySignature<
+  T extends { error?: string | null; projectSlug?: string | null },
+>(entries: readonly T[]): ArtFailureSignatureGroup[] {
+  const bySignature = new Map<
+    ArtFailureSignatureId,
+    { label: string; byProject: Map<string | null, number> }
+  >()
+
+  for (const entry of entries) {
+    const { signature, label } = classifyArtFailureSignature(entry.error)
+    const projectSlug = entry.projectSlug ?? null
+
+    let group = bySignature.get(signature)
+    if (!group) {
+      group = { label, byProject: new Map() }
+      bySignature.set(signature, group)
+    }
+    group.byProject.set(
+      projectSlug,
+      (group.byProject.get(projectSlug) ?? 0) + 1,
+    )
+  }
+
+  const groups: ArtFailureSignatureGroup[] = []
+  for (const [signature, { label, byProject }] of bySignature) {
+    const projectSlugs = Array.from(byProject.entries())
+      .map(([projectSlug, count]) => ({ projectSlug, count }))
+      .sort((a, b) => b.count - a.count)
+    const count = projectSlugs.reduce((sum, p) => sum + p.count, 0)
+    groups.push({ signature, label, count, projectSlugs })
+  }
+
+  return groups.sort((a, b) => b.count - a.count)
+}

--- a/utils/scripts/verifyArtFailureSignature.test.ts
+++ b/utils/scripts/verifyArtFailureSignature.test.ts
@@ -1,0 +1,164 @@
+// /utils/scripts/verifyArtFailureSignature.test.ts
+//
+// Regression test for ai-art-academy/t-073 (GET /api/art/queue/stats
+// recentFailed grouped by normalized error signature). Exercises
+// server/utils/artFailureSignature.ts's pure classification/grouping core
+// directly -- no prisma, no database, no Nuxt/H3 runtime -- same discipline
+// as utils/scripts/verifyRevenueSplit.test.ts.
+//
+// Fixture error strings below are real, byte-for-byte examples pulled from
+// conductor's RENDER-BACKLOG.md / ai-art-academy/roadmap.yaml RECHECK
+// history (t-044's lora_name rejection and charmap crash, t-068's
+// hostbuf_file_reader_read burst, and the recurring connection-refused
+// flakiness) -- not invented text, so the matchers are proven against the
+// actual failure signatures this task exists to distinguish.
+import assert from 'node:assert/strict'
+
+import {
+  classifyArtFailureSignature,
+  groupArtFailuresBySignature,
+} from '../../server/utils/artFailureSignature.js'
+
+// --- classifyArtFailureSignature: known signatures -------------------------
+
+{
+  const { signature, label } = classifyArtFailureSignature(
+    'ComfyUI reported a workflow error: node 3 (CLIPTextEncode): hostbuf_file_reader_read failed',
+  )
+  assert.equal(signature, 'hostbuf-file-reader-read')
+  assert.match(label, /hostbuf_file_reader_read/)
+}
+
+{
+  const { signature } = classifyArtFailureSignature(
+    "lora_name: 'Flux/SFW/3D_Cartoon_Vision_flux_v1.safetensors' not in (list of length 2231)",
+  )
+  assert.equal(signature, 'lora-not-in-list')
+}
+
+{
+  const { signature } = classifyArtFailureSignature(
+    "'charmap' codec can't encode character '\\U0001f527' in position 34: character maps to <undefined>",
+  )
+  assert.equal(signature, 'charmap-codec')
+}
+
+{
+  const { signature } = classifyArtFailureSignature(
+    'connection to http://127.0.0.1:8188 actively refused it (WinError 10061)',
+  )
+  assert.equal(signature, 'connection-refused')
+}
+
+// A generic ComfyUI workflow error that does NOT match any specific known
+// node/exception pattern still falls into the explicit "other" bucket, not
+// silently merged with hostbuf_file_reader_read -- this is the exact
+// over-collapsing bug recheck_render_queue.py's original substring match had
+// (checking "workflow error" before any specific signature).
+{
+  const { signature } = classifyArtFailureSignature(
+    'ComfyUI reported a workflow error: node 7 (VAEDecode): CUDA out of memory',
+  )
+  assert.equal(signature, 'workflow-error-other')
+  assert.notEqual(signature, 'hostbuf-file-reader-read')
+}
+
+{
+  const { signature, label } = classifyArtFailureSignature(null)
+  assert.equal(signature, 'no-error-text')
+  assert.equal(label, '(no error text)')
+}
+
+{
+  const { signature, label } = classifyArtFailureSignature(
+    'a completely unrecognized failure mode with id 48213 and path /tmp/foo/bar.png',
+  )
+  assert.equal(signature, 'other')
+  assert.ok(label.length > 0 && label.length <= 120)
+}
+
+// --- classifyArtFailureSignature: specificity ordering ----------------------
+// hostbuf_file_reader_read failures are also, textually, "a workflow error"
+// -- the fix must check the specific pattern first so it isn't swallowed by
+// the generic bucket.
+{
+  const { signature } = classifyArtFailureSignature(
+    'ComfyUI reported a workflow error: node 3 (CLIPTextEncode): hostbuf_file_reader_read failed',
+  )
+  assert.equal(signature, 'hostbuf-file-reader-read')
+}
+
+// --- groupArtFailuresBySignature: per-signature, per-projectSlug counts ----
+
+{
+  const recentFailed = [
+    {
+      error:
+        'ComfyUI reported a workflow error: node 3 (CLIPTextEncode): hostbuf_file_reader_read failed',
+      projectSlug: 'facet-catalog',
+    },
+    {
+      error:
+        'ComfyUI reported a workflow error: node 3 (CLIPTextEncode): hostbuf_file_reader_read failed',
+      projectSlug: 'facet-catalog',
+    },
+    {
+      error:
+        'ComfyUI reported a workflow error: node 3 (CLIPTextEncode): hostbuf_file_reader_read failed',
+      projectSlug: 'dream-cycle',
+    },
+    { error: null, projectSlug: 'academy-remix' },
+  ]
+
+  const groups = groupArtFailuresBySignature(recentFailed)
+  assert.ok(groups.length > 0)
+  const topGroup = groups[0]!
+
+  // hostbuf group should dominate (3/4) and be sorted first.
+  assert.equal(topGroup.signature, 'hostbuf-file-reader-read')
+  assert.equal(topGroup.count, 3)
+  assert.deepEqual(topGroup.projectSlugs, [
+    { projectSlug: 'facet-catalog', count: 2 },
+    { projectSlug: 'dream-cycle', count: 1 },
+  ])
+
+  const noErrorGroup = groups.find((g) => g.signature === 'no-error-text')
+  assert.ok(noErrorGroup)
+  assert.equal(noErrorGroup!.count, 1)
+  assert.deepEqual(noErrorGroup!.projectSlugs, [
+    { projectSlug: 'academy-remix', count: 1 },
+  ])
+
+  // Total across all groups equals the input length -- no entry dropped or
+  // double-counted.
+  const total = groups.reduce((sum, g) => sum + g.count, 0)
+  assert.equal(total, recentFailed.length)
+}
+
+// A clean render on a different project/workflow (t-069's ArtJob 9009) is
+// never conflated with an unrelated project's known-bad signature -- the
+// exact manual-scan pain point this task fixes.
+{
+  const recentFailed = [
+    {
+      error:
+        'ComfyUI reported a workflow error: node 3 (CLIPTextEncode): hostbuf_file_reader_read failed',
+      projectSlug: 'dream-cycle',
+    },
+  ]
+  const groups = groupArtFailuresBySignature(recentFailed)
+  assert.equal(groups.length, 1)
+  assert.equal(groups[0]!.signature, 'hostbuf-file-reader-read')
+  // 'academy' (the project a fresh render belongs to) never appears --
+  // grouping is purely a function of what's actually in the input.
+  assert.ok(
+    !groups.some((g) =>
+      g.projectSlugs.some((p) => p.projectSlug === 'academy'),
+    ),
+  )
+}
+
+// Empty input -> empty output, not an error.
+assert.deepEqual(groupArtFailuresBySignature([]), [])
+
+console.log('verifyArtFailureSignature: all assertions passed')


### PR DESCRIPTION
### Task
ai-art-academy/t-073: Break down `GET /api/art/queue/stats` `recentFailed` by error signature, not just free-text bucket (kind: software)

### What changed / what I produced
- New `server/utils/artFailureSignature.ts`: pure classification of an `ArtJob.error` string into a small set of known signatures (`connection-refused`, `lora-not-in-list`, `hostbuf-file-reader-read`, `charmap-codec`, `workflow-error-other`, `no-error-text`, `other`), checked in specificity order so a known node-level failure (e.g. `hostbuf_file_reader_read`) is never swallowed by the broader "workflow error" substring match. Also exports `groupArtFailuresBySignature()`, which buckets a batch of failed jobs by signature and then by `projectSlug`.
- `GET /api/art/queue/stats` now returns an additive `failuresBySignature` field alongside the existing flat `recentFailed` array (unchanged, still raw detail) — computed from the same 25-row `recentFailed` sample, no extra DB query. Summary mode (`?summary=true`) gets an empty `failuresBySignature: []` for shape parity since its `recentFailed` is also `[]`.
- New regression test `utils/scripts/verifyArtFailureSignature.test.ts` (`npm run test:art-failure-signature`), wired into `contract-tests.yml`, using real error strings pulled from conductor's `RENDER-BACKLOG.md`/`ai-art-academy/roadmap.yaml` RECHECK history (t-044's `lora_name` rejection, its charmap crash, t-068's `hostbuf_file_reader_read` burst, and the recurring connection-refused flakiness) — not invented fixtures.

### How I verified
- `npx tsx utils/scripts/verifyArtFailureSignature.test.ts` — all assertions pass, including a dedicated "specificity ordering" case proving `hostbuf_file_reader_read` (which textually also matches "workflow error") classifies as its own signature, not the generic bucket.
- `npx eslint` on all touched files — clean.
- `npx prettier --check` on all touched files — clean.
- `vue-tsc --noEmit -p tsconfig.json` (full project typecheck) — clean.
- No live/deployed verification possible pre-merge (no PR preview per AGENTS.md); the endpoint's DB-backed behavior itself is unchanged for existing consumers (additive field only).

### Stakes
reversible

### Flags for Reviewer
- I chose to derive `failuresBySignature` from the existing 25-row `recentFailed` sample rather than adding a separate broader-window query, per criterion 1's "recentFailed/recent-window failures" wording and to keep this a pure additive/no-extra-query change. Flag if you'd rather it scan a wider window independently of the 25-cap.
- Companion conductor-side change (extends `recheck_render_queue.py`'s own bucketing with the same signature set + per-projectSlug grouping, and updates t-068's RECHECK note prose) is being opened as a separate conductor PR in the same session.

### Kaizen suggestion
`recheck_render_queue.py`'s ledger entries are still one flat sentence per check; now that per-signature/per-project counts exist in the API, a future pass could have the ledger itself store/diff structured counts instead of prose, making "did this specific signature's count change since last check" a diff instead of a re-read.

### Notes for reviewer
Companion conductor PR: extends `scripts/recheck_render_queue.py`'s `summarize_failures()` to reuse the same signature categories (previously its "workflow error" substring check was the exact over-collapsing bug this task fixes) and adds per-projectSlug breakdown; also updates `ai-art-academy/t-068`'s RECHECK note prose only (not its `status`/gate) to reference the new grouped view.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UPXuLgCgGaX537PMyVkGMm)_