### PR TITLE
refactor(galleries): defer custom cards and complete Dream indexes

### DIFF
--- a/.github/workflows/gallery-progressive-rendering-contract.yml
+++ b/.github/workflows/gallery-progressive-rendering-contract.yml
@@ -13,8 +13,10 @@ on:
       - 'components/resources/resource-card.vue'
       - 'components/servers/checkpoint-card.vue'
       - 'components/achievements/earned-achievement-card.vue'
+      - 'server/api/dreams/index.get.ts'
       - 'utils/viewportHydration.ts'
       - 'utils/scripts/verifyGalleryProgressiveRendering.ts'
+      - 'utils/scripts/verifyGalleryIndexHydration.ts'
       - '.github/workflows/gallery-progressive-rendering-contract.yml'
   pull_request:
     branches: [main]
@@ -28,8 +30,10 @@ on:
       - 'components/resources/resource-card.vue'
       - 'components/servers/checkpoint-card.vue'
       - 'components/achievements/earned-achievement-card.vue'
+      - 'server/api/dreams/index.get.ts'
       - 'utils/viewportHydration.ts'
       - 'utils/scripts/verifyGalleryProgressiveRendering.ts'
+      - 'utils/scripts/verifyGalleryIndexHydration.ts'
       - '.github/workflows/gallery-progressive-rendering-contract.yml'
   workflow_dispatch:
 
@@ -59,3 +63,6 @@ jobs:
 
       - name: Verify gallery progressive rendering
         run: npx tsx utils/scripts/verifyGalleryProgressiveRendering.ts
+
+      - name: Verify complete gallery index hydration
+        run: npx tsx utils/scripts/verifyGalleryIndexHydration.ts

--- a/components/gallery/kr-gallery.vue
+++ b/components/gallery/kr-gallery.vue
@@ -63,13 +63,72 @@
           :style="itemVisibilityStyle"
           data-kr-gallery-item
         >
-          <slot
-            name="item"
-            :item="item"
-            :mode="mode"
-            :art-src="artSrc(item)"
-            :open="() => emit('open', item)"
-          />
+          <!--
+            A custom card can have setup hooks, watchers, store reads, and API
+            fallbacks that CSS `content-visibility` cannot suppress. Keep the
+            full lightweight text index in the DOM immediately, but do not
+            instantiate the custom component until the pooled viewport observer
+            says this item is near enough to matter. The 1800px overscan lives
+            in viewportHydration.ts and is shared with deferred images.
+          -->
+          <kr-viewport-gate @hydrate="hydrateSlotItem(item.id)">
+            <slot
+              v-if="hydratedSlotItems.has(item.id)"
+              name="item"
+              :item="item"
+              :mode="mode"
+              :art-src="artSrc(item)"
+              :open="() => emit('open', item)"
+            />
+
+            <div
+              v-else
+              class="overflow-hidden rounded-2xl border border-(--kr-surface-border) bg-(--kr-surface)"
+              :class="slotPlaceholderClass"
+              data-kr-gallery-placeholder
+            >
+              <div
+                v-if="mode !== 'icons'"
+                class="bg-(--kr-surface-sunken)"
+                :class="mode === 'heroes' ? 'aspect-video' : 'aspect-2/3'"
+                aria-hidden="true"
+              />
+
+              <div
+                class="min-w-0"
+                :class="mode === 'icons' ? 'p-3' : 'p-3'"
+              >
+                <div
+                  v-if="item.badges?.length"
+                  class="mb-1 flex flex-wrap gap-1"
+                >
+                  <span
+                    v-for="badge in item.badges"
+                    :key="badge.label"
+                    class="badge badge-xs"
+                    :class="badge.class"
+                  >
+                    {{ badge.label }}
+                  </span>
+                </div>
+                <h2 class="break-words font-black leading-tight">
+                  {{ item.title }}
+                </h2>
+                <p
+                  v-if="item.description"
+                  class="mt-0.5 line-clamp-2 text-xs text-base-content/55"
+                >
+                  {{ item.description }}
+                </p>
+                <p
+                  v-if="item.meta"
+                  class="mt-1.5 text-xs text-base-content/45"
+                >
+                  {{ item.meta }}
+                </p>
+              </div>
+            </div>
+          </kr-viewport-gate>
         </div>
       </template>
 
@@ -334,8 +393,22 @@ const itemVisibilityStyle = computed<CSSProperties>(() => ({
         : 'auto 24rem',
 }))
 
+const slotPlaceholderClass = computed(() =>
+  props.mode === 'icons'
+    ? 'min-h-20'
+    : props.mode === 'heroes'
+      ? 'min-h-56'
+      : 'min-h-96',
+)
+
 const modeVariant = computed<ArtVariant>(() => MODE_VARIANT[props.mode])
 const failedArt = ref(new Set<string>())
+const hydratedSlotItems = ref(new Set<string | number>())
+
+function hydrateSlotItem(id: string | number): void {
+  if (hydratedSlotItems.value.has(id)) return
+  hydratedSlotItems.value = new Set(hydratedSlotItems.value).add(id)
+}
 
 function artSrc(item: GalleryItem): string {
   const src = displayImage(item)

--- a/server/api/dreams/index.get.ts
+++ b/server/api/dreams/index.get.ts
@@ -23,26 +23,37 @@ type DreamListQuery = {
   rewardId?: string
 }
 
+// Browse responses carry only path/id metadata for art. Pathless legacy rows are
+// hydrated by DreamCard only after its kr-gallery item enters the shared viewport
+// window, so the full index never has to ship inline image bytes.
 const artImageCardSelect = {
   id: true,
   imagePath: true,
   path: true,
   fileName: true,
-  thumbnailData: true,
 } satisfies Prisma.ArtImageSelect
+
+const collectionPreviewSelect = {
+  id: true,
+  label: true,
+  imagePath: true,
+  description: true,
+  artPrompt: true,
+  ArtImages: {
+    take: 1,
+    orderBy: {
+      updatedAt: 'desc',
+    },
+    select: artImageCardSelect,
+  },
+} satisfies Prisma.ArtCollectionSelect
 
 const dreamListInclude = {
   ArtImage: {
     select: artImageCardSelect,
   },
   ArtCollection: {
-    select: {
-      id: true,
-      label: true,
-      imagePath: true,
-      description: true,
-      artPrompt: true,
-    },
+    select: collectionPreviewSelect,
   },
   ArtImages: {
     take: 1,
@@ -51,22 +62,10 @@ const dreamListInclude = {
     },
     select: artImageCardSelect,
   },
+  // Relationship galleries need every attached collection id to decide whether
+  // two Dreams are connected. Each collection still carries only one preview.
   ArtCollections: {
-    take: 1,
-    select: {
-      id: true,
-      label: true,
-      imagePath: true,
-      description: true,
-      artPrompt: true,
-      ArtImages: {
-        take: 1,
-        orderBy: {
-          updatedAt: 'desc',
-        },
-        select: artImageCardSelect,
-      },
-    },
+    select: collectionPreviewSelect,
   },
   Bots: {
     where: {
@@ -87,15 +86,19 @@ const dreamListInclude = {
       isPublic: true,
     },
   },
+  // These relation records are deliberately narrow, but complete. The old
+  // `take: 3` caps made Connected/Available and client-side search incorrect
+  // for Dreams with more than three scenarios, cast members, or rewards.
   Scenarios: {
     where: {
       isActive: true,
     },
-    take: 3,
     select: {
       id: true,
       title: true,
       description: true,
+      locations: true,
+      genres: true,
       imagePath: true,
       difficulty: true,
       tier: true,
@@ -109,15 +112,16 @@ const dreamListInclude = {
     where: {
       isActive: true,
     },
-    take: 3,
     select: {
       id: true,
       name: true,
       slug: true,
+      honorific: true,
       title: true,
       role: true,
       species: true,
       class: true,
+      genre: true,
       imagePath: true,
       artImageId: true,
       isActive: true,
@@ -128,11 +132,11 @@ const dreamListInclude = {
     where: {
       isActive: true,
     },
-    take: 3,
     select: {
       id: true,
       name: true,
       slug: true,
+      description: true,
       rewardType: true,
       rarity: true,
       imagePath: true,
@@ -157,9 +161,16 @@ const dreamListInclude = {
   },
 } satisfies Prisma.DreamInclude
 
-function normalizeLimit(value: unknown, fallback = 48, max = 200): number {
-  const parsed = Number(value)
+/**
+ * No `take` means the caller wants the complete lightweight browse index.
+ * Explicit slices remain bounded so picker/search consumers can still ask for
+ * a small window without turning an accidental huge value into an expensive
+ * query.
+ */
+function normalizeLimit(value: unknown, fallback = 48, max = 200): number | undefined {
+  if (value === undefined || value === null || value === '') return undefined
 
+  const parsed = Number(value)
   if (!Number.isInteger(parsed) || parsed <= 0) return fallback
 
   return Math.min(parsed, max)
@@ -376,7 +387,7 @@ export default defineEventHandler(async (event) => {
     const [dreams, count] = await Promise.all([
       prisma.dream.findMany({
         where,
-        take,
+        ...(take === undefined ? {} : { take }),
         skip,
         orderBy: {
           updatedAt: 'desc',

--- a/utils/scripts/verifyGalleryIndexHydration.ts
+++ b/utils/scripts/verifyGalleryIndexHydration.ts
@@ -47,7 +47,7 @@ forbidText(
 )
 forbidText(
   dreamListRoute,
-  'take: 3',
+  'take: 3,\n',
   'Dream browse relationships must not be truncated to three records',
 )
 requireText(

--- a/utils/scripts/verifyGalleryIndexHydration.ts
+++ b/utils/scripts/verifyGalleryIndexHydration.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'node:fs'
+
+const failures: string[] = []
+
+function read(path: string): string {
+  return readFileSync(path, 'utf8')
+}
+
+function requireText(source: string, text: string, message: string): void {
+  if (!source.includes(text)) failures.push(message)
+}
+
+function forbidText(source: string, text: string, message: string): void {
+  if (source.includes(text)) failures.push(message)
+}
+
+const gallery = read('components/gallery/kr-gallery.vue')
+const dreamListRoute = read('server/api/dreams/index.get.ts')
+
+for (const token of [
+  '<kr-viewport-gate @hydrate="hydrateSlotItem(item.id)">',
+  'v-if="hydratedSlotItems.has(item.id)"',
+  'data-kr-gallery-placeholder',
+  '{{ item.title }}',
+]) {
+  requireText(
+    gallery,
+    token,
+    `custom gallery slots must keep a text-first index and defer component mounting: ${token}`,
+  )
+}
+
+requireText(
+  dreamListRoute,
+  "if (value === undefined || value === null || value === '') return undefined",
+  'Dream list requests without an explicit take must mean complete browse index',
+)
+requireText(
+  dreamListRoute,
+  '...(take === undefined ? {} : { take })',
+  'Dream list query must omit Prisma take for complete browse-index requests',
+)
+forbidText(
+  dreamListRoute,
+  'thumbnailData: true',
+  'Dream browse index must not ship inline thumbnail blobs before viewport hydration',
+)
+forbidText(
+  dreamListRoute,
+  'take: 3',
+  'Dream browse relationships must not be truncated to three records',
+)
+requireText(
+  dreamListRoute,
+  'const collectionPreviewSelect = {',
+  'Dream browse records must carry a lightweight collection preview shape',
+)
+requireText(
+  dreamListRoute,
+  'ArtCollections: {\n    select: collectionPreviewSelect,\n  }',
+  'Dream relationship browsing must receive every attached collection id',
+)
+
+if (failures.length) {
+  for (const failure of failures) console.error(`FAIL - ${failure}`)
+  process.exit(1)
+}
+
+console.log(
+  'ok - galleries expose the complete text-first index, defer custom card setup near viewport, and Dream browsing is complete without inline image blobs',
+)


### PR DESCRIPTION
## Why
All 18 live Kind Robots galleries already use `kr-gallery`, so the remaining upgrade work is below the shell: full-index completeness and preventing offscreen custom-card setup from eagerly hydrating stores/APIs.

Two concrete leaks remained:
- `content-visibility` skipped offscreen paint, but Vue still instantiated every custom card slot, so setup hooks/watchers could run for the entire gallery immediately.
- `/api/dreams` silently defaulted to 48 rows and truncated Scenarios/Characters/Rewards/ArtCollections used by relationship browsing, so a gallery could look unpaginated while still receiving a partial index.

## What changed
- `kr-gallery` keeps the complete lightweight text index in the DOM immediately for custom slots, but mounts the real custom component only after the shared pooled viewport observer reaches it (1800px overscan).
- Offscreen placeholders retain title/description/meta/badges and stable approximate geometry, so scroll shape and searchable/readable index arrive before expensive cards.
- Dream list requests with no explicit `take` now return the complete browse index. Explicit `take=` requests remain bounded to 200.
- Dream browse art carries path/id metadata rather than inline `thumbnailData` blobs.
- Dream ArtCollection rows carry one preview image each, while every attached collection id is preserved.
- Scenario/Character/Reward relations in Dream browse results are narrow but complete instead of capped at three, fixing Connected/Available and client-side search for richer Dreams.
- Added `verifyGalleryIndexHydration.ts` and wired it into the Gallery Progressive Rendering workflow.

## Scope
This is the first backend/hydration finishing slice after the kr-gallery adoption sweep. Scenario's list endpoint is the next known overweight gallery provider and is intentionally left for the next bounded slice after this exact head is verified/merged.

## Safety
No schema migration. No production-data mutation. No deployment change.

Conductor: `interface-vision/t-104`
Session: `2026-08-24T100600Z-interface-vision-t-104-gallery-sweep-k4m7`