### PR TITLE
fix(model-builder): clear stale status banner before every fresh save (t-029 cycle 42)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -704,6 +704,12 @@ jobs:
       - name: Model Builder auto-build outcome-clear guard contract
         run: npm run test:model-builder-auto-build-outcome-clear-guard
 
+      - name: Model Builder stale status-banner clear guard checker self-test
+        run: npm run test:model-builder-stale-status-clear-guard-selftest
+
+      - name: Model Builder stale status-banner clear guard contract
+        run: npm run test:model-builder-stale-status-clear-guard
+
       - name: Model Builder field-blob continuation guard self-test
         run: npm run test:model-builder-field-blob-continuation-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -320,6 +320,8 @@
     "test:model-builder-auto-build-outcome-persistence-guard": "tsx utils/scripts/verifyModelBuilderAutoBuildOutcomePersistenceGuard.ts",
     "test:model-builder-auto-build-outcome-clear-guard-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildOutcomeClearGuard.test.ts",
     "test:model-builder-auto-build-outcome-clear-guard": "tsx utils/scripts/verifyModelBuilderAutoBuildOutcomeClearGuard.ts",
+    "test:model-builder-stale-status-clear-guard-selftest": "tsx utils/scripts/verifyModelBuilderStaleStatusClearGuard.test.ts",
+    "test:model-builder-stale-status-clear-guard": "tsx utils/scripts/verifyModelBuilderStaleStatusClearGuard.ts",
     "test:model-builder-field-blob-continuation-guard-selftest": "tsx utils/scripts/verifyModelBuilderFieldBlobContinuationGuard.test.ts",
     "test:model-builder-field-blob-continuation-guard": "tsx utils/scripts/verifyModelBuilderFieldBlobContinuationGuard.ts",
     "test:model-builder-stage-status-json-parse-guard-selftest": "tsx utils/scripts/verifyModelBuilderStageStatusJsonParseGuard.test.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -970,6 +970,33 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     })
   }
 
+  // clearStatus() immediately before each pushItem() call below (model-builder/
+  // t-029, cycle 42, found by inspection): the global status banner
+  // (state.statusMessage/statusTone, rendered in model-builder-manager.vue)
+  // is only ever cleared by clearStatus(), which every OTHER action that
+  // calls pushItem/batchPushItems already invokes at the start of its own
+  // fresh attempt -- generateItemAsset, generateItemAssetAsync, commitItem,
+  // draftText, autoBuildRun, batchDraftField, and batchAutoBuild all do this
+  // (see e.g. generateItemAsset's own `clearStatus()` right before its try
+  // block). pushItem's onFailure branch calls setStatusForRun(runId, 'error',
+  // ...) on a rejected PATCH, but its success branch does nothing at all --
+  // there is no corresponding "clear the stale error" step anywhere in
+  // approveStage/rejectStage/reopenStage/updatePitch/updateFields/
+  // updatePrompt themselves. Concrete repro: click "Approve pitch" while a
+  // transient PATCH failure pops "Failed to save changes." in the banner
+  // (approveStage's own onFailure reverts the stage locally, correctly) --
+  // then click "Approve pitch" again and have it succeed this time. Nothing
+  // in this file ever clears that banner: the same stale "Failed to save
+  // changes." text keeps showing, now describing a save that actually
+  // succeeded, until some unrelated LATER action (generateItemAsset,
+  // commitItem, draftText, autoBuildRun, or a batch action) happens to call
+  // clearStatus()/setStatus() of its own accord -- exactly the "indicator
+  // lying about what's actually stored" class of bug this codebase treats as
+  // real everywhere else it's found, just reached through the global status
+  // banner instead of a per-item field. Fixed by clearing the banner right
+  // before each of these functions' own pushItem() call, mirroring where
+  // every other pushItem/batchPushItems caller already places its own
+  // clearStatus().
   function approveStage(itemId: string, stageKey: BuildStageKey): void {
     const item = findItem(itemId)
     if (!item) return
@@ -983,6 +1010,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     if (next && item.stages[next.key].status === 'locked') {
       item.stages[next.key] = { status: 'ready' }
     }
+    clearStatus()
     pushItem(item, { stageStatuses: item.stages }, { stage: stageKey }, () => {
       item.stages = previousStages
     })
@@ -998,6 +1026,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     const previousStages = { ...item.stages }
     item.stages[stageKey] = { status: 'rejected', note }
     markDownstreamStale(item, stageKey)
+    clearStatus()
     pushItem(item, { stageStatuses: item.stages }, { stage: stageKey }, () => {
       item.stages = previousStages
     })
@@ -1010,6 +1039,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     const previousStages = { ...item.stages }
     item.stages[stageKey] = { status: 'ready' }
     markDownstreamStale(item, stageKey)
+    clearStatus()
     pushItem(item, { stageStatuses: item.stages }, { stage: stageKey }, () => {
       item.stages = previousStages
     })
@@ -1070,6 +1100,13 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     item.error = null
     item.lastAutoBuildOutcome = null
     markDownstreamStale(item, 'PITCH')
+    // See the doc comment above approveStage (model-builder/t-029, cycle 42)
+    // for the full shape of this fix -- every other pushItem/batchPushItems
+    // caller already clears the global status banner right before its own
+    // call; this setter (and updateFields/updatePrompt below) didn't, so a
+    // stale "Failed to save changes." banner from an earlier failed edit
+    // outlived a subsequent successful one.
+    clearStatus()
     pushItem(
       item,
       { stageStatuses: item.stages, pitch: item.pitch, error: null },
@@ -1094,6 +1131,9 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     item.error = null
     item.lastAutoBuildOutcome = null
     markDownstreamStale(item, 'FIELDS_AND_PROMPTS')
+    // See updatePitch's identical clearStatus() (model-builder/t-029,
+    // cycle 42).
+    clearStatus()
     pushItem(
       item,
       {
@@ -1122,6 +1162,9 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     item.error = null
     item.lastAutoBuildOutcome = null
     markDownstreamStale(item, 'FIELDS_AND_PROMPTS')
+    // See updatePitch's identical clearStatus() (model-builder/t-029,
+    // cycle 42).
+    clearStatus()
     pushItem(
       item,
       {
@@ -2498,6 +2541,12 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       })
     }
     batchingOutputSingleton.claim(outputKey)
+    // See approveStage's doc comment (model-builder/t-029, cycle 42) -- every
+    // other batchPushItems caller (batchDraftField, batchAutoBuild) already
+    // clears the global status banner right before starting its own fresh
+    // attempt; this one didn't, so a stale "Failed to save changes." banner
+    // from an earlier failed batch edit outlived a subsequent successful one.
+    clearStatus()
     try {
       const { ok, failedIds } = await batchPushItems(entries)
       // On failure, batchPushItems already surfaced the real error via
@@ -2610,6 +2659,9 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       })
     }
     batchingOutputSingleton.claim(outputKey)
+    // See batchSetField's identical clearStatus() (model-builder/t-029,
+    // cycle 42).
+    clearStatus()
     try {
       const { ok, failedIds } = await batchPushItems(entries)
       // On failure, batchPushItems already surfaced the real error via

--- a/utils/scripts/verifyModelBuilderStaleStatusClearGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderStaleStatusClearGuard.test.ts
@@ -1,0 +1,311 @@
+// /utils/scripts/verifyModelBuilderStaleStatusClearGuard.test.ts
+//
+// Regression test for checkStaleStatusClearGuard() in
+// verifyModelBuilderStaleStatusClearGuard.ts (model-builder/t-029, cycle 42).
+// Exercises the real check against synthetic store-shaped fixtures covering:
+// the pre-fix shape (none of the eight target functions call clearStatus()),
+// the fixed shape (every function does), a partially-fixed shape (some
+// fixed, some not), and all eight target functions absent.
+import assert from 'node:assert/strict'
+
+import { checkStaleStatusClearGuard } from './verifyModelBuilderStaleStatusClearGuard.js'
+
+const BUGGY_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    const previousStages = { ...item.stages }
+    item.stages[stageKey] = { status: 'approved' }
+    pushItem(item, { stageStatuses: item.stages }, { stage: stageKey }, () => {
+      item.stages = previousStages
+    })
+  }
+
+  function rejectStage(itemId: string, stageKey: BuildStageKey, note?: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    const previousStages = { ...item.stages }
+    item.stages[stageKey] = { status: 'rejected', note }
+    markDownstreamStale(item, stageKey)
+    pushItem(item, { stageStatuses: item.stages }, { stage: stageKey }, () => {
+      item.stages = previousStages
+    })
+  }
+
+  function reopenStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    const previousStages = { ...item.stages }
+    item.stages[stageKey] = { status: 'ready' }
+    markDownstreamStale(item, stageKey)
+    pushItem(item, { stageStatuses: item.stages }, { stage: stageKey }, () => {
+      item.stages = previousStages
+    })
+  }
+
+  function updatePitch(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.pitch = value
+    pushItem(item, { pitch: item.pitch }, { stage: 'PITCH' }, () => {})
+  }
+
+  function updateFields(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.fieldsDraft = value
+    pushItem(item, { fieldsDraft: item.fieldsDraft }, {}, () => {})
+  }
+
+  function updatePrompt(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.promptDraft = value
+    pushItem(item, { promptDraft: item.promptDraft }, {}, () => {})
+  }
+
+  async function batchSetField(outputKey: string, fieldKey: string, value: string): Promise<void> {
+    const entries = []
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      const { ok, failedIds } = await batchPushItems(entries)
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchApproveStage(outputKey: string, stageKey: BuildStageKey): Promise<void> {
+    const entries = []
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      const { ok, failedIds } = await batchPushItems(entries)
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    const previousStages = { ...item.stages }
+    item.stages[stageKey] = { status: 'approved' }
+    clearStatus()
+    pushItem(item, { stageStatuses: item.stages }, { stage: stageKey }, () => {
+      item.stages = previousStages
+    })
+  }
+
+  function rejectStage(itemId: string, stageKey: BuildStageKey, note?: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    const previousStages = { ...item.stages }
+    item.stages[stageKey] = { status: 'rejected', note }
+    markDownstreamStale(item, stageKey)
+    clearStatus()
+    pushItem(item, { stageStatuses: item.stages }, { stage: stageKey }, () => {
+      item.stages = previousStages
+    })
+  }
+
+  function reopenStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    const previousStages = { ...item.stages }
+    item.stages[stageKey] = { status: 'ready' }
+    markDownstreamStale(item, stageKey)
+    clearStatus()
+    pushItem(item, { stageStatuses: item.stages }, { stage: stageKey }, () => {
+      item.stages = previousStages
+    })
+  }
+
+  function updatePitch(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.pitch = value
+    clearStatus()
+    pushItem(item, { pitch: item.pitch }, { stage: 'PITCH' }, () => {})
+  }
+
+  function updateFields(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.fieldsDraft = value
+    clearStatus()
+    pushItem(item, { fieldsDraft: item.fieldsDraft }, {}, () => {})
+  }
+
+  function updatePrompt(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.promptDraft = value
+    clearStatus()
+    pushItem(item, { promptDraft: item.promptDraft }, {}, () => {})
+  }
+
+  async function batchSetField(outputKey: string, fieldKey: string, value: string): Promise<void> {
+    const entries = []
+    batchingOutputSingleton.claim(outputKey)
+    clearStatus()
+    try {
+      const { ok, failedIds } = await batchPushItems(entries)
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchApproveStage(outputKey: string, stageKey: BuildStageKey): Promise<void> {
+    const entries = []
+    batchingOutputSingleton.claim(outputKey)
+    clearStatus()
+    try {
+      const { ok, failedIds } = await batchPushItems(entries)
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+
+const PARTIALLY_FIXED_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+    clearStatus()
+    pushItem(item, { stageStatuses: item.stages }, { stage: stageKey }, () => {})
+  }
+
+  function rejectStage(itemId: string, stageKey: BuildStageKey, note?: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'rejected', note }
+    pushItem(item, { stageStatuses: item.stages }, { stage: stageKey }, () => {})
+  }
+
+  function reopenStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'ready' }
+    clearStatus()
+    pushItem(item, { stageStatuses: item.stages }, { stage: stageKey }, () => {})
+  }
+
+  function updatePitch(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.pitch = value
+    clearStatus()
+    pushItem(item, { pitch: item.pitch }, { stage: 'PITCH' }, () => {})
+  }
+
+  function updateFields(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.fieldsDraft = value
+    clearStatus()
+    pushItem(item, { fieldsDraft: item.fieldsDraft }, {}, () => {})
+  }
+
+  function updatePrompt(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.promptDraft = value
+    clearStatus()
+    pushItem(item, { promptDraft: item.promptDraft }, {}, () => {})
+  }
+
+  async function batchSetField(outputKey: string, fieldKey: string, value: string): Promise<void> {
+    const entries = []
+    batchingOutputSingleton.claim(outputKey)
+    clearStatus()
+    try {
+      const { ok, failedIds } = await batchPushItems(entries)
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchApproveStage(outputKey: string, stageKey: BuildStageKey): Promise<void> {
+    const entries = []
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      const { ok, failedIds } = await batchPushItems(entries)
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function unrelatedHelper(itemId: string): void {
+    const item = findItem(itemId)
+  }
+`
+
+const buggyErrors = checkStaleStatusClearGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  8,
+  `expected all 8 target functions to be flagged in the pre-fix shape, got ${buggyErrors.length}: ` +
+    JSON.stringify(buggyErrors),
+)
+
+const fixedErrors = checkStaleStatusClearGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const partialErrors = checkStaleStatusClearGuard(PARTIALLY_FIXED_FIXTURE)
+assert.equal(
+  partialErrors.length,
+  2,
+  `expected rejectStage and batchApproveStage (missing clearStatus()) to be flagged = 2, got ${partialErrors.length}: ` +
+    JSON.stringify(partialErrors),
+)
+assert.ok(partialErrors.some((e) => e.includes('rejectStage')))
+assert.ok(partialErrors.some((e) => e.includes('batchApproveStage')))
+assert.ok(
+  !partialErrors.some((e) => e.includes('approveStage(')),
+  'approveStage is fixed in this fixture and should not be flagged',
+)
+assert.ok(
+  !partialErrors.some((e) => e.includes('updateFields')),
+  'updateFields is fixed in this fixture and should not be flagged',
+)
+assert.ok(
+  !partialErrors.some((e) => e.includes('batchSetField')),
+  'batchSetField is fixed in this fixture and should not be flagged',
+)
+
+const missingErrors = checkStaleStatusClearGuard(MISSING_FIXTURE)
+assert.equal(
+  missingErrors.length,
+  8,
+  'expected 8 "function not found" violations when all target functions are absent',
+)
+for (const name of [
+  'approveStage',
+  'rejectStage',
+  'reopenStage',
+  'updatePitch',
+  'updateFields',
+  'updatePrompt',
+  'batchSetField',
+  'batchApproveStage',
+]) {
+  assert.ok(
+    missingErrors.some((e) => e.includes(name)),
+    `expected a violation naming ${name}`,
+  )
+}
+
+console.log(
+  'Model Builder stale status-banner clear guard checker verified: flags ' +
+    'clearStatus() never being called in each target function ' +
+    'independently, clears the fixed shape, and flags all eight target ' +
+    'functions being absent.',
+)

--- a/utils/scripts/verifyModelBuilderStaleStatusClearGuard.ts
+++ b/utils/scripts/verifyModelBuilderStaleStatusClearGuard.ts
@@ -1,0 +1,134 @@
+// /utils/scripts/verifyModelBuilderStaleStatusClearGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 42, found by inspection).
+// model-builder-manager.vue renders a single global status banner off
+// state.statusMessage/statusTone (`v-if="store.statusMessage"`), with no
+// auto-dismiss timer of its own -- it stays exactly as-is until the store
+// itself calls setStatus()/setStatusForRun() (an error or success message)
+// or clearStatus() (blanks it). Every action that persists a change via
+// pushItem()/batchPushItems() and can therefore have that PATCH/batch
+// request rejected -- generateItemAsset, generateItemAssetAsync, commitItem,
+// draftText, autoBuildRun, batchDraftField, and batchAutoBuild -- already
+// calls clearStatus() at the start of its own fresh attempt, specifically so
+// a stale banner from an earlier failed attempt doesn't linger through a
+// later successful one. approveStage, rejectStage, reopenStage, updatePitch,
+// updateFields, updatePrompt, batchSetField, and batchApproveStage are the
+// same shape of action (mutate local state optimistically, call pushItem/
+// batchPushItems, revert on a real failure) but never got this same
+// treatment.
+//
+// Concrete repro (pre-fix): click "Approve pitch" while the PATCH happens to
+// fail (a transient network blip is enough) -- approveStage's own onFailure
+// correctly reverts the stage locally, and pushItem's failure branch pops
+// "Failed to save changes." into the banner. Click "Approve pitch" again and
+// have it succeed this time -- nothing in approveStage (or any of its seven
+// siblings above) ever clears that banner, so the same stale "Failed to save
+// changes." text keeps showing, now describing a save that actually
+// succeeded, until some UNRELATED later action (a generate, a commit, a
+// draft, an auto-build/batch pass) happens to call clearStatus()/setStatus()
+// of its own accord. If the user's next several actions are all
+// approve/reject/reopen/edit/batch-field/batch-approve calls -- an entirely
+// normal editing session -- the stale error banner can outlive the entire
+// rest of the run. Exactly the "indicator lying about what's actually
+// stored" class of bug this codebase treats as real everywhere else it's
+// found (see verifyModelBuilderAutoBuildOutcomeClearGuard.ts for the
+// per-item-field instance of the same class), just reached through the
+// global status banner instead of a per-item field.
+//
+// Fixed by adding a `clearStatus()` call to each of the eight target
+// functions, placed the same way their fixed siblings already do -- right
+// before the pushItem()/batchPushItems() call it guards.
+//
+// This walks each target function in modelBuilderStore.ts and requires its
+// body to contain at least one bare `clearStatus()` call -- i.e. that the
+// function actually clears the stale banner somewhere on its way to
+// persisting, mirroring verifyModelBuilderAutoBuildOutcomeClearGuard.ts's own
+// presence-check style rather than proving every single branch does it.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const TARGET_FUNCTIONS = [
+  'approveStage',
+  'rejectStage',
+  'reopenStage',
+  'updatePitch',
+  'updateFields',
+  'updatePrompt',
+  'batchSetField',
+  'batchApproveStage',
+] as const
+
+const CLEARS_STATUS = /\bclearStatus\(\)/
+
+// Checks the fix's exact shape against the full source text of a file
+// containing these function names. Exported so the self-test below can run
+// it against synthetic buggy/fixed fixtures without touching the real store.
+export function checkStaleStatusClearGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+
+  for (const name of TARGET_FUNCTIONS) {
+    const fn = functions.find((f) => f.name === name)
+    if (!fn) {
+      errors.push(
+        `Could not find a function named ${name}() -- has it been renamed, ` +
+          'removed, or inlined? If so, this guard (and the stale-status-' +
+          'banner clearing it protects) needs to move with it.',
+      )
+      continue
+    }
+
+    if (!CLEARS_STATUS.test(fn.body)) {
+      errors.push(
+        `${name}() never calls clearStatus() (expected a bare ` +
+          '`clearStatus()` call in its body, mirroring how generateItemAsset/' +
+          'generateItemAssetAsync/commitItem/draftText/autoBuildRun/' +
+          'batchDraftField/batchAutoBuild already clear the global status ' +
+          'banner before their own fresh attempt). Without it, a stale ' +
+          '"Failed to save changes." banner from an earlier failed call to ' +
+          'this function outlives a subsequent successful one, with nothing ' +
+          'to clear it short of an unrelated later action happening to call ' +
+          'clearStatus()/setStatus() on its own.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkStaleStatusClearGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder stale status-banner clear guard contract failed in ' +
+        'modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder stale status-banner clear guard contract passed: ' +
+      'approveStage(), rejectStage(), reopenStage(), updatePitch(), ' +
+      'updateFields(), updatePrompt(), batchSetField(), and ' +
+      'batchApproveStage() all call clearStatus() before persisting, so a ' +
+      'stale error banner from an earlier failed attempt never outlives a ' +
+      'subsequent successful one.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What

Cycle 42 of the recurring `model-builder/t-029` polish task. Per cycle 41's kaizen suggestion, audited every ephemeral, non-server-persisted status-like field in `stores/modelBuilderStore.ts` for the same one-way-clear-gap bug class fixed in cycle 41 (`lastAutoBuildOutcome`): a flag set by one code path to signal failure/staleness/in-flight that a *different*, later corrective action fails to clear symmetrically.

### Audited and found already correct

- `item.artJobId` / `item.queueState` — always cleared together on terminal job status (DONE/FAILED/CANCELLED) or on `cancelRun`; `pollAsyncArtJob`'s only awaited calls (`getArtJobStatus`, `finalizeQueuedArtImage`) never throw, so there's no uncaught-rejection path that could strand them.
- `generatingItemId` / `committingItemId` / `autoBuildingItemId` / `batchingOutputKey` (the `createOwnedSingleton` flags) — always released in a `finally`, and every gap between an auto-build step's awaits is transitively covered by one of these same flags (autoBuildItem calls the very functions that claim them), so there's no window where the busy state is real but unsignaled.
- `sourcesError` — only ever set/read/cleared by `loadSources` itself; no other path resolves the condition it represents.
- `StageState.note` — never read as an authoritative "is this broken" signal by any Vue component (checked `components/model-builder/*`), so a stale value has no user-visible effect.

### Found and fixed: the global status banner

`state.statusMessage` / `statusTone` (rendered in `model-builder-manager.vue`, no auto-dismiss) is only ever cleared by `clearStatus()`. `generateItemAsset`, `generateItemAssetAsync`, `commitItem`, `draftText`, `autoBuildRun`, `batchDraftField`, and `batchAutoBuild` already call it at the start of their own fresh attempt. `approveStage`, `rejectStage`, `reopenStage`, `updatePitch`, `updateFields`, `updatePrompt`, `batchSetField`, and `batchApproveStage` never did — and `pushItem`'s `onFailure` branch sets an `'error'` status on a rejected PATCH, but its success branch does nothing.

**Concrete repro (pre-fix):** click "Approve pitch" while the PATCH happens to fail (a transient network blip) — the banner correctly shows "Failed to save changes." Click "Approve pitch" again and have it succeed this time — nothing clears the banner, so the same stale error text keeps showing a save that actually succeeded, until some unrelated later action (a generate, a commit, a draft, an auto-build/batch pass) happens to call `clearStatus()`/`setStatus()` on its own. An ordinary editing session of just approve/reject/reopen/edit/batch calls can leave it stuck for the whole run.

Fixed by adding `clearStatus()` to each of the eight functions, placed immediately before their own `pushItem()`/`batchPushItems()` call — mirroring exactly where every already-fixed sibling places its own.

## Guard

Added `utils/scripts/verifyModelBuilderStaleStatusClearGuard.ts` (+ `.test.ts`), following the `verifyModelBuilderAutoBuildOutcomeClearGuard.ts` convention exactly: walks the eight target functions via `extractFunctionBodies` and requires each body to contain a `clearStatus()` call. Confirmed it fails against the pre-fix code (`git stash`) and passes post-fix. Wired into `package.json` npm scripts and `.github/workflows/contract-tests.yml` matching the cycle-41 guard's registration.

## Verification

- All 133 `test:model-builder-*` npm scripts pass (including the 2 new ones).
- `vue-tsc --noEmit`: identical single pre-existing, unrelated error in `server/api/reactions/index.post.ts` (confirmed via `git stash` comparison) — zero new errors.
- `eslint` on touched files: only 2 pre-existing errors (empty catch blocks in `safeSet`/`safeRemove`, confirmed pre-existing via `git stash`), nothing new.
- `prettier --check` on the new files and `package.json`/`contract-tests.yml`: clean. `modelBuilderStore.ts` itself already fails `prettier --check` on `main` before this change (repo-wide pre-existing drift against the `printWidth: 80` config — confirmed via `git stash`) — kept this diff's own added lines under 80 columns rather than reformatting the whole file.

## Kaizen suggestion for cycle 43

The `modelBuilderStore.ts` file as a whole does not currently pass `prettier --check` under this repo's own `.prettierrc` (`printWidth: 80`) — dozens of lines throughout the file exceed 80 columns with unwrapped ternaries/calls. This predates this PR (confirmed via `git stash` against `main`) and is out of this cycle's scope (a full reformat would blow up the diff and violate "keep changes small and reviewable"), but it means `npm run lint:prettier` is silently red for this file in CI right now. Cycle 43 could either (a) run `prettier --write` on this file alone as its own dedicated, easy-to-review formatting-only PR, or (b) confirm CI's prettier check is scoped/allowed to fail on this file already and document why, so future cycles aren't repeatedly surprised by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MbVSAZtZneimqDR1YnmfnW)_