### PR TITLE
Home page: interstitial, art-queue toggle, and the missing half of the gate pipeline

### DIFF
--- a/components/home/home-art-shelf.vue
+++ b/components/home/home-art-shelf.vue
@@ -1,0 +1,254 @@
+<!-- /components/home/home-art-shelf.vue -->
+<!--
+  The art shelf, which is two shelves behind one toggle.
+
+  Silas, 2026-08-29: "we are already fighting for space, but the artqueue should
+  also be present. let me togle between the fresh from art queue and to see the
+  current progress, and choose from active to failed, etc, keeping the layout,
+  which otherwise is great."
+
+  So this owns no layout of its own. It renders the SAME home-rail in the same
+  two-row cell either way and only swaps what is in it -- finished ArtImages, or
+  the live ArtJob queue -- plus two controls that ride in the header row the
+  shelf already had. "Keeping the layout" is the constraint, and the way to keep
+  it is to not build a second component that looks nearly the same.
+
+  WHO SEES THE QUEUE. /api/art/queue is behind requireMachineUser: a signed-out
+  visitor gets a 401, an ordinary user sees their own jobs, an admin sees all of
+  them. So the toggle is rendered only for a signed-in user, and a failed fetch
+  (revoked session, server down) hides it again and drops the shelf back to
+  `fresh`. Nobody is offered a control that can only error for them.
+
+  NOTHING IS FETCHED UNTIL THE TOGGLE IS PRESSED. The home page already makes
+  one showcase request and one conductor request on load; the queue is a
+  third that most visits will never need, so it is lazy.
+-->
+<template>
+  <home-rail
+    :label="mode === 'fresh' ? 'Fresh from the art queue' : queueLabel"
+    :icon="mode === 'fresh' ? 'kind-icon:palette-color' : 'kind-icon:server'"
+    :items="visibleItems"
+    see-all-href="/art"
+    shape="wide"
+    plate-variant="card"
+    placeholder-icon="kind-icon:palette-color"
+    :rows="2"
+    fit="contain"
+    :interactive="mode === 'fresh'"
+    @select="emit('select', $event)"
+  >
+    <template #controls>
+      <!--
+        Two icons and, in queue mode, one select. All of it inside the header
+        row that already existed, so the toggle costs no page height -- which is
+        the whole point given "we are already fighting for space".
+      -->
+      <span
+        v-if="queueAvailable"
+        class="flex shrink-0 overflow-hidden rounded border border-base-300"
+      >
+        <button
+          v-for="option in MODES"
+          :key="option.key"
+          type="button"
+          class="grid size-5 place-items-center transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+          :class="
+            mode === option.key
+              ? 'bg-primary text-primary-content'
+              : 'text-base-content/45 hover:text-primary'
+          "
+          :aria-pressed="mode === option.key"
+          :title="option.label"
+          :aria-label="option.label"
+          @click="setMode(option.key)"
+        >
+          <Icon :name="option.icon" class="size-3" />
+        </button>
+      </span>
+
+      <select
+        v-if="mode === 'queue'"
+        v-model="statusFilter"
+        class="min-w-0 max-w-24 shrink rounded border border-base-300 bg-base-100 px-1 py-0 text-[0.6rem] font-bold focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+        aria-label="Filter the art queue by job status"
+        @change="loadQueue()"
+      >
+        <option
+          v-for="option in STATUS_OPTIONS"
+          :key="option.key"
+          :value="option.key"
+        >
+          {{ option.label }}
+        </option>
+      </select>
+
+      <span
+        v-if="mode === 'queue' && queuePending"
+        class="loading loading-spinner loading-xs shrink-0 text-primary"
+      />
+    </template>
+  </home-rail>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { RailItem, ShowcaseCard } from '@/utils/homeShowcase'
+import { performFetch } from '@/stores/utils'
+import { useUserStore } from '@/stores/userStore'
+
+const props = defineProps<{ fresh: ShowcaseCard[] }>()
+const emit = defineEmits<{ select: [item: RailItem] }>()
+
+type Mode = 'fresh' | 'queue'
+
+const MODES: { key: Mode; label: string; icon: string }[] = [
+  { key: 'fresh', label: 'Finished art', icon: 'kind-icon:palette-color' },
+  { key: 'queue', label: 'Queue progress', icon: 'kind-icon:server' },
+]
+
+/*
+ * ACTIVE is the useful default and is not a single ArtJobStatus -- it is
+ * PENDING plus RUNNING, "what the pipeline is chewing on right now". The
+ * endpoint filters on one status at a time, so ACTIVE fans out into two
+ * requests and merges them, rather than fetching every job and filtering in the
+ * browser (which would silently drop old active jobs behind a page of DONE).
+ */
+const STATUS_OPTIONS: { key: string; label: string; fetch: string[] }[] = [
+  { key: 'ACTIVE', label: 'Active', fetch: ['PENDING', 'RUNNING'] },
+  { key: 'PENDING', label: 'Pending', fetch: ['PENDING'] },
+  { key: 'RUNNING', label: 'Running', fetch: ['RUNNING'] },
+  { key: 'FAILED', label: 'Failed', fetch: ['FAILED'] },
+  { key: 'DONE', label: 'Done', fetch: ['DONE'] },
+  { key: 'CANCELLED', label: 'Cancelled', fetch: ['CANCELLED'] },
+]
+
+const PAGE_SIZE = 12
+
+type QueueJob = {
+  id: number
+  status: string
+  createdAt: string
+  artImageId: number | null
+  projectSlug: string | null
+  error: string | null
+  payload?: { title?: string | null; promptString?: string | null } | null
+}
+
+const userStore = useUserStore()
+
+const mode = ref<Mode>('fresh')
+const statusFilter = ref('ACTIVE')
+const queueJobs = ref<QueueJob[]>([])
+const queuePending = ref(false)
+/** Cleared by a failed fetch; see the note at the top of this file. */
+const queueReachable = ref(true)
+
+const queueAvailable = computed(
+  () => userStore.isLoggedIn && queueReachable.value,
+)
+
+const queueLabel = computed(() => {
+  const option = STATUS_OPTIONS.find(
+    (entry) => entry.key === statusFilter.value,
+  )
+  return `Art queue — ${option?.label ?? statusFilter.value}`
+})
+
+/**
+ * A job as a rail tile.
+ *
+ * A DONE job has a real ArtImage, so it gets the canonical file URL and looks
+ * exactly like a tile on the finished shelf. Everything else has no picture
+ * yet, so `art` is empty and home-rail falls through to the shared default-art
+ * pool -- the tile still reads as a tile rather than a hole, and the status chip
+ * is what carries the information.
+ */
+function jobToItem(job: QueueJob): RailItem {
+  const label =
+    job.payload?.title?.trim() ||
+    job.payload?.promptString?.trim() ||
+    job.projectSlug ||
+    `Job #${job.id}`
+
+  return {
+    kind: 'art',
+    id: job.artImageId ?? job.id,
+    title: label,
+    subtitle: job.error?.trim() || null,
+    slug: null,
+    badge: null,
+    createdAt: job.createdAt,
+    theme: null,
+    art: {
+      imagePath: job.artImageId
+        ? `/api/art/images/${job.artImageId}/file`
+        : null,
+      cardPath: null,
+      heroPath: null,
+      iconPath: null,
+      fileType: null,
+    },
+    // A queued job has no gallery record to open yet, so the tile points at the
+    // pipeline control room instead of a /art?art=<id> that would resolve to
+    // nothing.
+    href: job.artImageId ? `/art?art=${job.artImageId}` : '/artjob',
+    conductorSlug: null,
+    status: job.status,
+  }
+}
+
+const visibleItems = computed<RailItem[]>(() =>
+  mode.value === 'fresh'
+    ? props.fresh.map((card) => ({ ...card }))
+    : queueJobs.value.map(jobToItem),
+)
+
+async function loadQueue(): Promise<void> {
+  const option = STATUS_OPTIONS.find(
+    (entry) => entry.key === statusFilter.value,
+  )
+  if (!option) return
+
+  queuePending.value = true
+  try {
+    const responses = await Promise.all(
+      option.fetch.map((status) =>
+        performFetch<{ jobs: QueueJob[] }>(
+          `/api/art/queue?status=${status}&pageSize=${PAGE_SIZE}`,
+        ),
+      ),
+    )
+
+    if (responses.some((response) => !response.success)) {
+      throw new Error('queue unavailable')
+    }
+
+    queueJobs.value = responses
+      .flatMap((response) => response.data?.jobs ?? [])
+      .sort(
+        (left, right) =>
+          new Date(right.createdAt).getTime() -
+          new Date(left.createdAt).getTime(),
+      )
+      .slice(0, PAGE_SIZE)
+
+    queueReachable.value = true
+  } catch {
+    /*
+     * A 401 here is the ordinary signed-out case, not a fault worth a banner.
+     * Fall back to the finished shelf and keep the toggle hidden, so the only
+     * people who ever see the control are the ones it works for.
+     */
+    queueJobs.value = []
+    queueReachable.value = false
+    mode.value = 'fresh'
+  } finally {
+    queuePending.value = false
+  }
+}
+
+function setMode(next: Mode): void {
+  mode.value = next
+  if (next === 'queue' && !queueJobs.value.length) void loadQueue()
+}
+</script>

--- a/components/home/home-attention.vue
+++ b/components/home/home-attention.vue
@@ -1,35 +1,53 @@
 <!-- /components/home/home-attention.vue -->
 <!--
-  The things waiting on Silas.
+  The things waiting on Silas, and the place he answers them.
 
   Silas, 2026-08-29: "Dream entry should take up less horizontal space to leave
   room for a vertical notification scroll, especially things that I can answer
-  that are human gated."
+  that are human gated." Then, once it existed: "We need a definite pipeline, so
+  that if I click on one of the human gate notifications, it lets me enter a
+  comment and that comment is fed to the next agent dealing with that problem.
+  The infrastructure should be there, the excecition is missing the front
+  end....but also we might be missing whatever ties the response to the project
+  referenced. follow it end to end."
 
-  NOTHING NEW WAS BUILT FOR THIS. conductorStore already computes `humanGates` --
-  every conductor task at `status: needs-human`, filtered to active and
-  continuous projects and sorted -- and conductorCards.ts already labels that
-  status "Needs You". It simply had no surface: grepping components for it
-  returned nothing before this file. The home page is the first place these are
-  visible without going looking, which is the whole complaint the redesign
-  started from.
+  IT WAS BOTH. The front end was missing here, and following the chain end to
+  end found a real break behind it. The chain is:
 
-  LINKS, NOT INLINE APPROVE. /api/conductor/task-action takes approve, reject
-  and comment, so answering from here is possible and is the obvious next step.
-  It is deliberately not in this pass: approving writes to the coordination
-  system of record, and this sandbox has no database or live conductor data to
-  test that against. Shipping an untested one-click approve on a gate is a worse
-  outcome than one more click. Each row goes to /conductor with the project
-  open, where the existing controls live.
+    this component
+      -> conductorStore.submitTaskAction
+      -> POST /api/conductor/task-action        (Kind Robots, admin-only)
+      -> a YAML file committed to conductor's task-events/ via the GitHub API
+      -> .github/workflows/process-task-events.yml
+      -> scripts/process_task_events.py         (appends the note to the task)
+      -> sync-kind-robots-projection.yml        (projects it back here)
+
+  Every link of that existed and worked. The break was at the far end: the only
+  comment action available left the task at `status: needs-human`, and
+  conductor's Worker selects `status: ready` and nothing else. So an answer was
+  written into the roadmap and then never handed to anybody -- which is exactly
+  "we might be missing whatever ties the response to the project referenced".
+
+  The fix is the `answer` action (see task-action.post.ts): the same note, plus
+  the release back to `ready` that puts the task in the next Worker's queue.
+  That is the primary button here. `comment` survives as "note only", for
+  adding context to a gate that should stay gated, and conductor's
+  audit_human_gates.py now flags those so they surface in the session sweep
+  instead of sitting unread.
+
+  APPROVE IS DELIBERATELY NOT THE PRIMARY. Approving closes a gate on the
+  coordination system of record; answering hands it onward. The second is the
+  one Silas asked for and the safer default, so it is the one in reach.
 
   ADMIN-ONLY BY DATA, not by a check here: conductorStore only has gates when
-  the projection is readable, so a signed-out visitor sees the empty branch and
-  the column collapses out of the layout entirely.
+  the projection is readable, and /api/conductor/task-action is behind
+  requireAdminApiUser -- so a signed-out visitor sees the empty branch and the
+  column collapses out of the layout entirely.
 -->
 <template>
   <section
     v-if="gates.length || isLoading"
-    class="flex min-h-0 flex-col gap-1 kr-panel-flat p-2 lg:w-64 lg:shrink-0"
+    class="flex min-h-0 flex-col gap-1 kr-panel-flat p-2 lg:w-80 lg:shrink-0"
   >
     <header class="flex shrink-0 items-baseline justify-between gap-2">
       <h2
@@ -56,26 +74,123 @@
       region -- nested preview, not the page's scroll owner.
     -->
     <div
-      class="max-h-56 min-h-0 space-y-1 overflow-y-auto overscroll-contain pr-1"
+      class="max-h-64 min-h-0 space-y-1 overflow-y-auto overscroll-contain pr-1"
     >
-      <NuxtLink
+      <div
         v-for="gate in gates"
-        :key="`${gate.project.slug}-${gate.task.id}`"
-        :to="`/conductor?project=${encodeURIComponent(gate.project.slug)}`"
-        class="group block rounded-lg border border-base-300 bg-base-100 px-2 py-1.5 transition-colors hover:border-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
-        :title="gate.task.title"
+        :key="gateKey(gate)"
+        class="rounded-lg border border-base-300 bg-base-100 transition-colors"
+        :class="openKey === gateKey(gate) ? 'border-primary' : ''"
       >
-        <p
-          class="truncate text-[0.6rem] font-black uppercase tracking-[0.12em] text-primary"
+        <button
+          type="button"
+          class="group block w-full px-2 py-1.5 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+          :aria-expanded="openKey === gateKey(gate)"
+          :title="gate.task.title"
+          @click="toggle(gate)"
         >
-          {{ gate.project.name || gate.project.slug }}
-        </p>
-        <p
-          class="line-clamp-2 text-[0.7rem] font-bold leading-snug text-base-content group-hover:text-primary"
+          <p
+            class="truncate text-[0.6rem] font-black uppercase tracking-[0.12em] text-primary"
+          >
+            {{ gate.project.name || gate.project.slug }}
+            <span v-if="gate.task.softGate" class="text-base-content/35"
+              >· soft</span
+            >
+          </p>
+          <p
+            class="line-clamp-2 text-[0.7rem] font-bold leading-snug text-base-content group-hover:text-primary"
+          >
+            {{ gate.task.title }}
+          </p>
+        </button>
+
+        <!--
+          The composer, opened in place. Not a modal: answering three gates in a
+          row should not mean opening and dismissing three dialogs, and the list
+          it belongs to is already a scroller.
+        -->
+        <div
+          v-if="openKey === gateKey(gate)"
+          class="border-t border-base-300 p-2"
         >
-          {{ gate.task.title }}
-        </p>
-      </NuxtLink>
+          <p
+            v-if="gate.task.note"
+            class="mb-1.5 line-clamp-4 whitespace-pre-line rounded bg-base-200/60 p-1.5 text-[0.65rem] leading-snug text-base-content/60"
+          >
+            {{ gate.task.note }}
+          </p>
+
+          <label class="sr-only" :for="`gate-reply-${gateKey(gate)}`">
+            Your answer for {{ gate.task.title }}
+          </label>
+          <textarea
+            :id="`gate-reply-${gateKey(gate)}`"
+            v-model="replies[gateKey(gate)]"
+            rows="3"
+            class="w-full rounded border border-base-300 bg-base-100 p-1.5 text-[0.7rem] leading-snug focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+            placeholder="Answer this, and the next agent picks the task up carrying what you said."
+            :disabled="isUpdating(gate)"
+          />
+
+          <div class="mt-1.5 flex flex-wrap items-center gap-1">
+            <button
+              type="button"
+              class="btn btn-primary btn-xs gap-1 rounded-lg"
+              :disabled="isUpdating(gate) || !replyText(gate)"
+              @click="act(gate, 'answer')"
+            >
+              <span
+                v-if="isUpdating(gate)"
+                class="loading loading-spinner loading-xs"
+              />
+              <Icon v-else name="kind-icon:send" class="size-3" />
+              Send to agent
+            </button>
+
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs rounded-lg border border-base-300"
+              :disabled="isUpdating(gate) || !replyText(gate)"
+              title="Add this note but leave the gate open"
+              @click="act(gate, 'comment')"
+            >
+              Note only
+            </button>
+
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs rounded-lg border border-base-300 text-success"
+              :disabled="isUpdating(gate)"
+              title="Close this gate as approved"
+              @click="act(gate, 'approve')"
+            >
+              Approve
+            </button>
+
+            <NuxtLink
+              :to="`/conductor?project=${encodeURIComponent(gate.project.slug)}`"
+              class="btn btn-ghost btn-xs ml-auto rounded-lg text-base-content/50"
+            >
+              Open
+            </NuxtLink>
+          </div>
+
+          <p
+            v-if="conductorStore.taskUpdateError"
+            class="mt-1 text-[0.65rem] font-bold text-error"
+          >
+            {{ conductorStore.taskUpdateError }}
+          </p>
+
+          <p
+            v-else-if="sentKey === gateKey(gate)"
+            class="mt-1 text-[0.65rem] font-bold text-success"
+          >
+            Queued for conductor. It reaches the roadmap on the next task-events
+            run.
+          </p>
+        </div>
+      </div>
 
       <p
         v-if="isLoading && !gates.length"
@@ -88,13 +203,67 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
-import { useConductorStore } from '@/stores/conductorStore'
+import { computed, onMounted, ref } from 'vue'
+import {
+  useConductorStore,
+  type ConductorHumanGate,
+  type ConductorTaskAction,
+} from '@/stores/conductorStore'
 
 const conductorStore = useConductorStore()
 
 const gates = computed(() => conductorStore.humanGates)
 const isLoading = computed(() => !conductorStore.hasLoaded)
+
+const openKey = ref('')
+const sentKey = ref('')
+const replies = ref<Record<string, string>>({})
+
+function gateKey(gate: ConductorHumanGate): string {
+  return `${gate.project.slug}/${gate.task.id}`
+}
+
+function replyText(gate: ConductorHumanGate): string {
+  return (replies.value[gateKey(gate)] ?? '').trim()
+}
+
+function isUpdating(gate: ConductorHumanGate): boolean {
+  return conductorStore.updatingTaskKeys.includes(gateKey(gate))
+}
+
+function toggle(gate: ConductorHumanGate): void {
+  const key = gateKey(gate)
+  openKey.value = openKey.value === key ? '' : key
+  sentKey.value = ''
+  conductorStore.taskUpdateError = null
+}
+
+async function act(
+  gate: ConductorHumanGate,
+  action: ConductorTaskAction,
+): Promise<void> {
+  const key = gateKey(gate)
+  const completed = await conductorStore.submitTaskAction(
+    gate.project.slug,
+    gate.task.id,
+    action,
+    replies.value[key] ?? '',
+  )
+  if (!completed) return
+
+  // Cleared rather than deleted: the eslint rule against dynamic delete is
+  // right that the key set here is data, and an empty string is what
+  // `replyText` already treats as "nothing to send".
+  replies.value[key] = ''
+  sentKey.value = key
+  /*
+   * `answer` and `approve` both move the task off `needs-human`, so the store's
+   * optimistic update drops it out of `humanGates` and this row disappears on
+   * its own. A `comment` leaves it in place, so the panel stays open with the
+   * note now visible above the box.
+   */
+  if (action !== 'comment') openKey.value = ''
+}
 
 onMounted(() => {
   /*

--- a/components/home/home-dream-hero.vue
+++ b/components/home/home-dream-hero.vue
@@ -37,8 +37,15 @@
 
       So the cast went back to square plates (portrait ones had made the CAST
       set the band height, which is the reverse of what he asked for), and this
-      card is a fixed 11rem rather than a fifth of the page, freeing the width
+      card is a fixed width rather than a fifth of the page, freeing the width
       the Needs-you column now occupies.
+
+      THEN A LITTLE WIDER AGAIN, once it had something to say. Silas,
+      2026-08-29: "The hero is the right size, but make it a little wider
+      because we want to add the descrition for the dream, that is missing."
+      11rem fitted a title and a one-line hook and nothing else; 16rem fits a
+      three-line description without the whole band growing, because the cast
+      beside it gave up more width than this took (see the cast note below).
 
       ABOUT A FIFTH OF THE WIDTH, in its natural proportion. Silas, 2026-08-29:
       "Obviously the dream hero is horribly proportioned, It would be better to
@@ -55,7 +62,7 @@
     -->
     <NuxtLink
       :to="showcaseHref(hero.dream)"
-      class="group flex shrink-0 flex-col gap-1 rounded-xl border-2 border-primary/70 bg-base-100 p-1.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:hover:-translate-y-0.5 lg:w-44"
+      class="group flex shrink-0 flex-col gap-1 rounded-xl border-2 border-primary/70 bg-base-100 p-1.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:hover:-translate-y-0.5 lg:w-64"
     >
       <kr-art-plate
         :source="hero.dream.art"
@@ -82,9 +89,26 @@
 
         <p
           v-if="hero.hook"
-          class="mt-0.5 line-clamp-1 text-[0.7rem] leading-snug text-base-content/65"
+          class="mt-0.5 line-clamp-1 text-[0.7rem] font-bold leading-snug text-base-content/70"
         >
           {{ hero.hook }}
+        </p>
+
+        <!--
+          THE DESCRIPTION, which was simply never rendered. Silas, 2026-08-29:
+          "we want to add the descrition for the dream, that is missing."
+
+          It is clamped rather than truncated server-side so the text reflows
+          with the card instead of ending in a hard ellipsis at a fixed
+          character count. `hook` above is one line and this is three, so the
+          two do not read as the same sentence twice -- and where a dream has
+          only one of them, the other is simply absent.
+        -->
+        <p
+          v-if="hero.description"
+          class="mt-1 line-clamp-3 text-[0.7rem] leading-snug text-base-content/60"
+        >
+          {{ hero.description }}
         </p>
 
         <span
@@ -111,22 +135,41 @@
       forbids a SHARED component from gating its column count on a viewport
       breakpoint (it can be embedded in a narrower host), and a static count is
       not that.
+
+      SLIMMER TILES, on purpose and at a cost. Silas, 2026-08-29: "the other
+      elements on the daily dream can be 50% slimmer, to make room for a better
+      human gate needs you section." A literal half of 7rem is 3.5rem, at which
+      a name truncates to about four characters and the tile stops being
+      identifiable -- which fights his earlier "All the cards need to be big
+      enough to see more of the titles". 4.5rem is the floor where a short name
+      still reads, and the band gives up more width than the difference anyway,
+      because the Needs-you column beside it grew at the same time. If the cast
+      still feels wide, the next thing to cut is the tile CAPTION, not the plate.
     -->
     <div
       v-if="hero.cast.length"
-      class="grid content-start gap-1.5 grid-cols-[repeat(auto-fit,minmax(min(100%,7rem),1fr))] lg:min-w-0 lg:flex-1"
+      class="grid content-start gap-1 grid-cols-[repeat(auto-fit,minmax(min(100%,4.5rem),1fr))] lg:min-w-0 lg:flex-1"
     >
-      <NuxtLink
+      <!--
+        A BUTTON, not a link: a cast member opens the interstitial rather than
+        navigating away. Silas, 2026-08-29: "Whenever I click on one of the new
+        objects, I want it to expand to tell me about it ... with clicking
+        outside the container returning to the homepage." The dream plate above
+        still navigates, because its own caption says "Open the dream" and that
+        is a promise worth keeping.
+      -->
+      <button
         v-for="member in hero.cast"
         :key="`${member.kind}-${member.id}`"
-        :to="showcaseHref(member)"
+        type="button"
         :data-theme="themeFor(member)"
-        class="group flex min-w-0 flex-col overflow-hidden rounded-lg border-2 border-primary/70 bg-base-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:hover:-translate-y-0.5"
+        class="group flex min-w-0 flex-col overflow-hidden rounded-lg border-2 border-primary/70 bg-base-100 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:hover:-translate-y-0.5"
         :title="
           member.subtitle
             ? `${member.title} — ${member.subtitle}`
             : member.title
         "
+        @click="emit('select', member)"
       >
         <kr-art-plate
           :source="member.art"
@@ -169,7 +212,7 @@
             {{ member.title }}
           </p>
         </div>
-      </NuxtLink>
+      </button>
     </div>
   </section>
 </template>
@@ -185,6 +228,7 @@ import { defaultArtFor } from '@/utils/defaultArtPool'
 import { resolveEntityTheme } from '@/utils/entityTheme'
 
 const props = defineProps<{ hero: ShowcaseHero }>()
+const emit = defineEmits<{ select: [card: ShowcaseCard] }>()
 
 /*
  * Dated while the date still means something, plain otherwise. A hero that is

--- a/components/home/home-dream-hero.vue
+++ b/components/home/home-dream-hero.vue
@@ -151,17 +151,21 @@
       class="grid content-start gap-1 grid-cols-[repeat(auto-fit,minmax(min(100%,4.5rem),1fr))] lg:min-w-0 lg:flex-1"
     >
       <!--
-        A BUTTON, not a link: a cast member opens the interstitial rather than
-        navigating away. Silas, 2026-08-29: "Whenever I click on one of the new
-        objects, I want it to expand to tell me about it ... with clicking
-        outside the container returning to the homepage." The dream plate above
-        still navigates, because its own caption says "Open the dream" and that
-        is a promise worth keeping.
+        A cast member opens the interstitial rather than navigating away. Silas,
+        2026-08-29: "Whenever I click on one of the new objects, I want it to
+        expand to tell me about it ... with clicking outside the container
+        returning to the homepage." The dream plate above still navigates,
+        because its own caption says "Open the dream" and that is a promise
+        worth keeping.
+
+        It stays an anchor with a real destination and intercepts the plain
+        click -- see the same note in home-rail.vue for why the <button> version
+        of this was worse.
       -->
-      <button
+      <NuxtLink
         v-for="member in hero.cast"
         :key="`${member.kind}-${member.id}`"
-        type="button"
+        :to="showcaseHref(member)"
         :data-theme="themeFor(member)"
         class="group flex min-w-0 flex-col overflow-hidden rounded-lg border-2 border-primary/70 bg-base-100 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:hover:-translate-y-0.5"
         :title="
@@ -169,7 +173,7 @@
             ? `${member.title} — ${member.subtitle}`
             : member.title
         "
-        @click="emit('select', member)"
+        @click="onCastClick($event, member)"
       >
         <kr-art-plate
           :source="member.art"
@@ -212,7 +216,7 @@
             {{ member.title }}
           </p>
         </div>
-      </button>
+      </NuxtLink>
     </div>
   </section>
 </template>
@@ -251,6 +255,15 @@ const kicker = computed(() => {
 const dreamFallback = computed(() =>
   defaultArtFor(`dream-${props.hero.dream.id}`),
 )
+
+/** See home-rail.vue's onTileClick: same rule, same reasons. */
+function onCastClick(event: MouseEvent, member: ShowcaseCard): void {
+  if (event.button !== 0) return
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
+
+  event.preventDefault()
+  emit('select', member)
+}
 
 function fallbackFor(member: ShowcaseCard): string {
   return defaultArtFor(`${member.kind}-${member.id}`)

--- a/components/home/home-object-sheet.vue
+++ b/components/home/home-object-sheet.vue
@@ -1,0 +1,293 @@
+<!-- /components/home/home-object-sheet.vue -->
+<!--
+  The interstitial.
+
+  Silas, 2026-08-29: "Whenever I click on one of the new objects, I want it to
+  expand to tell me about it, pertinent details, basically what should happen
+  after clicking gallery items, with clicking outside the container returning to
+  the homepage. This is the interstitial, not quite edit, not quite interact
+  select, that leads us to those options, plus review."
+
+  So it is deliberately a READER, not an editor. It shows what the thing is,
+  shows the reviews left on it, and then hands you to the manager that already
+  knows how to edit, interact with and select it. The home page is where you
+  find out something exists; committing to it is one more click, and that click
+  lands somewhere that can actually do the job.
+
+  NOT daily-digest-object-dialog.vue, which looks similar and is not reusable
+  here: it is bound to DailyDreamArchiveObject and useDailyDreamArchiveStore,
+  carries Modify and Artwork tabs that write, and is admin-shaped. This reads one
+  public record through /api/showcase/detail and has no write path at all.
+
+  CLICK-OUTSIDE CLOSES, per the ask. Three ways out, because a modal with one is
+  a trap: the backdrop, the Escape key (native <dialog> `cancel`), and the X.
+
+  THE RECORD'S OWN THEME, on the wrapper above the surface that reads the
+  tokens -- the same rule the rails and character-card.vue follow. Opening a
+  character in their own colours is most of what makes this feel like arriving
+  somewhere rather than expanding a row.
+-->
+<template>
+  <Teleport to="body">
+    <dialog
+      class="modal modal-open"
+      aria-modal="true"
+      @cancel.prevent="emit('close')"
+      @click.self="emit('close')"
+    >
+      <div
+        :data-theme="detail?.theme || undefined"
+        class="modal-box flex max-h-[88dvh] w-[min(94vw,58rem)] max-w-none flex-col overflow-hidden rounded-3xl border-2 border-primary/60 bg-base-100 p-0 shadow-2xl"
+      >
+        <header
+          class="flex shrink-0 items-start gap-3 border-b border-base-300 p-3 sm:p-4"
+        >
+          <div class="min-w-0 flex-1">
+            <p
+              class="text-[0.6rem] font-black uppercase tracking-[0.18em] text-primary"
+            >
+              {{ kindLabel }}
+            </p>
+            <h2 class="truncate text-lg font-black sm:text-xl">
+              {{ detail?.title || card.title }}
+            </h2>
+            <p
+              v-if="detail?.subtitle"
+              class="mt-0.5 line-clamp-1 text-sm text-base-content/60"
+            >
+              {{ detail.subtitle }}
+            </p>
+          </div>
+
+          <button
+            type="button"
+            class="btn btn-ghost btn-square btn-sm shrink-0 rounded-xl"
+            aria-label="Close"
+            @click="emit('close')"
+          >
+            <Icon name="kind-icon:x" class="size-4" />
+          </button>
+        </header>
+
+        <!--
+          The one scroll region in here, and a bounded one: the layout
+          contract's one-scroll rule counts page-level owners, and a modal's
+          own body is not the page's.
+        -->
+        <div
+          class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3 sm:p-4"
+        >
+          <div v-if="pending" class="flex min-h-40 items-center justify-center">
+            <span class="loading loading-spinner loading-md text-primary" />
+            <span class="sr-only">Loading details…</span>
+          </div>
+
+          <div v-else-if="errorMessage" class="kr-note kr-note-warning">
+            {{ errorMessage }}
+          </div>
+
+          <!--
+            Container-width columns, not a viewport breakpoint. The layout
+            contract's viewport-grid rule caught the `lg:` version, and it was
+            right to: this box is `w-[min(94vw,58rem)]`, so on a wide screen the
+            grid is 58rem while `lg:` is asking about a 1280px viewport. auto-fit
+            splits when THIS element has room for two 20rem tracks, which is the
+            question actually being asked.
+          -->
+          <div
+            v-else
+            class="grid gap-4 grid-cols-[repeat(auto-fit,minmax(min(100%,20rem),1fr))]"
+          >
+            <div class="overflow-hidden rounded-2xl border border-base-300">
+              <kr-art-plate
+                :source="detail?.art ?? card.art"
+                variant="hero"
+                :shape="
+                  card.kind === 'art' || card.kind === 'animation'
+                    ? 'wide'
+                    : 'card'
+                "
+                frame="none"
+                :alt="detail?.title || card.title"
+                :fallback="fallback"
+                fit="contain"
+                eager
+              />
+            </div>
+
+            <div class="flex min-w-0 flex-col gap-3">
+              <p
+                v-if="detail?.body"
+                class="kr-prose whitespace-pre-line text-sm leading-relaxed"
+              >
+                {{ detail.body }}
+              </p>
+              <p v-else class="text-sm italic text-base-content/45">
+                No description has been written for this one yet.
+              </p>
+
+              <dl
+                v-if="detail?.facts.length"
+                class="grid gap-x-3 gap-y-1.5 grid-cols-[repeat(auto-fit,minmax(min(100%,10rem),1fr))]"
+              >
+                <div
+                  v-for="fact in detail.facts"
+                  :key="fact.label"
+                  class="min-w-0 rounded-lg border border-base-300 bg-base-200/50 px-2 py-1"
+                >
+                  <dt
+                    class="text-[0.55rem] font-black uppercase tracking-[0.14em] text-base-content/45"
+                  >
+                    {{ fact.label }}
+                  </dt>
+                  <dd class="line-clamp-3 text-xs font-bold leading-snug">
+                    {{ fact.value }}
+                  </dd>
+                </div>
+              </dl>
+
+              <!--
+                "plus review", and it is the reviews themselves rather than a
+                link to them. There is no /reviews route -- review-list.vue is a
+                component every gallery embeds, generic over Reaction target
+                type, and every showcase kind maps onto one of those types. So
+                the reviews can simply be here, which is better than the link I
+                first reached for and which would have 404'd.
+              -->
+              <review-list
+                v-if="reviewTarget"
+                :target-type="reviewTarget"
+                :target-id="card.id"
+                empty-label="No reviews yet — be the first."
+              />
+            </div>
+          </div>
+        </div>
+
+        <!--
+          ONE DOOR, because there is only one real one. Silas asked for the
+          interstitial to lead to "those options, plus review": edit, interact
+          and select all live on the record's own manager page, which
+          `detail.href` opens with this record already selected. Splitting that
+          into three buttons would have meant inventing /chat and /reviews
+          routes that do not exist -- the first version of this footer did
+          exactly that, and both links would have 404'd from the front page.
+          Reviews moved inline above instead.
+        -->
+        <footer
+          class="flex shrink-0 flex-wrap items-center justify-between gap-2 border-t border-base-300 p-3"
+        >
+          <p class="text-[0.65rem] text-base-content/45">
+            {{ createdLabel }}
+          </p>
+
+          <NuxtLink
+            :to="detail?.href || showcaseHref(card)"
+            class="btn btn-primary btn-sm gap-1.5 rounded-xl"
+          >
+            Open {{ kindLabel.toLowerCase() }}
+            <Icon name="kind-icon:chevron-right" class="size-4" />
+          </NuxtLink>
+        </footer>
+      </div>
+    </dialog>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import type { ShowcaseDetail } from '@/server/api/showcase/detail.get'
+import {
+  showcaseHref,
+  type RailItem,
+  type ShowcaseKind,
+} from '@/utils/homeShowcase'
+import type { ReactionTargetType } from '@/stores/reactionStore'
+import { defaultArtFor } from '@/utils/defaultArtPool'
+
+const props = defineProps<{ card: RailItem }>()
+const emit = defineEmits<{ close: [] }>()
+
+const detail = ref<ShowcaseDetail | null>(null)
+const pending = ref(true)
+const errorMessage = ref('')
+
+const KIND_LABELS: Record<string, string> = {
+  art: 'Render',
+  animation: 'Animation',
+  dream: 'Dream',
+  character: 'Character',
+  bot: 'Bot',
+  reward: 'Reward',
+  scenario: 'Scenario',
+  facet: 'Facet',
+  project: 'Project',
+}
+
+const kindLabel = computed(
+  () => KIND_LABELS[props.card.kind] ?? props.card.kind,
+)
+
+const fallback = computed(() =>
+  defaultArtFor(`${props.card.kind}-${props.card.id}`),
+)
+
+/*
+ * The Reaction target type for this kind, or null when the kind has none.
+ *
+ * Every showcase kind but `animation` maps straight onto a KARMA_REF_TARGET
+ * (utils/karmaRefTypes.ts); an animation is an ArtImage row like any render, so
+ * it maps there too. Reviews are stored against these names, so this is the
+ * whole join -- there is no separate reviews table to look up.
+ */
+const REVIEW_TARGETS: Partial<Record<ShowcaseKind, ReactionTargetType>> = {
+  art: 'artImage',
+  animation: 'artImage',
+  dream: 'dream',
+  character: 'character',
+  bot: 'bot',
+  reward: 'reward',
+  scenario: 'scenario',
+  facet: 'facet',
+  project: 'project',
+}
+
+const reviewTarget = computed<ReactionTargetType | null>(
+  () => REVIEW_TARGETS[props.card.kind] ?? null,
+)
+
+const createdLabel = computed(() => {
+  const created = new Date(detail.value?.createdAt || props.card.createdAt)
+  if (Number.isNaN(created.getTime())) return ''
+  return `Made ${created.toLocaleDateString(undefined, {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  })}`
+})
+
+async function load(): Promise<void> {
+  pending.value = true
+  errorMessage.value = ''
+  try {
+    detail.value = await $fetch<ShowcaseDetail>('/api/showcase/detail', {
+      query: { kind: props.card.kind, id: props.card.id },
+    })
+  } catch {
+    detail.value = null
+    // The tile is still on screen behind this and already said what it knew,
+    // so this is a soft failure: say the extra detail is unavailable rather
+    // than implying the object itself is gone.
+    errorMessage.value = 'Could not load the details for this one right now.'
+  } finally {
+    pending.value = false
+  }
+}
+
+onMounted(load)
+
+// The sheet stays mounted while the selection changes (clicking a second tile
+// underneath is not possible, but a route-driven selection could), so refetch
+// rather than assuming one card per mount.
+watch(() => [props.card.kind, props.card.id], load)
+</script>

--- a/components/home/home-object-sheet.vue
+++ b/components/home/home-object-sheet.vue
@@ -197,6 +197,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import type { ShowcaseDetail } from '@/server/api/showcase/detail.get'
+import { performFetch } from '@/stores/utils'
 import {
   showcaseHref,
   type RailItem,
@@ -270,9 +271,19 @@ async function load(): Promise<void> {
   pending.value = true
   errorMessage.value = ''
   try {
-    detail.value = await $fetch<ShowcaseDetail>('/api/showcase/detail', {
-      query: { kind: props.card.kind, id: props.card.id },
-    })
+    /*
+     * performFetch, not $fetch: it is what every other store here uses, it
+     * unwraps the endpoint's {success, message, data} envelope, and Nuxt's
+     * typed $fetch overload resolution failed outright on this call with
+     * TS2589 ("type instantiation is excessively deep").
+     */
+    const response = await performFetch<ShowcaseDetail>(
+      `/api/showcase/detail?kind=${encodeURIComponent(props.card.kind)}&id=${props.card.id}`,
+    )
+    if (!response.success || !response.data) {
+      throw new Error(response.message || 'detail unavailable')
+    }
+    detail.value = response.data
   } catch {
     detail.value = null
     // The tile is still on screen behind this and already said what it knew,

--- a/components/home/home-page.vue
+++ b/components/home/home-page.vue
@@ -60,6 +60,7 @@
         v-if="showcaseStore.hero"
         class="min-w-0 lg:flex-1"
         :hero="showcaseStore.hero"
+        @select="openCard"
       />
 
       <div
@@ -80,19 +81,38 @@
       v-if="visibleRails.length"
       class="grid auto-rows-fr gap-2 sm:grid-cols-2 lg:grid-cols-4"
     >
-      <home-rail
-        v-for="entry in visibleRails"
-        :key="entry.key"
-        :class="entry.cellClass"
-        :label="entry.label"
-        :items="entry.items"
-        :see-all-href="entry.href"
-        :shape="entry.shape"
-        :plate-variant="entry.plateVariant"
-        :placeholder-icon="entry.placeholderIcon"
-        :rows="entry.rows ?? 1"
-        :fit="entry.fit ?? 'cover'"
-      />
+      <template v-for="entry in visibleRails" :key="entry.key">
+        <!--
+          The art cell is the one shelf with two modes behind it. Silas,
+          2026-08-29: "let me togle between the fresh from art queue and to see
+          the current progress, and choose from active to failed, etc, keeping
+          the layout, which otherwise is great." home-art-shelf renders the SAME
+          home-rail in the same two-row cell and only swaps what fills it, so
+          "keeping the layout" is structural rather than a thing to re-check.
+        -->
+        <home-art-shelf
+          v-if="entry.key === 'art'"
+          :class="entry.cellClass"
+          :fresh="entry.items"
+          @select="openCard"
+        />
+
+        <home-rail
+          v-else
+          :class="entry.cellClass"
+          :label="entry.label"
+          :icon="entry.icon"
+          :items="entry.items"
+          :see-all-href="entry.href"
+          :shape="entry.shape"
+          :plate-variant="entry.plateVariant"
+          :placeholder-icon="entry.placeholderIcon"
+          :rows="entry.rows ?? 1"
+          :fit="entry.fit ?? 'cover'"
+          interactive
+          @select="openCard"
+        />
+      </template>
     </div>
 
     <div
@@ -206,43 +226,64 @@
       </div>
     </section>
 
-    <!-- The feed, still whole. -->
-    <section class="flex flex-col gap-1.5 kr-panel-flat p-3">
-      <header class="flex flex-wrap items-baseline justify-between gap-3">
-        <h2
-          class="text-[0.7rem] font-black uppercase tracking-[0.16em] text-primary"
-        >
-          From around the web
-        </h2>
+    <!--
+      The feed, still whole -- but its heading now sits IN its control strip
+      rather than in a section header above it. Silas, 2026-08-29: "The
+      selections like all ai news, etc, and the other icons, should be in line
+      with the From around the web and newsfeed tab section." That was two full
+      rows of chrome before the first story; the `lead`/`trail` slots on
+      newsfeed-feed make it one.
 
-        <NuxtLink
-          to="/plan/newsfeed"
-          class="link link-hover text-[0.7rem] font-bold text-base-content/50 hover:text-primary"
-        >
-          newsfeed lab →
-        </NuxtLink>
-      </header>
+      The scroller is bounded rather than however tall the feed wants to be
+      ("newsfeeds should scroll vertically, and take up less height"). The
+      contract's one-scroll rule deliberately does not count a `max-h-*` region
+      -- those are nested previews, not the page's scroll owner, which is still
+      pages/[...slug].vue's content-host.
+    -->
+    <section class="flex flex-col kr-panel-flat p-3">
+      <NewsfeedFeed :initial-limit="24" compact>
+        <template #lead>
+          <h2
+            class="hidden shrink-0 text-[0.7rem] font-black uppercase tracking-[0.16em] text-primary lg:block"
+          >
+            From around the web
+          </h2>
+        </template>
 
-      <!--
-        Bounded and vertically scrolling rather than however tall the feed
-        wants to be. Silas, 2026-08-29: "newsfeeds should scroll vertically, and
-        take up less height." The contract's one-scroll rule deliberately does
-        not count a `max-h-*` region -- those are nested previews, not the
-        page's scroll owner, which is still pages/[...slug].vue's content-host.
-      -->
-      <div class="max-h-64 overflow-y-auto overscroll-contain pr-1">
-        <NewsfeedFeed :initial-limit="24" compact />
-      </div>
+        <template #trail>
+          <NuxtLink
+            to="/plan/newsfeed"
+            class="link link-hover shrink-0 text-[0.7rem] font-bold text-base-content/50 hover:text-primary"
+          >
+            lab →
+          </NuxtLink>
+        </template>
+      </NewsfeedFeed>
     </section>
+
+    <!--
+      The interstitial. Silas, 2026-08-29: "Whenever I click on one of the new
+      objects, I want it to expand to tell me about it ... with clicking outside
+      the container returning to the homepage."
+
+      Mounted only while something is selected, so its detail fetch happens on
+      the click rather than on page load.
+    -->
+    <home-object-sheet
+      v-if="selectedCard"
+      :card="selectedCard"
+      @close="selectedCard = null"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useConductorStore } from '@/stores/conductorStore'
 import { useHomeShowcaseStore } from '@/stores/homeShowcaseStore'
 import {
   showcaseHref,
+  type RailItem,
   type ShowcaseCard,
   type ShowcaseRailKey,
 } from '@/utils/homeShowcase'
@@ -252,7 +293,15 @@ import type { ArtPlateShape } from '@/utils/galleryVocabulary'
 
 type RailDefinition = {
   key: ShowcaseRailKey
+  /**
+   * Still required, still not printed. Silas, 2026-08-29: "Would love to
+   * replace the words for new dreams, characters, etc with just an icon." The
+   * shelf renders `icon` and keeps this as its tooltip and accessible name --
+   * the words leave the screen, not the accessibility tree.
+   */
   label: string
+  /** The glyph shown in place of the label. */
+  icon: string
   /** Shown inside a plate that resolved no art at all -- never in the header. */
   placeholderIcon: string
   href: string
@@ -266,6 +315,19 @@ type RailDefinition = {
 
 const showcaseStore = useHomeShowcaseStore()
 const conductorStore = useConductorStore()
+
+/**
+ * The card the interstitial is showing, or null.
+ *
+ * Held here rather than in a store because nothing outside this page reads it,
+ * and because a page-scoped ref is cleared by navigation for free -- a store
+ * would keep the sheet "open" behind a route change.
+ */
+const selectedCard = ref<RailItem | null>(null)
+
+function openCard(card: RailItem): void {
+  selectedCard.value = card
+}
 
 /**
  * Percent complete for a project, joined to conductor's own figure on
@@ -308,6 +370,7 @@ const RAILS: RailDefinition[] = [
   {
     key: 'art',
     label: 'Fresh from the art queue',
+    icon: 'kind-icon:palette-color',
     placeholderIcon: 'kind-icon:palette-color',
     href: '/art',
     shape: 'wide',
@@ -323,6 +386,7 @@ const RAILS: RailDefinition[] = [
   {
     key: 'animations',
     label: 'Moving pictures',
+    icon: 'kind-icon:movie',
     placeholderIcon: 'kind-icon:movie',
     href: '/art',
     shape: 'wide',
@@ -331,6 +395,7 @@ const RAILS: RailDefinition[] = [
   {
     key: 'dreams',
     label: 'New dreams',
+    icon: 'kind-icon:dream',
     placeholderIcon: 'kind-icon:dream',
     href: '/dreams',
     shape: 'square',
@@ -339,6 +404,7 @@ const RAILS: RailDefinition[] = [
   {
     key: 'characters',
     label: 'New characters',
+    icon: 'kind-icon:character',
     placeholderIcon: 'kind-icon:character',
     href: '/characters',
     shape: 'square',
@@ -347,6 +413,7 @@ const RAILS: RailDefinition[] = [
   {
     key: 'scenarios',
     label: 'New scenarios',
+    icon: 'kind-icon:scenario',
     placeholderIcon: 'kind-icon:scenario',
     href: '/stories',
     shape: 'square',
@@ -355,6 +422,7 @@ const RAILS: RailDefinition[] = [
   {
     key: 'rewards',
     label: 'New items and skills',
+    icon: 'kind-icon:treasure',
     placeholderIcon: 'kind-icon:treasure',
     href: '/rewards',
     shape: 'square',
@@ -363,6 +431,7 @@ const RAILS: RailDefinition[] = [
   {
     key: 'bots',
     label: 'New bots',
+    icon: 'kind-icon:robot',
     placeholderIcon: 'kind-icon:robot',
     href: '/bots',
     shape: 'square',
@@ -371,6 +440,7 @@ const RAILS: RailDefinition[] = [
   {
     key: 'facets',
     label: 'New facets',
+    icon: 'kind-icon:shapes',
     placeholderIcon: 'kind-icon:shapes',
     href: '/facets',
     shape: 'square',

--- a/components/home/home-rail.vue
+++ b/components/home/home-rail.vue
@@ -1,6 +1,6 @@
 <!-- /components/home/home-rail.vue -->
 <!--
-  One shelf on the home page: a label, a destination, and a row of plates that
+  One shelf on the home page: an icon, a destination, and a row of plates that
   scrolls sideways.
 
   Silas, 2026-08-28: "These displays should always lead to something, not just
@@ -14,6 +14,21 @@
   label and a caption sitting directly on that had no ground of their own and
   dissolved into whatever the backdrop happened to be doing. The panel is that
   ground.
+
+  THE HEADER IS TWO GLYPHS. Silas, 2026-08-29: "Would love to replace the words
+  for new dreams, characters, etc with just an icon, same with see all, and slim
+  it does even more." The words cost a full text line per shelf across eight
+  shelves; the icons say the same thing in the height of the row they share with
+  the count. The label survives as the link's accessible name and its tooltip --
+  it is removed from the screen, not from the accessibility tree.
+
+  CHEVRONS, NOT A SCROLLBAR. Silas, same message: "Could we use <> chevrons
+  instead of a scrollbar, or at least, only show the scrollbar if highlighted,
+  there is a lot of space taken up by them overall." Eight shelves each reserving
+  a horizontal scrollbar gutter is eight rows of nothing. The track is
+  `.no-scrollbar` and the two chevrons sit IN the header row, which was already
+  there -- so the control costs no height at all, and disappears entirely on a
+  shelf whose tiles already fit.
 
   EVERY TILE WEARS ITS RECORD'S OWN THEME. Silas, 2026-08-29: "The lack of
   different theme colors is notable, it would give us more variety easily" --
@@ -37,18 +52,62 @@
 -->
 <template>
   <section class="flex h-full min-w-0 flex-col gap-1 kr-panel-flat p-2">
-    <header class="flex flex-wrap items-baseline justify-between gap-x-3">
-      <h2
-        class="text-[0.7rem] font-black uppercase tracking-[0.16em] text-primary"
+    <header class="flex shrink-0 items-center gap-1">
+      <!--
+        The shelf's identity, as one glyph. `title` and `aria-label` carry the
+        words so a screen reader and a hover both still get "New characters".
+      -->
+      <span
+        class="flex shrink-0 items-center gap-1 text-primary"
+        :title="label"
+        :aria-label="label"
       >
-        {{ label }}
-      </h2>
+        <Icon :name="icon || placeholderIcon" class="size-4" />
+        <span
+          v-if="items.length"
+          class="text-[0.6rem] font-black tabular-nums text-base-content/40"
+          >{{ items.length }}</span
+        >
+      </span>
+
+      <!-- Anything the host wants in this row (the art shelf's mode toggle). -->
+      <div class="flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
+        <slot name="controls" />
+      </div>
+
+      <!--
+        Both chevrons and the destination, all icon-sized, all in the row the
+        header already occupied. `v-show` rather than `v-if` on the chevrons so
+        the header's width does not jump as a shelf becomes scrollable.
+      -->
+      <span v-show="canScroll" class="flex shrink-0 items-center">
+        <button
+          type="button"
+          class="grid size-5 place-items-center rounded text-base-content/45 transition-colors hover:text-primary disabled:opacity-25 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+          :disabled="atStart"
+          :aria-label="`Scroll ${label} backwards`"
+          @click="scrollBy(-1)"
+        >
+          <Icon name="kind-icon:chevron-left" class="size-3.5" />
+        </button>
+        <button
+          type="button"
+          class="grid size-5 place-items-center rounded text-base-content/45 transition-colors hover:text-primary disabled:opacity-25 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+          :disabled="atEnd"
+          :aria-label="`Scroll ${label} forwards`"
+          @click="scrollBy(1)"
+        >
+          <Icon name="kind-icon:chevron-right" class="size-3.5" />
+        </button>
+      </span>
 
       <NuxtLink
         :to="seeAllHref"
-        class="link link-hover text-[0.7rem] font-bold text-base-content/50 transition-colors hover:text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+        class="grid size-5 shrink-0 place-items-center rounded text-base-content/45 transition-colors hover:text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+        :title="`${label} — ${seeAllLabel}`"
+        :aria-label="`${label} — ${seeAllLabel}`"
       >
-        {{ seeAllLabel }} →
+        <Icon name="kind-icon:arrow-right" class="size-3.5" />
       </NuxtLink>
     </header>
 
@@ -57,8 +116,7 @@
       container to keep focus rings from clipping; inside a panel that just
       pushed the first tile under the panel's own edge. The ring is handled with
       `outline-offset-0` on the tiles instead, which needs no bleed.
-    -->
-    <!--
+
       `rows="2"` lays the tiles out as a two-row grid flowing sideways rather
       than a single row. Silas, 2026-08-29: "on desktop, art queue can take up
       twice the height, so we have an even spacing for the other six objects" --
@@ -66,12 +124,14 @@
       cell instead of one row floating in it.
     -->
     <div
-      class="min-h-0 flex-1 overflow-x-auto pb-1"
+      ref="track"
+      class="no-scrollbar min-h-0 flex-1 overflow-x-auto scroll-smooth"
       :class="
         rows === 2
           ? 'grid grid-flow-col grid-rows-2 auto-cols-max content-between gap-2'
           : 'flex gap-2'
       "
+      @scroll.passive="measure"
     >
       <!--
         border-2 in the record's own PRIMARY, not base-300. Silas, 2026-08-29:
@@ -80,14 +140,17 @@
         but every theme's base-300 is a near-neutral grey, so the variety was
         invisible; primary is the token that actually differs between themes.
       -->
-      <NuxtLink
+      <component
+        :is="interactive ? 'button' : 'NuxtLink'"
         v-for="item in items"
         :key="`${item.kind}-${item.id}`"
-        :to="showcaseHref(item)"
+        :type="interactive ? 'button' : undefined"
+        :to="interactive ? undefined : showcaseHref(item)"
         :data-theme="themeFor(item)"
-        class="group flex shrink-0 flex-col overflow-hidden rounded-xl border-2 border-primary/70 bg-base-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:duration-300 motion-safe:hover:-translate-y-0.5"
+        class="group flex shrink-0 flex-col overflow-hidden rounded-xl border-2 border-primary/70 bg-base-100 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:duration-300 motion-safe:hover:-translate-y-0.5"
         :class="cardWidthClass"
         :title="item.subtitle ? `${item.title} — ${item.subtitle}` : item.title"
+        @click="interactive ? emit('select', item) : undefined"
       >
         <kr-art-plate
           :source="item.art"
@@ -99,7 +162,21 @@
           :placeholder-icon="placeholderIcon"
           hover-zoom
           :fit="fit"
-        />
+        >
+          <!--
+            A queue tile's state, as a corner chip. Only the art shelf's queue
+            mode sets this; every other shelf shows objects that are simply
+            finished and passes nothing.
+          -->
+          <template v-if="item.status" #overlay>
+            <span
+              class="absolute left-1 top-1 max-w-[calc(100%-0.5rem)] truncate rounded px-1 text-[0.45rem] font-black uppercase tracking-[0.08em] backdrop-blur"
+              :class="statusChipClass(item.status)"
+            >
+              {{ item.status }}
+            </span>
+          </template>
+        </kr-art-plate>
 
         <!--
           Title only. The subtitle used to sit under it, but at a 5rem tile it
@@ -113,14 +190,14 @@
             {{ item.title }}
           </p>
         </div>
-      </NuxtLink>
+      </component>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import { showcaseHref, type ShowcaseCard } from '@/utils/homeShowcase'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { showcaseHref, type RailItem } from '@/utils/homeShowcase'
 import type { ArtVariant } from '@/utils/artImageSrc'
 import type { ArtPlateShape } from '@/utils/galleryVocabulary'
 import { defaultArtFor } from '@/utils/defaultArtPool'
@@ -129,9 +206,11 @@ import { resolveEntityTheme } from '@/utils/entityTheme'
 const props = withDefaults(
   defineProps<{
     label: string
-    items: ShowcaseCard[]
+    items: RailItem[]
     seeAllHref: string
     seeAllLabel?: string
+    /** The glyph that replaces the shelf's written label on screen. */
+    icon?: string
     /** 'card' is the 2:3 portrait shelf; 'wide' is the 4:3 art shelf. */
     shape?: ArtPlateShape
     plateVariant?: ArtVariant
@@ -145,6 +224,12 @@ const props = withDefaults(
      * and wrong for the queue, where the point is what was actually made.
      */
     fit?: 'cover' | 'contain'
+    /**
+     * Tiles emit `select` instead of navigating. Silas, 2026-08-29: "Whenever I
+     * click on one of the new objects, I want it to expand to tell me about it
+     * ... with clicking outside the container returning to the homepage."
+     */
+    interactive?: boolean
   }>(),
   {
     seeAllLabel: 'see all',
@@ -152,9 +237,18 @@ const props = withDefaults(
     shape: 'card',
     plateVariant: 'card',
     placeholderIcon: 'kind-icon:image',
+    icon: '',
     rows: 1,
+    interactive: false,
   },
 )
+
+const emit = defineEmits<{ select: [item: RailItem] }>()
+
+const track = ref<HTMLElement | null>(null)
+const canScroll = ref(false)
+const atStart = ref(true)
+const atEnd = ref(false)
 
 /*
  * Fixed tile widths, not a responsive column count: a rail's job is to leave a
@@ -163,8 +257,7 @@ const props = withDefaults(
  * layout contract's viewport-grid rule exists because such a component gets
  * embedded in hosts narrower than the viewport implies. These rails now sit in
  * a multi-column grid, which is exactly that case.
- */
-/*
+ *
  * The landscape rails run wider than the portrait ones because the art rail is
  * the one that spans two grid rows: at w-40 its two rows of 4:3 tiles came up
  * ~90px short of the cell the six object shelves define beside it, leaving a
@@ -174,7 +267,7 @@ const cardWidthClass = computed(() =>
   props.shape === 'wide' || props.shape === 'hero' ? 'w-48' : 'w-32',
 )
 
-function fallbackFor(item: ShowcaseCard): string {
+function fallbackFor(item: RailItem): string {
   return defaultArtFor(`${item.kind}-${item.id}`)
 }
 
@@ -191,9 +284,82 @@ function fallbackFor(item: ShowcaseCard): string {
  * Art and clips keep the page theme, so a letterboxed render sits on warm paper
  * like everything else.
  */
-function themeFor(item: ShowcaseCard): string | undefined {
+function themeFor(item: RailItem): string | undefined {
   if (item.kind === 'art' || item.kind === 'animation') return undefined
 
   return resolveEntityTheme({ id: item.id, theme: item.theme })
 }
+
+/*
+ * Tone the queue chip by what it is telling you, using daisyUI's semantic
+ * tokens so it reads correctly in every theme rather than in the one it was
+ * designed against.
+ */
+function statusChipClass(status: string): string {
+  switch (status.toUpperCase()) {
+    case 'FAILED':
+      return 'bg-error text-error-content'
+    case 'RUNNING':
+      return 'bg-warning text-warning-content'
+    case 'DONE':
+      return 'bg-success text-success-content'
+    case 'CANCELLED':
+      return 'bg-base-300 text-base-content/70'
+    default:
+      return 'bg-base-100/90 text-base-content'
+  }
+}
+
+/**
+ * Whether the track overflows, and which ends it has reached — the chevrons'
+ * visible and disabled states.
+ *
+ * The 2px slack absorbs sub-pixel layout rounding: without it a track scrolled
+ * fully right reports `scrollLeft + clientWidth` a fraction under `scrollWidth`
+ * forever, and the forward chevron never disables.
+ */
+function measure(): void {
+  const element = track.value
+  if (!element) return
+
+  const max = element.scrollWidth - element.clientWidth
+  canScroll.value = max > 2
+  atStart.value = element.scrollLeft <= 2
+  atEnd.value = element.scrollLeft >= max - 2
+}
+
+/** One press moves about a screenful of shelf, keeping a tile of context. */
+function scrollBy(direction: 1 | -1): void {
+  const element = track.value
+  if (!element) return
+
+  element.scrollBy({
+    left: direction * Math.max(element.clientWidth * 0.8, 160),
+    behavior: 'smooth',
+  })
+}
+
+let observer: ResizeObserver | null = null
+
+onMounted(() => {
+  measure()
+  if (typeof ResizeObserver === 'undefined') return
+
+  // The shelf's width changes with the page grid, not just with its contents,
+  // so a content watcher alone would leave stale chevrons after a resize.
+  observer = new ResizeObserver(() => measure())
+  if (track.value) observer.observe(track.value)
+})
+
+onBeforeUnmount(() => {
+  observer?.disconnect()
+  observer = null
+})
+
+watch(
+  () => props.items.length,
+  () => {
+    void nextTick(measure)
+  },
+)
 </script>

--- a/components/home/home-rail.vue
+++ b/components/home/home-rail.vue
@@ -140,17 +140,25 @@
         but every theme's base-300 is a near-neutral grey, so the variety was
         invisible; primary is the token that actually differs between themes.
       -->
-      <component
-        :is="interactive ? 'button' : 'NuxtLink'"
+      <!--
+        STILL A LINK, even when it opens the interstitial. `interactive` used to
+        swap this element for a <button>, which threw away the href: no
+        middle-click, no "open in new tab", no destination in the status bar,
+        and nothing for a crawler -- on the page whose whole brief is "These
+        displays should always lead to something". Intercepting the plain click
+        keeps the anchor and its address and still opens the sheet, and a
+        modified click (cmd, ctrl, shift, middle) falls through to the browser
+        exactly as it should.
+      -->
+      <NuxtLink
         v-for="item in items"
         :key="`${item.kind}-${item.id}`"
-        :type="interactive ? 'button' : undefined"
-        :to="interactive ? undefined : showcaseHref(item)"
+        :to="showcaseHref(item)"
         :data-theme="themeFor(item)"
         class="group flex shrink-0 flex-col overflow-hidden rounded-xl border-2 border-primary/70 bg-base-100 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:duration-300 motion-safe:hover:-translate-y-0.5"
         :class="cardWidthClass"
         :title="item.subtitle ? `${item.title} — ${item.subtitle}` : item.title"
-        @click="interactive ? emit('select', item) : undefined"
+        @click="onTileClick($event, item)"
       >
         <kr-art-plate
           :source="item.art"
@@ -190,7 +198,7 @@
             {{ item.title }}
           </p>
         </div>
-      </component>
+      </NuxtLink>
     </div>
   </section>
 </template>
@@ -266,6 +274,24 @@ const atEnd = ref(false)
 const cardWidthClass = computed(() =>
   props.shape === 'wide' || props.shape === 'hero' ? 'w-48' : 'w-32',
 )
+
+/**
+ * Opens the interstitial for a plain left click on an interactive shelf, and
+ * otherwise leaves the anchor alone.
+ *
+ * The modifier checks are what keep cmd/ctrl-click ("open in a new tab"),
+ * shift-click ("open in a new window") and middle-click working: preventing
+ * those would break the ordinary browser affordances the anchor exists to
+ * provide.
+ */
+function onTileClick(event: MouseEvent, item: RailItem): void {
+  if (!props.interactive) return
+  if (event.button !== 0) return
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
+
+  event.preventDefault()
+  emit('select', item)
+}
 
 function fallbackFor(item: RailItem): string {
   return defaultArtFor(`${item.kind}-${item.id}`)

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -109,23 +109,50 @@
             THE EMPTY STRETCH, given something to say. Silas, 2026-08-29: "we
             still have a wide akward space in the navigation tab selector, it
             would be better on sufficiently large screens to show a unique tab
-            message, we should have something in front matter."
+            message, we should have something in front matter." And again after
+            that shipped: "Still seeing no information and a very large tab
+            seletor ... that giant bar is selectable with crazy whitespace ...
+            we could put something else there, a kind robots title and a
+            subtitle?"
 
             A dropdown needs room for one label and no more, so `flex-1` on it
-            spent the rest of the row on nothing. The tab-select now takes only
-            what it needs and this takes the remainder -- but only from `lg`,
-            because below that the row genuinely has no spare width and a
-            truncated half-sentence is worse than blank space.
-          -->
-          <p
-            v-if="tabMessage"
-            class="hidden min-w-0 flex-1 items-center truncate px-3 text-sm text-base-content/55 lg:flex"
-            :title="tabMessage"
-          >
-            {{ tabMessage }}
-          </p>
+            spent the rest of the row on nothing. tab-select now takes only what
+            it needs and this takes the remainder -- but only from `lg`, because
+            below that the row genuinely has no spare width and a truncated
+            half-sentence is worse than blank space.
 
-          <span v-else class="min-w-0 flex-1" />
+            TWO REASONS IT WAS STILL BLANK after the first attempt, both fixed:
+
+              1. `tabMessage` was not declared in content.config.ts, so Nuxt
+                 Content dropped the key while parsing frontmatter and
+                 pageStore.tabMessage was always ''. content/index.md had
+                 carried one the whole time. See the note there.
+              2. Nothing else filled in when a page HAD no tabMessage, which is
+                 every page but the home page. The brand line plus the page's
+                 own subtitle always exist, so the stretch now always says
+                 something rather than depending on per-page authoring.
+
+            NOT INTERACTIVE, and that matters: it sits inside the same bordered
+            shell as two dropdowns, so `pointer-events-none` keeps the whole
+            width from reading as one enormous button ("that giant bar is
+            selectable"). Only the tab label to its left opens the menu.
+          -->
+          <div
+            class="pointer-events-none hidden min-w-0 flex-1 flex-col justify-center px-3 leading-tight lg:flex"
+            :title="headerMessage"
+          >
+            <span
+              class="truncate text-[0.65rem] font-black uppercase tracking-[0.18em] text-primary/75"
+            >
+              {{ brandLine }}
+            </span>
+            <span
+              v-if="headerMessage"
+              class="truncate text-sm text-base-content/55"
+            >
+              {{ headerMessage }}
+            </span>
+          </div>
         </div>
 
         <!-- No tabs resolved (a bare route, or content still loading): fall
@@ -250,8 +277,6 @@ const resolvedTabs = computed(() => resolvedChannel.value?.tabs ?? [])
 // old title section. The channel name in channel-select says the same thing one
 // control to the left, so nothing repeats it.
 
-const tabMessage = computed(() => pageStore.tabMessage || '')
-
 const shellSummary = computed(
   () => pageStore.subtitle || pageStore.description || '',
 )
@@ -350,6 +375,27 @@ const activeTitle = computed(
     activeTabConfig.value.title ||
     activeTabConfig.value.label ||
     pageStore.title,
+)
+
+/*
+ * The brand, and then whatever this particular page has to say for itself.
+ *
+ * `tabMessage` is the authored, page-specific line and wins where it exists.
+ * Everything after it is a fallback so the stretch is never empty: a tab's own
+ * subtitle, then the page's. `activeTabConfig` resolves to fallbackTab (built
+ * from pageStore) on routes outside any channel, so this holds there too.
+ */
+const brandLine = computed(
+  () => pageStore.room || activeTitle.value || 'Kind Robots',
+)
+
+const headerMessage = computed(
+  () =>
+    pageStore.tabMessage ||
+    activeTabConfig.value.subtitle ||
+    pageStore.subtitle ||
+    activeTabConfig.value.summary ||
+    '',
 )
 
 /**

--- a/components/newsfeed/feed-card.vue
+++ b/components/newsfeed/feed-card.vue
@@ -5,13 +5,14 @@
     :href="allowNavigation ? item.url : undefined"
     :target="allowNavigation ? '_blank' : undefined"
     :rel="allowNavigation ? 'noopener noreferrer' : undefined"
-    class="group flex h-full flex-col gap-2 overflow-hidden kr-panel-flat p-3 shadow-sm transition-shadow duration-300 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 motion-safe:hover:-translate-y-0.5 motion-safe:transition-transform"
+    class="group flex h-full flex-col overflow-hidden kr-panel-flat shadow-sm transition-shadow duration-300 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 motion-safe:hover:-translate-y-0.5 motion-safe:transition-transform"
+    :class="compact ? 'gap-1 p-2' : 'gap-2 p-3'"
   >
     <kr-entity-card-body
       class="flex flex-1 flex-col"
       :title="item.title"
       :description="item.summary || undefined"
-      :show-description="!compact && Boolean(item.summary)"
+      :show-description="Boolean(item.summary)"
       :show-image="showImage"
       :source="imageSource"
       variant="hero"
@@ -19,40 +20,44 @@
       hover-zoom
       :badges="badges"
     >
+      <!--
+        ONE THIN LINE OF PROVENANCE. Silas, 2026-08-29: "I need more of the
+        title and description in the news feeds, way too much space is given to
+        origin, date and a return icon, we need an image and info. These aren't
+        that."
+
+        What went: the wrapping two-column row (source left, time right, each
+        free to claim a line of its own), the clock glyph, and the
+        external-link glyph. The card is a whole <a> to an external site, so
+        the arrow was decoration explaining what the entire card already is,
+        and the clock explained a string that reads "6h ago".
+
+        What stayed: the source, the time, and the perspective label -- the
+        last because BIAS-CONTROLS.md requires the rating to be visible
+        wherever a rated item is, not because it fits. All three now share one
+        truncating line at the smallest legible size, which returns roughly two
+        lines of card to the title and summary above.
+      -->
       <div
-        class="mt-auto flex flex-wrap items-center justify-between gap-2 pt-1"
+        class="mt-auto flex min-w-0 items-center gap-1.5 pt-1 text-[0.65rem] text-base-content/45"
       >
-        <span class="flex min-w-0 items-center gap-1.5">
-          <span
-            class="truncate text-xs font-bold text-base-content/55"
-            :title="item.source"
-          >
-            {{ item.source }}
-          </span>
-          <span
-            v-if="perspectiveLabel"
-            class="badge badge-ghost badge-xs shrink-0 gap-1 rounded-xl border-base-300"
-            :title="`Perspective rating from ${item.perspective?.source} — political-lean labels are provenance, not fact.`"
-          >
-            {{ perspectiveLabel }}
-          </span>
+        <span class="truncate font-bold" :title="item.source">
+          {{ item.source }}
         </span>
         <span
-          class="flex shrink-0 items-center gap-1 text-xs text-base-content/45"
+          v-if="perspectiveLabel"
+          class="shrink-0 rounded border border-base-300 px-1 font-bold"
+          :title="`Perspective rating from ${item.perspective?.source} — political-lean labels are provenance, not fact.`"
         >
-          <Icon name="kind-icon:clock" class="size-3" />
-          <time
-            :datetime="item.publishedAt"
-            :title="absoluteTime(item.publishedAt)"
-          >
-            {{ relativeTime(item.publishedAt) }}
-          </time>
-          <Icon
-            v-if="allowNavigation"
-            name="kind-icon:external-link"
-            class="size-3"
-          />
+          {{ perspectiveLabel }}
         </span>
+        <time
+          class="ml-auto shrink-0 tabular-nums"
+          :datetime="item.publishedAt"
+          :title="absoluteTime(item.publishedAt)"
+        >
+          {{ relativeTime(item.publishedAt) }}
+        </time>
       </div>
     </kr-entity-card-body>
   </component>
@@ -72,10 +77,15 @@ const props = withDefaults(
     showImage?: boolean
     allowNavigation?: boolean
     /**
-     * Drops the summary paragraph, keeping the plate, title, source and time.
-     * The home page shows the feed alongside eight other sections and asked for
-     * the whole page to fit in two screens (Silas, 2026-08-29); the Newsfeed Lab
-     * page, where the feed IS the page, leaves this off and reads in full.
+     * Tightens the card's own padding and gaps for the home page, where the
+     * feed sits alongside eight other sections.
+     *
+     * IT NO LONGER DROPS THE SUMMARY. It used to, to buy height back for the
+     * two-screen budget -- and that was the wrong thing to cut. Silas,
+     * 2026-08-29: "I need more of the title and description in the news feeds,
+     * way too much space is given to origin, date and a return icon." The
+     * height came back out of the provenance row instead, which was spending
+     * two lines on a source name and a timestamp.
      */
     compact?: boolean
   }>(),

--- a/components/newsfeed/newsfeed-feed.vue
+++ b/components/newsfeed/newsfeed-feed.vue
@@ -8,7 +8,7 @@
   (components/conductor/newsfeed-page.vue).
 -->
 <template>
-  <section class="flex flex-col gap-4">
+  <section class="flex flex-col gap-2">
     <!--
       ONE ROW. Silas, 2026-08-29: "we could condense the title and the selection
       for topics into one row instead of two large ones." The chips scroll
@@ -16,7 +16,21 @@
       label is guessable, so the whole strip is one line at any width.
     -->
     <header class="flex items-center gap-2">
-      <div class="flex min-w-0 flex-1 gap-1.5 overflow-x-auto">
+      <!--
+        ONE ROW WITH ITS HOST'S HEADING, not a row beneath it. Silas,
+        2026-08-29: "The selections like all ai news, etc, and the other icons,
+        should be in line with the From around the web and newsfeed tab
+        section."
+
+        The home page used to render its own "From around the web" heading and
+        "newsfeed lab" link in a section header, and then this strip below it --
+        two full rows of chrome above the first story. These slots let the host
+        put its heading and its link INTO this row, so there is one. The
+        Newsfeed Lab page passes neither and is unchanged.
+      -->
+      <slot name="lead" />
+
+      <div class="no-scrollbar flex min-w-0 flex-1 gap-1.5 overflow-x-auto">
         <button
           type="button"
           class="btn btn-sm shrink-0 rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
@@ -73,7 +87,7 @@
             :name="startsHere ? 'kind-icon:star' : 'kind-icon:stars'"
             class="size-4"
           />
-          <span class="hidden xl:inline">{{ pinLabel }}</span>
+          <span class="hidden 2xl:inline">{{ pinLabel }}</span>
         </button>
 
         <button
@@ -84,7 +98,7 @@
           @click="showManageFeeds = !showManageFeeds"
         >
           <Icon name="kind-icon:sliders" class="size-4" />
-          <span class="hidden xl:inline">Manage feeds</span>
+          <span class="hidden 2xl:inline">Manage feeds</span>
           <Icon
             :name="
               showManageFeeds
@@ -104,8 +118,10 @@
         >
           <span v-if="isLoading" class="loading loading-spinner loading-xs" />
           <Icon v-else name="kind-icon:refresh" class="size-4" />
-          <span class="hidden xl:inline">Refresh</span>
+          <span class="hidden 2xl:inline">Refresh</span>
         </button>
+
+        <slot name="trail" />
       </div>
     </header>
 

--- a/content.config.ts
+++ b/content.config.ts
@@ -89,6 +89,19 @@ const sharedNavigationSchema = z.object({
   backgroundTablet: z.string().optional(),
   backgroundDesktop: z.string().optional(),
   tooltip: z.string().optional(),
+  /*
+   * The line the workspace header shows beside the tab picker on wide screens.
+   *
+   * IT MUST BE DECLARED HERE TO EXIST AT ALL. Nuxt Content validates frontmatter
+   * against this schema and drops every key it does not know, so `tabMessage:`
+   * in a markdown file without this line parses to nothing and the header falls
+   * back to blank -- which is exactly what shipped: content/index.md carried a
+   * tabMessage from the day the header started reading one, and Silas
+   * (2026-08-29) still reported "no information and a very large tab selector".
+   * The renderer was never the problem; the field was being thrown away one
+   * layer earlier.
+   */
+  tabMessage: z.string().optional(),
   dottiTip: z.string().optional(),
   amiTip: z.string().optional(),
   // Simple author-facing narrator selector. The page loader normalizes this
@@ -154,6 +167,7 @@ export type PageBrief = {
   icon: string
   image: string
   tooltip: string
+  tabMessage?: string
   dottiTip: string
   amiTip: string
   narratorSlug?: string

--- a/server/api/conductor/task-action.post.ts
+++ b/server/api/conductor/task-action.post.ts
@@ -7,8 +7,8 @@ import { parseRoadmapYaml } from '@/server/utils/conductorRoadmap'
 
 const PROJECT_RE = /^[a-z0-9][a-z0-9-]*$/
 const TASK_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
-const ACTIONS = new Set(['approve', 'reject', 'comment'] as const)
-type TaskAction = 'approve' | 'reject' | 'comment'
+const ACTIONS = new Set(['approve', 'reject', 'comment', 'answer'] as const)
+type TaskAction = 'approve' | 'reject' | 'comment' | 'answer'
 
 type TaskActionBody = {
   projectSlug?: string
@@ -34,10 +34,10 @@ export default defineEventHandler(async (event) => {
   if (!ACTIONS.has(action)) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'action must be approve, reject, or comment',
+      statusMessage: 'action must be approve, reject, comment, or answer',
     })
   }
-  if ((action === 'reject' || action === 'comment') && !message) {
+  if (action !== 'approve' && !message) {
     throw createError({
       statusCode: 400,
       statusMessage: 'message is required for reject and comment actions',
@@ -86,10 +86,40 @@ export default defineEventHandler(async (event) => {
     eventPayload.operation = 'ready'
     eventPayload.approved_by_human = false
     eventPayload.note = `SENT BACK by ${actor} via Kind Robots For You. ${message}`
+  } else if (action === 'answer') {
+    /*
+     * THE MISSING LINK IN THE GATE PIPELINE. Silas, 2026-08-29: "if I click on
+     * one of the human gate notifications, it lets me enter a comment and that
+     * comment is fed to the next agent dealing with that problem ... we might
+     * be missing whatever ties the response to the project referenced. follow
+     * it end to end."
+     *
+     * Following it end to end found the break, and it is here rather than in
+     * the front end. `comment` writes the note and leaves the task at
+     * `needs-human`. Conductor's worker only ever selects `status: ready`
+     * (scripts/select_role.py -> run_worker.find_ready_task), so a commented
+     * gate is never picked up by anything: the answer lands in a YAML field
+     * and waits for a human to happen to read it. Answering a question and
+     * having nothing happen is the bug he could feel from the outside.
+     *
+     * `answer` is the action that was missing: the same note, plus the release
+     * back to `ready` that actually hands it to the next agent. It is NOT
+     * `reject` -- that sets approved_by_human: false, which is a verdict on the
+     * work, and stamps the note "SENT BACK". An answer is neither. This leaves
+     * approved_by_human untouched and says what it is.
+     */
+    eventPayload.operation = 'ready'
+    eventPayload.note = `HUMAN ANSWER from ${actor} via Kind Robots. Gate released for the next agent. ${message}`
   } else {
+    /*
+     * `comment` deliberately still parks. It is for adding context to a gate
+     * that should STAY gated. Conductor's audit_human_gates.py flags a gate
+     * whose newest note is one of these so the next session surfaces it rather
+     * than letting it sit unread -- which is the other half of the fix above.
+     */
     eventPayload.operation = 'needs-human'
     eventPayload.soft_gate = task.softGate
-    eventPayload.note = `HUMAN NOTE from ${actor} via Kind Robots For You. ${message}`
+    eventPayload.note = `HUMAN NOTE from ${actor} via Kind Robots. Still gated. ${message}`
   }
 
   const stamp = timestamp.replace(/[-:.]/g, '')

--- a/server/api/showcase/detail.get.ts
+++ b/server/api/showcase/detail.get.ts
@@ -1,0 +1,488 @@
+// /server/api/showcase/detail.get.ts
+//
+// One showcase card, expanded.
+//
+// Silas, 2026-08-29: "Whenever I click on one of the new objects, I want it to
+// expand to tell me about it, pertinent details, basically what should happen
+// after clicking gallery items, with clicking outside the container returning
+// to the homepage. This is the interstitial, not quite edit, not quite interact
+// select, that leads us to those options, plus review."
+//
+// WHY A SECOND ENDPOINT AND NOT A FATTER home.get.ts. The home payload draws
+// forty-odd tiles; adding every object's backstory, effect text and prompt to it
+// would multiply the page's first byte by the number of things nobody clicked.
+// This is fetched on the click, for exactly the one record that was clicked.
+//
+// PUBLIC-SAFE BY CONSTRUCTION, on the same terms as home.get.ts: every read is
+// pinned to isPublic + isActive + isMature:false, there is no auth path, and the
+// per-kind field lists below are allowlists rather than `select: undefined`.
+// `Scenario.secretNotes` is the reason that distinction is written down --
+// it is a field the interstitial must never surface, and an allowlist cannot
+// grow one by accident the way a spread of the whole row can.
+
+import { createError, defineEventHandler, getQuery, setHeader } from 'h3'
+import prisma from '@/server/utils/prisma'
+import { errorHandler } from '@/server/utils/error'
+import type { ShowcaseArt, ShowcaseKind } from '@/utils/homeShowcase'
+
+/** Public showcase gate, applied to every table this endpoint reads. */
+const PUBLIC = {
+  isActive: true,
+  isPublic: true,
+  isMature: false,
+} as const
+
+/** The art columns kr-art-plate reads, shared by every entity table. */
+const ENTITY_ART = {
+  imagePath: true,
+  cardPath: true,
+  heroPath: true,
+  iconPath: true,
+} as const
+
+export type ShowcaseFact = { label: string; value: string }
+
+export type ShowcaseDetail = {
+  kind: ShowcaseKind
+  id: number
+  title: string
+  subtitle: string | null
+  /** The long text: a backstory, a pitch, an effect. Rendered as prose. */
+  body: string | null
+  theme: string | null
+  art: ShowcaseArt
+  /** Short labelled attributes, rendered as a definition grid. */
+  facts: ShowcaseFact[]
+  createdAt: string
+  /** Where "open it properly" goes -- the manager page for this record. */
+  href: string
+}
+
+const KINDS = new Set<ShowcaseKind>([
+  'art',
+  'animation',
+  'dream',
+  'character',
+  'bot',
+  'reward',
+  'scenario',
+  'facet',
+  'project',
+])
+
+function text(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed || null
+}
+
+/** Only facts that actually have a value; an empty grid cell says nothing. */
+function facts(entries: Array<[string, unknown]>): ShowcaseFact[] {
+  const out: ShowcaseFact[] = []
+  for (const [label, raw] of entries) {
+    // Numeric columns (steps, level, seed) arrive as number or bigint and would
+    // otherwise be dropped by text()'s string check.
+    const value =
+      typeof raw === 'bigint' ||
+      (typeof raw === 'number' && Number.isFinite(raw))
+        ? String(raw)
+        : text(raw)
+    if (value)
+      out.push({
+        label,
+        value: value.length > 240 ? `${value.slice(0, 237)}…` : value,
+      })
+  }
+  return out
+}
+
+function art(
+  row: Partial<Record<keyof ShowcaseArt, string | null>>,
+): ShowcaseArt {
+  return {
+    imagePath: row.imagePath ?? null,
+    cardPath: row.cardPath ?? null,
+    heroPath: row.heroPath ?? null,
+    iconPath: row.iconPath ?? null,
+    fileType: row.fileType ?? null,
+  }
+}
+
+function iso(value: Date | null | undefined): string {
+  return (value ?? new Date()).toISOString()
+}
+
+export default defineEventHandler(async (event): Promise<ShowcaseDetail> => {
+  try {
+    const query = getQuery(event)
+    const kind = String(query.kind || '').trim() as ShowcaseKind
+    const id = Number(query.id)
+
+    if (!KINDS.has(kind)) {
+      throw createError({ statusCode: 400, statusMessage: 'unknown kind' })
+    }
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, statusMessage: 'invalid id' })
+    }
+
+    // Public and immutable enough to cache briefly at the edge: the same card
+    // is opened repeatedly while browsing the shelves.
+    setHeader(event, 'Cache-Control', 'public, max-age=60')
+
+    const missing = () =>
+      createError({ statusCode: 404, statusMessage: 'not found' })
+
+    if (kind === 'art' || kind === 'animation') {
+      const row = await prisma.artImage.findFirst({
+        where: { id, ...PUBLIC },
+        select: {
+          id: true,
+          createdAt: true,
+          promptString: true,
+          negativePrompt: true,
+          checkpoint: true,
+          sampler: true,
+          steps: true,
+          seed: true,
+          cfg: true,
+          designer: true,
+          genres: true,
+          fileType: true,
+          imagePath: true,
+          cardPath: true,
+          heroPath: true,
+          iconPath: true,
+        },
+      })
+      if (!row) throw missing()
+
+      return {
+        kind,
+        id: row.id,
+        title: text(row.promptString)?.slice(0, 80) || `Render #${row.id}`,
+        subtitle: text(row.checkpoint),
+        body: text(row.promptString),
+        // ArtImage has no `theme` column -- see the note in home-rail.vue about
+        // what an id-derived theme did to letterboxed renders.
+        theme: null,
+        art: {
+          ...art(row),
+          // The canonical URL: 302s to imagePath when set, serves the stored
+          // bytes when the render has not been written to disk yet.
+          imagePath: `/api/art/images/${row.id}/file`,
+        },
+        facts: facts([
+          ['Checkpoint', row.checkpoint],
+          ['Sampler', row.sampler],
+          ['Steps', row.steps],
+          ['CFG', row.cfg],
+          ['Seed', row.seed],
+          ['Designer', row.designer],
+          ['Genres', row.genres],
+          ['Negative', row.negativePrompt],
+        ]),
+        createdAt: iso(row.createdAt),
+        href: `/art?art=${row.id}`,
+      }
+    }
+
+    if (kind === 'dream') {
+      const row = await prisma.dream.findFirst({
+        where: { id, ...PUBLIC },
+        select: {
+          id: true,
+          createdAt: true,
+          title: true,
+          slug: true,
+          description: true,
+          pitch: true,
+          flavorText: true,
+          dreamType: true,
+          designer: true,
+          examples: true,
+          theme: true,
+          ...ENTITY_ART,
+        },
+      })
+      if (!row) throw missing()
+
+      return {
+        kind,
+        id: row.id,
+        title: text(row.title) || 'Untitled dream',
+        subtitle: text(row.flavorText),
+        body: text(row.description) || text(row.pitch),
+        theme: row.theme,
+        art: art(row),
+        facts: facts([
+          ['Type', row.dreamType],
+          ['Designer', row.designer],
+          ['Examples', row.examples],
+        ]),
+        createdAt: iso(row.createdAt),
+        href: `/dreams?dream=${row.id}`,
+      }
+    }
+
+    if (kind === 'character') {
+      const row = await prisma.character.findFirst({
+        where: { id, ...PUBLIC },
+        select: {
+          id: true,
+          createdAt: true,
+          name: true,
+          honorific: true,
+          title: true,
+          backstory: true,
+          personality: true,
+          drive: true,
+          quirks: true,
+          genre: true,
+          species: true,
+          class: true,
+          alignment: true,
+          role: true,
+          level: true,
+          designer: true,
+          theme: true,
+          ...ENTITY_ART,
+        },
+      })
+      if (!row) throw missing()
+
+      return {
+        kind,
+        id: row.id,
+        title: text(row.name) || 'Unnamed character',
+        subtitle: text(row.title) || text(row.honorific) || text(row.role),
+        body: text(row.backstory) || text(row.personality),
+        theme: row.theme,
+        art: art(row),
+        facts: facts([
+          ['Species', row.species],
+          ['Class', row.class],
+          ['Alignment', row.alignment],
+          ['Genre', row.genre],
+          ['Level', row.level],
+          ['Drive', row.drive],
+          ['Quirks', row.quirks],
+          ['Designer', row.designer],
+        ]),
+        createdAt: iso(row.createdAt),
+        href: `/characters?characterId=${row.id}`,
+      }
+    }
+
+    if (kind === 'bot') {
+      const row = await prisma.bot.findFirst({
+        where: { id, ...PUBLIC },
+        select: {
+          id: true,
+          createdAt: true,
+          name: true,
+          subtitle: true,
+          description: true,
+          botIntro: true,
+          tagline: true,
+          personality: true,
+          BotType: true,
+          narrativeVoice: true,
+          designer: true,
+          theme: true,
+          ...ENTITY_ART,
+        },
+      })
+      if (!row) throw missing()
+
+      return {
+        kind,
+        id: row.id,
+        title: text(row.name) || 'Unnamed bot',
+        subtitle: text(row.subtitle) || text(row.tagline),
+        body: text(row.description) || text(row.botIntro),
+        theme: row.theme,
+        art: art(row),
+        facts: facts([
+          ['Type', row.BotType],
+          ['Personality', row.personality],
+          ['Voice', row.narrativeVoice],
+          ['Designer', row.designer],
+        ]),
+        createdAt: iso(row.createdAt),
+        href: `/bots?botId=${row.id}`,
+      }
+    }
+
+    if (kind === 'reward') {
+      const row = await prisma.reward.findFirst({
+        where: { id, ...PUBLIC },
+        select: {
+          id: true,
+          createdAt: true,
+          name: true,
+          description: true,
+          effect: true,
+          flavorText: true,
+          rewardType: true,
+          rarity: true,
+          collection: true,
+          theme: true,
+          ...ENTITY_ART,
+        },
+      })
+      if (!row) throw missing()
+
+      return {
+        kind,
+        id: row.id,
+        title: text(row.name) || 'Unnamed reward',
+        subtitle: text(row.flavorText),
+        body: text(row.description) || text(row.effect),
+        theme: row.theme,
+        art: art(row),
+        facts: facts([
+          ['Kind', row.rewardType],
+          ['Rarity', row.rarity],
+          ['Collection', row.collection],
+          ['Effect', row.effect],
+        ]),
+        createdAt: iso(row.createdAt),
+        href: `/rewards?reward=${row.id}`,
+      }
+    }
+
+    if (kind === 'scenario') {
+      const row = await prisma.scenario.findFirst({
+        where: { id, ...PUBLIC },
+        select: {
+          id: true,
+          createdAt: true,
+          title: true,
+          description: true,
+          locations: true,
+          genres: true,
+          inspirations: true,
+          difficulty: true,
+          tier: true,
+          cast: true,
+          outputType: true,
+          theme: true,
+          // secretNotes is deliberately NOT selected. See the header note.
+          ...ENTITY_ART,
+        },
+      })
+      if (!row) throw missing()
+
+      return {
+        kind,
+        id: row.id,
+        title: text(row.title) || 'Untitled scenario',
+        subtitle: text(row.locations),
+        body: text(row.description),
+        theme: row.theme,
+        art: art(row),
+        facts: facts([
+          ['Difficulty', row.difficulty],
+          ['Tier', row.tier],
+          ['Genres', row.genres],
+          ['Cast', row.cast],
+          ['Output', row.outputType],
+          ['Inspirations', row.inspirations],
+        ]),
+        createdAt: iso(row.createdAt),
+        href: `/stories?scenario=${row.id}`,
+      }
+    }
+
+    if (kind === 'facet') {
+      const row = await prisma.facet.findFirst({
+        where: { id, ...PUBLIC },
+        select: {
+          id: true,
+          createdAt: true,
+          title: true,
+          slug: true,
+          description: true,
+          flavorText: true,
+          examples: true,
+          designer: true,
+          theme: true,
+          ...ENTITY_ART,
+        },
+      })
+      if (!row) throw missing()
+
+      return {
+        kind,
+        id: row.id,
+        title: text(row.title) || 'Untitled facet',
+        subtitle: text(row.flavorText),
+        body: text(row.description),
+        theme: row.theme,
+        art: art(row),
+        facts: facts([
+          ['Examples', row.examples],
+          ['Designer', row.designer],
+        ]),
+        createdAt: iso(row.createdAt),
+        href: row.slug
+          ? `/facets?facet=${encodeURIComponent(row.slug)}`
+          : '/facets',
+      }
+    }
+
+    const row = await prisma.project.findFirst({
+      where: { id, ...PUBLIC },
+      select: {
+        id: true,
+        createdAt: true,
+        title: true,
+        slug: true,
+        description: true,
+        pitch: true,
+        goal: true,
+        flavorText: true,
+        status: true,
+        priority: true,
+        conductorSlug: true,
+        liveUrl: true,
+        repoUrl: true,
+        ...ENTITY_ART,
+      },
+    })
+    if (!row) throw missing()
+
+    return {
+      kind: 'project',
+      id: row.id,
+      title: text(row.title) || 'Untitled project',
+      subtitle: text(row.flavorText) || text(row.goal),
+      body: text(row.description) || text(row.pitch),
+      theme: null,
+      art: art(row),
+      facts: facts([
+        ['Status', row.status],
+        ['Priority', row.priority],
+        ['Goal', row.goal],
+        ['Conductor', row.conductorSlug],
+        ['Live', row.liveUrl],
+        ['Repo', row.repoUrl],
+      ]),
+      createdAt: iso(row.createdAt),
+      href: row.conductorSlug
+        ? `/conductor?project=${encodeURIComponent(row.conductorSlug)}`
+        : '/conductor',
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    throw createError({
+      statusCode: handled.statusCode || 500,
+      // Fixed text, never the caught message: a Prisma failure here would
+      // otherwise print a query dump onto the front page.
+      statusMessage:
+        handled.statusCode === 404
+          ? 'not found'
+          : 'Could not load that item right now.',
+    })
+  }
+})

--- a/server/api/showcase/detail.get.ts
+++ b/server/api/showcase/detail.get.ts
@@ -20,6 +20,7 @@
 // it is a field the interstitial must never surface, and an allowlist cannot
 // grow one by accident the way a spread of the whole row can.
 
+import type { H3Event } from 'h3'
 import { createError, defineEventHandler, getQuery, setHeader } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
@@ -112,326 +113,97 @@ function iso(value: Date | null | undefined): string {
   return (value ?? new Date()).toISOString()
 }
 
-export default defineEventHandler(async (event): Promise<ShowcaseDetail> => {
-  try {
-    const query = getQuery(event)
-    const kind = String(query.kind || '').trim() as ShowcaseKind
-    const id = Number(query.id)
+/**
+ * The response envelope, matching home.get.ts rather than returning the record
+ * bare.
+ *
+ * Two reasons. It keeps both showcase endpoints on the one shape every store
+ * here consumes through `performFetch`, and returning bare made Nuxt's typed
+ * `$fetch` overload resolution blow up on the call site with TS2589 "type
+ * instantiation is excessively deep" -- the envelope plus performFetch avoids
+ * inventing a second convention to work around a compiler limit.
+ */
+export type ShowcaseDetailResponse = {
+  success: boolean
+  message: string
+  data: ShowcaseDetail | null
+}
 
-    if (!KINDS.has(kind)) {
-      throw createError({ statusCode: 400, statusMessage: 'unknown kind' })
+async function loadDetail(event: H3Event): Promise<ShowcaseDetail> {
+  const query = getQuery(event)
+  const kind = String(query.kind || '').trim() as ShowcaseKind
+  const id = Number(query.id)
+
+  if (!KINDS.has(kind)) {
+    throw createError({ statusCode: 400, statusMessage: 'unknown kind' })
+  }
+  if (!Number.isInteger(id) || id <= 0) {
+    throw createError({ statusCode: 400, statusMessage: 'invalid id' })
+  }
+
+  // Public and immutable enough to cache briefly at the edge: the same card
+  // is opened repeatedly while browsing the shelves.
+  setHeader(event, 'Cache-Control', 'public, max-age=60')
+
+  const missing = () =>
+    createError({ statusCode: 404, statusMessage: 'not found' })
+
+  if (kind === 'art' || kind === 'animation') {
+    const row = await prisma.artImage.findFirst({
+      where: { id, ...PUBLIC },
+      select: {
+        id: true,
+        createdAt: true,
+        promptString: true,
+        negativePrompt: true,
+        checkpoint: true,
+        sampler: true,
+        steps: true,
+        seed: true,
+        cfg: true,
+        designer: true,
+        genres: true,
+        fileType: true,
+        imagePath: true,
+        cardPath: true,
+        heroPath: true,
+        iconPath: true,
+      },
+    })
+    if (!row) throw missing()
+
+    return {
+      kind,
+      id: row.id,
+      title: text(row.promptString)?.slice(0, 80) || `Render #${row.id}`,
+      subtitle: text(row.checkpoint),
+      body: text(row.promptString),
+      // ArtImage has no `theme` column -- see the note in home-rail.vue about
+      // what an id-derived theme did to letterboxed renders.
+      theme: null,
+      art: {
+        ...art(row),
+        // The canonical URL: 302s to imagePath when set, serves the stored
+        // bytes when the render has not been written to disk yet.
+        imagePath: `/api/art/images/${row.id}/file`,
+      },
+      facts: facts([
+        ['Checkpoint', row.checkpoint],
+        ['Sampler', row.sampler],
+        ['Steps', row.steps],
+        ['CFG', row.cfg],
+        ['Seed', row.seed],
+        ['Designer', row.designer],
+        ['Genres', row.genres],
+        ['Negative', row.negativePrompt],
+      ]),
+      createdAt: iso(row.createdAt),
+      href: `/art?art=${row.id}`,
     }
-    if (!Number.isInteger(id) || id <= 0) {
-      throw createError({ statusCode: 400, statusMessage: 'invalid id' })
-    }
+  }
 
-    // Public and immutable enough to cache briefly at the edge: the same card
-    // is opened repeatedly while browsing the shelves.
-    setHeader(event, 'Cache-Control', 'public, max-age=60')
-
-    const missing = () =>
-      createError({ statusCode: 404, statusMessage: 'not found' })
-
-    if (kind === 'art' || kind === 'animation') {
-      const row = await prisma.artImage.findFirst({
-        where: { id, ...PUBLIC },
-        select: {
-          id: true,
-          createdAt: true,
-          promptString: true,
-          negativePrompt: true,
-          checkpoint: true,
-          sampler: true,
-          steps: true,
-          seed: true,
-          cfg: true,
-          designer: true,
-          genres: true,
-          fileType: true,
-          imagePath: true,
-          cardPath: true,
-          heroPath: true,
-          iconPath: true,
-        },
-      })
-      if (!row) throw missing()
-
-      return {
-        kind,
-        id: row.id,
-        title: text(row.promptString)?.slice(0, 80) || `Render #${row.id}`,
-        subtitle: text(row.checkpoint),
-        body: text(row.promptString),
-        // ArtImage has no `theme` column -- see the note in home-rail.vue about
-        // what an id-derived theme did to letterboxed renders.
-        theme: null,
-        art: {
-          ...art(row),
-          // The canonical URL: 302s to imagePath when set, serves the stored
-          // bytes when the render has not been written to disk yet.
-          imagePath: `/api/art/images/${row.id}/file`,
-        },
-        facts: facts([
-          ['Checkpoint', row.checkpoint],
-          ['Sampler', row.sampler],
-          ['Steps', row.steps],
-          ['CFG', row.cfg],
-          ['Seed', row.seed],
-          ['Designer', row.designer],
-          ['Genres', row.genres],
-          ['Negative', row.negativePrompt],
-        ]),
-        createdAt: iso(row.createdAt),
-        href: `/art?art=${row.id}`,
-      }
-    }
-
-    if (kind === 'dream') {
-      const row = await prisma.dream.findFirst({
-        where: { id, ...PUBLIC },
-        select: {
-          id: true,
-          createdAt: true,
-          title: true,
-          slug: true,
-          description: true,
-          pitch: true,
-          flavorText: true,
-          dreamType: true,
-          designer: true,
-          examples: true,
-          theme: true,
-          ...ENTITY_ART,
-        },
-      })
-      if (!row) throw missing()
-
-      return {
-        kind,
-        id: row.id,
-        title: text(row.title) || 'Untitled dream',
-        subtitle: text(row.flavorText),
-        body: text(row.description) || text(row.pitch),
-        theme: row.theme,
-        art: art(row),
-        facts: facts([
-          ['Type', row.dreamType],
-          ['Designer', row.designer],
-          ['Examples', row.examples],
-        ]),
-        createdAt: iso(row.createdAt),
-        href: `/dreams?dream=${row.id}`,
-      }
-    }
-
-    if (kind === 'character') {
-      const row = await prisma.character.findFirst({
-        where: { id, ...PUBLIC },
-        select: {
-          id: true,
-          createdAt: true,
-          name: true,
-          honorific: true,
-          title: true,
-          backstory: true,
-          personality: true,
-          drive: true,
-          quirks: true,
-          genre: true,
-          species: true,
-          class: true,
-          alignment: true,
-          role: true,
-          level: true,
-          designer: true,
-          theme: true,
-          ...ENTITY_ART,
-        },
-      })
-      if (!row) throw missing()
-
-      return {
-        kind,
-        id: row.id,
-        title: text(row.name) || 'Unnamed character',
-        subtitle: text(row.title) || text(row.honorific) || text(row.role),
-        body: text(row.backstory) || text(row.personality),
-        theme: row.theme,
-        art: art(row),
-        facts: facts([
-          ['Species', row.species],
-          ['Class', row.class],
-          ['Alignment', row.alignment],
-          ['Genre', row.genre],
-          ['Level', row.level],
-          ['Drive', row.drive],
-          ['Quirks', row.quirks],
-          ['Designer', row.designer],
-        ]),
-        createdAt: iso(row.createdAt),
-        href: `/characters?characterId=${row.id}`,
-      }
-    }
-
-    if (kind === 'bot') {
-      const row = await prisma.bot.findFirst({
-        where: { id, ...PUBLIC },
-        select: {
-          id: true,
-          createdAt: true,
-          name: true,
-          subtitle: true,
-          description: true,
-          botIntro: true,
-          tagline: true,
-          personality: true,
-          BotType: true,
-          narrativeVoice: true,
-          designer: true,
-          theme: true,
-          ...ENTITY_ART,
-        },
-      })
-      if (!row) throw missing()
-
-      return {
-        kind,
-        id: row.id,
-        title: text(row.name) || 'Unnamed bot',
-        subtitle: text(row.subtitle) || text(row.tagline),
-        body: text(row.description) || text(row.botIntro),
-        theme: row.theme,
-        art: art(row),
-        facts: facts([
-          ['Type', row.BotType],
-          ['Personality', row.personality],
-          ['Voice', row.narrativeVoice],
-          ['Designer', row.designer],
-        ]),
-        createdAt: iso(row.createdAt),
-        href: `/bots?botId=${row.id}`,
-      }
-    }
-
-    if (kind === 'reward') {
-      const row = await prisma.reward.findFirst({
-        where: { id, ...PUBLIC },
-        select: {
-          id: true,
-          createdAt: true,
-          name: true,
-          description: true,
-          effect: true,
-          flavorText: true,
-          rewardType: true,
-          rarity: true,
-          collection: true,
-          theme: true,
-          ...ENTITY_ART,
-        },
-      })
-      if (!row) throw missing()
-
-      return {
-        kind,
-        id: row.id,
-        title: text(row.name) || 'Unnamed reward',
-        subtitle: text(row.flavorText),
-        body: text(row.description) || text(row.effect),
-        theme: row.theme,
-        art: art(row),
-        facts: facts([
-          ['Kind', row.rewardType],
-          ['Rarity', row.rarity],
-          ['Collection', row.collection],
-          ['Effect', row.effect],
-        ]),
-        createdAt: iso(row.createdAt),
-        href: `/rewards?reward=${row.id}`,
-      }
-    }
-
-    if (kind === 'scenario') {
-      const row = await prisma.scenario.findFirst({
-        where: { id, ...PUBLIC },
-        select: {
-          id: true,
-          createdAt: true,
-          title: true,
-          description: true,
-          locations: true,
-          genres: true,
-          inspirations: true,
-          difficulty: true,
-          tier: true,
-          cast: true,
-          outputType: true,
-          theme: true,
-          // secretNotes is deliberately NOT selected. See the header note.
-          ...ENTITY_ART,
-        },
-      })
-      if (!row) throw missing()
-
-      return {
-        kind,
-        id: row.id,
-        title: text(row.title) || 'Untitled scenario',
-        subtitle: text(row.locations),
-        body: text(row.description),
-        theme: row.theme,
-        art: art(row),
-        facts: facts([
-          ['Difficulty', row.difficulty],
-          ['Tier', row.tier],
-          ['Genres', row.genres],
-          ['Cast', row.cast],
-          ['Output', row.outputType],
-          ['Inspirations', row.inspirations],
-        ]),
-        createdAt: iso(row.createdAt),
-        href: `/stories?scenario=${row.id}`,
-      }
-    }
-
-    if (kind === 'facet') {
-      const row = await prisma.facet.findFirst({
-        where: { id, ...PUBLIC },
-        select: {
-          id: true,
-          createdAt: true,
-          title: true,
-          slug: true,
-          description: true,
-          flavorText: true,
-          examples: true,
-          designer: true,
-          theme: true,
-          ...ENTITY_ART,
-        },
-      })
-      if (!row) throw missing()
-
-      return {
-        kind,
-        id: row.id,
-        title: text(row.title) || 'Untitled facet',
-        subtitle: text(row.flavorText),
-        body: text(row.description),
-        theme: row.theme,
-        art: art(row),
-        facts: facts([
-          ['Examples', row.examples],
-          ['Designer', row.designer],
-        ]),
-        createdAt: iso(row.createdAt),
-        href: row.slug
-          ? `/facets?facet=${encodeURIComponent(row.slug)}`
-          : '/facets',
-      }
-    }
-
-    const row = await prisma.project.findFirst({
+  if (kind === 'dream') {
+    const row = await prisma.dream.findFirst({
       where: { id, ...PUBLIC },
       select: {
         id: true,
@@ -440,49 +212,308 @@ export default defineEventHandler(async (event): Promise<ShowcaseDetail> => {
         slug: true,
         description: true,
         pitch: true,
-        goal: true,
         flavorText: true,
-        status: true,
-        priority: true,
-        conductorSlug: true,
-        liveUrl: true,
-        repoUrl: true,
+        dreamType: true,
+        designer: true,
+        examples: true,
+        theme: true,
         ...ENTITY_ART,
       },
     })
     if (!row) throw missing()
 
     return {
-      kind: 'project',
+      kind,
       id: row.id,
-      title: text(row.title) || 'Untitled project',
-      subtitle: text(row.flavorText) || text(row.goal),
+      title: text(row.title) || 'Untitled dream',
+      subtitle: text(row.flavorText),
       body: text(row.description) || text(row.pitch),
-      theme: null,
+      theme: row.theme,
       art: art(row),
       facts: facts([
-        ['Status', row.status],
-        ['Priority', row.priority],
-        ['Goal', row.goal],
-        ['Conductor', row.conductorSlug],
-        ['Live', row.liveUrl],
-        ['Repo', row.repoUrl],
+        ['Type', row.dreamType],
+        ['Designer', row.designer],
+        ['Examples', row.examples],
       ]),
       createdAt: iso(row.createdAt),
-      href: row.conductorSlug
-        ? `/conductor?project=${encodeURIComponent(row.conductorSlug)}`
-        : '/conductor',
+      href: `/dreams?dream=${row.id}`,
     }
-  } catch (error) {
-    const handled = errorHandler(error)
-    throw createError({
-      statusCode: handled.statusCode || 500,
-      // Fixed text, never the caught message: a Prisma failure here would
-      // otherwise print a query dump onto the front page.
-      statusMessage:
-        handled.statusCode === 404
-          ? 'not found'
-          : 'Could not load that item right now.',
-    })
   }
-})
+
+  if (kind === 'character') {
+    const row = await prisma.character.findFirst({
+      where: { id, ...PUBLIC },
+      select: {
+        id: true,
+        createdAt: true,
+        name: true,
+        honorific: true,
+        title: true,
+        backstory: true,
+        personality: true,
+        drive: true,
+        quirks: true,
+        genre: true,
+        species: true,
+        class: true,
+        alignment: true,
+        role: true,
+        level: true,
+        designer: true,
+        theme: true,
+        ...ENTITY_ART,
+      },
+    })
+    if (!row) throw missing()
+
+    return {
+      kind,
+      id: row.id,
+      title: text(row.name) || 'Unnamed character',
+      subtitle: text(row.title) || text(row.honorific) || text(row.role),
+      body: text(row.backstory) || text(row.personality),
+      theme: row.theme,
+      art: art(row),
+      facts: facts([
+        ['Species', row.species],
+        ['Class', row.class],
+        ['Alignment', row.alignment],
+        ['Genre', row.genre],
+        ['Level', row.level],
+        ['Drive', row.drive],
+        ['Quirks', row.quirks],
+        ['Designer', row.designer],
+      ]),
+      createdAt: iso(row.createdAt),
+      href: `/characters?characterId=${row.id}`,
+    }
+  }
+
+  if (kind === 'bot') {
+    const row = await prisma.bot.findFirst({
+      where: { id, ...PUBLIC },
+      select: {
+        id: true,
+        createdAt: true,
+        name: true,
+        subtitle: true,
+        description: true,
+        botIntro: true,
+        tagline: true,
+        personality: true,
+        BotType: true,
+        narrativeVoice: true,
+        designer: true,
+        theme: true,
+        ...ENTITY_ART,
+      },
+    })
+    if (!row) throw missing()
+
+    return {
+      kind,
+      id: row.id,
+      title: text(row.name) || 'Unnamed bot',
+      subtitle: text(row.subtitle) || text(row.tagline),
+      body: text(row.description) || text(row.botIntro),
+      theme: row.theme,
+      art: art(row),
+      facts: facts([
+        ['Type', row.BotType],
+        ['Personality', row.personality],
+        ['Voice', row.narrativeVoice],
+        ['Designer', row.designer],
+      ]),
+      createdAt: iso(row.createdAt),
+      href: `/bots?botId=${row.id}`,
+    }
+  }
+
+  if (kind === 'reward') {
+    const row = await prisma.reward.findFirst({
+      where: { id, ...PUBLIC },
+      select: {
+        id: true,
+        createdAt: true,
+        name: true,
+        description: true,
+        effect: true,
+        flavorText: true,
+        rewardType: true,
+        rarity: true,
+        collection: true,
+        theme: true,
+        ...ENTITY_ART,
+      },
+    })
+    if (!row) throw missing()
+
+    return {
+      kind,
+      id: row.id,
+      title: text(row.name) || 'Unnamed reward',
+      subtitle: text(row.flavorText),
+      body: text(row.description) || text(row.effect),
+      theme: row.theme,
+      art: art(row),
+      facts: facts([
+        ['Kind', row.rewardType],
+        ['Rarity', row.rarity],
+        ['Collection', row.collection],
+        ['Effect', row.effect],
+      ]),
+      createdAt: iso(row.createdAt),
+      href: `/rewards?reward=${row.id}`,
+    }
+  }
+
+  if (kind === 'scenario') {
+    const row = await prisma.scenario.findFirst({
+      where: { id, ...PUBLIC },
+      select: {
+        id: true,
+        createdAt: true,
+        title: true,
+        description: true,
+        locations: true,
+        genres: true,
+        inspirations: true,
+        difficulty: true,
+        tier: true,
+        cast: true,
+        outputType: true,
+        theme: true,
+        // secretNotes is deliberately NOT selected. See the header note.
+        ...ENTITY_ART,
+      },
+    })
+    if (!row) throw missing()
+
+    return {
+      kind,
+      id: row.id,
+      title: text(row.title) || 'Untitled scenario',
+      subtitle: text(row.locations),
+      body: text(row.description),
+      theme: row.theme,
+      art: art(row),
+      facts: facts([
+        ['Difficulty', row.difficulty],
+        ['Tier', row.tier],
+        ['Genres', row.genres],
+        ['Cast', row.cast],
+        ['Output', row.outputType],
+        ['Inspirations', row.inspirations],
+      ]),
+      createdAt: iso(row.createdAt),
+      href: `/stories?scenario=${row.id}`,
+    }
+  }
+
+  if (kind === 'facet') {
+    const row = await prisma.facet.findFirst({
+      where: { id, ...PUBLIC },
+      select: {
+        id: true,
+        createdAt: true,
+        title: true,
+        slug: true,
+        description: true,
+        flavorText: true,
+        examples: true,
+        designer: true,
+        theme: true,
+        ...ENTITY_ART,
+      },
+    })
+    if (!row) throw missing()
+
+    return {
+      kind,
+      id: row.id,
+      title: text(row.title) || 'Untitled facet',
+      subtitle: text(row.flavorText),
+      body: text(row.description),
+      theme: row.theme,
+      art: art(row),
+      facts: facts([
+        ['Examples', row.examples],
+        ['Designer', row.designer],
+      ]),
+      createdAt: iso(row.createdAt),
+      href: row.slug
+        ? `/facets?facet=${encodeURIComponent(row.slug)}`
+        : '/facets',
+    }
+  }
+
+  const row = await prisma.project.findFirst({
+    where: { id, ...PUBLIC },
+    select: {
+      id: true,
+      createdAt: true,
+      title: true,
+      slug: true,
+      description: true,
+      pitch: true,
+      goal: true,
+      flavorText: true,
+      status: true,
+      priority: true,
+      conductorSlug: true,
+      liveUrl: true,
+      repoUrl: true,
+      ...ENTITY_ART,
+    },
+  })
+  if (!row) throw missing()
+
+  return {
+    kind: 'project',
+    id: row.id,
+    title: text(row.title) || 'Untitled project',
+    subtitle: text(row.flavorText) || text(row.goal),
+    body: text(row.description) || text(row.pitch),
+    theme: null,
+    art: art(row),
+    facts: facts([
+      ['Status', row.status],
+      ['Priority', row.priority],
+      ['Goal', row.goal],
+      ['Conductor', row.conductorSlug],
+      ['Live', row.liveUrl],
+      ['Repo', row.repoUrl],
+    ]),
+    createdAt: iso(row.createdAt),
+    href: row.conductorSlug
+      ? `/conductor?project=${encodeURIComponent(row.conductorSlug)}`
+      : '/conductor',
+  }
+}
+
+export default defineEventHandler(
+  async (event): Promise<ShowcaseDetailResponse> => {
+    try {
+      return {
+        success: true,
+        message: 'Showcase detail loaded successfully.',
+        data: await loadDetail(event),
+      }
+    } catch (error) {
+      const handled = errorHandler(error)
+      const statusCode = handled.statusCode || 500
+      event.node.res.statusCode = statusCode
+
+      return {
+        success: false,
+        // Fixed text, never the caught message: a Prisma failure here would
+        // otherwise print a query dump onto the front page.
+        message:
+          statusCode === 404
+            ? "That item isn't available."
+            : "Couldn't load that item just now.",
+        data: null,
+      }
+    }
+  },
+)

--- a/server/api/showcase/home.get.ts
+++ b/server/api/showcase/home.get.ts
@@ -152,6 +152,26 @@ function summarize(
   return null
 }
 
+/**
+ * Several lines of a text field, for the hero's description.
+ *
+ * `summarize` above deliberately keeps one line at card length; this keeps a
+ * short paragraph. Both trim rather than wrap, because the hero clamps in CSS
+ * and a server-side ellipsis mid-clamp reads as corruption.
+ */
+function paragraph(
+  ...candidates: Array<string | null | undefined>
+): string | null {
+  for (const candidate of candidates) {
+    const text = (candidate ?? '').trim()
+    if (!text) continue
+
+    return text.length > 420 ? `${text.slice(0, 417)}…` : text
+  }
+
+  return null
+}
+
 function card(
   kind: ShowcaseKind,
   fields: {
@@ -454,6 +474,11 @@ function pickHero(candidates: HeroDream[]): ShowcaseHero | null {
           dream.PitchSheet?.pitch,
           dream.pitch,
           dream.description,
+        ),
+        description: paragraph(
+          dream.description,
+          dream.PitchSheet?.pitch,
+          dream.pitch,
         ),
         castWithArt,
       },

--- a/stores/conductorStore.ts
+++ b/stores/conductorStore.ts
@@ -19,7 +19,13 @@ export type PitchStatus =
   | 'superseded'
   | 'archived'
 export type PitchBucket = 'review' | 'approved' | 'rejected' | 'archived'
-export type ConductorTaskAction = 'approve' | 'reject' | 'comment'
+/**
+ * `answer` is a comment that also releases the gate back to `ready`, so the
+ * next Worker cycle picks the task up carrying the answer. `comment` adds the
+ * note and leaves the task parked. See the note in
+ * server/api/conductor/task-action.post.ts for why the distinction exists.
+ */
+export type ConductorTaskAction = 'approve' | 'reject' | 'comment' | 'answer'
 
 export interface ConductorHumanGate {
   project: ConductorProject
@@ -303,7 +309,7 @@ export const useConductorStore = defineStore('conductor', () => {
     if (updatingTaskKeys.value.includes(key)) return false
 
     const trimmedMessage = message.trim()
-    if ((action === 'reject' || action === 'comment') && !trimmedMessage) {
+    if (action !== 'approve' && !trimmedMessage) {
       taskUpdateError.value = 'Add a message before sending this action.'
       return false
     }
@@ -348,6 +354,17 @@ export const useConductorStore = defineStore('conductor', () => {
             ...task,
             status: 'ready',
             approvedByHuman: false,
+            softGate: false,
+            note,
+            updated: now,
+          }
+        }
+        if (action === 'answer') {
+          // Released, but with no verdict attached: approvedByHuman is left
+          // exactly as it was, unlike a reject.
+          return {
+            ...task,
+            status: 'ready',
             softGate: false,
             note,
             updated: now,

--- a/utils/homeShowcase.ts
+++ b/utils/homeShowcase.ts
@@ -75,12 +75,35 @@ export type ShowcaseCard = {
   conductorSlug: string | null
 }
 
+/**
+ * A showcase card as a rail tile, optionally carrying a pipeline state.
+ *
+ * Only the art shelf's queue mode sets `status`: an ArtJob has a lifecycle
+ * (PENDING/RUNNING/DONE/FAILED/CANCELLED) where a finished object simply
+ * exists. Every other shelf passes cards through untouched and renders no chip.
+ *
+ * It lives here rather than in home-rail.vue because `<script setup>` cannot
+ * export types -- and because the art shelf and the rail both need to name it.
+ */
+export type RailItem = ShowcaseCard & { status?: string | null }
+
 export type ShowcaseHero = {
   dream: ShowcaseCard
   /** Everything the dream cycle built around it, in reading order. */
   cast: ShowcaseCard[]
   hook: string | null
   pitch: string | null
+  /**
+   * The dream's actual description, at paragraph length rather than the
+   * one-line `hook`/`pitch` summaries beside it.
+   *
+   * Silas, 2026-08-29: "make it a little wider because we want to add the
+   * descrition for the dream, that is missing." Both existing fields run
+   * through `summarize`, which keeps the FIRST LINE only and caps at 160
+   * characters -- fine for a card subtitle, not a description. This is the same
+   * source text at paragraph length.
+   */
+  description: string | null
   /** How many cast members resolved art -- the "is it ready" signal. */
   castWithArt: number
 }


### PR DESCRIPTION
Fifth pass, from two messages on 2026-08-29. The largest item is not a layout change.

Pairs with [silasfelinus/conductor#3142](https://github.com/silasfelinus/conductor/pull/3142).

## Following the gate pipeline end to end found a real break

> "if I click on one of the human gate notifications, it lets me enter a comment and that comment is fed to the next agent dealing with that problem. The infrastructure should be there, the excecition is missing the front end....but also we might be missing whatever ties the response to the project referenced. follow it end to end."

It was both. Every link in the chain existed and worked:

composer → `submitTaskAction` → `POST /api/conductor/task-action` → a YAML event committed to conductor → `process_task_events.py` (appends the note) → projection back here.

**The break was at the far end.** The only comment action left the task at `status: needs-human`, and conductor's Worker selects `status: ready` and nothing else. So an answer was written into the roadmap and handed to nobody — that is exactly "whatever ties the response to the project referenced".

Fixed on both sides. Here: a new **`answer`** action — the same note, plus the release back to `ready` that actually queues it for the next agent. Deliberately *not* `reject`, which sets `approved_by_human: false` and stamps the note "SENT BACK"; an answer is not a verdict on the work. `comment` survives as "note only" for gates that should stay gated, and conductor's `audit_human_gates.py` now flags and prints those.

The Needs-you column is now a composer: **Send to agent** / **Note only** / **Approve**, opened in place rather than as a modal.

## The tab message was never rendering, and the renderer was never the problem

`tabMessage` was not declared in `content.config.ts`, so Nuxt Content dropped the key while parsing frontmatter — `content/index.md` had carried one since the day the header started reading it. Declared it, and gave the stretch a brand line plus a subtitle fallback so it says something on **every** page rather than only where a `tabMessage` was authored. It is also `pointer-events-none`, so the shell stops reading as one enormous button.

## The rest

- **Interstitial** (`home-object-sheet` + `/api/showcase/detail`): click an object, get its details and its reviews, click outside to return. Reviews are **embedded, not linked** — `review-list.vue` is a component, not a route, and the `/chat` and `/reviews` links this footer first reached for don't exist and would have 404'd off the front page.
- **Art shelf toggles** finished art vs. the live ArtJob queue, with a status filter (Active/Pending/Running/Failed/Done/Cancelled), rendering the *same* rail in the *same* two-row cell — "keeping the layout" is structural, not something to re-check. The controls ride in the header row the shelf already had, so it costs no page height. Signed-in only; a failed fetch hides it.
- **Rail headers are one glyph**, and chevrons replace eight reserved scrollbar gutters.
- **Hero is wider and finally renders the dream's description** — the payload had been `summarize`-ing it to one line and nothing rendered it. Cast tiles are slimmer (4.5rem, not a literal half of 7rem — see the note in the file for why).
- **Feed cards keep their summary** and spend one thin line on provenance instead of two; the feed's controls now share a row with the section heading via new `lead`/`trail` slots.
- Tiles stay **anchors** and intercept only the plain click, so middle-click and cmd-click still work.

## Verification

- `npm run test` (vue-tsc) — clean. It caught the interstitial's `$fetch` with TS2589; fixed by putting `/api/showcase/detail` on the same `{success, message, data}` envelope `home.get.ts` already uses, rather than casting past it
- `eslint` + `prettier` clean on every changed file
- `npm run test:layout-contract` — holds (the sheet's grid moved to container-width after the `viewport-grid` rule flagged it)
- `verifyMdcScrollOwnership.ts` — unchanged at 15
- `nuxi build` — completes
- All 8 new Prisma selects validated against the schema offline, **with a negative control** (`dream.path`, the exact field that 500'd the page on 2026-08-29) proving the probe isn't vacuous

## Not verified

No database or live conductor data in this sandbox, so the `answer` round trip is proven by construction and by conductor's own tests rather than by an observed event landing in a roadmap. Page height was not re-measured this pass — the mocked-payload Playwright harness wasn't rebuilt, so the net of a taller hero card, a shorter feed header and taller feed cards against the two-screen budget is unknown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aNg3fsHLGUGCwiMp25hkA