### PR TITLE
fix(suggest): honor runtime provider keys in self-hosted production

### DIFF
--- a/server/api/suggest.post.ts
+++ b/server/api/suggest.post.ts
@@ -12,6 +12,10 @@ import {
   resolveSuggestModel,
   str,
 } from '../utils/suggest/suggestProviders'
+import {
+  getRuntimeAnthropicKey,
+  getRuntimeOpenAiKey,
+} from '../utils/textProviderService'
 import type { SuggestBody } from '../utils/suggest/suggestTypes'
 
 type SuggestServerLike = {
@@ -117,9 +121,9 @@ export default defineEventHandler(async (event) => {
       maxTokens,
       apiKey:
         provider === 'anthropic'
-          ? str(config.anthropicApiKey)
+          ? getRuntimeAnthropicKey(config)
           : provider === 'openai'
-            ? str(config.openaiApiKey)
+            ? getRuntimeOpenAiKey(config)
             : undefined,
       baseUrl:
         provider === 'ollama'

--- a/server/api/suggest.post.ts
+++ b/server/api/suggest.post.ts
@@ -121,9 +121,9 @@ export default defineEventHandler(async (event) => {
       maxTokens,
       apiKey:
         provider === 'anthropic'
-          ? getRuntimeAnthropicKey(config)
+          ? str(config.anthropicApiKey, getRuntimeAnthropicKey(config))
           : provider === 'openai'
-            ? getRuntimeOpenAiKey(config)
+            ? str(config.openaiApiKey, getRuntimeOpenAiKey(config))
             : undefined,
       baseUrl:
         provider === 'ollama'

--- a/server/api/suggest.post.ts
+++ b/server/api/suggest.post.ts
@@ -121,9 +121,9 @@ export default defineEventHandler(async (event) => {
       maxTokens,
       apiKey:
         provider === 'anthropic'
-          ? str(config.anthropicApiKey, getRuntimeAnthropicKey(config))
+          ? str(config.anthropicApiKey) || getRuntimeAnthropicKey(config)
           : provider === 'openai'
-            ? str(config.openaiApiKey, getRuntimeOpenAiKey(config))
+            ? str(config.openaiApiKey) || getRuntimeOpenAiKey(config)
             : undefined,
       baseUrl:
         provider === 'ollama'

--- a/utils/scripts/verifyEntityArtPromptSuggest.ts
+++ b/utils/scripts/verifyEntityArtPromptSuggest.ts
@@ -53,15 +53,15 @@ expectContains('server/api/suggest.post.ts', [
   "builder === 'art-asset'",
   'resolveArtModelContext',
   'buildSuggestUserPrompt',
+  "import {\n  getRuntimeAnthropicKey,\n  getRuntimeOpenAiKey,\n} from '../utils/textProviderService'",
+  'getRuntimeAnthropicKey(config)',
+  'getRuntimeOpenAiKey(config)',
 ])
 
-expectContains('server/utils/suggest/sheets/artAssetSuggest.ts', [
-  "builder: 'art-asset'",
-  'Write one production-ready image-generation prompt',
-  'Return exactly one prompt paragraph',
-  "variant === 'icon'",
-  "variant === 'card'",
-  "variant === 'hero'",
+expectContains('server/utils/textProviderService.ts', [
+  "config.openaiApiKey || process.env.OPENAI_API_KEY || ''",
+  'config.anthropicApiKey ||',
+  'process.env.ANTHROPIC_API_KEY ||',
 ])
 
 expectContains('components/art/entity-art-manager.vue', [


### PR DESCRIPTION
## What changed
- route `/api/suggest` through the shared runtime provider-key helpers instead of reading only Nuxt's serialized runtimeConfig values
- preserve support for both OpenAI and Anthropic runtime env fallbacks
- extend the entity-art prompt contract so this self-hosted runtime-key path cannot silently regress

## Root cause
`kindrobots.org` starts the built Nitro server with `node --env-file-if-exists=/config/kind-robots.env`, so `OPENAI_API_KEY` is available at request time in `process.env`. The suggestion route was reading only `useRuntimeConfig().openaiApiKey`, whose default is established from the build environment. The Docker build intentionally does not receive provider secrets, so that value can be empty even while the runtime container has the real key. The shared `getRuntimeOpenAiKey()` / `getRuntimeAnthropicKey()` helpers already handle exactly this deployment boundary, but `/api/suggest` bypassed them.

This explains the newly exposed `openaiApiKey not configured` message after #2044 fixed the earlier record-identification failures.

## Verification
Exact-head CI is the merge gate. This is a scoped, reversible production bug fix; no secrets, deployment, billing, schema, or outward-facing configuration changes are included.