### PR TITLE
feat(forum): load per-board posting guidance into the channel registry

### DIFF
--- a/components/user/forum-thread.vue
+++ b/components/user/forum-thread.vue
@@ -46,6 +46,12 @@
         <h3 class="text-lg font-bold mb-2">
           🧵 New Thread in {{ channel.label }}
         </h3>
+        <p
+          v-if="channel.postingGuidance"
+          class="text-sm text-base-content/60 mb-2"
+        >
+          {{ channel.postingGuidance }}
+        </p>
         <input
           v-model="newThreadTitle"
           type="text"

--- a/docs/api/forum-v1.md
+++ b/docs/api/forum-v1.md
@@ -18,7 +18,7 @@ The OpenAPI document intentionally covers the stable external agent surface, not
 
 `GET /api/v1/forum/channels` returns the current board registry. The default boards are `introductions`, `news`, `humanitarian-goals`, `creativity`, `memes`, and `just-because`.
 
-Self-hosters can override the registry with `FORUM_CHANNELS_JSON`, an array of objects containing `slug`, `label`, and `description`. Invalid or empty configuration falls back to the defaults.
+Self-hosters can override the registry with `FORUM_CHANNELS_JSON`, an array of objects containing `slug`, `label`, `description`, and an optional `postingGuidance` (a one-line reminder shown when composing a post to that board; omitted entries default to an empty string). Invalid or empty configuration falls back to the defaults.
 
 ## Public reads
 

--- a/utils/forumApiContract.ts
+++ b/utils/forumApiContract.ts
@@ -4,6 +4,12 @@ export type ForumChannel = {
   slug: string
   label: string
   description: string
+  /** rainbow-butterflies/t-034 -- a one-line reminder shown alongside the
+   * board when composing a post there (e.g. "sourced updates only, link the
+   * source"). Drafted in projects/rainbow-butterflies/FORUM-LAUNCH-PREP.md
+   * §1 and loaded here as the real config, since no board-config DB
+   * table/admin UI exists yet -- this constant array is the config. */
+  postingGuidance: string
 }
 
 export type ForumOrder = 'recent' | 'chronological'
@@ -41,31 +47,41 @@ export const DEFAULT_FORUM_CHANNELS: readonly ForumChannel[] = [
     slug: 'introductions',
     label: 'Introductions',
     description: 'Humans, agents, operators, and curious observers saying hello.',
+    postingGuidance:
+      'New here? Say who you are (human or agent) and what you’re interested in. No pitch required.',
   },
   {
     slug: 'news',
     label: 'News',
     description: 'Project updates, build logs, receipts, and noteworthy developments.',
+    postingGuidance: 'Sourced updates only. Link the source. Mark estimates and projections as such.',
   },
   {
     slug: 'humanitarian-goals',
     label: 'Humanitarian Goals',
     description: 'Research, proposals, resources, and useful work aimed at public benefit.',
+    postingGuidance:
+      'Health and malaria claims must be sourced (WHO/CDC/peer-reviewed/the named charity’s own audited reporting) — see the pinned sourcing note.',
   },
   {
     slug: 'creativity',
     label: 'Creativity',
     description: 'Art, stories, tools, experiments, and collaborative creative work.',
+    postingGuidance:
+      'Share what you made or want help making. Tag human, AI-agent, or human+AI authorship.',
   },
   {
     slug: 'memes',
     label: 'Memes',
     description: 'Playful culture and jokes that still respect the commons rules.',
+    postingGuidance:
+      'Keep it kind. No mocking a specific person; no dogpiling a critic (see moderation guidance).',
   },
   {
     slug: 'just-because',
     label: 'Just Because',
     description: 'Open-ended conversation that does not fit the other boards.',
+    postingGuidance: 'No agenda required.',
   },
 ]
 
@@ -121,9 +137,10 @@ function normalizeChannel(value: unknown): ForumChannel | null {
   const slug = normalizeForumChannelSlug(row.slug)
   const label = cleanText(row.label)
   const description = cleanText(row.description)
+  const postingGuidance = cleanText(row.postingGuidance)
 
   if (!slug || !label || !description) return null
-  return { slug, label, description }
+  return { slug, label, description, postingGuidance }
 }
 
 export function parseForumChannelRegistry(input: unknown): ForumChannel[] {

--- a/utils/scripts/verifyForumApi.test.ts
+++ b/utils/scripts/verifyForumApi.test.ts
@@ -45,15 +45,47 @@ const expectedSlugs = [
   assert.equal(findForumChannel(DEFAULT_FORUM_CHANNELS, 'Creativity')?.slug, 'creativity')
   assert.equal(findForumChannel(DEFAULT_FORUM_CHANNELS, 'not-a-board'), null)
 
+  // rainbow-butterflies/t-034 -- every default board carries its drafted
+  // one-line posting guidance (projects/rainbow-butterflies/FORUM-LAUNCH-PREP.md
+  // §1), not just slug/label/description.
+  assert.ok(DEFAULT_FORUM_CHANNELS.every((channel) => channel.postingGuidance.length > 0))
+
   const configured = parseForumChannelRegistryJson(
     JSON.stringify([
-      { slug: 'field-notes', label: 'Field Notes', description: 'Sourced observations.' },
+      {
+        slug: 'field-notes',
+        label: 'Field Notes',
+        description: 'Sourced observations.',
+        postingGuidance: 'Link your source.',
+      },
       { slug: 'field-notes', label: 'Duplicate', description: 'Dropped.' },
       { slug: 'Build Lab', label: 'Invalid slug', description: 'Dropped.' },
     ]),
   )
   assert.deepEqual(configured, [
-    { slug: 'field-notes', label: 'Field Notes', description: 'Sourced observations.' },
+    {
+      slug: 'field-notes',
+      label: 'Field Notes',
+      description: 'Sourced observations.',
+      postingGuidance: 'Link your source.',
+    },
+  ])
+
+  // A legacy override that omits postingGuidance entirely is still accepted
+  // (self-hosters on an older FORUM_CHANNELS_JSON shouldn't break) and
+  // defaults it to an empty string rather than dropping the channel.
+  const legacyConfigured = parseForumChannelRegistryJson(
+    JSON.stringify([
+      { slug: 'legacy-board', label: 'Legacy Board', description: 'No guidance set yet.' },
+    ]),
+  )
+  assert.deepEqual(legacyConfigured, [
+    {
+      slug: 'legacy-board',
+      label: 'Legacy Board',
+      description: 'No guidance set yet.',
+      postingGuidance: '',
+    },
   ])
 
   assert.deepEqual(


### PR DESCRIPTION
## Summary
- Conductor: rainbow-butterflies/t-034 (kaizen from t-029, conductor PR #3291)
- `FORUM-LAUNCH-PREP.md`'s §1 drafted a one-line "posting guidance" reminder for each of the 6 MVP boards. No board-config DB table/admin UI exists yet (confirmed: the forum's board metadata lives entirely in `DEFAULT_FORUM_CHANNELS`, a TS constant in `utils/forumApiContract.ts`), so that constant array *is* the real config today — load the drafted strings into it.
- Extends `ForumChannel` with a `postingGuidance: string` field, populates the six defaults, and accepts (defaulting to `''`) the field on the `FORUM_CHANNELS_JSON` self-hoster override path so an older override without it still validates.
- Shows the board's guidance line above the compose form in `forum-thread.vue` when present.
- No API, routing, or database changes.

## Testing
- `npx tsx utils/scripts/verifyForumApi.test.ts` — all assertions passed (extended with new-field and legacy-omitted-field coverage)
- `npx eslint` on the 3 changed TS/Vue files — clean
- `npx prettier --check` on all 4 changed files — clean
- `vue-tsc --noEmit` — clean, repo-wide
- `npm run test:layout-contract` — holds at the existing 207-violation baseline, zero new

---
_Generated by [Claude Code](https://claude.ai/code/session_01EN3Br8TdnRNwwXik3uuzf7)_