### PR TITLE
polish(curation): compare color and B&W at equal scale

### DIFF
--- a/components/curation/coloring-book-curation.vue
+++ b/components/curation/coloring-book-curation.vue
@@ -63,36 +63,59 @@
     <div
       v-else
       class="grid gap-4"
-      style="grid-template-columns: repeat(auto-fill, minmax(min(290px, 100%), 1fr))"
+      style="grid-template-columns: repeat(auto-fill, minmax(min(540px, 100%), 1fr))"
     >
       <article
         v-for="proposal in visibleProposals"
         :key="proposal.id"
         class="kr-panel min-w-0 overflow-hidden"
       >
-        <div class="relative aspect-[17/22] overflow-hidden bg-base-200">
-          <img
-            v-if="proposal.colorUrl"
-            :src="proposal.colorUrl"
-            :alt="`${proposal.title} color candidate`"
-            class="size-full object-cover"
-            loading="lazy"
-          />
-          <img
-            v-else-if="bwDisplayUrl(proposal)"
-            :src="bwDisplayUrl(proposal) || ''"
-            :alt="`${proposal.title} black and white candidate`"
-            class="size-full object-cover grayscale"
-            loading="lazy"
-          />
-          <div v-else class="grid size-full place-items-center text-base-content/30">
-            <div class="text-center">
-              <Icon name="kind-icon:image" class="mx-auto size-12" />
-              <p class="mt-2 text-xs font-bold">No candidate art yet</p>
-            </div>
+        <div class="relative bg-base-300">
+          <div class="grid grid-cols-2 gap-px">
+            <figure class="relative min-w-0 bg-base-200">
+              <div class="aspect-[17/22] w-full overflow-hidden">
+                <img
+                  v-if="proposal.colorUrl"
+                  :src="proposal.colorUrl"
+                  :alt="`${proposal.title} color candidate`"
+                  class="size-full object-contain"
+                  loading="lazy"
+                />
+                <div v-else class="grid size-full place-items-center text-base-content/30">
+                  <div class="text-center">
+                    <Icon name="kind-icon:image" class="mx-auto size-10" />
+                    <p class="mt-2 text-xs font-bold">No color candidate</p>
+                  </div>
+                </div>
+              </div>
+              <figcaption class="absolute bottom-3 left-3 badge border-0 bg-base-100/90 font-black shadow-sm backdrop-blur">
+                Color
+              </figcaption>
+            </figure>
+
+            <figure class="relative min-w-0 bg-base-200">
+              <div class="aspect-[17/22] w-full overflow-hidden">
+                <img
+                  v-if="bwDisplayUrl(proposal)"
+                  :src="bwDisplayUrl(proposal) || ''"
+                  :alt="`${proposal.title} black and white candidate`"
+                  class="size-full object-contain grayscale"
+                  loading="lazy"
+                />
+                <div v-else class="grid size-full place-items-center text-base-content/30">
+                  <div class="text-center">
+                    <Icon name="kind-icon:image" class="mx-auto size-10" />
+                    <p class="mt-2 text-xs font-bold">No B&amp;W candidate</p>
+                  </div>
+                </div>
+              </div>
+              <figcaption class="absolute bottom-3 left-3 badge border-0 bg-base-100/90 font-black shadow-sm backdrop-blur">
+                B&amp;W
+              </figcaption>
+            </figure>
           </div>
 
-          <div class="absolute inset-x-0 top-0 flex items-start justify-between gap-2 p-3">
+          <div class="pointer-events-none absolute inset-x-0 top-0 flex items-start justify-between gap-2 p-3">
             <span class="badge border-0 bg-base-100/90 font-black shadow-sm backdrop-blur">
               {{ proposal.id }}
             </span>
@@ -100,21 +123,6 @@
               {{ stageLabel(proposal) }}
             </span>
           </div>
-
-          <figure
-            v-if="proposal.colorUrl && bwDisplayUrl(proposal)"
-            class="absolute bottom-3 right-3 w-[34%] overflow-hidden rounded-xl border-2 border-base-100 bg-base-100 shadow-lg"
-          >
-            <img
-              :src="bwDisplayUrl(proposal) || ''"
-              :alt="`${proposal.title} black and white candidate`"
-              class="aspect-[17/22] w-full object-cover grayscale"
-              loading="lazy"
-            />
-            <figcaption class="bg-base-100 px-2 py-1 text-center text-[10px] font-black">
-              B&amp;W
-            </figcaption>
-          </figure>
         </div>
 
         <div class="space-y-4 p-4">

--- a/pages/admin/curation-studio.vue
+++ b/pages/admin/curation-studio.vue
@@ -1,6 +1,6 @@
 <template>
   <main class="kr-surface h-full min-h-0 overflow-hidden">
-    <div class="kr-scroll kr-container-wide space-y-5 p-4 md:p-6">
+    <div class="kr-scroll w-full max-w-none space-y-5 p-4 md:p-6">
       <div v-if="!ready" class="grid min-h-60 place-items-center kr-panel">
         <span class="loading loading-spinner loading-lg text-primary" />
       </div>


### PR DESCRIPTION
## Why
The Coloring Book curation cards visually privileged the color render: it occupied the full media area while B&W was a small 34% inset. The page also inherited the shared `kr-container-wide` max-width, leaving a large unused strip on wide admin workspaces.

## What changed
- Let `/admin/curation-studio` use the full available workspace width instead of capping the scrolling content at `max-w-7xl`.
- Increase Coloring Book proposal cards from a 290px minimum to a responsive 540px minimum so pair review has enough room.
- Replace the primary-image + B&W inset treatment with a permanent 50/50 Color/B&W comparison grid.
- Give both variants identical `17:22` frames and `object-contain` presentation so neither candidate is larger or differently cropped.
- Keep equal-size placeholders when one side has not been generated yet, preserving the comparison geometry.
- Keep proposal/status badges, prompts, acceptance/finalization actions, production state, and API behavior unchanged.

## Visual intent
On wide desktop workspaces, the curation grid should now expand across the available canvas with substantial comparison cards rather than skinny cards clustered to the left. Color and B&W are peers because the production decision is about the pair.

Conductor: `interface-vision/t-105`
Session: `2026-08-25T070500Z-interface-vision-t-105-coloring-pair-layout-v8k2`