### PR TITLE
Add upscaler ResourceTypes, and point flux2 at models that actually exist

### DIFF
--- a/prisma/migrations/20260825000000_add_upscaler_resource_types/migration.sql
+++ b/prisma/migrations/20260825000000_add_upscaler_resource_types/migration.sql
@@ -1,0 +1,34 @@
+-- Add LATENT_UPSCALER and UPSCALER to ResourceType.
+--
+-- kind-robots/t-070. The enum had no way to describe an upscaler of any kind, so
+-- ltx-2.3-spatial-upscaler-x2-1.1 -- a latent upscale model loaded by
+-- LatentUpscaleModelLoader, and a hard requirement of the ltx-12gb-balanced video
+-- preset -- had to be registered as CHECKPOINT.
+--
+-- That stopped being cosmetic once conductor began resolving engine model paths FROM
+-- this registry keyed on resourceType (cthulhuquarium/t-034): the localPath
+-- prefix-stripping table is keyed by type, so a CHECKPOINT-typed row keeps its leading
+-- directory while a DIFFUSION_MODEL-typed one has it stripped. Wrong type, wrong path,
+-- no error.
+--
+-- Two values rather than one because they are genuinely different: latent upscalers
+-- load from models/latent_upscale_models/ via LatentUpscaleModelLoader and act on
+-- latents; pixel upscalers (ESRGAN and friends) load from models/upscale_models/ and
+-- act on images. Both directories exist on the array.
+--
+-- Purely additive: appending members to a MySQL ENUM rewrites no rows and invalidates
+-- no existing value. Both columns that use the type are widened so they stay in sync.
+
+ALTER TABLE `Resource`
+  MODIFY `resourceType` ENUM(
+    'CHECKPOINT', 'EMBEDDING', 'LORA', 'LYCORIS', 'HYPERNETWORK', 'SAMPLER',
+    'CONTROLNET', 'URL', 'API', 'VAE', 'TEXT_ENCODER', 'DIFFUSION_MODEL',
+    'LATENT_UPSCALER', 'UPSCALER'
+  ) NOT NULL DEFAULT 'EMBEDDING';
+
+ALTER TABLE `DownloadRequest`
+  MODIFY `resourceType` ENUM(
+    'CHECKPOINT', 'EMBEDDING', 'LORA', 'LYCORIS', 'HYPERNETWORK', 'SAMPLER',
+    'CONTROLNET', 'URL', 'API', 'VAE', 'TEXT_ENCODER', 'DIFFUSION_MODEL',
+    'LATENT_UPSCALER', 'UPSCALER'
+  ) NOT NULL DEFAULT 'LORA';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2681,6 +2681,13 @@ enum ResourceType {
   VAE
   TEXT_ENCODER
   DIFFUSION_MODEL
+  /// Operates on LATENTS, loaded by LatentUpscaleModelLoader from
+  /// models/latent_upscale_models/. LTX's spatial upscaler is one, and the
+  /// ltx-12gb-balanced video preset requires it. Distinct from UPSCALER: the
+  /// loaders, the directories and the graph positions are all different.
+  LATENT_UPSCALER
+  /// Operates on PIXELS (ESRGAN and friends), from models/upscale_models/.
+  UPSCALER
 }
 
 enum RewardType {

--- a/server/api/comfy/flux2/utils/workflow.ts
+++ b/server/api/comfy/flux2/utils/workflow.ts
@@ -7,7 +7,22 @@
 // text encode; otherwise the plain prompt string is used. Flux.2 uses its OWN
 // text encoder and VAE (different from Flux.1).
 //
-// VERIFY these filenames against the Comfy-Org Flux.2 release you download.
+// MODEL FILENAMES, corrected 2026-08-24 (kind-robots/t-070, cthulhuquarium/t-033).
+// These previously read `flux-2-klein-4b-Q4_K_M.gguf` and
+// `flux2_klein_text_encoder_fp8_scaled.safetensors`, neither of which exists in any
+// Comfy-Org release or on the render box -- so this engine had never once run. The
+// comment above them said to verify the names against the release; nobody did, and the
+// only failure signal was a ComfyUI error at render time months later.
+//
+// Now pointed at the Flux 2 stack that IS registered as a Resource and present on the
+// box: flux2_dev_fp8mixed (diffusion_models/), mistral_3_small_flux2_bf16
+// (text_encoders/) and flux2-vae (vae/). The unet is a .safetensors, so the loader
+// moves off UnetLoaderGGUF.
+//
+// NOT YET RUN END TO END: mistral_3_small_flux2_bf16 is 35.5 GB against a 12 GB card.
+// ComfyUI can offload a text encoder to CPU, but that needs a real render to confirm.
+// If it will not fit, register Comfy-Org's mistral_3_small_flux2_fp8 and change the one
+// name here -- do not invent a filename, which is how this broke the first time.
 import {
   buildSimpleCheckpointWorkflow,
   type ComfyWorkflow,
@@ -15,10 +30,9 @@ import {
 import type { LoraSelectionInput } from '../../utils/loraChain'
 
 export const FLUX2_KLEIN_UNET_LOADER: 'UNETLoader' | 'UnetLoaderGGUF' =
-  'UnetLoaderGGUF'
-export const FLUX2_KLEIN_MODEL = 'flux-2-klein-4b-Q4_K_M.gguf'
-export const FLUX2_KLEIN_CLIP =
-  'flux2_klein_text_encoder_fp8_scaled.safetensors'
+  'UNETLoader'
+export const FLUX2_KLEIN_MODEL = 'flux2_dev_fp8mixed.safetensors'
+export const FLUX2_KLEIN_CLIP = 'mistral_3_small_flux2_bf16.safetensors'
 export const FLUX2_KLEIN_CLIP_TYPE = 'flux2'
 export const FLUX2_KLEIN_VAE = 'flux2-vae.safetensors'
 export const FLUX2_KLEIN_DEFAULT_STEPS = 4


### PR DESCRIPTION
Two fixes, both of which were **silent** failures rather than loud ones.

## `ResourceType` gains `LATENT_UPSCALER` and `UPSCALER` — t-070

The enum had no way to describe an upscaler of any kind, so `ltx-2.3-spatial-upscaler-x2-1.1` — a latent upscale model loaded by `LatentUpscaleModelLoader`, and a **hard requirement of the `ltx-12gb-balanced` video preset** — had to be registered as `CHECKPOINT`.

That stopped being cosmetic once conductor began resolving engine model paths *from* this registry keyed on `resourceType` (cthulhuquarium/t-034). The localPath prefix-stripping table is keyed by type, so a `CHECKPOINT`-typed row keeps its leading directory while a `DIFFUSION_MODEL`-typed one has it stripped. **Wrong type, wrong path, no error.**

Two values rather than one because they're genuinely different — latent upscalers load from `models/latent_upscale_models/` and act on latents; pixel upscalers load from `models/upscale_models/` and act on images — and the array has both directories.

Migration is **additive and forward-only**: appending members to a MySQL `ENUM` rewrites no rows and invalidates no existing value. Both columns using the type (`Resource`, `DownloadRequest`) are widened so they stay in sync.

## flux2 pointed at models that exist — t-033

`server/api/comfy/flux2/utils/workflow.ts` declared `flux-2-klein-4b-Q4_K_M.gguf` and `flux2_klein_text_encoder_fp8_scaled.safetensors`. **Neither exists in any Comfy-Org release or on the render box, so this engine had never once run.**

The comment above them said to verify the names against the release you download. Nobody did, and the only failure signal was a ComfyUI error at render time, months later, on an unrelated task.

Now pointed at the Flux 2 stack that **is** registered and present:

| | was | now |
|---|---|---|
| unet | `flux-2-klein-4b-Q4_K_M.gguf` *(fictional)* | `flux2_dev_fp8mixed.safetensors` |
| clip | `flux2_klein_text_encoder_fp8_scaled.safetensors` *(fictional)* | `mistral_3_small_flux2_bf16.safetensors` |
| vae | `flux2-vae.safetensors` | unchanged — this one was real |
| loader | `UnetLoaderGGUF` | `UNETLoader` (the unet is a `.safetensors`) |

Conductor's mirror of these constants was corrected in the same pass — fixing one repo alone leaves the bug live on the other path.

**Recorded in the file rather than assumed:** this is *not yet run end to end*, because that encoder is 35.5 GB against a 12 GB card. If CPU offload won't cover it, the answer is registering Comfy-Org's `mistral_3_small_flux2_fp8` and changing one name — **not** inventing a filename, which is how this broke the first time.

## Verification

`prisma validate` clean, `vue-tsc` clean, `eslint` clean on the touched file.

Note: `prisma format` also reformatted two unrelated schema files (`brainstorm.prisma`, `facet-catalog.prisma`). Those were reverted rather than swept into this diff.

## Still open, deliberately

kind-robots/t-069 — the gemma text-encoder LoRA still has nowhere to load. `loraChain.ts` already implements the model+clip shape, so it's a routing change rather than new machinery, but `Resource` has no field distinguishing a unet LoRA from a text-encoder one. That discriminator has to land first, and rewiring the LTX graph needs a real render to confirm it still samples.

Companion: silasfelinus/conductor#2810.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFNZJyWZYdqphFMF2xXv5D)_