### PR TITLE
fix(model-builder): cap run-create items array server-side

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -500,6 +500,12 @@ jobs:
       - name: Model Builder run-create text-cap guard contract
         run: npm run test:model-builder-run-create-text-cap-guard
 
+      - name: Model Builder run-create items-cap guard checker self-test
+        run: npm run test:model-builder-run-create-items-cap-guard-selftest
+
+      - name: Model Builder run-create items-cap guard contract
+        run: npm run test:model-builder-run-create-items-cap-guard
+
       - name: Model Builder async poll-failure guard checker self-test
         run: npm run test:model-builder-async-poll-failure-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -271,6 +271,8 @@
     "test:model-builder-patch-text-cap-guard": "tsx utils/scripts/verifyModelBuilderPatchTextCapGuard.ts",
     "test:model-builder-run-create-text-cap-guard-selftest": "tsx utils/scripts/verifyModelBuilderRunCreateTextCapGuard.test.ts",
     "test:model-builder-run-create-text-cap-guard": "tsx utils/scripts/verifyModelBuilderRunCreateTextCapGuard.ts",
+    "test:model-builder-run-create-items-cap-guard-selftest": "tsx utils/scripts/verifyModelBuilderRunCreateItemsCapGuard.test.ts",
+    "test:model-builder-run-create-items-cap-guard": "tsx utils/scripts/verifyModelBuilderRunCreateItemsCapGuard.ts",
     "test:model-builder-async-poll-failure-guard-selftest": "tsx utils/scripts/verifyModelBuilderAsyncPollFailureGuard.test.ts",
     "test:model-builder-async-poll-failure-guard": "tsx utils/scripts/verifyModelBuilderAsyncPollFailureGuard.ts",
     "test:art-queue-poll-failure-guard-selftest": "tsx utils/scripts/verifyArtQueuePollFailureGuard.test.ts",

--- a/server/api/model-builder/runs/index.post.ts
+++ b/server/api/model-builder/runs/index.post.ts
@@ -4,7 +4,7 @@ import type { ModelBuildAction } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
-import { MAX_DRAFT_TEXT_LENGTH, runInclude } from './index'
+import { MAX_BATCH_ITEMS, MAX_DRAFT_TEXT_LENGTH, runInclude } from './index'
 
 const actions = new Set<ModelBuildAction>(['CREATE', 'UPDATE', 'ASSET_ONLY'])
 
@@ -123,6 +123,12 @@ export default defineEventHandler(async (event) => {
       throw createError({
         statusCode: 400,
         message: 'At least one build item is required.',
+      })
+    }
+    if (body.items.length > MAX_BATCH_ITEMS) {
+      throw createError({
+        statusCode: 400,
+        message: `A build run may contain at most ${MAX_BATCH_ITEMS} items.`,
       })
     }
 

--- a/server/api/model-builder/runs/index.ts
+++ b/server/api/model-builder/runs/index.ts
@@ -310,6 +310,18 @@ export type ContentStageKey = 'PITCH' | 'FIELDS_AND_PROMPTS' | 'GENERATE_ASSETS'
 // would keep anyway.
 export const MAX_DRAFT_TEXT_LENGTH = 20_000
 
+// Mirrors modelBuilderStore.ts's own MAX_BATCH (12) -- the quantity cap the
+// recipe-selector UI enforces client-side on `setOutputQuantity`. The CREATE
+// route's own `items` array had no equivalent server-side cap (model-builder/
+// t-029, cycle 72's own investigation flagged this and left it out of scope
+// as "low-severity, not a front-end-polish bug" -- addressed here instead),
+// so a direct API call bypassing the UI's stepper could hand this route an
+// arbitrarily large `items` array and create a run with thousands of rows in
+// one request. Kept as its own named constant (not literally re-imported from
+// the client store, which isn't available on the server) so the two stay
+// easy to compare and keep in sync by eye.
+export const MAX_BATCH_ITEMS = 12
+
 // Exported so callers can re-run this exact check a second time, against a
 // freshly-read stageStatuses value immediately before their write — see
 // PreparedItemUpdate.contentStageChecks' doc comment for why the single

--- a/utils/scripts/verifyModelBuilderRunCreateItemsCapGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderRunCreateItemsCapGuard.test.ts
@@ -1,0 +1,65 @@
+// /utils/scripts/verifyModelBuilderRunCreateItemsCapGuard.test.ts
+//
+// Regression test for verifyModelBuilderRunCreateItemsCapGuard.ts
+// (model-builder/t-029, cycle 73). Exercises the real checks against
+// synthetic runs/index.post.ts fixtures covering: the pre-fix buggy shape
+// (no cap at all), the fixed shape (capped against MAX_BATCH_ITEMS), and a
+// shape that imports the constant but never actually checks against it.
+import assert from 'node:assert/strict'
+
+import { findRunCreateItemsCapProblems } from './verifyModelBuilderRunCreateItemsCapGuard.js'
+
+const FIXED = `
+import { MAX_BATCH_ITEMS, MAX_DRAFT_TEXT_LENGTH, runInclude } from './index'
+
+    if (!Array.isArray(body.items) || body.items.length === 0) {
+      throw createError({ statusCode: 400, message: 'At least one build item is required.' })
+    }
+    if (body.items.length > MAX_BATCH_ITEMS) {
+      throw createError({ statusCode: 400, message: 'too many items' })
+    }
+`
+
+const PRE_FIX = `
+import { MAX_DRAFT_TEXT_LENGTH, runInclude } from './index'
+
+    if (!Array.isArray(body.items) || body.items.length === 0) {
+      throw createError({ statusCode: 400, message: 'At least one build item is required.' })
+    }
+`
+
+const IMPORTED_BUT_UNUSED = `
+import { MAX_BATCH_ITEMS, MAX_DRAFT_TEXT_LENGTH, runInclude } from './index'
+
+    if (!Array.isArray(body.items) || body.items.length === 0) {
+      throw createError({ statusCode: 400, message: 'At least one build item is required.' })
+    }
+`
+
+// --- findRunCreateItemsCapProblems: fixed shape reports nothing -------------
+
+assert.deepEqual(
+  findRunCreateItemsCapProblems(FIXED),
+  [],
+  'the fixed shape (imported and checked) should report no problems',
+)
+
+// --- findRunCreateItemsCapProblems: pre-fix shape reports both problems ----
+
+assert.deepEqual(
+  findRunCreateItemsCapProblems(PRE_FIX),
+  [{ reason: 'missing-import' }, { reason: 'missing-length-check' }],
+  'the pre-fix shape (no import, no check) should report both problems',
+)
+
+// --- findRunCreateItemsCapProblems: imported but never checked -------------
+
+assert.deepEqual(
+  findRunCreateItemsCapProblems(IMPORTED_BUT_UNUSED),
+  [{ reason: 'missing-length-check' }],
+  'importing the constant without checking against it should still fail',
+)
+
+console.log(
+  'verifyModelBuilderRunCreateItemsCapGuard.test.ts: all assertions passed.',
+)

--- a/utils/scripts/verifyModelBuilderRunCreateItemsCapGuard.ts
+++ b/utils/scripts/verifyModelBuilderRunCreateItemsCapGuard.ts
@@ -1,0 +1,79 @@
+// /utils/scripts/verifyModelBuilderRunCreateItemsCapGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 73). runs/index.post.ts (the
+// build-run CREATE route) rejects an empty `items` array but had no upper
+// bound at all -- modelBuilderStore.ts's own MAX_BATCH (12) is a client-side
+// stepper clamp on `setOutputQuantity` only, never enforced server-side. A
+// direct API call bypassing the UI could hand this route an arbitrarily
+// large `items` array and create a run with thousands of ModelBuildItem rows
+// in one request. Flagged as a real but out-of-scope observation in cycle
+// 72's investigation notes; addressed here.
+//
+// This walks runs/index.post.ts and fails if: the file no longer imports
+// MAX_BATCH_ITEMS from ./index, or the length check against it is missing.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const RUNS_CREATE_PATH = join(
+  repositoryRoot,
+  'server/api/model-builder/runs/index.post.ts',
+)
+
+export interface RunCreateItemsCapProblem {
+  reason: 'missing-import' | 'missing-length-check'
+}
+
+export function findRunCreateItemsCapProblems(
+  sourceContent: string,
+): RunCreateItemsCapProblem[] {
+  const problems: RunCreateItemsCapProblem[] = []
+
+  const importsConstant =
+    /import\s*\{[^}]*\bMAX_BATCH_ITEMS\b[^}]*\}\s*from\s*['"]\.\/index['"]/.test(
+      sourceContent,
+    )
+  if (!importsConstant) {
+    problems.push({ reason: 'missing-import' })
+  }
+
+  const hasLengthCheck = /body\.items\.length\s*>\s*MAX_BATCH_ITEMS/.test(
+    sourceContent,
+  )
+  if (!hasLengthCheck) {
+    problems.push({ reason: 'missing-length-check' })
+  }
+
+  return problems
+}
+
+function main(): void {
+  const sourceContent = readFileSync(RUNS_CREATE_PATH, 'utf8')
+  const problems = findRunCreateItemsCapProblems(sourceContent)
+
+  if (problems.length) {
+    console.error(
+      `Model Builder run-create items-cap contract failed: runs/index.post.ts ` +
+        'is missing its server-side cap on `items.length` against ' +
+        'MAX_BATCH_ITEMS -- an oversized `items` array from a direct API ' +
+        'call would reach Prisma unchecked instead of a clean 400:',
+    )
+    for (const problem of problems) {
+      console.error(`- ${problem.reason}`)
+    }
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder run-create items-cap contract passed: runs/index.post.ts ' +
+      'caps `items.length` against MAX_BATCH_ITEMS.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Summary

`server/api/model-builder/runs/index.post.ts` (the build-run CREATE route) rejected an empty `items` array but had no upper bound at all. `modelBuilderStore.ts`'s own `MAX_BATCH` (12) is a client-side stepper clamp on `setOutputQuantity` only, never enforced server-side — so a direct API call bypassing the UI could hand this route an arbitrarily large `items` array and create a run with thousands of `ModelBuildItem` rows in one request.

This was flagged as a real but out-of-scope observation during model-builder/t-029 cycle 72's investigation ("low-severity, not a front-end-polish bug") — addressed here as its own bounded slice (cycle 73).

## Changes

- Export `MAX_BATCH_ITEMS` (12) from `runs/index.ts`, mirroring the store's own `MAX_BATCH`.
- Reject `items.length > MAX_BATCH_ITEMS` with a clean 400 in `runs/index.post.ts`.
- Add `verifyModelBuilderRunCreateItemsCapGuard.ts` + self-test, wired into `package.json` and `contract-tests.yml`, matching this task's established regression-guard convention (mirrors `verifyModelBuilderRunCreateTextCapGuard.ts`).

## Verification

- New guard self-test passes (fixed / pre-fix / imported-but-unused fixtures).
- New guard passes against the real route.
- 149/151 `test:model-builder-*` scripts pass — the 2 `field-blob-continuation` failures are the pre-existing, unrelated sandbox limitation documented since cycle 59 (needs Nuxt's generated `@/stores` path alias, not provisioned in this sandbox).
- `prettier --check` clean on all changed files.
- `git status --porcelain` scoped to exactly 6 files.
- `eslint`/`vue-tsc` need `node_modules`/`.nuxt`, not provisioned in this sandbox — left to CI per established precedent for this recurring task.

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_019aFS1C4bP7SeiM8dMB8wWz)_