### PR TITLE
Revert: keep first-party-delegation out of requireHumanApiUser (security)

### DIFF
--- a/server/utils/authGuard.ts
+++ b/server/utils/authGuard.ts
@@ -214,18 +214,20 @@ export function authHasScope(
 }
 
 /**
- * Require a human-owned auth context. A first-party BFF delegation is allowed:
- * Rainbow is acting on behalf of the signed-in human and remains non-admin.
- * Machine AgentCredentials are not allowed to create, rotate, revoke, or
- * otherwise manage human-owned credentials/profile administration.
+ * Require a human-owned auth context. Delegated credentials -- machine
+ * AgentCredentials and first-party BFF delegation tokens alike -- are not
+ * allowed to create, rotate, revoke, or otherwise manage human-owned
+ * credentials/profile administration. See rainbow-butterflies/t-035 (conductor)
+ * for the open decision on a narrower, route-group-scoped allowance for
+ * first-party delegation on non-credential human-owned endpoints.
  */
 export async function requireHumanApiUser(event: H3Event): Promise<AuthGuardResult> {
   const auth = await requireApiUser(event)
 
-  if (auth.kind === 'agent-credential') {
+  if (auth.kind === 'agent-credential' || auth.kind === 'first-party-delegation') {
     throw createError({
       statusCode: 403,
-      message: 'Agent credentials cannot manage human-owned credentials or profiles.',
+      message: 'Delegated credentials cannot manage credentials.',
     })
   }
 

--- a/tests/contracts/verifyFirstPartyDelegation.ts
+++ b/tests/contracts/verifyFirstPartyDelegation.ts
@@ -38,13 +38,10 @@ assert.match(authGuard, /'first-party-delegation'/)
 assert.match(authGuard, /validateFirstPartyDelegationAuth\(bearerToken\)/)
 assert.match(authGuard, /clientId:\s*delegation\.clientId/)
 assert.match(authGuard, /isAdmin:\s*false/)
-
-const humanGuard = authGuard.match(
-  /export async function requireHumanApiUser[\s\S]*?\n}\n\nexport async function requireScopedApiUser/,
-)?.[0]
-assert.ok(humanGuard, 'requireHumanApiUser contract was not found')
-assert.match(humanGuard, /auth\.kind === 'agent-credential'/)
-assert.doesNotMatch(humanGuard, /auth\.kind === 'first-party-delegation'/)
+assert.match(
+  authGuard,
+  /auth\.kind === 'agent-credential' \|\| auth\.kind === 'first-party-delegation'/,
+)
 
 // Google provider tokens remain server-side and are never returned as the BFF delegation.
 assert.doesNotMatch(googleExchange, /return\s+\{[^}]*access_token/s)


### PR DESCRIPTION
**Security revert — prepared for Silas's review, not merging automatically.**

kind_robots#2289 merged (08:32:54Z) and removed `first-party-delegation` from `requireHumanApiUser`'s rejection list. That guard is the *sole* check on every `AgentCredential`/`AgentProfile` write endpoint:
- `server/api/agent-credentials/index.post.ts` (create), `[id].delete.ts` (revoke)
- `server/api/agent-profiles/index.post.ts`, `[id].patch.ts`, `[id].delete.ts`

This reopens the exact self-escalation path flagged on kind_robots#2285 and tracked as `rainbow-butterflies/t-035` (conductor repo — still open, `needs-human`, `gate_human: true`, `security_flag: true`, unresolved): a first-party delegation token — obtainable via `server/api/auth/first-party/password.post.ts`, which still has no rate limiting — can call `POST /api/agent-credentials` and mint itself a new, independently-scoped, longer-lived `AgentCredential` past its own 7-day window. #2289's own description ("continue rejecting `agent-credential`... not an expansion of admin capability") addresses the auth *kind*, not the *route* — the guard doesn't distinguish which route group is calling it, so the AgentProfile-management need #2289 describes reopened the AgentCredential path too.

## What this reverts
Restores `requireHumanApiUser`'s original rejection of both `agent-credential` and `first-party-delegation`, and the matching contract-test assertion. Byte-for-byte the pre-#2289 guard body, with an updated doc-comment pointing at `rainbow-butterflies/t-035` for context.

## What this does NOT do
Doesn't address the legitimate integration need #2289 was trying to solve (Rainbow needs *some* way to reach AgentProfile management as the signed-in human). That needs a route-group-scoped guard, not a blanket change to the shared one — exactly the kind of call `rainbow-butterflies/t-035` already routes to Silas. Left for that task's resolution rather than solved here.

## Why opened rather than merged
Two independent agent sessions flagged this same issue on #2289 within seconds of its merge (see comments there) — merging happened faster than review could land. Opening this revert now so mitigation is one click away, but leaving the merge decision to Silas in case there's context (e.g. an already-planned follow-up narrowing the guard) this session doesn't have.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5kTDEUsstH9H7ctTJGY6x)_