### PR TITLE
fix(model-builder): use kr-panel-flat for recipe-selector output rows

### DIFF
--- a/components/model-builder/model-builder-recipe-selector.vue
+++ b/components/model-builder/model-builder-recipe-selector.vue
@@ -56,10 +56,24 @@
 
     <!-- Outputs -->
     <div class="min-h-0 flex-1 space-y-1.5 overflow-y-auto">
+      <!--
+        Output rows (model-builder/t-029, cycle 70): this dense checkbox list
+        was hand-rolled as `rounded-xl border border-base-300 bg-base-100`
+        while model-builder-run-history.vue's identical dense-row list (same
+        border-base-300 + bg-base-100 combo, same selected-state override)
+        already uses the shared kr-panel-flat class -- kr-panel-flat's own
+        definition in tailwind.css even names "dense lists, rows, and
+        inboxes" as its purpose. Swapped to kr-panel-flat with an explicit
+        `rounded-xl` override so the corner radius stays exactly as before
+        (kr-panel-flat's own default is rounded-2xl) -- same override
+        pattern already used elsewhere (e.g. scenario-card.vue,
+        ruler-hooked-cosmetics.vue). border-base-300 and bg-base-100 match
+        kr-panel-flat exactly, so nothing else changes.
+      -->
       <label
         v-for="output in store.recipeOutputs"
         :key="output.key"
-        class="flex cursor-pointer items-center gap-3 rounded-xl border border-base-300 bg-base-100 p-2.5 transition hover:border-primary/50"
+        class="flex cursor-pointer items-center gap-3 kr-panel-flat rounded-xl p-2.5 transition hover:border-primary/50"
         :class="store.selections[output.key]?.on ? 'border-primary/60 bg-primary/5' : ''"
       >
         <input


### PR DESCRIPTION
## What
`model-builder-recipe-selector.vue`'s dense checkbox list of build outputs (step 2, "Choose a recipe & outputs") was hand-rolled as `rounded-xl border border-base-300 bg-base-100` for each output row `<label>`. `model-builder-run-history.vue`'s dense run-row list already uses the shared `kr-panel-flat` class for the exact same `border-base-300` + `bg-base-100` combo (and the same selected-state override pattern) — `kr-panel-flat`'s own definition in `assets/css/tailwind.css` names "dense lists, rows, and inboxes" as its purpose. This output list was the one remaining dense-row list in the model-builder feature area still hand-rolling that surface.

Swapped the row's base classes to `kr-panel-flat` with an explicit `rounded-xl` override, so the corner radius is unchanged (`kr-panel-flat`'s own default is `rounded-2xl`). This exact override pattern is already established elsewhere in the codebase (`scenario-card.vue`, `ruler-hooked-cosmetics.vue`).

No geometry, spacing, or behavior change — `border-base-300` and `bg-base-100` match `kr-panel-flat` exactly, so the rendered row is pixel-identical; only the class source changed.

Conductor task: `model-builder/t-029` (cycle 70) — recurring "Polish and upgrade Model Builder front-end surface" consistency-migration task.

## Verification
- `eslint components/model-builder/model-builder-recipe-selector.vue` — clean
- `vue-tsc --noEmit` — clean
- `npm run test:layout-contract` — holds at the 207-violation baseline, zero new
- All 149 `test:model-builder-*` scripts in `package.json` — 149/149 pass
- `git stash` + `prettier --write` round-trip confirmed prettier would reformat several pre-existing unrelated lines in this file (line-wrapping drift already present before this change) — reverted that and hand-applied only the intended class-attribute edit, so the diff is scoped to just this one change (verified via `git diff`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6gssQTzL5FcXR6ZcePG7M

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6gssQTzL5FcXR6ZcePG7M)_