### PR TITLE
interface-vision/t-104 slice 32: registration-page.vue onto kr-container

### DIFF
--- a/components/user/registration-page.vue
+++ b/components/user/registration-page.vue
@@ -18,7 +18,7 @@
         log out </a
       >?
     </div>
-    <form class="space-y-6 w-full max-w-md mx-auto" @submit.prevent="register">
+    <form class="kr-container max-w-md space-y-6" @submit.prevent="register">
       <div v-if="step === 1">
         <!-- Pick a Username Section -->
         <p class="text-4xl font-bold mb-4 text-center">Pick a</p>


### PR DESCRIPTION
## What

`components/user/registration-page.vue`'s registration `<form>` root now uses `kr-container max-w-md space-y-6` instead of the hand-rolled `space-y-6 w-full max-w-md mx-auto`.

## Why

Slice 32 of the recurring interface-vision/t-104 consistency sweep (driving hand-rolled Tailwind onto shared `kr-*` composition primitives). `.kr-container` is defined as `mx-auto w-full max-w-6xl` in `@layer components` (`assets/css/tailwind.css`), so the utilities-layer `max-w-md` on the same element still overrides `max-w-6xl` regardless of class order — the identical mechanism already proven in slice 30 (`password-reset.vue`) and slice 31 (`login-persister.vue`, `forum-thread.vue`, `mana-wallet.vue`, `subscription-manager.vue`).

No geometry or behavior change — this is a byte-equivalent utility substitution.

## Verification

- `eslint` on the changed file: clean
- `prettier --check`: clean
- `vue-tsc --noEmit`: 0 errors
- `npm run test:layout-contract`: holds, no new violations (an unrelated pre-existing `video-lora-picker.vue` ratchet opportunity showed up in the report; left untouched, out of scope for this slice)

## Flags for Reviewer

None — single-file, single-line, mechanical substitution matching the established slice pattern exactly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WsyeACrrYeqXZQLB4E6HBp)_