### PR TITLE
Strip surrounding quotes from MIGRATION_DATABASE_URL (unblocks production migration)

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -9,7 +9,14 @@ const requiresMigrationCredential =
   migrateIndex !== -1 ||
   (dbIndex !== -1 && ['execute', 'push'].includes(prismaArgs[dbIndex + 1] ?? ''))
 
-const migrationDatabaseUrl = process.env.MIGRATION_DATABASE_URL?.trim()
+// Same quote-stripping as shadowDatabaseUrl below, and for the same reason:
+// `docker run --env-file` is not a shell parser, so a quoted value in .env
+// arrives with its quotes attached. Without this, `prisma migrate status` run
+// out of the image fails on a URL that looks correct in the file.
+const migrationDatabaseUrl = process.env.MIGRATION_DATABASE_URL?.trim().replace(
+  /^(["'])(.*)\1$/,
+  '$2',
+)
 
 // Only a real shadow URL, or none at all.
 //

--- a/scripts/prisma-migrate-deploy.mjs
+++ b/scripts/prisma-migrate-deploy.mjs
@@ -10,7 +10,27 @@ import { withConnectionRetry } from './db-connection-retry.mjs'
 // Production migration execution must use the explicitly elevated migration
 // credential. DATABASE_URL belongs to the normal application/coding-agent lane
 // and is intentionally not accepted here.
-const databaseUrl = process.env.MIGRATION_DATABASE_URL?.trim()
+//
+// Strip surrounding quotes, for the same reason prisma.config.ts strips them
+// from SHADOW_DATABASE_URL: `import 'dotenv/config'` and docker compose's
+// `env_file:` both unquote values as they read them, but `docker run
+// --env-file` does NOT, because it is not a shell parser. So a perfectly
+// ordinary MIGRATION_DATABASE_URL="mysql://..." line in .env reaches this
+// script with the double quote as part of the value, and the failure lands
+// several steps later as an opaque
+//
+//   TypeError [ERR_INVALID_URL]: Invalid URL ... input: '"mysql:/
+//
+// from `new URL(databaseUrl)` further down -- after the CA has already loaded
+// and printed, which makes it read like a certificate problem rather than a
+// quoting one (2026-08-25: this blocked a production migration on Alexandria).
+// The runbook's documented invocation passes the credential from the shell via
+// `-e MIGRATION_DATABASE_URL`, where it is already unquoted; this is the
+// fallback path when it comes from --env-file instead.
+const databaseUrl = process.env.MIGRATION_DATABASE_URL?.trim().replace(
+  /^(["'])(.*)\1$/,
+  '$2',
+)
 const caFilePath = '/tmp/kindrobots-proxysql-ca.pem'
 
 if (!databaseUrl) {


### PR DESCRIPTION
Blocked a production migration on Alexandria today. The runbook's documented command failed with:

```
TypeError [ERR_INVALID_URL]: Invalid URL ... input: '"mysql:/
```

### This repo already knew about this bug
`prisma.config.ts` strips surrounding quotes from `SHADOW_DATABASE_URL` and carries a comment explaining exactly why:

> `import 'dotenv/config'` … strips surrounding quotes when it reads .env, and so does docker compose's `env_file:` — but `docker run --env-file` does **NOT**, because it is not a shell parser.

So an ordinary `MIGRATION_DATABASE_URL="mysql://..."` line in `.env` reaches the container with the double quote as part of the value. The strip was simply never applied to `MIGRATION_DATABASE_URL`, in **either** of the two places that read it. Both now do.

### Why it read as a certificate problem
The failure lands at `new URL(databaseUrl)` on line ~120 — **after** the CA has been decoded, validated and printed. The operator sees a successful `[database] Loaded ProxySQL CA subject=…` line and then `ERR_INVALID_URL`, which looks like TLS and isn't. The error also truncates the value (`'"mysql:/`), hiding that the problem is the very first character.

### Why this path opened at all
The runbook passes the credential from the shell via `-e MIGRATION_DATABASE_URL`, where it's already unquoted. That only falls through to `--env-file` when the shell variable is absent — which is what happened: `.secrets/kindrobots-db-migrate.env` didn't exist on the host, so `set -a; . ./.secrets/…` failed silently and the value came from `.env` instead.

**Worth checking separately:** whether the `MIGRATION_DATABASE_URL` in `.env` is the elevated `kindrobot_migrate` credential and not the app lane's. The credential boundary guard exists precisely to keep the application user out of schema writes, and it can only check the variable name, not which account is behind it.

### Safety
The regex uses a backreference — `^(["'])(.*)\1$` — so it strips only a **matched** pair. An unquoted URL is untouched; a password containing one stray quote isn't mangled.

### Verification
- `verifyMigrationCredentialBoundary.mjs` passes
- `vue-tsc --noEmit` exit 0
- All four quoting shapes (double, single, bare, whitespace-padded) parse as valid URLs after the strip

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFNZJyWZYdqphFMF2xXv5D)_