### PR TITLE
kind-robots/t-068: give Artwork panel the conductor fallback chain for Projects

### DIFF
--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -499,6 +499,7 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useResourceStore } from '@/stores/resourceStore'
 import { useUserStore } from '@/stores/userStore'
 import { performFetch } from '@/stores/utils'
+import { projectAssetFallback } from '@/components/conductor/projectFront'
 
 type EntityArtType =
   | 'bot'
@@ -620,13 +621,40 @@ const selectedSlot = computed(() => {
     height: configured?.height || 1024,
   }
 })
+/**
+ * A Project's own DB columns (heroPath/cardPath/imagePath) are only one of
+ * two places its art can live: conductor's art pipeline commits hero/card/
+ * icon images straight to the conductor repo and never writes them back to
+ * the Project row (kind-robots/t-068). Every other conductor-facing surface
+ * (project-front-page.vue, conductor-page.vue) already falls back to the
+ * conductor raw URL, keyed by conductorSlug, when the DB column is empty —
+ * mirror that here so the Artwork panel agrees with the rest of the site
+ * instead of reporting "no hero yet" for art that exists in conductor.
+ * (No local /images/projects/<slug>/ asset pool exists yet, so unlike
+ * project-front-page.vue's full local-then-raw chain, this goes straight to
+ * the raw fallback rather than adding a guaranteed-404 local candidate.)
+ */
+const PROJECT_ART_KIND_BY_FIELD: Record<string, 'hero' | 'card' | 'icon'> = {
+  heroPath: 'hero',
+  cardPath: 'card',
+  imagePath: 'icon',
+}
+
+function projectFallbackSrc(field: string): string {
+  if (props.entityType !== 'project') return ''
+  const kind = PROJECT_ART_KIND_BY_FIELD[field]
+  const slug = props.entity.conductorSlug as string | null | undefined
+  if (!kind || !slug) return ''
+  return projectAssetFallback(slug, kind)
+}
+
 function slotSrc(field: string): string {
   const direct = normalizeSrc(props.entity[field])
   if (direct) return direct
   if (props.entity.artImageId && ['imagePath', 'avatarImage'].includes(field)) {
     return `/api/art/images/${props.entity.artImageId}/file`
   }
-  return ''
+  return projectFallbackSrc(field)
 }
 const currentSrc = computed(() => slotSrc(selectedSlot.value.field))
 const filteredHistory = computed(() =>


### PR DESCRIPTION
## Problem

Reported by Silas 2026-08-24 (conductor kind-robots/t-068): the Cthulhuquarium gallery card shows its hero art while the project's own Artwork panel says "No hero yet" for the same project. Two independent image-resolution paths disagree:

- **Gallery**: `stores/helpers/conductorCards.ts` / `conductor-page.vue` / `conductor-project-gallery-page.vue` hardcode the conductor raw-GitHub URL. The file exists there, so the card renders.
- **Artwork panel**: `components/art/entity-art-manager.vue` resolved only from the entity's own DB columns (`artImageId`, `imagePath`, `heroPath`, ...). Conductor's art pipeline commits images to the conductor repo and never writes them back to the Project row, so those columns are null and the panel truthfully (but unhelpfully) reports no hero.

## Fix

Option (a) from the task note — cheapest, makes the panel agree with everything else: give `entity-art-manager.vue` the same conductorSlug-keyed fallback `project-front-page.vue` already uses for hero images, reusing `projectAssetFallback()` from `components/conductor/projectFront.ts` (the existing shared helper) instead of adding a fifth hardcoded raw-GitHub URL. Scoped to `entityType: 'project'` only — no change for bots/characters/scenarios/rewards/facets/achievements.

Unlike `project-front-page.vue`'s full local-asset-then-raw-URL chain, this goes straight to the raw fallback: `public/images/projects/<slug>/` doesn't have any files in it yet, and the Artwork panel has no error-cascade mechanism (a single `currentFailed` flag, not project-front-page's multi-candidate retry), so adding a guaranteed-404 local candidate first would just trade one broken state for another instead of fixing the reported one.

Option (b) (write hero/card/icon paths back onto the Project row from conductor's art pipeline) is the better long-term end state per the task note, but is the larger cross-repo change — left for a follow-up rather than doing both halfway.

## Verified

- `npx vue-tsc --noEmit` clean.
- `npx eslint components/art/entity-art-manager.vue` — the 3 pre-existing errors on this file (`vue/no-mutating-props`, two `no-empty`) are unchanged/unrelated to this diff (confirmed via `git stash` before/after comparison); no new errors introduced.
- Not verified live: this sandbox has no DB/production access, so the panel rendering an actual conductor hero image for a real project (e.g. Cthulhuquarium) needs a post-deploy check.

Closes conductor's kind-robots/t-068.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFJTpY8ohxv1GFoHtf2eRg)_