### PR TITLE
cthulhuquarium/t-026: set pieces -- the build layer and its synergies

### DIFF
--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -280,6 +280,84 @@
           </div>
         </template>
       </div>
+
+      <!-- Set pieces (cthulhuquarium/t-026): the build layer. Fish provide
+           colour and income; sets provide the variation and the surprise
+           combos (SYSTEMS.md's own framing) -- so unlike the bestiary this
+           panel is about a small, legible, COUNTED choice (setSlotsCap),
+           not a big collected list. -->
+      <div class="flex flex-col gap-2 border-t border-base-300 pt-3">
+        <button
+          type="button"
+          class="flex items-center justify-between gap-2 text-left"
+          @click="onToggleSets"
+        >
+          <span class="text-xs font-black uppercase tracking-wide opacity-60">
+            Set pieces
+            <span class="opacity-80">
+              — {{ tankStore.equippedSets.length }}/{{ tankStore.setSlotsCap }}
+              equipped
+            </span>
+          </span>
+          <Icon
+            :name="showSets ? 'kind-icon:chevron-up' : 'kind-icon:chevron-down'"
+            class="size-4 shrink-0 opacity-60"
+          />
+        </button>
+
+        <template v-if="showSets">
+          <p v-if="tankStore.setCatalogLoading" class="text-xs opacity-60">
+            Surveying the build layer…
+          </p>
+          <div
+            v-else
+            class="grid grid-cols-[repeat(auto-fit,minmax(15rem,1fr))] gap-2"
+          >
+            <div
+              v-for="entry in tankStore.setCatalog"
+              :key="entry.kind"
+              class="flex flex-col gap-1 rounded-xl border border-base-300 bg-base-100 p-3"
+              :class="{ 'border-primary/60': entry.equipped }"
+            >
+              <div class="flex items-start justify-between gap-2">
+                <p class="text-sm font-bold">{{ entry.title }}</p>
+                <span
+                  v-if="entry.equipped"
+                  class="badge badge-primary badge-xs shrink-0"
+                >
+                  Equipped
+                </span>
+              </div>
+              <p class="text-xs italic opacity-70">{{ entry.description }}</p>
+              <button
+                v-if="entry.equipped"
+                type="button"
+                class="btn btn-outline btn-xs min-h-11 mt-1 self-start"
+                @click="
+                  () => {
+                    const id = equippedSetId(entry.kind)
+                    if (id) tankStore.unequipSet(id)
+                  }
+                "
+              >
+                Unequip
+              </button>
+              <button
+                v-else
+                type="button"
+                class="btn btn-outline btn-xs min-h-11 mt-1 self-start"
+                :disabled="!canEquip(entry)"
+                @click="tankStore.equipSet(entry.kind)"
+              >
+                Equip ({{ entry.cost }})
+              </button>
+            </div>
+            <p v-if="!tankStore.setCatalog.length" class="text-xs opacity-60">
+              No set pieces to show right now.
+            </p>
+          </div>
+        </template>
+      </div>
     </div>
 
     <!-- The unlock reveal beat (cthulhuquarium/t-012): the field note is
@@ -428,6 +506,7 @@ import {
   TANK_POLL_INTERVAL_MS,
   useCthulhuquariumTankStore,
   type CatalogEntry,
+  type SetCatalogEntry,
   type TankStock,
 } from '~/stores/cthulhuquariumTankStore'
 import { touchHitRadius } from '~/utils/aquariumTouch'
@@ -536,6 +615,13 @@ function behaviorProfile(behavior: string | null): BehaviorProfile {
   return BEHAVIOR_PROFILES[(behavior || '').toLowerCase()] ?? DRIFT_PROFILE
 }
 
+// swim_speed (cthulhuquarium/t-026, economy.yaml set_pieces.swim_speed):
+// "cosmetic_only, value: null" -- there is no economy number to read here,
+// only a visual pacing choice this component owns. 1.4x is a deliberately
+// noticeable-but-not-frantic bump over each behavior's own base speed.
+const SWIM_SPEED_SET_KIND = 'swim_speed'
+const SWIM_SPEED_MULTIPLIER = 1.4
+
 // Deterministic fallback hue for a species Monster.hue hasn't been assigned
 // yet -- same slug always reads the same color instead of shifting on
 // every reload/re-render.
@@ -588,6 +674,16 @@ const swimmers = ref<Swimmer[]>([])
 const motes = ref<Mote[]>([])
 const feed = ref<FeedCreature[]>([])
 const showBestiary = ref(false)
+const showSets = ref(false)
+
+// Read live rather than baked into each Swimmer at spawn time, so
+// equipping/unequipping Swift Current takes effect immediately instead of
+// only for fish spawned afterward.
+const swimSpeedMultiplier = computed(() =>
+  tankStore.equippedSets.some((entry) => entry.kind === SWIM_SPEED_SET_KIND)
+    ? SWIM_SPEED_MULTIPLIER
+    : 1,
+)
 
 let frame = 0
 let lastFrameAt = 0
@@ -763,15 +859,15 @@ function step(delta: number) {
       const dx = target.x - swimmer.x
       const dy = target.y - swimmer.y
       const distance = Math.hypot(dx, dy) || 1
-      swimmer.x += (dx / distance) * 55 * delta
-      swimmer.y += (dy / distance) * 55 * delta
+      swimmer.x += (dx / distance) * 55 * swimSpeedMultiplier.value * delta
+      swimmer.y += (dy / distance) * 55 * swimSpeedMultiplier.value * delta
       swimmer.vx = dx >= 0 ? Math.abs(swimmer.vx) : -Math.abs(swimmer.vx)
     } else {
       const [minY, maxY] = swimmer.profile.vBand
       const bandTop = STAGE_HEIGHT * minY
       const bandBottom = STAGE_HEIGHT * maxY
       swimmer.phase += delta
-      swimmer.x += swimmer.vx * delta
+      swimmer.x += swimmer.vx * swimSpeedMultiplier.value * delta
       swimmer.y += Math.sin(swimmer.phase) * swimmer.profile.wobble * delta
       if (swimmer.profile.wallCling) {
         // Clings near whichever wall it's closest to rather than crossing
@@ -874,6 +970,25 @@ function onToggleBestiary() {
   if (showBestiary.value && !tankStore.bestiary.length) {
     void tankStore.loadBestiary()
   }
+}
+
+function onToggleSets() {
+  showSets.value = !showSets.value
+  if (showSets.value && !tankStore.setCatalog.length) {
+    void tankStore.loadSets()
+  }
+}
+
+function canEquip(entry: SetCatalogEntry): boolean {
+  return (
+    !entry.equipped &&
+    tankStore.coins >= entry.cost &&
+    tankStore.equippedSets.length < tankStore.setSlotsCap
+  )
+}
+
+function equippedSetId(kind: string): number | null {
+  return tankStore.equippedSets.find((entry) => entry.kind === kind)?.id ?? null
 }
 
 onMounted(async () => {

--- a/server/api/aquarium/sets/equip.post.ts
+++ b/server/api/aquarium/sets/equip.post.ts
@@ -1,0 +1,50 @@
+// /server/api/aquarium/sets/equip.post.ts
+//
+// Equips one set piece into the authenticated user's tank, priced and
+// validated entirely server-side (cthulhuquarium/t-026): rejects an unknown
+// kind, a duplicate, a full setSlotsCap, the no_stack_idle_effects pair
+// (roaming_collector + idle_hoarder), or insufficient coins.
+//
+// Body: { kind: string }
+
+import { defineEventHandler, readBody, createError } from 'h3'
+import { errorHandler } from '../../../utils/error'
+import { requireApiUser } from '../../../utils/authGuard'
+import { equipSetForUser } from '../../../utils/aquarium'
+
+export default defineEventHandler(async (event) => {
+  let response
+
+  try {
+    const { user } = await requireApiUser(event)
+
+    const body = await readBody(event)
+    const kind = String(body?.kind ?? '')
+    if (!kind) {
+      throw createError({
+        statusCode: 400,
+        message: 'kind is required.',
+      })
+    }
+
+    const result = await equipSetForUser(user.id, user.username, kind)
+
+    response = {
+      success: true,
+      message: `Equipped ${result.set.kind}.`,
+      data: result,
+      statusCode: 201,
+    }
+    event.node.res.statusCode = 201
+  } catch (error) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+    response = {
+      success: false,
+      message: handledError.message || 'Failed to equip that set piece.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+
+  return response
+})

--- a/server/api/aquarium/sets/index.get.ts
+++ b/server/api/aquarium/sets/index.get.ts
@@ -1,0 +1,38 @@
+// /server/api/aquarium/sets/index.get.ts
+//
+// Lists the Cthulhuquarium set-piece catalog (cthulhuquarium/t-026) alongside
+// which ones the authenticated user's tank currently has equipped -- the
+// build layer's own catalog view, same shape as GET /api/aquarium/catalog
+// for species.
+
+import { defineEventHandler } from 'h3'
+import { errorHandler } from '../../../utils/error'
+import { requireApiUser } from '../../../utils/authGuard'
+import { listSetsForUser } from '../../../utils/aquarium'
+
+export default defineEventHandler(async (event) => {
+  let response
+
+  try {
+    const { user } = await requireApiUser(event)
+
+    const result = await listSetsForUser(user.id, user.username)
+
+    response = {
+      success: true,
+      data: result,
+      statusCode: 200,
+    }
+    event.node.res.statusCode = 200
+  } catch (error) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+    response = {
+      success: false,
+      message: handledError.message || 'Failed to load set pieces.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+
+  return response
+})

--- a/server/api/aquarium/sets/unequip.post.ts
+++ b/server/api/aquarium/sets/unequip.post.ts
@@ -1,0 +1,53 @@
+// /server/api/aquarium/sets/unequip.post.ts
+//
+// Removes one equipped set piece from the authenticated user's tank
+// (cthulhuquarium/t-026), freeing its setSlotsCap slot. No coin refund --
+// see equipSetForUser/unequipSetForUser's own doc comments for why this
+// isn't treated as a reversible purchase.
+//
+// Body: { aquariumSetId: number }
+
+import { defineEventHandler, readBody, createError } from 'h3'
+import { errorHandler } from '../../../utils/error'
+import { requireApiUser } from '../../../utils/authGuard'
+import { unequipSetForUser } from '../../../utils/aquarium'
+
+export default defineEventHandler(async (event) => {
+  let response
+
+  try {
+    const { user } = await requireApiUser(event)
+
+    const body = await readBody(event)
+    const aquariumSetId = Number(body?.aquariumSetId)
+    if (!Number.isInteger(aquariumSetId) || aquariumSetId <= 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'aquariumSetId must be a positive integer.',
+      })
+    }
+
+    const result = await unequipSetForUser(
+      user.id,
+      user.username,
+      aquariumSetId,
+    )
+
+    response = {
+      success: true,
+      data: result,
+      statusCode: 200,
+    }
+    event.node.res.statusCode = 200
+  } catch (error) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+    response = {
+      success: false,
+      message: handledError.message || 'Failed to unequip that set piece.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+
+  return response
+})

--- a/server/utils/aquarium.ts
+++ b/server/utils/aquarium.ts
@@ -17,12 +17,17 @@ import prisma from './prisma'
 import { getUniqueAquariumSlugForUser } from './aquariumSlug'
 import {
   cleanDebris,
+  conflictsWithEquippedIdleSet,
   deriveFishRarityTier,
+  effectiveSizeCap,
+  feedCoinRebate,
   feedCost,
   FEED_RESTORES_HUNGER_TO,
   HUNGER_STARTING_VALUE,
+  isKnownSetPieceKind,
   justCompletedBestiary as computeJustCompletedBestiary,
   MAX_CLEAN_CLICKS_PER_REQUEST,
+  SET_PIECE_CATALOG,
   settleTick,
   unlockCost,
 } from './aquariumEconomy'
@@ -103,6 +108,15 @@ const ownedStockSelect = {
   Monster: { select: stockMonsterSelect },
 } satisfies Prisma.AquariumStockSelect
 
+// cthulhuquarium/t-026: the tank's equipped set pieces. Ordered oldest-
+// first so the UI can show "what you built up over time" rather than a
+// re-shuffling list on every load.
+const ownedSetSelect = {
+  id: true,
+  kind: true,
+  equippedAt: true,
+} satisfies Prisma.AquariumSetSelect
+
 const ownedAquariumSelect = {
   id: true,
   slug: true,
@@ -118,11 +132,32 @@ const ownedAquariumSelect = {
   createdAt: true,
   updatedAt: true,
   Stock: { select: ownedStockSelect },
+  Sets: { select: ownedSetSelect, orderBy: { equippedAt: 'asc' } },
 } satisfies Prisma.AquariumSelect
 
 export type OwnedAquarium = Prisma.AquariumGetPayload<{
   select: typeof ownedAquariumSelect
 }>
+
+// The wire shape every route actually returns: OwnedAquarium plus
+// effectiveSizeCap, the sizeCap.raw + extra_species_slot bonuses derived
+// number (aquariumEconomy.ts). Computed server-side rather than left for
+// the client to re-derive from `Sets` + a hardcoded bonus value -- same
+// "the server disposes, the client never invents an economy number"
+// discipline as everywhere else in this file.
+export interface ClientAquarium extends OwnedAquarium {
+  effectiveSizeCap: number
+}
+
+function toClientAquarium(aquarium: OwnedAquarium): ClientAquarium {
+  return {
+    ...aquarium,
+    effectiveSizeCap: effectiveSizeCap(
+      aquarium.sizeCap,
+      aquarium.Sets.map((set) => set.kind),
+    ),
+  }
+}
 
 const DEFAULT_STARTING_COINS = 0
 
@@ -146,17 +181,17 @@ async function logEvent(
 export async function getOrCreateTankForUser(
   userId: number,
   username: string,
-): Promise<OwnedAquarium> {
+): Promise<ClientAquarium> {
   const existing = await prisma.aquarium.findFirst({
     where: { userId },
     select: ownedAquariumSelect,
     orderBy: { id: 'asc' },
   })
-  if (existing) return existing
+  if (existing) return toClientAquarium(existing)
 
   const slug = await getUniqueAquariumSlugForUser(userId, username)
 
-  return prisma.aquarium.create({
+  const created = await prisma.aquarium.create({
     data: {
       userId,
       slug,
@@ -165,6 +200,7 @@ export async function getOrCreateTankForUser(
     },
     select: ownedAquariumSelect,
   })
+  return toClientAquarium(created)
 }
 
 // ---------------------------------------------------------------------------
@@ -172,7 +208,7 @@ export async function getOrCreateTankForUser(
 // ---------------------------------------------------------------------------
 
 export interface TickResult {
-  aquarium: OwnedAquarium
+  aquarium: ClientAquarium
   elapsedTicks: number
   ticksProcessed: number
   coinsEarned: number
@@ -183,6 +219,7 @@ export async function settleTickForUser(
   username: string,
 ): Promise<TickResult> {
   const tank = await getOrCreateTankForUser(userId, username)
+  const equippedSetKinds = tank.Sets.map((set) => set.kind)
 
   const settlement = settleTick({
     lastTickAt: tank.lastTickAt,
@@ -195,6 +232,7 @@ export async function settleTickForUser(
       yieldPerTick: stock.Monster.yieldPerTick,
       tickIntervalSeconds: stock.Monster.tickIntervalSeconds,
     })),
+    equippedSetKinds,
   })
 
   if (settlement.ticksProcessed <= 0) {
@@ -238,7 +276,7 @@ export async function settleTickForUser(
   })
 
   return {
-    aquarium,
+    aquarium: toClientAquarium(aquarium),
     elapsedTicks: settlement.elapsedTicks,
     ticksProcessed: settlement.ticksProcessed,
     coinsEarned: settlement.coinsEarned,
@@ -250,9 +288,14 @@ export async function settleTickForUser(
 // ---------------------------------------------------------------------------
 
 export interface FeedResult {
-  aquarium: OwnedAquarium
+  aquarium: ClientAquarium
   aquariumStockId: number
   cost: number
+  // feeding_bonus (cthulhuquarium/t-026): coins refunded from `cost` this
+  // feed, 0 unless that set is equipped. `cost` above stays the sticker
+  // price either way -- this is what actually left the tank's balance:
+  // netCharged = cost - rebate.
+  rebate: number
   hunger: number
 }
 
@@ -281,6 +324,10 @@ export async function feedFishForUser(
     )
   }
 
+  const equippedSetKinds = tank.Sets.map((set) => set.kind)
+  const rebate = feedCoinRebate(cost, equippedSetKinds)
+  const netCharged = cost - rebate
+
   const aquarium = await prisma.$transaction(async (tx) => {
     await tx.aquariumStock.update({
       where: { id: stock.id },
@@ -289,7 +336,7 @@ export async function feedFishForUser(
 
     const updated = await tx.aquarium.update({
       where: { id: tank.id },
-      data: { coins: { decrement: cost } },
+      data: { coins: { decrement: netCharged } },
       select: ownedAquariumSelect,
     })
 
@@ -297,15 +344,17 @@ export async function feedFishForUser(
       aquariumStockId: stock.id,
       monsterId: stock.monsterId,
       cost,
+      rebate,
     })
 
     return updated
   })
 
   return {
-    aquarium,
+    aquarium: toClientAquarium(aquarium),
     aquariumStockId: stock.id,
     cost,
+    rebate,
     hunger: FEED_RESTORES_HUNGER_TO,
   }
 }
@@ -320,7 +369,7 @@ export async function feedFishForUser(
 // ---------------------------------------------------------------------------
 
 export interface CleanResult {
-  aquarium: OwnedAquarium
+  aquarium: ClientAquarium
   debrisLevel: number
 }
 
@@ -364,7 +413,7 @@ export async function cleanTankForUser(
     return updated
   })
 
-  return { aquarium, debrisLevel: newDebrisLevel }
+  return { aquarium: toClientAquarium(aquarium), debrisLevel: newDebrisLevel }
 }
 
 // ---------------------------------------------------------------------------
@@ -526,10 +575,17 @@ async function countBestiaryTotals(
 // implemented: economy.yaml bundles buying+consuming food into a single
 // action (POST /feed already IS that purchase) and states capacity growth
 // is milestone-only, "never purchased with coins".
+//
+// cthulhuquarium/t-026's extra_species_slot set piece does NOT contradict
+// that rule: it never raises the base `sizeCap` column milestones grow, it
+// occupies one of the tank's scarce, counted setSlotsCap slots and only
+// widens the derived `effectiveSizeCap` used below while equipped --
+// unequip it (or lose the slot to a different set) and the bonus is gone.
+// That is a build choice, not a purchased permanent upgrade.
 // ---------------------------------------------------------------------------
 
 export interface PurchaseSpeciesResult {
-  aquarium: OwnedAquarium
+  aquarium: ClientAquarium
   stock: OwnedAquarium['Stock'][number]
   cost: number
   // True exactly once -- the settlement that brings collectedCount to
@@ -571,10 +627,13 @@ export async function purchaseSpeciesForUser(
     0,
   )
   const newSize = monster.size ?? 1
-  if (currentSize + newSize > tank.sizeCap) {
+  // tank.effectiveSizeCap (aquariumEconomy.ts's effectiveSizeCap) already
+  // folds in any equipped extra_species_slot bonus -- see this section's
+  // header comment for why that's not a "capacity purchased with coins".
+  if (currentSize + newSize > tank.effectiveSizeCap) {
     throw apiError(
       409,
-      `Adding ${monster.name} (size ${newSize}) would exceed your tank's capacity (${currentSize}/${tank.sizeCap} used).`,
+      `Adding ${monster.name} (size ${newSize}) would exceed your tank's capacity (${currentSize}/${tank.effectiveSizeCap} used).`,
     )
   }
 
@@ -664,7 +723,12 @@ export async function purchaseSpeciesForUser(
     },
   )
 
-  return { aquarium, stock, cost, justCompletedBestiary }
+  return {
+    aquarium: toClientAquarium(aquarium),
+    stock,
+    cost,
+    justCompletedBestiary,
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -850,4 +914,144 @@ export async function listCatalogForUser(
   }))
 
   return { data, take, skip, total }
+}
+
+// ---------------------------------------------------------------------------
+// Set pieces (cthulhuquarium/t-026) -- "the build layer and its synergies".
+// The catalog itself is static (aquariumEconomy.ts's SET_PIECE_CATALOG);
+// this section is only the per-tank equip/unequip state around it. Sets
+// draw from their own counted setSlotsCap pool, entirely separate from
+// sizeCap's weighed fish pool (SYSTEMS.md "Capacity: two pools, two
+// units") -- equipping a set never touches sizeCap/effectiveSizeCap
+// checks, and unlocking a species never touches setSlotsCap.
+// ---------------------------------------------------------------------------
+
+export interface SetCatalogEntry {
+  kind: string
+  title: string
+  description: string
+  effect: string
+  value: number | null
+  cost: number
+  equipped: boolean
+}
+
+export interface SetCatalogResult {
+  catalog: SetCatalogEntry[]
+  equipped: OwnedAquarium['Sets']
+  setSlotsCap: number
+}
+
+export async function listSetsForUser(
+  userId: number,
+  username: string,
+): Promise<SetCatalogResult> {
+  const tank = await getOrCreateTankForUser(userId, username)
+  const equippedKinds = new Set(tank.Sets.map((set) => set.kind))
+
+  const catalog = Object.values(SET_PIECE_CATALOG).map((config) => ({
+    ...config,
+    equipped: equippedKinds.has(config.kind),
+  }))
+
+  return { catalog, equipped: tank.Sets, setSlotsCap: tank.setSlotsCap }
+}
+
+export interface EquipSetResult {
+  aquarium: ClientAquarium
+  set: OwnedAquarium['Sets'][number]
+}
+
+export async function equipSetForUser(
+  userId: number,
+  username: string,
+  kind: string,
+): Promise<EquipSetResult> {
+  if (!isKnownSetPieceKind(kind)) {
+    throw apiError(400, `'${kind}' is not a known set piece.`)
+  }
+
+  const tank = await getOrCreateTankForUser(userId, username)
+  const equippedKinds = tank.Sets.map((set) => set.kind)
+  const config = SET_PIECE_CATALOG[kind]
+
+  if (equippedKinds.includes(kind)) {
+    throw apiError(409, `${config.title} is already equipped in your tank.`)
+  }
+  if (tank.Sets.length >= tank.setSlotsCap) {
+    throw apiError(
+      409,
+      `All ${tank.setSlotsCap} set slots are full -- unequip one first.`,
+    )
+  }
+  if (conflictsWithEquippedIdleSet(kind, equippedKinds)) {
+    throw apiError(
+      409,
+      `${config.title} does the same job as an already-equipped set (they don't stack) -- unequip that one first if you want to switch.`,
+    )
+  }
+  if (tank.coins < config.cost) {
+    throw apiError(
+      402,
+      `Equipping ${config.title} costs ${config.cost} coins; your tank only has ${tank.coins}.`,
+    )
+  }
+
+  const { aquarium, createdSet } = await prisma.$transaction(async (tx) => {
+    const createdSet = await tx.aquariumSet.create({
+      data: { aquariumId: tank.id, kind },
+      select: ownedSetSelect,
+    })
+
+    const updated = await tx.aquarium.update({
+      where: { id: tank.id },
+      data: { coins: { decrement: config.cost } },
+      select: ownedAquariumSelect,
+    })
+
+    await logEvent(tx, tank.id, 'equip-set', { kind, cost: config.cost })
+
+    return { aquarium: updated, createdSet }
+  })
+
+  return { aquarium: toClientAquarium(aquarium), set: createdSet }
+}
+
+export interface UnequipSetResult {
+  aquarium: ClientAquarium
+}
+
+export async function unequipSetForUser(
+  userId: number,
+  username: string,
+  aquariumSetId: number,
+): Promise<UnequipSetResult> {
+  const tank = await getOrCreateTankForUser(userId, username)
+  const existing = tank.Sets.find((set) => set.id === aquariumSetId)
+  if (!existing) {
+    throw apiError(
+      404,
+      `Set piece ${aquariumSetId} is not equipped in your tank.`,
+    )
+  }
+
+  // No coin refund on unequip -- equipping spent coins to occupy a scarce
+  // slot with an active build choice, same "not a refundable purchase"
+  // shape as a species unlock (SYSTEMS.md "The shop rotates; the book is
+  // forever" section covers selling FISH back; set pieces were never
+  // included in that discussion and get no analogous sell-back here).
+  const aquarium = await prisma.$transaction(async (tx) => {
+    await tx.aquariumSet.delete({ where: { id: aquariumSetId } })
+
+    const updated = await tx.aquarium.findUniqueOrThrow({
+      where: { id: tank.id },
+      select: ownedAquariumSelect,
+    })
+
+    await logEvent(tx, tank.id, 'unequip-set', { kind: existing.kind })
+
+    return updated
+  })
+
+  return { aquarium: toClientAquarium(aquarium) }
 }

--- a/server/utils/aquariumEconomy.ts
+++ b/server/utils/aquariumEconomy.ts
@@ -229,6 +229,214 @@ export function cleanDebris(debrisLevel: number, clicks = 1): number {
 }
 
 // ---------------------------------------------------------------------------
+// Set pieces -- economy.yaml `set_pieces` (cthulhuquarium/t-026). Bonuses
+// key off fish PROPERTIES or a scarce, counted setSlotsCap slot -- never a
+// flat percentage floating free of anything to build around (SYSTEMS.md
+// "For synergy to be real, set bonuses must key off fish properties, not
+// flat buffs"). AquariumSet.kind is a free-form string, same "a new tag is
+// a data commit, not a migration" convention as Monster.behavior /
+// AquariumEvent.kind -- this catalog IS that data commit, and its `kind`
+// keys match economy.yaml's set_pieces keys exactly so the two stay
+// trivially diffable.
+//
+// Unlock costs are new here -- economy.yaml prices each EFFECT but never
+// named a coin cost for equipping one ("full authoring... is t-026's job").
+// Priced against RARITY_TIERS as an anchor rather than inventing an
+// unrelated number: a slot occupying a set is roughly as valuable as a
+// same-tier species unlock, scaled by how strong a lever the effect is.
+// Flagged for reviewer/balance-pass revisit, same discipline as
+// Aquarium.sizeCap's own "starting-point guess" doc comment.
+// ---------------------------------------------------------------------------
+
+export type SetPieceEffect =
+  | 'slots_cap_delta'
+  | 'feed_coin_rebate'
+  | 'cosmetic_only'
+  | 'rivalry_multiplier_override'
+  | 'auto_click_collectibles'
+  | 'debris_clear_per_tick'
+  | 'idle_income_bonus_fraction'
+
+// The finite set of AquariumSet.kind values this catalog actually defines.
+// Keyed as a literal union (not `Record<string, ...>`) so dot/literal-key
+// access into SET_PIECE_CATALOG below is a real required property, not an
+// index signature -- noUncheckedIndexedAccess otherwise marks every access
+// `| undefined` even though the catalog is exhaustive over this union.
+export type SetPieceKind =
+  | 'extra_species_slot'
+  | 'feeding_bonus'
+  | 'swim_speed'
+  | 'peace_ward'
+  | 'roaming_collector'
+  | 'debris_skimmer'
+  | 'idle_hoarder'
+
+export interface SetPieceConfig {
+  kind: SetPieceKind
+  title: string
+  description: string
+  effect: SetPieceEffect
+  value: number | null
+  cost: number
+}
+
+export const SET_PIECE_CATALOG: Readonly<Record<SetPieceKind, SetPieceConfig>> =
+  {
+    extra_species_slot: {
+      kind: 'extra_species_slot',
+      title: 'Pressure Valve',
+      description:
+        "Widens the tank by one size unit while equipped -- buys a little capacity with coins instead of waiting on a milestone (SYSTEMS.md's own framing).",
+      effect: 'slots_cap_delta',
+      value: 1,
+      cost: RARITY_TIERS.UNCOMMON.unlockCost,
+    },
+    feeding_bonus: {
+      kind: 'feeding_bonus',
+      title: "Larder's Favor",
+      description: 'Feeding any occupant refunds half its coin cost.',
+      effect: 'feed_coin_rebate',
+      value: 0.5,
+      cost: RARITY_TIERS.UNCOMMON.unlockCost,
+    },
+    swim_speed: {
+      kind: 'swim_speed',
+      title: 'Swift Current',
+      description:
+        'Every occupant swims noticeably faster. Purely cosmetic -- economy.yaml explicitly carries no number for this one.',
+      effect: 'cosmetic_only',
+      value: null,
+      cost: RARITY_TIERS.COMMON.unlockCost,
+    },
+    peace_ward: {
+      kind: 'peace_ward',
+      title: 'Peace Ward',
+      description:
+        "Rivalry never applies anywhere in the tank while equipped. (Rivalry itself hasn't been built yet -- t-030/a successor owns that; this equips and holds ready for when it lands, same 'schema-ready, unread yet' discipline as Monster.depth.)",
+      effect: 'rivalry_multiplier_override',
+      value: 1.0,
+      cost: RARITY_TIERS.RARE.unlockCost,
+    },
+    roaming_collector: {
+      kind: 'roaming_collector',
+      title: 'Roaming Collector',
+      description:
+        'A little automaton drifts the tank collecting coins on its own -- capped well short of full automation, and never stacks with Idle Hoarder.',
+      effect: 'auto_click_collectibles',
+      value: 0.5,
+      cost: RARITY_TIERS.RARE.unlockCost,
+    },
+    debris_skimmer: {
+      kind: 'debris_skimmer',
+      title: 'Debris Skimmer',
+      description:
+        'Passively clears a little debris every tick -- one of three deliberately co-viable routes to a clean tank, never the only one.',
+      effect: 'debris_clear_per_tick',
+      value: 2,
+      cost: RARITY_TIERS.UNCOMMON.unlockCost,
+    },
+    idle_hoarder: {
+      kind: 'idle_hoarder',
+      title: 'Idle Hoarder',
+      description:
+        'Extra income while you are away, on top of the baseline offline rate -- never total; idling still stays strictly worse than playing.',
+      effect: 'idle_income_bonus_fraction',
+      value: 0.4,
+      cost: RARITY_TIERS.RARE.unlockCost,
+    },
+  } as const
+
+export const SET_PIECE_KINDS: readonly SetPieceKind[] = Object.keys(
+  SET_PIECE_CATALOG,
+) as SetPieceKind[]
+
+// Type guard, not just a boolean check: narrows `kind` to SetPieceKind for
+// every caller that checks this before indexing SET_PIECE_CATALOG (e.g.
+// aquarium.ts's equipSetForUser) -- AquariumSet.kind itself stays a plain
+// DB string (same "a new tag is a data commit, not a migration" convention
+// as Monster.behavior), this only narrows the in-memory value after
+// validation.
+export function isKnownSetPieceKind(kind: string): kind is SetPieceKind {
+  return Object.prototype.hasOwnProperty.call(SET_PIECE_CATALOG, kind)
+}
+
+// economy.yaml's own `no_stack_idle_effects`: roaming_collector and
+// idle_hoarder are two fictions over the same underlying "bonus income
+// while away" lever, not two independently-stacking bonuses -- equipping
+// both would double it. Equip-time validation (aquarium.ts) is the primary
+// guard; idleIncomeBonusFraction below (Math.max, never sum) is the
+// belt-and-suspenders backstop in the actual math.
+export const NO_STACK_IDLE_SET_KINDS: readonly SetPieceKind[] = [
+  'roaming_collector',
+  'idle_hoarder',
+]
+
+// AquariumSet.kind values are plain DB strings (see the type guard above),
+// so these checks compare against NO_STACK_IDLE_SET_KINDS by value rather
+// than relying on Array<SetPieceKind>.includes's narrower parameter type.
+const noStackIdleKindSet: ReadonlySet<string> = new Set(NO_STACK_IDLE_SET_KINDS)
+
+export function conflictsWithEquippedIdleSet(
+  candidateKind: string,
+  equippedKinds: readonly string[],
+): boolean {
+  if (!noStackIdleKindSet.has(candidateKind)) return false
+  return equippedKinds.some(
+    (kind) => kind !== candidateKind && noStackIdleKindSet.has(kind),
+  )
+}
+
+function idleIncomeBonusFraction(equippedKinds: readonly string[]): number {
+  const fractions: number[] = []
+  if (equippedKinds.includes('roaming_collector')) {
+    fractions.push(SET_PIECE_CATALOG.roaming_collector.value ?? 0)
+  }
+  if (equippedKinds.includes('idle_hoarder')) {
+    fractions.push(SET_PIECE_CATALOG.idle_hoarder.value ?? 0)
+  }
+  return fractions.length > 0 ? Math.max(...fractions) : 0
+}
+
+// Matches set_pieces.debris_skimmer.value in economy.yaml, which itself
+// notes it must stay in sync with debris.clean.debris_set_clears_per_tick
+// -- kept as one named constant here rather than two so the two can't drift
+// apart inside this file the way the YAML warns about across files.
+const DEBRIS_SKIMMER_CLEARS_PER_TICK =
+  SET_PIECE_CATALOG.debris_skimmer.value ?? 0
+
+// extra_species_slot (economy.yaml set_pieces.extra_species_slot): a
+// counted number of equipped slots that grant a flat sizeCap bonus each.
+// Duplicates of the same kind aren't offered by the equip flow today (each
+// kind equips at most once, aquarium.ts), so this is always 0 or
+// SET_PIECE_CATALOG.extra_species_slot.value in practice -- written as a
+// count rather than a boolean so it stays correct if that rule ever
+// relaxes.
+export function effectiveSizeCap(
+  baseSizeCap: number,
+  equippedKinds: readonly string[],
+): number {
+  const count = equippedKinds.filter(
+    (kind) => kind === 'extra_species_slot',
+  ).length
+  return baseSizeCap + count * (SET_PIECE_CATALOG.extra_species_slot.value ?? 0)
+}
+
+// feeding_bonus (economy.yaml set_pieces.feeding_bonus): feeding refunds a
+// fraction of that feed's own coin cost as a bonus payout. Floored, same
+// no-fabricated-coins discipline as settleTick's own rounding.
+export function feedCoinRebate(
+  cost: number,
+  equippedKinds: readonly string[],
+): number {
+  if (!equippedKinds.includes('feeding_bonus')) return 0
+  return Math.floor(cost * (SET_PIECE_CATALOG.feeding_bonus.value ?? 0))
+}
+
+export function isSwimSpeedActive(equippedKinds: readonly string[]): boolean {
+  return equippedKinds.includes('swim_speed')
+}
+
+// ---------------------------------------------------------------------------
 // Offline income -- economy.yaml `offline_income`
 // ---------------------------------------------------------------------------
 
@@ -270,6 +478,10 @@ export interface TickSettlementInput {
   now: Date
   debrisLevel: number
   fish: readonly TickFishState[]
+  // cthulhuquarium/t-026: AquariumSet.kind values currently equipped in the
+  // tank. Optional/defaults to none so every pre-t-026 caller (and any test
+  // that doesn't care about sets) keeps identical behavior.
+  equippedSetKinds?: readonly string[]
 }
 
 export interface TickSettlementResult {
@@ -322,6 +534,8 @@ export function settleTick(input: TickSettlementInput): TickSettlementResult {
 
   const ticksProcessed = Math.min(elapsedTicks, MAX_ACCRUAL_TICKS)
   const occupantCount = input.fish.length
+  const equippedSetKinds = input.equippedSetKinds ?? []
+  const debrisSkimmerActive = equippedSetKinds.includes('debris_skimmer')
 
   let debrisLevel = input.debrisLevel
   let grossProduction = 0
@@ -354,6 +568,17 @@ export function settleTick(input: TickSettlementInput): TickSettlementResult {
       DEBRIS_RANGE.max,
       debrisLevel + occupantCount * DEBRIS_ACCRUAL_PER_OCCUPANT_PER_TICK,
     )
+    // debris_skimmer (cthulhuquarium/t-026, economy.yaml
+    // set_pieces.debris_skimmer): one of the three deliberately co-viable
+    // debris routes (SYSTEMS.md), passive and weaker than a manual click
+    // spree -- it only ever partially offsets accrual, never zeroes it out
+    // on its own for an occupied tank producing debris faster than 2/tick.
+    if (debrisSkimmerActive) {
+      debrisLevel = Math.max(
+        DEBRIS_RANGE.min,
+        debrisLevel - DEBRIS_SKIMMER_CLEARS_PER_TICK,
+      )
+    }
   }
 
   // Math.floor, not Math.round, on both of these: rounding UP is
@@ -364,8 +589,20 @@ export function settleTick(input: TickSettlementInput): TickSettlementResult {
   // approximate it). Flooring means a fractional remainder is only ever
   // lost, never fabricated, regardless of how a client chunks its calls --
   // the server never pays out more than the elapsed time actually earned.
+  //
+  // idle_hoarder / roaming_collector (cthulhuquarium/t-026): both are
+  // "extra income while away" set pieces that economy.yaml explicitly
+  // marks non-stacking (no_stack_idle_effects) -- idleIncomeBonusFraction
+  // takes the MAX of whichever is equipped, never the sum, as a
+  // belt-and-suspenders backstop alongside the equip-time rejection in
+  // aquarium.ts. Multiplies the already-discounted offline rate rather
+  // than adding a second flat rate, so the hard "never 1.0, idling stays
+  // worse than playing" ceiling (SYSTEMS.md #3) holds even at both this
+  // multiplier's max and OFFLINE_INCOME_RATE_MULTIPLIER's current value.
   const coinsEarned = Math.floor(
-    grossProduction * OFFLINE_INCOME_RATE_MULTIPLIER,
+    grossProduction *
+      OFFLINE_INCOME_RATE_MULTIPLIER *
+      (1 + idleIncomeBonusFraction(equippedSetKinds)),
   )
 
   return {

--- a/stores/cthulhuquariumTankStore.ts
+++ b/stores/cthulhuquariumTankStore.ts
@@ -48,6 +48,14 @@ export interface TankStock {
   Monster: TankMonster
 }
 
+// cthulhuquarium/t-026: one equipped set piece, as returned in Tank.Sets and
+// by the /api/aquarium/sets endpoints.
+export interface TankSet {
+  id: number
+  kind: string
+  equippedAt: string
+}
+
 export interface Tank {
   id: number
   slug: string
@@ -58,11 +66,29 @@ export interface Tank {
   lastTickAt: string | null
   setSlotsCap: number
   sizeCap: number
+  // Server-computed sizeCap + any equipped extra_species_slot bonus
+  // (server/utils/aquariumEconomy.ts's effectiveSizeCap) -- this is what
+  // the unlock panel should check capacity against, not the raw sizeCap.
+  effectiveSizeCap: number
   debrisLevel: number
   lastCleanedAt: string | null
   createdAt: string
   updatedAt: string | null
   Stock: TankStock[]
+  Sets: TankSet[]
+}
+
+// cthulhuquarium/t-026: one catalog entry from GET /api/aquarium/sets,
+// static config (aquariumEconomy.ts's SET_PIECE_CATALOG) plus this tank's
+// own equipped flag.
+export interface SetCatalogEntry {
+  kind: string
+  title: string
+  description: string
+  effect: string
+  value: number | null
+  cost: number
+  equipped: boolean
 }
 
 export interface CatalogEntry {
@@ -100,7 +126,23 @@ interface FeedResponse {
   aquarium: Tank
   aquariumStockId: number
   cost: number
+  rebate: number
   hunger: number
+}
+
+interface SetCatalogResponse {
+  catalog: SetCatalogEntry[]
+  equipped: TankSet[]
+  setSlotsCap: number
+}
+
+interface EquipSetResponse {
+  aquarium: Tank
+  set: TankSet
+}
+
+interface UnequipSetResponse {
+  aquarium: Tank
 }
 
 interface CleanResponse {
@@ -192,12 +234,25 @@ export const useCthulhuquariumTankStore = defineStore(
     // bestiary later can't retrigger it.
     const bestiaryJustCompleted = ref(false)
 
+    // cthulhuquarium/t-026's set-piece catalog. Loaded lazily, same
+    // collapsed-panel-until-opened pattern as the bestiary above -- it
+    // isn't part of the tank's own poll loop.
+    const setCatalog = ref<SetCatalogEntry[]>([])
+    const setCatalogLoading = ref(false)
+
     const stock = computed(() => tank.value?.Stock ?? [])
     const coins = computed(() => tank.value?.coins ?? 0)
     const occupantSize = computed(() =>
       stock.value.reduce((sum, entry) => sum + (entry.Monster.size ?? 1), 0),
     )
-    const sizeCap = computed(() => tank.value?.sizeCap ?? 0)
+    // effectiveSizeCap folds in any equipped extra_species_slot bonus; falls
+    // back to the raw sizeCap for the brief window before the tank has
+    // loaded (tank.value is null) rather than reading 0.
+    const sizeCap = computed(
+      () => tank.value?.effectiveSizeCap ?? tank.value?.sizeCap ?? 0,
+    )
+    const equippedSets = computed(() => tank.value?.Sets ?? [])
+    const setSlotsCap = computed(() => tank.value?.setSlotsCap ?? 0)
     const debrisLevel = computed(() => tank.value?.debrisLevel ?? 0)
     const hungriest = computed<TankStock | null>(() =>
       stock.value.reduce<TankStock | null>(
@@ -368,6 +423,53 @@ export const useCthulhuquariumTankStore = defineStore(
       bestiaryJustCompleted.value = false
     }
 
+    // cthulhuquarium/t-026: the build layer. loadSets() is called lazily by
+    // the game component the first time its panel opens, same as
+    // loadBestiary() above.
+    async function loadSets(): Promise<void> {
+      setCatalogLoading.value = true
+      try {
+        const res = await performFetch<SetCatalogResponse>('/api/aquarium/sets')
+        if (res.success && res.data) setCatalog.value = res.data.catalog
+      } finally {
+        setCatalogLoading.value = false
+      }
+    }
+
+    async function equipSet(kind: string): Promise<boolean> {
+      const res = await performFetch<EquipSetResponse>(
+        '/api/aquarium/sets/equip',
+        {
+          method: 'POST',
+          body: JSON.stringify({ kind }),
+        },
+      )
+      if (res.success && res.data) {
+        tank.value = res.data.aquarium
+        if (setCatalog.value.length) await loadSets()
+        return true
+      }
+      error.value = res.message || 'Could not equip that set piece.'
+      return false
+    }
+
+    async function unequipSet(aquariumSetId: number): Promise<boolean> {
+      const res = await performFetch<UnequipSetResponse>(
+        '/api/aquarium/sets/unequip',
+        {
+          method: 'POST',
+          body: JSON.stringify({ aquariumSetId }),
+        },
+      )
+      if (res.success && res.data) {
+        tank.value = res.data.aquarium
+        if (setCatalog.value.length) await loadSets()
+        return true
+      }
+      error.value = res.message || 'Could not unequip that set piece.'
+      return false
+    }
+
     function clearOfflineEarnings(): void {
       offlineEarnings.value = 0
       offlineTicksProcessed.value = 0
@@ -395,6 +497,10 @@ export const useCthulhuquariumTankStore = defineStore(
       bestiaryTotalCount,
       bestiaryLoading,
       bestiaryJustCompleted,
+      equippedSets,
+      setSlotsCap,
+      setCatalog,
+      setCatalogLoading,
       load,
       settleTick,
       loadCatalog,
@@ -406,6 +512,9 @@ export const useCthulhuquariumTankStore = defineStore(
       clearOfflineEarnings,
       loadBestiary,
       dismissBestiaryCompletion,
+      loadSets,
+      equipSet,
+      unequipSet,
     }
   },
 )

--- a/utils/scripts/verifyAquariumEconomy.test.ts
+++ b/utils/scripts/verifyAquariumEconomy.test.ts
@@ -12,12 +12,19 @@
 import assert from 'node:assert/strict'
 
 import {
+  conflictsWithEquippedIdleSet,
   DEBRIS_CLICK_CLEARS,
   DEBRIS_RANGE,
+  effectiveSizeCap,
+  feedCoinRebate,
+  isKnownSetPieceKind,
   MAX_ACCRUAL_TICKS,
   MAX_CLEAN_CLICKS_PER_REQUEST,
+  NO_STACK_IDLE_SET_KINDS,
   OFFLINE_INCOME_RATE_MULTIPLIER,
   RARITY_TIERS,
+  SET_PIECE_CATALOG,
+  SET_PIECE_KINDS,
   TICK_SECONDS,
   cleanDebris,
   debrisMultiplier,
@@ -463,6 +470,166 @@ console.log(
 
 console.log(
   "✅ settleTick: per-species yieldPerTick/tickIntervalSeconds overrides change that fish's production as expected",
+)
+
+// --- set pieces (cthulhuquarium/t-026): catalog shape, capacity/rebate math,
+// idle-bonus non-stacking, debris_skimmer in settleTick -------------------
+
+// The catalog's keys must match economy.yaml's set_pieces keys exactly (see
+// aquariumEconomy.ts's own header comment on why).
+assert.deepEqual(
+  [...SET_PIECE_KINDS].sort(),
+  [
+    'debris_skimmer',
+    'extra_species_slot',
+    'feeding_bonus',
+    'idle_hoarder',
+    'peace_ward',
+    'roaming_collector',
+    'swim_speed',
+  ].sort(),
+)
+for (const kind of SET_PIECE_KINDS) {
+  assert.equal(SET_PIECE_CATALOG[kind].kind, kind)
+  assert.ok(SET_PIECE_CATALOG[kind].cost > 0)
+}
+assert.equal(isKnownSetPieceKind('extra_species_slot'), true)
+assert.equal(isKnownSetPieceKind('not-a-real-set'), false)
+
+console.log(
+  '✅ SET_PIECE_CATALOG: every economy.yaml set_pieces key is present, priced, self-consistent',
+)
+
+// extra_species_slot: +1 per equipped copy (economy.yaml value: 1).
+assert.equal(effectiveSizeCap(10, []), 10)
+assert.equal(effectiveSizeCap(10, ['extra_species_slot']), 11)
+assert.equal(effectiveSizeCap(10, ['swim_speed', 'debris_skimmer']), 10)
+
+console.log(
+  '✅ effectiveSizeCap: extra_species_slot adds exactly its configured delta, other kinds are no-ops',
+)
+
+// feeding_bonus: refunds 50% of cost, floored, only when equipped.
+assert.equal(feedCoinRebate(100, []), 0)
+assert.equal(feedCoinRebate(100, ['feeding_bonus']), 50)
+assert.equal(
+  feedCoinRebate(101, ['feeding_bonus']),
+  50,
+  'rebate floors rather than rounds, same anti-fabrication discipline as settleTick',
+)
+
+console.log(
+  '✅ feedCoinRebate: 50% refund only with feeding_bonus equipped, floored',
+)
+
+// no_stack_idle_effects: roaming_collector and idle_hoarder conflict with
+// each other but nothing else conflicts with anything.
+assert.deepEqual([...NO_STACK_IDLE_SET_KINDS].sort(), [
+  'idle_hoarder',
+  'roaming_collector',
+])
+assert.equal(
+  conflictsWithEquippedIdleSet('idle_hoarder', ['roaming_collector']),
+  true,
+)
+assert.equal(
+  conflictsWithEquippedIdleSet('roaming_collector', ['idle_hoarder']),
+  true,
+)
+assert.equal(
+  conflictsWithEquippedIdleSet('idle_hoarder', ['idle_hoarder']),
+  false,
+  'a kind never conflicts with itself -- equip-time duplicate rejection is a separate check',
+)
+assert.equal(
+  conflictsWithEquippedIdleSet('debris_skimmer', ['idle_hoarder']),
+  false,
+  'a non-idle set never conflicts with anything',
+)
+
+console.log(
+  '✅ conflictsWithEquippedIdleSet: only the roaming_collector/idle_hoarder pair conflicts',
+)
+
+// settleTick: debris_skimmer clears debris passively each tick, on top of
+// (not instead of) accrual -- and never undercuts manual clicking's larger
+// single clear (SYSTEMS.md's three-co-viable-routes rule).
+{
+  const start = new Date('2026-08-25T00:00:00Z')
+  const now = new Date(start.getTime() + TICK_SECONDS * 1000)
+  const withSkimmer = settleTick({
+    lastTickAt: start,
+    now,
+    debrisLevel: 50,
+    fish: [{ id: 1, rarity: 'COMMON', hunger: 100 }],
+    equippedSetKinds: ['debris_skimmer'],
+  })
+  const withoutSkimmer = settleTick({
+    lastTickAt: start,
+    now,
+    debrisLevel: 50,
+    fish: [{ id: 1, rarity: 'COMMON', hunger: 100 }],
+  })
+  assert.ok(
+    withSkimmer.newDebrisLevel < withoutSkimmer.newDebrisLevel,
+    'an equipped debris_skimmer must leave the tank cleaner than an otherwise-identical tank without one',
+  )
+  assert.ok(
+    withSkimmer.newDebrisLevel >= DEBRIS_RANGE.min,
+    'debris_skimmer never pushes debris below its floor',
+  )
+}
+
+// settleTick: idle_hoarder/roaming_collector scale coinsEarned up, and the
+// two never stack even if both are somehow passed at once (belt-and-
+// suspenders backstop behind the equip-time rejection).
+{
+  const start = new Date('2026-08-25T00:00:00Z')
+  const longNow = new Date(start.getTime() + 50 * TICK_SECONDS * 1000)
+  const base = settleTick({
+    lastTickAt: start,
+    now: longNow,
+    debrisLevel: 0,
+    fish: [{ id: 1, rarity: 'COMMON', hunger: 100 }],
+  })
+  const hoarder = settleTick({
+    lastTickAt: start,
+    now: longNow,
+    debrisLevel: 0,
+    fish: [{ id: 1, rarity: 'COMMON', hunger: 100 }],
+    equippedSetKinds: ['idle_hoarder'],
+  })
+  const collector = settleTick({
+    lastTickAt: start,
+    now: longNow,
+    debrisLevel: 0,
+    fish: [{ id: 1, rarity: 'COMMON', hunger: 100 }],
+    equippedSetKinds: ['roaming_collector'],
+  })
+  const bothIdleKinds = settleTick({
+    lastTickAt: start,
+    now: longNow,
+    debrisLevel: 0,
+    fish: [{ id: 1, rarity: 'COMMON', hunger: 100 }],
+    equippedSetKinds: ['idle_hoarder', 'roaming_collector'],
+  })
+  assert.ok(
+    hoarder.coinsEarned > base.coinsEarned,
+    'idle_hoarder must earn strictly more than the unequipped baseline over a long enough window',
+  )
+  assert.ok(
+    collector.coinsEarned > hoarder.coinsEarned,
+    "roaming_collector's larger configured fraction (0.5 vs idle_hoarder's 0.4) must earn more over a long enough window",
+  )
+  assert.equal(
+    bothIdleKinds.coinsEarned,
+    collector.coinsEarned,
+    'passing both no_stack_idle_effects kinds at once must earn exactly what the LARGER single one alone earns (Math.max) -- never their sum',
+  )
+}
+
+console.log(
+  '✅ settleTick: debris_skimmer and idle_hoarder/roaming_collector apply correctly and never double-stack',
 )
 
 // --- PROPERTY TEST: coinsEarned is always a non-negative integer, hunger is


### PR DESCRIPTION
### Task
`cthulhuquarium/t-026`: Set pieces — the build layer and its synergies (kind: software)

### What changed / what I produced
`data/economy.yaml` (conductor repo) already fully specified the `set_pieces` section for all seven kinds from Silas's seed list — this task wires those numbers into real code:

- **`server/utils/aquariumEconomy.ts`**: `SET_PIECE_CATALOG` (7 kinds, matching economy.yaml's keys exactly), plus pure math: `effectiveSizeCap`, `feedCoinRebate`, `conflictsWithEquippedIdleSet`, `isKnownSetPieceKind`. `settleTick` now takes an `equippedSetKinds` param and applies `debris_skimmer`'s passive per-tick clear and the `idle_hoarder`/`roaming_collector` income-bonus multiplier (Math.max, never sum — enforces `no_stack_idle_effects`).
- **`server/utils/aquarium.ts`**: `Aquarium.Sets` now selected everywhere; new `ClientAquarium` type carries a server-computed `effectiveSizeCap`. New `listSetsForUser`/`equipSetForUser`/`unequipSetForUser`. `purchaseSpeciesForUser`'s capacity check now reads `effectiveSizeCap`. `feedFishForUser` applies `feeding_bonus`'s rebate.
- **`server/api/aquarium/sets/{index.get,equip.post,unequip.post}.ts`**: new routes, same conventions as the existing `catalog`/`purchase`/`feed` routes.
- **`stores/cthulhuquariumTankStore.ts`**: `Tank.Sets`/`effectiveSizeCap`, `setCatalog` state, `loadSets`/`equipSet`/`unequipSet` actions.
- **`components/cthulhuquarium/cthulhuquarium-game.vue`**: a collapsible "Set pieces" panel (same pattern as the Bestiary panel) to equip/unequip within `setSlotsCap`; `swim_speed` hooked live into the canvas swim velocity (cosmetic only, no economy number, per economy.yaml).

Per-set implementation notes:
- `extra_species_slot`: +1 `effectiveSizeCap` while equipped. This is **not** a coin-purchased capacity upgrade (which economy.yaml explicitly bars) — it's a scarce, revocable set-slot bonus; unequip it and the bonus is gone. Documented inline for reviewer sign-off.
- `feeding_bonus`: feeding refunds 50% of that feed's own coin cost (floored).
- `swim_speed`: cosmetic only per economy.yaml (`value: null`) — 1.4x swim-velocity multiplier, live-reactive to equip/unequip.
- `peace_ward`: rivalry doesn't exist yet (t-030, unbuilt) — this equips and holds ready for when it lands, same "schema-ready, unread yet" discipline as `Monster.depth`. Flagging clearly: **no economic effect today.**
- `roaming_collector` / `idle_hoarder`: economy.yaml's own `no_stack_idle_effects` treats these as two skins over one "extra income while away" lever. Enforced at equip time (409 if the other is already equipped) and as a `Math.max`-not-sum backstop inside `settleTick` itself.
- `debris_skimmer`: passive `-2` debris/tick, one of the three deliberately co-viable debris routes (manual click / this set / the still-unbuilt Sexton).

Equip costs are new — economy.yaml priced each *effect* but never named a coin cost for equipping one ("full authoring... is t-026's job"). Priced against `RARITY_TIERS` as an anchor (COMMON/UNCOMMON/RARE tier costs by how strong a lever the effect is). Flagged for a balance-pass revisit, same as `Aquarium.sizeCap`'s own "starting-point guess" precedent.

No schema migration needed — `AquariumSet` (kind/aquariumId/equippedAt) and `Aquarium.setSlotsCap`/`Sets` relation already existed from t-025/t-032's schema work.

### How I verified
- `npx tsx utils/scripts/verifyAquariumEconomy.test.ts` — full suite passes, including new coverage for the catalog shape, `effectiveSizeCap`, `feedCoinRebate`, non-stacking, and `debris_skimmer`/idle-bonus behavior inside `settleTick`, plus the pre-existing 5000-iteration property test.
- `npx eslint` on all changed files — clean.
- `npx vue-tsc --noEmit` — clean, full repo.
- `npx prettier --check` on all changed files — clean.
- `npm run test:layout-contract` — holds, 0 new violations (an unrelated pre-existing `video-lora-picker.vue` ratchet improvement appears in the output, untouched by this diff).

### Stakes
`reversible`

### Flags for Reviewer
- `peace_ward` is genuinely inert today (rivalry isn't built) — confirm that's an acceptable "equip now, activates later" shape rather than holding this task until t-030 lands.
- `extra_species_slot`'s mapping onto `effectiveSizeCap` (the weighed fish pool) rather than `setSlotsCap` (the counted set pool) is an interpretation call — "allows an extra species" reads as fish capacity to me, not set capacity. Flagging for confirmation.
- Equip costs (priced against `RARITY_TIERS`) are new numbers with no economy.yaml precedent — a balance pass may want to revisit them.

### Kaizen suggestion
`roaming_collector`'s own economy.yaml note calls for it to "visibly move around the tank" as a distinct automaton sprite — this PR treats it as economically identical to `idle_hoarder` (both just scale the settled income) but does not add a distinct moving sprite for it, since there's no existing "drifting collectible" visual mechanic to hook into. A follow-up task could add a small roaming automaton sprite to the canvas renderer purely for flavor.

### Notes for reviewer
`data/economy.yaml`'s `set_pieces` section (conductor repo) is the source of truth this PR mirrors — every number traces back to it, same discipline as the rest of `aquariumEconomy.ts`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQRB3MH3ip1NP1V3aEnNz5)_