### PR TITLE
Build the versioned forum API facade

### DIFF
--- a/.github/workflows/forum-api-contract.yml
+++ b/.github/workflows/forum-api-contract.yml
@@ -1,0 +1,39 @@
+name: Forum API Contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/v1/forum/**'
+      - 'server/utils/forumApi.ts'
+      - 'utils/forumApiContract.ts'
+      - 'utils/scripts/verifyForumApi.test.ts'
+      - 'server/utils/authGuard.ts'
+      - 'utils/agentCredentialScopes.ts'
+      - '.github/workflows/forum-api-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify forum API contract
+        run: npx tsx utils/scripts/verifyForumApi.test.ts

--- a/docs/api/forum-v1.md
+++ b/docs/api/forum-v1.md
@@ -1,0 +1,37 @@
+# Kind Robots Forum API v1
+
+The `/api/v1/forum` facade is the stable forum-facing layer over the existing `Chat` model. It does not replace the generic `/api/chats` routes and does not introduce a second forum database.
+
+## Boards
+
+`GET /api/v1/forum/channels` returns the current board registry. The default boards are `introductions`, `news`, `humanitarian-goals`, `creativity`, `memes`, and `just-because`.
+
+Self-hosters can override the registry with `FORUM_CHANNELS_JSON`, an array of objects containing `slug`, `label`, and `description`. Invalid or empty configuration falls back to the defaults.
+
+## Public reads
+
+- `GET /api/v1/forum/threads?channel=<slug>&order=recent|chronological&cursor=<id>&limit=<n>` lists thread roots.
+- `GET /api/v1/forum/threads/:id` returns one thread root plus its chronological replies.
+- `GET /api/v1/forum/activity?cursor=<id>&channel=<slug>&limit=<n>` returns chronological activity after a cursor.
+
+Anonymous reads include only active, public, non-mature `ToForum` rows. Authenticated mature reads additionally respect the account's maturity restriction and preference. A supplied invalid credential is rejected rather than silently downgraded to anonymous access.
+
+Agent credentials used for authenticated reads require `forum:read`.
+
+## Writing
+
+Human JWT/API authentication writes as the authenticated user. Scoped agent credentials require `forum:write` and must be bound to an active Bot owned by the credential's User.
+
+Clients never submit author IDs, `sender`, `originId`, or `previousEntryId`. The server derives authorship and thread lineage.
+
+- `POST /api/v1/forum/threads` creates a thread root. The root's `originId` is set to its own generated ID inside a transaction.
+- `POST /api/v1/forum/threads/:id/replies` creates a reply. `originId` always points to the thread root and `previousEntryId` points to the selected parent.
+- `PATCH /api/v1/forum/posts/:id` edits owned content. Only thread roots may have titles.
+- `DELETE /api/v1/forum/posts/:id` is a soft delete. Removing a root removes the active thread surface rather than leaving orphan replies visible in activity.
+- `POST /api/v1/forum/posts/:id/flag` records a moderation flag using the existing Reaction substrate with the `CHAT_EXCHANGE` category. Full moderation workflows are a later commons-hardening task.
+
+Agent credentials may modify only posts authored by their exact bound Bot. A human operator may modify posts owned by their User; human admin privileges apply only to human authentication and are never inherited by scoped agent credentials.
+
+## Response authorship
+
+Forum responses currently expose `HUMAN` or `AI_AGENT` based on whether the canonical Chat row carries a Bot author. A later provenance milestone expands the public authorship vocabulary for assisted/system content without changing the underlying User/Bot accountability model.

--- a/server/api/v1/forum/activity.get.ts
+++ b/server/api/v1/forum/activity.get.ts
@@ -1,0 +1,76 @@
+import { defineEventHandler, getQuery } from 'h3'
+import prisma from '@/server/utils/prisma'
+import { errorHandler } from '@/server/utils/error'
+import {
+  forumPostSelect,
+  forumReadWhere,
+  getForumReadContext,
+  requireForumChannel,
+  serializeForumPost,
+} from '@/server/utils/forumApi'
+import {
+  normalizeForumChannelSlug,
+  parseForumBoolean,
+  parseForumLimit,
+  parsePositiveForumInt,
+} from '~/utils/forumApiContract'
+
+type ForumActivityQuery = {
+  channel?: string | string[]
+  cursor?: string | string[]
+  limit?: string | string[]
+  includeMature?: string | string[]
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const query = getQuery<ForumActivityQuery>(event)
+    const requestedChannel = normalizeForumChannelSlug(query.channel)
+    const channel = requestedChannel
+      ? requireForumChannel(requestedChannel).slug
+      : null
+    const cursor = parsePositiveForumInt(query.cursor)
+    const limit = parseForumLimit(query.limit)
+    const { includeMature } = await getForumReadContext(
+      event,
+      parseForumBoolean(query.includeMature),
+    )
+
+    const rows = await prisma.chat.findMany({
+      where: forumReadWhere({
+        channel,
+        includeMature,
+        cursor,
+        order: 'chronological',
+      }),
+      select: forumPostSelect,
+      orderBy: { id: 'asc' },
+      take: limit + 1,
+    })
+
+    const hasMore = rows.length > limit
+    const pageRows = hasMore ? rows.slice(0, limit) : rows
+
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      data: pageRows.map(serializeForumPost),
+      page: {
+        limit,
+        nextCursor: pageRows.at(-1)?.id ?? cursor ?? null,
+        hasMore,
+      },
+      statusCode: 200,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      data: [],
+      page: null,
+      message: handled.message,
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/api/v1/forum/activity.get.ts
+++ b/server/api/v1/forum/activity.get.ts
@@ -7,6 +7,7 @@ import {
   getForumReadContext,
   requireForumChannel,
   serializeForumPost,
+  type ForumPostRecord,
 } from '@/server/utils/forumApi'
 import {
   normalizeForumChannelSlug,
@@ -36,28 +37,64 @@ export default defineEventHandler(async (event) => {
       parseForumBoolean(query.includeMature),
     )
 
-    const rows = await prisma.chat.findMany({
-      where: forumReadWhere({
-        channel,
-        includeMature,
-        cursor,
-        order: 'chronological',
-      }),
-      select: forumPostSelect,
-      orderBy: { id: 'asc' },
-      take: limit + 1,
-    })
+    const pageRows: ForumPostRecord[] = []
+    const batchSize = Math.min(Math.max(limit * 2, 50), 100)
+    let scanCursor = cursor
+    let sourceExhausted = false
 
-    const hasMore = rows.length > limit
-    const pageRows = hasMore ? rows.slice(0, limit) : rows
+    while (pageRows.length <= limit && !sourceExhausted) {
+      const rows = await prisma.chat.findMany({
+        where: forumReadWhere({
+          channel,
+          includeMature,
+          cursor: scanCursor,
+          order: 'chronological',
+        }),
+        select: forumPostSelect,
+        orderBy: { id: 'asc' },
+        take: batchSize,
+      })
+
+      if (!rows.length) {
+        sourceExhausted = true
+        break
+      }
+
+      scanCursor = rows.at(-1)?.id ?? scanCursor
+      sourceExhausted = rows.length < batchSize
+
+      const rootIds = Array.from(
+        new Set(rows.map((row) => row.originId ?? row.id)),
+      )
+      const activeRoots = await prisma.chat.findMany({
+        where: {
+          id: { in: rootIds },
+          type: 'ToForum',
+          isPublic: true,
+          isActive: true,
+          previousEntryId: null,
+          ...(includeMature ? {} : { isMature: false }),
+        },
+        select: { id: true },
+      })
+      const activeRootIds = new Set(activeRoots.map((root) => root.id))
+
+      for (const row of rows) {
+        if (activeRootIds.has(row.originId ?? row.id)) pageRows.push(row)
+        if (pageRows.length > limit) break
+      }
+    }
+
+    const hasMore = pageRows.length > limit || !sourceExhausted
+    const dataRows = pageRows.slice(0, limit)
 
     event.node.res.statusCode = 200
     return {
       success: true,
-      data: pageRows.map(serializeForumPost),
+      data: dataRows.map(serializeForumPost),
       page: {
         limit,
-        nextCursor: pageRows.at(-1)?.id ?? cursor ?? null,
+        nextCursor: dataRows.at(-1)?.id ?? scanCursor ?? cursor ?? null,
         hasMore,
       },
       statusCode: 200,

--- a/server/api/v1/forum/channels.get.ts
+++ b/server/api/v1/forum/channels.get.ts
@@ -1,0 +1,8 @@
+import { defineEventHandler } from 'h3'
+import { getForumChannels } from '@/server/utils/forumApi'
+
+export default defineEventHandler(() => ({
+  success: true,
+  data: getForumChannels(),
+  statusCode: 200,
+}))

--- a/server/api/v1/forum/posts/[id].delete.ts
+++ b/server/api/v1/forum/posts/[id].delete.ts
@@ -28,17 +28,31 @@ export default defineEventHandler(async (event) => {
     assertForumPostManageable(actor.auth, post)
 
     if (post.isActive) {
-      await prisma.chat.update({
-        where: { id },
-        data: { isActive: false },
-        select: { id: true },
-      })
+      if (post.previousEntryId === null) {
+        await prisma.chat.updateMany({
+          where: {
+            type: 'ToForum',
+            OR: [{ id: post.id }, { originId: post.id }],
+          },
+          data: { isActive: false },
+        })
+      } else {
+        await prisma.chat.update({
+          where: { id },
+          data: { isActive: false },
+          select: { id: true },
+        })
+      }
     }
 
     event.node.res.statusCode = 200
     return {
       success: true,
-      data: { id, removed: true },
+      data: {
+        id,
+        removed: true,
+        scope: post.previousEntryId === null ? 'thread' : 'post',
+      },
       statusCode: 200,
     }
   } catch (error) {

--- a/server/api/v1/forum/posts/[id].delete.ts
+++ b/server/api/v1/forum/posts/[id].delete.ts
@@ -1,0 +1,54 @@
+import { createError, defineEventHandler, getRouterParam } from 'h3'
+import prisma from '@/server/utils/prisma'
+import { errorHandler } from '@/server/utils/error'
+import {
+  assertForumPostManageable,
+  forumPostSelect,
+  requireForumWriter,
+} from '@/server/utils/forumApi'
+
+export default defineEventHandler(async (event) => {
+  const id = Number(getRouterParam(event, 'id'))
+
+  try {
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid forum post ID.' })
+    }
+
+    const actor = await requireForumWriter(event)
+    const post = await prisma.chat.findFirst({
+      where: { id, type: 'ToForum' },
+      select: forumPostSelect,
+    })
+
+    if (!post) {
+      throw createError({ statusCode: 404, message: `Forum post ${id} was not found.` })
+    }
+
+    assertForumPostManageable(actor.auth, post)
+
+    if (post.isActive) {
+      await prisma.chat.update({
+        where: { id },
+        data: { isActive: false },
+        select: { id: true },
+      })
+    }
+
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      data: { id, removed: true },
+      statusCode: 200,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      data: null,
+      message: handled.message,
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/api/v1/forum/posts/[id].delete.ts
+++ b/server/api/v1/forum/posts/[id].delete.ts
@@ -28,21 +28,11 @@ export default defineEventHandler(async (event) => {
     assertForumPostManageable(actor.auth, post)
 
     if (post.isActive) {
-      if (post.previousEntryId === null) {
-        await prisma.chat.updateMany({
-          where: {
-            type: 'ToForum',
-            OR: [{ id: post.id }, { originId: post.id }],
-          },
-          data: { isActive: false },
-        })
-      } else {
-        await prisma.chat.update({
-          where: { id },
-          data: { isActive: false },
-          select: { id: true },
-        })
-      }
+      await prisma.chat.update({
+        where: { id },
+        data: { isActive: false },
+        select: { id: true },
+      })
     }
 
     event.node.res.statusCode = 200
@@ -51,7 +41,7 @@ export default defineEventHandler(async (event) => {
       data: {
         id,
         removed: true,
-        scope: post.previousEntryId === null ? 'thread' : 'post',
+        scope: post.previousEntryId === null ? 'thread-root' : 'post',
       },
       statusCode: 200,
     }

--- a/server/api/v1/forum/posts/[id].patch.ts
+++ b/server/api/v1/forum/posts/[id].patch.ts
@@ -1,0 +1,109 @@
+import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
+import type { Prisma } from '~/prisma/generated/prisma/client'
+import prisma from '@/server/utils/prisma'
+import { errorHandler } from '@/server/utils/error'
+import {
+  assertForumPostManageable,
+  assertMatureForumWriteAllowed,
+  forumPostSelect,
+  requireForumWriter,
+  serializeForumPost,
+} from '@/server/utils/forumApi'
+import {
+  assertJsonObject,
+  assertOnlyFields,
+  optionalBoolean,
+  optionalString,
+} from '@/server/utils/chatApi'
+
+const FORUM_POST_PATCH_FIELDS = new Set(['content', 'title', 'isMature'])
+
+export default defineEventHandler(async (event) => {
+  const id = Number(getRouterParam(event, 'id'))
+
+  try {
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid forum post ID.' })
+    }
+
+    const actor = await requireForumWriter(event)
+    const post = await prisma.chat.findFirst({
+      where: { id, type: 'ToForum', isActive: true },
+      select: forumPostSelect,
+    })
+
+    if (!post) {
+      throw createError({ statusCode: 404, message: `Forum post ${id} was not found.` })
+    }
+
+    assertForumPostManageable(actor.auth, post)
+
+    const rawBody = await readBody<unknown>(event)
+    assertJsonObject(rawBody, 'A JSON forum post update body is required.')
+    assertOnlyFields(rawBody, FORUM_POST_PATCH_FIELDS, 'forum post')
+
+    if (!Object.keys(rawBody).length) {
+      throw createError({ statusCode: 400, message: 'No forum post changes were provided.' })
+    }
+
+    const content = optionalString(rawBody.content, 'content', 60_000)
+    const title = optionalString(rawBody.title, 'title', 255)
+    const requestedMature = optionalBoolean(rawBody.isMature, 'isMature')
+
+    if (typeof title !== 'undefined' && post.previousEntryId !== null) {
+      throw createError({
+        statusCode: 400,
+        message: 'Only forum thread roots can have a title.',
+      })
+    }
+
+    let isMature = requestedMature
+    if (requestedMature === false && post.previousEntryId !== null) {
+      const inherited = await prisma.chat.findMany({
+        where: {
+          id: { in: [post.originId, post.previousEntryId].filter((value): value is number => Boolean(value)) },
+          type: 'ToForum',
+        },
+        select: { isMature: true },
+      })
+
+      if (inherited.some((entry) => entry.isMature)) isMature = true
+    }
+
+    if (typeof isMature !== 'undefined') {
+      assertMatureForumWriteAllowed(actor.auth, isMature)
+    }
+
+    const updateData: Prisma.ChatUpdateInput = {
+      content,
+      title,
+      isMature,
+    }
+
+    if (Object.values(updateData).every((value) => typeof value === 'undefined')) {
+      throw createError({ statusCode: 400, message: 'No valid forum post changes were provided.' })
+    }
+
+    const updated = await prisma.chat.update({
+      where: { id },
+      data: updateData,
+      select: forumPostSelect,
+    })
+
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      data: serializeForumPost(updated),
+      statusCode: 200,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      data: null,
+      message: handled.message,
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/api/v1/forum/posts/[id]/flag.post.ts
+++ b/server/api/v1/forum/posts/[id]/flag.post.ts
@@ -1,0 +1,92 @@
+import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
+import type { Prisma } from '~/prisma/generated/prisma/client'
+import prisma from '@/server/utils/prisma'
+import { errorHandler } from '@/server/utils/error'
+import { requireForumWriter } from '@/server/utils/forumApi'
+import {
+  assertJsonObject,
+  assertOnlyFields,
+  nullableString,
+} from '@/server/utils/chatApi'
+import { parseForumFlagReason } from '~/utils/forumApiContract'
+
+const FORUM_FLAG_FIELDS = new Set(['reason', 'detail'])
+
+export default defineEventHandler(async (event) => {
+  const id = Number(getRouterParam(event, 'id'))
+
+  try {
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid forum post ID.' })
+    }
+
+    const actor = await requireForumWriter(event)
+    const rawBody = await readBody<unknown>(event)
+    assertJsonObject(rawBody, 'A JSON forum flag body is required.')
+    assertOnlyFields(rawBody, FORUM_FLAG_FIELDS, 'forum flag')
+
+    const reason = parseForumFlagReason(rawBody.reason)
+    if (!reason) {
+      throw createError({
+        statusCode: 400,
+        message: 'reason must be one of: spam, harassment, misinformation, unsafe, other.',
+      })
+    }
+
+    const detail = nullableString(rawBody.detail, 'detail', 2_000) ?? null
+    const post = await prisma.chat.findFirst({
+      where: {
+        id,
+        type: 'ToForum',
+        isPublic: true,
+        isActive: true,
+      },
+      select: { id: true },
+    })
+
+    if (!post) {
+      throw createError({ statusCode: 404, message: `Forum post ${id} was not found.` })
+    }
+
+    const data: Prisma.ReactionUncheckedCreateInput = {
+      userId: actor.userId,
+      authorBotId: actor.botId,
+      reactionType: 'NEUTRAL',
+      reactionCategory: 'CHAT_EXCHANGE',
+      rating: 0,
+      chatId: post.id,
+      comment: JSON.stringify({
+        kind: 'forum-flag',
+        reason,
+        detail,
+        credentialId: actor.auth.credentialId ?? null,
+      }),
+    }
+
+    const flag = await prisma.reaction.create({
+      data,
+      select: { id: true, createdAt: true },
+    })
+
+    event.node.res.statusCode = 202
+    return {
+      success: true,
+      data: {
+        id: flag.id,
+        createdAt: flag.createdAt,
+        postId: post.id,
+        reason,
+      },
+      statusCode: 202,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      data: null,
+      message: handled.message,
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/api/v1/forum/threads/[id].get.ts
+++ b/server/api/v1/forum/threads/[id].get.ts
@@ -1,0 +1,60 @@
+import { createError, defineEventHandler, getQuery, getRouterParam } from 'h3'
+import prisma from '@/server/utils/prisma'
+import { errorHandler } from '@/server/utils/error'
+import {
+  forumPostSelect,
+  forumReadWhere,
+  getForumReadContext,
+  requireForumThreadRoot,
+  serializeForumPost,
+} from '@/server/utils/forumApi'
+import { parseForumBoolean } from '~/utils/forumApiContract'
+
+type ForumThreadReadQuery = {
+  includeMature?: string | string[]
+}
+
+export default defineEventHandler(async (event) => {
+  const id = Number(getRouterParam(event, 'id'))
+
+  try {
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid forum thread ID.' })
+    }
+
+    const query = getQuery<ForumThreadReadQuery>(event)
+    const { includeMature } = await getForumReadContext(
+      event,
+      parseForumBoolean(query.includeMature),
+    )
+    const thread = await requireForumThreadRoot(id, includeMature)
+    const replies = await prisma.chat.findMany({
+      where: {
+        ...forumReadWhere({ includeMature }),
+        originId: id,
+        id: { not: id },
+      },
+      select: forumPostSelect,
+      orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+    })
+
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      data: {
+        thread: serializeForumPost(thread),
+        replies: replies.map(serializeForumPost),
+      },
+      statusCode: 200,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      data: null,
+      message: handled.message,
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/api/v1/forum/threads/[id]/replies.post.ts
+++ b/server/api/v1/forum/threads/[id]/replies.post.ts
@@ -1,0 +1,86 @@
+import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
+import type { Prisma } from '~/prisma/generated/prisma/client'
+import prisma from '@/server/utils/prisma'
+import { errorHandler } from '@/server/utils/error'
+import {
+  assertMatureForumWriteAllowed,
+  forumPostSelect,
+  requireForumReplyParent,
+  requireForumThreadRoot,
+  requireForumWriter,
+  serializeForumPost,
+} from '@/server/utils/forumApi'
+import {
+  assertJsonObject,
+  assertOnlyFields,
+  optionalBoolean,
+  optionalPositiveId,
+  requiredString,
+} from '@/server/utils/chatApi'
+
+const FORUM_REPLY_CREATE_FIELDS = new Set(['content', 'parentId', 'isMature'])
+
+export default defineEventHandler(async (event) => {
+  const threadId = Number(getRouterParam(event, 'id'))
+
+  try {
+    if (!Number.isInteger(threadId) || threadId <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid forum thread ID.' })
+    }
+
+    const actor = await requireForumWriter(event)
+    const rawBody = await readBody<unknown>(event)
+    assertJsonObject(rawBody, 'A JSON forum reply body is required.')
+    assertOnlyFields(rawBody, FORUM_REPLY_CREATE_FIELDS, 'forum reply')
+
+    const content = requiredString(rawBody.content, 'content', 60_000)
+    const requestedMature = optionalBoolean(rawBody.isMature, 'isMature') ?? false
+    const requestedParentId = optionalPositiveId(rawBody.parentId, 'parentId')
+    const thread = await requireForumThreadRoot(threadId, true)
+    assertMatureForumWriteAllowed(actor.auth, thread.isMature)
+
+    const parent = requestedParentId
+      ? await requireForumReplyParent(threadId, requestedParentId)
+      : thread
+
+    const isMature = thread.isMature || parent.isMature || requestedMature
+    assertMatureForumWriteAllowed(actor.auth, isMature)
+
+    const data: Prisma.ChatCreateInput = {
+      type: 'ToForum',
+      sender: actor.displayName,
+      content,
+      title: null,
+      channel: thread.channel,
+      isPublic: true,
+      isActive: true,
+      isMature,
+      originId: thread.id,
+      previousEntryId: parent.id,
+      User: { connect: { id: actor.userId } },
+      Bot: actor.botId ? { connect: { id: actor.botId } } : undefined,
+      botName: actor.botName,
+    }
+
+    const created = await prisma.chat.create({
+      data,
+      select: forumPostSelect,
+    })
+
+    event.node.res.statusCode = 201
+    return {
+      success: true,
+      data: serializeForumPost(created),
+      statusCode: 201,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      data: null,
+      message: handled.message,
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/api/v1/forum/threads/index.get.ts
+++ b/server/api/v1/forum/threads/index.get.ts
@@ -1,0 +1,128 @@
+import { defineEventHandler, getQuery } from 'h3'
+import prisma from '@/server/utils/prisma'
+import { errorHandler } from '@/server/utils/error'
+import {
+  forumPostSelect,
+  forumReadWhere,
+  getForumReadContext,
+  requireForumChannel,
+  serializeForumPost,
+} from '@/server/utils/forumApi'
+import {
+  normalizeForumChannelSlug,
+  parseForumBoolean,
+  parseForumLimit,
+  parseForumOrder,
+  parsePositiveForumInt,
+} from '~/utils/forumApiContract'
+
+type ForumThreadQuery = {
+  channel?: string | string[]
+  cursor?: string | string[]
+  limit?: string | string[]
+  order?: string | string[]
+  includeMature?: string | string[]
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const query = getQuery<ForumThreadQuery>(event)
+    const requestedChannel = normalizeForumChannelSlug(query.channel)
+    const channel = requestedChannel
+      ? requireForumChannel(requestedChannel).slug
+      : null
+    const cursor = parsePositiveForumInt(query.cursor)
+    const limit = parseForumLimit(query.limit)
+    const order = parseForumOrder(query.order)
+    const { includeMature } = await getForumReadContext(
+      event,
+      parseForumBoolean(query.includeMature),
+    )
+
+    const rows = await prisma.chat.findMany({
+      where: forumReadWhere({
+        channel,
+        includeMature,
+        rootOnly: true,
+        cursor,
+        order,
+      }),
+      select: forumPostSelect,
+      orderBy: { id: order === 'chronological' ? 'asc' : 'desc' },
+      take: limit + 1,
+    })
+
+    const hasMore = rows.length > limit
+    const roots = hasMore ? rows.slice(0, limit) : rows
+    const rootIds = roots.map((row) => row.id)
+    const replyRows = rootIds.length
+      ? await prisma.chat.findMany({
+          where: {
+            ...forumReadWhere({ includeMature }),
+            originId: { in: rootIds },
+            id: { notIn: rootIds },
+          },
+          select: {
+            id: true,
+            originId: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        })
+      : []
+
+    const stats = new Map<
+      number,
+      { replyCount: number; lastActivityAt: Date }
+    >()
+
+    for (const root of roots) {
+      stats.set(root.id, {
+        replyCount: 0,
+        lastActivityAt: root.updatedAt ?? root.createdAt,
+      })
+    }
+
+    for (const reply of replyRows) {
+      if (!reply.originId) continue
+      const current = stats.get(reply.originId)
+      if (!current) continue
+
+      const activityAt = reply.updatedAt ?? reply.createdAt
+      current.replyCount += 1
+      if (activityAt.getTime() > current.lastActivityAt.getTime()) {
+        current.lastActivityAt = activityAt
+      }
+    }
+
+    const data = roots.map((root) => ({
+      ...serializeForumPost(root),
+      ...(stats.get(root.id) ?? {
+        replyCount: 0,
+        lastActivityAt: root.updatedAt ?? root.createdAt,
+      }),
+    }))
+
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      data,
+      page: {
+        order,
+        limit,
+        nextCursor: hasMore ? roots.at(-1)?.id ?? null : null,
+      },
+      statusCode: 200,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      data: [],
+      page: null,
+      message: handled.message,
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/api/v1/forum/threads/index.post.ts
+++ b/server/api/v1/forum/threads/index.post.ts
@@ -1,0 +1,84 @@
+import { defineEventHandler, readBody } from 'h3'
+import type { Prisma } from '~/prisma/generated/prisma/client'
+import prisma from '@/server/utils/prisma'
+import { errorHandler } from '@/server/utils/error'
+import {
+  assertMatureForumWriteAllowed,
+  forumPostSelect,
+  requireForumChannel,
+  requireForumWriter,
+  serializeForumPost,
+} from '@/server/utils/forumApi'
+import {
+  assertJsonObject,
+  assertOnlyFields,
+  optionalBoolean,
+  requiredString,
+} from '@/server/utils/chatApi'
+
+const FORUM_THREAD_CREATE_FIELDS = new Set([
+  'channel',
+  'title',
+  'content',
+  'isMature',
+])
+
+export default defineEventHandler(async (event) => {
+  try {
+    const actor = await requireForumWriter(event)
+    const rawBody = await readBody<unknown>(event)
+    assertJsonObject(rawBody, 'A JSON forum thread body is required.')
+    assertOnlyFields(rawBody, FORUM_THREAD_CREATE_FIELDS, 'forum thread')
+
+    const channel = requireForumChannel(rawBody.channel)
+    const title = requiredString(rawBody.title, 'title', 255)
+    const content = requiredString(rawBody.content, 'content', 60_000)
+    const isMature = optionalBoolean(rawBody.isMature, 'isMature') ?? false
+    assertMatureForumWriteAllowed(actor.auth, isMature)
+
+    const created = await prisma.$transaction(async (tx) => {
+      const data: Prisma.ChatCreateInput = {
+        type: 'ToForum',
+        sender: actor.displayName,
+        content,
+        title,
+        channel: channel.slug,
+        isPublic: true,
+        isActive: true,
+        isMature,
+        previousEntryId: null,
+        originId: null,
+        User: { connect: { id: actor.userId } },
+        Bot: actor.botId ? { connect: { id: actor.botId } } : undefined,
+        botName: actor.botName,
+      }
+
+      const root = await tx.chat.create({
+        data,
+        select: forumPostSelect,
+      })
+
+      return tx.chat.update({
+        where: { id: root.id },
+        data: { originId: root.id },
+        select: forumPostSelect,
+      })
+    })
+
+    event.node.res.statusCode = 201
+    return {
+      success: true,
+      data: serializeForumPost(created),
+      statusCode: 201,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      data: null,
+      message: handled.message,
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/utils/forumApi.ts
+++ b/server/utils/forumApi.ts
@@ -1,0 +1,301 @@
+import { createError, getHeader, type H3Event } from 'h3'
+import type { Prisma } from '~/prisma/generated/prisma/client'
+import {
+  buildForumReadFilter,
+  canManageForumPost,
+  findForumChannel,
+  forumParentBelongsToThread,
+  parseForumChannelRegistryJson,
+  type ForumChannel,
+  type ForumOrder,
+} from '~/utils/forumApiContract'
+import {
+  authHasScope,
+  getOptionalApiUser,
+  requireScopedApiUser,
+  type AuthGuardResult,
+} from './authGuard'
+import { effectiveShowMature, isMaturityRestricted } from './contentAccess'
+import prisma from './prisma'
+
+export const forumPostSelect = {
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+  type: true,
+  sender: true,
+  content: true,
+  title: true,
+  isPublic: true,
+  previousEntryId: true,
+  originId: true,
+  userId: true,
+  botId: true,
+  botName: true,
+  channel: true,
+  isMature: true,
+  isActive: true,
+  User: {
+    select: {
+      id: true,
+      username: true,
+      avatarImage: true,
+    },
+  },
+  Bot: {
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      avatarImage: true,
+    },
+  },
+} satisfies Prisma.ChatSelect
+
+export type ForumPostRecord = Prisma.ChatGetPayload<{
+  select: typeof forumPostSelect
+}>
+
+export type ForumActor = {
+  auth: AuthGuardResult
+  userId: number
+  botId: number | null
+  displayName: string
+  botName: string | null
+}
+
+export type ForumReadContext = {
+  auth: AuthGuardResult | null
+  includeMature: boolean
+}
+
+export function getForumChannels(): ForumChannel[] {
+  return parseForumChannelRegistryJson(process.env.FORUM_CHANNELS_JSON)
+}
+
+export function requireForumChannel(value: unknown): ForumChannel {
+  const channel = findForumChannel(getForumChannels(), value)
+
+  if (!channel) {
+    throw createError({
+      statusCode: 400,
+      message: 'A valid forum channel slug is required.',
+    })
+  }
+
+  return channel
+}
+
+function hasSuppliedAuth(event: H3Event): boolean {
+  return Boolean(
+    getHeader(event, 'authorization') ||
+      getHeader(event, 'x-api-key') ||
+      getHeader(event, 'x-beta-admin-token') ||
+      getHeader(event, 'x-admin-token'),
+  )
+}
+
+export async function getForumReadContext(
+  event: H3Event,
+  requestedMature = false,
+): Promise<ForumReadContext> {
+  const auth = await getOptionalApiUser(event)
+
+  if (!auth && hasSuppliedAuth(event)) {
+    throw createError({
+      statusCode: 401,
+      message: 'Invalid or expired token.',
+    })
+  }
+
+  if (auth && !authHasScope(auth, 'forum:read')) {
+    throw createError({
+      statusCode: 403,
+      message: 'This credential is not authorized for scope "forum:read".',
+    })
+  }
+
+  const includeMature = Boolean(
+    auth &&
+      !isMaturityRestricted(auth.user) &&
+      (requestedMature || effectiveShowMature(auth.user)),
+  )
+
+  return { auth, includeMature }
+}
+
+export function forumReadWhere(options: {
+  channel?: string | null
+  includeMature?: boolean
+  rootOnly?: boolean
+  cursor?: number | null
+  order?: ForumOrder
+}): Prisma.ChatWhereInput {
+  return buildForumReadFilter(options) as Prisma.ChatWhereInput
+}
+
+export async function requireForumWriter(event: H3Event): Promise<ForumActor> {
+  const auth = await requireScopedApiUser(event, 'forum:write')
+
+  if (auth.kind !== 'agent-credential') {
+    return {
+      auth,
+      userId: auth.user.id,
+      botId: null,
+      displayName: auth.user.username,
+      botName: null,
+    }
+  }
+
+  if (!auth.botId) {
+    throw createError({
+      statusCode: 403,
+      message: 'Forum-writing agent credentials must be bound to a Kind Robots Bot.',
+    })
+  }
+
+  const bot = await prisma.bot.findFirst({
+    where: {
+      id: auth.botId,
+      userId: auth.user.id,
+      isActive: true,
+    },
+    select: {
+      id: true,
+      name: true,
+    },
+  })
+
+  if (!bot) {
+    throw createError({
+      statusCode: 403,
+      message: 'The Bot bound to this credential is unavailable or no longer owned by the authenticated user.',
+    })
+  }
+
+  return {
+    auth,
+    userId: auth.user.id,
+    botId: bot.id,
+    displayName: bot.name,
+    botName: bot.name,
+  }
+}
+
+export function assertForumPostManageable(
+  auth: AuthGuardResult,
+  post: Pick<ForumPostRecord, 'userId' | 'botId'>,
+): void {
+  if (
+    !canManageForumPost(
+      {
+        kind: auth.kind,
+        userId: auth.user.id,
+        botId: auth.botId,
+        isAdmin: auth.isAdmin,
+      },
+      post,
+    )
+  ) {
+    throw createError({
+      statusCode: 403,
+      message: 'You do not have permission to modify this forum post.',
+    })
+  }
+}
+
+export function assertMatureForumWriteAllowed(
+  auth: AuthGuardResult,
+  isMature: boolean,
+): void {
+  if (isMature && isMaturityRestricted(auth.user)) {
+    throw createError({
+      statusCode: 403,
+      message: 'This account cannot create or participate in mature forum content.',
+    })
+  }
+}
+
+export async function requireForumThreadRoot(
+  id: number,
+  includeMature: boolean,
+): Promise<ForumPostRecord> {
+  const root = await prisma.chat.findFirst({
+    where: {
+      id,
+      type: 'ToForum',
+      isPublic: true,
+      isActive: true,
+      previousEntryId: null,
+      ...(includeMature ? {} : { isMature: false }),
+    },
+    select: forumPostSelect,
+  })
+
+  if (!root) {
+    throw createError({
+      statusCode: 404,
+      message: `Forum thread ${id} was not found.`,
+    })
+  }
+
+  return root
+}
+
+export async function requireForumReplyParent(
+  threadId: number,
+  parentId: number,
+): Promise<ForumPostRecord> {
+  const parent = await prisma.chat.findUnique({
+    where: { id: parentId },
+    select: forumPostSelect,
+  })
+
+  if (!parent || !forumParentBelongsToThread(threadId, parent)) {
+    throw createError({
+      statusCode: 400,
+      message: 'The requested reply parent does not belong to this forum thread.',
+    })
+  }
+
+  return parent
+}
+
+export function serializeForumPost(post: ForumPostRecord) {
+  const user = post.User
+    ? {
+        id: post.User.id,
+        username: post.User.username,
+        avatarImage: post.User.avatarImage,
+      }
+    : post.userId
+      ? { id: post.userId, username: post.sender, avatarImage: null }
+      : null
+
+  const bot = post.Bot
+    ? {
+        id: post.Bot.id,
+        name: post.Bot.name,
+        slug: post.Bot.slug,
+        avatarImage: post.Bot.avatarImage,
+      }
+    : null
+
+  return {
+    id: post.id,
+    createdAt: post.createdAt,
+    updatedAt: post.updatedAt,
+    threadId: post.originId ?? post.id,
+    parentId: post.previousEntryId,
+    channel: post.channel,
+    title: post.title,
+    content: post.content,
+    isMature: post.isMature,
+    author: {
+      kind: bot ? ('AI_AGENT' as const) : ('HUMAN' as const),
+      displayName: bot?.name ?? user?.username ?? post.sender,
+      user,
+      bot,
+    },
+  }
+}

--- a/utils/forumApiContract.ts
+++ b/utils/forumApiContract.ts
@@ -1,0 +1,249 @@
+import type { AgentCredentialScope } from './agentCredentialScopes'
+
+export type ForumChannel = {
+  slug: string
+  label: string
+  description: string
+}
+
+export type ForumOrder = 'recent' | 'chronological'
+
+export const DEFAULT_FORUM_CHANNELS: readonly ForumChannel[] = [
+  {
+    slug: 'introductions',
+    label: 'Introductions',
+    description: 'Humans, agents, operators, and curious observers saying hello.',
+  },
+  {
+    slug: 'news',
+    label: 'News',
+    description: 'Project updates, build logs, receipts, and noteworthy developments.',
+  },
+  {
+    slug: 'humanitarian-goals',
+    label: 'Humanitarian Goals',
+    description: 'Research, proposals, resources, and useful work aimed at public benefit.',
+  },
+  {
+    slug: 'creativity',
+    label: 'Creativity',
+    description: 'Art, stories, tools, experiments, and collaborative creative work.',
+  },
+  {
+    slug: 'memes',
+    label: 'Memes',
+    description: 'Playful culture and jokes that still respect the commons rules.',
+  },
+  {
+    slug: 'just-because',
+    label: 'Just Because',
+    description: 'Open-ended conversation that does not fit the other boards.',
+  },
+]
+
+export const FORUM_FLAG_REASONS = [
+  'spam',
+  'harassment',
+  'misinformation',
+  'unsafe',
+  'other',
+] as const
+
+export type ForumFlagReason = (typeof FORUM_FLAG_REASONS)[number]
+
+function firstValue(value: unknown): unknown {
+  return Array.isArray(value) ? value[0] : value
+}
+
+function cleanText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+export function parsePositiveForumInt(value: unknown): number | null {
+  const parsed = Number(firstValue(value))
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+export function parseForumLimit(value: unknown, fallback = 30): number {
+  const parsed = parsePositiveForumInt(value)
+  return parsed ? Math.min(parsed, 100) : fallback
+}
+
+export function parseForumBoolean(value: unknown): boolean {
+  const raw = firstValue(value)
+  return raw === true || raw === 'true' || raw === '1' || raw === 'yes'
+}
+
+export function parseForumOrder(value: unknown): ForumOrder {
+  return cleanText(firstValue(value)).toLowerCase() === 'chronological'
+    ? 'chronological'
+    : 'recent'
+}
+
+export function normalizeForumChannelSlug(value: unknown): string | null {
+  const slug = cleanText(firstValue(value)).toLowerCase()
+  if (!slug || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)) return null
+  return slug
+}
+
+function normalizeChannel(value: unknown): ForumChannel | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+
+  const row = value as Record<string, unknown>
+  const slug = normalizeForumChannelSlug(row.slug)
+  const label = cleanText(row.label)
+  const description = cleanText(row.description)
+
+  if (!slug || !label || !description) return null
+  return { slug, label, description }
+}
+
+export function parseForumChannelRegistry(input: unknown): ForumChannel[] {
+  if (!Array.isArray(input)) return DEFAULT_FORUM_CHANNELS.map((entry) => ({ ...entry }))
+
+  const seen = new Set<string>()
+  const channels: ForumChannel[] = []
+
+  for (const value of input) {
+    const channel = normalizeChannel(value)
+    if (!channel || seen.has(channel.slug)) continue
+    seen.add(channel.slug)
+    channels.push(channel)
+  }
+
+  return channels.length
+    ? channels
+    : DEFAULT_FORUM_CHANNELS.map((entry) => ({ ...entry }))
+}
+
+export function parseForumChannelRegistryJson(raw: string | undefined): ForumChannel[] {
+  const text = cleanText(raw)
+  if (!text) return DEFAULT_FORUM_CHANNELS.map((entry) => ({ ...entry }))
+
+  try {
+    return parseForumChannelRegistry(JSON.parse(text))
+  } catch {
+    return DEFAULT_FORUM_CHANNELS.map((entry) => ({ ...entry }))
+  }
+}
+
+export function findForumChannel(
+  channels: readonly ForumChannel[],
+  value: unknown,
+): ForumChannel | null {
+  const slug = normalizeForumChannelSlug(value)
+  return slug ? channels.find((channel) => channel.slug === slug) ?? null : null
+}
+
+export function credentialHasForumScope(
+  authKind: string,
+  scopes: readonly AgentCredentialScope[] | undefined,
+  required: AgentCredentialScope,
+): boolean {
+  return authKind !== 'agent-credential' || Boolean(scopes?.includes(required))
+}
+
+export type ForumPostAccessShape = {
+  id: number
+  type: string
+  userId: number | null
+  botId: number | null
+  originId: number | null
+  previousEntryId: number | null
+  isPublic: boolean
+  isActive: boolean
+  isMature: boolean
+}
+
+export type ForumActorAccessShape = {
+  kind: string
+  userId: number
+  botId?: number | null
+  isAdmin?: boolean
+}
+
+export function forumPostIsPubliclyVisible(
+  post: Pick<ForumPostAccessShape, 'type' | 'isPublic' | 'isActive' | 'isMature'>,
+  includeMature = false,
+): boolean {
+  return (
+    post.type === 'ToForum' &&
+    post.isPublic &&
+    post.isActive &&
+    (includeMature || !post.isMature)
+  )
+}
+
+export function canManageForumPost(
+  actor: ForumActorAccessShape,
+  post: Pick<ForumPostAccessShape, 'userId' | 'botId'>,
+): boolean {
+  if (actor.kind !== 'agent-credential' && actor.isAdmin) return true
+  if (post.userId !== actor.userId) return false
+
+  if (actor.kind === 'agent-credential') {
+    return Boolean(actor.botId) && post.botId === actor.botId
+  }
+
+  return true
+}
+
+export function isForumThreadRoot(
+  post: Pick<ForumPostAccessShape, 'id' | 'originId' | 'previousEntryId' | 'type'>,
+): boolean {
+  if (post.type !== 'ToForum' || post.previousEntryId !== null) return false
+  return post.originId === null || post.originId === post.id
+}
+
+export function forumParentBelongsToThread(
+  threadId: number,
+  parent: Pick<
+    ForumPostAccessShape,
+    'id' | 'originId' | 'type' | 'isPublic' | 'isActive'
+  >,
+): boolean {
+  return (
+    parent.type === 'ToForum' &&
+    parent.isPublic &&
+    parent.isActive &&
+    (parent.id === threadId || parent.originId === threadId)
+  )
+}
+
+export type ForumReadFilterOptions = {
+  channel?: string | null
+  includeMature?: boolean
+  rootOnly?: boolean
+  cursor?: number | null
+  order?: ForumOrder
+}
+
+export function buildForumReadFilter(
+  options: ForumReadFilterOptions = {},
+): Record<string, unknown> {
+  const where: Record<string, unknown> = {
+    type: 'ToForum',
+    isPublic: true,
+    isActive: true,
+  }
+
+  if (!options.includeMature) where.isMature = false
+  if (options.channel) where.channel = options.channel
+  if (options.rootOnly) where.previousEntryId = null
+
+  if (options.cursor) {
+    where.id =
+      options.order === 'chronological'
+        ? { gt: options.cursor }
+        : { lt: options.cursor }
+  }
+
+  return where
+}
+
+export function parseForumFlagReason(value: unknown): ForumFlagReason | null {
+  const reason = cleanText(value).toLowerCase()
+  return (FORUM_FLAG_REASONS as readonly string[]).includes(reason)
+    ? (reason as ForumFlagReason)
+    : null
+}

--- a/utils/scripts/verifyForumApi.test.ts
+++ b/utils/scripts/verifyForumApi.test.ts
@@ -1,0 +1,203 @@
+import assert from 'node:assert/strict'
+import {
+  DEFAULT_FORUM_CHANNELS,
+  buildForumReadFilter,
+  canManageForumPost,
+  credentialHasForumScope,
+  findForumChannel,
+  forumParentBelongsToThread,
+  forumPostIsPubliclyVisible,
+  isForumThreadRoot,
+  parseForumChannelRegistryJson,
+  parseForumFlagReason,
+  parseForumLimit,
+} from '../forumApiContract.js'
+
+const expectedSlugs = [
+  'introductions',
+  'news',
+  'humanitarian-goals',
+  'creativity',
+  'memes',
+  'just-because',
+]
+
+{
+  assert.deepEqual(
+    DEFAULT_FORUM_CHANNELS.map((channel) => channel.slug),
+    expectedSlugs,
+  )
+  assert.equal(findForumChannel(DEFAULT_FORUM_CHANNELS, 'Creativity')?.slug, 'creativity')
+  assert.equal(findForumChannel(DEFAULT_FORUM_CHANNELS, 'not-a-board'), null)
+
+  const configured = parseForumChannelRegistryJson(
+    JSON.stringify([
+      { slug: 'field-notes', label: 'Field Notes', description: 'Sourced observations.' },
+      { slug: 'field-notes', label: 'Duplicate', description: 'Dropped.' },
+      { slug: 'Build Lab', label: 'Invalid slug', description: 'Dropped.' },
+    ]),
+  )
+  assert.deepEqual(configured, [
+    { slug: 'field-notes', label: 'Field Notes', description: 'Sourced observations.' },
+  ])
+
+  assert.deepEqual(
+    parseForumChannelRegistryJson('not-json').map((channel) => channel.slug),
+    expectedSlugs,
+  )
+}
+
+{
+  const visible = {
+    type: 'ToForum',
+    isPublic: true,
+    isActive: true,
+    isMature: false,
+  }
+  assert.equal(forumPostIsPubliclyVisible(visible), true)
+  assert.equal(forumPostIsPubliclyVisible({ ...visible, isPublic: false }), false)
+  assert.equal(forumPostIsPubliclyVisible({ ...visible, isActive: false }), false)
+  assert.equal(forumPostIsPubliclyVisible({ ...visible, type: 'ToUser' }), false)
+  assert.equal(forumPostIsPubliclyVisible({ ...visible, isMature: true }), false)
+  assert.equal(forumPostIsPubliclyVisible({ ...visible, isMature: true }, true), true)
+
+  assert.deepEqual(buildForumReadFilter(), {
+    type: 'ToForum',
+    isPublic: true,
+    isActive: true,
+    isMature: false,
+  })
+  assert.deepEqual(
+    buildForumReadFilter({
+      channel: 'news',
+      includeMature: true,
+      rootOnly: true,
+      cursor: 50,
+      order: 'recent',
+    }),
+    {
+      type: 'ToForum',
+      isPublic: true,
+      isActive: true,
+      channel: 'news',
+      previousEntryId: null,
+      id: { lt: 50 },
+    },
+  )
+  assert.deepEqual(buildForumReadFilter({ cursor: 50, order: 'chronological' }).id, {
+    gt: 50,
+  })
+}
+
+{
+  assert.equal(credentialHasForumScope('jwt', undefined, 'forum:write'), true)
+  assert.equal(
+    credentialHasForumScope('agent-credential', ['forum:read'], 'forum:write'),
+    false,
+  )
+  assert.equal(
+    credentialHasForumScope(
+      'agent-credential',
+      ['profile:read', 'forum:read', 'forum:write'],
+      'forum:write',
+    ),
+    true,
+  )
+}
+
+{
+  const human = { kind: 'jwt', userId: 7, botId: null, isAdmin: false }
+  const admin = { kind: 'jwt', userId: 1, botId: null, isAdmin: true }
+  const agent = { kind: 'agent-credential', userId: 7, botId: 42, isAdmin: false }
+
+  assert.equal(canManageForumPost(human, { userId: 7, botId: null }), true)
+  assert.equal(canManageForumPost(human, { userId: 8, botId: null }), false)
+  assert.equal(canManageForumPost(admin, { userId: 8, botId: 99 }), true)
+  assert.equal(canManageForumPost(agent, { userId: 7, botId: 42 }), true)
+  assert.equal(canManageForumPost(agent, { userId: 7, botId: 43 }), false)
+  assert.equal(
+    canManageForumPost(
+      { kind: 'agent-credential', userId: 7, botId: null, isAdmin: false },
+      { userId: 7, botId: null },
+    ),
+    false,
+  )
+  assert.equal(canManageForumPost(agent, { userId: 8, botId: 42 }), false)
+}
+
+{
+  assert.equal(
+    isForumThreadRoot({ id: 10, type: 'ToForum', originId: 10, previousEntryId: null }),
+    true,
+  )
+  assert.equal(
+    isForumThreadRoot({ id: 10, type: 'ToForum', originId: null, previousEntryId: null }),
+    true,
+  )
+  assert.equal(
+    isForumThreadRoot({ id: 11, type: 'ToForum', originId: 10, previousEntryId: 10 }),
+    false,
+  )
+
+  assert.equal(
+    forumParentBelongsToThread(10, {
+      id: 10,
+      originId: 10,
+      type: 'ToForum',
+      isPublic: true,
+      isActive: true,
+    }),
+    true,
+  )
+  assert.equal(
+    forumParentBelongsToThread(10, {
+      id: 12,
+      originId: 10,
+      type: 'ToForum',
+      isPublic: true,
+      isActive: true,
+    }),
+    true,
+  )
+  assert.equal(
+    forumParentBelongsToThread(10, {
+      id: 12,
+      originId: 99,
+      type: 'ToForum',
+      isPublic: true,
+      isActive: true,
+    }),
+    false,
+  )
+  assert.equal(
+    forumParentBelongsToThread(10, {
+      id: 12,
+      originId: 10,
+      type: 'ToForum',
+      isPublic: false,
+      isActive: true,
+    }),
+    false,
+  )
+  assert.equal(
+    forumParentBelongsToThread(10, {
+      id: 12,
+      originId: 10,
+      type: 'ToForum',
+      isPublic: true,
+      isActive: false,
+    }),
+    false,
+  )
+}
+
+{
+  assert.equal(parseForumFlagReason('spam'), 'spam')
+  assert.equal(parseForumFlagReason(' MISINFORMATION '), 'misinformation')
+  assert.equal(parseForumFlagReason('not-real'), null)
+  assert.equal(parseForumLimit('30'), 30)
+  assert.equal(parseForumLimit('999'), 100)
+  assert.equal(parseForumLimit('nope'), 30)
+}
+
+console.log('verifyForumApi.test.ts: all assertions passed')


### PR DESCRIPTION
## What this builds

- adds `/api/v1/forum` as a stable forum-facing facade over the existing `Chat` / `ToForum` substrate
- keeps the existing generic `/api/chats` routes untouched
- adds configurable forum boards, public thread reads, chronological activity cursors, thread creation, nested replies, edits, soft deletes, and a moderation-flag endpoint shape
- derives User/Bot authorship from the authenticated human or scoped Bot-bound agent credential instead of accepting caller-supplied author IDs
- requires `forum:read` / `forum:write` on agent credentials, and prevents scoped credentials from inheriting their owner's admin privileges
- hides private/inactive/mature content from anonymous public reads and preserves CHILD maturity restrictions
- makes root deletion thread-aware so replies do not remain exposed as orphans
- adds a focused pure contract self-test plus a path-scoped GitHub Actions check
- documents the v1 facade behavior without adding a new database or OpenAPI/federation layer

## Deliberately unchanged

No database migration, passwords, production secrets, deployment settings, DNS, billing, token accounting, or generic Chat API behavior are changed here. Full moderation workflow, explicit HUMAN_AI/SYSTEM provenance, Rainbow SSO, UI, OpenAPI discovery, and object embeds remain later roadmap tasks.

Conductor: `rainbow-butterflies/t-016`.