### PR TITLE
storybook/t-023: guard taskmasterStore restore's getItem inside try

### DIFF
--- a/stores/taskmasterStore.ts
+++ b/stores/taskmasterStore.ts
@@ -600,11 +600,24 @@ export const useTaskmasterStore = defineStore('taskmasterStore', () => {
   }
 
   function restoreFromLocalStorage() {
+    // Storybook's equivalent (storybookStore.restoreFromLocalStorage()) reads
+    // localStorage.getItem() inside its try because content/storybook.md
+    // double-mounts it (storybook-library-page.vue wraps StorybookPage as a
+    // child, both onMounted() hooks call restoreFromLocalStorage() in the
+    // same tick), so it also carries a one-time `restoredFromStorage` guard
+    // ahead of any localStorage access. Taskmaster has no such wrapper today
+    // -- content/taskmaster.md mounts `:taskmaster-page` as the only call
+    // site, so the `!session.value` check below is this function's only
+    // real guard and is sufficient for that single mount. Still move the
+    // read itself inside the try: a bare getItem() outside any try, unlike
+    // Storybook's, would throw straight out of onMounted() if localStorage
+    // access itself failed (private-browsing/storage-disabled edge cases),
+    // instead of degrading the same way the JSON.parse() below already does.
     if (typeof localStorage === 'undefined' || session.value) return
-    const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return
 
     try {
+      const raw = localStorage.getItem(STORAGE_KEY)
+      if (!raw) return
       const restored = JSON.parse(raw) as TaskmasterSession
       if (!Array.isArray(restored.checkpoints)) {
         restored.checkpoints = restored.seed.taskTitle


### PR DESCRIPTION
### Task
conductor storybook/t-023: Audit taskmasterStore's localStorage READ path against Storybook's restore guards (kind: software)

### What changed / what I produced
- `stores/taskmasterStore.ts`: `restoreFromLocalStorage()` now reads `localStorage.getItem(STORAGE_KEY)` inside its `try`, matching `storybookStore.restoreFromLocalStorage()`'s pattern. Previously the read happened outside the try, so a `getItem()` throw (private-browsing/storage-disabled edge cases) would have escaped straight out of `onMounted()` instead of degrading the way the `JSON.parse()` failure path already does.
- Audited whether Taskmaster also needs Storybook's one-time `restoredFromStorage` guard (added there for a real parent/child double-mount race between `storybook-library-page.vue` and `storybook-page.vue`). Traced every caller: `content/taskmaster.md` mounts `:taskmaster-page` as the sole call site, with no wrapper component double-mounting it the way Storybook's does. No reachable mount-order race exists today, so the existing `!session.value` guard remains sufficient — confirmed by tracing callers, not assumed from the asymmetry alone. Left an in-code comment documenting this so a future reader doesn't have to re-derive it.
- No new CI contract added: the task's own scope made that conditional on "if a real invariant is established," and none was found for the read path beyond the unambiguous try/catch fix.

### How I verified
- `npx eslint stores/taskmasterStore.ts` — clean
- `npx vue-tsc --noEmit` (full project) — clean
- `npm run test` (vue-tsc typecheck) — clean
- `npx prettier --check` on the new function body specifically — clean (the rest of the file carries pre-existing prettier-version formatting drift unrelated to this change, left untouched per this repo's established convention of not widening a diff to re-format unrelated lines)
- Diff is scoped to exactly the touched function (15 insertions, 2 deletions)

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
The whole file has accumulated prettier-version formatting drift (multi-line union types collapsed, indentation on chained `&&` conditions, etc. — visible if you run `prettier --write` on the full file). Worth a dedicated, scope-only "reformat taskmasterStore.ts to current prettier" task at some point so future diffs on this file stop being adjacent to unrelated drift.

### Notes for reviewer
Conductor task: storybook/t-023


---
_Generated by [Claude Code](https://claude.ai/code/session_01FWx9gLCYNGEUwTpq5E6RCg)_