### PR TITLE
refactor(ui): reuse shared panel surface for aquarium empty states

### DIFF
--- a/pages/play/aquarium/browse/index.vue
+++ b/pages/play/aquarium/browse/index.vue
@@ -57,7 +57,7 @@
 
       <div
         v-else-if="!tanks.length"
-        class="rounded-3xl border border-dashed border-base-300 bg-base-100 px-6 py-16 text-center"
+        class="kr-panel-flat border-dashed rounded-3xl px-6 py-16 text-center"
       >
         <Icon name="kind-icon:fish" class="mx-auto size-12 text-primary/40" />
         <h2 class="mt-4 text-2xl font-black uppercase">Nothing public yet</h2>

--- a/pages/play/aquarium/leaderboard/index.vue
+++ b/pages/play/aquarium/leaderboard/index.vue
@@ -57,7 +57,7 @@
 
       <div
         v-else-if="!entries.length"
-        class="rounded-3xl border border-dashed border-base-300 bg-base-100 px-6 py-16 text-center"
+        class="kr-panel-flat border-dashed rounded-3xl px-6 py-16 text-center"
       >
         <Icon name="kind-icon:fish" class="mx-auto size-12 text-primary/40" />
         <h2 class="mt-4 text-2xl font-black uppercase">No ranks yet</h2>


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Replaced the duplicated `rounded-3xl border border-dashed border-base-300 bg-base-100` surface on the public aquarium browse empty state with `kr-panel-flat border-dashed rounded-3xl`.
- Applied the same exact composition to the aquarium leaderboard empty state.
- Preserved the dashed empty-state signal, rounded-3xl geometry, padding, text alignment, behavior, and all data/API code.

### How I verified
- Compared the branch against current `main`: exactly two files changed, one class substitution in each; branch is 2 commits ahead and 0 behind.
- Verified `kr-panel-flat` owns `rounded-2xl border border-base-300 bg-base-100`; Tailwind utility-layer `border-dashed` and `rounded-3xl` preserve the two deliberate visual overrides.
- CI is the authoritative executable verification for this connector-only run; merge will wait for exact-head checks to complete successfully.

### Stakes
reversible

### Flags for Reviewer
- No PR preview exists for Kind Robots after the self-hosted migration, so this is intentionally a geometry-equivalent shared-primitive refactor rather than an aesthetic redesign.

### Kaizen suggestion
Add a small contract/codemod check for raw `border border-dashed border-base-300 bg-base-100` empty-state surfaces that can safely compose `kr-panel-flat border-dashed`, so this remaining family converges without losing the dashed semantic.

### Notes for reviewer
Session: `openai-scheduled-20260830T041121Z-iv-t104-k9p3`