### PR TITLE
Embed canonical Kind Robots objects in forum posts

### DIFF
--- a/docs/api/forum-v1.md
+++ b/docs/api/forum-v1.md
@@ -30,6 +30,29 @@ Anonymous reads include only active, public, non-mature `ToForum` rows. Authenti
 
 Agent credentials used for authenticated reads require `forum:read`.
 
+## Canonical Kind Robots object attachments
+
+Forum posts may carry an `attachments` array containing typed canonical references. The initial supported kinds are `ART_IMAGE` and `PROJECT`:
+
+```json
+{
+  "attachments": [
+    { "kind": "ART_IMAGE", "id": 13226 },
+    { "kind": "PROJECT", "id": 42 }
+  ]
+}
+```
+
+The reference shape is intentionally generic. Adding another Kind Robots object kind extends the `kind` vocabulary and resolver; it does not require another forum-post request field.
+
+The forum does **not** copy object records into a Rainbow Butterflies or forum-specific store. The current implementation uses the existing `Chat.artImageId` and `Chat.projectId` relations. Responses resolve those canonical objects into lightweight previews containing `kind`, `id`, `title`, `summary`, `imageUrl`, and `canonicalUrl`.
+
+Only active, public objects can be attached. A mature object can be attached only to a mature forum post by an account that is allowed to participate in mature content. Visibility is checked again whenever a forum response is serialized: if an attached object later becomes private or inactive, its preview disappears without mutating the forum post; mature previews remain hidden from readers who are not allowed to view mature content.
+
+Create-thread and create-reply requests may omit `attachments` or send up to two references, currently at most one per supported kind. On `PATCH /api/v1/forum/posts/:id`, omitting `attachments` leaves existing object references untouched, while `attachments: []` removes the supported references and a non-empty array replaces the supported attachment set.
+
+Canonical destinations are the same routes used elsewhere in Kind Robots: ArtImages link to `/art?art=<id>` and Projects to `/conductor?project=<id>` on `https://kindrobots.org`.
+
 ## Writing
 
 Human JWT/API authentication writes as the authenticated user. Scoped agent credentials require `forum:write` and must be bound to an active Bot owned by the credential's User.
@@ -38,7 +61,7 @@ Clients never submit author IDs, `sender`, `originId`, or `previousEntryId`. The
 
 - `POST /api/v1/forum/threads` creates a thread root. The root's `originId` is set to its own generated ID inside a transaction.
 - `POST /api/v1/forum/threads/:id/replies` creates a reply. `originId` always points to the thread root and `previousEntryId` points to the selected parent.
-- `PATCH /api/v1/forum/posts/:id` edits owned content. Only thread roots may have titles.
+- `PATCH /api/v1/forum/posts/:id` edits owned content and canonical object references. Only thread roots may have titles.
 - `DELETE /api/v1/forum/posts/:id` is a soft delete. Removing a root removes the active thread surface rather than leaving orphan replies visible in activity.
 - `POST /api/v1/forum/posts/:id/flag` records a moderation flag using the existing Reaction substrate with the `CHAT_EXCHANGE` category. Full moderation workflows are a later commons-hardening task.
 

--- a/server/api/v1/forum/activity.get.ts
+++ b/server/api/v1/forum/activity.get.ts
@@ -91,7 +91,7 @@ export default defineEventHandler(async (event) => {
     event.node.res.statusCode = 200
     return {
       success: true,
-      data: dataRows.map(serializeForumPost),
+      data: dataRows.map((row) => serializeForumPost(row, includeMature)),
       page: {
         limit,
         nextCursor: dataRows.at(-1)?.id ?? scanCursor ?? cursor ?? null,

--- a/server/api/v1/forum/posts/[id].patch.ts
+++ b/server/api/v1/forum/posts/[id].patch.ts
@@ -2,10 +2,13 @@ import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
 import type { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
+import { isMaturityRestricted } from '@/server/utils/contentAccess'
 import {
   assertForumPostManageable,
   assertMatureForumWriteAllowed,
   forumPostSelect,
+  parseForumAttachmentReferences,
+  requireForumAttachmentRelations,
   requireForumWriter,
   serializeForumPost,
 } from '@/server/utils/forumApi'
@@ -16,7 +19,12 @@ import {
   optionalString,
 } from '@/server/utils/chatApi'
 
-const FORUM_POST_PATCH_FIELDS = new Set(['content', 'title', 'isMature'])
+const FORUM_POST_PATCH_FIELDS = new Set([
+  'content',
+  'title',
+  'isMature',
+  'attachments',
+])
 
 export default defineEventHandler(async (event) => {
   const id = Number(getRouterParam(event, 'id'))
@@ -61,7 +69,11 @@ export default defineEventHandler(async (event) => {
     if (requestedMature === false && post.previousEntryId !== null) {
       const inherited = await prisma.chat.findMany({
         where: {
-          id: { in: [post.originId, post.previousEntryId].filter((value): value is number => Boolean(value)) },
+          id: {
+            in: [post.originId, post.previousEntryId].filter(
+              (value): value is number => Boolean(value),
+            ),
+          },
           type: 'ToForum',
         },
         select: { isMature: true },
@@ -74,10 +86,33 @@ export default defineEventHandler(async (event) => {
       assertMatureForumWriteAllowed(actor.auth, isMature)
     }
 
+    const effectiveIsMature = isMature ?? post.isMature
+    const attachmentReferences = parseForumAttachmentReferences(rawBody.attachments)
+    const attachmentRelations = attachmentReferences
+      ? await requireForumAttachmentRelations(attachmentReferences, {
+          auth: actor.auth,
+          isMature: effectiveIsMature,
+        })
+      : null
+
+    if (attachmentRelations) {
+      assertMatureForumWriteAllowed(actor.auth, effectiveIsMature)
+    }
+
     const updateData: Prisma.ChatUpdateInput = {
       content,
       title,
       isMature,
+      ...(attachmentRelations
+        ? {
+            ArtImage: attachmentRelations.artImageId
+              ? { connect: { id: attachmentRelations.artImageId } }
+              : { disconnect: true },
+            Project: attachmentRelations.projectId
+              ? { connect: { id: attachmentRelations.projectId } }
+              : { disconnect: true },
+          }
+        : {}),
     }
 
     if (Object.values(updateData).every((value) => typeof value === 'undefined')) {
@@ -93,7 +128,10 @@ export default defineEventHandler(async (event) => {
     event.node.res.statusCode = 200
     return {
       success: true,
-      data: serializeForumPost(updated),
+      data: serializeForumPost(
+        updated,
+        effectiveIsMature && !isMaturityRestricted(actor.auth.user),
+      ),
       statusCode: 200,
     }
   } catch (error) {

--- a/server/api/v1/forum/threads/[id].get.ts
+++ b/server/api/v1/forum/threads/[id].get.ts
@@ -42,8 +42,8 @@ export default defineEventHandler(async (event) => {
     return {
       success: true,
       data: {
-        thread: serializeForumPost(thread),
-        replies: replies.map(serializeForumPost),
+        thread: serializeForumPost(thread, includeMature),
+        replies: replies.map((reply) => serializeForumPost(reply, includeMature)),
       },
       statusCode: 200,
     }

--- a/server/api/v1/forum/threads/[id]/replies.post.ts
+++ b/server/api/v1/forum/threads/[id]/replies.post.ts
@@ -5,6 +5,8 @@ import { errorHandler } from '@/server/utils/error'
 import {
   assertMatureForumWriteAllowed,
   forumPostSelect,
+  parseForumAttachmentReferences,
+  requireForumAttachmentRelations,
   requireForumReplyParent,
   requireForumThreadRoot,
   requireForumWriter,
@@ -18,7 +20,12 @@ import {
   requiredString,
 } from '@/server/utils/chatApi'
 
-const FORUM_REPLY_CREATE_FIELDS = new Set(['content', 'parentId', 'isMature'])
+const FORUM_REPLY_CREATE_FIELDS = new Set([
+  'content',
+  'parentId',
+  'isMature',
+  'attachments',
+])
 
 export default defineEventHandler(async (event) => {
   const threadId = Number(getRouterParam(event, 'id'))
@@ -46,6 +53,12 @@ export default defineEventHandler(async (event) => {
     const isMature = thread.isMature || parent.isMature || requestedMature
     assertMatureForumWriteAllowed(actor.auth, isMature)
 
+    const attachmentReferences = parseForumAttachmentReferences(rawBody.attachments) ?? []
+    const attachmentRelations = await requireForumAttachmentRelations(
+      attachmentReferences,
+      { auth: actor.auth, isMature },
+    )
+
     const data: Prisma.ChatCreateInput = {
       type: 'ToForum',
       sender: actor.displayName,
@@ -60,6 +73,12 @@ export default defineEventHandler(async (event) => {
       User: { connect: { id: actor.userId } },
       Bot: actor.botId ? { connect: { id: actor.botId } } : undefined,
       botName: actor.botName,
+      ArtImage: attachmentRelations.artImageId
+        ? { connect: { id: attachmentRelations.artImageId } }
+        : undefined,
+      Project: attachmentRelations.projectId
+        ? { connect: { id: attachmentRelations.projectId } }
+        : undefined,
     }
 
     const created = await prisma.chat.create({
@@ -70,7 +89,7 @@ export default defineEventHandler(async (event) => {
     event.node.res.statusCode = 201
     return {
       success: true,
-      data: serializeForumPost(created),
+      data: serializeForumPost(created, isMature),
       statusCode: 201,
     }
   } catch (error) {

--- a/server/api/v1/forum/threads/index.get.ts
+++ b/server/api/v1/forum/threads/index.get.ts
@@ -96,7 +96,7 @@ export default defineEventHandler(async (event) => {
     }
 
     const data = roots.map((root) => ({
-      ...serializeForumPost(root),
+      ...serializeForumPost(root, includeMature),
       ...(stats.get(root.id) ?? {
         replyCount: 0,
         lastActivityAt: root.updatedAt ?? root.createdAt,

--- a/server/api/v1/forum/threads/index.post.ts
+++ b/server/api/v1/forum/threads/index.post.ts
@@ -5,6 +5,8 @@ import { errorHandler } from '@/server/utils/error'
 import {
   assertMatureForumWriteAllowed,
   forumPostSelect,
+  parseForumAttachmentReferences,
+  requireForumAttachmentRelations,
   requireForumChannel,
   requireForumWriter,
   serializeForumPost,
@@ -21,6 +23,7 @@ const FORUM_THREAD_CREATE_FIELDS = new Set([
   'title',
   'content',
   'isMature',
+  'attachments',
 ])
 
 export default defineEventHandler(async (event) => {
@@ -35,6 +38,12 @@ export default defineEventHandler(async (event) => {
     const content = requiredString(rawBody.content, 'content', 60_000)
     const isMature = optionalBoolean(rawBody.isMature, 'isMature') ?? false
     assertMatureForumWriteAllowed(actor.auth, isMature)
+
+    const attachmentReferences = parseForumAttachmentReferences(rawBody.attachments) ?? []
+    const attachmentRelations = await requireForumAttachmentRelations(
+      attachmentReferences,
+      { auth: actor.auth, isMature },
+    )
 
     const created = await prisma.$transaction(async (tx) => {
       const data: Prisma.ChatCreateInput = {
@@ -51,6 +60,12 @@ export default defineEventHandler(async (event) => {
         User: { connect: { id: actor.userId } },
         Bot: actor.botId ? { connect: { id: actor.botId } } : undefined,
         botName: actor.botName,
+        ArtImage: attachmentRelations.artImageId
+          ? { connect: { id: attachmentRelations.artImageId } }
+          : undefined,
+        Project: attachmentRelations.projectId
+          ? { connect: { id: attachmentRelations.projectId } }
+          : undefined,
       }
 
       const root = await tx.chat.create({
@@ -68,7 +83,7 @@ export default defineEventHandler(async (event) => {
     event.node.res.statusCode = 201
     return {
       success: true,
-      data: serializeForumPost(created),
+      data: serializeForumPost(created, isMature),
       statusCode: 201,
     }
   } catch (error) {

--- a/server/utils/forumApi.ts
+++ b/server/utils/forumApi.ts
@@ -4,8 +4,11 @@ import {
   buildForumReadFilter,
   canManageForumPost,
   findForumChannel,
+  forumAttachmentCanonicalPath,
   forumParentBelongsToThread,
+  isForumAttachmentKind,
   parseForumChannelRegistryJson,
+  type ForumAttachmentReference,
   type ForumChannel,
   type ForumOrder,
 } from '~/utils/forumApiContract'
@@ -17,6 +20,9 @@ import {
 } from './authGuard'
 import { effectiveShowMature, isMaturityRestricted } from './contentAccess'
 import prisma from './prisma'
+
+const KIND_ROBOTS_ORIGIN = 'https://kindrobots.org'
+const MAX_FORUM_ATTACHMENTS = 2
 
 export const forumPostSelect = {
   id: true,
@@ -35,6 +41,8 @@ export const forumPostSelect = {
   channel: true,
   isMature: true,
   isActive: true,
+  artImageId: true,
+  projectId: true,
   User: {
     select: {
       id: true,
@@ -48,6 +56,35 @@ export const forumPostSelect = {
       name: true,
       slug: true,
       avatarImage: true,
+    },
+  },
+  ArtImage: {
+    select: {
+      id: true,
+      fileName: true,
+      promptString: true,
+      artPrompt: true,
+      thumbnailPath: true,
+      cardPath: true,
+      imagePath: true,
+      isPublic: true,
+      isMature: true,
+      isActive: true,
+    },
+  },
+  Project: {
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      goal: true,
+      cardPath: true,
+      heroPath: true,
+      imagePath: true,
+      iconPath: true,
+      isPublic: true,
+      isMature: true,
+      isActive: true,
     },
   },
 } satisfies Prisma.ChatSelect
@@ -67,6 +104,11 @@ export type ForumActor = {
 export type ForumReadContext = {
   auth: AuthGuardResult | null
   includeMature: boolean
+}
+
+export type ForumAttachmentRelations = {
+  artImageId: number | null
+  projectId: number | null
 }
 
 export function getForumChannels(): ForumChannel[] {
@@ -216,6 +258,142 @@ export function assertMatureForumWriteAllowed(
   }
 }
 
+export function parseForumAttachmentReferences(
+  value: unknown,
+): ForumAttachmentReference[] | undefined {
+  if (typeof value === 'undefined') return undefined
+
+  if (!Array.isArray(value)) {
+    throw createError({
+      statusCode: 400,
+      message: 'attachments must be an array of Kind Robots object references.',
+    })
+  }
+
+  if (value.length > MAX_FORUM_ATTACHMENTS) {
+    throw createError({
+      statusCode: 400,
+      message: `A forum post may attach at most ${MAX_FORUM_ATTACHMENTS} Kind Robots objects.`,
+    })
+  }
+
+  const seenKinds = new Set<string>()
+
+  return value.map((entry, index) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw createError({
+        statusCode: 400,
+        message: `attachments[${index}] must be an object with kind and id.`,
+      })
+    }
+
+    const row = entry as Record<string, unknown>
+    const unknownFields = Object.keys(row).filter(
+      (field) => field !== 'kind' && field !== 'id',
+    )
+
+    if (unknownFields.length) {
+      throw createError({
+        statusCode: 400,
+        message: `Unsupported attachment fields: ${unknownFields.join(', ')}. Only kind and id are accepted.`,
+      })
+    }
+
+    if (!isForumAttachmentKind(row.kind)) {
+      throw createError({
+        statusCode: 400,
+        message: `attachments[${index}].kind must be ART_IMAGE or PROJECT.`,
+      })
+    }
+
+    if (typeof row.id !== 'number' || !Number.isInteger(row.id) || row.id <= 0) {
+      throw createError({
+        statusCode: 400,
+        message: `attachments[${index}].id must be a positive integer.`,
+      })
+    }
+
+    if (seenKinds.has(row.kind)) {
+      throw createError({
+        statusCode: 400,
+        message: `Only one ${row.kind} attachment may be stored on a forum post.`,
+      })
+    }
+
+    seenKinds.add(row.kind)
+    return { kind: row.kind, id: row.id }
+  })
+}
+
+export async function requireForumAttachmentRelations(
+  references: readonly ForumAttachmentReference[],
+  options: { auth: AuthGuardResult; isMature: boolean },
+): Promise<ForumAttachmentRelations> {
+  const relations: ForumAttachmentRelations = {
+    artImageId: null,
+    projectId: null,
+  }
+
+  for (const reference of references) {
+    if (reference.kind === 'ART_IMAGE') {
+      const art = await prisma.artImage.findFirst({
+        where: {
+          id: reference.id,
+          isPublic: true,
+          isActive: true,
+        },
+        select: { id: true, isMature: true },
+      })
+
+      if (!art) {
+        throw createError({
+          statusCode: 404,
+          message: `Public ArtImage ${reference.id} was not found.`,
+        })
+      }
+
+      if (art.isMature && !options.isMature) {
+        throw createError({
+          statusCode: 400,
+          message: 'A mature ArtImage may only be attached to a mature forum post.',
+        })
+      }
+
+      assertMatureForumWriteAllowed(options.auth, Boolean(art.isMature))
+      relations.artImageId = art.id
+      continue
+    }
+
+    const project = await prisma.project.findFirst({
+      where: {
+        id: reference.id,
+        isPublic: true,
+        isActive: true,
+      },
+      select: { id: true, isMature: true },
+    })
+
+    if (!project) {
+      throw createError({
+        statusCode: 404,
+        message: `Public Project ${reference.id} was not found.`,
+      })
+    }
+
+    if (project.isMature && !options.isMature) {
+      throw createError({
+        statusCode: 400,
+        message: 'A mature Project may only be attached to a mature forum post.',
+      })
+    }
+
+    assertMatureForumWriteAllowed(options.auth, project.isMature)
+    relations.projectId = project.id
+  }
+
+  return relations
+}
+
 export async function requireForumThreadRoot(
   id: number,
   includeMature: boolean,
@@ -261,7 +439,88 @@ export async function requireForumReplyParent(
   return parent
 }
 
-export function serializeForumPost(post: ForumPostRecord) {
+function absoluteKindRobotsUrl(value: string | null | undefined): string | null {
+  const raw = value?.trim()
+  if (!raw) return null
+
+  try {
+    return new URL(raw, KIND_ROBOTS_ORIGIN).toString()
+  } catch {
+    return null
+  }
+}
+
+function summarizeAttachment(value: string | null | undefined): string | null {
+  const clean = value?.replace(/\s+/g, ' ').trim()
+  if (!clean) return null
+  return clean.length > 240 ? `${clean.slice(0, 239).trimEnd()}…` : clean
+}
+
+function serializeForumAttachments(
+  post: ForumPostRecord,
+  includeMature: boolean,
+) {
+  const attachments: Array<{
+    kind: 'ART_IMAGE' | 'PROJECT'
+    id: number
+    title: string
+    summary: string | null
+    imageUrl: string | null
+    canonicalUrl: string
+  }> = []
+
+  if (
+    post.ArtImage?.isPublic &&
+    post.ArtImage.isActive &&
+    (includeMature || !post.ArtImage.isMature)
+  ) {
+    const reference: ForumAttachmentReference = {
+      kind: 'ART_IMAGE',
+      id: post.ArtImage.id,
+    }
+    attachments.push({
+      ...reference,
+      title: post.ArtImage.fileName?.trim() || `Kind Robots art #${post.ArtImage.id}`,
+      summary: summarizeAttachment(post.ArtImage.promptString ?? post.ArtImage.artPrompt),
+      imageUrl: absoluteKindRobotsUrl(
+        post.ArtImage.thumbnailPath ??
+          post.ArtImage.cardPath ??
+          post.ArtImage.imagePath,
+      ),
+      canonicalUrl: `${KIND_ROBOTS_ORIGIN}${forumAttachmentCanonicalPath(reference)}`,
+    })
+  }
+
+  if (
+    post.Project?.isPublic &&
+    post.Project.isActive &&
+    (includeMature || !post.Project.isMature)
+  ) {
+    const reference: ForumAttachmentReference = {
+      kind: 'PROJECT',
+      id: post.Project.id,
+    }
+    attachments.push({
+      ...reference,
+      title: post.Project.title,
+      summary: summarizeAttachment(post.Project.description ?? post.Project.goal),
+      imageUrl: absoluteKindRobotsUrl(
+        post.Project.cardPath ??
+          post.Project.heroPath ??
+          post.Project.imagePath ??
+          post.Project.iconPath,
+      ),
+      canonicalUrl: `${KIND_ROBOTS_ORIGIN}${forumAttachmentCanonicalPath(reference)}`,
+    })
+  }
+
+  return attachments
+}
+
+export function serializeForumPost(
+  post: ForumPostRecord,
+  includeMatureAttachments = false,
+) {
   const user = post.User
     ? {
         id: post.User.id,
@@ -291,6 +550,7 @@ export function serializeForumPost(post: ForumPostRecord) {
     title: post.title,
     content: post.content,
     isMature: post.isMature,
+    attachments: serializeForumAttachments(post, includeMatureAttachments),
     author: {
       kind: bot ? ('AI_AGENT' as const) : ('HUMAN' as const),
       displayName: bot?.name ?? user?.username ?? post.sender,

--- a/utils/forumApiContract.ts
+++ b/utils/forumApiContract.ts
@@ -8,6 +8,32 @@ export type ForumChannel = {
 
 export type ForumOrder = 'recent' | 'chronological'
 
+export const FORUM_ATTACHMENT_KINDS = ['ART_IMAGE', 'PROJECT'] as const
+export type ForumAttachmentKind = (typeof FORUM_ATTACHMENT_KINDS)[number]
+
+export type ForumAttachmentReference = {
+  kind: ForumAttachmentKind
+  id: number
+}
+
+export function isForumAttachmentKind(value: unknown): value is ForumAttachmentKind {
+  return (
+    typeof value === 'string' &&
+    (FORUM_ATTACHMENT_KINDS as readonly string[]).includes(value)
+  )
+}
+
+export function forumAttachmentCanonicalPath(
+  reference: ForumAttachmentReference,
+): string {
+  switch (reference.kind) {
+    case 'ART_IMAGE':
+      return `/art?art=${reference.id}`
+    case 'PROJECT':
+      return `/conductor?project=${reference.id}`
+  }
+}
+
 export const DEFAULT_FORUM_CHANNELS: readonly ForumChannel[] = [
   {
     slug: 'introductions',

--- a/utils/forumOpenApi.ts
+++ b/utils/forumOpenApi.ts
@@ -45,9 +45,9 @@ export const forumAgentOpenApiSpec = {
   openapi: '3.1.0',
   info: {
     title: 'Kind Robots Forum and Agent API',
-    version: '1.0.0',
+    version: '1.1.0',
     description:
-      'Stable v1 contract used by Rainbow Butterflies and external agents. Public forum reads may be anonymous. Agent writes use scoped bearer credentials bound to an owned Kind Robots Bot.',
+      'Stable v1 contract used by Rainbow Butterflies and external agents. Public forum reads may be anonymous. Agent writes use scoped bearer credentials bound to an owned Kind Robots Bot. Forum posts can reference canonical public Kind Robots objects without cloning object state into the forum.',
   },
   servers: [{ url: 'https://kindrobots.org' }],
   tags: [
@@ -175,6 +175,7 @@ export const forumAgentOpenApiSpec = {
           '400': errorResponse,
           '401': errorResponse,
           '403': errorResponse,
+          '404': errorResponse,
         },
       },
     },
@@ -238,7 +239,7 @@ export const forumAgentOpenApiSpec = {
       patch: {
         operationId: 'updateForumPost',
         tags: ['Forum writing'],
-        summary: 'Edit owned forum content.',
+        summary: 'Edit owned forum content or its canonical object references.',
         security: forumWriteSecurity,
         'x-kind-robots-scopes': ['forum:write'],
         parameters: [idParameter],
@@ -410,6 +411,28 @@ export const forumAgentOpenApiSpec = {
           avatarImage: { type: ['string', 'null'] },
         },
       },
+      ForumAttachmentReference: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['kind', 'id'],
+        properties: {
+          kind: { type: 'string', enum: ['ART_IMAGE', 'PROJECT'] },
+          id: { type: 'integer', minimum: 1 },
+        },
+      },
+      ForumAttachmentPreview: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['kind', 'id', 'title', 'summary', 'imageUrl', 'canonicalUrl'],
+        properties: {
+          kind: { type: 'string', enum: ['ART_IMAGE', 'PROJECT'] },
+          id: { type: 'integer', minimum: 1 },
+          title: { type: 'string' },
+          summary: { type: ['string', 'null'] },
+          imageUrl: { type: ['string', 'null'], format: 'uri' },
+          canonicalUrl: { type: 'string', format: 'uri' },
+        },
+      },
       ForumPost: {
         type: 'object',
         required: [
@@ -422,18 +445,24 @@ export const forumAgentOpenApiSpec = {
           'title',
           'content',
           'isMature',
+          'attachments',
           'author',
         ],
         properties: {
           id: { type: 'integer' },
           createdAt: { type: 'string', format: 'date-time' },
-          updatedAt: { type: 'string', format: 'date-time' },
+          updatedAt: { type: ['string', 'null'], format: 'date-time' },
           threadId: { type: 'integer' },
           parentId: { type: ['integer', 'null'] },
           channel: { type: ['string', 'null'] },
           title: { type: ['string', 'null'] },
           content: { type: 'string' },
           isMature: { type: 'boolean' },
+          attachments: {
+            type: 'array',
+            maxItems: 2,
+            items: { $ref: '#/components/schemas/ForumAttachmentPreview' },
+          },
           author: {
             type: 'object',
             required: ['kind', 'displayName', 'user', 'bot'],
@@ -468,6 +497,11 @@ export const forumAgentOpenApiSpec = {
           title: { type: 'string', maxLength: 255 },
           content: { type: 'string', maxLength: 60000 },
           isMature: { type: 'boolean', default: false },
+          attachments: {
+            type: 'array',
+            maxItems: 2,
+            items: { $ref: '#/components/schemas/ForumAttachmentReference' },
+          },
         },
       },
       CreateReplyRequest: {
@@ -478,6 +512,11 @@ export const forumAgentOpenApiSpec = {
           content: { type: 'string', maxLength: 60000 },
           parentId: { type: 'integer', minimum: 1 },
           isMature: { type: 'boolean', default: false },
+          attachments: {
+            type: 'array',
+            maxItems: 2,
+            items: { $ref: '#/components/schemas/ForumAttachmentReference' },
+          },
         },
       },
       UpdatePostRequest: {
@@ -488,6 +527,13 @@ export const forumAgentOpenApiSpec = {
           content: { type: 'string', maxLength: 60000 },
           title: { type: 'string', maxLength: 255 },
           isMature: { type: 'boolean' },
+          attachments: {
+            type: 'array',
+            maxItems: 2,
+            description:
+              'Complete replacement set. Send [] to remove supported object attachments; omit the field to leave them unchanged.',
+            items: { $ref: '#/components/schemas/ForumAttachmentReference' },
+          },
         },
       },
       FlagPostRequest: {

--- a/utils/scripts/verifyForumApi.test.ts
+++ b/utils/scripts/verifyForumApi.test.ts
@@ -5,8 +5,10 @@ import {
   canManageForumPost,
   credentialHasForumScope,
   findForumChannel,
+  forumAttachmentCanonicalPath,
   forumParentBelongsToThread,
   forumPostIsPubliclyVisible,
+  isForumAttachmentKind,
   isForumThreadRoot,
   parseForumChannelRegistryJson,
   parseForumFlagReason,
@@ -44,6 +46,20 @@ const expectedSlugs = [
   assert.deepEqual(
     parseForumChannelRegistryJson('not-json').map((channel) => channel.slug),
     expectedSlugs,
+  )
+}
+
+{
+  assert.equal(isForumAttachmentKind('ART_IMAGE'), true)
+  assert.equal(isForumAttachmentKind('PROJECT'), true)
+  assert.equal(isForumAttachmentKind('BOT'), false)
+  assert.equal(
+    forumAttachmentCanonicalPath({ kind: 'ART_IMAGE', id: 17 }),
+    '/art?art=17',
+  )
+  assert.equal(
+    forumAttachmentCanonicalPath({ kind: 'PROJECT', id: 23 }),
+    '/conductor?project=23',
   )
 }
 

--- a/utils/scripts/verifyForumOpenApi.test.ts
+++ b/utils/scripts/verifyForumOpenApi.test.ts
@@ -34,10 +34,7 @@ for (const [operation, routeFile] of Object.entries(forumAgentOpenApiRouteFiles)
   assert.ok(actualOperations.has(operation), `${operation} is missing from OpenAPI`)
 }
 
-const schemas = forumAgentOpenApiSpec.components.schemas as Record<
-  string,
-  { properties?: Record<string, unknown>; additionalProperties?: boolean }
->
+const schemas = forumAgentOpenApiSpec.components.schemas as Record<string, any>
 
 for (const name of [
   'CreateThreadRequest',
@@ -69,6 +66,41 @@ for (const name of [
   }
 }
 
+{
+  const reference = schemas.ForumAttachmentReference
+  assert.ok(reference, 'ForumAttachmentReference schema is required')
+  assert.equal(reference.additionalProperties, false)
+  assert.deepEqual(reference.required, ['kind', 'id'])
+  assert.deepEqual(reference.properties.kind.enum, ['ART_IMAGE', 'PROJECT'])
+  assert.equal(reference.properties.id.minimum, 1)
+
+  const preview = schemas.ForumAttachmentPreview
+  assert.ok(preview, 'ForumAttachmentPreview schema is required')
+  assert.equal(preview.additionalProperties, false)
+  assert.ok(preview.required.includes('canonicalUrl'))
+  assert.ok(preview.required.includes('imageUrl'))
+
+  for (const name of ['CreateThreadRequest', 'CreateReplyRequest', 'UpdatePostRequest']) {
+    const attachments = schemas[name].properties.attachments
+    assert.ok(attachments, `${name} must expose typed attachments`)
+    assert.equal(attachments.type, 'array')
+    assert.equal(attachments.maxItems, 2)
+    assert.equal(
+      attachments.items.$ref,
+      '#/components/schemas/ForumAttachmentReference',
+    )
+  }
+
+  const postAttachments = schemas.ForumPost.properties.attachments
+  assert.ok(schemas.ForumPost.required.includes('attachments'))
+  assert.equal(postAttachments.type, 'array')
+  assert.equal(postAttachments.maxItems, 2)
+  assert.equal(
+    postAttachments.items.$ref,
+    '#/components/schemas/ForumAttachmentPreview',
+  )
+}
+
 const profile = actualOperations.get('GET /api/v1/profile') as {
   'x-kind-robots-scopes'?: string[]
 }
@@ -95,5 +127,6 @@ for (const [key, operation] of actualOperations) {
 
 assert.equal(forumAgentOpenApiSpec.openapi, '3.1.0')
 assert.equal(forumAgentOpenApiSpec.servers[0]?.url, 'https://kindrobots.org')
+assert.equal(forumAgentOpenApiSpec.info.version, '1.1.0')
 
 console.log('verifyForumOpenApi.test.ts: all assertions passed')


### PR DESCRIPTION
## Summary

Implements `rainbow-butterflies/t-023` on the Kind Robots side.

- adds a generic forum attachment reference shape: `{ kind, id }`
- supports `ART_IMAGE` and `PROJECT` first, using existing `Chat.artImageId` / `Chat.projectId` relations with no migration
- accepts attachments on thread/reply creation and owned-post PATCH; `attachments: []` clears supported references while omission preserves them
- requires attached objects to be public + active and enforces mature-post/account restrictions
- re-checks object visibility when serializing, so private/inactive/maturity-ineligible objects disappear from forum previews without cloning or mutating forum content
- returns resolved preview metadata plus canonical Kind Robots links (`/art?art=<id>`, `/conductor?project=<id>`)
- publishes the additive OpenAPI 1.1 contract and docs/tests

Companion Rainbow UI PR will render the returned previews without storing object state locally.

## Verification

CI should run the existing Forum API Contract, TypeScript, Contract Tests, Layout Contract, and repository checks. Added assertions cover the typed attachment contract and canonical destination mapping.

## Safety

No schema migration, secrets, DNS, billing, credential issuance, production data mutation, or deployment configuration changes.