### PR TITLE
interface-vision/t-104 slice 74: adopt kr-stage on 13 tab-content sections

### DIFF
--- a/components/academy/academy-manager.vue
+++ b/components/academy/academy-manager.vue
@@ -1,6 +1,8 @@
 <!-- /components/academy/academy-manager.vue -->
 <template>
-  <section class="flex h-full min-h-0 w-full flex-col overflow-hidden bg-base-200 text-base-content">
+  <section
+    class="flex h-full min-h-0 w-full flex-col overflow-hidden bg-base-200 text-base-content"
+  >
     <!--
       Timeline and Style Gallery render purely off academyStore's static seed
       data (hydrated synchronously in onMounted below) — they never need
@@ -9,7 +11,7 @@
       fetch (see loadManagerData). Keeping these two branches first ensures a
       failed or slow art-server call never hides tabs that don't depend on it.
     -->
-    <section class="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+    <section class="kr-stage h-full">
       <div class="kr-scroll overscroll-contain p-3">
         <academy-timeline
           v-if="activeTab === 'timeline'"
@@ -45,7 +47,7 @@
         <div
           v-else-if="managerError"
           role="alert"
-          class="kr-note kr-note-error flex min-h-0 flex-1 flex-col overflow-hidden"
+          class="kr-note kr-note-error kr-stage"
         >
           <div class="flex flex-wrap items-center justify-between gap-3">
             <span>{{ managerError }}</span>

--- a/components/art/art-manager.vue
+++ b/components/art/art-manager.vue
@@ -27,10 +27,7 @@
       </div>
     </div>
 
-    <section
-      v-else-if="activeTab === 'gallery'"
-      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
-    >
+    <section v-else-if="activeTab === 'gallery'" class="kr-stage h-full">
       <art-gallery
         class="h-full min-h-0 flex-1 overflow-hidden"
         variant="dashboard"
@@ -41,7 +38,7 @@
 
     <section
       v-else
-      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
+      class="kr-stage h-full"
       @click.capture="
         activeTab === 'artjob' ? handleArtJobImageClick($event) : undefined
       "
@@ -149,7 +146,7 @@
 
           <div
             v-show="artJobWorkspaceTab === 'queue'"
-            class="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden p-3"
+            class="kr-stage gap-3 p-3"
           >
             <artjob-failed-page-requeue class="shrink-0" />
             <artjob-queue-browser class="min-h-0 flex-1 overflow-hidden" />

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -36,7 +36,7 @@
       :show-stats="true"
     />
 
-    <section v-else class="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
+    <section v-else class="kr-stage gap-4">
       <div class="flex shrink-0 flex-wrap gap-2 kr-panel-flat p-2">
         <button
           v-for="tab in modeTabs"

--- a/components/giftshop/giftshop-manager.vue
+++ b/components/giftshop/giftshop-manager.vue
@@ -28,14 +28,14 @@
       </button>
     </div>
 
-    <section class="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
+    <section class="kr-stage gap-4">
       <section
         v-if="
           activeTab === 'community' ||
           activeTab === 'mana' ||
           activeTab === 'forum'
         "
-        class="flex h-full min-h-0 flex-1 flex-col overflow-hidden kr-panel-flat"
+        class="kr-stage h-full kr-panel-flat"
       >
         <div class="kr-scroll overscroll-contain p-4">
           <template v-if="activeTab === 'community'">
@@ -99,10 +99,7 @@
         </div>
       </section>
 
-      <section
-        v-else-if="activeTab === 'giftshop'"
-        class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
-      >
+      <section v-else-if="activeTab === 'giftshop'" class="kr-stage h-full">
         <giftshop-interact class="h-full min-h-0 flex-1 overflow-hidden" />
       </section>
 

--- a/components/user/user-manager.vue
+++ b/components/user/user-manager.vue
@@ -51,10 +51,7 @@
       </NuxtLink>
     </section>
 
-    <section
-      v-else-if="activeTab === 'profile'"
-      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
-    >
+    <section v-else-if="activeTab === 'profile'" class="kr-stage h-full">
       <user-dashboard class="min-h-0 flex-1" />
     </section>
 
@@ -64,7 +61,7 @@
         activeTab === 'friends' ||
         activeTab === 'achievements'
       "
-      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-200"
+      class="kr-stage h-full rounded-2xl border border-base-300 bg-base-200"
     >
       <div class="kr-scroll overscroll-contain p-4">
         <avatar-picker
@@ -79,20 +76,14 @@
       </div>
     </section>
 
-    <section
-      v-else-if="activeTab === 'themes'"
-      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
-    >
+    <section v-else-if="activeTab === 'themes'" class="kr-stage h-full">
       <theme-gallery
         class="h-full min-h-0 flex-1 overflow-hidden"
         :show-header="false"
       />
     </section>
 
-    <section
-      v-else-if="activeTab === 'chats'"
-      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
-    >
+    <section v-else-if="activeTab === 'chats'" class="kr-stage h-full">
       <chat-gallery
         class="h-full min-h-0 flex-1 overflow-hidden"
         :show-header="false"


### PR DESCRIPTION
## Summary

Bounded consistency slice for the Conductor `interface-vision/t-104` recurring umbrella task. Repo-wide scan for `class` attributes that are an exact superset of `.kr-stage`'s base token set (`flex min-h-0 flex-1 flex-col overflow-hidden`, from `assets/css/tailwind.css`) and don't already carry the shorthand class found a cluster of 13 instances across 5 manager-style components:

- `components/user/user-manager.vue` (4)
- `components/giftshop/giftshop-manager.vue` (3)
- `components/art/art-manager.vue` (3)
- `components/academy/academy-manager.vue` (2)
- `components/characters/character-flip-card.vue` (1)

All are non-scrolling tab-content sections that manage their own internal layout — exactly `.kr-stage`'s documented shape ("A page's single non-scrolling focal area... that manages its own internal layout instead of delegating to `.kr-scroll`"). Every extra utility already present (`h-full`, `gap-3`, `gap-4`, `p-3`, `kr-panel-flat`, color/border tokens, `kr-note-error`) is kept alongside the shorthand class. No geometry or behavior change.

## Verification

- `eslint`: clean (2 pre-existing, unrelated `no-unused-vars` errors in `character-flip-card.vue`/`giftshop-manager.vue`, confirmed via `git stash` to predate this change)
- `prettier --check`: clean
- `vue-tsc --noEmit`: clean, repo-wide
- `npm run test:layout-contract`: holds (207-violation baseline, zero new violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019SqdM1HeQCf3kuS87DqLMK)_