### PR TITLE
cthulhuquarium/t-053: generic bestiary-milestone toast

### DIFF
--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -60,6 +60,34 @@
         </button>
       </div>
 
+      <!-- cthulhuquarium/t-053: the generic, art-agnostic milestone toast --
+           t-028's bestiary-breakpoint gate (bestiary_5/10/15/20) fires
+           server-side and already applies the slot-cap increase before this
+           ever renders; this is only the dismissible notice saying so.
+           Same non-blocking dismissible-notice shape as the rare-event
+           block above, deliberately not a modal -- a full authored
+           Charlotte interstitial (t-028's own note) is a later layer. -->
+      <div
+        v-if="tankStore.nextMilestoneToast"
+        class="flex items-start gap-2 rounded-xl border border-success/40 bg-success/10 p-3 text-sm"
+      >
+        <Icon
+          name="kind-icon:trophy"
+          class="mt-0.5 size-4 shrink-0 text-success"
+        />
+        <p class="min-w-0 flex-1 font-bold">
+          {{ tankStore.nextMilestoneToast }}
+        </p>
+        <button
+          type="button"
+          class="btn btn-ghost btn-xs min-h-11 min-w-11 shrink-0"
+          aria-label="Dismiss"
+          @click="tankStore.dismissMilestoneToast()"
+        >
+          <Icon name="kind-icon:close" class="size-4" />
+        </button>
+      </div>
+
       <div class="flex flex-wrap items-center justify-between gap-2">
         <div class="flex items-center gap-3 text-sm font-bold">
           <span class="flex items-center gap-1">

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:aquarium-economy": "tsx utils/scripts/verifyAquariumEconomy.test.ts",
     "test:aquarium-genetics": "tsx utils/scripts/verifyAquariumGenetics.test.ts",
     "test:aquarium-touch": "tsx utils/scripts/verifyAquariumTouch.test.ts",
+    "test:aquarium-milestone-toast": "tsx utils/scripts/verifyAquariumMilestoneToast.test.ts",
     "test:creator-earnings": "tsx utils/scripts/verifyCreatorEarnings.test.ts",
     "test:social-post-draft": "tsx utils/scripts/verifySocialPostDraft.test.ts",
     "test:mission-accrual": "tsx utils/scripts/verifyMissionAccrual.test.ts",

--- a/stores/cthulhuquariumTankStore.ts
+++ b/stores/cthulhuquariumTankStore.ts
@@ -13,6 +13,7 @@
 import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
 import { performFetch } from './utils'
+import { formatMilestoneToastMessage } from '~/utils/aquariumMilestoneToast'
 
 export interface TankMonster {
   id: number
@@ -225,11 +226,23 @@ interface CleanResponse {
   debrisLevel: number
 }
 
+// cthulhuquarium/t-053: a bestiary-breakpoint milestone (t-028's
+// BESTIARY_MILESTONES) a purchase's response just fired. Declared locally
+// rather than importing server/utils/aquariumEconomy.ts's
+// BestiaryMilestoneConfig -- same frontend/backend type-boundary discipline
+// as the rest of this file.
+export interface FiredMilestone {
+  id: string
+  threshold: number
+  slotsCapDelta: number
+}
+
 interface PurchaseResponse {
   aquarium: Tank
   stock: TankStock
   cost: number
   justCompletedBestiary: boolean
+  firedMilestones: FiredMilestone[]
 }
 
 // The Ichthyonomicon -- the completionist codex (cthulhuquarium/t-024,
@@ -331,6 +344,20 @@ export const useCthulhuquariumTankStore = defineStore(
     // bestiaryCollectedCount/bestiaryTotalCount, so simply reloading the
     // bestiary later can't retrigger it.
     const bestiaryJustCompleted = ref(false)
+
+    // cthulhuquarium/t-053: any bestiary-breakpoint milestones (t-028) an
+    // unlock's response just fired, queued for a generic, art-agnostic
+    // toast -- one entry per crossed threshold, oldest first (in practice
+    // at most one per purchase, since collected count only ever advances
+    // by one species at a time, but the response shape is an array so this
+    // stays an array too). The game component reads the front entry
+    // (nextMilestoneToast below) and pops it via dismissMilestoneToast()
+    // once its toast has shown; never re-derived from bestiaryCollectedCount
+    // so reloading the bestiary later can't requeue an already-shown
+    // milestone. A full authored Charlotte interstitial (t-028's own note)
+    // is a separate, not-yet-built layer -- this is the placeholder/no-art
+    // gate itself.
+    const milestoneToastQueue = ref<FiredMilestone[]>([])
 
     // cthulhuquarium/t-026's set-piece catalog. Loaded lazily, same
     // collapsed-panel-until-opened pattern as the bestiary above -- it
@@ -477,6 +504,9 @@ export const useCthulhuquariumTankStore = defineStore(
         catalog.value = catalog.value.filter((entry) => entry.id !== monsterId)
         revealedUnlock.value = res.data.stock
         if (res.data.justCompletedBestiary) bestiaryJustCompleted.value = true
+        if (res.data.firedMilestones?.length) {
+          milestoneToastQueue.value.push(...res.data.firedMilestones)
+        }
         // A stale bestiary panel (or one never loaded yet) would otherwise
         // still show this species as uncollected after unlocking it.
         if (bestiary.value.length > 0) await loadBestiary()
@@ -548,6 +578,19 @@ export const useCthulhuquariumTankStore = defineStore(
 
     function dismissBestiaryCompletion(): void {
       bestiaryJustCompleted.value = false
+    }
+
+    // cthulhuquarium/t-053: the front of milestoneToastQueue, pre-formatted
+    // for display -- null when the queue is empty. Reading this instead of
+    // milestoneToastQueue.value[0] directly keeps the wording rule
+    // (formatMilestoneToastMessage) in one place.
+    const nextMilestoneToast = computed(() => {
+      const next = milestoneToastQueue.value[0]
+      return next ? formatMilestoneToastMessage(next) : null
+    })
+
+    function dismissMilestoneToast(): void {
+      milestoneToastQueue.value.shift()
     }
 
     // cthulhuquarium/t-026: the build layer. loadSets() is called lazily by
@@ -762,6 +805,7 @@ export const useCthulhuquariumTankStore = defineStore(
       bestiaryTotalCount,
       bestiaryLoading,
       bestiaryJustCompleted,
+      nextMilestoneToast,
       equippedSets,
       setSlotsCap,
       setCatalog,
@@ -782,6 +826,7 @@ export const useCthulhuquariumTankStore = defineStore(
       clearOfflineEarnings,
       loadBestiary,
       dismissBestiaryCompletion,
+      dismissMilestoneToast,
       loadSets,
       equipSet,
       unequipSet,

--- a/utils/aquariumMilestoneToast.ts
+++ b/utils/aquariumMilestoneToast.ts
@@ -1,0 +1,28 @@
+// /utils/aquariumMilestoneToast.ts
+//
+// cthulhuquarium/t-053: the generic, art-agnostic toast text for a bestiary
+// milestone (server/utils/aquariumEconomy.ts's BESTIARY_MILESTONES, fired by
+// t-028's firedBestiaryMilestones()). A full authored Charlotte interstitial
+// with background art is explicitly out of scope here -- see t-028's own
+// roadmap note -- this is only the placeholder wording for the mechanical
+// gate: "5 species collected -- +2 tank slots".
+//
+// Deliberately framework-free (no pinia, no fetch, no Vue) so both
+// stores/cthulhuquariumTankStore.ts and a plain `tsx` guard can use it, same
+// discipline as utils/artJobRetryNotice.ts.
+
+export type AquariumMilestoneToastInput = {
+  threshold: number
+  slotsCapDelta: number
+}
+
+export function formatMilestoneToastMessage(
+  milestone: AquariumMilestoneToastInput,
+): string {
+  // Every real BESTIARY_MILESTONES threshold is >= 5, so "species" is
+  // always plural in practice -- not special-cased against a singular
+  // threshold that can't occur.
+  const slots = Math.abs(milestone.slotsCapDelta) === 1 ? 'tank slot' : 'tank slots'
+  const sign = milestone.slotsCapDelta >= 0 ? '+' : ''
+  return `${milestone.threshold} species collected -- ${sign}${milestone.slotsCapDelta} ${slots}`
+}

--- a/utils/scripts/verifyAquariumMilestoneToast.test.ts
+++ b/utils/scripts/verifyAquariumMilestoneToast.test.ts
@@ -1,0 +1,39 @@
+// /utils/scripts/verifyAquariumMilestoneToast.test.ts
+//
+// Regression test for cthulhuquarium/t-053's generic milestone-toast
+// wording (utils/aquariumMilestoneToast.ts). No prisma, no Nuxt/H3 runtime
+// -- same discipline as verifyAquariumEconomy.test.ts and
+// verifyVideoRetryNotice.test.ts.
+import assert from 'node:assert/strict'
+
+import { formatMilestoneToastMessage } from '../aquariumMilestoneToast.js'
+
+// The four real BESTIARY_MILESTONES entries (server/utils/aquariumEconomy.ts)
+// -- each crosses at a different threshold but grants the same +2 slots.
+assert.equal(
+  formatMilestoneToastMessage({ threshold: 5, slotsCapDelta: 2 }),
+  '5 species collected -- +2 tank slots',
+)
+assert.equal(
+  formatMilestoneToastMessage({ threshold: 10, slotsCapDelta: 2 }),
+  '10 species collected -- +2 tank slots',
+)
+assert.equal(
+  formatMilestoneToastMessage({ threshold: 15, slotsCapDelta: 2 }),
+  '15 species collected -- +2 tank slots',
+)
+assert.equal(
+  formatMilestoneToastMessage({ threshold: 20, slotsCapDelta: 2 }),
+  '20 species collected -- +2 tank slots',
+)
+
+// Singular slot wording, in case a future milestone config ever grants
+// exactly one slot -- proves the plural isn't hardcoded.
+assert.equal(
+  formatMilestoneToastMessage({ threshold: 8, slotsCapDelta: 1 }),
+  '8 species collected -- +1 tank slot',
+)
+
+console.log(
+  '✅ formatMilestoneToastMessage: correct wording across every real BESTIARY_MILESTONES entry plus a singular-slot edge case',
+)


### PR DESCRIPTION
### Task
cthulhuquarium/t-053: Generic milestone/bestiary-completion toast (frontend surface for t-018/t-028's backend signals) (kind: software)

### What changed / what I produced
- `utils/aquariumMilestoneToast.ts`: pure `formatMilestoneToastMessage()` wording formatter ("5 species collected -- +2 tank slots"), framework-free like `utils/artJobRetryNotice.ts`.
- `utils/scripts/verifyAquariumMilestoneToast.test.ts` (+ `test:aquarium-milestone-toast` npm script): regression test covering every real `BESTIARY_MILESTONES` entry plus a singular-slot edge case.
- `stores/cthulhuquariumTankStore.ts`: `PurchaseResponse` now types `firedMilestones`; `unlock()` queues any fired milestones; new `nextMilestoneToast` computed / `dismissMilestoneToast()` expose and pop the front of the queue.
- `components/cthulhuquarium/cthulhuquarium-game.vue`: dismissible inline notice (not a modal), styled the same non-blocking way as the existing rare-event notice directly above it.

Server-side, `t-018`/`t-028`'s `justCompletedBestiary`/`firedMilestones` purchase-response signals already existed with zero frontend consumer — the slot-cap increase and `AquariumEvent` log already fire on the server by the time the response returns. This task only adds the frontend consumer, per its own note: a full authored Charlotte interstitial is explicitly out of scope here (see `t-028`'s roadmap note) — this ships the mechanical/placeholder gate now, the same "placeholder now, authored pass later" shape `t-039`'s finale dialog already established.

### How I verified
- `npx tsx utils/scripts/verifyAquariumMilestoneToast.test.ts` — new test passes.
- `npx tsx utils/scripts/verifyAquariumEconomy.test.ts` — full existing suite still green (no regression to `firedBestiaryMilestones`/`BESTIARY_MILESTONES`, which this PR reads but doesn't modify).
- `npx eslint` on all four changed/added files — clean.
- Full `vue-tsc --noEmit` typecheck — clean (caught and fixed one `noUncheckedIndexedAccess` narrowing issue in the new computed before this).

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
`stores/cthulhuquariumTankStore.ts`'s `unlock()` now has three near-identical "read a one-shot signal off the purchase response, stash it as a queued/one-shot ref" blocks (`justCompletedBestiary`, `firedMilestones`, and the pre-existing pattern from `t-039`'s `finaleJustTriggered` in `purchaseFinale()`). Worth a small shared helper once a fourth signal shows up, to keep `unlock()`/`purchaseFinale()` from drifting apart on this convention.

### Notes for reviewer
Conductor-side: this closes cthulhuquarium/t-053 (`depends_on: t-028`, already done). Will set `status: review` → `done` on the roadmap task in the companion conductor PR once this merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TXYGFU33qinKGhgHcUX3yB)_