### PR TITLE
interface-vision/t-104 slice 66: kr-note on admin-access-required gates

### DIFF
--- a/pages/admin/curation-studio.vue
+++ b/pages/admin/curation-studio.vue
@@ -7,9 +7,9 @@
 
       <div
         v-else-if="!userStore.isAdmin"
-        class="rounded-2xl border border-error/40 bg-error/10 p-8 text-center"
+        class="kr-note kr-note-error p-8 text-center font-normal"
       >
-        <p class="text-xl font-black">Administrator access required</p>
+        <p class="text-xl font-black text-base-content">Administrator access required</p>
         <p class="mt-2 text-sm text-base-content/60">
           This screen edits production curation data and can enqueue GPU work.
         </p>

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -43,9 +43,9 @@
 
       <div
         v-else-if="!userStore.isAdmin"
-        class="rounded-2xl border border-error/40 bg-error/10 p-8 text-center"
+        class="kr-note kr-note-error p-8 text-center font-normal"
       >
-        <p class="text-xl font-black">Administrator access required</p>
+        <p class="text-xl font-black text-base-content">Administrator access required</p>
         <p class="mt-2 text-sm text-base-content/60">
           LoRA maturity triage is restricted to administrators.
         </p>

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -33,9 +33,9 @@
 
       <div
         v-else-if="!userStore.isAdmin"
-        class="rounded-2xl border border-error/40 bg-error/10 p-8 text-center"
+        class="kr-note kr-note-error p-8 text-center font-normal"
       >
-        <p class="text-xl font-black">Administrator access required</p>
+        <p class="text-xl font-black text-base-content">Administrator access required</p>
         <p class="mt-2 text-sm text-base-content/60">
           Folder animation can enqueue substantial local GPU work, so this surface is admin-only.
         </p>
@@ -197,7 +197,7 @@
 
             <div
               v-if="store.error"
-              class="rounded-2xl border border-error/40 bg-error/10 p-4"
+              class="kr-note kr-note-error"
             >
               <div class="flex items-start justify-between gap-3">
                 <pre class="whitespace-pre-wrap font-sans text-sm text-error">{{ store.error }}</pre>

--- a/pages/admin/social-drafts.vue
+++ b/pages/admin/social-drafts.vue
@@ -33,9 +33,11 @@
 
       <div
         v-else-if="!userStore.isAdmin"
-        class="rounded-2xl border border-error/40 bg-error/10 p-8 text-center"
+        class="kr-note kr-note-error p-8 text-center font-normal"
       >
-        <p class="text-xl font-black">Administrator access required</p>
+        <p class="text-xl font-black text-base-content">
+          Administrator access required
+        </p>
         <p class="mt-2 text-sm text-base-content/60">
           The social post review queue is restricted to administrators.
         </p>


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software) — slice 66

### What changed / what I produced
Converts the "Administrator access required" gate panel (hand-rolled `rounded-2xl border border-error/40 bg-error/10 p-8 text-center`) to `kr-note kr-note-error` across 4 admin pages, following the exact `achievement-art.vue` precedent from slice 65:
- `pages/admin/lora-triage.vue`
- `pages/admin/social-drafts.vue`
- `pages/admin/curation-studio.vue`
- `pages/admin/scene-animator.vue` — both the admin gate and a second `store.error` leaf panel (padding/no-font-override already matched `kr-note`'s base exactly, so it needed no extra class overrides)

The heading (`<p class="text-xl font-black">`) in each gate gets an explicit `text-base-content` override so it doesn't inherit `kr-note-error`'s `text-error` color — this is exactly the caveat slice 64 flagged when it deliberately excluded these same 4 panels ("give the heading its own explicit text color first, then the wrapper becomes convertible"). The wrapper also carries `font-normal` since `kr-note`'s base (`font-semibold`) would otherwise bleed onto the body paragraph, which was never bold before.

### How I verified
- `npx eslint` on all 4 changed files — clean.
- `npx prettier --check` — clean on all 4 after formatting `social-drafts.vue` (my initial edit there ran one line over prettier's width and needed re-wrapping; the other 3 files' pre-existing prettier warnings were confirmed via `git stash` to predate this change).
- `npx vue-tsc --noEmit` repo-wide — clean.
- `npx tsx utils/scripts/verifyLayoutContract.ts` — holds, 0 new violations (207 baseline unchanged).

### Stakes
reversible

### Notes for reviewer
Recurring sweep task — roadmap `status: review`, will return to `ready` after this merges per the established t-104 convention.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdW48Vf4H5EWE3DdrynrVM)_