### PR TITLE
cthulhuquarium/t-012: gate the field note behind unlock, add a real reveal beat

### DIFF
--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -164,8 +164,12 @@
             />
             <div class="min-w-0 flex-1">
               <p class="truncate text-sm font-bold">{{ entry.name }}</p>
+              <!-- Deliberately never the field note here -- the server
+                   doesn't even send it for unowned species
+                   (cthulhuquarium/t-012). It reveals in the dialog below,
+                   once, on unlock. -->
               <p class="mt-0.5 line-clamp-2 text-xs italic opacity-70">
-                {{ entry.fieldNote || 'Not yet observed.' }}
+                Not yet observed.
               </p>
               <button
                 type="button"
@@ -183,6 +187,63 @@
         </div>
       </div>
     </div>
+
+    <!-- The unlock reveal beat (cthulhuquarium/t-012): the field note is
+         real information the player earned by paying for it, not shop
+         copy -- so it gets a moment of its own instead of quietly sitting
+         in a shrinking catalog card. -->
+    <Teleport to="body">
+      <dialog
+        v-if="tankStore.revealedUnlock"
+        class="modal modal-open"
+        aria-modal="true"
+        @cancel.prevent="tankStore.dismissReveal()"
+      >
+        <div
+          class="modal-box flex max-w-sm flex-col items-center gap-3 rounded-3xl border border-base-300 bg-base-100 text-center shadow-2xl"
+        >
+          <p class="text-xs font-black uppercase tracking-wide text-primary">
+            New occupant
+          </p>
+          <kr-art-plate
+            :source="tankStore.revealedUnlock.Monster"
+            variant="card"
+            shape="plate"
+            frame="thin"
+            fit="cover"
+            class="h-32 w-24"
+            placeholder-icon="kind-icon:fish"
+          />
+          <h3 class="text-lg font-black">
+            {{ tankStore.revealedUnlock.Monster.name }}
+          </h3>
+          <p
+            v-if="tankStore.revealedUnlock.Monster.species"
+            class="text-xs italic opacity-60"
+          >
+            {{ tankStore.revealedUnlock.Monster.species }}
+          </p>
+          <p class="text-sm opacity-80">
+            {{
+              tankStore.revealedUnlock.Monster.fieldNote ||
+              'Nothing is written about this one yet.'
+            }}
+          </p>
+          <button
+            type="button"
+            class="btn btn-primary btn-sm mt-1"
+            @click="tankStore.dismissReveal()"
+          >
+            Add it to the tank
+          </button>
+        </div>
+        <form method="dialog" class="modal-backdrop">
+          <button type="button" @click="tankStore.dismissReveal()">
+            close
+          </button>
+        </form>
+      </dialog>
+    </Teleport>
   </ClientOnly>
 </template>
 

--- a/server/utils/aquarium.ts
+++ b/server/utils/aquarium.ts
@@ -56,6 +56,12 @@ const stockMonsterSelect = {
   name: true,
   slug: true,
   species: true,
+  // fieldNote is safe to select here: this shape is only ever used for
+  // fish ALREADY placed in a tank (ownedStockSelect below, and the public
+  // browse selects have their own, separate, fieldNote-free shape) --
+  // never for the pre-unlock catalog (cthulhuquarium/t-012). See that
+  // task's note: "the field note reveals on first unlock, not before."
+  fieldNote: true,
   size: true,
   icon: true,
   iconPath: true,
@@ -483,6 +489,13 @@ export async function listPublicTanks(
 // (cthulhuquarium/t-011). `cost` is computed the exact same way
 // purchaseSpeciesForUser charges (deriveFishRarityTier + unlockCost) so the
 // displayed price never drifts from what unlocking actually costs.
+//
+// Deliberately no `fieldNote` here (cthulhuquarium/t-012): "unlocking a
+// species the player has never seen should feel like the point of the
+// game... the field note reveals on first unlock, not before." The
+// museum-placard text only becomes selectable once a species is owned
+// (see stockMonsterSelect) -- the server never sends the spoiler pre-sale,
+// same "server disposes" discipline as pricing.
 // ---------------------------------------------------------------------------
 
 const catalogMonsterSelect = {
@@ -490,7 +503,6 @@ const catalogMonsterSelect = {
   name: true,
   slug: true,
   species: true,
-  fieldNote: true,
   depth: true,
   size: true,
   icon: true,

--- a/stores/cthulhuquariumTankStore.ts
+++ b/stores/cthulhuquariumTankStore.ts
@@ -19,6 +19,10 @@ export interface TankMonster {
   name: string
   slug: string
   species: string | null
+  // Only ever populated for OWNED fish -- the server never sends this for
+  // catalog (unowned) entries (cthulhuquarium/t-012: "the field note
+  // reveals on first unlock, not before").
+  fieldNote: string | null
   size: number
   icon: string | null
   iconPath: string | null
@@ -66,7 +70,8 @@ export interface CatalogEntry {
   name: string
   slug: string
   species: string | null
-  fieldNote: string | null
+  // No fieldNote here on purpose -- see TankMonster's own comment. The
+  // catalog is what a NOT-yet-owned species looks like.
   depth: number | null
   size: number
   icon: string | null
@@ -114,6 +119,11 @@ export const useCthulhuquariumTankStore = defineStore(
     const catalogLoading = ref(false)
     const error = ref('')
     const ready = ref(false)
+    // The just-unlocked occupant, field note and all -- the ONE moment its
+    // fieldNote is legitimately known client-side (cthulhuquarium/t-012's
+    // "give it a real beat" call). The game component watches this to show
+    // a reveal, then clears it via dismissReveal().
+    const revealedUnlock = ref<TankStock | null>(null)
 
     const stock = computed(() => tank.value?.Stock ?? [])
     const coins = computed(() => tank.value?.coins ?? 0)
@@ -197,10 +207,15 @@ export const useCthulhuquariumTankStore = defineStore(
       if (res.success && res.data) {
         tank.value = res.data.aquarium
         catalog.value = catalog.value.filter((entry) => entry.id !== monsterId)
+        revealedUnlock.value = res.data.stock
         return true
       }
       error.value = res.message || 'Could not unlock that species.'
       return false
+    }
+
+    function dismissReveal(): void {
+      revealedUnlock.value = null
     }
 
     function clearOfflineEarnings(): void {
@@ -220,11 +235,13 @@ export const useCthulhuquariumTankStore = defineStore(
       catalogLoading,
       error,
       ready,
+      revealedUnlock,
       load,
       settleTick,
       loadCatalog,
       feed,
       unlock,
+      dismissReveal,
       clearOfflineEarnings,
     }
   },


### PR DESCRIPTION
### Task
cthulhuquarium/t-012: Economy wiring — coins, food, upgrades, species unlocks (kind: software)

### What changed / what I produced
- `server/utils/aquarium.ts`: moved `fieldNote` off the pre-unlock `catalogMonsterSelect` and onto `stockMonsterSelect` (owned fish only) — the server now genuinely withholds it pre-purchase instead of just hiding it client-side.
- `stores/cthulhuquariumTankStore.ts`: `unlock()` now captures the purchase response's newly-created stock (with its `fieldNote`) into a new `revealedUnlock` ref; added `dismissReveal()`.
- `components/cthulhuquarium/cthulhuquarium-game.vue`: the catalog card now shows a fixed "Not yet observed." teaser instead of the (previously leaked) field note. A new reveal dialog — `Teleport` + `<dialog>`, same modal pattern as `daily-digest-object-dialog.vue` — shows the unlocked species' art, name, and field note exactly once, on unlock.

### Why this was the right slice of t-012
Reading the existing code before touching anything: t-011 already wired buy-food (`POST /api/aquarium/feed`) and species-unlock (`POST /api/aquarium/purchase`) end-to-end, and unlocking already auto-places the species into the tank (`purchaseSpeciesForUser` creates the `AquariumStock` row directly) — so neither of those needed new work, and there's no separate "place" step to build.

What t-012's note explicitly calls for and wasn't yet true: *"Unlocking a species the player has never seen should feel like the point of the game, so give it a real beat: the field note reveals on first unlock, not before."* The catalog card was rendering `entry.fieldNote` directly — the reveal text was visible before purchase, the opposite of the intended design. This PR fixes that gap and gives it the "real beat" the note asks for.

"Buy upgrades" from the task's original note is **not** built here: `cthulhuquarium/t-026` ("Set pieces — the build layer and its synergies") explicitly `depends_on: t-012` and is `status: waiting` — it's the actual home for that system. `economy.yaml`'s own `slots` section is explicit that capacity growth is milestone-only, "never purchased with coins," so inventing a coin-priced upgrade shop here would contradict the balance spec. `purchase.post.ts` already documents this same reasoning for why `type: 'upgrade'` returns 400.

### How I verified
- `eslint` on all three changed files — clean
- `vue-tsc --noEmit` (full repo) — clean
- `prettier --check` on changed files — clean
- `npm run test:layout-contract` — holds, no new violations (an unrelated pre-existing ratchet improvement in `video-lora-picker.vue` shows up in the output but is untouched by this diff)
- `utils/scripts/verifyAquariumEconomy.test.ts` — all 15 assertions pass (this diff doesn't touch the pure economy math, included for completeness since it shares the file)
- No live DB in this sandbox, so the actual purchase → reveal round trip is verified by code inspection (matches t-011's own precedent for this constraint)

### Stakes
reversible

### Flags for Reviewer
- The reveal dialog's "close" affordance duplicates the primary button (`modal-backdrop` form + the `Add it to the tank` button) — same shape as the referenced `daily-digest-object-dialog.vue` pattern, just simplified since this dialog has one action, not several tabs.

### Kaizen suggestion
`Monster.yieldPerTick` / `Monster.tickIntervalSeconds` / `Monster.unlockCost` (per-species overrides of the tier-derived economy constants) exist on the schema but neither `aquariumEconomy.ts` nor `aquarium.ts` reads them yet — everything still derives purely from `tier`. The schema's own doc comment says this is fine for now ("not required at seed time"), but it's worth a task once a real per-species balance pass is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016b7UDwWwUMc7mz2tbaEWAN)_