### PR TITLE
refactor(admin): use kr-container-wide for social-drafts and achievement-art page roots

### DIFF
--- a/pages/admin/achievement-art.vue
+++ b/pages/admin/achievement-art.vue
@@ -1,6 +1,6 @@
 <template>
   <main class="kr-surface h-full min-h-0 overflow-hidden">
-    <div class="kr-scroll mx-auto w-full max-w-7xl space-y-4 p-4 md:p-6">
+    <div class="kr-scroll kr-container-wide space-y-4 p-4 md:p-6">
       <header class="kr-toolbar flex flex-wrap items-start justify-between gap-4">
         <div>
           <p class="text-xs font-black uppercase tracking-widest text-primary">

--- a/pages/admin/social-drafts.vue
+++ b/pages/admin/social-drafts.vue
@@ -1,6 +1,6 @@
 <template>
   <main class="kr-surface h-full min-h-0 overflow-hidden">
-    <div class="kr-scroll mx-auto w-full max-w-7xl space-y-4 p-4 md:p-6">
+    <div class="kr-scroll kr-container-wide space-y-4 p-4 md:p-6">
       <header
         class="kr-toolbar flex flex-wrap items-start justify-between gap-4"
       >


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 47: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- `pages/admin/social-drafts.vue` and `pages/admin/achievement-art.vue`: the scroll-body `<div>` (`kr-scroll mx-auto w-full max-w-7xl space-y-4 p-4 md:p-6`) now uses `kr-container-wide` in place of the hand-rolled `mx-auto w-full max-w-7xl` trio, keeping `kr-scroll` and the existing spacing/padding utilities as overrides. `kr-container-wide` is defined as exactly `mx-auto w-full max-w-7xl` (assets/css/tailwind.css:500-502), so this is a byte-exact substitution — no geometry or behavior change.
- Found via a fresh re-run of the `mx-auto`+`w-full`+`max-w-*` root-element grep this project's prior slices (30-32, 46) established. The `kr_panel_codemod.py` pool remains fully exhausted (0 candidates, confirmed this session). Of 8 files matching the broader grep, only these two are exact `max-w-7xl` matches with no competing primitive; the other six stay excluded per prior slices' documented reasoning (messenger.vue/project-front-page.vue/achievement-popup.vue: nested/bespoke; academy-timeline.vue/academy-styles-browser.vue/for-you-manager.vue: non-6xl/7xl custom max-widths kr-container/kr-container-wide don't cover).

### How I verified
- `eslint` on both files: clean
- `vue-tsc --noEmit`: clean (no errors, pre-existing or otherwise)
- `npm run test:layout-contract`: holds, 0 new violations (the -3 viewport-grid improvement is pre-existing baseline drift in `video-lora-picker.vue`, confirmed via `git stash`, unrelated to this change)
- `prettier --check`: `achievement-art.vue` flagged, confirmed pre-existing via `git stash` (present on baseline before this change)
- Confirmed the diff is exactly the two intended files (reverted incidental `prisma/generated/` regen noise from local dep provisioning before committing)

### Stakes
reversible

### Kaizen suggestion
None new — same standing suggestion as slice 46: the `kr_panel_codemod.py` pool is exhausted; a future slice should either broaden that codemod's matching or move to a different bounded shape (e.g. gallery empty/error-state placeholders, per t-104 slice 44's still-open FOR SILAS choice (b)).

### Notes for reviewer
Recurring multi-slice umbrella task — same pattern as slices 1-46. No open questions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9ZXsctFz6hEtWWrG7NaNw)_