### PR TITLE
rainbow-butterflies/t-026: forum MVP acceptance pass

### DIFF
--- a/components/user/forum-thread.vue
+++ b/components/user/forum-thread.vue
@@ -1,7 +1,7 @@
 <!-- /components/content/forum/forum-thread.vue -->
 <template>
   <div class="kr-container max-w-4xl space-y-6 px-4 py-8">
-    <div v-if="loadError" class="kr-note kr-note-error">
+    <div v-if="loadError" class="kr-note kr-note-error" role="alert">
       {{ loadError }}
     </div>
 
@@ -111,7 +111,11 @@
           v-if="expandedThreadId === thread.id"
           class="pl-4 border-l-2 border-base-300 space-y-3 mt-3"
         >
-          <div v-if="repliesLoading" class="text-sm text-base-content/60">
+          <div
+            v-if="repliesLoading"
+            class="text-sm text-base-content/60"
+            role="status"
+          >
             Loading replies…
           </div>
 

--- a/server/api/v1/forum/posts/[id].get.ts
+++ b/server/api/v1/forum/posts/[id].get.ts
@@ -50,6 +50,37 @@ export default defineEventHandler(async (event) => {
       })
     }
 
+    // A reply is only browsable through its thread, so it must not outlive
+    // that thread's root becoming unreachable (removed, privatized, or its
+    // author restricted) -- otherwise a direct link to the reply would keep
+    // working via GET by id even though threads/[id].get.ts's
+    // requireForumThreadRoot already 404s the same thread when browsed.
+    // Mirrors requireForumThreadRoot's own visibility filter exactly.
+    // (A thread root's own originId points at itself, so this only fires
+    // for genuine replies, not an extra round-trip re-checking the root
+    // against its own already-verified state.)
+    if (post.originId && post.originId !== post.id) {
+      const rootVisible = await prisma.chat.findFirst({
+        where: {
+          id: post.originId,
+          type: 'ToForum',
+          isPublic: true,
+          isActive: true,
+          previousEntryId: null,
+          ...(includeMature ? {} : { isMature: false }),
+          ...(await notInRestricted('userId')),
+        },
+        select: { id: true },
+      })
+
+      if (!rootVisible) {
+        throw createError({
+          statusCode: 404,
+          message: `Forum post ${id} was not found.`,
+        })
+      }
+    }
+
     event.node.res.statusCode = 200
     return {
       success: true,


### PR DESCRIPTION
### Task
rainbow-butterflies/t-026: Verify the complete forum MVP across security, accessibility, and responsive UX (kind: software)

### What changed / what I produced
Full acceptance pass over the forum MVP (auth, public/private/maturity access, credential revocation, nesting, embeds, generation permission boundaries, direct-load, keyboard/a11y). Fixed the two reversible findings from that pass:

- **Orphaned-reply visibility gap** (`server/api/v1/forum/posts/[id].get.ts`): a reply fetched directly by ID never re-checked whether its own thread *root* was still visible (public/active/not-restricted) the way `threads/[id].get.ts`'s `requireForumThreadRoot` already does when browsing. So if a thread root was later removed, privatized, or its author restricted, `threads/[id]` correctly 404s the whole thread, but a direct link to one of its still-`isActive` replies kept resolving normally — an orphaned reply outliving the thread it belongs to. Fixed by re-checking the origin post's visibility (same filter `requireForumThreadRoot` uses) whenever the fetched post is a reply (`originId !== id`).
- **Missing live-region announcements** (`components/user/forum-thread.vue`): the load-error banner and "Loading replies…" state had no `role="alert"`/`role="status"`, unlike the more careful `forum-art-generation-context.vue`, which already uses this pattern. Screen-reader users got no announcement of load failures or new content. Added `role="alert"` to the error banner and `role="status"` to the loading-replies indicator.

### How I verified
- `eslint` + `prettier --check` on both changed files — clean.
- `vue-tsc --noEmit` — clean repo-wide.
- All three forum contract test scripts (`verifyForumApi.test.ts`, `verifyForumGeneration.test.ts`, `verifyForumOpenApi.test.ts`) — all assertions pass.
- `npm run test:layout-contract` — holds at the 207-violation baseline, zero new violations (no layout/CSS changed, only `role` attributes added).

### Audit summary (all 8 dimensions the task asked to verify)
1. **Auth/key security** — CORRECT. Every write route requires `forum:write` scope via `requireScopedApiUser`; read routes are intentionally public-with-optional-auth and 401 on garbage credentials; no bypass found. (One unrelated dead-code note: `credentialHasForumScope` in `utils/forumApiContract.ts` is unit-tested but never called from a real route — all enforcement goes through `authHasScope`. Not a vulnerability, just worth a cleanup someday.)
2. **Public/private/maturity access** — CORRECT for thread-root browsing (same filter enforced on list and detail). The orphaned-reply gap above was the one real inconsistency; fixed.
3. **Credential revocation** — CORRECT. `validateAgentCredential` does a live DB lookup + `revokedAt`/`expiresAt` check on every request, no caching layer.
4. **Forum nesting** — cycles are structurally impossible (auto-increment IDs, `previousEntryId` must reference an existing row). No explicit max-depth guard exists, though — only indirect rate-limiting (12 posts/10min/actor) bounds how fast a deep chain could grow. Not exploitable as a crash today (client renders replies as a flat list), but a real gap. Filed as `rainbow-butterflies/t-032` rather than picking an arbitrary depth limit unreviewed.
5. **Object embeds** — CORRECT. Attach-time and read-time both re-check the live `isPublic`/`isActive`/`isMature` state of the embedded ArtImage/Project/Character, so a later-privatized embed silently disappears from every subsequent read rather than leaking.
6. **Generation permission boundaries** — CORRECT. Only the post's own author (human, or the specific bot bound to an agent credential) can trigger generation from their post; mana/tokens always charge the authenticated caller; independent checks at both request time and async-completion time prevent cross-user misattribution.
7. **Direct-load/refresh** — Backend is CORRECT (every GET-by-id route is self-contained, no reliance on prior client state). UI gap: no `useAsyncData`/SSR for the forum listing, and no dedicated per-thread permalink page/route — thread expansion is pure client-side state. Not a bug (nothing breaks on refresh), but a real product-scope question about whether "share a link to this thread" is expected for MVP. Left as a note rather than a task; flag for Silas if deep-linking is expected.
8. **Keyboard/focus/accessibility** — Largely CORRECT (every interactive control is a real `<button>`/`<a>`, no keyboard traps, no bare-div-with-click). Fixed the live-region gap above. Also found `avatarImage` is defined in every author type but never rendered anywhere in the forum UI (emoji-only identity) — not an a11y defect since no `<img>` is rendered, but an incomplete feature. Filed as `rainbow-butterflies/t-033`.

**Phone/tablet/desktop visual checks**: this PR changes no layout/CSS (only `role` attributes), and `test:layout-contract` holds at baseline. Per this repo's own documented constraints (kind_robots migrated off Vercel; no PR-preview deploys exist anymore), real cross-width pixel verification isn't possible pre-merge in this sandbox — that's covered by the scheduled `responsive-layout-audit.yml` `audit` check against production post-deploy, and final human visual sign-off is `rainbow-butterflies/t-027` (already a hard `needs-human` gate). Not claiming to have done a pixel-level check here.

### Stakes
reversible

### Notes for reviewer
Companion conductor PR closes `rainbow-butterflies/t-026` as `done` and files `t-032`/`t-033` for the two real-but-non-blocking gaps found.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jg1bFXdWbWrkFVM47w3Ckt)_