### PR TITLE
cthulhuquarium/t-052: filter isRestricted users out of public tank browse

### DIFF
--- a/server/utils/aquarium.ts
+++ b/server/utils/aquarium.ts
@@ -996,19 +996,29 @@ export interface PublicTankListResult {
   total: number
 }
 
+// cthulhuquarium/t-052 (kaizen from t-018): the leaderboard and
+// directory.get.ts both exclude restricted/moderated accounts from public
+// listings; this browse query only checked `isPublic` and let a restricted
+// user's public tank still surface here. Same `User: { isRestricted: false
+// }` filter as getSpeciesLeaderboard above, for consistency.
+const publicTankWhere = {
+  isPublic: true,
+  User: { isRestricted: false },
+} satisfies Prisma.AquariumWhereInput
+
 export async function listPublicTanks(
   take: number,
   skip: number,
 ): Promise<PublicTankListResult> {
   const [data, total] = await Promise.all([
     prisma.aquarium.findMany({
-      where: { isPublic: true },
+      where: publicTankWhere,
       select: publicAquariumSummarySelect,
       orderBy: { updatedAt: 'desc' },
       take,
       skip,
     }),
-    prisma.aquarium.count({ where: { isPublic: true } }),
+    prisma.aquarium.count({ where: publicTankWhere }),
   ])
 
   return { data, take, skip, total }


### PR DESCRIPTION
### Task
cthulhuquarium/t-052: Filter isRestricted users out of the public tank browse list (kind: software)

### What changed / what I produced
- `listPublicTanks` (`server/utils/aquarium.ts`) only filtered on `Aquarium.isPublic`. `getSpeciesLeaderboard` (t-018) and `server/api/users/directory.get.ts` both also exclude `User.isRestricted` accounts from public listings. A restricted/moderated user's public tank could still surface in `/play/aquarium/browse` even though the same user is already excluded from the leaderboard.
- Added a shared `publicTankWhere` (`isPublic: true, User: { isRestricted: false }`) used by both the `findMany` and `count` calls in `listPublicTanks`, matching the leaderboard's filter shape for consistency.

### How I verified
- `npx prisma validate` — clean.
- `npx vue-tsc --noEmit` — clean, full repo.
- `npx eslint server/utils/aquarium.ts` — clean.
- `npx prettier --check server/utils/aquarium.ts` — clean.
- `npm run test:aquarium-economy` / `npm run test:aquarium-touch` — both pass unaffected (this file's other exports untouched).
- No live DB in this sandbox, so the actual filtered query wasn't run against real data — typed against the generated Prisma client via `vue-tsc`, and shaped identically to the already-shipped `getSpeciesLeaderboard` precedent in the same file.

### Stakes
reversible — read-only query filter, no schema change.

### Flags for Reviewer
None.

### Kaizen suggestion
`getPublicTankByUsernameAndSlug` (single-tank detail fetch, same file) still has no `isRestricted` check either — out of this task's stated scope (it named `listPublicTanks` specifically) but the same gap in principle. Worth a follow-up task if Silas wants full consistency across all three public-tank read paths.

### Notes for reviewer
Safe to merge on green CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_016cQ9wuqqJ3HdtfAX1zw6PK)_