### PR TITLE
cthulhuquarium/t-013: welcome-back panel + debounced clean batching

### DIFF
--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -29,24 +29,6 @@
         {{ tankStore.error }}
       </p>
 
-      <div
-        v-if="tankStore.offlineEarnings > 0"
-        class="alert rounded-xl border border-info/40 bg-info/10 py-2 text-sm"
-      >
-        <Icon name="kind-icon:coin" class="size-4 shrink-0" />
-        <span>
-          Something was collected while you were gone:
-          <b>{{ tankStore.offlineEarnings }}</b> coins. Nobody says by whom.
-        </span>
-        <button
-          type="button"
-          class="btn btn-ghost btn-xs ml-auto"
-          @click="tankStore.clearOfflineEarnings()"
-        >
-          Dismiss
-        </button>
-      </div>
-
       <div class="flex flex-wrap items-center justify-between gap-2">
         <div class="flex items-center gap-3 text-sm font-bold">
           <span class="flex items-center gap-1">
@@ -97,10 +79,18 @@
         <button
           type="button"
           class="btn btn-outline btn-xs min-h-11 min-w-11"
-          :disabled="tankStore.debrisLevel <= 0"
-          @click="tankStore.clean()"
+          :disabled="
+            tankStore.debrisLevel <= 0 && tankStore.pendingCleanClicks === 0
+          "
+          @click="tankStore.requestClean()"
         >
           Clean
+          <span
+            v-if="tankStore.pendingCleanClicks > 0"
+            class="badge badge-neutral badge-xs ml-1"
+          >
+            ×{{ tankStore.pendingCleanClicks }}
+          </span>
         </button>
       </div>
 
@@ -388,11 +378,52 @@
         </form>
       </dialog>
     </Teleport>
+
+    <!-- The welcome-back beat (cthulhuquarium/t-013): settled on load()
+         from lastTickAt, before this component even finishes mounting.
+         Deliberately not congratulatory -- something worked while nobody
+         was watching, and the tank is not going to explain itself. -->
+    <Teleport to="body">
+      <dialog
+        v-if="tankStore.offlineEarnings > 0"
+        class="modal modal-open"
+        aria-modal="true"
+        @cancel.prevent="tankStore.clearOfflineEarnings()"
+      >
+        <div
+          class="modal-box flex max-w-sm flex-col items-center gap-3 rounded-3xl border border-base-300 bg-base-100 text-center shadow-2xl"
+        >
+          <Icon name="kind-icon:coin" class="size-8 text-warning" />
+          <p class="text-xs font-black uppercase tracking-wide text-primary">
+            While you were away
+          </p>
+          <h3 class="text-lg font-black">
+            {{ tankStore.offlineEarnings }} coins
+          </h3>
+          <p class="text-sm opacity-80">
+            Something kept working{{ offlineDurationLabel }}. Nobody says by
+            whom.
+          </p>
+          <button
+            type="button"
+            class="btn btn-primary btn-sm mt-1"
+            @click="tankStore.clearOfflineEarnings()"
+          >
+            Take it
+          </button>
+        </div>
+        <form method="dialog" class="modal-backdrop">
+          <button type="button" @click="tankStore.clearOfflineEarnings()">
+            close
+          </button>
+        </form>
+      </dialog>
+    </Teleport>
   </ClientOnly>
 </template>
 
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import {
   TANK_POLL_INTERVAL_MS,
   useCthulhuquariumTankStore,
@@ -535,6 +566,23 @@ type FeedCreature = { x: number; y: number; phase: number; lean: number }
 
 const tankStore = useCthulhuquariumTankStore()
 const canvasRef = ref<HTMLCanvasElement | null>(null)
+
+// Display-only mirror of server/utils/aquariumEconomy.ts's TICK_SECONDS,
+// for the welcome-back panel's duration line only -- never used to compute
+// coins or anything the server doesn't already own. Same "must be kept in
+// sync by hand" discipline that file's own header comment documents for
+// its relationship to economy.yaml.
+const DISPLAY_TICK_SECONDS = 60
+
+const offlineDurationLabel = computed(() => {
+  const seconds = tankStore.offlineTicksProcessed * DISPLAY_TICK_SECONDS
+  if (seconds < 60) return ''
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60)
+    return ` -- gone about ${minutes} minute${minutes === 1 ? '' : 's'}`
+  const hours = Math.floor(minutes / 60)
+  return ` -- gone about ${hours} hour${hours === 1 ? '' : 's'}`
+})
 
 const swimmers = ref<Swimmer[]>([])
 const motes = ref<Mote[]>([])
@@ -842,5 +890,8 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   if (frame) window.cancelAnimationFrame(frame)
   if (pollTimer) clearInterval(pollTimer)
+  // A click right before navigating away should still land instead of
+  // being dropped along with the debounce timer.
+  tankStore.flushCleanNow()
 })
 </script>

--- a/server/api/aquarium/clean.post.ts
+++ b/server/api/aquarium/clean.post.ts
@@ -4,9 +4,13 @@
 // play channel cthulhuquarium/t-027 builds: -5 debris per click, instant,
 // free, no cooldown (data/economy.yaml's debris.clean.click_clears).
 //
-// No body -- there is nothing to parse; every click clears the same amount.
+// Optional body `{ clicks?: number }` (cthulhuquarium/t-013): the client
+// debounces a click spree into one request instead of one POST per click
+// and reports how many landed. Missing/invalid `clicks` defaults to 1, so a
+// client that sends no body at all keeps the original single-click
+// behavior. `cleanTankForUser` clamps the value server-side.
 
-import { defineEventHandler } from 'h3'
+import { defineEventHandler, readBody } from 'h3'
 import { errorHandler } from '../../utils/error'
 import { requireApiUser } from '../../utils/authGuard'
 import { cleanTankForUser } from '../../utils/aquarium'
@@ -16,7 +20,12 @@ export default defineEventHandler(async (event) => {
 
   try {
     const { user } = await requireApiUser(event)
-    const result = await cleanTankForUser(user.id, user.username)
+    const body = await readBody(event).catch(() => null)
+    const clicks =
+      body && typeof body === 'object' && typeof body.clicks === 'number'
+        ? body.clicks
+        : 1
+    const result = await cleanTankForUser(user.id, user.username, clicks)
 
     response = {
       success: true,

--- a/server/utils/aquarium.ts
+++ b/server/utils/aquarium.ts
@@ -22,6 +22,7 @@ import {
   FEED_RESTORES_HUNGER_TO,
   HUNGER_STARTING_VALUE,
   justCompletedBestiary as computeJustCompletedBestiary,
+  MAX_CLEAN_CLICKS_PER_REQUEST,
   settleTick,
   unlockCost,
 } from './aquariumEconomy'
@@ -326,9 +327,21 @@ export interface CleanResult {
 export async function cleanTankForUser(
   userId: number,
   username: string,
+  // cthulhuquarium/t-013: the client debounces a click spree into one
+  // batched call instead of one POST per click; `clicks` is how many landed
+  // in that window. Defaults to 1 so every pre-t-013 call site (and a
+  // client that omits the field entirely) keeps identical single-click
+  // behavior. Clamped server-side -- never trust the request body for the
+  // clamp itself (MAX_CLEAN_CLICKS_PER_REQUEST above documents why a large
+  // value doesn't unlock anything, it just bounds one request's work).
+  clicks = 1,
 ): Promise<CleanResult> {
+  const safeClicks = Math.min(
+    Math.max(1, Math.floor(Number.isFinite(clicks) ? clicks : 1)),
+    MAX_CLEAN_CLICKS_PER_REQUEST,
+  )
   const tank = await getOrCreateTankForUser(userId, username)
-  const newDebrisLevel = cleanDebris(tank.debrisLevel)
+  const newDebrisLevel = cleanDebris(tank.debrisLevel, safeClicks)
 
   if (newDebrisLevel === tank.debrisLevel) {
     return { aquarium: tank, debrisLevel: tank.debrisLevel }
@@ -345,6 +358,7 @@ export async function cleanTankForUser(
     await logEvent(tx, tank.id, 'clean', {
       previousDebrisLevel: tank.debrisLevel,
       newDebrisLevel,
+      clicks: safeClicks,
     })
 
     return updated

--- a/server/utils/aquariumEconomy.ts
+++ b/server/utils/aquariumEconomy.ts
@@ -208,8 +208,24 @@ export function debrisMultiplier(debrisLevel: number): number {
 // route now does not foreclose the other two.
 export const DEBRIS_CLICK_CLEARS = 5
 
-export function cleanDebris(debrisLevel: number): number {
-  return Math.max(DEBRIS_RANGE.min, debrisLevel - DEBRIS_CLICK_CLEARS)
+// cthulhuquarium/t-013: the client batches a rapid click spree into one
+// debounced request instead of one POST per click (see
+// stores/cthulhuquariumTankStore.ts's flushClean()), and reports how many
+// clicks landed in that window as `clicks`. This is a defensive request-size
+// cap, not a balance constant -- clicking clean has nothing to lose by being
+// spammed (see this section's header comment), so a larger value doesn't
+// unlock anything a determined clicker couldn't already reach one request at
+// a time; it just bounds how much server work one request can demand.
+export const MAX_CLEAN_CLICKS_PER_REQUEST = 50
+
+export function cleanDebris(debrisLevel: number, clicks = 1): number {
+  const safeClicks = Number.isFinite(clicks)
+    ? Math.max(1, Math.floor(clicks))
+    : 1
+  return Math.max(
+    DEBRIS_RANGE.min,
+    debrisLevel - DEBRIS_CLICK_CLEARS * safeClicks,
+  )
 }
 
 // ---------------------------------------------------------------------------

--- a/stores/cthulhuquariumTankStore.ts
+++ b/stores/cthulhuquariumTankStore.ts
@@ -90,6 +90,12 @@ interface TickResponse {
   coinsEarned: number
 }
 
+// cthulhuquarium/t-013: how long the store waits after the last Clean click
+// before flushing the accumulated count as one request. Long enough to
+// collapse a real click spree into a single write, short enough that a
+// single deliberate click still feels immediate.
+const CLEAN_DEBOUNCE_MS = 400
+
 interface FeedResponse {
   aquarium: Tank
   aquariumStockId: number
@@ -150,6 +156,17 @@ export const useCthulhuquariumTankStore = defineStore(
     const tank = ref<Tank | null>(null)
     const catalog = ref<CatalogEntry[]>([])
     const offlineEarnings = ref(0)
+    // Ticks settled by the SAME offline-catch-up call that produced
+    // offlineEarnings above (load()'s initial settle only, never the live
+    // 20s poll -- see settleTickRaw()'s callers). Display-only: lets the
+    // welcome-back panel say roughly how long the tank ran unattended
+    // alongside what it earned, without the client inventing its own
+    // elapsed-time math.
+    const offlineTicksProcessed = ref(0)
+    // Clicks queued by requestClean() and not yet flushed to the server --
+    // see flushClean() below. Shown next to the Clean button so a click
+    // spree still gets instant feedback even though the write is batched.
+    const pendingCleanClicks = ref(0)
     const loading = ref(false)
     const catalogLoading = ref(false)
     const error = ref('')
@@ -190,15 +207,30 @@ export const useCthulhuquariumTankStore = defineStore(
       ),
     )
 
-    async function settleTick(): Promise<number> {
+    // Shared by settleTick() (the live 20s heartbeat -- see
+    // TANK_POLL_INTERVAL_MS's own comment) and load() (the offline
+    // catch-up). Only load() treats the result as an "offline" event;
+    // the heartbeat just wants coinsEarned for its coin-mote animation.
+    async function settleTickRaw(): Promise<{
+      coinsEarned: number
+      ticksProcessed: number
+    }> {
       const res = await performFetch<TickResponse>('/api/aquarium/tick', {
         method: 'POST',
       })
       if (res.success && res.data) {
         tank.value = res.data.aquarium
-        return res.data.coinsEarned
+        return {
+          coinsEarned: res.data.coinsEarned,
+          ticksProcessed: res.data.ticksProcessed,
+        }
       }
-      return 0
+      return { coinsEarned: 0, ticksProcessed: 0 }
+    }
+
+    async function settleTick(): Promise<number> {
+      const { coinsEarned } = await settleTickRaw()
+      return coinsEarned
     }
 
     async function load(): Promise<void> {
@@ -214,8 +246,11 @@ export const useCthulhuquariumTankStore = defineStore(
         // Settle any offline time immediately on load, same as the t-010
         // prototype's own init() did -- the difference is this is now a
         // real server-authoritative settlement, not a localStorage replay.
-        const earned = await settleTick()
-        if (earned > 0) offlineEarnings.value += earned
+        const { coinsEarned, ticksProcessed } = await settleTickRaw()
+        if (coinsEarned > 0) {
+          offlineEarnings.value += coinsEarned
+          offlineTicksProcessed.value += ticksProcessed
+        }
         ready.value = true
       } finally {
         loading.value = false
@@ -276,17 +311,41 @@ export const useCthulhuquariumTankStore = defineStore(
     // The active-play channel (cthulhuquarium/t-027): -5 debris per click,
     // instant, free, no cooldown. Debris only ever throttles the tank's
     // production RATE, never holdings, so there is nothing to lose by
-    // spamming this -- the button just disables itself at debrisLevel 0.
-    async function clean(): Promise<boolean> {
+    // spamming this economically -- but each click was still one POST, so a
+    // real click spree meant one write per click. cthulhuquarium/t-013
+    // batches that: requestClean() queues the click and (re)starts a
+    // debounce timer; only the LAST click in a spree actually fires the
+    // network request, carrying however many clicks queued up behind it.
+    let cleanDebounceTimer: ReturnType<typeof setTimeout> | undefined
+
+    async function flushClean(): Promise<void> {
+      const clicks = pendingCleanClicks.value
+      pendingCleanClicks.value = 0
+      if (clicks <= 0) return
       const res = await performFetch<CleanResponse>('/api/aquarium/clean', {
         method: 'POST',
+        body: JSON.stringify({ clicks }),
       })
       if (res.success && res.data) {
         tank.value = res.data.aquarium
-        return true
+      } else {
+        error.value = res.message || 'Could not clean the tank.'
       }
-      error.value = res.message || 'Could not clean the tank.'
-      return false
+    }
+
+    function requestClean(): void {
+      pendingCleanClicks.value += 1
+      clearTimeout(cleanDebounceTimer)
+      cleanDebounceTimer = setTimeout(() => {
+        void flushClean()
+      }, CLEAN_DEBOUNCE_MS)
+    }
+
+    // Called on unmount so a click right before navigating away still
+    // lands instead of being dropped with the cleared timer.
+    function flushCleanNow(): void {
+      clearTimeout(cleanDebounceTimer)
+      void flushClean()
     }
 
     async function loadBestiary(): Promise<void> {
@@ -311,6 +370,7 @@ export const useCthulhuquariumTankStore = defineStore(
 
     function clearOfflineEarnings(): void {
       offlineEarnings.value = 0
+      offlineTicksProcessed.value = 0
     }
 
     return {
@@ -323,6 +383,8 @@ export const useCthulhuquariumTankStore = defineStore(
       debrisLevel,
       hungriest,
       offlineEarnings,
+      offlineTicksProcessed,
+      pendingCleanClicks,
       loading,
       catalogLoading,
       error,
@@ -339,7 +401,8 @@ export const useCthulhuquariumTankStore = defineStore(
       feed,
       unlock,
       dismissReveal,
-      clean,
+      requestClean,
+      flushCleanNow,
       clearOfflineEarnings,
       loadBestiary,
       dismissBestiaryCompletion,

--- a/utils/scripts/verifyAquariumEconomy.test.ts
+++ b/utils/scripts/verifyAquariumEconomy.test.ts
@@ -15,6 +15,7 @@ import {
   DEBRIS_CLICK_CLEARS,
   DEBRIS_RANGE,
   MAX_ACCRUAL_TICKS,
+  MAX_CLEAN_CLICKS_PER_REQUEST,
   OFFLINE_INCOME_RATE_MULTIPLIER,
   RARITY_TIERS,
   TICK_SECONDS,
@@ -550,6 +551,47 @@ assert.ok(
 
 console.log(
   '✅ cleanDebris: clears exactly DEBRIS_CLICK_CLEARS per click, floors at DEBRIS_RANGE.min',
+)
+
+// --- cleanDebris(clicks): cthulhuquarium/t-013's debounced click batching --
+
+assert.equal(
+  cleanDebris(100, 1),
+  95,
+  'clicks=1 is identical to the pre-t-013 single-click call',
+)
+assert.equal(
+  cleanDebris(100, 3),
+  100 - DEBRIS_CLICK_CLEARS * 3,
+  'a batched flush of N clicks clears N times as much in one call',
+)
+assert.equal(
+  cleanDebris(10, 3),
+  0,
+  'a batch that would overshoot still floors at DEBRIS_RANGE.min, never negative',
+)
+assert.equal(
+  cleanDebris(50, 0),
+  cleanDebris(50, 1),
+  'clicks=0 clamps up to 1, never a zero-effect clear',
+)
+assert.equal(
+  cleanDebris(50, -3),
+  cleanDebris(50, 1),
+  'a negative clicks value clamps to 1, never subtracts negative debris',
+)
+assert.equal(
+  cleanDebris(50, 2.9),
+  cleanDebris(50, 2),
+  'a fractional clicks value floors to a whole click count',
+)
+assert.ok(
+  MAX_CLEAN_CLICKS_PER_REQUEST > 0,
+  'the batch-size cap is a positive request-shape guard, not a balance number',
+)
+
+console.log(
+  '✅ cleanDebris(clicks): batches N clicks into one clear, clamps clicks to a positive integer',
 )
 
 // --- justCompletedBestiary: cthulhuquarium/t-024's completion-beat gate ----


### PR DESCRIPTION
### Task
`cthulhuquarium/t-013`: Offline income and autosave (kind: software)

### What changed / what I produced
- Server-authoritative offline income settlement (`settleTick`/`lastTickAt`, capped at 8h/0.5x per `economy.yaml`) already existed from t-009/t-011 and needed no changes — the client already never proposes a coin amount, only actions.
- Replaced the inline offline-earnings alert banner in `cthulhuquarium-game.vue` with a proper `Teleport`+`<dialog>` modal, matching the two existing local precedents (`revealedUnlock`, `bestiaryJustCompleted`) rather than an easy-to-miss top-of-page banner. Copy stays in the dry/ominous DESIGN-BRIEF register ("Something kept working... Nobody says by whom.") rather than congratulatory, and shows a rough duration ("gone about N minutes/hours") derived from the settlement's own `ticksProcessed`.
- Batched the Clean button's click-spree write storm: `cleanDebris()` and `cleanTankForUser()` now accept an optional `clicks` count (default 1, fully backward compatible — every existing call site is unaffected). The store's `requestClean()` queues a click and restarts a 400ms debounce; only the last click in a spree actually fires the network request, carrying the accumulated count. `flushCleanNow()` runs on unmount so a click right before navigating away still lands. `MAX_CLEAN_CLICKS_PER_REQUEST` bounds one request's work server-side (a request-shape guard, not a balance number — clicking Clean has nothing to lose by being spammed, per its own existing design doc comment).
- Extended `verifyAquariumEconomy.test.ts` for the new `clicks` parameter (batched-clear math, clamping a fractional/zero/negative value to a positive integer).

### How I verified
- `npx tsx utils/scripts/verifyAquariumEconomy.test.ts` — full suite passes, including new `cleanDebris(clicks)` coverage and the existing 5000-iteration `settleTick` property test.
- `npm run test:aquarium-touch` — passes (unaffected, sanity check).
- `npx eslint` on all changed files — clean.
- `npx vue-tsc --noEmit` — clean, full repo.
- `npx prettier --check` on all changed files — clean.
- `npm run test:layout-contract` — holds, no new violations (the reused grid pattern was already layout-contract-compliant).

### Stakes
`reversible`

### Flags for Reviewer
- Most of the offline-income backend already existed (t-009/t-011); this task's actual gap was the "one clear panel" UI moment and the click-spree write-storm guard, per its own roadmap note.
- Conductor's `economy.yaml`/`ECONOMY.md` describe offline income as a single multiply at login against logout-time hunger/debris state; the shipped `settleTick` instead simulates tick-by-tick. This is pre-existing from t-009, not something this task touches — flagging for awareness only.

### Kaizen suggestion
No shared debounce utility exists anywhere in the codebase (grepped — every caller hand-rolls `setTimeout`/`clearTimeout`, including this PR's `requestClean`/`flushClean` and the pre-existing `watchlist-entry-detail.vue` autosave). A small `useDebouncedBatch` composable would let future click-spree-prone actions (and any future autosave surface) adopt the same pattern instead of re-deriving it.

---
_Generated by [Claude Code](https://claude.ai/code/session_019smZdoHzKC6f66zhTKvF5r)_