### PR TITLE
scene-animator/t-004: operator recovery controls, filters, and estimates

### DIFF
--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -63,7 +63,7 @@
                   :key="folder.name || '__root__'"
                   :value="folder.name"
                 >
-                  {{ folder.name || '(animate root)' }} · {{ folder.imageCount }} image{{ folder.imageCount === 1 ? '' : 's' }}
+                  {{ folder.name || '(animate root)' }} · {{ folder.imageCount }} image{{ folder.imageCount === 1 ? '' : 's' }}{{ folderCompletionSuffix(folder.name) }}
                 </option>
               </select>
             </label>
@@ -173,31 +173,26 @@
           <section class="space-y-4">
             <div class="kr-panel p-4">
               <div class="grid grid-cols-2 gap-3 md:grid-cols-5">
-                <div class="rounded-xl bg-base-200 p-3">
-                  <p class="text-xs font-bold text-base-content/50">Scenes</p>
-                  <p class="text-2xl font-black">{{ store.totalCount }}</p>
-                </div>
-                <div class="rounded-xl bg-base-200 p-3">
-                  <p class="text-xs font-bold text-base-content/50">Missing</p>
-                  <p class="text-2xl font-black">{{ store.missingCount }}</p>
-                </div>
-                <div class="rounded-xl bg-base-200 p-3">
-                  <p class="text-xs font-bold text-base-content/50">Active</p>
-                  <p class="text-2xl font-black">{{ store.activeCount }}</p>
-                </div>
-                <div class="rounded-xl bg-base-200 p-3">
-                  <p class="text-xs font-bold text-base-content/50">Done</p>
-                  <p class="text-2xl font-black">{{ store.doneCount }}</p>
-                </div>
-                <div class="rounded-xl bg-base-200 p-3">
-                  <p class="text-xs font-bold text-base-content/50">Failed</p>
-                  <p class="text-2xl font-black">{{ store.failedCount }}</p>
-                </div>
+                <button
+                  v-for="tile in statTiles"
+                  :key="tile.key"
+                  type="button"
+                  class="rounded-xl bg-base-200 p-3 text-left transition-colors hover:bg-base-300"
+                  :class="{ 'ring-2 ring-primary': statusFilter === tile.key }"
+                  @click="statusFilter = statusFilter === tile.key ? 'all' : tile.key"
+                >
+                  <p class="text-xs font-bold text-base-content/50">{{ tile.label }}</p>
+                  <p class="text-2xl font-black">{{ tile.count }}</p>
+                </button>
               </div>
               <div class="mt-3 flex items-center gap-3">
                 <progress class="progress progress-primary flex-1" :value="store.completionPercent" max="100" />
                 <span class="w-12 text-right text-sm font-black">{{ store.completionPercent }}%</span>
               </div>
+              <p v-if="statusFilter !== 'all'" class="mt-3 flex items-center gap-2 text-xs text-base-content/50">
+                Showing {{ filteredSources.length }} {{ statusFilter }} scene{{ filteredSources.length === 1 ? '' : 's' }} only.
+                <button type="button" class="link" @click="statusFilter = 'all'">Clear filter</button>
+              </p>
             </div>
 
             <div
@@ -228,9 +223,21 @@
               </div>
             </div>
 
+            <div
+              v-else-if="!filteredSources.length"
+              class="grid min-h-40 place-items-center rounded-2xl border border-dashed border-base-300 bg-base-100/50 p-6 text-center"
+            >
+              <div>
+                <p class="font-black">No {{ statusFilter }} scenes in this folder</p>
+                <button type="button" class="link mt-1 text-sm" @click="statusFilter = 'all'">
+                  Clear filter
+                </button>
+              </div>
+            </div>
+
             <div v-else class="grid gap-4 md:grid-cols-2 2xl:grid-cols-3">
               <article
-                v-for="source in store.sources"
+                v-for="source in filteredSources"
                 :key="source.dedupeKey"
                 class="kr-panel overflow-hidden"
               >
@@ -267,7 +274,10 @@
                       />
                     </template>
                     <div v-else class="grid size-full place-items-center p-3 text-center text-xs text-base-content/40">
-                      <span v-if="source.status === 'rendering' || source.status === 'queued'" class="loading loading-spinner loading-sm" />
+                      <template v-if="source.status === 'rendering' || source.status === 'queued'">
+                        <span class="loading loading-spinner loading-sm" />
+                        <span class="mt-1 block">{{ elapsedLabel(source) }}</span>
+                      </template>
                       <span v-else>{{ statusLabel(source.status) }}</span>
                     </div>
                     <span class="absolute left-2 top-2 badge badge-sm bg-base-100/90">motion</span>
@@ -290,6 +300,16 @@
                   <p v-if="source.error" class="line-clamp-3 text-xs text-error" :title="source.error">
                     {{ source.error }}
                   </p>
+                  <button
+                    v-if="source.status === 'failed' || source.status === 'cancelled'"
+                    type="button"
+                    class="btn btn-error btn-outline btn-xs w-full rounded-lg"
+                    :disabled="store.queueing"
+                    @click="store.retrySource(source.name)"
+                  >
+                    <span v-if="store.retryingSource === source.name" class="loading loading-spinner loading-xs" />
+                    Retry this scene
+                  </button>
                 </div>
               </article>
             </div>
@@ -301,15 +321,44 @@
 </template>
 
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useSceneAnimatorStore, type SceneAnimatorSource } from '@/stores/sceneAnimatorStore'
 import { useUserStore } from '@/stores/userStore'
 import type { VideoEngine, VideoPresetId } from '@/utils/videoPresets'
 
+type StatusFilter = 'all' | 'missing' | 'active' | 'done' | 'failed'
+
 const store = useSceneAnimatorStore()
 const userStore = useUserStore()
 const ready = ref(false)
+const statusFilter = ref<StatusFilter>('all')
 let pollTimer: ReturnType<typeof setInterval> | null = null
+
+const statTiles = computed(() => [
+  { key: 'all' as const, label: 'Scenes', count: store.totalCount },
+  { key: 'missing' as const, label: 'Missing', count: store.missingCount },
+  { key: 'active' as const, label: 'Active', count: store.activeCount },
+  { key: 'done' as const, label: 'Done', count: store.doneCount },
+  { key: 'failed' as const, label: 'Failed', count: store.failedCount },
+])
+
+function matchesFilter(source: SceneAnimatorSource, filter: StatusFilter): boolean {
+  if (filter === 'all') return true
+  if (filter === 'missing') return source.status === 'missing'
+  if (filter === 'active') return source.status === 'queued' || source.status === 'rendering'
+  if (filter === 'done') return source.status === 'done'
+  return source.status === 'failed' || source.status === 'cancelled'
+}
+
+const filteredSources = computed(() =>
+  store.sources.filter((source) => matchesFilter(source, statusFilter.value)),
+)
+
+function folderCompletionSuffix(folderName: string): string {
+  const stat = store.folderStats[folderName]
+  if (!stat || !stat.total) return ''
+  return ` · ${stat.done}/${stat.total} rendered`
+}
 
 onMounted(async () => {
   await userStore.initialize()
@@ -332,6 +381,7 @@ function eventValue(event: Event): string {
 }
 
 function onFolderChange(event: Event) {
+  statusFilter.value = 'all'
   void store.selectFolder(eventValue(event))
 }
 
@@ -377,5 +427,25 @@ function isVideoResult(source: SceneAnimatorSource): boolean {
   const type = String(source.resultFileType || '').toLowerCase()
   const url = store.resultUrl(source) || ''
   return type.includes('mp4') || type.includes('webm') || /\.(mp4|webm)(?:[?#]|$)/i.test(url)
+}
+
+function formatElapsed(seconds: number): string {
+  if (seconds < 60) return `${Math.max(0, Math.round(seconds))}s`
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `${minutes}m`
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`
+}
+
+// Elapsed-since-queued for a queued job, elapsed-since-last-update for a
+// rendering one, plus the current preset's own timeout as a rough "typically
+// finishes within" ceiling -- there's no per-job progress signal to report
+// against, so this is the clearest honest estimate available without one.
+function elapsedLabel(source: SceneAnimatorSource): string {
+  const since = source.status === 'rendering' ? source.updatedAt : source.createdAt
+  const ceiling = formatElapsed(store.selectedPreset.timeoutSeconds)
+  if (!since) return `typically ≤ ${ceiling}`
+  const elapsedSeconds = (Date.now() - new Date(since).getTime()) / 1000
+  if (!Number.isFinite(elapsedSeconds) || elapsedSeconds < 0) return `typically ≤ ${ceiling}`
+  return `${formatElapsed(elapsedSeconds)} elapsed · typically ≤ ${ceiling}`
 }
 </script>

--- a/server/api/scene-animator/enqueue.post.ts
+++ b/server/api/scene-animator/enqueue.post.ts
@@ -26,6 +26,11 @@ type SceneAnimatorEnqueueRequest = {
   durationSeconds?: number | null
   isMature?: boolean | null
   retryFailed?: boolean | null
+  // Scopes the whole batch loop below to one file -- a per-card "retry this
+  // one" action, as opposed to retryFailed's "retry every failed source in
+  // the folder." Exact filename match against listSceneAnimatorSourceFiles;
+  // anything else falls through to the normal empty-queue response.
+  sourceFile?: string | null
 }
 
 type EnqueueResponse = {
@@ -82,7 +87,11 @@ export default defineEventHandler(async (event) => {
   const folder = String(body.folder ?? '').trim()
   const config = resolveConfig(body)
   const preset = getVideoPreset(config.presetId) ?? getDefaultVideoPreset(config.engine)
-  const sources = await listSceneAnimatorSourceFiles(folder)
+  const requestedSourceFile = String(body.sourceFile ?? '').trim()
+  const allSources = await listSceneAnimatorSourceFiles(folder)
+  const sources = requestedSourceFile
+    ? allSources.filter((source) => source.name === requestedSourceFile)
+    : allSources
   const configKey = sceneAnimatorConfigKey(config)
 
   const existingJobs = await prisma.artJob.findMany({
@@ -105,6 +114,13 @@ export default defineEventHandler(async (event) => {
   const queued: Array<{ sourceFile: string; jobId: number }> = []
   const skipped: Array<{ sourceFile: string; jobId: number | null; reason: string }> = []
   const errors: Array<{ sourceFile: string; message: string }> = []
+
+  if (requestedSourceFile && !sources.length) {
+    errors.push({
+      sourceFile: requestedSourceFile,
+      message: 'No matching source file in this folder.',
+    })
+  }
 
   for (const source of sources) {
     const dedupeKey = sceneAnimatorDedupeKey(source.hash, config)

--- a/server/api/scene-animator/index.get.ts
+++ b/server/api/scene-animator/index.get.ts
@@ -59,6 +59,60 @@ function jobStatus(status: string): 'queued' | 'rendering' | 'done' | 'failed' |
   return 'queued'
 }
 
+type FolderStat = { total: number; done: number; active: number; failed: number }
+
+// Coarser than the per-source status the selected folder gets: this counts a
+// source file as "done" if ANY job for it (under any engine/preset/duration
+// config, not just the currently selected one) reached DONE, so the folder
+// picker's completion badge doesn't jump around every time the batch config
+// changes. It intentionally reuses the same jobs query every other branch
+// already pays for -- listing every folder's own image files (which requires
+// reading and hashing each file's bytes, see listSceneAnimatorSourceFiles) to
+// get a config-exact count would multiply that I/O by folder count.
+function buildFolderStats(
+  folders: Array<{ name: string; imageCount: number }>,
+  jobs: Array<{ payload: string; status: string }>,
+): Record<string, FolderStat> {
+  const stats: Record<string, FolderStat> = {}
+  for (const folder of folders) {
+    stats[folder.name] = { total: folder.imageCount, done: 0, active: 0, failed: 0 }
+  }
+
+  // Best status per (folder, file), across every config that ever rendered it.
+  // Nested by folder first so a filename that happens to collide across two
+  // folders can't merge two unrelated sources' counts together.
+  const bestByFolder = new Map<string, Map<string, 'done' | 'active' | 'failed'>>()
+  const rank = { failed: 0, active: 1, done: 2 } as const
+  for (const job of jobs) {
+    let payload: Record<string, unknown>
+    try {
+      payload = JSON.parse(job.payload) as Record<string, unknown>
+    } catch {
+      continue
+    }
+    const context = parseSceneAnimatorContext(payload.sceneAnimator)
+    if (!context || !(context.sourceFolder in stats)) continue
+    const status = jobStatus(job.status)
+    const current: 'done' | 'active' | 'failed' =
+      status === 'done' ? 'done' : status === 'rendering' || status === 'queued' ? 'active' : 'failed'
+    let byFile = bestByFolder.get(context.sourceFolder)
+    if (!byFile) {
+      byFile = new Map()
+      bestByFolder.set(context.sourceFolder, byFile)
+    }
+    const existing = byFile.get(context.sourceFile)
+    if (!existing || rank[current] > rank[existing]) byFile.set(context.sourceFile, current)
+  }
+
+  for (const [folderName, byFile] of bestByFolder) {
+    const stat = stats[folderName]
+    if (!stat) continue
+    for (const status of byFile.values()) stat[status] += 1
+  }
+
+  return stats
+}
+
 export default defineEventHandler(async (event) => {
   await requireAdminApiUser(event)
   const query = getQuery(event) as Record<string, unknown>
@@ -77,11 +131,25 @@ export default defineEventHandler(async (event) => {
         config,
         configKey: sceneAnimatorConfigKey(config),
         sources: [],
+        folderStats: {},
       },
     }
   }
 
   const folders = rootStatus.folders
+
+  // Cheap (DB rows, not filesystem reads) and shared by every return path
+  // below, including the two folder-less ones -- the folder picker shows a
+  // completion badge for every folder up front, not just the selected one.
+  const jobs = await prisma.artJob.findMany({
+    where: {
+      projectSlug: SCENE_ANIMATOR_PROJECT_SLUG,
+      payload: { contains: '"sceneAnimator"' },
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 1000,
+  })
+  const folderStats = buildFolderStats(folders, jobs)
 
   if (!folder && !folders.some((item) => item.name === '')) {
     return {
@@ -93,23 +161,16 @@ export default defineEventHandler(async (event) => {
         config,
         configKey: sceneAnimatorConfigKey(config),
         sources: [],
+        folderStats,
       },
     }
   }
 
   const sources = await listSceneAnimatorSourceFiles(folder)
-  const jobs = await prisma.artJob.findMany({
-    where: {
-      projectSlug: SCENE_ANIMATOR_PROJECT_SLUG,
-      payload: { contains: '"sceneAnimator"' },
-    },
-    orderBy: { createdAt: 'desc' },
-    take: 1000,
-  })
 
   const latestByKey = new Map<string, (typeof jobs)[number]>()
   for (const job of jobs) {
-    let payload: Record<string, unknown> | null = null
+    let payload: Record<string, unknown>
     try {
       payload = JSON.parse(job.payload) as Record<string, unknown>
     } catch {
@@ -154,6 +215,7 @@ export default defineEventHandler(async (event) => {
       resultPath: result?.imagePath ?? null,
       resultFileType: result?.fileType ?? null,
       error: job?.error ?? null,
+      createdAt: job?.createdAt ?? null,
       updatedAt: job?.updatedAt ?? null,
     }
   })
@@ -167,6 +229,7 @@ export default defineEventHandler(async (event) => {
       config,
       configKey,
       sources: rows,
+      folderStats,
     },
   }
 })

--- a/stores/sceneAnimatorStore.ts
+++ b/stores/sceneAnimatorStore.ts
@@ -36,7 +36,15 @@ export type SceneAnimatorSource = {
   resultPath: string | null
   resultFileType: string | null
   error: string | null
+  createdAt: string | null
   updatedAt: string | null
+}
+
+export type SceneAnimatorFolderStat = {
+  total: number
+  done: number
+  active: number
+  failed: number
 }
 
 type SceneAnimatorConfig = {
@@ -59,6 +67,7 @@ type SceneAnimatorIndexData = {
   config: SceneAnimatorConfig
   configKey: string
   sources: SceneAnimatorSource[]
+  folderStats: Record<string, SceneAnimatorFolderStat>
 }
 
 type SceneAnimatorEnqueueData = {
@@ -101,6 +110,7 @@ export const useSceneAnimatorStore = defineStore('sceneAnimatorStore', () => {
   const defaultPreset = getDefaultVideoPreset('wan')
 
   const folders = ref<SceneAnimatorFolder[]>([])
+  const folderStats = ref<Record<string, SceneAnimatorFolderStat>>({})
   const sources = ref<SceneAnimatorSource[]>([])
   const selectedFolder = ref('')
   const engine = ref<VideoEngine>('wan')
@@ -112,6 +122,7 @@ export const useSceneAnimatorStore = defineStore('sceneAnimatorStore', () => {
   const resultPreviewUrls = ref<Record<number, string>>({})
   const loading = ref(false)
   const queueing = ref(false)
+  const retryingSource = ref<string | null>(null)
   const initialized = ref(false)
   const error = ref<string | null>(null)
   const lastEnqueue = ref<SceneAnimatorEnqueueData | null>(null)
@@ -241,6 +252,7 @@ export const useSceneAnimatorStore = defineStore('sceneAnimatorStore', () => {
         // still answered normally), so this is reported through the same
         // error banner rather than thrown, with the server's specific reason.
         folders.value = []
+        folderStats.value = {}
         sources.value = []
         initialized.value = true
         error.value =
@@ -249,6 +261,7 @@ export const useSceneAnimatorStore = defineStore('sceneAnimatorStore', () => {
       }
 
       folders.value = response.data.folders
+      folderStats.value = response.data.folderStats
       configKey.value = response.data.configKey
       engine.value = response.data.config.engine
       presetId.value = response.data.config.presetId
@@ -313,6 +326,49 @@ export const useSceneAnimatorStore = defineStore('sceneAnimatorStore', () => {
     }
   }
 
+  async function retrySource(sourceFile: string): Promise<boolean> {
+    queueing.value = true
+    retryingSource.value = sourceFile
+    clearError()
+    try {
+      const response = await performFetch<SceneAnimatorEnqueueData>(
+        '/api/scene-animator/enqueue',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            folder: selectedFolder.value,
+            engine: engine.value,
+            presetId: presetId.value,
+            durationSeconds: durationSeconds.value,
+            isMature: isMature.value,
+            retryFailed: true,
+            sourceFile,
+          }),
+        },
+        1,
+        120_000,
+      )
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Failed to retry this scene.')
+      }
+      lastEnqueue.value = response.data
+      if (response.data.errors.length) {
+        error.value = response.data.errors
+          .map((item) => `${item.sourceFile}: ${item.message}`)
+          .join('\n')
+        return false
+      }
+      await load()
+      return true
+    } catch (cause) {
+      error.value = errorMessage(cause, 'Failed to retry this scene.')
+      return false
+    } finally {
+      queueing.value = false
+      retryingSource.value = null
+    }
+  }
+
   async function selectFolder(folder: string) {
     selectedFolder.value = folder
     await load(folder)
@@ -353,6 +409,7 @@ export const useSceneAnimatorStore = defineStore('sceneAnimatorStore', () => {
 
   return {
     folders,
+    folderStats,
     sources,
     selectedFolder,
     engine,
@@ -364,6 +421,7 @@ export const useSceneAnimatorStore = defineStore('sceneAnimatorStore', () => {
     resultPreviewUrls,
     loading,
     queueing,
+    retryingSource,
     initialized,
     error,
     lastEnqueue,
@@ -378,6 +436,7 @@ export const useSceneAnimatorStore = defineStore('sceneAnimatorStore', () => {
     clearError,
     load,
     enqueue,
+    retrySource,
     selectFolder,
     setEngine,
     setPreset,


### PR DESCRIPTION
### Task
scene-animator/t-004: Polish batch recovery, filtering, and gallery ergonomics (kind: software)

### What changed / what I produced
- **Per-source retry**: a "Retry this scene" button on individual failed/cancelled gallery cards, scoped to just that file via a new optional `sourceFile` param on `POST /api/scene-animator/enqueue`. The existing folder-wide "Retry N failed" button is unchanged.
- **Status filters**: the existing stat tiles (Scenes/Missing/Active/Done/Failed) are now clickable filters over the gallery grid, with a dedicated empty state when a filter matches nothing.
- **Per-folder completion summary**: the folder `<select>` now shows "X/Y rendered" per folder, computed from the ArtJob rows the index endpoint already fetches (grouped by each job's `sourceFolder`/`sourceFile`), rather than re-hashing every image in every folder (which would multiply `listSceneAnimatorSourceFiles`'s per-file read+sha256 cost by folder count).
- **Runtime estimates**: active (queued/rendering) cards show elapsed time since queued/last-update plus the current preset's own `timeoutSeconds` as a rough "typically ≤" ceiling — there's no per-job progress signal to report against, so this is the clearest honest estimate available without one.
- Fixed a pre-existing `no-useless-assignment` lint error in `index.get.ts`'s jobs-parsing loop (confirmed via `git stash` diff that it predates this change) and avoided introducing a second copy of the same pattern in the new folder-stats helper.

### How I verified
- `npx vue-tsc --noEmit` — clean, full repo.
- `npx eslint` on all four touched files — clean.
- `npm run test:layout-contract` — holds, no new violations (an unrelated pre-existing `video-lora-picker.vue` baseline improvement showed up in the same run; I did not touch that file and left its baseline alone).
- Read through the existing `enqueue.post.ts` dedupe/reuse logic carefully before adding `sourceFile` scoping, to confirm it composes with `retryFailed` rather than duplicating its logic.
- No live ComfyUI render available in this sandbox — could not watch an actual retry go from `failed` → `queued` → `done` end to end. The per-source retry reuses the exact same enqueue path the existing folder-wide retry already uses in production, just pre-filtered to one file.

### Stakes
reversible — pure application code (Vue page, Pinia store, two API route handlers), no schema/migration involved.

### Flags for Reviewer
- The per-folder completion count is intentionally config-agnostic ("rendered under any engine/preset/duration combo ever tried on this file") rather than scoped to the currently-selected config, so the folder picker's badge doesn't jump around every time you change presets. Worth a second look if that reads as confusing rather than useful.
- No automated test exists for the enqueue endpoint's dedupe/retry logic (checked `utils/scripts/verifySceneAnimatorHealth.test.ts` — it only covers the health check from t-003). Verification here is typecheck + lint + manual code reading, not integration tests.

### Kaizen suggestion
`enqueue.post.ts`'s existing-jobs "recheck immediately before the expensive enqueue" pattern (the `if (!existing || ...) { const live = await prisma.artJob.findFirst(...) }` block) re-derives its own dedupe lookup inline rather than sharing a helper with the `latestByKey` construction a few lines up — worth a small follow-up to extract a shared `findLatestJobForKey` helper if this file grows more entry points.

### Notes for reviewer
Safe to merge on green CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArG3QDLLjbZgMMe36AHmb4)_