### PR TITLE
brainstorm/t-031: add Promote to Character action on kept candidates

### DIFF
--- a/components/brainstorm/brainstorm-candidate-card.vue
+++ b/components/brainstorm/brainstorm-candidate-card.vue
@@ -346,6 +346,20 @@
           />
           More like this
         </button>
+        <button
+          v-if="candidate.status === 'kept'"
+          type="button"
+          class="btn btn-outline btn-sm"
+          data-testid="brainstorm-promote-to-character"
+          :disabled="disabled"
+          @click="promote"
+        >
+          <span
+            v-if="busy && busyAction === 'promote'"
+            class="loading loading-spinner loading-xs"
+          />
+          Promote to Character
+        </button>
       </div>
     </footer>
   </article>
@@ -366,7 +380,7 @@ const props = defineProps<{
   parentCandidate?: BrainstormCandidate | null
   disabled?: boolean
   busy?: boolean
-  busyAction?: 'regenerate' | 'branch' | 'art' | null
+  busyAction?: 'regenerate' | 'branch' | 'promote' | 'art' | null
   selectedForArt?: boolean
 }>()
 
@@ -377,6 +391,7 @@ const emit = defineEmits<{
   delete: []
   regenerate: []
   branch: []
+  promote: []
   restoreRevision: [revisionIndex: number]
   edit: [patch: { title: string; text: string }]
   feedback: [value: string]
@@ -541,5 +556,9 @@ function regenerate(): void {
 function branch(): void {
   emitFeedback()
   emit('branch')
+}
+
+function promote(): void {
+  emit('promote')
 }
 </script>

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -776,6 +776,7 @@
         @restore-revision="restoreRevision(candidate.id, $event)"
         @regenerate="regenerate(candidate.id)"
         @branch="branch(candidate.id)"
+        @promote="promoteCandidate(candidate.id)"
         @toggle-art-selection="store.toggleArtSelection(candidate.id)"
       />
     </div>
@@ -972,7 +973,7 @@ const {
 
 const pendingCandidateAction = ref<{
   id: string
-  action: 'regenerate' | 'branch'
+  action: 'regenerate' | 'branch' | 'promote'
 } | null>(null)
 
 // Kept ideas are selected for copy/export by default; deselect individual
@@ -1245,7 +1246,7 @@ function applyStarter(starter: (typeof starterPremises)[number]): void {
 
 function candidateBusyAction(
   candidateId: string,
-): 'regenerate' | 'branch' | 'art' | null {
+): 'regenerate' | 'branch' | 'promote' | 'art' | null {
   if (pendingCandidateAction.value?.id === candidateId) {
     return pendingCandidateAction.value.action
   }
@@ -1255,6 +1256,7 @@ function candidateBusyAction(
 function isCandidateBusy(candidateId: string): boolean {
   return (
     generationTargetId.value === candidateId ||
+    pendingCandidateAction.value?.id === candidateId ||
     artGeneratingCandidateIds.value.includes(candidateId)
   )
 }
@@ -1400,6 +1402,16 @@ async function branch(candidateId: string): Promise<void> {
   pendingCandidateAction.value = { id: candidateId, action: 'branch' }
   try {
     await store.branchCandidate(candidateId)
+  } finally {
+    pendingCandidateAction.value = null
+  }
+}
+
+async function promoteCandidate(candidateId: string): Promise<void> {
+  pendingCandidateAction.value = { id: candidateId, action: 'promote' }
+  try {
+    const result = await store.promoteCandidateToCharacter(candidateId)
+    showKeptExportMessage(result.message)
   } finally {
     pendingCandidateAction.value = null
   }

--- a/stores/brainstormStore.ts
+++ b/stores/brainstormStore.ts
@@ -1,5 +1,6 @@
 import { computed, ref, watch } from 'vue'
 import { defineStore } from 'pinia'
+import type { Character } from '~/prisma/generated/prisma/client'
 import { useArtStore } from '@/stores/artStore'
 import type { GenerateArtData } from '@/stores/artStore'
 import { useServerStore } from '@/stores/serverStore'
@@ -861,6 +862,56 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
     return Boolean(appendBranchCandidate(candidate, generated[0]))
   }
 
+  // brainstorm/t-031: promote a kept candidate into a real Character record.
+  // No entity-to-entity promotion in this app is currently wired to a UI
+  // element (promptStore.promoteToDream and dreamStore.promotePromptToDream
+  // both exist but are dead code, called from nowhere) -- this is the first
+  // one that actually is. Character's entityArt.ts model holds one scalar
+  // artImageId per art slot, while a candidate's meta.art.imageIds is an
+  // array (a candidate can accumulate more than one delivered generation
+  // across regenerate/retry cycles) -- imageIds is append-only
+  // (recordCandidateArtImage in brainstormCandidateLifecycle.ts always does
+  // `[...art.imageIds, imageId]`), so the last entry is the most recently
+  // delivered image and is what gets promoted; earlier deliveries for the
+  // same candidate are not carried over, matching the same "pick one primary
+  // image" trade-off entityArt.ts already makes for every other entity.
+  async function promoteCandidateToCharacter(
+    candidateId: string,
+  ): Promise<{ success: boolean; message: string; data?: Character }> {
+    const candidate = findCandidate(candidateId)
+    if (!candidate) {
+      return { success: false, message: 'Candidate not found.' }
+    }
+
+    const imageIds = candidate.meta.art?.imageIds ?? []
+    const artImageId = imageIds.length
+      ? imageIds[imageIds.length - 1]
+      : undefined
+
+    const { useCharacterStore } = await import('@/stores/characterStore')
+    const characterStore = useCharacterStore()
+
+    const created = await characterStore.createCharacter({
+      name: candidate.title || 'Untitled Character',
+      title: candidate.title || undefined,
+      backstory: candidate.text || undefined,
+      artImageId,
+    })
+
+    if (!created) {
+      return {
+        success: false,
+        message: 'Failed to promote candidate to a Character.',
+      }
+    }
+
+    return {
+      success: true,
+      message: `Promoted "${candidate.title}" to a new Character.`,
+      data: created,
+    }
+  }
+
   function isSelectedForArt(candidateId: string): boolean {
     return artSelectionIds.value.includes(candidateId)
   }
@@ -1347,6 +1398,7 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
     generateBatch,
     regenerateCandidate,
     branchCandidate,
+    promoteCandidateToCharacter,
     isSelectedForArt,
     toggleArtSelection,
     clearArtSelection,

--- a/utils/scripts/verifyBrainstormWorkbench.mjs
+++ b/utils/scripts/verifyBrainstormWorkbench.mjs
@@ -11,6 +11,7 @@ const card = readFileSync(
   resolve(root, 'components/brainstorm/brainstorm-candidate-card.vue'),
   'utf8',
 )
+const store = readFileSync(resolve(root, 'stores/brainstormStore.ts'), 'utf8')
 const content = readFileSync(resolve(root, 'content/brainstorm.md'), 'utf8')
 
 assert.match(content, /:brainstorm-manager/)
@@ -20,6 +21,8 @@ assert.match(manager, /useBrainstormStore\(\)/)
 assert.match(manager, /store\.generateBatch\(\)/)
 assert.match(manager, /store\.regenerateCandidate\(candidateId\)/)
 assert.match(manager, /store\.branchCandidate\(candidateId\)/)
+assert.match(manager, /store\.promoteCandidateToCharacter\(candidateId\)/)
+assert.match(manager, /@promote="promoteCandidate\(candidate\.id\)"/)
 assert.match(manager, /store\.restoreCandidateRevision\(candidateId, revisionIndex\)/)
 assert.match(manager, /store\.saveCurrentSession\(\)/)
 assert.match(manager, /store\.loadSavedSessions\(\)/)
@@ -104,6 +107,9 @@ assert.match(card, /emit\('reset'\)/)
 assert.match(card, /emit\('edit'/)
 assert.match(card, /emit\('regenerate'\)/)
 assert.match(card, /emit\('branch'\)/)
+assert.match(card, /emit\('promote'\)/)
+assert.match(card, /data-testid="brainstorm-promote-to-character"/)
+assert.match(card, /Promote to Character/)
 assert.match(card, /More like this/)
 assert.match(card, /Regenerate/)
 assert.match(card, /Save edit/)
@@ -112,5 +118,39 @@ assert.match(card, /What missed\?/)
 assert.match(card, /Delete candidate/)
 assert.doesNotMatch(card, /useBrainstormStore|\$fetch\(|performFetch\(|localStorage/)
 assert.doesNotMatch(card, /(?:sm|md|lg|xl):grid-cols-/)
+
+// The promote button is only offered on kept candidates -- guard against it
+// silently regaining visibility on pending/rejected ones.
+assert.match(
+  card,
+  /v-if="candidate\.status === 'kept'"\s*\n\s*type="button"\s*\n\s*class="btn btn-outline btn-sm"\s*\n\s*data-testid="brainstorm-promote-to-character"/,
+  'the "Promote to Character" button must stay gated to kept candidates only',
+)
+
+// brainstorm/t-031: assert the promotion path actually carries
+// meta.art.imageIds' most recent entry across as a single scalar artImageId
+// -- not the whole array (Character's entityArt.ts model holds one art id
+// per slot) and not silently dropped. Deliberately narrow, matching this
+// file's own style: a source-text check, not a runtime mock of Pinia.
+assert.match(
+  store,
+  /const imageIds = candidate\.meta\.art\?\.imageIds \?\? \[\]/,
+  'promoteCandidateToCharacter must read candidate.meta.art.imageIds',
+)
+assert.match(
+  store,
+  /const artImageId = imageIds\.length\s*\n\s*\? imageIds\[imageIds\.length - 1\]\s*\n\s*: undefined/,
+  'promoteCandidateToCharacter must pick a single scalar artImageId (the most recently delivered image) out of the array, not pass the array through',
+)
+assert.match(
+  store,
+  /await import\('@\/stores\/characterStore'\)/,
+  "promoteCandidateToCharacter must dynamically import characterStore (avoids a static circular import, matching promptStore.promoteToDream's precedent)",
+)
+assert.match(
+  store,
+  /characterStore\.createCharacter\(\{[\s\S]*?artImageId,?\s*\}\)/,
+  'promoteCandidateToCharacter must pass artImageId through to characterStore.createCharacter',
+)
 
 console.log('Brainstorm workbench contract passed.')


### PR DESCRIPTION
### Task
conductor brainstorm/t-031: Add a "promote candidate into an entity" action and wire its art across (kind: software)

### What changed / what I produced
- **`stores/brainstormStore.ts`**: new `promoteCandidateToCharacter(candidateId)`. This is the first entity-to-entity promotion in the app actually wired to a UI element — `promptStore.promoteToDream` and `dreamStore.promotePromptToDream` both exist but are dead code, called from nowhere (confirmed by repo-wide grep before writing this). Follows `promptStore.promoteToDream`'s shape: resolve the source candidate, dynamically `import('@/stores/characterStore')` (avoids a static circular import, same reason the prompt→dream pair does it), delegate to the target store's own `createCharacter`, return `{success, message, data}`.
- **The array→scalar art problem** (the task's own explicitly-flagged open question): a candidate's `meta.art.imageIds` is an array (a candidate can accumulate more than one delivered generation across regenerate/retry), while Character's `entityArt.ts` model holds one scalar `artImageId` per slot. `imageIds` is append-only (`recordCandidateArtImage` always does `[...art.imageIds, imageId]`), so the **last** entry is the most recently delivered image — that's what gets promoted. Earlier deliveries for the same candidate are not carried over, matching the same one-primary-image trade-off `entityArt.ts` already makes for every other entity. Documented inline.
- **`components/brainstorm/brainstorm-candidate-card.vue`**: "Promote to Character" button in the action footer, gated `v-if="candidate.status === 'kept'"` (mirrors the existing Regenerate/More-like-this buttons' styling and busy-spinner convention).
- **`components/brainstorm/brainstorm-manager.vue`**: wires the card's new `promote` emit to the store action, surfaces the result via the existing kept-export transient message (`showKeptExportMessage`, already used for Copy/Export). Also folds the new busy state into `isCandidateBusy` — that function previously only checked `generationTargetId`/`artGeneratingCandidateIds`, which regenerate/branch satisfy via `runGeneration`, but promotion doesn't call `runGeneration`, so without this the card's `:busy` prop would have stayed `false` during a promote and the spinner wouldn't have shown.
- **`utils/scripts/verifyBrainstormWorkbench.mjs`**: extended (this file already asserts every other candidate action's wiring shape) with: the manager→store call and `@promote` wiring, the card's emit/button/testid, a gate assertion that the button stays kept-only, and — per the task's explicit ask — assertions that the promotion path reads `meta.art.imageIds` and passes a single scalar `artImageId` through to `characterStore.createCharacter` rather than the array. Verified these new assertions genuinely fail against the pre-fix code (reverted the implementation, confirmed the contract script throws, then restored it) before trusting them.

### How I verified
- `node utils/scripts/verifyBrainstormWorkbench.mjs` — passes; confirmed the new assertions fail without the implementation (see above)
- `node utils/scripts/verifyBrainstormObjectEntryLinks.mjs`, `verifyBrainstormStoreContract.mjs`, `verifyBrainstormCandidateLifecycle.test.ts` — all pass (no regression in adjacent contracts)
- `npx eslint` on all 4 changed files — clean
- `npx vue-tsc --noEmit` (full project) — clean
- `npm run test` (vue-tsc typecheck) — clean
- Prettier: checked each changed file's diff against a piped `prettier` run; `brainstorm-manager.vue` carries pre-existing formatting drift unrelated to this change (confirmed none of the diffed lines are mine) — left untouched per this repo's established convention; my own new lines in all 4 files are prettier-clean

### Stakes
reversible

### Flags for Reviewer
- No live DB/browser smoke test was possible in this sandbox (no reachable `DATABASE_URL`) — the POST `/api/characters` path itself is unchanged, only a new caller was added, so this relies on kind_robots CI for confirmation.
- Went with Character as the promotion target per the task's own scope ("Character is the most developed entity-art consumer and the most plausible home"); `title`→`title`, `text`→`backstory` field mapping (Character has no plain `description` field).

### Kaizen suggestion
Neither `promptStore.promoteToDream` nor `dreamStore.promotePromptToDream` is wired to any UI element — worth a follow-up task to either wire one of them to a real button (Prompt manager → "Promote to Dream") or remove the dead code, since a promotion pattern with zero live callers is easy to silently bit-rot.

### Notes for reviewer
Conductor task: brainstorm/t-031


---
_Generated by [Claude Code](https://claude.ai/code/session_01FWx9gLCYNGEUwTpq5E6RCg)_