### PR TITLE
kind-robots/t-074: wire Status/Priority editing into the Project Profile panel

### DIFF
--- a/components/conductor/project-detail.vue
+++ b/components/conductor/project-detail.vue
@@ -189,6 +189,44 @@
                 @blur="autosave('repoUrl', $event)"
               />
             </div>
+            <template v-if="userStore.isAdmin">
+              <div class="form-control min-w-0">
+                <label class="label py-0.5">
+                  <span class="label-text text-xs font-semibold">Status</span>
+                </label>
+                <select
+                  class="select select-bordered select-sm w-full rounded-xl text-sm"
+                  :value="linkedProject.status"
+                  :disabled="projectSaving"
+                  @change="onStatusSelect"
+                >
+                  <option v-for="s in LIFECYCLE_STATUSES" :key="s" :value="s">
+                    {{ s }}
+                  </option>
+                  <option
+                    v-if="linkedProject.status === 'BRAINSTORM'"
+                    value="BRAINSTORM"
+                  >
+                    BRAINSTORM
+                  </option>
+                </select>
+              </div>
+              <div class="form-control min-w-0">
+                <label class="label py-0.5">
+                  <span class="label-text text-xs font-semibold">Priority</span>
+                </label>
+                <select
+                  class="select select-bordered select-sm w-full rounded-xl text-sm"
+                  :value="linkedProject.priority"
+                  :disabled="projectSaving"
+                  @change="onPrioritySelect"
+                >
+                  <option v-for="p in LIFECYCLE_PRIORITIES" :key="p" :value="p">
+                    {{ p }}
+                  </option>
+                </select>
+              </div>
+            </template>
           </div>
         </section>
 
@@ -442,6 +480,7 @@ import type {
 } from '@/server/api/conductor/projects.get'
 import {
   useProjectStore,
+  type ProjectLifecycleStatus,
   type ProjectPriorityLevel,
   type ProjectWithRelations,
 } from '@/stores/projectStore'
@@ -485,7 +524,18 @@ type ProjectPatch = {
   isPublic?: boolean
   isMature?: boolean
   allowReviews?: boolean
+  status?: ProjectLifecycleStatus
+  priority?: ProjectPriorityLevel
 }
+
+const LIFECYCLE_STATUSES: ProjectLifecycleStatus[] = [
+  'ACTIVE',
+  'CONTINUOUS',
+  'PAUSED',
+  'DONE',
+  'ARCHIVED',
+]
+const LIFECYCLE_PRIORITIES: ProjectPriorityLevel[] = ['HIGH', 'NORMAL', 'LOW']
 
 const linkedProject = computed(() => projectStore.projectForSlug(props.slug))
 
@@ -692,6 +742,18 @@ async function patchProject(patch: ProjectPatch) {
   } finally {
     projectSaving.value = false
   }
+}
+
+function onStatusSelect(event: Event) {
+  const value = (event.target as HTMLSelectElement).value as ProjectLifecycleStatus
+  if (!linkedProject.value || value === linkedProject.value.status) return
+  patchProject({ status: value })
+}
+
+function onPrioritySelect(event: Event) {
+  const value = (event.target as HTMLSelectElement).value as ProjectPriorityLevel
+  if (!linkedProject.value || value === linkedProject.value.priority) return
+  patchProject({ priority: value })
 }
 
 async function autosave(field: keyof ProjectPatch, event: FocusEvent) {

--- a/stores/projectStore.ts
+++ b/stores/projectStore.ts
@@ -30,6 +30,7 @@ export type ProjectWithRelations = Project & {
 }
 
 export type ProjectPriorityLevel = Project['priority']
+export type ProjectLifecycleStatus = Project['status']
 
 export type ProjectListOptions = {
   mine?: boolean


### PR DESCRIPTION
### Task
kind-robots/t-074: the workspace priority/status control isn't reaching Conductor (kind: software)

### What changed / what I produced
- Added admin-gated Status and Priority `<select>` fields to `ProjectDetail`'s existing Project Profile panel (`components/conductor/project-detail.vue`), alongside the Goal/Description/Live URL/Repo URL fields.
- Both wire through the existing `patchProject()` → `projectStore.updateProject()` path, same convention already used by the isPublic/isMature/allowReviews admin toggles in this component.
- Added `ProjectLifecycleStatus` type export to `stores/projectStore.ts` (mirrors the existing `ProjectPriorityLevel`).

### Root cause correction
t-074 was originally filed on the premise that nothing calls `POST /api/conductor/overrides`. That's true, but it's dead code, not the actual bug — a separate, already-working path exists: `updateProject()` routes status/priority changes through `updateLifecycle()` → `POST /api/conductor/project-state`, which updates the `Project` row *and* patches `project-overrides.yaml` via `updateConductorProjectOverride()` whenever the project carries a `conductorSlug`. That machinery is real and already used by the `isPublic`/`isMature`/`allowReviews` toggles in this same component.

The actual gap: `conductor-manager.vue` always routes a project slug to `ProjectDetail` (not `ConductorPage`), so `ProjectDetail` is the only live project-view surface — and it never had an editable Status/Priority control at all, only read-only badges. `conductor-page.vue`'s own project-detail rendering path is unreachable dead code for the same routing reason (left untouched — out of scope here, but worth a follow-up cleanup).

### How I verified
- `npm run test` (vue-tsc --noEmit): clean, no errors.
- `npx eslint components/conductor/project-detail.vue stores/projectStore.ts`: clean.
- `npm run test:layout-contract`: holds — the new fields sit inside the panel's existing container-query 2-column grid (`@container (min-width: 72rem)`), not a new viewport-breakpoint pattern.

### Stakes
reversible

### Flags for Reviewer
- Not verified end-to-end against production: no live admin session or production DB access from this sandbox to confirm that changing a project's priority in the actual UI produces a `project-overrides.yaml` commit. The code path exercised (`updateLifecycle` → `project-state.post.ts`) is not new — it's the same one already driving the isPublic/isMature/allowReviews toggles a few lines above, so this isn't introducing an unverified dependency, just a new caller of one.
- `conductor-page.vue` still has an unreachable duplicate of this same badge-display code (dead per the routing in `conductor-manager.vue`); flagged as a kaizen candidate rather than touched here to keep this diff scoped to t-074.

### Kaizen suggestion
`conductor-page.vue`'s internal `viewMode`/`selectedProject` project-detail rendering path (the header badges block) can never actually render for a real project slug, since `conductor-manager.vue`'s `v-else-if="projectSlug"` always wins first and routes to `ProjectDetail` instead. Worth a small follow-up to delete the dead branch and the now-unused `ConductorProject`-shaped project view code in `conductor-page.vue`, since it doubles the maintenance surface for zero live behavior.

### Notes for reviewer
kind-robots/t-074 claimed and closed to `review` in the same session; conductor roadmap PR follows separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWLTkbBdT2FUJ4Fpn88UjS)_