### PR TITLE
fix(model-builder): add empty-state to source picker

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -824,6 +824,12 @@ jobs:
       - name: Model Builder source loading announcement guard contract
         run: npm run test:model-builder-source-loading-announcement-guard
 
+      - name: Model Builder source empty-state guard self-test
+        run: npm run test:model-builder-source-empty-state-guard-selftest
+
+      - name: Model Builder source empty-state guard contract
+        run: npm run test:model-builder-source-empty-state-guard
+
       - name: Model Builder source-field guard self-test
         run: npm run test:model-builder-source-field-guard-selftest
 

--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -95,6 +95,27 @@
         </button>
       </div>
 
+      <!--
+        Empty state (model-builder/t-029, cycle 55/68): a successful load with
+        zero records fell through to this point with no branch to catch it --
+        the gallery/grid/list containers below all render on `v-else`-style
+        chains keyed to `viewMode`, so an empty `store.sources` produced a
+        blank panel with no feedback that the fetch actually completed.
+        Distinct from the sourcesError branch above (a failed request) and
+        the loadingSources branch (still in flight) -- this is specifically
+        "finished, worked, nothing came back".
+      -->
+      <div
+        v-else-if="!store.sources.length"
+        class="flex h-full min-h-32 flex-col items-center justify-center gap-1 kr-panel-flat border-dashed p-6 text-center text-sm text-base-content/50"
+      >
+        <Icon
+          :name="activeType?.icon || 'kind-icon:blueprint'"
+          class="h-6 w-6 text-base-content/30"
+        />
+        No {{ activeType?.plural.toLowerCase() }} yet.
+      </div>
+
       <!-- GALLERY: image-forward tiles, packs tight to kill whitespace -->
       <div
         v-else-if="viewMode === 'gallery'"

--- a/package.json
+++ b/package.json
@@ -379,6 +379,8 @@
     "test:model-builder-step-content-focus-guard": "tsx utils/scripts/verifyModelBuilderStepContentFocusGuard.ts",
     "test:model-builder-source-loading-announcement-guard-selftest": "tsx utils/scripts/verifyModelBuilderSourceLoadingAnnouncementGuard.test.ts",
     "test:model-builder-source-loading-announcement-guard": "tsx utils/scripts/verifyModelBuilderSourceLoadingAnnouncementGuard.ts",
+    "test:model-builder-source-empty-state-guard-selftest": "tsx utils/scripts/verifyModelBuilderSourceEmptyStateGuard.test.ts",
+    "test:model-builder-source-empty-state-guard": "tsx utils/scripts/verifyModelBuilderSourceEmptyStateGuard.ts",
     "test:model-builder-source-field-guard-selftest": "tsx utils/scripts/verifyModelBuilderSourceFieldGuard.test.ts",
     "test:model-builder-source-field-guard": "tsx utils/scripts/verifyModelBuilderSourceFieldGuard.ts",
     "test:model-builder-contract-tests-coverage-guard-selftest": "tsx utils/scripts/verifyModelBuilderContractTestsCoverageGuard.test.ts",

--- a/utils/scripts/verifyModelBuilderSourceEmptyStateGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderSourceEmptyStateGuard.test.ts
@@ -1,0 +1,76 @@
+// /utils/scripts/verifyModelBuilderSourceEmptyStateGuard.test.ts
+//
+// Regression test for checkSourceEmptyStateGuard() in
+// verifyModelBuilderSourceEmptyStateGuard.ts (model-builder/t-029,
+// cycle 68). Exercises the check against synthetic component-shaped
+// fixtures covering: the fixed shape (empty-state branch present and
+// correctly ordered), the pre-fix shape (branch missing entirely), and a
+// mis-ordered regression (branch present but placed after the gallery
+// branch, where it would never win).
+import assert from 'node:assert/strict'
+
+import { checkSourceEmptyStateGuard } from './verifyModelBuilderSourceEmptyStateGuard.js'
+
+const FIXED = `
+<template>
+  <div v-else-if="store.sourcesError">Error state</div>
+  <div v-else-if="!store.sources.length">No records yet.</div>
+  <div v-else-if="viewMode === 'gallery'">Gallery</div>
+</template>
+`
+
+const MISSING = `
+<template>
+  <div v-else-if="store.sourcesError">Error state</div>
+  <div v-else-if="viewMode === 'gallery'">Gallery</div>
+</template>
+`
+
+const MISORDERED = `
+<template>
+  <div v-else-if="store.sourcesError">Error state</div>
+  <div v-else-if="viewMode === 'gallery'">Gallery</div>
+  <div v-else-if="!store.sources.length">No records yet.</div>
+</template>
+`
+
+const NO_ERROR_BLOCK = `
+<template>
+  <div v-else-if="!store.sources.length">No records yet.</div>
+  <div v-else-if="viewMode === 'gallery'">Gallery</div>
+</template>
+`
+
+function run(): void {
+  // Fixed fixture passes.
+  const fixedErrors = checkSourceEmptyStateGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  // Branch missing entirely fails with a single "no longer has" error.
+  const missingErrors = checkSourceEmptyStateGuard(MISSING)
+  assert.equal(missingErrors.length, 1)
+  assert.ok(missingErrors.some((e) => /no longer has/.test(e)))
+
+  // Branch present but after the gallery branch fails the ordering check.
+  const misorderedErrors = checkSourceEmptyStateGuard(MISORDERED)
+  assert.equal(misorderedErrors.length, 1)
+  assert.ok(misorderedErrors.some((e) => /out of order/.test(e)))
+
+  // Missing sourcesError anchor fails with a single "could not find" error.
+  const noErrorBlockErrors = checkSourceEmptyStateGuard(NO_ERROR_BLOCK)
+  assert.equal(noErrorBlockErrors.length, 1)
+  assert.ok(noErrorBlockErrors.some((e) => /Could not find the/.test(e)))
+
+  console.log(
+    'Model Builder source empty-state guard self-test passed: the fixed ' +
+      'fixture passes, a missing branch fails clearly, a mis-ordered ' +
+      'branch fails the ordering check, and a missing anchor fails ' +
+      'clearly.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyModelBuilderSourceEmptyStateGuard.ts
+++ b/utils/scripts/verifyModelBuilderSourceEmptyStateGuard.ts
@@ -1,0 +1,105 @@
+// /utils/scripts/verifyModelBuilderSourceEmptyStateGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 68) -- the source-picker's
+// v-if/v-else-if chain over `store.sourceType` covered "no type picked yet"
+// (store.sourceType unset), "still fetching" (store.loadingSources), and
+// "fetch failed" (store.sourcesError), then fell straight through to three
+// viewMode-keyed render branches (gallery/grid/list) that all iterate
+// `store.sources`. A successful fetch that resolved to zero records matched
+// none of the three named states and none of the viewMode branches guard
+// against an empty array, so it silently rendered a blank panel -- no
+// indication the load had actually finished, unlike every other terminal
+// state in the same chain (loading has role="status" text, error has
+// role="alert" text and a Retry button).
+//
+// Cycle 55 first identified this gap (source-picker data-fetch/error-
+// handling audit) but could not land the fix in that pass; this asserts the
+// empty-state branch it described stays in place: a `v-else-if` keyed to
+// `!store.sources.length`, positioned after the error branch and before the
+// viewMode branches so it wins the chain before any of them can render an
+// empty grid.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const SOURCE_PICKER_PATH = join(
+  repositoryRoot,
+  'components/model-builder/model-builder-source-picker.vue',
+)
+
+const ERROR_MARKER = 'v-else-if="store.sourcesError"'
+const EMPTY_MARKER = 'v-else-if="!store.sources.length"'
+const GALLERY_MARKER = 'v-else-if="viewMode === \'gallery\'"'
+
+export function checkSourceEmptyStateGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const errorIndex = content.indexOf(ERROR_MARKER)
+  if (errorIndex === -1) {
+    errors.push(
+      `Could not find the \`${ERROR_MARKER}\` block in ` +
+        'model-builder-source-picker.vue -- has the sourcesError state been ' +
+        'renamed, removed, or restructured? If so, this guard needs to move ' +
+        'with it.',
+    )
+    return errors
+  }
+
+  const emptyIndex = content.indexOf(EMPTY_MARKER)
+  if (emptyIndex === -1) {
+    errors.push(
+      'model-builder-source-picker.vue no longer has an ' +
+        `\`${EMPTY_MARKER}\` branch -- a successful load that resolves to ` +
+        'zero records will fall through to a viewMode branch and render a ' +
+        'blank panel with no feedback, instead of an explicit empty state.',
+    )
+    return errors
+  }
+
+  const galleryIndex = content.indexOf(GALLERY_MARKER)
+  if (galleryIndex === -1) {
+    errors.push(
+      `Could not find the \`${GALLERY_MARKER}\` block in ` +
+        'model-builder-source-picker.vue -- has the gallery view mode been ' +
+        'renamed, removed, or restructured? If so, this guard needs to move ' +
+        'with it.',
+    )
+    return errors
+  }
+
+  if (!(errorIndex < emptyIndex && emptyIndex < galleryIndex)) {
+    errors.push(
+      "model-builder-source-picker.vue's empty-state branch must sit " +
+        'between the sourcesError branch and the viewMode branches in the ' +
+        'v-if/v-else-if chain -- found it out of order, so it either never ' +
+        'wins (shadowed by an earlier branch) or wins too early (shadowing ' +
+        'the error state).',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(SOURCE_PICKER_PATH, 'utf8')
+  const errors = checkSourceEmptyStateGuard(content)
+
+  if (errors.length) {
+    console.error('Model Builder source empty-state guard contract failed:')
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder source empty-state guard contract passed: a successful ' +
+      'zero-record load still renders an explicit empty state.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
Conductor model-builder/t-029 (cycle 68). The source-picker's step-1 record chooser handled "no type picked yet", "still fetching", and "fetch failed", but a successful load resolving to zero records fell through to the viewMode-keyed gallery/grid/list branches with nothing to render — a blank panel with no feedback that the fetch actually completed. This was flagged as a concrete lead in cycle 55 but not landed at the time.

Adds an explicit empty-state branch between the error state and the viewMode branches, matching the dashed `kr-panel-flat` treatment already used for the "no source type selected" state.

Added `verifyModelBuilderSourceEmptyStateGuard.ts` + self-test following this project's narrow-textual-checker convention, wired into `package.json` and `contract-tests.yml`.

Verified: new guard fails pre-fix / passes post-fix (git-stash round-trip); all `test:model-builder-*` scripts pass; eslint clean; prettier --check clean (scoped diff only — the file carries unrelated pre-existing prettier drift, confirmed via git-stash round-trip and left untouched); `vue-tsc --noEmit` clean repo-wide; `test:layout-contract` holds (207 baseline, zero new).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWW36f4Sxiug6cNTcVHUDu)_