### PR TITLE
Keep legacy Daily Dreams from collapsing into one world

### DIFF
--- a/server/utils/dailyDreamCreativeDiversity.ts
+++ b/server/utils/dailyDreamCreativeDiversity.ts
@@ -1,0 +1,128 @@
+import type { DailyDreamBlueprint } from './dailyDreamFacetBlueprint'
+
+// The legacy Facet-engine endpoint still exists beside the canonical Conductor
+// Daily Dream pipeline. Keep it from collapsing every Facet combination into the
+// same pitch skeleton and generic cinematic illustration language.
+const STORY_ENGINES = [
+  'KINETIC',
+  'DISCOVERY',
+  'RELATIONSHIP',
+  'CAPER',
+  'SURVIVAL',
+  'MYTHIC',
+  'COMPETITION',
+  'JOURNEY',
+] as const
+
+const VISUAL_MEDIA = [
+  'bold four-color superhero-comic rendering with muscular ink contours, saturated cel color, halftone texture, and dramatic foreshortening',
+  'charcoal-and-chalk cosmic-horror drawing on rough paper, crushed blacks, pale luminous accents, smeared edges, and unsettling changes of scale',
+  'luminous gouache storybook painting with matte pigment, simplified confident shapes, layered brush texture, and soft edge variation',
+  'tactile stop-motion miniature aesthetic with sculpted clay and felt surfaces, handmade imperfections, practical miniature lighting, and shallow depth of field',
+  'high-contrast risograph aesthetic with limited spot-color layers, coarse paper grain, slight registration offsets, and bold graphic silhouettes',
+  'low-poly 3D diorama with faceted geometry, toy-scale materials, crisp ambient occlusion, clean volumetric lighting, and deliberately simplified forms',
+  'cinematic photorealism with natural lens behavior, physically believable materials, volumetric atmosphere, restrained color grading, and fine environmental detail',
+  'stained-glass mosaic aesthetic with strong leaded contours, jewel-tone translucent panes, fractured colored light, and geometric shape language',
+  'watercolor-and-ink naturalist illustration with transparent washes, dry-brush texture, expressive line variation, visible paper tooth, and selective fine detail',
+  'layered paper-cut collage with visible paper fibers, simplified cut shapes, physical layer shadows, tactile depth, and hand-cut irregular edges',
+] as const
+
+function hashSeed(input: string): number {
+  let hash = 2166136261
+  for (let index = 0; index < input.length; index++) {
+    hash ^= input.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return hash >>> 0
+}
+
+function facetValue(
+  blueprint: DailyDreamBlueprint,
+  taxonomy: string,
+): string {
+  const facet = blueprint.facets.find((entry) => entry.taxonomy === taxonomy)
+  return String(facet?.value || facet?.title || '').trim()
+}
+
+function storyPitch(
+  blueprint: DailyDreamBlueprint,
+  engine: (typeof STORY_ENGINES)[number],
+): string {
+  const hero = blueprint.characters[0]?.name || 'a stranger'
+  const foil = blueprint.characters[1]?.name || 'someone who wants the opposite'
+  const reward = blueprint.rewards[0]?.name || 'an impossible gift'
+  const secondReward = blueprint.rewards[1]?.name || 'a second impossible tool'
+  const firstPlace = blueprint.locations[0]?.name || 'a place that should not exist'
+  const secondPlace = blueprint.locations[1]?.name || firstPlace
+  const theme = facetValue(blueprint, 'THEME') || 'the world’s central rule'
+  const genre = facetValue(blueprint, 'GENRE')
+  const genreClause = genre ? ` In this ${genre} world,` : ''
+
+  switch (engine) {
+    case 'KINETIC':
+      return `${hero} has one narrowing chance to carry ${reward} through ${firstPlace} while the place changes around them. ${foil} can clear the way, seize the reward, or force the crisis into ${secondPlace}.${genreClause} ${theme} becomes pressure that demands action rather than explanation.`
+    case 'DISCOVERY':
+      return `${hero} discovers ${reward} at ${firstPlace} and tests what it can actually do. Each use exposes a new physical rule of the world, while ${foil} follows a conflicting explanation toward ${secondPlace}.${genreClause} the mystery of ${theme} is learned by encounter, not by paperwork.`
+    case 'RELATIONSHIP':
+      return `${hero} and ${foil} need ${reward} for incompatible reasons, and neither can reach ${secondPlace} alone. Their bargain changes as ${secondReward} makes the cost of ${theme} personal.${genreClause} the central turn is a choice about another person, not an institution.`
+    case 'CAPER':
+      return `${hero} plans an audacious theft of ${reward} from ${firstPlace}; ${foil} is the indispensable part of the plan who may also ruin it. The escape route through ${secondPlace} depends on using ${secondReward} at exactly the wrong-looking moment.${genreClause} ${theme} drives the trick and its reversal.`
+    case 'SURVIVAL':
+      return `${firstPlace} becomes dangerous in stages, forcing ${hero} and ${foil} toward ${secondPlace}. ${reward} can get one of them through the worst passage, while ${secondReward} changes who counts as safe.${genreClause} ${theme} is embodied in terrain, bodies, weather, hunger, pursuit, or transformation.`
+    case 'MYTHIC':
+      return `${reward} awakens at ${firstPlace} and reveals that ${theme} operates at a scale nobody expected. ${hero} must choose whether to use it, destroy it, or carry it to ${secondPlace} before ${foil} makes the choice for them.${genreClause} awe, dread, or impossible scale should be visible in the consequences.`
+    case 'COMPETITION':
+      return `${firstPlace} hosts a contest whose prize is ${reward}, and ${hero} enters for a reason that clashes with ${foil}. The rules mutate when ${secondReward} appears, turning the final round toward ${secondPlace}.${genreClause} ${theme} shapes the game, rivalry, and reversal.`
+    case 'JOURNEY':
+      return `${hero} must cross from ${firstPlace} to ${secondPlace} carrying ${reward}, with ${foil} joining for a different destination. Each leg reveals a different consequence of ${theme}, and ${secondReward} can bypass one obstacle only by creating another.${genreClause} movement through distinct terrain is the story engine.`
+  }
+}
+
+function withVisualDirection(prompt: string, direction: string): string {
+  return `${direction}; ${prompt}`
+}
+
+export function diversifyDailyDreamCreativeDirection(
+  blueprint: DailyDreamBlueprint,
+  options: { dateKey: string; userId: number },
+): DailyDreamBlueprint {
+  const storyIndex =
+    hashSeed(`${options.dateKey}:${options.userId}:story-engine`) %
+    STORY_ENGINES.length
+  const visualIndex =
+    hashSeed(`${options.dateKey}:${options.userId}:visual-medium`) %
+    VISUAL_MEDIA.length
+  const engine = STORY_ENGINES[storyIndex]!
+  const medium = VISUAL_MEDIA[visualIndex]!
+  const facetStyle = facetValue(blueprint, 'STYLE')
+  const direction = facetStyle
+    ? `${medium}; honor the selected STYLE Facet (${facetStyle}) through shape language, costume, architecture, and detail without replacing the primary medium`
+    : medium
+
+  return {
+    ...blueprint,
+    pitch: storyPitch(blueprint, engine),
+    flavorText: `${blueprint.flavorText} Story engine: ${engine.toLowerCase()}.`,
+    artPrompt: withVisualDirection(blueprint.artPrompt, direction),
+    narrator: blueprint.narrator
+      ? {
+          ...blueprint.narrator,
+          artPrompt: withVisualDirection(
+            blueprint.narrator.artPrompt,
+            direction,
+          ),
+        }
+      : null,
+    characters: blueprint.characters.map((character) => ({
+      ...character,
+      artPrompt: withVisualDirection(character.artPrompt, direction),
+    })),
+    rewards: blueprint.rewards.map((reward) => ({
+      ...reward,
+      artPrompt: withVisualDirection(reward.artPrompt, direction),
+    })),
+  }
+}
+
+export const DAILY_DREAM_STORY_ENGINES = STORY_ENGINES
+export const DAILY_DREAM_VISUAL_MEDIA = VISUAL_MEDIA

--- a/server/utils/dailyDreamCreativeDiversity.ts
+++ b/server/utils/dailyDreamCreativeDiversity.ts
@@ -55,26 +55,24 @@ function storyPitch(
   const firstPlace = blueprint.locations[0]?.name || 'a place that should not exist'
   const secondPlace = blueprint.locations[1]?.name || firstPlace
   const theme = facetValue(blueprint, 'THEME') || 'the world’s central rule'
-  const genre = facetValue(blueprint, 'GENRE')
-  const genreClause = genre ? ` In this ${genre} world,` : ''
 
   switch (engine) {
     case 'KINETIC':
-      return `${hero} has one narrowing chance to carry ${reward} through ${firstPlace} while the place changes around them. ${foil} can clear the way, seize the reward, or force the crisis into ${secondPlace}.${genreClause} ${theme} becomes pressure that demands action rather than explanation.`
+      return `${hero} has one narrowing chance to carry ${reward} through ${firstPlace} while the place changes around them. ${foil} can clear the way, seize the reward, or force the crisis into ${secondPlace}. Every consequence of ${theme} arrives in motion.`
     case 'DISCOVERY':
-      return `${hero} discovers ${reward} at ${firstPlace} and tests what it can actually do. Each use exposes a new physical rule of the world, while ${foil} follows a conflicting explanation toward ${secondPlace}.${genreClause} the mystery of ${theme} is learned by encounter, not by paperwork.`
+      return `${hero} discovers ${reward} at ${firstPlace} and tests what it can actually do. Each use exposes a new physical rule, while ${foil} follows a conflicting explanation toward ${secondPlace}. The truth of ${theme} can only be learned by going deeper.`
     case 'RELATIONSHIP':
-      return `${hero} and ${foil} need ${reward} for incompatible reasons, and neither can reach ${secondPlace} alone. Their bargain changes as ${secondReward} makes the cost of ${theme} personal.${genreClause} the central turn is a choice about another person, not an institution.`
+      return `${hero} and ${foil} need ${reward} for incompatible reasons, and neither can reach ${secondPlace} alone. Their bargain changes as ${secondReward} makes the cost of ${theme} personal. The decisive turn is whether they choose the goal or each other.`
     case 'CAPER':
-      return `${hero} plans an audacious theft of ${reward} from ${firstPlace}; ${foil} is the indispensable part of the plan who may also ruin it. The escape route through ${secondPlace} depends on using ${secondReward} at exactly the wrong-looking moment.${genreClause} ${theme} drives the trick and its reversal.`
+      return `${hero} plans an audacious theft of ${reward} from ${firstPlace}; ${foil} is the indispensable part of the plan who may also ruin it. The escape route through ${secondPlace} depends on using ${secondReward} at exactly the wrong-looking moment, with ${theme} driving the final reversal.`
     case 'SURVIVAL':
-      return `${firstPlace} becomes dangerous in stages, forcing ${hero} and ${foil} toward ${secondPlace}. ${reward} can get one of them through the worst passage, while ${secondReward} changes who counts as safe.${genreClause} ${theme} is embodied in terrain, bodies, weather, hunger, pursuit, or transformation.`
+      return `${firstPlace} becomes dangerous in stages, forcing ${hero} and ${foil} toward ${secondPlace}. ${reward} can get one of them through the worst passage, while ${secondReward} changes who counts as safe. ${theme} expresses itself through bodies, terrain, pursuit, weather, hunger, or transformation.`
     case 'MYTHIC':
-      return `${reward} awakens at ${firstPlace} and reveals that ${theme} operates at a scale nobody expected. ${hero} must choose whether to use it, destroy it, or carry it to ${secondPlace} before ${foil} makes the choice for them.${genreClause} awe, dread, or impossible scale should be visible in the consequences.`
+      return `${reward} awakens at ${firstPlace} and reveals that ${theme} operates at a scale nobody expected. ${hero} must choose whether to use it, destroy it, or carry it to ${secondPlace} before ${foil} makes the choice for them, while the visible consequences grow larger than either of them.`
     case 'COMPETITION':
-      return `${firstPlace} hosts a contest whose prize is ${reward}, and ${hero} enters for a reason that clashes with ${foil}. The rules mutate when ${secondReward} appears, turning the final round toward ${secondPlace}.${genreClause} ${theme} shapes the game, rivalry, and reversal.`
+      return `${firstPlace} hosts a contest whose prize is ${reward}, and ${hero} enters for a reason that clashes with ${foil}. The rules mutate when ${secondReward} appears, turning the final round toward ${secondPlace}. ${theme} reshapes the rivalry with every reversal.`
     case 'JOURNEY':
-      return `${hero} must cross from ${firstPlace} to ${secondPlace} carrying ${reward}, with ${foil} joining for a different destination. Each leg reveals a different consequence of ${theme}, and ${secondReward} can bypass one obstacle only by creating another.${genreClause} movement through distinct terrain is the story engine.`
+      return `${hero} must cross from ${firstPlace} to ${secondPlace} carrying ${reward}, with ${foil} joining for a different destination. Each leg reveals a different consequence of ${theme}, and ${secondReward} can bypass one obstacle only by creating another.`
   }
 }
 
@@ -102,7 +100,6 @@ export function diversifyDailyDreamCreativeDirection(
   return {
     ...blueprint,
     pitch: storyPitch(blueprint, engine),
-    flavorText: `${blueprint.flavorText} Story engine: ${engine.toLowerCase()}.`,
     artPrompt: withVisualDirection(blueprint.artPrompt, direction),
     narrator: blueprint.narrator
       ? {

--- a/server/utils/dailyDreamNameDiversity.ts
+++ b/server/utils/dailyDreamNameDiversity.ts
@@ -1,4 +1,5 @@
 import type { DailyDreamBlueprint } from './dailyDreamFacetBlueprint'
+import { diversifyDailyDreamCreativeDirection } from './dailyDreamCreativeDiversity'
 
 const GROUNDED_NAMES = [
   'Nadia Reyes',
@@ -147,9 +148,9 @@ function pickUniqueName(options: {
     (hashSeed(`${options.dateKey}:${options.userId}:style`) + options.slot) %
     NAME_STYLE_POOLS.length
   const pool = NAME_STYLE_POOLS[styleIndex]!
-  const start = hashSeed(
-    `${options.dateKey}:${options.userId}:name:${options.slot}`,
-  ) % pool.length
+  const start =
+    hashSeed(`${options.dateKey}:${options.userId}:name:${options.slot}`) %
+    pool.length
 
   for (let offset = 0; offset < pool.length; offset++) {
     const candidate = pool[(start + offset) % pool.length]!
@@ -206,7 +207,7 @@ export function diversifyDailyDreamNames(
     ...characterAssignments,
   ]
 
-  return {
+  const namedBlueprint: DailyDreamBlueprint = {
     ...blueprint,
     description: replaceSequence(blueprint.description, descriptionOrder),
     pitch: replaceSequence(blueprint.pitch, pitchOrder),
@@ -247,4 +248,9 @@ export function diversifyDailyDreamNames(
       artPrompt: replaceSequence(reward.artPrompt, descriptionOrder),
     })),
   }
+
+  // /api/dreams/daily historically calls this one postprocessor before persistence.
+  // Keep that compatibility surface, but finish the same pass by varying the legacy
+  // pitch engine and renderer medium so this sibling cannot reintroduce the old rut.
+  return diversifyDailyDreamCreativeDirection(namedBlueprint, options)
 }


### PR DESCRIPTION
### Task
Companion implementation for `conductor dream-cycle/t-006` (`kind: software`).

### What changed / what I produced
- Audited the older `/api/dreams/daily` Facet-engine path that remained after the canonical Conductor pipeline became primary.
- Added a deterministic creative-diversity post-pass with eight distinct story engines instead of the legacy single pitch formula.
- Added ten materially different visual media lanes, including superhero-comic, charcoal cosmic horror, gouache, stop-motion miniature, risograph, low-poly 3D, photorealism, stained glass, watercolor/ink, and paper-cut collage.
- The selected medium is shared by the Dream, narrator, characters, and rewards within one bundle for visual coherence, while date/user seeds vary the medium across Daily Dreams.
- Existing STYLE Facets are still honored as world-specific shape/costume/architecture/detail direction rather than discarded.
- Hooked the creative pass into the existing name-diversity postprocessor, preserving the endpoint's current single postprocessing seam and its existing deterministic-name contract tests.

### How I verified
- Read `dailyDreamFacetBlueprint.ts`, `dailyDreamNameDiversity.ts`, `/api/dreams/daily.post.ts`, and the Daily Dream Facet contract verifier before editing.
- Existing contract verification already executes the postprocessor deterministically and checks cross-day variation; TypeScript and contract CI are the executable verification surfaces for this connector-only session.

### Stakes
`reversible`

### Flags for Reviewer
- This affects only newly generated legacy Facet-engine Daily Dreams. Persisted Dreams are unchanged.
- The canonical scheduled Daily Dream author/render pipeline is fixed separately in conductor#2996.
- No production generation or ArtJobs were triggered as part of verification.

### Kaizen suggestion
Keep the legacy generator behaviorally downstream of the canonical creative-diversity contract until it can eventually be retired, so manual and scheduled entry points do not evolve different creative biases.

### Notes for reviewer
The earlier character-name diversity pass used this same postprocessing seam. This companion closes the corresponding storyline/style gap rather than leaving a second generator with the old creative defaults.