### PR TITLE
Fix Conductor project-state writes on self-hosted runtime

### DIFF
--- a/assets/css/conductor-feedback.css
+++ b/assets/css/conductor-feedback.css
@@ -1,0 +1,34 @@
+/* /assets/css/conductor-feedback.css
+ * Conductor's save/sync feedback sits on top of project art and translucent
+ * surfaces. Status-colored text alone disappears into that background, so the
+ * feedback gets its own opaque status chip instead of relying on foreground
+ * color for contrast.
+ */
+
+.kr-toolbar > span.text-error,
+.kr-surface
+  div:has(> select > option[value='HIGH'])
+  > span.self-center.text-xs.text-error {
+  border: 1px solid var(--color-error);
+  border-radius: var(--radius-field);
+  background: var(--color-error);
+  color: var(--color-error-content);
+  padding: 0.25rem 0.5rem;
+  font-weight: 700;
+  box-shadow: 0 0.25rem 0.75rem
+    color-mix(in oklch, var(--color-error) 22%, transparent);
+}
+
+.kr-toolbar > span.text-success,
+.kr-surface
+  div:has(> select > option[value='HIGH'])
+  > span.self-center.text-xs.text-success {
+  border: 1px solid var(--color-success);
+  border-radius: var(--radius-field);
+  background: var(--color-success);
+  color: var(--color-success-content);
+  padding: 0.25rem 0.5rem;
+  font-weight: 700;
+  box-shadow: 0 0.25rem 0.75rem
+    color-mix(in oklch, var(--color-success) 22%, transparent);
+}

--- a/plugins/conductor-admin-data.client.ts
+++ b/plugins/conductor-admin-data.client.ts
@@ -1,3 +1,4 @@
+import '~/assets/css/conductor-feedback.css'
 import { computed, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { useConductorStore } from '@/stores/conductorStore'

--- a/server/utils/conductor-github.ts
+++ b/server/utils/conductor-github.ts
@@ -1,16 +1,29 @@
 // /server/utils/conductor-github.ts
 // Shared helpers for reading/writing files in silasfelinus/conductor via GitHub API.
-// Requires GITHUB_TOKEN in Vercel environment variables.
+//
+// Production is self-hosted from a prebuilt GHCR image. `GITHUB_TOKEN` is loaded
+// into the running container by docker-compose's env_file, while Nuxt runtime
+// config defaults are serialized when that image is built. Read the live Node
+// environment first so a runtime-only secret is not mistaken for a missing one;
+// keep runtimeConfig as the development / NUXT_GITHUB_TOKEN fallback.
 
 export interface ConductorFile {
   sha: string
   content: string
 }
 
+function conductorGithubToken(): string {
+  const runtimeToken = useRuntimeConfig().githubToken
+  return (
+    process.env.GITHUB_TOKEN ||
+    (typeof runtimeToken === 'string' ? runtimeToken : '')
+  ).trim()
+}
+
 export async function conductorGet(
   path: string,
 ): Promise<ConductorFile | null> {
-  const { githubToken } = useRuntimeConfig()
+  const githubToken = conductorGithubToken()
 
   const headers: Record<string, string> = {
     Accept: 'application/vnd.github.v3+json',
@@ -48,13 +61,13 @@ export async function conductorPut(
   message: string,
   existingSha?: string,
 ): Promise<void> {
-  const { githubToken } = useRuntimeConfig()
+  const githubToken = conductorGithubToken()
 
   if (!githubToken) {
     throw createError({
       statusCode: 503,
       statusMessage:
-        'GITHUB_TOKEN is not configured. Add it to Vercel environment variables.',
+        'GitHub write access is not configured on this Kind Robots server. Set GITHUB_TOKEN in the runtime environment.',
     })
   }
 
@@ -97,7 +110,7 @@ export interface ConductorDirEntry {
 export async function conductorList(
   path: string,
 ): Promise<ConductorDirEntry[] | null> {
-  const { githubToken } = useRuntimeConfig()
+  const githubToken = conductorGithubToken()
 
   const headers: Record<string, string> = {
     Accept: 'application/vnd.github.v3+json',


### PR DESCRIPTION
## Root cause

Conductor project priority/status writes use `server/utils/conductor-github.ts`. That helper read only Nuxt `runtimeConfig.githubToken` and still told users to add `GITHUB_TOKEN` to Vercel. Production now runs as a prebuilt GHCR image under Docker Compose, where `.env` is loaded into the running container. A runtime-only `GITHUB_TOKEN` therefore needs to be read from `process.env` rather than relying on a config default serialized with the image build.

The project editor also rendered save/sync failures as status-colored text directly over translucent/project-art backgrounds, making the message difficult to read.

## Changes

- Read live `process.env.GITHUB_TOKEN` first for Conductor GitHub reads/writes, with Nuxt runtime config as fallback.
- Replace the stale Vercel-specific configuration error with self-hosted/runtime wording.
- Add an opaque DaisyUI-token-backed error/success surface for Conductor save/sync feedback.
- Load the feedback CSS with the existing Conductor admin plugin so it stays scoped to this surface.

## Safety / source of truth

This keeps Conductor as the canonical owner of project lifecycle/priority state. It repairs the existing authenticated GitHub write path rather than bypassing Conductor with a direct local-only Project mutation.

## Verification

CI checks on the exact PR head must complete green before merge. Production secret presence is intentionally not changed by this PR.