### PR TITLE
cthulhuquarium/t-020: touch targets, canvas scaling, and a cached water gradient

### DIFF
--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -64,7 +64,7 @@
 
         <button
           type="button"
-          class="btn btn-primary btn-sm"
+          class="btn btn-primary btn-sm min-h-11 min-w-11"
           :disabled="!tankStore.hungriest"
           @click="onFeed"
         >
@@ -74,10 +74,10 @@
 
       <canvas
         ref="canvasRef"
-        class="w-full cursor-pointer rounded-2xl border border-base-300 bg-base-300"
+        class="aspect-[16/9] w-full cursor-pointer rounded-2xl border border-base-300 bg-base-300"
         :width="STAGE_WIDTH"
         :height="STAGE_HEIGHT"
-        aria-label="Aquarium tank. Click drifting coins to collect them."
+        aria-label="Aquarium tank. Tap drifting coins to collect them."
         @click="onCanvasClick"
       />
 
@@ -114,7 +114,7 @@
               </div>
               <button
                 type="button"
-                class="btn btn-outline btn-xs shrink-0"
+                class="btn btn-outline btn-xs min-h-11 min-w-11 shrink-0"
                 :disabled="entry.hunger >= 100"
                 @click="tankStore.feed(entry.id)"
               >
@@ -173,7 +173,7 @@
               </p>
               <button
                 type="button"
-                class="btn btn-outline btn-xs mt-1"
+                class="btn btn-outline btn-xs min-h-11 mt-1"
                 :disabled="!canUnlock(entry)"
                 @click="tankStore.unlock(entry.id)"
               >
@@ -255,6 +255,7 @@ import {
   type CatalogEntry,
   type TankStock,
 } from '~/stores/cthulhuquariumTankStore'
+import { touchHitRadius } from '~/utils/aquariumTouch'
 
 /* Fixed logical resolution; CSS scales it to the host width so the canvas
    survives phone widths without its own breakpoint logic. */
@@ -489,11 +490,24 @@ function drawFish(
   context.restore()
 }
 
+// The water gradient never changes shape (it only spans the fixed stage
+// dimensions), so it's built once per context instead of allocated fresh on
+// every animation frame -- a full tank redraws this 60x/sec, and a mid-range
+// phone shouldn't pay for a gradient rebuild it doesn't need.
+let waterGradient: CanvasGradient | null = null
+let waterGradientContext: CanvasRenderingContext2D | null = null
+
+function getWaterGradient(context: CanvasRenderingContext2D): CanvasGradient {
+  if (waterGradient && waterGradientContext === context) return waterGradient
+  waterGradient = context.createLinearGradient(0, 0, 0, STAGE_HEIGHT)
+  waterGradient.addColorStop(0, '#0d2b2a')
+  waterGradient.addColorStop(1, '#04100f')
+  waterGradientContext = context
+  return waterGradient
+}
+
 function render(context: CanvasRenderingContext2D) {
-  const water = context.createLinearGradient(0, 0, 0, STAGE_HEIGHT)
-  water.addColorStop(0, '#0d2b2a')
-  water.addColorStop(1, '#04100f')
-  context.fillStyle = water
+  context.fillStyle = getWaterGradient(context)
   context.fillRect(0, 0, STAGE_WIDTH, STAGE_HEIGHT)
 
   // Debris tints the water -- ambient only, no interaction wired here.
@@ -627,8 +641,14 @@ function onCanvasClick(event: MouseEvent) {
   const bounds = canvas.getBoundingClientRect()
   const x = ((event.clientX - bounds.left) / bounds.width) * STAGE_WIDTH
   const y = ((event.clientY - bounds.top) / bounds.height) * STAGE_HEIGHT
+  // The canvas is scaled by CSS to fit the host panel, so its display width
+  // can be well under STAGE_WIDTH on a phone -- a fixed canvas-space hit
+  // radius would then cover only a few real screen pixels. Grow the hit
+  // radius (never the drawn dot) so the actual tap target stays thumb-sized
+  // regardless of viewport width.
+  const hitRadius = touchHitRadius(MOTE_RADIUS + 8, STAGE_WIDTH, bounds.width)
   const index = motes.value.findIndex(
-    (mote) => Math.hypot(mote.x - x, mote.y - y) <= MOTE_RADIUS + 8,
+    (mote) => Math.hypot(mote.x - x, mote.y - y) <= hitRadius,
   )
   // Clicking a mote just dismisses it -- the coins it represents were
   // already credited by the tick settlement that spawned it.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:mana-attribution": "tsx utils/scripts/verifyManaAttribution.test.ts",
     "test:revenue-split": "tsx utils/scripts/verifyRevenueSplit.test.ts",
     "test:aquarium-economy": "tsx utils/scripts/verifyAquariumEconomy.test.ts",
+    "test:aquarium-touch": "tsx utils/scripts/verifyAquariumTouch.test.ts",
     "test:creator-earnings": "tsx utils/scripts/verifyCreatorEarnings.test.ts",
     "test:social-post-draft": "tsx utils/scripts/verifySocialPostDraft.test.ts",
     "test:mission-accrual": "tsx utils/scripts/verifyMissionAccrual.test.ts",

--- a/utils/aquariumTouch.ts
+++ b/utils/aquariumTouch.ts
@@ -1,0 +1,35 @@
+// /utils/aquariumTouch.ts
+//
+// Pure geometry helper for cthulhuquarium/t-020 (performance, responsive
+// layout, and the layout contract). The tank canvas renders at a fixed
+// logical resolution (STAGE_WIDTH x STAGE_HEIGHT) and is scaled to the host
+// panel's actual width by CSS -- on a phone that scale factor can be well
+// under 1, which silently shrinks every canvas-space hit target (motes,
+// eventually anything else clickable in the tank) to something well under a
+// thumb-sized tap target even though nothing about the drawn radius itself
+// changed. This function is the one place that math happens, so it can be
+// unit-tested without a canvas or a browser (see
+// utils/scripts/verifyAquariumTouch.test.ts).
+
+/**
+ * Given a base hit radius expressed in canvas/stage units, return a radius
+ * (still in stage units) that is at least large enough for the target to
+ * cover `minTouchPx` CSS pixels on screen once the canvas has been scaled
+ * from `stageWidth` down to `displayWidth`. Never shrinks the base radius --
+ * only ever grows it to compensate for a small display scale.
+ */
+export function touchHitRadius(
+  baseRadius: number,
+  stageWidth: number,
+  displayWidth: number,
+  minTouchPx = 44,
+): number {
+  if (!Number.isFinite(displayWidth) || displayWidth <= 0) return baseRadius
+  if (!Number.isFinite(stageWidth) || stageWidth <= 0) return baseRadius
+
+  const scale = displayWidth / stageWidth
+  if (scale <= 0) return baseRadius
+
+  const minRadiusForTouch = minTouchPx / 2 / scale
+  return Math.max(baseRadius, minRadiusForTouch)
+}

--- a/utils/scripts/verifyAquariumTouch.test.ts
+++ b/utils/scripts/verifyAquariumTouch.test.ts
@@ -1,0 +1,41 @@
+// /utils/scripts/verifyAquariumTouch.test.ts
+//
+// Regression test for cthulhuquarium/t-020's touch-hit-radius scaling
+// (utils/aquariumTouch.ts). No canvas, no DOM -- pure geometry, same
+// discipline as verifyAquariumEconomy.test.ts.
+import assert from 'node:assert/strict'
+
+import { touchHitRadius } from '../aquariumTouch.js'
+
+// --- at 1:1 scale, a target already >= the minimum is left alone ----------
+
+assert.equal(touchHitRadius(30, 640, 640), 30)
+
+// --- a small base radius grows to cover the minimum touch size ------------
+// Even at full stage width (no scaling down), a 17px hit radius (MOTE_RADIUS
+// + 8) is smaller than the 44px minimum touch diameter's 22px radius, so it
+// grows to 22.
+
+assert.equal(touchHitRadius(17, 640, 640), 22)
+
+// --- shrunk to a phone-width canvas, the same radius must grow ------------
+// display=320 against stage=640 is a 0.5 scale factor; a 44px touch target
+// needs a 22px CSS radius, which is 44 stage units at 0.5 scale.
+
+assert.equal(touchHitRadius(17, 640, 320), 44)
+
+// --- an even smaller phone (or a narrow embedded panel) scales further -----
+
+assert.equal(
+  Math.round(touchHitRadius(17, 640, 200) * 100) / 100,
+  Math.round((22 / (200 / 640)) * 100) / 100,
+)
+
+// --- degenerate inputs fall back to the base radius, never throw ----------
+
+assert.equal(touchHitRadius(17, 640, 0), 17)
+assert.equal(touchHitRadius(17, 640, -10), 17)
+assert.equal(touchHitRadius(17, 0, 320), 17)
+assert.equal(touchHitRadius(17, 640, Number.NaN), 17)
+
+console.log('verifyAquariumTouch: all assertions passed')


### PR DESCRIPTION
## Summary

Conductor `cthulhuquarium/t-020`: "Performance, responsive layout, and the layout contract" — make the tank hold up at phone/tablet/desktop widths, with canvas scaling, thumb-sized touch targets, no horizontal overflow, and a frame budget that survives a full tank on a mid-range phone.

- Bumped the **Feed hungriest**, per-fish **Feed**, and **Unlock** buttons to a real 44px touch target (`min-h-11`/`min-w-11`) while keeping their compact `btn-xs`/`btn-sm` visual size, since these are the game's most-repeated taps.
- Gave the tank `<canvas>` an explicit `aspect-[16/9]` class matching its 640×360 logical resolution instead of relying on implicit replaced-element aspect-ratio behavior.
- The canvas is CSS-scaled to the host panel's width, so a fixed hit radius on a drifting coin mote shrinks to a few real screen pixels on a narrow phone even though the drawn dot never changed size. Added `utils/aquariumTouch.ts`'s `touchHitRadius()` — a small pure function that grows the *hit* radius (never the drawn one) so a tap always covers at least 44 real CSS pixels regardless of viewport width, with a selftest (`verifyAquariumTouch.test.ts`, wired as `npm run test:aquarium-touch`).
- Cached the water gradient per canvas context instead of allocating a new `CanvasGradient` on every animation frame — a full tank redraws this 60×/sec.

## Verification

- `eslint` clean on all changed files
- `prettier --check` clean
- `vue-tsc` clean (`npm test`)
- `npm run test:layout-contract` — holds, 0 new violations (an unrelated pre-existing `video-lora-picker.vue` ratchet improvement shows in the output, untouched by this diff)
- `npm run test:aquarium-touch` (new) and `npm run test:aquarium-economy` both pass

No PR previews exist for this repo, so real-pixel verification (phone/tablet/desktop screenshots) comes from the `responsive-layout-audit` workflow against production after the next deploy, per the task's own note in `roadmap.yaml`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BqUctaVrquzQB7su2G4YaA)_