### PR TITLE
fix(gallery): make shared renderer own Cards Heroes Icons

### DIFF
--- a/components/gallery/kr-gallery.vue
+++ b/components/gallery/kr-gallery.vue
@@ -230,117 +230,179 @@
         />
       </template>
 
-      <button
-        v-for="item in pagedItems"
-        v-else
-        :key="item.id"
-        type="button"
-        :data-theme="themed ? itemTheme(item) : undefined"
-        class="group overflow-hidden rounded-2xl border border-(--kr-surface-border) bg-(--kr-surface) text-left transition hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-lg"
-        @click="emit('open', item)"
-      >
-        <div class="relative overflow-hidden" :class="imageWrapClass">
-          <img
-            v-if="artSrc(item)"
-            :src="artSrc(item)"
-            :alt="item.title"
-            class="absolute inset-0 h-full w-full object-cover transition duration-500 group-hover:scale-105"
-            @error="onArtError(artSrc(item))"
-          />
-          <!-- Art-absent placeholder. Without this an unillustrated row renders
-               <img src="">, which browsers treat as "reload the current page"
-               and paint as a broken image. Galleries whose rows are routinely
-               unillustrated (facets, where art is queued rather than required)
-               could not adopt this shell at all until it degraded properly.
-
-               It now also covers art that is PRESENT but fails to load, which
-               is a different failure with the same remedy: a broken <img>
-               paints its alt text inside the layout box where the art should
-               be, so a card whose art 404s renders its title sprawling across
-               the artwork area. That is interface-vision t-069 -- reported as
-               "description text renders over the card art", reproduced against
-               production 2026-08-03, and invisible to source review because
-               nothing in the markup is wrong. It only exists while art is
-               missing, which right now is common: art is still generating. -->
-          <div
-            v-else
-            class="absolute inset-0 flex flex-col items-center justify-center gap-1 bg-linear-to-br from-base-200 to-base-300 text-base-content/40"
-          >
-            <Icon
-              :name="item.placeholderIcon || 'kind-icon:image'"
-              class="size-8"
-            />
-            <span
-              v-if="item.placeholderLabel"
-              class="text-[10px] uppercase tracking-wide"
-            >
-              {{ item.placeholderLabel }}
-            </span>
-          </div>
-          <div
-            class="absolute inset-0 bg-linear-to-t from-base-300/90 via-transparent to-transparent"
-          />
-          <div
-            v-if="item.badges?.length"
-            class="absolute left-2 top-2 flex gap-1"
-          >
-            <span
-              v-for="badge in item.badges"
-              :key="badge.label"
-              class="badge badge-xs"
-              :class="badge.class"
-            >
-              {{ badge.label }}
-            </span>
-          </div>
-          <!-- The corner icon puck. Same failed-source guard as the art above:
-               alt="" means a missing file paints no TEXT, but it still paints a
-               broken-image box, which is the small broken glyph left on
-               /conductor after the main-art fix landed (the CI audit found
-               exactly one, interface-vision-icon.webp, missing from the
-               conductor repo). A decorative icon that will not load should
-               simply not render. -->
-          <img
-            v-if="mode !== 'icons' && item.icon && !failedArt.has(item.icon)"
-            :src="item.icon"
-            alt=""
-            class="absolute bottom-2 left-2 size-11 rounded-xl border border-white/25 object-cover shadow"
-            @error="onArtError(item.icon)"
-          />
-        </div>
-        <div class="p-3" :class="mode === 'icons' ? 'text-center' : ''">
-          <div
-            class="flex items-start gap-2"
-            :class="mode === 'icons' ? 'justify-center' : ''"
-          >
-            <div class="min-w-0 flex-1">
-              <h2 class="truncate font-black">{{ item.title }}</h2>
-              <p
-                v-if="mode !== 'icons' && item.description"
-                class="line-clamp-2 text-xs text-base-content/55"
-              >
-                {{ item.description }}
-              </p>
-            </div>
-            <slot name="item-trailing" :item="item" />
-          </div>
-          <p
-            v-if="mode !== 'icons' && item.meta"
-            class="mt-2 text-xs text-base-content/45"
-          >
-            {{ item.meta }}
-          </p>
-          <div
-            v-if="mode !== 'icons' && item.progressPercent !== undefined"
-            class="mt-1.5 h-1 overflow-hidden rounded-full bg-base-content/10"
+      <template v-else>
+        <template v-for="item in pagedItems" :key="item.id">
+          <button
+            v-if="mode === 'icons'"
+            type="button"
+            :data-theme="themed ? itemTheme(item) : undefined"
+            class="group flex min-w-0 items-center gap-3 rounded-2xl border border-(--kr-surface-border) bg-(--kr-surface) p-3 text-left transition hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-lg"
+            @click="emit('open', item)"
           >
             <div
-              class="h-full bg-primary"
-              :style="{ width: `${item.progressPercent}%` }"
-            />
-          </div>
-        </div>
-      </button>
+              class="relative size-16 shrink-0 overflow-hidden rounded-xl bg-(--kr-surface-sunken)"
+            >
+              <img
+                v-if="artSrc(item)"
+                :src="artSrc(item)"
+                :alt="item.title"
+                class="absolute inset-0 h-full w-full object-cover transition duration-300 group-hover:scale-105"
+                @error="onArtError(artSrc(item))"
+              />
+              <div
+                v-else
+                class="absolute inset-0 flex flex-col items-center justify-center gap-1 bg-linear-to-br from-base-200 to-base-300 text-base-content/40"
+              >
+                <Icon
+                  :name="item.placeholderIcon || 'kind-icon:image'"
+                  class="size-7"
+                />
+                <span
+                  v-if="item.placeholderLabel"
+                  class="text-[9px] uppercase tracking-wide"
+                >
+                  {{ item.placeholderLabel }}
+                </span>
+              </div>
+            </div>
+
+            <div class="min-w-0 flex-1">
+              <div
+                v-if="item.badges?.length"
+                class="mb-1 flex flex-wrap gap-1"
+              >
+                <span
+                  v-for="badge in item.badges"
+                  :key="badge.label"
+                  class="badge badge-xs"
+                  :class="badge.class"
+                >
+                  {{ badge.label }}
+                </span>
+              </div>
+
+              <div class="flex items-start gap-2">
+                <div class="min-w-0 flex-1">
+                  <h2 class="break-words font-black leading-tight">
+                    {{ item.title }}
+                  </h2>
+                  <p
+                    v-if="item.description"
+                    class="mt-0.5 line-clamp-2 text-xs text-base-content/55"
+                  >
+                    {{ item.description }}
+                  </p>
+                </div>
+                <slot name="item-trailing" :item="item" />
+              </div>
+
+              <p
+                v-if="item.meta"
+                class="mt-1.5 text-xs text-base-content/45"
+              >
+                {{ item.meta }}
+              </p>
+              <div
+                v-if="item.progressPercent !== undefined"
+                class="mt-1.5 h-1 overflow-hidden rounded-full bg-base-content/10"
+              >
+                <div
+                  class="h-full bg-primary"
+                  :style="{ width: `${item.progressPercent}%` }"
+                />
+              </div>
+            </div>
+          </button>
+
+          <button
+            v-else
+            type="button"
+            :data-theme="themed ? itemTheme(item) : undefined"
+            class="group overflow-hidden rounded-2xl border border-(--kr-surface-border) bg-(--kr-surface) text-left transition hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-lg"
+            @click="emit('open', item)"
+          >
+            <div
+              class="relative overflow-hidden bg-(--kr-surface-sunken)"
+              :class="mode === 'cards' ? 'aspect-2/3' : 'aspect-video'"
+            >
+              <img
+                v-if="artSrc(item)"
+                :src="artSrc(item)"
+                :alt="item.title"
+                class="absolute inset-0 h-full w-full object-cover transition duration-500 group-hover:scale-105"
+                @error="onArtError(artSrc(item))"
+              />
+              <div
+                v-else
+                class="absolute inset-0 flex flex-col items-center justify-center gap-1 bg-linear-to-br from-base-200 to-base-300 text-base-content/40"
+              >
+                <Icon
+                  :name="item.placeholderIcon || 'kind-icon:image'"
+                  class="size-8"
+                />
+                <span
+                  v-if="item.placeholderLabel"
+                  class="text-[10px] uppercase tracking-wide"
+                >
+                  {{ item.placeholderLabel }}
+                </span>
+              </div>
+              <div
+                class="absolute inset-0 bg-linear-to-t from-base-300/90 via-transparent to-transparent"
+              />
+              <div
+                v-if="item.badges?.length"
+                class="absolute left-2 top-2 flex flex-wrap gap-1"
+              >
+                <span
+                  v-for="badge in item.badges"
+                  :key="badge.label"
+                  class="badge badge-xs"
+                  :class="badge.class"
+                >
+                  {{ badge.label }}
+                </span>
+              </div>
+              <img
+                v-if="item.icon && !failedArt.has(item.icon)"
+                :src="item.icon"
+                alt=""
+                class="absolute bottom-2 left-2 size-11 rounded-xl border border-white/25 object-cover shadow"
+                @error="onArtError(item.icon)"
+              />
+            </div>
+
+            <div class="p-3">
+              <div class="flex items-start gap-2">
+                <div class="min-w-0 flex-1">
+                  <h2 class="break-words font-black leading-tight">
+                    {{ item.title }}
+                  </h2>
+                  <p
+                    v-if="item.description"
+                    class="line-clamp-2 text-xs text-base-content/55"
+                  >
+                    {{ item.description }}
+                  </p>
+                </div>
+                <slot name="item-trailing" :item="item" />
+              </div>
+              <p v-if="item.meta" class="mt-2 text-xs text-base-content/45">
+                {{ item.meta }}
+              </p>
+              <div
+                v-if="item.progressPercent !== undefined"
+                class="mt-1.5 h-1 overflow-hidden rounded-full bg-base-content/10"
+              >
+                <div
+                  class="h-full bg-primary"
+                  :style="{ width: `${item.progressPercent}%` }"
+                />
+              </div>
+            </div>
+          </button>
+        </template>
+      </template>
     </section>
   </div>
 </template>
@@ -517,13 +579,6 @@ const pageRangeLabel = computed(() => {
   return `${first}–${last} of ${total}`
 })
 
-const imageWrapClass = computed(() =>
-  props.mode === 'heroes'
-    ? 'min-h-64'
-    : props.mode === 'icons'
-      ? 'mx-auto mt-3 size-24 rounded-2xl'
-      : 'aspect-[4/3]',
-)
 const modeVariant = computed<ArtVariant>(() => MODE_VARIANT[props.mode])
 
 /**

--- a/components/pages/conductor-project-gallery-page.vue
+++ b/components/pages/conductor-project-gallery-page.vue
@@ -201,133 +201,6 @@
             </button>
           </div>
         </template>
-
-        <template #item="{ item, mode, artSrc, open: openItem }">
-          <button
-            v-if="mode === 'icons'"
-            type="button"
-            class="group flex min-w-0 items-center gap-3 rounded-2xl border border-(--kr-surface-border) bg-(--kr-surface) p-3 text-left transition hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-lg"
-            @click="openItem"
-          >
-            <div
-              class="relative size-20 shrink-0 overflow-hidden rounded-xl bg-base-200"
-            >
-              <div
-                class="absolute inset-0 flex items-center justify-center bg-linear-to-br from-base-200 to-base-300 text-base-content/35"
-              >
-                <Icon name="kind-icon:image" class="size-8" />
-              </div>
-              <img
-                v-if="artSrc"
-                :src="artSrc"
-                :alt="(item as Item).title"
-                class="absolute inset-0 size-full object-cover transition duration-300 group-hover:scale-105"
-                @error="hideBrokenImage"
-              />
-            </div>
-            <div class="min-w-0 flex-1">
-              <div class="mb-1 flex flex-wrap items-center gap-1">
-                <span
-                  v-for="badge in (item as Item).badges"
-                  :key="badge.label"
-                  class="badge badge-xs"
-                  :class="badge.class"
-                >
-                  {{ badge.label }}
-                </span>
-                <span
-                  class="badge badge-xs"
-                  :class="priorityClass((item as Item).priority)"
-                >
-                  {{ (item as Item).priority }}
-                </span>
-              </div>
-              <h2 class="break-words font-black leading-tight">
-                {{ (item as Item).title }}
-              </h2>
-              <p class="mt-1 line-clamp-2 text-xs text-base-content/60">
-                {{ (item as Item).description }}
-              </p>
-              <p class="mt-2 text-[0.68rem] font-semibold text-base-content/45">
-                {{ (item as Item).meta }}
-              </p>
-              <progress
-                class="progress progress-primary mt-1 h-1 w-full"
-                :value="(item as Item).progressPercent"
-                max="100"
-              />
-            </div>
-          </button>
-
-          <button
-            v-else
-            type="button"
-            class="group overflow-hidden rounded-2xl border border-(--kr-surface-border) bg-(--kr-surface) text-left transition hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-lg"
-            @click="openItem"
-          >
-            <div
-              class="relative overflow-hidden bg-base-200"
-              :class="mode === 'cards' ? 'aspect-[2/3]' : 'aspect-video'"
-            >
-              <div
-                class="absolute inset-0 flex items-center justify-center bg-linear-to-br from-base-200 to-base-300 text-base-content/35"
-              >
-                <Icon name="kind-icon:image" class="size-10" />
-              </div>
-              <img
-                v-if="artSrc"
-                :src="artSrc"
-                :alt="(item as Item).title"
-                class="absolute inset-0 size-full object-cover transition duration-500 group-hover:scale-105"
-                @error="hideBrokenImage"
-              />
-              <div
-                class="absolute inset-0 bg-linear-to-t from-base-300/80 via-transparent to-transparent"
-              />
-              <div class="absolute left-2 top-2 flex flex-wrap gap-1">
-                <span
-                  v-for="badge in (item as Item).badges"
-                  :key="badge.label"
-                  class="badge badge-xs"
-                  :class="badge.class"
-                >
-                  {{ badge.label }}
-                </span>
-              </div>
-              <img
-                v-if="(item as Item).icon"
-                :src="(item as Item).icon"
-                alt=""
-                class="absolute bottom-2 left-2 size-11 rounded-xl border border-white/25 object-cover shadow"
-                @error="hideBrokenImage"
-              />
-            </div>
-            <div class="space-y-1.5 p-3">
-              <div class="flex items-start gap-2">
-                <h2 class="min-w-0 flex-1 break-words font-black leading-tight">
-                  {{ (item as Item).title }}
-                </h2>
-                <span
-                  class="badge badge-xs shrink-0"
-                  :class="priorityClass((item as Item).priority)"
-                >
-                  {{ (item as Item).priority }}
-                </span>
-              </div>
-              <p class="line-clamp-2 text-xs text-base-content/60">
-                {{ (item as Item).description }}
-              </p>
-              <p class="text-[0.68rem] font-semibold text-base-content/45">
-                {{ (item as Item).meta }}
-              </p>
-              <progress
-                class="progress progress-primary h-1 w-full"
-                :value="(item as Item).progressPercent"
-                max="100"
-              />
-            </div>
-          </button>
-        </template>
       </kr-gallery>
     </main>
   </section>
@@ -457,11 +330,6 @@ function onSlugBlur() {
   createForm.value.slug = slugify(createForm.value.slug)
 }
 
-function hideBrokenImage(event: Event) {
-  const target = event.currentTarget
-  if (target instanceof HTMLImageElement) target.remove()
-}
-
 const loading = computed(() => projects.loading || conductor.pending)
 const error = computed(() => projects.error || conductor.error || '')
 const conductorBySlug = computed(
@@ -553,7 +421,10 @@ function toItem(record: ProjectWithRelations): Item {
   const metaParts = [`${progress}%`, `${done}/${total} done`]
   if (blocked) metaParts.push(`${blocked} blocked`)
   if (needsHuman) metaParts.push(`${needsHuman} need you`)
-  const badges = [{ label: statusLabel(status), class: statusClass(status) }]
+  const badges = [
+    { label: statusLabel(status), class: statusClass(status) },
+    { label: priority, class: priorityClass(priority) },
+  ]
   if (drift) badges.push({ label: 'drift', class: 'badge-warning' })
   return {
     id: record.id,

--- a/utils/scripts/verifyGalleryConsistency.ts
+++ b/utils/scripts/verifyGalleryConsistency.ts
@@ -355,6 +355,49 @@ for (const model of CORE_MODELS) {
 }
 ok(`${CORE_MODELS.length} core objects carry all four art variants`)
 
+/* ------------------------------------------------------------------ *
+ * 7. kr-gallery's built-in renderer must implement the same vocabulary.
+ * ------------------------------------------------------------------ */
+const sharedGallery = stripComments(
+  await readFile('components/gallery/kr-gallery.vue', 'utf8'),
+)
+const projectGallery = stripComments(
+  await readFile('components/pages/conductor-project-gallery-page.vue', 'utf8'),
+)
+
+if (!sharedGallery.includes(`v-if="mode === 'icons'"`)) {
+  fail(
+    'kr-gallery has no dedicated Icons branch. Icons are a text-forward row, not a centered mini-card.',
+  )
+}
+if (!sharedGallery.includes('size-16 shrink-0')) {
+  fail(
+    'kr-gallery Icons mode no longer reserves a small fixed square intro image before the text.',
+  )
+}
+if (
+  !sharedGallery.includes(
+    `:class="mode === 'cards' ? 'aspect-2/3' : 'aspect-video'"`,
+  )
+) {
+  fail(
+    'kr-gallery built-in Cards/Heroes geometry drifted. Cards must be 2:3 portrait and Heroes 16:9.',
+  )
+}
+if (/<h2[^>]*\btruncate\b/.test(sharedGallery)) {
+  fail(
+    'kr-gallery truncates a built-in item title. Gallery titles must wrap so the shared renderer does not silently discard names.',
+  )
+}
+if (/<template\s+#item(?:=|\s|>)/.test(projectGallery)) {
+  fail(
+    'conductor-project-gallery-page.vue reintroduced a bespoke item renderer. Projects fit GalleryItem and must exercise the shared renderer so gallery geometry cannot drift separately again.',
+  )
+}
+if (!failures.length) {
+  ok('kr-gallery built-in Cards/Heroes/Icons renderer follows the shared vocabulary')
+}
+
 /* ------------------------------------------------------------------ */
 
 for (const note of notes) console.log(note)
@@ -367,5 +410,6 @@ if (failures.length) {
 
 console.log(
   '\nGallery consistency contract passed: grids size to their container, cards ' +
-    'follow the gallery mode, and every mode bar is wired to something.',
+    'follow the gallery mode, built-in rendering matches the shared vocabulary, ' +
+    'and every mode bar is wired to something.',
 )


### PR DESCRIPTION
## What changed
- fix `kr-gallery`'s built-in renderer so **Cards are 2:3 portrait**, **Heroes are 16:9 landscape**, and **Icons are square-art + text-forward rows**
- let built-in gallery titles wrap instead of truncating them
- preserve badges, description, metadata, progress, theming, trailing actions, pagination, and failed-art placeholders across all three modes
- remove the Projects gallery's compensating `#item` implementation so Projects now exercises the same shared renderer as other simple galleries
- carry project priority as a normal shared gallery badge alongside lifecycle/drift
- extend `verifyGalleryConsistency.ts` so the shared renderer geometry/title contract is enforced and Projects cannot silently fork it again

## Root cause
The canonical vocabulary in `galleryVocabulary.ts` and `kr-entity-card-body.vue` already said card = 2:3, hero = 16:9, icon = square/text-forward. The default renderer inside `kr-gallery.vue` had drifted independently: cards were 4:3, heroes used a minimum height instead of the hero aspect, icons were centered mini-cards, and titles were truncated. Project PR #2032 fixed the symptom by hand-rendering all three modes, which made Projects look right while leaving the generic renderer wrong.

## Scope
Three files:
- `components/gallery/kr-gallery.vue`
- `components/pages/conductor-project-gallery-page.vue`
- `utils/scripts/verifyGalleryConsistency.ts`

Conductor: `interface-vision/t-104`
Session: `2026-08-23T001920Z-chatgpt-iv-t104-gallery-generic-8c2f`

## Verification
Connector-only environment could not clone the repository for local commands because outbound DNS is unavailable. Exact-head GitHub Actions are the verification gate for this PR; do not merge until TypeScript, Contract Tests (including gallery consistency), Layout Contract, and all other triggered checks have completed successfully.