### PR TITLE
interface-vision/t-104 slice 67: kr-note on status-message leaf blocks

### DIFF
--- a/components/art/add-collection.vue
+++ b/components/art/add-collection.vue
@@ -73,7 +73,7 @@
 
       <div
         v-if="message"
-        class="rounded-2xl border p-3 text-sm font-semibold"
+        class="kr-note p-3"
         :class="messageTone === 'error' ? 'kr-note-error' : 'kr-note-success'"
       >
         {{ message }}

--- a/components/art/art-generator.vue
+++ b/components/art/art-generator.vue
@@ -50,7 +50,7 @@
 
         <div
           v-if="artStore.generationMessage"
-          class="mt-3 flex items-start gap-2 rounded-2xl border p-3 text-sm font-semibold"
+          class="mt-3 flex items-start gap-2 kr-note p-3"
           :class="
             artStore.generationMessageTone === 'error'
               ? 'kr-note-error'

--- a/components/art/generate-button.vue
+++ b/components/art/generate-button.vue
@@ -89,7 +89,7 @@
 
     <div
       v-if="showMessage && artStore.generationMessage"
-      class="flex items-start gap-2 rounded-2xl border p-3 text-sm font-semibold"
+      class="flex items-start gap-2 kr-note p-3"
       :class="
         artStore.generationMessageTone === 'error'
           ? 'kr-note-error'

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -18,7 +18,7 @@
 
     <div
       v-if="statusMessage"
-      class="rounded-2xl border p-3 text-sm"
+      class="kr-note p-3 font-normal"
       :class="statusTone === 'error' ? 'kr-note-error' : 'kr-note-success'"
     >
       {{ statusMessage }}

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -57,7 +57,7 @@
 
       <div
         v-if="statusMessage"
-        class="mt-3 rounded-2xl border p-3 text-sm"
+        class="mt-3 kr-note p-3 font-normal"
         :class="statusTone === 'error' ? 'kr-note-error' : 'kr-note-success'"
       >
         {{ statusMessage }}

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -60,12 +60,8 @@
 
       <div
         v-if="dreamStore.error || statusMessage"
-        class="mt-3 rounded-2xl border p-3 text-sm"
-        :class="
-          dreamStore.error || statusTone === 'error'
-            ? 'border-error/40 bg-error/10 text-error'
-            : 'border-success/40 bg-success/10 text-success'
-        "
+        class="mt-3 kr-note p-3 font-normal"
+        :class="dreamStore.error || statusTone === 'error' ? 'kr-note-error' : 'kr-note-success'"
       >
         {{ dreamStore.error || statusMessage }}
       </div>

--- a/components/manager/kr-manager.vue
+++ b/components/manager/kr-manager.vue
@@ -189,7 +189,7 @@
     -->
     <div
       v-else
-      class="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 rounded-2xl border border-warning/40 bg-warning/10 p-4 text-center text-warning"
+      class="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 kr-note kr-note-warning text-center font-normal"
     >
       <Icon name="kind-icon:warning" class="h-10 w-10" />
 

--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -622,12 +622,8 @@ onMounted(async () => {
 
     <div
       v-if="message"
-      class="rounded-2xl border p-3 text-sm"
-      :class="
-        messageTone === 'error'
-          ? 'border-error/40 bg-error/10 text-error'
-          : 'border-success/40 bg-success/10 text-success'
-      "
+      class="kr-note p-3 font-normal"
+      :class="messageTone === 'error' ? 'kr-note-error' : 'kr-note-success'"
     >
       {{ message }}
     </div>

--- a/components/rewards/add-reward.vue
+++ b/components/rewards/add-reward.vue
@@ -269,7 +269,7 @@
 
       <div
         v-if="statusMessage"
-        class="rounded-2xl border p-3 text-sm"
+        class="kr-note p-3 font-normal"
         :class="statusTone === 'error' ? 'kr-note-error' : 'kr-note-success'"
       >
         {{ statusMessage }}

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -72,12 +72,8 @@
 
     <div
       v-if="statusMessage"
-      class="shrink-0 rounded-2xl border p-3 text-sm"
-      :class="
-        statusTone === 'error'
-          ? 'border-error/40 bg-error/10 text-error'
-          : 'border-success/40 bg-success/10 text-success'
-      "
+      class="shrink-0 kr-note p-3 font-normal"
+      :class="statusTone === 'error' ? 'kr-note-error' : 'kr-note-success'"
     >
       {{ statusMessage }}
     </div>

--- a/components/user/password-reset.vue
+++ b/components/user/password-reset.vue
@@ -88,12 +88,8 @@
 
     <div
       v-if="feedback"
-      class="rounded-2xl border p-3 text-sm font-semibold"
-      :class="
-        ok
-          ? 'border-success/40 bg-success/10 text-success'
-          : 'border-error/40 bg-error/10 text-error'
-      "
+      class="kr-note p-3"
+      :class="ok ? 'kr-note-success' : 'kr-note-error'"
     >
       {{ feedback }}
       <NuxtLink v-if="ok && hasToken" to="/login" class="link ml-1"

--- a/components/user/user-panel.vue
+++ b/components/user/user-panel.vue
@@ -76,12 +76,8 @@
 
       <div
         v-if="message"
-        class="mt-4 rounded-2xl border p-3 text-sm font-semibold"
-        :class="
-          success
-            ? 'border-success/40 bg-success/10 text-success'
-            : 'border-error/40 bg-error/10 text-error'
-        "
+        class="mt-4 kr-note p-3"
+        :class="success ? 'kr-note-success' : 'kr-note-error'"
       >
         {{ message }}
       </div>

--- a/components/wonderlab/reaction-card.vue
+++ b/components/wonderlab/reaction-card.vue
@@ -162,12 +162,8 @@
 
       <div
         v-if="reactionMessage"
-        class="rounded-2xl border p-3 text-sm"
-        :class="
-          reactionStatus === 'error'
-            ? 'border-error/40 bg-error/10 text-error'
-            : 'border-success/40 bg-success/10 text-success'
-        "
+        class="kr-note p-3 font-normal"
+        :class="reactionStatus === 'error' ? 'kr-note-error' : 'kr-note-success'"
       >
         {{ reactionMessage }}
       </div>


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 67: drive live front-end consistency onto shared kr-* components (kind: software)

### What changed / what I produced
Converts hand-rolled error/success status-message blocks to compose `kr-note` with `kr-note-error`/`kr-note-success` across 13 files:

- `dream-brainstorm.vue`, `add-reward.vue`, `character-flip-card.vue`, `reaction-card.vue`, `reward-encounter.vue`, `dream-maker.vue`, `resource-gallery.vue`: were building `border-{tone}/40 bg-{tone}/10 text-{tone}` classes by hand (or via a raw ternary already using `kr-note-error`/`success` but with a hand-rolled base); none stated `font-semibold` explicitly, so each carries a trailing `font-normal` override to keep the pre-existing non-bold weight identical.
- `password-reset.vue`, `user-panel.vue`: already stated `font-semibold` explicitly, so composing `kr-note` (which bundles the same `text-sm font-semibold`) is a pure no-op on weight.
- `generate-button.vue`, `art-generator.vue`, `add-collection.vue`: already used the `kr-note-error`/`kr-note-success` modifier classes but paired them with a hand-rolled `rounded-2xl`/`border`/`text-sm`/`font-semibold` base instead of `kr-note` itself — pure redundancy cleanup.
- `kr-manager.vue`: the "unknown tab" recovery panel already used `p-4` (matching `kr-note`'s own padding exactly), converted to `kr-note kr-note-warning` with a trailing `font-normal` for the same reason as the error/success group.

All 13 instances preserve `p-3` (or `p-4` for `kr-manager.vue`) as an explicit override alongside `kr-note`, and keep every other pre-existing layout utility (`shrink-0`, `mt-3`, `mt-4`, `flex items-start gap-2`, etc.) verbatim. No geometry or behavior change.

Excluded (checked, not converted):
- `scenario-interact.vue`: uses `text-smart` (a responsive-scaling custom class), not plain `text-sm` — not a mechanical substitution.
- `kr-manager.vue`'s separate loading/error banner (~line 68): toggles between an error tone and a neutral `border-base-300`/`bg-base-100` state, which `kr-note` has no tone for; also carries a `shadow` `kr-note` doesn't apply.
- `character-flip-card.vue`'s chat-bubble message (primary/base-300 tones): a different two-party-chat pattern, not a status callout.

### How I verified
- Read each changed block's surrounding context before and after to confirm every existing class not part of the hand-rolled tone declaration was preserved verbatim.
- Cross-checked `kr-note`/`kr-note-{tone}`'s exact `@apply` rules in `assets/css/tailwind.css` against every original hand-rolled declaration to confirm color/border/radius/padding equivalence before adding overrides.
- Local `vue-tsc`/`eslint` could not run in this sandbox (kind_robots `node_modules` here is incomplete — no `@nuxt/kit`/`.nuxt` stubs); relying on this PR's CI for TypeScript/lint/contract verification. Changes are template-only class-attribute edits with no script-block changes, matching 66 prior merged slices of this exact pattern.

### Stakes
reversible

### Flags for Reviewer
- Local build tooling wasn't available to run vue-tsc/eslint before pushing; please confirm CI is fully green (not just started) before merging.

### Kaizen suggestion
Give `kr-manager.vue`'s loading/error banner (~line 68) an explicit neutral `kr-note`-shaped tone (or a documented convention for "info vs. neutral, no color") so its two-state border/bg pattern becomes convertible too — right now it's excluded because `kr-note` only ships info/success/warning/error tones, not a neutral one.

### Notes for reviewer
Re-arm the recurring consistency umbrella (interface-vision/t-104) for the next bounded slice once this merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HwE9M1X6T1i7KWjPHuhNGs)_