### PR TITLE
storybook/t-010: close the Export menu on selection

### DIFF
--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -35,17 +35,23 @@
             <Icon name="kind-icon:copy" class="size-4" /> Duplicate
           </button>
 
-          <details class="dropdown dropdown-end">
-            <summary class="btn btn-ghost btn-sm rounded-xl border border-base-300">
+          <div class="dropdown dropdown-end">
+            <button
+              type="button"
+              tabindex="0"
+              class="btn btn-ghost btn-sm rounded-xl border border-base-300"
+              aria-haspopup="menu"
+            >
               <Icon name="kind-icon:download" class="size-4" /> Export
-            </summary>
+            </button>
             <ul
+              tabindex="0"
               class="menu dropdown-content z-20 mt-2 w-44 kr-panel-flat p-2 shadow-xl"
             >
-              <li><button type="button" @click="downloadStory(undefined, 'markdown')">Markdown</button></li>
-              <li><button type="button" @click="downloadStory(undefined, 'json')">JSON</button></li>
+              <li><button type="button" @click="downloadStory(undefined, 'markdown'); closeExportMenu()">Markdown</button></li>
+              <li><button type="button" @click="downloadStory(undefined, 'json'); closeExportMenu()">JSON</button></li>
             </ul>
-          </details>
+          </div>
 
           <button
             v-if="!restartArmed"
@@ -274,6 +280,21 @@ function downloadStory(
 ): void {
   const payload = storyStore.buildExport(sessionId, format)
   if (payload) triggerDownload(payload)
+}
+
+// The Export menu used to be a native <details>/<summary> dropdown, the only
+// one in the codebase built that way -- every sibling dropdown (channel-select
+// .vue, tab-select.vue, watchlist-browse.vue) is the focus-based
+// `.dropdown`/`.dropdown-content` pair instead, which channel-select.vue
+// explicitly closes on selection via its own closeDropdown() (blurring
+// document.activeElement). <details> has no such behavior: clicking an item
+// inside it does not close the menu, so after switching to the same
+// focus-based pattern here, closing on click still needs to be wired up by
+// hand -- this mirrors that one closeDropdown() helper.
+function closeExportMenu(): void {
+  if (typeof document === 'undefined') return
+  const element = document.activeElement as HTMLElement | null
+  element?.blur()
 }
 
 function startNewStory(): void {


### PR DESCRIPTION
## Summary
Conductor `storybook/t-010` (recurring polish task, cycle 41) — kaizen from cycle 40 flagged `storybook-library-page.vue` for a full top-to-bottom read; this is what it turned up.

## What was wrong
`storybook-library-page.vue`'s Export menu was built as a native `<details>`/`<summary>` dropdown — the only one in the codebase. Every sibling dropdown (`channel-select.vue`, `tab-select.vue`, `watchlist-browse.vue`) uses the focus-based `.dropdown`/`.dropdown-content` pair instead, and `channel-select.vue` explicitly closes on selection via its own `closeDropdown()` (blurring `document.activeElement`). `<details>` has no such behavior — clicking "Markdown" or "JSON" left the menu open afterward, unlike every other dropdown in the app.

## Fix
Converted the Export menu to the standard `div.dropdown` + `button[tabindex=0]` + `ul.dropdown-content[tabindex=0]` pattern (matching `tab-select.vue`'s trigger button styling), and added a `closeExportMenu()` helper mirroring `channel-select.vue`'s `closeDropdown()`, called from both export buttons. Template/script only — `components/pages/storybook-library-page.vue`, no data/store behavior change.

## Verification
- `eslint` on the changed file: clean
- `prettier --check`: flags pre-existing drift on this file, confirmed via `git stash` to predate this change, left alone
- `npm run test` (`vue-tsc --noEmit`, repo-wide): clean
- `npm run test:layout-contract`: holds, 0 new violations (207 baseline unchanged)

Honest limit on visual verification: this sandbox has no reachable database and no PR-preview infrastructure (see conductor AGENTS.md's "Visually verifying a front-end change" section), so only static/structural verification was possible — the same header/button/blur pattern already works correctly in production on `channel-select.vue`/`tab-select.vue`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBhTwQgDYVdZ3kaBhnPzex)_