### PR TITLE
ui: reuse shared flat panel for ruler cosmetics

### DIFF
--- a/components/art/artjob-queue-card.vue
+++ b/components/art/artjob-queue-card.vue
@@ -36,7 +36,7 @@
 
       <div
         v-else
-        class="flex h-full w-full flex-col items-center justify-center gap-3 kr-panel-flat border-dashed p-5 text-center"
+        class="flex h-full w-full flex-col items-center justify-center gap-3 border-dashed border-base-300 bg-base-100 p-5 text-center"
       >
         <span
           class="text-xs font-black uppercase tracking-widest text-base-content/35"
@@ -79,140 +79,439 @@
       <div
         class="absolute right-2 top-2 flex max-w-[65%] flex-wrap justify-end gap-1"
       >
-        <span
-          v-if="job.entityType"
-          class="badge badge-outline badge-sm rounded-2xl"
-        >
-          {{ job.entityType }}
+        <span class="badge badge-outline badge-sm rounded-2xl">
+          {{ job.engine }}
         </span>
         <span
-          v-if="job.entityId"
-          class="badge badge-outline badge-sm rounded-2xl font-mono"
+          v-if="job.priority > 0"
+          class="badge badge-accent badge-sm rounded-2xl"
         >
-          #{{ job.entityId }}
+          Priority {{ job.priority }}
         </span>
       </div>
     </div>
 
-    <div class="flex min-w-0 flex-1 flex-col gap-3 p-4">
-      <div class="flex min-w-0 items-start justify-between gap-3">
-        <div class="min-w-0">
-          <p class="truncate text-sm font-black text-base-content">
-            {{ job.label || `ArtJob #${job.id}` }}
-          </p>
-          <p class="mt-0.5 truncate text-xs text-base-content/50">
-            {{ job.prompt || 'No prompt recorded' }}
-          </p>
+    <div class="flex min-w-0 flex-1 flex-col gap-3 p-3">
+      <div
+        v-if="job.status !== 'DONE'"
+        class="flex flex-wrap items-center justify-between gap-2"
+      >
+        <div class="flex flex-wrap gap-1">
+          <span class="badge badge-neutral badge-sm rounded-2xl font-mono">
+            #{{ job.id }}
+          </span>
+          <span
+            class="badge badge-sm rounded-2xl"
+            :class="jobStatusClass(job.status)"
+          >
+            {{ job.status }}
+          </span>
         </div>
-        <span class="shrink-0 text-xs text-base-content/45">
-          {{ formatAge(job.createdAt) }}
-        </span>
+        <div class="flex flex-wrap justify-end gap-1">
+          <span class="badge badge-outline badge-sm rounded-2xl">
+            {{ job.engine }}
+          </span>
+          <span
+            v-if="job.priority > 0"
+            class="badge badge-accent badge-sm rounded-2xl"
+          >
+            Priority {{ job.priority }}
+          </span>
+        </div>
       </div>
 
-      <div class="flex flex-wrap items-center gap-1.5 text-xs">
-        <span v-if="job.engine" class="badge badge-ghost badge-sm rounded-xl">
-          {{ job.engine }}
-        </span>
-        <span v-if="job.model" class="badge badge-ghost badge-sm rounded-xl">
-          {{ job.model }}
+      <div class="min-w-0">
+        <div class="flex flex-wrap items-start justify-between gap-2">
+          <div class="min-w-0 flex-1">
+            <h3 class="truncate text-base font-black" :title="jobTitle">
+              {{ jobTitle }}
+            </h3>
+            <p
+              v-if="jobPageLabel"
+              class="mt-0.5 truncate text-xs font-semibold text-primary"
+              :title="jobPageLabel"
+            >
+              Destination · {{ jobPageLabel }}
+            </p>
+          </div>
+          <span
+            v-if="jobVariant"
+            class="badge badge-ghost badge-sm rounded-2xl"
+          >
+            {{ jobVariant }}
+          </span>
+        </div>
+
+        <p
+          v-if="jobImagePath"
+          class="mt-1 truncate font-mono text-[10px] text-base-content/45"
+          :title="jobImagePath"
+        >
+          {{ jobImagePath }}
+        </p>
+      </div>
+
+      <div class="flex flex-wrap gap-1">
+        <span
+          class="badge badge-sm rounded-2xl"
+          :class="jobVisibility.isMature ? 'badge-warning' : 'badge-outline'"
+        >
+          {{ jobVisibility.isMature ? 'Mature' : 'General' }}
         </span>
         <span
-          v-if="job.durationSeconds"
-          class="badge badge-ghost badge-sm rounded-xl"
+          class="badge badge-sm rounded-2xl"
+          :class="
+            jobVisibility.isPublic
+              ? 'badge-success badge-outline'
+              : 'badge-neutral'
+          "
         >
-          {{ job.durationSeconds }}s
+          {{ jobVisibility.isPublic ? 'Public' : 'Private' }}
+        </span>
+        <span
+          v-if="job.projectSlug"
+          class="badge badge-secondary badge-sm rounded-2xl"
+        >
+          {{ job.projectSlug }}
+        </span>
+        <span
+          v-if="jobRequestId"
+          class="badge badge-ghost badge-sm max-w-full truncate rounded-2xl"
+          :title="jobRequestId"
+        >
+          {{ jobRequestId }}
         </span>
       </div>
 
-      <p v-if="job.error" class="line-clamp-3 text-xs leading-relaxed text-error">
-        {{ job.error }}
+      <p
+        v-if="canShowJobContent"
+        class="line-clamp-3 whitespace-pre-wrap text-sm leading-relaxed"
+      >
+        {{ jobPrompt || 'Prompt unavailable.' }}
+      </p>
+      <p
+        v-else
+        class="rounded-xl border border-warning/30 bg-warning/10 p-2 text-xs text-warning-content"
+      >
+        Mature prompt and preview are hidden by your account setting.
       </p>
 
-      <div class="mt-auto flex flex-wrap items-center justify-end gap-2 pt-1">
-        <button
-          v-if="canRetry"
-          type="button"
-          class="btn btn-outline btn-xs rounded-xl"
-          :disabled="busy"
-          @click="$emit('retry', job.id)"
+      <div class="flex flex-wrap gap-1">
+        <span
+          v-for="setting in jobSettings.slice(0, 6)"
+          :key="setting"
+          class="badge badge-ghost badge-sm h-auto rounded-2xl py-1 text-[10px]"
         >
-          Retry
-        </button>
+          {{ setting }}
+        </span>
+      </div>
+
+      <p class="text-[11px] text-base-content/50">
+        {{ formatDateTime(job.createdAt) }} · attempt {{ job.attempts }} ·
+        priority {{ job.priority }}
+      </p>
+
+      <div
+        v-if="job.error"
+        class="rounded-2xl border border-error/30 bg-error/10 p-2 text-xs text-error"
+      >
+        {{ job.error }}
+      </div>
+
+      <details class="kr-panel-flat">
+        <summary class="cursor-pointer px-3 py-2 text-xs font-semibold">
+          Full brief and generation fields
+        </summary>
+        <div class="flex flex-col gap-3 border-t border-base-300 p-3 text-xs">
+          <div
+            v-if="!canShowJobContent"
+            class="rounded-xl border border-warning/30 bg-warning/10 p-3 text-warning-content"
+          >
+            Enable mature content in your account settings to view or edit this
+            job's prompt and preview.
+          </div>
+          <template v-else>
+            <div v-if="jobPageLabel || jobImagePath">
+              <div
+                class="font-semibold uppercase tracking-wide text-base-content/50"
+              >
+                Destination
+              </div>
+              <p v-if="jobPageLabel" class="mt-1">{{ jobPageLabel }}</p>
+              <p
+                v-if="jobImagePath"
+                class="mt-1 break-all font-mono text-[10px] text-base-content/70"
+              >
+                {{ jobImagePath }}
+              </p>
+            </div>
+            <div>
+              <div
+                class="font-semibold uppercase tracking-wide text-base-content/50"
+              >
+                Prompt
+              </div>
+              <p class="mt-1 whitespace-pre-wrap leading-relaxed">
+                {{ jobPrompt }}
+              </p>
+            </div>
+            <div>
+              <div
+                class="font-semibold uppercase tracking-wide text-base-content/50"
+              >
+                Negative prompt
+              </div>
+              <p class="mt-1 whitespace-pre-wrap text-base-content/70">
+                {{ jobNegativePrompt || 'None' }}
+              </p>
+            </div>
+            <div class="flex flex-wrap gap-1">
+              <span
+                v-for="setting in jobSettings"
+                :key="setting"
+                class="badge badge-outline badge-sm h-auto rounded-2xl py-1 text-[10px]"
+              >
+                {{ setting }}
+              </span>
+            </div>
+          </template>
+        </div>
+      </details>
+
+      <div class="mt-auto flex flex-wrap items-center justify-between gap-2">
         <button
-          v-if="canCancel"
           type="button"
-          class="btn btn-ghost btn-xs rounded-xl text-warning"
-          :disabled="busy"
-          @click="$emit('cancel', job.id)"
+          class="btn btn-ghost btn-xs rounded-2xl"
+          :disabled="!jobPrompt || !canShowJobContent"
+          :title="
+            canShowJobContent
+              ? 'Copy prompt'
+              : 'Enable mature content to reveal this prompt'
+          "
+          @click="handleCopy"
         >
-          Cancel
+          {{ copied ? 'Copied' : 'Copy prompt' }}
         </button>
-        <button
-          v-if="canDelete"
-          type="button"
-          class="btn btn-ghost btn-xs rounded-xl text-error"
-          :disabled="busy"
-          @click="$emit('delete', job.id)"
-        >
-          Delete
-        </button>
+
+        <div class="flex flex-wrap items-center justify-end gap-1">
+          <button
+            v-if="job.status === 'PENDING'"
+            type="button"
+            class="btn btn-xs rounded-2xl"
+            :class="job.priority > 0 ? 'btn-outline' : 'btn-accent'"
+            :disabled="priorityStore.prioritizingJobIds.includes(job.id)"
+            @click="togglePriority"
+          >
+            <span
+              v-if="priorityStore.prioritizingJobIds.includes(job.id)"
+              class="loading loading-spinner loading-xs"
+            />
+            {{ job.priority > 0 ? 'Normal priority' : 'Move to front' }}
+          </button>
+          <button
+            v-if="isEditableInPlace"
+            type="button"
+            class="btn btn-primary btn-xs rounded-2xl"
+            :disabled="!canShowJobContent"
+            @click="emit('edit', job, 'EDIT')"
+          >
+            Edit & queue
+          </button>
+          <button
+            v-else-if="job.status === 'RUNNING'"
+            type="button"
+            class="btn btn-primary btn-xs rounded-2xl"
+            :disabled="!canShowJobContent"
+            @click="emit('edit', job, 'NEW_OUTPUT')"
+          >
+            Edit as new job
+          </button>
+          <button
+            v-if="job.status === 'DONE'"
+            type="button"
+            class="btn btn-primary btn-xs rounded-2xl"
+            :disabled="!canShowJobContent"
+            @click="emit('edit', job, 'NEW_OUTPUT')"
+          >
+            Edited output
+          </button>
+          <button
+            v-if="job.status === 'DONE' && job.artImageId"
+            type="button"
+            class="btn btn-warning btn-xs rounded-2xl"
+            :disabled="!canShowJobContent"
+            @click="emit('edit', job, 'OVERWRITE')"
+          >
+            Edit & replace
+          </button>
+          <button
+            v-if="job.status === 'FAILED'"
+            type="button"
+            class="btn btn-ghost btn-xs rounded-2xl"
+            @click="artJobStore.requeueJob(job.id)"
+          >
+            Resume unchanged
+          </button>
+          <button
+            v-if="
+              job.status === 'PENDING' ||
+              job.status === 'RUNNING' ||
+              job.status === 'FAILED'
+            "
+            type="button"
+            class="btn btn-ghost btn-xs rounded-2xl text-error"
+            @click="artJobStore.cancelJob(job.id)"
+          >
+            {{ job.status === 'FAILED' ? 'Clear failure' : 'Cancel' }}
+          </button>
+        </div>
       </div>
     </div>
   </article>
 </template>
 
 <script setup lang="ts">
-import type { ArtJob } from '@/stores/artJobStore'
+import { computed, ref } from 'vue'
+import { useArtJobStore, type ArtJobRecord } from '@/stores/artJobStore'
+import { useArtJobPriorityStore } from '@/stores/artJobPriorityStore'
+import { useArtStore } from '@/stores/artStore'
+import {
+  artJobImagePath,
+  artJobImageVersion,
+  artJobNegativePrompt,
+  artJobPageLabel,
+  artJobPrompt,
+  artJobPublicImageSrc,
+  artJobRequestId,
+  artJobSettings,
+  artJobTitle,
+  artJobVariant,
+  artJobVisibility,
+} from '@/utils/artJobFields'
+
+type EditorAction = 'EDIT' | 'NEW_OUTPUT' | 'OVERWRITE'
 
 const props = defineProps<{
-  job: ArtJob
-  busy?: boolean
-  jobImageSrc?: string
-  jobImageKind?: 'image' | 'video'
-  canShowJobContent?: boolean
-  canLoadProtectedPreview?: boolean
-  isLoadingPreview?: boolean
-  previewPlaceholder?: string
+  job: ArtJobRecord
 }>()
 
 const emit = defineEmits<{
-  retry: [id: number]
-  cancel: [id: number]
-  delete: [id: number]
-  loadProtectedPreview: [id: number]
+  edit: [job: ArtJobRecord, action: EditorAction]
 }>()
 
-const canRetry = computed(() =>
-  ['FAILED', 'CANCELLED'].includes(props.job.status),
-)
-const canCancel = computed(() =>
-  ['PENDING', 'QUEUED', 'RUNNING'].includes(props.job.status),
-)
-const canDelete = computed(() =>
-  ['DONE', 'FAILED', 'CANCELLED'].includes(props.job.status),
+const artJobStore = useArtJobStore()
+const priorityStore = useArtJobPriorityStore()
+const artStore = useArtStore()
+const copied = ref(false)
+
+const jobPrompt = computed<string>(() => artJobPrompt(props.job))
+
+const jobNegativePrompt = computed<string>(() =>
+  artJobNegativePrompt(props.job),
 )
 
-function loadProtectedPreview(): void {
-  emit('loadProtectedPreview', props.job.id)
+const jobVisibility = computed(() => artJobVisibility(props.job))
+
+const canShowJobContent = computed<boolean>(
+  () => !jobVisibility.value.isMature || artStore.showMature,
+)
+
+const jobTitle = computed<string>(() => artJobTitle(props.job))
+
+const jobPageLabel = computed<string>(() => artJobPageLabel(props.job))
+
+const jobVariant = computed<string>(() => artJobVariant(props.job))
+
+const jobRequestId = computed<string>(() => artJobRequestId(props.job))
+
+const jobImagePath = computed<string>(() => artJobImagePath(props.job))
+
+const jobSettings = computed<string[]>(() => artJobSettings(props.job))
+
+const imageVersion = computed<string>(() => artJobImageVersion(props.job))
+
+const publicImageSrc = computed<string>(() => artJobPublicImageSrc(props.job))
+
+const jobImageSrc = computed<string>(() => {
+  const id = props.job.artImageId
+  if (typeof id !== 'number') return ''
+  return publicImageSrc.value || artJobStore.imageSrcById[id] || ''
+})
+
+const jobImageKind = computed<string>(() => {
+  const id = props.job.artImageId
+  if (typeof id !== 'number' || publicImageSrc.value) return 'image'
+  return artJobStore.imageInfoById[id]?.kind || 'image'
+})
+
+const isLoadingPreview = computed<boolean>(() => {
+  const id = props.job.artImageId
+  return typeof id === 'number' && artJobStore.loadingImageIds.includes(id)
+})
+
+const canLoadProtectedPreview = computed<boolean>(() => {
+  return (
+    canShowJobContent.value &&
+    typeof props.job.artImageId === 'number' &&
+    !publicImageSrc.value &&
+    !jobImageSrc.value
+  )
+})
+
+const previewPlaceholder = computed<string>(() => {
+  if (props.job.status !== 'DONE') return props.job.status
+  if (typeof props.job.artImageId !== 'number') return 'No output image'
+  return 'Protected output'
+})
+
+const isEditableInPlace = computed<boolean>(() =>
+  ['PENDING', 'FAILED', 'CANCELLED'].includes(props.job.status),
+)
+
+async function loadProtectedPreview(): Promise<void> {
+  const id = props.job.artImageId
+  if (typeof id !== 'number') return
+  // Pass the job's version so an OVERWRITE retry — which reuses this ArtImage
+  // id with new bytes — refetches instead of serving the previous render.
+  await artJobStore.loadJobImage(id, imageVersion.value)
+}
+
+async function handleCopy(): Promise<void> {
+  if (!canShowJobContent.value) return
+  const prompt = jobPrompt.value
+  if (!prompt || !navigator.clipboard) return
+  await navigator.clipboard.writeText(prompt)
+  copied.value = true
+  window.setTimeout(() => {
+    copied.value = false
+  }, 1500)
+}
+
+async function togglePriority(): Promise<void> {
+  if (props.job.priority > 0) {
+    await priorityStore.returnToNormal(props.job.id)
+    return
+  }
+  await priorityStore.moveToFront(props.job.id)
 }
 
 function jobStatusClass(status: string): string {
   if (status === 'DONE') return 'badge-success'
   if (status === 'FAILED') return 'badge-error'
   if (status === 'RUNNING') return 'badge-info'
-  if (status === 'CANCELLED') return 'badge-warning'
-  return 'badge-neutral'
+  if (status === 'CANCELLED') return 'badge-ghost'
+  return 'badge-warning'
 }
 
-function formatAge(value: string | Date): string {
+function formatDateTime(value: string | Date | null): string {
+  if (!value) return '—'
   const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return ''
-  const delta = Math.max(0, Date.now() - date.getTime())
-  const minutes = Math.floor(delta / 60_000)
-  if (minutes < 1) return 'now'
-  if (minutes < 60) return `${minutes}m`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h`
-  return `${Math.floor(hours / 24)}d`
+  if (!Number.isFinite(date.getTime())) return '—'
+  return date.toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
 }
 </script>

--- a/components/art/artjob-queue-card.vue
+++ b/components/art/artjob-queue-card.vue
@@ -36,7 +36,7 @@
 
       <div
         v-else
-        class="flex h-full w-full flex-col items-center justify-center gap-3 border-dashed border-base-300 bg-base-100 p-5 text-center"
+        class="flex h-full w-full flex-col items-center justify-center gap-3 kr-panel-flat border-dashed p-5 text-center"
       >
         <span
           class="text-xs font-black uppercase tracking-widest text-base-content/35"
@@ -79,439 +79,140 @@
       <div
         class="absolute right-2 top-2 flex max-w-[65%] flex-wrap justify-end gap-1"
       >
-        <span class="badge badge-outline badge-sm rounded-2xl">
-          {{ job.engine }}
+        <span
+          v-if="job.entityType"
+          class="badge badge-outline badge-sm rounded-2xl"
+        >
+          {{ job.entityType }}
         </span>
         <span
-          v-if="job.priority > 0"
-          class="badge badge-accent badge-sm rounded-2xl"
+          v-if="job.entityId"
+          class="badge badge-outline badge-sm rounded-2xl font-mono"
         >
-          Priority {{ job.priority }}
+          #{{ job.entityId }}
         </span>
       </div>
     </div>
 
-    <div class="flex min-w-0 flex-1 flex-col gap-3 p-3">
-      <div
-        v-if="job.status !== 'DONE'"
-        class="flex flex-wrap items-center justify-between gap-2"
-      >
-        <div class="flex flex-wrap gap-1">
-          <span class="badge badge-neutral badge-sm rounded-2xl font-mono">
-            #{{ job.id }}
-          </span>
-          <span
-            class="badge badge-sm rounded-2xl"
-            :class="jobStatusClass(job.status)"
-          >
-            {{ job.status }}
-          </span>
+    <div class="flex min-w-0 flex-1 flex-col gap-3 p-4">
+      <div class="flex min-w-0 items-start justify-between gap-3">
+        <div class="min-w-0">
+          <p class="truncate text-sm font-black text-base-content">
+            {{ job.label || `ArtJob #${job.id}` }}
+          </p>
+          <p class="mt-0.5 truncate text-xs text-base-content/50">
+            {{ job.prompt || 'No prompt recorded' }}
+          </p>
         </div>
-        <div class="flex flex-wrap justify-end gap-1">
-          <span class="badge badge-outline badge-sm rounded-2xl">
-            {{ job.engine }}
-          </span>
-          <span
-            v-if="job.priority > 0"
-            class="badge badge-accent badge-sm rounded-2xl"
-          >
-            Priority {{ job.priority }}
-          </span>
-        </div>
-      </div>
-
-      <div class="min-w-0">
-        <div class="flex flex-wrap items-start justify-between gap-2">
-          <div class="min-w-0 flex-1">
-            <h3 class="truncate text-base font-black" :title="jobTitle">
-              {{ jobTitle }}
-            </h3>
-            <p
-              v-if="jobPageLabel"
-              class="mt-0.5 truncate text-xs font-semibold text-primary"
-              :title="jobPageLabel"
-            >
-              Destination · {{ jobPageLabel }}
-            </p>
-          </div>
-          <span
-            v-if="jobVariant"
-            class="badge badge-ghost badge-sm rounded-2xl"
-          >
-            {{ jobVariant }}
-          </span>
-        </div>
-
-        <p
-          v-if="jobImagePath"
-          class="mt-1 truncate font-mono text-[10px] text-base-content/45"
-          :title="jobImagePath"
-        >
-          {{ jobImagePath }}
-        </p>
-      </div>
-
-      <div class="flex flex-wrap gap-1">
-        <span
-          class="badge badge-sm rounded-2xl"
-          :class="jobVisibility.isMature ? 'badge-warning' : 'badge-outline'"
-        >
-          {{ jobVisibility.isMature ? 'Mature' : 'General' }}
-        </span>
-        <span
-          class="badge badge-sm rounded-2xl"
-          :class="
-            jobVisibility.isPublic
-              ? 'badge-success badge-outline'
-              : 'badge-neutral'
-          "
-        >
-          {{ jobVisibility.isPublic ? 'Public' : 'Private' }}
-        </span>
-        <span
-          v-if="job.projectSlug"
-          class="badge badge-secondary badge-sm rounded-2xl"
-        >
-          {{ job.projectSlug }}
-        </span>
-        <span
-          v-if="jobRequestId"
-          class="badge badge-ghost badge-sm max-w-full truncate rounded-2xl"
-          :title="jobRequestId"
-        >
-          {{ jobRequestId }}
+        <span class="shrink-0 text-xs text-base-content/45">
+          {{ formatAge(job.createdAt) }}
         </span>
       </div>
 
-      <p
-        v-if="canShowJobContent"
-        class="line-clamp-3 whitespace-pre-wrap text-sm leading-relaxed"
-      >
-        {{ jobPrompt || 'Prompt unavailable.' }}
-      </p>
-      <p
-        v-else
-        class="rounded-xl border border-warning/30 bg-warning/10 p-2 text-xs text-warning-content"
-      >
-        Mature prompt and preview are hidden by your account setting.
-      </p>
-
-      <div class="flex flex-wrap gap-1">
+      <div class="flex flex-wrap items-center gap-1.5 text-xs">
+        <span v-if="job.engine" class="badge badge-ghost badge-sm rounded-xl">
+          {{ job.engine }}
+        </span>
+        <span v-if="job.model" class="badge badge-ghost badge-sm rounded-xl">
+          {{ job.model }}
+        </span>
         <span
-          v-for="setting in jobSettings.slice(0, 6)"
-          :key="setting"
-          class="badge badge-ghost badge-sm h-auto rounded-2xl py-1 text-[10px]"
+          v-if="job.durationSeconds"
+          class="badge badge-ghost badge-sm rounded-xl"
         >
-          {{ setting }}
+          {{ job.durationSeconds }}s
         </span>
       </div>
 
-      <p class="text-[11px] text-base-content/50">
-        {{ formatDateTime(job.createdAt) }} · attempt {{ job.attempts }} ·
-        priority {{ job.priority }}
-      </p>
-
-      <div
-        v-if="job.error"
-        class="rounded-2xl border border-error/30 bg-error/10 p-2 text-xs text-error"
-      >
+      <p v-if="job.error" class="line-clamp-3 text-xs leading-relaxed text-error">
         {{ job.error }}
-      </div>
+      </p>
 
-      <details class="kr-panel-flat">
-        <summary class="cursor-pointer px-3 py-2 text-xs font-semibold">
-          Full brief and generation fields
-        </summary>
-        <div class="flex flex-col gap-3 border-t border-base-300 p-3 text-xs">
-          <div
-            v-if="!canShowJobContent"
-            class="rounded-xl border border-warning/30 bg-warning/10 p-3 text-warning-content"
-          >
-            Enable mature content in your account settings to view or edit this
-            job's prompt and preview.
-          </div>
-          <template v-else>
-            <div v-if="jobPageLabel || jobImagePath">
-              <div
-                class="font-semibold uppercase tracking-wide text-base-content/50"
-              >
-                Destination
-              </div>
-              <p v-if="jobPageLabel" class="mt-1">{{ jobPageLabel }}</p>
-              <p
-                v-if="jobImagePath"
-                class="mt-1 break-all font-mono text-[10px] text-base-content/70"
-              >
-                {{ jobImagePath }}
-              </p>
-            </div>
-            <div>
-              <div
-                class="font-semibold uppercase tracking-wide text-base-content/50"
-              >
-                Prompt
-              </div>
-              <p class="mt-1 whitespace-pre-wrap leading-relaxed">
-                {{ jobPrompt }}
-              </p>
-            </div>
-            <div>
-              <div
-                class="font-semibold uppercase tracking-wide text-base-content/50"
-              >
-                Negative prompt
-              </div>
-              <p class="mt-1 whitespace-pre-wrap text-base-content/70">
-                {{ jobNegativePrompt || 'None' }}
-              </p>
-            </div>
-            <div class="flex flex-wrap gap-1">
-              <span
-                v-for="setting in jobSettings"
-                :key="setting"
-                class="badge badge-outline badge-sm h-auto rounded-2xl py-1 text-[10px]"
-              >
-                {{ setting }}
-              </span>
-            </div>
-          </template>
-        </div>
-      </details>
-
-      <div class="mt-auto flex flex-wrap items-center justify-between gap-2">
+      <div class="mt-auto flex flex-wrap items-center justify-end gap-2 pt-1">
         <button
+          v-if="canRetry"
           type="button"
-          class="btn btn-ghost btn-xs rounded-2xl"
-          :disabled="!jobPrompt || !canShowJobContent"
-          :title="
-            canShowJobContent
-              ? 'Copy prompt'
-              : 'Enable mature content to reveal this prompt'
-          "
-          @click="handleCopy"
+          class="btn btn-outline btn-xs rounded-xl"
+          :disabled="busy"
+          @click="$emit('retry', job.id)"
         >
-          {{ copied ? 'Copied' : 'Copy prompt' }}
+          Retry
         </button>
-
-        <div class="flex flex-wrap items-center justify-end gap-1">
-          <button
-            v-if="job.status === 'PENDING'"
-            type="button"
-            class="btn btn-xs rounded-2xl"
-            :class="job.priority > 0 ? 'btn-outline' : 'btn-accent'"
-            :disabled="priorityStore.prioritizingJobIds.includes(job.id)"
-            @click="togglePriority"
-          >
-            <span
-              v-if="priorityStore.prioritizingJobIds.includes(job.id)"
-              class="loading loading-spinner loading-xs"
-            />
-            {{ job.priority > 0 ? 'Normal priority' : 'Move to front' }}
-          </button>
-          <button
-            v-if="isEditableInPlace"
-            type="button"
-            class="btn btn-primary btn-xs rounded-2xl"
-            :disabled="!canShowJobContent"
-            @click="emit('edit', job, 'EDIT')"
-          >
-            Edit & queue
-          </button>
-          <button
-            v-else-if="job.status === 'RUNNING'"
-            type="button"
-            class="btn btn-primary btn-xs rounded-2xl"
-            :disabled="!canShowJobContent"
-            @click="emit('edit', job, 'NEW_OUTPUT')"
-          >
-            Edit as new job
-          </button>
-          <button
-            v-if="job.status === 'DONE'"
-            type="button"
-            class="btn btn-primary btn-xs rounded-2xl"
-            :disabled="!canShowJobContent"
-            @click="emit('edit', job, 'NEW_OUTPUT')"
-          >
-            Edited output
-          </button>
-          <button
-            v-if="job.status === 'DONE' && job.artImageId"
-            type="button"
-            class="btn btn-warning btn-xs rounded-2xl"
-            :disabled="!canShowJobContent"
-            @click="emit('edit', job, 'OVERWRITE')"
-          >
-            Edit & replace
-          </button>
-          <button
-            v-if="job.status === 'FAILED'"
-            type="button"
-            class="btn btn-ghost btn-xs rounded-2xl"
-            @click="artJobStore.requeueJob(job.id)"
-          >
-            Resume unchanged
-          </button>
-          <button
-            v-if="
-              job.status === 'PENDING' ||
-              job.status === 'RUNNING' ||
-              job.status === 'FAILED'
-            "
-            type="button"
-            class="btn btn-ghost btn-xs rounded-2xl text-error"
-            @click="artJobStore.cancelJob(job.id)"
-          >
-            {{ job.status === 'FAILED' ? 'Clear failure' : 'Cancel' }}
-          </button>
-        </div>
+        <button
+          v-if="canCancel"
+          type="button"
+          class="btn btn-ghost btn-xs rounded-xl text-warning"
+          :disabled="busy"
+          @click="$emit('cancel', job.id)"
+        >
+          Cancel
+        </button>
+        <button
+          v-if="canDelete"
+          type="button"
+          class="btn btn-ghost btn-xs rounded-xl text-error"
+          :disabled="busy"
+          @click="$emit('delete', job.id)"
+        >
+          Delete
+        </button>
       </div>
     </div>
   </article>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
-import { useArtJobStore, type ArtJobRecord } from '@/stores/artJobStore'
-import { useArtJobPriorityStore } from '@/stores/artJobPriorityStore'
-import { useArtStore } from '@/stores/artStore'
-import {
-  artJobImagePath,
-  artJobImageVersion,
-  artJobNegativePrompt,
-  artJobPageLabel,
-  artJobPrompt,
-  artJobPublicImageSrc,
-  artJobRequestId,
-  artJobSettings,
-  artJobTitle,
-  artJobVariant,
-  artJobVisibility,
-} from '@/utils/artJobFields'
-
-type EditorAction = 'EDIT' | 'NEW_OUTPUT' | 'OVERWRITE'
+import type { ArtJob } from '@/stores/artJobStore'
 
 const props = defineProps<{
-  job: ArtJobRecord
+  job: ArtJob
+  busy?: boolean
+  jobImageSrc?: string
+  jobImageKind?: 'image' | 'video'
+  canShowJobContent?: boolean
+  canLoadProtectedPreview?: boolean
+  isLoadingPreview?: boolean
+  previewPlaceholder?: string
 }>()
 
 const emit = defineEmits<{
-  edit: [job: ArtJobRecord, action: EditorAction]
+  retry: [id: number]
+  cancel: [id: number]
+  delete: [id: number]
+  loadProtectedPreview: [id: number]
 }>()
 
-const artJobStore = useArtJobStore()
-const priorityStore = useArtJobPriorityStore()
-const artStore = useArtStore()
-const copied = ref(false)
-
-const jobPrompt = computed<string>(() => artJobPrompt(props.job))
-
-const jobNegativePrompt = computed<string>(() =>
-  artJobNegativePrompt(props.job),
+const canRetry = computed(() =>
+  ['FAILED', 'CANCELLED'].includes(props.job.status),
+)
+const canCancel = computed(() =>
+  ['PENDING', 'QUEUED', 'RUNNING'].includes(props.job.status),
+)
+const canDelete = computed(() =>
+  ['DONE', 'FAILED', 'CANCELLED'].includes(props.job.status),
 )
 
-const jobVisibility = computed(() => artJobVisibility(props.job))
-
-const canShowJobContent = computed<boolean>(
-  () => !jobVisibility.value.isMature || artStore.showMature,
-)
-
-const jobTitle = computed<string>(() => artJobTitle(props.job))
-
-const jobPageLabel = computed<string>(() => artJobPageLabel(props.job))
-
-const jobVariant = computed<string>(() => artJobVariant(props.job))
-
-const jobRequestId = computed<string>(() => artJobRequestId(props.job))
-
-const jobImagePath = computed<string>(() => artJobImagePath(props.job))
-
-const jobSettings = computed<string[]>(() => artJobSettings(props.job))
-
-const imageVersion = computed<string>(() => artJobImageVersion(props.job))
-
-const publicImageSrc = computed<string>(() => artJobPublicImageSrc(props.job))
-
-const jobImageSrc = computed<string>(() => {
-  const id = props.job.artImageId
-  if (typeof id !== 'number') return ''
-  return publicImageSrc.value || artJobStore.imageSrcById[id] || ''
-})
-
-const jobImageKind = computed<string>(() => {
-  const id = props.job.artImageId
-  if (typeof id !== 'number' || publicImageSrc.value) return 'image'
-  return artJobStore.imageInfoById[id]?.kind || 'image'
-})
-
-const isLoadingPreview = computed<boolean>(() => {
-  const id = props.job.artImageId
-  return typeof id === 'number' && artJobStore.loadingImageIds.includes(id)
-})
-
-const canLoadProtectedPreview = computed<boolean>(() => {
-  return (
-    canShowJobContent.value &&
-    typeof props.job.artImageId === 'number' &&
-    !publicImageSrc.value &&
-    !jobImageSrc.value
-  )
-})
-
-const previewPlaceholder = computed<string>(() => {
-  if (props.job.status !== 'DONE') return props.job.status
-  if (typeof props.job.artImageId !== 'number') return 'No output image'
-  return 'Protected output'
-})
-
-const isEditableInPlace = computed<boolean>(() =>
-  ['PENDING', 'FAILED', 'CANCELLED'].includes(props.job.status),
-)
-
-async function loadProtectedPreview(): Promise<void> {
-  const id = props.job.artImageId
-  if (typeof id !== 'number') return
-  // Pass the job's version so an OVERWRITE retry — which reuses this ArtImage
-  // id with new bytes — refetches instead of serving the previous render.
-  await artJobStore.loadJobImage(id, imageVersion.value)
-}
-
-async function handleCopy(): Promise<void> {
-  if (!canShowJobContent.value) return
-  const prompt = jobPrompt.value
-  if (!prompt || !navigator.clipboard) return
-  await navigator.clipboard.writeText(prompt)
-  copied.value = true
-  window.setTimeout(() => {
-    copied.value = false
-  }, 1500)
-}
-
-async function togglePriority(): Promise<void> {
-  if (props.job.priority > 0) {
-    await priorityStore.returnToNormal(props.job.id)
-    return
-  }
-  await priorityStore.moveToFront(props.job.id)
+function loadProtectedPreview(): void {
+  emit('loadProtectedPreview', props.job.id)
 }
 
 function jobStatusClass(status: string): string {
   if (status === 'DONE') return 'badge-success'
   if (status === 'FAILED') return 'badge-error'
   if (status === 'RUNNING') return 'badge-info'
-  if (status === 'CANCELLED') return 'badge-ghost'
-  return 'badge-warning'
+  if (status === 'CANCELLED') return 'badge-warning'
+  return 'badge-neutral'
 }
 
-function formatDateTime(value: string | Date | null): string {
-  if (!value) return '—'
+function formatAge(value: string | Date): string {
   const date = new Date(value)
-  if (!Number.isFinite(date.getTime())) return '—'
-  return date.toLocaleString([], {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
+  if (Number.isNaN(date.getTime())) return ''
+  const delta = Math.max(0, Date.now() - date.getTime())
+  const minutes = Math.floor(delta / 60_000)
+  if (minutes < 1) return 'now'
+  if (minutes < 60) return `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h`
+  return `${Math.floor(hours / 24)}d`
 }
 </script>

--- a/components/ruler-hooked/ruler-hooked-cosmetics.vue
+++ b/components/ruler-hooked/ruler-hooked-cosmetics.vue
@@ -4,7 +4,7 @@
      creation"). Collapsed by default so it doesn't compete with the play
      screen; opens onto the same picker the new-game form uses. -->
 <template>
-  <details class="rounded-xl border border-base-300 bg-base-100 p-3">
+  <details class="kr-panel-flat rounded-xl p-3">
     <summary class="cursor-pointer text-xs font-medium opacity-70">
       Change appearance
     </summary>


### PR DESCRIPTION
Interface Vision t-104 bounded consistency slice. Migrates the small Ruler Hooked in-play cosmetics disclosure from hand-rolled `border border-base-300 bg-base-100` to `kr-panel-flat`, retaining its existing `rounded-xl` and `p-3` overrides. No behavior or geometry change.

The earlier ArtJob connector edit on this branch was fully reverted before this change; current net diff is only `components/ruler-hooked/ruler-hooked-cosmetics.vue`.

Session: `openai-scheduled-20260831T031331Z-interface-vision-t104-k3p7`