### PR TITLE
refactor: share watchlist entry-detail panel surface

### DIFF
--- a/components/watchlist/watchlist-entry-detail.vue
+++ b/components/watchlist/watchlist-entry-detail.vue
@@ -8,9 +8,7 @@
   an admin viewer.
 -->
 <template>
-  <section
-    class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5"
-  >
+  <section class="kr-panel-flat flex flex-col gap-4 rounded-3xl p-5">
     <div class="flex items-start justify-between gap-3">
       <div class="flex min-w-0 items-center gap-2">
         <button


### PR DESCRIPTION
Conductor interface-vision/t-104. Scoped reversible UI consistency refactor: migrate `components/watchlist/watchlist-entry-detail.vue`'s root section from hand-rolled `border border-base-300 bg-base-100` to the shared `kr-panel-flat` primitive, preserving the explicit `rounded-3xl` override and all other classes. No geometry or behavior change.

Verified: eslint clean, prettier clean, `vue-tsc --noEmit` clean repo-wide, `test:layout-contract` holds (207 baseline, zero new).

Required checks must complete before merge.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4guRTZgbLfii92XegSUNK)_