### PR TITLE
cthulhuquarium/t-014: browsable public aquariums

### DIFF
--- a/components/conductor/aquarium-page.vue
+++ b/components/conductor/aquarium-page.vue
@@ -41,8 +41,9 @@ const config: ProjectFrontConfig = {
       'Server-backed tanks with real offline income',
       'The real play loop — server-driven feeding and species unlocks',
       'Bestiary schema shared with Ruler Hooked',
+      'Browsable public aquariums',
     ],
-    next: ['Twenty species with generated art', 'Browsable public aquariums'],
+    next: ['Twenty species with generated art'],
   },
 }
 </script>

--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -383,6 +383,37 @@
           </div>
         </template>
       </div>
+
+      <!-- Visibility (cthulhuquarium/t-014): "Each user should be viewable"
+           -- new tanks default public, and this is the one-click way to
+           change that. Read-only for visitors either way: the toggle only
+           ever writes the owner's own tank. -->
+      <div
+        class="flex flex-wrap items-center justify-between gap-2 border-t border-base-300 pt-3"
+      >
+        <label class="flex cursor-pointer items-center gap-2">
+          <input
+            type="checkbox"
+            class="toggle toggle-success toggle-sm"
+            :checked="tankStore.tank?.isPublic ?? false"
+            :disabled="visibilitySaving"
+            @change="onToggleVisibility"
+          />
+          <span class="text-xs font-bold">
+            {{ tankStore.tank?.isPublic ? 'Public tank' : 'Private tank' }}
+          </span>
+        </label>
+        <NuxtLink
+          v-if="tankStore.tank?.isPublic && username"
+          :to="`/play/aquarium/browse/${username}/${tankStore.tank.slug}`"
+          class="link text-xs opacity-70"
+        >
+          View your public page
+        </NuxtLink>
+        <NuxtLink to="/play/aquarium/browse" class="link text-xs opacity-70">
+          Browse public tanks
+        </NuxtLink>
+      </div>
     </div>
 
     <!-- The unlock reveal beat (cthulhuquarium/t-012): the field note is
@@ -536,6 +567,7 @@ import {
   type TankStock,
 } from '~/stores/cthulhuquariumTankStore'
 import { touchHitRadius } from '~/utils/aquariumTouch'
+import { useUserStore } from '~/stores/userStore'
 
 /* Fixed logical resolution; CSS scales it to the host width so the canvas
    survives phone widths without its own breakpoint logic. */
@@ -677,7 +709,10 @@ type Mote = { x: number; y: number; drift: number }
 type FeedCreature = { x: number; y: number; phase: number; lean: number }
 
 const tankStore = useCthulhuquariumTankStore()
+const userStore = useUserStore()
+const username = computed(() => userStore.username)
 const canvasRef = ref<HTMLCanvasElement | null>(null)
+const visibilitySaving = ref(false)
 
 // Display-only mirror of server/utils/aquariumEconomy.ts's TICK_SECONDS,
 // for the welcome-back panel's duration line only -- never used to compute
@@ -1021,6 +1056,16 @@ function onToggleSets() {
   showSets.value = !showSets.value
   if (showSets.value && !tankStore.setCatalog.length) {
     void tankStore.loadSets()
+  }
+}
+
+async function onToggleVisibility(event: Event): Promise<void> {
+  const next = (event.target as HTMLInputElement).checked
+  visibilitySaving.value = true
+  try {
+    await tankStore.setVisibility(next)
+  } finally {
+    visibilitySaving.value = false
   }
 }
 

--- a/pages/play/aquarium/browse/[username]/[slug].vue
+++ b/pages/play/aquarium/browse/[username]/[slug].vue
@@ -1,0 +1,220 @@
+<!-- /pages/play/aquarium/browse/[username]/[slug].vue
+     One public tank, unauthenticated, read-only (cthulhuquarium/t-014).
+     Addressed by (username, slug) together -- Aquarium.slug is unique per
+     owner, not globally (see server/utils/aquarium.ts's own comment on
+     this). Backed by GET /api/aquarium/browse/[username]/[slug]
+     (cthulhuquarium/t-009). No feeding, no clicking, no writes of any kind
+     -- this page never calls a mutating endpoint. -->
+<template>
+  <main class="kr-surface bg-base-200/40">
+    <div
+      class="kr-scroll mx-auto max-w-4xl space-y-5 px-3 py-5 sm:px-6 sm:py-8"
+    >
+      <nav>
+        <NuxtLink
+          to="/play/aquarium/browse"
+          class="btn btn-ghost btn-sm rounded-xl"
+        >
+          <Icon name="kind-icon:arrow-left" class="size-4" />
+          Public tanks
+        </NuxtLink>
+      </nav>
+
+      <div
+        v-if="loading && !tank"
+        class="grid min-h-[50vh] place-items-center rounded-3xl border border-base-300 bg-base-100"
+      >
+        <div class="text-center">
+          <span class="loading loading-ring loading-lg text-primary" />
+          <p class="mt-3 text-sm font-bold text-base-content/55">
+            Peering into the tank…
+          </p>
+        </div>
+      </div>
+
+      <div
+        v-else-if="errorMessage && !tank"
+        class="rounded-3xl border border-error/30 bg-error/10 p-8 text-center"
+      >
+        <Icon name="kind-icon:warning" class="mx-auto size-10 text-error" />
+        <p class="mt-3 text-xl font-black">Tank unavailable</p>
+        <p class="mt-2 text-sm text-base-content/65">{{ errorMessage }}</p>
+        <p class="mt-2 text-xs text-base-content/45">
+          Either this tank doesn't exist, or its owner has kept it private.
+        </p>
+      </div>
+
+      <template v-else-if="tank">
+        <header
+          class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-lg sm:p-7"
+        >
+          <div class="flex items-center gap-3">
+            <div
+              class="grid size-12 shrink-0 place-items-center overflow-hidden rounded-2xl border border-base-300 bg-base-200"
+            >
+              <img
+                v-if="tank.User.avatarImage"
+                :src="normalizeImagePath(tank.User.avatarImage)"
+                :alt="tank.User.username"
+                class="h-full w-full object-cover"
+              />
+              <Icon
+                v-else
+                name="kind-icon:user"
+                class="size-6 text-primary/60"
+              />
+            </div>
+            <div class="min-w-0">
+              <p
+                class="text-xs font-black uppercase tracking-widest text-primary"
+              >
+                @{{ tank.User.username }}'s tank
+              </p>
+              <h2 class="truncate text-2xl font-black sm:text-3xl">
+                {{ tank.title }}
+              </h2>
+            </div>
+          </div>
+          <p
+            class="mt-4 text-xs font-bold uppercase tracking-wide text-base-content/45"
+          >
+            Read-only -- visiting doesn't feed, clean, or change anything here.
+          </p>
+        </header>
+
+        <section
+          v-if="tank.Stock.length"
+          class="grid grid-cols-[repeat(auto-fit,minmax(11rem,1fr))] gap-3"
+        >
+          <div
+            v-for="entry in tank.Stock"
+            :key="entry.id"
+            class="flex items-center gap-3 rounded-2xl border border-base-300 bg-base-100 p-3 shadow-sm"
+          >
+            <kr-art-plate
+              :source="entry.Monster"
+              variant="icon"
+              shape="plate"
+              frame="thin"
+              fit="cover"
+              class="size-12 shrink-0"
+              placeholder-icon="kind-icon:fish"
+            />
+            <div class="min-w-0">
+              <p class="truncate text-sm font-bold">
+                {{ entry.nickname || entry.Monster.name }}
+              </p>
+              <p class="truncate text-xs italic opacity-60">
+                {{ entry.Monster.species || 'Unknown species' }}
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section
+          v-else
+          class="rounded-3xl border border-dashed border-base-300 bg-base-100 px-6 py-16 text-center"
+        >
+          <Icon name="kind-icon:fish" class="mx-auto size-12 text-primary/40" />
+          <p class="mt-3 text-sm text-base-content/60">
+            Nothing in this tank yet.
+          </p>
+        </section>
+      </template>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { performFetch } from '@/stores/utils'
+
+interface PublicTankMonster {
+  id: number
+  name: string
+  slug: string
+  species: string | null
+  size: number
+  icon: string | null
+  iconPath: string | null
+  cardPath: string | null
+}
+
+interface PublicTankStock {
+  id: number
+  nickname: string | null
+  hunger: number
+  mood: string | null
+  placedAt: string
+  Monster: PublicTankMonster
+}
+
+interface PublicTankOwner {
+  username: string
+  avatarImage: string | null
+}
+
+interface PublicTankDetail {
+  slug: string
+  title: string
+  coins: number
+  backgroundKey: string | null
+  debrisLevel: number
+  sizeCap: number
+  setSlotsCap: number
+  updatedAt: string
+  User: PublicTankOwner
+  Stock: PublicTankStock[]
+}
+
+const route = useRoute()
+const tank = ref<PublicTankDetail | null>(null)
+const loading = ref(false)
+const errorMessage = ref('')
+let requestSequence = 0
+
+const username = computed(() => String(route.params.username || '').trim())
+const slug = computed(() => String(route.params.slug || '').trim())
+
+useHead(() => ({
+  title: tank.value
+    ? `${tank.value.title} · @${tank.value.User.username} · Cthulhuquarium`
+    : 'Public tank · Cthulhuquarium',
+}))
+
+function normalizeImagePath(value: string): string {
+  if (value.startsWith('/') || value.startsWith('http')) return value
+  return `/images/${value}`
+}
+
+async function loadTank(): Promise<void> {
+  if (!username.value || !slug.value) return
+
+  const sequence = ++requestSequence
+  loading.value = true
+  errorMessage.value = ''
+
+  try {
+    const response = await performFetch<PublicTankDetail>(
+      `/api/aquarium/browse/${encodeURIComponent(username.value)}/${encodeURIComponent(slug.value)}`,
+    )
+
+    if (sequence !== requestSequence) return
+
+    if (!response.success || !response.data) {
+      throw new Error(response.message || 'Could not load this tank.')
+    }
+
+    tank.value = response.data
+  } catch (error: unknown) {
+    if (sequence !== requestSequence) return
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Could not load this tank.'
+  } finally {
+    if (sequence === requestSequence) loading.value = false
+  }
+}
+
+watch([username, slug], loadTank)
+onMounted(loadTank)
+</script>

--- a/pages/play/aquarium/browse/index.vue
+++ b/pages/play/aquarium/browse/index.vue
@@ -1,0 +1,203 @@
+<!-- /pages/play/aquarium/browse/index.vue
+     Public tank index (cthulhuquarium/t-014) -- unauthenticated, paginated,
+     read-only. Backed by GET /api/aquarium/browse (cthulhuquarium/t-009).
+     Only isPublic tanks ever appear here; the response already carries
+     nothing but display name + tank summary (server/utils/aquarium.ts's
+     publicAquariumSummarySelect). -->
+<template>
+  <main class="kr-surface bg-base-200/40">
+    <div
+      class="kr-scroll mx-auto max-w-5xl space-y-5 px-3 py-5 sm:px-6 sm:py-8"
+    >
+      <nav class="flex items-center justify-between gap-3">
+        <NuxtLink to="/play/aquarium" class="btn btn-ghost btn-sm rounded-xl">
+          <Icon name="kind-icon:arrow-left" class="size-4" />
+          Your tank
+        </NuxtLink>
+      </nav>
+
+      <header
+        class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-lg sm:p-7"
+      >
+        <p class="text-xs font-black uppercase tracking-[0.25em] text-primary">
+          Cthulhuquarium
+        </p>
+        <h2 class="mt-1 text-3xl font-black uppercase sm:text-4xl">
+          Public tanks
+        </h2>
+        <p class="mt-2 max-w-2xl text-sm text-base-content/65">
+          Every owner viewable, per the pitch. Read-only -- no feeding, no
+          clicking, no writes from a visitor session.
+        </p>
+      </header>
+
+      <div
+        v-if="loading && !tanks.length"
+        class="grid min-h-[40vh] place-items-center rounded-3xl border border-base-300 bg-base-100"
+      >
+        <div class="text-center">
+          <span class="loading loading-ring loading-lg text-primary" />
+          <p class="mt-3 text-sm font-bold text-base-content/55">
+            Finding public tanks…
+          </p>
+        </div>
+      </div>
+
+      <div
+        v-else-if="errorMessage && !tanks.length"
+        class="rounded-3xl border border-error/30 bg-error/10 p-8 text-center"
+      >
+        <Icon name="kind-icon:warning" class="mx-auto size-10 text-error" />
+        <p class="mt-3 text-xl font-black">Could not load public tanks</p>
+        <p class="mt-2 text-sm text-base-content/65">{{ errorMessage }}</p>
+        <button class="btn btn-error btn-sm mt-5 rounded-xl" @click="load()">
+          Try again
+        </button>
+      </div>
+
+      <div
+        v-else-if="!tanks.length"
+        class="rounded-3xl border border-dashed border-base-300 bg-base-100 px-6 py-16 text-center"
+      >
+        <Icon name="kind-icon:fish" class="mx-auto size-12 text-primary/40" />
+        <h2 class="mt-4 text-2xl font-black uppercase">Nothing public yet</h2>
+        <p class="mx-auto mt-2 max-w-xl text-sm text-base-content/60">
+          No owner has made their tank public. Yours defaults to public -- check
+          the toggle at the bottom of your own tank.
+        </p>
+      </div>
+
+      <template v-else>
+        <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <NuxtLink
+            v-for="tank in tanks"
+            :key="`${tank.User.username}/${tank.slug}`"
+            :to="`/play/aquarium/browse/${tank.User.username}/${tank.slug}`"
+            class="group flex flex-col gap-2 rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
+          >
+            <div class="flex items-center gap-3">
+              <div
+                class="grid size-10 shrink-0 place-items-center overflow-hidden rounded-xl border border-base-300 bg-base-200"
+              >
+                <img
+                  v-if="tank.User.avatarImage"
+                  :src="normalizeImagePath(tank.User.avatarImage)"
+                  :alt="tank.User.username"
+                  class="h-full w-full object-cover"
+                />
+                <Icon
+                  v-else
+                  name="kind-icon:user"
+                  class="size-5 text-primary/60"
+                />
+              </div>
+              <div class="min-w-0">
+                <p class="truncate text-sm font-black">{{ tank.title }}</p>
+                <p class="truncate text-xs text-base-content/55">
+                  @{{ tank.User.username }}
+                </p>
+              </div>
+            </div>
+            <p class="text-xs font-bold text-base-content/60">
+              {{ tank._count.Stock }}
+              {{ tank._count.Stock === 1 ? 'occupant' : 'occupants' }}
+            </p>
+          </NuxtLink>
+        </div>
+
+        <div class="flex items-center justify-between gap-3 pt-2">
+          <button
+            type="button"
+            class="btn btn-outline btn-sm rounded-xl"
+            :disabled="loading || skip <= 0"
+            @click="prevPage"
+          >
+            <Icon name="kind-icon:arrow-left" class="size-4" />
+            Newer
+          </button>
+          <p class="text-xs font-bold text-base-content/50">
+            {{ Math.min(skip + tanks.length, total) }} of {{ total }}
+          </p>
+          <button
+            type="button"
+            class="btn btn-outline btn-sm rounded-xl"
+            :disabled="loading || skip + tanks.length >= total"
+            @click="nextPage"
+          >
+            Older
+            <Icon name="kind-icon:arrow-right" class="size-4" />
+          </button>
+        </div>
+      </template>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { performFetch } from '@/stores/utils'
+import type { ApiResponse } from '@/types/api'
+
+interface PublicTankOwner {
+  username: string
+  avatarImage: string | null
+}
+
+interface PublicTankSummary {
+  slug: string
+  title: string
+  backgroundKey: string | null
+  updatedAt: string
+  User: PublicTankOwner
+  _count: { Stock: number }
+}
+
+const TAKE = 12
+
+const tanks = ref<PublicTankSummary[]>([])
+const total = ref(0)
+const skip = ref(0)
+const loading = ref(false)
+const errorMessage = ref('')
+
+useHead({ title: 'Public tanks · Cthulhuquarium' })
+
+function normalizeImagePath(value: string): string {
+  if (value.startsWith('/') || value.startsWith('http')) return value
+  return `/images/${value}`
+}
+
+async function load(): Promise<void> {
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    const response = (await performFetch<PublicTankSummary[]>(
+      `/api/aquarium/browse?take=${TAKE}&skip=${skip.value}`,
+    )) as ApiResponse<PublicTankSummary[]> & {
+      meta?: { take: number; skip: number; total: number }
+    }
+    if (!response.success || !response.data) {
+      throw new Error(response.message || 'Could not load public tanks.')
+    }
+    tanks.value = response.data
+    total.value = response.meta?.total ?? response.data.length
+  } catch (error: unknown) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Could not load public tanks.'
+  } finally {
+    loading.value = false
+  }
+}
+
+function nextPage(): void {
+  skip.value += TAKE
+  void load()
+}
+
+function prevPage(): void {
+  skip.value = Math.max(0, skip.value - TAKE)
+  void load()
+}
+
+onMounted(load)
+</script>

--- a/server/api/aquarium/visibility.post.ts
+++ b/server/api/aquarium/visibility.post.ts
@@ -1,0 +1,55 @@
+// /server/api/aquarium/visibility.post.ts
+//
+// One-click public/private toggle for the authenticated user's own tank
+// (cthulhuquarium/t-014's "make the toggle obvious and one click"). Body:
+// `{ isPublic: boolean }`. Never affects anyone else's tank -- always reads
+// and writes against the caller's own aquarium, same as feed/clean/purchase.
+
+import { defineEventHandler, readBody, createError } from 'h3'
+import { errorHandler } from '../../utils/error'
+import { requireApiUser } from '../../utils/authGuard'
+import { setTankVisibilityForUser } from '../../utils/aquarium'
+
+export default defineEventHandler(async (event) => {
+  let response
+
+  try {
+    const { user } = await requireApiUser(event)
+    const body = await readBody(event).catch(() => null)
+
+    if (
+      !body ||
+      typeof body !== 'object' ||
+      typeof body.isPublic !== 'boolean'
+    ) {
+      throw createError({
+        statusCode: 400,
+        message: 'isPublic (boolean) is required.',
+      })
+    }
+
+    const result = await setTankVisibilityForUser(
+      user.id,
+      user.username,
+      body.isPublic,
+    )
+
+    response = {
+      success: true,
+      data: result,
+      statusCode: 200,
+    }
+    event.node.res.statusCode = 200
+  } catch (error) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+    response = {
+      success: false,
+      message:
+        handledError.message || "Could not update the tank's visibility.",
+      statusCode: event.node.res.statusCode,
+    }
+  }
+
+  return response
+})

--- a/server/utils/aquarium.ts
+++ b/server/utils/aquarium.ts
@@ -199,6 +199,13 @@ export async function getOrCreateTankForUser(
       slug,
       title: `${username}'s Tank`,
       coins: DEFAULT_STARTING_COINS,
+      // cthulhuquarium/t-014: "default new tanks to public per the pitch" --
+      // set explicitly here rather than relying on the schema column
+      // default, which stays false so existing rows created before this
+      // task are unaffected. The owner can flip it back off any time via
+      // setTankVisibilityForUser below; this only decides the starting
+      // state for a brand-new tank.
+      isPublic: true,
     },
     select: ownedAquariumSelect,
   })
@@ -1176,6 +1183,40 @@ export async function unequipSetForUser(
 
     await logEvent(tx, tank.id, 'unequip-set', { kind: existing.kind })
 
+    return updated
+  })
+
+  return { aquarium: toClientAquarium(aquarium) }
+}
+
+// ---------------------------------------------------------------------------
+// Visibility toggle (cthulhuquarium/t-014) -- the one-click public/private
+// switch the task note calls for. New tanks already default to public (see
+// getOrCreateTankForUser above); this is how an owner changes their mind
+// either way afterward. A no-op write (flipping to the value it's already
+// at) still round-trips through the same update rather than short-
+// circuiting, so `updatedAt` and the event log stay an honest record of
+// when the owner last touched this setting.
+// ---------------------------------------------------------------------------
+
+export interface SetVisibilityResult {
+  aquarium: ClientAquarium
+}
+
+export async function setTankVisibilityForUser(
+  userId: number,
+  username: string,
+  isPublic: boolean,
+): Promise<SetVisibilityResult> {
+  const tank = await getOrCreateTankForUser(userId, username)
+
+  const aquarium = await prisma.$transaction(async (tx) => {
+    const updated = await tx.aquarium.update({
+      where: { id: tank.id },
+      data: { isPublic },
+      select: ownedAquariumSelect,
+    })
+    await logEvent(tx, tank.id, 'set-visibility', { isPublic })
     return updated
   })
 

--- a/stores/cthulhuquariumTankStore.ts
+++ b/stores/cthulhuquariumTankStore.ts
@@ -145,6 +145,10 @@ interface UnequipSetResponse {
   aquarium: Tank
 }
 
+interface SetVisibilityResponse {
+  aquarium: Tank
+}
+
 interface CleanResponse {
   aquarium: Tank
   debrisLevel: number
@@ -492,6 +496,27 @@ export const useCthulhuquariumTankStore = defineStore(
       offlineTicksProcessed.value = 0
     }
 
+    // cthulhuquarium/t-014: the one-click public/private toggle. Optimistic
+    // on the visible switch would just mean flipping it back on failure, so
+    // instead this simply waits for the server's own isPublic on the
+    // returned aquarium -- the same "server disposes" pattern as every
+    // other mutation in this store.
+    async function setVisibility(isPublic: boolean): Promise<boolean> {
+      const res = await performFetch<SetVisibilityResponse>(
+        '/api/aquarium/visibility',
+        {
+          method: 'POST',
+          body: JSON.stringify({ isPublic }),
+        },
+      )
+      if (res.success && res.data) {
+        tank.value = res.data.aquarium
+        return true
+      }
+      error.value = res.message || "Could not update the tank's visibility."
+      return false
+    }
+
     return {
       tank,
       catalog,
@@ -532,6 +557,7 @@ export const useCthulhuquariumTankStore = defineStore(
       loadSets,
       equipSet,
       unequipSet,
+      setVisibility,
     }
   },
 )


### PR DESCRIPTION
## Summary

cthulhuquarium/t-014's remaining scope, on top of t-009's already-shipped
server API (`server/api/aquarium/browse/**`): default-public new tanks, a
one-click visibility toggle, and the actual browse/view frontend.

- **Default visibility**: `getOrCreateTankForUser` now creates new tanks with
  `isPublic: true` (task note: "default new tanks to public per the pitch").
  Existing rows are untouched -- this only changes the value used on create,
  not the schema column default, so no migration is needed.
- **Visibility toggle**: new `POST /api/aquarium/visibility` + `setTankVisibilityForUser`
  util, wrapped by a new `tankStore.setVisibility(isPublic)` store action. A
  toggle + "View your public page" / "Browse public tanks" links now sit at
  the bottom of the tank panel in `cthulhuquarium-game.vue`.
- **Browse index**: `pages/play/aquarium/browse/index.vue` -- paginated,
  unauthenticated, backed by the existing `GET /api/aquarium/browse`.
- **Single public tank**: `pages/play/aquarium/browse/[username]/[slug].vue`
  -- read-only, addressed by (username, slug) together since `Aquarium.slug`
  is unique per owner, not globally (per t-032/t-009's existing convention).
  No feeding, no clicking, no writes of any kind from this page.
- `components/conductor/aquarium-page.vue`'s deliverables list updated to
  move "Browsable public aquariums" from `next` to `done`.

## Verification

- `vue-tsc --noEmit` clean (full repo)
- `eslint` / `prettier --check` clean on every changed/new file
- `npm run test:aquarium-economy` -- full suite passes (no economy math touched)
- `npm run test:layout-contract` holds -- fixed an initial violation (the two
  new pages rendered their own `<h1>`; switched to `<h2>` per the one-header
  rule, matching the existing `pages/play/challenges/*` convention). The
  output also shows an unrelated pre-existing `video-lora-picker.vue` ratchet
  improvement, untouched by this diff.
- No `prisma/schema.prisma` changes -- `Aquarium.isPublic` already existed.

## Flags for Reviewer

- The visibility toggle writes unconditionally (even a no-op flip) so
  `updatedAt` and the event log (`set-visibility` `AquariumEvent`) stay an
  honest record of when the owner last touched the setting -- flagging in
  case a stricter no-op short-circuit is preferred.
- No dedicated test was added for the new pages/endpoint (no existing
  Cypress/unit harness covers page components or single-purpose API routes
  in this codebase's aquarium surface yet) -- verified via type-check/lint/
  the existing economy suite plus manual reading of the request/response
  shapes against the already-shipped `getPublicTankByUsernameAndSlug`/
  `listPublicTanks` utils.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYGEtmw3eFxCBjSENWMusS)_