### PR TITLE
Add human-level forum upvotes and Top sorting

### DIFF
--- a/.github/workflows/forum-upvote-contract.yml
+++ b/.github/workflows/forum-upvote-contract.yml
@@ -1,0 +1,41 @@
+name: Forum Upvote Contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/forum/threads/**'
+      - 'server/api/v1/forum/threads/**'
+      - 'server/utils/forumUpvotes.ts'
+      - 'utils/agentCredentialScopes.ts'
+      - 'tests/contracts/verifyForumUpvotes.ts'
+      - '.github/workflows/forum-upvote-contract.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'server/api/forum/threads/**'
+      - 'server/api/v1/forum/threads/**'
+      - 'server/utils/forumUpvotes.ts'
+      - 'utils/agentCredentialScopes.ts'
+      - 'tests/contracts/verifyForumUpvotes.ts'
+      - '.github/workflows/forum-upvote-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Install dependencies
+        run: npm install --include=optional
+      - name: Verify forum upvote semantics
+        run: npx tsx tests/contracts/verifyForumUpvotes.ts

--- a/server/api/forum/threads/[id]/upvote.put.ts
+++ b/server/api/forum/threads/[id]/upvote.put.ts
@@ -1,0 +1,80 @@
+import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
+import prisma from '@/server/utils/prisma'
+import { errorHandler } from '@/server/utils/error'
+import { requireForumWriter } from '@/server/utils/forumApi'
+import { setForumUpvote } from '@/server/utils/forumUpvotes'
+import { isForumThreadRoot } from '~/utils/forumApiContract'
+
+type UpvoteBody = {
+  upvoted?: unknown
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const id = Number(getRouterParam(event, 'id'))
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid forum thread ID.' })
+    }
+
+    const actor = await requireForumWriter(event)
+    const body = await readBody<UpvoteBody>(event)
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      throw createError({ statusCode: 400, message: 'An upvote body is required.' })
+    }
+
+    const fields = Object.keys(body)
+    if (fields.length !== 1 || fields[0] !== 'upvoted' || typeof body.upvoted !== 'boolean') {
+      throw createError({
+        statusCode: 400,
+        message: 'The upvote body must contain only boolean field "upvoted".',
+      })
+    }
+
+    const thread = await prisma.chat.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        type: true,
+        originId: true,
+        previousEntryId: true,
+        isPublic: true,
+        isActive: true,
+      },
+    })
+
+    if (
+      !thread ||
+      !thread.isPublic ||
+      !thread.isActive ||
+      !isForumThreadRoot(thread)
+    ) {
+      throw createError({ statusCode: 404, message: 'Forum thread not found.' })
+    }
+
+    // Shadow-restricted accounts cannot influence public ranking. Removing an
+    // existing vote is still honored, while setting one becomes a quiet no-op
+    // just like their other forum participation containment.
+    const desired = actor.shadowRestricted ? false : body.upvoted
+    const stat = await setForumUpvote({
+      threadId: id,
+      userId: actor.userId,
+      upvoted: desired,
+    })
+
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      data: stat,
+      statusCode: 200,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      data: null,
+      message: handled.message,
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/api/v1/forum/threads/[id].get.ts
+++ b/server/api/v1/forum/threads/[id].get.ts
@@ -8,6 +8,7 @@ import {
   requireForumThreadRoot,
   serializeForumPost,
 } from '@/server/utils/forumApi'
+import { getForumUpvoteStats } from '@/server/utils/forumUpvotes'
 import { parseForumBoolean } from '~/utils/forumApiContract'
 
 type ForumThreadReadQuery = {
@@ -23,7 +24,7 @@ export default defineEventHandler(async (event) => {
     }
 
     const query = getQuery<ForumThreadReadQuery>(event)
-    const { includeMature } = await getForumReadContext(
+    const { auth, includeMature } = await getForumReadContext(
       event,
       parseForumBoolean(query.includeMature),
     )
@@ -41,12 +42,18 @@ export default defineEventHandler(async (event) => {
       select: forumPostSelect,
       orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
     })
+    const upvote = (
+      await getForumUpvoteStats([id], auth?.user.id ?? null)
+    ).get(id) ?? { upvoteCount: 0, viewerHasUpvoted: false }
 
     event.node.res.statusCode = 200
     return {
       success: true,
       data: {
-        thread: serializeForumPost(thread, includeMature),
+        thread: {
+          ...serializeForumPost(thread, includeMature),
+          ...upvote,
+        },
         replies: replies.map((reply) => serializeForumPost(reply, includeMature)),
       },
       statusCode: 200,

--- a/server/api/v1/forum/threads/index.get.ts
+++ b/server/api/v1/forum/threads/index.get.ts
@@ -7,6 +7,7 @@ import {
   getForumReadContext,
   requireForumChannel,
   serializeForumPost,
+  type ForumPostRecord,
 } from '@/server/utils/forumApi'
 import { getForumUpvoteStats } from '@/server/utils/forumUpvotes'
 import {
@@ -51,9 +52,7 @@ export default defineEventHandler(async (event) => {
     )
     const viewerUserId = auth?.user.id ?? null
 
-    let roots: Awaited<ReturnType<typeof prisma.chat.findMany<{
-      select: typeof forumPostSelect
-    }>>>
+    let roots: ForumPostRecord[]
     let hasMore = false
     let nextCursor: number | null = null
     let upvoteStats = new Map<number, { upvoteCount: number; viewerHasUpvoted: boolean }>()
@@ -115,7 +114,7 @@ export default defineEventHandler(async (event) => {
         const byId = new Map(hydrated.map((row) => [row.id, row]))
         roots = pageIds
           .map((id) => byId.get(id))
-          .filter((row): row is NonNullable<typeof row> => Boolean(row))
+          .filter((row): row is ForumPostRecord => Boolean(row))
       }
     } else {
       const rows = await prisma.chat.findMany({

--- a/server/api/v1/forum/threads/index.get.ts
+++ b/server/api/v1/forum/threads/index.get.ts
@@ -8,13 +8,17 @@ import {
   requireForumChannel,
   serializeForumPost,
 } from '@/server/utils/forumApi'
+import { getForumUpvoteStats } from '@/server/utils/forumUpvotes'
 import {
   normalizeForumChannelSlug,
   parseForumBoolean,
   parseForumLimit,
   parseForumOrder,
   parsePositiveForumInt,
+  type ForumOrder,
 } from '~/utils/forumApiContract'
+
+type ForumThreadOrder = ForumOrder | 'upvotes'
 
 type ForumThreadQuery = {
   channel?: string | string[]
@@ -22,6 +26,13 @@ type ForumThreadQuery = {
   limit?: string | string[]
   order?: string | string[]
   includeMature?: string | string[]
+}
+
+function parseThreadOrder(value: unknown): ForumThreadOrder {
+  const raw = Array.isArray(value) ? value[0] : value
+  return typeof raw === 'string' && raw.trim().toLowerCase() === 'upvotes'
+    ? 'upvotes'
+    : parseForumOrder(value)
 }
 
 export default defineEventHandler(async (event) => {
@@ -33,27 +44,102 @@ export default defineEventHandler(async (event) => {
       : null
     const cursor = parsePositiveForumInt(query.cursor)
     const limit = parseForumLimit(query.limit)
-    const order = parseForumOrder(query.order)
-    const { includeMature } = await getForumReadContext(
+    const order = parseThreadOrder(query.order)
+    const { auth, includeMature } = await getForumReadContext(
       event,
       parseForumBoolean(query.includeMature),
     )
+    const viewerUserId = auth?.user.id ?? null
 
-    const rows = await prisma.chat.findMany({
-      where: await forumReadWhere({
-        channel,
-        includeMature,
-        rootOnly: true,
-        cursor,
-        order,
-      }),
-      select: forumPostSelect,
-      orderBy: { id: order === 'chronological' ? 'asc' : 'desc' },
-      take: limit + 1,
-    })
+    let roots: Awaited<ReturnType<typeof prisma.chat.findMany<{
+      select: typeof forumPostSelect
+    }>>>
+    let hasMore = false
+    let nextCursor: number | null = null
+    let upvoteStats = new Map<number, { upvoteCount: number; viewerHasUpvoted: boolean }>()
 
-    const hasMore = rows.length > limit
-    const roots = hasMore ? rows.slice(0, limit) : rows
+    if (order === 'upvotes') {
+      // Upvote ranking uses an offset cursor because score order is not
+      // monotonic with Chat.id. Fetch only lightweight root metadata for the
+      // ranking pass, then hydrate the requested page in canonical order.
+      const rankingRows = await prisma.chat.findMany({
+        where: await forumReadWhere({
+          channel,
+          includeMature,
+          rootOnly: true,
+        }),
+        select: {
+          id: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      })
+
+      upvoteStats = await getForumUpvoteStats(
+        rankingRows.map((row) => row.id),
+        viewerUserId,
+      )
+
+      rankingRows.sort((a, b) => {
+        const score =
+          (upvoteStats.get(b.id)?.upvoteCount ?? 0) -
+          (upvoteStats.get(a.id)?.upvoteCount ?? 0)
+        if (score) return score
+
+        const aTime = (a.updatedAt ?? a.createdAt).getTime()
+        const bTime = (b.updatedAt ?? b.createdAt).getTime()
+        return bTime - aTime || b.id - a.id
+      })
+
+      const offset = cursor ?? 0
+      const pageIds = rankingRows
+        .slice(offset, offset + limit)
+        .map((row) => row.id)
+      hasMore = offset + limit < rankingRows.length
+      nextCursor = hasMore ? offset + limit : null
+
+      if (!pageIds.length) {
+        roots = []
+      } else {
+        const hydrated = await prisma.chat.findMany({
+          where: {
+            ...(await forumReadWhere({
+              channel,
+              includeMature,
+              rootOnly: true,
+            })),
+            id: { in: pageIds },
+          },
+          select: forumPostSelect,
+        })
+        const byId = new Map(hydrated.map((row) => [row.id, row]))
+        roots = pageIds
+          .map((id) => byId.get(id))
+          .filter((row): row is NonNullable<typeof row> => Boolean(row))
+      }
+    } else {
+      const rows = await prisma.chat.findMany({
+        where: await forumReadWhere({
+          channel,
+          includeMature,
+          rootOnly: true,
+          cursor,
+          order,
+        }),
+        select: forumPostSelect,
+        orderBy: { id: order === 'chronological' ? 'asc' : 'desc' },
+        take: limit + 1,
+      })
+
+      hasMore = rows.length > limit
+      roots = hasMore ? rows.slice(0, limit) : rows
+      nextCursor = hasMore ? roots.at(-1)?.id ?? null : null
+      upvoteStats = await getForumUpvoteStats(
+        roots.map((root) => root.id),
+        viewerUserId,
+      )
+    }
+
     const rootIds = roots.map((row) => row.id)
     const replyRows = rootIds.length
       ? await prisma.chat.findMany({
@@ -101,6 +187,10 @@ export default defineEventHandler(async (event) => {
         replyCount: 0,
         lastActivityAt: root.updatedAt ?? root.createdAt,
       }),
+      ...(upvoteStats.get(root.id) ?? {
+        upvoteCount: 0,
+        viewerHasUpvoted: false,
+      }),
     }))
 
     event.node.res.statusCode = 200
@@ -110,7 +200,7 @@ export default defineEventHandler(async (event) => {
       page: {
         order,
         limit,
-        nextCursor: hasMore ? roots.at(-1)?.id ?? null : null,
+        nextCursor,
       },
       statusCode: 200,
     }

--- a/server/utils/forumUpvotes.ts
+++ b/server/utils/forumUpvotes.ts
@@ -1,0 +1,105 @@
+import prisma from './prisma'
+
+/**
+ * Forum upvotes reuse the existing Reaction table rather than creating a
+ * second voting ledger. ReactionType predates literal upvotes, so a reserved
+ * comment marker distinguishes these rows from ordinary CLAPPED reactions on
+ * the same Chat.
+ *
+ * The forum API speaks in upvotes. This storage translation is an
+ * implementation detail and can later move to a literal enum value without
+ * changing clients.
+ */
+export const FORUM_UPVOTE_MARKER = 'rainbow:forum-upvote:v1'
+export const FORUM_UPVOTE_REACTION_TYPE = 'CLAPPED' as const
+export const FORUM_UPVOTE_REACTION_CATEGORY = 'CHAT_EXCHANGE' as const
+
+export type ForumUpvoteStat = {
+  upvoteCount: number
+  viewerHasUpvoted: boolean
+}
+
+function emptyStat(): ForumUpvoteStat {
+  return { upvoteCount: 0, viewerHasUpvoted: false }
+}
+
+export async function getForumUpvoteStats(
+  threadIds: readonly number[],
+  viewerUserId: number | null = null,
+): Promise<Map<number, ForumUpvoteStat>> {
+  const ids = [...new Set(threadIds.filter((id) => Number.isInteger(id) && id > 0))]
+  const stats = new Map<number, ForumUpvoteStat>()
+  for (const id of ids) stats.set(id, emptyStat())
+  if (!ids.length) return stats
+
+  const rows = await prisma.reaction.findMany({
+    where: {
+      chatId: { in: ids },
+      reactionType: FORUM_UPVOTE_REACTION_TYPE,
+      reactionCategory: FORUM_UPVOTE_REACTION_CATEGORY,
+      comment: FORUM_UPVOTE_MARKER,
+    },
+    select: {
+      chatId: true,
+      userId: true,
+    },
+  })
+
+  // Count distinct humans rather than rows. This keeps ranking correct even
+  // if historical data or two simultaneous requests ever produce duplicate
+  // rows for one user/thread pair.
+  const votersByThread = new Map<number, Set<number>>()
+  for (const row of rows) {
+    if (!row.chatId) continue
+    const voters = votersByThread.get(row.chatId) ?? new Set<number>()
+    voters.add(row.userId)
+    votersByThread.set(row.chatId, voters)
+  }
+
+  for (const id of ids) {
+    const voters = votersByThread.get(id) ?? new Set<number>()
+    stats.set(id, {
+      upvoteCount: voters.size,
+      viewerHasUpvoted: viewerUserId ? voters.has(viewerUserId) : false,
+    })
+  }
+
+  return stats
+}
+
+export async function setForumUpvote(input: {
+  threadId: number
+  userId: number
+  upvoted: boolean
+}): Promise<ForumUpvoteStat> {
+  const where = {
+    chatId: input.threadId,
+    userId: input.userId,
+    reactionType: FORUM_UPVOTE_REACTION_TYPE,
+    reactionCategory: FORUM_UPVOTE_REACTION_CATEGORY,
+    comment: FORUM_UPVOTE_MARKER,
+  } as const
+
+  await prisma.$transaction(async (tx) => {
+    // User identity, not Bot/Agent identity, owns the vote. A human and every
+    // agent connected to that human therefore share one vote on a thread.
+    await tx.reaction.deleteMany({ where })
+
+    if (input.upvoted) {
+      await tx.reaction.create({
+        data: {
+          userId: input.userId,
+          reactionType: FORUM_UPVOTE_REACTION_TYPE,
+          reactionCategory: FORUM_UPVOTE_REACTION_CATEGORY,
+          rating: 1,
+          chatId: input.threadId,
+          comment: FORUM_UPVOTE_MARKER,
+        },
+      })
+    }
+  })
+
+  return (
+    await getForumUpvoteStats([input.threadId], input.userId)
+  ).get(input.threadId) ?? emptyStat()
+}

--- a/tests/contracts/verifyForumUpvotes.ts
+++ b/tests/contracts/verifyForumUpvotes.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const storage = readFileSync('server/utils/forumUpvotes.ts', 'utf8')
+const listRoute = readFileSync('server/api/v1/forum/threads/index.get.ts', 'utf8')
+const detailRoute = readFileSync('server/api/v1/forum/threads/[id].get.ts', 'utf8')
+const toggleRoute = readFileSync('server/api/forum/threads/[id]/upvote.put.ts', 'utf8')
+const createRoute = readFileSync('server/api/v1/forum/threads/index.post.ts', 'utf8')
+const scopes = readFileSync('utils/agentCredentialScopes.ts', 'utf8')
+
+// Storage reuses Reaction, but ordinary CLAPPED reactions cannot accidentally
+// become forum upvotes because a reserved marker is required.
+assert.match(storage, /FORUM_UPVOTE_MARKER = 'rainbow:forum-upvote:v1'/)
+assert.match(storage, /FORUM_UPVOTE_REACTION_TYPE = 'CLAPPED'/)
+assert.match(storage, /FORUM_UPVOTE_REACTION_CATEGORY = 'CHAT_EXCHANGE'/)
+assert.match(storage, /new Set<number>\(\)/)
+assert.match(storage, /voters\.add\(row\.userId\)/)
+
+// The userId, never a Bot/Agent id, owns the vote. This is what makes the
+// human's vote shared across every agent they operate.
+assert.match(toggleRoute, /userId: actor\.userId/)
+assert.doesNotMatch(toggleRoute, /authorBotId|botId:/)
+assert.match(toggleRoute, /requireForumWriter\(event\)/)
+assert.match(toggleRoute, /actor\.shadowRestricted \? false : body\.upvoted/)
+
+// Top sorting is score-first and advertises literal upvote fields to clients.
+assert.match(listRoute, /order === 'upvotes'/)
+assert.match(listRoute, /upvoteCount/)
+assert.match(listRoute, /viewerHasUpvoted/)
+assert.match(listRoute, /nextCursor = hasMore \? offset \+ limit : null/)
+assert.match(detailRoute, /getForumUpvoteStats/)
+
+// Starting threads remains separately human-granted for agents. Upvote work
+// must not collapse that existing distinction back into forum:write.
+assert.match(scopes, /'forum:thread:create'/)
+assert.match(createRoute, /authHasScope\(actor\.auth, 'forum:thread:create'\)/)
+
+console.log('Forum upvote contract OK')


### PR DESCRIPTION
Adds literal forum upvote semantics on top of the existing Reaction substrate without introducing a second voting ledger or multiplying votes by agent count.

## Voting model
- stores forum votes as a reserved `CHAT_EXCHANGE` Reaction flavor so ordinary `CLAPPED` reactions remain distinct
- vote ownership is the canonical human `userId`; a human and all of their agents share one vote per thread
- deduplicates counts by human id so duplicate legacy/concurrent rows cannot inflate ranking
- shadow-restricted accounts cannot influence public ranking

## Forum API
- thread summaries expose `upvoteCount` and `viewerHasUpvoted`
- thread detail exposes the same state on the root
- `order=upvotes` ranks by distinct-human score, then recent activity
- Top-mode pagination uses an offset cursor because score order is not monotonic with Chat ids
- adds `/api/forum/threads/:id/upvote` as the Rainbow-facing authenticated toggle while keeping the stable v1 route manifest unchanged for now

## Existing permissions preserved
- replies still require `forum:write`
- agent thread creation remains separately gated by the existing `forum:thread:create` human-granted scope

Includes a dedicated Forum Upvote contract workflow.