### PR TITLE
scene-animator/t-003: add clear health diagnostics for the media root

### DIFF
--- a/docs/scene-animator.md
+++ b/docs/scene-animator.md
@@ -56,6 +56,20 @@ The source API only accepts normalized relative folders and image filenames.
 Absolute paths, `..` traversal, and symlink escapes are rejected. The MVP is
 read-only: it never deletes, renames, or mutates source stills.
 
+## Verifying the mount
+
+`GET /api/scene-animator/health` (admin-only) reports whether the configured
+source root actually resolves, without loading the full folder/source
+listing: which of `ANIMATE_PATH`, an `IMAGES_PATH`-derived sibling, or the
+local `<repo>/animate` fallback is in effect, plus a folder/image count when
+reachable. It answers `200` when the root is reachable and `503` with a
+specific reason (not mounted, wrong permissions, etc.) when it is not.
+
+The batch page's own `GET /api/scene-animator` reports the same signal inline
+as `rootAvailable` in its response, so a misconfigured or not-yet-mounted
+root surfaces as a clear message in the admin UI instead of an opaque request
+failure.
+
 The application/container still needs read access to the chosen source root.
 Adding or changing a production bind mount is an operator deployment step; the
 code does not attempt to alter container configuration itself.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:nexus-comments": "tsx utils/scripts/verifyNexusComments.ts",
     "audit:fitness": "tsx utils/scripts/auditObjectFitness.ts",
     "test:migrate-on-deploy": "tsx utils/scripts/verifyMigrateOnDeploy.ts",
+    "test:scene-animator-health": "tsx utils/scripts/verifySceneAnimatorHealth.test.ts",
     "test:facet-aliases": "tsx utils/scripts/verifyFacetAliases.ts",
     "audit:art-coverage": "tsx utils/scripts/auditEntityArtCoverage.ts",
     "test:facet-content": "tsx utils/scripts/verifyFacetContentQuality.ts",

--- a/server/api/scene-animator/health.get.ts
+++ b/server/api/scene-animator/health.get.ts
@@ -1,0 +1,36 @@
+// /server/api/scene-animator/health.get.ts
+//
+// Dedicated diagnostic for the scene-animator source root, separate from
+// `GET /api/scene-animator` (which loads folders/sources for the batch UI).
+// An operator checking whether a mount landed shouldn't have to wade through
+// the full listing payload -- and before this endpoint existed, an
+// unreachable root only surfaced as an uncaught 503 buried inside that
+// listing request (see readSceneAnimatorRootStatus's doc comment).
+import { defineEventHandler, setResponseHeader } from 'h3'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { readSceneAnimatorRootStatus } from '@/server/utils/sceneAnimator'
+
+export default defineEventHandler(async (event) => {
+  await requireAdminApiUser(event)
+  setResponseHeader(event, 'Cache-Control', 'no-store')
+  const startedAt = Date.now()
+
+  const status = await readSceneAnimatorRootStatus()
+  const imageCount = status.folders.reduce((total, folder) => total + folder.imageCount, 0)
+  event.node.res.statusCode = status.available ? 200 : 503
+
+  return {
+    success: status.available,
+    message: status.available
+      ? `Scene Animator source root is reachable (${status.folders.length} folder${status.folders.length === 1 ? '' : 's'}, ${imageCount} image${imageCount === 1 ? '' : 's'}).`
+      : (status.reason ?? 'Scene Animator source root is unavailable.'),
+    data: {
+      root: status.root,
+      source: status.source,
+      folderCount: status.folders.length,
+      imageCount,
+      latencyMs: Date.now() - startedAt,
+    },
+    statusCode: status.available ? 200 : 503,
+  }
+})

--- a/server/api/scene-animator/index.get.ts
+++ b/server/api/scene-animator/index.get.ts
@@ -3,9 +3,9 @@ import prisma from '@/server/utils/prisma'
 import { requireAdminApiUser } from '@/server/utils/authGuard'
 import {
   SCENE_ANIMATOR_PROJECT_SLUG,
-  listSceneAnimatorFolders,
   listSceneAnimatorSourceFiles,
   parseSceneAnimatorContext,
+  readSceneAnimatorRootStatus,
   sceneAnimatorConfigKey,
   sceneAnimatorDedupeKey,
   type SceneAnimatorRenderConfig,
@@ -64,7 +64,24 @@ export default defineEventHandler(async (event) => {
   const query = getQuery(event) as Record<string, unknown>
   const folder = queryString(query.folder).trim()
   const config = resolveConfig(query)
-  const folders = await listSceneAnimatorFolders()
+  const rootStatus = await readSceneAnimatorRootStatus()
+
+  if (!rootStatus.available) {
+    return {
+      success: true,
+      message: rootStatus.reason,
+      data: {
+        rootAvailable: false,
+        folders: [],
+        selectedFolder: null,
+        config,
+        configKey: sceneAnimatorConfigKey(config),
+        sources: [],
+      },
+    }
+  }
+
+  const folders = rootStatus.folders
 
   if (!folder && !folders.some((item) => item.name === '')) {
     return {

--- a/server/utils/sceneAnimator.ts
+++ b/server/utils/sceneAnimator.ts
@@ -103,6 +103,58 @@ export function getSceneAnimatorRoot(): string {
   return path.resolve(process.cwd(), 'animate')
 }
 
+/** How `getSceneAnimatorRoot()` arrived at its answer — surfaced in health
+ *  diagnostics so an operator can tell "misconfigured" from "not mounted yet"
+ *  without reading source. */
+export type SceneAnimatorRootSource =
+  | 'ANIMATE_PATH'
+  | 'IMAGES_PATH-derived'
+  | 'fallback'
+
+export function getSceneAnimatorRootSource(): SceneAnimatorRootSource {
+  if (process.env.ANIMATE_PATH?.trim()) return 'ANIMATE_PATH'
+  if (process.env.IMAGES_PATH?.trim()) return 'IMAGES_PATH-derived'
+  return 'fallback'
+}
+
+export type SceneAnimatorRootStatus = {
+  available: boolean
+  root: string
+  source: SceneAnimatorRootSource
+  folders: Array<{ name: string; imageCount: number }>
+  reason: string | null
+}
+
+/**
+ * Non-throwing read of the configured source root. `listSceneAnimatorFolders()`
+ * throws (a 503 "source root is unavailable" H3 error, or a raw fs error if the
+ * root exists but isn't readable) the moment ANIMATE_PATH points at a mount that
+ * hasn't landed yet -- exactly the operator-visible case this exists to make
+ * legible instead of an opaque request failure. Single source of truth for both
+ * the `/api/scene-animator` listing (which needs the folder list either way) and
+ * the dedicated `/api/scene-animator/health` check (which only needs the verdict).
+ */
+export async function readSceneAnimatorRootStatus(): Promise<SceneAnimatorRootStatus> {
+  const root = getSceneAnimatorRoot()
+  const source = getSceneAnimatorRootSource()
+
+  try {
+    const folders = await listSceneAnimatorFolders()
+    return { available: true, root, source, folders, reason: null }
+  } catch (error) {
+    return {
+      available: false,
+      root,
+      source,
+      folders: [],
+      reason:
+        error instanceof Error
+          ? error.message
+          : `Scene Animator source root is unavailable: ${root}`,
+    }
+  }
+}
+
 async function resolveContainedPath(folder: string, filename?: string): Promise<string> {
   const root = getSceneAnimatorRoot()
   let resolvedRoot: string

--- a/stores/sceneAnimatorStore.ts
+++ b/stores/sceneAnimatorStore.ts
@@ -236,6 +236,18 @@ export const useSceneAnimatorStore = defineStore('sceneAnimatorStore', () => {
         throw new Error(response.message || 'Failed to load Scene Animator.')
       }
 
+      if (!response.data.rootAvailable) {
+        // Root not mounted/reachable yet — not a request failure (the API
+        // still answered normally), so this is reported through the same
+        // error banner rather than thrown, with the server's specific reason.
+        folders.value = []
+        sources.value = []
+        initialized.value = true
+        error.value =
+          response.message || 'Scene Animator source root is unavailable.'
+        return
+      }
+
       folders.value = response.data.folders
       configKey.value = response.data.configKey
       engine.value = response.data.config.engine

--- a/utils/scripts/verifySceneAnimatorHealth.test.ts
+++ b/utils/scripts/verifySceneAnimatorHealth.test.ts
@@ -1,0 +1,99 @@
+// /utils/scripts/verifySceneAnimatorHealth.test.ts
+//
+// scene-animator/t-003: exercises the real readSceneAnimatorRootStatus() and
+// getSceneAnimatorRootSource() against a hermetic temp directory instead of
+// re-describing their behaviour. Before this, an unreachable ANIMATE_PATH
+// only surfaced as an uncaught 503 buried inside the folder-listing request
+// (index.get.ts hardcoded `rootAvailable: true` unconditionally) -- this
+// asserts the replacement actually reports the unavailable case instead of
+// throwing, and that it names the right source for each of the three ways
+// the root can be configured.
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  getSceneAnimatorRootSource,
+  readSceneAnimatorRootStatus,
+} from '../../server/utils/sceneAnimator.js'
+
+const ORIGINAL_ANIMATE_PATH = process.env.ANIMATE_PATH
+const ORIGINAL_IMAGES_PATH = process.env.IMAGES_PATH
+
+function resetEnv(): void {
+  delete process.env.ANIMATE_PATH
+  delete process.env.IMAGES_PATH
+}
+
+async function run(): Promise<void> {
+  const workDir = mkdtempSync(join(tmpdir(), 'scene-animator-health-'))
+
+  try {
+    // --- source attribution, independent of what's actually on disk -------
+    resetEnv()
+    assert.equal(
+      getSceneAnimatorRootSource(),
+      'fallback',
+      'with neither env var set, the source must be reported as fallback',
+    )
+
+    process.env.IMAGES_PATH = join(workDir, 'images')
+    assert.equal(
+      getSceneAnimatorRootSource(),
+      'IMAGES_PATH-derived',
+      'IMAGES_PATH alone must be reported as IMAGES_PATH-derived',
+    )
+
+    process.env.ANIMATE_PATH = join(workDir, 'animate')
+    assert.equal(
+      getSceneAnimatorRootSource(),
+      'ANIMATE_PATH',
+      'ANIMATE_PATH must win over IMAGES_PATH and be reported as such',
+    )
+
+    // --- unavailable root: reported, not thrown ----------------------------
+    resetEnv()
+    process.env.ANIMATE_PATH = join(workDir, 'does-not-exist')
+    const missing = await readSceneAnimatorRootStatus()
+    assert.equal(
+      missing.available,
+      false,
+      'a nonexistent ANIMATE_PATH must be reported as unavailable, not thrown',
+    )
+    assert.equal(missing.source, 'ANIMATE_PATH')
+    assert.deepEqual(missing.folders, [])
+    assert.ok(
+      missing.reason && missing.reason.length > 0,
+      'an unavailable root must carry a human-readable reason',
+    )
+
+    // --- available root: real folders and counts ---------------------------
+    const animateRoot = join(workDir, 'animate')
+    const projectA = join(animateRoot, 'project-a')
+    mkdirSync(projectA, { recursive: true })
+    writeFileSync(join(projectA, 'scene-001.png'), Buffer.from([0]))
+    writeFileSync(join(projectA, 'scene-002.webp'), Buffer.from([0]))
+    writeFileSync(join(projectA, 'notes.txt'), 'not an image')
+
+    resetEnv()
+    process.env.ANIMATE_PATH = animateRoot
+    const available = await readSceneAnimatorRootStatus()
+    assert.equal(available.available, true)
+    assert.equal(available.reason, null)
+    assert.deepEqual(
+      available.folders,
+      [{ name: 'project-a', imageCount: 2 }],
+      'non-image files must not count toward imageCount',
+    )
+  } finally {
+    resetEnv()
+    if (ORIGINAL_ANIMATE_PATH !== undefined) process.env.ANIMATE_PATH = ORIGINAL_ANIMATE_PATH
+    if (ORIGINAL_IMAGES_PATH !== undefined) process.env.IMAGES_PATH = ORIGINAL_IMAGES_PATH
+    rmSync(workDir, { recursive: true, force: true })
+  }
+
+  console.log('Scene Animator health status verified: source attribution and availability both hold.')
+}
+
+await run()


### PR DESCRIPTION
### Task
scene-animator/t-003: Harden media-root deployment and source-folder operations (kind: software)

### What changed / what I produced
- `GET /api/scene-animator/health` (admin-only, new) reports whether the configured source root actually resolves — which of `ANIMATE_PATH`, an `IMAGES_PATH`-derived sibling, or the local `<repo>/animate` fallback is in effect, plus a folder/image count when reachable. `200` when reachable, `503` with a specific reason when not.
- `server/utils/sceneAnimator.ts` gained `readSceneAnimatorRootStatus()` (non-throwing) and `getSceneAnimatorRootSource()`, shared by the new health endpoint and the existing listing endpoint.
- `GET /api/scene-animator` (`index.get.ts`) no longer hardcodes `rootAvailable: true` — it was hardcoded in both response branches and never actually checked, so an unmounted/unreadable root previously surfaced as an uncaught 503 buried inside `listSceneAnimatorFolders()` instead of the structured signal the frontend type (`SceneAnimatorIndexData.rootAvailable`) already declared but never received.
- `stores/sceneAnimatorStore.ts`'s `load()` now surfaces that specific reason through the existing error banner when the root isn't available, instead of a generic failure message.
- `docs/scene-animator.md` documents the new endpoint and the `rootAvailable` signal.

Traversal protection (`normalizeFolder`/`normalizeFile` + `realpath` containment in `resolveContainedPath`) was already solid and untouched by this change — the task's remaining gap here was diagnostics, not containment.

### How I verified
- `npm run test:scene-animator-health` (new `utils/scripts/verifySceneAnimatorHealth.test.ts`, following the repo's `verify*.test.ts` convention) — exercises the real `readSceneAnimatorRootStatus()`/`getSceneAnimatorRootSource()` against a hermetic temp directory: source attribution for all three configurations, an unavailable root reported (not thrown) with a reason, and an available root's real folder/image counts (non-image files excluded).
- `npx vue-tsc --noEmit` — clean.
- `npx eslint` on every touched/new file — clean. (`index.get.ts` carries one pre-existing, unrelated `no-useless-assignment` warning at the `payload = JSON.parse(...)` loop line, confirmed via `git stash` to predate this diff.)

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
`listSceneAnimatorSourceFiles()` reads and hashes every source file's full bytes just to list it (`readSceneAnimatorSource` per entry) — fine at MVP folder sizes, but worth a lighter listing path (stat-based, hash on demand) if folders grow large enough that the batch page's initial load gets slow.

### Notes for reviewer
scene-animator/t-002 ("Confirm the Scene Animator scope with Silas") is a soft `needs-human` and does not gate this task — t-003/t-004 don't `depends_on` it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WDWTV8vgN3sfdnupC1LKF2)_