### PR TITLE
fix(model-builder): gate Execute-commit on every upstream stage being approved (t-029 cycle 50)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -530,6 +530,12 @@ jobs:
       - name: Model Builder PATCH stale stage-status guard contract
         run: npm run test:model-builder-patch-stale-stage-status-guard
 
+      - name: Model Builder commit stale-gate guard checker self-test
+        run: npm run test:model-builder-commit-stale-gate-guard-selftest
+
+      - name: Model Builder commit stale-gate guard contract
+        run: npm run test:model-builder-commit-stale-gate-guard
+
       - name: Model Builder content-stage freshness guard checker self-test
         run: npm run test:model-builder-content-stage-freshness-guard-selftest
 

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -1,9 +1,6 @@
 <!-- /components/model-builder/model-builder-item-panel.vue -->
 <template>
-  <div
-    v-if="item"
-    class="flex min-h-0 flex-1 flex-col gap-2 kr-panel-flat p-3"
-  >
+  <div v-if="item" class="flex min-h-0 flex-1 flex-col gap-2 kr-panel-flat p-3">
     <div class="flex items-center gap-2">
       <h4 class="text-sm font-black text-base-content">{{ item.label }}</h4>
       <span class="badge badge-sm badge-ghost">{{ item.action }}</span>
@@ -57,7 +54,10 @@
           title="Draft this pitch with AI"
           @click="draft('pitch')"
         >
-          <span v-if="isDrafting('pitch')" class="loading loading-dots loading-xs" />
+          <span
+            v-if="isDrafting('pitch')"
+            class="loading loading-dots loading-xs"
+          />
           <template v-else>
             <Icon name="kind-icon:magic" class="h-3.5 w-3.5" />
             Draft with AI
@@ -88,8 +88,13 @@
     <section class="rounded-xl border border-base-300 p-2.5">
       <div class="mb-1.5 flex items-center gap-2">
         <Icon name="kind-icon:list" class="h-4 w-4 text-primary" />
-        <span class="text-xs font-bold uppercase tracking-wide">Fields &amp; Prompts</span>
-        <span class="badge badge-xs ml-auto" :class="badgeFor('FIELDS_AND_PROMPTS')">
+        <span class="text-xs font-bold uppercase tracking-wide"
+          >Fields &amp; Prompts</span
+        >
+        <span
+          class="badge badge-xs ml-auto"
+          :class="badgeFor('FIELDS_AND_PROMPTS')"
+        >
           {{ item.stages.FIELDS_AND_PROMPTS.status }}
         </span>
       </div>
@@ -105,7 +110,10 @@
           title="Draft the schema fields and relationships with AI"
           @click="draft('fields')"
         >
-          <span v-if="isDrafting('fields')" class="loading loading-dots loading-xs" />
+          <span
+            v-if="isDrafting('fields')"
+            class="loading loading-dots loading-xs"
+          />
           <template v-else>
             <Icon name="kind-icon:magic" class="h-3 w-3" />
             Draft
@@ -132,7 +140,10 @@
           title="Draft the generation prompt with AI"
           @click="draft('artPrompt')"
         >
-          <span v-if="isDrafting('artPrompt')" class="loading loading-dots loading-xs" />
+          <span
+            v-if="isDrafting('artPrompt')"
+            class="loading loading-dots loading-xs"
+          />
           <template v-else>
             <Icon name="kind-icon:magic" class="h-3 w-3" />
             Draft
@@ -173,8 +184,13 @@
     <section class="rounded-xl border border-base-300 p-2.5">
       <div class="mb-1.5 flex items-center gap-2">
         <Icon name="kind-icon:sparkles" class="h-4 w-4 text-primary" />
-        <span class="text-xs font-bold uppercase tracking-wide">Generate Assets</span>
-        <span class="badge badge-xs ml-auto" :class="badgeFor('GENERATE_ASSETS')">
+        <span class="text-xs font-bold uppercase tracking-wide"
+          >Generate Assets</span
+        >
+        <span
+          class="badge badge-xs ml-auto"
+          :class="badgeFor('GENERATE_ASSETS')"
+        >
           {{ item.stages.GENERATE_ASSETS.status }}
         </span>
       </div>
@@ -204,23 +220,33 @@
           <button
             type="button"
             class="btn btn-sm btn-primary flex-1 rounded-xl"
-            :disabled="!isEditable('GENERATE_ASSETS') || isGenerating || isQueued"
-            :title="item.imagePath ? 'Regenerate candidate' : 'Generate candidate'"
+            :disabled="
+              !isEditable('GENERATE_ASSETS') || isGenerating || isQueued
+            "
+            :title="
+              item.imagePath ? 'Regenerate candidate' : 'Generate candidate'
+            "
             @click="store.generateItemAsset(item.id)"
           >
             <span v-if="isGenerating" class="loading loading-dots loading-sm" />
             <template v-else>
               <Icon name="kind-icon:sparkles" class="h-4 w-4" />
-              {{ item.imagePath ? 'Regenerate candidate' : 'Generate candidate' }}
+              {{
+                item.imagePath ? 'Regenerate candidate' : 'Generate candidate'
+              }}
             </template>
           </button>
           <button
             type="button"
             class="btn btn-sm btn-outline btn-primary rounded-xl"
-            :disabled="!isEditable('GENERATE_ASSETS') || isGenerating || isQueued"
+            :disabled="
+              !isEditable('GENERATE_ASSETS') || isGenerating || isQueued
+            "
             title="Queue generation and keep working — polls in the background, no need to wait here."
             :aria-label="
-              item.imagePath ? 'Queue regeneration in background' : 'Queue generation in background'
+              item.imagePath
+                ? 'Queue regeneration in background'
+                : 'Queue generation in background'
             "
             @click="store.generateItemAssetAsync(item.id)"
           >
@@ -308,14 +334,19 @@
           :disabled="
             isLocked('COMMIT') ||
             item.stages.COMMIT.status === 'approved' ||
-            isCommitting
+            isCommitting ||
+            isCommitBlocked
           "
-          title="Execute commit"
+          :title="commitButtonTitle"
           @click="store.commitItem(item.id)"
         >
           <span v-if="isCommitting" class="loading loading-dots loading-xs" />
           <template v-else>
-            {{ item.stages.COMMIT.status === 'approved' ? 'Committed' : 'Execute commit' }}
+            {{
+              item.stages.COMMIT.status === 'approved'
+                ? 'Committed'
+                : 'Execute commit'
+            }}
           </template>
         </button>
       </div>
@@ -327,6 +358,7 @@
 import { computed, ref, watch } from 'vue'
 import { useModelBuilderStore } from '@/stores/modelBuilderStore'
 import type { DraftField } from '@/stores/modelBuilderStore'
+import { BUILD_STAGES } from '@/stores/helpers/modelBuilderRecipes'
 import type { BuildStageKey } from '@/stores/helpers/modelBuilderRecipes'
 
 const props = defineProps<{ itemId: string }>()
@@ -445,6 +477,50 @@ const canApproveAssets = computed(() => {
   if (item.value.action === 'ASSET_ONLY') return Boolean(item.value.artImageId)
   return true
 })
+
+// Bug (model-builder/t-029, cycle 50): the Execute-commit button previously
+// disabled only on isLocked('COMMIT') || approved || isCommitting -- it
+// stayed clickable while COMMIT.status === 'stale' (an upstream edit
+// reopened an earlier stage after this item had already been ready/approved
+// to commit -- see markDownstreamStale). server/api/model-builder/items/
+// [id]/commit.post.ts independently requires every OTHER stage to be
+// status === 'approved' before committing (dryRun aside), so a stale-commit
+// click was previously a guaranteed round-trip to that 400, with the caught
+// error resetting COMMIT to 'ready' via finishCommit -- silently discarding
+// the accurate "an upstream stage still needs to be redone" signal the
+// 'stale' badge was showing (the same "badge lying about what's actually
+// stored" class of bug this file's updatePitch/updateFields/updatePrompt
+// comment above already treats as real).
+//
+// The fix must NOT simply add `item.stages.COMMIT.status === 'stale'` to
+// the disabled list: 'stale' is COMMIT's only recovery path in this store.
+// approveStage's "unlock the next stage" branch only flips a *locked* next
+// stage to 'ready' (`if (next && item.stages[next.key].status === 'locked')
+// ...`) -- it never un-stales one, so once COMMIT goes 'stale' there is no
+// other code path that ever moves it back to 'ready'/'approved' short of a
+// commitItem() call itself succeeding. Disabling on status === 'stale'
+// verbatim would permanently soft-lock the item: re-approving the upstream
+// stage that caused the staleness would leave COMMIT stuck at 'stale'
+// forever with no enabled button left to clear it.
+//
+// Mirroring the server's own gate instead -- every other stage must be
+// 'approved' -- closes the guaranteed-400 round-trip without that soft-lock:
+// the button re-enables the instant the real prerequisite is satisfied,
+// regardless of whether COMMIT's own badge still reads 'stale' or 'ready'.
+const commitBlockedStage = computed(() => {
+  if (!item.value) return undefined
+  const stages = item.value.stages
+  return BUILD_STAGES.find(
+    (stage) =>
+      stage.key !== 'COMMIT' && stages[stage.key].status !== 'approved',
+  )
+})
+const isCommitBlocked = computed(() => Boolean(commitBlockedStage.value))
+const commitButtonTitle = computed(() =>
+  commitBlockedStage.value
+    ? `${commitBlockedStage.value.label} must be approved before committing.`
+    : 'Execute commit',
+)
 
 function isLocked(stage: BuildStageKey): boolean {
   const status = item.value?.stages[stage].status

--- a/package.json
+++ b/package.json
@@ -262,6 +262,8 @@
     "test:model-builder-commit-target-persistence-guard": "tsx utils/scripts/verifyModelBuilderCommitTargetPersistenceGuard.ts",
     "test:model-builder-patch-stale-stage-status-guard-selftest": "tsx utils/scripts/verifyModelBuilderPatchStaleStageStatusGuard.test.ts",
     "test:model-builder-patch-stale-stage-status-guard": "tsx utils/scripts/verifyModelBuilderPatchStaleStageStatusGuard.ts",
+    "test:model-builder-commit-stale-gate-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitStaleGateGuard.test.ts",
+    "test:model-builder-commit-stale-gate-guard": "tsx utils/scripts/verifyModelBuilderCommitStaleGateGuard.ts",
     "test:model-builder-content-stage-freshness-guard-selftest": "tsx utils/scripts/verifyModelBuilderContentStageFreshnessGuard.test.ts",
     "test:model-builder-content-stage-freshness-guard": "tsx utils/scripts/verifyModelBuilderContentStageFreshnessGuard.ts",
     "test:model-builder-reset-all-guard-selftest": "tsx utils/scripts/verifyModelBuilderResetAllGuard.test.ts",

--- a/utils/scripts/verifyModelBuilderCommitStaleGateGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderCommitStaleGateGuard.test.ts
@@ -1,0 +1,159 @@
+// /utils/scripts/verifyModelBuilderCommitStaleGateGuard.test.ts
+//
+// Regression test for checkCommitStaleGateGuard()/checkCommitRouteStageGate()
+// in verifyModelBuilderCommitStaleGateGuard.ts (model-builder/t-029, cycle
+// 50). Exercises the real checks against synthetic panel/route-shaped
+// fixtures covering: the original pre-fix shape (no isCommitBlocked gate at
+// all -- a guaranteed round-trip to the server's 400 while stale), the
+// tempting-but-wrong soft-lock shape (gating directly on
+// `status === 'stale'`, which permanently disables the only recovery path),
+// and the actual fixed shape (a BUILD_STAGES-driven isCommitBlocked).
+import assert from 'node:assert/strict'
+
+import {
+  checkCommitStaleGateGuard,
+  checkCommitRouteStageGate,
+} from './verifyModelBuilderCommitStaleGateGuard.js'
+
+const PRE_FIX_PANEL = `
+        <button
+          type="button"
+          class="btn btn-xs btn-success rounded-lg"
+          :disabled="
+            isLocked('COMMIT') ||
+            item.stages.COMMIT.status === 'approved' ||
+            isCommitting
+          "
+          title="Execute commit"
+          @click="store.commitItem(item.id)"
+        >
+        </button>
+`
+
+const SOFT_LOCK_PANEL = `
+        <button
+          type="button"
+          class="btn btn-xs btn-success rounded-lg"
+          :disabled="
+            isLocked('COMMIT') ||
+            item.stages.COMMIT.status === 'approved' ||
+            item.stages.COMMIT.status === 'stale' ||
+            isCommitting
+          "
+          title="Execute commit"
+          @click="store.commitItem(item.id)"
+        >
+        </button>
+
+        const isCommitBlocked = computed(() => item.value?.stages.COMMIT.status === 'stale')
+`
+
+const FIXED_PANEL = `
+        <button
+          type="button"
+          class="btn btn-xs btn-success rounded-lg"
+          :disabled="
+            isLocked('COMMIT') ||
+            item.stages.COMMIT.status === 'approved' ||
+            isCommitting ||
+            isCommitBlocked
+          "
+          :title="commitButtonTitle"
+          @click="store.commitItem(item.id)"
+        >
+        </button>
+
+const commitBlockedStage = computed(() => {
+  if (!item.value) return undefined
+  const stages = item.value.stages
+  return BUILD_STAGES.find(
+    (stage) => stage.key !== 'COMMIT' && stages[stage.key].status !== 'approved',
+  )
+})
+const isCommitBlocked = computed(() => Boolean(commitBlockedStage.value))
+`
+
+const MISSING_BUTTON = `
+  <div>no commit button here</div>
+`
+
+const preFixErrors = checkCommitStaleGateGuard(PRE_FIX_PANEL)
+assert.equal(
+  preFixErrors.length,
+  2,
+  `expected the pre-fix shape (missing isCommitBlocked in the button AND no ` +
+    `commitBlockedStage computed at all) to raise 2 errors, got ` +
+    `${preFixErrors.length}: ${JSON.stringify(preFixErrors)}`,
+)
+assert.ok(
+  preFixErrors.some((e) => e.includes('isCommitBlocked')),
+  'expected a violation naming isCommitBlocked as missing from the button',
+)
+assert.ok(
+  preFixErrors.some((e) => e.includes('commitBlockedStage')),
+  'expected a violation for the missing commitBlockedStage computed',
+)
+
+const softLockErrors = checkCommitStaleGateGuard(SOFT_LOCK_PANEL)
+assert.equal(
+  softLockErrors.length,
+  1,
+  `expected the soft-lock shape (naive status === 'stale' check) to raise 1 ` +
+    `error, got ${softLockErrors.length}: ${JSON.stringify(softLockErrors)}`,
+)
+assert.ok(
+  softLockErrors[0]!.includes('soft-lock'),
+  'expected a violation calling out the soft-lock risk',
+)
+
+const fixedErrors = checkCommitStaleGateGuard(FIXED_PANEL)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingErrors = checkCommitStaleGateGuard(MISSING_BUTTON)
+assert.equal(
+  missingErrors.length,
+  1,
+  'expected a single "button not found" violation when the commit button is absent',
+)
+assert.ok(missingErrors[0]!.includes('Execute-commit'))
+
+const FIXED_ROUTE = `
+      const unapprovedStage = BUILD_STAGES.find(
+        (stage) =>
+          stage.key !== 'COMMIT' &&
+          currentStages[stage.key]?.status !== 'approved',
+      )
+      if (unapprovedStage) {
+        throw createError({ statusCode: 400, message: 'nope' })
+      }
+`
+const BROKEN_ROUTE = `
+      // no stage gate at all anymore
+      const target = { type: 'Dream', id: 1 }
+`
+
+const routeFixedErrors = checkCommitRouteStageGate(FIXED_ROUTE)
+assert.equal(
+  routeFixedErrors.length,
+  0,
+  `expected the real route shape to raise no errors, got: ${JSON.stringify(routeFixedErrors)}`,
+)
+
+const routeBrokenErrors = checkCommitRouteStageGate(BROKEN_ROUTE)
+assert.equal(
+  routeBrokenErrors.length,
+  1,
+  'expected a violation when the route no longer gates on unapproved stages',
+)
+
+console.log(
+  'Model Builder commit stale-gate guard checker verified: flags the ' +
+    'pre-fix shape (no isCommitBlocked gate), flags the tempting soft-lock ' +
+    "shape (naive status === 'stale' check), clears the real fixed shape, " +
+    'flags the commit button being absent, and cross-checks the server ' +
+    'route half of the same contract.',
+)

--- a/utils/scripts/verifyModelBuilderCommitStaleGateGuard.ts
+++ b/utils/scripts/verifyModelBuilderCommitStaleGateGuard.ts
@@ -1,0 +1,185 @@
+// /utils/scripts/verifyModelBuilderCommitStaleGateGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 50) -- the Execute-commit
+// button in model-builder-item-panel.vue previously disabled only on
+// isLocked('COMMIT') || COMMIT.status === 'approved' || isCommitting. It
+// stayed clickable while COMMIT.status === 'stale' (an upstream edit
+// reopened an earlier stage after this item had already been ready/approved
+// to commit -- see modelBuilderStore.ts's markDownstreamStale).
+// server/api/model-builder/items/[id]/commit.post.ts independently requires
+// every OTHER stage to be status === 'approved' before committing (dryRun
+// aside), so a stale-commit click was a guaranteed round-trip to that 400 --
+// and the caught error reset COMMIT to 'ready' via finishCommit, silently
+// discarding the accurate "an upstream stage still needs to be redone"
+// signal the 'stale' badge was showing.
+//
+// The correct fix must NOT simply add `COMMIT.status === 'stale'` to the
+// disabled list. 'stale' is COMMIT's only recovery path in this store:
+// approveStage's "unlock the next stage" branch only flips a *locked* next
+// stage to 'ready' -- it never un-stales one, so once COMMIT goes 'stale'
+// there is no other code path that ever moves it back to 'ready'/'approved'
+// short of a commitItem() call itself succeeding. Disabling on
+// `status === 'stale'` verbatim would permanently soft-lock the item:
+// re-approving the upstream stage that caused the staleness would leave
+// COMMIT stuck at 'stale' forever with no enabled button left to clear it.
+//
+// The fix instead mirrors the server's own gate -- every OTHER build stage
+// must be 'approved' -- via a BUILD_STAGES-driven `isCommitBlocked` computed.
+// This closes the guaranteed-400 round-trip without the soft-lock: the
+// button re-enables the instant the real prerequisite is satisfied,
+// regardless of whether COMMIT's own badge still reads 'stale' or 'ready'.
+//
+// This checker protects three things:
+// 1. The Execute-commit button's :disabled includes isCommitBlocked.
+// 2. isCommitBlocked is derived from BUILD_STAGES (every stage but COMMIT
+//    must be 'approved'), not a naive `COMMIT.status === 'stale'` check that
+//    would soft-lock the item.
+// 3. The server route still enforces the identical rule, so the UI gate and
+//    the authoritative check can never drift apart silently.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const PANEL_PATH = join(
+  repositoryRoot,
+  'components/model-builder/model-builder-item-panel.vue',
+)
+const COMMIT_ROUTE_PATH = join(
+  repositoryRoot,
+  'server/api/model-builder/items/[id]/commit.post.ts',
+)
+
+const CLICK_ANCHOR = '@click="store.commitItem(item.id)"'
+const SOFT_LOCK_SHAPE = "item.stages.COMMIT.status === 'stale'"
+
+// Checks the item panel's template + script halves. Exported for the self-test.
+export function checkCommitStaleGateGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const clickIndex = content.indexOf(CLICK_ANCHOR)
+  if (clickIndex === -1) {
+    errors.push(
+      `Could not find \`${CLICK_ANCHOR}\` in model-builder-item-panel.vue -- ` +
+        'has the Execute-commit button been renamed or restructured? Re-check ' +
+        'the stale-commit gate.',
+    )
+    return errors
+  }
+
+  // The button's opening <button ...> tag sits just before its @click, so the
+  // :disabled attribute is a short window back from this anchor, not the
+  // whole file -- keeps a coincidental isCommitBlocked mention elsewhere from
+  // passing this check.
+  const buttonStart = content.lastIndexOf('<button', clickIndex)
+  if (buttonStart === -1) {
+    errors.push(
+      'Could not find the opening <button> tag before the Execute-commit ' +
+        '@click -- this guard anchor has moved.',
+    )
+    return errors
+  }
+  const disabledBlock = content.slice(buttonStart, clickIndex)
+
+  if (disabledBlock.includes(SOFT_LOCK_SHAPE)) {
+    errors.push(
+      `Execute-commit's :disabled checks \`${SOFT_LOCK_SHAPE}\` directly. ` +
+        "'stale' is COMMIT's only recovery path -- approveStage never " +
+        "un-stales a next stage, only unlocks a 'locked' one -- so gating on " +
+        'this literally soft-locks the item: once COMMIT goes stale, no ' +
+        'button can ever re-enable it, even after the real upstream stage is ' +
+        're-approved. Use the BUILD_STAGES-driven isCommitBlocked computed ' +
+        'instead.',
+    )
+    return errors
+  }
+
+  if (!disabledBlock.includes('isCommitBlocked')) {
+    errors.push(
+      "Execute-commit's :disabled no longer includes isCommitBlocked -- " +
+        'without it, clicking while an upstream stage is unapproved (COMMIT ' +
+        "showing 'stale' after markDownstreamStale, or reached some other " +
+        "way) is a guaranteed round-trip to the server's 400 in " +
+        'commit.post.ts.',
+    )
+  }
+
+  const computedStart = content.indexOf('const commitBlockedStage = computed(')
+  if (computedStart === -1) {
+    errors.push(
+      'Could not find the commitBlockedStage computed in ' +
+        'model-builder-item-panel.vue -- this guard anchor has moved.',
+    )
+    return errors
+  }
+  const computedEnd = content.indexOf('\n})', computedStart)
+  const computedBody =
+    computedEnd === -1
+      ? content.slice(computedStart)
+      : content.slice(computedStart, computedEnd)
+
+  if (
+    !computedBody.includes('BUILD_STAGES.find(') ||
+    !computedBody.includes("stage.key !== 'COMMIT'") ||
+    !computedBody.includes("!== 'approved'")
+  ) {
+    errors.push(
+      'commitBlockedStage no longer derives from BUILD_STAGES checking every ' +
+        "stage but COMMIT for status !== 'approved' -- this must mirror " +
+        "commit.post.ts's own unapprovedStage check exactly, or the UI gate " +
+        'and the server rule can silently drift apart (either soft-locking ' +
+        'the button when the server would actually accept the commit, or ' +
+        're-opening the guaranteed-400 round-trip this guard exists to close).',
+    )
+  }
+
+  return errors
+}
+
+// The server route is the authoritative half of the contract this UI gate
+// mirrors -- if its own unapproved-stage check moves or is removed, the UI
+// gate silently stops matching the real rule.
+export function checkCommitRouteStageGate(content: string): string[] {
+  const errors: string[] = []
+  if (
+    !content.includes("stage.key !== 'COMMIT'") ||
+    !content.includes("?.status !== 'approved'")
+  ) {
+    errors.push(
+      'commit.post.ts no longer rejects a commit when a non-COMMIT stage is ' +
+        "not 'approved' -- this is the server-side rule " +
+        "model-builder-item-panel.vue's isCommitBlocked computed mirrors; if " +
+        'it moved or changed shape, the UI gate needs to follow it.',
+    )
+  }
+  return errors
+}
+
+function main(): void {
+  const panelContent = readFileSync(PANEL_PATH, 'utf8')
+  const routeContent = readFileSync(COMMIT_ROUTE_PATH, 'utf8')
+  const errors = [
+    ...checkCommitStaleGateGuard(panelContent),
+    ...checkCommitRouteStageGate(routeContent),
+  ]
+
+  if (errors.length) {
+    console.error('Model Builder commit stale-gate guard contract failed:')
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder commit stale-gate guard contract passed: Execute-commit ' +
+      'stays disabled whenever any non-COMMIT stage is unapproved (mirroring ' +
+      "commit.post.ts's own rule), without soft-locking on COMMIT's own " +
+      "'stale' status.",
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Summary

Cycle 50 of model-builder/t-029's ongoing polish pass. Cycle 49 left two leads: a fresh read of `model-builder-run-history.vue`/`model-builder-source-picker.vue` (both read end to end this cycle, no new bug found), or a UX-only fix for Execute-commit staying clickable while `COMMIT.status === 'stale'` (cycle 49's own characterization: "cosmetic, not a correctness bug"). Took the second lead — and found the naive version of that fix would actually be a regression.

## What changed

`Execute-commit`'s `:disabled` previously checked `isLocked('COMMIT') || approved || isCommitting` — it stayed clickable while `COMMIT.status === 'stale'` (an upstream edit reopened an earlier stage after this item was already ready/approved to commit — see `markDownstreamStale`). `commit.post.ts` independently requires every OTHER stage to be `status === 'approved'` before committing, so a stale-commit click was a guaranteed round-trip to that server 400 — and the caught error reset `COMMIT` to `'ready'` via `finishCommit`, silently discarding the accurate "an upstream stage still needs to be redone" signal the `'stale'` badge was showing.

**The naive fix (`COMMIT.status === 'stale'` added directly to `:disabled`) would have been a regression**, not just cosmetic: `'stale'` is `COMMIT`'s only recovery path in this store. `approveStage`'s "unlock the next stage" branch only flips a *locked* next stage to `'ready'` — it never un-stales one — so disabling on `status === 'stale'` verbatim permanently soft-locks the item: re-approving the upstream stage that caused the staleness would leave `COMMIT` stuck at `'stale'` forever with no enabled button left to clear it.

Fixed by mirroring the server's own gate instead: a `BUILD_STAGES`-driven `isCommitBlocked` computed disables the button whenever any non-`COMMIT` stage isn't `'approved'`, and re-enables the instant it is — regardless of whether `COMMIT`'s own badge still reads `'stale'` or `'ready'`.

Added `verifyModelBuilderCommitStaleGateGuard.ts` + `.test.ts` (narrow textual checker, this project's established convention) covering both the missing-gate regression and the soft-lock-shape regression, wired into `package.json` and `contract-tests.yml`.

## How I verified

- New guard fails pre-fix / passes post-fix (`git stash` round-trip against the real component)
- Guard's own selftest (missing-gate fixture, soft-lock fixture, fixed fixture, missing-button fixture, route cross-check) passes
- All 70 other `test:model-builder-*-guard` contracts + selftests still pass
- `test:model-builder-contract-tests-coverage-guard` confirms the new script is wired into `contract-tests.yml`
- `eslint` clean on touched files
- `prettier --check` clean
- `vue-tsc --noEmit` repo-wide shows only the pre-existing, unrelated `server/api/reactions/index.post.ts` type error (confirmed present before this change too, documented in prior cycles)
- `git status --porcelain` scoped to exactly 5 intended files

## Stakes
reversible

## Flags for Reviewer
None — additive UI gate + a matching regression guard, no schema/API/behavior change beyond correctly disabling a button that was previously a guaranteed-error round-trip.

## Kaizen suggestion
Two fresh leads remain unread by recent cycles: the `components/model-builder/model-builder-batch-editor.vue`/`model-builder-progress-matrix.vue`/`model-builder-recipe-selector.vue` trio (not read end-to-end in recent cycles per this task's history), or a fresh audit of `server/api/model-builder/**` against `stores/modelBuilderStore.ts`'s client-side assumptions now that this cycle closed the last open item-panel.vue lead from cycle 49.

### Notes for reviewer

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nt4dBWui4poysHVT7ENjNc)_