### PR TITLE
interface-vision/t-104 slice 60: kr-panel-flat on rebel-button.vue reset modal

### DIFF
--- a/components/pages/rebel-button.vue
+++ b/components/pages/rebel-button.vue
@@ -126,9 +126,7 @@
           aria-modal="true"
           @click.self="state.showResetPopup = false"
         >
-          <div
-            class="w-full max-w-sm rounded-2xl border border-base-300 bg-base-100 p-6 shadow-2xl"
-          >
+          <div class="w-full max-w-sm kr-panel-flat p-6 shadow-2xl">
             <p>Are you sure you want to reset the leaderboard?</p>
             <div class="flex justify-end space-x-4 mt-4">
               <button


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- `components/pages/rebel-button.vue`'s reset-confirmation modal panel div had
  root class `rounded-2xl border border-base-300 bg-base-100` — an exact
  byte-match for the shared `kr-panel-flat` utility class (declared in
  `assets/css/tailwind.css`'s `@layer components`). This class was introduced
  by #2194 (t-105's Rebel Button polish), which landed just before this
  slice's scan.
- Substituted mechanically via `utils/scripts/codemods/kr_panel_codemod.py
  --apply`, which only fires when every other token on the element is a
  documented-safe plain-utility extra (here: `w-full max-w-sm p-6
  shadow-2xl` — no competing DaisyUI component-root class).
- `prettier --write` collapsed the now-shorter `class="..."` attribute back
  onto one line.
- No geometry or behavior change.

### How I verified
- `eslint components/pages/rebel-button.vue` — clean.
- `vue-tsc --noEmit` — clean repo-wide.
- `npm run test:layout-contract` — holds, 207 baseline violations unchanged,
  0 new.
- `prettier --check` — clean after `--write`.
- Re-ran `kr_panel_codemod.py --root .` dry-run repo-wide: no other new
  candidates. Remaining skips (`ruler-hooked-fishopedia.vue`,
  `kr-stat-tile.vue`, `chat-gallery.vue`) are unchanged from prior slices —
  each mixes a bare DaisyUI component-root class with the kr-panel-flat
  tokens, left for manual per-file review per the codemod's own conservative
  policy.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
None new this slice — same recurring mechanical-scan cadence as prior slices.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W7S8wEzYwWzJwyTLpw2daf)_