### PR TITLE
Make Rainbow agent credentials self-service

### DIFF
--- a/.github/workflows/agent-onboarding-contract.yml
+++ b/.github/workflows/agent-onboarding-contract.yml
@@ -26,7 +26,12 @@ permissions:
 
 jobs:
   agent-onboarding-contract:
-    name: Agent onboarding contract
+    # Kind Robots' main ruleset requires a GitHub Actions check named exactly
+    # "verify". The original producer is path-filtered to forum API files, so
+    # credential-only PRs otherwise never emit that required check. Keep this
+    # onboarding slice mergeable without weakening the contract by running both
+    # the focused onboarding verifier and the canonical forum API verifier here.
+    name: verify
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -44,3 +49,6 @@ jobs:
 
       - name: Verify self-service agent onboarding contract
         run: npx tsx utils/scripts/verifyAgentOnboarding.test.ts
+
+      - name: Verify canonical forum API contract
+        run: npx tsx utils/scripts/verifyForumApi.test.ts

--- a/.github/workflows/agent-onboarding-contract.yml
+++ b/.github/workflows/agent-onboarding-contract.yml
@@ -1,0 +1,46 @@
+name: Agent Onboarding Contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'components/user/agent-credentials-panel.vue'
+      - 'stores/agentCredentialStore.ts'
+      - 'server/api/v1/profile.get.ts'
+      - 'server/api/agent-credentials/**'
+      - 'utils/scripts/verifyAgentOnboarding.test.ts'
+      - '.github/workflows/agent-onboarding-contract.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'components/user/agent-credentials-panel.vue'
+      - 'stores/agentCredentialStore.ts'
+      - 'server/api/v1/profile.get.ts'
+      - 'server/api/agent-credentials/**'
+      - 'utils/scripts/verifyAgentOnboarding.test.ts'
+      - '.github/workflows/agent-onboarding-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  agent-onboarding-contract:
+    name: Agent onboarding contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: npm install --include=optional
+
+      - name: Verify self-service agent onboarding contract
+        run: npx tsx utils/scripts/verifyAgentOnboarding.test.ts

--- a/components/user/agent-credentials-panel.vue
+++ b/components/user/agent-credentials-panel.vue
@@ -93,7 +93,7 @@
           </span>
         </div>
 
-        <dl class="mt-3 grid grid-cols-1 gap-1 text-xs text-base-content/60 sm:grid-cols-2">
+        <dl class="mt-3 grid grid-cols-1 gap-1 text-xs text-base-content/60">
           <div>
             <dt class="font-bold text-base-content/75">Created</dt>
             <dd>{{ formatDate(credential.createdAt) }}</dd>
@@ -230,7 +230,7 @@
       </p>
       <pre class="mt-2 overflow-x-auto rounded-lg bg-base-100 p-2 text-[0.68rem]"><code>export RAINBOW_BUTTERFLIES_API_KEY='paste-into-your-local-secret-environment'
 curl -H "Authorization: Bearer $RAINBOW_BUTTERFLIES_API_KEY" https://kindrobots.org/api/v1/profile
-curl -H "Authorization: Bearer $RAINBOW_BUTTERFLIES_API_KEY" https://kindrobots.org/api/v1/forum/channels</code></pre>
+curl -H "Authorization: Bearer $RAINBOW_BUTTERFLIES_API_KEY" 'https://kindrobots.org/api/v1/forum/threads?channel=introductions&amp;limit=1'</code></pre>
     </details>
   </div>
 </template>

--- a/components/user/agent-credentials-panel.vue
+++ b/components/user/agent-credentials-panel.vue
@@ -1,33 +1,25 @@
-<!-- /components/user/agent-credentials-panel.vue -->
-<!--
-  rainbow-butterflies/t-015: management UI for scoped per-agent credentials
-  (server/utils/agentCredentials.ts, server/api/agent-credentials/*). Replaces
-  the legacy whole-user apiKey for machine/agent callers -- a credential is
-  shown exactly once at creation, then only ever shown as its keyPrefix.
--->
 <template>
-  <div class="kr-panel-flat p-4">
+  <div id="agent-credentials" class="kr-panel-flat p-4">
     <div class="mb-2 flex items-center gap-2">
       <Icon name="kind-icon:key" class="h-5 w-5 text-primary" />
       <span class="text-sm font-black">Agent credentials</span>
     </div>
 
     <p class="mb-3 text-xs text-base-content/55">
-      Scoped tokens for bots/agents to act on your behalf without sharing your
-      full account. Each secret is shown once, right after you create it -- copy
-      it now.
+      Give one owned Bot a narrow token instead of sharing your whole account.
+      Forum agents normally need only profile:read, forum:read, and forum:write.
     </p>
 
     <div v-if="justCreatedToken" class="mb-3 kr-note kr-note-success">
-      <p class="font-bold">
-        New credential created -- copy this token now, it won't be shown again:
+      <p class="font-bold">Copy this token now. It will not be shown again.</p>
+      <p class="mt-1 text-xs">
+        Put it in the agent's environment or secret store, never in prompts,
+        URLs, screenshots, analytics, or committed source.
       </p>
       <div class="mt-2 flex items-center gap-2">
         <code
-          class="min-w-0 flex-1 truncate rounded-lg bg-base-100 px-2 py-1 text-xs"
-        >
-          {{ justCreatedToken }}
-        </code>
+          class="min-w-0 flex-1 overflow-x-auto rounded-lg bg-base-100 px-2 py-1 text-xs"
+        >{{ justCreatedToken }}</code>
         <button
           type="button"
           class="btn btn-ghost btn-xs rounded-lg"
@@ -36,13 +28,28 @@
           {{ copied ? 'Copied' : 'Copy' }}
         </button>
       </div>
-      <button
-        type="button"
-        class="btn btn-ghost btn-xs mt-2 rounded-lg"
-        @click="justCreatedToken = null"
-      >
-        Done
-      </button>
+      <div class="mt-2 flex flex-wrap gap-2">
+        <button
+          v-if="replacementSourceId"
+          type="button"
+          class="btn btn-error btn-outline btn-xs rounded-lg"
+          :disabled="revokingId === replacementSourceId"
+          @click="revokeReplacementSource"
+        >
+          Revoke old key
+        </button>
+        <button
+          type="button"
+          class="btn btn-ghost btn-xs rounded-lg"
+          @click="dismissCreatedToken"
+        >
+          Done
+        </button>
+      </div>
+      <p v-if="replacementSourceId" class="mt-2 text-xs">
+        This is a replacement key. Update the agent first, confirm the new key
+        works, then revoke the old one.
+      </p>
     </div>
 
     <div v-if="errorMessage" class="mb-3 kr-note kr-note-error">
@@ -56,186 +63,311 @@
         No agent credentials yet.
       </p>
 
-      <div
+      <article
         v-for="credential in credentials"
         :key="credential.id"
-        class="flex items-center justify-between gap-2 rounded-xl bg-base-200 p-2"
+        class="rounded-xl bg-base-200 p-3"
       >
-        <div class="min-w-0">
-          <p class="truncate text-sm font-bold">{{ credential.label }}</p>
-          <p class="truncate text-xs text-base-content/55">
-            {{ credential.keyPrefix }}… ·
-            {{ credential.scopes.join(', ') || 'no scopes' }}
-            <span v-if="credential.revokedAt" class="text-error">
-              · revoked</span
-            >
-          </p>
+        <div class="flex items-start justify-between gap-3">
+          <div class="min-w-0">
+            <p class="truncate text-sm font-bold">{{ credential.label }}</p>
+            <p class="truncate text-xs text-base-content/55">
+              {{ botLabel(credential.botId) }} · {{ credential.keyPrefix }}…
+            </p>
+          </div>
+          <span
+            class="badge badge-sm shrink-0"
+            :class="credential.revokedAt ? 'badge-error' : credentialExpired(credential) ? 'badge-warning' : 'badge-success'"
+          >
+            {{ credentialStatus(credential) }}
+          </span>
         </div>
 
-        <button
-          v-if="!credential.revokedAt"
-          type="button"
-          class="btn btn-ghost btn-xs shrink-0 rounded-lg text-error"
-          :disabled="revokingId === credential.id"
-          @click="revoke(credential.id)"
-        >
-          Revoke
-        </button>
-      </div>
+        <div class="mt-2 flex flex-wrap gap-1">
+          <span
+            v-for="scope in credential.scopes"
+            :key="scope"
+            class="badge badge-ghost badge-sm font-mono text-[0.65rem]"
+          >
+            {{ scope }}
+          </span>
+        </div>
+
+        <dl class="mt-3 grid grid-cols-1 gap-1 text-xs text-base-content/60 sm:grid-cols-2">
+          <div>
+            <dt class="font-bold text-base-content/75">Created</dt>
+            <dd>{{ formatDate(credential.createdAt) }}</dd>
+          </div>
+          <div>
+            <dt class="font-bold text-base-content/75">Last used</dt>
+            <dd>{{ credential.lastUsedAt ? formatDate(credential.lastUsedAt) : 'Never' }}</dd>
+          </div>
+          <div>
+            <dt class="font-bold text-base-content/75">Expires</dt>
+            <dd>{{ credential.expiresAt ? formatDate(credential.expiresAt) : 'No expiry' }}</dd>
+          </div>
+          <div v-if="credential.revokedAt">
+            <dt class="font-bold text-base-content/75">Revoked</dt>
+            <dd>{{ formatDate(credential.revokedAt) }}</dd>
+          </div>
+        </dl>
+
+        <div v-if="!credential.revokedAt" class="mt-3 flex flex-wrap gap-2">
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs rounded-lg"
+            @click="prepareReplacement(credential)"
+          >
+            Replace
+          </button>
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs rounded-lg text-error"
+            :disabled="revokingId === credential.id"
+            @click="credentialStore.revoke(credential.id)"
+          >
+            {{ revokingId === credential.id ? 'Revoking…' : 'Revoke' }}
+          </button>
+        </div>
+      </article>
     </div>
 
     <form
-      class="mt-4 flex flex-col gap-2 border-t border-base-300 pt-3"
-      @submit.prevent="create"
+      class="mt-4 flex flex-col gap-3 border-t border-base-300 pt-3"
+      @submit.prevent="createCredential"
     >
-      <p
-        class="text-xs font-black uppercase tracking-widest text-base-content/50"
-      >
-        New credential
-      </p>
+      <div class="flex items-center justify-between gap-3">
+        <p class="text-xs font-black uppercase tracking-widest text-base-content/50">
+          {{ replacingCredentialId ? 'Replacement credential' : 'New credential' }}
+        </p>
+        <button
+          v-if="replacingCredentialId"
+          type="button"
+          class="btn btn-ghost btn-xs rounded-lg"
+          @click="resetForm"
+        >
+          Cancel replacement
+        </button>
+      </div>
 
       <input
         v-model="newLabel"
         type="text"
-        placeholder="Label (e.g. Forum bot)"
+        placeholder="Label, e.g. Rainbow research agent"
         class="input input-bordered input-sm w-full rounded-xl bg-base-200"
         required
       />
 
-      <div class="flex flex-wrap gap-3">
-        <label
-          v-for="scope in scopeOptions"
-          :key="scope"
-          class="flex items-center gap-1.5 text-xs"
+      <label class="form-control w-full">
+        <span class="label-text mb-1 text-xs font-bold">Bot identity</span>
+        <select
+          v-model.number="newBotId"
+          class="select select-bordered select-sm w-full rounded-xl bg-base-200"
+          required
         >
-          <input
-            v-model="newScopes"
-            type="checkbox"
-            :value="scope"
-            class="checkbox checkbox-xs rounded"
-          />
-          {{ scope }}
-        </label>
-      </div>
+          <option :value="0" disabled>Choose one of your Bots</option>
+          <option v-for="bot in ownedBots" :key="bot.id" :value="bot.id">
+            {{ bot.name || `Bot #${bot.id}` }}
+          </option>
+        </select>
+      </label>
+
+      <p v-if="!ownedBots.length" class="kr-note kr-note-warning text-xs">
+        A forum-writing agent key must be bound to a Bot you own.
+        <NuxtLink to="/bots" class="link font-bold">Create a Bot first.</NuxtLink>
+      </p>
+      <NuxtLink v-else to="/bots" class="link text-xs font-bold">
+        Create or edit Bot identities
+      </NuxtLink>
+
+      <fieldset>
+        <legend class="mb-2 text-xs font-bold">Scopes</legend>
+        <div class="flex flex-wrap gap-3">
+          <label
+            v-for="scope in scopeOptions"
+            :key="scope"
+            class="flex items-center gap-1.5 text-xs"
+          >
+            <input
+              v-model="newScopes"
+              type="checkbox"
+              :value="scope"
+              class="checkbox checkbox-xs rounded"
+            />
+            {{ scope }}
+          </label>
+        </div>
+      </fieldset>
+
+      <label class="form-control w-full">
+        <span class="label-text mb-1 text-xs font-bold">Expiry</span>
+        <select
+          v-model="expiryChoice"
+          class="select select-bordered select-sm w-full rounded-xl bg-base-200"
+        >
+          <option value="30">30 days</option>
+          <option value="90">90 days</option>
+          <option value="365">1 year</option>
+          <option value="never">No expiry</option>
+        </select>
+      </label>
 
       <button
         type="submit"
-        class="btn btn-primary btn-sm mt-1 w-full rounded-xl"
-        :disabled="isCreating || !newLabel.trim()"
+        class="btn btn-primary btn-sm w-full rounded-xl"
+        :disabled="isCreating || !newLabel.trim() || !newBotId || !newScopes.length"
       >
         <span v-if="isCreating" class="loading loading-spinner loading-xs" />
-        Create credential
+        {{ replacingCredentialId ? 'Create replacement key' : 'Create credential' }}
       </button>
     </form>
+
+    <details class="mt-4 rounded-xl border border-base-300 bg-base-200 p-3 text-xs">
+      <summary class="cursor-pointer font-bold">Test a key without exposing it</summary>
+      <p class="mt-2 text-base-content/60">
+        Store the token in an environment variable, then make harmless read-only requests.
+        These examples contain no real secret.
+      </p>
+      <pre class="mt-2 overflow-x-auto rounded-lg bg-base-100 p-2 text-[0.68rem]"><code>export RAINBOW_BUTTERFLIES_API_KEY='paste-into-your-local-secret-environment'
+curl -H "Authorization: Bearer $RAINBOW_BUTTERFLIES_API_KEY" https://kindrobots.org/api/v1/profile
+curl -H "Authorization: Bearer $RAINBOW_BUTTERFLIES_API_KEY" https://kindrobots.org/api/v1/forum/channels</code></pre>
+    </details>
   </div>
 </template>
 
 <script setup lang="ts">
+import { storeToRefs } from 'pinia'
 import { onMounted, ref } from 'vue'
-import { performFetch } from '@/stores/utils'
+import { useAgentCredentialStore, type AgentCredentialRow } from '@/stores/agentCredentialStore'
+import { useBotStore } from '@/stores/botStore'
 import {
   AGENT_CREDENTIAL_SCOPES,
   DEFAULT_FORUM_AGENT_SCOPES,
   type AgentCredentialScope,
 } from '@/utils/agentCredentialScopes'
 
-type CredentialRow = {
-  id: number
-  label: string
-  keyPrefix: string
-  scopes: AgentCredentialScope[]
-  revokedAt: string | null
-}
+const credentialStore = useAgentCredentialStore()
+const botStore = useBotStore()
+
+const {
+  credentials,
+  isLoading,
+  isCreating,
+  revokingId,
+  errorMessage,
+  justCreatedToken,
+  replacementSourceId,
+} = storeToRefs(credentialStore)
+const { ownedBots } = storeToRefs(botStore)
 
 const scopeOptions = AGENT_CREDENTIAL_SCOPES
-
-const credentials = ref<CredentialRow[]>([])
-const isLoading = ref(false)
-const isCreating = ref(false)
-const revokingId = ref<number | null>(null)
-const errorMessage = ref('')
-const justCreatedToken = ref<string | null>(null)
+const newLabel = ref('')
+const newBotId = ref(0)
+const newScopes = ref<AgentCredentialScope[]>([...DEFAULT_FORUM_AGENT_SCOPES])
+const expiryChoice = ref<'30' | '90' | '365' | 'never'>('90')
+const replacingCredentialId = ref<number | null>(null)
 const copied = ref(false)
 
-const newLabel = ref('')
-const newScopes = ref<AgentCredentialScope[]>([...DEFAULT_FORUM_AGENT_SCOPES])
+function expiryIso(): string | null {
+  if (expiryChoice.value === 'never') return null
 
-async function load() {
-  isLoading.value = true
-  errorMessage.value = ''
-  try {
-    const res = await performFetch<{ credentials: CredentialRow[] }>(
-      '/api/agent-credentials',
-    )
-    credentials.value =
-      res.success && Array.isArray(res.data?.credentials)
-        ? res.data.credentials
-        : []
-    if (!res.success)
-      errorMessage.value = res.message || 'Failed to load credentials.'
-  } finally {
-    isLoading.value = false
-  }
+  const days = Number(expiryChoice.value)
+  const expiresAt = new Date(Date.now() + days * 24 * 60 * 60 * 1000)
+  return expiresAt.toISOString()
 }
 
-async function create() {
+function resetForm(): void {
+  newLabel.value = ''
+  newBotId.value = ownedBots.value[0]?.id ?? 0
+  newScopes.value = [...DEFAULT_FORUM_AGENT_SCOPES]
+  expiryChoice.value = '90'
+  replacingCredentialId.value = null
+}
+
+async function createCredential(): Promise<void> {
   const label = newLabel.value.trim()
-  if (!label) return
+  if (!label || !newBotId.value || !newScopes.value.length) return
 
-  isCreating.value = true
-  errorMessage.value = ''
-  justCreatedToken.value = null
   copied.value = false
+  const created = await credentialStore.create(
+    {
+      label,
+      botId: newBotId.value,
+      scopes: [...newScopes.value],
+      expiresAt: expiryIso(),
+    },
+    replacingCredentialId.value,
+  )
 
-  try {
-    const res = await performFetch<{
-      credential: CredentialRow
-      token: string
-    }>('/api/agent-credentials', {
-      method: 'POST',
-      body: JSON.stringify({ label, scopes: newScopes.value }),
-    })
-
-    if (res.success && res.data?.token) {
-      justCreatedToken.value = res.data.token
-      newLabel.value = ''
-      newScopes.value = [...DEFAULT_FORUM_AGENT_SCOPES]
-      await load()
-    } else {
-      errorMessage.value = res.message || 'Failed to create credential.'
-    }
-  } finally {
-    isCreating.value = false
-  }
+  if (created) resetForm()
 }
 
-async function revoke(id: number) {
-  revokingId.value = id
-  errorMessage.value = ''
-  try {
-    const res = await performFetch(`/api/agent-credentials/${id}`, {
-      method: 'DELETE',
-    })
-    if (res.success) {
-      await load()
-    } else {
-      errorMessage.value = res.message || 'Failed to revoke credential.'
-    }
-  } finally {
-    revokingId.value = null
-  }
+function prepareReplacement(credential: AgentCredentialRow): void {
+  replacingCredentialId.value = credential.id
+  newLabel.value = `${credential.label} replacement`
+  newBotId.value = credential.botId ?? 0
+  newScopes.value = [...credential.scopes]
+  expiryChoice.value = '90'
 }
 
-async function copyToken() {
+function botLabel(botId: number | null): string {
+  if (!botId) return 'Unbound credential'
+  const bot = ownedBots.value.find((entry) => entry.id === botId)
+  return bot?.name || `Bot #${botId}`
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return 'Unknown'
+  return new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date)
+}
+
+function credentialExpired(credential: AgentCredentialRow): boolean {
+  return Boolean(
+    credential.expiresAt && new Date(credential.expiresAt).getTime() < Date.now(),
+  )
+}
+
+function credentialStatus(credential: AgentCredentialRow): string {
+  if (credential.revokedAt) return 'Revoked'
+  if (credentialExpired(credential)) return 'Expired'
+  return 'Active'
+}
+
+async function copyToken(): Promise<void> {
   if (!justCreatedToken.value) return
   try {
     await navigator.clipboard.writeText(justCreatedToken.value)
     copied.value = true
   } catch {
-    // Clipboard access can be denied by the browser; the token stays
-    // selectable in the <code> block either way.
+    copied.value = false
   }
 }
 
-onMounted(load)
+function dismissCreatedToken(): void {
+  copied.value = false
+  credentialStore.clearCreatedToken()
+}
+
+async function revokeReplacementSource(): Promise<void> {
+  if (!replacementSourceId.value) return
+  const revoked = await credentialStore.revoke(replacementSourceId.value)
+  if (revoked) credentialStore.clearCreatedToken()
+}
+
+onMounted(async () => {
+  await botStore.initialize({
+    fetchRemote: true,
+    initializeServerStore: false,
+    createBlankForm: false,
+  })
+  resetForm()
+  await credentialStore.load()
+})
 </script>

--- a/server/api/v1/profile.get.ts
+++ b/server/api/v1/profile.get.ts
@@ -1,0 +1,51 @@
+import { defineEventHandler } from 'h3'
+import { errorHandler } from '@/server/utils/error'
+import { requireScopedApiUser } from '@/server/utils/authGuard'
+import prisma from '@/server/utils/prisma'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireScopedApiUser(event, 'profile:read')
+
+    const bot = auth.botId
+      ? await prisma.bot.findFirst({
+          where: {
+            id: auth.botId,
+            userId: auth.user.id,
+            isActive: true,
+          },
+          select: {
+            id: true,
+            name: true,
+            slug: true,
+            avatarImage: true,
+          },
+        })
+      : null
+
+    return {
+      success: true,
+      data: {
+        actorKind: auth.kind === 'agent-credential' ? 'AI_AGENT' : 'HUMAN',
+        authKind: auth.kind,
+        operator: {
+          id: auth.user.id,
+          username: auth.user.username,
+        },
+        bot,
+        scopes: auth.kind === 'agent-credential' ? (auth.scopes ?? []) : null,
+      },
+      statusCode: 200,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+
+    return {
+      success: false,
+      data: null,
+      message: handled.message,
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/stores/agentCredentialStore.ts
+++ b/stores/agentCredentialStore.ts
@@ -1,0 +1,151 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import { performFetch } from './utils'
+import type { AgentCredentialScope } from '@/utils/agentCredentialScopes'
+
+export type AgentCredentialRow = {
+  id: number
+  userId: number
+  botId: number | null
+  label: string
+  keyPrefix: string
+  scopes: AgentCredentialScope[]
+  createdAt: string
+  updatedAt: string
+  expiresAt: string | null
+  lastUsedAt: string | null
+  revokedAt: string | null
+}
+
+export type CreateAgentCredentialPayload = {
+  label: string
+  botId: number
+  scopes: AgentCredentialScope[]
+  expiresAt: string | null
+}
+
+type CredentialListResponse = {
+  credentials?: AgentCredentialRow[]
+}
+
+type CredentialCreateResponse = {
+  credential?: AgentCredentialRow
+  token?: string
+}
+
+export const useAgentCredentialStore = defineStore('agentCredentialStore', () => {
+  const credentials = ref<AgentCredentialRow[]>([])
+  const isLoading = ref(false)
+  const isCreating = ref(false)
+  const revokingId = ref<number | null>(null)
+  const errorMessage = ref('')
+  const justCreatedToken = ref<string | null>(null)
+  const replacementSourceId = ref<number | null>(null)
+
+  const activeCredentials = computed(() =>
+    credentials.value.filter((credential) => !credential.revokedAt),
+  )
+
+  function clearError(): void {
+    errorMessage.value = ''
+  }
+
+  function clearCreatedToken(): void {
+    justCreatedToken.value = null
+    replacementSourceId.value = null
+  }
+
+  async function load(): Promise<void> {
+    isLoading.value = true
+    clearError()
+
+    try {
+      const response = await performFetch<CredentialListResponse>(
+        '/api/agent-credentials',
+      )
+
+      if (!response.success) {
+        credentials.value = []
+        errorMessage.value =
+          response.message || 'Failed to load agent credentials.'
+        return
+      }
+
+      credentials.value = Array.isArray(response.data?.credentials)
+        ? response.data.credentials
+        : []
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function create(
+    payload: CreateAgentCredentialPayload,
+    replacingId: number | null = null,
+  ): Promise<boolean> {
+    isCreating.value = true
+    clearError()
+    clearCreatedToken()
+
+    try {
+      const response = await performFetch<CredentialCreateResponse>(
+        '/api/agent-credentials',
+        {
+          method: 'POST',
+          body: JSON.stringify(payload),
+        },
+      )
+
+      if (!response.success || !response.data?.token) {
+        errorMessage.value =
+          response.message || 'Failed to create agent credential.'
+        return false
+      }
+
+      justCreatedToken.value = response.data.token
+      replacementSourceId.value = replacingId
+      await load()
+      return true
+    } finally {
+      isCreating.value = false
+    }
+  }
+
+  async function revoke(id: number): Promise<boolean> {
+    revokingId.value = id
+    clearError()
+
+    try {
+      const response = await performFetch(`/api/agent-credentials/${id}`, {
+        method: 'DELETE',
+      })
+
+      if (!response.success) {
+        errorMessage.value =
+          response.message || 'Failed to revoke agent credential.'
+        return false
+      }
+
+      await load()
+      return true
+    } finally {
+      revokingId.value = null
+    }
+  }
+
+  return {
+    credentials,
+    activeCredentials,
+    isLoading,
+    isCreating,
+    revokingId,
+    errorMessage,
+    justCreatedToken,
+    replacementSourceId,
+    load,
+    create,
+    revoke,
+    clearError,
+    clearCreatedToken,
+  }
+})

--- a/utils/scripts/verifyAgentOnboarding.test.ts
+++ b/utils/scripts/verifyAgentOnboarding.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const panel = readFileSync('components/user/agent-credentials-panel.vue', 'utf8')
+const store = readFileSync('stores/agentCredentialStore.ts', 'utf8')
+const profile = readFileSync('server/api/v1/profile.get.ts', 'utf8')
+const createRoute = readFileSync('server/api/agent-credentials/index.post.ts', 'utf8')
+
+assert.match(panel, /id="agent-credentials"/)
+assert.match(panel, /Bot identity/)
+assert.match(panel, /Last used/)
+assert.match(panel, /Expires/)
+assert.match(panel, /Replace/)
+assert.match(panel, /Create replacement key/)
+assert.match(panel, /RAINBOW_BUTTERFLIES_API_KEY/)
+assert.doesNotMatch(panel, /performFetch\(/)
+assert.doesNotMatch(panel, /\$fetch\(/)
+
+assert.match(store, /defineStore\('agentCredentialStore'/)
+assert.match(store, /performFetch/)
+assert.match(store, /expiresAt: string \| null/)
+assert.match(store, /replacementSourceId/)
+
+assert.match(profile, /requireScopedApiUser\(event, 'profile:read'\)/)
+assert.match(profile, /actorKind/)
+assert.match(profile, /operator/)
+assert.match(profile, /bot/)
+assert.doesNotMatch(profile, /email:/)
+assert.doesNotMatch(profile, /apiKey/)
+
+assert.match(createRoute, /botId must reference a Bot you own/)
+assert.match(createRoute, /expiresAt/)
+
+console.log('Kind Robots self-service agent onboarding contract: OK')


### PR DESCRIPTION
## What this builds

- moves the Agent Credentials panel's network work into a dedicated Pinia store, matching the Kind Robots component/store boundary
- makes Bot binding explicit in the UI so forum-writing agent credentials identify a real owned Bot
- lets operators choose credential expiry and see creation, last-use, expiry, revocation, and active/expired state
- adds a safe replacement/rotation flow: mint replacement first, update and verify the agent, then revoke the old key
- preserves one-time plaintext display and never persists the secret in client state beyond the current Pinia session
- adds `GET /api/v1/profile` as a harmless `profile:read` identity probe that reports the derived operator, bound Bot, auth kind, and granted scopes without email/apiKey fields
- adds a focused Agent Onboarding Contract workflow

## Security boundary

The scoped credential remains derived server-side. The self-service form does not accept arbitrary User identity, and no real credential is created by this PR. The profile probe uses the existing scope guard and exposes only the authenticated credential's own public/accountability identity.

## Cross-repo task

This is the Kind Robots half of `rainbow-butterflies/t-021`. The paired Rainbow PR adds the human-facing Connect an Agent walkthrough and live documentation. Merge this PR first so the identity probe and improved credential manager exist before Rainbow advertises them as live.