### PR TITLE
refactor(art-manager): use kr-panel-flat for image-preview modal box

### DIFF
--- a/components/art/art-manager.vue
+++ b/components/art/art-manager.vue
@@ -176,7 +176,7 @@
       @close="clearArtPreview"
     >
       <div
-        class="modal-box flex h-[92vh] w-[96vw] max-w-7xl flex-col rounded-2xl border border-base-300 bg-base-100 p-3"
+        class="modal-box flex h-[92vh] w-[96vw] max-w-7xl flex-col kr-panel-flat p-3"
       >
         <div class="flex items-center justify-between gap-3 px-1 pb-3">
           <div class="min-w-0">


### PR DESCRIPTION
### Task
interface-vision/t-119: Re-check the kr-panel-flat DaisyUI-conflict skip pool for now-safe hand-migration candidates  (kind: software)

### What changed / what I produced
- `components/art/art-manager.vue`: the art-preview dialog's `.modal-box` root now uses `kr-panel-flat` instead of the hand-rolled `rounded-2xl border border-base-300 bg-base-100` trio. No geometry or behavior change.
- Re-examined all 3 files / 4 occurrences in `kr_panel_codemod.py`'s DaisyUI-conflict skip pool (`art-manager.vue`'s `modal-box`, `kr-stat-tile.vue`'s `stat`, `chat-gallery.vue`'s two `btn btn-ghost` occurrences). Only the `modal-box` case is safe to migrate — `kr-stat-tile.vue` and `chat-gallery.vue` stay as-is (see verification below); their original codemod exclusion was correct, not overly conservative.
- Did not touch the codemod's allowlist — this was a hand-verified, case-by-case migration per t-119's instructions, not a rule generalization.

### How I verified
Built the actual compiled Tailwind v4 + daisyUI v5 CSS (`@tailwindcss/postcss` against `assets/css/tailwind.css`) and loaded it in a real headless Chromium (Playwright, local `file://`, no network) with both the current and proposed class combinations for all 4 flagged occurrences, then diffed `getComputedStyle` (background-color, border-color/width/style, border-radius, box-shadow, padding):
- `art-manager.vue` modal-box: **identical** computed styles before/after. daisyUI's own component classes (`.modal-box`, `.stat`, `.btn`) are emitted inside the Tailwind `utilities` cascade layer (nested `daisyui.l1.l2...` sub-layers), not `components`, so ordinarily they'd beat a `components`-layer class like `.kr-panel-flat` — but `.modal-box` itself doesn't set background/border/radius/shadow, so there's nothing to conflict with; the utility values pass through untouched either way.
- `kr-stat-tile.vue` `.stat`: **not** identical — swapping to `kr-panel-flat` produces a mixed dashed/solid border (`.stat`'s own border rules partially win). Confirmed the existing exclusion (from slice 12) is correct; left unchanged.
- `chat-gallery.vue` both `btn btn-ghost` buttons: **not** identical — `.btn`'s own background/border/radius wins over `kr-panel-flat` (background goes transparent, border disappears, radius changes 16px→12px). Confirmed the existing exclusion is correct; left unchanged.

Also ran, on the changed file: `eslint` (clean), `prettier --check` (clean), `vue-tsc --noEmit` full project (one pre-existing, unrelated error in `server/api/reactions/index.post.ts`, confirmed present on baseline via `git stash`), `test:layout-contract` (holds, 0 new violations — the reported viewport-grid `-3` improvement is pre-existing baseline drift in `video-lora-picker.vue`, confirmed via `git stash`, unrelated to this change).

### Stakes
reversible

### Kaizen suggestion
`kr_panel_codemod.py`'s "unsafe extra tokens" heuristic could be sharpened for the `modal-box`-shaped case specifically: when the only co-occurring DaisyUI class doesn't itself declare background/border/radius/shadow (as opposed to `.stat`/`.btn`, which do), the substitution is provably safe without per-occurrence manual review. Not implemented here since it's a 1-occurrence win and the task explicitly asked for hand judgment, not allowlist expansion — leaving as a suggestion for whoever next revisits the codemod.

### Notes for reviewer
The kr-stat-tile.vue and chat-gallery.vue skip-pool entries are now considered resolved (verified-correct-to-skip), not just deferred — no follow-on task needed for them.

---
_Generated by [Claude Code](https://claude.ai/code/session_017hwqhXGQSQj89LdB81D1on)_