### PR TITLE
interface-vision/t-104: adopt kr-surface for the shared manager shell and 6 standalone managers

### DIFF
--- a/components/animation/animation-manager.vue
+++ b/components/animation/animation-manager.vue
@@ -1,6 +1,6 @@
 <!-- /components/animation/animation-manager.vue -->
 <template>
-  <section class="flex h-full min-h-0 w-full flex-col overflow-hidden">
+  <section class="kr-surface gap-0">
     <div
       v-if="showHeader"
       class="flex flex-wrap items-center justify-between gap-3 border-b border-base-300 px-4 py-3"

--- a/components/art/art-manager.vue
+++ b/components/art/art-manager.vue
@@ -1,6 +1,6 @@
 <!-- /components/art/art-manager.vue -->
 <template>
-  <section class="flex h-full min-h-0 w-full flex-col overflow-hidden">
+  <section class="kr-surface gap-0">
     <div
       v-if="isLoadingManager"
       class="flex h-full min-h-0 flex-1 items-center justify-center kr-panel"

--- a/components/art/art-studio.vue
+++ b/components/art/art-studio.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="flex h-full min-h-0 w-full flex-col overflow-hidden">
+  <section class="kr-surface gap-0">
     <nav
       class="mb-2 flex shrink-0 items-center gap-2 kr-panel-flat p-2"
       aria-label="Art studio views"

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -1,6 +1,6 @@
 <!-- /components/art/artjob-queue-browser.vue -->
 <template>
-  <section class="flex h-full min-h-0 w-full flex-col overflow-hidden">
+  <section class="kr-surface gap-0">
     <div
       v-if="!userStore.isAdmin"
       class="flex h-full min-h-0 flex-1 items-center justify-center rounded-2xl border border-warning/40 bg-warning/10 p-6 text-center text-warning"

--- a/components/art/stylist-relay-status.vue
+++ b/components/art/stylist-relay-status.vue
@@ -12,7 +12,7 @@
   capabilities, and agent version.
 -->
 <template>
-  <section class="flex h-full min-h-0 w-full flex-col overflow-hidden">
+  <section class="kr-surface gap-0">
     <div
       v-if="!userStore.isAdmin"
       class="flex h-full min-h-0 flex-1 items-center justify-center rounded-2xl border border-warning/40 bg-warning/10 p-6 text-center text-warning"

--- a/components/giftshop/giftshop-manager.vue
+++ b/components/giftshop/giftshop-manager.vue
@@ -1,6 +1,6 @@
 <!-- /components/content/giftshop/giftshop-manager.vue -->
 <template>
-  <section class="flex h-full min-h-0 w-full flex-col overflow-hidden">
+  <section class="kr-surface gap-0">
     <div
       v-if="isLoadingManager || managerError"
       class="mb-3 flex shrink-0 flex-wrap items-center justify-between gap-2 kr-panel-flat p-3 text-sm shadow"

--- a/components/manager/kr-manager.vue
+++ b/components/manager/kr-manager.vue
@@ -55,7 +55,7 @@
           verifyGalleryAdoption.ts.
 -->
 <template>
-  <section class="flex h-full min-h-0 w-full flex-col overflow-hidden">
+  <section class="kr-surface gap-0">
     <!--
       ONE status banner. It appears only while loading or after a failure, so
       the common case costs no vertical space — that was true of every variant


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 56: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring)

### What changed
The `kr-surface` pool (`.kr-surface = flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden`) was a parallel-but-unswept sibling of the `kr-container` `mx-auto`/`max-w-*` pool this task has been sweeping — flagged as a kaizen suggestion from the rainbow-butterflies/t-015 credentials PR (kind_robots#2211).

Converted 7 root elements that hand-rolled the identical class set minus gap (`flex h-full min-h-0 w-full flex-col overflow-hidden`) to `kr-surface gap-0`, preserving the existing zero-gap layout exactly — the utilities layer's `gap-0` wins over the components layer's `kr-surface` `gap-3`, the same override convention already used by `user-manager.vue` (`kr-surface gap-4`) and `user-dashboard.vue`:

- `components/manager/kr-manager.vue` — the shared manager shell every primary-model dashboard wears (bot, character, reward, facet, scenario managers, etc. all render through `<kr-manager>`). The single highest-leverage conversion in the pool: one file change reaches every manager that delegates its root to it.
- `components/art/art-manager.vue`
- `components/art/artjob-queue-browser.vue`
- `components/art/art-studio.vue`
- `components/art/stylist-relay-status.vue`
- `components/animation/animation-manager.vue`
- `components/giftshop/giftshop-manager.vue`

No geometry or behavior change — byte-exact substitution apart from the gap override, same standard this task's prior 55 slices have held.

**Skipped as out of scope this slice:**
- `server-manager.vue` (root omits `w-full`, not an exact match)
- `bot-manager.vue`/`character-manager.vue`/`reward-manager.vue`/`facet-manager.vue`/`scenario-manager.vue` (root is already `<kr-manager>`, so they inherit this slice's fix transitively rather than needing their own edit)
- `model-builder-manager.vue` (root also carries `rounded-2xl border bg-base-200`, a different shape, not a clean substitution)

### How I verified
- `npx eslint` on all 7 changed files — clean (`giftshop-manager.vue`'s one pre-existing unused-var error reproduces identically on `main`, unrelated to this change).
- `npx prettier --check` on all 7 — clean (`animation-manager.vue`'s one pre-existing formatting warning reproduces identically on `main`, on untouched lines).
- `npm run test` (`vue-tsc --noEmit`, repo-wide) — clean.
- `npm run test:layout-contract` — holds, 0 new violations (207 baseline unchanged).

### Stakes
reversible — pure class-name substitution on 7 root elements, no geometry or behavior change.

### Kaizen suggestion
The `kr-surface` pool now has one clean sweep pass; a follow-up slice could look at whether `server-manager.vue`'s missing `w-full` is itself a bug worth a separate, deliberate fix (not a mechanical substitution).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMZ4jxmJ6jF8WXkyzvMpoA)_