### PR TITLE
interface-vision/t-104: use kr-container for Academy Style Gallery

### DIFF
--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -1,6 +1,6 @@
 <!-- /components/academy/academy-styles-browser.vue -->
 <template>
-  <section class="mx-auto flex w-full max-w-[1600px] flex-col gap-4">
+  <section class="kr-container flex max-w-[1600px] flex-col gap-4">
     <header
       class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-4 shadow-sm sm:p-5 lg:flex-row lg:items-end lg:justify-between"
     >


### PR DESCRIPTION
## What changed

- Replace `academy-styles-browser.vue`'s hand-rolled `mx-auto flex w-full max-w-[1600px]` root geometry with the shared `kr-container` primitive plus the same `max-w-[1600px]` override.
- Preserve the existing flex column/gap and all behavior.

## Why

This is the next bounded slice from interface-vision/t-104. The immediately preceding slice (#2202) queued `academy-styles-browser.vue` among the remaining clean container candidates.

## Validation

- `npx eslint components/academy/academy-styles-browser.vue` clean.
- `npx prettier --check` flags pre-existing drift on this file, confirmed via `git stash` to predate this change — left alone.
- `npm run test` (vue-tsc --noEmit, full project) exit 0.
- `npm run test:layout-contract` holds — 0 new violations.

Conductor session: `20260829T173309Z-ivt104-sched`

---
_Generated by [Claude Code](https://claude.ai/code/session_016X9CozbAbZjV5QYvxgHP8S)_