### PR TITLE
refactor dream sheet toolbar to shared flat panel

### DIFF
--- a/components/dreams/dream-sheet-toolbar.vue
+++ b/components/dreams/dream-sheet-toolbar.vue
@@ -1,6 +1,6 @@
 <!-- /components/dreams/dream-sheet-toolbar.vue -->
 <template>
-  <aside class="rounded-2xl border border-base-300 bg-base-100/90 p-3 shadow-sm backdrop-blur">
+  <aside class="kr-panel-flat bg-base-100/90 p-3 shadow-sm backdrop-blur">
     <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div class="min-w-0">
         <p class="flex items-center gap-2 text-xs font-black uppercase tracking-[0.22em] text-primary">


### PR DESCRIPTION
## Summary
- migrate the live Dream PitchSheets toolbar from its hand-rolled flat panel shell to `kr-panel-flat`
- preserve the intentional translucent `bg-base-100/90`, padding, shadow, and backdrop blur
- no behavior, API, schema, or production-data changes

Conductor: interface-vision/t-104
Session: openai-scheduled-20260831T191539Z-interface-vision-t104-oai11f3

## Verification
- branch-to-main compare is exactly one file, +1/-1
- rely on exact-head repository CI before merge