### PR TITLE
fix(ruler-hooked): make game reachable from Play navigation

### DIFF
--- a/content/channels/play/ruler-hooked.md
+++ b/content/channels/play/ruler-hooked.md
@@ -1,0 +1,14 @@
+---
+contentType: tab
+channelKey: play
+tabKey: ruler-hooked
+label: The Ruler Is Hooked
+title: The Ruler Is Hooked
+subtitle: Fish first. Govern eventually.
+description: A fishing-and-kingdom-management slideshow game where every interruption can reshape the shore.
+icon: kind-icon:crown
+route: /plan/projects/ruler-hooked
+sort: 140
+---
+
+Cast a line, dodge the paperwork, and live with what your kingdom becomes.

--- a/content/plan/projects/ruler-hooked.md
+++ b/content/plan/projects/ruler-hooked.md
@@ -6,8 +6,8 @@ description: A fishing-meets-kingdom-management slideshow sim of tides, catches,
 image: nav/heroes/games.webp
 icon: kind-icon:crown
 tooltip: Cast lines, land catches, and run a seaside kingdom.
-channelKey: plan
-tabKey: projects
+channelKey: play
+tabKey: ruler-hooked
 dashboardKey: wonder
 dashboardTab: ruler-hooked
 cards: navCards

--- a/utils/projectPlacements.ts
+++ b/utils/projectPlacements.ts
@@ -98,8 +98,8 @@ export const PROJECT_PLACEMENTS: Record<string, ProjectPlacement> = {
     route: '/plan/projects/coat-dance',
   },
   'ruler-hooked': {
-    channelKey: 'plan',
-    tabKey: 'projects',
+    channelKey: 'play',
+    tabKey: 'ruler-hooked',
     route: '/plan/projects/ruler-hooked',
   },
   newsfeed: {


### PR DESCRIPTION
### Task
Silas-directed Ruler Hooked discoverability fix (kind: software)

### What changed / what I produced
- Added a first-class **The Ruler Is Hooked** tab under the Play channel.
- Aligned the existing Ruler Hooked page metadata to `play/ruler-hooked`.
- Aligned `PROJECT_PLACEMENTS['ruler-hooked']` with that Play tab while preserving the existing `/plan/projects/ruler-hooked` route so existing links keep working.

### How I verified
- Compared the branch against `main`: exactly 3 files changed, 18 additions / 4 deletions, no gameplay code touched.
- CI/checks still need to complete on this PR before merge.

### Stakes
reversible

### Flags for Reviewer
- The broader Conductor audit found the project is marked `finished` against a PoC-sized goal even though the actual bucket-list game remains far from content/art complete. I am treating that reconciliation as separate coordination work rather than smuggling it into this navigation diff.

### Kaizen suggestion
Add a navigation contract asserting every user-facing playable project has a direct user-visible tab rather than only a generic project-planner placement.
