### PR TITLE
refactor: share checkout-success container surface

### DIFF
--- a/components/giftshop/checkout-success.vue
+++ b/components/giftshop/checkout-success.vue
@@ -1,7 +1,7 @@
 <!-- /components/giftshop/checkout-success.vue -->
 <template>
   <section
-    class="mx-auto flex min-h-full max-w-3xl flex-col items-center justify-center gap-5 px-4 py-8 text-center"
+    class="kr-container max-w-3xl flex min-h-full flex-col items-center justify-center gap-5 px-4 py-8 text-center"
   >
     <div
       class="w-full rounded-3xl border bg-base-100 p-6 shadow-lg sm:p-10"


### PR DESCRIPTION
Conductor interface-vision/t-104. Recurring UI-consistency sweep: migrate `components/giftshop/checkout-success.vue`'s root section from a hand-rolled `mx-auto ... max-w-3xl` container to the shared `kr-container` primitive, preserving the explicit `max-w-3xl` override and all other classes (`flex`, `min-h-full`, `flex-col`, `items-center`, `justify-center`, `gap-5`, `px-4`, `py-8`, `text-center`). No geometry or behavior change.

Verified: eslint clean, prettier clean, `vue-tsc --noEmit` clean repo-wide, `test:layout-contract` holds (207 baseline, zero new).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NksB81B9TUhXiGEMvwMsoP)_