### PR TITLE
interface-vision/t-105: give Creator Earnings its first page header

### DIFF
--- a/components/pages/creator-earnings-page.vue
+++ b/components/pages/creator-earnings-page.vue
@@ -1,5 +1,20 @@
 <template>
   <div class="kr-unbound kr-container max-w-3xl p-6 space-y-8">
+    <header class="flex items-center gap-3">
+      <span
+        class="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-primary/15 text-primary"
+      >
+        <Icon name="kind-icon:coin" class="h-7 w-7" />
+      </span>
+      <div>
+        <p class="text-2xl font-black tracking-tight">Creator Earnings</p>
+        <p class="text-sm text-base-content/60">
+          What you've earned when someone spent tokens on something you made — a
+          Bot, Character, Facet, Scenario, Pitch, Art, Pack, Reward, or Dream.
+        </p>
+      </div>
+    </header>
+
     <div
       v-if="userStore.isGuest"
       class="rounded-2xl border border-accent/30 bg-(--kr-surface) p-6 text-center space-y-3"
@@ -13,11 +28,6 @@
     </div>
 
     <template v-else>
-      <p class="text-sm text-base-content/60">
-        What you've earned when someone spent tokens on something you made — a
-        Bot, Character, Facet, Scenario, Pitch, Art, Pack, Reward, or Dream.
-      </p>
-
       <div
         class="flex items-start gap-3 rounded-2xl border border-info/30 bg-info/10 p-4 text-sm text-base-content/75"
       >


### PR DESCRIPTION
Slice: polished `/creator-earnings` (Creator Earnings — read-only running total of what a user has earned when someone spent tokens on something they made). Prior state had no page header at all: guests saw a bare sign-in prompt, signed-in users saw a plain intro paragraph with no visual hierarchy.

Changes (`components/pages/creator-earnings-page.vue` only, template/classes, no script/store changes): adopted the established icon-badge + title/subtitle header pattern (`kind-icon:coin` badge, 2xl bold title, 60%-opacity subtitle) already used on `serendipity-page.vue`, `build-bench.vue`, and `mission-accrual-page.vue`. The existing intro paragraph's text ("What you've earned when someone spent tokens on something you made — a Bot, Character, Facet, Scenario, Pitch, Art, Pack, Reward, or Dream.") is folded into the subtitle rather than duplicated, matching the `mission-accrual-page.vue` slice's convention.

Verification: `eslint` clean, `vue-tsc --noEmit` clean, `npm run test:layout-contract` holds (0 new violations; a pre-existing `video-lora-picker.vue` viewport-grid baseline improvement was observed and left untouched, out of scope), `prettier --check` clean (fixed formatting drift my own edit introduced before committing).

Honest limit on visual verification: same sandbox constraints as every prior `interface-vision/t-105` slice (no reachable database, no PR-preview infrastructure since the Vercel migration) — only class-level/structural verification was possible pre-merge.

Conductor task: `interface-vision/t-105` (recurring page-polish umbrella).

---
🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M3rJvWvv9SzStx7vEG6BGa

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3rJvWvv9SzStx7vEG6BGa)_