### PR TITLE
fix: make Coloring Book art-first

### DIFF
--- a/components/coloring/coloring-book-page.vue
+++ b/components/coloring/coloring-book-page.vue
@@ -8,20 +8,44 @@
   >
     <template #interactive>
       <div class="flex flex-col gap-5">
-        <coloring-book-readiness />
-        <coloring-book-package-readiness />
-        <coloring-book-cover-studio />
-        <div id="coloring-production-actions">
-          <coloring-book-production-toolbar />
-        </div>
-        <coloring-book-production-history />
-        <coloring-book-studio />
+        <CurationColoringBookCuration />
+
+        <details class="group rounded-3xl border border-base-300 bg-base-100 shadow-sm">
+          <summary
+            class="flex cursor-pointer list-none flex-wrap items-center justify-between gap-3 p-4 marker:hidden"
+          >
+            <div>
+              <h3 class="flex items-center gap-2 text-lg font-black">
+                <Icon name="kind-icon:activity" class="size-5 text-primary" />
+                Production controls & diagnostics
+              </h3>
+              <p class="mt-1 text-sm text-base-content/55">
+                Readiness, packaging, covers, queue actions, history, and the full ledger inspector.
+              </p>
+            </div>
+            <span class="badge badge-outline rounded-2xl group-open:badge-primary">
+              Secondary tools
+            </span>
+          </summary>
+
+          <div class="flex flex-col gap-5 border-t border-base-300 p-4">
+            <coloring-book-readiness />
+            <coloring-book-package-readiness />
+            <coloring-book-cover-studio />
+            <div id="coloring-production-actions">
+              <coloring-book-production-toolbar />
+            </div>
+            <coloring-book-production-history />
+            <coloring-book-studio />
+          </div>
+        </details>
       </div>
     </template>
   </project-front-page>
 </template>
 
 <script setup lang="ts">
+import CurationColoringBookCuration from '@/components/curation/coloring-book-curation.vue'
 import type { ProjectFrontConfig } from '@/components/conductor/projectFront'
 
 const config: ProjectFrontConfig = {

--- a/components/curation/coloring-book-curation.vue
+++ b/components/curation/coloring-book-curation.vue
@@ -9,7 +9,7 @@
           @change="store.selectBook(eventValue($event))"
         >
           <option v-for="book in store.books" :key="book.slug" :value="book.slug">
-            {{ book.title }} · {{ book.counts.finalPairs }}/{{ book.counts.total }} final
+            {{ book.title }} · {{ book.counts.acceptedColor }}/{{ book.counts.total }} color accepted
           </option>
         </select>
       </label>
@@ -29,7 +29,12 @@
         Hide final pairs
       </label>
 
-      <button class="btn btn-sm rounded-xl" type="button" :disabled="store.loading" @click="refresh">
+      <button
+        class="btn btn-sm rounded-xl"
+        type="button"
+        :disabled="store.loading"
+        @click="refresh"
+      >
         <span v-if="store.loading" class="loading loading-spinner loading-xs" />
         Refresh
       </button>
@@ -44,7 +49,7 @@
       <button class="btn btn-ghost btn-xs" type="button" @click="error = ''">Dismiss</button>
     </div>
 
-    <div v-if="store.loading" class="grid min-h-64 place-items-center kr-panel">
+    <div v-if="store.loading && !store.books.length" class="grid min-h-64 place-items-center kr-panel">
       <span class="loading loading-spinner loading-lg text-primary" />
     </div>
 
@@ -55,78 +60,91 @@
       <p class="font-black">No pages match this view.</p>
     </div>
 
-    <div v-else class="flex flex-wrap items-start gap-4">
+    <div
+      v-else
+      class="grid gap-4"
+      style="grid-template-columns: repeat(auto-fill, minmax(min(290px, 100%), 1fr))"
+    >
       <article
         v-for="proposal in visibleProposals"
         :key="proposal.id"
-        class="kr-panel min-w-0 flex-[1_1_28rem] overflow-hidden"
+        class="kr-panel min-w-0 overflow-hidden"
       >
-        <div class="border-b border-base-300 bg-base-200/60 p-4">
-          <div class="flex items-start justify-between gap-3">
-            <div>
-              <p class="text-[11px] font-black uppercase tracking-wider text-primary">Slot {{ proposal.slot }}</p>
-              <h2 class="mt-1 text-xl font-black">{{ proposal.title }}</h2>
+        <div class="relative aspect-[17/22] overflow-hidden bg-base-200">
+          <img
+            v-if="proposal.colorUrl"
+            :src="proposal.colorUrl"
+            :alt="`${proposal.title} color candidate`"
+            class="size-full object-cover"
+            loading="lazy"
+          />
+          <img
+            v-else-if="bwDisplayUrl(proposal)"
+            :src="bwDisplayUrl(proposal) || ''"
+            :alt="`${proposal.title} black and white candidate`"
+            class="size-full object-cover grayscale"
+            loading="lazy"
+          />
+          <div v-else class="grid size-full place-items-center text-base-content/30">
+            <div class="text-center">
+              <Icon name="kind-icon:image" class="mx-auto size-12" />
+              <p class="mt-2 text-xs font-bold">No candidate art yet</p>
             </div>
-            <span
-              class="badge badge-sm"
-              :class="proposal.final.color && proposal.final.bw ? 'badge-success' : 'badge-outline'"
-            >
-              {{ proposal.final.color && proposal.final.bw ? 'final' : proposal.queue.status }}
+          </div>
+
+          <div class="absolute inset-x-0 top-0 flex items-start justify-between gap-2 p-3">
+            <span class="badge border-0 bg-base-100/90 font-black shadow-sm backdrop-blur">
+              {{ proposal.id }}
+            </span>
+            <span class="badge border-0 shadow-sm" :class="stageBadge(proposal)">
+              {{ stageLabel(proposal) }}
             </span>
           </div>
-          <p v-if="proposal.notes.length" class="mt-2 text-xs leading-5 text-base-content/55">
-            {{ proposal.notes.join(' · ') }}
-          </p>
+
+          <figure
+            v-if="proposal.colorUrl && bwDisplayUrl(proposal)"
+            class="absolute bottom-3 right-3 w-[34%] overflow-hidden rounded-xl border-2 border-base-100 bg-base-100 shadow-lg"
+          >
+            <img
+              :src="bwDisplayUrl(proposal) || ''"
+              :alt="`${proposal.title} black and white candidate`"
+              class="aspect-[17/22] w-full object-cover grayscale"
+              loading="lazy"
+            />
+            <figcaption class="bg-base-100 px-2 py-1 text-center text-[10px] font-black">
+              B&amp;W
+            </figcaption>
+          </figure>
         </div>
 
         <div class="space-y-4 p-4">
-          <div class="grid grid-cols-2 gap-2">
-            <figure class="overflow-hidden rounded-xl bg-base-200">
-              <div class="aspect-square">
-                <img
-                  v-if="proposal.colorUrl"
-                  :src="proposal.colorUrl"
-                  :alt="`${proposal.title} color candidate`"
-                  class="size-full object-cover"
-                />
-                <div v-else class="grid size-full place-items-center text-xs text-base-content/35">
-                  No color candidate
-                </div>
-              </div>
-              <figcaption class="flex items-center justify-between gap-2 p-2 text-[11px] font-black">
-                <span>COLOR</span>
-                <span class="opacity-50">{{ proposal.accepted.color ? 'accepted' : 'candidate' }}</span>
-              </figcaption>
-            </figure>
-
-            <figure class="overflow-hidden rounded-xl bg-base-200">
-              <div class="aspect-square">
-                <img
-                  v-if="proposal.bwUrl"
-                  :src="proposal.bwUrl"
-                  :alt="`${proposal.title} black and white candidate`"
-                  class="size-full object-cover"
-                />
-                <div v-else class="grid size-full place-items-center text-xs text-base-content/35">
-                  No B&amp;W candidate
-                </div>
-              </div>
-              <figcaption class="flex items-center justify-between gap-2 p-2 text-[11px] font-black">
-                <span>BLACK + WHITE</span>
-                <span class="opacity-50">{{ proposal.accepted.bw ? 'accepted' : 'candidate' }}</span>
-              </figcaption>
-            </figure>
+          <div>
+            <p class="text-[11px] font-black uppercase tracking-wider text-primary">
+              Slot {{ proposal.slot }}
+            </p>
+            <h2 class="mt-1 text-xl font-black leading-tight">{{ proposal.title }}</h2>
+            <p v-if="proposal.notes.length" class="mt-2 line-clamp-2 text-xs leading-5 text-base-content/55">
+              {{ proposal.notes.join(' · ') }}
+            </p>
           </div>
 
           <div v-if="proposal.inspirations.length" class="flex gap-2 overflow-x-auto pb-1">
-            <figure v-for="asset in proposal.inspirations" :key="asset.path" class="w-20 shrink-0">
+            <figure
+              v-for="asset in proposal.inspirations"
+              :key="`${proposal.id}:${asset.path}`"
+              class="w-16 shrink-0"
+            >
               <img
                 v-if="asset.url"
                 :src="asset.url"
                 :alt="asset.kind"
                 class="aspect-square w-full rounded-lg object-cover"
+                loading="lazy"
               />
-              <div v-else class="grid aspect-square w-full place-items-center rounded-lg bg-base-200 text-[10px] text-base-content/35">
+              <div
+                v-else
+                class="grid aspect-square w-full place-items-center rounded-lg bg-base-200 text-[10px] text-base-content/35"
+              >
                 reference
               </div>
             </figure>
@@ -136,35 +154,52 @@
             <span class="text-xs font-black">Pitch / art prompt</span>
             <textarea
               v-model="drafts[proposal.id]"
-              class="textarea textarea-bordered min-h-32 rounded-xl text-sm leading-5"
+              class="textarea textarea-bordered min-h-28 rounded-xl text-sm leading-5"
+              :readonly="!userStore.isAdmin"
             />
           </label>
 
-          <div class="flex flex-wrap gap-2">
-            <button class="btn btn-primary btn-sm rounded-xl" type="button" :disabled="store.savingPrompt" @click="savePrompt(proposal.id)">
+          <div v-if="userStore.isAdmin" class="flex flex-wrap gap-2">
+            <button
+              class="btn btn-primary btn-sm rounded-xl"
+              type="button"
+              :disabled="store.savingPrompt || !promptChanged(proposal)"
+              @click="savePrompt(proposal.id)"
+            >
               Save prompt
             </button>
-            <button class="btn btn-sm rounded-xl" type="button" :disabled="store.requestingAction" @click="render(proposal.id, 'color')">
+            <button
+              class="btn btn-sm rounded-xl"
+              type="button"
+              :disabled="store.requestingAction"
+              @click="render(proposal.id, 'color')"
+            >
               New color
             </button>
-            <button class="btn btn-sm rounded-xl" type="button" :disabled="store.requestingAction" @click="render(proposal.id, 'bw')">
+            <button
+              v-if="proposal.accepted.color"
+              class="btn btn-sm rounded-xl"
+              type="button"
+              :disabled="store.requestingAction"
+              @click="render(proposal.id, 'bw')"
+            >
               New B&amp;W
             </button>
             <button
-              v-if="proposal.colorPath"
+              v-if="colorCandidatePath(proposal)"
               class="btn btn-success btn-outline btn-sm rounded-xl"
               type="button"
               :disabled="store.requestingAction"
-              @click="acceptColor(proposal.id, proposal.colorPath)"
+              @click="acceptColor(proposal.id, colorCandidatePath(proposal) || '')"
             >
               Accept color
             </button>
             <button
-              v-if="proposal.bwPath"
+              v-if="bwCandidatePath(proposal)"
               class="btn btn-success btn-outline btn-sm rounded-xl"
               type="button"
               :disabled="store.requestingAction"
-              @click="acceptBw(proposal.id, proposal.bwPath)"
+              @click="acceptBw(proposal.id, bwCandidatePath(proposal) || '')"
             >
               Accept B&amp;W
             </button>
@@ -178,6 +213,11 @@
               Finalize pair
             </button>
           </div>
+
+          <div v-else class="flex items-center gap-2 text-xs text-base-content/45">
+            <Icon name="kind-icon:lock" class="size-4" />
+            Production edits are admin-only.
+          </div>
         </div>
       </article>
     </div>
@@ -186,10 +226,15 @@
 
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref } from 'vue'
-import type { ColoringBookProposal } from '~/types/coloringBookStudio'
+import type {
+  ColoringBookProductionState,
+  ColoringBookProposal,
+} from '~/types/coloringBookStudio'
 import { useColoringBookStudioStore } from '@/stores/coloringBookStudioStore'
+import { useUserStore } from '@/stores/userStore'
 
 const store = useColoringBookStudioStore()
+const userStore = useUserStore()
 const search = ref('')
 const hideFinal = ref(false)
 const notice = ref('')
@@ -208,63 +253,135 @@ const visibleProposals = computed<ColoringBookProposal[]>(() => {
   })
 })
 
-onMounted(refresh)
+onMounted(async () => {
+  await userStore.initialize()
+  await refresh()
+})
 
-async function refresh() {
+async function refresh(): Promise<void> {
   error.value = ''
   await store.fetchStudio()
+  syncDrafts()
+  if (store.error) error.value = store.error
+}
+
+function syncDrafts(): void {
   for (const book of store.books) {
     for (const proposal of book.proposals) {
       drafts[proposal.id] = proposal.prompt
     }
   }
-  if (store.error) error.value = store.error
 }
 
 function eventValue(event: Event): string {
   return (event.target as HTMLSelectElement).value
 }
 
-function select(proposalId: string) {
+function productionState(proposalId: string): ColoringBookProductionState | null {
+  return store.productionStates[`${store.selectedBookSlug}:${proposalId}`] ?? null
+}
+
+function bwDisplayUrl(proposal: ColoringBookProposal): string | null {
+  return productionState(proposal.id)?.bwUrl || proposal.bwUrl
+}
+
+function colorCandidatePath(proposal: ColoringBookProposal): string | null {
+  if (proposal.accepted.color || proposal.final.color) return null
+  return proposal.queue.renderedPath
+}
+
+function bwCandidatePath(proposal: ColoringBookProposal): string | null {
+  if (proposal.accepted.bw || proposal.final.bw) return null
+  return productionState(proposal.id)?.bwRenderedPath ?? null
+}
+
+function promptChanged(proposal: ColoringBookProposal): boolean {
+  return (drafts[proposal.id] || '').trim() !== proposal.prompt.trim()
+}
+
+function stageLabel(proposal: ColoringBookProposal): string {
+  if (proposal.final.color && proposal.final.bw) return 'Final pair'
+  if (proposal.accepted.color && proposal.accepted.bw) return 'Ready to finalize'
+  if (bwCandidatePath(proposal)) return 'Accept B&W'
+  if (proposal.accepted.color) return 'Build B&W'
+  if (colorCandidatePath(proposal)) return 'Accept color'
+  if (proposal.queue.status === 'pending' || proposal.queue.status === 'running') {
+    return 'Rendering color'
+  }
+  if (proposal.queue.status === 'needs_review' || proposal.queue.semanticGateError) {
+    return 'Needs review'
+  }
+  return 'Needs color'
+}
+
+function stageBadge(proposal: ColoringBookProposal): string {
+  if (proposal.final.color && proposal.final.bw) return 'badge-success'
+  if (proposal.accepted.color && proposal.accepted.bw) return 'badge-success'
+  if (proposal.queue.status === 'needs_review' || proposal.queue.semanticGateError) {
+    return 'badge-warning'
+  }
+  if (proposal.queue.status === 'pending' || proposal.queue.status === 'running') {
+    return 'badge-info'
+  }
+  return 'badge-neutral'
+}
+
+function select(proposalId: string): void {
   store.selectProposal(proposalId)
 }
 
-async function savePrompt(proposalId: string) {
+async function savePrompt(proposalId: string): Promise<void> {
   select(proposalId)
   const ok = await store.savePrompt(drafts[proposalId] || '')
   if (ok) {
     notice.value = store.message || 'Prompt saved.'
-    await refresh()
-  } else if (store.error) error.value = store.error
+    syncDrafts()
+  } else if (store.error) {
+    error.value = store.error
+  }
 }
 
-async function render(proposalId: string, variant: 'color' | 'bw') {
+async function render(proposalId: string, variant: 'color' | 'bw'): Promise<void> {
   select(proposalId)
-  const ok = variant === 'color'
-    ? await store.requestColorRender(true, 'Requested from Curation Studio')
-    : await store.requestBw(true, 'Requested from Curation Studio')
-  if (ok) notice.value = store.message || `${variant} render requested.`
-  else if (store.error) error.value = store.error
+  const ok =
+    variant === 'color'
+      ? await store.requestColorRender(true, 'Requested from Coloring Book curation')
+      : await store.requestBw(true, 'Requested from Coloring Book curation')
+  if (ok) {
+    notice.value = store.message || `${variant} render requested.`
+    syncDrafts()
+  } else if (store.error) {
+    error.value = store.error
+  }
 }
 
-async function acceptColor(proposalId: string, sourcePath: string) {
+async function acceptColor(proposalId: string, sourcePath: string): Promise<void> {
   select(proposalId)
-  if (await store.acceptColor('Accepted from Curation Studio', sourcePath)) {
+  if (await store.acceptColor('Accepted from Coloring Book curation', sourcePath)) {
     notice.value = store.message || 'Color candidate accepted.'
-  } else if (store.error) error.value = store.error
+    syncDrafts()
+  } else if (store.error) {
+    error.value = store.error
+  }
 }
 
-async function acceptBw(proposalId: string, sourcePath: string) {
+async function acceptBw(proposalId: string, sourcePath: string): Promise<void> {
   select(proposalId)
-  if (await store.acceptBw('Accepted from Curation Studio', sourcePath)) {
+  if (await store.acceptBw('Accepted from Coloring Book curation', sourcePath)) {
     notice.value = store.message || 'B&W candidate accepted.'
-  } else if (store.error) error.value = store.error
+    syncDrafts()
+  } else if (store.error) {
+    error.value = store.error
+  }
 }
 
-async function finalize(proposalId: string) {
+async function finalize(proposalId: string): Promise<void> {
   select(proposalId)
-  if (await store.finalizePair('Finalized from Curation Studio')) {
+  if (await store.finalizePair('Finalized from Coloring Book curation')) {
     notice.value = store.message || 'Pair finalized.'
-  } else if (store.error) error.value = store.error
+    syncDrafts()
+  } else if (store.error) {
+    error.value = store.error
+  }
 }
 </script>


### PR DESCRIPTION
## What was wrong
The live `/coloring` project surface still mounted the text-only readiness dashboard first. The art-forward curation component added in #2079 existed on `/admin/curation-studio`, but it was never made the primary Coloring Book surface. The screenshot Silas supplied is therefore the old readiness renderer, not the curation gallery.

## What this changes
- Makes the existing Coloring Book curation gallery the first production surface on `/coloring`.
- Moves readiness, package, cover, queue/history, and the full ledger inspector into a collapsed secondary diagnostics section instead of leading with text cards.
- Makes proposal cards image-first with a large portrait color candidate and an inset B&W pair when available.
- Keeps search, book selection, final-pair filtering, inspiration references, and inline prompt editing directly beside the art.
- Hides production edits from non-admin users while preserving a read-only art view.
- Repairs candidate acceptance so color uses the queue's rendered path and B&W uses the production state's rendered path instead of optional proposal path fields that were never populated.
- Preserves the color-first contract: B&W generation only appears after the color composition is accepted.

## Scope
Two Vue components only. No schema changes, no new API surface, no deployment action, and no duplicate source of production truth.

## Verification
Branch is current with `main` and changes only the two intended frontend files. Required CI should validate TypeScript, layout contracts, component reachability, and repo contracts on the PR head.

## Flags for Reviewer
This corrects the actual route Silas was viewing rather than adding another parallel manager. Real pixel verification still requires the self-hosted `kindrobots.org` container to pick up the merged commit; this PR does not trigger deployment.