### PR TITLE
model-builder: cap batch item-update items array server-side

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -506,6 +506,12 @@ jobs:
       - name: Model Builder run-create items-cap guard contract
         run: npm run test:model-builder-run-create-items-cap-guard
 
+      - name: Model Builder batch items-cap guard checker self-test
+        run: npm run test:model-builder-batch-items-cap-guard-selftest
+
+      - name: Model Builder batch items-cap guard contract
+        run: npm run test:model-builder-batch-items-cap-guard
+
       - name: Model Builder async poll-failure guard checker self-test
         run: npm run test:model-builder-async-poll-failure-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -273,6 +273,8 @@
     "test:model-builder-run-create-text-cap-guard": "tsx utils/scripts/verifyModelBuilderRunCreateTextCapGuard.ts",
     "test:model-builder-run-create-items-cap-guard-selftest": "tsx utils/scripts/verifyModelBuilderRunCreateItemsCapGuard.test.ts",
     "test:model-builder-run-create-items-cap-guard": "tsx utils/scripts/verifyModelBuilderRunCreateItemsCapGuard.ts",
+    "test:model-builder-batch-items-cap-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchItemsCapGuard.test.ts",
+    "test:model-builder-batch-items-cap-guard": "tsx utils/scripts/verifyModelBuilderBatchItemsCapGuard.ts",
     "test:model-builder-async-poll-failure-guard-selftest": "tsx utils/scripts/verifyModelBuilderAsyncPollFailureGuard.test.ts",
     "test:model-builder-async-poll-failure-guard": "tsx utils/scripts/verifyModelBuilderAsyncPollFailureGuard.ts",
     "test:art-queue-poll-failure-guard-selftest": "tsx utils/scripts/verifyArtQueuePollFailureGuard.test.ts",

--- a/server/api/model-builder/items/batch.patch.ts
+++ b/server/api/model-builder/items/batch.patch.ts
@@ -14,6 +14,7 @@ import {
   assertContentStageEditable,
   assertRunAccess,
   assertRunWritable,
+  MAX_BATCH_ITEMS,
   mergeStageStatusChanges,
   prepareItemUpdate,
   type ItemPatchBody,
@@ -49,6 +50,20 @@ export default defineEventHandler(async (event) => {
       throw createError({
         statusCode: 400,
         message: 'Request body must include a non-empty "items" array.',
+      })
+    }
+
+    // Mirrors runs/index.post.ts's identical cap (model-builder/t-029, cycle
+    // 73) -- the client never sends more than one run's worth of items
+    // (bounded by MAX_BATCH at run creation), but a direct API call bypasses
+    // that entirely. Without this, an oversized `items` array here forces
+    // this route's per-entry sequential findUnique + attachability checks,
+    // plus the single all-or-nothing transaction, over an unbounded amount
+    // of work in one request.
+    if (body.items.length > MAX_BATCH_ITEMS) {
+      throw createError({
+        statusCode: 400,
+        message: `A batch request may include at most ${MAX_BATCH_ITEMS} items.`,
       })
     }
 

--- a/utils/scripts/verifyModelBuilderBatchItemsCapGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderBatchItemsCapGuard.test.ts
@@ -1,0 +1,88 @@
+// /utils/scripts/verifyModelBuilderBatchItemsCapGuard.test.ts
+//
+// Regression test for verifyModelBuilderBatchItemsCapGuard.ts
+// (model-builder/t-029, cycle 74). Exercises the real checks against
+// synthetic items/batch.patch.ts fixtures covering: the pre-fix buggy shape
+// (no cap at all), the fixed shape (capped against MAX_BATCH_ITEMS), and a
+// shape that imports the constant but never actually checks against it.
+import assert from 'node:assert/strict'
+
+import { findBatchItemsCapProblems } from './verifyModelBuilderBatchItemsCapGuard.js'
+
+const FIXED = `
+import {
+  assertContentStageEditable,
+  assertRunAccess,
+  assertRunWritable,
+  MAX_BATCH_ITEMS,
+  mergeStageStatusChanges,
+  prepareItemUpdate,
+  type ItemPatchBody,
+} from '../runs/index'
+
+    if (!body || !Array.isArray(body.items) || body.items.length === 0) {
+      throw createError({ statusCode: 400, message: 'Request body must include a non-empty "items" array.' })
+    }
+    if (body.items.length > MAX_BATCH_ITEMS) {
+      throw createError({ statusCode: 400, message: 'too many items' })
+    }
+`
+
+const PRE_FIX = `
+import {
+  assertContentStageEditable,
+  assertRunAccess,
+  assertRunWritable,
+  mergeStageStatusChanges,
+  prepareItemUpdate,
+  type ItemPatchBody,
+} from '../runs/index'
+
+    if (!body || !Array.isArray(body.items) || body.items.length === 0) {
+      throw createError({ statusCode: 400, message: 'Request body must include a non-empty "items" array.' })
+    }
+`
+
+const IMPORTED_BUT_UNUSED = `
+import {
+  assertContentStageEditable,
+  assertRunAccess,
+  assertRunWritable,
+  MAX_BATCH_ITEMS,
+  mergeStageStatusChanges,
+  prepareItemUpdate,
+  type ItemPatchBody,
+} from '../runs/index'
+
+    if (!body || !Array.isArray(body.items) || body.items.length === 0) {
+      throw createError({ statusCode: 400, message: 'Request body must include a non-empty "items" array.' })
+    }
+`
+
+// --- findBatchItemsCapProblems: fixed shape reports nothing -----------------
+
+assert.deepEqual(
+  findBatchItemsCapProblems(FIXED),
+  [],
+  'the fixed shape (imported and checked) should report no problems',
+)
+
+// --- findBatchItemsCapProblems: pre-fix shape reports both problems --------
+
+assert.deepEqual(
+  findBatchItemsCapProblems(PRE_FIX),
+  [{ reason: 'missing-import' }, { reason: 'missing-length-check' }],
+  'the pre-fix shape (no import, no check) should report both problems',
+)
+
+// --- findBatchItemsCapProblems: imported but never checked -----------------
+
+assert.deepEqual(
+  findBatchItemsCapProblems(IMPORTED_BUT_UNUSED),
+  [{ reason: 'missing-length-check' }],
+  'importing the constant without checking against it should still fail',
+)
+
+console.log(
+  'verifyModelBuilderBatchItemsCapGuard.test.ts: all assertions passed.',
+)

--- a/utils/scripts/verifyModelBuilderBatchItemsCapGuard.ts
+++ b/utils/scripts/verifyModelBuilderBatchItemsCapGuard.ts
@@ -1,0 +1,84 @@
+// /utils/scripts/verifyModelBuilderBatchItemsCapGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 74). Cycle 73 capped
+// runs/index.post.ts's (the build-run CREATE route) `items` array against
+// MAX_BATCH_ITEMS, but left items/batch.patch.ts (the batch item-update
+// route added by t-030) unaudited for the identical gap. The client-side
+// caller (batchPushItems in stores/modelBuilderStore.ts) only ever sends one
+// run's worth of items, itself bounded by MAX_BATCH at run creation -- but a
+// direct API call bypasses that entirely. Without a server-side cap, an
+// oversized `items` array here forces this route's per-entry sequential
+// findUnique + assertArtImageAttachable checks, plus the single
+// all-or-nothing transaction, over an unbounded amount of work in one
+// request -- the same shape of gap cycle 73 fixed for the CREATE route.
+//
+// This walks items/batch.patch.ts and fails if: the file no longer imports
+// MAX_BATCH_ITEMS from ../runs/index, or the length check against it is
+// missing.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const ITEMS_BATCH_PATCH_PATH = join(
+  repositoryRoot,
+  'server/api/model-builder/items/batch.patch.ts',
+)
+
+export interface BatchItemsCapProblem {
+  reason: 'missing-import' | 'missing-length-check'
+}
+
+export function findBatchItemsCapProblems(
+  sourceContent: string,
+): BatchItemsCapProblem[] {
+  const problems: BatchItemsCapProblem[] = []
+
+  const importsConstant =
+    /import\s*\{[^}]*\bMAX_BATCH_ITEMS\b[^}]*\}\s*from\s*['"]\.\.\/runs\/index['"]/.test(
+      sourceContent,
+    )
+  if (!importsConstant) {
+    problems.push({ reason: 'missing-import' })
+  }
+
+  const hasLengthCheck = /body\.items\.length\s*>\s*MAX_BATCH_ITEMS/.test(
+    sourceContent,
+  )
+  if (!hasLengthCheck) {
+    problems.push({ reason: 'missing-length-check' })
+  }
+
+  return problems
+}
+
+function main(): void {
+  const sourceContent = readFileSync(ITEMS_BATCH_PATCH_PATH, 'utf8')
+  const problems = findBatchItemsCapProblems(sourceContent)
+
+  if (problems.length) {
+    console.error(
+      `Model Builder batch-items-cap contract failed: items/batch.patch.ts ` +
+        'is missing its server-side cap on `items.length` against ' +
+        'MAX_BATCH_ITEMS -- an oversized `items` array from a direct API ' +
+        'call would force unbounded sequential per-entry work instead of a ' +
+        'clean 400:',
+    )
+    for (const problem of problems) {
+      console.error(`- ${problem.reason}`)
+    }
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder batch-items-cap contract passed: items/batch.patch.ts ' +
+      'caps `items.length` against MAX_BATCH_ITEMS.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Bug

`server/api/model-builder/items/batch.patch.ts` (the batch item-update route added by t-030) accepted an unbounded `items` array with no server-side upper bound — unlike its sibling run-CREATE route (`runs/index.post.ts`), which cycle 73 of model-builder/t-029 capped against the exported `MAX_BATCH_ITEMS` constant (12).

The client-side caller (`batchPushItems` in `stores/modelBuilderStore.ts`) never sends more than one run's worth of items, itself bounded by `MAX_BATCH` at run creation — but a direct API call bypasses that entirely. An oversized `items` array here would force this route's per-entry sequential `findUnique` + `assertArtImageAttachable` checks, plus its single all-or-nothing transaction, over an unbounded amount of work in one request instead of a clean 400.

## Fix

Imported the existing `MAX_BATCH_ITEMS` constant from `runs/index.ts` and rejected an oversized `items` array with a 400, mirroring `runs/index.post.ts`'s identical guard exactly (same constant, same shape).

Added `verifyModelBuilderBatchItemsCapGuard.ts` + `.test.ts` (narrow textual checker, this recurring task's established convention), wired into `package.json` and `contract-tests.yml`.

## Verification

- New guard fails against the pre-fix file / passes against the fixed file (confirmed via a `git stash` round-trip against the real route file)
- All 153 `test:model-builder-*` npm scripts pass (checked via exit code)
- `eslint` clean on all 5 changed/added files
- `prettier --check` clean on all 5 changed/added files
- `vue-tsc --noEmit` repo-wide: exit 0, zero errors
- `git status --porcelain` scoped to exactly the 5 intended files (reverted an incidental `prisma generate` regen diff before committing)

model-builder/t-029 cycle 74 (Conductor coordination repo — recurring polish/bugfix task on the Model Builder front-end/server surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGEf1YxArfWqwQZbw6QEFx)_