### PR TITLE
cthulhuquarium/t-027: manual click-to-clean debris

### DIFF
--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -72,6 +72,38 @@
         </button>
       </div>
 
+      <!-- Debris and cleaning (cthulhuquarium/t-027): the active-play
+           channel. Debris only ever throttles the production RATE, never
+           holdings, so clicking Clean can never lose anything -- it just
+           speeds the tank back up. Manual clicking is one of three
+           deliberately co-viable routes (the debris set and The Sexton are
+           the other two, both still unbuilt); this is only the first. -->
+      <div class="flex items-center gap-2">
+        <Icon name="kind-icon:sparkles" class="size-4 shrink-0 opacity-60" />
+        <div
+          class="h-1.5 flex-1 overflow-hidden rounded-full bg-base-300"
+          role="meter"
+          :aria-valuenow="tankStore.debrisLevel"
+          aria-valuemin="0"
+          aria-valuemax="100"
+          aria-label="Tank debris"
+        >
+          <div
+            class="h-full rounded-full bg-warning/70 transition-all"
+            :class="{ 'bg-error/70': tankStore.debrisLevel >= 80 }"
+            :style="{ width: `${tankStore.debrisLevel}%` }"
+          />
+        </div>
+        <button
+          type="button"
+          class="btn btn-outline btn-xs min-h-11 min-w-11"
+          :disabled="tankStore.debrisLevel <= 0"
+          @click="tankStore.clean()"
+        >
+          Clean
+        </button>
+      </div>
+
       <canvas
         ref="canvasRef"
         class="aspect-[16/9] w-full cursor-pointer rounded-2xl border border-base-300 bg-base-300"

--- a/server/api/aquarium/clean.post.ts
+++ b/server/api/aquarium/clean.post.ts
@@ -1,0 +1,38 @@
+// /server/api/aquarium/clean.post.ts
+//
+// Manually clears debris from the authenticated user's tank -- the active-
+// play channel cthulhuquarium/t-027 builds: -5 debris per click, instant,
+// free, no cooldown (data/economy.yaml's debris.clean.click_clears).
+//
+// No body -- there is nothing to parse; every click clears the same amount.
+
+import { defineEventHandler } from 'h3'
+import { errorHandler } from '../../utils/error'
+import { requireApiUser } from '../../utils/authGuard'
+import { cleanTankForUser } from '../../utils/aquarium'
+
+export default defineEventHandler(async (event) => {
+  let response
+
+  try {
+    const { user } = await requireApiUser(event)
+    const result = await cleanTankForUser(user.id, user.username)
+
+    response = {
+      success: true,
+      data: result,
+      statusCode: 200,
+    }
+    event.node.res.statusCode = 200
+  } catch (error) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+    response = {
+      success: false,
+      message: handledError.message || 'Failed to clean the tank.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+
+  return response
+})

--- a/server/utils/aquarium.ts
+++ b/server/utils/aquarium.ts
@@ -16,6 +16,7 @@ import type { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from './prisma'
 import { getUniqueAquariumSlugForUser } from './aquariumSlug'
 import {
+  cleanDebris,
   deriveFishRarityTier,
   feedCost,
   FEED_RESTORES_HUNGER_TO,
@@ -291,6 +292,50 @@ export async function feedFishForUser(
     cost,
     hunger: FEED_RESTORES_HUNGER_TO,
   }
+}
+
+// ---------------------------------------------------------------------------
+// Clean -- the manual-click active-play channel (cthulhuquarium/t-027).
+// Instant, free, no cooldown: debris only ever throttles the production
+// RATE (see aquariumEconomy.ts's own header comment on that section), so
+// there is nothing here to gate -- clicking can never lose progress, only
+// speed it back up. Idempotent at debrisLevel 0 rather than erroring, so a
+// client racing its own disabled-button state never has to handle a 4xx.
+// ---------------------------------------------------------------------------
+
+export interface CleanResult {
+  aquarium: OwnedAquarium
+  debrisLevel: number
+}
+
+export async function cleanTankForUser(
+  userId: number,
+  username: string,
+): Promise<CleanResult> {
+  const tank = await getOrCreateTankForUser(userId, username)
+  const newDebrisLevel = cleanDebris(tank.debrisLevel)
+
+  if (newDebrisLevel === tank.debrisLevel) {
+    return { aquarium: tank, debrisLevel: tank.debrisLevel }
+  }
+
+  const aquarium = await prisma.$transaction(async (tx) => {
+    const now = new Date()
+    const updated = await tx.aquarium.update({
+      where: { id: tank.id },
+      data: { debrisLevel: newDebrisLevel, lastCleanedAt: now },
+      select: ownedAquariumSelect,
+    })
+
+    await logEvent(tx, tank.id, 'clean', {
+      previousDebrisLevel: tank.debrisLevel,
+      newDebrisLevel,
+    })
+
+    return updated
+  })
+
+  return { aquarium, debrisLevel: newDebrisLevel }
 }
 
 // ---------------------------------------------------------------------------

--- a/server/utils/aquariumEconomy.ts
+++ b/server/utils/aquariumEconomy.ts
@@ -170,11 +170,23 @@ export function debrisMultiplier(debrisLevel: number): number {
   return 1.0
 }
 
-// Manual/set-piece/Sexton cleaning (economy.yaml `debris.clean`) has no
-// endpoint in this task's scope -- t-009's endpoint list is tank/tick/feed/
-// purchase/browse only; a manual "clean" action, if ever added, is a
-// natural follow-up but was not requested here and AquariumSet/Sexton-style
-// fish placement are both explicitly out of scope per the task note.
+// Manual clicking -- economy.yaml `debris.clean.click_clears` -- is the
+// active-play channel cthulhuquarium/t-027 builds: instant, no coin cost, no
+// cooldown. Debris only ever throttles the production RATE, never holdings
+// (see this section's header comment), so clearing it can never lose
+// anything -- only speed production back up. The other two routes named in
+// economy.yaml (`debris_set_clears_per_tick` for the t-026 set piece,
+// `sexton_clears_per_tick` for the still-unbuilt functional Sexton fish) are
+// deliberately NOT implemented here -- both are passive, per-tick income-loop
+// mechanics that belong to their own tasks (t-026 is still `waiting`), not
+// this one's manual-click scope. SYSTEMS.md's own rule is to keep all three
+// routes co-viable rather than let one dominate; building only the manual
+// route now does not foreclose the other two.
+export const DEBRIS_CLICK_CLEARS = 5
+
+export function cleanDebris(debrisLevel: number): number {
+  return Math.max(DEBRIS_RANGE.min, debrisLevel - DEBRIS_CLICK_CLEARS)
+}
 
 // ---------------------------------------------------------------------------
 // Offline income -- economy.yaml `offline_income`

--- a/stores/cthulhuquariumTankStore.ts
+++ b/stores/cthulhuquariumTankStore.ts
@@ -97,6 +97,11 @@ interface FeedResponse {
   hunger: number
 }
 
+interface CleanResponse {
+  aquarium: Tank
+  debrisLevel: number
+}
+
 interface PurchaseResponse {
   aquarium: Tank
   stock: TankStock
@@ -131,6 +136,7 @@ export const useCthulhuquariumTankStore = defineStore(
       stock.value.reduce((sum, entry) => sum + (entry.Monster.size ?? 1), 0),
     )
     const sizeCap = computed(() => tank.value?.sizeCap ?? 0)
+    const debrisLevel = computed(() => tank.value?.debrisLevel ?? 0)
     const hungriest = computed<TankStock | null>(() =>
       stock.value.reduce<TankStock | null>(
         (worst, entry) =>
@@ -218,6 +224,22 @@ export const useCthulhuquariumTankStore = defineStore(
       revealedUnlock.value = null
     }
 
+    // The active-play channel (cthulhuquarium/t-027): -5 debris per click,
+    // instant, free, no cooldown. Debris only ever throttles the tank's
+    // production RATE, never holdings, so there is nothing to lose by
+    // spamming this -- the button just disables itself at debrisLevel 0.
+    async function clean(): Promise<boolean> {
+      const res = await performFetch<CleanResponse>('/api/aquarium/clean', {
+        method: 'POST',
+      })
+      if (res.success && res.data) {
+        tank.value = res.data.aquarium
+        return true
+      }
+      error.value = res.message || 'Could not clean the tank.'
+      return false
+    }
+
     function clearOfflineEarnings(): void {
       offlineEarnings.value = 0
     }
@@ -229,6 +251,7 @@ export const useCthulhuquariumTankStore = defineStore(
       coins,
       occupantSize,
       sizeCap,
+      debrisLevel,
       hungriest,
       offlineEarnings,
       loading,
@@ -242,6 +265,7 @@ export const useCthulhuquariumTankStore = defineStore(
       feed,
       unlock,
       dismissReveal,
+      clean,
       clearOfflineEarnings,
     }
   },

--- a/utils/scripts/verifyAquariumEconomy.test.ts
+++ b/utils/scripts/verifyAquariumEconomy.test.ts
@@ -12,11 +12,13 @@
 import assert from 'node:assert/strict'
 
 import {
+  DEBRIS_CLICK_CLEARS,
   DEBRIS_RANGE,
   MAX_ACCRUAL_TICKS,
   OFFLINE_INCOME_RATE_MULTIPLIER,
   RARITY_TIERS,
   TICK_SECONDS,
+  cleanDebris,
   debrisMultiplier,
   deriveFishRarityTier,
   feedCost,
@@ -432,6 +434,26 @@ for (let i = 0; i < ITERATIONS; i++) {
 
 console.log(
   `✅ settleTick property test: coinsEarned/debris/hunger invariants held across ${ITERATIONS} random scenarios`,
+)
+
+// --- cleanDebris: the manual-click active-play channel (t-027) ------------
+
+assert.equal(DEBRIS_CLICK_CLEARS, 5)
+assert.equal(cleanDebris(100), 95)
+assert.equal(cleanDebris(5), 0, 'clears exactly to zero, not negative')
+assert.equal(
+  cleanDebris(3),
+  0,
+  'never goes below DEBRIS_RANGE.min even from a partial click',
+)
+assert.equal(cleanDebris(0), 0, 'idempotent at zero')
+assert.ok(
+  cleanDebris(50) >= DEBRIS_RANGE.min,
+  'result always stays within DEBRIS_RANGE',
+)
+
+console.log(
+  '✅ cleanDebris: clears exactly DEBRIS_CLICK_CLEARS per click, floors at DEBRIS_RANGE.min',
 )
 
 console.log('✅ verifyAquariumEconomy: all assertions passed')


### PR DESCRIPTION
## Summary

Conductor `cthulhuquarium/t-027`. Silas, 2026-08-24: "cleaning a fish tank is a reasonable task for users for a clicking game." Debris already existed (accrual, tick-throttling, `schema.prisma`'s own `lastCleanedAt` column marked "t-027 dependency"), but nothing could ever clear it -- the rate only ever climbed. This builds the manual-click route named in the task's own note; the debris set (t-026, still `waiting`) and The Sexton (a still-unbuilt functional fish) are the other two, deliberately left for their own tasks per SYSTEMS.md's "keep all three viable, none dominant" rule.

- New pure `cleanDebris(debrisLevel)` in `aquariumEconomy.ts`: -5 per click (economy.yaml's `debris.clean.click_clears`), floored at `DEBRIS_RANGE.min`. Debris only ever throttles the production RATE, never holdings, so a click can never lose anything -- only speed production back up.
- New `POST /api/aquarium/clean` (`cleanTankForUser`): instant, free, no cooldown, idempotent at `debrisLevel` 0 rather than erroring so a client racing its own disabled-button state never hits a 4xx. Sets `lastCleanedAt` on an actual change.
- Client: a debris meter + Clean button in `cthulhuquarium-game.vue`, same 44px touch target as the other repeated-tap buttons (t-020).

## Verification

- `eslint`/`prettier --check` clean on all changed files
- `vue-tsc` clean (`npm test`), full repo
- `npm run test:layout-contract` holds, 0 new violations
- `npm run test:aquarium-economy` passes, extended with `cleanDebris` coverage (clears exactly 5, floors at 0, idempotent, stays in range)

Ref: conductor `cthulhuquarium/t-027`


---
_Generated by [Claude Code](https://claude.ai/code/session_019t2F3qEbzYwa7yyen1YhfT)_