### PR TITLE
refactor: share Scenario card inspirations panel

### DIFF
--- a/components/scenarios/scenario-card.vue
+++ b/components/scenarios/scenario-card.vue
@@ -99,7 +99,7 @@
         <!-- The one genuinely Scenario-shaped thing on the card. -->
         <div
           v-if="showInspirations && scenario.inspirations && !compact"
-          class="mx-0.5 mt-2.5 rounded-xl border border-base-300 bg-base-100 p-2.5"
+          class="mx-0.5 mt-2.5 kr-panel-flat rounded-xl p-2.5"
         >
           <p
             class="text-[0.65rem] font-bold uppercase tracking-wider text-base-content/50"


### PR DESCRIPTION
Bounded consistency slice for interface-vision/t-104 (recurring kr-* migration sweep).

`components/scenarios/scenario-card.vue`'s inspirations-summary panel now uses the shared `kr-panel-flat` class instead of hand-rolled `border border-base-300 bg-base-100`. `rounded-xl` and the existing spacing (`mx-0.5 mt-2.5 p-2.5`) are preserved as overrides on top — no geometry or behavior change.

Verified locally:
- `eslint components/scenarios/scenario-card.vue` — clean
- `vue-tsc --noEmit` — clean
- `test:layout-contract` — 207 baseline, zero new violations

---
_Generated by [Claude Code](https://claude.ai/code/session_01NY4ra8aEt8DmJaiLmAGZpr)_