### PR TITLE
interface-vision/t-104: use kr-container for Academy timeline

### DIFF
--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -1,6 +1,6 @@
 <!-- /components/academy/academy-timeline.vue -->
 <template>
-  <section class="mx-auto flex w-full max-w-[1600px] flex-col gap-5">
+  <section class="kr-container max-w-[1600px] flex flex-col gap-5">
     <header
       class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,30rem),1fr))] overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-sm"
     >


### PR DESCRIPTION
## What changed

- Replace `academy-timeline.vue`'s hand-rolled `mx-auto w-full max-w-[1600px]` root geometry with the shared `kr-container` primitive plus the same `max-w-[1600px]` override.
- Preserve the existing flex column/gap and all behavior.

## Why

This is the next bounded slice from interface-vision/t-104. The immediately preceding slice (#2201) explicitly queued `academy-timeline.vue` among the remaining clean container candidates.

## Validation

The branch diff is one intended class substitution in one file. CI is authoritative for type/layout/contracts; merge only after the exact-head checks complete successfully.

Conductor session: `openai-scheduled-20260829T171603Z-ivt104-a3f7`