### PR TITLE
feat(brainstorm): add a Brainstorm-variations entry point to Project's detail view

### DIFF
--- a/.github/workflows/brainstorm-object-entry-links-contract.yml
+++ b/.github/workflows/brainstorm-object-entry-links-contract.yml
@@ -9,6 +9,8 @@ on:
       - 'components/characters/character-manager.vue'
       - 'components/scenarios/scenario-manager.vue'
       - 'components/rewards/reward-manager.vue'
+      - 'components/bots/bot-manager.vue'
+      - 'components/conductor/project-detail.vue'
       - 'utils/scripts/verifyBrainstormObjectEntryLinks.mjs'
   pull_request:
     branches: [main]
@@ -18,6 +20,8 @@ on:
       - 'components/characters/character-manager.vue'
       - 'components/scenarios/scenario-manager.vue'
       - 'components/rewards/reward-manager.vue'
+      - 'components/bots/bot-manager.vue'
+      - 'components/conductor/project-detail.vue'
       - 'utils/scripts/verifyBrainstormObjectEntryLinks.mjs'
   workflow_dispatch:
 

--- a/components/conductor/project-detail.vue
+++ b/components/conductor/project-detail.vue
@@ -94,6 +94,16 @@
         {{ projectSaveError ? 'save failed' : 'saved' }}
       </span>
       <button
+        v-if="linkedProject"
+        type="button"
+        class="btn btn-ghost btn-xs rounded-lg"
+        title="Brainstorm variations grounded in this Project"
+        aria-label="Brainstorm variations grounded in this Project"
+        @click="startBrainstormWithProject"
+      >
+        <Icon name="kind-icon:brain" class="size-3.5" />
+      </button>
+      <button
         type="button"
         class="btn btn-ghost btn-xs rounded-lg"
         :disabled="refreshing"
@@ -706,6 +716,19 @@ async function refreshProject() {
   } finally {
     refreshing.value = false
   }
+}
+
+function startBrainstormWithProject(): void {
+  const project = linkedProject.value
+  if (!project?.id) return
+  void navigateTo({
+    path: '/brainstorm',
+    query: {
+      source: 'project',
+      sourceId: String(project.id),
+      intent: `Generate variations for the Project "${project.title || 'this Project'}" that preserve its goal and direction.`,
+    },
+  })
 }
 
 async function submitProjectTask() {

--- a/stores/helpers/brainstormSourceAdapters.ts
+++ b/stores/helpers/brainstormSourceAdapters.ts
@@ -14,10 +14,11 @@
 //
 // Started with Character and Dream (BrainstormSourceRef.modelType is a free
 // string; these were the first two with real adapters). Scenario joined them
-// in brainstorm/t-014, Reward in brainstorm/t-028, Bot in brainstorm/t-029.
-// Project and Prompt can each register a BrainstormSourceAdapter the same
-// way, with no new API surface and no bespoke endpoint -- just another entry
-// in BRAINSTORM_SOURCE_ADAPTERS backed by that entity's existing store.
+// in brainstorm/t-014, Reward in brainstorm/t-028, Bot in brainstorm/t-029,
+// Project in brainstorm/t-030. Prompt can register a BrainstormSourceAdapter
+// the same way, with no new API surface and no bespoke endpoint -- just
+// another entry in BRAINSTORM_SOURCE_ADAPTERS backed by that entity's
+// existing store.
 //
 // The store-agnostic dispatch/fallback logic lives in
 // brainstormSourceAdapterKit.ts (no Pinia imports, unit-testable with plain
@@ -25,6 +26,7 @@
 import { useBotStore } from '@/stores/botStore'
 import { useCharacterStore } from '@/stores/characterStore'
 import { useDreamStore } from '@/stores/dreamStore'
+import { useProjectStore } from '@/stores/projectStore'
 import { useRewardStore } from '@/stores/rewardStore'
 import { useScenarioStore } from '@/stores/scenarioStore'
 import { resolveArtImageSrc } from '@/utils/artImageSrc'
@@ -290,6 +292,61 @@ const botAdapter: BrainstormSourceAdapter = {
   },
 }
 
+const projectAdapter: BrainstormSourceAdapter = {
+  modelType: 'project',
+  label: 'Project',
+  async resolve(ref) {
+    if (!ref.id) return null
+    const store = useProjectStore()
+    // fetchProject throws (rather than resolving falsy) when the id can't be
+    // found, unlike the other stores' fetch-by-id helpers -- catch it here so
+    // this adapter still honors the "null if it can't be found" contract.
+    try {
+      const project = await store.fetchProject(ref.id)
+      if (!project) return null
+
+      return {
+        modelType: 'project',
+        id: project.id,
+        title: project.title || `Project #${project.id}`,
+        subtitle:
+          project.goal || project.pitch || project.flavorText || undefined,
+        thumbnailUrl: project.imagePath || null,
+      }
+    } catch {
+      return null
+    }
+  },
+  async search(query) {
+    const store = useProjectStore()
+    // Same fail-closed contract as the other adapters: a failed fresh fetch
+    // must never fall back to searching a possibly-stale cache. Includes
+    // inactive/mature projects, matching refreshProject()'s own broad fetch
+    // in components/conductor/project-detail.vue -- Brainstorm variations
+    // should be reachable from any Project, not just the public/active ones.
+    const freshProjects = await fetchFreshSourceRows(
+      () =>
+        store.fetchProjects(
+          { includeInactive: true, includeMature: true },
+          true,
+        ),
+      () => Boolean(store.error),
+    )
+
+    return freshProjects
+      .filter((project) =>
+        matchesQuery([project.title, project.goal, project.pitch], query),
+      )
+      .slice(0, SEARCH_RESULT_LIMIT)
+      .map((project) => ({
+        modelType: 'project',
+        id: project.id,
+        title: project.title || `Project #${project.id}`,
+        subtitle: project.goal || undefined,
+      }))
+  },
+}
+
 /** The adapter registry. Keys are lowercase modelType strings. */
 export const BRAINSTORM_SOURCE_ADAPTERS: Record<
   string,
@@ -300,6 +357,7 @@ export const BRAINSTORM_SOURCE_ADAPTERS: Record<
   scenario: scenarioAdapter,
   reward: rewardAdapter,
   bot: botAdapter,
+  project: projectAdapter,
 }
 
 export function listBrainstormSourceAdapters(): BrainstormSourceAdapter[] {

--- a/utils/scripts/verifyBrainstormObjectEntryLinks.mjs
+++ b/utils/scripts/verifyBrainstormObjectEntryLinks.mjs
@@ -32,6 +32,7 @@ const characterManagerPath = 'components/characters/character-manager.vue'
 const scenarioManagerPath = 'components/scenarios/scenario-manager.vue'
 const rewardManagerPath = 'components/rewards/reward-manager.vue'
 const botManagerPath = 'components/bots/bot-manager.vue'
+const projectDetailPath = 'components/conductor/project-detail.vue'
 const brainstormManagerPath = 'components/brainstorm/brainstorm-manager.vue'
 
 includesAll(characterManagerPath, [
@@ -77,6 +78,18 @@ includesAll(botManagerPath, [
   'sourceId: String(bot.id)',
 ])
 
+// brainstorm/t-030: Project is the fifth surface wired into the same
+// seedFromQuery() contract, following the same adapter/CTA pair Reward and
+// Bot shipped (BRAINSTORM_SOURCE_ADAPTERS entry + a gated CTA in the same
+// PR).
+includesAll(projectDetailPath, [
+  'startBrainstormWithProject',
+  '@click="startBrainstormWithProject"',
+  "path: '/brainstorm'",
+  "source: 'project'",
+  'sourceId: String(project.id)',
+])
+
 includesAll(brainstormManagerPath, [
   'function seedFromQuery',
   'seedFromQuery()',
@@ -89,7 +102,7 @@ includesAll(brainstormManagerPath, [
 
 console.log(
   'Brainstorm object-entry links contract passed: Character, Scenario, ' +
-    'Reward, and Bot can each launch a Brainstorm session grounded in ' +
-    'themselves, and Brainstorm still seeds its source and premise from ' +
+    'Reward, Bot, and Project can each launch a Brainstorm session grounded ' +
+    'in themselves, and Brainstorm still seeds its source and premise from ' +
     'the source/sourceId/intent query keys.',
 )


### PR DESCRIPTION
## Summary

Kaizen from t-029 (kind_robots#2052). Project is the next remaining core entity without a `BrainstormSourceAdapter`/CTA pair after Character, Dream, Scenario, Reward, and Bot (conductor `brainstorm/t-030`).

## Changes

- Registered a `projectAdapter` in `BRAINSTORM_SOURCE_ADAPTERS`: `resolve()` via `projectStore.fetchProject(id)`, `search()` via `fetchProjects({ includeInactive: true, includeMature: true }, true)` with the same fail-closed fresh-fetch contract as every other adapter. `fetchProject()` throws rather than resolving falsy on a miss (unlike the other stores' fetch-by-id helpers), so `resolve()` wraps it in a try/catch to keep the "null if it can't be found" contract.
- Added a `v-if="linkedProject"`-gated "Brainstorm variations" icon button to `project-detail.vue`'s toolbar, matching that toolbar's existing `btn-ghost btn-xs` icon-button convention (rather than copying the larger labeled button other managers use, which would be visually inconsistent with this component's compact toolbar) — wired to `startBrainstormWithProject()`, the same `navigateTo(/brainstorm, {source, sourceId, intent})` pattern as `reward-manager.vue`/`bot-manager.vue`.
- Extended `verifyBrainstormObjectEntryLinks.mjs` with a Project assertion block.
- Added `components/conductor/project-detail.vue` to the contract workflow's path triggers so it actually runs when that file changes (t-028's own precedent). Also added `components/bots/bot-manager.vue`, which t-029 (Bot's own adapter/CTA) left out of the trigger paths despite the guard script already asserting against it — a real gap where a `bot-manager.vue` change wouldn't run this contract on push/PR; fixed opportunistically since it's a one-line, directly-related omission.

## Verification

- `node utils/scripts/verifyBrainstormObjectEntryLinks.mjs` passes
- `npm run test:brainstorm-source-adapters` passes
- `vue-tsc --noEmit` repo-wide: exit 0
- `eslint` clean on changed files
- `prettier --check` clean (fixed one pre-existing-clean file's own new lines to stay clean; left `project-detail.vue`'s pre-existing unrelated prettier drift untouched, same convention prior PRs in this area followed)
- `git status --porcelain` scoped to exactly the 4 intended files

## Flags for Reviewer

- No schema/API change — purely a new adapter registry entry + a gated UI affordance, following an established pattern shipped four times already.
- Once Project lands, per t-030's own note: re-check whether any further natural detail-view entities remain before assuming this task type is exhausted for the project (Prompt is the one still explicitly called out as a candidate in the adapter file's own header comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNSCgBsf6AxqHnVb9FLiQ2)_