### PR TITLE
feat(aquarium): server API for tank state, tick, feed, purchase, browse (cthulhuquarium/t-009)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:mana-resource-split": "tsx utils/scripts/verifyManaResourceSplit.test.ts",
     "test:mana-attribution": "tsx utils/scripts/verifyManaAttribution.test.ts",
     "test:revenue-split": "tsx utils/scripts/verifyRevenueSplit.test.ts",
+    "test:aquarium-economy": "tsx utils/scripts/verifyAquariumEconomy.test.ts",
     "test:creator-earnings": "tsx utils/scripts/verifyCreatorEarnings.test.ts",
     "test:social-post-draft": "tsx utils/scripts/verifySocialPostDraft.test.ts",
     "test:mission-accrual": "tsx utils/scripts/verifyMissionAccrual.test.ts",

--- a/server/api/aquarium/browse/[username]/[slug].get.ts
+++ b/server/api/aquarium/browse/[username]/[slug].get.ts
@@ -1,0 +1,50 @@
+// /server/api/aquarium/browse/[username]/[slug].get.ts
+//
+// One public tank, unauthenticated (cthulhuquarium/t-009). Only tanks with
+// isPublic: true are visible; response exposes display name + tank
+// contents only, never email or userId.
+//
+// Addressed by (username, slug) together, NOT slug alone: Aquarium.slug is
+// unique per (userId, slug) -- deliberately not globally unique, per the
+// t-032 schema comment fixing exactly this class of collision -- so a
+// bare-slug route would be ambiguous the moment two users pick the same
+// tank name.
+
+import { defineEventHandler, createError } from 'h3'
+import { errorHandler } from '../../../../utils/error'
+import { getPublicTankByUsernameAndSlug } from '../../../../utils/aquarium'
+
+export default defineEventHandler(async (event) => {
+  let response
+
+  try {
+    const username = String(event.context.params?.username ?? '').trim()
+    const slug = String(event.context.params?.slug ?? '').trim()
+
+    if (!username || !slug) {
+      throw createError({
+        statusCode: 400,
+        message: 'Both username and slug are required.',
+      })
+    }
+
+    const data = await getPublicTankByUsernameAndSlug(username, slug)
+
+    response = {
+      success: true,
+      data,
+      statusCode: 200,
+    }
+    event.node.res.statusCode = 200
+  } catch (error) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+    response = {
+      success: false,
+      message: handledError.message || 'Failed to load public tank.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+
+  return response
+})

--- a/server/api/aquarium/browse/index.get.ts
+++ b/server/api/aquarium/browse/index.get.ts
@@ -1,0 +1,56 @@
+// /server/api/aquarium/browse/index.get.ts
+//
+// Public tank index -- paginated, unauthenticated (cthulhuquarium/t-009).
+// Exposes display name + tank summary only, never email or userId.
+//
+// Query: ?take=20&skip=0 (take capped and defaulted like other browse
+// endpoints in this codebase's list conventions, e.g. server/api/dreams).
+
+import { defineEventHandler, getQuery } from 'h3'
+import { errorHandler } from '../../../utils/error'
+import { listPublicTanks } from '../../../utils/aquarium'
+
+const DEFAULT_TAKE = 20
+const MAX_TAKE = 50
+
+function parsePositiveInt(
+  value: unknown,
+  fallback: number,
+  max?: number,
+): number {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback
+  const truncated = Math.trunc(parsed)
+  return max ? Math.min(truncated, max) : truncated
+}
+
+export default defineEventHandler(async (event) => {
+  let response
+
+  try {
+    const query = getQuery(event)
+    const take =
+      parsePositiveInt(query.take, DEFAULT_TAKE, MAX_TAKE) || DEFAULT_TAKE
+    const skip = parsePositiveInt(query.skip, 0)
+
+    const result = await listPublicTanks(take, skip)
+
+    response = {
+      success: true,
+      data: result.data,
+      meta: { take: result.take, skip: result.skip, total: result.total },
+      statusCode: 200,
+    }
+    event.node.res.statusCode = 200
+  } catch (error) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+    response = {
+      success: false,
+      message: handledError.message || 'Failed to load public tanks.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+
+  return response
+})

--- a/server/api/aquarium/feed.post.ts
+++ b/server/api/aquarium/feed.post.ts
@@ -1,0 +1,54 @@
+// /server/api/aquarium/feed.post.ts
+//
+// Feeds one fish in the authenticated user's tank, restoring its hunger to
+// data/economy.yaml's feed.restores_hunger_to and charging
+// feed.cost_factor_of_unlock_cost * that fish's unlock_cost in coins,
+// rejecting if the tank can't afford it (cthulhuquarium/t-009).
+//
+// Body: { aquariumStockId: number }
+
+import { defineEventHandler, readBody, createError } from 'h3'
+import { errorHandler } from '../../utils/error'
+import { requireApiUser } from '../../utils/authGuard'
+import { feedFishForUser } from '../../utils/aquarium'
+
+export default defineEventHandler(async (event) => {
+  let response
+
+  try {
+    const { user } = await requireApiUser(event)
+
+    const body = await readBody(event)
+    const aquariumStockId = Number(body?.aquariumStockId)
+    if (!Number.isInteger(aquariumStockId) || aquariumStockId <= 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'aquariumStockId must be a positive integer.',
+      })
+    }
+
+    const result = await feedFishForUser(
+      user.id,
+      user.username,
+      aquariumStockId,
+    )
+
+    response = {
+      success: true,
+      message: `Fed for ${result.cost} coins.`,
+      data: result,
+      statusCode: 200,
+    }
+    event.node.res.statusCode = 200
+  } catch (error) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+    response = {
+      success: false,
+      message: handledError.message || 'Failed to feed fish.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+
+  return response
+})

--- a/server/api/aquarium/index.get.ts
+++ b/server/api/aquarium/index.get.ts
@@ -1,0 +1,36 @@
+// /server/api/aquarium/index.get.ts
+//
+// Returns the authenticated user's Cthulhuquarium tank, creating one with
+// default state on first visit (cthulhuquarium/t-009).
+
+import { defineEventHandler } from 'h3'
+import { errorHandler } from '../../utils/error'
+import { requireApiUser } from '../../utils/authGuard'
+import { getOrCreateTankForUser } from '../../utils/aquarium'
+
+export default defineEventHandler(async (event) => {
+  let response
+
+  try {
+    const { user } = await requireApiUser(event)
+
+    const data = await getOrCreateTankForUser(user.id, user.username)
+
+    response = {
+      success: true,
+      data,
+      statusCode: 200,
+    }
+    event.node.res.statusCode = 200
+  } catch (error) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+    response = {
+      success: false,
+      message: handledError.message || 'Failed to load your tank.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+
+  return response
+})

--- a/server/api/aquarium/purchase.post.ts
+++ b/server/api/aquarium/purchase.post.ts
@@ -1,0 +1,81 @@
+// /server/api/aquarium/purchase.post.ts
+//
+// Purchases into the authenticated user's tank, priced and validated
+// entirely server-side from data/economy.yaml (cthulhuquarium/t-009).
+//
+// Body: { type: 'species', characterId: number }
+//
+// Only `type: 'species'` (unlocking a new fish species) is implemented.
+// The task note also named `food` and `upgrade` purchase types, but neither
+// has a real mechanic to price against in economy.yaml or the live schema:
+//   - food: economy.yaml bundles buying and consuming food into a single
+//     action ("the food is alive") -- POST /api/aquarium/feed already IS
+//     that purchase, priced the same way (feed.cost_factor_of_unlock_cost *
+//     the fish's unlock_cost). A standalone food-purchase-for-later type
+//     would need its own inventory column that does not exist on any
+//     Aquarium/AquariumStock row.
+//   - upgrade: economy.yaml's `slots` section states capacity growth is
+//     "entirely landmark-driven... never purchased with coins" ("coins buy
+//     breadth, milestones buy room"). Inventing a coin price for it would
+//     contradict the balance spec this task is required to read from.
+// Both return 400 rather than silently succeeding at a made-up price --
+// the whole point of "the server disposes" is refusing to invent economy
+// the spec doesn't define. Flagged in the PR for reviewer confirmation.
+
+import { defineEventHandler, readBody, createError } from 'h3'
+import { errorHandler } from '../../utils/error'
+import { requireApiUser } from '../../utils/authGuard'
+import { purchaseSpeciesForUser } from '../../utils/aquarium'
+
+export default defineEventHandler(async (event) => {
+  let response
+
+  try {
+    const { user } = await requireApiUser(event)
+
+    const body = await readBody(event)
+    const type = String(body?.type ?? '')
+
+    if (type !== 'species') {
+      throw createError({
+        statusCode: 400,
+        message:
+          type === 'food' || type === 'upgrade'
+            ? `Purchase type '${type}' is not implemented -- see this route's file header for why (feed food via POST /api/aquarium/feed; capacity grows only via milestones).`
+            : "Unsupported purchase type. Only { type: 'species', characterId } is implemented.",
+      })
+    }
+
+    const characterId = Number(body?.characterId)
+    if (!Number.isInteger(characterId) || characterId <= 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'characterId must be a positive integer.',
+      })
+    }
+
+    const result = await purchaseSpeciesForUser(
+      user.id,
+      user.username,
+      characterId,
+    )
+
+    response = {
+      success: true,
+      message: `Unlocked for ${result.cost} coins.`,
+      data: result,
+      statusCode: 201,
+    }
+    event.node.res.statusCode = 201
+  } catch (error) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+    response = {
+      success: false,
+      message: handledError.message || 'Failed to complete purchase.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+
+  return response
+})

--- a/server/api/aquarium/tick.post.ts
+++ b/server/api/aquarium/tick.post.ts
@@ -1,0 +1,42 @@
+// /server/api/aquarium/tick.post.ts
+//
+// Settles offline income against the authenticated user's tank, server-
+// authoritative and capped per data/economy.yaml (cthulhuquarium/t-009).
+// The client submits no earned amount -- only elapsed real time (implicit,
+// via `lastTickAt` on the tank row) drives what gets credited.
+
+import { defineEventHandler } from 'h3'
+import { errorHandler } from '../../utils/error'
+import { requireApiUser } from '../../utils/authGuard'
+import { settleTickForUser } from '../../utils/aquarium'
+
+export default defineEventHandler(async (event) => {
+  let response
+
+  try {
+    const { user } = await requireApiUser(event)
+
+    const result = await settleTickForUser(user.id, user.username)
+
+    response = {
+      success: true,
+      message:
+        result.ticksProcessed > 0
+          ? `Settled ${result.ticksProcessed} tick(s): +${result.coinsEarned} coins.`
+          : 'No ticks have elapsed since your last visit.',
+      data: result,
+      statusCode: 200,
+    }
+    event.node.res.statusCode = 200
+  } catch (error) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+    response = {
+      success: false,
+      message: handledError.message || 'Failed to settle tank tick.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+
+  return response
+})

--- a/server/utils/aquarium.ts
+++ b/server/utils/aquarium.ts
@@ -1,0 +1,470 @@
+// /server/utils/aquarium.ts
+//
+// Cthulhuquarium tank business logic (cthulhuquarium/t-009). Route handlers
+// under server/api/aquarium/** stay thin (auth, param parsing, response
+// shape) and delegate here, mirroring server/utils/davinci.ts's split with
+// the davinci runs API.
+//
+// All economy math is delegated to server/utils/aquariumEconomy.ts (pure,
+// no prisma) -- this file's job is loading/persisting Prisma state around
+// that math and enforcing ownership/authorization. The client proposes
+// (a characterId to unlock, an aquariumStockId to feed); the server disposes
+// (prices, caps, and elapsed-tick income all come from here, never from the
+// request body).
+
+import type { Prisma } from '~/prisma/generated/prisma/client'
+import prisma from './prisma'
+import { getUniqueAquariumSlugForUser } from './aquariumSlug'
+import {
+  deriveFishRarityTier,
+  feedCost,
+  FEED_RESTORES_HUNGER_TO,
+  HUNGER_STARTING_VALUE,
+  settleTick,
+  unlockCost,
+} from './aquariumEconomy'
+
+function apiError(statusCode: number, message: string): Error {
+  const error = new Error(message) as Error & { statusCode: number }
+  error.statusCode = statusCode
+  return error
+}
+
+// prisma is $extends()-wrapped (see server/utils/prisma.ts), so its
+// $transaction callback's tx param has extended InternalArgs that don't
+// structurally match the plain Prisma.TransactionClient type. Derive the
+// type from the actual instance instead of the generated default -- same
+// workaround as server/utils/davinci.ts.
+type TransactionClient = Parameters<
+  Parameters<typeof prisma.$transaction>[0]
+>[0]
+
+// Six Rarity stat fields every Character row carries -- see
+// aquariumEconomy.ts's deriveFishRarityTier for why this stands in for a
+// canonical per-species rarity/tier column that does not exist yet.
+const characterRaritySelect = {
+  charm: true,
+  empathy: true,
+  grace: true,
+  luck: true,
+  might: true,
+  wits: true,
+} satisfies Prisma.CharacterSelect
+
+const stockCharacterSelect = {
+  id: true,
+  name: true,
+  slug: true,
+  species: true,
+  size: true,
+  icon: true,
+  iconPath: true,
+  cardPath: true,
+  ...characterRaritySelect,
+} satisfies Prisma.CharacterSelect
+
+const ownedStockSelect = {
+  id: true,
+  characterId: true,
+  nickname: true,
+  hunger: true,
+  mood: true,
+  placedAt: true,
+  Character: { select: stockCharacterSelect },
+} satisfies Prisma.AquariumStockSelect
+
+const ownedAquariumSelect = {
+  id: true,
+  slug: true,
+  title: true,
+  coins: true,
+  backgroundKey: true,
+  isPublic: true,
+  lastTickAt: true,
+  setSlotsCap: true,
+  sizeCap: true,
+  debrisLevel: true,
+  lastCleanedAt: true,
+  createdAt: true,
+  updatedAt: true,
+  Stock: { select: ownedStockSelect },
+} satisfies Prisma.AquariumSelect
+
+export type OwnedAquarium = Prisma.AquariumGetPayload<{
+  select: typeof ownedAquariumSelect
+}>
+
+const DEFAULT_STARTING_COINS = 0
+
+async function logEvent(
+  tx: TransactionClient,
+  aquariumId: number,
+  kind: string,
+  payload: unknown,
+): Promise<void> {
+  await tx.aquariumEvent.create({
+    data: {
+      aquariumId,
+      kind,
+      payload: payload === undefined ? null : JSON.stringify(payload),
+    },
+  })
+}
+
+// Loads the authenticated user's tank, creating one with default state on
+// first visit rather than 404ing (t-009 task note).
+export async function getOrCreateTankForUser(
+  userId: number,
+  username: string,
+): Promise<OwnedAquarium> {
+  const existing = await prisma.aquarium.findFirst({
+    where: { userId },
+    select: ownedAquariumSelect,
+    orderBy: { id: 'asc' },
+  })
+  if (existing) return existing
+
+  const slug = await getUniqueAquariumSlugForUser(userId, username)
+
+  return prisma.aquarium.create({
+    data: {
+      userId,
+      slug,
+      title: `${username}'s Tank`,
+      coins: DEFAULT_STARTING_COINS,
+    },
+    select: ownedAquariumSelect,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tick
+// ---------------------------------------------------------------------------
+
+export interface TickResult {
+  aquarium: OwnedAquarium
+  elapsedTicks: number
+  ticksProcessed: number
+  coinsEarned: number
+}
+
+export async function settleTickForUser(
+  userId: number,
+  username: string,
+): Promise<TickResult> {
+  const tank = await getOrCreateTankForUser(userId, username)
+
+  const settlement = settleTick({
+    lastTickAt: tank.lastTickAt,
+    now: new Date(),
+    debrisLevel: tank.debrisLevel,
+    fish: tank.Stock.map((stock) => ({
+      id: stock.id,
+      rarity: deriveFishRarityTier(stock.Character),
+      hunger: stock.hunger,
+    })),
+  })
+
+  if (settlement.ticksProcessed <= 0) {
+    return {
+      aquarium: tank,
+      elapsedTicks: settlement.elapsedTicks,
+      ticksProcessed: 0,
+      coinsEarned: 0,
+    }
+  }
+
+  const aquarium = await prisma.$transaction(async (tx) => {
+    for (const stock of tank.Stock) {
+      const newHunger = settlement.fishHunger.get(stock.id)
+      if (newHunger !== undefined && newHunger !== stock.hunger) {
+        await tx.aquariumStock.update({
+          where: { id: stock.id },
+          data: { hunger: newHunger },
+        })
+      }
+    }
+
+    const updated = await tx.aquarium.update({
+      where: { id: tank.id },
+      data: {
+        coins: { increment: settlement.coinsEarned },
+        debrisLevel: settlement.newDebrisLevel,
+        lastTickAt: settlement.newLastTickAt,
+      },
+      select: ownedAquariumSelect,
+    })
+
+    await logEvent(tx, tank.id, 'tick', {
+      elapsedTicks: settlement.elapsedTicks,
+      ticksProcessed: settlement.ticksProcessed,
+      coinsEarned: settlement.coinsEarned,
+      newDebrisLevel: settlement.newDebrisLevel,
+    })
+
+    return updated
+  })
+
+  return {
+    aquarium,
+    elapsedTicks: settlement.elapsedTicks,
+    ticksProcessed: settlement.ticksProcessed,
+    coinsEarned: settlement.coinsEarned,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Feed
+// ---------------------------------------------------------------------------
+
+export interface FeedResult {
+  aquarium: OwnedAquarium
+  aquariumStockId: number
+  cost: number
+  hunger: number
+}
+
+export async function feedFishForUser(
+  userId: number,
+  username: string,
+  aquariumStockId: number,
+): Promise<FeedResult> {
+  const tank = await getOrCreateTankForUser(userId, username)
+
+  const stock = tank.Stock.find((row) => row.id === aquariumStockId)
+  if (!stock) {
+    throw apiError(
+      404,
+      `AquariumStock ${aquariumStockId} was not found in your tank.`,
+    )
+  }
+
+  const rarity = deriveFishRarityTier(stock.Character)
+  const cost = feedCost(rarity)
+
+  if (tank.coins < cost) {
+    throw apiError(
+      402,
+      `Feeding ${stock.Character.name} costs ${cost} coins; your tank only has ${tank.coins}.`,
+    )
+  }
+
+  const aquarium = await prisma.$transaction(async (tx) => {
+    await tx.aquariumStock.update({
+      where: { id: stock.id },
+      data: { hunger: FEED_RESTORES_HUNGER_TO },
+    })
+
+    const updated = await tx.aquarium.update({
+      where: { id: tank.id },
+      data: { coins: { decrement: cost } },
+      select: ownedAquariumSelect,
+    })
+
+    await logEvent(tx, tank.id, 'feed', {
+      aquariumStockId: stock.id,
+      characterId: stock.characterId,
+      cost,
+    })
+
+    return updated
+  })
+
+  return {
+    aquarium,
+    aquariumStockId: stock.id,
+    cost,
+    hunger: FEED_RESTORES_HUNGER_TO,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Purchase -- species unlock only. See PR description for why `food` and
+// `upgrade` purchase types (named in the task note) are intentionally not
+// implemented: economy.yaml bundles buying+consuming food into a single
+// action (POST /feed already IS that purchase) and states capacity growth
+// is milestone-only, "never purchased with coins".
+// ---------------------------------------------------------------------------
+
+export interface PurchaseSpeciesResult {
+  aquarium: OwnedAquarium
+  stock: OwnedAquarium['Stock'][number]
+  cost: number
+}
+
+export async function purchaseSpeciesForUser(
+  userId: number,
+  username: string,
+  characterId: number,
+): Promise<PurchaseSpeciesResult> {
+  const tank = await getOrCreateTankForUser(userId, username)
+
+  const character = await prisma.character.findFirst({
+    where: { id: characterId, isActive: true, isPublic: true },
+    select: stockCharacterSelect,
+  })
+  if (!character) {
+    throw apiError(
+      404,
+      `Character ${characterId} does not exist or is not available to unlock.`,
+    )
+  }
+
+  const alreadyOwned = tank.Stock.some((row) => row.characterId === characterId)
+  if (alreadyOwned) {
+    throw apiError(
+      409,
+      `${character.name} is already in your tank -- Cthulhuquarium is a collection, not copies of the same fish.`,
+    )
+  }
+
+  const currentSize = tank.Stock.reduce(
+    (sum, row) => sum + (row.Character.size ?? 1),
+    0,
+  )
+  const newSize = character.size ?? 1
+  if (currentSize + newSize > tank.sizeCap) {
+    throw apiError(
+      409,
+      `Adding ${character.name} (size ${newSize}) would exceed your tank's capacity (${currentSize}/${tank.sizeCap} used).`,
+    )
+  }
+
+  const rarity = deriveFishRarityTier(character)
+  const cost = unlockCost(rarity)
+
+  if (tank.coins < cost) {
+    throw apiError(
+      402,
+      `Unlocking ${character.name} costs ${cost} coins; your tank only has ${tank.coins}.`,
+    )
+  }
+
+  const { aquarium, stock } = await prisma.$transaction(async (tx) => {
+    const createdStock = await tx.aquariumStock.create({
+      data: {
+        aquariumId: tank.id,
+        characterId: character.id,
+        hunger: HUNGER_STARTING_VALUE,
+      },
+      select: ownedStockSelect,
+    })
+
+    const updatedAquarium = await tx.aquarium.update({
+      where: { id: tank.id },
+      data: { coins: { decrement: cost } },
+      select: ownedAquariumSelect,
+    })
+
+    await logEvent(tx, tank.id, 'purchase', {
+      type: 'species',
+      characterId: character.id,
+      aquariumStockId: createdStock.id,
+      cost,
+    })
+
+    return { aquarium: updatedAquarium, stock: createdStock }
+  })
+
+  return { aquarium, stock, cost }
+}
+
+// ---------------------------------------------------------------------------
+// Public browse -- display name + tank contents ONLY, never email or userId.
+// ---------------------------------------------------------------------------
+
+const publicOwnerSelect = {
+  username: true,
+  avatarImage: true,
+} satisfies Prisma.UserSelect
+
+const publicStockSelect = {
+  id: true,
+  nickname: true,
+  hunger: true,
+  mood: true,
+  placedAt: true,
+  Character: {
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      species: true,
+      size: true,
+      icon: true,
+      iconPath: true,
+      cardPath: true,
+    },
+  },
+} satisfies Prisma.AquariumStockSelect
+
+const publicAquariumDetailSelect = {
+  slug: true,
+  title: true,
+  coins: true,
+  backgroundKey: true,
+  debrisLevel: true,
+  sizeCap: true,
+  setSlotsCap: true,
+  updatedAt: true,
+  User: { select: publicOwnerSelect },
+  Stock: { select: publicStockSelect },
+} satisfies Prisma.AquariumSelect
+
+const publicAquariumSummarySelect = {
+  slug: true,
+  title: true,
+  backgroundKey: true,
+  updatedAt: true,
+  User: { select: publicOwnerSelect },
+  _count: { select: { Stock: true } },
+} satisfies Prisma.AquariumSelect
+
+export type PublicAquarium = Prisma.AquariumGetPayload<{
+  select: typeof publicAquariumDetailSelect
+}>
+export type PublicAquariumSummary = Prisma.AquariumGetPayload<{
+  select: typeof publicAquariumSummarySelect
+}>
+
+// Aquarium.slug is unique per (userId, slug), NOT globally (t-032 fixed a
+// real collision bug caused by a global unique constraint) -- so a public
+// tank is addressed by (username, slug) together, never slug alone.
+export async function getPublicTankByUsernameAndSlug(
+  username: string,
+  slug: string,
+): Promise<PublicAquarium> {
+  const tank = await prisma.aquarium.findFirst({
+    where: { slug, isPublic: true, User: { username } },
+    select: publicAquariumDetailSelect,
+  })
+  if (!tank) {
+    throw apiError(404, 'Public tank not found.')
+  }
+  return tank
+}
+
+export interface PublicTankListResult {
+  data: PublicAquariumSummary[]
+  take: number
+  skip: number
+  total: number
+}
+
+export async function listPublicTanks(
+  take: number,
+  skip: number,
+): Promise<PublicTankListResult> {
+  const [data, total] = await Promise.all([
+    prisma.aquarium.findMany({
+      where: { isPublic: true },
+      select: publicAquariumSummarySelect,
+      orderBy: { updatedAt: 'desc' },
+      take,
+      skip,
+    }),
+    prisma.aquarium.count({ where: { isPublic: true } }),
+  ])
+
+  return { data, take, skip, total }
+}

--- a/server/utils/aquariumEconomy.ts
+++ b/server/utils/aquariumEconomy.ts
@@ -1,0 +1,304 @@
+// /server/utils/aquariumEconomy.ts
+//
+// Cthulhuquarium economy constants and pure balance math (cthulhuquarium/t-009).
+// No prisma, no Nuxt/H3 imports -- unit-testable without a database, same
+// discipline as server/utils/revenueSplit.ts (see
+// utils/scripts/verifyAquariumEconomy.test.ts).
+//
+// SOURCE OF TRUTH: this is a committed TypeScript transcription of conductor's
+// projects/cthulhuquarium/data/economy.yaml (schema_version 1, status
+// draft-v1 as of 2026-08-25). That YAML lives in the separate conductor repo,
+// which this deployed server has no runtime filesystem access to -- and this
+// codebase's existing fs.readFileSync-a-repo-file patterns are documented as
+// unreliable on this project's Vercel deploy target (see
+// server/utils/folderNames.ts's own explicit Vercel fallback branch) -- so
+// "read balance.yaml at runtime" is satisfied here as a same-shape,
+// same-values TS module instead of a literal YAML parse at request time. A
+// balance-pass edit to economy.yaml must be mirrored here by hand; nothing
+// computes a hash or diff between the two files, so keeping them in sync is
+// a human discipline, same as davinciDimensions.ts's relationship to
+// conductor's ending-dimensions.yaml.
+//
+// Every number below traces to a section of economy.yaml. Nothing in
+// server/api/aquarium/** or server/utils/aquarium.ts should hardcode a
+// balance constant -- import it from here.
+
+import type { Rarity } from '~/prisma/generated/prisma/client'
+
+// economy.yaml: economy.tick_seconds
+export const TICK_SECONDS = 60
+
+// ---------------------------------------------------------------------------
+// Rarity tiers -- economy.yaml `rarity_tiers`
+// ---------------------------------------------------------------------------
+
+export interface RarityTierConfig {
+  incomePerTick: number
+  unlockCost: number
+}
+
+export const RARITY_TIERS: Record<Rarity, RarityTierConfig> = {
+  COMMON: { incomePerTick: 1, unlockCost: 50 },
+  UNCOMMON: { incomePerTick: 3, unlockCost: 200 },
+  RARE: { incomePerTick: 8, unlockCost: 750 },
+  EPIC: { incomePerTick: 20, unlockCost: 3000 },
+  LEGENDARY: { incomePerTick: 50, unlockCost: 12000 },
+  MYTHIC: { incomePerTick: 120, unlockCost: 50000 },
+}
+
+const RARITY_ORDER: readonly Rarity[] = [
+  'COMMON',
+  'UNCOMMON',
+  'RARE',
+  'EPIC',
+  'LEGENDARY',
+  'MYTHIC',
+]
+
+function rarityRank(rarity: Rarity): number {
+  return RARITY_ORDER.indexOf(rarity)
+}
+
+export function incomePerTick(rarity: Rarity): number {
+  return RARITY_TIERS[rarity].incomePerTick
+}
+
+export function unlockCost(rarity: Rarity): number {
+  return RARITY_TIERS[rarity].unlockCost
+}
+
+// Character has no single canonical "species rarity"/tier column -- it has
+// six PER-STAT Rarity fields (charm/empathy/grace/luck/might/wits), reused
+// from its original chatbot-personality design. t-003's fish bible
+// (conductor projects/cthulhuquarium, external to this repo) tracks a
+// separate singular `tier`/`rarity` per species, but no matching column
+// exists on Character yet, and adding one is a schema change this task is
+// explicitly barred from making speculatively (see t-009's task note: STOP
+// and report a blocker rather than write a new migration). Until a real
+// bestiary-seeding task (t-008, itself currently blocked on an unrelated new
+// `Creature` table per a 2026-08-25 roadmap correction -- fish are no longer
+// planned to seed into Character at all) lands a canonical field, this
+// derives a fish's ECONOMIC tier as the HIGHEST of its six existing Rarity
+// stats -- deterministic, needs no migration, and defensible ("a fish with
+// any MYTHIC stat behaves as a mythic-tier fish" for income/unlock/feed
+// pricing purposes). Flagged prominently in the PR for reviewer sign-off;
+// this is the one function to swap when a canonical field exists.
+export function deriveFishRarityTier(character: {
+  charm: Rarity
+  empathy: Rarity
+  grace: Rarity
+  luck: Rarity
+  might: Rarity
+  wits: Rarity
+}): Rarity {
+  const stats: Rarity[] = [
+    character.charm,
+    character.empathy,
+    character.grace,
+    character.luck,
+    character.might,
+    character.wits,
+  ]
+  return stats.reduce((best, current) =>
+    rarityRank(current) > rarityRank(best) ? current : best,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Hunger -- economy.yaml `hunger`. Rate gate only, never a loss.
+// ---------------------------------------------------------------------------
+
+export const HUNGER_RANGE = { min: 0, max: 100 } as const
+export const HUNGER_STARTING_VALUE = 100
+export const HUNGER_DECAY_PER_TICK = 1
+
+// Matched top-down: first band whose `min` the hunger value meets or
+// exceeds wins. Order matters -- keep descending by `min`.
+const HUNGER_BANDS: ReadonlyArray<{ min: number; multiplier: number }> = [
+  { min: 50, multiplier: 1.0 },
+  { min: 20, multiplier: 0.5 },
+  { min: 1, multiplier: 0.2 },
+  { min: 0, multiplier: 0.0 },
+]
+
+export function hungerMultiplier(hunger: number): number {
+  for (const band of HUNGER_BANDS) {
+    if (hunger >= band.min) return band.multiplier
+  }
+  return 0
+}
+
+export const FEED_RESTORES_HUNGER_TO = 100
+export const FEED_COST_FACTOR_OF_UNLOCK_COST = 0.2
+
+// Feed cost scales with the fish's own unlock-cost curve ("the food is
+// alive" -- feeding a MYTHIC costs more than feeding a COMMON). Rounded to
+// the nearest coin: cost = round(unlockCost * factor).
+export function feedCost(rarity: Rarity): number {
+  return Math.round(unlockCost(rarity) * FEED_COST_FACTOR_OF_UNLOCK_COST)
+}
+
+// ---------------------------------------------------------------------------
+// Debris -- economy.yaml `debris`. Throttles the tank's shared production
+// rate, never holdings. Tank-wide, not per-fish.
+// ---------------------------------------------------------------------------
+
+export const DEBRIS_RANGE = { min: 0, max: 100 } as const
+export const DEBRIS_STARTING_VALUE = 0
+export const DEBRIS_ACCRUAL_PER_OCCUPANT_PER_TICK = 0.5
+
+const DEBRIS_BANDS: ReadonlyArray<{ min: number; multiplier: number }> = [
+  { min: 80, multiplier: 0.25 },
+  { min: 50, multiplier: 0.5 },
+  { min: 20, multiplier: 0.8 },
+  { min: 0, multiplier: 1.0 },
+]
+
+export function debrisMultiplier(debrisLevel: number): number {
+  for (const band of DEBRIS_BANDS) {
+    if (debrisLevel >= band.min) return band.multiplier
+  }
+  return 1.0
+}
+
+// Manual/set-piece/Sexton cleaning (economy.yaml `debris.clean`) has no
+// endpoint in this task's scope -- t-009's endpoint list is tank/tick/feed/
+// purchase/browse only; a manual "clean" action, if ever added, is a
+// natural follow-up but was not requested here and AquariumSet/Sexton-style
+// fish placement are both explicitly out of scope per the task note.
+
+// ---------------------------------------------------------------------------
+// Offline income -- economy.yaml `offline_income`
+// ---------------------------------------------------------------------------
+
+export const OFFLINE_INCOME_RATE_MULTIPLIER = 0.5
+export const OFFLINE_INCOME_MAX_ACCRUAL_HOURS = 8
+
+// The largest number of ticks any single settlement will ever credit income
+// for, or simulate hunger/debris across. economy.yaml's "beyond this, no
+// further income accrues (return and it resumes)" is implemented in
+// settleTick as: a settlement forfeits any elapsed real time beyond this
+// many ticks rather than banking it for a later call. Safe to reuse as the
+// hunger/debris simulation-loop bound too -- hunger fully floors at 0
+// within HUNGER_STARTING_VALUE / HUNGER_DECAY_PER_TICK = 100 ticks, well
+// inside this cap, so nothing downstream of the cap is ever left
+// meaningfully "unsimulated".
+export const MAX_ACCRUAL_TICKS = Math.floor(
+  (OFFLINE_INCOME_MAX_ACCRUAL_HOURS * 3600) / TICK_SECONDS,
+)
+
+// ---------------------------------------------------------------------------
+// Tick settlement
+// ---------------------------------------------------------------------------
+
+export interface TickFishState {
+  id: number
+  rarity: Rarity
+  hunger: number
+}
+
+export interface TickSettlementInput {
+  lastTickAt: Date | null
+  now: Date
+  debrisLevel: number
+  fish: readonly TickFishState[]
+}
+
+export interface TickSettlementResult {
+  elapsedTicks: number
+  ticksProcessed: number
+  coinsEarned: number
+  newDebrisLevel: number
+  fishHunger: ReadonlyMap<number, number>
+  newLastTickAt: Date
+}
+
+// Settles coins/hunger/debris for every whole tick elapsed since
+// `lastTickAt`, entirely server-side -- the caller never supplies an
+// "earned" amount, only the state to settle FROM. Pure function: callers
+// (server/utils/aquarium.ts) own reading the current row and persisting the
+// result.
+//
+// This is the ONLY production-crediting path this task builds -- there is
+// no separate live/foreground income stream (that would be UI/frontend
+// work, explicitly out of scope for t-009). Per economy.yaml's own framing,
+// everything settled through a single "how much elapsed since we last
+// checked" call IS offline income by construction, so
+// OFFLINE_INCOME_RATE_MULTIPLIER is applied uniformly to every tick
+// credited here, not just ones judged to be a "real" absence. Flagged for
+// reviewer awareness: if a later task adds a live/foreground heartbeat
+// distinct from this settle-on-demand endpoint, that path should NOT apply
+// this discount, and this comment should move with it.
+export function settleTick(input: TickSettlementInput): TickSettlementResult {
+  const tickMs = TICK_SECONDS * 1000
+  const lastTickMs = input.lastTickAt
+    ? input.lastTickAt.getTime()
+    : input.now.getTime()
+  const elapsedMs = Math.max(0, input.now.getTime() - lastTickMs)
+  const elapsedTicks = Math.floor(elapsedMs / tickMs)
+
+  const fishHunger = new Map<number, number>(
+    input.fish.map((fish) => [fish.id, fish.hunger]),
+  )
+
+  if (elapsedTicks <= 0) {
+    return {
+      elapsedTicks: 0,
+      ticksProcessed: 0,
+      coinsEarned: 0,
+      newDebrisLevel: input.debrisLevel,
+      fishHunger,
+      newLastTickAt: input.lastTickAt ?? input.now,
+    }
+  }
+
+  const ticksProcessed = Math.min(elapsedTicks, MAX_ACCRUAL_TICKS)
+  const occupantCount = input.fish.length
+
+  let debrisLevel = input.debrisLevel
+  let grossProduction = 0
+
+  for (let tick = 0; tick < ticksProcessed; tick++) {
+    const debrisMult = debrisMultiplier(debrisLevel)
+
+    for (const fish of input.fish) {
+      const hunger = fishHunger.get(fish.id) ?? 0
+      grossProduction +=
+        incomePerTick(fish.rarity) * hungerMultiplier(hunger) * debrisMult
+      fishHunger.set(
+        fish.id,
+        Math.max(HUNGER_RANGE.min, hunger - HUNGER_DECAY_PER_TICK),
+      )
+    }
+
+    debrisLevel = Math.min(
+      DEBRIS_RANGE.max,
+      debrisLevel + occupantCount * DEBRIS_ACCRUAL_PER_OCCUPANT_PER_TICK,
+    )
+  }
+
+  // Math.floor, not Math.round, on both of these: rounding UP is
+  // exploitable by calling this endpoint in many small increments instead
+  // of one large one (e.g. one fish's gross production per tick is 1 coin;
+  // credited = round(1 * 0.5) = 1 on EVERY single-tick call, so polling
+  // every tick_seconds would double the true 0.5x rate rather than
+  // approximate it). Flooring means a fractional remainder is only ever
+  // lost, never fabricated, regardless of how a client chunks its calls --
+  // the server never pays out more than the elapsed time actually earned.
+  const coinsEarned = Math.floor(
+    grossProduction * OFFLINE_INCOME_RATE_MULTIPLIER,
+  )
+
+  return {
+    elapsedTicks,
+    ticksProcessed,
+    coinsEarned,
+    newDebrisLevel: Math.floor(debrisLevel),
+    fishHunger,
+    // Always advance to `now`, even when ticksProcessed was capped below
+    // elapsedTicks -- the excess elapsed time beyond the cap is forfeited
+    // per economy.yaml ("beyond this, no further income accrues"), not
+    // banked for a later call. Standard idle-game convention.
+    newLastTickAt: input.now,
+  }
+}

--- a/server/utils/aquariumSlug.ts
+++ b/server/utils/aquariumSlug.ts
@@ -1,0 +1,34 @@
+// /server/utils/aquariumSlug.ts
+//
+// Unique-per-owner slug generation for Aquarium, mirroring
+// server/utils/characterSlug.ts's reserveUniqueSlug pattern. Aquarium.slug
+// is @@unique([userId, slug]) (cthulhuquarium/t-032 -- deliberately NOT
+// globally unique, since a global unique constraint collided the moment a
+// second user picked the same tank name), so uniqueness is checked only
+// against the same user's existing tanks.
+
+import { slugify } from '../../utils/slugify'
+import { reserveUniqueSlug } from './characterSlug'
+import prisma from './prisma'
+
+const FALLBACK_BASE = 'tank'
+
+// Picks a slug unique among `userId`'s own Aquarium rows, seeded from
+// `source` (typically the user's username). Falls back to a generic base
+// when `source` slugifies to nothing (e.g. a username that is entirely
+// non-ASCII punctuation).
+export async function getUniqueAquariumSlugForUser(
+  userId: number,
+  source: string,
+): Promise<string> {
+  const base = slugify(source) || FALLBACK_BASE
+
+  const rows = await prisma.aquarium.findMany({
+    where: { userId },
+    select: { slug: true },
+  })
+
+  const taken = new Set(rows.map((row) => row.slug))
+
+  return reserveUniqueSlug(base, taken) ?? `${FALLBACK_BASE}-${Date.now()}`
+}

--- a/utils/scripts/verifyAquariumEconomy.test.ts
+++ b/utils/scripts/verifyAquariumEconomy.test.ts
@@ -1,0 +1,437 @@
+// /utils/scripts/verifyAquariumEconomy.test.ts
+//
+// Regression + property test for cthulhuquarium/t-009's pure balance core.
+// Exercises server/utils/aquariumEconomy.ts's pure calculation functions --
+// no prisma, no database, no Nuxt/H3 runtime -- same discipline as
+// utils/scripts/verifyRevenueSplit.test.ts.
+//
+// Every expected number here should trace back to
+// projects/cthulhuquarium/data/economy.yaml in the conductor repo (see
+// aquariumEconomy.ts's header comment for why the constants are a
+// hand-mirrored TS transcription rather than a runtime YAML parse).
+import assert from 'node:assert/strict'
+
+import {
+  DEBRIS_RANGE,
+  MAX_ACCRUAL_TICKS,
+  OFFLINE_INCOME_RATE_MULTIPLIER,
+  RARITY_TIERS,
+  TICK_SECONDS,
+  debrisMultiplier,
+  deriveFishRarityTier,
+  feedCost,
+  hungerMultiplier,
+  incomePerTick,
+  settleTick,
+  unlockCost,
+} from '../../server/utils/aquariumEconomy.js'
+
+// --- rarity tiers: exact economy.yaml values --------------------------------
+
+assert.equal(TICK_SECONDS, 60)
+
+assert.deepEqual(RARITY_TIERS.COMMON, { incomePerTick: 1, unlockCost: 50 })
+assert.deepEqual(RARITY_TIERS.UNCOMMON, { incomePerTick: 3, unlockCost: 200 })
+assert.deepEqual(RARITY_TIERS.RARE, { incomePerTick: 8, unlockCost: 750 })
+assert.deepEqual(RARITY_TIERS.EPIC, { incomePerTick: 20, unlockCost: 3000 })
+assert.deepEqual(RARITY_TIERS.LEGENDARY, {
+  incomePerTick: 50,
+  unlockCost: 12000,
+})
+assert.deepEqual(RARITY_TIERS.MYTHIC, {
+  incomePerTick: 120,
+  unlockCost: 50000,
+})
+
+assert.equal(incomePerTick('RARE'), 8)
+assert.equal(unlockCost('MYTHIC'), 50000)
+
+console.log('✅ rarity tiers match economy.yaml exactly')
+
+// --- deriveFishRarityTier: highest of the six stat fields wins -------------
+
+assert.equal(
+  deriveFishRarityTier({
+    charm: 'COMMON',
+    empathy: 'COMMON',
+    grace: 'COMMON',
+    luck: 'COMMON',
+    might: 'COMMON',
+    wits: 'COMMON',
+  }),
+  'COMMON',
+)
+
+assert.equal(
+  deriveFishRarityTier({
+    charm: 'COMMON',
+    empathy: 'MYTHIC',
+    grace: 'COMMON',
+    luck: 'COMMON',
+    might: 'RARE',
+    wits: 'COMMON',
+  }),
+  'MYTHIC',
+  'the highest of the six stats determines the derived economic tier',
+)
+
+assert.equal(
+  deriveFishRarityTier({
+    charm: 'RARE',
+    empathy: 'UNCOMMON',
+    grace: 'EPIC',
+    luck: 'UNCOMMON',
+    might: 'RARE',
+    wits: 'COMMON',
+  }),
+  'EPIC',
+)
+
+console.log('✅ deriveFishRarityTier: highest-of-six-stats derivation correct')
+
+// --- hunger multiplier bands (top-down, first band whose min is met) -------
+
+assert.equal(hungerMultiplier(100), 1.0)
+assert.equal(hungerMultiplier(50), 1.0, 'band boundary is inclusive at min')
+assert.equal(hungerMultiplier(49), 0.5)
+assert.equal(hungerMultiplier(20), 0.5, 'band boundary is inclusive at min')
+assert.equal(hungerMultiplier(19), 0.2)
+assert.equal(hungerMultiplier(1), 0.2)
+assert.equal(hungerMultiplier(0), 0.0, 'paused, not punished -- exactly zero')
+assert.equal(
+  hungerMultiplier(-5),
+  0.0,
+  'a defensively out-of-range negative value still falls through to the floor band',
+)
+
+console.log(
+  '✅ hungerMultiplier: all four bands correct at and around their boundaries',
+)
+
+// --- debris multiplier bands ------------------------------------------------
+
+assert.equal(debrisMultiplier(0), 1.0)
+assert.equal(debrisMultiplier(19), 1.0)
+assert.equal(debrisMultiplier(20), 0.8, 'band boundary is inclusive at min')
+assert.equal(debrisMultiplier(49), 0.8)
+assert.equal(debrisMultiplier(50), 0.5)
+assert.equal(debrisMultiplier(79), 0.5)
+assert.equal(debrisMultiplier(80), 0.25)
+assert.equal(
+  debrisMultiplier(100),
+  0.25,
+  'debris production never fully zeroes, per economy.yaml -- floors at 0.25x',
+)
+
+console.log('✅ debrisMultiplier: all four bands correct, never floors to zero')
+
+// --- feedCost: cost_factor_of_unlock_cost * unlockCost, rounded ------------
+
+assert.equal(feedCost('COMMON'), 10, 'round(50 * 0.2) = 10')
+assert.equal(feedCost('MYTHIC'), 10000, 'round(50000 * 0.2) = 10000')
+assert.equal(feedCost('RARE'), 150, 'round(750 * 0.2) = 150')
+
+console.log('✅ feedCost: scales with unlock cost, rounded correctly')
+
+// --- MAX_ACCRUAL_TICKS: 8 hours at 60s/tick = 480 ---------------------------
+
+assert.equal(MAX_ACCRUAL_TICKS, 480)
+
+console.log('✅ MAX_ACCRUAL_TICKS = 480 (8h offline cap at 60s/tick)')
+
+// --- settleTick: no time elapsed -> no-op -----------------------------------
+
+{
+  const now = new Date('2026-08-25T00:00:00Z')
+  const result = settleTick({
+    lastTickAt: now,
+    now,
+    debrisLevel: 0,
+    fish: [{ id: 1, rarity: 'COMMON', hunger: 100 }],
+  })
+  assert.equal(result.elapsedTicks, 0)
+  assert.equal(result.ticksProcessed, 0)
+  assert.equal(result.coinsEarned, 0)
+  assert.equal(result.newDebrisLevel, 0)
+  assert.equal(result.fishHunger.get(1), 100)
+  assert.equal(result.newLastTickAt.getTime(), now.getTime())
+}
+
+console.log('✅ settleTick: zero elapsed time is a true no-op')
+
+// --- settleTick: one tick, one COMMON fish, full hunger, no debris ---------
+
+{
+  const start = new Date('2026-08-25T00:00:00Z')
+  const now = new Date(start.getTime() + TICK_SECONDS * 1000)
+  const result = settleTick({
+    lastTickAt: start,
+    now,
+    debrisLevel: 0,
+    fish: [{ id: 1, rarity: 'COMMON', hunger: 100 }],
+  })
+  // gross = 1 (income) * 1.0 (hunger mult) * 1.0 (debris mult) = 1
+  // credited = floor(1 * 0.5 offline multiplier) = floor(0.5) = 0 -- floor,
+  // not round, so a client cannot double-dip the 0.5x rate by calling this
+  // endpoint in many single-tick increments instead of one large one.
+  assert.equal(result.elapsedTicks, 1)
+  assert.equal(result.ticksProcessed, 1)
+  assert.equal(
+    result.coinsEarned,
+    Math.floor(1 * OFFLINE_INCOME_RATE_MULTIPLIER),
+  )
+  assert.equal(result.coinsEarned, 0)
+  assert.equal(result.fishHunger.get(1), 99, 'hunger decays by 1 per tick')
+  assert.equal(
+    result.newDebrisLevel,
+    0,
+    'one occupant accrues 0.5 debris/tick, but it floors (not rounds) into the Int column -- same anti-double-dip reasoning as coinsEarned',
+  )
+  assert.equal(result.newLastTickAt.getTime(), now.getTime())
+}
+
+console.log(
+  '✅ settleTick: single-tick single-fish production, hunger decay, debris accrual all correct',
+)
+
+// --- settleTick: flooring never lets frequent small calls out-earn one
+// equivalent large call (the exploit the floor-not-round choice prevents) --
+
+{
+  const start = new Date('2026-08-25T00:00:00Z')
+  const twoTicksLater = new Date(start.getTime() + 2 * TICK_SECONDS * 1000)
+
+  // One call settling both ticks at once.
+  const combined = settleTick({
+    lastTickAt: start,
+    now: twoTicksLater,
+    debrisLevel: 0,
+    fish: [{ id: 1, rarity: 'COMMON', hunger: 100 }],
+  })
+
+  // Two calls, one tick each, chained.
+  const oneTickLater = new Date(start.getTime() + TICK_SECONDS * 1000)
+  const first = settleTick({
+    lastTickAt: start,
+    now: oneTickLater,
+    debrisLevel: 0,
+    fish: [{ id: 1, rarity: 'COMMON', hunger: 100 }],
+  })
+  const second = settleTick({
+    lastTickAt: first.newLastTickAt,
+    now: twoTicksLater,
+    debrisLevel: first.newDebrisLevel,
+    fish: [{ id: 1, rarity: 'COMMON', hunger: first.fishHunger.get(1)! }],
+  })
+  const chainedCoins = first.coinsEarned + second.coinsEarned
+  const chainedDebris = second.newDebrisLevel
+
+  assert.ok(
+    chainedCoins <= combined.coinsEarned + 1,
+    `chaining two 1-tick calls must not out-earn one 2-tick call by more than a single unit of floor slop (combined=${combined.coinsEarned}, chained=${chainedCoins})`,
+  )
+  assert.ok(
+    chainedDebris <= combined.newDebrisLevel + 1,
+    `chaining two 1-tick calls must not out-accrue one 2-tick call by more than a single unit of floor slop (combined=${combined.newDebrisLevel}, chained=${chainedDebris})`,
+  )
+}
+
+console.log(
+  '✅ settleTick: flooring prevents frequent small calls from out-earning one equivalent large call',
+)
+
+// --- settleTick: hunger never goes below 0, production stops at hunger 0 ---
+
+{
+  const start = new Date('2026-08-25T00:00:00Z')
+  // 150 ticks: hunger (starting at 100) hits 0 by tick 100 and stays there.
+  const now = new Date(start.getTime() + 150 * TICK_SECONDS * 1000)
+  const result = settleTick({
+    lastTickAt: start,
+    now,
+    debrisLevel: 0,
+    fish: [{ id: 1, rarity: 'COMMON', hunger: 100 }],
+  })
+  assert.equal(
+    result.fishHunger.get(1),
+    0,
+    'hunger floors at 0, never negative',
+  )
+  assert.equal(result.ticksProcessed, 150)
+}
+
+console.log(
+  '✅ settleTick: hunger floors at 0 and stays there across a long gap',
+)
+
+// --- settleTick: debris never exceeds its range max ------------------------
+
+{
+  const start = new Date('2026-08-25T00:00:00Z')
+  const now = new Date(
+    start.getTime() + MAX_ACCRUAL_TICKS * TICK_SECONDS * 1000,
+  )
+  const result = settleTick({
+    lastTickAt: start,
+    now,
+    debrisLevel: 90,
+    fish: [
+      { id: 1, rarity: 'COMMON', hunger: 100 },
+      { id: 2, rarity: 'COMMON', hunger: 100 },
+      { id: 3, rarity: 'COMMON', hunger: 100 },
+    ],
+  })
+  assert.equal(result.newDebrisLevel, DEBRIS_RANGE.max)
+}
+
+console.log('✅ settleTick: debris caps at its range max, never overflows')
+
+// --- settleTick: elapsed time beyond MAX_ACCRUAL_TICKS is capped for income,
+// and lastTickAt always advances fully to `now` (excess forfeited, not
+// banked for a later call) -------------------------------------------------
+
+{
+  const start = new Date('2026-08-25T00:00:00Z')
+  // Far beyond the 8h/480-tick cap.
+  const now = new Date(start.getTime() + 2000 * TICK_SECONDS * 1000)
+  const result = settleTick({
+    lastTickAt: start,
+    now,
+    debrisLevel: 0,
+    fish: [{ id: 1, rarity: 'MYTHIC', hunger: 100 }],
+  })
+  assert.equal(result.elapsedTicks, 2000)
+  assert.equal(
+    result.ticksProcessed,
+    MAX_ACCRUAL_TICKS,
+    'income/simulation ticks are capped at MAX_ACCRUAL_TICKS regardless of how much real time elapsed',
+  )
+  assert.equal(
+    result.newLastTickAt.getTime(),
+    now.getTime(),
+    'lastTickAt always advances fully to now -- excess elapsed time beyond the cap is forfeited, not owed later',
+  )
+}
+
+console.log(
+  '✅ settleTick: offline cap forfeits excess elapsed time and does not bank it',
+)
+
+// --- settleTick: never earns negative coins, never produces NaN ------------
+
+{
+  const start = new Date('2026-08-25T00:00:00Z')
+  const now = new Date(start.getTime() + 5 * TICK_SECONDS * 1000)
+  const result = settleTick({
+    lastTickAt: start,
+    now,
+    debrisLevel: 100,
+    fish: [{ id: 1, rarity: 'COMMON', hunger: 0 }],
+  })
+  assert.equal(
+    result.coinsEarned,
+    0,
+    'a starved fish in a filthy tank earns exactly 0, never negative',
+  )
+  assert.ok(!Number.isNaN(result.coinsEarned))
+}
+
+console.log(
+  '✅ settleTick: starved fish + maxed debris earns exactly 0, never negative or NaN',
+)
+
+// --- settleTick: an empty tank (no fish) is a safe, coin-free no-op on
+// production but still advances lastTickAt and leaves debris untouched
+// (no occupants -> no accrual) -----------------------------------------------
+
+{
+  const start = new Date('2026-08-25T00:00:00Z')
+  const now = new Date(start.getTime() + 10 * TICK_SECONDS * 1000)
+  const result = settleTick({
+    lastTickAt: start,
+    now,
+    debrisLevel: 5,
+    fish: [],
+  })
+  assert.equal(result.coinsEarned, 0)
+  assert.equal(
+    result.newDebrisLevel,
+    5,
+    'zero occupants means zero debris accrual',
+  )
+  assert.equal(result.newLastTickAt.getTime(), now.getTime())
+}
+
+console.log(
+  '✅ settleTick: an empty tank settles safely with zero production and zero debris accrual',
+)
+
+// --- PROPERTY TEST: coinsEarned is always a non-negative integer, hunger is
+// always within [0, 100], debris is always within [0, 100], for a wide
+// sweep of random elapsed windows and fish rosters. ---------------------
+
+function mulberry32(seed: number): () => number {
+  let a = seed
+  return () => {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const RARITIES = [
+  'COMMON',
+  'UNCOMMON',
+  'RARE',
+  'EPIC',
+  'LEGENDARY',
+  'MYTHIC',
+] as const
+
+const rand = mulberry32(20260825)
+const ITERATIONS = 5000
+
+for (let i = 0; i < ITERATIONS; i++) {
+  const start = new Date(2026, 0, 1).getTime()
+  const elapsedTicks = Math.floor(rand() * 3000)
+  const now = new Date(start + elapsedTicks * TICK_SECONDS * 1000)
+  const debrisLevel = Math.floor(rand() * 101)
+  const fishCount = Math.floor(rand() * 6)
+  const fish = Array.from({ length: fishCount }, (_, idx) => ({
+    id: idx + 1,
+    rarity: RARITIES[Math.floor(rand() * RARITIES.length)]!,
+    hunger: Math.floor(rand() * 101),
+  }))
+
+  const result = settleTick({
+    lastTickAt: new Date(start),
+    now,
+    debrisLevel,
+    fish,
+  })
+
+  assert.ok(
+    Number.isInteger(result.coinsEarned) && result.coinsEarned >= 0,
+    `coinsEarned must be a non-negative integer (got ${result.coinsEarned})`,
+  )
+  assert.ok(
+    result.newDebrisLevel >= DEBRIS_RANGE.min &&
+      result.newDebrisLevel <= DEBRIS_RANGE.max,
+    `newDebrisLevel must stay within [${DEBRIS_RANGE.min}, ${DEBRIS_RANGE.max}] (got ${result.newDebrisLevel})`,
+  )
+  for (const h of result.fishHunger.values()) {
+    assert.ok(h >= 0 && h <= 100, `hunger must stay within [0, 100] (got ${h})`)
+  }
+  assert.ok(
+    result.newLastTickAt.getTime() <= now.getTime(),
+    'newLastTickAt must never be after `now`',
+  )
+}
+
+console.log(
+  `✅ settleTick property test: coinsEarned/debris/hunger invariants held across ${ITERATIONS} random scenarios`,
+)
+
+console.log('✅ verifyAquariumEconomy: all assertions passed')


### PR DESCRIPTION
## What changed

Implements `server/api/aquarium/**` for cthulhuquarium/t-009, following the `davinci/runs` API for shape and auth (thin route handlers delegating to a `server/utils` business-logic module).

**Endpoints:**
- `GET /api/aquarium` — the authenticated user's tank, created with default state on first visit (never 404s)
- `POST /api/aquarium/tick` — settles offline income against `lastTickAt`, server-authoritative and capped per the balance spec
- `POST /api/aquarium/feed` — feeds one fish (`{ aquariumStockId }`), restores hunger, charges coins
- `POST /api/aquarium/purchase` — `{ type: 'species', characterId }` unlocks a new fish species
- `GET /api/aquarium/browse` — paginated public tank index (`?take=&skip=`)
- `GET /api/aquarium/browse/[username]/[slug]` — one public tank

All economy math (income/tick, hunger/debris multiplier bands, feed cost, offline-income rate + cap) lives in `server/utils/aquariumEconomy.ts` — a pure, dependency-free module (no prisma) that is a committed TypeScript transcription of conductor's `projects/cthulhuquarium/data/economy.yaml`. `server/utils/aquarium.ts` wires that math to Prisma reads/writes and `AquariumEvent` audit logging (tick/feed/purchase each write an event row).

No `prisma/schema.prisma` changes — built entirely against the existing `Aquarium`/`AquariumStock`/`AquariumEvent`/`Character` models from t-007's merged migration.

## Scope decisions (please confirm these read right)

1. **Public browse is addressed by `(username, slug)`, not slug alone.** `Aquarium.slug` is unique per `(userId, slug)`, not globally — the schema's own t-032 comment explains a global unique constraint caused exactly this collision once before. A bare-slug route would reintroduce that bug the moment two users pick the same tank name.

2. **`purchase` only implements `type: 'species'`.** The task note also named `food` and `upgrade`:
   - `food` — economy.yaml bundles buying and consuming food into one action ("the food is alive"). `POST /api/aquarium/feed` already *is* that purchase, priced identically (`feed.cost_factor_of_unlock_cost * unlock_cost`). A standalone "buy food for later" type has no inventory column to spend from.
   - `upgrade` — economy.yaml's `slots` section states capacity growth is "entirely landmark-driven... never purchased with coins" ("coins buy breadth, milestones buy room"). Inventing a coin price here would contradict the balance spec.
   Both return a `400` with an explanation rather than silently succeeding at a made-up price.

3. **Character has no canonical rarity/tier column.** It has six per-stat `Rarity` fields (charm/empathy/grace/luck/might/wits) from its original chatbot-personality design. t-003's fish bible tracks a separate singular tier/rarity per species, but no matching column exists yet, and adding one would be a schema change this task is explicitly barred from making speculatively. `deriveFishRarityTier()` uses the **highest of the six stats** as a deterministic, no-migration-needed proxy — flagged clearly in code for whoever lands a real field (t-008, itself currently blocked on an unrelated new `Creature` table per a same-day roadmap correction — fish are no longer even planned to seed into `Character`).

4. **`settleTick` floors, not rounds, `coinsEarned`/`debrisLevel`.** Rounding up is exploitable: calling `/tick` in many single-tick increments instead of one large one would otherwise let a client earn roughly 2x by repeatedly hitting `Math.round(0.5) === 1`. Flooring means the server never pays out more than the elapsed time actually earned, however a client chunks its calls. Covered by a dedicated regression test.

5. **The `offline_income` 0.5x rate / 8h cap applies uniformly to every `/tick` call.** This task builds only the settle-on-demand path — there's no separate live/foreground income stream (that's frontend/UI, explicitly out of scope for t-009). Per economy.yaml's own framing, everything settled through a single "how much elapsed since we last checked" call *is* offline income by construction. Flagged in code: if a future task adds a live/foreground heartbeat distinct from this endpoint, that path should NOT apply this discount.

6. No `clean`/debris-manual-clear endpoint — not in t-009's endpoint list, and `AquariumSet`/Sexton-style fish are explicitly out of scope.

## Verification

- `npm run test:aquarium-economy` (new pure-logic regression + 5000-iteration property test over `settleTick`) — **all pass**
- `npx vue-tsc --noEmit -p tsconfig.json` — **zero errors** (full repo run, not just changed files)
- `npx eslint` on all changed files — **zero errors/warnings**
- `npx prettier --check` on all changed files — **clean**
- No existing DB-backed route tests exist for this API family to run; added a lightweight dependency-free `utils/scripts/verifyAquariumEconomy.test.ts` (same pattern as `verifyRevenueSplit.test.ts`) and wired it as `npm run test:aquarium-economy`. Not wired into `contract-tests.yml` — matching the existing precedent that `test:revenue-split` and similar pure-economy tests aren't CI-gated either.

## Stakes

Reversible, additive-only, no schema/migration changes, no other feature's code touched. New API surface only — nothing else in the app calls these routes yet (frontend is separate scope), so there's no behavior change for existing users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SkxR5DbZLD4nYL3gX538Xd)_