### PR TITLE
ui: reuse flat panel for public tank header

### DIFF
--- a/pages/play/aquarium/browse/index.vue
+++ b/pages/play/aquarium/browse/index.vue
@@ -16,9 +16,7 @@
         </NuxtLink>
       </nav>
 
-      <header
-        class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-lg sm:p-7"
-      >
+      <header class="kr-panel-flat rounded-3xl p-5 shadow-lg sm:p-7">
         <p class="text-xs font-black uppercase tracking-[0.25em] text-primary">
           Cthulhuquarium
         </p>


### PR DESCRIPTION
## Summary
- reuse `kr-panel-flat` for the public Cthulhuquarium tank-browser header surface
- preserve the existing rounded-3xl geometry, padding, shadow, content, and behavior

Conductor: `interface-vision/t-104`
Session: `openai-scheduled-20260831T062108Z-interface-vision-t104-k4r9`