### PR TITLE
mandarin-tutor/t-018: show a visible confirmation when illustration is queued

### DIFF
--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -286,6 +286,7 @@
                     <button v-if="canQueueArt" type="button" class="btn btn-outline btn-xs" :disabled="artBusy" @click="queueCurrentIllustration">
                       {{ artBusy ? 'Submitting…' : 'Request illustration' }}
                     </button>
+                    <p v-if="artNotice" class="mt-1 text-xs text-success">{{ artNotice }}</p>
                   </div>
                   <div v-else class="space-y-3">
                     <Icon name="kind-icon:volume" class="mx-auto size-12 opacity-60" />
@@ -346,6 +347,7 @@
                         Check art #{{ currentArtJobId }}
                       </button>
                     </div>
+                    <p v-if="artNotice" class="text-xs text-success">{{ artNotice }}</p>
                   </div>
                   <div class="grid grid-cols-2 gap-2 sm:grid-cols-4">
                     <button type="button" class="btn btn-sm btn-outline btn-error" @click="store.rateStudyCard('again')">Again</button>
@@ -404,6 +406,7 @@
                     Check art #{{ currentArtJobId }}
                   </button>
                 </div>
+                <p v-if="artNotice" class="text-xs text-success">{{ artNotice }}</p>
               </div>
 
               <div class="flex min-h-64 flex-col p-5">
@@ -535,6 +538,7 @@ const newSetNotice = ref('')
 const cardPanel = ref<HTMLElement | null>(null)
 const brokenArtKeys = ref(new Set<string>())
 const artNotice = ref('')
+let artNoticeTimer: ReturnType<typeof setTimeout> | null = null
 
 const workspaceViews: Array<{ value: WorkspaceView; label: string; icon: string }> = [
   { value: 'card', label: 'Card', icon: 'kind-icon:cards' },
@@ -668,16 +672,30 @@ async function requestCurrentWord() {
   if (created) await scrollToCard()
 }
 
+function setArtNotice(message: string) {
+  if (artNoticeTimer) {
+    clearTimeout(artNoticeTimer)
+    artNoticeTimer = null
+  }
+  artNotice.value = message
+  if (message) {
+    artNoticeTimer = setTimeout(() => {
+      artNotice.value = ''
+      artNoticeTimer = null
+    }, 4000)
+  }
+}
+
 async function queueCurrentIllustration() {
-  artNotice.value = ''
+  setArtNotice('')
   const jobId = await store.queueIllustration(currentCard.value)
-  if (jobId) artNotice.value = `Illustration queued as ArtJob ${jobId}.`
+  if (jobId) setArtNotice(`Illustration queued as ArtJob ${jobId}.`)
 }
 
 async function refreshCurrentIllustration() {
   const card = currentCard.value
   if (!card) return
-  artNotice.value = ''
+  setArtNotice('')
   const canonical = await store.probeCanonicalIllustration(card.key)
   if (canonical) return
   const url = currentRequested.value


### PR DESCRIPTION
### Task
mandarin-tutor/t-018: Show a visible confirmation when an illustration is queued on the study card (kind: software)

### What changed / what I produced
- `queueCurrentIllustration`/`refreshCurrentIllustration` in `pages/play/mandarin.vue` already set an `artNotice` ref, but nothing in the template rendered it — a user clicking "Request illustration" got no visible feedback that anything happened.
- Render `artNotice` as a small transient banner (matching `newSetNotice`'s existing `text-xs text-success` style) next to each of the three Request/Check-art button groups: study "picture" prompt mode, the study revealed/rating panel, and explore mode.
- Added a small `setArtNotice()` helper that auto-clears the notice after 4s, since none of `newSetNotice`'s own clear triggers (re-creating a deck) apply to a study-card notice — the task note allows a short timeout when no equivalent trigger exists.

### How I verified
- `npm run test` (`vue-tsc --noEmit`) — clean
- `npx eslint pages/play/mandarin.vue` — clean
- `npx prettier --check pages/play/mandarin.vue` — pre-existing formatting warnings on this file, unchanged by this diff (confirmed via `git stash` before/after comparison)
- `npm run test:mandarin-srs-selftest` — all green, unaffected
- `npm run test:layout-contract` — holds, no new violations

### Stakes
reversible

### Kaizen suggestion
`refreshCurrentIllustration` never sets a success notice when a refresh actually finds art (only clears on start) — a user clicking "Check art" gets the same "nothing visibly happened" gap this task just fixed for the queue action. Worth a small follow-up mirroring this same pattern.

### Notes for reviewer
Single-file, self-contained, no store/API changes — `artNotice` was already being set correctly, this only wires up the missing render + a sensible auto-dismiss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qy3WrKnrPsFhWQASB8G6nW)_