### PR TITLE
fix: patch project-overrides.yaml instead of regenerating it (kind-robots/t-067)

### DIFF
--- a/server/api/conductor/overrides.post.ts
+++ b/server/api/conductor/overrides.post.ts
@@ -21,21 +21,60 @@ interface OverrideEntry {
   kind?: Kind
 }
 
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/** Locate the `  - slug: <slug>` block. Returns the [start, end) span of the
+ * whole block (up to the next top-level `- slug:` entry, or EOF). */
+function findBlockSpan(text: string, slug: string): [number, number] | null {
+  const startRe = new RegExp(`^  - slug: ${escapeRegExp(slug)}\\s*$`, 'm')
+  const m = startRe.exec(text)
+  if (!m) return null
+  const blockStart = m.index
+  const afterStart = m.index + m[0].length
+  const nextRe = /^ {2}- slug: /m
+  const nextM = nextRe.exec(text.slice(afterStart))
+  const blockEnd = nextM ? afterStart + nextM.index : text.length
+  return [blockStart, blockEnd]
+}
+
+/** Patch only the `status`/`priority`/`kind` fields of an existing block, in
+ * place, leaving every other line (liveUrl, channelKey, tabKey, inline
+ * comments, blank-line separators) untouched. Only the field's own value
+ * token is replaced -- never the rest of the line -- so a trailing inline
+ * comment (e.g. "status: paused # tabled 2026-07-26 by Silas...") survives. */
+function patchBlock(
+  block: string,
+  status: Status,
+  priority: Priority,
+  kind: Kind | undefined,
+): string {
+  block = block.replace(/^(\s*status:)\s*\S+/m, `$1 ${status}`)
+  block = block.replace(/^(\s*priority:)\s*\S+/m, `$1 ${priority}`)
+
+  if (kind) {
+    if (/^\s*kind:\s*\S+/m.test(block)) {
+      block = block.replace(/^(\s*kind:)\s*\S+/m, `$1 ${kind}`)
+    } else {
+      // Insert right after the priority line -- keep that line's own
+      // trailing comment intact by capturing the whole line, not just its value.
+      block = block.replace(/^(\s*priority:.*)$/m, `$1\n    kind: ${kind}`)
+    }
+  }
+  // kind omitted -> the UI isn't setting it for this slug; leave whatever the
+  // file already has (do not clear an existing kind field).
+
+  return block
+}
+
 export default defineEventHandler(async (event) => {
   await requireAdminApiUser(event)
 
   const body = await readBody<Record<string, OverrideEntry>>(event)
 
-  const lines = [
-    '# Human-managed project overrides. Written by the workspace UI.',
-    '# Agents: finite active work outranks continuous; paused/retired/finished are not selectable work.',
-    '# Priority controls how often agents pick tasks (high = more attention).',
-    '# status:   active | continuous | paused | retired | finished',
-    '# priority: low | normal | high | urgent',
-    '# kind:     software | content | proposal | brainstorm (overrides roadmap kind for UI)',
-    '',
-    'overrides:',
-  ]
+  const existing = await conductorGet('project-overrides.yaml')
+  let text = existing?.content ?? 'overrides:\n'
 
   for (const [slug, o] of Object.entries(body)) {
     if (!/^[a-z0-9-]+$/.test(slug)) continue
@@ -47,18 +86,36 @@ export default defineEventHandler(async (event) => {
       : 'normal'
     const kind =
       o?.kind && VALID_KINDS.includes(o.kind as Kind) ? o.kind : undefined
-    lines.push('')
-    lines.push(`  - slug: ${slug}`)
-    lines.push(`    status: ${status}`)
-    lines.push(`    priority: ${priority}`)
-    if (kind) lines.push(`    kind: ${kind}`)
+
+    const span = findBlockSpan(text, slug)
+    if (span) {
+      const [start, end] = span
+      const patched = patchBlock(text.slice(start, end), status, priority, kind)
+      text = text.slice(0, start) + patched + text.slice(end)
+      continue
+    }
+
+    // New slug -- append a fresh block at the end of the file, same
+    // convention as scripts/intake.py's register_override.
+    const entryLines = [
+      `  - slug: ${slug}`,
+      `    status: ${status}`,
+      `    priority: ${priority}`,
+    ]
+    if (kind) entryLines.push(`    kind: ${kind}`)
+    const entry = entryLines.join('\n') + '\n'
+
+    const hasOverridesKey = /^overrides:\s*$/m.test(text)
+    text =
+      text.replace(/\s*$/, '\n') +
+      '\n' +
+      (hasOverridesKey ? '' : 'overrides:\n') +
+      entry
   }
 
-  const content = lines.join('\n') + '\n'
-  const existing = await conductorGet('project-overrides.yaml')
   await conductorPut(
     'project-overrides.yaml',
-    content,
+    text,
     'chore: update project overrides from workspace UI',
     existing?.sha,
   )


### PR DESCRIPTION
## What

`server/api/conductor/overrides.post.ts` previously rebuilt the whole of `project-overrides.yaml` from a fixed template on every save, emitting only `slug`/`status`/`priority`/`kind` per entry. The first successful save from the workspace UI would have silently discarded:

- `liveUrl`/`channelKey`/`tabKey` — the frontend placement fields, present on roughly a dozen projects and load-bearing for the Projects board
- Every inline comment, including dated human rationale ("tabled 2026-07-26 by Silas", etc.) and the file's own explanatory header

This had not fired in production only because the endpoint appears to never have run successfully yet (`git log -- project-overrides.yaml` in conductor shows no workspace-authored commit).

## Fix

Patch, don't regenerate: read the existing YAML text, and per changed slug do targeted text surgery — locate that slug's block, replace only the `status`/`priority`/`kind` value tokens in place (never the whole line, so a trailing inline comment survives), and append a fresh block only for a genuinely new slug. Same approach conductor's `scripts/intake.py` `register_override` already uses for the identical class of bug (conductor#2767).

Verified against the real `project-overrides.yaml` content (52 entries) with a standalone harness before porting into the endpoint:
- Existing `liveUrl`/`channelKey`/`tabKey` fields and inline comments survive a patch untouched
- A no-op patch (values unchanged) produces zero diff
- A new-slug append lands a well-formed block at the end of the file
- Result re-parses as valid YAML

## Investigated (not fixed here — separate gap)

The task note also asked to check whether the workspace priority control is even wired to this endpoint. It is not: there is no caller of `POST /api/conductor/overrides` anywhere in the current frontend. That confirms Silas's report (priority change not reaching Conductor) is a real, separate sync gap — worth its own follow-up task rather than folding into this bugfix's scope.

## Verification

- `npx eslint server/api/conductor/overrides.post.ts` — clean
- `npm run test` (vue-tsc typecheck) — clean, no new errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7JVKDW7RzDzSVZG8hGhtV)_