### PR TITLE
fix(appmaker): recognize external-repo scaffold Todos in the pending list (t-012)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -260,6 +260,12 @@ jobs:
       - name: AppMaker scaffold-collision guard
         run: npm run test:appmaker-scaffold-collision-guard
 
+      - name: AppMaker pending-scaffold-pattern guard self-test
+        run: npm run test:appmaker-pending-scaffold-pattern-guard-selftest
+
+      - name: AppMaker pending-scaffold-pattern guard
+        run: npm run test:appmaker-pending-scaffold-pattern-guard
+
       - name: Da Vinci narration bounds contract
         run: npm run test:davinci-narration
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "test:appmaker-fleet-description-guard": "tsx utils/scripts/verifyAppmakerFleetDescriptionGuard.ts",
     "test:appmaker-scaffold-collision-guard-selftest": "tsx utils/scripts/verifyAppmakerScaffoldCollisionGuard.test.ts",
     "test:appmaker-scaffold-collision-guard": "tsx utils/scripts/verifyAppmakerScaffoldCollisionGuard.ts",
+    "test:appmaker-pending-scaffold-pattern-guard-selftest": "tsx utils/scripts/verifyAppmakerPendingScaffoldPatternGuard.test.ts",
+    "test:appmaker-pending-scaffold-pattern-guard": "tsx utils/scripts/verifyAppmakerPendingScaffoldPatternGuard.ts",
     "test:comment-prefix": "tsx utils/scripts/verifyPartialPublishPrefix.ts",
     "test:comment-quality": "tsx utils/scripts/verifyCommentDraftQuality.ts",
     "test:population-quality": "tsx utils/scripts/verifyPopulationDraftQuality.ts",

--- a/server/api/appmaker/apps.get.ts
+++ b/server/api/appmaker/apps.get.ts
@@ -6,7 +6,17 @@ import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { conductorList } from '~/server/utils/conductor-github'
 
-const SCAFFOLD_TITLE_RE = /^Scaffold new app '([a-z0-9-]+)'/
+// Two self-serve flows file a scaffold Todo: scaffold-request.post.ts (the
+// monorepo apps/<slug>/ flow, "Scaffold new app '<slug>' ...") and
+// github/create-app.post.ts (the external-repo GitHub-integration flow,
+// appmaker/t-009, "Scaffold external app '<slug>' via AppMaker GitHub
+// integration"). This route only ever recognized the first pattern — the
+// `startsWith` filter below excluded every external-repo Todo before it even
+// reached the regex, so a request filed through create-app.post.ts (already
+// API-reachable with no front-end wired up yet, per t-012's 2026-08-21 cycle)
+// would never appear in the "Being built" pending list: a real, open Todo
+// waiting for the next Worker cycle, silently invisible to the requester.
+const SCAFFOLD_TITLE_RE = /^Scaffold (?:new|external) app '([a-z0-9-]+)'/
 
 export default defineEventHandler(async () => {
   try {
@@ -20,7 +30,10 @@ export default defineEventHandler(async () => {
       where: {
         status: 'OPEN',
         category: 'AGENT',
-        title: { startsWith: "Scaffold new app '" },
+        OR: [
+          { title: { startsWith: "Scaffold new app '" } },
+          { title: { startsWith: "Scaffold external app '" } },
+        ],
       },
       select: {
         title: true,

--- a/utils/scripts/verifyAppmakerPendingScaffoldPatternGuard.test.ts
+++ b/utils/scripts/verifyAppmakerPendingScaffoldPatternGuard.test.ts
@@ -1,0 +1,100 @@
+// /utils/scripts/verifyAppmakerPendingScaffoldPatternGuard.test.ts
+//
+// Regression test for checkPendingScaffoldPatternGuard() in
+// verifyAppmakerPendingScaffoldPatternGuard.ts (appmaker/t-012). Exercises
+// the real check against synthetic route-shaped fixtures covering: the fixed
+// shape (both title prefixes queried, both patterns recognized by the
+// regex), the pre-fix shape (only the monorepo "new app" pattern), and a
+// partial regression (query widened but the regex not updated to match).
+import assert from 'node:assert/strict'
+
+import { checkPendingScaffoldPatternGuard } from './verifyAppmakerPendingScaffoldPatternGuard.js'
+
+function fixture(whereClause: string, regexSource: string): string {
+  return `
+import { defineEventHandler, H3Error } from 'h3'
+import prisma from '@/server/utils/prisma'
+
+const SCAFFOLD_TITLE_RE = ${regexSource}
+
+export default defineEventHandler(async () => {
+  const openScaffoldTodos = await prisma.todo.findMany({
+    where: {
+      status: 'OPEN',
+      category: 'AGENT',
+      ${whereClause}
+    },
+  })
+})
+`
+}
+
+const FIXED = fixture(
+  `OR: [
+        { title: { startsWith: "Scaffold new app '" } },
+        { title: { startsWith: "Scaffold external app '" } },
+      ],`,
+  `/^Scaffold (?:new|external) app '([a-z0-9-]+)'/`,
+)
+
+// Pre-fix shape: the query and regex only ever recognized the monorepo flow.
+const BUGGY = fixture(
+  `title: { startsWith: "Scaffold new app '" },`,
+  `/^Scaffold new app '([a-z0-9-]+)'/`,
+)
+
+// Partial regression: the query was widened to cover both flows, but the
+// extraction regex was never updated to match the external-repo title.
+const PARTIALLY_REGRESSED = fixture(
+  `OR: [
+        { title: { startsWith: "Scaffold new app '" } },
+        { title: { startsWith: "Scaffold external app '" } },
+      ],`,
+  `/^Scaffold new app '([a-z0-9-]+)'/`,
+)
+
+function run(): void {
+  const fixedErrors = checkPendingScaffoldPatternGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const buggyErrors = checkPendingScaffoldPatternGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    2,
+    'expected the pre-fix fixture (no external-repo prefix in the query, ' +
+      `regex not widened) to fail both checks, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(
+    buggyErrors.some((e) => /"Scaffold external app '" title prefix/.test(e)),
+  )
+  assert.ok(
+    buggyErrors.some((e) =>
+      /no longer recognizes both "new" and "external"/.test(e),
+    ),
+  )
+
+  const regressedErrors = checkPendingScaffoldPatternGuard(PARTIALLY_REGRESSED)
+  assert.equal(
+    regressedErrors.length,
+    1,
+    'expected a fixture with a widened query but a stale regex to fail ' +
+      `only the regex assertion, got: ${JSON.stringify(regressedErrors)}`,
+  )
+  assert.ok(
+    regressedErrors.some((e) =>
+      /no longer recognizes both "new" and "external"/.test(e),
+    ),
+  )
+
+  console.log(
+    'AppMaker pending-scaffold-pattern guard self-test passed: buggy ' +
+      'fixture fails both checks, fixed fixture passes, and a ' +
+      'query-widened-but-regex-stale regression fails only the regex check.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyAppmakerPendingScaffoldPatternGuard.ts
+++ b/utils/scripts/verifyAppmakerPendingScaffoldPatternGuard.ts
@@ -1,0 +1,94 @@
+// /utils/scripts/verifyAppmakerPendingScaffoldPatternGuard.ts
+//
+// Regression guard (appmaker/t-012) -- two self-serve flows file a scaffold
+// Todo: scaffold-request.post.ts (the monorepo apps/<slug>/ flow, title
+// "Scaffold new app '<slug>' with scripts/new_app.py") and
+// github/create-app.post.ts (the external-repo GitHub-integration flow,
+// appmaker/t-009, title "Scaffold external app '<slug>' via AppMaker GitHub
+// integration"). apps.get.ts's `pending` list -- the "Being built" section
+// appmaker-page.vue renders -- only ever recognized the first title pattern:
+// its Prisma query filtered on `title: { startsWith: "Scaffold new app '" }`
+// and its extraction regex only matched `^Scaffold new app '...`. A request
+// filed through create-app.post.ts (already API-reachable even before any
+// front-end wires up to it, per t-012's 2026-08-21 cycle) created a real,
+// open Todo that was silently excluded from both the DB query and the
+// regex -- it would never appear in the pending list, leaving the requester
+// with no visibility that their request was filed and waiting on a Worker
+// cycle.
+//
+// Fixed by widening the Prisma `where` to an OR across both known title
+// prefixes, and widening SCAFFOLD_TITLE_RE to `^Scaffold (?:new|external)
+// app '...` so the extraction step recognizes either flow's Todo.
+//
+// This asserts the textual shape of that fix stays in place: the query still
+// matches both prefixes, and the regex still recognizes both the "new" and
+// "external" scaffold-title patterns, rather than silently regressing to
+// recognizing only one flow again.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const ROUTE_PATH = join(repositoryRoot, 'server/api/appmaker/apps.get.ts')
+
+export function checkPendingScaffoldPatternGuard(content: string): string[] {
+  const errors: string[] = []
+
+  if (!/startsWith:\s*"Scaffold new app '"/.test(content)) {
+    errors.push(
+      "the Prisma query no longer filters on the monorepo flow's " +
+        '"Scaffold new app \'" title prefix -- has scaffold-request.post.ts\'s ' +
+        'Todo shape changed, or was this branch of the OR dropped?',
+    )
+  }
+
+  if (!/startsWith:\s*"Scaffold external app '"/.test(content)) {
+    errors.push(
+      "the Prisma query no longer filters on the external-repo flow's " +
+        '"Scaffold external app \'" title prefix -- a Todo filed through ' +
+        'github/create-app.post.ts will be excluded before it ever reaches ' +
+        'the extraction regex, silently vanishing from the pending list ' +
+        'again.',
+    )
+  }
+
+  if (
+    !/SCAFFOLD_TITLE_RE\s*=\s*\/\^Scaffold \(\?:new\|external\) app/.test(
+      content,
+    )
+  ) {
+    errors.push(
+      'SCAFFOLD_TITLE_RE no longer recognizes both "new" and "external" ' +
+        'scaffold-title patterns -- has it regressed to matching only one ' +
+        "self-serve flow's Todo title?",
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(ROUTE_PATH, 'utf8')
+  const errors = checkPendingScaffoldPatternGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'AppMaker pending-scaffold-pattern guard contract failed in apps.get.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'AppMaker pending-scaffold-pattern guard contract passed: both the ' +
+      "monorepo and external-repo self-serve flows' Todos are recognized " +
+      'in the pending-scaffold list.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
appmaker/t-012: Polish and upgrade AppMaker front-end surface (kind: software, recurring)

### What changed / what I produced
- `apps.get.ts`'s pending-scaffold query and extraction regex only ever recognized `scaffold-request.post.ts`'s monorepo-flow Todo title (`"Scaffold new app '<slug>' ..."`), never `github/create-app.post.ts`'s external-repo-flow title (`"Scaffold external app '<slug>' via AppMaker GitHub integration"`). A request filed through the external-repo flow (already API-reachable, no front-end wired up yet per t-012's 2026-08-21 cycle) created a real, open Todo that silently never appeared in the AppMaker page's "Being built" section.
- Widened the Prisma query's title filter to an `OR` across both known prefixes and widened `SCAFFOLD_TITLE_RE` to match either flow's title.
- Added `verifyAppmakerPendingScaffoldPatternGuard.ts` + `.test.ts` following this project's established narrow-textual-checker convention, wired into `package.json` and `contract-tests.yml` alongside the sibling appmaker guards.

### How I verified
- New guard fails pre-fix / passes post-fix (git-stash round-trip against the real file).
- All 3 existing appmaker guards (slug-candidate, fleet-description, scaffold-collision) still pass.
- `eslint` clean on touched/new files.
- `prettier --check` clean.
- `vue-tsc --noEmit` repo-wide, exit 0.
- `git status --porcelain` scoped to exactly 5 files.

### Stakes
reversible

### Flags for Reviewer
- No front-end UI calls the external-repo GitHub-integration flow yet (per t-012's own history), so this fix has no live user-visible effect today — it closes a real gap in an already API-reachable endpoint, matching the precedent set by the 2026-08-21 cycle's collision-guard fix on the same endpoint.

### Kaizen suggestion
A future t-012 cycle should do a fresh full-surface read of `appmaker-page.vue` and its server routes excluding every fix landed so far (refreshToken sequencing, fetchProjects force in-flight sharing, slug-candidate validation, fleet-description fallback, monorepo scaffold-collision guard, create-app.post.ts collision gap, this pending-list pattern gap).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012AkTVkgPoyGatuXnH2SDsz)_