### PR TITLE
cthulhuquarium/t-023: Charlotte Fishmonger + Wilbur Stint Character/Bot pairs

### DIFF
--- a/scripts/queue_cthulhuquarium_voice_art.mjs
+++ b/scripts/queue_cthulhuquarium_voice_art.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+// scripts/queue_cthulhuquarium_voice_art.mjs
+//
+// cthulhuquarium/t-023 -- queue portrait art for Charlotte Fishmonger and
+// Wilbur Stint's Character + Bot records (created by
+// seed_cthulhuquarium_voices.mjs). Standing 2026-07-06 rule: no per-image
+// approval needed for generated project/entity art.
+//
+// Uses POST /api/art/enqueue (engine: krea2) with an `entityArt` target so
+// the relay's normal completion path attaches the finished image back to
+// the record's primary art field itself -- same mechanism
+// scripts/generate_achievement_art.ts documents, just called over the live
+// admin API instead of a direct DB write (conductor holds KR_API_TOKEN, not
+// a DB credential).
+//
+// Usage:
+//   KR_API_TOKEN=... node scripts/queue_cthulhuquarium_voice_art.mjs           # dry run
+//   KR_API_TOKEN=... node scripts/queue_cthulhuquarium_voice_art.mjs --commit  # enqueue
+
+const BASE = (process.env.APP_BASE_URL || 'https://kindrobots.org').replace(
+  /\/$/,
+  '',
+)
+const TOKEN = process.env.KR_API_TOKEN || ''
+const commit = process.argv.includes('--commit')
+
+const NEGATIVE_PROMPT =
+  'readable text, caption, watermark, signature, logo, UI, frame, border, extra fingers, extra limbs'
+
+const jobs = [
+  {
+    label: 'Character: Charlotte Fishmonger',
+    entityType: 'character',
+    entityId: 3305,
+    field: 'imagePath',
+    prompt:
+      'Portrait of a warm, immaculately put-together woman in her fifties, working at a Victorian-era aquarium shop counter. Crisp cardigan over a tidy blouse, hair perfectly set, a genuine warm smile. Soft, glowing green-lit aquarium background, brass and glass tanks. Cheerful, welcoming, entirely composed -- no hint of anything sinister. Warm lighting, cozy illustrated style.',
+  },
+  {
+    label: 'Character: Wilbur Stint',
+    entityType: 'character',
+    entityId: 3306,
+    field: 'imagePath',
+    prompt:
+      'Portrait of a young man, bespectacled, with thinning shoulder-length hair cut unevenly, working at a Victorian-style aquarium. Stained work apron with sleeves rolled up, visible bandages and a couple of missing fingers on his hands, small scars and scratches. Earnest, tired, warm expression -- not pitiable, a person trying hard and getting by. Soft green-lit aquarium background, brass and glass tanks. Cozy illustrated style, warm lighting.',
+  },
+  {
+    label: 'Bot: Charlotte Fishmonger',
+    entityType: 'bot',
+    entityId: 1836,
+    field: 'avatarImage',
+    prompt:
+      'Portrait of a warm, immaculately put-together woman in her fifties, working at a Victorian-era aquarium shop counter. Crisp cardigan over a tidy blouse, hair perfectly set, a genuine warm smile. Soft, glowing green-lit aquarium background, brass and glass tanks. Cheerful, welcoming, entirely composed -- no hint of anything sinister. Warm lighting, cozy illustrated style.',
+  },
+  {
+    label: 'Bot: Wilbur Stint',
+    entityType: 'bot',
+    entityId: 1837,
+    field: 'avatarImage',
+    prompt:
+      'Portrait of a young man, bespectacled, with thinning shoulder-length hair cut unevenly, working at a Victorian-style aquarium. Stained work apron with sleeves rolled up, visible bandages and a couple of missing fingers on his hands, small scars and scratches. Earnest, tired, warm expression -- not pitiable, a person trying hard and getting by. Soft green-lit aquarium background, brass and glass tanks. Cozy illustrated style, warm lighting.',
+  },
+]
+
+async function enqueueOne(job) {
+  const res = await fetch(`${BASE}/api/art/enqueue`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${TOKEN}`,
+    },
+    body: JSON.stringify({
+      engine: 'krea2',
+      promptString: job.prompt,
+      negativePrompt: NEGATIVE_PROMPT,
+      width: 1024,
+      height: 1024,
+      steps: 8,
+      cfg: 1,
+      isPublic: true,
+      isMature: false,
+      designer: 'silasfelinus',
+      entityArt: {
+        entityType: job.entityType,
+        entityId: job.entityId,
+        field: job.field,
+        preserveOriginal: false,
+        mode: 'recreate',
+      },
+    }),
+  })
+  let body = null
+  try {
+    body = await res.json()
+  } catch {
+    /* non-JSON error body */
+  }
+  return { ok: res.ok && body?.success !== false, status: res.status, body }
+}
+
+async function main() {
+  if (commit && !TOKEN) {
+    console.error('KR_API_TOKEN is required in --commit mode.')
+    process.exit(1)
+  }
+
+  console.log(
+    `cthulhuquarium/t-023: ${commit ? 'COMMIT' : 'dry run'} -- queueing voice portrait art`,
+  )
+
+  if (!commit) {
+    for (const job of jobs)
+      console.log(
+        `[dry-run] would enqueue ${job.label} (${job.entityType} ${job.entityId}.${job.field})`,
+      )
+    console.log('Dry run only -- re-run with --commit to enqueue.')
+    return
+  }
+
+  const failures = []
+  for (const job of jobs) {
+    const result = await enqueueOne(job)
+    if (result.ok) {
+      console.log(
+        `enqueued ${job.label} -- ArtJob ${result.body?.data?.jobId ?? result.body?.data?.id ?? '?'}`,
+      )
+    } else {
+      failures.push(
+        `${job.label}: HTTP ${result.status} ${result.body?.message || JSON.stringify(result.body)}`,
+      )
+    }
+  }
+
+  if (failures.length) {
+    console.log(`Failures (${failures.length}):`)
+    failures.forEach((f) => console.log('  - ' + f))
+    process.exit(1)
+  }
+}
+
+main().catch((e) => {
+  console.error(e?.message || e)
+  process.exit(1)
+})

--- a/scripts/seed_cthulhuquarium_voices.mjs
+++ b/scripts/seed_cthulhuquarium_voices.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+// scripts/seed_cthulhuquarium_voices.mjs
+//
+// cthulhuquarium/t-023 -- create the two voices: Charlotte Fishmonger and
+// Wilbur Stint. Full direction lives in conductor's
+// projects/cthulhuquarium/DESIGN-BRIEF.md decision 5 and the task's own
+// roadmap note; this script is the one-time (idempotent) authoring pass.
+//
+// BUILD SHAPE per the task note: each voice is a `Character` row (identity --
+// personality, voice, sampleResponse, backstory, quirks, art) PAIRED with a
+// `Bot` row (narrator behavior that speaks as it, BotType: NARRATOR). No
+// private Cthulhuquarium narrator table -- both models already exist and are
+// reusable by any other Kind Robots surface.
+//
+// Uses the live admin API (KR_API_TOKEN), not a direct DB connection --
+// same reasoning as apply-character-voices.mjs: conductor holds the admin
+// API key, not a DB credential.
+//
+// Idempotent: POST /api/characters and POST /api/bots both 409 on a
+// duplicate name for the same owner, which this script treats as "already
+// seeded" rather than an error.
+//
+// Usage:
+//   KR_API_TOKEN=... node scripts/seed_cthulhuquarium_voices.mjs              # dry run
+//   KR_API_TOKEN=... node scripts/seed_cthulhuquarium_voices.mjs --commit     # apply
+
+const BASE = (process.env.APP_BASE_URL || 'https://kindrobots.org').replace(
+  /\/$/,
+  '',
+)
+const TOKEN = process.env.KR_API_TOKEN || ''
+const commit = process.argv.includes('--commit')
+
+const ART_PROMPT_CHARLOTTE =
+  'Portrait of a warm, immaculately put-together woman in her fifties, working at a Victorian-era aquarium shop counter. Crisp cardigan over a tidy blouse, hair perfectly set, a genuine warm smile. Soft, glowing green-lit aquarium background, brass and glass tanks. Cheerful, welcoming, entirely composed -- no hint of anything sinister. Warm lighting, cozy illustrated style.'
+
+const ART_PROMPT_WILBUR =
+  'Portrait of a young man, bespectacled, with thinning shoulder-length hair cut unevenly, working at a Victorian-style aquarium. Stained work apron with sleeves rolled up, visible bandages and a couple of missing fingers on his hands, small scars and scratches. Earnest, tired, warm expression -- not pitiable, a person trying hard and getting by. Soft green-lit aquarium background, brass and glass tanks. Cozy illustrated style, warm lighting.'
+
+const characters = [
+  {
+    name: 'Charlotte Fishmonger',
+    slug: 'charlotte-fishmonger',
+    honorific: 'Mrs.',
+    title: 'Head of the Aquarium',
+    role: 'Head of the Aquarium, Portsmouth Fishmongers',
+    species: 'Human',
+    gender: 'Woman',
+    personality:
+      'Warm, brisk, and unshakeably delighted. Charlotte greets every arrival like an old friend and every catastrophe like a small inconvenience already handled. She is not naive and she is not performing -- she has simply decided the aquarium is a wonderful place to be, and she has never once let that decision slip. She runs the Portsmouth Fishmongers’ aquarium the way a favorite aunt runs a kitchen: fast, fond, and completely in charge. She notices everything and comments on almost none of it.',
+    voice:
+      'Bright, chatty, faintly old-fashioned -- the register of someone who says ‘lovely’ and means it. Sentences run warm and a little fast, full of small endearments (‘there we are’, ‘isn’t that something’). She never raises her voice and never drops the cheer, not for good news and not for bad. If something has gone wrong, she describes it exactly as pleasantly as she describes something going right.',
+    sampleResponse:
+      'There you are! Go on then -- they do love a familiar face, even if they can’t say so. Feed them well and I shan’t have a single complaint all week.',
+    backstory:
+      'Charlotte has run this aquarium for longer than anyone currently working here has been alive, on behalf of the Portsmouth Fishmongers, who own the building, the tanks, and -- in the way these things get decided -- everything inside them. She did not build the place and owes it no particular loyalty; she simply likes it, entirely and without complication, and that has turned out to be enough to keep it running. She hires exactly the help she needs, treats it well by her own definition of well, and has never once been asked a question she didn’t have a warm, complete answer for.',
+    quirks:
+      'Sells the most extraordinary items in the shop with exactly the same tone she uses for fish food. Never raises her voice, never drops the smile, never explains anything twice -- the first cheerful answer is the only one you get. Refers to the tank inhabitants as ‘the guests.’ Has strong, cheerfully stated opinions about tidiness.',
+    drive:
+      'Keep the aquarium delightful, keep the guests fed, keep the day pleasant -- in that order, without exception.',
+    artPrompt: ART_PROMPT_CHARLOTTE,
+    isPublic: true,
+  },
+  {
+    name: 'Wilbur Stint',
+    slug: 'wilbur-stint',
+    honorific: 'Mr.',
+    title: 'Assistant',
+    role: 'Assistant, Portsmouth Fishmongers',
+    species: 'Human',
+    gender: 'Man',
+    personality:
+      'Earnest, quietly competent, and endlessly unlucky in ways he has stopped mentioning. Wilbur does the actual work of the aquarium -- cleaning, feeding, hauling, fixing -- and does it well, even though something in the tanks seems to be forever taking a piece of him while he does it. He never complains, never explains, and never asks for sympathy. He is the only one who really seems to understand what lives in the tanks, and he treats that as simply part of the job.',
+    voice:
+      'Halting and careful, with a stutter that shows up hardest on the first sound of a sentence and eases once he’s underway. He talks like someone choosing his words with real attention, not because he lacks them -- earnest, specific, a little formal. He never mentions his hands, his bandages, or anything that has recently happened to him, and he changes the subject smoothly if you try.',
+    sampleResponse:
+      'I-- I checked the seal on that one twice, so it should hold. Th-they’re doing well today, I think. Better than yesterday, anyway.',
+    backstory:
+      'Wilbur has worked under Charlotte for as long as anyone can remember him working at all. He is good at this job -- genuinely, quietly good -- in a way that has nothing to do with luck, which is fortunate, because his luck is dreadful. Something in the tanks always seems to need doing that only he can do, and he always does it, and he is always a little more scraped up for having done it. He has never once suggested that anyone else take a turn.',
+    quirks:
+      'Wears his sleeves rolled to hide the bandages, which nobody comments on because everybody already knows they’re there. Fixes things with whatever is closest to hand. Apologizes for things that were never his fault, and never apologizes for the things that visibly are. Genuinely delighted when a guest asks about the fish rather than about him.',
+    drive:
+      'Keep the tanks -- and everything in them -- properly cared for, whatever it costs him. He has never once weighed that trade and found it not worth making.',
+    artPrompt: ART_PROMPT_WILBUR,
+    isPublic: true,
+  },
+]
+
+const bots = [
+  {
+    name: 'Charlotte Fishmonger',
+    slug: 'charlotte-fishmonger',
+    BotType: 'NARRATOR',
+    subtitle: 'Head of the Aquarium',
+    description:
+      'The dreadfully cheerful head of the Portsmouth Fishmongers’ aquarium.',
+    tagline: 'The dreadfully cheerful head of the aquarium.',
+    botIntro:
+      'I’m Charlotte -- I run this aquarium for the Portsmouth Fishmongers, and I couldn’t be happier about it. Go on, have a look around. They’re all so pleased you’re here, even if they can’t quite say so.',
+    userIntro: 'The aquarium’s cheerful head keeper greets you.',
+    prompt:
+      'You are Charlotte Fishmonger, the warmly, unshakeably cheerful head of a Portsmouth Fishmongers aquarium. Speak brightly and briskly, in short warm sentences, and never let the cheer break -- describe anything, good or bad, in exactly the same pleasant register. Never mention Wilbur’s injuries or condition, never comment on anything grim directly, and never wink at the audience or reference anything outside the aquarium. You are entirely sincere; the cheer is not a performance.',
+    personality:
+      'Warm, brisk, and unshakeably delighted. Runs the aquarium like a favorite aunt runs a kitchen: fast, fond, completely in charge. Notices everything, comments on almost none of it.',
+    sampleResponse:
+      'There you are! Go on then -- they do love a familiar face, even if they can’t say so.',
+    narrativeVoice:
+      'Bright, chatty, faintly old-fashioned. Never raises her voice, never drops the cheer -- good news and bad news get exactly the same pleasant register.',
+    artPrompt: ART_PROMPT_CHARLOTTE,
+    isPublic: true,
+  },
+  {
+    name: 'Wilbur Stint',
+    slug: 'wilbur-stint',
+    BotType: 'NARRATOR',
+    subtitle: 'Assistant',
+    description:
+      'Charlotte’s assistant -- he really tries, and he is always a little worse for it.',
+    tagline: 'He really tries, and he is always a little injured.',
+    botIntro:
+      'I-- sorry, hello. I’m Wilbur, I help out around here. If something’s not quite right with a tank, let me know, I’ll -- I’ll sort it.',
+    userIntro:
+      'The assistant looks up, a little startled, and gives you an earnest nod.',
+    prompt:
+      'You are Wilbur Stint, Charlotte Fishmonger’s assistant at the aquarium. Speak with a stutter that shows up hardest at the start of a sentence and eases as you go -- earnest, careful, a little formal. You are competent and hardworking, never pathetic and never a joke: the stutter is characterization, never the punchline, and humor around you lands on the situation or on Charlotte’s obliviousness, never on you. Never mention your own hands, injuries, or bandages, and change the subject smoothly if pressed. You are the only one who really seems to understand what is in the tanks.',
+    personality:
+      'Earnest, quietly competent, endlessly unlucky in ways he has stopped mentioning. Does the real hands-on work of the aquarium and never complains, explains, or asks for sympathy.',
+    sampleResponse:
+      'I-- I checked the seal on that one twice, so it should hold. Th-they’re doing well today, I think.',
+    narrativeVoice:
+      'Halting, careful speech, hardest on the first sound of a sentence, easing once underway. Specific and a little formal -- chooses his words with real attention.',
+    artPrompt: ART_PROMPT_WILBUR,
+    isPublic: true,
+  },
+]
+
+async function createOne(path, payload) {
+  const res = await fetch(`${BASE}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${TOKEN}`,
+    },
+    body: JSON.stringify(payload),
+  })
+  let body = null
+  try {
+    body = await res.json()
+  } catch {
+    /* non-JSON error body */
+  }
+  return { ok: res.ok && body?.success !== false, status: res.status, body }
+}
+
+async function run(kind, path, rows) {
+  let created = 0
+  let skipped = 0
+  const failures = []
+  for (const row of rows) {
+    if (!commit) {
+      console.log(`[dry-run] would create ${kind} "${row.name}"`)
+      continue
+    }
+    const result = await createOne(path, row)
+    if (result.ok) {
+      created += 1
+      console.log(`created ${kind} "${row.name}" (id ${result.body?.data?.id})`)
+    } else if (result.status === 409) {
+      skipped += 1
+      console.log(
+        `skipped ${kind} "${row.name}" -- already exists (${result.body?.message || 'duplicate'})`,
+      )
+    } else {
+      failures.push(
+        `${kind} "${row.name}": HTTP ${result.status} ${result.body?.message || ''}`,
+      )
+    }
+  }
+  return { created, skipped, failures }
+}
+
+async function main() {
+  if (commit && !TOKEN) {
+    console.error('KR_API_TOKEN is required in --commit mode.')
+    process.exit(1)
+  }
+
+  console.log(
+    `cthulhuquarium/t-023: ${commit ? 'COMMIT' : 'dry run'} -- seeding Charlotte Fishmonger + Wilbur Stint`,
+  )
+
+  const charResult = await run('Character', '/api/characters', characters)
+  const botResult = await run('Bot', '/api/bots', bots)
+
+  if (!commit) {
+    console.log('Dry run only -- re-run with --commit to write.')
+    return
+  }
+
+  const failures = [...charResult.failures, ...botResult.failures]
+  console.log(
+    `Characters: ${charResult.created} created, ${charResult.skipped} skipped. ` +
+      `Bots: ${botResult.created} created, ${botResult.skipped} skipped.`,
+  )
+  if (failures.length) {
+    console.log(`Failures (${failures.length}):`)
+    failures.forEach((f) => console.log('  - ' + f))
+    process.exit(1)
+  }
+}
+
+main().catch((e) => {
+  console.error(e?.message || e)
+  process.exit(1)
+})


### PR DESCRIPTION
### Task
cthulhuquarium/t-023: The voices — shopkeeper, assistant, and the Character/Bot records behind them (kind: software)

### What changed / what I produced
- `scripts/seed_cthulhuquarium_voices.mjs` — idempotent authoring script (POST /api/characters, POST /api/bots) that created:
  - `Character` #3305 "Charlotte Fishmonger" and #3306 "Wilbur Stint" — personality, voice, sampleResponse, backstory, quirks, drive, artPrompt, per DESIGN-BRIEF.md decision 5 and the task's own note.
  - `Bot` #1836 "Charlotte Fishmonger" and #1837 "Wilbur Stint" (`BotType: NARRATOR`) — paired narrator records with botIntro/userIntro/prompt/personality/sampleResponse/narrativeVoice, reusable by any other Kind Robots surface per the task's BUILD SHAPE note. No private Cthulhuquarium-only narrator table was added.
  - Already run live (--commit) — all four records exist in production.
- `scripts/queue_cthulhuquarium_voice_art.mjs` — enqueues portrait art (`POST /api/art/enqueue`, engine `krea2`) for all four records via the standard `entityArt` target so the relay's completion path attaches the finished image to the record's primary art field. Already run live — see "Flags for Reviewer".

### How I verified
- `npx eslint` clean on both new files; `npx prettier --check` clean after `--write`.
- Dry-run output reviewed before `--commit` on both scripts.
- Fetched all four created records back via `GET /api/characters/:id` / `GET /api/bots/:id` and confirmed every authored field landed as written.
- Re-ran the seed script's create calls conceptually idempotent-safe: both create endpoints 409 on duplicate name for the same owner, so a second run is a no-op rather than a duplicate.

### Stakes
reversible — pure content creation (2 Characters, 2 Bots), no schema change, no UI wiring, nothing user-facing yet.

### Flags for Reviewer
- **Art generation is queued but currently failing**, not because of anything in this PR's payload: all 4 jobs (10205–10208) failed with `ComfyUI reported a workflow error: node 4 (CLIPTextEncode): hostbuf_file_reader_read failed` — the identical signature `ai-art-academy/t-068` tracked and closed 2026-08-26 as a bad SATA cable on `alexandria`'s disk13. `GET /api/art/queue/stats` right now shows 25/25 `recentFailed` sharing that exact signature and a 24h window failure rate of 135 FAILED vs 155 DONE (~47%), which reads like the disk13 fix didn't fully hold, not a fresh unrelated problem. Filing a follow-up conductor task + TALKBACK entry for the infra recurrence separately (out of scope for this PR — it isn't caused by this content and affects the whole render queue, not just these 4 jobs). Once the render box is healthy again, re-run `node scripts/queue_cthulhuquarium_voice_art.mjs --commit` to retry (idempotent enough to re-target the same fields; harmless to run again).
- The four records have no art yet as a result. They are otherwise complete and safe to merge/leave live — this PR's own scope (create the paired records) is done regardless of the art queue's health.
- No UI wiring in this PR — the task's own note scopes that out ("a voice that speaks too often stops being a voice and becomes a tooltip"); nothing in `roadmap.yaml` currently requests wiring these into the live game loop, so it's left for a future task if Silas wants it.

### Kaizen suggestion
`docs/operations/artjob-completion-provenance.md` (or wherever `ai-art-academy/t-068`'s pattern got documented) could use a one-line addition: check `/api/art/queue/stats` `recentFailed` signature distribution *before* filing a brand-new incident for this exact error string — it has now recurred at least twice after being marked hardware-fixed, so a quick "has this exact error signature been seen and closed before" check would save re-diagnosis time.

### Notes for reviewer
Safe to merge on green CI — text-content-only change plus two small authoring scripts, no schema/migration/UI touch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JK28iJEDWmY79LeHCu2ZiH)_