### PR TITLE
cthulhuquarium/t-029: genetics — hidden stats, breeding, secret evolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:mana-attribution": "tsx utils/scripts/verifyManaAttribution.test.ts",
     "test:revenue-split": "tsx utils/scripts/verifyRevenueSplit.test.ts",
     "test:aquarium-economy": "tsx utils/scripts/verifyAquariumEconomy.test.ts",
+    "test:aquarium-genetics": "tsx utils/scripts/verifyAquariumGenetics.test.ts",
     "test:aquarium-touch": "tsx utils/scripts/verifyAquariumTouch.test.ts",
     "test:creator-earnings": "tsx utils/scripts/verifyCreatorEarnings.test.ts",
     "test:social-post-draft": "tsx utils/scripts/verifySocialPostDraft.test.ts",

--- a/server/api/aquarium/breed.post.ts
+++ b/server/api/aquarium/breed.post.ts
@@ -1,0 +1,66 @@
+// /server/api/aquarium/breed.post.ts
+//
+// Breeds two individuals of the same species in the authenticated user's
+// tank into a new offspring, priced and validated entirely server-side
+// (cthulhuquarium/t-029). Parents are never consumed or modified -- see
+// server/utils/aquarium.ts's breedFishForUser header comment for the full
+// design rationale and the v1 same-species scope decision.
+//
+// Body: { parentAId: number, parentBId: number }
+
+import { defineEventHandler, readBody, createError } from 'h3'
+import { errorHandler } from '../../utils/error'
+import { requireApiUser } from '../../utils/authGuard'
+import { breedFishForUser } from '../../utils/aquarium'
+
+export default defineEventHandler(async (event) => {
+  let response
+
+  try {
+    const { user } = await requireApiUser(event)
+
+    const body = await readBody(event)
+    const parentAId = Number(body?.parentAId)
+    const parentBId = Number(body?.parentBId)
+
+    if (!Number.isInteger(parentAId) || parentAId <= 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'parentAId must be a positive integer.',
+      })
+    }
+    if (!Number.isInteger(parentBId) || parentBId <= 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'parentBId must be a positive integer.',
+      })
+    }
+
+    const result = await breedFishForUser(
+      user.id,
+      user.username,
+      parentAId,
+      parentBId,
+    )
+
+    response = {
+      success: true,
+      message: result.evolved
+        ? `A secret evolution! Bred for ${result.cost} coins.`
+        : `Bred for ${result.cost} coins.`,
+      data: result,
+      statusCode: 201,
+    }
+    event.node.res.statusCode = 201
+  } catch (error) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+    response = {
+      success: false,
+      message: handledError.message || 'Failed to breed fish.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+
+  return response
+})

--- a/server/utils/aquarium.ts
+++ b/server/utils/aquarium.ts
@@ -16,9 +16,11 @@ import type { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from './prisma'
 import { getUniqueAquariumSlugForUser } from './aquariumSlug'
 import {
+  breedCost,
   cleanDebris,
   clampDecorCoordinate,
   conflictsWithEquippedIdleSet,
+  convergeBreedStats,
   DECOR_CATALOG,
   deriveFishRarityTier,
   effectiveSizeCap,
@@ -33,14 +35,18 @@ import {
   LAST_AQUARIUM_CONFIG,
   MAX_CLEAN_CLICKS_PER_REQUEST,
   mergeBestStats,
+  qualifiesForBreedingEvolution,
+  rollIndividualStats,
   rollRareEvent,
   SET_PIECE_CATALOG,
   settleTick,
+  STAT_BLOCK_KEYS,
   unlockCost,
   type BestiaryMilestoneConfig,
   type LastAquariumConfig,
   type RareEventResult,
   type StatBlock,
+  type StatRolls,
 } from './aquariumEconomy'
 
 function apiError(statusCode: number, message: string): Error {
@@ -637,6 +643,52 @@ function fromStatBlock(stats: StatBlock): CodexBestStatColumns {
   }
 }
 
+// cthulhuquarium/t-029: AquariumStock's own individual stat* columns --
+// same shape/role as CodexBestStatColumns above, but for the fish's OWN
+// rolled stats rather than the book's per-species best-ever record.
+interface IndividualStatColumns {
+  statCharm: number | null
+  statEmpathy: number | null
+  statGrace: number | null
+  statLuck: number | null
+  statMight: number | null
+  statWits: number | null
+}
+
+function toIndividualStatBlock(row: IndividualStatColumns): StatBlock {
+  return {
+    charm: row.statCharm,
+    empathy: row.statEmpathy,
+    grace: row.statGrace,
+    luck: row.statLuck,
+    might: row.statMight,
+    wits: row.statWits,
+  }
+}
+
+function fromIndividualStatBlock(stats: StatBlock): IndividualStatColumns {
+  return {
+    statCharm: stats.charm,
+    statEmpathy: stats.empathy,
+    statGrace: stats.grace,
+    statLuck: stats.luck,
+    statMight: stats.might,
+    statWits: stats.wits,
+  }
+}
+
+// One fresh [0,1) roll per hidden stat -- the one place in this file that
+// actually calls Math.random, threaded into aquariumEconomy.ts's pure
+// rollIndividualStats/convergeBreedStats functions (same "randomness lives
+// outside the pure module" discipline as rollRareEvent's call site below).
+function rollSixRandoms(): StatRolls {
+  const rolls = {} as Record<(typeof STAT_BLOCK_KEYS)[number], number>
+  for (const key of STAT_BLOCK_KEYS) {
+    rolls[key] = Math.random()
+  }
+  return rolls
+}
+
 function toBestiaryEntry(
   monster: BestiaryMonster,
   firstAcquiredAt: Date | null,
@@ -826,6 +878,11 @@ export async function purchaseSpeciesForUser(
     )
   }
 
+  // t-029: roll this individual's hidden stats once, on acquisition --
+  // never rerolled afterward (SYSTEMS.md "Hidden stats are discovered, not
+  // rolled-for-forever").
+  const rolledStats = rollIndividualStats(monster, rollSixRandoms())
+
   const { aquarium, stock, justCompletedBestiary, firedMilestones } =
     await prisma.$transaction(async (tx) => {
       const { totalCount, collectedCount: collectedCountBefore } =
@@ -836,6 +893,7 @@ export async function purchaseSpeciesForUser(
           aquariumId: tank.id,
           monsterId: monster.id,
           hunger: HUNGER_STARTING_VALUE,
+          ...fromIndividualStatBlock(rolledStats),
         },
         select: ownedStockSelect,
       })
@@ -853,16 +911,11 @@ export async function purchaseSpeciesForUser(
         where: { userId_monsterId: { userId, monsterId: monster.id } },
         select: { id: true, ...codexBestStatSelect },
       })
-      // t-031: fold this individual's rolled stats into the book's
-      // best-ever record. createdStock above always has null stat columns
-      // today (t-029/genetics hasn't landed -- see mergeBestStats's own
-      // comment), so NULL_STAT_BLOCK is not a shortcut, it's the actual
-      // observed value; this still runs the real merge so the record is
-      // wired correctly the moment t-029 starts rolling individuals rather
-      // than needing a second pass through this call site later.
+      // t-031/t-029: fold this individual's freshly-rolled stats into the
+      // book's best-ever record.
       const mergedStats = mergeBestStats(
         existingEntry ? toStatBlock(existingEntry) : NULL_STAT_BLOCK,
-        NULL_STAT_BLOCK,
+        rolledStats,
       )
       await tx.aquariumCodexEntry.upsert({
         where: { userId_monsterId: { userId, monsterId: monster.id } },
@@ -969,6 +1022,300 @@ export async function purchaseSpeciesForUser(
     aquarium: toClientAquarium(aquarium),
     stock,
     cost,
+    justCompletedBestiary,
+    firedMilestones,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Breeding -- cthulhuquarium/t-029. "Breeding never consumes the parents"
+// (SYSTEMS.md): both parent AquariumStock rows are read-only here, never
+// updated or deleted -- only a new offspring row is created, linked back to
+// both via parentAId/parentBId (nullable/SetNull, per t-032's own schema
+// comment on those columns).
+//
+// v1 SCOPE DECISION (flagged for reviewer/Silas): only two individuals of
+// the SAME species may breed together. SYSTEMS.md describes secret
+// evolution as "a second, separate evolution axis... same evolves_to
+// plumbing" as growth evolution, and Monster.evolvesToId/evolutionKind are
+// both PER-SPECIES fields, not a cross-species pairing rule -- there is no
+// design text describing what a cross-species offspring's species would
+// even be. Same-species pairing is the smallest change that satisfies every
+// written rule (never consumes parents, converges stats, unlocks a second
+// evolution axis) without inventing an unspecified hybridization mechanic.
+// Revisit if Silas wants cross-species breeding.
+// ---------------------------------------------------------------------------
+
+const breedStockSelect = {
+  id: true,
+  aquariumId: true,
+  monsterId: true,
+  statCharm: true,
+  statEmpathy: true,
+  statGrace: true,
+  statLuck: true,
+  statMight: true,
+  statWits: true,
+  Monster: {
+    select: {
+      id: true,
+      name: true,
+      size: true,
+      isActive: true,
+      isPublic: true,
+      evolutionKind: true,
+      evolvesToId: true,
+      ...monsterRaritySelect,
+      ...monsterEconomyOverridesSelect,
+    },
+  },
+} satisfies Prisma.AquariumStockSelect
+
+type BreedParentStock = Prisma.AquariumStockGetPayload<{
+  select: typeof breedStockSelect
+}>
+
+export interface BreedResult {
+  aquarium: ClientAquarium
+  stock: OwnedAquarium['Stock'][number]
+  cost: number
+  // True when the offspring's rolled stats qualified for the parent
+  // species' Monster.evolutionKind === 'BREEDING' secret evolution -- the
+  // created stock row is then the EVOLVED species, not the parents' own.
+  evolved: boolean
+  justCompletedBestiary: boolean
+  firedMilestones: BestiaryMilestoneConfig[]
+}
+
+export async function breedFishForUser(
+  userId: number,
+  username: string,
+  parentAId: number,
+  parentBId: number,
+): Promise<BreedResult> {
+  if (parentAId === parentBId) {
+    throw apiError(
+      400,
+      'A fish cannot breed with itself -- pick two different individuals.',
+    )
+  }
+
+  const tank = await getOrCreateTankForUser(userId, username)
+
+  const [parentA, parentB]: [BreedParentStock | null, BreedParentStock | null] =
+    await Promise.all([
+      prisma.aquariumStock.findUnique({
+        where: { id: parentAId },
+        select: breedStockSelect,
+      }),
+      prisma.aquariumStock.findUnique({
+        where: { id: parentBId },
+        select: breedStockSelect,
+      }),
+    ])
+
+  // Always scoped back to the caller's own tank (tank.id, resolved from the
+  // verified userId above) -- never trust aquariumId from the client, same
+  // ownership discipline as every other route in this file.
+  if (!parentA || parentA.aquariumId !== tank.id) {
+    throw apiError(404, `Fish ${parentAId} is not in your tank.`)
+  }
+  if (!parentB || parentB.aquariumId !== tank.id) {
+    throw apiError(404, `Fish ${parentBId} is not in your tank.`)
+  }
+  if (parentA.monsterId !== parentB.monsterId) {
+    throw apiError(
+      409,
+      'Only two of the same species can breed together (for now).',
+    )
+  }
+
+  const monster = parentA.Monster
+  if (!monster.isActive || !monster.isPublic) {
+    throw apiError(409, `${monster.name} is not currently breedable.`)
+  }
+
+  const currentSize = tank.Stock.reduce(
+    (sum, row) => sum + (row.Monster.size ?? 1),
+    0,
+  )
+  const offspringSize = monster.size ?? 1
+  if (currentSize + offspringSize > tank.effectiveSizeCap) {
+    throw apiError(
+      409,
+      `Breeding would exceed your tank's capacity (${currentSize}/${tank.effectiveSizeCap} used).`,
+    )
+  }
+
+  const rarity = deriveFishRarityTier(monster)
+  const cost = breedCost(rarity, monster.unlockCost)
+  if (tank.coins < cost) {
+    throw apiError(
+      402,
+      `Breeding costs ${cost} coins; your tank only has ${tank.coins}.`,
+    )
+  }
+
+  const offspringStats = convergeBreedStats(
+    toIndividualStatBlock(parentA),
+    toIndividualStatBlock(parentB),
+    rollSixRandoms(),
+  )
+
+  // Secret evolution (Monster.evolutionKind === 'BREEDING'): gated on the
+  // offspring's own rolled stats, not on the pairing alone -- "the payoff"
+  // (SYSTEMS.md), not a guaranteed outcome of breeding at all. Re-checks the
+  // evolved species is itself active/public before committing to it, same
+  // as purchaseSpeciesForUser's own monster lookup -- an evolvesToId
+  // pointing at a retired/unpublished species falls back to the parents'
+  // own species rather than creating an offspring nobody can otherwise own.
+  let evolved = false
+  let offspringMonsterId = monster.id
+  if (
+    monster.evolutionKind === 'BREEDING' &&
+    monster.evolvesToId &&
+    qualifiesForBreedingEvolution(offspringStats)
+  ) {
+    const evolvedMonster = await prisma.monster.findFirst({
+      where: { id: monster.evolvesToId, isActive: true, isPublic: true },
+      select: { id: true },
+    })
+    if (evolvedMonster) {
+      offspringMonsterId = evolvedMonster.id
+      evolved = true
+    }
+  }
+
+  const { aquarium, stock, justCompletedBestiary, firedMilestones } =
+    await prisma.$transaction(async (tx) => {
+      const { totalCount, collectedCount: collectedCountBefore } =
+        await countBestiaryTotals(tx, userId)
+
+      const createdStock = await tx.aquariumStock.create({
+        data: {
+          aquariumId: tank.id,
+          monsterId: offspringMonsterId,
+          hunger: HUNGER_STARTING_VALUE,
+          parentAId: parentA.id,
+          parentBId: parentB.id,
+          ...fromIndividualStatBlock(offspringStats),
+        },
+        select: ownedStockSelect,
+      })
+
+      const existingEntry = await tx.aquariumCodexEntry.findUnique({
+        where: {
+          userId_monsterId: { userId, monsterId: offspringMonsterId },
+        },
+        select: { id: true, ...codexBestStatSelect },
+      })
+      const mergedStats = mergeBestStats(
+        existingEntry ? toStatBlock(existingEntry) : NULL_STAT_BLOCK,
+        offspringStats,
+      )
+      await tx.aquariumCodexEntry.upsert({
+        where: {
+          userId_monsterId: { userId, monsterId: offspringMonsterId },
+        },
+        create: {
+          userId,
+          monsterId: offspringMonsterId,
+          ...fromStatBlock(mergedStats),
+        },
+        update: { ...fromStatBlock(mergedStats) },
+      })
+      const collectedCountAfter = collectedCountBefore + (existingEntry ? 0 : 1)
+
+      const candidateMilestones = firedBestiaryMilestones(
+        collectedCountBefore,
+        collectedCountAfter,
+      )
+      const firedMilestones: BestiaryMilestoneConfig[] = []
+      if (candidateMilestones.length > 0) {
+        const alreadyLoggedKinds = new Set(
+          (
+            await tx.aquariumEvent.findMany({
+              where: {
+                aquariumId: tank.id,
+                kind: { in: candidateMilestones.map(milestoneEventKind) },
+              },
+              select: { kind: true },
+            })
+          ).map((row) => row.kind),
+        )
+        for (const milestone of candidateMilestones) {
+          if (!alreadyLoggedKinds.has(milestoneEventKind(milestone))) {
+            firedMilestones.push(milestone)
+          }
+        }
+      }
+      const slotsCapDelta = firedMilestones.reduce(
+        (sum, milestone) => sum + milestone.slotsCapDelta,
+        0,
+      )
+
+      const updatedAquarium = await tx.aquarium.update({
+        where: { id: tank.id },
+        data: {
+          coins: { decrement: cost },
+          ...(slotsCapDelta > 0
+            ? { setSlotsCap: { increment: slotsCapDelta } }
+            : {}),
+        },
+        select: ownedAquariumSelect,
+      })
+
+      let justCompletedBestiary = false
+      if (
+        computeJustCompletedBestiary(
+          totalCount,
+          collectedCountBefore,
+          collectedCountAfter,
+        )
+      ) {
+        const alreadyCelebrated = await tx.aquariumEvent.findFirst({
+          where: { aquariumId: tank.id, kind: BESTIARY_COMPLETE_EVENT_KIND },
+          select: { id: true },
+        })
+        if (!alreadyCelebrated) {
+          justCompletedBestiary = true
+          await logEvent(tx, tank.id, BESTIARY_COMPLETE_EVENT_KIND, {
+            collectedCount: collectedCountAfter,
+            totalCount,
+          })
+        }
+      }
+
+      for (const milestone of firedMilestones) {
+        await logEvent(tx, tank.id, milestoneEventKind(milestone), {
+          landmark: milestone.id,
+          slotsCapDelta: milestone.slotsCapDelta,
+          collectedCount: collectedCountAfter,
+        })
+      }
+
+      await logEvent(tx, tank.id, 'breed', {
+        parentAId: parentA.id,
+        parentBId: parentB.id,
+        offspringStockId: createdStock.id,
+        monsterId: offspringMonsterId,
+        evolved,
+        cost,
+      })
+
+      return {
+        aquarium: updatedAquarium,
+        stock: createdStock,
+        justCompletedBestiary,
+        firedMilestones,
+      }
+    })
+
+  return {
+    aquarium: toClientAquarium(aquarium),
+    stock,
+    cost,
+    evolved,
     justCompletedBestiary,
     firedMilestones,
   }

--- a/server/utils/aquariumEconomy.ts
+++ b/server/utils/aquariumEconomy.ts
@@ -940,7 +940,7 @@ export interface StatBlock {
   wits: number | null
 }
 
-const STAT_BLOCK_KEYS = [
+export const STAT_BLOCK_KEYS = [
   'charm',
   'empathy',
   'grace',
@@ -964,4 +964,141 @@ export function mergeBestStats(
     merged[key] = a == null ? b : b == null ? a : Math.max(a, b)
   }
   return merged
+}
+
+// ---------------------------------------------------------------------------
+// Genetics -- cthulhuquarium/t-029 (SYSTEMS.md "Genetics: hidden stats,
+// breeding, and secret evolutions"). economy.yaml predates this design
+// section (authored 2026-08-24, after economy.yaml's schema_version 1 draft)
+// and has no `genetics` block to transcribe yet -- these constants are the
+// same kind of anchored-against-RARITY_TIERS v1 placeholder as
+// SET_PIECE_CATALOG's/DECOR_CATALOG's costs: "wrong on purpose at first,
+// fixed by t-019's balance pass" (SYSTEMS.md's own scope framing). Flagged
+// for reviewer/balance-pass revisit, same discipline as every other
+// under-tuned constant in this file.
+//
+// Randomness lives outside this file, same discipline as rollRareEvent:
+// every function below takes the caller's own [0,1) Math.random() values as
+// explicit arguments rather than calling Math.random itself.
+// ---------------------------------------------------------------------------
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.min(1, Math.max(0, value))
+}
+
+// One roll input per hidden stat, keyed the same as StatBlock/STAT_BLOCK_KEYS.
+export type StatRolls = Readonly<
+  Record<(typeof STAT_BLOCK_KEYS)[number], number>
+>
+
+// Numeric roll range for ONE individual stat, keyed by the SPECIES' own
+// Rarity tier for that stat (Monster.charm/.../wits) -- distinct from
+// RARITY_TIERS, which prices/pays a whole species rather than rolling one
+// individual's hidden number. A COMMON-tier species with a MYTHIC `luck`
+// still rolls that fish's luck from the MYTHIC range (deriveFishRarityTier's
+// same "highest stat wins" spirit, applied per-stat instead of per-species).
+export interface StatRollRange {
+  min: number
+  max: number
+}
+
+export const STAT_ROLL_RANGES: Record<Rarity, StatRollRange> = {
+  COMMON: { min: 1, max: 20 },
+  UNCOMMON: { min: 10, max: 35 },
+  RARE: { min: 25, max: 55 },
+  EPIC: { min: 45, max: 75 },
+  LEGENDARY: { min: 65, max: 90 },
+  MYTHIC: { min: 85, max: 100 },
+}
+
+export interface SpeciesStatRarities {
+  charm: Rarity
+  empathy: Rarity
+  grace: Rarity
+  luck: Rarity
+  might: Rarity
+  wits: Rarity
+}
+
+// Rolls one individual's six hidden stats on acquisition/hatch (t-029's
+// "Hidden stats are discovered" rule -- every AquariumStock is rolled once,
+// never rerolled). Each stat is drawn independently from its own species
+// Rarity tier's range, linear across [min, max], rounded to the nearest
+// integer.
+export function rollIndividualStats(
+  speciesStats: SpeciesStatRarities,
+  rolls: StatRolls,
+): StatBlock {
+  const result = {} as StatBlock
+  for (const key of STAT_BLOCK_KEYS) {
+    const range = STAT_ROLL_RANGES[speciesStats[key]]
+    const roll = clamp01(rolls[key])
+    result[key] = Math.round(range.min + roll * (range.max - range.min))
+  }
+  return result
+}
+
+// Breeding convergence (SYSTEMS.md's second genetics rule: "hidden stats are
+// discovered, not rolled-for-forever... breeding should converge -- offspring
+// should inherit toward the better parent -- so effort compounds instead of
+// resetting"). Anchors each stat INDEPENDENTLY on whichever parent rolled
+// higher for that stat (one parent can be the better source for charm, the
+// other for luck -- there is no single "better parent" as a whole), then
+// rolls the offspring's value in a narrow band ABOVE that anchor, never
+// below it. A null on one side loses to the other's real number; both null
+// stays null (an offspring of two never-rolled parents, which should not
+// happen in practice since every AquariumStock is rolled on creation, but
+// this keeps the function total rather than throwing on unexpected input).
+export const BREED_CONVERGENCE_UPSIDE = 8
+
+export function convergeBreedStats(
+  parentA: StatBlock,
+  parentB: StatBlock,
+  rolls: StatRolls,
+): StatBlock {
+  const result = {} as StatBlock
+  for (const key of STAT_BLOCK_KEYS) {
+    const a = parentA[key]
+    const b = parentB[key]
+    const anchor = a == null ? b : b == null ? a : Math.max(a, b)
+    if (anchor == null) {
+      result[key] = null
+      continue
+    }
+    const roll = clamp01(rolls[key])
+    result[key] = Math.round(anchor + roll * BREED_CONVERGENCE_UPSIDE)
+  }
+  return result
+}
+
+// Breeding cost -- priced against RARITY_TIERS as an anchor, same "not an
+// unrelated invented number" discipline as SET_PIECE_CATALOG's costs.
+// `unlockCostOverride` is Monster.unlockCost, same null-means-tier-default
+// contract as feedCost/unlockCost above.
+export const BREED_COST_FACTOR_OF_UNLOCK_COST = 0.5
+
+export function breedCost(
+  rarity: Rarity,
+  unlockCostOverride?: number | null,
+): number {
+  return Math.round(
+    unlockCost(rarity, unlockCostOverride) * BREED_COST_FACTOR_OF_UNLOCK_COST,
+  )
+}
+
+// Secret evolutions (Monster.evolutionKind === 'BREEDING') are "the payoff"
+// (SYSTEMS.md) -- gated on the offspring's rolled stats actually being good,
+// not on breeding alone, so it rewards convergence effort rather than firing
+// on the first pairing. v1 threshold: every one of the offspring's six
+// stats must average at or above this bar. [v1 placeholder -- see file
+// header; a real balance pass may prefer a per-stat minimum over an average,
+// which is a one-line change here once tuning data exists.]
+export const SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD = 85
+
+export function qualifiesForBreedingEvolution(stats: StatBlock): boolean {
+  const values = STAT_BLOCK_KEYS.map((key) => stats[key])
+  if (values.some((value) => value == null)) return false
+  const total = (values as number[]).reduce((sum, value) => sum + value, 0)
+  return total / values.length >= SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD
 }

--- a/utils/scripts/verifyAquariumGenetics.test.ts
+++ b/utils/scripts/verifyAquariumGenetics.test.ts
@@ -1,0 +1,294 @@
+// /utils/scripts/verifyAquariumGenetics.test.ts
+//
+// Regression + property test for cthulhuquarium/t-029's pure genetics core
+// (rollIndividualStats, convergeBreedStats, breedCost,
+// qualifiesForBreedingEvolution) in server/utils/aquariumEconomy.ts -- no
+// prisma, no database, no Nuxt/H3 runtime, same discipline as
+// verifyAquariumEconomy.test.ts.
+import assert from 'node:assert/strict'
+
+import {
+  BREED_CONVERGENCE_UPSIDE,
+  BREED_COST_FACTOR_OF_UNLOCK_COST,
+  breedCost,
+  convergeBreedStats,
+  mergeBestStats,
+  qualifiesForBreedingEvolution,
+  RARITY_TIERS,
+  rollIndividualStats,
+  SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD,
+  STAT_BLOCK_KEYS,
+  STAT_ROLL_RANGES,
+  unlockCost,
+  type StatBlock,
+  type StatRolls,
+} from '../../server/utils/aquariumEconomy.js'
+
+const ZERO_ROLLS: StatRolls = {
+  charm: 0,
+  empathy: 0,
+  grace: 0,
+  luck: 0,
+  might: 0,
+  wits: 0,
+}
+const MAX_ROLLS: StatRolls = {
+  charm: 0.999999,
+  empathy: 0.999999,
+  grace: 0.999999,
+  luck: 0.999999,
+  might: 0.999999,
+  wits: 0.999999,
+}
+// --- rollIndividualStats: draws from the species' own per-stat tier range --
+
+const commonSpecies = {
+  charm: 'COMMON',
+  empathy: 'COMMON',
+  grace: 'COMMON',
+  luck: 'COMMON',
+  might: 'COMMON',
+  wits: 'COMMON',
+} as const
+
+const mixedTierSpecies = {
+  charm: 'COMMON',
+  empathy: 'MYTHIC',
+  grace: 'COMMON',
+  luck: 'COMMON',
+  might: 'COMMON',
+  wits: 'COMMON',
+} as const
+
+assert.deepEqual(rollIndividualStats(commonSpecies, ZERO_ROLLS), {
+  charm: STAT_ROLL_RANGES.COMMON.min,
+  empathy: STAT_ROLL_RANGES.COMMON.min,
+  grace: STAT_ROLL_RANGES.COMMON.min,
+  luck: STAT_ROLL_RANGES.COMMON.min,
+  might: STAT_ROLL_RANGES.COMMON.min,
+  wits: STAT_ROLL_RANGES.COMMON.min,
+})
+assert.deepEqual(rollIndividualStats(commonSpecies, MAX_ROLLS), {
+  charm: STAT_ROLL_RANGES.COMMON.max,
+  empathy: STAT_ROLL_RANGES.COMMON.max,
+  grace: STAT_ROLL_RANGES.COMMON.max,
+  luck: STAT_ROLL_RANGES.COMMON.max,
+  might: STAT_ROLL_RANGES.COMMON.max,
+  wits: STAT_ROLL_RANGES.COMMON.max,
+})
+
+// A COMMON-tier species (by deriveFishRarityTier's "highest wins" spirit)
+// can still roll a MYTHIC-range value on the one stat it carries MYTHIC --
+// each stat is drawn independently from ITS OWN tier, not the species'
+// overall economic tier.
+const mixedRoll = rollIndividualStats(mixedTierSpecies, MAX_ROLLS)
+assert.equal(mixedRoll.empathy, STAT_ROLL_RANGES.MYTHIC.max)
+assert.equal(mixedRoll.charm, STAT_ROLL_RANGES.COMMON.max)
+assert.ok(
+  mixedRoll.empathy! > mixedRoll.charm!,
+  'a MYTHIC-tier stat rolls in a strictly higher range than a COMMON-tier stat on the same individual',
+)
+
+console.log(
+  '✅ rollIndividualStats: each stat draws linearly from its OWN species-tier range, independent of the other five',
+)
+
+// Every tier's range is non-degenerate and ranges are monotonically
+// non-decreasing as tier rises -- a balance-pass typo (e.g. RARE.max below
+// UNCOMMON.max) would silently make higher tiers worse, so this guards the
+// ordering invariant even though the exact numbers are placeholders.
+const TIER_ORDER = [
+  'COMMON',
+  'UNCOMMON',
+  'RARE',
+  'EPIC',
+  'LEGENDARY',
+  'MYTHIC',
+] as const
+for (let i = 0; i < TIER_ORDER.length; i++) {
+  const range = STAT_ROLL_RANGES[TIER_ORDER[i]!]
+  assert.ok(range.max > range.min, `${TIER_ORDER[i]}: max must exceed min`)
+  if (i > 0) {
+    const prev = STAT_ROLL_RANGES[TIER_ORDER[i - 1]!]
+    assert.ok(
+      range.min >= prev.min && range.max >= prev.max,
+      `${TIER_ORDER[i]} must roll no lower than ${TIER_ORDER[i - 1]} at either end of its range`,
+    )
+  }
+}
+
+console.log(
+  '✅ STAT_ROLL_RANGES: strictly non-empty per tier, monotonically non-decreasing as tier rises',
+)
+
+// --- convergeBreedStats: anchors on the higher parent, per stat, never below it --
+
+const lowParent: StatBlock = {
+  charm: 10,
+  empathy: 10,
+  grace: 10,
+  luck: 10,
+  might: 10,
+  wits: 10,
+}
+const highParent: StatBlock = {
+  charm: 50,
+  empathy: 5, // deliberately the WEAKER parent for this one stat
+  grace: 50,
+  luck: 50,
+  might: 50,
+  wits: 50,
+}
+
+const offspringFloor = convergeBreedStats(lowParent, highParent, ZERO_ROLLS)
+for (const key of STAT_BLOCK_KEYS) {
+  const anchor = Math.max(lowParent[key]!, highParent[key]!)
+  assert.equal(
+    offspringFloor[key],
+    anchor,
+    `${key}: a zero roll lands exactly on the better parent's value, never below it`,
+  )
+}
+// empathy: lowParent (10) is the BETTER parent for this one stat even
+// though highParent is better everywhere else -- convergence anchors PER
+// STAT, not on "the better parent" as a single fish.
+assert.equal(
+  offspringFloor.empathy,
+  10,
+  'convergence anchors each stat independently -- the weaker fish overall can still be the better SOURCE for one stat',
+)
+
+const offspringCeiling = convergeBreedStats(lowParent, highParent, MAX_ROLLS)
+for (const key of STAT_BLOCK_KEYS) {
+  const anchor = Math.max(lowParent[key]!, highParent[key]!)
+  assert.equal(offspringCeiling[key], anchor + BREED_CONVERGENCE_UPSIDE)
+  assert.ok(
+    offspringCeiling[key]! >= anchor,
+    'convergence never rolls BELOW the better parent -- effort compounds, it never resets',
+  )
+}
+
+// A null stat on one side (a never-rolled parent, which should not occur in
+// practice since every AquariumStock is rolled on creation) loses to the
+// other side's real number rather than propagating null.
+const nullOnOneSide = convergeBreedStats(
+  {
+    charm: null,
+    empathy: 20,
+    grace: null,
+    luck: null,
+    might: null,
+    wits: null,
+  },
+  {
+    charm: 30,
+    empathy: null,
+    grace: null,
+    luck: null,
+    might: null,
+    wits: null,
+  },
+  ZERO_ROLLS,
+)
+assert.equal(nullOnOneSide.charm, 30)
+assert.equal(nullOnOneSide.empathy, 20)
+assert.equal(
+  nullOnOneSide.grace,
+  null,
+  'both sides null stays null rather than becoming 0',
+)
+
+console.log(
+  '✅ convergeBreedStats: anchors each stat independently on the better parent, rolls a strictly-upside band above it, null-safe',
+)
+
+// --- breedCost: anchored against RARITY_TIERS, same as feedCost ------------
+
+assert.equal(BREED_COST_FACTOR_OF_UNLOCK_COST, 0.5)
+assert.equal(
+  breedCost('COMMON'),
+  Math.round(RARITY_TIERS.COMMON.unlockCost * 0.5),
+)
+assert.equal(
+  breedCost('MYTHIC'),
+  Math.round(RARITY_TIERS.MYTHIC.unlockCost * 0.5),
+)
+// Per-species unlockCost override threads through breedCost exactly like
+// feedCost/unlockCost.
+assert.equal(breedCost('COMMON', 1000), Math.round(1000 * 0.5))
+assert.equal(
+  breedCost('COMMON'),
+  Math.round(unlockCost('COMMON') * BREED_COST_FACTOR_OF_UNLOCK_COST),
+)
+
+console.log(
+  '✅ breedCost: 0.5x the species unlock cost, respects a per-species unlockCost override',
+)
+
+// --- qualifiesForBreedingEvolution: gated on stats, not on the pairing alone --
+
+const belowThreshold: StatBlock = {
+  charm: SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD - 1,
+  empathy: SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD - 1,
+  grace: SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD - 1,
+  luck: SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD - 1,
+  might: SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD - 1,
+  wits: SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD - 1,
+}
+assert.equal(qualifiesForBreedingEvolution(belowThreshold), false)
+
+const atThreshold: StatBlock = {
+  charm: SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD,
+  empathy: SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD,
+  grace: SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD,
+  luck: SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD,
+  might: SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD,
+  wits: SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD,
+}
+assert.equal(qualifiesForBreedingEvolution(atThreshold), true)
+
+// A high average with one weak stat can still average above the bar --
+// documents the current "average" rule explicitly, since a future balance
+// pass may prefer a strict per-stat minimum instead (see the function's own
+// doc comment).
+const highAverageOneWeakStat: StatBlock = {
+  charm: 100,
+  empathy: 100,
+  grace: 100,
+  luck: 100,
+  might: 100,
+  wits: 10, // average = 510/6 = 85, exactly at SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD
+}
+assert.equal(qualifiesForBreedingEvolution(highAverageOneWeakStat), true)
+
+// Any unrolled (null) stat fails the check outright rather than treating
+// null as 0 and averaging around it.
+assert.equal(
+  qualifiesForBreedingEvolution({ ...atThreshold, wits: null }),
+  false,
+  'a null stat never partially qualifies -- every stat must actually be rolled',
+)
+
+console.log(
+  '✅ qualifiesForBreedingEvolution: average-of-six gate at the configured threshold, null stats never qualify',
+)
+
+// --- mergeBestStats still holds under a real rolled/converged StatBlock ---
+// (regression guard: t-029 is the first real caller passing non-null
+// observed stats through this t-031 function.)
+
+const observed: StatBlock = { ...atThreshold, luck: 40 }
+const merged = mergeBestStats(belowThreshold, observed)
+for (const key of STAT_BLOCK_KEYS) {
+  assert.equal(
+    merged[key],
+    Math.max(belowThreshold[key]!, observed[key]!),
+    `${key}: mergeBestStats still takes the max under real rolled data`,
+  )
+}
+
+console.log(
+  '✅ mergeBestStats: correct under real rolled/converged StatBlock input, not just placeholder nulls',
+)
+
+console.log('✅ verifyAquariumGenetics: all assertions passed')


### PR DESCRIPTION
### Task
cthulhuquarium/t-029: Genetics — hidden individual stats, breeding, and secret evolutions (kind: software)

### What changed / what I produced
Wires the individual-genetics mechanic onto the `AquariumStock`/`AquariumCodexEntry` schema t-032 already shipped (`statCharm..statWits`, `parentAId`/`parentBId`, `EvolutionKind.BREEDING`/`evolvesToId` all existed but were unread until now).

- `server/utils/aquariumEconomy.ts`: `rollIndividualStats` (per-stat roll drawn from the species' own Rarity tier range — a COMMON-tier species with a MYTHIC `luck` still rolls that stat's luck from the MYTHIC range), `convergeBreedStats` (offspring inherits toward whichever parent rolled higher, **per stat independently** — not "the better parent" as a whole — in a strictly-upside band, never rerolls down), `breedCost` (anchored against `RARITY_TIERS`, same discipline as `feedCost`/`SET_PIECE_CATALOG`), `qualifiesForBreedingEvolution` (average-of-six threshold gate for secret evolutions).
- `server/utils/aquarium.ts`: `purchaseSpeciesForUser` now rolls and persists an individual's hidden stats on acquisition instead of leaving the columns null; new `breedFishForUser` transaction creates an offspring from two owned same-species parents (**parents are never modified or consumed**, per SYSTEMS.md's rule), checks tank capacity/coins, folds observed stats into the Ichthyonomicon record, fires bestiary milestones/completion exactly like a purchase does, and promotes the offspring to a species' `evolvesToId` when `evolutionKind === 'BREEDING'` and the roll qualifies.
- New `POST /api/aquarium/breed` route (`server/api/aquarium/breed.post.ts`), same shape/error-handling convention as `purchase.post.ts`/`feed.post.ts`.
- `utils/scripts/verifyAquariumGenetics.test.ts` (+ `test:aquarium-genetics` npm script): pure-function regression/property coverage for all four new economy functions — no prisma/db.

**No schema migration.** Every column this reads/writes already exists from t-032's migration.

### How I verified
- `npm run test:aquarium-genetics` — new suite, all assertions pass
- `npm run test:aquarium-economy` — no regressions
- `npx vue-tsc --noEmit` — clean
- `npx eslint` on all changed files — clean
- `npx prettier --check` on all changed files — clean
- `npx prisma validate` — schema unchanged, still valid

### Stakes
reversible

### Flags for Reviewer
- **v1 scope decision**: only two individuals of the **same species** may breed together. SYSTEMS.md describes secret evolution as "a second, separate evolution axis... same evolves_to plumbing" as growth evolution, and `Monster.evolvesToId`/`evolutionKind` are per-species fields, not a cross-species pairing rule — there's no design text specifying what a cross-species offspring's species would even be. Same-species pairing is the smallest change that satisfies every written rule without inventing an unspecified hybridization mechanic. Happy to revisit if Silas wants cross-species breeding.
- Stat roll ranges, breeding convergence upside, breed cost factor, and the secret-evolution stat threshold are all v1 placeholders anchored against `RARITY_TIERS` — same "wrong on purpose at first, fixed by t-019's balance pass" discipline as every other under-tuned constant in `aquariumEconomy.ts`. Flagged for a future balance pass, not a confirmed number.
- No frontend/store wiring in this PR (no UI for picking breeding pairs yet) — following the same "mechanical gate now, authored/UI pass later" precedent t-028/t-039/t-053 already established for this project. A follow-on task for the client surface would need to extend `stores/cthulhuquariumTankStore.ts`'s `TankStock` type with the new stat/parentage fields.
- No seed data exists yet with `evolutionKind: BREEDING` set on any species, so the secret-evolution branch is exercised by the pure `qualifiesForBreedingEvolution` unit tests but is inert in production until a species is authored with that field — same "schema-ready, unread yet" convention as `Monster.depth`.

### Kaizen suggestion
Extend `stores/cthulhuquariumTankStore.ts` and the tank UI to surface breeding as a real player action (pick two owned individuals, call `POST /api/aquarium/breed`), and author at least one species with `evolutionKind: BREEDING` + `evolvesToId` set so the secret-evolution path has real data to exercise end-to-end.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013GoquDsXoCzq3tQDe5tzPS)_