### PR TITLE
interface-vision/t-104: adopt kr-panel-flat for translucent dashed empty-state panels

### DIFF
--- a/components/curation/coloring-book-curation.vue
+++ b/components/curation/coloring-book-curation.vue
@@ -55,7 +55,7 @@
 
     <div
       v-else-if="!visibleProposals.length"
-      class="grid min-h-52 place-items-center rounded-2xl border border-dashed border-base-300 bg-base-100/50 p-8 text-center"
+      class="grid min-h-52 place-items-center kr-panel-flat border-dashed bg-base-100/50 p-8 text-center"
     >
       <p class="font-black">No pages match this view.</p>
     </div>

--- a/components/curation/cthulhuquarium-curation.vue
+++ b/components/curation/cthulhuquarium-curation.vue
@@ -42,7 +42,7 @@
 
     <div
       v-else-if="!visibleRows.length"
-      class="grid min-h-52 place-items-center rounded-2xl border border-dashed border-base-300 bg-base-100/50 p-8 text-center"
+      class="grid min-h-52 place-items-center kr-panel-flat border-dashed bg-base-100/50 p-8 text-center"
     >
       <p class="font-black">No monsters match this view.</p>
     </div>

--- a/components/narrative/narrative-ingredient-multi-picker.vue
+++ b/components/narrative/narrative-ingredient-multi-picker.vue
@@ -77,7 +77,7 @@
     <div
       v-else-if="loading"
       role="status"
-      class="flex min-h-32 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-100/60"
+      class="flex min-h-32 items-center justify-center kr-panel-flat border-dashed bg-base-100/60"
     >
       <span
         class="loading loading-dots loading-md text-secondary motion-reduce:hidden"
@@ -89,7 +89,7 @@
     <div
       v-else-if="!items.length"
       role="status"
-      class="rounded-2xl border border-dashed border-base-300 bg-base-100/60 p-4 text-center text-xs text-base-content/50"
+      class="kr-panel-flat border-dashed bg-base-100/60 p-4 text-center text-xs text-base-content/50"
     >
       {{ emptyState }}
     </div>
@@ -97,7 +97,7 @@
     <p
       v-else-if="query.trim() && !filteredItems.length"
       role="status"
-      class="rounded-xl border border-dashed border-base-300 bg-base-100/60 px-3 py-2 text-xs text-base-content/45"
+      class="kr-panel-flat border-dashed rounded-xl bg-base-100/60 px-3 py-2 text-xs text-base-content/45"
     >
       No matching {{ label.toLowerCase() }}.
     </p>

--- a/components/narrative/narrative-ingredient-picker.vue
+++ b/components/narrative/narrative-ingredient-picker.vue
@@ -59,7 +59,7 @@
     <p
       v-if="query.trim() && !filteredItems.length"
       role="status"
-      class="rounded-xl border border-dashed border-base-300 bg-base-100/60 px-3 py-2 text-xs text-base-content/45"
+      class="kr-panel-flat border-dashed rounded-xl bg-base-100/60 px-3 py-2 text-xs text-base-content/45"
     >
       No matching {{ label.toLowerCase() }}. Clear the search or leave the
       narrator free to choose.
@@ -81,7 +81,7 @@
     <div
       v-else-if="loading"
       role="status"
-      class="flex min-h-32 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-100/60"
+      class="flex min-h-32 items-center justify-center kr-panel-flat border-dashed bg-base-100/60"
     >
       <span
         class="loading loading-dots loading-md text-secondary motion-reduce:hidden"
@@ -93,7 +93,7 @@
     <div
       v-else-if="!items.length"
       role="status"
-      class="rounded-2xl border border-dashed border-base-300 bg-base-100/60 p-4 text-center text-xs text-base-content/50"
+      class="kr-panel-flat border-dashed bg-base-100/60 p-4 text-center text-xs text-base-content/50"
     >
       {{ emptyState }}
     </div>

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -766,7 +766,7 @@
               </div>
               <div
                 v-else
-                class="rounded-2xl border border-dashed border-base-300 bg-base-100/50 p-4 text-center text-xs text-base-content/40"
+                class="kr-panel-flat border-dashed bg-base-100/50 p-4 text-center text-xs text-base-content/40"
               >
                 <Icon
                   name="kind-icon:dream"

--- a/components/pages/conductor-pitch-manager.vue
+++ b/components/pages/conductor-pitch-manager.vue
@@ -277,7 +277,7 @@
 
         <div
           v-else
-          class="flex min-h-72 flex-col items-center justify-center rounded-3xl border border-dashed border-base-300 bg-base-100/70 p-8 text-center"
+          class="flex min-h-72 flex-col items-center justify-center kr-panel-flat border-dashed rounded-3xl bg-base-100/70 p-8 text-center"
         >
           <span class="flex size-16 items-center justify-center rounded-3xl bg-success/10 text-success">
             <Icon :name="emptyIcon" class="size-8" />

--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -168,7 +168,7 @@
 
       <div
         v-else
-        class="rounded-2xl border border-dashed border-base-300 bg-base-100/70 p-5 text-center"
+        class="kr-panel-flat border-dashed bg-base-100/70 p-5 text-center"
       >
         <p class="font-bold">No saved stories yet</p>
         <p class="mt-1 text-xs text-base-content/50">

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -211,7 +211,7 @@
 
             <div
               v-else-if="!store.totalCount"
-              class="grid min-h-64 place-items-center rounded-2xl border border-dashed border-base-300 bg-base-100/50 p-8 text-center"
+              class="grid min-h-64 place-items-center kr-panel-flat border-dashed bg-base-100/50 p-8 text-center"
             >
               <div>
                 <Icon name="kind-icon:server" class="mx-auto size-10 text-base-content/30" />
@@ -225,7 +225,7 @@
 
             <div
               v-else-if="!filteredSources.length"
-              class="grid min-h-40 place-items-center rounded-2xl border border-dashed border-base-300 bg-base-100/50 p-6 text-center"
+              class="grid min-h-40 place-items-center kr-panel-flat border-dashed bg-base-100/50 p-6 text-center"
             >
               <div>
                 <p class="font-black">No {{ statusFilter }} scenes in this folder</p>


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Opens a fourth mechanical pool alongside the three prior slices' `kr-container` (mx-auto/max-w-), `kr-surface`, and opaque `kr-panel-flat` dashed empty-state pools (all reported close to exhausted).
- 10 hand-rolled `rounded-Nxl border border-dashed border-base-300 bg-base-100/N` empty/loading-state panels across 8 files now compose `kr-panel-flat border-dashed` (+ a `rounded-Nxl` override where the caller used `rounded-xl`/`rounded-3xl` instead of `kr-panel-flat`'s own `rounded-2xl`), with the existing `bg-base-100/N` translucency override preserved verbatim as a trailing utility class.
- Files: `components/narrative/narrative-ingredient-picker.vue` (×3), `components/narrative/narrative-ingredient-multi-picker.vue` (×3), `components/curation/cthulhuquarium-curation.vue`, `components/curation/coloring-book-curation.vue`, `components/pages/conductor-pitch-manager.vue`, `components/pages/conductor-page.vue`, `components/pages/storybook-library-page.vue`, `pages/admin/scene-animator.vue` (×2).
- No geometry or behavior change.

### How I verified
- `npx eslint` on all 8 touched files — 1 pre-existing `no-unused-vars` error in `conductor-pitch-manager.vue` (`normalizePitchStatus`), confirmed via `git show origin/main:` that it predates this change and sits on a line this diff never touches.
- `npx prettier --check` on all 8 files — flagged, but confirmed via `git stash` + re-check against `main` that every file was already prettier-dirty before this edit (pre-existing baseline drift, not introduced here).
- `npm run test` (`vue-tsc --noEmit`, repo-wide) — clean.
- `npm run test:layout-contract` — holds (207 baseline unchanged, 0 new violations).

### Stakes
reversible

### Flags for Reviewer
- The prior slice's note flagged this translucent-opacity pool as needing someone to confirm "deliberate or drift" before sweeping it. This PR sidesteps that question rather than answering it: each panel's exact `bg-base-100/N` value is preserved as a trailing utility override (utilities layer wins over `kr-panel-flat`'s baked-in opaque background), so the substitution is byte-for-visual-effect identical whether the opacity was intentional or copy-paste drift — same convention kind_robots#2213/#2214 already used to preserve `rounded-3xl` overrides on the opaque variant of this pool.

### Kaizen suggestion
None new this slice — all four now-identified mechanical pools (`kr-container`, `kr-surface`, opaque `kr-panel-flat` dashed empty-state, translucent `kr-panel-flat` dashed empty-state) are reported close to exhausted. The next slice likely needs a fresh grep pass across `main` rather than reusing a known pool, per the established "re-derive, don't trust the note" lesson from earlier slices.

### Notes for reviewer
Recurring sweep task — roadmap `status: review`, will return to `ready` after this merges per the established t-104 convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_015WqwWmva1R8NAJcSdRHKA4)_