### PR TITLE
interface-vision/t-105: polish Projects overview header (conductor-project-gallery-page.vue)

### DIFF
--- a/components/pages/conductor-project-gallery-page.vue
+++ b/components/pages/conductor-project-gallery-page.vue
@@ -2,6 +2,21 @@
   <section
     class="kr-surface rounded-2xl border border-base-300 bg-(--kr-surface) p-3"
   >
+    <header class="flex shrink-0 items-start gap-3">
+      <div
+        class="flex size-12 shrink-0 items-center justify-center rounded-2xl bg-primary/15 text-primary"
+      >
+        <Icon name="kind-icon:gallery" class="size-6" />
+      </div>
+      <div class="min-w-0 flex-1">
+        <h2 class="text-2xl font-black tracking-tight">Projects</h2>
+        <p class="text-sm text-base-content/60">
+          Browse every Conductor project, filter by status, or start a new
+          one.
+        </p>
+      </div>
+    </header>
+
     <section
       v-if="createOpen"
       class="shrink-0 rounded-xl border border-base-300 bg-base-100"


### PR DESCRIPTION
### Task
interface-vision/t-105: Polish every reachable Kind Robots surface page-by-page (kind: software)

### What changed / what I produced
- Added the established icon-badge + title/subtitle header pattern to `components/pages/conductor-project-gallery-page.vue`. Prior state had no page-level header at all — it opened straight into the create-project form / drift-detection panels / project list.
- This page is the default "overview" view inside `conductor-manager.vue`'s workspace switch, and is also embedded as the "Projects" tab in `user-galleries.vue`. Every sibling view reached through that same switch (`AppmakerPage`, `PortosPage`, `ConductorPitchManager`) already had the header treatment — this was the one gap, and the highest-traffic one.
- Icon: `kind-icon:gallery`, matching the icon already assigned to the `gallery` view for the `project` core object in `utils/scripts/coreObjectRoutes.ts`. Header shape follows `portos-page.vue`'s closest-sibling precedent (same embedded-default-view role, no back button since this page IS the overview).
- Template/classes only — no script or store changes.

### How I verified
- `npx eslint components/pages/conductor-project-gallery-page.vue` — clean
- `npx vue-tsc --noEmit` — clean
- `npm run test:layout-contract` — holds, 0 new violations (an unrelated pre-existing `video-lora-picker.vue` viewport-grid baseline improvement was observed and left untouched, out of scope)
- `npx prettier --check` on the file flags pre-existing drift, confirmed via `git stash` to predate this change — left alone

### Stakes
reversible

### Kaizen suggestion
None filed — the next `t-105` slice should re-survey `pages/music-mentor.vue` and `pages/coloring-page.vue`, both of which use an emoji + bare bold text instead of the icon-badge container, as the next candidates.

### Notes for reviewer
Part of the recurring interface-vision/t-105 page-polish task tracked in the `conductor` repo's roadmap.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QXi1S8iSkT74ZnQkoJe9bg)_