### PR TITLE
cthulhuquarium/t-016: rare random events -- the retention hook

### DIFF
--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -29,6 +29,37 @@
         {{ tankStore.error }}
       </p>
 
+      <!-- Rare random events (cthulhuquarium/t-016): brief, dry, unsettling
+           -- never a jump scare, never explained. A settled tick's own
+           coinsEarned already includes any bonus; this is purely the
+           dismissible notice of what happened. -->
+      <div
+        v-if="tankStore.lastRareEvent"
+        class="flex items-start gap-2 rounded-xl border border-base-300 bg-base-200/60 p-3 text-sm"
+      >
+        <Icon
+          name="kind-icon:sparkles"
+          class="mt-0.5 size-4 shrink-0 opacity-60"
+        />
+        <div class="min-w-0 flex-1">
+          <p class="italic opacity-80">{{ tankStore.lastRareEvent.tone }}</p>
+          <p
+            v-if="tankStore.lastRareEvent.bonusCoins > 0"
+            class="mt-1 text-xs font-bold opacity-60"
+          >
+            +{{ tankStore.lastRareEvent.bonusCoins }} coins
+          </p>
+        </div>
+        <button
+          type="button"
+          class="btn btn-ghost btn-xs min-h-11 min-w-11 shrink-0"
+          aria-label="Dismiss"
+          @click="tankStore.dismissRareEvent()"
+        >
+          <Icon name="kind-icon:close" class="size-4" />
+        </button>
+      </div>
+
       <div class="flex flex-wrap items-center justify-between gap-2">
         <div class="flex items-center gap-3 text-sm font-bold">
           <span class="flex items-center gap-1">

--- a/server/utils/aquarium.ts
+++ b/server/utils/aquarium.ts
@@ -28,11 +28,12 @@ import {
   justCompletedBestiary as computeJustCompletedBestiary,
   MAX_CLEAN_CLICKS_PER_REQUEST,
   mergeBestStats,
+  rollRareEvent,
   SET_PIECE_CATALOG,
   settleTick,
   unlockCost,
 } from './aquariumEconomy'
-import type { StatBlock } from './aquariumEconomy'
+import type { RareEventResult, StatBlock } from './aquariumEconomy'
 
 function apiError(statusCode: number, message: string): Error {
   const error = new Error(message) as Error & { statusCode: number }
@@ -221,6 +222,11 @@ export interface TickResult {
   elapsedTicks: number
   ticksProcessed: number
   coinsEarned: number
+  // cthulhuquarium/t-016: null on the overwhelming majority of calls (see
+  // rollRareEvent's own docs). `coinsEarned` above already has any bonus
+  // folded in -- this is purely so the client can show what happened and
+  // why, never a separate balance to reconcile.
+  rareEvent: RareEventResult | null
 }
 
 export async function settleTickForUser(
@@ -250,8 +256,16 @@ export async function settleTickForUser(
       elapsedTicks: settlement.elapsedTicks,
       ticksProcessed: 0,
       coinsEarned: 0,
+      rareEvent: null,
     }
   }
+
+  // cthulhuquarium/t-016: rolled here, not inside settleTick, so the pure
+  // economy math stays a deterministic function of its inputs -- only ever
+  // rolled when this call actually processed real elapsed time, per
+  // rare_events' own "never on a no-op poll" rule.
+  const rareEvent = rollRareEvent(Math.random(), Math.random())
+  const totalCoinsEarned = settlement.coinsEarned + (rareEvent?.bonusCoins ?? 0)
 
   const aquarium = await prisma.$transaction(async (tx) => {
     for (const stock of tank.Stock) {
@@ -267,7 +281,7 @@ export async function settleTickForUser(
     const updated = await tx.aquarium.update({
       where: { id: tank.id },
       data: {
-        coins: { increment: settlement.coinsEarned },
+        coins: { increment: totalCoinsEarned },
         debrisLevel: settlement.newDebrisLevel,
         lastTickAt: settlement.newLastTickAt,
       },
@@ -281,6 +295,13 @@ export async function settleTickForUser(
       newDebrisLevel: settlement.newDebrisLevel,
     })
 
+    if (rareEvent) {
+      await logEvent(tx, tank.id, 'rare-event', {
+        kind: rareEvent.kind,
+        bonusCoins: rareEvent.bonusCoins,
+      })
+    }
+
     return updated
   })
 
@@ -288,7 +309,8 @@ export async function settleTickForUser(
     aquarium: toClientAquarium(aquarium),
     elapsedTicks: settlement.elapsedTicks,
     ticksProcessed: settlement.ticksProcessed,
-    coinsEarned: settlement.coinsEarned,
+    coinsEarned: totalCoinsEarned,
+    rareEvent,
   }
 }
 

--- a/server/utils/aquariumEconomy.ts
+++ b/server/utils/aquariumEconomy.ts
@@ -620,6 +620,100 @@ export function settleTick(input: TickSettlementInput): TickSettlementResult {
 }
 
 // ---------------------------------------------------------------------------
+// Rare random events (cthulhuquarium/t-016) -- economy.yaml `rare_events`.
+// HARD CONSTRAINT (Silas, 2026-08-24, amending t-016's own note): no event
+// may ever take anything away -- every kind here is additive-only or purely
+// cosmetic; none may reduce coins, fish, or unlocks. v1 never implements an
+// actual income pause (accounting for "paused, but still catches up exactly
+// right" is real complexity for very little player-visible difference from
+// "no economic effect at all"), so every kind is either a coin bonus or a
+// zero-effect cosmetic beat.
+//
+// Randomness intentionally lives OUTSIDE this file, same discipline as the
+// rest of aquariumEconomy.ts: rollRareEvent takes the caller's own
+// Math.random() values as explicit arguments rather than calling Math.random
+// itself, so it stays a pure, unit-testable function of its inputs. The
+// caller (server/utils/aquarium.ts's settleTickForUser) is responsible for
+// only rolling once per settle call that actually processed >=1 real tick.
+// ---------------------------------------------------------------------------
+
+export type RareEventKind =
+  'rare_visitor' | 'windfall_collectible' | 'tank_gone_wrong'
+
+export interface RareEventConfig {
+  chance: number
+  bonusCoinsMin: number
+  bonusCoinsMax: number
+  tone: string
+}
+
+// economy.yaml `rare_events.events`. Order matters: rollRareEvent walks this
+// object in key order, carving out each kind's `chance` as its own slice of
+// the [0, 1) roll space -- changing the order changes which slice belongs to
+// which kind, never the total probability that some event fires.
+export const RARE_EVENT_CATALOG: Readonly<
+  Record<RareEventKind, RareEventConfig>
+> = Object.freeze({
+  rare_visitor: {
+    chance: 0.03,
+    bonusCoinsMin: 15,
+    bonusCoinsMax: 40,
+    tone: 'Something paid a short visit, left more than it took, and did not linger.',
+  },
+  windfall_collectible: {
+    chance: 0.008,
+    bonusCoinsMin: 60,
+    bonusCoinsMax: 150,
+    tone: 'One piece of gravel is worth far more than gravel. Nobody asks why.',
+  },
+  tank_gone_wrong: {
+    chance: 0.015,
+    bonusCoinsMin: 0,
+    bonusCoinsMax: 0,
+    tone: 'For a few seconds the water was the wrong color. Then it was not.',
+  },
+})
+
+export const RARE_EVENT_KINDS: readonly RareEventKind[] = Object.keys(
+  RARE_EVENT_CATALOG,
+) as RareEventKind[]
+
+export interface RareEventResult {
+  kind: RareEventKind
+  bonusCoins: number
+  tone: string
+}
+
+// Pure. `selectRoll` decides WHICH kind (or none) fires; `magnitudeRoll`
+// decides the bonus-coin amount within that kind's range. Both are expected
+// to be independent values in [0, 1) (i.e. two separate Math.random() calls)
+// -- reusing one roll for both would correlate which kind fires with how
+// large its bonus is, which is not a real design intent here, just an
+// accident of implementation.
+//
+// At most one kind ever fires per call. `selectRoll` falling past the last
+// configured kind's slice (the overwhelmingly common case, since the
+// catalog's chances intentionally sum to well under 1) returns null.
+export function rollRareEvent(
+  selectRoll: number,
+  magnitudeRoll: number,
+): RareEventResult | null {
+  let floor = 0
+  for (const kind of RARE_EVENT_KINDS) {
+    const config = RARE_EVENT_CATALOG[kind]
+    const ceiling = floor + config.chance
+    if (selectRoll >= floor && selectRoll < ceiling) {
+      const span = config.bonusCoinsMax - config.bonusCoinsMin
+      const bonusCoins =
+        config.bonusCoinsMin + Math.floor(magnitudeRoll * (span + 1))
+      return { kind, bonusCoins, tone: config.tone }
+    }
+    floor = ceiling
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
 // Bestiary completion (cthulhuquarium/t-024) -- pure decision logic only.
 // Loading/persisting the actual codex rows is server/utils/aquarium.ts's
 // job (AquariumCodexEntry, prisma); this stays a plain arithmetic check so

--- a/stores/cthulhuquariumTankStore.ts
+++ b/stores/cthulhuquariumTankStore.ts
@@ -109,11 +109,21 @@ export interface CatalogEntry {
   cost: number
 }
 
+// cthulhuquarium/t-016: one rare random event, as returned alongside a tick
+// settlement. `bonusCoins` is already folded into that same response's
+// `coinsEarned` -- this is purely display, never a separate balance.
+export interface RareEvent {
+  kind: 'rare_visitor' | 'windfall_collectible' | 'tank_gone_wrong'
+  bonusCoins: number
+  tone: string
+}
+
 interface TickResponse {
   aquarium: Tank
   elapsedTicks: number
   ticksProcessed: number
   coinsEarned: number
+  rareEvent: RareEvent | null
 }
 
 // cthulhuquarium/t-013: how long the store waits after the last Clean click
@@ -240,6 +250,12 @@ export const useCthulhuquariumTankStore = defineStore(
     // a reveal, then clears it via dismissReveal().
     const revealedUnlock = ref<TankStock | null>(null)
 
+    // cthulhuquarium/t-016: the most recent rare event, if the last settle
+    // fired one -- null the overwhelming majority of the time. The game
+    // component watches this to show a brief notice, then clears it via
+    // dismissRareEvent().
+    const lastRareEvent = ref<RareEvent | null>(null)
+
     // cthulhuquarium/t-024's bestiary. Loaded lazily (the panel starts
     // collapsed) rather than alongside load()/loadCatalog() on every mount --
     // it is the completionist book, not something the tank loop needs every
@@ -296,6 +312,7 @@ export const useCthulhuquariumTankStore = defineStore(
       })
       if (res.success && res.data) {
         tank.value = res.data.aquarium
+        if (res.data.rareEvent) lastRareEvent.value = res.data.rareEvent
         return {
           coinsEarned: res.data.coinsEarned,
           ticksProcessed: res.data.ticksProcessed,
@@ -307,6 +324,10 @@ export const useCthulhuquariumTankStore = defineStore(
     async function settleTick(): Promise<number> {
       const { coinsEarned } = await settleTickRaw()
       return coinsEarned
+    }
+
+    function dismissRareEvent(): void {
+      lastRareEvent.value = null
     }
 
     async function load(): Promise<void> {
@@ -534,6 +555,7 @@ export const useCthulhuquariumTankStore = defineStore(
       error,
       ready,
       revealedUnlock,
+      lastRareEvent,
       bestiary,
       bestiaryCollectedCount,
       bestiaryTotalCount,
@@ -549,6 +571,7 @@ export const useCthulhuquariumTankStore = defineStore(
       feed,
       unlock,
       dismissReveal,
+      dismissRareEvent,
       requestClean,
       flushCleanNow,
       clearOfflineEarnings,

--- a/utils/scripts/verifyAquariumEconomy.test.ts
+++ b/utils/scripts/verifyAquariumEconomy.test.ts
@@ -22,6 +22,8 @@ import {
   MAX_CLEAN_CLICKS_PER_REQUEST,
   NO_STACK_IDLE_SET_KINDS,
   OFFLINE_INCOME_RATE_MULTIPLIER,
+  RARE_EVENT_CATALOG,
+  RARE_EVENT_KINDS,
   RARITY_TIERS,
   SET_PIECE_CATALOG,
   SET_PIECE_KINDS,
@@ -35,6 +37,7 @@ import {
   incomePerTick,
   justCompletedBestiary,
   mergeBestStats,
+  rollRareEvent,
   settleTick,
   unlockCost,
 } from '../../server/utils/aquariumEconomy.js'
@@ -825,6 +828,70 @@ assert.deepEqual(mergeBestStats({ ...ALL_NULL, might: 7 }, ALL_NULL), {
 
 console.log(
   '✅ mergeBestStats: per-stat max, independently, never regresses an existing best',
+)
+
+// --- rare random events (cthulhuquarium/t-016) ------------------------------
+
+// Catalog shape: every kind priced/toned, no kind ever configured to take
+// anything away (bonusCoinsMin can be 0 -- a purely cosmetic kind -- but
+// never negative, and max is never below min).
+assert.deepEqual(
+  [...RARE_EVENT_KINDS].sort(),
+  ['rare_visitor', 'tank_gone_wrong', 'windfall_collectible'].sort(),
+)
+for (const kind of RARE_EVENT_KINDS) {
+  const config = RARE_EVENT_CATALOG[kind]
+  assert.ok(config.chance > 0 && config.chance < 1)
+  assert.ok(config.bonusCoinsMin >= 0)
+  assert.ok(config.bonusCoinsMax >= config.bonusCoinsMin)
+  assert.ok(config.tone.length > 0)
+}
+assert.ok(
+  RARE_EVENT_KINDS.reduce(
+    (sum, kind) => sum + RARE_EVENT_CATALOG[kind].chance,
+    0,
+  ) < 1,
+  'chances must sum to under 1 so "nothing happened" stays possible',
+)
+
+console.log(
+  '✅ RARE_EVENT_CATALOG: every economy.yaml rare_events key is present, priced, self-consistent',
+)
+
+// rollRareEvent: selectRoll walks RARE_EVENT_KINDS in order -- rare_visitor
+// [0, 0.03), windfall_collectible [0.03, 0.038), tank_gone_wrong
+// [0.038, 0.053), no event [0.053, 1).
+assert.equal(rollRareEvent(0, 0)?.kind, 'rare_visitor')
+assert.equal(rollRareEvent(0.0299, 0)?.kind, 'rare_visitor')
+assert.equal(rollRareEvent(0.03, 0)?.kind, 'windfall_collectible')
+assert.equal(rollRareEvent(0.0379, 0)?.kind, 'windfall_collectible')
+assert.equal(rollRareEvent(0.038, 0)?.kind, 'tank_gone_wrong')
+assert.equal(rollRareEvent(0.0529, 0)?.kind, 'tank_gone_wrong')
+assert.equal(
+  rollRareEvent(0.053, 0),
+  null,
+  'selectRoll landing exactly on the total configured chance is a no-event roll, not an off-by-one hit',
+)
+assert.equal(rollRareEvent(0.9999, 0), null)
+
+console.log(
+  '✅ rollRareEvent: selectRoll walks RARE_EVENT_KINDS in order, exact boundaries land in the right slice (or none)',
+)
+
+// magnitudeRoll: linear across [bonusCoinsMin, bonusCoinsMax], floored -- 0
+// gives the min, just-under-1 gives the max, never above it.
+assert.equal(rollRareEvent(0, 0)?.bonusCoins, 15)
+assert.equal(rollRareEvent(0, 0.999999)?.bonusCoins, 40)
+assert.equal(rollRareEvent(0.03, 0)?.bonusCoins, 60)
+assert.equal(rollRareEvent(0.03, 0.999999)?.bonusCoins, 150)
+assert.equal(
+  rollRareEvent(0.038, 0.999999)?.bonusCoins,
+  0,
+  'tank_gone_wrong is configured min=max=0 -- purely cosmetic, never a coin effect regardless of the roll',
+)
+
+console.log(
+  "✅ rollRareEvent: bonusCoins scales linearly across each kind's configured range, floored, never exceeds bonusCoinsMax",
 )
 
 console.log('✅ verifyAquariumEconomy: all assertions passed')


### PR DESCRIPTION
## Summary

The "random rare experiences" from the pitch: rare timed visitors, a collectible that pays far too much, a tank that goes briefly wrong -- driven from `AquariumEvent` rows so they're auditable and replayable, with rates in `economy.yaml`.

**HARD CONSTRAINT (Silas, 2026-08-24, amending this task's own note): no event may take anything away** -- not a fish, not coins, not an unlock. Every kind here is additive-only or purely cosmetic:

- `rare_visitor` -- small coin bonus (15-40), common-ish (3% per qualifying tick settle)
- `windfall_collectible` -- bigger, rarer coin bonus (60-150), 0.8%
- `tank_gone_wrong` -- zero economic effect, purely cosmetic/flavor beat, 1.5%

Chances sum to well under 1 so "nothing happened" stays the overwhelmingly common outcome of any roll.

## Scope decision (flagging for reviewer/Silas)

The task note says an event "may pause or redirect income briefly." v1 never implements an actual pause: correctly accounting for "paused, yet the tank still catches up to the exact right total once resumed" is real complexity for very little player-visible difference from "no economic effect at all" here. Every kind is either a coin bonus or a zero-effect cosmetic beat instead. If a real pause mechanic is wanted later, this is the scope it was deliberately left out of.

## Changes

- `economy.yaml` (conductor repo, mirrored by hand into this repo's `aquariumEconomy.ts` per that file's existing SOURCE OF TRUTH convention): new `rare_events` section.
- `aquariumEconomy.ts`: `RARE_EVENT_CATALOG` + `rollRareEvent`, a pure function taking the caller's own `Math.random()` values as explicit arguments (`selectRoll` picks the kind or none, `magnitudeRoll` picks the bonus amount within that kind's range) -- randomness lives at the orchestration layer, same discipline as the rest of this file (settleTick stays a pure function of its inputs).
- `aquarium.ts`: `settleTickForUser` rolls at most once per settle call that actually processed >=1 real tick (never on a no-op poll), folds any bonus into `coinsEarned`, logs a `rare-event` `AquariumEvent`, and returns the event on `TickResult`.
- Store + UI: `tankStore.lastRareEvent` surfaces the most recent event; a small dismissible notice (tone text + bonus, if any) appears above the tank controls in `cthulhuquarium-game.vue`. Tone is written as a dry incident-log line, never a character speaking -- no outside reference, no lore, no hint at the finale, per `DESIGN-BRIEF.md`'s guardrails (Charlotte/Wilbur don't narrate these).

## Verification

- `vue-tsc --noEmit` clean (full repo)
- `eslint` / `prettier --check` clean on every changed file
- `npm run test:aquarium-economy` -- full suite passes, including new `RARE_EVENT_CATALOG` shape assertions and `rollRareEvent` boundary/magnitude tests (exact slice edges per kind, min/max bonus clamping, the no-event region)
- `npm run test:layout-contract` holds, 0 new violations
- No `prisma/schema.prisma` changes -- driven entirely through the existing `AquariumEvent` table

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYGEtmw3eFxCBjSENWMusS)_