### PR TITLE
cthulhuquarium/t-062: show sell price before clicking Sell

### DIFF
--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -241,13 +241,17 @@
                      a well-bred fish can sell for more than it cost. Always
                      re-orderable afterward from the Ichthyonomicon below, so
                      no confirmation dialog, same one-click shape as
-                     unequip/remove elsewhere in this component. -->
+                     unequip/remove elsewhere in this component. t-062: the
+                     button label itself shows the payout (server-computed,
+                     entry.sellPrice) so the player sees what pressing it
+                     pays before clicking, same "Breed for N" idiom as the
+                     breed confirm dialog below. -->
                 <button
                   type="button"
                   class="btn btn-outline btn-xs min-h-11 min-w-11"
                   @click="tankStore.sell(entry.id)"
                 >
-                  Sell
+                  Sell for {{ entry.sellPrice }}
                 </button>
                 <!-- Breed (t-055): a two-step pick, same "choose, then click
                      to commit" idiom as the decor placement flow -- clicking

--- a/server/utils/aquarium.ts
+++ b/server/utils/aquarium.ts
@@ -222,8 +222,17 @@ export type OwnedAquarium = Prisma.AquariumGetPayload<{
 // itself uses to price a breed -- computed here purely so the tank UI can
 // show "breed for N coins" in its confirmation step before the player
 // commits, without the client re-deriving rarity/pricing math of its own.
+// cthulhuquarium/t-062: sellPrice mirrors breedCost's discipline just above
+// -- computed here with the SAME sellFishForUser(server/utils/aquarium.ts)
+// math (unlockCost + sellPrice off the individual's own rolled stats) so
+// the tank UI can show what pressing Sell would actually pay before the
+// player commits, without re-deriving the sell curve client-side. Kept as
+// a top-level ClientStock field rather than nested under Monster like
+// breedCost -- unlike breedCost, this is per-individual (depends on THIS
+// fish's own stat roll), not a fixed per-species number.
 type ClientStock = OwnedAquarium['Stock'][number] & {
   Monster: OwnedAquarium['Stock'][number]['Monster'] & { breedCost: number }
+  sellPrice: number
 }
 
 export interface ClientAquarium extends Omit<OwnedAquarium, 'Stock'> {
@@ -238,16 +247,20 @@ function toClientAquarium(aquarium: OwnedAquarium): ClientAquarium {
       aquarium.sizeCap,
       aquarium.Sets.map((set) => set.kind),
     ),
-    Stock: aquarium.Stock.map((stock) => ({
-      ...stock,
-      Monster: {
-        ...stock.Monster,
-        breedCost: breedCost(
-          deriveFishRarityTier(stock.Monster),
-          stock.Monster.unlockCost,
+    Stock: aquarium.Stock.map((stock) => {
+      const rarity = deriveFishRarityTier(stock.Monster)
+      return {
+        ...stock,
+        Monster: {
+          ...stock.Monster,
+          breedCost: breedCost(rarity, stock.Monster.unlockCost),
+        },
+        sellPrice: sellPrice(
+          unlockCost(rarity, stock.Monster.unlockCost),
+          toIndividualStatBlock(stock),
         ),
-      },
-    })),
+      }
+    }),
   }
 }
 

--- a/stores/cthulhuquariumTankStore.ts
+++ b/stores/cthulhuquariumTankStore.ts
@@ -69,6 +69,11 @@ export interface TankStock {
   statWits: number | null
   parentAId: number | null
   parentBId: number | null
+  // cthulhuquarium/t-062: what selling THIS individual would pay right now,
+  // server-computed (aquariumEconomy.ts's sellPrice) off its own rolled
+  // stats -- same "server disposes" discipline as breedCost above, shown
+  // next to the Sell action so the player sees the payout before clicking.
+  sellPrice: number
   Monster: TankMonster
 }
 


### PR DESCRIPTION
## What changed

Kaizen from t-059 (rolled-stat readout on the tank card, #2179): a fish's own rolled stats are visible now, which makes it obvious `sellPrice()` varies per individual — but nothing showed what a specific fish would actually sell for before the one-click Sell button was pressed.

- `server/utils/aquarium.ts`: `ClientStock` gains a top-level `sellPrice: number` field, computed in `toClientAquarium()` with the exact same `unlockCost(rarity, ...)` + `sellPrice(...)` math `sellFishForUser` already uses to pay out on an actual sale — same "the server disposes" discipline as the existing `breedCost` field just above it. Kept as a sibling of `Monster` rather than nested under it (unlike `breedCost`, this is per-individual, not per-species).
- `stores/cthulhuquariumTankStore.ts`: `TankStock` gains the matching `sellPrice: number` field.
- `components/cthulhuquarium/cthulhuquarium-game.vue`: the Sell button now reads "Sell for N" instead of just "Sell", same "Breed for N" idiom the breed-confirm dialog already uses.

No change to the sell curve itself — presentation-plus-small-payload only, per the task's own note.

## Verification

- `npm run test:aquarium-economy` — pass
- `npm run test:aquarium-shop` — pass (covers `sellPrice()` itself, unchanged)
- `npm run test:aquarium-touch` — pass
- `npx vue-tsc --noEmit` — clean
- `npx eslint` on the three changed files — clean
- `npx prettier --check` on the three changed files — clean
- `npm run test:layout-contract` — holds, no new violations

## Flags for Reviewer

None — purely additive server field + one label change, no schema/migration touch, no behavior change to the actual sale transaction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVTDVG1zXejCRtRU4pAYdd)_