### PR TITLE
interface-vision/t-105: polish Privacy Policy page header

### DIFF
--- a/components/pages/privacy-page.vue
+++ b/components/pages/privacy-page.vue
@@ -2,9 +2,16 @@
   <div
     class="kr-unbound privacy-page max-w-3xl mx-auto px-6 py-12 text-base leading-relaxed"
   >
-    <header class="mb-10">
-      <p class="text-4xl font-bold mb-2">Privacy Policy</p>
-      <p class="text-sm opacity-60">Last updated: May 2026</p>
+    <header class="mb-10 flex items-center gap-3">
+      <span
+        class="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-primary/15 text-primary"
+      >
+        <Icon name="kind-icon:shield" class="h-7 w-7" />
+      </span>
+      <div>
+        <p class="text-2xl font-black tracking-tight">Privacy Policy</p>
+        <p class="text-sm text-base-content/60">Last updated: May 2026</p>
+      </div>
     </header>
 
     <!-- Short Version -->


### PR DESCRIPTION
Slice of the recurring interface-vision/t-105 page-polish task (conductor).

**Prior state:** the Privacy Policy page had a bare text header (4xl bold title + subtitle, no icon) — inconsistent with every other polished content/legal page on the site.

**Change** (`components/pages/privacy-page.vue` only, template only, no script changes): adopted the established icon-badge + title/subtitle header pattern (`kind-icon:shield` badge, 2xl bold title, 60%-opacity subtitle) matching `serendipity-page.vue`/`build-bench.vue`/`mission-accrual-page.vue`/`wallet-page.vue` precedent, sized for a left-aligned content page the way `giving-page.vue` and `about-page.vue` already do for their own text-heavy pages.

**Verification:**
- `eslint` on the changed file: clean
- `vue-tsc --noEmit`: clean
- `npm run test:layout-contract`: holds, 0 new violations
- `prettier --check`: flags pre-existing drift on this file, confirmed via `git stash` to predate this change — left alone per established precedent from prior slices of this same task

---
_Generated by [Claude Code](https://claude.ai/code/session_018UhFt2QJJWo6oBTkw94yC5)_