### PR TITLE
feat(admin): moderation queue for health-claim-escalated forum posts

### DIFF
--- a/content/channels/admin/forum-moderation.md
+++ b/content/channels/admin/forum-moderation.md
@@ -1,0 +1,15 @@
+---
+contentType: tab
+channelKey: admin
+tabKey: forum-moderation
+label: Forum Moderation
+title: Forum Moderation
+subtitle: Review health-claim-escalated posts
+description: Posts auto-hidden after crossing the health-claim flag-escalation threshold, pending a human decision to restore or confirm removal.
+icon: kind-icon:flag
+route: /admin/forum-moderation
+sort: 60
+requiredRole: ADMIN
+---
+
+Review forum posts the flag-escalation pipeline auto-hid, and restore or confirm their removal.

--- a/pages/admin/forum-moderation.vue
+++ b/pages/admin/forum-moderation.vue
@@ -1,0 +1,134 @@
+<template>
+  <main class="kr-surface h-full min-h-0 overflow-hidden">
+    <div class="kr-scroll kr-container-wide space-y-4 p-4 md:p-6">
+      <header
+        class="kr-toolbar flex flex-wrap items-start justify-between gap-4"
+      >
+        <div>
+          <p class="text-xs font-black uppercase tracking-widest text-primary">
+            Forum moderation
+          </p>
+          <p class="mt-1 text-2xl font-black">Health-claim escalation queue</p>
+          <p class="mt-1 max-w-2xl text-sm text-base-content/60">
+            Posts here were auto-hidden because at least two distinct people
+            flagged them as misinformation or unsafe. Restore the post if the
+            flag was wrong, or confirm removal if it should stay down.
+          </p>
+        </div>
+        <button
+          type="button"
+          class="btn btn-ghost btn-sm rounded-xl"
+          :disabled="loading"
+          @click="moderationStore.fetchHiddenPosts()"
+        >
+          <span v-if="loading" class="loading loading-spinner loading-xs" />
+          Refresh
+        </button>
+      </header>
+
+      <div v-if="!ready" class="grid min-h-52 place-items-center kr-panel">
+        <span class="loading loading-spinner loading-lg text-primary" />
+      </div>
+
+      <div
+        v-else-if="!userStore.isAdmin"
+        class="kr-note kr-note-error p-8 text-center font-normal"
+      >
+        <p class="text-xl font-black text-base-content">
+          Administrator access required
+        </p>
+        <p class="mt-2 text-sm text-base-content/60">
+          The forum moderation queue is restricted to administrators.
+        </p>
+      </div>
+
+      <template v-else>
+        <p
+          v-if="moderationStore.error"
+          class="kr-note kr-note-error rounded-xl p-3 font-normal"
+        >
+          {{ moderationStore.error }}
+        </p>
+
+        <section class="grid gap-4 md:grid-cols-2">
+          <article
+            v-for="post in moderationStore.posts"
+            :key="post.id"
+            class="kr-panel flex flex-col gap-3 p-4"
+          >
+            <div class="flex items-start justify-between gap-2">
+              <div class="flex items-center gap-2">
+                <span class="badge badge-warning badge-sm">
+                  pending review
+                </span>
+                <span v-if="post.channel" class="badge badge-outline">
+                  {{ post.channel }}
+                </span>
+              </div>
+              <span class="text-xs text-base-content/40">#{{ post.id }}</span>
+            </div>
+
+            <p class="whitespace-pre-line text-sm">{{ post.content }}</p>
+
+            <p class="text-xs text-base-content/50">
+              By {{ post.botName || post.sender }} &middot; posted
+              {{ formatDate(post.createdAt) }}
+              <template v-if="post.updatedAt">
+                &middot; hidden {{ formatDate(post.updatedAt) }}
+              </template>
+            </p>
+
+            <div class="flex gap-2">
+              <button
+                type="button"
+                class="btn btn-success btn-sm flex-1 rounded-xl"
+                @click="moderationStore.restore(post.id)"
+              >
+                Restore
+              </button>
+              <button
+                type="button"
+                class="btn btn-error btn-outline btn-sm flex-1 rounded-xl"
+                @click="moderationStore.remove(post.id)"
+              >
+                Confirm removal
+              </button>
+            </div>
+          </article>
+
+          <p
+            v-if="!moderationStore.posts.length"
+            class="col-span-full rounded-xl border border-dashed border-base-300 p-6 text-center text-sm text-base-content/50"
+          >
+            Nothing pending review right now.
+          </p>
+        </section>
+      </template>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useUserStore } from '@/stores/userStore'
+import { useForumModerationStore } from '@/stores/forumModerationStore'
+
+const userStore = useUserStore()
+const moderationStore = useForumModerationStore()
+const ready = ref(false)
+const loading = computed(() => moderationStore.loading)
+
+onMounted(async () => {
+  await userStore.initialize()
+  if (userStore.isAdmin) await moderationStore.fetchHiddenPosts()
+  ready.value = true
+})
+
+function formatDate(value: string) {
+  try {
+    return new Date(value).toLocaleString()
+  } catch {
+    return value
+  }
+}
+</script>

--- a/server/api/admin/forum/hidden-posts.get.ts
+++ b/server/api/admin/forum/hidden-posts.get.ts
@@ -1,0 +1,61 @@
+// /server/api/admin/forum/hidden-posts.get.ts
+//
+// rainbow-butterflies/t-031: admin-only listing of forum posts auto-hidden
+// by the health-claim flag-escalation threshold (see escalateHealthClaimFlagsIfNeeded
+// in forumApi.ts), pending human review. No new schema -- the escalation function
+// is the only place a ToForum Chat row's isPublic ever flips to false, so
+// `type: 'ToForum', isPublic: false, isActive: true` reliably identifies the
+// pending-review queue (isActive: false means already confirmed-removed, so
+// those are excluded once resolved).
+import { defineEventHandler, getQuery } from 'h3'
+import prisma from '../../../utils/prisma'
+import { errorHandler } from '../../../utils/error'
+import { requireAdminApiUser } from '../../../utils/authGuard'
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireAdminApiUser(event)
+
+    const query = getQuery(event)
+    const rawTake = Number(query.take || 50)
+    if (!Number.isInteger(rawTake) || rawTake < 1 || rawTake > 100) {
+      return {
+        success: false,
+        message: 'take must be an integer from 1 to 100.',
+        statusCode: 400,
+      }
+    }
+
+    const posts = await prisma.chat.findMany({
+      where: { type: 'ToForum', isPublic: false, isActive: true },
+      orderBy: { updatedAt: 'desc' },
+      take: rawTake,
+      select: {
+        id: true,
+        content: true,
+        sender: true,
+        botName: true,
+        channel: true,
+        userId: true,
+        botId: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    })
+
+    return {
+      success: true,
+      message: 'Hidden forum posts loaded.',
+      statusCode: 200,
+      data: { posts },
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      message: handled.message || 'Failed to load hidden forum posts.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/api/admin/forum/hidden-posts/[id]/remove.post.ts
+++ b/server/api/admin/forum/hidden-posts/[id]/remove.post.ts
@@ -1,0 +1,64 @@
+// /server/api/admin/forum/hidden-posts/[id]/remove.post.ts
+//
+// rainbow-butterflies/t-031: admin-only confirmation that an auto-hidden
+// post should stay hidden. Sets isActive: false (the existing soft-delete
+// field) rather than deleting the row, so the audit trail and any
+// reply/reaction relations stay intact. Terminal: an already-removed or
+// never-hidden post 409s the same as restore.post.ts.
+import { createError, defineEventHandler } from 'h3'
+import prisma from '../../../../../utils/prisma'
+import { errorHandler } from '../../../../../utils/error'
+import { requireAdminApiUser } from '../../../../../utils/authGuard'
+import { logAdminAction } from '../../../../../utils/audit'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const { user: admin } = await requireAdminApiUser(event)
+
+    const id = Number(event.context.params?.id)
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid post id.' })
+    }
+
+    const post = await prisma.chat.findUnique({
+      where: { id },
+      select: { id: true, type: true, isPublic: true, isActive: true },
+    })
+
+    if (!post || post.type !== 'ToForum') {
+      throw createError({ statusCode: 404, message: 'Forum post not found.' })
+    }
+    if (post.isPublic || !post.isActive) {
+      throw createError({
+        statusCode: 409,
+        message: 'This post is not pending review.',
+      })
+    }
+
+    const updated = await prisma.chat.update({
+      where: { id },
+      data: { isActive: false },
+      select: { id: true, isPublic: true, isActive: true, updatedAt: true },
+    })
+
+    await logAdminAction(
+      admin,
+      `Removed forum post #${id}: confirmed removal after health-claim flag escalation.`,
+    )
+
+    return {
+      success: true,
+      message: `Forum post #${id} removed.`,
+      statusCode: 200,
+      data: updated,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      message: handled.message || 'Failed to remove forum post.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/api/admin/forum/hidden-posts/[id]/restore.post.ts
+++ b/server/api/admin/forum/hidden-posts/[id]/restore.post.ts
@@ -1,0 +1,64 @@
+// /server/api/admin/forum/hidden-posts/[id]/restore.post.ts
+//
+// rainbow-butterflies/t-031: admin-only restore of a post the health-claim
+// flag-escalation threshold auto-hid. Sets isPublic back to true -- the same
+// field the escalation function flipped, no new schema. Only acts on a post
+// that is actually in the pending-review state (ToForum, isPublic: false,
+// isActive: true); already-removed or never-hidden posts 409.
+import { createError, defineEventHandler } from 'h3'
+import prisma from '../../../../../utils/prisma'
+import { errorHandler } from '../../../../../utils/error'
+import { requireAdminApiUser } from '../../../../../utils/authGuard'
+import { logAdminAction } from '../../../../../utils/audit'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const { user: admin } = await requireAdminApiUser(event)
+
+    const id = Number(event.context.params?.id)
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid post id.' })
+    }
+
+    const post = await prisma.chat.findUnique({
+      where: { id },
+      select: { id: true, type: true, isPublic: true, isActive: true },
+    })
+
+    if (!post || post.type !== 'ToForum') {
+      throw createError({ statusCode: 404, message: 'Forum post not found.' })
+    }
+    if (post.isPublic || !post.isActive) {
+      throw createError({
+        statusCode: 409,
+        message: 'This post is not pending review.',
+      })
+    }
+
+    const updated = await prisma.chat.update({
+      where: { id },
+      data: { isPublic: true },
+      select: { id: true, isPublic: true, isActive: true, updatedAt: true },
+    })
+
+    await logAdminAction(
+      admin,
+      `Restored forum post #${id}: cleared auto-hide, post is public again.`,
+    )
+
+    return {
+      success: true,
+      message: `Forum post #${id} restored.`,
+      statusCode: 200,
+      data: updated,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      message: handled.message || 'Failed to restore forum post.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/stores/forumModerationStore.ts
+++ b/stores/forumModerationStore.ts
@@ -1,0 +1,104 @@
+// /stores/forumModerationStore.ts
+//
+// rainbow-butterflies/t-031: owns the fetch/restore/remove calls behind the
+// admin forum-moderation review queue (pages/admin/forum-moderation.vue).
+// Components never call APIs directly, per AGENTS.md -- same shape as
+// socialDraftsStore.ts. There is exactly one queue: posts the health-claim
+// flag-escalation threshold auto-hid, pending a human decision.
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { performFetch, handleError } from './utils'
+
+export type HiddenForumPost = {
+  id: number
+  content: string
+  sender: string
+  botName: string | null
+  channel: string | null
+  userId: number | null
+  botId: number | null
+  createdAt: string
+  updatedAt: string | null
+}
+
+export const useForumModerationStore = defineStore(
+  'forumModerationStore',
+  () => {
+    const posts = ref<HiddenForumPost[]>([])
+    const loading = ref(false)
+    const error = ref('')
+
+    async function fetchHiddenPosts() {
+      loading.value = true
+      error.value = ''
+      try {
+        const res = await performFetch<{ posts: HiddenForumPost[] }>(
+          '/api/admin/forum/hidden-posts',
+        )
+        if (res.success && res.data) {
+          posts.value = res.data.posts
+        } else {
+          error.value = res.message || 'Failed to load hidden forum posts.'
+        }
+      } catch (err) {
+        handleError(err, 'forumModerationStore.fetchHiddenPosts')
+        error.value = 'Failed to load hidden forum posts.'
+      } finally {
+        loading.value = false
+      }
+    }
+
+    async function restore(id: number) {
+      error.value = ''
+      try {
+        const res = await performFetch(
+          `/api/admin/forum/hidden-posts/${id}/restore`,
+          {
+            method: 'POST',
+          },
+        )
+        if (res.success) {
+          posts.value = posts.value.filter((post) => post.id !== id)
+        } else {
+          error.value = res.message || 'Failed to restore forum post.'
+        }
+        return res
+      } catch (err) {
+        handleError(err, 'forumModerationStore.restore')
+        error.value = 'Failed to restore forum post.'
+        return null
+      }
+    }
+
+    async function remove(id: number) {
+      error.value = ''
+      try {
+        const res = await performFetch(
+          `/api/admin/forum/hidden-posts/${id}/remove`,
+          {
+            method: 'POST',
+          },
+        )
+        if (res.success) {
+          posts.value = posts.value.filter((post) => post.id !== id)
+        } else {
+          error.value = res.message || 'Failed to remove forum post.'
+        }
+        return res
+      } catch (err) {
+        handleError(err, 'forumModerationStore.remove')
+        error.value = 'Failed to remove forum post.'
+        return null
+      }
+    }
+
+    return {
+      posts,
+      loading,
+      error,
+      fetchHiddenPosts,
+      restore,
+      remove,
+    }
+  },
+)


### PR DESCRIPTION
rainbow-butterflies/t-031 (kaizen from t-025, kind_robots#2236): forum posts that cross the health-claim flag-escalation threshold (≥2 distinct flaggers citing misinformation/unsafe) are auto-hidden (`isPublic: false`) and logged via `logSystemAction`, but there was no admin-facing surface listing them — a moderator had to grep `Log` entries by hand.

**Adds:**
- `GET /api/admin/forum/hidden-posts` — lists `ToForum` posts with `isPublic: false, isActive: true`. `escalateHealthClaimFlagsIfNeeded` (forumApi.ts) is the only place that ever flips `isPublic` on a `ToForum` post, so this state reliably identifies the pending-review queue without any new schema.
- `POST .../[id]/restore` — clears the auto-hide (`isPublic: true`).
- `POST .../[id]/remove` — confirms removal (`isActive: false`, the existing soft-delete field).
- `stores/forumModerationStore.ts` + `pages/admin/forum-moderation.vue` — mirrors the existing `social-drafts` admin review-queue pattern (same card/filter/action shape).
- `content/channels/admin/forum-moderation.md` — tab registration under the admin channel.

All three endpoints are admin-gated via `requireAdminApiUser`; restore/remove both write an audit trail entry via `logAdminAction`.

**Flags for Reviewer:**
- No new Prisma schema — reuses `Chat.isPublic`/`Chat.isActive`, per the task note.
- `restore`/`remove` both 409 if the post isn't currently in the pending-review state (`isPublic: true` or `isActive: false`), so a double-click or stale UI can't double-apply.

**Verification:** eslint clean, prettier clean, `vue-tsc --noEmit` clean repo-wide, `test:layout-contract` holds (207-violation baseline, zero new).

Session: `claude-scheduled-20260831T042737Z-rb-t031`

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01QNrdhALG6XzTASWRg4gZdZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNrdhALG6XzTASWRg4gZdZ)_