### PR TITLE
mandarin-tutor/t-017: add self-test coverage for mandarinTutorStore's cloud-state merge logic

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -100,6 +100,9 @@ jobs:
       - name: Mandarin proficiency-coverage contract
         run: npm run test:mandarin-proficiency-coverage-selftest
 
+      - name: Mandarin cloud-state merge contract
+        run: npm run test:mandarin-cloud-merge-selftest
+
       - name: Reaction route auth contract
         run: npm run test:reaction-route-auth
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "audit:mandarin-proficiency-coverage": "tsx utils/scripts/auditMandarinProficiencyCoverage.ts",
     "test:mandarin-proficiency-coverage-selftest": "tsx utils/scripts/auditMandarinProficiencyCoverage.ts --self-test",
     "test:mandarin-srs-selftest": "tsx utils/scripts/verifyMandarinSrs.test.ts",
+    "test:mandarin-cloud-merge-selftest": "tsx utils/scripts/verifyMandarinCloudMerge.test.ts",
     "audit:checkpoints": "prisma generate && tsx utils/scripts/auditCheckpointResources.ts",
     "repair:checkpoints": "prisma generate && tsx utils/scripts/repairCheckpointResources.ts",
     "audit:facet-data": "prisma generate && tsx utils/scripts/auditFacetCatalogData.ts",

--- a/stores/mandarinTutorStore.ts
+++ b/stores/mandarinTutorStore.ts
@@ -8,6 +8,7 @@ import type {
   MandarinCustomSet,
   MandarinStudySet,
 } from '@/utils/mandarin'
+import { mergeArtJobs, mergeCustomSets } from '@/utils/mandarinCloudMerge'
 
 const STORAGE_KEY = 'kind-robots:mandarin-tutor:v1'
 const CANONICAL_ART_RECIPE = 'v2'
@@ -539,23 +540,19 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
       )
       if (!response.success || !response.data) return
 
-      const serverSets = response.data.sets ?? []
-      const serverSetIds = new Set(serverSets.map((set) => set.id))
-      const unsyncedLocalSets = customSets.value.filter(
-        (set) => !serverSetIds.has(set.id),
+      const setsResult = mergeCustomSets(
+        response.data.sets ?? [],
+        customSets.value,
       )
-      customSets.value = [...serverSets, ...unsyncedLocalSets]
-      for (const set of unsyncedLocalSets) void persistCustomSet(set)
+      customSets.value = setsResult.merged
+      for (const set of setsResult.unsynced) void persistCustomSet(set)
 
-      const serverArtJobs = response.data.artJobs ?? {}
-      const unsyncedLocalArtJobs = Object.entries(artJobs.value).filter(
-        ([cardKey]) => !(cardKey in serverArtJobs),
+      const artJobsResult = mergeArtJobs(
+        response.data.artJobs ?? {},
+        artJobs.value,
       )
-      artJobs.value = {
-        ...serverArtJobs,
-        ...Object.fromEntries(unsyncedLocalArtJobs),
-      }
-      for (const [cardKey, jobId] of unsyncedLocalArtJobs)
+      artJobs.value = artJobsResult.merged
+      for (const [cardKey, jobId] of artJobsResult.unsynced)
         void persistArtJobLink(cardKey, jobId)
 
       saveLocalState()

--- a/utils/mandarinCloudMerge.ts
+++ b/utils/mandarinCloudMerge.ts
@@ -1,0 +1,64 @@
+// /utils/mandarinCloudMerge.ts
+//
+// mandarin-tutor/t-017. Pure extraction of `mandarinTutorStore.loadCloudState`'s
+// merge semantics, so the rule "server is authoritative, but a local-only
+// customSet/artJob the server doesn't know about yet is kept and re-pushed
+// rather than dropped" is checkable without Pinia, Nuxt, or a real backend --
+// same discipline as `server/utils/mandarinSrs.ts` / `verifyMandarinSrs.test.ts`.
+//
+// The store itself (`stores/mandarinTutorStore.ts`) calls these two functions
+// and re-pushes whatever comes back in `unsynced`; it does not duplicate the
+// merge logic inline any more.
+
+import type { MandarinCustomSet } from './mandarin'
+
+export type MandarinCustomSetMergeResult = {
+  /** Server sets first, followed by any local-only sets the server hasn't seen. */
+  merged: MandarinCustomSet[]
+  /** Local-only sets that need to be persisted to the server. */
+  unsynced: MandarinCustomSet[]
+}
+
+/**
+ * Merge a learner's server-side customSets with whatever is already in local
+ * state. A set present on the server always wins for that id -- the server
+ * copy is authoritative and a local edit made on another device is exactly
+ * what `persistCustomSet` is for, not this merge. A set the server has never
+ * seen (created offline, or on a device that hasn't synced yet) is kept
+ * rather than silently dropped, and reported back in `unsynced` so the caller
+ * can re-push it.
+ */
+export function mergeCustomSets(
+  serverSets: MandarinCustomSet[],
+  localSets: MandarinCustomSet[],
+): MandarinCustomSetMergeResult {
+  const serverIds = new Set(serverSets.map((set) => set.id))
+  const unsynced = localSets.filter((set) => !serverIds.has(set.id))
+  return { merged: [...serverSets, ...unsynced], unsynced }
+}
+
+export type MandarinArtJobMergeResult = {
+  /** Server links first, with any local-only cardKey -> jobId entries layered on top. */
+  merged: Record<string, number>
+  /** Local-only [cardKey, jobId] pairs the server doesn't have yet. */
+  unsynced: Array<[string, number]>
+}
+
+/**
+ * Merge a learner's server-side art-job links (cardKey -> ArtJob id) with
+ * local state. A cardKey the server already links wins its server value
+ * (same authoritative-server rule as customSets). A cardKey only known
+ * locally is kept and reported in `unsynced` for re-push.
+ */
+export function mergeArtJobs(
+  serverArtJobs: Record<string, number>,
+  localArtJobs: Record<string, number>,
+): MandarinArtJobMergeResult {
+  const unsynced = Object.entries(localArtJobs).filter(
+    ([cardKey]) => !(cardKey in serverArtJobs),
+  )
+  return {
+    merged: { ...serverArtJobs, ...Object.fromEntries(unsynced) },
+    unsynced,
+  }
+}

--- a/utils/scripts/verifyMandarinCloudMerge.test.ts
+++ b/utils/scripts/verifyMandarinCloudMerge.test.ts
@@ -1,0 +1,119 @@
+// /utils/scripts/verifyMandarinCloudMerge.test.ts
+//
+// Regression test for mandarin-tutor/t-017, covering
+// utils/mandarinCloudMerge.ts -- the merge rules `mandarinTutorStore.loadCloudState`
+// (mandarin-tutor/t-016) relies on to keep a learner's customSets/artJobs
+// consistent once the server becomes reachable. Pure functions only -- no
+// prisma, no database, no Nuxt/Pinia runtime -- same discipline as
+// utils/scripts/verifyMandarinSrs.test.ts.
+import assert from 'node:assert/strict'
+
+import { mergeArtJobs, mergeCustomSets } from '../mandarinCloudMerge'
+import type { MandarinCustomSet } from '../mandarin'
+
+function makeSet(id: string, name: string): MandarinCustomSet {
+  return { id, name, cardKeys: [], createdAt: '2026-08-26T00:00:00.000Z' }
+}
+
+// --- mergeCustomSets ---------------------------------------------------------
+
+{
+  // Server-only sets pass through untouched: nothing local to merge, nothing
+  // to re-push.
+  const server = [makeSet('s1', 'Server Set')]
+  const result = mergeCustomSets(server, [])
+  assert.deepEqual(result.merged, server)
+  assert.deepEqual(result.unsynced, [])
+}
+
+{
+  // A local-only set the server has never seen is kept, ordered after the
+  // server's sets, and reported for re-push.
+  const server = [makeSet('s1', 'Server Set')]
+  const local = [makeSet('local-only', 'Offline Set')]
+  const result = mergeCustomSets(server, local)
+  assert.deepEqual(result.merged, [...server, ...local])
+  assert.deepEqual(result.unsynced, local)
+}
+
+{
+  // A set present on both sides prefers the server's value -- even if the
+  // local copy has a different name, the server row for that id wins and is
+  // NOT reported as needing a re-push.
+  const server = [makeSet('shared', 'Server Name')]
+  const local = [makeSet('shared', 'Stale Local Name')]
+  const result = mergeCustomSets(server, local)
+  assert.deepEqual(result.merged, server)
+  assert.equal(
+    result.merged[0]?.name,
+    'Server Name',
+    'server copy must win over a stale local copy with the same id',
+  )
+  assert.deepEqual(
+    result.unsynced,
+    [],
+    'a server-known id must not be re-pushed',
+  )
+}
+
+{
+  // Mixed: one shared id (server wins, no re-push) plus one local-only id
+  // (kept and re-pushed), in one merge.
+  const server = [makeSet('shared', 'Server Name'), makeSet('s2', 'Server Two')]
+  const local = [
+    makeSet('shared', 'Stale Local Name'),
+    makeSet('local-only', 'Offline Set'),
+  ]
+  const result = mergeCustomSets(server, local)
+  assert.deepEqual(result.merged, [
+    ...server,
+    makeSet('local-only', 'Offline Set'),
+  ])
+  assert.deepEqual(result.unsynced, [makeSet('local-only', 'Offline Set')])
+}
+
+// --- mergeArtJobs -------------------------------------------------------------
+
+{
+  // Server-only links pass through untouched.
+  const server = { 'card-1': 101 }
+  const result = mergeArtJobs(server, {})
+  assert.deepEqual(result.merged, server)
+  assert.deepEqual(result.unsynced, [])
+}
+
+{
+  // A local-only cardKey the server doesn't know about is kept and reported
+  // for re-push.
+  const server = { 'card-1': 101 }
+  const local = { 'card-2': 202 }
+  const result = mergeArtJobs(server, local)
+  assert.deepEqual(result.merged, { 'card-1': 101, 'card-2': 202 })
+  assert.deepEqual(result.unsynced, [['card-2', 202]])
+}
+
+{
+  // A cardKey present on both sides prefers the server's jobId, and is not
+  // re-pushed.
+  const server = { 'card-1': 101 }
+  const local = { 'card-1': 999 }
+  const result = mergeArtJobs(server, local)
+  assert.deepEqual(result.merged, { 'card-1': 101 })
+  assert.deepEqual(result.unsynced, [])
+}
+
+{
+  // Mixed: one shared cardKey (server wins) plus one local-only cardKey
+  // (kept and re-pushed), in one merge.
+  const server = { 'card-1': 101, 'card-3': 303 }
+  const local = { 'card-1': 999, 'card-2': 202 }
+  const result = mergeArtJobs(server, local)
+  assert.deepEqual(result.merged, {
+    'card-1': 101,
+    'card-3': 303,
+    'card-2': 202,
+  })
+  assert.deepEqual(result.unsynced, [['card-2', 202]])
+}
+
+console.log('verifyMandarinCloudMerge: all assertions passed')


### PR DESCRIPTION
### Task
mandarin-tutor/t-017: Add self-test coverage for `mandarinTutorStore`'s cloud-state merge logic (kind: software)

### What changed / what I produced
- Extracted `loadCloudState`'s merge rules into pure, testable functions in `utils/mandarinCloudMerge.ts`: `mergeCustomSets` and `mergeArtJobs`. Both implement the same rule — server state is authoritative for any id/cardKey it knows about, but a local-only entry the server hasn't seen yet is kept and reported back for re-push, never dropped.
- `stores/mandarinTutorStore.ts`'s `loadCloudState` now calls these two functions instead of doing the merge inline — no behavior change, same logic, just testable.
- Added `utils/scripts/verifyMandarinCloudMerge.test.ts` (pure-function, no DB, no Nuxt/Pinia runtime — matches `verifyMandarinSrs.test.ts`'s pattern) covering: server-only entries pass through untouched, local-only entries are preserved and trigger a re-push, entries present on both sides prefer the server's value, and a mixed case with both in one merge — for both customSets and artJobs.
- Wired the new selftest into `package.json` (`test:mandarin-cloud-merge-selftest`) and `.github/workflows/contract-tests.yml` alongside the other DB-free contract checks.

### How I verified
- `npx tsx utils/scripts/verifyMandarinCloudMerge.test.ts` — all assertions pass.
- Full `npm run test` (`vue-tsc --noEmit`, whole repo) — clean.
- `npx eslint` on all changed files — clean.
- `npx prettier --check` on all changed files — clean.
- `npm run test:no-promise-in-store-state` — still passes (105 stores checked).

### Stakes
reversible

### Notes for reviewer
No behavior change to `loadCloudState` itself — this is a pure refactor-for-testability plus new test coverage, per the task's own framing (kaizen from mandarin-tutor/t-016).

### Kaizen suggestion
`server/utils/mandarinCatalog.ts`'s cache-invalidation logic has similarly no dedicated self-test today; worth the same pure-extraction treatment if a future task touches it.


---
_Generated by [Claude Code](https://claude.ai/code/session_012LACNGNwLGuPZqUqckD1f6)_