### PR TITLE
interface-vision/t-104: adopt kr-panel-muted for dashed empty-state panels

### DIFF
--- a/components/dreams/dream-art-chooser.vue
+++ b/components/dreams/dream-art-chooser.vue
@@ -164,7 +164,7 @@
 
       <div
         v-if="!visibleImages.length"
-        class="col-span-full flex min-h-40 flex-col items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-200 p-6 text-center text-sm text-base-content/60"
+        class="kr-panel-muted col-span-full flex min-h-40 flex-col items-center justify-center border-dashed text-center text-sm text-base-content/60"
       >
         <Icon name="kind-icon:image" class="h-10 w-10 text-primary/60" />
         <p class="mt-2 font-bold">No art found for this filter.</p>

--- a/components/lora/lora-discover.vue
+++ b/components/lora/lora-discover.vue
@@ -165,7 +165,7 @@
 
     <div
       v-if="!loading && !visibleCards.length"
-      class="rounded-2xl border border-dashed border-base-300 bg-base-200 p-6 text-center"
+      class="kr-panel-muted border-dashed text-center"
     >
       <p class="font-bold">No results.</p>
       <p class="text-sm text-base-content/60">

--- a/components/servers/checkpoint-gallery.vue
+++ b/components/servers/checkpoint-gallery.vue
@@ -138,9 +138,7 @@
       </template>
 
       <template #empty>
-        <div
-          class="rounded-2xl border border-dashed border-base-300 bg-base-200 p-6 text-center"
-        >
+        <div class="kr-panel-muted border-dashed text-center">
           <p class="font-bold">No checkpoints found.</p>
           <p class="text-sm text-base-content/60">
             Try another filter or add a checkpoint.

--- a/components/servers/server-gallery.vue
+++ b/components/servers/server-gallery.vue
@@ -97,9 +97,7 @@
       </template>
 
       <template #empty>
-        <div
-          class="rounded-2xl border border-dashed border-base-300 bg-base-200 p-6 text-center"
-        >
+        <div class="kr-panel-muted border-dashed text-center">
           <Icon
             name="kind-icon:server-off"
             class="mx-auto mb-2 h-8 w-8 text-base-content/40"

--- a/components/themes/theme-gallery.vue
+++ b/components/themes/theme-gallery.vue
@@ -311,7 +311,7 @@
 
             <template #empty>
               <div
-                class="flex min-h-44 flex-col items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-200 p-6 text-center text-base-content/55"
+                class="kr-panel-muted flex min-h-44 flex-col items-center justify-center border-dashed text-center text-base-content/55"
               >
                 <Icon
                   name="kind-icon:palette"


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring)

### What changed / what I produced
- Opens a fifth mechanical pool: `kr-panel-muted` (`rounded-2xl border border-base-300 bg-base-200 p-6`), the recessed/muted-surface sibling of the `kr-panel-flat` dashed empty-state pool swept in the last two slices.
- 5 hand-rolled `rounded-2xl border border-dashed border-base-300 bg-base-200 p-6` empty-state panels now compose `kr-panel-muted border-dashed`, with every other utility class on the element preserved verbatim (flex/min-h/text-color/etc.).
- Files: `components/lora/lora-discover.vue`, `components/dreams/dream-art-chooser.vue`, `components/themes/theme-gallery.vue`, `components/servers/server-gallery.vue`, `components/servers/checkpoint-gallery.vue`.
- No geometry or behavior change — `border-dashed` only overrides border-style and is independent of `kr-panel-muted`'s baked-in radius/border/background/padding.
- One incidental prettier fix (`server-gallery.vue`, `checkpoint-gallery.vue`) where the shortened class string now fits on one line — both were prettier-clean at baseline.

### How I verified
- `eslint` on all 5 changed files: 0 issues, matches baseline.
- `prettier --check`: `lora-discover.vue` reports pre-existing formatting drift, confirmed identical on `main` via `git stash` before this change — left untouched. The other 4 files are prettier-clean (2 needed a scoped `--write` after the substitution shortened their class line, applied and re-verified).
- `vue-tsc --noEmit` (via `npm run test`, repo-wide): clean, exit 0.
- `npm run test:layout-contract`: holds — 207-item baseline unchanged, 0 new violations.

### Stakes
reversible

### Flags for Reviewer
- Excluded a near-match in `theme-gallery.vue` line 195 (`rounded-2xl border border-dashed border-base-300 bg-base-200 p-4 ...`) — `p-4` instead of `kr-panel-muted`'s `p-6`, not byte-exact.
- Deliberately did not touch the much larger `border-{status}/40 bg-{status}/10 text-{status}` (`kr-note`) family surfaced by a broader grep this slice — every instance checked uses a different padding (`p-3`, dynamic ternary classes, etc.) than `kr-note`'s exact `rounded-2xl border p-4 text-sm font-semibold` base, so a mechanical substitution there would change padding/geometry. Flagging as a lead for whoever looks next, not a ready pool.

### Kaizen suggestion
The `kr-note` family above is worth a dedicated audit (not a mechanical sweep) to see whether the `p-3`/`p-4` split across ~50 files is intentional variation or drift — too much per-instance judgment for this recurring task's mechanical-substitution scope.

### Notes for reviewer
Mechanical, single-pattern substitution across 5 files; verified pre-existing lint/format issue does not block this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_018a4e21JYhwkSNUvdNDKeT3)_