### PR TITLE
ruler-hooked/t-021: ruler character creator (presets, honorific, cosmetic axis)

### DIFF
--- a/components/ruler-hooked/ruler-hooked-cosmetics-editor.vue
+++ b/components/ruler-hooked/ruler-hooked-cosmetics-editor.vue
@@ -1,0 +1,94 @@
+<!-- components/ruler-hooked/ruler-hooked-cosmetics-editor.vue
+     The ruler's name, honorific, and portrait preset -- all cosmetic-only, so
+     this one form covers both "new reign" (no `save` prop) and "edit this
+     reign" (ruler-hooked/t-021: presets and honorific are not locked at
+     creation). Presets/suggestions are read as data from rulerPresets.ts, never
+     hardcoded here. -->
+<template>
+  <div class="flex flex-wrap items-end gap-2">
+    <label class="form-control">
+      <span class="label-text text-xs">Ruler name</span>
+      <input
+        v-model="name"
+        type="text"
+        placeholder="Mo"
+        class="input input-bordered input-sm w-28"
+      />
+    </label>
+    <label class="form-control">
+      <span class="label-text text-xs">Title</span>
+      <input
+        v-model="honorific"
+        type="text"
+        :list="honorificListId"
+        placeholder="Ruler"
+        class="input input-bordered input-sm w-32"
+      />
+    </label>
+    <label class="form-control">
+      <span class="label-text text-xs">Portrait</span>
+      <select v-model="presetId" class="select select-bordered select-sm">
+        <option
+          v-for="preset in RULER_PRESETS"
+          :key="preset.id"
+          :value="preset.id"
+        >
+          {{ preset.title }} — {{ preset.id }}
+        </option>
+      </select>
+    </label>
+    <button
+      type="button"
+      class="btn btn-primary btn-sm"
+      :disabled="!name.trim()"
+      @click="submit"
+    >
+      {{ submitLabel ?? 'Save' }}
+    </button>
+  </div>
+  <datalist :id="honorificListId">
+    <option
+      v-for="title in HONORIFIC_SUGGESTIONS"
+      :key="title"
+      :value="title"
+    />
+  </datalist>
+</template>
+
+<script setup lang="ts">
+import {
+  RULER_PRESETS,
+  HONORIFIC_SUGGESTIONS,
+  DEFAULT_RULER_PRESET_ID,
+} from '~/utils/rulerHooked/rulerPresets'
+import type { RunSave } from '~/types/ruler-hooked'
+
+const props = defineProps<{
+  /** Omit (or pass null) for the "new reign" case -- fields start blank/default. */
+  save?: RunSave | null
+  submitLabel?: string
+}>()
+const emit = defineEmits<{
+  submit: [{ name: string; honorific: string; presetId: string }]
+}>()
+
+const honorificListId = `ruler-honorific-suggestions-${useId()}`
+
+// "New reign" (no `save`) keeps the PoC's original ready-to-go defaults so the
+// button isn't disabled on first render; editing an existing reign always shows
+// its real values.
+const name = ref(props.save?.ruler.name ?? 'Mo')
+const honorific = ref(props.save?.ruler.honorific ?? 'Queen')
+const presetId = ref(
+  props.save?.ruler.cosmetics?.presetId ?? DEFAULT_RULER_PRESET_ID,
+)
+
+function submit() {
+  if (!name.value.trim()) return
+  emit('submit', {
+    name: name.value.trim(),
+    honorific: honorific.value.trim() || 'Ruler',
+    presetId: presetId.value,
+  })
+}
+</script>

--- a/components/ruler-hooked/ruler-hooked-game.vue
+++ b/components/ruler-hooked/ruler-hooked-game.vue
@@ -6,22 +6,40 @@
   <ClientOnly>
     <div class="kr-container max-w-3xl flex flex-col gap-4">
       <template v-if="store.save">
-        <RulerHookedStage :scene="store.scene" :regions="store.bundle.regions" />
+        <RulerHookedStage
+          :scene="store.scene"
+          :regions="store.bundle.regions"
+          :ruler-cosmetic-id="store.save.ruler.cosmetics?.presetId ?? DEFAULT_RULER_PRESET_ID"
+        />
 
         <div class="flex items-center justify-between gap-3">
           <div>
             <p class="text-sm font-bold">{{ store.save.ruler.honorific }} {{ store.save.ruler.name }}</p>
             <p class="text-xs opacity-60">Turn {{ store.save.turnCount }} · {{ store.save.status.toLowerCase() }} · {{ store.save.counters.fishCaught ?? 0 }} fish</p>
           </div>
-          <button
-            type="button"
-            class="btn btn-primary"
-            :disabled="!store.canFish"
-            @click="store.startFishing()"
-          >
-            🎣 Cast a line
-          </button>
+          <div class="flex items-center gap-2">
+            <button type="button" class="btn btn-ghost btn-xs" @click="showEditor = !showEditor">
+              {{ showEditor ? 'Close' : 'Edit reign' }}
+            </button>
+            <button
+              type="button"
+              class="btn btn-primary"
+              :disabled="!store.canFish"
+              @click="store.startFishing()"
+            >
+              🎣 Cast a line
+            </button>
+          </div>
         </div>
+
+        <!-- Cosmetics are cosmetic-only by design (ruler-hooked/t-021) -- change
+             name/honorific/portrait any time, not just at creation. -->
+        <RulerHookedCosmeticsEditor
+          v-if="showEditor"
+          :save="store.save"
+          submit-label="Save changes"
+          @submit="onUpdateRuler"
+        />
 
         <RulerHookedHealth :health="store.save.kingdomHealth" />
 
@@ -80,12 +98,19 @@
 
 <script setup lang="ts">
 import { useRulerHookedStore } from '~/stores/rulerHookedStore'
+import { DEFAULT_RULER_PRESET_ID } from '~/utils/rulerHooked/rulerPresets'
 
 const store = useRulerHookedStore()
+const showEditor = ref(false)
 
 onMounted(() => {
   store.init()
 })
+
+function onUpdateRuler(payload: { name: string; honorific: string; presetId: string }) {
+  store.updateRuler(payload)
+  showEditor.value = false
+}
 
 function endingTitleFor(key: string | null): string {
   const e = store.bundle.endings.find((x) => x.outcomeKey === key)

--- a/components/ruler-hooked/ruler-hooked-slots.vue
+++ b/components/ruler-hooked/ruler-hooked-slots.vue
@@ -22,21 +22,7 @@
     </div>
     <p v-else class="mb-3 text-xs opacity-60">No saves yet — start a new reign.</p>
 
-    <div class="flex flex-wrap items-end gap-2">
-      <label class="form-control">
-        <span class="label-text text-xs">Ruler name</span>
-        <input v-model="rulerName" type="text" placeholder="Mo" class="input input-bordered input-sm w-28" />
-      </label>
-      <label class="form-control">
-        <span class="label-text text-xs">Title</span>
-        <select v-model="honorific" class="select select-bordered select-sm">
-          <option>Queen</option><option>King</option><option>Ruler</option>
-        </select>
-      </label>
-      <button type="button" class="btn btn-primary btn-sm" :disabled="!rulerName.trim()" @click="start">
-        New reign
-      </button>
-    </div>
+    <RulerHookedCosmeticsEditor submit-label="New reign" @submit="start" />
   </div>
 </template>
 
@@ -44,12 +30,9 @@
 import { useRulerHookedStore } from '~/stores/rulerHookedStore'
 
 const store = useRulerHookedStore()
-const rulerName = ref('Mo')
-const honorific = ref('Queen')
 
-function start() {
-  if (!rulerName.value.trim()) return
-  store.newGame('', rulerName.value.trim(), honorific.value)
+function start(payload: { name: string; honorific: string; presetId: string }) {
+  store.newGame('', payload.name, payload.honorific, payload.presetId)
 }
 function rename(saveId: string, current: string) {
   const name = typeof window !== 'undefined' ? window.prompt('Rename this reign', current) : null

--- a/components/ruler-hooked/ruler-hooked-stage.vue
+++ b/components/ruler-hooked/ruler-hooked-stage.vue
@@ -71,9 +71,13 @@ const props = withDefaults(
     scene: SceneState | null
     regions: RegionsManifest
     showImages?: boolean
+    /** Ruler cosmetic preset id (ruler-hooked/t-021) -- only the `ruler` region
+     *  consumes this; every other region ignores it. */
+    rulerCosmeticId?: string
   }>(),
   {
     showImages: true,
+    rulerCosmeticId: undefined,
   },
 )
 
@@ -126,7 +130,13 @@ const layers = computed<Layer[]>(() => {
     .map((region) => {
       const state = scene.regionStates[region]
       const cands = props.showImages
-        ? assetCandidates(region, state, scene.time)
+        ? assetCandidates(
+            region,
+            state,
+            scene.time,
+            undefined,
+            region === 'ruler' ? props.rulerCosmeticId : undefined,
+          )
         : []
       const idx = errIndex[region] ?? 0
       return {

--- a/stores/rulerHookedStore.ts
+++ b/stores/rulerHookedStore.ts
@@ -71,7 +71,7 @@ export const useRulerHookedStore = defineStore('rulerHooked', () => {
     }
   }
 
-  function newGame(name: string, rulerName: string, honorific = 'Ruler') {
+  function newGame(name: string, rulerName: string, honorific = 'Ruler', presetId?: string) {
     const stamp = nowStamp()
     const saveId = makeSaveId(stamp, rulerName + slots.value.length)
     const run = createRun(bundle, {
@@ -80,12 +80,27 @@ export const useRulerHookedStore = defineStore('rulerHooked', () => {
       seed: `${rulerName}-${saveId}`,
       rulerName,
       honorific,
+      presetId,
       stamp,
     })
     save.value = run
     clearTransientPlayState()
     writeSave(run, stamp)
     refreshSlots()
+  }
+
+  /** Change the ruler's name/honorific/portrait on an existing reign (t-021: these
+   *  are cosmetic-only, so there is no reason to lock them at creation). */
+  function updateRuler(patch: { name?: string; honorific?: string; presetId?: string }) {
+    if (!save.value) return
+    const next = cloneSave(save.value)
+    if (patch.name !== undefined) next.ruler.name = patch.name
+    if (patch.honorific !== undefined) next.ruler.honorific = patch.honorific
+    if (patch.presetId !== undefined) {
+      next.ruler.cosmetics = { ...(next.ruler.cosmetics ?? {}), presetId: patch.presetId }
+    }
+    save.value = next
+    persist()
   }
 
   function loadSlot(saveId: string) {
@@ -184,7 +199,7 @@ export const useRulerHookedStore = defineStore('rulerHooked', () => {
   return {
     bundle, save, activeCard, activeArcId, pendingEnding, activeFishing,
     lastCatch, lastEscape, slots, scene, canFish,
-    init, newGame, loadSlot, startFishing, fishingAction, choose,
+    init, newGame, updateRuler, loadSlot, startFishing, fishingAction, choose,
     acceptEnding, declineEnding, renameSlot, deleteSlot, refreshSlots,
   }
 })

--- a/types/ruler-hooked.ts
+++ b/types/ruler-hooked.ts
@@ -299,6 +299,17 @@ export interface DeckState {
   drawBag: string[]
 }
 
+/** Cosmetic-only choices for the player character (ruler-hooked/t-021). `honorific`
+ *  on the enclosing `ruler` is free text; `presetId` selects a whole pre-authored
+ *  figure (utils/rulerHooked/rulerPresets.ts) rather than composable parts -- see
+ *  that module's header for why. `outfit`/`crownTilt` predate the preset system
+ *  and are kept for back-compat; nothing currently reads them. */
+export interface RulerCosmetics {
+  presetId?: string
+  outfit?: string
+  crownTilt?: boolean
+}
+
 export interface RunSave {
   schemaVersion: number
   saveId: string
@@ -311,7 +322,7 @@ export interface RunSave {
     name: string
     honorific?: string
     characterSlug?: string
-    cosmetics?: Record<string, unknown>
+    cosmetics?: RulerCosmetics
   }
   turnCount: number
   cyclePosition: number

--- a/utils/rulerHooked/compositor.ts
+++ b/utils/rulerHooked/compositor.ts
@@ -70,6 +70,12 @@ export function resolveScene(
  * contract {region}-{state}[-{time}].webp (compositing.md §4.3). Returns the
  * ordered fallback candidates (exact → settle-neighbour → base) so the caller's
  * <img> onError ladder can degrade gracefully instead of showing a hole.
+ *
+ * `cosmeticId` is the ruler-only cosmetic axis (ruler-hooked/t-021): when the
+ * `ruler` region resolves with a chosen preset id, its layer at
+ * ruler/<cosmeticId>.webp is tried FIRST, ahead of every other candidate --
+ * missing preset art falls through to the same base-ruler-layer candidates
+ * every other region already has, never a hole. Every other region ignores it.
  */
 const SETTLE: Record<TimeKey, TimeKey> = {
   day: 'day',
@@ -83,6 +89,7 @@ export function assetCandidates(
   state: RegionState | undefined,
   time: TimeKey,
   dir = '/images/ruler-hooked',
+  cosmeticId?: string,
 ): string[] {
   const base = state ? `${region}-${state}` : `${region}`
   const settle = SETTLE[time]
@@ -91,6 +98,7 @@ export function assetCandidates(
     `${base}-${settle}`, // treat → nearest settle
     base, // time-agnostic
   ]
+  if (region === 'ruler' && cosmeticId) names.unshift(`ruler/${cosmeticId}`)
   // de-dupe while preserving order
   const seen = new Set<string>()
   return names

--- a/utils/rulerHooked/engine.selftest.ts
+++ b/utils/rulerHooked/engine.selftest.ts
@@ -9,7 +9,7 @@ import type { Card, RegionsManifest, RunSave } from '~/types/ruler-hooked'
 
 function baseSave(): RunSave {
   return {
-    schemaVersion: 4, saveId: 'sv_test', name: 'Test', dreamSlug: 'ruler-hooked',
+    schemaVersion: 5, saveId: 'sv_test', name: 'Test', dreamSlug: 'ruler-hooked',
     contentVersion: '2026.07', seed: 'mo-4820', status: 'ACTIVE',
     ruler: { name: 'Mo', honorific: 'Queen' },
     turnCount: 5, cyclePosition: 0,
@@ -93,6 +93,24 @@ function baseSave(): RunSave {
     '/images/ruler-hooked/treeline-wild-day.webp',
     '/images/ruler-hooked/treeline-wild.webp',
   ], 'golden falls back to day settle then base')
+
+  // Ruler cosmetic axis (ruler-hooked/t-021): a chosen preset's layer is tried
+  // first, ahead of the region's normal state/time candidates.
+  const rulerCands = assetCandidates('ruler', 'fishing', 'day', undefined, 'king-osric')
+  assert.deepEqual(rulerCands, [
+    '/images/ruler-hooked/ruler/king-osric.webp',
+    '/images/ruler-hooked/ruler-fishing-day.webp',
+    '/images/ruler-hooked/ruler-fishing.webp',
+  ], 'preset layer tried first, falls back to the base ruler layer')
+  assert.deepEqual(
+    assetCandidates('ruler', 'fishing', 'day'),
+    ['/images/ruler-hooked/ruler-fishing-day.webp', '/images/ruler-hooked/ruler-fishing.webp'],
+    'no cosmeticId -> unchanged base-ruler-layer candidates',
+  )
+  assert.ok(
+    !assetCandidates('treeline', 'wild', 'day', undefined, 'king-osric').some((c) => c.includes('/ruler/')),
+    'cosmeticId is ignored for every region other than ruler',
+  )
 }
 
 // 5. Selection determinism + gating

--- a/utils/rulerHooked/game.selftest.ts
+++ b/utils/rulerHooked/game.selftest.ts
@@ -13,7 +13,7 @@ import { resolveChoice } from '~/utils/rulerHooked/applyEffects'
 import { resolveScene } from '~/utils/rulerHooked/compositor'
 import { makeRng } from '~/utils/rulerHooked/seed'
 import {
-  loadIndex, loadSave, writeSave, renameSlot, deleteSlot, makeSaveId,
+  loadIndex, loadSave, writeSave, renameSlot, deleteSlot, makeSaveId, SAVE_SCHEMA_VERSION,
 } from '~/utils/rulerHooked/save'
 import type { RunSave } from '~/types/ruler-hooked'
 
@@ -37,10 +37,20 @@ const fresh = (id = 'sv_a'): RunSave =>
   const s = fresh()
   assert.equal(s.turnCount, 0)
   assert.equal(s.status, 'ACTIVE')
-  assert.equal(s.schemaVersion, 4)
+  assert.equal(s.schemaVersion, SAVE_SCHEMA_VERSION)
   assert.equal(s.kingdomHealth.nature, 50)
   assert.equal(s.contentVersion, C.contentVersion)
   assert.deepEqual(s.fishopedia, {})
+  assert.deepEqual(s.ruler.cosmetics, {}, 'no presetId chosen -> empty cosmetics, not undefined')
+}
+
+// 1b. A chosen ruler preset is threaded through to the save (ruler-hooked/t-021)
+{
+  const s = createRun(C, {
+    saveId: 'sv_preset', name: 'Test Reign', seed: 'mo-4820',
+    rulerName: 'Mo', honorific: 'Queen', presetId: 'queen-mabel', stamp: 'T0',
+  })
+  assert.equal(s.ruler.cosmetics?.presetId, 'queen-mabel')
 }
 
 // 2. Turn loop is deterministic, advances turnCount, and lands a real species
@@ -139,8 +149,23 @@ const fresh = (id = 'sv_a'): RunSave =>
   delete old.fishopedia
   backingStore.set('rulerHooked:save:sv_old', JSON.stringify(old))
   const migrated = loadSave('sv_old')
-  assert.equal(migrated?.schemaVersion, 4, 'legacy slot is promoted to schema 4')
+  assert.equal(migrated?.schemaVersion, 5, 'legacy slot is promoted to the current schema')
   assert.deepEqual(migrated?.fishopedia, {}, 'legacy slot receives an empty Fishopedia')
+}
+
+// 8. A pre-cosmetics schema-4 slot (ruler-hooked/t-021) migrates to a real
+// cosmetics object rather than leaving `ruler.cosmetics` undefined
+{
+  type PreCosmeticsRunSave = Omit<RunSave, 'ruler'> & {
+    ruler: Omit<RunSave['ruler'], 'cosmetics'> & { cosmetics?: RunSave['ruler']['cosmetics'] }
+  }
+  const old = fresh('sv_old_cosmetics') as PreCosmeticsRunSave
+  old.schemaVersion = 4
+  delete old.ruler.cosmetics
+  backingStore.set('rulerHooked:save:sv_old_cosmetics', JSON.stringify(old))
+  const migrated = loadSave('sv_old_cosmetics')
+  assert.equal(migrated?.schemaVersion, 5, 'legacy slot is promoted to the current schema')
+  assert.deepEqual(migrated?.ruler.cosmetics, {}, 'legacy slot receives an empty cosmetics object, not a presetId it never chose')
 }
 
 console.log('ruler-hooked GAME self-test: ALL PASS')

--- a/utils/rulerHooked/newGame.ts
+++ b/utils/rulerHooked/newGame.ts
@@ -5,6 +5,7 @@
 
 import type { ContentBundle, RunSave } from '~/types/ruler-hooked'
 import { AXIS_KEYS } from '~/types/ruler-hooked'
+import { SAVE_SCHEMA_VERSION } from '~/utils/rulerHooked/save'
 
 export interface NewGameOpts {
   saveId: string
@@ -12,6 +13,9 @@ export interface NewGameOpts {
   seed: string
   rulerName: string
   honorific?: string
+  /** Chosen ruler cosmetic preset id (utils/rulerHooked/rulerPresets.ts). Undefined
+   *  leaves cosmetics empty; the compositor/UI fall back to the default preset. */
+  presetId?: string
   stamp: string // ISO timestamp supplied by the caller (no Date.now in the engine)
 }
 
@@ -25,14 +29,18 @@ export function createRun(bundle: ContentBundle, opts: NewGameOpts): RunSave {
   const drawBag = bundle.decks.flatMap((d) => d.cards.map((c) => c.id))
 
   return {
-    schemaVersion: 4,
+    schemaVersion: SAVE_SCHEMA_VERSION,
     saveId: opts.saveId,
     name: opts.name,
     dreamSlug: 'ruler-hooked',
     contentVersion: bundle.contentVersion,
     seed: opts.seed,
     status: 'ACTIVE',
-    ruler: { name: opts.rulerName, honorific: opts.honorific, cosmetics: {} },
+    ruler: {
+      name: opts.rulerName,
+      honorific: opts.honorific,
+      cosmetics: opts.presetId ? { presetId: opts.presetId } : {},
+    },
     turnCount: 0,
     cyclePosition: 0,
     kingdomHealth,

--- a/utils/rulerHooked/rulerPresets.ts
+++ b/utils/rulerHooked/rulerPresets.ts
@@ -1,0 +1,50 @@
+// utils/rulerHooked/rulerPresets.ts
+//
+// Data for the ruler cosmetic axis (ruler-hooked/t-021). Silas, 2026-08-26:
+// "preset figures, custom name and honorific, your presets are fine ... custom
+// should be an option" -- so the figure itself is chosen from a fixed roster
+// (no composable body/skin/species parts; a diffusion model can't produce
+// separable parts that register against each other, per t-021's own reasoning),
+// while name and honorific are free text.
+//
+// One preset = one compositor-ready layer at
+// public/images/ruler-hooked/ruler/<id>.webp (art pipeline: conductor's
+// scripts/build_ruler_hooked_art_queue.py RULER_PRESETS -- keep this list in
+// sync with that one). Read as data everywhere: adding a preset is one entry
+// here plus one asset, never a code change.
+
+export interface RulerPreset {
+  id: string
+  title: string
+}
+
+export const RULER_PRESETS: RulerPreset[] = [
+  { id: 'king-osric', title: 'King' },
+  { id: 'queen-mabel', title: 'Queen' },
+  { id: 'sovereign-wren', title: 'Sovereign' },
+  { id: 'regent-halvard', title: 'Regent' },
+  { id: 'matriarch-oshun', title: 'Matriarch' },
+  { id: 'chieftain-brakka', title: 'Chieftain' },
+  { id: 'heron-queen-sedge', title: 'Queen' },
+  { id: 'little-monarch-pip', title: 'Monarch' },
+  { id: 'boy-king-tobin', title: 'King' },
+  { id: 'girl-queen-marisol', title: 'Queen' },
+  { id: 'cub-prince-bramble', title: 'Prince' },
+  { id: 'elder-tortoise-yew', title: 'Sovereign' },
+]
+
+/** The hero preset -- used whenever a save has no `ruler.cosmetics.presetId`
+ *  yet (pre-t-021 saves, or a fresh reign that hasn't picked one). */
+export const DEFAULT_RULER_PRESET_ID = 'king-osric'
+
+/** Unique honorific titles drawn from the preset roster, offered as suggestions
+ *  only -- `honorific` itself is free text (Silas, 2026-08-26 decision). */
+export const HONORIFIC_SUGGESTIONS: string[] = Array.from(
+  new Set(RULER_PRESETS.map((p) => p.title)),
+)
+
+export function rulerPresetById(
+  id: string | undefined,
+): RulerPreset | undefined {
+  return RULER_PRESETS.find((p) => p.id === id)
+}

--- a/utils/rulerHooked/save.ts
+++ b/utils/rulerHooked/save.ts
@@ -10,7 +10,7 @@ import type { RunSave, SaveIndex, SaveSlotMeta } from '~/types/ruler-hooked'
 
 const INDEX_KEY = 'rulerHooked:index'
 const slotKey = (saveId: string) => `rulerHooked:save:${saveId}`
-export const SAVE_SCHEMA_VERSION = 4
+export const SAVE_SCHEMA_VERSION = 5
 
 // Checked per-call (not captured at module load) so SSR — and headless tests
 // that install a window shim after import — behave correctly.
@@ -53,6 +53,11 @@ function parse<T>(raw: string | null): T | null {
 /** Add fields introduced after the original PoC without invalidating old slots. */
 function migrateSave(save: RunSave): RunSave {
   if (!save.fishopedia) save.fishopedia = {}
+  // v4 -> v5 (ruler-hooked/t-021): ruler.cosmetics gained a `presetId` axis. A
+  // slot from before this existed has no cosmetics object at all (or an empty
+  // one) -- both cases already read correctly as "use the default preset", so
+  // this only needs to guarantee the object exists, never invent a presetId.
+  if (!save.ruler.cosmetics) save.ruler.cosmetics = {}
   save.schemaVersion = SAVE_SCHEMA_VERSION
   return save
 }


### PR DESCRIPTION
### Task
ruler-hooked/t-021 (conductor): Build the ruler character creator

### What changed / what I produced
- `types/ruler-hooked.ts`: real `RulerCosmetics` interface (`presetId`, plus the pre-existing `outfit`/`crownTilt` kept for back-compat) replacing the untyped `Record<string, unknown>`.
- `utils/rulerHooked/save.ts`: `SAVE_SCHEMA_VERSION` 4→5; `migrateSave` guarantees `ruler.cosmetics` exists on load for older saves.
- `utils/rulerHooked/compositor.ts`: `assetCandidates()` gains an optional `cosmeticId` param — for the `ruler` region only, a chosen preset's layer (`ruler/<presetId>.webp`) is tried first, then falls through to the existing base-ruler-layer candidates, mirroring the time-variant ladder's exact → settle → base collapse.
- `utils/rulerHooked/rulerPresets.ts` (new): the twelve preset ids/titles as data (mirrors `RULER_PRESETS` in conductor's `scripts/build_ruler_hooked_art_queue.py`).
- New shared `components/ruler-hooked/ruler-hooked-cosmetics-editor.vue`: name/honorific free-text + datalist suggestions + preset picker. Used both for "new reign" (`ruler-hooked-slots.vue`, replacing the old 3-option honorific `<select>`) and for editing an existing reign (`ruler-hooked-game.vue`'s new "Edit reign" toggle).
- `stores/rulerHookedStore.ts`: `newGame()` threads `presetId` through; new `updateRuler()` action so cosmetics aren't locked at creation.

Body/skin/species composable axes from the task's earlier draft note are **not** implemented — Silas's own DECIDED note on the task supersedes that framing in favor of whole pre-authored figure presets (a diffusion model can't produce registered separable parts), so there's no composable-parts axis to build.

**Deferred as separate follow-on tasks** (conductor ruler-hooked/t-023, t-024) rather than forced into one diff:
- t-023: the custom-portrait-upload escape hatch — genuinely new infrastructure (kind_robots has no IndexedDB usage anywhere today).
- t-024: rendering real transparent-layer preset art (t-020's twelve images are portrait reference sheets, not drop-in compositor layers). The cosmetic axis already falls back gracefully to the base layer in the meantime — a real but non-breaking gap.

### How I verified
- `npx tsx utils/rulerHooked/engine.selftest.ts` / `game.selftest.ts` / `encounter.selftest.ts` — all pass (added a compositor cosmetic-axis case, a schema 4→5 migration case, and a presetId-threading case).
- `npx vue-tsc --noEmit` — clean.
- `npx eslint` on every touched file — clean.
- `npx tsx utils/scripts/verifyLayoutContract.ts` — holds, no new violations.
- No live DB/browser in this sandbox, so the new UI was not visually verified pre-merge — structural/logic verification only.

### Stakes
reversible

### Flags for Reviewer
- None outstanding.

### Kaizen suggestion
Filed as conductor ruler-hooked/t-023 and t-024 (see above) rather than a generic suggestion — those are the concrete next steps this slice's own scope triage surfaced.


---
_Generated by [Claude Code](https://claude.ai/code/session_011kuy7JG7JyTjch3PfqMyHg)_