### PR TITLE
interface-vision/t-104 slice 69: kr-scroll on 6 hand-rolled scroll regions

### DIFF
--- a/components/art/artjob-feedback-manager.vue
+++ b/components/art/artjob-feedback-manager.vue
@@ -48,7 +48,7 @@
       </div>
     </div>
 
-    <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3">
+    <div class="kr-scroll p-3">
       <div v-if="visibleJobs.length" class="flex flex-col gap-3">
         <article
           v-for="job in visibleJobs"

--- a/components/art/hair-studio-manager.vue
+++ b/components/art/hair-studio-manager.vue
@@ -24,7 +24,7 @@
       </span>
     </header>
 
-    <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+    <div class="kr-scroll">
       <stylist-restyle />
     </div>
   </section>

--- a/components/art/stylist-manager.vue
+++ b/components/art/stylist-manager.vue
@@ -44,7 +44,7 @@
       {{ superkate.syncError }} — working from this device's copy.
     </p>
 
-    <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+    <div class="kr-scroll">
       <stylist-calculator v-if="superkate.activeView === 'calculator'" />
       <stylist-clients v-else-if="superkate.activeView === 'clients'" />
       <stylist-history v-else-if="superkate.activeView === 'history'" />

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -67,7 +67,7 @@
       </div>
     </header>
 
-    <main class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3">
+    <main class="kr-scroll p-3">
       <div class="grid gap-3 xl:grid-cols-[minmax(0,1fr)_22rem]">
         <section class="grid gap-3">
           <div class="kr-panel-flat p-4">

--- a/components/home/home-object-sheet.vue
+++ b/components/home/home-object-sheet.vue
@@ -74,9 +74,7 @@
           contract's one-scroll rule counts page-level owners, and a modal's
           own body is not the page's.
         -->
-        <div
-          class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3 sm:p-4"
-        >
+        <div class="kr-scroll p-3 sm:p-4">
           <div v-if="pending" class="flex min-h-40 items-center justify-center">
             <span class="loading loading-spinner loading-md text-primary" />
             <span class="sr-only">Loading details…</span>

--- a/components/manager/kr-manager.vue
+++ b/components/manager/kr-manager.vue
@@ -123,7 +123,7 @@
       :key="renderedTab"
       :class="
         isPanelTab(renderedTab)
-          ? 'kr-panel-flat min-h-0 flex-1 overflow-y-auto overscroll-contain p-4'
+          ? 'kr-panel-flat kr-scroll p-4'
           : 'flex h-full min-h-0 flex-1 flex-col overflow-hidden'
       "
     >


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Consolidated the exact `min-h-0 flex-1 overflow-y-auto overscroll-contain` idiom into the `.kr-scroll` primitive across 6 files: `components/dreams/dream-maker.vue`, `components/home/home-object-sheet.vue`, `components/art/artjob-feedback-manager.vue`, `components/art/stylist-manager.vue`, `components/art/hair-studio-manager.vue`, and `components/manager/kr-manager.vue` (already partially on `kr-panel-flat`, now also `kr-scroll`).
- Every candidate matched `kr-scroll`'s exact `@apply` rule (`assets/css/tailwind.css`) byte-for-byte; other utilities (padding, etc.) on the same element are preserved as siblings. No geometry, scroll-ownership, or behavior change.
- This is `.kr-scroll`/`.kr-page`/`.kr-surface`/`.kr-toolbar` territory — a less-examined primitive family per the prior slice's (#2230) own note. Checked `.kr-toolbar` candidates too (`relative z-20 flex shrink-0 flex-wrap items-center gap-2`) but excluded all 4 found: one lacked `relative z-20` entirely alongside extra classes (a real structural difference, not a match), and the other three would have *added* `relative z-20` — a genuine new stacking-context behavior, not a pure class-name consolidation, so left for a slice that can verify no overlap/positioning side effects.

### How I verified
- `npx eslint` on all 6 changed files: 1 pre-existing, unrelated error in `dream-maker.vue` (an overload-signature lint issue at line 388, far from my edit at line 70) — confirmed present on `main` before this change via `git stash`.
- `npx prettier --check` on all 6 files: pre-existing formatting drift in `dream-maker.vue` and `artjob-feedback-manager.vue`, none touching the edited lines — confirmed present on `main` before this change via `git stash`.
- `npx vue-tsc --noEmit`: clean repo-wide.
- `npm run test:layout-contract`: holds at its 207-violation baseline (all pre-existing `viewport-grid` items), zero new violations.

### Stakes
reversible

### Flags for Reviewer
- None — this is a pure class-name consolidation with matching utilities verified byte-for-byte against `kr-scroll`'s CSS source, same discipline as the last several slices.

### Kaizen suggestion
The `.kr-toolbar` candidates excluded above (`dream-relationship-gallery.vue`, `scenario-relationship-gallery.vue`, `conductor-pitch-manager.vue`) are worth a dedicated slice that specifically checks each toolbar row for absolutely-positioned descendants or z-index-sensitive siblings before adopting `relative z-20`, since that's an additive behavior change rather than a pure consolidation.

### Notes for reviewer
Recurring consistency umbrella (`interface-vision/t-104`) — will re-arm the conductor task to `ready` after this merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_016RWDaFw5W3G4eEk2mZTYkC)_