### PR TITLE
cthulhuquarium/t-048: pause tank poll/render loop when the tab is hidden

### DIFF
--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -1036,20 +1036,57 @@ function equippedSetId(kind: string): number | null {
   return tankStore.equippedSets.find((entry) => entry.kind === kind)?.id ?? null
 }
 
+// cthulhuquarium/t-048: both loops pause on a hidden tab and resume cleanly
+// on foreground. Browsers already throttle background-tab timers/rAF on
+// their own, so this isn't a functional fix -- it's the difference between
+// "the browser happens to slow this down" and "this app declares it has
+// nothing to do while hidden," which matters more once/if this ever runs
+// inside a native wrapper (t-021's mobile-packaging audit). `loop`'s own
+// delta clamp already means a stale `lastFrameAt` after a long hidden gap
+// can't simulate a giant step, but resetting it on resume (same pattern as
+// the initial kick-off below) keeps the very first frame back honest too.
+function startLoops() {
+  if (pollTimer === null) {
+    pollTimer = setInterval(pollTick, TANK_POLL_INTERVAL_MS)
+  }
+  if (frame === 0) {
+    frame = window.requestAnimationFrame((timestamp) => {
+      lastFrameAt = timestamp
+      frame = window.requestAnimationFrame(loop)
+    })
+  }
+}
+
+function stopLoops() {
+  if (frame) {
+    window.cancelAnimationFrame(frame)
+    frame = 0
+  }
+  if (pollTimer) {
+    clearInterval(pollTimer)
+    pollTimer = null
+  }
+}
+
+function handleVisibilityChange() {
+  if (document.hidden) {
+    stopLoops()
+  } else {
+    startLoops()
+  }
+}
+
 onMounted(async () => {
   await tankStore.load()
   await tankStore.loadCatalog()
   syncSwimmers()
-  pollTimer = setInterval(pollTick, TANK_POLL_INTERVAL_MS)
-  frame = window.requestAnimationFrame((timestamp) => {
-    lastFrameAt = timestamp
-    frame = window.requestAnimationFrame(loop)
-  })
+  if (!document.hidden) startLoops()
+  document.addEventListener('visibilitychange', handleVisibilityChange)
 })
 
 onBeforeUnmount(() => {
-  if (frame) window.cancelAnimationFrame(frame)
-  if (pollTimer) clearInterval(pollTimer)
+  document.removeEventListener('visibilitychange', handleVisibilityChange)
+  stopLoops()
   // A click right before navigating away should still land instead of
   // being dropped along with the debounce timer.
   tankStore.flushCleanNow()


### PR DESCRIPTION
### Task
cthulhuquarium/t-048: Pause the tank's 20s poll/render loop when the tab is hidden (kind: software)

### What changed / what I produced
- `components/cthulhuquarium/cthulhuquarium-game.vue`: extracted `startLoops()`/`stopLoops()` from the existing `onMounted`/`onBeforeUnmount` bodies (same guard-then-assign shape, no behavior change on mount/unmount) and added a `visibilitychange` listener that stops both the `TANK_POLL_INTERVAL_MS` poll and the `requestAnimationFrame` render loop on `document.hidden`, restarting them on foreground through the same "kick a first rAF frame to reset `lastFrameAt`" pattern the initial mount already used.

### How I verified
- `npx eslint` + `npx prettier --check` on the changed file — clean.
- `npx vue-tsc --noEmit` — clean, full repo.
- `npm run test:layout-contract` — holds (0 new violations; an unrelated pre-existing `video-lora-picker.vue` ratchet improvement appears in the output, untouched by this diff).
- No existing unit test covers this component's mount lifecycle (searched `utils/scripts/` and `test/` — none reference `cthulhuquarium-game`/`TANK_POLL_INTERVAL_MS`/`pollTimer`), so this is verified by type-check + lint + manual reasoning about the extracted control flow, not a new automated test.
- `git diff --stat` matches intended scope (1 file, 44/7).

### Stakes
reversible

### Flags for Reviewer
- Purely a background-CPU/battery behavior change — browsers already throttle background-tab timers/rAF on their own, so this isn't a functional bug fix, just declaring the app's own intent (per the task note, relevant once/if this ships inside a native Capacitor wrapper).
- `loop()`'s existing delta clamp (`Math.min(..., 0.1)`) already prevented a stale `lastFrameAt` from simulating a giant step after a long hidden gap; resetting `lastFrameAt` on resume is belt-and-suspenders, not a fix for an observed bug.

### Kaizen suggestion
None beyond this task's scope — it's a small, self-contained kaizen item itself (from the t-021 mobile-packaging audit).

### Notes for reviewer
No dependencies; task had no `depends_on`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SMPqfrmbbQvT2a2E7Gy2gd)_