### PR TITLE
cthulhuquarium/t-031: The Ichthyonomicon -- best-stats record, re-order, ownership tracking

### DIFF
--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -209,12 +209,14 @@
         </div>
       </div>
 
-      <!-- The bestiary (cthulhuquarium/t-024): the collection is the actual
-           progression spine now ("ENDLESS BUT THE BESTIARY COMPLETES"), so it
-           gets a view worth returning to rather than living only as a side
-           effect of the unlock panel above. Collapsed by default and loaded
-           on first open -- it's the completionist book, not part of the
-           tank's own poll loop. -->
+      <!-- The Ichthyonomicon (cthulhuquarium/t-024, extended by t-031): the
+           collection is the actual progression spine now ("ENDLESS BUT THE
+           BESTIARY COMPLETES"), so it gets a view worth returning to rather
+           than living only as a side effect of the unlock panel above.
+           Collapsed by default and loaded on first open -- it's the
+           completionist book, not part of the tank's own poll loop. Formal
+           name on the cover; Charlotte and Wilbur would just call it "the
+           book" (SYSTEMS.md). -->
       <div class="flex flex-col gap-2 border-t border-base-300 pt-3">
         <button
           type="button"
@@ -222,7 +224,7 @@
           @click="onToggleBestiary"
         >
           <span class="text-xs font-black uppercase tracking-wide opacity-60">
-            Bestiary
+            The Ichthyonomicon
             <span v-if="tankStore.bestiaryTotalCount > 0" class="opacity-80">
               — {{ tankStore.bestiaryCollectedCount }}/{{
                 tankStore.bestiaryTotalCount
@@ -240,7 +242,7 @@
 
         <template v-if="showBestiary">
           <p v-if="tankStore.bestiaryLoading" class="text-xs opacity-60">
-            Reading the codex…
+            Reading the book…
           </p>
           <div
             v-else
@@ -272,10 +274,33 @@
                       : 'Not yet observed.'
                   }}
                 </p>
+                <!-- Best-individual-seen record (t-031). Stays hidden until
+                     cthulhuquarium/t-029 (genetics) rolls a first individual
+                     -- there is nothing honest to show before then. -->
+                <p
+                  v-if="entry.bestStats"
+                  class="mt-1 text-[0.65rem] uppercase tracking-wide opacity-60"
+                >
+                  Best seen: {{ formatBestStats(entry.bestStats) }}
+                </p>
+                <!-- Re-order (t-031): the book remembers a species whether
+                     or not it's currently in the tank, so it's re-orderable
+                     from here rather than access being tied to today's
+                     rotating shop stock. Always equal to "already owned"
+                     until t-030 ships a sell path -- this button simply
+                     never renders yet in practice. -->
+                <button
+                  v-if="entry.collected && !entry.currentlyOwned"
+                  type="button"
+                  class="btn btn-outline btn-xs min-h-11 mt-1"
+                  @click="tankStore.unlock(entry.id)"
+                >
+                  Re-order
+                </button>
               </div>
             </div>
             <p v-if="!tankStore.bestiary.length" class="text-xs opacity-60">
-              Nothing in the bestiary yet.
+              Nothing in the book yet.
             </p>
           </div>
         </template>
@@ -505,6 +530,7 @@ import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import {
   TANK_POLL_INTERVAL_MS,
   useCthulhuquariumTankStore,
+  type BestiaryStatBlock,
   type CatalogEntry,
   type SetCatalogEntry,
   type TankStock,
@@ -694,6 +720,25 @@ function canUnlock(entry: CatalogEntry): boolean {
     tankStore.coins >= entry.cost &&
     tankStore.occupantSize + (entry.size ?? 1) <= tankStore.sizeCap
   )
+}
+
+// t-031: compact "best seen" line for the Ichthyonomicon. Only ever called
+// with a non-null block (the template guards on `entry.bestStats`), so a
+// still-null individual stat here means "never recorded," not "zero."
+const BEST_STAT_LABELS: Record<keyof BestiaryStatBlock, string> = {
+  charm: 'CHA',
+  empathy: 'EMP',
+  grace: 'GRA',
+  luck: 'LUC',
+  might: 'MGT',
+  wits: 'WIT',
+}
+
+function formatBestStats(stats: BestiaryStatBlock): string {
+  return (Object.keys(BEST_STAT_LABELS) as Array<keyof BestiaryStatBlock>)
+    .filter((key) => stats[key] != null)
+    .map((key) => `${BEST_STAT_LABELS[key]} ${stats[key]}`)
+    .join(' · ')
 }
 
 function spawnSwimmer(stock: TankStock): Swimmer {

--- a/server/utils/aquarium.ts
+++ b/server/utils/aquarium.ts
@@ -27,10 +27,12 @@ import {
   isKnownSetPieceKind,
   justCompletedBestiary as computeJustCompletedBestiary,
   MAX_CLEAN_CLICKS_PER_REQUEST,
+  mergeBestStats,
   SET_PIECE_CATALOG,
   settleTick,
   unlockCost,
 } from './aquariumEconomy'
+import type { StatBlock } from './aquariumEconomy'
 
 function apiError(statusCode: number, message: string): Error {
   const error = new Error(message) as Error & { statusCode: number }
@@ -417,7 +419,8 @@ export async function cleanTankForUser(
 }
 
 // ---------------------------------------------------------------------------
-// Bestiary -- the completionist codex (cthulhuquarium/t-024). AquariumCodexEntry
+// The Ichthyonomicon -- the completionist codex, and the record that makes
+// selling safe (cthulhuquarium/t-024, extended by t-031). AquariumCodexEntry
 // is the permanent "you found this" record: unlike AquariumStock (what's
 // CURRENTLY in the tank), a codex row is never deleted, so a species stays
 // collected even if the fish is later removed from the tank or the species
@@ -426,6 +429,16 @@ export async function cleanTankForUser(
 // therefore the UNION of the currently-active bible and every species this
 // user has ever collected, never the active set alone: retiring an
 // already-collected species must never shrink the count.
+//
+// t-031 adds two things on top of t-024's collected/fieldNote view: the
+// book's own best-individual-stats record (AquariumCodexEntry.bestStat*,
+// t-032's columns -- see mergeBestStats in aquariumEconomy.ts) and a
+// currentlyOwned flag distinct from collected, so a species can be "in the
+// book" without being "in the tank right now." Today those are always equal
+// (there is no sell path yet -- t-030 is `waiting` on this task), but the
+// distinction is what t-030's sell-back and re-order flow needs to exist
+// safely, per this task's own note: "t-030's rotating stock and sell-back
+// are only safe because this exists."
 // ---------------------------------------------------------------------------
 
 const BESTIARY_COMPLETE_EVENT_KIND = 'bestiary-complete'
@@ -468,6 +481,14 @@ export interface BestiaryEntry {
   collected: boolean
   firstAcquiredAt: string | null
   fieldNote: string | null
+  // t-031: distinct from `collected` -- true only while a live AquariumStock
+  // row exists for this species. Always equal to `collected` until t-030
+  // ships a sell path; drives the book's re-order affordance once it does.
+  currentlyOwned: boolean
+  // t-031: the book's best-individual-seen record (AquariumCodexEntry's
+  // bestStat* columns). All null for any species until cthulhuquarium/t-029
+  // (genetics) starts rolling individual stats -- see mergeBestStats.
+  bestStats: StatBlock | null
 }
 
 export interface BestiaryResult {
@@ -494,9 +515,74 @@ function bestiaryUnionWhere(collectedIds: number[]): Prisma.MonsterWhereInput {
   }
 }
 
+const codexBestStatSelect = {
+  bestStatCharm: true,
+  bestStatEmpathy: true,
+  bestStatGrace: true,
+  bestStatLuck: true,
+  bestStatMight: true,
+  bestStatWits: true,
+} satisfies Prisma.AquariumCodexEntrySelect
+
+type CodexBestStats = Prisma.AquariumCodexEntryGetPayload<{
+  select: typeof codexBestStatSelect
+}>
+
+function toStatBlock(row: CodexBestStats): StatBlock {
+  return {
+    charm: row.bestStatCharm,
+    empathy: row.bestStatEmpathy,
+    grace: row.bestStatGrace,
+    luck: row.bestStatLuck,
+    might: row.bestStatMight,
+    wits: row.bestStatWits,
+  }
+}
+
+function isAllNull(stats: StatBlock): boolean {
+  return Object.values(stats).every((value) => value == null)
+}
+
+// The observed side of every mergeBestStats call in this file today -- see
+// the call site's own comment for why that's provably correct, not a stub.
+const NULL_STAT_BLOCK: StatBlock = {
+  charm: null,
+  empathy: null,
+  grace: null,
+  luck: null,
+  might: null,
+  wits: null,
+}
+
+// Plain scalar shape, not a Prisma *Input type -- these six columns are
+// identical between the checked/unchecked create and update input variants,
+// so tying this to one of them would fight whichever call site spreads it
+// alongside userId/monsterId (unchecked-style FK scalars).
+interface CodexBestStatColumns {
+  bestStatCharm: number | null
+  bestStatEmpathy: number | null
+  bestStatGrace: number | null
+  bestStatLuck: number | null
+  bestStatMight: number | null
+  bestStatWits: number | null
+}
+
+function fromStatBlock(stats: StatBlock): CodexBestStatColumns {
+  return {
+    bestStatCharm: stats.charm,
+    bestStatEmpathy: stats.empathy,
+    bestStatGrace: stats.grace,
+    bestStatLuck: stats.luck,
+    bestStatMight: stats.might,
+    bestStatWits: stats.wits,
+  }
+}
+
 function toBestiaryEntry(
   monster: BestiaryMonster,
   firstAcquiredAt: Date | null,
+  bestStats: StatBlock | null,
+  currentlyOwned: boolean,
 ): BestiaryEntry {
   const collected = firstAcquiredAt !== null
   return {
@@ -514,19 +600,39 @@ function toBestiaryEntry(
     collected,
     firstAcquiredAt: firstAcquiredAt ? firstAcquiredAt.toISOString() : null,
     fieldNote: collected ? monster.fieldNote : null,
+    // Never owned means never bought a live fish either -- collected can
+    // still be true here in the future via a non-purchase route (e.g. a
+    // hatched offspring), so this doesn't just mirror `collected`.
+    currentlyOwned: collected && currentlyOwned,
+    bestStats:
+      collected && bestStats && !isAllNull(bestStats) ? bestStats : null,
   }
 }
 
 export async function listBestiaryForUser(
   userId: number,
 ): Promise<BestiaryResult> {
-  const codexEntries = await prisma.aquariumCodexEntry.findMany({
-    where: { userId },
-    select: { monsterId: true, firstAcquiredAt: true },
-  })
+  const [codexEntries, ownedStock] = await Promise.all([
+    prisma.aquariumCodexEntry.findMany({
+      where: { userId },
+      select: {
+        monsterId: true,
+        firstAcquiredAt: true,
+        ...codexBestStatSelect,
+      },
+    }),
+    prisma.aquariumStock.findMany({
+      where: { Aquarium: { userId } },
+      select: { monsterId: true },
+    }),
+  ])
   const collectedAt = new Map(
     codexEntries.map((entry) => [entry.monsterId, entry.firstAcquiredAt]),
   )
+  const bestStatsByMonster = new Map(
+    codexEntries.map((entry) => [entry.monsterId, toStatBlock(entry)]),
+  )
+  const ownedMonsterIds = new Set(ownedStock.map((row) => row.monsterId))
 
   const monsters = await prisma.monster.findMany({
     where: bestiaryUnionWhere([...collectedAt.keys()]),
@@ -535,7 +641,12 @@ export async function listBestiaryForUser(
   })
 
   const data = monsters.map((monster) =>
-    toBestiaryEntry(monster, collectedAt.get(monster.id) ?? null),
+    toBestiaryEntry(
+      monster,
+      collectedAt.get(monster.id) ?? null,
+      bestStatsByMonster.get(monster.id) ?? null,
+      ownedMonsterIds.has(monster.id),
+    ),
   )
   const totalCount = data.length
   const collectedCount = data.filter((entry) => entry.collected).length
@@ -678,12 +789,27 @@ export async function purchaseSpeciesForUser(
       // call site.
       const existingEntry = await tx.aquariumCodexEntry.findUnique({
         where: { userId_monsterId: { userId, monsterId: monster.id } },
-        select: { id: true },
+        select: { id: true, ...codexBestStatSelect },
       })
+      // t-031: fold this individual's rolled stats into the book's
+      // best-ever record. createdStock above always has null stat columns
+      // today (t-029/genetics hasn't landed -- see mergeBestStats's own
+      // comment), so NULL_STAT_BLOCK is not a shortcut, it's the actual
+      // observed value; this still runs the real merge so the record is
+      // wired correctly the moment t-029 starts rolling individuals rather
+      // than needing a second pass through this call site later.
+      const mergedStats = mergeBestStats(
+        existingEntry ? toStatBlock(existingEntry) : NULL_STAT_BLOCK,
+        NULL_STAT_BLOCK,
+      )
       await tx.aquariumCodexEntry.upsert({
         where: { userId_monsterId: { userId, monsterId: monster.id } },
-        create: { userId, monsterId: monster.id },
-        update: {},
+        create: {
+          userId,
+          monsterId: monster.id,
+          ...fromStatBlock(mergedStats),
+        },
+        update: { ...fromStatBlock(mergedStats) },
       })
       const collectedCountAfter = collectedCountBefore + (existingEntry ? 0 : 1)
 

--- a/server/utils/aquariumEconomy.ts
+++ b/server/utils/aquariumEconomy.ts
@@ -645,3 +645,55 @@ export function justCompletedBestiary(
   const isComplete = collectedCountAfter >= totalCount
   return !wasComplete && isComplete
 }
+
+// ---------------------------------------------------------------------------
+// The Ichthyonomicon (cthulhuquarium/t-031) -- pure decision logic only.
+// AquariumCodexEntry.bestStat* (added by t-032) is the book's "best
+// individual seen of this species" record, independent of which fish is
+// currently in the tank or whether the species is currently owned at all.
+// Loading/persisting the actual rows is server/utils/aquarium.ts's job; this
+// stays plain arithmetic so it is unit-testable the same way as the rest of
+// this file.
+//
+// No caller rolls an individual's stats yet -- that is cthulhuquarium/t-029
+// (genetics), still `waiting` on this task's own dependency graph. Every
+// AquariumStock stat column is null until it lands, which makes every call
+// through here a provable no-op today: this wires the record now, correctly,
+// rather than leaving it for t-029 to invent from scratch, per t-031's note
+// that t-030's sell-back is "only safe because this exists."
+// ---------------------------------------------------------------------------
+
+export interface StatBlock {
+  charm: number | null
+  empathy: number | null
+  grace: number | null
+  luck: number | null
+  might: number | null
+  wits: number | null
+}
+
+const STAT_BLOCK_KEYS = [
+  'charm',
+  'empathy',
+  'grace',
+  'luck',
+  'might',
+  'wits',
+] as const satisfies readonly (keyof StatBlock)[]
+
+// Per-stat max, independently -- never a lower value replacing a higher one
+// (SYSTEMS.md's "nothing here may ever decrease" rule applies to the book's
+// best-stat record same as it does to the bestiary count). A null on either
+// side loses to whichever side has a real number; both null stays null.
+export function mergeBestStats(
+  existing: StatBlock,
+  observed: StatBlock,
+): StatBlock {
+  const merged = {} as StatBlock
+  for (const key of STAT_BLOCK_KEYS) {
+    const a = existing[key]
+    const b = observed[key]
+    merged[key] = a == null ? b : b == null ? a : Math.max(a, b)
+  }
+  return merged
+}

--- a/stores/cthulhuquariumTankStore.ts
+++ b/stores/cthulhuquariumTankStore.ts
@@ -157,11 +157,20 @@ interface PurchaseResponse {
   justCompletedBestiary: boolean
 }
 
-// The completionist codex (cthulhuquarium/t-024). A collected entry carries
-// full art and its fieldNote; an uncollected one is only ever known by name
-// and shows as a silhouette in the panel -- the server never sends its
-// fieldNote or art paths (same "the server disposes" discipline as
-// CatalogEntry above).
+// The Ichthyonomicon -- the completionist codex (cthulhuquarium/t-024,
+// extended by t-031). A collected entry carries full art and its fieldNote;
+// an uncollected one is only ever known by name and shows as a silhouette in
+// the panel -- the server never sends its fieldNote or art paths (same "the
+// server disposes" discipline as CatalogEntry above).
+export interface BestiaryStatBlock {
+  charm: number | null
+  empathy: number | null
+  grace: number | null
+  luck: number | null
+  might: number | null
+  wits: number | null
+}
+
 export interface BestiaryEntry {
   id: number
   name: string
@@ -177,6 +186,14 @@ export interface BestiaryEntry {
   collected: boolean
   firstAcquiredAt: string | null
   fieldNote: string | null
+  // t-031: distinct from `collected` -- true only while the species has a
+  // live AquariumStock row. Equal to `collected` until t-030 ships a sell
+  // path; when it isn't, the panel offers re-order instead of "not yet
+  // observed."
+  currentlyOwned: boolean
+  // t-031: the book's best-individual-seen record. Null until
+  // cthulhuquarium/t-029 (genetics) starts rolling individual stats.
+  bestStats: BestiaryStatBlock | null
 }
 
 interface BestiaryResponse {

--- a/utils/scripts/verifyAquariumEconomy.test.ts
+++ b/utils/scripts/verifyAquariumEconomy.test.ts
@@ -34,6 +34,7 @@ import {
   hungerMultiplier,
   incomePerTick,
   justCompletedBestiary,
+  mergeBestStats,
   settleTick,
   unlockCost,
 } from '../../server/utils/aquariumEconomy.js'
@@ -778,6 +779,52 @@ assert.equal(justCompletedBestiary(5, 6, 7), false)
 
 console.log(
   '✅ justCompletedBestiary: fires exactly once, on the crossing, never before or after',
+)
+
+// --- mergeBestStats: the Ichthyonomicon's best-individual-seen record ------
+// (cthulhuquarium/t-031) ------------------------------------------------
+
+const ALL_NULL = {
+  charm: null,
+  empathy: null,
+  grace: null,
+  luck: null,
+  might: null,
+  wits: null,
+}
+
+// Both sides null (t-029/genetics hasn't rolled anything yet) -- the actual
+// shape of every real call site today. Must be a true no-op.
+assert.deepEqual(mergeBestStats(ALL_NULL, ALL_NULL), ALL_NULL)
+
+// A first observation on a fresh (never-observed) record adopts the
+// observed value outright, per-stat, independently of the others.
+assert.deepEqual(mergeBestStats(ALL_NULL, { ...ALL_NULL, charm: 4, wits: 2 }), {
+  ...ALL_NULL,
+  charm: 4,
+  wits: 2,
+})
+
+// A higher observed value replaces the existing best; a lower one does not
+// -- per-stat max, never a regression (SYSTEMS.md's "nothing here may ever
+// decrease").
+assert.deepEqual(
+  mergeBestStats(
+    { ...ALL_NULL, charm: 5, grace: 8 },
+    { ...ALL_NULL, charm: 3, grace: 9 },
+  ),
+  { ...ALL_NULL, charm: 5, grace: 9 },
+)
+
+// An observed null (a stat this individual never rolled, or a future
+// partial-observation caller) never overwrites an existing recorded best.
+assert.deepEqual(mergeBestStats({ ...ALL_NULL, might: 7 }, ALL_NULL), {
+  ...ALL_NULL,
+  might: 7,
+})
+
+console.log(
+  '✅ mergeBestStats: per-stat max, independently, never regresses an existing best',
 )
 
 console.log('✅ verifyAquariumEconomy: all assertions passed')


### PR DESCRIPTION
### Task
cthulhuquarium/t-031: The Ichthyonomicon — the record that makes everything else safe (kind: software)

### What changed / what I produced
- `server/utils/aquariumEconomy.ts`: new `StatBlock` type + `mergeBestStats` pure function — per-stat max merge for `AquariumCodexEntry.bestStat*` (t-032's columns), never regressing an existing best.
- `server/utils/aquarium.ts`: `listBestiaryForUser` now returns `bestStats` (from the codex row, null until observed) and `currentlyOwned` (distinct from `collected` — checks live `AquariumStock`, always equal to `collected` until t-030 ships a sell path). The purchase transaction now folds the newly-acquired individual's stats into the codex's best-ever record via `mergeBestStats` (a provable no-op today, since t-029/genetics hasn't rolled any individual stats yet — but wired correctly now rather than needing a second pass later).
- `stores/cthulhuquariumTankStore.ts`: mirrors the extended `BestiaryEntry` shape client-side (`currentlyOwned`, `bestStats`).
- `components/cthulhuquarium/cthulhuquarium-game.vue`: panel renamed "The Ichthyonomicon" (Silas's grimoire-not-encyclopedia naming; Greek `ichthyo-` combining form checked), shows a best-stats line once one is recorded, and adds a "Re-order" button for any collected-but-not-currently-owned species. No purchase-endpoint change was needed for re-order: `purchaseSpeciesForUser`'s "already owned" check already keys off live `AquariumStock`, not the codex, so re-acquiring a previously-collected-but-since-removed species already worked — this just surfaces it from the book itself.
- `utils/scripts/verifyAquariumEconomy.test.ts`: unit tests for `mergeBestStats` (both-null no-op, first observation, max-wins, never-regresses).

### How I verified
- `npx vue-tsc --noEmit` — clean, full repo.
- `npx eslint` + `npx prettier --check` on every changed file — clean.
- `npm run test:aquarium-economy` — full suite passes, including the new `mergeBestStats` assertions and the existing 5000-iteration property test.
- `npm run test:layout-contract` — holds (0 new violations; an unrelated pre-existing `video-lora-picker.vue` ratchet improvement appears in the output, untouched by this diff).
- `git diff --stat` against `main` matches intended scope (5 files, 310/23).

### Stakes
reversible

### Flags for Reviewer
- `bestStats`/the "Re-order" button are functionally inert today (genetics/t-029 and the sell path/t-030 haven't landed), by design — this task's note explicitly asks for the record to exist *before* t-030 so the sell-back mechanic is safe from day one. Nothing here is speculative UI dead-weight; it's the same "wire the record correctly now" discipline the codex itself already used for `firstAcquiredAt`.
- Did not rename the `bestiary`/`BestiaryEntry`/`loadBestiary` identifiers or the `/api/aquarium/bestiary` route — kept the formal "Ichthyonomicon" rename to user-facing copy only, to avoid an unnecessarily wide diff across an already-shipped API surface for a naming preference.

### Kaizen suggestion
Once cthulhuquarium/t-029 (genetics) lands and starts rolling individual stats, add a call to `mergeBestStats` at whatever point an individual's stats become known (hatch, breed) beyond the purchase-time call site added here — search for other `AquariumStock` stat-writing call sites at that point, since this PR only wires the one that exists today.

### Notes for reviewer
Dependencies (`t-024`, `t-032`) were already `done` on `main` before this task was claimed; confirmed via the conductor roadmap before starting.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SMPqfrmbbQvT2a2E7Gy2gd)_