### PR TITLE
feat: add Mandarin Tutor study MVP

### DIFF
--- a/components/mandarin/mandarin-voice-coach.vue
+++ b/components/mandarin/mandarin-voice-coach.vue
@@ -141,6 +141,9 @@ let mediaRecorder: MediaRecorder | null = null
 let mediaStream: MediaStream | null = null
 let chunks: Blob[] = []
 let autoStopTimer: ReturnType<typeof setTimeout> | null = null
+let recordingCardKey = ''
+let recordingPinyin = ''
+let disposed = false
 
 const voiceSupported = computed(
   () =>
@@ -216,7 +219,8 @@ async function transcribe(file: File): Promise<string> {
   return heard
 }
 
-async function evaluateRecording(blob: Blob) {
+async function evaluateRecording(blob: Blob, cardKey: string, pinyin: string) {
+  if (disposed || props.card.key !== cardKey) return
   evaluating.value = true
   error.value = null
   const mimeType = blob.type || 'audio/webm'
@@ -230,8 +234,13 @@ async function evaluateRecording(blob: Blob) {
 
   const [transcriptionResult, toneResult] = await Promise.allSettled([
     transcribe(file),
-    analyzeMandarinToneShapes(file, props.card.pinyin),
+    analyzeMandarinToneShapes(file, pinyin),
   ])
+
+  if (disposed || props.card.key !== cardKey) {
+    evaluating.value = false
+    return
+  }
 
   if (transcriptionResult.status === 'fulfilled') {
     transcript.value = transcriptionResult.value
@@ -267,6 +276,8 @@ async function startRecording() {
       },
     })
     chunks = []
+    recordingCardKey = props.card.key
+    recordingPinyin = props.card.pinyin
     const mimeType = preferredMimeType()
     mediaRecorder = mimeType
       ? new MediaRecorder(mediaStream, { mimeType })
@@ -276,13 +287,16 @@ async function startRecording() {
       if (event.data.size > 0) chunks.push(event.data)
     }
     mediaRecorder.onstop = () => {
+      const cardKey = recordingCardKey
+      const pinyin = recordingPinyin
       const blob = new Blob(chunks, {
         type: mediaRecorder?.mimeType || mimeType || 'audio/webm',
       })
       chunks = []
       mediaRecorder = null
       stopMediaStream()
-      if (blob.size > 0) void evaluateRecording(blob)
+      if (disposed || props.card.key !== cardKey) return
+      if (blob.size > 0) void evaluateRecording(blob, cardKey, pinyin)
       else error.value = 'The microphone recording was empty. Try again.'
     }
 
@@ -321,6 +335,7 @@ watch(
 )
 
 onBeforeUnmount(() => {
+  disposed = true
   clearTimer()
   if (mediaRecorder?.state !== 'inactive') mediaRecorder?.stop()
   stopMediaStream()

--- a/components/mandarin/mandarin-voice-coach.vue
+++ b/components/mandarin/mandarin-voice-coach.vue
@@ -1,0 +1,329 @@
+<template>
+  <section class="border-t border-base-300 bg-base-100 p-5 sm:p-7">
+    <div class="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+      <div class="max-w-2xl">
+        <div class="flex flex-wrap items-center gap-2">
+          <h3 class="text-lg font-bold">Say it</h3>
+          <span class="badge badge-outline">voice coach</span>
+        </div>
+        <p class="mt-1 text-sm leading-relaxed opacity-70">
+          Record the word. The speech recognizer reports what it heard without being told the target,
+          while a separate on-device pitch check compares the broad tone shape.
+        </p>
+        <div class="mt-3 flex flex-wrap gap-2">
+          <span
+            v-for="tone in toneTargets"
+            :key="`${tone.syllable}:${tone.spokenTone}`"
+            class="badge badge-lg gap-2 bg-base-200"
+            :title="tone.note || tone.label"
+          >
+            <span class="font-semibold">{{ tone.syllable }}</span>
+            <span aria-hidden="true">{{ tone.arrow }}</span>
+            <span class="text-xs opacity-65">T{{ tone.spokenTone }}</span>
+          </span>
+        </div>
+      </div>
+
+      <div class="flex flex-wrap items-center gap-2">
+        <button
+          v-if="!recording"
+          type="button"
+          class="btn btn-primary"
+          :disabled="evaluating || !voiceSupported"
+          @click="startRecording"
+        >
+          <span v-if="evaluating" class="loading loading-spinner loading-xs" />
+          {{ evaluating ? 'Listening…' : transcript ? 'Try again' : 'Record me' }}
+        </button>
+        <button
+          v-else
+          type="button"
+          class="btn btn-error"
+          @click="stopRecording"
+        >
+          Stop & check
+        </button>
+        <span v-if="recording" class="flex items-center gap-2 text-sm font-semibold text-error" role="status">
+          <span class="h-2.5 w-2.5 animate-pulse rounded-full bg-current" />
+          Recording
+        </span>
+      </div>
+    </div>
+
+    <p v-if="!voiceSupported" class="mt-3 text-sm opacity-60">
+      This browser does not expose microphone recording. The regular pronunciation playback still works.
+    </p>
+    <p v-if="error" class="mt-3 text-sm text-error" role="alert">{{ error }}</p>
+
+    <div v-if="audioUrl" class="mt-4 rounded-2xl border border-base-300 bg-base-200/40 p-4">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p class="text-xs font-semibold uppercase tracking-wide opacity-55">Your recording</p>
+          <p class="text-xs opacity-60">Not saved by Kind Robots. The clip is sent to the configured speech service only for transcription.</p>
+        </div>
+        <audio :src="audioUrl" controls class="h-10 max-w-full" />
+      </div>
+    </div>
+
+    <div v-if="transcript || toneAnalysis" class="mt-4 grid gap-4 lg:grid-cols-2" aria-live="polite">
+      <div class="rounded-2xl border border-base-300 bg-base-200/40 p-4">
+        <p class="text-xs font-semibold uppercase tracking-wide opacity-55">What I heard</p>
+        <p v-if="transcript" class="mt-2 text-2xl font-bold">{{ transcript }}</p>
+        <p v-else class="mt-2 text-sm opacity-60">The transcript was unavailable.</p>
+        <div v-if="comparison" class="mt-3 text-sm leading-relaxed">
+          <span
+            class="badge mr-2"
+            :class="comparison.status === 'match' ? 'badge-success' : comparison.status === 'contains' ? 'badge-warning' : 'badge-error'"
+          >
+            {{ comparison.status === 'match' ? 'heard target' : comparison.status === 'contains' ? 'heard inside phrase' : 'heard differently' }}
+          </span>
+          {{ comparison.message }}
+        </div>
+        <p class="mt-3 text-xs opacity-55">
+          Target: <span class="font-semibold">{{ card.simplified }}</span> · {{ card.pinyin }}
+        </p>
+      </div>
+
+      <div class="rounded-2xl border border-base-300 bg-base-200/40 p-4">
+        <p class="text-xs font-semibold uppercase tracking-wide opacity-55">Rough tone shape</p>
+        <div v-if="toneAnalysis?.observations.length" class="mt-2 space-y-2">
+          <div
+            v-for="observation in toneAnalysis.observations"
+            :key="`${observation.syllable}:${observation.expectedTone}`"
+            class="rounded-xl border border-base-300 bg-base-100 p-3"
+          >
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="text-lg font-bold">{{ observation.syllable }}</span>
+              <span class="badge badge-outline">{{ observation.expectedArrow }} T{{ observation.expectedTone }}</span>
+              <span class="badge" :class="verdictClass(observation.verdict)">
+                heard {{ observation.observedShape }}
+              </span>
+            </div>
+            <p class="mt-1 text-sm leading-relaxed opacity-75">{{ observation.feedback }}</p>
+          </div>
+        </div>
+        <p v-else class="mt-2 text-sm opacity-60">No stable pitch trace was available for this attempt.</p>
+        <p v-if="toneAnalysis" class="mt-3 text-xs leading-relaxed opacity-55">
+          {{ toneAnalysis.note }} Voiced frames: {{ toneAnalysis.voicedPercent }}%.
+        </p>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { performFetch } from '@/stores/utils'
+import { analyzeMandarinToneShapes, type MandarinToneAnalysis } from '@/stores/helpers/mandarinToneAnalysis'
+import {
+  compareMandarinTranscript,
+  parsePinyinToneTargets,
+} from '@/utils/mandarinPronunciation'
+import type { MandarinCard } from '@/utils/mandarin'
+
+const props = defineProps<{
+  card: MandarinCard
+}>()
+
+type TranscriptionData = {
+  transcript?: string
+  model?: string
+}
+
+const recording = ref(false)
+const evaluating = ref(false)
+const error = ref<string | null>(null)
+const transcript = ref('')
+const toneAnalysis = ref<MandarinToneAnalysis | null>(null)
+const audioUrl = ref<string | null>(null)
+
+let mediaRecorder: MediaRecorder | null = null
+let mediaStream: MediaStream | null = null
+let chunks: Blob[] = []
+let autoStopTimer: ReturnType<typeof setTimeout> | null = null
+
+const voiceSupported = computed(
+  () =>
+    import.meta.client &&
+    typeof MediaRecorder !== 'undefined' &&
+    Boolean(navigator.mediaDevices?.getUserMedia),
+)
+
+const toneTargets = computed(() => parsePinyinToneTargets(props.card.pinyin))
+const comparison = computed(() =>
+  transcript.value
+    ? compareMandarinTranscript({
+        transcript: transcript.value,
+        simplified: props.card.simplified,
+        traditional: props.card.traditional,
+      })
+    : null,
+)
+
+function clearTimer() {
+  if (autoStopTimer) clearTimeout(autoStopTimer)
+  autoStopTimer = null
+}
+
+function stopMediaStream() {
+  mediaStream?.getTracks().forEach((track) => track.stop())
+  mediaStream = null
+}
+
+function clearAttempt() {
+  transcript.value = ''
+  toneAnalysis.value = null
+  error.value = null
+  if (audioUrl.value) URL.revokeObjectURL(audioUrl.value)
+  audioUrl.value = null
+}
+
+function preferredMimeType(): string | undefined {
+  const candidates = [
+    'audio/webm;codecs=opus',
+    'audio/mp4',
+    'audio/webm',
+    'audio/ogg;codecs=opus',
+  ]
+  return candidates.find((type) => MediaRecorder.isTypeSupported(type))
+}
+
+function extensionForMimeType(value: string): string {
+  const type = value.split(';')[0]?.toLowerCase()
+  if (type === 'audio/mp4') return 'm4a'
+  if (type === 'audio/ogg') return 'ogg'
+  if (type === 'audio/wav') return 'wav'
+  return 'webm'
+}
+
+async function transcribe(file: File): Promise<string> {
+  const form = new FormData()
+  form.append('audio', file, file.name)
+  const response = await performFetch<TranscriptionData>(
+    '/api/mandarin/pronunciation',
+    {
+      method: 'POST',
+      body: form,
+    },
+    1,
+    45_000,
+  )
+
+  const heard = response.data?.transcript?.trim() || ''
+  if (!response.success || !heard) {
+    throw new Error(response.message || 'The speech recognizer did not return a transcript.')
+  }
+  return heard
+}
+
+async function evaluateRecording(blob: Blob) {
+  evaluating.value = true
+  error.value = null
+  const mimeType = blob.type || 'audio/webm'
+  const extension = extensionForMimeType(mimeType)
+  const file = new File([blob], `mandarin-${Date.now()}.${extension}`, {
+    type: mimeType,
+  })
+
+  if (audioUrl.value) URL.revokeObjectURL(audioUrl.value)
+  audioUrl.value = URL.createObjectURL(blob)
+
+  const [transcriptionResult, toneResult] = await Promise.allSettled([
+    transcribe(file),
+    analyzeMandarinToneShapes(file, props.card.pinyin),
+  ])
+
+  if (transcriptionResult.status === 'fulfilled') {
+    transcript.value = transcriptionResult.value
+  } else {
+    error.value =
+      transcriptionResult.reason instanceof Error
+        ? transcriptionResult.reason.message
+        : 'The speech recognizer could not evaluate this attempt.'
+  }
+
+  if (toneResult.status === 'fulfilled') {
+    toneAnalysis.value = toneResult.value
+  } else if (!error.value) {
+    error.value =
+      toneResult.reason instanceof Error
+        ? toneResult.reason.message
+        : 'Local tone analysis could not evaluate this attempt.'
+  }
+
+  evaluating.value = false
+}
+
+async function startRecording() {
+  if (!voiceSupported.value || evaluating.value) return
+  clearAttempt()
+
+  try {
+    mediaStream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+      },
+    })
+    chunks = []
+    const mimeType = preferredMimeType()
+    mediaRecorder = mimeType
+      ? new MediaRecorder(mediaStream, { mimeType })
+      : new MediaRecorder(mediaStream)
+
+    mediaRecorder.ondataavailable = (event) => {
+      if (event.data.size > 0) chunks.push(event.data)
+    }
+    mediaRecorder.onstop = () => {
+      const blob = new Blob(chunks, {
+        type: mediaRecorder?.mimeType || mimeType || 'audio/webm',
+      })
+      chunks = []
+      mediaRecorder = null
+      stopMediaStream()
+      if (blob.size > 0) void evaluateRecording(blob)
+      else error.value = 'The microphone recording was empty. Try again.'
+    }
+
+    mediaRecorder.start(250)
+    recording.value = true
+    autoStopTimer = setTimeout(() => stopRecording(), 12_000)
+  } catch (cause) {
+    stopMediaStream()
+    error.value =
+      cause instanceof Error
+        ? `Microphone unavailable: ${cause.message}`
+        : 'Microphone access was not available.'
+  }
+}
+
+function stopRecording() {
+  if (!recording.value) return
+  recording.value = false
+  clearTimer()
+  if (mediaRecorder?.state !== 'inactive') mediaRecorder?.stop()
+  else stopMediaStream()
+}
+
+function verdictClass(verdict: MandarinToneAnalysis['observations'][number]['verdict']): string {
+  if (verdict === 'good') return 'badge-success'
+  if (verdict === 'practice') return 'badge-warning'
+  return 'badge-ghost'
+}
+
+watch(
+  () => props.card.key,
+  () => {
+    if (recording.value) stopRecording()
+    clearAttempt()
+  },
+)
+
+onBeforeUnmount(() => {
+  clearTimer()
+  if (mediaRecorder?.state !== 'inactive') mediaRecorder?.stop()
+  stopMediaStream()
+  if (audioUrl.value) URL.revokeObjectURL(audioUrl.value)
+})
+</script>

--- a/components/mandarin/mandarin-voice-coach.vue
+++ b/components/mandarin/mandarin-voice-coach.vue
@@ -65,7 +65,11 @@
       </div>
     </div>
 
-    <div v-if="transcript || toneAnalysis" class="mt-4 grid gap-4 lg:grid-cols-2" aria-live="polite">
+    <div
+      v-if="transcript || toneAnalysis"
+      class="mt-4 grid grid-cols-[repeat(auto-fit,minmax(min(100%,20rem),1fr))] gap-4"
+      aria-live="polite"
+    >
       <div class="rounded-2xl border border-base-300 bg-base-200/40 p-4">
         <p class="text-xs font-semibold uppercase tracking-wide opacity-55">What I heard</p>
         <p v-if="transcript" class="mt-2 text-2xl font-bold">{{ transcript }}</p>

--- a/content/channels/play/mandarin.md
+++ b/content/channels/play/mandarin.md
@@ -1,0 +1,14 @@
+---
+contentType: tab
+channelKey: play
+tabKey: mandarin
+label: Mandarin
+title: Mandarin Tutor
+subtitle: Open the characters and see how they work
+description: Image-ready flashcards with pronunciation, component roles, character history, custom decks, beginner sets, and practical casino Mandarin.
+icon: kind-icon:book-open
+route: /play/mandarin
+sort: 136
+---
+
+Study the word first, then peel back the writing system one layer at a time.

--- a/docs/mandarin-tutor.md
+++ b/docs/mandarin-tutor.md
@@ -23,11 +23,25 @@ A radical is never presented as a complete etymology merely because the dictiona
 
 The first hand-checked starter analyses cover a few high-value semantic-phonetic patterns such as `说`, `妈`, `请`, `清`, and `河`. A broader sourced decomposition/history dataset is Conductor `mandarin-tutor/t-003`.
 
-## Pronunciation
+## Pronunciation playback
 
 Every normalized lexical card has tone-marked pinyin and a pronunciation action. The current web MVP uses the browser's `SpeechSynthesis` Mandarin voice when available so every card is immediately speakable without storing hundreds of generated files.
 
-That playback is intentionally not described as the final audio asset system. Conductor `mandarin-tutor/t-004` owns durable, deterministic per-word audio clips that can be cached and shared by web, iOS, and Android clients.
+That playback is intentionally not described as the final audio asset system. Conductor `mandarin-tutor/t-004` owns durable, deterministic per-word reference audio clips that can be cached and shared by web, iOS, and Android clients.
+
+## Voice practice and correction
+
+The study card also has a record → transcribe → compare → retry loop.
+
+- The browser records a short microphone attempt with `MediaRecorder`.
+- `POST /api/mandarin/pronunciation` accepts that authenticated multipart audio and forwards it to the configured OpenAI transcription service using `gpt-4o-mini-transcribe` with Mandarin language selection.
+- The endpoint intentionally **does not send the target Hanzi or pinyin as an ASR prompt**. “What I heard” is therefore an independent recognition signal rather than a target-biased autocorrection.
+- Kind Robots does not persist the learner's recording. The browser keeps only the current object URL for replay; changing cards or leaving the component drops it.
+- Broad tone-shape analysis happens locally in the browser. `mandarinToneAnalysis.ts` reuses the Music Mentor YIN pitch detector rather than introducing a second pitch algorithm.
+- Tone feedback is deliberately modest: level, rising, falling, dipping, mixed, or insufficient pitch. It handles the common 3 + 3 third-tone sandhi case and avoids a fake numerical “pronunciation score.”
+- Recognition evidence and acoustic evidence remain separate. A transcript mismatch is an intelligibility clue, not proof that a particular consonant or vowel was wrong; a pitch-shape match likewise does not prove the whole pronunciation was native-like.
+
+The MVP uses equal voiced-span syllable partitioning for multi-syllable tone guidance. Forced alignment, phoneme-level consonant/vowel assessment, richer tone-sandhi modeling, and persistent personal pronunciation diagnostics belong in the next pronunciation-depth task rather than being implied by this first pass.
 
 ## Art
 
@@ -37,7 +51,7 @@ The MVP remembers queued ArtJob IDs locally. Durable card-to-ArtImage attachment
 
 ## Learner state
 
-Custom study sets and queued illustration IDs are persisted by `mandarinTutorStore` in local storage. Components never touch local storage or APIs directly. This is an intentionally lightweight first learning loop; portable authenticated mastery/review state is `mandarin-tutor/t-009`.
+Custom study sets and queued illustration IDs are persisted by `mandarinTutorStore` in local storage. Components never touch local storage or APIs directly. Voice-practice recordings are not added to that state. This is an intentionally lightweight first learning loop; portable authenticated mastery/review state is `mandarin-tutor/t-009`.
 
 ## Requested words
 

--- a/docs/mandarin-tutor.md
+++ b/docs/mandarin-tutor.md
@@ -1,0 +1,44 @@
+# Mandarin Tutor
+
+Mandarin Tutor is the Play-channel study surface at `/play/mandarin`.
+
+## Current foundation
+
+The starter catalog normalizes the inclusive new-HSK level 1 and level 2 data from `jelleverheyen/hsk-vocabulary`, pinned to commit `a66fd30b9580da2c2af7eb19e4b9d8099a29c061`. The API refuses to serve the catalog if fewer than 500 unique usable cards survive normalization.
+
+The upstream dataset provides simplified forms, traditional forms, pinyin, meanings, radicals, frequency, parts of speech, and classifiers. Kind Robots overlays curated study-set membership and a small practical vocabulary layer for categories that should not depend on an exam list, especially animals, colors, and casino language.
+
+The upstream repository and its source/attribution information remain the provenance authority for imported dictionary data. Do not strip provenance when the catalog is later vendored or moved into the database.
+
+## Character-analysis rule
+
+The UI deliberately distinguishes:
+
+- semantic components;
+- phonetic components;
+- dictionary/indexing radicals;
+- uncertain or not-yet-sourced historical analysis.
+
+A radical is never presented as a complete etymology merely because the dictionary indexes the character under it. Cards without a vetted decomposition say so instead of generating a mnemonic and labeling it history.
+
+The first hand-checked starter analyses cover a few high-value semantic-phonetic patterns such as `说`, `妈`, `请`, `清`, and `河`. A broader sourced decomposition/history dataset is Conductor `mandarin-tutor/t-003`.
+
+## Pronunciation
+
+Every normalized lexical card has tone-marked pinyin and a pronunciation action. The current web MVP uses the browser's `SpeechSynthesis` Mandarin voice when available so every card is immediately speakable without storing hundreds of generated files.
+
+That playback is intentionally not described as the final audio asset system. Conductor `mandarin-tutor/t-004` owns durable, deterministic per-word audio clips that can be cached and shared by web, iOS, and Android clients.
+
+## Art
+
+A learner can queue a private Krea 2 illustration for the current card. The store calls the existing durable `/api/art/enqueue` path with `projectSlug: mandarin-tutor`; the prompt asks for the concept only and explicitly forbids generated text or Chinese characters.
+
+The MVP remembers queued ArtJob IDs locally. Durable card-to-ArtImage attachment and batch coverage are tracked by `mandarin-tutor/t-005` and `t-010`. Do not create a second render queue.
+
+## Learner state
+
+Custom study sets and queued illustration IDs are persisted by `mandarinTutorStore` in local storage. Components never touch local storage or APIs directly. This is an intentionally lightweight first learning loop; portable authenticated mastery/review state is `mandarin-tutor/t-009`.
+
+## Requested words
+
+The first catalog can search Hanzi, traditional forms, pinyin, and English definitions. Arbitrary words not present in the starter catalog are not synthesized into fake dictionary facts. Structured requested-word creation, with generated fields clearly separated from sourced facts and a Krea 2 request, is `mandarin-tutor/t-005`.

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -203,6 +203,8 @@
                 </div>
               </div>
 
+              <MandarinVoiceCoach :card="currentCard" />
+
               <section v-if="detailsVisible" class="border-t border-base-300 bg-base-200/30 p-5 sm:p-7">
                 <div class="grid gap-5 xl:grid-cols-2">
                   <div class="space-y-3">
@@ -275,6 +277,7 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
 import { storeToRefs } from 'pinia'
+import MandarinVoiceCoach from '@/components/mandarin/mandarin-voice-coach.vue'
 import { useMandarinTutorStore } from '@/stores/mandarinTutorStore'
 import type { MandarinCard, MandarinComponentRole } from '@/utils/mandarin'
 

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -1,0 +1,305 @@
+<template>
+  <div class="kr-surface">
+    <div class="kr-scroll mx-auto max-w-7xl space-y-6 p-4 sm:p-6">
+      <header class="space-y-2">
+        <div class="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p class="text-3xl font-bold">Mandarin Tutor</p>
+            <p class="mt-1 max-w-3xl text-sm opacity-70">
+              Learn the word, hear it, then open the character and see what its pieces are actually doing.
+            </p>
+          </div>
+          <div class="stats stats-horizontal border border-base-300 bg-base-100 shadow-sm">
+            <div class="stat px-4 py-2">
+              <div class="stat-title text-xs">Cards</div>
+              <div class="stat-value text-xl">{{ cards.length }}</div>
+            </div>
+            <div class="stat px-4 py-2">
+              <div class="stat-title text-xs">Sets</div>
+              <div class="stat-value text-xl">{{ allSets.length }}</div>
+            </div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-base-300 bg-base-200/50 p-3 text-xs leading-relaxed opacity-80">
+          Component roles are labeled separately from dictionary radicals. A radical is useful for indexing and pattern recognition, but it is not automatically the historical “meaning” of the whole character.
+        </div>
+      </header>
+
+      <div v-if="store.error" class="alert alert-error text-sm" role="alert">
+        <span>{{ store.error }}</span>
+        <button class="btn btn-sm" type="button" @click="store.loadCatalog()">Retry</button>
+      </div>
+
+      <div v-if="loading && !initialized" class="flex min-h-64 items-center justify-center">
+        <span class="loading loading-spinner loading-lg" />
+      </div>
+
+      <template v-else>
+        <section class="rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm">
+          <div class="flex flex-col gap-3 lg:flex-row lg:items-end">
+            <label class="form-control flex-1">
+              <span class="label-text mb-1 font-semibold">Find a word, Hanzi, pinyin, or English meaning</span>
+              <input
+                v-model="searchQuery"
+                class="input input-bordered w-full"
+                placeholder="说, shuō, speak, casino…"
+                autocomplete="off"
+              />
+            </label>
+            <div class="flex gap-2">
+              <input
+                v-model="newSetName"
+                class="input input-bordered min-w-0"
+                placeholder="New custom set"
+                @keyup.enter="createSet"
+              />
+              <button class="btn btn-outline" type="button" @click="createSet">
+                Create set
+              </button>
+            </div>
+          </div>
+
+          <div v-if="searchQuery.trim()" class="mt-3">
+            <div v-if="searchResults.length" class="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+              <button
+                v-for="card in searchResults"
+                :key="card.key"
+                type="button"
+                class="rounded-xl border border-base-300 bg-base-200/40 p-3 text-left transition hover:border-accent hover:bg-base-200"
+                @click="store.focusCard(card.key)"
+              >
+                <span class="text-2xl font-semibold">{{ card.simplified }}</span>
+                <span class="ml-2 text-sm opacity-65">{{ card.pinyin }}</span>
+                <span class="mt-1 block truncate text-xs opacity-70">{{ card.meaning }}</span>
+              </button>
+            </div>
+            <p v-else class="mt-2 text-sm opacity-60">
+              That term is not in the starter catalog yet. Free-form word creation is tracked separately so generated translations and etymology never masquerade as curated facts.
+            </p>
+          </div>
+        </section>
+
+        <div class="grid gap-5 lg:grid-cols-[18rem_minmax(0,1fr)]">
+          <aside class="space-y-3 lg:sticky lg:top-4 lg:self-start">
+            <div class="rounded-2xl border border-base-300 bg-base-100 p-3 shadow-sm">
+              <div class="mb-2 flex items-center justify-between gap-2">
+                <h2 class="font-bold">Study sets</h2>
+                <span class="badge badge-ghost">{{ selectedSet?.cardKeys.length ?? 0 }}</span>
+              </div>
+              <div class="max-h-[32rem] space-y-1 overflow-y-auto pr-1">
+                <button
+                  v-for="set in allSets"
+                  :key="set.id"
+                  type="button"
+                  class="w-full rounded-xl px-3 py-2 text-left text-sm transition"
+                  :class="set.id === selectedSetId ? 'bg-accent text-accent-content' : 'hover:bg-base-200'"
+                  @click="store.selectSet(set.id)"
+                >
+                  <span class="flex items-center justify-between gap-2">
+                    <span class="font-semibold">{{ set.label }}</span>
+                    <span class="text-xs opacity-70">{{ set.cardKeys.length }}</span>
+                  </span>
+                  <span class="mt-0.5 block text-xs opacity-70">{{ set.description }}</span>
+                </button>
+              </div>
+            </div>
+          </aside>
+
+          <main class="min-w-0 space-y-4">
+            <div v-if="selectedSet" class="flex flex-wrap items-center justify-between gap-2 text-sm">
+              <div>
+                <span class="font-semibold">{{ selectedSet.label }}</span>
+                <span class="ml-2 opacity-60">{{ selectedSet.description }}</span>
+              </div>
+              <button v-if="focusKey" type="button" class="btn btn-ghost btn-sm" @click="store.clearFocus()">
+                Return to deck
+              </button>
+            </div>
+
+            <article
+              v-if="currentCard"
+              class="overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-xl"
+            >
+              <div class="grid md:grid-cols-[minmax(16rem,0.9fr)_minmax(18rem,1.1fr)]">
+                <div class="flex min-h-80 flex-col items-center justify-center gap-4 bg-base-200/70 p-6 text-center">
+                  <div class="flex h-36 w-36 items-center justify-center rounded-3xl border border-base-300 bg-base-100 shadow-inner">
+                    <span class="text-7xl font-semibold leading-none">{{ currentCard.simplified }}</span>
+                  </div>
+                  <div>
+                    <p class="text-2xl font-bold tracking-wide">{{ currentCard.pinyin }}</p>
+                    <p v-if="currentCard.traditional" class="mt-1 text-sm opacity-60">
+                      Traditional: <span class="text-lg">{{ currentCard.traditional }}</span>
+                    </p>
+                  </div>
+                  <button type="button" class="btn btn-accent" @click="store.speak(currentCard)">
+                    Hear pronunciation
+                  </button>
+                  <p v-if="store.speechError" class="text-xs text-error">{{ store.speechError }}</p>
+                  <p v-else-if="!audioSupported" class="text-xs opacity-60">
+                    This browser does not expose speech synthesis.
+                  </p>
+                </div>
+
+                <div class="flex min-h-80 flex-col p-5 sm:p-7">
+                  <div class="flex flex-wrap gap-2">
+                    <span v-if="currentCard.hskLevel" class="badge badge-outline">HSK {{ currentCard.hskLevel }}</span>
+                    <span v-if="currentCard.radical" class="badge badge-outline">Radical {{ currentCard.radical }}</span>
+                    <span v-for="category in currentCard.categories.slice(0, 4)" :key="category" class="badge badge-ghost">
+                      {{ category }}
+                    </span>
+                  </div>
+
+                  <div class="my-auto py-8 text-center">
+                    <button
+                      v-if="!meaningVisible"
+                      type="button"
+                      class="btn btn-primary btn-lg"
+                      @click="store.toggleMeaning()"
+                    >
+                      Reveal meaning
+                    </button>
+                    <div v-else class="space-y-2">
+                      <p class="text-3xl font-bold">{{ currentCard.meaning }}</p>
+                      <p v-if="currentCard.meanings.length > 1" class="mx-auto max-w-xl text-sm leading-relaxed opacity-65">
+                        {{ currentCard.meanings.slice(1).join(' · ') }}
+                      </p>
+                    </div>
+                  </div>
+
+                  <div class="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                    <button type="button" class="btn btn-outline" @click="store.previousCard()">Previous</button>
+                    <button type="button" class="btn btn-outline" @click="store.nextCard()">Next</button>
+                    <button type="button" class="btn btn-outline" @click="store.toggleDetails()">
+                      {{ detailsVisible ? 'Hide parts' : 'Parts & history' }}
+                    </button>
+                    <button
+                      type="button"
+                      class="btn btn-outline"
+                      :disabled="Boolean(store.artQueueingKey)"
+                      @click="store.queueIllustration(currentCard)"
+                    >
+                      <span v-if="store.artQueueingKey === currentCard.key" class="loading loading-spinner loading-xs" />
+                      {{ store.illustrationJobId(currentCard.key) ? `ArtJob #${store.illustrationJobId(currentCard.key)}` : 'Queue Krea 2 art' }}
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              <section v-if="detailsVisible" class="border-t border-base-300 bg-base-200/30 p-5 sm:p-7">
+                <div class="grid gap-5 xl:grid-cols-2">
+                  <div class="space-y-3">
+                    <h3 class="text-lg font-bold">What is this built from?</h3>
+                    <div v-if="currentCard.components.length" class="grid gap-2 sm:grid-cols-2">
+                      <div
+                        v-for="component in currentCard.components"
+                        :key="`${component.glyph}:${component.role}`"
+                        class="rounded-2xl border border-base-300 bg-base-100 p-4"
+                      >
+                        <div class="flex items-start gap-3">
+                          <span class="text-4xl font-semibold">{{ component.glyph }}</span>
+                          <div>
+                            <p class="font-semibold">{{ component.label }}</p>
+                            <p class="text-xs uppercase tracking-wide opacity-55">{{ roleLabel(component.role) }}</p>
+                            <p v-if="component.meaning" class="mt-1 text-sm">{{ component.meaning }}</p>
+                          </div>
+                        </div>
+                        <p v-if="component.note" class="mt-2 text-xs leading-relaxed opacity-70">{{ component.note }}</p>
+                      </div>
+                    </div>
+                    <p v-else class="rounded-xl border border-base-300 bg-base-100 p-4 text-sm opacity-65">
+                      A source-backed decomposition has not been attached to this card yet. The tutor leaves that blank rather than inventing a memorable story and calling it history.
+                    </p>
+                  </div>
+
+                  <div class="space-y-3">
+                    <h3 class="text-lg font-bold">How did the character get here?</h3>
+                    <p v-if="currentCard.history" class="rounded-2xl border border-base-300 bg-base-100 p-4 text-sm leading-relaxed">
+                      {{ currentCard.history }}
+                    </p>
+                    <p v-else class="rounded-2xl border border-base-300 bg-base-100 p-4 text-sm leading-relaxed opacity-65">
+                      Historical development is pending a dedicated decomposition source. The current radical, when shown, is an indexing clue rather than an etymological claim.
+                    </p>
+                    <div class="text-xs opacity-55">
+                      Source: {{ currentCard.source.label }} · {{ currentCard.source.version }}
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <section class="border-t border-base-300 p-5 sm:p-7">
+                <div class="flex flex-wrap items-center gap-2">
+                  <span class="mr-1 text-sm font-semibold">Save this card to:</span>
+                  <button
+                    v-for="set in customSets"
+                    :key="set.id"
+                    type="button"
+                    class="btn btn-sm"
+                    :class="store.cardIsInCustomSet(set.id, currentCard.key) ? 'btn-accent' : 'btn-outline'"
+                    @click="store.toggleCardInCustomSet(set.id, currentCard.key)"
+                  >
+                    {{ set.name }}
+                  </button>
+                  <span v-if="!customSets.length" class="text-xs opacity-55">Create a custom set above to collect cards.</span>
+                </div>
+              </section>
+            </article>
+
+            <div v-else class="rounded-2xl border border-base-300 bg-base-100 p-8 text-center opacity-65">
+              This set has no cards yet.
+            </div>
+          </main>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useMandarinTutorStore } from '@/stores/mandarinTutorStore'
+import type { MandarinComponentRole } from '@/utils/mandarin'
+
+const store = useMandarinTutorStore()
+const {
+  cards,
+  allSets,
+  customSets,
+  selectedSetId,
+  selectedSet,
+  currentCard,
+  searchQuery,
+  searchResults,
+  focusKey,
+  meaningVisible,
+  detailsVisible,
+  loading,
+  initialized,
+  audioSupported,
+} = storeToRefs(store)
+
+const newSetName = ref('')
+
+function createSet() {
+  const created = store.createCustomSet(newSetName.value)
+  if (!created) return
+  newSetName.value = ''
+  store.selectSet(`custom:${created.id}`)
+}
+
+function roleLabel(role: MandarinComponentRole): string {
+  if (role === 'semantic') return 'meaning clue'
+  if (role === 'phonetic') return 'sound clue'
+  if (role === 'radical') return 'indexing radical'
+  if (role === 'form') return 'written form'
+  return 'uncertain role'
+}
+
+onMounted(() => {
+  void store.initialize()
+})
+
+useHead({
+  title: 'Mandarin Tutor · Kind Robots',
+})
+</script>

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -122,8 +122,20 @@
             >
               <div class="grid md:grid-cols-[minmax(16rem,0.9fr)_minmax(18rem,1.1fr)]">
                 <div class="flex min-h-80 flex-col items-center justify-center gap-4 bg-base-200/70 p-6 text-center">
-                  <div class="flex h-36 w-36 items-center justify-center rounded-3xl border border-base-300 bg-base-100 shadow-inner">
-                    <span class="text-7xl font-semibold leading-none">{{ currentCard.simplified }}</span>
+                  <div class="relative flex h-56 w-56 items-center justify-center overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-inner">
+                    <img
+                      v-if="store.illustrationUrl(currentCard.key)"
+                      :src="store.illustrationUrl(currentCard.key) || ''"
+                      :alt="`Generated study illustration for ${currentCard.meaning}`"
+                      class="h-full w-full object-cover"
+                    />
+                    <span v-else class="text-7xl font-semibold leading-none">{{ currentCard.simplified }}</span>
+                    <span
+                      v-if="store.illustrationUrl(currentCard.key)"
+                      class="absolute bottom-2 right-2 rounded-xl bg-base-100/90 px-3 py-1 text-3xl font-semibold shadow"
+                    >
+                      {{ currentCard.simplified }}
+                    </span>
                   </div>
                   <div>
                     <p class="text-2xl font-bold tracking-wide">{{ currentCard.pinyin }}</p>
@@ -175,13 +187,19 @@
                     <button
                       type="button"
                       class="btn btn-outline"
-                      :disabled="Boolean(store.artQueueingKey)"
-                      @click="store.queueIllustration(currentCard)"
+                      :disabled="Boolean(store.artQueueingKey || store.artRefreshingKey || store.illustrationUrl(currentCard.key))"
+                      @click="artAction(currentCard)"
                     >
-                      <span v-if="store.artQueueingKey === currentCard.key" class="loading loading-spinner loading-xs" />
-                      {{ store.illustrationJobId(currentCard.key) ? `ArtJob #${store.illustrationJobId(currentCard.key)}` : 'Queue Krea 2 art' }}
+                      <span
+                        v-if="store.artQueueingKey === currentCard.key || store.artRefreshingKey === currentCard.key"
+                        class="loading loading-spinner loading-xs"
+                      />
+                      {{ artActionLabel(currentCard) }}
                     </button>
                   </div>
+                  <p v-if="store.illustrationStatus(currentCard.key)" class="mt-2 text-right text-xs opacity-60">
+                    Illustration: {{ store.illustrationStatus(currentCard.key) }}
+                  </p>
                 </div>
               </div>
 
@@ -258,7 +276,7 @@
 import { onMounted, ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useMandarinTutorStore } from '@/stores/mandarinTutorStore'
-import type { MandarinComponentRole } from '@/utils/mandarin'
+import type { MandarinCard, MandarinComponentRole } from '@/utils/mandarin'
 
 const store = useMandarinTutorStore()
 const {
@@ -285,6 +303,21 @@ function createSet() {
   if (!created) return
   newSetName.value = ''
   store.selectSet(`custom:${created.id}`)
+}
+
+async function artAction(card: MandarinCard) {
+  if (store.illustrationUrl(card.key)) return
+  if (store.illustrationJobId(card.key)) {
+    await store.refreshIllustration(card)
+    return
+  }
+  await store.queueIllustration(card)
+}
+
+function artActionLabel(card: MandarinCard): string {
+  if (store.illustrationUrl(card.key)) return 'Art ready'
+  const jobId = store.illustrationJobId(card.key)
+  return jobId ? `Refresh ArtJob #${jobId}` : 'Queue Krea 2 art'
 }
 
 function roleLabel(role: MandarinComponentRole): string {

--- a/server/api/mandarin/index.get.ts
+++ b/server/api/mandarin/index.get.ts
@@ -1,0 +1,25 @@
+import { defineEventHandler, setHeader } from 'h3'
+import { errorHandler } from '../../utils/error'
+import { getMandarinCatalog } from '../../utils/mandarinCatalog'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const catalog = await getMandarinCatalog()
+    setHeader(event, 'Cache-Control', 'public, max-age=300, stale-while-revalidate=3600')
+    return {
+      success: true,
+      statusCode: 200,
+      message: `${catalog.cards.length} Mandarin cards ready to study.`,
+      data: catalog,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      statusCode: handled.statusCode || 500,
+      message: handled.message || 'Failed to load the Mandarin starter catalog.',
+      data: null,
+    }
+  }
+})

--- a/server/api/mandarin/pronunciation.post.ts
+++ b/server/api/mandarin/pronunciation.post.ts
@@ -1,0 +1,170 @@
+import {
+  createError,
+  defineEventHandler,
+  getHeader,
+  readMultipartFormData,
+} from 'h3'
+import { requireApiUser } from '../../utils/authGuard'
+import { errorHandler } from '../../utils/error'
+import { manaGate } from '../../utils/manaGate'
+import { safeFetch } from '../../utils/safeFetch'
+import {
+  assertProviderApiKey,
+  getRuntimeOpenAiKey,
+  readJsonWithSizeCap,
+} from '../../utils/textProviderService'
+
+const MAX_AUDIO_BYTES = 6 * 1024 * 1024
+const MAX_REQUEST_BYTES = MAX_AUDIO_BYTES + 512 * 1024
+const MAX_TRANSCRIPT_BYTES = 64 * 1024
+const TRANSCRIPTION_MODEL = 'gpt-4o-mini-transcribe'
+
+const ALLOWED_AUDIO_TYPES = new Set([
+  'audio/webm',
+  'audio/ogg',
+  'audio/mp4',
+  'audio/mpeg',
+  'audio/mp3',
+  'audio/wav',
+  'audio/x-wav',
+  'audio/m4a',
+  'audio/x-m4a',
+])
+
+type TranscriptionPayload = {
+  text?: unknown
+}
+
+function assertRequestSize(event: Parameters<typeof getHeader>[0]): void {
+  const contentLength = Number(getHeader(event, 'content-length') || 0)
+  if (Number.isFinite(contentLength) && contentLength > MAX_REQUEST_BYTES) {
+    throw createError({
+      statusCode: 413,
+      message: 'Pronunciation recording is too large. Keep practice clips short.',
+    })
+  }
+}
+
+function cleanMimeType(value: string | undefined): string {
+  return String(value || '')
+    .split(';')[0]
+    ?.trim()
+    .toLowerCase() || ''
+}
+
+function extensionForMimeType(mimeType: string): string {
+  if (mimeType === 'audio/webm') return 'webm'
+  if (mimeType === 'audio/ogg') return 'ogg'
+  if (mimeType === 'audio/mp4' || mimeType === 'audio/m4a' || mimeType === 'audio/x-m4a') return 'm4a'
+  if (mimeType === 'audio/mpeg' || mimeType === 'audio/mp3') return 'mp3'
+  return 'wav'
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireApiUser(event)
+    assertRequestSize(event)
+
+    const form = await readMultipartFormData(event)
+    const audio = form?.find((field) => field.name === 'audio' || field.name === 'file')
+
+    if (!audio?.data?.length) {
+      throw createError({
+        statusCode: 400,
+        message: 'No pronunciation recording was received.',
+      })
+    }
+
+    if (audio.data.length > MAX_AUDIO_BYTES) {
+      throw createError({
+        statusCode: 413,
+        message: 'Pronunciation recording is too large. Keep practice clips short.',
+      })
+    }
+
+    const mimeType = cleanMimeType(audio.type)
+    if (!ALLOWED_AUDIO_TYPES.has(mimeType)) {
+      throw createError({
+        statusCode: 415,
+        message: `Unsupported pronunciation audio type: ${mimeType || 'unknown'}.`,
+      })
+    }
+
+    const config = useRuntimeConfig()
+    const apiKey = getRuntimeOpenAiKey(config)
+    assertProviderApiKey({
+      apiKey,
+      providerLabel: 'OpenAI',
+      expectedPrefix: 'sk-',
+    })
+
+    // A short practice utterance is normally only a few seconds. This estimate
+    // intentionally rounds above the current mini-transcription per-minute rate;
+    // manaGate itself enforces the app's minimum non-free charge.
+    const gate = await manaGate(event, {
+      kind: 'text',
+      estCostUsd: 0.002,
+    })
+
+    const upstreamForm = new FormData()
+    const audioBytes = Uint8Array.from(audio.data)
+    const extension = extensionForMimeType(mimeType)
+    upstreamForm.append(
+      'file',
+      new Blob([audioBytes], { type: mimeType }),
+      audio.filename || `mandarin-practice.${extension}`,
+    )
+    upstreamForm.append('model', TRANSCRIPTION_MODEL)
+    upstreamForm.append('language', 'zh')
+    upstreamForm.append('response_format', 'json')
+
+    // Deliberately do not send the target Hanzi or pinyin as a transcription
+    // prompt. The learner needs to see what the recognizer actually heard, not
+    // a target-biased guess that quietly autocorrects the attempt.
+    const upstream = await safeFetch(
+      'https://api.openai.com/v1/audio/transcriptions',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: upstreamForm,
+      },
+      { connectTimeoutMs: 30_000 },
+    )
+
+    const payload = (await readJsonWithSizeCap(
+      upstream,
+      MAX_TRANSCRIPT_BYTES,
+    )) as TranscriptionPayload
+
+    if (!upstream.ok) {
+      throw createError({
+        statusCode: upstream.status,
+        message: `Mandarin transcription failed with status ${upstream.status}.`,
+      })
+    }
+
+    const transcript = typeof payload.text === 'string' ? payload.text.trim() : ''
+    if (!transcript) {
+      throw createError({
+        statusCode: 422,
+        message: 'The recording was received, but no Mandarin speech was recognized.',
+      })
+    }
+
+    await gate.commit(`mandarin-pronunciation:${Date.now()}`)
+
+    return {
+      success: true,
+      statusCode: 200,
+      message: 'Pronunciation recording transcribed.',
+      data: {
+        transcript,
+        model: TRANSCRIPTION_MODEL,
+      },
+    }
+  } catch (error) {
+    return errorHandler(error)
+  }
+})

--- a/server/utils/mandarinCatalog.ts
+++ b/server/utils/mandarinCatalog.ts
@@ -106,7 +106,9 @@ function normalizeSourceEntry(entry: SourceEntry, level: number): MandarinCard |
     meanings: selectedMeanings.slice(0, 6),
     kind: [...simplified].length === 1 ? 'character' : 'word',
     ...(radical ? { radical } : {}),
-    ...(Number.isFinite(entry.q) ? { frequency: Number(entry.q) } : {}),
+    ...(typeof entry.q === 'number' && Number.isFinite(entry.q)
+      ? { frequency: entry.q }
+      : {}),
     hskLevel: level,
     partsOfSpeech: Array.isArray(entry.p) ? entry.p.filter(Boolean) : [],
     classifiers: Array.isArray(form.c) ? form.c.filter(Boolean) : [],
@@ -119,10 +121,13 @@ function normalizeSourceEntry(entry: SourceEntry, level: number): MandarinCard |
 }
 
 async function fetchLevel(level: number): Promise<MandarinCard[]> {
-  const entries = await $fetch<SourceEntry[]>(`${SOURCE_BASE}/${level}.min.json`, {
-    retry: 2,
-    timeout: 20_000,
-  })
+  const entries = await $fetch<SourceEntry[], string>(
+    `${SOURCE_BASE}/${level}.min.json`,
+    {
+      retry: 2,
+      timeout: 20_000,
+    },
+  )
   if (!Array.isArray(entries)) throw new Error(`HSK level ${level} source was not an array.`)
   return entries
     .map((entry) => normalizeSourceEntry(entry, level))
@@ -182,9 +187,11 @@ function buildSets(cards: MandarinCard[]): MandarinStudySet[] {
     },
     {
       id: 'hsk-2',
-      label: 'HSK 2 vocabulary',
-      description: 'Level 2 vocabulary, including level 1 words where the source is inclusive.',
-      cardKeys: cards.filter((card) => card.hskLevel === 2).map((card) => card.key),
+      label: 'HSK 1–2 vocabulary',
+      description: 'The cumulative beginner vocabulary through HSK level 2.',
+      cardKeys: cards
+        .filter((card) => (card.hskLevel ?? 99) <= 2)
+        .map((card) => card.key),
     },
   ]
 

--- a/server/utils/mandarinCatalog.ts
+++ b/server/utils/mandarinCatalog.ts
@@ -1,0 +1,227 @@
+import {
+  BUILT_IN_SET_META,
+  BUILT_IN_SET_TERMS,
+  CURATED_MANDARIN_CARDS,
+  MANDARIN_SOURCE,
+  STARTER_COMPONENT_GUIDES,
+  type MandarinCard,
+  type MandarinCatalogPayload,
+  type MandarinStudySet,
+} from '~/utils/mandarin'
+
+type SourcePronunciation = {
+  y?: string
+  n?: string
+}
+
+type SourceForm = {
+  t?: string
+  i?: SourcePronunciation
+  m?: string[]
+  c?: string[]
+}
+
+type SourceEntry = {
+  s?: string
+  r?: string
+  q?: number
+  p?: string[]
+  f?: SourceForm[]
+}
+
+const SOURCE_COMMIT = 'a66fd30b9580da2c2af7eb19e4b9d8099a29c061'
+const SOURCE_BASE = `https://raw.githubusercontent.com/jelleverheyen/hsk-vocabulary/${SOURCE_COMMIT}/wordlists/inclusive/new`
+const MINIMUM_CARD_COUNT = 500
+let catalogPromise: Promise<MandarinCatalogPayload> | null = null
+
+function cleanText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function pedagogicalMeaning(value: string): boolean {
+  const lower = value.toLowerCase()
+  return !(
+    lower.startsWith('surname ') ||
+    lower.startsWith('variant of ') ||
+    lower.startsWith('old variant of ') ||
+    lower.startsWith('archaic variant of ')
+  )
+}
+
+function scoreForm(form: SourceForm): number {
+  const meanings = Array.isArray(form.m) ? form.m.filter(Boolean) : []
+  const pinyin = cleanText(form.i?.y)
+  const usefulMeanings = meanings.filter(pedagogicalMeaning)
+  let score = usefulMeanings.length * 4 + meanings.length
+  if (pinyin && pinyin[0] === pinyin[0]?.toLowerCase()) score += 3
+  if (meanings.some((meaning) => meaning.toLowerCase().startsWith('surname '))) score -= 8
+  if (meanings.every((meaning) => !pedagogicalMeaning(meaning))) score -= 20
+  return score
+}
+
+function chooseForm(forms: SourceForm[]): SourceForm | null {
+  return (
+    [...forms]
+      .filter((form) => cleanText(form.i?.y) && Array.isArray(form.m) && form.m.length)
+      .sort((a, b) => scoreForm(b) - scoreForm(a))[0] ?? null
+  )
+}
+
+function normalizeSourceEntry(entry: SourceEntry, level: number): MandarinCard | null {
+  const simplified = cleanText(entry.s)
+  if (!simplified) return null
+  const forms = Array.isArray(entry.f) ? entry.f : []
+  const form = chooseForm(forms)
+  if (!form) return null
+
+  const meanings = (form.m ?? []).map(cleanText).filter(Boolean)
+  const usefulMeanings = meanings.filter(pedagogicalMeaning)
+  const selectedMeanings = usefulMeanings.length ? usefulMeanings : meanings
+  const meaning = selectedMeanings[0]
+  const pinyin = cleanText(form.i?.y)
+  if (!meaning || !pinyin) return null
+
+  const traditional = cleanText(form.t)
+  const radical = cleanText(entry.r)
+  const guide = STARTER_COMPONENT_GUIDES[simplified]
+  const components = guide
+    ? guide.components
+    : radical && radical !== simplified
+      ? [
+          {
+            glyph: radical,
+            role: 'radical' as const,
+            label: 'dictionary radical',
+            note: 'Useful for indexing and pattern recognition, but not by itself a complete etymology.',
+          },
+        ]
+      : []
+
+  return {
+    key: `hsk:${level}:${simplified}`,
+    simplified,
+    ...(traditional && traditional !== simplified ? { traditional } : {}),
+    pinyin,
+    meaning,
+    meanings: selectedMeanings.slice(0, 6),
+    kind: [...simplified].length === 1 ? 'character' : 'word',
+    ...(radical ? { radical } : {}),
+    ...(Number.isFinite(entry.q) ? { frequency: Number(entry.q) } : {}),
+    hskLevel: level,
+    partsOfSpeech: Array.isArray(entry.p) ? entry.p.filter(Boolean) : [],
+    classifiers: Array.isArray(form.c) ? form.c.filter(Boolean) : [],
+    categories: ['beginner', `hsk-${level}`],
+    components,
+    ...(guide ? { history: guide.history } : {}),
+    historyStatus: guide ? 'starter' : 'pending',
+    source: MANDARIN_SOURCE,
+  }
+}
+
+async function fetchLevel(level: number): Promise<MandarinCard[]> {
+  const entries = await $fetch<SourceEntry[]>(`${SOURCE_BASE}/${level}.min.json`, {
+    retry: 2,
+    timeout: 20_000,
+  })
+  if (!Array.isArray(entries)) throw new Error(`HSK level ${level} source was not an array.`)
+  return entries
+    .map((entry) => normalizeSourceEntry(entry, level))
+    .filter((card): card is MandarinCard => Boolean(card))
+}
+
+function mergeCards(sourceCards: MandarinCard[]): MandarinCard[] {
+  const bySimplified = new Map<string, MandarinCard>()
+
+  for (const card of sourceCards) {
+    if (!bySimplified.has(card.simplified)) bySimplified.set(card.simplified, card)
+  }
+
+  for (const curated of CURATED_MANDARIN_CARDS) {
+    const existing = bySimplified.get(curated.simplified)
+    if (!existing) {
+      bySimplified.set(curated.simplified, curated)
+      continue
+    }
+    existing.categories = [...new Set([...existing.categories, ...curated.categories])]
+  }
+
+  for (const [setId, terms] of Object.entries(BUILT_IN_SET_TERMS)) {
+    for (const term of terms) {
+      const card = bySimplified.get(term)
+      if (card && !card.categories.includes(setId)) card.categories.push(setId)
+    }
+  }
+
+  return [...bySimplified.values()].sort((a, b) => {
+    const levelA = a.hskLevel ?? 99
+    const levelB = b.hskLevel ?? 99
+    if (levelA !== levelB) return levelA - levelB
+    return (a.frequency ?? 1_000_000) - (b.frequency ?? 1_000_000)
+  })
+}
+
+function buildSets(cards: MandarinCard[]): MandarinStudySet[] {
+  const bySimplified = new Map(cards.map((card) => [card.simplified, card]))
+  const starterKeys = cards
+    .filter((card) => card.hskLevel === 1 || card.hskLevel === 2)
+    .slice(0, 500)
+    .map((card) => card.key)
+
+  const sets: MandarinStudySet[] = [
+    {
+      id: 'starter-500',
+      label: 'Starter 500',
+      description: 'A frequency-aware first 500 drawn from the beginner HSK vocabulary pool.',
+      cardKeys: starterKeys,
+    },
+    {
+      id: 'hsk-1',
+      label: 'HSK 1 vocabulary',
+      description: 'Words tagged in the pinned HSK level 1 source.',
+      cardKeys: cards.filter((card) => card.hskLevel === 1).map((card) => card.key),
+    },
+    {
+      id: 'hsk-2',
+      label: 'HSK 2 vocabulary',
+      description: 'Level 2 vocabulary, including level 1 words where the source is inclusive.',
+      cardKeys: cards.filter((card) => card.hskLevel === 2).map((card) => card.key),
+    },
+  ]
+
+  for (const [id, terms] of Object.entries(BUILT_IN_SET_TERMS)) {
+    const meta = BUILT_IN_SET_META[id]
+    if (!meta) continue
+    sets.push({
+      id,
+      label: meta.label,
+      description: meta.description,
+      cardKeys: [...new Set(terms.map((term) => bySimplified.get(term)?.key).filter(Boolean))] as string[],
+    })
+  }
+
+  return sets.filter((set) => set.cardKeys.length > 0)
+}
+
+async function createCatalog(): Promise<MandarinCatalogPayload> {
+  const [levelOne, levelTwo] = await Promise.all([fetchLevel(1), fetchLevel(2)])
+  const cards = mergeCards([...levelOne, ...levelTwo])
+  if (cards.length < MINIMUM_CARD_COUNT) {
+    throw new Error(
+      `Mandarin starter catalog only normalized ${cards.length} cards; expected at least ${MINIMUM_CARD_COUNT}.`,
+    )
+  }
+
+  return {
+    cards,
+    sets: buildSets(cards),
+    source: MANDARIN_SOURCE,
+  }
+}
+
+export function getMandarinCatalog(): Promise<MandarinCatalogPayload> {
+  catalogPromise ??= createCatalog().catch((error) => {
+    catalogPromise = null
+    throw error
+  })
+  return catalogPromise
+}

--- a/stores/helpers/mandarinToneAnalysis.ts
+++ b/stores/helpers/mandarinToneAnalysis.ts
@@ -1,0 +1,287 @@
+import { detectPitchYIN } from './audioAnalysisHelper'
+import {
+  parsePinyinToneTargets,
+  type MandarinToneNumber,
+} from '@/utils/mandarinPronunciation'
+
+export type ObservedToneShape =
+  | 'level'
+  | 'rising'
+  | 'falling'
+  | 'dipping'
+  | 'mixed'
+  | 'unvoiced'
+
+export type MandarinToneObservation = {
+  syllable: string
+  expectedTone: MandarinToneNumber
+  expectedLabel: string
+  expectedArrow: string
+  observedShape: ObservedToneShape
+  verdict: 'good' | 'practice' | 'uncertain'
+  feedback: string
+}
+
+export type MandarinToneAnalysis = {
+  durationSec: number
+  voicedPercent: number
+  observations: MandarinToneObservation[]
+  note: string
+}
+
+type PitchPoint = {
+  timeSec: number
+  hz: number
+}
+
+const FRAME_SIZE = 1024
+const HOP_SIZE = 256
+
+function getAudioContextCtor(): typeof AudioContext | null {
+  if (typeof window === 'undefined') return null
+  const candidate = window as typeof window & {
+    webkitAudioContext?: typeof AudioContext
+  }
+  return window.AudioContext || candidate.webkitAudioContext || null
+}
+
+async function decodeMono(file: File): Promise<{
+  samples: Float32Array
+  sampleRate: number
+  durationSec: number
+}> {
+  const Ctx = getAudioContextCtor()
+  if (!Ctx) throw new Error('This browser cannot analyze microphone pitch.')
+
+  const context = new Ctx()
+  try {
+    const decoded = await context.decodeAudioData((await file.arrayBuffer()).slice(0))
+    const samples = new Float32Array(decoded.length)
+
+    for (let channel = 0; channel < decoded.numberOfChannels; channel++) {
+      const data = decoded.getChannelData(channel)
+      for (let index = 0; index < data.length; index++) {
+        samples[index] =
+          (samples[index] ?? 0) + (data[index] ?? 0) / decoded.numberOfChannels
+      }
+    }
+
+    return {
+      samples,
+      sampleRate: decoded.sampleRate,
+      durationSec: decoded.duration,
+    }
+  } catch {
+    throw new Error('The recording could not be decoded for local tone analysis.')
+  } finally {
+    await context.close()
+  }
+}
+
+function median(values: number[]): number | null {
+  if (!values.length) return null
+  const sorted = [...values].sort((a, b) => a - b)
+  const middle = Math.floor(sorted.length / 2)
+  return sorted.length % 2
+    ? (sorted[middle] ?? null)
+    : ((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2
+}
+
+function percentile(values: number[], fraction: number): number | null {
+  if (!values.length) return null
+  const sorted = [...values].sort((a, b) => a - b)
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.round((sorted.length - 1) * fraction)),
+  )
+  return sorted[index] ?? null
+}
+
+function medianSlice(values: number[], from: number, to: number): number | null {
+  if (!values.length) return null
+  const start = Math.floor(values.length * from)
+  const end = Math.max(start + 1, Math.ceil(values.length * to))
+  return median(values.slice(start, end))
+}
+
+function classifyShape(points: PitchPoint[]): ObservedToneShape {
+  if (points.length < 4) return 'unvoiced'
+  const center = median(points.map((point) => point.hz))
+  if (!center || center <= 0) return 'unvoiced'
+
+  const semitones = points.map((point) => 12 * Math.log2(point.hz / center))
+  const first = medianSlice(semitones, 0, 0.28)
+  const middle = medianSlice(semitones, 0.36, 0.64)
+  const last = medianSlice(semitones, 0.72, 1)
+  const low = percentile(semitones, 0.1)
+  const high = percentile(semitones, 0.9)
+
+  if (
+    first == null ||
+    middle == null ||
+    last == null ||
+    low == null ||
+    high == null
+  ) {
+    return 'unvoiced'
+  }
+
+  const delta = last - first
+  const robustRange = high - low
+
+  if (middle < first - 0.7 && middle < last - 0.7) return 'dipping'
+  if (delta >= 1.0) return 'rising'
+  if (delta <= -1.0) return 'falling'
+  if (robustRange <= 1.6) return 'level'
+  return 'mixed'
+}
+
+function feedbackForTone(
+  tone: MandarinToneNumber,
+  shape: ObservedToneShape,
+): Pick<MandarinToneObservation, 'verdict' | 'feedback'> {
+  if (shape === 'unvoiced') {
+    return {
+      verdict: 'uncertain',
+      feedback: 'Not enough stable voiced pitch was detected for this syllable. Try a clean, natural repetition a little closer to the microphone.',
+    }
+  }
+
+  if (tone === 5) {
+    return {
+      verdict: 'uncertain',
+      feedback: 'Neutral tone is mainly about being short and light. This pitch-only check intentionally does not pretend to grade it.',
+    }
+  }
+
+  if (tone === 1) {
+    return shape === 'level'
+      ? {
+          verdict: 'good',
+          feedback: 'The pitch stayed broadly level, which matches the first-tone target.',
+        }
+      : {
+          verdict: 'practice',
+          feedback: 'Aim for a steadier high pitch without a noticeable rise or drop.',
+        }
+  }
+
+  if (tone === 2) {
+    return shape === 'rising'
+      ? {
+          verdict: 'good',
+          feedback: 'A clear rise was detected, matching the second-tone target.',
+        }
+      : {
+          verdict: 'practice',
+          feedback: 'Start comfortably low-to-mid and let the pitch climb through the syllable.',
+        }
+  }
+
+  if (tone === 4) {
+    return shape === 'falling'
+      ? {
+          verdict: 'good',
+          feedback: 'A clear fall was detected, matching the fourth-tone target.',
+        }
+      : {
+          verdict: 'practice',
+          feedback: 'Start higher and make the drop decisive rather than level or rising.',
+        }
+  }
+
+  // Third tone is context-sensitive: in connected speech it is frequently a
+  // low "half third" rather than a theatrical full dip-and-rise. We only call
+  // a visible dip a clear match; other shapes get guidance rather than a false
+  // hard failure.
+  if (shape === 'dipping') {
+    return {
+      verdict: 'good',
+      feedback: 'A low dip was detected, which is a good isolated third-tone shape.',
+    }
+  }
+
+  return {
+    verdict: 'uncertain',
+    feedback: 'Third tone often stays low in connected speech. Aim for a distinctly low center; a full rise is not always required.',
+  }
+}
+
+export async function analyzeMandarinToneShapes(
+  file: File,
+  pinyin: string,
+): Promise<MandarinToneAnalysis> {
+  const targets = parsePinyinToneTargets(pinyin)
+  const decoded = await decodeMono(file)
+  const points: PitchPoint[] = []
+  let totalFrames = 0
+
+  for (
+    let start = 0;
+    start + FRAME_SIZE <= decoded.samples.length;
+    start += HOP_SIZE
+  ) {
+    const frame = decoded.samples.subarray(start, start + FRAME_SIZE)
+    const hz = detectPitchYIN(frame, decoded.sampleRate)
+    totalFrames += 1
+    if (hz != null) {
+      points.push({
+        timeSec: (start + FRAME_SIZE / 2) / decoded.sampleRate,
+        hz,
+      })
+    }
+  }
+
+  const voicedPercent = totalFrames
+    ? Math.round((points.length / totalFrames) * 1000) / 10
+    : 0
+
+  if (!targets.length || !points.length) {
+    return {
+      durationSec: decoded.durationSec,
+      voicedPercent,
+      observations: targets.map((target) => ({
+        syllable: target.syllable,
+        expectedTone: target.spokenTone,
+        expectedLabel: target.label,
+        expectedArrow: target.arrow,
+        observedShape: 'unvoiced',
+        verdict: 'uncertain',
+        feedback: 'No stable pitch contour was available for comparison.',
+      })),
+      note: 'Tone analysis is a rough on-device pitch guide, not a phonetic exam score.',
+    }
+  }
+
+  // Trim silence by using the first/last voiced frame, then divide that voiced
+  // span among the known pinyin syllables. This is intentionally a lightweight
+  // MVP heuristic; later forced alignment can replace it without changing the
+  // UI contract.
+  const firstTime = points[0]?.timeSec ?? 0
+  const lastTime = points.at(-1)?.timeSec ?? decoded.durationSec
+  const voicedSpan = Math.max(0.05, lastTime - firstTime)
+
+  const observations = targets.map((target, index) => {
+    const start = firstTime + (voicedSpan * index) / targets.length
+    const end = firstTime + (voicedSpan * (index + 1)) / targets.length
+    const segment = points.filter((point) => point.timeSec >= start && point.timeSec <= end)
+    const observedShape = classifyShape(segment)
+    const assessment = feedbackForTone(target.spokenTone, observedShape)
+
+    return {
+      syllable: target.syllable,
+      expectedTone: target.spokenTone,
+      expectedLabel: target.label,
+      expectedArrow: target.arrow,
+      observedShape,
+      ...assessment,
+    }
+  })
+
+  return {
+    durationSec: decoded.durationSec,
+    voicedPercent,
+    observations,
+    note: 'Tone analysis stays in your browser and compares broad pitch movement only. Consonants, vowels, rhythm, and native-like naturalness need separate pronunciation evidence.',
+  }
+}

--- a/stores/mandarinTutorStore.ts
+++ b/stores/mandarinTutorStore.ts
@@ -1,0 +1,375 @@
+import { computed, ref } from 'vue'
+import { defineStore } from 'pinia'
+import { performFetch } from './utils'
+import type {
+  MandarinCard,
+  MandarinCatalogPayload,
+  MandarinCustomSet,
+  MandarinStudySet,
+} from '@/utils/mandarin'
+
+const STORAGE_KEY = 'kind-robots:mandarin-tutor:v1'
+
+type LocalState = {
+  customSets: MandarinCustomSet[]
+  selectedSetId: string
+  artJobs: Record<string, number>
+}
+
+type ArtEnqueueData = {
+  jobId?: number
+  status?: string
+  deduplicated?: boolean
+}
+
+function safeId(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60)
+}
+
+export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
+  const cards = ref<MandarinCard[]>([])
+  const builtInSets = ref<MandarinStudySet[]>([])
+  const customSets = ref<MandarinCustomSet[]>([])
+  const selectedSetId = ref('starter-500')
+  const studyIndex = ref(0)
+  const searchQuery = ref('')
+  const focusKey = ref<string | null>(null)
+  const meaningVisible = ref(false)
+  const detailsVisible = ref(false)
+  const loading = ref(false)
+  const initialized = ref(false)
+  const error = ref<string | null>(null)
+  const speechError = ref<string | null>(null)
+  const artJobs = ref<Record<string, number>>({})
+  const artQueueingKey = ref<string | null>(null)
+
+  const cardMap = computed(
+    () => new Map(cards.value.map((card) => [card.key, card] as const)),
+  )
+
+  const allSets = computed<MandarinStudySet[]>(() => [
+    ...builtInSets.value,
+    ...customSets.value.map((set) => ({
+      id: `custom:${set.id}`,
+      label: set.name,
+      description: 'Your custom study set.',
+      cardKeys: set.cardKeys,
+    })),
+  ])
+
+  const selectedSet = computed(
+    () =>
+      allSets.value.find((set) => set.id === selectedSetId.value) ??
+      allSets.value[0] ??
+      null,
+  )
+
+  const studyCards = computed(() => {
+    const keys = selectedSet.value?.cardKeys ?? []
+    return keys
+      .map((key) => cardMap.value.get(key))
+      .filter((card): card is MandarinCard => Boolean(card))
+  })
+
+  const currentCard = computed<MandarinCard | null>(() => {
+    if (focusKey.value) return cardMap.value.get(focusKey.value) ?? null
+    if (!studyCards.value.length) return null
+    return studyCards.value[studyIndex.value % studyCards.value.length] ?? null
+  })
+
+  const searchResults = computed(() => {
+    const query = searchQuery.value.trim().toLowerCase()
+    if (!query) return []
+    return cards.value
+      .filter((card) => {
+        const haystack = [
+          card.simplified,
+          card.traditional ?? '',
+          card.pinyin,
+          card.meaning,
+          ...card.meanings,
+        ]
+          .join(' ')
+          .toLowerCase()
+        return haystack.includes(query)
+      })
+      .slice(0, 24)
+  })
+
+  const customSetCount = computed(() => customSets.value.length)
+  const audioSupported = computed(
+    () => import.meta.client && 'speechSynthesis' in window,
+  )
+
+  function resetReveal() {
+    meaningVisible.value = false
+    detailsVisible.value = false
+    speechError.value = null
+  }
+
+  function saveLocalState() {
+    if (!import.meta.client) return
+    const state: LocalState = {
+      customSets: customSets.value,
+      selectedSetId: selectedSetId.value,
+      artJobs: artJobs.value,
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  }
+
+  function loadLocalState() {
+    if (!import.meta.client) return
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY)
+      if (!raw) return
+      const parsed = JSON.parse(raw) as Partial<LocalState>
+      if (Array.isArray(parsed.customSets)) customSets.value = parsed.customSets
+      if (typeof parsed.selectedSetId === 'string') {
+        selectedSetId.value = parsed.selectedSetId
+      }
+      if (parsed.artJobs && typeof parsed.artJobs === 'object') {
+        artJobs.value = parsed.artJobs
+      }
+    } catch {
+      localStorage.removeItem(STORAGE_KEY)
+    }
+  }
+
+  async function loadCatalog() {
+    if (loading.value) return
+    loading.value = true
+    error.value = null
+    try {
+      const response = await performFetch<MandarinCatalogPayload>(
+        '/api/mandarin',
+        {},
+        2,
+        30_000,
+      )
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Failed to load Mandarin cards.')
+      }
+      cards.value = response.data.cards
+      builtInSets.value = response.data.sets
+      if (!allSets.value.some((set) => set.id === selectedSetId.value)) {
+        selectedSetId.value = builtInSets.value[0]?.id ?? 'starter-500'
+      }
+      initialized.value = true
+      studyIndex.value = 0
+      resetReveal()
+    } catch (cause) {
+      error.value =
+        cause instanceof Error ? cause.message : 'Failed to load Mandarin cards.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function initialize() {
+    if (initialized.value || loading.value) return
+    loadLocalState()
+    await loadCatalog()
+  }
+
+  function selectSet(id: string) {
+    if (!allSets.value.some((set) => set.id === id)) return
+    selectedSetId.value = id
+    studyIndex.value = 0
+    focusKey.value = null
+    resetReveal()
+    saveLocalState()
+  }
+
+  function nextCard() {
+    if (!studyCards.value.length) return
+    focusKey.value = null
+    studyIndex.value = (studyIndex.value + 1) % studyCards.value.length
+    resetReveal()
+  }
+
+  function previousCard() {
+    if (!studyCards.value.length) return
+    focusKey.value = null
+    studyIndex.value =
+      (studyIndex.value - 1 + studyCards.value.length) % studyCards.value.length
+    resetReveal()
+  }
+
+  function focusCard(key: string) {
+    if (!cardMap.value.has(key)) return
+    focusKey.value = key
+    resetReveal()
+  }
+
+  function clearFocus() {
+    focusKey.value = null
+    resetReveal()
+  }
+
+  function toggleMeaning() {
+    meaningVisible.value = !meaningVisible.value
+  }
+
+  function toggleDetails() {
+    detailsVisible.value = !detailsVisible.value
+  }
+
+  function createCustomSet(name: string): MandarinCustomSet | null {
+    const cleanName = name.trim()
+    if (!cleanName) return null
+    const base = safeId(cleanName) || 'deck'
+    let id = base
+    let suffix = 2
+    while (customSets.value.some((set) => set.id === id)) {
+      id = `${base}-${suffix}`
+      suffix += 1
+    }
+    const set: MandarinCustomSet = {
+      id,
+      name: cleanName.slice(0, 80),
+      cardKeys: [],
+      createdAt: new Date().toISOString(),
+    }
+    customSets.value.push(set)
+    saveLocalState()
+    return set
+  }
+
+  function toggleCardInCustomSet(setId: string, cardKey: string) {
+    const set = customSets.value.find((candidate) => candidate.id === setId)
+    if (!set || !cardMap.value.has(cardKey)) return
+    set.cardKeys = set.cardKeys.includes(cardKey)
+      ? set.cardKeys.filter((key) => key !== cardKey)
+      : [...set.cardKeys, cardKey]
+    saveLocalState()
+  }
+
+  function cardIsInCustomSet(setId: string, cardKey: string): boolean {
+    return Boolean(
+      customSets.value
+        .find((set) => set.id === setId)
+        ?.cardKeys.includes(cardKey),
+    )
+  }
+
+  function speak(card: MandarinCard | null = currentCard.value) {
+    speechError.value = null
+    if (!card || !import.meta.client || !('speechSynthesis' in window)) {
+      speechError.value = 'Mandarin speech playback is not available in this browser.'
+      return
+    }
+
+    window.speechSynthesis.cancel()
+    const utterance = new SpeechSynthesisUtterance(card.simplified)
+    utterance.lang = 'zh-CN'
+    utterance.rate = 0.82
+    const voices = window.speechSynthesis.getVoices()
+    const voice =
+      voices.find((candidate) => candidate.lang.toLowerCase() === 'zh-cn') ??
+      voices.find((candidate) => candidate.lang.toLowerCase().startsWith('zh'))
+    if (voice) utterance.voice = voice
+    utterance.onerror = () => {
+      speechError.value = 'The Mandarin voice could not play this word.'
+    }
+    window.speechSynthesis.speak(utterance)
+  }
+
+  async function queueIllustration(
+    card: MandarinCard | null = currentCard.value,
+  ): Promise<number | null> {
+    if (!card || artQueueingKey.value) return null
+    artQueueingKey.value = card.key
+    error.value = null
+    try {
+      const promptString = [
+        `Educational flashcard illustration for the Mandarin concept “${card.meaning}”.`,
+        'One clear memorable everyday scene or object that communicates the meaning at a glance.',
+        'Culturally grounded, friendly, uncluttered, polished editorial illustration.',
+        'No text, no letters, no Chinese characters, no captions, no logo, no watermark.',
+      ].join(' ')
+      const response = await performFetch<ArtEnqueueData>(
+        '/api/art/enqueue',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            engine: 'krea2',
+            promptString,
+            projectSlug: 'mandarin-tutor',
+            width: 768,
+            height: 768,
+            isPublic: false,
+            isMature: false,
+            designer: `mandarin:${card.key}`,
+          }),
+        },
+        1,
+        45_000,
+      )
+      const jobId = Number(response.data?.jobId)
+      if (!response.success || !Number.isInteger(jobId) || jobId <= 0) {
+        throw new Error(response.message || 'Failed to queue the Krea 2 illustration.')
+      }
+      artJobs.value = { ...artJobs.value, [card.key]: jobId }
+      saveLocalState()
+      return jobId
+    } catch (cause) {
+      error.value =
+        cause instanceof Error
+          ? cause.message
+          : 'Failed to queue the Krea 2 illustration.'
+      return null
+    } finally {
+      artQueueingKey.value = null
+    }
+  }
+
+  function illustrationJobId(cardKey: string): number | null {
+    const id = Number(artJobs.value[cardKey])
+    return Number.isInteger(id) && id > 0 ? id : null
+  }
+
+  return {
+    cards,
+    builtInSets,
+    customSets,
+    selectedSetId,
+    studyIndex,
+    searchQuery,
+    focusKey,
+    meaningVisible,
+    detailsVisible,
+    loading,
+    initialized,
+    error,
+    speechError,
+    artJobs,
+    artQueueingKey,
+    allSets,
+    selectedSet,
+    studyCards,
+    currentCard,
+    searchResults,
+    customSetCount,
+    audioSupported,
+    initialize,
+    loadCatalog,
+    selectSet,
+    nextCard,
+    previousCard,
+    focusCard,
+    clearFocus,
+    toggleMeaning,
+    toggleDetails,
+    createCustomSet,
+    toggleCardInCustomSet,
+    cardIsInCustomSet,
+    speak,
+    queueIllustration,
+    illustrationJobId,
+  }
+})

--- a/stores/mandarinTutorStore.ts
+++ b/stores/mandarinTutorStore.ts
@@ -1,6 +1,7 @@
 import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
 import { performFetch } from './utils'
+import { useUserStore } from './userStore'
 import type {
   MandarinCard,
   MandarinCatalogPayload,
@@ -14,12 +15,20 @@ type LocalState = {
   customSets: MandarinCustomSet[]
   selectedSetId: string
   artJobs: Record<string, number>
+  artImageIds: Record<string, number>
 }
 
 type ArtEnqueueData = {
   jobId?: number
   status?: string
   deduplicated?: boolean
+}
+
+type ArtJobData = {
+  job?: {
+    status?: string
+    artImageId?: number | null
+  }
 }
 
 function safeId(value: string): string {
@@ -46,7 +55,11 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
   const error = ref<string | null>(null)
   const speechError = ref<string | null>(null)
   const artJobs = ref<Record<string, number>>({})
+  const artImageIds = ref<Record<string, number>>({})
+  const artImageUrls = ref<Record<string, string>>({})
+  const artStatuses = ref<Record<string, string>>({})
   const artQueueingKey = ref<string | null>(null)
+  const artRefreshingKey = ref<string | null>(null)
 
   const cardMap = computed(
     () => new Map(cards.value.map((card) => [card.key, card] as const)),
@@ -118,6 +131,7 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
       customSets: customSets.value,
       selectedSetId: selectedSetId.value,
       artJobs: artJobs.value,
+      artImageIds: artImageIds.value,
     }
     localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
   }
@@ -134,6 +148,9 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
       }
       if (parsed.artJobs && typeof parsed.artJobs === 'object') {
         artJobs.value = parsed.artJobs
+      }
+      if (parsed.artImageIds && typeof parsed.artImageIds === 'object') {
+        artImageIds.value = parsed.artImageIds
       }
     } catch {
       localStorage.removeItem(STORAGE_KEY)
@@ -279,6 +296,17 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
     window.speechSynthesis.speak(utterance)
   }
 
+  async function fetchProtectedImage(artImageId: number): Promise<string | null> {
+    if (!import.meta.client) return null
+    const userStore = useUserStore()
+    const token = userStore.token || userStore.user?.token || ''
+    const headers = new Headers()
+    if (token) headers.set('Authorization', `Bearer ${token}`)
+    const response = await fetch(`/api/art/images/${artImageId}/file`, { headers })
+    if (!response.ok) return null
+    return URL.createObjectURL(await response.blob())
+  }
+
   async function queueIllustration(
     card: MandarinCard | null = currentCard.value,
   ): Promise<number | null> {
@@ -315,6 +343,7 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
         throw new Error(response.message || 'Failed to queue the Krea 2 illustration.')
       }
       artJobs.value = { ...artJobs.value, [card.key]: jobId }
+      artStatuses.value = { ...artStatuses.value, [card.key]: response.data?.status || 'PENDING' }
       saveLocalState()
       return jobId
     } catch (cause) {
@@ -328,9 +357,64 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
     }
   }
 
+  async function refreshIllustration(
+    card: MandarinCard | null = currentCard.value,
+  ): Promise<string | null> {
+    if (!card || artRefreshingKey.value) return null
+    const jobId = illustrationJobId(card.key)
+    const knownImageId = Number(artImageIds.value[card.key])
+    artRefreshingKey.value = card.key
+    error.value = null
+    try {
+      let artImageId =
+        Number.isInteger(knownImageId) && knownImageId > 0 ? knownImageId : 0
+
+      if (!artImageId) {
+        if (!jobId) return null
+        const response = await performFetch<ArtJobData>(
+          `/api/art/queue/${jobId}`,
+          {},
+          1,
+          20_000,
+        )
+        if (!response.success || !response.data?.job) {
+          throw new Error(response.message || `Failed to read ArtJob ${jobId}.`)
+        }
+        const status = String(response.data.job.status || 'UNKNOWN')
+        artStatuses.value = { ...artStatuses.value, [card.key]: status }
+        artImageId = Number(response.data.job.artImageId)
+        if (!Number.isInteger(artImageId) || artImageId <= 0) return null
+        artImageIds.value = { ...artImageIds.value, [card.key]: artImageId }
+        saveLocalState()
+      }
+
+      const nextUrl = await fetchProtectedImage(artImageId)
+      if (!nextUrl) throw new Error('The finished illustration is not available yet.')
+      const previousUrl = artImageUrls.value[card.key]
+      if (previousUrl?.startsWith('blob:')) URL.revokeObjectURL(previousUrl)
+      artImageUrls.value = { ...artImageUrls.value, [card.key]: nextUrl }
+      artStatuses.value = { ...artStatuses.value, [card.key]: 'DONE' }
+      return nextUrl
+    } catch (cause) {
+      error.value =
+        cause instanceof Error ? cause.message : 'Failed to refresh the illustration.'
+      return null
+    } finally {
+      artRefreshingKey.value = null
+    }
+  }
+
   function illustrationJobId(cardKey: string): number | null {
     const id = Number(artJobs.value[cardKey])
     return Number.isInteger(id) && id > 0 ? id : null
+  }
+
+  function illustrationUrl(cardKey: string): string | null {
+    return artImageUrls.value[cardKey] || null
+  }
+
+  function illustrationStatus(cardKey: string): string | null {
+    return artStatuses.value[cardKey] || null
   }
 
   return {
@@ -348,7 +432,11 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
     error,
     speechError,
     artJobs,
+    artImageIds,
+    artImageUrls,
+    artStatuses,
     artQueueingKey,
+    artRefreshingKey,
     allSets,
     selectedSet,
     studyCards,
@@ -370,6 +458,9 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
     cardIsInCustomSet,
     speak,
     queueIllustration,
+    refreshIllustration,
     illustrationJobId,
+    illustrationUrl,
+    illustrationStatus,
   }
 })

--- a/utils/mandarin.ts
+++ b/utils/mandarin.ts
@@ -1,0 +1,356 @@
+export type MandarinComponentRole =
+  | 'semantic'
+  | 'phonetic'
+  | 'radical'
+  | 'form'
+  | 'uncertain'
+
+export type MandarinComponent = {
+  glyph: string
+  role: MandarinComponentRole
+  label: string
+  meaning?: string
+  note?: string
+}
+
+export type MandarinSource = {
+  label: string
+  version: string
+  url?: string
+  licenseNote?: string
+}
+
+export type MandarinCard = {
+  key: string
+  simplified: string
+  traditional?: string
+  pinyin: string
+  meaning: string
+  meanings: string[]
+  kind: 'word' | 'character' | 'phrase' | 'component'
+  radical?: string
+  frequency?: number
+  hskLevel?: number
+  partsOfSpeech: string[]
+  classifiers: string[]
+  categories: string[]
+  components: MandarinComponent[]
+  history?: string
+  historyStatus: 'starter' | 'pending'
+  source: MandarinSource
+}
+
+export type MandarinStudySet = {
+  id: string
+  label: string
+  description: string
+  cardKeys: string[]
+}
+
+export type MandarinCatalogPayload = {
+  cards: MandarinCard[]
+  sets: MandarinStudySet[]
+  source: MandarinSource
+}
+
+export type MandarinCustomSet = {
+  id: string
+  name: string
+  cardKeys: string[]
+  createdAt: string
+}
+
+export const MANDARIN_SOURCE: MandarinSource = {
+  label: 'HSK Vocabulary / CC-CEDICT compilation',
+  version: 'jelleverheyen/hsk-vocabulary@a66fd30b9580da2c2af7eb19e4b9d8099a29c061',
+  url: 'https://github.com/jelleverheyen/hsk-vocabulary',
+  licenseNote: 'Source and attribution details are preserved from the upstream dataset.',
+}
+
+const curatedSource: MandarinSource = {
+  label: 'Kind Robots curated starter vocabulary',
+  version: '2026-08-24',
+}
+
+type CuratedSeed = [
+  simplified: string,
+  pinyin: string,
+  meaning: string,
+  category: string,
+  traditional?: string,
+]
+
+const CURATED_SEEDS: CuratedSeed[] = [
+  ['猫', 'māo', 'cat', 'animals', '貓'],
+  ['狗', 'gǒu', 'dog', 'animals'],
+  ['鸟', 'niǎo', 'bird', 'animals', '鳥'],
+  ['鱼', 'yú', 'fish', 'animals', '魚'],
+  ['兔子', 'tù zi', 'rabbit', 'animals'],
+  ['老虎', 'lǎo hǔ', 'tiger', 'animals'],
+  ['狮子', 'shī zi', 'lion', 'animals', '獅子'],
+  ['熊', 'xióng', 'bear', 'animals'],
+  ['熊猫', 'xióng māo', 'giant panda', 'animals', '熊貓'],
+  ['猴子', 'hóu zi', 'monkey', 'animals'],
+  ['大象', 'dà xiàng', 'elephant', 'animals'],
+  ['蛇', 'shé', 'snake', 'animals'],
+  ['龙', 'lóng', 'dragon', 'animals', '龍'],
+  ['老鼠', 'lǎo shǔ', 'mouse; rat', 'animals'],
+  ['猪', 'zhū', 'pig', 'animals', '豬'],
+  ['羊', 'yáng', 'sheep; goat', 'animals'],
+  ['鸭子', 'yā zi', 'duck', 'animals', '鴨子'],
+  ['红色', 'hóng sè', 'red', 'colors', '紅色'],
+  ['蓝色', 'lán sè', 'blue', 'colors', '藍色'],
+  ['绿色', 'lǜ sè', 'green', 'colors', '綠色'],
+  ['黄色', 'huáng sè', 'yellow', 'colors', '黃色'],
+  ['黑色', 'hēi sè', 'black', 'colors'],
+  ['白色', 'bái sè', 'white', 'colors'],
+  ['紫色', 'zǐ sè', 'purple', 'colors'],
+  ['粉红色', 'fěn hóng sè', 'pink', 'colors', '粉紅色'],
+  ['橙色', 'chéng sè', 'orange', 'colors'],
+  ['灰色', 'huī sè', 'gray', 'colors'],
+  ['赌场', 'dǔ chǎng', 'casino', 'casino', '賭場'],
+  ['赌博', 'dǔ bó', 'gambling; to gamble', 'casino', '賭博'],
+  ['赌注', 'dǔ zhù', 'bet; wager', 'casino', '賭注'],
+  ['下注', 'xià zhù', 'to place a bet', 'casino'],
+  ['筹码', 'chóu mǎ', 'casino chip', 'casino', '籌碼'],
+  ['牌', 'pái', 'card; tile;牌', 'casino'],
+  ['扑克牌', 'pū kè pái', 'playing cards', 'casino', '撲克牌'],
+  ['牌桌', 'pái zhuō', 'card or gaming table', 'casino'],
+  ['荷官', 'hé guān', 'casino dealer', 'casino'],
+  ['庄家', 'zhuāng jiā', 'banker; house/dealer role', 'casino', '莊家'],
+  ['玩家', 'wán jiā', 'player', 'casino'],
+  ['洗牌', 'xǐ pái', 'to shuffle cards', 'casino'],
+  ['切牌', 'qiē pái', 'to cut the cards', 'casino'],
+  ['发牌', 'fā pái', 'to deal cards', 'casino', '發牌'],
+  ['补牌', 'bǔ pái', 'to draw an additional card', 'casino', '補牌'],
+  ['赢', 'yíng', 'to win', 'casino', '贏'],
+  ['输', 'shū', 'to lose', 'casino', '輸'],
+  ['平局', 'píng jú', 'tie; draw', 'casino'],
+  ['赔率', 'péi lǜ', 'odds; payout rate', 'casino', '賠率'],
+  ['赔付', 'péi fù', 'payout; to pay winnings', 'casino', '賠付'],
+  ['现金', 'xiàn jīn', 'cash', 'casino', '現金'],
+  ['兑现', 'duì xiàn', 'to cash out; redeem', 'casino', '兌現'],
+  ['换筹码', 'huàn chóu mǎ', 'exchange for chips', 'casino', '換籌碼'],
+  ['黑桃', 'hēi táo', 'spades', 'casino'],
+  ['红桃', 'hóng táo', 'hearts', 'casino', '紅桃'],
+  ['方块', 'fāng kuài', 'diamonds', 'casino', '方塊'],
+  ['梅花', 'méi huā', 'clubs', 'casino'],
+  ['点数', 'diǎn shù', 'point value; total of pips', 'casino', '點數'],
+  ['总数', 'zǒng shù', 'total number; total', 'casino', '總數'],
+  ['双倍', 'shuāng bèi', 'double; twice as much', 'casino', '雙倍'],
+  ['请下注', 'qǐng xià zhù', 'please place your bets', 'casino', '請下注'],
+  ['停止下注', 'tíng zhǐ xià zhù', 'betting is closed; no more bets', 'casino'],
+  ['最小下注', 'zuì xiǎo xià zhù', 'minimum bet', 'casino'],
+  ['最大下注', 'zuì dà xià zhù', 'maximum bet', 'casino'],
+  ['请稍等', 'qǐng shāo děng', 'please wait a moment', 'casino', '請稍等'],
+  ['好运', 'hǎo yùn', 'good luck', 'casino', '好運'],
+]
+
+export const CURATED_MANDARIN_CARDS: MandarinCard[] = CURATED_SEEDS.map(
+  ([simplified, pinyin, meaning, category, traditional]) => ({
+    key: `curated:${simplified}`,
+    simplified,
+    ...(traditional && traditional !== simplified ? { traditional } : {}),
+    pinyin,
+    meaning,
+    meanings: [meaning],
+    kind: simplified.length === 1 ? 'character' : 'phrase',
+    partsOfSpeech: [],
+    classifiers: [],
+    categories: [category, 'beginner'],
+    components: [],
+    historyStatus: 'pending',
+    source: curatedSource,
+  }),
+)
+
+export const STARTER_COMPONENT_GUIDES: Record<
+  string,
+  { components: MandarinComponent[]; history: string }
+> = {
+  说: {
+    components: [
+      {
+        glyph: '讠',
+        role: 'semantic',
+        label: 'speech component',
+        meaning: 'speech; language',
+        note: 'The simplified left-side form of 言 points toward the meaning domain.',
+      },
+      {
+        glyph: '兑',
+        role: 'phonetic',
+        label: 'sound component',
+        note: 'This side primarily supplies a historical sound clue rather than a second definition.',
+      },
+    ],
+    history:
+      'Traditional 說 uses 言 on the left and 兌 as the phonetic element. Simplified 说 compresses 言 to 讠 and uses the simplified form 兑. The semantic/phonetic roles are more useful than a literal picture-story.',
+  },
+  妈: {
+    components: [
+      {
+        glyph: '女',
+        role: 'semantic',
+        label: 'female component',
+        meaning: 'woman; female',
+      },
+      {
+        glyph: '马',
+        role: 'phonetic',
+        label: 'sound component',
+        note: '馬/马 contributes the sound family, not the meaning “horse.”',
+      },
+    ],
+    history:
+      'Traditional 媽 combines 女 with phonetic 馬. Simplified 妈 keeps the same structure while simplifying 馬 to 马.',
+  },
+  请: {
+    components: [
+      {
+        glyph: '讠',
+        role: 'semantic',
+        label: 'speech component',
+        meaning: 'speech; language',
+      },
+      {
+        glyph: '青',
+        role: 'phonetic',
+        label: 'sound component',
+        note: '青 links 请 to a large phonetic family including 清 and 情.',
+      },
+    ],
+    history:
+      'Traditional 請 combines 言 with phonetic 青. Simplified 请 compresses 言 to 讠 while preserving 青.',
+  },
+  清: {
+    components: [
+      {
+        glyph: '氵',
+        role: 'semantic',
+        label: 'water component',
+        meaning: 'water; liquid',
+      },
+      {
+        glyph: '青',
+        role: 'phonetic',
+        label: 'sound component',
+      },
+    ],
+    history:
+      '清 belongs to the common semantic-phonetic pattern: water 氵 identifies the meaning field and 青 supplies a sound clue.',
+  },
+  河: {
+    components: [
+      {
+        glyph: '氵',
+        role: 'semantic',
+        label: 'water component',
+        meaning: 'water; liquid',
+      },
+      {
+        glyph: '可',
+        role: 'phonetic',
+        label: 'sound component',
+      },
+    ],
+    history:
+      '河 combines the water component 氵 with phonetic 可. The two sides do different jobs: meaning field on the left, historical sound clue on the right.',
+  },
+}
+
+export const BUILT_IN_SET_TERMS: Record<string, string[]> = {
+  numbers: [
+    '零', '一', '二', '两', '三', '四', '五', '六', '七', '八', '九', '十', '百',
+    '千', '万', '多少', '半', '一半', '元', '钱', '双倍',
+  ],
+  family: [
+    '家', '家人', '爸爸', '妈妈', '父亲', '母亲', '哥哥', '姐姐', '弟弟', '妹妹',
+    '儿子', '女儿', '爷爷', '奶奶', '孩子', '朋友',
+  ],
+  'food-drink': [
+    '吃', '吃饭', '喝', '水', '茶', '牛奶', '米饭', '饭', '饭店', '面包', '鸡蛋',
+    '水果', '菜', '杯子',
+  ],
+  animals: [
+    '猫', '狗', '鸟', '鱼', '马', '牛', '鸡', '兔子', '老虎', '狮子', '熊', '熊猫',
+    '猴子', '大象', '蛇', '龙', '老鼠', '猪', '羊', '鸭子',
+  ],
+  colors: [
+    '红色', '蓝色', '绿色', '黄色', '黑色', '白色', '紫色', '粉红色', '橙色', '灰色',
+    '白', '黑', '红', '蓝', '绿', '黄',
+  ],
+  'time-calendar': [
+    '今天', '明天', '昨天', '现在', '时间', '小时', '上午', '下午', '晚上', '早上',
+    '中午', '星期', '月', '年', '今年', '明年', '去年', '生日', '日期',
+  ],
+  'travel-places': [
+    '车', '汽车', '火车', '飞机', '机场', '车站', '路', '地图', '医院', '学校',
+    '商店', '商场', '饭店', '北京', '中国', '外国', '家', '房间',
+  ],
+  'everyday-actions': [
+    '来', '去', '走', '跑', '看', '听', '说', '写', '读', '吃', '喝', '睡', '学习',
+    '工作', '买', '找', '给', '拿', '坐', '站', '开', '关', '洗', '想', '知道',
+  ],
+  'questions-grammar': [
+    '吗', '呢', '什么', '怎么', '谁', '哪', '哪儿', '哪里', '多少', '为什么', '的',
+    '了', '着', '也', '都', '很', '不', '没', '没有', '有', '是', '在', '会', '能', '要',
+  ],
+  greetings: [
+    '你好', '您好', '谢谢', '再见', '对不起', '没关系', '不客气', '请', '请问', '请进',
+    '请坐', '早上', '晚上',
+  ],
+  casino: CURATED_SEEDS.filter((seed) => seed[3] === 'casino').map(
+    (seed) => seed[0],
+  ),
+}
+
+export const BUILT_IN_SET_META: Record<
+  string,
+  { label: string; description: string }
+> = {
+  numbers: {
+    label: 'Numbers & money',
+    description: 'Counting, quantities, prices, and the number language you use constantly.',
+  },
+  family: {
+    label: 'Family & people',
+    description: 'Family relationships and everyday people words.',
+  },
+  'food-drink': {
+    label: 'Food & drink',
+    description: 'Meals, drinks, ordering, and everyday kitchen vocabulary.',
+  },
+  animals: {
+    label: 'Animals',
+    description: 'The beginner-deck menagerie, from cats and dogs through pandas and dragons.',
+  },
+  colors: {
+    label: 'Colors',
+    description: 'Core color words in practical noun-friendly forms.',
+  },
+  'time-calendar': {
+    label: 'Time & calendar',
+    description: 'Days, dates, clock time, and words for past, present, and future.',
+  },
+  'travel-places': {
+    label: 'Travel & places',
+    description: 'Transport, directions, buildings, and common destinations.',
+  },
+  'everyday-actions': {
+    label: 'Everyday actions',
+    description: 'High-frequency verbs that make beginner sentences move.',
+  },
+  'questions-grammar': {
+    label: 'Questions & glue words',
+    description: 'Question words, particles, negation, and other high-frequency sentence machinery.',
+  },
+  greetings: {
+    label: 'Greetings & practical phrases',
+    description: 'Polite expressions and phrases that are useful immediately.',
+  },
+  casino: {
+    label: 'Casino Mandarin',
+    description: 'Dealer-facing bets, chips, cards, payouts, suits, table instructions, and customer phrases.',
+  },
+}

--- a/utils/mandarinPronunciation.ts
+++ b/utils/mandarinPronunciation.ts
@@ -1,0 +1,131 @@
+export type MandarinToneNumber = 1 | 2 | 3 | 4 | 5
+
+export type MandarinToneTarget = {
+  syllable: string
+  lexicalTone: MandarinToneNumber
+  spokenTone: MandarinToneNumber
+  label: string
+  arrow: string
+  note?: string
+}
+
+export type MandarinTranscriptComparison = {
+  status: 'match' | 'contains' | 'different'
+  message: string
+}
+
+const TONE_MARKS: Record<string, MandarinToneNumber> = {
+  ā: 1,
+  ē: 1,
+  ī: 1,
+  ō: 1,
+  ū: 1,
+  ǖ: 1,
+  á: 2,
+  é: 2,
+  í: 2,
+  ó: 2,
+  ú: 2,
+  ǘ: 2,
+  ǎ: 3,
+  ě: 3,
+  ǐ: 3,
+  ǒ: 3,
+  ǔ: 3,
+  ǚ: 3,
+  à: 4,
+  è: 4,
+  ì: 4,
+  ò: 4,
+  ù: 4,
+  ǜ: 4,
+}
+
+const TONE_LABELS: Record<MandarinToneNumber, { label: string; arrow: string }> = {
+  1: { label: '1st tone · high and level', arrow: '→' },
+  2: { label: '2nd tone · rising', arrow: '↗' },
+  3: { label: '3rd tone · low / dipping', arrow: '↘↗' },
+  4: { label: '4th tone · falling', arrow: '↘' },
+  5: { label: 'neutral tone · light', arrow: '·' },
+}
+
+function toneOfSyllable(syllable: string): MandarinToneNumber {
+  const numeric = syllable.match(/([1-5])$/)
+  if (numeric?.[1]) return Number(numeric[1]) as MandarinToneNumber
+
+  for (const character of syllable.toLowerCase()) {
+    const tone = TONE_MARKS[character]
+    if (tone) return tone
+  }
+
+  return 5
+}
+
+export function parsePinyinToneTargets(pinyin: string): MandarinToneTarget[] {
+  const syllables = pinyin
+    .trim()
+    .split(/[\s'’·-]+/u)
+    .map((syllable) => syllable.replace(/[.,!?;:，。！？；：]/gu, '').trim())
+    .filter(Boolean)
+
+  const lexical = syllables.map((syllable) => toneOfSyllable(syllable))
+
+  return syllables.map((syllable, index) => {
+    const lexicalTone = lexical[index] ?? 5
+    const nextTone = lexical[index + 1]
+    const thirdToneSandhi = lexicalTone === 3 && nextTone === 3
+    const spokenTone: MandarinToneNumber = thirdToneSandhi ? 2 : lexicalTone
+    const display = TONE_LABELS[spokenTone]
+
+    return {
+      syllable,
+      lexicalTone,
+      spokenTone,
+      label: display.label,
+      arrow: display.arrow,
+      ...(thirdToneSandhi
+        ? {
+            note: 'Two third tones meet here, so this syllable is normally pronounced with a rising second-tone shape.',
+          }
+        : {}),
+    }
+  })
+}
+
+export function normalizeMandarinTranscript(value: string): string {
+  return value
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[\p{P}\p{S}\s]/gu, '')
+}
+
+export function compareMandarinTranscript(input: {
+  transcript: string
+  simplified: string
+  traditional?: string
+}): MandarinTranscriptComparison {
+  const heard = normalizeMandarinTranscript(input.transcript)
+  const accepted = [input.simplified, input.traditional]
+    .filter((value): value is string => Boolean(value))
+    .map(normalizeMandarinTranscript)
+    .filter(Boolean)
+
+  if (accepted.some((target) => heard === target)) {
+    return {
+      status: 'match',
+      message: 'The recognizer heard the target word. That is a strong intelligibility signal; use the tone trace below for the next layer of refinement.',
+    }
+  }
+
+  if (accepted.some((target) => heard.includes(target))) {
+    return {
+      status: 'contains',
+      message: 'The recognizer heard the target inside a longer utterance. Try it once more as a clean, isolated word so the comparison is less forgiving.',
+    }
+  }
+
+  return {
+    status: 'different',
+    message: 'The recognizer heard something different from the target. Treat that as an intelligibility clue, not proof of one specific phonetic error; the pitch guide can separately flag the broad tone shape.',
+  }
+}

--- a/utils/projectPlacements.ts
+++ b/utils/projectPlacements.ts
@@ -17,6 +17,11 @@ export const PROJECT_PLACEMENTS: Record<string, ProjectPlacement> = {
     tabKey: 'music-mentor',
     route: '/music-mentor',
   },
+  'mandarin-tutor': {
+    channelKey: 'play',
+    tabKey: 'mandarin',
+    route: '/play/mandarin',
+  },
   'coloring-book': {
     channelKey: 'plan',
     tabKey: 'coloring',


### PR DESCRIPTION
## Summary
- add Play > Mandarin at `/play/mandarin`
- normalize a pinned HSK level 1/2 vocabulary source and enforce a 500-card minimum
- add broad built-in beginner sets plus curated animals, colors, and practical casino/dealer Mandarin
- add pronunciation playback, traditional forms, meaning reveal, component-role/history panels, search, and local custom decks
- add a microphone practice loop: record → unbiased Mandarin transcription → show exactly what was heard → retry
- reuse the existing tested YIN pitch detector for on-device broad tone-shape coaching, including basic third-tone sandhi handling, without presenting a fake pronunciation score
- keep practice recordings out of Kind Robots persistence; only the clip needed for transcription is sent to the configured speech provider
- keep radicals explicitly separate from semantic/phonetic decomposition so the UI does not teach folk etymology as fact
- add per-card private Krea 2 ArtJob requests through the existing `/api/art/enqueue` path
- register the Kind Robots project placement for Conductor slug `mandarin-tutor`

## MVP boundaries / follow-up
- pronunciation playback currently uses the browser Mandarin speech voice; durable cached per-word reference audio remains `mandarin-tutor/t-004` and is required before the broader curriculum milestone is complete
- the tone coach is intentionally a broad pitch-shape guide; forced syllable alignment, consonant/vowel acoustic scoring, and long-term learner weakness tracking remain follow-up work
- arbitrary out-of-catalog word creation and durable card-to-ArtImage attachment remain `t-005`; the MVP searches the 500+ sourced catalog rather than inventing unsourced dictionary facts
- broad source-backed historical decomposition remains `t-003`

## Data provenance
Starter vocabulary is pinned to `jelleverheyen/hsk-vocabulary@a66fd30b9580da2c2af7eb19e4b9d8099a29c061`; the app preserves upstream provenance metadata rather than silently copying dictionary facts.

## Voice design note
The transcription request deliberately does **not** include the target Hanzi or pinyin as an ASR prompt. This keeps “what I heard” useful instead of biasing recognition toward the expected answer. Tone-shape analysis runs locally in the browser using the repo’s existing YIN detector and is clearly labeled as approximate.