### PR TITLE
kind-robots: full-screen ArtJob slideshow off the art queue

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -49,6 +49,9 @@ jobs:
       - name: ArtJob priority bounds contract
         run: npm run test:artjob-priority-bounds
 
+      - name: ArtJob slideshow rotation contract
+        run: npm run test:art-slideshow-rotation
+
       - name: Art failure-signature grouping contract
         run: npm run test:art-failure-signature
 

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -33,6 +33,14 @@
           </select>
           <button
             type="button"
+            class="btn btn-secondary btn-sm rounded-2xl"
+            title="Watch finished renders full screen, newest first"
+            @click="slideshowOpen = true"
+          >
+            Slideshow
+          </button>
+          <button
+            type="button"
             class="btn btn-primary btn-sm rounded-2xl"
             :disabled="isLoading"
             @click="refresh"
@@ -349,6 +357,8 @@
       </section>
     </div>
 
+    <artjob-slideshow v-if="slideshowOpen" @close="slideshowOpen = false" />
+
     <artjob-editor
       v-if="editorJob"
       :job="editorJob"
@@ -386,6 +396,7 @@ const selectedWindow = ref(24)
 const pageSizeInput = ref('20')
 const pageInput = ref('1')
 const editorJob = ref<ArtJobRecord | null>(null)
+const slideshowOpen = ref(false)
 const editorAction = ref<EditorAction>('EDIT')
 const refreshingServerIds = ref<number[]>([])
 const removingServerIds = ref<number[]>([])

--- a/components/art/artjob-queue-card.vue
+++ b/components/art/artjob-queue-card.vue
@@ -375,10 +375,21 @@ import { computed, ref } from 'vue'
 import { useArtJobStore, type ArtJobRecord } from '@/stores/artJobStore'
 import { useArtJobPriorityStore } from '@/stores/artJobPriorityStore'
 import { useArtStore } from '@/stores/artStore'
-import { resolveMaturityPrivacy } from '@/utils/maturityPrivacy'
+import {
+  artJobImagePath,
+  artJobImageVersion,
+  artJobNegativePrompt,
+  artJobPageLabel,
+  artJobPrompt,
+  artJobPublicImageSrc,
+  artJobRequestId,
+  artJobSettings,
+  artJobTitle,
+  artJobVariant,
+  artJobVisibility,
+} from '@/utils/artJobFields'
 
 type EditorAction = 'EDIT' | 'NEW_OUTPUT' | 'OVERWRITE'
-type JsonRecord = Record<string, unknown>
 
 const props = defineProps<{
   job: ArtJobRecord
@@ -393,192 +404,33 @@ const priorityStore = useArtJobPriorityStore()
 const artStore = useArtStore()
 const copied = ref(false)
 
-function asRecord(value: unknown): JsonRecord {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
-  return value as JsonRecord
-}
+const jobPrompt = computed<string>(() => artJobPrompt(props.job))
 
-function scalar(value: unknown): string {
-  if (typeof value === 'string') return value.trim()
-  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
-  return ''
-}
-
-function nestedScalar(value: unknown, keys: string[], depth = 0): string {
-  if (depth > 6 || value === null || value === undefined) return ''
-  if (Array.isArray(value)) {
-    for (const child of value) {
-      const result = nestedScalar(child, keys, depth + 1)
-      if (result) return result
-    }
-    return ''
-  }
-
-  const record = asRecord(value)
-  for (const key of keys) {
-    const direct = scalar(record[key])
-    if (direct) return direct
-  }
-  for (const child of Object.values(record)) {
-    const result = nestedScalar(child, keys, depth + 1)
-    if (result) return result
-  }
-  return ''
-}
-
-function directPayloadScalar(job: ArtJobRecord, keys: string[]): string {
-  const payload = asRecord(job.payload)
-  for (const key of keys) {
-    const value = scalar(payload[key])
-    if (value) return value
-  }
-  return ''
-}
-
-function payloadScalar(job: ArtJobRecord, keys: string[]): string {
-  const direct = directPayloadScalar(job, keys)
-  if (direct) return direct
-  return nestedScalar(asRecord(job.payload).workflow, keys)
-}
-
-function workflowPrompt(
-  job: ArtJobRecord,
-  kind: 'positive' | 'negative',
-): string {
-  const workflow = asRecord(asRecord(job.payload).workflow)
-  for (const value of Object.values(workflow)) {
-    const node = asRecord(value)
-    const classType = scalar(node.class_type).toLowerCase()
-    const inputs = asRecord(node.inputs)
-    const title = scalar(asRecord(node._meta).title).toLowerCase()
-    const isNegative = title.includes('negative')
-    if (kind === 'negative' && !isNegative) continue
-    if (kind === 'positive' && isNegative) continue
-    if (!classType.includes('clip') && !classType.includes('wildcard')) continue
-    const text =
-      scalar(inputs.text) ||
-      scalar(inputs.wildcard_text) ||
-      scalar(inputs.populated_text) ||
-      scalar(inputs.t5xxl) ||
-      scalar(inputs.clip_l)
-    if (text) return text
-  }
-  return ''
-}
-
-const jobPrompt = computed<string>(
-  () =>
-    payloadScalar(props.job, [
-      'promptString',
-      'artPrompt',
-      'positivePrompt',
-      'prompt',
-    ]) || workflowPrompt(props.job, 'positive'),
+const jobNegativePrompt = computed<string>(() =>
+  artJobNegativePrompt(props.job),
 )
 
-const jobNegativePrompt = computed<string>(
-  () =>
-    payloadScalar(props.job, [
-      'negativePrompt',
-      'negative_prompt',
-      'negative',
-    ]) || workflowPrompt(props.job, 'negative'),
-)
-
-const jobVisibility = computed(() =>
-  resolveMaturityPrivacy(asRecord(asRecord(props.job.payload).save)),
-)
+const jobVisibility = computed(() => artJobVisibility(props.job))
 
 const canShowJobContent = computed<boolean>(
   () => !jobVisibility.value.isMature || artStore.showMature,
 )
 
-const jobTitle = computed<string>(() => {
-  return (
-    directPayloadScalar(props.job, ['title', 'label', 'name']) ||
-    props.job.projectSlug ||
-    `ArtJob #${props.job.id}`
-  )
-})
+const jobTitle = computed<string>(() => artJobTitle(props.job))
 
-const jobPage = computed<string>(() =>
-  directPayloadScalar(props.job, [
-    'page',
-    'pagePath',
-    'route',
-    'destinationPage',
-  ]),
-)
+const jobPageLabel = computed<string>(() => artJobPageLabel(props.job))
 
-const jobPageLabel = computed<string>(() => {
-  const page = jobPage.value
-  if (!page) return ''
-  if (page === 'index' || page === 'home') return '/'
-  return page.startsWith('/') ? page : `/${page}`
-})
+const jobVariant = computed<string>(() => artJobVariant(props.job))
 
-const jobVariant = computed<string>(() =>
-  directPayloadScalar(props.job, ['variant', 'breakpoint']),
-)
+const jobRequestId = computed<string>(() => artJobRequestId(props.job))
 
-const jobRequestId = computed<string>(() =>
-  directPayloadScalar(props.job, ['requestId', 'requestID', 'request_id']),
-)
+const jobImagePath = computed<string>(() => artJobImagePath(props.job))
 
-const jobImagePath = computed<string>(() =>
-  directPayloadScalar(props.job, [
-    'imagePath',
-    'outputPath',
-    'destinationPath',
-  ]),
-)
+const jobSettings = computed<string[]>(() => artJobSettings(props.job))
 
-const jobSettings = computed<string[]>(() => {
-  const job = props.job
-  const values = [
-    [
-      'size',
-      `${payloadScalar(job, ['width'])}×${payloadScalar(job, ['height'])}`,
-    ],
-    [
-      'model',
-      payloadScalar(job, [
-        'checkpoint',
-        'ckpt_name',
-        'unet_name',
-        'model_name',
-      ]),
-    ],
-    ['sampler', payloadScalar(job, ['sampler', 'sampler_name'])],
-    ['scheduler', payloadScalar(job, ['scheduler'])],
-    ['steps', payloadScalar(job, ['steps'])],
-    ['cfg', payloadScalar(job, ['cfg', 'cfg_scale'])],
-    ['guidance', payloadScalar(job, ['guidance'])],
-    ['denoise', payloadScalar(job, ['denoise'])],
-    ['seed', payloadScalar(job, ['seed', 'noise_seed'])],
-  ]
+const imageVersion = computed<string>(() => artJobImageVersion(props.job))
 
-  return values
-    .filter(([, value]) => value && value !== '×')
-    .map(([label, value]) => `${label}: ${value}`)
-})
-
-// updatedAt is DateTime? in the schema, so it can genuinely be null; a null
-// timestamp simply means no cache-buster. Shared by the public URL and the
-// protected-preview cache key so both invalidate together on an overwrite.
-const imageVersion = computed<string>(() => {
-  const updatedAt = props.job.updatedAt
-    ? new Date(props.job.updatedAt).getTime()
-    : Number.NaN
-  return Number.isFinite(updatedAt) ? `?v=${updatedAt}` : ''
-})
-
-const publicImageSrc = computed<string>(() => {
-  const id = props.job.artImageId
-  if (typeof id !== 'number') return ''
-  if (!jobVisibility.value.isPublic || jobVisibility.value.isMature) return ''
-  return `/api/art/images/${id}/file${imageVersion.value}`
-})
+const publicImageSrc = computed<string>(() => artJobPublicImageSrc(props.job))
 
 const jobImageSrc = computed<string>(() => {
   const id = props.job.artImageId

--- a/components/art/artjob-slideshow.vue
+++ b/components/art/artjob-slideshow.vue
@@ -1,0 +1,773 @@
+<!-- /components/art/artjob-slideshow.vue -->
+<template>
+  <Teleport to="body">
+    <div
+      ref="rootElement"
+      class="fixed inset-0 z-[100] flex select-none flex-col bg-base-300"
+      @mousemove="wakeChrome"
+      @touchstart="wakeChrome"
+    >
+      <div
+        class="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden"
+      >
+        <transition name="kr-slideshow-fade">
+          <div
+            v-if="slideSrc && canShowSlide"
+            :key="slideKey"
+            class="absolute inset-0 flex items-center justify-center"
+          >
+            <video
+              v-if="slideKind === 'video'"
+              :src="slideSrc"
+              class="h-full w-full"
+              :class="fitClass"
+              autoplay
+              loop
+              muted
+              playsinline
+            />
+            <img
+              v-else
+              :src="slideSrc"
+              :alt="slideTitle"
+              class="h-full w-full"
+              :class="fitClass"
+              decoding="async"
+              data-missing-image-report="false"
+            />
+          </div>
+        </transition>
+
+        <div
+          v-if="!slideSrc || !canShowSlide"
+          class="flex max-w-md flex-col items-center gap-3 rounded-2xl border border-base-content/10 bg-base-100/70 p-8 text-center"
+        >
+          <span
+            v-if="slideshowStore.loadingPool"
+            class="loading loading-spinner loading-lg text-primary"
+          />
+          <p class="text-sm font-semibold">{{ stageMessage }}</p>
+          <p v-if="slideshowStore.error" class="text-xs text-error">
+            {{ slideshowStore.error }}
+          </p>
+        </div>
+
+        <transition name="kr-slideshow-fade">
+          <header
+            v-if="chromeVisible"
+            class="absolute inset-x-0 top-0 flex flex-wrap items-center justify-between gap-2 bg-gradient-to-b from-base-300/90 to-transparent p-3"
+          >
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="text-sm font-black tracking-wide"
+                >Art slideshow</span
+              >
+              <span
+                class="badge badge-sm rounded-2xl"
+                :class="isPlaying ? 'badge-success' : 'badge-ghost'"
+              >
+                {{ isPlaying ? `${intervalSeconds}s` : 'Paused' }}
+              </span>
+              <span
+                class="badge badge-outline badge-sm rounded-2xl"
+                :title="`Drawing at random from the ${depth} most recent finished jobs`"
+              >
+                depth {{ slideshowStore.pool.length }}/{{ depth }}
+              </span>
+              <span
+                v-if="slideshowStore.pendingArrivalCount"
+                class="badge badge-accent badge-sm rounded-2xl"
+              >
+                {{ slideshowStore.pendingArrivalCount }} new queued
+              </span>
+              <span
+                v-if="showingArrival"
+                class="badge badge-accent badge-sm rounded-2xl"
+              >
+                Fresh off the queue
+              </span>
+            </div>
+
+            <div class="flex flex-wrap items-center gap-1">
+              <button
+                type="button"
+                class="btn btn-ghost btn-sm rounded-2xl"
+                :disabled="!slideshowStore.hasPreviousSlide"
+                title="Previous (left arrow)"
+                @click="previousSlide"
+              >
+                Prev
+              </button>
+              <button
+                type="button"
+                class="btn btn-sm rounded-2xl"
+                :class="isPlaying ? 'btn-ghost' : 'btn-primary'"
+                title="Play or pause (space)"
+                @click="togglePlaying"
+              >
+                {{ isPlaying ? 'Pause' : 'Play' }}
+              </button>
+              <button
+                type="button"
+                class="btn btn-ghost btn-sm rounded-2xl"
+                title="Next (right arrow)"
+                @click="nextSlide"
+              >
+                Next
+              </button>
+              <button
+                type="button"
+                class="btn btn-ghost btn-sm rounded-2xl"
+                title="Show or hide the caption (i)"
+                @click="toggleAllOverlay"
+              >
+                {{ anyOverlayVisible ? 'Hide info' : 'Show info' }}
+              </button>
+              <button
+                type="button"
+                class="btn btn-sm rounded-2xl"
+                :class="settingsOpen ? 'btn-primary' : 'btn-ghost'"
+                title="Slideshow options (s)"
+                @click="settingsOpen = !settingsOpen"
+              >
+                Options
+              </button>
+              <button
+                type="button"
+                class="btn btn-ghost btn-sm rounded-2xl"
+                title="Toggle browser fullscreen (f)"
+                @click="toggleFullscreen"
+              >
+                {{ isFullscreen ? 'Exit fullscreen' : 'Fullscreen' }}
+              </button>
+              <button
+                type="button"
+                class="btn btn-ghost btn-sm rounded-2xl text-error"
+                title="Close the slideshow (esc)"
+                @click="close"
+              >
+                Close
+              </button>
+            </div>
+          </header>
+        </transition>
+
+        <transition name="kr-slideshow-fade">
+          <footer
+            v-if="captionVisible"
+            class="absolute inset-x-0 bottom-0 flex flex-col gap-1 bg-gradient-to-t from-base-300/90 to-transparent p-4"
+          >
+            <div
+              v-if="overlay.title"
+              class="flex flex-wrap items-baseline gap-2"
+            >
+              <span class="text-lg font-black">{{ slideTitle }}</span>
+              <span
+                v-if="currentJob?.projectSlug"
+                class="badge badge-secondary badge-sm rounded-2xl"
+              >
+                {{ currentJob.projectSlug }}
+              </span>
+              <span
+                v-if="currentJob?.engine"
+                class="badge badge-outline badge-sm rounded-2xl"
+              >
+                {{ currentJob.engine }}
+              </span>
+            </div>
+
+            <p
+              v-if="overlay.fileName && slideFileName"
+              class="break-all font-mono text-xs text-base-content/80"
+              :title="slidePath"
+            >
+              {{ slideFileName }}
+              <span
+                v-if="slidePath !== slideFileName"
+                class="text-base-content/45"
+              >
+                · {{ slidePath }}
+              </span>
+            </p>
+
+            <p
+              v-if="overlay.prompt && slidePrompt"
+              class="line-clamp-3 max-w-4xl whitespace-pre-wrap text-sm leading-relaxed text-base-content/85"
+            >
+              {{ slidePrompt }}
+            </p>
+
+            <div
+              v-if="overlay.settings && slideSettings.length"
+              class="flex flex-wrap gap-1"
+            >
+              <span
+                v-for="setting in slideSettings"
+                :key="setting"
+                class="badge badge-ghost badge-sm h-auto rounded-2xl py-1 text-[10px]"
+              >
+                {{ setting }}
+              </span>
+            </div>
+
+            <p
+              v-if="overlay.timestamp"
+              class="text-[11px] text-base-content/60"
+            >
+              ArtJob #{{ currentJob?.id }}
+              <span v-if="currentJob?.artImageId">
+                · ArtImage #{{ currentJob.artImageId }}
+              </span>
+              · finished {{ slideFinishedAt }}
+            </p>
+          </footer>
+        </transition>
+
+        <div
+          v-if="overlay.progress"
+          class="absolute inset-x-0 bottom-0 h-1 bg-base-content/10"
+        >
+          <div
+            class="h-full bg-primary transition-[width] duration-200 ease-linear"
+            :style="{ width: `${progressPercent}%` }"
+          />
+        </div>
+
+        <transition name="kr-slideshow-slide">
+          <aside
+            v-if="settingsOpen"
+            class="absolute inset-y-0 right-0 flex w-80 max-w-full flex-col gap-4 overflow-y-auto overscroll-contain border-l border-base-content/10 bg-base-100/95 p-4"
+          >
+            <div class="flex items-center justify-between gap-2">
+              <h3 class="text-sm font-black">Slideshow options</h3>
+              <button
+                type="button"
+                class="btn btn-ghost btn-xs rounded-2xl"
+                @click="settingsOpen = false"
+              >
+                Done
+              </button>
+            </div>
+
+            <label class="flex flex-col gap-1">
+              <span
+                class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
+              >
+                Seconds per slide
+              </span>
+              <div class="flex items-center gap-2">
+                <input
+                  v-model.number="intervalInput"
+                  type="range"
+                  min="1"
+                  max="60"
+                  class="range range-primary range-xs"
+                  @change="applyInterval"
+                />
+                <input
+                  v-model.number="intervalInput"
+                  type="number"
+                  min="1"
+                  max="600"
+                  class="input input-bordered input-xs w-20 rounded-xl"
+                  @change="applyInterval"
+                />
+              </div>
+              <div class="flex flex-wrap gap-1">
+                <button
+                  v-for="choice in intervalChoices"
+                  :key="choice"
+                  type="button"
+                  class="btn btn-xs rounded-2xl"
+                  :class="
+                    intervalSeconds === choice ? 'btn-primary' : 'btn-ghost'
+                  "
+                  @click="selectInterval(choice)"
+                >
+                  {{ choice }}s
+                </button>
+              </div>
+            </label>
+
+            <label class="flex flex-col gap-1">
+              <span
+                class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
+              >
+                Random draw depth
+              </span>
+              <div class="flex flex-wrap gap-1">
+                <button
+                  v-for="choice in depthChoices"
+                  :key="choice"
+                  type="button"
+                  class="btn btn-xs rounded-2xl"
+                  :class="depth === choice ? 'btn-primary' : 'btn-ghost'"
+                  @click="selectDepth(choice)"
+                >
+                  {{ choice }}
+                </button>
+              </div>
+              <span class="text-[11px] text-base-content/50">
+                Slides are drawn at random from the {{ depth }} most recent
+                finished jobs, without repeating until the pool runs out.
+              </span>
+            </label>
+
+            <label class="flex items-start gap-2 text-sm">
+              <input
+                type="checkbox"
+                class="checkbox checkbox-sm mt-0.5"
+                :checked="interruptOnArrival"
+                @change="applyInterrupt"
+              />
+              <span class="flex flex-col">
+                <span class="font-semibold">Cut to new art immediately</span>
+                <span class="text-[11px] text-base-content/50">
+                  Off: a finished render waits its turn and shows at the next
+                  slide change instead of interrupting the current one.
+                </span>
+              </span>
+            </label>
+
+            <div class="flex flex-col gap-1">
+              <span
+                class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
+              >
+                Image fit
+              </span>
+              <div class="flex gap-1">
+                <button
+                  type="button"
+                  class="btn btn-xs flex-1 rounded-2xl"
+                  :class="fitMode === 'contain' ? 'btn-primary' : 'btn-ghost'"
+                  @click="slideshowStore.setFitMode('contain')"
+                >
+                  Fit whole image
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-xs flex-1 rounded-2xl"
+                  :class="fitMode === 'cover' ? 'btn-primary' : 'btn-ghost'"
+                  @click="slideshowStore.setFitMode('cover')"
+                >
+                  Fill screen
+                </button>
+              </div>
+            </div>
+
+            <div class="flex flex-col gap-2">
+              <span
+                class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
+              >
+                Caption
+              </span>
+              <label
+                v-for="field in overlayFields"
+                :key="field.key"
+                class="flex items-center gap-2 text-sm"
+              >
+                <input
+                  type="checkbox"
+                  class="checkbox checkbox-sm"
+                  :checked="overlay[field.key]"
+                  @change="applyOverlayField(field.key, $event)"
+                />
+                <span>{{ field.label }}</span>
+              </label>
+            </div>
+
+            <div
+              class="rounded-2xl border border-base-300 p-3 text-[11px] leading-relaxed text-base-content/60"
+            >
+              <span class="font-semibold text-base-content/80">Keys</span>
+              <br />space play/pause · arrows previous/next · i caption · f
+              fullscreen · s options · esc close
+            </div>
+          </aside>
+        </transition>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useArtJobStore } from '@/stores/artJobStore'
+import { useArtStore } from '@/stores/artStore'
+import {
+  SLIDESHOW_DEPTH_CHOICES,
+  SLIDESHOW_INTERVAL_CHOICES,
+  useArtSlideshowStore,
+  type SlideshowOverlayField,
+} from '@/stores/artSlideshowStore'
+import {
+  artJobFileName,
+  artJobImagePath,
+  artJobImageVersion,
+  artJobPrompt,
+  artJobPublicImageSrc,
+  artJobSettings,
+  artJobTitle,
+  artJobVisibility,
+} from '@/utils/artJobFields'
+
+const emit = defineEmits<{ close: [] }>()
+
+const TICK_MS = 100
+const CHROME_IDLE_MS = 2600
+const ARRIVAL_POLL_MS = 15_000
+const POOL_REFRESH_MS = 300_000
+const ARRIVAL_FLASH_MS = 6000
+
+const slideshowStore = useArtSlideshowStore()
+const artJobStore = useArtJobStore()
+const artStore = useArtStore()
+
+const rootElement = ref<HTMLElement | null>(null)
+const isPlaying = ref(true)
+const settingsOpen = ref(false)
+const isFullscreen = ref(false)
+const chromeVisible = ref(true)
+const showingArrival = ref(false)
+const elapsedMs = ref(0)
+const intervalInput = ref(slideshowStore.settings.intervalSeconds)
+
+let tickTimer: ReturnType<typeof setInterval> | null = null
+let arrivalTimer: ReturnType<typeof setInterval> | null = null
+let poolTimer: ReturnType<typeof setInterval> | null = null
+let chromeTimer: ReturnType<typeof setTimeout> | null = null
+let arrivalFlashTimer: ReturnType<typeof setTimeout> | null = null
+
+const overlayFields: Array<{ key: SlideshowOverlayField; label: string }> = [
+  { key: 'title', label: 'Title, project, and engine' },
+  { key: 'fileName', label: 'File name and destination path' },
+  { key: 'prompt', label: 'Prompt' },
+  { key: 'settings', label: 'Model and generation settings' },
+  { key: 'timestamp', label: 'Job id and finish time' },
+  { key: 'progress', label: 'Timer bar' },
+]
+
+const depthChoices = SLIDESHOW_DEPTH_CHOICES
+const intervalChoices = SLIDESHOW_INTERVAL_CHOICES
+
+const currentJob = computed(() => slideshowStore.currentJob)
+const overlay = computed(() => slideshowStore.settings.overlay)
+const depth = computed(() => slideshowStore.settings.depth)
+const intervalSeconds = computed(() => slideshowStore.settings.intervalSeconds)
+const fitMode = computed(() => slideshowStore.settings.fitMode)
+const interruptOnArrival = computed(
+  () => slideshowStore.settings.interruptOnArrival,
+)
+
+const fitClass = computed(() =>
+  fitMode.value === 'cover' ? 'object-cover' : 'object-contain',
+)
+
+const canShowSlide = computed<boolean>(() => {
+  const job = currentJob.value
+  if (!job) return false
+  return !artJobVisibility(job).isMature || artStore.showMature
+})
+
+const slideSrc = computed<string>(() => {
+  const job = currentJob.value
+  if (!job || typeof job.artImageId !== 'number') return ''
+  return (
+    artJobPublicImageSrc(job) || artJobStore.imageSrcById[job.artImageId] || ''
+  )
+})
+
+const slideKind = computed<string>(() => {
+  const job = currentJob.value
+  if (!job || typeof job.artImageId !== 'number') return 'image'
+  if (artJobPublicImageSrc(job)) return 'image'
+  return artJobStore.imageInfoById[job.artImageId]?.kind || 'image'
+})
+
+const slideKey = computed<string>(
+  () => `${currentJob.value?.id ?? 0}:${slideSrc.value}`,
+)
+const slideTitle = computed<string>(() =>
+  currentJob.value ? artJobTitle(currentJob.value) : '',
+)
+const slidePath = computed<string>(() =>
+  currentJob.value ? artJobImagePath(currentJob.value) : '',
+)
+const slideFileName = computed<string>(() =>
+  currentJob.value ? artJobFileName(currentJob.value) : '',
+)
+const slidePrompt = computed<string>(() =>
+  currentJob.value ? artJobPrompt(currentJob.value) : '',
+)
+const slideSettings = computed<string[]>(() =>
+  currentJob.value ? artJobSettings(currentJob.value) : [],
+)
+const slideFinishedAt = computed<string>(() => {
+  const value = currentJob.value?.updatedAt || currentJob.value?.createdAt
+  if (!value) return 'unknown'
+  const date = new Date(value)
+  if (!Number.isFinite(date.getTime())) return 'unknown'
+  return date.toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+})
+
+const anyOverlayVisible = computed<boolean>(() =>
+  overlayFields.some((field) => overlay.value[field.key]),
+)
+
+const captionVisible = computed<boolean>(
+  () =>
+    Boolean(currentJob.value) &&
+    overlayFields
+      .filter((field) => field.key !== 'progress')
+      .some((field) => overlay.value[field.key]),
+)
+
+const progressPercent = computed<number>(() => {
+  const total = intervalSeconds.value * 1000
+  if (total <= 0) return 0
+  return Math.min(100, (elapsedMs.value / total) * 100)
+})
+
+const stageMessage = computed<string>(() => {
+  if (slideshowStore.loadingPool) return 'Loading finished art...'
+  if (slideshowStore.error) return 'Could not load the finished queue.'
+  if (!slideshowStore.pool.length) return 'No finished art to show yet.'
+  if (!canShowSlide.value) {
+    return 'This render is marked mature and your account setting hides it.'
+  }
+  return 'Waiting for this render to load...'
+})
+
+function isViewable(job: typeof currentJob.value): boolean {
+  if (!job) return false
+  return !artJobVisibility(job).isMature || artStore.showMature
+}
+
+function markArrival(): void {
+  showingArrival.value = true
+  if (arrivalFlashTimer) clearTimeout(arrivalFlashTimer)
+  arrivalFlashTimer = setTimeout(() => {
+    showingArrival.value = false
+  }, ARRIVAL_FLASH_MS)
+}
+
+function advanceSlide(): void {
+  const wasArrival = slideshowStore.pendingArrivalCount > 0
+  const attempts = Math.max(1, slideshowStore.pool.length)
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    slideshowStore.advance()
+    if (isViewable(currentJob.value)) break
+  }
+  elapsedMs.value = 0
+  if (wasArrival) markArrival()
+  else showingArrival.value = false
+  void loadProtectedSlide()
+}
+
+async function loadProtectedSlide(): Promise<void> {
+  const job = currentJob.value
+  if (!job || typeof job.artImageId !== 'number') return
+  if (artJobPublicImageSrc(job)) return
+  if (!isViewable(job)) return
+  await artJobStore.loadJobImage(job.artImageId, artJobImageVersion(job))
+}
+
+function nextSlide(): void {
+  advanceSlide()
+}
+
+function previousSlide(): void {
+  slideshowStore.stepBack()
+  elapsedMs.value = 0
+  showingArrival.value = false
+  void loadProtectedSlide()
+}
+
+function togglePlaying(): void {
+  isPlaying.value = !isPlaying.value
+  elapsedMs.value = 0
+  wakeChrome()
+}
+
+function toggleAllOverlay(): void {
+  slideshowStore.setAllOverlayFields(!anyOverlayVisible.value)
+}
+
+function applyOverlayField(field: SlideshowOverlayField, event: Event): void {
+  const target = event.target as HTMLInputElement | null
+  slideshowStore.setOverlayField(field, Boolean(target?.checked))
+}
+
+function applyInterrupt(event: Event): void {
+  const target = event.target as HTMLInputElement | null
+  slideshowStore.setInterruptOnArrival(Boolean(target?.checked))
+}
+
+function applyInterval(): void {
+  slideshowStore.setIntervalSeconds(intervalInput.value)
+  intervalInput.value = slideshowStore.settings.intervalSeconds
+  elapsedMs.value = 0
+}
+
+function selectInterval(seconds: number): void {
+  intervalInput.value = seconds
+  applyInterval()
+}
+
+async function selectDepth(value: number): Promise<void> {
+  await slideshowStore.setDepth(value)
+}
+
+function wakeChrome(): void {
+  chromeVisible.value = true
+  if (chromeTimer) clearTimeout(chromeTimer)
+  chromeTimer = setTimeout(() => {
+    if (settingsOpen.value || !isPlaying.value) return
+    chromeVisible.value = false
+  }, CHROME_IDLE_MS)
+}
+
+async function toggleFullscreen(): Promise<void> {
+  if (!import.meta.client) return
+  try {
+    if (document.fullscreenElement) {
+      await document.exitFullscreen()
+      return
+    }
+    await rootElement.value?.requestFullscreen()
+  } catch {
+    isFullscreen.value = Boolean(document.fullscreenElement)
+  }
+}
+
+function syncFullscreen(): void {
+  isFullscreen.value = Boolean(document.fullscreenElement)
+}
+
+function close(): void {
+  if (import.meta.client && document.fullscreenElement) {
+    void document.exitFullscreen().catch(() => undefined)
+  }
+  emit('close')
+}
+
+function handleKeydown(event: KeyboardEvent): void {
+  const target = event.target as HTMLElement | null
+  if (target && ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName)) return
+
+  switch (event.key) {
+    case ' ':
+    case 'Spacebar':
+      event.preventDefault()
+      togglePlaying()
+      break
+    case 'ArrowRight':
+    case 'n':
+      event.preventDefault()
+      nextSlide()
+      break
+    case 'ArrowLeft':
+    case 'p':
+      event.preventDefault()
+      previousSlide()
+      break
+    case 'i':
+      toggleAllOverlay()
+      break
+    case 'f':
+      void toggleFullscreen()
+      break
+    case 's':
+      settingsOpen.value = !settingsOpen.value
+      break
+    case 'Escape':
+      if (document.fullscreenElement) return
+      close()
+      break
+    default:
+      break
+  }
+  wakeChrome()
+}
+
+watch(
+  () => slideshowStore.pendingArrivalCount,
+  (count, previous) => {
+    if (!count || previous !== 0 || !interruptOnArrival.value) return
+    advanceSlide()
+  },
+)
+
+watch(settingsOpen, (open) => {
+  if (open) wakeChrome()
+})
+
+watch(canShowSlide, (viewable) => {
+  if (!viewable && slideshowStore.pool.length > 1) advanceSlide()
+})
+
+onMounted(async () => {
+  slideshowStore.initialize()
+  intervalInput.value = slideshowStore.settings.intervalSeconds
+  window.addEventListener('keydown', handleKeydown)
+  document.addEventListener('fullscreenchange', syncFullscreen)
+
+  await toggleFullscreen()
+  syncFullscreen()
+  wakeChrome()
+
+  await slideshowStore.refreshPool()
+  if (!isViewable(currentJob.value)) advanceSlide()
+  void loadProtectedSlide()
+
+  tickTimer = setInterval(() => {
+    if (!isPlaying.value) return
+    elapsedMs.value += TICK_MS
+    if (elapsedMs.value >= intervalSeconds.value * 1000) advanceSlide()
+  }, TICK_MS)
+
+  arrivalTimer = setInterval(() => {
+    void slideshowStore.pollArrivals()
+  }, ARRIVAL_POLL_MS)
+
+  poolTimer = setInterval(() => {
+    void slideshowStore.refreshPool()
+  }, POOL_REFRESH_MS)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', handleKeydown)
+  document.removeEventListener('fullscreenchange', syncFullscreen)
+  if (tickTimer) clearInterval(tickTimer)
+  if (arrivalTimer) clearInterval(arrivalTimer)
+  if (poolTimer) clearInterval(poolTimer)
+  if (chromeTimer) clearTimeout(chromeTimer)
+  if (arrivalFlashTimer) clearTimeout(arrivalFlashTimer)
+})
+</script>
+
+<style scoped>
+.kr-slideshow-fade-enter-active,
+.kr-slideshow-fade-leave-active {
+  transition: opacity 400ms ease;
+}
+
+.kr-slideshow-fade-enter-from,
+.kr-slideshow-fade-leave-to {
+  opacity: 0;
+}
+
+.kr-slideshow-slide-enter-active,
+.kr-slideshow-slide-leave-active {
+  transition: transform 200ms ease;
+}
+
+.kr-slideshow-slide-enter-from,
+.kr-slideshow-slide-leave-to {
+  transform: translateX(100%);
+}
+</style>

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "test:facet-closure": "tsx utils/scripts/verifyFacetClosure.ts",
     "test:facet-gallery": "tsx utils/scripts/verifyFacetGallery.ts",
     "test:layout-contract": "tsx utils/scripts/verifyLayoutContract.ts",
+    "test:art-slideshow-rotation": "tsx utils/scripts/verifyArtSlideshowRotation.test.ts",
     "audit:responsive": "node utils/scripts/auditResponsiveLayout.mjs",
     "test:daily-dream-facets": "prisma validate && tsx utils/scripts/verifyDailyDreamFacets.ts",
     "test:prompt-variants": "tsx utils/scripts/verifyPromptVariants.ts",

--- a/stores/artJobStore.ts
+++ b/stores/artJobStore.ts
@@ -5,14 +5,10 @@ import type { ArtImage, ArtJob, Prisma } from '~/prisma/generated/prisma/client'
 import { performFetch } from '@/stores/utils'
 import { resolveArtImageSource } from '~/utils/artImageSource'
 import type { ArtImageSource } from '~/utils/artImageSource'
-import { resolveMaturityPrivacy } from '~/utils/maturityPrivacy'
+import { artJobImageVersion, artJobPublicImageSrc } from '~/utils/artJobFields'
 
 export type ArtJobStatus =
-  | 'PENDING'
-  | 'RUNNING'
-  | 'DONE'
-  | 'FAILED'
-  | 'CANCELLED'
+  'PENDING' | 'RUNNING' | 'DONE' | 'FAILED' | 'CANCELLED'
 
 export type ArtJobRetryMode = 'NEW_OUTPUT' | 'OVERWRITE'
 
@@ -194,16 +190,9 @@ type ArtJobState = {
 const DEFAULT_JOB_PAGE_SIZE = 20
 const MAX_JOB_PAGE_SIZE = 100
 
-type JsonRecord = Record<string, unknown>
-
 function normalizePageSize(value: number): number {
   if (!Number.isFinite(value)) return DEFAULT_JOB_PAGE_SIZE
   return Math.min(Math.max(Math.floor(value), 1), MAX_JOB_PAGE_SIZE)
-}
-
-function asRecord(value: unknown): JsonRecord {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
-  return value as JsonRecord
 }
 
 export const useArtJobStore = defineStore('artJobStore', () => {
@@ -240,22 +229,13 @@ export const useArtJobStore = defineStore('artJobStore', () => {
   function cachePublicImageUrls(jobs: ArtJobRecord[]): void {
     for (const job of jobs) {
       if (typeof job.artImageId !== 'number') continue
-      const visibility = resolveMaturityPrivacy(
-        asRecord(asRecord(job.payload).save),
-      )
-      if (!visibility.isPublic || visibility.isMature) continue
+      const src = artJobPublicImageSrc(job)
+      if (!src) continue
 
-      // updatedAt is DateTime? in the schema. Same guard as
-      // artjob-queue-card.vue: a null timestamp simply means no cache-buster.
-      const updatedAt = job.updatedAt
-        ? new Date(job.updatedAt).getTime()
-        : Number.NaN
-      const version = Number.isFinite(updatedAt) ? `?v=${updatedAt}` : ''
-      const src = `/api/art/images/${job.artImageId}/file${version}`
       const info = resolveArtImageSource({ imagePath: src, fileType: 'webp' })
       state.imageSrcById[job.artImageId] = src
       state.imageInfoById[job.artImageId] = info
-      state.imageVersionById[job.artImageId] = version
+      state.imageVersionById[job.artImageId] = artJobImageVersion(job)
     }
   }
 
@@ -650,6 +630,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
 
   return {
     ...toRefs(state),
+    cachePublicImageUrls,
     fetchStats,
     fetchUptime,
     fetchJobs,

--- a/stores/artSlideshowStore.ts
+++ b/stores/artSlideshowStore.ts
@@ -1,0 +1,339 @@
+// /stores/artSlideshowStore.ts
+import { defineStore } from 'pinia'
+import { computed, reactive, toRefs } from 'vue'
+import { performFetch } from '@/stores/utils'
+import { useArtJobStore, type ArtJobRecord } from '@/stores/artJobStore'
+import {
+  mergeSlideshowPool,
+  pickRandomJobId,
+  rememberShownId,
+  unseenJobIds,
+} from '~/utils/artSlideshowRotation'
+
+export type SlideshowFitMode = 'contain' | 'cover'
+
+export type SlideshowOverlayField =
+  'title' | 'fileName' | 'prompt' | 'settings' | 'timestamp' | 'progress'
+
+export type SlideshowSettings = {
+  depth: number
+  intervalSeconds: number
+  fitMode: SlideshowFitMode
+  interruptOnArrival: boolean
+  overlay: Record<SlideshowOverlayField, boolean>
+}
+
+type ArtSlideshowState = {
+  pool: ArtJobRecord[]
+  seenIds: number[]
+  freshIds: number[]
+  history: number[]
+  currentId: number | null
+  loadingPool: boolean
+  pollingArrivals: boolean
+  error: string | null
+  initialized: boolean
+  settings: SlideshowSettings
+}
+
+export const SLIDESHOW_DEPTH_CHOICES = [12, 25, 50, 100, 200]
+export const SLIDESHOW_INTERVAL_CHOICES = [3, 5, 8, 12, 20, 30, 60]
+
+const MIN_DEPTH = 1
+const MAX_DEPTH = 200
+const MIN_INTERVAL_SECONDS = 1
+const MAX_INTERVAL_SECONDS = 600
+const ARRIVAL_HEAD_SIZE = 12
+const STORAGE_KEY = 'kr-artjob-slideshow'
+
+const DEFAULT_SETTINGS: SlideshowSettings = {
+  depth: 50,
+  intervalSeconds: 8,
+  fitMode: 'contain',
+  interruptOnArrival: true,
+  overlay: {
+    title: true,
+    fileName: true,
+    prompt: false,
+    settings: false,
+    timestamp: true,
+    progress: true,
+  },
+}
+
+const OVERLAY_FIELDS: SlideshowOverlayField[] = [
+  'title',
+  'fileName',
+  'prompt',
+  'settings',
+  'timestamp',
+  'progress',
+]
+
+function clampInteger(
+  value: unknown,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return fallback
+  return Math.min(Math.max(Math.round(parsed), min), max)
+}
+
+function sanitizeSettings(value: unknown): SlideshowSettings {
+  const source =
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {}
+  const overlaySource =
+    source.overlay &&
+    typeof source.overlay === 'object' &&
+    !Array.isArray(source.overlay)
+      ? (source.overlay as Record<string, unknown>)
+      : {}
+
+  const overlay = {} as Record<SlideshowOverlayField, boolean>
+  for (const field of OVERLAY_FIELDS) {
+    const stored = overlaySource[field]
+    overlay[field] =
+      typeof stored === 'boolean' ? stored : DEFAULT_SETTINGS.overlay[field]
+  }
+
+  return {
+    depth: clampInteger(
+      source.depth,
+      MIN_DEPTH,
+      MAX_DEPTH,
+      DEFAULT_SETTINGS.depth,
+    ),
+    intervalSeconds: clampInteger(
+      source.intervalSeconds,
+      MIN_INTERVAL_SECONDS,
+      MAX_INTERVAL_SECONDS,
+      DEFAULT_SETTINGS.intervalSeconds,
+    ),
+    fitMode: source.fitMode === 'cover' ? 'cover' : 'contain',
+    interruptOnArrival:
+      typeof source.interruptOnArrival === 'boolean'
+        ? source.interruptOnArrival
+        : DEFAULT_SETTINGS.interruptOnArrival,
+    overlay,
+  }
+}
+
+export const useArtSlideshowStore = defineStore('artSlideshowStore', () => {
+  const state = reactive<ArtSlideshowState>({
+    pool: [],
+    seenIds: [],
+    freshIds: [],
+    history: [],
+    currentId: null,
+    loadingPool: false,
+    pollingArrivals: false,
+    error: null,
+    initialized: false,
+    settings: sanitizeSettings(null),
+  })
+
+  const poolIds = computed<number[]>(() => state.pool.map((job) => job.id))
+
+  const currentJob = computed<ArtJobRecord | null>(
+    () => state.pool.find((job) => job.id === state.currentId) ?? null,
+  )
+
+  const currentIndex = computed<number>(() =>
+    state.currentId === null
+      ? -1
+      : state.pool.findIndex((job) => job.id === state.currentId),
+  )
+
+  const hasPreviousSlide = computed<boolean>(() => state.history.length > 1)
+
+  const pendingArrivalCount = computed<number>(() => state.freshIds.length)
+
+  function persist(): void {
+    if (!import.meta.client || !state.initialized) return
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state.settings))
+    } catch {
+      return
+    }
+  }
+
+  function initialize(): void {
+    if (!import.meta.client || state.initialized) return
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      state.settings = sanitizeSettings(stored ? JSON.parse(stored) : null)
+    } catch {
+      state.settings = sanitizeSettings(null)
+    }
+    state.initialized = true
+  }
+
+  function ingest(jobs: ArtJobRecord[], seedAsSeen: boolean): void {
+    const renderable = jobs.filter((job) => typeof job.artImageId === 'number')
+    const arrivals = seedAsSeen ? [] : unseenJobIds(state.seenIds, renderable)
+
+    state.pool = mergeSlideshowPool(
+      state.pool,
+      renderable,
+      state.settings.depth,
+    )
+    state.seenIds = [
+      ...new Set([...state.seenIds, ...renderable.map((job) => job.id)]),
+    ]
+    if (arrivals.length) state.freshIds = [...state.freshIds, ...arrivals]
+
+    useArtJobStore().cachePublicImageUrls(renderable)
+  }
+
+  async function fetchDoneJobs(
+    pageSize: number,
+  ): Promise<ArtJobRecord[] | null> {
+    const params = new URLSearchParams({
+      status: 'DONE',
+      page: '1',
+      pageSize: String(pageSize),
+    })
+    const res = await performFetch<{ jobs: ArtJobRecord[] }>(
+      `/api/art/queue?${params.toString()}`,
+    )
+    if (!res.success || !res.data) {
+      state.error = res.message || 'Failed to load finished art.'
+      return null
+    }
+    state.error = null
+    return res.data.jobs
+  }
+
+  /**
+   * Reload the whole depth window. This never announces arrivals: raising the
+   * depth pulls in jobs that finished hours ago, and treating those as "new"
+   * would queue the entire widened window as cut-to-front slides. Genuinely new
+   * renders come from pollArrivals, which watches the head of the queue.
+   */
+  async function refreshPool(): Promise<void> {
+    if (state.loadingPool) return
+    state.loadingPool = true
+    try {
+      const jobs = await fetchDoneJobs(state.settings.depth)
+      if (!jobs) return
+      ingest(jobs, true)
+      if (state.currentId === null) advance()
+    } finally {
+      state.loadingPool = false
+    }
+  }
+
+  async function pollArrivals(): Promise<void> {
+    if (state.pollingArrivals || state.loadingPool) return
+    state.pollingArrivals = true
+    try {
+      const jobs = await fetchDoneJobs(ARRIVAL_HEAD_SIZE)
+      if (!jobs) return
+      ingest(jobs, !state.seenIds.length)
+    } finally {
+      state.pollingArrivals = false
+    }
+  }
+
+  function show(id: number | null): void {
+    if (id === null) return
+    state.currentId = id
+    state.history = rememberShownId(state.history, id)
+  }
+
+  function advance(): void {
+    const fresh = state.freshIds[0]
+    if (typeof fresh === 'number') {
+      state.freshIds = state.freshIds.slice(1)
+      show(fresh)
+      return
+    }
+    show(pickRandomJobId(poolIds.value, state.history))
+  }
+
+  function stepBack(): void {
+    if (state.history.length < 2) return
+    const trimmed = state.history.slice(0, -1)
+    state.history = trimmed
+    state.currentId = trimmed[trimmed.length - 1] ?? null
+  }
+
+  async function setDepth(depth: number): Promise<void> {
+    const next = clampInteger(
+      depth,
+      MIN_DEPTH,
+      MAX_DEPTH,
+      DEFAULT_SETTINGS.depth,
+    )
+    if (next === state.settings.depth) return
+    state.settings.depth = next
+    persist()
+    state.pool = mergeSlideshowPool(state.pool, [], next)
+    await refreshPool()
+  }
+
+  function setIntervalSeconds(seconds: number): void {
+    state.settings.intervalSeconds = clampInteger(
+      seconds,
+      MIN_INTERVAL_SECONDS,
+      MAX_INTERVAL_SECONDS,
+      DEFAULT_SETTINGS.intervalSeconds,
+    )
+    persist()
+  }
+
+  function setFitMode(mode: SlideshowFitMode): void {
+    state.settings.fitMode = mode === 'cover' ? 'cover' : 'contain'
+    persist()
+  }
+
+  function setInterruptOnArrival(value: boolean): void {
+    state.settings.interruptOnArrival = value
+    persist()
+  }
+
+  function setOverlayField(field: SlideshowOverlayField, value: boolean): void {
+    state.settings.overlay[field] = value
+    persist()
+  }
+
+  function setAllOverlayFields(value: boolean): void {
+    for (const field of OVERLAY_FIELDS) state.settings.overlay[field] = value
+    persist()
+  }
+
+  function reset(): void {
+    state.pool = []
+    state.seenIds = []
+    state.freshIds = []
+    state.history = []
+    state.currentId = null
+    state.error = null
+  }
+
+  return {
+    ...toRefs(state),
+    poolIds,
+    currentJob,
+    currentIndex,
+    hasPreviousSlide,
+    pendingArrivalCount,
+    initialize,
+    refreshPool,
+    pollArrivals,
+    advance,
+    stepBack,
+    show,
+    setDepth,
+    setIntervalSeconds,
+    setFitMode,
+    setInterruptOnArrival,
+    setOverlayField,
+    setAllOverlayFields,
+    reset,
+  }
+})

--- a/utils/artJobFields.ts
+++ b/utils/artJobFields.ts
@@ -1,0 +1,229 @@
+// /utils/artJobFields.ts
+//
+// One reader for the loosely-shaped ArtJob.payload blob.
+//
+// A job's brief arrives from several producers (the generator, kr-relay's
+// ComfyUI workflow graph, the conductor art-request path), so the same fact
+// lives under a different key depending on who queued it: a prompt is
+// `promptString`, `artPrompt`, `positivePrompt`, `prompt`, or only the `text`
+// input of a CLIP node buried in `workflow`. artjob-queue-card.vue grew a set
+// of tolerant readers for exactly this, and every new surface that renders a
+// job (the slideshow, next time something else) would otherwise copy them --
+// the near-duplicate pattern AGENTS.md calls out as this codebase's
+// highest-risk shape. These are those readers, extracted verbatim in behaviour.
+//
+// Structurally typed on purpose: no Prisma or Pinia import, so this stays a
+// pure util that both components and stores can call without a cycle.
+import { resolveMaturityPrivacy } from './maturityPrivacy'
+import type { MaturityPrivacy } from './maturityPrivacy'
+
+export type ArtJobFieldsSource = {
+  id: number
+  payload?: unknown
+  projectSlug?: string | null
+  artImageId?: number | null
+  updatedAt?: Date | string | null
+}
+
+type JsonRecord = Record<string, unknown>
+
+export function asRecord(value: unknown): JsonRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as JsonRecord
+}
+
+function scalar(value: unknown): string {
+  if (typeof value === 'string') return value.trim()
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  return ''
+}
+
+function nestedScalar(value: unknown, keys: string[], depth = 0): string {
+  if (depth > 6 || value === null || value === undefined) return ''
+  if (Array.isArray(value)) {
+    for (const child of value) {
+      const result = nestedScalar(child, keys, depth + 1)
+      if (result) return result
+    }
+    return ''
+  }
+
+  const record = asRecord(value)
+  for (const key of keys) {
+    const direct = scalar(record[key])
+    if (direct) return direct
+  }
+  for (const child of Object.values(record)) {
+    const result = nestedScalar(child, keys, depth + 1)
+    if (result) return result
+  }
+  return ''
+}
+
+export function directPayloadScalar(
+  job: ArtJobFieldsSource,
+  keys: string[],
+): string {
+  const payload = asRecord(job.payload)
+  for (const key of keys) {
+    const value = scalar(payload[key])
+    if (value) return value
+  }
+  return ''
+}
+
+export function payloadScalar(job: ArtJobFieldsSource, keys: string[]): string {
+  const direct = directPayloadScalar(job, keys)
+  if (direct) return direct
+  return nestedScalar(asRecord(job.payload).workflow, keys)
+}
+
+export function workflowPrompt(
+  job: ArtJobFieldsSource,
+  kind: 'positive' | 'negative',
+): string {
+  const workflow = asRecord(asRecord(job.payload).workflow)
+  for (const value of Object.values(workflow)) {
+    const node = asRecord(value)
+    const classType = scalar(node.class_type).toLowerCase()
+    const inputs = asRecord(node.inputs)
+    const title = scalar(asRecord(node._meta).title).toLowerCase()
+    const isNegative = title.includes('negative')
+    if (kind === 'negative' && !isNegative) continue
+    if (kind === 'positive' && isNegative) continue
+    if (!classType.includes('clip') && !classType.includes('wildcard')) continue
+    const text =
+      scalar(inputs.text) ||
+      scalar(inputs.wildcard_text) ||
+      scalar(inputs.populated_text) ||
+      scalar(inputs.t5xxl) ||
+      scalar(inputs.clip_l)
+    if (text) return text
+  }
+  return ''
+}
+
+export function artJobPrompt(job: ArtJobFieldsSource): string {
+  return (
+    payloadScalar(job, [
+      'promptString',
+      'artPrompt',
+      'positivePrompt',
+      'prompt',
+    ]) || workflowPrompt(job, 'positive')
+  )
+}
+
+export function artJobNegativePrompt(job: ArtJobFieldsSource): string {
+  return (
+    payloadScalar(job, ['negativePrompt', 'negative_prompt', 'negative']) ||
+    workflowPrompt(job, 'negative')
+  )
+}
+
+export function artJobTitle(job: ArtJobFieldsSource): string {
+  return (
+    directPayloadScalar(job, ['title', 'label', 'name']) ||
+    job.projectSlug ||
+    `ArtJob #${job.id}`
+  )
+}
+
+export function artJobPage(job: ArtJobFieldsSource): string {
+  return directPayloadScalar(job, [
+    'page',
+    'pagePath',
+    'route',
+    'destinationPage',
+  ])
+}
+
+export function artJobPageLabel(job: ArtJobFieldsSource): string {
+  const page = artJobPage(job)
+  if (!page) return ''
+  if (page === 'index' || page === 'home') return '/'
+  return page.startsWith('/') ? page : `/${page}`
+}
+
+export function artJobVariant(job: ArtJobFieldsSource): string {
+  return directPayloadScalar(job, ['variant', 'breakpoint'])
+}
+
+export function artJobRequestId(job: ArtJobFieldsSource): string {
+  return directPayloadScalar(job, ['requestId', 'requestID', 'request_id'])
+}
+
+export function artJobImagePath(job: ArtJobFieldsSource): string {
+  return directPayloadScalar(job, [
+    'imagePath',
+    'outputPath',
+    'destinationPath',
+  ])
+}
+
+/** Trailing path segment of the job's destination path, query/hash stripped. */
+export function artJobFileName(job: ArtJobFieldsSource): string {
+  const path = artJobImagePath(job)
+  if (!path) return ''
+  const bare = path.split(/[?#]/)[0] || ''
+  const segments = bare.split('/').filter(Boolean)
+  return segments[segments.length - 1] || ''
+}
+
+export function artJobSettings(job: ArtJobFieldsSource): string[] {
+  const values: Array<[string, string]> = [
+    [
+      'size',
+      `${payloadScalar(job, ['width'])}×${payloadScalar(job, ['height'])}`,
+    ],
+    [
+      'model',
+      payloadScalar(job, [
+        'checkpoint',
+        'ckpt_name',
+        'unet_name',
+        'model_name',
+      ]),
+    ],
+    ['sampler', payloadScalar(job, ['sampler', 'sampler_name'])],
+    ['scheduler', payloadScalar(job, ['scheduler'])],
+    ['steps', payloadScalar(job, ['steps'])],
+    ['cfg', payloadScalar(job, ['cfg', 'cfg_scale'])],
+    ['guidance', payloadScalar(job, ['guidance'])],
+    ['denoise', payloadScalar(job, ['denoise'])],
+    ['seed', payloadScalar(job, ['seed', 'noise_seed'])],
+  ]
+
+  return values
+    .filter(([, value]) => value && value !== '×')
+    .map(([label, value]) => `${label}: ${value}`)
+}
+
+export function artJobVisibility(job: ArtJobFieldsSource): MaturityPrivacy {
+  return resolveMaturityPrivacy(asRecord(asRecord(job.payload).save))
+}
+
+/**
+ * Cache-buster derived from the job's own updatedAt. updatedAt is DateTime? in
+ * the schema, so a null timestamp simply means no cache-buster. An OVERWRITE
+ * retry replaces the bytes of an existing ArtImage id in place, so the id alone
+ * is not a safe cache key -- this version string is what makes it one.
+ */
+export function artJobImageVersion(job: ArtJobFieldsSource): string {
+  const updatedAt = job.updatedAt
+    ? new Date(job.updatedAt).getTime()
+    : Number.NaN
+  return Number.isFinite(updatedAt) ? `?v=${updatedAt}` : ''
+}
+
+/**
+ * The unauthenticated file URL for a finished job, or '' when the job's own
+ * visibility says the bytes need the protected preview route instead.
+ */
+export function artJobPublicImageSrc(job: ArtJobFieldsSource): string {
+  const id = job.artImageId
+  if (typeof id !== 'number') return ''
+  const visibility = artJobVisibility(job)
+  if (!visibility.isPublic || visibility.isMature) return ''
+  return `/api/art/images/${id}/file${artJobImageVersion(job)}`
+}

--- a/utils/artSlideshowRotation.ts
+++ b/utils/artSlideshowRotation.ts
@@ -1,0 +1,107 @@
+// /utils/artSlideshowRotation.ts
+//
+// The pure half of the ArtJob slideshow: which finished render comes next.
+//
+// Two things drive the rotation and they pull in opposite directions. New art
+// should appear as soon as it finishes -- that is the whole point of leaving
+// the slideshow running next to the queue -- while everything else is a random
+// draw from the last N finished jobs, so a long watch doesn't just replay the
+// same handful. Keeping the arithmetic here (rather than inside the store's
+// reactive state) means the awkward cases are testable without a Pinia
+// instance: see utils/scripts/verifyArtSlideshowRotation.test.ts.
+//
+// WHY ARRIVALS ARE TRACKED BY SET MEMBERSHIP, NOT BY MAX ID
+// A "newest id wins" watermark looks equivalent and isn't. Jobs finish out of
+// order -- a slow job queued this morning can reach DONE after one queued five
+// minutes ago -- so the older id would land below the watermark and never be
+// announced. Membership in the seen set is the only test that survives that.
+
+export type SlideshowJobLike = { id: number }
+
+/** Ceiling on the no-repeat window, so a small pool still rotates at all. */
+export function historyLimit(poolSize: number): number {
+  if (poolSize <= 1) return 0
+  return Math.min(poolSize - 1, 25)
+}
+
+/**
+ * Fold freshly fetched rows into the pool: same-id rows are replaced (a retry
+ * can rewrite a job's payload under a stable id), the result is ordered newest
+ * id first, and anything past `depth` falls off the end.
+ */
+export function mergeSlideshowPool<T extends SlideshowJobLike>(
+  pool: readonly T[],
+  incoming: readonly T[],
+  depth: number,
+): T[] {
+  const byId = new Map<number, T>()
+  for (const job of pool) byId.set(job.id, job)
+  for (const job of incoming) byId.set(job.id, job)
+
+  const merged = [...byId.values()].sort((a, b) => b.id - a.id)
+  const limit = Math.max(1, Math.floor(depth))
+  return merged.slice(0, limit)
+}
+
+/**
+ * Ids in `incoming` the slideshow has never held, oldest first so they play in
+ * the order they finished rather than newest-first as the API returns them.
+ */
+export function unseenJobIds(
+  seenIds: Iterable<number>,
+  incoming: readonly SlideshowJobLike[],
+): number[] {
+  const seen = new Set(seenIds)
+  const fresh: number[] = []
+  for (const job of incoming) {
+    if (seen.has(job.id)) continue
+    seen.add(job.id)
+    fresh.push(job.id)
+  }
+  return fresh.reverse()
+}
+
+/**
+ * A random id from the pool that hasn't been shown recently.
+ *
+ * `recentIds` is the no-repeat window, most recent last. Once the window covers
+ * everything available the draw falls back to the whole pool minus whatever is
+ * on screen right now, which is what keeps a two-image pool alternating instead
+ * of stalling on one frame.
+ */
+export function pickRandomJobId(
+  poolIds: readonly number[],
+  recentIds: readonly number[],
+  random: () => number = Math.random,
+): number | null {
+  if (!poolIds.length) return null
+  if (poolIds.length === 1) return poolIds[0] ?? null
+
+  const window = recentIds.slice(-historyLimit(poolIds.length))
+  const blocked = new Set(window)
+  let candidates = poolIds.filter((id) => !blocked.has(id))
+
+  if (!candidates.length) {
+    const current = recentIds[recentIds.length - 1]
+    candidates = poolIds.filter((id) => id !== current)
+  }
+  if (!candidates.length) candidates = [...poolIds]
+
+  const roll = random()
+  const safeRoll = Number.isFinite(roll)
+    ? Math.min(Math.max(roll, 0), 0.999999)
+    : 0
+  const index = Math.floor(safeRoll * candidates.length)
+  return candidates[index] ?? candidates[0] ?? null
+}
+
+/** Append a shown id to the history tail, capped so it can't grow unbounded. */
+export function rememberShownId(
+  history: readonly number[],
+  id: number,
+  cap = 50,
+): number[] {
+  const next = [...history, id]
+  const limit = Math.max(1, Math.floor(cap))
+  return next.length > limit ? next.slice(next.length - limit) : next
+}

--- a/utils/scripts/verifyArtSlideshowRotation.test.ts
+++ b/utils/scripts/verifyArtSlideshowRotation.test.ts
@@ -1,0 +1,140 @@
+// /utils/scripts/verifyArtSlideshowRotation.test.ts
+//
+// Self-test for utils/artSlideshowRotation.ts -- the pure "what plays next"
+// arithmetic behind the fullscreen ArtJob slideshow.
+//
+// The cases that matter here are the ones a hand-check misses: a job that
+// reaches DONE out of id order (so a max-id watermark would swallow it), a
+// pool smaller than the no-repeat window (so a naive exclusion leaves no
+// candidate and the slideshow freezes), and a depth reduction that has to drop
+// the oldest rows rather than the newest.
+import assert from 'node:assert/strict'
+
+import {
+  historyLimit,
+  mergeSlideshowPool,
+  pickRandomJobId,
+  rememberShownId,
+  unseenJobIds,
+} from '../artSlideshowRotation.js'
+
+function job(id: number, tag = ''): { id: number; tag: string } {
+  return { id, tag }
+}
+
+function run(): void {
+  // --- mergeSlideshowPool ---
+  const merged = mergeSlideshowPool([job(3), job(1)], [job(4), job(2)], 10)
+  assert.deepEqual(
+    merged.map((entry) => entry.id),
+    [4, 3, 2, 1],
+    'merged pool is ordered newest id first',
+  )
+
+  const replaced = mergeSlideshowPool([job(2, 'stale')], [job(2, 'fresh')], 10)
+  assert.equal(replaced.length, 1, 'a re-fetched id does not duplicate')
+  assert.equal(
+    replaced[0]?.tag,
+    'fresh',
+    'the incoming row wins on id collision',
+  )
+
+  const trimmed = mergeSlideshowPool([job(1), job(2), job(3)], [job(4)], 2)
+  assert.deepEqual(
+    trimmed.map((entry) => entry.id),
+    [4, 3],
+    'depth trims the oldest rows, not the newest',
+  )
+  assert.equal(
+    mergeSlideshowPool([job(1), job(2)], [], 0).length,
+    1,
+    'a nonsense depth still leaves one slide rather than an empty pool',
+  )
+
+  // --- unseenJobIds ---
+  assert.deepEqual(
+    unseenJobIds([5, 4], [job(7), job(6), job(5), job(4)]),
+    [6, 7],
+    'new arrivals come back oldest first so they play in finish order',
+  )
+  assert.deepEqual(
+    unseenJobIds([9, 8, 7], [job(9), job(8)]),
+    [],
+    'a poll with nothing new announces nothing',
+  )
+  assert.deepEqual(
+    unseenJobIds([9], [job(9), job(3)]),
+    [3],
+    'a job that finishes out of id order is still announced (no max-id watermark)',
+  )
+  assert.deepEqual(
+    unseenJobIds([], [job(2), job(2)]),
+    [2],
+    'a duplicated row in one response is announced once',
+  )
+
+  // --- pickRandomJobId ---
+  assert.equal(
+    pickRandomJobId([], [], () => 0),
+    null,
+    'an empty pool picks nothing',
+  )
+  assert.equal(
+    pickRandomJobId([11], [11], () => 0),
+    11,
+    'a single-image pool keeps showing its one image',
+  )
+  assert.equal(
+    pickRandomJobId([11, 12], [12], () => 0),
+    11,
+    'a two-image pool alternates instead of repeating',
+  )
+  assert.equal(
+    pickRandomJobId([11, 12], [11, 12], () => 0),
+    11,
+    'an exhausted no-repeat window falls back to everything but the current slide',
+  )
+  assert.equal(
+    pickRandomJobId([1, 2, 3, 4], [4], () => 0.99),
+    3,
+    'a roll of ~1 lands on the last candidate rather than past the end',
+  )
+  assert.equal(
+    pickRandomJobId([1, 2, 3], [], () => Number.NaN),
+    1,
+    'a broken random source still yields a slide',
+  )
+
+  const draws = new Set<number>()
+  for (const roll of [0, 0.25, 0.5, 0.75, 0.99]) {
+    const picked = pickRandomJobId([1, 2, 3, 4, 5], [], () => roll)
+    assert.ok(picked !== null, 'every roll yields a slide')
+    draws.add(picked as number)
+  }
+  assert.equal(draws.size, 5, 'the draw spreads across the whole pool')
+
+  // --- historyLimit / rememberShownId ---
+  assert.equal(historyLimit(1), 0, 'a one-image pool blocks nothing')
+  assert.equal(historyLimit(4), 3, 'a small pool blocks all but one')
+  assert.equal(historyLimit(500), 25, 'the no-repeat window is capped')
+
+  assert.deepEqual(rememberShownId([1, 2], 3), [1, 2, 3])
+  assert.deepEqual(
+    rememberShownId([1, 2, 3], 4, 3),
+    [2, 3, 4],
+    'history is capped from the front',
+  )
+  assert.deepEqual(
+    rememberShownId([1, 2, 3], 4, 0),
+    [4],
+    'a nonsense cap keeps at least the current slide',
+  )
+
+  console.log(
+    'Art slideshow rotation self-test passed: pool merge/trim, out-of-order ' +
+      'arrival detection, no-repeat draw with small-pool fallback, and ' +
+      'history capping all behave.',
+  )
+}
+
+run()


### PR DESCRIPTION
Silas, 2026-08-28: *"realized with all our new art coming through, can I get a slideshow option, where I can just watch a slideshow of art that gets made, full screen in browser? It should be an extension of the artqueue, and have a timer, so it should show new art that comes in, but give random art from the finished queue (chosen depth) and options for showing file name or other info."*

## What this adds

A **Slideshow** button in the ArtJob queue header (Images → ArtJob → Queue). It opens a teleported `fixed inset-0` overlay that requests browser fullscreen on open.

- **Random draw at a chosen depth.** Slides come at random from the N most recent `DONE` jobs — 12 / 25 / 50 / 100 / 200 — with a no-repeat window (up to 25 back) so a long watch doesn't replay the same handful. Small pools fall back to "anything but what's on screen" instead of stalling.
- **New art cuts in.** The head of the queue is polled every 15s; a freshly finished render is shown as soon as it lands, badged *Fresh off the queue*. Toggle that off and it waits its turn at the next slide change instead. The full depth window refreshes every 5 minutes.
- **Timer.** 1–600s per slide (presets 3/5/8/12/20/30/60, plus a slider and a number field), with a progress bar, play/pause, and previous/next.
- **Caption toggles.** Each field is independent: title/project/engine, **file name and destination path**, prompt, model + generation settings, job id + finish time, timer bar. One key (`i`) hides or restores the whole caption for pure art mode.
- **Keyboard:** space play/pause · ← → previous/next · `i` caption · `f` fullscreen · `s` options · `esc` close. Chrome auto-hides after ~2.6s idle while playing.
- Settings persist to `localStorage` through the store.

Mature renders stay behind the account's existing `showMature` gate and are **skipped** rather than shown as blanks; protected outputs load through the same `artJobStore` preview path the queue cards already use. The overlay is admin-only by inheritance — it only exists inside the admin-gated queue browser.

## Two supporting extractions, not a third near-copy

AGENTS.md flags ArtJob routes/galleries as this repo's highest-risk near-duplicate area, so rather than copying the queue card's payload readers a third time:

- **`utils/artJobFields.ts`** — the tolerant `ArtJob.payload` readers `artjob-queue-card.vue` had grown locally (prompt/negative prompt incl. the ComfyUI workflow-graph fallback, title, destination path + file name, generation settings, visibility, public image URL and its `updatedAt` cache-buster). The card and `artJobStore.cachePublicImageUrls` now share them. The card loses ~200 lines and the ESLint ratchet drops **-57** problems.
- **`utils/artSlideshowRotation.ts`** — the pure "what plays next" arithmetic, so the awkward cases are testable without Pinia.

## Tests

`utils/scripts/verifyArtSlideshowRotation.test.ts`, wired into the **Contract Tests** workflow. It covers the cases a hand-check misses:

- a job that reaches `DONE` **out of id order** (a max-id watermark would silently swallow it — arrivals are tracked by set membership instead);
- a pool smaller than the no-repeat window (a naive exclusion leaves no candidate and the slideshow freezes);
- a depth reduction dropping the oldest rows rather than the newest;
- a roll of ~1.0 landing on the last candidate rather than past the end, and a `NaN` random source still yielding a slide.

## Verification

`vue-tsc --noEmit` clean (exit 0). `eslint` and `prettier --check` clean on every changed file. Green locally: layout-contract (unchanged at 209, no new violations), component-reachability (0 orphans), lint-ratchet (-57), maturity-privacy, no-promise-in-store-state, disabled-affordance, ui-tier-vocabulary, card-action, art-image-caching, gallery-adoption, gallery-consistency, workflow-paths, workflow-pipefail, nightly-workflows, and the new rotation self-test.

No route, channel, or tab was added — this hangs off the existing ArtJob queue surface, so nothing needs dashboard/tutorial registration or a `Project.liveUrl` change.

---
_Generated by [Claude Code](https://claude.ai/code/session_0127Ato4As7T9JGgF5TkGCKR)_