### PR TITLE
feat: surface canonical Mandarin v2 art in tutor

### DIFF
--- a/server/api/mandarin/requests/[id]/art.post.ts
+++ b/server/api/mandarin/requests/[id]/art.post.ts
@@ -7,6 +7,7 @@ import { requireApiUser } from '../../../../utils/authGuard'
 import { errorHandler } from '../../../../utils/error'
 import { prisma } from '../../../../utils/prisma'
 import {
+  ensureRequestedArtRecipe,
   reconcileRequestedCardArt,
   requestedCardPublicDataEnriched,
 } from '../../../../utils/mandarinRequestedCards'
@@ -75,7 +76,11 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 404, message: 'Requested Mandarin card not found.' })
     }
 
-    const reconciled = await reconcileRequestedCardArt(row)
+    // v2 is a deliberate visual reset. An older requested-card image must not
+    // short-circuit the new house style: upgrade its persisted prompt first and
+    // clear the stale v1 job/image linkage before checking queue state.
+    const recipeCurrent = await ensureRequestedArtRecipe(row)
+    const reconciled = await reconcileRequestedCardArt(recipeCurrent)
     if (reconciled.artImageId) {
       return {
         success: true,
@@ -113,7 +118,7 @@ export default defineEventHandler(async (event) => {
         height: 768,
         isPublic: false,
         isMature: false,
-        designer: `mandarin-request:${reconciled.id}`,
+        designer: `mandarin-request:v2:${reconciled.id}`,
       },
     })
 
@@ -143,7 +148,7 @@ export default defineEventHandler(async (event) => {
     return {
       success: true,
       statusCode: 201,
-      message: 'Requested-card illustration queued.',
+      message: 'Requested-card v2 illustration queued.',
       data: await requestedCardPublicDataEnriched(updated),
     }
   } catch (error) {

--- a/server/utils/mandarinRequestedCards.ts
+++ b/server/utils/mandarinRequestedCards.ts
@@ -1,10 +1,14 @@
 import { createError } from 'h3'
 import type { MandarinCard } from '~/utils/mandarin'
 import { enrichMandarinCharacterData } from './mandarinCharacterData'
+import {
+  buildMandarinIllustrationPrompt,
+  MANDARIN_ILLUSTRATION_RECIPE_VERSION,
+} from './mandarinIllustrationManifest'
 import { prisma } from './prisma'
 
 export const MANDARIN_REQUEST_RECIPE_VERSION = 'v1'
-export const MANDARIN_REQUEST_ART_VERSION = 'v1'
+export const MANDARIN_REQUEST_ART_VERSION = MANDARIN_ILLUSTRATION_RECIPE_VERSION
 const MAX_REQUEST_LENGTH = 120
 const MAX_TEXT_RESPONSE_LENGTH = 20_000
 
@@ -142,14 +146,71 @@ export function requestedCardPrompt(requestText: string): string {
   return `Create a Mandarin learning card for this requested word or short phrase: ${JSON.stringify(requestText)}`
 }
 
+function requestedArtCategories(fields: GeneratedMandarinFields): string[] {
+  const context = `${fields.meaning} ${fields.usageNote || ''}`
+  if (/casino|gambl|wager|bet|dealer|banker|chip|baccarat|blackjack|roulette|poker/i.test(context)) {
+    return ['requested', 'casino']
+  }
+  if (/food|drink|tea|coffee|meal|rice|noodle|bread|restaurant|eat|cook/i.test(context)) {
+    return ['requested', 'food-drink']
+  }
+  return ['requested']
+}
+
 export function requestedArtPrompt(fields: GeneratedMandarinFields): string {
-  return [
-    `Educational flashcard illustration for the Mandarin concept “${fields.meaning}”.`,
-    `The underlying Chinese learning item is ${fields.simplified}, but do not render written language in the image.`,
-    'Show one concrete, memorable everyday object, action, or scene that communicates the concept at a glance.',
-    'Friendly, culturally grounded, uncluttered, polished editorial illustration.',
-    'No text, no letters, no Chinese characters, no captions, no logo, no watermark.',
-  ].join(' ')
+  const promptCard: MandarinCard = {
+    key: 'requested:prompt',
+    simplified: fields.simplified,
+    ...(fields.traditional ? { traditional: fields.traditional } : {}),
+    pinyin: fields.pinyin,
+    meaning: fields.meaning,
+    meanings: fields.meanings,
+    kind: [...fields.simplified].length === 1 ? 'character' : 'phrase',
+    partsOfSpeech: [],
+    classifiers: [],
+    categories: requestedArtCategories(fields),
+    components: [],
+    historyStatus: 'pending',
+    source: {
+      label: 'Requested Mandarin card',
+      version: MANDARIN_REQUEST_ART_VERSION,
+    },
+  }
+  return buildMandarinIllustrationPrompt(promptCard)
+}
+
+function rowGeneratedFields(row: RequestedCardRow): GeneratedMandarinFields {
+  return {
+    simplified: row.simplified,
+    traditional: row.traditional,
+    pinyin: row.pinyin,
+    meaning: row.meaning,
+    meanings: parseStoredMeanings(row.meanings, row.meaning),
+    usageNote: row.usageNote,
+  }
+}
+
+export async function ensureRequestedArtRecipe<T extends RequestedCardRow>(row: T): Promise<T> {
+  if (row.artPromptVersion === MANDARIN_REQUEST_ART_VERSION) return row
+
+  const artPrompt = requestedArtPrompt(rowGeneratedFields(row))
+  await prisma.mandarinRequestedCard.update({
+    where: { id: row.id },
+    data: {
+      artPrompt,
+      artPromptVersion: MANDARIN_REQUEST_ART_VERSION,
+      artJobId: null,
+      artImageId: null,
+    },
+  })
+
+  return {
+    ...row,
+    artPrompt,
+    artPromptVersion: MANDARIN_REQUEST_ART_VERSION,
+    artJobId: null,
+    artImageId: null,
+  }
 }
 
 function parseStoredMeanings(raw: string, fallback: string): string[] {
@@ -226,6 +287,7 @@ export async function reconcileRequestedCardArt<T extends RequestedCardRow>(
 }
 
 export function requestedCardPublicData(row: RequestedCardRow) {
+  const artIsCurrent = row.artPromptVersion === MANDARIN_REQUEST_ART_VERSION
   return {
     id: row.id,
     card: requestedRowToCard(row),
@@ -241,9 +303,9 @@ export function requestedCardPublicData(row: RequestedCardRow) {
     art: {
       prompt: row.artPrompt,
       promptVersion: row.artPromptVersion,
-      jobId: row.artJobId,
-      imageId: row.artImageId,
-      imageUrl: row.artImageId ? `/api/art/images/${row.artImageId}/file` : null,
+      jobId: artIsCurrent ? row.artJobId : null,
+      imageId: artIsCurrent ? row.artImageId : null,
+      imageUrl: artIsCurrent && row.artImageId ? `/api/art/images/${row.artImageId}/file` : null,
     },
   }
 }

--- a/stores/mandarinTutorStore.ts
+++ b/stores/mandarinTutorStore.ts
@@ -1,4 +1,4 @@
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { defineStore } from 'pinia'
 import { performFetch } from './utils'
 import { useUserStore } from './userStore'
@@ -10,6 +10,8 @@ import type {
 } from '@/utils/mandarin'
 
 const STORAGE_KEY = 'kind-robots:mandarin-tutor:v1'
+const CANONICAL_ART_RECIPE = 'v2'
+const CANONICAL_ART_DIRECTION = 'modern-chinese-picturebook-v2'
 
 type LocalState = {
   customSets: MandarinCustomSet[]
@@ -62,6 +64,23 @@ type MandarinRequestedCardsPayload = {
   cards: MandarinRequestedCardData[]
 }
 
+type MandarinIllustrationManifestEntry = {
+  cardKey: string
+  imageUrl?: string
+  prompt?: string | null
+  strategy: 'illustrate' | 'glyph-only'
+  recipeVersion?: string
+  artDirectionId?: string
+}
+
+type MandarinIllustrationManifestPayload = {
+  recipeVersion: string
+  artDirection?: {
+    id?: string
+  }
+  entries: MandarinIllustrationManifestEntry[]
+}
+
 function safeId(value: string): string {
   return value
     .trim()
@@ -100,8 +119,12 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
   const artImageIds = ref<Record<string, number>>({})
   const artImageUrls = ref<Record<string, string>>({})
   const artStatuses = ref<Record<string, string>>({})
+  const canonicalArtUrls = ref<Record<string, string>>({})
+  const canonicalArtPrompts = ref<Record<string, string>>({})
+  const canonicalArtStrategies = ref<Record<string, 'illustrate' | 'glyph-only'>>({})
   const artQueueingKey = ref<string | null>(null)
   const artRefreshingKey = ref<string | null>(null)
+  const canonicalArtProbeInFlight = new Set<string>()
   let activeReferenceAudio: HTMLAudioElement | null = null
 
   const cardMap = computed(
@@ -243,6 +266,82 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
     }
   }
 
+  async function loadIllustrationManifest() {
+    if (!import.meta.client) return
+    try {
+      const response = await performFetch<MandarinIllustrationManifestPayload>(
+        '/api/mandarin/art-manifest',
+        {},
+        1,
+        30_000,
+      )
+      const manifest = response.data
+      if (!response.success || !manifest || !Array.isArray(manifest.entries)) return
+      if (manifest.recipeVersion !== CANONICAL_ART_RECIPE) return
+      if (manifest.artDirection?.id !== CANONICAL_ART_DIRECTION) return
+
+      const urls: Record<string, string> = {}
+      const prompts: Record<string, string> = {}
+      const strategies: Record<string, 'illustrate' | 'glyph-only'> = {}
+      const statusDefaults: Record<string, string> = {}
+
+      for (const entry of manifest.entries) {
+        const key = String(entry.cardKey || '').trim()
+        if (!key) continue
+        strategies[key] = entry.strategy
+        if (entry.strategy === 'glyph-only') {
+          statusDefaults[key] = 'GLYPH ONLY'
+          continue
+        }
+
+        const imageUrl = String(entry.imageUrl || '').trim()
+        const prompt = String(entry.prompt || '').trim()
+        if (imageUrl.startsWith('/images/mandarin-tutor/cards/v2/')) {
+          urls[key] = imageUrl
+          statusDefaults[key] = 'V2 PENDING'
+        }
+        if (prompt) prompts[key] = prompt
+      }
+
+      canonicalArtUrls.value = urls
+      canonicalArtPrompts.value = prompts
+      canonicalArtStrategies.value = strategies
+      artStatuses.value = { ...statusDefaults, ...artStatuses.value }
+    } catch (cause) {
+      console.warn('[mandarin] v2 illustration manifest load failed', cause)
+    }
+  }
+
+  async function probeCanonicalIllustration(cardKey: string): Promise<string | null> {
+    if (!import.meta.client || requestedId(cardKey)) return null
+    if (artImageUrls.value[cardKey]) return artImageUrls.value[cardKey] || null
+    if (canonicalArtProbeInFlight.has(cardKey)) return null
+
+    const url = canonicalArtUrls.value[cardKey]
+    if (!url) return null
+
+    canonicalArtProbeInFlight.add(cardKey)
+    try {
+      const response = await fetch(url, {
+        method: 'HEAD',
+        cache: 'no-store',
+      })
+      if (!response.ok) {
+        artStatuses.value = { ...artStatuses.value, [cardKey]: 'V2 PENDING' }
+        return null
+      }
+
+      artImageUrls.value = { ...artImageUrls.value, [cardKey]: url }
+      artStatuses.value = { ...artStatuses.value, [cardKey]: 'V2 READY' }
+      return url
+    } catch {
+      artStatuses.value = { ...artStatuses.value, [cardKey]: 'V2 PENDING' }
+      return null
+    } finally {
+      canonicalArtProbeInFlight.delete(cardKey)
+    }
+  }
+
   async function fetchProtectedImage(artImageId: number): Promise<string | null> {
     if (!import.meta.client) return null
     const userStore = useUserStore()
@@ -321,7 +420,10 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
     if (initialized.value || loading.value) return
     loadLocalState()
     await loadCatalog()
+    await loadIllustrationManifest()
     await loadRequestedCards()
+    const key = currentCard.value?.key
+    if (key) await probeCanonicalIllustration(key)
   }
 
   function selectSet(id: string) {
@@ -570,12 +672,14 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
     artQueueingKey.value = card.key
     error.value = null
     try {
-      const promptString = [
-        `Educational flashcard illustration for the Mandarin concept “${card.meaning}”.`,
-        'One clear memorable everyday scene or object that communicates the meaning at a glance.',
-        'Culturally grounded, friendly, uncluttered, polished editorial illustration.',
-        'No text, no letters, no Chinese characters, no captions, no logo, no watermark.',
-      ].join(' ')
+      const promptString = canonicalArtPrompts.value[card.key]
+      if (!promptString) {
+        if (canonicalArtStrategies.value[card.key] === 'glyph-only') {
+          throw new Error('This card is intentionally glyph-only because a decorative image would misteach it.')
+        }
+        throw new Error('The canonical Mandarin v2 art prompt is not available yet.')
+      }
+
       const response = await performFetch<ArtEnqueueData>(
         '/api/art/enqueue',
         {
@@ -588,7 +692,7 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
             height: 768,
             isPublic: false,
             isMature: false,
-            designer: `mandarin:${card.key}`,
+            designer: `mandarin:v2:${card.key}`,
           }),
         },
         1,
@@ -675,6 +779,14 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
     return artStatuses.value[cardKey] || null
   }
 
+  watch(
+    () => currentCard.value?.key ?? null,
+    (cardKey) => {
+      if (!cardKey) return
+      void probeCanonicalIllustration(cardKey)
+    },
+  )
+
   return {
     cards,
     builtInSets,
@@ -697,6 +809,8 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
     artImageIds,
     artImageUrls,
     artStatuses,
+    canonicalArtUrls,
+    canonicalArtStrategies,
     artQueueingKey,
     artRefreshingKey,
     allSets,
@@ -708,7 +822,9 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
     audioSupported,
     initialize,
     loadCatalog,
+    loadIllustrationManifest,
     loadRequestedCards,
+    probeCanonicalIllustration,
     selectSet,
     nextCard,
     previousCard,


### PR DESCRIPTION
## Summary
- load the canonical Mandarin v2 illustration manifest into the Pinia tutor store
- probe only the currently viewed sourced card's deterministic self-hosted media path
- automatically display the v2 image when it exists and keep the Hanzi fallback while it is pending
- surface `V2 PENDING`, `V2 READY`, and intentional `GLYPH ONLY` status without probing hundreds of images at boot
- make manual sourced-card Krea2 retries use the exact server-supplied `modern-chinese-picturebook-v2` prompt instead of rebuilding the old generic browser prompt
- keep requested-card ArtImage handling independent

## Why
The bulk v2 pipeline and tutor UI were previously separate. Without this join, deterministic `/images/mandarin-tutor/cards/v2/...` media could render successfully but never appear automatically in the flashcard UI.

## Art contract
This does not create another prompt recipe. The store trusts `/api/mandarin/art-manifest` only when it reports recipe `v2` and art direction `modern-chinese-picturebook-v2`. Glyph-only cards cannot silently fall back to decorative generation.