### PR TITLE
interface-vision/t-104: reuse flat panel surface on public profiles

### DIFF
--- a/pages/users/[id].vue
+++ b/pages/users/[id].vue
@@ -12,7 +12,7 @@
 
       <article
         v-if="user"
-        class="overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-lg"
+        class="overflow-hidden rounded-3xl kr-panel-flat shadow-lg"
       >
         <div
           class="h-28 bg-linear-to-br from-primary/25 via-secondary/15 to-accent/20"
@@ -66,7 +66,7 @@
 
       <div
         v-else-if="status === 'pending'"
-        class="flex min-h-64 items-center justify-center rounded-3xl border border-base-300 bg-base-100"
+        class="flex min-h-64 items-center justify-center rounded-3xl kr-panel-flat"
       >
         <span class="loading loading-spinner loading-lg text-primary" />
       </div>


### PR DESCRIPTION
## Summary
- replace two hand-rolled `border-base-300 bg-base-100` public-profile surfaces with the shared `kr-panel-flat` primitive
- preserve the existing intentional `rounded-3xl`, overflow, shadow, and loading layout overrides
- template/classes only; no data, routing, API, or behavior changes

## Conductor
- project/task: `interface-vision/t-104`
- session: `openai-scheduled-20260830T011501Z-t104-v7k2`

## Verification
- branch diff is one file, 2 additions / 2 deletions
- `kr-panel-flat` is exactly `rounded-2xl border border-base-300 bg-base-100`; the existing `rounded-3xl` utility remains on both surfaces and overrides the primitive's radius in the utilities layer, so rendered geometry is unchanged
- rely on repository PR CI for TypeScript/layout/contracts before merge

No production data or deployment actions are involved.