### PR TITLE
interface-vision/t-104: use kr-container for For You Manager

### DIFF
--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -5,7 +5,7 @@
   >
     <div class="kr-scroll min-h-0 flex-1 overscroll-contain">
       <div
-        class="mx-auto w-full max-w-[1800px] space-y-6 p-2 pb-8 sm:p-4 sm:pb-10 xl:p-6"
+        class="kr-container max-w-[1800px] space-y-6 p-2 pb-8 sm:p-4 sm:pb-10 xl:p-6"
       >
         <!--
           daily-dream-generator moved here from dream-manager, where it sat in a


### PR DESCRIPTION
### Task
interface-vision/t-104: bounded consistency slice (kind: software)

### What changed / what I produced
- `components/pages/for-you-manager.vue`'s root scroll wrapper now uses `kr-container` plus its existing `max-w-[1800px]` override instead of the hand-rolled `mx-auto w-full max-w-[1800px]`. No geometry or behavior change (`kr-container` is `mx-auto w-full max-w-6xl`; the explicit `max-w-[1800px]` on the element still overrides it, same as every prior slice's pattern).

### How I verified
- `eslint` on the changed file: 1 pre-existing error (`no-dynamic-delete` at line 563, unrelated to this change) confirmed via `git stash` to predate this diff.
- `prettier --check`: clean.
- `npm run test` (`vue-tsc --noEmit`, repo-wide): clean.
- `npm run test:layout-contract`: holds, 0 new violations (207 baseline for the pre-existing "grid-cols behind breakpoint" metric, unchanged).

### Stakes
reversible

### Flags for Reviewer
- The prior slice's note also queued `components/achievements/achievement-popup.vue` as a "straightforward" candidate, but an earlier slice (31) had explicitly assessed it out of scope: its `mx-auto w-full max-w-md` sits on a "modal-content" div that also carries `border`/`bg-base-100`/`shadow-2xl` decorative utilities on the same class string — a different shape than every accepted conversion so far (which only combine `kr-container` with layout/spacing utilities, e.g. `mana-wallet.vue`'s `kr-container max-w-3xl p-6 space-y-8`). I re-read the file and kept it out of scope again this slice rather than trust the more recent note over the earlier file-level assessment; flagging the discrepancy for a maintainer to resolve one way or the other rather than silently re-deciding it.

### Kaizen suggestion
Resolve the `achievement-popup.vue` ambiguity explicitly (in the roadmap note or via a quick Silas call) so it stops bouncing between "out of scope" and "straightforward" across slices — either broaden the accepted pattern to include decorative-utility siblings, or mark it permanently out of scope like `messenger.vue`.

### Notes for reviewer
`components/user/messenger.vue` remains out of scope (root mixes the `kr-panes` grid primitive with an arbitrary `h-[70vh]`).

---
_Generated by [Claude Code](https://claude.ai/code/session_018g3QeQ3UEYLmHKho8MnpHL)_