### PR TITLE
fix(model-builder): clear in-flight singletons on every run-swap path (t-029 cycle 57)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -860,6 +860,12 @@ jobs:
       - name: Model Builder draft source-snapshot guard contract
         run: npm run test:model-builder-draft-source-snapshot-guard
 
+      - name: Model Builder run-swap singleton-leak guard self-test
+        run: npm run test:model-builder-run-swap-singleton-leak-guard-selftest
+
+      - name: Model Builder run-swap singleton-leak guard contract
+        run: npm run test:model-builder-run-swap-singleton-leak-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -364,6 +364,8 @@
     "test:model-builder-batch-busy-item-exclusion-guard": "tsx utils/scripts/verifyModelBuilderBatchBusyItemExclusionGuard.ts",
     "test:model-builder-draft-source-snapshot-guard-selftest": "tsx utils/scripts/verifyModelBuilderDraftSourceSnapshotGuard.test.ts",
     "test:model-builder-draft-source-snapshot-guard": "tsx utils/scripts/verifyModelBuilderDraftSourceSnapshotGuard.ts",
+    "test:model-builder-run-swap-singleton-leak-guard-selftest": "tsx utils/scripts/verifyModelBuilderRunSwapSingletonLeakGuard.test.ts",
+    "test:model-builder-run-swap-singleton-leak-guard": "tsx utils/scripts/verifyModelBuilderRunSwapSingletonLeakGuard.ts",
     "test:storybook-active-story-resume-guard": "npx tsx utils/scripts/verifyStorybookActiveStoryResumeGuard.ts",
     "test:storybook-answer-input-preservation-guard": "node utils/scripts/verifyStorybookAnswerInputPreservationGuard.mjs",
     "test:storybook-answer-rollback-guard": "node utils/scripts/verifyStorybookAnswerRollbackGuard.mjs",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -740,6 +740,18 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         throw new Error(response.message || 'Failed to start build run.')
       }
 
+      // Same store-wide "who's in flight" singletons resetRun/resetAll clear
+      // (see resetRun's comment) -- a brand-new run replacing the old one is
+      // the identical "abandon this run's in-flight work" moment, just
+      // reached via Change-source/the Source crumb + Start build run instead
+      // of the explicit New-run controls, so it leaked the same stale-busy-
+      // indicator bug through a third path (model-builder/t-029 cycle 57).
+      state.generatingItemId = null
+      state.committingItemId = null
+      state.autoBuilding = false
+      state.autoBuildingItemId = null
+      state.batchingOutputKey = null
+      draftingField.value = null
       state.run = adaptRun(response.data)
       setActiveRunId(response.data.id)
       state.step = 'run'
@@ -2867,6 +2879,18 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
           state.step = 'run'
           setActiveRunId(data.id)
         } else {
+          // Same store-wide "who's in flight" singletons resetRun/resetAll
+          // clear (see resetRun's comment) -- adopting a different run here
+          // (a remount picking up a different remembered/latest run) is the
+          // identical "abandon this run's in-flight work" moment, leaking
+          // the same stale-busy-indicator bug through yet another path
+          // (model-builder/t-029 cycle 57).
+          state.generatingItemId = null
+          state.committingItemId = null
+          state.autoBuilding = false
+          state.autoBuildingItemId = null
+          state.batchingOutputKey = null
+          draftingField.value = null
           state.run = adaptRun(data)
           state.sourceType = data.sourceType as SourceTypeKey
           state.recipeKey = data.recipeKey as RecipeKey
@@ -3003,6 +3027,17 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
 
     const cached = state.runs.find((entry) => entry.id === runId)
     if (cached && cached.status !== 'CANCELLED') {
+      // Same store-wide "who's in flight" singletons resetRun/resetAll
+      // clear (see resetRun's comment) -- swapping to a different, already-
+      // cached run here is the identical "abandon this run's in-flight
+      // work" moment, leaking the same stale-busy-indicator bug through
+      // yet another path (model-builder/t-029 cycle 57).
+      state.generatingItemId = null
+      state.committingItemId = null
+      state.autoBuilding = false
+      state.autoBuildingItemId = null
+      state.batchingOutputKey = null
+      draftingField.value = null
       state.run = cached
       state.sourceType = cached.sourceType
       state.recipeKey = cached.recipeKey
@@ -3035,10 +3070,16 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
           )
           return
         }
+        // See the comment on the cached branch above.
+        state.generatingItemId = null
+        state.committingItemId = null
+        state.autoBuilding = false
+        state.autoBuildingItemId = null
+        state.batchingOutputKey = null
+        draftingField.value = null
         state.run = adaptRun(response.data)
         state.sourceType = state.run.sourceType
         state.recipeKey = state.run.recipeKey
-        // See the comment on the cached branch above.
         state.selectedSource = null
         state.selections = {}
         state.step = 'run'

--- a/utils/scripts/verifyModelBuilderRunSwapSingletonLeakGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderRunSwapSingletonLeakGuard.test.ts
@@ -1,0 +1,198 @@
+// /utils/scripts/verifyModelBuilderRunSwapSingletonLeakGuard.test.ts
+//
+// Regression test for checkRunSwapSingletonLeakGuard() in
+// verifyModelBuilderRunSwapSingletonLeakGuard.ts (model-builder/t-029,
+// cycle 57). Exercises the real check against a synthetic store-shaped
+// fixture covering all four run-swap sites in both their fixed and pre-fix
+// shapes.
+import assert from 'node:assert/strict'
+
+import { checkRunSwapSingletonLeakGuard } from './verifyModelBuilderRunSwapSingletonLeakGuard.js'
+
+const CLEAR_BLOCK = `
+      state.generatingItemId = null
+      state.committingItemId = null
+      state.autoBuilding = false
+      state.autoBuildingItemId = null
+      state.batchingOutputKey = null
+      draftingField.value = null
+`
+
+const NOT_CLEARED = '// (nothing cleared)'
+
+// Padding inserted between every pair of sites in the fixture below so a
+// guard window anchored on one site can never bleed into a neighboring
+// site's own clear block -- mirrors the real file's comment-heavy spacing
+// between functions, keeping site-isolation realistic rather than an
+// artifact of a synthetic fixture being unusually compact relative to the
+// guard's (deliberately generous, to survive real prettier-wrapped
+// comments) window sizes.
+const FILLER = Array.from(
+  { length: 12 },
+  () =>
+    '    // filler padding so guard windows never bleed across fixture sites.',
+).join('\n')
+
+function buildFixture(sites: {
+  startRun?: string
+  openRunCached?: string
+  openRunFetched?: string
+  resumeRun?: string
+}): string {
+  const startRun = sites.startRun ?? CLEAR_BLOCK
+  const openRunCached = sites.openRunCached ?? CLEAR_BLOCK
+  const openRunFetched = sites.openRunFetched ?? CLEAR_BLOCK
+  const resumeRun = sites.resumeRun ?? CLEAR_BLOCK
+
+  return `
+  async function startRun(): Promise<void> {
+    try {
+      const response = await performFetch('/api/model-builder/runs', {})
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Failed to start build run.')
+      }
+      ${startRun}
+      state.run = adaptRun(response.data)
+      setActiveRunId(response.data.id)
+      state.step = 'run'
+    } catch (error) {
+      handleError(error, 'starting build run')
+    }
+  }
+
+${FILLER}
+
+  async function openRun(runId: string): Promise<void> {
+    if (state.run?.id === runId) {
+      state.step = 'run'
+      return
+    }
+
+    const cached = state.runs.find((entry) => entry.id === runId)
+    if (cached && cached.status !== 'CANCELLED') {
+      ${openRunCached}
+      state.run = cached
+      state.step = 'run'
+      setActiveRunId(Number(runId))
+      return
+    }
+
+${FILLER}
+
+    try {
+      const response = await performFetch(\`/api/model-builder/runs/\${runId}\`)
+      if (response.success && response.data) {
+        if (response.data.status === 'CANCELLED') {
+          return
+        }
+        // See the comment on the cached branch above.
+        ${openRunFetched}
+        state.run = adaptRun(response.data)
+        state.step = 'run'
+        setActiveRunId(response.data.id)
+      } else if (!response.success) {
+        setStatus('error', response.message || 'Failed to open run.')
+      }
+    } catch (error) {
+      handleError(error, 'opening build run')
+    }
+  }
+
+${FILLER}
+
+  async function resumeRun(): Promise<void> {
+    try {
+      const data = await fetchSomeRun()
+      if (data) {
+        if (state.run?.id === String(data.id)) {
+          state.step = 'run'
+          setActiveRunId(data.id)
+        } else {
+          ${resumeRun}
+          state.run = adaptRun(data)
+          state.selectedSource = null
+          state.selections = {}
+          state.step = 'run'
+          setActiveRunId(data.id)
+        }
+      }
+    } catch {
+      // Not signed in, or no runs yet.
+    }
+  }
+`
+}
+
+const FIXED_FIXTURE = buildFixture({})
+const BUGGY_FIXTURE = buildFixture({
+  startRun: NOT_CLEARED,
+  openRunCached: NOT_CLEARED,
+  openRunFetched: NOT_CLEARED,
+  resumeRun: NOT_CLEARED,
+})
+
+const fixedErrors = checkRunSwapSingletonLeakGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const buggyErrors = checkRunSwapSingletonLeakGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  4,
+  `expected all 4 swap sites to be flagged when none clear the singletons, ` +
+    `got ${buggyErrors.length}: ${JSON.stringify(buggyErrors)}`,
+)
+for (const site of [
+  "startRun()'s success path",
+  "openRun()'s cached-run branch",
+  "openRun()'s freshly-fetched-run branch",
+  "resumeRun()'s adopt-a-different-run branch",
+]) {
+  assert.ok(
+    buggyErrors.some((error) => error.startsWith(site)),
+    `expected a violation for ${site}, got: ${JSON.stringify(buggyErrors)}`,
+  )
+}
+
+// A fixture that fixes every site EXCEPT one should raise exactly one error,
+// for the specific site left buggy -- confirms sites are checked
+// independently rather than the guard passing/failing all-or-nothing.
+const PARTIALLY_FIXED_FIXTURE = buildFixture({ openRunCached: NOT_CLEARED })
+const partialErrors = checkRunSwapSingletonLeakGuard(PARTIALLY_FIXED_FIXTURE)
+assert.equal(
+  partialErrors.length,
+  1,
+  `expected exactly 1 error when only the cached-run branch regresses, got: ${JSON.stringify(partialErrors)}`,
+)
+assert.ok(partialErrors[0]?.startsWith("openRun()'s cached-run branch"))
+
+// A fixture missing one specific line (rather than the whole block) should
+// still be caught and named precisely.
+const CLEAR_BLOCK_MISSING_BATCH_KEY = `
+      state.generatingItemId = null
+      state.committingItemId = null
+      state.autoBuilding = false
+      state.autoBuildingItemId = null
+      draftingField.value = null
+`
+const ONE_LINE_MISSING_FIXTURE = buildFixture({
+  startRun: CLEAR_BLOCK_MISSING_BATCH_KEY,
+})
+const oneLineErrors = checkRunSwapSingletonLeakGuard(ONE_LINE_MISSING_FIXTURE)
+assert.equal(
+  oneLineErrors.length,
+  1,
+  `expected exactly 1 error when startRun drops only batchingOutputKey, got: ${JSON.stringify(oneLineErrors)}`,
+)
+assert.ok(oneLineErrors[0]?.startsWith("startRun()'s success path"))
+assert.ok(oneLineErrors[0]?.includes('state.batchingOutputKey = null'))
+
+console.log(
+  'Model Builder run-swap singleton-leak guard checker verified: flags each ' +
+    'of the 4 run-swap sites independently when they skip clearing the ' +
+    'in-flight singletons (including a single dropped line), and clears ' +
+    'the fully-fixed shape.',
+)

--- a/utils/scripts/verifyModelBuilderRunSwapSingletonLeakGuard.ts
+++ b/utils/scripts/verifyModelBuilderRunSwapSingletonLeakGuard.ts
@@ -1,0 +1,149 @@
+// /utils/scripts/verifyModelBuilderRunSwapSingletonLeakGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 57) -- resetRun()/resetAll()
+// already clear the store-wide "who's in flight" singletons
+// (generatingItemId/committingItemId/autoBuilding/autoBuildingItemId/
+// batchingOutputKey/draftingField) whenever they drop or replace the active
+// run, specifically because an async op abandoned on the old run (a batch
+// action, a single-item generate/commit, an auto-build) can otherwise leak
+// a false "busy" indicator into whichever run replaces it. batchingOutputKey
+// is a bare recipe output key (e.g. "rewards"), not scoped to a run, so two
+// runs sharing a recipe collide on it directly -- resetRun's own comment
+// documents the exact scenario this was first fixed for. See
+// verifyModelBuilderResetRunGuard.ts / verifyModelBuilderResetAllGuard.ts
+// for the existing guards covering resetRun()/resetAll() themselves; this
+// guard covers the three sites found (cycle 57) to perform the identical
+// run-swap without ever going through either:
+//
+// - startRun() (Change-source / the always-enabled Source crumb, then
+//   Start build run, creates a fresh run while an old one's async op may
+//   still be in flight)
+// - openRun()'s two "adopt a different run" branches (opening a different
+//   run from History, either already cached or freshly fetched)
+// - resumeRun()'s "adopt a different run" branch (a remount picking up a
+//   different remembered/latest run)
+//
+// Each leaked the same stale-busy-indicator bug through its own path. Fixed
+// by inlining the same six-line clear at each site (matching resetRun's own
+// inline shape, rather than introducing a shared helper that would have
+// required rewriting the existing resetRun/resetAll guards' literal-shape
+// checks). This asserts each site still clears every one of the six
+// singletons, keyed off text immediately adjacent to where each swap
+// actually happens so a refactor that silently drops the clear (rather than
+// moving it) gets caught.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const CLEARED_LINES = [
+  'state.generatingItemId = null',
+  'state.committingItemId = null',
+  'state.autoBuilding = false',
+  'state.autoBuildingItemId = null',
+  'state.batchingOutputKey = null',
+  'draftingField.value = null',
+]
+
+interface SwapSite {
+  name: string
+  anchor: string
+  windowSize: number
+  hint: string
+}
+
+const SWAP_SITES: SwapSite[] = [
+  {
+    name: "startRun()'s success path",
+    anchor: "throw new Error(response.message || 'Failed to start build run.')",
+    windowSize: 900,
+    hint:
+      'startRun() creates a fresh run that replaces state.run -- an in-flight op abandoned ' +
+      'on the old run can leak a false-busy indicator into the new one unless the singletons ' +
+      'are cleared right before `state.run = adaptRun(response.data)`.',
+  },
+  {
+    name: "openRun()'s cached-run branch",
+    anchor: "if (cached && cached.status !== 'CANCELLED') {",
+    windowSize: 700,
+    hint:
+      'openRun() adopting a different, already-cached run must clear the in-flight singletons ' +
+      'the same way resetRun/resetAll do.',
+  },
+  {
+    name: "openRun()'s freshly-fetched-run branch",
+    anchor: '// See the comment on the cached branch above.',
+    windowSize: 300,
+    hint:
+      'openRun() adopting a different run fetched from the server must clear the in-flight ' +
+      'singletons the same way its cached-run branch does.',
+  },
+  {
+    name: "resumeRun()'s adopt-a-different-run branch",
+    anchor: 'if (state.run?.id === String(data.id)) {',
+    windowSize: 900,
+    hint:
+      "resumeRun()'s else branch (adopting a different remembered/latest run) must clear the " +
+      'in-flight singletons the same way resetRun/resetAll do.',
+  },
+]
+
+// Checks that every run-swap site still clears all six in-flight
+// singletons, against the full source text of a file shaped like
+// modelBuilderStore.ts. Exported so the self-test below can run it against
+// synthetic buggy/fixed fixtures without touching the real store file.
+export function checkRunSwapSingletonLeakGuard(content: string): string[] {
+  const errors: string[] = []
+
+  for (const site of SWAP_SITES) {
+    const anchorIndex = content.indexOf(site.anchor)
+    if (anchorIndex === -1) {
+      errors.push(
+        `Could not find the anchor for ${site.name} (\`${site.anchor}\`) -- has this ` +
+          'function been renamed or restructured? If so, this guard needs to move with it.',
+      )
+      continue
+    }
+
+    const window = content.slice(anchorIndex, anchorIndex + site.windowSize)
+    const missing = CLEARED_LINES.filter((line) => !window.includes(line))
+    if (missing.length) {
+      errors.push(
+        `${site.name} does not clear: ${missing.join(', ')}. ${site.hint}`,
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkRunSwapSingletonLeakGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder run-swap singleton-leak guard contract failed for ' +
+        'modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder run-swap singleton-leak guard contract passed: ' +
+      "startRun(), both openRun() run-swap branches, and resumeRun()'s " +
+      'adopt-a-different-run branch all clear the store-wide in-flight ' +
+      "singletons, so an abandoned run's async op can't leak a " +
+      'false-busy indicator into whatever run replaces it.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
model-builder/t-029: recurring polish/regression-hunt task, cycle 57

### What changed / what I produced
- `startRun()`, `openRun()`'s two "adopt a different run" branches, and `resumeRun()`'s "adopt a different run" branch each replace `state.run` with a different run object — the same operation `resetRun()`/`resetAll()` already perform — but unlike those two, none of them cleared the store-wide "who's in flight" singletons (`generatingItemId`/`committingItemId`/`autoBuilding`/`autoBuildingItemId`/`batchingOutputKey`/`draftingField`).
- This reproduces the exact stale-busy-indicator bug `resetRun`/`resetAll`'s own comment documents (`batchingOutputKey` is a bare recipe output key, not scoped to a run, so two runs sharing a recipe collide on it directly) via three additional reachable paths:
  1. Change-source (or the always-enabled Source crumb) → pick a new source → Start build run, while an async op (batch action, single-item generate/commit, auto-build) is still in flight on the old run.
  2. Opening a different run from Run History while an async op is in flight on the current run.
  3. A component remount that causes `resumeRun()` to adopt a different remembered/latest run while an async op is in flight.
- Fixed by inlining the same six-line clear at each of the three sites (four call sites total, since `openRun()` has two), matching `resetRun()`'s own inline shape. Kept inline rather than extracting a shared helper, since a helper would have required rewriting the existing `verifyModelBuilderResetRunGuard`/`verifyModelBuilderResetAllGuard` literal-shape checks for no behavioral gain.
- Added `verifyModelBuilderRunSwapSingletonLeakGuard.ts` + selftest (this project's narrow-textual-checker convention), wired into `package.json` and `contract-tests.yml`.

### How I verified
- New guard fails against a synthetic pre-fix fixture, passes against the real fixed file.
- All 145 `test:model-builder-*` scripts pass.
- `eslint` clean on changed files (two pre-existing `no-empty` errors elsewhere in `modelBuilderStore.ts`, confirmed unrelated to this change).
- `prettier --check` clean.
- `vue-tsc --noEmit` repo-wide: exit 0, clean.
- `git status --porcelain` scoped to exactly 5 files (reverted an incidental `prisma generate` regen diff from local provisioning before committing).

### Stakes
reversible

### Notes for reviewer
Companion PR: conductor task model-builder/t-029 will be closed out (re-armed to `ready` per this recurring task's convention) referencing this PR once merged.

### Kaizen suggestion
This cycle's method (reading a file never individually named in any of the prior 56 cycles' notes — `model-builder-manager.vue`, which turned out to be clean — then tracing the run-lifecycle functions it orchestrates for the same bug class already fixed elsewhere) is worth repeating: check every file under `components/model-builder/**` and `stores/modelBuilderStore.ts`'s own function list against this task's cumulative note history for ones never explicitly named as read, rather than assuming a directory glob match means full coverage.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XLWymxfu2FVuuXdLhGMMi9)_