### PR TITLE
fix(watchlist): stabilize related entry ordering

### DIFF
--- a/server/api/media-entries/[id]/related.get.ts
+++ b/server/api/media-entries/[id]/related.get.ts
@@ -43,6 +43,7 @@ export default defineEventHandler(async (event) => {
         { year: 'desc' },
         { watchedMonth: 'desc' },
         { watchedDay: 'desc' },
+        { id: 'desc' },
       ],
       take: RELATED_LIMIT,
     })


### PR DESCRIPTION
## Summary
- add a final `id DESC` tie-breaker to the Media Watchlist related-entry query
- preserve the existing newest-first year/month/day ordering
- prevent unstable result ordering when same-title entries share the same date or have null date fields

Conductor: `media-watchlist/t-006`
Session: `openai-scheduled-20260831T221430Z-media-watchlist-t006-oai9c4`

## Validation
CI is authoritative for this connector-only cycle. No database writes or production actions performed.