### PR TITLE
cthulhuquarium/t-059: show a rolled individual's stats on its tank card

### DIFF
--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -215,6 +215,17 @@
                 <p class="mt-0.5 text-xs italic opacity-70">
                   {{ entry.Monster.species || entry.Monster.behavior || '—' }}
                 </p>
+                <!-- t-059: this individual's own rolled stats (t-029/t-055),
+                     reusing the Ichthyonomicon's formatBestStats/
+                     BEST_STAT_LABELS idiom (t-031) rather than a second
+                     stat-formatting scheme. Hidden until rolled -- any
+                     individual placed before t-029 shipped has none. -->
+                <p
+                  v-if="tankStockStatsLine(entry)"
+                  class="mt-1 text-[0.65rem] uppercase tracking-wide opacity-60"
+                >
+                  {{ tankStockStatsLine(entry) }}
+                </p>
               </div>
               <div class="flex shrink-0 flex-col gap-1">
                 <button
@@ -1484,6 +1495,23 @@ function formatBestStats(stats: BestiaryStatBlock): string {
     .filter((key) => stats[key] != null)
     .map((key) => `${BEST_STAT_LABELS[key]} ${stats[key]}`)
     .join(' · ')
+}
+
+// t-059: THIS individual's own rolled stats live on TankStock as
+// stat<Name> (t-029/t-055), not as a BestiaryStatBlock -- reshape once here
+// so the display can reuse formatBestStats/BEST_STAT_LABELS unchanged
+// instead of a second formatting scheme.
+function tankStockStatsLine(entry: TankStock): string | null {
+  const stats: BestiaryStatBlock = {
+    charm: entry.statCharm,
+    empathy: entry.statEmpathy,
+    grace: entry.statGrace,
+    luck: entry.statLuck,
+    might: entry.statMight,
+    wits: entry.statWits,
+  }
+  if (Object.values(stats).every((value) => value == null)) return null
+  return formatBestStats(stats)
 }
 
 function spawnSwimmer(stock: TankStock): Swimmer {


### PR DESCRIPTION
## What

Kaizen from t-055/t-053 (PR #2176): breeding exposed each owned fish's rolled individual stats (`statCharm`..`statWits`) on `TankStock` so the store could read them, but nothing in `cthulhuquarium-game.vue` displayed them — the sell/breed copy already leans on "well-bred fish" framing (t-030) without anywhere a player can actually see a fish's own numbers.

Adds a compact stat readout to each tank card, right under the species line — reuses the Ichthyonomicon's existing `formatBestStats()`/`BEST_STAT_LABELS` idiom (t-031) rather than inventing a second formatting scheme. A small `tankStockStatsLine()` helper reshapes `TankStock`'s `stat<Name>` fields into a `BestiaryStatBlock` and hands it to the unchanged `formatBestStats()`.

Hidden for any individual placed before t-029 (genetics) shipped, since those have no rolled stats to show — same "null until rolled" discipline as the Ichthyonomicon's own "Best seen" line.

Presentation-only: no new endpoint, no store/economy change.

## Verification
- `npx eslint components/cthulhuquarium/cthulhuquarium-game.vue` — clean
- `npx prettier --check components/cthulhuquarium/cthulhuquarium-game.vue` — clean
- `npx vue-tsc --noEmit` — clean, no new errors
- `npm run test:layout-contract` — holds, no new violations (the run's "3 fewer viewport-grid baseline entries" note is from an unrelated file, `video-lora-picker.vue`, not touched here)

## Flags for Reviewer
None. Roadmap task `cthulhuquarium/t-059` set to `status: review` in the paired conductor PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GXpiv8G7NTTXVk3Vbt97PY)_