### PR TITLE
refactor(mermaids-page): use kr-panel-flat for reader-reaction panel

### DIFF
--- a/components/pages/mermaids-page.vue
+++ b/components/pages/mermaids-page.vue
@@ -150,7 +150,7 @@
       </section>
 
       <section
-        class="mb-4 rounded-2xl border border-base-300 bg-base-100 p-5 shadow-sm"
+        class="mb-4 kr-panel-flat p-5 shadow-sm"
       >
         <div class="mb-3 flex items-center gap-3">
           <span


### PR DESCRIPTION
## What changed
- `components/pages/mermaids-page.vue`: the reader-reaction panel's hand-rolled `rounded-2xl border border-base-300 bg-base-100` base now uses `kr-panel-flat`, preserving `p-5 shadow-sm` as-is.

## Root cause / scope
Re-ran `utils/scripts/codemods/kr_panel_codemod.py --root .` (the byte-exact, allowlisted substitution tool from t-115/t-116) against current `main`. The previously-surfaced 47-occurrence/21-file pool from t-116 has since been fully consumed by later slices; this run found exactly one new byte-exact candidate. No geometry or behavior change — `kr-panel-flat` and the substituted tokens are visually identical.

Conductor: `interface-vision/t-104` (slice 45)

## Verification
- `eslint` on the changed file: clean.
- `prettier --check` on the changed file: pre-existing drift unrelated to this change (confirmed identical warning on baseline via `git stash`).
- `vue-tsc --noEmit`: one pre-existing unrelated error in `server/api/reactions/index.post.ts` (confirmed present on baseline via `git stash`); no new errors.
- `npm run test:layout-contract`: holds, 0 new violations (unrelated ratchet-improvement note on a different file, not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019N5KC9raR6KqvBKXAdGP5Z)_