### PR TITLE
Add first-class AgentProfile identity

### DIFF
--- a/.github/workflows/agent-profile-contract.yml
+++ b/.github/workflows/agent-profile-contract.yml
@@ -1,0 +1,41 @@
+name: Agent Profile Contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'prisma/agent-profile.prisma'
+      - 'prisma/migrations/20260901063000_add_agent_profile/**'
+      - 'server/api/agent-profiles/**'
+      - 'server/api/agent-credentials/**'
+      - 'server/utils/agentCredentials.ts'
+      - 'server/utils/authGuard.ts'
+      - 'utils/scripts/verifyAgentProfiles.test.ts'
+      - '.github/workflows/agent-profile-contract.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'prisma/agent-profile.prisma'
+      - 'prisma/migrations/20260901063000_add_agent_profile/**'
+      - 'server/api/agent-profiles/**'
+      - 'server/api/agent-credentials/**'
+      - 'server/utils/agentCredentials.ts'
+      - 'server/utils/authGuard.ts'
+      - 'utils/scripts/verifyAgentProfiles.test.ts'
+      - '.github/workflows/agent-profile-contract.yml'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci --ignore-scripts
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+      - name: Verify AgentProfile contract
+        run: npx tsx utils/scripts/verifyAgentProfiles.test.ts

--- a/prisma/agent-profile.prisma
+++ b/prisma/agent-profile.prisma
@@ -1,0 +1,38 @@
+/// Durable public identity for a user-operated external AI agent.
+///
+/// `userId` is intentionally an indexed ownership scalar rather than another
+/// back-relation on the already-large User model. Authenticated API routes are
+/// the authority for owner scoping, matching BrainstormSession's precedent.
+/// Credentials are separate durable secrets and are linked through
+/// AgentProfileCredential so keys can rotate without erasing profile history.
+model AgentProfile {
+  id            Int                      @id @default(autoincrement())
+  createdAt     DateTime                 @default(now())
+  updatedAt     DateTime                 @default(now()) @updatedAt
+  userId        Int
+  name          String                   @db.VarChar(120)
+  avatarImage   String?                  @db.VarChar(764)
+  description   String?                  @db.Text
+  isPublic      Boolean                  @default(true)
+  allowMessages Boolean                  @default(false)
+  isActive      Boolean                  @default(true)
+  Credentials   AgentProfileCredential[]
+
+  @@index([userId, isActive])
+  @@index([isPublic, isActive])
+  @@index([name])
+}
+
+/// One credential may identify at most one AgentProfile. `credentialId` is a
+/// scalar reference to the existing AgentCredential row rather than a Prisma
+/// relation so the legacy AgentCredential model does not need a new back-field.
+/// Application code verifies same-user ownership whenever links are created.
+model AgentProfileCredential {
+  id             Int          @id @default(autoincrement())
+  createdAt      DateTime     @default(now())
+  agentProfileId Int
+  credentialId   Int          @unique
+  Profile        AgentProfile @relation(fields: [agentProfileId], references: [id], onDelete: Cascade)
+
+  @@index([agentProfileId])
+}

--- a/prisma/migrations/20260901063000_add_agent_profile/migration.sql
+++ b/prisma/migrations/20260901063000_add_agent_profile/migration.sql
@@ -1,0 +1,36 @@
+-- Rainbow Butterflies v2: durable external-agent identity, separate from Bot
+-- records and separate from revocable credentials. Purely additive.
+
+CREATE TABLE `AgentProfile` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `userId` INTEGER NOT NULL,
+    `name` VARCHAR(120) NOT NULL,
+    `avatarImage` VARCHAR(764) NULL,
+    `description` TEXT NULL,
+    `isPublic` BOOLEAN NOT NULL DEFAULT true,
+    `allowMessages` BOOLEAN NOT NULL DEFAULT false,
+    `isActive` BOOLEAN NOT NULL DEFAULT true,
+
+    INDEX `AgentProfile_userId_isActive_idx`(`userId`, `isActive`),
+    INDEX `AgentProfile_isPublic_isActive_idx`(`isPublic`, `isActive`),
+    INDEX `AgentProfile_name_idx`(`name`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `AgentProfileCredential` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `agentProfileId` INTEGER NOT NULL,
+    `credentialId` INTEGER NOT NULL,
+
+    UNIQUE INDEX `AgentProfileCredential_credentialId_key`(`credentialId`),
+    INDEX `AgentProfileCredential_agentProfileId_idx`(`agentProfileId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE `AgentProfileCredential`
+    ADD CONSTRAINT `AgentProfileCredential_agentProfileId_fkey`
+    FOREIGN KEY (`agentProfileId`) REFERENCES `AgentProfile`(`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/api/agent-credentials/index.post.ts
+++ b/server/api/agent-credentials/index.post.ts
@@ -1,8 +1,7 @@
 // /server/api/agent-credentials/index.post.ts
-// rainbow-butterflies/t-015: issue a new agent credential for the current
-// user (optionally scoped to one of their Bots). The plaintext token is
-// returned exactly once in this response and never persisted -- callers
-// must copy it now.
+// Issue a new scoped machine credential for the current user. Legacy Kind
+// Robots callers may bind it to one owned Bot; Rainbow v2 callers bind it to a
+// durable AgentProfile instead. The plaintext token is returned exactly once.
 import { createError, defineEventHandler, readBody } from 'h3'
 import { errorHandler } from '../../utils/error'
 import prisma from '../../utils/prisma'
@@ -15,6 +14,7 @@ import {
 type CreatePayload = {
   label?: unknown
   botId?: unknown
+  agentProfileId?: unknown
   scopes?: unknown
   expiresAt?: unknown
 }
@@ -50,6 +50,40 @@ export default defineEventHandler(async (event) => {
       botId = parsed
     }
 
+    let agentProfileId: number | null = null
+    if (
+      body?.agentProfileId !== undefined &&
+      body.agentProfileId !== null
+    ) {
+      const parsed = Number(body.agentProfileId)
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw createError({
+          statusCode: 400,
+          message: 'agentProfileId must be a positive integer.',
+        })
+      }
+
+      const profile = await prisma.agentProfile.findUnique({
+        where: { id: parsed },
+        select: { userId: true, isActive: true },
+      })
+      if (!profile || profile.userId !== auth.user.id || !profile.isActive) {
+        throw createError({
+          statusCode: 403,
+          message: 'agentProfileId must reference an active profile you own.',
+        })
+      }
+
+      agentProfileId = parsed
+    }
+
+    if (botId && agentProfileId) {
+      throw createError({
+        statusCode: 400,
+        message: 'A credential cannot bind both botId and agentProfileId.',
+      })
+    }
+
     const scopes = sanitizeScopes(body?.scopes)
 
     let expiresAt: Date | null = null
@@ -67,6 +101,7 @@ export default defineEventHandler(async (event) => {
     const { credential, token } = await createAgentCredential({
       userId: auth.user.id,
       botId,
+      agentProfileId,
       label,
       scopes,
       expiresAt,

--- a/server/api/agent-profiles/[id].delete.ts
+++ b/server/api/agent-profiles/[id].delete.ts
@@ -1,0 +1,61 @@
+import { createError, defineEventHandler, getRouterParam } from 'h3'
+import { errorHandler } from '../../utils/error'
+import prisma from '../../utils/prisma'
+import { requireHumanApiUser } from '@/server/utils/authGuard'
+
+function parseId(value: string | undefined) {
+  const id = Number(value)
+  if (!Number.isInteger(id) || id <= 0) {
+    throw createError({ statusCode: 400, message: 'Invalid agent profile id.' })
+  }
+  return id
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireHumanApiUser(event)
+    const id = parseId(getRouterParam(event, 'id'))
+    const profile = await prisma.agentProfile.findUnique({
+      where: { id },
+      include: { Credentials: { select: { credentialId: true } } },
+    })
+
+    if (!profile) {
+      throw createError({ statusCode: 404, message: 'Agent profile not found.' })
+    }
+    if (profile.userId !== auth.user.id) {
+      throw createError({ statusCode: 403, message: 'You do not own this agent profile.' })
+    }
+
+    const credentialIds = profile.Credentials.map((link) => link.credentialId)
+    const revokedAt = new Date()
+
+    await prisma.$transaction(async (tx) => {
+      await tx.agentProfile.update({
+        where: { id },
+        data: { isActive: false },
+      })
+
+      if (credentialIds.length > 0) {
+        await tx.agentCredential.updateMany({
+          where: {
+            id: { in: credentialIds },
+            userId: auth.user.id,
+            revokedAt: null,
+          },
+          data: { revokedAt },
+        })
+      }
+    })
+
+    return {
+      success: true,
+      profileId: id,
+      revokedCredentials: credentialIds.length,
+    }
+  } catch (error) {
+    const { message, statusCode } = errorHandler(error)
+    event.node.res.statusCode = statusCode || 500
+    return { success: false, message: message || 'Failed to deactivate agent profile.' }
+  }
+})

--- a/server/api/agent-profiles/[id].get.ts
+++ b/server/api/agent-profiles/[id].get.ts
@@ -1,0 +1,44 @@
+import { createError, defineEventHandler, getRouterParam } from 'h3'
+import { errorHandler } from '../../utils/error'
+import prisma from '../../utils/prisma'
+import { requireHumanApiUser } from '@/server/utils/authGuard'
+
+function parseId(value: string | undefined) {
+  const id = Number(value)
+  if (!Number.isInteger(id) || id <= 0) {
+    throw createError({ statusCode: 400, message: 'Invalid agent profile id.' })
+  }
+  return id
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireHumanApiUser(event)
+    const id = parseId(getRouterParam(event, 'id'))
+    const profile = await prisma.agentProfile.findUnique({
+      where: { id },
+      include: {
+        Credentials: {
+          select: { credentialId: true },
+        },
+      },
+    })
+
+    if (!profile) {
+      throw createError({ statusCode: 404, message: 'Agent profile not found.' })
+    }
+    if (profile.userId !== auth.user.id) {
+      throw createError({ statusCode: 403, message: 'You do not own this agent profile.' })
+    }
+
+    const { Credentials, ...safeProfile } = profile
+    return {
+      success: true,
+      profile: { ...safeProfile, credentialCount: Credentials.length },
+    }
+  } catch (error) {
+    const { message, statusCode } = errorHandler(error)
+    event.node.res.statusCode = statusCode || 500
+    return { success: false, message: message || 'Failed to load agent profile.' }
+  }
+})

--- a/server/api/agent-profiles/[id].patch.ts
+++ b/server/api/agent-profiles/[id].patch.ts
@@ -1,0 +1,96 @@
+import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
+import { errorHandler } from '../../utils/error'
+import prisma from '../../utils/prisma'
+import { requireHumanApiUser } from '@/server/utils/authGuard'
+
+type UpdateAgentProfilePayload = {
+  name?: unknown
+  avatarImage?: unknown
+  description?: unknown
+  isPublic?: unknown
+  allowMessages?: unknown
+}
+
+function parseId(value: string | undefined) {
+  const id = Number(value)
+  if (!Number.isInteger(id) || id <= 0) {
+    throw createError({ statusCode: 400, message: 'Invalid agent profile id.' })
+  }
+  return id
+}
+
+function optionalString(value: unknown, maxLength: number, field: string) {
+  if (value === null || value === '') return null
+  if (typeof value !== 'string') {
+    throw createError({ statusCode: 400, message: `${field} must be a string or null.` })
+  }
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  if (trimmed.length > maxLength) {
+    throw createError({
+      statusCode: 400,
+      message: `${field} must be ${maxLength} characters or fewer.`,
+    })
+  }
+  return trimmed
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireHumanApiUser(event)
+    const id = parseId(getRouterParam(event, 'id'))
+    const existing = await prisma.agentProfile.findUnique({ where: { id } })
+
+    if (!existing) {
+      throw createError({ statusCode: 404, message: 'Agent profile not found.' })
+    }
+    if (existing.userId !== auth.user.id) {
+      throw createError({ statusCode: 403, message: 'You do not own this agent profile.' })
+    }
+
+    const body = await readBody<UpdateAgentProfilePayload>(event)
+    const data: {
+      name?: string
+      avatarImage?: string | null
+      description?: string | null
+      isPublic?: boolean
+      allowMessages?: boolean
+    } = {}
+
+    if (body.name !== undefined) {
+      if (typeof body.name !== 'string' || !body.name.trim()) {
+        throw createError({ statusCode: 400, message: 'name cannot be empty.' })
+      }
+      const name = body.name.trim()
+      if (name.length > 120) {
+        throw createError({ statusCode: 400, message: 'name must be 120 characters or fewer.' })
+      }
+      data.name = name
+    }
+    if (body.avatarImage !== undefined) {
+      data.avatarImage = optionalString(body.avatarImage, 764, 'avatarImage')
+    }
+    if (body.description !== undefined) {
+      data.description = optionalString(body.description, 5000, 'description')
+    }
+    if (body.isPublic !== undefined) {
+      if (typeof body.isPublic !== 'boolean') {
+        throw createError({ statusCode: 400, message: 'isPublic must be boolean.' })
+      }
+      data.isPublic = body.isPublic
+    }
+    if (body.allowMessages !== undefined) {
+      if (typeof body.allowMessages !== 'boolean') {
+        throw createError({ statusCode: 400, message: 'allowMessages must be boolean.' })
+      }
+      data.allowMessages = body.allowMessages
+    }
+
+    const profile = await prisma.agentProfile.update({ where: { id }, data })
+    return { success: true, profile }
+  } catch (error) {
+    const { message, statusCode } = errorHandler(error)
+    event.node.res.statusCode = statusCode || 500
+    return { success: false, message: message || 'Failed to update agent profile.' }
+  }
+})

--- a/server/api/agent-profiles/index.get.ts
+++ b/server/api/agent-profiles/index.get.ts
@@ -1,0 +1,31 @@
+import { defineEventHandler } from 'h3'
+import { errorHandler } from '../../utils/error'
+import prisma from '../../utils/prisma'
+import { requireHumanApiUser } from '@/server/utils/authGuard'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireHumanApiUser(event)
+    const profiles = await prisma.agentProfile.findMany({
+      where: { userId: auth.user.id },
+      orderBy: { createdAt: 'desc' },
+      include: {
+        Credentials: {
+          select: { credentialId: true },
+        },
+      },
+    })
+
+    return {
+      success: true,
+      profiles: profiles.map(({ Credentials, ...profile }) => ({
+        ...profile,
+        credentialCount: Credentials.length,
+      })),
+    }
+  } catch (error) {
+    const { message, statusCode } = errorHandler(error)
+    event.node.res.statusCode = statusCode || 500
+    return { success: false, message: message || 'Failed to list agent profiles.' }
+  }
+})

--- a/server/api/agent-profiles/index.post.ts
+++ b/server/api/agent-profiles/index.post.ts
@@ -1,0 +1,64 @@
+import { createError, defineEventHandler, readBody } from 'h3'
+import { errorHandler } from '../../utils/error'
+import prisma from '../../utils/prisma'
+import { requireHumanApiUser } from '@/server/utils/authGuard'
+
+type CreateAgentProfilePayload = {
+  name?: unknown
+  avatarImage?: unknown
+  description?: unknown
+  isPublic?: unknown
+  allowMessages?: unknown
+}
+
+function optionalString(value: unknown, maxLength: number, field: string) {
+  if (value === undefined || value === null || value === '') return null
+  if (typeof value !== 'string') {
+    throw createError({ statusCode: 400, message: `${field} must be a string.` })
+  }
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  if (trimmed.length > maxLength) {
+    throw createError({
+      statusCode: 400,
+      message: `${field} must be ${maxLength} characters or fewer.`,
+    })
+  }
+  return trimmed
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireHumanApiUser(event)
+    const body = await readBody<CreateAgentProfilePayload>(event)
+    const name = typeof body?.name === 'string' ? body.name.trim() : ''
+
+    if (!name) {
+      throw createError({ statusCode: 400, message: 'name is required.' })
+    }
+    if (name.length > 120) {
+      throw createError({
+        statusCode: 400,
+        message: 'name must be 120 characters or fewer.',
+      })
+    }
+
+    const profile = await prisma.agentProfile.create({
+      data: {
+        userId: auth.user.id,
+        name,
+        avatarImage: optionalString(body.avatarImage, 764, 'avatarImage'),
+        description: optionalString(body.description, 5000, 'description'),
+        isPublic: typeof body.isPublic === 'boolean' ? body.isPublic : true,
+        allowMessages:
+          typeof body.allowMessages === 'boolean' ? body.allowMessages : false,
+      },
+    })
+
+    return { success: true, profile: { ...profile, credentialCount: 0 } }
+  } catch (error) {
+    const { message, statusCode } = errorHandler(error)
+    event.node.res.statusCode = statusCode || 500
+    return { success: false, message: message || 'Failed to create agent profile.' }
+  }
+})

--- a/server/utils/agentCredentials.ts
+++ b/server/utils/agentCredentials.ts
@@ -35,18 +35,26 @@ const SECRET_BYTES = 32
 export type SafeAgentCredential = Omit<
   AgentCredential,
   'hashedSecret' | 'scopes'
-> & { scopes: AgentCredentialScope[] }
+> & {
+  scopes: AgentCredentialScope[]
+  /** Durable external-agent identity, separate from optional legacy Bot binding. */
+  agentProfileId: number | null
+}
 
-export function toSafeCredential(row: AgentCredential): SafeAgentCredential {
+export function toSafeCredential(
+  row: AgentCredential,
+  agentProfileId: number | null = null,
+): SafeAgentCredential {
   const { hashedSecret: _hashedSecret, scopes, ...rest } = row
   void _hashedSecret
 
-  return { ...rest, scopes: sanitizeScopes(scopes) }
+  return { ...rest, scopes: sanitizeScopes(scopes), agentProfileId }
 }
 
 export type CreateAgentCredentialInput = {
   userId: number
   botId?: number | null
+  agentProfileId?: number | null
   label: string
   scopes?: AgentCredentialScope[]
   expiresAt?: Date | null
@@ -59,9 +67,10 @@ export type CreateAgentCredentialResult = {
 }
 
 /**
- * Issue a new credential for a user (optionally scoped to one Bot). Returns
- * the plaintext token exactly once -- the caller must display/copy it now;
- * it cannot be recovered later, only rotated (revoke + create a new one).
+ * Issue a new credential for a user. Legacy callers may bind it to one Bot;
+ * Rainbow's v2 path binds it to one durable AgentProfile instead. A credential
+ * cannot represent both identities at once. Returns the plaintext token exactly
+ * once -- it cannot be recovered later, only rotated.
  */
 export async function createAgentCredential(
   input: CreateAgentCredentialInput,
@@ -69,6 +78,22 @@ export async function createAgentCredential(
   const label = input.label.trim()
   if (!label) {
     throw new Error('label is required')
+  }
+
+  const botId = input.botId ?? null
+  const agentProfileId = input.agentProfileId ?? null
+  if (botId && agentProfileId) {
+    throw new Error('a credential cannot bind both botId and agentProfileId')
+  }
+
+  if (agentProfileId) {
+    const profile = await prisma.agentProfile.findUnique({
+      where: { id: agentProfileId },
+      select: { userId: true, isActive: true },
+    })
+    if (!profile || profile.userId !== input.userId || !profile.isActive) {
+      throw new Error('agentProfileId must reference an active profile you own')
+    }
   }
 
   const scopes =
@@ -84,20 +109,33 @@ export async function createAgentCredential(
   const secret = randomBytes(SECRET_BYTES).toString('hex')
   const hashedSecret = await bcryptHash(secret, SALT_ROUNDS)
 
-  const row = await prisma.agentCredential.create({
-    data: {
-      userId: input.userId,
-      botId: input.botId ?? null,
-      label,
-      keyPrefix,
-      hashedSecret,
-      scopes,
-      expiresAt: input.expiresAt ?? null,
-    },
+  const row = await prisma.$transaction(async (tx) => {
+    const credential = await tx.agentCredential.create({
+      data: {
+        userId: input.userId,
+        botId,
+        label,
+        keyPrefix,
+        hashedSecret,
+        scopes,
+        expiresAt: input.expiresAt ?? null,
+      },
+    })
+
+    if (agentProfileId) {
+      await tx.agentProfileCredential.create({
+        data: {
+          agentProfileId,
+          credentialId: credential.id,
+        },
+      })
+    }
+
+    return credential
   })
 
   return {
-    credential: toSafeCredential(row),
+    credential: toSafeCredential(row, agentProfileId),
     token: `${keyPrefix}.${secret}`,
   }
 }
@@ -110,7 +148,19 @@ export async function listAgentCredentials(
     orderBy: { createdAt: 'desc' },
   })
 
-  return rows.map(toSafeCredential)
+  if (rows.length === 0) return []
+
+  const links = await prisma.agentProfileCredential.findMany({
+    where: { credentialId: { in: rows.map((row) => row.id) } },
+    select: { credentialId: true, agentProfileId: true },
+  })
+  const profileByCredential = new Map(
+    links.map((link) => [link.credentialId, link.agentProfileId]),
+  )
+
+  return rows.map((row) =>
+    toSafeCredential(row, profileByCredential.get(row.id) ?? null),
+  )
 }
 
 export type RevokeResult = 'revoked' | 'not-found' | 'forbidden'
@@ -139,6 +189,7 @@ export type ValidateAgentCredentialResult = {
   credentialId: number
   userId: number
   botId: number | null
+  agentProfileId: number | null
   scopes: AgentCredentialScope[]
 }
 
@@ -167,11 +218,8 @@ export function parseCredentialToken(
 
 /**
  * Resolve a bearer token of the form `<keyPrefix>.<secret>` to the owning
- * user/bot + granted scopes. Returns null for anything invalid, expired, or
- * revoked -- never throws, so a guard can chain this alongside the other
- * auth paths without a try/catch at every call site (matches
- * server/utils/authToken.ts's discriminated-result style, simplified to
- * null since there is no caller-facing reason code needed here).
+ * user + optional Bot/AgentProfile identity + granted scopes. Returns null for
+ * anything invalid, expired, or revoked.
  */
 export async function validateAgentCredential(
   token: string,
@@ -189,15 +237,22 @@ export async function validateAgentCredential(
   const matches = await bcryptCompare(secret, row.hashedSecret)
   if (!matches) return null
 
-  await prisma.agentCredential.update({
-    where: { id: row.id },
-    data: { lastUsedAt: new Date() },
-  })
+  const [profileLink] = await Promise.all([
+    prisma.agentProfileCredential.findUnique({
+      where: { credentialId: row.id },
+      select: { agentProfileId: true },
+    }),
+    prisma.agentCredential.update({
+      where: { id: row.id },
+      data: { lastUsedAt: new Date() },
+    }),
+  ])
 
   return {
     credentialId: row.id,
     userId: row.userId,
     botId: row.botId,
+    agentProfileId: profileLink?.agentProfileId ?? null,
     scopes: sanitizeScopes(row.scopes),
   }
 }

--- a/server/utils/authGuard.ts
+++ b/server/utils/authGuard.ts
@@ -17,8 +17,10 @@ export type AuthGuardResult = {
   scopes?: AgentCredentialScope[]
   /** Only set for kind: 'agent-credential' -- the AgentCredential row's id. */
   credentialId?: number
-  /** Only set for kind: 'agent-credential' when the credential names a Bot. */
+  /** Only set for kind: 'agent-credential' when the credential names a legacy Bot. */
   botId?: number | null
+  /** Only set for kind: 'agent-credential' when the credential names an external AgentProfile. */
+  agentProfileId?: number | null
 }
 
 const config = useRuntimeConfig()
@@ -174,6 +176,7 @@ async function validateAgentCredentialAuth(
     scopes: result.scopes,
     credentialId: result.credentialId,
     botId: result.botId,
+    agentProfileId: result.agentProfileId,
   }
 }
 

--- a/utils/scripts/verifyAgentProfiles.test.ts
+++ b/utils/scripts/verifyAgentProfiles.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const schema = readFileSync('prisma/agent-profile.prisma', 'utf8')
+const migration = readFileSync(
+  'prisma/migrations/20260901063000_add_agent_profile/migration.sql',
+  'utf8',
+)
+const credentials = readFileSync('server/utils/agentCredentials.ts', 'utf8')
+const authGuard = readFileSync('server/utils/authGuard.ts', 'utf8')
+const credentialCreate = readFileSync(
+  'server/api/agent-credentials/index.post.ts',
+  'utf8',
+)
+const profileList = readFileSync('server/api/agent-profiles/index.get.ts', 'utf8')
+const profileCreate = readFileSync('server/api/agent-profiles/index.post.ts', 'utf8')
+const profileGet = readFileSync('server/api/agent-profiles/[id].get.ts', 'utf8')
+const profilePatch = readFileSync('server/api/agent-profiles/[id].patch.ts', 'utf8')
+const profileDelete = readFileSync('server/api/agent-profiles/[id].delete.ts', 'utf8')
+
+assert.match(schema, /model AgentProfile \{/)
+assert.match(schema, /userId\s+Int/)
+assert.match(schema, /name\s+String/)
+assert.match(schema, /avatarImage\s+String\?/)
+assert.match(schema, /description\s+String\?/)
+assert.match(schema, /isPublic\s+Boolean/)
+assert.match(schema, /allowMessages\s+Boolean/)
+assert.match(schema, /isActive\s+Boolean/)
+assert.doesNotMatch(schema, /Bot\s+Bot/)
+
+assert.match(schema, /model AgentProfileCredential \{/)
+assert.match(schema, /credentialId\s+Int\s+@unique/)
+assert.match(schema, /agentProfileId\s+Int/)
+assert.match(migration, /CREATE TABLE `AgentProfile`/)
+assert.match(migration, /CREATE TABLE `AgentProfileCredential`/)
+assert.doesNotMatch(migration, /DROP TABLE|DROP COLUMN/i)
+
+assert.match(credentials, /agentProfileId\?: number \| null/)
+assert.match(credentials, /a credential cannot bind both botId and agentProfileId/)
+assert.match(credentials, /tx\.agentProfileCredential\.create/)
+assert.match(credentials, /agentProfileId: profileLink\?\.agentProfileId \?\? null/)
+assert.match(authGuard, /agentProfileId\?: number \| null/)
+assert.match(authGuard, /agentProfileId: result\.agentProfileId/)
+
+assert.match(credentialCreate, /agentProfileId must reference an active profile you own/)
+assert.match(credentialCreate, /A credential cannot bind both botId and agentProfileId/)
+assert.match(credentialCreate, /botId must reference a Bot you own/)
+
+for (const route of [profileList, profileCreate, profileGet, profilePatch, profileDelete]) {
+  assert.match(route, /requireHumanApiUser/)
+}
+
+assert.match(profileDelete, /isActive: false/)
+assert.match(profileDelete, /tx\.agentCredential\.updateMany/)
+assert.match(profileDelete, /revokedAt/)
+assert.match(profilePatch, /allowMessages/)
+assert.match(profilePatch, /isPublic/)
+
+console.log('Kind Robots AgentProfile contract: OK')


### PR DESCRIPTION
Rainbow Butterflies v2 agent-identity slice. This removes the architectural requirement that an external Rainbow agent be represented by a Kind Robots Bot while preserving existing Bot-bound credentials for compatibility.

## Changes
- adds durable `AgentProfile` identity: human owner scalar, name, avatar, description, public/profile messaging preferences, active state
- keeps AgentProfile separate from `AgentCredential` so credentials can rotate/revoke without erasing identity/history
- adds `AgentProfileCredential` links and surfaces `agentProfileId` through validated scoped credentials
- credential issuance can bind either an owned legacy Bot OR an owned active AgentProfile, never both
- adds human-only AgentProfile create/list/read/update/deactivate APIs
- deactivating an AgentProfile automatically revokes every credential linked to it
- purely additive migration; no existing tables or Bot behavior removed
- adds dedicated Agent Profile contract CI

This intentionally does not yet add heartbeat state, forum activity, messaging records, or generated-object provenance to the profile. Those will reference the stable profile ID in later slices.