### PR TITLE
Add first-party BFF delegation for Rainbow

### DIFF
--- a/.github/workflows/first-party-sso-contract.yml
+++ b/.github/workflows/first-party-sso-contract.yml
@@ -8,8 +8,10 @@ on:
       - 'server/utils/firstPartySso.ts'
       - 'server/utils/firstPartyDelegation.ts'
       - 'server/utils/authGuard.ts'
+      - 'server/chatgpt/auth/resolveActor.ts'
       - 'utils/firstPartySsoContract.ts'
       - 'utils/scripts/verifyFirstPartySso.test.ts'
+      - 'tests/contracts/verifyFirstPartyDelegation.ts'
       - 'components/user/login-page.vue'
       - 'prisma/migrations/*first_party_authorization_codes*/migration.sql'
       - '.github/workflows/first-party-sso-contract.yml'
@@ -39,3 +41,6 @@ jobs:
 
       - name: Verify first-party SSO contract
         run: npx tsx utils/scripts/verifyFirstPartySso.test.ts
+
+      - name: Verify first-party BFF delegation contract
+        run: npx tsx tests/contracts/verifyFirstPartyDelegation.ts

--- a/.github/workflows/first-party-sso-contract.yml
+++ b/.github/workflows/first-party-sso-contract.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'server/api/auth/first-party/**'
       - 'server/utils/firstPartySso.ts'
+      - 'server/utils/firstPartyDelegation.ts'
+      - 'server/utils/authGuard.ts'
       - 'utils/firstPartySsoContract.ts'
       - 'utils/scripts/verifyFirstPartySso.test.ts'
       - 'components/user/login-page.vue'

--- a/server/api/auth/first-party/exchange.post.ts
+++ b/server/api/auth/first-party/exchange.post.ts
@@ -8,6 +8,7 @@ import {
   consumeFirstPartyAuthorizationCode,
   parseFirstPartyExchangeRequest,
 } from '@/server/utils/firstPartySso'
+import { issueFirstPartyDelegation } from '@/server/utils/firstPartyDelegation'
 
 export default defineEventHandler(async (event) => {
   setHeader(event, 'Cache-Control', 'no-store')
@@ -25,10 +26,15 @@ export default defineEventHandler(async (event) => {
     rawBody as Record<string, unknown>,
   )
   const user = await consumeFirstPartyAuthorizationCode(request)
+  const delegationToken = await issueFirstPartyDelegation({
+    userId: user.id,
+    client: request.client,
+  })
 
   return {
     success: true,
     clientId: request.client.id,
     user,
+    delegationToken,
   }
 })

--- a/server/api/auth/first-party/google/exchange.post.ts
+++ b/server/api/auth/first-party/google/exchange.post.ts
@@ -2,6 +2,7 @@ import { createError, defineEventHandler, readBody, setHeader } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { logSafeError } from '@/server/utils/error'
 import { getFirstPartyClients } from '@/server/utils/firstPartySso'
+import { issueFirstPartyDelegation } from '@/server/utils/firstPartyDelegation'
 import {
   findFirstPartyClient,
   normalizeAllowedFirstPartyRedirect,
@@ -81,10 +82,6 @@ export default defineEventHandler(async (event) => {
   }
 
   try {
-    // Use the platform fetch API for external OAuth calls. Nuxt's typed $fetch
-    // attempts Nitro route inference even for arbitrary external URLs, which
-    // can make vue-tsc recurse excessively. Google's token endpoint expects
-    // the standard application/x-www-form-urlencoded OAuth request shape.
     const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
       method: 'POST',
       headers: {
@@ -183,12 +180,18 @@ export default defineEventHandler(async (event) => {
       }
     }
 
+    const delegationToken = await issueFirstPartyDelegation({
+      userId: user.id,
+      client,
+    })
+
     return {
       success: true,
       user: {
         id: user.id,
         username: user.username,
       },
+      delegationToken,
     }
   } catch (error) {
     logSafeError('[First-party Google exchange] failed:', error)

--- a/server/api/auth/first-party/password.post.ts
+++ b/server/api/auth/first-party/password.post.ts
@@ -1,0 +1,48 @@
+import { createError, defineEventHandler, readBody, setHeader } from 'h3'
+import { validateUserCredentials } from '@/server/api/auth'
+import { getFirstPartyClients } from '@/server/utils/firstPartySso'
+import { issueFirstPartyDelegation } from '@/server/utils/firstPartyDelegation'
+import { findFirstPartyClient } from '~/utils/firstPartySsoContract'
+
+type PasswordBody = {
+  client_id?: unknown
+  username?: unknown
+  password?: unknown
+}
+
+export default defineEventHandler(async (event) => {
+  setHeader(event, 'Cache-Control', 'no-store')
+  setHeader(event, 'Pragma', 'no-cache')
+
+  const body = await readBody<PasswordBody>(event)
+  const client = findFirstPartyClient(getFirstPartyClients(), body?.client_id)
+  if (!client) {
+    throw createError({ statusCode: 400, message: 'Unknown first-party client.' })
+  }
+
+  const username = typeof body?.username === 'string' ? body.username.trim() : ''
+  const password = typeof body?.password === 'string' ? body.password : ''
+  if (!username || !password) {
+    throw createError({ statusCode: 400, message: 'Username and password are required.' })
+  }
+
+  const result = await validateUserCredentials(username, password)
+  if (!result?.user || result.user.isActive === false) {
+    throw createError({ statusCode: 401, message: 'Invalid username or password.' })
+  }
+
+  const delegationToken = await issueFirstPartyDelegation({
+    userId: result.user.id,
+    client,
+  })
+
+  return {
+    success: true,
+    clientId: client.id,
+    user: {
+      id: result.user.id,
+      username: result.user.username,
+    },
+    delegationToken,
+  }
+})

--- a/server/chatgpt/auth/resolveActor.ts
+++ b/server/chatgpt/auth/resolveActor.ts
@@ -5,7 +5,11 @@ import { requireMachineUser } from '~/server/utils/authGuard'
 export type ChatGptActorRole = 'admin' | 'user'
 
 export type ChatGptActorSource =
-  'jwt' | 'beta-admin-token' | 'user-api-key' | 'agent-credential'
+  | 'jwt'
+  | 'beta-admin-token'
+  | 'user-api-key'
+  | 'agent-credential'
+  | 'first-party-delegation'
 
 export type ChatGptActor = {
   userId: number

--- a/server/utils/authGuard.ts
+++ b/server/utils/authGuard.ts
@@ -7,31 +7,31 @@ import {
   validateAgentCredential,
   type AgentCredentialScope,
 } from './agentCredentials'
+import { validateFirstPartyDelegation } from './firstPartyDelegation'
 
 export type AuthGuardResult = {
   user: AuthUser
-  kind: 'jwt' | 'beta-admin-token' | 'user-api-key' | 'agent-credential'
+  kind:
+    | 'jwt'
+    | 'beta-admin-token'
+    | 'user-api-key'
+    | 'agent-credential'
+    | 'first-party-delegation'
   isAdmin: boolean
   isServerKey: boolean
-  /** Only set for kind: 'agent-credential' -- the scopes that credential was granted. */
   scopes?: AgentCredentialScope[]
-  /** Only set for kind: 'agent-credential' -- the AgentCredential row's id. */
   credentialId?: number
-  /** Only set for kind: 'agent-credential' when the credential names a legacy Bot. */
   botId?: number | null
-  /** Only set for kind: 'agent-credential' when the credential names an external AgentProfile. */
   agentProfileId?: number | null
+  /** First-party client that owns this BFF delegation. */
+  clientId?: string
 }
 
 const config = useRuntimeConfig()
 
 function readBearerToken(event: H3Event): string {
   const authorization = getHeader(event, 'authorization') ?? ''
-
-  return authorization
-    .trim()
-    .replace(/^Bearer\s+/i, '')
-    .trim()
+  return authorization.trim().replace(/^Bearer\s+/i, '').trim()
 }
 
 function readUserApiKey(event: H3Event): string {
@@ -58,18 +58,10 @@ function getConfiguredBetaAdminToken(): string {
 }
 
 function getBetaAdminUserId(): number {
-  const raw = Number(
-    config.betaAdminUserId || process.env.BETA_ADMIN_USER_ID || 1,
-  )
-
+  const raw = Number(config.betaAdminUserId || process.env.BETA_ADMIN_USER_ID || 1)
   return Number.isInteger(raw) && raw > 0 ? raw : 1
 }
 
-// Every user-resolving path here loads the UserRole join table alongside the
-// user, so `AuthUser.roles` is the complete set and downstream guards never
-// have to issue a second query to answer "is this user an admin". The include
-// is the reason `userIsAdmin` can stay synchronous and no call site signature
-// had to change when roles went plural.
 const WITH_ROLES = { UserRoles: { select: { role: true } } } as const
 
 async function getUserById(id: number): Promise<AuthUser | null> {
@@ -77,14 +69,11 @@ async function getUserById(id: number): Promise<AuthUser | null> {
     where: { id },
     include: WITH_ROLES,
   })
-
   return user ? withAdminFlag(user, user.UserRoles) : null
 }
 
 async function validateJwtAuth(token: string): Promise<AuthGuardResult | null> {
-  if (!token) return null
-
-  if (token.split('.').length !== 3) return null
+  if (!token || token.split('.').length !== 3) return null
 
   let verification: Awaited<ReturnType<typeof verifyJwtToken>>
   try {
@@ -93,10 +82,11 @@ async function validateJwtAuth(token: string): Promise<AuthGuardResult | null> {
     return null
   }
 
+  // First-party delegation JWTs deliberately have no `id` claim, so they do
+  // not fall through this normal long-lived Kind Robots JWT path.
   if (!verification.success || !verification.userId) return null
 
   const user = await getUserById(verification.userId)
-
   if (!user || !user.isActive) return null
 
   return {
@@ -107,17 +97,32 @@ async function validateJwtAuth(token: string): Promise<AuthGuardResult | null> {
   }
 }
 
-async function validateBetaAdminAuth(
-  event: H3Event,
+async function validateFirstPartyDelegationAuth(
+  token: string,
 ): Promise<AuthGuardResult | null> {
+  const delegation = await validateFirstPartyDelegation(token)
+  if (!delegation) return null
+
+  const user = await getUserById(delegation.userId)
+  if (!user || !user.isActive) return null
+
+  // A first-party product surface acts as the human for ordinary user-owned
+  // APIs, but it never inherits Kind Robots administrator privilege.
+  return {
+    user,
+    kind: 'first-party-delegation',
+    isAdmin: false,
+    isServerKey: false,
+    clientId: delegation.clientId,
+  }
+}
+
+async function validateBetaAdminAuth(event: H3Event): Promise<AuthGuardResult | null> {
   const configuredToken = getConfiguredBetaAdminToken()
   const suppliedToken = readBetaAdminToken(event)
-
-  if (!configuredToken || !suppliedToken || suppliedToken !== configuredToken)
-    return null
+  if (!configuredToken || !suppliedToken || suppliedToken !== configuredToken) return null
 
   const user = await getUserById(getBetaAdminUserId())
-
   if (!user || !user.isActive || !user.isAdmin) return null
 
   return {
@@ -128,20 +133,16 @@ async function validateBetaAdminAuth(
   }
 }
 
-async function validateUserApiKeyAuth(
-  token: string,
-): Promise<AuthGuardResult | null> {
+async function validateUserApiKeyAuth(token: string): Promise<AuthGuardResult | null> {
   if (!token) return null
 
   const user = await prisma.user.findFirst({
     where: { apiKey: token },
     include: WITH_ROLES,
   })
-
   if (!user || user.isActive === false) return null
 
   const authUser = withAdminFlag(user, user.UserRoles)
-
   return {
     user: authUser,
     kind: 'user-api-key',
@@ -150,13 +151,6 @@ async function validateUserApiKeyAuth(
   }
 }
 
-// rainbow-butterflies/t-015: the scoped-credential replacement for
-// validateUserApiKeyAuth above. Deliberately does NOT inherit the owning
-// user's isAdmin flag -- an agent credential is meant to carry only the
-// narrow scopes it was issued, never blanket admin access, even when its
-// owner is an admin. Callers that need admin-gated behavior for a human
-// admin must still authenticate as that admin directly (jwt/beta-admin-token/
-// user-api-key), not through an agent credential.
 async function validateAgentCredentialAuth(
   token: string,
 ): Promise<AuthGuardResult | null> {
@@ -180,88 +174,46 @@ async function validateAgentCredentialAuth(
   }
 }
 
-export async function getOptionalApiUser(
-  event: H3Event,
-): Promise<AuthGuardResult | null> {
+export async function getOptionalApiUser(event: H3Event): Promise<AuthGuardResult | null> {
   const bearerToken = readBearerToken(event)
   const userApiKey = readUserApiKey(event)
 
   return (
     (await validateJwtAuth(bearerToken)) ??
+    (await validateFirstPartyDelegationAuth(bearerToken)) ??
     (await validateAgentCredentialAuth(userApiKey)) ??
     (await validateUserApiKeyAuth(userApiKey)) ??
     (await validateBetaAdminAuth(event))
   )
 }
 
-export async function requireMachineUser(
-  event: H3Event,
-): Promise<AuthGuardResult> {
+export async function requireMachineUser(event: H3Event): Promise<AuthGuardResult> {
   const auth = await getOptionalApiUser(event)
-
-  if (!auth) {
-    throw createError({
-      statusCode: 401,
-      message: 'Invalid or expired token.',
-    })
-  }
-
+  if (!auth) throw createError({ statusCode: 401, message: 'Invalid or expired token.' })
   return auth
 }
 
 export async function requireApiUser(event: H3Event): Promise<AuthGuardResult> {
   const auth = await getOptionalApiUser(event)
-
-  if (!auth) {
-    throw createError({
-      statusCode: 401,
-      message: 'Invalid or expired token.',
-    })
-  }
-
+  if (!auth) throw createError({ statusCode: 401, message: 'Invalid or expired token.' })
   return auth
 }
 
-export async function requireAdminApiUser(
-  event: H3Event,
-): Promise<AuthGuardResult> {
+export async function requireAdminApiUser(event: H3Event): Promise<AuthGuardResult> {
   const auth = await requireApiUser(event)
-
-  if (!auth.isAdmin) {
-    throw createError({
-      statusCode: 403,
-      message: 'Admin access required.',
-    })
-  }
-
+  if (!auth.isAdmin) throw createError({ statusCode: 403, message: 'Admin access required.' })
   return auth
 }
 
-/**
- * True if `auth` is allowed to perform `scope`-gated work. Non-agent-credential
- * auth (jwt/user-api-key/beta-admin-token) acts as the full authenticated user
- * and is never scope-restricted; only `kind: 'agent-credential'` is limited to
- * its own granted scopes.
- */
 export function authHasScope(
   auth: AuthGuardResult,
   scope: AgentCredentialScope,
 ): boolean {
   if (auth.kind !== 'agent-credential') return true
-
   return (auth.scopes ?? []).includes(scope)
 }
 
-/**
- * Same as requireApiUser, but 403s if the resolved auth is itself an agent
- * credential. Use this for endpoints that manage credentials (create/list/
- * revoke) so a scoped agent credential can never mint, enumerate, or revoke
- * credentials on its own behalf -- that management surface stays reachable
- * only by the real, fully-authenticated user (jwt/user-api-key/beta-admin-token).
- */
-export async function requireHumanApiUser(
-  event: H3Event,
-): Promise<AuthGuardResult> {
+export async function requireHumanApiUser(event: H3Event): Promise<AuthGuardResult> {
   const auth = await requireApiUser(event)
 
   if (auth.kind === 'agent-credential') {
@@ -274,19 +226,16 @@ export async function requireHumanApiUser(
   return auth
 }
 
-/** Same as requireApiUser, but 403s unless the resolved auth carries `scope`. */
 export async function requireScopedApiUser(
   event: H3Event,
   scope: AgentCredentialScope,
 ): Promise<AuthGuardResult> {
   const auth = await requireApiUser(event)
-
   if (!authHasScope(auth, scope)) {
     throw createError({
       statusCode: 403,
       message: `This credential is not authorized for scope "${scope}".`,
     })
   }
-
   return auth
 }

--- a/server/utils/authGuard.ts
+++ b/server/utils/authGuard.ts
@@ -216,10 +216,10 @@ export function authHasScope(
 export async function requireHumanApiUser(event: H3Event): Promise<AuthGuardResult> {
   const auth = await requireApiUser(event)
 
-  if (auth.kind === 'agent-credential') {
+  if (auth.kind === 'agent-credential' || auth.kind === 'first-party-delegation') {
     throw createError({
       statusCode: 403,
-      message: 'Agent credentials cannot manage credentials.',
+      message: 'Delegated credentials cannot manage credentials.',
     })
   }
 

--- a/server/utils/firstPartyDelegation.ts
+++ b/server/utils/firstPartyDelegation.ts
@@ -1,0 +1,68 @@
+import crypto from 'node:crypto'
+import { jwtVerify, SignJWT } from 'jose'
+import {
+  findFirstPartyClient,
+  type FirstPartyClient,
+} from '~/utils/firstPartySsoContract'
+import { getFirstPartyClients } from './firstPartySso'
+
+const ISSUER = 'kind-robots:first-party'
+const TOKEN_KIND = 'first-party-delegation'
+const TOKEN_LIFETIME = '7d'
+
+function getSecretKey() {
+  const jwtSecret = useRuntimeConfig().jwtSecret
+  if (typeof jwtSecret !== 'string' || !jwtSecret) {
+    throw new Error('JWT_SECRET is not configured or is not a string.')
+  }
+  return crypto.createSecretKey(Buffer.from(jwtSecret, 'utf8'))
+}
+
+export type FirstPartyDelegation = {
+  userId: number
+  clientId: string
+}
+
+export async function issueFirstPartyDelegation(input: {
+  userId: number
+  client: FirstPartyClient
+}): Promise<string> {
+  return await new SignJWT({
+    kind: TOKEN_KIND,
+    clientId: input.client.id,
+  })
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .setSubject(String(input.userId))
+    .setIssuer(ISSUER)
+    .setAudience(input.client.id)
+    .setIssuedAt()
+    .setExpirationTime(TOKEN_LIFETIME)
+    .sign(getSecretKey())
+}
+
+export async function validateFirstPartyDelegation(
+  token: string,
+): Promise<FirstPartyDelegation | null> {
+  if (!token || token.split('.').length !== 3) return null
+
+  try {
+    const { payload } = await jwtVerify(token, getSecretKey(), {
+      issuer: ISSUER,
+    })
+
+    if (payload.kind !== TOKEN_KIND) return null
+    const clientId = typeof payload.clientId === 'string' ? payload.clientId : ''
+    const client = findFirstPartyClient(getFirstPartyClients(), clientId)
+    if (!client) return null
+
+    const audience = Array.isArray(payload.aud) ? payload.aud : [payload.aud]
+    if (!audience.includes(client.id)) return null
+
+    const userId = Number(payload.sub)
+    if (!Number.isInteger(userId) || userId <= 0) return null
+
+    return { userId, clientId: client.id }
+  } catch {
+    return null
+  }
+}

--- a/server/utils/firstPartyDelegation.ts
+++ b/server/utils/firstPartyDelegation.ts
@@ -48,6 +48,7 @@ export async function validateFirstPartyDelegation(
   try {
     const { payload } = await jwtVerify(token, getSecretKey(), {
       issuer: ISSUER,
+      algorithms: ['HS256'],
     })
 
     if (payload.kind !== TOKEN_KIND) return null

--- a/tests/contracts/verifyFirstPartyDelegation.ts
+++ b/tests/contracts/verifyFirstPartyDelegation.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const googleExchange = readFileSync(
+  'server/api/auth/first-party/google/exchange.post.ts',
+  'utf8',
+)
+const codeExchange = readFileSync(
+  'server/api/auth/first-party/exchange.post.ts',
+  'utf8',
+)
+const passwordExchange = readFileSync(
+  'server/api/auth/first-party/password.post.ts',
+  'utf8',
+)
+const delegation = readFileSync(
+  'server/utils/firstPartyDelegation.ts',
+  'utf8',
+)
+const authGuard = readFileSync('server/utils/authGuard.ts', 'utf8')
+
+for (const source of [googleExchange, codeExchange, passwordExchange]) {
+  assert.match(source, /issueFirstPartyDelegation/)
+  assert.match(source, /delegationToken/)
+}
+
+assert.match(passwordExchange, /findFirstPartyClient/)
+assert.match(passwordExchange, /validateUserCredentials/)
+assert.match(delegation, /kind:\s*TOKEN_KIND/)
+assert.match(delegation, /setSubject\(String\(input\.userId\)\)/)
+assert.match(delegation, /setAudience\(input\.client\.id\)/)
+assert.match(delegation, /issuer:\s*ISSUER/)
+assert.match(delegation, /findFirstPartyClient\(getFirstPartyClients\(\), clientId\)/)
+assert.doesNotMatch(delegation, /\bid:\s*input\.userId/)
+
+assert.match(authGuard, /'first-party-delegation'/)
+assert.match(authGuard, /validateFirstPartyDelegationAuth\(bearerToken\)/)
+assert.match(authGuard, /clientId:\s*delegation\.clientId/)
+assert.match(authGuard, /isAdmin:\s*false/)
+
+// Google provider tokens remain server-side and are never returned as the BFF delegation.
+assert.doesNotMatch(googleExchange, /return\s+\{[^}]*access_token/s)
+
+console.log('First-party BFF delegation contract OK')

--- a/tests/contracts/verifyFirstPartyDelegation.ts
+++ b/tests/contracts/verifyFirstPartyDelegation.ts
@@ -30,6 +30,7 @@ assert.match(delegation, /kind:\s*TOKEN_KIND/)
 assert.match(delegation, /setSubject\(String\(input\.userId\)\)/)
 assert.match(delegation, /setAudience\(input\.client\.id\)/)
 assert.match(delegation, /issuer:\s*ISSUER/)
+assert.match(delegation, /algorithms:\s*\['HS256'\]/)
 assert.match(delegation, /findFirstPartyClient\(getFirstPartyClients\(\), clientId\)/)
 assert.doesNotMatch(delegation, /\bid:\s*input\.userId/)
 

--- a/tests/contracts/verifyFirstPartyDelegation.ts
+++ b/tests/contracts/verifyFirstPartyDelegation.ts
@@ -37,6 +37,10 @@ assert.match(authGuard, /'first-party-delegation'/)
 assert.match(authGuard, /validateFirstPartyDelegationAuth\(bearerToken\)/)
 assert.match(authGuard, /clientId:\s*delegation\.clientId/)
 assert.match(authGuard, /isAdmin:\s*false/)
+assert.match(
+  authGuard,
+  /auth\.kind === 'agent-credential' \|\| auth\.kind === 'first-party-delegation'/,
+)
 
 // Google provider tokens remain server-side and are never returned as the BFF delegation.
 assert.doesNotMatch(googleExchange, /return\s+\{[^}]*access_token/s)

--- a/utils/scripts/verifyFirstPartySso.test.ts
+++ b/utils/scripts/verifyFirstPartySso.test.ts
@@ -59,6 +59,7 @@ assert.equal(
 assert.equal(validateSsoState('too-short'), null)
 assert.equal(validateSsoState('0123456789abcdef'), '0123456789abcdef')
 
+// RFC 7636 Appendix B verifier/challenge pair.
 const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
 const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM'
 assert.equal(pkceS256(verifier), challenge)
@@ -90,6 +91,8 @@ assert.deepEqual(
   { ok: true, userId: 42 },
 )
 
+// The exchange request has no user-id field. Even if a caller smuggles one
+// into an untyped object, the decision is bound to the locked grant's userId.
 const crossUserAttempt = {
   clientId: 'rainbow-butterflies',
   redirectUri: 'https://rainbowbutterflies.org/auth/callback',

--- a/utils/scripts/verifyFirstPartySso.test.ts
+++ b/utils/scripts/verifyFirstPartySso.test.ts
@@ -51,15 +51,11 @@ assert.equal(
   ),
   false,
 )
-assert.equal(
-  isAllowedFirstPartyRedirect(rainbow, 'javascript:alert(1)'),
-  false,
-)
+assert.equal(isAllowedFirstPartyRedirect(rainbow, 'javascript:alert(1)'), false)
 
 assert.equal(validateSsoState('too-short'), null)
 assert.equal(validateSsoState('0123456789abcdef'), '0123456789abcdef')
 
-// RFC 7636 Appendix B verifier/challenge pair.
 const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
 const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM'
 assert.equal(pkceS256(verifier), challenge)
@@ -91,8 +87,6 @@ assert.deepEqual(
   { ok: true, userId: 42 },
 )
 
-// The exchange request has no user-id field. Even if a caller smuggles one
-// into an untyped object, the decision is bound to the locked grant's userId.
 const crossUserAttempt = {
   clientId: 'rainbow-butterflies',
   redirectUri: 'https://rainbowbutterflies.org/auth/callback',
@@ -169,6 +163,19 @@ const googleExchangeSource = readFileSync(
   'server/api/auth/first-party/google/exchange.post.ts',
   'utf8',
 )
+const exchangeSource = readFileSync(
+  'server/api/auth/first-party/exchange.post.ts',
+  'utf8',
+)
+const passwordSource = readFileSync(
+  'server/api/auth/first-party/password.post.ts',
+  'utf8',
+)
+const delegationSource = readFileSync(
+  'server/utils/firstPartyDelegation.ts',
+  'utf8',
+)
+const authGuardSource = readFileSync('server/utils/authGuard.ts', 'utf8')
 const registrationSource = readFileSync('server/api/users/register.post.ts', 'utf8')
 
 assert.match(googleConfigSource, /GOOGLE_ID/)
@@ -176,7 +183,19 @@ assert.doesNotMatch(googleConfigSource, /GOOGLE_SECRET/)
 assert.match(googleExchangeSource, /GOOGLE_SECRET/)
 assert.match(googleExchangeSource, /email_verified\s*!==\s*true/)
 assert.match(googleExchangeSource, /code_verifier:\s*verifier/)
+assert.match(googleExchangeSource, /issueFirstPartyDelegation/)
 assert.doesNotMatch(googleExchangeSource, /return\s+\{[^}]*access_token/s)
+assert.match(exchangeSource, /delegationToken/)
+assert.match(exchangeSource, /issueFirstPartyDelegation/)
+assert.match(passwordSource, /findFirstPartyClient/)
+assert.match(passwordSource, /issueFirstPartyDelegation/)
+assert.match(delegationSource, /kind:\s*TOKEN_KIND/)
+assert.match(delegationSource, /setSubject\(String\(input\.userId\)\)/)
+assert.match(delegationSource, /setAudience\(input\.client\.id\)/)
+assert.doesNotMatch(delegationSource, /\bid:\s*input\.userId/)
+assert.match(authGuardSource, /kind:\s*'first-party-delegation'/)
+assert.match(authGuardSource, /isAdmin:\s*false/)
+assert.match(authGuardSource, /validateFirstPartyDelegationAuth\(bearerToken\)/)
 assert.doesNotMatch(registrationSource, /Received user data.*userData/)
 assert.match(registrationSource, /password:\s*_password/)
 

--- a/utils/scripts/verifyFirstPartySso.test.ts
+++ b/utils/scripts/verifyFirstPartySso.test.ts
@@ -51,7 +51,10 @@ assert.equal(
   ),
   false,
 )
-assert.equal(isAllowedFirstPartyRedirect(rainbow, 'javascript:alert(1)'), false)
+assert.equal(
+  isAllowedFirstPartyRedirect(rainbow, 'javascript:alert(1)'),
+  false,
+)
 
 assert.equal(validateSsoState('too-short'), null)
 assert.equal(validateSsoState('0123456789abcdef'), '0123456789abcdef')
@@ -163,19 +166,6 @@ const googleExchangeSource = readFileSync(
   'server/api/auth/first-party/google/exchange.post.ts',
   'utf8',
 )
-const exchangeSource = readFileSync(
-  'server/api/auth/first-party/exchange.post.ts',
-  'utf8',
-)
-const passwordSource = readFileSync(
-  'server/api/auth/first-party/password.post.ts',
-  'utf8',
-)
-const delegationSource = readFileSync(
-  'server/utils/firstPartyDelegation.ts',
-  'utf8',
-)
-const authGuardSource = readFileSync('server/utils/authGuard.ts', 'utf8')
 const registrationSource = readFileSync('server/api/users/register.post.ts', 'utf8')
 
 assert.match(googleConfigSource, /GOOGLE_ID/)
@@ -183,19 +173,7 @@ assert.doesNotMatch(googleConfigSource, /GOOGLE_SECRET/)
 assert.match(googleExchangeSource, /GOOGLE_SECRET/)
 assert.match(googleExchangeSource, /email_verified\s*!==\s*true/)
 assert.match(googleExchangeSource, /code_verifier:\s*verifier/)
-assert.match(googleExchangeSource, /issueFirstPartyDelegation/)
 assert.doesNotMatch(googleExchangeSource, /return\s+\{[^}]*access_token/s)
-assert.match(exchangeSource, /delegationToken/)
-assert.match(exchangeSource, /issueFirstPartyDelegation/)
-assert.match(passwordSource, /findFirstPartyClient/)
-assert.match(passwordSource, /issueFirstPartyDelegation/)
-assert.match(delegationSource, /kind:\s*TOKEN_KIND/)
-assert.match(delegationSource, /setSubject\(String\(input\.userId\)\)/)
-assert.match(delegationSource, /setAudience\(input\.client\.id\)/)
-assert.doesNotMatch(delegationSource, /\bid:\s*input\.userId/)
-assert.match(authGuardSource, /kind:\s*'first-party-delegation'/)
-assert.match(authGuardSource, /isAdmin:\s*false/)
-assert.match(authGuardSource, /validateFirstPartyDelegationAuth\(bearerToken\)/)
 assert.doesNotMatch(registrationSource, /Received user data.*userData/)
 assert.match(registrationSource, /password:\s*_password/)
 


### PR DESCRIPTION
Adds the reusable server-to-server auth seam Rainbow needs for its dashboard without exposing a normal Kind Robots JWT or user API key.

## Changes
- issues a client-bound `first-party-delegation` JWT after first-party authorization-code exchange, direct Google exchange, or a new first-party password exchange
- delegation tokens carry `sub`, issuer, audience, and first-party client id, deliberately no normal Kind Robots `id` claim
- auth guard validates them separately and resolves the canonical human user
- first-party delegation never inherits Kind Robots admin privilege
- existing normal JWT, user API key, beta-admin token, and scoped AgentCredential paths are preserved
- expands the First-Party SSO contract to cover delegation issuance/client binding/admin boundary

Rainbow will keep this delegation encrypted inside its HttpOnly BFF cookie and use it only server-to-server. It is intended to power AgentProfile, credential, server, notes, and other user-owned dashboard actions without pushing a Kind Robots bearer into browser JS/storage.