### PR TITLE
refactor: reuse kr-panel on project front cards

### DIFF
--- a/components/conductor/project-front-page.vue
+++ b/components/conductor/project-front-page.vue
@@ -116,7 +116,7 @@
       <!-- Description -->
       <section
         v-if="view.description"
-        class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
+        class="kr-panel rounded-3xl p-5"
       >
         <p class="text-sm leading-relaxed text-base-content/80 sm:text-base">
           {{ view.description }}
@@ -134,7 +134,7 @@
         <article
           v-for="block in view.sections"
           :key="block.key"
-          class="flex flex-col gap-2 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
+          class="kr-panel flex flex-col gap-2 rounded-3xl p-5"
         >
           <div class="flex items-center gap-2">
             <span


### PR DESCRIPTION
Interface Vision t-104 slice 63.

Replaces two hand-rolled raised-surface declarations in the shared project front-page shell with `kr-panel`, preserving the existing `rounded-3xl` and `p-5` overrides. This is a styling-vocabulary dedupe only; layout and behavior are unchanged.

Session: `openai-scheduled-20260830T081530Z-t104-a6f2`