### PR TITLE
interface-vision/t-104: use kr-container for Project Front Page

### DIFF
--- a/components/conductor/project-front-page.vue
+++ b/components/conductor/project-front-page.vue
@@ -24,7 +24,7 @@
         class="absolute inset-0 bg-gradient-to-t from-base-200 via-base-200/70 to-transparent"
       />
       <div
-        class="relative mx-auto flex w-full max-w-5xl flex-col gap-4 px-5 pb-6 pt-16 sm:pt-24"
+        class="relative kr-container flex max-w-5xl flex-col gap-4 px-5 pb-6 pt-16 sm:pt-24"
       >
         <div class="flex flex-wrap items-center gap-2">
           <span
@@ -112,7 +112,7 @@
       </div>
     </header>
 
-    <div class="mx-auto flex w-full max-w-5xl flex-col gap-5 px-5 pb-10 pt-5">
+    <div class="kr-container flex max-w-5xl flex-col gap-5 px-5 pb-10 pt-5">
       <!-- Description -->
       <section
         v-if="view.description"


### PR DESCRIPTION
### Task
interface-vision/t-104: bounded consistency slice 32 — `kr-container` sweep (kind: software, recurring)

### What changed / what I produced
- `components/conductor/project-front-page.vue`: both root-level wrappers (hero and body) now use the shared `kr-container` primitive plus their existing `max-w-5xl` override, instead of hand-rolled `mx-auto flex w-full max-w-5xl`. No geometry or behavior change — `kr-container` is `mx-auto w-full max-w-6xl`, so the explicit `max-w-5xl` continues to win via Tailwind's later-class-wins ordering, same pattern as prior slices (`error.vue`, `academy-timeline.vue`, `academy-styles-browser.vue`).

### How I verified
- `eslint components/conductor/project-front-page.vue` — clean
- `vue-tsc --noEmit` repo-wide — clean
- `npm run test:layout-contract` — holds, 207 baseline / 0 new violations
- `prettier --check` flags pre-existing drift on this file — confirmed via `git stash` that the same warning fires identically before this change, so it's not introduced by this diff

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Remaining queued candidates from this recurring task's last note: `components/achievements/achievement-popup.vue` (max-w-md) and `components/pages/for-you-manager.vue` (max-w-[1800px]) — both straightforward single-occurrence substitutions for the next slice. `components/user/messenger.vue` remains explicitly out of scope (root mixes `kr-panes` grid primitive with an arbitrary `h-[70vh]`, not a clean container substitution).

### Notes for reviewer
Second occurrence in this same file — both converted in one slice since they're the same component/pattern.

---
_Generated by [Claude Code](https://claude.ai/code/session_0176pLeHXBbDhMXX2gBXoQYC)_