### PR TITLE
rainbow-butterflies/t-020: wire forum-thread.vue to the canonical forum API

### DIFF
--- a/components/user/forum-author-badge.vue
+++ b/components/user/forum-author-badge.vue
@@ -1,0 +1,44 @@
+<!-- /components/user/forum-author-badge.vue -->
+<!--
+  Renders a forum post's explicit authorship (server/utils/forumApi.ts's
+  serializeForumPost) — who actually wrote this, not just a display name.
+
+  AI_AGENT posts always retain the operator User (server/utils/forumApi.ts's
+  requireForumWriter connects both Bot and User on write) so accountability is
+  never lost even when a scoped agent credential posted on the Bot's behalf.
+-->
+<template>
+  <div
+    class="flex items-center gap-1.5 text-sm font-medium text-base-content"
+    :class="{ 'text-xs': small }"
+  >
+    <span v-if="author.kind === 'AI_AGENT'" title="AI agent">🤖</span>
+    <span v-else title="Human">👤</span>
+    <span>{{ author.displayName }}</span>
+    <span
+      v-if="author.kind === 'AI_AGENT' && author.user"
+      class="text-base-content/50 font-normal"
+    >
+      via {{ author.user.username }}
+    </span>
+  </div>
+</template>
+
+<script setup lang="ts">
+type ForumAuthor = {
+  kind: 'HUMAN' | 'AI_AGENT'
+  displayName: string
+  user: { id: number; username: string; avatarImage: string | null } | null
+  bot: {
+    id: number
+    name: string
+    slug: string
+    avatarImage: string | null
+  } | null
+}
+
+defineProps<{
+  author: ForumAuthor
+  small?: boolean
+}>()
+</script>

--- a/components/user/forum-thread.vue
+++ b/components/user/forum-thread.vue
@@ -1,99 +1,148 @@
 <!-- /components/content/forum/forum-thread.vue -->
 <template>
   <div class="kr-container max-w-4xl space-y-6 px-4 py-8">
+    <div v-if="loadError" class="kr-note kr-note-error">
+      {{ loadError }}
+    </div>
+
     <div class="flex flex-wrap justify-center gap-2 mb-6">
       <button
-        v-for="channel in allChannels"
-        :key="channel"
-        @click="toggleChannel(channel)"
+        v-for="channel in channels"
+        :key="channel.slug"
         class="btn btn-sm"
         :class="{
-          'btn-accent': visibleChannels.includes(channel),
-          'btn-outline': !visibleChannels.includes(channel),
+          'btn-accent': visibleChannels.includes(channel.slug),
+          'btn-outline': !visibleChannels.includes(channel.slug),
         }"
+        :title="channel.description"
+        @click="toggleChannel(channel.slug)"
       >
-        {{ formatChannel(channel) }}
+        {{ channel.label }}
       </button>
     </div>
 
-    <div v-for="channel in visibleChannels" :key="channel" class="space-y-4">
+    <div
+      v-for="channel in visibleChannelObjects"
+      :key="channel.slug"
+      class="space-y-4"
+    >
       <div class="flex justify-between items-center mt-8 mb-2">
         <h2 class="text-xl font-bold">
-          {{ formatChannel(channel) }}
+          {{ channel.label }}
         </h2>
         <button
-          class="btn btn-sm btn-primary"
           v-if="userStore.isLoggedIn"
-          @click="startNewThread(channel)"
+          class="btn btn-sm btn-primary"
+          @click="startNewThread(channel.slug)"
         >
           ➕ New Post
         </button>
       </div>
 
       <div
-        v-for="thread in threadsByChannel(channel)"
+        v-if="userStore.isLoggedIn && composeChannel === channel.slug"
+        class="bg-base-200 p-4 rounded-xl shadow"
+      >
+        <h3 class="text-lg font-bold mb-2">
+          🧵 New Thread in {{ channel.label }}
+        </h3>
+        <input
+          v-model="newThreadTitle"
+          type="text"
+          class="input input-bordered w-full mb-2"
+          placeholder="Title"
+          maxlength="255"
+        />
+        <textarea
+          v-model="newThreadContent"
+          class="textarea textarea-bordered w-full mb-2"
+          rows="3"
+          placeholder="What's on your mind?"
+        />
+        <div class="flex gap-2">
+          <button
+            class="btn btn-primary"
+            :disabled="posting"
+            @click="postThread(channel.slug)"
+          >
+            Post
+          </button>
+          <button class="btn btn-outline" @click="cancelPost">Cancel</button>
+        </div>
+      </div>
+
+      <div
+        v-if="!threadsByChannel(channel.slug).length"
+        class="text-sm text-base-content/60"
+      >
+        No posts yet. Be the first to say something.
+      </div>
+
+      <div
+        v-for="thread in threadsByChannel(channel.slug)"
         :key="thread.id"
         class="bg-base-100 p-4 rounded-xl shadow space-y-2"
       >
         <div class="text-sm text-gray-400">
           {{ formatDate(thread.createdAt) }}
         </div>
-        <div class="font-semibold text-base-content">{{ thread.sender }}:</div>
+        <forum-author-badge :author="thread.author" />
+        <div v-if="thread.title" class="font-semibold text-base-content">
+          {{ thread.title }}
+        </div>
         <div class="whitespace-pre-line">{{ thread.content }}</div>
 
         <div class="flex justify-between items-center">
           <button
             class="btn btn-sm btn-outline mt-2"
-            @click="replyTo(thread.id)"
+            @click="toggleThread(thread.id)"
           >
-            💬 Reply
+            💬 {{ expandedThreadId === thread.id ? 'Hide' : 'Reply' }}
           </button>
 
-          <span
-            v-if="getReplies(thread.id).length"
-            class="text-sm text-accent-content"
-          >
-            {{ getReplies(thread.id).length }} repl{{
-              getReplies(thread.id).length === 1 ? 'y' : 'ies'
+          <span v-if="thread.replyCount" class="text-sm text-accent-content">
+            {{ thread.replyCount }} repl{{
+              thread.replyCount === 1 ? 'y' : 'ies'
             }}
           </span>
         </div>
 
         <div
-          v-if="getReplies(thread.id).length"
+          v-if="expandedThreadId === thread.id"
           class="pl-4 border-l-2 border-base-300 space-y-3 mt-3"
         >
+          <div v-if="repliesLoading" class="text-sm text-base-content/60">
+            Loading replies…
+          </div>
+
           <div
-            v-for="reply in getReplies(thread.id)"
+            v-for="reply in expandedReplies[thread.id] ?? []"
             :key="reply.id"
             class="bg-base-200 p-3 rounded"
           >
             <div class="text-xs text-gray-400">
               {{ formatDate(reply.createdAt) }}
             </div>
-            <div class="font-medium">{{ reply.sender }}</div>
+            <forum-author-badge :author="reply.author" small />
             <div class="whitespace-pre-line">{{ reply.content }}</div>
           </div>
-        </div>
-      </div>
-    </div>
 
-    <div
-      v-if="userStore.isLoggedIn && composeChannel"
-      class="bg-base-200 p-4 rounded-xl shadow mt-8"
-    >
-      <h2 class="text-lg font-bold mb-2">
-        🧵 New Thread in {{ formatChannel(composeChannel) }}
-      </h2>
-      <textarea
-        v-model="newThreadContent"
-        class="textarea textarea-bordered w-full mb-2"
-        rows="3"
-        placeholder="What’s on your mind?"
-      />
-      <div class="flex gap-2">
-        <button class="btn btn-primary" @click="postThread">Post</button>
-        <button class="btn btn-outline" @click="cancelPost">Cancel</button>
+          <div v-if="userStore.isLoggedIn" class="space-y-2">
+            <textarea
+              v-model="replyDrafts[thread.id]"
+              class="textarea textarea-bordered w-full"
+              rows="2"
+              placeholder="Write a reply…"
+            />
+            <button
+              class="btn btn-sm btn-primary"
+              :disabled="posting || !replyDrafts[thread.id]?.trim()"
+              @click="postReply(thread.id)"
+            >
+              Reply
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -101,82 +150,192 @@
 
 <script setup lang="ts">
 // /components/content/forum/forum-thread.vue
-import { ref } from 'vue'
-import { useChatStore } from '@/stores/chatStore'
+//
+// Talks directly to the canonical /api/v1/forum/* endpoints (server/utils/forumApi.ts)
+// so both authenticated humans and scoped external agents post through the same API
+// and the same explicit authorship record (author.kind: 'HUMAN' | 'AI_AGENT', with the
+// operator User always retained on an agent-authored post for accountability).
+//
+// rainbow-butterflies/t-020: composing, replies, and authorship rendering. The task's
+// note also names HUMAN_AI and SYSTEM as authorship kinds; the API and schema only
+// distinguish HUMAN/AI_AGENT today (there's no "disclosed AI assistance" flag or
+// system-post concept yet), so those two are left as a follow-up pending a product
+// decision on what triggers them, rather than invented here.
+import { computed, onMounted, reactive, ref } from 'vue'
+import { performFetch } from '@/stores/utils'
 import { useUserStore } from '@/stores/userStore'
+import type { ForumChannel } from '~/utils/forumApiContract'
 
-const chatStore = useChatStore()
+type ForumAuthor = {
+  kind: 'HUMAN' | 'AI_AGENT'
+  displayName: string
+  user: { id: number; username: string; avatarImage: string | null } | null
+  bot: {
+    id: number
+    name: string
+    slug: string
+    avatarImage: string | null
+  } | null
+}
+
+type ForumPost = {
+  id: number
+  createdAt: string
+  updatedAt: string
+  threadId: number
+  parentId: number | null
+  channel: string
+  title: string | null
+  content: string
+  isMature: boolean
+  author: ForumAuthor
+}
+
+type ForumThreadSummary = ForumPost & {
+  replyCount: number
+  lastActivityAt: string
+}
+
 const userStore = useUserStore()
 
-const allChannels = ['share', 'introductions', 'news', 'activism'] as const
-type ForumChannel = (typeof allChannels)[number]
-
-const visibleChannels = ref<ForumChannel[]>([...allChannels])
-const composeChannel = ref<ForumChannel | null>(null)
+const channels = ref<ForumChannel[]>([])
+const visibleChannels = ref<string[]>([])
+const threads = ref<ForumThreadSummary[]>([])
+const expandedThreadId = ref<number | null>(null)
+const expandedReplies = reactive<Record<number, ForumPost[]>>({})
+const repliesLoading = ref(false)
+const composeChannel = ref<string | null>(null)
+const newThreadTitle = ref('')
 const newThreadContent = ref('')
-const replyOriginId = ref<number | null>(null)
+const replyDrafts = reactive<Record<number, string>>({})
+const posting = ref(false)
+const loadError = ref('')
 
-function toggleChannel(channel: ForumChannel) {
-  const index = visibleChannels.value.indexOf(channel)
+const visibleChannelObjects = computed(() =>
+  channels.value.filter((channel) =>
+    visibleChannels.value.includes(channel.slug),
+  ),
+)
+
+function toggleChannel(slug: string) {
+  const index = visibleChannels.value.indexOf(slug)
   if (index > -1) visibleChannels.value.splice(index, 1)
-  else visibleChannels.value.push(channel)
+  else visibleChannels.value.push(slug)
 }
 
-const threadsByChannel = (channel: ForumChannel) => {
-  const uid = userStore.user?.id ?? null
-  const showMature = userStore.showMature
-
-  return chatStore.chats.filter((chat) => {
-    const isRoot = chat.originId == null
-    const chatChannel = (chat.channel ?? '').trim()
-    const isVisibleChannel = chatChannel === channel
-
-    const isPublic = chat.isPublic ?? false
-    const isOwner = uid != null && chat.userId === uid
-    const canSee = isPublic || isOwner
-
-    const isMature = chat.isMature ?? false
-    const matureOk = !isMature || showMature
-
-    return isRoot && isVisibleChannel && canSee && matureOk
-  })
+function threadsByChannel(slug: string) {
+  return threads.value.filter((thread) => thread.channel === slug)
 }
 
-const getReplies = (originId: number) => {
-  return chatStore.chats.filter((chat) => chat.originId === originId)
+async function loadChannels() {
+  const res = await performFetch<ForumChannel[]>('/api/v1/forum/channels')
+  if (res.success && res.data) {
+    channels.value = res.data
+    visibleChannels.value = res.data.map((channel) => channel.slug)
+  } else {
+    loadError.value = res.message || 'Could not load forum channels.'
+  }
 }
 
-function startNewThread(channel: ForumChannel) {
-  composeChannel.value = channel
+async function loadThreads() {
+  const res = await performFetch<ForumThreadSummary[]>('/api/v1/forum/threads')
+  if (res.success && res.data) {
+    threads.value = res.data
+  } else {
+    loadError.value = res.message || 'Could not load forum threads.'
+  }
+}
+
+function startNewThread(slug: string) {
+  composeChannel.value = slug
+  newThreadTitle.value = ''
   newThreadContent.value = ''
 }
 
 function cancelPost() {
   composeChannel.value = null
+  newThreadTitle.value = ''
   newThreadContent.value = ''
 }
 
-async function postThread() {
+async function postThread(slug: string) {
+  const title = newThreadTitle.value.trim()
   const content = newThreadContent.value.trim()
-  const channel = composeChannel.value
-  if (!content || !channel) return
+  if (!title || !content) return
 
-  await chatStore.addChat({
-    content,
-    type: 'ToForum',
-    channel,
-    sender: userStore.user?.designerName || 'Anonymous',
-    userId: userStore.user?.id || 0,
-    originId: null,
-    recipientId: null,
-    characterId: null,
-  })
+  posting.value = true
+  try {
+    const res = await performFetch<ForumPost>('/api/v1/forum/threads', {
+      method: 'POST',
+      body: JSON.stringify({ channel: slug, title, content }),
+    })
 
-  cancelPost()
+    if (res.success && res.data) {
+      threads.value = [
+        { ...res.data, replyCount: 0, lastActivityAt: res.data.createdAt },
+        ...threads.value,
+      ]
+      cancelPost()
+    } else {
+      loadError.value = res.message || 'Could not post that thread.'
+    }
+  } finally {
+    posting.value = false
+  }
 }
 
-function replyTo(id: number) {
-  replyOriginId.value = id
+async function toggleThread(threadId: number) {
+  if (expandedThreadId.value === threadId) {
+    expandedThreadId.value = null
+    return
+  }
+
+  expandedThreadId.value = threadId
+  if (expandedReplies[threadId]) return
+
+  repliesLoading.value = true
+  try {
+    const res = await performFetch<{ thread: ForumPost; replies: ForumPost[] }>(
+      `/api/v1/forum/threads/${threadId}`,
+    )
+    if (res.success && res.data) {
+      expandedReplies[threadId] = res.data.replies
+    } else {
+      loadError.value = res.message || 'Could not load that thread.'
+    }
+  } finally {
+    repliesLoading.value = false
+  }
+}
+
+async function postReply(threadId: number) {
+  const content = replyDrafts[threadId]?.trim()
+  if (!content) return
+
+  posting.value = true
+  try {
+    const res = await performFetch<ForumPost>(
+      `/api/v1/forum/threads/${threadId}/replies`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ content }),
+      },
+    )
+
+    if (res.success && res.data) {
+      expandedReplies[threadId] = [
+        ...(expandedReplies[threadId] ?? []),
+        res.data,
+      ]
+      replyDrafts[threadId] = ''
+      const thread = threads.value.find((t) => t.id === threadId)
+      if (thread) thread.replyCount += 1
+    } else {
+      loadError.value = res.message || 'Could not post that reply.'
+    }
+  } finally {
+    posting.value = false
+  }
 }
 
 function formatDate(date: Date | string) {
@@ -187,16 +346,7 @@ function formatDate(date: Date | string) {
   })}`
 }
 
-function formatChannel(channel: ForumChannel) {
-  switch (channel) {
-    case 'share':
-      return '📸 Share Work'
-    case 'introductions':
-      return '👋 Introductions'
-    case 'news':
-      return '📰 News'
-    case 'activism':
-      return '✊ Activism'
-  }
-}
+onMounted(async () => {
+  await Promise.all([loadChannels(), loadThreads()])
+})
 </script>


### PR DESCRIPTION
### Task
rainbow-butterflies/t-020: Add forum composing, replies, and explicit authorship provenance (kind: software)

### What changed / what I produced
`components/user/forum-thread.vue` was talking to the legacy `chatStore`/`Chat` model directly — a hardcoded channel list (`share/introductions/news/activism`) that didn't match the real channel registry, thread posting with no `title` (the API requires one), and a `replyTo()` handler that only set local state with nothing consuming it (replying was entirely unimplemented). It never touched the canonical `/api/v1/forum/*` endpoints (`server/utils/forumApi.ts`) that already support scoped external agents posting through the same API with explicit authorship.

- Channels, threads, and thread detail (with replies) now come from the live API (`GET /api/v1/forum/channels`, `GET /api/v1/forum/threads`, `GET /api/v1/forum/threads/:id`) instead of a stale hardcoded list.
- New-thread composing now collects the `title` the API requires.
- **Reply composing is implemented for the first time**: expanding a thread lazily loads its replies (`GET /api/v1/forum/threads/:id`) and offers a reply box that posts through `POST /api/v1/forum/threads/:id/replies`.
- Explicit authorship is now rendered via a new `components/user/forum-author-badge.vue`, using the API's existing `author.kind` (`'HUMAN' | 'AI_AGENT'`) plus the operator `User` that `forumApi.ts`'s `requireForumWriter` always retains on an agent-authored post, so accountability is visible even when a Bot posted.

### How I verified
- `npx eslint` — clean (fixed 4 pre-existing-pattern attribute-order warnings with `--fix`).
- `npx prettier --check` — clean (both files are new/rewritten, no pre-existing drift to preserve).
- `npx vue-tsc --noEmit` (repo-wide) — clean.
- `npm run test:layout-contract` — holds; 207 baseline violations unchanged, 0 new.
- Read `server/utils/authGuard.ts` to confirm the client's existing `performFetch` helper (`stores/utils.ts`) already attaches the logged-in user's JWT as a Bearer token to every request, so no new auth plumbing was needed for a human's session to satisfy `requireForumWriter`'s `forum:write` scope check.
- No existing Cypress coverage references this component (`grep` across `cypress/`), so nothing else exercises the legacy behavior being replaced.

### Stakes
reversible

### Flags for Reviewer
- **Out of scope this slice, flagged rather than guessed at:** the task's note also names `HUMAN_AI` and `SYSTEM` as authorship kinds. Neither the schema nor `forumApi.ts`'s `serializeForumPost` has a concept of "disclosed AI assistance" or a system-generated post today — inventing the trigger condition for either would be a product decision, not an implementation detail. `author.kind` today only ever emits `HUMAN` or `AI_AGENT`, matching what's actually persisted.
- No live smoke test against a running dev server/database was possible in this sandbox (no local DB) — verification is typecheck/lint/layout-contract plus reading the auth chain, not an end-to-end request.

### Kaizen suggestion
A live smoke test (create a thread, reply, as both a plain user and a scoped agent credential) would close the verification gap flagged above — worth a follow-up task once a session has DB access to actually exercise it.

### Notes for reviewer
Self-merging in the same session per AGENTS.md's standing merge-when-green authorization (`stakes: reversible`, software kind, not human-gated).

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyKPP6oe83ST7eS7chKhE5)_