### PR TITLE
feat(brainstorm): add a Brainstorm-variations entry point to Reward's detail view (t-028)

### DIFF
--- a/.github/workflows/brainstorm-object-entry-links-contract.yml
+++ b/.github/workflows/brainstorm-object-entry-links-contract.yml
@@ -8,6 +8,7 @@ on:
       - 'components/brainstorm/**'
       - 'components/characters/character-manager.vue'
       - 'components/scenarios/scenario-manager.vue'
+      - 'components/rewards/reward-manager.vue'
       - 'utils/scripts/verifyBrainstormObjectEntryLinks.mjs'
   pull_request:
     branches: [main]
@@ -16,6 +17,7 @@ on:
       - 'components/brainstorm/**'
       - 'components/characters/character-manager.vue'
       - 'components/scenarios/scenario-manager.vue'
+      - 'components/rewards/reward-manager.vue'
       - 'utils/scripts/verifyBrainstormObjectEntryLinks.mjs'
   workflow_dispatch:
 
@@ -28,7 +30,7 @@ concurrency:
 
 jobs:
   contract:
-    name: Character/Scenario -> Brainstorm object-entry contract
+    name: Character/Scenario/Reward -> Brainstorm object-entry contract
     runs-on: ubuntu-latest
     timeout-minutes: 5
 

--- a/components/rewards/reward-manager.vue
+++ b/components/rewards/reward-manager.vue
@@ -9,7 +9,23 @@
     @refresh="refreshManagerData"
   >
     <template #rewards>
-      <reward-interact class="h-full min-h-0 flex-1 overflow-hidden" />
+      <div class="flex h-full min-h-0 flex-1 flex-col gap-2">
+        <div
+          v-if="rewardStore.selectedReward"
+          class="flex shrink-0 justify-end"
+        >
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm rounded-xl"
+            title="Brainstorm variations grounded in this Reward"
+            @click="startBrainstormWithReward"
+          >
+            <Icon name="kind-icon:brain" class="size-4" />
+            <span class="hidden sm:inline">Brainstorm variations</span>
+          </button>
+        </div>
+        <reward-interact class="h-full min-h-0 flex-1 overflow-hidden" />
+      </div>
     </template>
 
     <template #add>
@@ -59,6 +75,19 @@ async function refreshManagerData() {
 
 function goToRewards() {
   navStore.setDashboardTab(dashboardKey, 'rewards')
+}
+
+function startBrainstormWithReward(): void {
+  const reward = rewardStore.selectedReward
+  if (!reward?.id) return
+  void navigateTo({
+    path: '/brainstorm',
+    query: {
+      source: 'reward',
+      sourceId: String(reward.id),
+      intent: `Generate variations for the Reward "${reward.name || 'this Reward'}" that preserve its effect and tone.`,
+    },
+  })
 }
 
 async function handleRewardSaved() {

--- a/stores/helpers/brainstormSourceAdapters.ts
+++ b/stores/helpers/brainstormSourceAdapters.ts
@@ -14,16 +14,17 @@
 //
 // Started with Character and Dream (BrainstormSourceRef.modelType is a free
 // string; these were the first two with real adapters). Scenario joined them
-// in brainstorm/t-014. Reward, Bot, Project, and Prompt can each register a
-// BrainstormSourceAdapter the same way, with no new API surface and no
-// bespoke endpoint -- just another entry in BRAINSTORM_SOURCE_ADAPTERS
-// backed by that entity's existing store.
+// in brainstorm/t-014, Reward in brainstorm/t-028. Bot, Project, and Prompt
+// can each register a BrainstormSourceAdapter the same way, with no new API
+// surface and no bespoke endpoint -- just another entry in
+// BRAINSTORM_SOURCE_ADAPTERS backed by that entity's existing store.
 //
 // The store-agnostic dispatch/fallback logic lives in
 // brainstormSourceAdapterKit.ts (no Pinia imports, unit-testable with plain
 // tsx) and is re-exported here bound to the real registry below.
 import { useCharacterStore } from '@/stores/characterStore'
 import { useDreamStore } from '@/stores/dreamStore'
+import { useRewardStore } from '@/stores/rewardStore'
 import { useScenarioStore } from '@/stores/scenarioStore'
 import { resolveArtImageSrc } from '@/utils/artImageSrc'
 import {
@@ -192,6 +193,54 @@ const scenarioAdapter: BrainstormSourceAdapter = {
   },
 }
 
+const rewardAdapter: BrainstormSourceAdapter = {
+  modelType: 'reward',
+  label: 'Reward',
+  async resolve(ref) {
+    if (!ref.id) return null
+    const store = useRewardStore()
+    // fetchRewardById has no force param (unlike character/scenario) -- it
+    // already serves a cached row from store.rewards before hitting the
+    // network, which is fine here since Reward carries no view-permission
+    // gate the way Character/Scenario's canView check does.
+    const reward = await store.fetchRewardById(ref.id)
+    if (!reward) return null
+
+    return {
+      modelType: 'reward',
+      id: reward.id,
+      title: reward.name || `Reward #${reward.id}`,
+      subtitle: reward.description || reward.flavorText || undefined,
+      thumbnailUrl: reward.imagePath || null,
+    }
+  },
+  async search(query) {
+    const store = useRewardStore()
+    // Same fail-closed contract as characterAdapter/dreamAdapter/
+    // scenarioAdapter: a failed fresh fetch must never fall back to
+    // searching a possibly-stale cache.
+    const freshRewards = await fetchFreshSourceRows(
+      () => store.fetchRewards(true),
+      () => Boolean(store.error),
+    )
+
+    return freshRewards
+      .filter((reward) =>
+        matchesQuery(
+          [reward.name, reward.description, reward.flavorText],
+          query,
+        ),
+      )
+      .slice(0, SEARCH_RESULT_LIMIT)
+      .map((reward) => ({
+        modelType: 'reward',
+        id: reward.id,
+        title: reward.name || `Reward #${reward.id}`,
+        subtitle: reward.description || undefined,
+      }))
+  },
+}
+
 /** The adapter registry. Keys are lowercase modelType strings. */
 export const BRAINSTORM_SOURCE_ADAPTERS: Record<
   string,
@@ -200,6 +249,7 @@ export const BRAINSTORM_SOURCE_ADAPTERS: Record<
   character: characterAdapter,
   dream: dreamAdapter,
   scenario: scenarioAdapter,
+  reward: rewardAdapter,
 }
 
 export function listBrainstormSourceAdapters(): BrainstormSourceAdapter[] {

--- a/utils/scripts/verifyBrainstormObjectEntryLinks.mjs
+++ b/utils/scripts/verifyBrainstormObjectEntryLinks.mjs
@@ -30,6 +30,7 @@ function includesAll(path, values) {
 
 const characterManagerPath = 'components/characters/character-manager.vue'
 const scenarioManagerPath = 'components/scenarios/scenario-manager.vue'
+const rewardManagerPath = 'components/rewards/reward-manager.vue'
 const brainstormManagerPath = 'components/brainstorm/brainstorm-manager.vue'
 
 includesAll(characterManagerPath, [
@@ -51,6 +52,18 @@ includesAll(scenarioManagerPath, [
   'sourceId: String(scenario.id)',
 ])
 
+// brainstorm/t-028: Reward is the third surface wired into the same
+// seedFromQuery() contract -- its BRAINSTORM_SOURCE_ADAPTERS entry (this
+// task) ships alongside its own gated CTA, unlike Scenario's adapter/CTA
+// gap in t-027.
+includesAll(rewardManagerPath, [
+  'startBrainstormWithReward',
+  '@click="startBrainstormWithReward"',
+  "path: '/brainstorm'",
+  "source: 'reward'",
+  'sourceId: String(reward.id)',
+])
+
 includesAll(brainstormManagerPath, [
   'function seedFromQuery',
   'seedFromQuery()',
@@ -62,7 +75,8 @@ includesAll(brainstormManagerPath, [
 ])
 
 console.log(
-  'Brainstorm object-entry links contract passed: Character can launch a ' +
-    'Brainstorm session grounded in itself, and Brainstorm still seeds its ' +
-    'source and premise from the source/sourceId/intent query keys.',
+  'Brainstorm object-entry links contract passed: Character, Scenario, and ' +
+    'Reward can each launch a Brainstorm session grounded in themselves, ' +
+    'and Brainstorm still seeds its source and premise from the ' +
+    'source/sourceId/intent query keys.',
 )


### PR DESCRIPTION
### Task
brainstorm/t-028: Add a Brainstorm-variations entry point to Reward's detail view (kind: software)

### What changed / what I produced
- Registered a `rewardAdapter` in `BRAINSTORM_SOURCE_ADAPTERS` (`stores/helpers/brainstormSourceAdapters.ts`), mirroring the Scenario adapter's shape: `resolve()` via `fetchRewardById`, `search()` via the same fail-closed `fetchFreshSourceRows` contract already used by Character/Dream/Scenario.
- Added a `v-if="rewardStore.selectedReward"` gating div + "Brainstorm variations" button to `reward-manager.vue`'s `#rewards` slot, following the same `startBrainstormWith*()` → `navigateTo({ source, sourceId, intent })` pattern as `character-manager.vue`/`scenario-manager.vue`.
- Extended `verifyBrainstormObjectEntryLinks.mjs` with a Reward assertion block (CTA handler exists, wires `source: 'reward'`/`sourceId`/query-driven navigation).
- Added `components/rewards/reward-manager.vue` to the `brainstorm-object-entry-links-contract.yml` workflow's path triggers so the contract actually runs when that file changes (it wasn't covered before).

### How I verified
- `node utils/scripts/verifyBrainstormObjectEntryLinks.mjs` — passes.
- `npm run test:brainstorm-source-adapters` — passes.
- `npx eslint` on all 3 changed source files — clean.
- `npx prettier --check` on all 4 changed files — clean.
- Full-project `npx vue-tsc --noEmit` — exit 0.
- `git status --porcelain` scoped to exactly the 4 intended files (reverted an incidental `prisma generate` regen diff from local provisioning before committing).

### Stakes
reversible

### Notes for reviewer
Reward's `fetchRewardById` has no `force` param (unlike Character's/Scenario's `fetchCharacterById(id, true)`/`fetchScenarioById(id, true)`) — it already serves a cached row before hitting the network. This is fine here since, unlike Character/Scenario, Reward carries no per-request `canView` authorization gate the force-revalidate pattern exists to re-check; noted inline in the adapter.

### Kaizen suggestion
Bot and Project are the two remaining core entities without a `BrainstormSourceAdapter`/CTA pair (Prompt has no natural "detail view" to hang a button on). Bot in particular already has an interact-style detail surface analogous to Reward's, so it's the next-cheapest slice in this same series.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPV8akWFkDbuAR1zoPW7rp)_