### PR TITLE
interface-vision/t-104: adopt kr-panel-flat for dashed empty-state panels

### DIFF
--- a/components/art/art-test.vue
+++ b/components/art/art-test.vue
@@ -1305,7 +1305,7 @@ onMounted(async () => {
           </div>
 
           <div
-            class="flex min-h-105 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-100 p-4"
+            class="flex min-h-105 items-center justify-center kr-panel-flat border-dashed p-4"
           >
             <div
               v-if="isGenerating"

--- a/components/art/artjob-feedback-manager.vue
+++ b/components/art/artjob-feedback-manager.vue
@@ -83,7 +83,7 @@
             <div
               v-else
               :title="jobImageDiag(job)"
-              class="flex h-28 w-24 shrink-0 flex-col items-center justify-center gap-0.5 rounded-2xl border border-dashed border-base-300 bg-base-100 p-2 text-center text-[10px] uppercase tracking-wide text-base-content/40"
+              class="flex h-28 w-24 shrink-0 flex-col items-center justify-center gap-0.5 kr-panel-flat border-dashed p-2 text-center text-[10px] uppercase tracking-wide text-base-content/40"
             >
               <span>{{ jobImageReason(job) || 'Loading art' }}</span>
             </div>

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -340,7 +340,7 @@
 
             <div
               v-else
-              class="flex min-h-64 flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-base-300 bg-base-100 p-6 text-center text-base-content/50"
+              class="flex min-h-64 flex-col items-center justify-center gap-3 kr-panel-flat border-dashed p-6 text-center text-base-content/50"
             >
               <Icon
                 name="kind-icon:sparkles"

--- a/components/giftshop/shopping-cart.vue
+++ b/components/giftshop/shopping-cart.vue
@@ -34,7 +34,7 @@
 
     <div
       v-else-if="!cartStore.hasItems"
-      class="rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center"
+      class="kr-panel-flat border-dashed p-8 text-center"
     >
       <Icon name="kind-icon:cart" class="mx-auto h-10 w-10 text-base-content/35" />
       <p class="mt-3 text-lg font-black text-base-content">Your cart is empty.</p>

--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -175,7 +175,7 @@
     />
     <div
       v-else
-      class="flex flex-1 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-100 p-6 text-center text-sm text-base-content/50"
+      class="flex flex-1 items-center justify-center kr-panel-flat border-dashed p-6 text-center text-sm text-base-content/50"
     >
       Select a row to work through its stages.
     </div>

--- a/components/model-builder/model-builder-run-history.vue
+++ b/components/model-builder/model-builder-run-history.vue
@@ -45,7 +45,7 @@
 
       <div
         v-else-if="!store.runs.length"
-        class="flex h-full min-h-32 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-base-300 bg-base-100 p-6 text-center text-sm text-base-content/50"
+        class="flex h-full min-h-32 flex-col items-center justify-center gap-2 kr-panel-flat border-dashed p-6 text-center text-sm text-base-content/50"
       >
         <Icon
           name="kind-icon:blueprint"

--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -63,7 +63,7 @@
     <div class="min-h-0 flex-1 overflow-y-auto">
       <div
         v-if="!store.sourceType"
-        class="flex h-full min-h-32 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-100 p-6 text-center text-sm text-base-content/50"
+        class="flex h-full min-h-32 items-center justify-center kr-panel-flat border-dashed p-6 text-center text-sm text-base-content/50"
       >
         Select a source type above to load records.
       </div>

--- a/components/newsfeed/newsfeed-feed.vue
+++ b/components/newsfeed/newsfeed-feed.vue
@@ -149,7 +149,7 @@
 
       <div
         v-else-if="!visibleItems.length"
-        class="rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center"
+        class="kr-panel-flat border-dashed p-8 text-center"
       >
         <Icon
           name="kind-icon:news"

--- a/components/pages/creator-earnings-page.vue
+++ b/components/pages/creator-earnings-page.vue
@@ -111,7 +111,7 @@
 
         <section
           v-if="isEmpty"
-          class="flex min-h-48 flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-base-300 bg-base-100 p-6 text-center"
+          class="flex min-h-48 flex-col items-center justify-center gap-3 kr-panel-flat border-dashed p-6 text-center"
         >
           <Icon name="kind-icon:coin" class="h-10 w-10 text-base-content/30" />
           <p class="text-base font-bold text-base-content">

--- a/components/pages/mission-accrual-page.vue
+++ b/components/pages/mission-accrual-page.vue
@@ -193,7 +193,7 @@
 
         <section
           v-if="!data.remittances.length"
-          class="flex min-h-32 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-base-300 bg-base-100 p-6 text-center"
+          class="flex min-h-32 flex-col items-center justify-center gap-2 kr-panel-flat border-dashed p-6 text-center"
         >
           <p class="text-sm text-base-content/55">No remittances logged yet.</p>
         </section>

--- a/components/ruler-hooked/ruler-hooked-fishopedia.vue
+++ b/components/ruler-hooked/ruler-hooked-fishopedia.vue
@@ -1,5 +1,5 @@
 <template>
-  <details class="fishopedia-shell collapse collapse-arrow rounded-2xl border border-base-300 bg-base-100">
+  <details class="fishopedia-shell collapse collapse-arrow kr-panel-flat">
     <summary class="collapse-title flex items-center justify-between gap-3 pr-12 font-bold">
       <span>📖 Fishopedia</span>
       <span class="badge badge-outline">{{ discoveredCount }}/{{ roster.length }} discovered</span>

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -50,7 +50,7 @@
       <div class="flex flex-col gap-4 pr-1">
         <div
           v-if="isGuest"
-          class="flex min-h-64 flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-base-300 bg-base-100 p-6 text-center"
+          class="flex min-h-64 flex-col items-center justify-center gap-3 kr-panel-flat border-dashed p-6 text-center"
         >
           <span
             class="flex h-14 w-14 items-center justify-center rounded-2xl bg-base-200 text-base-content/40"

--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -36,10 +36,7 @@
 -->
 <template>
   <section class="flex flex-col gap-4">
-    <div
-      v-if="!isAdmin"
-      class="rounded-2xl border border-dashed border-base-300 bg-base-100 p-6 text-center"
-    >
+    <div v-if="!isAdmin" class="kr-panel-flat border-dashed p-6 text-center">
       <Icon name="kind-icon:lock" class="mx-auto size-8 text-base-content/30" />
       <p class="mt-2 text-sm font-semibold text-base-content/60">
         This is a private personal log. Sign in as an admin to browse it.
@@ -462,7 +459,7 @@
 
         <div
           v-else-if="!entries.length"
-          class="rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center"
+          class="kr-panel-flat border-dashed p-8 text-center"
         >
           <Icon
             name="kind-icon:movie"


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring)

### What changed / what I produced
- 13 hand-rolled `rounded-2xl border border-dashed border-base-300 bg-base-100` empty-state/placeholder panels (plus one non-dashed `rounded-2xl border border-base-300 bg-base-100` on `ruler-hooked-fishopedia.vue`) now compose the shared `kr-panel-flat` surface primitive (`rounded-2xl border border-base-300 bg-base-100`) plus `border-dashed` where the dashed signal was present.
- No geometry or behavior change — `border-dashed` only overrides border-style and is independent of the width/color utilities `kr-panel-flat` supplies.
- Files touched: `model-builder-run-history.vue`, `model-builder-source-picker.vue`, `model-builder-progress-matrix.vue`, `user-dashboard.vue`, `newsfeed-feed.vue`, `dream-brainstorm.vue`, `watchlist-browse.vue` (2 occurrences), `shopping-cart.vue`, `artjob-feedback-manager.vue`, `art-test.vue`, `mission-accrual-page.vue`, `creator-earnings-page.vue`, `ruler-hooked-fishopedia.vue`.
- One incidental prettier fix (`watchlist-browse.vue`) where the shortened class string now fits on one line — that file was prettier-clean at baseline, so this keeps it that way.

### How I verified
- `eslint` on all changed files: 0 new issues (one pre-existing `no-dynamic-delete` error in `shopping-cart.vue` reproduces identically on `main`, confirmed via `git stash`, unrelated to this change).
- `prettier --check` on all changed files: 8 files report pre-existing formatting drift, confirmed identical on `main` before this change; none of that drift was introduced here. `watchlist-browse.vue` (the only file prettier-clean at baseline) stays clean.
- `vue-tsc --noEmit` (via `npm run test`, repo-wide): clean, exit 0.
- `npm run test:layout-contract`: holds — 207-item baseline unchanged, 0 new violations.

### Stakes
reversible

### Flags for Reviewer
- Deliberately excluded near-matches using `bg-base-100/50`, `/60`, `/70` (translucent backgrounds — not byte-exact vs `kr-panel-flat`'s opaque background) and button elements (`chat-gallery.vue`, `project-front-page.vue`) that incidentally share the same substring but aren't panel surfaces.
- The `mx-auto`/`max-w-` (`kr-container`) and `flex h-full min-h-0 w-full flex-col overflow-hidden` (`kr-surface`) pools were reported close to exhausted by the last two slices; this slice opens a third mechanical pool (`kr-panel-flat` dashed empty-states) that had not been swept before.

### Kaizen suggestion
The excluded `bg-base-100/50`/`/60`/`/70` translucent-background empty-state panels (`cthulhuquarium-curation.vue`, `coloring-book-curation.vue`, `conductor-page.vue`, `storybook-library-page.vue`, `scene-animator.vue` x2, `narrative-ingredient-picker.vue`, `narrative-ingredient-multi-picker.vue`) form their own consistent pool — worth a follow-up slice once someone confirms whether the opacity is a deliberate distinct pattern or drift, since `kr-panel-flat` has no translucent variant today.

### Notes for reviewer
Mechanical, single-pattern substitution across 13 files; verified pre-existing lint/format issues do not block this diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_018JHDSDZaX52k5U2U28wGDy)_