### PR TITLE
feat: reset Mandarin Tutor art direction to v2

### DIFF
--- a/docs/mandarin-tutor-art-direction.md
+++ b/docs/mandarin-tutor-art-direction.md
@@ -1,0 +1,126 @@
+# Mandarin Tutor art direction v2
+
+Mandarin Tutor uses one canonical vocabulary catalog and a versioned illustration recipe. Art recipe versions are not vocabulary editions.
+
+## Goal
+
+The deck should feel intentionally art-directed rather than like a collection of unrelated generated images. v2 gives every image-eligible card a coherent modern Chinese educational illustration language while keeping pedagogy ahead of decoration.
+
+The target is **modern Chinese picture-book gouache**: hand-painted educational illustration with restrained watercolor and ink-wash influence, matte pigments, subtle paper texture, clean silhouettes, limited deliberate detail, harmonious color, and generous negative space.
+
+## Cultural grounding
+
+Chinese identity should come from believable lived detail, not tourist shorthand. Use contemporary domestic life, foodways, ceramics, bamboo, wood, textiles, markets, neighborhood streets, transit, furnishings, games, landscapes, tableware, kitchens, classrooms, and workplaces when they naturally support the concept.
+
+Do not decorate unrelated cards with pagodas, lantern walls, dragons, Great Wall imagery, calligraphy, red-and-gold festival styling, or historical costume. Those elements belong only when they are actually the concept being taught.
+
+People should appear as ordinary contemporary people in believable situations, with natural variety in age, body, presentation, and role. Avoid costume-like ethnic shorthand.
+
+## Anti-synthetic-image rules
+
+Prefer deliberate simplification and visible illustration decisions over maximal rendering. Avoid the visual habits that make generated art feel interchangeable:
+
+- photorealism or glossy CGI surfaces
+- plastic-looking skin
+- indiscriminate micro-detail
+- perfect mechanical symmetry
+- excessive cinematic rim lighting
+- lens flare, bokeh, and neon glow used as filler
+- crowded object fields and decorative nonsense
+- elaborate hand poses when a simpler pose teaches the word better
+- uncanny facial close-ups
+- impossible object relationships or anatomy
+
+A successful card should look as though an illustrator chose what **not** to paint.
+
+## Composition
+
+Every illustration should have one strong memory anchor or one compact scene. The learner should understand the intended concept before studying background detail.
+
+Prefer:
+
+- one focal subject
+- one clear action
+- natural asymmetry
+- modest perspective
+- restrained lighting
+- readable silhouette
+- simple, believable props
+
+Avoid crowds, spectacle, dramatic camera tricks, and busy scenery unless the vocabulary genuinely requires them.
+
+## Category direction
+
+### Food and drink
+
+Use Chinese everyday food culture naturally: ceramic bowls and cups, chopsticks, bamboo steamers, shared dishes, market ingredients, ordinary kitchens, and table settings. The food or action remains the focal subject.
+
+### Family and home
+
+Use contemporary domestic life such as apartments, homes, courtyards, or neighborhoods. Relationships should read through interaction rather than labels.
+
+### Everyday actions
+
+Show one person clearly performing the action. Favor simple, believable poses and hands over cinematic staging.
+
+### Travel and places
+
+Use contemporary Chinese urban, neighborhood, transit, street, or room contexts when useful. Never depend on readable signage.
+
+### Greetings and social phrases
+
+Use concise human interactions with natural gesture and distance. Avoid speech bubbles and close-up generated faces.
+
+### Time and calendar
+
+Use lighting and ordinary routines such as breakfast, commuting, school, work, dinner, or evening neighborhood activity rather than written calendars or numerals.
+
+### Numbers
+
+Communicate quantity with groups of countable objects, preferably familiar household, food, school, market, or game objects when appropriate. Do not render digits.
+
+### Colors
+
+Make the target color unmistakable through one familiar object or simple scene. Chinese ceramics, textiles, food, plants, or household materials can provide subtle cultural grounding.
+
+### Animals
+
+Keep species recognition dominant. Landscape, garden, farm, or neighborhood cues should remain secondary.
+
+### Casino Mandarin
+
+Use a real working table-game visual language: believable felt, chips, playing cards, tiles, dealer gestures, payouts, cash handling, and player interactions. Chinese or Chinese-speaking casino context may be used where natural, but avoid fantasy luxury and invented table text, chip denominations, or card-face numerals.
+
+### Grammar and function words
+
+Do not force decorative metaphors onto particles, classifiers, components, or abstract sentence machinery when an image would misteach. These remain `glyph-only` until a pedagogically useful visual treatment is explicitly designed.
+
+## Text policy
+
+Generated card art contains no Hanzi, pinyin, English, Latin letters, numerals, pseudo-writing, labels, captions, signage, speech bubbles, logos, or watermarks. The tutor UI owns language rendering.
+
+## Versioning and regeneration
+
+v2 is a full art-direction reset.
+
+- recipe version: `v2`
+- art direction id: `modern-chinese-picturebook-v2`
+- canonical media root: `/images/mandarin-tutor/cards/v2/`
+- request identity includes `v2`
+- every `illustrate` card is eligible for a new v2 render regardless of v1 coverage
+- v1 files remain historical assets and never suppress a v2 request
+- `glyph-only` cards are intentionally excluded from the render queue
+
+A future art-direction change should become v3 rather than mutating v2 in place once v2 is in broad production.
+
+## Quality rubric
+
+Before accepting an image, ask:
+
+1. Does the picture teach the intended meaning quickly?
+2. Does it visibly belong to the Mandarin Tutor house style?
+3. Does its Chinese cultural grounding feel lived-in rather than decorative or stereotyped?
+4. Does it avoid common synthetic-image tells?
+5. Would it sit comfortably beside hundreds of other cards without visual whiplash?
+
+Failure on any of these is a reason to regenerate, not to create another vocabulary edition.

--- a/server/utils/mandarinIllustrationManifest.ts
+++ b/server/utils/mandarinIllustrationManifest.ts
@@ -2,7 +2,9 @@ import { createHash } from 'node:crypto'
 import type { MandarinCard, MandarinCatalogPayload } from '~/utils/mandarin'
 import { getMandarinCatalog } from './mandarinCatalog'
 
-export const MANDARIN_ILLUSTRATION_RECIPE_VERSION = 'v1'
+export const MANDARIN_ILLUSTRATION_RECIPE_VERSION = 'v2'
+export const MANDARIN_ART_DIRECTION_ID = 'modern-chinese-picturebook-v2'
+export const MANDARIN_ART_DIRECTION_LABEL = 'Modern Chinese picture-book gouache'
 export const MANDARIN_ILLUSTRATION_ENGINE = 'krea2'
 export const MANDARIN_ILLUSTRATION_SIZE = 768
 
@@ -21,6 +23,7 @@ export type MandarinIllustrationManifestEntry = {
   strategy: MandarinIllustrationStrategy
   strategyReason: string
   recipeVersion: string
+  artDirectionId: string
   engine: string
   width: number
   height: number
@@ -31,6 +34,14 @@ export type MandarinIllustrationManifestEntry = {
 
 export type MandarinIllustrationManifest = {
   recipeVersion: string
+  artDirection: {
+    id: string
+    label: string
+    medium: string
+    culturalGrounding: string
+    antiAiTells: string[]
+    textPolicy: string
+  }
   engine: string
   generatedFrom: MandarinCatalogPayload['source']
   selection: {
@@ -43,6 +54,25 @@ export type MandarinIllustrationManifest = {
 }
 
 const FUNCTION_WORD_PARTS_OF_SPEECH = new Set(['u', 'y', 'c', 'p', 'd', 'r'])
+
+const ART_DIRECTION = {
+  id: MANDARIN_ART_DIRECTION_ID,
+  label: MANDARIN_ART_DIRECTION_LABEL,
+  medium:
+    'Hand-painted educational picture-book illustration with Chinese gouache, watercolor, and restrained ink-wash influence; matte pigments on subtly textured paper.',
+  culturalGrounding:
+    'Use ordinary contemporary Chinese material culture, domestic life, foodways, streets, transit, tableware, textiles, games, and environments when they naturally support the vocabulary. Cultural specificity should come from believable lived details, not tourist shorthand.',
+  antiAiTells: [
+    'simplified deliberate forms instead of indiscriminate micro-detail',
+    'matte pigment and paper texture instead of glossy CGI surfaces',
+    'natural asymmetry and hand-painted edge variation instead of mechanical perfection',
+    'one clear focal subject instead of decorative filler and object clutter',
+    'simple believable anatomy instead of elaborate hand or face poses',
+    'restrained lighting instead of cinematic rim-light, lens flare, bokeh, or neon glow',
+  ],
+  textPolicy:
+    'No Hanzi, pinyin, English, numerals, pseudo-writing, captions, signage, logos, speech bubbles, labels, or watermarks inside generated art.',
+} as const
 
 function stableToken(cardKey: string): string {
   return createHash('sha256').update(cardKey, 'utf8').digest('hex').slice(0, 24)
@@ -84,9 +114,7 @@ function illustrationStrategy(card: MandarinCard): {
     }
   }
 
-  if (
-    /^(?:\(?(?:modal |grammar )?particle\b|prefix\b|suffix\b)/i.test(card.meaning.trim())
-  ) {
+  if (/^(?:\(?(?:modal |grammar )?particle\b|prefix\b|suffix\b)/i.test(card.meaning.trim())) {
     return {
       strategy: 'glyph-only',
       reason: 'This entry is primarily grammatical morphology rather than a concrete visual concept.',
@@ -104,51 +132,53 @@ function categoryDirection(card: MandarinCard): string {
 
   if (categories.has('casino')) {
     return [
-      'Use a professional modern table-game or casino-service setting only when it helps express the concept.',
-      'Cards, chips, table layouts, dealer/player actions, cash handling, and suits should look physically plausible and brand-neutral.',
-      'Do not invent readable table labels, betting text, chip denominations, or card-face numerals.',
+      'Use a grounded contemporary Chinese or Chinese-speaking table-game context when it clarifies the concept: believable felt tables, chips, cards, tiles, cash handling, dealer gestures, and player interactions.',
+      'Favor the visual language of a real working casino floor over fantasy luxury. Keep equipment physically plausible and brand-neutral.',
+      'Do not invent readable table labels, chip denominations, card-face numerals, or gambling signage.',
     ].join(' ')
   }
-  if (categories.has('animals')) {
-    return 'Center one clearly recognizable animal or small natural animal scene; make species identity unmistakable.'
-  }
-  if (categories.has('colors')) {
-    return 'Use one familiar central object or tiny scene whose dominant named color is unmistakable; communicate the color without swatches, labels, or text.'
-  }
-  if (categories.has('numbers')) {
-    return 'Communicate quantity with a clean group of countable everyday objects; use objects rather than written digits or number symbols.'
-  }
   if (categories.has('food-drink')) {
-    return 'Make the food, drink, meal, vessel, or eating action immediately recognizable and appetizing without packaging text.'
+    return 'Use recognizable Chinese everyday food culture where natural: ceramic bowls and cups, chopsticks, bamboo steamers, shared dishes, market ingredients, or an ordinary kitchen/table setting. The food or action remains the focal point.'
   }
   if (categories.has('family')) {
-    return 'Use a warm contemporary everyday people scene that makes the relationship or person concept clear without relying on labels.'
-  }
-  if (categories.has('everyday-actions')) {
-    return 'Show the action unmistakably in progress with a clear subject, readable body language, and minimal background distraction.'
+    return 'Use a warm contemporary Chinese domestic-life scene: an ordinary apartment, home, courtyard, or neighborhood context with believable everyday clothing and furnishings. Make the relationship obvious through interaction, not labels.'
   }
   if (categories.has('travel-places')) {
-    return 'Use a recognizable contemporary vehicle, destination, room, street, or travel situation with no readable signage.'
-  }
-  if (categories.has('time-calendar')) {
-    return 'Express the time-of-day, date, duration, or temporal idea through lighting and ordinary activity, avoiding clocks or calendars with readable numerals unless essential.'
+    return 'Use a practical contemporary Chinese urban, neighborhood, transit, room, street, or travel setting where it helps. Architecture and objects should feel lived-in and specific, with no readable signage.'
   }
   if (categories.has('greetings')) {
-    return 'Use a simple contemporary social interaction whose gesture and situation communicate the phrase without speech bubbles or written language.'
+    return 'Use a simple contemporary Chinese social interaction with natural gesture, distance, and body language. Keep faces expressive but lightly rendered rather than uncanny close-up portraits.'
+  }
+  if (categories.has('time-calendar')) {
+    return 'Express time through lighting and recognizable Chinese everyday routines such as breakfast, commuting, school, work, evening meals, or neighborhood activity. Avoid clocks or calendars with readable numerals unless absolutely necessary.'
+  }
+  if (categories.has('everyday-actions')) {
+    return 'Show one person clearly performing the action in an ordinary contemporary Chinese daily-life setting where useful. Use a simple pose, believable hands, and minimal background distraction.'
+  }
+  if (categories.has('numbers')) {
+    return 'Communicate quantity with a clean group of countable everyday objects, preferably familiar Chinese household, food, market, school, or game objects when appropriate. Use objects rather than written digits or number symbols.'
+  }
+  if (categories.has('colors')) {
+    return 'Use one familiar central object or tiny scene whose target color is unmistakable. Chinese ceramics, textiles, food, plants, or ordinary household objects may provide subtle cultural grounding without turning into ornament.'
+  }
+  if (categories.has('animals')) {
+    return 'Center one clearly recognizable animal or a tiny natural scene. Chinese landscape, garden, farm, or neighborhood cues may appear lightly when relevant, but the animal must remain the unmistakable memory anchor.'
   }
 
-  return 'Choose the simplest ordinary object or everyday scene that makes the primary meaning visually obvious at a glance.'
+  return 'Choose the simplest ordinary object or everyday scene that makes the primary meaning obvious at a glance. When cultural context helps, ground it in contemporary Chinese lived environments and material culture rather than decorative stereotypes.'
 }
 
 export function buildMandarinIllustrationPrompt(card: MandarinCard): string {
   const concept = compactConcept(card.meaning)
   return [
-    `Educational flashcard illustration for the vocabulary concept: ${concept}.`,
+    `Create a square educational flashcard illustration for the vocabulary concept: ${concept}.`,
     categoryDirection(card),
-    'One memorable focal subject or compact everyday scene, square composition, polished educational editorial illustration, friendly but not childish, crisp silhouette, natural light, tactile detail, uncluttered background.',
-    'Use contemporary everyday Chinese context only when the vocabulary itself makes location or culture relevant; otherwise keep the scene universal.',
-    'Avoid generic cultural shorthand such as decorative pagodas, lanterns, calligraphy, dragons, or historical costume unless that object is genuinely the vocabulary concept.',
-    'No readable text, no Chinese characters, no Latin letters, no numerals, no captions, no signage, no labels, no speech bubbles, no logos, no watermarks, no collage.',
+    'House style: modern Chinese educational picture-book art, hand-painted gouache with gentle watercolor and restrained ink-wash influence, matte pigments, subtle paper grain, clean shapes, clear silhouettes, limited deliberate detail, warm harmonious color, and generous negative space.',
+    'The composition should feel designed by an illustrator: one strong memory anchor or one compact scene, natural asymmetry, modest depth, quiet lighting, and believable object relationships.',
+    'Ground Chinese cultural flavor through truthful everyday details such as ceramics, bamboo, wood, textiles, foodways, interiors, markets, streets, transit, games, furnishings, or landscape only when they naturally belong to the concept.',
+    'Do not use generic China shorthand as decoration: no gratuitous pagodas, lantern walls, dragons, Great Wall imagery, calligraphy, red-and-gold festival dressing, or historical costume unless that specific thing is genuinely the vocabulary concept.',
+    'Avoid characteristic synthetic-image tells: no photorealism, glossy plastic skin, 3D-render surfaces, hyper-detailed microtexture everywhere, perfect symmetry, excessive cinematic rim lighting, lens flare, bokeh, neon glow, decorative filler, implausible anatomy, or crowded hands.',
+    'No readable text, no Chinese characters, no pinyin, no English, no Latin letters, no numerals, no pseudo-writing, no captions, no signage, no labels, no speech bubbles, no logos, no watermarks, no collage.',
   ].join(' ')
 }
 
@@ -189,20 +219,19 @@ export async function getMandarinIllustrationManifest(): Promise<MandarinIllustr
         strategy: decision.strategy,
         strategyReason: decision.reason,
         recipeVersion: MANDARIN_ILLUSTRATION_RECIPE_VERSION,
+        artDirectionId: MANDARIN_ART_DIRECTION_ID,
         engine: MANDARIN_ILLUSTRATION_ENGINE,
         width: MANDARIN_ILLUSTRATION_SIZE,
         height: MANDARIN_ILLUSTRATION_SIZE,
         imagePath,
         imageUrl: imagePath.replace(/^public/, ''),
-        prompt:
-          decision.strategy === 'illustrate'
-            ? buildMandarinIllustrationPrompt(card)
-            : null,
+        prompt: decision.strategy === 'illustrate' ? buildMandarinIllustrationPrompt(card) : null,
       }
     })
 
   return {
     recipeVersion: MANDARIN_ILLUSTRATION_RECIPE_VERSION,
+    artDirection: { ...ART_DIRECTION, antiAiTells: [...ART_DIRECTION.antiAiTells] },
     engine: MANDARIN_ILLUSTRATION_ENGINE,
     generatedFrom: catalog.source,
     selection: {


### PR DESCRIPTION
## Summary
- make Mandarin Tutor art recipe `v2`, so prior v1 coverage never suppresses the new visual pass
- establish the definitive `modern-chinese-picturebook-v2` house style
- ground cards in contemporary Chinese material culture and daily life without tourist shorthand
- add explicit anti-synthetic-image guidance: matte gouache/paper texture, deliberate simplification, natural asymmetry, restrained lighting, uncluttered compositions, and no glossy CGI/photoreal tells
- keep grammar/function entries glyph-only when a decorative image would misteach
- move all canonical v2 media to `/images/mandarin-tutor/cards/v2/` and all request identities to `mandarin-tutor-v2-*`
- document the full art-direction, category, text, regeneration, and quality rubric in `docs/mandarin-tutor-art-direction.md`

## Regeneration policy
This is intentionally a full art reset. Every image-eligible Starter 500 + Casino card is eligible for a fresh v2 render regardless of v1 art. v1 remains historical only.

## Cultural direction
Chinese flavor should come from believable lived detail: ceramics, foodways, homes, markets, streets, transit, games, textiles, furnishings, landscapes, and working environments when relevant. Pagodas, lanterns, dragons, calligraphy, festival red-and-gold, Great Wall imagery, and historical costume are explicitly rejected as generic decoration unless they are actually the vocabulary concept.

## Conductor
Extends `mandarin-tutor/t-010` after the art-direction reset requested during review.