### PR TITLE
rainbow-butterflies/t-025: harden commons moderation, anti-spam, and credential controls

### DIFF
--- a/server/api/v1/forum/activity.get.ts
+++ b/server/api/v1/forum/activity.get.ts
@@ -1,6 +1,7 @@
 import { defineEventHandler, getQuery } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
+import { notInRestricted } from '@/server/utils/restriction'
 import {
   forumPostSelect,
   forumReadWhere,
@@ -44,7 +45,7 @@ export default defineEventHandler(async (event) => {
 
     while (pageRows.length <= limit && !sourceExhausted) {
       const rows = await prisma.chat.findMany({
-        where: forumReadWhere({
+        where: await forumReadWhere({
           channel,
           includeMature,
           cursor: scanCursor,
@@ -74,6 +75,7 @@ export default defineEventHandler(async (event) => {
           isActive: true,
           previousEntryId: null,
           ...(includeMature ? {} : { isMature: false }),
+          ...(await notInRestricted('userId')),
         },
         select: { id: true },
       })

--- a/server/api/v1/forum/posts/[id].delete.ts
+++ b/server/api/v1/forum/posts/[id].delete.ts
@@ -1,6 +1,7 @@
 import { createError, defineEventHandler, getRouterParam } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
+import { logAdminAction } from '@/server/utils/audit'
 import {
   assertForumPostManageable,
   forumPostSelect,
@@ -27,12 +28,25 @@ export default defineEventHandler(async (event) => {
 
     assertForumPostManageable(actor.auth, post)
 
+    // assertForumPostManageable already enforced ownership-or-admin, so a
+    // userId mismatch here can only mean an admin is moderating someone
+    // else's content -- that's the case worth an audit trail (a self-
+    // delete needs no separate record beyond the post's own removed state).
+    const isModerationAction = post.userId !== actor.userId
+
     if (post.isActive) {
       await prisma.chat.update({
         where: { id },
         data: { isActive: false },
         select: { id: true },
       })
+
+      if (isModerationAction) {
+        await logAdminAction(
+          actor.auth.user,
+          `Removed forum ${post.previousEntryId === null ? 'thread' : 'post'} #${id} authored by ${post.Bot?.name ?? post.User?.username ?? post.sender}.`,
+        )
+      }
     }
 
     event.node.res.statusCode = 200

--- a/server/api/v1/forum/posts/[id].get.ts
+++ b/server/api/v1/forum/posts/[id].get.ts
@@ -6,6 +6,7 @@ import {
   getForumReadContext,
   serializeForumPost,
 } from '@/server/utils/forumApi'
+import { notInRestricted } from '@/server/utils/restriction'
 import { parseForumBoolean } from '~/utils/forumApiContract'
 
 type ForumPostReadQuery = {
@@ -31,8 +32,13 @@ export default defineEventHandler(async (event) => {
         id,
         type: 'ToForum',
         isPublic: true,
-        isActive: true,
+        // No isActive filter here: a removed post still resolves so a
+        // direct link (e.g. from a thread's own reply list) renders a
+        // "[removed]" tombstone instead of an opaque 404. A restricted
+        // author's post, by contrast, should look like it never existed --
+        // notInRestricted below still excludes it outright.
         ...(includeMature ? {} : { isMature: false }),
+        ...(await notInRestricted('userId')),
       },
       select: forumPostSelect,
     })

--- a/server/api/v1/forum/posts/[id].patch.ts
+++ b/server/api/v1/forum/posts/[id].patch.ts
@@ -2,6 +2,7 @@ import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
 import type { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
+import { logAdminAction } from '@/server/utils/audit'
 import { isMaturityRestricted } from '@/server/utils/contentAccess'
 import {
   assertForumPostManageable,
@@ -127,6 +128,16 @@ export default defineEventHandler(async (event) => {
       data: updateData,
       select: forumPostSelect,
     })
+
+    // assertForumPostManageable already enforced ownership-or-admin above,
+    // so a userId mismatch here can only mean an admin is editing someone
+    // else's content -- the moderation action worth an audit trail.
+    if (post.userId !== actor.userId) {
+      await logAdminAction(
+        actor.auth.user,
+        `Edited forum ${post.previousEntryId === null ? 'thread' : 'post'} #${id} authored by ${post.Bot?.name ?? post.User?.username ?? post.sender}.`,
+      )
+    }
 
     event.node.res.statusCode = 200
     return {

--- a/server/api/v1/forum/posts/[id]/flag.post.ts
+++ b/server/api/v1/forum/posts/[id]/flag.post.ts
@@ -2,13 +2,19 @@ import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
 import type { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
-import { requireForumWriter } from '@/server/utils/forumApi'
+import {
+  escalateHealthClaimFlagsIfNeeded,
+  requireForumWriter,
+} from '@/server/utils/forumApi'
 import {
   assertJsonObject,
   assertOnlyFields,
   nullableString,
 } from '@/server/utils/chatApi'
-import { parseForumFlagReason } from '~/utils/forumApiContract'
+import {
+  isHealthClaimFlagReason,
+  parseForumFlagReason,
+} from '~/utils/forumApiContract'
 
 const FORUM_FLAG_FIELDS = new Set(['reason', 'detail'])
 
@@ -68,6 +74,10 @@ export default defineEventHandler(async (event) => {
       select: { id: true, createdAt: true },
     })
 
+    const escalated = isHealthClaimFlagReason(reason)
+      ? await escalateHealthClaimFlagsIfNeeded(post.id)
+      : false
+
     event.node.res.statusCode = 202
     return {
       success: true,
@@ -76,6 +86,7 @@ export default defineEventHandler(async (event) => {
         createdAt: flag.createdAt,
         postId: post.id,
         reason,
+        escalated,
       },
       statusCode: 202,
     }

--- a/server/api/v1/forum/threads/[id].get.ts
+++ b/server/api/v1/forum/threads/[id].get.ts
@@ -3,7 +3,7 @@ import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import {
   forumPostSelect,
-  forumReadWhere,
+  forumReplyReadWhere,
   getForumReadContext,
   requireForumThreadRoot,
   serializeForumPost,
@@ -30,7 +30,11 @@ export default defineEventHandler(async (event) => {
     const thread = await requireForumThreadRoot(id, includeMature)
     const replies = await prisma.chat.findMany({
       where: {
-        ...forumReadWhere({ includeMature }),
+        // Deliberately not forumReadWhere here: a removed reply renders as
+        // a "[removed]" tombstone in this thread-detail view rather than
+        // vanishing (see buildForumReplyReadFilter / serializeForumPost),
+        // so the reply nesting readers already loaded stays coherent.
+        ...(await forumReplyReadWhere({ includeMature })),
         originId: id,
         id: { not: id },
       },

--- a/server/api/v1/forum/threads/[id]/replies.post.ts
+++ b/server/api/v1/forum/threads/[id]/replies.post.ts
@@ -3,6 +3,7 @@ import type { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import {
+  assertForumWriteAllowed,
   assertMatureForumWriteAllowed,
   forumPostSelect,
   parseForumAttachmentReferences,
@@ -52,6 +53,7 @@ export default defineEventHandler(async (event) => {
 
     const isMature = thread.isMature || parent.isMature || requestedMature
     assertMatureForumWriteAllowed(actor.auth, isMature)
+    await assertForumWriteAllowed(event, actor, content)
 
     const attachmentReferences = parseForumAttachmentReferences(rawBody.attachments) ?? []
     const attachmentRelations = await requireForumAttachmentRelations(
@@ -65,7 +67,7 @@ export default defineEventHandler(async (event) => {
       content,
       title: null,
       channel: thread.channel,
-      isPublic: true,
+      isPublic: !actor.shadowRestricted,
       isActive: true,
       isMature,
       originId: thread.id,

--- a/server/api/v1/forum/threads/index.get.ts
+++ b/server/api/v1/forum/threads/index.get.ts
@@ -40,7 +40,7 @@ export default defineEventHandler(async (event) => {
     )
 
     const rows = await prisma.chat.findMany({
-      where: forumReadWhere({
+      where: await forumReadWhere({
         channel,
         includeMature,
         rootOnly: true,
@@ -58,7 +58,7 @@ export default defineEventHandler(async (event) => {
     const replyRows = rootIds.length
       ? await prisma.chat.findMany({
           where: {
-            ...forumReadWhere({ includeMature }),
+            ...(await forumReadWhere({ includeMature })),
             originId: { in: rootIds },
             id: { notIn: rootIds },
           },

--- a/server/api/v1/forum/threads/index.post.ts
+++ b/server/api/v1/forum/threads/index.post.ts
@@ -3,6 +3,7 @@ import type { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import {
+  assertForumWriteAllowed,
   assertMatureForumWriteAllowed,
   forumPostSelect,
   parseForumAttachmentReferences,
@@ -38,6 +39,7 @@ export default defineEventHandler(async (event) => {
     const content = requiredString(rawBody.content, 'content', 60_000)
     const isMature = optionalBoolean(rawBody.isMature, 'isMature') ?? false
     assertMatureForumWriteAllowed(actor.auth, isMature)
+    await assertForumWriteAllowed(event, actor, content)
 
     const attachmentReferences = parseForumAttachmentReferences(rawBody.attachments) ?? []
     const attachmentRelations = await requireForumAttachmentRelations(
@@ -52,7 +54,7 @@ export default defineEventHandler(async (event) => {
         content,
         title,
         channel: channel.slug,
-        isPublic: true,
+        isPublic: !actor.shadowRestricted,
         isActive: true,
         isMature,
         previousEntryId: null,

--- a/server/utils/audit.ts
+++ b/server/utils/audit.ts
@@ -20,3 +20,23 @@ export async function logAdminAction(
     console.error('[audit] failed to write admin log:', err)
   }
 }
+
+/** Same audit trail, for an action the system took automatically rather
+ * than one a human admin performed (e.g. auto-hiding a post that crossed
+ * the health-claim flag-escalation threshold -- see forumApi.ts). Log.userId
+ * is nullable specifically so these system entries don't have to borrow a
+ * real admin's identity. */
+export async function logSystemAction(message: string): Promise<void> {
+  try {
+    await prisma.log.create({
+      data: {
+        message,
+        username: 'system',
+        userId: null,
+        timestamp: new Date(),
+      },
+    })
+  } catch (err) {
+    console.error('[audit] failed to write system log:', err)
+  }
+}

--- a/server/utils/forumApi.ts
+++ b/server/utils/forumApi.ts
@@ -2,14 +2,25 @@ import { createError, getHeader, type H3Event } from 'h3'
 import type { Prisma } from '~/prisma/generated/prisma/client'
 import {
   buildForumReadFilter,
+  buildForumReplyReadFilter,
   canManageForumPost,
   findForumChannel,
   forumAttachmentCanonicalPath,
   forumParentBelongsToThread,
+  forumRetryAfterSeconds,
+  FORUM_DUPLICATE_WINDOW_MS,
+  FORUM_WRITE_WINDOW_MAX_POSTS,
+  FORUM_WRITE_WINDOW_MS,
   isForumAttachmentKind,
+  isForumNearDuplicate,
+  isForumPostEdited,
+  isForumPostRemoved,
+  isHealthClaimFlagReason,
   parseForumChannelRegistryJson,
+  shouldEscalateHealthClaimFlags,
   type ForumAttachmentReference,
   type ForumChannel,
+  type ForumFlagReason,
   type ForumOrder,
 } from '~/utils/forumApiContract'
 import {
@@ -18,7 +29,9 @@ import {
   requireScopedApiUser,
   type AuthGuardResult,
 } from './authGuard'
+import { logSystemAction } from './audit'
 import { effectiveShowMature, isMaturityRestricted } from './contentAccess'
+import { notInRestricted } from './restriction'
 import prisma from './prisma'
 
 const KIND_ROBOTS_ORIGIN = 'https://kindrobots.org'
@@ -114,6 +127,14 @@ export type ForumActor = {
   botId: number | null
   displayName: string
   botName: string | null
+  /** True when the underlying account is shadow-restricted
+   * (`User.isRestricted`, see server/utils/restriction.ts). Forum writes
+   * still succeed normally for a restricted actor -- explicitly rejecting
+   * them would tip off exactly the bad-faith accounts this exists to
+   * quietly contain -- but the resulting post is forced private so it
+   * never reaches the public commons. Set by requireForumWriter; callers
+   * that create Chat rows must fold this into `isPublic`. */
+  shadowRestricted: boolean
 }
 
 export type ForumReadContext = {
@@ -182,18 +203,46 @@ export async function getForumReadContext(
   return { auth, includeMature }
 }
 
-export function forumReadWhere(options: {
+/**
+ * Async because it now also excludes shadow-restricted accounts' content
+ * (server/utils/restriction.ts's `notInRestricted`) -- the existing
+ * "credential-level and Bot/account restriction" gap this closes: a
+ * restricted account could still write to the forum, and its posts still
+ * showed up in every public read path since the forum's own read filter
+ * never checked restriction status. A Bot inherits its owner's restriction
+ * since `notInRestricted` matches on the post's `userId`, which every forum
+ * post (bot-authored or not) always carries.
+ */
+export async function forumReadWhere(options: {
   channel?: string | null
   includeMature?: boolean
   rootOnly?: boolean
   cursor?: number | null
   order?: ForumOrder
-}): Prisma.ChatWhereInput {
-  return buildForumReadFilter(options) as Prisma.ChatWhereInput
+}): Promise<Prisma.ChatWhereInput> {
+  return {
+    ...(buildForumReadFilter(options) as Prisma.ChatWhereInput),
+    ...(await notInRestricted('userId')),
+  }
+}
+
+/** Reply-listing counterpart of `forumReadWhere` for a single thread's
+ * detail view -- see `buildForumReplyReadFilter`'s doc comment for why it
+ * deliberately omits the `isActive` filter (removed replies render as
+ * tombstones instead of vanishing). Still excludes restricted accounts'
+ * content, same as every other read path. */
+export async function forumReplyReadWhere(options: {
+  includeMature?: boolean
+}): Promise<Prisma.ChatWhereInput> {
+  return {
+    ...(buildForumReplyReadFilter(options) as Prisma.ChatWhereInput),
+    ...(await notInRestricted('userId')),
+  }
 }
 
 export async function requireForumWriter(event: H3Event): Promise<ForumActor> {
   const auth = await requireScopedApiUser(event, 'forum:write')
+  const shadowRestricted = Boolean(auth.user.isRestricted)
 
   if (auth.kind !== 'agent-credential') {
     return {
@@ -202,6 +251,7 @@ export async function requireForumWriter(event: H3Event): Promise<ForumActor> {
       botId: null,
       displayName: auth.user.username,
       botName: null,
+      shadowRestricted,
     }
   }
 
@@ -237,7 +287,163 @@ export async function requireForumWriter(event: H3Event): Promise<ForumActor> {
     botId: bot.id,
     displayName: bot.name,
     botName: bot.name,
+    shadowRestricted,
   }
+}
+
+// --- Conservative per-actor write limits & duplicate rejection -------------
+
+/** Same actor identity used for rate-limit/duplicate lookups everywhere:
+ * a bound Bot gets its own budget (so one credential can't be starved by a
+ * sibling bot on the same account), otherwise the human account itself. */
+function forumWriteActorFilter(actor: ForumActor): Prisma.ChatWhereInput {
+  return actor.botId
+    ? { botId: actor.botId }
+    : { userId: actor.userId, botId: null }
+}
+
+export function setForumRetryAfterHeader(
+  event: H3Event,
+  unblockAtMs: number,
+): void {
+  event.node.res.setHeader(
+    'Retry-After',
+    String(forumRetryAfterSeconds(unblockAtMs)),
+  )
+}
+
+/**
+ * Guards thread/reply creation with a conservative rolling write-count limit
+ * and a short-window near-duplicate check. Throws a 429 (with a Retry-After
+ * header already set) rather than letting either through -- call this after
+ * validating `content` but before writing the Chat row. Not applied to
+ * edits or flags: this is specifically about not rewarding raw posting
+ * volume, per rainbow-butterflies/t-025.
+ */
+export async function assertForumWriteAllowed(
+  event: H3Event,
+  actor: ForumActor,
+  content: string,
+): Promise<void> {
+  const actorFilter = forumWriteActorFilter(actor)
+  const windowStart = new Date(Date.now() - FORUM_WRITE_WINDOW_MS)
+
+  const writeCount = await prisma.chat.count({
+    where: {
+      type: 'ToForum',
+      ...actorFilter,
+      createdAt: { gte: windowStart },
+    },
+  })
+
+  if (writeCount >= FORUM_WRITE_WINDOW_MAX_POSTS) {
+    const oldest = await prisma.chat.findFirst({
+      where: {
+        type: 'ToForum',
+        ...actorFilter,
+        createdAt: { gte: windowStart },
+      },
+      orderBy: { createdAt: 'asc' },
+      select: { createdAt: true },
+    })
+    const unblockAt =
+      (oldest?.createdAt.getTime() ?? Date.now()) + FORUM_WRITE_WINDOW_MS
+    setForumRetryAfterHeader(event, unblockAt)
+    throw createError({
+      statusCode: 429,
+      message:
+        'Too many forum posts in a short period. Please slow down and try again shortly.',
+    })
+  }
+
+  const duplicateWindowStart = new Date(Date.now() - FORUM_DUPLICATE_WINDOW_MS)
+  const recent = await prisma.chat.findMany({
+    where: {
+      type: 'ToForum',
+      ...actorFilter,
+      createdAt: { gte: duplicateWindowStart },
+    },
+    orderBy: { createdAt: 'desc' },
+    select: { content: true, createdAt: true },
+    take: 5,
+  })
+
+  const duplicate = recent.find((entry) =>
+    isForumNearDuplicate(content, entry.content),
+  )
+
+  if (duplicate) {
+    const unblockAt = duplicate.createdAt.getTime() + FORUM_DUPLICATE_WINDOW_MS
+    setForumRetryAfterHeader(event, unblockAt)
+    throw createError({
+      statusCode: 429,
+      message:
+        'This looks like a duplicate of a post you made moments ago. Please wait or change your content before posting again.',
+    })
+  }
+}
+
+// --- Health-claim flag escalation -------------------------------------------
+
+const FORUM_FLAG_REACTION_MARKER = '"kind":"forum-flag"'
+
+/**
+ * Called after a flag is recorded (posts/[id]/flag.post.ts). When a post has
+ * accumulated flags from at least FORUM_HEALTH_CLAIM_ESCALATION_THRESHOLD
+ * distinct flaggers citing a health-claim-relevant reason (misinformation or
+ * unsafe), auto-hides it (isPublic: false) pending human review and writes
+ * a system audit entry. Counts distinct flaggers, not raw flag rows, so one
+ * hostile account can't unilaterally hide a post by flagging it repeatedly.
+ * Best-effort and idempotent: re-hiding an already-hidden post is a no-op.
+ */
+export async function escalateHealthClaimFlagsIfNeeded(
+  postId: number,
+): Promise<boolean> {
+  const flagReactions = await prisma.reaction.findMany({
+    where: {
+      chatId: postId,
+      comment: { contains: FORUM_FLAG_REACTION_MARKER },
+    },
+    select: { userId: true, authorBotId: true, comment: true },
+  })
+
+  const distinctFlaggers = new Set<string>()
+
+  for (const reaction of flagReactions) {
+    if (!reaction.comment) continue
+
+    let parsed: { kind?: string; reason?: string }
+    try {
+      parsed = JSON.parse(reaction.comment)
+    } catch {
+      continue
+    }
+
+    if (parsed.kind !== 'forum-flag' || !parsed.reason) continue
+    if (!isHealthClaimFlagReason(parsed.reason as ForumFlagReason)) continue
+
+    distinctFlaggers.add(`${reaction.userId}:${reaction.authorBotId ?? ''}`)
+  }
+
+  if (!shouldEscalateHealthClaimFlags(distinctFlaggers.size)) return false
+
+  const post = await prisma.chat.findFirst({
+    where: { id: postId, type: 'ToForum', isPublic: true },
+    select: { id: true },
+  })
+
+  if (!post) return false
+
+  await prisma.chat.update({
+    where: { id: postId },
+    data: { isPublic: false },
+  })
+
+  await logSystemAction(
+    `Forum post #${postId} auto-hidden pending review: ${distinctFlaggers.size} distinct health-claim (misinformation/unsafe) flags reached the escalation threshold.`,
+  )
+
+  return true
 }
 
 export function assertForumPostManageable(
@@ -452,6 +658,7 @@ export async function requireForumThreadRoot(
       isActive: true,
       previousEntryId: null,
       ...(includeMature ? {} : { isMature: false }),
+      ...(await notInRestricted('userId')),
     },
     select: forumPostSelect,
   })
@@ -590,6 +797,35 @@ export function serializeForumPost(
   post: ForumPostRecord,
   includeMatureAttachments = false,
 ) {
+  const removed = isForumPostRemoved(post)
+
+  // A removed post renders as a tombstone: the thread/reply slot stays in
+  // place (so nesting and reply counts elsewhere stay coherent) but content
+  // and authorship are redacted rather than the post silently vanishing
+  // from a thread it's still structurally part of.
+  if (removed) {
+    return {
+      id: post.id,
+      createdAt: post.createdAt,
+      updatedAt: post.updatedAt,
+      threadId: post.originId ?? post.id,
+      parentId: post.previousEntryId,
+      channel: post.channel,
+      title: null,
+      content: '[removed]',
+      isMature: post.isMature,
+      removed: true,
+      edited: false,
+      attachments: [],
+      author: {
+        kind: 'REMOVED' as const,
+        displayName: '[removed]',
+        user: null,
+        bot: null,
+      },
+    }
+  }
+
   const user = post.User
     ? {
         id: post.User.id,
@@ -619,6 +855,8 @@ export function serializeForumPost(
     title: post.title,
     content: post.content,
     isMature: post.isMature,
+    removed: false,
+    edited: isForumPostEdited(post),
     attachments: serializeForumAttachments(post, includeMatureAttachments),
     author: {
       kind: bot ? ('AI_AGENT' as const) : ('HUMAN' as const),

--- a/utils/forumApiContract.ts
+++ b/utils/forumApiContract.ts
@@ -275,3 +275,142 @@ export function parseForumFlagReason(value: unknown): ForumFlagReason | null {
     ? (reason as ForumFlagReason)
     : null
 }
+
+// rainbow-butterflies/t-025 -- minimum safe commons controls. Everything
+// below is pure/DB-free so it stays covered by verifyForumApi.test.ts the
+// same way the rest of this file is; the DB-touching call sites live in
+// server/utils/forumApi.ts.
+
+/** A reply-listing filter that deliberately omits `isActive`, unlike
+ * `buildForumReadFilter` above: a thread's own detail view renders a
+ * removed reply as a "[removed]" tombstone (see `isForumPostRemoved` /
+ * forumApi.ts's `serializeForumPost`) instead of letting it silently vanish
+ * and orphan any still-visible replies nested under it. Feeds/listings keep
+ * using `buildForumReadFilter` (removed posts don't clutter browse views);
+ * only a thread's own reply list needs the tombstone-inclusive shape. */
+export function buildForumReplyReadFilter(
+  options: Pick<ForumReadFilterOptions, 'includeMature'> = {},
+): Record<string, unknown> {
+  const where: Record<string, unknown> = {
+    type: 'ToForum',
+    isPublic: true,
+  }
+
+  if (!options.includeMature) where.isMature = false
+
+  return where
+}
+
+/** Whether a post's own createdAt/updatedAt shows it was edited after
+ * creation. `updatedAt` is nullable in the historical Chat schema (rows
+ * created before the column existed), so no `updatedAt` at all reads as
+ * "never edited," not an error. */
+export function isForumPostEdited(post: {
+  createdAt: Date
+  updatedAt: Date | null
+}): boolean {
+  if (!post.updatedAt) return false
+  return post.updatedAt.getTime() > post.createdAt.getTime()
+}
+
+/** Whether a post has been moderated/self-deleted out of the live commons.
+ * `isActive: false` is the existing soft-delete flag (see posts/[id].delete.ts);
+ * this just names the check so callers don't inline the negation. */
+export function isForumPostRemoved(post: { isActive: boolean }): boolean {
+  return !post.isActive
+}
+
+// --- Conservative per-actor write limits -----------------------------------
+
+/** Rolling window a single credential/account's forum writes (thread + reply
+ * creation, not edits/flags) are counted against. Deliberately generous
+ * enough for real conversation, tight enough to blunt a flooding script:
+ * a well-behaved human or agent posting a message every minute or two never
+ * approaches this. */
+export const FORUM_WRITE_WINDOW_MS = 10 * 60 * 1000
+export const FORUM_WRITE_WINDOW_MAX_POSTS = 12
+
+/** Shorter window + higher bar used only to catch near-identical rapid
+ * reposts (the "did you mean to submit this twice" / flood-a-script case),
+ * not to rate-limit ordinary conversation. */
+export const FORUM_DUPLICATE_WINDOW_MS = 5 * 60 * 1000
+export const FORUM_DUPLICATE_SIMILARITY_THRESHOLD = 0.85
+
+/** Collapses whitespace/case so trivial formatting differences (extra
+ * spaces, a changed capital letter) don't defeat duplicate detection. */
+export function normalizeForumContent(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, ' ')
+}
+
+function characterBigrams(value: string): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (let i = 0; i < value.length - 1; i++) {
+    const gram = value.slice(i, i + 2)
+    counts.set(gram, (counts.get(gram) ?? 0) + 1)
+  }
+  return counts
+}
+
+/** Sorensen-Dice coefficient over character bigrams: cheap (linear time, no
+ * external deps), symmetric, and a good "near-duplicate" signal for the
+ * short-to-medium prose typical of forum posts. 1 = identical content,
+ * 0 = no shared bigrams at all. */
+export function forumContentSimilarity(a: string, b: string): number {
+  const normalizedA = normalizeForumContent(a)
+  const normalizedB = normalizeForumContent(b)
+
+  if (normalizedA === normalizedB) return 1
+  if (normalizedA.length < 2 || normalizedB.length < 2) {
+    return normalizedA === normalizedB ? 1 : 0
+  }
+
+  const bigramsA = characterBigrams(normalizedA)
+  const bigramsB = characterBigrams(normalizedB)
+
+  let intersection = 0
+  for (const [gram, count] of bigramsA) {
+    const other = bigramsB.get(gram)
+    if (other) intersection += Math.min(count, other)
+  }
+
+  const totalGrams = normalizedA.length - 1 + (normalizedB.length - 1)
+  return (2 * intersection) / totalGrams
+}
+
+export function isForumNearDuplicate(a: string, b: string): boolean {
+  return forumContentSimilarity(a, b) >= FORUM_DUPLICATE_SIMILARITY_THRESHOLD
+}
+
+/** Seconds until `unblockAtMs` from `nowMs`, floored at 1 so a Retry-After
+ * header never reads 0 or negative. */
+export function forumRetryAfterSeconds(
+  unblockAtMs: number,
+  nowMs = Date.now(),
+): number {
+  return Math.max(1, Math.ceil((unblockAtMs - nowMs) / 1000))
+}
+
+// --- Health-claim flag escalation -------------------------------------------
+
+/** Flag reasons treated as potentially health-claim-adjacent for the
+ * anti-malaria mission commons -- misinformation and unsafe content get
+ * escalated faster than ordinary spam/harassment/other flags. */
+export const FORUM_HEALTH_CLAIM_FLAG_REASONS: readonly ForumFlagReason[] = [
+  'misinformation',
+  'unsafe',
+]
+
+export function isHealthClaimFlagReason(reason: ForumFlagReason): boolean {
+  return (FORUM_HEALTH_CLAIM_FLAG_REASONS as readonly string[]).includes(reason)
+}
+
+/** Distinct flaggers (not raw flag count, so one hostile actor can't
+ * unilaterally hide a post by flagging it repeatedly) required before a
+ * post is auto-hidden pending review. */
+export const FORUM_HEALTH_CLAIM_ESCALATION_THRESHOLD = 2
+
+export function shouldEscalateHealthClaimFlags(
+  distinctFlaggerCount: number,
+): boolean {
+  return distinctFlaggerCount >= FORUM_HEALTH_CLAIM_ESCALATION_THRESHOLD
+}

--- a/utils/forumOpenApi.ts
+++ b/utils/forumOpenApi.ts
@@ -176,6 +176,7 @@ export const forumAgentOpenApiSpec = {
           '401': errorResponse,
           '403': errorResponse,
           '404': errorResponse,
+          '429': errorResponse,
         },
       },
     },
@@ -232,6 +233,7 @@ export const forumAgentOpenApiSpec = {
           '401': errorResponse,
           '403': errorResponse,
           '404': errorResponse,
+          '429': errorResponse,
         },
       },
     },
@@ -445,6 +447,8 @@ export const forumAgentOpenApiSpec = {
           'title',
           'content',
           'isMature',
+          'removed',
+          'edited',
           'attachments',
           'author',
         ],
@@ -458,6 +462,16 @@ export const forumAgentOpenApiSpec = {
           title: { type: ['string', 'null'] },
           content: { type: 'string' },
           isMature: { type: 'boolean' },
+          removed: {
+            type: 'boolean',
+            description:
+              'True when this post was moderated or self-deleted. Removed posts keep their id/thread position (a tombstone) instead of vanishing -- content and author are redacted.',
+          },
+          edited: {
+            type: 'boolean',
+            description:
+              'True when the post was changed after creation (updatedAt > createdAt). Always false for a removed post.',
+          },
           attachments: {
             type: 'array',
             maxItems: 2,
@@ -467,7 +481,10 @@ export const forumAgentOpenApiSpec = {
             type: 'object',
             required: ['kind', 'displayName', 'user', 'bot'],
             properties: {
-              kind: { type: 'string', enum: ['HUMAN', 'AI_AGENT', 'HUMAN_AI', 'SYSTEM'] },
+              kind: {
+                type: 'string',
+                enum: ['HUMAN', 'AI_AGENT', 'HUMAN_AI', 'SYSTEM', 'REMOVED'],
+              },
               displayName: { type: 'string' },
               user: { $ref: '#/components/schemas/UserIdentity' },
               bot: { $ref: '#/components/schemas/BotIdentity' },
@@ -654,12 +671,17 @@ export const forumAgentOpenApiSpec = {
           success: { const: true },
           data: {
             type: 'object',
-            required: ['id', 'createdAt', 'postId', 'reason'],
+            required: ['id', 'createdAt', 'postId', 'reason', 'escalated'],
             properties: {
               id: { type: 'integer' },
               createdAt: { type: 'string', format: 'date-time' },
               postId: { type: 'integer' },
               reason: { type: 'string' },
+              escalated: {
+                type: 'boolean',
+                description:
+                  'True when this flag pushed the post over the health-claim (misinformation/unsafe) escalation threshold and it was auto-hidden pending review.',
+              },
             },
           },
           statusCode: { type: 'integer' },

--- a/utils/scripts/verifyForumApi.test.ts
+++ b/utils/scripts/verifyForumApi.test.ts
@@ -1,18 +1,29 @@
 import assert from 'node:assert/strict'
 import {
   DEFAULT_FORUM_CHANNELS,
+  FORUM_DUPLICATE_SIMILARITY_THRESHOLD,
+  FORUM_HEALTH_CLAIM_ESCALATION_THRESHOLD,
   buildForumReadFilter,
+  buildForumReplyReadFilter,
   canManageForumPost,
   credentialHasForumScope,
   findForumChannel,
   forumAttachmentCanonicalPath,
+  forumContentSimilarity,
   forumParentBelongsToThread,
   forumPostIsPubliclyVisible,
+  forumRetryAfterSeconds,
   isForumAttachmentKind,
+  isForumNearDuplicate,
+  isForumPostEdited,
+  isForumPostRemoved,
   isForumThreadRoot,
+  isHealthClaimFlagReason,
+  normalizeForumContent,
   parseForumChannelRegistryJson,
   parseForumFlagReason,
   parseForumLimit,
+  shouldEscalateHealthClaimFlags,
 } from '../forumApiContract.js'
 
 const expectedSlugs = [
@@ -219,6 +230,101 @@ const expectedSlugs = [
   assert.equal(parseForumLimit('30'), 30)
   assert.equal(parseForumLimit('999'), 100)
   assert.equal(parseForumLimit('nope'), 30)
+}
+
+// rainbow-butterflies/t-025 -- minimum safe commons controls.
+{
+  assert.equal(normalizeForumContent('  Hello   World  '), 'hello world')
+  assert.equal(normalizeForumContent('SAME'), normalizeForumContent('same'))
+
+  assert.equal(forumContentSimilarity('hello world', 'hello world'), 1)
+  assert.equal(forumContentSimilarity('hello world', 'HELLO   WORLD'), 1)
+  assert.equal(forumContentSimilarity('', ''), 1)
+  assert.equal(forumContentSimilarity('a', 'ab'), 0)
+
+  const nearlyIdentical = forumContentSimilarity(
+    'Please check out my new project, it is really cool!',
+    'Please check out my new project, it is really cool.',
+  )
+  assert.ok(
+    nearlyIdentical >= FORUM_DUPLICATE_SIMILARITY_THRESHOLD,
+    `expected near-identical strings to score >= ${FORUM_DUPLICATE_SIMILARITY_THRESHOLD}, got ${nearlyIdentical}`,
+  )
+  assert.equal(
+    isForumNearDuplicate(
+      'Please check out my new project, it is really cool!',
+      'Please check out my new project, it is really cool.',
+    ),
+    true,
+  )
+
+  const unrelated = forumContentSimilarity(
+    'Please check out my new project, it is really cool!',
+    'The weather has been unusually mild this week in the valley.',
+  )
+  assert.ok(
+    unrelated < FORUM_DUPLICATE_SIMILARITY_THRESHOLD,
+    `expected unrelated strings to score < ${FORUM_DUPLICATE_SIMILARITY_THRESHOLD}, got ${unrelated}`,
+  )
+  assert.equal(
+    isForumNearDuplicate(
+      'Please check out my new project, it is really cool!',
+      'The weather has been unusually mild this week in the valley.',
+    ),
+    false,
+  )
+
+  assert.equal(forumRetryAfterSeconds(10_000, 0), 10)
+  assert.equal(forumRetryAfterSeconds(1_500, 0), 2)
+  assert.equal(forumRetryAfterSeconds(-5_000, 0), 1)
+}
+
+{
+  const created = new Date('2026-08-01T00:00:00Z')
+  assert.equal(isForumPostEdited({ createdAt: created, updatedAt: null }), false)
+  assert.equal(isForumPostEdited({ createdAt: created, updatedAt: created }), false)
+  assert.equal(
+    isForumPostEdited({
+      createdAt: created,
+      updatedAt: new Date('2026-08-01T00:05:00Z'),
+    }),
+    true,
+  )
+
+  assert.equal(isForumPostRemoved({ isActive: true }), false)
+  assert.equal(isForumPostRemoved({ isActive: false }), true)
+
+  assert.deepEqual(buildForumReplyReadFilter(), {
+    type: 'ToForum',
+    isPublic: true,
+    isMature: false,
+  })
+  assert.deepEqual(buildForumReplyReadFilter({ includeMature: true }), {
+    type: 'ToForum',
+    isPublic: true,
+  })
+  assert.equal('isActive' in buildForumReplyReadFilter(), false)
+}
+
+{
+  assert.equal(isHealthClaimFlagReason('misinformation'), true)
+  assert.equal(isHealthClaimFlagReason('unsafe'), true)
+  assert.equal(isHealthClaimFlagReason('spam'), false)
+  assert.equal(isHealthClaimFlagReason('harassment'), false)
+  assert.equal(isHealthClaimFlagReason('other'), false)
+
+  assert.equal(
+    shouldEscalateHealthClaimFlags(FORUM_HEALTH_CLAIM_ESCALATION_THRESHOLD - 1),
+    false,
+  )
+  assert.equal(
+    shouldEscalateHealthClaimFlags(FORUM_HEALTH_CLAIM_ESCALATION_THRESHOLD),
+    true,
+  )
+  assert.equal(
+    shouldEscalateHealthClaimFlags(FORUM_HEALTH_CLAIM_ESCALATION_THRESHOLD + 5),
+    true,
+  )
 }
 
 console.log('verifyForumApi.test.ts: all assertions passed')


### PR DESCRIPTION
### Task
rainbow-butterflies/t-025: Harden commons moderation, anti-spam, and credential controls (kind: software)

### What changed / what I produced
- **Credential-level and Bot/account restriction (real gap closed):** `requireForumWriter` now flags a shadow-restricted account (`User.isRestricted`) via a new `shadowRestricted` field on `ForumActor`; thread/reply creation forces `isPublic: false` for such an actor rather than rejecting outright (preserves shadow-ban semantics — no signal to the bad-faith account). Every forum read path (`forumReadWhere`, the new `forumReplyReadWhere`, `requireForumThreadRoot`, direct post fetch) now also excludes restricted accounts' content via the existing `notInRestricted` helper — previously the forum never checked restriction at all on either the write or read side. A Bot inherits its owner's restriction since every post carries a real `userId`.
- **Conservative per-actor write limits + duplicate rejection + Retry-After:** new `assertForumWriteAllowed` (called from thread + reply creation only, not edits/flags) enforces a rolling 12-posts/10-minutes cap and a 5-minute near-duplicate check (Sørensen–Dice bigram similarity ≥ 0.85) per actor (bound Bot gets its own budget, otherwise the account). Both throw a 429 with a `Retry-After` header already set.
- **Health-claim escalation hooks:** `escalateHealthClaimFlagsIfNeeded`, called after a flag is recorded, auto-hides (`isPublic: false`) a post once ≥ 2 *distinct* flaggers have cited `misinformation`/`unsafe`, and writes a system audit entry. Distinct-flagger counting (not raw flag count) keeps one hostile account from unilaterally hiding a post.
- **Moderation audit metadata:** `posts/[id].patch.ts` / `posts/[id].delete.ts` now write a `logAdminAction` entry (the existing admin-audit `Log` helper) whenever the actor moderating a post isn't its author (i.e. an admin acting on someone else's content) — a self-edit/delete stays unlogged beyond the post's own state.
- **Clear edited/removed states:** every serialized post now reports `edited` (derived from `createdAt`/`updatedAt`) and `removed`. A removed (`isActive: false`) post renders as a `"[removed]"` tombstone — in thread detail and direct-by-id fetch — instead of vanishing, so reply nesting stays structurally coherent; feeds/listings still filter removed posts out entirely.
- Report/flag handling already existed (`posts/[id]/flag.post.ts`); its response now also reports `escalated`.
- `utils/forumOpenApi.ts` updated to document the new response fields (`removed`, `edited`, `escalated`), the `REMOVED` author kind, and `429` responses on the two write endpoints.

No schema/migration changes — everything reuses existing model fields (`User.isRestricted`, `Reaction`-based flags, the `Log` model via `logAdminAction`/new `logSystemAction`).

### How I verified
- `npx tsx utils/scripts/verifyForumApi.test.ts` — pass (extended with new pure-function coverage for rate-limit/duplicate/escalation/edited/removed logic)
- `npx tsx utils/scripts/verifyForumGeneration.test.ts` — pass (unchanged, confirms no regression)
- `npx tsx utils/scripts/verifyForumOpenApi.test.ts` — pass (contract still matches the implemented route set)
- `npx vue-tsc --noEmit` — clean repo-wide
- `npx eslint` on every changed file — clean
- `npx prettier --check` on every changed file — the same pre-existing warnings present on `main` before this change (confirmed file-by-file via `git stash`); every line prettier still flags after my diff is outside the hunks I added

### Stakes
reversible

### Flags for Reviewer
- The write-limit (12/10min) and duplicate-similarity threshold (0.85/5min) are my own conservative defaults, not numbers Silas specified — easy to retune later if they prove too tight/loose once real traffic shows up.
- Health-claim escalation auto-*hides* rather than deletes, and is reversible by any admin/author edit that flips `isPublic` back — no data is destroyed.
- Tombstoning removed posts (rather than 404ing) is a UX-visible behavior change for `GET /api/v1/forum/posts/{id}` and thread detail; feeds/browse listings are unaffected (still filter removed posts out).

### Kaizen suggestion
`buildForumReplyReadFilter`'s reply-listing path and `forumReadWhere`'s feed path could share more logic (dedup the two `notInRestricted` merges into one internal helper) if a future slice adds a third read-shape — not worth abstracting for two call sites today.

### Notes for reviewer
Conductor task `rainbow-butterflies/t-025` claimed and will be closed out from this PR once merged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPPcK9ua7gD1S3Udg7pPe4)_