### PR TITLE
fix: protect Mandarin curation drafts

### DIFF
--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -190,6 +190,7 @@
             <div class="flex flex-wrap items-center gap-2">
               <span class="text-4xl font-black">{{ selectedRow.effective.simplified }}</span>
               <span v-if="selectedRow.hasOverride" class="badge badge-warning">global override</span>
+              <span v-if="draftDirty" class="badge badge-info badge-outline">unsaved</span>
             </div>
             <p class="mt-1 text-xs text-base-content/50">
               {{ selectedRow.cardKey }} · {{ selectedRow.source.sourceLabel }}
@@ -201,6 +202,14 @@
         </div>
 
         <div class="max-h-[74vh] space-y-4 overflow-y-auto p-4">
+          <div
+            v-if="draftDirty"
+            class="rounded-xl border border-info/30 bg-info/10 p-3 text-xs leading-5"
+            role="status"
+          >
+            This draft has unsaved changes. Saving, discarding, or restoring to the source is explicit so a row switch cannot erase work silently.
+          </div>
+
           <div class="rounded-xl border border-base-300 bg-base-200/40 p-3 text-xs leading-5">
             <p class="font-black uppercase tracking-wide text-base-content/55">Immutable source</p>
             <p class="mt-1">
@@ -287,9 +296,18 @@
           </label>
 
           <div class="flex flex-wrap gap-2">
-            <button class="btn btn-primary btn-sm rounded-xl" type="button" :disabled="saving" @click="store.saveSelected()">
+            <button class="btn btn-primary btn-sm rounded-xl" type="button" :disabled="!canSave" @click="store.saveSelected()">
               <span v-if="saving" class="loading loading-spinner loading-xs" />
-              Submit change
+              Save changes
+            </button>
+            <button
+              v-if="draftDirty"
+              class="btn btn-ghost btn-sm rounded-xl"
+              type="button"
+              :disabled="saving"
+              @click="store.discardDraft()"
+            >
+              Discard draft
             </button>
             <button class="btn btn-outline btn-sm rounded-xl" type="button" :disabled="saving" @click="store.resetDraftToSource()">
               Restore source values
@@ -345,6 +363,8 @@ const {
   selectedCardKey,
   draft,
   selectedRow,
+  draftDirty,
+  canSave,
   visibleRows,
 } = storeToRefs(store)
 

--- a/stores/mandarinCurationStore.ts
+++ b/stores/mandarinCurationStore.ts
@@ -58,6 +58,28 @@ function splitCategories(value: string): string[] {
     .slice(0, 40)
 }
 
+function comparableDraft(draft: MandarinCurationDraft) {
+  return {
+    traditional: draft.traditional.trim(),
+    pinyin: draft.pinyin.trim(),
+    meaning: draft.meaning.trim(),
+    meanings: splitMeanings(draft.meaningsText),
+    usageNote: draft.usageNote.trim(),
+    categories: [...splitCategories(draft.categoriesText)].sort(),
+  }
+}
+
+function comparableRow(row: MandarinCurationRow) {
+  return {
+    traditional: row.effective.traditional.trim(),
+    pinyin: row.effective.pinyin.trim(),
+    meaning: row.effective.meaning.trim(),
+    meanings: row.effective.meanings.map((item) => item.trim()).filter(Boolean),
+    usageNote: row.effective.usageNote.trim(),
+    categories: [...editableCategories(row.effective.categories)].sort(),
+  }
+}
+
 function firstTopicalCategory(row: MandarinCurationRow): string {
   return editableCategories(row.effective.categories)[0] ?? 'zzzz'
 }
@@ -84,6 +106,15 @@ export const useMandarinCurationStore = defineStore(
           (row) => row.cardKey === selectedCardKey.value,
         ) ?? null,
     )
+
+    const draftDirty = computed(() => {
+      const row = selectedRow.value
+      const currentDraft = draft.value
+      if (!row || !currentDraft) return false
+      return JSON.stringify(comparableDraft(currentDraft)) !== JSON.stringify(comparableRow(row))
+    })
+
+    const canSave = computed(() => draftDirty.value && !saving.value)
 
     const visibleRows = computed(() => {
       const query = search.value.trim().toLowerCase()
@@ -178,20 +209,41 @@ export const useMandarinCurationStore = defineStore(
       }
     }
 
-    function selectCard(cardKey: string) {
+    function guardUnsavedDraft(): boolean {
+      if (!draftDirty.value) return true
+      error.value = 'This entry has unsaved changes. Save them or discard the draft before leaving it.'
+      notice.value = ''
+      return false
+    }
+
+    function selectCard(cardKey: string): boolean {
+      if (cardKey === selectedCardKey.value) return true
+      if (!guardUnsavedDraft()) return false
       const row = payload.value?.rows.find(
         (candidate) => candidate.cardKey === cardKey,
       )
-      if (!row) return
+      if (!row) return false
       selectedCardKey.value = cardKey
       draft.value = draftFromRow(row)
       notice.value = ''
       error.value = ''
+      return true
     }
 
-    function closeEditor() {
+    function closeEditor(): boolean {
+      if (!guardUnsavedDraft()) return false
       selectedCardKey.value = null
       draft.value = null
+      error.value = ''
+      return true
+    }
+
+    function discardDraft() {
+      const row = selectedRow.value
+      if (!row) return
+      draft.value = draftFromRow(row)
+      error.value = ''
+      notice.value = 'Unsaved changes discarded.'
     }
 
     function resetDraftToSource() {
@@ -211,7 +263,7 @@ export const useMandarinCurationStore = defineStore(
     async function saveSelected(): Promise<boolean> {
       const row = selectedRow.value
       const currentDraft = draft.value
-      if (!row || !currentDraft || saving.value) return false
+      if (!row || !currentDraft || saving.value || !draftDirty.value) return false
       saving.value = true
       error.value = ''
       notice.value = ''
@@ -287,10 +339,13 @@ export const useMandarinCurationStore = defineStore(
       selectedCardKey,
       draft,
       selectedRow,
+      draftDirty,
+      canSave,
       visibleRows,
       load,
       selectCard,
       closeEditor,
+      discardDraft,
       resetDraftToSource,
       saveSelected,
     }


### PR DESCRIPTION
## Summary
- detect learner-facing curation changes in the Pinia store
- block row switching and editor close when unsaved changes would be lost
- add an explicit Discard draft action
- disable Save when no learner-facing values changed
- surface an unsaved badge/callout in the Mandarin curation editor

This is intentionally separate from the learner interaction PR so admin safety can merge independently.