### PR TITLE
interface-vision/t-104 slice 64: convert 8 status-message blocks to kr-note

### DIFF
--- a/components/art/artjob-editor.vue
+++ b/components/art/artjob-editor.vue
@@ -32,7 +32,7 @@
       <div class="min-h-0 flex-1 overflow-y-auto p-4">
         <div
           v-if="localError"
-          class="mb-3 rounded-2xl border border-error/40 bg-error/10 p-3 text-sm text-error"
+          class="mb-3 kr-note kr-note-error p-3 font-normal"
         >
           {{ localError }}
         </div>

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -53,14 +53,14 @@
 
       <div
         v-if="artJobStore.error"
-        class="rounded-2xl border border-error/40 bg-error/10 p-3 text-sm text-error"
+        class="kr-note kr-note-error p-3 font-normal"
       >
         {{ artJobStore.error }}
       </div>
 
       <div
         v-if="stats?.oldestPending"
-        class="rounded-2xl border border-warning/40 bg-warning/10 p-3 text-xs text-warning-content"
+        class="kr-note kr-note-warning p-3 text-xs text-warning-content font-normal"
       >
         Oldest pending job #{{ stats.oldestPending.id }} has waited
         {{ formatAge(stats.oldestPending.ageSeconds) }}.

--- a/components/user/user-manager-directory.vue
+++ b/components/user/user-manager-directory.vue
@@ -40,13 +40,13 @@
 
     <div
       v-if="store.lastMessage"
-      class="rounded-xl border border-success/40 bg-success/10 p-2 text-sm text-success"
+      class="kr-note kr-note-success rounded-xl p-2 font-normal"
     >
       {{ store.lastMessage }}
     </div>
     <div
       v-if="store.lastError"
-      class="rounded-xl border border-error/40 bg-error/10 p-2 text-sm text-error"
+      class="kr-note kr-note-error rounded-xl p-2 font-normal"
     >
       {{ store.lastError }}
     </div>

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -142,13 +142,13 @@
 
         <div
           v-if="triageStore.saveMessage"
-          class="rounded-2xl border border-success/40 bg-success/10 p-3 text-sm text-success"
+          class="kr-note kr-note-success p-3 font-normal"
         >
           {{ triageStore.saveMessage }}
         </div>
         <div
           v-if="triageStore.saveError"
-          class="rounded-2xl border border-error/40 bg-error/10 p-3 text-sm text-error"
+          class="kr-note kr-note-error p-3 font-normal"
         >
           {{ triageStore.saveError }}
         </div>

--- a/pages/admin/social-drafts.vue
+++ b/pages/admin/social-drafts.vue
@@ -112,7 +112,7 @@
 
         <p
           v-if="draftsStore.error"
-          class="rounded-xl border border-error/40 bg-error/10 p-3 text-sm text-error"
+          class="kr-note kr-note-error rounded-xl p-3 font-normal"
         >
           {{ draftsStore.error }}
         </p>


### PR DESCRIPTION
### Task
interface-vision/t-104 (recurring): "Drive live front-end consistency onto shared kr-* components and composition rules" (kind: software)

### What changed / what I produced
Continuing the audit of the large (~150-instance) status-callout pool flagged by slice 62 (kind_robots#2219) as needing a careful per-instance pass rather than a mechanical sweep (padding/text-size/font-weight vary across instances). This slice converts 8 hand-rolled `border-{status}/40 bg-{status}/10 text-sm text-{status}` blocks across 5 files to `kr-note kr-note-{status}`:

- `components/user/user-manager-directory.vue`: `store.lastMessage` / `store.lastError` banners
- `components/art/artjob-editor.vue`: `localError` banner
- `components/art/artjob-queue-browser.vue`: `artJobStore.error` and `stats.oldestPending` banners
- `pages/admin/lora-triage.vue`: `triageStore.saveMessage` / `triageStore.saveError` banners
- `pages/admin/social-drafts.vue`: `draftsStore.error` banner

Each converted instance is a self-contained leaf status-text node (a message string with no nested heading carrying its own unstated color) — the exact shape kr-note targets. None of the five files stated `font-semibold` explicitly (kr-note's base class adds it), so each carries a trailing `font-normal` override to keep the pre-existing, non-bold weight identical rather than silently adding weight that wasn't there before. Padding/rounding/text-size overrides are preserved the same way wherever they differ from kr-note's defaults (e.g. `rounded-xl`, `p-2`/`p-3`, `text-xs text-warning-content` on the oldest-pending banner). No geometry or behavior change.

Excluded from this slice (checked, not converted): several `border-{status}/40 bg-{status}/10` matches in `pages/admin/*.vue` "admin access required" gate panels turned out to wrap a heading with no explicit text color of its own — converting those would silently recolor the heading via inherited `text-error`, a real visual change, not a mechanical substitution. Left those alone.

### How I verified
- `npx eslint` on all 5 changed files — clean.
- `npx prettier --check` on all 5 changed files — 2 pre-existing formatting issues (`artjob-editor.vue`, `lora-triage.vue`) reproduce identically on `main` (confirmed via `git stash` before deciding not to `--write`); the other 3 files are clean.
- `npx vue-tsc --noEmit` repo-wide — clean.
- `npm run test:layout-contract` — holds, 207 baseline unchanged, 0 new violations.

### Stakes
reversible

### Flags for Reviewer
None — small, scoped, mechanical class substitution with careful per-instance override handling.

### Kaizen suggestion
The larger kr-note pool (~150 instances total) still has the "admin access required" gate-panel shape (5+ files: `scene-animator.vue`, `social-drafts.vue`, `curation-studio.vue`, `achievement-art.vue`, `lora-triage.vue`) as an excluded, unconverted lead — those wrap a heading whose color would change if converted naively; a future slice could give the heading its own explicit `text-base-content` (or similar) class first, then convert the wrapper to kr-note-error as a two-step, visually-neutral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmA7oGxNaSaHjyx6sBgTXy)_