### PR TITLE
chore(chatStore): remove dead pendingChatId/pendingChat/pendingText singleton

### DIFF
--- a/stores/chatStore.ts
+++ b/stores/chatStore.ts
@@ -113,13 +113,11 @@ type StreamResponseOptions = Omit<GenerateTextData, 'prompt'>
 /**
  * Fired synchronously once `generateText` has created its chat row and is
  * about to start streaming into it -- before the function's own `await`
- * settles. Lets a caller capture the concrete chat id it owns instead of
- * relying on the module-level `pendingChatId` singleton, which two
+ * settles. Lets a caller capture the concrete chat id it owns, since two
  * concurrent `generateText` calls (Storybook and Taskmaster both call it
- * from the same shared chatStore) would otherwise race: whichever call's
- * chat was created last wins the singleton while it streams, and whichever
- * call's `finally` runs first unconditionally nulls it out from under a
- * still-streaming sibling call. See `chatText()` below for the read side.
+ * from the same shared chatStore) stream independently and neither should
+ * assume it is the only in-flight call. See `chatText()` below for the
+ * read side.
  */
 type GenerateTextHooks = {
   onChatId?: (chatId: number) => void
@@ -282,12 +280,6 @@ export const useChatStore = defineStore('chatStore', () => {
   const selectedChat = ref<Chat | null>(null)
   const selectedRecipientId = ref<number | null>(null)
   const isInitialized = ref(false)
-
-  // Set to the chat's id while generateText is streaming its response, and
-  // cleared once the stream settles (success or failure). Lets streaming
-  // consumers (e.g. Serendipity) reference the in-flight chat directly
-  // instead of assuming it is always the last entry in `chats`.
-  const pendingChatId = ref<number | null>(null)
 
   const initializePromise = ref<Promise<void> | null>(null)
   const fetchChatsPromise = ref<Promise<void> | null>(null)
@@ -486,30 +478,19 @@ export const useChatStore = defineStore('chatStore', () => {
     return Boolean(!state.isGenerating && state.textForm.prompt.trim())
   })
 
-  const pendingChat = computed<Chat | null>(() => {
-    if (pendingChatId.value === null) return null
-    return chats.value.find((chat) => chat.id === pendingChatId.value) ?? null
-  })
-
-  const pendingText = computed(() => pendingChat.value?.botResponse ?? '')
-
   /**
-   * The live `botResponse` for a specific chat id, independent of the
-   * `pendingChatId` singleton above.
+   * The live `botResponse` for a specific chat id.
    *
-   * `pendingChatId`/`pendingChat`/`pendingText` reflect whichever
-   * `generateText` call most recently started -- fine for a single active
-   * caller, but storybookStore and taskmasterStore each call
-   * `chatStore.generateText()` from their own `weaveBeat`, and neither
-   * cancels its in-flight call on navigation. If both happen to be
-   * streaming at once (e.g. the reader leaves Storybook mid-scene and
-   * answers a Taskmaster beat before Storybook's own call resolves), the
-   * singleton can point at the WRONG caller's chat, or get nulled by
-   * whichever call's `finally` happens to run first -- surfacing one
-   * product's streaming prose inside the other's transcript, or blanking a
-   * still-streaming one back to the loading state. Callers that captured
-   * their own chat id via `generateText`'s `onChatId` hook should read it
-   * through here instead.
+   * storybookStore and taskmasterStore each call `chatStore.generateText()`
+   * from their own `weaveBeat`, and neither cancels its in-flight call on
+   * navigation. If both happen to be streaming at once (e.g. the reader
+   * leaves Storybook mid-scene and answers a Taskmaster beat before
+   * Storybook's own call resolves), a caller that assumed there was only
+   * ever one in-flight chat could read the WRONG caller's text, or see it
+   * blanked out by whichever call's `finally` happens to run first --
+   * surfacing one product's streaming prose inside the other's transcript.
+   * Callers must capture their own chat id via `generateText`'s `onChatId`
+   * hook and read it through here, scoped to that id.
    */
   function chatText(chatId: number | null): string {
     if (chatId === null) return ''
@@ -1436,7 +1417,6 @@ export const useChatStore = defineStore('chatStore', () => {
 
       const newChat = await createChat(chatPayload)
       chats.value.push(newChat)
-      pendingChatId.value = newChat.id
       hooks.onChatId?.(newChat.id)
       refreshUnreadMessages()
       saveToLocalStorage()
@@ -1470,7 +1450,6 @@ export const useChatStore = defineStore('chatStore', () => {
       }
     } finally {
       state.isGenerating = false
-      pendingChatId.value = null
     }
   }
 
@@ -1790,9 +1769,6 @@ export const useChatStore = defineStore('chatStore', () => {
     selectedChat,
     selectedRecipientId,
     isInitialized,
-    pendingChatId,
-    pendingChat,
-    pendingText,
     chatText,
     /*
      * initializePromise is deliberately NOT returned.

--- a/stores/storybookStore.ts
+++ b/stores/storybookStore.ts
@@ -336,16 +336,14 @@ export const useStorybookStore = defineStore('storybookStore', () => {
   const isWeaving = ref(false)
   /*
    * The chat row THIS session's in-flight `weaveBeat` is streaming into.
-   * chatStore.pendingText/pendingChatId is a single shared singleton across
-   * every `generateText` caller, and Taskmaster's own weaveBeat calls the
-   * same store -- neither call is cancelled on navigation, so a reader who
-   * leaves Storybook mid-scene and answers a Taskmaster beat before
-   * Storybook's call resolves can end up with `streamingText` showing
-   * Taskmaster's prose (or going blank while Storybook is still streaming,
-   * if Taskmaster's call happens to finish and clear the singleton first).
-   * Tracking our own chat id and reading it via chatStore.chatText() keeps
-   * this session's streaming text scoped to its own call regardless of what
-   * else is concurrently generating.
+   * Taskmaster's own weaveBeat calls the same shared chatStore, and neither
+   * call is cancelled on navigation, so a reader who leaves Storybook
+   * mid-scene and answers a Taskmaster beat before Storybook's call
+   * resolves could otherwise end up with `streamingText` showing
+   * Taskmaster's prose (or going blank while Storybook is still
+   * streaming). Tracking our own chat id and reading it via
+   * chatStore.chatText() keeps this session's streaming text scoped to its
+   * own call regardless of what else is concurrently generating.
    */
   const weavingChatId = ref<number | null>(null)
   const errorMessage = ref('')

--- a/stores/taskmasterStore.ts
+++ b/stores/taskmasterStore.ts
@@ -185,16 +185,14 @@ export const useTaskmasterStore = defineStore('taskmasterStore', () => {
   const isWeaving = ref(false)
   /*
    * The chat row THIS session's in-flight `weaveBeat` is streaming into.
-   * chatStore.pendingText/pendingChatId is a single shared singleton across
-   * every `generateText` caller, and Storybook's own weaveBeat calls the
-   * same store -- neither call is cancelled on navigation, so a reader who
-   * leaves Taskmaster mid-scene and answers a Storybook beat before
-   * Taskmaster's call resolves can end up with `streamingText` showing
-   * Storybook's prose (or going blank while Taskmaster is still streaming,
-   * if Storybook's call happens to finish and clear the singleton first).
-   * Tracking our own chat id and reading it via chatStore.chatText() keeps
-   * this session's streaming text scoped to its own call regardless of what
-   * else is concurrently generating.
+   * Storybook's own weaveBeat calls the same shared chatStore, and neither
+   * call is cancelled on navigation, so a reader who leaves Taskmaster
+   * mid-scene and answers a Storybook beat before Taskmaster's call
+   * resolves could otherwise end up with `streamingText` showing
+   * Storybook's prose (or going blank while Taskmaster is still
+   * streaming). Tracking our own chat id and reading it via
+   * chatStore.chatText() keeps this session's streaming text scoped to its
+   * own call regardless of what else is concurrently generating.
    */
   const weavingChatId = ref<number | null>(null)
   const errorMessage = ref('')


### PR DESCRIPTION
### Task
conductor/storybook/t-010 cycle 35: follow-up from cycle 34 (kind_robots#2054)

### What changed
Cycle 34 fixed a real cross-store streaming-text race by giving `storybookStore`/`taskmasterStore` their own scoped `weavingChatId` + `chatStore.chatText(id)`, replacing the old shared `chatStore.pendingChatId`/`pendingChat`/`pendingText` singleton in both real callers — but left the singleton itself in place, flagging it as dead code worth a fresh look.

Confirmed (repo-wide grep, no node_modules) that `pendingChatId`/`pendingChat`/`pendingText` have no remaining consumer outside `chatStore.ts` itself — every other reference was a comment explaining the old bug the fix replaced, not a live read. Removed:
- the `pendingChatId` ref
- the `pendingChat`/`pendingText` computeds
- their set/clear sites inside `generateText()`
- their three store exports

Also updated the surrounding comments in `chatStore.ts`, `storybookStore.ts`, and `taskmasterStore.ts` that described the now-removed singleton so they read accurately (past-tense references to a field that no longer exists were confusing otherwise).

### How I verified
- `node utils/scripts/verifyNarrativeStreamingTextIsolationGuard.mjs` — passes (this regression guard from cycle 34 only asserts `chatText()`/`weavingChatId` don't delegate back to the singleton; it never asserted the singleton fields themselves exist, so removing them doesn't weaken the guard)
- `npm run test` (`vue-tsc --noEmit`) — passes clean, no type errors from the removed exports
- `npx eslint stores/chatStore.ts stores/storybookStore.ts stores/taskmasterStore.ts` — same 4 errors present on `main` before this change (2× `no-empty`, 1× `no-useless-assignment`, all pre-existing and unrelated to this diff); none introduced

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
None beyond this task's own scope — cycle 34's note already named this exact cleanup as the next lead, and it's now done.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EL18rbNmcRrhqm5MTbafWc)_