### PR TITLE
cthulhuquarium/t-030: rotating shop stock, selling fish back, individual-stat economy

### DIFF
--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -216,14 +216,29 @@
                   {{ entry.Monster.species || entry.Monster.behavior || '—' }}
                 </p>
               </div>
-              <button
-                type="button"
-                class="btn btn-outline btn-xs min-h-11 min-w-11 shrink-0"
-                :disabled="entry.hunger >= 100"
-                @click="tankStore.feed(entry.id)"
-              >
-                Feed
-              </button>
+              <div class="flex shrink-0 flex-col gap-1">
+                <button
+                  type="button"
+                  class="btn btn-outline btn-xs min-h-11 min-w-11"
+                  :disabled="entry.hunger >= 100"
+                  @click="tankStore.feed(entry.id)"
+                >
+                  Feed
+                </button>
+                <!-- Sell (t-030): priced off THIS individual's own rolled
+                     stats, never a flat species price -- usually a loss, but
+                     a well-bred fish can sell for more than it cost. Always
+                     re-orderable afterward from the Ichthyonomicon below, so
+                     no confirmation dialog, same one-click shape as
+                     unequip/remove elsewhere in this component. -->
+                <button
+                  type="button"
+                  class="btn btn-outline btn-xs min-h-11 min-w-11"
+                  @click="tankStore.sell(entry.id)"
+                >
+                  Sell
+                </button>
+              </div>
             </div>
             <div
               class="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-base-300"
@@ -244,6 +259,14 @@
       <div class="flex flex-col gap-2">
         <p class="text-xs font-black uppercase tracking-wide opacity-60">
           Unlock a new occupant
+        </p>
+        <!-- t-030: the shop rotates -- this is a slice of what's never been
+             owned, not the whole remaining bestiary. Anything sold or
+             already discovered stays available any time via the
+             Ichthyonomicon's re-order button below, regardless of today's
+             slate. -->
+        <p class="text-xs italic opacity-50">
+          Today's arrivals -- check back tomorrow for more.
         </p>
         <p v-if="tankStore.catalogLoading" class="text-xs opacity-60">
           Reading the bestiary…
@@ -365,12 +388,10 @@
                 >
                   Best seen: {{ formatBestStats(entry.bestStats) }}
                 </p>
-                <!-- Re-order (t-031): the book remembers a species whether
-                     or not it's currently in the tank, so it's re-orderable
-                     from here rather than access being tied to today's
-                     rotating shop stock. Always equal to "already owned"
-                     until t-030 ships a sell path -- this button simply
-                     never renders yet in practice. -->
+                <!-- Re-order (t-031, sell path shipped in t-030): the book
+                     remembers a species whether or not it's currently in
+                     the tank, so a sold species is re-orderable from here
+                     regardless of today's rotating shop stock. -->
                 <button
                   v-if="entry.collected && !entry.currentlyOwned"
                   type="button"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:revenue-split": "tsx utils/scripts/verifyRevenueSplit.test.ts",
     "test:aquarium-economy": "tsx utils/scripts/verifyAquariumEconomy.test.ts",
     "test:aquarium-genetics": "tsx utils/scripts/verifyAquariumGenetics.test.ts",
+    "test:aquarium-shop": "tsx utils/scripts/verifyAquariumShop.test.ts",
     "test:aquarium-touch": "tsx utils/scripts/verifyAquariumTouch.test.ts",
     "test:aquarium-milestone-toast": "tsx utils/scripts/verifyAquariumMilestoneToast.test.ts",
     "test:creator-earnings": "tsx utils/scripts/verifyCreatorEarnings.test.ts",

--- a/server/api/aquarium/catalog.get.ts
+++ b/server/api/aquarium/catalog.get.ts
@@ -42,7 +42,12 @@ export default defineEventHandler(async (event) => {
     response = {
       success: true,
       data: result.data,
-      meta: { take: result.take, skip: result.skip, total: result.total },
+      meta: {
+        take: result.take,
+        skip: result.skip,
+        total: result.total,
+        dateKey: result.dateKey,
+      },
       statusCode: 200,
     }
     event.node.res.statusCode = 200

--- a/server/api/aquarium/sell.post.ts
+++ b/server/api/aquarium/sell.post.ts
@@ -1,0 +1,59 @@
+// /server/api/aquarium/sell.post.ts
+//
+// Sells one individual fish out of the authenticated user's tank back to
+// the shop, priced entirely server-side off that individual's own rolled
+// stats (cthulhuquarium/t-030) -- usually a loss, but a well-bred individual
+// can sell for more than its species' base unlock cost. The species stays
+// re-orderable afterward through the Ichthyonomicon (GET
+// /api/aquarium/bestiary's `currentlyOwned` flag + POST /api/aquarium/purchase)
+// regardless of today's rotating catalog -- selling never touches
+// AquariumCodexEntry.
+//
+// Body: { aquariumStockId: number }
+
+import { defineEventHandler, readBody, createError } from 'h3'
+import { errorHandler } from '../../utils/error'
+import { requireApiUser } from '../../utils/authGuard'
+import { sellFishForUser } from '../../utils/aquarium'
+
+export default defineEventHandler(async (event) => {
+  let response
+
+  try {
+    const { user } = await requireApiUser(event)
+
+    const body = await readBody(event)
+    const aquariumStockId = Number(body?.aquariumStockId)
+
+    if (!Number.isInteger(aquariumStockId) || aquariumStockId <= 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'aquariumStockId must be a positive integer.',
+      })
+    }
+
+    const result = await sellFishForUser(
+      user.id,
+      user.username,
+      aquariumStockId,
+    )
+
+    response = {
+      success: true,
+      message: `Sold for ${result.salePrice} coins.`,
+      data: result,
+      statusCode: 200,
+    }
+    event.node.res.statusCode = 200
+  } catch (error) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+    response = {
+      success: false,
+      message: handledError.message || 'Failed to sell that fish.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+
+  return response
+})

--- a/server/utils/aquarium.ts
+++ b/server/utils/aquarium.ts
@@ -38,9 +38,12 @@ import {
   qualifiesForBreedingEvolution,
   rollIndividualStats,
   rollRareEvent,
+  rotateShopStock,
+  sellPrice,
   SET_PIECE_CATALOG,
   settleTick,
   STAT_BLOCK_KEYS,
+  todaysShopDateKey,
   unlockCost,
   type BestiaryMilestoneConfig,
   type LastAquariumConfig,
@@ -489,11 +492,11 @@ export async function cleanTankForUser(
 // book's own best-individual-stats record (AquariumCodexEntry.bestStat*,
 // t-032's columns -- see mergeBestStats in aquariumEconomy.ts) and a
 // currentlyOwned flag distinct from collected, so a species can be "in the
-// book" without being "in the tank right now." Today those are always equal
-// (there is no sell path yet -- t-030 is `waiting` on this task), but the
-// distinction is what t-030's sell-back and re-order flow needs to exist
-// safely, per this task's own note: "t-030's rotating stock and sell-back
-// are only safe because this exists."
+// book" without being "in the tank right now." They diverge the moment a
+// fish is sold (t-030's sellFishForUser below): collected stays true
+// forever, currentlyOwned goes false, and the book's re-order affordance
+// (see toBestiaryEntry) is what makes that safe -- per t-031's own note,
+// "t-030's rotating stock and sell-back are only safe because this exists."
 // ---------------------------------------------------------------------------
 
 const BESTIARY_COMPLETE_EVENT_KIND = 'bestiary-complete'
@@ -547,8 +550,8 @@ export interface BestiaryEntry {
   firstAcquiredAt: string | null
   fieldNote: string | null
   // t-031: distinct from `collected` -- true only while a live AquariumStock
-  // row exists for this species. Always equal to `collected` until t-030
-  // ships a sell path; drives the book's re-order affordance once it does.
+  // row exists for this species. False after a sell (t-030) even though
+  // `collected` stays true forever; drives the book's re-order affordance.
   currentlyOwned: boolean
   // t-031: the book's best-individual-seen record (AquariumCodexEntry's
   // bestStat* columns). All null for any species until cthulhuquarium/t-029
@@ -1322,6 +1325,91 @@ export async function breedFishForUser(
 }
 
 // ---------------------------------------------------------------------------
+// Selling -- cthulhuquarium/t-030. Deletes the live AquariumStock row and
+// pays out aquariumEconomy.ts's sellPrice(...) coins, priced off THIS
+// individual's own rolled stats. AquariumCodexEntry (the Ichthyonomicon) is
+// never touched -- t-031's "never decreases" record is exactly what makes
+// this safe: purchaseSpeciesForUser's re-order path only checks live
+// ownership, so the species stays buyable again afterward regardless of
+// today's rotating catalog (see listCatalogForUser's own note). Selling
+// never refunds a set piece or decor slot -- this only ever touches
+// AquariumStock, same "narrow, single-purpose mutation" shape as
+// unequipSetForUser/removeDecorForUser above.
+// ---------------------------------------------------------------------------
+
+const sellStockSelect = {
+  id: true,
+  aquariumId: true,
+  monsterId: true,
+  statCharm: true,
+  statEmpathy: true,
+  statGrace: true,
+  statLuck: true,
+  statMight: true,
+  statWits: true,
+  Monster: {
+    select: {
+      name: true,
+      ...monsterRaritySelect,
+      ...monsterEconomyOverridesSelect,
+    },
+  },
+} satisfies Prisma.AquariumStockSelect
+
+export interface SellFishResult {
+  aquarium: ClientAquarium
+  monsterId: number
+  salePrice: number
+}
+
+export async function sellFishForUser(
+  userId: number,
+  username: string,
+  aquariumStockId: number,
+): Promise<SellFishResult> {
+  const tank = await getOrCreateTankForUser(userId, username)
+
+  const stock = await prisma.aquariumStock.findUnique({
+    where: { id: aquariumStockId },
+    select: sellStockSelect,
+  })
+  // Always scoped back to the caller's own tank (tank.id, resolved from the
+  // verified userId above) -- never trust aquariumId from the client, same
+  // ownership discipline as breedFishForUser's parent lookups.
+  if (!stock || stock.aquariumId !== tank.id) {
+    throw apiError(404, `Fish ${aquariumStockId} is not in your tank.`)
+  }
+
+  const rarity = deriveFishRarityTier(stock.Monster)
+  const baseCost = unlockCost(rarity, stock.Monster.unlockCost)
+  const salePrice = sellPrice(baseCost, toIndividualStatBlock(stock))
+
+  const aquarium = await prisma.$transaction(async (tx) => {
+    await tx.aquariumStock.delete({ where: { id: aquariumStockId } })
+
+    const updated = await tx.aquarium.update({
+      where: { id: tank.id },
+      data: { coins: { increment: salePrice } },
+      select: ownedAquariumSelect,
+    })
+
+    await logEvent(tx, tank.id, 'sell', {
+      aquariumStockId,
+      monsterId: stock.monsterId,
+      salePrice,
+    })
+
+    return updated
+  })
+
+  return {
+    aquarium: toClientAquarium(aquarium),
+    monsterId: stock.monsterId,
+    salePrice,
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Public browse -- display name + tank contents ONLY, never email or userId.
 // ---------------------------------------------------------------------------
 
@@ -1536,6 +1624,14 @@ export async function getSpeciesLeaderboard(
 // purchaseSpeciesForUser charges (deriveFishRarityTier + unlockCost) so the
 // displayed price never drifts from what unlocking actually costs.
 //
+// cthulhuquarium/t-030: this list is further narrowed to today's rotating
+// slate (aquariumEconomy.ts's rotateShopStock) -- "the shop rotates; the
+// book is forever". A species that has ever been owned is NOT gated by this
+// rotation at all: it stays buyable through the Ichthyonomicon's re-order
+// path (listBestiaryForUser's `currentlyOwned` flag), which calls the same
+// purchaseSpeciesForUser this catalog's `cost` mirrors. Rotation only ever
+// decides what a never-yet-owned species' DISCOVERY looks like.
+//
 // Deliberately no `fieldNote` here (cthulhuquarium/t-012): "unlocking a
 // species the player has never seen should feel like the point of the
 // game... the field note reveals on first unlock, not before." The
@@ -1574,6 +1670,10 @@ export interface CatalogResult {
   take: number
   skip: number
   total: number
+  // cthulhuquarium/t-030: today's UTC rotation key (aquariumEconomy.ts's
+  // todaysShopDateKey), so the client can tell "still today's slate" from
+  // "the shop rotated" without re-deriving the date itself.
+  dateKey: string
 }
 
 export async function listCatalogForUser(
@@ -1589,11 +1689,33 @@ export async function listCatalogForUser(
   // column) -- a ruler-hooked-only row should not show up here as
   // unlockable. cthulhuquarium/t-022 (shared bestiary handshake) owns
   // deciding cross-game unlock rules beyond this simple membership filter.
-  const where: Prisma.MonsterWhereInput = {
+  const eligibleWhere: Prisma.MonsterWhereInput = {
     isActive: true,
     isPublic: true,
     games: { contains: 'cthulhuquarium' },
     ...(ownedIds.length > 0 ? { id: { notIn: ownedIds } } : {}),
+  }
+
+  // cthulhuquarium/t-030: rotation governs DISCOVERY only -- this filters
+  // which not-yet-owned species are visible today, never whether an
+  // ALREADY-owned-at-some-point species can be bought back (that's
+  // purchaseSpeciesForUser + the Ichthyonomicon's re-order path below,
+  // neither of which consults this). See aquariumEconomy.ts's own header
+  // comment on rotateShopStock for the full rationale.
+  const eligibleIds = (
+    await prisma.monster.findMany({
+      where: eligibleWhere,
+      select: { id: true },
+      orderBy: [{ depth: 'asc' }, { name: 'asc' }],
+    })
+  ).map((row) => row.id)
+
+  const dateKey = todaysShopDateKey()
+  const todaysIds = rotateShopStock(eligibleIds, userId, dateKey)
+  // No monster has a negative id -- this simply returns zero rows rather
+  // than needing a second query shape when nothing is eligible yet.
+  const where: Prisma.MonsterWhereInput = {
+    id: { in: todaysIds.length > 0 ? todaysIds : [-1] },
   }
 
   const [rows, total] = await Promise.all([
@@ -1612,7 +1734,7 @@ export async function listCatalogForUser(
     cost: unlockCost(deriveFishRarityTier(monster), monster.unlockCost),
   }))
 
-  return { data, take, skip, total }
+  return { data, take, skip, total, dateKey }
 }
 
 // ---------------------------------------------------------------------------

--- a/server/utils/aquariumEconomy.ts
+++ b/server/utils/aquariumEconomy.ts
@@ -1102,3 +1102,144 @@ export function qualifiesForBreedingEvolution(stats: StatBlock): boolean {
   const total = (values as number[]).reduce((sum, value) => sum + value, 0)
   return total / values.length >= SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD
 }
+
+// ---------------------------------------------------------------------------
+// Selling fish back -- cthulhuquarium/t-030. Silas, 2026-08-24: "usually at a
+// loss, but if they end up breeding fish with good stats, or a new evolve,
+// it could be worth more... Selling AT A LOSS is fine; that is spending...
+// A well-bred individual selling for MORE is the good version, because it
+// turns breeding into an economy." Priced off the INDIVIDUAL's own rolled
+// stats (StatBlock), never a flat per-species price -- same "the fish is the
+// economy, not the species" discipline as feedCost pricing food off the
+// fish's own rarity tier.
+//
+// Piecewise-linear against the average of the six stats, anchored at the
+// SAME bar a breeding pair already has to clear for a secret evolution
+// (SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD) -- selling a fish that good is
+// meant to feel like the same kind of payoff, not an unrelated number.
+// [v1 placeholder, same "wrong on purpose at first" discipline as every
+// other constant in this section -- flagged for t-019's balance pass.]
+// ---------------------------------------------------------------------------
+
+// Worst possible roll (average stat 0): sells for this fraction of unlockCost.
+export const SELL_PRICE_FLOOR_FRACTION = 0.2
+// Exactly base price at the breeding-evolution stat-average bar.
+export const SELL_PRICE_BREAKEVEN_STAT_AVERAGE =
+  SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD
+export const SELL_PRICE_BREAKEVEN_FRACTION = 1
+// Perfect roll (average stat 100): sells for this fraction of unlockCost.
+export const SELL_PRICE_CEILING_FRACTION = 1.5
+
+// Average of the individual's six rolled stats, clamped into [0, 100].
+// Every AquariumStock is rolled once on creation, so a null stat should not
+// happen in practice -- nulls are simply excluded from the average rather
+// than throwing, same defensive-but-total discipline as
+// qualifiesForBreedingEvolution's own null handling.
+function averageStat(stats: StatBlock): number {
+  const values = STAT_BLOCK_KEYS.map((key) => stats[key]).filter(
+    (value): value is number => value != null,
+  )
+  if (values.length === 0) return 0
+  const total = values.reduce((sum, value) => sum + value, 0)
+  return Math.min(100, Math.max(0, total / values.length))
+}
+
+// `baseCost` is the same unlockCost(deriveFishRarityTier(monster), ...)
+// purchaseSpeciesForUser already charges to buy this species, so a sale
+// never drifts from what a re-purchase would cost. Rounded to the nearest
+// coin, floored at 1 so a worthless roll still pays something rather than
+// nothing.
+export function sellPrice(baseCost: number, stats: StatBlock): number {
+  const average = averageStat(stats)
+  const breakeven = SELL_PRICE_BREAKEVEN_STAT_AVERAGE
+  const fraction =
+    average <= breakeven
+      ? SELL_PRICE_FLOOR_FRACTION +
+        (average / breakeven) *
+          (SELL_PRICE_BREAKEVEN_FRACTION - SELL_PRICE_FLOOR_FRACTION)
+      : SELL_PRICE_BREAKEVEN_FRACTION +
+        ((average - breakeven) / (100 - breakeven)) *
+          (SELL_PRICE_CEILING_FRACTION - SELL_PRICE_BREAKEVEN_FRACTION)
+  return Math.max(1, Math.round(baseCost * fraction))
+}
+
+// ---------------------------------------------------------------------------
+// Rotating shop stock -- cthulhuquarium/t-030. "THE FIX... make [the
+// Ichthyonomicon] the RE-PURCHASE MECHANISM, not just a trophy case. Then
+// rotation governs DISCOVERY rather than ACCESS: today's stock is what is
+// new, cheap, or well-rolled, a reason to check in rather than a gate, and
+// anything ever owned is orderable from the book at any time" (Silas,
+// 2026-08-24, this task's own note).
+//
+// This section only decides WHICH of the eligible (not-currently-owned)
+// species show up in today's catalog -- it has no opinion on price or
+// ownership. purchaseSpeciesForUser (server/utils/aquarium.ts) never
+// consults this: a species that has ever been owned stays buyable through
+// the Ichthyonomicon's re-order path regardless of what is rotated in here,
+// which is exactly what keeps selling safe (see t-031's own note: "t-030's
+// rotating stock and sell-back are only safe because this exists").
+//
+// Deterministic per (userId, dateKey) rather than a persisted "today's
+// offer" row -- same seeded-PRNG idiom as the daily dream feature
+// (server/utils/dailyDreamFacetBlueprint.ts's hashSeed/mulberry32), so every
+// request from the same player on the same day sees the same slate without
+// a new migration (per this task's own note: extend t-032's schema, don't
+// open a second migration path into the same tables -- this needs none).
+//
+// [v1 placeholder: a uniform-random subset, not a real "new, cheap, or
+// well-rolled" weighting -- same "wrong on purpose at first" discipline as
+// the rest of this file, flagged for t-019's balance pass.]
+// ---------------------------------------------------------------------------
+
+// How many not-yet-owned species show up in a given day's rotation. Early
+// game, with fewer eligible species than this, rotation is a no-op and the
+// catalog simply shows everything -- it only becomes meaningful once the
+// pool of undiscovered species grows past this window.
+export const SHOP_ROTATION_SIZE = 8
+
+function hashSeed(input: string): number {
+  let hash = 2166136261
+  for (let index = 0; index < input.length; index++) {
+    hash ^= input.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return hash >>> 0
+}
+
+function mulberry32(seed: number): () => number {
+  return () => {
+    seed |= 0
+    seed = (seed + 0x6d2b79f5) | 0
+    let value = Math.imul(seed ^ (seed >>> 15), 1 | seed)
+    value = (value + Math.imul(value ^ (value >>> 7), 61 | value)) ^ value
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+// UTC calendar day, matching the daily dream feature's own dateKey
+// convention -- a simple, timezone-agnostic "which day is it" that never
+// depends on the request's local clock.
+export function todaysShopDateKey(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 10)
+}
+
+// Deterministically shuffles `eligibleIds` for this (userId, dateKey) and
+// returns the first SHOP_ROTATION_SIZE of them -- same id list in, same
+// slate out, for every request from this player on this day. Fisher-Yates
+// over a seeded PRNG rather than sort-by-random-key, so this stays an exact,
+// unbiased permutation of the input rather than an approximation.
+export function rotateShopStock(
+  eligibleIds: readonly number[],
+  userId: number,
+  dateKey: string,
+): number[] {
+  const random = mulberry32(hashSeed(`${userId}:${dateKey}:shop`))
+  const shuffled = [...eligibleIds]
+  for (let index = shuffled.length - 1; index > 0; index--) {
+    const swapIndex = Math.floor(random() * (index + 1))
+    const current = shuffled[index]!
+    shuffled[index] = shuffled[swapIndex]!
+    shuffled[swapIndex] = current
+  }
+  return shuffled.slice(0, SHOP_ROTATION_SIZE)
+}

--- a/stores/cthulhuquariumTankStore.ts
+++ b/stores/cthulhuquariumTankStore.ts
@@ -245,6 +245,15 @@ interface PurchaseResponse {
   firedMilestones: FiredMilestone[]
 }
 
+// cthulhuquarium/t-030: sell.post.ts's response shape. `monsterId` (rather
+// than the now-deleted aquariumStockId) is what the store needs to refresh
+// the bestiary's `currentlyOwned` flag for the right species.
+interface SellResponse {
+  aquarium: Tank
+  monsterId: number
+  salePrice: number
+}
+
 // The Ichthyonomicon -- the completionist codex (cthulhuquarium/t-024,
 // extended by t-031). A collected entry carries full art and its fieldNote;
 // an uncollected one is only ever known by name and shows as a silhouette in
@@ -275,9 +284,9 @@ export interface BestiaryEntry {
   firstAcquiredAt: string | null
   fieldNote: string | null
   // t-031: distinct from `collected` -- true only while the species has a
-  // live AquariumStock row. Equal to `collected` until t-030 ships a sell
-  // path; when it isn't, the panel offers re-order instead of "not yet
-  // observed."
+  // live AquariumStock row. False after a sell (t-030) even though
+  // `collected` stays true forever; when it's false, the panel offers
+  // re-order instead of "not yet observed."
   currentlyOwned: boolean
   // t-031: the book's best-individual-seen record. Null until
   // cthulhuquarium/t-029 (genetics) starts rolling individual stats.
@@ -518,6 +527,26 @@ export const useCthulhuquariumTankStore = defineStore(
 
     function dismissReveal(): void {
       revealedUnlock.value = null
+    }
+
+    // cthulhuquarium/t-030: sells one individual fish back to the shop.
+    // Usually a loss, sometimes worth more than base price -- see
+    // server/utils/aquariumEconomy.ts's sellPrice for the exact curve. The
+    // species itself is never lost: it stays re-orderable from the
+    // Ichthyonomicon the moment currentlyOwned flips to false, so this
+    // refreshes the bestiary the same way unlock() does when it's loaded.
+    async function sell(aquariumStockId: number): Promise<boolean> {
+      const res = await performFetch<SellResponse>('/api/aquarium/sell', {
+        method: 'POST',
+        body: JSON.stringify({ aquariumStockId }),
+      })
+      if (res.success && res.data) {
+        tank.value = res.data.aquarium
+        if (bestiary.value.length > 0) await loadBestiary()
+        return true
+      }
+      error.value = res.message || 'Could not sell that fish.'
+      return false
     }
 
     // The active-play channel (cthulhuquarium/t-027): -5 debris per click,
@@ -819,6 +848,7 @@ export const useCthulhuquariumTankStore = defineStore(
       loadCatalog,
       feed,
       unlock,
+      sell,
       dismissReveal,
       dismissRareEvent,
       requestClean,

--- a/utils/scripts/verifyAquariumShop.test.ts
+++ b/utils/scripts/verifyAquariumShop.test.ts
@@ -1,0 +1,161 @@
+// /utils/scripts/verifyAquariumShop.test.ts
+//
+// Regression + property test for cthulhuquarium/t-030's pure shop core
+// (sellPrice, rotateShopStock, todaysShopDateKey) in
+// server/utils/aquariumEconomy.ts -- no prisma, no database, no Nuxt/H3
+// runtime, same discipline as verifyAquariumGenetics.test.ts.
+import assert from 'node:assert/strict'
+
+import {
+  RARITY_TIERS,
+  rotateShopStock,
+  SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD,
+  SELL_PRICE_BREAKEVEN_FRACTION,
+  SELL_PRICE_BREAKEVEN_STAT_AVERAGE,
+  SELL_PRICE_CEILING_FRACTION,
+  SELL_PRICE_FLOOR_FRACTION,
+  sellPrice,
+  SHOP_ROTATION_SIZE,
+  todaysShopDateKey,
+  type StatBlock,
+} from '../../server/utils/aquariumEconomy.js'
+
+// --- sellPrice: floor/breakeven/ceiling curve, anchored on unlockCost ------
+
+const BASE_COST = RARITY_TIERS.RARE.unlockCost
+
+function uniformStats(value: number | null): StatBlock {
+  return {
+    charm: value,
+    empathy: value,
+    grace: value,
+    luck: value,
+    might: value,
+    wits: value,
+  }
+}
+
+assert.equal(SELL_PRICE_BREAKEVEN_STAT_AVERAGE, SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD)
+
+// A worst-possible roll sells at the floor fraction -- a loss, never zero.
+assert.equal(
+  sellPrice(BASE_COST, uniformStats(0)),
+  Math.round(BASE_COST * SELL_PRICE_FLOOR_FRACTION),
+)
+assert.ok(
+  sellPrice(BASE_COST, uniformStats(0)) < BASE_COST,
+  'a worst-possible roll always sells at a loss',
+)
+
+// Exactly the breeding-evolution stat-average bar sells at exactly base
+// price -- selling a fish that good is meant to feel like the same payoff a
+// secret evolution does, not an unrelated number.
+assert.equal(SELL_PRICE_BREAKEVEN_FRACTION, 1)
+assert.equal(
+  sellPrice(BASE_COST, uniformStats(SECRET_EVOLUTION_AVERAGE_STAT_THRESHOLD)),
+  BASE_COST,
+)
+
+// A perfect roll sells above base price -- "a well-bred individual...
+// worth more" (Silas, 2026-08-24).
+assert.equal(
+  sellPrice(BASE_COST, uniformStats(100)),
+  Math.round(BASE_COST * SELL_PRICE_CEILING_FRACTION),
+)
+assert.ok(
+  sellPrice(BASE_COST, uniformStats(100)) > BASE_COST,
+  'a perfect roll always sells for a profit',
+)
+
+// Monotonic: a strictly better roll never sells for less.
+let previous = -Infinity
+for (let average = 0; average <= 100; average += 5) {
+  const price = sellPrice(BASE_COST, uniformStats(average))
+  assert.ok(
+    price >= previous,
+    `sellPrice must be monotonically non-decreasing in stat average (broke at ${average})`,
+  )
+  previous = price
+}
+
+// A fully-unrolled (all-null) fish -- should not happen in practice since
+// every AquariumStock is rolled on creation -- still returns a real, total
+// price rather than throwing or returning NaN.
+const unrolledPrice = sellPrice(BASE_COST, uniformStats(null))
+assert.ok(
+  Number.isFinite(unrolledPrice) && unrolledPrice >= 1,
+  'an all-null StatBlock still produces a finite, positive sale price',
+)
+
+// Never below 1 coin even at a tiny base cost.
+assert.ok(sellPrice(1, uniformStats(0)) >= 1)
+
+console.log(
+  '✅ sellPrice: floor fraction at 0, exactly base price at the breeding-evolution bar, ceiling fraction at 100, monotonic, null-safe',
+)
+
+// --- todaysShopDateKey: UTC calendar day, YYYY-MM-DD -----------------------
+
+assert.equal(
+  todaysShopDateKey(new Date('2026-08-28T23:59:59.999Z')),
+  '2026-08-28',
+)
+assert.equal(
+  todaysShopDateKey(new Date('2026-01-01T00:00:00.000Z')),
+  '2026-01-01',
+)
+
+console.log('✅ todaysShopDateKey: UTC calendar day, YYYY-MM-DD')
+
+// --- rotateShopStock: deterministic, size-bounded, a real permutation ------
+
+const eligible = Array.from({ length: 40 }, (_, index) => index + 1)
+
+const rotationA = rotateShopStock(eligible, 7, '2026-08-28')
+const rotationB = rotateShopStock(eligible, 7, '2026-08-28')
+assert.deepEqual(
+  rotationA,
+  rotationB,
+  'same (userId, dateKey) always produces the same slate',
+)
+
+const rotationNextDay = rotateShopStock(eligible, 7, '2026-08-29')
+assert.notDeepEqual(
+  rotationA,
+  rotationNextDay,
+  'a different dateKey produces a different slate (in practice, for a large enough pool)',
+)
+
+const rotationOtherUser = rotateShopStock(eligible, 8, '2026-08-28')
+assert.notDeepEqual(
+  rotationA,
+  rotationOtherUser,
+  'a different userId produces a different slate on the same day',
+)
+
+assert.equal(rotationA.length, SHOP_ROTATION_SIZE)
+assert.equal(new Set(rotationA).size, rotationA.length, 'no duplicate ids in one slate')
+for (const id of rotationA) {
+  assert.ok(eligible.includes(id), 'every id in the slate came from the eligible pool')
+}
+
+// A pool smaller than the rotation window returns everything, unshrunk --
+// rotation only ever narrows a pool bigger than the window, never an
+// already-small one (early game should never see FEWER unlockable species
+// than actually exist).
+const smallPool = [101, 102, 103]
+const smallRotation = rotateShopStock(smallPool, 7, '2026-08-28')
+assert.equal(smallRotation.length, smallPool.length)
+assert.deepEqual(
+  [...smallRotation].sort((a, b) => a - b),
+  [...smallPool].sort((a, b) => a - b),
+)
+
+// An empty pool is a no-op, not a crash.
+assert.deepEqual(rotateShopStock([], 7, '2026-08-28'), [])
+
+console.log(
+  '✅ rotateShopStock: deterministic per (userId, dateKey), size-bounded, a real subset with no duplicates, never shrinks a pool smaller than the window',
+)
+
+console.log('✅ verifyAquariumShop: all assertions passed')


### PR DESCRIPTION
### Task
cthulhuquarium/t-030: Rotating shop stock, selling fish back, and the individual-stat economy (kind: software)

### What changed / what I produced
- **Rotating shop stock**: `listCatalogForUser` now narrows the not-yet-owned catalog to a deterministic per-`(userId, dateKey)` subset (`aquariumEconomy.ts`'s new `rotateShopStock`, seeded the same `hashSeed`/`mulberry32` way the daily-dream feature already seeds its own per-user-per-day randomness — no new persisted "today's offer" table). Rotation only ever governs **discovery** of species never yet owned; `purchaseSpeciesForUser` is untouched and still only checks live ownership, so it never gates a re-purchase.
- **Selling fish back**: new `sellFishForUser` + `POST /api/aquarium/sell` deletes the individual's `AquariumStock` row and pays out `aquariumEconomy.ts`'s new `sellPrice(...)` — a piecewise-linear curve on that fish's own rolled stats (t-029): floor fraction of `unlockCost` at a worst-possible roll, exactly base price at the same stat-average bar a secret evolution needs (85), above base price for a well-bred individual (up to 1.5x at a perfect roll).
- **The trap the task note calls out, fixed the way it names**: `AquariumCodexEntry` (the Ichthyonomicon, t-031) is never touched by selling, so a sold species stays re-orderable at any time via the bestiary's existing "Re-order" button — which t-031 built ahead of time and was previously dead code (`currentlyOwned` was always equal to `collected`). It now actually renders once a species is sold.
- **UI**: a Sell button next to Feed in the tank panel, a "today's arrivals" hint on the unlock panel, no confirmation dialog (matches this component's existing one-click unequip/remove convention — selling is safe by design, per the point above).
- No Prisma migration — this task's note explicitly said to extend t-032's already-shipped schema rather than open a second migration path, and nothing here needed a new column or table.

### How I verified
- `npm run test` (vue-tsc, full repo) — clean.
- `eslint` on every touched file — clean.
- New `utils/scripts/verifyAquariumShop.test.ts` (`npm run test:aquarium-shop`): `sellPrice`'s floor/breakeven/ceiling curve and monotonicity, null-safety on an all-null `StatBlock`; `rotateShopStock`'s determinism per `(userId, dateKey)`, different slates for a different day or user, size bound, no duplicates, and — importantly — never shrinks a pool smaller than the rotation window (so an early-game player with fewer species than the window sees everything, not an artificially gated subset).
- Re-ran the existing `test:aquarium-genetics` and `test:aquarium-economy` suites — still passing, no regressions.

### Stakes
reversible

### Flags for Reviewer
- `SHOP_ROTATION_SIZE` (8) and the sell-price fractions (floor 0.2x, breakeven 1.0x at stat-average 85, ceiling 1.5x) are v1 placeholders in the same "wrong on purpose at first" spirit as this file's other constants (`SET_PIECE_CATALOG`, `STAT_ROLL_RANGES`, etc.) — flagged for t-019's balance pass, same as everything else in `aquariumEconomy.ts`.
- Rotation is pure computation (deterministic seed), not a persisted "today's offer" row — matches the daily-dream feature's precedent and avoids a second migration path, but means there's no audit trail of exactly what was offered on a given day beyond re-deriving it. Flag if you'd rather have an `AquariumShopOffer` table for that.

### Kaizen suggestion
Add a small "shop refreshes in Xh" countdown to the catalog panel using the `dateKey` this task's `catalog.get.ts` now returns in `meta` (currently plumbed through but unused by the frontend) — a concrete "reason to check in" beat the task's design note calls for but this PR doesn't build UI for beyond the static hint text.

### Notes for reviewer
Dependencies t-029 (genetics) and t-031 (Ichthyonomicon) were both already `done` and landed exactly the hooks this task's own note said to build on (`AquariumStock.stat*`, `AquariumCodexEntry.bestStat*`, the bestiary's `currentlyOwned` flag and dead Re-order button) — this PR is almost entirely "wire the pieces together," not new schema or new UI surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vcm9hRrcRs9VBivJNCDRhc)_