### PR TITLE
refactor(brainstorm-manager): use kr-container-wide for root layout

### DIFF
--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -1,6 +1,6 @@
 <template>
   <section
-    class="mx-auto flex w-full max-w-7xl flex-col gap-4 px-1 pb-8 sm:gap-5 sm:px-2"
+    class="kr-container-wide flex flex-col gap-4 px-1 pb-8 sm:gap-5 sm:px-2"
     aria-label="Brainstorm idea workbench"
     data-testid="brainstorm-manager"
   >


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed
`components/brainstorm/brainstorm-manager.vue`'s root `<section>` now uses `kr-container-wide` instead of the hand-rolled `mx-auto w-full max-w-7xl` trio (`kr-container-wide` = `mx-auto w-full max-w-7xl` per `assets/css/tailwind.css`). No geometry or behavior change.

Found via a fresh grep for the `mx-auto`+`w-full`+`max-w-*` root-element pattern this umbrella has used since slice 30 — the automated `kr_panel_codemod.py` pool (kr-panel-flat migrations) is now fully exhausted (confirmed 0 candidates, re-verified this session). The other six files matching the broader `mx-auto`+`w-full`+`max-w-` grep were already excluded in slice 31's note (messenger.vue, project-front-page.vue, achievement-popup.vue) or use non-6xl/7xl custom max-widths that `kr-container`/`kr-container-wide` don't cover (academy-timeline.vue, academy-styles-browser.vue, for-you-manager.vue use `max-w-[1600px]`/`max-w-[1800px]`).

### How I verified
- `eslint` on the changed file: clean
- `prettier --check`: pre-existing drift on this file, confirmed via `git stash` A/B check (not introduced by this change)
- `vue-tsc --noEmit` (full project): one pre-existing, unrelated error in `server/api/reactions/index.post.ts`, confirmed present on baseline via `git stash`
- `npm run test:layout-contract`: holds, 0 new violations (the reported `-3` viewport-grid improvement is pre-existing baseline drift in `video-lora-picker.vue`, confirmed via `git stash`, unrelated to this change)

### Stakes
reversible

---
_Generated by [Claude Code](https://claude.ai/code/session_019nxS4s49ibAK88T5kL4amu)_