### PR TITLE
fix(davinci): discard stale narrateChapter() responses (t-021 slice 12)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -341,6 +341,12 @@ jobs:
       - name: Da Vinci phase-focus guard
         run: npm run test:davinci-phase-focus-guard
 
+      - name: Da Vinci narrate-stale-response guard self-test
+        run: npm run test:davinci-narrate-stale-response-guard-selftest
+
+      - name: Da Vinci narrate-stale-response guard
+        run: npm run test:davinci-narrate-stale-response-guard
+
       - name: Serendipity Voice poll guard self-test
         run: npm run test:serendipity-voice-poll-guard-selftest
 

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -737,6 +737,22 @@ const narrating = ref(false)
 const narrationError = ref('')
 const narratorName = ref('')
 const aiChapter = ref<ActiveChapter | null>(null)
+// narrateChapter() is called from resumeRun(), startLife(), and
+// chooseOption() -- but nothing stopped a PRIOR call's response from landing
+// after a NEWER one. "Abandon this life" is only disabled by `submitting`,
+// which chooseOption() already clears before its own narrateChapter() call
+// begins, so a player can abandon a run while its post-choice narration
+// request is still in flight, then immediately start (or resume) a
+// different run before the old response resolves. Without this ticket, that
+// stale response would silently overwrite aiChapter/narratorName with the
+// abandoned run's chapter, and requestChapterArt() would then attach the
+// abandoned run's art job to the *new* run's id (run.value.id has already
+// moved on by the time the stale response lands) via
+// POST /api/davinci/runs/{id}/art -- corrupting the new run's art, not just
+// a stale UI flash. Same pattern as modelBuilderStore.ts's
+// fetchRunsRequestId/loadSources' requestedType: capture a ticket per call,
+// discard any response whose ticket no longer matches the latest one.
+let narrateChapterRequestId = 0
 // The region wrapping the narrating/narrationError/currentChapter/resolve
 // blocks (template) -- tabindex="-1" so it can receive focus
 // programmatically without joining the normal Tab order. See the paired
@@ -1061,6 +1077,7 @@ async function startLife() {
 // chooseOption() posts it to /choices.
 async function narrateChapter() {
   if (!run.value) return
+  const requestId = ++narrateChapterRequestId
   narrating.value = true
   narrationError.value = ''
   aiChapter.value = null
@@ -1072,6 +1089,11 @@ async function narrateChapter() {
       body: JSON.stringify({ chapter: chapterIndex.value }),
     },
   )
+
+  // A newer narrateChapter() call has since started (abandon-and-restart,
+  // or any other overlap) -- that call owns `narrating`/`aiChapter` now, so
+  // this response is discarded rather than applied.
+  if (narrateChapterRequestId !== requestId) return
 
   narrating.value = false
 

--- a/package.json
+++ b/package.json
@@ -113,6 +113,8 @@
     "test:davinci-chapter-focus-guard": "tsx utils/scripts/verifyDaVinciChapterFocusGuard.ts",
     "test:davinci-phase-focus-guard-selftest": "tsx utils/scripts/verifyDaVinciPhaseFocusGuard.test.ts",
     "test:davinci-phase-focus-guard": "tsx utils/scripts/verifyDaVinciPhaseFocusGuard.ts",
+    "test:davinci-narrate-stale-response-guard-selftest": "tsx utils/scripts/verifyDaVinciNarrateStaleResponseGuard.test.ts",
+    "test:davinci-narrate-stale-response-guard": "tsx utils/scripts/verifyDaVinciNarrateStaleResponseGuard.ts",
     "test:serendipity-voice-poll-guard-selftest": "tsx utils/scripts/verifySerendipityVoicePollGuard.test.ts",
     "test:serendipity-voice-poll-guard": "tsx utils/scripts/verifySerendipityVoicePollGuard.ts",
     "test:serendipity-voice-cursor-reset-selftest": "tsx utils/scripts/verifySerendipityVoiceCursorReset.test.ts",

--- a/utils/scripts/verifyDaVinciNarrateStaleResponseGuard.test.ts
+++ b/utils/scripts/verifyDaVinciNarrateStaleResponseGuard.test.ts
@@ -1,0 +1,151 @@
+// /utils/scripts/verifyDaVinciNarrateStaleResponseGuard.test.ts
+//
+// Regression test for checkNarrateStaleResponseGuard() in
+// verifyDaVinciNarrateStaleResponseGuard.ts (davinci/t-021 slice 12).
+// Exercises the real check against synthetic component-shaped fixtures
+// covering: the fixed shape (ticket declared, captured before the await,
+// checked after it), a missing-declaration regression, a
+// missing-capture regression, a missing-check regression, and a
+// missing-function regression (narrateChapter removed entirely).
+import assert from 'node:assert/strict'
+
+import {
+  checkNarrateStaleResponseGuard,
+  extractNarrateChapterFunction,
+} from './verifyDaVinciNarrateStaleResponseGuard.js'
+
+function fixture(declaration: string, capture: string, check: string): string {
+  return `
+<script setup lang="ts">
+const aiChapter = ref<ActiveChapter | null>(null)
+${declaration}
+
+async function narrateChapter() {
+  if (!run.value) return
+  ${capture}
+  narrating.value = true
+  narrationError.value = ''
+  aiChapter.value = null
+
+  const response = await performFetch<NarrationResponseData>(
+    \`/api/davinci/runs/\${run.value.id}/narrate\`,
+    { method: 'POST', body: JSON.stringify({ chapter: chapterIndex.value }) },
+  )
+
+  ${check}
+
+  narrating.value = false
+
+  if (!response.success || !response.data) {
+    narrationError.value = response.message || 'The narrator could not be reached.'
+    return
+  }
+}
+
+function useCuratedChapters() {
+  narrationMode.value = 'curated'
+}
+</script>
+`
+}
+
+const DECLARATION = 'let narrateChapterRequestId = 0'
+const CAPTURE = 'const requestId = ++narrateChapterRequestId'
+const CHECK = 'if (narrateChapterRequestId !== requestId) return'
+
+const FIXED = fixture(DECLARATION, CAPTURE, CHECK)
+
+// Pre-fix shape: no ticket at all.
+const BUGGY = fixture('', '', '')
+
+// Declaration and capture present, but the post-await check was dropped.
+const NO_CHECK = fixture(DECLARATION, CAPTURE, '')
+
+// Declaration and check present, but the pre-await capture was dropped.
+const NO_CAPTURE = fixture(DECLARATION, '', CHECK)
+
+// The ticket variable itself was renamed/removed.
+const NO_DECLARATION = fixture('', CAPTURE, CHECK)
+
+const FUNCTION_REMOVED = `
+<script setup lang="ts">
+function useCuratedChapters() {
+  narrationMode.value = 'curated'
+}
+</script>
+`
+
+function run(): void {
+  const fixedErrors = checkNarrateStaleResponseGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const buggyErrors = checkNarrateStaleResponseGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    3,
+    `expected the buggy fixture to fail all three checks, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(
+    buggyErrors.some((e) =>
+      /Could not find `let narrateChapterRequestId/.test(e),
+    ),
+  )
+  assert.ok(
+    buggyErrors.some((e) => /no longer captures `const requestId/.test(e)),
+  )
+  assert.ok(
+    buggyErrors.some((e) =>
+      /no longer checks `narrateChapterRequestId/.test(e),
+    ),
+  )
+
+  const noCheckErrors = checkNarrateStaleResponseGuard(NO_CHECK)
+  assert.equal(noCheckErrors.length, 1)
+  assert.ok(
+    noCheckErrors.some((e) =>
+      /no longer checks `narrateChapterRequestId/.test(e),
+    ),
+  )
+
+  const noCaptureErrors = checkNarrateStaleResponseGuard(NO_CAPTURE)
+  assert.equal(noCaptureErrors.length, 1)
+  assert.ok(
+    noCaptureErrors.some((e) => /no longer captures `const requestId/.test(e)),
+  )
+
+  const noDeclarationErrors = checkNarrateStaleResponseGuard(NO_DECLARATION)
+  assert.equal(noDeclarationErrors.length, 1)
+  assert.ok(
+    noDeclarationErrors.some((e) =>
+      /Could not find `let narrateChapterRequestId/.test(e),
+    ),
+  )
+
+  const functionRemovedErrors = checkNarrateStaleResponseGuard(FUNCTION_REMOVED)
+  assert.equal(functionRemovedErrors.length, 2)
+  assert.ok(
+    functionRemovedErrors.some((e) =>
+      /Could not find `let narrateChapterRequestId/.test(e),
+    ),
+  )
+  assert.ok(
+    functionRemovedErrors.some((e) =>
+      /Could not find `async function narrateChapter/.test(e),
+    ),
+  )
+
+  assert.equal(extractNarrateChapterFunction(FUNCTION_REMOVED), null)
+
+  console.log(
+    'Da Vinci narrate-stale-response guard self-test passed: buggy ' +
+      'fixture fails all three checks, fixed fixture passes, and the ' +
+      'missing-declaration/missing-capture/missing-check/missing-function ' +
+      'regressions all fail individually as expected.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyDaVinciNarrateStaleResponseGuard.ts
+++ b/utils/scripts/verifyDaVinciNarrateStaleResponseGuard.ts
@@ -1,0 +1,139 @@
+// /utils/scripts/verifyDaVinciNarrateStaleResponseGuard.ts
+//
+// Regression guard (davinci/t-021 slice 12) -- narrateChapter() in
+// components/conductor/davinci-page.vue is called from resumeRun(),
+// startLife(), and chooseOption(), and nothing stopped a PRIOR call's
+// response from landing after a NEWER one. "Abandon this life" is only
+// disabled by `submitting`, which chooseOption() already clears before its
+// own post-choice narrateChapter() call begins, so a player can abandon a
+// run while its narration request is still in flight, then immediately
+// start (or resume) a different run before the old response resolves.
+// Without a per-call ticket, that stale response would silently overwrite
+// aiChapter/narratorName with the abandoned run's chapter, and
+// requestChapterArt() would then attach the abandoned run's art job to the
+// *new* run's id (run.value.id has already moved on by the time the stale
+// response lands) via POST /api/davinci/runs/{id}/art -- corrupting the new
+// run's persisted art, not just a stale UI flash. Same pattern this
+// codebase already uses for the identical class of bug elsewhere (see
+// stores/modelBuilderStore.ts's `fetchRunsRequestId`/`loadSources`'
+// `requestedType`): capture a ticket per call, discard any response whose
+// ticket no longer matches the latest one.
+//
+// This asserts the textual shape of the fix stays in place: narrateChapter()
+// captures a ticket from a shared, monotonically-incrementing counter before
+// awaiting the fetch, and checks that ticket against the counter's current
+// value before applying the response. Deliberately scoped to this one
+// function via narrow textual checks, mirroring this project's other guards
+// over a general-purpose static analyzer (see
+// verifyDaVinciDimensionToneGuard.ts).
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const COMPONENT_PATH = join(
+  repositoryRoot,
+  'components/conductor/davinci-page.vue',
+)
+
+const FUNCTION_MARKER = 'async function narrateChapter()'
+const NEXT_FUNCTION_MARKER = 'function useCuratedChapters()'
+
+const TICKET_DECLARATION_RE = /let\s+narrateChapterRequestId\s*=\s*0/
+
+export function extractNarrateChapterFunction(content: string): string | null {
+  const markerIndex = content.indexOf(FUNCTION_MARKER)
+  if (markerIndex === -1) return null
+
+  const nextIndex = content.indexOf(NEXT_FUNCTION_MARKER, markerIndex)
+  const end = nextIndex === -1 ? content.length : nextIndex
+
+  return content.slice(markerIndex, end)
+}
+
+export function checkNarrateStaleResponseGuard(content: string): string[] {
+  const errors: string[] = []
+
+  if (!TICKET_DECLARATION_RE.test(content)) {
+    errors.push(
+      'Could not find `let narrateChapterRequestId = 0` in ' +
+        'davinci-page.vue -- has the stale-response ticket for ' +
+        'narrateChapter() been removed or renamed? A shared, ' +
+        'monotonically-incrementing counter is required for the guard ' +
+        'below to mean anything.',
+    )
+  }
+
+  const fn = extractNarrateChapterFunction(content)
+  if (!fn) {
+    errors.push(
+      'Could not find `async function narrateChapter()` in ' +
+        'davinci-page.vue -- has it been restructured or removed? If so, ' +
+        'this guard needs to move with it.',
+    )
+    return errors
+  }
+
+  const awaitIndex = fn.indexOf('await performFetch')
+  if (awaitIndex === -1) {
+    errors.push(
+      'narrateChapter() no longer calls `await performFetch` where ' +
+        'expected -- has the narration request been restructured?',
+    )
+    return errors
+  }
+
+  const beforeAwait = fn.slice(0, awaitIndex)
+  const afterAwait = fn.slice(awaitIndex)
+
+  if (
+    !/const\s+requestId\s*=\s*\+\+narrateChapterRequestId/.test(beforeAwait)
+  ) {
+    errors.push(
+      'narrateChapter() no longer captures `const requestId = ' +
+        '++narrateChapterRequestId` before awaiting the narration ' +
+        'fetch -- without a ticket captured up front, a stale response ' +
+        'can no longer be told apart from the current one.',
+    )
+  }
+
+  if (!/narrateChapterRequestId\s*!==\s*requestId/.test(afterAwait)) {
+    errors.push(
+      'narrateChapter() no longer checks `narrateChapterRequestId !== ' +
+        'requestId` after awaiting the narration fetch -- a stale ' +
+        'response (e.g. from a run the player already abandoned and ' +
+        "replaced) would be applied on top of the current run's state " +
+        'instead of being discarded.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(COMPONENT_PATH, 'utf8')
+  const errors = checkNarrateStaleResponseGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Da Vinci narrate-stale-response guard contract failed in ' +
+        'davinci-page.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Da Vinci narrate-stale-response guard contract passed: ' +
+      'narrateChapter() captures a per-call ticket and discards any ' +
+      "response whose ticket no longer matches the counter's current " +
+      'value, so an abandoned run cannot overwrite a newer one.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Summary

Slice 12 of davinci/t-021's ongoing polish pass. Eleven prior slices closed
every accessibility/tone/focus gap found by re-reading `davinci-page.vue`
(slice 11's own note explicitly asked for "a genuinely new interaction gap"
rather than re-checking that ground again). This slice found one: a real
correctness bug, not another a11y gap.

`narrateChapter()` is called from `resumeRun()`, `startLife()`, and
`chooseOption()`, but nothing stopped a **prior** call's response from
landing after a **newer** one. "Abandon this life" is only disabled by
`submitting`, which `chooseOption()` already clears before its own
post-choice `narrateChapter()` call begins — so a player can abandon a run
while its narration request is still in flight, then immediately start (or
resume) a different run before the old response resolves.

Without a per-call ticket, that stale response would silently overwrite
`aiChapter`/`narratorName` with the abandoned run's chapter, and
`requestChapterArt()` would then attach the abandoned run's art job to the
**new** run's id (`run.value.id` has already moved on by the time the stale
response lands) via `POST /api/davinci/runs/{id}/art` — corrupting the new
run's persisted art, not just a stale UI flash.

## Fix

Adds a monotonic request ticket around `narrateChapter()`, matching the same
pattern already established in this codebase for the identical class of bug
(`stores/modelBuilderStore.ts`'s `fetchRunsRequestId` / `loadSources`'
`requestedType`): capture a ticket per call, discard any response whose
ticket no longer matches the latest one.

Adds `verifyDaVinciNarrateStaleResponseGuard.ts` + selftest following this
project's narrow-textual-checker convention, wired into `package.json` and
`contract-tests.yml` alongside the ten existing davinci guards.

## Verification

- New guard fails pre-fix / passes post-fix (git-stash round-trip)
- All ten prior `verifyDaVinci*` guards + selftests still pass
- `test:davinci-narration` still passes
- `eslint` clean on touched files
- `prettier --check` clean
- `vue-tsc --noEmit` repo-wide exit 0
- `git status --porcelain` showed exactly the 5 intended files (reverted an
  incidental `prisma generate` regen diff before committing)

## Flags for Reviewer

None — reversible, scoped, additive-only (a ref, a monotonic counter, two
early-return checks, and a new guard file pair). No schema/API/behavior
change other than discarding an out-of-order response that would otherwise
corrupt state.


---
_Generated by [Claude Code](https://claude.ai/code/session_011vAsQxvN8HM4Xw9cmxGyTJ)_