### PR TITLE
refactor(model-builder): dedupe redundant Number(quantityIndex) calls

### DIFF
--- a/server/api/model-builder/runs/index.post.ts
+++ b/server/api/model-builder/runs/index.post.ts
@@ -169,15 +169,19 @@ export default defineEventHandler(async (event) => {
         return value
       }
 
+      // Computed once and reused below (model-builder/t-029, cycle 52 noted
+      // this as a non-bug worth cleaning up: the prior form called
+      // Number(item.quantityIndex) three times for one value).
+      const quantityIndex = Number(item.quantityIndex)
+
       return {
         outputKey,
         label: typeof item.label === 'string' ? item.label.slice(0, 255) : null,
         action,
         generation,
         quantityIndex:
-          Number.isInteger(Number(item.quantityIndex)) &&
-          Number(item.quantityIndex) >= 0
-            ? Number(item.quantityIndex)
+          Number.isInteger(quantityIndex) && quantityIndex >= 0
+            ? quantityIndex
             : 0,
         stageStatuses,
         pitch: text(item.pitch, index, 'pitch'),


### PR DESCRIPTION
## Why
`runs/index.post.ts`'s `quantityIndex` validation called `Number(item.quantityIndex)` three times for a single value. Compute it once and reuse it.

## What changed
- `server/api/model-builder/runs/index.post.ts`: hoist the repeated `Number(item.quantityIndex)` call into a local `const quantityIndex` before the object literal, keeping the exact same `Number.isInteger(...) && ... >= 0` guard and 0 fallback. No behavior change.

## Verification
- `npx vue-tsc --noEmit`: clean, repo-wide.
- `npx eslint server/api/model-builder/runs/index.post.ts`: clean.
- `npx prettier --check server/api/model-builder/runs/index.post.ts`: clean.
- All 147 `test:model-builder-*` contract/guard scripts: pass (verified via exit code, not just output grep).
- `git status --porcelain`: scoped to exactly this one file.

## Scope
This cycle's other work was a full read of every `server/api/model-builder/**` route file for missing auth/ownership checks (the lens `model-builder/t-029` cycle 52 first tried and flagged this dedup from). No access-control gap found — every route already gates on `requireApiUser` + `assertRunAccess`/`assertSourceOwnership` + `assertRunWritable`, and re-checks `assertArtImageAttachable`/`assertContentStageEditable` against a fresh read immediately before each write. This PR is the one concrete, safe cleanup that fell out of that sweep.

Conductor: `model-builder/t-029` cycle 65

---
_Generated by [Claude Code](https://claude.ai/code/session_01Chq6RBm5GFFM43VjBeFe3a)_