### PR TITLE
interface-vision/t-104: use kr-surface for User Manager root

### DIFF
--- a/components/user/user-manager.vue
+++ b/components/user/user-manager.vue
@@ -1,6 +1,6 @@
 <!-- /components/content/user/user-manager.vue -->
 <template>
-  <section class="flex h-full min-h-0 w-full flex-col gap-4 overflow-hidden">
+  <section class="kr-surface gap-4">
     <!--
       NO ACCOUNT ROW HERE, and none teleported elsewhere either.
 


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring bounded slice)

### What changed / what I produced
- `components/user/user-manager.vue`'s root `<section>` used hand-rolled `flex h-full min-h-0 w-full flex-col gap-4 overflow-hidden` — byte-identical to `kr-surface`'s own contract (`flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden`, `assets/css/tailwind.css`) apart from `gap-4` vs `gap-3`. Converted to `kr-surface gap-4`, the same base-class-plus-override shape the established `mx-auto`/`max-w-*` → `kr-container max-w-N` sweep already uses (Tailwind's `@layer components` class loses to a plain `@layer utilities` class of equal selector weight, so `gap-4` correctly overrides `kr-surface`'s baked-in `gap-3` the same way `max-w-3xl` already overrides `kr-container`'s `max-w-6xl` elsewhere in this sweep).

### How I verified
- Re-derived the `mx-auto`/`max-w-*` root-wrapper pool fresh against current `main` (18 hits, all already handled or correctly out of scope per the task's own history) — confirmed that pool is exhausted again.
- Broadened to the `kr-surface` root-wrapper pool (hand-rolled `flex h-full min-h-0 ... overflow-hidden`): most `*-manager.vue` hits were false positives (root is `<kr-manager>`, match was nested), several others (`giftshop-manager.vue`, `art-manager.vue`) are missing `gap-3` entirely — converting those would add spacing that isn't there today, not a byte-exact substitution, so left alone. `user-manager.vue` was the one genuine byte-exact-apart-from-override match.
- `npx eslint components/user/user-manager.vue` — clean.
- `npx prettier --check components/user/user-manager.vue` — clean.
- `npm run test` (`vue-tsc --noEmit`, repo-wide) — clean.
- `npm run test:layout-contract` — holds: 0 root-surface violations (unchanged), 207 viewport-grid baseline (unchanged), no new violations.

### Stakes
reversible

### Flags for Reviewer
None outstanding. The broader `kr-surface` pool has a couple of near-misses (`giftshop-manager.vue`, `art-manager.vue` missing `gap-*` entirely) that are NOT byte-exact and were correctly left alone this slice — flagging for a future slice's awareness rather than reopening them here.

### Kaizen suggestion
The `kr-surface` root-wrapper pool (parallel to the `kr-container` `mx-auto`/`max-w-*` pool) hasn't been systematically swept yet — worth a dedicated future slice once this one's mechanical shape is confirmed safe in production.

### Notes for reviewer
Recurring sweep task — roadmap `status: review`, will return to `ready` after this merges per the established t-104 convention. Self-merging in this session per AGENTS.md's standing merge-when-green authorization.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Kp9kWnqPWaRJcqzZyaBoC)_