### PR TITLE
fix(model-builder): cap pitch/fieldsDraft/promptDraft on run CREATE (t-029 cycle 46)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -458,6 +458,12 @@ jobs:
       - name: Model Builder patch text-cap guard contract
         run: npm run test:model-builder-patch-text-cap-guard
 
+      - name: Model Builder run-create text-cap guard checker self-test
+        run: npm run test:model-builder-run-create-text-cap-guard-selftest
+
+      - name: Model Builder run-create text-cap guard contract
+        run: npm run test:model-builder-run-create-text-cap-guard
+
       - name: Model Builder async poll-failure guard checker self-test
         run: npm run test:model-builder-async-poll-failure-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -238,6 +238,8 @@
     "test:model-builder-commit-name-width-guard": "tsx utils/scripts/verifyModelBuilderCommitNameWidthGuard.ts",
     "test:model-builder-patch-text-cap-guard-selftest": "tsx utils/scripts/verifyModelBuilderPatchTextCapGuard.test.ts",
     "test:model-builder-patch-text-cap-guard": "tsx utils/scripts/verifyModelBuilderPatchTextCapGuard.ts",
+    "test:model-builder-run-create-text-cap-guard-selftest": "tsx utils/scripts/verifyModelBuilderRunCreateTextCapGuard.test.ts",
+    "test:model-builder-run-create-text-cap-guard": "tsx utils/scripts/verifyModelBuilderRunCreateTextCapGuard.ts",
     "test:model-builder-async-poll-failure-guard-selftest": "tsx utils/scripts/verifyModelBuilderAsyncPollFailureGuard.test.ts",
     "test:model-builder-async-poll-failure-guard": "tsx utils/scripts/verifyModelBuilderAsyncPollFailureGuard.ts",
     "test:art-queue-poll-failure-guard-selftest": "tsx utils/scripts/verifyArtQueuePollFailureGuard.test.ts",

--- a/server/api/model-builder/runs/index.post.ts
+++ b/server/api/model-builder/runs/index.post.ts
@@ -4,7 +4,7 @@ import type { ModelBuildAction } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
-import { runInclude } from './index'
+import { MAX_DRAFT_TEXT_LENGTH, runInclude } from './index'
 
 const actions = new Set<ModelBuildAction>(['CREATE', 'UPDATE', 'ASSET_ONLY'])
 
@@ -112,7 +112,12 @@ export default defineEventHandler(async (event) => {
     // at another user's Bot/Character/Dream/etc. and overwrite it on commit
     // (audit P6 CRITICAL). This also constrains sourceType to the models the
     // commit path can actually target.
-    await assertSourceOwnership(sourceType, sourceId, auth.user.id, auth.isAdmin)
+    await assertSourceOwnership(
+      sourceType,
+      sourceId,
+      auth.user.id,
+      auth.isAdmin,
+    )
 
     if (!Array.isArray(body.items) || body.items.length === 0) {
       throw createError({
@@ -122,7 +127,11 @@ export default defineEventHandler(async (event) => {
     }
 
     const items = (body.items as RunItemInput[]).map((item, index) => {
-      const outputKey = requiredString(item.outputKey, `items[${index}].outputKey`, 64)
+      const outputKey = requiredString(
+        item.outputKey,
+        `items[${index}].outputKey`,
+        64,
+      )
       const generation = requiredString(
         item.generation,
         `items[${index}].generation`,
@@ -137,13 +146,32 @@ export default defineEventHandler(async (event) => {
           : {},
       )
 
-      const text = (value: unknown): string | null =>
-        typeof value === 'string' && value.trim() ? value : null
+      // pitch/fieldsDraft/promptDraft are `@db.Text` (prisma/model-builder.prisma,
+      // 65,535-byte MySQL TEXT limit). The item PATCH path (prepareItemUpdate in
+      // ./index) already caps these at MAX_DRAFT_TEXT_LENGTH via normalizeText,
+      // throwing a clean 400 -- but this CREATE route's own `items` mapping had
+      // no cap at all (model-builder/t-029, cycle 46), so a run created with an
+      // oversized draft in its initial payload would sail through here uncapped
+      // and only get caught later, on the first PATCH that re-saves the same
+      // field. Reusing the same constant keeps the two routes from drifting.
+      const text = (
+        value: unknown,
+        index: number,
+        field: string,
+      ): string | null => {
+        if (typeof value !== 'string' || !value.trim()) return null
+        if (value.length > MAX_DRAFT_TEXT_LENGTH) {
+          throw createError({
+            statusCode: 400,
+            message: `"items[${index}].${field}" must be ${MAX_DRAFT_TEXT_LENGTH} characters or fewer.`,
+          })
+        }
+        return value
+      }
 
       return {
         outputKey,
-        label:
-          typeof item.label === 'string' ? item.label.slice(0, 255) : null,
+        label: typeof item.label === 'string' ? item.label.slice(0, 255) : null,
         action,
         generation,
         quantityIndex:
@@ -152,9 +180,9 @@ export default defineEventHandler(async (event) => {
             ? Number(item.quantityIndex)
             : 0,
         stageStatuses,
-        pitch: text(item.pitch),
-        fieldsDraft: text(item.fieldsDraft),
-        promptDraft: text(item.promptDraft),
+        pitch: text(item.pitch, index, 'pitch'),
+        fieldsDraft: text(item.fieldsDraft, index, 'fieldsDraft'),
+        promptDraft: text(item.promptDraft, index, 'promptDraft'),
       }
     })
 

--- a/utils/scripts/verifyModelBuilderRunCreateTextCapGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderRunCreateTextCapGuard.test.ts
@@ -1,0 +1,109 @@
+// /utils/scripts/verifyModelBuilderRunCreateTextCapGuard.test.ts
+//
+// Regression test for verifyModelBuilderRunCreateTextCapGuard.ts
+// (model-builder/t-029, cycle 46). Exercises the real checks against
+// synthetic runs/index.post.ts fixtures covering: the pre-fix buggy shape (no
+// cap at all), the fixed shape (capped against MAX_DRAFT_TEXT_LENGTH), and a
+// shape missing one field's call site entirely.
+import assert from 'node:assert/strict'
+
+import {
+  extractTextHelperBody,
+  findRunCreateTextCapProblems,
+} from './verifyModelBuilderRunCreateTextCapGuard.js'
+
+const FIXED = `
+import { MAX_DRAFT_TEXT_LENGTH, runInclude } from './index'
+
+      const text = (value: unknown, index: number, field: string): string | null => {
+        if (typeof value !== 'string' || !value.trim()) return null
+        if (value.length > MAX_DRAFT_TEXT_LENGTH) {
+          throw createError({ statusCode: 400, message: 'too long' })
+        }
+        return value
+      }
+
+      return {
+        pitch: text(item.pitch, index, 'pitch'),
+        fieldsDraft: text(item.fieldsDraft, index, 'fieldsDraft'),
+        promptDraft: text(item.promptDraft, index, 'promptDraft'),
+      }
+`
+
+const PRE_FIX = `
+import { runInclude } from './index'
+
+      const text = (value: unknown): string | null =>
+        typeof value === 'string' && value.trim() ? value : null
+
+      return {
+        pitch: text(item.pitch),
+        fieldsDraft: text(item.fieldsDraft),
+        promptDraft: text(item.promptDraft),
+      }
+`
+
+const MISSING_FIELD = `
+import { MAX_DRAFT_TEXT_LENGTH, runInclude } from './index'
+
+      const text = (value: unknown, index: number, field: string): string | null => {
+        if (typeof value !== 'string' || !value.trim()) return null
+        if (value.length > MAX_DRAFT_TEXT_LENGTH) {
+          throw createError({ statusCode: 400, message: 'too long' })
+        }
+        return value
+      }
+
+      return {
+        pitch: text(item.pitch, index, 'pitch'),
+        fieldsDraft: text(item.fieldsDraft, index, 'fieldsDraft'),
+      }
+`
+
+// --- extractTextHelperBody ---------------------------------------------------
+
+assert.match(
+  extractTextHelperBody(FIXED) ?? '',
+  /MAX_DRAFT_TEXT_LENGTH/,
+  'the fixed helper body should reference MAX_DRAFT_TEXT_LENGTH',
+)
+assert.equal(
+  extractTextHelperBody('no helper here'),
+  null,
+  'a source with no text() helper should report null',
+)
+
+// --- findRunCreateTextCapProblems: fixed shape reports nothing --------------
+
+assert.deepEqual(
+  findRunCreateTextCapProblems(FIXED),
+  [],
+  'the fixed shape (all three fields capped against the constant) should report no problems',
+)
+
+// --- findRunCreateTextCapProblems: pre-fix shape (no cap at all) is caught ---
+
+const preFixProblems = findRunCreateTextCapProblems(PRE_FIX)
+assert.equal(
+  preFixProblems.length,
+  3,
+  'the pre-fix shape should report all three guarded fields as uncapped',
+)
+for (const problem of preFixProblems) {
+  assert.equal(problem.reason, 'not-capped-against-constant')
+}
+
+// --- findRunCreateTextCapProblems: a missing call site is caught ------------
+
+const missingFieldProblems = findRunCreateTextCapProblems(MISSING_FIELD)
+assert.equal(
+  missingFieldProblems.length,
+  1,
+  'a field with no call site at all should be reported once',
+)
+assert.equal(missingFieldProblems[0]!.field, 'promptDraft')
+assert.equal(missingFieldProblems[0]!.reason, 'missing-call-site')
+
+console.log(
+  'verifyModelBuilderRunCreateTextCapGuard.test.ts: all assertions passed.',
+)

--- a/utils/scripts/verifyModelBuilderRunCreateTextCapGuard.ts
+++ b/utils/scripts/verifyModelBuilderRunCreateTextCapGuard.ts
@@ -1,0 +1,120 @@
+// /utils/scripts/verifyModelBuilderRunCreateTextCapGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 46). pitch/fieldsDraft/
+// promptDraft are `@db.Text` (prisma/model-builder.prisma, a real 65,535-byte
+// MySQL TEXT limit). The item PATCH path (prepareItemUpdate in runs/index.ts)
+// already caps all three at MAX_DRAFT_TEXT_LENGTH via normalizeText -- but
+// the run CREATE route's own `items` mapping (runs/index.post.ts) had no cap
+// at all before this fix, so a run created with an oversized draft in its
+// initial payload sailed through uncapped and was only caught later, on the
+// first PATCH that re-saved the same field.
+//
+// This walks runs/index.post.ts and fails if: the file no longer imports
+// MAX_DRAFT_TEXT_LENGTH from ./index, any of the three guarded fields'
+// `text(item.<field>, ...)` call site is missing, or the cap's own
+// implementation no longer compares against MAX_DRAFT_TEXT_LENGTH (e.g. a
+// drifted hardcoded number).
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const RUNS_CREATE_PATH = join(
+  repositoryRoot,
+  'server/api/model-builder/runs/index.post.ts',
+)
+
+export const GUARDED_ITEM_TEXT_FIELDS = [
+  'pitch',
+  'fieldsDraft',
+  'promptDraft',
+] as const
+
+export interface RunCreateTextCapProblem {
+  field: string
+  reason: 'missing-call-site' | 'not-capped-against-constant'
+}
+
+// Extracts the body of the local `text(...)` helper function defined in
+// runs/index.post.ts (between its `const text = (` opener and the matching
+// closing `}` of its arrow function), or null if it can't be found.
+export function extractTextHelperBody(sourceContent: string): string | null {
+  const anchor = 'const text = ('
+  const start = sourceContent.indexOf(anchor)
+  if (start === -1) return null
+  const braceStart = sourceContent.indexOf('{', start)
+  if (braceStart === -1) return null
+  let depth = 0
+  for (let i = braceStart; i < sourceContent.length; i++) {
+    if (sourceContent[i] === '{') depth++
+    else if (sourceContent[i] === '}') {
+      depth--
+      if (depth === 0) return sourceContent.slice(braceStart, i + 1)
+    }
+  }
+  return null
+}
+
+export function findRunCreateTextCapProblems(
+  sourceContent: string,
+): RunCreateTextCapProblem[] {
+  const problems: RunCreateTextCapProblem[] = []
+
+  const importsConstant =
+    /import\s*\{[^}]*\bMAX_DRAFT_TEXT_LENGTH\b[^}]*\}\s*from\s*['"]\.\/index['"]/.test(
+      sourceContent,
+    )
+
+  const helperBody = extractTextHelperBody(sourceContent)
+  const helperCapsAgainstConstant =
+    importsConstant &&
+    helperBody !== null &&
+    /MAX_DRAFT_TEXT_LENGTH/.test(helperBody)
+
+  for (const field of GUARDED_ITEM_TEXT_FIELDS) {
+    const hasCallSite = new RegExp(`text\\(item\\.${field}\\b`).test(
+      sourceContent,
+    )
+    if (!hasCallSite) {
+      problems.push({ field, reason: 'missing-call-site' })
+      continue
+    }
+    if (!helperCapsAgainstConstant) {
+      problems.push({ field, reason: 'not-capped-against-constant' })
+    }
+  }
+
+  return problems
+}
+
+function main(): void {
+  const sourceContent = readFileSync(RUNS_CREATE_PATH, 'utf8')
+  const problems = findRunCreateTextCapProblems(sourceContent)
+
+  if (problems.length) {
+    console.error(
+      `Model Builder run-create text-cap contract failed: ${problems.length} ` +
+        'guarded field(s) in runs/index.post.ts are missing a cap against ' +
+        "MAX_DRAFT_TEXT_LENGTH -- a value over the TEXT column's real limit " +
+        'would reach Prisma unchecked and fail at the DB with a raw "Data too ' +
+        'long for column" error instead of a clean 400:',
+    )
+    for (const problem of problems) {
+      console.error(`- ${problem.field}: ${problem.reason}`)
+    }
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder run-create text-cap contract passed: pitch/fieldsDraft/' +
+      'promptDraft are all capped against MAX_DRAFT_TEXT_LENGTH in ' +
+      'runs/index.post.ts.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What

The item PATCH path (`prepareItemUpdate` in `runs/index.ts`) already caps `pitch`/`fieldsDraft`/`promptDraft` at `MAX_DRAFT_TEXT_LENGTH` via `normalizeText`, since these are `@db.Text` columns (a real 65,535-byte MySQL TEXT limit, not unbounded). The run **CREATE** route's own `items` mapping (`runs/index.post.ts`) had no cap on these fields at all — a run created with an oversized draft in its initial payload would sail through here uncapped, and only get caught later on the first PATCH that re-saves the same field, surfacing as an opaque "Data too long for column" 500 instead of a clean 400.

## Fix

- `runs/index.post.ts`: the local `text()` helper now takes an index/field label and throws a 400 (matching every other validated field in this file) when a value exceeds `MAX_DRAFT_TEXT_LENGTH`, imported from `./index` so it can never drift from the PATCH path's cap.
- Added `verifyModelBuilderRunCreateTextCapGuard.ts` + `.test.ts` (mirrors `verifyModelBuilderPatchTextCapGuard.ts`'s approach from the prior cycle), wired into `package.json` and `contract-tests.yml`, so the two routes can't silently drift apart again.

## Verification

- All 69 `test:model-builder-*` contract scripts pass, all 68 `-selftest` variants pass.
- `vue-tsc --noEmit` clean (one pre-existing, unrelated error in `server/api/reactions/index.post.ts` confirmed via `git stash` — not touched by this change).
- `eslint` / `prettier --check` clean on all changed files.

## Flags for Reviewer

None — additive validation only, no schema change, no behavior change for any value that was already within the existing limits.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YE4azoAGx1dZnXncxpsqmz)_