### PR TITLE
mandarin-tutor/t-009: establish explicit Study vs Explore modes

### DIFF
--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -27,6 +27,37 @@
         <div class="rounded-2xl border border-base-300 bg-base-200/50 p-3 text-xs leading-relaxed opacity-80">
           Component roles are labeled separately from dictionary radicals. A radical is useful for indexing and pattern recognition, but it is not automatically the historical “meaning” of the whole character.
         </div>
+
+        <div class="join" role="tablist" aria-label="Interaction mode">
+          <button
+            type="button"
+            role="tab"
+            :aria-selected="interactionMode === 'study'"
+            class="btn join-item"
+            :class="interactionMode === 'study' ? 'btn-primary' : 'btn-outline'"
+            @click="store.setInteractionMode('study')"
+          >
+            Study
+          </button>
+          <button
+            type="button"
+            role="tab"
+            :aria-selected="interactionMode === 'explore'"
+            class="btn join-item"
+            :class="interactionMode === 'explore' ? 'btn-primary' : 'btn-outline'"
+            @click="store.setInteractionMode('explore')"
+          >
+            Explore
+          </button>
+        </div>
+        <p class="text-xs leading-relaxed opacity-60">
+          <template v-if="interactionMode === 'study'">
+            Study is a deliberate recall loop: guess from the character, reveal, hear it, then rate yourself.
+          </template>
+          <template v-else>
+            Explore is for searching, browsing decomposition and history, and curating decks.
+          </template>
+        </p>
       </header>
 
       <div v-if="store.error" class="alert alert-error text-sm" role="alert">
@@ -39,7 +70,7 @@
       </div>
 
       <template v-else>
-        <section class="kr-panel-flat p-4 shadow-sm">
+        <section v-if="interactionMode === 'explore'" class="kr-panel-flat p-4 shadow-sm">
           <label class="form-control">
             <span class="label-text mb-1 font-semibold">Find a word, Hanzi, pinyin, or English meaning</span>
             <input
@@ -200,7 +231,7 @@
             </div>
 
             <article
-              v-if="currentCard"
+              v-if="interactionMode === 'explore' && currentCard"
               ref="cardPanel"
               class="scroll-mt-4 overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-xl"
             >
@@ -346,6 +377,66 @@
               </section>
             </article>
 
+            <article
+              v-else-if="interactionMode === 'study' && currentCard"
+              ref="cardPanel"
+              class="scroll-mt-4 overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-xl"
+            >
+              <div class="flex flex-col items-center gap-6 p-6 text-center sm:p-10">
+                <div class="flex flex-wrap items-center justify-center gap-2">
+                  <span v-if="currentCard.hskLevel" class="badge badge-outline">HSK {{ currentCard.hskLevel }}</span>
+                  <span class="badge badge-ghost">{{ studySessionRatedForSet }} rated this session</span>
+                </div>
+
+                <span class="text-8xl font-semibold leading-none">{{ currentCard.simplified }}</span>
+
+                <button
+                  v-if="studyPhase !== 'revealed'"
+                  type="button"
+                  class="btn btn-primary btn-lg"
+                  @click="store.revealStudyCard()"
+                >
+                  Reveal
+                </button>
+
+                <div v-else class="w-full max-w-md space-y-3">
+                  <div class="relative mx-auto flex h-40 w-40 items-center justify-center overflow-hidden rounded-3xl border border-base-300 bg-base-200/70 shadow-inner">
+                    <img
+                      v-if="store.illustrationUrl(currentCard.key)"
+                      :src="store.illustrationUrl(currentCard.key) || ''"
+                      :alt="`Study illustration for ${currentCard.meaning}`"
+                      class="h-full w-full object-cover"
+                    />
+                    <span v-else class="text-5xl font-semibold leading-none opacity-60">{{ currentCard.simplified }}</span>
+                  </div>
+                  <p class="text-2xl font-bold tracking-wide">{{ currentCard.pinyin }}</p>
+                  <p class="text-xl font-semibold">{{ currentCard.meaning }}</p>
+                  <p v-if="currentCard.meanings.length > 1" class="text-sm leading-relaxed opacity-65">
+                    {{ currentCard.meanings.slice(1).join(' · ') }}
+                  </p>
+                </div>
+              </div>
+
+              <MandarinVoiceCoach v-if="studyPhase === 'revealed'" :card="currentCard" />
+
+              <section v-if="studyPhase === 'revealed'" class="border-t border-base-300 p-5 sm:p-7">
+                <p class="mb-2 text-sm font-semibold">How well did you recall this?</p>
+                <div class="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                  <button type="button" class="btn btn-outline btn-error" @click="store.rateStudyCard('again')">Again</button>
+                  <button type="button" class="btn btn-outline btn-warning" @click="store.rateStudyCard('hard')">Hard</button>
+                  <button type="button" class="btn btn-outline btn-success" @click="store.rateStudyCard('good')">Good</button>
+                  <button type="button" class="btn btn-outline btn-accent" @click="store.rateStudyCard('easy')">Easy</button>
+                </div>
+                <p class="mt-2 text-xs leading-relaxed opacity-55">
+                  Ratings guide this session only for now — they are not yet scheduled into spaced repetition.
+                </p>
+              </section>
+
+              <section v-else class="border-t border-base-300 p-4 text-center">
+                <button type="button" class="btn btn-ghost btn-sm" @click="store.nextCard()">Skip for now</button>
+              </section>
+            </article>
+
             <div v-else class="kr-panel-flat p-8 text-center opacity-65">
               This set has no cards yet.
             </div>
@@ -381,6 +472,9 @@ const {
   loading,
   initialized,
   requestingWord,
+  interactionMode,
+  studyPhase,
+  studySessionRatedForSet,
 } = storeToRefs(store)
 
 const newSetName = ref('')

--- a/stores/mandarinTutorStore.ts
+++ b/stores/mandarinTutorStore.ts
@@ -18,6 +18,16 @@ type LocalState = {
   selectedSetId: string
   artJobs: Record<string, number>
   artImageIds: Record<string, number>
+  interactionMode?: InteractionMode
+}
+
+export type InteractionMode = 'study' | 'explore'
+export type StudyRating = 'again' | 'hard' | 'good' | 'easy'
+
+type StudySessionEntry = {
+  cardKey: string
+  rating: StudyRating
+  ratedAt: string
 }
 
 type ArtEnqueueData = {
@@ -104,6 +114,15 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
   const requestedCards = ref<MandarinRequestedCardData[]>([])
   const selectedSetId = ref('starter-500')
   const studyIndex = ref(0)
+  // Interaction mode: 'study' is the deliberate recall loop (challenge -> reveal ->
+  // pronunciation -> self-rating -> next); 'explore' is the prior all-purpose page
+  // (search, requested words, decomposition/history, provenance, deck curation).
+  // mandarin-tutor/t-009: establishes the mode split. `studySessionLog` below is a
+  // client-only, in-session record -- durable SRS scheduling and mastery-history
+  // persistence is deliberately deferred to a follow-up task (see that task's note).
+  const interactionMode = ref<InteractionMode>('study')
+  const studyPhase = ref<'challenge' | 'revealed'>('challenge')
+  const studySessionLog = ref<StudySessionEntry[]>([])
   const searchQuery = ref('')
   const focusKey = ref<string | null>(null)
   const focusKeys = ref<string[]>([])
@@ -207,9 +226,22 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
     () => import.meta.client && typeof Audio !== 'undefined',
   )
 
+  // In-session diagnostic only (not durable mastery history): how many distinct
+  // cards in the current set have been rated since the page loaded.
+  const studySessionRatedForSet = computed(() => {
+    const keys = new Set(studyCards.value.map((card) => card.key))
+    const rated = new Set(
+      studySessionLog.value
+        .filter((entry) => keys.has(entry.cardKey))
+        .map((entry) => entry.cardKey),
+    )
+    return rated.size
+  })
+
   function resetReveal() {
     meaningVisible.value = false
     detailsVisible.value = false
+    studyPhase.value = 'challenge'
     speechError.value = null
   }
 
@@ -220,6 +252,7 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
       selectedSetId: selectedSetId.value,
       artJobs: artJobs.value,
       artImageIds: artImageIds.value,
+      interactionMode: interactionMode.value,
     }
     localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
   }
@@ -239,6 +272,9 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
       }
       if (parsed.artImageIds && typeof parsed.artImageIds === 'object') {
         artImageIds.value = parsed.artImageIds
+      }
+      if (parsed.interactionMode === 'study' || parsed.interactionMode === 'explore') {
+        interactionMode.value = parsed.interactionMode
       }
     } catch {
       localStorage.removeItem(STORAGE_KEY)
@@ -500,6 +536,31 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
 
   function toggleDetails() {
     detailsVisible.value = !detailsVisible.value
+  }
+
+  function setInteractionMode(mode: InteractionMode) {
+    if (interactionMode.value === mode) return
+    interactionMode.value = mode
+    clearFocus()
+    resetReveal()
+    saveLocalState()
+  }
+
+  function revealStudyCard() {
+    if (interactionMode.value !== 'study' || !currentCard.value) return
+    studyPhase.value = 'revealed'
+  }
+
+  function rateStudyCard(rating: StudyRating) {
+    if (interactionMode.value !== 'study' || studyPhase.value !== 'revealed') return
+    const card = currentCard.value
+    if (!card) return
+    studySessionLog.value = [
+      ...studySessionLog.value,
+      { cardKey: card.key, rating, ratedAt: new Date().toISOString() },
+    ]
+    // nextCard() calls resetReveal(), which returns studyPhase to 'challenge'.
+    nextCard()
   }
 
   function createCustomSet(name: string): MandarinCustomSet | null {
@@ -839,6 +900,9 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
     requestedCards,
     selectedSetId,
     studyIndex,
+    interactionMode,
+    studyPhase,
+    studySessionLog,
     searchQuery,
     focusKey,
     focusKeys,
@@ -867,6 +931,7 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
     focusPosition,
     customSetCount,
     audioSupported,
+    studySessionRatedForSet,
     initialize,
     loadCatalog,
     loadIllustrationManifest,
@@ -879,6 +944,9 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
     clearFocus,
     toggleMeaning,
     toggleDetails,
+    setInteractionMode,
+    revealStudyCard,
+    rateStudyCard,
     createCustomSet,
     renameCustomSet,
     toggleCardInCustomSet,


### PR DESCRIPTION
### Task
mandarin-tutor/t-009: Add spaced repetition, mastery history, and study diagnostics (kind: software)

This PR lands the first, explicitly-sequenced slice of t-009 per the task's own note: "Establish explicit Study vs Explore modes before persisting SRS/mastery." Durable SRS scheduling, mastery-history persistence, and richer diagnostics are deferred to a follow-up task (filed alongside this PR).

### What changed / what I produced
- `stores/mandarinTutorStore.ts`: added `interactionMode` ('study' | 'explore', persisted to the existing localStorage blob), `studyPhase` ('challenge' | 'revealed'), and `studySessionLog` (in-memory only — not sent to the server). New actions `setInteractionMode`, `revealStudyCard`, `rateStudyCard`. `resetReveal()` now also resets `studyPhase`, so every existing navigation path (`selectSet`, `nextCard`, `previousCard`, `focusCard`, `clearFocus`) already returns Study mode to the challenge phase for free.
- `pages/play/mandarin.vue`: added a Study/Explore tab toggle in the header. Explore keeps the exact prior markup and behavior (search, requested-word creation, full card with Previous/Next, "Parts & history", deck curation) — gated behind `interactionMode === 'explore'` but otherwise byte-identical. Study is a new, separate card view: the Hanzi character only, a "Reveal" button, then (once revealed) pinyin/illustration/meaning, the existing `MandarinVoiceCoach` pronunciation-practice component, and four self-rating buttons (Again/Hard/Good/Easy) that log the rating and advance to the next card. A lightweight "N rated this session" badge is shown as an in-session diagnostic.

### How I verified
- `npx eslint pages/play/mandarin.vue stores/mandarinTutorStore.ts` — clean.
- `npx vue-tsc --noEmit` — clean, full repo.
- `npx prettier --check` on both changed files shows pre-existing warnings confirmed present on baseline `main` too (via `git stash`), not a regression.
- `npm run test:layout-contract` — holds, 0 new violations (the pre-existing `video-lora-picker.vue` baseline-ratchet note is unrelated/untouched).
- `npm run test:mandarin-content-audit` and `npm run test:mandarin-proficiency-coverage-selftest` — both pass unchanged.

### Stakes
reversible — new client-only interaction state, no schema change, no new persistence, Explore mode's behavior is unchanged.

### Flags for Reviewer
- Self-ratings are intentionally NOT persisted to the server yet — `studySessionLog` lives only in the Pinia store for the current page load. The task's own note explicitly sequences "modes first, persistence second," so I scoped this pass to the mode split and interaction loop only.
- Default `interactionMode` is `'study'` (the primary learning loop for a page named "Mandarin Tutor"); it persists per-browser via the existing localStorage blob once changed.

### Kaizen suggestion
None new — the natural next step is already the follow-up task filed alongside this PR (persist ratings into real SRS scheduling + mastery history, replacing `studySessionLog`).

### Notes for reviewer
Safe to merge on green CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3WVkCHNeASwBkrehKaZcm)_