### PR TITLE
ui: reuse flat panel for aquarium leaderboard loading state

### DIFF
--- a/pages/play/aquarium/leaderboard/index.vue
+++ b/pages/play/aquarium/leaderboard/index.vue
@@ -33,7 +33,7 @@
 
       <div
         v-if="loading && !entries.length"
-        class="grid min-h-[40vh] place-items-center rounded-3xl border border-base-300 bg-base-100"
+        class="kr-panel-flat grid min-h-[40vh] place-items-center rounded-3xl"
       >
         <div class="text-center">
           <span class="loading loading-ring loading-lg text-primary" />


### PR DESCRIPTION
Interface Vision t-104 bounded consistency slice. The Cthulhuquarium leaderboard's initial-loading panel duplicated the shared flat-panel border/background tokens. This replaces those tokens with `kr-panel-flat` while retaining the existing `rounded-3xl`, grid, minimum-height, and centering geometry. No behavior or data changes.

Session: `openai-scheduled-20260831T041650Z-interface-vision-t104-q8m2`