### PR TITLE
refactor: share checkout-cancel container surface

### DIFF
--- a/components/giftshop/checkout-cancel.vue
+++ b/components/giftshop/checkout-cancel.vue
@@ -1,7 +1,7 @@
 <!-- /components/giftshop/checkout-cancel.vue -->
 <template>
   <section
-    class="mx-auto flex min-h-full max-w-3xl flex-col items-center justify-center gap-5 px-4 py-8 text-center"
+    class="kr-container flex min-h-full max-w-3xl flex-col items-center justify-center gap-5 px-4 py-8 text-center"
   >
     <div
       class="w-full rounded-3xl border border-warning/40 bg-base-100 p-6 shadow-lg sm:p-10"


### PR DESCRIPTION
Conductor interface-vision/t-104 recurring consistency slice.

`checkout-cancel.vue` is the sibling of the just-standardized checkout-success surface. Its root section still hand-rolls `mx-auto ... max-w-3xl`; this replaces that container geometry with `kr-container` while preserving the explicit `max-w-3xl` override and every existing flex, min-height, centering, gap, padding, and text class.

Scope: one file, one class substitution, no behavior/data/schema changes.

Session: `openai-scheduled-20260831T141535Z-interface-vision-t104-cxl5`.