### PR TITLE
mandarin-tutor/t-008: coverage report against the applicable HSK 3.0 standard

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -97,6 +97,9 @@ jobs:
       - name: Reaction target coverage contract
         run: npm run test:reaction-targets
 
+      - name: Mandarin proficiency-coverage contract
+        run: npm run test:mandarin-proficiency-coverage-selftest
+
       - name: Reaction route auth contract
         run: npm run test:reaction-route-auth
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "audit:channel-assets": "tsx utils/scripts/auditChannelAssets.ts",
     "audit:mandarin-provenance": "tsx utils/scripts/auditMandarinCatalog.ts",
     "test:mandarin-content-audit": "tsx utils/scripts/auditMandarinCatalog.ts --self-test",
+    "audit:mandarin-proficiency-coverage": "tsx utils/scripts/auditMandarinProficiencyCoverage.ts",
+    "test:mandarin-proficiency-coverage-selftest": "tsx utils/scripts/auditMandarinProficiencyCoverage.ts --self-test",
     "audit:checkpoints": "prisma generate && tsx utils/scripts/auditCheckpointResources.ts",
     "repair:checkpoints": "prisma generate && tsx utils/scripts/repairCheckpointResources.ts",
     "audit:facet-data": "prisma generate && tsx utils/scripts/auditFacetCatalogData.ts",

--- a/server/utils/mandarinCatalog.ts
+++ b/server/utils/mandarinCatalog.ts
@@ -3,6 +3,7 @@ import {
   BUILT_IN_SET_TERMS,
   CURATED_MANDARIN_CARDS,
   MANDARIN_SOURCE,
+  MANDARIN_SOURCE_COMMIT,
   STARTER_COMPONENT_GUIDES,
   type MandarinCard,
   type MandarinCatalogPayload,
@@ -37,8 +38,9 @@ type SourceEntry = {
   f?: SourceForm[]
 }
 
-const SOURCE_COMMIT = 'a66fd30b9580da2c2af7eb19e4b9d8099a29c061'
-const SOURCE_BASE = `https://raw.githubusercontent.com/jelleverheyen/hsk-vocabulary/${SOURCE_COMMIT}/wordlists/inclusive/new`
+// Pin lives in utils/mandarin.ts (MANDARIN_SOURCE_COMMIT) so this fetch and
+// MANDARIN_SOURCE's own version string can never drift apart.
+const SOURCE_BASE = `https://raw.githubusercontent.com/jelleverheyen/hsk-vocabulary/${MANDARIN_SOURCE_COMMIT}/wordlists/inclusive/new`
 const MINIMUM_CARD_COUNT = 500
 let sourceCatalogPromise: Promise<MandarinCatalogPayload> | null = null
 let catalogPromise: Promise<MandarinCatalogPayload> | null = null

--- a/utils/mandarin.ts
+++ b/utils/mandarin.ts
@@ -60,10 +60,18 @@ export type MandarinCustomSet = {
   createdAt: string
 }
 
+// Single source of truth for the pinned upstream commit/URL -- also read by
+// server/utils/mandarinCatalog.ts (which fetches from it) and
+// utils/mandarinProficiencyStandards.ts (which records which official
+// standard that pinned data maps to, mandarin-tutor/t-008). Keeping this in
+// one place means bumping the pin can't silently desync the two.
+export const MANDARIN_SOURCE_COMMIT = 'a66fd30b9580da2c2af7eb19e4b9d8099a29c061'
+export const MANDARIN_SOURCE_REPO_URL = 'https://github.com/jelleverheyen/hsk-vocabulary'
+
 export const MANDARIN_SOURCE: MandarinSource = {
   label: 'HSK Vocabulary / CC-CEDICT compilation',
-  version: 'jelleverheyen/hsk-vocabulary@a66fd30b9580da2c2af7eb19e4b9d8099a29c061',
-  url: 'https://github.com/jelleverheyen/hsk-vocabulary',
+  version: `jelleverheyen/hsk-vocabulary@${MANDARIN_SOURCE_COMMIT}`,
+  url: MANDARIN_SOURCE_REPO_URL,
   licenseNote: 'Source and attribution details are preserved from the upstream dataset.',
 }
 

--- a/utils/mandarinProficiencyCoverage.ts
+++ b/utils/mandarinProficiencyCoverage.ts
@@ -1,0 +1,127 @@
+// /utils/mandarinProficiencyCoverage.ts
+//
+// mandarin-tutor/t-008: pure, database-free proficiency-standard coverage
+// report for the Mandarin Tutor catalog. Companion to
+// utils/mandarinContentAudit.ts (content QUALITY) -- this checks coverage
+// BREADTH against the officially applicable proficiency standard instead, so
+// future roadmap work can target "HSK 3.0 level 3" instead of an arbitrary
+// card count. See utils/mandarinProficiencyStandards.ts for the standard's
+// own metadata (levels, reference vocabulary sizes, source pin).
+//
+// WHAT THIS DOES NOT DO: like mandarinContentAudit.ts, this never fetches.
+// Callers supply the catalog's cards, plus (optionally) how many vocabulary
+// entries the pinned upstream source has cumulatively for each level -- the
+// CLI wrapper (utils/scripts/auditMandarinProficiencyCoverage.ts) is the one
+// piece allowed to hit the network for that, since a level not yet ingested
+// into the catalog has no cards here to inspect at all.
+//
+// "Sourced" is derived from the cards themselves (does the live catalog
+// actually contain any card at this level), not from a second hardcoded list
+// of which levels server/utils/mandarinCatalog.ts currently fetches --
+// duplicating that list here would drift the moment someone adds a level
+// there without remembering to update it here too.
+import type { MandarinCard } from './mandarin'
+import {
+  DEFAULT_MANDARIN_PROFICIENCY_STANDARD,
+  type MandarinProficiencyStandard,
+} from './mandarinProficiencyStandards'
+
+export type MandarinLevelCoverage = {
+  level: number
+  label: string
+  /** True when the live catalog contains at least one card at this level. */
+  sourced: boolean
+  cardCount: number
+  /** Cards with an explanatory character/component breakdown beyond a bare dictionary radical. */
+  withComponentBreakdown: number
+  /** Cards with hand-authored or otherwise sourced character-origin history (historyStatus === 'starter'). */
+  withCharacterHistory: number
+  /** HSK 3.0's own published cumulative vocabulary size through this level. Informational only. */
+  referenceCumulativeVocabulary?: number
+  /** The pinned upstream source's own cumulative entry count for this level, when the caller checked. */
+  upstreamCumulativeVocabulary?: number
+}
+
+export type MandarinProficiencyCoverageReport = {
+  standard: {
+    id: string
+    label: string
+    sourceLabel: string
+    sourceUrl: string
+    sourceCommit: string
+  }
+  levels: MandarinLevelCoverage[]
+  totals: {
+    cardsWithLevel: number
+    cardsWithoutLevel: number
+    sourcedLevelCount: number
+    totalLevelCount: number
+  }
+  /** Concrete, ordered next targets -- the lowest-numbered unsourced level first. */
+  nextTargets: string[]
+}
+
+export function computeMandarinProficiencyCoverage(
+  cards: MandarinCard[],
+  options?: {
+    standard?: MandarinProficiencyStandard
+    upstreamCumulativeVocabulary?: Partial<Record<number, number>>
+  },
+): MandarinProficiencyCoverageReport {
+  const standard = options?.standard ?? DEFAULT_MANDARIN_PROFICIENCY_STANDARD
+  const upstream = options?.upstreamCumulativeVocabulary ?? {}
+
+  const levels: MandarinLevelCoverage[] = standard.levels.map((levelMeta) => {
+    const levelCards = cards.filter((card) => card.hskLevel === levelMeta.level)
+    return {
+      level: levelMeta.level,
+      label: levelMeta.label,
+      sourced: levelCards.length > 0,
+      cardCount: levelCards.length,
+      withComponentBreakdown: levelCards.filter(
+        (card) => card.components.length > 0,
+      ).length,
+      withCharacterHistory: levelCards.filter(
+        (card) => card.historyStatus === 'starter',
+      ).length,
+      referenceCumulativeVocabulary: levelMeta.referenceCumulativeVocabulary,
+      ...(typeof upstream[levelMeta.level] === 'number'
+        ? { upstreamCumulativeVocabulary: upstream[levelMeta.level] }
+        : {}),
+    }
+  })
+
+  const cardsWithLevel = cards.filter(
+    (card) => typeof card.hskLevel === 'number',
+  ).length
+  const sourcedLevelCount = levels.filter((entry) => entry.sourced).length
+
+  const nextTargets = levels
+    .filter((entry) => !entry.sourced)
+    .sort((a, b) => a.level - b.level)
+    .map((entry) => {
+      const upstreamNote =
+        typeof entry.upstreamCumulativeVocabulary === 'number'
+          ? `${entry.upstreamCumulativeVocabulary} cumulative entries already available upstream`
+          : 'upstream availability not checked in this run'
+      return `${entry.label}: not yet sourced into the catalog (${upstreamNote}).`
+    })
+
+  return {
+    standard: {
+      id: standard.id,
+      label: standard.label,
+      sourceLabel: standard.sourceLabel,
+      sourceUrl: standard.sourceUrl,
+      sourceCommit: standard.sourceCommit,
+    },
+    levels,
+    totals: {
+      cardsWithLevel,
+      cardsWithoutLevel: cards.length - cardsWithLevel,
+      sourcedLevelCount,
+      totalLevelCount: levels.length,
+    },
+    nextTargets,
+  }
+}

--- a/utils/mandarinProficiencyStandards.ts
+++ b/utils/mandarinProficiencyStandards.ts
@@ -1,0 +1,69 @@
+// /utils/mandarinProficiencyStandards.ts
+//
+// mandarin-tutor/t-008: proficiency-standard metadata, kept separate from the
+// catalog builder (server/utils/mandarinCatalog.ts) so a coverage report can
+// name which official standard -- and which pinned revision of it -- the
+// product currently measures against, instead of baking one exam edition in
+// permanently. HSK 3.0 (7 cumulative levels) replaced the older HSK 1-6
+// scale as mainland China's official standard in 2021 and is the standard
+// this product currently targets. MANDARIN_PROFICIENCY_STANDARDS is an array
+// so a second entry (the older 2.0 scale, or a future revision) can be added
+// later without restructuring callers -- see utils/mandarinProficiencyCoverage.ts
+// for the report built from this metadata plus the live catalog.
+//
+// referenceCumulativeVocabulary figures are HSK 3.0's own published
+// cumulative vocabulary sizes (500 / 1,272 / 2,245 / 3,245 / 4,316 / 5,456 /
+// 11,092 words through levels 1-7), included for orientation only -- never a
+// pass/fail gate. The pinned upstream source's own per-level cumulative
+// counts land within ~2% of these (it is a CC-CEDICT + word-frequency
+// compilation, not a verbatim transcription of the official blueprint),
+// which is close enough to confirm the level mapping without asserting
+// exact parity with it.
+import { MANDARIN_SOURCE_COMMIT, MANDARIN_SOURCE_REPO_URL } from './mandarin'
+
+export type MandarinProficiencyLevel = {
+  level: number
+  label: string
+  /** HSK 3.0's own published cumulative vocabulary size through this level. Informational only. */
+  referenceCumulativeVocabulary: number
+}
+
+export type MandarinProficiencyStandard = {
+  id: string
+  label: string
+  levels: MandarinProficiencyLevel[]
+  sourceLabel: string
+  sourceUrl: string
+  sourceCommit: string
+}
+
+const HSK_3_LEVELS: MandarinProficiencyLevel[] = [
+  { level: 1, label: 'HSK 3.0 Level 1', referenceCumulativeVocabulary: 500 },
+  { level: 2, label: 'HSK 3.0 Level 2', referenceCumulativeVocabulary: 1_272 },
+  { level: 3, label: 'HSK 3.0 Level 3', referenceCumulativeVocabulary: 2_245 },
+  { level: 4, label: 'HSK 3.0 Level 4', referenceCumulativeVocabulary: 3_245 },
+  { level: 5, label: 'HSK 3.0 Level 5', referenceCumulativeVocabulary: 4_316 },
+  { level: 6, label: 'HSK 3.0 Level 6', referenceCumulativeVocabulary: 5_456 },
+  {
+    level: 7,
+    label: 'HSK 3.0 Levels 7-9 (advanced band)',
+    referenceCumulativeVocabulary: 11_092,
+  },
+]
+
+export const HSK_3_STANDARD: MandarinProficiencyStandard = {
+  id: 'hsk-3.0',
+  label: 'HSK 3.0 (2021 revision)',
+  levels: HSK_3_LEVELS,
+  sourceLabel: 'HSK Vocabulary / CC-CEDICT compilation',
+  sourceUrl: MANDARIN_SOURCE_REPO_URL,
+  sourceCommit: MANDARIN_SOURCE_COMMIT,
+}
+
+/** All standards this product knows how to report coverage against. */
+export const MANDARIN_PROFICIENCY_STANDARDS: MandarinProficiencyStandard[] = [
+  HSK_3_STANDARD,
+]
+
+/** The standard the live catalog is currently built from and measured against. */
+export const DEFAULT_MANDARIN_PROFICIENCY_STANDARD = HSK_3_STANDARD

--- a/utils/scripts/auditMandarinProficiencyCoverage.ts
+++ b/utils/scripts/auditMandarinProficiencyCoverage.ts
@@ -1,0 +1,255 @@
+// /utils/scripts/auditMandarinProficiencyCoverage.ts
+//
+// mandarin-tutor/t-008: reports catalog coverage against the currently
+// applicable Mandarin proficiency standard (HSK 3.0 by default -- see
+// utils/mandarinProficiencyStandards.ts). Checks live in
+// utils/mandarinProficiencyCoverage.ts (pure, no I/O); this file supplies
+// data to them two ways, matching utils/scripts/auditMandarinCatalog.ts's
+// established shape:
+//
+//   npm run audit:mandarin-proficiency-coverage
+//     Live report: fetches the served catalog (GET /api/mandarin) plus the
+//     pinned upstream source's raw per-level entry counts, for every level
+//     of the standard -- including levels the catalog does not source yet.
+//
+//   npm run audit:mandarin-proficiency-coverage -- --strict
+//     Exits 1 if a SOURCED level's card count is under half its reference
+//     size (a genuine regression). Never fails on an unsourced level --
+//     that is expected, measured future work, not a defect.
+//
+//   npm run test:mandarin-proficiency-coverage-selftest
+//     --self-test: a fixed in-memory fixture, no network, no database --
+//     this is the one CI runs.
+import type { MandarinCard, MandarinCatalogPayload } from '../mandarin'
+import {
+  computeMandarinProficiencyCoverage,
+  type MandarinProficiencyCoverageReport,
+} from '../mandarinProficiencyCoverage'
+import {
+  DEFAULT_MANDARIN_PROFICIENCY_STANDARD,
+  type MandarinProficiencyStandard,
+} from '../mandarinProficiencyStandards'
+
+const selfTest = process.argv.includes('--self-test')
+const strict = process.argv.includes('--strict')
+const baseUrlArg = process.argv.find((arg) => arg.startsWith('--base-url='))
+const baseUrl = baseUrlArg
+  ? baseUrlArg.slice('--base-url='.length)
+  : (process.env.MANDARIN_AUDIT_BASE_URL ?? 'https://kindrobots.org')
+
+/* -------------------------------------------------------------------------- */
+/* self-test -- the check logic, provable without a database or the network   */
+/* -------------------------------------------------------------------------- */
+
+function fixtureCard(overrides: Partial<MandarinCard>): MandarinCard {
+  return {
+    key: 'fixture:x',
+    simplified: 'x',
+    pinyin: 'xie',
+    meaning: 'placeholder',
+    meanings: ['placeholder'],
+    kind: 'word',
+    partsOfSpeech: [],
+    classifiers: [],
+    categories: [],
+    components: [],
+    historyStatus: 'pending',
+    source: { label: 'fixture', version: 'fixture' },
+    ...overrides,
+  }
+}
+
+if (selfTest) {
+  const failures: string[] = []
+
+  const cards: MandarinCard[] = [
+    fixtureCard({
+      key: 'l1-a',
+      hskLevel: 1,
+      historyStatus: 'starter',
+      components: [{ glyph: 'x', role: 'radical', label: 'r' }],
+    }),
+    fixtureCard({ key: 'l1-b', hskLevel: 1 }),
+    fixtureCard({ key: 'l2-a', hskLevel: 2 }),
+    fixtureCard({ key: 'no-level' }),
+  ]
+
+  const report = computeMandarinProficiencyCoverage(cards, {
+    upstreamCumulativeVocabulary: { 3: 2225 },
+  })
+
+  const byLevel = (level: number) =>
+    report.levels.find((entry) => entry.level === level)
+
+  const expectations: [boolean, string][] = [
+    [byLevel(1)?.sourced === true, 'level 1 should be sourced (has cards)'],
+    [byLevel(1)?.cardCount === 2, 'level 1 should count 2 cards'],
+    [
+      byLevel(1)?.withCharacterHistory === 1,
+      'level 1 should count 1 card with character history',
+    ],
+    [
+      byLevel(1)?.withComponentBreakdown === 1,
+      'level 1 should count 1 card with a component breakdown',
+    ],
+    [byLevel(2)?.sourced === true, 'level 2 should be sourced'],
+    [byLevel(3)?.sourced === false, 'level 3 should not be sourced (no cards)'],
+    [
+      byLevel(3)?.upstreamCumulativeVocabulary === 2225,
+      'level 3 should carry the supplied upstream count',
+    ],
+    [byLevel(7)?.sourced === false, 'level 7 should not be sourced'],
+    [
+      report.totals.cardsWithLevel === 3,
+      'totals.cardsWithLevel should count the 3 leveled cards',
+    ],
+    [
+      report.totals.cardsWithoutLevel === 1,
+      'totals.cardsWithoutLevel should count the 1 unleveled card',
+    ],
+    [
+      report.totals.sourcedLevelCount === 2,
+      'totals.sourcedLevelCount should be 2 (levels 1 and 2)',
+    ],
+    [
+      report.totals.totalLevelCount ===
+        DEFAULT_MANDARIN_PROFICIENCY_STANDARD.levels.length,
+      'totalLevelCount should match the standard',
+    ],
+    [
+      report.nextTargets.length ===
+        report.totals.totalLevelCount - report.totals.sourcedLevelCount,
+      'nextTargets should list every unsourced level',
+    ],
+    [
+      report.nextTargets[0]?.includes('Level 3') === true,
+      'the lowest unsourced level should sort first',
+    ],
+  ]
+
+  for (const [passed, message] of expectations) {
+    if (!passed) failures.push(message)
+  }
+
+  if (failures.length) {
+    console.error('❌ Mandarin proficiency-coverage self-test FAILED:')
+    for (const failure of failures) console.error(`  - ${failure}`)
+    process.exit(1)
+  }
+
+  console.log(
+    `✅ Mandarin proficiency-coverage self-test passed (${expectations.length} checks).`,
+  )
+  process.exit(0)
+}
+
+/* -------------------------------------------------------------------------- */
+/* live report                                                                */
+/* -------------------------------------------------------------------------- */
+
+type CatalogResponse = {
+  success: boolean
+  message?: string
+  data: MandarinCatalogPayload | null
+}
+
+async function fetchLiveCatalog(): Promise<MandarinCatalogPayload> {
+  const url = `${baseUrl.replace(/\/$/, '')}/api/mandarin`
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`GET ${url} -> HTTP ${response.status}`)
+  }
+  const body = (await response.json()) as CatalogResponse
+  if (!body.success || !body.data) {
+    throw new Error(
+      `GET ${url} responded without a usable catalog: ${body.message ?? 'no message'}`,
+    )
+  }
+  return body.data
+}
+
+// The upstream source's per-level files are plain static JSON served over
+// HTTPS -- reachable directly, same as server/utils/mandarinCatalog.ts's own
+// fetchLevel, just without the Nuxt-only $fetch helper (this runs as a plain
+// tsx process, not inside Nitro).
+async function fetchUpstreamCumulativeCount(
+  standard: MandarinProficiencyStandard,
+  level: number,
+): Promise<number | undefined> {
+  const repoPath = standard.sourceUrl.replace('https://github.com/', '')
+  const url = `https://raw.githubusercontent.com/${repoPath}/${standard.sourceCommit}/wordlists/inclusive/new/${level}.min.json`
+  try {
+    const response = await fetch(url)
+    if (!response.ok) return undefined
+    const entries = (await response.json()) as unknown
+    return Array.isArray(entries) ? entries.length : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function printReport(report: MandarinProficiencyCoverageReport): void {
+  const output = {
+    generatedAt: new Date().toISOString(),
+    mode: strict ? 'strict' : 'report',
+    standard: report.standard,
+    levels: report.levels,
+    totals: report.totals,
+    nextTargets: report.nextTargets,
+  }
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+}
+
+async function main(): Promise<void> {
+  const standard = DEFAULT_MANDARIN_PROFICIENCY_STANDARD
+
+  const [catalog, upstreamCounts] = await Promise.all([
+    fetchLiveCatalog(),
+    Promise.all(
+      standard.levels.map(
+        async (levelMeta) =>
+          [
+            levelMeta.level,
+            await fetchUpstreamCumulativeCount(standard, levelMeta.level),
+          ] as const,
+      ),
+    ),
+  ])
+
+  const upstreamCumulativeVocabulary = Object.fromEntries(
+    upstreamCounts.filter(
+      (entry): entry is [number, number] => typeof entry[1] === 'number',
+    ),
+  ) as Partial<Record<number, number>>
+
+  const report = computeMandarinProficiencyCoverage(catalog.cards, {
+    standard,
+    upstreamCumulativeVocabulary,
+  })
+
+  printReport(report)
+
+  if (strict) {
+    const regressions = report.levels.filter(
+      (entry) =>
+        entry.sourced &&
+        typeof entry.referenceCumulativeVocabulary === 'number' &&
+        entry.cardCount < entry.referenceCumulativeVocabulary / 2,
+    )
+    if (regressions.length) {
+      throw new Error(
+        `Strict Mandarin proficiency-coverage check failed: ${regressions
+          .map(
+            (entry) =>
+              `${entry.label} has ${entry.cardCount} cards, under half its ${entry.referenceCumulativeVocabulary}-word reference size`,
+          )
+          .join('; ')}.`,
+      )
+    }
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
### Task
mandarin-tutor/t-008: Map the curriculum to official Mandarin proficiency tests (kind: software)

### What changed / what I produced
- `utils/mandarinProficiencyStandards.ts` — proficiency-standard metadata. Records HSK 3.0 (the standard that replaced HSK 1-6 in 2021) as the standard the product currently targets, with its 7 official cumulative levels and their published reference vocabulary sizes. Designed as an array (`MANDARIN_PROFICIENCY_STANDARDS`) so a second standard/revision can be added later without restructuring callers — "track source/version-specific proficiency metadata rather than baking one exam revision into the product," per the task note.
- `utils/mandarinProficiencyCoverage.ts` — pure, DB-free coverage-report computation. For each official level: whether it's sourced (derived from the cards themselves, so it can't drift from what `server/utils/mandarinCatalog.ts` actually fetches), card count, cards with component/character-history depth, and reference/upstream vocabulary sizes. Produces an ordered `nextTargets` list — concrete, measurable next levels to target, not an arbitrary card count.
- `utils/scripts/auditMandarinProficiencyCoverage.ts` — CLI wrapper, matching `auditMandarinCatalog.ts`'s established shape: `--self-test` (fixture, no I/O — wired into `contract-tests.yml`), a live mode that fetches `GET /api/mandarin` plus the pinned upstream source's raw per-level entry counts (including levels not yet ingested, so gaps are measured against real availability, not guesswork), and `--strict` (fails only on a genuine regression in an already-sourced level).
- Hoisted `MANDARIN_SOURCE_COMMIT`/`MANDARIN_SOURCE_REPO_URL` out of `server/utils/mandarinCatalog.ts`'s local constant into `utils/mandarin.ts` as the single source of truth, so the new standard's `sourceCommit` metadata and the actual fetch URL can never drift apart.

### Live finding (ran against production)
Only HSK levels 1–2 of 7 are currently sourced (1,256 leveled cards). Levels 3–7 are fully available upstream from the already-pinned source (2,225 / 3,197 / 4,258 / 5,384 / 10,993 cumulative entries respectively) and simply not yet ingested — the report's `nextTargets` names them in order. That's the measurable gap the task asked for.

### How I verified
- `npm run test:mandarin-proficiency-coverage-selftest` — passes (14 fixture checks).
- `npx eslint` on all touched/new files — clean.
- `npx vue-tsc --noEmit` — clean, full repo.
- `npx prettier --check` — clean on all touched/new files (confirmed via `git stash` that the two pre-existing prettier warnings in `utils/mandarin.ts` / `server/utils/mandarinCatalog.ts` predate this change and aren't a regression).
- Ran the live CLI against `https://kindrobots.org` — produced the coverage report above.
- `npm run test:mandarin-content-audit` (pre-existing, unrelated self-test) still passes.

### Stakes
Reversible — new files plus a small, behavior-preserving constant hoist. No schema change, no runtime behavior change to the served catalog.

### Kaizen suggestion
`test:mandarin-content-audit` (mandarin-tutor/t-011) documents itself as "the one CI runs" but isn't wired into any workflow — confirmed via grep across `.github/workflows/`. Left as-is (out of scope here) rather than silently expanding this PR; worth a follow-up task if it's not intentional.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4pHYbJsFD2unAF13zFXeH)_