### PR TITLE
Home page, fourth pass: newsfeed resilience, a Needs-you column, project progress

### DIFF
--- a/components/home/home-attention.vue
+++ b/components/home/home-attention.vue
@@ -1,0 +1,106 @@
+<!-- /components/home/home-attention.vue -->
+<!--
+  The things waiting on Silas.
+
+  Silas, 2026-08-29: "Dream entry should take up less horizontal space to leave
+  room for a vertical notification scroll, especially things that I can answer
+  that are human gated."
+
+  NOTHING NEW WAS BUILT FOR THIS. conductorStore already computes `humanGates` --
+  every conductor task at `status: needs-human`, filtered to active and
+  continuous projects and sorted -- and conductorCards.ts already labels that
+  status "Needs You". It simply had no surface: grepping components for it
+  returned nothing before this file. The home page is the first place these are
+  visible without going looking, which is the whole complaint the redesign
+  started from.
+
+  LINKS, NOT INLINE APPROVE. /api/conductor/task-action takes approve, reject
+  and comment, so answering from here is possible and is the obvious next step.
+  It is deliberately not in this pass: approving writes to the coordination
+  system of record, and this sandbox has no database or live conductor data to
+  test that against. Shipping an untested one-click approve on a gate is a worse
+  outcome than one more click. Each row goes to /conductor with the project
+  open, where the existing controls live.
+
+  ADMIN-ONLY BY DATA, not by a check here: conductorStore only has gates when
+  the projection is readable, so a signed-out visitor sees the empty branch and
+  the column collapses out of the layout entirely.
+-->
+<template>
+  <section
+    v-if="gates.length || isLoading"
+    class="flex min-h-0 flex-col gap-1 kr-panel-flat p-2 lg:w-64 lg:shrink-0"
+  >
+    <header class="flex shrink-0 items-baseline justify-between gap-2">
+      <h2
+        class="text-[0.7rem] font-black uppercase tracking-[0.16em] text-primary"
+      >
+        Needs you
+        <span v-if="gates.length" class="text-base-content/40"
+          >· {{ gates.length }}</span
+        >
+      </h2>
+
+      <NuxtLink
+        to="/conductor"
+        class="link link-hover text-[0.7rem] font-bold text-base-content/50 hover:text-primary"
+      >
+        conductor →
+      </NuxtLink>
+    </header>
+
+    <!--
+      A bounded scroller, not an unbounded list: the gate count is unpredictable
+      (it has been twenty-plus) and this sits beside a fixed-height hero. The
+      layout contract's one-scroll rule deliberately does not count a `max-h-*`
+      region -- nested preview, not the page's scroll owner.
+    -->
+    <div
+      class="max-h-56 min-h-0 space-y-1 overflow-y-auto overscroll-contain pr-1"
+    >
+      <NuxtLink
+        v-for="gate in gates"
+        :key="`${gate.project.slug}-${gate.task.id}`"
+        :to="`/conductor?project=${encodeURIComponent(gate.project.slug)}`"
+        class="group block rounded-lg border border-base-300 bg-base-100 px-2 py-1.5 transition-colors hover:border-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+        :title="gate.task.title"
+      >
+        <p
+          class="truncate text-[0.6rem] font-black uppercase tracking-[0.12em] text-primary"
+        >
+          {{ gate.project.name || gate.project.slug }}
+        </p>
+        <p
+          class="line-clamp-2 text-[0.7rem] font-bold leading-snug text-base-content group-hover:text-primary"
+        >
+          {{ gate.task.title }}
+        </p>
+      </NuxtLink>
+
+      <p
+        v-if="isLoading && !gates.length"
+        class="px-1 py-2 text-[0.7rem] text-base-content/50"
+      >
+        Checking what's waiting…
+      </p>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useConductorStore } from '@/stores/conductorStore'
+
+const conductorStore = useConductorStore()
+
+const gates = computed(() => conductorStore.humanGates)
+const isLoading = computed(() => !conductorStore.hasLoaded)
+
+onMounted(() => {
+  /*
+   * fetchProjects is cached in the store (FRESH_DATA_MS), so this is a no-op
+   * when anything else on the session has already asked.
+   */
+  void conductorStore.fetchProjects()
+})
+</script>

--- a/components/home/home-dream-hero.vue
+++ b/components/home/home-dream-hero.vue
@@ -29,6 +29,17 @@
 <template>
   <section class="flex flex-col gap-2 kr-panel-flat p-3 lg:flex-row">
     <!--
+      NARROWER STILL, and it is the part that gives. Silas, 2026-08-29: "the
+      dream elements are matched according to the dream hero, and that leaves a
+      bunch of dead space, it would be better if the dream hero shrunk rather
+      than the others gained, to save room" -- and "Dream entry should take up
+      less horizontal space to leave room for a vertical notification scroll."
+
+      So the cast went back to square plates (portrait ones had made the CAST
+      set the band height, which is the reverse of what he asked for), and this
+      card is a fixed 11rem rather than a fifth of the page, freeing the width
+      the Needs-you column now occupies.
+
       ABOUT A FIFTH OF THE WIDTH, in its natural proportion. Silas, 2026-08-29:
       "Obviously the dream hero is horribly proportioned, It would be better to
       have something that fits about 20% width of screen, properly fitted
@@ -44,7 +55,7 @@
     -->
     <NuxtLink
       :to="showcaseHref(hero.dream)"
-      class="group flex shrink-0 flex-col gap-1 rounded-xl border-2 border-primary/70 bg-base-100 p-1.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:hover:-translate-y-0.5 lg:w-1/5"
+      class="group flex shrink-0 flex-col gap-1 rounded-xl border-2 border-primary/70 bg-base-100 p-1.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:hover:-translate-y-0.5 lg:w-44"
     >
       <kr-art-plate
         :source="hero.dream.art"
@@ -71,7 +82,7 @@
 
         <p
           v-if="hero.hook"
-          class="mt-0.5 line-clamp-2 text-[0.7rem] leading-snug text-base-content/65"
+          class="mt-0.5 line-clamp-1 text-[0.7rem] leading-snug text-base-content/65"
         >
           {{ hero.hook }}
         </p>
@@ -120,7 +131,7 @@
         <kr-art-plate
           :source="member.art"
           variant="card"
-          shape="card"
+          shape="square"
           frame="none"
           :alt="member.title"
           :fallback="fallbackFor(member)"

--- a/components/home/home-page.vue
+++ b/components/home/home-page.vue
@@ -49,13 +49,27 @@
       {{ showcaseStore.errorMessage }}
     </div>
 
-    <home-dream-hero v-if="showcaseStore.hero" :hero="showcaseStore.hero" />
+    <!--
+      The top band is the dream, its cast, and whatever is waiting on Silas.
+      He asked for the dream to give up horizontal space for the third
+      (2026-08-29: "Dream entry should take up less horizontal space to leave
+      room for a vertical notification scroll").
+    -->
+    <div class="flex flex-col gap-2 lg:flex-row lg:items-stretch">
+      <home-dream-hero
+        v-if="showcaseStore.hero"
+        class="min-w-0 lg:flex-1"
+        :hero="showcaseStore.hero"
+      />
 
-    <div
-      v-else-if="!showcaseStore.hasLoaded"
-      class="h-48 w-full animate-pulse rounded-2xl bg-base-200 lg:h-64"
-      aria-hidden="true"
-    />
+      <div
+        v-else-if="!showcaseStore.hasLoaded"
+        class="h-40 w-full animate-pulse rounded-2xl bg-base-200 lg:flex-1"
+        aria-hidden="true"
+      />
+
+      <home-attention />
+    </div>
 
     <!--
       The rails. `auto-rows-fr` so neighbouring shelves in a row share a height
@@ -77,6 +91,7 @@
         :plate-variant="entry.plateVariant"
         :placeholder-icon="entry.placeholderIcon"
         :rows="entry.rows ?? 1"
+        :fit="entry.fit ?? 'cover'"
       />
     </div>
 
@@ -138,34 +153,55 @@
             />
           </div>
 
-          <div class="min-w-0 flex-1">
-            <p class="flex items-center gap-1">
-              <span
-                class="truncate text-xs font-black group-hover:text-primary"
-                :title="project.title"
-              >
-                {{ project.title }}
-              </span>
-              <span
-                v-if="project.badge"
-                class="badge badge-primary badge-xs shrink-0 font-bold"
-              >
-                {{ project.badge }}
-              </span>
-            </p>
-            <p
-              v-if="project.subtitle"
-              class="truncate text-[0.65rem] text-base-content/55"
-              :title="project.subtitle"
-            >
-              {{ project.subtitle }}
-            </p>
-          </div>
+          <!--
+            Silas, 2026-08-29: "project titles are still getting cut off ...
+            they are the most important part, and we should see progress
+            indicator, the priority rating could be a simple single letter.
+            description is not needed, these are things I'm well aquainted
+            with." So the description is gone, the priority is one glyph, and
+            everything the title was competing with for width went with them.
 
-          <Icon
-            name="kind-icon:chevron-right"
-            class="size-3.5 shrink-0 text-base-content/30 group-hover:text-primary"
-          />
+            Progress comes from conductorStore, which already computes it per
+            project; the two are joined on conductorSlug.
+          -->
+          <div class="min-w-0 flex-1">
+            <p
+              class="truncate text-xs font-black leading-tight group-hover:text-primary"
+              :title="project.title"
+            >
+              {{ project.title }}
+            </p>
+
+            <div class="mt-1 flex items-center gap-1.5">
+              <span
+                v-if="priorityLetter(project)"
+                class="grid size-3.5 shrink-0 place-items-center rounded bg-primary text-[0.5rem] font-black text-primary-content"
+                :title="`${project.badge || 'Priority'}`"
+              >
+                {{ priorityLetter(project) }}
+              </span>
+
+              <template v-if="progressFor(project) !== null">
+                <span
+                  class="h-1.5 min-w-0 flex-1 overflow-hidden rounded-full bg-base-300"
+                  :title="`${progressFor(project)}% complete`"
+                >
+                  <span
+                    class="block h-full rounded-full bg-primary"
+                    :style="{ width: `${progressFor(project)}%` }"
+                  />
+                </span>
+
+                <span
+                  class="shrink-0 text-[0.6rem] font-bold tabular-nums text-base-content/55"
+                >
+                  {{ progressFor(project) }}%
+                </span>
+              </template>
+
+              <span v-else class="min-w-0 flex-1" />
+            </div>
+          </div>
         </NuxtLink>
       </div>
     </section>
@@ -203,6 +239,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted } from 'vue'
+import { useConductorStore } from '@/stores/conductorStore'
 import { useHomeShowcaseStore } from '@/stores/homeShowcaseStore'
 import {
   showcaseHref,
@@ -224,9 +261,38 @@ type RailDefinition = {
   /** Extra grid classes for this shelf's cell, and its internal row count. */
   cellClass?: string
   rows?: 1 | 2
+  fit?: 'cover' | 'contain'
 }
 
 const showcaseStore = useHomeShowcaseStore()
+const conductorStore = useConductorStore()
+
+/**
+ * Percent complete for a project, joined to conductor's own figure on
+ * conductorSlug. Conductor computes it from the roadmap (done weight plus half
+ * for in-progress), which is the number Silas already reads elsewhere -- so
+ * this shows the same one rather than inventing a second definition.
+ */
+function progressFor(project: ShowcaseCard): number | null {
+  const slug = project.conductorSlug
+  if (!slug) return null
+
+  const match = conductorStore.projects.find((entry) => entry.slug === slug)
+  /*
+   * NULL, not 0, when there is no match. A project conductor has never heard of
+   * is of UNKNOWN progress; rendering an empty bar at 0% asserts that no work
+   * has been done on it, which is a different and probably false claim. The bar
+   * is omitted instead.
+   */
+  if (typeof match?.progress !== 'number') return null
+
+  return Math.max(0, Math.min(100, Math.round(match.progress)))
+}
+
+/** HIGH -> H. The word cost more width than the title could spare. */
+function priorityLetter(project: ShowcaseCard): string {
+  return (project.badge || '').trim().charAt(0).toUpperCase()
+}
 
 /*
  * ORDER IS THE ARGUMENT. Art first because it is the most immediately legible
@@ -252,6 +318,7 @@ const RAILS: RailDefinition[] = [
     // shelves filling a tidy 3x2 beside it.
     cellClass: 'lg:row-span-2',
     rows: 2,
+    fit: 'contain',
   },
   {
     key: 'animations',

--- a/components/home/home-rail.vue
+++ b/components/home/home-rail.vue
@@ -36,7 +36,7 @@
   so it is gone rather than tuned.
 -->
 <template>
-  <section class="flex min-w-0 flex-col gap-1 kr-panel-flat p-2">
+  <section class="flex h-full min-w-0 flex-col gap-1 kr-panel-flat p-2">
     <header class="flex flex-wrap items-baseline justify-between gap-x-3">
       <h2
         class="text-[0.7rem] font-black uppercase tracking-[0.16em] text-primary"
@@ -66,10 +66,10 @@
       cell instead of one row floating in it.
     -->
     <div
-      class="overflow-x-auto pb-1"
+      class="min-h-0 flex-1 overflow-x-auto pb-1"
       :class="
         rows === 2
-          ? 'grid grid-flow-col grid-rows-2 auto-cols-max gap-2'
+          ? 'grid grid-flow-col grid-rows-2 auto-cols-max content-between gap-2'
           : 'flex gap-2'
       "
     >
@@ -98,7 +98,7 @@
           :fallback="fallbackFor(item)"
           :placeholder-icon="placeholderIcon"
           hover-zoom
-          fit="cover"
+          :fit="fit"
         />
 
         <!--
@@ -138,9 +138,17 @@ const props = withDefaults(
     placeholderIcon?: string
     /** 2 lays the tiles out in two rows, for a rail spanning two grid rows. */
     rows?: 1 | 2
+    /**
+     * 'contain' shows the whole frame. Silas, 2026-08-29, on the art queue:
+     * "we sghould get full views of the images". Cropping a render to a tile's
+     * aspect is fine for an object whose card art was composed for that box,
+     * and wrong for the queue, where the point is what was actually made.
+     */
+    fit?: 'cover' | 'contain'
   }>(),
   {
     seeAllLabel: 'see all',
+    fit: 'cover',
     shape: 'card',
     plateVariant: 'card',
     placeholderIcon: 'kind-icon:image',
@@ -170,7 +178,22 @@ function fallbackFor(item: ShowcaseCard): string {
   return defaultArtFor(`${item.kind}-${item.id}`)
 }
 
-function themeFor(item: ShowcaseCard): string {
+/**
+ * The record's own theme, or none.
+ *
+ * resolveEntityTheme falls back to an id-derived pick when a record has no
+ * stored theme, which is what gives the object shelves their variety. ArtImage
+ * has no `theme` column at all, so every render was being dressed in an
+ * arbitrary theme -- harmless while plates were cropped, and obvious once they
+ * switched to `contain`, because the letterbox bars took that theme's base
+ * colour and the art queue turned into a row of bright pink and navy frames.
+ *
+ * Art and clips keep the page theme, so a letterboxed render sits on warm paper
+ * like everything else.
+ */
+function themeFor(item: ShowcaseCard): string | undefined {
+  if (item.kind === 'art' || item.kind === 'animation') return undefined
+
   return resolveEntityTheme({ id: item.id, theme: item.theme })
 }
 </script>

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -99,11 +99,33 @@
           class="flex min-w-0 flex-1 items-stretch border-l border-base-300"
         >
           <tab-select
-            class="min-w-0 flex-1"
+            class="min-w-0 shrink-0"
             :channel="resolvedChannel"
             :active-tab-key="activeTabKey"
             @select="goToTab"
           />
+
+          <!--
+            THE EMPTY STRETCH, given something to say. Silas, 2026-08-29: "we
+            still have a wide akward space in the navigation tab selector, it
+            would be better on sufficiently large screens to show a unique tab
+            message, we should have something in front matter."
+
+            A dropdown needs room for one label and no more, so `flex-1` on it
+            spent the rest of the row on nothing. The tab-select now takes only
+            what it needs and this takes the remainder -- but only from `lg`,
+            because below that the row genuinely has no spare width and a
+            truncated half-sentence is worse than blank space.
+          -->
+          <p
+            v-if="tabMessage"
+            class="hidden min-w-0 flex-1 items-center truncate px-3 text-sm text-base-content/55 lg:flex"
+            :title="tabMessage"
+          >
+            {{ tabMessage }}
+          </p>
+
+          <span v-else class="min-w-0 flex-1" />
         </div>
 
         <!-- No tabs resolved (a bare route, or content still loading): fall
@@ -227,6 +249,8 @@ const resolvedTabs = computed(() => resolvedChannel.value?.tabs ?? [])
 // The room label this fed ("CREATIVE WORLDS") sat above the page title in the
 // old title section. The channel name in channel-select says the same thing one
 // control to the left, so nothing repeats it.
+
+const tabMessage = computed(() => pageStore.tabMessage || '')
 
 const shellSummary = computed(
   () => pageStore.subtitle || pageStore.description || '',

--- a/components/newsfeed/newsfeed-feed.vue
+++ b/components/newsfeed/newsfeed-feed.vue
@@ -9,11 +9,17 @@
 -->
 <template>
   <section class="flex flex-col gap-4">
-    <header class="flex flex-wrap items-center justify-between gap-3">
-      <div class="flex flex-wrap gap-1.5">
+    <!--
+      ONE ROW. Silas, 2026-08-29: "we could condense the title and the selection
+      for topics into one row instead of two large ones." The chips scroll
+      sideways instead of wrapping, and the controls shrink to icons where the
+      label is guessable, so the whole strip is one line at any width.
+    -->
+    <header class="flex items-center gap-2">
+      <div class="flex min-w-0 flex-1 gap-1.5 overflow-x-auto">
         <button
           type="button"
-          class="btn btn-sm rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          class="btn btn-sm shrink-0 rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
           :class="
             activeSlug === ALL_FEEDS_SLUG
               ? 'btn-primary'
@@ -28,7 +34,7 @@
           v-for="group in groups"
           :key="group.slug"
           type="button"
-          class="btn btn-sm gap-1.5 rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          class="btn btn-sm shrink-0 gap-1.5 rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
           :class="
             activeSlug === group.slug
               ? 'btn-primary'
@@ -42,7 +48,7 @@
         </button>
       </div>
 
-      <div class="flex items-center gap-2">
+      <div class="flex shrink-0 items-center gap-1">
         <!--
           Pin the tab you want to land on. Silas, 2026-08-28: "We should be able
           to choose the starting feed, I only get all as the starting option and
@@ -67,7 +73,7 @@
             :name="startsHere ? 'kind-icon:star' : 'kind-icon:stars'"
             class="size-4"
           />
-          <span class="hidden sm:inline">{{ pinLabel }}</span>
+          <span class="hidden xl:inline">{{ pinLabel }}</span>
         </button>
 
         <button
@@ -78,7 +84,7 @@
           @click="showManageFeeds = !showManageFeeds"
         >
           <Icon name="kind-icon:sliders" class="size-4" />
-          Manage feeds
+          <span class="hidden xl:inline">Manage feeds</span>
           <Icon
             :name="
               showManageFeeds
@@ -98,7 +104,7 @@
         >
           <span v-if="isLoading" class="loading loading-spinner loading-xs" />
           <Icon v-else name="kind-icon:refresh" class="size-4" />
-          Refresh
+          <span class="hidden xl:inline">Refresh</span>
         </button>
       </div>
     </header>
@@ -133,10 +139,26 @@
           name="kind-icon:news"
           class="mx-auto size-10 text-base-content/25"
         />
-        <p class="mt-2 font-black">Nothing here yet</p>
+        <!--
+          Two different silences, told apart. "Nothing published lately" and
+          "we could not reach the source" look identical on screen but mean
+          opposite things: the first is the world being quiet, the second is us
+          being broken. Reporting the first when the second is true is how an
+          outage reads as an empty site.
+        -->
+        <p class="mt-2 font-black">
+          {{
+            sourceErrorCount
+              ? 'Could not reach the sources'
+              : 'Nothing here yet'
+          }}
+        </p>
         <p class="mt-1 text-sm text-base-content/55">
-          The swarm hasn't published anything for this feed in a bit — check
-          back soon.
+          {{
+            sourceErrorCount
+              ? 'This feed’s sources did not answer on the last refresh. Try Refresh in a moment.'
+              : 'The swarm hasn’t published anything for this feed in a bit — check back soon.'
+          }}
         </p>
       </div>
     </div>
@@ -360,10 +382,26 @@ async function loadFeed(): Promise<void> {
     if (!hasAppliedStartingFeed) {
       hasAppliedStartingFeed = true
       const preferred = feedPreferenceStore.startingFeedSlug
-      if (
-        preferred !== ALL_FEEDS_SLUG &&
-        groups.value.some((group) => group.slug === preferred)
-      ) {
+      /*
+       * The pinned feed has to have something IN it, not merely exist.
+       *
+       * Silas, 2026-08-29: "something broke on the newsfeed. there were ai
+       * gaming news articles and now there is nothing." Nothing had broken in
+       * the data -- /api/newsfeed?feeds=ai-gaming was serving 20 items when
+       * checked -- but one of that feed's two sources had failed on his
+       * refresh, and pinning a starting feed (added earlier this week) turned a
+       * transient upstream hiccup into an apparently empty site. Before the
+       * pin he would have landed on All and seen everything else.
+       *
+       * So the pin is a preference about where to LAND, not a filter to honour
+       * into an empty room: if the preferred feed has no items this refresh,
+       * All is the honest place to be. An explicit click on that tab still goes
+       * there and stays there -- this only governs the automatic first landing.
+       */
+      const preferredGroup = groups.value.find(
+        (group) => group.slug === preferred,
+      )
+      if (preferred !== ALL_FEEDS_SLUG && preferredGroup?.items.length) {
         activeSlug.value = preferred
       }
     }

--- a/content/index.md
+++ b/content/index.md
@@ -2,6 +2,7 @@
 title: 'Kind Robots'
 room: 'Dashboard Room'
 subtitle: 'Craft your universe'
+tabMessage: 'Everything the swarm made lately — all of it clickable.'
 description: Welcome to Kind Robots, a consortium of AI-assisted tools to generate and share your creations with others.
 image: splash/robots.png
 icon: kind-icon:home

--- a/server/api/showcase/home.get.ts
+++ b/server/api/showcase/home.get.ts
@@ -161,6 +161,7 @@ function card(
     slug?: string | null
     badge?: string | null
     href?: string | null
+    conductorSlug?: string | null
     theme?: string | null
     createdAt: Date | null
     art: ShowcaseArt
@@ -174,6 +175,7 @@ function card(
     slug: fields.slug ?? null,
     badge: fields.badge ?? null,
     href: fields.href ?? null,
+    conductorSlug: fields.conductorSlug ?? null,
     theme: fields.theme ?? null,
     createdAt: iso(fields.createdAt),
     art: fields.art,
@@ -780,7 +782,8 @@ async function loadProjects(): Promise<ShowcaseCard[]> {
       title: project.title,
       subtitle: summarize(project.pitch, project.goal, project.description),
       slug: project.slug,
-      badge: project.priority === 'HIGH' ? 'High priority' : null,
+      badge: project.priority,
+      conductorSlug: project.conductorSlug,
       href: projectHref(project),
       createdAt: project.createdAt,
       art: artOfEntity(project),

--- a/stores/pageStore.ts
+++ b/stores/pageStore.ts
@@ -14,10 +14,7 @@ import { useNavStore } from '@/stores/navStore'
 import { useSheetStore } from '@/stores/sheetStore'
 
 export type PageLayoutKey = 'default' | 'minimal' | 'vertical-scroll' | false
-export type WorkspaceCardsInput =
-  | string
-  | BuilderCard[]
-  | NavigationCard[]
+export type WorkspaceCardsInput = string | BuilderCard[] | NavigationCard[]
 export type PageNarratorKind = 'bot' | 'character'
 export type PageNarratorRef =
   | string
@@ -37,6 +34,15 @@ export type WorkspacePage = ContentCollectionItem & {
   refreshLabel?: string
   room?: string
   subtitle?: string
+  /**
+   * A line for the wide empty stretch beside the tab dropdown. Silas,
+   * 2026-08-29: "we still have a wide akward space in the navigation tab
+   * selector, it would be better on sufficiently large screens to show a unique
+   * tab message, we should have something in front matter." Per-page, falling
+   * back to the tab's and then the channel's, so a page can say something
+   * specific without every page having to.
+   */
+  tabMessage?: string
   tooltip?: string
   dottiTip?: string
   amiTip?: string
@@ -64,7 +70,6 @@ export type WorkspacePage = ContentCollectionItem & {
 // utils/pageImagePath.ts now — same behaviour for every value in content/
 // today, plus `data:` support and a guard against double-prefixing an
 // `images/`-rooted path into `/images/images/…`.
-
 
 function isBuilderCardArray(value: unknown): value is BuilderCard[] {
   return (
@@ -154,6 +159,7 @@ export const usePageStore = defineStore('pageStore', () => {
     room: getString(currentPage.value?.room) || 'Kind Robots',
     subtitle:
       getString(currentPage.value?.subtitle) || 'Welcome to Kind Robots',
+    tabMessage: getString(currentPage.value?.tabMessage),
     description: getString(currentPage.value?.description),
     summary: getString(currentPage.value?.summary),
     icon: getString(currentPage.value?.icon) || 'mdi:robot-happy',
@@ -272,8 +278,7 @@ export const usePageStore = defineStore('pageStore', () => {
       summary: tab?.summary || channel?.summary || meta.value.summary,
       dashboardKey:
         tab?.dashboardKey || channel?.dashboardKey || meta.value.dashboardKey,
-      dashboardTab:
-        tab?.dashboardTab || tab?.tabKey || meta.value.dashboardTab,
+      dashboardTab: tab?.dashboardTab || tab?.tabKey || meta.value.dashboardTab,
       cards: tabCards || cardsKey.value,
       loadingMessage:
         tab?.loadingMessage ||
@@ -438,6 +443,7 @@ export const usePageStore = defineStore('pageStore', () => {
     title: computed(() => meta.value.title),
     room: computed(() => meta.value.room),
     subtitle: computed(() => meta.value.subtitle),
+    tabMessage: computed(() => meta.value.tabMessage),
     description: computed(() => meta.value.description),
     summary: computed(() => meta.value.summary),
     icon: computed(() => meta.value.icon),

--- a/utils/homeShowcase.ts
+++ b/utils/homeShowcase.ts
@@ -67,6 +67,12 @@ export type ShowcaseCard = {
    * under nav paths" problem this page exists to fix.
    */
   href: string | null
+  /**
+   * Projects only: the conductor project this record mirrors. The home strip
+   * joins on it to show conductor's own progress percentage rather than
+   * inventing a second definition of "how far along is this".
+   */
+  conductorSlug: string | null
 }
 
 export type ShowcaseHero = {


### PR DESCRIPTION
Silas's notes on the third pass, worked through.

## The newsfeed wasn't broken — my pin made it look broken

He reported *"there were ai gaming news articles and now there is nothing."*

Nothing had broken in the data: production was serving **20 items** for `ai-gaming` when I queried it directly. But one of that feed's two sources had failed on his refresh, and **the starting-feed pin I added earlier this week turned a transient upstream hiccup into an apparently empty site.** Before the pin he'd have landed on All and seen everything else.

Two fixes:
- A pinned feed with **no items this refresh** falls back to All for the automatic first landing. An explicit click on that tab still goes there and stays.
- The empty state now distinguishes *"nothing published lately"* from *"we could not reach the source."* They look identical on screen and mean opposite things, and reporting the first when the second is true is exactly how an outage reads as an empty site.

## Needs you (new `home-attention.vue`)

*"Dream entry should take up less horizontal space to leave room for a vertical notification scroll, especially things that I can answer that are human gated."*

**Nothing new was built for the data.** `conductorStore` already computes `humanGates` — every conductor task at `needs-human`, filtered to active projects and sorted — and `conductorCards.ts` already labels that status "Needs You". It had no surface at all; grepping components for it returned nothing.

It deliberately **links** to `/conductor` rather than approving inline. `/api/conductor/task-action` does take approve/reject/comment, but approving writes to the coordination system of record and there's no database or live conductor data here to test against. An untested one-click approve on a gate is worse than one more click — say the word and it's a small follow-up.

## The hero gives, rather than the cast gaining

*"it would be better if the dream hero shrunk rather than the others gained."* The cast went back to square plates — portrait ones had made the **cast** set the band height, the reverse of the ask — and the dream card is a fixed 11rem, freeing the width the Needs-you column now occupies.

## Projects

Description dropped (*"these are things I'm well aquainted with"*), priority reduced to one letter with the full word as a tooltip, and a progress bar joined to conductor's own per-project figure on `conductorSlug`, so it shows the same number you already read elsewhere.

**Progress is `null`, not `0`, when conductor has no matching project.** An unknown project isn't a project at 0% — an empty bar asserts no work has been done, which is a different and probably false claim. The bar is omitted instead.

## Art queue

Plates now `contain` so the whole render shows. The rail fills its two-row cell instead of floating in it.

Art and clips also **stopped wearing a theme**: `ArtImage` has no `theme` column, so `resolveEntityTheme`'s id-derived fallback was dressing every render in an arbitrary one. Invisible while plates were cropped — the moment they became `contain`, the letterbox bars took that theme's base colour and the queue turned into a row of bright pink and navy frames. Object shelves keep the fallback, which is where the variety is wanted.

## Also

- **Newsfeed header** and topic chips are one row rather than two; chips scroll sideways instead of wrapping, control labels collapse below `xl`.
- **Nav tab message** (not a home-page issue, but asked for): a `tabMessage` frontmatter field, resolved through `pageStore`, fills the wide empty stretch beside the tab dropdown from `lg` up. A dropdown needs room for one label, so `tab-select`'s `flex-1` was spending the rest of the row on nothing.

## Verification

1106px / **2.17 screens** at his viewport. `vue-tsc`, `eslint`, `prettier --check`, layout contract and MDC scroll ownership all clean. Heights and screenshots are against a mocked payload — the sandbox has no database, so the conductor progress join in particular is unexercised against real slugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aNg3fsHLGUGCwiMp25hkA

---
_Generated by [Claude Code](https://claude.ai/code/session_017aNg3fsHLGUGCwiMp25hkA)_