### PR TITLE
feat: add resumable Scene Animator admin workflow

### DIFF
--- a/content/channels/admin/scene-animator.md
+++ b/content/channels/admin/scene-animator.md
@@ -1,0 +1,15 @@
+---
+contentType: tab
+channelKey: admin
+tabKey: scene-animator
+label: Scene Animator
+title: Scene Animator
+subtitle: Turn folders of still scenes into short living clips
+description: Select a source folder, video preset, duration, and maturity setting; resume durable Comfy renders and browse the finished clips.
+icon: kind-icon:server
+route: /admin/scene-animator
+sort: 90
+requiredRole: ADMIN
+---
+
+Animate still-scene folders through the existing ArtJob-backed video pipeline without hand-writing motion prompts for every image.

--- a/docs/scene-animator.md
+++ b/docs/scene-animator.md
@@ -1,0 +1,101 @@
+# Scene Animator
+
+Scene Animator is an administrator-only folder-to-video production surface at
+`/admin/scene-animator`. It turns a directory of still scene images into short
+LTX or WAN clips by reusing the normal Kind Robots video path:
+
+```text
+Scene Animator
+  -> POST /api/scene-animator/enqueue
+  -> POST /api/video/generate
+  -> POST /api/art/enqueue
+  -> ArtJob
+  -> kr-relay
+  -> ComfyUI LTX/WAN
+  -> ArtImage
+```
+
+It deliberately does not own another render queue. ArtJobs remain the durable
+ledger for pending, running, failed, cancelled, and completed work.
+
+## Source tree
+
+Scene Animator reads source stills from a dedicated tree, separate from
+`kindrobots/images` generated/public art.
+
+Production target:
+
+```text
+/mnt/user/pc/kindrobots/animate/
+  project-a/
+    scene-001.webp
+    scene-002.png
+  project-b/
+    shot-01.jpg
+```
+
+Set the source root explicitly when the application can see that path:
+
+```dotenv
+ANIMATE_PATH=/mnt/user/pc/kindrobots/animate
+```
+
+For WSL development the equivalent is typically:
+
+```dotenv
+ANIMATE_PATH=/mnt/z/kindrobots/animate
+```
+
+When `ANIMATE_PATH` is absent but `IMAGES_PATH` is configured, Scene Animator
+uses an `animate` sibling of the configured image root. With
+`IMAGES_PATH=/mnt/user/pc/kindrobots/images`, that resolves to
+`/mnt/user/pc/kindrobots/animate`. When neither variable exists, local
+development falls back to `<repo>/animate`.
+
+The source API only accepts normalized relative folders and image filenames.
+Absolute paths, `..` traversal, and symlink escapes are rejected. The MVP is
+read-only: it never deletes, renames, or mutates source stills.
+
+The application/container still needs read access to the chosen source root.
+Adding or changing a production bind mount is an operator deployment step; the
+code does not attempt to alter container configuration itself.
+
+## Automatic motion prompt
+
+The still image is treated as the creative prompt. Every batch uses the same
+scene-preserving motion direction:
+
+> Bring this still scene naturally to life with subtle coherent motion. Preserve
+> the subjects, composition, identity, lighting, and visual style. Add only
+> plausible ambient movement, gentle secondary motion, and stable cinematic
+> camera behavior. Do not introduce new characters, objects, text, or scene
+> changes.
+
+Manual per-shot prompting remains available in `/play/video-generator` rather
+than complicating the batch workflow.
+
+## Resume and deduplication
+
+Each Scene Animator ArtJob receives a `sceneAnimator` provenance object in its
+payload containing:
+
+- source folder and filename
+- SHA-256 of the source bytes
+- effective video configuration
+- a deterministic dedupe key
+
+The dedupe key is derived from source bytes plus engine, preset, duration, FPS,
+size, output format, loop mode, render scale, and maturity. The admin page
+reconstructs progress from those ArtJobs after a refresh or restart.
+
+`Start / Resume` skips matching PENDING, RUNNING, and DONE jobs. Failed and
+cancelled jobs stay visible and can be retried explicitly. Editing a source
+image or changing effective render settings creates a new key on purpose.
+
+## Privacy and maturity
+
+Generated Scene Animator ArtImages are private by default. The batch maturity
+toggle is forwarded to the existing ArtJob/ArtImage maturity fields; no new
+content classification system is introduced. Source previews are streamed
+through an authenticated admin API rather than exposed as a public source
+folder.

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -6,7 +6,7 @@
           <p class="text-xs font-black uppercase tracking-widest text-primary">
             Admin production
           </p>
-          <h1 class="mt-1 text-3xl font-black">Scene Animator</h1>
+          <p class="mt-1 text-3xl font-black">Scene Animator</p>
           <p class="mt-2 text-sm text-base-content/65">
             Point Kind Robots at a folder of still scenes and let the existing Comfy video
             queue bring each one to life. No shot-by-shot prompt writing required.

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -1,0 +1,381 @@
+<template>
+  <main class="kr-surface h-full min-h-0 overflow-hidden">
+    <div class="kr-scroll kr-container-wide space-y-5 p-4 md:p-6">
+      <header class="kr-toolbar flex flex-wrap items-start justify-between gap-4">
+        <div class="max-w-3xl">
+          <p class="text-xs font-black uppercase tracking-widest text-primary">
+            Admin production
+          </p>
+          <h1 class="mt-1 text-3xl font-black">Scene Animator</h1>
+          <p class="mt-2 text-sm text-base-content/65">
+            Point Kind Robots at a folder of still scenes and let the existing Comfy video
+            queue bring each one to life. No shot-by-shot prompt writing required.
+          </p>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <span class="badge badge-outline">Private output</span>
+          <span class="badge badge-outline">ArtJob-backed resume</span>
+          <button
+            type="button"
+            class="btn btn-sm rounded-xl"
+            :disabled="store.loading || store.queueing || !userStore.isAdmin"
+            @click="store.load()"
+          >
+            <span v-if="store.loading" class="loading loading-spinner loading-xs" />
+            Refresh
+          </button>
+        </div>
+      </header>
+
+      <div v-if="!ready" class="grid min-h-60 place-items-center kr-panel">
+        <span class="loading loading-spinner loading-lg text-primary" />
+      </div>
+
+      <div
+        v-else-if="!userStore.isAdmin"
+        class="rounded-2xl border border-error/40 bg-error/10 p-8 text-center"
+      >
+        <p class="text-xl font-black">Administrator access required</p>
+        <p class="mt-2 text-sm text-base-content/60">
+          Folder animation can enqueue substantial local GPU work, so this surface is admin-only.
+        </p>
+      </div>
+
+      <template v-else>
+        <section class="grid gap-4 xl:grid-cols-[minmax(270px,0.34fr)_minmax(0,1fr)]">
+          <aside class="kr-panel space-y-4 p-4 md:p-5">
+            <div>
+              <p class="text-xs font-black uppercase tracking-wider text-primary">Batch setup</p>
+              <h2 class="mt-1 text-xl font-black">Choose the source, then motion</h2>
+            </div>
+
+            <label class="form-control gap-1">
+              <span class="text-xs font-bold text-base-content/60">Source folder</span>
+              <select
+                class="select select-bordered rounded-xl"
+                :value="store.selectedFolder"
+                :disabled="store.loading || store.queueing || !store.folders.length"
+                @change="onFolderChange"
+              >
+                <option v-if="!store.folders.length" value="">No image folders found</option>
+                <option
+                  v-for="folder in store.folders"
+                  :key="folder.name || '__root__'"
+                  :value="folder.name"
+                >
+                  {{ folder.name || '(animate root)' }} · {{ folder.imageCount }} image{{ folder.imageCount === 1 ? '' : 's' }}
+                </option>
+              </select>
+            </label>
+
+            <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-1 2xl:grid-cols-2">
+              <label class="form-control gap-1">
+                <span class="text-xs font-bold text-base-content/60">Engine</span>
+                <select
+                  class="select select-bordered rounded-xl"
+                  :value="store.engine"
+                  :disabled="store.loading || store.queueing"
+                  @change="onEngineChange"
+                >
+                  <option value="wan">WAN</option>
+                  <option value="ltx">LTX</option>
+                </select>
+              </label>
+
+              <label class="form-control gap-1">
+                <span class="text-xs font-bold text-base-content/60">Clip length</span>
+                <div class="join w-full">
+                  <input
+                    v-model.number="store.durationSeconds"
+                    type="number"
+                    min="0.25"
+                    max="30"
+                    step="0.25"
+                    class="input input-bordered join-item min-w-0 flex-1"
+                    :disabled="store.loading || store.queueing"
+                    @change="onDurationChange"
+                  />
+                  <span class="join-item grid place-items-center border border-base-300 bg-base-200 px-3 text-sm font-bold">sec</span>
+                </div>
+              </label>
+            </div>
+
+            <label class="form-control gap-1">
+              <span class="text-xs font-bold text-base-content/60">Video preset</span>
+              <select
+                class="select select-bordered rounded-xl"
+                :value="store.presetId"
+                :disabled="store.loading || store.queueing"
+                @change="onPresetChange"
+              >
+                <option v-for="preset in store.presets" :key="preset.id" :value="preset.id">
+                  {{ preset.label }} · {{ preset.width }}×{{ preset.height }} · {{ preset.fps }} fps
+                </option>
+              </select>
+              <span class="text-xs leading-relaxed text-base-content/50">
+                {{ store.selectedPreset.description }}
+              </span>
+            </label>
+
+            <label class="flex cursor-pointer items-center justify-between gap-4 rounded-xl border border-base-300 bg-base-100 p-3">
+              <div>
+                <span class="block text-sm font-black">Mature batch</span>
+                <span class="block text-xs text-base-content/50">
+                  Carries the existing ArtJob maturity flag into every generated clip.
+                </span>
+              </div>
+              <input
+                v-model="store.isMature"
+                type="checkbox"
+                class="toggle toggle-warning"
+                :disabled="store.loading || store.queueing"
+                @change="onMaturityChange"
+              />
+            </label>
+
+            <details class="rounded-xl border border-base-300 bg-base-100 p-3 text-sm">
+              <summary class="cursor-pointer font-black">Automatic motion direction</summary>
+              <p class="mt-2 leading-relaxed text-base-content/60">
+                Bring this still scene naturally to life with subtle coherent motion. Preserve the
+                subjects, composition, identity, lighting, and visual style. Add only plausible
+                ambient movement, gentle secondary motion, and stable cinematic camera behavior.
+                Do not introduce new characters, objects, text, or scene changes.
+              </p>
+            </details>
+
+            <div class="space-y-2">
+              <button
+                type="button"
+                class="btn btn-primary w-full rounded-xl"
+                :disabled="store.queueing || store.loading || !store.totalCount"
+                @click="store.enqueue(false)"
+              >
+                <span v-if="store.queueing" class="loading loading-spinner loading-sm" />
+                {{ store.missingCount ? `Start / Resume ${store.missingCount} missing` : 'Resume / verify batch' }}
+              </button>
+              <button
+                v-if="store.failedCount"
+                type="button"
+                class="btn btn-warning btn-outline w-full rounded-xl"
+                :disabled="store.queueing || store.loading"
+                @click="store.enqueue(true)"
+              >
+                Retry {{ store.failedCount }} failed / cancelled
+              </button>
+            </div>
+
+            <p class="text-xs leading-relaxed text-base-content/50">
+              Resume is idempotent for the current source bytes and settings. Change the image,
+              preset, duration, or maturity and it intentionally becomes a new render.
+            </p>
+          </aside>
+
+          <section class="space-y-4">
+            <div class="kr-panel p-4">
+              <div class="grid grid-cols-2 gap-3 md:grid-cols-5">
+                <div class="rounded-xl bg-base-200 p-3">
+                  <p class="text-xs font-bold text-base-content/50">Scenes</p>
+                  <p class="text-2xl font-black">{{ store.totalCount }}</p>
+                </div>
+                <div class="rounded-xl bg-base-200 p-3">
+                  <p class="text-xs font-bold text-base-content/50">Missing</p>
+                  <p class="text-2xl font-black">{{ store.missingCount }}</p>
+                </div>
+                <div class="rounded-xl bg-base-200 p-3">
+                  <p class="text-xs font-bold text-base-content/50">Active</p>
+                  <p class="text-2xl font-black">{{ store.activeCount }}</p>
+                </div>
+                <div class="rounded-xl bg-base-200 p-3">
+                  <p class="text-xs font-bold text-base-content/50">Done</p>
+                  <p class="text-2xl font-black">{{ store.doneCount }}</p>
+                </div>
+                <div class="rounded-xl bg-base-200 p-3">
+                  <p class="text-xs font-bold text-base-content/50">Failed</p>
+                  <p class="text-2xl font-black">{{ store.failedCount }}</p>
+                </div>
+              </div>
+              <div class="mt-3 flex items-center gap-3">
+                <progress class="progress progress-primary flex-1" :value="store.completionPercent" max="100" />
+                <span class="w-12 text-right text-sm font-black">{{ store.completionPercent }}%</span>
+              </div>
+            </div>
+
+            <div
+              v-if="store.error"
+              class="rounded-2xl border border-error/40 bg-error/10 p-4"
+            >
+              <div class="flex items-start justify-between gap-3">
+                <pre class="whitespace-pre-wrap font-sans text-sm text-error">{{ store.error }}</pre>
+                <button class="btn btn-ghost btn-xs" type="button" @click="store.clearError()">Dismiss</button>
+              </div>
+            </div>
+
+            <div v-if="store.loading && !store.initialized" class="grid min-h-64 place-items-center kr-panel">
+              <span class="loading loading-spinner loading-lg text-primary" />
+            </div>
+
+            <div
+              v-else-if="!store.totalCount"
+              class="grid min-h-64 place-items-center rounded-2xl border border-dashed border-base-300 bg-base-100/50 p-8 text-center"
+            >
+              <div>
+                <Icon name="kind-icon:server" class="mx-auto size-10 text-base-content/30" />
+                <p class="mt-3 font-black">No source images in this folder</p>
+                <p class="mt-1 max-w-lg text-sm text-base-content/50">
+                  Add PNG, JPG, WebP, or GIF stills under the configured animate source root,
+                  then refresh this page.
+                </p>
+              </div>
+            </div>
+
+            <div v-else class="grid gap-4 md:grid-cols-2 2xl:grid-cols-3">
+              <article
+                v-for="source in store.sources"
+                :key="source.dedupeKey"
+                class="kr-panel overflow-hidden"
+              >
+                <div class="grid grid-cols-2 bg-base-200">
+                  <div class="relative aspect-video overflow-hidden border-r border-base-300">
+                    <img
+                      v-if="store.sourcePreviewUrls[source.name]"
+                      :src="store.sourcePreviewUrls[source.name]"
+                      :alt="`Source ${source.name}`"
+                      class="size-full object-cover"
+                    />
+                    <div v-else class="grid size-full place-items-center text-xs text-base-content/35">
+                      Source
+                    </div>
+                    <span class="absolute left-2 top-2 badge badge-sm bg-base-100/90">still</span>
+                  </div>
+
+                  <div class="relative aspect-video overflow-hidden">
+                    <template v-if="source.status === 'done' && store.resultUrl(source)">
+                      <video
+                        v-if="isVideoResult(source)"
+                        :src="store.resultUrl(source) || undefined"
+                        class="size-full object-cover"
+                        controls
+                        muted
+                        loop
+                        playsinline
+                      />
+                      <img
+                        v-else
+                        :src="store.resultUrl(source) || undefined"
+                        :alt="`Animated result for ${source.name}`"
+                        class="size-full object-cover"
+                      />
+                    </template>
+                    <div v-else class="grid size-full place-items-center p-3 text-center text-xs text-base-content/40">
+                      <span v-if="source.status === 'rendering' || source.status === 'queued'" class="loading loading-spinner loading-sm" />
+                      <span v-else>{{ statusLabel(source.status) }}</span>
+                    </div>
+                    <span class="absolute left-2 top-2 badge badge-sm bg-base-100/90">motion</span>
+                  </div>
+                </div>
+
+                <div class="space-y-2 p-3">
+                  <div class="flex items-start justify-between gap-2">
+                    <div class="min-w-0">
+                      <p class="truncate text-sm font-black" :title="source.name">{{ source.name }}</p>
+                      <p class="text-xs text-base-content/45">
+                        {{ formatBytes(source.bytes) }}
+                        <template v-if="source.jobId"> · ArtJob #{{ source.jobId }}</template>
+                      </p>
+                    </div>
+                    <span class="badge badge-sm shrink-0" :class="statusClass(source.status)">
+                      {{ statusLabel(source.status) }}
+                    </span>
+                  </div>
+                  <p v-if="source.error" class="line-clamp-3 text-xs text-error" :title="source.error">
+                    {{ source.error }}
+                  </p>
+                </div>
+              </article>
+            </div>
+          </section>
+        </section>
+      </template>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { useSceneAnimatorStore, type SceneAnimatorSource } from '@/stores/sceneAnimatorStore'
+import { useUserStore } from '@/stores/userStore'
+import type { VideoEngine, VideoPresetId } from '@/utils/videoPresets'
+
+const store = useSceneAnimatorStore()
+const userStore = useUserStore()
+const ready = ref(false)
+let pollTimer: ReturnType<typeof setInterval> | null = null
+
+onMounted(async () => {
+  await userStore.initialize()
+  if (userStore.isAdmin) {
+    await store.load()
+    pollTimer = setInterval(() => {
+      if (store.activeCount && !store.loading && !store.queueing) void store.load()
+    }, 15_000)
+  }
+  ready.value = true
+})
+
+onBeforeUnmount(() => {
+  if (pollTimer) clearInterval(pollTimer)
+  store.clearSourcePreviews()
+})
+
+function eventValue(event: Event): string {
+  return (event.target as HTMLSelectElement | HTMLInputElement).value
+}
+
+function onFolderChange(event: Event) {
+  void store.selectFolder(eventValue(event))
+}
+
+function onEngineChange(event: Event) {
+  void store.setEngine(eventValue(event) as VideoEngine)
+}
+
+function onPresetChange(event: Event) {
+  void store.setPreset(eventValue(event) as VideoPresetId)
+}
+
+function onDurationChange() {
+  void store.setDuration(Number(store.durationSeconds))
+}
+
+function onMaturityChange() {
+  void store.setMaturity(Boolean(store.isMature))
+}
+
+function statusLabel(status: SceneAnimatorSource['status']): string {
+  if (status === 'rendering') return 'Rendering'
+  if (status === 'queued') return 'Queued'
+  if (status === 'done') return 'Done'
+  if (status === 'failed') return 'Failed'
+  if (status === 'cancelled') return 'Cancelled'
+  return 'Missing'
+}
+
+function statusClass(status: SceneAnimatorSource['status']): string {
+  if (status === 'done') return 'badge-success'
+  if (status === 'rendering' || status === 'queued') return 'badge-info'
+  if (status === 'failed' || status === 'cancelled') return 'badge-error'
+  return 'badge-ghost'
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
+function isVideoResult(source: SceneAnimatorSource): boolean {
+  const type = String(source.resultFileType || '').toLowerCase()
+  const url = store.resultUrl(source) || ''
+  return type.includes('mp4') || type.includes('webm') || /\.(mp4|webm)(?:[?#]|$)/i.test(url)
+}
+</script>

--- a/server/api/scene-animator/enqueue.post.ts
+++ b/server/api/scene-animator/enqueue.post.ts
@@ -1,0 +1,231 @@
+import { defineEventHandler, readBody } from 'h3'
+import prisma from '@/server/utils/prisma'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import {
+  SCENE_ANIMATOR_PROJECT_SLUG,
+  SCENE_ANIMATOR_PROMPT,
+  listSceneAnimatorSourceFiles,
+  parseSceneAnimatorContext,
+  readSceneAnimatorSource,
+  sceneAnimatorConfigKey,
+  sceneAnimatorDedupeKey,
+  type SceneAnimatorContext,
+  type SceneAnimatorRenderConfig,
+} from '@/server/utils/sceneAnimator'
+import {
+  getDefaultVideoPreset,
+  getVideoPreset,
+  type VideoEngine,
+  type VideoPresetId,
+} from '@/utils/videoPresets'
+
+type SceneAnimatorEnqueueRequest = {
+  folder?: string | null
+  engine?: VideoEngine | null
+  presetId?: VideoPresetId | null
+  durationSeconds?: number | null
+  isMature?: boolean | null
+  retryFailed?: boolean | null
+}
+
+type EnqueueResponse = {
+  success: boolean
+  message: string
+  statusCode: number
+  data?: {
+    jobId?: number
+    status?: string
+  }
+}
+
+function resolveConfig(body: SceneAnimatorEnqueueRequest): SceneAnimatorRenderConfig {
+  const engine: VideoEngine = body.engine === 'ltx' ? 'ltx' : 'wan'
+  const requestedPreset = getVideoPreset(body.presetId)
+  const preset =
+    requestedPreset?.engine === engine ? requestedPreset : getDefaultVideoPreset(engine)
+  const requestedDuration = Number(body.durationSeconds)
+  const durationSeconds =
+    Number.isFinite(requestedDuration) && requestedDuration >= 0.25 && requestedDuration <= 30
+      ? requestedDuration
+      : preset.durationSeconds
+
+  return {
+    engine,
+    presetId: preset.id,
+    durationSeconds,
+    fps: preset.fps,
+    width: preset.width,
+    height: preset.height,
+    outputFormat: preset.outputFormat,
+    loop: preset.loop,
+    renderScale: preset.renderScale,
+    isMature: Boolean(body.isMature),
+  }
+}
+
+function isReusableStatus(status: string): boolean {
+  return status === 'PENDING' || status === 'RUNNING' || status === 'DONE'
+}
+
+function contextFromPayload(payload: string): SceneAnimatorContext | null {
+  try {
+    const parsed = JSON.parse(payload) as Record<string, unknown>
+    return parseSceneAnimatorContext(parsed.sceneAnimator)
+  } catch {
+    return null
+  }
+}
+
+export default defineEventHandler(async (event) => {
+  await requireAdminApiUser(event)
+  const body = ((await readBody(event)) ?? {}) as SceneAnimatorEnqueueRequest
+  const folder = String(body.folder ?? '').trim()
+  const config = resolveConfig(body)
+  const preset = getVideoPreset(config.presetId) ?? getDefaultVideoPreset(config.engine)
+  const sources = await listSceneAnimatorSourceFiles(folder)
+  const configKey = sceneAnimatorConfigKey(config)
+
+  const existingJobs = await prisma.artJob.findMany({
+    where: {
+      projectSlug: SCENE_ANIMATOR_PROJECT_SLUG,
+      payload: { contains: '"sceneAnimator"' },
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 1000,
+    select: { id: true, status: true, payload: true },
+  })
+
+  const latestByKey = new Map<string, (typeof existingJobs)[number]>()
+  for (const job of existingJobs) {
+    const context = contextFromPayload(job.payload)
+    if (!context || latestByKey.has(context.dedupeKey)) continue
+    latestByKey.set(context.dedupeKey, job)
+  }
+
+  const queued: Array<{ sourceFile: string; jobId: number }> = []
+  const skipped: Array<{ sourceFile: string; jobId: number | null; reason: string }> = []
+  const errors: Array<{ sourceFile: string; message: string }> = []
+
+  for (const source of sources) {
+    const dedupeKey = sceneAnimatorDedupeKey(source.hash, config)
+    let existing = latestByKey.get(dedupeKey) ?? null
+
+    // Recheck immediately before the expensive enqueue so two open admin tabs are
+    // unlikely to duplicate the same active/completed render.
+    if (!existing || (!isReusableStatus(existing.status) && body.retryFailed)) {
+      const live = await prisma.artJob.findFirst({
+        where: {
+          projectSlug: SCENE_ANIMATOR_PROJECT_SLUG,
+          payload: { contains: `"dedupeKey":"${dedupeKey}"` },
+        },
+        orderBy: { createdAt: 'desc' },
+        select: { id: true, status: true, payload: true },
+      })
+      if (live) existing = live
+    }
+
+    if (existing && isReusableStatus(existing.status)) {
+      skipped.push({ sourceFile: source.name, jobId: existing.id, reason: existing.status })
+      continue
+    }
+    if (existing && !body.retryFailed) {
+      skipped.push({
+        sourceFile: source.name,
+        jobId: existing.id,
+        reason: `${existing.status}; retry not requested`,
+      })
+      continue
+    }
+
+    try {
+      const sourceData = await readSceneAnimatorSource(folder, source.name)
+      const context: SceneAnimatorContext = {
+        sourceFolder: sourceData.folder,
+        sourceFile: sourceData.filename,
+        sourceHash: sourceData.hash,
+        configKey,
+        dedupeKey,
+      }
+      const firstImageBase64 = `data:${sourceData.mime};base64,${sourceData.bytes.toString('base64')}`
+
+      const response = await event.$fetch<EnqueueResponse, string>('/api/video/generate', {
+        method: 'POST',
+        body: {
+          engine: config.engine,
+          presetId: config.presetId,
+          promptString: SCENE_ANIMATOR_PROMPT,
+          negativePrompt: '',
+          firstImageBase64,
+          durationSeconds: config.durationSeconds,
+          fps: config.fps,
+          loop: config.loop,
+          width: config.width,
+          height: config.height,
+          outputFormat: config.outputFormat,
+          renderScale: config.renderScale,
+          latentUpscaleModel: preset.latentUpscaleModel,
+          refineSampler: preset.refineSampler,
+          refineSigmas: preset.refineSigmas,
+          timeoutSeconds: preset.timeoutSeconds,
+          isPublic: false,
+          isMature: config.isMature,
+          designer: 'Scene Animator',
+          projectSlug: SCENE_ANIMATOR_PROJECT_SLUG,
+        },
+      })
+
+      const jobId = Number(response.data?.jobId)
+      if (!response.success || !Number.isInteger(jobId) || jobId <= 0) {
+        throw new Error(response.message || 'Video enqueue did not return a valid ArtJob ID.')
+      }
+
+      const created = await prisma.artJob.findUnique({
+        where: { id: jobId },
+        select: { payload: true },
+      })
+      if (!created) throw new Error(`Queued ArtJob #${jobId} could not be reloaded.`)
+
+      let payload: Record<string, unknown>
+      try {
+        payload = JSON.parse(created.payload) as Record<string, unknown>
+      } catch {
+        throw new Error(`Queued ArtJob #${jobId} has invalid payload JSON.`)
+      }
+
+      await prisma.artJob.update({
+        where: { id: jobId },
+        data: {
+          payload: JSON.stringify({ ...payload, sceneAnimator: context }),
+        },
+      })
+
+      queued.push({ sourceFile: source.name, jobId })
+      latestByKey.set(dedupeKey, {
+        id: jobId,
+        status: 'PENDING',
+        payload: JSON.stringify({ ...payload, sceneAnimator: context }),
+      })
+    } catch (error) {
+      errors.push({
+        sourceFile: source.name,
+        message: error instanceof Error ? error.message : 'Unknown enqueue failure.',
+      })
+    }
+  }
+
+  return {
+    success: true,
+    message: errors.length
+      ? `Queued ${queued.length}; ${errors.length} source(s) failed to enqueue.`
+      : `Queued ${queued.length}; ${skipped.length} already accounted for.`,
+    data: {
+      folder,
+      config,
+      configKey,
+      total: sources.length,
+      queued,
+      skipped,
+      errors,
+    },
+  }
+})

--- a/server/api/scene-animator/index.get.ts
+++ b/server/api/scene-animator/index.get.ts
@@ -41,7 +41,7 @@ function resolveConfig(query: Record<string, unknown>): SceneAnimatorRenderConfi
     engine,
     presetId: preset.id,
     durationSeconds,
-    fps: preset.frameRate,
+    fps: preset.fps,
     width: preset.width,
     height: preset.height,
     outputFormat: preset.outputFormat,

--- a/server/api/scene-animator/index.get.ts
+++ b/server/api/scene-animator/index.get.ts
@@ -1,0 +1,149 @@
+import { defineEventHandler, getQuery } from 'h3'
+import prisma from '@/server/utils/prisma'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import {
+  SCENE_ANIMATOR_PROJECT_SLUG,
+  listSceneAnimatorFolders,
+  listSceneAnimatorSourceFiles,
+  parseSceneAnimatorContext,
+  sceneAnimatorConfigKey,
+  sceneAnimatorDedupeKey,
+  type SceneAnimatorRenderConfig,
+} from '@/server/utils/sceneAnimator'
+import {
+  getDefaultVideoPreset,
+  getVideoPreset,
+  type VideoEngine,
+  type VideoPresetId,
+} from '@/utils/videoPresets'
+
+function queryString(value: unknown): string {
+  return Array.isArray(value) ? String(value[0] ?? '') : String(value ?? '')
+}
+
+function queryBoolean(value: unknown): boolean {
+  return ['1', 'true', 'yes', 'on'].includes(queryString(value).trim().toLowerCase())
+}
+
+function resolveConfig(query: Record<string, unknown>): SceneAnimatorRenderConfig {
+  const requestedEngine = queryString(query.engine)
+  const engine: VideoEngine = requestedEngine === 'ltx' ? 'ltx' : 'wan'
+  const requestedPreset = getVideoPreset(queryString(query.presetId) as VideoPresetId)
+  const preset =
+    requestedPreset?.engine === engine ? requestedPreset : getDefaultVideoPreset(engine)
+  const requestedDuration = Number(queryString(query.durationSeconds))
+  const durationSeconds =
+    Number.isFinite(requestedDuration) && requestedDuration >= 0.25 && requestedDuration <= 30
+      ? requestedDuration
+      : preset.durationSeconds
+
+  return {
+    engine,
+    presetId: preset.id,
+    durationSeconds,
+    fps: preset.frameRate,
+    width: preset.width,
+    height: preset.height,
+    outputFormat: preset.outputFormat,
+    loop: preset.loop,
+    renderScale: preset.renderScale,
+    isMature: queryBoolean(query.isMature),
+  }
+}
+
+function jobStatus(status: string): 'queued' | 'rendering' | 'done' | 'failed' | 'cancelled' {
+  if (status === 'RUNNING') return 'rendering'
+  if (status === 'DONE') return 'done'
+  if (status === 'FAILED') return 'failed'
+  if (status === 'CANCELLED') return 'cancelled'
+  return 'queued'
+}
+
+export default defineEventHandler(async (event) => {
+  await requireAdminApiUser(event)
+  const query = getQuery(event) as Record<string, unknown>
+  const folder = queryString(query.folder).trim()
+  const config = resolveConfig(query)
+  const folders = await listSceneAnimatorFolders()
+
+  if (!folder && !folders.some((item) => item.name === '')) {
+    return {
+      success: true,
+      data: {
+        rootAvailable: true,
+        folders,
+        selectedFolder: null,
+        config,
+        configKey: sceneAnimatorConfigKey(config),
+        sources: [],
+      },
+    }
+  }
+
+  const sources = await listSceneAnimatorSourceFiles(folder)
+  const jobs = await prisma.artJob.findMany({
+    where: {
+      projectSlug: SCENE_ANIMATOR_PROJECT_SLUG,
+      payload: { contains: '"sceneAnimator"' },
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 1000,
+    include: {
+      ArtImage: {
+        select: {
+          id: true,
+          imagePath: true,
+          fileType: true,
+          isMature: true,
+        },
+      },
+    },
+  })
+
+  const latestByKey = new Map<string, (typeof jobs)[number]>()
+  for (const job of jobs) {
+    let payload: Record<string, unknown> | null = null
+    try {
+      payload = JSON.parse(job.payload) as Record<string, unknown>
+    } catch {
+      continue
+    }
+    const context = parseSceneAnimatorContext(payload.sceneAnimator)
+    if (!context || latestByKey.has(context.dedupeKey)) continue
+    latestByKey.set(context.dedupeKey, job)
+  }
+
+  const configKey = sceneAnimatorConfigKey(config)
+  const rows = sources.map((source) => {
+    const dedupeKey = sceneAnimatorDedupeKey(source.hash, config)
+    const job = latestByKey.get(dedupeKey)
+    const result = job?.ArtImage ?? null
+    return {
+      name: source.name,
+      bytes: source.bytes,
+      hash: source.hash,
+      mime: source.mime,
+      sourceUrl: `/api/scene-animator/source?folder=${encodeURIComponent(folder)}&file=${encodeURIComponent(source.name)}`,
+      dedupeKey,
+      status: job ? jobStatus(job.status) : 'missing',
+      jobId: job?.id ?? null,
+      artImageId: job?.artImageId ?? null,
+      resultPath: result?.imagePath ?? null,
+      resultFileType: result?.fileType ?? null,
+      error: job?.error ?? null,
+      updatedAt: job?.updatedAt ?? null,
+    }
+  })
+
+  return {
+    success: true,
+    data: {
+      rootAvailable: true,
+      folders,
+      selectedFolder: folder,
+      config,
+      configKey,
+      sources: rows,
+    },
+  }
+})

--- a/server/api/scene-animator/index.get.ts
+++ b/server/api/scene-animator/index.get.ts
@@ -88,16 +88,6 @@ export default defineEventHandler(async (event) => {
     },
     orderBy: { createdAt: 'desc' },
     take: 1000,
-    include: {
-      ArtImage: {
-        select: {
-          id: true,
-          imagePath: true,
-          fileType: true,
-          isMature: true,
-        },
-      },
-    },
   })
 
   const latestByKey = new Map<string, (typeof jobs)[number]>()
@@ -113,11 +103,27 @@ export default defineEventHandler(async (event) => {
     latestByKey.set(context.dedupeKey, job)
   }
 
+  // ArtJob has no declared relation to ArtImage (only a plain `artImageId`
+  // int column), so the result image has to be batch-fetched separately
+  // rather than `include`d.
+  const resultImageIds = [...new Set(
+    [...latestByKey.values()]
+      .map((job) => job.artImageId)
+      .filter((id): id is number => id != null),
+  )]
+  const resultImages = resultImageIds.length
+    ? await prisma.artImage.findMany({
+        where: { id: { in: resultImageIds } },
+        select: { id: true, imagePath: true, fileType: true, isMature: true },
+      })
+    : []
+  const resultImageById = new Map(resultImages.map((image) => [image.id, image]))
+
   const configKey = sceneAnimatorConfigKey(config)
   const rows = sources.map((source) => {
     const dedupeKey = sceneAnimatorDedupeKey(source.hash, config)
     const job = latestByKey.get(dedupeKey)
-    const result = job?.ArtImage ?? null
+    const result = job?.artImageId != null ? (resultImageById.get(job.artImageId) ?? null) : null
     return {
       name: source.name,
       bytes: source.bytes,

--- a/server/api/scene-animator/source.get.ts
+++ b/server/api/scene-animator/source.get.ts
@@ -15,7 +15,7 @@ export default defineEventHandler(async (event) => {
   )
 
   setHeader(event, 'Content-Type', source.mime)
-  setHeader(event, 'Content-Length', String(source.bytes.length))
+  setHeader(event, 'Content-Length', source.bytes.length)
   setHeader(event, 'Cache-Control', 'private, max-age=60')
   setHeader(event, 'ETag', `"${source.hash}"`)
   return source.bytes

--- a/server/api/scene-animator/source.get.ts
+++ b/server/api/scene-animator/source.get.ts
@@ -1,0 +1,22 @@
+import { defineEventHandler, getQuery, setHeader } from 'h3'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { readSceneAnimatorSource } from '@/server/utils/sceneAnimator'
+
+function queryString(value: unknown): string {
+  return Array.isArray(value) ? String(value[0] ?? '') : String(value ?? '')
+}
+
+export default defineEventHandler(async (event) => {
+  await requireAdminApiUser(event)
+  const query = getQuery(event)
+  const source = await readSceneAnimatorSource(
+    queryString(query.folder),
+    queryString(query.file),
+  )
+
+  setHeader(event, 'Content-Type', source.mime)
+  setHeader(event, 'Content-Length', String(source.bytes.length))
+  setHeader(event, 'Cache-Control', 'private, max-age=60')
+  setHeader(event, 'ETag', `"${source.hash}"`)
+  return source.bytes
+})

--- a/server/utils/sceneAnimator.ts
+++ b/server/utils/sceneAnimator.ts
@@ -1,0 +1,250 @@
+import { createHash } from 'node:crypto'
+import { readdir, readFile, realpath } from 'node:fs/promises'
+import path from 'node:path'
+import { createError } from 'h3'
+import { getImageStorageRoot } from './imageStorageRoot'
+import type {
+  VideoEngine,
+  VideoOutputFormat,
+  VideoPresetId,
+} from '@/utils/videoPresets'
+
+export const SCENE_ANIMATOR_PROJECT_SLUG = 'scene-animator'
+
+export const SCENE_ANIMATOR_PROMPT =
+  'Bring this still scene naturally to life with subtle coherent motion. Preserve the subjects, composition, identity, lighting, and visual style. Add only plausible ambient movement, gentle secondary motion, and stable cinematic camera behavior. Do not introduce new characters, objects, text, or scene changes.'
+
+const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif'])
+
+export type SceneAnimatorRenderConfig = {
+  engine: VideoEngine
+  presetId: VideoPresetId
+  durationSeconds: number
+  fps: number
+  width: number
+  height: number
+  outputFormat: VideoOutputFormat
+  loop: boolean
+  renderScale: number
+  isMature: boolean
+}
+
+export type SceneAnimatorContext = {
+  sourceFolder: string
+  sourceFile: string
+  sourceHash: string
+  configKey: string
+  dedupeKey: string
+}
+
+export type SceneAnimatorSourceFile = {
+  name: string
+  bytes: number
+  hash: string
+  mime: string
+}
+
+function badPath(message = 'Invalid animation source path.') {
+  return createError({ statusCode: 400, message })
+}
+
+function normalizeFolder(value: unknown): string {
+  const raw = String(value ?? '').trim().replace(/\\/g, '/')
+  if (!raw) return ''
+  if (raw.includes('\0') || raw.startsWith('/')) throw badPath()
+  const normalized = path.posix.normalize(raw).replace(/^\.\//, '')
+  if (
+    !normalized ||
+    normalized === '.' ||
+    normalized === '..' ||
+    normalized.startsWith('../') ||
+    normalized.includes('/../')
+  ) {
+    throw badPath()
+  }
+  return normalized
+}
+
+function normalizeFile(value: unknown): string {
+  const raw = String(value ?? '').trim().replace(/\\/g, '/')
+  if (!raw || raw.includes('\0') || raw.includes('/') || raw === '.' || raw === '..') {
+    throw badPath('Invalid animation source filename.')
+  }
+  const ext = path.extname(raw).toLowerCase()
+  if (!IMAGE_EXTENSIONS.has(ext)) {
+    throw badPath('Unsupported animation source image type.')
+  }
+  return raw
+}
+
+function mimeForFile(filename: string): string {
+  switch (path.extname(filename).toLowerCase()) {
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg'
+    case '.webp':
+      return 'image/webp'
+    case '.gif':
+      return 'image/gif'
+    default:
+      return 'image/png'
+  }
+}
+
+export function getSceneAnimatorRoot(): string {
+  const configured = process.env.ANIMATE_PATH?.trim()
+  if (configured) return path.resolve(configured)
+
+  const imageRoot = getImageStorageRoot()
+  if (process.env.IMAGES_PATH?.trim()) {
+    return path.resolve(imageRoot, '..', 'animate')
+  }
+
+  return path.resolve(process.cwd(), 'animate')
+}
+
+async function resolveContainedPath(folder: string, filename?: string): Promise<string> {
+  const root = getSceneAnimatorRoot()
+  let resolvedRoot: string
+  try {
+    resolvedRoot = await realpath(root)
+  } catch {
+    throw createError({
+      statusCode: 503,
+      message: `Scene Animator source root is unavailable: ${root}`,
+    })
+  }
+
+  const normalizedFolder = normalizeFolder(folder)
+  const candidate = filename
+    ? path.resolve(resolvedRoot, normalizedFolder, normalizeFile(filename))
+    : path.resolve(resolvedRoot, normalizedFolder)
+
+  let resolvedCandidate: string
+  try {
+    resolvedCandidate = await realpath(candidate)
+  } catch {
+    throw createError({ statusCode: 404, message: 'Animation source not found.' })
+  }
+
+  if (
+    resolvedCandidate !== resolvedRoot &&
+    !resolvedCandidate.startsWith(`${resolvedRoot}${path.sep}`)
+  ) {
+    throw badPath('Animation source escaped the configured root.')
+  }
+
+  return resolvedCandidate
+}
+
+export async function listSceneAnimatorFolders(): Promise<
+  Array<{ name: string; imageCount: number }>
+> {
+  const root = await resolveContainedPath('')
+  const entries = await readdir(root, { withFileTypes: true })
+  const folders: Array<{ name: string; imageCount: number }> = []
+
+  const rootImages = entries.filter(
+    (entry) => entry.isFile() && IMAGE_EXTENSIONS.has(path.extname(entry.name).toLowerCase()),
+  )
+  if (rootImages.length) folders.push({ name: '', imageCount: rootImages.length })
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    try {
+      const directory = await resolveContainedPath(entry.name)
+      const children = await readdir(directory, { withFileTypes: true })
+      const imageCount = children.filter(
+        (child) =>
+          child.isFile() && IMAGE_EXTENSIONS.has(path.extname(child.name).toLowerCase()),
+      ).length
+      if (imageCount) folders.push({ name: entry.name, imageCount })
+    } catch {
+      // Ignore unreadable or symlink-escaping children instead of failing the whole picker.
+    }
+  }
+
+  return folders.sort((left, right) => left.name.localeCompare(right.name))
+}
+
+export async function listSceneAnimatorSourceFiles(
+  folder: string,
+): Promise<SceneAnimatorSourceFile[]> {
+  const normalizedFolder = normalizeFolder(folder)
+  const directory = await resolveContainedPath(normalizedFolder)
+  const entries = await readdir(directory, { withFileTypes: true })
+  const files: SceneAnimatorSourceFile[] = []
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !IMAGE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) {
+      continue
+    }
+    const source = await readSceneAnimatorSource(normalizedFolder, entry.name)
+    files.push({
+      name: entry.name,
+      bytes: source.bytes.length,
+      hash: source.hash,
+      mime: source.mime,
+    })
+  }
+
+  return files.sort((left, right) =>
+    left.name.localeCompare(right.name, undefined, { numeric: true }),
+  )
+}
+
+export async function readSceneAnimatorSource(folder: string, filename: string) {
+  const normalizedFolder = normalizeFolder(folder)
+  const normalizedFile = normalizeFile(filename)
+  const sourcePath = await resolveContainedPath(normalizedFolder, normalizedFile)
+  const bytes = await readFile(sourcePath)
+  return {
+    folder: normalizedFolder,
+    filename: normalizedFile,
+    bytes,
+    mime: mimeForFile(normalizedFile),
+    hash: createHash('sha256').update(bytes).digest('hex'),
+  }
+}
+
+function stableNumber(value: number): string {
+  return Number(value.toFixed(3)).toString()
+}
+
+export function sceneAnimatorConfigKey(config: SceneAnimatorRenderConfig): string {
+  return [
+    config.engine,
+    config.presetId,
+    `${config.width}x${config.height}`,
+    `${stableNumber(config.durationSeconds)}s`,
+    `${stableNumber(config.fps)}fps`,
+    config.outputFormat,
+    config.loop ? 'loop' : 'once',
+    `scale-${stableNumber(config.renderScale)}`,
+    config.isMature ? 'mature' : 'general',
+  ].join('|')
+}
+
+export function sceneAnimatorDedupeKey(
+  sourceHash: string,
+  config: SceneAnimatorRenderConfig,
+): string {
+  return `scene-animator:${sourceHash}:${createHash('sha256')
+    .update(sceneAnimatorConfigKey(config))
+    .digest('hex')}`
+}
+
+export function parseSceneAnimatorContext(value: unknown): SceneAnimatorContext | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const raw = value as Record<string, unknown>
+  const context: SceneAnimatorContext = {
+    sourceFolder: String(raw.sourceFolder ?? ''),
+    sourceFile: String(raw.sourceFile ?? ''),
+    sourceHash: String(raw.sourceHash ?? ''),
+    configKey: String(raw.configKey ?? ''),
+    dedupeKey: String(raw.dedupeKey ?? ''),
+  }
+  return context.sourceFile && context.sourceHash && context.configKey && context.dedupeKey
+    ? context
+    : null
+}

--- a/stores/sceneAnimatorStore.ts
+++ b/stores/sceneAnimatorStore.ts
@@ -105,7 +105,7 @@ export const useSceneAnimatorStore = defineStore('sceneAnimatorStore', () => {
   const selectedFolder = ref('')
   const engine = ref<VideoEngine>('wan')
   const presetId = ref<VideoPresetId>(defaultPreset.id)
-  const durationSeconds = ref(defaultPreset.durationSeconds)
+  const durationSeconds = ref<number>(defaultPreset.durationSeconds)
   const isMature = ref(false)
   const configKey = ref('')
   const sourcePreviewUrls = ref<Record<string, string>>({})
@@ -243,8 +243,9 @@ export const useSceneAnimatorStore = defineStore('sceneAnimatorStore', () => {
       durationSeconds.value = response.data.config.durationSeconds
       isMature.value = response.data.config.isMature
 
-      if (response.data.selectedFolder === null && response.data.folders.length) {
-        selectedFolder.value = response.data.folders[0].name
+      const firstFolder = response.data.selectedFolder === null ? response.data.folders[0] : null
+      if (firstFolder) {
+        selectedFolder.value = firstFolder.name
         loading.value = false
         return load(selectedFolder.value)
       }

--- a/stores/sceneAnimatorStore.ts
+++ b/stores/sceneAnimatorStore.ts
@@ -1,0 +1,376 @@
+import { computed, ref } from 'vue'
+import { defineStore } from 'pinia'
+import { performFetch } from './utils'
+import { useUserStore } from './userStore'
+import {
+  VIDEO_PRESETS,
+  getDefaultVideoPreset,
+  getVideoPreset,
+  type VideoEngine,
+  type VideoPresetId,
+} from '@/utils/videoPresets'
+
+export type SceneAnimatorSourceStatus =
+  | 'missing'
+  | 'queued'
+  | 'rendering'
+  | 'done'
+  | 'failed'
+  | 'cancelled'
+
+export type SceneAnimatorFolder = {
+  name: string
+  imageCount: number
+}
+
+export type SceneAnimatorSource = {
+  name: string
+  bytes: number
+  hash: string
+  mime: string
+  sourceUrl: string
+  dedupeKey: string
+  status: SceneAnimatorSourceStatus
+  jobId: number | null
+  artImageId: number | null
+  resultPath: string | null
+  resultFileType: string | null
+  error: string | null
+  updatedAt: string | null
+}
+
+type SceneAnimatorConfig = {
+  engine: VideoEngine
+  presetId: VideoPresetId
+  durationSeconds: number
+  fps: number
+  width: number
+  height: number
+  outputFormat: 'webp' | 'mp4' | 'webm'
+  loop: boolean
+  renderScale: number
+  isMature: boolean
+}
+
+type SceneAnimatorIndexData = {
+  rootAvailable: boolean
+  folders: SceneAnimatorFolder[]
+  selectedFolder: string | null
+  config: SceneAnimatorConfig
+  configKey: string
+  sources: SceneAnimatorSource[]
+}
+
+type SceneAnimatorEnqueueData = {
+  folder: string
+  config: SceneAnimatorConfig
+  configKey: string
+  total: number
+  queued: Array<{ sourceFile: string; jobId: number }>
+  skipped: Array<{ sourceFile: string; jobId: number | null; reason: string }>
+  errors: Array<{ sourceFile: string; message: string }>
+}
+
+type ArtImagePreview = {
+  id: number
+  imageData?: string | null
+  imagePath?: string | null
+  fileType?: string | null
+}
+
+function errorMessage(value: unknown, fallback: string): string {
+  return value instanceof Error ? value.message : fallback
+}
+
+function mimeFromFileType(fileType: string | null | undefined): string {
+  const normalized = String(fileType ?? '').toLowerCase().replace(/^\./, '')
+  if (normalized.includes('/')) return normalized
+  if (normalized === 'mp4') return 'video/mp4'
+  if (normalized === 'webm') return 'video/webm'
+  if (normalized === 'jpg' || normalized === 'jpeg') return 'image/jpeg'
+  if (normalized === 'png') return 'image/png'
+  if (normalized === 'gif') return 'image/gif'
+  return 'image/webp'
+}
+
+function asDataUrl(data: string, fileType: string | null | undefined): string {
+  return data.startsWith('data:') ? data : `data:${mimeFromFileType(fileType)};base64,${data}`
+}
+
+export const useSceneAnimatorStore = defineStore('sceneAnimatorStore', () => {
+  const defaultPreset = getDefaultVideoPreset('wan')
+
+  const folders = ref<SceneAnimatorFolder[]>([])
+  const sources = ref<SceneAnimatorSource[]>([])
+  const selectedFolder = ref('')
+  const engine = ref<VideoEngine>('wan')
+  const presetId = ref<VideoPresetId>(defaultPreset.id)
+  const durationSeconds = ref(defaultPreset.durationSeconds)
+  const isMature = ref(false)
+  const configKey = ref('')
+  const sourcePreviewUrls = ref<Record<string, string>>({})
+  const resultPreviewUrls = ref<Record<number, string>>({})
+  const loading = ref(false)
+  const queueing = ref(false)
+  const initialized = ref(false)
+  const error = ref<string | null>(null)
+  const lastEnqueue = ref<SceneAnimatorEnqueueData | null>(null)
+
+  const presets = computed(() => VIDEO_PRESETS.filter((preset) => preset.engine === engine.value))
+  const selectedPreset = computed(
+    () => getVideoPreset(presetId.value) ?? getDefaultVideoPreset(engine.value),
+  )
+  const totalCount = computed(() => sources.value.length)
+  const missingCount = computed(
+    () => sources.value.filter((source) => source.status === 'missing').length,
+  )
+  const activeCount = computed(
+    () =>
+      sources.value.filter(
+        (source) => source.status === 'queued' || source.status === 'rendering',
+      ).length,
+  )
+  const doneCount = computed(
+    () => sources.value.filter((source) => source.status === 'done').length,
+  )
+  const failedCount = computed(
+    () =>
+      sources.value.filter(
+        (source) => source.status === 'failed' || source.status === 'cancelled',
+      ).length,
+  )
+  const completionPercent = computed(() =>
+    totalCount.value ? Math.round((doneCount.value / totalCount.value) * 100) : 0,
+  )
+
+  function clearError() {
+    error.value = null
+  }
+
+  function clearSourcePreviews() {
+    if (import.meta.client) {
+      for (const url of Object.values(sourcePreviewUrls.value)) URL.revokeObjectURL(url)
+    }
+    sourcePreviewUrls.value = {}
+  }
+
+  async function fetchProtectedBlob(url: string): Promise<string | null> {
+    if (!import.meta.client) return null
+    const userStore = useUserStore()
+    const token = userStore.token || userStore.user?.token || ''
+    const headers = new Headers()
+    if (token) headers.set('Authorization', `Bearer ${token}`)
+
+    const response = await fetch(url, { headers })
+    if (!response.ok) return null
+    return URL.createObjectURL(await response.blob())
+  }
+
+  async function hydrateSourcePreviews() {
+    clearSourcePreviews()
+    const pairs = await Promise.all(
+      sources.value.map(async (source) => [source.name, await fetchProtectedBlob(source.sourceUrl)] as const),
+    )
+    const next: Record<string, string> = {}
+    for (const [name, url] of pairs) {
+      if (url) next[name] = url
+    }
+    sourcePreviewUrls.value = next
+  }
+
+  async function hydrateResultPreview(source: SceneAnimatorSource) {
+    if (!source.artImageId || source.status !== 'done') return
+    if (source.resultPath) {
+      resultPreviewUrls.value[source.artImageId] = source.resultPath
+      return
+    }
+
+    const response = await performFetch<ArtImagePreview>(
+      `/api/art/image/${source.artImageId}?includeImageData=true&showMature=true`,
+      {},
+      1,
+      15_000,
+    )
+    if (!response.success || !response.data) return
+    if (response.data.imagePath) {
+      resultPreviewUrls.value[source.artImageId] = response.data.imagePath
+      return
+    }
+    if (response.data.imageData) {
+      resultPreviewUrls.value[source.artImageId] = asDataUrl(
+        response.data.imageData,
+        response.data.fileType || source.resultFileType,
+      )
+    }
+  }
+
+  async function hydrateResultPreviews() {
+    const doneSources = sources.value.filter(
+      (source) => source.status === 'done' && source.artImageId,
+    )
+    await Promise.all(doneSources.map(hydrateResultPreview))
+  }
+
+  function buildQuery(folder = selectedFolder.value): string {
+    const params = new URLSearchParams({
+      folder,
+      engine: engine.value,
+      presetId: presetId.value,
+      durationSeconds: String(durationSeconds.value),
+      isMature: String(isMature.value),
+    })
+    return params.toString()
+  }
+
+  async function load(folder = selectedFolder.value): Promise<void> {
+    loading.value = true
+    clearError()
+    try {
+      const response = await performFetch<SceneAnimatorIndexData>(
+        `/api/scene-animator?${buildQuery(folder)}`,
+        {},
+        1,
+        30_000,
+      )
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Failed to load Scene Animator.')
+      }
+
+      folders.value = response.data.folders
+      configKey.value = response.data.configKey
+      engine.value = response.data.config.engine
+      presetId.value = response.data.config.presetId
+      durationSeconds.value = response.data.config.durationSeconds
+      isMature.value = response.data.config.isMature
+
+      if (response.data.selectedFolder === null && response.data.folders.length) {
+        selectedFolder.value = response.data.folders[0].name
+        loading.value = false
+        return load(selectedFolder.value)
+      }
+
+      selectedFolder.value = response.data.selectedFolder ?? folder
+      sources.value = response.data.sources
+      initialized.value = true
+      await Promise.all([hydrateSourcePreviews(), hydrateResultPreviews()])
+    } catch (cause) {
+      error.value = errorMessage(cause, 'Failed to load Scene Animator.')
+      sources.value = []
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function enqueue(retryFailed = false): Promise<SceneAnimatorEnqueueData | null> {
+    queueing.value = true
+    clearError()
+    try {
+      const response = await performFetch<SceneAnimatorEnqueueData>(
+        '/api/scene-animator/enqueue',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            folder: selectedFolder.value,
+            engine: engine.value,
+            presetId: presetId.value,
+            durationSeconds: durationSeconds.value,
+            isMature: isMature.value,
+            retryFailed,
+          }),
+        },
+        1,
+        120_000,
+      )
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Failed to enqueue Scene Animator batch.')
+      }
+      lastEnqueue.value = response.data
+      if (response.data.errors.length) {
+        error.value = response.data.errors
+          .map((item) => `${item.sourceFile}: ${item.message}`)
+          .join('\n')
+      }
+      await load()
+      return response.data
+    } catch (cause) {
+      error.value = errorMessage(cause, 'Failed to enqueue Scene Animator batch.')
+      return null
+    } finally {
+      queueing.value = false
+    }
+  }
+
+  async function selectFolder(folder: string) {
+    selectedFolder.value = folder
+    await load(folder)
+  }
+
+  async function setEngine(next: VideoEngine) {
+    engine.value = next
+    const preset = getDefaultVideoPreset(next)
+    presetId.value = preset.id
+    durationSeconds.value = preset.durationSeconds
+    await load()
+  }
+
+  async function setPreset(next: VideoPresetId) {
+    const preset = getVideoPreset(next)
+    if (!preset) return
+    engine.value = preset.engine
+    presetId.value = preset.id
+    durationSeconds.value = preset.durationSeconds
+    await load()
+  }
+
+  async function setDuration(next: number) {
+    if (!Number.isFinite(next)) return
+    durationSeconds.value = Math.min(30, Math.max(0.25, next))
+    await load()
+  }
+
+  async function setMaturity(next: boolean) {
+    isMature.value = next
+    await load()
+  }
+
+  function resultUrl(source: SceneAnimatorSource): string | null {
+    if (!source.artImageId) return source.resultPath
+    return resultPreviewUrls.value[source.artImageId] || source.resultPath
+  }
+
+  return {
+    folders,
+    sources,
+    selectedFolder,
+    engine,
+    presetId,
+    durationSeconds,
+    isMature,
+    configKey,
+    sourcePreviewUrls,
+    resultPreviewUrls,
+    loading,
+    queueing,
+    initialized,
+    error,
+    lastEnqueue,
+    presets,
+    selectedPreset,
+    totalCount,
+    missingCount,
+    activeCount,
+    doneCount,
+    failedCount,
+    completionPercent,
+    clearError,
+    load,
+    enqueue,
+    selectFolder,
+    setEngine,
+    setPreset,
+    setDuration,
+    setMaturity,
+    resultUrl,
+    clearSourcePreviews,
+  }
+})

--- a/utils/projectPlacements.ts
+++ b/utils/projectPlacements.ts
@@ -52,6 +52,11 @@ export const PROJECT_PLACEMENTS: Record<string, ProjectPlacement> = {
     tabKey: 'animation-manager',
     route: '/build/animation-manager',
   },
+  'scene-animator': {
+    channelKey: 'admin',
+    tabKey: 'scene-animator',
+    route: '/admin/scene-animator',
+  },
   storybook: {
     channelKey: 'play',
     tabKey: 'storybook',


### PR DESCRIPTION
## Summary
- add an Admin Scene Animator page that turns a folder of still scenes into short LTX/WAN clips without per-image prompting
- reuse the existing `/api/video/generate` -> `/api/art/enqueue` -> durable `ArtJob` -> relay/Comfy pipeline
- reconstruct folder progress from ArtJobs using source SHA-256 + effective video settings as a stable dedupe key
- support folder selection, existing video presets, duration overrides, maturity, private output, failed-job retry, progress polling, and a side-by-side source/result gallery
- add authenticated read-only source browsing under `ANIMATE_PATH`, with traversal/symlink escape protection
- place the project under Admin navigation and document the media-root contract

## Source storage
The preferred production source tree is the sibling `/mnt/user/pc/kindrobots/animate`. `ANIMATE_PATH` can set it explicitly; when omitted with `IMAGES_PATH` configured, the app derives the sibling `animate` directory. No production mount/container configuration is changed by this PR.

## Resume contract
Scene Animator annotates the normal ArtJob payload with `sceneAnimator` provenance (source folder/file/hash, config key, dedupe key). Start/Resume skips matching PENDING, RUNNING, and DONE work. FAILED/CANCELLED work is retried only by explicit action. Changing source bytes or effective settings intentionally creates a new render.

## Conductor
`scene-animator/t-001` is in review under session `2026-08-24T131000Z-scene-animator-t-001-g56s`.

## Human gate
After merge, the self-hosted Kind Robots container may still need read access/bind mounting for `/mnt/user/pc/kindrobots/animate`; that deployment/infrastructure step is tracked separately as `scene-animator/t-003`.