### PR TITLE
fix(davinci): guard recordLifeChoice against duplicate chapter submissions

### DIFF
--- a/server/utils/davinci.ts
+++ b/server/utils/davinci.ts
@@ -421,6 +421,29 @@ export async function recordLifeChoice(
       )
     }
 
+    // Idempotency guard: exactly one LifeChoice is ever meant to exist per
+    // (lifeRunId, chapter) — the front end derives chapterIndex from
+    // playedCount and only advances it after a choice lands (davinci-page.vue),
+    // so a second submission for an already-recorded chapter is always a
+    // duplicate, never a legitimate second choice. Without this guard, two
+    // browser tabs open on the same run (or a client retry after a dropped
+    // response) would each create their own LifeChoice row and double-apply
+    // `effects` via the increment upsert below, silently corrupting stats and
+    // duplicating narrative history. Re-derive and return the already-recorded
+    // result instead of writing again — same "read back, don't recompute"
+    // idempotency shape as resolveCompletedLifeRun's COMPLETE-run guard above.
+    const existingChoice = await tx.lifeChoice.findFirst({
+      where: { lifeRunId, chapter: input.chapter },
+      orderBy: { id: 'asc' },
+    })
+    if (existingChoice) {
+      const stats = await tx.lifeStat.findMany({
+        where: { lifeRunId },
+        orderBy: { key: 'asc' },
+      })
+      return { choice: existingChoice, stats }
+    }
+
     const choice = await tx.lifeChoice.create({
       data: {
         lifeRunId,

--- a/utils/scripts/verifyDaVinciPlayLoop.ts
+++ b/utils/scripts/verifyDaVinciPlayLoop.ts
@@ -75,6 +75,39 @@ async function main() {
       `all ${DAVINCI_DIMENSIONS.length} dimensions got a LifeStat row (${stats.length})`,
     )
 
+    console.log('2b. duplicate choice on the same chapter is idempotent')
+    const statsBeforeDuplicate = await prisma.lifeStat.findMany({
+      where: { lifeRunId: run.id },
+      orderBy: { key: 'asc' },
+    })
+    const duplicateEffects = Object.fromEntries(
+      DAVINCI_DIMENSIONS.map((dimension) => [dimension, 1]),
+    )
+    const duplicate = await recordLifeChoice(run.id, user.id, {
+      chapter: 1,
+      prompt: 'Test prompt (resubmitted, e.g. a second open tab)',
+      choiceText: 'A different choice than the first',
+      effects: duplicateEffects,
+    })
+    check(
+      duplicate.choice.id === choice.id,
+      'resubmitting chapter 1 returns the original LifeChoice, not a new row',
+    )
+    check(
+      duplicate.stats.every((stat) => {
+        const before = statsBeforeDuplicate.find((s) => s.key === stat.key)
+        return before?.value === stat.value
+      }),
+      'resubmitting chapter 1 does not re-apply effects to LifeStat',
+    )
+    const choiceRowCount = await prisma.lifeChoice.count({
+      where: { lifeRunId: run.id, chapter: 1 },
+    })
+    check(
+      choiceRowCount === 1,
+      `exactly one LifeChoice row exists for chapter 1 (got ${choiceRowCount})`,
+    )
+
     console.log('3. resolve')
     const expectedOutcomeKey = resolveOutcomeKey(
       Object.fromEntries(stats.map((stat) => [stat.key, stat.value])),


### PR DESCRIPTION
### Task
conductor/davinci/t-021: Da Vinci visual style and interaction polish pass (kind: software)

Continuing the "async-race family" bug hunt this task's own note flagged as not yet exhausted — specifically: "concurrent tab/session interaction with the same run was not traced this cycle."

### What changed / what I produced
- `server/utils/davinci.ts`: `recordLifeChoice` now checks for an existing `LifeChoice` on `(lifeRunId, chapter)` inside its transaction before writing. If one exists, it returns that choice + the current stats instead of creating a second row and re-applying `effects`.
  - Root cause: the front end derives `chapterIndex` from `playedCount`, which only advances after a choice successfully lands (`davinci-page.vue`'s `chooseOption`). So exactly one `LifeChoice` is ever meant to exist per chapter — but the server never enforced that. Two browser tabs open on the same run (no shared client-side `submitting` state across tabs), or a client retry after a dropped response, would each create their own `LifeChoice` row and double-apply stat deltas via the `LifeStat` increment upsert — silently inflating stats, duplicating narrative history, and potentially steering `resolveLifeRunEnding` to the wrong `outcomeKey`.
  - Fix mirrors the file's own existing idempotency idiom (`resolveCompletedLifeRun`'s "read back, don't recompute" pattern for an already-`COMPLETE` run) rather than introducing a new shape.
- `utils/scripts/verifyDaVinciPlayLoop.ts` (the live play-loop regression check, davinci/t-011): added step "2b" — resubmit chapter 1 with different `choiceText`/`effects` and assert it returns the *original* `LifeChoice` unchanged, does not re-apply effects to `LifeStat`, and leaves exactly one `LifeChoice` row for that chapter.

### How I verified
- `npx vue-tsc --noEmit` — repo-wide, exit 0.
- `npx eslint server/utils/davinci.ts utils/scripts/verifyDaVinciPlayLoop.ts` — clean except one pre-existing, unrelated warning (`DAVINCI_DIMENSIONS` unused import in `davinci.ts`) confirmed present on `main` before this change (via `git stash` + re-run); left untouched per scope discipline.
- `npx prettier --check` on both files — confirmed the only formatting drift is pre-existing (an import-wrap and a missing trailing newline, both present on `main` before this change); my added lines required zero reformatting.
- `git diff --stat` — exactly the 2 intended files, 56 insertions, 0 deletions.
- **Not run**: the new `verifyDaVinciPlayLoop.ts` case itself, and `npm run seed:davinci:playloop-verify` generally — this needs a live `DATABASE_URL` with a seeded `LifeEnding`, which this sandbox doesn't have (dummy `DATABASE_URL` is sufficient for `prisma generate`/`vue-tsc` only, not real queries). This is the same sandbox limitation documented elsewhere in this task's own history for cross-width visual verification. The added test follows the exact structure of the existing steps 1/3/4/5 in the same file, which do exercise this code path in CI/locally with a real DB.

### Stakes
reversible

### Flags for Reviewer
- The fix closes the realistic, reliably-reachable case (two tabs, or any client retry at a normal human/network interval) but not a theoretical sub-millisecond concurrent-transaction race, since MySQL's default isolation doesn't lock the read-before-write inside the transaction. A DB-level `@@unique([lifeRunId, chapter])` constraint on `LifeChoice` would close that last sliver, but I did not add one this slice: if any duplicate `(lifeRunId, chapter)` rows already exist in production from this exact bug, a `CREATE UNIQUE INDEX` migration would fail to apply until that data is cleaned up first. Flagging as a natural follow-up rather than risking an unverified migration in this pass.
- Please double-check my read of `chapterIndex`/`playedCount` in `davinci-page.vue` (lines ~788, ~1254-1284) — I traced it as: exactly one intended `LifeChoice` per chapter, but I don't have a live app to click through in this sandbox.

### Kaizen suggestion
Audit production `LifeChoice` rows for any existing `(lifeRunId, chapter)` duplicates (a one-off read-only query), and if none are found, land the `@@unique([lifeRunId, chapter])` migration to close the race at the DB level too.

### Notes for reviewer
Scoped narrowly to the one concrete gap identified — no cosmetic changes, per this task's established "concrete, verifiable gap, not a reskin" discipline across its prior slices.

---
_Generated by [Claude Code](https://claude.ai/code/session_0187LkxZtKpMvre61FdAxjV4)_