### PR TITLE
style(model-builder): use kr-panel-flat for item-panel stage sections

### DIFF
--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -36,7 +36,7 @@
     </p>
 
     <!-- Stage: PITCH -->
-    <section class="rounded-xl border border-base-300 p-2.5">
+    <section class="kr-panel-flat rounded-xl p-2.5">
       <div class="mb-1.5 flex items-center gap-2">
         <Icon name="kind-icon:lightbulb" class="h-4 w-4 text-primary" />
         <span class="text-xs font-bold uppercase tracking-wide">Pitch</span>
@@ -94,7 +94,7 @@
     </section>
 
     <!-- Stage: FIELDS_AND_PROMPTS -->
-    <section class="rounded-xl border border-base-300 p-2.5">
+    <section class="kr-panel-flat rounded-xl p-2.5">
       <div class="mb-1.5 flex items-center gap-2">
         <Icon name="kind-icon:list" class="h-4 w-4 text-primary" />
         <span class="text-xs font-bold uppercase tracking-wide"
@@ -194,7 +194,7 @@
     </section>
 
     <!-- Stage: GENERATE_ASSETS -->
-    <section class="rounded-xl border border-base-300 p-2.5">
+    <section class="kr-panel-flat rounded-xl p-2.5">
       <div class="mb-1.5 flex items-center gap-2">
         <Icon name="kind-icon:sparkles" class="h-4 w-4 text-primary" />
         <span class="text-xs font-bold uppercase tracking-wide"
@@ -310,7 +310,7 @@
     </section>
 
     <!-- Stage: COMMIT -->
-    <section class="rounded-xl border border-base-300 p-2.5">
+    <section class="kr-panel-flat rounded-xl p-2.5">
       <div class="mb-1.5 flex items-center gap-2">
         <Icon name="kind-icon:check" class="h-4 w-4 text-primary" />
         <span class="text-xs font-bold uppercase tracking-wide">Commit</span>


### PR DESCRIPTION
Conductor `model-builder/t-029` bounded consistency slice.

`model-builder-item-panel.vue`'s four stage-section dividers (Pitch, Fields & Prompts, Generate Assets, Commit) hand-rolled `rounded-xl border border-base-300` with no background utility. The section's parent container is already `kr-panel-flat` (`bg-base-100`), so these dividers currently render transparent — visually identical to `kr-panel-flat`'s own `bg-base-100`. Moves them onto the shared primitive (preserving the `rounded-xl` override and `p-2.5` padding), matching this task's established migration convention across the rest of the model-builder component family (source-picker, recipe-selector, run-history, batch-editor, manager).

Net diff is one file, four class-list changes. No markup structure, behavior, or visual change.

### Verification
- `npx eslint components/model-builder/model-builder-item-panel.vue` — clean
- `npx vue-tsc --noEmit` — clean, repo-wide
- All 149 `test:model-builder-*` scripts pass
- `npm run test:layout-contract` — holds, 207 baseline, zero new violations
- `npx prettier --check` — clean

Session: `claude-scheduled-20260901T012830-mb-t029`

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaCvgEp2AJAVBNLQ1PPXpr)_