### PR TITLE
Add Rainbow-native Google identity API

### DIFF
--- a/server/api/auth/first-party/google/config.get.ts
+++ b/server/api/auth/first-party/google/config.get.ts
@@ -1,0 +1,32 @@
+import { createError, defineEventHandler, getQuery, setHeader } from 'h3'
+import { findFirstPartyClient, normalizeAllowedFirstPartyRedirect } from '~/utils/firstPartySsoContract'
+import { getFirstPartyClients } from '@/server/utils/firstPartySso'
+
+export default defineEventHandler((event) => {
+  setHeader(event, 'Cache-Control', 'no-store')
+
+  const query = getQuery(event)
+  const client = findFirstPartyClient(getFirstPartyClients(), query.client_id)
+  if (!client) {
+    throw createError({ statusCode: 400, message: 'Unknown first-party client.' })
+  }
+
+  const redirectUri = normalizeAllowedFirstPartyRedirect(client, query.redirect_uri)
+  if (!redirectUri) {
+    throw createError({
+      statusCode: 400,
+      message: 'redirect_uri is not registered for this first-party client.',
+    })
+  }
+
+  const googleClientId = String(process.env.GOOGLE_ID || '').trim()
+  if (!googleClientId) {
+    throw createError({ statusCode: 503, message: 'Google sign-in is not configured.' })
+  }
+
+  return {
+    success: true,
+    clientId: googleClientId,
+    redirectUri,
+  }
+})

--- a/server/api/auth/first-party/google/exchange.post.ts
+++ b/server/api/auth/first-party/google/exchange.post.ts
@@ -27,6 +27,23 @@ type GoogleUserInfoResponse = {
   picture?: string
 }
 
+async function reserveGoogleUsername(name: string, googleId: string): Promise<string> {
+  const cleanName = name.trim().slice(0, 220)
+  const base = cleanName || `user-${googleId.slice(0, 8)}`
+
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const suffix = attempt === 0 ? '' : `-${googleId.slice(0, 6)}${attempt === 1 ? '' : `-${attempt}`}`
+    const candidate = `${base.slice(0, 255 - suffix.length)}${suffix}`
+    const existing = await prisma.user.findUnique({
+      where: { username: candidate },
+      select: { id: true },
+    })
+    if (!existing) return candidate
+  }
+
+  return `user-${googleId.slice(0, 20)}`
+}
+
 export default defineEventHandler(async (event) => {
   setHeader(event, 'Cache-Control', 'no-store')
   setHeader(event, 'Pragma', 'no-cache')
@@ -48,7 +65,10 @@ export default defineEventHandler(async (event) => {
   const code = typeof body?.code === 'string' ? body.code.trim() : ''
   const verifier = validatePkceVerifier(body?.code_verifier)
   if (!code || !verifier) {
-    throw createError({ statusCode: 400, message: 'A valid Google authorization code and PKCE verifier are required.' })
+    throw createError({
+      statusCode: 400,
+      message: 'A valid Google authorization code and PKCE verifier are required.',
+    })
   }
 
   const googleClientId = String(process.env.GOOGLE_ID || '').trim()
@@ -58,54 +78,77 @@ export default defineEventHandler(async (event) => {
   }
 
   try {
-    const tokenResponse = await $fetch<GoogleTokenResponse>('https://oauth2.googleapis.com/token', {
-      method: 'POST',
-      body: {
-        code,
-        client_id: googleClientId,
-        client_secret: googleClientSecret,
-        redirect_uri: redirectUri,
-        grant_type: 'authorization_code',
-        code_verifier: verifier,
+    const tokenResponse = await $fetch<GoogleTokenResponse>(
+      'https://oauth2.googleapis.com/token',
+      {
+        method: 'POST',
+        body: {
+          code,
+          client_id: googleClientId,
+          client_secret: googleClientSecret,
+          redirect_uri: redirectUri,
+          grant_type: 'authorization_code',
+          code_verifier: verifier,
+        },
       },
-    })
+    )
 
     const accessToken = String(tokenResponse.access_token || '').trim()
     if (!accessToken) {
-      throw createError({ statusCode: 401, message: 'Google did not return an access token.' })
+      throw createError({
+        statusCode: 401,
+        message: 'Google did not return an access token.',
+      })
     }
 
-    const googleUser = await $fetch<GoogleUserInfoResponse>('https://www.googleapis.com/oauth2/v3/userinfo', {
-      headers: { Authorization: `Bearer ${accessToken}` },
-    })
+    const googleUser = await $fetch<GoogleUserInfoResponse>(
+      'https://www.googleapis.com/oauth2/v3/userinfo',
+      { headers: { Authorization: `Bearer ${accessToken}` } },
+    )
 
     const email = String(googleUser.email || '').trim().toLowerCase()
     const googleId = String(googleUser.sub || '').trim()
     if (!email || !googleId || googleUser.email_verified !== true) {
-      throw createError({ statusCode: 403, message: 'A verified Google email address is required.' })
+      throw createError({
+        statusCode: 403,
+        message: 'A verified Google email address is required.',
+      })
     }
 
     let user = await prisma.user.findUnique({ where: { email } })
 
     if (!user) {
+      const username = await reserveGoogleUsername(
+        String(googleUser.name || ''),
+        googleId,
+      )
       user = await prisma.user.create({
         data: {
           email,
           googleId,
-          username: String(googleUser.name || '').trim() || `user-${googleId.slice(0, 8)}`,
+          username,
           avatarImage: String(googleUser.picture || '').trim() || null,
           emailVerified: new Date(),
         },
       })
     } else {
       if (user.isActive === false) {
-        throw createError({ statusCode: 403, message: 'The Kind Robots account is unavailable.' })
+        throw createError({
+          statusCode: 403,
+          message: 'The Kind Robots account is unavailable.',
+        })
       }
 
-      const update: { googleId?: string; emailVerified?: Date; avatarImage?: string } = {}
+      const update: {
+        googleId?: string
+        emailVerified?: Date
+        avatarImage?: string
+      } = {}
       if (!user.googleId) update.googleId = googleId
       if (!user.emailVerified) update.emailVerified = new Date()
-      if (!user.avatarImage && googleUser.picture) update.avatarImage = googleUser.picture
+      if (!user.avatarImage && googleUser.picture) {
+        update.avatarImage = googleUser.picture
+      }
 
       if (Object.keys(update).length) {
         user = await prisma.user.update({ where: { id: user.id }, data: update })
@@ -122,6 +165,9 @@ export default defineEventHandler(async (event) => {
   } catch (error) {
     logSafeError('[First-party Google exchange] failed:', error)
     if (error && typeof error === 'object' && 'statusCode' in error) throw error
-    throw createError({ statusCode: 401, message: 'Google sign-in could not be completed.' })
+    throw createError({
+      statusCode: 401,
+      message: 'Google sign-in could not be completed.',
+    })
   }
 })

--- a/server/api/auth/first-party/google/exchange.post.ts
+++ b/server/api/auth/first-party/google/exchange.post.ts
@@ -81,22 +81,35 @@ export default defineEventHandler(async (event) => {
   }
 
   try {
-    const tokenResponse = await $fetch<GoogleTokenResponse>(
-      'https://oauth2.googleapis.com/token',
-      {
-        method: 'POST',
-        body: {
-          code,
-          client_id: googleClientId,
-          client_secret: googleClientSecret,
-          redirect_uri: redirectUri,
-          grant_type: 'authorization_code',
-          code_verifier: verifier,
-        },
+    // Use the platform fetch API for external OAuth calls. Nuxt's typed $fetch
+    // attempts Nitro route inference even for arbitrary external URLs, which
+    // can make vue-tsc recurse excessively. Google's token endpoint expects
+    // the standard application/x-www-form-urlencoded OAuth request shape.
+    const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
       },
-    )
+      body: new URLSearchParams({
+        code,
+        client_id: googleClientId,
+        client_secret: googleClientSecret,
+        redirect_uri: redirectUri,
+        grant_type: 'authorization_code',
+        code_verifier: verifier,
+      }),
+    })
 
-    const accessToken = String(tokenResponse.access_token || '').trim()
+    if (!tokenResponse.ok) {
+      throw createError({
+        statusCode: 401,
+        message: 'Google authorization code exchange failed.',
+      })
+    }
+
+    const tokenPayload = (await tokenResponse.json()) as GoogleTokenResponse
+    const accessToken = String(tokenPayload.access_token || '').trim()
     if (!accessToken) {
       throw createError({
         statusCode: 401,
@@ -104,13 +117,13 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    // Native fetch is deliberate here: Nuxt's typed $fetch tries to infer an
-    // internal Nitro route for arbitrary external URLs and can recurse deeply
-    // enough to fail vue-tsc. This is a plain external HTTP boundary.
     const userInfoResponse = await fetch(
       'https://www.googleapis.com/oauth2/v3/userinfo',
       {
-        headers: { Authorization: `Bearer ${accessToken}` },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          Accept: 'application/json',
+        },
       },
     )
     if (!userInfoResponse.ok) {

--- a/server/api/auth/first-party/google/exchange.post.ts
+++ b/server/api/auth/first-party/google/exchange.post.ts
@@ -32,7 +32,10 @@ async function reserveGoogleUsername(name: string, googleId: string): Promise<st
   const base = cleanName || `user-${googleId.slice(0, 8)}`
 
   for (let attempt = 0; attempt < 20; attempt++) {
-    const suffix = attempt === 0 ? '' : `-${googleId.slice(0, 6)}${attempt === 1 ? '' : `-${attempt}`}`
+    const suffix =
+      attempt === 0
+        ? ''
+        : `-${googleId.slice(0, 6)}${attempt === 1 ? '' : `-${attempt}`}`
     const candidate = `${base.slice(0, 255 - suffix.length)}${suffix}`
     const existing = await prisma.user.findUnique({
       where: { username: candidate },
@@ -101,10 +104,22 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const googleUser = await $fetch<GoogleUserInfoResponse>(
+    // Native fetch is deliberate here: Nuxt's typed $fetch tries to infer an
+    // internal Nitro route for arbitrary external URLs and can recurse deeply
+    // enough to fail vue-tsc. This is a plain external HTTP boundary.
+    const userInfoResponse = await fetch(
       'https://www.googleapis.com/oauth2/v3/userinfo',
-      { headers: { Authorization: `Bearer ${accessToken}` } },
+      {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      },
     )
+    if (!userInfoResponse.ok) {
+      throw createError({
+        statusCode: 401,
+        message: 'Google user information could not be retrieved.',
+      })
+    }
+    const googleUser = (await userInfoResponse.json()) as GoogleUserInfoResponse
 
     const email = String(googleUser.email || '').trim().toLowerCase()
     const googleId = String(googleUser.sub || '').trim()

--- a/server/api/auth/first-party/google/exchange.post.ts
+++ b/server/api/auth/first-party/google/exchange.post.ts
@@ -1,0 +1,127 @@
+import { createError, defineEventHandler, readBody, setHeader } from 'h3'
+import prisma from '@/server/utils/prisma'
+import { logSafeError } from '@/server/utils/error'
+import { getFirstPartyClients } from '@/server/utils/firstPartySso'
+import {
+  findFirstPartyClient,
+  normalizeAllowedFirstPartyRedirect,
+  validatePkceVerifier,
+} from '~/utils/firstPartySsoContract'
+
+type ExchangeBody = {
+  client_id?: unknown
+  redirect_uri?: unknown
+  code?: unknown
+  code_verifier?: unknown
+}
+
+type GoogleTokenResponse = {
+  access_token?: string
+}
+
+type GoogleUserInfoResponse = {
+  sub?: string
+  email?: string
+  email_verified?: boolean
+  name?: string
+  picture?: string
+}
+
+export default defineEventHandler(async (event) => {
+  setHeader(event, 'Cache-Control', 'no-store')
+  setHeader(event, 'Pragma', 'no-cache')
+
+  const body = await readBody<ExchangeBody>(event)
+  const client = findFirstPartyClient(getFirstPartyClients(), body?.client_id)
+  if (!client) {
+    throw createError({ statusCode: 400, message: 'Unknown first-party client.' })
+  }
+
+  const redirectUri = normalizeAllowedFirstPartyRedirect(client, body?.redirect_uri)
+  if (!redirectUri) {
+    throw createError({
+      statusCode: 400,
+      message: 'redirect_uri is not registered for this first-party client.',
+    })
+  }
+
+  const code = typeof body?.code === 'string' ? body.code.trim() : ''
+  const verifier = validatePkceVerifier(body?.code_verifier)
+  if (!code || !verifier) {
+    throw createError({ statusCode: 400, message: 'A valid Google authorization code and PKCE verifier are required.' })
+  }
+
+  const googleClientId = String(process.env.GOOGLE_ID || '').trim()
+  const googleClientSecret = String(process.env.GOOGLE_SECRET || '').trim()
+  if (!googleClientId || !googleClientSecret) {
+    throw createError({ statusCode: 503, message: 'Google sign-in is not configured.' })
+  }
+
+  try {
+    const tokenResponse = await $fetch<GoogleTokenResponse>('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      body: {
+        code,
+        client_id: googleClientId,
+        client_secret: googleClientSecret,
+        redirect_uri: redirectUri,
+        grant_type: 'authorization_code',
+        code_verifier: verifier,
+      },
+    })
+
+    const accessToken = String(tokenResponse.access_token || '').trim()
+    if (!accessToken) {
+      throw createError({ statusCode: 401, message: 'Google did not return an access token.' })
+    }
+
+    const googleUser = await $fetch<GoogleUserInfoResponse>('https://www.googleapis.com/oauth2/v3/userinfo', {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    })
+
+    const email = String(googleUser.email || '').trim().toLowerCase()
+    const googleId = String(googleUser.sub || '').trim()
+    if (!email || !googleId || googleUser.email_verified !== true) {
+      throw createError({ statusCode: 403, message: 'A verified Google email address is required.' })
+    }
+
+    let user = await prisma.user.findUnique({ where: { email } })
+
+    if (!user) {
+      user = await prisma.user.create({
+        data: {
+          email,
+          googleId,
+          username: String(googleUser.name || '').trim() || `user-${googleId.slice(0, 8)}`,
+          avatarImage: String(googleUser.picture || '').trim() || null,
+          emailVerified: new Date(),
+        },
+      })
+    } else {
+      if (user.isActive === false) {
+        throw createError({ statusCode: 403, message: 'The Kind Robots account is unavailable.' })
+      }
+
+      const update: { googleId?: string; emailVerified?: Date; avatarImage?: string } = {}
+      if (!user.googleId) update.googleId = googleId
+      if (!user.emailVerified) update.emailVerified = new Date()
+      if (!user.avatarImage && googleUser.picture) update.avatarImage = googleUser.picture
+
+      if (Object.keys(update).length) {
+        user = await prisma.user.update({ where: { id: user.id }, data: update })
+      }
+    }
+
+    return {
+      success: true,
+      user: {
+        id: user.id,
+        username: user.username,
+      },
+    }
+  } catch (error) {
+    logSafeError('[First-party Google exchange] failed:', error)
+    if (error && typeof error === 'object' && 'statusCode' in error) throw error
+    throw createError({ statusCode: 401, message: 'Google sign-in could not be completed.' })
+  }
+})

--- a/server/api/users/register.post.ts
+++ b/server/api/users/register.post.ts
@@ -10,11 +10,14 @@ export default defineEventHandler(async (event) => {
   console.log('🚀 Launching the user creation journey...')
 
   try {
-    // Reading the user data from the event body
     const userData = await readBody(event)
-    console.log('📬 Received user data:', userData)
+    // Never log registration bodies: they can contain plaintext passwords.
+    console.log('📬 Received user registration request:', {
+      hasUsername: Boolean(userData?.username),
+      hasEmail: Boolean(userData?.email),
+      hasReferralCode: Boolean(userData?.referralCode),
+    })
 
-    // Ensuring the essential fields are provided
     if (!userData.username && !userData.email) {
       return {
         success: false,
@@ -32,22 +35,18 @@ export default defineEventHandler(async (event) => {
       }
     }
 
-    // Initiating the user creation with the gathered stellar dust (user data)
     const result = await createUser({
       username: userData.username,
       email: userData.email,
       password: userData.password,
     })
 
-    // If the star formation (user creation) is successful, we celebrate with a warm welcome
     if (result.success && result.user) {
       console.log('🌟 A new star is born in our user universe:', {
         id: result.user.id,
         username: result.user.username,
       })
 
-      // Auto-send the inbox welcome message. Non-fatal: a failure here
-      // should never block a successful registration.
       try {
         await sendWelcomeMessage(result.user.id, { markAsRead: false })
         console.log('💌 Welcome message delivered to', result.user.id)
@@ -58,7 +57,6 @@ export default defineEventHandler(async (event) => {
         )
       }
 
-      // Referral attribution. Non-fatal: failure here never blocks registration.
       if (userData.referralCode && typeof userData.referralCode === 'string') {
         try {
           const referrer = await prisma.user.findFirst({
@@ -88,16 +86,18 @@ export default defineEventHandler(async (event) => {
         }
       }
 
+      const { password: _password, ...safeUser } = result.user
+      void _password
+
       return {
         success: true,
         message:
           '🌟 Welcome to our cosmic family, brave explorer! Your account has been created.',
-        user: result.user as User,
+        user: safeUser,
         statusCode: 201,
       }
     }
 
-    // If something goes amiss in the cosmic process, we communicate the issue
     return {
       success: false,
       message:
@@ -108,7 +108,6 @@ export default defineEventHandler(async (event) => {
     }
   } catch (error: unknown) {
     const { message, statusCode } = errorHandler(error)
-    // If a cosmic storm (error) occurs, we navigate safely with our error handler
     console.error('🌩️ Cosmic storm encountered:', message)
     return {
       success: false,

--- a/utils/firstPartySsoContract.ts
+++ b/utils/firstPartySsoContract.ts
@@ -24,8 +24,11 @@ export const DEFAULT_FIRST_PARTY_CLIENTS: readonly FirstPartyClient[] = [
     label: 'Rainbow Butterflies',
     redirectUris: [
       'https://rainbowbutterflies.org/auth/callback',
+      'https://rainbowbutterflies.org/auth/google/callback',
       'http://localhost:3000/auth/callback',
+      'http://localhost:3000/auth/google/callback',
       'http://127.0.0.1:3000/auth/callback',
+      'http://127.0.0.1:3000/auth/google/callback',
     ],
   },
 ]

--- a/utils/scripts/verifyFirstPartySso.test.ts
+++ b/utils/scripts/verifyFirstPartySso.test.ts
@@ -26,6 +26,13 @@ assert.equal(
   true,
 )
 assert.equal(
+  isAllowedFirstPartyRedirect(
+    rainbow,
+    'https://rainbowbutterflies.org/auth/google/callback',
+  ),
+  true,
+)
+assert.equal(
   isAllowedFirstPartyRedirect(rainbow, 'https://evil.example/auth/callback'),
   false,
 )

--- a/utils/scripts/verifyFirstPartySso.test.ts
+++ b/utils/scripts/verifyFirstPartySso.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 
 import {
   DEFAULT_FIRST_PARTY_CLIENTS,
@@ -159,5 +160,24 @@ assert.deepEqual(
   }),
   { ok: false, reason: 'pkce' },
 )
+
+const googleConfigSource = readFileSync(
+  'server/api/auth/first-party/google/config.get.ts',
+  'utf8',
+)
+const googleExchangeSource = readFileSync(
+  'server/api/auth/first-party/google/exchange.post.ts',
+  'utf8',
+)
+const registrationSource = readFileSync('server/api/users/register.post.ts', 'utf8')
+
+assert.match(googleConfigSource, /GOOGLE_ID/)
+assert.doesNotMatch(googleConfigSource, /GOOGLE_SECRET/)
+assert.match(googleExchangeSource, /GOOGLE_SECRET/)
+assert.match(googleExchangeSource, /email_verified\s*!==\s*true/)
+assert.match(googleExchangeSource, /code_verifier:\s*verifier/)
+assert.doesNotMatch(googleExchangeSource, /return\s+\{[^}]*access_token/s)
+assert.doesNotMatch(registrationSource, /Received user data.*userData/)
+assert.match(registrationSource, /password:\s*_password/)
 
 console.log('First-party SSO contract OK')


### PR DESCRIPTION
Rainbow Butterflies v2 auth slice: keep Kind Robots as canonical identity/API backend without sending Rainbow users through the Kind Robots login UI.

## Changes
- registers Rainbow's direct Google callback (`https://rainbowbutterflies.org/auth/google/callback`) as a first-party redirect
- exposes a first-party endpoint that returns only the public Google client ID after validating the requesting client/callback
- adds a server-side Google code exchange endpoint that keeps `GOOGLE_SECRET` on Kind Robots, requires PKCE + verified Google email, and returns only canonical `{id, username}` to Rainbow
- creates/links the existing Kind Robots `User`, including collision-safe usernames for new Google accounts
- preserves the existing Kind Robots Google callback for direct Kind Robots login
- fixes registration so plaintext passwords are never logged and bcrypt hashes are never returned in the registration response
- extends the first-party SSO contract checks for the Rainbow Google callback and secret boundary

No new identity database, no schema migration, no Google token persistence, and no deployment/DNS/secrets changes.