### PR TITLE
fix(storybook,taskmaster): scope streamingText to each session's own chat (t-010 cycle 34)

### DIFF
--- a/.github/workflows/narrative-streaming-text-isolation-contract.yml
+++ b/.github/workflows/narrative-streaming-text-isolation-contract.yml
@@ -1,0 +1,30 @@
+name: Narrative Streaming Text Isolation Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: narrative-streaming-text-isolation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Narrative streaming-text isolation contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify narrative streaming-text isolation guard
+        run: node utils/scripts/verifyNarrativeStreamingTextIsolationGuard.mjs

--- a/stores/chatStore.ts
+++ b/stores/chatStore.ts
@@ -110,6 +110,21 @@ export interface GenerateTextData {
 
 type StreamResponseOptions = Omit<GenerateTextData, 'prompt'>
 
+/**
+ * Fired synchronously once `generateText` has created its chat row and is
+ * about to start streaming into it -- before the function's own `await`
+ * settles. Lets a caller capture the concrete chat id it owns instead of
+ * relying on the module-level `pendingChatId` singleton, which two
+ * concurrent `generateText` calls (Storybook and Taskmaster both call it
+ * from the same shared chatStore) would otherwise race: whichever call's
+ * chat was created last wins the singleton while it streams, and whichever
+ * call's `finally` runs first unconditionally nulls it out from under a
+ * still-streaming sibling call. See `chatText()` below for the read side.
+ */
+type GenerateTextHooks = {
+  onChatId?: (chatId: number) => void
+}
+
 type GenerateTextResult = {
   chat: Chat
   text: string
@@ -477,6 +492,29 @@ export const useChatStore = defineStore('chatStore', () => {
   })
 
   const pendingText = computed(() => pendingChat.value?.botResponse ?? '')
+
+  /**
+   * The live `botResponse` for a specific chat id, independent of the
+   * `pendingChatId` singleton above.
+   *
+   * `pendingChatId`/`pendingChat`/`pendingText` reflect whichever
+   * `generateText` call most recently started -- fine for a single active
+   * caller, but storybookStore and taskmasterStore each call
+   * `chatStore.generateText()` from their own `weaveBeat`, and neither
+   * cancels its in-flight call on navigation. If both happen to be
+   * streaming at once (e.g. the reader leaves Storybook mid-scene and
+   * answers a Taskmaster beat before Storybook's own call resolves), the
+   * singleton can point at the WRONG caller's chat, or get nulled by
+   * whichever call's `finally` happens to run first -- surfacing one
+   * product's streaming prose inside the other's transcript, or blanking a
+   * still-streaming one back to the loading state. Callers that captured
+   * their own chat id via `generateText`'s `onChatId` hook should read it
+   * through here instead.
+   */
+  function chatText(chatId: number | null): string {
+    if (chatId === null) return ''
+    return chats.value.find((chat) => chat.id === chatId)?.botResponse ?? ''
+  }
 
   function setGenerationMessage(
     tone: 'success' | 'error',
@@ -1332,6 +1370,7 @@ export const useChatStore = defineStore('chatStore', () => {
 
   async function generateText(
     data: Partial<GenerateTextData> = {},
+    hooks: GenerateTextHooks = {},
   ): Promise<ApiResponse<GenerateTextResult>> {
     const prompt = data.prompt?.trim() || state.textForm.prompt.trim()
     const promptValidation = validateTextPrompt(prompt)
@@ -1398,6 +1437,7 @@ export const useChatStore = defineStore('chatStore', () => {
       const newChat = await createChat(chatPayload)
       chats.value.push(newChat)
       pendingChatId.value = newChat.id
+      hooks.onChatId?.(newChat.id)
       refreshUnreadMessages()
       saveToLocalStorage()
 
@@ -1753,6 +1793,7 @@ export const useChatStore = defineStore('chatStore', () => {
     pendingChatId,
     pendingChat,
     pendingText,
+    chatText,
     /*
      * initializePromise is deliberately NOT returned.
      *

--- a/stores/storybookStore.ts
+++ b/stores/storybookStore.ts
@@ -334,6 +334,20 @@ export const useStorybookStore = defineStore('storybookStore', () => {
   const setupDraft = ref<StorybookSetupDraft>(defaultDraft())
   const session = ref<StorybookSession | null>(null)
   const isWeaving = ref(false)
+  /*
+   * The chat row THIS session's in-flight `weaveBeat` is streaming into.
+   * chatStore.pendingText/pendingChatId is a single shared singleton across
+   * every `generateText` caller, and Taskmaster's own weaveBeat calls the
+   * same store -- neither call is cancelled on navigation, so a reader who
+   * leaves Storybook mid-scene and answers a Taskmaster beat before
+   * Storybook's call resolves can end up with `streamingText` showing
+   * Taskmaster's prose (or going blank while Storybook is still streaming,
+   * if Taskmaster's call happens to finish and clear the singleton first).
+   * Tracking our own chat id and reading it via chatStore.chatText() keeps
+   * this session's streaming text scoped to its own call regardless of what
+   * else is concurrently generating.
+   */
+  const weavingChatId = ref<number | null>(null)
   const errorMessage = ref('')
   let restoredFromStorage = false
 
@@ -388,7 +402,7 @@ export const useStorybookStore = defineStore('storybookStore', () => {
   })
 
   const streamingText = computed(() =>
-    isWeaving.value ? chatStore.pendingText : '',
+    isWeaving.value ? chatStore.chatText(weavingChatId.value) : '',
   )
   const currentBeat = computed(
     () => session.value?.beats[session.value.beats.length - 1] ?? null,
@@ -741,9 +755,17 @@ export const useStorybookStore = defineStore('storybookStore', () => {
     if (!active) return false
 
     isWeaving.value = true
+    weavingChatId.value = null
     errorMessage.value = ''
     try {
-      const result = await chatStore.generateText({ prompt, isPublic: false })
+      const result = await chatStore.generateText(
+        { prompt, isPublic: false },
+        {
+          onChatId: (chatId) => {
+            weavingChatId.value = chatId
+          },
+        },
+      )
       if (!result.success || !result.data) {
         errorMessage.value = result.message || 'The story thread slipped away.'
         return false
@@ -788,6 +810,7 @@ export const useStorybookStore = defineStore('storybookStore', () => {
       return false
     } finally {
       isWeaving.value = false
+      weavingChatId.value = null
     }
   }
 

--- a/stores/taskmasterStore.ts
+++ b/stores/taskmasterStore.ts
@@ -183,10 +183,24 @@ export const useTaskmasterStore = defineStore('taskmasterStore', () => {
 
   const session = ref<TaskmasterSession | null>(null)
   const isWeaving = ref(false)
+  /*
+   * The chat row THIS session's in-flight `weaveBeat` is streaming into.
+   * chatStore.pendingText/pendingChatId is a single shared singleton across
+   * every `generateText` caller, and Storybook's own weaveBeat calls the
+   * same store -- neither call is cancelled on navigation, so a reader who
+   * leaves Taskmaster mid-scene and answers a Storybook beat before
+   * Taskmaster's call resolves can end up with `streamingText` showing
+   * Storybook's prose (or going blank while Taskmaster is still streaming,
+   * if Storybook's call happens to finish and clear the singleton first).
+   * Tracking our own chat id and reading it via chatStore.chatText() keeps
+   * this session's streaming text scoped to its own call regardless of what
+   * else is concurrently generating.
+   */
+  const weavingChatId = ref<number | null>(null)
   const errorMessage = ref('')
 
   const streamingText = computed(() =>
-    isWeaving.value ? chatStore.pendingText : '',
+    isWeaving.value ? chatStore.chatText(weavingChatId.value) : '',
   )
 
   const currentBeat = computed(
@@ -818,12 +832,17 @@ The protagonist is ready to finish this session. Resolve the fictional threads, 
     if (!active) return false
 
     isWeaving.value = true
+    weavingChatId.value = null
     errorMessage.value = ''
     try {
-      const result = await chatStore.generateText({
-        prompt,
-        isPublic: false,
-      })
+      const result = await chatStore.generateText(
+        { prompt, isPublic: false },
+        {
+          onChatId: (chatId) => {
+            weavingChatId.value = chatId
+          },
+        },
+      )
       if (!result.success || !result.data) {
         errorMessage.value =
           result.message || 'The quest thread slipped away. Try again.'
@@ -871,6 +890,7 @@ The protagonist is ready to finish this session. Resolve the fictional threads, 
       return false
     } finally {
       isWeaving.value = false
+      weavingChatId.value = null
     }
   }
 

--- a/utils/scripts/verifyNarrativeStreamingTextIsolationGuard.mjs
+++ b/utils/scripts/verifyNarrativeStreamingTextIsolationGuard.mjs
@@ -1,0 +1,151 @@
+// /utils/scripts/verifyNarrativeStreamingTextIsolationGuard.mjs
+//
+// Regression guard (storybook/t-010, cycle 34). storybookStore.ts and
+// taskmasterStore.ts each call the shared chatStore's `generateText()` from
+// their own `weaveBeat()`, and both derived their `streamingText` computed
+// from `chatStore.pendingText` -- a SINGLE module-level singleton
+// (`pendingChatId`) shared across every `generateText` caller in the app,
+// not scoped per caller.
+//
+// Neither store cancels its in-flight `weaveBeat()` call when the reader
+// navigates away (no AbortController, and Pinia store state outlives the
+// unmounted page component). Concrete failure: a reader leaves Storybook
+// mid-scene while its `weaveBeat()` is still awaiting `generateText()`, then
+// answers a Taskmaster beat before Storybook's call resolves. Taskmaster's
+// own `generateText()` call overwrites the shared `pendingChatId`, so while
+// both calls are in flight, `chatStore.pendingText` reflects whichever
+// call's chat was created LAST -- if the reader returns to Storybook while
+// its own call is still streaming, `streamingText` shows Taskmaster's prose
+// under Storybook's "weaving the next scene" placeholder. Worse, whichever
+// call's `finally` runs first unconditionally nulls `pendingChatId`, which
+// can blank a still-streaming sibling call's `streamingText` back to empty
+// (the loading-dots fallback) even though it has live text arriving.
+//
+// Fixed by giving each store its own `weavingChatId` ref, populated via
+// `generateText()`'s new `onChatId` hook (fired synchronously once the chat
+// row is created, before the function's own `await` settles) and read back
+// through `chatStore.chatText(id)` -- a lookup scoped to that specific chat
+// id, independent of the shared singleton. This asserts the fix's shape
+// stays in place in both stores, and that the chatStore side (the hook and
+// the scoped reader) hasn't been quietly removed out from under them.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { extractTsFunctionBody } from './lib/extractTsFunctionBody.mjs'
+
+const CHAT_STORE_PATH = 'stores/chatStore.ts'
+const NARRATIVE_STORES = [
+  { path: 'stores/storybookStore.ts', fn: 'weaveBeat' },
+  { path: 'stores/taskmasterStore.ts', fn: 'weaveBeat' },
+]
+
+const chatStoreContent = readFileSync(
+  resolve(process.cwd(), CHAT_STORE_PATH),
+  'utf8',
+)
+
+// The scoped read side must still exist and stay independent of the shared
+// `pendingChatId`/`pendingChat`/`pendingText` singleton -- it looks the id
+// up in `chats.value` directly rather than delegating to `pendingChat`.
+assert.ok(
+  /function chatText\(chatId: number \| null\): string \{/.test(
+    chatStoreContent,
+  ),
+  `${CHAT_STORE_PATH} no longer declares chatText(chatId) with its expected ` +
+    'signature -- storybookStore/taskmasterStore rely on this to read their ' +
+    "own in-flight chat's text without racing the shared pendingChatId " +
+    'singleton.',
+)
+assert.ok(
+  !/function chatText\([^)]*\)[^{]*\{\s*return pendingText/.test(
+    chatStoreContent,
+  ),
+  `${CHAT_STORE_PATH}'s chatText() must read chats.value by the given id ` +
+    'directly, not delegate to the shared pendingText/pendingChat singleton ' +
+    '-- delegating would silently reopen the exact cross-caller race this ' +
+    'guard exists to prevent.',
+)
+
+// generateText() must still offer callers a way to learn their own chat id
+// synchronously, before the stream settles.
+const generateTextSignatureIndex = chatStoreContent.indexOf(
+  'async function generateText(',
+)
+assert.ok(
+  generateTextSignatureIndex !== -1,
+  `Could not find \`async function generateText(\` in ${CHAT_STORE_PATH} -- ` +
+    'has it been renamed or restructured? If so, this guard needs to move ' +
+    'with it.',
+)
+const generateTextTail = chatStoreContent.slice(generateTextSignatureIndex)
+assert.ok(
+  /hooks\.onChatId\?\.\(newChat\.id\)/.test(
+    generateTextTail.slice(0, generateTextTail.indexOf('\n\n')),
+  ) || /hooks\.onChatId\?\.\(newChat\.id\)/.test(generateTextTail),
+  `generateText() in ${CHAT_STORE_PATH} no longer fires an onChatId hook ` +
+    'with the newly created chat id -- storybookStore/taskmasterStore have ' +
+    'no other way to learn which chat is theirs before the call resolves.',
+)
+
+for (const { path, fn } of NARRATIVE_STORES) {
+  const content = readFileSync(resolve(process.cwd(), path), 'utf8')
+
+  assert.ok(
+    /const weavingChatId = ref<number \| null>\(null\)/.test(content),
+    `${path} no longer declares its own \`weavingChatId\` ref -- without it, ` +
+      'streamingText has nothing to scope its read to and falls back to the ' +
+      'shared chatStore singleton, reopening the cross-store race.',
+  )
+
+  assert.ok(
+    content.includes('chatStore.chatText(weavingChatId.value)'),
+    `${path}'s streamingText computed no longer reads ` +
+      'chatStore.chatText(weavingChatId.value) -- has it gone back to the ' +
+      'shared chatStore.pendingText singleton? That singleton is shared by ' +
+      'every generateText() caller in the app and does not distinguish ' +
+      "which caller's chat is currently streaming.",
+  )
+  assert.ok(
+    !/streamingText = computed\(\s*\(\)\s*=>\s*\n?\s*isWeaving\.value \? chatStore\.pendingText/.test(
+      content,
+    ),
+    `${path}'s streamingText computed reads chatStore.pendingText directly ` +
+      '-- this is the exact shared-singleton shape the fix replaced.',
+  )
+
+  const body = extractTsFunctionBody(content, fn, {
+    path,
+    notFoundHint:
+      `has ${fn}() been renamed, removed, or restructured? If so, this ` +
+      'guard (and the cross-store streaming-text race it protects against) ' +
+      'needs to move with it.',
+  })
+
+  assert.ok(
+    body.includes('onChatId:'),
+    `${fn}() in ${path} no longer passes an onChatId hook to ` +
+      'chatStore.generateText() -- without it, weavingChatId is never set ' +
+      "and streamingText can't scope itself to this call's own chat.",
+  )
+
+  // weavingChatId must be reset to null both before the call starts (so a
+  // stale id from a previous call can't briefly leak into this one) and in
+  // the finally block (so a completed call stops claiming a chat id at
+  // all, the same discipline isWeaving.value already follows).
+  const setNullCount = (body.match(/weavingChatId\.value = null/g) ?? []).length
+  assert.ok(
+    setNullCount >= 2,
+    `${fn}() in ${path} should reset weavingChatId.value to null both ` +
+      'before starting a new call and in its finally block (found ' +
+      `${setNullCount} reset(s)) -- without both, a stale id from a prior ` +
+      "call, or a lingering id after this call's own completion, can " +
+      'attribute streaming text to the wrong beat.',
+  )
+}
+
+console.log(
+  'Narrative streaming-text isolation guard contract passed: ' +
+    'storybookStore.ts and taskmasterStore.ts each scope streamingText to ' +
+    'their own in-flight chat id via chatStore.chatText(), rather than ' +
+    'racing the shared chatStore.pendingText singleton.',
+)


### PR DESCRIPTION
### Task
conductor storybook/t-010, cycle 34: "Polish and upgrade Storybook front-end surface" (recurring audit task)

### What changed
Cycle 33 left a fresh lead: read `kr-chat-window.vue`'s streaming-turn path cross-checked against `storybookStore.ts`'s turn-building code end to end. That surfaced a real cross-store race:

`chatStore.pendingChatId`/`pendingChat`/`pendingText` is a single module-level singleton shared across every `generateText()` caller in the app. Both `storybookStore.ts` and `taskmasterStore.ts` call `chatStore.generateText()` from their own `weaveBeat()`, and both derived their `streamingText` computed straight from `chatStore.pendingText`.

Neither store cancels its in-flight `weaveBeat()` call when the reader navigates away (no `AbortController`, and Pinia store state outlives the unmounted page component). Concrete failure: a reader leaves Storybook mid-scene while its `weaveBeat()` is still awaiting `generateText()`, then answers a Taskmaster beat before Storybook's call resolves. Taskmaster's own `generateText()` call overwrites the shared `pendingChatId` — if the reader returns to Storybook while its own call is still streaming, `streamingText` shows Taskmaster's prose under Storybook's "weaving the next scene" placeholder. Worse, whichever call's `finally` runs first unconditionally nulls `pendingChatId`, which can blank a still-streaming sibling call's `streamingText` back to empty even though it has live text arriving.

- `stores/chatStore.ts`: `generateText()` now accepts an optional `hooks.onChatId` callback, fired synchronously with the newly created chat id (before the function's own `await` settles). Added `chatText(chatId)`, a read scoped to a specific chat id, independent of the `pendingChatId` singleton.
- `stores/storybookStore.ts` / `stores/taskmasterStore.ts`: each now tracks its own `weavingChatId` ref, populated via the new hook and reset to `null` both before a call starts and in its `finally`. `streamingText` reads `chatStore.chatText(weavingChatId.value)` instead of the shared `chatStore.pendingText`.
- Added `utils/scripts/verifyNarrativeStreamingTextIsolationGuard.mjs` (+ dedicated `narrative-streaming-text-isolation-contract.yml` workflow), following the existing `verifyStorybook*Guard.mjs` textual-guard convention. Verified it fails against the old shared-singleton shape (confirmed by temporarily reverting one line) and passes against the fix.

Left `pendingChatId`/`pendingChat`/`pendingText` in place on `chatStore.ts` rather than removing them — no other consumer references them after this change, but removing a still-exported piece of API felt like a larger, less-reversible edit than this cycle's scope called for.

### How I verified
- New guard: `node utils/scripts/verifyNarrativeStreamingTextIsolationGuard.mjs` — pass. Confirmed it catches the regression by temporarily reverting `storybookStore.ts`'s `streamingText` back to `chatStore.pendingText` and re-running (fails with a clear message), then restored and re-ran (passes).
- Ran the 12 other existing `verifyStorybook*`/`verifyNarrative*`/`verifyTaskmasterCheckpointEngine` guards that reference `storybookStore.ts`/`taskmasterStore.ts` — all still pass.
- `prettier --check` on all 5 changed/added files: pass (the new `.mjs` guard was formatted with `--write` since it's a brand-new file; the two edited stores were NOT full-file `--write`'d since both were already prettier-noncompliant elsewhere on `main` — matched the intended edit's exact formatting by hand against a throwaway file run through the project's local prettier, per davinci/t-025's documented lesson on this).
- `eslint` / `vue-tsc --noEmit`: not run locally — `.nuxt/eslint.config.mjs` and generated types need a full `npm install` + `nuxi prepare`, not provisioned in this sandbox (consistent with prior cycles of this same task). PR CI's checks are the verification gate for those.

### Stakes
reversible

### Flags for Reviewer
- eslint/vue-tsc rely on CI rather than local verification (sandbox limitation, consistent with prior cycles).

### Kaizen suggestion
None beyond what's already in the task's own cycle notes.

### Notes for reviewer
This is cycle 34 of a long-running recurring audit task (conductor storybook/t-010). Prior cycles' pattern and conventions are documented in the conductor roadmap task note.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALxksBbMXL5ooPmRRassFj)_