### PR TITLE
fix(model-builder): use kr-panel-flat for source-picker LIST rows

### DIFF
--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -199,13 +199,25 @@
         </button>
       </div>
 
-      <!-- LIST: dense single-column rows for fast scanning -->
+      <!--
+        LIST: dense single-column rows for fast scanning (model-builder/
+        t-029, cycle 69). Row surface was hand-rolled as `rounded-lg border
+        border-base-300 bg-base-100` while the GALLERY and GRID views one
+        toggle away already use the shared `kr-panel-flat` class for their
+        record buttons -- kr-panel-flat's own definition in tailwind.css
+        even names "dense lists, rows, and inboxes" as its purpose, so the
+        one view that's actually a dense row list was the one view not
+        using it. Swapped to kr-panel-flat (bg-base-100 + border-base-300
+        match exactly; only the corner radius changes, rounded-lg ->
+        rounded-2xl, aligning it with this file's other two views and with
+        model-builder-run-history.vue's identical list-row pattern).
+      -->
       <div v-else class="flex flex-col gap-1">
         <button
           v-for="record in store.sources"
           :key="record.id"
           type="button"
-          class="flex items-center gap-3 rounded-lg border border-base-300 bg-base-100 px-2.5 py-1.5 text-left transition hover:border-primary hover:bg-base-200"
+          class="flex items-center gap-3 kr-panel-flat px-2.5 py-1.5 text-left transition hover:border-primary hover:bg-base-200"
           @click="store.selectSource(record)"
         >
           <div


### PR DESCRIPTION
Conductor: model-builder/t-029 (cycle 69)
Session: claude-scheduled-20260831T153047Z-mb-t029-c69

## What
`model-builder-source-picker.vue`'s LIST view (the densest of its three view modes: gallery/grid/list) hand-rolled its record row surface as `rounded-lg border border-base-300 bg-base-100`, while the GALLERY and GRID views one toggle away already use the shared `kr-panel-flat` class for their own record buttons. `kr-panel-flat`'s own definition in `assets/css/tailwind.css` names "dense lists, rows, and inboxes" as its purpose — the one view that's actually a dense row list was the one view not using it. `model-builder-run-history.vue`'s own list rows already follow the `kr-panel-flat` convention for the identical row shape (icon + label + subtitle in a bordered surface).

Swapped LIST's row class to `kr-panel-flat` — `bg-base-100` and `border-base-300` match exactly, so the only visible change is the corner radius (`rounded-lg` → `rounded-2xl`), aligning it with this file's other two view modes and with `model-builder-run-history.vue`'s list rows. No markup structure, conditional, or event-handler change.

## Why this is safe
- Purely a class-list consolidation, same shape as cycle 66's kr-panel-flat sweep (kind_robots#2214) — no guard added, matching that precedent.
- `kr-panel-flat`'s definition (`rounded-2xl border border-base-300 bg-base-100`) is a byte-exact superset of what it replaces, confirmed by reading the class directly.

## Verified
- `eslint` clean on the changed file
- `prettier --check` — the file carries unrelated pre-existing formatting drift (confirmed via a `git stash` round-trip before editing); scoped diff itself is prettier-clean, left the pre-existing drift untouched per this project's established convention
- `vue-tsc --noEmit` clean repo-wide (exit 0)
- All 148 `test:model-builder-*` npm scripts pass
- `test:layout-contract` holds — 207 baseline, zero new violations
- `git status --porcelain` scoped to exactly 1 file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014UysNTwQdWC3thg6TwuND9)_