### PR TITLE
mandarin-tutor/t-011: add linguistic provenance and content-quality audits

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "addFilePathComments": "node utils/scripts/addFilePathComment.js",
     "audit": "node ./utils/scripts/audit.mjs",
     "audit:channel-assets": "tsx utils/scripts/auditChannelAssets.ts",
+    "audit:mandarin-provenance": "tsx utils/scripts/auditMandarinCatalog.ts",
+    "test:mandarin-content-audit": "tsx utils/scripts/auditMandarinCatalog.ts --self-test",
     "audit:checkpoints": "prisma generate && tsx utils/scripts/auditCheckpointResources.ts",
     "repair:checkpoints": "prisma generate && tsx utils/scripts/repairCheckpointResources.ts",
     "audit:facet-data": "prisma generate && tsx utils/scripts/auditFacetCatalogData.ts",

--- a/utils/mandarinContentAudit.ts
+++ b/utils/mandarinContentAudit.ts
@@ -1,0 +1,321 @@
+// /utils/mandarinContentAudit.ts
+//
+// Pure, database-free content-quality checks for the Mandarin Tutor catalog
+// (mandarin-tutor/t-011). Kept separate from the CLI wrapper for the same
+// reason utils/facetCatalogAudit.ts and utils/matureTerms.ts are: the rules
+// should be unit-testable and reviewable without touching a database or the
+// network, and reusable from more than one entry point later (a future admin
+// UI audit view, a pre-publish check on a requested card, etc).
+//
+// WHAT THIS DOES NOT DO
+// ----------------------
+// It does not fetch data. Callers pass in the catalog (cards + sets) they
+// already built, however they built it -- from the live source catalog
+// (utils/scripts/auditMandarinCatalog.ts's default mode), or from a small
+// fixture (its --self-test mode). This module never imports `$fetch`, Prisma,
+// or anything else with I/O.
+import { matchMatureTerms } from './matureTerms'
+import type { MandarinCard, MandarinStudySet } from './mandarin'
+
+export type MandarinAuditIssue = {
+  /** Stable machine-readable reason code, one per check below. */
+  code:
+    | 'duplicate-curated-seed'
+    | 'duplicate-card-key'
+    | 'malformed-pinyin'
+    | 'missing-audio-contract'
+    | 'orphan-set-term'
+    | 'orphan-set-card-key'
+    | 'unsupported-etymology-claim'
+    | 'adult-or-irrelevant-meaning'
+  /** The card key or set id the issue is about, when there is one card in play. */
+  subject: string
+  detail: string
+}
+
+export type MandarinAuditReport = {
+  totals: {
+    cards: number
+    sets: number
+    issues: number
+  }
+  byCode: Record<string, number>
+  issues: MandarinAuditIssue[]
+}
+
+/**
+ * A single pinyin syllable: Latin letters (including ü/Ü) with either a tone
+ * diacritic already applied, or a trailing tone digit 1-5, or neither
+ * (neutral tone written bare, e.g. "de", "ma"). This is deliberately
+ * permissive about which letters combine -- it is not a phonotactics
+ * validator -- but it does reject stray punctuation, digits in the wrong
+ * place, or empty syllables, which is the actual failure mode a bad edit or a
+ * bad upstream source row produces.
+ */
+const PINYIN_SYLLABLE_RE =
+  /^[a-zA-Züÿāēīōūǖáéíóúǘǎěǐǒǔǚàèìòùǜ]+[1-5]?$/u
+
+/** Same separator set utils/mandarinPronunciation.ts's tone parser splits on. */
+const PINYIN_SEPARATOR_RE = /[\s'’·-]+/u
+
+export function pinyinSyllables(pinyin: string): string[] {
+  return pinyin
+    .trim()
+    .split(PINYIN_SEPARATOR_RE)
+    .map((syllable) => syllable.trim())
+    .filter(Boolean)
+}
+
+export function isWellFormedPinyin(pinyin: string): boolean {
+  const trimmed = pinyin.trim()
+  if (!trimmed) return false
+  const syllables = pinyinSyllables(trimmed)
+  if (!syllables.length) return false
+  return syllables.every((syllable) => PINYIN_SYLLABLE_RE.test(syllable))
+}
+
+function pushIssue(
+  issues: MandarinAuditIssue[],
+  code: MandarinAuditIssue['code'],
+  subject: string,
+  detail: string,
+): void {
+  issues.push({ code, subject, detail })
+}
+
+/**
+ * Duplicate Hanzi in the curated-seed list (utils/mandarin.ts's
+ * CURATED_MANDARIN_CARDS, one entry per CURATED_SEEDS row -- the raw tuple
+ * array itself is not exported, but a duplicate `simplified` in it produces
+ * an equally duplicate `simplified`/`key` here). `mergeCards()` in
+ * server/utils/mandarinCatalog.ts keys a Map by `simplified`, so a repeated
+ * seed entry is silently dropped with no warning anywhere -- this is the
+ * check that would have caught it.
+ */
+export function auditDuplicateSeeds(
+  curatedCards: readonly MandarinCard[],
+): MandarinAuditIssue[] {
+  const issues: MandarinAuditIssue[] = []
+  const seen = new Map<string, number>()
+  curatedCards.forEach((card, index) => {
+    const firstIndex = seen.get(card.simplified)
+    if (firstIndex === undefined) {
+      seen.set(card.simplified, index)
+      return
+    }
+    pushIssue(
+      issues,
+      'duplicate-curated-seed',
+      card.simplified,
+      `CURATED_SEEDS has "${card.simplified}" at index ${firstIndex} and again at index ${index}; the later entry is silently discarded by mergeCards()'s Map, not merged or reported.`,
+    )
+  })
+  return issues
+}
+
+function auditDuplicateKeys(cards: readonly MandarinCard[]): MandarinAuditIssue[] {
+  const issues: MandarinAuditIssue[] = []
+  const seen = new Set<string>()
+  for (const card of cards) {
+    if (seen.has(card.key)) {
+      pushIssue(
+        issues,
+        'duplicate-card-key',
+        card.key,
+        `More than one card in the built catalog shares key "${card.key}". Downstream lookups by key (sets, overrides, audio) can silently resolve to the wrong one.`,
+      )
+      continue
+    }
+    seen.add(card.key)
+  }
+  return issues
+}
+
+function auditPinyin(cards: readonly MandarinCard[]): MandarinAuditIssue[] {
+  const issues: MandarinAuditIssue[] = []
+  for (const card of cards) {
+    if (!isWellFormedPinyin(card.pinyin)) {
+      pushIssue(
+        issues,
+        'malformed-pinyin',
+        card.key,
+        `pinyin "${card.pinyin}" does not parse as one or more Latin pinyin syllables (optionally toned).`,
+      )
+    }
+  }
+  return issues
+}
+
+/**
+ * mandarinAudio.ts's deterministic audio-asset id is built from
+ * [recipeVersion, provider, model, voice, format, simplified, pinyin]. A card
+ * missing either half of that pair can never get a working audio contract --
+ * flag it before it reaches the player rather than after.
+ */
+function auditAudioContracts(cards: readonly MandarinCard[]): MandarinAuditIssue[] {
+  const issues: MandarinAuditIssue[] = []
+  for (const card of cards) {
+    const missing: string[] = []
+    if (!card.simplified?.trim()) missing.push('simplified')
+    if (!card.pinyin?.trim()) missing.push('pinyin')
+    if (missing.length) {
+      pushIssue(
+        issues,
+        'missing-audio-contract',
+        card.key,
+        `card is missing ${missing.join(' and ')}, so no audio asset id can be derived for it.`,
+      )
+    }
+  }
+  return issues
+}
+
+/**
+ * Two directions of orphan check: a study set's cardKeys pointing at a card
+ * that doesn't exist in the built catalog (a stale reference), and a
+ * BUILT_IN_SET_TERMS term that matched no card at all (silently contributes
+ * nothing to its set, with nothing surfacing that fact today).
+ */
+export function auditOrphanSets(
+  cards: readonly MandarinCard[],
+  sets: readonly MandarinStudySet[],
+  builtInSetTerms?: Readonly<Record<string, readonly string[]>>,
+): MandarinAuditIssue[] {
+  const issues: MandarinAuditIssue[] = []
+  const cardKeys = new Set(cards.map((card) => card.key))
+  const simplifiedForms = new Set(cards.map((card) => card.simplified))
+
+  for (const set of sets) {
+    for (const cardKey of set.cardKeys) {
+      if (!cardKeys.has(cardKey)) {
+        pushIssue(
+          issues,
+          'orphan-set-card-key',
+          set.id,
+          `set "${set.id}" references cardKey "${cardKey}", which is not in the built catalog.`,
+        )
+      }
+    }
+  }
+
+  if (builtInSetTerms) {
+    for (const [setId, terms] of Object.entries(builtInSetTerms)) {
+      for (const term of terms) {
+        if (!simplifiedForms.has(term)) {
+          pushIssue(
+            issues,
+            'orphan-set-term',
+            setId,
+            `BUILT_IN_SET_TERMS["${setId}"] lists "${term}", which matches no card's simplified form -- it silently contributes nothing to the set.`,
+          )
+        }
+      }
+    }
+  }
+
+  return issues
+}
+
+/**
+ * Structural invariant, not a linguistic judgment: every semantic/phonetic
+ * component this catalog assembles (server/utils/mandarinCharacterData.ts) is
+ * supposed to carry a sourcing note, and every card whose historyStatus
+ * claims "starter" (vetted/source-backed) is supposed to carry actual history
+ * text. A component or card that fails this slipped past the code paths that
+ * are meant to guarantee it, which is exactly the "unsupported claim" this
+ * check exists to catch -- a formation/etymology assertion with the
+ * provenance that should back it left off.
+ */
+function auditEtymologyClaims(cards: readonly MandarinCard[]): MandarinAuditIssue[] {
+  const issues: MandarinAuditIssue[] = []
+  for (const card of cards) {
+    for (const component of card.components) {
+      if (
+        (component.role === 'semantic' || component.role === 'phonetic') &&
+        !component.note?.trim()
+      ) {
+        pushIssue(
+          issues,
+          'unsupported-etymology-claim',
+          card.key,
+          `component "${component.glyph}" (role: ${component.role}) has no sourcing note.`,
+        )
+      }
+    }
+    if (card.historyStatus === 'starter' && !card.history?.trim()) {
+      pushIssue(
+        issues,
+        'unsupported-etymology-claim',
+        card.key,
+        `historyStatus is "starter" (source-backed) but the history field is empty.`,
+      )
+    }
+  }
+  return issues
+}
+
+/**
+ * This is a beginner-facing, kid-safe curriculum by default (see the
+ * "casino" set for the one deliberately adult-audience exception, which is
+ * itself never mature content, just gambling vocabulary). Reuses the same
+ * word-boundary-safe matcher the Resource catalog's mature-content sweep
+ * uses (utils/matureTerms.ts) rather than a second ad hoc implementation --
+ * false positives here are cheap (a human reviews the flagged card), false
+ * negatives are not.
+ */
+function auditMeaningContent(cards: readonly MandarinCard[]): MandarinAuditIssue[] {
+  const issues: MandarinAuditIssue[] = []
+  for (const card of cards) {
+    const text = [card.meaning, ...card.meanings, card.history ?? '']
+      .filter(Boolean)
+      .join(' \n ')
+    const matches = matchMatureTerms(text)
+    if (matches.length) {
+      pushIssue(
+        issues,
+        'adult-or-irrelevant-meaning',
+        card.key,
+        `meaning/history text matched: ${matches.map((match) => `${match.term} (${match.tier})`).join(', ')}.`,
+      )
+    }
+  }
+  return issues
+}
+
+export type MandarinCatalogAuditInput = {
+  cards: readonly MandarinCard[]
+  sets: readonly MandarinStudySet[]
+  /** Optional: enables the orphan-set-term half of the orphan-set check. */
+  builtInSetTerms?: Readonly<Record<string, readonly string[]>>
+  /** Optional: enables the duplicate-curated-seed check. */
+  curatedCards?: readonly MandarinCard[]
+}
+
+export function auditMandarinCatalog(
+  input: MandarinCatalogAuditInput,
+): MandarinAuditReport {
+  const issues: MandarinAuditIssue[] = [
+    ...(input.curatedCards ? auditDuplicateSeeds(input.curatedCards) : []),
+    ...auditDuplicateKeys(input.cards),
+    ...auditPinyin(input.cards),
+    ...auditAudioContracts(input.cards),
+    ...auditOrphanSets(input.cards, input.sets, input.builtInSetTerms),
+    ...auditEtymologyClaims(input.cards),
+    ...auditMeaningContent(input.cards),
+  ]
+
+  const byCode: Record<string, number> = {}
+  for (const issue of issues) {
+    byCode[issue.code] = (byCode[issue.code] ?? 0) + 1
+  }
+
+  return {
+    totals: {
+      cards: input.cards.length,
+      sets: input.sets.length,
+      issues: issues.length,
+    },
+    byCode,
+    issues,
+  }
+}

--- a/utils/scripts/auditMandarinCatalog.ts
+++ b/utils/scripts/auditMandarinCatalog.ts
@@ -1,0 +1,266 @@
+// /utils/scripts/auditMandarinCatalog.ts
+//
+// mandarin-tutor/t-011: content-quality and provenance audits for the
+// Mandarin Tutor catalog. Checks live in utils/mandarinContentAudit.ts (pure,
+// no I/O); this file is the CLI wrapper that supplies data to them two ways:
+//
+//   npm run audit:mandarin-provenance             # fetch the LIVE served
+//                                                  # catalog (GET /api/mandarin
+//                                                  # on kindrobots.org by
+//                                                  # default) and report
+//   npm run audit:mandarin-provenance -- --strict  # exit 1 if any issues found
+//   npm run audit:mandarin-provenance -- --base-url=http://localhost:3000
+//   npm run test:mandarin-content-audit            # --self-test: a fixed
+//                                                  # in-memory fixture, no
+//                                                  # network, no database --
+//                                                  # this is the one CI runs
+//
+// WHY A PLAIN HTTPS FETCH INSTEAD OF IMPORTING THE SERVER CATALOG BUILDER
+// -------------------------------------------------------------------------
+// server/utils/mandarinCatalog.ts and mandarinCharacterData.ts call Nuxt's
+// auto-imported `$fetch`, which only exists inside the Nuxt/Nitro runtime --
+// not in a plain `tsx` process. GET /api/mandarin (server/api/mandarin/index.get.ts)
+// already calls getMandarinCatalog() and returns the exact payload this audit
+// wants, unauthenticated, so hitting it over HTTPS is both simpler and closer
+// to what a real client sees than re-deriving the catalog here would be. This
+// follows the same "plain HTTPS against kindrobots.org is a normal, working
+// verification path from this sandbox" precedent documented in this repo's
+// AGENTS.md for other post-deploy checks.
+import {
+  BUILT_IN_SET_TERMS,
+  CURATED_MANDARIN_CARDS,
+  type MandarinCard,
+  type MandarinCatalogPayload,
+  type MandarinStudySet,
+} from '../mandarin'
+import {
+  auditMandarinCatalog,
+  type MandarinAuditReport,
+} from '../mandarinContentAudit'
+
+const selfTest = process.argv.includes('--self-test')
+const strict = process.argv.includes('--strict')
+const baseUrlArg = process.argv.find((arg) => arg.startsWith('--base-url='))
+const baseUrl = baseUrlArg
+  ? baseUrlArg.slice('--base-url='.length)
+  : (process.env.MANDARIN_AUDIT_BASE_URL ?? 'https://kindrobots.org')
+
+/* -------------------------------------------------------------------------- */
+/* self-test -- the check logic, provable without a database or the network   */
+/* -------------------------------------------------------------------------- */
+
+function fixtureCard(overrides: Partial<MandarinCard>): MandarinCard {
+  return {
+    key: 'fixture:x',
+    simplified: 'x',
+    pinyin: 'xiè',
+    meaning: 'placeholder',
+    meanings: ['placeholder'],
+    kind: 'character',
+    partsOfSpeech: [],
+    classifiers: [],
+    categories: [],
+    components: [],
+    historyStatus: 'pending',
+    source: { label: 'fixture', version: 'fixture' },
+    ...overrides,
+  }
+}
+
+if (selfTest) {
+  const failures: string[] = []
+
+  const goodCard = fixtureCard({ key: 'good', simplified: '好', pinyin: 'hǎo' })
+  const badPinyinCard = fixtureCard({
+    key: 'bad-pinyin',
+    simplified: '坏',
+    pinyin: 'h4o!!',
+  })
+  const missingAudioCard = fixtureCard({
+    key: 'no-audio',
+    simplified: '',
+    pinyin: 'wú',
+  })
+  const matureMeaningCard = fixtureCard({
+    key: 'mature',
+    simplified: '色',
+    pinyin: 'sè',
+    meaning: 'nsfw content',
+    meanings: ['nsfw content'],
+  })
+  const ungroundedEtymologyCard = fixtureCard({
+    key: 'ungrounded',
+    simplified: '青',
+    pinyin: 'qīng',
+    components: [{ glyph: '青', role: 'phonetic', label: 'sound component' }],
+  })
+  const claimedButEmptyHistoryCard = fixtureCard({
+    key: 'empty-history',
+    simplified: '空',
+    pinyin: 'kōng',
+    historyStatus: 'starter',
+    history: undefined,
+  })
+
+  const cards: MandarinCard[] = [
+    goodCard,
+    badPinyinCard,
+    missingAudioCard,
+    matureMeaningCard,
+    ungroundedEtymologyCard,
+    claimedButEmptyHistoryCard,
+  ]
+
+  const sets: MandarinStudySet[] = [
+    {
+      id: 'demo-set',
+      label: 'Demo',
+      description: 'demo',
+      cardKeys: ['good', 'this-key-does-not-exist'],
+    },
+  ]
+
+  const builtInSetTerms = { animals: ['好', 'this-term-matches-nothing'] }
+
+  const duplicateCurated: MandarinCard[] = [
+    fixtureCard({ key: 'curated:重', simplified: '重', pinyin: 'zhòng' }),
+    fixtureCard({ key: 'curated:重', simplified: '重', pinyin: 'chóng' }),
+  ]
+
+  const report = auditMandarinCatalog({
+    cards,
+    sets,
+    builtInSetTerms,
+    curatedCards: duplicateCurated,
+  })
+
+  const has = (code: string, subject: string) =>
+    report.issues.some((issue) => issue.code === code && issue.subject === subject)
+
+  const expectations: [boolean, string][] = [
+    [has('malformed-pinyin', 'bad-pinyin'), 'expected malformed-pinyin for bad-pinyin'],
+    [!has('malformed-pinyin', 'good'), 'good card must not be flagged for pinyin'],
+    [has('missing-audio-contract', 'no-audio'), 'expected missing-audio-contract for no-audio'],
+    [has('adult-or-irrelevant-meaning', 'mature'), 'expected adult-or-irrelevant-meaning for mature'],
+    [
+      has('unsupported-etymology-claim', 'ungrounded'),
+      'expected unsupported-etymology-claim for an unsourced phonetic component',
+    ],
+    [
+      has('unsupported-etymology-claim', 'empty-history'),
+      'expected unsupported-etymology-claim for historyStatus=starter with empty history',
+    ],
+    [
+      has('orphan-set-card-key', 'demo-set'),
+      'expected orphan-set-card-key for demo-set\'s dangling cardKey',
+    ],
+    [
+      has('orphan-set-term', 'animals'),
+      'expected orphan-set-term for a BUILT_IN_SET_TERMS entry matching no card',
+    ],
+    [
+      has('duplicate-curated-seed', '重'),
+      'expected duplicate-curated-seed for the repeated 重 fixture',
+    ],
+    [report.totals.cards === cards.length, 'totals.cards must match the input card count'],
+  ]
+
+  for (const [passed, message] of expectations) {
+    if (!passed) failures.push(message)
+  }
+
+  // A real, non-crashing pass over the actual static curated data + built-in
+  // set terms -- the fixture cases above prove each rule fires; this proves
+  // the rules also run clean against the real hand-authored data they exist
+  // to guard, without needing the network to fetch the full live catalog.
+  try {
+    const realReport = auditMandarinCatalog({
+      cards: CURATED_MANDARIN_CARDS,
+      sets: [],
+      curatedCards: CURATED_MANDARIN_CARDS,
+    })
+    const realDuplicates = realReport.issues.filter(
+      (issue) => issue.code === 'duplicate-curated-seed',
+    )
+    if (realDuplicates.length) {
+      failures.push(
+        `CURATED_SEEDS has ${realDuplicates.length} real duplicate(s): ${realDuplicates
+          .map((issue) => issue.subject)
+          .join(', ')}`,
+      )
+    }
+  } catch (error: unknown) {
+    failures.push(
+      `auditMandarinCatalog threw against the real curated data: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+
+  if (failures.length) {
+    console.error('❌ Mandarin content-audit self-test FAILED:')
+    for (const failure of failures) console.error(`  - ${failure}`)
+    process.exit(1)
+  }
+
+  console.log(
+    `✅ Mandarin content-audit self-test passed (${expectations.length} fixture checks, ` +
+      `${CURATED_MANDARIN_CARDS.length} real curated cards clean of duplicates).`,
+  )
+  process.exit(0)
+}
+
+/* -------------------------------------------------------------------------- */
+/* live report                                                                */
+/* -------------------------------------------------------------------------- */
+
+type CatalogResponse = {
+  success: boolean
+  message?: string
+  data: MandarinCatalogPayload | null
+}
+
+async function fetchLiveCatalog(): Promise<MandarinCatalogPayload> {
+  const url = `${baseUrl.replace(/\/$/, '')}/api/mandarin`
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`GET ${url} -> HTTP ${response.status}`)
+  }
+  const body = (await response.json()) as CatalogResponse
+  if (!body.success || !body.data) {
+    throw new Error(`GET ${url} responded without a usable catalog: ${body.message ?? 'no message'}`)
+  }
+  return body.data
+}
+
+function printReport(report: MandarinAuditReport): void {
+  const output = {
+    generatedAt: new Date().toISOString(),
+    mode: strict ? 'strict' : 'report',
+    totals: report.totals,
+    byCode: report.byCode,
+    issues: report.issues,
+  }
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+}
+
+async function main(): Promise<void> {
+  const catalog = await fetchLiveCatalog()
+  const report = auditMandarinCatalog({
+    cards: catalog.cards,
+    sets: catalog.sets,
+    builtInSetTerms: BUILT_IN_SET_TERMS,
+    curatedCards: CURATED_MANDARIN_CARDS,
+  })
+
+  printReport(report)
+
+  if (strict && report.totals.issues > 0) {
+    throw new Error(
+      `Strict Mandarin content audit failed: ${report.totals.issues} issue(s) across ${Object.keys(report.byCode).length} categor${Object.keys(report.byCode).length === 1 ? 'y' : 'ies'}.`,
+    )
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
### Task
mandarin-tutor/t-011: Add linguistic provenance and content-quality audits (kind: software)

### What changed / what I produced
- `utils/mandarinContentAudit.ts` — pure, DB-free/network-free check functions operating on `MandarinCard[]`/`MandarinStudySet[]`:
  - duplicate Hanzi in the curated-seed list (`CURATED_MANDARIN_CARDS`)
  - malformed pinyin (structural syllable validation)
  - missing audio-synthesis contracts (`simplified`/`pinyin` required by `mandarinAudio.ts`'s deterministic asset id)
  - orphan set membership — both directions: a set's `cardKeys` pointing at a card that doesn't exist, and a `BUILT_IN_SET_TERMS` entry matching no card
  - unsupported etymology claims — a `semantic`/`phonetic` component with no sourcing note, or `historyStatus: 'starter'` with empty `history` text
  - accidental adult/irrelevant meanings — reuses the existing word-boundary-safe `utils/matureTerms.ts` matcher rather than a second ad hoc implementation
- `utils/scripts/auditMandarinCatalog.ts` — CLI wrapper, two modes:
  - `npm run test:mandarin-content-audit` (`--self-test`): fixed in-memory fixtures proving each check fires, plus a real pass over `CURATED_MANDARIN_CARDS`. No network, no database — this is the one CI should run.
  - `npm run audit:mandarin-provenance`: fetches the **live served catalog** (`GET /api/mandarin`) and prints a JSON report; `--strict` exits 1 on any issue. Uses a plain HTTPS fetch against the existing endpoint rather than importing `server/utils/mandarinCatalog.ts` directly, since that module's `$fetch` is a Nuxt auto-import not available in a bare `tsx` process.
- `package.json`: registered both npm scripts.

### How I verified
- `npm run test:mandarin-content-audit` — passes (10 fixture checks + a clean real pass over the 63 curated cards).
- `npx eslint utils/mandarinContentAudit.ts utils/scripts/auditMandarinCatalog.ts` — clean.
- `npx vue-tsc --noEmit` (full repo) — clean.
- `npm run audit:mandarin-provenance` against production — see "Flags for Reviewer" below.

### Stakes
reversible — two new files plus two new npm script entries, no existing behavior touched.

### Flags for Reviewer
- Running `audit:mandarin-provenance` against `https://kindrobots.org/api/mandarin` right now returns `HTTP 400`, `"HSK level 1 source was not an array"` — reproduced 4 times, not a flake. This is a **pre-existing production bug**, unrelated to this PR (the endpoint is broken before and after this change). I did not fix it here — root-causing and fixing `server/utils/mandarinCatalog.ts`'s `$fetch` call is out of scope for a content-audit task and I don't have a way to reproduce the exact `$fetch` behavior outside the Nuxt runtime from this sandbox. Filed as `mandarin-tutor/t-014` in conductor with my diagnosis (leading theory: GitHub raw content is served as `content-type: text/plain`, which may make `$fetch` return a string instead of parsed JSON) so a future session can pick it up. The self-test mode this PR adds doesn't depend on the live endpoint, so it isn't blocked by this.

### Kaizen suggestion
`server/utils/mandarinCatalog.ts` and `mandarinCharacterData.ts` both call `$fetch` on a pinned `raw.githubusercontent.com` URL with no explicit `responseType`. If t-014's theory is right, an explicit `responseType: 'json'` (or a manual `JSON.parse` of `response.text()`) on both call sites would fix the live break in one small PR — worth prioritizing since it currently means the whole Mandarin Tutor page is unservable in production.

### Notes for reviewer
Safe to merge on green CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEanrqv5JHcZTa6QdMAb7X)_