### PR TITLE
interface-vision/t-104 slice 58: kr-panel-flat on 3 aquarium browse/leaderboard rows

### DIFF
--- a/pages/play/aquarium/browse/[username]/[slug].vue
+++ b/pages/play/aquarium/browse/[username]/[slug].vue
@@ -110,7 +110,7 @@
           <div
             v-for="entry in tank.Stock"
             :key="entry.id"
-            class="flex items-center gap-3 rounded-2xl border border-base-300 bg-base-100 p-3 shadow-sm"
+            class="flex items-center gap-3 kr-panel-flat p-3 shadow-sm"
           >
             <kr-art-plate
               :source="entry.Monster"

--- a/pages/play/aquarium/browse/index.vue
+++ b/pages/play/aquarium/browse/index.vue
@@ -73,7 +73,7 @@
             v-for="tank in tanks"
             :key="`${tank.User.username}/${tank.slug}`"
             :to="`/play/aquarium/browse/${tank.User.username}/${tank.slug}`"
-            class="group flex flex-col gap-2 rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
+            class="group flex flex-col gap-2 kr-panel-flat p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
           >
             <div class="flex items-center gap-3">
               <div

--- a/pages/play/aquarium/leaderboard/index.vue
+++ b/pages/play/aquarium/leaderboard/index.vue
@@ -71,7 +71,7 @@
           <li
             v-for="entry in entries"
             :key="entry.userId"
-            class="flex items-center gap-3 rounded-2xl border border-base-300 bg-base-100 p-3 shadow-sm"
+            class="flex items-center gap-3 kr-panel-flat p-3 shadow-sm"
           >
             <span
               class="grid size-8 shrink-0 place-items-center rounded-full bg-base-200 text-xs font-black"


### PR DESCRIPTION
### Task
interface-vision/t-104 (conductor): Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring umbrella)

### What changed / what I produced
- Three hand-rolled panel roots in the cthulhuquarium aquarium browse/leaderboard surfaces byte-exact-matched `kr-panel-flat`'s definition (`rounded-2xl border border-base-300 bg-base-100`); substituted, keeping each row's own padding/flex/shadow/transition utilities. No geometry or behavior change.
  - `pages/play/aquarium/browse/[username]/[slug].vue`: tank stock row
  - `pages/play/aquarium/browse/index.vue`: tank card
  - `pages/play/aquarium/leaderboard/index.vue`: leaderboard row
- Found via `utils/scripts/codemods/kr_panel_codemod.py --root .` against current `main` (f1ba035, includes the home-page redesign passes #2189-2192 and the Animation Manager Strandbeest build #2190 merged since t-104 slice 57's last check a few hours earlier). These three files were newly added by cthulhuquarium/t-017 and t-061 on 2026-08-27/28.
- Re-ran the `mx-auto`+`w-full`+`max-w-*` container pool and the `kr-note` `border-{status}/40`+`bg-{status}/10` co-occurrence pool too; both remain exhausted, unchanged from slice 57's findings (same previously-excluded file sets, no new byte-exact candidates from the recent merges).

### How I verified
- `npx eslint` on the three changed files — clean
- `npx vue-tsc --noEmit` — clean, repo-wide
- `npm run test:layout-contract` — holds, 0 new violations (207 baseline, unchanged)
- `npx prettier --check` on the three changed files — clean
- `git diff --stat` confirms exactly 3 files / 1 net line each

### Stakes
reversible

### Flags for Reviewer
- Correctly skipped by the codemod (unsafe extra tokens, not touched): `components/ruler-hooked/ruler-hooked-fishopedia.vue`, `components/ui/kr-stat-tile.vue`, `components/user/chat-gallery.vue` — each mixes a bare DaisyUI/structural root class with the kr-panel-flat token sequence, per this task's established slice-12 stylesheet-source-order risk.

### Kaizen suggestion
None new this cycle — the umbrella's established convention (re-check both mechanical pools each slice, escalate to Silas only when both are genuinely exhausted with no new merges to re-check against) is working as intended; this slice is exactly the "new commits landed, pools worth re-checking" case it's designed for.

### Notes for reviewer
Software-kind, reversible, byte-exact, additive-only class substitution — safe to merge once CI is green, consistent with slices 1-57 of this same recurring umbrella task.

---
_Generated by [Claude Code](https://claude.ai/code/session_015CwG8LxosBmUPQsiyjWAxh)_