### PR TITLE
interface-vision/t-121: polish music-mentor.vue and coloring-page.vue headers to icon-badge pattern

### DIFF
--- a/pages/coloring-page.vue
+++ b/pages/coloring-page.vue
@@ -9,21 +9,27 @@
 <template>
   <div class="kr-surface kr-container max-w-4xl">
     <div class="kr-scroll flex flex-col gap-4 p-4 sm:p-6">
-      <header class="flex flex-col gap-2">
-        <div class="flex flex-wrap items-center gap-2">
-          <span class="text-3xl leading-none">🖍️</span>
-          <p class="text-2xl font-black text-base-content sm:text-3xl">
-            Coloring Page Maker
-          </p>
-          <span class="badge badge-primary badge-sm font-bold">New</span>
+      <header class="flex items-start gap-3">
+        <div
+          class="flex size-12 shrink-0 items-center justify-center rounded-2xl bg-primary/15 text-primary"
+        >
+          <Icon name="kind-icon:magic" class="size-6" />
         </div>
-        <p class="max-w-2xl text-sm text-base-content/60">
-          Turn any photo or finished design into a printable black-and-white
-          coloring page. Upload an image or pick one from your gallery, choose
-          <b class="text-base-content/80">Coloring Page</b> for crisp line art or
-          <b class="text-base-content/80">Bold Coloring</b> for thick,
-          kid-friendly outlines, then generate, download, and print.
-        </p>
+        <div class="min-w-0 flex-1">
+          <div class="flex flex-wrap items-center gap-2">
+            <p class="text-2xl font-black tracking-tight text-base-content">
+              Coloring Page Maker
+            </p>
+            <span class="badge badge-primary badge-sm font-bold">New</span>
+          </div>
+          <p class="max-w-2xl text-sm text-base-content/60">
+            Turn any photo or finished design into a printable black-and-white
+            coloring page. Upload an image or pick one from your gallery, choose
+            <b class="text-base-content/80">Coloring Page</b> for crisp line art
+            or <b class="text-base-content/80">Bold Coloring</b> for thick,
+            kid-friendly outlines, then generate, download, and print.
+          </p>
+        </div>
       </header>
 
       <art-styler

--- a/pages/music-mentor.vue
+++ b/pages/music-mentor.vue
@@ -1,20 +1,27 @@
 <template>
   <div class="kr-surface">
     <div class="kr-scroll p-6 space-y-6 max-w-3xl mx-auto">
-      <header class="space-y-1">
-        <p class="text-2xl font-bold">🎤 Music Mentor</p>
-        <p class="text-sm opacity-70">
-          Upload a recording of your sung medley and get honest, specific
-          feedback on the singing and the arrangement. Everything is analyzed
-          <strong>in your browser</strong> — the audio never leaves your device,
-          and nothing is stored.
-        </p>
-        <p class="text-xs opacity-60">
-          Honest heads-up: this measures the objective stuff (pitch, timing,
-          dynamics, structure) and reasons over your setlist. It can't judge
-          tone, emotion, or "is this a good voice" — that still needs a human
-          ear.
-        </p>
+      <header class="flex items-start gap-3">
+        <div
+          class="flex size-12 shrink-0 items-center justify-center rounded-2xl bg-primary/15 text-primary"
+        >
+          <Icon name="kind-icon:microphone" class="size-6" />
+        </div>
+        <div class="min-w-0 flex-1 space-y-1">
+          <p class="text-2xl font-black tracking-tight">Music Mentor</p>
+          <p class="text-sm text-base-content/60">
+            Upload a recording of your sung medley and get honest, specific
+            feedback on the singing and the arrangement. Everything is analyzed
+            <strong>in your browser</strong> — the audio never leaves your
+            device, and nothing is stored.
+          </p>
+          <p class="text-xs text-base-content/50">
+            Honest heads-up: this measures the objective stuff (pitch, timing,
+            dynamics, structure) and reasons over your setlist. It can't judge
+            tone, emotion, or "is this a good voice" — that still needs a human
+            ear.
+          </p>
+        </div>
       </header>
 
       <div v-if="!isLoggedIn" class="alert alert-warning text-sm" role="alert">


### PR DESCRIPTION
### Task
interface-vision/t-121: Kaizen: polish pages/music-mentor.vue and pages/coloring-page.vue headers to the icon-badge pattern (kind: software)

### What changed / what I produced
- `pages/music-mentor.vue`: replaced the inline 🎤 emoji + bare bold text header with the established icon-badge (`kind-icon:microphone`) + title/subtitle pattern used across other interface-vision slices (e.g. t-105's `conductor-project-gallery-page.vue`). Kept both existing subtitle paragraphs (the main description and the "honest heads-up" caveat).
- `pages/coloring-page.vue`: replaced the inline 🖍️ emoji + bare bold text header with an icon-badge (`kind-icon:magic` — the icon this exact route already uses in its own dashboard tab entry in `stores/helpers/dashboardHelper.ts`). Kept the "New" badge inline with the title.
- Both changes are template/markup only — no script or store changes.

### How I verified
- `npx eslint pages/music-mentor.vue pages/coloring-page.vue` — clean
- `npx vue-tsc --noEmit` — clean, full repo
- `npx prettier --check` on both files — clean (ran `--write` once to match repo formatting)
- `npm run test:layout-contract` — holds, 0 new violations. Note: the title element in each header is a `<p>`, not `<h1>`, per the `one-header` rule ("the shell renders the page title; a page component never does") — matches every other page/component's convention. The pre-existing `video-lora-picker.vue` viewport-grid baseline improvement was observed again and left untouched (out of scope, same as prior slices).

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
`t-121`'s own note already named these as "straightforward next candidates" — no further top-level route pages were found still needing this treatment during this pass, but a future slice could re-run the same page-by-page sweep to confirm.

### Notes for reviewer
Safe to merge on green CI — markup-only change, no behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_019mTexbhvptrWULpJ4YMoAC)_