### PR TITLE
kind-robots/t-073: finish the app-account least-privilege boundary

### DIFF
--- a/docs/runbooks/app-account-privilege-narrowing.md
+++ b/docs/runbooks/app-account-privilege-narrowing.md
@@ -1,162 +1,167 @@
 # Narrowing the application database account
 
-**kind-robots/t-073.** The application account `kindrobot` holds
-`ALL PRIVILEGES ON *.*` **`WITH GRANT OPTION`**, plus `ALL PRIVILEGES` on
-`kindrobots`, `kindblank`, `kindblank_fresh` and `kindblank_shadow`.
+**kind-robots/t-073.** This runbook records the remaining MariaDB privilege
+cleanup for the production application account, `kindrobot`.
 
-That credential is `DATABASE_URL`. It lives in the app service's env file and is
-loaded into the long-running Nuxt container, so **the permanently-running web
-process holds server-wide superuser on every database, and can re-grant itself
-anything it likes.**
+## Current state, verified live 2026-08-27
 
-This makes the two-lane design decorative. `prisma.config.ts` refusing
-`DATABASE_URL` for migrate commands, `prisma-migrate-deploy.mjs` refusing it
-again, `verifyMigrateOnDeploy.ts` warning that moving `MIGRATION_DATABASE_URL`
-into the app service "would hand a permanently-running web process the ability to
-drop tables" — all of it carefully prevents something the app account can already
-do. See [migration-credential-boundary.md](./migration-credential-boundary.md)
-for the boundary this is supposed to enforce. **The boundary is real in the code
-and absent in the database.** Code cannot enforce a database privilege.
+The original t-073 investigation found a server-wide `ALL PRIVILEGES ON *.* WITH
+GRANT OPTION` grant. That worst-case grant was subsequently removed manually on
+Alexandria. A fresh `SHOW GRANTS FOR 'kindrobot'@'%'` on 2026-08-27 showed:
 
-> **A wrong revoke takes the site down.** Work the sequence below in order. Do
-> not skip step 0.
+```text
+GRANT USAGE ON *.* TO `kindrobot`@`%` IDENTIFIED BY PASSWORD '<redacted>'
+GRANT ALL PRIVILEGES ON `kindrobots`.* TO `kindrobot`@`%`
+GRANT ALL PRIVILEGES ON `kindblank`.* TO `kindrobot`@`%`
+GRANT ALL PRIVILEGES ON `kindblank_fresh`.* TO `kindrobot`@`%`
+GRANT ALL PRIVILEGES ON `kindblank_shadow`.* TO `kindrobot`@`%`
+```
+
+So the production web process is **not** a server-wide superuser and does **not**
+hold `GRANT OPTION` anymore. The remaining problem is smaller but real:
+
+- it can still run DDL such as `CREATE`, `ALTER`, and `DROP` inside
+  `kindblank_fresh`;
+- it still has full access to three databases the running app does not need;
+- the separate `kindrobot_migrate` lane exists specifically so schema-changing
+  work does not need to live in the always-running web process.
+
+The intended final state is:
+
+```text
+USAGE on *.*
+SELECT, INSERT, UPDATE, DELETE on `kindblank_fresh`.*
+```
+
+Nothing in the PR that added this runbook changes grants automatically. The live
+change remains a human-gated Alexandria operation.
 
 ---
 
-## Step 0 — rotate the password first, before any of this
+## 1. Why DML-only is enough
 
-The `kindrobot` password was disclosed twice in an agent session transcript on
-2026-08-25: once in plaintext, and once as the `mysql_native_password` hash from
-a `SHOW GRANTS` dump. **A hash is a credential, not a fingerprint** — it is
-sufficient to authenticate with some clients. Treat the transcript as untrusted
-storage.
-
-Rotate before narrowing, because narrowing takes planning and the disclosure is
-live now. Rotation is independent of everything below and can ship on its own.
-
-After rotating, update the app service's env file and restart it. Nothing else
-reads this credential.
-
----
-
-## Step 1 — what the app actually executes (done; recorded here as evidence)
-
-The dangerous part of a narrowing is discovering, at revoke time, that something
-quietly depended on a privilege it should not have had. Enumerated 2026-08-25
-across the whole runtime path:
+The runtime path was enumerated during t-073:
 
 | operation | count in `server/` | privilege needed |
-|---|---|---|
-| `SELECT` (incl. `SELECT … FOR UPDATE`) | 10 | `SELECT` |
+|---|---:|---|
+| `SELECT` including `SELECT ... FOR UPDATE` | 10 | `SELECT` |
 | `INSERT` | 1 | `INSERT` |
 | `UPDATE` | 1 | `UPDATE` |
 | `DELETE` | 1 | `DELETE` |
-| `GET_LOCK()` | 1 | none — any user may call it |
-| **DDL of any kind** | **0** | — |
+| `GET_LOCK()` | 1 | none beyond the connection itself |
+| DDL | 0 | none |
 
-Everything else goes through Prisma Client, which emits only DML.
+Everything else goes through Prisma Client and remains DML.
 
-Two things that look like exceptions and are not:
+Two apparent exceptions do not widen the app lane:
 
-- **`server/plugins/01-migration-drift-check.ts`** reads `_prisma_migrations` at
-  boot. That is a plain `SELECT` on a table in the app's own database. Its own
-  comment says it "needs to know what was migrated, never to migrate anything",
-  which is exactly right and stays true under the narrowed grant.
-- **`CREATE TEMPORARY TABLE`** appears only in hand-run maintenance scripts under
-  `utils/scripts/`. Those are a different lane, run deliberately by a human, and
-  must not widen the app lane. If one needs the privilege, give it the migration
-  credential for that run.
-
-**Conclusion: the app lane needs `SELECT, INSERT, UPDATE, DELETE` on
-`kindblank_fresh` and nothing else.**
-
-Still worth eyeballing before you revoke, because they are outside this repo:
-ProxySQL's query rules, and anything on the box that reuses `DATABASE_URL`.
+- `server/plugins/01-migration-drift-check.ts` only reads `_prisma_migrations`.
+- maintenance scripts under `utils/scripts/` that need schema privileges belong
+  on the migration credential, not `DATABASE_URL`.
 
 ---
 
-## Step 2 — record the current grant so it can be restored
+## 2. Credential disclosure status is separate
 
-```sql
-SHOW GRANTS FOR 'kindrobot'@'%';
-```
+The August 25 investigation also recorded that an application credential or
+password hash had appeared in an agent transcript. Grant narrowing does not tell
+us whether that credential was later rotated.
 
-Save the output somewhere you can reach in a hurry. **Redact the
-`IDENTIFIED BY PASSWORD '…'` portion before it goes anywhere persistent** — that
-is the disclosure in step 0 repeating itself.
+If it was already rotated after that disclosure, do not rotate it again merely
+because this runbook exists. If it was not, rotate it before doing unrelated
+privilege work and update the application service atomically.
 
-Restoring is `GRANT ALL PRIVILEGES ON *.* TO 'kindrobot'@'%' WITH GRANT OPTION;`
-followed by `FLUSH PRIVILEGES;` — under a minute, if something breaks.
+Do not print or persist a MariaDB password hash. Redact `IDENTIFIED BY PASSWORD`
+from any saved `SHOW GRANTS` output.
 
 ---
 
-## Step 3 — verify against a narrowed account first, not in production
+## 3. Snapshot the current grants
 
-Create a second account with the target grant and point a **non-production**
-app instance at it:
+Before changing anything, capture the current **redacted** grants. The known
+2026-08-27 rollback target is the four database-wide `ALL PRIVILEGES` grants
+listed at the top of this document. Do **not** restore the historical global
+`ALL PRIVILEGES ON *.* WITH GRANT OPTION`; that state has already been fixed.
+
+A rollback, if needed, is therefore:
 
 ```sql
-CREATE USER 'kindrobot_app'@'%' IDENTIFIED BY '<new password>';
-GRANT SELECT, INSERT, UPDATE, DELETE ON `kindblank_fresh`.* TO 'kindrobot_app'@'%';
+GRANT ALL PRIVILEGES ON `kindrobots`.* TO 'kindrobot'@'%';
+GRANT ALL PRIVILEGES ON `kindblank`.* TO 'kindrobot'@'%';
+GRANT ALL PRIVILEGES ON `kindblank_fresh`.* TO 'kindrobot'@'%';
+GRANT ALL PRIVILEGES ON `kindblank_shadow`.* TO 'kindrobot'@'%';
 FLUSH PRIVILEGES;
 ```
 
-Exercise the app against it: boot it (the drift-check plugin runs on boot), load
-a few pages, write something, and run the art queue path — that one takes a
-`GET_LOCK` and a `SELECT … FOR UPDATE`, so it is the best single smoke test.
-
-Then confirm the account is actually as narrow as intended:
-
-```bash
-DATABASE_URL='<narrowed url>' npx tsx utils/scripts/verifyAppAccountPrivileges.ts
-```
-
-That script asks the **database** what the connected account holds and exits 1 on
-anything beyond `SELECT/INSERT/UPDATE/DELETE` on one database, on any `*.*`
-grant, and on `GRANT OPTION`. It redacts password hashes from everything it
-prints, including error messages.
-
 ---
 
-## Step 4 — narrow the real account
+## 4. Narrow the real account
 
-Only once step 3 is green:
+The cleanest transition is to remove all database privileges from the account,
+then immediately add back only the DML set the app needs:
 
 ```sql
 REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'kindrobot'@'%';
-GRANT SELECT, INSERT, UPDATE, DELETE ON `kindblank_fresh`.* TO 'kindrobot'@'%';
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON `kindblank_fresh`.*
+  TO 'kindrobot'@'%';
 FLUSH PRIVILEGES;
 ```
 
-Then re-run the verifier against the real `DATABASE_URL` and restart the app.
+`USAGE ON *.*` is the account/authentication baseline and is expected to remain.
 
-`REVOKE ALL PRIVILEGES, GRANT OPTION` removes the global grant **and** the four
-per-database ones in a single statement, which is what you want: the account
-should not keep `ALL PRIVILEGES` on `kindrobots`, `kindblank`, or
-`kindblank_shadow` either.
+This intentionally removes access to:
 
-**`kindblank_shadow` in particular.** It is a Prisma shadow database, created and
-dropped by tooling. That is a reasonable thing for a *migration* account to
-reach and not something the web process needs.
+- `kindrobots`
+- `kindblank`
+- `kindblank_shadow`
 
----
+and removes schema-changing privileges from `kindblank_fresh`.
 
-## Step 5 — keep it narrow
-
-Add the verifier to whatever runs against the live database on a schedule. The
-failure mode this guards against is not someone deliberately re-granting
-superuser; it is a future incident where a wide grant is handed out to unblock
-something at 2am and never taken back.
+`kindblank_shadow` belongs to migration/tooling behavior, not the production web
+process. The dedicated `kindrobot_migrate` identity is the schema-changing lane.
 
 ---
 
-## Two smaller things, cheap to fix while you are in here
+## 5. Verify immediately
 
-- **`.env` is mode `0640`, owner `silasfelinus:users`.** Any process running as
-  group `users` can read the database credential. `0600` unless something else
-  genuinely needs it.
-- **The connection string carries `sslaccept=accept_invalid_certs`.** The
-  application lane connects without verifying the ProxySQL certificate. The
-  migration lane already does a TLS preflight; this one does not.
+From the repository checkout, with the production `DATABASE_URL` available to
+the process running the command:
 
-Neither is the headline. Both are a few minutes.
+```bash
+npm run test:app-account-privileges
+```
+
+The verifier:
+
+- asks MariaDB what the connected identity actually holds;
+- allows only global `USAGE`;
+- allows only `SELECT`, `INSERT`, `UPDATE`, `DELETE`;
+- requires those DML privileges to be database-wide on the database the app is
+  actually connected to;
+- rejects `ALL PRIVILEGES`, `GRANT OPTION`, server-wide privileges, grants on
+  another database, and bespoke table-level grants;
+- redacts credential material from all output.
+
+Then exercise the production app through normal application paths, including at
+least one read and one write. The art queue is a useful smoke path because it
+uses both `GET_LOCK()` and `SELECT ... FOR UPDATE`.
+
+If anything unexpectedly fails, restore the four database grants from section 3
+first, then investigate. Do not widen the account beyond that known 2026-08-27
+state as a troubleshooting shortcut.
+
+---
+
+## 6. Keep the boundary testable
+
+The long-term failure mode is configuration drift: a wide grant gets handed out
+during an incident and survives after the incident is over. Keep the verifier as
+a cheap explicit check whenever database credentials or ProxySQL/MariaDB routing
+are changed.
+
+Two adjacent hardening items remain separate from this grant cleanup:
+
+- keep the application `.env` readable only by the account/process that needs it;
+- avoid disabling certificate verification on the application DB connection if
+  the current ProxySQL TLS setup can support verified certificates.

--- a/docs/runbooks/app-account-privilege-narrowing.md
+++ b/docs/runbooks/app-account-privilege-narrowing.md
@@ -1,0 +1,162 @@
+# Narrowing the application database account
+
+**kind-robots/t-073.** The application account `kindrobot` holds
+`ALL PRIVILEGES ON *.*` **`WITH GRANT OPTION`**, plus `ALL PRIVILEGES` on
+`kindrobots`, `kindblank`, `kindblank_fresh` and `kindblank_shadow`.
+
+That credential is `DATABASE_URL`. It lives in the app service's env file and is
+loaded into the long-running Nuxt container, so **the permanently-running web
+process holds server-wide superuser on every database, and can re-grant itself
+anything it likes.**
+
+This makes the two-lane design decorative. `prisma.config.ts` refusing
+`DATABASE_URL` for migrate commands, `prisma-migrate-deploy.mjs` refusing it
+again, `verifyMigrateOnDeploy.ts` warning that moving `MIGRATION_DATABASE_URL`
+into the app service "would hand a permanently-running web process the ability to
+drop tables" — all of it carefully prevents something the app account can already
+do. See [migration-credential-boundary.md](./migration-credential-boundary.md)
+for the boundary this is supposed to enforce. **The boundary is real in the code
+and absent in the database.** Code cannot enforce a database privilege.
+
+> **A wrong revoke takes the site down.** Work the sequence below in order. Do
+> not skip step 0.
+
+---
+
+## Step 0 — rotate the password first, before any of this
+
+The `kindrobot` password was disclosed twice in an agent session transcript on
+2026-08-25: once in plaintext, and once as the `mysql_native_password` hash from
+a `SHOW GRANTS` dump. **A hash is a credential, not a fingerprint** — it is
+sufficient to authenticate with some clients. Treat the transcript as untrusted
+storage.
+
+Rotate before narrowing, because narrowing takes planning and the disclosure is
+live now. Rotation is independent of everything below and can ship on its own.
+
+After rotating, update the app service's env file and restart it. Nothing else
+reads this credential.
+
+---
+
+## Step 1 — what the app actually executes (done; recorded here as evidence)
+
+The dangerous part of a narrowing is discovering, at revoke time, that something
+quietly depended on a privilege it should not have had. Enumerated 2026-08-25
+across the whole runtime path:
+
+| operation | count in `server/` | privilege needed |
+|---|---|---|
+| `SELECT` (incl. `SELECT … FOR UPDATE`) | 10 | `SELECT` |
+| `INSERT` | 1 | `INSERT` |
+| `UPDATE` | 1 | `UPDATE` |
+| `DELETE` | 1 | `DELETE` |
+| `GET_LOCK()` | 1 | none — any user may call it |
+| **DDL of any kind** | **0** | — |
+
+Everything else goes through Prisma Client, which emits only DML.
+
+Two things that look like exceptions and are not:
+
+- **`server/plugins/01-migration-drift-check.ts`** reads `_prisma_migrations` at
+  boot. That is a plain `SELECT` on a table in the app's own database. Its own
+  comment says it "needs to know what was migrated, never to migrate anything",
+  which is exactly right and stays true under the narrowed grant.
+- **`CREATE TEMPORARY TABLE`** appears only in hand-run maintenance scripts under
+  `utils/scripts/`. Those are a different lane, run deliberately by a human, and
+  must not widen the app lane. If one needs the privilege, give it the migration
+  credential for that run.
+
+**Conclusion: the app lane needs `SELECT, INSERT, UPDATE, DELETE` on
+`kindblank_fresh` and nothing else.**
+
+Still worth eyeballing before you revoke, because they are outside this repo:
+ProxySQL's query rules, and anything on the box that reuses `DATABASE_URL`.
+
+---
+
+## Step 2 — record the current grant so it can be restored
+
+```sql
+SHOW GRANTS FOR 'kindrobot'@'%';
+```
+
+Save the output somewhere you can reach in a hurry. **Redact the
+`IDENTIFIED BY PASSWORD '…'` portion before it goes anywhere persistent** — that
+is the disclosure in step 0 repeating itself.
+
+Restoring is `GRANT ALL PRIVILEGES ON *.* TO 'kindrobot'@'%' WITH GRANT OPTION;`
+followed by `FLUSH PRIVILEGES;` — under a minute, if something breaks.
+
+---
+
+## Step 3 — verify against a narrowed account first, not in production
+
+Create a second account with the target grant and point a **non-production**
+app instance at it:
+
+```sql
+CREATE USER 'kindrobot_app'@'%' IDENTIFIED BY '<new password>';
+GRANT SELECT, INSERT, UPDATE, DELETE ON `kindblank_fresh`.* TO 'kindrobot_app'@'%';
+FLUSH PRIVILEGES;
+```
+
+Exercise the app against it: boot it (the drift-check plugin runs on boot), load
+a few pages, write something, and run the art queue path — that one takes a
+`GET_LOCK` and a `SELECT … FOR UPDATE`, so it is the best single smoke test.
+
+Then confirm the account is actually as narrow as intended:
+
+```bash
+DATABASE_URL='<narrowed url>' npx tsx utils/scripts/verifyAppAccountPrivileges.ts
+```
+
+That script asks the **database** what the connected account holds and exits 1 on
+anything beyond `SELECT/INSERT/UPDATE/DELETE` on one database, on any `*.*`
+grant, and on `GRANT OPTION`. It redacts password hashes from everything it
+prints, including error messages.
+
+---
+
+## Step 4 — narrow the real account
+
+Only once step 3 is green:
+
+```sql
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'kindrobot'@'%';
+GRANT SELECT, INSERT, UPDATE, DELETE ON `kindblank_fresh`.* TO 'kindrobot'@'%';
+FLUSH PRIVILEGES;
+```
+
+Then re-run the verifier against the real `DATABASE_URL` and restart the app.
+
+`REVOKE ALL PRIVILEGES, GRANT OPTION` removes the global grant **and** the four
+per-database ones in a single statement, which is what you want: the account
+should not keep `ALL PRIVILEGES` on `kindrobots`, `kindblank`, or
+`kindblank_shadow` either.
+
+**`kindblank_shadow` in particular.** It is a Prisma shadow database, created and
+dropped by tooling. That is a reasonable thing for a *migration* account to
+reach and not something the web process needs.
+
+---
+
+## Step 5 — keep it narrow
+
+Add the verifier to whatever runs against the live database on a schedule. The
+failure mode this guards against is not someone deliberately re-granting
+superuser; it is a future incident where a wide grant is handed out to unblock
+something at 2am and never taken back.
+
+---
+
+## Two smaller things, cheap to fix while you are in here
+
+- **`.env` is mode `0640`, owner `silasfelinus:users`.** Any process running as
+  group `users` can read the database credential. `0600` unless something else
+  genuinely needs it.
+- **The connection string carries `sslaccept=accept_invalid_certs`.** The
+  application lane connects without verifying the ProxySQL certificate. The
+  migration lane already does a TLS preflight; this one does not.
+
+Neither is the headline. Both are a few minutes.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "test:comments": "npm run test:comment-migration && npm run test:comment-signals && npm run test:comment-calibration",
     "test:comment-authors": "tsx utils/scripts/verifyCommentBackfillAuthors.ts",
     "test:app-base-url": "tsx utils/scripts/verifyAppBaseUrl.ts",
+    "test:app-account-privileges": "tsx utils/scripts/verifyAppAccountPrivileges.ts",
+    "test:app-account-privileges-selftest": "tsx utils/scripts/verifyAppAccountPrivileges.test.ts",
     "test:appmaker-slug-candidate-guard-selftest": "tsx utils/scripts/verifyAppmakerSlugCandidateGuard.test.ts",
     "test:mana-resource-split": "tsx utils/scripts/verifyManaResourceSplit.test.ts",
     "test:mana-attribution": "tsx utils/scripts/verifyManaAttribution.test.ts",

--- a/utils/scripts/verifyAppAccountPrivileges.test.ts
+++ b/utils/scripts/verifyAppAccountPrivileges.test.ts
@@ -1,53 +1,40 @@
 // utils/scripts/verifyAppAccountPrivileges.test.ts
 //
-// kind-robots/t-073. The redaction is the part that must not be wrong, so it is
-// tested against the real SHAPES of the grants this account actually holds.
+// kind-robots/t-073. Regression coverage for grant parsing, scope checks, and
+// credential redaction. The observed grant fixture matches the live 2026-08-27
+// state after the historical global superuser grant had already been removed.
 //
-// No real hash appears here. The placeholder below is deliberately obvious --
-// the point of the redactor is that a hash never reaches a log, and a test that
-// embedded one to prove that would defeat itself.
+// No real hash appears here. The placeholder below is deliberately obvious.
 //
 //   npx tsx utils/scripts/verifyAppAccountPrivileges.test.ts
 
 import assert from 'node:assert/strict'
 import {
+  databaseScopeIn,
   isGlobal,
   privilegesIn,
   redactGrant,
 } from './verifyAppAccountPrivileges'
 
-// Deliberately NOT hash-shaped. The redactor matches whatever sits inside the
-// quotes, so the test proves just as much with a string no scanner or reader
-// could ever mistake for a real credential.
 const FAKE_HASH = 'PLACEHOLDER-NOT-A-REAL-CREDENTIAL'
 
 // --- redaction -------------------------------------------------------------
 {
-  const line = `GRANT ALL PRIVILEGES ON *.* TO \`kindrobot\`@\`%\` IDENTIFIED BY PASSWORD '${FAKE_HASH}' WITH GRANT OPTION`
+  const line = `GRANT USAGE ON *.* TO \`kindrobot\`@\`%\` IDENTIFIED BY PASSWORD '${FAKE_HASH}'`
   const out = redactGrant(line)
   assert.ok(!out.includes(FAKE_HASH), 'password hash survived redaction')
   assert.ok(
     out.includes("IDENTIFIED BY PASSWORD '<redacted>'"),
     'hash was not replaced in place',
   )
-  assert.ok(
-    out.includes('WITH GRANT OPTION'),
-    'redaction destroyed the part we need to read',
-  )
-  assert.ok(
-    out.includes('ALL PRIVILEGES'),
-    'redaction destroyed the privilege list',
-  )
 }
 {
-  // Plaintext form, which some servers return.
   const out = redactGrant(
     `GRANT USAGE ON *.* TO \`app\`@\`%\` IDENTIFIED BY 'hunter2'`,
   )
   assert.ok(!out.includes('hunter2'), 'plaintext password survived redaction')
 }
 {
-  // MariaDB's auth-plugin form.
   const out = redactGrant(
     `GRANT USAGE ON *.* TO \`app\`@\`%\` IDENTIFIED VIA ed25519 USING '${FAKE_HASH}'`,
   )
@@ -57,7 +44,6 @@ const FAKE_HASH = 'PLACEHOLDER-NOT-A-REAL-CREDENTIAL'
   )
 }
 {
-  // A grant with no credential material must pass through untouched.
   const line =
     'GRANT SELECT, INSERT, UPDATE, DELETE ON `kindblank_fresh`.* TO `kindrobot`@`%`'
   assert.equal(
@@ -75,48 +61,64 @@ assert.deepEqual(
   ['SELECT', 'INSERT', 'UPDATE', 'DELETE'],
 )
 assert.deepEqual(
-  privilegesIn('GRANT ALL PRIVILEGES ON *.* TO `kindrobot`@`%`'),
+  privilegesIn('GRANT ALL PRIVILEGES ON `kindblank_fresh`.* TO `kindrobot`@`%`'),
   ['ALL PRIVILEGES'],
 )
 assert.deepEqual(privilegesIn('GRANT USAGE ON *.* TO `kindrobot`@`%`'), [
   'USAGE',
 ])
-// Column-scoped grants carry a parenthesised column list that is not a privilege.
 assert.deepEqual(
   privilegesIn('GRANT SELECT (id, name), UPDATE (name) ON `db`.`t` TO `u`@`%`'),
   ['SELECT', 'UPDATE'],
 )
 assert.deepEqual(privilegesIn('not a grant line'), [])
 
-// --- global vs database scope ----------------------------------------------
-assert.equal(isGlobal('GRANT ALL PRIVILEGES ON *.* TO `kindrobot`@`%`'), true)
+// --- grant scope -----------------------------------------------------------
+assert.equal(isGlobal('GRANT USAGE ON *.* TO `kindrobot`@`%`'), true)
 assert.equal(
   isGlobal('GRANT ALL PRIVILEGES ON `kindblank_fresh`.* TO `kindrobot`@`%`'),
   false,
 )
-assert.equal(isGlobal('GRANT SELECT ON `db`.`table` TO `u`@`%`'), false)
+assert.equal(
+  databaseScopeIn(
+    'GRANT SELECT, INSERT ON `kindblank_fresh`.* TO `kindrobot`@`%`',
+  ),
+  'kindblank_fresh',
+)
+assert.equal(databaseScopeIn('GRANT SELECT ON kindblank_fresh.* TO `u`@`%`'), 'kindblank_fresh')
+assert.equal(databaseScopeIn('GRANT USAGE ON *.* TO `u`@`%`'), null)
+assert.equal(databaseScopeIn('GRANT SELECT ON `db`.`table` TO `u`@`%`'), null)
 
-// --- the five grants t-073 actually found, as a whole ----------------------
-// If the narrowing lands, every one of these must stop matching.
+// --- live 2026-08-27 grant shape ------------------------------------------
 {
   const observed = [
-    `GRANT ALL PRIVILEGES ON *.* TO \`kindrobot\`@\`%\` IDENTIFIED BY PASSWORD '${FAKE_HASH}' WITH GRANT OPTION`,
+    `GRANT USAGE ON *.* TO \`kindrobot\`@\`%\` IDENTIFIED BY PASSWORD '${FAKE_HASH}'`,
     'GRANT ALL PRIVILEGES ON `kindrobots`.* TO `kindrobot`@`%`',
     'GRANT ALL PRIVILEGES ON `kindblank`.* TO `kindrobot`@`%`',
     'GRANT ALL PRIVILEGES ON `kindblank_fresh`.* TO `kindrobot`@`%`',
     'GRANT ALL PRIVILEGES ON `kindblank_shadow`.* TO `kindrobot`@`%`',
   ]
-  for (const grant of observed) {
-    assert.ok(
-      !redactGrant(grant).includes(FAKE_HASH),
-      'a hash reached the output',
-    )
+
+  assert.ok(!redactGrant(observed[0]!).includes(FAKE_HASH))
+  assert.deepEqual(privilegesIn(observed[0]!), ['USAGE'])
+  assert.equal(isGlobal(observed[0]!), true)
+
+  for (const grant of observed.slice(1)) {
     assert.ok(
       privilegesIn(grant).includes('ALL PRIVILEGES'),
       `failed to flag ALL PRIVILEGES in: ${grant}`,
     )
   }
-  // And the target state passes.
+
+  assert.deepEqual(
+    observed.slice(1).map((grant) => databaseScopeIn(grant)),
+    ['kindrobots', 'kindblank', 'kindblank_fresh', 'kindblank_shadow'],
+  )
+}
+
+// The intended final state is global USAGE for account existence/auth plus one
+// database-wide DML grant on the live application schema.
+{
   const target =
     'GRANT SELECT, INSERT, UPDATE, DELETE ON `kindblank_fresh`.* TO `kindrobot`@`%`'
   const allowed = new Set(['SELECT', 'INSERT', 'UPDATE', 'DELETE'])
@@ -125,6 +127,7 @@ assert.equal(isGlobal('GRANT SELECT ON `db`.`table` TO `u`@`%`'), false)
     'target grant would be rejected',
   )
   assert.equal(isGlobal(target), false)
+  assert.equal(databaseScopeIn(target), 'kindblank_fresh')
 }
 
 console.log('verifyAppAccountPrivileges: all assertions passed')

--- a/utils/scripts/verifyAppAccountPrivileges.test.ts
+++ b/utils/scripts/verifyAppAccountPrivileges.test.ts
@@ -1,0 +1,130 @@
+// utils/scripts/verifyAppAccountPrivileges.test.ts
+//
+// kind-robots/t-073. The redaction is the part that must not be wrong, so it is
+// tested against the real SHAPES of the grants this account actually holds.
+//
+// No real hash appears here. The placeholder below is deliberately obvious --
+// the point of the redactor is that a hash never reaches a log, and a test that
+// embedded one to prove that would defeat itself.
+//
+//   npx tsx utils/scripts/verifyAppAccountPrivileges.test.ts
+
+import assert from 'node:assert/strict'
+import {
+  isGlobal,
+  privilegesIn,
+  redactGrant,
+} from './verifyAppAccountPrivileges'
+
+// Deliberately NOT hash-shaped. The redactor matches whatever sits inside the
+// quotes, so the test proves just as much with a string no scanner or reader
+// could ever mistake for a real credential.
+const FAKE_HASH = 'PLACEHOLDER-NOT-A-REAL-CREDENTIAL'
+
+// --- redaction -------------------------------------------------------------
+{
+  const line = `GRANT ALL PRIVILEGES ON *.* TO \`kindrobot\`@\`%\` IDENTIFIED BY PASSWORD '${FAKE_HASH}' WITH GRANT OPTION`
+  const out = redactGrant(line)
+  assert.ok(!out.includes(FAKE_HASH), 'password hash survived redaction')
+  assert.ok(
+    out.includes("IDENTIFIED BY PASSWORD '<redacted>'"),
+    'hash was not replaced in place',
+  )
+  assert.ok(
+    out.includes('WITH GRANT OPTION'),
+    'redaction destroyed the part we need to read',
+  )
+  assert.ok(
+    out.includes('ALL PRIVILEGES'),
+    'redaction destroyed the privilege list',
+  )
+}
+{
+  // Plaintext form, which some servers return.
+  const out = redactGrant(
+    `GRANT USAGE ON *.* TO \`app\`@\`%\` IDENTIFIED BY 'hunter2'`,
+  )
+  assert.ok(!out.includes('hunter2'), 'plaintext password survived redaction')
+}
+{
+  // MariaDB's auth-plugin form.
+  const out = redactGrant(
+    `GRANT USAGE ON *.* TO \`app\`@\`%\` IDENTIFIED VIA ed25519 USING '${FAKE_HASH}'`,
+  )
+  assert.ok(
+    !out.includes(FAKE_HASH),
+    'auth-plugin credential survived redaction',
+  )
+}
+{
+  // A grant with no credential material must pass through untouched.
+  const line =
+    'GRANT SELECT, INSERT, UPDATE, DELETE ON `kindblank_fresh`.* TO `kindrobot`@`%`'
+  assert.equal(
+    redactGrant(line),
+    line,
+    'redactor altered a credential-free grant',
+  )
+}
+
+// --- privilege parsing -----------------------------------------------------
+assert.deepEqual(
+  privilegesIn(
+    'GRANT SELECT, INSERT, UPDATE, DELETE ON `kindblank_fresh`.* TO `kindrobot`@`%`',
+  ),
+  ['SELECT', 'INSERT', 'UPDATE', 'DELETE'],
+)
+assert.deepEqual(
+  privilegesIn('GRANT ALL PRIVILEGES ON *.* TO `kindrobot`@`%`'),
+  ['ALL PRIVILEGES'],
+)
+assert.deepEqual(privilegesIn('GRANT USAGE ON *.* TO `kindrobot`@`%`'), [
+  'USAGE',
+])
+// Column-scoped grants carry a parenthesised column list that is not a privilege.
+assert.deepEqual(
+  privilegesIn('GRANT SELECT (id, name), UPDATE (name) ON `db`.`t` TO `u`@`%`'),
+  ['SELECT', 'UPDATE'],
+)
+assert.deepEqual(privilegesIn('not a grant line'), [])
+
+// --- global vs database scope ----------------------------------------------
+assert.equal(isGlobal('GRANT ALL PRIVILEGES ON *.* TO `kindrobot`@`%`'), true)
+assert.equal(
+  isGlobal('GRANT ALL PRIVILEGES ON `kindblank_fresh`.* TO `kindrobot`@`%`'),
+  false,
+)
+assert.equal(isGlobal('GRANT SELECT ON `db`.`table` TO `u`@`%`'), false)
+
+// --- the five grants t-073 actually found, as a whole ----------------------
+// If the narrowing lands, every one of these must stop matching.
+{
+  const observed = [
+    `GRANT ALL PRIVILEGES ON *.* TO \`kindrobot\`@\`%\` IDENTIFIED BY PASSWORD '${FAKE_HASH}' WITH GRANT OPTION`,
+    'GRANT ALL PRIVILEGES ON `kindrobots`.* TO `kindrobot`@`%`',
+    'GRANT ALL PRIVILEGES ON `kindblank`.* TO `kindrobot`@`%`',
+    'GRANT ALL PRIVILEGES ON `kindblank_fresh`.* TO `kindrobot`@`%`',
+    'GRANT ALL PRIVILEGES ON `kindblank_shadow`.* TO `kindrobot`@`%`',
+  ]
+  for (const grant of observed) {
+    assert.ok(
+      !redactGrant(grant).includes(FAKE_HASH),
+      'a hash reached the output',
+    )
+    assert.ok(
+      privilegesIn(grant).includes('ALL PRIVILEGES'),
+      `failed to flag ALL PRIVILEGES in: ${grant}`,
+    )
+  }
+  // And the target state passes.
+  const target =
+    'GRANT SELECT, INSERT, UPDATE, DELETE ON `kindblank_fresh`.* TO `kindrobot`@`%`'
+  const allowed = new Set(['SELECT', 'INSERT', 'UPDATE', 'DELETE'])
+  assert.ok(
+    privilegesIn(target).every((p) => allowed.has(p)),
+    'target grant would be rejected',
+  )
+  assert.equal(isGlobal(target), false)
+}
+
+console.log('verifyAppAccountPrivileges: all assertions passed')

--- a/utils/scripts/verifyAppAccountPrivileges.ts
+++ b/utils/scripts/verifyAppAccountPrivileges.ts
@@ -1,0 +1,146 @@
+// utils/scripts/verifyAppAccountPrivileges.ts
+//
+// kind-robots/t-073. Makes the application/migration credential boundary
+// TESTABLE instead of aspirational.
+//
+// The boundary was, until this script, entirely a code convention:
+// prisma.config.ts refuses DATABASE_URL for migrate commands,
+// prisma-migrate-deploy.mjs refuses it again, and a runbook explains why. All
+// of it was carefully preventing something the application account could
+// already do -- `kindrobot` holds ALL PRIVILEGES ON *.* WITH GRANT OPTION, so
+// the permanently-running Nuxt process has server-wide superuser and can
+// re-grant itself anything it likes. Code cannot enforce a database privilege;
+// only the database can. This asks it.
+//
+// PASSWORD HASHES ARE REDACTED FROM ALL OUTPUT. `SHOW GRANTS` returns
+// `IDENTIFIED BY PASSWORD '<hash>'`, and a mysql_native_password hash is
+// sufficient to authenticate with some clients -- it is a credential, not a
+// fingerprint. Leaking one into a terminal, a CI log, or an agent transcript is
+// the same class of disclosure as leaking the password. That is not
+// hypothetical: it is how this very problem was disclosed on 2026-08-25.
+//
+//   npx tsx utils/scripts/verifyAppAccountPrivileges.ts
+//
+// Exits 1 if the account the app connects as holds more than it needs.
+
+import 'dotenv/config'
+import { createScriptPrismaClient } from '../../scripts/lib/databaseRetry'
+
+// What the web process actually executes, established by enumerating every raw
+// SQL site in server/ (t-073 step 1). Runtime raw SQL is 10 SELECT, 1 INSERT,
+// 1 UPDATE, 1 DELETE, plus `SELECT ... FOR UPDATE` and `GET_LOCK()`, neither of
+// which needs a privilege beyond SELECT. There is NO DDL anywhere in the
+// runtime path. `CREATE TEMPORARY TABLES` appears only in hand-run maintenance
+// scripts under utils/scripts/, which are a different lane and should not
+// widen this one.
+const ALLOWED = new Set(['SELECT', 'INSERT', 'UPDATE', 'DELETE'])
+
+// Privileges that make the two-lane design decorative if the app lane holds
+// them. GRANT OPTION is the worst: it means any narrowing can be undone by the
+// process the narrowing was meant to contain.
+const FORBIDDEN = [
+  'ALL PRIVILEGES',
+  'GRANT OPTION',
+  'SUPER',
+  'FILE',
+  'PROCESS',
+  'SHUTDOWN',
+]
+
+/** Strip credential material from a grant line before it can reach any log. */
+export function redactGrant(line: string): string {
+  return line
+    .replace(
+      /IDENTIFIED BY PASSWORD\s+'[^']*'/gi,
+      "IDENTIFIED BY PASSWORD '<redacted>'",
+    )
+    .replace(/IDENTIFIED BY\s+'[^']*'/gi, "IDENTIFIED BY '<redacted>'")
+    .replace(
+      /IDENTIFIED VIA\s+\S+\s+USING\s+'[^']*'/gi,
+      'IDENTIFIED VIA <redacted>',
+    )
+}
+
+/** Privilege names in the grant, e.g. "GRANT SELECT, INSERT ON `db`.* TO ..." */
+export function privilegesIn(line: string): string[] {
+  const match = /^GRANT\s+(.+?)\s+ON\s+/i.exec(line)
+  if (!match) return []
+  // Strip the parenthesised column list BEFORE splitting on commas. A
+  // column-scoped grant like `SELECT (id, name)` carries a comma INSIDE the
+  // parentheses, so splitting first yields "SELECT (ID" and "NAME)" -- two
+  // privileges that do not exist, one of which would be reported as an
+  // unexpected privilege the account does not actually hold.
+  return match[1]
+    .replace(/\s*\([^)]*\)/g, '')
+    .split(',')
+    .map((p) => p.trim().toUpperCase())
+    .filter(Boolean)
+}
+
+/** Does this grant apply server-wide (*.*) rather than to one database? */
+export function isGlobal(line: string): boolean {
+  return /\sON\s+\*\.\*\s/i.test(line)
+}
+
+async function main() {
+  const prisma = createScriptPrismaClient()
+  const problems: string[] = []
+  try {
+    const rows =
+      await prisma.$queryRawUnsafe<Record<string, string>[]>('SHOW GRANTS')
+    const grants = rows.map((row) =>
+      redactGrant(String(Object.values(row)[0] ?? '')),
+    )
+
+    console.log(`the application account holds ${grants.length} grant(s):`)
+    for (const grant of grants) console.log(`  ${grant}`)
+    console.log()
+
+    for (const grant of grants) {
+      const privileges = privilegesIn(grant)
+      const upper = grant.toUpperCase()
+
+      for (const forbidden of FORBIDDEN) {
+        if (upper.includes(forbidden)) {
+          problems.push(`holds ${forbidden} -- ${grant}`)
+        }
+      }
+      if (isGlobal(grant) && privileges.some((p) => p !== 'USAGE')) {
+        problems.push(
+          `holds a server-wide (*.*) grant beyond USAGE -- ${grant}`,
+        )
+      }
+      for (const privilege of privileges) {
+        if (privilege === 'USAGE' || ALLOWED.has(privilege)) continue
+        problems.push(
+          `holds ${privilege}, which the runtime never uses -- ${grant}`,
+        )
+      }
+    }
+  } finally {
+    await prisma.$disconnect()
+  }
+
+  if (problems.length) {
+    console.error(`${problems.length} privilege problem(s):`)
+    for (const problem of [...new Set(problems)])
+      console.error(`  x ${problem}`)
+    console.error(
+      '\nThe application lane should hold SELECT, INSERT, UPDATE, DELETE on the ' +
+        'database it serves, and nothing else. See ' +
+        'docs/runbooks/app-account-privilege-narrowing.md -- and read its sequencing ' +
+        'section before revoking anything, because a wrong revoke takes the site down.',
+    )
+    process.exit(1)
+  }
+  console.log('application account holds only DML on its own database')
+}
+
+if (process.argv[1]?.endsWith('verifyAppAccountPrivileges.ts')) {
+  main().catch((error) => {
+    console.error(
+      redactGrant(error instanceof Error ? error.message : String(error)),
+    )
+    process.exit(1)
+  })
+}

--- a/utils/scripts/verifyAppAccountPrivileges.ts
+++ b/utils/scripts/verifyAppAccountPrivileges.ts
@@ -1,23 +1,18 @@
 // utils/scripts/verifyAppAccountPrivileges.ts
 //
 // kind-robots/t-073. Makes the application/migration credential boundary
-// TESTABLE instead of aspirational.
+// testable at the database layer instead of relying only on code conventions.
 //
-// The boundary was, until this script, entirely a code convention:
-// prisma.config.ts refuses DATABASE_URL for migrate commands,
-// prisma-migrate-deploy.mjs refuses it again, and a runbook explains why. All
-// of it was carefully preventing something the application account could
-// already do -- `kindrobot` holds ALL PRIVILEGES ON *.* WITH GRANT OPTION, so
-// the permanently-running Nuxt process has server-wide superuser and can
-// re-grant itself anything it likes. Code cannot enforce a database privilege;
-// only the database can. This asks it.
+// Live recheck on 2026-08-27 confirmed the worst historical grant had already
+// been removed manually on Alexandria: `kindrobot` now has only USAGE on *.* and
+// no GRANT OPTION. The remaining drift is narrower but still real: the app user
+// holds ALL PRIVILEGES on kindrobots, kindblank, kindblank_fresh, and
+// kindblank_shadow. The permanently-running web process should only have DML on
+// the database it actually serves. This verifier enforces that target.
 //
-// PASSWORD HASHES ARE REDACTED FROM ALL OUTPUT. `SHOW GRANTS` returns
-// `IDENTIFIED BY PASSWORD '<hash>'`, and a mysql_native_password hash is
-// sufficient to authenticate with some clients -- it is a credential, not a
-// fingerprint. Leaking one into a terminal, a CI log, or an agent transcript is
-// the same class of disclosure as leaking the password. That is not
-// hypothetical: it is how this very problem was disclosed on 2026-08-25.
+// PASSWORD HASHES ARE REDACTED FROM ALL OUTPUT. `SHOW GRANTS` can return
+// `IDENTIFIED BY PASSWORD '<hash>'`, and a mysql_native_password hash can be
+// credential material. It must not reach terminal logs, CI logs, or transcripts.
 //
 //   npx tsx utils/scripts/verifyAppAccountPrivileges.ts
 //
@@ -29,15 +24,11 @@ import { createScriptPrismaClient } from '../../scripts/lib/databaseRetry'
 // What the web process actually executes, established by enumerating every raw
 // SQL site in server/ (t-073 step 1). Runtime raw SQL is 10 SELECT, 1 INSERT,
 // 1 UPDATE, 1 DELETE, plus `SELECT ... FOR UPDATE` and `GET_LOCK()`, neither of
-// which needs a privilege beyond SELECT. There is NO DDL anywhere in the
-// runtime path. `CREATE TEMPORARY TABLES` appears only in hand-run maintenance
-// scripts under utils/scripts/, which are a different lane and should not
-// widen this one.
+// which needs a privilege beyond SELECT. There is no DDL in the runtime path.
+// `CREATE TEMPORARY TABLES` appears only in hand-run maintenance scripts under
+// utils/scripts/, which are a different lane and should not widen this one.
 const ALLOWED = new Set(['SELECT', 'INSERT', 'UPDATE', 'DELETE'])
 
-// Privileges that make the two-lane design decorative if the app lane holds
-// them. GRANT OPTION is the worst: it means any narrowing can be undone by the
-// process the narrowing was meant to contain.
 const FORBIDDEN = [
   'ALL PRIVILEGES',
   'GRANT OPTION',
@@ -65,11 +56,9 @@ export function redactGrant(line: string): string {
 export function privilegesIn(line: string): string[] {
   const match = /^GRANT\s+(.+?)\s+ON\s+/i.exec(line)
   if (!match) return []
-  // Strip the parenthesised column list BEFORE splitting on commas. A
-  // column-scoped grant like `SELECT (id, name)` carries a comma INSIDE the
-  // parentheses, so splitting first yields "SELECT (ID" and "NAME)" -- two
-  // privileges that do not exist, one of which would be reported as an
-  // unexpected privilege the account does not actually hold.
+  // Strip the parenthesised column list before splitting on commas. A
+  // column-scoped grant like `SELECT (id, name)` carries a comma inside the
+  // parentheses, so splitting first invents privilege names that do not exist.
   return match[1]!
     .replace(/\s*\([^)]*\)/g, '')
     .split(',')
@@ -82,17 +71,46 @@ export function isGlobal(line: string): boolean {
   return /\sON\s+\*\.\*\s/i.test(line)
 }
 
+/**
+ * Return the database name for an exact database-wide grant (`db`.*).
+ * Table/column scopes intentionally return null because the target state is one
+ * simple database-wide DML grant, not a collection of bespoke sub-grants.
+ */
+export function databaseScopeIn(line: string): string | null {
+  const match = /\sON\s+(.+?)\s+TO\s+/i.exec(line)
+  const scope = match?.[1]?.trim()
+  if (!scope || scope === '*.*') return null
+
+  const quoted = /^`([^`]+)`\.\*$/.exec(scope)
+  if (quoted?.[1]) return quoted[1]
+
+  const bare = /^([A-Za-z0-9_]+)\.\*$/.exec(scope)
+  return bare?.[1] ?? null
+}
+
 async function main() {
   const prisma = createScriptPrismaClient()
   const problems: string[] = []
   try {
+    const databaseRows = await prisma.$queryRawUnsafe<Record<string, unknown>[]>(
+      'SELECT DATABASE() AS database_name',
+    )
+    const activeDatabase = String(
+      databaseRows[0]?.database_name ?? Object.values(databaseRows[0] ?? {})[0] ?? '',
+    )
+    if (!activeDatabase) {
+      throw new Error('could not determine the application database')
+    }
+
     const rows =
       await prisma.$queryRawUnsafe<Record<string, string>[]>('SHOW GRANTS')
     const grants = rows.map((row) =>
       redactGrant(String(Object.values(row)[0] ?? '')),
     )
 
-    console.log(`the application account holds ${grants.length} grant(s):`)
+    console.log(
+      `the application account holds ${grants.length} grant(s); active database is ${activeDatabase}:`,
+    )
     for (const grant of grants) console.log(`  ${grant}`)
     console.log()
 
@@ -105,11 +123,22 @@ async function main() {
           problems.push(`holds ${forbidden} -- ${grant}`)
         }
       }
-      if (isGlobal(grant) && privileges.some((p) => p !== 'USAGE')) {
-        problems.push(
-          `holds a server-wide (*.*) grant beyond USAGE -- ${grant}`,
-        )
+
+      if (isGlobal(grant)) {
+        if (privileges.some((p) => p !== 'USAGE')) {
+          problems.push(
+            `holds a server-wide (*.*) grant beyond USAGE -- ${grant}`,
+          )
+        }
+      } else if (privileges.some((p) => p !== 'USAGE')) {
+        const databaseScope = databaseScopeIn(grant)
+        if (databaseScope !== activeDatabase) {
+          problems.push(
+            `grant is not database-wide DML on ${activeDatabase} -- ${grant}`,
+          )
+        }
       }
+
       for (const privilege of privileges) {
         if (privilege === 'USAGE' || ALLOWED.has(privilege)) continue
         problems.push(
@@ -122,14 +151,13 @@ async function main() {
   }
 
   if (problems.length) {
-    console.error(`${problems.length} privilege problem(s):`)
-    for (const problem of [...new Set(problems)])
-      console.error(`  x ${problem}`)
+    const uniqueProblems = [...new Set(problems)]
+    console.error(`${uniqueProblems.length} privilege problem(s):`)
+    for (const problem of uniqueProblems) console.error(`  x ${problem}`)
     console.error(
       '\nThe application lane should hold SELECT, INSERT, UPDATE, DELETE on the ' +
         'database it serves, and nothing else. See ' +
-        'docs/runbooks/app-account-privilege-narrowing.md -- and read its sequencing ' +
-        'section before revoking anything, because a wrong revoke takes the site down.',
+        'docs/runbooks/app-account-privilege-narrowing.md before changing grants.',
     )
     process.exit(1)
   }

--- a/utils/scripts/verifyAppAccountPrivileges.ts
+++ b/utils/scripts/verifyAppAccountPrivileges.ts
@@ -70,7 +70,7 @@ export function privilegesIn(line: string): string[] {
   // parentheses, so splitting first yields "SELECT (ID" and "NAME)" -- two
   // privileges that do not exist, one of which would be reported as an
   // unexpected privilege the account does not actually hold.
-  return match[1]
+  return match[1]!
     .replace(/\s*\([^)]*\)/g, '')
     .split(',')
     .map((p) => p.trim().toUpperCase())


### PR DESCRIPTION
## Current live state

Fresh Alexandria verification on 2026-08-27 first corrected the stale premise this PR originally carried: the historical server-wide `ALL PRIVILEGES ON *.* WITH GRANT OPTION` grant had already been removed manually and was never represented in Git history.

Silas then completed the remaining least-privilege cleanup on Alexandria on 2026-08-27. `kindrobot` now has exactly:

```text
GRANT USAGE ON *.* TO `kindrobot`@`%` IDENTIFIED BY PASSWORD '<redacted>'
GRANT SELECT, INSERT, UPDATE, DELETE ON `kindblank_fresh`.* TO `kindrobot`@`%`
```

The obsolete grants on `kindrobots`, `kindblank`, and `kindblank_shadow` are gone. Schema-changing work remains on the separate `kindrobot_migrate` lane behind the human gate.

Post-change ProxySQL/MariaDB diagnostics were healthy:

- HG10 ONLINE, max 40, `ConnOK 102`, `ConnERR 0`, `MaxConnUsed 12`, 243607 queries;
- HG30 ONLINE, max 4, `ConnOK 2`, `ConnERR 0`;
- `Access_Denied_Max_Connections = 0`;
- `Access_Denied_Max_User_Connections = 0`;
- `Server_Connections_aborted = 0`;
- MariaDB `Connection_errors_max_connections = 0`;
- MariaDB `Max_used_connections = 24/100`;
- no open `kindrobot` transactions.

A redacted rollback snapshot was saved locally before the production grant change.

## What this PR does

The repository changes themselves make no live privilege mutation. They make the boundary testable and document the completed production state:

- add a read-only verifier for the app account;
- add offline regression tests for grant parsing and credential redaction;
- add npm commands for running the verifier/self-test;
- document the least-privilege boundary and rollback-safe Alexandria procedure.

The verifier was tightened during the 2026-08-27 refresh. The original implementation rejected privilege names beyond DML but did not actually prove otherwise-allowed DML grants were scoped to the app's active database. It now resolves `SELECT DATABASE()` and rejects grants on a different database or bespoke table-level scopes.

## Runtime privilege audit

The production server path needs only:

| operation | count | privilege |
|---|---:|---|
| SELECT including `FOR UPDATE` | 10 | SELECT |
| INSERT | 1 | INSERT |
| UPDATE | 1 | UPDATE |
| DELETE | 1 | DELETE |
| GET_LOCK() | 1 | none beyond connection |
| DDL | 0 | none |

Everything schema-changing belongs on the dedicated migration identity.

## Final boundary

- production app: HG10 / `kindrobot`, DML only on `kindblank_fresh`;
- migrations: HG30 / `kindrobot_migrate`, explicit human-gated schema work;
- no direct coding-agent DB lane;
- no Preview DB lane.

Credential rotation from the August 25 disclosure remains separate: if it was already rotated manually, no duplicate rotation is required; if not, it should still be rotated.

### Stakes

Repository changes: reversible/read-only.
Production grant change: completed and verified manually on Alexandria.