### PR TITLE
interface-vision/t-104 slice 70: kr-toolbar, kr-surface, kr-stage consolidation

### DIFF
--- a/components/art/art-manager.vue
+++ b/components/art/art-manager.vue
@@ -14,10 +14,7 @@
       </div>
     </div>
 
-    <div
-      v-else-if="managerError"
-      class="flex min-h-0 flex-1 flex-col overflow-hidden kr-note kr-note-error"
-    >
+    <div v-else-if="managerError" class="kr-stage kr-note kr-note-error">
       <div class="flex flex-wrap items-center justify-between gap-3">
         <span>{{ managerError }}</span>
         <button

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -1,7 +1,7 @@
 <!-- /components/dreams/dream-brainstorm.vue -->
 <template>
   <section
-    class="flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden rounded-2xl border border-base-300 bg-base-200 p-3"
+    class="kr-surface rounded-2xl border border-base-300 bg-base-200 p-3"
   >
     <header class="shrink-0 kr-panel-flat p-4">
       <div

--- a/components/dreams/dream-narration.vue
+++ b/components/dreams/dream-narration.vue
@@ -1,7 +1,7 @@
 <!-- /components/dreams/dream-narration.vue -->
 <template>
   <section
-    class="flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden rounded-2xl border border-base-300 bg-base-200 p-3"
+    class="kr-surface rounded-2xl border border-base-300 bg-base-200 p-3"
   >
     <header class="shrink-0 kr-panel-flat p-3">
       <div class="flex flex-wrap items-center justify-between gap-3">

--- a/components/dreams/dream-relationship-gallery.vue
+++ b/components/dreams/dream-relationship-gallery.vue
@@ -16,7 +16,7 @@
           </p>
         </div>
 
-        <div class="flex shrink-0 flex-wrap items-center gap-2">
+        <div class="kr-toolbar">
           <span class="badge badge-ghost">{{ filteredDreams.length }}</span>
           <span
             v-if="resolvedDreamId"

--- a/components/pages/conductor-pitch-manager.vue
+++ b/components/pages/conductor-pitch-manager.vue
@@ -75,7 +75,7 @@
     </header>
 
     <div class="flex min-h-0 flex-1 flex-col gap-3 p-3 sm:p-4">
-      <div class="flex shrink-0 flex-wrap items-center gap-2">
+      <div class="kr-toolbar">
         <label class="input input-bordered input-sm flex min-w-52 flex-1 items-center gap-2 rounded-2xl bg-base-100">
           <Icon name="kind-icon:search" class="size-4 text-base-content/35" />
           <input

--- a/components/scenarios/scenario-relationship-gallery.vue
+++ b/components/scenarios/scenario-relationship-gallery.vue
@@ -16,7 +16,7 @@
           </p>
         </div>
 
-        <div class="flex shrink-0 flex-wrap items-center gap-2">
+        <div class="kr-toolbar">
           <span class="badge badge-ghost">{{ filteredScenarios.length }}</span>
           <span
             v-if="resolvedDreamId"

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -177,10 +177,7 @@
       </div>
     </section>
 
-    <section
-      v-else
-      class="flex min-h-0 flex-1 flex-col overflow-hidden kr-panel-flat"
-    >
+    <section v-else class="kr-stage kr-panel-flat">
       <div
         class="flex shrink-0 items-center gap-3 border-b border-base-300 bg-base-200 p-3"
       >


### PR DESCRIPTION
## What
Continues the interface-vision/t-104 kr-* consolidation series (slice 70). Converts 7 hand-rolled utility-class combinations to their equivalent shared primitives:

- **kr-toolbar** on 3 control rows: `dream-relationship-gallery.vue`, `scenario-relationship-gallery.vue`, `conductor-pitch-manager.vue`. Verified none has absolutely-positioned descendants or z-index-sensitive siblings before adopting the `relative z-20` stacking-context promotion `.kr-toolbar` bakes in.
- **kr-surface** on 2 panel roots: `dream-brainstorm.vue`, `dream-narration.vue`. Base utility list (`flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden`) matched byte-for-byte; kept the panel decoration (`rounded-2xl border border-base-300 bg-base-200 p-3`) alongside it.
- **kr-stage** on 2 non-scrolling focal-area fills: `chat-gallery.vue`'s active-thread panel, `art-manager.vue`'s error state. Pure rename — zero visual change.

## Excluded (checked, not converted)
- `stage-manager.vue`'s toolbar look-alike — carries extra classes beyond the exact match, already excluded in slice 69.
- `kr-entity-card-body.vue`'s `flex w-full flex-col` wrapper — matches `.kr-unbound`'s utility string, but `.kr-unbound` is documented (and enforced by `verifyLayoutContract.ts`'s root-surface rule) as a page-ROOT-only marker; this is a nested card-body div, not a page root.
- `academy-manager.vue`'s error box — matches `.kr-stage`'s base string, but the element sits nested inside a `.kr-scroll` region, contradicting `.kr-stage`'s documented design intent as an *alternative* to `.kr-scroll`, not a child of one.

## Verification
- `eslint` / `prettier --check` on all 7 changed files — clean (one pre-existing, unrelated `no-unused-vars` error in `conductor-pitch-manager.vue` confirmed present on `main` via `git stash` before/after).
- `vue-tsc --noEmit` — clean repo-wide.
- `npm run test:layout-contract` — holds at the 207-violation baseline, zero new violations.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7QUJaJpJy9TjDpuaan9Cd)_