### PR TITLE
interface-vision/t-104: swap error.vue's hand-rolled max-width wrapper for kr-container

### DIFF
--- a/error.vue
+++ b/error.vue
@@ -3,7 +3,7 @@
     class="min-h-screen bg-base-300 px-4 py-8 text-base-content sm:px-6 lg:px-8"
   >
     <section
-      class="mx-auto flex min-h-[calc(100vh-4rem)] w-full max-w-5xl flex-col items-center justify-center gap-6"
+      class="kr-container flex min-h-[calc(100vh-4rem)] max-w-5xl flex-col items-center justify-center gap-6"
     >
       <img
         src="/images/background/error.webp"


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring)

### What changed / what I produced
- `error.vue`'s `<section>` root used the hand-rolled `mx-auto flex w-full max-w-5xl flex-col ...` pattern — the exact pattern `.kr-container` (`mx-auto w-full max-w-6xl`) already codifies. Swapped to `kr-container max-w-5xl` (same override-the-default-max-w pattern as slice 30's `password-reset.vue` conversion, per that task's roadmap note), keeping every other class (`min-h-[calc(100vh-4rem)] flex-col items-center justify-center gap-6`) unchanged.
- No geometry or behavior change: `kr-container` compiles to `mx-auto w-full max-w-6xl`, and `max-w-5xl` after it overrides the max-width the same way the existing precedent does.

### How I verified
- `npx eslint error.vue` — clean
- `npx prettier --check error.vue` — clean
- `npm run test:layout-contract` — holds, no new violations (all 9 tracked metrics unchanged)
- `npm run test` (vue-tsc `--noEmit`) — exit 0, no type errors

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Several more hand-rolled `mx-auto ... w-full ... max-w-*` candidates are still present repo-wide (e.g. `components/conductor/project-front-page.vue`, `components/academy/academy-timeline.vue`, `components/academy/academy-styles-browser.vue`, `components/pages/for-you-manager.vue`, `components/achievements/achievement-popup.vue`) — this recurring task is not actually exhausted the way several same-day sessions' TALKBACK notes assumed; the next t-104 cycle has real work queued.

### Notes for reviewer


---
_Generated by [Claude Code](https://claude.ai/code/session_01SYLbVpwpDa7MEu67RCNmUn)_