### PR TITLE
interface-vision/t-104: compose achievement admin gate with kr-note

### DIFF
--- a/pages/admin/achievement-art.vue
+++ b/pages/admin/achievement-art.vue
@@ -28,9 +28,9 @@
 
       <div
         v-else-if="!userStore.isAdmin"
-        class="rounded-2xl border border-error/40 bg-error/10 p-8 text-center"
+        class="kr-note kr-note-error p-8 text-center font-normal"
       >
-        <p class="text-xl font-black">Administrator access required</p>
+        <p class="text-xl font-black text-base-content">Administrator access required</p>
         <p class="mt-2 text-sm text-base-content/60">
           Achievement artwork management is restricted to administrators.
         </p>


### PR DESCRIPTION
## Summary
- replace the Achievement Artwork admin-access gate's hand-rolled error surface with `kr-note kr-note-error`
- preserve the previous `p-8`, centered layout, normal wrapper font weight, and base-content title/body colors via explicit overrides
- no script, store, API, or production-data changes

## Verification
- scoped one-file template/class change only
- exact diff reviewed against current `main`
- required PR checks must complete successfully before merge

## Flags for Reviewer
- this is the bounded Interface Vision t-104 slice 65 described by `openai-scheduled-20260830T101218Z-t104-a6q9`
- the explicit `text-base-content` on the heading is intentional: `kr-note-error` sets `text-error` on the wrapper, while the old gate inherited normal base-content for its title
