### PR TITLE
fix(davinci): discard stale art-job results from an abandoned run (t-021 slice 13)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -347,6 +347,12 @@ jobs:
       - name: Da Vinci narrate-stale-response guard
         run: npm run test:davinci-narrate-stale-response-guard
 
+      - name: Da Vinci art-run guard self-test
+        run: npm run test:davinci-art-run-guard-selftest
+
+      - name: Da Vinci art-run guard
+        run: npm run test:davinci-art-run-guard
+
       - name: Serendipity Voice poll guard self-test
         run: npm run test:serendipity-voice-poll-guard-selftest
 

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -853,15 +853,20 @@ const currentChapterArt = computed<NarrativeArtJobState | undefined>(
 )
 
 function retryCurrentChapterArt() {
+  if (!run.value) return
+  const runId = run.value.id
   const chapter = chapterIndex.value
   const art = chapterArt.value[chapter]
   if (!art) return
-  narrativeArtJobs.retry(art, (next) => updateChapterArt(chapter, next))
+  narrativeArtJobs.retry(art, (next) => updateChapterArt(runId, chapter, next))
 }
 
 function retryEndingArt() {
-  if (!endingArt.value) return
-  narrativeArtJobs.retry(endingArt.value, updateEndingArt)
+  if (!run.value || !endingArt.value) return
+  const runId = run.value.id
+  narrativeArtJobs.retry(endingArt.value, (next) =>
+    updateEndingArt(runId, next),
+  )
 }
 
 function statsToMap(stats: LifeStatRow[]): Record<string, number> {
@@ -919,7 +924,29 @@ async function persistLifeRunArt(
   }).catch(() => null)
 }
 
-function updateChapterArt(chapter: number, art: NarrativeArtJobState) {
+// `runId` is the id of the run that was active when this art job was
+// *enqueued* (requestChapterArt/retryCurrentChapterArt below), not whatever
+// run happens to be active when the job's poll callback fires. Art jobs can
+// take minutes to resolve and nothing here cancels the poll on
+// abandon/restart (narrativeArtJobsHelper's poll timers are keyed by
+// dedupeKey, independent of this component's refs) -- so a player who
+// abandons a run and starts or resumes a *different* one before the old
+// job resolves would otherwise have the stale callback fire against the
+// new run's state instead. `chapterArt` is keyed only by chapter number
+// (1, 2, 3...), which resets to 1 for every new run, so the stale result
+// would silently overwrite the new run's own chapter art, and
+// persistLifeRunArt reads `run.value.id` at call time -- attaching the
+// abandoned run's illustration to the new run's LifeRunArt row server-side.
+// Discarding any result whose captured runId no longer matches the active
+// run mirrors narrateChapter()'s requestId guard (davinci/t-021 slice 12)
+// for the same "stale async result lands after the player has moved on"
+// shape, applied to the art-attachment path instead of narration text.
+function updateChapterArt(
+  runId: number,
+  chapter: number,
+  art: NarrativeArtJobState,
+) {
+  if (run.value?.id !== runId) return
   const wasDone = chapterArt.value[chapter]?.status === 'done'
   chapterArt.value = { ...chapterArt.value, [chapter]: art }
   if (!wasDone && art.status === 'done' && art.artImageId) {
@@ -932,7 +959,14 @@ function updateChapterArt(chapter: number, art: NarrativeArtJobState) {
   }
 }
 
-function updateEndingArt(art: NarrativeArtJobState) {
+// Same guard as updateChapterArt above, for the single ending-art slot.
+// Without it, a stale abandoned-run callback landing after a new run is
+// already playing would also block requestEndingArt() for the *new* run
+// once it resolves: requestEndingArt() no-ops when `endingArt.value` is
+// already set, so the leaked stale value would silently suppress the new
+// run's own ending illustration in addition to mis-attributing art server-side.
+function updateEndingArt(runId: number, art: NarrativeArtJobState) {
+  if (run.value?.id !== runId) return
   const wasDone = endingArt.value?.status === 'done'
   endingArt.value = art
   if (!wasDone && art.status === 'done' && art.artImageId) {
@@ -946,6 +980,7 @@ function updateEndingArt(art: NarrativeArtJobState) {
 // duplicate narrate() call for the same chapter).
 function requestChapterArt(chapter: number, artPrompt: string) {
   if (!run.value || chapterArt.value[chapter]) return
+  const runId = run.value.id
   void narrativeArtJobs.enqueue(
     {
       product: 'davinci',
@@ -955,7 +990,7 @@ function requestChapterArt(chapter: number, artPrompt: string) {
       narrative: artPrompt,
       title: run.value.protagonistName || run.value.title,
     },
-    (art) => updateChapterArt(chapter, art),
+    (art) => updateChapterArt(runId, chapter, art),
   )
 }
 
@@ -967,6 +1002,7 @@ function requestChapterArt(chapter: number, artPrompt: string) {
 // ever proposed one (e.g. the curated fallback pool, which has no narrator).
 function requestEndingArt() {
   if (!run.value || !endingData.value || endingArt.value) return
+  const runId = run.value.id
   const ending = endingData.value
   const artPrompt =
     lastArtPrompt.value ||
@@ -981,7 +1017,7 @@ function requestEndingArt() {
       title: run.value.protagonistName || run.value.title,
       objective: ending.title,
     },
-    updateEndingArt,
+    (art) => updateEndingArt(runId, art),
   )
 }
 

--- a/package.json
+++ b/package.json
@@ -115,6 +115,8 @@
     "test:davinci-phase-focus-guard": "tsx utils/scripts/verifyDaVinciPhaseFocusGuard.ts",
     "test:davinci-narrate-stale-response-guard-selftest": "tsx utils/scripts/verifyDaVinciNarrateStaleResponseGuard.test.ts",
     "test:davinci-narrate-stale-response-guard": "tsx utils/scripts/verifyDaVinciNarrateStaleResponseGuard.ts",
+    "test:davinci-art-run-guard-selftest": "tsx utils/scripts/verifyDaVinciArtRunGuard.test.ts",
+    "test:davinci-art-run-guard": "tsx utils/scripts/verifyDaVinciArtRunGuard.ts",
     "test:serendipity-voice-poll-guard-selftest": "tsx utils/scripts/verifySerendipityVoicePollGuard.test.ts",
     "test:serendipity-voice-poll-guard": "tsx utils/scripts/verifySerendipityVoicePollGuard.ts",
     "test:serendipity-voice-cursor-reset-selftest": "tsx utils/scripts/verifySerendipityVoiceCursorReset.test.ts",

--- a/utils/scripts/verifyDaVinciArtRunGuard.test.ts
+++ b/utils/scripts/verifyDaVinciArtRunGuard.test.ts
@@ -1,0 +1,204 @@
+// /utils/scripts/verifyDaVinciArtRunGuard.test.ts
+//
+// Regression test for checkArtRunGuard() in verifyDaVinciArtRunGuard.ts
+// (davinci/t-021 slice 13). Exercises the real check against synthetic
+// component-shaped fixtures covering: the fixed shape (runId parameter +
+// guard on both update functions, both request functions capturing and
+// threading runId through), and regressions dropping each piece
+// individually.
+import assert from 'node:assert/strict'
+
+import { checkArtRunGuard } from './verifyDaVinciArtRunGuard.js'
+
+function fixture(opts: {
+  updateChapterParam: string
+  updateChapterCheck: string
+  updateEndingParam: string
+  updateEndingCheck: string
+  requestChapterCapture: string
+  requestChapterPass: string
+  requestEndingCapture: string
+  requestEndingPass: string
+}): string {
+  return `
+<script setup lang="ts">
+function requestChapterArt(chapter: number, artPrompt: string) {
+  if (!run.value || chapterArt.value[chapter]) return
+  ${opts.requestChapterCapture}
+  void narrativeArtJobs.enqueue(
+    { product: 'davinci', sessionId: \`davinci-run-\${run.value.id}\` },
+    (art) => ${opts.requestChapterPass},
+  )
+}
+
+function requestEndingArt() {
+  if (!run.value || !endingData.value || endingArt.value) return
+  ${opts.requestEndingCapture}
+  void narrativeArtJobs.enqueue(
+    { product: 'davinci', sessionId: \`davinci-run-\${run.value.id}\` },
+    (art) => ${opts.requestEndingPass},
+  )
+}
+
+function hydrateArtFromRun(data: LifeRunRecord) {
+  chapterArt.value = {}
+}
+
+function updateChapterArt(
+  ${opts.updateChapterParam}
+  chapter: number,
+  art: NarrativeArtJobState,
+) {
+  ${opts.updateChapterCheck}
+  chapterArt.value = { ...chapterArt.value, [chapter]: art }
+}
+
+function updateEndingArt(${opts.updateEndingParam} art: NarrativeArtJobState) {
+  ${opts.updateEndingCheck}
+  endingArt.value = art
+}
+
+async function resumeRun(id: number) {
+  phase.value = 'loading'
+}
+</script>
+`
+}
+
+const FIXED_ARGS = {
+  updateChapterParam: 'runId: number,',
+  updateChapterCheck: 'if (run.value?.id !== runId) return',
+  updateEndingParam: 'runId: number,',
+  updateEndingCheck: 'if (run.value?.id !== runId) return',
+  requestChapterCapture: 'const runId = run.value.id',
+  requestChapterPass: 'updateChapterArt(runId, chapter, art)',
+  requestEndingCapture: 'const runId = run.value.id',
+  requestEndingPass: 'updateEndingArt(runId, art)',
+}
+
+const FIXED = fixture(FIXED_ARGS)
+
+// Pre-fix shape: no runId anywhere.
+const BUGGY = fixture({
+  updateChapterParam: '',
+  updateChapterCheck: '',
+  updateEndingParam: '',
+  updateEndingCheck: '',
+  requestChapterCapture: '',
+  requestChapterPass: 'updateChapterArt(chapter, art)',
+  requestEndingCapture: '',
+  requestEndingPass: 'updateEndingArt(art)',
+})
+
+function run(): void {
+  const fixedErrors = checkArtRunGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const buggyErrors = checkArtRunGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    8,
+    `expected the buggy fixture to fail all eight checks, got: ${JSON.stringify(buggyErrors)}`,
+  )
+
+  // Each piece dropped individually still fails only its own check(s).
+  const missingChapterParam = checkArtRunGuard(
+    fixture({ ...FIXED_ARGS, updateChapterParam: '' }),
+  )
+  assert.equal(missingChapterParam.length, 1)
+  assert.ok(
+    missingChapterParam.some((e) =>
+      /no longer takes a `runId: number` parameter/.test(e),
+    ),
+  )
+
+  const missingChapterCheck = checkArtRunGuard(
+    fixture({ ...FIXED_ARGS, updateChapterCheck: '' }),
+  )
+  assert.equal(missingChapterCheck.length, 1)
+  assert.ok(
+    missingChapterCheck.some((e) =>
+      /updateChapterArt\(\) no longer checks `run\.value\?\.id !== runId`/.test(
+        e,
+      ),
+    ),
+  )
+
+  const missingEndingParam = checkArtRunGuard(
+    fixture({ ...FIXED_ARGS, updateEndingParam: '' }),
+  )
+  assert.equal(missingEndingParam.length, 1)
+  assert.ok(
+    missingEndingParam.some((e) =>
+      /no longer takes a `runId: number` parameter/.test(e),
+    ),
+  )
+
+  const missingEndingCheck = checkArtRunGuard(
+    fixture({ ...FIXED_ARGS, updateEndingCheck: '' }),
+  )
+  assert.equal(missingEndingCheck.length, 1)
+  assert.ok(
+    missingEndingCheck.some((e) =>
+      /updateEndingArt\(\) no longer checks `run\.value\?\.id !== runId`/.test(
+        e,
+      ),
+    ),
+  )
+
+  const missingChapterCapture = checkArtRunGuard(
+    fixture({ ...FIXED_ARGS, requestChapterCapture: '' }),
+  )
+  assert.equal(missingChapterCapture.length, 1)
+  assert.ok(
+    missingChapterCapture.some((e) =>
+      /requestChapterArt\(\) no longer captures/.test(e),
+    ),
+  )
+
+  const missingChapterPass = checkArtRunGuard(
+    fixture({
+      ...FIXED_ARGS,
+      requestChapterPass: 'updateChapterArt(chapter, art)',
+    }),
+  )
+  assert.equal(missingChapterPass.length, 1)
+  assert.ok(
+    missingChapterPass.some((e) =>
+      /requestChapterArt\(\) no longer passes/.test(e),
+    ),
+  )
+
+  const missingEndingCapture = checkArtRunGuard(
+    fixture({ ...FIXED_ARGS, requestEndingCapture: '' }),
+  )
+  assert.equal(missingEndingCapture.length, 1)
+  assert.ok(
+    missingEndingCapture.some((e) =>
+      /requestEndingArt\(\) no longer captures/.test(e),
+    ),
+  )
+
+  const missingEndingPass = checkArtRunGuard(
+    fixture({ ...FIXED_ARGS, requestEndingPass: 'updateEndingArt(art)' }),
+  )
+  assert.equal(missingEndingPass.length, 1)
+  assert.ok(
+    missingEndingPass.some((e) =>
+      /requestEndingArt\(\) no longer passes/.test(e),
+    ),
+  )
+
+  console.log(
+    'Da Vinci art-run guard self-test passed: buggy fixture fails all ' +
+      'eight checks, fixed fixture passes, and each individual regression ' +
+      '(missing param/check/capture/pass, chapter and ending sides) fails ' +
+      'only its own check.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyDaVinciArtRunGuard.ts
+++ b/utils/scripts/verifyDaVinciArtRunGuard.ts
@@ -1,0 +1,199 @@
+// /utils/scripts/verifyDaVinciArtRunGuard.ts
+//
+// Regression guard (davinci/t-021 slice 13) -- updateChapterArt()/
+// updateEndingArt() in components/conductor/davinci-page.vue are passed as
+// callbacks to narrativeArtJobsHelper's enqueue()/retry(), which can take
+// minutes to resolve (5s poll interval, up to 120 attempts) and has no
+// concept of "is this run still active" -- nothing cancels the poll on
+// abandon/restart (its timers live in a module-level Map keyed by
+// dedupeKey, independent of this component's refs). Without a guard, a
+// player who abandons a run and starts or resumes a *different* one before
+// an old art job resolves would have the stale callback fire against the
+// new run's state: `chapterArt` is keyed only by chapter number (which
+// resets to 1 for every new run), so the stale result would silently
+// overwrite the new run's own chapter art, and persistLifeRunArt() reads
+// `run.value.id` at call time -- attaching the abandoned run's illustration
+// to the new run's LifeRunArt row server-side. For the single endingArt
+// slot it's worse: requestEndingArt() no-ops once `endingArt.value` is
+// already set, so a leaked stale value would also silently suppress the new
+// run's own ending illustration from ever being requested. Same shape as
+// narrateChapter()'s requestId ticket (davinci/t-021 slice 12, see
+// verifyDaVinciNarrateStaleResponseGuard.ts) applied to the art-attachment
+// path instead of narration text -- here the run's own id (unique per run,
+// unlike a chapter number) doubles as the ticket.
+//
+// This asserts the textual shape of the fix stays in place: both update
+// functions take a `runId` parameter and check it against `run.value?.id`
+// before applying anything, and both request functions (plus both retry
+// functions) capture `runId` from `run.value.id` before enqueueing/
+// retrying and thread it through to the callback. Deliberately scoped via
+// narrow textual checks, mirroring this project's other guards over a
+// general-purpose static analyzer (see verifyDaVinciDimensionToneGuard.ts).
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const COMPONENT_PATH = join(
+  repositoryRoot,
+  'components/conductor/davinci-page.vue',
+)
+
+const RUN_ID_CHECK_RE = /if\s*\(\s*run\.value\?\.id\s*!==\s*runId\s*\)\s*return/
+
+function extractFunction(
+  content: string,
+  startMarker: string,
+  endMarkers: string[],
+): string | null {
+  const startIndex = content.indexOf(startMarker)
+  if (startIndex === -1) return null
+
+  let end = content.length
+  for (const marker of endMarkers) {
+    const markerIndex = content.indexOf(marker, startIndex + startMarker.length)
+    if (markerIndex !== -1 && markerIndex < end) end = markerIndex
+  }
+
+  return content.slice(startIndex, end)
+}
+
+export function checkArtRunGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const updateChapterArt = extractFunction(
+    content,
+    'function updateChapterArt(',
+    ['function updateEndingArt(', 'async function resumeRun('],
+  )
+  if (!updateChapterArt) {
+    errors.push(
+      'Could not find `function updateChapterArt(` in davinci-page.vue -- ' +
+        'has it been restructured or removed? If so, this guard needs to ' +
+        'move with it.',
+    )
+  } else {
+    if (!/runId:\s*number/.test(updateChapterArt)) {
+      errors.push(
+        'updateChapterArt() no longer takes a `runId: number` parameter -- ' +
+          'without the run that requested this art job, a stale result ' +
+          "from an abandoned run can't be told apart from the active one.",
+      )
+    }
+    if (!RUN_ID_CHECK_RE.test(updateChapterArt)) {
+      errors.push(
+        'updateChapterArt() no longer checks `run.value?.id !== runId` ' +
+          'before applying the art update -- a stale result (e.g. from a ' +
+          'run the player already abandoned and replaced) would overwrite ' +
+          "the new run's own chapter art and could attach the wrong " +
+          'illustration to it server-side.',
+      )
+    }
+  }
+
+  const updateEndingArt = extractFunction(
+    content,
+    'function updateEndingArt(',
+    ['async function resumeRun(', 'async function startLife('],
+  )
+  if (!updateEndingArt) {
+    errors.push(
+      'Could not find `function updateEndingArt(` in davinci-page.vue -- ' +
+        'has it been restructured or removed? If so, this guard needs to ' +
+        'move with it.',
+    )
+  } else {
+    if (!/runId:\s*number/.test(updateEndingArt)) {
+      errors.push(
+        'updateEndingArt() no longer takes a `runId: number` parameter -- ' +
+          'without the run that requested this art job, a stale result ' +
+          "from an abandoned run can't be told apart from the active one.",
+      )
+    }
+    if (!RUN_ID_CHECK_RE.test(updateEndingArt)) {
+      errors.push(
+        'updateEndingArt() no longer checks `run.value?.id !== runId` ' +
+          'before applying the art update -- a stale result could both ' +
+          'mis-attribute art server-side and silently suppress the new ' +
+          "run's own ending illustration from ever being requested " +
+          '(requestEndingArt() no-ops once endingArt.value is set).',
+      )
+    }
+  }
+
+  const requestChapterArt = extractFunction(
+    content,
+    'function requestChapterArt(',
+    ['function requestEndingArt('],
+  )
+  if (
+    requestChapterArt &&
+    !/const\s+runId\s*=\s*run\.value\.id/.test(requestChapterArt)
+  ) {
+    errors.push(
+      'requestChapterArt() no longer captures `const runId = ' +
+        'run.value.id` before enqueueing the art job -- the callback has ' +
+        'no way to know which run requested it.',
+    )
+  }
+  if (
+    requestChapterArt &&
+    !/updateChapterArt\(runId,/.test(requestChapterArt)
+  ) {
+    errors.push(
+      'requestChapterArt() no longer passes the captured `runId` through ' +
+        'to updateChapterArt() -- the guard in updateChapterArt() has ' +
+        'nothing to check against.',
+    )
+  }
+
+  const requestEndingArt = extractFunction(
+    content,
+    'function requestEndingArt(',
+    ['function hydrateArtFromRun('],
+  )
+  if (
+    requestEndingArt &&
+    !/const\s+runId\s*=\s*run\.value\.id/.test(requestEndingArt)
+  ) {
+    errors.push(
+      'requestEndingArt() no longer captures `const runId = ' +
+        'run.value.id` before enqueueing the art job -- the callback has ' +
+        'no way to know which run requested it.',
+    )
+  }
+  if (requestEndingArt && !/updateEndingArt\(runId,/.test(requestEndingArt)) {
+    errors.push(
+      'requestEndingArt() no longer passes the captured `runId` through ' +
+        'to updateEndingArt() -- the guard in updateEndingArt() has ' +
+        'nothing to check against.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(COMPONENT_PATH, 'utf8')
+  const errors = checkArtRunGuard(content)
+
+  if (errors.length) {
+    console.error('Da Vinci art-run guard contract failed in davinci-page.vue:')
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Da Vinci art-run guard contract passed: updateChapterArt()/' +
+      'updateEndingArt() both check the requesting run is still active ' +
+      "before applying a poll result, so an abandoned run's art job " +
+      "can't overwrite or block the currently active run's art.",
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
davinci/t-021 slice 13: Da Vinci visual style and interaction polish pass (kind: software)

### What changed / what I produced
- `updateChapterArt()`/`updateEndingArt()` in `components/conductor/davinci-page.vue` now take the requesting run's id and discard any art-job poll result once `run.value.id` no longer matches it.
- `requestChapterArt()`/`requestEndingArt()`/`retryCurrentChapterArt()`/`retryEndingArt()` capture `runId` and thread it through to the callbacks.
- Added `verifyDaVinciArtRunGuard.ts` + selftest (the 12th `verifyDaVinci*` guard), wired into `package.json` and `contract-tests.yml`.

### Root cause
`narrativeArtJobsHelper`'s `enqueue()`/`retry()` poll for up to 10 minutes (5s interval × 120 attempts) and have no concept of "is this run still active" — nothing cancels the poll on abandon/restart (its timers live in a module-level `Map` keyed by dedupeKey, independent of the component's refs). A player who abandons a run and starts or resumes a *different* one before an old art job resolves would have the stale callback fire against the new run's state:
- `chapterArt` is keyed only by chapter number, which resets to 1 for every new run, so the stale result silently overwrote the new run's own chapter art — and `persistLifeRunArt()` reads `run.value.id` at *call time*, attaching the abandoned run's illustration to the new run's `LifeRunArt` row server-side.
- `endingArt` is a single slot; `requestEndingArt()` no-ops once it's already set, so a leaked stale value would also silently suppress the new run's own ending illustration from ever being requested.

Same shape as `narrateChapter()`'s `requestId` ticket fixed in slice 12, applied here to the art-attachment path — the run's own id doubles as the ticket.

### How I verified
- New guard fails pre-fix / passes post-fix (git-stash round-trip against the real component).
- All 11 prior `verifyDaVinci*` guards + selftests still pass.
- `test:davinci-narration` still passes.
- `test:layout-contract` holds with no new violations (one unrelated pre-existing baseline improvement elsewhere, untouched by this PR).
- `eslint` clean, `prettier --check` clean.
- `vue-tsc --noEmit` repo-wide exit 0.
- `git status --porcelain` showed exactly the 5 intended files (reverted an incidental `prisma generate` regen diff before committing).

### Stakes
reversible

### Flags for Reviewer
- Outstanding cross-width visual verification for t-021 remains unaddressed (documented as not possible pre-merge in this sandbox per AGENTS.md's Vercel-preview-retirement section, unchanged from every prior slice).

### Kaizen suggestion
Thirteen slices in, every fix so far was found by static reading alone. A future slice could try scripting an actual reproduction (e.g. mock the art-job poll to resolve slowly, abandon mid-poll, start a new run, assert no cross-run leakage) rather than continuing purely static audits — same idea model-builder/t-029's own kaizen note raised for its batch-editor race.

### Notes for reviewer
Conductor roadmap task davinci/t-021 claimed under session `sched-conductor-davinci-t021-20260822T222803Z`; will close out to `ready` (re-arm for a follow-up slice) after this merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_014AAt94GQsUpJf9WUpDoKDN)_