### PR TITLE
fix(model-builder): ground AI drafts in source canon after a run resume (t-029 cycle 56)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -854,6 +854,12 @@ jobs:
       - name: Model Builder batch busy-item exclusion guard contract
         run: npm run test:model-builder-batch-busy-item-exclusion-guard
 
+      - name: Model Builder draft source-snapshot guard self-test
+        run: npm run test:model-builder-draft-source-snapshot-guard-selftest
+
+      - name: Model Builder draft source-snapshot guard contract
+        run: npm run test:model-builder-draft-source-snapshot-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -362,6 +362,8 @@
     "test:model-builder-contract-tests-coverage-guard": "tsx utils/scripts/verifyModelBuilderContractTestsCoverageGuard.ts",
     "test:model-builder-batch-busy-item-exclusion-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchBusyItemExclusionGuard.test.ts",
     "test:model-builder-batch-busy-item-exclusion-guard": "tsx utils/scripts/verifyModelBuilderBatchBusyItemExclusionGuard.ts",
+    "test:model-builder-draft-source-snapshot-guard-selftest": "tsx utils/scripts/verifyModelBuilderDraftSourceSnapshotGuard.test.ts",
+    "test:model-builder-draft-source-snapshot-guard": "tsx utils/scripts/verifyModelBuilderDraftSourceSnapshotGuard.ts",
     "test:storybook-active-story-resume-guard": "npx tsx utils/scripts/verifyStorybookActiveStoryResumeGuard.ts",
     "test:storybook-answer-input-preservation-guard": "node utils/scripts/verifyStorybookAnswerInputPreservationGuard.mjs",
     "test:storybook-answer-rollback-guard": "node utils/scripts/verifyStorybookAnswerRollbackGuard.mjs",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1280,7 +1280,21 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
               expectedFields: fieldsBrief(targetModel),
               pitch: item.pitch,
               fields: item.fieldsDraft,
-              source: state.selectedSource ?? undefined,
+              // state.selectedSource is only ever set by an in-session
+              // selectSource() call and is deliberately nulled on resume
+              // (see adaptRun's/resumeRun's own comments, model-builder/
+              // t-029 cycle 24) -- so after resuming a run (a reload, or
+              // reopening one from Run History), this was always undefined
+              // and the suggest sheet's whole canon-grounding block
+              // (name/class/species/personality/backstory/etc., see
+              // modelBuilderSuggest.ts's buildSourceContext) silently
+              // vanished from every AI draft request, with no error, no
+              // matter how well-populated the record actually was. Fall
+              // back to the run's persisted sourceSnapshot first, matching
+              // model-builder-progress-matrix.vue's identical `source`
+              // computed precedence for the same resume-survival reason.
+              source:
+                state.run.sourceSnapshot ?? state.selectedSource ?? undefined,
             },
             extra: {
               // The registered 'model-builder' suggest sheet owns the per-field

--- a/utils/scripts/verifyModelBuilderDraftSourceSnapshotGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderDraftSourceSnapshotGuard.test.ts
@@ -1,0 +1,152 @@
+// /utils/scripts/verifyModelBuilderDraftSourceSnapshotGuard.test.ts
+//
+// Regression test for checkDraftSourceSnapshotGuard() in
+// verifyModelBuilderDraftSourceSnapshotGuard.ts (model-builder/t-029, cycle
+// 56). Exercises the real check against synthetic store-shaped fixtures
+// covering: the pre-fix shape (context.source reads state.selectedSource
+// alone -- the exact bug found by tracing draftText()'s /api/suggest
+// payload against resumeRun()/openRun()'s cycle-24 selectedSource-nulling
+// fix), the fixed shape (falls back to state.run.sourceSnapshot first), and
+// the anchor missing entirely (function renamed/restructured).
+import assert from 'node:assert/strict'
+
+import { checkDraftSourceSnapshotGuard } from './verifyModelBuilderDraftSourceSnapshotGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function draftText(
+    itemId: string,
+    field: DraftField,
+    instruction?: string,
+  ): Promise<boolean> {
+    try {
+      const result = await performFetch<{ value: string }>(
+        '/api/suggest',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            builder: 'model-builder',
+            context: {
+              sourceType: state.run.sourceType,
+              targetModel,
+              expectedFields: fieldsBrief(targetModel),
+              pitch: item.pitch,
+              fields: item.fieldsDraft,
+              source: state.selectedSource ?? undefined,
+            },
+          }),
+        },
+      )
+    } catch (error) {}
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function draftText(
+    itemId: string,
+    field: DraftField,
+    instruction?: string,
+  ): Promise<boolean> {
+    try {
+      const result = await performFetch<{ value: string }>(
+        '/api/suggest',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            builder: 'model-builder',
+            context: {
+              sourceType: state.run.sourceType,
+              targetModel,
+              expectedFields: fieldsBrief(targetModel),
+              pitch: item.pitch,
+              fields: item.fieldsDraft,
+              source: state.run.sourceSnapshot ?? state.selectedSource ?? undefined,
+            },
+          }),
+        },
+      )
+    } catch (error) {}
+  }
+`
+
+// Prettier wraps the real file's long \`source:\` line onto its own
+// continuation line (\`source:\n  state.run.sourceSnapshot ?? ...\`) -- this
+// fixture exercises that exact real-world shape, not just the single-line
+// version above.
+const FIXED_WRAPPED_FIXTURE = `
+  async function draftText(
+    itemId: string,
+    field: DraftField,
+    instruction?: string,
+  ): Promise<boolean> {
+    try {
+      const result = await performFetch<{ value: string }>(
+        '/api/suggest',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            builder: 'model-builder',
+            context: {
+              sourceType: state.run.sourceType,
+              targetModel,
+              expectedFields: fieldsBrief(targetModel),
+              pitch: item.pitch,
+              fields: item.fieldsDraft,
+              source:
+                state.run.sourceSnapshot ?? state.selectedSource ?? undefined,
+            },
+          }),
+        },
+      )
+    } catch (error) {}
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkDraftSourceSnapshotGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  1,
+  `expected the pre-fix shape to raise 1 error, got ${buggyErrors.length}: ` +
+    `${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors[0]?.includes('state.selectedSource ?? undefined` alone'),
+  'expected the bare-selectedSource violation message',
+)
+
+const fixedErrors = checkDraftSourceSnapshotGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const fixedWrappedErrors = checkDraftSourceSnapshotGuard(FIXED_WRAPPED_FIXTURE)
+assert.equal(
+  fixedWrappedErrors.length,
+  0,
+  'expected the prettier-wrapped fixed shape (source: on its own ' +
+    `continuation line) to raise no errors, got: ${JSON.stringify(fixedWrappedErrors)}`,
+)
+
+const missingErrors = checkDraftSourceSnapshotGuard(MISSING_FIXTURE)
+assert.equal(
+  missingErrors.length,
+  1,
+  'expected one "anchor not found" violation when draftText is absent',
+)
+assert.ok(missingErrors[0]?.includes('Could not find'))
+
+console.log(
+  'Model Builder draft source-snapshot guard checker verified: flags the ' +
+    'pre-fix bare-selectedSource shape, clears the fixed sourceSnapshot- ' +
+    'fallback shape (both single-line and prettier-wrapped), and flags ' +
+    'the anchor being absent.',
+)

--- a/utils/scripts/verifyModelBuilderDraftSourceSnapshotGuard.ts
+++ b/utils/scripts/verifyModelBuilderDraftSourceSnapshotGuard.ts
@@ -1,0 +1,134 @@
+// /utils/scripts/verifyModelBuilderDraftSourceSnapshotGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 56) -- draftText() (the
+// store function behind every "Draft with AI" click for pitch/fields/
+// artPrompt) sent `source: state.selectedSource ?? undefined` as the
+// `context.source` the 'model-builder' suggest sheet
+// (server/utils/suggest/sheets/modelBuilderSuggest.ts's buildSourceContext)
+// uses to ground the draft in the selected SOURCE record's canon
+// (name/class/species/personality/quirks/backstory/description/pitch/
+// flavorText/botIntro).
+//
+// state.selectedSource is only ever set by an in-session selectSource()
+// call and is deliberately nulled in every "adopt a different run" branch
+// of resumeRun()/openRun() (cycle 24's own fix -- see
+// verifyModelBuilderStaleSelectionOnReopenGuard.ts and adaptRun's comment).
+// So after resuming a run -- a page reload, or reopening one from Run
+// History, both ordinary paths -- state.selectedSource is null and
+// draftText's `context.source` silently became `undefined`. The suggest
+// sheet's whole canon-grounding block vanished from the prompt with no
+// error surfaced anywhere: the request still "succeeds", it just drafts
+// generic, ungrounded text that can contradict the source's established
+// identity -- exactly what modelBuilderSuggest.ts's own system prompt says
+// never to do.
+//
+// model-builder-progress-matrix.vue's `source` computed already solved the
+// identical resume-survival problem for the read-only "Source context"
+// card by preferring the run's persisted `sourceSnapshot` and falling back
+// to `selectedSource` only when that's absent (`run.value?.sourceSnapshot
+// ?? store.selectedSource ?? null`) -- draftText's request payload just
+// never adopted the same precedence. Fixed by matching it exactly:
+// `state.run.sourceSnapshot ?? state.selectedSource ?? undefined`.
+//
+// This asserts the textual shape of that fix stays in place: the
+// `context.source:` line inside draftText's /api/suggest request body
+// reads the run's sourceSnapshot before falling back to selectedSource,
+// rather than reading selectedSource alone.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const ANCHOR = 'fields: item.fieldsDraft,'
+const FIXED_SOURCE_LINE =
+  'source: state.run.sourceSnapshot ?? state.selectedSource ?? undefined,'
+const BARE_SOURCE_LINE = 'source: state.selectedSource ?? undefined,'
+
+// Checks the fix's exact shape against the full source text of a file
+// shaped like modelBuilderStore.ts. Exported so the self-test below can run
+// it against synthetic buggy/fixed fixtures without touching the real store
+// file.
+export function checkDraftSourceSnapshotGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const anchorIndex = content.indexOf(ANCHOR)
+  if (anchorIndex === -1) {
+    errors.push(
+      `Could not find \`${ANCHOR}\` in modelBuilderStore.ts -- has ` +
+        "draftText()'s /api/suggest request body been renamed or " +
+        'restructured? If so, this guard needs to move with it.',
+    )
+    return errors
+  }
+
+  // The source line follows the anchor, possibly after an explanatory
+  // comment block -- give it a generous window rather than requiring an
+  // exact line count. Collapse whitespace before matching so prettier
+  // wrapping a long `source:` line onto its own continuation line (as it
+  // does for the fixed shape) doesn't defeat a literal substring match.
+  const window = content
+    .slice(anchorIndex, anchorIndex + 1200)
+    .replace(/\s+/g, ' ')
+
+  if (window.includes(FIXED_SOURCE_LINE.replace(/\s+/g, ' '))) {
+    return errors
+  }
+
+  if (window.includes(BARE_SOURCE_LINE.replace(/\s+/g, ' '))) {
+    errors.push(
+      "draftText()'s context.source still reads `state.selectedSource ?? " +
+        'undefined` alone -- state.selectedSource is deliberately nulled ' +
+        'on every resumeRun()/openRun() "adopt a different run" branch ' +
+        '(cycle 24), so after resuming a run (a reload, or reopening one ' +
+        'from Run History) every subsequent "Draft with AI" request ' +
+        "silently drops the suggest sheet's entire canon-grounding block " +
+        '(source name/class/species/personality/backstory/etc.) with no ' +
+        'error, producing generic drafts that can contradict the source ' +
+        "record's established identity. Fall back to the run's persisted " +
+        `\`state.run.sourceSnapshot\` first, matching model-builder-` +
+        "progress-matrix.vue's identical `source` computed precedence: " +
+        `\`${FIXED_SOURCE_LINE}\``,
+    )
+    return errors
+  }
+
+  errors.push(
+    "Could not find draftText()'s `context.source:` line in its expected " +
+      'shape near the fieldsDraft anchor -- has the /api/suggest request ' +
+      'body been restructured? If so, verify by hand that context.source ' +
+      'still falls back to state.run.sourceSnapshot before ' +
+      'state.selectedSource, and update this guard to match.',
+  )
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkDraftSourceSnapshotGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder draft source-snapshot guard contract failed for ' +
+        'modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder draft source-snapshot guard contract passed: ' +
+      "draftText()'s /api/suggest request falls back to the run's " +
+      'persisted sourceSnapshot before selectedSource, so an AI draft ' +
+      'requested after resuming a run still grounds in the source ' +
+      "record's canon instead of silently going generic.",
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
model-builder/t-029 cycle 56: recurring polish/regression-hunt task (kind: software)

### What changed / what I produced
- `stores/modelBuilderStore.ts`: `draftText()`'s `/api/suggest` request body sent `context.source: state.selectedSource ?? undefined`. `state.selectedSource` is only ever set by an in-session `selectSource()` call and is deliberately nulled in every "adopt a different run" branch of `resumeRun()`/`openRun()` (cycle 24's own fix). So after resuming a run — a page reload, or reopening one from Run History, both ordinary paths — `context.source` was silently `undefined`, and the `'model-builder'` suggest sheet's entire canon-grounding block (source name/class/species/personality/backstory/etc., see `server/utils/suggest/sheets/modelBuilderSuggest.ts`'s `buildSourceContext`) vanished from every AI draft request with no error. The request still "succeeded" — it just drafted generic, ungrounded text that could contradict the source record's established identity, exactly what the suggest sheet's own system prompt says never to do.
  - `model-builder-progress-matrix.vue`'s `source` computed already solves the identical resume-survival problem for the read-only "Source context" card (`run.value?.sourceSnapshot ?? store.selectedSource ?? null`). Matched the same precedence in `draftText`'s request payload: `state.run.sourceSnapshot ?? state.selectedSource ?? undefined`.
- `utils/scripts/verifyModelBuilderDraftSourceSnapshotGuard.ts` + `.test.ts`: new regression guard (57th in this task's established pattern), wired into `package.json` and `contract-tests.yml`.

### How I verified
- New guard fails pre-fix / passes post-fix (fixture round-trip in the self-test, covering both the single-line and prettier-wrapped shapes of the fix).
- All 142 `test:model-builder-*` npm scripts pass.
- `eslint` clean on every changed file (two pre-existing `no-empty` errors elsewhere in `modelBuilderStore.ts`, and one pre-existing, unrelated `vue-tsc` error in `server/api/reactions/index.post.ts`, both confirmed via `git stash`/`git blame` as unaffected by this change).
- `prettier --check` clean.
- `vue-tsc --noEmit` shows only that one pre-existing, unrelated error.
- `git status --porcelain` scoped to exactly 5 files (reverted an incidental `prisma generate` regen diff picked up from local dependency provisioning, per this task's own established precedent, before committing).

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
This cycle's lead (checking a file the task's own file-set audit hadn't covered: `server/utils/suggest/sheets/modelBuilderSuggest.ts` and its store-side caller) came from grepping the whole repo for `model-builder`/`modelBuilder`/`ModelBuild` references and diffing against every file this task's TALKBACK/note history had already named as read. Worth codifying as a standing first step for this task's future cycles once client-state-race/Prisma/error-handling territory looks exhausted again, rather than re-deriving the same grep each time.

### Notes for reviewer
Conductor-side: claimed via `claim_task.py`, roadmap note appended and task re-armed to `ready` for a future slice as part of this same PR flow (companion conductor close-out to follow in the conductor repo).


---
_Generated by [Claude Code](https://claude.ai/code/session_01J32XEKHfmjus7CU2MtWyzD)_