### PR TITLE
cthulhuquarium/t-057: live shop-rotation countdown on the unlock panel

### DIFF
--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -303,9 +303,13 @@
              owned, not the whole remaining bestiary. Anything sold or
              already discovered stays available any time via the
              Ichthyonomicon's re-order button below, regardless of today's
-             slate. -->
+             slate. t-057: a live countdown to the next rotation replaces the
+             old static hint once the catalog has loaded. -->
         <p class="text-xs italic opacity-50">
-          Today's arrivals -- check back tomorrow for more.
+          {{
+            shopRefreshLabel ??
+            "Today's arrivals -- check back tomorrow for more."
+          }}
         </p>
         <p v-if="tankStore.catalogLoading" class="text-xs opacity-60">
           Reading the bestiary…
@@ -1163,6 +1167,7 @@ import {
   type TankStock,
 } from '~/stores/cthulhuquariumTankStore'
 import { touchHitRadius } from '~/utils/aquariumTouch'
+import { formatShopRefreshCountdown } from '~/utils/aquariumShopCountdown'
 import { useUserStore } from '~/stores/userStore'
 
 /* Fixed logical resolution; CSS scales it to the host width so the canvas
@@ -1394,6 +1399,22 @@ const roamingCollectorEquipped = computed(() =>
 let frame = 0
 let lastFrameAt = 0
 let pollTimer: ReturnType<typeof setInterval> | null = null
+
+// cthulhuquarium/t-057: bumped alongside pollTick's own 20s cadence (see
+// startLoops()) so shopRefreshLabel below recomputes without a second
+// timer -- a countdown display only shown in whole minutes doesn't need
+// finer-grained ticking than the tank's existing poll loop already gives it.
+const now = ref(Date.now())
+
+// The unlock panel's live "refreshes in Xh Ym" readout, replacing the old
+// static "check back tomorrow" hint. Null (falls back to that static hint
+// in the template) until the catalog has loaded at least once, or for the
+// brief window after a rotation flips server-side but before the next
+// loadCatalog() call picks up the new dateKey.
+const shopRefreshLabel = computed(() => {
+  const dateKey = tankStore.catalogDateKey
+  return dateKey ? formatShopRefreshCountdown(dateKey, now.value) : null
+})
 
 function canUnlock(entry: CatalogEntry): boolean {
   return (
@@ -1959,6 +1980,9 @@ async function onFeed() {
 async function pollTick() {
   const earned = await tankStore.settleTick()
   if (earned > 0) spawnMotes(earned)
+  // cthulhuquarium/t-057: keeps shopRefreshLabel's countdown live without a
+  // second timer -- see `now`'s own comment.
+  now.value = Date.now()
 }
 
 function onToggleBestiary() {
@@ -2034,6 +2058,10 @@ function canBuyEgg(entry: EggCatalogEntry): boolean {
 // can't simulate a giant step, but resetting it on resume (same pattern as
 // the initial kick-off below) keeps the very first frame back honest too.
 function startLoops() {
+  // cthulhuquarium/t-057: refresh immediately on resume rather than leaving
+  // shopRefreshLabel showing however stale `now` was when the tab hid --
+  // matches lastFrameAt's own "keep the first beat back honest" reasoning.
+  now.value = Date.now()
   if (pollTimer === null) {
     pollTimer = setInterval(pollTick, TANK_POLL_INTERVAL_MS)
   }

--- a/stores/cthulhuquariumTankStore.ts
+++ b/stores/cthulhuquariumTankStore.ts
@@ -156,6 +156,17 @@ export interface CatalogEntry {
   cost: number
 }
 
+// cthulhuquarium/t-057: GET /api/aquarium/catalog's meta object (server/api/
+// aquarium/catalog.get.ts). `dateKey` is the only field this store reads
+// today (utils/aquariumShopCountdown.ts derives the rotation countdown from
+// it) -- take/skip/total are mirrored here for accuracy, not currently used.
+export interface CatalogMeta {
+  take: number
+  skip: number
+  total: number
+  dateKey: string
+}
+
 // cthulhuquarium/t-016: one rare random event, as returned alongside a tick
 // settlement. `bonusCoins` is already folded into that same response's
 // `coinsEarned` -- this is purely display, never a separate balance.
@@ -399,6 +410,11 @@ export const useCthulhuquariumTankStore = defineStore(
   () => {
     const tank = ref<Tank | null>(null)
     const catalog = ref<CatalogEntry[]>([])
+    // cthulhuquarium/t-057: today's rotation key from the catalog response's
+    // meta ("YYYY-MM-DD", server's todaysShopDateKey) -- null until
+    // loadCatalog() has completed at least once. The unlock panel's refresh
+    // countdown (utils/aquariumShopCountdown.ts) reads this.
+    const catalogDateKey = ref<string | null>(null)
     const offlineEarnings = ref(0)
     // Ticks settled by the SAME offline-catch-up call that produced
     // offlineEarnings above (load()'s initial settle only, never the live
@@ -602,10 +618,13 @@ export const useCthulhuquariumTankStore = defineStore(
     async function loadCatalog(): Promise<void> {
       catalogLoading.value = true
       try {
-        const res = await performFetch<CatalogEntry[]>(
+        const res = await performFetch<CatalogEntry[], CatalogMeta>(
           '/api/aquarium/catalog?take=24',
         )
         if (res.success && res.data) catalog.value = res.data
+        // cthulhuquarium/t-057: the unlock panel's live refresh countdown
+        // reads this -- see utils/aquariumShopCountdown.ts.
+        if (res.meta?.dateKey) catalogDateKey.value = res.meta.dateKey
       } finally {
         catalogLoading.value = false
       }
@@ -1026,6 +1045,7 @@ export const useCthulhuquariumTankStore = defineStore(
     return {
       tank,
       catalog,
+      catalogDateKey,
       stock,
       coins,
       occupantSize,

--- a/stores/utils.ts
+++ b/stores/utils.ts
@@ -35,12 +35,12 @@ function recordTransportSuccess(): void {
   circuitOpenUntil = 0
 }
 
-export async function performFetch<T = unknown>(
+export async function performFetch<T = unknown, M = unknown>(
   url: string,
   options: RequestInit = {},
   retries = 1,
   timeout = 10000,
-): Promise<ApiResponse<T> & { status?: number }> {
+): Promise<ApiResponse<T, M> & { status?: number }> {
   const userStore = useUserStore()
   const errorStore = useErrorStore()
   const token = userStore.token || userStore.user?.token || ''
@@ -117,6 +117,7 @@ export async function performFetch<T = unknown>(
         success: res.ok && bodySuccess,
         status: effectiveStatus,
         data: (body.data ?? parsedBody) as T,
+        meta: body.meta as M,
         message:
           typeof body.message === 'string'
             ? body.message

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,9 +1,16 @@
 import type { User } from '~/prisma/generated/prisma/client'
 
-export type ApiResponse<T = unknown> = {
+export type ApiResponse<T = unknown, M = unknown> = {
   success: boolean
   message: string
   data?: T
+  // Optional out-of-band info alongside `data` -- pagination (take/skip/
+  // total), a rotation dateKey, etc. Several server routes already return a
+  // `meta` object (server/api/aquarium/catalog.get.ts among them); this was
+  // simply dropped by performFetch until cthulhuquarium/t-057 threaded it
+  // through. Untyped here (M defaults to unknown) -- each caller narrows to
+  // its own endpoint's actual meta shape.
+  meta?: M
   statusCode?: number
   user?: User
   token?: string

--- a/utils/aquariumShopCountdown.ts
+++ b/utils/aquariumShopCountdown.ts
@@ -1,0 +1,37 @@
+// @/utils/aquariumShopCountdown.ts
+//
+// cthulhuquarium/t-057: formats the rotating shop's next-refresh countdown
+// for the unlock panel. GET /api/aquarium/catalog's meta.dateKey (server/
+// utils/aquariumEconomy.ts's todaysShopDateKey -- today's UTC calendar day,
+// "YYYY-MM-DD") is the only server-side signal this needs; the rotation
+// always flips at the next UTC midnight after that date, so there's nothing
+// else to derive it from and no new endpoint required.
+//
+// Deliberately framework-free (no Vue) so both
+// stores/cthulhuquariumTankStore.ts and a plain script can use it, same
+// discipline as utils/aquariumMilestoneToast.ts.
+
+const MS_PER_HOUR = 60 * 60 * 1000
+const MS_PER_MINUTE = 60 * 1000
+
+// Midnight UTC of the day AFTER `dateKey` -- the moment the rotation flips.
+// `dateKey` is always "YYYY-MM-DD" (todaysShopDateKey's own format); that
+// form is specified to parse as UTC midnight of that date, so adding one day
+// lands exactly on the next rotation.
+export function nextShopRotationAt(dateKey: string): number {
+  return Date.parse(`${dateKey}T00:00:00.000Z`) + 24 * MS_PER_HOUR
+}
+
+// "Refreshes in Xh Ym" -- null once `now` has reached/passed the rotation
+// (the next loadCatalog() call picks up the new dateKey; this never counts
+// negative or claims a refresh that hasn't landed client-side yet).
+export function formatShopRefreshCountdown(
+  dateKey: string,
+  now: number = Date.now(),
+): string | null {
+  const remainingMs = nextShopRotationAt(dateKey) - now
+  if (remainingMs <= 0) return null
+  const hours = Math.floor(remainingMs / MS_PER_HOUR)
+  const minutes = Math.floor((remainingMs % MS_PER_HOUR) / MS_PER_MINUTE)
+  return `Refreshes in ${hours}h ${minutes}m`
+}


### PR DESCRIPTION
### Task
cthulhuquarium/t-057: Show the rotating shop's refresh countdown on the unlock panel (kind: software)

### What changed / what I produced
- `types/api.ts`: `ApiResponse<T, M>` gains an optional second generic `meta?: M` field (default `unknown`, backward compatible with every existing call site — `performFetch()` was silently dropping a response's `meta` object entirely, only ever surfacing `data`).
- `stores/utils.ts`: `performFetch<T, M>()` now threads `body.meta` through into the returned object.
- `stores/cthulhuquariumTankStore.ts`: `loadCatalog()` captures `GET /api/aquarium/catalog`'s `meta.dateKey` (today's UTC rotation key, already computed server-side — no new endpoint) into a new `catalogDateKey` ref, exposed on the store.
- `utils/aquariumShopCountdown.ts` (new): framework-free `nextShopRotationAt()` / `formatShopRefreshCountdown()` — derives "next UTC midnight after dateKey" and formats "Refreshes in Xh Ym".
- `components/cthulhuquarium/cthulhuquarium-game.vue`: the unlock panel's old static "Today's arrivals -- check back tomorrow for more" hint is now a live countdown (falls back to the static text until the catalog has loaded at least once). Recomputed on the existing 20s tank-poll cadence via a `now` ref — no new timer — and refreshed immediately on tab-visibility resume.

### How I verified
- `vue-tsc --noEmit -p tsconfig.json` — clean
- `eslint` on all five changed/added files — clean
- `prettier --check` on all five files — clean
- Standalone self-test of the countdown math (start-of-day, mid-day, last-minute, at/after rotation, `nextShopRotationAt` exactness) — all correct
- `npm run test:aquarium-economy` / `test:aquarium-shop` / `test:aquarium-touch` — all pass unchanged
- `npm run test:layout-contract` — no new violations

### Stakes
reversible

### Flags for Reviewer
`ApiResponse`/`performFetch`'s new `meta` plumbing is a small, additive, backward-compatible type change (17 existing server routes already return a `meta` object that was previously unreachable from any store) — worth knowing this task widened a shared type, even though the change itself is a pure addition with a default type param.

### Kaizen suggestion
Now that `performFetch` surfaces `meta`, several other stores fetching from routes that already return pagination `meta` (take/skip/total) could drop their own hand-rolled pagination tracking in favor of reading it directly — worth a follow-up audit if that pattern recurs.

### Notes for reviewer
Presentation-only on the UI side; the `meta` plumbing is the only "shared infrastructure" touch, and it's purely additive.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KoKuc5UcAnbxpMfrgWVDsM)_