### PR TITLE
interface-vision/t-104: watchlist-browse.vue error banner -> kr-note kr-note-error

### DIFF
--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -448,10 +448,7 @@
 
       <!-- Results -->
       <div aria-live="polite" aria-atomic="true">
-        <div
-          v-if="errorMessage"
-          class="rounded-2xl border border-error/40 bg-error/10 p-4 text-sm text-error"
-        >
+        <div v-if="errorMessage" class="kr-note kr-note-error">
           {{ errorMessage }}
         </div>
 


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring)

### What changed / what I produced
- `components/watchlist/watchlist-browse.vue`: the results `v-if="errorMessage"` banner was hand-rolled as `rounded-2xl border border-error/40 bg-error/10 p-4 text-sm text-error`, missing only `font-semibold` from `kr-note-error`'s canonical shape (`assets/css/tailwind.css`: `.kr-note { rounded-2xl border p-4 text-sm font-semibold }` + `.kr-note-error { border-error/40 bg-error/10 text-error }`). `components/newsfeed/newsfeed-feed.vue` renders the identical structural pattern — same `errorMessage` variable name, same `aria-live="polite" aria-atomic="true"` wrapper, same `v-if="errorMessage"` div — via `class="kr-note kr-note-error"` (bold). So the same kind of inline error notice was rendering at two different font weights depending on which component displayed it: a real, live visual inconsistency, not blind dedup. Swapped to `class="kr-note kr-note-error"`. No geometry or behavior change (just drops the redundant hand-rolled classes and adds `font-semibold`).

### How I verified
- `npx vue-tsc --noEmit` — clean (full project)
- `npx eslint components/watchlist/watchlist-browse.vue` — clean
- `npx prettier --check components/watchlist/watchlist-browse.vue` — clean
- `npm run test:layout-contract` — holds, 0 new violations (an unrelated pre-existing 3-entry viewport-grid baseline improvement on `components/video-lora-picker.vue` was observed but left untouched, out of scope for this diff)
- `git diff --stat` — confirmed exactly 1 file changed, net -3 lines

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
This is slice 52 of the recurring consistency umbrella. Per slice 43's note, a future slice should widen the search beyond the exact `border-{status}/40 bg-{status}/10 p-4 text-{status}` shape (e.g. the `p-3`-padded variants, or components using `text-{status}` alone with no border/bg at all, like `watchlist-entry-detail.vue`'s `<p class="text-xs text-error">` — a genuinely different structural shape, not a byte-exact candidate, but worth a considered non-blind pass per slice 35's standing recommendation).

### Notes for reviewer
This closes out slice 39's flagged runner-up lead (`user-manager.vue`/`academy-manager.vue`) as already fixed by slice 40 — confirmed via the roadmap note history before starting this fresh search.


---
_Generated by [Claude Code](https://claude.ai/code/session_015cVdQmkBqHLreTfMQdqBdV)_