### PR TITLE
cthulhuquarium/t-056: extract shared one-shot-signal primitive

### DIFF
--- a/stores/cthulhuquariumTankStore.ts
+++ b/stores/cthulhuquariumTankStore.ts
@@ -14,6 +14,7 @@ import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
 import { performFetch } from './utils'
 import { formatMilestoneToastMessage } from '~/utils/aquariumMilestoneToast'
+import { useOneShotFlag, useOneShotQueue } from '~/utils/useOneShotSignal'
 
 export interface TankMonster {
   id: number
@@ -438,8 +439,11 @@ export const useCthulhuquariumTankStore = defineStore(
     // set -- the game component watches it for the one-time completion beat,
     // then clears it via dismissBestiaryCompletion(). Never re-derived from
     // bestiaryCollectedCount/bestiaryTotalCount, so simply reloading the
-    // bestiary later can't retrigger it.
-    const bestiaryJustCompleted = ref(false)
+    // bestiary later can't retrigger it. useOneShotFlag() (t-056) is the
+    // shared one-shot-signal primitive; bestiaryJustCompleted is just its
+    // `flag`, kept under the original ref name.
+    const bestiaryCompletionSignal = useOneShotFlag()
+    const bestiaryJustCompleted = bestiaryCompletionSignal.flag
 
     // cthulhuquarium/t-053: any bestiary-breakpoint milestones (t-028) an
     // unlock's response just fired, queued for a generic, art-agnostic
@@ -452,8 +456,12 @@ export const useCthulhuquariumTankStore = defineStore(
     // so reloading the bestiary later can't requeue an already-shown
     // milestone. A full authored Charlotte interstitial (t-028's own note)
     // is a separate, not-yet-built layer -- this is the placeholder/no-art
-    // gate itself.
-    const milestoneToastQueue = ref<FiredMilestone[]>([])
+    // gate itself. Built on useOneShotQueue() (t-056), the same shared
+    // primitive as bestiaryCompletionSignal/finaleRevealSignal below --
+    // this was never exposed on the store directly (only nextMilestoneToast/
+    // dismissMilestoneToast below were), so there's no external ref name to
+    // preserve here.
+    const milestoneToastSignal = useOneShotQueue<FiredMilestone>()
 
     // cthulhuquarium/t-026's set-piece catalog. Loaded lazily, same
     // collapsed-panel-until-opened pattern as the bestiary above -- it
@@ -482,7 +490,10 @@ export const useCthulhuquariumTankStore = defineStore(
     // fired -- the game component watches it for the one-time reveal dialog,
     // then clears it via dismissFinaleReveal(). Never re-derived from
     // finaleTriggered, so reloading the status later can't retrigger it.
-    const finaleJustTriggered = ref(false)
+    // Built on useOneShotFlag() (t-056), same primitive as
+    // bestiaryCompletionSignal above.
+    const finaleRevealSignal = useOneShotFlag()
+    const finaleJustTriggered = finaleRevealSignal.flag
 
     // cthulhuquarium/t-041's egg catalog. Loaded lazily, same
     // collapsed-panel-until-opened pattern as sets/decor above -- it never
@@ -625,9 +636,9 @@ export const useCthulhuquariumTankStore = defineStore(
         tank.value = res.data.aquarium
         catalog.value = catalog.value.filter((entry) => entry.id !== monsterId)
         revealedUnlock.value = res.data.stock
-        if (res.data.justCompletedBestiary) bestiaryJustCompleted.value = true
+        if (res.data.justCompletedBestiary) bestiaryCompletionSignal.trigger()
         if (res.data.firedMilestones?.length) {
-          milestoneToastQueue.value.push(...res.data.firedMilestones)
+          milestoneToastSignal.push(...res.data.firedMilestones)
         }
         // A stale bestiary panel (or one never loaded yet) would otherwise
         // still show this species as uncollected after unlocking it.
@@ -719,20 +730,20 @@ export const useCthulhuquariumTankStore = defineStore(
     }
 
     function dismissBestiaryCompletion(): void {
-      bestiaryJustCompleted.value = false
+      bestiaryCompletionSignal.dismiss()
     }
 
-    // cthulhuquarium/t-053: the front of milestoneToastQueue, pre-formatted
-    // for display -- null when the queue is empty. Reading this instead of
-    // milestoneToastQueue.value[0] directly keeps the wording rule
-    // (formatMilestoneToastMessage) in one place.
+    // cthulhuquarium/t-053: the front of milestoneToastSignal's queue,
+    // pre-formatted for display -- null when the queue is empty. Reading
+    // this instead of milestoneToastSignal.next.value directly keeps the
+    // wording rule (formatMilestoneToastMessage) in one place.
     const nextMilestoneToast = computed(() => {
-      const next = milestoneToastQueue.value[0]
+      const next = milestoneToastSignal.next.value
       return next ? formatMilestoneToastMessage(next) : null
     })
 
     function dismissMilestoneToast(): void {
-      milestoneToastQueue.value.shift()
+      milestoneToastSignal.dismiss()
     }
 
     // cthulhuquarium/t-026: the build layer. loadSets() is called lazily by
@@ -913,7 +924,7 @@ export const useCthulhuquariumTankStore = defineStore(
       if (res.success && res.data) {
         tank.value = res.data.aquarium
         finaleTriggered.value = true
-        if (res.data.finaleJustTriggered) finaleJustTriggered.value = true
+        if (res.data.finaleJustTriggered) finaleRevealSignal.trigger()
         return true
       }
       error.value = res.message || 'Could not buy the last aquarium.'
@@ -921,7 +932,7 @@ export const useCthulhuquariumTankStore = defineStore(
     }
 
     function dismissFinaleReveal(): void {
-      finaleJustTriggered.value = false
+      finaleRevealSignal.dismiss()
     }
 
     // cthulhuquarium/t-041: lazy-loaded, same pattern as loadSets/loadDecor.
@@ -961,9 +972,9 @@ export const useCthulhuquariumTankStore = defineStore(
       if (res.success && res.data) {
         tank.value = res.data.aquarium
         revealedHatch.value = res.data.stock
-        if (res.data.justCompletedBestiary) bestiaryJustCompleted.value = true
+        if (res.data.justCompletedBestiary) bestiaryCompletionSignal.trigger()
         if (res.data.firedMilestones?.length) {
-          milestoneToastQueue.value.push(...res.data.firedMilestones)
+          milestoneToastSignal.push(...res.data.firedMilestones)
         }
         if (bestiary.value.length > 0) await loadBestiary()
         return true
@@ -997,9 +1008,9 @@ export const useCthulhuquariumTankStore = defineStore(
           stock: res.data.stock,
           evolved: res.data.evolved,
         }
-        if (res.data.justCompletedBestiary) bestiaryJustCompleted.value = true
+        if (res.data.justCompletedBestiary) bestiaryCompletionSignal.trigger()
         if (res.data.firedMilestones?.length) {
-          milestoneToastQueue.value.push(...res.data.firedMilestones)
+          milestoneToastSignal.push(...res.data.firedMilestones)
         }
         if (bestiary.value.length > 0) await loadBestiary()
         return true

--- a/utils/useOneShotSignal.ts
+++ b/utils/useOneShotSignal.ts
@@ -1,0 +1,63 @@
+// @/utils/useOneShotSignal.ts
+//
+// cthulhuquarium/t-056 (kaizen from t-053's generic milestone toast, kind_robots
+// PR #2169): stores/cthulhuquariumTankStore.ts's unlock()/hatchEgg()/breed() and
+// the separate purchaseFinale() each hand-rolled the same "read a one-shot
+// signal off a purchase response, stash it for the game component to consume,
+// let it clear via a dismiss function, never re-derive it from a later reload"
+// shape three times over: bestiaryJustCompleted (t-024, a bare boolean flag),
+// milestoneToastQueue (t-053, a real FIFO queue of FiredMilestone), and
+// finaleJustTriggered (t-039, another bare boolean flag). This is the one
+// shared primitive all three now build on -- presentation-only extraction, no
+// behavior change, no new signals.
+//
+// Deliberately framework-light (just Vue's reactivity, no pinia/fetch) so it
+// composes cleanly inside any setup-style store, same discipline as
+// utils/useRandomColor.ts.
+
+import { computed, ref, type ComputedRef, type Ref } from 'vue'
+
+// The base primitive: a FIFO queue of one-shot values. `next` is the front
+// entry (or null when empty) -- a consumer reads `next`, shows it, then
+// calls `dismiss()` once shown. Mirrors milestoneToastQueue's original
+// push(...)/shift() shape exactly.
+export function useOneShotQueue<T>(): {
+  queue: Ref<T[]>
+  next: ComputedRef<T | null>
+  push: (...items: T[]) => void
+  dismiss: () => void
+} {
+  const queue = ref<T[]>([]) as Ref<T[]>
+  const next = computed<T | null>(() => queue.value[0] ?? null)
+
+  function push(...items: T[]): void {
+    if (items.length) queue.value.push(...items)
+  }
+
+  function dismiss(): void {
+    queue.value.shift()
+  }
+
+  return { queue, next, push, dismiss }
+}
+
+// The boolean specialization -- bestiaryJustCompleted and finaleJustTriggered
+// are both really a one-entry queue of `true`: `trigger()` sets the flag (a
+// no-op if it's already set, since neither original call site ever needed
+// more than "has this fired"), `flag` reads whether it's active, and
+// `dismiss()` clears it. Built on useOneShotQueue rather than a second
+// bespoke ref so both shapes share the same underlying primitive.
+export function useOneShotFlag(): {
+  flag: ComputedRef<boolean>
+  trigger: () => void
+  dismiss: () => void
+} {
+  const { next, push, dismiss } = useOneShotQueue<true>()
+  const flag = computed(() => next.value === true)
+
+  function trigger(): void {
+    if (!flag.value) push(true)
+  }
+
+  return { flag, trigger, dismiss }
+}


### PR DESCRIPTION
### Task
cthulhuquarium/t-056: Consolidate cthulhuquariumTankStore's repeated one-shot-signal queuing pattern (kind: software)

### What changed / what I produced
- Added `utils/useOneShotSignal.ts`: `useOneShotQueue<T>()` (base FIFO-queue primitive — `queue`/`next`/`push`/`dismiss`) and `useOneShotFlag()` (boolean specialization built on it — `flag`/`trigger`/`dismiss`).
- `stores/cthulhuquariumTankStore.ts`'s `bestiaryJustCompleted` (t-024), `milestoneToastQueue` (t-053), and `finaleJustTriggered` (t-039, `purchaseFinale()`) all now build on one of these two composables instead of a hand-rolled `ref`.
- Every external ref/function name on the store is unchanged (`bestiaryJustCompleted`, `nextMilestoneToast`, `finaleJustTriggered`, `dismissBestiaryCompletion`, `dismissMilestoneToast`, `dismissFinaleReveal`) — `components/cthulhuquarium/cthulhuquarium-game.vue` needs no changes.

### How I verified
- `vue-tsc --noEmit -p tsconfig.json` — clean
- `eslint stores/cthulhuquariumTankStore.ts utils/useOneShotSignal.ts` — clean
- `prettier --check` on both changed files — clean
- `npm run test:aquarium-milestone-toast` — passes
- `npm run test:layout-contract` — no new violations

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
`revealedUnlock`/`revealedHatch`/`revealedBreed` are a related but distinct pattern (a typed reveal payload, not a bare flag or queue) — worth its own small `useOneShotReveal<T>()` if a fourth reveal-shaped signal shows up, but three near-identical instances didn't exist yet so this task didn't extend to them.

### Notes for reviewer
Presentation-only refactor per the task note — no behavior change, no new signals.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KoKuc5UcAnbxpMfrgWVDsM)_