### PR TITLE
mandarin-tutor/t-019: show a confirmation when Check art finds the illustration

### DIFF
--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -697,11 +697,17 @@ async function refreshCurrentIllustration() {
   if (!card) return
   setArtNotice('')
   const canonical = await store.probeCanonicalIllustration(card.key)
-  if (canonical) return
+  if (canonical) {
+    setArtNotice('Illustration ready.')
+    return
+  }
   const url = currentRequested.value
     ? await store.refreshRequestedIllustration(card)
     : await store.refreshIllustration(card)
-  if (url) brokenArtKeys.value.delete(card.key)
+  if (url) {
+    brokenArtKeys.value.delete(card.key)
+    setArtNotice('Illustration ready.')
+  }
 }
 
 function roleLabel(role: MandarinComponentRole): string {


### PR DESCRIPTION
### Task
mandarin-tutor/t-019: Show a confirmation when "Check art" actually finds the illustration (kind: software)

### What changed / what I produced
- `refreshCurrentIllustration` in `pages/play/mandarin.vue` cleared `artNotice` on start but never set a success message when the refresh actually found art — a user clicking "Check art" got the same "nothing visibly happened" gap t-018 (kind_robots#2173) just fixed for the queue action.
- Mirrors t-018's `setArtNotice()` pattern: sets a short-lived "Illustration ready." notice when a canonical illustration is found, or when `refreshRequestedIllustration`/`refreshIllustration` returns a url. Stays silent when neither finds anything, since a job that's still processing isn't a failure worth surfacing.

### How I verified
- `npm run test` (`vue-tsc --noEmit`) — clean
- `npx eslint pages/play/mandarin.vue` — clean
- `npm run test:mandarin-srs-selftest` — all green, unaffected
- `npm run test:layout-contract` — holds, no new violations

### Stakes
reversible

### Notes for reviewer
Single-file, 8-line diff, reuses the `setArtNotice()` helper t-018 already added — no new state or API calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qy3WrKnrPsFhWQASB8G6nW)_