### PR TITLE
rainbow-butterflies/t-032: add max reply-nesting-depth guard to forum replies

### DIFF
--- a/server/utils/forumApi.ts
+++ b/server/utils/forumApi.ts
@@ -7,8 +7,10 @@ import {
   findForumChannel,
   forumAttachmentCanonicalPath,
   forumParentBelongsToThread,
+  forumReplyDepthAtLimit,
   forumRetryAfterSeconds,
   FORUM_DUPLICATE_WINDOW_MS,
+  FORUM_MAX_REPLY_DEPTH,
   FORUM_WRITE_WINDOW_MAX_POSTS,
   FORUM_WRITE_WINDOW_MS,
   isForumAttachmentKind,
@@ -673,6 +675,31 @@ export async function requireForumThreadRoot(
   return root
 }
 
+/** Walks the previousEntryId chain from `postId` back toward the thread root,
+ * counting hops. Bails out as soon as the count reaches FORUM_MAX_REPLY_DEPTH
+ * + 1 rather than walking all the way to the root every time -- callers only
+ * ever need to know whether the depth is at/over the cap, not its exact value
+ * once it's already over. Cycles are structurally impossible (see
+ * forumReplyDepthAtLimit's doc comment), so this always terminates. */
+async function forumReplyDepth(postId: number): Promise<number> {
+  let depth = 0
+  let currentId: number | null = postId
+
+  while (currentId !== null && depth <= FORUM_MAX_REPLY_DEPTH) {
+    const parentId: number = currentId
+    const row: { previousEntryId: number | null } | null =
+      await prisma.chat.findUnique({
+        where: { id: parentId },
+        select: { previousEntryId: true },
+      })
+    if (!row || row.previousEntryId === null) break
+    depth += 1
+    currentId = row.previousEntryId
+  }
+
+  return depth
+}
+
 export async function requireForumReplyParent(
   threadId: number,
   parentId: number,
@@ -686,6 +713,14 @@ export async function requireForumReplyParent(
     throw createError({
       statusCode: 400,
       message: 'The requested reply parent does not belong to this forum thread.',
+    })
+  }
+
+  const parentDepth = await forumReplyDepth(parent.id)
+  if (forumReplyDepthAtLimit(parentDepth)) {
+    throw createError({
+      statusCode: 400,
+      message: `This thread has reached the maximum reply nesting depth (${FORUM_MAX_REPLY_DEPTH}). Reply to an earlier post in the thread instead.`,
     })
   }
 

--- a/utils/forumApiContract.ts
+++ b/utils/forumApiContract.ts
@@ -238,6 +238,26 @@ export function forumParentBelongsToThread(
   )
 }
 
+/** rainbow-butterflies/t-032 -- reply nesting is unbounded by data-model
+ * design (cycles are structurally impossible: auto-increment Chat IDs,
+ * previousEntryId must reference an already-existing row) and today's
+ * forum-thread.vue renders replies as a flat list, not a recursive tree, so
+ * depth alone can't crash anything client-side. It's also bounded indirectly
+ * by the per-actor write rate limit above. Still, a determined actor with
+ * multiple accounts/credentials could build an arbitrarily deep
+ * previousEntryId chain over time, so cap it explicitly rather than relying
+ * only on the indirect rate limit. */
+export const FORUM_MAX_REPLY_DEPTH = 8
+
+/** A reply's depth is its parent's depth + 1 (the thread root is depth 0).
+ * `parentDepth` is the number of previousEntryId hops from the root to the
+ * proposed parent -- see forumReplyDepth() in server/utils/forumApi.ts,
+ * which walks that chain (the walk itself needs Prisma, so it can't live
+ * here). */
+export function forumReplyDepthAtLimit(parentDepth: number): boolean {
+  return parentDepth >= FORUM_MAX_REPLY_DEPTH
+}
+
 export type ForumReadFilterOptions = {
   channel?: string | null
   includeMature?: boolean

--- a/utils/scripts/verifyForumApi.test.ts
+++ b/utils/scripts/verifyForumApi.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_FORUM_CHANNELS,
   FORUM_DUPLICATE_SIMILARITY_THRESHOLD,
   FORUM_HEALTH_CLAIM_ESCALATION_THRESHOLD,
+  FORUM_MAX_REPLY_DEPTH,
   buildForumReadFilter,
   buildForumReplyReadFilter,
   canManageForumPost,
@@ -12,6 +13,7 @@ import {
   forumContentSimilarity,
   forumParentBelongsToThread,
   forumPostIsPubliclyVisible,
+  forumReplyDepthAtLimit,
   forumRetryAfterSeconds,
   isForumAttachmentKind,
   isForumNearDuplicate,
@@ -221,6 +223,14 @@ const expectedSlugs = [
     }),
     false,
   )
+}
+
+// rainbow-butterflies/t-032 -- max reply-nesting-depth guard.
+{
+  assert.equal(forumReplyDepthAtLimit(0), false)
+  assert.equal(forumReplyDepthAtLimit(FORUM_MAX_REPLY_DEPTH - 1), false)
+  assert.equal(forumReplyDepthAtLimit(FORUM_MAX_REPLY_DEPTH), true)
+  assert.equal(forumReplyDepthAtLimit(FORUM_MAX_REPLY_DEPTH + 1), true)
 }
 
 {


### PR DESCRIPTION
## What

Kaizen/finding from t-026's forum MVP acceptance pass: `requireForumReplyParent` (`server/utils/forumApi.ts`) accepts any `parentId` as long as it belongs to the thread, with no explicit max-nesting-depth check. Cycles are structurally impossible (auto-increment Chat IDs, `previousEntryId` must reference an already-existing row), and depth wasn't exploitable as a crash/DoS today (`forum-thread.vue` renders replies as a flat list, not a recursive tree) — it was only indirectly bounded by the per-actor write rate limit (12 posts/10min). A determined actor with multiple accounts/credentials could still build an arbitrarily deep `previousEntryId` chain over time.

## Change

- `utils/forumApiContract.ts`: adds `FORUM_MAX_REPLY_DEPTH` (8) and a pure `forumReplyDepthAtLimit(parentDepth)` helper.
- `server/utils/forumApi.ts`: adds `forumReplyDepth(postId)`, which walks the `previousEntryId` chain from a proposed parent back toward the thread root, bailing out after at most `FORUM_MAX_REPLY_DEPTH + 1` hops regardless of actual chain length. `requireForumReplyParent` now rejects with a 400 (`This thread has reached the maximum reply nesting depth (8). Reply to an earlier post in the thread instead.`) once the parent is already at the cap.
- `utils/scripts/verifyForumApi.test.ts`: boundary assertions for `forumReplyDepthAtLimit`.

Purely additive/defensive — does not change the shape of any existing reply, does not touch rate limiting or moderation, and every thread under the 8-level cap behaves exactly as before.

## Verification

- `npx tsx utils/scripts/verifyForumApi.test.ts` — all assertions pass.
- `npx eslint server/utils/forumApi.ts utils/forumApiContract.ts utils/scripts/verifyForumApi.test.ts` — clean.
- `vue-tsc --noEmit` — clean repo-wide.
- Diff scoped to exactly the 3 files above (confirmed pre-existing whole-file `prettier --check` drift on `main` for these files — not CI-enforced in this repo, no prettier step in `.github/workflows/` — so left untouched rather than reformatting ~90 unrelated pre-existing lines).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ruNFWNsaG6nGojchdzqdH)_