### PR TITLE
brainstorm: add an engine picker to selected-candidate art generation

### DIFF
--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -698,10 +698,28 @@
           {{ selectedForArtCount }} of {{ keptCandidates.length }} kept idea{{
             keptCandidates.length === 1 ? '' : 's'
           }}
-          selected · Krea 2
+          selected
         </p>
       </div>
       <div class="flex flex-wrap items-center gap-2">
+        <label class="form-control">
+          <span class="sr-only">Art engine</span>
+          <select
+            v-model="artEngine"
+            class="select select-bordered select-sm rounded-xl"
+            :disabled="isGeneratingArt"
+            data-testid="brainstorm-art-engine"
+            aria-label="Art engine"
+          >
+            <option
+              v-for="profile in artEngineOptions"
+              :key="profile.engine"
+              :value="profile.engine"
+            >
+              {{ profile.label }}
+            </option>
+          </select>
+        </label>
         <button
           type="button"
           class="btn btn-ghost btn-sm"
@@ -856,6 +874,8 @@ import type {
 } from '@/stores/helpers/brainstormSourceAdapters'
 import { useBotStore } from '@/stores/botStore'
 import type { Bot } from '~/prisma/generated/prisma/client'
+import { ART_ENGINE_PROFILES } from '@/utils/artGeneratorPresets'
+import type { ArtGeneratorEngine } from '@/utils/artGeneratorPresets'
 
 const creativeDirections = [
   {
@@ -969,6 +989,7 @@ const {
   suggestedSessionName,
   source,
   selectedForArtCandidates,
+  artEngine,
   artGenerationState,
   artGenerationError,
   artGenerationProgress,
@@ -1122,6 +1143,16 @@ const artProgressLabel = computed(() => {
     ? `Generating ${progress.completed}/${progress.total}…`
     : 'Generating…'
 })
+
+// brainstorm/t-025: every artGeneratorPresets.ts engine is prompt-only
+// (krea2/flux2/flux/comfy) -- sdxl-img2img/kontext are deliberately not in
+// this catalog at all, since those are entity-recreation/edit engines that
+// need a source image, which no brainstorm candidate has.
+const artEngineOptions: { engine: ArtGeneratorEngine; label: string }[] =
+  Object.values(ART_ENGINE_PROFILES).map((profile) => ({
+    engine: profile.engine,
+    label: profile.label,
+  }))
 
 const errorHeading = computed(() => {
   switch (generationError.value?.kind) {

--- a/stores/brainstormStore.ts
+++ b/stores/brainstormStore.ts
@@ -5,6 +5,7 @@ import { useArtStore } from '@/stores/artStore'
 import type { GenerateArtData } from '@/stores/artStore'
 import { useServerStore } from '@/stores/serverStore'
 import { performFetch } from '@/stores/utils'
+import type { ArtGeneratorEngine } from '@/utils/artGeneratorPresets'
 import {
   applyCandidateEdit,
   applyCandidateRegeneration,
@@ -124,6 +125,14 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
   // now), not durable creative state worth persisting through save/load the
   // way meta.art (the resulting job/image linkage) is.
   const artSelectionIds = ref<string[]>([])
+  // brainstorm/t-025: which of artGeneratorPresets.ts's prompt-only engines
+  // (krea2/flux2/flux/comfy) the batch "Generate art" control enqueues with.
+  // sdxl-img2img/kontext are deliberately excluded from the picker -- those
+  // are entity-recreation/edit engines that require an existing image
+  // (server/api/art/enqueue.post.ts rejects them for a prompt-only request),
+  // and every Brainstorm candidate generates fresh from text with no source
+  // image. Default stays krea2 per t-016's original note.
+  const artEngine = ref<ArtGeneratorEngine>('krea2')
   const artGenerationState = ref<'idle' | 'generating'>('idle')
   const artGenerationError = ref<BrainstormError | null>(null)
   const artGenerationProgress = ref<{
@@ -1002,7 +1011,7 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
       } else {
         const enqueued = await artStore.enqueueArtGeneration({
           promptString: prompt,
-          engine: 'krea2',
+          engine: artEngine.value,
           isPublic: false,
           isMature: false,
           brainstormContext: {
@@ -1345,6 +1354,7 @@ export const useBrainstormStore = defineStore('brainstormStore', () => {
     generationTargetId,
     lastGeneratedAt,
     artSelectionIds,
+    artEngine,
     artGenerationState,
     artGenerationError,
     artGenerationProgress,


### PR DESCRIPTION
### Task
conductor brainstorm/t-025: Add an engine picker to Brainstorm's selected-candidate art generation

### What changed
- `stores/brainstormStore.ts`: new `artEngine` ref (`ArtGeneratorEngine`, default `krea2`), threaded through `generateArtForCandidate`'s `enqueueArtGeneration` call instead of the hardcoded `'krea2'` string. Exposed in the store's return object.
- `components/brainstorm/brainstorm-manager.vue`: a small `<select>` in the "Generate art" batch control (`kept idea(s) selected`), built from `artGeneratorPresets.ts`'s `ART_ENGINE_PROFILES` — the existing single source of truth for prompt-only engine labels (Krea 2 Turbo / FLUX.2 Klein / FLUX.1 / SDXL checkpoint), already consumed the same way by `daily-dream-object-art-workbench.vue`. Removed the now-redundant hardcoded "· Krea 2" text.

`sdxl-img2img` and `kontext` are deliberately excluded from the picker: `server/api/art/enqueue.post.ts` requires those two for entity recreation/edit (an existing source image to work from), and every Brainstorm candidate generates fresh from a text prompt with no source image — `ART_ENGINE_PROFILES` already only enumerates the four prompt-only engines, so no extra filtering was needed.

### How I verified
- `npx eslint stores/brainstormStore.ts components/brainstorm/brainstorm-manager.vue` — clean.
- `npx vue-tsc --noEmit` (full project) — clean.
- `npx prettier --check` on both changed files — clean (confirmed via `git stash` that `brainstorm-manager.vue`'s prior prettier warning predates this change and is untouched by it).
- `npm run test:layout-contract` — holds, 0 new violations.
- `npm run test:brainstorm-art-poll-failure-guard`, `test:brainstorm-candidate-lifecycle`, `test:brainstorm-source-adapters`, `test:brainstorm-source-context` — all pass.
- Honest limit: no reachable database in this sandbox and no PR-preview infrastructure, so no rendered screenshot of the new `<select>` — verification is class-level/structural (the same `select select-bordered select-sm rounded-xl` classes already render correctly on the daily-dream-object-art-workbench.vue precedent) plus typecheck/lint/layout-contract/unit tests.

### Stakes
reversible — additive UI control, default behavior (Krea 2) unchanged.

### Notes for reviewer
Small, self-contained, matches the task's own "small, reversible, self-contained" framing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EzQ3uj7snBGXaNpPsLi92f)_