### PR TITLE
Allow Rainbow BFF delegation through human-owned API guard

### DIFF
--- a/server/utils/authGuard.ts
+++ b/server/utils/authGuard.ts
@@ -213,13 +213,19 @@ export function authHasScope(
   return (auth.scopes ?? []).includes(scope)
 }
 
+/**
+ * Require a human-owned auth context. A first-party BFF delegation is allowed:
+ * Rainbow is acting on behalf of the signed-in human and remains non-admin.
+ * Machine AgentCredentials are not allowed to create, rotate, revoke, or
+ * otherwise manage human-owned credentials/profile administration.
+ */
 export async function requireHumanApiUser(event: H3Event): Promise<AuthGuardResult> {
   const auth = await requireApiUser(event)
 
-  if (auth.kind === 'agent-credential' || auth.kind === 'first-party-delegation') {
+  if (auth.kind === 'agent-credential') {
     throw createError({
       statusCode: 403,
-      message: 'Delegated credentials cannot manage credentials.',
+      message: 'Agent credentials cannot manage human-owned credentials or profiles.',
     })
   }
 

--- a/tests/contracts/verifyFirstPartyDelegation.ts
+++ b/tests/contracts/verifyFirstPartyDelegation.ts
@@ -38,10 +38,13 @@ assert.match(authGuard, /'first-party-delegation'/)
 assert.match(authGuard, /validateFirstPartyDelegationAuth\(bearerToken\)/)
 assert.match(authGuard, /clientId:\s*delegation\.clientId/)
 assert.match(authGuard, /isAdmin:\s*false/)
-assert.match(
-  authGuard,
-  /auth\.kind === 'agent-credential' \|\| auth\.kind === 'first-party-delegation'/,
-)
+
+const humanGuard = authGuard.match(
+  /export async function requireHumanApiUser[\s\S]*?\n}\n\nexport async function requireScopedApiUser/,
+)?.[0]
+assert.ok(humanGuard, 'requireHumanApiUser contract was not found')
+assert.match(humanGuard, /auth\.kind === 'agent-credential'/)
+assert.doesNotMatch(humanGuard, /auth\.kind === 'first-party-delegation'/)
 
 // Google provider tokens remain server-side and are never returned as the BFF delegation.
 assert.doesNotMatch(googleExchange, /return\s+\{[^}]*access_token/s)


### PR DESCRIPTION
Fixes the first integration bug found while wiring Rainbow AgentProfile management.

`first-party-delegation` authenticates a signed-in human through a trusted first-party BFF and is explicitly non-admin, but `requireHumanApiUser()` was still rejecting it together with machine AgentCredentials. That would make Rainbow sign-in succeed and then 403 on AgentProfile/credential/server management.

## Fix
- allow `first-party-delegation` through `requireHumanApiUser()`
- continue rejecting `agent-credential` from human-owned administration
- clarify the guard contract/comment
- update the first-party delegation contract to assert this distinction

This is intentionally a narrow auth-boundary correction, not an expansion of admin capability.