### PR TITLE
cthulhuquarium/t-018: species-collected leaderboard

### DIFF
--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -537,6 +537,12 @@
         <NuxtLink to="/play/aquarium/browse" class="link text-xs opacity-70">
           Browse public tanks
         </NuxtLink>
+        <NuxtLink
+          to="/play/aquarium/leaderboard"
+          class="link text-xs opacity-70"
+        >
+          Leaderboard
+        </NuxtLink>
       </div>
     </div>
 

--- a/pages/play/aquarium/leaderboard/index.vue
+++ b/pages/play/aquarium/leaderboard/index.vue
@@ -1,0 +1,194 @@
+<!-- /pages/play/aquarium/leaderboard/index.vue
+     Species-collected leaderboard (cthulhuquarium/t-018) -- unauthenticated,
+     paginated, read-only. Backed by GET /api/aquarium/leaderboard
+     (server/utils/aquarium.ts's getSpeciesLeaderboard). Ranked on distinct
+     species collected, never coins -- see that function's own comment for
+     why. Display name only, same consent boundary as /play/aquarium/browse:
+     only players with at least one public tank are ranked. -->
+<template>
+  <main class="kr-surface bg-base-200/40">
+    <div
+      class="kr-scroll mx-auto max-w-3xl space-y-5 px-3 py-5 sm:px-6 sm:py-8"
+    >
+      <nav class="flex items-center justify-between gap-3">
+        <NuxtLink to="/play/aquarium" class="btn btn-ghost btn-sm rounded-xl">
+          <Icon name="kind-icon:arrow-left" class="size-4" />
+          Your tank
+        </NuxtLink>
+      </nav>
+
+      <header
+        class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-lg sm:p-7"
+      >
+        <p class="text-xs font-black uppercase tracking-[0.25em] text-primary">
+          Cthulhuquarium
+        </p>
+        <h2 class="mt-1 text-3xl font-black uppercase sm:text-4xl">
+          Leaderboard
+        </h2>
+        <p class="mt-2 max-w-2xl text-sm text-base-content/65">
+          Ranked by species collected. Coins aren't scored here.
+        </p>
+      </header>
+
+      <div
+        v-if="loading && !entries.length"
+        class="grid min-h-[40vh] place-items-center rounded-3xl border border-base-300 bg-base-100"
+      >
+        <div class="text-center">
+          <span class="loading loading-ring loading-lg text-primary" />
+          <p class="mt-3 text-sm font-bold text-base-content/55">
+            Tallying specimens…
+          </p>
+        </div>
+      </div>
+
+      <div
+        v-else-if="errorMessage && !entries.length"
+        class="rounded-3xl border border-error/30 bg-error/10 p-8 text-center"
+      >
+        <Icon name="kind-icon:warning" class="mx-auto size-10 text-error" />
+        <p class="mt-3 text-xl font-black">Could not load the leaderboard</p>
+        <p class="mt-2 text-sm text-base-content/65">{{ errorMessage }}</p>
+        <button class="btn btn-error btn-sm mt-5 rounded-xl" @click="load()">
+          Try again
+        </button>
+      </div>
+
+      <div
+        v-else-if="!entries.length"
+        class="rounded-3xl border border-dashed border-base-300 bg-base-100 px-6 py-16 text-center"
+      >
+        <Icon name="kind-icon:fish" class="mx-auto size-12 text-primary/40" />
+        <h2 class="mt-4 text-2xl font-black uppercase">No ranks yet</h2>
+        <p class="mx-auto mt-2 max-w-xl text-sm text-base-content/60">
+          Nobody with a public tank has collected a species yet.
+        </p>
+      </div>
+
+      <template v-else>
+        <ol class="flex flex-col gap-2">
+          <li
+            v-for="entry in entries"
+            :key="entry.userId"
+            class="flex items-center gap-3 rounded-2xl border border-base-300 bg-base-100 p-3 shadow-sm"
+          >
+            <span
+              class="grid size-8 shrink-0 place-items-center rounded-full bg-base-200 text-xs font-black"
+            >
+              {{ entry.rank }}
+            </span>
+            <div
+              class="grid size-9 shrink-0 place-items-center overflow-hidden rounded-xl border border-base-300 bg-base-200"
+            >
+              <img
+                v-if="entry.avatarImage"
+                :src="normalizeImagePath(entry.avatarImage)"
+                :alt="entry.username"
+                class="h-full w-full object-cover"
+              />
+              <Icon
+                v-else
+                name="kind-icon:user"
+                class="size-4 text-primary/60"
+              />
+            </div>
+            <p class="min-w-0 flex-1 truncate text-sm font-bold">
+              @{{ entry.username }}
+            </p>
+            <p class="shrink-0 text-sm font-black text-primary">
+              {{ entry.speciesCollected }} species
+            </p>
+          </li>
+        </ol>
+
+        <div class="flex items-center justify-between gap-3 pt-2">
+          <button
+            type="button"
+            class="btn btn-outline btn-sm rounded-xl"
+            :disabled="loading || skip <= 0"
+            @click="prevPage"
+          >
+            <Icon name="kind-icon:arrow-left" class="size-4" />
+            Higher ranks
+          </button>
+          <p class="text-xs font-bold text-base-content/50">
+            {{ Math.min(skip + entries.length, total) }} of {{ total }}
+          </p>
+          <button
+            type="button"
+            class="btn btn-outline btn-sm rounded-xl"
+            :disabled="loading || skip + entries.length >= total"
+            @click="nextPage"
+          >
+            Lower ranks
+            <Icon name="kind-icon:arrow-right" class="size-4" />
+          </button>
+        </div>
+      </template>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { performFetch } from '@/stores/utils'
+import type { ApiResponse } from '@/types/api'
+
+interface LeaderboardEntry {
+  rank: number
+  userId: number
+  username: string
+  avatarImage: string | null
+  speciesCollected: number
+}
+
+const TAKE = 25
+
+const entries = ref<LeaderboardEntry[]>([])
+const total = ref(0)
+const skip = ref(0)
+const loading = ref(false)
+const errorMessage = ref('')
+
+useHead({ title: 'Leaderboard · Cthulhuquarium' })
+
+function normalizeImagePath(value: string): string {
+  if (value.startsWith('/') || value.startsWith('http')) return value
+  return `/images/${value}`
+}
+
+async function load(): Promise<void> {
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    const response = (await performFetch<LeaderboardEntry[]>(
+      `/api/aquarium/leaderboard?take=${TAKE}&skip=${skip.value}`,
+    )) as ApiResponse<LeaderboardEntry[]> & {
+      meta?: { take: number; skip: number; total: number }
+    }
+    if (!response.success || !response.data) {
+      throw new Error(response.message || 'Could not load the leaderboard.')
+    }
+    entries.value = response.data
+    total.value = response.meta?.total ?? response.data.length
+  } catch (error: unknown) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Could not load the leaderboard.'
+  } finally {
+    loading.value = false
+  }
+}
+
+function nextPage(): void {
+  skip.value += TAKE
+  void load()
+}
+
+function prevPage(): void {
+  skip.value = Math.max(0, skip.value - TAKE)
+  void load()
+}
+
+onMounted(load)
+</script>

--- a/server/api/aquarium/leaderboard.get.ts
+++ b/server/api/aquarium/leaderboard.get.ts
@@ -1,0 +1,58 @@
+// /server/api/aquarium/leaderboard.get.ts
+//
+// Public species-collected leaderboard -- paginated, unauthenticated
+// (cthulhuquarium/t-018). Ranks display name only, never email or userId
+// beyond what's already exposed by the public browse endpoints. Metric is
+// distinct species collected, not coins -- see getSpeciesLeaderboard's own
+// comment in server/utils/aquarium.ts for why.
+//
+// Query: ?take=20&skip=0 (same defaults/cap as browse/index.get.ts).
+
+import { defineEventHandler, getQuery } from 'h3'
+import { errorHandler } from '../../utils/error'
+import { getSpeciesLeaderboard } from '../../utils/aquarium'
+
+const DEFAULT_TAKE = 20
+const MAX_TAKE = 50
+
+function parsePositiveInt(
+  value: unknown,
+  fallback: number,
+  max?: number,
+): number {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback
+  const truncated = Math.trunc(parsed)
+  return max ? Math.min(truncated, max) : truncated
+}
+
+export default defineEventHandler(async (event) => {
+  let response
+
+  try {
+    const query = getQuery(event)
+    const take =
+      parsePositiveInt(query.take, DEFAULT_TAKE, MAX_TAKE) || DEFAULT_TAKE
+    const skip = parsePositiveInt(query.skip, 0)
+
+    const result = await getSpeciesLeaderboard(take, skip)
+
+    response = {
+      success: true,
+      data: result.data,
+      meta: { take: result.take, skip: result.skip, total: result.total },
+      statusCode: 200,
+    }
+    event.node.res.statusCode = 200
+  } catch (error) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+    response = {
+      success: false,
+      message: handledError.message || 'Failed to load leaderboard.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+
+  return response
+})

--- a/server/utils/aquarium.ts
+++ b/server/utils/aquarium.ts
@@ -1015,6 +1015,92 @@ export async function listPublicTanks(
 }
 
 // ---------------------------------------------------------------------------
+// Leaderboard -- ranks players by DISTINCT SPECIES COLLECTED, never coins
+// (cthulhuquarium/t-018). Decided 2026-08-24: the game is endless with the
+// bestiary as the win state, so a coin leaderboard would only rank whoever
+// left a tab open longest. AquariumCodexEntry carries a `@@unique([userId,
+// monsterId])` constraint and is never deleted once written (t-024/t-031's
+// "nothing here may ever decrease" rule), so a plain per-user row count
+// already equals distinct species collected -- no DISTINCT needed.
+//
+// Same consent boundary as the public browse above: only ranks users who
+// have at least one `isPublic` tank (the per-feature opt-in t-014 already
+// established -- a player who has never made a tank public hasn't agreed to
+// be identified here either), and never a restricted/moderated account.
+// Display names only, same publicOwnerSelect as the rest of this file.
+// ---------------------------------------------------------------------------
+
+export interface SpeciesLeaderboardEntry {
+  rank: number
+  userId: number
+  username: string
+  avatarImage: string | null
+  speciesCollected: number
+}
+
+export interface SpeciesLeaderboardResult {
+  data: SpeciesLeaderboardEntry[]
+  take: number
+  skip: number
+  total: number
+}
+
+export async function getSpeciesLeaderboard(
+  take: number,
+  skip: number,
+): Promise<SpeciesLeaderboardResult> {
+  const rankableUserWhere = {
+    isRestricted: false,
+    Aquariums: { some: { isPublic: true } },
+  } satisfies Prisma.UserWhereInput
+
+  const [grouped, total] = await Promise.all([
+    prisma.aquariumCodexEntry.groupBy({
+      by: ['userId'],
+      where: { User: rankableUserWhere },
+      _count: { monsterId: true },
+      orderBy: [
+        { _count: { monsterId: 'desc' } },
+        // Tie-break deterministically (lowest userId first) rather than
+        // leaving groupBy's tie order unspecified across pages.
+        { userId: 'asc' },
+      ],
+      take,
+      skip,
+    }),
+    prisma.aquariumCodexEntry
+      .groupBy({
+        by: ['userId'],
+        where: { User: rankableUserWhere },
+      })
+      .then((rows) => rows.length),
+  ])
+
+  const userIds = grouped.map((row) => row.userId)
+  const users = await prisma.user.findMany({
+    where: { id: { in: userIds } },
+    select: { id: true, ...publicOwnerSelect },
+  })
+  const userById = new Map(users.map((user) => [user.id, user]))
+
+  const data: SpeciesLeaderboardEntry[] = grouped
+    .map((row, index) => {
+      const user = userById.get(row.userId)
+      if (!user) return null
+      return {
+        rank: skip + index + 1,
+        userId: user.id,
+        username: user.username,
+        avatarImage: user.avatarImage,
+        speciesCollected: row._count.monsterId,
+      }
+    })
+    .filter((entry): entry is SpeciesLeaderboardEntry => entry !== null)
+
+  return { data, take, skip, total }
+}
+
+// ---------------------------------------------------------------------------
 // Catalog -- species the user's tank does not yet own, for the unlock panel
 // (cthulhuquarium/t-011). `cost` is computed the exact same way
 // purchaseSpeciesForUser charges (deriveFishRarityTier + unlockCost) so the


### PR DESCRIPTION
### Task
cthulhuquarium/t-018 -- Leaderboard. Deferred from MVP on purpose, but the metric is no longer open: Silas decided 2026-08-24 that the game is endless with the bestiary as the win state, so rank on species collected. Do not rank on coins. Ranks show display names only.

### What changed / what I produced
- `server/utils/aquarium.ts`: `getSpeciesLeaderboard(take, skip)` -- `groupBy` over `AquariumCodexEntry` by `userId` (its `@@unique([userId, monsterId])` constraint means a plain row count already equals distinct species collected, no `DISTINCT` needed). Restricted to users with at least one `isPublic` tank (the same per-feature consent boundary t-014 already established -- a player who never made a tank public hasn't agreed to be identified here either) and never a restricted/moderated account. Hydrates `username`/`avatarImage` only, reusing the existing `publicOwnerSelect`.
- `server/api/aquarium/leaderboard.get.ts`: new public, unauthenticated, paginated `GET /api/aquarium/leaderboard`, mirroring `browse/index.get.ts`'s exact shape (`?take=&skip=`, `{ success, data, meta, statusCode }`).
- `pages/play/aquarium/leaderboard/index.vue`: new paginated ranked-list page, mirroring `browse/index.vue`'s structure/conventions (loading/error/empty states, `performFetch`, no Pinia -- it's read-only public data unrelated to "my tank" state).
- `components/cthulhuquarium/cthulhuquarium-game.vue`: one low-key nav link next to "Browse public tanks", matching DESIGN-BRIEF's own note for this task ("ranks specimens... leave it alone; it is funnier untouched").

No schema/migration needed -- this reuses `AquariumCodexEntry`, which already exists and is never deleted from (t-024/t-031's "nothing here may ever decrease" rule).

### How I verified
- `prisma validate` -- clean (no schema change).
- `vue-tsc --noEmit` -- clean, full repo.
- `eslint` / `prettier --check` -- clean on every changed/new file.
- `npm run test:layout-contract` -- holds, 0 new violations (only pre-existing unrelated baseline movement in `video-lora-picker.vue`, already noted by prior sessions).
- `npm run test:aquarium-economy` / `npm run test:aquarium-touch` -- unaffected, all pass.
- No live DB in this sandbox, so the actual query wasn't run against real data -- the `groupBy`/`findMany` shape follows the established precedent in `server/api/economy/karma-earned.post.ts` and the schema's own constraints closely enough that I'm confident in the types (`vue-tsc` also type-checks the Prisma call shape against the generated client).

### Stakes
Reversible. Purely additive (new route, new page, one new nav link, one new exported function). No writes, no schema change, no auth changes.

### Flags for Reviewer
- Consent boundary: I chose to gate ranking on `Aquarium.isPublic` (t-014's existing per-feature opt-in) rather than the general-purpose `listInDirectory` friend-finder flag, since they're different consents for different features and `isPublic` is the one a player has actually already made a decision about in this game. I did keep `isRestricted: false` as a moderation safety net, matching `server/api/users/directory.get.ts`'s precedent.
- Tie-breaking: players tied on species count are ordered by `userId asc` for a stable, deterministic page order (unspecified otherwise).

### Kaizen suggestion
`listPublicTanks` (t-014, this leaderboard's own dependency) doesn't currently filter on `isRestricted`, only `isPublic` -- worth a small follow-up task to add that same moderation safety net there for consistency, since a restricted/moderated user's tank can otherwise still appear in public browse today.

### Notes for reviewer
cthulhuquarium/t-018 in conductor is set to `status: review`; conductor PR opened separately for that bookkeeping.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPpTW5d1Q6gXpMjVzrgM8D)_