### PR TITLE
cthulhuquarium: pre-expand Monster bestiary database

### DIFF
--- a/prisma/migrations/20260826045500_extend_monster_bestiary_fields/migration.sql
+++ b/prisma/migrations/20260826045500_extend_monster_bestiary_fields/migration.sql
@@ -1,0 +1,15 @@
+-- cthulhuquarium/t-042: expand the production database before the Prisma
+-- client starts selecting these fields. This is deliberately migration-only
+-- for the first rollout step so the currently deployed client remains fully
+-- compatible while Alexandria is prepared for the later schema/seed wiring.
+--
+-- Additive only: three nullable columns and one additional enum value.
+-- No DROP, rename, or existing data rewrite is requested here.
+
+ALTER TABLE `Monster`
+    ADD COLUMN `depth` INTEGER NULL,
+    ADD COLUMN `dietRole` VARCHAR(255) NULL,
+    ADD COLUMN `schoolRole` VARCHAR(255) NULL;
+
+ALTER TABLE `Monster`
+    MODIFY `evolutionKind` ENUM('GROWTH', 'BREEDING', 'SECRET') NULL;


### PR DESCRIPTION
## Purpose
First half of a safe expand-then-client rollout for Conductor `cthulhuquarium/t-042`.

This PR contains **only** the additive production migration. It intentionally does not change `schema.prisma`, generated Prisma client files, or seed code yet. That lets Alexandria apply the DB expansion while the currently serving app remains compatible, eliminating the client-before-column outage class that originally gated t-042.

Adds to `Monster`:
- nullable `depth` INT
- nullable `dietRole` VARCHAR(255)
- nullable `schoolRole` VARCHAR(255)
- `SECRET` as an allowed `evolutionKind` enum value

No DROP, rename, or application code change.

## Rollout
1. Merge only after exact-head CI is green.
2. Verify the merge SHA's GHCR production image publishes successfully.
3. On Alexandria, run the documented one-shot `scripts/prisma-migrate-deploy.mjs` from that exact `:latest` image using the dedicated migration credential.
4. Verify migration success.
5. Then land the already-preserved Prisma schema/seed wiring from #2103 on current main.

Do not use docker compose on Alexandria.