### PR TITLE
interface-vision/t-104 slice 73: adopt kr-scroll on the workspace sheet body

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -106,7 +106,7 @@
               </button>
             </div>
 
-            <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3">
+            <div class="kr-scroll p-3">
               <ClientOnly>
                 <LazyWorkspaceSheet />
 


### PR DESCRIPTION
### Task
Conductor interface-vision/t-104 (recurring): drive live front-end consistency onto shared `kr-*` components and composition rules. Slice 73.

### What changed / what I produced
`app.vue`'s workspace-sheet scroll region (the sheet opened by the header's "?" button) carried the exact base utility set `.kr-scroll` already bakes in (`min-h-0 flex-1 overflow-y-auto overscroll-contain`), mixed with its own extra `p-3` padding. Swapped to the shorthand class, keeping `p-3` as the only sibling utility. Pure rename, no geometry/behavior change.

Found via a repo-wide scan for class attributes that are an exact superset of the `.kr-scroll`/`.kr-toolbar` base token sets and don't already carry the shorthand class. This was the only remaining `.kr-scroll` exact match; no remaining `.kr-toolbar` exact matches were found (slice 72 cleared the last 6 known candidates).

### How I verified
- `eslint app.vue` — clean (1 pre-existing unrelated warning: `@pageReady` hyphenation)
- `prettier --check app.vue` — clean
- `npm run test` (vue-tsc --noEmit, repo-wide) — clean
- `test:layout-contract` — holds at the existing 207-violation baseline, zero new violations

### Stakes
Reversible, scoped, single-line CSS-class rename.

### Flags for Reviewer
None.

### Notes for reviewer
Continues the established slice-by-slice `kr-*` adoption pattern from slices 71/72 (conductor PRs #2241/#2242). See `projects/interface-vision/roadmap.yaml` t-104 in conductor for full history.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8Ka5bPb8ndD13gCRbpPZJ)_