### PR TITLE
fix(taskmaster): guard saveToLocalStorage against a throwing localStorage write (storybook/t-010)

### DIFF
--- a/stores/taskmasterStore.ts
+++ b/stores/taskmasterStore.ts
@@ -560,10 +560,42 @@ export const useTaskmasterStore = defineStore('taskmasterStore', () => {
 
   function saveToLocalStorage() {
     if (typeof localStorage === 'undefined') return
-    if (session.value) {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(session.value))
-    } else {
-      localStorage.removeItem(STORAGE_KEY)
+    try {
+      if (session.value) {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(session.value))
+      } else {
+        localStorage.removeItem(STORAGE_KEY)
+      }
+    } catch {
+      // Private browsing and storage quotas should not break the quest.
+      //
+      // This was the one unguarded localStorage writer left in the narrative
+      // family -- storybookStore.ts's persist(), storybookLibraryHelper.ts's
+      // persistLibrary(), and persistedNarrativeArtJobsHelper.ts's
+      // writeLocalStorage() all already swallow a failed write for exactly
+      // this reason, and this store is otherwise byte-for-byte Storybook's
+      // shape (see verifyNarrativeArtPersistence.mjs's lockstep assertions).
+      // A `setItem` that throws QuotaExceededError -- routine once a long
+      // quest's beats have grown the serialized session, and immediate in a
+      // Safari private window -- propagated straight out of every call site:
+      //   - updateBeatArt(), the art-job update callback, is invoked from
+      //     narrativeArtJobsHelper's `void poll(...)`/`void submit(...)` with
+      //     no catch of their own, so the throw both became an unhandled
+      //     rejection and killed that beat's poll loop -- the illustration
+      //     then never resolved, with no failure state and so no retry
+      //     affordance (NarrativeArtStatus only offers retry on 'failed').
+      //   - answerCurrentBeat(), prepareQuest(), startQuest() and
+      //     resetSession() are all called from taskmaster-page.vue without a
+      //     `.catch()`, so the throw surfaced as an unhandled rejection
+      //     instead of the store's own errorMessage.
+      //   - weaveBeat()'s call sits inside its try/catch, so a throw there
+      //     was caught -- but only after `active.beats.push(beat)` had
+      //     already committed the beat in memory, so it returned false and
+      //     showed a raw browser quota string for a beat that had in fact
+      //     been woven, and skipped that beat's requestBeatArt() entirely.
+      // Losing the persisted copy degrades to "this quest doesn't survive a
+      // reload," which is the same trade Storybook already accepted; taking
+      // the whole in-memory session down with it was never intended.
     }
   }
 

--- a/utils/scripts/verifyNarrativeArtPersistence.mjs
+++ b/utils/scripts/verifyNarrativeArtPersistence.mjs
@@ -177,6 +177,26 @@ assert.ok(
   'Narrative text generation must not wait for scene art rendering',
 )
 
+// A failed localStorage write must never take the in-memory session down with
+// it. Both stores persist on every beat/answer/art-status transition, and
+// updateBeatArt() in particular runs as narrativeArtJobsHelper's uncaught
+// `void poll(...)` callback -- a throw there kills that beat's poll loop and
+// leaves the illustration stuck with no retry affordance. Storybook has
+// guarded this since it was written; Taskmaster went unguarded until
+// storybook/t-010 cycle 36.
+for (const [label, storeSource, writer] of [
+  ['Storybook', storyStore, 'function persist()'],
+  ['Taskmaster', taskStore, 'function saveToLocalStorage()'],
+]) {
+  const start = storeSource.indexOf(writer)
+  assert.ok(start >= 0, `${label} must keep its localStorage writer`)
+  const body = storeSource.slice(start, storeSource.indexOf('\n  }', start))
+  assert.ok(
+    body.includes('localStorage.setItem') && body.includes('} catch {'),
+    `${label}'s localStorage writer must swallow a failed write (private browsing / quota) rather than throwing into its callers`,
+  )
+}
+
 includesAll(turnsPath, [
   'beatIdFromTurnId',
   'null for anything else',


### PR DESCRIPTION
## Summary

conductor `storybook/t-010` cycle 36. Cycle 35's own lead named a fresh angle — "Pinia persistence edge cases for storybookStore.ts/taskmasterStore.ts have not had a dedicated pass in this task's history". Took it, and found a real correctness gap.

`taskmasterStore.ts`'s `saveToLocalStorage()` was the **one unguarded localStorage writer left in the narrative family**. Its three siblings all already swallow a failed write:

- `storybookStore.ts`'s `persist()` — *"Private browsing and storage quotas should not break the studio."*
- `storybookLibraryHelper.ts`'s `persistLibrary()` — *"A storage quota should not break the active Storybook session."*
- `persistedNarrativeArtJobsHelper.ts`'s `writeLocalStorage()` — *"Private browsing and storage quotas should not break the caller."*

…and the two stores are otherwise held in lockstep by `verifyNarrativeArtPersistence.mjs`, whose own header calls them "byte-for-byte the same shape."

## The failure

A `setItem` that throws `QuotaExceededError` — routine once a long quest's beats have grown the serialized session, immediate in a Safari private window — propagated straight out of every one of the ten call sites. Traced each:

- **`updateBeatArt()`** is the art-job update callback, invoked from `narrativeArtJobsHelper`'s `void poll(...)` / `void submit(...)`, neither of which has a catch of its own. The throw both became an unhandled rejection **and killed that beat's poll loop** — so the illustration never resolved, and never reached `'failed'` either, meaning `NarrativeArtStatus` (which only renders retry on `'failed'`) offered no retry affordance. This is the sharpest one: the art silently hangs forever.
- **`answerCurrentBeat()`, `prepareQuest()`, `startQuest()`, `resetSession()`** are all reached from `taskmaster-page.vue` with no `.catch()` (`@click="store.startQuest()"`, `await store.answerCurrentBeat(...)`, etc.), so the throw surfaced as an unhandled rejection instead of the store's own `errorMessage`.
- **`weaveBeat()`**'s call *is* inside its own try/catch — but only reached after `active.beats.push(beat)` had already committed the beat in memory. So it returned `false` and showed a raw browser quota string for a beat that had in fact been woven, and skipped that beat's `requestBeatArt()` entirely.

Losing the persisted copy degrades to "this quest doesn't survive a reload," which is the same trade Storybook already accepted. Taking the whole in-memory session down with it was never intended.

## Changes

- `stores/taskmasterStore.ts` — wrap `saveToLocalStorage()`'s body in try/catch, mirroring `persist()`'s shape exactly. The `typeof localStorage === 'undefined'` early return is unchanged.
- `utils/scripts/verifyNarrativeArtPersistence.mjs` — add the matching lockstep assertion over **both** stores' writers, so neither can silently drift back to unguarded. `narrative-art-persistence-contract.yml` runs on every PR with no path filter, so this is CI-enforced from here on.

## Verification

- `node utils/scripts/verifyNarrativeArtPersistence.mjs` passes — and **fails as expected when the fix is stashed** (verified the guard actually catches the regression rather than being vacuously true)
- `npm run test` (`vue-tsc --noEmit`) repo-wide: exit 0
- `npm run test:storybook`: all 22 contracts pass
- `eslint` clean on both changed files
- `prettier`: both new blocks are byte-identical to prettier's own output (compared function-by-function). The two files' remaining `--check` warnings are pre-existing drift present on `main` unchanged — confirmed by re-running the check with the change stashed. Left untouched, matching the convention prior PRs in this area followed.
- `git status --porcelain` scoped to exactly the 2 intended files

## Flags for Reviewer

- No schema, API, or behavior change on the success path — this only changes what happens when a localStorage write fails, which previously threw.
- The new contract assertion slices each store's writer function body by name (`function persist()` / `function saveToLocalStorage()`) and asserts it contains both `localStorage.setItem` and `} catch {`. If either writer is renamed, the assertion fails loudly with "must keep its localStorage writer" rather than silently passing.
- Next lead for cycle 37: this pass covered the localStorage **write** path. The **read** path still differs between the two stores — `storybookStore.restoreFromLocalStorage()` reads `getItem` inside its try, `taskmasterStore.restoreFromLocalStorage()` reads it outside (line 572), and Taskmaster has no equivalent of Storybook's `restoredFromStorage` one-time guard (it guards on `session.value` instead, which is sufficient for its single mount site but not the same invariant). Worth a dedicated look at whether Taskmaster has a mount-order race of the kind `verifyStorybookRestoreIdempotencyGuard` covers for Storybook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TupAMkkBnEt1LEvKJ2XXWc)_