### PR TITLE
fix(model-builder): guard resumeRun() against a stale remount race (t-029 cycle 59)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -866,6 +866,12 @@ jobs:
       - name: Model Builder run-swap singleton-leak guard contract
         run: npm run test:model-builder-run-swap-singleton-leak-guard
 
+      - name: Model Builder resumeRun request guard checker self-test
+        run: npm run test:model-builder-resume-run-request-guard-selftest
+
+      - name: Model Builder resumeRun request guard contract
+        run: npm run test:model-builder-resume-run-request-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -366,6 +366,8 @@
     "test:model-builder-draft-source-snapshot-guard": "tsx utils/scripts/verifyModelBuilderDraftSourceSnapshotGuard.ts",
     "test:model-builder-run-swap-singleton-leak-guard-selftest": "tsx utils/scripts/verifyModelBuilderRunSwapSingletonLeakGuard.test.ts",
     "test:model-builder-run-swap-singleton-leak-guard": "tsx utils/scripts/verifyModelBuilderRunSwapSingletonLeakGuard.ts",
+    "test:model-builder-resume-run-request-guard-selftest": "tsx utils/scripts/verifyModelBuilderResumeRunRequestGuard.test.ts",
+    "test:model-builder-resume-run-request-guard": "tsx utils/scripts/verifyModelBuilderResumeRunRequestGuard.ts",
     "test:storybook-active-story-resume-guard": "npx tsx utils/scripts/verifyStorybookActiveStoryResumeGuard.ts",
     "test:storybook-answer-input-preservation-guard": "node utils/scripts/verifyStorybookAnswerInputPreservationGuard.mjs",
     "test:storybook-answer-rollback-guard": "node utils/scripts/verifyStorybookAnswerRollbackGuard.mjs",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -2828,7 +2828,29 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
 
   // Resume the most recent run: the remembered run id if still present, else the
   // newest non-cancelled run for this user. Silent on failure (e.g. signed out).
+  //
+  // resumeRun() only ever fires from model-builder-manager.vue's onMounted --
+  // but that component remounts on every navigation away from and back to the
+  // Model Builder page (no keep-alive anywhere in this app; see this file's
+  // comment above on the "adopt a different run" branch), and unmounting a
+  // component does not cancel its in-flight promises. Navigate away, then
+  // back before the first mount's resumeRun() resolves, and TWO calls race
+  // against the same store singleton -- the second (from the new mount) can
+  // finish first and unblock the UI (model-builder-manager.vue's
+  // `resumingRun` gate only tracks its OWN call), letting the user start a
+  // genuinely different run (resetRun()/openRun()) before the first, now
+  // very stale, call finally resolves. Without a ticket, that stale call's
+  // `data` -- fetched for whatever run WAS remembered/latest back when it
+  // started -- lands on top of the user's new run: same "different run"
+  // branch below, same unconditional clobber of state.run and the in-flight
+  // singletons, as the very race openRun()/fetchRuns()/loadSources() are
+  // each guarded against (model-builder/t-029 cycle 59; flagged but not yet
+  // traced by cycle 58). Guarded the same way: a monotonic ticket captured up
+  // front, checked after each of the two sequential performFetch calls.
+  let resumeRunRequestId = 0
+
   async function resumeRun(): Promise<void> {
+    const requestId = ++resumeRunRequestId
     try {
       const remembered = safeGet(runIdKey)
       let data: ServerRun | undefined
@@ -2837,6 +2859,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         const response = await performFetch<ServerRun>(
           `/api/model-builder/runs/${remembered}`,
         )
+        if (resumeRunRequestId !== requestId) return
         if (
           response.success &&
           response.data &&
@@ -2856,6 +2879,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         const response = await performFetch<ServerRun[]>(
           '/api/model-builder/runs?take=1',
         )
+        if (resumeRunRequestId !== requestId) return
         if (
           response.success &&
           Array.isArray(response.data) &&

--- a/utils/scripts/verifyModelBuilderResumeRunRequestGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderResumeRunRequestGuard.test.ts
@@ -1,0 +1,239 @@
+// /utils/scripts/verifyModelBuilderResumeRunRequestGuard.test.ts
+//
+// Regression test for checkResumeRunRequestGuard() in
+// verifyModelBuilderResumeRunRequestGuard.ts (model-builder/t-029, cycle
+// 59). Exercises the real check against synthetic store-shaped fixtures
+// covering: the pre-fix shape (no request ticket at all -- the exact gap
+// found by manual read-through), the fixed shape (a monotonic ticket
+// captured up front and gating both sequential performFetch calls), a
+// partially-fixed shape (ticket declared and captured, but only the first
+// performFetch call checks it -- the fallback fetch can still apply a stale
+// response), and resumeRun being absent entirely.
+import assert from 'node:assert/strict'
+
+import { checkResumeRunRequestGuard } from './verifyModelBuilderResumeRunRequestGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function resumeRun(): Promise<void> {
+    try {
+      const remembered = safeGet(runIdKey)
+      let data: ServerRun | undefined
+
+      if (remembered) {
+        const response = await performFetch<ServerRun>(
+          \`/api/model-builder/runs/\${remembered}\`,
+        )
+        if (
+          response.success &&
+          response.data &&
+          response.data.status !== 'CANCELLED'
+        ) {
+          data = response.data
+        } else if (response.success && response.data) {
+          safeRemove(runIdKey)
+        }
+      }
+
+      if (!data) {
+        const response = await performFetch<ServerRun[]>(
+          '/api/model-builder/runs?take=1',
+        )
+        if (
+          response.success &&
+          Array.isArray(response.data) &&
+          response.data.length
+        ) {
+          data = response.data[0]
+        }
+      }
+
+      if (data) {
+        if (state.run?.id === String(data.id)) {
+          state.step = 'run'
+          setActiveRunId(data.id)
+        } else {
+          state.generatingItemId = null
+          state.committingItemId = null
+          state.autoBuilding = false
+          state.autoBuildingItemId = null
+          state.batchingOutputKey = null
+          draftingField.value = null
+          state.run = adaptRun(data)
+          state.sourceType = data.sourceType as SourceTypeKey
+          state.recipeKey = data.recipeKey as RecipeKey
+          state.selectedSource = null
+          state.selections = {}
+          state.step = 'run'
+          setActiveRunId(data.id)
+        }
+      }
+    } catch {
+      // Not signed in, or no runs yet — start fresh at the source picker.
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  let resumeRunRequestId = 0
+
+  async function resumeRun(): Promise<void> {
+    const requestId = ++resumeRunRequestId
+    try {
+      const remembered = safeGet(runIdKey)
+      let data: ServerRun | undefined
+
+      if (remembered) {
+        const response = await performFetch<ServerRun>(
+          \`/api/model-builder/runs/\${remembered}\`,
+        )
+        if (resumeRunRequestId !== requestId) return
+        if (
+          response.success &&
+          response.data &&
+          response.data.status !== 'CANCELLED'
+        ) {
+          data = response.data
+        } else if (response.success && response.data) {
+          safeRemove(runIdKey)
+        }
+      }
+
+      if (!data) {
+        const response = await performFetch<ServerRun[]>(
+          '/api/model-builder/runs?take=1',
+        )
+        if (resumeRunRequestId !== requestId) return
+        if (
+          response.success &&
+          Array.isArray(response.data) &&
+          response.data.length
+        ) {
+          data = response.data[0]
+        }
+      }
+
+      if (data) {
+        if (state.run?.id === String(data.id)) {
+          state.step = 'run'
+          setActiveRunId(data.id)
+        } else {
+          state.generatingItemId = null
+          state.committingItemId = null
+          state.autoBuilding = false
+          state.autoBuildingItemId = null
+          state.batchingOutputKey = null
+          draftingField.value = null
+          state.run = adaptRun(data)
+          state.sourceType = data.sourceType as SourceTypeKey
+          state.recipeKey = data.recipeKey as RecipeKey
+          state.selectedSource = null
+          state.selections = {}
+          state.step = 'run'
+          setActiveRunId(data.id)
+        }
+      }
+    } catch {
+      // Not signed in, or no runs yet — start fresh at the source picker.
+    }
+  }
+`
+
+const PARTIAL_FIXTURE = `
+  let resumeRunRequestId = 0
+
+  async function resumeRun(): Promise<void> {
+    const requestId = ++resumeRunRequestId
+    try {
+      const remembered = safeGet(runIdKey)
+      let data: ServerRun | undefined
+
+      if (remembered) {
+        const response = await performFetch<ServerRun>(
+          \`/api/model-builder/runs/\${remembered}\`,
+        )
+        if (resumeRunRequestId !== requestId) return
+        if (
+          response.success &&
+          response.data &&
+          response.data.status !== 'CANCELLED'
+        ) {
+          data = response.data
+        } else if (response.success && response.data) {
+          safeRemove(runIdKey)
+        }
+      }
+
+      if (!data) {
+        const response = await performFetch<ServerRun[]>(
+          '/api/model-builder/runs?take=1',
+        )
+        if (
+          response.success &&
+          Array.isArray(response.data) &&
+          response.data.length
+        ) {
+          data = response.data[0]
+        }
+      }
+
+      if (data) {
+        state.run = adaptRun(data)
+        state.step = 'run'
+        setActiveRunId(data.id)
+      }
+    } catch {
+      // Not signed in, or no runs yet — start fresh at the source picker.
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkResumeRunRequestGuard(BUGGY_FIXTURE)
+assert.ok(
+  buggyErrors.some((e) => e.includes('resumeRunRequestId = 0')),
+  `expected the pre-fix shape to flag the missing request ticket, got: ${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors.some((e) =>
+    e.includes('checks `resumeRunRequestId !== requestId` only 0 time(s)'),
+  ),
+  `expected the pre-fix shape to flag zero stale-response checks, got: ${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes('does not capture')),
+  `expected the pre-fix shape to flag the missing ticket capture, got: ${JSON.stringify(buggyErrors)}`,
+)
+
+const fixedErrors = checkResumeRunRequestGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const partialErrors = checkResumeRunRequestGuard(PARTIAL_FIXTURE)
+assert.ok(
+  partialErrors.some((e) => e.includes('only 1 time(s)')),
+  `expected the partial fix (fallback fetch not scoped) to flag only 1 stale-response check, got: ${JSON.stringify(partialErrors)}`,
+)
+
+const missingFnErrors = checkResumeRunRequestGuard(MISSING_FIXTURE)
+assert.ok(
+  missingFnErrors.some((e) => e.includes('resumeRun')),
+  'expected a "function not found" violation when resumeRun is absent',
+)
+
+console.log(
+  'Model Builder resumeRun request guard checker verified: flags the ' +
+    'pre-fix shape (no request ticket), clears the fixed shape (ticket ' +
+    'captured up front and gating both sequential performFetch calls), ' +
+    'flags a partial fix (fallback fetch not scoped), and flags resumeRun ' +
+    'being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderResumeRunRequestGuard.ts
+++ b/utils/scripts/verifyModelBuilderResumeRunRequestGuard.ts
@@ -1,0 +1,141 @@
+// /utils/scripts/verifyModelBuilderResumeRunRequestGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 59) -- resumeRun() had no
+// request-scoping at all, unlike openRun()/fetchRuns()/loadSources() in this
+// same file, which each guard the identical class of bug (an async
+// list/record fetch whose response can land out of order) by capturing a
+// ticket up front and discarding any response that arrives after state has
+// moved on.
+//
+// Concrete repro: resumeRun() only ever fires from model-builder-manager.
+// vue's onMounted, but that component remounts on every navigation away
+// from and back to the Model Builder page (no keep-alive anywhere in this
+// app), and unmounting a component does not cancel its in-flight promises.
+// Navigate away, then back before the first mount's resumeRun() resolves --
+// its `resumingRun` gate is a per-mount ref, so it does not block the
+// SECOND mount's own UI once that call resolves. If the second call
+// finishes first and the user starts a genuinely different run
+// (resetRun()/openRun()) before the first, now very stale, call finally
+// resolves, that stale call's `data` -- fetched for whatever run WAS
+// remembered/latest back when it started -- lands on top of the user's new
+// run: the "adopt a different run" branch unconditionally overwrites
+// state.run and clears every in-flight singleton, exactly the class of bug
+// openRun()/fetchRuns()/loadSources() are each already guarded against.
+//
+// Fixed by a monotonic request ticket (`resumeRunRequestId`), the same
+// pattern as openRunRequestId: captured as `requestId` at the very top of
+// every call, and checked after each of resumeRun()'s two sequential
+// performFetch calls before applying (or acting on) their response.
+//
+// This asserts the textual shape of that fix stays in place -- deliberately
+// scoped to this one function/bug, mirroring
+// verifyModelBuilderOpenRunRequestGuard.ts's identical pattern for its
+// sibling function.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'resumeRun'
+const TICKET_VAR = 'resumeRunRequestId'
+
+const REQUIRED_BODY_STATEMENTS = [
+  `const requestId = ++${TICKET_VAR}`,
+  `if (${TICKET_VAR} !== requestId) return`,
+]
+
+// Checks the fix's exact shape against the full source text of a file
+// containing a `resumeRun`-named function. Exported (rather than only
+// exercised via main()) so the self-test below can run it against synthetic
+// buggy/fixed fixtures without touching the real store file.
+export function checkResumeRunRequestGuard(content: string): string[] {
+  const errors: string[] = []
+
+  if (!new RegExp(`let ${TICKET_VAR}\\s*=\\s*0`).test(content)) {
+    errors.push(
+      `Could not find \`let ${TICKET_VAR} = 0\` -- resumeRun() needs a ` +
+        'closure-scoped request ticket to tell a stale performFetch ' +
+        'response apart from the latest one, the same pattern ' +
+        'openRunRequestId already uses for openRun().',
+    )
+  }
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find a function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the race it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  const staleChecks = (
+    fn.body.match(new RegExp(`${TICKET_VAR} !== requestId`, 'g')) ?? []
+  ).length
+  if (staleChecks < 2) {
+    errors.push(
+      `${FN_NAME}() checks \`${TICKET_VAR} !== requestId\` only ` +
+        `${staleChecks} time(s) -- both sequential performFetch calls (the ` +
+        'remembered-run lookup and the latest-run fallback) must bail out ' +
+        'on a stale response, or a slower, older resumeRun() call (e.g. ' +
+        'from a component remount) can still overwrite state.run with a ' +
+        'different run after a newer call already resolved and the user ' +
+        'moved on.',
+    )
+  }
+
+  if (!fn.body.trimStart().startsWith(`const requestId = ++${TICKET_VAR}`)) {
+    errors.push(
+      `${FN_NAME}() does not capture \`const requestId = ++${TICKET_VAR}\` ` +
+        'as its first statement. The ticket must be captured before either ' +
+        'performFetch call so that ANY newer call always invalidates an ' +
+        "older call's still-pending fetches.",
+    )
+  }
+
+  for (const statement of REQUIRED_BODY_STATEMENTS) {
+    if (!fn.body.includes(statement)) {
+      errors.push(
+        `${FN_NAME}() no longer contains \`${statement}\`. Without every ` +
+          'one of these, a stale (out-of-order) response from either fetch ' +
+          'can silently overwrite state.run with data for a run the user ' +
+          'is no longer looking at.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkResumeRunRequestGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder resumeRun request guard contract failed for ' +
+        `${FN_NAME}() in modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Model Builder resumeRun request guard contract passed: ${FN_NAME}() ` +
+      'discards any performFetch response that lands after a newer call ' +
+      "has already started, mirroring openRun()'s own requestId guard.",
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
conductor model-builder/t-029, cycle 59: "Polish and upgrade Model Builder front-end surface" (recurring audit task)

### What changed
`resumeRun()` in `stores/modelBuilderStore.ts` only ever fires from `model-builder-manager.vue`'s `onMounted`, but that component remounts on every navigation away from and back to the Model Builder page (no `keep-alive` anywhere in this app), and unmounting a component does not cancel its in-flight promises.

Concrete race: navigate away, then back before the first mount's `resumeRun()` resolves — two calls race the same Pinia store singleton. If the second (new mount) call resolves first and unblocks its own UI (`model-builder-manager.vue`'s `resumingRun` gate is scoped to its own call only), the user can start a genuinely different run (`resetRun()`/`openRun()`) before the first, now stale, call finally resolves. That stale call's data then lands on top of the user's new run via `resumeRun()`'s unconditional "adopt a different run" branch — overwriting `state.run` and clearing every in-flight singleton out from under whatever the user just started.

This is the exact class of out-of-order-response bug `openRun()`/`fetchRuns()`/`loadSources()` in the same file already guard against — `resumeRun()` was the one caller missing a request ticket.

- Added `resumeRunRequestId` (monotonic ticket, same pattern as `openRunRequestId`), captured as `requestId` at the top of `resumeRun()`, checked after each of its two sequential `performFetch` calls before acting on the response.
- Added `utils/scripts/verifyModelBuilderResumeRunRequestGuard.ts` + matching `.test.ts` self-test, following the existing `verifyModelBuilder*.ts` textual-guard convention (mirrors `verifyModelBuilderOpenRunRequestGuard.ts`'s exact shape).
- Wired into `package.json` and `.github/workflows/contract-tests.yml`.

Also swept `model-builder-item-panel.vue`'s action buttons against the run-wide/group-wide in-flight gates (cycle 58's second lead) — found no gap. Every button either claims its ownership flag synchronously before its first `await` (closing the click-race window entirely), or relies on the store's existing completion-gate discard (`finishGenerateAssets`/`finishCommit`/`draftText`'s `isStageEditable` re-check) to drop a stale result rather than apply it — the same general property `verifyModelBuilderCompletionGate.ts` already enforces repo-wide. No code change needed for this half.

### How I verified
- New guard self-test: pass (`npx tsx utils/scripts/verifyModelBuilderResumeRunRequestGuard.test.ts`)
- New guard against the real store: pass
- `verifyModelBuilderContractTestsCoverageGuard.ts` (package.json ↔ workflow wiring drift check): pass
- Full `verifyModelBuilder*` suite run directly via `npx tsx` (node_modules not provisioned in this sandbox, so `npm run` scripts can't resolve `tsx` — ran each script file directly instead): selftests 72/73 pass, contract checks 74/75 pass — the one pre-existing failure in both (`verifyModelBuilderFieldBlobContinuationGuard`, needs Nuxt's generated `@/stores` path alias) is an environment limitation unrelated to this change.
- `prettier --check` on all 5 changed/added files: pass
- `eslint` / `vue-tsc --noEmit`: not run locally — `.nuxt/eslint.config.mjs` and generated types need a full `npm install` + `nuxi prepare`, not provisioned in this sandbox. PR CI's checks are the verification gate for those.

### Stakes
reversible

### Flags for Reviewer
- eslint/vue-tsc rely on CI rather than local verification (sandbox limitation, consistent with prior cycles of this same task).

### Kaizen suggestion
None beyond the task's own cycle 60 lead (recorded in the conductor roadmap note): a fresh per-button sweep of `model-builder-batch-editor.vue`'s batch-group buttons against `isItemManualActionInFlight`/completion-gate coverage, mirroring this cycle's item-panel sweep.

### Notes for reviewer
This is cycle 59 of a long-running recurring audit task (conductor model-builder/t-029). Prior 58 cycles' pattern and conventions are documented in the conductor roadmap task note.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017X5GXqCpxsUMMUPimW1HQC)_