### PR TITLE
cthulhuquarium/t-061: use performFetch's typed meta generic for pagination

### DIFF
--- a/pages/play/aquarium/browse/index.vue
+++ b/pages/play/aquarium/browse/index.vue
@@ -136,7 +136,7 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
 import { performFetch } from '@/stores/utils'
-import type { ApiResponse } from '@/types/api'
+import type { PaginationMeta } from '@/types/api'
 
 interface PublicTankOwner {
   username: string
@@ -171,11 +171,9 @@ async function load(): Promise<void> {
   loading.value = true
   errorMessage.value = ''
   try {
-    const response = (await performFetch<PublicTankSummary[]>(
+    const response = await performFetch<PublicTankSummary[], PaginationMeta>(
       `/api/aquarium/browse?take=${TAKE}&skip=${skip.value}`,
-    )) as ApiResponse<PublicTankSummary[]> & {
-      meta?: { take: number; skip: number; total: number }
-    }
+    )
     if (!response.success || !response.data) {
       throw new Error(response.message || 'Could not load public tanks.')
     }

--- a/pages/play/aquarium/leaderboard/index.vue
+++ b/pages/play/aquarium/leaderboard/index.vue
@@ -133,7 +133,7 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
 import { performFetch } from '@/stores/utils'
-import type { ApiResponse } from '@/types/api'
+import type { PaginationMeta } from '@/types/api'
 
 interface LeaderboardEntry {
   rank: number
@@ -162,11 +162,9 @@ async function load(): Promise<void> {
   loading.value = true
   errorMessage.value = ''
   try {
-    const response = (await performFetch<LeaderboardEntry[]>(
+    const response = await performFetch<LeaderboardEntry[], PaginationMeta>(
       `/api/aquarium/leaderboard?take=${TAKE}&skip=${skip.value}`,
-    )) as ApiResponse<LeaderboardEntry[]> & {
-      meta?: { take: number; skip: number; total: number }
-    }
+    )
     if (!response.success || !response.data) {
       throw new Error(response.message || 'Could not load the leaderboard.')
     }

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,5 +1,18 @@
 import type { User } from '~/prisma/generated/prisma/client'
 
+// Shared shape for the take/skip/total pagination `meta` several list
+// endpoints return (server/api/aquarium/browse/index.get.ts,
+// server/api/aquarium/leaderboard.get.ts, and others following the same
+// convention). Callers that only need pagination -- not a route-specific
+// extra field like catalog.get.ts's `dateKey` -- can use
+// `performFetch<T, PaginationMeta>(url)` directly instead of hand-casting
+// the result (cthulhuquarium/t-061).
+export type PaginationMeta = {
+  take: number
+  skip: number
+  total: number
+}
+
 export type ApiResponse<T = unknown, M = unknown> = {
   success: boolean
   message: string


### PR DESCRIPTION
## Summary

Kaizen audit from cthulhuquarium/t-057 (conductor roadmap), which discovered `performFetch()` (`stores/utils.ts`) silently dropped every response's `meta` object and fixed it by adding an optional second generic to `ApiResponse<T, M>`. t-057 only updated the one call site it touched (catalog); this task audits every other server route that returns a `meta` object for a store/page still hand-rolling that read.

## What was found

Audited all matches of `meta:` under `server/`. 17 files matched broadly, but only three server routes return an actual API-response `meta` object — everything else is ComfyUI workflow node `_meta` (unrelated internal shape):

- `server/api/aquarium/catalog.get.ts` — caller (`stores/cthulhuquariumTankStore.ts`) already uses the typed generic (t-057). No change needed.
- `server/api/aquarium/browse/index.get.ts` — caller (`pages/play/aquarium/browse/index.vue`) predates t-057 and hand-cast the response to read `meta.total`.
- `server/api/aquarium/leaderboard.get.ts` — caller (`pages/play/aquarium/leaderboard/index.vue`) has the identical hand-cast pattern.

## What changed

- Added a shared `PaginationMeta` type (`types/api.ts`) for the `{ take, skip, total }` shape both routes return, alongside the existing `CatalogMeta` precedent.
- Switched both pages to `performFetch<T, PaginationMeta>(url)`, dropping the manual `ApiResponse<T> & { meta?: {...} }` cast.

No behavior change — both pages already read the server's `meta.total` correctly, just via a less direct path than the generic now supports.

## Verification

- `vue-tsc --noEmit` — clean
- `eslint` on changed files — clean
- `prettier --check` on changed files — clean
- `npm run test:layout-contract` — holds, no new violations

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSXGRqD17JM37wg1q1ojG3)_