### PR TITLE
interface-vision/t-105: give Global Leaderboard a real header

### DIFF
--- a/components/pages/click-leaderboard.vue
+++ b/components/pages/click-leaderboard.vue
@@ -2,7 +2,19 @@
 <template>
   <div class="kr-surface">
     <div class="kr-scroll p-4">
-      <p class="text-xl font-bold mb-4">Global Leaderboard</p>
+      <header class="flex items-center gap-3 mb-4">
+        <span
+          class="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-primary/15 text-primary"
+        >
+          <Icon name="kind-icon:trophy" class="h-7 w-7" />
+        </span>
+        <div>
+          <p class="text-2xl font-black tracking-tight">Global Leaderboard</p>
+          <p class="text-sm text-base-content/60">
+            The highest click records ever recorded, ranked best to worst.
+          </p>
+        </div>
+      </header>
       <leaderboard-table
         :rows="leaderboard"
         score-label="Click Record"


### PR DESCRIPTION
### Task
interface-vision/t-105 (recurring): "Polish every reachable Kind Robots surface page-by-page." Next slice in the ongoing sweep after wallet-page.vue, mission-accrual-page.vue, build-bench.vue, creator-earnings-page.vue.

### What changed
`components/pages/click-leaderboard.vue` only, template/classes, no script/store changes. Prior state was a bare `text-xl font-bold` label with no icon, hierarchy, or subtitle. Added the established icon-badge + title/subtitle header pattern (`kind-icon:trophy` badge, 2xl bold title, 60%-opacity subtitle) already used on serendipity-page.vue/build-bench.vue/mission-accrual-page.vue/wallet-page.vue.

### Verification
- `eslint` on the changed file: clean
- `vue-tsc --noEmit`: clean
- `npm run test:layout-contract`: holds, zero new violations (the same pre-existing `video-lora-picker.vue` viewport-grid baseline improvement noted by several prior slices was observed again and left untouched, out of scope)
- `prettier --check`: clean

Honest limit on visual verification: this sandbox has no reachable database and kind_robots has no PR-preview infrastructure since the Vercel migration, so only class-level/structural verification was possible (same constraint every prior slice in this task has documented). The classes used already render correctly in production on the four precedent pages above.

### Kaizen suggestion
None beyond this task's scope — return the reusable page-polish task to `ready` for the next slice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cusgb5c8Dt4pGu6uLT8FHk)_