### PR TITLE
ruler-hooked/t-021: build the ruler character creator

### DIFF
--- a/.github/workflows/ruler-hooked.yml
+++ b/.github/workflows/ruler-hooked.yml
@@ -31,3 +31,5 @@ jobs:
         run: npx tsx utils/rulerHooked/game.selftest.ts
       - name: Fishing encounter self-test
         run: npx tsx utils/rulerHooked/encounter.selftest.ts
+      - name: Core engine self-test
+        run: npx tsx utils/rulerHooked/engine.selftest.ts

--- a/components/ruler-hooked/ruler-hooked-cosmetics-picker.vue
+++ b/components/ruler-hooked/ruler-hooked-cosmetics-picker.vue
@@ -1,0 +1,129 @@
+<!-- components/ruler-hooked/ruler-hooked-cosmetics-picker.vue
+     Shared ruler-appearance picker (ruler-hooked/t-021): a grid of the twelve
+     preset rulers (t-020's approved cast) plus a "use my own picture instead"
+     file input. Used both at new-game creation (ruler-hooked-slots.vue) and
+     from the in-play "change appearance" panel (ruler-hooked-cosmetics.vue) —
+     cosmetics are cosmetic-only by design, so nothing here is locked to
+     creation time. Presets are read entirely from RULER_PRESETS data; no id
+     is ever hardcoded in the template (t-021: "read the list as data"). -->
+<template>
+  <div class="flex flex-col gap-3">
+    <div class="grid grid-cols-[repeat(auto-fit,minmax(4.5rem,1fr))] gap-2">
+      <button
+        v-for="preset in presets"
+        :key="preset.id"
+        type="button"
+        class="group flex flex-col items-center gap-1 rounded-lg border p-1.5 text-center transition-colors"
+        :class="
+          !customFile && modelValue === preset.id
+            ? 'border-primary bg-primary/10'
+            : 'border-base-300 hover:border-primary/50'
+        "
+        :title="preset.look"
+        :aria-pressed="!customFile && modelValue === preset.id"
+        @click="selectPreset(preset.id)"
+      >
+        <img
+          v-if="!brokenPresets[preset.id]"
+          :src="`/images/ruler-hooked/ruler-${preset.id}.webp`"
+          :alt="`${preset.title} ${preset.id}`"
+          class="aspect-square w-full rounded-md bg-base-200 object-cover"
+          loading="lazy"
+          @error="onPresetImgError(preset.id)"
+        />
+        <div
+          v-else
+          class="flex aspect-square w-full items-center justify-center rounded-md bg-base-200 text-lg font-bold opacity-50"
+        >
+          {{ preset.title.charAt(0) }}
+        </div>
+        <span class="line-clamp-1 text-[10px] font-medium opacity-80">{{
+          preset.title
+        }}</span>
+      </button>
+    </div>
+
+    <div
+      class="flex flex-wrap items-center gap-2 border-t border-base-300 pt-2"
+    >
+      <label class="btn btn-outline btn-xs">
+        Use my own picture instead
+        <input
+          type="file"
+          accept="image/*"
+          class="hidden"
+          @change="onFilePicked"
+        />
+      </label>
+      <span
+        v-if="customFile"
+        class="flex items-center gap-1 text-xs opacity-70"
+      >
+        <img
+          v-if="customPreviewUrl"
+          :src="customPreviewUrl"
+          alt="Custom portrait preview"
+          class="size-8 rounded object-cover"
+        />
+        {{ customFile.name }}
+        <button type="button" class="btn btn-ghost btn-xs" @click="clearCustom">
+          clear
+        </button>
+      </span>
+      <span v-else class="text-xs opacity-50"
+        >Stored on this device only — never uploaded.</span
+      >
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { RULER_PRESETS } from '~/utils/rulerHooked/rulerPresets'
+
+defineProps<{
+  /** Selected preset id — ignored for display purposes while a custom file is staged. */
+  modelValue: string
+}>()
+const emit = defineEmits<{
+  'update:modelValue': [id: string]
+  /** A new custom-portrait file was picked (or cleared, with null). */
+  'custom-file': [file: File | null]
+}>()
+
+const presets = RULER_PRESETS
+const customFile = ref<File | null>(null)
+const customPreviewUrl = ref<string | null>(null)
+
+// A preset's own dedicated layer may not be rendered yet (t-021/t-020); a
+// broken preview thumbnail just hides the <img> rather than showing a
+// browser broken-image icon — the picker still works by title/tooltip.
+const brokenPresets = reactive<Record<string, boolean>>({})
+function onPresetImgError(id: string) {
+  brokenPresets[id] = true
+}
+
+function selectPreset(id: string) {
+  clearCustom()
+  emit('update:modelValue', id)
+}
+
+function onFilePicked(e: Event) {
+  const file = (e.target as HTMLInputElement).files?.[0]
+  if (!file) return
+  if (customPreviewUrl.value) URL.revokeObjectURL(customPreviewUrl.value)
+  customFile.value = file
+  customPreviewUrl.value = URL.createObjectURL(file)
+  emit('custom-file', file)
+}
+
+function clearCustom() {
+  if (customPreviewUrl.value) URL.revokeObjectURL(customPreviewUrl.value)
+  customFile.value = null
+  customPreviewUrl.value = null
+  emit('custom-file', null)
+}
+
+onBeforeUnmount(() => {
+  if (customPreviewUrl.value) URL.revokeObjectURL(customPreviewUrl.value)
+})
+</script>

--- a/components/ruler-hooked/ruler-hooked-cosmetics.vue
+++ b/components/ruler-hooked/ruler-hooked-cosmetics.vue
@@ -1,0 +1,53 @@
+<!-- components/ruler-hooked/ruler-hooked-cosmetics.vue
+     In-play "change appearance" panel (ruler-hooked/t-021: "they are
+     cosmetic-only by design, so there is no reason to lock them at
+     creation"). Collapsed by default so it doesn't compete with the play
+     screen; opens onto the same picker the new-game form uses. -->
+<template>
+  <details class="rounded-xl border border-base-300 bg-base-100 p-3">
+    <summary class="cursor-pointer text-xs font-medium opacity-70">
+      Change appearance
+    </summary>
+    <div class="mt-2 flex flex-col gap-2">
+      <RulerHookedCosmeticsPicker
+        v-model="presetId"
+        @custom-file="(f: File | null) => (customPortraitFile = f)"
+      />
+      <div class="flex justify-end gap-2">
+        <button
+          type="button"
+          class="btn btn-primary btn-sm"
+          :disabled="saving"
+          @click="save"
+        >
+          {{ saving ? 'Saving…' : 'Save appearance' }}
+        </button>
+      </div>
+    </div>
+  </details>
+</template>
+
+<script setup lang="ts">
+import { useRulerHookedStore } from '~/stores/rulerHookedStore'
+import { HERO_RULER_PRESET_ID } from '~/utils/rulerHooked/rulerPresets'
+
+const store = useRulerHookedStore()
+const presetId = ref(
+  store.save?.ruler.cosmetics?.presetId ?? HERO_RULER_PRESET_ID,
+)
+const customPortraitFile = ref<File | null>(null)
+const saving = ref(false)
+
+async function save() {
+  saving.value = true
+  try {
+    await store.updateCosmetics({
+      presetId: presetId.value,
+      customPortraitFile: customPortraitFile.value ?? undefined,
+    })
+    customPortraitFile.value = null
+  } finally {
+    saving.value = false
+  }
+}
+</script>

--- a/components/ruler-hooked/ruler-hooked-game.vue
+++ b/components/ruler-hooked/ruler-hooked-game.vue
@@ -6,7 +6,13 @@
   <ClientOnly>
     <div class="kr-container max-w-3xl flex flex-col gap-4">
       <template v-if="store.save">
-        <RulerHookedStage :scene="store.scene" :regions="store.bundle.regions" />
+        <RulerHookedStage
+          :scene="store.scene"
+          :regions="store.bundle.regions"
+          :ruler-custom-portrait-id="
+            store.save.ruler.cosmetics?.customPortraitId ?? null
+          "
+        />
 
         <div class="flex items-center justify-between gap-3">
           <div>
@@ -22,6 +28,8 @@
             🎣 Cast a line
           </button>
         </div>
+
+        <RulerHookedCosmetics />
 
         <RulerHookedHealth :health="store.save.kingdomHealth" />
 

--- a/components/ruler-hooked/ruler-hooked-slots.vue
+++ b/components/ruler-hooked/ruler-hooked-slots.vue
@@ -22,34 +22,67 @@
     </div>
     <p v-else class="mb-3 text-xs opacity-60">No saves yet — start a new reign.</p>
 
-    <div class="flex flex-wrap items-end gap-2">
-      <label class="form-control">
-        <span class="label-text text-xs">Ruler name</span>
-        <input v-model="rulerName" type="text" placeholder="Mo" class="input input-bordered input-sm w-28" />
-      </label>
-      <label class="form-control">
-        <span class="label-text text-xs">Title</span>
-        <select v-model="honorific" class="select select-bordered select-sm">
-          <option>Queen</option><option>King</option><option>Ruler</option>
-        </select>
-      </label>
-      <button type="button" class="btn btn-primary btn-sm" :disabled="!rulerName.trim()" @click="start">
-        New reign
-      </button>
+    <div class="flex flex-col gap-2">
+      <div class="flex flex-wrap items-end gap-2">
+        <label class="form-control">
+          <span class="label-text text-xs">Ruler name</span>
+          <input v-model="rulerName" type="text" placeholder="Mo" class="input input-bordered input-sm w-28" />
+        </label>
+        <label class="form-control">
+          <span class="label-text text-xs">Title</span>
+          <input
+            v-model="honorific"
+            type="text"
+            list="ruler-honorific-suggestions"
+            placeholder="Queen"
+            class="input input-bordered input-sm w-32"
+          />
+          <datalist id="ruler-honorific-suggestions">
+            <option v-for="h in honorificSuggestions" :key="h" :value="h" />
+          </datalist>
+        </label>
+        <button type="button" class="btn btn-primary btn-sm" :disabled="!rulerName.trim()" @click="start">
+          New reign
+        </button>
+      </div>
+
+      <details class="rounded-lg border border-base-300 p-2">
+        <summary class="cursor-pointer text-xs font-medium opacity-70">
+          Choose your ruler's look
+        </summary>
+        <div class="mt-2">
+          <RulerHookedCosmeticsPicker
+            v-model="presetId"
+            @custom-file="(f: File | null) => (customPortraitFile = f)"
+          />
+        </div>
+      </details>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { useRulerHookedStore } from '~/stores/rulerHookedStore'
+import {
+  HERO_RULER_PRESET_ID,
+  RULER_PRESETS,
+} from '~/utils/rulerHooked/rulerPresets'
 
 const store = useRulerHookedStore()
 const rulerName = ref('Mo')
 const honorific = ref('Queen')
+const presetId = ref(HERO_RULER_PRESET_ID)
+const customPortraitFile = ref<File | null>(null)
 
-function start() {
+// Preset honorifics as suggestions, not a constraint (t-021: free text).
+const honorificSuggestions = [...new Set(RULER_PRESETS.map((p) => p.title))]
+
+async function start() {
   if (!rulerName.value.trim()) return
-  store.newGame('', rulerName.value.trim(), honorific.value)
+  await store.newGame('', rulerName.value.trim(), honorific.value, {
+    presetId: presetId.value,
+    customPortraitFile: customPortraitFile.value ?? undefined,
+  })
 }
 function rename(saveId: string, current: string) {
   const name = typeof window !== 'undefined' ? window.prompt('Rename this reign', current) : null

--- a/components/ruler-hooked/ruler-hooked-stage.vue
+++ b/components/ruler-hooked/ruler-hooked-stage.vue
@@ -60,6 +60,8 @@
 
 <script setup lang="ts">
 import { assetCandidates } from '~/utils/rulerHooked/compositor'
+import { getPortraitUrl } from '~/utils/rulerHooked/portraitStore'
+import { RULER_LAYER_FALLBACK_STATE } from '~/utils/rulerHooked/rulerPresets'
 import type {
   RegionKey,
   RegionsManifest,
@@ -71,17 +73,64 @@ const props = withDefaults(
     scene: SceneState | null
     regions: RegionsManifest
     showImages?: boolean
+    /** t-021: a locally-stored custom portrait, when set, replaces the ruler
+     *  region's preset layer entirely (highest priority — see resolveScene's
+     *  ruler cosmetic axis for how presetId is picked underneath it). */
+    rulerCustomPortraitId?: string | null
   }>(),
   {
     showImages: true,
+    rulerCustomPortraitId: null,
   },
 )
 
+// Resolve the custom portrait id (if any) to a displayable object URL.
+// Async by nature (IndexedDB) — starts null so the preset/fallback layer
+// shows first and swaps in once resolved, never a gap.
+const customPortraitUrl = ref<string | null>(null)
+watch(
+  () => props.rulerCustomPortraitId,
+  async (id, _prev, onCleanup) => {
+    let cancelled = false
+    onCleanup(() => {
+      cancelled = true
+    })
+    if (!id) {
+      customPortraitUrl.value = null
+      return
+    }
+    const url = await getPortraitUrl(id)
+    if (!cancelled) customPortraitUrl.value = url
+  },
+  { immediate: true },
+)
+const prevUrl = ref<string | null>(null)
+watch(customPortraitUrl, (url) => {
+  // Revoke the previous object URL once it's no longer displayed, not before
+  // (revoking the URL still in `src` would blank the image mid-swap).
+  if (prevUrl.value && prevUrl.value !== url) URL.revokeObjectURL(prevUrl.value)
+  prevUrl.value = url
+})
+onBeforeUnmount(() => {
+  if (prevUrl.value) URL.revokeObjectURL(prevUrl.value)
+})
+
 // Per-region index into the asset fallback ladder (advances on <img> error).
 const errIndex = reactive<Record<string, number>>({})
+// If the custom portrait itself fails to load (corrupt/unreadable blob), stop
+// offering it and degrade to the normal preset fallback ladder instead of
+// retrying the same broken src forever.
+const customPortraitFailed = ref(false)
 function onImgError(region: string) {
+  if (region === 'ruler' && customPortraitUrl.value) {
+    customPortraitFailed.value = true
+    return
+  }
   errIndex[region] = (errIndex[region] ?? 0) + 1
 }
+watch(customPortraitUrl, () => {
+  customPortraitFailed.value = false
+})
 
 // A readable placeholder palette keyed by state so recompositing is visible.
 const STATE_CLASS: Record<string, string> = {
@@ -125,15 +174,29 @@ const layers = computed<Layer[]>(() => {
     .sort((a, b) => (regs[a]!.z ?? 0) - (regs[b]!.z ?? 0))
     .map((region) => {
       const state = scene.regionStates[region]
+      const isRuler = region === 'ruler'
+      // The ruler region falls back to its one already-rendered layer
+      // (ruler-fishing.webp) until a given cosmetic preset's own file exists
+      // (t-021) — every other region has no such fallback.
       const cands = props.showImages
-        ? assetCandidates(region, state, scene.time)
+        ? assetCandidates(
+            region,
+            state,
+            scene.time,
+            undefined,
+            isRuler ? RULER_LAYER_FALLBACK_STATE : undefined,
+          )
         : []
       const idx = errIndex[region] ?? 0
+      // A custom portrait (once resolved) takes priority over any preset
+      // layer for the ruler region specifically.
+      const customSrc =
+        isRuler && !customPortraitFailed.value ? customPortraitUrl.value : null
       return {
         region,
         label: state ? `${region} · ${state}` : region,
         classes: STATE_CLASS[state ?? 'open'] ?? 'bg-base-300',
-        src: cands[idx] ?? null,
+        src: customSrc ?? cands[idx] ?? null,
       }
     })
 })

--- a/stores/rulerHookedStore.ts
+++ b/stores/rulerHookedStore.ts
@@ -22,6 +22,10 @@ import {
   loadIndex, loadSave, writeSave, renameSlot as renameSlotStore,
   deleteSlot as deleteSlotStore, setActive, makeSaveId,
 } from '~/utils/rulerHooked/save'
+import {
+  putPortrait, deletePortrait, makePortraitId,
+} from '~/utils/rulerHooked/portraitStore'
+import { HERO_RULER_PRESET_ID } from '~/utils/rulerHooked/rulerPresets'
 import type { Card, CatchResult, RunSave, SaveSlotMeta } from '~/types/ruler-hooked'
 
 const nowStamp = (): string => new Date().toISOString()
@@ -71,9 +75,28 @@ export const useRulerHookedStore = defineStore('rulerHooked', () => {
     }
   }
 
-  function newGame(name: string, rulerName: string, honorific = 'Ruler') {
+  /**
+   * `presetId` picks a ruler cosmetic preset (defaults to the hero preset);
+   * `customPortraitFile` — when supplied — is downscaled and stored locally
+   * (portraitStore.ts, IndexedDB) and takes priority over `presetId` for
+   * display (t-021). A failed/unavailable portrait import (e.g. IndexedDB
+   * blocked by a privacy setting) silently falls back to the preset instead
+   * of blocking new-game creation.
+   */
+  async function newGame(
+    name: string,
+    rulerName: string,
+    honorific = 'Ruler',
+    opts: { presetId?: string; customPortraitFile?: File } = {},
+  ) {
     const stamp = nowStamp()
     const saveId = makeSaveId(stamp, rulerName + slots.value.length)
+    let customPortraitId: string | undefined
+    if (opts.customPortraitFile) {
+      const id = makePortraitId(`${saveId}:${opts.customPortraitFile.name}`)
+      customPortraitId =
+        (await putPortrait(opts.customPortraitFile, id)) ?? undefined
+    }
     const run = createRun(bundle, {
       saveId,
       name: name || `${honorific} ${rulerName}'s reign`,
@@ -81,11 +104,53 @@ export const useRulerHookedStore = defineStore('rulerHooked', () => {
       rulerName,
       honorific,
       stamp,
+      presetId: opts.presetId,
+      customPortraitId,
     })
     save.value = run
     clearTransientPlayState()
     writeSave(run, stamp)
     refreshSlots()
+  }
+
+  /**
+   * Change the active save's ruler cosmetics after creation ("cosmetic-only
+   * by design, so there is no reason to lock them at creation" — t-021).
+   * Replaces (rather than merges) any previous custom portrait, deleting the
+   * old blob so switching presets/portraits repeatedly doesn't leak storage.
+   */
+  async function updateCosmetics(opts: {
+    presetId?: string
+    customPortraitFile?: File
+  }) {
+    if (!save.value) return
+    const prevPortraitId = save.value.ruler.cosmetics?.customPortraitId
+    let customPortraitId: string | undefined
+    if (opts.customPortraitFile) {
+      const id = makePortraitId(
+        `${save.value.saveId}:${nowStamp()}:${opts.customPortraitFile.name}`,
+      )
+      customPortraitId =
+        (await putPortrait(opts.customPortraitFile, id)) ?? undefined
+    }
+    save.value.ruler.cosmetics = {
+      ...save.value.ruler.cosmetics,
+      presetId:
+        opts.presetId ??
+        save.value.ruler.cosmetics?.presetId ??
+        HERO_RULER_PRESET_ID,
+      // Explicitly picking a preset (no new file) clears any prior custom
+      // portrait so the preset actually takes visual effect.
+      customPortraitId:
+        customPortraitId ?? (opts.presetId ? undefined : prevPortraitId),
+    }
+    if (
+      prevPortraitId &&
+      prevPortraitId !== save.value.ruler.cosmetics.customPortraitId
+    ) {
+      void deletePortrait(prevPortraitId)
+    }
+    persist()
   }
 
   function loadSlot(saveId: string) {
@@ -184,7 +249,7 @@ export const useRulerHookedStore = defineStore('rulerHooked', () => {
   return {
     bundle, save, activeCard, activeArcId, pendingEnding, activeFishing,
     lastCatch, lastEscape, slots, scene, canFish,
-    init, newGame, loadSlot, startFishing, fishingAction, choose,
+    init, newGame, updateCosmetics, loadSlot, startFishing, fishingAction, choose,
     acceptEnding, declineEnding, renameSlot, deleteSlot, refreshSlots,
   }
 })

--- a/types/ruler-hooked.ts
+++ b/types/ruler-hooked.ts
@@ -299,6 +299,26 @@ export interface DeckState {
   drawBag: string[]
 }
 
+/**
+ * Cosmetic-only ruler customization (ruler-hooked/t-021). `presetId` selects
+ * one of RULER_PRESETS (utils/rulerHooked/rulerPresets.ts); `customPortraitId`
+ * — when set — takes priority over `presetId` and points at a locally-stored
+ * player-supplied image (utils/rulerHooked/portraitStore.ts, IndexedDB, never
+ * uploaded). `body`/`skin`/`species`/`outfit`/`crownTilt` are reserved for a
+ * future composable-overlay upgrade path (t-021's note: presets today, an
+ * additive overlay system later if the combinatorial range turns out to
+ * matter more than preset coherence) — nothing currently reads them.
+ */
+export interface RulerCosmetics {
+  presetId?: string
+  customPortraitId?: string
+  body?: string
+  skin?: string
+  species?: string
+  outfit?: string
+  crownTilt?: boolean
+}
+
 export interface RunSave {
   schemaVersion: number
   saveId: string
@@ -311,7 +331,7 @@ export interface RunSave {
     name: string
     honorific?: string
     characterSlug?: string
-    cosmetics?: Record<string, unknown>
+    cosmetics?: RulerCosmetics
   }
   turnCount: number
   cyclePosition: number

--- a/utils/rulerHooked/compositor.ts
+++ b/utils/rulerHooked/compositor.ts
@@ -16,6 +16,7 @@ import type {
   SceneState,
   TimeKey,
 } from '~/types/ruler-hooked'
+import { HERO_RULER_PRESET_ID } from '~/utils/rulerHooked/rulerPresets'
 
 /** Even-threshold a 0..100 slider value across an ordered ramp (compositing.md §3). */
 export function rampState(value: number, ramp: RegionState[]): RegionState {
@@ -50,6 +51,15 @@ export function resolveScene(
   for (const key of Object.keys(manifest.regions) as RegionKey[]) {
     const def = manifest.regions[key]
     if (!def) continue
+    if (key === 'ruler') {
+      // Cosmetic axis (t-021): the ruler region's "state" is the player's
+      // chosen preset id, not a ramp/event-driven state. A custom portrait
+      // (handled separately by the stage/portraitStore) still needs a preset
+      // id underneath it for save-index display and as the degrade target if
+      // the custom image is ever unreadable, so this always resolves to one.
+      regionStates[key] = save.ruler.cosmetics?.presetId ?? HERO_RULER_PRESET_ID
+      continue
+    }
     const override = save.regionOverrides[key]
     if (override !== undefined) {
       regionStates[key] = override
@@ -83,14 +93,24 @@ export function assetCandidates(
   state: RegionState | undefined,
   time: TimeKey,
   dir = '/images/ruler-hooked',
+  /**
+   * A second state to fall back to (all three time rungs) if `state`'s own
+   * files don't exist — e.g. the ruler region falls back to its one
+   * already-rendered layer (RULER_LAYER_FALLBACK_STATE = 'fishing') until a
+   * given cosmetic preset gets its own dedicated file (t-021). Never used for
+   * any other region today.
+   */
+  fallbackState?: RegionState,
 ): string[] {
-  const base = state ? `${region}-${state}` : `${region}`
   const settle = SETTLE[time]
-  const names = [
-    `${base}-${time}`, // exact
-    `${base}-${settle}`, // treat → nearest settle
-    base, // time-agnostic
-  ]
+  const rungs = (s: RegionState | undefined): string[] => {
+    const base = s ? `${region}-${s}` : `${region}`
+    return [`${base}-${time}`, `${base}-${settle}`, base]
+  }
+  const names = rungs(state)
+  if (fallbackState !== undefined && fallbackState !== state) {
+    names.push(...rungs(fallbackState))
+  }
   // de-dupe while preserving order
   const seen = new Set<string>()
   return names

--- a/utils/rulerHooked/content.ts
+++ b/utils/rulerHooked/content.ts
@@ -20,6 +20,10 @@
 // Characters where they fit."
 
 import type { ContentBundle } from '~/types/ruler-hooked'
+import {
+  RULER_PRESET_IDS,
+  RULER_LAYER_FALLBACK_STATE,
+} from '~/utils/rulerHooked/rulerPresets'
 
 export const RULER_HOOKED_CONTENT: ContentBundle = {
   contentVersion: '2026.08-content-depth',
@@ -65,7 +69,16 @@ export const RULER_HOOKED_CONTENT: ContentBundle = {
       },
       lake: { z: 5, states: ['clear'], times: ['day', 'night'] },
       near_bank: { z: 6, states: ['grassy'] },
-      ruler: { z: 7, states: ['fishing'] },
+      // States = the cosmetic preset ids (t-021) plus the one already-rendered
+      // layer name (RULER_LAYER_FALLBACK_STATE = 'fishing') that every preset
+      // currently degrades to — resolveScene() picks the state directly from
+      // save.ruler.cosmetics.presetId, never from this list's order/first
+      // entry, but the list stays authored here so it reads as real data
+      // (compositor.ts's ruler special-case, assetCandidates' fallbackState).
+      ruler: {
+        z: 7,
+        states: [...RULER_PRESET_IDS, RULER_LAYER_FALLBACK_STATE],
+      },
     },
   },
 

--- a/utils/rulerHooked/engine.selftest.ts
+++ b/utils/rulerHooked/engine.selftest.ts
@@ -5,6 +5,7 @@ import { triggerHolds, effectiveWeight } from '~/utils/rulerHooked/triggers'
 import { rampState, resolveScene, cycleTime, assetCandidates } from '~/utils/rulerHooked/compositor'
 import { eligiblePool, weightedPick, selectCard, tickCooldowns } from '~/utils/rulerHooked/select'
 import { availableFish, resolveFishingCatch, RULER_HOOKED_FISH } from '~/utils/rulerHooked/fish'
+import { HERO_RULER_PRESET_ID, RULER_PRESET_IDS } from '~/utils/rulerHooked/rulerPresets'
 import type { Card, RegionsManifest, RunSave } from '~/types/ruler-hooked'
 
 function baseSave(): RunSave {
@@ -155,6 +156,51 @@ function baseSave(): RunSave {
   const ca2 = resolveFishingCatch(a, makeRng('fish-seed'))
   assert.equal(ca2.newDiscovery, false, 'later catch of same species is not new')
   assert.equal(a.fishopedia[ca.fishSlug]?.countCaught, 2, 'repeat catch increments species record')
+}
+
+// 7. Ruler cosmetics (t-021): resolveScene's ruler special-case + the
+//    ruler-only assetCandidates fallback ladder.
+{
+  const manifest: RegionsManifest = { regions: {
+    ruler: { z: 7, states: [...RULER_PRESET_IDS, 'fishing'] },
+  } }
+
+  // No cosmetics at all (an old/migrated save) -> the hero preset, never a hole.
+  const bare = baseSave()
+  assert.equal(resolveScene(bare, manifest).regionStates.ruler, HERO_RULER_PRESET_ID, 'no cosmetics -> hero preset')
+
+  // An explicit preset choice wins, and is never routed through regionOverrides.
+  const withPreset = baseSave()
+  withPreset.ruler.cosmetics = { presetId: 'chieftain-brakka' }
+  assert.equal(resolveScene(withPreset, manifest).regionStates.ruler, 'chieftain-brakka', 'explicit presetId is honored')
+  assert.equal(withPreset.regionOverrides.ruler, undefined, 'ruler cosmetics never touch regionOverrides')
+
+  // A ruler-only fallback rung: a preset with no dedicated file yet still
+  // resolves to the one already-rendered layer, at every time-of-day rung.
+  const noFallback = assetCandidates('ruler', 'chieftain-brakka', 'night')
+  assert.deepEqual(noFallback, [
+    '/images/ruler-hooked/ruler-chieftain-brakka-night.webp',
+    '/images/ruler-hooked/ruler-chieftain-brakka.webp',
+  ], 'no fallbackState -> the normal ladder only (settle(night)=night dedupes), no fishing rung')
+
+  const withFallback = assetCandidates('ruler', 'chieftain-brakka', 'night', undefined, 'fishing')
+  assert.deepEqual(withFallback, [
+    '/images/ruler-hooked/ruler-chieftain-brakka-night.webp',
+    '/images/ruler-hooked/ruler-chieftain-brakka.webp',
+    '/images/ruler-hooked/ruler-fishing-night.webp',
+    '/images/ruler-hooked/ruler-fishing.webp',
+  ], 'fallbackState appends the fishing rungs after the preset rungs, de-duped')
+
+  // fallbackState === state is a no-op (never doubles the ladder).
+  const sameState = assetCandidates('ruler', 'fishing', 'day', undefined, 'fishing')
+  assert.deepEqual(sameState, ['/images/ruler-hooked/ruler-fishing-day.webp', '/images/ruler-hooked/ruler-fishing.webp'], 'fallbackState equal to state adds nothing new')
+
+  // Every other region is unaffected by the ruler special-case or the new param.
+  const otherManifest: RegionsManifest = { regions: {
+    lake: { z: 5, states: ['clear'] },
+  } }
+  const withLake = baseSave()
+  assert.equal(resolveScene(withLake, otherManifest).regionStates.lake, 'clear', 'non-ruler regions resolve exactly as before')
 }
 
 console.log('ruler-hooked engine self-test: ALL PASS')

--- a/utils/rulerHooked/game.selftest.ts
+++ b/utils/rulerHooked/game.selftest.ts
@@ -14,7 +14,9 @@ import { resolveScene } from '~/utils/rulerHooked/compositor'
 import { makeRng } from '~/utils/rulerHooked/seed'
 import {
   loadIndex, loadSave, writeSave, renameSlot, deleteSlot, makeSaveId,
+  SAVE_SCHEMA_VERSION,
 } from '~/utils/rulerHooked/save'
+import { HERO_RULER_PRESET_ID } from '~/utils/rulerHooked/rulerPresets'
 import type { RunSave } from '~/types/ruler-hooked'
 
 // --- localStorage shim for node -------------------------------------------
@@ -139,8 +141,31 @@ const fresh = (id = 'sv_a'): RunSave =>
   delete old.fishopedia
   backingStore.set('rulerHooked:save:sv_old', JSON.stringify(old))
   const migrated = loadSave('sv_old')
-  assert.equal(migrated?.schemaVersion, 4, 'legacy slot is promoted to schema 4')
+  assert.equal(migrated?.schemaVersion, SAVE_SCHEMA_VERSION, 'legacy slot is promoted to the current schema')
   assert.deepEqual(migrated?.fishopedia, {}, 'legacy slot receives an empty Fishopedia')
+}
+
+// 8. A pre-cosmetics schema-4 slot (t-021) migrates to a hero-preset default
+// rather than leaving the ruler region with nothing to resolve to.
+{
+  const old = fresh('sv_precosmetics')
+  old.schemaVersion = 4
+  delete old.ruler.cosmetics
+  backingStore.set('rulerHooked:save:sv_precosmetics', JSON.stringify(old))
+  const migrated = loadSave('sv_precosmetics')
+  assert.equal(migrated?.schemaVersion, SAVE_SCHEMA_VERSION, 'legacy slot is promoted to the current schema')
+  assert.equal(migrated?.ruler.cosmetics?.presetId, HERO_RULER_PRESET_ID, 'legacy slot defaults to the hero ruler preset')
+
+  // A save that already had SOME cosmetics (but no presetId, e.g. an
+  // intermediate schema-5 slot written before this migration rule existed)
+  // is filled in without disturbing whatever else was already there.
+  const oldWithCosmetics = fresh('sv_partial_cosmetics')
+  oldWithCosmetics.schemaVersion = 5
+  oldWithCosmetics.ruler.cosmetics = { crownTilt: true }
+  backingStore.set('rulerHooked:save:sv_partial_cosmetics', JSON.stringify(oldWithCosmetics))
+  const migratedPartial = loadSave('sv_partial_cosmetics')
+  assert.equal(migratedPartial?.ruler.cosmetics?.presetId, HERO_RULER_PRESET_ID, 'a presetId-less cosmetics bag also gets the hero default')
+  assert.equal(migratedPartial?.ruler.cosmetics?.crownTilt, true, 'existing cosmetics fields survive migration untouched')
 }
 
 console.log('ruler-hooked GAME self-test: ALL PASS')

--- a/utils/rulerHooked/newGame.ts
+++ b/utils/rulerHooked/newGame.ts
@@ -3,8 +3,13 @@
 // Fresh RunSave factory (data-model.md §3). Deterministic given the seed; the
 // caller stamps createdAt/updatedAt (display metadata, never game logic).
 
-import type { ContentBundle, RunSave } from '~/types/ruler-hooked'
+import type {
+  ContentBundle,
+  RulerCosmetics,
+  RunSave,
+} from '~/types/ruler-hooked'
 import { AXIS_KEYS } from '~/types/ruler-hooked'
+import { HERO_RULER_PRESET_ID } from '~/utils/rulerHooked/rulerPresets'
 
 export interface NewGameOpts {
   saveId: string
@@ -13,6 +18,10 @@ export interface NewGameOpts {
   rulerName: string
   honorific?: string
   stamp: string // ISO timestamp supplied by the caller (no Date.now in the engine)
+  /** Cosmetic preset id (t-021). Defaults to the hero preset. */
+  presetId?: string
+  /** IndexedDB portraitStore key for a player-supplied custom image, if any. */
+  customPortraitId?: string
 }
 
 export function createRun(bundle: ContentBundle, opts: NewGameOpts): RunSave {
@@ -24,6 +33,11 @@ export function createRun(bundle: ContentBundle, opts: NewGameOpts): RunSave {
   // deck directly, but the bag is part of the serialized schema).
   const drawBag = bundle.decks.flatMap((d) => d.cards.map((c) => c.id))
 
+  const cosmetics: RulerCosmetics = {
+    presetId: opts.presetId ?? HERO_RULER_PRESET_ID,
+  }
+  if (opts.customPortraitId) cosmetics.customPortraitId = opts.customPortraitId
+
   return {
     schemaVersion: 4,
     saveId: opts.saveId,
@@ -32,7 +46,7 @@ export function createRun(bundle: ContentBundle, opts: NewGameOpts): RunSave {
     contentVersion: bundle.contentVersion,
     seed: opts.seed,
     status: 'ACTIVE',
-    ruler: { name: opts.rulerName, honorific: opts.honorific, cosmetics: {} },
+    ruler: { name: opts.rulerName, honorific: opts.honorific, cosmetics },
     turnCount: 0,
     cyclePosition: 0,
     kingdomHealth,

--- a/utils/rulerHooked/portraitStore.ts
+++ b/utils/rulerHooked/portraitStore.ts
@@ -1,0 +1,162 @@
+// utils/rulerHooked/portraitStore.ts
+//
+// Local-only storage for a player-supplied custom ruler portrait
+// (ruler-hooked/t-021: "the player supplies their own ruler picture from
+// their own device... your picture, your name, your title is a complete
+// custom ruler with no runtime AI, no registration problem, and no network").
+//
+// IndexedDB, not localStorage: the save documents themselves stay in
+// localStorage (save.ts) — small, synchronous, well within its ~5MB quota —
+// but a portrait image is 80-200KB+ even downscaled, and the brief guarantees
+// multiple named saves, so base64-in-localStorage does not scale past a
+// handful of custom-portrait saves (t-021's own storage caveat). IndexedDB
+// holds the blob; the save only carries a `customPortraitId` key, and a
+// missing/unreadable blob degrades to the preset picker (never a hole).
+//
+// Everything here is SSR-guarded (checked per-call, not captured at module
+// load) the same way save.ts guards `window`/`localStorage`, and every
+// operation degrades to a no-op/null rather than throwing — a portrait is a
+// nice-to-have cosmetic, never something that should be able to break a save.
+
+const DB_NAME = 'rulerHookedPortraits'
+const DB_VERSION = 1
+const STORE = 'portraits'
+
+/** Cap the imported image to this longest edge (px) before storing. */
+const MAX_DIMENSION = 512
+/** Re-encoded quality for the downscaled JPEG/WebP re-encode. */
+const REENCODE_QUALITY = 0.85
+
+/** Deterministic id from a caller-supplied seed (same fnv1a shape as
+ *  save.ts's makeSaveId) — no Date.now()/crypto dependency in the engine. */
+export function makePortraitId(seed: string): string {
+  let h = 0x811c9dc5
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return 'portrait_' + (h >>> 0).toString(36)
+}
+
+const hasIndexedDb = (): boolean =>
+  typeof window !== 'undefined' && typeof window.indexedDB !== 'undefined'
+
+function openDb(): Promise<IDBDatabase | null> {
+  if (!hasIndexedDb()) return Promise.resolve(null)
+  return new Promise((resolve) => {
+    try {
+      const req = window.indexedDB.open(DB_NAME, DB_VERSION)
+      req.onupgradeneeded = () => {
+        if (!req.result.objectStoreNames.contains(STORE)) {
+          req.result.createObjectStore(STORE)
+        }
+      }
+      req.onsuccess = () => resolve(req.result)
+      req.onerror = () => resolve(null) // quota / privacy mode — non-fatal
+    } catch {
+      resolve(null)
+    }
+  })
+}
+
+/**
+ * Downscale + re-encode an image file to keep the stored blob small
+ * (t-021: "cap or downscale on import... do not let a custom portrait be the
+ * thing that makes save #12 fail to write"). Falls back to the original file
+ * if decoding/canvas re-encode isn't available (e.g. a non-image mimetype
+ * slipped past the file-input's `accept` filter, or a headless test env).
+ */
+async function downscale(file: File): Promise<Blob> {
+  if (
+    typeof createImageBitmap !== 'function' ||
+    typeof document === 'undefined'
+  ) {
+    return file
+  }
+  try {
+    const bitmap = await createImageBitmap(file)
+    const scale = Math.min(
+      1,
+      MAX_DIMENSION / Math.max(bitmap.width, bitmap.height),
+    )
+    const w = Math.max(1, Math.round(bitmap.width * scale))
+    const h = Math.max(1, Math.round(bitmap.height * scale))
+    const canvas = document.createElement('canvas')
+    canvas.width = w
+    canvas.height = h
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return file
+    ctx.drawImage(bitmap, 0, 0, w, h)
+    bitmap.close?.()
+    const blob = await new Promise<Blob | null>((resolve) =>
+      canvas.toBlob(resolve, 'image/webp', REENCODE_QUALITY),
+    )
+    return blob ?? file
+  } catch {
+    return file // decode failed — store the original rather than lose it
+  }
+}
+
+/**
+ * Import a player-picked file: downscale it, store it under a fresh id, and
+ * return that id for the save's `ruler.cosmetics.customPortraitId`. Returns
+ * null if IndexedDB is unavailable or the write failed — callers should fall
+ * back to the preset picker rather than block save creation on this.
+ */
+export async function putPortrait(
+  file: File,
+  id: string,
+): Promise<string | null> {
+  const db = await openDb()
+  if (!db) return null
+  const blob = await downscale(file)
+  return new Promise((resolve) => {
+    try {
+      const tx = db.transaction(STORE, 'readwrite')
+      tx.objectStore(STORE).put(blob, id)
+      tx.oncomplete = () => resolve(id)
+      tx.onerror = () => resolve(null)
+    } catch {
+      resolve(null)
+    }
+  })
+}
+
+/** Fetch a stored portrait as an object URL, or null if missing/unavailable.
+ *  Callers own the URL and must revokeObjectURL it when done (e.g. on unmount
+ *  or when swapping portraits) — this module never revokes URLs itself since
+ *  it doesn't know how long the caller needs it displayed. */
+export async function getPortraitUrl(id: string): Promise<string | null> {
+  const db = await openDb()
+  if (!db) return null
+  return new Promise((resolve) => {
+    try {
+      const tx = db.transaction(STORE, 'readonly')
+      const req = tx.objectStore(STORE).get(id)
+      req.onsuccess = () => {
+        const blob = req.result as Blob | undefined
+        resolve(blob ? URL.createObjectURL(blob) : null)
+      }
+      req.onerror = () => resolve(null)
+    } catch {
+      resolve(null)
+    }
+  })
+}
+
+/** Best-effort delete (save.ts's deleteSlot calls this when a save carrying a
+ *  custom portrait is removed, so orphaned blobs don't accumulate). */
+export async function deletePortrait(id: string): Promise<void> {
+  const db = await openDb()
+  if (!db) return
+  await new Promise<void>((resolve) => {
+    try {
+      const tx = db.transaction(STORE, 'readwrite')
+      tx.objectStore(STORE).delete(id)
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => resolve()
+    } catch {
+      resolve()
+    }
+  })
+}

--- a/utils/rulerHooked/rulerPresets.ts
+++ b/utils/rulerHooked/rulerPresets.ts
@@ -1,0 +1,102 @@
+// utils/rulerHooked/rulerPresets.ts
+//
+// The twelve ruler cosmetic presets (ruler-hooked/t-020, approved by Silas
+// 2026-08-26: "those rulers are better than my suggestions, no reason to stick
+// with speciesism" + the four child rulers added the same session). This list
+// mirrors conductor's `scripts/build_ruler_hooked_art_queue.py` RULER_PRESETS,
+// which is the source of truth for the rendered art (id + prompt "look" text) —
+// if a preset is added or renamed there, mirror the change here too. `title` is
+// the character's own honorific from that pipeline (offered as a suggestion,
+// never a constraint — ruler-hooked/t-021, Silas: "custom name and honorific").
+//
+// `HERO_RULER_PRESET_ID` matches conductor's `HERO_RULER_ID`: the one preset
+// with an already-rendered dedicated layer (`ruler-fishing.webp`, t-018). Every
+// other preset gracefully degrades to that same file until its own
+// `ruler-<id>.webp` layer is rendered (compositor.ts's `fallbackState`).
+
+export interface RulerPreset {
+  id: string
+  /** Suggested honorific — a starting point, not a constraint (t-021). */
+  title: string
+  /** Short description for alt text / picker tooltips. */
+  look: string
+}
+
+export const RULER_PRESETS: RulerPreset[] = [
+  {
+    id: 'king-osric',
+    title: 'King',
+    look: 'A plump contented middle-aged monarch, deep brown skin, grey-streaked locs, a slightly-too-large crown worn askew.',
+  },
+  {
+    id: 'queen-mabel',
+    title: 'Queen',
+    look: 'A tall broad-shouldered monarch in her fifties, close-cropped silver hair under a slim gold circlet, an embroidered fishing coat over her robes.',
+  },
+  {
+    id: 'sovereign-wren',
+    title: 'Sovereign',
+    look: 'A lanky young androgynous monarch, dark hair shaved at the sides, the circlet worn loose around the throat, patched waders under a half-cape.',
+  },
+  {
+    id: 'regent-halvard',
+    title: 'Regent',
+    look: 'A very old wiry monarch, a long white beard tucked into a belt, swimming in robes several sizes too big, a folding stool and a thermos.',
+  },
+  {
+    id: 'matriarch-oshun',
+    title: 'Matriarch',
+    look: 'A short and gloriously round monarch, an enormous coiled crown of braided hair with the actual crown perched on top of it, beaded rings on every finger.',
+  },
+  {
+    id: 'chieftain-brakka',
+    title: 'Chieftain',
+    look: 'A powerfully built orcish monarch, moss-green skin, small proud tusks, a crown of shed antlers, forearms like tree roots.',
+  },
+  {
+    id: 'heron-queen-sedge',
+    title: 'Queen',
+    look: 'A tall heron-folk monarch, soft grey-blue plumage and a long elegant neck, the crown balanced between two head plumes, standing on one leg out of habit.',
+  },
+  {
+    id: 'little-monarch-pip',
+    title: 'Monarch',
+    look: 'A tiny mouse-folk monarch barely taller than a boot, an enormous crown resting on both ears at once, seated on a stack of unread royal ledgers.',
+  },
+  {
+    id: 'boy-king-tobin',
+    title: 'King',
+    look: 'A small boy king of about eight, a mop of red hair, a crown far too big for him pushed back off his forehead, feet swinging nowhere near the ground.',
+  },
+  {
+    id: 'girl-queen-marisol',
+    title: 'Queen',
+    look: 'A small girl queen of about nine, two tight buns, a gap-toothed look of total concentration, a crown pinned firmly in place because she checked.',
+  },
+  {
+    id: 'cub-prince-bramble',
+    title: 'Prince',
+    look: 'A bear-cub-folk child ruler, round and shaggy in brown fur, a circlet of woven river-reeds, enormous paws entirely unsuited to a delicate reel.',
+  },
+  {
+    id: 'elder-tortoise-yew',
+    title: 'Sovereign',
+    look: 'An immensely old tortoise-folk sovereign, mossy shell and a kindly wrinkled face, a crown worn smooth by centuries, unhurried.',
+  },
+]
+
+export const RULER_PRESET_IDS: string[] = RULER_PRESETS.map((p) => p.id)
+
+export const RULER_PRESET_BY_ID: Record<string, RulerPreset> =
+  Object.fromEntries(RULER_PRESETS.map((p) => [p.id, p]))
+
+/** The one preset with an already-rendered dedicated layer (t-018/t-020). */
+export const HERO_RULER_PRESET_ID = 'king-osric'
+
+/**
+ * The compositor "state" name for the ruler region's already-rendered layer
+ * file (`ruler-fishing.webp`) — distinct from any preset id, kept as the
+ * universal fallback until per-preset layers are rendered (see
+ * compositor.ts's `assetCandidates` `fallbackState` param).
+ */
+export const RULER_LAYER_FALLBACK_STATE = 'fishing'

--- a/utils/rulerHooked/save.ts
+++ b/utils/rulerHooked/save.ts
@@ -7,10 +7,16 @@
 // packaged app can swap the adapter without touching callers.
 
 import type { RunSave, SaveIndex, SaveSlotMeta } from '~/types/ruler-hooked'
+import { HERO_RULER_PRESET_ID } from '~/utils/rulerHooked/rulerPresets'
+import { deletePortrait } from '~/utils/rulerHooked/portraitStore'
 
 const INDEX_KEY = 'rulerHooked:index'
 const slotKey = (saveId: string) => `rulerHooked:save:${saveId}`
-export const SAVE_SCHEMA_VERSION = 4
+// v5 (t-021): ruler.cosmetics widened from an untyped bag to RulerCosmetics
+// with a required-in-practice presetId. Old saves (schemaVersion <= 4) never
+// wrote presetId, so migrateSave() below fills it in with the hero preset
+// rather than leaving the ruler region with nothing to resolve to.
+export const SAVE_SCHEMA_VERSION = 5
 
 // Checked per-call (not captured at module load) so SSR — and headless tests
 // that install a window shim after import — behave correctly.
@@ -53,6 +59,10 @@ function parse<T>(raw: string | null): T | null {
 /** Add fields introduced after the original PoC without invalidating old slots. */
 function migrateSave(save: RunSave): RunSave {
   if (!save.fishopedia) save.fishopedia = {}
+  if (!save.ruler.cosmetics) save.ruler.cosmetics = {}
+  if (!save.ruler.cosmetics.presetId) {
+    save.ruler.cosmetics.presetId = HERO_RULER_PRESET_ID
+  }
   save.schemaVersion = SAVE_SCHEMA_VERSION
   return save
 }
@@ -118,7 +128,10 @@ export function renameSlot(saveId: string, name: string): void {
 }
 
 export function deleteSlot(saveId: string): void {
+  const existing = loadSave(saveId)
+  const portraitId = existing?.ruler.cosmetics?.customPortraitId
   safeRemove(slotKey(saveId))
+  if (portraitId) void deletePortrait(portraitId) // best-effort, fire-and-forget
   const index = loadIndex()
   index.slots = index.slots.filter((s) => s.saveId !== saveId)
   if (index.activeSaveId === saveId) {


### PR DESCRIPTION
### Task
ruler-hooked/t-021: Build the ruler character creator (body, skin, honorific, species)

Silas, 2026-08-26: "we will need to add a character creator element that lets the user pick body shapes, skin color, and ruler title, etc." Decided in the same session: preset figures (t-020's approved cast of twelve), free-text name and honorific, and a custom-portrait escape hatch — no runtime AI, no network, per the offline design pillar.

### What changed
- **`types/ruler-hooked.ts`**: new `RulerCosmetics` interface (`presetId`, `customPortraitId`, plus reserved `body`/`skin`/`species`/`outfit`/`crownTilt` for a possible future overlay system); `ruler.cosmetics` is now typed instead of an untyped bag.
- **`utils/rulerHooked/rulerPresets.ts`** (new): the twelve approved presets as data (id/title/look), mirroring conductor's `build_ruler_hooked_art_queue.py` `RULER_PRESETS` — no id is ever hardcoded in the UI.
- **`utils/rulerHooked/compositor.ts`**: `resolveScene` special-cases the `ruler` region to resolve from `save.ruler.cosmetics.presetId` (defaulting to the hero preset) instead of the generic ramp/first-state path. `assetCandidates` gains an optional `fallbackState` param so the ruler region degrades to its one already-rendered layer (`ruler-fishing.webp`) until a given preset gets its own dedicated file — never a hole.
- **`utils/rulerHooked/content.ts`**: the `ruler` region's `states` now lists the preset ids + the fallback state, read as data.
- **`utils/rulerHooked/newGame.ts`** / **`stores/rulerHookedStore.ts`**: `newGame()` accepts a preset id and/or a custom portrait file; new `updateCosmetics()` action changes either after creation (cosmetics are cosmetic-only by design, so nothing is locked at creation time).
- **`utils/rulerHooked/portraitStore.ts`** (new): IndexedDB storage for a player-supplied portrait — downscaled/re-encoded to ≤512px webp on import so it can't blow the save quota, SSR-guarded, fails soft to the preset picker.
- **`utils/rulerHooked/save.ts`**: `SAVE_SCHEMA_VERSION` 4→5; `migrateSave()` fills in a hero-preset default for any save missing `cosmetics.presetId`; `deleteSlot()` cleans up an orphaned portrait blob.
- **`components/ruler-hooked/ruler-hooked-cosmetics-picker.vue`** (new): shared preset grid + "use my own picture instead" file input, used both at creation and later.
- **`components/ruler-hooked/ruler-hooked-cosmetics.vue`** (new): collapsed in-play "change appearance" panel.
- **`ruler-hooked-slots.vue`**: honorific is now free text (with the preset titles as `<datalist>` suggestions) plus the preset/portrait picker, replacing the old 3-option honorific `<select>`.
- **`ruler-hooked-stage.vue`**: resolves and displays a custom portrait (object URL from IndexedDB) in priority over the preset layer for the ruler region, with its own broken-image fallback back to the preset ladder.
- **`.github/workflows/ruler-hooked.yml`**: added the `engine.selftest.ts` step — it existed but was never wired into CI, so this PR's new coverage in it wouldn't otherwise have run in CI.

### How I verified
- `npx vue-tsc --noEmit` — clean, full repo.
- `npx eslint` on every touched/new file — clean.
- `npx prettier --check` — every line I added is prettier-clean; several touched files (`ruler-hooked-game.vue`, `ruler-hooked-slots.vue`, `rulerHookedStore.ts`, `types/ruler-hooked.ts`) carry pre-existing whole-file drift outside my diff (confirmed via the `HEAD`-version-still-fails-check technique) — left untouched rather than reformatted wholesale, matching established precedent in this repo.
- `npm run test:layout-contract` — holds, no new violations (fixed one along the way: the preset grid used a viewport-breakpoint `sm:grid-cols-4` gate, switched to `grid-cols-[repeat(auto-fit,minmax(...))]` per the container-width rule).
- All three `utils/rulerHooked/*.selftest.ts` scripts pass, including new/extended coverage: the ruler cosmetic axis (default hero preset, explicit preset, never touches `regionOverrides`), the new `assetCandidates` `fallbackState` ladder (with/without, and the equal-state no-op case), and two migration cases in `game.selftest.ts` (a schema-4 save with no `cosmetics` at all, and one with partial cosmetics but no `presetId`) — plus fixed a stale hardcoded `schemaVersion: 4` assertion the version bump broke.
- Manually reasoned through the degrade ladder: no preset art exists yet for any of the twelve presets (confirmed via `find` — only `ruler-fishing.webp` is rendered), so every preset currently displays via the fallback rung; the picker's own thumbnails show a title-initial placeholder instead of a broken-image icon for the same reason.

### Stakes
reversible

### Flags for Reviewer
- Per-preset ruler layer art (`ruler-<id>.webp`) is NOT rendered by this PR — that's a separate async ArtJob pipeline task (t-020's own note flags it as follow-up work). Everything here is designed to degrade gracefully until that art lands; nothing needs to change in this code when it does.
- `body`/`skin`/`species`/`outfit` on `RulerCosmetics` are typed but unused — reserved for the additive-overlay upgrade path t-021's own note describes as a possible future step, not built here (presets won on coherence grounds, per Silas's decision).
- Custom-portrait honorific/name stay fixed after creation; only the preset/portrait axis is editable later, matching the note's literal "they are cosmetic-only by design."

---
_Generated by [Claude Code](https://claude.ai/code/session_019mTexbhvptrWULpJ4YMoAC)_