### PR TITLE
fix(art): resolve project prompt context in compact workspace

### DIFF
--- a/plugins/entity-art-prompt-suggest.client.ts
+++ b/plugins/entity-art-prompt-suggest.client.ts
@@ -1,4 +1,6 @@
 import { suggestArtAssetPrompt } from '@/stores/helpers/artAssetSuggest'
+import { usePageStore } from '@/stores/pageStore'
+import { useProjectStore } from '@/stores/projectStore'
 import {
   normalizeArtModelType,
   type ArtModelRef,
@@ -34,8 +36,16 @@ type ManagerContext = {
   slots: EntityArtSlot[]
 }
 
+type PageStore = ReturnType<typeof usePageStore>
+type ProjectStore = ReturnType<typeof useProjectStore>
+
 const BUTTON_MARKER = 'data-entity-art-prompt-suggest'
 const attached = new WeakSet<HTMLTextAreaElement>()
+const PROJECT_ART_SLOTS: EntityArtSlot[] = [
+  { field: 'heroPath', label: 'Hero', width: 1280, height: 720 },
+  { field: 'cardPath', label: 'Card', width: 512, height: 768 },
+  { field: 'imagePath', label: 'Icon', width: 256, height: 256 },
+]
 
 function cleanString(value: unknown): string {
   return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : ''
@@ -126,6 +136,7 @@ function managerContextFromPage(element: HTMLElement): ManagerContext | null {
       ...(id ? { id } : {}),
       ...(slug ? { slug } : {}),
       title:
+        cleanString(context?.dataset.artSubject) ||
         cleanString(document.querySelector('h1')?.textContent) ||
         cleanString(document.title),
     },
@@ -133,12 +144,43 @@ function managerContextFromPage(element: HTMLElement): ManagerContext | null {
   }
 }
 
-function managerContext(element: HTMLElement): ManagerContext | null {
+function managerContextFromWorkspaceProject(
+  element: HTMLElement,
+  pageStore: PageStore,
+  projectStore: ProjectStore,
+): ManagerContext | null {
+  if (!element.closest('.project-art-compact')) return null
+
+  const workspaceSlug = cleanString(pageStore.workspaceCardKey)
+  if (!workspaceSlug) return null
+  const project = projectStore.projectForSlug(workspaceSlug)
+  if (!project) return null
+
+  const slug = cleanString(
+    project.conductorSlug || project.slug || workspaceSlug,
+  )
+  return {
+    entityType: 'project',
+    entity: {
+      id: project.id,
+      ...(slug ? { slug } : {}),
+      title: project.title,
+    },
+    slots: PROJECT_ART_SLOTS,
+  }
+}
+
+function managerContext(
+  element: HTMLElement,
+  pageStore: PageStore,
+  projectStore: ProjectStore,
+): ManagerContext | null {
   const section = element.closest<HTMLElement>('section')
   return (
     managerContextFromVue(element) ||
     (section ? managerContextFromVue(section) : null) ||
-    managerContextFromPage(element)
+    managerContextFromPage(element) ||
+    managerContextFromWorkspaceProject(element, pageStore, projectStore)
   )
 }
 
@@ -219,7 +261,11 @@ function setTextareaValue(textarea: HTMLTextAreaElement, value: string): void {
   textarea.dispatchEvent(new Event('change', { bubbles: true }))
 }
 
-function addSuggestButton(textarea: HTMLTextAreaElement): void {
+function addSuggestButton(
+  textarea: HTMLTextAreaElement,
+  pageStore: PageStore,
+  projectStore: ProjectStore,
+): void {
   if (attached.has(textarea)) return
   const form = textarea.closest<HTMLFormElement>('form')
   if (!form) return
@@ -243,7 +289,7 @@ function addSuggestButton(textarea: HTMLTextAreaElement): void {
 
   button.addEventListener('click', async () => {
     if (button.dataset.loading === 'true') return
-    const context = managerContext(textarea)
+    const context = managerContext(textarea, pageStore, projectStore)
     if (!context) {
       button.textContent = 'Could not identify record'
       window.setTimeout(() => {
@@ -314,25 +360,36 @@ function addSuggestButton(textarea: HTMLTextAreaElement): void {
   })
 }
 
-function scanForEntityArtPrompts(root: ParentNode = document): void {
+function scanForEntityArtPrompts(
+  root: ParentNode,
+  pageStore: PageStore,
+  projectStore: ProjectStore,
+): void {
   for (const textarea of root.querySelectorAll<HTMLTextAreaElement>(
     'textarea[maxlength="5000"]',
   )) {
-    addSuggestButton(textarea)
+    addSuggestButton(textarea, pageStore, projectStore)
   }
 }
 
 export default defineNuxtPlugin((nuxtApp) => {
+  const pageStore = usePageStore()
+  const projectStore = useProjectStore()
+
   nuxtApp.hook('app:mounted', () => {
-    scanForEntityArtPrompts()
+    scanForEntityArtPrompts(document, pageStore, projectStore)
     const observer = new MutationObserver((records) => {
       for (const record of records) {
         for (const node of record.addedNodes) {
           if (!(node instanceof Element)) continue
           if (node.matches('textarea[maxlength="5000"]')) {
-            addSuggestButton(node as HTMLTextAreaElement)
+            addSuggestButton(
+              node as HTMLTextAreaElement,
+              pageStore,
+              projectStore,
+            )
           }
-          scanForEntityArtPrompts(node)
+          scanForEntityArtPrompts(node, pageStore, projectStore)
         }
       }
     })

--- a/utils/scripts/verifyEntityArtPromptSuggest.ts
+++ b/utils/scripts/verifyEntityArtPromptSuggest.ts
@@ -15,8 +15,15 @@ function expectContains(path: string, needles: string[]): void {
 
 expectContains('plugins/entity-art-prompt-suggest.client.ts', [
   "import { suggestArtAssetPrompt } from '@/stores/helpers/artAssetSuggest'",
+  "import { usePageStore } from '@/stores/pageStore'",
+  "import { useProjectStore } from '@/stores/projectStore'",
   '✨ Suggest prompt',
   'managerContextFromVue',
+  'managerContextFromWorkspaceProject',
+  "element.closest('.project-art-compact')",
+  'projectStore.projectForSlug(workspaceSlug)',
+  "entityType: 'project'",
+  "{ field: 'heroPath', label: 'Hero', width: 1280, height: 720 }",
   'entityRef: entityRef(context)',
   'current: textarea.value',
   'variantForSlot',


### PR DESCRIPTION
## What changed
- teach the shared entity-art prompt helper how to resolve the active Project when artwork is opened from the compact Projects workspace
- scope that fallback to `.project-art-compact`, then resolve `pageStore.workspaceCardKey` through `projectStore.projectForSlug`
- preserve the existing Vue-instance, DOM metadata, and route resolution paths as higher-priority context sources
- carry the Project Hero/Card/Icon slot metadata into the suggestion request so Hero prompts stay 1280×720, Cards 512×768, and Icons 256×256
- use existing `data-art-subject` metadata as a title fallback where available
- extend the entity-art prompt contract to guard this exact workspace fallback

## Root cause
The visible `Could not identify record` pill is the shared Suggest prompt plugin, not the ArtJob enqueue path. The plugin could identify entities from Vue DOM internals, route paths, or explicit `data-art-model` attributes. The compact Project detail is selected through `pageStore.workspaceCardKey` and does not encode the Project in the URL, while the textarea's Vue ancestry is not reliable for this DOM-enhancement plugin. The helper therefore attached successfully but had no record context when clicked.

## Scope
Two files changed:
- `plugins/entity-art-prompt-suggest.client.ts`
- `utils/scripts/verifyEntityArtPromptSuggest.ts`

Conductor: `interface-vision/t-104`
Session: `2026-08-23T031600Z-iv-t104-project-art-context-9d6e`

## Verification
Exact-head GitHub Actions are the executable gate. Merge only after every triggered check completes successfully. Production remains the self-hosted `kindrobots.org` deployment path; Vercel status is not authoritative.