### PR TITLE
feat: add Mandarin catalog curation admin

### DIFF
--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -37,7 +37,7 @@
         </div>
       </div>
 
-      <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-[minmax(15rem,1.4fr)_minmax(11rem,0.7fr)_minmax(9rem,0.5fr)_minmax(10rem,0.6fr)_auto]">
+      <div class="grid gap-3" style="grid-template-columns: repeat(auto-fit, minmax(min(12rem, 100%), 1fr));">
         <label class="form-control gap-1">
           <span class="text-xs font-black text-base-content/55">Search catalog</span>
           <input
@@ -98,7 +98,11 @@
       <span class="loading loading-spinner loading-lg text-primary" />
     </div>
 
-    <div v-else class="grid min-h-0 gap-4" :class="selectedRow ? 'xl:grid-cols-[minmax(0,1.55fr)_minmax(25rem,0.8fr)]' : ''">
+    <div
+      v-else
+      class="grid min-h-0 gap-4"
+      style="grid-template-columns: repeat(auto-fit, minmax(min(25rem, 100%), 1fr));"
+    >
       <div class="kr-panel min-w-0 overflow-hidden">
         <div class="flex flex-wrap items-center justify-between gap-2 border-b border-base-300 bg-base-200/60 px-4 py-3">
           <p class="font-black">{{ visibleRows.length }} words shown</p>

--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -1,0 +1,359 @@
+<template>
+  <section class="space-y-4">
+    <div class="kr-panel space-y-4 p-4">
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 class="text-xl font-black">Mandarin catalog</h1>
+          <p class="mt-1 max-w-3xl text-xs leading-5 text-base-content/55">
+            Curate one canonical learner-facing entry while the pinned source data stays untouched. Changes are global overrides with an append-only audit trail, not parallel editions.
+          </p>
+        </div>
+        <button class="btn btn-sm rounded-xl" type="button" :disabled="loading" @click="store.load()">
+          <span v-if="loading" class="loading loading-spinner loading-xs" />
+          Refresh
+        </button>
+      </div>
+
+      <div v-if="payload" class="stats stats-horizontal max-w-full overflow-x-auto bg-base-200 shadow-sm">
+        <div class="stat px-4 py-2">
+          <div class="stat-title text-xs">Canonical cards</div>
+          <div class="stat-value text-xl">{{ payload.stats.cards }}</div>
+        </div>
+        <div class="stat px-4 py-2">
+          <div class="stat-title text-xs">Overrides</div>
+          <div class="stat-value text-xl">{{ payload.stats.overridden }}</div>
+        </div>
+        <div class="stat px-4 py-2">
+          <div class="stat-title text-xs">Audio cached</div>
+          <div class="stat-value text-xl">{{ payload.stats.withAudio }}</div>
+        </div>
+        <div class="stat px-4 py-2">
+          <div class="stat-title text-xs">HSK 1</div>
+          <div class="stat-value text-xl">{{ payload.stats.hsk1 }}</div>
+        </div>
+        <div class="stat px-4 py-2">
+          <div class="stat-title text-xs">HSK 2</div>
+          <div class="stat-value text-xl">{{ payload.stats.hsk2 }}</div>
+        </div>
+      </div>
+
+      <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-[minmax(15rem,1.4fr)_minmax(11rem,0.7fr)_minmax(9rem,0.5fr)_minmax(10rem,0.6fr)_auto]">
+        <label class="form-control gap-1">
+          <span class="text-xs font-black text-base-content/55">Search catalog</span>
+          <input
+            v-model="search"
+            type="search"
+            class="input input-bordered input-sm rounded-xl"
+            placeholder="Hanzi, pinyin, meaning, source…"
+          />
+        </label>
+
+        <label class="form-control gap-1">
+          <span class="text-xs font-black text-base-content/55">Category</span>
+          <select v-model="categoryFilter" class="select select-bordered select-sm rounded-xl">
+            <option value="all">All categories</option>
+            <option v-for="category in payload?.categories || []" :key="category" :value="category">
+              {{ category }}
+            </option>
+          </select>
+        </label>
+
+        <label class="form-control gap-1">
+          <span class="text-xs font-black text-base-content/55">HSK</span>
+          <select v-model="hskFilter" class="select select-bordered select-sm rounded-xl">
+            <option value="all">All levels</option>
+            <option value="1">HSK 1</option>
+            <option value="2">HSK 2</option>
+          </select>
+        </label>
+
+        <label class="form-control gap-1">
+          <span class="text-xs font-black text-base-content/55">Sort</span>
+          <select v-model="sortKey" class="select select-bordered select-sm rounded-xl">
+            <option value="hsk">HSK / frequency</option>
+            <option value="hanzi">Hanzi</option>
+            <option value="pinyin">Pinyin</option>
+            <option value="meaning">English meaning</option>
+            <option value="category">Category</option>
+          </select>
+        </label>
+
+        <label class="mt-auto flex cursor-pointer items-center gap-2 rounded-xl border border-base-300 px-3 py-2 text-sm font-bold">
+          <input v-model="overrideOnly" type="checkbox" class="checkbox checkbox-sm" />
+          Changed only
+        </label>
+      </div>
+    </div>
+
+    <div v-if="notice" class="alert border border-success/25 bg-success/10 text-sm">
+      <span>{{ notice }}</span>
+      <button class="btn btn-ghost btn-xs" type="button" @click="notice = ''">Dismiss</button>
+    </div>
+    <div v-if="error" class="alert border border-error/25 bg-error/10 text-sm">
+      <span class="min-w-0 flex-1 break-words">{{ error }}</span>
+      <button class="btn btn-ghost btn-xs" type="button" @click="error = ''">Dismiss</button>
+    </div>
+
+    <div v-if="loading && !payload" class="grid min-h-64 place-items-center kr-panel">
+      <span class="loading loading-spinner loading-lg text-primary" />
+    </div>
+
+    <div v-else class="grid min-h-0 gap-4" :class="selectedRow ? 'xl:grid-cols-[minmax(0,1.55fr)_minmax(25rem,0.8fr)]' : ''">
+      <div class="kr-panel min-w-0 overflow-hidden">
+        <div class="flex flex-wrap items-center justify-between gap-2 border-b border-base-300 bg-base-200/60 px-4 py-3">
+          <p class="font-black">{{ visibleRows.length }} words shown</p>
+          <p class="text-xs text-base-content/45">
+            Source identity is immutable. Select a row to edit its effective learner-facing values.
+          </p>
+        </div>
+
+        <div class="max-h-[68vh] overflow-auto">
+          <table class="table table-pin-rows table-sm min-w-[64rem]">
+            <thead>
+              <tr>
+                <th>Hanzi</th>
+                <th>Pinyin</th>
+                <th>Meaning</th>
+                <th>HSK</th>
+                <th>Categories</th>
+                <th>Media</th>
+                <th>Status</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="row in visibleRows"
+                :key="row.cardKey"
+                class="cursor-pointer hover:bg-base-200/60"
+                :class="{ 'bg-primary/5': row.cardKey === selectedCardKey }"
+                @click="store.selectCard(row.cardKey)"
+              >
+                <td>
+                  <div class="flex items-center gap-2">
+                    <span class="text-2xl font-black">{{ row.effective.simplified }}</span>
+                    <span v-if="row.effective.traditional" class="text-xs text-base-content/45">
+                      {{ row.effective.traditional }}
+                    </span>
+                  </div>
+                </td>
+                <td class="font-semibold">
+                  {{ row.effective.pinyin }}
+                  <span v-if="fieldChanged(row, 'pinyin')" class="text-warning" title="Admin override">•</span>
+                </td>
+                <td class="max-w-80">
+                  <span class="line-clamp-2">{{ row.effective.meaning }}</span>
+                </td>
+                <td>
+                  <span v-if="row.effective.hskLevel" class="badge badge-sm badge-outline">
+                    {{ row.effective.hskLevel }}
+                  </span>
+                </td>
+                <td class="max-w-72">
+                  <div class="flex max-h-12 flex-wrap gap-1 overflow-hidden">
+                    <span
+                      v-for="category in row.effective.categories"
+                      :key="category"
+                      class="badge badge-ghost badge-sm"
+                    >
+                      {{ category }}
+                    </span>
+                  </div>
+                </td>
+                <td>
+                  <span class="badge badge-sm" :class="row.audioReady ? 'badge-success badge-outline' : 'badge-ghost'">
+                    {{ row.audioReady ? 'audio' : 'no audio' }}
+                  </span>
+                </td>
+                <td>
+                  <span v-if="row.hasOverride" class="badge badge-warning badge-sm">overridden</span>
+                  <span v-else class="text-xs text-base-content/35">source</span>
+                </td>
+                <td>
+                  <button class="btn btn-ghost btn-xs" type="button" @click.stop="store.selectCard(row.cardKey)">
+                    Edit
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <aside v-if="selectedRow && draft" class="kr-panel min-w-0 overflow-hidden xl:sticky xl:top-4 xl:self-start">
+        <div class="flex items-start justify-between gap-3 border-b border-base-300 bg-base-200/60 p-4">
+          <div>
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="text-4xl font-black">{{ selectedRow.effective.simplified }}</span>
+              <span v-if="selectedRow.hasOverride" class="badge badge-warning">global override</span>
+            </div>
+            <p class="mt-1 text-xs text-base-content/50">
+              {{ selectedRow.cardKey }} · {{ selectedRow.source.sourceLabel }}
+            </p>
+          </div>
+          <button class="btn btn-circle btn-ghost btn-sm" type="button" aria-label="Close editor" @click="store.closeEditor()">
+            ×
+          </button>
+        </div>
+
+        <div class="max-h-[74vh] space-y-4 overflow-y-auto p-4">
+          <div class="rounded-xl border border-base-300 bg-base-200/40 p-3 text-xs leading-5">
+            <p class="font-black uppercase tracking-wide text-base-content/55">Immutable source</p>
+            <p class="mt-1">
+              <strong>{{ selectedRow.source.pinyin }}</strong> · {{ selectedRow.source.meaning }}
+            </p>
+            <p class="mt-1 text-base-content/50">
+              {{ selectedRow.source.sourceVersion }}
+            </p>
+            <div class="mt-2 flex flex-wrap gap-1">
+              <span v-for="category in selectedRow.source.categories" :key="category" class="badge badge-ghost badge-xs">
+                {{ category }}
+              </span>
+            </div>
+          </div>
+
+          <div v-if="selectedRow.overriddenFields.length" class="flex flex-wrap gap-1">
+            <span class="mr-1 text-xs font-black">Overridden:</span>
+            <span v-for="field in selectedRow.overriddenFields" :key="field" class="badge badge-warning badge-outline badge-sm">
+              {{ field }}
+            </span>
+          </div>
+
+          <label class="form-control gap-1">
+            <span class="text-xs font-black">Traditional form</span>
+            <input v-model="draft.traditional" class="input input-bordered input-sm rounded-xl" placeholder="Leave blank if none" />
+          </label>
+
+          <label class="form-control gap-1">
+            <span class="flex items-center justify-between gap-2 text-xs font-black">
+              Pinyin
+              <span v-if="draft.pinyin !== selectedRow.source.pinyin" class="text-warning">changed</span>
+            </span>
+            <input v-model="draft.pinyin" class="input input-bordered input-sm rounded-xl" />
+            <span class="text-[11px] text-base-content/45">Use tone marks, not tone numbers.</span>
+          </label>
+
+          <label class="form-control gap-1">
+            <span class="flex items-center justify-between gap-2 text-xs font-black">
+              Primary meaning
+              <span v-if="draft.meaning !== selectedRow.source.meaning" class="text-warning">changed</span>
+            </span>
+            <input v-model="draft.meaning" class="input input-bordered input-sm rounded-xl" />
+          </label>
+
+          <label class="form-control gap-1">
+            <span class="text-xs font-black">Meanings / senses</span>
+            <textarea
+              v-model="draft.meaningsText"
+              class="textarea textarea-bordered min-h-28 rounded-xl text-sm leading-5"
+              placeholder="One sense per line"
+            />
+            <span class="text-[11px] text-base-content/45">One sense per line. The primary meaning is always kept first.</span>
+          </label>
+
+          <label class="form-control gap-1">
+            <span class="text-xs font-black">Topical categories</span>
+            <input
+              v-model="draft.categoriesText"
+              class="input input-bordered input-sm rounded-xl"
+              placeholder="animals, food-drink, casino"
+            />
+            <span class="text-[11px] leading-5 text-base-content/45">
+              Comma-separated. Beginner and HSK tags are source-controlled and cannot be removed here.
+            </span>
+          </label>
+
+          <label class="form-control gap-1">
+            <span class="text-xs font-black">Usage note</span>
+            <textarea
+              v-model="draft.usageNote"
+              class="textarea textarea-bordered min-h-20 rounded-xl text-sm leading-5"
+              placeholder="Regional, formal, colloquial, casino-specific, or other learner context"
+            />
+          </label>
+
+          <label class="form-control gap-1">
+            <span class="text-xs font-black">Change note</span>
+            <textarea
+              v-model="draft.note"
+              class="textarea textarea-bordered min-h-16 rounded-xl text-sm leading-5"
+              placeholder="Why are we changing this entry?"
+            />
+            <span class="text-[11px] text-base-content/45">Stored with the audit record. Useful, but not required.</span>
+          </label>
+
+          <div class="flex flex-wrap gap-2">
+            <button class="btn btn-primary btn-sm rounded-xl" type="button" :disabled="saving" @click="store.saveSelected()">
+              <span v-if="saving" class="loading loading-spinner loading-xs" />
+              Submit change
+            </button>
+            <button class="btn btn-outline btn-sm rounded-xl" type="button" :disabled="saving" @click="store.resetDraftToSource()">
+              Restore source values
+            </button>
+          </div>
+
+          <details v-if="selectedRow.changes.length" class="rounded-xl border border-base-300 bg-base-100 p-3">
+            <summary class="cursor-pointer text-xs font-black">
+              Audit history · {{ selectedRow.changes.length }} recent change{{ selectedRow.changes.length === 1 ? '' : 's' }}
+            </summary>
+            <div class="mt-3 space-y-3">
+              <article v-for="change in selectedRow.changes" :key="change.id" class="rounded-lg bg-base-200/60 p-3 text-xs leading-5">
+                <div class="flex flex-wrap justify-between gap-2 text-base-content/50">
+                  <span>#{{ change.id }} · admin {{ change.adminUserId }}</span>
+                  <span>{{ formatTime(change.createdAt) }}</span>
+                </div>
+                <p v-if="change.note" class="mt-1 font-semibold">{{ change.note }}</p>
+                <p class="mt-1">
+                  <span class="text-base-content/45">Before:</span>
+                  {{ change.before.pinyin }} · {{ change.before.meaning }}
+                </p>
+                <p>
+                  <span class="text-base-content/45">After:</span>
+                  {{ change.after.pinyin }} · {{ change.after.meaning }}
+                </p>
+              </article>
+            </div>
+          </details>
+        </div>
+      </aside>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { storeToRefs } from 'pinia'
+import type { MandarinCurationRow } from '@/types/mandarinCuration'
+import { useMandarinCurationStore } from '@/stores/mandarinCurationStore'
+
+const store = useMandarinCurationStore()
+const {
+  payload,
+  loading,
+  saving,
+  error,
+  notice,
+  search,
+  categoryFilter,
+  hskFilter,
+  sortKey,
+  overrideOnly,
+  selectedCardKey,
+  draft,
+  selectedRow,
+  visibleRows,
+} = storeToRefs(store)
+
+function fieldChanged(row: MandarinCurationRow, field: string): boolean {
+  return row.overriddenFields.includes(field)
+}
+
+function formatTime(value: string): string {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString()
+}
+
+onMounted(() => {
+  void store.load()
+})
+</script>

--- a/pages/admin/curation-studio.vue
+++ b/pages/admin/curation-studio.vue
@@ -11,7 +11,7 @@
       >
         <p class="text-xl font-black">Administrator access required</p>
         <p class="mt-2 text-sm text-base-content/60">
-          This screen edits production prompts and can enqueue GPU work.
+          This screen edits production curation data and can enqueue GPU work.
         </p>
       </div>
 
@@ -34,15 +34,25 @@
             >
               ✏️ Coloring Book
             </button>
+            <button
+              type="button"
+              class="tab font-black"
+              :class="{ 'tab-active': project === 'mandarin' }"
+              @click="project = 'mandarin'"
+            >
+              🀄 Mandarin
+            </button>
           </nav>
           <div class="flex flex-wrap gap-2">
             <span class="badge badge-outline">Admin only</span>
+            <span class="badge badge-outline">Audited changes</span>
             <span class="badge badge-outline">ArtJob backed</span>
           </div>
         </div>
 
         <CurationCthulhuquariumCuration v-if="project === 'cthulhuquarium'" />
-        <CurationColoringBookCuration v-else />
+        <CurationColoringBookCuration v-else-if="project === 'coloring-book'" />
+        <CurationMandarinCuration v-else />
       </template>
     </div>
   </main>
@@ -52,11 +62,14 @@
 import { onMounted, ref } from 'vue'
 import CurationColoringBookCuration from '@/components/curation/coloring-book-curation.vue'
 import CurationCthulhuquariumCuration from '@/components/curation/cthulhuquarium-curation.vue'
+import CurationMandarinCuration from '@/components/curation/mandarin-curation.vue'
 import { useUserStore } from '@/stores/userStore'
 
 const userStore = useUserStore()
 const ready = ref(false)
-const project = ref<'cthulhuquarium' | 'coloring-book'>('cthulhuquarium')
+const project = ref<'cthulhuquarium' | 'coloring-book' | 'mandarin'>(
+  'cthulhuquarium',
+)
 
 onMounted(async () => {
   await userStore.initialize()

--- a/prisma/mandarin_curation.prisma
+++ b/prisma/mandarin_curation.prisma
@@ -1,0 +1,35 @@
+/// One canonical administrative overlay per sourced Mandarin card.
+/// The source catalog remains immutable; null fields inherit the current source
+/// value. This deliberately has no edition/version dimension.
+model MandarinCatalogOverride {
+  id              Int      @id @default(autoincrement())
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @default(now()) @updatedAt
+  cardKey         String   @unique @db.VarChar(255)
+  traditional     String?  @db.VarChar(255)
+  pinyin          String?  @db.VarChar(512)
+  meaning         String?  @db.Text
+  meanings        String?  @db.LongText
+  usageNote       String?  @db.Text
+  categories      String?  @db.LongText
+  updatedByUserId Int
+  isActive        Boolean  @default(true)
+
+  @@index([updatedByUserId])
+  @@index([isActive])
+}
+
+/// Append-only audit trail for Mandarin catalog curation. beforeJson and
+/// afterJson are effective learner-facing snapshots, not mutable source data.
+model MandarinCatalogChange {
+  id          Int      @id @default(autoincrement())
+  createdAt   DateTime @default(now())
+  cardKey     String   @db.VarChar(255)
+  adminUserId Int
+  beforeJson  String   @db.LongText
+  afterJson   String   @db.LongText
+  note        String?  @db.Text
+
+  @@index([cardKey, createdAt])
+  @@index([adminUserId, createdAt])
+}

--- a/prisma/migrations/20260825061000_add_mandarin_catalog_curation/migration.sql
+++ b/prisma/migrations/20260825061000_add_mandarin_catalog_curation/migration.sql
@@ -1,0 +1,35 @@
+-- CreateTable
+CREATE TABLE `MandarinCatalogOverride` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+    `cardKey` VARCHAR(255) NOT NULL,
+    `traditional` VARCHAR(255) NULL,
+    `pinyin` VARCHAR(512) NULL,
+    `meaning` TEXT NULL,
+    `meanings` LONGTEXT NULL,
+    `usageNote` TEXT NULL,
+    `categories` LONGTEXT NULL,
+    `updatedByUserId` INTEGER NOT NULL,
+    `isActive` BOOLEAN NOT NULL DEFAULT true,
+
+    UNIQUE INDEX `MandarinCatalogOverride_cardKey_key`(`cardKey`),
+    INDEX `MandarinCatalogOverride_updatedByUserId_idx`(`updatedByUserId`),
+    INDEX `MandarinCatalogOverride_isActive_idx`(`isActive`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `MandarinCatalogChange` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `cardKey` VARCHAR(255) NOT NULL,
+    `adminUserId` INTEGER NOT NULL,
+    `beforeJson` LONGTEXT NOT NULL,
+    `afterJson` LONGTEXT NOT NULL,
+    `note` TEXT NULL,
+
+    INDEX `MandarinCatalogChange_cardKey_createdAt_idx`(`cardKey`, `createdAt`),
+    INDEX `MandarinCatalogChange_adminUserId_createdAt_idx`(`adminUserId`, `createdAt`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/server/api/admin/curation-studio/mandarin.get.ts
+++ b/server/api/admin/curation-studio/mandarin.get.ts
@@ -1,0 +1,26 @@
+import { defineEventHandler } from 'h3'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { getMandarinCurationData } from '@/server/utils/mandarinCatalogCuration'
+import { errorHandler } from '@/server/utils/error'
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireAdminApiUser(event)
+    const data = await getMandarinCurationData()
+    return {
+      success: true,
+      message: 'Mandarin catalog curation loaded.',
+      data,
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+    event.node.res.statusCode = statusCode
+    return {
+      success: false,
+      message: handled.message || 'Failed to load Mandarin catalog curation.',
+      statusCode,
+    }
+  }
+})

--- a/server/api/admin/curation-studio/mandarin.post.ts
+++ b/server/api/admin/curation-studio/mandarin.post.ts
@@ -1,0 +1,40 @@
+import { createError, defineEventHandler, readBody } from 'h3'
+import type { MandarinCurationUpdate } from '~/types/mandarinCuration'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { updateMandarinCuration } from '@/server/utils/mandarinCatalogCuration'
+import { errorHandler } from '@/server/utils/error'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireAdminApiUser(event)
+    const body = (await readBody(event)) as MandarinCurationUpdate | null
+    if (!body?.cardKey) {
+      throw createError({
+        statusCode: 400,
+        message: 'Mandarin card key is required.',
+      })
+    }
+
+    const result = await updateMandarinCuration({
+      adminUserId: auth.user.id,
+      body,
+    })
+    return {
+      success: true,
+      message: result.changed
+        ? 'Mandarin catalog override saved.'
+        : 'No learner-facing Mandarin changes to save.',
+      data: result.row,
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+    event.node.res.statusCode = statusCode
+    return {
+      success: false,
+      message: handled.message || 'Failed to save Mandarin catalog curation.',
+      statusCode,
+    }
+  }
+})

--- a/server/utils/mandarinCatalog.ts
+++ b/server/utils/mandarinCatalog.ts
@@ -9,6 +9,7 @@ import {
   type MandarinStudySet,
 } from '~/utils/mandarin'
 import { enrichMandarinCharacterData } from './mandarinCharacterData'
+import { applyMandarinCatalogOverrides } from './mandarinCatalogOverrides'
 
 type SourcePronunciation = {
   y?: string
@@ -33,6 +34,7 @@ type SourceEntry = {
 const SOURCE_COMMIT = 'a66fd30b9580da2c2af7eb19e4b9d8099a29c061'
 const SOURCE_BASE = `https://raw.githubusercontent.com/jelleverheyen/hsk-vocabulary/${SOURCE_COMMIT}/wordlists/inclusive/new`
 const MINIMUM_CARD_COUNT = 500
+let sourceCatalogPromise: Promise<MandarinCatalogPayload> | null = null
 let catalogPromise: Promise<MandarinCatalogPayload> | null = null
 
 function cleanText(value: unknown): string {
@@ -167,7 +169,6 @@ function mergeCards(sourceCards: MandarinCard[]): MandarinCard[] {
 }
 
 function buildSets(cards: MandarinCard[]): MandarinStudySet[] {
-  const bySimplified = new Map(cards.map((card) => [card.simplified, card]))
   const starterKeys = cards
     .filter((card) => card.hskLevel === 1 || card.hskLevel === 2)
     .slice(0, 500)
@@ -196,14 +197,14 @@ function buildSets(cards: MandarinCard[]): MandarinStudySet[] {
     },
   ]
 
-  for (const [id, terms] of Object.entries(BUILT_IN_SET_TERMS)) {
-    const meta = BUILT_IN_SET_META[id]
-    if (!meta) continue
+  for (const [id, meta] of Object.entries(BUILT_IN_SET_META)) {
     sets.push({
       id,
       label: meta.label,
       description: meta.description,
-      cardKeys: [...new Set(terms.map((term) => bySimplified.get(term)?.key).filter(Boolean))] as string[],
+      cardKeys: cards
+        .filter((card) => card.categories.includes(id))
+        .map((card) => card.key),
     })
   }
 
@@ -222,7 +223,7 @@ async function enrichCharacterDataSafely(cards: MandarinCard[]): Promise<Mandari
   }
 }
 
-async function createCatalog(): Promise<MandarinCatalogPayload> {
+async function createSourceCatalog(): Promise<MandarinCatalogPayload> {
   const [levelOne, levelTwo] = await Promise.all([fetchLevel(1), fetchLevel(2)])
   const baseCards = mergeCards([...levelOne, ...levelTwo])
   if (baseCards.length < MINIMUM_CARD_COUNT) {
@@ -231,18 +232,33 @@ async function createCatalog(): Promise<MandarinCatalogPayload> {
     )
   }
 
-  // Character formation data is a separate provenance layer from lexical
-  // meanings. Enrich only after the vocabulary catalog is normalized so a
-  // character source can never silently replace a word's dictionary meaning.
-  // If the secondary source is temporarily unavailable, keep the core study
-  // deck alive and leave its existing pending/curated analysis intact.
+  // Character formation is source-backed enrichment, still part of the
+  // immutable underlying curriculum snapshot. Administrative lexical/category
+  // overrides are deliberately applied only after this stage.
   const cards = await enrichCharacterDataSafely(baseCards)
-
   return {
     cards,
     sets: buildSets(cards),
     source: MANDARIN_SOURCE,
   }
+}
+
+async function createCatalog(): Promise<MandarinCatalogPayload> {
+  const sourceCatalog = await getMandarinSourceCatalog()
+  const cards = await applyMandarinCatalogOverrides(sourceCatalog.cards)
+  return {
+    cards,
+    sets: buildSets(cards),
+    source: sourceCatalog.source,
+  }
+}
+
+export function getMandarinSourceCatalog(): Promise<MandarinCatalogPayload> {
+  sourceCatalogPromise ??= createSourceCatalog().catch((error) => {
+    sourceCatalogPromise = null
+    throw error
+  })
+  return sourceCatalogPromise
 }
 
 export function getMandarinCatalog(): Promise<MandarinCatalogPayload> {
@@ -251,4 +267,8 @@ export function getMandarinCatalog(): Promise<MandarinCatalogPayload> {
     throw error
   })
   return catalogPromise
+}
+
+export function invalidateMandarinCatalog(): void {
+  catalogPromise = null
 }

--- a/server/utils/mandarinCatalogCuration.ts
+++ b/server/utils/mandarinCatalogCuration.ts
@@ -1,0 +1,359 @@
+import { createError } from 'h3'
+import type {
+  MandarinCurationChange,
+  MandarinCurationPayload,
+  MandarinCurationRow,
+  MandarinCurationSnapshot,
+  MandarinCurationUpdate,
+} from '~/types/mandarinCuration'
+import type { MandarinCard } from '~/utils/mandarin'
+import {
+  getMandarinCatalog,
+  getMandarinSourceCatalog,
+  invalidateMandarinCatalog,
+} from './mandarinCatalog'
+import {
+  isMandarinSystemCategory,
+  normalizeMandarinCategories,
+  type MandarinCardWithUsage,
+} from './mandarinCatalogOverrides'
+import { prisma } from './prisma'
+
+type OverrideRow = Awaited<
+  ReturnType<typeof prisma.mandarinCatalogOverride.findFirst>
+>
+
+type ChangeRow = Awaited<
+  ReturnType<typeof prisma.mandarinCatalogChange.findFirst>
+>
+
+function clean(value: unknown, max: number): string {
+  return typeof value === 'string' ? value.trim().slice(0, max) : ''
+}
+
+function usageNote(card: MandarinCard): string {
+  return clean((card as MandarinCardWithUsage).usageNote, 2_000)
+}
+
+function snapshot(card: MandarinCard): MandarinCurationSnapshot {
+  return {
+    cardKey: card.key,
+    simplified: card.simplified,
+    traditional: card.traditional ?? '',
+    pinyin: card.pinyin,
+    meaning: card.meaning,
+    meanings: [...card.meanings],
+    usageNote: usageNote(card),
+    categories: [...card.categories],
+    hskLevel: card.hskLevel ?? null,
+    frequency: card.frequency ?? null,
+    sourceLabel: card.source.label,
+    sourceVersion: card.source.version,
+  }
+}
+
+function parseSnapshot(raw: string): MandarinCurationSnapshot | null {
+  try {
+    const value = JSON.parse(raw) as MandarinCurationSnapshot
+    if (!value || typeof value !== 'object' || !value.cardKey) return null
+    return value
+  } catch {
+    return null
+  }
+}
+
+function changePublic(row: NonNullable<ChangeRow>): MandarinCurationChange | null {
+  const before = parseSnapshot(row.beforeJson)
+  const after = parseSnapshot(row.afterJson)
+  if (!before || !after) return null
+  return {
+    id: row.id,
+    createdAt: row.createdAt.toISOString(),
+    adminUserId: row.adminUserId,
+    note: row.note ?? '',
+    before,
+    after,
+  }
+}
+
+function overriddenFields(row: OverrideRow): string[] {
+  if (!row?.isActive) return []
+  return [
+    row.traditional !== null ? 'traditional' : '',
+    row.pinyin !== null ? 'pinyin' : '',
+    row.meaning !== null ? 'meaning' : '',
+    row.meanings !== null ? 'meanings' : '',
+    row.usageNote !== null ? 'usageNote' : '',
+    row.categories !== null ? 'categories' : '',
+  ].filter(Boolean)
+}
+
+function rowPublic(input: {
+  source: MandarinCard
+  effective: MandarinCard
+  override: OverrideRow
+  audioReady: boolean
+  changes: MandarinCurationChange[]
+}): MandarinCurationRow {
+  return {
+    cardKey: input.source.key,
+    source: snapshot(input.source),
+    effective: snapshot(input.effective),
+    hasOverride: Boolean(input.override?.isActive),
+    overrideUpdatedAt: input.override?.isActive
+      ? input.override.updatedAt.toISOString()
+      : null,
+    updatedByUserId: input.override?.isActive
+      ? input.override.updatedByUserId
+      : null,
+    overriddenFields: overriddenFields(input.override),
+    audioReady: input.audioReady,
+    changes: input.changes,
+  }
+}
+
+export async function getMandarinCurationData(): Promise<MandarinCurationPayload> {
+  const [sourceCatalog, effectiveCatalog, overrides, audioAssets, changeRows] =
+    await Promise.all([
+      getMandarinSourceCatalog(),
+      getMandarinCatalog(),
+      prisma.mandarinCatalogOverride.findMany(),
+      prisma.mandarinAudioAsset.findMany({ select: { cardKey: true } }),
+      prisma.mandarinCatalogChange.findMany({
+        orderBy: { createdAt: 'desc' },
+        take: 500,
+      }),
+    ])
+
+  const effectiveByKey = new Map(
+    effectiveCatalog.cards.map((card) => [card.key, card] as const),
+  )
+  const overrideByKey = new Map(
+    overrides.map((row) => [row.cardKey, row] as const),
+  )
+  const audioKeys = new Set(audioAssets.map((asset) => asset.cardKey))
+  const changesByKey = new Map<string, MandarinCurationChange[]>()
+
+  for (const row of changeRows) {
+    const parsed = changePublic(row)
+    if (!parsed) continue
+    const current = changesByKey.get(row.cardKey) ?? []
+    if (current.length < 8) current.push(parsed)
+    changesByKey.set(row.cardKey, current)
+  }
+
+  const rows = sourceCatalog.cards.map((source) =>
+    rowPublic({
+      source,
+      effective: effectiveByKey.get(source.key) ?? source,
+      override: overrideByKey.get(source.key) ?? null,
+      audioReady: audioKeys.has(source.key),
+      changes: changesByKey.get(source.key) ?? [],
+    }),
+  )
+  const categories = [
+    ...new Set(rows.flatMap((row) => row.effective.categories)),
+  ].sort((a, b) => a.localeCompare(b))
+
+  return {
+    rows,
+    categories,
+    editableCategories: categories.filter(
+      (category) => !isMandarinSystemCategory(category),
+    ),
+    stats: {
+      cards: rows.length,
+      overridden: rows.filter((row) => row.hasOverride).length,
+      withAudio: rows.filter((row) => row.audioReady).length,
+      hsk1: rows.filter((row) => row.effective.hskLevel === 1).length,
+      hsk2: rows.filter((row) => row.effective.hskLevel === 2).length,
+    },
+  }
+}
+
+export async function getMandarinCurationRow(
+  cardKey: string,
+): Promise<MandarinCurationRow> {
+  const [sourceCatalog, effectiveCatalog, override, audioAsset, changeRows] =
+    await Promise.all([
+      getMandarinSourceCatalog(),
+      getMandarinCatalog(),
+      prisma.mandarinCatalogOverride.findUnique({ where: { cardKey } }),
+      prisma.mandarinAudioAsset.findFirst({
+        where: { cardKey },
+        select: { id: true },
+      }),
+      prisma.mandarinCatalogChange.findMany({
+        where: { cardKey },
+        orderBy: { createdAt: 'desc' },
+        take: 8,
+      }),
+    ])
+  const source = sourceCatalog.cards.find((card) => card.key === cardKey)
+  if (!source) {
+    throw createError({
+      statusCode: 404,
+      message: 'Mandarin source card not found.',
+    })
+  }
+  const effective =
+    effectiveCatalog.cards.find((card) => card.key === cardKey) ?? source
+  return rowPublic({
+    source,
+    effective,
+    override,
+    audioReady: Boolean(audioAsset),
+    changes: changeRows
+      .map(changePublic)
+      .filter((change): change is MandarinCurationChange => Boolean(change)),
+  })
+}
+
+function normalizedMeanings(primary: string, values: unknown): string[] {
+  const requested = Array.isArray(values) ? values : []
+  const cleaned = requested
+    .map((value) => clean(value, 500))
+    .filter(Boolean)
+    .slice(0, 12)
+  return [...new Set([primary, ...cleaned])]
+}
+
+function sameArray(a: string[], b: string[]): boolean {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+function sameCategorySet(a: string[], b: string[]): boolean {
+  return JSON.stringify([...a].sort()) === JSON.stringify([...b].sort())
+}
+
+function snapshotEqual(
+  a: MandarinCurationSnapshot,
+  b: MandarinCurationSnapshot,
+): boolean {
+  return (
+    a.traditional === b.traditional &&
+    a.pinyin === b.pinyin &&
+    a.meaning === b.meaning &&
+    sameArray(a.meanings, b.meanings) &&
+    a.usageNote === b.usageNote &&
+    sameCategorySet(a.categories, b.categories)
+  )
+}
+
+export async function updateMandarinCuration(input: {
+  adminUserId: number
+  body: MandarinCurationUpdate
+}): Promise<{ row: MandarinCurationRow; changed: boolean }> {
+  const cardKey = clean(input.body.cardKey, 255)
+  if (!cardKey) {
+    throw createError({ statusCode: 400, message: 'Mandarin card key is required.' })
+  }
+
+  const [sourceCatalog, effectiveCatalog, existingOverride] = await Promise.all([
+    getMandarinSourceCatalog(),
+    getMandarinCatalog(),
+    prisma.mandarinCatalogOverride.findUnique({ where: { cardKey } }),
+  ])
+  const sourceCard = sourceCatalog.cards.find((card) => card.key === cardKey)
+  if (!sourceCard) {
+    throw createError({
+      statusCode: 404,
+      message: 'Only canonical sourced Mandarin cards can be curated here.',
+    })
+  }
+  const currentCard =
+    effectiveCatalog.cards.find((card) => card.key === cardKey) ?? sourceCard
+
+  const traditional = clean(input.body.traditional, 255)
+  const pinyin = clean(input.body.pinyin, 512)
+  const meaning = clean(input.body.meaning, 500)
+  const note = clean(input.body.note, 2_000)
+  const requestedUsageNote = clean(input.body.usageNote, 2_000)
+  if (!pinyin || !meaning) {
+    throw createError({
+      statusCode: 400,
+      message: 'Pinyin and primary meaning cannot be blank.',
+    })
+  }
+
+  const meanings = normalizedMeanings(meaning, input.body.meanings)
+  const categories = normalizeMandarinCategories(
+    input.body.categories,
+    sourceCard.categories,
+  )
+  const source = snapshot(sourceCard)
+  const before = snapshot(currentCard)
+  const desired: MandarinCurationSnapshot = {
+    ...source,
+    traditional,
+    pinyin,
+    meaning,
+    meanings,
+    usageNote: requestedUsageNote,
+    categories,
+  }
+
+  if (snapshotEqual(before, desired)) {
+    return { row: await getMandarinCurationRow(cardKey), changed: false }
+  }
+
+  const sourceMeanings = normalizedMeanings(source.meaning, source.meanings)
+  const traditionalOverride =
+    desired.traditional === source.traditional ? null : desired.traditional
+  const pinyinOverride = desired.pinyin === source.pinyin ? null : desired.pinyin
+  const meaningOverride = desired.meaning === source.meaning ? null : desired.meaning
+  const meaningsOverride = sameArray(desired.meanings, sourceMeanings)
+    ? null
+    : JSON.stringify(desired.meanings)
+  const usageNoteOverride = desired.usageNote ? desired.usageNote : null
+  const categoriesOverride = sameCategorySet(desired.categories, source.categories)
+    ? null
+    : JSON.stringify(desired.categories)
+  const hasOverride = Boolean(
+    traditionalOverride !== null ||
+      pinyinOverride !== null ||
+      meaningOverride !== null ||
+      meaningsOverride !== null ||
+      usageNoteOverride !== null ||
+      categoriesOverride !== null,
+  )
+
+  await prisma.$transaction(async (tx) => {
+    await tx.mandarinCatalogOverride.upsert({
+      where: { cardKey },
+      create: {
+        cardKey,
+        traditional: traditionalOverride,
+        pinyin: pinyinOverride,
+        meaning: meaningOverride,
+        meanings: meaningsOverride,
+        usageNote: usageNoteOverride,
+        categories: categoriesOverride,
+        updatedByUserId: input.adminUserId,
+        isActive: hasOverride,
+      },
+      update: {
+        traditional: traditionalOverride,
+        pinyin: pinyinOverride,
+        meaning: meaningOverride,
+        meanings: meaningsOverride,
+        usageNote: usageNoteOverride,
+        categories: categoriesOverride,
+        updatedByUserId: input.adminUserId,
+        isActive: hasOverride,
+      },
+    })
+    await tx.mandarinCatalogChange.create({
+      data: {
+        cardKey,
+        adminUserId: input.adminUserId,
+        beforeJson: JSON.stringify(before),
+        afterJson: JSON.stringify(desired),
+        note: note || null,
+      },
+    })
+  })
+
+  invalidateMandarinCatalog()
+  return { row: await getMandarinCurationRow(cardKey), changed: true }
+}

--- a/server/utils/mandarinCatalogCuration.ts
+++ b/server/utils/mandarinCatalogCuration.ts
@@ -19,13 +19,28 @@ import {
 } from './mandarinCatalogOverrides'
 import { prisma } from './prisma'
 
-type OverrideRow = Awaited<
-  ReturnType<typeof prisma.mandarinCatalogOverride.findFirst>
->
+type OverrideRecord = {
+  cardKey: string
+  traditional: string | null
+  pinyin: string | null
+  meaning: string | null
+  meanings: string | null
+  usageNote: string | null
+  categories: string | null
+  updatedByUserId: number
+  isActive: boolean
+  updatedAt: Date
+}
 
-type ChangeRow = Awaited<
-  ReturnType<typeof prisma.mandarinCatalogChange.findFirst>
->
+type ChangeRecord = {
+  id: number
+  cardKey: string
+  adminUserId: number
+  beforeJson: string
+  afterJson: string
+  note: string | null
+  createdAt: Date
+}
 
 function clean(value: unknown, max: number): string {
   return typeof value === 'string' ? value.trim().slice(0, max) : ''
@@ -62,7 +77,7 @@ function parseSnapshot(raw: string): MandarinCurationSnapshot | null {
   }
 }
 
-function changePublic(row: NonNullable<ChangeRow>): MandarinCurationChange | null {
+function changePublic(row: ChangeRecord): MandarinCurationChange | null {
   const before = parseSnapshot(row.beforeJson)
   const after = parseSnapshot(row.afterJson)
   if (!before || !after) return null
@@ -76,7 +91,7 @@ function changePublic(row: NonNullable<ChangeRow>): MandarinCurationChange | nul
   }
 }
 
-function overriddenFields(row: OverrideRow): string[] {
+function overriddenFields(row: OverrideRecord | null): string[] {
   if (!row?.isActive) return []
   return [
     row.traditional !== null ? 'traditional' : '',
@@ -91,7 +106,7 @@ function overriddenFields(row: OverrideRow): string[] {
 function rowPublic(input: {
   source: MandarinCard
   effective: MandarinCard
-  override: OverrideRow
+  override: OverrideRecord | null
   audioReady: boolean
   changes: MandarinCurationChange[]
 }): MandarinCurationRow {
@@ -249,10 +264,9 @@ export async function updateMandarinCuration(input: {
     throw createError({ statusCode: 400, message: 'Mandarin card key is required.' })
   }
 
-  const [sourceCatalog, effectiveCatalog, existingOverride] = await Promise.all([
+  const [sourceCatalog, effectiveCatalog] = await Promise.all([
     getMandarinSourceCatalog(),
     getMandarinCatalog(),
-    prisma.mandarinCatalogOverride.findUnique({ where: { cardKey } }),
   ])
   const sourceCard = sourceCatalog.cards.find((card) => card.key === cardKey)
   if (!sourceCard) {
@@ -305,7 +319,8 @@ export async function updateMandarinCuration(input: {
   const meaningsOverride = sameArray(desired.meanings, sourceMeanings)
     ? null
     : JSON.stringify(desired.meanings)
-  const usageNoteOverride = desired.usageNote ? desired.usageNote : null
+  const usageNoteOverride =
+    desired.usageNote === source.usageNote ? null : desired.usageNote
   const categoriesOverride = sameCategorySet(desired.categories, source.categories)
     ? null
     : JSON.stringify(desired.categories)

--- a/server/utils/mandarinCatalogOverrides.ts
+++ b/server/utils/mandarinCatalogOverrides.ts
@@ -1,0 +1,153 @@
+import type { MandarinCard } from '~/utils/mandarin'
+import { prisma } from './prisma'
+
+type MandarinOverrideRow = {
+  cardKey: string
+  traditional: string | null
+  pinyin: string | null
+  meaning: string | null
+  meanings: string | null
+  usageNote: string | null
+  categories: string | null
+  isActive: boolean
+}
+
+export type MandarinCardWithUsage = MandarinCard & {
+  usageNote?: string
+}
+
+function cleanText(value: unknown, max = 2_000): string {
+  return typeof value === 'string' ? value.trim().slice(0, max) : ''
+}
+
+export function parseMandarinStringArray(
+  raw: string | null | undefined,
+  maxItems = 40,
+  maxLength = 240,
+): string[] | null {
+  if (raw === null || raw === undefined) return null
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return []
+    return [
+      ...new Set(
+        parsed
+          .map((value) => cleanText(value, maxLength))
+          .filter(Boolean)
+          .slice(0, maxItems),
+      ),
+    ]
+  } catch {
+    return []
+  }
+}
+
+export function isMandarinSystemCategory(category: string): boolean {
+  return category === 'beginner' || /^hsk-\d+$/i.test(category)
+}
+
+export function normalizeMandarinCategories(
+  categories: unknown,
+  sourceCategories: string[] = [],
+): string[] {
+  const requested = Array.isArray(categories) ? categories : []
+  const topical = requested
+    .map((value) =>
+      cleanText(value, 80)
+        .toLowerCase()
+        .replace(/\s+/g, '-')
+        .replace(/[^a-z0-9-]/g, '')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, ''),
+    )
+    .filter((value) => value && !isMandarinSystemCategory(value))
+  const locked = sourceCategories.filter(isMandarinSystemCategory)
+  return [...new Set([...locked, ...topical])]
+}
+
+function cloneCard(card: MandarinCard): MandarinCardWithUsage {
+  return {
+    ...card,
+    meanings: [...card.meanings],
+    partsOfSpeech: [...card.partsOfSpeech],
+    classifiers: [...card.classifiers],
+    categories: [...card.categories],
+    components: card.components.map((component) => ({ ...component })),
+    source: { ...card.source },
+  }
+}
+
+export function applyMandarinOverride(
+  card: MandarinCard,
+  override: MandarinOverrideRow | null | undefined,
+): MandarinCardWithUsage {
+  const next = cloneCard(card)
+  if (!override?.isActive) return next
+
+  if (override.traditional !== null) {
+    const traditional = cleanText(override.traditional, 255)
+    if (traditional && traditional !== next.simplified) next.traditional = traditional
+    else delete next.traditional
+  }
+
+  if (override.pinyin !== null) {
+    const pinyin = cleanText(override.pinyin, 512)
+    if (pinyin) next.pinyin = pinyin
+  }
+
+  if (override.meaning !== null) {
+    const meaning = cleanText(override.meaning, 500)
+    if (meaning) next.meaning = meaning
+  }
+
+  const meanings = parseMandarinStringArray(override.meanings, 12, 500)
+  if (meanings !== null) {
+    const combined = [next.meaning, ...meanings].map((value) => cleanText(value, 500)).filter(Boolean)
+    next.meanings = [...new Set(combined)]
+  }
+
+  const categories = parseMandarinStringArray(override.categories, 40, 80)
+  if (categories !== null) {
+    next.categories = normalizeMandarinCategories(categories, card.categories)
+  }
+
+  if (override.usageNote !== null) {
+    const usageNote = cleanText(override.usageNote, 2_000)
+    if (usageNote) next.usageNote = usageNote
+    else delete next.usageNote
+  }
+
+  return next
+}
+
+export async function getMandarinCatalogOverrides(): Promise<MandarinOverrideRow[]> {
+  return await prisma.mandarinCatalogOverride.findMany({
+    where: { isActive: true },
+    select: {
+      cardKey: true,
+      traditional: true,
+      pinyin: true,
+      meaning: true,
+      meanings: true,
+      usageNote: true,
+      categories: true,
+      isActive: true,
+    },
+  })
+}
+
+export async function applyMandarinCatalogOverrides(
+  cards: MandarinCard[],
+): Promise<MandarinCard[]> {
+  try {
+    const overrides = await getMandarinCatalogOverrides()
+    if (!overrides.length) return cards.map(cloneCard)
+    const byKey = new Map(overrides.map((override) => [override.cardKey, override] as const))
+    return cards.map((card) => applyMandarinOverride(card, byKey.get(card.key)))
+  } catch (error: unknown) {
+    console.warn('[mandarin] catalog overrides unavailable; serving immutable source catalog', {
+      message: error instanceof Error ? error.message : String(error),
+    })
+    return cards.map(cloneCard)
+  }
+}

--- a/stores/mandarinCurationStore.ts
+++ b/stores/mandarinCurationStore.ts
@@ -7,7 +7,12 @@ import type {
   MandarinCurationUpdate,
 } from '@/types/mandarinCuration'
 
-export type MandarinCurationSort = 'hanzi' | 'pinyin' | 'meaning' | 'hsk'
+export type MandarinCurationSort =
+  | 'hanzi'
+  | 'pinyin'
+  | 'meaning'
+  | 'hsk'
+  | 'category'
 
 export type MandarinCurationDraft = {
   traditional: string
@@ -51,6 +56,10 @@ function splitCategories(value: string): string[] {
     .map((item) => item.trim())
     .filter(Boolean)
     .slice(0, 40)
+}
+
+function firstTopicalCategory(row: MandarinCurationRow): string {
+  return editableCategories(row.effective.categories)[0] ?? 'zzzz'
 }
 
 export const useMandarinCurationStore = defineStore(
@@ -119,6 +128,13 @@ export const useMandarinCurationStore = defineStore(
         }
         if (sortKey.value === 'meaning') {
           return a.effective.meaning.localeCompare(b.effective.meaning)
+        }
+        if (sortKey.value === 'category') {
+          const categoryOrder = firstTopicalCategory(a).localeCompare(
+            firstTopicalCategory(b),
+          )
+          if (categoryOrder !== 0) return categoryOrder
+          return a.effective.pinyin.localeCompare(b.effective.pinyin)
         }
         const levelA = a.effective.hskLevel ?? 99
         const levelB = b.effective.hskLevel ?? 99

--- a/stores/mandarinCurationStore.ts
+++ b/stores/mandarinCurationStore.ts
@@ -1,0 +1,282 @@
+import { computed, ref } from 'vue'
+import { defineStore } from 'pinia'
+import { performFetch } from './utils'
+import type {
+  MandarinCurationPayload,
+  MandarinCurationRow,
+  MandarinCurationUpdate,
+} from '@/types/mandarinCuration'
+
+export type MandarinCurationSort = 'hanzi' | 'pinyin' | 'meaning' | 'hsk'
+
+export type MandarinCurationDraft = {
+  traditional: string
+  pinyin: string
+  meaning: string
+  meaningsText: string
+  usageNote: string
+  categoriesText: string
+  note: string
+}
+
+function editableCategories(categories: string[]): string[] {
+  return categories.filter(
+    (category) => category !== 'beginner' && !/^hsk-\d+$/i.test(category),
+  )
+}
+
+function draftFromRow(row: MandarinCurationRow): MandarinCurationDraft {
+  return {
+    traditional: row.effective.traditional,
+    pinyin: row.effective.pinyin,
+    meaning: row.effective.meaning,
+    meaningsText: row.effective.meanings.join('\n'),
+    usageNote: row.effective.usageNote,
+    categoriesText: editableCategories(row.effective.categories).join(', '),
+    note: '',
+  }
+}
+
+function splitMeanings(value: string): string[] {
+  return value
+    .split(/\r?\n/)
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .slice(0, 12)
+}
+
+function splitCategories(value: string): string[] {
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .slice(0, 40)
+}
+
+export const useMandarinCurationStore = defineStore(
+  'mandarinCurationStore',
+  () => {
+    const payload = ref<MandarinCurationPayload | null>(null)
+    const loading = ref(false)
+    const saving = ref(false)
+    const error = ref('')
+    const notice = ref('')
+    const search = ref('')
+    const categoryFilter = ref('all')
+    const hskFilter = ref<'all' | '1' | '2'>('all')
+    const sortKey = ref<MandarinCurationSort>('hsk')
+    const overrideOnly = ref(false)
+    const selectedCardKey = ref<string | null>(null)
+    const draft = ref<MandarinCurationDraft | null>(null)
+
+    const selectedRow = computed(
+      () =>
+        payload.value?.rows.find(
+          (row) => row.cardKey === selectedCardKey.value,
+        ) ?? null,
+    )
+
+    const visibleRows = computed(() => {
+      const query = search.value.trim().toLowerCase()
+      const rows = (payload.value?.rows ?? []).filter((row) => {
+        if (overrideOnly.value && !row.hasOverride) return false
+        if (
+          hskFilter.value !== 'all' &&
+          row.effective.hskLevel !== Number(hskFilter.value)
+        ) {
+          return false
+        }
+        if (
+          categoryFilter.value !== 'all' &&
+          !row.effective.categories.includes(categoryFilter.value)
+        ) {
+          return false
+        }
+        if (!query) return true
+        return [
+          row.effective.simplified,
+          row.effective.traditional,
+          row.effective.pinyin,
+          row.effective.meaning,
+          ...row.effective.meanings,
+          ...row.effective.categories,
+          row.effective.sourceLabel,
+        ]
+          .join(' ')
+          .toLowerCase()
+          .includes(query)
+      })
+
+      return [...rows].sort((a, b) => {
+        if (sortKey.value === 'hanzi') {
+          return a.effective.simplified.localeCompare(
+            b.effective.simplified,
+            'zh-Hans',
+          )
+        }
+        if (sortKey.value === 'pinyin') {
+          return a.effective.pinyin.localeCompare(b.effective.pinyin)
+        }
+        if (sortKey.value === 'meaning') {
+          return a.effective.meaning.localeCompare(b.effective.meaning)
+        }
+        const levelA = a.effective.hskLevel ?? 99
+        const levelB = b.effective.hskLevel ?? 99
+        if (levelA !== levelB) return levelA - levelB
+        return (a.effective.frequency ?? 1_000_000) -
+          (b.effective.frequency ?? 1_000_000)
+      })
+    })
+
+    async function load() {
+      if (loading.value) return
+      loading.value = true
+      error.value = ''
+      try {
+        const response = await performFetch<MandarinCurationPayload>(
+          '/api/admin/curation-studio/mandarin',
+          {},
+          1,
+          45_000,
+        )
+        if (!response.success || !response.data) {
+          throw new Error(response.message || 'Failed to load Mandarin curation.')
+        }
+        payload.value = response.data
+        if (
+          selectedCardKey.value &&
+          !response.data.rows.some(
+            (row) => row.cardKey === selectedCardKey.value,
+          )
+        ) {
+          selectedCardKey.value = null
+          draft.value = null
+        }
+      } catch (cause) {
+        error.value =
+          cause instanceof Error
+            ? cause.message
+            : 'Failed to load Mandarin curation.'
+      } finally {
+        loading.value = false
+      }
+    }
+
+    function selectCard(cardKey: string) {
+      const row = payload.value?.rows.find(
+        (candidate) => candidate.cardKey === cardKey,
+      )
+      if (!row) return
+      selectedCardKey.value = cardKey
+      draft.value = draftFromRow(row)
+      notice.value = ''
+      error.value = ''
+    }
+
+    function closeEditor() {
+      selectedCardKey.value = null
+      draft.value = null
+    }
+
+    function resetDraftToSource() {
+      const row = selectedRow.value
+      if (!row) return
+      draft.value = {
+        traditional: row.source.traditional,
+        pinyin: row.source.pinyin,
+        meaning: row.source.meaning,
+        meaningsText: row.source.meanings.join('\n'),
+        usageNote: '',
+        categoriesText: editableCategories(row.source.categories).join(', '),
+        note: 'Restore the learner-facing entry to the immutable source values.',
+      }
+    }
+
+    async function saveSelected(): Promise<boolean> {
+      const row = selectedRow.value
+      const currentDraft = draft.value
+      if (!row || !currentDraft || saving.value) return false
+      saving.value = true
+      error.value = ''
+      notice.value = ''
+      try {
+        const body: MandarinCurationUpdate = {
+          cardKey: row.cardKey,
+          traditional: currentDraft.traditional,
+          pinyin: currentDraft.pinyin,
+          meaning: currentDraft.meaning,
+          meanings: splitMeanings(currentDraft.meaningsText),
+          usageNote: currentDraft.usageNote,
+          categories: splitCategories(currentDraft.categoriesText),
+          note: currentDraft.note,
+        }
+        const response = await performFetch<MandarinCurationRow>(
+          '/api/admin/curation-studio/mandarin',
+          {
+            method: 'POST',
+            body: JSON.stringify(body),
+          },
+          1,
+          30_000,
+        )
+        if (!response.success || !response.data) {
+          throw new Error(response.message || 'Failed to save Mandarin curation.')
+        }
+
+        if (payload.value) {
+          const index = payload.value.rows.findIndex(
+            (candidate) => candidate.cardKey === row.cardKey,
+          )
+          if (index >= 0) payload.value.rows.splice(index, 1, response.data)
+          payload.value.categories = [
+            ...new Set(
+              payload.value.rows.flatMap(
+                (candidate) => candidate.effective.categories,
+              ),
+            ),
+          ].sort((a, b) => a.localeCompare(b))
+          payload.value.editableCategories = payload.value.categories.filter(
+            (category) =>
+              category !== 'beginner' && !/^hsk-\d+$/i.test(category),
+          )
+          payload.value.stats.overridden = payload.value.rows.filter(
+            (candidate) => candidate.hasOverride,
+          ).length
+        }
+        draft.value = draftFromRow(response.data)
+        notice.value = response.message || 'Mandarin catalog change saved.'
+        return true
+      } catch (cause) {
+        error.value =
+          cause instanceof Error
+            ? cause.message
+            : 'Failed to save Mandarin curation.'
+        return false
+      } finally {
+        saving.value = false
+      }
+    }
+
+    return {
+      payload,
+      loading,
+      saving,
+      error,
+      notice,
+      search,
+      categoryFilter,
+      hskFilter,
+      sortKey,
+      overrideOnly,
+      selectedCardKey,
+      draft,
+      selectedRow,
+      visibleRows,
+      load,
+      selectCard,
+      closeEditor,
+      resetDraftToSource,
+      saveSelected,
+    }
+  },
+)

--- a/types/mandarinCuration.ts
+++ b/types/mandarinCuration.ts
@@ -1,0 +1,59 @@
+export type MandarinCurationSnapshot = {
+  cardKey: string
+  simplified: string
+  traditional: string
+  pinyin: string
+  meaning: string
+  meanings: string[]
+  usageNote: string
+  categories: string[]
+  hskLevel: number | null
+  frequency: number | null
+  sourceLabel: string
+  sourceVersion: string
+}
+
+export type MandarinCurationChange = {
+  id: number
+  createdAt: string
+  adminUserId: number
+  note: string
+  before: MandarinCurationSnapshot
+  after: MandarinCurationSnapshot
+}
+
+export type MandarinCurationRow = {
+  cardKey: string
+  source: MandarinCurationSnapshot
+  effective: MandarinCurationSnapshot
+  hasOverride: boolean
+  overrideUpdatedAt: string | null
+  updatedByUserId: number | null
+  overriddenFields: string[]
+  audioReady: boolean
+  changes: MandarinCurationChange[]
+}
+
+export type MandarinCurationPayload = {
+  rows: MandarinCurationRow[]
+  categories: string[]
+  editableCategories: string[]
+  stats: {
+    cards: number
+    overridden: number
+    withAudio: number
+    hsk1: number
+    hsk2: number
+  }
+}
+
+export type MandarinCurationUpdate = {
+  cardKey: string
+  traditional: string
+  pinyin: string
+  meaning: string
+  meanings: string[]
+  usageNote: string
+  categories: string[]
+  note?: string
+}


### PR DESCRIPTION
## Summary
- add Mandarin as a third tab in the existing Admin Curation Studio
- provide dense search/filter/sort across canonical sourced cards
- show immutable source values beside effective learner-facing values
- allow admin overrides for traditional form, pinyin, meanings, usage note, and topical categories
- keep HSK/system tags source-controlled
- persist exactly one active override per canonical card with append-only before/after audit history
- apply overrides to the effective Mandarin catalog and invalidate cache immediately after saves
- surface audio coverage without introducing Coloring Book-style lexical editions

## Persistence
Adds `MandarinCatalogOverride` and `MandarinCatalogChange` tables through an additive migration. Source vocabulary remains immutable; corrections are overlays and audit records, not cloned editions.

## Curation contract
One canonical card identity. `null` override fields inherit the pinned source. Category overrides preserve system-owned HSK/beginner tags. A no-op submit writes no fake history. Reset-to-source deactivates the effective override while retaining audit history.

## Conductor
Implements `mandarin-tutor/t-013`.