### PR TITLE
interface-vision/t-104: kr-panel-flat on Mandarin Tutor panels (slice 36)

### DIFF
--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -39,7 +39,7 @@
       </div>
 
       <template v-else>
-        <section class="rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm">
+        <section class="kr-panel-flat p-4 shadow-sm">
           <label class="form-control">
             <span class="label-text mb-1 font-semibold">Find a word, Hanzi, pinyin, or English meaning</span>
             <input
@@ -86,7 +86,7 @@
 
         <div class="grid gap-5 lg:grid-cols-[18rem_minmax(0,1fr)]">
           <aside class="space-y-3 lg:sticky lg:top-4 lg:self-start">
-            <div class="rounded-2xl border border-base-300 bg-base-100 p-3 shadow-sm">
+            <div class="kr-panel-flat p-3 shadow-sm">
               <div class="mb-2 flex items-center justify-between gap-2">
                 <h2 class="font-bold">Study sets</h2>
                 <span class="badge badge-ghost">{{ selectedSet?.cardKeys.length ?? 0 }}</span>
@@ -292,7 +292,7 @@
                       <div
                         v-for="component in currentCard.components"
                         :key="`${component.glyph}:${component.role}`"
-                        class="rounded-2xl border border-base-300 bg-base-100 p-4"
+                        class="kr-panel-flat p-4"
                       >
                         <div class="flex items-start gap-3">
                           <span class="text-4xl font-semibold">{{ component.glyph }}</span>
@@ -312,10 +312,10 @@
 
                   <div class="space-y-3">
                     <h3 class="text-lg font-bold">How did the character get here?</h3>
-                    <p v-if="currentCard.history" class="rounded-2xl border border-base-300 bg-base-100 p-4 text-sm leading-relaxed">
+                    <p v-if="currentCard.history" class="kr-panel-flat p-4 text-sm leading-relaxed">
                       {{ currentCard.history }}
                     </p>
-                    <p v-else class="rounded-2xl border border-base-300 bg-base-100 p-4 text-sm leading-relaxed opacity-65">
+                    <p v-else class="kr-panel-flat p-4 text-sm leading-relaxed opacity-65">
                       Historical development is pending a dedicated decomposition source. The current radical, when shown, is an indexing clue rather than an etymological claim.
                     </p>
                     <div class="text-xs opacity-55">
@@ -346,7 +346,7 @@
               </section>
             </article>
 
-            <div v-else class="rounded-2xl border border-base-300 bg-base-100 p-8 text-center opacity-65">
+            <div v-else class="kr-panel-flat p-8 text-center opacity-65">
               This set has no cards yet.
             </div>
           </main>


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- `pages/play/mandarin.vue`: six hand-rolled `rounded-2xl border border-base-300 bg-base-100` panel roots (search-panel `<section>`, study-sets sidebar `<div>`, two component-decomposition detail cards, the "no history" `<p>`, and the empty-set notice `<div>`) now use `kr-panel-flat`, keeping each element's own padding/text utilities alongside it. No geometry or behavior change — byte-exact substitution of the box shape only.

### How I verified
- `eslint pages/play/mandarin.vue` — clean
- `npx prettier --check pages/play/mandarin.vue` — one pre-existing warning, confirmed present on baseline `main` too (unrelated to this diff) via `git stash` + re-check
- `vue-tsc --noEmit` (full project) — clean
- `npm run test:layout-contract` — holds, 0 new violations (an unrelated pre-existing baseline-ratchet note on `video-lora-picker.vue` is untouched/out of scope)

### Stakes
reversible

### Flags for Reviewer
- Slices 32 and 35 of this same recurring task both concluded the `kr-container`/`kr-panel*` pools were exhausted repo-wide as of their date. This slice re-ran a fresh token-set grep (order-independent, same method as slice 34) and found `pages/play/mandarin.vue` had landed after those searches with fresh byte-exact `kr-panel-flat` matches — so the pool isn't fully static; worth a periodic re-grep rather than treating "exhausted" as permanent.
- Everything else the fresh grep surfaced was already correctly out of scope: the `border-dashed` empty-state family (real visual difference, flagged since slice 34), `kr-stat-tile.vue`'s `.stat` DaisyUI conflict, and `chat-gallery.vue`'s `.btn`/`.btn-ghost` DaisyUI conflict.

### Kaizen suggestion
None new this slice — the standing kaizen from the prior slice (a considered, non-blind pass over the `kr-note` family, since none of its ~20 candidates are byte-exact) is still the best-scoped next step and doesn't need restating.

### Notes for reviewer
Recurring task — after merge, please return `interface-vision/t-104` to `status: ready` in conductor's roadmap for the next slice (handled from the conductor side of this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011unsjNyiDC2CKEt2aojHQu

---
_Generated by [Claude Code](https://claude.ai/code/session_011unsjNyiDC2CKEt2aojHQu)_