### PR TITLE
Migrate project front page stat pill to kr-panel-flat

### DIFF
--- a/components/conductor/project-front-page.vue
+++ b/components/conductor/project-front-page.vue
@@ -94,7 +94,7 @@
           <div
             v-for="stat in view.stats"
             :key="stat.label"
-            class="flex items-center gap-2 rounded-2xl border border-base-300 bg-base-100/70 px-3 py-1.5 backdrop-blur"
+            class="flex items-center gap-2 kr-panel-flat bg-base-100/70 px-3 py-1.5 backdrop-blur"
           >
             <Icon
               v-if="stat.icon"


### PR DESCRIPTION
## What changed

One line in `components/conductor/project-front-page.vue` (hero stat strip pill, line ~97):

```diff
-class="flex items-center gap-2 rounded-2xl border border-base-300 bg-base-100/70 px-3 py-1.5 backdrop-blur"
+class="flex items-center gap-2 kr-panel-flat bg-base-100/70 px-3 py-1.5 backdrop-blur"
```

## Why

`interface-vision/t-104` — drive live front-end consistency onto shared `kr-*` components and composition rules. The pill hand-rolled the exact surface `kr-panel-flat` already owns (`rounded-2xl border border-base-300 bg-base-100`, `assets/css/tailwind.css:537`), so it now composes the shared utility instead.

## What was preserved

Only genuine overrides remain alongside the utility:

- `bg-base-100/70` — the translucent background override (needed over the hero image)
- `px-3 py-1.5` — the pill's own padding (`kr-panel-flat` ships none)
- `backdrop-blur` — the frosted effect

Rendered output is unchanged: `bg-base-100/70` sits in Tailwind's utilities layer and wins over the components-layer `bg-base-100` baked into `kr-panel-flat`. This is the same override pattern prior slices of this task used — e.g. `components/dreams/dream-sheet-toolbar.vue:3` (`kr-panel-flat bg-base-100/90 p-3 shadow-sm backdrop-blur`) and `components/pages/mermaids-page.vue:6`.

## Out of scope (deliberately untouched)

- `components/conductor/project-front-page.vue:79` — the sibling links element is `btn btn-ghost ... bg-base-100/60`, a button, not a panel surface.
- `components/user/chat-gallery.vue:21,48` — same shape but also `btn btn-ghost` buttons.

A repo-wide grep for `rounded-(2xl|3xl) border border-base-300 bg-base-100/<opacity>` (non-button) returns no other un-migrated candidates, so this slice is the single remaining instance of that surface shape.

## Verification

- `npx eslint components/conductor/project-front-page.vue` — clean, no output.
- `npx vue-tsc --noEmit` (repo-wide) — clean. Note: this required `prisma generate` first; the checked-in `prisma/generated/` output on `main` is stale relative to `prisma/schema.prisma` (missing `AgentProfile`/`AgentProfileCredential`), which produces ~16 pre-existing `TS2551 Property 'agentProfile' does not exist` errors in `server/api/agent-profiles/*` and `server/utils/agentCredentials.ts` on unmodified `main`. Verified identical before and after this change via `git stash`; unrelated to this diff, and the regenerated client was reverted so it is not part of this PR.
- `npm run test:layout-contract` — "Layout contract holds — no new violations." Baseline unchanged (207 grid-cols breakpoint findings, all `(unchanged)`).
- `git diff` scoped to exactly one file, one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5kTDEUsstH9H7ctTJGY6x

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5kTDEUsstH9H7ctTJGY6x)_