### PR TITLE
cthulhuquarium/t-024: bestiary completion view and codex

### DIFF
--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -186,6 +186,78 @@
           </p>
         </div>
       </div>
+
+      <!-- The bestiary (cthulhuquarium/t-024): the collection is the actual
+           progression spine now ("ENDLESS BUT THE BESTIARY COMPLETES"), so it
+           gets a view worth returning to rather than living only as a side
+           effect of the unlock panel above. Collapsed by default and loaded
+           on first open -- it's the completionist book, not part of the
+           tank's own poll loop. -->
+      <div class="flex flex-col gap-2 border-t border-base-300 pt-3">
+        <button
+          type="button"
+          class="flex items-center justify-between gap-2 text-left"
+          @click="onToggleBestiary"
+        >
+          <span class="text-xs font-black uppercase tracking-wide opacity-60">
+            Bestiary
+            <span v-if="tankStore.bestiaryTotalCount > 0" class="opacity-80">
+              — {{ tankStore.bestiaryCollectedCount }}/{{
+                tankStore.bestiaryTotalCount
+              }}
+              observed
+            </span>
+          </span>
+          <Icon
+            :name="
+              showBestiary ? 'kind-icon:chevron-up' : 'kind-icon:chevron-down'
+            "
+            class="size-4 shrink-0 opacity-60"
+          />
+        </button>
+
+        <template v-if="showBestiary">
+          <p v-if="tankStore.bestiaryLoading" class="text-xs opacity-60">
+            Reading the codex…
+          </p>
+          <div
+            v-else
+            class="grid grid-cols-[repeat(auto-fit,minmax(15rem,1fr))] gap-2"
+          >
+            <div
+              v-for="entry in tankStore.bestiary"
+              :key="entry.id"
+              class="flex items-start gap-2 rounded-xl border border-base-300 bg-base-100 p-3"
+              :class="{ 'opacity-60': !entry.collected }"
+            >
+              <kr-art-plate
+                :source="entry.collected ? entry : null"
+                variant="icon"
+                shape="plate"
+                frame="thin"
+                fit="cover"
+                class="size-12 shrink-0"
+                :placeholder-icon="
+                  entry.collected ? 'kind-icon:fish' : 'kind-icon:lock'
+                "
+              />
+              <div class="min-w-0 flex-1">
+                <p class="truncate text-sm font-bold">{{ entry.name }}</p>
+                <p class="mt-0.5 line-clamp-2 text-xs italic opacity-70">
+                  {{
+                    entry.collected
+                      ? entry.fieldNote || 'Nothing is written down yet.'
+                      : 'Not yet observed.'
+                  }}
+                </p>
+              </div>
+            </div>
+            <p v-if="!tankStore.bestiary.length" class="text-xs opacity-60">
+              Nothing in the bestiary yet.
+            </p>
+          </div>
+        </template>
+      </div>
     </div>
 
     <!-- The unlock reveal beat (cthulhuquarium/t-012): the field note is
@@ -239,6 +311,46 @@
         </div>
         <form method="dialog" class="modal-backdrop">
           <button type="button" @click="tankStore.dismissReveal()">
+            close
+          </button>
+        </form>
+      </dialog>
+    </Teleport>
+
+    <!-- The bestiary completion beat (cthulhuquarium/t-024): "the closest
+         thing this game has to an ending... but it must not end the session
+         or lock anything, because the tank keeps running." Dismissing this
+         does nothing but close the dialog -- the tank, coins, and stock are
+         all untouched. -->
+    <Teleport to="body">
+      <dialog
+        v-if="tankStore.bestiaryJustCompleted"
+        class="modal modal-open"
+        aria-modal="true"
+        @cancel.prevent="tankStore.dismissBestiaryCompletion()"
+      >
+        <div
+          class="modal-box flex max-w-sm flex-col items-center gap-3 rounded-3xl border border-base-300 bg-base-100 text-center shadow-2xl"
+        >
+          <Icon name="kind-icon:trophy" class="size-10 text-warning" />
+          <p class="text-xs font-black uppercase tracking-wide text-primary">
+            The bestiary is complete
+          </p>
+          <h3 class="text-lg font-black">Every species, observed.</h3>
+          <p class="text-sm opacity-80">
+            Nothing here resets and nothing leaves the collection -- the tank
+            keeps running exactly as it was. This is just the beat that says so.
+          </p>
+          <button
+            type="button"
+            class="btn btn-primary btn-sm mt-1"
+            @click="tankStore.dismissBestiaryCompletion()"
+          >
+            Back to the tank
+          </button>
+        </div>
+        <form method="dialog" class="modal-backdrop">
+          <button type="button" @click="tankStore.dismissBestiaryCompletion()">
             close
           </button>
         </form>
@@ -394,6 +506,7 @@ const canvasRef = ref<HTMLCanvasElement | null>(null)
 const swimmers = ref<Swimmer[]>([])
 const motes = ref<Mote[]>([])
 const feed = ref<FeedCreature[]>([])
+const showBestiary = ref(false)
 
 let frame = 0
 let lastFrameAt = 0
@@ -652,6 +765,15 @@ async function onFeed() {
 async function pollTick() {
   const earned = await tankStore.settleTick()
   if (earned > 0) spawnMotes(earned)
+}
+
+function onToggleBestiary() {
+  showBestiary.value = !showBestiary.value
+  // Loaded once on first open, not eagerly on mount -- see the store's own
+  // comment on why the codex isn't part of the tank's poll loop.
+  if (showBestiary.value && !tankStore.bestiary.length) {
+    void tankStore.loadBestiary()
+  }
 }
 
 onMounted(async () => {

--- a/server/api/aquarium/bestiary.get.ts
+++ b/server/api/aquarium/bestiary.get.ts
@@ -1,0 +1,40 @@
+// /server/api/aquarium/bestiary.get.ts
+//
+// The completionist codex (cthulhuquarium/t-024): every species in the
+// bestiary the authenticated user has ever collected stays listed and
+// collected forever, plus every currently-active species not yet found (shown
+// without art or field note -- see server/utils/aquarium.ts's
+// toBestiaryEntry). Includes the collected/total counts the bestiary panel's
+// completion badge reads directly, so the client never has to derive them
+// from the list itself.
+
+import { defineEventHandler } from 'h3'
+import { errorHandler } from '../../utils/error'
+import { requireApiUser } from '../../utils/authGuard'
+import { listBestiaryForUser } from '../../utils/aquarium'
+
+export default defineEventHandler(async (event) => {
+  let response
+
+  try {
+    const { user } = await requireApiUser(event)
+    const result = await listBestiaryForUser(user.id)
+
+    response = {
+      success: true,
+      data: result,
+      statusCode: 200,
+    }
+    event.node.res.statusCode = 200
+  } catch (error) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+    response = {
+      success: false,
+      message: handledError.message || 'Failed to load the bestiary.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+
+  return response
+})

--- a/server/utils/aquarium.ts
+++ b/server/utils/aquarium.ts
@@ -20,6 +20,7 @@ import {
   feedCost,
   FEED_RESTORES_HUNGER_TO,
   HUNGER_STARTING_VALUE,
+  justCompletedBestiary as computeJustCompletedBestiary,
   settleTick,
   unlockCost,
 } from './aquariumEconomy'
@@ -294,6 +295,159 @@ export async function feedFishForUser(
 }
 
 // ---------------------------------------------------------------------------
+// Bestiary -- the completionist codex (cthulhuquarium/t-024). AquariumCodexEntry
+// is the permanent "you found this" record: unlike AquariumStock (what's
+// CURRENTLY in the tank), a codex row is never deleted, so a species stays
+// collected even if the fish is later removed from the tank or the species
+// itself is retired from the bible (isActive: false) -- Silas's 2026-08-24
+// "nothing here may ever decrease" rule. The bestiary view's denominator is
+// therefore the UNION of the currently-active bible and every species this
+// user has ever collected, never the active set alone: retiring an
+// already-collected species must never shrink the count.
+// ---------------------------------------------------------------------------
+
+const BESTIARY_COMPLETE_EVENT_KIND = 'bestiary-complete'
+
+const bestiaryMonsterSelect = {
+  id: true,
+  name: true,
+  slug: true,
+  species: true,
+  // Selected at the DB level for every row (owned or not) -- stripped in
+  // toBestiaryEntry for anything not yet in the user's codex, same "server
+  // disposes, never sends the spoiler pre-unlock" discipline as
+  // catalogMonsterSelect (cthulhuquarium/t-012).
+  fieldNote: true,
+  size: true,
+  icon: true,
+  iconPath: true,
+  cardPath: true,
+  tier: true,
+  behavior: true,
+  hue: true,
+} satisfies Prisma.MonsterSelect
+
+type BestiaryMonster = Prisma.MonsterGetPayload<{
+  select: typeof bestiaryMonsterSelect
+}>
+
+export interface BestiaryEntry {
+  id: number
+  name: string
+  slug: string
+  species: string | null
+  size: number
+  icon: string | null
+  iconPath: string | null
+  cardPath: string | null
+  tier: string
+  behavior: string | null
+  hue: number | null
+  collected: boolean
+  firstAcquiredAt: string | null
+  fieldNote: string | null
+}
+
+export interface BestiaryResult {
+  data: BestiaryEntry[]
+  collectedCount: number
+  totalCount: number
+  completed: boolean
+}
+
+const cthulhuquariumBestiaryWhere = {
+  isPublic: true,
+  games: { contains: 'cthulhuquarium' },
+} satisfies Prisma.MonsterWhereInput
+
+function bestiaryUnionWhere(collectedIds: number[]): Prisma.MonsterWhereInput {
+  return {
+    OR: [
+      { ...cthulhuquariumBestiaryWhere, isActive: true },
+      // No monster has a negative id -- this arm simply drops out of the OR
+      // when nothing has been collected yet, rather than needing a second
+      // query shape for that case.
+      { id: { in: collectedIds.length > 0 ? collectedIds : [-1] } },
+    ],
+  }
+}
+
+function toBestiaryEntry(
+  monster: BestiaryMonster,
+  firstAcquiredAt: Date | null,
+): BestiaryEntry {
+  const collected = firstAcquiredAt !== null
+  return {
+    id: monster.id,
+    name: monster.name,
+    slug: monster.slug,
+    species: monster.species,
+    size: monster.size,
+    icon: monster.icon,
+    iconPath: monster.iconPath,
+    cardPath: monster.cardPath,
+    tier: monster.tier,
+    behavior: monster.behavior,
+    hue: monster.hue,
+    collected,
+    firstAcquiredAt: firstAcquiredAt ? firstAcquiredAt.toISOString() : null,
+    fieldNote: collected ? monster.fieldNote : null,
+  }
+}
+
+export async function listBestiaryForUser(
+  userId: number,
+): Promise<BestiaryResult> {
+  const codexEntries = await prisma.aquariumCodexEntry.findMany({
+    where: { userId },
+    select: { monsterId: true, firstAcquiredAt: true },
+  })
+  const collectedAt = new Map(
+    codexEntries.map((entry) => [entry.monsterId, entry.firstAcquiredAt]),
+  )
+
+  const monsters = await prisma.monster.findMany({
+    where: bestiaryUnionWhere([...collectedAt.keys()]),
+    select: bestiaryMonsterSelect,
+    orderBy: [{ name: 'asc' }],
+  })
+
+  const data = monsters.map((monster) =>
+    toBestiaryEntry(monster, collectedAt.get(monster.id) ?? null),
+  )
+  const totalCount = data.length
+  const collectedCount = data.filter((entry) => entry.collected).length
+
+  return {
+    data,
+    collectedCount,
+    totalCount,
+    completed: totalCount > 0 && collectedCount >= totalCount,
+  }
+}
+
+// Counts-only version of the same union rule, for use inside
+// purchaseSpeciesForUser's transaction to detect a first-time full
+// completion without pulling the whole display payload.
+async function countBestiaryTotals(
+  tx: TransactionClient,
+  userId: number,
+): Promise<{ totalCount: number; collectedCount: number }> {
+  const collectedIds = (
+    await tx.aquariumCodexEntry.findMany({
+      where: { userId },
+      select: { monsterId: true },
+    })
+  ).map((row) => row.monsterId)
+
+  const totalCount = await tx.monster.count({
+    where: bestiaryUnionWhere(collectedIds),
+  })
+
+  return { totalCount, collectedCount: collectedIds.length }
+}
+
+// ---------------------------------------------------------------------------
 // Purchase -- species unlock only. See PR description for why `food` and
 // `upgrade` purchase types (named in the task note) are intentionally not
 // implemented: economy.yaml bundles buying+consuming food into a single
@@ -305,6 +459,12 @@ export interface PurchaseSpeciesResult {
   aquarium: OwnedAquarium
   stock: OwnedAquarium['Stock'][number]
   cost: number
+  // True exactly once -- the settlement that brings collectedCount to
+  // totalCount for the first time (cthulhuquarium/t-024's "a real beat when
+  // the set closes"). Never true again afterward, even though completion
+  // itself is never revoked -- see BESTIARY_COMPLETE_EVENT_KIND's guard in
+  // the transaction below.
+  justCompletedBestiary: boolean
 }
 
 export async function purchaseSpeciesForUser(
@@ -355,33 +515,83 @@ export async function purchaseSpeciesForUser(
     )
   }
 
-  const { aquarium, stock } = await prisma.$transaction(async (tx) => {
-    const createdStock = await tx.aquariumStock.create({
-      data: {
-        aquariumId: tank.id,
+  const { aquarium, stock, justCompletedBestiary } = await prisma.$transaction(
+    async (tx) => {
+      const { totalCount, collectedCount: collectedCountBefore } =
+        await countBestiaryTotals(tx, userId)
+
+      const createdStock = await tx.aquariumStock.create({
+        data: {
+          aquariumId: tank.id,
+          monsterId: monster.id,
+          hunger: HUNGER_STARTING_VALUE,
+        },
+        select: ownedStockSelect,
+      })
+
+      const updatedAquarium = await tx.aquarium.update({
+        where: { id: tank.id },
+        data: { coins: { decrement: cost } },
+        select: ownedAquariumSelect,
+      })
+
+      // The permanent codex record -- upsert rather than create, so that if
+      // a future feature ever lets a species leave the tank and be rebought,
+      // firstAcquiredAt keeps the ORIGINAL discovery date (t-024's "cannot
+      // be un-collected" applies to the record, not just the count) instead
+      // of a unique-constraint error. Today `alreadyOwned` above already
+      // guarantees this monster has no codex row yet -- there is no
+      // release/sell path -- so this always takes the `create` branch, but
+      // upsert keeps that an invariant of the data rather than of this one
+      // call site.
+      const existingEntry = await tx.aquariumCodexEntry.findUnique({
+        where: { userId_monsterId: { userId, monsterId: monster.id } },
+        select: { id: true },
+      })
+      await tx.aquariumCodexEntry.upsert({
+        where: { userId_monsterId: { userId, monsterId: monster.id } },
+        create: { userId, monsterId: monster.id },
+        update: {},
+      })
+      const collectedCountAfter = collectedCountBefore + (existingEntry ? 0 : 1)
+
+      let justCompletedBestiary = false
+      if (
+        computeJustCompletedBestiary(
+          totalCount,
+          collectedCountBefore,
+          collectedCountAfter,
+        )
+      ) {
+        const alreadyCelebrated = await tx.aquariumEvent.findFirst({
+          where: { aquariumId: tank.id, kind: BESTIARY_COMPLETE_EVENT_KIND },
+          select: { id: true },
+        })
+        if (!alreadyCelebrated) {
+          justCompletedBestiary = true
+          await logEvent(tx, tank.id, BESTIARY_COMPLETE_EVENT_KIND, {
+            collectedCount: collectedCountAfter,
+            totalCount,
+          })
+        }
+      }
+
+      await logEvent(tx, tank.id, 'purchase', {
+        type: 'species',
         monsterId: monster.id,
-        hunger: HUNGER_STARTING_VALUE,
-      },
-      select: ownedStockSelect,
-    })
+        aquariumStockId: createdStock.id,
+        cost,
+      })
 
-    const updatedAquarium = await tx.aquarium.update({
-      where: { id: tank.id },
-      data: { coins: { decrement: cost } },
-      select: ownedAquariumSelect,
-    })
+      return {
+        aquarium: updatedAquarium,
+        stock: createdStock,
+        justCompletedBestiary,
+      }
+    },
+  )
 
-    await logEvent(tx, tank.id, 'purchase', {
-      type: 'species',
-      monsterId: monster.id,
-      aquariumStockId: createdStock.id,
-      cost,
-    })
-
-    return { aquarium: updatedAquarium, stock: createdStock }
-  })
-
-  return { aquarium, stock, cost }
+  return { aquarium, stock, cost, justCompletedBestiary }
 }
 
 // ---------------------------------------------------------------------------

--- a/server/utils/aquariumEconomy.ts
+++ b/server/utils/aquariumEconomy.ts
@@ -311,3 +311,30 @@ export function settleTick(input: TickSettlementInput): TickSettlementResult {
     newLastTickAt: input.now,
   }
 }
+
+// ---------------------------------------------------------------------------
+// Bestiary completion (cthulhuquarium/t-024) -- pure decision logic only.
+// Loading/persisting the actual codex rows is server/utils/aquarium.ts's
+// job (AquariumCodexEntry, prisma); this stays a plain arithmetic check so
+// it can be unit-tested the same way as the rest of this file.
+//
+// Silas's 2026-08-24 decision this task follows: the game is ENDLESS BUT
+// THE BESTIARY COMPLETES, and "nothing here may ever decrease" -- a species
+// cannot be un-collected and completion cannot be reset. That invariant is
+// enforced by the CALLER's counting rule (collectedCount comes from
+// AquariumCodexEntry rows, which are never deleted, and totalCount is the
+// union of currently-active bestiary species and every species the user has
+// ever collected -- so retiring an already-collected species can never
+// shrink the denominator below what was already counted), not by anything
+// here. This function only decides whether a count transition crosses the
+// completion line for the first time.
+export function justCompletedBestiary(
+  totalCount: number,
+  collectedCountBefore: number,
+  collectedCountAfter: number,
+): boolean {
+  if (totalCount <= 0) return false
+  const wasComplete = collectedCountBefore >= totalCount
+  const isComplete = collectedCountAfter >= totalCount
+  return !wasComplete && isComplete
+}

--- a/stores/cthulhuquariumTankStore.ts
+++ b/stores/cthulhuquariumTankStore.ts
@@ -101,6 +101,36 @@ interface PurchaseResponse {
   aquarium: Tank
   stock: TankStock
   cost: number
+  justCompletedBestiary: boolean
+}
+
+// The completionist codex (cthulhuquarium/t-024). A collected entry carries
+// full art and its fieldNote; an uncollected one is only ever known by name
+// and shows as a silhouette in the panel -- the server never sends its
+// fieldNote or art paths (same "the server disposes" discipline as
+// CatalogEntry above).
+export interface BestiaryEntry {
+  id: number
+  name: string
+  slug: string
+  species: string | null
+  size: number
+  icon: string | null
+  iconPath: string | null
+  cardPath: string | null
+  tier: string
+  behavior: string | null
+  hue: number | null
+  collected: boolean
+  firstAcquiredAt: string | null
+  fieldNote: string | null
+}
+
+interface BestiaryResponse {
+  data: BestiaryEntry[]
+  collectedCount: number
+  totalCount: number
+  completed: boolean
 }
 
 // How often the mounted game component re-settles the tick while the tab is
@@ -124,6 +154,21 @@ export const useCthulhuquariumTankStore = defineStore(
     // "give it a real beat" call). The game component watches this to show
     // a reveal, then clears it via dismissReveal().
     const revealedUnlock = ref<TankStock | null>(null)
+
+    // cthulhuquarium/t-024's bestiary. Loaded lazily (the panel starts
+    // collapsed) rather than alongside load()/loadCatalog() on every mount --
+    // it is the completionist book, not something the tank loop needs every
+    // poll.
+    const bestiary = ref<BestiaryEntry[]>([])
+    const bestiaryCollectedCount = ref(0)
+    const bestiaryTotalCount = ref(0)
+    const bestiaryLoading = ref(false)
+    // Set once, the moment a purchase's response says this unlock closed the
+    // set -- the game component watches it for the one-time completion beat,
+    // then clears it via dismissBestiaryCompletion(). Never re-derived from
+    // bestiaryCollectedCount/bestiaryTotalCount, so simply reloading the
+    // bestiary later can't retrigger it.
+    const bestiaryJustCompleted = ref(false)
 
     const stock = computed(() => tank.value?.Stock ?? [])
     const coins = computed(() => tank.value?.coins ?? 0)
@@ -208,6 +253,10 @@ export const useCthulhuquariumTankStore = defineStore(
         tank.value = res.data.aquarium
         catalog.value = catalog.value.filter((entry) => entry.id !== monsterId)
         revealedUnlock.value = res.data.stock
+        if (res.data.justCompletedBestiary) bestiaryJustCompleted.value = true
+        // A stale bestiary panel (or one never loaded yet) would otherwise
+        // still show this species as uncollected after unlocking it.
+        if (bestiary.value.length > 0) await loadBestiary()
         return true
       }
       error.value = res.message || 'Could not unlock that species.'
@@ -216,6 +265,26 @@ export const useCthulhuquariumTankStore = defineStore(
 
     function dismissReveal(): void {
       revealedUnlock.value = null
+    }
+
+    async function loadBestiary(): Promise<void> {
+      bestiaryLoading.value = true
+      try {
+        const res = await performFetch<BestiaryResponse>(
+          '/api/aquarium/bestiary',
+        )
+        if (res.success && res.data) {
+          bestiary.value = res.data.data
+          bestiaryCollectedCount.value = res.data.collectedCount
+          bestiaryTotalCount.value = res.data.totalCount
+        }
+      } finally {
+        bestiaryLoading.value = false
+      }
+    }
+
+    function dismissBestiaryCompletion(): void {
+      bestiaryJustCompleted.value = false
     }
 
     function clearOfflineEarnings(): void {
@@ -236,6 +305,11 @@ export const useCthulhuquariumTankStore = defineStore(
       error,
       ready,
       revealedUnlock,
+      bestiary,
+      bestiaryCollectedCount,
+      bestiaryTotalCount,
+      bestiaryLoading,
+      bestiaryJustCompleted,
       load,
       settleTick,
       loadCatalog,
@@ -243,6 +317,8 @@ export const useCthulhuquariumTankStore = defineStore(
       unlock,
       dismissReveal,
       clearOfflineEarnings,
+      loadBestiary,
+      dismissBestiaryCompletion,
     }
   },
 )

--- a/utils/scripts/verifyAquariumEconomy.test.ts
+++ b/utils/scripts/verifyAquariumEconomy.test.ts
@@ -22,6 +22,7 @@ import {
   feedCost,
   hungerMultiplier,
   incomePerTick,
+  justCompletedBestiary,
   settleTick,
   unlockCost,
 } from '../../server/utils/aquariumEconomy.js'
@@ -432,6 +433,25 @@ for (let i = 0; i < ITERATIONS; i++) {
 
 console.log(
   `✅ settleTick property test: coinsEarned/debris/hunger invariants held across ${ITERATIONS} random scenarios`,
+)
+
+// --- justCompletedBestiary: cthulhuquarium/t-024's completion-beat gate ----
+
+// Crossing the line for the first time fires.
+assert.equal(justCompletedBestiary(10, 9, 10), true)
+// Already complete before this call -- must not fire again.
+assert.equal(justCompletedBestiary(10, 10, 10), false)
+// Still short of the total -- no beat.
+assert.equal(justCompletedBestiary(10, 5, 6), false)
+// An empty bestiary (no species seeded yet) never reads as "complete".
+assert.equal(justCompletedBestiary(0, 0, 0), false)
+// Overshooting totalCount (e.g. a race with a retired species changing the
+// denominator) still only fires once, on the crossing itself.
+assert.equal(justCompletedBestiary(5, 4, 6), true)
+assert.equal(justCompletedBestiary(5, 6, 7), false)
+
+console.log(
+  '✅ justCompletedBestiary: fires exactly once, on the crossing, never before or after',
 )
 
 console.log('✅ verifyAquariumEconomy: all assertions passed')


### PR DESCRIPTION
## Summary

Conductor `cthulhuquarium/t-024`: Silas's 2026-08-24 decision that the game is ENDLESS BUT THE BESTIARY COMPLETES -- no ending screen, no prestige reset, the last species is the credits roll. That makes the collection the actual progression spine, but nothing in the build tracked it that way: `AquariumStock` is only ever CURRENT tank contents, and `AquariumCodexEntry` (the model built for exactly this) was never read or written anywhere.

- `purchaseSpeciesForUser` now upserts a permanent `AquariumCodexEntry` on every species unlock -- a codex row is never deleted, so a species stays collected even if it's later removed from the tank or the species itself is retired from the bible (`isActive: false`). The bestiary's denominator is the union of the currently-active bible and every species ever collected, so retiring an already-collected species can never shrink the count ("nothing here may ever decrease").
- New `GET /api/aquarium/bestiary` (`listBestiaryForUser`) returns every species in that union, plus collected/total counts. An uncollected entry never carries its `fieldNote` or art paths -- same "the server disposes, never sends the spoiler pre-unlock" discipline t-012 set for the unlock catalog.
- New pure `justCompletedBestiary(totalCount, before, after)` in `aquariumEconomy.ts` decides the one-time completion beat: fires exactly once, on the settlement that first brings `collectedCount` to `totalCount`, guarded against a duplicate `AquariumEvent` so it can never refire on a later reload or purchase.
- Client: a collapsible Bestiary panel in `cthulhuquarium-game.vue` (collected species show art + field note, uncollected show a `kind-icon:lock` silhouette and "Not yet observed"), loaded lazily on first open, plus a dismissible one-time completion dialog. Dismissing it does nothing but close the dialog -- the tank keeps running, exactly as the task note requires ("it must not end the session or lock anything").

## Verification

- `eslint`/`prettier --check` clean on all changed files
- `vue-tsc` clean (`npm test`), full repo
- `npm run test:layout-contract` holds, 0 new violations
- `npm run test:aquarium-economy` passes, extended with `justCompletedBestiary` coverage (crosses once, never before/after, empty bestiary never reads complete, overshoot still fires once)

No PR previews exist for this repo, so real-pixel verification of the new panel comes from the `responsive-layout-audit` workflow against production after the next deploy, same as other cthulhuquarium UI tasks.

Ref: conductor `cthulhuquarium/t-024`


---
_Generated by [Claude Code](https://claude.ai/code/session_019t2F3qEbzYwa7yyen1YhfT)_