### PR TITLE
Add first-party Kind Robots authorization-code SSO

### DIFF
--- a/.github/workflows/first-party-sso-contract.yml
+++ b/.github/workflows/first-party-sso-contract.yml
@@ -1,0 +1,39 @@
+name: First-Party SSO Contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/auth/first-party/**'
+      - 'server/utils/firstPartySso.ts'
+      - 'utils/firstPartySsoContract.ts'
+      - 'utils/scripts/verifyFirstPartySso.test.ts'
+      - 'components/user/login-page.vue'
+      - 'prisma/migrations/*first_party_authorization_codes*/migration.sql'
+      - '.github/workflows/first-party-sso-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify first-party SSO contract
+        run: npx tsx utils/scripts/verifyFirstPartySso.test.ts

--- a/components/user/login-page.vue
+++ b/components/user/login-page.vue
@@ -191,7 +191,7 @@
           </NuxtLink>
         </div>
 
-        <div class="my-5 flex items-center gap-3">
+        <div v-if="!returnTarget" class="my-5 flex items-center gap-3">
           <span class="h-px flex-1 bg-base-content/15" />
           <span
             class="rounded-full border border-base-content/10 bg-base-100/80 px-3 py-1 text-xs font-black uppercase tracking-widest text-base-content/45"
@@ -202,6 +202,7 @@
         </div>
 
         <div
+          v-if="!returnTarget"
           class="flex justify-center rounded-2xl border border-base-300/70 bg-base-100/70 p-2 shadow-sm"
         >
           <GoogleLogin />

--- a/components/user/login-page.vue
+++ b/components/user/login-page.vue
@@ -89,6 +89,13 @@
             You are browsing as Kind Guest. Sign in to use your own account.
           </div>
 
+          <div
+            v-if="returnTarget"
+            class="rounded-2xl border border-secondary/30 bg-secondary/10 p-3 text-sm font-semibold text-secondary"
+          >
+            Sign in to continue to the trusted Kind Robots service that sent you here.
+          </div>
+
           <label for="login" class="flex flex-col gap-2">
             <span class="pl-1 text-sm font-black text-base-content/80">
               Username
@@ -252,11 +259,12 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useErrorStore, ErrorType } from '~/stores/errorStore'
 import { useUserStore } from '~/stores/userStore'
 
 const store = useUserStore()
+const route = useRoute()
 const router = useRouter()
 const errorStore = useErrorStore()
 
@@ -264,6 +272,34 @@ const login = ref('')
 const password = ref('')
 const errorMessage = ref('')
 const userNotFound = ref(false)
+
+function normalizeLocalReturnTarget(value: unknown): string {
+  const raw = Array.isArray(value) ? value[0] : value
+  if (typeof raw !== 'string') return ''
+
+  const candidate = raw.trim()
+  if (
+    !candidate.startsWith('/') ||
+    candidate.startsWith('//') ||
+    candidate.includes('\\') ||
+    candidate.length > 4096
+  ) {
+    return ''
+  }
+
+  try {
+    const base = 'https://kindrobots.invalid'
+    const parsed = new URL(candidate, base)
+    if (parsed.origin !== base) return ''
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`
+  } catch {
+    return ''
+  }
+}
+
+const returnTarget = computed(() => {
+  return normalizeLocalReturnTarget(route.query.returnTo)
+})
 
 const normalizedUsername = computed(() => {
   return String(store.username || '')
@@ -276,7 +312,9 @@ const isKindGuest = computed(() => {
 })
 
 const shouldShowLoginForm = computed(() => {
-  return !store.isLoggedIn || isKindGuest.value
+  // A first-party SSO return request must refresh the server cookie even when
+  // stale client state still thinks the user is logged in.
+  return !store.isLoggedIn || isKindGuest.value || Boolean(returnTarget.value)
 })
 
 const stayLoggedIn = computed({
@@ -300,6 +338,14 @@ async function handleLogin(): Promise<void> {
       errorMessage.value =
         result.message || 'That username or password does not look right.'
       userNotFound.value = result.message?.includes('User not found') || false
+      return
+    }
+
+    if (returnTarget.value) {
+      // Use a real document navigation for API authorization endpoints. A
+      // vue-router push would treat /api/... as an app page and never reach
+      // Nitro's authorization handler.
+      window.location.assign(returnTarget.value)
       return
     }
 

--- a/docs/api/first-party-sso.md
+++ b/docs/api/first-party-sso.md
@@ -1,0 +1,65 @@
+# First-party Kind Robots SSO
+
+Kind Robots is the identity authority for trusted first-party sites such as Rainbow Butterflies. The handoff is an authorization-code flow with an exact redirect allowlist and PKCE S256. A first-party site never receives a Kind Robots password or the long-lived `kind-session` JWT.
+
+## Browser authorization
+
+Send the browser to:
+
+`GET /api/auth/first-party/authorize`
+
+Required query parameters:
+
+- `response_type=code`
+- `client_id=rainbow-butterflies`
+- `redirect_uri=https://rainbowbutterflies.org/auth/callback`
+- `code_challenge=<PKCE S256 challenge>`
+- `code_challenge_method=S256`
+- `state=<high-entropy anti-forgery value>`
+
+The redirect URI must exactly match a URI registered for the client. Invalid client or redirect input is rejected locally and is never followed, so the endpoint cannot be used as an open redirect.
+
+If the browser has no valid `kind-session` cookie, Kind Robots sends it through `/login` with a same-origin `returnTo` value. After a successful password login, the browser resumes the authorization request. The authorization code is random, stored only as a SHA-256 hash, expires after two minutes, and is single use.
+
+On success the browser is redirected to the registered callback with `code` and the original `state` query values.
+
+## Server-side exchange
+
+The first-party backend exchanges the code with:
+
+`POST /api/auth/first-party/exchange`
+
+JSON body:
+
+```json
+{
+  "grant_type": "authorization_code",
+  "client_id": "rainbow-butterflies",
+  "redirect_uri": "https://rainbowbutterflies.org/auth/callback",
+  "code": "<authorization code>",
+  "code_verifier": "<original PKCE verifier>"
+}
+```
+
+A valid exchange returns only the minimum identity handoff:
+
+```json
+{
+  "success": true,
+  "clientId": "rainbow-butterflies",
+  "user": {
+    "id": 123,
+    "username": "example"
+  }
+}
+```
+
+The exchange does **not** return the user's Kind Robots password, password hash, API key, agent credential, or normal Kind Robots JWT. Rainbow Butterflies is expected to create its own short-lived HttpOnly session after validating `state` and completing this exchange.
+
+The exchange locks the authorization-code row, verifies client, redirect URI, expiry, single-use state, and PKCE, then marks the row consumed in the same database transaction. Replay attempts receive the same generic invalid-code response as other invalid grants.
+
+## Client registry
+
+The built-in registry includes Rainbow Butterflies production plus local callback addresses. Deployments may replace the registry with `FIRST_PARTY_SSO_CLIENTS_JSON`, an array of objects with `id`, `label`, and `redirectUris`.
+
+Only HTTPS redirect URIs are accepted, except `http://localhost` and `http://127.0.0.1` for development. Userinfo, fragments, malformed URLs, and unregistered destinations are rejected.

--- a/prisma/migrations/20260830053500_add_first_party_authorization_codes/migration.sql
+++ b/prisma/migrations/20260830053500_add_first_party_authorization_codes/migration.sql
@@ -1,0 +1,25 @@
+-- First-party SSO authorization codes are intentionally a short-lived server-only
+-- exchange primitive. They are accessed with parameterized raw Prisma queries so
+-- the public Prisma application model does not grow a reusable token surface.
+CREATE TABLE `FirstPartyAuthorizationCode` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `codeHash` CHAR(64) NOT NULL,
+    `userId` INTEGER NOT NULL,
+    `clientId` VARCHAR(128) NOT NULL,
+    `redirectUri` VARCHAR(1024) NOT NULL,
+    `codeChallenge` VARCHAR(128) NOT NULL,
+    `codeChallengeMethod` VARCHAR(16) NOT NULL DEFAULT 'S256',
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `expiresAt` DATETIME(3) NOT NULL,
+    `consumedAt` DATETIME(3) NULL,
+
+    UNIQUE INDEX `FirstPartyAuthorizationCode_codeHash_key`(`codeHash`),
+    INDEX `FirstPartyAuthorizationCode_clientId_expiresAt_idx`(`clientId`, `expiresAt`),
+    INDEX `FirstPartyAuthorizationCode_userId_idx`(`userId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE `FirstPartyAuthorizationCode`
+    ADD CONSTRAINT `FirstPartyAuthorizationCode_userId_fkey`
+    FOREIGN KEY (`userId`) REFERENCES `User`(`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/api/auth/first-party/authorize.get.ts
+++ b/server/api/auth/first-party/authorize.get.ts
@@ -1,0 +1,47 @@
+import {
+  defineEventHandler,
+  getQuery,
+  sendRedirect,
+  setHeader,
+} from 'h3'
+import {
+  getKindSessionIdentity,
+  issueFirstPartyAuthorizationCode,
+  parseFirstPartyAuthorizeRequest,
+} from '@/server/utils/firstPartySso'
+
+export default defineEventHandler(async (event) => {
+  setHeader(event, 'Cache-Control', 'no-store')
+  setHeader(event, 'Pragma', 'no-cache')
+
+  const request = parseFirstPartyAuthorizeRequest(
+    getQuery(event) as Record<string, unknown>,
+  )
+  const identity = await getKindSessionIdentity(event)
+
+  if (!identity) {
+    const rawRequestPath = event.node.req.url || '/api/auth/first-party/authorize'
+    const returnTo = rawRequestPath.startsWith('/') && !rawRequestPath.startsWith('//')
+      ? rawRequestPath
+      : '/api/auth/first-party/authorize'
+
+    return await sendRedirect(
+      event,
+      `/login?returnTo=${encodeURIComponent(returnTo)}`,
+      302,
+    )
+  }
+
+  const grant = await issueFirstPartyAuthorizationCode({
+    userId: identity.id,
+    clientId: request.client.id,
+    redirectUri: request.redirectUri,
+    codeChallenge: request.codeChallenge,
+  })
+
+  const destination = new URL(request.redirectUri)
+  destination.searchParams.set('code', grant.code)
+  destination.searchParams.set('state', request.state)
+
+  return await sendRedirect(event, destination.toString(), 302)
+})

--- a/server/api/auth/first-party/exchange.post.ts
+++ b/server/api/auth/first-party/exchange.post.ts
@@ -1,0 +1,34 @@
+import {
+  createError,
+  defineEventHandler,
+  readBody,
+  setHeader,
+} from 'h3'
+import {
+  consumeFirstPartyAuthorizationCode,
+  parseFirstPartyExchangeRequest,
+} from '@/server/utils/firstPartySso'
+
+export default defineEventHandler(async (event) => {
+  setHeader(event, 'Cache-Control', 'no-store')
+  setHeader(event, 'Pragma', 'no-cache')
+
+  const rawBody = await readBody<unknown>(event)
+  if (!rawBody || typeof rawBody !== 'object' || Array.isArray(rawBody)) {
+    throw createError({
+      statusCode: 400,
+      message: 'A JSON authorization-code exchange body is required.',
+    })
+  }
+
+  const request = parseFirstPartyExchangeRequest(
+    rawBody as Record<string, unknown>,
+  )
+  const user = await consumeFirstPartyAuthorizationCode(request)
+
+  return {
+    success: true,
+    clientId: request.client.id,
+    user,
+  }
+})

--- a/server/utils/firstPartySso.ts
+++ b/server/utils/firstPartySso.ts
@@ -1,0 +1,277 @@
+import {
+  createError,
+  getCookie,
+  type H3Event,
+} from 'h3'
+import { verifyJwtToken } from '@/server/api/auth'
+import {
+  evaluateAuthorizationCodeExchange,
+  findFirstPartyClient,
+  generateAuthorizationCode,
+  hashAuthorizationCode,
+  normalizeAllowedFirstPartyRedirect,
+  parseFirstPartyClientsJson,
+  validatePkceChallenge,
+  validatePkceVerifier,
+  validateSsoState,
+  type AuthorizationCodeRecord,
+  type FirstPartyClient,
+} from '~/utils/firstPartySsoContract'
+import prisma from './prisma'
+
+const AUTHORIZATION_CODE_LIFETIME_MS = 2 * 60 * 1000
+const AUTHORIZATION_CODE_RETENTION_MS = 24 * 60 * 60 * 1000
+const MAX_AUTHORIZATION_CODE_LENGTH = 256
+
+export type FirstPartyIdentity = {
+  id: number
+  username: string
+}
+
+export type FirstPartyAuthorizeRequest = {
+  client: FirstPartyClient
+  redirectUri: string
+  state: string
+  codeChallenge: string
+}
+
+export type FirstPartyExchangeRequest = {
+  client: FirstPartyClient
+  redirectUri: string
+  code: string
+  verifier: string
+}
+
+export function getFirstPartyClients(): FirstPartyClient[] {
+  return parseFirstPartyClientsJson(process.env.FIRST_PARTY_SSO_CLIENTS_JSON)
+}
+
+export function parseFirstPartyAuthorizeRequest(
+  query: Record<string, unknown>,
+): FirstPartyAuthorizeRequest {
+  if (query.response_type !== 'code') {
+    throw createError({
+      statusCode: 400,
+      message: 'response_type must be "code".',
+    })
+  }
+
+  const client = findFirstPartyClient(getFirstPartyClients(), query.client_id)
+  if (!client) {
+    throw createError({
+      statusCode: 400,
+      message: 'Unknown first-party client.',
+    })
+  }
+
+  const redirectUri = normalizeAllowedFirstPartyRedirect(client, query.redirect_uri)
+  if (!redirectUri) {
+    // Never redirect an error to an untrusted URI. An invalid redirect target is
+    // reported locally so this endpoint cannot be turned into an open redirect.
+    throw createError({
+      statusCode: 400,
+      message: 'redirect_uri is not registered for this first-party client.',
+    })
+  }
+
+  if (query.code_challenge_method !== 'S256') {
+    throw createError({
+      statusCode: 400,
+      message: 'code_challenge_method must be "S256".',
+    })
+  }
+
+  const codeChallenge = validatePkceChallenge(query.code_challenge)
+  if (!codeChallenge) {
+    throw createError({
+      statusCode: 400,
+      message: 'A valid PKCE S256 code_challenge is required.',
+    })
+  }
+
+  const state = validateSsoState(query.state)
+  if (!state) {
+    throw createError({
+      statusCode: 400,
+      message: 'A high-entropy state value is required.',
+    })
+  }
+
+  return { client, redirectUri, state, codeChallenge }
+}
+
+export function parseFirstPartyExchangeRequest(
+  body: Record<string, unknown>,
+): FirstPartyExchangeRequest {
+  if (body.grant_type !== 'authorization_code') {
+    throw createError({
+      statusCode: 400,
+      message: 'grant_type must be "authorization_code".',
+    })
+  }
+
+  const client = findFirstPartyClient(getFirstPartyClients(), body.client_id)
+  if (!client) {
+    throw createError({
+      statusCode: 400,
+      message: 'Unknown first-party client.',
+    })
+  }
+
+  const redirectUri = normalizeAllowedFirstPartyRedirect(client, body.redirect_uri)
+  if (!redirectUri) {
+    throw createError({
+      statusCode: 400,
+      message: 'redirect_uri is not registered for this first-party client.',
+    })
+  }
+
+  const verifier = validatePkceVerifier(body.code_verifier)
+  if (!verifier) {
+    throw createError({
+      statusCode: 400,
+      message: 'A valid PKCE code_verifier is required.',
+    })
+  }
+
+  const code = typeof body.code === 'string' ? body.code.trim() : ''
+  if (!code || code.length > MAX_AUTHORIZATION_CODE_LENGTH) {
+    throw createError({
+      statusCode: 400,
+      message: 'A valid authorization code is required.',
+    })
+  }
+
+  return { client, redirectUri, code, verifier }
+}
+
+export async function getKindSessionIdentity(
+  event: H3Event,
+): Promise<FirstPartyIdentity | null> {
+  const token = getCookie(event, 'kind-session')?.trim() ?? ''
+  if (!token) return null
+
+  const verification = await verifyJwtToken(token)
+  if (!verification.success || !verification.userId) return null
+
+  const user = await prisma.user.findUnique({
+    where: { id: verification.userId },
+    select: {
+      id: true,
+      username: true,
+      isActive: true,
+    },
+  })
+
+  if (!user || user.isActive === false) return null
+
+  return {
+    id: user.id,
+    username: user.username,
+  }
+}
+
+export async function issueFirstPartyAuthorizationCode(input: {
+  userId: number
+  clientId: string
+  redirectUri: string
+  codeChallenge: string
+}): Promise<{ code: string; expiresAt: Date }> {
+  const now = new Date()
+  const expiresAt = new Date(now.getTime() + AUTHORIZATION_CODE_LIFETIME_MS)
+  const code = generateAuthorizationCode()
+  const codeHash = hashAuthorizationCode(code)
+
+  // Keep the server-only handoff table bounded without adding a scheduler.
+  const retentionCutoff = new Date(now.getTime() - AUTHORIZATION_CODE_RETENTION_MS)
+  await prisma.$executeRaw`
+    DELETE FROM \`FirstPartyAuthorizationCode\`
+    WHERE \`expiresAt\` < ${retentionCutoff}
+  `
+
+  await prisma.$executeRaw`
+    INSERT INTO \`FirstPartyAuthorizationCode\`
+      (\`codeHash\`, \`userId\`, \`clientId\`, \`redirectUri\`, \`codeChallenge\`, \`codeChallengeMethod\`, \`createdAt\`, \`expiresAt\`)
+    VALUES
+      (${codeHash}, ${input.userId}, ${input.clientId}, ${input.redirectUri}, ${input.codeChallenge}, 'S256', ${now}, ${expiresAt})
+  `
+
+  return { code, expiresAt }
+}
+
+export async function consumeFirstPartyAuthorizationCode(
+  input: FirstPartyExchangeRequest,
+): Promise<FirstPartyIdentity> {
+  const codeHash = hashAuthorizationCode(input.code)
+
+  return await prisma.$transaction(async (tx) => {
+    const rows = await tx.$queryRaw<AuthorizationCodeRecord[]>`
+      SELECT
+        \`id\`, \`codeHash\`, \`userId\`, \`clientId\`, \`redirectUri\`,
+        \`codeChallenge\`, \`codeChallengeMethod\`, \`expiresAt\`, \`consumedAt\`
+      FROM \`FirstPartyAuthorizationCode\`
+      WHERE \`codeHash\` = ${codeHash}
+      LIMIT 1
+      FOR UPDATE
+    `
+
+    const record = rows[0]
+    if (!record) {
+      throw createError({
+        statusCode: 400,
+        message: 'Invalid or expired authorization code.',
+      })
+    }
+
+    const decision = evaluateAuthorizationCodeExchange(record, {
+      clientId: input.client.id,
+      redirectUri: input.redirectUri,
+      verifier: input.verifier,
+    })
+
+    if (!decision.ok) {
+      // Do not reveal which grant component failed. The caller gets one stable
+      // invalid-grant shape, while the row lock prevents racing replays.
+      throw createError({
+        statusCode: 400,
+        message: 'Invalid or expired authorization code.',
+      })
+    }
+
+    const consumedAt = new Date()
+    const changed = await tx.$executeRaw`
+      UPDATE \`FirstPartyAuthorizationCode\`
+      SET \`consumedAt\` = ${consumedAt}
+      WHERE \`codeHash\` = ${codeHash}
+        AND \`consumedAt\` IS NULL
+    `
+
+    if (changed !== 1) {
+      throw createError({
+        statusCode: 400,
+        message: 'Invalid or expired authorization code.',
+      })
+    }
+
+    const user = await tx.user.findUnique({
+      where: { id: decision.userId },
+      select: {
+        id: true,
+        username: true,
+        isActive: true,
+      },
+    })
+
+    if (!user || user.isActive === false) {
+      throw createError({
+        statusCode: 403,
+        message: 'The Kind Robots account is unavailable.',
+      })
+    }
+
+    return {
+      id: user.id,
+      username: user.username,
+    }
+  })
+}

--- a/utils/firstPartySsoContract.ts
+++ b/utils/firstPartySsoContract.ts
@@ -1,0 +1,197 @@
+import crypto from 'node:crypto'
+
+export type FirstPartyClient = {
+  id: string
+  label: string
+  redirectUris: string[]
+}
+
+export type AuthorizationCodeRecord = {
+  id: bigint | number
+  codeHash: string
+  userId: number
+  clientId: string
+  redirectUri: string
+  codeChallenge: string
+  codeChallengeMethod: string
+  expiresAt: Date
+  consumedAt: Date | null
+}
+
+export const DEFAULT_FIRST_PARTY_CLIENTS: readonly FirstPartyClient[] = [
+  {
+    id: 'rainbow-butterflies',
+    label: 'Rainbow Butterflies',
+    redirectUris: [
+      'https://rainbowbutterflies.org/auth/callback',
+      'http://localhost:3000/auth/callback',
+      'http://127.0.0.1:3000/auth/callback',
+    ],
+  },
+]
+
+const CLIENT_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/
+
+function cleanString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function normalizeRedirectUri(value: unknown): string | null {
+  const raw = cleanString(value)
+  if (!raw || raw.length > 1024) return null
+
+  try {
+    const url = new URL(raw)
+    const local = url.hostname === 'localhost' || url.hostname === '127.0.0.1'
+    if (url.username || url.password || url.hash) return null
+    if (url.protocol !== 'https:' && !(local && url.protocol === 'http:')) return null
+    return url.toString()
+  } catch {
+    return null
+  }
+}
+
+function normalizeClient(value: unknown): FirstPartyClient | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const row = value as Record<string, unknown>
+  const id = cleanString(row.id).toLowerCase()
+  const label = cleanString(row.label)
+  if (!CLIENT_ID_PATTERN.test(id) || !label || !Array.isArray(row.redirectUris)) return null
+
+  const redirectUris = Array.from(
+    new Set(
+      row.redirectUris
+        .map(normalizeRedirectUri)
+        .filter((uri): uri is string => Boolean(uri)),
+    ),
+  )
+  if (!redirectUris.length) return null
+
+  return { id, label, redirectUris }
+}
+
+export function parseFirstPartyClients(input: unknown): FirstPartyClient[] {
+  if (!Array.isArray(input)) return DEFAULT_FIRST_PARTY_CLIENTS.map(cloneClient)
+
+  const clients: FirstPartyClient[] = []
+  const seen = new Set<string>()
+  for (const value of input) {
+    const client = normalizeClient(value)
+    if (!client || seen.has(client.id)) continue
+    seen.add(client.id)
+    clients.push(client)
+  }
+
+  return clients.length ? clients : DEFAULT_FIRST_PARTY_CLIENTS.map(cloneClient)
+}
+
+export function parseFirstPartyClientsJson(raw: string | undefined): FirstPartyClient[] {
+  const text = cleanString(raw)
+  if (!text) return DEFAULT_FIRST_PARTY_CLIENTS.map(cloneClient)
+
+  try {
+    return parseFirstPartyClients(JSON.parse(text))
+  } catch {
+    return DEFAULT_FIRST_PARTY_CLIENTS.map(cloneClient)
+  }
+}
+
+function cloneClient(client: FirstPartyClient): FirstPartyClient {
+  return { ...client, redirectUris: [...client.redirectUris] }
+}
+
+export function findFirstPartyClient(
+  clients: readonly FirstPartyClient[],
+  clientId: unknown,
+): FirstPartyClient | null {
+  const id = cleanString(clientId).toLowerCase()
+  return clients.find((client) => client.id === id) ?? null
+}
+
+export function isAllowedFirstPartyRedirect(
+  client: FirstPartyClient,
+  redirectUri: unknown,
+): boolean {
+  const normalized = normalizeRedirectUri(redirectUri)
+  return Boolean(normalized && client.redirectUris.includes(normalized))
+}
+
+export function normalizeAllowedFirstPartyRedirect(
+  client: FirstPartyClient,
+  redirectUri: unknown,
+): string | null {
+  const normalized = normalizeRedirectUri(redirectUri)
+  return normalized && client.redirectUris.includes(normalized) ? normalized : null
+}
+
+export function validateSsoState(value: unknown): string | null {
+  const state = cleanString(value)
+  return state.length >= 16 && state.length <= 512 ? state : null
+}
+
+export function validatePkceChallenge(value: unknown): string | null {
+  const challenge = cleanString(value)
+  if (challenge.length < 43 || challenge.length > 128) return null
+  return BASE64URL_PATTERN.test(challenge) ? challenge : null
+}
+
+export function validatePkceVerifier(value: unknown): string | null {
+  const verifier = cleanString(value)
+  if (verifier.length < 43 || verifier.length > 128) return null
+  return BASE64URL_PATTERN.test(verifier) ? verifier : null
+}
+
+export function pkceS256(verifier: string): string {
+  return crypto.createHash('sha256').update(verifier, 'ascii').digest('base64url')
+}
+
+export function verifyPkceS256(verifier: string, challenge: string): boolean {
+  const derived = Buffer.from(pkceS256(verifier), 'utf8')
+  const expected = Buffer.from(challenge, 'utf8')
+  return derived.length === expected.length && crypto.timingSafeEqual(derived, expected)
+}
+
+export function hashAuthorizationCode(code: string): string {
+  return crypto.createHash('sha256').update(code, 'utf8').digest('hex')
+}
+
+export function generateAuthorizationCode(): string {
+  return crypto.randomBytes(32).toString('base64url')
+}
+
+export type AuthorizationCodeExchangeInput = {
+  clientId: string
+  redirectUri: string
+  verifier: string
+  now?: Date
+}
+
+export type AuthorizationCodeExchangeDecision =
+  | { ok: true; userId: number }
+  | { ok: false; reason: 'consumed' | 'expired' | 'client' | 'redirect' | 'pkce' }
+
+export function evaluateAuthorizationCodeExchange(
+  record: AuthorizationCodeRecord,
+  input: AuthorizationCodeExchangeInput,
+): AuthorizationCodeExchangeDecision {
+  if (record.consumedAt) return { ok: false, reason: 'consumed' }
+  const now = input.now ?? new Date()
+  if (record.expiresAt.getTime() <= now.getTime()) return { ok: false, reason: 'expired' }
+  if (record.clientId !== input.clientId) return { ok: false, reason: 'client' }
+  if (record.redirectUri !== input.redirectUri) return { ok: false, reason: 'redirect' }
+  if (record.codeChallengeMethod !== 'S256') return { ok: false, reason: 'pkce' }
+  if (!verifyPkceS256(input.verifier, record.codeChallenge)) {
+    return { ok: false, reason: 'pkce' }
+  }
+
+  return { ok: true, userId: record.userId }
+}
+
+export const FIRST_PARTY_EXCHANGE_FIELDS = new Set([
+  'grant_type',
+  'client_id',
+  'redirect_uri',
+  'code',
+  'code_verifier',
+])

--- a/utils/scripts/verifyFirstPartySso.test.ts
+++ b/utils/scripts/verifyFirstPartySso.test.ts
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict'
+
+import {
+  DEFAULT_FIRST_PARTY_CLIENTS,
+  evaluateAuthorizationCodeExchange,
+  findFirstPartyClient,
+  hashAuthorizationCode,
+  isAllowedFirstPartyRedirect,
+  parseFirstPartyClientsJson,
+  pkceS256,
+  validatePkceChallenge,
+  validatePkceVerifier,
+  validateSsoState,
+} from '../firstPartySsoContract.js'
+
+const clients = parseFirstPartyClientsJson(undefined)
+const rainbow = findFirstPartyClient(clients, 'rainbow-butterflies')
+assert.ok(rainbow)
+assert.deepEqual(clients, DEFAULT_FIRST_PARTY_CLIENTS)
+
+assert.equal(
+  isAllowedFirstPartyRedirect(
+    rainbow,
+    'https://rainbowbutterflies.org/auth/callback',
+  ),
+  true,
+)
+assert.equal(
+  isAllowedFirstPartyRedirect(rainbow, 'https://evil.example/auth/callback'),
+  false,
+)
+assert.equal(
+  isAllowedFirstPartyRedirect(
+    rainbow,
+    'https://rainbowbutterflies.org.evil.example/auth/callback',
+  ),
+  false,
+)
+assert.equal(
+  isAllowedFirstPartyRedirect(
+    rainbow,
+    'https://rainbowbutterflies.org/auth/callback#steal-me',
+  ),
+  false,
+)
+assert.equal(
+  isAllowedFirstPartyRedirect(rainbow, 'javascript:alert(1)'),
+  false,
+)
+
+assert.equal(validateSsoState('too-short'), null)
+assert.equal(validateSsoState('0123456789abcdef'), '0123456789abcdef')
+
+// RFC 7636 Appendix B verifier/challenge pair.
+const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
+const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM'
+assert.equal(pkceS256(verifier), challenge)
+assert.equal(validatePkceVerifier(verifier), verifier)
+assert.equal(validatePkceChallenge(challenge), challenge)
+assert.equal(validatePkceVerifier('short'), null)
+assert.equal(validatePkceChallenge('short'), null)
+
+const now = new Date('2026-08-30T05:30:00.000Z')
+const record = {
+  id: 1,
+  codeHash: hashAuthorizationCode('single-use-code'),
+  userId: 42,
+  clientId: 'rainbow-butterflies',
+  redirectUri: 'https://rainbowbutterflies.org/auth/callback',
+  codeChallenge: challenge,
+  codeChallengeMethod: 'S256',
+  expiresAt: new Date('2026-08-30T05:32:00.000Z'),
+  consumedAt: null,
+}
+
+assert.deepEqual(
+  evaluateAuthorizationCodeExchange(record, {
+    clientId: 'rainbow-butterflies',
+    redirectUri: 'https://rainbowbutterflies.org/auth/callback',
+    verifier,
+    now,
+  }),
+  { ok: true, userId: 42 },
+)
+
+assert.deepEqual(
+  evaluateAuthorizationCodeExchange(
+    { ...record, consumedAt: new Date('2026-08-30T05:29:00.000Z') },
+    {
+      clientId: 'rainbow-butterflies',
+      redirectUri: 'https://rainbowbutterflies.org/auth/callback',
+      verifier,
+      now,
+    },
+  ),
+  { ok: false, reason: 'consumed' },
+)
+
+assert.deepEqual(
+  evaluateAuthorizationCodeExchange(
+    { ...record, expiresAt: new Date('2026-08-30T05:29:59.000Z') },
+    {
+      clientId: 'rainbow-butterflies',
+      redirectUri: 'https://rainbowbutterflies.org/auth/callback',
+      verifier,
+      now,
+    },
+  ),
+  { ok: false, reason: 'expired' },
+)
+
+assert.deepEqual(
+  evaluateAuthorizationCodeExchange(record, {
+    clientId: 'other-client',
+    redirectUri: 'https://rainbowbutterflies.org/auth/callback',
+    verifier,
+    now,
+  }),
+  { ok: false, reason: 'client' },
+)
+
+assert.deepEqual(
+  evaluateAuthorizationCodeExchange(record, {
+    clientId: 'rainbow-butterflies',
+    redirectUri: 'https://rainbowbutterflies.org/auth/other',
+    verifier,
+    now,
+  }),
+  { ok: false, reason: 'redirect' },
+)
+
+assert.deepEqual(
+  evaluateAuthorizationCodeExchange(record, {
+    clientId: 'rainbow-butterflies',
+    redirectUri: 'https://rainbowbutterflies.org/auth/callback',
+    verifier: `${verifier.slice(0, -1)}A`,
+    now,
+  }),
+  { ok: false, reason: 'pkce' },
+)
+
+console.log('First-party SSO contract OK')

--- a/utils/scripts/verifyFirstPartySso.test.ts
+++ b/utils/scripts/verifyFirstPartySso.test.ts
@@ -83,6 +83,20 @@ assert.deepEqual(
   { ok: true, userId: 42 },
 )
 
+// The exchange request has no user-id field. Even if a caller smuggles one
+// into an untyped object, the decision is bound to the locked grant's userId.
+const crossUserAttempt = {
+  clientId: 'rainbow-butterflies',
+  redirectUri: 'https://rainbowbutterflies.org/auth/callback',
+  verifier,
+  now,
+  userId: 99,
+}
+assert.deepEqual(evaluateAuthorizationCodeExchange(record, crossUserAttempt), {
+  ok: true,
+  userId: 42,
+})
+
 assert.deepEqual(
   evaluateAuthorizationCodeExchange(
     { ...record, consumedAt: new Date('2026-08-30T05:29:00.000Z') },


### PR DESCRIPTION
## What this builds

- adds a first-party authorization-code flow for trusted Kind Robots-powered sites, starting with Rainbow Butterflies
- validates exact registered redirect URIs and high-entropy state values before any redirect occurs
- uses PKCE S256 and two-minute random authorization codes stored only as SHA-256 hashes
- makes authorization codes single-use with a transactional row lock and consumed marker, so replay races fail closed
- derives the authorizing user only from the Kind Robots `kind-session` cookie and never accepts a caller-supplied user id
- returns only minimum identity (`id`, `username`) from the server-to-server exchange; no password, password hash, API key, agent credential, or normal Kind Robots JWT crosses the boundary
- safely resumes the authorization request through `/login` using a same-origin-only `returnTo`
- adds migration, documentation, contract tests, and a focused `verify` workflow

## Security cases covered

- unregistered/open redirect targets are rejected locally
- malformed/short state and PKCE values fail closed
- consumed and expired grants are rejected
- client and redirect substitution are rejected
- PKCE verifier mismatch is rejected
- exchange identity comes from the locked grant record, not exchange input

No production secrets, DNS, account creation, billing, or public-domain activation are changed here.

Conductor: `rainbow-butterflies/t-017`.