### PR TITLE
interface-vision/t-104 slice 68: kr-panel-flat on kr-stat-tile

### DIFF
--- a/components/ui/kr-stat-tile.vue
+++ b/components/ui/kr-stat-tile.vue
@@ -1,8 +1,6 @@
 <!-- /components/ui/kr-stat-tile.vue -->
 <template>
-  <article
-    class="stat rounded-2xl border border-base-300 bg-base-100 shadow-sm"
-  >
+  <article class="stat kr-panel-flat shadow-sm">
     <div class="stat-title">{{ title }}</div>
     <div class="stat-value" :class="toneClass">{{ value }}</div>
     <div v-if="desc" class="stat-desc">{{ desc }}</div>


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring)

### What changed / what I produced
- `components/ui/kr-stat-tile.vue`: the shared `KrStatTile` component's root `<article>` hand-rolled `rounded-2xl border border-base-300 bg-base-100` instead of composing `.kr-panel-flat` (`assets/css/tailwind.css`), which declares that exact same rule. Since every caller renders through this one component, fixing it here propagates the canonical surface class everywhere `KrStatTile` is used, rather than needing a per-callsite sweep. `shadow-sm` and the DaisyUI `stat` class are preserved verbatim on the element; no geometry, padding, color, or behavior change.

### How I verified
- `eslint` and `prettier --check` clean on the changed file
- `vue-tsc --noEmit` clean repo-wide
- `npm run test:layout-contract` holds (207 baseline, 0 new violations)
- Manually diffed `.kr-panel-flat`'s `@apply` rule against the original hand-rolled classes to confirm byte-for-byte equivalence before converting

### Stakes
reversible

### Flags for Reviewer
- This was an unusually thin slice by design: I grepped broadly (kr-panel-flat's exact `rounded-2xl border border-base-300 bg-base-100`, kr-panel's `...bg-base-100 p-6 shadow-sm`, kr-panel-muted's `...bg-base-200 p-6`, and kr-container's `mx-auto w-full max-w-6xl`) across `components/`, `pages/`, and `layouts/`, and this was the only genuine exact-match, zero-visual-change candidate remaining. Everything else I found was excluded for a real reason:
  - `components/user/chat-gallery.vue` (2 buttons): class-output-identical to `kr-panel-flat`, but semantically a decorative button border/bg treatment, not a content panel — left alone rather than stretching the utility's intent.
  - `dream-gallery.vue`, `dream-card.vue`, `daily-digest-object-dialog.vue`, `dream-sheet-toolbar.vue`, `project-front-page.vue` (x2), `mermaids-page.vue`: all use `bg-base-100/NN` (an opacity modifier) rather than plain `bg-base-100` — composing `kr-panel-flat` would change opacity, a real visual change.
  - `tutorial-flyer.vue`: `border-base-300/60` (opacity modifier on the border) — same reason, excluded.
  - `coloring-book-manager.vue`: `border-2 border-base-300` (2px border width vs. the utility's implicit 1px) — excluded.
  - `first-launch-intro.vue` / `server-selector.vue` modals: `rounded-t-2xl` base with `p-0` and viewport-height sizing, only picking up `rounded-2xl` at `sm:` — not a plain match.
  - `mission-accrual-page.vue`'s reconciliation banner: dynamic `border-{tone}/40 bg-{tone}/10 text-base-content/85` — deliberately keeps text neutral while the border/bg signal status, unlike `kr-note`'s `text-{tone}`. Converting would recolor the text, a real change — excluded.
- No new `kr-panel`/`kr-panel-muted`/`kr-container` hand-rolled duplicates found this pass.

### Kaizen suggestion
The `chat-gallery.vue` button pair above is the one near-miss worth a deliberate follow-up rather than a silent skip: if this decorative bordered-button treatment recurs elsewhere, it may be worth a small dedicated utility (e.g. `.kr-btn-outline-panel`) rather than reusing `kr-panel-flat` outside its documented "dense lists, rows, and inboxes" scope.

### Notes for reviewer
Given how much of `interface-vision/t-104`'s established grep surface (kr-note, kr-container, kr-panel-flat) is now converted, future slices may need to look at less-mined primitives (`kr-page`/`kr-surface`/`kr-toolbar`/`kr-scroll`) or a different kind of drift (e.g. duplicated spacing/flex idioms) rather than more `border`/`bg` callout hunting — flagging this in case that's useful for scoping the next cycle's search.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmRPi5DiFVwmHxoyokKYgJ)_