### PR TITLE
Refresh README around current products, Conductor, and Rainbow Butterflies

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,45 @@ Each generated asset can connect back to others, so a Dream becomes a living, ex
 
 ---
 
+## Product Families
+
+The Dream engine above is the common substrate; most of what's live at kindrobots.org is a
+purpose-built surface built on top of it. Broad current families, grouped by what they're for
+(not exhaustive — new ones ship regularly):
+
+- **Worldbuilding & narrative** — the core Dream flow, **Storybook**, **Da Vinci** (branching AI narration), **Taskmaster** (a story-woven task engine).
+- **Games & play** — **Cthulhuquarium** (a creature-collecting aquarium sim), **Ruler is Hooked** (a fishing/kingdom-management game), **Mandarin Tutor** (visual-linguistics-forward language learning), **Challenge Center**, **Music Mentor**, **Coloring Book**.
+- **Creative tools** — **Model Builder** (custom model/LoRA training workflows), **Animation Manager**, **Scene Animator**, **Mural Design**, **Brainstorm**.
+- **Community & content** — **Newsfeed**, **Forums**, **AI Art Academy**, **Watchlist**.
+- **Commerce & mission** — the **Sanctuary** giftshop (digital downloads, print-on-demand swag, mana top-ups, and a direct link to the malaria fundraiser), **Rainbow Butterflies** (see below).
+
+Every product shares the same account, mana/token balance, and generation backends described in
+this README — there's one Kind Robots account, not a separate signup per product.
+
+---
+
+## Conductor
+
+**[Conductor](https://kindrobots.org/conductor)** is the project's own multi-agent build system —
+a service-agnostic coordination layer where AI agents (and Silas) pick up roadmap tasks, implement
+them, open PRs, and review each other's work, with or without a human in the loop at any given
+moment. A meaningful share of Kind Robots' own ongoing development, including parts of this
+README, runs through it. Conductor is also a first-class product in its own right (project
+tracking, task roadmaps, human-approval gates), not only internal tooling.
+
+---
+
+## Rainbow Butterflies
+
+**Rainbow Butterflies** is Kind Robots' mission and outreach project: an in-progress agent-assisted
+commons where humans and AI agents will research, build, create, and collaborate around the
+Against Malaria fundraiser, carrying AMI's identity into places beyond kindrobots.org itself. It's
+still in active build-out (no public launch yet), and it operates under its own written disclosure
+and outreach rules — AMI is always declared as AI, never impersonates a human, and never runs
+unsolicited bulk outreach or manufactured engagement.
+
+---
+
 ## Self-Hosting
 
 **Most people don't need this section** — the full experience is live at **[kindrobots.org](https://kindrobots.org)**. Follow the steps below only if you want to run your own independent instance.
@@ -177,94 +216,4 @@ Kind Robots exists to encourage creativity with AI tools — and to turn that cr
 
 ## License & Contributing
 
-This is an actively evolving solo project. If you'd like to get involved, open an issue to start a conversation.
-
-
-[Commands]
-Install files:
-npm install
-
-Launch prisma studio:
-npx prisma studio
-
-Run lint and prettier:
-npx run lint
-
-Install files:
-npm install
-
-Start dev server:
-npx run dev
-
-Start Production Build:
-npx run build
-npx run start
-
-Setup Database:
-npx prisma studio
-npx prisma db pull
-npx prisma migrate dev
-
-Update Database:
-npx prisma migrate dev --name [NAME]
-npx prisma generate
-
-
-Run Typescript tests:
- npm run test
-
-Run cypress Tests:
- npm run cypress:run
-
- Run Single Cypress Test:
-npx cypress run --spec "cypress/e2e/api/users.cy.ts"
-
-Update Smart Icons
-node utils/scripts/updateKindIcons.js 
-
-
-Run  comfy-test
-curl -X POST "https://kindrobots.org/prompt" \
-  -H "Content-Type: application/json" \
-  --data-binary @utils/fluxKontext.json
-
-******
-Database migration fix! [replace UPDATE_NAME]
-
-# 1) Create SQL from live DB vs schema (no shadow)
-npx prisma migrate diff \
-  --from-schema-datasource prisma/schema.prisma \
-  --to-schema-datamodel   prisma/schema.prisma \
-  --script > migration.sql
-
-# 2) Apply it to the DB (reads .env via --schema)
-npx prisma db execute --file migration.sql --schema prisma/schema.prisma
-
-# 3) Record it as a proper migration folder
-TS=$(date +%Y%m%d%H%M%S); MIGR="${TS}_chattype_and_pitchtype"
-mkdir -p prisma/migrations/"$MIGR"
-mv migration.sql prisma/migrations/"$MIGR"/migration.sql
-npx prisma migrate resolve --schema=prisma/schema.prisma --applied "$MIGR"
-
-# 4) Regenerate + sanity check
-npx prisma generate
-npx prisma migrate status --schema=prisma/schema.prisma
-
-**********
-Convert Images: 
-node ./utils/scripts/convertImagesToWebp.mjs ../../convert ../../convert/webp
-
-
-***
-Github whitespace error (if git is out of sync with minor edits)
-
-## confirm the edits are minor
-git diff --summary
-git diff --check
-git diff --ignore-space-at-eol --stat
-
-## Sync
-git fetch origin
-git reset --hard origin/main
-git clean -fd
-git status
+This is an actively evolving solo project. If you'd like to get involved, open an issue to start a conversation. Command cheatsheet and internal dev/ops notes live in [`docs/DEV-NOTES.md`](docs/DEV-NOTES.md).

--- a/docs/DEV-NOTES.md
+++ b/docs/DEV-NOTES.md
@@ -1,0 +1,104 @@
+# Developer notes / command cheatsheet
+
+Working notes for people developing on this repo. Not part of the public README because it's
+operational scratch, not an introduction to the project.
+
+## Everyday commands
+
+```bash
+# Install
+npm install
+
+# Dev server
+npm run dev
+
+# Production build
+npm run build
+npm run start
+
+# Lint + prettier
+npm run lint
+
+# Prisma studio (DB browser UI)
+npx prisma studio
+```
+
+## Database
+
+```bash
+# Set up / apply pending migrations
+npx prisma db pull
+npx prisma migrate dev
+
+# Create a new migration after a schema change
+npx prisma migrate dev --name <name>
+npx prisma generate
+```
+
+### Manual migration-diff fix (when the shadow DB path doesn't apply cleanly)
+
+```bash
+# 1) Create SQL from live DB vs schema (no shadow)
+npx prisma migrate diff \
+  --from-schema-datasource prisma/schema.prisma \
+  --to-schema-datamodel   prisma/schema.prisma \
+  --script > migration.sql
+
+# 2) Apply it to the DB (reads .env via --schema)
+npx prisma db execute --file migration.sql --schema prisma/schema.prisma
+
+# 3) Record it as a proper migration folder
+TS=$(date +%Y%m%d%H%M%S); MIGR="${TS}_<name>"
+mkdir -p prisma/migrations/"$MIGR"
+mv migration.sql prisma/migrations/"$MIGR"/migration.sql
+npx prisma migrate resolve --schema=prisma/schema.prisma --applied "$MIGR"
+
+# 4) Regenerate + sanity check
+npx prisma generate
+npx prisma migrate status --schema=prisma/schema.prisma
+```
+
+## Tests
+
+```bash
+# TypeScript/unit tests
+npm run test
+
+# Cypress (full suite)
+npm run cypress:run
+
+# Cypress (single spec)
+npx cypress run --spec "cypress/e2e/api/users.cy.ts"
+```
+
+## Assets and one-off scripts
+
+```bash
+# Regenerate smart icons
+node utils/scripts/updateKindIcons.js
+
+# Convert a folder of images to webp
+node ./utils/scripts/convertImagesToWebp.mjs <source-dir> <source-dir>/webp
+
+# Smoke-test the ComfyUI prompt endpoint
+curl -X POST "https://kindrobots.org/prompt" \
+  -H "Content-Type: application/json" \
+  --data-binary @utils/fluxKontext.json
+```
+
+## Recovering from a whitespace-only git desync
+
+If `git status` shows the working tree diverged from `origin/main` by whitespace-only churn:
+
+```bash
+# Confirm the edits are actually minor before discarding anything
+git diff --summary
+git diff --check
+git diff --ignore-space-at-eol --stat
+
+# Then sync
+git fetch origin
+git reset --hard origin/main
+git clean -fd
+git status
+```


### PR DESCRIPTION
## What

Refreshes `README.md` (last touched 2026-08-27, but missing several current-state facts) per `rainbow-butterflies/t-005`:

- **Product Families** — a new section grouping the ~20 live surfaces beyond the core Dream flow (worldbuilding/narrative, games & play, creative tools, community & content, commerce & mission), since the README previously only described the Dream engine and a short "What Else You Can Do" list.
- **Conductor** — a short section on the project's own multi-agent build system, which does a meaningful share of Kind Robots' own ongoing development.
- **Rainbow Butterflies** — a short section on the mission/outreach project, explicitly noted as still in build-out with no public launch yet (per its own roadmap gates — t-028 is a hard human gate).
- Moves the internal command cheatsheet (migration-diff workaround, cypress commands, icon regen, whitespace-desync recovery) out of the public README into a new `docs/DEV-NOTES.md`, linked from License & Contributing, so the public intro doesn't read as an ops runbook.

## What I deliberately did NOT change

- The existing "Token & Revenue Model" section already correctly labels the three-way revenue split as **Planned**, not live — per t-005's "do not claim live paid revenue sharing until Kind Economy verifies it," left as-is.
- Did not touch the epigraph, Meet AMI, Core Idea: Dreams, Self-Hosting, Configuring AI Backends, Tech Stack, or Roadmap sections — all still accurate.
- Left the pre-existing prettier prose-wrap warnings on README.md alone (confirmed present before this change via `git stash`; not introduced by this PR, and README.md isn't part of any CI lint job).

## Verification

- `npx prettier --check docs/DEV-NOTES.md` — clean
- Confirmed README.md's pre-existing prettier warnings predate this change (`git stash` + re-check)
- Confirmed README.md isn't referenced by any `.github/workflows/*.yml` lint step — pure documentation change, no CI surface

## Task tracking

Implements `rainbow-butterflies/t-005` (tracked in the `conductor` repo), claimed via `claim_task.py`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PekRvhJ27jdbVB98Grrc8z)_