### PR TITLE
interface-vision/t-105: remove Wallet's double heading

### DIFF
--- a/components/giftshop/mana-wallet.vue
+++ b/components/giftshop/mana-wallet.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="kr-container max-w-3xl p-6 space-y-8">
-    <div class="text-center space-y-2">
+    <div v-if="showHeader" class="text-center space-y-2">
       <h1 class="text-3xl font-extrabold text-primary">
         ⚡ {{ userStore.username }}'s Mana Wallet
       </h1>
@@ -145,6 +145,8 @@
 import { onMounted } from 'vue'
 import { useManaStore } from '@/stores/manaStore'
 import { useUserStore } from '@/stores/userStore'
+
+withDefaults(defineProps<{ showHeader?: boolean }>(), { showHeader: true })
 
 const manaStore = useManaStore()
 const userStore = useUserStore()

--- a/components/pages/wallet-page.vue
+++ b/components/pages/wallet-page.vue
@@ -89,7 +89,7 @@
         </ul>
       </section>
 
-      <mana-wallet />
+      <mana-wallet :show-header="false" />
     </template>
   </div>
 </template>


### PR DESCRIPTION
Small follow-up flagged by the previous t-105 slice (#2129): `mana-wallet.vue`'s own bare "Mana Wallet" `h1` duplicated `wallet-page.vue`'s new top-level header when nested there.

**Changes:**
- Added a `showHeader` prop (default `true`) to `components/giftshop/mana-wallet.vue`, gated its own header behind it.
- `wallet-page.vue` now passes `:show-header="false"` since its own header already covers this.
- `giftshop-manager.vue`'s "mana" tab (the component's other consumer, which has no header of its own around it) is unaffected and keeps `mana-wallet`'s built-in header by default.

**Verification:** eslint clean; `vue-tsc --noEmit` clean; `npm run test:layout-contract` holds (0 new violations, including the contract's own `:show-header passed to a component that never declared it` check — the prop is properly declared); `prettier --check` flags pre-existing drift on `wallet-page.vue` confirmed via `git stash` to predate this change, left alone.

Conductor task: `interface-vision/t-105` (recurring page-polish task).

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8SXnS11ftwpybuLThVj5q)_