### PR TITLE
fix(model-builder): clear stale lastAutoBuildOutcome on retry (t-029 cycle 41)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -698,6 +698,12 @@ jobs:
       - name: Model Builder auto-build outcome-persistence guard contract
         run: npm run test:model-builder-auto-build-outcome-persistence-guard
 
+      - name: Model Builder auto-build outcome-clear guard checker self-test
+        run: npm run test:model-builder-auto-build-outcome-clear-guard-selftest
+
+      - name: Model Builder auto-build outcome-clear guard contract
+        run: npm run test:model-builder-auto-build-outcome-clear-guard
+
       - name: Model Builder field-blob continuation guard self-test
         run: npm run test:model-builder-field-blob-continuation-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -318,6 +318,8 @@
     "test:model-builder-auto-build-failed-summary-guard": "tsx utils/scripts/verifyModelBuilderAutoBuildFailedSummaryGuard.ts",
     "test:model-builder-auto-build-outcome-persistence-guard-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildOutcomePersistenceGuard.test.ts",
     "test:model-builder-auto-build-outcome-persistence-guard": "tsx utils/scripts/verifyModelBuilderAutoBuildOutcomePersistenceGuard.ts",
+    "test:model-builder-auto-build-outcome-clear-guard-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildOutcomeClearGuard.test.ts",
+    "test:model-builder-auto-build-outcome-clear-guard": "tsx utils/scripts/verifyModelBuilderAutoBuildOutcomeClearGuard.ts",
     "test:model-builder-field-blob-continuation-guard-selftest": "tsx utils/scripts/verifyModelBuilderFieldBlobContinuationGuard.test.ts",
     "test:model-builder-field-blob-continuation-guard": "tsx utils/scripts/verifyModelBuilderFieldBlobContinuationGuard.ts",
     "test:model-builder-stage-status-json-parse-guard-selftest": "tsx utils/scripts/verifyModelBuilderStageStatusJsonParseGuard.test.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1027,6 +1027,35 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   // anyway. Clearing here uniformly (manual edit or AI draft alike) also
   // avoids a confusing asymmetry where an AI-redrafted fix clears the item's
   // error banner but retyping the identical fix by hand does not.
+  //
+  // Bug (model-builder/t-029, cycle 41, found by inspection): item.error
+  // being cleared here was never mirrored onto item.lastAutoBuildOutcome,
+  // which model-builder-progress-matrix.vue's and model-builder-batch-
+  // editor.vue's own autoBuildFailed() also OR into the same "failed" badge
+  // (see verifyModelBuilderAutoBuildOutcomePersistenceGuard.ts's doc comment
+  // for why that field exists). lastAutoBuildOutcome is written ONLY by
+  // autoBuildRun()/batchAutoBuild() and is never cleared anywhere else in
+  // this file -- not here, not by generateItemAsset/generateItemAssetAsync's
+  // own optimistic `item.error = null` at the start of a fresh attempt, not
+  // by commitItem's identical optimistic clear. Concrete repro: run
+  // "Auto-build all" on a run where one item's FIELDS_AND_PROMPTS AI draft
+  // fails (a transient text-server hiccup is enough) -- autoBuildRun sets
+  // that item's lastAutoBuildOutcome = 'failed' and item.error to the
+  // failure message, and the row in model-builder-progress-matrix.vue shows
+  // the red warning icon with a "failed" summary badge, correctly. The user
+  // then opens the item and either types the fields by hand or clicks
+  // "Draft with AI" again and it succeeds this time -- either path routes
+  // through updateFields (draftText's own success path calls it too), which
+  // clears item.error (and the item panel's error banner correctly
+  // disappears) but left lastAutoBuildOutcome sitting at 'failed' with
+  // nothing to ever clear it short of a full COMMIT or another whole
+  // auto-build/batch pass. The progress-matrix row and batch-editor badge
+  // kept flashing "failed" with the warning icon for an item the user was
+  // actively, successfully fixing -- exactly the "badge lying about what's
+  // actually stored" class of bug this codebase treats as real everywhere
+  // else it's found, just reached through the newer lastAutoBuildOutcome
+  // field instead of stageStatuses/error itself. Snapshotted and reverted
+  // alongside item.error on a failed PATCH, for the same reason.
   function updatePitch(itemId: string, value: string): void {
     const item = findItem(itemId)
     if (!item) return
@@ -1035,9 +1064,11 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     // onFailure doc comment).
     const previousPitch = item.pitch
     const previousError = item.error
+    const previousLastAutoBuildOutcome = item.lastAutoBuildOutcome
     const previousStages = { ...item.stages }
     item.pitch = value
     item.error = null
+    item.lastAutoBuildOutcome = null
     markDownstreamStale(item, 'PITCH')
     pushItem(
       item,
@@ -1046,6 +1077,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       () => {
         item.pitch = previousPitch
         item.error = previousError
+        item.lastAutoBuildOutcome = previousLastAutoBuildOutcome
         item.stages = previousStages
       },
     )
@@ -1056,9 +1088,11 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     if (!item) return
     const previousFieldsDraft = item.fieldsDraft
     const previousError = item.error
+    const previousLastAutoBuildOutcome = item.lastAutoBuildOutcome
     const previousStages = { ...item.stages }
     item.fieldsDraft = value
     item.error = null
+    item.lastAutoBuildOutcome = null
     markDownstreamStale(item, 'FIELDS_AND_PROMPTS')
     pushItem(
       item,
@@ -1071,6 +1105,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       () => {
         item.fieldsDraft = previousFieldsDraft
         item.error = previousError
+        item.lastAutoBuildOutcome = previousLastAutoBuildOutcome
         item.stages = previousStages
       },
     )
@@ -1081,9 +1116,11 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     if (!item) return
     const previousPromptDraft = item.promptDraft
     const previousError = item.error
+    const previousLastAutoBuildOutcome = item.lastAutoBuildOutcome
     const previousStages = { ...item.stages }
     item.promptDraft = value
     item.error = null
+    item.lastAutoBuildOutcome = null
     markDownstreamStale(item, 'FIELDS_AND_PROMPTS')
     pushItem(
       item,
@@ -1096,6 +1133,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       () => {
         item.promptDraft = previousPromptDraft
         item.error = previousError
+        item.lastAutoBuildOutcome = previousLastAutoBuildOutcome
         item.stages = previousStages
       },
     )
@@ -1381,6 +1419,13 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
 
     generatingItemSingleton.claim(item.id)
     item.error = null
+    // See updatePitch's doc comment (model-builder/t-029, cycle 41) for the
+    // full shape of this bug -- a fresh generate/regenerate attempt already
+    // optimistically clears item.error, so it must clear the stale
+    // lastAutoBuildOutcome the same way, or the progress-matrix/batch-editor
+    // "failed" badge keeps flashing for an item the user is actively
+    // re-rendering right now.
+    item.lastAutoBuildOutcome = null
     item.stages.GENERATE_ASSETS = { status: 'in-progress' }
     clearStatus()
 
@@ -1718,6 +1763,10 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     const artStore = useArtStore()
 
     item.error = null
+    // See generateItemAsset's identical clear (model-builder/t-029, cycle
+    // 41) -- a fresh queued attempt must clear the stale 'failed' outcome
+    // the same way it already clears the stale error.
+    item.lastAutoBuildOutcome = null
     item.queueState = 'queued'
     item.stages.GENERATE_ASSETS = { status: 'in-progress', note: 'queued' }
     clearStatus()
@@ -1836,6 +1885,15 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
 
     committingItemSingleton.claim(item.id)
     item.error = null
+    // See generateItemAsset's identical clear (model-builder/t-029, cycle
+    // 41) -- a fresh commit attempt must clear the stale 'failed' outcome
+    // the same way it already clears the stale error. Not strictly required
+    // for COMMIT itself (autoBuildFailed's own COMMIT-approved gate already
+    // clears the badge on a successful commit regardless), but keeps the
+    // invariant -- "an in-flight retry never shows a stale failed badge" --
+    // uniform across every stage instead of leaving COMMIT as a silent
+    // exception.
+    item.lastAutoBuildOutcome = null
     item.stages.COMMIT = { status: 'in-progress' }
     clearStatus()
 

--- a/utils/scripts/verifyModelBuilderAsyncPollFailureGuard.ts
+++ b/utils/scripts/verifyModelBuilderAsyncPollFailureGuard.ts
@@ -85,10 +85,55 @@ export function extractPollAsyncArtJobBody(content: string): string | null {
   // message) can't desync the brace-depth count -- the same class of bug
   // verifyCaptureGroupGuards.ts's afterCaptureCallClose already guards
   // against for regex literals.
+  //
+  // Bug (model-builder/t-029, cycle 41, found by inspection while verifying
+  // an unrelated fix): this used to skip only string/template literals, not
+  // `//` line comments or `/* */` block comments -- but this file's own
+  // comments are full of ordinary English contractions ("doesn't", "isn't",
+  // "can't", "it's" ...), and a lone apostrophe inside a `//` comment reads
+  // to this scanner exactly like an opening single-quoted string literal. It
+  // then swallows everything up to the NEXT apostrophe anywhere in the file
+  // (there is no shortage of them) as if it were still inside that "string",
+  // silently eating real braces along the way and desyncing the depth
+  // count. On the pre-fix version of this file, that miscount happened to
+  // still reach depth 0 at SOME later point deep inside a completely
+  // different function (batchDraftField's own success-toast string, far
+  // past pollAsyncArtJob/generateItemAssetAsync/commitItem/autoBuildItem/
+  // autoBuildRun) -- so `body` was never null and every substantive check
+  // below still passed, but only because the real `if (!job) {...}` pattern
+  // it was supposed to verify happened to be included as a small part of a
+  // vastly over-captured region, not because the extraction was actually
+  // correct. Editing any code between pollAsyncArtJob and that coincidental
+  // stopping point (a normal, unrelated change elsewhere in the file) could
+  // shift where the miscounted depth happens to land -- including all the
+  // way past the end of the file, which turns a silent false-positive into
+  // a hard, misleading "Could not find `async function pollAsyncArtJob(`"
+  // failure for a function that is right there, unchanged. Skipping
+  // comments before the quote check closes the hole at its root instead of
+  // patching around wherever it next happens to surface.
   let depth = 0
   let i = bodyOpen
   for (; i < content.length; i++) {
     const char = content[i]
+    const next = content[i + 1]
+
+    if (char === '/' && next === '/') {
+      i += 2
+      while (i < content.length && content[i] !== '\n') i += 1
+      continue
+    }
+
+    if (char === '/' && next === '*') {
+      i += 2
+      while (
+        i < content.length &&
+        !(content[i] === '*' && content[i + 1] === '/')
+      ) {
+        i += 1
+      }
+      i += 1 // land on the '/' of '*/'; the loop's own i++ steps past it
+      continue
+    }
 
     if (char === "'" || char === '"' || char === '`') {
       i += 1

--- a/utils/scripts/verifyModelBuilderAutoBuildOutcomeClearGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildOutcomeClearGuard.test.ts
@@ -1,0 +1,326 @@
+// /utils/scripts/verifyModelBuilderAutoBuildOutcomeClearGuard.test.ts
+//
+// Regression test for checkAutoBuildOutcomeClearGuard() in
+// verifyModelBuilderAutoBuildOutcomeClearGuard.ts (model-builder/t-029,
+// cycle 41). Exercises the real check against synthetic store-shaped
+// fixtures covering: the pre-fix shape (item.error cleared/reverted in all
+// six target functions but item.lastAutoBuildOutcome never touched), the
+// fixed shape (every function also clears -- and the three setters also
+// snapshot/restore -- lastAutoBuildOutcome), a partially-fixed shape (only
+// some functions fixed, and one setter clears but forgets the revert half),
+// and all six target functions absent.
+import assert from 'node:assert/strict'
+
+import { checkAutoBuildOutcomeClearGuard } from './verifyModelBuilderAutoBuildOutcomeClearGuard.js'
+
+const BUGGY_FIXTURE = `
+  function updatePitch(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    const previousPitch = item.pitch
+    const previousError = item.error
+    const previousStages = { ...item.stages }
+    item.pitch = value
+    item.error = null
+    markDownstreamStale(item, 'PITCH')
+    pushItem(
+      item,
+      { stageStatuses: item.stages, pitch: item.pitch, error: null },
+      { stage: 'PITCH' },
+      () => {
+        item.pitch = previousPitch
+        item.error = previousError
+        item.stages = previousStages
+      },
+    )
+  }
+
+  function updateFields(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    const previousFieldsDraft = item.fieldsDraft
+    const previousError = item.error
+    const previousStages = { ...item.stages }
+    item.fieldsDraft = value
+    item.error = null
+    pushItem(item, { fieldsDraft: item.fieldsDraft, error: null }, {}, () => {
+      item.fieldsDraft = previousFieldsDraft
+      item.error = previousError
+      item.stages = previousStages
+    })
+  }
+
+  function updatePrompt(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    const previousPromptDraft = item.promptDraft
+    const previousError = item.error
+    item.promptDraft = value
+    item.error = null
+    pushItem(item, { promptDraft: item.promptDraft, error: null }, {}, () => {
+      item.promptDraft = previousPromptDraft
+      item.error = previousError
+    })
+  }
+
+  async function generateItemAsset(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    generatingItemSingleton.claim(item.id)
+    item.error = null
+    item.stages.GENERATE_ASSETS = { status: 'in-progress' }
+    return true
+  }
+
+  async function generateItemAssetAsync(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    item.error = null
+    item.queueState = 'queued'
+    return true
+  }
+
+  async function commitItem(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    committingItemSingleton.claim(item.id)
+    item.error = null
+    item.stages.COMMIT = { status: 'in-progress' }
+    return true
+  }
+`
+
+const FIXED_FIXTURE = `
+  function updatePitch(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    const previousPitch = item.pitch
+    const previousError = item.error
+    const previousLastAutoBuildOutcome = item.lastAutoBuildOutcome
+    const previousStages = { ...item.stages }
+    item.pitch = value
+    item.error = null
+    item.lastAutoBuildOutcome = null
+    markDownstreamStale(item, 'PITCH')
+    pushItem(
+      item,
+      { stageStatuses: item.stages, pitch: item.pitch, error: null },
+      { stage: 'PITCH' },
+      () => {
+        item.pitch = previousPitch
+        item.error = previousError
+        item.lastAutoBuildOutcome = previousLastAutoBuildOutcome
+        item.stages = previousStages
+      },
+    )
+  }
+
+  function updateFields(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    const previousFieldsDraft = item.fieldsDraft
+    const previousError = item.error
+    const previousLastAutoBuildOutcome = item.lastAutoBuildOutcome
+    item.fieldsDraft = value
+    item.error = null
+    item.lastAutoBuildOutcome = null
+    pushItem(item, { fieldsDraft: item.fieldsDraft, error: null }, {}, () => {
+      item.fieldsDraft = previousFieldsDraft
+      item.error = previousError
+      item.lastAutoBuildOutcome = previousLastAutoBuildOutcome
+    })
+  }
+
+  function updatePrompt(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    const previousPromptDraft = item.promptDraft
+    const previousError = item.error
+    const previousLastAutoBuildOutcome = item.lastAutoBuildOutcome
+    item.promptDraft = value
+    item.error = null
+    item.lastAutoBuildOutcome = null
+    pushItem(item, { promptDraft: item.promptDraft, error: null }, {}, () => {
+      item.promptDraft = previousPromptDraft
+      item.error = previousError
+      item.lastAutoBuildOutcome = previousLastAutoBuildOutcome
+    })
+  }
+
+  async function generateItemAsset(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    generatingItemSingleton.claim(item.id)
+    item.error = null
+    item.lastAutoBuildOutcome = null
+    item.stages.GENERATE_ASSETS = { status: 'in-progress' }
+    return true
+  }
+
+  async function generateItemAssetAsync(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    item.error = null
+    item.lastAutoBuildOutcome = null
+    item.queueState = 'queued'
+    return true
+  }
+
+  async function commitItem(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    committingItemSingleton.claim(item.id)
+    item.error = null
+    item.lastAutoBuildOutcome = null
+    item.stages.COMMIT = { status: 'in-progress' }
+    return true
+  }
+`
+
+const PARTIALLY_FIXED_FIXTURE = `
+  function updatePitch(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    const previousError = item.error
+    item.error = null
+    item.lastAutoBuildOutcome = null
+    pushItem(item, { error: null }, {}, () => {
+      item.error = previousError
+    })
+  }
+
+  function updateFields(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    const previousError = item.error
+    const previousLastAutoBuildOutcome = item.lastAutoBuildOutcome
+    item.error = null
+    item.lastAutoBuildOutcome = null
+    pushItem(item, { error: null }, {}, () => {
+      item.error = previousError
+      item.lastAutoBuildOutcome = previousLastAutoBuildOutcome
+    })
+  }
+
+  function updatePrompt(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    item.error = null
+  }
+
+  async function generateItemAsset(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    item.error = null
+    item.lastAutoBuildOutcome = null
+    return true
+  }
+
+  async function generateItemAssetAsync(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    item.error = null
+    return true
+  }
+
+  async function commitItem(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    item.error = null
+    item.lastAutoBuildOutcome = null
+    return true
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkAutoBuildOutcomeClearGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  9,
+  'expected the pre-fix shape to raise 2 violations each for the three ' +
+    'setters (never clears, never snapshots/restores) plus 1 each for the ' +
+    `three retry functions (never clears) = 9, got ${buggyErrors.length}: ` +
+    JSON.stringify(buggyErrors),
+)
+
+const fixedErrors = checkAutoBuildOutcomeClearGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const partialErrors = checkAutoBuildOutcomeClearGuard(PARTIALLY_FIXED_FIXTURE)
+assert.equal(
+  partialErrors.length,
+  4,
+  'expected updatePitch (clears but never snapshots/restores) to raise 1, ' +
+    'updatePrompt (never touches lastAutoBuildOutcome at all) to raise 2 ' +
+    '(never-clears + never-snapshots/restores), and generateItemAssetAsync ' +
+    `(never clears) to raise 1 = 4 total, got ${partialErrors.length}: ` +
+    JSON.stringify(partialErrors),
+)
+assert.ok(
+  partialErrors.some(
+    (e) => e.includes('updatePitch') && e.includes('snapshot and restore'),
+  ),
+)
+assert.ok(
+  !partialErrors.some(
+    (e) => e.includes('updatePitch') && e.includes('never clears'),
+  ),
+  'updatePitch does clear lastAutoBuildOutcome in this fixture -- only the snapshot/restore half should be flagged',
+)
+assert.ok(
+  partialErrors.some(
+    (e) => e.includes('updatePrompt') && e.includes('never clears'),
+  ),
+)
+assert.ok(
+  partialErrors.some(
+    (e) => e.includes('updatePrompt') && e.includes('snapshot and restore'),
+  ),
+)
+assert.ok(
+  partialErrors.some(
+    (e) => e.includes('generateItemAssetAsync') && e.includes('never clears'),
+  ),
+)
+assert.ok(
+  !partialErrors.some((e) => e.includes('updateFields')),
+  'updateFields is fully fixed in this fixture and should not be flagged',
+)
+assert.ok(
+  !partialErrors.some(
+    (e) =>
+      e.includes('generateItemAsset(') && !e.includes('generateItemAssetAsync'),
+  ),
+  'generateItemAsset is fully fixed in this fixture and should not be flagged',
+)
+assert.ok(
+  !partialErrors.some((e) => e.includes('commitItem')),
+  'commitItem is fully fixed in this fixture and should not be flagged',
+)
+
+const missingErrors = checkAutoBuildOutcomeClearGuard(MISSING_FIXTURE)
+assert.equal(
+  missingErrors.length,
+  6,
+  'expected 6 "function not found" violations when all target functions are absent',
+)
+for (const name of [
+  'updatePitch',
+  'updateFields',
+  'updatePrompt',
+  'generateItemAsset',
+  'generateItemAssetAsync',
+  'commitItem',
+]) {
+  assert.ok(
+    missingErrors.some((e) => e.includes(name)),
+    `expected a violation naming ${name}`,
+  )
+}
+
+console.log(
+  'Model Builder auto-build outcome-clear guard checker verified: flags ' +
+    'item.lastAutoBuildOutcome never being cleared (and, for the three ' +
+    'setters, never being snapshotted/restored) in each target function ' +
+    'independently, clears the fixed shape, and flags all six target ' +
+    'functions being absent.',
+)

--- a/utils/scripts/verifyModelBuilderAutoBuildOutcomeClearGuard.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildOutcomeClearGuard.ts
@@ -1,0 +1,187 @@
+// /utils/scripts/verifyModelBuilderAutoBuildOutcomeClearGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 41, found by inspection).
+// model-builder-progress-matrix.vue's and model-builder-batch-editor.vue's
+// own autoBuildFailed() render a per-item "failed" badge (a red warning icon
+// plus a summary badge) whenever
+// `item.lastAutoBuildOutcome === 'failed' || Boolean(item.error)` and the
+// item isn't COMMIT-approved yet. lastAutoBuildOutcome is written ONLY by
+// autoBuildRun()/batchAutoBuild() (see
+// verifyModelBuilderAutoBuildOutcomePersistenceGuard.ts for why that field
+// exists) and, before this fix, was never cleared anywhere else in this
+// file -- not by updatePitch/updateFields/updatePrompt (which already clear
+// the sibling item.error the moment the user edits or AI-redrafts a field,
+// specifically to avoid "a confusing asymmetry" between the two repair
+// paths -- see updatePitch's own doc comment), not by generateItemAsset/
+// generateItemAssetAsync's own optimistic `item.error = null` at the start
+// of a fresh render, and not by commitItem's identical optimistic clear.
+//
+// Concrete repro: run "Auto-build all" on a run where one item's
+// FIELDS_AND_PROMPTS AI draft fails (a transient text-server hiccup is
+// enough) -- autoBuildRun sets that item's lastAutoBuildOutcome = 'failed'
+// and item.error to the failure message, and the row in model-builder-
+// progress-matrix.vue correctly shows the red warning icon with a "failed"
+// summary badge. The user then opens the item and either types the fields
+// by hand or clicks "Draft with AI" again and it succeeds -- either path
+// routes through updateFields (draftText's own success path calls it too),
+// which clears item.error (the item panel's error banner correctly
+// disappears) but left lastAutoBuildOutcome sitting at 'failed' with
+// nothing to ever clear it short of a full COMMIT or another whole
+// auto-build/batch pass. The progress-matrix row and batch-editor badge
+// kept flashing "failed" for an item the user was actively, successfully
+// fixing -- exactly the "badge lying about what's actually stored" class of
+// bug this codebase treats as real everywhere else it's found, just reached
+// through the newer lastAutoBuildOutcome field instead of stageStatuses/
+// error itself.
+//
+// Fixed by clearing `item.lastAutoBuildOutcome = null` at every point that
+// already clears (or reverts) `item.error` as part of a fresh attempt or
+// manual/AI fix: updatePitch, updateFields, updatePrompt (both the
+// optimistic clear and its onFailure revert), and the optimistic clear at
+// the start of generateItemAsset, generateItemAssetAsync, and commitItem.
+//
+// This walks each target function in modelBuilderStore.ts and requires its
+// body to contain at least one `item.lastAutoBuildOutcome = null` (or, for
+// the three setters' revert closures, a matching
+// `previousLastAutoBuildOutcome` snapshot/restore pair) -- i.e. that the
+// function actually clears the stale outcome somewhere, on some path,
+// mirroring verifyModelBuilderErrorPersistenceGuard.ts's own presence-check
+// style rather than proving every single branch does it.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+// The three manual/AI-edit setters also need a snapshot/restore pair around
+// their optimistic clear, mirroring how they already snapshot/restore
+// item.error on a failed PATCH -- otherwise a rejected write would leave the
+// outcome permanently cleared even though the edit itself never persisted.
+const SETTER_FUNCTIONS = [
+  'updatePitch',
+  'updateFields',
+  'updatePrompt',
+] as const
+
+// generateItemAsset/generateItemAssetAsync/commitItem only need the
+// optimistic clear at the start of a fresh attempt -- there is no revert
+// path for these (a failed attempt re-sets item.error again in its own
+// catch block, which the badge's `Boolean(item.error)` half already
+// re-flags correctly with no help from lastAutoBuildOutcome).
+const RETRY_FUNCTIONS = [
+  'generateItemAsset',
+  'generateItemAssetAsync',
+  'commitItem',
+] as const
+
+const CLEARS_OUTCOME = /item\.lastAutoBuildOutcome\s*=\s*null\b/
+const SNAPSHOTS_OUTCOME =
+  /const previousLastAutoBuildOutcome\s*=\s*item\.lastAutoBuildOutcome\b/
+const RESTORES_OUTCOME =
+  /item\.lastAutoBuildOutcome\s*=\s*previousLastAutoBuildOutcome\b/
+
+// Checks the fix's exact shape against the full source text of a file
+// containing these function names. Exported so the self-test below can run
+// it against synthetic buggy/fixed fixtures without touching the real store.
+export function checkAutoBuildOutcomeClearGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+
+  for (const name of SETTER_FUNCTIONS) {
+    const fn = functions.find((f) => f.name === name)
+    if (!fn) {
+      errors.push(
+        `Could not find a function named ${name}() -- has it been renamed, ` +
+          'removed, or inlined? If so, this guard (and the stale-outcome ' +
+          'clearing it protects) needs to move with it.',
+      )
+      continue
+    }
+
+    if (!CLEARS_OUTCOME.test(fn.body)) {
+      errors.push(
+        `${name}() never clears item.lastAutoBuildOutcome (expected an ` +
+          '`item.lastAutoBuildOutcome = null` assignment in its body, ' +
+          'alongside its existing `item.error = null` clear). Without it, ' +
+          'a manual edit or successful AI redraft that fixes a previously ' +
+          'failed auto-build pass clears item.error but leaves the ' +
+          'progress-matrix/batch-editor "failed" badge stuck showing a ' +
+          'stale outcome for an item the user is actively fixing.',
+      )
+    }
+    if (!SNAPSHOTS_OUTCOME.test(fn.body) || !RESTORES_OUTCOME.test(fn.body)) {
+      errors.push(
+        `${name}() does not snapshot and restore item.lastAutoBuildOutcome ` +
+          'around its optimistic clear (expected both ' +
+          '`const previousLastAutoBuildOutcome = item.lastAutoBuildOutcome` ' +
+          'and a matching ' +
+          '`item.lastAutoBuildOutcome = previousLastAutoBuildOutcome` in ' +
+          'its onFailure revert). Without it, a rejected PATCH reverts ' +
+          'item.error and item.stages but permanently clears a genuinely ' +
+          'still-failed outcome, the same "revert only what this call ' +
+          'actually changed" gap pushItem\'s onFailure exists to close ' +
+          'everywhere else.',
+      )
+    }
+  }
+
+  for (const name of RETRY_FUNCTIONS) {
+    const fn = functions.find((f) => f.name === name)
+    if (!fn) {
+      errors.push(
+        `Could not find a function named ${name}() -- has it been renamed, ` +
+          'removed, or inlined? If so, this guard (and the stale-outcome ' +
+          'clearing it protects) needs to move with it.',
+      )
+      continue
+    }
+
+    if (!CLEARS_OUTCOME.test(fn.body)) {
+      errors.push(
+        `${name}() never clears item.lastAutoBuildOutcome at the start of ` +
+          'a fresh attempt (expected an `item.lastAutoBuildOutcome = null` ' +
+          'assignment in its body, alongside its existing ' +
+          '`item.error = null` optimistic clear). Without it, retrying a ' +
+          'failed stage through this function leaves the progress-matrix/' +
+          'batch-editor "failed" badge stuck showing a stale outcome while ' +
+          'the retry is in flight or has already succeeded.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkAutoBuildOutcomeClearGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder auto-build outcome-clear guard contract failed in ' +
+        'modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder auto-build outcome-clear guard contract passed: ' +
+      'updatePitch(), updateFields(), updatePrompt(), generateItemAsset(), ' +
+      'generateItemAssetAsync(), and commitItem() all clear (and, for the ' +
+      'three setters, snapshot/restore) item.lastAutoBuildOutcome, so a ' +
+      'manual fix or a successful retry never leaves the per-item "failed" ' +
+      'badge stuck showing a stale outcome.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Bug

`BuildItem.lastAutoBuildOutcome` is written **only** by `autoBuildRun()`/`batchAutoBuild()` in `stores/modelBuilderStore.ts`, and both `model-builder-progress-matrix.vue` and `model-builder-batch-editor.vue` render a per-item red "failed" badge/warning icon whenever `item.lastAutoBuildOutcome === 'failed' || Boolean(item.error)` (and the item isn't COMMIT-approved yet).

Nothing ever cleared `lastAutoBuildOutcome` after it was set to `'failed'` — not `updatePitch`/`updateFields`/`updatePrompt` (which already clear the sibling `item.error` on every manual edit or successful AI redraft, specifically to avoid "a confusing asymmetry" between the two repair paths, per that code's own existing doc comment), and not the optimistic `item.error = null` at the start of a fresh `generateItemAsset`/`generateItemAssetAsync`/`commitItem` attempt.

### Concrete failure scenario
1. Click "Auto-build all" on a run where one item's `FIELDS_AND_PROMPTS` AI draft fails (a transient text-server hiccup is enough). `autoBuildRun` sets `item.lastAutoBuildOutcome = 'failed'` and `item.error` to the failure message — the progress-matrix row correctly shows the red warning icon and "failed" badge.
2. The user opens that item and either types the fields by hand or clicks "Draft with AI" again and it succeeds. Either path routes through `updateFields` (`draftText`'s own success path calls it too), which clears `item.error` — the item panel's error banner correctly disappears — but leaves `lastAutoBuildOutcome` stuck at `'failed'`.
3. The progress-matrix row and batch-editor badge keep showing "failed" with the warning icon for an item the user just successfully fixed, with nothing to clear it short of a full commit or another whole auto-build/batch pass.

This is exactly the "badge lying about what's actually stored" class of bug this codebase already treats as real everywhere else it's found (see the extensive existing `item.error`-persistence fixes), just reached through the newer `lastAutoBuildOutcome` field instead of `stageStatuses`/`error` itself.

## Fix

Clear `item.lastAutoBuildOutcome = null` everywhere `item.error` is already being cleared as part of a fresh attempt or manual/AI fix:
- `updatePitch`, `updateFields`, `updatePrompt` — both the optimistic clear and their `onFailure` revert closure (snapshot/restore, mirroring how `item.error` is already snapshotted/restored on a rejected PATCH).
- The optimistic clear at the start of `generateItemAsset`, `generateItemAssetAsync`, and `commitItem`.

## Guard added

- `utils/scripts/verifyModelBuilderAutoBuildOutcomeClearGuard.ts` + `.test.ts` — walks each of the six target functions and requires the clear (and, for the three setters, the snapshot/restore pair). Confirmed it fails against the pre-fix store and passes against the fixed one.
- Wired into `package.json` (`test:model-builder-auto-build-outcome-clear-guard[-selftest]`) and `.github/workflows/contract-tests.yml`, next to the existing `auto-build-outcome-persistence-guard` steps.

## Bonus fix (found while verifying)

Running the full model-builder guard suite after my change turned up a **separate, pre-existing** bug in `verifyModelBuilderAsyncPollFailureGuard.ts`'s own brace-matching helper (`extractPollAsyncArtJobBody`): it skipped string/template literals but never `//` or `/* */` comments before checking for quote characters. This file's comments are full of ordinary English contractions ("doesn't", "isn't", "it's"...), and a lone apostrophe inside a `//` comment reads to that naive scanner exactly like an opening single-quoted string literal — it then swallows everything up to the *next* apostrophe anywhere in the file, silently eating real braces along the way.

On the pre-fix file this miscount happened to still reach depth 0 at some *coincidental* later point deep inside a completely different function (`batchDraftField`'s own success-toast string, far past `pollAsyncArtJob`) — so the guard never failed outright, it just silently over-captured a much bigger region than intended (its substantive checks still passed since the real patterns were a subset of that region). My otherwise-unrelated edits elsewhere in the file shifted where that coincidental balance landed, which turned the latent bug into a hard, misleading "Could not find `async function pollAsyncArtJob(`" failure for a function that was right there, unchanged.

Fixed by skipping `//` and `/* */` comments in the scanner before the quote check. Verified the guard now correctly extracts just `pollAsyncArtJob`'s real body (confirmed it no longer includes `generateItemAssetAsync`'s text), and both the guard and its self-test pass.

## Verification

- `npx tsx utils/scripts/verifyModelBuilderAutoBuildOutcomeClearGuard.test.ts` — pass
- `npx tsx utils/scripts/verifyModelBuilderAutoBuildOutcomeClearGuard.ts` — pass; confirmed it fails against the pre-fix store (stashed test) with 9 violations
- `npx tsx utils/scripts/verifyModelBuilderAsyncPollFailureGuard.test.ts` / `.ts` — pass
- All 132 `test:model-builder-*` npm scripts (guards + self-tests) — pass
- `npx vue-tsc --noEmit -p tsconfig.json` — identical single pre-existing error before and after (`server/api/reactions/index.post.ts`, unrelated to this change) — zero new errors
- `npx eslint` on all touched files — clean
- `npx prettier --check` on all touched files — clean (confirmed the one pre-existing, unrelated prettier drift already in `modelBuilderStore.ts` at baseline was left untouched, not reformatted wholesale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bd4K71LGiaeozjEJuaAxR2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bd4K71LGiaeozjEJuaAxR2)_