### PR TITLE
interface-vision/t-104: use kr-container for Music Mentor page root

### DIFF
--- a/pages/music-mentor.vue
+++ b/pages/music-mentor.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="kr-surface">
-    <div class="kr-scroll p-6 space-y-6 max-w-3xl mx-auto">
+    <div class="kr-scroll kr-container max-w-3xl p-6 space-y-6">
       <header class="flex items-start gap-3">
         <div
           class="flex size-12 shrink-0 items-center justify-center rounded-2xl bg-primary/15 text-primary"


### PR DESCRIPTION
Slice of the recurring `kr-container` consistency sweep (conductor `interface-vision/t-104`).

`pages/music-mentor.vue`'s root scroll wrapper used hand-rolled `max-w-3xl mx-auto` alongside `kr-scroll`, the same shape as the 8 files converted in slice 34 (`kr-scroll mx-auto max-w-N ...` → `kr-scroll kr-container max-w-N ...`). Converted to `kr-scroll kr-container max-w-3xl ...`.

`kr-container` is `mx-auto w-full max-w-6xl`, overridden here to `max-w-3xl` exactly as before — no geometry or behavior change.

Verified locally:
- `eslint pages/music-mentor.vue` — clean
- `prettier --check pages/music-mentor.vue` — clean
- `npm run test` (vue-tsc --noEmit, repo-wide) — clean
- `npm run test:layout-contract` — holds, 0 new violations (207 baseline unchanged)

---
_Generated by [Claude Code](https://claude.ai/code/session_0144shLALT3jCC99tDp9hDSy)_