### PR TITLE
Add privacy-preserving Rainbow mission metrics

### DIFF
--- a/.github/workflows/mission-metrics-contract.yml
+++ b/.github/workflows/mission-metrics-contract.yml
@@ -1,0 +1,38 @@
+name: Mission Metrics Contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/v1/mission/**'
+      - 'server/utils/missionMetrics.ts'
+      - 'utils/missionMetricsContract.ts'
+      - 'utils/scripts/verifyMissionMetrics.test.ts'
+      - 'docs/api/mission-metrics.md'
+      - '.github/workflows/mission-metrics-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify mission metrics contract
+        run: npx tsx utils/scripts/verifyMissionMetrics.test.ts

--- a/docs/api/mission-metrics.md
+++ b/docs/api/mission-metrics.md
@@ -14,6 +14,8 @@ Each event may carry three low-cardinality labels: `source`, `campaign`, and `pl
 
 Accepted events are written to the existing Kind Robots `Log` model as JSON with `username = rainbow-metrics` and `userId = null`. The payload contains only the event and those three coarse labels. It does not contain a visitor identifier, account id, IP address, user agent, referrer, full URL, browser fingerprint, or arbitrary metadata.
 
+Event timestamps are deliberately reduced to the UTC day (`00:00:00`) before storage. The reporting goal is a daily funnel, so retaining an exact visit/click time would add needless identifying detail without improving the decision signal.
+
 The public ingest endpoint uses the request IP transiently in process memory for a one-minute anti-abuse rate-limit bucket. The IP is not persisted, logged, returned, hashed into a durable identifier, or combined with other signals.
 
 ## What is derived from canonical Kind Robots state

--- a/docs/api/mission-metrics.md
+++ b/docs/api/mission-metrics.md
@@ -1,0 +1,42 @@
+# Rainbow Butterflies mission metrics
+
+Rainbow Butterflies uses a deliberately small first-party measurement surface so launch experiments can be evaluated without adding a surveillance stack.
+
+## What is recorded
+
+`POST /api/v1/mission/events` accepts only three anonymous event types:
+
+- `visit`
+- `return_visit`
+- `fundraiser_click`
+
+Each event may carry three low-cardinality labels: `source`, `campaign`, and `placement`. Values are lowercased, reduced to letters/numbers/hyphens, and capped at 48 characters. Unknown request fields are rejected.
+
+Accepted events are written to the existing Kind Robots `Log` model as JSON with `username = rainbow-metrics` and `userId = null`. The payload contains only the event and those three coarse labels. It does not contain a visitor identifier, account id, IP address, user agent, referrer, full URL, browser fingerprint, or arbitrary metadata.
+
+The public ingest endpoint uses the request IP transiently in process memory for a one-minute anti-abuse rate-limit bucket. The IP is not persisted, logged, returned, hashed into a durable identifier, or combined with other signals.
+
+## What is derived from canonical Kind Robots state
+
+`GET /api/v1/mission/summary?days=30` returns aggregate counts for a 1–90 day UTC window.
+
+Rather than trusting browser events for product activity, it derives these figures from canonical Kind Robots records:
+
+- public human forum contributions from active/public `Chat` rows with no author Bot;
+- public AI-agent forum contributions from active/public `Chat` rows with an author Bot;
+- completed Rainbow Butterflies art-generation objects from durable `ArtJob` rows with `projectSlug = rainbow-butterflies`;
+- public forum posts carrying a canonical ArtImage, Project, or Character attachment.
+
+Anonymous event rows provide only first/returning visit counts and outbound fundraiser-click attribution. The summary exposes coarse source/campaign and page-placement breakdowns for fundraiser clicks plus a daily event series.
+
+## Return visits
+
+The Rainbow Butterflies client may store a boolean `seen before` marker and the last UTC day on which a visit was counted. Those values contain no random id and are never sent to Kind Robots. They exist only so one browser is not counted repeatedly on every reload and so a later visit can be classified as returning.
+
+Campaign attribution may persist the sanitized source/campaign labels themselves. It does not persist the referring URL or a visitor id.
+
+## Donation boundary
+
+Against Malaria remains the donation processor. These metrics record only that a visitor followed the outbound fundraiser link. They do **not** establish that a donation occurred, identify a donor, or reveal a donation amount.
+
+The summary response therefore explicitly reports that donor identities and donation amounts are unknown. Any future verified AMF integration must be designed and documented separately rather than inferred from click behavior.

--- a/docs/api/mission-metrics.md
+++ b/docs/api/mission-metrics.md
@@ -10,9 +10,9 @@ Rainbow Butterflies uses a deliberately small first-party measurement surface so
 - `return_visit`
 - `fundraiser_click`
 
-Each event may carry three low-cardinality labels: `source`, `campaign`, and `placement`. Values are lowercased, reduced to letters/numbers/hyphens, and capped at 48 characters. Unknown request fields are rejected.
+Each event may carry three low-cardinality labels: `source`, `campaign`, and `placement`. Unknown request fields are rejected. The values are not stored as arbitrary client text: source, campaign, and placement are normalized into small checked-in vocabularies, with unknown source/campaign values collapsing to `other` and unknown placements to `unknown`. This keeps query strings from becoming an accidental free-form analytics field.
 
-Accepted events are written to the existing Kind Robots `Log` model as JSON with `username = rainbow-metrics` and `userId = null`. The payload contains only the event and those three coarse labels. It does not contain a visitor identifier, account id, IP address, user agent, referrer, full URL, browser fingerprint, or arbitrary metadata.
+Accepted events are written to the existing Kind Robots `Log` model as JSON with `username = rainbow-metrics` and `userId = null`. The payload contains only the event and those three coarse bucket labels. It does not contain a visitor identifier, account id, IP address, user agent, referrer, full URL, browser fingerprint, or arbitrary metadata.
 
 Event timestamps are deliberately reduced to the UTC day (`00:00:00`) before storage. The reporting goal is a daily funnel, so retaining an exact visit/click time would add needless identifying detail without improving the decision signal.
 
@@ -35,7 +35,7 @@ Anonymous event rows provide only first/returning visit counts and outbound fund
 
 The Rainbow Butterflies client may store a boolean `seen before` marker and the last UTC day on which a visit was counted. Those values contain no random id and are never sent to Kind Robots. They exist only so one browser is not counted repeatedly on every reload and so a later visit can be classified as returning.
 
-Campaign attribution may persist the sanitized source/campaign labels themselves. It does not persist the referring URL or a visitor id.
+Campaign attribution may persist the already-bucketed source/campaign labels themselves. It does not persist the referring URL or a visitor id.
 
 ## Donation boundary
 

--- a/server/api/v1/mission/events.post.ts
+++ b/server/api/v1/mission/events.post.ts
@@ -1,0 +1,59 @@
+import { createError, defineEventHandler, readBody } from 'h3'
+import { errorHandler } from '@/server/utils/error'
+import {
+  assertMissionEventRateLimit,
+  recordMissionEvent,
+} from '@/server/utils/missionMetrics'
+import { normalizeMissionEventInput } from '@/utils/missionMetricsContract'
+
+const ALLOWED_FIELDS = new Set(['event', 'source', 'campaign', 'placement'])
+
+export default defineEventHandler(async (event) => {
+  try {
+    assertMissionEventRateLimit(event)
+
+    const body = await readBody<unknown>(event)
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      throw createError({
+        statusCode: 400,
+        message: 'Mission event body must be a JSON object.',
+      })
+    }
+
+    const unknownField = Object.keys(body as Record<string, unknown>).find(
+      (key) => !ALLOWED_FIELDS.has(key),
+    )
+    if (unknownField) {
+      throw createError({
+        statusCode: 400,
+        message: `Unsupported mission event field: ${unknownField}.`,
+      })
+    }
+
+    const input = normalizeMissionEventInput(body)
+    if (!input) {
+      throw createError({
+        statusCode: 400,
+        message:
+          'Mission event must be one of visit, return_visit, or fundraiser_click.',
+      })
+    }
+
+    await recordMissionEvent(input)
+
+    event.node.res.statusCode = 202
+    return {
+      success: true,
+      message: 'Mission event accepted.',
+      statusCode: 202,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      message: handled.message,
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/api/v1/mission/summary.get.ts
+++ b/server/api/v1/mission/summary.get.ts
@@ -1,0 +1,40 @@
+import { createError, defineEventHandler, getQuery } from 'h3'
+import { errorHandler } from '@/server/utils/error'
+import { summarizeMissionMetrics } from '@/server/utils/missionMetrics'
+
+const DEFAULT_DAYS = 30
+const MAX_DAYS = 90
+
+export default defineEventHandler(async (event) => {
+  try {
+    const query = getQuery(event)
+    const rawDays = Array.isArray(query.days) ? query.days[0] : query.days
+    const days = rawDays == null || rawDays === '' ? DEFAULT_DAYS : Number(rawDays)
+
+    if (!Number.isInteger(days) || days < 1 || days > MAX_DAYS) {
+      throw createError({
+        statusCode: 400,
+        message: `days must be an integer from 1 to ${MAX_DAYS}.`,
+      })
+    }
+
+    const summary = await summarizeMissionMetrics(days)
+
+    return {
+      success: true,
+      data: summary,
+      message:
+        'Aggregate Rainbow Butterflies mission metrics. These counts do not include donor identities or donation amounts.',
+      statusCode: 200,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      data: null,
+      message: handled.message,
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/utils/missionMetrics.ts
+++ b/server/utils/missionMetrics.ts
@@ -59,6 +59,7 @@ export type MissionMetricSummary = {
   privacy: {
     visitorIdsStored: false
     ipAddressesStored: false
+    exactEventTimesStored: false
     referrersStored: false
     userAgentsStored: false
     donationIdentitiesKnown: false
@@ -73,12 +74,20 @@ function rateLimitKey(event: H3Event): string {
   return getRequestIP(event, { xForwardedFor: true }) || 'unknown'
 }
 
+function sweepExpiredRateWindows(now: number): void {
+  for (const [key, value] of rateWindows) {
+    if (value.resetAt <= now) rateWindows.delete(key)
+  }
+}
+
 export function assertMissionEventRateLimit(event: H3Event): void {
   const now = Date.now()
+  sweepExpiredRateWindows(now)
+
   const key = rateLimitKey(event)
   const current = rateWindows.get(key)
 
-  if (!current || current.resetAt <= now) {
+  if (!current) {
     rateWindows.set(key, { count: 1, resetAt: now + RATE_WINDOW_MS })
     return
   }
@@ -97,20 +106,26 @@ export function assertMissionEventRateLimit(event: H3Event): void {
   current.count += 1
 }
 
+function utcDayBucket(value = new Date()): Date {
+  const day = new Date(value)
+  day.setUTCHours(0, 0, 0, 0)
+  return day
+}
+
 export async function recordMissionEvent(input: MissionEventInput): Promise<void> {
   await prisma.log.create({
     data: {
       message: encodeMissionEventLog(input),
       username: MISSION_LOG_USERNAME,
       userId: null,
-      timestamp: new Date(),
+      // Mission reporting needs daily trends, not an exact click timestamp.
+      timestamp: utcDayBucket(),
     },
   })
 }
 
 function periodStart(days: number): Date {
-  const start = new Date()
-  start.setUTCHours(0, 0, 0, 0)
+  const start = utcDayBucket()
   start.setUTCDate(start.getUTCDate() - (days - 1))
   return start
 }
@@ -248,6 +263,7 @@ export async function summarizeMissionMetrics(days: number): Promise<MissionMetr
     privacy: {
       visitorIdsStored: false,
       ipAddressesStored: false,
+      exactEventTimesStored: false,
       referrersStored: false,
       userAgentsStored: false,
       donationIdentitiesKnown: false,

--- a/server/utils/missionMetrics.ts
+++ b/server/utils/missionMetrics.ts
@@ -1,0 +1,257 @@
+import { createError, getRequestIP, type H3Event } from 'h3'
+import prisma from './prisma'
+import {
+  encodeMissionEventLog,
+  parseMissionEventLog,
+  type MissionEventInput,
+  type MissionEventType,
+} from '~/utils/missionMetricsContract'
+
+const MISSION_LOG_USERNAME = 'rainbow-metrics'
+const RATE_WINDOW_MS = 60_000
+const RATE_WINDOW_MAX_EVENTS = 30
+
+type RateWindow = {
+  count: number
+  resetAt: number
+}
+
+const rateWindows = new Map<string, RateWindow>()
+
+export type MissionMetricSummary = {
+  period: {
+    days: number
+    since: string
+    through: string
+  }
+  visits: {
+    first: number
+    returning: number
+    total: number
+  }
+  fundraiserClicks: {
+    total: number
+    byAttribution: Array<{
+      source: string
+      campaign: string
+      count: number
+    }>
+    byPlacement: Array<{
+      placement: string
+      count: number
+    }>
+  }
+  contributions: {
+    human: number
+    agent: number
+    total: number
+  }
+  usefulObjects: {
+    generatedArt: number
+    publicAttachments: number
+  }
+  daily: Array<{
+    date: string
+    visit: number
+    returnVisit: number
+    fundraiserClick: number
+  }>
+  privacy: {
+    visitorIdsStored: false
+    ipAddressesStored: false
+    referrersStored: false
+    userAgentsStored: false
+    donationIdentitiesKnown: false
+    donationAmountsKnown: false
+  }
+}
+
+function rateLimitKey(event: H3Event): string {
+  // The address is held only in process memory for this one-minute anti-abuse
+  // window. It is never written to Log, returned by the API, or combined with
+  // any other signal to form a visitor identifier.
+  return getRequestIP(event, { xForwardedFor: true }) || 'unknown'
+}
+
+export function assertMissionEventRateLimit(event: H3Event): void {
+  const now = Date.now()
+  const key = rateLimitKey(event)
+  const current = rateWindows.get(key)
+
+  if (!current || current.resetAt <= now) {
+    rateWindows.set(key, { count: 1, resetAt: now + RATE_WINDOW_MS })
+    return
+  }
+
+  if (current.count >= RATE_WINDOW_MAX_EVENTS) {
+    event.node.res.setHeader(
+      'Retry-After',
+      String(Math.max(1, Math.ceil((current.resetAt - now) / 1000))),
+    )
+    throw createError({
+      statusCode: 429,
+      message: 'Too many mission metric events. Please try again shortly.',
+    })
+  }
+
+  current.count += 1
+}
+
+export async function recordMissionEvent(input: MissionEventInput): Promise<void> {
+  await prisma.log.create({
+    data: {
+      message: encodeMissionEventLog(input),
+      username: MISSION_LOG_USERNAME,
+      userId: null,
+      timestamp: new Date(),
+    },
+  })
+}
+
+function periodStart(days: number): Date {
+  const start = new Date()
+  start.setUTCHours(0, 0, 0, 0)
+  start.setUTCDate(start.getUTCDate() - (days - 1))
+  return start
+}
+
+function addCount(map: Map<string, number>, key: string): void {
+  map.set(key, (map.get(key) ?? 0) + 1)
+}
+
+function eventKeyForDay(event: MissionEventType): 'visit' | 'returnVisit' | 'fundraiserClick' {
+  if (event === 'return_visit') return 'returnVisit'
+  if (event === 'fundraiser_click') return 'fundraiserClick'
+  return 'visit'
+}
+
+export async function summarizeMissionMetrics(days: number): Promise<MissionMetricSummary> {
+  const since = periodStart(days)
+  const through = new Date()
+
+  const [eventRows, humanContributions, agentContributions, generatedArt, publicAttachments] =
+    await Promise.all([
+      prisma.log.findMany({
+        where: {
+          username: MISSION_LOG_USERNAME,
+          timestamp: { gte: since },
+        },
+        orderBy: { timestamp: 'asc' },
+        select: { message: true, timestamp: true },
+      }),
+      prisma.chat.count({
+        where: {
+          type: 'ToForum',
+          isPublic: true,
+          isActive: true,
+          botId: null,
+          createdAt: { gte: since },
+        },
+      }),
+      prisma.chat.count({
+        where: {
+          type: 'ToForum',
+          isPublic: true,
+          isActive: true,
+          botId: { not: null },
+          createdAt: { gte: since },
+        },
+      }),
+      prisma.artJob.count({
+        where: {
+          projectSlug: 'rainbow-butterflies',
+          status: 'DONE',
+          artImageId: { not: null },
+          createdAt: { gte: since },
+        },
+      }),
+      prisma.chat.count({
+        where: {
+          type: 'ToForum',
+          isPublic: true,
+          isActive: true,
+          createdAt: { gte: since },
+          OR: [
+            { artImageId: { not: null } },
+            { projectId: { not: null } },
+            { characterId: { not: null } },
+          ],
+        },
+      }),
+    ])
+
+  let firstVisits = 0
+  let returnVisits = 0
+  let fundraiserClicks = 0
+  const attribution = new Map<string, number>()
+  const placements = new Map<string, number>()
+  const daily = new Map<
+    string,
+    { visit: number; returnVisit: number; fundraiserClick: number }
+  >()
+
+  for (const row of eventRows) {
+    const parsed = parseMissionEventLog(row.message)
+    if (!parsed) continue
+
+    if (parsed.event === 'visit') firstVisits += 1
+    if (parsed.event === 'return_visit') returnVisits += 1
+    if (parsed.event === 'fundraiser_click') {
+      fundraiserClicks += 1
+      addCount(attribution, `${parsed.source}\u0000${parsed.campaign}`)
+      addCount(placements, parsed.placement)
+    }
+
+    const date = row.timestamp.toISOString().slice(0, 10)
+    const bucket = daily.get(date) ?? {
+      visit: 0,
+      returnVisit: 0,
+      fundraiserClick: 0,
+    }
+    bucket[eventKeyForDay(parsed.event)] += 1
+    daily.set(date, bucket)
+  }
+
+  return {
+    period: {
+      days,
+      since: since.toISOString(),
+      through: through.toISOString(),
+    },
+    visits: {
+      first: firstVisits,
+      returning: returnVisits,
+      total: firstVisits + returnVisits,
+    },
+    fundraiserClicks: {
+      total: fundraiserClicks,
+      byAttribution: [...attribution.entries()]
+        .map(([key, count]) => {
+          const [source, campaign] = key.split('\u0000')
+          return { source, campaign, count }
+        })
+        .sort((a, b) => b.count - a.count || a.source.localeCompare(b.source)),
+      byPlacement: [...placements.entries()]
+        .map(([placement, count]) => ({ placement, count }))
+        .sort((a, b) => b.count - a.count || a.placement.localeCompare(b.placement)),
+    },
+    contributions: {
+      human: humanContributions,
+      agent: agentContributions,
+      total: humanContributions + agentContributions,
+    },
+    usefulObjects: {
+      generatedArt,
+      publicAttachments,
+    },
+    daily: [...daily.entries()].map(([date, counts]) => ({ date, ...counts })),
+    privacy: {
+      visitorIdsStored: false,
+      ipAddressesStored: false,
+      referrersStored: false,
+      userAgentsStored: false,
+      donationIdentitiesKnown: false,
+      donationAmountsKnown: false,
+    },
+  }
+}

--- a/server/utils/missionMetrics.ts
+++ b/server/utils/missionMetrics.ts
@@ -140,6 +140,18 @@ function eventKeyForDay(event: MissionEventType): 'visit' | 'returnVisit' | 'fun
   return 'visit'
 }
 
+function decodeAttributionKey(key: string): { source: string; campaign: string } {
+  const separator = key.indexOf('\u0000')
+  if (separator < 0) {
+    return { source: key || 'direct', campaign: 'none' }
+  }
+
+  return {
+    source: key.slice(0, separator) || 'direct',
+    campaign: key.slice(separator + 1) || 'none',
+  }
+}
+
 export async function summarizeMissionMetrics(days: number): Promise<MissionMetricSummary> {
   const since = periodStart(days)
   const through = new Date()
@@ -241,10 +253,7 @@ export async function summarizeMissionMetrics(days: number): Promise<MissionMetr
     fundraiserClicks: {
       total: fundraiserClicks,
       byAttribution: [...attribution.entries()]
-        .map(([key, count]) => {
-          const [source, campaign] = key.split('\u0000')
-          return { source, campaign, count }
-        })
+        .map(([key, count]) => ({ ...decodeAttributionKey(key), count }))
         .sort((a, b) => b.count - a.count || a.source.localeCompare(b.source)),
       byPlacement: [...placements.entries()]
         .map(([placement, count]) => ({ placement, count }))

--- a/utils/missionMetricsContract.ts
+++ b/utils/missionMetricsContract.ts
@@ -6,13 +6,60 @@ export const MISSION_EVENT_TYPES = [
   'fundraiser_click',
 ] as const
 
+export const MISSION_SOURCES = [
+  'direct',
+  'rainbow',
+  'kindrobots',
+  'github',
+  'bluesky',
+  'fediverse',
+  'mastodon',
+  'reddit',
+  'discord',
+  'moltbook',
+  'nexus-0',
+  'openagents',
+  'newsletter',
+  'x',
+  'meta',
+  'youtube',
+  'tiktok',
+  'linkedin',
+  'other',
+] as const
+
+export const MISSION_CAMPAIGNS = [
+  'none',
+  'founding',
+  'agent-native-pilot',
+  'open-social-pilot',
+  'human-community-pilot',
+  'butterfly-bounty',
+  'useful-object-relay',
+  'direct-fundraiser',
+  'skeptical-chair',
+  'other',
+] as const
+
+export const MISSION_PLACEMENTS = [
+  'home',
+  'header',
+  'hero',
+  'impact',
+  'footer',
+  'unknown',
+] as const
+
 export type MissionEventType = (typeof MISSION_EVENT_TYPES)[number]
+export type MissionSource = (typeof MISSION_SOURCES)[number]
+export type MissionCampaign = (typeof MISSION_CAMPAIGNS)[number]
+export type MissionPlacement = (typeof MISSION_PLACEMENTS)[number]
 
 export type MissionEventInput = {
   event: MissionEventType
-  source: string
-  campaign: string
-  placement: string
+  source: MissionSource
+  campaign: MissionCampaign
+  placement: MissionPlacement
 }
 
 export type MissionEventLog = MissionEventInput & {
@@ -30,10 +77,7 @@ export function isMissionEventType(value: unknown): value is MissionEventType {
   )
 }
 
-export function normalizeMissionDimension(
-  value: unknown,
-  fallback: string,
-): string {
+export function normalizeMissionDimension(value: unknown, fallback: string): string {
   if (typeof value !== 'string') return fallback
 
   const normalized = value
@@ -47,6 +91,30 @@ export function normalizeMissionDimension(
   return normalized || fallback
 }
 
+function bucketDimension<T extends readonly string[]>(
+  value: unknown,
+  allowed: T,
+  fallback: T[number],
+  unknown: T[number],
+): T[number] {
+  const normalized = normalizeMissionDimension(value, fallback)
+  return (allowed as readonly string[]).includes(normalized)
+    ? (normalized as T[number])
+    : unknown
+}
+
+export function normalizeMissionSource(value: unknown): MissionSource {
+  return bucketDimension(value, MISSION_SOURCES, 'direct', 'other')
+}
+
+export function normalizeMissionCampaign(value: unknown): MissionCampaign {
+  return bucketDimension(value, MISSION_CAMPAIGNS, 'none', 'other')
+}
+
+export function normalizeMissionPlacement(value: unknown): MissionPlacement {
+  return bucketDimension(value, MISSION_PLACEMENTS, 'unknown', 'unknown')
+}
+
 export function normalizeMissionEventInput(value: unknown): MissionEventInput | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null
 
@@ -55,9 +123,9 @@ export function normalizeMissionEventInput(value: unknown): MissionEventInput | 
 
   return {
     event: row.event,
-    source: normalizeMissionDimension(row.source, 'direct'),
-    campaign: normalizeMissionDimension(row.campaign, 'none'),
-    placement: normalizeMissionDimension(row.placement, 'unknown'),
+    source: normalizeMissionSource(row.source),
+    campaign: normalizeMissionCampaign(row.campaign),
+    placement: normalizeMissionPlacement(row.placement),
   }
 }
 
@@ -87,9 +155,9 @@ export function parseMissionEventLog(value: unknown): MissionEventLog | null {
       kind: MISSION_EVENT_LOG_KIND,
       version: 1,
       event: parsed.event,
-      source: normalizeMissionDimension(parsed.source, 'direct'),
-      campaign: normalizeMissionDimension(parsed.campaign, 'none'),
-      placement: normalizeMissionDimension(parsed.placement, 'unknown'),
+      source: normalizeMissionSource(parsed.source),
+      campaign: normalizeMissionCampaign(parsed.campaign),
+      placement: normalizeMissionPlacement(parsed.placement),
     }
   } catch {
     return null

--- a/utils/missionMetricsContract.ts
+++ b/utils/missionMetricsContract.ts
@@ -1,0 +1,97 @@
+export const MISSION_EVENT_LOG_KIND = 'rainbow-mission-event' as const
+
+export const MISSION_EVENT_TYPES = [
+  'visit',
+  'return_visit',
+  'fundraiser_click',
+] as const
+
+export type MissionEventType = (typeof MISSION_EVENT_TYPES)[number]
+
+export type MissionEventInput = {
+  event: MissionEventType
+  source: string
+  campaign: string
+  placement: string
+}
+
+export type MissionEventLog = MissionEventInput & {
+  kind: typeof MISSION_EVENT_LOG_KIND
+  version: 1
+}
+
+const DIMENSION_MAX_LENGTH = 48
+const DIMENSION_PATTERN = /[^a-z0-9]+/g
+
+export function isMissionEventType(value: unknown): value is MissionEventType {
+  return (
+    typeof value === 'string' &&
+    (MISSION_EVENT_TYPES as readonly string[]).includes(value)
+  )
+}
+
+export function normalizeMissionDimension(
+  value: unknown,
+  fallback: string,
+): string {
+  if (typeof value !== 'string') return fallback
+
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(DIMENSION_PATTERN, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, DIMENSION_MAX_LENGTH)
+    .replace(/-+$/g, '')
+
+  return normalized || fallback
+}
+
+export function normalizeMissionEventInput(value: unknown): MissionEventInput | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+
+  const row = value as Record<string, unknown>
+  if (!isMissionEventType(row.event)) return null
+
+  return {
+    event: row.event,
+    source: normalizeMissionDimension(row.source, 'direct'),
+    campaign: normalizeMissionDimension(row.campaign, 'none'),
+    placement: normalizeMissionDimension(row.placement, 'unknown'),
+  }
+}
+
+export function encodeMissionEventLog(input: MissionEventInput): string {
+  const row: MissionEventLog = {
+    kind: MISSION_EVENT_LOG_KIND,
+    version: 1,
+    ...input,
+  }
+  return JSON.stringify(row)
+}
+
+export function parseMissionEventLog(value: unknown): MissionEventLog | null {
+  if (typeof value !== 'string') return null
+
+  try {
+    const parsed = JSON.parse(value) as Record<string, unknown>
+    if (
+      parsed.kind !== MISSION_EVENT_LOG_KIND ||
+      parsed.version !== 1 ||
+      !isMissionEventType(parsed.event)
+    ) {
+      return null
+    }
+
+    return {
+      kind: MISSION_EVENT_LOG_KIND,
+      version: 1,
+      event: parsed.event,
+      source: normalizeMissionDimension(parsed.source, 'direct'),
+      campaign: normalizeMissionDimension(parsed.campaign, 'none'),
+      placement: normalizeMissionDimension(parsed.placement, 'unknown'),
+    }
+  } catch {
+    return null
+  }
+}

--- a/utils/scripts/verifyMissionMetrics.test.ts
+++ b/utils/scripts/verifyMissionMetrics.test.ts
@@ -14,15 +14,29 @@ assert.equal(normalizeMissionDimension('X'.repeat(100), 'none').length, 48)
 const input = normalizeMissionEventInput({
   event: 'fundraiser_click',
   source: 'Bluesky',
-  campaign: 'Launch Week 1',
-  placement: 'Hero CTA',
+  campaign: 'Open Social Pilot',
+  placement: 'Hero',
 })
 assert.deepEqual(input, {
   event: 'fundraiser_click',
   source: 'bluesky',
-  campaign: 'launch-week-1',
-  placement: 'hero-cta',
+  campaign: 'open-social-pilot',
+  placement: 'hero',
 })
+assert.deepEqual(
+  normalizeMissionEventInput({
+    event: 'fundraiser_click',
+    source: 'someone@example.com',
+    campaign: 'visitor-9f8e7d6c',
+    placement: 'made-up-slot',
+  }),
+  {
+    event: 'fundraiser_click',
+    source: 'other',
+    campaign: 'other',
+    placement: 'unknown',
+  },
+)
 assert.equal(normalizeMissionEventInput({ event: 'donation' }), null)
 
 const encoded = encodeMissionEventLog(input!)
@@ -46,6 +60,7 @@ assert.match(metricsSource, /username: MISSION_LOG_USERNAME/)
 assert.match(metricsSource, /getRequestIP/)
 assert.match(metricsSource, /visitorIdsStored: false/)
 assert.match(metricsSource, /ipAddressesStored: false/)
+assert.match(metricsSource, /exactEventTimesStored: false/)
 assert.match(metricsSource, /referrersStored: false/)
 assert.match(metricsSource, /donationIdentitiesKnown: false/)
 assert.match(metricsSource, /donationAmountsKnown: false/)

--- a/utils/scripts/verifyMissionMetrics.test.ts
+++ b/utils/scripts/verifyMissionMetrics.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import {
+  encodeMissionEventLog,
+  normalizeMissionDimension,
+  normalizeMissionEventInput,
+  parseMissionEventLog,
+} from '../missionMetricsContract.js'
+
+assert.equal(normalizeMissionDimension(' Bluesky / Launch ', 'direct'), 'bluesky-launch')
+assert.equal(normalizeMissionDimension('', 'direct'), 'direct')
+assert.equal(normalizeMissionDimension('X'.repeat(100), 'none').length, 48)
+
+const input = normalizeMissionEventInput({
+  event: 'fundraiser_click',
+  source: 'Bluesky',
+  campaign: 'Launch Week 1',
+  placement: 'Hero CTA',
+})
+assert.deepEqual(input, {
+  event: 'fundraiser_click',
+  source: 'bluesky',
+  campaign: 'launch-week-1',
+  placement: 'hero-cta',
+})
+assert.equal(normalizeMissionEventInput({ event: 'donation' }), null)
+
+const encoded = encodeMissionEventLog(input!)
+assert.deepEqual(parseMissionEventLog(encoded), {
+  kind: 'rainbow-mission-event',
+  version: 1,
+  ...input!,
+})
+assert.equal(parseMissionEventLog('not json'), null)
+
+const [ingestSource, metricsSource, summarySource] = await Promise.all([
+  readFile('server/api/v1/mission/events.post.ts', 'utf8'),
+  readFile('server/utils/missionMetrics.ts', 'utf8'),
+  readFile('server/api/v1/mission/summary.get.ts', 'utf8'),
+])
+
+assert.match(ingestSource, /ALLOWED_FIELDS = new Set\(\['event', 'source', 'campaign', 'placement'\]\)/)
+assert.doesNotMatch(ingestSource, /visitorId|fingerprint|referrer|userAgent/i)
+assert.match(metricsSource, /userId: null/)
+assert.match(metricsSource, /username: MISSION_LOG_USERNAME/)
+assert.match(metricsSource, /getRequestIP/)
+assert.match(metricsSource, /visitorIdsStored: false/)
+assert.match(metricsSource, /ipAddressesStored: false/)
+assert.match(metricsSource, /referrersStored: false/)
+assert.match(metricsSource, /donationIdentitiesKnown: false/)
+assert.match(metricsSource, /donationAmountsKnown: false/)
+assert.match(metricsSource, /projectSlug: 'rainbow-butterflies'/)
+assert.match(summarySource, /do not include donor identities or donation amounts/i)
+
+console.log('verifyMissionMetrics.test.ts: all assertions passed')


### PR DESCRIPTION
## Summary

Implements Rainbow Butterflies roadmap `t-011` on the canonical Kind Robots backend without adding a second analytics database or third-party tracker.

### Anonymous first-party events

Adds `POST /api/v1/mission/events` for exactly three events:

- `visit`
- `return_visit`
- `fundraiser_click`

Only coarse `source`, `campaign`, and `placement` buckets are accepted. They map into checked-in vocabularies; unknown source/campaign text collapses to `other`, and unknown placement to `unknown`, so arbitrary query strings cannot become stored analytics metadata.

Events reuse the existing `Log` model with `userId = null`. Exact event time is reduced to the UTC day before persistence.

The ingest rate limiter uses request IP only transiently in a one-minute in-memory bucket. IPs, referrers, user agents, full URLs, fingerprints, visitor IDs, and arbitrary metadata are never stored.

### Aggregate mission report

Adds `GET /api/v1/mission/summary?days=1..90`, combining anonymous visit/click events with canonical Kind Robots state:

- public human forum contributions
- public AI-agent forum contributions
- completed Rainbow-tagged ArtJobs
- public forum posts with canonical ArtImage/Project/Character attachments
- fundraiser-click source/campaign/placement attribution
- daily event totals

The response explicitly states that donor identities and donation amounts are unknown. An outbound click is not treated as evidence of a donation.

### Verification

Adds a focused Mission Metrics Contract workflow and documentation of the privacy/accounting boundary.

No Prisma schema/migration, DNS, secrets, accounts, payments, donation plumbing, or public routing changes.