### PR TITLE
interface-vision/t-105: give Wallet its first page header

### DIFF
--- a/components/pages/wallet-page.vue
+++ b/components/pages/wallet-page.vue
@@ -1,5 +1,20 @@
 <template>
   <div class="kr-unbound kr-container max-w-3xl p-6 space-y-8">
+    <header class="flex items-center gap-3">
+      <span
+        class="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-primary/15 text-primary"
+      >
+        <Icon name="kind-icon:money" class="h-7 w-7" />
+      </span>
+      <div>
+        <p class="text-2xl font-black tracking-tight">Wallet</p>
+        <p class="text-sm text-base-content/60">
+          Your karma and mana balance — earned by contributing, spent to
+          create.
+        </p>
+      </div>
+    </header>
+
     <div
       v-if="userStore.isGuest"
       class="rounded-2xl border border-accent/30 bg-(--kr-surface) p-6 text-center space-y-3"


### PR DESCRIPTION
### Task
interface-vision/t-105: Polish every reachable Kind Robots surface page-by-page (kind: software)

### What changed / what I produced
- `components/pages/wallet-page.vue`: added the established icon-badge + title/subtitle header pattern (`kind-icon:money` badge, 2xl bold title "Wallet", 60%-opacity subtitle) matching the precedent already set on `serendipity-page.vue`/`build-bench.vue`/`mission-accrual-page.vue`/`creator-earnings-page.vue`. Prior state had no header at all — the guest sign-up card or karma balance section led straight into content, with the nested `mana-wallet.vue` component's own bare h1 the only heading on the page.
- Template/classes only, no script/store changes.

### How I verified
- `eslint` on the changed file: clean.
- `vue-tsc --noEmit`: clean.
- `npm run test:layout-contract`: holds, 0 new violations (the same pre-existing `video-lora-picker.vue` viewport-grid baseline improvement noted in prior slices was observed again and left untouched, out of scope).
- `prettier --check`: flags pre-existing drift on this file, confirmed via `git stash` to predate this change — left alone rather than reformatting unrelated lines.
- Honest limit on visual verification: this sandbox has no reachable database and kind_robots has no PR-preview infrastructure since the Vercel migration, so no rendered pre-merge screenshot was possible. What was verified is class-level/structural — the same header classes already render correctly in production on the four precedent pages, template type-checking, and the layout contract.

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
`mana-wallet.vue` (nested inside this page) has its own bare `⚡ {{username}}'s Mana Wallet` h1, which now sits below this page's new top-level header — a minor visual double-heading. Out of scope for this single-file slice; worth folding into a future t-105 slice if it reads awkwardly in production.

### Notes for reviewer
Recurring interface-vision/t-105 slice — conductor task returns to `ready` after this merges for the next visual-review slice.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AUZu3UH7PHCEkBZbUofNX5

---
_Generated by [Claude Code](https://claude.ai/code/session_01AUZu3UH7PHCEkBZbUofNX5)_