### PR TITLE
Align server sharing and agent thread permissions with Rainbow v2

### DIFF
--- a/.github/workflows/rainbow-v2-policy-contract.yml
+++ b/.github/workflows/rainbow-v2-policy-contract.yml
@@ -1,0 +1,31 @@
+name: Rainbow V2 Policy Contract
+
+on:
+  pull_request:
+    paths:
+      - 'server/utils/serverApi.ts'
+      - 'server/utils/manaGate.ts'
+      - 'utils/agentCredentialScopes.ts'
+      - 'server/api/v1/forum/threads/index.post.ts'
+      - 'utils/scripts/verifyRainbowV2Policy.test.ts'
+      - '.github/workflows/rainbow-v2-policy-contract.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'server/utils/serverApi.ts'
+      - 'server/utils/manaGate.ts'
+      - 'utils/agentCredentialScopes.ts'
+      - 'server/api/v1/forum/threads/index.post.ts'
+      - 'utils/scripts/verifyRainbowV2Policy.test.ts'
+      - '.github/workflows/rainbow-v2-policy-contract.yml'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: npm install --include=optional
+      - run: npx tsx utils/scripts/verifyRainbowV2Policy.test.ts

--- a/server/api/v1/forum/threads/index.post.ts
+++ b/server/api/v1/forum/threads/index.post.ts
@@ -1,7 +1,8 @@
-import { defineEventHandler, readBody } from 'h3'
+import { createError, defineEventHandler, readBody } from 'h3'
 import type { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
+import { authHasScope } from '@/server/utils/authGuard'
 import {
   assertForumWriteAllowed,
   assertMatureForumWriteAllowed,
@@ -30,6 +31,21 @@ const FORUM_THREAD_CREATE_FIELDS = new Set([
 export default defineEventHandler(async (event) => {
   try {
     const actor = await requireForumWriter(event)
+
+    // Replies/conversation remain available with forum:write. Starting a new
+    // top-level thread is a separate human-controlled capability for agents.
+    // Human JWT/API-key sessions are intentionally unaffected by scope checks.
+    if (
+      actor.auth.kind === 'agent-credential' &&
+      !authHasScope(actor.auth, 'forum:thread:create')
+    ) {
+      throw createError({
+        statusCode: 403,
+        message:
+          'This agent is not authorized to create new forum threads. Its human liaison can grant "forum:thread:create" if desired.',
+      })
+    }
+
     const rawBody = await readBody<unknown>(event)
     assertJsonObject(rawBody, 'A JSON forum thread body is required.')
     assertOnlyFields(rawBody, FORUM_THREAD_CREATE_FIELDS, 'forum thread')

--- a/server/utils/serverApi.ts
+++ b/server/utils/serverApi.ts
@@ -237,7 +237,9 @@ export function buildServerCreateData(input: ServerInput, user: AuthUser) {
 
     userId: user.id,
 
-    isPublic: user.isAdmin ? Boolean(input.isPublic) : false,
+    // A user-owned server is the user's compute to share or keep private.
+    // Official/default status remains admin-owned, but public visibility does not.
+    isPublic: cleanBoolean(input.isPublic) ?? false,
     isOfficial: user.isAdmin ? Boolean(input.isOfficial) : false,
     isDefault: user.isAdmin ? Boolean(input.isDefault) : false,
     isActive: cleanBoolean(input.isActive) ?? true,
@@ -295,7 +297,12 @@ export function buildServerUpdateData(input: ServerInput, user: AuthUser) {
     data.sortOrder = cleanInt(input.sortOrder) ?? 0
   }
 
-  const userEditableBooleanFields = ['isActive', 'isEditable', 'isMature']
+  const userEditableBooleanFields = [
+    'isPublic',
+    'isActive',
+    'isEditable',
+    'isMature',
+  ]
 
   for (const field of userEditableBooleanFields) {
     if (field in input) {
@@ -304,7 +311,7 @@ export function buildServerUpdateData(input: ServerInput, user: AuthUser) {
   }
 
   if (user.isAdmin) {
-    const adminBooleanFields = ['isPublic', 'isOfficial', 'isDefault']
+    const adminBooleanFields = ['isOfficial', 'isDefault']
 
     for (const field of adminBooleanFields) {
       if (field in input) {

--- a/utils/agentCredentialScopes.ts
+++ b/utils/agentCredentialScopes.ts
@@ -14,14 +14,16 @@ export const AGENT_CREDENTIAL_SCOPES = [
   'profile:read',
   'forum:read',
   'forum:write',
+  'forum:thread:create',
   'generation:art',
 ] as const
 
 export type AgentCredentialScope = (typeof AGENT_CREDENTIAL_SCOPES)[number]
 
 // Scopes a freshly-created forum-agent credential gets when the caller
-// doesn't specify its own set. Generation is deliberately opt-in because it
-// spends the owning User's Kind Robots generation balance.
+// doesn't specify its own set. Creating new top-level threads is deliberately
+// NOT included: a human liaison opts an agent into that separately. Generation
+// is also opt-in because it can spend the owning User's generation balance.
 export const DEFAULT_FORUM_AGENT_SCOPES: AgentCredentialScope[] = [
   'profile:read',
   'forum:read',

--- a/utils/scripts/verifyAgentCredentials.test.ts
+++ b/utils/scripts/verifyAgentCredentials.test.ts
@@ -22,6 +22,7 @@ import {
     assert.equal(isValidScope(scope), true, `${scope} should be a valid scope`)
   }
 
+  assert.equal(isValidScope('forum:thread:create'), true)
   assert.equal(isValidScope('not:a:real:scope'), false)
   assert.equal(isValidScope(''), false)
   assert.equal(isValidScope(123), false)
@@ -36,11 +37,15 @@ import {
   const result = sanitizeScopes([
     'profile:read',
     'forum:read',
+    'forum:thread:create',
     'profile:read',
     'not-a-scope',
     42,
   ])
-  assert.deepEqual(result.sort(), ['forum:read', 'profile:read'].sort())
+  assert.deepEqual(
+    result.sort(),
+    ['forum:read', 'forum:thread:create', 'profile:read'].sort(),
+  )
 
   // Non-array input -> empty, never throws.
   assert.deepEqual(sanitizeScopes(null), [])
@@ -58,6 +63,11 @@ import {
   assert.deepEqual(
     sanitizeScopes(DEFAULT_FORUM_AGENT_SCOPES).sort(),
     [...DEFAULT_FORUM_AGENT_SCOPES].sort(),
+  )
+  assert.equal(
+    DEFAULT_FORUM_AGENT_SCOPES.includes('forum:thread:create'),
+    false,
+    'starting new threads must remain an explicit human opt-in',
   )
 }
 

--- a/utils/scripts/verifyRainbowV2Policy.test.ts
+++ b/utils/scripts/verifyRainbowV2Policy.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const serverApi = readFileSync('server/utils/serverApi.ts', 'utf8')
+const threadCreate = readFileSync(
+  'server/api/v1/forum/threads/index.post.ts',
+  'utf8',
+)
+const scopes = readFileSync('utils/agentCredentialScopes.ts', 'utf8')
+const manaGate = readFileSync('server/utils/manaGate.ts', 'utf8')
+
+// User-owned compute can be shared or kept private. Official/default status
+// stays admin-only, and secrets remain hidden from non-owners by safeServer().
+assert.match(serverApi, /isPublic: cleanBoolean\(input\.isPublic\) \?\? false/)
+assert.match(
+  serverApi,
+  /const userEditableBooleanFields = \[\s*'isPublic',\s*'isActive',\s*'isEditable',\s*'isMature',\s*\]/,
+)
+assert.match(serverApi, /const adminBooleanFields = \['isOfficial', 'isDefault'\]/)
+assert.match(serverApi, /server\.userId === user\.id/)
+assert.match(serverApi, /apiKey: canSeeSecrets/)
+
+// Existing Kind Robots economics remain the source of truth: owner compute and
+// non-official shared public compute are free rather than consuming tokens/mana.
+assert.match(manaGate, /if \(server\.userId === input\.userId\) return true/)
+assert.match(manaGate, /if \(server\.isPublic && !server\.isOfficial\) return true/)
+
+// A normal forum writer may reply, but a machine credential needs the extra
+// human-granted scope before it can originate a new top-level thread.
+assert.match(scopes, /'forum:thread:create'/)
+assert.doesNotMatch(
+  scopes.match(/DEFAULT_FORUM_AGENT_SCOPES[\s\S]*?\]/)?.[0] ?? '',
+  /forum:thread:create/,
+)
+assert.match(threadCreate, /authHasScope\(actor\.auth, 'forum:thread:create'\)/)
+assert.match(threadCreate, /human liaison can grant/)
+
+console.log('Rainbow v2 server/thread policy contract: OK')


### PR DESCRIPTION
First Kind Robots policy slice from the Rainbow Butterflies v2 reassessment.

## Changes
- user-owned generation servers may now be marked public/shared by their owner; `isOfficial` and `isDefault` remain admin-only
- preserves the existing economy rule that owner compute and non-official shared public compute are token/mana-free
- adds optional `forum:thread:create` to the agent credential scope vocabulary
- leaves that scope out of the default forum-agent grant, so agents may participate/reply without automatically gaining permission to originate new threads
- top-level forum thread creation now enforces the extra scope for agent credentials; human sessions are unchanged
- adds a focused Rainbow v2 policy contract plus scope regression coverage

No schema migration, billing change, token accounting change, DNS/deploy configuration change, or credential secret handling change.