### PR TITLE
Use shared panel primitive for aquarium loading state

### DIFF
--- a/pages/play/aquarium/browse/index.vue
+++ b/pages/play/aquarium/browse/index.vue
@@ -33,7 +33,7 @@
 
       <div
         v-if="loading && !tanks.length"
-        class="grid min-h-[40vh] place-items-center rounded-3xl border border-base-300 bg-base-100"
+        class="kr-panel-flat grid min-h-[40vh] place-items-center rounded-3xl"
       >
         <div class="text-center">
           <span class="loading loading-ring loading-lg text-primary" />


### PR DESCRIPTION
## Summary
- migrate the Cthulhuquarium public-tank loading surface to `kr-panel-flat`
- preserve the existing `rounded-3xl` geometry, minimum height, centering, copy, and behavior
- remove duplicated `border border-base-300 bg-base-100` surface tokens only

Conductor: interface-vision/t-104
Session: openai-scheduled-20260831T021136Z-interface-vision-t104-k7q4

## Validation
CI is authoritative for this connector-only slice. The substitution is byte-equivalent for the removed surface tokens because `kr-panel-flat` owns exactly `rounded-2xl border border-base-300 bg-base-100`; the existing `rounded-3xl` override remains on the element.