### PR TITLE
interface-vision/t-122: warn when layout-contract baseline could shrink

### DIFF
--- a/utils/scripts/verifyLayoutContract.ts
+++ b/utils/scripts/verifyLayoutContract.ts
@@ -152,6 +152,16 @@ function walk(dir: string, ext: string, out: string[] = []): string[] {
 const read = (path: string): string => readFileSync(path, 'utf8')
 const rel = (path: string): string => relative(ROOT, path).replace(/\\/g, '/')
 
+/*
+ * Escapes a string for use inside a GitHub Actions workflow command
+ * (`::warning ...::message`). Same rule GitHub documents for `%`/CR/LF in
+ * command properties and message text; matches the pattern already used by
+ * verifyCommentCalibrationBatch002Contract.ts's own `workflowEscape`.
+ */
+function workflowEscape(value: string): string {
+  return value.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A')
+}
+
 /* Strip <script> and <style> so we only ever match real template markup. */
 function templateOf(source: string): string {
   return source
@@ -1051,6 +1061,24 @@ function main(): void {
       )
       for (const entry of removed) console.log(`  - ${entry}`)
       console.log('')
+
+      /*
+       * interface-vision t-122: this is the same comparison --update would
+       * make, just without writing the file, so it doubles as the "scratch/
+       * dry mode" check the kaizen asked for. Surface it as a warning
+       * annotation (not a failing check) on whichever PR/push caused the
+       * shrink, instead of leaving it to sit unnoticed in a log until some
+       * later session happens to run --report and spot it (as happened with
+       * video-lora-picker.vue's stale viewport-grid entries, kind_robots
+       * PR #2184).
+       */
+      const summary =
+        `${removed.length} entr${removed.length === 1 ? 'y' : 'ies'} in "${key}" (${RULE_TITLES[key]}) ` +
+        `no longer violate the layout contract and can be ratcheted out of the baseline: ` +
+        `${removed.join(', ')}. Run \`npm run test:layout-contract -- --update\` to shrink it.`
+      console.log(
+        `::warning title=Layout contract baseline could shrink (${key})::${workflowEscape(summary)}`,
+      )
     }
   }
 


### PR DESCRIPTION
### Task
conductor `interface-vision/t-122` — kaizen filed from the t-104 slice that ratcheted the viewport-grid baseline for `components/video-lora-picker.vue` (kind_robots PR #2184). The baseline had listed 3 stale violations that no longer matched the file's actual (already-fixed) grid classes — an unrelated change had silently fixed the code without anyone ratcheting the baseline down to match, and it only surfaced because a session happened to run `npm run test:layout-contract` directly and notice.

### What changed / what I produced
`utils/scripts/verifyLayoutContract.ts`: the default (non-`--update`) check path already computed which baseline entries a `--update` run would remove ("Contract improved ... Run with --update to ratchet the baseline down"), but only printed it to the job log where nobody would notice unless they read the full output. Each shrunk rule now also emits a GitHub Actions `::warning::` annotation (non-failing) naming the entries that could be ratcheted out, using the same `workflowEscape` pattern already established in `verifyCommentCalibrationBatch002Contract.ts`.

This reuses the existing "Verify layout contract" step already in `.github/workflows/layout-contract.yml` (runs on every PR and push to `main`) — no workflow YAML change needed. The comparison it makes is identical to what `--update` would do, just without writing the file, so it doubles as the "scratch/dry mode" check the kaizen asked for.

### How I verified
- Ran `npm run test:layout-contract` against the real baseline: clean, 209 unchanged violations, no annotation (as expected — nothing to ratchet right now).
- Temporarily appended a synthetic stale entry to the baseline JSON and re-ran: confirmed the `::warning title=Layout contract baseline could shrink (viewport-grid)::...` annotation fires and correctly names the removed entry, then restored the real baseline and confirmed a clean run stays silent.
- `npx eslint utils/scripts/verifyLayoutContract.ts` clean.
- `npx prettier --check utils/scripts/verifyLayoutContract.ts` clean.
- `npx vue-tsc --noEmit` reports no new errors for this file.

### Stakes
Reversible — CI script change only, adds a non-failing annotation. No behavior change to the pass/fail gate itself.

### Flags for Reviewer
None.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DZzK8EtQppCagjHpLr5Gu3)_