### PR TITLE
refactor(galleries): stop hydrating Reward relation graphs

### DIFF
--- a/server/api/rewards/index.get.ts
+++ b/server/api/rewards/index.get.ts
@@ -1,7 +1,6 @@
 // /server/api/rewards/index.get.ts
 import { defineEventHandler } from 'h3'
 import prisma from '../../utils/prisma'
-import { rewardInclude } from './'
 import { errorHandler } from '../../utils/error'
 import { getOptionalApiUser } from '../../utils/authGuard'
 import { viewablePackIds } from '../../utils/contentAccess'
@@ -25,12 +24,16 @@ export default defineEventHandler(async (event) => {
           }
         : { isPublic: true }
 
+    // Gallery/search/edit callers consume Reward scalars only. Do not hydrate
+    // ArtImage, Characters, Dreams, Reactions, or User for every catalog row;
+    // rich relation graphs remain available through /api/rewards/:id.
+    // reward-card already resolves art lazily from artImageId when its card is
+    // mounted near the viewport by kr-gallery's progressive slot hydration.
     const data = await prisma.reward.findMany({
       where: {
         isActive: true,
         ...visibility,
       },
-      include: rewardInclude,
       orderBy: [{ updatedAt: 'desc' }, { id: 'desc' }],
     })
 

--- a/utils/scripts/verifyGalleryIndexHydration.ts
+++ b/utils/scripts/verifyGalleryIndexHydration.ts
@@ -25,6 +25,9 @@ const gallery = read('components/gallery/kr-gallery.vue')
 const dreamListRoute = read('server/api/dreams/index.get.ts')
 const scenarioListRoute = read('server/api/scenarios/index.get.ts')
 const scenarioDetailRoute = read('server/api/scenarios/[id].get.ts')
+const rewardListRoute = read('server/api/rewards/index.get.ts')
+const rewardModel = read('server/api/rewards/index.ts')
+const rewardCard = read('components/rewards/reward-card.vue')
 
 for (const token of [
   '<kr-viewport-gate @hydrate="hydrateSlotItem(item.id)">',
@@ -146,11 +149,78 @@ for (const token of [
   )
 }
 
+forbidText(
+  rewardListRoute,
+  "import { rewardInclude } from './'",
+  'Reward list must not import the rich Reward relation graph',
+)
+forbidText(
+  rewardListRoute,
+  'include: rewardInclude',
+  'Reward list must return scalar browse records instead of hydrating every relation',
+)
+
+for (const token of [
+  'ArtImage: true',
+  'Characters: true',
+  'Dreams: true',
+  'Reactions: true',
+  'User: {',
+]) {
+  forbidText(
+    rewardListRoute,
+    token,
+    `Reward list must not inline catalog-wide relation payload: ${token}`,
+  )
+}
+
+const rewardDetailInclude = between(
+  rewardModel,
+  'export const rewardInclude = {',
+  '\n} satisfies Prisma.RewardInclude',
+)
+
+for (const token of [
+  'ArtImage: true',
+  'Characters: true',
+  'Dreams: true',
+  'Reactions: true',
+  'User: {',
+]) {
+  requireText(
+    rewardDetailInclude,
+    token,
+    `Reward detail model must retain rich relation hydration: ${token}`,
+  )
+}
+
+const fetchRewardDetail = between(
+  rewardModel,
+  'export async function fetchRewardById(',
+  '\n}\n\nexport async function fetchRewardBySlug',
+)
+requireText(
+  fetchRewardDetail,
+  'include: rewardInclude',
+  'Reward by-id detail fetch must keep the rich relation graph',
+)
+
+requireText(
+  rewardCard,
+  'if (!props.reward.artImageId || !props.showImage || embeddedArtImage.value)',
+  'Reward cards must keep lazy ArtImage fallback when browse rows omit embedded ArtImage',
+)
+requireText(
+  rewardCard,
+  'artImage.value = await fetchArtImageById(props.reward.artImageId)',
+  'Reward cards must hydrate ArtImage by id only when the mounted card needs it',
+)
+
 if (failures.length) {
   for (const failure of failures) console.error(`FAIL - ${failure}`)
   process.exit(1)
 }
 
 console.log(
-  'ok - galleries expose complete text-first indexes, defer custom card setup, and keep Dream/Scenario browse relationships lightweight without losing detail endpoints',
+  'ok - galleries expose complete text-first indexes, defer custom card setup, and keep Dream/Scenario/Reward browse payloads lightweight without losing rich detail hydration',
 )


### PR DESCRIPTION
## Why
Reward Gallery still fetched the richest list payload among the upgraded galleries: every `/api/rewards` row included the complete `ArtImage`, `Characters`, `Dreams`, `Reactions`, and `User` relation graph even though the gallery/store consume plain Reward scalars.

That made the earlier progressive-card work less effective than it could be. `reward-card` already knows how to resolve its ArtImage lazily from `artImageId`; once the list stops embedding ArtImage, that fetch happens only when the card itself mounts near the viewport.

## What changed
- Remove `rewardInclude` from `GET /api/rewards`; the catalog now returns plain Reward scalar rows with the same visibility and ordering semantics.
- Preserve the existing rich `rewardInclude` graph for `GET /api/rewards/:id` and other explicit detail helpers.
- Keep existing `reward-card` lazy ArtImage-by-id hydration as the visual fallback when browse rows do not embed `ArtImage`.
- Extend the gallery index/hydration contract to prevent catalog-wide Reward relation hydration from returning while requiring the detail relation graph and lazy art path to remain intact.

## Audit notes
- `rewardStore.rewards` is typed `Reward[]` and reads no relation objects.
- Reward Gallery search/filter/edit/selection surfaces use Reward scalar fields only.
- Reward reviews/reactions already use dedicated APIs.
- Existing Reward Cypress list coverage asserts scalar fields, not joined relation payloads.

## Scope
Two-file provider slice only. No schema migration, production-data mutation, deployment change, store rewrite, or visible gallery UI change.

Conductor: `interface-vision/t-104`
Session: `2026-08-24T112600Z-interface-vision-t-104-reward-gallery-q8n5`