### PR TITLE
brainstorm/t-022: accessibility/responsive/failure-state verification pass on the candidate workbench

### DIFF
--- a/components/brainstorm/brainstorm-candidate-card.vue
+++ b/components/brainstorm/brainstorm-candidate-card.vue
@@ -63,6 +63,7 @@
           </label>
           <input
             :id="`${candidate.id}-title`"
+            ref="editTitleInput"
             v-model="draftTitle"
             class="input input-bordered input-sm w-full font-bold"
             maxlength="120"
@@ -80,7 +81,7 @@
 
       <button
         type="button"
-        class="btn btn-ghost btn-xs shrink-0"
+        class="btn btn-ghost btn-xs h-auto min-h-11 min-w-11 shrink-0"
         :disabled="disabled"
         :aria-label="`Delete candidate${candidate.title ? ` ${candidate.title}` : ''}`"
         @click="emit('delete')"
@@ -106,7 +107,7 @@
         <div class="mt-2 flex flex-wrap justify-end gap-2">
           <button
             type="button"
-            class="btn btn-ghost btn-sm"
+            class="btn btn-ghost btn-sm h-auto min-h-11"
             :disabled="disabled"
             @click="cancelEdit"
           >
@@ -114,7 +115,7 @@
           </button>
           <button
             type="button"
-            class="btn btn-primary btn-sm"
+            class="btn btn-primary btn-sm h-auto min-h-11"
             :disabled="disabled || !draftText.trim()"
             @click="saveEdit"
           >
@@ -159,6 +160,15 @@
     >
       Art generation failed{{ artError ? `: ${artError}` : '.' }} Select for art
       and try again.
+    </p>
+
+    <p
+      v-if="artInterrupted"
+      class="kr-note kr-note-warning mt-3 text-xs"
+      data-testid="brainstorm-candidate-art-interrupted"
+    >
+      Art generation was still {{ candidate.meta.art?.status }} when this
+      session last closed. Select for art and generate again to pick it back up.
     </p>
 
     <details
@@ -293,7 +303,7 @@
     >
       <button
         type="button"
-        class="btn btn-sm"
+        class="btn btn-sm h-auto min-h-11"
         :class="candidate.status === 'kept' ? 'btn-success' : 'btn-ghost'"
         :disabled="disabled"
         @click="toggleKeep"
@@ -303,7 +313,7 @@
 
       <button
         type="button"
-        class="btn btn-sm"
+        class="btn btn-sm h-auto min-h-11"
         :class="candidate.status === 'rejected' ? 'btn-error' : 'btn-ghost'"
         :disabled="disabled"
         @click="toggleReject"
@@ -313,8 +323,9 @@
 
       <button
         v-if="!editing"
+        ref="editButton"
         type="button"
-        class="btn btn-ghost btn-sm"
+        class="btn btn-ghost btn-sm h-auto min-h-11"
         :disabled="disabled"
         @click="beginEdit"
       >
@@ -324,7 +335,7 @@
       <div class="ml-auto flex flex-wrap gap-2">
         <button
           type="button"
-          class="btn btn-outline btn-sm"
+          class="btn btn-outline btn-sm h-auto min-h-11"
           :disabled="disabled"
           @click="regenerate"
         >
@@ -336,7 +347,7 @@
         </button>
         <button
           type="button"
-          class="btn btn-secondary btn-sm"
+          class="btn btn-secondary btn-sm h-auto min-h-11"
           :disabled="disabled"
           @click="branch"
         >
@@ -366,7 +377,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { BRAINSTORM_RETURN_TYPES } from '@/types/brainstorm'
 import type {
   BrainstormCandidate,
@@ -402,6 +413,8 @@ const editing = ref(false)
 const draftTitle = ref(props.candidate.title)
 const draftText = ref(props.candidate.text)
 const feedbackDraft = ref(props.candidate.feedback)
+const editTitleInput = ref<HTMLInputElement | null>(null)
+const editButton = ref<HTMLButtonElement | null>(null)
 
 watch(
   () => props.candidate.title,
@@ -456,6 +469,19 @@ const artFailed = computed(
   () => !artBusy.value && props.candidate.meta.art?.status === 'failed',
 )
 const artError = computed(() => props.candidate.meta.art?.error || null)
+// A `queued`/`processing` status with nothing in *this* session actively
+// polling it (artBusy false) means an earlier attempt's poll loop was
+// interrupted -- most commonly a page reload or closed tab mid-generation.
+// Without this, the card renders identically to "art never requested",
+// silently orphaning the ArtJob instead of telling the user it needs a
+// manual retry (generateArtForCandidate's resumableJobId path only runs once
+// they select the candidate and generate again).
+const artInterrupted = computed(
+  () =>
+    !artBusy.value &&
+    (props.candidate.meta.art?.status === 'queued' ||
+      props.candidate.meta.art?.status === 'processing'),
+)
 
 const returnType = computed(() =>
   BRAINSTORM_RETURN_TYPES.find(
@@ -525,23 +551,33 @@ function toggleReject(): void {
   else emit('reject')
 }
 
-function beginEdit(): void {
+// The Edit button and the title input it swaps for both v-if out of the DOM
+// on their own side of the toggle, so a keyboard user's focus would
+// otherwise silently drop to <body> on every entry/exit -- explicitly move
+// it to whichever control just took that control's place instead.
+async function beginEdit(): Promise<void> {
   draftTitle.value = props.candidate.title
   draftText.value = props.candidate.text
   editing.value = true
+  await nextTick()
+  editTitleInput.value?.focus()
 }
 
-function cancelEdit(): void {
+async function cancelEdit(): Promise<void> {
   draftTitle.value = props.candidate.title
   draftText.value = props.candidate.text
   editing.value = false
+  await nextTick()
+  editButton.value?.focus()
 }
 
-function saveEdit(): void {
+async function saveEdit(): Promise<void> {
   const text = draftText.value.trim()
   if (!text) return
   emit('edit', { title: draftTitle.value.trim(), text })
   editing.value = false
+  await nextTick()
+  editButton.value?.focus()
 }
 
 function emitFeedback(): void {

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -784,12 +784,16 @@
     <div
       v-else-if="isBatchGenerating"
       class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,20rem),1fr))] gap-4"
+      role="status"
+      aria-live="polite"
       aria-label="Generating Brainstorm candidates"
     >
+      <span class="sr-only">Brainstorming a fresh batch of candidates…</span>
       <div
         v-for="index in skeletonCount"
         :key="index"
         class="kr-panel-flat min-h-56 animate-pulse border border-base-content/8 bg-base-100/75 p-5"
+        aria-hidden="true"
       >
         <div class="h-4 w-24 rounded bg-base-300" />
         <div class="mt-4 h-5 w-2/3 rounded bg-base-300" />


### PR DESCRIPTION
## What this covers

Task: `brainstorm/t-022` — "Run accessibility, responsive, failure-state, and preview verification pass" over the Brainstorm feature.

**Sandbox caveat, stated up front:** this environment has no way to visually preview a live PR or drive a headless browser (Vercel previews are retired repo-wide per `AGENTS.md`, and a headless-Chromium fallback is dead against this sandbox's network proxy). So the literal "verify at phone/tablet/desktop widths, direct load/refresh" instruction was not achievable here. What follows is what *is* achievable: reading the components end-to-end against the project's own layout/a11y contracts and fixing real gaps, not a visual/live-browser claim.

## Fixed (small, scoped)

- **`brainstorm-candidate-card.vue` — keyboard focus management.** Entering edit mode (`beginEdit`) and leaving it (`cancelEdit`/`saveEdit`) each `v-if` a control out of the DOM on one side of the toggle (the "Edit" button vs. the title input), so a keyboard user's focus was silently dropping to `<body>` on every entry/exit. Now focus moves into the title input on entry and back onto the Edit button on exit, via `nextTick()` + a template `ref`, following the existing pattern in `kr-search-field.vue`.
- **`brainstorm-candidate-card.vue` — touch targets.** Keep/Reject/Edit/Regenerate/Branch/Cancel-edit/Save-edit and the icon-only Delete button were 32px (`btn-sm`) or 24px (`btn-xs`, Delete) tall — under the ~44px touch-target convention already used elsewhere in this codebase for primary interactive controls (`channel-tab-list.vue`, `chat-gallery.vue`, `scenario-story.vue`, `art-generator.vue`'s `min-h-11`/`min-h-12`). Added `h-auto min-h-11` (and `min-w-11` for the icon-only Delete button) to match. Left the newer "Promote to Character" button's classes untouched — `verifyBrainstormWorkbench.mjs` pins its exact class string in a regex, and touching it wasn't in scope for this pass.
- **`brainstorm-candidate-card.vue` — orphaned ArtJob state.** A candidate's `meta.art.status` can persist as `queued`/`processing` from an interrupted session (reload/closed tab mid-generation) with nothing in the *new* session actively polling it. Before this fix that rendered identically to "art never requested" — a real dead end, since `generateArtForCandidate`'s resume path only runs once the user reselects the candidate and asks again, and nothing told them to. Added a warning note (mirroring the existing `artFailed` note) surfacing this.
- **`brainstorm-manager.vue` — loading-state announcement.** The batch-generating skeleton grid had an `aria-label` but no live region, so a screen-reader user got zero feedback that generation started until the result (or the error alert, which does have `role="alert"`) landed. Added `role="status" aria-live="polite"` plus a screen-reader-only status line, and marked the decorative skeleton placeholders `aria-hidden="true"` — matches the `role=status`/`aria-live` convention already used for loading states in `model-builder-manager.vue`.

## Verified for real (commands run, all pass)

- `npm run test` (`vue-tsc --noEmit`) — clean
- `npx eslint` on both touched files — clean
- `npx prettier --check` on both touched files — clean (note: `brainstorm-manager.vue` carries pre-existing `printWidth` drift on `main` outside the lines touched here, predating this PR — left as-is to keep the diff scoped)
- `npm run test:layout-contract` — holds, no new violations (the candidate grid already uses `grid-cols-[repeat(auto-fit,minmax(...))]` rather than viewport-breakpoint `grid-cols`, so it was already contract-compliant for phone/tablet/desktop)
- `npm run test:brainstorm-source-adapters`
- `npm run test:brainstorm-source-context`
- `npm run test:brainstorm-candidate-lifecycle`
- `npm run test:brainstorm-art-poll-failure-guard` and its selftest
- `node utils/scripts/verifyBrainstormWorkbench.mjs` (pins the Promote-to-Character button's exact class string — still passes)
- `node utils/scripts/verifyBrainstormStoreContract.mjs`
- `node utils/scripts/verifyBrainstormObjectEntryLinks.mjs`
- `npx tsx utils/scripts/verifyBrainstormGeneration.ts`
- `npx tsx utils/scripts/verifyBrainstormPersistence.ts`

## Read end-to-end, confirmed already handled (no code change needed)

Empty state; the error banner covering every `BrainstormErrorKind` (validation/auth/mana/server/provider/malformed/network) via `classifyError`; saved-session load/save/open with a distinct persistence-error banner; source/object-context resolve+search with request-identity tokens guarding against stale overwrites; regeneration and branch/promote lineage; revision history + restore; 1-result and max-result (`BRAINSTORM_MIN_RESULTS`/`BRAINSTORM_MAX_RESULTS`) batches via the auto-fit grid; and slow generation (the 60s `GENERATION_TIMEOUT_MS` collapses to the generic network-error banner rather than a stuck spinner).

## Not verifiable in this sandbox

No live browser or PR preview exists here. Actual rendered geometry at phone/390px, tablet/820px, and desktop/1440px widths (`npm run audit:responsive`), direct-load/refresh behavior, and Cypress were **not run** — this PR does not claim visual verification it didn't do. If a live check is wanted, `docs/contracts/responsive-layout-audit.md` documents `npm run audit:responsive` against a running dev server or the deployed app.

## A note on getting this pushed

This worktree's original local `main` was ~80 commits stale and had **no common ancestor** with the true `origin/main` (a disjoint history — `git merge-base` failed). A first attempt to `git rebase origin/main` produced spurious `add/add` conflicts across nearly the entire repo. Aborted that rebase, branched fresh off the actual `origin/main` tip, and reapplied this same diff there (re-verifying it against the current file content, which had since gained an unrelated "Promote to Character" feature) rather than merging/rebasing the stale history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRVwU9vnnNbS2794RzjRtb

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRVwU9vnnNbS2794RzjRtb)_