### PR TITLE
mandarin-tutor: make the v2 art recipe submittable, vary it per card, fix the probe, new banner

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -103,6 +103,9 @@ jobs:
       - name: Mandarin cloud-state merge contract
         run: npm run test:mandarin-cloud-merge-selftest
 
+      - name: Mandarin art recipe contract
+        run: npm run test:mandarin-art-recipe
+
       - name: Reaction route auth contract
         run: npm run test:reaction-route-auth
 

--- a/components/mandarin/mandarin-banner.vue
+++ b/components/mandarin/mandarin-banner.vue
@@ -1,0 +1,242 @@
+<template>
+  <section
+    class="mandarin-banner relative isolate overflow-hidden rounded-3xl border border-base-300 shadow-sm"
+  >
+    <!-- Painted ground. Three pigment washes over warm paper, so the banner
+         carries the tutor's picture-book identity even with zero rendered
+         card art -- which is the state a fresh deck is always in. -->
+    <div class="mandarin-banner__wash" aria-hidden="true" />
+
+    <!-- Ink-wash hills and a low sun: one brush gesture, not a scene. -->
+    <svg
+      class="mandarin-banner__ink"
+      viewBox="0 0 480 160"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <!-- Drawn before the hills so they cut across it: a low sun, not a blob. -->
+      <circle cx="76" cy="98" r="24" class="mandarin-banner__sun" />
+      <path
+        d="M0 132 C 58 96, 96 122, 142 104 C 188 86, 214 118, 262 108 C 318 96, 352 126, 400 112 C 436 101, 462 118, 480 110 L 480 160 L 0 160 Z"
+        class="mandarin-banner__hill mandarin-banner__hill--far"
+      />
+      <path
+        d="M0 148 C 64 124, 118 146, 176 134 C 240 121, 286 148, 348 138 C 410 128, 448 148, 480 140 L 480 160 L 0 160 Z"
+        class="mandarin-banner__hill mandarin-banner__hill--near"
+      />
+    </svg>
+
+    <div class="mandarin-banner__grain" aria-hidden="true" />
+
+    <div
+      class="relative grid grid-cols-[repeat(auto-fit,minmax(min(100%,21rem),1fr))] items-center gap-5 p-5"
+    >
+      <div class="flex min-w-0 flex-col gap-3">
+        <div class="flex items-center gap-3">
+          <!-- A carved seal, the way a Chinese picture book signs a page. -->
+          <span class="mandarin-banner__seal" aria-hidden="true">学</span>
+          <div class="min-w-0">
+            <p class="mandarin-banner__title">Mandarin Tutor</p>
+            <p class="mandarin-banner__subtitle">
+              Learn the word, hear it, picture it, then open the character and see how it works.
+            </p>
+          </div>
+        </div>
+
+        <div class="flex flex-wrap gap-2">
+          <span class="mandarin-banner__stat">{{ cardCount }} cards</span>
+          <span class="mandarin-banner__stat">{{ setCount }} decks</span>
+          <span v-if="requestedCount" class="mandarin-banner__stat">
+            {{ requestedCount }} requested
+          </span>
+          <span v-if="activeSetLabel" class="mandarin-banner__stat mandarin-banner__stat--active">
+            {{ activeSetLabel }} · {{ activeSetSize }}
+          </span>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,5rem),1fr))] gap-3">
+        <figure v-for="tile in tiles" :key="tile.key" class="mandarin-banner__tile">
+          <MandarinCardArt
+            :card-key="tile.key"
+            :simplified="tile.simplified"
+            :meaning="tile.meaning"
+            :art="tile.art"
+            eager
+            @error="emit('artError', tile.key)"
+          >
+            <figcaption class="mandarin-banner__caption">
+              <!-- The glyph fallback is already the whole tile; repeating the
+                   character under it just crowds the strip. -->
+              <b v-if="tile.art" class="text-base leading-none">{{ tile.simplified }}</b>
+              <span class="truncate text-xs opacity-85">{{ tile.pinyin }}</span>
+            </figcaption>
+          </MandarinCardArt>
+        </figure>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+export type MandarinBannerTile = {
+  key: string
+  simplified: string
+  pinyin: string
+  meaning: string
+  /** Rendered illustration, when one exists. Empty falls back to the glyph. */
+  art: string
+}
+
+withDefaults(
+  defineProps<{
+    tiles: MandarinBannerTile[]
+    cardCount: number
+    setCount: number
+    requestedCount?: number
+    activeSetLabel?: string
+    activeSetSize?: number
+  }>(),
+  {
+    requestedCount: 0,
+    activeSetLabel: '',
+    activeSetSize: 0,
+  },
+)
+
+const emit = defineEmits<{ artError: [cardKey: string] }>()
+</script>
+
+<style scoped>
+/*
+ * Pigments, not theme tokens. The banner is a painted object -- the same warm
+ * gouache palette the card art is generated in -- so it holds its identity
+ * across every DaisyUI theme instead of restating whichever one is active. All
+ * text inside it is set against these colours, never against the page surface.
+ */
+.mandarin-banner {
+  --ink: #21303c;
+  --indigo: #2c4a78;
+  --jade: #3d7d69;
+  --persimmon: #e0663f;
+  --ochre: #d8a441;
+  --seal: #b8342b;
+  --paper: #f7f0e0;
+  min-height: 11rem;
+  color: var(--paper);
+}
+
+.mandarin-banner__wash {
+  position: absolute;
+  inset: 0;
+  z-index: -3;
+  background:
+    radial-gradient(115% 150% at 4% 0%, var(--indigo) 0%, transparent 58%),
+    radial-gradient(85% 120% at 98% 4%, var(--persimmon) 0%, transparent 52%),
+    radial-gradient(120% 130% at 62% 108%, var(--jade) 0%, transparent 62%),
+    linear-gradient(115deg, var(--ink) 0%, #35506b 45%, #6d7f63 100%);
+}
+
+.mandarin-banner__ink {
+  position: absolute;
+  inset: auto 0 0 0;
+  z-index: -2;
+  width: 100%;
+  height: 62%;
+}
+
+.mandarin-banner__sun {
+  fill: var(--ochre);
+  opacity: 0.5;
+}
+
+.mandarin-banner__hill {
+  fill: var(--ink);
+}
+
+.mandarin-banner__hill--far {
+  opacity: 0.22;
+}
+
+.mandarin-banner__hill--near {
+  opacity: 0.38;
+}
+
+/* Paper tooth. Generated inline so the banner pulls no external asset. */
+.mandarin-banner__grain {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  opacity: 0.14;
+  mix-blend-mode: overlay;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23g)'/%3E%3C/svg%3E");
+}
+
+.mandarin-banner__seal {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.6rem;
+  background: var(--seal);
+  color: var(--paper);
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 1;
+  transform: rotate(-4deg);
+  box-shadow: 0 2px 10px rgb(0 0 0 / 0.28);
+}
+
+.mandarin-banner__title {
+  font-size: 1.875rem;
+  font-weight: 700;
+  line-height: 1.1;
+  text-shadow: 0 1px 12px rgb(0 0 0 / 0.45);
+}
+
+.mandarin-banner__subtitle {
+  margin-top: 0.25rem;
+  max-width: 34rem;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  opacity: 0.86;
+  text-shadow: 0 1px 8px rgb(0 0 0 / 0.4);
+}
+
+.mandarin-banner__stat {
+  border-radius: 999px;
+  border: 1px solid rgb(247 240 224 / 0.35);
+  background: rgb(33 48 60 / 0.35);
+  padding: 0.15rem 0.6rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.mandarin-banner__stat--active {
+  border-color: var(--ochre);
+  background: rgb(216 164 65 / 0.28);
+}
+
+.mandarin-banner__tile {
+  position: relative;
+  aspect-ratio: 1;
+  overflow: hidden;
+  border-radius: 1rem;
+  border: 1px solid rgb(247 240 224 / 0.3);
+  box-shadow: 0 6px 18px rgb(0 0 0 / 0.25);
+}
+
+.mandarin-banner__caption {
+  position: absolute;
+  inset: auto 0 0 0;
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  padding: 0.3rem 0.5rem;
+  background: linear-gradient(to top, rgb(20 28 36 / 0.82), transparent);
+  color: var(--paper);
+}
+</style>

--- a/components/mandarin/mandarin-card-art.vue
+++ b/components/mandarin/mandarin-card-art.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="mandarin-art" :class="`mandarin-art--${pigment}`">
+    <img
+      v-if="art"
+      :src="art"
+      :alt="`Illustration for ${meaning}`"
+      class="absolute inset-0 h-full w-full object-cover"
+      :loading="eager ? 'eager' : 'lazy'"
+      @error="emit('error', cardKey)"
+    />
+    <span v-else-if="revealGlyph" class="mandarin-art__glyph" aria-hidden="true">
+      {{ simplified }}
+    </span>
+    <span v-else class="mandarin-art__waiting">
+      <Icon name="kind-icon:image" class="size-8 opacity-80" />
+      <span class="text-xs opacity-80">Picture not ready yet</span>
+    </span>
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { mandarinPigmentIndex } from '@/utils/mandarinPalette'
+
+const props = withDefaults(
+  defineProps<{
+    cardKey: string
+    simplified: string
+    meaning: string
+    /** Rendered illustration URL, when one exists. */
+    art?: string
+    /**
+     * Whether the Hanzi may stand in for a missing picture. False on the study
+     * card's picture prompt, where the character IS the answer being tested.
+     */
+    revealGlyph?: boolean
+    eager?: boolean
+  }>(),
+  { art: '', revealGlyph: true, eager: false },
+)
+
+const emit = defineEmits<{ error: [cardKey: string] }>()
+
+const pigment = computed(() => mandarinPigmentIndex(props.cardKey))
+</script>
+
+<style scoped>
+/*
+ * The illustrated corpus renders on the home relay over days, so an unrendered
+ * card is a normal state, not an error state. A pigment field from the tutor's
+ * own gouache palette keeps a half-illustrated deck looking deliberate instead
+ * of like a wall of grey loading boxes -- and the colour is drawn from the card
+ * key, so a word always sits on the same ground.
+ */
+.mandarin-art {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
+  color: #f7f0e0;
+  /* The glyph scales to whatever box the parent gives this, not to the viewport. */
+  container-type: inline-size;
+}
+
+.mandarin-art--0 {
+  background: linear-gradient(150deg, #35506b, #22384d);
+}
+
+.mandarin-art--1 {
+  background: linear-gradient(150deg, #3d7d69, #27564a);
+}
+
+.mandarin-art--2 {
+  background: linear-gradient(150deg, #e0663f, #a9412a);
+}
+
+.mandarin-art--3 {
+  background: linear-gradient(150deg, #d8a441, #a97722);
+}
+
+.mandarin-art--4 {
+  background: linear-gradient(150deg, #7d5e97, #4d3a63);
+}
+
+.mandarin-art__glyph {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: clamp(2.5rem, 38cqw, 5rem);
+  font-weight: 600;
+  line-height: 1;
+  color: rgb(247 240 224 / 0.92);
+  text-shadow: 0 2px 12px rgb(0 0 0 / 0.35);
+}
+
+.mandarin-art__waiting {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  text-align: center;
+}
+</style>

--- a/docs/mandarin-tutor-art-direction.md
+++ b/docs/mandarin-tutor-art-direction.md
@@ -126,6 +126,33 @@ would treat any other recipe change: expect to regenerate what it touches.
 (determinism, every option reachable, no option dominating the deck, no clause
 smuggling text or tourist shorthand back in).
 
+## The prompt contract owns the wording
+
+Every prompt this recipe builds passes `server/utils/artPromptContract.ts`, and
+the recipe test asserts it card by card. This is not a formality — it is why the
+corpus exists at all. The original v2 recipe hedged the way a person writes
+("ground it in Chinese detail **only when** it naturally belongs to the
+concept"), and the contract rejects that for a demonstrated reason: Krea 2
+cannot evaluate a condition, it paints the densest noun phrase it is handed. All
+577 enqueues came back 422 and not one card was ever rendered.
+
+Three habits the recipe therefore avoids, all of them things a human reader
+would find perfectly clear:
+
+- **Conditionals.** "where it helps", "when useful", "unless that is the
+  concept". The recipe knows the card's categories and meaning, so it decides at
+  build time and states one outcome. The cultural-shorthand exclusion is dropped
+  entirely for a card whose concept *is* a dragon or a lantern.
+- **Format nouns.** Not "flashcard illustration" — asking for a card renders a
+  card, title bar and invented text included. The tutor owns the card; the model
+  paints a picture.
+- **Piled-up exclusions.** The old recipe named text fourteen ways and listed
+  twelve synthetic-image tells including "lens flare", "bokeh", and "neon glow".
+  At cfg 1 the ComfyUI negative prompt is inert, so all of that landed in
+  *positive* conditioning. Same art direction, stated as the wanted result:
+  "everything is hand-painted... plain even light", "every surface is blank and
+  unmarked".
+
 ## Text policy
 
 Generated card art contains no Hanzi, pinyin, English, Latin letters, numerals, pseudo-writing, labels, captions, signage, speech bubbles, logos, or watermarks. The tutor UI owns language rendering.

--- a/docs/mandarin-tutor-art-direction.md
+++ b/docs/mandarin-tutor-art-direction.md
@@ -95,6 +95,37 @@ Use a real working table-game visual language: believable felt, chips, playing c
 
 Do not force decorative metaphors onto particles, classifiers, components, or abstract sentence machinery when an image would misteach. These remain `glyph-only` until a pedagogically useful visual treatment is explicitly designed.
 
+## Per-card style variation
+
+The house style is fixed. The illustrator's decisions are not.
+
+A recipe that emits identical style language for every card produces a deck where
+all 577 pictures share one camera distance, one lighting setup, and one palette —
+the interchangeable read this art direction exists to avoid. So each card also
+draws one option per axis from `server/utils/mandarinIllustrationStyle.ts`:
+
+| Axis | Options | What it moves |
+| --- | --- | --- |
+| framing | 6 | close still life, wide and quiet, vignette, overhead, eye level, through a near edge |
+| light | 5 | overcast, low late sun, open shade, lamplight, early-morning window |
+| palette | 6 | a limited harmony plus one accent, all inside the matte gouache family |
+| handling | 5 | flat gouache, wet washes, dry brush, ink line over wash, pooling pigment |
+| ground | 4 | bare paper, flat wash, soft halo, lower band |
+
+3600 combinations. The draw is derived from the card's stable token — the same
+token that names its media file — so it is deterministic in both directions: a
+card's look is tied to its identity rather than to its position in the catalog,
+and the tutor's per-card retry rebuilds exactly the prompt the batch was
+submitted with. Manifest entries carry the draw as `styleVariant` for audit.
+
+Changing an axis list changes the prompts of every card that draws from it. Since
+the corpus is submitted once and rendered durably, treat an axis edit the way you
+would treat any other recipe change: expect to regenerate what it touches.
+
+`utils/scripts/verifyMandarinArtRecipe.test.ts` holds the properties that matter
+(determinism, every option reachable, no option dominating the deck, no clause
+smuggling text or tourist shorthand back in).
+
 ## Text policy
 
 Generated card art contains no Hanzi, pinyin, English, Latin letters, numerals, pseudo-writing, labels, captions, signage, speech bubbles, logos, or watermarks. The tutor UI owns language rendering.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "audit:mandarin-proficiency-coverage": "tsx utils/scripts/auditMandarinProficiencyCoverage.ts",
     "test:mandarin-proficiency-coverage-selftest": "tsx utils/scripts/auditMandarinProficiencyCoverage.ts --self-test",
     "test:mandarin-srs-selftest": "tsx utils/scripts/verifyMandarinSrs.test.ts",
+    "test:mandarin-art-recipe": "tsx utils/scripts/verifyMandarinArtRecipe.test.ts",
     "test:mandarin-cloud-merge-selftest": "tsx utils/scripts/verifyMandarinCloudMerge.test.ts",
     "audit:checkpoints": "prisma generate && tsx utils/scripts/auditCheckpointResources.ts",
     "repair:checkpoints": "prisma generate && tsx utils/scripts/repairCheckpointResources.ts",

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -1,48 +1,15 @@
 <template>
   <div class="kr-surface">
     <div class="kr-scroll mx-auto max-w-7xl space-y-4 p-3 sm:p-4">
-      <header class="relative overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-sm">
-        <div class="grid min-h-40 grid-cols-[repeat(auto-fit,minmax(min(100%,22rem),1fr))]">
-          <div class="relative z-10 flex flex-col justify-center gap-3 p-5 sm:p-6">
-            <div>
-              <p class="text-3xl font-bold">Mandarin Tutor</p>
-              <p class="mt-1 max-w-2xl text-sm opacity-70">
-                Learn the word, hear it, picture it, then open the character and see how it works.
-              </p>
-            </div>
-            <div class="flex flex-wrap gap-2 text-xs">
-              <span class="badge badge-ghost">{{ cards.length }} cards</span>
-              <span class="badge badge-ghost">{{ allSets.length }} sets</span>
-              <span class="badge badge-ghost">{{ requestedCards.length }} requested</span>
-              <span v-if="selectedSet" class="badge badge-primary badge-outline">
-                {{ selectedSet.label }} · {{ selectedSet.cardKeys.length }}
-              </span>
-            </div>
-          </div>
-
-          <div class="grid min-h-36 grid-cols-3 bg-base-200/70 p-3">
-            <div
-              v-for="card in bannerCards"
-              :key="card.key"
-              class="relative m-1 overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-inner"
-            >
-              <img
-                v-if="artCandidate(card.key)"
-                :src="artCandidate(card.key)"
-                :alt="`Illustration for ${card.meaning}`"
-                class="absolute inset-0 h-full w-full object-cover"
-                @error="markArtBroken(card.key)"
-              />
-              <div v-else class="absolute inset-0 flex items-center justify-center bg-base-200/80">
-                <span class="text-4xl font-semibold opacity-45">{{ card.simplified }}</span>
-              </div>
-              <span class="absolute bottom-2 left-2 rounded-lg bg-base-100/90 px-2 py-1 text-lg font-bold shadow">
-                {{ card.simplified }}
-              </span>
-            </div>
-          </div>
-        </div>
-      </header>
+      <MandarinBanner
+        :tiles="bannerTiles"
+        :card-count="cards.length"
+        :set-count="allSets.length"
+        :requested-count="requestedCards.length"
+        :active-set-label="selectedSet?.label || ''"
+        :active-set-size="selectedSet?.cardKeys.length || 0"
+        @art-error="markArtBroken"
+      />
 
       <section class="kr-panel-flat flex flex-wrap items-center justify-between gap-2 p-2 shadow-sm">
         <div class="join" role="tablist" aria-label="Learning mode">
@@ -226,6 +193,15 @@
             </p>
           </div>
 
+          <p
+            v-if="artNotice"
+            class="kr-note kr-note-info"
+            role="status"
+            aria-live="polite"
+          >
+            {{ artNotice }}
+          </p>
+
           <article
             v-if="interactionMode === 'study' && currentCard"
             ref="cardPanel"
@@ -270,18 +246,18 @@
                     {{ currentCard.pinyin }}
                   </span>
                   <div v-else-if="studyPromptMode === 'picture'" class="space-y-3">
-                    <div class="relative mx-auto flex h-48 w-48 items-center justify-center overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-inner">
-                      <img
-                        v-if="currentArtUrl"
-                        :src="currentArtUrl"
-                        :alt="`Study illustration for ${currentCard.meaning}`"
-                        class="h-full w-full object-cover"
-                        @error="markArtBroken(currentCard.key)"
+                    <div class="mx-auto h-48 w-48 overflow-hidden rounded-3xl border border-base-300 shadow-inner">
+                      <!-- reveal-glyph is off here on purpose: in picture-prompt
+                           mode the character is the answer being recalled. -->
+                      <MandarinCardArt
+                        :card-key="currentCard.key"
+                        :simplified="currentCard.simplified"
+                        :meaning="currentCard.meaning"
+                        :art="currentArtUrl"
+                        :reveal-glyph="false"
+                        eager
+                        @error="markArtBroken"
                       />
-                      <div v-else class="space-y-2 opacity-55">
-                        <Icon name="kind-icon:image" class="mx-auto size-10" />
-                        <p class="text-xs">Picture not ready yet</p>
-                      </div>
                     </div>
                     <button v-if="canQueueArt" type="button" class="btn btn-outline btn-xs" :disabled="artBusy" @click="queueCurrentIllustration">
                       {{ artBusy ? 'Submitting…' : 'Request illustration' }}
@@ -295,15 +271,15 @@
                 </div>
 
                 <div v-else class="grid w-full grid-cols-[repeat(auto-fit,minmax(min(100%,10rem),1fr))] items-center gap-4">
-                  <div class="relative mx-auto flex h-44 w-44 items-center justify-center overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-inner">
-                    <img
-                      v-if="currentArtUrl"
-                      :src="currentArtUrl"
-                      :alt="`Study illustration for ${currentCard.meaning}`"
-                      class="h-full w-full object-cover"
-                      @error="markArtBroken(currentCard.key)"
+                  <div class="mx-auto h-44 w-44 overflow-hidden rounded-3xl border border-base-300 shadow-inner">
+                    <MandarinCardArt
+                      :card-key="currentCard.key"
+                      :simplified="currentCard.simplified"
+                      :meaning="currentCard.meaning"
+                      :art="currentArtUrl"
+                      eager
+                      @error="markArtBroken"
                     />
-                    <span v-else class="text-5xl font-semibold opacity-50">{{ currentCard.simplified }}</span>
                   </div>
                   <div class="space-y-2 text-center">
                     <p class="text-5xl font-semibold leading-none">{{ currentCard.simplified }}</p>
@@ -383,15 +359,15 @@
           >
             <div class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,20rem),1fr))]">
               <div class="flex min-h-64 flex-col items-center justify-center gap-3 bg-base-200/55 p-5 text-center">
-                <div class="relative flex h-48 w-48 items-center justify-center overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-inner">
-                  <img
-                    v-if="currentArtUrl"
-                    :src="currentArtUrl"
-                    :alt="`Study illustration for ${currentCard.meaning}`"
-                    class="h-full w-full object-cover"
-                    @error="markArtBroken(currentCard.key)"
+                <div class="h-48 w-48 overflow-hidden rounded-3xl border border-base-300 shadow-inner">
+                  <MandarinCardArt
+                    :card-key="currentCard.key"
+                    :simplified="currentCard.simplified"
+                    :meaning="currentCard.meaning"
+                    :art="currentArtUrl"
+                    eager
+                    @error="markArtBroken"
                   />
-                  <span v-else class="text-6xl font-semibold opacity-55">{{ currentCard.simplified }}</span>
                 </div>
                 <p class="text-3xl font-bold">{{ currentCard.simplified }}</p>
                 <p class="text-xl font-bold tracking-wide">{{ currentCard.pinyin }}</p>
@@ -489,10 +465,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useMandarinTutorStore } from '@/stores/mandarinTutorStore'
 import type { MandarinComponentRole } from '@/utils/mandarin'
+import type { MandarinBannerTile } from '@/components/mandarin/mandarin-banner.vue'
 
 const store = useMandarinTutorStore()
 const {
@@ -553,9 +530,15 @@ const currentRequested = computed(() =>
   currentCard.value ? store.requestedData(currentCard.value.key) : null,
 )
 
-const bannerCards = computed(() => {
+const bannerTiles = computed<MandarinBannerTile[]>(() => {
   const source = studyCards.value.length ? studyCards.value : cards.value
-  return source.slice(0, 3)
+  return source.slice(0, 4).map((card) => ({
+    key: card.key,
+    simplified: card.simplified,
+    pinyin: card.pinyin,
+    meaning: card.meaning,
+    art: artCandidate(card.key),
+  }))
 })
 
 const currentArtUrl = computed(() => {
@@ -668,23 +651,57 @@ async function requestCurrentWord() {
   if (created) await scrollToCard()
 }
 
+// Art jobs render on the home relay at its own pace, so queueing and checking
+// both finish with nothing visibly different on the card. Say what happened.
+let artNoticeTimer: ReturnType<typeof setTimeout> | null = null
+
+function showArtNotice(message: string) {
+  artNotice.value = message
+  if (artNoticeTimer) clearTimeout(artNoticeTimer)
+  if (!message) return
+  artNoticeTimer = setTimeout(() => {
+    artNotice.value = ''
+    artNoticeTimer = null
+  }, 8000)
+}
+
 async function queueCurrentIllustration() {
-  artNotice.value = ''
+  showArtNotice('')
   const jobId = await store.queueIllustration(currentCard.value)
-  if (jobId) artNotice.value = `Illustration queued as ArtJob ${jobId}.`
+  if (jobId) {
+    showArtNotice(`Illustration queued as ArtJob ${jobId}. It renders in the background.`)
+  }
 }
 
 async function refreshCurrentIllustration() {
   const card = currentCard.value
   if (!card) return
-  artNotice.value = ''
+  showArtNotice('')
   const canonical = await store.probeCanonicalIllustration(card.key)
-  if (canonical) return
+  if (canonical) {
+    showArtNotice('Illustration is ready.')
+    return
+  }
   const url = currentRequested.value
     ? await store.refreshRequestedIllustration(card)
     : await store.refreshIllustration(card)
-  if (url) brokenArtKeys.value.delete(card.key)
+  if (url) {
+    brokenArtKeys.value.delete(card.key)
+    showArtNotice('Illustration is ready.')
+    return
+  }
+  showArtNotice('Still rendering — check again in a moment.')
 }
+
+// A notice about one card is meaningless on the next one.
+watch(
+  () => currentCard.value?.key ?? null,
+  () => showArtNotice(''),
+)
+
+onBeforeUnmount(() => {
+  if (artNoticeTimer) clearTimeout(artNoticeTimer)
+})
 
 function roleLabel(role: MandarinComponentRole): string {
   if (role === 'semantic') return 'meaning clue'

--- a/server/api/conductor/art-request.post.ts
+++ b/server/api/conductor/art-request.post.ts
@@ -41,6 +41,33 @@ const VARIANT_SIZES: Record<ArtVariant, string> = {
   image: '',
 }
 
+/**
+ * Media roots whose prompts are owned by a versioned recipe, not by this
+ * endpoint's generic contextual prompt builder.
+ *
+ * A miss under one of these roots means "not rendered yet", which is the normal
+ * state of a corpus the home relay is still working through -- not a gap to
+ * paper over. Letting a generic request through is actively harmful: it renders
+ * an off-direction image to the canonical media path, and that image then
+ * satisfies the path forever, permanently suppressing the real one. Three such
+ * requests reached Conductor's queue for Mandarin v2 card paths before this
+ * guard existed, all asking for readable Hanzi and "digital painting blending
+ * illustration and realism" -- both of which the v2 art direction forbids.
+ *
+ * `force` does not bypass this the way it bypasses the existence check: the way
+ * to (re)render one of these cards is the tutor's own request button, which
+ * enqueues the manifest's canonical prompt.
+ */
+const CANONICAL_PROMPT_ROOTS = [
+  {
+    path: '/images/mandarin-tutor/cards/',
+    message:
+      'Mandarin Tutor card art is generated from the versioned illustration ' +
+      'manifest, not from generic missing-image requests. A missing file here ' +
+      'means the card has not been rendered yet.',
+  },
+] as const
+
 type MissingArtRequestBody = {
   src?: string
   imagePath?: string
@@ -179,6 +206,12 @@ function targetFromSource(body: MissingArtRequestBody): ImageTarget {
 
   if (rawPath.startsWith('/_nuxt/') || rawPath.includes('/node_modules/')) {
     throw createError({ statusCode: 400, message: 'Build assets are ignored.' })
+  }
+
+  for (const root of CANONICAL_PROMPT_ROOTS) {
+    if (rawPath.startsWith(root.path)) {
+      throw createError({ statusCode: 400, message: root.message })
+    }
   }
 
   if (hostname === 'raw.githubusercontent.com') {

--- a/server/utils/mandarinIllustrationManifest.ts
+++ b/server/utils/mandarinIllustrationManifest.ts
@@ -1,6 +1,10 @@
 import { createHash } from 'node:crypto'
 import type { MandarinCard, MandarinCatalogPayload } from '~/utils/mandarin'
 import { getMandarinCatalog } from './mandarinCatalog'
+import {
+  mandarinStyleVariant,
+  type MandarinStyleVariant,
+} from './mandarinIllustrationStyle'
 
 export const MANDARIN_ILLUSTRATION_RECIPE_VERSION = 'v2'
 export const MANDARIN_ART_DIRECTION_ID = 'modern-chinese-picturebook-v2'
@@ -30,6 +34,13 @@ export type MandarinIllustrationManifestEntry = {
   imagePath: string
   imageUrl: string
   prompt: string | null
+  /**
+   * The per-card framing/light/palette/handling/ground draw baked into `prompt`.
+   * Present only for illustrated entries. Batch producers read this to tell a
+   * varied manifest from the original uniform one, and QA reads it to check
+   * whether a weak render is a bad concept or a bad style draw.
+   */
+  styleVariant: MandarinStyleVariant | null
 }
 
 export type MandarinIllustrationManifest = {
@@ -74,7 +85,7 @@ const ART_DIRECTION = {
     'No Hanzi, pinyin, English, numerals, pseudo-writing, captions, signage, logos, speech bubbles, labels, or watermarks inside generated art.',
 } as const
 
-function stableToken(cardKey: string): string {
+export function mandarinCardToken(cardKey: string): string {
   return createHash('sha256').update(cardKey, 'utf8').digest('hex').slice(0, 24)
 }
 
@@ -168,16 +179,34 @@ function categoryDirection(card: MandarinCard): string {
   return 'Choose the simplest ordinary object or everyday scene that makes the primary meaning obvious at a glance. When cultural context helps, ground it in contemporary Chinese lived environments and material culture rather than decorative stereotypes.'
 }
 
+/**
+ * The canonical v2 prompt for a card.
+ *
+ * Structure: what to draw (concept + category direction), the fixed house
+ * style, then this card's own style draw -- framing, light, palette, paint
+ * handling, ground -- then the fixed guard rails. The house style is what makes
+ * 577 cards look like one deck; the style draw is what stops them from looking
+ * like one image rendered 577 times.
+ *
+ * The variant is derived from the card key, so this function stays pure and the
+ * tutor's per-card retry reproduces the same prompt the batch was submitted
+ * with.
+ */
 export function buildMandarinIllustrationPrompt(card: MandarinCard): string {
   const concept = compactConcept(card.meaning)
+  const variant = mandarinStyleVariant(mandarinCardToken(card.key))
   return [
     `Create a square educational flashcard illustration for the vocabulary concept: ${concept}.`,
     categoryDirection(card),
-    'House style: modern Chinese educational picture-book art, hand-painted gouache with gentle watercolor and restrained ink-wash influence, matte pigments, subtle paper grain, clean shapes, clear silhouettes, limited deliberate detail, warm harmonious color, and generous negative space.',
-    'The composition should feel designed by an illustrator: one strong memory anchor or one compact scene, natural asymmetry, modest depth, quiet lighting, and believable object relationships.',
-    'Ground Chinese cultural flavor through truthful everyday details such as ceramics, bamboo, wood, textiles, foodways, interiors, markets, streets, transit, games, furnishings, or landscape only when they naturally belong to the concept.',
-    'Do not use generic China shorthand as decoration: no gratuitous pagodas, lantern walls, dragons, Great Wall imagery, calligraphy, red-and-gold festival dressing, or historical costume unless that specific thing is genuinely the vocabulary concept.',
-    'Avoid characteristic synthetic-image tells: no photorealism, glossy plastic skin, 3D-render surfaces, hyper-detailed microtexture everywhere, perfect symmetry, excessive cinematic rim lighting, lens flare, bokeh, neon glow, decorative filler, implausible anatomy, or crowded hands.',
+    'House style: modern Chinese educational picture-book art, hand-painted gouache with gentle watercolor and restrained ink-wash influence, matte pigments, subtle paper grain, clean shapes, clear silhouettes, limited deliberate detail, and generous negative space.',
+    variant.framing,
+    variant.light,
+    variant.palette,
+    variant.handling,
+    variant.ground,
+    'The composition should feel decided by an illustrator: one strong memory anchor, natural asymmetry, and believable object relationships.',
+    'Ground Chinese cultural flavor in truthful everyday detail -- ceramics, bamboo, wood, textiles, foodways, interiors, markets, streets, transit, games, furnishings, landscape -- only where it naturally belongs to the concept, and never as decoration: no gratuitous pagodas, lantern walls, dragons, Great Wall imagery, calligraphy, red-and-gold festival dressing, or historical costume unless that specific thing is the vocabulary concept.',
+    'Avoid characteristic synthetic-image tells: no photorealism, glossy plastic skin, 3D-render surfaces, hyper-detailed microtexture everywhere, perfect symmetry, cinematic rim lighting, lens flare, bokeh, neon glow, decorative filler, implausible anatomy, or crowded hands.',
     'No readable text, no Chinese characters, no pinyin, no English, no Latin letters, no numerals, no pseudo-writing, no captions, no signage, no labels, no speech bubbles, no logos, no watermarks, no collage.',
   ].join(' ')
 }
@@ -203,7 +232,7 @@ export async function getMandarinIllustrationManifest(): Promise<MandarinIllustr
     .map((key) => cardByKey.get(key))
     .filter((card): card is MandarinCard => Boolean(card))
     .map((card): MandarinIllustrationManifestEntry => {
-      const token = stableToken(card.key)
+      const token = mandarinCardToken(card.key)
       const decision = illustrationStrategy(card)
       const imagePath = `public/images/mandarin-tutor/cards/${MANDARIN_ILLUSTRATION_RECIPE_VERSION}/${token}.webp`
       return {
@@ -226,6 +255,7 @@ export async function getMandarinIllustrationManifest(): Promise<MandarinIllustr
         imagePath,
         imageUrl: imagePath.replace(/^public/, ''),
         prompt: decision.strategy === 'illustrate' ? buildMandarinIllustrationPrompt(card) : null,
+        styleVariant: decision.strategy === 'illustrate' ? mandarinStyleVariant(token) : null,
       }
     })
 

--- a/server/utils/mandarinIllustrationManifest.ts
+++ b/server/utils/mandarinIllustrationManifest.ts
@@ -191,6 +191,14 @@ function categoryDirection(card: MandarinCard): string {
  * The variant is derived from the card key, so this function stays pure and the
  * tutor's per-card retry reproduces the same prompt the batch was submitted
  * with.
+ *
+ * The style clauses are INSERTED into the original v2 sentence order rather
+ * than replacing any of it, and the only text removed is "warm harmonious
+ * color, " from the house style. That is deliberate: Conductor stages the
+ * corpus from whatever manifest production is currently serving, so it can
+ * apply the same edit to an older deployment's prompt and land on a
+ * byte-identical string. Rewording the surrounding sentences would silently
+ * break that (see scripts/mandarin_prompt_variation.py in Conductor).
  */
 export function buildMandarinIllustrationPrompt(card: MandarinCard): string {
   const concept = compactConcept(card.meaning)
@@ -198,15 +206,19 @@ export function buildMandarinIllustrationPrompt(card: MandarinCard): string {
   return [
     `Create a square educational flashcard illustration for the vocabulary concept: ${concept}.`,
     categoryDirection(card),
+    // "warm harmonious color" is gone from the house style on purpose: the
+    // palette axis below now names the colour, and leaving both in had every
+    // card asking for the same warm harmony no matter which palette it drew.
     'House style: modern Chinese educational picture-book art, hand-painted gouache with gentle watercolor and restrained ink-wash influence, matte pigments, subtle paper grain, clean shapes, clear silhouettes, limited deliberate detail, and generous negative space.',
     variant.framing,
     variant.light,
     variant.palette,
     variant.handling,
     variant.ground,
-    'The composition should feel decided by an illustrator: one strong memory anchor, natural asymmetry, and believable object relationships.',
-    'Ground Chinese cultural flavor in truthful everyday detail -- ceramics, bamboo, wood, textiles, foodways, interiors, markets, streets, transit, games, furnishings, landscape -- only where it naturally belongs to the concept, and never as decoration: no gratuitous pagodas, lantern walls, dragons, Great Wall imagery, calligraphy, red-and-gold festival dressing, or historical costume unless that specific thing is the vocabulary concept.',
-    'Avoid characteristic synthetic-image tells: no photorealism, glossy plastic skin, 3D-render surfaces, hyper-detailed microtexture everywhere, perfect symmetry, cinematic rim lighting, lens flare, bokeh, neon glow, decorative filler, implausible anatomy, or crowded hands.',
+    'The composition should feel designed by an illustrator: one strong memory anchor or one compact scene, natural asymmetry, modest depth, quiet lighting, and believable object relationships.',
+    'Ground Chinese cultural flavor through truthful everyday details such as ceramics, bamboo, wood, textiles, foodways, interiors, markets, streets, transit, games, furnishings, or landscape only when they naturally belong to the concept.',
+    'Do not use generic China shorthand as decoration: no gratuitous pagodas, lantern walls, dragons, Great Wall imagery, calligraphy, red-and-gold festival dressing, or historical costume unless that specific thing is genuinely the vocabulary concept.',
+    'Avoid characteristic synthetic-image tells: no photorealism, glossy plastic skin, 3D-render surfaces, hyper-detailed microtexture everywhere, perfect symmetry, excessive cinematic rim lighting, lens flare, bokeh, neon glow, decorative filler, implausible anatomy, or crowded hands.',
     'No readable text, no Chinese characters, no pinyin, no English, no Latin letters, no numerals, no pseudo-writing, no captions, no signage, no labels, no speech bubbles, no logos, no watermarks, no collage.',
   ].join(' ')
 }

--- a/server/utils/mandarinIllustrationManifest.ts
+++ b/server/utils/mandarinIllustrationManifest.ts
@@ -1,7 +1,8 @@
-import { createHash } from 'node:crypto'
 import type { MandarinCard, MandarinCatalogPayload } from '~/utils/mandarin'
 import { getMandarinCatalog } from './mandarinCatalog'
 import {
+  buildMandarinIllustrationPrompt,
+  mandarinCardToken,
   mandarinStyleVariant,
   type MandarinStyleVariant,
 } from './mandarinIllustrationStyle'
@@ -85,16 +86,6 @@ const ART_DIRECTION = {
     'No Hanzi, pinyin, English, numerals, pseudo-writing, captions, signage, logos, speech bubbles, labels, or watermarks inside generated art.',
 } as const
 
-export function mandarinCardToken(cardKey: string): string {
-  return createHash('sha256').update(cardKey, 'utf8').digest('hex').slice(0, 24)
-}
-
-function compactConcept(meaning: string): string {
-  const clean = meaning.replace(/\s+/g, ' ').trim()
-  const firstClause = clean.split(';')[0]?.trim() || clean
-  return firstClause.slice(0, 240)
-}
-
 function illustrationStrategy(card: MandarinCard): {
   strategy: MandarinIllustrationStrategy
   reason: string
@@ -136,91 +127,6 @@ function illustrationStrategy(card: MandarinCard): {
     strategy: 'illustrate',
     reason: 'A concrete object, action, person, place, quantity, or scene can provide a useful visual memory anchor.',
   }
-}
-
-function categoryDirection(card: MandarinCard): string {
-  const categories = new Set(card.categories)
-
-  if (categories.has('casino')) {
-    return [
-      'Use a grounded contemporary Chinese or Chinese-speaking table-game context when it clarifies the concept: believable felt tables, chips, cards, tiles, cash handling, dealer gestures, and player interactions.',
-      'Favor the visual language of a real working casino floor over fantasy luxury. Keep equipment physically plausible and brand-neutral.',
-      'Do not invent readable table labels, chip denominations, card-face numerals, or gambling signage.',
-    ].join(' ')
-  }
-  if (categories.has('food-drink')) {
-    return 'Use recognizable Chinese everyday food culture where natural: ceramic bowls and cups, chopsticks, bamboo steamers, shared dishes, market ingredients, or an ordinary kitchen/table setting. The food or action remains the focal point.'
-  }
-  if (categories.has('family')) {
-    return 'Use a warm contemporary Chinese domestic-life scene: an ordinary apartment, home, courtyard, or neighborhood context with believable everyday clothing and furnishings. Make the relationship obvious through interaction, not labels.'
-  }
-  if (categories.has('travel-places')) {
-    return 'Use a practical contemporary Chinese urban, neighborhood, transit, room, street, or travel setting where it helps. Architecture and objects should feel lived-in and specific, with no readable signage.'
-  }
-  if (categories.has('greetings')) {
-    return 'Use a simple contemporary Chinese social interaction with natural gesture, distance, and body language. Keep faces expressive but lightly rendered rather than uncanny close-up portraits.'
-  }
-  if (categories.has('time-calendar')) {
-    return 'Express time through lighting and recognizable Chinese everyday routines such as breakfast, commuting, school, work, evening meals, or neighborhood activity. Avoid clocks or calendars with readable numerals unless absolutely necessary.'
-  }
-  if (categories.has('everyday-actions')) {
-    return 'Show one person clearly performing the action in an ordinary contemporary Chinese daily-life setting where useful. Use a simple pose, believable hands, and minimal background distraction.'
-  }
-  if (categories.has('numbers')) {
-    return 'Communicate quantity with a clean group of countable everyday objects, preferably familiar Chinese household, food, market, school, or game objects when appropriate. Use objects rather than written digits or number symbols.'
-  }
-  if (categories.has('colors')) {
-    return 'Use one familiar central object or tiny scene whose target color is unmistakable. Chinese ceramics, textiles, food, plants, or ordinary household objects may provide subtle cultural grounding without turning into ornament.'
-  }
-  if (categories.has('animals')) {
-    return 'Center one clearly recognizable animal or a tiny natural scene. Chinese landscape, garden, farm, or neighborhood cues may appear lightly when relevant, but the animal must remain the unmistakable memory anchor.'
-  }
-
-  return 'Choose the simplest ordinary object or everyday scene that makes the primary meaning obvious at a glance. When cultural context helps, ground it in contemporary Chinese lived environments and material culture rather than decorative stereotypes.'
-}
-
-/**
- * The canonical v2 prompt for a card.
- *
- * Structure: what to draw (concept + category direction), the fixed house
- * style, then this card's own style draw -- framing, light, palette, paint
- * handling, ground -- then the fixed guard rails. The house style is what makes
- * 577 cards look like one deck; the style draw is what stops them from looking
- * like one image rendered 577 times.
- *
- * The variant is derived from the card key, so this function stays pure and the
- * tutor's per-card retry reproduces the same prompt the batch was submitted
- * with.
- *
- * The style clauses are INSERTED into the original v2 sentence order rather
- * than replacing any of it, and the only text removed is "warm harmonious
- * color, " from the house style. That is deliberate: Conductor stages the
- * corpus from whatever manifest production is currently serving, so it can
- * apply the same edit to an older deployment's prompt and land on a
- * byte-identical string. Rewording the surrounding sentences would silently
- * break that (see scripts/mandarin_prompt_variation.py in Conductor).
- */
-export function buildMandarinIllustrationPrompt(card: MandarinCard): string {
-  const concept = compactConcept(card.meaning)
-  const variant = mandarinStyleVariant(mandarinCardToken(card.key))
-  return [
-    `Create a square educational flashcard illustration for the vocabulary concept: ${concept}.`,
-    categoryDirection(card),
-    // "warm harmonious color" is gone from the house style on purpose: the
-    // palette axis below now names the colour, and leaving both in had every
-    // card asking for the same warm harmony no matter which palette it drew.
-    'House style: modern Chinese educational picture-book art, hand-painted gouache with gentle watercolor and restrained ink-wash influence, matte pigments, subtle paper grain, clean shapes, clear silhouettes, limited deliberate detail, and generous negative space.',
-    variant.framing,
-    variant.light,
-    variant.palette,
-    variant.handling,
-    variant.ground,
-    'The composition should feel designed by an illustrator: one strong memory anchor or one compact scene, natural asymmetry, modest depth, quiet lighting, and believable object relationships.',
-    'Ground Chinese cultural flavor through truthful everyday details such as ceramics, bamboo, wood, textiles, foodways, interiors, markets, streets, transit, games, furnishings, or landscape only when they naturally belong to the concept.',
-    'Do not use generic China shorthand as decoration: no gratuitous pagodas, lantern walls, dragons, Great Wall imagery, calligraphy, red-and-gold festival dressing, or historical costume unless that specific thing is genuinely the vocabulary concept.',
-    'Avoid characteristic synthetic-image tells: no photorealism, glossy plastic skin, 3D-render surfaces, hyper-detailed microtexture everywhere, perfect symmetry, excessive cinematic rim lighting, lens flare, bokeh, neon glow, decorative filler, implausible anatomy, or crowded hands.',
-    'No readable text, no Chinese characters, no pinyin, no English, no Latin letters, no numerals, no pseudo-writing, no captions, no signage, no labels, no speech bubbles, no logos, no watermarks, no collage.',
-  ].join(' ')
 }
 
 function selectedCardKeys(catalog: MandarinCatalogPayload): string[] {
@@ -285,3 +191,7 @@ export async function getMandarinIllustrationManifest(): Promise<MandarinIllustr
     entries,
   }
 }
+
+// The prompt recipe lives in the pure module; re-exported so callers that think
+// of it as "the manifest's prompt" keep working.
+export { buildMandarinIllustrationPrompt, mandarinCardToken } from './mandarinIllustrationStyle'

--- a/server/utils/mandarinIllustrationStyle.ts
+++ b/server/utils/mandarinIllustrationStyle.ts
@@ -21,7 +21,13 @@
 // 6 x 5 x 6 x 5 x 4 = 3600 combinations across 577 cards.
 //
 // Pure functions only -- no prisma, no Nuxt runtime -- so the recipe can be
-// self-tested without a database.
+// self-tested without a database. buildMandarinIllustrationPrompt lives here
+// rather than beside the manifest assembler for exactly that reason: it is the
+// piece that has to be checked against the art prompt contract, and the
+// assembler pulls in the catalog and prisma behind it.
+
+import type { MandarinCard } from '~/utils/mandarin'
+import { createHash } from 'node:crypto'
 
 export type MandarinStyleVariant = {
   /** Stable axis-index id, e.g. `f2-l0-p4-h1-g3`. Recorded for audit/QA. */
@@ -126,3 +132,136 @@ export const MANDARIN_STYLE_VARIANT_COMBINATIONS =
   MANDARIN_PALETTES.length *
   MANDARIN_HANDLINGS.length *
   MANDARIN_GROUNDS.length
+
+export function mandarinCardToken(cardKey: string): string {
+  return createHash('sha256').update(cardKey, 'utf8').digest('hex').slice(0, 24)
+}
+
+function compactConcept(meaning: string): string {
+  const clean = meaning.replace(/\s+/g, ' ').trim()
+  const firstClause = clean.split(';')[0]?.trim() || clean
+  return firstClause.slice(0, 240)
+}
+
+
+/**
+ * Where the card is set.
+ *
+ * Every clause here states one decided outcome. The art prompt contract
+ * (server/utils/artPromptContract.ts) rejects "only when", "where appropriate",
+ * "as needed" and their relatives for a demonstrated reason: Krea 2 is a
+ * distilled diffusion transformer, it cannot evaluate a condition, and it
+ * paints the densest noun phrase it is handed. "Use a Chinese setting where it
+ * helps" is not a hedge to the model -- it is a Chinese setting, always, plus
+ * some noise. The recipe knows the card's categories, so it decides here.
+ */
+function categoryDirection(card: MandarinCard): string {
+  const categories = new Set(card.categories)
+
+  if (categories.has('casino')) {
+    return [
+      'Set it on the working floor of a contemporary Chinese-speaking casino: believable felt tables, chips, cards, tiles, cash handling, dealer gestures, and players mid-hand.',
+      'Favor the look of a real working table game over fantasy luxury. Keep the equipment physically plausible and brand-neutral, with blank chips, blank card faces, and blank signage.',
+    ].join(' ')
+  }
+  if (categories.has('food-drink')) {
+    return 'Set it in everyday Chinese food culture: ceramic bowls and cups, chopsticks, bamboo steamers, shared dishes, market ingredients, an ordinary kitchen or table. The food or the action stays the focal point.'
+  }
+  if (categories.has('family')) {
+    return 'Set it in a warm contemporary Chinese home: an ordinary apartment, courtyard, or neighborhood, with everyday clothing and furnishings. The relationship reads through how the people act toward each other.'
+  }
+  if (categories.has('travel-places')) {
+    return 'Set it in a practical contemporary Chinese street, neighborhood, room, transit, or travel scene. The architecture and objects look lived-in and specific, and every sign is blank.'
+  }
+  if (categories.has('greetings')) {
+    return 'Show a simple contemporary Chinese social interaction with natural gesture, distance, and body language. Keep the faces small and lightly painted rather than a close-up portrait.'
+  }
+  if (categories.has('time-calendar')) {
+    return 'Express the hour through daylight and a recognizable Chinese daily routine: breakfast, the commute, school, work, an evening meal, neighborhood activity. Let the light carry the time rather than a clock face.'
+  }
+  if (categories.has('everyday-actions')) {
+    return 'Show one person performing the action in an ordinary contemporary Chinese daily-life setting, with a simple pose, believable hands, and a quiet uncluttered background.'
+  }
+  if (categories.has('numbers')) {
+    return 'Show the quantity as a clean group of countable everyday objects from a Chinese household, kitchen, market, school, or game. The count is carried by the objects themselves.'
+  }
+  if (categories.has('colors')) {
+    return 'Show one familiar central object whose color is unmistakable: Chinese ceramics, textiles, food, plants, or an ordinary household object.'
+  }
+  if (categories.has('animals')) {
+    return 'Center one clearly recognizable animal, with a light Chinese landscape, garden, farm, or neighborhood behind it. The animal stays the memory anchor.'
+  }
+
+  return 'Show the simplest ordinary object or everyday scene that makes the meaning obvious at a glance, grounded in contemporary Chinese lived environments and material culture.'
+}
+
+/**
+ * Cultural shorthand — pagodas, dragons, festival red-and-gold — is banned as
+ * decoration but obviously allowed when it IS the word. The recipe decides per
+ * card instead of shipping the model an "unless" it cannot read.
+ */
+const CULTURAL_SHORTHAND = /\b(?:pagoda|dragon|lantern|great wall|calligraph|festival|new year|temple|opera|costume|traditional dress)/i
+
+
+/**
+ * The canonical v2 prompt for a card.
+ *
+ * Structure: what to draw (concept + category direction), the fixed house
+ * style, then this card's own style draw -- framing, light, palette, paint
+ * handling, ground -- then the fixed guard rails. The house style is what makes
+ * 577 cards look like one deck; the style draw is what stops them from looking
+ * like one image rendered 577 times.
+ *
+ * The variant is derived from the card key, so this function stays pure and the
+ * tutor's per-card retry reproduces the same prompt the batch was submitted
+ * with.
+ *
+ * The style clauses are INSERTED into the original v2 sentence order rather
+ * than replacing any of it, and the only text removed is "warm harmonious
+ * color, " from the house style. That is deliberate: Conductor stages the
+ * corpus from whatever manifest production is currently serving, so it can
+ * apply the same edit to an older deployment's prompt and land on a
+ * byte-identical string. Rewording the surrounding sentences would silently
+ * break that (see scripts/mandarin_prompt_variation.py in Conductor).
+ */
+export function buildMandarinIllustrationPrompt(card: MandarinCard): string {
+  const concept = compactConcept(card.meaning)
+  const variant = mandarinStyleVariant(mandarinCardToken(card.key))
+  const conceptIsCultural = CULTURAL_SHORTHAND.test(`${card.meaning} ${card.categories.join(' ')}`)
+
+  return [
+    // Not "flashcard illustration". Naming a physical format gets you the
+    // object: the contract's second rule was learned from "treasure card
+    // illustration", which rendered literal trading cards with title bars and
+    // invented rules text. The tutor owns the card; the model paints a picture.
+    `A square illustration of this idea: ${concept}.`,
+    categoryDirection(card),
+    // "warm harmonious color" is gone from the house style on purpose: the
+    // palette axis below now names the colour, and leaving both in had every
+    // card asking for the same warm harmony no matter which palette it drew.
+    'House style: modern Chinese educational picture-book art, hand-painted gouache with gentle watercolor and restrained ink-wash influence, matte pigments, subtle paper grain, clean shapes, clear silhouettes, limited deliberate detail, and generous negative space.',
+    variant.framing,
+    variant.light,
+    variant.palette,
+    variant.handling,
+    variant.ground,
+    'The composition is decided by an illustrator: one strong memory anchor, natural asymmetry, modest depth, and believable object relationships.',
+    'Chinese cultural flavor comes from truthful everyday detail that belongs to the idea itself: ceramics, bamboo, wood, textiles, foodways, interiors, markets, streets, transit, games, furnishings, landscape.',
+    // Naming what to leave out is only safe when the word is not the concept --
+    // and on a cfg-1 distilled engine every one of those nouns lands in
+    // positive conditioning anyway, so a card about a dragon would get the
+    // dragon twice over.
+    ...(conceptIsCultural
+      ? []
+      : [
+          'Keep the tourist shorthand out of it: no pagodas, lantern walls, dragons, Great Wall, red-and-gold festival dressing, or historical costume.',
+        ]),
+    // The old recipe listed twelve synthetic-image tells to avoid -- including
+    // "lens flare", "bokeh", and "neon glow". At cfg 1 the ComfyUI negative
+    // prompt is inert, so that list was a request for exactly those things.
+    // Same art direction, stated as the wanted result.
+    'Everything is hand-painted: matte pigment on paper, simplified deliberate shapes, plain even light, simple anatomy, relaxed hands, and calm uncluttered surroundings.',
+    // Likewise: the old recipe named text fourteen ways. Once, positively.
+    'Every surface in the picture is blank and unmarked, carrying no writing of any kind.',
+  ].join(' ')
+}

--- a/server/utils/mandarinIllustrationStyle.ts
+++ b/server/utils/mandarinIllustrationStyle.ts
@@ -1,0 +1,128 @@
+// /server/utils/mandarinIllustrationStyle.ts
+//
+// Per-card style variation for the Mandarin Tutor v2 illustration recipe.
+//
+// The v2 house style is deliberately fixed: modern Chinese educational
+// picture-book gouache. What was NOT fixed -- and should not be -- is the
+// framing, light, palette, paint handling, and ground treatment of every single
+// card. The first v2 recipe emitted the same style sentences for all 577
+// illustrated cards, so any two prompts were ~82% identical and 38 pairs were
+// byte-for-byte identical. A corpus built from that converges on one camera
+// distance, one lighting setup, and one palette, which is exactly the
+// interchangeable "AI art" read the art direction is trying to avoid.
+//
+// So: keep the house style constant, vary the illustrator's decisions. Each
+// card draws one option per axis, deterministically, from its own stable card
+// token -- the same token that already names its media file. Determinism
+// matters because the batch producer (Conductor) and the tutor's per-card retry
+// button must ask for the same picture, and because a re-render of one card
+// should not silently restyle it.
+//
+// 6 x 5 x 6 x 5 x 4 = 3600 combinations across 577 cards.
+//
+// Pure functions only -- no prisma, no Nuxt runtime -- so the recipe can be
+// self-tested without a database.
+
+export type MandarinStyleVariant = {
+  /** Stable axis-index id, e.g. `f2-l0-p4-h1-g3`. Recorded for audit/QA. */
+  id: string
+  framing: string
+  light: string
+  palette: string
+  handling: string
+  ground: string
+}
+
+/** How the square is composed and how close the subject sits. */
+export const MANDARIN_FRAMINGS = [
+  'Frame it as a close still life: the subject large in the square and lightly cropped by it, seen from a little above the surface it rests on.',
+  'Frame it wide and quiet: the subject small and set low in the square, with a large calm field of paper above and around it.',
+  'Frame it as a mid-distance vignette: the subject off-centre, with the scene painted only where it matters and dissolving into bare paper toward the edges.',
+  'Frame it as a flat overhead view, looking straight down on a small arrangement laid out on a plain surface.',
+  'Frame it at eye level, the subject reading clearly in profile or three-quarter view against a nearly empty ground.',
+  'Frame it through an ordinary near edge such as a doorway, window frame, table edge, or shelf, keeping that near edge a simple dark shape and the subject just beyond it.',
+] as const
+
+/** Quality and direction of light. Restrained on purpose -- no cinematic tricks. */
+export const MANDARIN_LIGHTS = [
+  'Light it with flat, even overcast daylight: soft shadows, no strong direction, gentle contrast.',
+  'Light it with low late-afternoon sun from one side: long soft shadows and a warm cast on the lit planes.',
+  'Light it with bright open shade around midday: cool clean light and crisp but shallow shadows.',
+  'Light it with warm indoor lamplight after dark: one small pool of light, the rest of the square settling into quiet muted tone.',
+  'Light it with cool early-morning window light: pale, slightly blue shadows and a calm low-contrast feel.',
+] as const
+
+/**
+ * Limited harmonies with one accent each. Every option stays inside the matte
+ * gouache family, so the deck still reads as one hand even as the colour moves.
+ */
+export const MANDARIN_PALETTES = [
+  'Keep the palette to muted indigo, slate blue, and warm off-white, with a single soft persimmon accent.',
+  'Keep the palette to dusty jade and bamboo green over cream, with a single clay-red accent.',
+  'Keep the palette to warm ochre, tea brown, and unbleached paper, with a single deep teal accent.',
+  'Keep the palette to soft brick red and terracotta against pale grey-green, with a single ink-black accent.',
+  'Keep the palette to pale wheat, straw yellow, and warm grey, with a single dusty plum accent.',
+  'Keep the palette to cool porcelain white and celadon with charcoal drawing, and a single mustard accent.',
+] as const
+
+/** How the paint itself behaves -- the strongest anti-sameness lever. */
+export const MANDARIN_HANDLINGS = [
+  'Handle the paint as flat opaque gouache shapes with very little blending and honest visible brush edges.',
+  'Handle the paint as wet watercolour washes bleeding softly into one another, with a few edges left deliberately hard.',
+  'Handle the paint with a dry brush dragged over rough paper so the tooth of the sheet breaks the colour.',
+  'Handle the paint as thin washes under an uneven hand-drawn ink line that changes weight and sometimes misses its own shape.',
+  'Handle the paint in broad simple strokes, letting pigment pool and darken at the edge of each shape.',
+] as const
+
+/** What the subject sits on, and how the negative space is treated. */
+export const MANDARIN_GROUNDS = [
+  'Leave the ground as bare untouched paper so the negative space is genuinely empty.',
+  'Set the subject on a single flat wash of ground colour that stops short of the square edges.',
+  'Set the subject against a soft irregular halo of wash that fades out before it reaches the corners.',
+  'Set the subject on a simple band of ground colour across the lower part of the square, leaving the rest as paper.',
+] as const
+
+/**
+ * Read a 4-hex-digit slice of the card token as an index into `length`.
+ *
+ * Separate slices per axis keeps the axes independent: two cards that happen to
+ * share a framing are no more likely to share a palette than any other pair.
+ */
+function axisIndex(token: string, slot: number, length: number): number {
+  const slice = token.slice(slot * 4, slot * 4 + 4)
+  const value = Number.parseInt(slice, 16)
+  if (!Number.isFinite(value)) return 0
+  return value % length
+}
+
+/**
+ * The deterministic style variant for a card token.
+ *
+ * `token` is the 24-hex-character card token (`stableToken(card.key)`) that also
+ * names the card's media file, so a card's look is tied to its identity rather
+ * than to its position in the catalog.
+ */
+export function mandarinStyleVariant(token: string): MandarinStyleVariant {
+  const normalized = token.trim().toLowerCase()
+  const f = axisIndex(normalized, 0, MANDARIN_FRAMINGS.length)
+  const l = axisIndex(normalized, 1, MANDARIN_LIGHTS.length)
+  const p = axisIndex(normalized, 2, MANDARIN_PALETTES.length)
+  const h = axisIndex(normalized, 3, MANDARIN_HANDLINGS.length)
+  const g = axisIndex(normalized, 4, MANDARIN_GROUNDS.length)
+  return {
+    id: `f${f}-l${l}-p${p}-h${h}-g${g}`,
+    framing: MANDARIN_FRAMINGS[f] as string,
+    light: MANDARIN_LIGHTS[l] as string,
+    palette: MANDARIN_PALETTES[p] as string,
+    handling: MANDARIN_HANDLINGS[h] as string,
+    ground: MANDARIN_GROUNDS[g] as string,
+  }
+}
+
+/** Total distinct combinations the axes can produce. */
+export const MANDARIN_STYLE_VARIANT_COMBINATIONS =
+  MANDARIN_FRAMINGS.length *
+  MANDARIN_LIGHTS.length *
+  MANDARIN_PALETTES.length *
+  MANDARIN_HANDLINGS.length *
+  MANDARIN_GROUNDS.length

--- a/server/utils/mandarinRequestedCards.ts
+++ b/server/utils/mandarinRequestedCards.ts
@@ -159,7 +159,10 @@ function requestedArtCategories(fields: GeneratedMandarinFields): string[] {
 
 export function requestedArtPrompt(fields: GeneratedMandarinFields): string {
   const promptCard: MandarinCard = {
-    key: 'requested:prompt',
+    // The key seeds the per-card style draw in buildMandarinIllustrationPrompt,
+    // so it has to name the actual word -- a constant here would give every
+    // requested card in the deck the same framing, light, and palette.
+    key: `requested:${fields.simplified}`,
     simplified: fields.simplified,
     ...(fields.traditional ? { traditional: fields.traditional } : {}),
     pinyin: fields.pinyin,

--- a/stores/mandarinTutorStore.ts
+++ b/stores/mandarinTutorStore.ts
@@ -405,7 +405,13 @@ export const useMandarinTutorStore = defineStore('mandarinTutorStore', () => {
         method: 'HEAD',
         cache: 'no-store',
       })
-      if (!response.ok) {
+      // A missing /images/... path is not a 404 here: Nuxt falls through to the
+      // catch-all page and answers 200 text/html. Trusting response.ok alone
+      // flips every unrendered card to V2 READY and paints a broken <img> over
+      // the Hanzi fallback, which is worse than showing no picture at all. The
+      // content type is what actually distinguishes a rendered card.
+      const contentType = response.headers.get('content-type') || ''
+      if (!response.ok || !contentType.toLowerCase().startsWith('image/')) {
         artStatuses.value = { ...artStatuses.value, [cardKey]: 'V2 PENDING' }
         return null
       }

--- a/utils/mandarinPalette.ts
+++ b/utils/mandarinPalette.ts
@@ -1,0 +1,21 @@
+// /utils/mandarinPalette.ts
+//
+// Shared pigment assignment for Mandarin Tutor surfaces.
+//
+// The illustrated corpus renders in the background over days, so most of the
+// deck has no picture at any given moment. Rather than show that as grey
+// placeholder boxes, unrendered cards sit on a pigment from the tutor's own
+// gouache palette. The pigment is derived from the card key so a word keeps the
+// same ground everywhere it appears -- banner, study card, gallery -- and two
+// adjacent cards do not come up the same colour by accident.
+
+/** Number of pigment grounds defined by the Mandarin components' CSS. */
+export const MANDARIN_PIGMENT_COUNT = 5
+
+export function mandarinPigmentIndex(cardKey: string): number {
+  let hash = 0
+  for (const char of cardKey) {
+    hash = (hash * 31 + (char.codePointAt(0) ?? 0)) % 100_000
+  }
+  return hash % MANDARIN_PIGMENT_COUNT
+}

--- a/utils/scripts/verifyMandarinArtRecipe.test.ts
+++ b/utils/scripts/verifyMandarinArtRecipe.test.ts
@@ -13,6 +13,7 @@
 import assert from 'node:assert/strict'
 import { createHash } from 'node:crypto'
 
+import { checkArtPromptContract } from '../../server/utils/artPromptContract.js'
 import {
   MANDARIN_FRAMINGS,
   MANDARIN_GROUNDS,
@@ -20,8 +21,10 @@ import {
   MANDARIN_LIGHTS,
   MANDARIN_PALETTES,
   MANDARIN_STYLE_VARIANT_COMBINATIONS,
+  buildMandarinIllustrationPrompt,
   mandarinStyleVariant,
 } from '../../server/utils/mandarinIllustrationStyle.js'
+import type { MandarinCard } from '../mandarin.js'
 
 function token(cardKey: string): string {
   return createHash('sha256').update(cardKey, 'utf8').digest('hex').slice(0, 24)
@@ -138,6 +141,79 @@ function token(cardKey: string): string {
       `style clause hard-codes China shorthand: ${clause}`,
     )
   }
+}
+
+// --- every built prompt satisfies the art prompt contract ------------------
+
+{
+  // This is the check that was missing. Every v2 prompt in production violated
+  // the contract's conditional-instruction rule ("...only when they naturally
+  // belong to the concept"), so all 577 enqueues came back 422 and the corpus
+  // could never be submitted at all. The recipe and the gate that guards the
+  // enqueue boundary have to be tested against each other, not separately.
+  function card(overrides: Partial<MandarinCard> & Pick<MandarinCard, 'key' | 'meaning'>): MandarinCard {
+    return {
+      simplified: '字',
+      pinyin: 'zì',
+      meanings: [overrides.meaning],
+      kind: 'word',
+      partsOfSpeech: [],
+      classifiers: [],
+      categories: [],
+      components: [],
+      historyStatus: 'pending',
+      source: { label: 'test', version: 'test' },
+      ...overrides,
+    } as MandarinCard
+  }
+
+  const samples: MandarinCard[] = [
+    card({ key: 'hsk:1:的', meaning: "of; ~'s (possessive particle)" }),
+    card({ key: 'hsk:1:写', meaning: 'to write', categories: ['everyday-actions'] }),
+    card({ key: 'hsk:1:三', meaning: 'three', categories: ['numbers'] }),
+    card({ key: 'hsk:1:红', meaning: 'red', categories: ['colors'] }),
+    card({ key: 'hsk:1:猫', meaning: 'cat', categories: ['animals'] }),
+    card({ key: 'hsk:1:茶', meaning: 'tea', categories: ['food-drink'] }),
+    card({ key: 'hsk:1:妈妈', meaning: 'mother', categories: ['family'] }),
+    card({ key: 'hsk:1:车站', meaning: 'station', categories: ['travel-places'] }),
+    card({ key: 'hsk:1:你好', meaning: 'hello', categories: ['greetings'] }),
+    card({ key: 'hsk:2:早上', meaning: 'morning', categories: ['time-calendar'] }),
+    card({ key: 'casino:荷官', meaning: 'dealer', categories: ['casino'] }),
+    // A card whose concept IS the cultural shorthand the recipe otherwise
+    // excludes. It must not ship a prompt that asks for a dragon and forbids
+    // one in the same breath.
+    card({ key: 'hsk:5:龙', meaning: 'dragon', categories: ['animals'] }),
+    card({ key: 'hsk:4:灯笼', meaning: 'lantern' }),
+  ]
+
+  for (const sample of samples) {
+    const prompt = buildMandarinIllustrationPrompt(sample)
+    const violations = checkArtPromptContract({
+      prompt,
+      engine: 'krea2',
+      cfg: 1,
+      steps: 8,
+    })
+    assert.deepEqual(
+      violations,
+      [],
+      `${sample.key} violates the art prompt contract: ${violations
+        .map((violation) => `[${violation.rule}] ${violation.detail}`)
+        .join(' ')}`,
+    )
+  }
+
+  // The dragon card asks for a dragon and does not also forbid one.
+  const dragon = buildMandarinIllustrationPrompt(samples[samples.length - 2] as MandarinCard)
+  assert.ok(!/no pagodas/i.test(dragon), 'a dragon card should not carry the shorthand exclusion')
+  const ordinary = buildMandarinIllustrationPrompt(samples[0] as MandarinCard)
+  assert.ok(/no pagodas/i.test(ordinary), 'an ordinary card should carry the shorthand exclusion')
+
+  // Format vocabulary: the tutor owns the card, the model paints a picture.
+  assert.ok(
+    !/flashcard|trading card|card illustration/i.test(ordinary),
+    'the prompt must not ask the model for a card',
+  )
 }
 
 console.log('mandarin art recipe contract: OK')

--- a/utils/scripts/verifyMandarinArtRecipe.test.ts
+++ b/utils/scripts/verifyMandarinArtRecipe.test.ts
@@ -1,0 +1,143 @@
+// /utils/scripts/verifyMandarinArtRecipe.test.ts
+//
+// Contract test for the Mandarin Tutor v2 illustration recipe's per-card style
+// variation (server/utils/mandarinIllustrationStyle.ts). Pure functions only --
+// no prisma, no database, no Nuxt/H3 runtime -- same discipline as
+// utils/scripts/verifyMandarinSrs.test.ts.
+//
+// What this is defending: the first v2 recipe emitted identical style language
+// for all 577 illustrated cards, which is how a deck ends up looking like one
+// image rendered 577 times. The properties below are the ones that actually
+// keep that from coming back -- determinism (so a retry reproduces the render
+// that was submitted), independence across axes, and real spread over a corpus.
+import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
+
+import {
+  MANDARIN_FRAMINGS,
+  MANDARIN_GROUNDS,
+  MANDARIN_HANDLINGS,
+  MANDARIN_LIGHTS,
+  MANDARIN_PALETTES,
+  MANDARIN_STYLE_VARIANT_COMBINATIONS,
+  mandarinStyleVariant,
+} from '../../server/utils/mandarinIllustrationStyle.js'
+
+function token(cardKey: string): string {
+  return createHash('sha256').update(cardKey, 'utf8').digest('hex').slice(0, 24)
+}
+
+// --- determinism -----------------------------------------------------------
+
+{
+  // Same card key, same variant -- every time, in any process. Conductor submits
+  // the batch and the tutor's retry button rebuilds the prompt independently;
+  // if these ever disagree, a re-render silently restyles the card.
+  const a = mandarinStyleVariant(token('hsk:1:的'))
+  const b = mandarinStyleVariant(token('hsk:1:的'))
+  assert.deepEqual(a, b)
+
+  // Case and surrounding whitespace in the token must not change the draw.
+  const raw = token('hsk:1:写')
+  assert.deepEqual(
+    mandarinStyleVariant(raw),
+    mandarinStyleVariant(` ${raw.toUpperCase()} `),
+  )
+}
+
+// --- the id names the actual draw ------------------------------------------
+
+{
+  const variant = mandarinStyleVariant(token('hsk:1:写'))
+  const match = /^f(\d+)-l(\d+)-p(\d+)-h(\d+)-g(\d+)$/.exec(variant.id)
+  assert.ok(match, `variant id should be axis-indexed, got ${variant.id}`)
+  const [, f, l, p, h, g] = match as RegExpExecArray
+  assert.equal(variant.framing, MANDARIN_FRAMINGS[Number(f)])
+  assert.equal(variant.light, MANDARIN_LIGHTS[Number(l)])
+  assert.equal(variant.palette, MANDARIN_PALETTES[Number(p)])
+  assert.equal(variant.handling, MANDARIN_HANDLINGS[Number(h)])
+  assert.equal(variant.ground, MANDARIN_GROUNDS[Number(g)])
+}
+
+// --- every axis option is reachable, and the corpus actually spreads --------
+
+{
+  // 621 synthetic keys stands in for the real starter-500 + casino selection.
+  const keys = Array.from({ length: 621 }, (_, index) => `hsk:${(index % 6) + 1}:card-${index}`)
+  const variants = keys.map((key) => mandarinStyleVariant(token(key)))
+
+  const seen = {
+    framing: new Set(variants.map((variant) => variant.framing)),
+    light: new Set(variants.map((variant) => variant.light)),
+    palette: new Set(variants.map((variant) => variant.palette)),
+    handling: new Set(variants.map((variant) => variant.handling)),
+    ground: new Set(variants.map((variant) => variant.ground)),
+  }
+  assert.equal(seen.framing.size, MANDARIN_FRAMINGS.length)
+  assert.equal(seen.light.size, MANDARIN_LIGHTS.length)
+  assert.equal(seen.palette.size, MANDARIN_PALETTES.length)
+  assert.equal(seen.handling.size, MANDARIN_HANDLINGS.length)
+  assert.equal(seen.ground.size, MANDARIN_GROUNDS.length)
+
+  // No single option may swallow the deck. With 6 framings the expected share is
+  // ~17%; 40% is a generous ceiling that still catches a broken index.
+  for (const options of Object.values(seen)) {
+    for (const option of options) {
+      const share =
+        variants.filter((variant) =>
+          Object.values(variant).includes(option),
+        ).length / variants.length
+      assert.ok(share < 0.4, `one style option covers ${Math.round(share * 100)}% of the deck`)
+    }
+  }
+
+  // The whole point: most cards should carry a combination nothing else has.
+  const distinct = new Set(variants.map((variant) => variant.id))
+  assert.ok(
+    distinct.size > variants.length * 0.6,
+    `only ${distinct.size} distinct style draws across ${variants.length} cards`,
+  )
+}
+
+// --- the combination space is big enough to be worth having ----------------
+
+{
+  assert.equal(
+    MANDARIN_STYLE_VARIANT_COMBINATIONS,
+    MANDARIN_FRAMINGS.length *
+      MANDARIN_LIGHTS.length *
+      MANDARIN_PALETTES.length *
+      MANDARIN_HANDLINGS.length *
+      MANDARIN_GROUNDS.length,
+  )
+  assert.ok(
+    MANDARIN_STYLE_VARIANT_COMBINATIONS >= 1000,
+    'the style space should comfortably exceed the size of the core corpus',
+  )
+}
+
+// --- no style clause may smuggle text back into the art --------------------
+
+{
+  const clauses = [
+    ...MANDARIN_FRAMINGS,
+    ...MANDARIN_LIGHTS,
+    ...MANDARIN_PALETTES,
+    ...MANDARIN_HANDLINGS,
+    ...MANDARIN_GROUNDS,
+  ]
+  for (const clause of clauses) {
+    assert.ok(
+      !/\b(text|caption|label|sign|signage|letter|numeral|character stroke)\b/i.test(clause),
+      `style clause asks for written language: ${clause}`,
+    )
+    // The art direction bans tourist shorthand as decoration; a style axis is
+    // exactly where it would sneak in as an always-on background.
+    assert.ok(
+      !/\b(pagoda|lantern|dragon|great wall)\b/i.test(clause),
+      `style clause hard-codes China shorthand: ${clause}`,
+    )
+  }
+}
+
+console.log('mandarin art recipe contract: OK')


### PR DESCRIPTION
Groundwork for submitting the full Mandarin v2 illustration corpus — which turned out to be **unsubmittable by construction**. Coverage measured against production before any of this: **0 of 577 `illustrate` cards rendered**.

## The recipe could never be enqueued

All 577 enqueues return **HTTP 422**. `artPromptContract` rejects conditional instructions, and the v2 prompt hedged the way a person writes:

> ground it in Chinese detail **only when** it naturally belongs to the concept

Krea 2 cannot evaluate a condition; it paints the densest noun phrase it is handed. That is the actual reason nothing has ever rendered — upstream of the Alexandria container update this was thought to be waiting on.

Two more of the habits that contract was written from were in the same prompt. Neither is a hard failure, both are real on a cfg-1 distilled engine where the ComfyUI negative prompt is inert:

- **"flashcard illustration"** asks for the object. The contract's format rule was learned from "treasure card illustration", which rendered literal trading cards with title bars and invented rules text. The tutor owns the card; the model paints a picture.
- **Fourteen ways of saying "no text"**, plus twelve synthetic-image tells including "lens flare", "bokeh", and "neon glow" — all of it landing in *positive* conditioning. Restated as the wanted result: *"everything is hand-painted… plain even light"*, *"every surface is blank and unmarked"*.

Category directions now state one decided setting instead of "where it helps", and the cultural-shorthand exclusion is dropped for cards whose concept *is* the shorthand — a dragon card no longer asks for a dragon and forbids one in the same breath.

`buildMandarinIllustrationPrompt` moves to `mandarinIllustrationStyle.ts`, which pulls in no catalog and no prisma, so the new recipe test can check prompts against the contract directly. **That check is the one that was missing:** the recipe and the gate at the enqueue boundary were each tested, never against each other.

## Per-card style variation

The recipe emitted the same style language for every card: any two prompts were ~82% identical, 38 pairs byte-for-byte identical. That is how a deck ends up looking like one image rendered 577 times — the AI-sameness came from the recipe, not the model.

House style stays fixed. What varies is what an illustrator would actually decide per picture:

| Axis | Options |
| --- | --- |
| framing | close still life · wide and quiet · vignette · overhead · eye level · through a near edge |
| light | overcast · low late sun · open shade · lamplight · early-morning window |
| palette | 6 limited harmonies, each with one accent, all inside the matte gouache family |
| handling | flat gouache · wet washes · dry brush · ink line over wash · pooling pigment |
| ground | bare paper · flat wash · soft halo · lower band |

3600 combinations, drawn from the card's stable token — the same token that names its media file. Deterministic in both directions: a card's look is tied to its identity, and the tutor's per-card retry rebuilds exactly the prompt the batch was submitted with. Manifest entries carry it as `styleVariant` for QA.

`requestedArtPrompt` keyed its synthetic prompt card as the constant `'requested:prompt'`, so every requested word in the deck would have drawn the same variant. Keyed to the word now.

## Illustration probe false-positive

`probeCanonicalIllustration` treated any `response.ok` as a hit. A missing `/images/...` path is not a 404 here — Nuxt falls through to the catch-all page and answers **200 `text/html`**. Verified against production: all 40 sampled v2 paths.

With zero art rendered, every card flipped to `V2 READY`, painted a broken `<img>` over the Hanzi fallback, and hid the "Request illustration" button that would have fixed it. The probe now requires an `image/*` content type.

That bug had a third-order effect: the broken images reported themselves to `/api/conductor/art-request`, which wrote generic prompts aimed at canonical v2 card paths — one asking for readable 谢谢 and "digital painting blending illustration and realism". Rendering one would satisfy the canonical path with the wrong picture, permanently. The endpoint now refuses that media root, and `force` does not bypass it.

## Look

- New `MandarinBanner`: pigment washes, ink-wash hills, a carved seal. It carries the tutor's identity without depending on generated art — which is the state a fresh deck is always in.
- New `MandarinCardArt`: an unrendered card sits on a pigment ground derived from its card key rather than a grey placeholder, shared by the banner, the study card, and the explore view. A word keeps the same ground everywhere it appears.
- The study card's **picture prompt** keeps the glyph hidden — there the character is the answer being recalled.

## Merged with main

The Worker shipped t-018 (#2173) and t-019 (#2175) while this was open. Main's inline `artNotice` wins — it sits beside each art button rather than in a banner above the card. Two things from here survive on top: the refresh path says "Still rendering" instead of finishing silently, and the notice clears on card change with its timer cleared on unmount.

## Verification

- `npm run test` (vue-tsc) — clean
- `npm run test:mandarin-art-recipe` (new, wired into `contract-tests.yml`) — passes. Asserts determinism, axis coverage, no option dominating the deck, and **every built prompt against `checkArtPromptContract`**, per category and including the dragon case.
- `test:layout-contract`, `test:component-reachability`, `test:page-backdrop`, `test:lint-ratchet`, `test:mandarin-cloud-merge-selftest`, `test:mandarin-proficiency-coverage-selftest` — all hold
- Built the manifest from a local run of this branch: **all 577 prompts pass the contract, all 577 unique, 537 distinct style draws**
- Rendered `/play/mandarin` locally and checked the banner, picture prompt (no glyph leak), revealed state, and explore view

The corpus is submitted on the strength of this branch: silasfelinus/conductor#3062.