### PR TITLE
refactor(academy): extract shared per-style coverage-contract helper (ai-art-academy/t-075)

### DIFF
--- a/utils/scripts/academyCoverageContract.ts
+++ b/utils/scripts/academyCoverageContract.ts
@@ -1,0 +1,117 @@
+// utils/scripts/academyCoverageContract.ts
+//
+// ai-art-academy/t-075: three Academy verifier scripts
+// (verifyAcademyExamplesManifest.ts, verifyAcademyFailureModeCoverage.ts,
+// verifyAcademyArtistPortraitsManifest.ts) each independently re-derived the
+// same pattern — iterate every academyStyles.ts entry, check a per-style
+// optional field, cross-reference an exceptions/coverage list, report
+// bespoke-vs-fallback counts. Extracted per the same precedent as
+// academyProvenanceSchema.ts (t-028): a small shared helper both existing
+// verifiers (and the third one added after this task was filed) can adopt
+// without changing their pass/fail behavior.
+//
+// Covers the two reusable pieces:
+//   - loadExceptionsFile: read + parse + validate a JSON array of per-slug
+//     exception entries into a Map<string, T>, with the same per-entry and
+//     duplicate-key error reporting every verifier already hand-wrote.
+//   - summarizeCoverage / findStaleExceptionSlugs: the covered/excepted/pct
+//     arithmetic and the "exception names a style that no longer exists"
+//     check every verifier already hand-wrote.
+//
+// Not covered (deliberately): each verifier's own per-field validation and
+// cross-referencing against academyStyles.ts stays bespoke — that's the part
+// that actually differs between "has exampleWorks", "has failureMode", and
+// "artist has a portrait", and folding it into one generic shape would cost
+// more clarity than the dedup is worth.
+
+import { readFile } from 'node:fs/promises'
+import { academyStyles } from '../../stores/seeds/academyStyles'
+
+/** Every canonical style slug currently in academyStyles.ts. */
+export const canonicalSlugs = new Set(academyStyles.map((style) => style.slug))
+
+export interface ExceptionsFileResult<T> {
+  bySlug: Map<string, T>
+  errors: string[]
+}
+
+/**
+ * Load a JSON array file of per-slug exception entries, validating each with
+ * `isValid` (which must at least confirm a non-empty `slug` string) and
+ * rejecting duplicate slugs. Mirrors the loader every verifier with an
+ * exceptions file already hand-wrote for itself.
+ */
+export async function loadExceptionsFile<T extends { slug: string }>(
+  url: URL,
+  fileLabel: string,
+  isValid: (value: unknown) => value is T,
+): Promise<ExceptionsFileResult<T>> {
+  const errors: string[] = []
+  let raw: unknown
+  try {
+    raw = JSON.parse(await readFile(url, 'utf8'))
+  } catch (error) {
+    errors.push(
+      `${fileLabel} is not valid JSON — ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    )
+    raw = []
+  }
+
+  if (!Array.isArray(raw)) {
+    errors.push(`${fileLabel} must be a JSON array, got ${typeof raw}`)
+    raw = []
+  }
+
+  const bySlug = new Map<string, T>()
+  for (const [index, candidate] of (raw as unknown[]).entries()) {
+    if (!isValid(candidate)) {
+      errors.push(`${fileLabel} entry #${index}: failed validation`)
+      continue
+    }
+    if (bySlug.has(candidate.slug)) {
+      errors.push(
+        `${fileLabel}: duplicate exception entry for "${candidate.slug}"`,
+      )
+      continue
+    }
+    bySlug.set(candidate.slug, candidate)
+  }
+
+  return { bySlug, errors }
+}
+
+/**
+ * Exception entries naming a slug that is no longer in academyStyles.ts are
+ * stale bookkeeping, not a real gap — every verifier with an exceptions file
+ * already flagged this so stale entries get cleaned up instead of silently
+ * accumulating.
+ */
+export function findStaleExceptionSlugs(
+  bySlug: Map<string, unknown>,
+): string[] {
+  return [...bySlug.keys()].filter((slug) => !canonicalSlugs.has(slug))
+}
+
+export interface CoverageSummary {
+  total: number
+  covered: number
+  excepted: number
+  pct: number
+}
+
+/**
+ * Compute the covered/excepted/percentage summary every verifier logs on
+ * success. `total` is the denominator (usually `canonicalSlugs.size`, but a
+ * verifier counting a nested field — e.g. named artists rather than styles —
+ * passes its own denominator).
+ */
+export function summarizeCoverage(
+  total: number,
+  covered: number,
+  excepted = 0,
+): CoverageSummary {
+  const pct = total === 0 ? 100 : Math.round((covered / total) * 100)
+  return { total, covered, excepted, pct }
+}

--- a/utils/scripts/verifyAcademyArtistPortraitsManifest.ts
+++ b/utils/scripts/verifyAcademyArtistPortraitsManifest.ts
@@ -26,6 +26,7 @@
 
 import { readFile } from 'node:fs/promises'
 import { academyStyles } from '../../stores/seeds/academyStyles'
+import { summarizeCoverage } from './academyCoverageContract'
 import { validateProvenanceRecord } from './academyProvenanceSchema'
 import {
   imageSrcToMediaPath,
@@ -232,10 +233,7 @@ async function main(): Promise<void> {
     return
   }
 
-  const pct =
-    namedArtistCount === 0
-      ? 100
-      : Math.round((portraitCount / namedArtistCount) * 100)
+  const { pct } = summarizeCoverage(namedArtistCount, portraitCount)
   const zeroCoverageStyles = styleCoverage.filter(
     (s) => s.withPortrait === 0,
   ).length

--- a/utils/scripts/verifyAcademyExamplesManifest.ts
+++ b/utils/scripts/verifyAcademyExamplesManifest.ts
@@ -26,6 +26,10 @@
 
 import { readFile } from 'node:fs/promises'
 import { academyStyles } from '../../stores/seeds/academyStyles'
+import {
+  findStaleExceptionSlugs,
+  loadExceptionsFile,
+} from './academyCoverageContract'
 import { validateProvenanceRecord } from './academyProvenanceSchema'
 import {
   imageSrcToMediaPath,
@@ -225,43 +229,14 @@ async function main(): Promise<void> {
   // seedImageSrcByMovement above) or a named, reasoned exception below --
   // never silently neither, which is exactly how the 21/21-vs-47-style drift
   // this task fixes went undetected.
-  let rawExceptions: unknown
-  try {
-    rawExceptions = JSON.parse(await readFile(exceptionsUrl, 'utf8'))
-  } catch (error) {
-    errors.push(
-      `academy-example-work-exceptions.json is not valid JSON — ${
-        error instanceof Error ? error.message : String(error)
-      }`,
+  const { bySlug: exceptionsBySlug, errors: exceptionsErrors } =
+    await loadExceptionsFile<ExampleWorkException>(
+      exceptionsUrl,
+      'academy-example-work-exceptions.json',
+      isExampleWorkException,
     )
-    rawExceptions = []
-  }
+  errors.push(...exceptionsErrors)
 
-  if (!Array.isArray(rawExceptions)) {
-    errors.push(
-      `academy-example-work-exceptions.json must be a JSON array, got ${typeof rawExceptions}`,
-    )
-    rawExceptions = []
-  }
-
-  const exceptionsBySlug = new Map<string, ExampleWorkException>()
-  for (const [index, candidate] of (rawExceptions as unknown[]).entries()) {
-    if (!isExampleWorkException(candidate)) {
-      errors.push(
-        `academy-example-work-exceptions.json entry #${index}: must have non-empty string "slug", "reason", and "followUpTask" fields`,
-      )
-      continue
-    }
-    if (exceptionsBySlug.has(candidate.slug)) {
-      errors.push(
-        `academy-example-work-exceptions.json: duplicate exception entry for "${candidate.slug}"`,
-      )
-      continue
-    }
-    exceptionsBySlug.set(candidate.slug, candidate)
-  }
-
-  const canonicalSlugs = new Set(academyStyles.map((style) => style.slug))
   let coveredCount = 0
   let exceptedCount = 0
   for (const style of academyStyles) {
@@ -289,12 +264,10 @@ async function main(): Promise<void> {
   // Exceptions naming a style that no longer exists in academyStyles.ts are
   // stale bookkeeping, not a real gap -- flag so they get cleaned up rather
   // than silently accumulating.
-  for (const slug of exceptionsBySlug.keys()) {
-    if (!canonicalSlugs.has(slug)) {
-      errors.push(
-        `academy-example-work-exceptions.json: "${slug}" is not a current academyStyles.ts slug — remove the stale exception`,
-      )
-    }
+  for (const slug of findStaleExceptionSlugs(exceptionsBySlug)) {
+    errors.push(
+      `academy-example-work-exceptions.json: "${slug}" is not a current academyStyles.ts slug — remove the stale exception`,
+    )
   }
 
   if (errors.length) {

--- a/utils/scripts/verifyAcademyFailureModeCoverage.ts
+++ b/utils/scripts/verifyAcademyFailureModeCoverage.ts
@@ -15,6 +15,7 @@
 // Run: npm run test:academy-failuremode-coverage
 
 import { academyStyles } from '../../stores/seeds/academyStyles'
+import { summarizeCoverage } from './academyCoverageContract'
 
 // Slugs intentionally left on the generic mode-level fallback, with why.
 // Empty today (t-071 brought coverage to 47/47) — add an entry here only
@@ -43,9 +44,10 @@ function main(): void {
     (slug) => !(slug in DOCUMENTED_FALLBACK_EXCEPTIONS),
   )
 
-  const total = academyStyles.length
-  const covered = total - missing.length
-  const pct = total === 0 ? 100 : Math.round((covered / total) * 100)
+  const { total, covered, pct } = summarizeCoverage(
+    academyStyles.length,
+    academyStyles.length - missing.length,
+  )
 
   if (trulyMissing.length || undocumentedExceptions.length) {
     console.error(


### PR DESCRIPTION
### Task
ai-art-academy/t-075: Extract a shared per-style coverage-contract helper for Academy verifier scripts (kind: software)

### What changed / what I produced
- Added `utils/scripts/academyCoverageContract.ts` (same precedent as `academyProvenanceSchema.ts` from t-028): `loadExceptionsFile` (generic JSON exceptions-file loader/validator), `findStaleExceptionSlugs`, and `summarizeCoverage` (shared covered/excepted/pct arithmetic).
- Migrated `verifyAcademyExamplesManifest.ts` to use `loadExceptionsFile`/`findStaleExceptionSlugs` for its `academy-example-work-exceptions.json` handling.
- Migrated `verifyAcademyFailureModeCoverage.ts` and `verifyAcademyArtistPortraitsManifest.ts` to use `summarizeCoverage`.
- Per the task note, also folded in `verifyAcademyArtistPortraitsManifest.ts` (t-072), which shipped a third independent re-derivation of the same pattern before this task landed.

### How I verified
- `npm run test:academy-examples-manifest` — passes, identical output: 41/47 covered, 6 tracked exceptions, 0 undocumented gaps.
- `npm run test:academy-failuremode-coverage` — passes, identical output: 47/47 (100%).
- `npm run test:academy-artist-portraits-manifest` — passes, identical output: 8/116 (7%) named artists, 0/47 styles fully covered, 39/47 zero coverage.
- `vue-tsc --noEmit` — zero new errors (the one pre-existing unrelated error in `server/api/reactions/index.post.ts` confirmed present on `main` via `git stash` before/after comparison).
- `eslint` and `prettier --check` clean on all 4 touched files.
- `git status --porcelain` scoped to exactly the 4 intended files.

### Stakes
reversible

### Kaizen suggestion
The next per-field coverage contract (e.g. artist portraits growing its own exceptions file, or a future starter-manifest coverage check) can now adopt `loadExceptionsFile`/`summarizeCoverage` directly instead of re-deriving the pattern a fourth time.


---
_Generated by [Claude Code](https://claude.ai/code/session_016GuHCqD1XAKGHFz6wWqZqc)_