### PR TITLE
fix(davinci): reconnect in-flight chapter/ending art jobs after a reload

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -353,6 +353,12 @@ jobs:
       - name: Da Vinci art-run guard
         run: npm run test:davinci-art-run-guard
 
+      - name: Da Vinci art-resume guard self-test
+        run: npm run test:davinci-art-resume-guard-selftest
+
+      - name: Da Vinci art-resume guard
+        run: npm run test:davinci-art-resume-guard
+
       - name: Serendipity Voice poll guard self-test
         run: npm run test:serendipity-voice-poll-guard-selftest
 

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -716,6 +716,13 @@ type NarrationMode = 'ai' | 'curated'
 const MIN_CHAPTERS_BEFORE_ENDING = 6
 
 const STORAGE_KEY = 'davinci-active-life-run-id'
+// Client-only cache of the active run's in-flight art job states (davinci/t-021
+// slice 14). See the doc comment on persistArtJobs()/resumePendingArtJobs()
+// below for the bug this closes: unlike storybookStore's beats, a queued or
+// rendering LifeRunArt job has no server-side row until it reaches 'done'
+// (persistLifeRunArt only fires on a done poll result), so hydrateArtFromRun()
+// alone can never see it -- this key is what lets a reload find it again.
+const ART_JOBS_STORAGE_KEY = 'davinci-active-life-run-art-jobs'
 
 const userStore = useUserStore()
 const achievementStore = useAchievementStore()
@@ -949,6 +956,7 @@ function updateChapterArt(
   if (run.value?.id !== runId) return
   const wasDone = chapterArt.value[chapter]?.status === 'done'
   chapterArt.value = { ...chapterArt.value, [chapter]: art }
+  persistArtJobs()
   if (!wasDone && art.status === 'done' && art.artImageId) {
     void persistLifeRunArt(
       chapter,
@@ -969,8 +977,82 @@ function updateEndingArt(runId: number, art: NarrativeArtJobState) {
   if (run.value?.id !== runId) return
   const wasDone = endingArt.value?.status === 'done'
   endingArt.value = art
+  persistArtJobs()
   if (!wasDone && art.status === 'done' && art.artImageId) {
     void persistLifeRunArt(null, 'ENDING', art.promptString, art.artImageId)
+  }
+}
+
+// Everything narrativeArtJobsHelper's poll/submit path knows about the active
+// run's art jobs lives only in the chapterArt/endingArt refs above -- a
+// queued or rendering job has no server row until persistLifeRunArt() fires
+// on a 'done' result. A page reload (or any remount: closing the tab,
+// navigating away and back) wipes those refs along with the rest of this
+// component's setup-scoped state, and hydrateArtFromRun() below only ever
+// rebuilds *terminal* 'done' states from the server's LifeRunArt rows -- so a
+// job that was still queued/rendering (or had already failed, with its retry
+// button showing) at the moment of reload was previously lost outright: no
+// busy indicator, no retry button, and nothing left holding its dedupeKey or
+// jobId to reconnect polling, even though the backend job could still be
+// running or have already finished with an orphaned ArtImage never attached
+// to the run. Best-effort and non-blocking, same as persistLifeRunArt --
+// losing this cache (private browsing, a cleared storage, JSON.stringify
+// somehow throwing) only means a slower reconnect on reload, not a broken run.
+function persistArtJobs() {
+  if (!run.value) return
+  try {
+    localStorage.setItem(
+      ART_JOBS_STORAGE_KEY,
+      JSON.stringify({
+        runId: run.value.id,
+        chapterArt: chapterArt.value,
+        endingArt: endingArt.value,
+      }),
+    )
+  } catch {
+    // best-effort cache -- see the doc comment above.
+  }
+}
+
+// The other half of persistArtJobs() above: called once per resumeRun(),
+// right after hydrateArtFromRun() has rebuilt whatever terminal art the
+// server already knows about. Reuses narrativeArtJobsHelper's own resume()
+// (already relied on for exactly this by storybookStore's
+// resumeNarrativeArtJobs()) rather than re-deriving its recover-or-resubmit
+// logic here -- resume() itself no-ops for a 'done'/'failed'/'cancelled'
+// state, so it is safe to call unconditionally for every cached entry the
+// server hydration didn't already cover. Seeding chapterArt/endingArt via
+// updateChapterArt()/updateEndingArt() first (rather than leaving the UI
+// blank until the first poll response) also restores a failed job's retry
+// button immediately, not just a still-in-flight job's busy indicator.
+function resumePendingArtJobs(runId: number) {
+  let cached: {
+    runId?: number
+    chapterArt?: Record<string, NarrativeArtJobState>
+    endingArt?: NarrativeArtJobState | null
+  } | null = null
+  try {
+    const raw = localStorage.getItem(ART_JOBS_STORAGE_KEY)
+    cached = raw ? JSON.parse(raw) : null
+  } catch {
+    cached = null
+  }
+  if (!cached || cached.runId !== runId) return
+
+  for (const [key, state] of Object.entries(cached.chapterArt ?? {})) {
+    const chapter = Number(key)
+    if (!state || !chapter || chapterArt.value[chapter]) continue
+    updateChapterArt(runId, chapter, state)
+    narrativeArtJobs.resume(state, (art) =>
+      updateChapterArt(runId, chapter, art),
+    )
+  }
+
+  if (cached.endingArt && !endingArt.value) {
+    updateEndingArt(runId, cached.endingArt)
+    narrativeArtJobs.resume(cached.endingArt, (art) =>
+      updateEndingArt(runId, art),
+    )
   }
 }
 
@@ -1066,6 +1148,7 @@ async function resumeRun(id: number) {
   statMap.value = statsToMap(response.data.Stats || [])
   playedCount.value = response.data.Choices?.length ?? 0
   hydrateArtFromRun(response.data)
+  resumePendingArtJobs(response.data.id)
 
   if (response.data.status === 'COMPLETE' && response.data.Ending) {
     endingData.value = response.data.Ending
@@ -1242,6 +1325,7 @@ async function resolveLife() {
 
 function playAgain() {
   localStorage.removeItem(STORAGE_KEY)
+  localStorage.removeItem(ART_JOBS_STORAGE_KEY)
   run.value = null
   statMap.value = {}
   playedCount.value = 0

--- a/package.json
+++ b/package.json
@@ -117,6 +117,8 @@
     "test:davinci-narrate-stale-response-guard": "tsx utils/scripts/verifyDaVinciNarrateStaleResponseGuard.ts",
     "test:davinci-art-run-guard-selftest": "tsx utils/scripts/verifyDaVinciArtRunGuard.test.ts",
     "test:davinci-art-run-guard": "tsx utils/scripts/verifyDaVinciArtRunGuard.ts",
+    "test:davinci-art-resume-guard-selftest": "tsx utils/scripts/verifyDaVinciArtResumeGuard.test.ts",
+    "test:davinci-art-resume-guard": "tsx utils/scripts/verifyDaVinciArtResumeGuard.ts",
     "test:serendipity-voice-poll-guard-selftest": "tsx utils/scripts/verifySerendipityVoicePollGuard.test.ts",
     "test:serendipity-voice-poll-guard": "tsx utils/scripts/verifySerendipityVoicePollGuard.ts",
     "test:serendipity-voice-cursor-reset-selftest": "tsx utils/scripts/verifySerendipityVoiceCursorReset.test.ts",

--- a/utils/scripts/verifyDaVinciArtResumeGuard.test.ts
+++ b/utils/scripts/verifyDaVinciArtResumeGuard.test.ts
@@ -1,0 +1,239 @@
+// /utils/scripts/verifyDaVinciArtResumeGuard.test.ts
+//
+// Regression test for checkArtResumeGuard() in verifyDaVinciArtResumeGuard.ts
+// (davinci/t-021 slice 14). Exercises the real check against synthetic
+// component-shaped fixtures covering: the fixed shape (both update
+// functions persist, resumePendingArtJobs() reads the cache and resumes
+// both slots while seeding chapterArt first, resumeRun() calls it after
+// hydrating, playAgain() clears the cache), and regressions dropping each
+// piece individually.
+import assert from 'node:assert/strict'
+
+import { checkArtResumeGuard } from './verifyDaVinciArtResumeGuard.js'
+
+function fixture(opts: {
+  updateChapterPersist: string
+  updateEndingPersist: string
+  resumePendingBody: string
+  resumeRunHydrate: string
+  resumeRunResume: string
+  playAgainClear: string
+}): string {
+  return `
+<script setup lang="ts">
+function updateChapterArt(runId: number, chapter: number, art: NarrativeArtJobState) {
+  if (run.value?.id !== runId) return
+  chapterArt.value = { ...chapterArt.value, [chapter]: art }
+  ${opts.updateChapterPersist}
+}
+
+function updateEndingArt(runId: number, art: NarrativeArtJobState) {
+  if (run.value?.id !== runId) return
+  endingArt.value = art
+  ${opts.updateEndingPersist}
+}
+
+function persistArtJobs() {
+  if (!run.value) return
+  localStorage.setItem(ART_JOBS_STORAGE_KEY, JSON.stringify({
+    runId: run.value.id,
+    chapterArt: chapterArt.value,
+    endingArt: endingArt.value,
+  }))
+}
+
+function resumePendingArtJobs(runId: number) {
+  ${opts.resumePendingBody}
+}
+
+function requestChapterArt(chapter: number, artPrompt: string) {
+  if (!run.value || chapterArt.value[chapter]) return
+}
+
+function hydrateArtFromRun(data: LifeRunRecord) {
+  chapterArt.value = {}
+  endingArt.value = null
+}
+
+async function resumeRun(id: number) {
+  phase.value = 'loading'
+  run.value = response.data
+  ${opts.resumeRunHydrate}
+  ${opts.resumeRunResume}
+
+  if (response.data.status === 'COMPLETE' && response.data.Ending) {
+    phase.value = 'ending'
+  }
+}
+
+async function startLife() {
+  submitting.value = true
+}
+
+function playAgain() {
+  localStorage.removeItem(STORAGE_KEY)
+  ${opts.playAgainClear}
+  run.value = null
+}
+
+function abandonRun() {
+  if (submitting.value) return
+}
+</script>
+`
+}
+
+const FIXED_ARGS = {
+  updateChapterPersist: 'persistArtJobs()',
+  updateEndingPersist: 'persistArtJobs()',
+  resumePendingBody: `
+    const raw = localStorage.getItem(ART_JOBS_STORAGE_KEY)
+    const cached = raw ? JSON.parse(raw) : null
+    if (!cached || cached.runId !== runId) return
+    for (const [key, state] of Object.entries(cached.chapterArt ?? {})) {
+      const chapter = Number(key)
+      updateChapterArt(runId, chapter, state)
+      narrativeArtJobs.resume(state, (art) => updateChapterArt(runId, chapter, art))
+    }
+    if (cached.endingArt && !endingArt.value) {
+      updateEndingArt(runId, cached.endingArt)
+      narrativeArtJobs.resume(cached.endingArt, (art) => updateEndingArt(runId, art))
+    }
+  `,
+  resumeRunHydrate: 'hydrateArtFromRun(response.data)',
+  resumeRunResume: 'resumePendingArtJobs(response.data.id)',
+  playAgainClear: 'localStorage.removeItem(ART_JOBS_STORAGE_KEY)',
+}
+
+const FIXED = fixture(FIXED_ARGS)
+
+// Pre-fix shape: none of slice 14's additions exist at all.
+const BUGGY = fixture({
+  updateChapterPersist: '',
+  updateEndingPersist: '',
+  resumePendingBody: '',
+  resumeRunHydrate: 'hydrateArtFromRun(response.data)',
+  resumeRunResume: '',
+  playAgainClear: '',
+})
+
+function run(): void {
+  const fixedErrors = checkArtResumeGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const buggyErrors = checkArtResumeGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    7,
+    `expected the buggy fixture to fail all seven checks, got: ${JSON.stringify(buggyErrors)}`,
+  )
+
+  // Each piece dropped individually still fails only its own check(s).
+  const missingChapterPersist = checkArtResumeGuard(
+    fixture({ ...FIXED_ARGS, updateChapterPersist: '' }),
+  )
+  assert.equal(missingChapterPersist.length, 1)
+  assert.ok(
+    missingChapterPersist.some((e) =>
+      /updateChapterArt\(\) no longer calls persistArtJobs\(\)/.test(e),
+    ),
+  )
+
+  const missingEndingPersist = checkArtResumeGuard(
+    fixture({ ...FIXED_ARGS, updateEndingPersist: '' }),
+  )
+  assert.equal(missingEndingPersist.length, 1)
+  assert.ok(
+    missingEndingPersist.some((e) =>
+      /updateEndingArt\(\) no longer calls persistArtJobs\(\)/.test(e),
+    ),
+  )
+
+  const missingResumeCall = checkArtResumeGuard(
+    fixture({
+      ...FIXED_ARGS,
+      resumePendingBody: `
+        const raw = localStorage.getItem(ART_JOBS_STORAGE_KEY)
+        const cached = raw ? JSON.parse(raw) : null
+        if (!cached || cached.runId !== runId) return
+        for (const [key, state] of Object.entries(cached.chapterArt ?? {})) {
+          const chapter = Number(key)
+          updateChapterArt(runId, chapter, state)
+        }
+      `,
+    }),
+  )
+  assert.equal(missingResumeCall.length, 1)
+  assert.ok(
+    missingResumeCall.some((e) =>
+      /no longer calls narrativeArtJobs\.resume\(\) for both/.test(e),
+    ),
+  )
+
+  const missingSeed = checkArtResumeGuard(
+    fixture({
+      ...FIXED_ARGS,
+      resumePendingBody: `
+        const raw = localStorage.getItem(ART_JOBS_STORAGE_KEY)
+        const cached = raw ? JSON.parse(raw) : null
+        if (!cached || cached.runId !== runId) return
+        for (const [key, state] of Object.entries(cached.chapterArt ?? {})) {
+          const chapter = Number(key)
+          narrativeArtJobs.resume(state, (art) => updateChapterArt(runId, chapter, art))
+        }
+        if (cached.endingArt && !endingArt.value) {
+          narrativeArtJobs.resume(cached.endingArt, (art) => updateEndingArt(runId, art))
+        }
+      `,
+    }),
+  )
+  assert.equal(missingSeed.length, 1)
+  assert.ok(missingSeed.some((e) => /no longer seeds chapterArt via/.test(e)))
+
+  const missingResumeRunCall = checkArtResumeGuard(
+    fixture({ ...FIXED_ARGS, resumeRunResume: '' }),
+  )
+  assert.equal(missingResumeRunCall.length, 1)
+  assert.ok(
+    missingResumeRunCall.some((e) =>
+      /resumeRun\(\) no longer calls resumePendingArtJobs\(\)/.test(e),
+    ),
+  )
+
+  const wrongOrder = checkArtResumeGuard(
+    fixture({
+      ...FIXED_ARGS,
+      resumeRunHydrate: '',
+      resumeRunResume:
+        'resumePendingArtJobs(response.data.id)\n  hydrateArtFromRun(response.data)',
+    }),
+  )
+  assert.equal(wrongOrder.length, 1)
+  assert.ok(
+    wrongOrder.some((e) =>
+      /before \(or without\) hydrateArtFromRun\(\)/.test(e),
+    ),
+  )
+
+  const missingPlayAgainClear = checkArtResumeGuard(
+    fixture({ ...FIXED_ARGS, playAgainClear: '' }),
+  )
+  assert.equal(missingPlayAgainClear.length, 1)
+  assert.ok(
+    missingPlayAgainClear.some((e) =>
+      /playAgain\(\) no longer removes ART_JOBS_STORAGE_KEY/.test(e),
+    ),
+  )
+
+  console.log(
+    'Da Vinci art-resume guard self-test passed: buggy fixture fails all ' +
+      'seven checks, fixed fixture passes, and each individual regression ' +
+      'fails only its own check.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyDaVinciArtResumeGuard.ts
+++ b/utils/scripts/verifyDaVinciArtResumeGuard.ts
@@ -1,0 +1,213 @@
+// /utils/scripts/verifyDaVinciArtResumeGuard.ts
+//
+// Regression guard (davinci/t-021 slice 14) -- a queued or rendering chapter/
+// ending art job in components/conductor/davinci-page.vue has no server-side
+// row until it reaches 'done' (persistLifeRunArt() in updateChapterArt()/
+// updateEndingArt() only POSTs to /api/davinci/runs/{id}/art on a 'done'
+// result with an artImageId). hydrateArtFromRun() rebuilds chapterArt/
+// endingArt from the server's LifeRunArt rows on every resumeRun() call, but
+// since those rows only ever cover *terminal* 'done' art, a job that was
+// still queued/rendering -- or had already failed, with its retry button
+// showing -- at the moment of a page reload (or any other remount: closing
+// the tab, navigating away and back) was silently lost: no busy indicator,
+// no retry button, and nothing left holding its dedupeKey or jobId to
+// reconnect polling, even though the backend job could still be running or
+// have already finished with an ArtImage that never gets attached to the
+// run. Same "long-lived async state the component loses track of" shape as
+// the stale-response guards above, but the failure direction is reversed --
+// those guard against a stale result *arriving late and being misapplied*,
+// this guards against an in-flight result *never being tracked again at
+// all*.
+//
+// The fix mirrors storybookStore.ts's own resumeNarrativeArtJobs() (its
+// `session.value.beats[].art` is persisted to localStorage in full and
+// resumeNarrativeArtJobs() calls narrativeArtJobsHelper's resume() -- which
+// already no-ops safely for a terminal state -- unconditionally on every
+// beat that has one): here, updateChapterArt()/updateEndingArt() persist the
+// current chapterArt/endingArt refs to a dedicated localStorage key on every
+// transition, and resumeRun() calls resumePendingArtJobs() right after
+// hydrateArtFromRun() to seed back and reconnect anything the server
+// hydration didn't already cover.
+//
+// This asserts the textual shape of the fix stays in place: both update
+// functions persist on every call, resumePendingArtJobs() reads the cache
+// and calls narrativeArtJobs.resume() for both the chapter and ending slots,
+// resumeRun() calls it after hydrating from the server, and playAgain()
+// clears the cache along with the existing active-run-id key. Deliberately
+// scoped via narrow textual checks, mirroring this project's other guards
+// over a general-purpose static analyzer (see verifyDaVinciDimensionToneGuard.ts).
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const COMPONENT_PATH = join(
+  repositoryRoot,
+  'components/conductor/davinci-page.vue',
+)
+
+function extractFunction(
+  content: string,
+  startMarker: string,
+  endMarkers: string[],
+): string | null {
+  const startIndex = content.indexOf(startMarker)
+  if (startIndex === -1) return null
+
+  let end = content.length
+  for (const marker of endMarkers) {
+    const markerIndex = content.indexOf(marker, startIndex + startMarker.length)
+    if (markerIndex !== -1 && markerIndex < end) end = markerIndex
+  }
+
+  return content.slice(startIndex, end)
+}
+
+export function checkArtResumeGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const updateChapterArt = extractFunction(
+    content,
+    'function updateChapterArt(',
+    ['function updateEndingArt(', 'async function resumeRun('],
+  )
+  if (updateChapterArt && !/persistArtJobs\(\)/.test(updateChapterArt)) {
+    errors.push(
+      'updateChapterArt() no longer calls persistArtJobs() -- a queued or ' +
+        "rendering chapter art job's state won't survive a page reload, " +
+        'so it would be silently lost instead of reconnecting on resume.',
+    )
+  }
+
+  const updateEndingArt = extractFunction(
+    content,
+    'function updateEndingArt(',
+    [
+      'function persistArtJobs(',
+      'function resumePendingArtJobs(',
+      'async function resumeRun(',
+    ],
+  )
+  if (updateEndingArt && !/persistArtJobs\(\)/.test(updateEndingArt)) {
+    errors.push(
+      'updateEndingArt() no longer calls persistArtJobs() -- a queued or ' +
+        "rendering ending art job's state won't survive a page reload, " +
+        'so it would be silently lost instead of reconnecting on resume.',
+    )
+  }
+
+  const resumePendingArtJobs = extractFunction(
+    content,
+    'function resumePendingArtJobs(',
+    ['function requestChapterArt(', 'function hydrateArtFromRun('],
+  )
+  if (!resumePendingArtJobs) {
+    errors.push(
+      'Could not find `function resumePendingArtJobs(` in davinci-page.vue ' +
+        '-- without it, a cached queued/rendering/failed art job from a ' +
+        'prior page load is never seeded back into chapterArt/endingArt or ' +
+        'reconnected to polling.',
+    )
+  } else {
+    if (
+      !/localStorage\.getItem\(\s*ART_JOBS_STORAGE_KEY\s*\)/.test(
+        resumePendingArtJobs,
+      )
+    ) {
+      errors.push(
+        'resumePendingArtJobs() no longer reads ART_JOBS_STORAGE_KEY from ' +
+          'localStorage -- it has nothing to resume from.',
+      )
+    }
+    const chapterResumeCount = (
+      resumePendingArtJobs.match(/narrativeArtJobs\.resume\(/g) || []
+    ).length
+    if (chapterResumeCount < 2) {
+      errors.push(
+        'resumePendingArtJobs() no longer calls narrativeArtJobs.resume() ' +
+          'for both the chapter-art loop and the ending-art slot -- a ' +
+          'cached in-flight job would be seeded into the UI but never ' +
+          'reconnected to its poll, so it would stay stuck showing a busy ' +
+          'state that never resolves.',
+      )
+    }
+    if (
+      !/updateChapterArt\(runId,\s*chapter,\s*state\)/.test(
+        resumePendingArtJobs,
+      )
+    ) {
+      errors.push(
+        'resumePendingArtJobs() no longer seeds chapterArt via ' +
+          'updateChapterArt() before resuming -- a cached failed job would ' +
+          "lose its retry button until the next poll, and a queued job's " +
+          'busy indicator would be blank until the first poll response.',
+      )
+    }
+  }
+
+  const resumeRun = extractFunction(content, 'async function resumeRun(', [
+    'async function startLife(',
+  ])
+  if (resumeRun) {
+    const hydrateIndex = resumeRun.indexOf('hydrateArtFromRun(')
+    const resumePendingIndex = resumeRun.indexOf('resumePendingArtJobs(')
+    if (resumePendingIndex === -1) {
+      errors.push(
+        'resumeRun() no longer calls resumePendingArtJobs() -- a page ' +
+          "reload while an art job is still queued/rendering won't " +
+          'reconnect it, even though hydrateArtFromRun() only ever ' +
+          'restores terminal (done) art from the server.',
+      )
+    } else if (hydrateIndex === -1 || resumePendingIndex < hydrateIndex) {
+      errors.push(
+        'resumeRun() calls resumePendingArtJobs() before (or without) ' +
+          'hydrateArtFromRun() -- the resume step needs to run after the ' +
+          "server's terminal art has already been loaded, so it only " +
+          "fills in what the server hydration didn't cover.",
+      )
+    }
+  }
+
+  const playAgain = extractFunction(content, 'function playAgain(', [
+    'function abandonRun(',
+  ])
+  if (
+    playAgain &&
+    !/localStorage\.removeItem\(\s*ART_JOBS_STORAGE_KEY\s*\)/.test(playAgain)
+  ) {
+    errors.push(
+      'playAgain() no longer removes ART_JOBS_STORAGE_KEY from ' +
+        "localStorage -- an abandoned or completed run's cached art jobs " +
+        'would leak into the next run resumePendingArtJobs() sees.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(COMPONENT_PATH, 'utf8')
+  const errors = checkArtResumeGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Da Vinci art-resume guard contract failed in davinci-page.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Da Vinci art-resume guard contract passed: a queued, rendering, or ' +
+      'failed chapter/ending art job is cached to localStorage and ' +
+      "reconnected on resumeRun(), so a page reload can't silently lose " +
+      "track of an in-flight illustration the server hasn't persisted yet.",
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Task
davinci/t-021 slice 14 (Da Vinci visual style and interaction polish pass) — per
slice 13's own recommendation, this slice tried scripting/tracing an actual
async-race reproduction in the play loop rather than a purely static audit,
and found a new correctness bug in the same "long-lived async callback +
component state" family as slices 12/13.

## What changed
**Root cause:** a chapter or ending art job's *in-flight* state (`queueing`,
`queued`, `rendering`, or `failed`/`cancelled` with its retry button showing)
lives only in `davinci-page.vue`'s setup-scoped `chapterArt`/`endingArt` refs.
`persistLifeRunArt()` only POSTs a `LifeRunArt` row to the server once a poll
sees `status: 'done'` — so `hydrateArtFromRun()`, which rebuilds those refs
purely from the server's `LifeRunArt` rows on every `resumeRun()`, can only
ever restore *terminal* art. A page reload (or any other remount: closing the
tab, navigating away and back) while a job was still in flight silently
dropped it: no busy indicator, no retry button, and nothing left holding its
`dedupeKey`/`jobId` to reconnect polling — even though the backend job could
still be running, or could already have finished with an `ArtImage` that
never gets attached to the run's `LifeRunArt` row at all.

This is the twin of slice 13's art-run bug (also in `updateChapterArt()`/
`updateEndingArt()`): that one guarded against a *stale* result arriving
late and overwriting the *wrong* run; this one guards against an *in-flight*
result for the *same* run never being tracked again after a remount.

**Fix**, mirroring `storybookStore.ts`'s existing `resumeNarrativeArtJobs()`
pattern (its `session.value.beats[].art` is persisted to localStorage in
full, and it calls `narrativeArtJobsHelper`'s `resume()` — which already
no-ops safely for a terminal state — unconditionally on every beat that has
one):
- `updateChapterArt()`/`updateEndingArt()` now call a new `persistArtJobs()`
  on every transition, caching the current `chapterArt`/`endingArt` to a new
  `ART_JOBS_STORAGE_KEY` localStorage entry (best-effort, wrapped in
  try/catch, same as `persistLifeRunArt`'s own best-effort framing).
- A new `resumePendingArtJobs(runId)` is called in `resumeRun()` right after
  `hydrateArtFromRun()`: for any chapter/ending the server hydration didn't
  already cover, it seeds the cached state back in via
  `updateChapterArt()`/`updateEndingArt()` (so a failed job's retry button
  reappears immediately) and calls `narrativeArtJobs.resume()` to reconnect
  polling for anything still queued/rendering.
- `playAgain()` clears `ART_JOBS_STORAGE_KEY` alongside the existing
  active-run-id key.

Files touched: `components/conductor/davinci-page.vue`.

New guard: `utils/scripts/verifyDaVinciArtResumeGuard.ts` +
`verifyDaVinciArtResumeGuard.test.ts`, wired into `package.json`
(`test:davinci-art-resume-guard[-selftest]`) and
`.github/workflows/contract-tests.yml`, following the exact pattern of the
prior 13 `verifyDaVinci*` guards.

## How I verified
- New guard round-trip: `git stash` the component change, ran
  `npx tsx utils/scripts/verifyDaVinciArtResumeGuard.ts` → **fails** (5
  errors: missing persistArtJobs calls, missing resumePendingArtJobs,
  missing resumeRun wiring, missing playAgain cleanup). `git stash pop`,
  ran again → **passes**.
- `npm run test:davinci-art-resume-guard-selftest` → **pass** (7/7 synthetic
  regressions each caught individually, fixed fixture clean).
- `npm run test:davinci-art-resume-guard` → **pass** against the real file.
- `npm run test:davinci-art-run-guard[-selftest]` and all 11 other existing
  `verifyDaVinci*` guards/self-tests (dimension-tone, narration-error-tone,
  resolve-panel, narrating-status, resuming-status, choice-list,
  dimension-group, narration-error-role, chapter-focus, phase-focus,
  narrate-stale-response) → **all still pass**, unaffected.
- `npm run test:davinci-narration` → **pass** (unaffected, narration-layer
  contract).
- `npx eslint components/conductor/davinci-page.vue
  utils/scripts/verifyDaVinciArtResumeGuard.ts
  utils/scripts/verifyDaVinciArtResumeGuard.test.ts` → **clean**, no errors.
- `npx prettier --check` on the same files → **clean**.
- `npx vue-tsc --noEmit` (repo-wide) → same single pre-existing baseline
  error in `server/api/reactions/index.post.ts` (confirmed via `git stash`
  before/after — identical either way, unrelated to this change) and no new
  errors.
- `npm run test:layout-contract` → holds, no new violations (reports an
  unrelated pre-existing 3-entry baseline improvement opportunity in
  `video-lora-picker.vue`, not touched by this PR).
- `git status --porcelain` before committing showed only the 5 intended
  files.

## Stakes: reversible
Client-only change (one Vue component + a new localStorage key), fully
additive and behind existing guard rails (`narrativeArtJobsHelper.resume()`
already no-ops for terminal/failed states). No server, schema, or API
changes. Easy to revert as a single commit if anything looks off.

## Flags for Reviewer
- The new localStorage cache (`davinci-active-life-run-art-jobs`) stores
  full `NarrativeArtJobState` objects (prompt text, dedupeKey, etc.) client
  side, same category of data `storybookStore.ts` already persists this way
  for its own sessions — flagging in case that convention wants a second
  look at some point, not something I think blocks this PR.
- I could not exercise this live (no dev server / browser in this sandbox,
  per AGENTS.md's documented Cross-repo-tasks constraint) — verification is
  static (guard round-trip) plus eslint/tsc/prettier, same as every prior
  slice's fixes.
- `resumePendingArtJobs()` is called unconditionally in `resumeRun()`,
  including the `resolveLife()` → `resumeRun(sameRunId)` path (not just the
  onMounted/page-reload path). In the same-session case this is a harmless
  redundant `narrativeArtJobsHelper.resume()` call (it clears/reschedules
  the existing poll timer for the same dedupeKey rather than duplicating
  it), traded for a simpler, single call site — flagging the tradeoff
  explicitly in case a reviewer prefers scoping it to the reload path only.

## Kaizen suggestion
The recurring theme across slices 12-14 is that async work
(`narrativeArtJobsHelper`'s poll, `narrateChapter()`'s fetch) outlives this
component's own state, and every fix so far has been a bespoke guard
threaded through by hand. If Da Vinci or another narrative surface adds a
third or fourth long-lived async job type, it might be worth promoting
`narrativeArtJobsHelper`'s resume/cache pattern (already duplicated now
between `storybookStore.ts` and `davinci-page.vue`) into a small shared
composable (`usePersistedNarrativeArtJobs(storageKey, runId)` or similar)
rather than hand-rolling the localStorage cache + resume-on-hydrate dance a
third time in whichever surface needs it next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bhsy1h9KMuMn3avxedxgJd)_