### PR TITLE
Add the Cthulhuquarium Play tab, and carry pitch text into scaffold todos

### DIFF
--- a/components/conductor/aquarium-page.vue
+++ b/components/conductor/aquarium-page.vue
@@ -1,0 +1,48 @@
+<!-- /components/conductor/aquarium-page.vue -->
+<template>
+  <project-front-page
+    class="kr-surface"
+    slug="cthulhuquarium"
+    :fallback="config"
+  >
+    <template #interactive>
+      <CthulhuquariumGame />
+    </template>
+  </project-front-page>
+</template>
+
+<script setup lang="ts">
+import type { ProjectFrontConfig } from '@/components/conductor/projectFront'
+
+const config: ProjectFrontConfig = {
+  slug: 'cthulhuquarium',
+  title: 'Cthulhuquarium',
+  icon: 'kind-icon:fish',
+  tagline:
+    'It sits in the back of the curiosity shop, and now it is yours to feed.',
+  description:
+    'A darkly funny idle aquarium. Click the drifting motes for coins, spend them on food, and keep the occupants fed well enough to keep paying you. Every species has a field note, a rarity, and a reason it is not in any book — and the tank goes deeper than the three you can see.',
+  sections: [
+    {
+      key: 'loop',
+      title: 'Feed the tank',
+      body: 'Click for coins, buy food, keep the occupants fed. Fed things pay out; hungry things stop.',
+      icon: 'kind-icon:coin',
+    },
+    {
+      key: 'collect',
+      title: 'Collect the unlistable',
+      body: 'Each unlock reveals a field note written by someone who is not telling you everything.',
+      icon: 'kind-icon:fish',
+    },
+  ],
+  deliverables: {
+    done: ['Play-loop prototype', 'Bestiary schema shared with Ruler Hooked'],
+    next: [
+      'Server-backed tanks and offline income',
+      'Twenty species with generated art',
+      'Browsable public aquariums',
+    ],
+  },
+}
+</script>

--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -1,0 +1,388 @@
+<!-- components/cthulhuquarium/cthulhuquarium-game.vue
+     The Cthulhuquarium play-loop prototype, dropped into the /play/aquarium
+     scaffold's #interactive slot (conductor cthulhuquarium/t-010).
+
+     Client-only and localStorage-backed on purpose: it makes the Play tab
+     playable the day it lands rather than shipping an empty shell. Fish are
+     drawn shapes, not art, and the species list is a placeholder subset of the
+     canonical fish bible. cthulhuquarium/t-009 and t-011 replace the store and
+     the renderer with the server-authoritative loop and real generated art;
+     this component's job until then is to prove the loop is fun. -->
+<template>
+  <ClientOnly>
+    <div class="kr-container flex max-w-3xl flex-col gap-3">
+      <div
+        v-if="store.offlineEarnings > 0"
+        class="alert rounded-xl border border-info/40 bg-info/10 py-2 text-sm"
+      >
+        <Icon name="kind-icon:coin" class="size-4 shrink-0" />
+        <span>
+          Something was collected while you were gone:
+          <b>{{ store.offlineEarnings }}</b> coins. Nobody says by whom.
+        </span>
+      </div>
+
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <div class="flex items-center gap-3 text-sm font-bold">
+          <span class="flex items-center gap-1">
+            <Icon name="kind-icon:coin" class="size-4 text-warning" />
+            {{ store.coins }}
+          </span>
+          <span class="flex items-center gap-1 opacity-70">
+            <Icon name="kind-icon:fish" class="size-4" />
+            {{ store.stock.length }}
+          </span>
+          <span class="flex items-center gap-1 opacity-70">
+            🍖 {{ store.food }}
+          </span>
+        </div>
+
+        <div class="flex flex-wrap gap-2">
+          <button
+            type="button"
+            class="btn btn-sm"
+            :disabled="store.coins < store.foodCost"
+            @click="store.buyFood()"
+          >
+            Buy food ({{ store.foodCost }})
+          </button>
+          <button
+            type="button"
+            class="btn btn-primary btn-sm"
+            :disabled="store.food <= 0"
+            @click="onFeed"
+          >
+            Feed
+          </button>
+        </div>
+      </div>
+
+      <canvas
+        ref="canvasRef"
+        class="w-full cursor-pointer rounded-2xl border border-base-300 bg-base-300"
+        :width="STAGE_WIDTH"
+        :height="STAGE_HEIGHT"
+        aria-label="Aquarium tank. Click drifting motes to collect coins."
+        @click="onCanvasClick"
+      />
+
+      <p class="text-xs opacity-60">
+        Click the drifting motes for coins. Fed occupants pay out on their own;
+        hungry ones stop. Progress saves in this browser only — a real
+        account-backed tank arrives with the aquarium API.
+      </p>
+
+      <div class="flex flex-col gap-2">
+        <p class="text-xs font-black uppercase tracking-wide opacity-60">
+          The tank
+        </p>
+        <!-- Column count follows the host panel's real width, not the viewport:
+             this is a shared component and the layout contract's viewport-grid
+             rule forbids sm:/md: grid-cols here. -->
+        <div class="grid grid-cols-[repeat(auto-fit,minmax(15rem,1fr))] gap-2">
+          <div
+            v-for="species in PROTOTYPE_SPECIES"
+            :key="species.slug"
+            class="rounded-xl border border-base-300 bg-base-100 p-3"
+          >
+            <div class="flex items-start justify-between gap-2">
+              <div>
+                <p class="text-sm font-bold">
+                  {{ store.unlocked.has(species.slug) ? species.name : '???' }}
+                </p>
+                <p class="mt-0.5 text-xs italic opacity-70">
+                  {{
+                    store.unlocked.has(species.slug)
+                      ? species.note
+                      : 'Not yet observed.'
+                  }}
+                </p>
+              </div>
+              <button
+                v-if="!store.unlocked.has(species.slug)"
+                type="button"
+                class="btn btn-outline btn-xs shrink-0"
+                :disabled="store.coins < species.unlockCost"
+                @click="store.unlock(species.slug)"
+              >
+                {{ species.unlockCost }}
+              </button>
+            </div>
+            <p
+              v-if="store.unlocked.has(species.slug)"
+              class="mt-1 text-xs opacity-60"
+            >
+              {{ species.yield }} coins every {{ species.interval }}s
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </ClientOnly>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import {
+  PROTOTYPE_SPECIES,
+  useCthulhuquariumStore,
+} from '~/stores/cthulhuquariumStore'
+
+/* Fixed logical resolution; CSS scales it to the host width so the canvas
+   survives phone widths without its own breakpoint logic. */
+const STAGE_WIDTH = 640
+const STAGE_HEIGHT = 360
+
+const MOTE_RADIUS = 9
+const MOTE_VALUE = 4
+const MOTE_SPAWN_SECONDS = 2.4
+const MAX_MOTES = 6
+const FOOD_FALL_SPEED = 70
+
+type Swimmer = {
+  slug: string
+  x: number
+  y: number
+  vx: number
+  vy: number
+  phase: number
+}
+
+type Mote = { x: number; y: number; drift: number; born: number }
+type Pellet = { x: number; y: number }
+
+const store = useCthulhuquariumStore()
+const canvasRef = ref<HTMLCanvasElement | null>(null)
+
+const swimmers = ref<Swimmer[]>([])
+const motes = ref<Mote[]>([])
+const pellets = ref<Pellet[]>([])
+
+let frame = 0
+let lastFrameAt = 0
+let sinceMote = 0
+let sincePersist = 0
+
+function spawnSwimmer(slug: string): Swimmer {
+  const species = store.speciesBySlug.get(slug)
+  const speed =
+    species?.behavior === 'dart' ? 62 : species?.behavior === 'lurk' ? 16 : 34
+  return {
+    slug,
+    x: Math.random() * STAGE_WIDTH,
+    y: 60 + Math.random() * (STAGE_HEIGHT - 110),
+    vx: Math.random() < 0.5 ? -speed : speed,
+    vy: 0,
+    phase: Math.random() * Math.PI * 2,
+  }
+}
+
+/** Keep one drawn swimmer per stocked occupant. */
+function syncSwimmers() {
+  const want = store.stock.map((entry) => entry.slug)
+  const have = swimmers.value.map((entry) => entry.slug)
+  for (const slug of want) {
+    const index = have.indexOf(slug)
+    if (index === -1) swimmers.value.push(spawnSwimmer(slug))
+    else have[index] = ''
+  }
+  swimmers.value = swimmers.value.filter((swimmer) =>
+    want.includes(swimmer.slug),
+  )
+}
+
+function drawFish(
+  context: CanvasRenderingContext2D,
+  swimmer: Swimmer,
+  hunger: number,
+) {
+  const species = store.speciesBySlug.get(swimmer.slug)
+  if (!species) return
+  const facing = swimmer.vx >= 0 ? 1 : -1
+  const size = 10 + species.tier * 5
+  // Hungry occupants desaturate and dim rather than vanishing, so a neglected
+  // tank reads as neglected at a glance.
+  const life = 0.3 + (hunger / 100) * 0.7
+
+  context.save()
+  context.translate(swimmer.x, swimmer.y)
+  context.scale(facing, 1)
+  context.fillStyle = `hsla(${species.hue}, ${28 + hunger * 0.35}%, ${20 + hunger * 0.14}%, ${life})`
+
+  context.beginPath()
+  context.ellipse(0, 0, size, size * 0.55, 0, 0, Math.PI * 2)
+  context.fill()
+
+  context.beginPath()
+  context.moveTo(-size, 0)
+  context.lineTo(-size - size * 0.7, -size * 0.5)
+  context.lineTo(-size - size * 0.7, size * 0.5)
+  context.closePath()
+  context.fill()
+
+  context.fillStyle = `rgba(240, 250, 245, ${life})`
+  context.beginPath()
+  context.arc(
+    size * 0.45,
+    -size * 0.12,
+    Math.max(1.6, size * 0.13),
+    0,
+    Math.PI * 2,
+  )
+  context.fill()
+
+  if (species.behavior === 'lurk') {
+    // The angler's lure — the one light in the tank that is bait.
+    context.fillStyle = `rgba(190, 255, 140, ${life})`
+    context.beginPath()
+    context.arc(size * 1.1, -size * 0.75, 2.6, 0, Math.PI * 2)
+    context.fill()
+  }
+  context.restore()
+}
+
+function render(context: CanvasRenderingContext2D) {
+  const water = context.createLinearGradient(0, 0, 0, STAGE_HEIGHT)
+  water.addColorStop(0, '#0d2b2a')
+  water.addColorStop(1, '#04100f')
+  context.fillStyle = water
+  context.fillRect(0, 0, STAGE_WIDTH, STAGE_HEIGHT)
+
+  context.fillStyle = 'rgba(150, 255, 210, 0.06)'
+  context.beginPath()
+  context.moveTo(STAGE_WIDTH * 0.35, 0)
+  context.lineTo(STAGE_WIDTH * 0.62, 0)
+  context.lineTo(STAGE_WIDTH * 0.78, STAGE_HEIGHT)
+  context.lineTo(STAGE_WIDTH * 0.2, STAGE_HEIGHT)
+  context.closePath()
+  context.fill()
+
+  for (const pellet of pellets.value) {
+    context.fillStyle = 'rgba(214, 178, 122, 0.9)'
+    context.beginPath()
+    context.arc(pellet.x, pellet.y, 3, 0, Math.PI * 2)
+    context.fill()
+  }
+
+  for (const swimmer of swimmers.value) {
+    const entry = store.stock.find((item) => item.slug === swimmer.slug)
+    drawFish(context, swimmer, entry?.hunger ?? 0)
+  }
+
+  for (const mote of motes.value) {
+    context.fillStyle = 'rgba(255, 236, 160, 0.85)'
+    context.beginPath()
+    context.arc(mote.x, mote.y, MOTE_RADIUS, 0, Math.PI * 2)
+    context.fill()
+    context.strokeStyle = 'rgba(255, 236, 160, 0.35)'
+    context.lineWidth = 2
+    context.beginPath()
+    context.arc(mote.x, mote.y, MOTE_RADIUS + 4, 0, Math.PI * 2)
+    context.stroke()
+  }
+}
+
+function step(delta: number) {
+  store.tick(delta)
+  syncSwimmers()
+
+  for (const swimmer of swimmers.value) {
+    const target = pellets.value[0]
+    if (target) {
+      // Fish path toward food rather than ignoring it — the feed button has to
+      // visibly do something or nobody presses it twice.
+      const dx = target.x - swimmer.x
+      const dy = target.y - swimmer.y
+      const distance = Math.hypot(dx, dy) || 1
+      swimmer.x += (dx / distance) * 55 * delta
+      swimmer.y += (dy / distance) * 55 * delta
+      swimmer.vx = dx >= 0 ? Math.abs(swimmer.vx) : -Math.abs(swimmer.vx)
+    } else {
+      swimmer.phase += delta
+      swimmer.x += swimmer.vx * delta
+      swimmer.y += Math.sin(swimmer.phase) * 9 * delta
+      if (swimmer.x < 20 || swimmer.x > STAGE_WIDTH - 20) swimmer.vx *= -1
+      swimmer.y = Math.min(Math.max(swimmer.y, 40), STAGE_HEIGHT - 30)
+    }
+  }
+
+  pellets.value = pellets.value.filter((pellet) => {
+    pellet.y += FOOD_FALL_SPEED * delta
+    const eaten = swimmers.value.some(
+      (swimmer) => Math.hypot(swimmer.x - pellet.x, swimmer.y - pellet.y) < 14,
+    )
+    return !eaten && pellet.y < STAGE_HEIGHT - 8
+  })
+
+  sinceMote += delta
+  if (sinceMote >= MOTE_SPAWN_SECONDS && motes.value.length < MAX_MOTES) {
+    sinceMote = 0
+    motes.value.push({
+      x: 30 + Math.random() * (STAGE_WIDTH - 60),
+      y: STAGE_HEIGHT - 20,
+      drift: (Math.random() - 0.5) * 14,
+      born: 0,
+    })
+  }
+  motes.value = motes.value.filter((mote) => {
+    mote.born += delta
+    mote.y -= 26 * delta
+    mote.x += mote.drift * delta
+    return mote.y > 10
+  })
+
+  sincePersist += delta
+  if (sincePersist >= 5) {
+    sincePersist = 0
+    store.persist()
+  }
+}
+
+function loop(timestamp: number) {
+  const context = canvasRef.value?.getContext('2d')
+  if (!context) return
+  // Clamp the delta so a backgrounded tab returning does not simulate one giant
+  // step — offline time is settled by the store on init, not by the frame loop.
+  const delta = Math.min((timestamp - lastFrameAt) / 1000 || 0, 0.1)
+  lastFrameAt = timestamp
+  step(delta)
+  render(context)
+  frame = window.requestAnimationFrame(loop)
+}
+
+function onCanvasClick(event: MouseEvent) {
+  const canvas = canvasRef.value
+  if (!canvas) return
+  const bounds = canvas.getBoundingClientRect()
+  const x = ((event.clientX - bounds.left) / bounds.width) * STAGE_WIDTH
+  const y = ((event.clientY - bounds.top) / bounds.height) * STAGE_HEIGHT
+  const index = motes.value.findIndex(
+    (mote) => Math.hypot(mote.x - x, mote.y - y) <= MOTE_RADIUS + 8,
+  )
+  if (index === -1) return
+  motes.value.splice(index, 1)
+  store.collect(MOTE_VALUE)
+}
+
+function onFeed() {
+  if (!store.feed()) return
+  pellets.value.push({
+    x: 60 + Math.random() * (STAGE_WIDTH - 120),
+    y: 12,
+  })
+}
+
+onMounted(() => {
+  store.init()
+  syncSwimmers()
+  frame = window.requestAnimationFrame((timestamp) => {
+    lastFrameAt = timestamp
+    frame = window.requestAnimationFrame(loop)
+  })
+})
+
+onBeforeUnmount(() => {
+  if (frame) window.cancelAnimationFrame(frame)
+  store.persist()
+})
+</script>

--- a/content/channels/play/aquarium.md
+++ b/content/channels/play/aquarium.md
@@ -1,0 +1,14 @@
+---
+contentType: tab
+channelKey: play
+tabKey: aquarium
+label: Cthulhuquarium
+title: Cthulhuquarium
+subtitle: Feed the things in the tank
+description: A darkly funny idle aquarium. Click for coins, buy food, keep the monsters fed, and find out what else is down there.
+icon: kind-icon:fish
+route: /play/aquarium
+sort: 135
+---
+
+It sits in the back of the curiosity shop, and now it is yours to feed.

--- a/content/play/aquarium.md
+++ b/content/play/aquarium.md
@@ -1,0 +1,15 @@
+---
+title: 'Cthulhuquarium'
+room: 'Cthulhuquarium'
+subtitle: 'Feed the things in the tank.'
+description: A darkly funny idle aquarium — click for coins, buy food, keep the monsters fed, and find out what else is down there.
+icon: kind-icon:fish
+tooltip: Tend an aquarium of things that are probably not fish.
+channelKey: play
+tabKey: aquarium
+cards: navCards
+loadingMessage: Filling the tank...
+refreshLabel: Refresh Cthulhuquarium
+---
+
+:aquarium-page

--- a/server/api/projects/index.post.ts
+++ b/server/api/projects/index.post.ts
@@ -77,6 +77,13 @@ async function createProjectWithScaffoldTodo(
         conductorSlug,
         projectId: project.id,
         requesterUserId,
+        // Carry the pitch across: this todo is Conductor's only view of a
+        // project created here, so a slug on its own is not a briefable handoff.
+        title: data.title,
+        description: data.description,
+        goal: data.goal,
+        pitch: data.pitch,
+        repoUrl: data.repoUrl,
       })
 
       await tx.todo.create({
@@ -146,9 +153,7 @@ export default defineEventHandler(async (event) => {
       ? (body.priority as ProjectPriority)
       : 'NORMAL'
     const isActive =
-      typeof body.isActive === 'boolean'
-        ? body.isActive
-        : status !== 'ARCHIVED'
+      typeof body.isActive === 'boolean' ? body.isActive : status !== 'ARCHIVED'
 
     if (isActive && (status === 'ACTIVE' || status === 'PAUSED')) {
       await enforceProjectCap({

--- a/server/utils/projectDirectWrite.ts
+++ b/server/utils/projectDirectWrite.ts
@@ -80,17 +80,52 @@ function workerUserId(): number {
   return Number.isInteger(raw) && raw > 0 ? raw : 1
 }
 
+/**
+ * The handoff an agent picks up out of the Todo queue when someone creates a
+ * Project here. It is the ONLY signal Conductor gets that a new project exists —
+ * `sync_kind_robots_projection.py` pushes Conductor -> Kind Robots and never reads
+ * back, so nothing else carries a Kind-Robots-authored project across.
+ *
+ * That makes the pitch text load-bearing. This used to send the slug and nothing
+ * else, so an agent claiming the todo knew a project existed but not what it was
+ * for, and had to already know to go read the Project row. Cthulhuquarium
+ * (Project 2112, 2026-08-24) is the case that surfaced it: its scaffold todo was
+ * closed while no `projects/cthulhuquarium/` ever appeared in Conductor, and the
+ * whole pitch — the part that makes the project scaffoldable — was sitting in
+ * `description` and `goal` where the todo never looked.
+ */
 export function projectScaffoldTodoContent(input: {
   conductorSlug: string
   projectId: number
   requesterUserId: number
+  title?: string | null
+  description?: string | null
+  goal?: string | null
+  pitch?: string | null
+  repoUrl?: string | null
 }) {
   const title = `Scaffold conductor project for ${input.conductorSlug}`
+  const detail = (label: string, value?: string | null) =>
+    value && value.trim() ? [`${label}:`, value.trim(), ''] : []
+
   const description = [
     `New Project created by Kind Robots user ${input.requesterUserId} with slug '${input.conductorSlug}'.`,
-    `Create projects/${input.conductorSlug}/roadmap.yaml with at least one ready task.`,
     `Project ${input.projectId} already exists in Kind Robots; do not create another.`,
-  ].join('\n')
+    '',
+    `Scaffold it in the conductor repo:`,
+    `  python scripts/intake.py ${input.conductorSlug} --kind software`,
+    `Then write projects/${input.conductorSlug}/roadmap.yaml with at least one ready`,
+    `task and projects/${input.conductorSlug}/DESIGN-BRIEF.md from the pitch below.`,
+    `Do not close this todo until that directory exists on conductor's main branch.`,
+    '',
+    ...detail('Title', input.title),
+    ...detail('Goal', input.goal),
+    ...detail('Description', input.description),
+    ...detail('Pitch', input.pitch),
+    ...detail('Repo', input.repoUrl),
+  ]
+    .join('\n')
+    .trimEnd()
 
   return { title, description }
 }

--- a/stores/cthulhuquariumStore.ts
+++ b/stores/cthulhuquariumStore.ts
@@ -1,0 +1,257 @@
+// stores/cthulhuquariumStore.ts
+//
+// Prototype state for the Cthulhuquarium play loop (conductor cthulhuquarium/t-010).
+//
+// DELIBERATELY CLIENT-ONLY AND TEMPORARY. This holds coins, food, hunger, and the
+// stocked species in localStorage so the /play/aquarium tab is playable the day it
+// lands instead of being an empty shell waiting on a migration. cthulhuquarium/t-009
+// replaces every field here with the server-authoritative aquarium API, and t-011
+// rewires the game component to it. Nothing else should import this store — when the
+// real API lands, this file is deleted, not extended.
+//
+// The species list below is a hand-seeded subset of the canonical fish bible in
+// silasfelinus/cthulhuquarium (fish/*.yaml). It is a placeholder for rendering, not a
+// second source of truth: t-008 seeds the real bible into kind_robots Character rows
+// and t-011 reads them from there.
+
+import { defineStore } from 'pinia'
+
+const SAVE_KEY = 'cthulhuquarium.prototype.v1'
+
+/** Offline earnings are capped so idling is rewarding but strictly worse than playing. */
+const OFFLINE_CAP_SECONDS = 60 * 60 * 4
+const FOOD_COST = 10
+const HUNGER_PER_SECOND = 0.55
+const FEED_RESTORE = 45
+
+export type PrototypeSpecies = {
+  slug: string
+  name: string
+  note: string
+  tier: number
+  /** Coins produced per drop cycle. */
+  yield: number
+  /** Seconds between coin drops when fed. */
+  interval: number
+  unlockCost: number
+  hue: number
+  /** How it moves. Mirrors the bible's `behavior` field. */
+  behavior: 'drift' | 'dart' | 'lurk'
+}
+
+export const PROTOTYPE_SPECIES: PrototypeSpecies[] = [
+  {
+    slug: 'gutter-minnow',
+    name: 'Gutter Minnow',
+    note: 'Common. Thrives in water no one has changed. Grateful for very little.',
+    tier: 1,
+    yield: 3,
+    interval: 6,
+    unlockCost: 0,
+    hue: 168,
+    behavior: 'drift',
+  },
+  {
+    slug: 'lamplight-angler',
+    name: 'Lamplight Angler',
+    note: 'The light is not for you. It has never been for you.',
+    tier: 2,
+    yield: 9,
+    interval: 9,
+    unlockCost: 120,
+    hue: 96,
+    behavior: 'lurk',
+  },
+  {
+    slug: 'the-understudy',
+    name: 'The Understudy',
+    note: 'Resembles whichever fish you looked at last. Specimen unavailable for photography.',
+    tier: 3,
+    yield: 22,
+    interval: 12,
+    unlockCost: 480,
+    hue: 286,
+    behavior: 'dart',
+  },
+]
+
+type StockEntry = { slug: string; hunger: number; nextDropAt: number }
+
+type SaveShape = {
+  coins: number
+  food: number
+  stock: StockEntry[]
+  lastSeenAt: number
+}
+
+function defaultSave(): SaveShape {
+  return {
+    coins: 25,
+    food: 3,
+    stock: [{ slug: 'gutter-minnow', hunger: 100, nextDropAt: 0 }],
+    lastSeenAt: Date.now(),
+  }
+}
+
+function readSave(): SaveShape {
+  if (typeof window === 'undefined') return defaultSave()
+  try {
+    const raw = window.localStorage.getItem(SAVE_KEY)
+    if (!raw) return defaultSave()
+    const parsed = JSON.parse(raw) as Partial<SaveShape>
+    const known = new Set(PROTOTYPE_SPECIES.map((entry) => entry.slug))
+    return {
+      coins: Number(parsed.coins) || 0,
+      food: Number(parsed.food) || 0,
+      // Drop stock referencing a species this build no longer knows, rather than
+      // rendering an undefined lookup.
+      stock: (parsed.stock ?? []).filter((entry) => known.has(entry?.slug)),
+      lastSeenAt: Number(parsed.lastSeenAt) || Date.now(),
+    }
+  } catch {
+    /* A corrupt or unreadable save is not worth failing the page over. */
+    return defaultSave()
+  }
+}
+
+export const useCthulhuquariumStore = defineStore('cthulhuquarium', () => {
+  const coins = ref(0)
+  const food = ref(0)
+  const stock = ref<StockEntry[]>([])
+  const offlineEarnings = ref(0)
+  const ready = ref(false)
+
+  const speciesBySlug = computed(
+    () => new Map(PROTOTYPE_SPECIES.map((entry) => [entry.slug, entry])),
+  )
+  const unlocked = computed(
+    () => new Set(stock.value.map((entry) => entry.slug)),
+  )
+  const hungriest = computed(() =>
+    stock.value.reduce((low, entry) => Math.min(low, entry.hunger), 100),
+  )
+
+  function persist() {
+    if (typeof window === 'undefined') return
+    try {
+      const payload: SaveShape = {
+        coins: coins.value,
+        food: food.value,
+        stock: stock.value,
+        lastSeenAt: Date.now(),
+      }
+      window.localStorage.setItem(SAVE_KEY, JSON.stringify(payload))
+    } catch {
+      /* Private-mode or quota-exhausted storage just means no save this session. */
+    }
+  }
+
+  /** Settle time away, capped, then start the live clock. */
+  function init() {
+    const save = readSave()
+    coins.value = save.coins
+    food.value = save.food
+    stock.value = save.stock
+
+    const away = Math.min(
+      Math.max(0, (Date.now() - save.lastSeenAt) / 1000),
+      OFFLINE_CAP_SECONDS,
+    )
+    let earned = 0
+    for (const entry of stock.value) {
+      const species = speciesBySlug.value.get(entry.slug)
+      if (!species) continue
+      // Away time drains hunger first; a fish only pays for the stretch it was fed.
+      const fedSeconds = Math.min(away, entry.hunger / HUNGER_PER_SECOND)
+      earned += Math.floor(fedSeconds / species.interval) * species.yield
+      entry.hunger = Math.max(0, entry.hunger - away * HUNGER_PER_SECOND)
+      entry.nextDropAt = 0
+    }
+    offlineEarnings.value = Math.floor(earned)
+    coins.value += offlineEarnings.value
+    ready.value = true
+    persist()
+  }
+
+  /** One simulation step. `delta` is seconds since the previous tick. */
+  function tick(delta: number) {
+    let gained = 0
+    for (const entry of stock.value) {
+      const species = speciesBySlug.value.get(entry.slug)
+      if (!species) continue
+      entry.hunger = Math.max(0, entry.hunger - delta * HUNGER_PER_SECOND)
+      if (entry.hunger <= 0) continue
+      entry.nextDropAt -= delta
+      if (entry.nextDropAt <= 0) {
+        entry.nextDropAt = species.interval
+        gained += species.yield
+      }
+    }
+    if (gained > 0) coins.value += gained
+  }
+
+  function collect(amount: number) {
+    coins.value += amount
+  }
+
+  function buyFood(): boolean {
+    if (coins.value < FOOD_COST) return false
+    coins.value -= FOOD_COST
+    food.value += 1
+    persist()
+    return true
+  }
+
+  /** Spend one food on the hungriest occupant. Returns false when there is nothing to do. */
+  function feed(): boolean {
+    if (food.value <= 0) return false
+    const target = stock.value.reduce<StockEntry | null>(
+      (worst, entry) => (!worst || entry.hunger < worst.hunger ? entry : worst),
+      null,
+    )
+    if (!target) return false
+    food.value -= 1
+    target.hunger = Math.min(100, target.hunger + FEED_RESTORE)
+    persist()
+    return true
+  }
+
+  function unlock(slug: string): boolean {
+    const species = speciesBySlug.value.get(slug)
+    if (!species || unlocked.value.has(slug)) return false
+    if (coins.value < species.unlockCost) return false
+    coins.value -= species.unlockCost
+    stock.value.push({ slug, hunger: 100, nextDropAt: species.interval })
+    persist()
+    return true
+  }
+
+  function reset() {
+    const save = defaultSave()
+    coins.value = save.coins
+    food.value = save.food
+    stock.value = save.stock
+    offlineEarnings.value = 0
+    persist()
+  }
+
+  return {
+    coins,
+    food,
+    stock,
+    ready,
+    offlineEarnings,
+    hungriest,
+    unlocked,
+    speciesBySlug,
+    foodCost: FOOD_COST,
+    init,
+    tick,
+    collect,
+    buyFood,
+    feed,
+    unlock,
+    persist,
+    reset,
+  }
+})

--- a/utils/projectPlacements.ts
+++ b/utils/projectPlacements.ts
@@ -72,6 +72,11 @@ export const PROJECT_PLACEMENTS: Record<string, ProjectPlacement> = {
     tabKey: 'davinci',
     route: '/play/davinci',
   },
+  cthulhuquarium: {
+    channelKey: 'play',
+    tabKey: 'aquarium',
+    route: '/play/aquarium',
+  },
   'media-watchlist': {
     channelKey: 'plan',
     tabKey: 'watchlist',


### PR DESCRIPTION
Cthulhuquarium (conductor `cthulhuquarium/t-010`) is a darkly funny idle aquarium. Its game code lives here, same pattern as music-mentor and davinci; the fish bible and balance tables live in `silasfelinus/cthulhuquarium` as portable canon.

## The Play tab

- `utils/projectPlacements.ts` — `cthulhuquarium` → `play` / `aquarium` / `/play/aquarium`
- `content/channels/play/aquarium.md` — the Play directory tab
- `content/play/aquarium.md` — the page, mounting `:aquarium-page`
- `components/conductor/aquarium-page.vue` — project front page wrapper

`dashboardKey`/`dashboardTab` are deliberately omitted. Setting them derives a dashboard image path (`/images/dashboard-tabs/{key}/{tab}.webp`) that would 404 until the art exists — the exact bug taskmaster/t-004 was filed for. music-mentor omits them for the same reason. They go in with the art.

## A prototype, not an empty shell

`components/cthulhuquarium/cthulhuquarium-game.vue` and `stores/cthulhuquariumStore.ts` make the tab playable the day it lands: canvas fish with per-species behavior (drift / dart / lurk), clickable drifting collectibles, food that falls and gets eaten, hunger decay that visibly dims a neglected tank, capped offline earnings, and a localStorage save.

Both files are explicitly temporary and say so in their headers. cthulhuquarium/t-009 and t-011 replace them with the server-authoritative aquarium API, at which point the store is **deleted rather than extended**. The species list in the store is a placeholder subset of the real bible, not a second source of truth — t-008 seeds the canonical bible into `Character` rows.

Structure mirrors ruler-hooked: a `project-front-page` wrapper in `components/conductor/`, the game itself in `components/<project>/`, and a localStorage-backed Pinia store.

## Scaffold todos now carry the pitch

When a Project is created here, the Todo it writes is the **only** signal Conductor gets that the project exists — `sync_kind_robots_projection.py` pushes one way and never reads back. That todo used to carry the slug and nothing else, so an agent claiming it knew a project existed but not what it was for, with the entire pitch sitting unread in the Project row.

`projectScaffoldTodoContent` now carries title, goal, description, pitch, and repo, plus the exact `intake.py` command and an instruction not to close the todo until the conductor project directory actually exists.

Filed as conductor/t-125: the other half of that gap — that nothing *verifies* the handoff happened — is still open. Cthulhuquarium's own scaffold todo (#1320) was closed while no such directory ever existed, which is how this surfaced.

## Verification

All clean locally: `vue-tsc --noEmit` (exit 0), `eslint` on every touched file, `prettier --check`, `npm run test:layout-contract`, and `npm run test:channel-content` (5 channels, 57 tabs, 28 project placements, 68 MDC mounts resolved, 0 nav manifest errors).

The layout contract caught one real violation on the first pass — a `sm:grid-cols-2` in a shared component, which its `viewport-grid` rule forbids because a shared component can be embedded in a host narrower than its viewport class implies. Replaced with a container-width `auto-fit` grid.

No PR preview exists for this repo, so nothing here is a claim about pixels or hydration — that comes from the audit workflow against production after a Force Update.

Companion PRs: silasfelinus/conductor#2767 (project scaffold) and silasfelinus/cthulhuquarium#1 (data canon).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFNZJyWZYdqphFMF2xXv5D)_