### PR TITLE
style(model-builder): use muted panel primitive for manager shell

### DIFF
--- a/components/model-builder/model-builder-manager.vue
+++ b/components/model-builder/model-builder-manager.vue
@@ -1,7 +1,7 @@
 <!-- /components/model-builder/model-builder-manager.vue -->
 <template>
   <section
-    class="flex h-full min-h-0 max-h-full w-full flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-200"
+    class="flex h-full min-h-0 max-h-full w-full flex-col overflow-hidden kr-panel-muted"
     :aria-busy="resumingRun"
   >
     <header


### PR DESCRIPTION
## Summary
- replace the Model Builder manager shell's duplicated `rounded-2xl border border-base-300 bg-base-200` surface with `kr-panel-muted`
- preserve all shell geometry, overflow, and behavior

Conductor: `model-builder/t-029`
Session: `openai-scheduled-20260831T201554Z-model-builder-t029-oai7c2`

## Verification
- branch-to-main compare is exactly one file, +1/-1
- repository CI is the execution gate for this connector-only cycle