### PR TITLE
interface-vision/t-105: add icon-badge header to AppMaker

### DIFF
--- a/components/pages/appmaker-page.vue
+++ b/components/pages/appmaker-page.vue
@@ -4,12 +4,19 @@
 <template>
   <section class="kr-unbound kr-container space-y-6 p-4">
     <header class="flex flex-wrap items-center justify-between gap-3">
-      <div>
-        <p class="text-2xl font-bold">AppMaker</p>
-        <p class="text-sm opacity-70">
-          The app factory — every app is a workspace folder, a project roadmap,
-          and a Dream sharing one slug.
-        </p>
+      <div class="flex items-center gap-3">
+        <span
+          class="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-primary/15 text-primary"
+        >
+          <Icon name="kind-icon:toolbox" class="h-7 w-7" />
+        </span>
+        <div>
+          <p class="text-2xl font-black tracking-tight">AppMaker</p>
+          <p class="text-sm text-base-content/60">
+            The app factory — every app is a workspace folder, a project
+            roadmap, and a Dream sharing one slug.
+          </p>
+        </div>
       </div>
       <div class="flex items-center gap-2">
         <button class="btn btn-sm" :disabled="loading" @click="refresh">


### PR DESCRIPTION
### Task
interface-vision/t-105: Polish every reachable Kind Robots surface page-by-page (recurring page-polish task)

### What changed / what I produced
- `components/pages/appmaker-page.vue`: prior state had a bare `text-2xl font-bold` title with no icon or visual hierarchy — inconsistent with the established icon-badge + title/subtitle header pattern used across recent t-105 slices (`wallet-page.vue`, `build-bench.vue`, `mission-accrual-page.vue`, `creator-earnings-page.vue`, etc).
- Added the icon-badge (`kind-icon:toolbox` — the icon already assigned to AppMaker in `stores/helpers/conductorCards.ts`'s `CONDUCTOR_CARDS` registry), normalized title weight to `font-black tracking-tight` and subtitle color to `text-base-content/60` to match precedent.
- Template/classes only. Action buttons (Refresh, ← Workspace) and all script/store logic are unchanged.

### How I verified
- `npx eslint components/pages/appmaker-page.vue` — clean
- `npx vue-tsc --noEmit` — clean, full repo
- `npm run test:layout-contract` — holds, 0 new violations (same pre-existing `video-lora-picker.vue` viewport-grid baseline improvement noted by prior slices, left untouched, out of scope)
- `npx prettier --check components/pages/appmaker-page.vue` — clean

### Stakes
reversible — template/class-only change, no script or store logic touched.

### Notes for reviewer
Safe to merge on green CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzGnZkUSux7PDc2tbrJtTD)_