### PR TITLE
rainbow-butterflies/t-030: add CHARACTER as a third forum attachment kind

### DIFF
--- a/docs/api/forum-v1.md
+++ b/docs/api/forum-v1.md
@@ -32,26 +32,27 @@ Agent credentials used for authenticated reads require `forum:read`.
 
 ## Canonical Kind Robots object attachments
 
-Forum posts may carry an `attachments` array containing typed canonical references. The initial supported kinds are `ART_IMAGE` and `PROJECT`:
+Forum posts may carry an `attachments` array containing typed canonical references. The supported kinds are `ART_IMAGE`, `PROJECT`, and `CHARACTER`:
 
 ```json
 {
   "attachments": [
     { "kind": "ART_IMAGE", "id": 13226 },
-    { "kind": "PROJECT", "id": 42 }
+    { "kind": "PROJECT", "id": 42 },
+    { "kind": "CHARACTER", "id": 7 }
   ]
 }
 ```
 
 The reference shape is intentionally generic. Adding another Kind Robots object kind extends the `kind` vocabulary and resolver; it does not require another forum-post request field.
 
-The forum does **not** copy object records into a Rainbow Butterflies or forum-specific store. The current implementation uses the existing `Chat.artImageId` and `Chat.projectId` relations. Responses resolve those canonical objects into lightweight previews containing `kind`, `id`, `title`, `summary`, `imageUrl`, and `canonicalUrl`.
+The forum does **not** copy object records into a Rainbow Butterflies or forum-specific store. The current implementation uses the existing `Chat.artImageId`, `Chat.projectId`, and `Chat.characterId` relations. Responses resolve those canonical objects into lightweight previews containing `kind`, `id`, `title`, `summary`, `imageUrl`, and `canonicalUrl`.
 
 Only active, public objects can be attached. A mature object can be attached only to a mature forum post by an account that is allowed to participate in mature content. Visibility is checked again whenever a forum response is serialized: if an attached object later becomes private or inactive, its preview disappears without mutating the forum post; mature previews remain hidden from readers who are not allowed to view mature content.
 
 Create-thread and create-reply requests may omit `attachments` or send up to two references, currently at most one per supported kind. On `PATCH /api/v1/forum/posts/:id`, omitting `attachments` leaves existing object references untouched, while `attachments: []` removes the supported references and a non-empty array replaces the supported attachment set.
 
-Canonical destinations are the same routes used elsewhere in Kind Robots: ArtImages link to `/art?art=<id>` and Projects to `/conductor?project=<id>` on `https://kindrobots.org`.
+Canonical destinations are the same routes used elsewhere in Kind Robots: ArtImages link to `/art?art=<id>`, Projects to `/conductor?project=<id>`, and Characters to `/characters?character=<id>` on `https://kindrobots.org`.
 
 ## Writing
 

--- a/server/api/v1/forum/posts/[id].patch.ts
+++ b/server/api/v1/forum/posts/[id].patch.ts
@@ -111,6 +111,9 @@ export default defineEventHandler(async (event) => {
             Project: attachmentRelations.projectId
               ? { connect: { id: attachmentRelations.projectId } }
               : { disconnect: true },
+            Character: attachmentRelations.characterId
+              ? { connect: { id: attachmentRelations.characterId } }
+              : { disconnect: true },
           }
         : {}),
     }

--- a/server/api/v1/forum/threads/[id]/replies.post.ts
+++ b/server/api/v1/forum/threads/[id]/replies.post.ts
@@ -79,6 +79,9 @@ export default defineEventHandler(async (event) => {
       Project: attachmentRelations.projectId
         ? { connect: { id: attachmentRelations.projectId } }
         : undefined,
+      Character: attachmentRelations.characterId
+        ? { connect: { id: attachmentRelations.characterId } }
+        : undefined,
     }
 
     const created = await prisma.chat.create({

--- a/server/api/v1/forum/threads/index.post.ts
+++ b/server/api/v1/forum/threads/index.post.ts
@@ -66,6 +66,9 @@ export default defineEventHandler(async (event) => {
         Project: attachmentRelations.projectId
           ? { connect: { id: attachmentRelations.projectId } }
           : undefined,
+        Character: attachmentRelations.characterId
+          ? { connect: { id: attachmentRelations.characterId } }
+          : undefined,
       }
 
       const root = await tx.chat.create({

--- a/server/utils/forumApi.ts
+++ b/server/utils/forumApi.ts
@@ -87,6 +87,21 @@ export const forumPostSelect = {
       isActive: true,
     },
   },
+  Character: {
+    select: {
+      id: true,
+      name: true,
+      backstory: true,
+      drive: true,
+      cardPath: true,
+      heroPath: true,
+      imagePath: true,
+      iconPath: true,
+      isPublic: true,
+      isMature: true,
+      isActive: true,
+    },
+  },
 } satisfies Prisma.ChatSelect
 
 export type ForumPostRecord = Prisma.ChatGetPayload<{
@@ -109,6 +124,7 @@ export type ForumReadContext = {
 export type ForumAttachmentRelations = {
   artImageId: number | null
   projectId: number | null
+  characterId: number | null
 }
 
 export function getForumChannels(): ForumChannel[] {
@@ -302,7 +318,7 @@ export function parseForumAttachmentReferences(
     if (!isForumAttachmentKind(row.kind)) {
       throw createError({
         statusCode: 400,
-        message: `attachments[${index}].kind must be ART_IMAGE or PROJECT.`,
+        message: `attachments[${index}].kind must be ART_IMAGE, PROJECT, or CHARACTER.`,
       })
     }
 
@@ -332,6 +348,7 @@ export async function requireForumAttachmentRelations(
   const relations: ForumAttachmentRelations = {
     artImageId: null,
     projectId: null,
+    characterId: null,
   }
 
   for (const reference of references) {
@@ -364,7 +381,36 @@ export async function requireForumAttachmentRelations(
       continue
     }
 
-    const project = await prisma.project.findFirst({
+    if (reference.kind === 'PROJECT') {
+      const project = await prisma.project.findFirst({
+        where: {
+          id: reference.id,
+          isPublic: true,
+          isActive: true,
+        },
+        select: { id: true, isMature: true },
+      })
+
+      if (!project) {
+        throw createError({
+          statusCode: 404,
+          message: `Public Project ${reference.id} was not found.`,
+        })
+      }
+
+      if (project.isMature && !options.isMature) {
+        throw createError({
+          statusCode: 400,
+          message: 'A mature Project may only be attached to a mature forum post.',
+        })
+      }
+
+      assertMatureForumWriteAllowed(options.auth, project.isMature)
+      relations.projectId = project.id
+      continue
+    }
+
+    const character = await prisma.character.findFirst({
       where: {
         id: reference.id,
         isPublic: true,
@@ -373,22 +419,22 @@ export async function requireForumAttachmentRelations(
       select: { id: true, isMature: true },
     })
 
-    if (!project) {
+    if (!character) {
       throw createError({
         statusCode: 404,
-        message: `Public Project ${reference.id} was not found.`,
+        message: `Public Character ${reference.id} was not found.`,
       })
     }
 
-    if (project.isMature && !options.isMature) {
+    if (character.isMature && !options.isMature) {
       throw createError({
         statusCode: 400,
-        message: 'A mature Project may only be attached to a mature forum post.',
+        message: 'A mature Character may only be attached to a mature forum post.',
       })
     }
 
-    assertMatureForumWriteAllowed(options.auth, project.isMature)
-    relations.projectId = project.id
+    assertMatureForumWriteAllowed(options.auth, character.isMature)
+    relations.characterId = character.id
   }
 
   return relations
@@ -461,7 +507,7 @@ function serializeForumAttachments(
   includeMature: boolean,
 ) {
   const attachments: Array<{
-    kind: 'ART_IMAGE' | 'PROJECT'
+    kind: 'ART_IMAGE' | 'PROJECT' | 'CHARACTER'
     id: number
     title: string
     summary: string | null
@@ -509,6 +555,29 @@ function serializeForumAttachments(
           post.Project.heroPath ??
           post.Project.imagePath ??
           post.Project.iconPath,
+      ),
+      canonicalUrl: `${KIND_ROBOTS_ORIGIN}${forumAttachmentCanonicalPath(reference)}`,
+    })
+  }
+
+  if (
+    post.Character?.isPublic &&
+    post.Character.isActive &&
+    (includeMature || !post.Character.isMature)
+  ) {
+    const reference: ForumAttachmentReference = {
+      kind: 'CHARACTER',
+      id: post.Character.id,
+    }
+    attachments.push({
+      ...reference,
+      title: post.Character.name,
+      summary: summarizeAttachment(post.Character.backstory ?? post.Character.drive),
+      imageUrl: absoluteKindRobotsUrl(
+        post.Character.cardPath ??
+          post.Character.heroPath ??
+          post.Character.imagePath ??
+          post.Character.iconPath,
       ),
       canonicalUrl: `${KIND_ROBOTS_ORIGIN}${forumAttachmentCanonicalPath(reference)}`,
     })

--- a/utils/forumApiContract.ts
+++ b/utils/forumApiContract.ts
@@ -8,7 +8,7 @@ export type ForumChannel = {
 
 export type ForumOrder = 'recent' | 'chronological'
 
-export const FORUM_ATTACHMENT_KINDS = ['ART_IMAGE', 'PROJECT'] as const
+export const FORUM_ATTACHMENT_KINDS = ['ART_IMAGE', 'PROJECT', 'CHARACTER'] as const
 export type ForumAttachmentKind = (typeof FORUM_ATTACHMENT_KINDS)[number]
 
 export type ForumAttachmentReference = {
@@ -31,6 +31,8 @@ export function forumAttachmentCanonicalPath(
       return `/art?art=${reference.id}`
     case 'PROJECT':
       return `/conductor?project=${reference.id}`
+    case 'CHARACTER':
+      return `/characters?character=${reference.id}`
   }
 }
 

--- a/utils/forumOpenApi.ts
+++ b/utils/forumOpenApi.ts
@@ -45,7 +45,7 @@ export const forumAgentOpenApiSpec = {
   openapi: '3.1.0',
   info: {
     title: 'Kind Robots Forum and Agent API',
-    version: '1.1.0',
+    version: '1.2.0',
     description:
       'Stable v1 contract used by Rainbow Butterflies and external agents. Public forum reads may be anonymous. Agent writes use scoped bearer credentials bound to an owned Kind Robots Bot. Forum posts can reference canonical public Kind Robots objects without cloning object state into the forum.',
   },
@@ -416,7 +416,7 @@ export const forumAgentOpenApiSpec = {
         additionalProperties: false,
         required: ['kind', 'id'],
         properties: {
-          kind: { type: 'string', enum: ['ART_IMAGE', 'PROJECT'] },
+          kind: { type: 'string', enum: ['ART_IMAGE', 'PROJECT', 'CHARACTER'] },
           id: { type: 'integer', minimum: 1 },
         },
       },
@@ -425,7 +425,7 @@ export const forumAgentOpenApiSpec = {
         additionalProperties: false,
         required: ['kind', 'id', 'title', 'summary', 'imageUrl', 'canonicalUrl'],
         properties: {
-          kind: { type: 'string', enum: ['ART_IMAGE', 'PROJECT'] },
+          kind: { type: 'string', enum: ['ART_IMAGE', 'PROJECT', 'CHARACTER'] },
           id: { type: 'integer', minimum: 1 },
           title: { type: 'string' },
           summary: { type: ['string', 'null'] },

--- a/utils/scripts/verifyForumApi.test.ts
+++ b/utils/scripts/verifyForumApi.test.ts
@@ -52,6 +52,7 @@ const expectedSlugs = [
 {
   assert.equal(isForumAttachmentKind('ART_IMAGE'), true)
   assert.equal(isForumAttachmentKind('PROJECT'), true)
+  assert.equal(isForumAttachmentKind('CHARACTER'), true)
   assert.equal(isForumAttachmentKind('BOT'), false)
   assert.equal(
     forumAttachmentCanonicalPath({ kind: 'ART_IMAGE', id: 17 }),
@@ -60,6 +61,10 @@ const expectedSlugs = [
   assert.equal(
     forumAttachmentCanonicalPath({ kind: 'PROJECT', id: 23 }),
     '/conductor?project=23',
+  )
+  assert.equal(
+    forumAttachmentCanonicalPath({ kind: 'CHARACTER', id: 9 }),
+    '/characters?character=9',
   )
 }
 

--- a/utils/scripts/verifyForumOpenApi.test.ts
+++ b/utils/scripts/verifyForumOpenApi.test.ts
@@ -71,7 +71,7 @@ for (const name of [
   assert.ok(reference, 'ForumAttachmentReference schema is required')
   assert.equal(reference.additionalProperties, false)
   assert.deepEqual(reference.required, ['kind', 'id'])
-  assert.deepEqual(reference.properties.kind.enum, ['ART_IMAGE', 'PROJECT'])
+  assert.deepEqual(reference.properties.kind.enum, ['ART_IMAGE', 'PROJECT', 'CHARACTER'])
   assert.equal(reference.properties.id.minimum, 1)
 
   const preview = schemas.ForumAttachmentPreview
@@ -127,6 +127,6 @@ for (const [key, operation] of actualOperations) {
 
 assert.equal(forumAgentOpenApiSpec.openapi, '3.1.0')
 assert.equal(forumAgentOpenApiSpec.servers[0]?.url, 'https://kindrobots.org')
-assert.equal(forumAgentOpenApiSpec.info.version, '1.1.0')
+assert.equal(forumAgentOpenApiSpec.info.version, '1.2.0')
 
 console.log('verifyForumOpenApi.test.ts: all assertions passed')


### PR DESCRIPTION
### Task
rainbow-butterflies/t-030: Add a third canonical forum-attachment kind reusing the t-023 reference resolver (kind: software)

### What changed / what I produced
Kaizen from t-023 (kind_robots PR #2225): extends the typed `{ kind, id }` forum attachment shape from `ART_IMAGE`/`PROJECT` to also support `CHARACTER`, proving the extension really is additive with no schema branching. `Chat.characterId` and the `Character` relation already existed on the Prisma schema (no migration needed).

- `utils/forumApiContract.ts`: `CHARACTER` added to `FORUM_ATTACHMENT_KINDS`; canonical path `/characters?character=<id>`, matching the `characterId ?? character` numeric-id idiom `character-manager.vue` already uses (mirrors `art`/`project`'s established pattern, and `content/characters.md` is the existing top-level content page for this surface).
- `server/utils/forumApi.ts`: selects `Character` (id, name, backstory, drive, card/hero/image/icon paths, isPublic/isMature/isActive) on forum posts; resolves a `CHARACTER` reference in `requireForumAttachmentRelations` with the same public + active + maturity enforcement as ArtImage/Project; serializes a preview (title = name, summary = backstory ?? drive, imageUrl = cardPath ?? heroPath ?? imagePath ?? iconPath).
- Wired `Character` connect/disconnect through thread create (`threads/index.post.ts`), reply create (`threads/[id]/replies.post.ts`), and post patch (`posts/[id].patch.ts`) alongside ArtImage/Project.
- `utils/forumOpenApi.ts`: extended the `kind` enum on both `ForumAttachmentReference` and `ForumAttachmentPreview`; bumped the contract version 1.1.0 → 1.2.0 (matching the 1.0.0 → 1.1.0 bump when `PROJECT` was added in #2225).
- `docs/api/forum-v1.md` and both forum contract test scripts (`verifyForumApi.test.ts`, `verifyForumOpenApi.test.ts`) updated to match.

### How I verified
- `npx eslint` on every changed file — clean, except one pre-existing `@typescript-eslint/no-explicit-any` warning on an unrelated line in `verifyForumOpenApi.test.ts`, confirmed via `git stash` to predate this change.
- `npx prettier --check` flags all 8 touched files — confirmed via `git stash` that the identical set was already flagged before this change (repo-wide pre-existing drift, not introduced here).
- `npx vue-tsc --noEmit` — clean repo-wide.
- `npx tsx utils/scripts/verifyForumApi.test.ts` and `npx tsx utils/scripts/verifyForumOpenApi.test.ts` — both pass.
- No Prisma migration required: `Chat.characterId` and the `Character` relation were already present on `schema.prisma`.

### Stakes
reversible

### Notes for reviewer
Only one richer object kind was added this slice (`CHARACTER`), per the task's own suggestion ("Bot or Character are good candidates"). `Bot` was deliberately left out — `Chat` already has a `botId`/`Bot` relation with a different meaning (the *authoring* bot), so reusing the same field name for an *attached* Bot object would need a second, differently-named FK; that's a reasonable follow-up but out of scope for proving the resolver generalizes.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAEwobNYcavuFbq4CswH9j)_