### PR TITLE
ui: reuse flat panel for human-gate cards

### DIFF
--- a/components/home/home-attention.vue
+++ b/components/home/home-attention.vue
@@ -89,7 +89,7 @@
       <div
         v-for="gate in gates"
         :key="gateKey(gate)"
-        class="min-w-0 rounded-lg border border-base-300 bg-base-100 transition-colors"
+        class="min-w-0 kr-panel-flat rounded-lg transition-colors"
         :class="
           openKey === gateKey(gate) ? 'border-primary [grid-column:1/-1]' : ''
         "


### PR DESCRIPTION
## Summary
- migrate the Home `Needs you` gate cards from duplicated `border border-base-300 bg-base-100` surface tokens to the shared `kr-panel-flat` primitive
- preserve the cards' existing `rounded-lg`, transition behavior, and open-card `border-primary` override
- no API, store, routing, database, or production-data changes

Conductor: interface-vision/t-104
Session: openai-scheduled-20260831T071900Z-interface-vision-t104-k2v7