### PR TITLE
interface-vision/t-104: use kr-container for 8 kr-scroll page roots

### DIFF
--- a/pages/play/aquarium/browse/[username]/[slug].vue
+++ b/pages/play/aquarium/browse/[username]/[slug].vue
@@ -8,7 +8,7 @@
 <template>
   <main class="kr-surface bg-base-200/40">
     <div
-      class="kr-scroll mx-auto max-w-4xl space-y-5 px-3 py-5 sm:px-6 sm:py-8"
+      class="kr-scroll kr-container max-w-4xl space-y-5 px-3 py-5 sm:px-6 sm:py-8"
     >
       <nav>
         <NuxtLink

--- a/pages/play/aquarium/browse/index.vue
+++ b/pages/play/aquarium/browse/index.vue
@@ -7,7 +7,7 @@
 <template>
   <main class="kr-surface bg-base-200/40">
     <div
-      class="kr-scroll mx-auto max-w-5xl space-y-5 px-3 py-5 sm:px-6 sm:py-8"
+      class="kr-scroll kr-container max-w-5xl space-y-5 px-3 py-5 sm:px-6 sm:py-8"
     >
       <nav class="flex items-center justify-between gap-3">
         <NuxtLink to="/play/aquarium" class="btn btn-ghost btn-sm rounded-xl">

--- a/pages/play/aquarium/leaderboard/index.vue
+++ b/pages/play/aquarium/leaderboard/index.vue
@@ -8,7 +8,7 @@
 <template>
   <main class="kr-surface bg-base-200/40">
     <div
-      class="kr-scroll mx-auto max-w-3xl space-y-5 px-3 py-5 sm:px-6 sm:py-8"
+      class="kr-scroll kr-container max-w-3xl space-y-5 px-3 py-5 sm:px-6 sm:py-8"
     >
       <nav class="flex items-center justify-between gap-3">
         <NuxtLink to="/play/aquarium" class="btn btn-ghost btn-sm rounded-xl">

--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -1,7 +1,7 @@
 <template>
   <main class="kr-surface bg-base-200/40">
     <div
-      class="kr-scroll mx-auto max-w-7xl space-y-5 px-3 py-5 sm:px-6 sm:py-8"
+      class="kr-scroll kr-container max-w-7xl space-y-5 px-3 py-5 sm:px-6 sm:py-8"
     >
       <nav class="flex flex-wrap items-center justify-between gap-3">
         <NuxtLink to="/play/challenges" class="btn btn-ghost btn-sm rounded-xl">

--- a/pages/play/challenges/leaderboard.vue
+++ b/pages/play/challenges/leaderboard.vue
@@ -1,7 +1,7 @@
 <template>
   <main class="kr-surface bg-base-200/40">
     <div
-      class="kr-scroll mx-auto max-w-7xl space-y-5 px-3 py-5 sm:px-6 sm:py-8"
+      class="kr-scroll kr-container max-w-7xl space-y-5 px-3 py-5 sm:px-6 sm:py-8"
     >
       <nav class="flex flex-wrap items-center justify-between gap-3">
         <NuxtLink to="/play/challenges" class="btn btn-ghost btn-sm rounded-xl">

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="kr-surface">
-    <div class="kr-scroll mx-auto max-w-7xl space-y-4 p-3 sm:p-4">
+    <div class="kr-scroll kr-container max-w-7xl space-y-4 p-3 sm:p-4">
       <MandarinBanner
         :tiles="bannerTiles"
         :card-count="cards.length"

--- a/pages/play/video-generator.vue
+++ b/pages/play/video-generator.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="kr-surface">
-    <div class="kr-scroll mx-auto max-w-7xl space-y-6 p-6">
+    <div class="kr-scroll kr-container max-w-7xl space-y-6 p-6">
       <header class="space-y-1">
         <p class="text-sm opacity-70">
           Animate a still into a short clip. Presets choose sensible studio

--- a/pages/users/[id].vue
+++ b/pages/users/[id].vue
@@ -1,7 +1,7 @@
 <!-- /pages/users/[id].vue -->
 <template>
   <section class="kr-surface">
-    <div class="kr-scroll mx-auto max-w-2xl p-4 sm:p-6">
+    <div class="kr-scroll kr-container max-w-2xl p-4 sm:p-6">
       <NuxtLink
         to="/plan/wonderlab"
         class="btn btn-ghost btn-sm mb-4 rounded-xl"


### PR DESCRIPTION
Bounded consistency slice of the recurring interface-vision/t-104 sweep.

## What
Composes `kr-container` onto the root `kr-scroll` wrapper of eight `play/`/`users` route pages, replacing the hand-rolled `mx-auto max-w-*` pair with `kr-container` (which is `mx-auto w-full max-w-6xl`), keeping each page's own `max-w-*` override. No geometry or behavior change.

This follows the exact `kr-scroll kr-container[-wide]` composition pattern already established in `pages/admin/{scene-animator,social-drafts,achievement-art,lora-triage}.vue` — this slice extends the same precedent to the `play`/`users` routes, found via a fresh repo-wide grep for `mx-auto`+`max-w-` root wrappers rather than trusting the previously-recorded candidate list (which had gone stale/exhausted for the narrower `mx-auto w-full max-w-*` pattern).

## Files
- `pages/play/aquarium/browse/[username]/[slug].vue`
- `pages/play/aquarium/browse/index.vue`
- `pages/play/aquarium/leaderboard/index.vue`
- `pages/play/challenges/[slug].vue`
- `pages/play/challenges/leaderboard.vue`
- `pages/play/mandarin.vue`
- `pages/play/video-generator.vue`
- `pages/users/[id].vue`

## Verification
- `eslint` on changed files: clean
- `prettier --check`: flagged pre-existing drift on `pages/play/mandarin.vue` and `pages/play/video-generator.vue`, confirmed via `git stash` to predate this change
- `vue-tsc --noEmit` (repo-wide): clean
- `npm run test:layout-contract`: holds, 0 new violations (207 baseline unchanged)

## Flags for Reviewer
None. Mechanical, low-risk, same pattern as prior `t-104` slices (30-33) and the pre-existing admin-page precedent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GMvTWa8dDadHzULm5RLs5v)_