### PR TITLE
fix(davinci,storybook): extract shared persisted-art-job resume composable (t-025)

### DIFF
--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -447,7 +447,7 @@ import { performFetch } from '@/stores/utils'
 import { useUserStore } from '@/stores/userStore'
 import type { ProjectFrontConfig } from '@/components/conductor/projectFront'
 import { useAchievementStore } from '@/stores/achievementStore'
-import { createNarrativeArtJobsController } from '@/stores/helpers/narrativeArtJobsHelper'
+import { createPersistedNarrativeArtJobsController } from '@/stores/helpers/persistedNarrativeArtJobsHelper'
 import type { NarrativeArtJobState } from '@/utils/narrativeArtJobs'
 import type { NarrativeChoice } from '@/components/narrative/kr-choice-list.vue'
 
@@ -780,7 +780,7 @@ const phaseRegion = ref<HTMLElement | null>(null)
 // ArtImage — see server/utils/davinci.ts's attachLifeRunArt. Reading/choosing
 // never blocks on this: chapterArt/endingArt render a pending/skeleton state
 // via <NarrativeArtStatus> until the illustration is ready.
-const narrativeArtJobs = createNarrativeArtJobsController()
+const narrativeArtJobs = createPersistedNarrativeArtJobsController()
 const chapterArt = ref<Record<number, NarrativeArtJobState>>({})
 const endingArt = ref<NarrativeArtJobState | null>(null)
 const lastArtPrompt = ref<string | null>(null)
@@ -998,20 +998,14 @@ function updateEndingArt(runId: number, art: NarrativeArtJobState) {
 // to the run. Best-effort and non-blocking, same as persistLifeRunArt --
 // losing this cache (private browsing, a cleared storage, JSON.stringify
 // somehow throwing) only means a slower reconnect on reload, not a broken run.
+// The read/write mechanics are shared with storybookStore.ts's equivalent
+// pattern via persistedNarrativeArtJobsHelper.ts (davinci/t-025).
 function persistArtJobs() {
   if (!run.value) return
-  try {
-    localStorage.setItem(
-      ART_JOBS_STORAGE_KEY,
-      JSON.stringify({
-        runId: run.value.id,
-        chapterArt: chapterArt.value,
-        endingArt: endingArt.value,
-      }),
-    )
-  } catch {
-    // best-effort cache -- see the doc comment above.
-  }
+  narrativeArtJobs.writeCache(ART_JOBS_STORAGE_KEY, run.value.id, {
+    chapterArt: chapterArt.value,
+    endingArt: endingArt.value,
+  })
 }
 
 // The other half of persistArtJobs() above: called once per resumeRun(),
@@ -1026,18 +1020,11 @@ function persistArtJobs() {
 // blank until the first poll response) also restores a failed job's retry
 // button immediately, not just a still-in-flight job's busy indicator.
 function resumePendingArtJobs(runId: number) {
-  let cached: {
-    runId?: number
+  const cached = narrativeArtJobs.readCache<{
     chapterArt?: Record<string, NarrativeArtJobState>
     endingArt?: NarrativeArtJobState | null
-  } | null = null
-  try {
-    const raw = localStorage.getItem(ART_JOBS_STORAGE_KEY)
-    cached = raw ? JSON.parse(raw) : null
-  } catch {
-    cached = null
-  }
-  if (!cached || cached.runId !== runId) return
+  }>(ART_JOBS_STORAGE_KEY, runId)
+  if (!cached) return
 
   for (const [key, state] of Object.entries(cached.chapterArt ?? {})) {
     const chapter = Number(key)

--- a/stores/helpers/persistedNarrativeArtJobsHelper.ts
+++ b/stores/helpers/persistedNarrativeArtJobsHelper.ts
@@ -1,0 +1,109 @@
+// /stores/helpers/persistedNarrativeArtJobsHelper.ts
+//
+// Shared resume-on-reload wiring for narrativeArtJobsHelper's async art jobs
+// (davinci/t-025, kaizen from t-021 slice 14 / kind_robots#2046).
+// storybookStore.ts, taskmasterStore.ts, and davinci-page.vue each
+// independently persist a long-lived art job's in-flight state to
+// localStorage so a page reload/remount can find it again, then call
+// narrativeArtJobsHelper's resume() unconditionally on whatever the cache
+// holds (resume() already no-ops safely for a terminal 'done'/'failed'/
+// 'cancelled' state). storybookStore.ts and taskmasterStore.ts are, in
+// fact, byte-for-byte the same shape -- the exact "third narrative surface"
+// t-025's kaizen note anticipated turned out to already exist at the time
+// this task was picked up (verifyNarrativeArtPersistence.mjs enforces both
+// stores stay in lockstep).
+//
+// This wraps createNarrativeArtJobsController() so all three call sites
+// share one controller-creation entrypoint, and adds the two genuinely
+// reusable pieces of that pattern:
+//   - a best-effort, owner-scoped localStorage cache (read/write), for a
+//     surface that needs its own dedicated art-jobs cache key (davinci-page.vue
+//     does -- a queued/rendering LifeRunArt job has no server-side row until
+//     it reaches 'done', so hydrateArtFromRun() alone can never see it);
+//   - resumeEntries(), which loops a collection of cached job states and
+//     calls resume() for each one, so a future fourth narrative surface with
+//     its own keyed collection doesn't need to hand-roll that loop either.
+//
+// storybookStore.ts's and taskmasterStore.ts's beats already ride inside
+// each store's own persisted session JSON (persist()/restoreFromLocalStorage())
+// -- neither has a separate art-jobs cache to own, so they only use the
+// controller + resumeEntries() below, not readCache()/writeCache().
+// davinci-page.vue uses all of it. See
+// utils/scripts/verifyDaVinciArtResumeGuard.ts for the regression guard that
+// covers davinci-page.vue's specific usage, and
+// utils/scripts/verifyNarrativeArtPersistence.mjs for the one covering
+// storybookStore.ts/taskmasterStore.ts.
+import { createNarrativeArtJobsController } from '@/stores/helpers/narrativeArtJobsHelper'
+import type { NarrativeArtJobState } from '@/utils/narrativeArtJobs'
+
+function readLocalStorage(key: string): string | null {
+  if (typeof localStorage === 'undefined') return null
+  try {
+    return localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+function writeLocalStorage(key: string, value: string): void {
+  if (typeof localStorage === 'undefined') return
+  try {
+    localStorage.setItem(key, value)
+  } catch {
+    // Private browsing and storage quotas should not break the caller.
+  }
+}
+
+export function createPersistedNarrativeArtJobsController() {
+  const controller = createNarrativeArtJobsController()
+
+  /** Best-effort cache read, scoped to `ownerId` (e.g. a run/session id).
+   * Returns null on any parse failure or an ownerId mismatch (a cache left
+   * over from a different run/session than the one being resumed). */
+  function readCache<T>(storageKey: string, ownerId: number): T | null {
+    const raw = readLocalStorage(storageKey)
+    if (!raw) return null
+    try {
+      const parsed = JSON.parse(raw) as { ownerId?: number; payload?: T }
+      if (parsed.ownerId !== ownerId) return null
+      return parsed.payload ?? null
+    } catch {
+      return null
+    }
+  }
+
+  /** Best-effort cache write, scoped to `ownerId`. Safe to call on every
+   * job-state transition -- a failed write only means a slower reconnect on
+   * the next reload, never a broken caller. */
+  function writeCache<T>(
+    storageKey: string,
+    ownerId: number,
+    payload: T,
+  ): void {
+    writeLocalStorage(storageKey, JSON.stringify({ ownerId, payload }))
+  }
+
+  /** Calls resume() for every non-null entry in `entries`. Safe to call
+   * unconditionally over a whole cached collection -- resume() itself no-ops
+   * for a terminal state. */
+  function resumeEntries<K>(
+    entries: Iterable<readonly [K, NarrativeArtJobState | null | undefined]>,
+    onUpdate: (key: K, next: NarrativeArtJobState) => void,
+  ): void {
+    for (const [key, state] of entries) {
+      if (!state) continue
+      controller.resume(state, (next: NarrativeArtJobState) =>
+        onUpdate(key, next),
+      )
+    }
+  }
+
+  return {
+    enqueue: controller.enqueue,
+    resume: controller.resume,
+    retry: controller.retry,
+    resumeEntries,
+    readCache,
+    writeCache,
+  }
+}

--- a/stores/storybookStore.ts
+++ b/stores/storybookStore.ts
@@ -3,7 +3,7 @@
 // task write-back behavior; the two products share presentation only.
 import { computed, ref, watch } from 'vue'
 import { defineStore } from 'pinia'
-import { createNarrativeArtJobsController } from '@/stores/helpers/narrativeArtJobsHelper'
+import { createPersistedNarrativeArtJobsController } from '@/stores/helpers/persistedNarrativeArtJobsHelper'
 import { createStorybookLibraryController } from '@/stores/helpers/storybookLibraryHelper'
 import { useChatStore } from '@/stores/chatStore'
 import { useUserStore } from '@/stores/userStore'
@@ -329,7 +329,7 @@ function normalizeRestoredSession(value: StorybookSession): StorybookSession {
 export const useStorybookStore = defineStore('storybookStore', () => {
   const chatStore = useChatStore()
   const userStore = useUserStore()
-  const narrativeArtJobs = createNarrativeArtJobsController()
+  const narrativeArtJobs = createPersistedNarrativeArtJobsController()
 
   const setupDraft = ref<StorybookSetupDraft>(defaultDraft())
   const session = ref<StorybookSession | null>(null)
@@ -507,10 +507,14 @@ export const useStorybookStore = defineStore('storybookStore', () => {
   }
 
   function resumeNarrativeArtJobs(): void {
-    for (const beat of session.value?.beats ?? []) {
-      if (!beat.art) continue
-      narrativeArtJobs.resume(beat.art, (art) => updateBeatArt(beat.id, art))
-    }
+    // davinci/t-025: shared resume-all-cached-entries wiring (see
+    // persistedNarrativeArtJobsHelper.ts) -- beats already ride inside this
+    // store's own persisted session JSON, so this only needs the resume
+    // loop, not the helper's cache read/write.
+    narrativeArtJobs.resumeEntries(
+      (session.value?.beats ?? []).map((beat) => [beat.id, beat.art] as const),
+      (beatId, art) => updateBeatArt(beatId, art),
+    )
   }
 
   function retryBeatArt(beatId: string): void {

--- a/stores/taskmasterStore.ts
+++ b/stores/taskmasterStore.ts
@@ -3,7 +3,7 @@
 // behind an explicit per-item Apply action; conductor roadmap YAML is read-only.
 import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
-import { createNarrativeArtJobsController } from '@/stores/helpers/narrativeArtJobsHelper'
+import { createPersistedNarrativeArtJobsController } from '@/stores/helpers/persistedNarrativeArtJobsHelper'
 import { useChatStore } from '@/stores/chatStore'
 import { useConductorStore } from '@/stores/conductorStore'
 import { useProjectStore } from '@/stores/projectStore'
@@ -179,7 +179,7 @@ export const useTaskmasterStore = defineStore('taskmasterStore', () => {
   const projectStore = useProjectStore()
   const todoStore = useTodoStore()
   const userStore = useUserStore()
-  const narrativeArtJobs = createNarrativeArtJobsController()
+  const narrativeArtJobs = createPersistedNarrativeArtJobsController()
 
   const session = ref<TaskmasterSession | null>(null)
   const isWeaving = ref(false)
@@ -630,10 +630,14 @@ export const useTaskmasterStore = defineStore('taskmasterStore', () => {
   }
 
   function resumeNarrativeArtJobs(): void {
-    for (const beat of session.value?.beats ?? []) {
-      if (!beat.art) continue
-      narrativeArtJobs.resume(beat.art, (art) => updateBeatArt(beat.id, art))
-    }
+    // davinci/t-025: shared resume-all-cached-entries wiring (see
+    // persistedNarrativeArtJobsHelper.ts) -- beats already ride inside this
+    // store's own persisted session JSON, so this only needs the resume
+    // loop, not the helper's cache read/write.
+    narrativeArtJobs.resumeEntries(
+      (session.value?.beats ?? []).map((beat) => [beat.id, beat.art] as const),
+      (beatId, art) => updateBeatArt(beatId, art),
+    )
   }
 
   function retryBeatArt(beatId: string): void {

--- a/utils/scripts/verifyDaVinciArtResumeGuard.test.ts
+++ b/utils/scripts/verifyDaVinciArtResumeGuard.test.ts
@@ -1,7 +1,9 @@
 // /utils/scripts/verifyDaVinciArtResumeGuard.test.ts
 //
 // Regression test for checkArtResumeGuard() in verifyDaVinciArtResumeGuard.ts
-// (davinci/t-021 slice 14). Exercises the real check against synthetic
+// (davinci/t-021 slice 14; cache read/write moved to
+// createPersistedNarrativeArtJobsController()'s readCache()/writeCache() in
+// davinci/t-025). Exercises the real check against synthetic
 // component-shaped fixtures covering: the fixed shape (both update
 // functions persist, resumePendingArtJobs() reads the cache and resumes
 // both slots while seeding chapterArt first, resumeRun() calls it after
@@ -35,11 +37,10 @@ function updateEndingArt(runId: number, art: NarrativeArtJobState) {
 
 function persistArtJobs() {
   if (!run.value) return
-  localStorage.setItem(ART_JOBS_STORAGE_KEY, JSON.stringify({
-    runId: run.value.id,
+  narrativeArtJobs.writeCache(ART_JOBS_STORAGE_KEY, run.value.id, {
     chapterArt: chapterArt.value,
     endingArt: endingArt.value,
-  }))
+  })
 }
 
 function resumePendingArtJobs(runId: number) {
@@ -87,9 +88,11 @@ const FIXED_ARGS = {
   updateChapterPersist: 'persistArtJobs()',
   updateEndingPersist: 'persistArtJobs()',
   resumePendingBody: `
-    const raw = localStorage.getItem(ART_JOBS_STORAGE_KEY)
-    const cached = raw ? JSON.parse(raw) : null
-    if (!cached || cached.runId !== runId) return
+    const cached = narrativeArtJobs.readCache<{
+      chapterArt?: Record<string, NarrativeArtJobState>
+      endingArt?: NarrativeArtJobState | null
+    }>(ART_JOBS_STORAGE_KEY, runId)
+    if (!cached) return
     for (const [key, state] of Object.entries(cached.chapterArt ?? {})) {
       const chapter = Number(key)
       updateChapterArt(runId, chapter, state)
@@ -157,9 +160,11 @@ function run(): void {
     fixture({
       ...FIXED_ARGS,
       resumePendingBody: `
-        const raw = localStorage.getItem(ART_JOBS_STORAGE_KEY)
-        const cached = raw ? JSON.parse(raw) : null
-        if (!cached || cached.runId !== runId) return
+        const cached = narrativeArtJobs.readCache<{
+          chapterArt?: Record<string, NarrativeArtJobState>
+          endingArt?: NarrativeArtJobState | null
+        }>(ART_JOBS_STORAGE_KEY, runId)
+        if (!cached) return
         for (const [key, state] of Object.entries(cached.chapterArt ?? {})) {
           const chapter = Number(key)
           updateChapterArt(runId, chapter, state)
@@ -178,9 +183,11 @@ function run(): void {
     fixture({
       ...FIXED_ARGS,
       resumePendingBody: `
-        const raw = localStorage.getItem(ART_JOBS_STORAGE_KEY)
-        const cached = raw ? JSON.parse(raw) : null
-        if (!cached || cached.runId !== runId) return
+        const cached = narrativeArtJobs.readCache<{
+          chapterArt?: Record<string, NarrativeArtJobState>
+          endingArt?: NarrativeArtJobState | null
+        }>(ART_JOBS_STORAGE_KEY, runId)
+        if (!cached) return
         for (const [key, state] of Object.entries(cached.chapterArt ?? {})) {
           const chapter = Number(key)
           narrativeArtJobs.resume(state, (art) => updateChapterArt(runId, chapter, art))

--- a/utils/scripts/verifyDaVinciArtResumeGuard.ts
+++ b/utils/scripts/verifyDaVinciArtResumeGuard.ts
@@ -29,13 +29,22 @@
 // hydrateArtFromRun() to seed back and reconnect anything the server
 // hydration didn't already cover.
 //
+// davinci/t-025: persistArtJobs()/resumePendingArtJobs() now read/write that
+// cache through createPersistedNarrativeArtJobsController()'s writeCache()/
+// readCache() (persistedNarrativeArtJobsHelper.ts) instead of calling
+// localStorage directly -- the same controller storybookStore.ts's
+// resumeNarrativeArtJobs() uses for its resume loop -- but the function
+// names, the ART_JOBS_STORAGE_KEY cache key, and the seed-then-resume shape
+// this guard protects are unchanged.
+//
 // This asserts the textual shape of the fix stays in place: both update
 // functions persist on every call, resumePendingArtJobs() reads the cache
-// and calls narrativeArtJobs.resume() for both the chapter and ending slots,
-// resumeRun() calls it after hydrating from the server, and playAgain()
-// clears the cache along with the existing active-run-id key. Deliberately
-// scoped via narrow textual checks, mirroring this project's other guards
-// over a general-purpose static analyzer (see verifyDaVinciDimensionToneGuard.ts).
+// via readCache() and calls narrativeArtJobs.resume() for both the chapter
+// and ending slots, resumeRun() calls it after hydrating from the server,
+// and playAgain() clears the cache along with the existing active-run-id
+// key. Deliberately scoped via narrow textual checks, mirroring this
+// project's other guards over a general-purpose static analyzer (see
+// verifyDaVinciDimensionToneGuard.ts).
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -112,13 +121,13 @@ export function checkArtResumeGuard(content: string): string[] {
     )
   } else {
     if (
-      !/localStorage\.getItem\(\s*ART_JOBS_STORAGE_KEY\s*\)/.test(
+      !/narrativeArtJobs\.readCache[\s\S]*?\(\s*ART_JOBS_STORAGE_KEY\s*,/.test(
         resumePendingArtJobs,
       )
     ) {
       errors.push(
-        'resumePendingArtJobs() no longer reads ART_JOBS_STORAGE_KEY from ' +
-          'localStorage -- it has nothing to resume from.',
+        'resumePendingArtJobs() no longer reads ART_JOBS_STORAGE_KEY via ' +
+          'narrativeArtJobs.readCache() -- it has nothing to resume from.',
       )
     }
     const chapterResumeCount = (

--- a/utils/scripts/verifyNarrativeArtPersistence.mjs
+++ b/utils/scripts/verifyNarrativeArtPersistence.mjs
@@ -156,10 +156,15 @@ assert.ok(
 for (const storePath of [storyStorePath, taskStorePath]) {
   includesAll(storePath, [
     'art?: NarrativeArtJobState',
-    'createNarrativeArtJobsController()',
+    // davinci/t-025: both stores now share
+    // createPersistedNarrativeArtJobsController() (which itself wraps
+    // createNarrativeArtJobsController()) instead of calling the bare
+    // controller factory directly.
+    'createPersistedNarrativeArtJobsController()',
     'updateBeatArt',
     'requestBeatArt',
     'resumeNarrativeArtJobs',
+    'resumeEntries',
     'retryBeatArt',
     "? 'finale'",
     "? 'opening'",


### PR DESCRIPTION
### Task
davinci/t-025: Extract narrativeArtJobsHelper's resume/cache pattern into a shared composable (kind: software)

### What changed / what I produced
- Added `stores/helpers/persistedNarrativeArtJobsHelper.ts` (`createPersistedNarrativeArtJobsController()`), wrapping `createNarrativeArtJobsController()` with the two genuinely reusable pieces of the duplicated pattern: an owner-scoped best-effort localStorage cache (`readCache`/`writeCache`) and a `resumeEntries()` loop over a keyed collection of cached job states.
- `stores/storybookStore.ts` **and** `stores/taskmasterStore.ts`: `resumeNarrativeArtJobs()` now iterates `session.beats` via `resumeEntries()` instead of a hand-rolled for-loop. Persistence stays as-is — beats already ride inside each store's own persisted session JSON, so neither needs the cache read/write half.
  - CI caught something my initial investigation missed: `taskmasterStore.ts` is a byte-for-byte identical third copy of this pattern (`verifyNarrativeArtPersistence.mjs` keeps the two stores in lockstep), i.e. the exact "third narrative surface" this task's own note named as the trigger for doing the full extraction. Migrated it too.
- `components/conductor/davinci-page.vue`: `persistArtJobs()`/`resumePendingArtJobs()` now read/write the `ART_JOBS_STORAGE_KEY` cache via the composable's `readCache()`/`writeCache()` instead of calling `localStorage` directly. Behavior is unchanged — same cache key, same seed-then-resume shape, same runId-staleness check.
- Updated `utils/scripts/verifyDaVinciArtResumeGuard.ts`'s textual checks (and its self-test) and `verifyNarrativeArtPersistence.mjs`'s store-contract checks to match the new shape while still asserting the same protected invariants.

### How I verified
- All 27 `test:davinci-*` + 23 `test:storybook-*` contract-test scripts pass, plus `verifyNarrativeArtPersistence.mjs` directly (this is what caught the taskmaster gap in CI on the first push).
- `eslint` clean on every touched file (2 pre-existing, unrelated `storybookStore.ts` errors confirmed present on `main` before this change).
- `prettier --check` clean on every file except `taskmasterStore.ts` and `verifyNarrativeArtPersistence.mjs`, both confirmed already prettier-noncompliant on `main` before this change (pre-existing repo-wide drift) — kept the diff to exactly the lines this task touches rather than letting a full-file `prettier --write` introduce unrelated reformatting across either file.
- `vue-tsc --noEmit` shows only one pre-existing, unrelated error in `server/api/reactions/index.post.ts` — confirmed present on `main` via `git stash` before this diff.

### Stakes
reversible

### Flags for Reviewer
- Not urgent per the task's own note; scoped to exactly the composable + migrating the three existing call sites (once taskmaster surfaced), no speculative refactor of any store's session-persistence format.
- `verifyDaVinciArtResumeGuard.ts` is one of this project's "narrow textual checker" regression guards — I updated its checks to match the relocated (but behaviorally identical) implementation rather than leave it stale or route around it.

### Kaizen suggestion
Fix the pre-existing `prisma/generated` staleness surfaced by `vue-tsc` (`BUTTERFLY` missing from `Reaction_reactionCategory`'s `ExpectedTargetField` map in `server/api/reactions/index.post.ts`) — unrelated to this change, confirmed present on `main`.

### Notes for reviewer
Companion conductor close-out branch already pushed (`status: review`), will follow with `status: done` after this merges.
