### PR TITLE
kind-robots/t-075: drop Character.size from production schema

### DIFF
--- a/prisma/migration-provenance/20260827233000_drop_character_size.pending.txt
+++ b/prisma/migration-provenance/20260827233000_drop_character_size.pending.txt
@@ -1,7 +1,0 @@
-# kind-robots/t-075 contract-then-migration rollout.
-# Character.size is removed from the client/schema first. Do not create or run
-# this destructive migration until the new container has been Force Updated
-# and GET /api/characters/<id> has returned HTTP 200 in production.
-# Step 2 is a human production gate; the follow-up migration PR must remove
-# this pending marker only after that gate is confirmed.
-prisma/migrations/20260827233000_drop_character_size/migration.sql

--- a/prisma/migrations/20260827233000_drop_character_size/migration.sql
+++ b/prisma/migrations/20260827233000_drop_character_size/migration.sql
@@ -1,0 +1,9 @@
+-- kind-robots/t-075, step 3 of the contract-then-migration rollout.
+--
+-- Production precondition confirmed by Silas on 2026-08-27 after Force Update:
+-- GET /api/characters/200 returned successfully with the deployed Prisma client
+-- that no longer contains Character.size.
+--
+-- The application contract has therefore moved off this column. This migration
+-- performs only the final destructive database cleanup.
+ALTER TABLE `Character` DROP COLUMN `size`;


### PR DESCRIPTION
### Task
kind-robots/t-075, step 3 of the contract-then-migration rollout.

This is the destructive database cleanup that follows #2164.

### Production gate satisfied
Silas confirmed on 2026-08-27 that, after the production Force Update, `https://kindrobots.org/api/characters/200` works. That exercises the full single-character `prisma.character.findUnique()` path with the deployed Prisma client that no longer contains `Character.size`.

### Changes
- Add `prisma/migrations/20260827233000_drop_character_size/migration.sql`.
- Migration contains only `ALTER TABLE `Character` DROP COLUMN `size`;`.
- Remove `prisma/migration-provenance/20260827233000_drop_character_size.pending.txt`, consuming the contract-first marker now that its production prerequisite is satisfied.

### Safety
- #2164 already removed `Character.size` from the application schema and generated client.
- The production detail route has been verified after deploy.
- The historical migration that added `size` remains untouched.
- This PR is intentionally **not approved for automatic merge** because the DROP is destructive/irreversible. Merge only after explicit human approval.

### Expected parity behavior
The schema already lacks `Character.size`; this PR pairs the deferred removal with its named migration and removes the pending marker in the same diff, which should satisfy Schema Migration Parity.