### PR TITLE
interface-vision/t-104 slice 71: adopt kr-scroll on 3 more scroll regions

### DIFF
--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -8,10 +8,7 @@
       The ArtJob dashboard is admin-only.
     </div>
 
-    <div
-      v-else
-      class="flex h-full min-h-0 flex-1 flex-col gap-3 overflow-y-auto overscroll-contain p-3"
-    >
+    <div v-else class="flex h-full kr-scroll flex-col gap-3 p-3">
       <header class="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h2 class="text-lg font-semibold">ArtJob Pipeline</h2>

--- a/components/art/stylist-relay-status.vue
+++ b/components/art/stylist-relay-status.vue
@@ -20,10 +20,7 @@
       Relay diagnostics are admin-only.
     </div>
 
-    <div
-      v-else
-      class="flex h-full min-h-0 flex-1 flex-col gap-3 overflow-y-auto overscroll-contain p-3"
-    >
+    <div v-else class="flex h-full kr-scroll flex-col gap-3 p-3">
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h2 class="text-lg font-semibold">Relay Diagnostics</h2>

--- a/components/scenarios/scenario-story.vue
+++ b/components/scenarios/scenario-story.vue
@@ -21,7 +21,7 @@
 <template>
   <section
     v-if="storyStore.phase === 'configure'"
-    class="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto overscroll-contain"
+    class="flex kr-scroll flex-col gap-3"
   >
     <div
       class="flex shrink-0 items-center justify-between gap-2 kr-panel-flat p-2 pl-1 shadow-sm"


### PR DESCRIPTION
### Task
interface-vision/t-104 (conductor): drive live front-end consistency onto shared kr-* components and composition rules — slice 71 (kind: software)

### What changed
Found 3 components carrying the exact `.kr-scroll` base utility set
(`min-h-0 flex-1 overflow-y-auto overscroll-contain`) mixed with other,
unrelated utilities (`flex flex-col gap-3`, `h-full`, `p-3`) but not yet
using the primitive class:

- `components/scenarios/scenario-story.vue` — the `configure`-phase root
  `<section>` (mutually exclusive with a `v-else` grid-layout branch, so
  still exactly one scroll owner).
- `components/art/stylist-relay-status.vue` — the admin-only `v-else`
  branch (the `v-if` non-admin branch has no `overflow-y-auto`, so still
  exactly one scroll owner at runtime).
- `components/art/artjob-queue-browser.vue` — same shape as the above.

All three replace the 4-class base string with `kr-scroll`, keeping the
sibling utilities (`flex`, `flex-col`, `gap-3`, `h-full`, `p-3`) as-is —
`kr-scroll` doesn't declare `display`, so it composes cleanly with them.
Pure rename, no geometry or behavior change.

### How I verified
- `npx eslint` on the 3 changed files: clean.
- `npx prettier --check`: clean (had to `--write` 2 files after the edit
  shortened their `class` attribute onto one line; diffed to confirm the
  only change was the class-attribute collapse).
- `npx vue-tsc --noEmit`: clean repo-wide.
- `npm run test:layout-contract`: holds — 0 components declaring more than
  one scroll region (unchanged), no new violations in any bucket.

### Stakes
reversible

### Notes for reviewer
Continuing the recurring interface-vision/t-104 slice series (prior slices
68-70 covered `.kr-scroll`/`.kr-toolbar`/`.kr-surface`/`.kr-stage` on other
files). Also grepped for remaining `.kr-toolbar` candidates
(`relative z-20 flex shrink-0 flex-wrap items-center gap-2`) and found 6
more matches, but none carry `relative z-20` already and none were checked
this slice for absolutely-positioned descendants/z-index-sensitive
siblings — left for a future slice rather than adopting `kr-toolbar`'s
baked-in stacking-context change without that check.

### Kaizen suggestion
The 6 `.kr-toolbar` candidates found but not converted this slice
(`model-builder-recipe-selector.vue`, `stage-manager.vue` [already
excluded once for lacking `relative z-20`], `kr-manager.vue`,
`giftshop-manager.vue`, `home-object-sheet.vue`, `art-manager.vue`) are a
concrete next target for slice 72 — read each for absolutely-positioned
descendants before adopting `relative z-20`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKe16LswXwhHHmnPREyxJ8)_