### PR TITLE
cthulhuquarium/t-055: surface breeding as a real player action in the tank UI

### DIFF
--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -238,6 +238,45 @@
                 >
                   Sell
                 </button>
+                <!-- Breed (t-055): a two-step pick, same "choose, then click
+                     to commit" idiom as the decor placement flow -- clicking
+                     Breed on one card arms it as parent A, then only other
+                     cards of the SAME species offer "Breed with this" as
+                     parent B. Neither click mutates the tank; that only
+                     happens once the confirm dialog below is accepted. -->
+                <button
+                  v-if="pendingBreedParentId === entry.id"
+                  type="button"
+                  class="btn btn-primary btn-xs min-h-11 min-w-11"
+                  @click="onBreedClick(entry)"
+                >
+                  Cancel breed
+                </button>
+                <button
+                  v-else-if="
+                    pendingBreedParent &&
+                    pendingBreedParent.monsterId === entry.monsterId
+                  "
+                  type="button"
+                  class="btn btn-primary btn-xs min-h-11 min-w-11"
+                  @click="onBreedClick(entry)"
+                >
+                  Breed with this
+                </button>
+                <button
+                  v-else
+                  type="button"
+                  class="btn btn-outline btn-xs min-h-11 min-w-11"
+                  :disabled="pendingBreedParentId !== null"
+                  :title="
+                    pendingBreedParentId !== null
+                      ? 'Pick another individual of the same species, or cancel first.'
+                      : undefined
+                  "
+                  @click="onBreedClick(entry)"
+                >
+                  Breed
+                </button>
               </div>
             </div>
             <div
@@ -848,6 +887,138 @@
       </dialog>
     </Teleport>
 
+    <!-- The breed confirmation (cthulhuquarium/t-055): the second half of
+         the choose-then-click-to-commit flow above. Shows the coin cost
+         before anything is spent -- the one thing the task asked for by
+         name -- and disables Confirm rather than guessing when the pair
+         can't actually be afforded or would overflow the tank; the server
+         re-checks both regardless, this is just so the button doesn't lie. -->
+    <Teleport to="body">
+      <dialog
+        v-if="breedConfirmPair"
+        class="modal modal-open"
+        aria-modal="true"
+        @cancel.prevent="breedConfirmPair = null"
+      >
+        <div
+          class="modal-box flex max-w-sm flex-col items-center gap-3 rounded-3xl border border-base-300 bg-base-100 text-center shadow-2xl"
+        >
+          <p class="text-xs font-black uppercase tracking-wide text-primary">
+            Breed these two?
+          </p>
+          <kr-art-plate
+            :source="breedConfirmPair.a.Monster"
+            variant="card"
+            shape="plate"
+            frame="thin"
+            fit="cover"
+            class="h-32 w-24"
+            placeholder-icon="kind-icon:fish"
+          />
+          <h3 class="text-lg font-black">
+            {{ breedConfirmPair.a.Monster.name }}
+          </h3>
+          <p class="text-sm opacity-80">
+            Costs {{ breedConfirmPair.a.Monster.breedCost }} coins. Neither
+            parent is consumed -- you'll get a new individual with converged
+            stats, and just maybe, a secret evolution.
+          </p>
+          <p v-if="!canConfirmBreed" class="text-xs text-error">
+            Not enough coins, or not enough tank room, for this pairing right
+            now.
+          </p>
+          <div class="flex gap-2">
+            <button
+              type="button"
+              class="btn btn-outline btn-sm"
+              @click="breedConfirmPair = null"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              class="btn btn-primary btn-sm"
+              :disabled="!canConfirmBreed"
+              @click="onConfirmBreed"
+            >
+              Breed for {{ breedConfirmPair.a.Monster.breedCost }}
+            </button>
+          </div>
+        </div>
+        <form method="dialog" class="modal-backdrop">
+          <button type="button" @click="breedConfirmPair = null">close</button>
+        </form>
+      </dialog>
+    </Teleport>
+
+    <!-- The breed reveal (cthulhuquarium/t-055): same "must be shown, never
+         silent" beat as the hatch reveal above, but doubling as the payoff
+         moment for a secret BREEDING evolution (SYSTEMS.md's "the payoff,
+         not a guaranteed outcome") -- `evolved` swaps the framing so that
+         rare beat actually reads as special rather than an ordinary
+         offspring reveal with different art. -->
+    <Teleport to="body">
+      <dialog
+        v-if="tankStore.revealedBreed"
+        class="modal modal-open"
+        aria-modal="true"
+        @cancel.prevent="tankStore.dismissBreedReveal()"
+      >
+        <div
+          class="modal-box flex max-w-sm flex-col items-center gap-3 rounded-3xl border border-base-300 bg-base-100 text-center shadow-2xl"
+        >
+          <Icon
+            v-if="tankStore.revealedBreed.evolved"
+            name="kind-icon:sparkles"
+            class="size-8 text-warning"
+          />
+          <p class="text-xs font-black uppercase tracking-wide text-primary">
+            {{
+              tankStore.revealedBreed.evolved
+                ? 'A secret evolution!'
+                : 'It bred'
+            }}
+          </p>
+          <kr-art-plate
+            :source="tankStore.revealedBreed.stock.Monster"
+            variant="card"
+            shape="plate"
+            frame="thin"
+            fit="cover"
+            class="h-32 w-24"
+            placeholder-icon="kind-icon:fish"
+          />
+          <h3 class="text-lg font-black">
+            {{ tankStore.revealedBreed.stock.Monster.name }}
+          </h3>
+          <p
+            v-if="tankStore.revealedBreed.stock.Monster.species"
+            class="text-xs italic opacity-60"
+          >
+            {{ tankStore.revealedBreed.stock.Monster.species }}
+          </p>
+          <p class="text-sm opacity-80">
+            {{
+              tankStore.revealedBreed.stock.Monster.fieldNote ||
+              'Nothing is written about this one yet.'
+            }}
+          </p>
+          <button
+            type="button"
+            class="btn btn-primary btn-sm mt-1"
+            @click="tankStore.dismissBreedReveal()"
+          >
+            Add it to the tank
+          </button>
+        </div>
+        <form method="dialog" class="modal-backdrop">
+          <button type="button" @click="tankStore.dismissBreedReveal()">
+            close
+          </button>
+        </form>
+      </dialog>
+    </Teleport>
+
     <!-- The bestiary completion beat (cthulhuquarium/t-024): "the closest
          thing this game has to an ending... but it must not end the session
          or lock anything, because the tank keeps running." Dismissing this
@@ -1196,6 +1367,15 @@ const showSets = ref(false)
 const showDecor = ref(false)
 const showEggs = ref(false)
 
+// Breeding (cthulhuquarium/t-055): pendingBreedParentId is the "choose"
+// half of the choose-then-click-to-commit flow -- set by clicking Breed on
+// one tank card, cleared by clicking it again or by confirming/cancelling
+// the pairing below. breedConfirmPair is the "click to commit" half: set
+// once a second, same-species card is chosen, cleared once the confirm
+// dialog closes either way.
+const pendingBreedParentId = ref<number | null>(null)
+const breedConfirmPair = ref<{ a: TankStock; b: TankStock } | null>(null)
+
 // Read live rather than baked into each Swimmer at spawn time, so
 // equipping/unequipping Swift Current takes effect immediately instead of
 // only for fish spawned afterward.
@@ -1220,6 +1400,50 @@ function canUnlock(entry: CatalogEntry): boolean {
     tankStore.coins >= entry.cost &&
     tankStore.occupantSize + (entry.size ?? 1) <= tankStore.sizeCap
   )
+}
+
+// cthulhuquarium/t-055: the currently-armed first parent, if any -- looked
+// up live off tankStore.stock (rather than cached at click time) so a sell
+// or feed elsewhere in the tank while a pairing is pending can't leave this
+// pointing at stale data.
+const pendingBreedParent = computed<TankStock | null>(
+  () =>
+    tankStore.stock.find((entry) => entry.id === pendingBreedParentId.value) ??
+    null,
+)
+
+function onBreedClick(entry: TankStock): void {
+  if (pendingBreedParentId.value === entry.id) {
+    pendingBreedParentId.value = null
+    return
+  }
+  const pending = pendingBreedParent.value
+  if (pending && pending.monsterId === entry.monsterId) {
+    breedConfirmPair.value = { a: pending, b: entry }
+    pendingBreedParentId.value = null
+    return
+  }
+  pendingBreedParentId.value = entry.id
+}
+
+// Same capacity/coin math the confirm button's disabled state and the
+// server's own breedFishForUser check independently -- this is only so the
+// button doesn't invite a click the server would reject anyway; the server
+// re-checks both for real regardless (aquarium.ts never trusts the client).
+const canConfirmBreed = computed(() => {
+  const pair = breedConfirmPair.value
+  if (!pair) return false
+  return (
+    tankStore.coins >= pair.a.Monster.breedCost &&
+    tankStore.occupantSize + (pair.a.Monster.size ?? 1) <= tankStore.sizeCap
+  )
+})
+
+async function onConfirmBreed(): Promise<void> {
+  const pair = breedConfirmPair.value
+  if (!pair) return
+  breedConfirmPair.value = null
+  await tankStore.breed(pair.a.id, pair.b.id)
 }
 
 // t-031: compact "best seen" line for the Ichthyonomicon. Only ever called

--- a/server/utils/aquarium.ts
+++ b/server/utils/aquarium.ts
@@ -124,6 +124,15 @@ const stockMonsterSelect = {
   ...monsterEconomyOverridesSelect,
 } satisfies Prisma.MonsterSelect
 
+// cthulhuquarium/t-055: the rolled individual stats and parentage were
+// already written by t-029's breedFishForUser/purchaseSpeciesForUser (see
+// breedStockSelect/sellStockSelect below, which needed them for their own
+// server-side math) but never reached the general tank load -- there was no
+// frontend surface asking for them yet. Surfacing them here is what lets the
+// tank UI offer a breeding flow at all: picking two owned individuals of the
+// same species needs their ids (parentAId/parentBId are read back, not
+// written, from this shape) and the rolled stats are what a future stat
+// display would read, though this task only wires the action itself.
 const ownedStockSelect = {
   id: true,
   monsterId: true,
@@ -131,6 +140,14 @@ const ownedStockSelect = {
   hunger: true,
   mood: true,
   placedAt: true,
+  statCharm: true,
+  statEmpathy: true,
+  statGrace: true,
+  statLuck: true,
+  statMight: true,
+  statWits: true,
+  parentAId: true,
+  parentBId: true,
   Monster: { select: stockMonsterSelect },
 } satisfies Prisma.AquariumStockSelect
 
@@ -199,8 +216,19 @@ export type OwnedAquarium = Prisma.AquariumGetPayload<{
 // the client to re-derive from `Sets` + a hardcoded bonus value -- same
 // "the server disposes, the client never invents an economy number"
 // discipline as everywhere else in this file.
-export interface ClientAquarium extends OwnedAquarium {
+//
+// cthulhuquarium/t-055: each Stock row's Monster also carries `breedCost`,
+// the SAME breedCost(deriveFishRarityTier(...), ...) call breedFishForUser
+// itself uses to price a breed -- computed here purely so the tank UI can
+// show "breed for N coins" in its confirmation step before the player
+// commits, without the client re-deriving rarity/pricing math of its own.
+type ClientStock = OwnedAquarium['Stock'][number] & {
+  Monster: OwnedAquarium['Stock'][number]['Monster'] & { breedCost: number }
+}
+
+export interface ClientAquarium extends Omit<OwnedAquarium, 'Stock'> {
   effectiveSizeCap: number
+  Stock: ClientStock[]
 }
 
 function toClientAquarium(aquarium: OwnedAquarium): ClientAquarium {
@@ -210,6 +238,16 @@ function toClientAquarium(aquarium: OwnedAquarium): ClientAquarium {
       aquarium.sizeCap,
       aquarium.Sets.map((set) => set.kind),
     ),
+    Stock: aquarium.Stock.map((stock) => ({
+      ...stock,
+      Monster: {
+        ...stock.Monster,
+        breedCost: breedCost(
+          deriveFishRarityTier(stock.Monster),
+          stock.Monster.unlockCost,
+        ),
+      },
+    })),
   }
 }
 

--- a/stores/cthulhuquariumTankStore.ts
+++ b/stores/cthulhuquariumTankStore.ts
@@ -37,6 +37,11 @@ export interface TankMonster {
   luck: string
   might: string
   wits: string
+  // cthulhuquarium/t-055: what breeding two owned individuals of this
+  // species costs, server-computed (aquariumEconomy.ts's breedCost) off
+  // this same rarity/unlockCost -- never re-derived client-side, same
+  // "server disposes" discipline as every other price in this store.
+  breedCost: number
 }
 
 export interface TankStock {
@@ -46,6 +51,19 @@ export interface TankStock {
   hunger: number
   mood: string | null
   placedAt: string
+  // cthulhuquarium/t-055/t-029: hidden rolled individual stats and
+  // parentage. Null until rolled -- every individual placed before t-029
+  // shipped has null stats and no parents. Read-only here (breed() sends
+  // parent ids, never these stats); a future stat display is the only
+  // thing waiting on this, not this task's own breeding action.
+  statCharm: number | null
+  statEmpathy: number | null
+  statGrace: number | null
+  statLuck: number | null
+  statMight: number | null
+  statWits: number | null
+  parentAId: number | null
+  parentBId: number | null
   Monster: TankMonster
 }
 
@@ -267,6 +285,29 @@ interface HatchEggResponse {
   firedMilestones: FiredMilestone[]
 }
 
+// cthulhuquarium/t-055: breed.post.ts's response shape. `evolved` mirrors
+// server/utils/aquarium.ts's BreedResult -- true only when the offspring's
+// rolled stats qualified for the parent species' secret BREEDING evolution,
+// in which case `stock` is already the evolved species, not the parents'
+// own (see breedFishForUser's own comment).
+interface BreedResponse {
+  aquarium: Tank
+  stock: TankStock
+  cost: number
+  evolved: boolean
+  justCompletedBestiary: boolean
+  firedMilestones: FiredMilestone[]
+}
+
+// The breed reveal beat, same "the one moment this is legitimately known
+// client-side" shape as revealedUnlock/revealedHatch -- `evolved` is carried
+// alongside the stock so the dialog can tell "a normal offspring" from "a
+// secret evolution" apart without re-deriving it from the parent species.
+export interface RevealedBreed {
+  stock: TankStock
+  evolved: boolean
+}
+
 interface CleanResponse {
   aquarium: Tank
   debrisLevel: number
@@ -454,6 +495,12 @@ export const useCthulhuquariumTankStore = defineStore(
     // dismissHatchReveal(). A hatch must never be silent (the task's own
     // "ONE THING THAT MUST NOT HAPPEN" adjacent rule): this ref is that beat.
     const revealedHatch = ref<TankStock | null>(null)
+
+    // cthulhuquarium/t-055: the just-bred offspring, same "the one moment
+    // this is legitimately known client-side" shape as revealedHatch above
+    // -- the game component watches this to show the breed reveal, then
+    // clears it via dismissBreedReveal().
+    const revealedBreed = ref<RevealedBreed | null>(null)
 
     const stock = computed(() => tank.value?.Stock ?? [])
     const coins = computed(() => tank.value?.coins ?? 0)
@@ -929,6 +976,42 @@ export const useCthulhuquariumTankStore = defineStore(
       revealedHatch.value = null
     }
 
+    // cthulhuquarium/t-055: breeds two owned individuals of the same
+    // species into a new offspring. Neither parent is consumed or modified
+    // -- see server/utils/aquarium.ts's breedFishForUser for the full price/
+    // capacity/ownership checks, all enforced server-side same as every
+    // other action here. Refreshes the bestiary the same way unlock()/
+    // hatchEgg() do, since a breed can land on a species the book hasn't
+    // seen yet (most notably a secret evolution's own species).
+    async function breed(
+      parentAId: number,
+      parentBId: number,
+    ): Promise<boolean> {
+      const res = await performFetch<BreedResponse>('/api/aquarium/breed', {
+        method: 'POST',
+        body: JSON.stringify({ parentAId, parentBId }),
+      })
+      if (res.success && res.data) {
+        tank.value = res.data.aquarium
+        revealedBreed.value = {
+          stock: res.data.stock,
+          evolved: res.data.evolved,
+        }
+        if (res.data.justCompletedBestiary) bestiaryJustCompleted.value = true
+        if (res.data.firedMilestones?.length) {
+          milestoneToastQueue.value.push(...res.data.firedMilestones)
+        }
+        if (bestiary.value.length > 0) await loadBestiary()
+        return true
+      }
+      error.value = res.message || 'Could not breed those two.'
+      return false
+    }
+
+    function dismissBreedReveal(): void {
+      revealedBreed.value = null
+    }
+
     return {
       tank,
       catalog,
@@ -1000,6 +1083,9 @@ export const useCthulhuquariumTankStore = defineStore(
       purchaseEgg,
       hatchEgg,
       dismissHatchReveal,
+      revealedBreed,
+      breed,
+      dismissBreedReveal,
     }
   },
 )


### PR DESCRIPTION
### Task
cthulhuquarium/t-055: surface breeding as a real player action in the tank UI (kind: software)

### What changed / what I produced
- `server/utils/aquarium.ts`: `ownedStockSelect` now returns each stock row's rolled individual stats and parentage (`statCharm..statWits`, `parentAId`/`parentBId`) — previously only `breedStockSelect`/`sellStockSelect` (t-029/t-030's own internal selects) carried them. `toClientAquarium` now also stamps each `Stock` row's `Monster` with `breedCost`, reusing `aquariumEconomy.ts`'s own `breedCost(deriveFishRarityTier(...), ...)` so the UI can show a real price without re-deriving pricing math client-side.
- `stores/cthulhuquariumTankStore.ts`: `TankStock`/`TankMonster` gain the new fields; a `breed(parentAId, parentBId)` action posts to the existing `POST /api/aquarium/breed` endpoint, refreshes the tank/bestiary, and exposes a `revealedBreed` reveal (mirrors `hatchEgg`'s reveal shape) so a secret `BREEDING` evolution gets an actual payoff moment instead of landing silently.
- `components/cthulhuquarium/cthulhuquarium-game.vue`: a Breed button per tank card arms a first parent; only other same-species cards then offer "Breed with this" (same choose-then-click-to-commit idiom the decor placement flow already uses). A confirm dialog shows the coin cost and disables Confirm when it can't be afforded or would overflow tank capacity, before any request fires. A reveal dialog shows the offspring afterward, framed differently when it evolved.

### How I verified
- `npx vue-tsc --noEmit` — clean
- `npx eslint` on the three changed files — clean
- `npx prettier --check` on the three changed files — clean
- `npm run test:aquarium-economy` — all assertions pass (unchanged, confirms `breedCost`/`deriveFishRarityTier` behavior I reused)
- `npm run test:aquarium-genetics` — all assertions pass
- `npm run test:layout-contract` — holds, no new violations (the grid in the new UI reuses the existing `auto-fit` viewport-width pattern already used elsewhere in this component)

### Stakes
reversible

### Flags for Reviewer
- This PR does **not** author a species with `evolutionKind: BREEDING` + `evolvesToId` in the fish bible, which was the second half of t-055's own task note ("author at least one species... so the secret-evolution path... has something real to reveal end-to-end"). The bible lives in `silasfelinus/cthulhuquarium` (a separate GitHub repo, `fish/*.yaml`), which is outside this session's repo access and not locally cloned. Tracked as a separate conductor follow-up (handoff doc + new roadmap task) rather than guessed at blind.
- `breedCost` is a new computed (non-DB) field added to each Stock row's Monster in the general tank-load response. It's cheap (two pure function calls per owned fish) but is a new per-request computation on every tank load/tick, not just on a breed action — flagging in case that cadence matters for anything downstream.

### Kaizen suggestion
Once the bible-authored `BREEDING` species pair exists, add a lightweight stat display (using the now-exposed `statCharm..statWits`) to the tank card or a fish detail view — right now the rolled individual stats reach the client but nothing shows them, which slightly undercuts the "well-bred fish" framing the confirm/reveal copy already leans on.

### Notes for reviewer
Verified locally via `scripts/provision_kind_robots_deps.sh` from the conductor repo (no live DB in this sandbox; `test:*` scripts here are all pure-function/mocked, no network required).


---
_Generated by [Claude Code](https://claude.ai/code/session_019DCN9pwCuHqmMJ2j7Lkr4N)_