### PR TITLE
model-builder: consolidate source-picker list-view row onto kr-panel-flat

### DIFF
--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -184,7 +184,7 @@
           v-for="record in store.sources"
           :key="record.id"
           type="button"
-          class="flex items-center gap-3 rounded-lg border border-base-300 bg-base-100 px-2.5 py-1.5 text-left transition hover:border-primary hover:bg-base-200"
+          class="flex items-center gap-3 kr-panel-flat rounded-lg px-2.5 py-1.5 text-left transition hover:border-primary hover:bg-base-200"
           @click="store.selectSource(record)"
         >
           <div


### PR DESCRIPTION
Closing unmerged: my session's local worktree had a stale `origin/main` (force-updated from `0887bdf` to `3a65da0` on fetch — many commits behind, discovered only when this PR reported a genuine merge conflict despite an apparently-matching base SHA). Current main already carries this exact LIST-view `kr-panel-flat` consolidation for `model-builder-source-picker.vue` (cycle 68/69, plus a newer empty-state branch this PR's diff doesn't account for), so this change is fully redundant and now conflicts with real main's content. No action needed — re-doing this cycle's work against a freshly-synced main instead.

model-builder/t-029, cycle 72.