### PR TITLE
style: migrate remaining sticky/overlay panels to kr-panel-flat

### DIFF
--- a/components/dreams/daily-digest-object-dialog.vue
+++ b/components/dreams/daily-digest-object-dialog.vue
@@ -143,7 +143,7 @@
                 />
               </label>
 
-              <div class="sticky bottom-0 flex flex-wrap items-center gap-3 rounded-2xl border border-base-300 bg-base-100/95 p-3 shadow-lg backdrop-blur">
+              <div class="kr-panel-flat sticky bottom-0 flex flex-wrap items-center gap-3 bg-base-100/95 p-3 shadow-lg backdrop-blur">
                 <p
                   v-if="saveMessage"
                   class="min-w-0 flex-1 text-sm"

--- a/components/dreams/dream-card.vue
+++ b/components/dreams/dream-card.vue
@@ -75,7 +75,7 @@
 
       <details
         v-if="showDebug"
-        class="absolute inset-x-2 bottom-2 z-10 rounded-2xl border border-base-300 bg-base-100/95 p-2 text-xs shadow backdrop-blur"
+        class="kr-panel-flat absolute inset-x-2 bottom-2 z-10 bg-base-100/95 p-2 text-xs shadow backdrop-blur"
         @click.stop
       >
         <summary class="cursor-pointer font-bold text-primary">

--- a/components/pages/mermaids-page.vue
+++ b/components/pages/mermaids-page.vue
@@ -3,7 +3,7 @@
     <div class="w-full max-w-3xl">
       <div
         v-if="userStore.isAdmin"
-        class="sticky top-3 z-30 mb-4 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-100/95 p-3 shadow-lg backdrop-blur"
+        class="kr-panel-flat sticky top-3 z-30 mb-4 flex flex-wrap items-center justify-between gap-3 bg-base-100/95 p-3 shadow-lg backdrop-blur"
       >
         <div class="join">
           <button


### PR DESCRIPTION
Conductor `interface-vision/t-104` bounded consistency slice.

Three more hand-rolled `rounded-2xl border border-base-300 bg-base-100` surfaces move onto the shared `kr-panel-flat` class, following the same pattern `dream-sheet-toolbar.vue` and `dream-gallery.vue` already migrated to. Each keeps its existing `bg-base-100/<opacity>` override, padding, shadow, and backdrop blur — no geometry or behavior change.

### What changed
- `components/pages/mermaids-page.vue` — admin writing/preview toolbar
- `components/dreams/daily-digest-object-dialog.vue` — sticky save bar
- `components/dreams/dream-card.vue` — image debug details panel

Net diff: 3 files, +3/-3.

### How I verified
- `npx eslint` on all three changed files — 2 pre-existing errors remain (`daily-digest-object-dialog.vue:520` `vue/no-mutating-props`, `dream-card.vue:437` `no-empty`), confirmed present on `main` before this change via `git stash`; unrelated to this diff.
- `npx vue-tsc --noEmit` repo-wide — clean.
- `npm run test:layout-contract` — holds, no new violations (207 baseline unchanged).

### Stakes
reversible

### Notes for reviewer
No API, state, database, routing, or behavior changes — pure class-name consolidation onto the shared surface primitive.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgR2joMm6h8NEWexjzjF1M)_