### PR TITLE
ops: restore branch janitor after one-shot cleanup

### DIFF
--- a/.github/workflows/branch-janitor.yml
+++ b/.github/workflows/branch-janitor.yml
@@ -39,10 +39,8 @@ jobs:
           python-version: "3.12"
 
       - name: Delete merged branches and report stranded work
-        env:
-          FORCE_DELETE_BRANCHES: ${{ github.event_name == 'pull_request' && 'worker/mandarin-interactions-admin-sk90,worker/mandarin-requested-words-final-sk7y,worker/mandarin-requested-words-sk7y' || github.event.inputs.force_delete_branches }}
         run: |
           python scripts/branch_janitor.py \
             ${{ (github.event.inputs.dry_run == 'true') && '--dry-run' || '' }} \
-            --force-delete "$FORCE_DELETE_BRANCHES" \
+            --force-delete "${{ github.event.inputs.force_delete_branches }}" \
             | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Task
Restore `.github/workflows/branch-janitor.yml` byte-for-byte after the explicitly approved one-shot superseded-branch cleanup in #2162.

### What changed
- Removes the temporary pull-request-close force-delete environment variable.
- Restores the workflow to blob `01fdf9bf0444a120c893da20cd02ad1b787f2287`, exactly the pre-cleanup content.

### Verification
- GitHub reports the restored content blob SHA is exactly the original pre-cleanup SHA.
- Merge only after #2162's Branch janitor run confirms the three superseded refs are gone and this PR's checks finish green.

### Stakes
reversible workflow cleanup; no application or database changes.
