### PR TITLE
refactor(ui): reuse flat panel for achievement empty state

### DIFF
--- a/pages/admin/achievement-art.vue
+++ b/pages/admin/achievement-art.vue
@@ -48,12 +48,10 @@
                 placeholder="Search label, trigger, or message"
               />
             </label>
-
             <div class="flex flex-wrap gap-2 text-xs">
               <span class="badge badge-ghost">{{ achievements.length }} total</span>
               <span class="badge badge-warning">{{ missingArtCount }} without art</span>
             </div>
-
             <div class="space-y-2 pr-1">
               <button
                 v-for="achievement in filteredAchievements"
@@ -88,7 +86,7 @@
 
               <p
                 v-if="!filteredAchievements.length"
-                class="rounded-xl border border-dashed border-base-300 p-6 text-center text-sm text-base-content/50"
+                class="kr-panel-flat border-dashed p-6 text-center text-sm text-base-content/50"
               >
                 No matching achievements.
               </p>


### PR DESCRIPTION
Interface Vision t-104 bounded consistency slice.

Replaces the Achievement Artwork search-empty state's hand-rolled rounded/border/background surface with the existing `kr-panel-flat` primitive plus `border-dashed`. Padding and text treatment stay unchanged; the only intentional visual normalization is the shared `rounded-2xl` panel radius replacing the bespoke `rounded-xl`.

No script, store, API, schema, migration, or production-data changes.

Session: `openai-scheduled-20260830T121035Z-t104-k8p2`