### PR TITLE
mandarin-tutor/t-014: fix GET /api/mandarin 400ing on production

### DIFF
--- a/server/utils/mandarinCatalog.ts
+++ b/server/utils/mandarinCatalog.ts
@@ -124,11 +124,19 @@ function normalizeSourceEntry(entry: SourceEntry, level: number): MandarinCard |
 }
 
 async function fetchLevel(level: number): Promise<MandarinCard[]> {
+  // GitHub serves raw .json content as `text/plain; charset=utf-8`, not
+  // `application/json`. ofetch's default JSON auto-parsing keys off the
+  // response's Content-Type header, so without an explicit `parseResponse`
+  // it silently returns the raw response text instead of a parsed array
+  // whenever that header disagrees with the file extension. Forcing
+  // JSON.parse here makes parsing independent of what the upstream host
+  // decides to label the response as.
   const entries = await $fetch<SourceEntry[], string>(
     `${SOURCE_BASE}/${level}.min.json`,
     {
       retry: 2,
       timeout: 20_000,
+      parseResponse: (responseText) => JSON.parse(responseText),
     },
   )
   if (!Array.isArray(entries)) throw new Error(`HSK level ${level} source was not an array.`)


### PR DESCRIPTION
### Task
mandarin-tutor/t-014: `GET /api/mandarin` returns `400 HSK level 1 source was not an array.` in production — the whole Mandarin catalog is unservable. (kind: software)

### What changed / what I produced
- `server/utils/mandarinCatalog.ts`'s `fetchLevel()` now passes an explicit `parseResponse: (t) => JSON.parse(t)` to the `$fetch` call against the pinned HSK vocabulary source.

### Root cause
The pinned source (`raw.githubusercontent.com/jelleverheyen/hsk-vocabulary@a66fd30/wordlists/inclusive/new/{level}.min.json`) is served by GitHub with `Content-Type: text/plain; charset=utf-8`, not `application/json`, confirmed via `curl -I` against the live URL. `ofetch`'s default JSON auto-parsing keys off that header, so without an explicit override it silently returned the raw response text instead of a parsed array. `Array.isArray(entries)` then failed and threw exactly the production error message.

### How I verified
- Reproduced directly against the live pinned URL with a standalone `ofetch` script (kind_robots' own installed dependency, via `provision_kind_robots_deps.sh`):
  - Without the fix: `typeof === 'string'`, `Array.isArray === false` — reproduces the production bug exactly.
  - With the fix: `Array.isArray === true`, 511 entries parsed correctly for HSK level 1.
- `vue-tsc --noEmit`: clean.
- `eslint server/utils/mandarinCatalog.ts`: clean.
- Checked the sibling file `mandarinCharacterData.ts`'s `loadDictionary()` (same task note flagged it as having "the identical pattern") — it already passes `responseType: 'text'` explicitly and manually parses each NDJSON line itself, so it does not depend on ofetch's content-type-based auto-detection and was not affected by this bug.
- Grepped the rest of `server/` for other `raw.githubusercontent.com` fetches expecting a parsed JSON array without an explicit parse override — none found; the other raw.githubusercontent.com usages are plain asset/image URLs, not JSON fetches.

### Stakes
reversible

### Flags for Reviewer
- No automated test previously covered this path (no `mandarin`-named test files exist yet); verification here is a direct live-source reproduction rather than a unit test, since a mock can't reproduce a real upstream Content-Type header. Worth a follow-up if a fixture-based regression test is wanted.

### Kaizen suggestion
Add a unit test that fixtures a non-`application/json` Content-Type response and asserts `fetchLevel()` still returns a parsed array — this exact bug class (raw-GitHub-serves-.json-as-text/plain) is generic enough to bite the next raw.githubusercontent.com JSON fetch someone adds.

### Notes for reviewer
Confirmed via `git status`/`git log` at session start that no other agent had already claimed or fixed this task.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HKinDeAFWFDH4E3bM9rSUd)_