### PR TITLE
feat: add durable requested Mandarin cards

### DIFF
--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -18,6 +18,10 @@
               <div class="stat-title text-xs">Sets</div>
               <div class="stat-value text-xl">{{ allSets.length }}</div>
             </div>
+            <div class="stat px-4 py-2">
+              <div class="stat-title text-xs">Requested</div>
+              <div class="stat-value text-xl">{{ requestedCards.length }}</div>
+            </div>
           </div>
         </div>
         <div class="rounded-2xl border border-base-300 bg-base-200/50 p-3 text-xs leading-relaxed opacity-80">
@@ -73,9 +77,23 @@
                 <span class="mt-1 block truncate text-xs opacity-70">{{ card.meaning }}</span>
               </button>
             </div>
-            <p v-else class="mt-2 text-sm opacity-60">
-              That term is not in the starter catalog yet. Free-form word creation is tracked separately so generated translations and etymology never masquerade as curated facts.
-            </p>
+            <div v-else class="flex flex-col gap-3 rounded-2xl border border-dashed border-base-300 bg-base-200/30 p-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p class="font-semibold">Not in the catalog yet.</p>
+                <p class="mt-1 max-w-2xl text-xs leading-relaxed opacity-65">
+                  Create a requested card for “{{ searchQuery.trim() }}”. Its translation and usage fields will be clearly labeled as AI-generated; character decomposition remains separately sourced when available.
+                </p>
+              </div>
+              <button
+                class="btn btn-primary shrink-0"
+                type="button"
+                :disabled="requestingWord"
+                @click="requestCurrentWord"
+              >
+                <span v-if="requestingWord" class="loading loading-spinner loading-xs" />
+                {{ requestingWord ? 'Creating card…' : 'Create requested card' }}
+              </button>
+            </div>
           </div>
         </section>
 
@@ -114,6 +132,27 @@
               <button v-if="focusKey" type="button" class="btn btn-ghost btn-sm" @click="store.clearFocus()">
                 Return to deck
               </button>
+            </div>
+
+            <div
+              v-if="currentRequested"
+              class="rounded-2xl border border-warning/40 bg-warning/10 p-4 text-sm"
+            >
+              <div class="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p class="font-black">AI-generated requested card</p>
+                  <p class="mt-1 max-w-3xl text-xs leading-relaxed opacity-75">
+                    This card was generated for “{{ currentRequested.requestText }}”; it is not being presented as a dictionary-sourced entry. Character analysis, when shown below, is enriched separately from the sourced character dataset.
+                  </p>
+                </div>
+                <span class="badge badge-warning badge-outline">requested</span>
+              </div>
+              <p v-if="currentRequested.usageNote" class="mt-3 rounded-xl bg-base-100/60 p-3 text-xs leading-relaxed">
+                <span class="font-bold">Usage note:</span> {{ currentRequested.usageNote }}
+              </p>
+              <p class="mt-2 text-[11px] opacity-60">
+                {{ currentRequested.provenance.provider }} · {{ currentRequested.provenance.model }} · recipe {{ currentRequested.provenance.recipeVersion }}
+              </p>
             </div>
 
             <article
@@ -254,6 +293,9 @@
                     <div class="text-xs opacity-55">
                       Source: {{ currentCard.source.label }} · {{ currentCard.source.version }}
                     </div>
+                    <p v-if="currentCard.source.licenseNote" class="text-[11px] leading-relaxed opacity-50">
+                      {{ currentCard.source.licenseNote }}
+                    </p>
                   </div>
                 </div>
               </section>
@@ -287,7 +329,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import MandarinVoiceCoach from '@/components/mandarin/mandarin-voice-coach.vue'
 import { useMandarinTutorStore } from '@/stores/mandarinTutorStore'
@@ -298,6 +340,7 @@ const {
   cards,
   allSets,
   customSets,
+  requestedCards,
   selectedSetId,
   selectedSet,
   currentCard,
@@ -308,10 +351,14 @@ const {
   detailsVisible,
   loading,
   initialized,
+  requestingWord,
   audioSupported,
 } = storeToRefs(store)
 
 const newSetName = ref('')
+const currentRequested = computed(() =>
+  currentCard.value ? store.requestedData(currentCard.value.key) : null,
+)
 
 function createSet() {
   const created = store.createCustomSet(newSetName.value)
@@ -320,8 +367,16 @@ function createSet() {
   store.selectSet(`custom:${created.id}`)
 }
 
+async function requestCurrentWord() {
+  await store.requestWord(searchQuery.value)
+}
+
 async function artAction(card: MandarinCard) {
   if (store.illustrationUrl(card.key)) return
+  if (store.requestedData(card.key)) {
+    await store.refreshRequestedIllustration(card)
+    return
+  }
   if (store.illustrationJobId(card.key)) {
     await store.refreshIllustration(card)
     return
@@ -332,6 +387,9 @@ async function artAction(card: MandarinCard) {
 function artActionLabel(card: MandarinCard): string {
   if (store.illustrationUrl(card.key)) return 'Art ready'
   const jobId = store.illustrationJobId(card.key)
+  if (store.requestedData(card.key)) {
+    return jobId ? `Refresh ArtJob #${jobId}` : 'Queue Krea 2 art'
+  }
   return jobId ? `Refresh ArtJob #${jobId}` : 'Queue Krea 2 art'
 }
 

--- a/prisma/mandarin_requests.prisma
+++ b/prisma/mandarin_requests.prisma
@@ -1,0 +1,36 @@
+/// User-requested Mandarin learning cards. Core HSK/curated vocabulary remains
+/// source-backed and code/data driven; these rows are explicitly generated
+/// additions whose provider/model provenance is retained permanently.
+///
+/// userId is intentionally a plain ownership scalar in v1 rather than a Prisma
+/// relation so this additive model does not need to modify the already-crowded
+/// User model merely to establish a back-reference. Every API access is scoped
+/// by authenticated userId.
+model MandarinRequestedCard {
+  id                    Int      @id @default(autoincrement())
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @default(now()) @updatedAt
+  userId                Int
+  requestText           String   @db.VarChar(255)
+  normalizedRequest     String   @db.VarChar(255)
+  simplified            String   @db.VarChar(255)
+  traditional           String?  @db.VarChar(255)
+  pinyin                String   @db.VarChar(512)
+  meaning               String   @db.Text
+  meanings              String   @db.LongText
+  usageNote             String?  @db.Text
+  provider              String   @db.VarChar(64)
+  model                 String   @db.VarChar(255)
+  recipeVersion         String   @db.VarChar(32)
+  generationProvenance  String   @db.Text
+  artPrompt             String   @db.Text
+  artPromptVersion      String   @db.VarChar(32)
+  artJobId              Int?
+  artImageId            Int?
+  isActive              Boolean  @default(true)
+
+  @@unique([userId, normalizedRequest])
+  @@index([userId, isActive])
+  @@index([artJobId])
+  @@index([artImageId])
+}

--- a/prisma/migrations/20260825053000_add_mandarin_requested_card/migration.sql
+++ b/prisma/migrations/20260825053000_add_mandarin_requested_card/migration.sql
@@ -1,0 +1,30 @@
+-- CreateTable
+CREATE TABLE `MandarinRequestedCard` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+    `userId` INTEGER NOT NULL,
+    `requestText` VARCHAR(255) NOT NULL,
+    `normalizedRequest` VARCHAR(255) NOT NULL,
+    `simplified` VARCHAR(255) NOT NULL,
+    `traditional` VARCHAR(255) NULL,
+    `pinyin` VARCHAR(512) NOT NULL,
+    `meaning` TEXT NOT NULL,
+    `meanings` LONGTEXT NOT NULL,
+    `usageNote` TEXT NULL,
+    `provider` VARCHAR(64) NOT NULL,
+    `model` VARCHAR(255) NOT NULL,
+    `recipeVersion` VARCHAR(32) NOT NULL,
+    `generationProvenance` TEXT NOT NULL,
+    `artPrompt` TEXT NOT NULL,
+    `artPromptVersion` VARCHAR(32) NOT NULL,
+    `artJobId` INTEGER NULL,
+    `artImageId` INTEGER NULL,
+    `isActive` BOOLEAN NOT NULL DEFAULT true,
+
+    UNIQUE INDEX `MandarinRequestedCard_userId_normalizedRequest_key`(`userId`, `normalizedRequest`),
+    INDEX `MandarinRequestedCard_userId_isActive_idx`(`userId`, `isActive`),
+    INDEX `MandarinRequestedCard_artJobId_idx`(`artJobId`),
+    INDEX `MandarinRequestedCard_artImageId_idx`(`artImageId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/server/api/mandarin/audio.post.ts
+++ b/server/api/mandarin/audio.post.ts
@@ -4,7 +4,7 @@ import { errorHandler } from '../../utils/error'
 import {
   ensureMandarinAudioAsset,
   mandarinAudioUrl,
-  resolveMandarinCatalogCard,
+  resolveMandarinAudioCard,
 } from '../../utils/mandarinAudio'
 
 type MandarinAudioRequest = {
@@ -13,25 +13,26 @@ type MandarinAudioRequest = {
 
 export default defineEventHandler(async (event) => {
   try {
-    await requireApiUser(event)
+    const auth = await requireApiUser(event)
     const body = await readBody<MandarinAudioRequest>(event)
     const cardKey = typeof body?.cardKey === 'string' ? body.cardKey.trim() : ''
 
     if (!cardKey || cardKey.length > 255) {
       throw createError({
         statusCode: 400,
-        message: 'A valid Mandarin catalog card key is required.',
+        message: 'A valid Mandarin card key is required.',
       })
     }
 
     // Never turn this endpoint into arbitrary user-supplied TTS. Generation is
-    // limited to the sourced/curated Mandarin catalog, and the server chooses
-    // the exact Hanzi + pinyin that reach the provider.
-    const card = await resolveMandarinCatalogCard(cardKey)
+    // limited to the sourced/curated catalog or an authenticated user's own
+    // durable requested card, and the server chooses the exact Hanzi + pinyin
+    // that reach the provider.
+    const card = await resolveMandarinAudioCard(cardKey, auth.user.id)
     if (!card) {
       throw createError({
         statusCode: 404,
-        message: 'That Mandarin card is not in the current catalog.',
+        message: 'That Mandarin card is not available to this user.',
       })
     }
 

--- a/server/api/mandarin/requests/[id]/art.post.ts
+++ b/server/api/mandarin/requests/[id]/art.post.ts
@@ -1,0 +1,158 @@
+import {
+  createError,
+  defineEventHandler,
+  getRouterParam,
+} from 'h3'
+import { requireApiUser } from '../../../../utils/authGuard'
+import { errorHandler } from '../../../../utils/error'
+import { prisma } from '../../../../utils/prisma'
+import {
+  reconcileRequestedCardArt,
+  requestedCardPublicDataEnriched,
+} from '../../../../utils/mandarinRequestedCards'
+
+type ArtEnqueueResponse = {
+  success?: boolean
+  message?: string
+  data?: {
+    jobId?: number
+    status?: string
+    deduplicated?: boolean
+  }
+}
+
+async function tagJob(input: {
+  jobId: number
+  userId: number
+  cardId: number
+  artPromptVersion: string
+}): Promise<void> {
+  const job = await prisma.artJob.findUnique({
+    where: { id: input.jobId },
+    select: { userId: true, payload: true },
+  })
+  if (!job || job.userId !== input.userId) return
+
+  let payload: Record<string, unknown>
+  try {
+    payload = JSON.parse(job.payload) as Record<string, unknown>
+  } catch {
+    return
+  }
+
+  await prisma.artJob.update({
+    where: { id: input.jobId },
+    data: {
+      payload: JSON.stringify({
+        ...payload,
+        mandarinContext: {
+          product: 'mandarin',
+          cardId: input.cardId,
+          artPromptVersion: input.artPromptVersion,
+          dedupeKey: `mandarin:${input.cardId}:${input.artPromptVersion}`,
+        },
+      }),
+    },
+  })
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireApiUser(event)
+    const id = Number(getRouterParam(event, 'id'))
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid requested-card ID.' })
+    }
+
+    const row = await prisma.mandarinRequestedCard.findFirst({
+      where: {
+        id,
+        userId: auth.user.id,
+        isActive: true,
+      },
+    })
+    if (!row) {
+      throw createError({ statusCode: 404, message: 'Requested Mandarin card not found.' })
+    }
+
+    const reconciled = await reconcileRequestedCardArt(row)
+    if (reconciled.artImageId) {
+      return {
+        success: true,
+        statusCode: 200,
+        message: 'Requested-card illustration is already complete.',
+        data: await requestedCardPublicDataEnriched(reconciled),
+      }
+    }
+
+    if (reconciled.artJobId) {
+      const existingJob = await prisma.artJob.findUnique({
+        where: { id: reconciled.artJobId },
+        select: { userId: true, status: true },
+      })
+      if (
+        existingJob?.userId === auth.user.id &&
+        (existingJob.status === 'PENDING' || existingJob.status === 'RUNNING')
+      ) {
+        return {
+          success: true,
+          statusCode: 200,
+          message: 'Requested-card illustration is already queued.',
+          data: await requestedCardPublicDataEnriched(reconciled),
+        }
+      }
+    }
+
+    const art = await event.$fetch<ArtEnqueueResponse, string>('/api/art/enqueue', {
+      method: 'POST',
+      body: {
+        engine: 'krea2',
+        promptString: reconciled.artPrompt,
+        projectSlug: 'mandarin-tutor',
+        width: 768,
+        height: 768,
+        isPublic: false,
+        isMature: false,
+        designer: `mandarin-request:${reconciled.id}`,
+      },
+    })
+
+    const jobId = Number(art.data?.jobId)
+    if (!art.success || !Number.isInteger(jobId) || jobId <= 0) {
+      throw createError({
+        statusCode: 502,
+        message: art.message || 'Krea2 did not return a valid ArtJob.',
+      })
+    }
+
+    await tagJob({
+      jobId,
+      userId: auth.user.id,
+      cardId: reconciled.id,
+      artPromptVersion: reconciled.artPromptVersion,
+    })
+    const updated = await prisma.mandarinRequestedCard.update({
+      where: { id: reconciled.id },
+      data: {
+        artJobId: jobId,
+        artImageId: null,
+      },
+    })
+
+    event.node.res.statusCode = 201
+    return {
+      success: true,
+      statusCode: 201,
+      message: 'Requested-card illustration queued.',
+      data: await requestedCardPublicDataEnriched(updated),
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      statusCode: handled.statusCode || 500,
+      message: handled.message || 'Failed to queue requested-card illustration.',
+    }
+  }
+})

--- a/server/api/mandarin/requests/index.get.ts
+++ b/server/api/mandarin/requests/index.get.ts
@@ -1,0 +1,46 @@
+import { defineEventHandler } from 'h3'
+import { requireApiUser } from '../../../utils/authGuard'
+import { errorHandler } from '../../../utils/error'
+import { prisma } from '../../../utils/prisma'
+import {
+  reconcileRequestedCardArt,
+  requestedCardPublicDataEnriched,
+} from '../../../utils/mandarinRequestedCards'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireApiUser(event)
+    const rows = await prisma.mandarinRequestedCard.findMany({
+      where: {
+        userId: auth.user.id,
+        isActive: true,
+      },
+      orderBy: { createdAt: 'desc' },
+      take: 200,
+    })
+
+    const reconciled = await Promise.all(
+      rows.map((row) => reconcileRequestedCardArt(row)),
+    )
+    const publicCards = await Promise.all(
+      reconciled.map((row) => requestedCardPublicDataEnriched(row)),
+    )
+
+    return {
+      success: true,
+      statusCode: 200,
+      message: 'Requested Mandarin cards loaded.',
+      data: {
+        cards: publicCards,
+      },
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      statusCode: handled.statusCode || 500,
+      message: handled.message || 'Failed to load requested Mandarin cards.',
+    }
+  }
+})

--- a/server/api/mandarin/requests/index.post.ts
+++ b/server/api/mandarin/requests/index.post.ts
@@ -1,0 +1,221 @@
+import { defineEventHandler, readBody } from 'h3'
+import { requireApiUser } from '../../../utils/authGuard'
+import { errorHandler } from '../../../utils/error'
+import { prisma } from '../../../utils/prisma'
+import {
+  MANDARIN_REQUEST_ART_VERSION,
+  MANDARIN_REQUEST_RECIPE_VERSION,
+  normalizeMandarinRequest,
+  parseGeneratedMandarinCard,
+  reconcileRequestedCardArt,
+  requestedArtPrompt,
+  requestedCardPrompt,
+  requestedCardPublicDataEnriched,
+  requestedCardSystemPrompt,
+} from '../../../utils/mandarinRequestedCards'
+
+type RequestBody = {
+  request?: unknown
+}
+
+type GenerateTextResponse = {
+  provider?: string
+  model?: string
+  text?: string
+}
+
+type ArtEnqueueResponse = {
+  success?: boolean
+  message?: string
+  data?: {
+    jobId?: number
+    status?: string
+    deduplicated?: boolean
+  }
+}
+
+function generationNote(provider: string, model: string): string {
+  return [
+    'Generated learning-card fields are AI output, not dictionary-sourced facts.',
+    `Provider: ${provider || 'unknown'}.`,
+    `Model: ${model || 'unknown'}.`,
+    `Recipe: ${MANDARIN_REQUEST_RECIPE_VERSION}.`,
+    'Character decomposition/history comes from the separate pinned character-data layer when available.',
+  ].join(' ')
+}
+
+async function attachMandarinJobContext(input: {
+  jobId: number
+  userId: number
+  cardId: number
+  artPromptVersion: string
+}): Promise<void> {
+  const job = await prisma.artJob.findUnique({
+    where: { id: input.jobId },
+    select: { userId: true, payload: true },
+  })
+  if (!job || job.userId !== input.userId) return
+
+  let payload: Record<string, unknown>
+  try {
+    payload = JSON.parse(job.payload) as Record<string, unknown>
+  } catch {
+    return
+  }
+
+  const dedupeKey = `mandarin:${input.cardId}:${input.artPromptVersion}`
+  await prisma.artJob.update({
+    where: { id: input.jobId },
+    data: {
+      payload: JSON.stringify({
+        ...payload,
+        mandarinContext: {
+          product: 'mandarin',
+          cardId: input.cardId,
+          artPromptVersion: input.artPromptVersion,
+          dedupeKey,
+        },
+      }),
+    },
+  })
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireApiUser(event)
+    const body = ((await readBody(event)) ?? {}) as RequestBody
+    const { requestText, normalizedRequest } = normalizeMandarinRequest(body.request)
+
+    const existing = await prisma.mandarinRequestedCard.findUnique({
+      where: {
+        userId_normalizedRequest: {
+          userId: auth.user.id,
+          normalizedRequest,
+        },
+      },
+    })
+    if (existing?.isActive) {
+      const reconciled = await reconcileRequestedCardArt(existing)
+      return {
+        success: true,
+        statusCode: 200,
+        message: 'Existing requested Mandarin card reused.',
+        data: await requestedCardPublicDataEnriched(reconciled),
+      }
+    }
+
+    const generated = await event.$fetch<GenerateTextResponse, string>(
+      '/api/generate/text',
+      {
+        method: 'POST',
+        body: {
+          system: requestedCardSystemPrompt(),
+          prompt: requestedCardPrompt(requestText),
+          temperature: 0.2,
+          maxTokens: 600,
+          stream: false,
+        },
+      },
+    )
+
+    const fields = parseGeneratedMandarinCard(String(generated.text || ''))
+    const provider = String(generated.provider || 'unknown').slice(0, 64)
+    const model = String(generated.model || 'unknown').slice(0, 255)
+    const provenance = generationNote(provider, model)
+    const artPrompt = requestedArtPrompt(fields)
+
+    const created = await prisma.mandarinRequestedCard.upsert({
+      where: {
+        userId_normalizedRequest: {
+          userId: auth.user.id,
+          normalizedRequest,
+        },
+      },
+      create: {
+        userId: auth.user.id,
+        requestText,
+        normalizedRequest,
+        simplified: fields.simplified,
+        traditional: fields.traditional,
+        pinyin: fields.pinyin,
+        meaning: fields.meaning,
+        meanings: JSON.stringify(fields.meanings),
+        usageNote: fields.usageNote,
+        provider,
+        model,
+        recipeVersion: MANDARIN_REQUEST_RECIPE_VERSION,
+        generationProvenance: provenance,
+        artPrompt,
+        artPromptVersion: MANDARIN_REQUEST_ART_VERSION,
+      },
+      update: {
+        isActive: true,
+      },
+    })
+
+    // The card is durable before art is attempted. A renderer outage should
+    // never erase a useful generated learning card.
+    if (!created.artJobId) {
+      try {
+        const art = await event.$fetch<ArtEnqueueResponse, string>(
+          '/api/art/enqueue',
+          {
+            method: 'POST',
+            body: {
+              engine: 'krea2',
+              promptString: created.artPrompt,
+              projectSlug: 'mandarin-tutor',
+              width: 768,
+              height: 768,
+              isPublic: false,
+              isMature: false,
+              designer: `mandarin-request:${created.id}`,
+            },
+          },
+        )
+
+        const jobId = Number(art.data?.jobId)
+        if (art.success && Number.isInteger(jobId) && jobId > 0) {
+          await attachMandarinJobContext({
+            jobId,
+            userId: auth.user.id,
+            cardId: created.id,
+            artPromptVersion: created.artPromptVersion,
+          })
+          const withJob = await prisma.mandarinRequestedCard.update({
+            where: { id: created.id },
+            data: { artJobId: jobId },
+          })
+          event.node.res.statusCode = 201
+          return {
+            success: true,
+            statusCode: 201,
+            message: 'Requested Mandarin card created and illustration queued.',
+            data: await requestedCardPublicDataEnriched(withJob),
+          }
+        }
+      } catch (artError) {
+        console.warn('[mandarin] requested-card art enqueue failed; keeping card', {
+          cardId: created.id,
+          message: artError instanceof Error ? artError.message : String(artError),
+        })
+      }
+    }
+
+    event.node.res.statusCode = 201
+    return {
+      success: true,
+      statusCode: 201,
+      message: 'Requested Mandarin card created. Illustration can be retried later.',
+      data: await requestedCardPublicDataEnriched(created),
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      statusCode: handled.statusCode || 500,
+      message: handled.message || 'Failed to create requested Mandarin card.',
+    }
+  }
+})

--- a/server/utils/mandarinAudio.ts
+++ b/server/utils/mandarinAudio.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto'
 import type { H3Event } from 'h3'
 import type { MandarinCard } from '~/utils/mandarin'
 import { getMandarinCatalog } from './mandarinCatalog'
+import { requestedRowToCard } from './mandarinRequestedCards'
 import { manaGate } from './manaGate'
 import { prisma } from './prisma'
 import { safeFetch } from './safeFetch'
@@ -50,6 +51,26 @@ export function mandarinAudioUrl(id: string): string {
 export async function resolveMandarinCatalogCard(cardKey: string): Promise<MandarinCard | null> {
   const catalog = await getMandarinCatalog()
   return catalog.cards.find((card) => card.key === cardKey) ?? null
+}
+
+export async function resolveMandarinAudioCard(
+  cardKey: string,
+  userId: number,
+): Promise<MandarinCard | null> {
+  const requestedMatch = cardKey.match(/^requested:(\d+)$/)
+  if (requestedMatch) {
+    const id = Number(requestedMatch[1])
+    if (!Number.isInteger(id) || id <= 0) return null
+    const row = await prisma.mandarinRequestedCard.findFirst({
+      where: {
+        id,
+        userId,
+        isActive: true,
+      },
+    })
+    return row ? requestedRowToCard(row) : null
+  }
+  return resolveMandarinCatalogCard(cardKey)
 }
 
 async function synthesizeAndStore(

--- a/server/utils/mandarinAudio.ts
+++ b/server/utils/mandarinAudio.ts
@@ -59,7 +59,7 @@ export async function resolveMandarinAudioCard(
 ): Promise<MandarinCard | null> {
   const requestedMatch = cardKey.match(/^requested:(\d+)$/)
   if (requestedMatch) {
-    const id = Number(requestedMatch[1])
+    const id = Number(requestedMatch?.[1])
     if (!Number.isInteger(id) || id <= 0) return null
     const row = await prisma.mandarinRequestedCard.findFirst({
       where: {

--- a/server/utils/mandarinRequestedCards.ts
+++ b/server/utils/mandarinRequestedCards.ts
@@ -1,0 +1,257 @@
+import { createError } from 'h3'
+import type { MandarinCard } from '~/utils/mandarin'
+import { enrichMandarinCharacterData } from './mandarinCharacterData'
+import { prisma } from './prisma'
+
+export const MANDARIN_REQUEST_RECIPE_VERSION = 'v1'
+export const MANDARIN_REQUEST_ART_VERSION = 'v1'
+const MAX_REQUEST_LENGTH = 120
+const MAX_TEXT_RESPONSE_LENGTH = 20_000
+
+type GeneratedMandarinFields = {
+  simplified: string
+  traditional: string | null
+  pinyin: string
+  meaning: string
+  meanings: string[]
+  usageNote: string | null
+}
+
+type RequestedCardRow = {
+  id: number
+  userId: number
+  requestText: string
+  normalizedRequest: string
+  simplified: string
+  traditional: string | null
+  pinyin: string
+  meaning: string
+  meanings: string
+  usageNote: string | null
+  provider: string
+  model: string
+  recipeVersion: string
+  generationProvenance: string
+  artPrompt: string
+  artPromptVersion: string
+  artJobId: number | null
+  artImageId: number | null
+}
+
+function clean(value: unknown, maxLength: number): string {
+  return typeof value === 'string' ? value.trim().slice(0, maxLength) : ''
+}
+
+function stripMarkdownFence(text: string): string {
+  const trimmed = text.trim()
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i)
+  return fenced?.[1]?.trim() || trimmed
+}
+
+function parseJsonObject(text: string): Record<string, unknown> {
+  const stripped = stripMarkdownFence(text)
+  const first = stripped.indexOf('{')
+  const last = stripped.lastIndexOf('}')
+  const candidate = first >= 0 && last > first ? stripped.slice(first, last + 1) : stripped
+  try {
+    const parsed = JSON.parse(candidate) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('not an object')
+    }
+    return parsed as Record<string, unknown>
+  } catch {
+    throw createError({
+      statusCode: 502,
+      message: 'The language model did not return a valid requested-word card.',
+    })
+  }
+}
+
+function usefulMeanings(value: unknown, fallback: string): string[] {
+  const raw = Array.isArray(value) ? value : []
+  const meanings = raw
+    .map((item) => clean(item, 240))
+    .filter(Boolean)
+    .slice(0, 6)
+  if (!meanings.length && fallback) meanings.push(fallback)
+  return [...new Set(meanings)]
+}
+
+function containsHan(value: string): boolean {
+  return /[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]/u.test(value)
+}
+
+export function normalizeMandarinRequest(value: unknown): {
+  requestText: string
+  normalizedRequest: string
+} {
+  const requestText = clean(value, MAX_REQUEST_LENGTH)
+  if (!requestText) {
+    throw createError({ statusCode: 400, message: 'Enter a word or short phrase to add.' })
+  }
+  const normalizedRequest = requestText
+    .normalize('NFKC')
+    .toLocaleLowerCase('en-US')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return { requestText, normalizedRequest }
+}
+
+export function parseGeneratedMandarinCard(text: string): GeneratedMandarinFields {
+  if (!text || text.length > MAX_TEXT_RESPONSE_LENGTH) {
+    throw createError({
+      statusCode: 502,
+      message: 'The generated Mandarin card response had an invalid size.',
+    })
+  }
+
+  const parsed = parseJsonObject(text)
+  const simplified = clean(parsed.simplified, 255)
+  const traditionalRaw = clean(parsed.traditional, 255)
+  const traditional = traditionalRaw && traditionalRaw !== simplified ? traditionalRaw : null
+  const pinyin = clean(parsed.pinyin, 512)
+  const meaning = clean(parsed.meaning, 500)
+  const meanings = usefulMeanings(parsed.meanings, meaning)
+  const usageNote = clean(parsed.usageNote, 1200) || null
+
+  if (!simplified || !containsHan(simplified) || !pinyin || !meaning) {
+    throw createError({
+      statusCode: 502,
+      message: 'The generated card was missing Hanzi, tone-marked pinyin, or a meaning.',
+    })
+  }
+
+  return { simplified, traditional, pinyin, meaning, meanings, usageNote }
+}
+
+export function requestedCardSystemPrompt(): string {
+  return [
+    'You create concise beginner Mandarin Chinese learning cards.',
+    'Return exactly one JSON object and no markdown.',
+    'Use Standard Mandarin and simplified Chinese as the primary written form.',
+    'Pinyin MUST use tone marks (for example nǐ hǎo), not tone numbers.',
+    'If the input is already Chinese, explain that Chinese expression rather than translating it into a different concept.',
+    'If the input is English or another language, choose the most ordinary useful Mandarin equivalent rather than a rare literary synonym.',
+    'Do not invent historical etymology or character-component explanations.',
+    'When usage is regional, formal, colloquial, casino-specific, or context-sensitive, say so briefly in usageNote.',
+    'JSON schema: {"simplified":string,"traditional":string|null,"pinyin":string,"meaning":string,"meanings":string[],"usageNote":string|null}.',
+  ].join(' ')
+}
+
+export function requestedCardPrompt(requestText: string): string {
+  return `Create a Mandarin learning card for this requested word or short phrase: ${JSON.stringify(requestText)}`
+}
+
+export function requestedArtPrompt(fields: GeneratedMandarinFields): string {
+  return [
+    `Educational flashcard illustration for the Mandarin concept “${fields.meaning}”.`,
+    `The underlying Chinese learning item is ${fields.simplified}, but do not render written language in the image.`,
+    'Show one concrete, memorable everyday object, action, or scene that communicates the concept at a glance.',
+    'Friendly, culturally grounded, uncluttered, polished editorial illustration.',
+    'No text, no letters, no Chinese characters, no captions, no logo, no watermark.',
+  ].join(' ')
+}
+
+function parseStoredMeanings(raw: string, fallback: string): string[] {
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (Array.isArray(parsed)) {
+      const values = parsed.map((item) => clean(item, 240)).filter(Boolean).slice(0, 6)
+      if (values.length) return values
+    }
+  } catch {
+    // Older/corrupt generated metadata should not break the entire tutor.
+  }
+  return [fallback]
+}
+
+export function requestedRowToCard(row: RequestedCardRow): MandarinCard {
+  return {
+    key: `requested:${row.id}`,
+    simplified: row.simplified,
+    ...(row.traditional && row.traditional !== row.simplified
+      ? { traditional: row.traditional }
+      : {}),
+    pinyin: row.pinyin,
+    meaning: row.meaning,
+    meanings: parseStoredMeanings(row.meanings, row.meaning),
+    kind: [...row.simplified].length === 1 ? 'character' : 'phrase',
+    partsOfSpeech: [],
+    classifiers: [],
+    categories: ['requested'],
+    components: [],
+    historyStatus: 'pending',
+    source: {
+      label: 'AI-generated requested card · not dictionary-sourced',
+      version: `${row.provider}:${row.model} · recipe ${row.recipeVersion}`,
+      licenseNote: row.generationProvenance,
+    },
+  }
+}
+
+async function enrichRequestedCard(card: MandarinCard): Promise<MandarinCard> {
+  try {
+    const enriched = await enrichMandarinCharacterData([card])
+    return enriched[0] ?? card
+  } catch (error: unknown) {
+    console.warn('[mandarin] requested-card character enrichment unavailable', {
+      cardKey: card.key,
+      message: error instanceof Error ? error.message : String(error),
+    })
+    return card
+  }
+}
+
+export async function reconcileRequestedCardArt<T extends RequestedCardRow>(
+  row: T,
+): Promise<T> {
+  if (row.artImageId || !row.artJobId) return row
+
+  const job = await prisma.artJob.findUnique({
+    where: { id: row.artJobId },
+    select: { userId: true, status: true, artImageId: true },
+  })
+  if (!job || job.userId !== row.userId) return row
+
+  const artImageId = Number(job.artImageId)
+  if (job.status !== 'DONE' || !Number.isInteger(artImageId) || artImageId <= 0) {
+    return row
+  }
+
+  const updated = await prisma.mandarinRequestedCard.update({
+    where: { id: row.id },
+    data: { artImageId },
+  })
+  return updated as T
+}
+
+export function requestedCardPublicData(row: RequestedCardRow) {
+  return {
+    id: row.id,
+    card: requestedRowToCard(row),
+    requestText: row.requestText,
+    usageNote: row.usageNote,
+    generated: true as const,
+    provenance: {
+      provider: row.provider,
+      model: row.model,
+      recipeVersion: row.recipeVersion,
+      note: row.generationProvenance,
+    },
+    art: {
+      prompt: row.artPrompt,
+      promptVersion: row.artPromptVersion,
+      jobId: row.artJobId,
+      imageId: row.artImageId,
+      imageUrl: row.artImageId ? `/api/art/images/${row.artImageId}/file` : null,
+    },
+  }
+}
+
+export async function requestedCardPublicDataEnriched(row: RequestedCardRow) {
+  const base = requestedCardPublicData(row)
+  return {
+    ...base,
+    card: await enrichRequestedCard(base.card),
+  }
+}

--- a/server/utils/mandarinRequestedCards.ts
+++ b/server/utils/mandarinRequestedCards.ts
@@ -218,11 +218,11 @@ export async function reconcileRequestedCardArt<T extends RequestedCardRow>(
     return row
   }
 
-  const updated = await prisma.mandarinRequestedCard.update({
+  await prisma.mandarinRequestedCard.update({
     where: { id: row.id },
     data: { artImageId },
   })
-  return updated as T
+  return { ...row, artImageId }
 }
 
 export function requestedCardPublicData(row: RequestedCardRow) {

--- a/stores/mandarinTutorStore.ts
+++ b/stores/mandarinTutorStore.ts
@@ -37,6 +37,31 @@ type MandarinAudioData = {
   cached?: boolean
 }
 
+export type MandarinRequestedCardData = {
+  id: number
+  card: MandarinCard
+  requestText: string
+  usageNote?: string | null
+  generated: true
+  provenance: {
+    provider: string
+    model: string
+    recipeVersion: string
+    note: string
+  }
+  art: {
+    prompt: string
+    promptVersion: string
+    jobId?: number | null
+    imageId?: number | null
+    imageUrl?: string | null
+  }
+}
+
+type MandarinRequestedCardsPayload = {
+  cards: MandarinRequestedCardData[]
+}
+
 function safeId(value: string): string {
   return value
     .trim()
@@ -46,10 +71,18 @@ function safeId(value: string): string {
     .slice(0, 60)
 }
 
+function requestedId(cardKey: string): number | null {
+  const match = cardKey.match(/^requested:(\d+)$/)
+  if (!match) return null
+  const id = Number(match[1])
+  return Number.isInteger(id) && id > 0 ? id : null
+}
+
 export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
   const cards = ref<MandarinCard[]>([])
   const builtInSets = ref<MandarinStudySet[]>([])
   const customSets = ref<MandarinCustomSet[]>([])
+  const requestedCards = ref<MandarinRequestedCardData[]>([])
   const selectedSetId = ref('starter-500')
   const studyIndex = ref(0)
   const searchQuery = ref('')
@@ -58,6 +91,7 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
   const detailsVisible = ref(false)
   const loading = ref(false)
   const initialized = ref(false)
+  const requestingWord = ref(false)
   const error = ref<string | null>(null)
   const speechError = ref<string | null>(null)
   const audioUrls = ref<Record<string, string>>({})
@@ -74,8 +108,20 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
     () => new Map(cards.value.map((card) => [card.key, card] as const)),
   )
 
+  const requestedSet = computed<MandarinStudySet | null>(() => {
+    const cardKeys = requestedCards.value.map((entry) => entry.card.key)
+    if (!cardKeys.length) return null
+    return {
+      id: 'requested',
+      label: 'Requested words',
+      description: 'Your generated additions, kept separate from sourced starter vocabulary.',
+      cardKeys,
+    }
+  })
+
   const allSets = computed<MandarinStudySet[]>(() => [
     ...builtInSets.value,
+    ...(requestedSet.value ? [requestedSet.value] : []),
     ...customSets.value.map((set) => ({
       id: `custom:${set.id}`,
       label: set.name,
@@ -180,7 +226,8 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
       if (!response.success || !response.data) {
         throw new Error(response.message || 'Failed to load Mandarin cards.')
       }
-      cards.value = response.data.cards
+      const requested = cards.value.filter((card) => requestedId(card.key))
+      cards.value = [...response.data.cards, ...requested]
       builtInSets.value = response.data.sets
       if (!allSets.value.some((set) => set.id === selectedSetId.value)) {
         selectedSetId.value = builtInSets.value[0]?.id ?? 'starter-500'
@@ -196,10 +243,85 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
     }
   }
 
+  async function fetchProtectedImage(artImageId: number): Promise<string | null> {
+    if (!import.meta.client) return null
+    const userStore = useUserStore()
+    const token = userStore.token || userStore.user?.token || ''
+    const headers = new Headers()
+    if (token) headers.set('Authorization', `Bearer ${token}`)
+    const response = await fetch(`/api/art/images/${artImageId}/file`, { headers })
+    if (!response.ok) return null
+    return URL.createObjectURL(await response.blob())
+  }
+
+  async function hydrateRequestedArt(entry: MandarinRequestedCardData) {
+    const key = entry.card.key
+    const jobId = Number(entry.art.jobId)
+    const imageId = Number(entry.art.imageId)
+
+    if (Number.isInteger(jobId) && jobId > 0) {
+      artJobs.value = { ...artJobs.value, [key]: jobId }
+      if (!entry.art.imageId) {
+        artStatuses.value = { ...artStatuses.value, [key]: 'PENDING' }
+      }
+    }
+
+    if (!Number.isInteger(imageId) || imageId <= 0) return
+    artImageIds.value = { ...artImageIds.value, [key]: imageId }
+    artStatuses.value = { ...artStatuses.value, [key]: 'DONE' }
+
+    const nextUrl = await fetchProtectedImage(imageId)
+    if (!nextUrl) return
+    const previousUrl = artImageUrls.value[key]
+    if (previousUrl?.startsWith('blob:')) URL.revokeObjectURL(previousUrl)
+    artImageUrls.value = { ...artImageUrls.value, [key]: nextUrl }
+  }
+
+  async function upsertRequestedCard(entry: MandarinRequestedCardData) {
+    requestedCards.value = [
+      entry,
+      ...requestedCards.value.filter((candidate) => candidate.id !== entry.id),
+    ]
+    cards.value = [
+      ...cards.value.filter((candidate) => candidate.key !== entry.card.key),
+      entry.card,
+    ]
+    await hydrateRequestedArt(entry)
+  }
+
+  async function loadRequestedCards() {
+    if (!import.meta.client) return
+    const userStore = useUserStore()
+    const token = userStore.token || userStore.user?.token || ''
+    if (!token) return
+
+    try {
+      const response = await performFetch<MandarinRequestedCardsPayload>(
+        '/api/mandarin/requests',
+        {},
+        1,
+        30_000,
+      )
+      if (!response.success || !response.data) return
+
+      const existingRequestedKeys = new Set(
+        cards.value.filter((card) => requestedId(card.key)).map((card) => card.key),
+      )
+      cards.value = cards.value.filter((card) => !existingRequestedKeys.has(card.key))
+      requestedCards.value = []
+      for (const entry of response.data.cards) {
+        await upsertRequestedCard(entry)
+      }
+    } catch (cause) {
+      console.warn('[mandarin] requested-card load failed', cause)
+    }
+  }
+
   async function initialize() {
     if (initialized.value || loading.value) return
     loadLocalState()
     await loadCatalog()
+    await loadRequestedCards()
   }
 
   function selectSet(id: string) {
@@ -281,6 +403,73 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
         .find((set) => set.id === setId)
         ?.cardKeys.includes(cardKey),
     )
+  }
+
+  function requestedData(cardKey: string): MandarinRequestedCardData | null {
+    const id = requestedId(cardKey)
+    if (!id) return null
+    return requestedCards.value.find((entry) => entry.id === id) ?? null
+  }
+
+  async function requestWord(request = searchQuery.value): Promise<MandarinRequestedCardData | null> {
+    const cleanRequest = request.trim()
+    if (!cleanRequest || requestingWord.value) return null
+    requestingWord.value = true
+    error.value = null
+    try {
+      const response = await performFetch<MandarinRequestedCardData>(
+        '/api/mandarin/requests',
+        {
+          method: 'POST',
+          body: JSON.stringify({ request: cleanRequest }),
+        },
+        1,
+        60_000,
+      )
+      if (!response.success || !response.data?.card) {
+        throw new Error(response.message || 'Failed to create the requested Mandarin card.')
+      }
+      await upsertRequestedCard(response.data)
+      focusKey.value = response.data.card.key
+      searchQuery.value = ''
+      resetReveal()
+      return response.data
+    } catch (cause) {
+      error.value =
+        cause instanceof Error ? cause.message : 'Failed to create the requested Mandarin card.'
+      return null
+    } finally {
+      requestingWord.value = false
+    }
+  }
+
+  async function refreshRequestedIllustration(
+    card: MandarinCard | null = currentCard.value,
+  ): Promise<string | null> {
+    if (!card || !requestedId(card.key) || artRefreshingKey.value) return null
+    const id = requestedId(card.key)
+    if (!id) return null
+    artRefreshingKey.value = card.key
+    error.value = null
+    try {
+      const response = await performFetch<MandarinRequestedCardData>(
+        `/api/mandarin/requests/${id}/art`,
+        { method: 'POST' },
+        1,
+        45_000,
+      )
+      if (!response.success || !response.data?.card) {
+        throw new Error(response.message || 'Failed to refresh requested-card art.')
+      }
+      await upsertRequestedCard(response.data)
+      return artImageUrls.value[card.key] || null
+    } catch (cause) {
+      error.value =
+        cause instanceof Error ? cause.message : 'Failed to refresh requested-card art.'
+      return null
+    } finally {
+      artRefreshingKey.value = null
+    }
   }
 
   function playBrowserSpeech(card: MandarinCard): boolean {
@@ -368,31 +557,16 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
 
     if (await playReferenceAudio(url)) return
 
-    // Safari/iOS can reject a play() that follows an async cache-generation
-    // request because the original tap's user activation has expired. The URL
-    // is retained, so the next tap plays immediately; browser speech keeps the
-    // first tap useful instead of turning that policy quirk into a dead button.
     if (playBrowserSpeech(card)) return
 
     speechError.value =
       'The reference clip is ready, but this browser blocked audio playback. Tap Hear pronunciation again.'
   }
 
-  async function fetchProtectedImage(artImageId: number): Promise<string | null> {
-    if (!import.meta.client) return null
-    const userStore = useUserStore()
-    const token = userStore.token || userStore.user?.token || ''
-    const headers = new Headers()
-    if (token) headers.set('Authorization', `Bearer ${token}`)
-    const response = await fetch(`/api/art/images/${artImageId}/file`, { headers })
-    if (!response.ok) return null
-    return URL.createObjectURL(await response.blob())
-  }
-
   async function queueIllustration(
     card: MandarinCard | null = currentCard.value,
   ): Promise<number | null> {
-    if (!card || artQueueingKey.value) return null
+    if (!card || requestedId(card.key) || artQueueingKey.value) return null
     artQueueingKey.value = card.key
     error.value = null
     try {
@@ -442,7 +616,7 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
   async function refreshIllustration(
     card: MandarinCard | null = currentCard.value,
   ): Promise<string | null> {
-    if (!card || artRefreshingKey.value) return null
+    if (!card || requestedId(card.key) || artRefreshingKey.value) return null
     const jobId = illustrationJobId(card.key)
     const knownImageId = Number(artImageIds.value[card.key])
     artRefreshingKey.value = card.key
@@ -487,7 +661,8 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
   }
 
   function illustrationJobId(cardKey: string): number | null {
-    const id = Number(artJobs.value[cardKey])
+    const requested = requestedData(cardKey)
+    const id = Number(requested?.art.jobId ?? artJobs.value[cardKey])
     return Number.isInteger(id) && id > 0 ? id : null
   }
 
@@ -496,6 +671,7 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
   }
 
   function illustrationStatus(cardKey: string): string | null {
+    if (requestedData(cardKey)?.art.imageId) return 'DONE'
     return artStatuses.value[cardKey] || null
   }
 
@@ -503,6 +679,7 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
     cards,
     builtInSets,
     customSets,
+    requestedCards,
     selectedSetId,
     studyIndex,
     searchQuery,
@@ -511,6 +688,7 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
     detailsVisible,
     loading,
     initialized,
+    requestingWord,
     error,
     speechError,
     audioUrls,
@@ -530,6 +708,7 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
     audioSupported,
     initialize,
     loadCatalog,
+    loadRequestedCards,
     selectSet,
     nextCard,
     previousCard,
@@ -540,6 +719,9 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
     createCustomSet,
     toggleCardInCustomSet,
     cardIsInCustomSet,
+    requestedData,
+    requestWord,
+    refreshRequestedIllustration,
     speak,
     queueIllustration,
     refreshIllustration,


### PR DESCRIPTION
## Summary
- create durable user-owned requested Mandarin cards from a word/phrase entered in Tutor search
- generate linguistic fields through the existing provider-agnostic `/api/generate/text` path and retain provider/model/recipe provenance
- clearly distinguish AI-generated requested-card facts from dictionary-sourced core vocabulary
- enrich requested Hanzi through the same pinned source-backed character analysis used by core cards
- enqueue illustrations through the existing Krea2 ArtJob pipeline and persist/reconcile ArtJob + ArtImage identity server-side
- reuse the durable Mandarin reference-audio cache for requested cards without exposing arbitrary-text TTS
- add a Requested words deck and explicit create-from-search UI with provenance/usage notes

## Persistence
Adds one user-scoped `MandarinRequestedCard` table with a unique `(userId, normalizedRequest)` identity. The migration is additive only: CREATE TABLE plus indexes, no existing-table DROP/ALTER.

## Art behavior
A requested card is persisted before Krea2 enqueue. Rendering failure therefore leaves a useful card that can retry illustration later. ArtJobs receive deterministic Mandarin context (`mandarin:<cardId>:<artPromptVersion>`), and completed ArtImage IDs are reconciled into the card row.

## Trust boundary
Generated meaning/pinyin/usage fields are labeled as generated and never presented as CC-CEDICT/HSK facts. Character decomposition comes from the separate pinned character-data layer and fails open if that source is unavailable.

## Conductor
Advances `mandarin-tutor/t-005`.