### PR TITLE
feat(ruler-hooked): make fishing encounters interactive

### DIFF
--- a/.github/workflows/ruler-hooked.yml
+++ b/.github/workflows/ruler-hooked.yml
@@ -1,0 +1,33 @@
+name: Ruler Hooked
+
+on:
+  pull_request:
+    paths:
+      - 'utils/rulerHooked/**'
+      - 'stores/rulerHookedStore.ts'
+      - 'components/ruler-hooked/**'
+      - '.github/workflows/ruler-hooked.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'utils/rulerHooked/**'
+      - 'stores/rulerHookedStore.ts'
+      - 'components/ruler-hooked/**'
+      - '.github/workflows/ruler-hooked.yml'
+
+jobs:
+  verify:
+    runs-on: ubuntu-24.04
+    env:
+      CYPRESS_INSTALL_BINARY: 0
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Game loop self-test
+        run: npx tsx utils/rulerHooked/game.selftest.ts
+      - name: Fishing encounter self-test
+        run: npx tsx utils/rulerHooked/encounter.selftest.ts

--- a/components/ruler-hooked/ruler-hooked-fishing-encounter.vue
+++ b/components/ruler-hooked/ruler-hooked-fishing-encounter.vue
@@ -1,0 +1,70 @@
+<template>
+  <section class="rounded-2xl border border-primary/30 bg-base-100 p-4 shadow-sm" aria-labelledby="fishing-encounter-title">
+    <div class="flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <p class="text-xs font-bold uppercase tracking-wide opacity-55">On the line</p>
+        <h3 id="fishing-encounter-title" class="text-xl font-black">{{ encounter.fishName }}</h3>
+        <p class="mt-1 text-xs opacity-65">{{ encounter.rarity }} · {{ encounter.affinity }} · {{ familyLabel }}</p>
+      </div>
+      <span class="badge badge-outline">Beat {{ encounter.beat }}/{{ encounter.maxBeats }}</span>
+    </div>
+
+    <p class="mt-3 text-sm opacity-80">{{ encounter.catchBehavior }}</p>
+
+    <div class="mt-4 grid gap-3">
+      <label class="grid gap-1 text-xs font-semibold">
+        <span class="flex justify-between gap-2">
+          <span>Landing progress</span>
+          <span>{{ Math.round(encounter.progress) }}%</span>
+        </span>
+        <progress class="progress progress-success w-full" :value="encounter.progress" max="100" />
+      </label>
+
+      <label class="grid gap-1 text-xs font-semibold">
+        <span class="flex justify-between gap-2">
+          <span>Line tension</span>
+          <span>{{ Math.round(encounter.tension) }}%</span>
+        </span>
+        <progress class="progress progress-warning w-full" :value="encounter.tension" max="100" />
+      </label>
+    </div>
+
+    <div
+      class="mt-4 rounded-xl border border-base-300 bg-base-200/60 p-3 text-sm font-semibold"
+      role="status"
+      aria-live="polite"
+    >
+      <span v-if="encounter.reversed" class="badge badge-error badge-sm mr-2">Controls reversed</span>
+      {{ encounter.cue }}
+    </div>
+
+    <div class="mt-4 flex flex-wrap gap-2" aria-label="Fishing actions">
+      <button type="button" class="btn btn-primary flex-1" @click="emit('action', 'REEL')">
+        🎣 Reel
+      </button>
+      <button type="button" class="btn btn-secondary flex-1" @click="emit('action', 'SLACK')">
+        🪢 Give slack
+      </button>
+      <button type="button" class="btn btn-ghost flex-1" @click="emit('action', 'WAIT')">
+        👀 Wait
+      </button>
+    </div>
+
+    <p class="mt-3 text-xs opacity-55">
+      Fishing is beat-based, not twitch-based. Read the cue, choose an action, and the same action sequence will reproduce the same encounter.
+    </p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import type { FishingAction, FishingEncounter } from '~/utils/rulerHooked/encounter'
+
+const props = defineProps<{ encounter: FishingEncounter }>()
+const emit = defineEmits<{ action: [action: FishingAction] }>()
+
+const familyLabel = computed(() => ({
+  STANDARD_TENSION: 'steady tension',
+  PATIENCE: 'patience',
+  REVERSE_CONTROL: 'inside-out line',
+}[props.encounter.family]))
+</script>

--- a/components/ruler-hooked/ruler-hooked-game.vue
+++ b/components/ruler-hooked/ruler-hooked-game.vue
@@ -17,13 +17,28 @@
             type="button"
             class="btn btn-primary"
             :disabled="!store.canFish"
-            @click="store.fish()"
+            @click="store.startFishing()"
           >
             🎣 Cast a line
           </button>
         </div>
 
         <RulerHookedHealth :health="store.save.kingdomHealth" />
+
+        <RulerHookedFishingEncounter
+          v-if="store.activeFishing"
+          :encounter="store.activeFishing"
+          @action="store.fishingAction($event)"
+        />
+
+        <div
+          v-if="store.lastEscape"
+          class="rounded-xl border border-warning/40 bg-warning/10 p-4"
+          role="status"
+        >
+          <p class="font-bold">{{ store.lastEscape.fishName }} got away.</p>
+          <p class="mt-1 text-sm opacity-75">{{ store.lastEscape.cue }}</p>
+        </div>
 
         <RulerHookedCatch
           v-if="store.lastCatch"

--- a/stores/rulerHookedStore.ts
+++ b/stores/rulerHookedStore.ts
@@ -1,17 +1,23 @@
 // stores/rulerHookedStore.ts
 //
-// The Ruler Hooked playthrough store (data-model.md §8). A thin Pinia setup-store
-// over the verified framework-free engine (utils/rulerHooked/*): it holds the
-// active RunSave + current card, drives the turn loop, and persists via the
-// localStorage SaveStore. All game logic lives in the engine; this is UI glue.
+// The Ruler Hooked playthrough store. A thin Pinia setup-store over the verified
+// framework-free engine: active RunSave + current card + current fishing encounter,
+// persisted through the localStorage SaveStore.
 
 import { defineStore } from 'pinia'
 import { RULER_HOOKED_CONTENT as BUNDLE } from '~/utils/rulerHooked/content'
 import { createRun } from '~/utils/rulerHooked/newGame'
-import { takeTurn, eligibleEnding } from '~/utils/rulerHooked/loop'
+import { advanceAfterFishingAttempt, takeTurn, eligibleEnding } from '~/utils/rulerHooked/loop'
 import { resolveChoice, applyEffect, cloneSave } from '~/utils/rulerHooked/applyEffects'
 import { resolveScene } from '~/utils/rulerHooked/compositor'
 import { makeRng } from '~/utils/rulerHooked/seed'
+import {
+  applyFishingAction,
+  fishingEncounterFinished,
+  startFishingEncounter,
+  type FishingAction,
+  type FishingEncounter,
+} from '~/utils/rulerHooked/encounter'
 import {
   loadIndex, loadSave, writeSave, renameSlot as renameSlotStore,
   deleteSlot as deleteSlotStore, setActive, makeSaveId,
@@ -26,18 +32,33 @@ export const useRulerHookedStore = defineStore('rulerHooked', () => {
   const activeCard = ref<Card | null>(null)
   const activeArcId = ref<string | null>(null)
   const pendingEnding = ref<string | null>(null)
+  const activeFishing = ref<FishingEncounter | null>(null)
   const lastCatch = ref<CatchResult | null>(null)
+  const lastEscape = ref<{ fishName: string; cue: string } | null>(null)
   const slots = ref<SaveSlotMeta[]>([])
 
   const scene = computed(() =>
     save.value ? resolveScene(save.value, bundle.regions) : null,
   )
   const canFish = computed(
-    () => !!save.value && !activeCard.value && !pendingEnding.value && save.value.status === 'ACTIVE',
+    () => !!save.value
+      && !activeCard.value
+      && !activeFishing.value
+      && !pendingEnding.value
+      && save.value.status === 'ACTIVE',
   )
 
   function refreshSlots() {
     slots.value = loadIndex().slots
+  }
+
+  function clearTransientPlayState() {
+    activeCard.value = null
+    activeArcId.value = null
+    pendingEnding.value = null
+    activeFishing.value = null
+    lastCatch.value = null
+    lastEscape.value = null
   }
 
   /** Load the last active slot (or leave null for the title screen). */
@@ -62,9 +83,7 @@ export const useRulerHookedStore = defineStore('rulerHooked', () => {
       stamp,
     })
     save.value = run
-    activeCard.value = null
-    pendingEnding.value = null
-    lastCatch.value = null
+    clearTransientPlayState()
     writeSave(run, stamp)
     refreshSlots()
   }
@@ -73,22 +92,43 @@ export const useRulerHookedStore = defineStore('rulerHooked', () => {
     const s = loadSave(saveId)
     if (!s) return
     save.value = s
-    activeCard.value = null
-    pendingEnding.value = null
-    lastCatch.value = null
+    clearTransientPlayState()
     setActive(saveId)
     refreshSlots()
   }
 
-  /** Advance one turn: land a fish, then present any kingdom interruption. */
-  function fish() {
+  /** Select a deterministic fish and enter its beat-based encounter. */
+  function startFishing() {
     if (!save.value || !canFish.value) return
-    const rng = makeRng(`${save.value.seed}:${save.value.turnCount}`)
-    const result = takeTurn(bundle, save.value, rng)
-    save.value = result.save
-    lastCatch.value = result.catch
-    activeCard.value = result.card
-    activeArcId.value = result.arcId ?? null
+    lastCatch.value = null
+    lastEscape.value = null
+    activeFishing.value = startFishingEncounter(save.value)
+  }
+
+  /** Apply one player beat. Terminal outcomes immediately advance the reign turn. */
+  function fishingAction(action: FishingAction) {
+    if (!save.value || !activeFishing.value) return
+    const nextEncounter = applyFishingAction(activeFishing.value, action)
+    activeFishing.value = nextEncounter
+    if (!fishingEncounterFinished(nextEncounter)) return
+
+    const narrativeRng = makeRng(`${save.value.seed}:${save.value.turnCount}`)
+    if (nextEncounter.phase === 'LANDED') {
+      const result = takeTurn(bundle, save.value, narrativeRng)
+      save.value = result.save
+      lastCatch.value = result.catch
+      lastEscape.value = null
+      activeCard.value = result.card
+      activeArcId.value = result.arcId ?? null
+    } else {
+      const result = advanceAfterFishingAttempt(bundle, save.value, narrativeRng)
+      save.value = result.save
+      lastCatch.value = null
+      lastEscape.value = { fishName: nextEncounter.fishName, cue: nextEncounter.cue }
+      activeCard.value = result.card
+      activeArcId.value = result.arcId ?? null
+    }
+    activeFishing.value = null
     persist()
   }
 
@@ -116,8 +156,9 @@ export const useRulerHookedStore = defineStore('rulerHooked', () => {
     pendingEnding.value = null
     persist()
   }
+
   function declineEnding() {
-    pendingEnding.value = null // reachable, never forced
+    pendingEnding.value = null
   }
 
   function renameSlot(saveId: string, name: string) {
@@ -125,9 +166,13 @@ export const useRulerHookedStore = defineStore('rulerHooked', () => {
     if (save.value?.saveId === saveId) save.value.name = name
     refreshSlots()
   }
+
   function deleteSlot(saveId: string) {
     deleteSlotStore(saveId)
-    if (save.value?.saveId === saveId) save.value = null
+    if (save.value?.saveId === saveId) {
+      save.value = null
+      clearTransientPlayState()
+    }
     refreshSlots()
   }
 
@@ -137,9 +182,9 @@ export const useRulerHookedStore = defineStore('rulerHooked', () => {
   }
 
   return {
-    bundle, save, activeCard, activeArcId, pendingEnding, lastCatch, slots,
-    scene, canFish,
-    init, newGame, loadSlot, fish, choose, acceptEnding, declineEnding,
-    renameSlot, deleteSlot, refreshSlots,
+    bundle, save, activeCard, activeArcId, pendingEnding, activeFishing,
+    lastCatch, lastEscape, slots, scene, canFish,
+    init, newGame, loadSlot, startFishing, fishingAction, choose,
+    acceptEnding, declineEnding, renameSlot, deleteSlot, refreshSlots,
   }
 })

--- a/utils/rulerHooked/encounter.selftest.ts
+++ b/utils/rulerHooked/encounter.selftest.ts
@@ -4,11 +4,12 @@
 import assert from 'node:assert/strict'
 import { RULER_HOOKED_CONTENT as C } from './content'
 import { createRun } from './newGame'
-import { advanceAfterFishingAttempt } from './loop'
+import { advanceAfterFishingAttempt, takeTurn } from './loop'
 import { makeRng } from './seed'
 import {
   applyFishingAction,
   fishingEncounterFinished,
+  startFishingEncounter,
   startFishingEncounterForFish,
   type FishingAction,
   type FishingEncounter,
@@ -98,6 +99,14 @@ function playSmart(encounter: FishingEncounter): FishingEncounter {
   assert.equal(result.save.turnCount, 1)
   assert.equal(result.save.counters.fishCaught ?? 0, 0)
   assert.deepEqual(result.save.fishopedia, {})
+}
+
+// 7. The encounter preview and successful compatibility turn resolve the same species.
+{
+  const save = fresh()
+  const encounter = startFishingEncounter(save)
+  const turn = takeTurn(C, save, makeRng('narrative'))
+  assert.equal(encounter.fishSlug, turn.catch.fishSlug)
 }
 
 console.log('ruler-hooked ENCOUNTER self-test: ALL PASS')

--- a/utils/rulerHooked/encounter.selftest.ts
+++ b/utils/rulerHooked/encounter.selftest.ts
@@ -1,0 +1,103 @@
+// utils/rulerHooked/encounter.selftest.ts
+// Headless behavioral coverage for the beat-based fishing reducer.
+
+import assert from 'node:assert/strict'
+import { RULER_HOOKED_CONTENT as C } from './content'
+import { createRun } from './newGame'
+import { advanceAfterFishingAttempt } from './loop'
+import { makeRng } from './seed'
+import {
+  applyFishingAction,
+  fishingEncounterFinished,
+  startFishingEncounterForFish,
+  type FishingAction,
+  type FishingEncounter,
+} from './encounter'
+
+const fresh = () => createRun(C, {
+  saveId: 'encounter-test',
+  name: 'Encounter Test',
+  seed: 'encounter-seed',
+  rulerName: 'Mo',
+  honorific: 'Ruler',
+  stamp: 'T0',
+})
+
+function smartAction(encounter: FishingEncounter): FishingAction {
+  if (encounter.phase === 'APPROACH') return 'WAIT'
+  if (encounter.reversed) return encounter.tension > 70 ? 'REEL' : 'SLACK'
+  return encounter.tension > 70 ? 'SLACK' : 'REEL'
+}
+
+function playSmart(encounter: FishingEncounter): FishingEncounter {
+  let current = encounter
+  while (!fishingEncounterFinished(current)) {
+    current = applyFishingAction(current, smartAction(current))
+  }
+  return current
+}
+
+// 1. Baseline Rustfish is a real tension-management encounter and can be landed.
+{
+  const start = startFishingEncounterForFish(fresh(), 'parlour-rustfish')
+  assert.equal(start.family, 'STANDARD_TENSION')
+  assert.equal(start.phase, 'FIGHT')
+  const end = playSmart(start)
+  assert.equal(end.phase, 'LANDED')
+  assert.ok(end.history.length >= 3)
+}
+
+// 2. Same seed + same action sequence reproduces exactly the same encounter state.
+{
+  const a0 = startFishingEncounterForFish(fresh(), 'parlour-rustfish')
+  const b0 = startFishingEncounterForFish(fresh(), 'parlour-rustfish')
+  const actions: FishingAction[] = ['REEL', 'REEL', 'SLACK', 'REEL']
+  const a = actions.reduce((state, action) => applyFishingAction(state, action), a0)
+  const b = actions.reduce((state, action) => applyFishingAction(state, action), b0)
+  assert.deepEqual(a, b)
+}
+
+// 3. Sunspoke Koi requires explicit patience; giving line is not equivalent to waiting.
+{
+  let koi = startFishingEncounterForFish(fresh(), 'sunspoke-koi')
+  assert.equal(koi.family, 'PATIENCE')
+  assert.equal(koi.phase, 'APPROACH')
+  koi = applyFishingAction(koi, 'SLACK')
+  assert.equal(koi.phase, 'APPROACH')
+  koi = applyFishingAction(koi, 'WAIT')
+  assert.equal(koi.phase, 'FIGHT')
+  assert.equal(playSmart(koi).phase, 'LANDED')
+}
+
+// 4. Three impatient Sunspoke inputs lose the fish before the fight even begins.
+{
+  let koi = startFishingEncounterForFish(fresh(), 'sunspoke-koi')
+  koi = applyFishingAction(koi, 'REEL')
+  koi = applyFishingAction(koi, 'REEL')
+  koi = applyFishingAction(koi, 'REEL')
+  assert.equal(koi.phase, 'ESCAPED')
+}
+
+// 5. Moebius Crab visibly reverses controls after two fight beats.
+{
+  let crab = startFishingEncounterForFish(fresh(), 'moebius-crab')
+  assert.equal(crab.family, 'REVERSE_CONTROL')
+  crab = applyFishingAction(crab, 'REEL')
+  crab = applyFishingAction(crab, 'SLACK')
+  assert.equal(crab.reversed, true)
+  const before = crab.progress
+  crab = applyFishingAction(crab, 'SLACK')
+  assert.ok(crab.progress > before, 'SLACK gains line while controls are reversed')
+  assert.equal(playSmart(crab).phase, 'LANDED')
+}
+
+// 6. An escaped attempt advances governance without inventing a catch.
+{
+  const save = fresh()
+  const result = advanceAfterFishingAttempt(C, save, makeRng('narrative'))
+  assert.equal(result.save.turnCount, 1)
+  assert.equal(result.save.counters.fishCaught ?? 0, 0)
+  assert.deepEqual(result.save.fishopedia, {})
+}
+
+console.log('ruler-hooked ENCOUNTER self-test: ALL PASS')

--- a/utils/rulerHooked/encounter.ts
+++ b/utils/rulerHooked/encounter.ts
@@ -1,0 +1,244 @@
+// utils/rulerHooked/encounter.ts
+//
+// Framework-free, beat-based fishing encounters for The Ruler Is Hooked.
+// Canonical outcomes depend on encounter state + player actions + seeded RNG,
+// never elapsed milliseconds, animation frames, device speed, or wall clock.
+
+import type { FishAffinity, Rarity, RunSave } from '~/types/ruler-hooked'
+import { cloneSave } from './applyEffects'
+import { resolveFishingCatch } from './fish'
+import { makeRng } from './seed'
+
+export type FishingAction = 'REEL' | 'SLACK' | 'WAIT'
+export type FishingPhase = 'APPROACH' | 'FIGHT' | 'LANDED' | 'ESCAPED'
+export type FishingFamily = 'STANDARD_TENSION' | 'PATIENCE' | 'REVERSE_CONTROL'
+
+export interface FishingBeatRecord {
+  beat: number
+  action: FishingAction
+  phase: FishingPhase
+  progress: number
+  tension: number
+  reversed: boolean
+  cue: string
+}
+
+export interface FishingEncounter {
+  id: string
+  seed: string
+  fishSlug: string
+  fishName: string
+  affinity: FishAffinity
+  rarity: Rarity
+  catchBehavior: string
+  family: FishingFamily
+  phase: FishingPhase
+  beat: number
+  maxBeats: number
+  progress: number
+  tension: number
+  reversed: boolean
+  approachMistakes: number
+  cue: string
+  history: FishingBeatRecord[]
+}
+
+interface FishingProfile {
+  family: FishingFamily
+  maxBeats: number
+  progressPerReel: number
+  tensionPerReel: number
+  slackRecovery: number
+}
+
+const STANDARD_PROFILE: FishingProfile = {
+  family: 'STANDARD_TENSION',
+  maxBeats: 8,
+  progressPerReel: 30,
+  tensionPerReel: 22,
+  slackRecovery: 28,
+}
+
+const PROFILES: Record<string, FishingProfile> = {
+  'sunspoke-koi': {
+    family: 'PATIENCE',
+    maxBeats: 9,
+    progressPerReel: 29,
+    tensionPerReel: 20,
+    slackRecovery: 26,
+  },
+  'moebius-crab': {
+    family: 'REVERSE_CONTROL',
+    maxBeats: 9,
+    progressPerReel: 31,
+    tensionPerReel: 21,
+    slackRecovery: 27,
+  },
+}
+
+export function profileForFish(fishSlug: string): FishingProfile {
+  return PROFILES[fishSlug] ?? STANDARD_PROFILE
+}
+
+/**
+ * Select the same fish the compatibility takeTurn() path will later record,
+ * but against a clone so beginning an encounter does not mutate the real save.
+ */
+export function startFishingEncounter(save: RunSave): FishingEncounter {
+  const fishSeed = `${save.seed}:${save.turnCount}:fish`
+  const preview = resolveFishingCatch(cloneSave(save), makeRng(fishSeed))
+  const profile = profileForFish(preview.fishSlug)
+  const patience = profile.family === 'PATIENCE'
+
+  return {
+    id: `${save.saveId}:${save.turnCount}:${preview.fishSlug}`,
+    seed: `${save.seed}:${save.turnCount}:fight:${preview.fishSlug}`,
+    fishSlug: preview.fishSlug,
+    fishName: preview.name,
+    affinity: preview.affinity,
+    rarity: preview.rarity,
+    catchBehavior: preview.catchBehavior,
+    family: profile.family,
+    phase: patience ? 'APPROACH' : 'FIGHT',
+    beat: 0,
+    maxBeats: profile.maxBeats,
+    progress: 0,
+    tension: patience ? 0 : 30,
+    reversed: false,
+    approachMistakes: 0,
+    cue: patience
+      ? `${preview.name} circles the lure without committing. Stop pulling and watch it.`
+      : `${preview.name} takes the hook. Build progress without letting line tension spike.`,
+    history: [],
+  }
+}
+
+const clamp = (value: number, min = 0, max = 100): number =>
+  Math.max(min, Math.min(max, value))
+
+function recordBeat(encounter: FishingEncounter, action: FishingAction): FishingEncounter {
+  return {
+    ...encounter,
+    history: [
+      ...encounter.history,
+      {
+        beat: encounter.beat,
+        action,
+        phase: encounter.phase,
+        progress: encounter.progress,
+        tension: encounter.tension,
+        reversed: encounter.reversed,
+        cue: encounter.cue,
+      },
+    ],
+  }
+}
+
+function resolveApproach(encounter: FishingEncounter, action: FishingAction): FishingEncounter {
+  const next: FishingEncounter = {
+    ...encounter,
+    beat: encounter.beat + 1,
+  }
+
+  if (action === 'WAIT') {
+    next.phase = 'FIGHT'
+    next.progress = 8
+    next.tension = 24
+    next.cue = `${next.fishName} finally turns inward. The fins flare: now the hook is real.`
+    return recordBeat(next, action)
+  }
+
+  next.approachMistakes += 1
+  next.tension = clamp(next.tension + (action === 'REEL' ? 16 : 6))
+  next.cue = action === 'REEL'
+    ? `${next.fishName} widens its circle. Pulling now only convinces it that you are impatient.`
+    : `${next.fishName} keeps circling. Giving line is not the same thing as waiting.`
+
+  if (next.approachMistakes >= 3) {
+    next.phase = 'ESCAPED'
+    next.cue = `${next.fishName} loses interest and glides away. The lake has judged your patience.`
+  }
+  return recordBeat(next, action)
+}
+
+function effectiveAction(encounter: FishingEncounter, action: FishingAction): FishingAction {
+  if (!encounter.reversed) return action
+  if (action === 'REEL') return 'SLACK'
+  if (action === 'SLACK') return 'REEL'
+  return action
+}
+
+function resolveFight(encounter: FishingEncounter, action: FishingAction): FishingEncounter {
+  const profile = profileForFish(encounter.fishSlug)
+  const next: FishingEncounter = {
+    ...encounter,
+    beat: encounter.beat + 1,
+  }
+  const rng = makeRng(`${encounter.seed}:${next.beat}:${action}`)
+  const surge = Math.floor(rng.next() * 8)
+  const resistance = Math.floor(rng.next() * 5)
+  const applied = effectiveAction(encounter, action)
+
+  if (applied === 'REEL') {
+    next.progress = clamp(next.progress + profile.progressPerReel - resistance)
+    next.tension = clamp(next.tension + profile.tensionPerReel + surge)
+  } else if (applied === 'SLACK') {
+    next.progress = clamp(next.progress - 5)
+    next.tension = clamp(next.tension - profile.slackRecovery)
+  } else {
+    next.progress = clamp(next.progress - 1)
+    next.tension = clamp(next.tension - 12 + Math.floor(surge / 2))
+  }
+
+  if (next.tension >= 100) {
+    next.phase = 'ESCAPED'
+    next.cue = `The line snaps tight and ${next.fishName} tears free.`
+    return recordBeat(next, action)
+  }
+
+  if (next.progress >= 100) {
+    next.phase = 'LANDED'
+    next.cue = `${next.fishName} breaks the surface. Landed.`
+    return recordBeat(next, action)
+  }
+
+  if (next.beat >= next.maxBeats) {
+    next.phase = 'ESCAPED'
+    next.cue = `${next.fishName} finds one last reserve of energy and slips the hook.`
+    return recordBeat(next, action)
+  }
+
+  if (next.family === 'REVERSE_CONTROL' && !next.reversed && next.beat >= 2) {
+    next.reversed = true
+    next.cue = 'The Moebius shell turns through itself. Controls are reversed: REEL now gives line; SLACK gains line.'
+    return recordBeat(next, action)
+  }
+
+  if (next.reversed) {
+    next.cue = next.tension > 78
+      ? 'Inside-out line, high tension. Remember: REEL gives line while the loop is reversed.'
+      : 'The loop is still reversed. SLACK pulls the crab closer; REEL releases tension.'
+  } else if (next.tension > 80) {
+    next.cue = 'The line is singing. Give it slack before the next hard pull.'
+  } else if (next.tension < 20) {
+    next.cue = 'The line has gone soft. Reel carefully to recover progress.'
+  } else {
+    next.cue = 'Tension is workable. Choose whether to gain ground or prepare for the next surge.'
+  }
+
+  return recordBeat(next, action)
+}
+
+/** Pure reducer: same encounter state + action always produces the same next state. */
+export function applyFishingAction(
+  encounter: FishingEncounter,
+  action: FishingAction,
+): FishingEncounter {
+  if (encounter.phase === 'LANDED' || encounter.phase === 'ESCAPED') return encounter
+  if (encounter.phase === 'APPROACH') return resolveApproach(encounter, action)
+  return resolveFight(encounter, action)
+}
+
+export function fishingEncounterFinished(encounter: FishingEncounter): boolean {
+  return encounter.phase === 'LANDED' || encounter.phase === 'ESCAPED'
+}

--- a/utils/rulerHooked/encounter.ts
+++ b/utils/rulerHooked/encounter.ts
@@ -6,7 +6,7 @@
 
 import type { FishAffinity, Rarity, RunSave } from '~/types/ruler-hooked'
 import { cloneSave } from './applyEffects'
-import { resolveFishingCatch } from './fish'
+import { RULER_HOOKED_FISH, resolveFishingCatch } from './fish'
 import { makeRng } from './seed'
 
 export type FishingAction = 'REEL' | 'SLACK' | 'WAIT'
@@ -51,6 +51,14 @@ interface FishingProfile {
   slackRecovery: number
 }
 
+interface EncounterFish {
+  fishSlug: string
+  name: string
+  affinity: FishAffinity
+  rarity: Rarity
+  catchBehavior: string
+}
+
 const STANDARD_PROFILE: FishingProfile = {
   family: 'STANDARD_TENSION',
   maxBeats: 8,
@@ -80,13 +88,7 @@ export function profileForFish(fishSlug: string): FishingProfile {
   return PROFILES[fishSlug] ?? STANDARD_PROFILE
 }
 
-/**
- * Select the same fish the compatibility takeTurn() path will later record,
- * but against a clone so beginning an encounter does not mutate the real save.
- */
-export function startFishingEncounter(save: RunSave): FishingEncounter {
-  const fishSeed = `${save.seed}:${save.turnCount}:fish`
-  const preview = resolveFishingCatch(cloneSave(save), makeRng(fishSeed))
+function buildEncounter(save: RunSave, preview: EncounterFish): FishingEncounter {
   const profile = profileForFish(preview.fishSlug)
   const patience = profile.family === 'PATIENCE'
 
@@ -113,6 +115,29 @@ export function startFishingEncounter(save: RunSave): FishingEncounter {
   }
 }
 
+/**
+ * Select the same fish the compatibility takeTurn() path will later record,
+ * but against a clone so beginning an encounter does not mutate the real save.
+ */
+export function startFishingEncounter(save: RunSave): FishingEncounter {
+  const fishSeed = `${save.seed}:${save.turnCount}:fish`
+  const preview = resolveFishingCatch(cloneSave(save), makeRng(fishSeed))
+  return buildEncounter(save, preview)
+}
+
+/** Deterministic direct constructor for reducer tests and authored previews. */
+export function startFishingEncounterForFish(save: RunSave, fishSlug: string): FishingEncounter {
+  const fish = RULER_HOOKED_FISH.find((candidate) => candidate.slug === fishSlug)
+  if (!fish) throw new Error(`Unknown Ruler Hooked fish: ${fishSlug}`)
+  return buildEncounter(save, {
+    fishSlug: fish.slug,
+    name: fish.name,
+    affinity: fish.affinity,
+    rarity: fish.rarity,
+    catchBehavior: fish.catchBehavior,
+  })
+}
+
 const clamp = (value: number, min = 0, max = 100): number =>
   Math.max(min, Math.min(max, value))
 
@@ -135,10 +160,7 @@ function recordBeat(encounter: FishingEncounter, action: FishingAction): Fishing
 }
 
 function resolveApproach(encounter: FishingEncounter, action: FishingAction): FishingEncounter {
-  const next: FishingEncounter = {
-    ...encounter,
-    beat: encounter.beat + 1,
-  }
+  const next: FishingEncounter = { ...encounter, beat: encounter.beat + 1 }
 
   if (action === 'WAIT') {
     next.phase = 'FIGHT'
@@ -170,10 +192,7 @@ function effectiveAction(encounter: FishingEncounter, action: FishingAction): Fi
 
 function resolveFight(encounter: FishingEncounter, action: FishingAction): FishingEncounter {
   const profile = profileForFish(encounter.fishSlug)
-  const next: FishingEncounter = {
-    ...encounter,
-    beat: encounter.beat + 1,
-  }
+  const next: FishingEncounter = { ...encounter, beat: encounter.beat + 1 }
   const rng = makeRng(`${encounter.seed}:${next.beat}:${action}`)
   const surge = Math.floor(rng.next() * 8)
   const resistance = Math.floor(rng.next() * 5)

--- a/utils/rulerHooked/loop.ts
+++ b/utils/rulerHooked/loop.ts
@@ -1,9 +1,12 @@
 // utils/rulerHooked/loop.ts
 //
 // The pure turn loop (data-model.md §5). Keeps ALL game logic framework-free so
-// the Pinia store is a thin wrapper and the loop is testable headlessly. One turn:
-// fish beat → maybe an arc step, else maybe an interrupt/ambient draw → present a
-// card (or none). Applying the chosen effect is resolveChoice() (applyEffects.ts).
+// the Pinia store is a thin wrapper and the loop is testable headlessly.
+//
+// Interactive fishing now resolves before the kingdom interruption. The legacy
+// takeTurn() wrapper remains for headless tests and callers that want an automatic
+// successful catch, while advanceAfterFishingAttempt() advances governance after
+// either a landed or escaped interactive encounter.
 //
 // No wall-clock anywhere: turnCount is the only progression counter and time-of-day
 // is derived from it.
@@ -23,6 +26,12 @@ export interface TurnResult {
   arcId?: string
 }
 
+export interface KingdomTurnResult {
+  save: RunSave
+  card: Card | null
+  arcId?: string
+}
+
 /** Find an arc-step card by id across all arcs in the bundle. */
 export function findArcStep(bundle: ContentBundle, stepId: string): { card: Card; arcId: string } | null {
   for (const arc of bundle.arcs) {
@@ -37,15 +46,67 @@ export function allDeckCards(bundle: ContentBundle): Card[] {
   return bundle.decks.flatMap((d) => d.cards)
 }
 
+/** Resolve governance after the fishing attempt has already consumed the turn. */
+function resolveNarrative(
+  bundle: ContentBundle,
+  next: RunSave,
+  rng: RngStream,
+  interruptChance = 0.6,
+): KingdomTurnResult {
+  tickCooldowns(next)
+  const seen = new Set(next.deckState.seenCardIds)
+
+  // 1. A pending active-arc step (arcs resolve before free draws).
+  for (const arcId of Object.keys(next.deckState.activeArcs)) {
+    const step = next.deckState.activeArcs[arcId]?.step
+    if (step && !seen.has(step)) {
+      const found = findArcStep(bundle, step)
+      if (found) return { save: next, card: found.card, arcId }
+    }
+  }
+
+  // 2. Start a newly eligible arc (seeded chance), presenting its first step.
+  for (const arc of bundle.arcs) {
+    if (next.deckState.activeArcs[arc.id]) continue
+    if (arc.steps.some((s) => seen.has(s.id))) continue
+    const trig = arc.start?.trigger
+    if (!triggerHolds(next, trig)) continue
+    const chance = trig?.chance ?? 1
+    if (rng.next() >= chance) continue
+    const first = arc.steps[0]
+    if (!first) continue
+    next.deckState.activeArcs[arc.id] = { step: first.id, flags: {} }
+    return { save: next, card: first, arcId: arc.id }
+  }
+
+  // 3. A free interrupt/ambient draw (seeded, may be null → quiet fishing).
+  const card = selectCard(next, allDeckCards(bundle), rng, interruptChance)
+  if (card && card.trigger?.cooldown) {
+    next.deckState.cooldowns[card.id] = card.trigger.cooldown
+  }
+  return { save: next, card }
+}
+
 /**
- * Advance one turn. Priority: (1) land a deterministic fish from the currently
- * available ecology, (2) a pending active-arc step, (3) starting a newly eligible
- * arc, (4) a seeded interrupt/ambient draw. Returns a new save plus the catch and
- * any card to present.
- *
- * Fishing uses a turn-scoped child RNG derived from the run seed. Narrative draws
- * keep the caller-supplied RNG stream. This deliberately prevents future changes to
- * specimen math (size/quality/fight cues) from changing which kingdom card appears.
+ * Consume one reign turn after an interactive fishing attempt, successful or not,
+ * then resolve the normal kingdom interruption. No fish is recorded here.
+ */
+export function advanceAfterFishingAttempt(
+  bundle: ContentBundle,
+  save: RunSave,
+  rng: RngStream,
+  interruptChance = 0.6,
+): KingdomTurnResult {
+  const next = cloneSave(save)
+  next.turnCount += 1
+  next.cyclePosition = cyclePosition(next.turnCount)
+  return resolveNarrative(bundle, next, rng, interruptChance)
+}
+
+/**
+ * Compatibility wrapper for an automatic successful catch. Fishing uses a
+ * turn-scoped child RNG derived from the run seed. Narrative draws keep the
+ * caller-supplied RNG stream, so specimen math cannot perturb kingdom cards.
  */
 export function takeTurn(
   bundle: ContentBundle,
@@ -56,44 +117,15 @@ export function takeTurn(
   const next = cloneSave(save)
   const fishRng = makeRng(`${next.seed}:${next.turnCount}:fish`)
 
-  // 1. Fish beat — now a real species/specimen, not the original 50% counter flip.
   next.turnCount += 1
   next.cyclePosition = cyclePosition(next.turnCount)
   const caught = resolveFishingCatch(next, fishRng)
-  tickCooldowns(next)
+  const narrative = resolveNarrative(bundle, next, rng, interruptChance)
 
-  const seen = new Set(next.deckState.seenCardIds)
-
-  // 2. A pending active-arc step (arcs resolve before free draws).
-  for (const arcId of Object.keys(next.deckState.activeArcs)) {
-    const step = next.deckState.activeArcs[arcId]?.step
-    if (step && !seen.has(step)) {
-      const found = findArcStep(bundle, step)
-      if (found) return { save: next, catch: caught, card: found.card, arcId }
-    }
+  return {
+    ...narrative,
+    catch: caught,
   }
-
-  // 3. Start a newly eligible arc (seeded chance), presenting its first step.
-  for (const arc of bundle.arcs) {
-    if (next.deckState.activeArcs[arc.id]) continue // already active
-    // completed arcs leave no active entry but their steps are in seenCardIds
-    if (arc.steps.some((s) => seen.has(s.id))) continue
-    const trig = arc.start?.trigger
-    if (!triggerHolds(next, trig)) continue
-    const chance = trig?.chance ?? 1
-    if (rng.next() >= chance) continue
-    const first = arc.steps[0]
-    if (!first) continue
-    next.deckState.activeArcs[arc.id] = { step: first.id, flags: {} }
-    return { save: next, catch: caught, card: first, arcId: arc.id }
-  }
-
-  // 4. A free interrupt/ambient draw (seeded, may be null → quiet fishing).
-  const card = selectCard(next, allDeckCards(bundle), rng, interruptChance)
-  if (card && card.trigger?.cooldown) {
-    next.deckState.cooldowns[card.id] = card.trigger.cooldown
-  }
-  return { save: next, catch: caught, card }
 }
 
 /**


### PR DESCRIPTION
### Task
Implement the first interactive catch-mechanics slice from the merged Ruler Hooked catch contract.

### What changed
- Adds one framework-free, deterministic beat-based fishing encounter reducer.
- `Cast a line` now opens an encounter instead of immediately awarding a fish.
- Adds shared REEL / SLACK / WAIT actions, progress, tension, readable cues, and landed/escaped outcomes.
- Implements three distinct behavior families:
  - Parlour Rustfish / default catches: standard tension management.
  - Sunspoke Koi: PATIENCE approach, where only WAIT creates the bite window.
  - Moebius Crab: REVERSE_CONTROL, visibly swapping REEL and SLACK semantics mid-fight.
- Escaped fish consume the reign turn but are not recorded as catches; kingdom interruptions still resolve normally afterward.
- Landed fish continue through the existing deterministic catch resolver, preserving specimen/Fishopedia behavior and fish-vs-narrative RNG isolation.
- Adds a reusable accessible encounter panel with non-twitch controls and explicit state/cue text.
- Adds headless reducer coverage for deterministic replay, baseline landing, patience success/failure, reversed controls, escape-without-catch turn advancement, and encounter-preview/landed-species parity.
- Adds a focused Ruler Hooked GitHub Actions workflow so the existing game self-test and new encounter self-test execute on relevant changes.

### Scope boundary
This is the first behavior slice, not all fifteen authored behavior primitives. Unsupported species currently fall back to the standard-tension family until their composable primitives are implemented in subsequent slices. No one-off species branch was added to the top-level kingdom loop.

An in-progress encounter is currently transient UI state rather than save-schema state. Reloading mid-fight therefore restarts the same deterministic encounter at the same reign turn. Persist/resume-mid-catch should be addressed before calling fight-state persistence complete.

### Determinism
Canonical outcomes depend on save state, encounter seed, and player action sequence. Real-time milliseconds, animation frames, and wall clock do not affect catch outcome.

### CI note
GitGuardian is green on the current head. At the time of this update GitHub has not emitted Actions workflow runs for this PR head despite opened/reopened/synchronize events. Auto-merge is enabled, but the repository ruleset has mandatory TypeScript, Contract verifiers, and schema `verify` checks with no bypass actors, so this PR cannot merge until those checks actually run and pass.