### PR TITLE
feat(ruler-hooked): make fantasy fish catchable

### DIFF
--- a/components/ruler-hooked/ruler-hooked-catch.vue
+++ b/components/ruler-hooked/ruler-hooked-catch.vue
@@ -1,0 +1,42 @@
+<template>
+  <section class="rounded-2xl border border-base-300 bg-base-200/70 p-4 shadow-sm">
+    <div class="flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <div class="flex flex-wrap items-center gap-2">
+          <span v-if="catchResult.newDiscovery" class="badge badge-primary badge-sm">NEW SPECIES</span>
+          <span class="badge badge-sm" :class="affinityClass">{{ catchResult.affinity }}</span>
+          <span class="badge badge-outline badge-sm">{{ catchResult.rarity }}</span>
+        </div>
+        <h3 class="mt-2 text-xl font-black">{{ catchResult.name }}</h3>
+        <p class="mt-1 text-sm opacity-75">{{ catchResult.catchBehavior }}</p>
+      </div>
+      <div class="text-right">
+        <p class="text-lg font-bold">{{ formatSize(catchResult.sizeCm) }}</p>
+        <p class="text-xs uppercase tracking-wide opacity-60">{{ catchResult.quality }} · {{ catchResult.qualityScore }}/100</p>
+      </div>
+    </div>
+
+    <div class="mt-3 rounded-xl bg-base-100/70 p-3 text-sm">
+      <p class="font-semibold">Fishopedia</p>
+      <p class="mt-1 opacity-80">{{ catchResult.fishopediaNote }}</p>
+      <p v-if="catchResult.newDiscovery" class="mt-2 text-xs opacity-65">{{ catchResult.consequenceReveal }}</p>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import type { CatchResult } from '~/types/ruler-hooked'
+
+const props = defineProps<{ catchResult: CatchResult }>()
+
+const affinityClass = computed(() => ({
+  GOOD: 'badge-success',
+  NEUTRAL: 'badge-ghost',
+  EVIL: 'badge-error',
+}[props.catchResult.affinity]))
+
+function formatSize(cm: number): string {
+  if (cm >= 100) return `${(cm / 100).toFixed(cm >= 1000 ? 1 : 2)} m`
+  return `${cm.toFixed(1)} cm`
+}
+</script>

--- a/components/ruler-hooked/ruler-hooked-fishopedia.vue
+++ b/components/ruler-hooked/ruler-hooked-fishopedia.vue
@@ -1,5 +1,5 @@
 <template>
-  <details class="collapse collapse-arrow rounded-2xl border border-base-300 bg-base-100">
+  <details class="fishopedia-shell collapse collapse-arrow rounded-2xl border border-base-300 bg-base-100">
     <summary class="collapse-title flex items-center justify-between gap-3 pr-12 font-bold">
       <span>📖 Fishopedia</span>
       <span class="badge badge-outline">{{ discoveredCount }}/{{ roster.length }} discovered</span>
@@ -10,7 +10,7 @@
         Unknown species stay hidden until caught. Discovered entries remember your best specimen and why that creature could exist in this reign.
       </p>
 
-      <div class="grid gap-3 sm:grid-cols-2">
+      <div class="fishopedia-grid grid gap-3">
         <article
           v-for="fish in roster"
           :key="fish.slug"
@@ -77,3 +77,19 @@ function formatSize(cm: number): string {
   return `${cm.toFixed(1)} cm`
 }
 </script>
+
+<style scoped>
+.fishopedia-shell {
+  container-type: inline-size;
+}
+
+.fishopedia-grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+@container (min-width: 32rem) {
+  .fishopedia-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+</style>

--- a/components/ruler-hooked/ruler-hooked-fishopedia.vue
+++ b/components/ruler-hooked/ruler-hooked-fishopedia.vue
@@ -1,0 +1,79 @@
+<template>
+  <details class="collapse collapse-arrow rounded-2xl border border-base-300 bg-base-100">
+    <summary class="collapse-title flex items-center justify-between gap-3 pr-12 font-bold">
+      <span>📖 Fishopedia</span>
+      <span class="badge badge-outline">{{ discoveredCount }}/{{ roster.length }} discovered</span>
+    </summary>
+
+    <div class="collapse-content">
+      <p class="mb-3 text-xs opacity-60">
+        Unknown species stay hidden until caught. Discovered entries remember your best specimen and why that creature could exist in this reign.
+      </p>
+
+      <div class="grid gap-3 sm:grid-cols-2">
+        <article
+          v-for="fish in roster"
+          :key="fish.slug"
+          class="min-h-32 rounded-xl border border-base-300 bg-base-200/50 p-3"
+        >
+          <template v-if="entryFor(fish.slug)">
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="badge badge-xs" :class="affinityClass(fish.affinity)">{{ fish.affinity }}</span>
+              <span class="badge badge-outline badge-xs">{{ fish.rarity }}</span>
+              <span class="text-xs opacity-50">×{{ entryFor(fish.slug)!.countCaught }}</span>
+            </div>
+            <h4 class="mt-2 font-black">{{ fish.name }}</h4>
+            <p class="mt-1 text-xs opacity-75">{{ fish.fishopediaNote }}</p>
+            <dl class="mt-2 grid grid-cols-2 gap-2 text-xs">
+              <div>
+                <dt class="opacity-50">Best size</dt>
+                <dd class="font-semibold">{{ formatSize(entryFor(fish.slug)!.bestSizeCm) }}</dd>
+              </div>
+              <div>
+                <dt class="opacity-50">Best quality</dt>
+                <dd class="font-semibold">{{ entryFor(fish.slug)!.bestQualityScore }}/100</dd>
+              </div>
+            </dl>
+            <p class="mt-2 border-t border-base-300 pt-2 text-xs opacity-60">{{ fish.consequenceReveal }}</p>
+          </template>
+
+          <template v-else>
+            <div class="flex h-full min-h-24 items-center gap-3 opacity-40">
+              <div class="flex size-14 shrink-0 items-center justify-center rounded-full border border-dashed border-current text-2xl">?</div>
+              <div>
+                <p class="font-bold">Unknown specimen</p>
+                <p class="text-xs">Its place in this version of the lake has not been discovered.</p>
+              </div>
+            </div>
+          </template>
+        </article>
+      </div>
+    </div>
+  </details>
+</template>
+
+<script setup lang="ts">
+import type { FishAffinity, RunSave } from '~/types/ruler-hooked'
+import { RULER_HOOKED_FISH } from '~/utils/rulerHooked/fish'
+
+const props = defineProps<{ save: RunSave }>()
+const roster = RULER_HOOKED_FISH
+const discoveredCount = computed(() => Object.keys(props.save.fishopedia).length)
+
+function entryFor(slug: string) {
+  return props.save.fishopedia[slug]
+}
+
+function affinityClass(affinity: FishAffinity): string {
+  return {
+    GOOD: 'badge-success',
+    NEUTRAL: 'badge-ghost',
+    EVIL: 'badge-error',
+  }[affinity]
+}
+
+function formatSize(cm: number): string {
+  if (cm >= 100) return `${(cm / 100).toFixed(cm >= 1000 ? 1 : 2)} m`
+  return `${cm.toFixed(1)} cm`
+}
+</script>

--- a/components/ruler-hooked/ruler-hooked-game.vue
+++ b/components/ruler-hooked/ruler-hooked-game.vue
@@ -11,7 +11,7 @@
         <div class="flex items-center justify-between gap-3">
           <div>
             <p class="text-sm font-bold">{{ store.save.ruler.honorific }} {{ store.save.ruler.name }}</p>
-            <p class="text-xs opacity-60">Turn {{ store.save.turnCount }} · {{ store.save.status.toLowerCase() }}</p>
+            <p class="text-xs opacity-60">Turn {{ store.save.turnCount }} · {{ store.save.status.toLowerCase() }} · {{ store.save.counters.fishCaught ?? 0 }} fish</p>
           </div>
           <button
             type="button"
@@ -24,6 +24,11 @@
         </div>
 
         <RulerHookedHealth :health="store.save.kingdomHealth" />
+
+        <RulerHookedCatch
+          v-if="store.lastCatch"
+          :catch-result="store.lastCatch"
+        />
 
         <RulerHookedCard
           v-if="store.activeCard"
@@ -45,6 +50,8 @@
           <p class="text-lg font-bold">{{ endingTitleFor(store.save.endingKey) }}</p>
           <p class="text-sm opacity-80">The reign is complete. Start another from the slots below.</p>
         </div>
+
+        <RulerHookedFishopedia :save="store.save" />
       </template>
 
       <RulerHookedSlots />

--- a/stores/rulerHookedStore.ts
+++ b/stores/rulerHookedStore.ts
@@ -16,7 +16,7 @@ import {
   loadIndex, loadSave, writeSave, renameSlot as renameSlotStore,
   deleteSlot as deleteSlotStore, setActive, makeSaveId,
 } from '~/utils/rulerHooked/save'
-import type { Card, RunSave, SaveSlotMeta } from '~/types/ruler-hooked'
+import type { Card, CatchResult, RunSave, SaveSlotMeta } from '~/types/ruler-hooked'
 
 const nowStamp = (): string => new Date().toISOString()
 
@@ -26,6 +26,7 @@ export const useRulerHookedStore = defineStore('rulerHooked', () => {
   const activeCard = ref<Card | null>(null)
   const activeArcId = ref<string | null>(null)
   const pendingEnding = ref<string | null>(null)
+  const lastCatch = ref<CatchResult | null>(null)
   const slots = ref<SaveSlotMeta[]>([])
 
   const scene = computed(() =>
@@ -63,6 +64,7 @@ export const useRulerHookedStore = defineStore('rulerHooked', () => {
     save.value = run
     activeCard.value = null
     pendingEnding.value = null
+    lastCatch.value = null
     writeSave(run, stamp)
     refreshSlots()
   }
@@ -73,16 +75,18 @@ export const useRulerHookedStore = defineStore('rulerHooked', () => {
     save.value = s
     activeCard.value = null
     pendingEnding.value = null
+    lastCatch.value = null
     setActive(saveId)
     refreshSlots()
   }
 
-  /** Advance one turn: present a card if one fires, else it's a quiet catch. */
+  /** Advance one turn: land a fish, then present any kingdom interruption. */
   function fish() {
     if (!save.value || !canFish.value) return
     const rng = makeRng(`${save.value.seed}:${save.value.turnCount}`)
     const result = takeTurn(bundle, save.value, rng)
     save.value = result.save
+    lastCatch.value = result.catch
     activeCard.value = result.card
     activeArcId.value = result.arcId ?? null
     persist()
@@ -133,7 +137,7 @@ export const useRulerHookedStore = defineStore('rulerHooked', () => {
   }
 
   return {
-    bundle, save, activeCard, activeArcId, pendingEnding, slots,
+    bundle, save, activeCard, activeArcId, pendingEnding, lastCatch, slots,
     scene, canFish,
     init, newGame, loadSlot, fish, choose, acceptEnding, declineEnding,
     renameSlot, deleteSlot, refreshSlots,

--- a/types/ruler-hooked.ts
+++ b/types/ruler-hooked.ts
@@ -23,6 +23,10 @@ export type Rarity =
   | 'LEGENDARY'
   | 'MYTHIC'
 
+export type FishAffinity = 'GOOD' | 'NEUTRAL' | 'EVIL'
+export type FishQuality = 'ORDINARY' | 'FINE' | 'EXCEPTIONAL' | 'TROPHY'
+export type FishSource = 'cthulhuquarium' | 'ruler-hooked'
+
 // --- regions / compositing (compositing.md) ---------------------------------
 
 /** Canonical region keys, back-to-front z-order (compositing.md §1). */
@@ -185,6 +189,56 @@ export interface Ending {
   trigger?: Trigger
 }
 
+// --- fish ecology / Fishopedia ----------------------------------------------
+
+export interface FishUnlock {
+  /** Every clause must hold. */
+  all?: TriggerClause[]
+  /** If supplied, at least one clause must hold. */
+  any?: TriggerClause[]
+}
+
+export interface FishDefinition {
+  slug: string
+  name: string
+  source: FishSource
+  affinity: FishAffinity
+  rarity: Rarity
+  habitats: RegionKey[]
+  sizeRangeCm: [number, number]
+  silhouette: string
+  distinction: string
+  catchBehavior: string
+  fishopediaNote: string
+  consequenceReveal: string
+  unlock?: FishUnlock
+  /** Optional authored draw weight override; otherwise rarity supplies it. */
+  baseWeight?: number
+}
+
+export interface FishopediaEntry {
+  fishSlug: string
+  firstCaughtTurn: number
+  countCaught: number
+  bestSizeCm: number
+  bestQualityScore: number
+}
+
+export interface CatchResult {
+  fishSlug: string
+  name: string
+  affinity: FishAffinity
+  rarity: Rarity
+  sizeCm: number
+  qualityScore: number
+  quality: FishQuality
+  newDiscovery: boolean
+  countCaught: number
+  fishopediaNote: string
+  consequenceReveal: string
+  catchBehavior: string
+}
+
 // --- content bundle (data-model.md §6) --------------------------------------
 
 export interface CharacterRef {
@@ -269,6 +323,7 @@ export interface RunSave {
   inventory: { skills: InventoryReward[]; items: InventoryReward[] }
   choiceLog: ChoiceLogEntry[]
   flags: Record<string, boolean>
+  fishopedia: Record<string, FishopediaEntry>
   endingKey: string | null
   createdAt: string // display metadata only — never read by game logic
   updatedAt: string

--- a/utils/rulerHooked/engine.selftest.ts
+++ b/utils/rulerHooked/engine.selftest.ts
@@ -4,7 +4,7 @@ import { applyEffect, resolveChoice, cloneSave } from '~/utils/rulerHooked/apply
 import { triggerHolds, effectiveWeight } from '~/utils/rulerHooked/triggers'
 import { rampState, resolveScene, cycleTime, assetCandidates } from '~/utils/rulerHooked/compositor'
 import { eligiblePool, weightedPick, selectCard, tickCooldowns } from '~/utils/rulerHooked/select'
-import { availableFish, resolveFishingCatch } from '~/utils/rulerHooked/fish'
+import { availableFish, resolveFishingCatch, RULER_HOOKED_FISH } from '~/utils/rulerHooked/fish'
 import type { Card, RegionsManifest, RunSave } from '~/types/ruler-hooked'
 
 function baseSave(): RunSave {
@@ -121,8 +121,13 @@ function baseSave(): RunSave {
   assert.equal(r1?.id ?? null, r2?.id ?? null, 'selectCard deterministic per seed (replay==reload)')
 }
 
-// 6. Fish ecology: world state changes the pool; catches are deterministic and recorded
+// 6. Fish ecology: roster contract, world-state pool changes, deterministic records
 {
+  assert.equal(RULER_HOOKED_FISH.length, 15, 'vertical slice stays at 15 authored species')
+  for (const affinity of ['GOOD', 'NEUTRAL', 'EVIL'] as const) {
+    assert.equal(RULER_HOOKED_FISH.filter((f) => f.affinity === affinity).length, 5, `${affinity} roster stays at five species`)
+  }
+
   const neutral = baseSave()
   neutral.kingdomHealth = { nature: 50, prosperity: 50, treasury: 50, joy: 50, order: 50 }
   const neutralPool = availableFish(neutral).map((f) => f.slug)

--- a/utils/rulerHooked/engine.selftest.ts
+++ b/utils/rulerHooked/engine.selftest.ts
@@ -4,11 +4,12 @@ import { applyEffect, resolveChoice, cloneSave } from '~/utils/rulerHooked/apply
 import { triggerHolds, effectiveWeight } from '~/utils/rulerHooked/triggers'
 import { rampState, resolveScene, cycleTime, assetCandidates } from '~/utils/rulerHooked/compositor'
 import { eligiblePool, weightedPick, selectCard, tickCooldowns } from '~/utils/rulerHooked/select'
+import { availableFish, resolveFishingCatch } from '~/utils/rulerHooked/fish'
 import type { Card, RegionsManifest, RunSave } from '~/types/ruler-hooked'
 
 function baseSave(): RunSave {
   return {
-    schemaVersion: 3, saveId: 'sv_test', name: 'Test', dreamSlug: 'ruler-hooked',
+    schemaVersion: 4, saveId: 'sv_test', name: 'Test', dreamSlug: 'ruler-hooked',
     contentVersion: '2026.07', seed: 'mo-4820', status: 'ACTIVE',
     ruler: { name: 'Mo', honorific: 'Queen' },
     turnCount: 5, cyclePosition: 0,
@@ -17,7 +18,7 @@ function baseSave(): RunSave {
     regionStates: {}, regionOverrides: {},
     deckState: { seenCardIds: [], activeArcs: {}, cooldowns: {}, drawBag: [] },
     inventory: { skills: [], items: [] },
-    choiceLog: [], flags: {}, endingKey: null,
+    choiceLog: [], flags: {}, fishopedia: {}, endingKey: null,
     createdAt: 'x', updatedAt: 'x',
   }
 }
@@ -30,8 +31,8 @@ function baseSave(): RunSave {
   const seqB = [b.next(), b.next(), b.next()]
   assert.deepEqual(seqA, seqB, 'same seed -> same sequence')
   const c = makeRng('mo-4820'); c.next()
-  const resumed = makeRng(0, c.state()) // resume from mid-stream state
-  assert.equal(resumed.next(), a === b ? c.next() : c.next(), 'state resume continues stream')
+  const resumed = makeRng(0, c.state())
+  assert.equal(resumed.next(), c.next(), 'state resume continues stream')
   assert.notDeepEqual(makeRng('other').next(), seqA[0], 'different seed differs')
 }
 
@@ -111,7 +112,6 @@ function baseSave(): RunSave {
   assert.ok(!eligiblePool(s, cards).some((c) => c.id === 'a'), 'cooldown excluded')
   tickCooldowns(s); assert.equal(s.deckState.cooldowns.a, 1, 'cooldown ticks down')
 
-  // deterministic pick: same seed -> same choice
   const p1 = weightedPick(baseSave(), cards.filter((c) => c.kind === 'interrupt'), makeRng('seedX'))
   const p2 = weightedPick(baseSave(), cards.filter((c) => c.kind === 'interrupt'), makeRng('seedX'))
   assert.equal(p1?.id, p2?.id, 'weightedPick deterministic per seed')
@@ -119,6 +119,37 @@ function baseSave(): RunSave {
   const r1 = selectCard(s2, cards, makeRng('t5'))
   const r2 = selectCard(s2, cards, makeRng('t5'))
   assert.equal(r1?.id ?? null, r2?.id ?? null, 'selectCard deterministic per seed (replay==reload)')
+}
+
+// 6. Fish ecology: world state changes the pool; catches are deterministic and recorded
+{
+  const neutral = baseSave()
+  neutral.kingdomHealth = { nature: 50, prosperity: 50, treasury: 50, joy: 50, order: 50 }
+  const neutralPool = availableFish(neutral).map((f) => f.slug)
+  assert.deepEqual(neutralPool, ['parlour-rustfish'], 'baseline lake starts with the universal Rustfish')
+
+  const green = baseSave()
+  green.flags.treelineSanctuarySettled = true
+  green.kingdomHealth.nature = 70
+  assert.ok(availableFish(green).some((f) => f.slug === 'sunspoke-koi'), 'sanctuary + nature unlocks Sunspoke Koi')
+
+  const taxed = baseSave()
+  taxed.counters.taxHikes = 2
+  taxed.kingdomHealth.joy = 35
+  taxed.kingdomHealth.treasury = 70
+  assert.ok(availableFish(taxed).some((f) => f.slug === 'tithe-lamprey'), 'repeated extraction unlocks Tithe Lamprey')
+
+  const a = baseSave(); a.kingdomHealth = { nature: 50, prosperity: 50, treasury: 50, joy: 50, order: 50 }
+  const b = cloneSave(a)
+  const ca = resolveFishingCatch(a, makeRng('fish-seed'))
+  const cb = resolveFishingCatch(b, makeRng('fish-seed'))
+  assert.deepEqual(ca, cb, 'same save + RNG seed gives identical specimen')
+  assert.equal(a.counters.fishCaught, 4, 'catch increments fish count')
+  assert.equal(a.fishopedia[ca.fishSlug]?.countCaught, 1, 'catch is recorded in Fishopedia')
+  assert.equal(ca.newDiscovery, true, 'first catch marks a discovery')
+  const ca2 = resolveFishingCatch(a, makeRng('fish-seed'))
+  assert.equal(ca2.newDiscovery, false, 'later catch of same species is not new')
+  assert.equal(a.fishopedia[ca.fishSlug]?.countCaught, 2, 'repeat catch increments species record')
 }
 
 console.log('ruler-hooked engine self-test: ALL PASS')

--- a/utils/rulerHooked/fish.ts
+++ b/utils/rulerHooked/fish.ts
@@ -1,0 +1,248 @@
+// utils/rulerHooked/fish.ts
+//
+// Consequence-driven fantasy fishing for The Ruler Is Hooked. The roster is
+// deliberately plain data plus a small deterministic resolver: kingdom choices
+// determine which species exist in the current lake, rarity determines draw
+// weight, and the run RNG determines species/specimen details. No wall clock.
+
+import type {
+  CatchResult,
+  FishDefinition,
+  FishQuality,
+  Rarity,
+  RunSave,
+} from '~/types/ruler-hooked'
+import type { RngStream } from './seed'
+import { clauseHolds } from './triggers'
+
+const rarityWeight: Record<Rarity, number> = {
+  COMMON: 60,
+  UNCOMMON: 30,
+  RARE: 14,
+  EPIC: 6,
+  LEGENDARY: 2,
+  MYTHIC: 1,
+}
+
+export const RULER_HOOKED_FISH: FishDefinition[] = [
+  {
+    slug: 'choirfish', name: 'Choirfish', source: 'cthulhuquarium', affinity: 'GOOD', rarity: 'RARE',
+    habitats: ['village_edge', 'near_bank'], sizeRangeCm: [12, 24],
+    silhouette: 'three slender ribbon-finned fish moving as one ascending chord',
+    distinction: 'A three-fish choir caught as one specimen; their throats glow in different notes.',
+    catchBehavior: 'Three bites arrive in sequence while the line hums like a tuning fork.',
+    fishopediaNote: 'Sings only when the shore is quiet enough to hear it. Three specimens have never been recorded disagreeing on the key.',
+    consequenceReveal: 'Appeared after the kingdom became joyful enough to keep celebrating without stripping the living shoreline around it.',
+    unlock: { all: [{ sliders: { joy: { gte: 65 }, nature: { gte: 50 } }, counters: { festivals: { gte: 1 } } }] },
+  },
+  {
+    slug: 'sunspoke-koi', name: 'Sunspoke Koi', source: 'ruler-hooked', affinity: 'GOOD', rarity: 'UNCOMMON',
+    habitats: ['near_bank', 'lake'], sizeRangeCm: [30, 65],
+    silhouette: 'deep-bodied koi with six long translucent fins radiating like sunbeams',
+    distinction: 'Its clear fins refract daylight into moving bands of color through the shallows.',
+    catchBehavior: 'Circles the lure until the angler stops pulling; patience produces the strike.',
+    fishopediaNote: 'The fins contain no pigment. The color belongs to whatever light the kingdom has managed to leave it.',
+    consequenceReveal: 'Returned once protected land and healthier water made bright shallows reliable again.',
+    unlock: { all: [{ flags: ['treelineSanctuarySettled'], sliders: { nature: { gte: 65 } } }] },
+  },
+  {
+    slug: 'orchardjaw-perch', name: 'Orchardjaw Perch', source: 'ruler-hooked', affinity: 'GOOD', rarity: 'COMMON',
+    habitats: ['village_edge', 'near_bank'], sizeRangeCm: [20, 42],
+    silhouette: 'chunky green perch with a mossy back carrying tiny flowering fruit trees',
+    distinction: 'Seeds sprout in the moss along its spine into miniature orchards.',
+    catchBehavior: 'Prefers fruit scraps; ripe specimens scatter tiny fruit when lifted.',
+    fishopediaNote: 'Carries an orchard because the shore once carried one first. The fish insists it discovered the arrangement independently.',
+    consequenceReveal: 'Appeared after Robin and Ash were given a garden beside the lake and the shore remained healthy enough to share it.',
+    unlock: { all: [{ flags: ['newlywedsGarden'], sliders: { joy: { gte: 55 }, nature: { gte: 50 } } }] },
+  },
+  {
+    slug: 'bridgeback-sturgeon', name: 'Bridgeback Sturgeon', source: 'ruler-hooked', affinity: 'GOOD', rarity: 'EPIC',
+    habitats: ['far_shore', 'lake'], sizeRangeCm: [180, 330],
+    silhouette: 'enormous silver sturgeon with broad flat stone-like scutes forming a stepped back',
+    distinction: 'Frogs and waterfowl use its broad back as a moving causeway.',
+    catchBehavior: 'Hard pulling makes it settle to the bottom; steady low tension persuades it upstream.',
+    fishopediaNote: 'Smaller creatures cross on its back. None appear to know where it is going, which has not reduced traffic.',
+    consequenceReveal: 'Recorded after the ruler listened to the lake and left enough migration route intact for old giants to return.',
+    unlock: { all: [{ flags: ['heededNix'], sliders: { nature: { gte: 70 }, order: { gte: 45 } } }] },
+  },
+  {
+    slug: 'crown-of-reeds-pike', name: 'Crown-of-Reeds Pike', source: 'ruler-hooked', affinity: 'GOOD', rarity: 'LEGENDARY',
+    habitats: ['lake', 'far_shore'], sizeRangeCm: [140, 250],
+    silhouette: 'immense pale pike crowned by branching living reeds and water lilies',
+    distinction: 'Its crown is a living wetland carrying insects, flowers, and tiny nesting birds.',
+    catchBehavior: 'Powerful runs alternate with still phases when tension must be released to protect the living crown.',
+    fishopediaNote: 'Old accounts call the crown a sign of royal favor. The pike appears not to have been consulted about the monarchy.',
+    consequenceReveal: 'Appeared only after protected woods and the strange bog were both allowed to flourish into connected habitat.',
+    unlock: { all: [{ flags: ['treelineSanctuarySettled', 'bogBloomed'], sliders: { nature: { gte: 85 }, joy: { gte: 60 } } }] },
+  },
+  {
+    slug: 'parlour-rustfish', name: 'Parlour Rustfish', source: 'cthulhuquarium', affinity: 'NEUTRAL', rarity: 'COMMON',
+    habitats: ['near_bank', 'lake'], sizeRangeCm: [10, 30], baseWeight: 42,
+    silhouette: 'small cheerful rust-orange fish with a flowing double tail',
+    distinction: 'Its copper sheen oxidizes out of water and clears again when released.',
+    catchBehavior: 'A forgiving, straightforward catch that teaches the normal fishing rhythm.',
+    fishopediaNote: 'Ornamental and harmless. Grows to the size of its container. The ocean is a container.',
+    consequenceReveal: 'Native to almost every version of the lake; policy mostly changes what appears beside it.',
+  },
+  {
+    slug: 'errand-guppy', name: 'Errand Guppy', source: 'cthulhuquarium', affinity: 'NEUTRAL', rarity: 'COMMON',
+    habitats: ['village_edge', 'near_bank'], sizeRangeCm: [3, 8],
+    silhouette: 'tiny bright guppy carrying one improbable object in its mouth',
+    distinction: 'Every specimen is transporting a pebble, button, tiny key, seal fragment, or ribbon scrap.',
+    catchBehavior: 'Darts laterally in abrupt bursts while refusing to drop its cargo.',
+    fishopediaNote: 'Carries small objects from one end of the lake to the other and back. Neither end has requested this.',
+    consequenceReveal: 'Appeared when the generous trade accord made the kingdom busier moving messages and goods.',
+    unlock: { all: [{ flags: ['envoyTreatySigned'], sliders: { prosperity: { gte: 55 } } }] },
+  },
+  {
+    slug: 'moebius-crab', name: 'Moebius Crab', source: 'cthulhuquarium', affinity: 'NEUTRAL', rarity: 'EPIC',
+    habitats: ['castle_grounds', 'lake'], sizeRangeCm: [10, 22],
+    silhouette: 'hermit crab carrying a shell that forms one impossible continuous loop',
+    distinction: 'Its shell has one side and appears simultaneously in front of and behind itself.',
+    catchBehavior: 'The line seems to reverse direction halfway through the fight.',
+    fishopediaNote: 'Its shell has one surface. It has been trying to get out for some time.',
+    consequenceReveal: 'Appeared after the ruler accepted Mossy’s hex, whose ecological meaning remains considerably less clear than its consequences.',
+    unlock: { all: [{ flags: ['mossyHexAccepted'], sliders: { nature: { gte: 45 } } }] },
+  },
+  {
+    slug: 'masquerade-ray', name: 'Masquerade Ray', source: 'ruler-hooked', affinity: 'NEUTRAL', rarity: 'RARE',
+    habitats: ['lake', 'castle_grounds'], sizeRangeCm: [70, 145],
+    silhouette: 'broad ray whose back forms a theatrical mask with long ribbon fins',
+    distinction: 'Its mask-pattern changes to imitate whatever fashion currently dominates the royal court.',
+    catchBehavior: 'Glides in huge slow arcs and changes direction when courtly commotion reaches the shore.',
+    fishopediaNote: 'Has never attended court. This has not prevented it from being dressed for the occasion.',
+    consequenceReveal: 'Appeared once performance and spectacle became important enough for even the lake to start dressing for an audience.',
+    unlock: { all: [{ rewards: ['bards-ballad'], sliders: { joy: { gte: 55 } } }] },
+  },
+  {
+    slug: 'tollbell-sturgeon', name: 'Tollbell Sturgeon', source: 'ruler-hooked', affinity: 'NEUTRAL', rarity: 'UNCOMMON',
+    habitats: ['far_shore', 'village_edge'], sizeRangeCm: [130, 225],
+    silhouette: 'long bronze-grey sturgeon with hollow bell-shaped scutes down both flanks',
+    distinction: 'Crossing invisible underwater boundaries rings one of its bell-shaped scutes.',
+    catchBehavior: 'Its bells reveal a turn before its body does, making the erratic fight audible.',
+    fishopediaNote: 'Rings whenever it crosses a boundary. The lake has declined to publish the boundaries.',
+    consequenceReveal: 'Appeared after the crown negotiated borders and tariffs hard enough for the lake to notice.',
+    unlock: { all: [{ flags: ['envoyTreatyHard'], sliders: { treasury: { gte: 60 } } }] },
+  },
+  {
+    slug: 'drowned-carp', name: 'Drowned Carp', source: 'cthulhuquarium', affinity: 'EVIL', rarity: 'COMMON',
+    habitats: ['far_shore', 'lake'], sizeRangeCm: [30, 65],
+    silhouette: 'bloated pale translucent carp with ragged fins and unmistakably dead eyes',
+    distinction: 'It is unquestionably dead and equally unquestionably still hungry.',
+    catchBehavior: 'Periodically goes corpse-slack; pulling during the dead phase works against the catch.',
+    fishopediaNote: 'Died some time ago. Continues to feed, and continues to be hungry.',
+    consequenceReveal: 'Appeared once development pushed the lake far enough from healthy that death stopped being a meaningful ecological boundary.',
+    unlock: { all: [{ flags: ['metWarlock'], sliders: { nature: { lte: 40 } } }] },
+  },
+  {
+    slug: 'lamplight-angler', name: 'Lamplight Angler', source: 'cthulhuquarium', affinity: 'EVIL', rarity: 'UNCOMMON',
+    habitats: ['far_shore', 'lake'], sizeRangeCm: [40, 85],
+    silhouette: 'rotund dark angler with an enormous underbite and a bright drooping lamp',
+    distinction: 'Its lure resembles the kingdom’s own work lamps after industrial development.',
+    catchBehavior: 'The visible lure moves separately from the hidden body; striking too soon catches only the false light.',
+    fishopediaNote: 'The light is not for you. It has never been for you.',
+    consequenceReveal: 'Appeared when artificial light gave the lake’s hunters something new to imitate.',
+    unlock: { all: [{ flags: ['farShoreFleetSettled'], sliders: { nature: { lte: 45 } } }] },
+  },
+  {
+    slug: 'ashbelly-gar', name: 'Ashbelly Gar', source: 'ruler-hooked', affinity: 'EVIL', rarity: 'RARE',
+    habitats: ['far_shore', 'lake'], sizeRangeCm: [100, 185],
+    silhouette: 'long armored black gar with a furnace-orange belly and chimney gills',
+    distinction: 'Soot plates its scales while ember-light pulses under the armor; each breath releases a neat smoke ring.',
+    catchBehavior: 'Powerful runs heat the line in pulses, rewarding moments of deliberate slack.',
+    fishopediaNote: 'Filters ash with remarkable efficiency. The report praising this fact does not say where the ash came from.',
+    consequenceReveal: 'Appeared when industrial success made pollution reliable enough to become habitat.',
+    unlock: { all: [{ flags: ['farShoreFleetSettled'], sliders: { nature: { lte: 30 }, prosperity: { gte: 60 } } }] },
+  },
+  {
+    slug: 'tithe-lamprey', name: 'Tithe Lamprey', source: 'ruler-hooked', affinity: 'EVIL', rarity: 'EPIC',
+    habitats: ['castle_grounds', 'village_edge'], sizeRangeCm: [50, 105],
+    silhouette: 'thick black-gold lamprey with a circular mouth ringed by coin-shaped teeth',
+    distinction: 'It swells with metallic scales stolen from other fish, becoming more golden and less mobile as it feeds.',
+    catchBehavior: 'Arrives attached to another hooked fish, turning the catch into an extraction-versus-rescue choice.',
+    fishopediaNote: 'Takes a modest portion from anything larger than itself. It has not defined modest.',
+    consequenceReveal: 'Appeared once repeated levies turned extraction from an emergency into a habitat.',
+    unlock: { all: [{ counters: { taxHikes: { gte: 2 } }, sliders: { joy: { lte: 40 }, treasury: { gte: 60 } } }] },
+  },
+  {
+    slug: 'the-pleasant-island', name: 'The Pleasant Island', source: 'cthulhuquarium', affinity: 'EVIL', rarity: 'LEGENDARY',
+    habitats: ['far_shore', 'lake'], sizeRangeCm: [1200, 3000],
+    silhouette: 'cheerful tiny tropical island above water attached to an enormous monster below',
+    distinction: 'What first reads as new scenery is the creature itself; palms, sand, and warm shallows are part of its body.',
+    catchBehavior: 'Begins as scenery; casting near it wakes a lake-scale legendary encounter.',
+    fishopediaNote: 'Presents as a small warm island. Visitors are encouraged to remain on the island.',
+    consequenceReveal: 'Appeared after the far shore became valuable enough that nobody asked what the new shoreline attraction was standing on.',
+    unlock: { all: [{ flags: ['farShoreFleetSettled'], sliders: { nature: { lte: 30 }, prosperity: { gte: 70 }, treasury: { gte: 60 } } }] },
+  },
+]
+
+export function fishUnlocked(save: RunSave, fish: FishDefinition): boolean {
+  const all = fish.unlock?.all ?? []
+  if (all.some((clause) => !clauseHolds(save, clause))) return false
+  const any = fish.unlock?.any ?? []
+  if (any.length && !any.some((clause) => clauseHolds(save, clause))) return false
+  return true
+}
+
+export function availableFish(save: RunSave): FishDefinition[] {
+  return RULER_HOOKED_FISH.filter((fish) => fishUnlocked(save, fish))
+}
+
+function quality(score: number): FishQuality {
+  if (score >= 92) return 'TROPHY'
+  if (score >= 78) return 'EXCEPTIONAL'
+  if (score >= 58) return 'FINE'
+  return 'ORDINARY'
+}
+
+function pickFish(save: RunSave, rng: RngStream): FishDefinition {
+  const pool = availableFish(save)
+  // Parlour Rustfish is intentionally unconditional, so this is defensive only.
+  if (!pool.length) return RULER_HOOKED_FISH.find((f) => f.slug === 'parlour-rustfish')!
+  const weights = pool.map((f) => f.baseWeight ?? rarityWeight[f.rarity])
+  const total = weights.reduce((sum, w) => sum + Math.max(0, w), 0)
+  let roll = rng.next() * Math.max(total, 1)
+  for (let i = 0; i < pool.length; i++) {
+    roll -= Math.max(0, weights[i] ?? 0)
+    if (roll <= 0) return pool[i]!
+  }
+  return pool[pool.length - 1]!
+}
+
+/** Resolve and record one successful cast. Mutates the caller-owned save clone. */
+export function resolveFishingCatch(save: RunSave, rng: RngStream): CatchResult {
+  const fish = pickFish(save, rng)
+  const [lo, hi] = fish.sizeRangeCm
+  const sizeCm = Math.round((lo + rng.next() * (hi - lo)) * 10) / 10
+  const qualityScore = Math.max(1, Math.min(100, Math.floor(rng.next() * 100) + 1))
+  const specimenQuality = quality(qualityScore)
+  const previous = save.fishopedia[fish.slug]
+  const isNew = !previous
+  const entry = previous ?? {
+    fishSlug: fish.slug,
+    firstCaughtTurn: save.turnCount,
+    countCaught: 0,
+    bestSizeCm: 0,
+    bestQualityScore: 0,
+  }
+  entry.countCaught += 1
+  entry.bestSizeCm = Math.max(entry.bestSizeCm, sizeCm)
+  entry.bestQualityScore = Math.max(entry.bestQualityScore, qualityScore)
+  save.fishopedia[fish.slug] = entry
+  save.counters.fishCaught = (save.counters.fishCaught ?? 0) + 1
+
+  return {
+    fishSlug: fish.slug,
+    name: fish.name,
+    affinity: fish.affinity,
+    rarity: fish.rarity,
+    sizeCm,
+    qualityScore,
+    quality: specimenQuality,
+    newDiscovery: isNew,
+    countCaught: entry.countCaught,
+    fishopediaNote: fish.fishopediaNote,
+    consequenceReveal: fish.consequenceReveal,
+    catchBehavior: fish.catchBehavior,
+  }
+}

--- a/utils/rulerHooked/game.selftest.ts
+++ b/utils/rulerHooked/game.selftest.ts
@@ -1,10 +1,9 @@
 // utils/rulerHooked/game.selftest.ts
 //
 // Headless behavioral test of the whole game loop (content + newGame + loop +
-// save), run via `npx tsx`. Proves the four DESIGN-BRIEF m2 exit criteria hold at
-// the logic layer, independent of the Vue UI: playable fish→card→choice loop;
-// regions recomposite in response to choices; the heir-elopes arc runs end to end;
-// multi-slot save/load. A tiny localStorage shim lets the SaveStore run in node.
+// save), run via `npx tsx`. Proves the core PoC criteria plus the first full-game
+// fishing slice: real deterministic catches, persistent Fishopedia, region
+// recomposition, narrative arcs, and multi-slot save/load.
 
 import assert from 'node:assert/strict'
 import { RULER_HOOKED_CONTENT as C } from '~/utils/rulerHooked/content'
@@ -19,13 +18,13 @@ import {
 import type { RunSave } from '~/types/ruler-hooked'
 
 // --- localStorage shim for node -------------------------------------------
+const backingStore = new Map<string, string>()
 {
-  const store = new Map<string, string>()
   ;(globalThis as unknown as { window: unknown }).window = {
     localStorage: {
-      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
-      setItem: (k: string, v: string) => void store.set(k, v),
-      removeItem: (k: string) => void store.delete(k),
+      getItem: (k: string) => (backingStore.has(k) ? backingStore.get(k)! : null),
+      setItem: (k: string, v: string) => void backingStore.set(k, v),
+      removeItem: (k: string) => void backingStore.delete(k),
     },
   }
 }
@@ -33,21 +32,27 @@ import type { RunSave } from '~/types/ruler-hooked'
 const fresh = (id = 'sv_a'): RunSave =>
   createRun(C, { saveId: id, name: 'Test Reign', seed: 'mo-4820', rulerName: 'Mo', honorific: 'Queen', stamp: 'T0' })
 
-// 1. New game is well-formed
+// 1. New game is well-formed and ready to catalogue fish
 {
   const s = fresh()
   assert.equal(s.turnCount, 0)
   assert.equal(s.status, 'ACTIVE')
+  assert.equal(s.schemaVersion, 4)
   assert.equal(s.kingdomHealth.nature, 50)
   assert.equal(s.contentVersion, C.contentVersion)
+  assert.deepEqual(s.fishopedia, {})
 }
 
-// 2. Turn loop is deterministic and advances turnCount
+// 2. Turn loop is deterministic, advances turnCount, and lands a real species
 {
   const a = takeTurn(C, fresh(), makeRng('run-1'))
   const b = takeTurn(C, fresh(), makeRng('run-1'))
   assert.equal(a.save.turnCount, 1)
-  assert.equal(a.card?.id ?? null, b.card?.id ?? null, 'same seed -> same turn outcome')
+  assert.equal(a.card?.id ?? null, b.card?.id ?? null, 'same seed -> same card outcome')
+  assert.deepEqual(a.catch, b.catch, 'same seed -> same fish specimen')
+  assert.equal(a.catch.fishSlug, 'parlour-rustfish', 'neutral starting lake has its baseline species')
+  assert.equal(a.save.counters.fishCaught, 1, 'a cast lands one fish')
+  assert.equal(a.save.fishopedia['parlour-rustfish']?.countCaught, 1, 'catch persists to Fishopedia')
 }
 
 // 3. The warlock/druid choice recomposites regions (exit criterion 2)
@@ -61,14 +66,12 @@ const fresh = (id = 'sv_a'): RunSave =>
   assert.equal(afterScene.regionStates.far_shore, 'industrial', 'develop pins far_shore industrial')
   assert.notEqual(afterScene.regionStates.treeline, beforeScene.regionStates.treeline, 'lower nature shifts treeline state')
   assert.ok(after.inventory.items.some((r) => r.slug === 'buildpermit-scroll'), 'reward granted')
-  // preserve is the opposite pole
   const preserved = resolveChoice(fresh(), card, card.choices.find((c) => c.id === 'preserve')!)
   assert.equal(resolveScene(preserved, C.regions).regionStates.far_shore, 'pristine', 'preserve pins far_shore pristine')
 }
 
 // 4. The heir-elopes arc runs end to end (exit criterion 3)
 {
-  // Force the arc active at its first step, then walk it via choices.
   let s = fresh()
   s.turnCount = 4
   s.deckState.activeArcs['child-elopes'] = { step: 'elope-1', flags: {} }
@@ -111,6 +114,17 @@ const fresh = (id = 'sv_a'): RunSave =>
   idx = loadIndex()
   assert.equal(idx.slots.length, 1, 'delete removes a slot')
   assert.equal(idx.activeSaveId, idA, 'active falls back after deleting the active slot')
+}
+
+// 7. A pre-Fishopedia schema-3 slot migrates rather than being discarded
+{
+  const old = fresh('sv_old') as RunSave & { fishopedia?: RunSave['fishopedia'] }
+  old.schemaVersion = 3
+  delete old.fishopedia
+  backingStore.set('rulerHooked:save:sv_old', JSON.stringify(old))
+  const migrated = loadSave('sv_old')
+  assert.equal(migrated?.schemaVersion, 4, 'legacy slot is promoted to schema 4')
+  assert.deepEqual(migrated?.fishopedia, {}, 'legacy slot receives an empty Fishopedia')
 }
 
 console.log('ruler-hooked GAME self-test: ALL PASS')

--- a/utils/rulerHooked/game.selftest.ts
+++ b/utils/rulerHooked/game.selftest.ts
@@ -118,7 +118,8 @@ const fresh = (id = 'sv_a'): RunSave =>
 
 // 7. A pre-Fishopedia schema-3 slot migrates rather than being discarded
 {
-  const old = fresh('sv_old') as RunSave & { fishopedia?: RunSave['fishopedia'] }
+  type LegacyRunSave = Omit<RunSave, 'fishopedia'> & { fishopedia?: RunSave['fishopedia'] }
+  const old = fresh('sv_old') as LegacyRunSave
   old.schemaVersion = 3
   delete old.fishopedia
   backingStore.set('rulerHooked:save:sv_old', JSON.stringify(old))

--- a/utils/rulerHooked/game.selftest.ts
+++ b/utils/rulerHooked/game.selftest.ts
@@ -55,6 +55,21 @@ const fresh = (id = 'sv_a'): RunSave =>
   assert.equal(a.save.fishopedia['parlour-rustfish']?.countCaught, 1, 'catch persists to Fishopedia')
 }
 
+// 2b. Fish randomness is isolated from the narrative draw stream
+{
+  const a = fresh('sv_rng_a')
+  const b = fresh('sv_rng_b')
+  a.seed = 'fish-world-alpha'
+  b.seed = 'fish-world-beta'
+  const turnA = takeTurn(C, a, makeRng('same-narrative-stream'))
+  const turnB = takeTurn(C, b, makeRng('same-narrative-stream'))
+  assert.equal(
+    turnA.card?.id ?? null,
+    turnB.card?.id ?? null,
+    'changing the fish RNG seed cannot change the kingdom card draw',
+  )
+}
+
 // 3. The warlock/druid choice recomposites regions (exit criterion 2)
 {
   const card = C.decks[0]!.cards.find((c) => c.id === 'warlock-druid-north')!

--- a/utils/rulerHooked/loop.ts
+++ b/utils/rulerHooked/loop.ts
@@ -9,7 +9,7 @@
 // is derived from it.
 
 import type { Card, CatchResult, ContentBundle, RunSave } from '~/types/ruler-hooked'
-import type { RngStream } from './seed'
+import { makeRng, type RngStream } from './seed'
 import { cloneSave } from './applyEffects'
 import { cyclePosition } from './compositor'
 import { resolveFishingCatch } from './fish'
@@ -42,6 +42,10 @@ export function allDeckCards(bundle: ContentBundle): Card[] {
  * available ecology, (2) a pending active-arc step, (3) starting a newly eligible
  * arc, (4) a seeded interrupt/ambient draw. Returns a new save plus the catch and
  * any card to present.
+ *
+ * Fishing uses a turn-scoped child RNG derived from the run seed. Narrative draws
+ * keep the caller-supplied RNG stream. This deliberately prevents future changes to
+ * specimen math (size/quality/fight cues) from changing which kingdom card appears.
  */
 export function takeTurn(
   bundle: ContentBundle,
@@ -50,11 +54,12 @@ export function takeTurn(
   interruptChance = 0.6,
 ): TurnResult {
   const next = cloneSave(save)
+  const fishRng = makeRng(`${next.seed}:${next.turnCount}:fish`)
 
   // 1. Fish beat — now a real species/specimen, not the original 50% counter flip.
   next.turnCount += 1
   next.cyclePosition = cyclePosition(next.turnCount)
-  const caught = resolveFishingCatch(next, rng)
+  const caught = resolveFishingCatch(next, fishRng)
   tickCooldowns(next)
 
   const seen = new Set(next.deckState.seenCardIds)

--- a/utils/rulerHooked/loop.ts
+++ b/utils/rulerHooked/loop.ts
@@ -8,15 +8,17 @@
 // No wall-clock anywhere: turnCount is the only progression counter and time-of-day
 // is derived from it.
 
-import type { Card, ContentBundle, RunSave } from '~/types/ruler-hooked'
+import type { Card, CatchResult, ContentBundle, RunSave } from '~/types/ruler-hooked'
 import type { RngStream } from './seed'
 import { cloneSave } from './applyEffects'
 import { cyclePosition } from './compositor'
+import { resolveFishingCatch } from './fish'
 import { selectCard, tickCooldowns } from './select'
 import { triggerHolds } from './triggers'
 
 export interface TurnResult {
   save: RunSave
+  catch: CatchResult
   card: Card | null
   arcId?: string
 }
@@ -36,9 +38,10 @@ export function allDeckCards(bundle: ContentBundle): Card[] {
 }
 
 /**
- * Advance one turn. Priority: (1) a pending active-arc step, (2) starting a newly
- * eligible arc, (3) a seeded interrupt/ambient draw, else pure fishing. Returns a
- * new save (input untouched) plus the card to present, if any.
+ * Advance one turn. Priority: (1) land a deterministic fish from the currently
+ * available ecology, (2) a pending active-arc step, (3) starting a newly eligible
+ * arc, (4) a seeded interrupt/ambient draw. Returns a new save plus the catch and
+ * any card to present.
  */
 export function takeTurn(
   bundle: ContentBundle,
@@ -48,10 +51,10 @@ export function takeTurn(
 ): TurnResult {
   const next = cloneSave(save)
 
-  // 1. Fish beat — the cosmetic, always-valid heartbeat.
+  // 1. Fish beat — now a real species/specimen, not the original 50% counter flip.
   next.turnCount += 1
   next.cyclePosition = cyclePosition(next.turnCount)
-  next.counters.fishCaught = (next.counters.fishCaught ?? 0) + (rng.next() < 0.5 ? 1 : 0)
+  const caught = resolveFishingCatch(next, rng)
   tickCooldowns(next)
 
   const seen = new Set(next.deckState.seenCardIds)
@@ -61,7 +64,7 @@ export function takeTurn(
     const step = next.deckState.activeArcs[arcId]?.step
     if (step && !seen.has(step)) {
       const found = findArcStep(bundle, step)
-      if (found) return { save: next, card: found.card, arcId }
+      if (found) return { save: next, catch: caught, card: found.card, arcId }
     }
   }
 
@@ -77,15 +80,15 @@ export function takeTurn(
     const first = arc.steps[0]
     if (!first) continue
     next.deckState.activeArcs[arc.id] = { step: first.id, flags: {} }
-    return { save: next, card: first, arcId: arc.id }
+    return { save: next, catch: caught, card: first, arcId: arc.id }
   }
 
-  // 4. A free interrupt/ambient draw (seeded, may be null → pure fishing).
+  // 4. A free interrupt/ambient draw (seeded, may be null → quiet fishing).
   const card = selectCard(next, allDeckCards(bundle), rng, interruptChance)
   if (card && card.trigger?.cooldown) {
     next.deckState.cooldowns[card.id] = card.trigger.cooldown
   }
-  return { save: next, card }
+  return { save: next, catch: caught, card }
 }
 
 /**

--- a/utils/rulerHooked/newGame.ts
+++ b/utils/rulerHooked/newGame.ts
@@ -25,7 +25,7 @@ export function createRun(bundle: ContentBundle, opts: NewGameOpts): RunSave {
   const drawBag = bundle.decks.flatMap((d) => d.cards.map((c) => c.id))
 
   return {
-    schemaVersion: 3,
+    schemaVersion: 4,
     saveId: opts.saveId,
     name: opts.name,
     dreamSlug: 'ruler-hooked',
@@ -43,6 +43,7 @@ export function createRun(bundle: ContentBundle, opts: NewGameOpts): RunSave {
     inventory: { skills: [], items: [] },
     choiceLog: [],
     flags: {},
+    fishopedia: {},
     endingKey: null,
     createdAt: opts.stamp,
     updatedAt: opts.stamp,

--- a/utils/rulerHooked/save.ts
+++ b/utils/rulerHooked/save.ts
@@ -10,7 +10,7 @@ import type { RunSave, SaveIndex, SaveSlotMeta } from '~/types/ruler-hooked'
 
 const INDEX_KEY = 'rulerHooked:index'
 const slotKey = (saveId: string) => `rulerHooked:save:${saveId}`
-export const SAVE_SCHEMA_VERSION = 3
+export const SAVE_SCHEMA_VERSION = 4
 
 // Checked per-call (not captured at module load) so SSR — and headless tests
 // that install a window shim after import — behave correctly.
@@ -50,6 +50,13 @@ function parse<T>(raw: string | null): T | null {
   }
 }
 
+/** Add fields introduced after the original PoC without invalidating old slots. */
+function migrateSave(save: RunSave): RunSave {
+  if (!save.fishopedia) save.fishopedia = {}
+  save.schemaVersion = SAVE_SCHEMA_VERSION
+  return save
+}
+
 function metaOf(save: RunSave): SaveSlotMeta {
   return {
     saveId: save.saveId,
@@ -64,25 +71,28 @@ function metaOf(save: RunSave): SaveSlotMeta {
 }
 
 export function loadIndex(): SaveIndex {
-  return (
-    parse<SaveIndex>(safeGet(INDEX_KEY)) ?? {
-      schemaVersion: SAVE_SCHEMA_VERSION,
-      activeSaveId: null,
-      slots: [],
-    }
-  )
+  const index = parse<SaveIndex>(safeGet(INDEX_KEY)) ?? {
+    schemaVersion: SAVE_SCHEMA_VERSION,
+    activeSaveId: null,
+    slots: [],
+  }
+  index.schemaVersion = SAVE_SCHEMA_VERSION
+  return index
 }
 
 function writeIndex(index: SaveIndex): void {
+  index.schemaVersion = SAVE_SCHEMA_VERSION
   safeSet(INDEX_KEY, JSON.stringify(index))
 }
 
 export function loadSave(saveId: string): RunSave | null {
-  return parse<RunSave>(safeGet(slotKey(saveId)))
+  const save = parse<RunSave>(safeGet(slotKey(saveId)))
+  return save ? migrateSave(save) : null
 }
 
 /** Write a save body and upsert its slot into the index (last-writer-wins). */
 export function writeSave(save: RunSave, stamp: string): void {
+  migrateSave(save)
   save.updatedAt = stamp
   safeSet(slotKey(save.saveId), JSON.stringify(save))
   const index = loadIndex()


### PR DESCRIPTION
### Task
Move The Ruler Is Hooked from a 50% `fishCaught` counter flip to the first playable consequence-driven fishing slice.

### What changed
- Added all 15 approved fantasy species as typed runtime content: 5 GOOD, 5 NEUTRAL, 5 EVIL.
- Reuses the existing trigger predicate grammar for fish unlocks, so kingdom flags, rewards, counters, and the five canonical health axes determine the available ecology.
- Every cast now lands one deterministic species/specimen with size and quality instead of incrementing a counter on a coin flip.
- Added persistent Fishopedia records: first caught turn, count, best size, and best quality.
- Added a catch card and collapsible 15-slot Fishopedia to the game UI. Unknown species remain hidden; discovered fish reveal their lore and the ecological consequence that made them possible.
- Added schema-v4 save migration so existing local Ruler saves gain an empty Fishopedia rather than becoming invalid.
- Added engine/game self-test coverage for deterministic catches, world-state roster divergence, Tithe Lamprey and Sunspoke unlocks, repeat catches, Fishopedia persistence, and schema-3 migration.

### Important scope boundary
The distinct authored catch behaviors are now represented in the fish model and UI, but this PR does not yet turn all 15 behaviors into separate interactive reel minigames. This is the vertical-slice foundation: real species selection, ecology, specimen records, and Fishopedia first.

### Determinism
No wall-clock gates were added. Fish selection, size, quality, card selection, and run progression continue to derive from run state plus seeded RNG.