### PR TITLE
feat(brainstorm): add a Brainstorm-variations entry point to Bot's detail view (t-029)

### DIFF
--- a/components/bots/bot-manager.vue
+++ b/components/bots/bot-manager.vue
@@ -9,7 +9,20 @@
     @refresh="refreshManagerData"
   >
     <template #bots>
-      <bot-interact class="h-full min-h-0 flex-1 overflow-hidden" />
+      <div class="flex h-full min-h-0 flex-1 flex-col gap-2">
+        <div v-if="botStore.selectedBot" class="flex shrink-0 justify-end">
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm rounded-xl"
+            title="Brainstorm variations grounded in this Bot"
+            @click="startBrainstormWithBot"
+          >
+            <Icon name="kind-icon:brain" class="size-4" />
+            <span class="hidden sm:inline">Brainstorm variations</span>
+          </button>
+        </div>
+        <bot-interact class="h-full min-h-0 flex-1 overflow-hidden" />
+      </div>
     </template>
 
     <template #forge>
@@ -77,6 +90,19 @@ async function refreshManagerData() {
 
 function goToBots() {
   navStore.setDashboardTab(dashboardKey, 'bots')
+}
+
+function startBrainstormWithBot(): void {
+  const bot = botStore.selectedBot
+  if (!bot?.id) return
+  void navigateTo({
+    path: '/brainstorm',
+    query: {
+      source: 'bot',
+      sourceId: String(bot.id),
+      intent: `Generate variations for the Bot "${bot.name || 'this Bot'}" that preserve its personality and voice.`,
+    },
+  })
 }
 
 async function handleBotSaved() {

--- a/stores/helpers/brainstormSourceAdapters.ts
+++ b/stores/helpers/brainstormSourceAdapters.ts
@@ -14,14 +14,15 @@
 //
 // Started with Character and Dream (BrainstormSourceRef.modelType is a free
 // string; these were the first two with real adapters). Scenario joined them
-// in brainstorm/t-014, Reward in brainstorm/t-028. Bot, Project, and Prompt
-// can each register a BrainstormSourceAdapter the same way, with no new API
-// surface and no bespoke endpoint -- just another entry in
-// BRAINSTORM_SOURCE_ADAPTERS backed by that entity's existing store.
+// in brainstorm/t-014, Reward in brainstorm/t-028, Bot in brainstorm/t-029.
+// Project and Prompt can each register a BrainstormSourceAdapter the same
+// way, with no new API surface and no bespoke endpoint -- just another entry
+// in BRAINSTORM_SOURCE_ADAPTERS backed by that entity's existing store.
 //
 // The store-agnostic dispatch/fallback logic lives in
 // brainstormSourceAdapterKit.ts (no Pinia imports, unit-testable with plain
 // tsx) and is re-exported here bound to the real registry below.
+import { useBotStore } from '@/stores/botStore'
 import { useCharacterStore } from '@/stores/characterStore'
 import { useDreamStore } from '@/stores/dreamStore'
 import { useRewardStore } from '@/stores/rewardStore'
@@ -241,6 +242,54 @@ const rewardAdapter: BrainstormSourceAdapter = {
   },
 }
 
+const botAdapter: BrainstormSourceAdapter = {
+  modelType: 'bot',
+  label: 'Bot',
+  async resolve(ref) {
+    if (!ref.id) return null
+    const store = useBotStore()
+    // loadBotById has no force param -- like rewardAdapter, it serves a
+    // cached row from store.bots before hitting the network, which is fine
+    // here since Bot carries no view-permission gate the way
+    // Character/Scenario's canView check does.
+    const bot = await store.loadBotById(ref.id)
+    if (!bot) return null
+
+    return {
+      modelType: 'bot',
+      id: bot.id,
+      title: bot.name || `Bot #${bot.id}`,
+      subtitle: bot.subtitle || bot.tagline || bot.description || undefined,
+      thumbnailUrl: bot.avatarImage || bot.imagePath || null,
+    }
+  },
+  async search(query) {
+    const store = useBotStore()
+    // Same fail-closed contract as characterAdapter/dreamAdapter/
+    // scenarioAdapter/rewardAdapter: a failed fresh fetch must never fall
+    // back to searching a possibly-stale cache.
+    const freshBots = await fetchFreshSourceRows(
+      () => store.fetchBots(true),
+      () => Boolean(store.error),
+    )
+
+    return freshBots
+      .filter((bot) =>
+        matchesQuery(
+          [bot.name, bot.subtitle, bot.tagline, bot.description],
+          query,
+        ),
+      )
+      .slice(0, SEARCH_RESULT_LIMIT)
+      .map((bot) => ({
+        modelType: 'bot',
+        id: bot.id,
+        title: bot.name || `Bot #${bot.id}`,
+        subtitle: bot.subtitle || bot.tagline || undefined,
+      }))
+  },
+}
+
 /** The adapter registry. Keys are lowercase modelType strings. */
 export const BRAINSTORM_SOURCE_ADAPTERS: Record<
   string,
@@ -250,6 +299,7 @@ export const BRAINSTORM_SOURCE_ADAPTERS: Record<
   dream: dreamAdapter,
   scenario: scenarioAdapter,
   reward: rewardAdapter,
+  bot: botAdapter,
 }
 
 export function listBrainstormSourceAdapters(): BrainstormSourceAdapter[] {

--- a/utils/scripts/verifyBrainstormObjectEntryLinks.mjs
+++ b/utils/scripts/verifyBrainstormObjectEntryLinks.mjs
@@ -31,6 +31,7 @@ function includesAll(path, values) {
 const characterManagerPath = 'components/characters/character-manager.vue'
 const scenarioManagerPath = 'components/scenarios/scenario-manager.vue'
 const rewardManagerPath = 'components/rewards/reward-manager.vue'
+const botManagerPath = 'components/bots/bot-manager.vue'
 const brainstormManagerPath = 'components/brainstorm/brainstorm-manager.vue'
 
 includesAll(characterManagerPath, [
@@ -64,6 +65,18 @@ includesAll(rewardManagerPath, [
   'sourceId: String(reward.id)',
 ])
 
+// brainstorm/t-029: Bot is the fourth surface wired into the same
+// seedFromQuery() contract, following the same adapter/CTA pair Reward
+// shipped in t-028 (BRAINSTORM_SOURCE_ADAPTERS entry + a gated CTA in the
+// same PR, not split across two tasks the way Scenario's was in t-027).
+includesAll(botManagerPath, [
+  'startBrainstormWithBot',
+  '@click="startBrainstormWithBot"',
+  "path: '/brainstorm'",
+  "source: 'bot'",
+  'sourceId: String(bot.id)',
+])
+
 includesAll(brainstormManagerPath, [
   'function seedFromQuery',
   'seedFromQuery()',
@@ -75,8 +88,8 @@ includesAll(brainstormManagerPath, [
 ])
 
 console.log(
-  'Brainstorm object-entry links contract passed: Character, Scenario, and ' +
-    'Reward can each launch a Brainstorm session grounded in themselves, ' +
-    'and Brainstorm still seeds its source and premise from the ' +
-    'source/sourceId/intent query keys.',
+  'Brainstorm object-entry links contract passed: Character, Scenario, ' +
+    'Reward, and Bot can each launch a Brainstorm session grounded in ' +
+    'themselves, and Brainstorm still seeds its source and premise from ' +
+    'the source/sourceId/intent query keys.',
 )


### PR DESCRIPTION
### Task
brainstorm/t-029: Add a Brainstorm-variations entry point to Bot's detail view (kind: software)

### What changed / what I produced
- Registered `botAdapter` in `BRAINSTORM_SOURCE_ADAPTERS` (`stores/helpers/brainstormSourceAdapters.ts`), mirroring `rewardAdapter`'s shape: `resolve()` via `botStore.loadBotById` (no force param, same as reward — Bot carries no view-permission gate), `search()` via `botStore.fetchBots(true)` with the same fail-closed fresh-fetch contract as every other adapter.
- Added a `v-if="botStore.selectedBot"` gated "Brainstorm variations" CTA to `bot-manager.vue`'s `#bots` template, wired to `startBrainstormWithBot()` (same `navigateTo('/brainstorm', {source, sourceId, intent})` shape as `startBrainstormWithReward()`).
- Extended `verifyBrainstormObjectEntryLinks.mjs` with a Bot assertion block.
- `brainstorm-manager.vue`'s `seedFromQuery()` is already source-agnostic (reads `route.query.source` as a modelType string, dispatches via the adapter registry) — no changes needed there.

### How I verified
- All 5 `test:brainstorm-*` contract scripts pass, plus `verifyBrainstormObjectEntryLinks.mjs` directly.
- `eslint` clean, `prettier --check` clean.
- `vue-tsc --noEmit` shows only the same pre-existing, unrelated error in `server/api/reactions/index.post.ts` (tracked as davinci/t-026).
- `test:layout-contract` holds, no new violations.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Project is the one other entity flagged (t-027's note) as having a natural detail-view home for the same adapter/CTA pattern — could be its own follow-on task.

### Notes for reviewer
Companion conductor close-out branch already pushed (`status: review`), will follow with `status: done` after this merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_011ctaF2TkMsWwMrsgo7dPbC)_