### PR TITLE
interface-vision/t-105: give Mission Accrual an icon-badge header

### DIFF
--- a/components/pages/mission-accrual-page.vue
+++ b/components/pages/mission-accrual-page.vue
@@ -1,5 +1,21 @@
 <template>
   <div class="kr-unbound kr-container max-w-3xl p-6 space-y-8">
+    <header class="flex items-center gap-3">
+      <span
+        class="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-primary/15 text-primary"
+      >
+        <Icon name="kind-icon:hand-heart" class="h-7 w-7" />
+      </span>
+      <div>
+        <p class="text-2xl font-black tracking-tight">Mission Accrual</p>
+        <p class="text-sm text-base-content/60">
+          How much mission share has accrued from the RevenueSplit ledger, how
+          much has actually been remitted, and the outstanding balance still
+          owed to the fundraiser.
+        </p>
+      </div>
+    </header>
+
     <div
       v-if="!userStore.isAdmin"
       class="rounded-2xl border border-accent/30 bg-(--kr-surface) p-6 text-center space-y-3"
@@ -11,12 +27,6 @@
     </div>
 
     <template v-else>
-      <p class="text-sm text-base-content/60">
-        How much mission share has accrued from the RevenueSplit ledger, how
-        much of it has actually been remitted, and the outstanding balance still
-        owed to the fundraiser.
-      </p>
-
       <div
         class="flex items-start gap-3 rounded-2xl border border-warning/30 bg-warning/10 p-4 text-sm text-base-content/75"
       >


### PR DESCRIPTION
## Summary
`components/pages/mission-accrual-page.vue` (the admin-only mission-share accrual/remittance ledger) had no page header at all — just a plain intro paragraph, inconsistent with the rest of the site. Added the established icon-badge + title/subtitle header pattern (`kind-icon:hand-heart` badge, 2xl bold title, 60%-opacity subtitle) matching `serendipity-page.vue` and `build-bench.vue` precedent from this same recurring interface-vision/t-105 "page-by-page polish" umbrella.

Template/classes only — no script, store, or behavior changes. The restricted-access message shown to non-admins is unchanged.

## Verification
- `eslint` on the changed file: clean
- `vue-tsc --noEmit`: clean
- `npm run test:layout-contract`: holds, zero new violations (pre-existing `video-lora-picker.vue` viewport-grid baseline improvement observed but left untouched, out of scope)
- `prettier --check`: clean

## Flags for Reviewer
- Purely visual/structural — no risk to the financial data or admin gating logic (the `v-if="!userStore.isAdmin"` restricted-access block is untouched).
- Same header pattern already used elsewhere in production (serendipity-page.vue, build-bench.vue), so no new visual language introduced.
- Honest limit on visual verification: this sandbox has no reachable database and no PR-preview infrastructure (kind_robots migrated off Vercel), so only class-level/structural verification was possible — no rendered screenshot.

## Kaizen suggestion
None beyond the task's own recurring nature — return interface-vision/t-105 to `ready` for the next visual review slice.


---
_Generated by [Claude Code](https://claude.ai/code/session_01APnixBDfxgvNpWFvgCfVsq)_