### PR TITLE
style: use shared flat panel for Dream gallery toolbar

### DIFF
--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -17,7 +17,7 @@
     -->
     <header
       v-if="showToolbar && !isDropdownMode"
-      class="relative z-30 shrink-0 rounded-2xl border border-base-300 bg-base-100/95 px-2 py-2 shadow-sm backdrop-blur"
+      class="relative z-30 shrink-0 kr-panel-flat bg-base-100/95 px-2 py-2 shadow-sm backdrop-blur"
     >
       <!-- Wraps, rather than scrolling sideways. This row used to be
            `overflow-x-auto whitespace-nowrap` with shrink-0 controls, so on a


### PR DESCRIPTION
Conductor `interface-vision/t-104` bounded consistency slice.

The Dream gallery's view-picker toolbar (`components/dreams/dream-gallery.vue`) hand-rolled the neutral `rounded-2xl border border-base-300 bg-base-100` surface with a translucent `/95` background override — the same shape `dream-sheet-toolbar.vue` already migrated. This moves it onto `kr-panel-flat` while preserving the existing `bg-base-100/95` override, padding, shadow, and backdrop blur.

Net diff against current main is one file, +1/-1. No API, state, database, routing, or behavior changes.

### Verification
- `npx eslint components/dreams/dream-gallery.vue` — only the 3 pre-existing, unrelated `@typescript-eslint/unified-signatures` errors (confirmed present on `main` before this change via `git stash`).
- `npx vue-tsc --noEmit` repo-wide — clean.
- `npm run test:layout-contract` — holds, no new violations (207 baseline unchanged).

Session: `claude-conductor-sweep-20260901T002802Z-iv104-slice`

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHztkQfnr776FMZE5QZ4eF)_