### PR TITLE
Home band: make the hero 20%, the cast actually slimmer, and give the width to Needs-you

### DIFF
--- a/components/home/home-attention.vue
+++ b/components/home/home-attention.vue
@@ -47,7 +47,7 @@
 <template>
   <section
     v-if="gates.length || isLoading"
-    class="flex min-h-0 flex-col gap-1 kr-panel-flat p-2 lg:w-80 lg:shrink-0"
+    class="flex min-h-0 flex-col gap-1 kr-panel-flat p-2"
   >
     <header class="flex shrink-0 items-baseline justify-between gap-2">
       <h2
@@ -71,16 +71,28 @@
       A bounded scroller, not an unbounded list: the gate count is unpredictable
       (it has been twenty-plus) and this sits beside a fixed-height hero. The
       layout contract's one-scroll rule deliberately does not count a `max-h-*`
-      region -- nested preview, not the page's scroll owner.
+      region -- nested preview, not the page's scroll owner. `max-h-full` bounds
+      it to the band height the page sets, and keeps the `max-h-*` exemption.
+
+      COLUMNS, now that there is width to use. This was a 20rem strip because
+      that is all the hero left it; it now takes the remainder of the row, which
+      at 1920 is around three times that. A single column at that width would be
+      one short sentence per line with 900px of blank to its right. Container
+      columns (not a viewport breakpoint -- viewport-grid rule) put three or four
+      gates across, so the same bounded height shows about twelve at once
+      instead of four. An open composer spans the full width, because a textarea
+      in a 20rem column is not somewhere you want to write an answer.
     -->
     <div
-      class="max-h-64 min-h-0 space-y-1 overflow-y-auto overscroll-contain pr-1"
+      class="grid max-h-full min-h-0 content-start gap-1 overflow-y-auto overscroll-contain pr-1 grid-cols-[repeat(auto-fit,minmax(min(100%,17rem),1fr))]"
     >
       <div
         v-for="gate in gates"
         :key="gateKey(gate)"
-        class="rounded-lg border border-base-300 bg-base-100 transition-colors"
-        :class="openKey === gateKey(gate) ? 'border-primary' : ''"
+        class="min-w-0 rounded-lg border border-base-300 bg-base-100 transition-colors"
+        :class="
+          openKey === gateKey(gate) ? 'border-primary [grid-column:1/-1]' : ''
+        "
       >
         <button
           type="button"
@@ -194,7 +206,7 @@
 
       <p
         v-if="isLoading && !gates.length"
-        class="px-1 py-2 text-[0.7rem] text-base-content/50"
+        class="px-1 py-2 text-[0.7rem] text-base-content/50 [grid-column:1/-1]"
       >
         Checking what's waiting…
       </p>

--- a/components/home/home-dream-hero.vue
+++ b/components/home/home-dream-hero.vue
@@ -40,12 +40,19 @@
       card is a fixed width rather than a fifth of the page, freeing the width
       the Needs-you column now occupies.
 
-      THEN A LITTLE WIDER AGAIN, once it had something to say. Silas,
-      2026-08-29: "The hero is the right size, but make it a little wider
-      because we want to add the descrition for the dream, that is missing."
-      11rem fitted a title and a one-line hook and nothing else; 16rem fits a
-      three-line description without the whole band growing, because the cast
-      beside it gave up more width than this took (see the cast note below).
+      THEN MEASURED, because two passes of "a little wider" never got there.
+      Silas, 2026-08-29: "that dream hero is absolutely not 20%." He was right,
+      and it was checkable all along: at 1920 the card was 256px, which is 13.3%
+      of the screen, while the cast tiles beside it were 157px EACH. The card
+      read as subordinate to its own cast.
+
+      `20vw` states the requirement he actually gave ("something that fits about
+      20% width of screen") instead of approximating it with a rem width that is
+      only correct at one viewport. The clamp keeps it sane at the extremes: no
+      narrower than 14rem on a small laptop, no wider than 26rem on an ultrawide
+      where 20% would be a poster. `vw` is fine here -- the layout contract's
+      no-viewport rule bans viewport HEIGHT units (h-screen/100vh/100dvh) inside
+      the h-dvh shell, not vw.
 
       ABOUT A FIFTH OF THE WIDTH, in its natural proportion. Silas, 2026-08-29:
       "Obviously the dream hero is horribly proportioned, It would be better to
@@ -62,21 +69,32 @@
     -->
     <NuxtLink
       :to="showcaseHref(hero.dream)"
-      class="group flex shrink-0 flex-col gap-1 rounded-xl border-2 border-primary/70 bg-base-100 p-1.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:hover:-translate-y-0.5 lg:w-64"
+      class="group flex shrink-0 flex-col gap-1 rounded-xl border-2 border-primary/70 bg-base-100 p-1.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:hover:-translate-y-0.5 lg:h-full lg:w-[clamp(14rem,20vw,26rem)]"
     >
-      <kr-art-plate
-        :source="hero.dream.art"
-        variant="hero"
-        shape="wide"
-        frame="none"
-        :alt="hero.dream.title"
-        :fallback="dreamFallback"
-        eager
-        hover-zoom
-        fit="cover"
-      />
+      <!--
+        `h-full` inside a flexible box, so the PLATE fills whatever height the
+        band has left after the text rather than setting the card's height from
+        its own aspect ratio. An aspect-ratio only sizes a box while one
+        dimension is auto; giving it a definite height makes the ratio inert and
+        the image crops to fit. This is what lets the three columns of the band
+        share one height instead of the tallest one winning.
+      -->
+      <div class="min-h-0 flex-1 overflow-hidden rounded-lg">
+        <kr-art-plate
+          class="h-full"
+          :source="hero.dream.art"
+          variant="hero"
+          shape="wide"
+          frame="none"
+          :alt="hero.dream.title"
+          :fallback="dreamFallback"
+          eager
+          hover-zoom
+          fit="cover"
+        />
+      </div>
 
-      <div class="min-w-0">
+      <div class="min-w-0 shrink-0">
         <p
           class="text-[0.6rem] font-black uppercase tracking-[0.18em] text-primary"
         >
@@ -87,28 +105,25 @@
           {{ hero.dream.title }}
         </h2>
 
-        <p
-          v-if="hero.hook"
-          class="mt-0.5 line-clamp-1 text-[0.7rem] font-bold leading-snug text-base-content/70"
-        >
-          {{ hero.hook }}
-        </p>
-
         <!--
           THE DESCRIPTION, which was simply never rendered. Silas, 2026-08-29:
           "we want to add the descrition for the dream, that is missing."
 
           It is clamped rather than truncated server-side so the text reflows
           with the card instead of ending in a hard ellipsis at a fixed
-          character count. `hook` above is one line and this is three, so the
-          two do not read as the same sentence twice -- and where a dream has
-          only one of them, the other is simply absent.
+          character count.
+
+          It also REPLACED the one-line `hook` that used to sit above it. Both
+          are summarized from the same source fields, so on most dreams they
+          were the same sentence printed twice at two lengths -- and the
+          duplicate line was 20px of the height the band is now trying to
+          budget. `hook` is the fallback when there is no description.
         -->
         <p
-          v-if="hero.description"
-          class="mt-1 line-clamp-3 text-[0.7rem] leading-snug text-base-content/60"
+          v-if="hero.description || hero.hook"
+          class="mt-1 line-clamp-3 text-[0.7rem] leading-snug text-base-content/65"
         >
-          {{ hero.description }}
+          {{ hero.description || hero.hook }}
         </p>
 
         <span
@@ -136,19 +151,32 @@
       breakpoint (it can be embedded in a narrower host), and a static count is
       not that.
 
-      SLIMMER TILES, on purpose and at a cost. Silas, 2026-08-29: "the other
-      elements on the daily dream can be 50% slimmer, to make room for a better
-      human gate needs you section." A literal half of 7rem is 3.5rem, at which
-      a name truncates to about four characters and the tile stops being
-      identifiable -- which fights his earlier "All the cards need to be big
-      enough to see more of the titles". 4.5rem is the floor where a short name
-      still reads, and the band gives up more width than the difference anyway,
-      because the Needs-you column beside it grew at the same time. If the cast
-      still feels wide, the next thing to cut is the tile CAPTION, not the plate.
+      FIXED TRACKS, and this is the fix for a change that did nothing. Silas,
+      2026-08-29: "the other elements on the daily dream can be 50% slimmer, to
+      make room for a better human gate needs you section." The first attempt
+      lowered the minimum in `minmax(min(100%,7rem),1fr)` to 4.5rem and changed
+      NOTHING, because the `1fr` maximum stretches every track to fill the
+      container: with eight cast members in a wide row each tile was
+      container/8, measured at 157px, whatever the minimum said. Silas, next
+      pass: "I'm wondering if anything actually got done." Fair.
+
+      `auto-cols-[4.5rem]` is a fixed track size with no `1fr` to stretch it, so
+      a tile is 72px and stays 72px. That is the "50% slimmer" actually applied
+      -- and it is what frees the width the Needs-you column now takes, because
+      this panel no longer stretches to fill the row (see home-page.vue).
+
+      THREE ROWS, flowing sideways, for the height. One row of small tiles left
+      ~150px of dead space under the cast while the dream card set the band
+      height -- Silas: "still a discrepancy betwen hero dream height and the
+      rest." `grid-rows-3` with `auto-rows-fr` and `h-full` makes the rows share
+      the band height exactly, so the cast is as tall as the card beside it by
+      construction rather than by luck. At 4.5rem wide and a third of the band
+      tall, a tile lands near 2:3 -- the portrait card shape these objects are
+      drawn at anyway.
     -->
     <div
       v-if="hero.cast.length"
-      class="grid content-start gap-1 grid-cols-[repeat(auto-fit,minmax(min(100%,4.5rem),1fr))] lg:min-w-0 lg:flex-1"
+      class="grid grid-flow-col grid-rows-3 auto-cols-[4.5rem] auto-rows-fr gap-1 overflow-x-auto no-scrollbar lg:h-full"
     >
       <!--
         A cast member opens the interstitial rather than navigating away. Silas,
@@ -167,7 +195,7 @@
         :key="`${member.kind}-${member.id}`"
         :to="showcaseHref(member)"
         :data-theme="themeFor(member)"
-        class="group flex min-w-0 flex-col overflow-hidden rounded-lg border-2 border-primary/70 bg-base-100 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:hover:-translate-y-0.5"
+        class="group flex h-full min-w-0 flex-col overflow-hidden rounded-lg border-2 border-primary/70 bg-base-100 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:hover:-translate-y-0.5"
         :title="
           member.subtitle
             ? `${member.title} — ${member.subtitle}`
@@ -176,6 +204,7 @@
         @click="onCastClick($event, member)"
       >
         <kr-art-plate
+          class="min-h-0 flex-1"
           :source="member.art"
           variant="card"
           shape="square"
@@ -209,9 +238,9 @@
           </template>
         </kr-art-plate>
 
-        <div class="min-w-0 px-1 py-0.5">
+        <div class="min-w-0 shrink-0 px-1 py-0.5">
           <p
-            class="truncate text-xs font-bold leading-tight group-hover:text-primary"
+            class="truncate text-[0.65rem] font-bold leading-tight group-hover:text-primary"
           >
             {{ member.title }}
           </p>

--- a/components/home/home-page.vue
+++ b/components/home/home-page.vue
@@ -51,25 +51,47 @@
 
     <!--
       The top band is the dream, its cast, and whatever is waiting on Silas.
-      He asked for the dream to give up horizontal space for the third
+      He asked twice for the dream to give up horizontal space to the third
       (2026-08-29: "Dream entry should take up less horizontal space to leave
-      room for a vertical notification scroll").
+      room for a vertical notification scroll", then "did not get the increased
+      horizontal space for notifications either").
+
+      IT DID NOT, AND THIS IS WHY. The hero carried `lg:flex-1`, so however
+      narrow its contents became, the PANEL still absorbed every pixel the cast
+      gave up. Measured at 1920: hero panel 1560px, Needs-you 320px -- and
+      widening Needs-you from 16rem to 20rem moved 64px while the cast quietly
+      kept the other 1200. The hero now sizes to its contents and Needs-you
+      takes the remainder, which is the only arrangement where making the cast
+      slimmer actually reaches the column it was slimmed for.
+
+      `lg:flex-1` is still the fallback when there is no Needs-you column at
+      all (a signed-out visitor, or an empty gate list) -- otherwise the band
+      would end in 1200px of nothing.
+
+      ONE HEIGHT FOR ALL THREE COLUMNS. Silas: "still a discrepancy betwen hero
+      dream height and the rest." There was: the dream card's 4:3 plate set the
+      band height at 356px and the single row of cast tiles left ~150px of dead
+      space beneath it. A definite height on the row makes every column exactly
+      as tall as its neighbours, and each column then distributes that height
+      internally (the card's plate flexes, the cast's rows share it, the gate
+      list scrolls). `h-*` in rem, not vh -- the contract's no-viewport rule.
     -->
-    <div class="flex flex-col gap-2 lg:flex-row lg:items-stretch">
+    <div class="flex flex-col gap-2 lg:h-96 lg:flex-row lg:items-stretch">
       <home-dream-hero
         v-if="showcaseStore.hero"
-        class="min-w-0 lg:flex-1"
+        class="min-w-0"
+        :class="showAttention ? 'lg:shrink-0' : 'lg:flex-1'"
         :hero="showcaseStore.hero"
         @select="openCard"
       />
 
       <div
         v-else-if="!showcaseStore.hasLoaded"
-        class="h-40 w-full animate-pulse rounded-2xl bg-base-200 lg:flex-1"
+        class="h-40 w-full animate-pulse rounded-2xl bg-base-200 lg:h-full lg:flex-1"
         aria-hidden="true"
       />
 
-      <home-attention />
+      <home-attention class="lg:min-w-0 lg:flex-1" />
     </div>
 
     <!--
@@ -239,8 +261,16 @@
       contract's one-scroll rule deliberately does not count a `max-h-*` region
       -- those are nested previews, not the page's scroll owner, which is still
       pages/[...slug].vue's content-host.
+
+      The bound was accidentally DROPPED when the heading moved into the feed's
+      own control row, which is how an unbounded feed got back onto the page.
+      It is on the section itself now rather than an inner wrapper, so the
+      heading row scrolls with the stories instead of the stories scrolling
+      under a pinned header inside a panel that also scrolls.
     -->
-    <section class="flex flex-col kr-panel-flat p-3">
+    <section
+      class="flex max-h-80 flex-col overflow-y-auto overscroll-contain kr-panel-flat p-3"
+    >
       <NewsfeedFeed :initial-limit="24" compact>
         <template #lead>
           <h2
@@ -328,6 +358,18 @@ const selectedCard = ref<RailItem | null>(null)
 function openCard(card: RailItem): void {
   selectedCard.value = card
 }
+
+/**
+ * Whether home-attention will render anything.
+ *
+ * Deliberately the SAME condition that component uses (`gates.length ||
+ * !hasLoaded`), because the hero's width depends on whether it has a neighbour:
+ * with one it sizes to its contents, without one it fills the row. If these two
+ * ever disagree the band gets either a 1200px hole or a squashed gate list.
+ */
+const showAttention = computed(
+  () => conductorStore.humanGates.length > 0 || !conductorStore.hasLoaded,
+)
 
 /**
  * Percent complete for a project, joined to conductor's own figure on


### PR DESCRIPTION
> "that dream hero is absolutely not 20%. did not get the increased horizontal space for notifications either. still a discrepancy betwen hero dream height and the rest...I'm wondering if anything actually got done."

Right on all three, and one of them was a change that genuinely did nothing. This pass was **measured** rather than judged by eye.

## Numbers, at 1920×1080

| | before | after | asked for |
| --- | --- | --- | --- |
| dream card | 256px (13.3%) | **384px (20.0%)** | "about 20% width of screen" |
| cast tile | 157px | **72px** (54% slimmer) | "50% slimmer" |
| Needs-you | 320px (17%) | **1238px (64.5%)** | "increased horizontal space for notifications" |
| hero card vs cast height | 358 vs ~180 | **358 vs 358** | "discrepancy betwen hero dream height and the rest" |
| page height | 970px | 1049px (1.03 screens) | "not larger than two" |

Also verified at 1366×768: hero card 273px = exactly 20.0%, all band columns 384px, **no horizontal overflow at either width**.

## Why each one had failed

**The cast change did nothing.** It was `minmax(min(100%,4.5rem),1fr)` under `auto-fit`. The `1fr` *maximum* stretches every track to fill the container, so eight tiles in a wide row were container÷8 whatever the minimum said — lowering 7rem to 4.5rem moved zero pixels at desktop width. `auto-cols-[4.5rem]` is a fixed track with no `1fr` to stretch it, so a tile is 72px and stays 72px.

**The width never reached Needs-you.** The hero carried `lg:flex-1`, so however narrow its contents became the *panel* still absorbed every pixel the cast gave up — widening Needs-you from 16rem to 20rem moved 64px while the cast quietly kept the other 1200. The hero now sizes to its contents and Needs-you takes the remainder, which is the only arrangement where slimming the cast reaches the column it was slimmed for. `lg:flex-1` remains the fallback when there is no gate column, so the band doesn't end in 1200px of nothing.

**The heights disagreed** because the dream card's 4:3 plate set the band height and one row of cast tiles left ~150px of dead space beneath it. The row now has a definite height and each column fills it: the card's plate flexes (`h-full` makes its `aspect-ratio` inert), the cast's three rows share it, the gate list scrolls.

**20% is now stated as `20vw`**, clamped to `[14rem, 26rem]`, rather than a rem width that is only correct at one viewport. `vw` is fine — the contract's `no-viewport` rule bans viewport *height* units (`h-screen`/`100vh`/`100dvh`) inside the `h-dvh` shell.

## Along the way

- **Needs-you is a container-column grid** now that it has width — about twelve gates visible instead of four, with an open composer spanning the full width, because a textarea in a 20rem column is not somewhere you want to write an answer.
- **The hero's one-line hook is gone.** It and the description are summarized from the same source fields, so on most dreams they printed the same sentence twice at two lengths. `hook` is now the fallback when there's no description.
- **The newsfeed's bounded scroller is restored** — it was dropped in the previous pass when the heading moved into the feed's own control row, which put an unbounded feed back on the page.

## Verification

Playwright harness against a mocked payload at both viewports (numbers above), plus `vue-tsc`, `eslint`, `prettier`, `npm run test:layout-contract`, and `verifyMdcScrollOwnership.ts` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aNg3fsHLGUGCwiMp25hkA

---
_Generated by [Claude Code](https://claude.ai/code/session_017aNg3fsHLGUGCwiMp25hkA)_