### PR TITLE
fix(gallery): drop redundant #item demo override in ui-gallery

### DIFF
--- a/components/ui/ui-gallery.vue
+++ b/components/ui/ui-gallery.vue
@@ -372,25 +372,17 @@
           :density="demoGalleryDensity"
           empty-label="specimens"
           @update:mode="demoGalleryMode = $event"
-        >
-          <template #item="{ item, mode }">
-            <div class="flex flex-col gap-1 kr-panel-flat p-3">
-              <span class="text-smart-heading font-black">{{
-                item.title
-              }}</span>
-              <span class="text-smart-compact opacity-70">
-                {{ item.description }}
-              </span>
-              <span class="badge badge-ghost badge-sm w-fit">{{ mode }}</span>
-            </div>
-          </template>
-        </kr-gallery>
+        />
 
         <p class="text-smart-compact mt-2 opacity-70">
           The Cards / Heroes / Icons bar is the shell's, and it is sticky inside
           whichever ancestor scrolls. Swap modes above and the grid changes with
           it -- each mode is a different MODE_GRID_CLASS, container-responsive
-          rather than viewport-keyed.
+          rather than viewport-keyed. No <code class="font-mono">#item</code>
+          override here on purpose -- this demo now renders the shared built-in
+          item template directly, so it documents the real Cards/Heroes/Icons
+          contract every other gallery gets by default instead of a bespoke
+          stand-in for it.
         </p>
       </section>
 


### PR DESCRIPTION
## What changed
`components/ui/ui-gallery.vue`'s living-style-guide demo of `<kr-gallery>` supplied its own `#item` template — a plain title/description/mode-badge stack with no image or aspect-ratio handling, none of the geometry the shared renderer now correctly implements (Cards 2:3, Heroes 16:9, Icons square-plus-text, fixed in #2034). Removed the override so the demo falls through to the shared built-in item template, which is a better showcase for a documentation page anyway.

## Why
Conductor task `interface-vision/t-118` (kaizen from t-104's #2034 review): audit all 16 `kr-gallery` consumers still supplying a bespoke `#item` override now that the shared renderer is correct, and remove the ones that are redundant with it.

Classified all 16:
- **15 stay bespoke** — every "core object" gallery (bots, characters, dreams ×2, rewards, scenarios ×2) and several others (achievements, art, stylist-client, checkpoints, servers, themes, friends, resources) hand real custom behavior through the slot: edit/clone/delete/select/test/message actions, bulk-select, karma display, theme-swatch grids — none of that is in the shared `GalleryItem` contract, so they correctly stay custom.
- **1 was redundant** — `ui-gallery.vue`'s demo item, fixed here.

## How I verified
Read `kr-gallery.vue`'s full built-in-renderer contract and this file end to end before editing. The demo's `demoGalleryItems` only ever set `id`/`title`/`description` (no image), so it already relied on the shared renderer's placeholder-icon fallback (`item.placeholderIcon || 'kind-icon:image'`) for art even before this change — removing the `#item` slot doesn't change what art renders, only removes the duplicate title/description/badge markup. No other file references the removed `mode` template-slot variable.

## Stakes
Reversible, single-file, no logic/data changes — a Vue template slot removal on a documentation page. Not a live-user-facing production surface change (this is the internal `/ui` style guide).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBuHQwtMWCUDP15J5GM6F4)_