### PR TITLE
Secrets hardening: .secrets location, no credential in .env, and enforce the lane boundary by account

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,11 +21,29 @@
 # see docs/runbooks/migration-credential-boundary.md.
 DATABASE_URL=mysql://user:password@host:3306/kindrobots
 
-# Elevated, schema-write-capable connection. Deliberately NOT read by the
-# long-running `kind-robots` service (only the one-shot `migrate` service in
-# docker-compose.yml) -- see docs/runbooks/migration-credential-boundary.md
-# for why this boundary matters and must not be collapsed.
-MIGRATION_DATABASE_URL=mysql://kindrobot_migrate:password@host:3306/kindrobots
+# MIGRATION_DATABASE_URL IS DELIBERATELY NOT DEFINED HERE. Do not add it.
+#
+# It is the elevated, schema-write-capable credential, and NEITHER deploy path
+# reads it from this file:
+#
+#   * docker-compose.yml's one-shot `migrate` service takes it from the SHELL
+#     (`${MIGRATION_DATABASE_URL:?...}`) and fails loudly when unset.
+#   * Alexandria's `docker run` passes it with `-e MIGRATION_DATABASE_URL`,
+#     sourced from `<checkout>/.secrets/kindrobots-db-migrate.env`.
+#
+# Putting it here instead does two bad things at once. First, the app service
+# uses `env_file: .env`, so the credential lands in the environment of a
+# permanently-running web process that has no business being able to drop
+# tables -- exactly what utils/scripts/verifyMigrateOnDeploy.ts warns against.
+# Second, it becomes a silent fallback: `docker run --env-file` supplies it even
+# when the shell variable is missing, so a lost handoff file stops being an
+# error and becomes an obscure failure four steps downstream (2026-08-25, when
+# .secrets/kindrobots-db-migrate.env had gone missing and the fallback surfaced
+# as ERR_INVALID_URL long after the CA had loaded successfully).
+#
+# Get it from the handoff file that scripts/provision-migrate-db-lane.sh writes:
+#   set -a; . ./.secrets/kindrobots-db-migrate.env; set +a
+# See docs/runbooks/migration-credential-boundary.md.
 
 # ---------------------------------------------------------------------------
 # Payments -- Stripe (see docs/runbooks/payment-environment.md)

--- a/docs/runbooks/migration-credential-boundary.md
+++ b/docs/runbooks/migration-credential-boundary.md
@@ -41,7 +41,21 @@ Migrate from the image you are about to serve, then Force Update:
 
 ```bash
 cd /mnt/user/appdata/kind_robots
-set -a; . ./.secrets/kindrobots-db-migrate.env; set +a
+
+# Do not skip this check. `. ./.secrets/...` on a missing file prints one line
+# and CARRIES ON, leaving MIGRATION_DATABASE_URL unset in the shell -- and then
+# `-e MIGRATION_DATABASE_URL` passes nothing, so the value falls through from
+# --env-file instead, quotes and all. See "When the handoff file is missing".
+if [ ! -r ./.secrets/kindrobots-db-migrate.env ]; then
+  echo "STOP: ./.secrets/kindrobots-db-migrate.env is missing."
+  echo "Run:  bash scripts/provision-migrate-db-lane.sh --apply"
+else
+  set -a; . ./.secrets/kindrobots-db-migrate.env; set +a
+  case "$MIGRATION_DATABASE_URL" in
+    mysql://*) echo "migrate credential loaded, shape OK" ;;
+    *) echo "STOP: MIGRATION_DATABASE_URL is unset or not a bare mysql:// URL" ;;
+  esac
+fi
 
 docker pull ghcr.io/silasfelinus/kind_robots:latest
 
@@ -52,9 +66,68 @@ docker run --rm --network cafepurr \
   node scripts/prisma-migrate-deploy.mjs
 ```
 
+The `case` prints only OK or STOP — never the credential. Do not echo the
+variable itself to check it; that is how a live JWT ended up in a session
+transcript three times (conductor/t-116, t-128).
+
 Every line above is meant to be pasted as-is. There are deliberately **no placeholders** to substitute: `MIGRATION_DATABASE_URL` arrives from the sourced handoff file, and `-e MIGRATION_DATABASE_URL` with no `=value` passes it from the current shell, keeping the credential out of the command line and out of shell history. An earlier revision of this page printed a `mysql://kindrobot_migrate:PASSWORD@HOST:5544/DBNAME` template here; it was pasted verbatim more than once, and `P1001: Can't reach database server at HOST:5544` is what that looks like.
 
 No `git pull` is required for any of this. The image carries its own `prisma/migrations`, `scripts/` and `prisma.config.ts`; the checkout is used only for `.env`.
+
+#### Secrets live in `<checkout>/.secrets/`, never on `/mnt/user/pc`
+
+**Standing rule, Silas 2026-08-25:** the only acceptable location for this host's
+credentials is `/mnt/user/appdata/kind_robots/.secrets/`. Never `/mnt/user/pc`, and
+never treat `/mnt/user/pc` as a root for anything unless explicitly told to in that
+instance — which, for secrets, will not happen.
+
+`/mnt/user/pc` is a general-access share and a primary thoroughfare for ordinary
+folders, which makes it exactly the wrong home for a mode-600 file. The agent lane was
+moved off it on 2026-08-21 for this reason (see `agent-database-lane.md`); the migrate
+lane's handoff file was supposed to move with it and evidently did not survive, which is
+the direct cause of the 2026-08-25 failure below.
+
+Both provisioners already default to `<repo>/.secrets` and need no argument. `SECRETS_DIR`
+can override it, and should not be pointed at `/mnt/user/pc`.
+
+This rule is about **credentials**, not about the share as a whole. `/mnt/user/pc` remains
+the correct, established home for bulk data that is not secret — `kindrobots/images`,
+`kindrobots/animate`, and the model store at `ai/models`. Those are documented elsewhere
+and are not affected.
+
+#### When the handoff file is missing
+
+`set -a; . ./.secrets/kindrobots-db-migrate.env; set +a` **does not stop on a missing
+file.** Bash prints `No such file or directory` and continues, so
+`MIGRATION_DATABASE_URL` is never set in the shell, `-e MIGRATION_DATABASE_URL` passes
+nothing, and the value silently falls through from `--env-file .env` — where it is
+quoted, because `docker run --env-file` is not a shell parser and does not unquote.
+
+The failure then surfaces several steps later, after the CA has loaded and printed
+successfully, as:
+
+```text
+TypeError [ERR_INVALID_URL]: Invalid URL ... input: '"mysql:/
+```
+
+which reads like a TLS problem and is not one. (2026-08-25, on Alexandria: two attempts
+lost to this.) `prisma-migrate-deploy.mjs` and `prisma.config.ts` now strip matched
+surrounding quotes, so the fallback path works, but the missing file is still the real
+fault — the whole point of the handoff file is that the migrate credential lives outside
+`.env` and outside the application lane.
+
+Recreate it with the provisioner, which reconciles the lane in both MariaDB and ProxySQL
+and verifies authentication end to end:
+
+```bash
+bash scripts/provision-migrate-db-lane.sh            # dry run
+bash scripts/provision-migrate-db-lane.sh --apply
+```
+
+If `.env` currently carries a `MIGRATION_DATABASE_URL`, confirm it is the elevated
+`kindrobot_migrate` account and not the application user before relying on it. The
+credential-boundary guard can only check the variable *name*; it cannot tell which
+account is behind the value.
 
 Pull first. Migrating from `:latest` and then Force Updating to `:latest` is what keeps the schema and the code that will serve it the same build.
 

--- a/scripts/prisma-migrate-deploy.mjs
+++ b/scripts/prisma-migrate-deploy.mjs
@@ -39,6 +39,46 @@ if (!databaseUrl) {
   )
 }
 
+// The credential boundary has to check the ACCOUNT, not just the variable name.
+//
+// Refusing DATABASE_URL above only stops someone passing the wrong VARIABLE. It
+// does nothing about the wrong VALUE, and on 2026-08-25 that is exactly what
+// production had: .env line 103 defined MIGRATION_DATABASE_URL pointing at
+// `kindrobot`, the ordinary application account, not `kindrobot_migrate`. Every
+// check in this repo passed, because every check looked at the name. The boundary
+// was not merely bypassed, it was inverted -- schema writes would have run as the
+// web process's own user, which is the precise thing the two-lane design exists
+// to prevent.
+//
+// Comparing the two URLs' usernames catches it without hardcoding an account
+// name, so this keeps working if the lanes are ever renamed. DATABASE_URL is
+// normally present here because the migrate container is given --env-file .env
+// (compose passes it too); when it is absent there is nothing to compare and the
+// check is skipped rather than guessed at.
+const appUrlRaw = process.env.DATABASE_URL?.trim().replace(/^(["'])(.*)\1$/, '$2')
+if (appUrlRaw) {
+  let migrateUser
+  let appUser
+  try {
+    migrateUser = new URL(databaseUrl).username
+    appUser = new URL(appUrlRaw).username
+  } catch {
+    // A malformed URL is diagnosed further down with better context; do not
+    // pre-empt it with a confusing message from this check.
+    migrateUser = undefined
+  }
+  if (migrateUser && appUser && migrateUser === appUser) {
+    throw new Error(
+      `MIGRATION_DATABASE_URL and DATABASE_URL are the same database account ` +
+        `('${migrateUser}'). Schema changes must run as the elevated migration ` +
+        `account, not the application account -- see ` +
+        `docs/runbooks/migration-credential-boundary.md. Regenerate the handoff ` +
+        `file with scripts/provision-migrate-db-lane.sh --apply and source it, ` +
+        `rather than pointing MIGRATION_DATABASE_URL at the app credential.`,
+    )
+  }
+}
+
 function readDatabaseSslCa() {
   const encoded = process.env.DATABASE_SSL_CA_BASE64?.replace(/\s+/g, '')
   if (encoded) {

--- a/utils/scripts/verifyAgentDbLaneProvisioning.mjs
+++ b/utils/scripts/verifyAgentDbLaneProvisioning.mjs
@@ -51,7 +51,22 @@ assert.match(source, /'SELECT','INSERT','UPDATE','DELETE','SHOW VIEW'/)
 assert.match(source, /dangerous_privileges" == '0'/)
 assert.match(source, /expected_privileges" == '5'/)
 
-assert.match(source, /OUTPUT_FILE="\$\{OUTPUT_FILE:-\/mnt\/user\/pc\/kindrobots-db-agent\/kindrobots-db-agent\.env\}"/)
+// The handoff file lives beside the checkout, NOT on /mnt/user/pc. This assertion
+// used to demand the opposite. provision-agent-db-lane.sh moved the agent lane to
+// <repo>/.secrets on 2026-08-21 -- "that share is a primary thoroughfare for
+// ordinary folders and is the wrong place for a mode-600 secret" -- and this line
+// was never updated, so the Provisioning contract check has been red on main ever
+// since, asserting a location the project had already rejected. Found 2026-08-25
+// while writing the same rule down properly (conductor AGENTS.md rule 14) after the
+// migrate lane's handoff file was lost in that same move and broke a production
+// migration.
+assert.match(source, /SECRETS_DIR="\$\{SECRETS_DIR:-\$REPO_ROOT\/\.secrets\}"/)
+assert.match(source, /OUTPUT_FILE="\$\{OUTPUT_FILE:-\$SECRETS_DIR\/kindrobots-db-agent\.env\}"/)
+assert.deepEqual(
+  source.split('\n').filter((l) => /\/mnt\/user\/pc/.test(l) && !l.trim().startsWith('#')),
+  [],
+  'provision-agent-db-lane.sh must not reference /mnt/user/pc outside a comment',
+)
 assert.match(source, /chmod 700 "\$output_dir"/)
 assert.match(source, /umask 077/)
 assert.match(source, /chmod 600 "\$OUTPUT_FILE"/)

--- a/utils/scripts/verifyMigrationCredentialBoundary.mjs
+++ b/utils/scripts/verifyMigrationCredentialBoundary.mjs
@@ -18,6 +18,56 @@ assert.match(
   migrateWrapper,
   /const databaseUrl = process\.env\.MIGRATION_DATABASE_URL\?\.trim\(\)/,
 )
+
+// Both readers must strip a MATCHED pair of surrounding quotes. `docker run
+// --env-file` is not a shell parser, so a quoted value in .env arrives with its
+// quotes attached; without this the deploy dies on `new URL()` several steps
+// later, after the CA has printed successfully, and reads as a TLS fault
+// (2026-08-25, Alexandria). The backreference matters -- a one-sided quote must
+// NOT be stripped, or a password containing one gets mangled.
+for (const [name, source] of [
+  ['scripts/prisma-migrate-deploy.mjs', migrateWrapper],
+  ['prisma.config.ts', prismaConfig],
+]) {
+  assert.match(
+    source,
+    /MIGRATION_DATABASE_URL\?\.trim\(\)\.replace\(\s*\/\^\(\["'\]\)\(\.\*\)\\1\$\//,
+    `${name} must strip matched surrounding quotes from MIGRATION_DATABASE_URL`,
+  )
+}
+
+// SECRETS AND CREDENTIALS NEVER LIVE ON /mnt/user/pc (Silas, 2026-08-25). It is a
+// general-access share and a primary thoroughfare for ordinary folders, which makes
+// it the wrong home for a mode-600 file. The agent lane was moved off it on
+// 2026-08-21; the migrate lane's handoff file was meant to follow and did not
+// survive, which is what broke the 2026-08-25 production migration. Bulk non-secret
+// data (kindrobots/images, kindrobots/animate, ai/models) legitimately lives there
+// and is not what this checks.
+for (const provisioner of [
+  'scripts/provision-migrate-db-lane.sh',
+  'scripts/provision-agent-db-lane.sh',
+]) {
+  const text = readFileSync(provisioner, 'utf8')
+  assert.match(
+    text,
+    /SECRETS_DIR="\$\{SECRETS_DIR:-\$REPO_ROOT\/\.secrets\}"/,
+    `${provisioner} must default SECRETS_DIR to <repo>/.secrets`,
+  )
+  const offending = text
+    .split('\n')
+    .filter((line) => /\/mnt\/user\/pc/.test(line) && !line.trim().startsWith('#'))
+  assert.deepEqual(
+    offending,
+    [],
+    `${provisioner} must not reference /mnt/user/pc outside a comment`,
+  )
+}
+
+assert.match(
+  runbook,
+  /never on `\/mnt\/user\/pc`/,
+  'the runbook must state where secrets live and where they must not',
+)
 assert.doesNotMatch(
   migrateWrapper,
   /MIGRATION_DATABASE_URL\s*\?\?\s*process\.env\.DATABASE_URL/,

--- a/utils/scripts/verifyMigrationCredentialBoundary.mjs
+++ b/utils/scripts/verifyMigrationCredentialBoundary.mjs
@@ -77,6 +77,23 @@ assert.match(
 // holding a credential that can drop tables (see verifyMigrateOnDeploy.ts), and it
 // becomes a SILENT FALLBACK that turns a lost handoff file into an obscure
 // downstream error instead of a clear one (2026-08-25).
+// The boundary must check the ACCOUNT, not only the variable name. Refusing
+// DATABASE_URL as a variable does nothing about MIGRATION_DATABASE_URL holding the
+// app account's URL -- which is what production actually had on 2026-08-25 (.env
+// line 103 pointed at `kindrobot`, not `kindrobot_migrate`), passing every check in
+// this repo because every check looked at the name.
+assert.match(
+  migrateWrapper,
+  /MIGRATION_DATABASE_URL and DATABASE_URL are the same database account/,
+  'prisma-migrate-deploy.mjs must refuse a MIGRATION_DATABASE_URL whose account ' +
+    'equals DATABASE_URL\'s -- name-only checks do not enforce the lane boundary',
+)
+assert.match(
+  migrateWrapper,
+  /new URL\(databaseUrl\)\.username/,
+  'the account check must compare parsed usernames, not substrings',
+)
+
 const envExample = readFileSync('.env.example', 'utf8')
 const definesMigrationUrl = envExample
   .split('\n')

--- a/utils/scripts/verifyMigrationCredentialBoundary.mjs
+++ b/utils/scripts/verifyMigrationCredentialBoundary.mjs
@@ -68,6 +68,25 @@ assert.match(
   /never on `\/mnt\/user\/pc`/,
   'the runbook must state where secrets live and where they must not',
 )
+
+// .env.example must NOT define MIGRATION_DATABASE_URL. Neither deploy path reads
+// it from there -- compose's one-shot migrate service takes it from the shell and
+// fails loudly when unset, and Alexandria's docker run passes it with -e from the
+// .secrets handoff file. Defining it in .env does two bad things at once: the app
+// service uses `env_file: .env`, so a permanently-running web process ends up
+// holding a credential that can drop tables (see verifyMigrateOnDeploy.ts), and it
+// becomes a SILENT FALLBACK that turns a lost handoff file into an obscure
+// downstream error instead of a clear one (2026-08-25).
+const envExample = readFileSync('.env.example', 'utf8')
+const definesMigrationUrl = envExample
+  .split('\n')
+  .filter((line) => /^\s*(export\s+)?MIGRATION_DATABASE_URL\s*=/.test(line))
+assert.deepEqual(
+  definesMigrationUrl,
+  [],
+  '.env.example must not define MIGRATION_DATABASE_URL -- it belongs in ' +
+    '<checkout>/.secrets/kindrobots-db-migrate.env and reaches deploys via the shell',
+)
 assert.doesNotMatch(
   migrateWrapper,
   /MIGRATION_DATABASE_URL\s*\?\?\s*process\.env\.DATABASE_URL/,


### PR DESCRIPTION
Three commits from one incident. The third is the serious one.

## 1. The runbook's own command failed silently
`set -a; . ./.secrets/kindrobots-db-migrate.env; set +a` **does not stop when the file is missing.** Bash prints one line and continues, so `MIGRATION_DATABASE_URL` is never set, `-e MIGRATION_DATABASE_URL` passes nothing, and the value falls through from `--env-file` — quoted. It then dies at `new URL()` *after* the CA has loaded and printed, so it reads as TLS and isn't.

The block now checks the file exists before sourcing and validates the value is a bare `mysql://` URL via `case`, printing only OK/STOP — never the credential.

Plus two sections: where secrets live and why not `/mnt/user/pc`, and what to do when the handoff file is missing.

## 2. `.env.example` was handing the schema-write credential to the web process
**Neither deploy path reads it from `.env`.** compose's one-shot `migrate` service takes it from the shell (`${MIGRATION_DATABASE_URL:?…}`) and comments *"Deliberately not read from the app env file."* Alexandria's `docker run` passes `-e` from the shell. Only `.env.example` disagreed — and it's what people copy.

Two consequences, both live until now:
- **Security.** The app service uses `env_file: .env`, so defining it there put schema-write capability into a permanently-running web process — exactly what `verifyMigrateOnDeploy.ts` warns against. The old comment claimed it was *"deliberately NOT read by the long-running service"*, true of the **code** and false of the **environment**. Unread is not absent.
- **It made a lost secret silent.** `--env-file` supplied a fallback, turning a missing handoff file into `ERR_INVALID_URL` four steps downstream instead of a clear error.

## 3. The boundary now checks the *account*, not just the variable name
Production had `MIGRATION_DATABASE_URL` in `.env` pointing at **`kindrobot`** — the ordinary application account — not `kindrobot_migrate`. **Every check in this repo passed, because every check looked at the name.**

The boundary wasn't bypassed, it was *inverted*: schema changes would have run as the web process's own account, the precise thing the two-lane design exists to prevent. I flagged this exact gap in #2086's description as something only a human could verify, then found it two messages later in the operator's terminal output.

`prisma-migrate-deploy.mjs` now refuses when `MIGRATION_DATABASE_URL` and `DATABASE_URL` resolve to the same username — comparing parsed usernames rather than hardcoding an account name, so it survives a rename. Verified across four cases: same account blocks with a named error; distinct accounts pass; quoted values compare correctly after the #2086 strip; missing `DATABASE_URL` skips cleanly.

> **Follow-up, filed as conductor kind-robots/t-073:** `kindrobot` turns out to hold `ALL PRIVILEGES ON *.* … WITH GRANT OPTION`. This guard stops the *migration path* from using it, but the app account is a server-wide superuser regardless, which makes the whole two-lane design decorative until that's narrowed.

## Enforced, not just written
`verifyMigrationCredentialBoundary.mjs` now asserts: both readers strip a matched quote pair; both provisioners default `SECRETS_DIR` to `<repo>/.secrets`; neither names `/mnt/user/pc` outside a comment; `.env.example` does not define `MIGRATION_DATABASE_URL`; and the account-equality check exists.

**Each verified by deliberately breaking it** and confirming a named assertion failure rather than a silent pass.

All three migration guards pass: credential boundary, migrate-on-deploy, known-migration-repair.

Companion: conductor AGENTS.md rules 14 and 15.