### PR TITLE
fix(model-builder): gate item-panel Auto button on run/batch in-flight state (t-029 cycle 51)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -536,6 +536,12 @@ jobs:
       - name: Model Builder commit stale-gate guard contract
         run: npm run test:model-builder-commit-stale-gate-guard
 
+      - name: Model Builder item-panel Auto run-in-flight guard checker self-test
+        run: npm run test:model-builder-item-panel-auto-run-guard-selftest
+
+      - name: Model Builder item-panel Auto run-in-flight guard contract
+        run: npm run test:model-builder-item-panel-auto-run-guard
+
       - name: Model Builder content-stage freshness guard checker self-test
         run: npm run test:model-builder-content-stage-freshness-guard-selftest
 

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -8,8 +8,10 @@
       <button
         type="button"
         class="btn btn-xs btn-ghost ml-auto gap-1 rounded-lg text-primary"
-        :disabled="isAutoBuilding || isManualActionInFlight"
-        title="Draft, generate, and commit this item automatically"
+        :disabled="
+          isAutoBuilding || isManualActionInFlight || runOperationInFlight
+        "
+        :title="autoButtonTitle"
         @click="store.autoBuildItem(item.id)"
       >
         <span v-if="isAutoBuilding" class="loading loading-dots loading-xs" />
@@ -431,6 +433,36 @@ const isManualActionInFlight = computed(
     isQueued.value ||
     isCommitting.value ||
     isAnyDraftInFlight.value,
+)
+
+// Bug (model-builder/t-029, cycle 51): this panel's own single-item "Auto"
+// button was the one entry point cycle 25's isRunOperationInFlight fix
+// never reached. autoBuildItem() (the exact function this button calls) is
+// also the function autoBuildRun() and batchAutoBuild() call internally for
+// every item they walk -- it has no store.autoBuilding/batchingOutputKey
+// check of its own, by design, since those callers legitimately invoke it
+// while their own flag is already true. That leaves the two whole-run/group
+// entry points to police each other (which cycle 25 fixed, on both
+// model-builder-progress-matrix.vue's "Auto-build all" and this project's
+// model-builder-batch-editor.vue's group buttons) and leaves this panel's
+// own button as the unguarded third path in. isManualActionInFlight above
+// only reads THIS item's own generating/queued/committing/drafting flags --
+// none of which are set for an item an in-progress run/batch loop hasn't
+// reached yet -- so clicking Auto here on a not-yet-processed item started
+// a second, fully concurrent autoBuildItem() call racing the run/batch
+// loop's own eventual call for the very same item, exactly the
+// "two different items in the same run mid-generate/mid-commit at once"
+// class isRunOperationInFlight exists to prevent. Mirrors
+// modelBuilderStore.ts's own isRunOperationInFlight (not called directly --
+// it's not exported -- so the same two flags it checks are read here).
+const runOperationInFlight = computed(
+  () => store.autoBuilding || store.batchingOutputKey !== null,
+)
+const autoButtonTitle = computed(() =>
+  runOperationInFlight.value
+    ? 'A run or batch auto-build is already in progress -- wait for it to ' +
+      'finish before auto-building this item on its own.'
+    : 'Draft, generate, and commit this item automatically',
 )
 
 function draft(field: DraftField): void {

--- a/package.json
+++ b/package.json
@@ -308,6 +308,8 @@
     "test:model-builder-confirmed-outcome-guard": "tsx utils/scripts/verifyModelBuilderConfirmedOutcomeGuard.ts",
     "test:model-builder-batch-any-in-flight-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchAnyInFlightGuard.test.ts",
     "test:model-builder-batch-any-in-flight-guard": "tsx utils/scripts/verifyModelBuilderBatchAnyInFlightGuard.ts",
+    "test:model-builder-item-panel-auto-run-guard-selftest": "tsx utils/scripts/verifyModelBuilderItemPanelAutoRunGuard.test.ts",
+    "test:model-builder-item-panel-auto-run-guard": "tsx utils/scripts/verifyModelBuilderItemPanelAutoRunGuard.ts",
     "test:model-builder-async-enqueue-cancelled-run-guard-selftest": "tsx utils/scripts/verifyModelBuilderAsyncEnqueueCancelledRunGuard.test.ts",
     "test:model-builder-async-enqueue-cancelled-run-guard": "tsx utils/scripts/verifyModelBuilderAsyncEnqueueCancelledRunGuard.ts",
     "test:model-builder-async-enqueue-success-cancelled-run-guard-selftest": "tsx utils/scripts/verifyModelBuilderAsyncEnqueueSuccessCancelledRunGuard.test.ts",

--- a/utils/scripts/verifyModelBuilderItemPanelAutoRunGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderItemPanelAutoRunGuard.test.ts
@@ -1,0 +1,124 @@
+// /utils/scripts/verifyModelBuilderItemPanelAutoRunGuard.test.ts
+//
+// Regression test for checkItemPanelAutoRunGuard() in
+// verifyModelBuilderItemPanelAutoRunGuard.ts (model-builder/t-029, cycle 51).
+// Exercises the real check against synthetic script-block-shaped fixtures
+// covering: the pre-fix shape (Auto button gates only on this item's own
+// flags, runOperationInFlight computed absent), the fixed shape, a partial
+// fix (computed defined but the button's :disabled left unchanged), and the
+// Auto button markup itself being restructured beyond recognition.
+import assert from 'node:assert/strict'
+
+import { checkItemPanelAutoRunGuard } from './verifyModelBuilderItemPanelAutoRunGuard.js'
+
+const BUGGY_FIXTURE = `
+<template>
+  <button
+    type="button"
+    :disabled="isAutoBuilding || isManualActionInFlight"
+    :title="autoButtonTitle"
+    @click="store.autoBuildItem(item.id)"
+  >
+    Auto
+  </button>
+</template>
+<script setup lang="ts">
+const isAutoBuilding = computed(() => store.autoBuildingItemId === props.itemId)
+</script>
+`
+
+const FIXED_FIXTURE = `
+<template>
+  <button
+    type="button"
+    :disabled="isAutoBuilding || isManualActionInFlight || runOperationInFlight"
+    :title="autoButtonTitle"
+    @click="store.autoBuildItem(item.id)"
+  >
+    Auto
+  </button>
+</template>
+<script setup lang="ts">
+const isAutoBuilding = computed(() => store.autoBuildingItemId === props.itemId)
+const runOperationInFlight = computed(
+  () => store.autoBuilding || store.batchingOutputKey !== null,
+)
+</script>
+`
+
+const PARTIAL_FIX_FIXTURE = `
+<template>
+  <button
+    type="button"
+    :disabled="isAutoBuilding || isManualActionInFlight"
+    :title="autoButtonTitle"
+    @click="store.autoBuildItem(item.id)"
+  >
+    Auto
+  </button>
+</template>
+<script setup lang="ts">
+const isAutoBuilding = computed(() => store.autoBuildingItemId === props.itemId)
+const runOperationInFlight = computed(
+  () => store.autoBuilding || store.batchingOutputKey !== null,
+)
+</script>
+`
+
+const MISSING_BUTTON_FIXTURE = `
+<template>
+  <button type="button" @click="store.autoBuildItem(item.id)">Auto</button>
+</template>
+<script setup lang="ts">
+const runOperationInFlight = computed(
+  () => store.autoBuilding || store.batchingOutputKey !== null,
+)
+</script>
+`
+
+const buggyErrors = checkItemPanelAutoRunGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  2,
+  'expected the pre-fix shape to raise the "missing runOperationInFlight" ' +
+    `error plus the button-not-gating error, got ${buggyErrors.length}: ` +
+    `${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(buggyErrors[0]!.includes('runOperationInFlight` computed'))
+assert.ok(buggyErrors[1]!.includes('not gating on'))
+
+const fixedErrors = checkItemPanelAutoRunGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const partialErrors = checkItemPanelAutoRunGuard(PARTIAL_FIX_FIXTURE)
+assert.equal(
+  partialErrors.length,
+  1,
+  'expected the partial-fix shape (computed defined, button unchanged) to ' +
+    `raise exactly 1 error, got ${partialErrors.length}: ` +
+    `${JSON.stringify(partialErrors)}`,
+)
+assert.ok(partialErrors[0]!.includes('not gating on'))
+
+const missingButtonErrors = checkItemPanelAutoRunGuard(MISSING_BUTTON_FIXTURE)
+assert.equal(
+  missingButtonErrors.length,
+  1,
+  'expected the restructured-button shape (no :disabled/:title pair before ' +
+    `the click handler) to raise exactly 1 error, got ` +
+    `${missingButtonErrors.length}: ${JSON.stringify(missingButtonErrors)}`,
+)
+assert.ok(missingButtonErrors[0]!.includes('Could not find the Auto button'))
+
+console.log(
+  'Model Builder item-panel Auto run-in-flight guard checker verified: ' +
+    'flags the pre-fix shape (Auto button ungated on run/batch state, ' +
+    'runOperationInFlight absent), clears the fixed shape, flags a partial ' +
+    "fix that defines the computed but leaves the button's :disabled " +
+    'unchanged, and flags the button markup being restructured beyond ' +
+    'recognition.',
+)

--- a/utils/scripts/verifyModelBuilderItemPanelAutoRunGuard.ts
+++ b/utils/scripts/verifyModelBuilderItemPanelAutoRunGuard.ts
@@ -1,0 +1,119 @@
+// /utils/scripts/verifyModelBuilderItemPanelAutoRunGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 51) -- model-builder-item-
+// panel.vue's own single-item "Auto" button (`store.autoBuildItem(item.id)`)
+// was the one entry point cycle 25's isRunOperationInFlight fix never
+// reached. autoBuildItem() -- the exact store function this button calls --
+// is also the function autoBuildRun() (model-builder-progress-matrix.vue's
+// "Auto-build all") and batchAutoBuild() (model-builder-batch-editor.vue's
+// "Auto-build group") call internally for every item they walk, so it has
+// no store.autoBuilding/batchingOutputKey check of its own by design --
+// those two callers legitimately invoke it while their own flag is already
+// true. That left the whole-run and group entry points to police each
+// other (cycle 25's fix, verified by verifyModelBuilderBatchAnyInFlightGuard
+// and this file's sibling progress-matrix guard), and left this panel's
+// button as the unguarded third path in: `isManualActionInFlight` only
+// reads THIS item's own generating/queued/committing/drafting flags, none
+// of which are set for an item an in-progress run/batch loop hasn't reached
+// yet, so clicking Auto here on a not-yet-processed item started a second,
+// fully concurrent autoBuildItem() call racing the run/batch loop's own
+// eventual call for the same item -- the exact "two different items in the
+// same run mid-generate/mid-commit at once" class isRunOperationInFlight
+// exists to prevent.
+//
+// Fixed by adding `runOperationInFlight = computed(() => store.autoBuilding
+// || store.batchingOutputKey !== null)` (mirroring modelBuilderStore.ts's
+// own isRunOperationInFlight, which isn't exported) and folding it into the
+// Auto button's `:disabled`.
+//
+// This asserts the textual shape of that fix stays in place: the computed
+// definition, and the Auto button's `:disabled` attribute referencing it --
+// deliberately scoped to this one bug shape, mirroring this project's other
+// narrow textual guards over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const ITEM_PANEL_PATH = join(
+  repositoryRoot,
+  'components/model-builder/model-builder-item-panel.vue',
+)
+
+const RUN_OPERATION_IN_FLIGHT_DEF =
+  'const runOperationInFlight = computed(\n  () => store.autoBuilding || store.batchingOutputKey !== null,\n)'
+
+// The Auto button is the only `@click="store.autoBuildItem(item.id)"` call
+// in this file -- find its `:disabled="..."` attribute specifically, rather
+// than scanning every `:disabled` in the file (most of which correctly have
+// nothing to do with this race).
+const AUTO_BUTTON_PATTERN =
+  /:disabled="([^"]*)"\s*\n\s*:title="[^"]*"\s*\n\s*@click="store\.autoBuildItem\(item\.id\)"/
+
+export function checkItemPanelAutoRunGuard(content: string): string[] {
+  const errors: string[] = []
+
+  if (!content.includes(RUN_OPERATION_IN_FLIGHT_DEF)) {
+    errors.push(
+      'Could not find the `runOperationInFlight` computed (checking ' +
+        'store.autoBuilding || store.batchingOutputKey !== null) in ' +
+        "model-builder-item-panel.vue -- without it, this item's own Auto " +
+        'button has no way to know a whole-run or batch-group auto-build is ' +
+        'already walking the run, and can start a second, fully concurrent ' +
+        'orchestration pass over a different item.',
+    )
+  }
+
+  const match = content.match(AUTO_BUTTON_PATTERN)
+  if (!match) {
+    errors.push(
+      'Could not find the Auto button\'s `:disabled="..."` attribute ' +
+        '(the button with `@click="store.autoBuildItem(item.id)"`) in ' +
+        'model-builder-item-panel.vue -- has it been renamed or ' +
+        'restructured? If so, this guard (and the bug it protects against) ' +
+        'needs to move with it.',
+    )
+    return errors
+  }
+
+  const expression = match[1] ?? ''
+  if (!expression.includes('runOperationInFlight')) {
+    errors.push(
+      `Found the Auto button's :disabled="${expression}" not gating on ` +
+        '`runOperationInFlight` -- this button stays clickable while a ' +
+        'whole-run "Auto-build all" or a batch "Auto-build group" is ' +
+        'already in progress, letting the user start a second, concurrent ' +
+        'orchestration pass over the same run.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(ITEM_PANEL_PATH, 'utf8')
+  const errors = checkItemPanelAutoRunGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder item-panel Auto run-in-flight guard contract failed ' +
+        'for model-builder-item-panel.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder item-panel Auto run-in-flight guard contract passed: ' +
+      'the single-item Auto button gates on runOperationInFlight, so it ' +
+      'can no longer start a second, concurrent auto-build pass while a ' +
+      'whole-run or batch-group auto-build is already walking this run.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Summary

Cycle 51 of `model-builder/t-029`'s ongoing polish pass. Cycle 50 left three fresh leads: `model-builder-batch-editor.vue`, `model-builder-progress-matrix.vue`, and `model-builder-recipe-selector.vue`, none read end-to-end in recent cycles.

Read all three:
- `model-builder-recipe-selector.vue`'s quantity input has no client-side clamp, but `store.setOutputQuantity` already clamps `1..MAX_BATCH` server-side (store) — not a bug.
- `model-builder-progress-matrix.vue`'s `selectedItemId` ref only initializes once at mount, which looked like a stale-selection risk across a run switch — but confirmed (mirroring cycle 48's own finding) that switching runs always goes through the History panel's own unmount/remount of this component, so it's always freshly initialized. Not a bug.
- `model-builder-batch-editor.vue`: consistent with `progress-matrix.vue`'s helpers (`autoBuildFailed`, `commitBadge`, `itemStageSummary` — all three files already keep these in agreement per their own comments). Not a bug.

Reading on into the sibling single-item surface, `model-builder-item-panel.vue`, found a real gap: its own "Auto" button (`store.autoBuildItem(item.id)`) never checked `store.autoBuilding` or `store.batchingOutputKey`, unlike the whole-run ("Auto-build all", `model-builder-progress-matrix.vue`) and batch-group ("Auto-build group", `model-builder-batch-editor.vue`) Auto buttons, both already fixed for this exact race in cycle 25 (`isRunOperationInFlight`). `isManualActionInFlight` here only reads *this item's own* generating/queued/committing/drafting flags — none of which are set for an item a whole-run or batch loop hasn't reached yet — so clicking Auto on an item not yet processed by an in-progress "Auto-build all"/"Auto-build group" started a second, fully concurrent `autoBuildItem()` call racing the loop's own eventual call for that same item: two different items in the same run mid-generate/mid-commit at once, the exact class `isRunOperationInFlight` exists to prevent.

## Fix

Added a `runOperationInFlight` computed (mirroring `modelBuilderStore.ts`'s own unexported `isRunOperationInFlight`) and folded it into the Auto button's `:disabled`, plus a matching disabled-state title explaining why.

Added `verifyModelBuilderItemPanelAutoRunGuard.ts` + selftest following this project's narrow-textual-checker convention, wired into `package.json` and `contract-tests.yml` alongside the existing model-builder guards.

## Verification

- New guard fails pre-fix / passes post-fix (git-stash round-trip)
- All 141 `test:model-builder-*` scripts pass
- `eslint` clean on touched files
- `prettier --check` clean
- `vue-tsc --noEmit` repo-wide exit 0
- `git status --porcelain` scoped to exactly 5 files (reverted an incidental `prisma generate` regen diff before committing)

## Flags for Reviewer

None — reversible, scoped, additive-only (a computed, a title computed, one `:disabled` edit, and a new guard file pair).

---
_Generated by [Claude Code](https://claude.ai/code/session_017PkTmiW2GDZtWCP5hdoYuV)_