### PR TITLE
cthulhuquarium/t-039: the last aquarium (finale purchase + reframe)

### DIFF
--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -508,6 +508,39 @@
         </template>
       </div>
 
+      <!-- The last aquarium (cthulhuquarium/t-039): a single, standalone,
+           one-time terminal purchase -- deliberately not folded into "Set
+           pieces" above, since it never occupies a setSlotsCap slot and can
+           never be unequipped. Charlotte sells it "cheerfully and without
+           comment" per the task's own design note, so this stays a plain
+           shop row; the moment itself is the reveal dialog below. -->
+      <div
+        v-if="tankStore.finaleConfig"
+        class="flex flex-col gap-1 border-t border-base-300 pt-3"
+      >
+        <div class="flex items-start justify-between gap-2">
+          <p class="text-sm font-bold">{{ tankStore.finaleConfig.title }}</p>
+          <span
+            v-if="tankStore.finaleTriggered"
+            class="badge badge-primary badge-xs shrink-0"
+          >
+            Yours
+          </span>
+        </div>
+        <p class="text-xs italic opacity-70">
+          {{ tankStore.finaleConfig.description }}
+        </p>
+        <button
+          v-if="!tankStore.finaleTriggered"
+          type="button"
+          class="btn btn-outline btn-xs min-h-11 mt-1 self-start"
+          :disabled="tankStore.coins < tankStore.finaleConfig.cost"
+          @click="tankStore.purchaseFinale()"
+        >
+          Buy ({{ tankStore.finaleConfig.cost }})
+        </button>
+      </div>
+
       <!-- Visibility (cthulhuquarium/t-014): "Each user should be viewable"
            -- new tanks default public, and this is the one-click way to
            change that. Read-only for visitors either way: the toggle only
@@ -637,6 +670,54 @@
         </div>
         <form method="dialog" class="modal-backdrop">
           <button type="button" @click="tankStore.dismissBestiaryCompletion()">
+            close
+          </button>
+        </form>
+      </dialog>
+    </Teleport>
+
+    <!-- The finale (cthulhuquarium/t-039): "you are also in an aquarium."
+         PLACEHOLDER PRESENTATION -- the real screen-finale plate (the same
+         albumen interior stock as screen-shop/screen-bestiary, an eye
+         mid-drift and incurious beyond the pane) is queued in conductor's
+         art-generate.yaml but not yet generated. This dialog ships the
+         mechanical gate now, text-only, and gets the real plate swapped in
+         once it exists -- the exact "placeholder now, authored pass later"
+         precedent t-028/t-053 already established for the milestone toast.
+         Never re-triggers: finaleJustTriggered only ever flips true once,
+         the same one-time-reveal shape as bestiaryJustCompleted above. -->
+    <Teleport to="body">
+      <dialog
+        v-if="tankStore.finaleJustTriggered"
+        class="modal modal-open"
+        aria-modal="true"
+        @cancel.prevent="tankStore.dismissFinaleReveal()"
+      >
+        <div
+          class="modal-box flex max-w-sm flex-col items-center gap-3 rounded-3xl border border-base-300 bg-base-100 text-center shadow-2xl"
+        >
+          <Icon name="kind-icon:eye" class="size-10 text-primary" />
+          <p class="text-xs font-black uppercase tracking-wide text-primary">
+            The last aquarium
+          </p>
+          <h3 class="text-lg font-black">
+            Everything is exactly as you left it.
+          </h3>
+          <p class="text-sm opacity-80">
+            Nothing in your tank has changed. But through the glass across the
+            shop's window, something enormous drifts past, pauses for a moment
+            the way you pause at a tank you've already seen today, and moves on.
+          </p>
+          <button
+            type="button"
+            class="btn btn-primary btn-sm mt-1"
+            @click="tankStore.dismissFinaleReveal()"
+          >
+            Back to the tank
+          </button>
+        </div>
+        <form method="dialog" class="modal-backdrop">
+          <button type="button" @click="tankStore.dismissFinaleReveal()">
             close
           </button>
         </form>
@@ -1132,6 +1213,34 @@ function getWaterGradient(context: CanvasRenderingContext2D): CanvasGradient {
   return waterGradient
 }
 
+// cthulhuquarium/t-039: the finale's "cosmetic reframe" of the tank the
+// player already built. Deliberately code-only -- reframe_scope is
+// existing_tank_contents, meaning re-render what's already here rather than
+// author new content, and this canvas has never drawn a raster image at all
+// (every occupant/decor is a procedural shape), so a real asset was never
+// the right tool for this specific effect anyway. Drawn LAST, over
+// everything else, so "same fish, same set pieces, same room" never has to
+// change -- only a vignette (a photograph of the same room, not a new one)
+// plus a faint cooler wash (re-lit). Permanent once the purchase lands: this
+// function doesn't gate on anything but tankStore.finaleTriggered.
+function drawFinaleReframe(context: CanvasRenderingContext2D) {
+  const vignette = context.createRadialGradient(
+    STAGE_WIDTH / 2,
+    STAGE_HEIGHT / 2,
+    STAGE_HEIGHT * 0.25,
+    STAGE_WIDTH / 2,
+    STAGE_HEIGHT / 2,
+    STAGE_HEIGHT * 0.78,
+  )
+  vignette.addColorStop(0, 'rgba(6, 14, 20, 0)')
+  vignette.addColorStop(1, 'rgba(4, 10, 14, 0.55)')
+  context.fillStyle = vignette
+  context.fillRect(0, 0, STAGE_WIDTH, STAGE_HEIGHT)
+
+  context.fillStyle = 'rgba(70, 110, 140, 0.08)'
+  context.fillRect(0, 0, STAGE_WIDTH, STAGE_HEIGHT)
+}
+
 function render(context: CanvasRenderingContext2D) {
   context.fillStyle = getWaterGradient(context)
   context.fillRect(0, 0, STAGE_WIDTH, STAGE_HEIGHT)
@@ -1201,6 +1310,8 @@ function render(context: CanvasRenderingContext2D) {
   }
 
   if (collector.value) drawCollector(context, collector.value)
+
+  if (tankStore.finaleTriggered) drawFinaleReframe(context)
 }
 
 function step(delta: number) {
@@ -1494,6 +1605,10 @@ function handleVisibilityChange() {
 onMounted(async () => {
   await tankStore.load()
   await tankStore.loadCatalog()
+  // cthulhuquarium/t-039: loaded eagerly, not lazily behind a panel toggle
+  // like sets/decor/bestiary -- the shop row's disabled/owned state and the
+  // canvas reframe below both need finaleTriggered as soon as the tank does.
+  void tankStore.loadFinaleStatus()
   syncSwimmers()
   if (!document.hidden) startLoops()
   document.addEventListener('visibilitychange', handleVisibilityChange)

--- a/server/api/aquarium/finale/index.get.ts
+++ b/server/api/aquarium/finale/index.get.ts
@@ -1,0 +1,37 @@
+// /server/api/aquarium/finale/index.get.ts
+//
+// Reports the last-aquarium terminal purchase (cthulhuquarium/t-039):
+// its static config (cost/description) plus whether this tank has already
+// triggered it. Same shape as GET /api/aquarium/sets for the build layer.
+
+import { defineEventHandler } from 'h3'
+import { errorHandler } from '../../../utils/error'
+import { requireApiUser } from '../../../utils/authGuard'
+import { getFinaleStatusForUser } from '../../../utils/aquarium'
+
+export default defineEventHandler(async (event) => {
+  let response
+
+  try {
+    const { user } = await requireApiUser(event)
+
+    const result = await getFinaleStatusForUser(user.id, user.username)
+
+    response = {
+      success: true,
+      data: result,
+      statusCode: 200,
+    }
+    event.node.res.statusCode = 200
+  } catch (error) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+    response = {
+      success: false,
+      message: handledError.message || 'Failed to load the finale status.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+
+  return response
+})

--- a/server/api/aquarium/finale/purchase.post.ts
+++ b/server/api/aquarium/finale/purchase.post.ts
@@ -1,0 +1,39 @@
+// /server/api/aquarium/finale/purchase.post.ts
+//
+// Buys the last aquarium (cthulhuquarium/t-039): a one-time, non-refundable,
+// non-equippable terminal purchase. Priced and validated entirely
+// server-side, same discipline as sets/equip.post.ts -- rejects a repeat
+// purchase or insufficient coins. No request body.
+
+import { defineEventHandler } from 'h3'
+import { errorHandler } from '../../../utils/error'
+import { requireApiUser } from '../../../utils/authGuard'
+import { purchaseLastAquariumForUser } from '../../../utils/aquarium'
+
+export default defineEventHandler(async (event) => {
+  let response
+
+  try {
+    const { user } = await requireApiUser(event)
+
+    const result = await purchaseLastAquariumForUser(user.id, user.username)
+
+    response = {
+      success: true,
+      message: 'The last aquarium is yours.',
+      data: result,
+      statusCode: 201,
+    }
+    event.node.res.statusCode = 201
+  } catch (error) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+    response = {
+      success: false,
+      message: handledError.message || 'Could not buy the last aquarium.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+
+  return response
+})

--- a/server/utils/aquarium.ts
+++ b/server/utils/aquarium.ts
@@ -30,6 +30,7 @@ import {
   isKnownDecorKind,
   isKnownSetPieceKind,
   justCompletedBestiary as computeJustCompletedBestiary,
+  LAST_AQUARIUM_CONFIG,
   MAX_CLEAN_CLICKS_PER_REQUEST,
   mergeBestStats,
   rollRareEvent,
@@ -37,6 +38,7 @@ import {
   settleTick,
   unlockCost,
   type BestiaryMilestoneConfig,
+  type LastAquariumConfig,
   type RareEventResult,
   type StatBlock,
 } from './aquariumEconomy'
@@ -1404,6 +1406,84 @@ export async function unequipSetForUser(
   })
 
   return { aquarium: toClientAquarium(aquarium) }
+}
+
+// ---------------------------------------------------------------------------
+// The last aquarium (cthulhuquarium/t-039) -- a single, standalone terminal
+// purchase. Not a SetPieceKind: it never occupies a setSlotsCap slot and can
+// never be unequipped -- once bought it's permanent, the same "not a
+// refundable purchase" shape as a species unlock. "Has this fired" lives on
+// an AquariumEvent guard rather than a durable Aquarium column, the same
+// idempotency shape as BESTIARY_COMPLETE_EVENT_KIND above -- a boolean this
+// cheap to derive doesn't need its own migration.
+// ---------------------------------------------------------------------------
+
+const FINALE_EVENT_KIND = 'finale'
+
+export interface FinaleStatus {
+  config: LastAquariumConfig
+  triggered: boolean
+}
+
+export async function getFinaleStatusForUser(
+  userId: number,
+  username: string,
+): Promise<FinaleStatus> {
+  const tank = await getOrCreateTankForUser(userId, username)
+  const fired = await prisma.aquariumEvent.findFirst({
+    where: { aquariumId: tank.id, kind: FINALE_EVENT_KIND },
+    select: { id: true },
+  })
+  return { config: LAST_AQUARIUM_CONFIG, triggered: Boolean(fired) }
+}
+
+export interface PurchaseLastAquariumResult {
+  aquarium: ClientAquarium
+  // Always true on a successful response -- purchaseLastAquariumForUser
+  // throws (409) rather than returning false for an already-triggered tank,
+  // same convention as equipSetForUser's duplicate-equip guard above. Kept
+  // as an explicit field (rather than the caller inferring "success means
+  // triggered") so the client response shape matches PurchaseSpeciesResult's
+  // justCompletedBestiary convention -- a boolean the frontend watches to
+  // fire a one-time reveal, not a status the frontend has to derive.
+  finaleJustTriggered: boolean
+}
+
+export async function purchaseLastAquariumForUser(
+  userId: number,
+  username: string,
+): Promise<PurchaseLastAquariumResult> {
+  const tank = await getOrCreateTankForUser(userId, username)
+
+  const alreadyTriggered = await prisma.aquariumEvent.findFirst({
+    where: { aquariumId: tank.id, kind: FINALE_EVENT_KIND },
+    select: { id: true },
+  })
+  if (alreadyTriggered) {
+    throw apiError(409, `${LAST_AQUARIUM_CONFIG.title} is already yours.`)
+  }
+  if (tank.coins < LAST_AQUARIUM_CONFIG.cost) {
+    throw apiError(
+      402,
+      `${LAST_AQUARIUM_CONFIG.title} costs ${LAST_AQUARIUM_CONFIG.cost} coins; your tank only has ${tank.coins}.`,
+    )
+  }
+
+  const aquarium = await prisma.$transaction(async (tx) => {
+    const updated = await tx.aquarium.update({
+      where: { id: tank.id },
+      data: { coins: { decrement: LAST_AQUARIUM_CONFIG.cost } },
+      select: ownedAquariumSelect,
+    })
+
+    await logEvent(tx, tank.id, FINALE_EVENT_KIND, {
+      cost: LAST_AQUARIUM_CONFIG.cost,
+    })
+
+    return updated
+  })
+
+  return { aquarium: toClientAquarium(aquarium), finaleJustTriggered: true }
 }
 
 // ---------------------------------------------------------------------------

--- a/server/utils/aquariumEconomy.ts
+++ b/server/utils/aquariumEconomy.ts
@@ -360,6 +360,39 @@ export function isKnownSetPieceKind(kind: string): kind is SetPieceKind {
   return Object.prototype.hasOwnProperty.call(SET_PIECE_CATALOG, kind)
 }
 
+// ---------------------------------------------------------------------------
+// The last aquarium -- cthulhuquarium/t-039, economy.yaml's `last_aquarium`.
+// Deliberately NOT a SetPieceKind: it doesn't occupy a setSlotsCap slot and
+// can never be unequipped -- a one-time terminal purchase, permanent the
+// moment it's bought, same as a species unlock (aquarium.ts's
+// purchaseLastAquariumForUser). `slotsCapDelta: 0` is the whole point: this
+// is the one purchasable thing in the game whose effect is purely
+// `cosmetic_reframe`, so SYSTEMS.md's "coins buy breadth, milestones buy
+// room" needs no exception at all -- see the task note for the full design
+// reasoning. It is also, by design, the single most expensive item here.
+// ---------------------------------------------------------------------------
+
+export interface LastAquariumConfig {
+  title: string
+  description: string
+  cost: number
+  effect: 'cosmetic_reframe'
+  // Machine-readable form of "same fish, same set pieces, same room --
+  // re-lit, re-framed, seen from a step further back" (the task note's own
+  // phrase): the purchase re-renders what the player already owns rather
+  // than adding new content.
+  reframeScope: 'existing_tank_contents'
+}
+
+export const LAST_AQUARIUM_CONFIG: LastAquariumConfig = {
+  title: 'The Last Aquarium',
+  description:
+    'An enormous ornate tank, empty on its plinth. Buying it changes nothing about what you already keep -- it only changes how you see it.',
+  cost: 250000,
+  effect: 'cosmetic_reframe',
+  reframeScope: 'existing_tank_contents',
+}
+
 // economy.yaml's own `no_stack_idle_effects`: roaming_collector and
 // idle_hoarder are two fictions over the same underlying "bonus income
 // while away" lever, not two independently-stacking bonuses -- equipping

--- a/stores/cthulhuquariumTankStore.ts
+++ b/stores/cthulhuquariumTankStore.ts
@@ -199,6 +199,27 @@ interface SetVisibilityResponse {
   aquarium: Tank
 }
 
+// cthulhuquarium/t-039: the terminal purchase's static config, as returned
+// by GET /api/aquarium/finale (server/utils/aquariumEconomy.ts's
+// LAST_AQUARIUM_CONFIG).
+export interface FinaleConfig {
+  title: string
+  description: string
+  cost: number
+  effect: 'cosmetic_reframe'
+  reframeScope: 'existing_tank_contents'
+}
+
+interface FinaleStatusResponse {
+  config: FinaleConfig
+  triggered: boolean
+}
+
+interface PurchaseFinaleResponse {
+  aquarium: Tank
+  finaleJustTriggered: boolean
+}
+
 interface CleanResponse {
   aquarium: Tank
   debrisLevel: number
@@ -326,6 +347,19 @@ export const useCthulhuquariumTankStore = defineStore(
     // Mirrors stage-manager.vue's pendingPerformer idiom: choose, then
     // click to commit.
     const pendingDecorKind = ref<string | null>(null)
+
+    // cthulhuquarium/t-039: the last aquarium. Loaded lazily on mount (not
+    // gated behind a panel toggle like sets/decor/bestiary above) since the
+    // shop button's disabled/owned state needs `finaleTriggered` immediately,
+    // not only once a player opens a collapsed section.
+    const finaleConfig = ref<FinaleConfig | null>(null)
+    const finaleTriggered = ref(false)
+    const finaleLoading = ref(false)
+    // Set once, the moment a purchase's response confirms the finale just
+    // fired -- the game component watches it for the one-time reveal dialog,
+    // then clears it via dismissFinaleReveal(). Never re-derived from
+    // finaleTriggered, so reloading the status later can't retrigger it.
+    const finaleJustTriggered = ref(false)
 
     const stock = computed(() => tank.value?.Stock ?? [])
     const coins = computed(() => tank.value?.coins ?? 0)
@@ -669,6 +703,42 @@ export const useCthulhuquariumTankStore = defineStore(
       return false
     }
 
+    // cthulhuquarium/t-039: loaded once on mount (see finaleConfig's own
+    // comment for why this isn't lazy like sets/decor/bestiary).
+    async function loadFinaleStatus(): Promise<void> {
+      finaleLoading.value = true
+      try {
+        const res = await performFetch<FinaleStatusResponse>(
+          '/api/aquarium/finale',
+        )
+        if (res.success && res.data) {
+          finaleConfig.value = res.data.config
+          finaleTriggered.value = res.data.triggered
+        }
+      } finally {
+        finaleLoading.value = false
+      }
+    }
+
+    async function purchaseFinale(): Promise<boolean> {
+      const res = await performFetch<PurchaseFinaleResponse>(
+        '/api/aquarium/finale/purchase',
+        { method: 'POST' },
+      )
+      if (res.success && res.data) {
+        tank.value = res.data.aquarium
+        finaleTriggered.value = true
+        if (res.data.finaleJustTriggered) finaleJustTriggered.value = true
+        return true
+      }
+      error.value = res.message || 'Could not buy the last aquarium.'
+      return false
+    }
+
+    function dismissFinaleReveal(): void {
+      finaleJustTriggered.value = false
+    }
+
     return {
       tank,
       catalog,
@@ -722,6 +792,13 @@ export const useCthulhuquariumTankStore = defineStore(
       purchaseDecor,
       moveDecor,
       removeDecor,
+      finaleConfig,
+      finaleTriggered,
+      finaleLoading,
+      finaleJustTriggered,
+      loadFinaleStatus,
+      purchaseFinale,
+      dismissFinaleReveal,
     }
   },
 )

--- a/utils/scripts/verifyAquariumEconomy.test.ts
+++ b/utils/scripts/verifyAquariumEconomy.test.ts
@@ -20,6 +20,7 @@ import {
   feedCoinRebate,
   firedBestiaryMilestones,
   isKnownSetPieceKind,
+  LAST_AQUARIUM_CONFIG,
   MAX_ACCRUAL_TICKS,
   MAX_CLEAN_CLICKS_PER_REQUEST,
   NO_STACK_IDLE_SET_KINDS,
@@ -936,6 +937,30 @@ assert.equal(
 
 console.log(
   "✅ rollRareEvent: bonusCoins scales linearly across each kind's configured range, floored, never exceeds bonusCoinsMax",
+)
+
+// --- the last aquarium (cthulhuquarium/t-039): a standalone terminal
+// purchase, not a SetPieceKind -------------------------------------------
+
+assert.equal(LAST_AQUARIUM_CONFIG.effect, 'cosmetic_reframe')
+assert.equal(LAST_AQUARIUM_CONFIG.reframeScope, 'existing_tank_contents')
+assert.ok(
+  LAST_AQUARIUM_CONFIG.cost > 0,
+  'the last aquarium must cost something -- it is a purchase, not a freebie',
+)
+assert.ok(
+  LAST_AQUARIUM_CONFIG.cost >
+    Math.max(...SET_PIECE_KINDS.map((kind) => SET_PIECE_CATALOG[kind].cost)),
+  'the last aquarium is, by design, the single most expensive purchasable in the game',
+)
+assert.equal(
+  isKnownSetPieceKind('last_aquarium'),
+  false,
+  'the last aquarium is intentionally not a SetPieceKind -- it never occupies a setSlotsCap slot and is never equipped/unequipped',
+)
+
+console.log(
+  '✅ LAST_AQUARIUM_CONFIG: priced above every set piece, purely cosmetic_reframe, and not a SetPieceKind',
 )
 
 console.log('✅ verifyAquariumEconomy: all assertions passed')


### PR DESCRIPTION
### Task
cthulhuquarium/t-039: "The finale — the eye at the window, and the last tank that has to exist first"  (kind: software)

### What changed / what I produced
- `server/utils/aquariumEconomy.ts`: `LAST_AQUARIUM_CONFIG` — a standalone terminal purchase (250000 coins, `effect: cosmetic_reframe`), deliberately **not** a `SetPieceKind` since it never occupies a `setSlotsCap` slot and can never be unequipped. Keeps SYSTEMS.md's "coins buy breadth, milestones buy room" with zero exceptions.
- `server/utils/aquarium.ts`: `getFinaleStatusForUser` / `purchaseLastAquariumForUser`, guarded by a `'finale'` `AquariumEvent` (same idempotency shape as `BESTIARY_COMPLETE_EVENT_KIND` — no migration needed).
- `server/api/aquarium/finale/{index.get,purchase.post}.ts`: new endpoints mirroring the existing `sets/equip` pattern.
- `stores/cthulhuquariumTankStore.ts` + `components/cthulhuquarium/cthulhuquarium-game.vue`: a shop row for the purchase, a one-time reveal dialog, and a permanent canvas vignette/cool-wash "reframe" once triggered.
- `utils/scripts/verifyAquariumEconomy.test.ts`: assertions on `LAST_AQUARIUM_CONFIG` (priced above every set piece, purely cosmetic, not a `SetPieceKind`).

### How I verified
- `npx vue-tsc --noEmit` — clean.
- `npx eslint` on every changed file — clean.
- `npx prettier --check` on every changed file — clean.
- `npx prisma validate` — clean (no schema change at all).
- `npm run test:aquarium-economy` — all green, including the new assertions.
- `npm run test:aquarium-touch` — green, unaffected.
- `npm run test:layout-contract` — holds, no new violations.

### Stakes
reversible

### Flags for Reviewer
- **Placeholder art, by design.** The task note calls for the finale to swap in a real illustrated interstitial (`screen-finale`, an eye "mid-drift and incurious" beyond a window pane) and a shop plate (`set-last-aquarium`) — both are queued in conductor's `art-generate.yaml` (`build_cthulhuquarium_art_queue.py`) but **not yet generated**. Rather than block the whole feature on the render pipeline, I shipped the mechanical gate now with a text-only reveal dialog, following the exact "placeholder now, authored pass later" precedent t-028/t-053 already established for the milestone toast. Filed a conductor follow-up task to swap in the real plates once they exist.
- **The "cosmetic reframe" is a vignette, not a raster re-render.** The live tank canvas has never drawn a single raster image — every fish/decor is a procedural shape (ellipses, gradients, emoji glyphs) — so I kept the reframe code-only: a radial vignette + a faint cool wash, drawn last, permanent once `finaleTriggered` is true. This can't be visually spot-checked from this sandbox (no browser/canvas rendering available here) — worth a look once deployed.
- `last_aquarium` is intentionally **not** added to `SET_PIECE_CATALOG`/`SetPieceKind` — it has different semantics (permanent, no equip slot, no unequip) from every existing set piece, so it gets its own dedicated purchase path instead of overloading the equip/unequip flow.

### Kaizen suggestion
`firedMilestones` (t-028's bestiary-breakpoint signal) is computed server-side but never consumed client-side — dead data on the wire. cthulhuquarium/t-053 is already tracking this as its own task (a generic milestone/bestiary-completion toast), so no new task needed here, just flagging that this PR's `finaleJustTriggered`/reveal-dialog pattern is a ready-made template for that same wiring.

### Notes for reviewer
This is the last of the three `t-039` blockers (t-032, t-028, t-017 all `done`); the design question itself was already fully settled by Silas on 2026-08-25 per the task's own note. Real art landing is the one remaining piece, tracked as a conductor follow-up rather than blocking this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FD92r1PTFN5Ywhi9eLAefi)_