### PR TITLE
Add scoped agent check-ins and human notes (safe delegation scope)

### DIFF
--- a/.github/workflows/agent-checkin-contract.yml
+++ b/.github/workflows/agent-checkin-contract.yml
@@ -1,0 +1,45 @@
+name: Agent Check-in Contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'prisma/agent-profile.prisma'
+      - 'prisma/migrations/**agent_checkins_notes/**'
+      - 'utils/agentCredentialScopes.ts'
+      - 'server/utils/authGuard.ts'
+      - 'server/api/v1/agent/**'
+      - 'server/api/agent-profiles/**'
+      - 'utils/scripts/verifyAgentCheckins.test.ts'
+      - '.github/workflows/agent-checkin-contract.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'prisma/agent-profile.prisma'
+      - 'prisma/migrations/**agent_checkins_notes/**'
+      - 'utils/agentCredentialScopes.ts'
+      - 'server/utils/authGuard.ts'
+      - 'server/api/v1/agent/**'
+      - 'server/api/agent-profiles/**'
+      - 'utils/scripts/verifyAgentCheckins.test.ts'
+      - '.github/workflows/agent-checkin-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Install dependencies
+        run: npm install --include=optional
+      - name: Verify agent check-in and note contract
+        run: npx tsx utils/scripts/verifyAgentCheckins.test.ts

--- a/prisma/agent-profile.prisma
+++ b/prisma/agent-profile.prisma
@@ -17,6 +17,8 @@ model AgentProfile {
   allowMessages Boolean                  @default(false)
   isActive      Boolean                  @default(true)
   Credentials   AgentProfileCredential[]
+  CheckIns      AgentCheckIn[]
+  Notes         AgentNote[]
 
   @@index([userId, isActive])
   @@index([isPublic, isActive])
@@ -35,4 +37,37 @@ model AgentProfileCredential {
   Profile        AgentProfile @relation(fields: [agentProfileId], references: [id], onDelete: Cascade)
 
   @@index([agentProfileId])
+}
+
+/// Durable heartbeat/report from an authenticated external agent. `userId` and
+/// `credentialId` are scalar audit fields so historical check-ins survive key
+/// rotation/revocation without turning credentials into identity records.
+model AgentCheckIn {
+  id             Int          @id @default(autoincrement())
+  createdAt      DateTime     @default(now())
+  agentProfileId Int
+  userId         Int
+  credentialId   Int?
+  status         String?      @db.VarChar(32)
+  summary        String?      @db.Text
+  Profile        AgentProfile @relation(fields: [agentProfileId], references: [id], onDelete: Cascade)
+
+  @@index([agentProfileId, createdAt])
+  @@index([userId, createdAt])
+}
+
+/// Human-authored inbox note for one AgentProfile. Notes are delivered once on
+/// the next successful agent check-in; `deliveredAt` is the durable hand-off
+/// marker so providers do not receive the same instruction on every heartbeat.
+model AgentNote {
+  id             Int          @id @default(autoincrement())
+  createdAt      DateTime     @default(now())
+  agentProfileId Int
+  userId         Int
+  body           String       @db.Text
+  deliveredAt    DateTime?
+  Profile        AgentProfile @relation(fields: [agentProfileId], references: [id], onDelete: Cascade)
+
+  @@index([agentProfileId, deliveredAt, createdAt])
+  @@index([userId, createdAt])
 }

--- a/prisma/agent-profile.prisma
+++ b/prisma/agent-profile.prisma
@@ -57,17 +57,19 @@ model AgentCheckIn {
 }
 
 /// Human-authored inbox note for one AgentProfile. Notes are delivered once on
-/// the next successful agent check-in; `deliveredAt` is the durable hand-off
-/// marker so providers do not receive the same instruction on every heartbeat.
+/// the next successful agent check-in. `deliveredCheckInId` makes the claim
+/// durable even if two provider timers happen to check in concurrently.
 model AgentNote {
-  id             Int          @id @default(autoincrement())
-  createdAt      DateTime     @default(now())
-  agentProfileId Int
-  userId         Int
-  body           String       @db.Text
-  deliveredAt    DateTime?
-  Profile        AgentProfile @relation(fields: [agentProfileId], references: [id], onDelete: Cascade)
+  id                 Int          @id @default(autoincrement())
+  createdAt          DateTime     @default(now())
+  agentProfileId     Int
+  userId             Int
+  body               String       @db.Text
+  deliveredAt        DateTime?
+  deliveredCheckInId Int?
+  Profile            AgentProfile @relation(fields: [agentProfileId], references: [id], onDelete: Cascade)
 
   @@index([agentProfileId, deliveredAt, createdAt])
+  @@index([deliveredCheckInId])
   @@index([userId, createdAt])
 }

--- a/prisma/migrations/20260901083000_add_agent_checkins_notes/migration.sql
+++ b/prisma/migrations/20260901083000_add_agent_checkins_notes/migration.sql
@@ -22,8 +22,10 @@ CREATE TABLE `AgentNote` (
     `userId` INTEGER NOT NULL,
     `body` TEXT NOT NULL,
     `deliveredAt` DATETIME(3) NULL,
+    `deliveredCheckInId` INTEGER NULL,
 
     INDEX `AgentNote_agentProfileId_deliveredAt_createdAt_idx`(`agentProfileId`, `deliveredAt`, `createdAt`),
+    INDEX `AgentNote_deliveredCheckInId_idx`(`deliveredCheckInId`),
     INDEX `AgentNote_userId_createdAt_idx`(`userId`, `createdAt`),
     PRIMARY KEY (`id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/migrations/20260901083000_add_agent_checkins_notes/migration.sql
+++ b/prisma/migrations/20260901083000_add_agent_checkins_notes/migration.sql
@@ -1,0 +1,39 @@
+-- Rainbow Butterflies v2: durable agent heartbeat history and human-to-agent
+-- inbox notes. Additive; no existing AgentProfile or credential rows change.
+
+CREATE TABLE `AgentCheckIn` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `agentProfileId` INTEGER NOT NULL,
+    `userId` INTEGER NOT NULL,
+    `credentialId` INTEGER NULL,
+    `status` VARCHAR(32) NULL,
+    `summary` TEXT NULL,
+
+    INDEX `AgentCheckIn_agentProfileId_createdAt_idx`(`agentProfileId`, `createdAt`),
+    INDEX `AgentCheckIn_userId_createdAt_idx`(`userId`, `createdAt`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `AgentNote` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `agentProfileId` INTEGER NOT NULL,
+    `userId` INTEGER NOT NULL,
+    `body` TEXT NOT NULL,
+    `deliveredAt` DATETIME(3) NULL,
+
+    INDEX `AgentNote_agentProfileId_deliveredAt_createdAt_idx`(`agentProfileId`, `deliveredAt`, `createdAt`),
+    INDEX `AgentNote_userId_createdAt_idx`(`userId`, `createdAt`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE `AgentCheckIn`
+    ADD CONSTRAINT `AgentCheckIn_agentProfileId_fkey`
+    FOREIGN KEY (`agentProfileId`) REFERENCES `AgentProfile`(`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `AgentNote`
+    ADD CONSTRAINT `AgentNote_agentProfileId_fkey`
+    FOREIGN KEY (`agentProfileId`) REFERENCES `AgentProfile`(`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/api/agent-profiles/[id]/activity.get.ts
+++ b/server/api/agent-profiles/[id]/activity.get.ts
@@ -1,0 +1,80 @@
+import { createError, defineEventHandler, getRouterParam, setHeader } from 'h3'
+import { requireHumanApiUser } from '@/server/utils/authGuard'
+import { errorHandler } from '@/server/utils/error'
+import prisma from '@/server/utils/prisma'
+
+function parseId(value: string | undefined) {
+  const id = Number(value)
+  if (!Number.isInteger(id) || id <= 0) {
+    throw createError({ statusCode: 400, message: 'Invalid agent profile id.' })
+  }
+  return id
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    setHeader(event, 'Cache-Control', 'no-store')
+    const auth = await requireHumanApiUser(event)
+    const id = parseId(getRouterParam(event, 'id'))
+    const profile = await prisma.agentProfile.findUnique({
+      where: { id },
+      select: { id: true, userId: true, name: true, isActive: true },
+    })
+
+    if (!profile) {
+      throw createError({ statusCode: 404, message: 'Agent profile not found.' })
+    }
+    if (profile.userId !== auth.user.id) {
+      throw createError({ statusCode: 403, message: 'You do not own this agent profile.' })
+    }
+
+    const [checkIns, notes, pendingNotes] = await Promise.all([
+      prisma.agentCheckIn.findMany({
+        where: { agentProfileId: id, userId: auth.user.id },
+        orderBy: { createdAt: 'desc' },
+        take: 25,
+        select: {
+          id: true,
+          createdAt: true,
+          status: true,
+          summary: true,
+        },
+      }),
+      prisma.agentNote.findMany({
+        where: { agentProfileId: id, userId: auth.user.id },
+        orderBy: { createdAt: 'desc' },
+        take: 50,
+        select: {
+          id: true,
+          createdAt: true,
+          body: true,
+          deliveredAt: true,
+        },
+      }),
+      prisma.agentNote.count({
+        where: {
+          agentProfileId: id,
+          userId: auth.user.id,
+          deliveredAt: null,
+        },
+      }),
+    ])
+
+    return {
+      success: true,
+      profile: {
+        id: profile.id,
+        name: profile.name,
+        isActive: profile.isActive,
+      },
+      lastCheckInAt: checkIns[0]?.createdAt ?? null,
+      pendingNotes,
+      checkIns,
+      notes,
+    }
+  } catch (error) {
+    const { message, statusCode } = errorHandler(error)
+    event.node.res.statusCode = statusCode || 500
+    return { success: false, message: message || 'Failed to load agent activity.' }
+  }
+})

--- a/server/api/agent-profiles/[id]/activity.get.ts
+++ b/server/api/agent-profiles/[id]/activity.get.ts
@@ -1,5 +1,5 @@
 import { createError, defineEventHandler, getRouterParam, setHeader } from 'h3'
-import { requireHumanApiUser } from '@/server/utils/authGuard'
+import { requireHumanOrDelegatedApiUser } from '@/server/utils/authGuard'
 import { errorHandler } from '@/server/utils/error'
 import prisma from '@/server/utils/prisma'
 
@@ -14,7 +14,7 @@ function parseId(value: string | undefined) {
 export default defineEventHandler(async (event) => {
   try {
     setHeader(event, 'Cache-Control', 'no-store')
-    const auth = await requireHumanApiUser(event)
+    const auth = await requireHumanOrDelegatedApiUser(event)
     const id = parseId(getRouterParam(event, 'id'))
     const profile = await prisma.agentProfile.findUnique({
       where: { id },
@@ -22,10 +22,16 @@ export default defineEventHandler(async (event) => {
     })
 
     if (!profile) {
-      throw createError({ statusCode: 404, message: 'Agent profile not found.' })
+      throw createError({
+        statusCode: 404,
+        message: 'Agent profile not found.',
+      })
     }
     if (profile.userId !== auth.user.id) {
-      throw createError({ statusCode: 403, message: 'You do not own this agent profile.' })
+      throw createError({
+        statusCode: 403,
+        message: 'You do not own this agent profile.',
+      })
     }
 
     const [checkIns, notes, pendingNotes] = await Promise.all([
@@ -75,6 +81,9 @@ export default defineEventHandler(async (event) => {
   } catch (error) {
     const { message, statusCode } = errorHandler(error)
     event.node.res.statusCode = statusCode || 500
-    return { success: false, message: message || 'Failed to load agent activity.' }
+    return {
+      success: false,
+      message: message || 'Failed to load agent activity.',
+    }
   }
 })

--- a/server/api/agent-profiles/[id]/notes.post.ts
+++ b/server/api/agent-profiles/[id]/notes.post.ts
@@ -1,0 +1,66 @@
+import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
+import { requireHumanApiUser } from '@/server/utils/authGuard'
+import { errorHandler } from '@/server/utils/error'
+import prisma from '@/server/utils/prisma'
+
+function parseId(value: string | undefined) {
+  const id = Number(value)
+  if (!Number.isInteger(id) || id <= 0) {
+    throw createError({ statusCode: 400, message: 'Invalid agent profile id.' })
+  }
+  return id
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireHumanApiUser(event)
+    const id = parseId(getRouterParam(event, 'id'))
+    const body = await readBody<{ body?: unknown }>(event)
+    const noteBody = typeof body?.body === 'string' ? body.body.trim() : ''
+
+    if (!noteBody) {
+      throw createError({ statusCode: 400, message: 'Note text is required.' })
+    }
+    if (noteBody.length > 5000) {
+      throw createError({ statusCode: 400, message: 'Notes must be 5000 characters or fewer.' })
+    }
+
+    const profile = await prisma.agentProfile.findUnique({
+      where: { id },
+      select: { id: true, userId: true, isActive: true },
+    })
+    if (!profile) {
+      throw createError({ statusCode: 404, message: 'Agent profile not found.' })
+    }
+    if (profile.userId !== auth.user.id) {
+      throw createError({ statusCode: 403, message: 'You do not own this agent profile.' })
+    }
+    if (!profile.isActive) {
+      throw createError({ statusCode: 409, message: 'Reactivate this agent before sending it notes.' })
+    }
+
+    const note = await prisma.agentNote.create({
+      data: {
+        agentProfileId: id,
+        userId: auth.user.id,
+        body: noteBody,
+      },
+      select: {
+        id: true,
+        createdAt: true,
+        body: true,
+        deliveredAt: true,
+      },
+    })
+
+    return {
+      success: true,
+      note,
+      message: 'Note queued for the agent’s next check-in.',
+    }
+  } catch (error) {
+    const { message, statusCode } = errorHandler(error)
+    event.node.res.statusCode = statusCode || 500
+    return { success: false, message: message || 'Failed to create agent note.' }
+  }
+})

--- a/server/api/agent-profiles/[id]/notes.post.ts
+++ b/server/api/agent-profiles/[id]/notes.post.ts
@@ -1,5 +1,5 @@
 import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
-import { requireHumanApiUser } from '@/server/utils/authGuard'
+import { requireHumanOrDelegatedApiUser } from '@/server/utils/authGuard'
 import { errorHandler } from '@/server/utils/error'
 import prisma from '@/server/utils/prisma'
 
@@ -13,7 +13,7 @@ function parseId(value: string | undefined) {
 
 export default defineEventHandler(async (event) => {
   try {
-    const auth = await requireHumanApiUser(event)
+    const auth = await requireHumanOrDelegatedApiUser(event)
     const id = parseId(getRouterParam(event, 'id'))
     const body = await readBody<{ body?: unknown }>(event)
     const noteBody = typeof body?.body === 'string' ? body.body.trim() : ''
@@ -22,7 +22,10 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 400, message: 'Note text is required.' })
     }
     if (noteBody.length > 5000) {
-      throw createError({ statusCode: 400, message: 'Notes must be 5000 characters or fewer.' })
+      throw createError({
+        statusCode: 400,
+        message: 'Notes must be 5000 characters or fewer.',
+      })
     }
 
     const profile = await prisma.agentProfile.findUnique({
@@ -30,13 +33,22 @@ export default defineEventHandler(async (event) => {
       select: { id: true, userId: true, isActive: true },
     })
     if (!profile) {
-      throw createError({ statusCode: 404, message: 'Agent profile not found.' })
+      throw createError({
+        statusCode: 404,
+        message: 'Agent profile not found.',
+      })
     }
     if (profile.userId !== auth.user.id) {
-      throw createError({ statusCode: 403, message: 'You do not own this agent profile.' })
+      throw createError({
+        statusCode: 403,
+        message: 'You do not own this agent profile.',
+      })
     }
     if (!profile.isActive) {
-      throw createError({ statusCode: 409, message: 'Reactivate this agent before sending it notes.' })
+      throw createError({
+        statusCode: 409,
+        message: 'Reactivate this agent before sending it notes.',
+      })
     }
 
     const note = await prisma.agentNote.create({
@@ -61,6 +73,9 @@ export default defineEventHandler(async (event) => {
   } catch (error) {
     const { message, statusCode } = errorHandler(error)
     event.node.res.statusCode = statusCode || 500
-    return { success: false, message: message || 'Failed to create agent note.' }
+    return {
+      success: false,
+      message: message || 'Failed to create agent note.',
+    }
   }
 })

--- a/server/api/v1/agent/check-in.post.ts
+++ b/server/api/v1/agent/check-in.post.ts
@@ -1,0 +1,126 @@
+import { createError, defineEventHandler, readBody, setHeader } from 'h3'
+import { requireScopedApiUser } from '@/server/utils/authGuard'
+import prisma from '@/server/utils/prisma'
+
+const allowedStatuses = new Set(['idle', 'working', 'blocked', 'completed'])
+
+type CheckInBody = {
+  status?: unknown
+  summary?: unknown
+}
+
+function cleanStatus(value: unknown) {
+  if (value === undefined || value === null || value === '') return null
+  if (typeof value !== 'string' || !allowedStatuses.has(value)) {
+    throw createError({
+      statusCode: 400,
+      message: 'status must be one of: idle, working, blocked, completed.',
+    })
+  }
+  return value
+}
+
+function cleanSummary(value: unknown) {
+  if (value === undefined || value === null || value === '') return null
+  if (typeof value !== 'string') {
+    throw createError({ statusCode: 400, message: 'summary must be text.' })
+  }
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  if (trimmed.length > 5000) {
+    throw createError({ statusCode: 400, message: 'summary must be 5000 characters or fewer.' })
+  }
+  return trimmed
+}
+
+export default defineEventHandler(async (event) => {
+  setHeader(event, 'Cache-Control', 'no-store')
+  const auth = await requireScopedApiUser(event, 'agent:checkin')
+
+  if (auth.kind !== 'agent-credential' || !auth.agentProfileId) {
+    throw createError({
+      statusCode: 403,
+      message: 'Agent check-in requires a credential bound to an AgentProfile.',
+    })
+  }
+
+  const profile = await prisma.agentProfile.findUnique({
+    where: { id: auth.agentProfileId },
+    select: { id: true, userId: true, name: true, isActive: true },
+  })
+  if (!profile || !profile.isActive || profile.userId !== auth.user.id) {
+    throw createError({ statusCode: 403, message: 'This AgentProfile is not active.' })
+  }
+
+  const body = (await readBody<CheckInBody>(event)) ?? {}
+  const status = cleanStatus(body.status)
+  const summary = cleanSummary(body.summary)
+  const deliveredAt = new Date()
+
+  const result = await prisma.$transaction(async (tx) => {
+    const checkIn = await tx.agentCheckIn.create({
+      data: {
+        agentProfileId: profile.id,
+        userId: auth.user.id,
+        credentialId: auth.credentialId ?? null,
+        status,
+        summary,
+      },
+    })
+
+    const pending = await tx.agentNote.findMany({
+      where: {
+        agentProfileId: profile.id,
+        userId: auth.user.id,
+        deliveredAt: null,
+      },
+      orderBy: { createdAt: 'asc' },
+      take: 20,
+      select: { id: true },
+    })
+
+    if (pending.length) {
+      await tx.agentNote.updateMany({
+        where: {
+          id: { in: pending.map((note) => note.id) },
+          deliveredAt: null,
+        },
+        data: {
+          deliveredAt,
+          deliveredCheckInId: checkIn.id,
+        },
+      })
+    }
+
+    const notes = await tx.agentNote.findMany({
+      where: { deliveredCheckInId: checkIn.id },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        id: true,
+        createdAt: true,
+        body: true,
+      },
+    })
+
+    return { checkIn, notes }
+  })
+
+  return {
+    success: true,
+    agent: {
+      id: profile.id,
+      name: profile.name,
+    },
+    checkIn: {
+      id: result.checkIn.id,
+      createdAt: result.checkIn.createdAt,
+      status: result.checkIn.status,
+      summary: result.checkIn.summary,
+    },
+    notes: result.notes,
+    message:
+      result.notes.length > 0
+        ? `${result.notes.length} human note${result.notes.length === 1 ? '' : 's'} delivered.`
+        : 'Check-in recorded. No new human notes.',
+  }
+})

--- a/server/utils/authGuard.ts
+++ b/server/utils/authGuard.ts
@@ -31,7 +31,10 @@ const config = useRuntimeConfig()
 
 function readBearerToken(event: H3Event): string {
   const authorization = getHeader(event, 'authorization') ?? ''
-  return authorization.trim().replace(/^Bearer\s+/i, '').trim()
+  return authorization
+    .trim()
+    .replace(/^Bearer\s+/i, '')
+    .trim()
 }
 
 function readUserApiKey(event: H3Event): string {
@@ -58,7 +61,9 @@ function getConfiguredBetaAdminToken(): string {
 }
 
 function getBetaAdminUserId(): number {
-  const raw = Number(config.betaAdminUserId || process.env.BETA_ADMIN_USER_ID || 1)
+  const raw = Number(
+    config.betaAdminUserId || process.env.BETA_ADMIN_USER_ID || 1,
+  )
   return Number.isInteger(raw) && raw > 0 ? raw : 1
 }
 
@@ -117,10 +122,13 @@ async function validateFirstPartyDelegationAuth(
   }
 }
 
-async function validateBetaAdminAuth(event: H3Event): Promise<AuthGuardResult | null> {
+async function validateBetaAdminAuth(
+  event: H3Event,
+): Promise<AuthGuardResult | null> {
   const configuredToken = getConfiguredBetaAdminToken()
   const suppliedToken = readBetaAdminToken(event)
-  if (!configuredToken || !suppliedToken || suppliedToken !== configuredToken) return null
+  if (!configuredToken || !suppliedToken || suppliedToken !== configuredToken)
+    return null
 
   const user = await getUserById(getBetaAdminUserId())
   if (!user || !user.isActive || !user.isAdmin) return null
@@ -133,7 +141,9 @@ async function validateBetaAdminAuth(event: H3Event): Promise<AuthGuardResult | 
   }
 }
 
-async function validateUserApiKeyAuth(token: string): Promise<AuthGuardResult | null> {
+async function validateUserApiKeyAuth(
+  token: string,
+): Promise<AuthGuardResult | null> {
   if (!token) return null
 
   const user = await prisma.user.findFirst({
@@ -174,7 +184,9 @@ async function validateAgentCredentialAuth(
   }
 }
 
-export async function getOptionalApiUser(event: H3Event): Promise<AuthGuardResult | null> {
+export async function getOptionalApiUser(
+  event: H3Event,
+): Promise<AuthGuardResult | null> {
   const bearerToken = readBearerToken(event)
   const userApiKey = readUserApiKey(event)
 
@@ -187,21 +199,28 @@ export async function getOptionalApiUser(event: H3Event): Promise<AuthGuardResul
   )
 }
 
-export async function requireMachineUser(event: H3Event): Promise<AuthGuardResult> {
+export async function requireMachineUser(
+  event: H3Event,
+): Promise<AuthGuardResult> {
   const auth = await getOptionalApiUser(event)
-  if (!auth) throw createError({ statusCode: 401, message: 'Invalid or expired token.' })
+  if (!auth)
+    throw createError({ statusCode: 401, message: 'Invalid or expired token.' })
   return auth
 }
 
 export async function requireApiUser(event: H3Event): Promise<AuthGuardResult> {
   const auth = await getOptionalApiUser(event)
-  if (!auth) throw createError({ statusCode: 401, message: 'Invalid or expired token.' })
+  if (!auth)
+    throw createError({ statusCode: 401, message: 'Invalid or expired token.' })
   return auth
 }
 
-export async function requireAdminApiUser(event: H3Event): Promise<AuthGuardResult> {
+export async function requireAdminApiUser(
+  event: H3Event,
+): Promise<AuthGuardResult> {
   const auth = await requireApiUser(event)
-  if (!auth.isAdmin) throw createError({ statusCode: 403, message: 'Admin access required.' })
+  if (!auth.isAdmin)
+    throw createError({ statusCode: 403, message: 'Admin access required.' })
   return auth
 }
 
@@ -217,9 +236,12 @@ export function authHasScope(
  * Require a human-owned auth context. Delegated credentials -- machine
  * AgentCredentials and first-party BFF delegation tokens alike -- are not
  * allowed to create, rotate, revoke, or otherwise manage human-owned
- * credentials/profile administration. See rainbow-butterflies/t-035 (conductor)
- * for the open decision on a narrower, route-group-scoped allowance for
- * first-party delegation on non-credential human-owned endpoints.
+ * credentials/profile administration (AgentCredential create/delete,
+ * AgentProfile create/patch/delete). See rainbow-butterflies/t-035
+ * (conductor) for the incident this guard closed. Non-admin, non-credential
+ * routes that a first-party delegation legitimately needs (e.g. agent
+ * check-in notes/activity) should use requireHumanOrDelegatedApiUser below
+ * instead of loosening this one.
  */
 export async function requireHumanApiUser(event: H3Event): Promise<AuthGuardResult> {
   const auth = await requireApiUser(event)
@@ -228,6 +250,31 @@ export async function requireHumanApiUser(event: H3Event): Promise<AuthGuardResu
     throw createError({
       statusCode: 403,
       message: 'Delegated credentials cannot manage credentials.',
+    })
+  }
+
+  return auth
+}
+
+/**
+ * Require a human-owned auth context, additionally allowing a first-party BFF
+ * delegation token. This is the narrower allowance rainbow-butterflies/t-035
+ * asked for: only routes that are neither AgentCredential administration nor
+ * AgentProfile creation/deletion/reassignment should use this guard, since a
+ * delegation token is scoped to "the signed-in human acting through a trusted
+ * first-party app," not "an admin of that human's credentials." Machine
+ * AgentCredentials are still rejected outright -- only a real human or a
+ * first-party delegation acting on their behalf may pass.
+ */
+export async function requireHumanOrDelegatedApiUser(
+  event: H3Event,
+): Promise<AuthGuardResult> {
+  const auth = await requireApiUser(event)
+
+  if (auth.kind === 'agent-credential') {
+    throw createError({
+      statusCode: 403,
+      message: 'Agent credentials cannot act as a human user.',
     })
   }
 

--- a/utils/agentCredentialScopes.ts
+++ b/utils/agentCredentialScopes.ts
@@ -12,6 +12,7 @@
 // a migration (same convention as Monster.behavior/dietRole/schoolRole).
 export const AGENT_CREDENTIAL_SCOPES = [
   'profile:read',
+  'agent:checkin',
   'forum:read',
   'forum:write',
   'forum:thread:create',
@@ -23,7 +24,8 @@ export type AgentCredentialScope = (typeof AGENT_CREDENTIAL_SCOPES)[number]
 // Scopes a freshly-created forum-agent credential gets when the caller
 // doesn't specify its own set. Creating new top-level threads is deliberately
 // NOT included: a human liaison opts an agent into that separately. Generation
-// is also opt-in because it can spend the owning User's generation balance.
+// and recurring check-ins are also opt-in because they respectively spend
+// generation balance and enable background agent activity.
 export const DEFAULT_FORUM_AGENT_SCOPES: AgentCredentialScope[] = [
   'profile:read',
   'forum:read',

--- a/utils/scripts/verifyAgentCheckins.test.ts
+++ b/utils/scripts/verifyAgentCheckins.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const schema = readFileSync('prisma/agent-profile.prisma', 'utf8')
+const migration = readFileSync(
+  'prisma/migrations/20260901083000_add_agent_checkins_notes/migration.sql',
+  'utf8',
+)
+const scopes = readFileSync('utils/agentCredentialScopes.ts', 'utf8')
+const authGuard = readFileSync('server/utils/authGuard.ts', 'utf8')
+const checkIn = readFileSync('server/api/v1/agent/check-in.post.ts', 'utf8')
+const notes = readFileSync('server/api/agent-profiles/[id]/notes.post.ts', 'utf8')
+const activity = readFileSync('server/api/agent-profiles/[id]/activity.get.ts', 'utf8')
+
+assert.match(schema, /model AgentCheckIn \{/)
+assert.match(schema, /model AgentNote \{/)
+assert.match(schema, /deliveredCheckInId\s+Int\?/)
+assert.match(schema, /@@index\(\[agentProfileId, deliveredAt, createdAt\]\)/)
+assert.match(migration, /CREATE TABLE `AgentCheckIn`/)
+assert.match(migration, /CREATE TABLE `AgentNote`/)
+assert.match(migration, /`deliveredCheckInId` INTEGER NULL/)
+assert.match(migration, /ON DELETE CASCADE/)
+
+assert.match(scopes, /'agent:checkin'/)
+assert.doesNotMatch(
+  scopes.match(/DEFAULT_FORUM_AGENT_SCOPES[\s\S]*?\n\]/)?.[0] ?? '',
+  /agent:checkin/,
+)
+
+assert.match(checkIn, /requireScopedApiUser\(event, 'agent:checkin'\)/)
+assert.match(checkIn, /auth\.kind !== 'agent-credential'/)
+assert.match(checkIn, /!auth\.agentProfileId/)
+assert.match(checkIn, /profile\.userId !== auth\.user\.id/)
+assert.match(checkIn, /tx\.agentCheckIn\.create/)
+assert.match(checkIn, /deliveredAt:\s*null/)
+assert.match(checkIn, /deliveredCheckInId:\s*checkIn\.id/)
+assert.match(checkIn, /where:\s*\{ deliveredCheckInId: checkIn\.id \}/)
+assert.match(checkIn, /take:\s*20/)
+
+for (const source of [notes, activity]) {
+  assert.match(source, /requireHumanApiUser\(event\)/)
+  assert.match(source, /profile\.userId !== auth\.user\.id/)
+}
+assert.match(notes, /Note queued for the agent’s next check-in/)
+assert.match(activity, /pendingNotes/)
+assert.match(activity, /lastCheckInAt/)
+
+const humanGuard = authGuard.match(
+  /export async function requireHumanApiUser[\s\S]*?\n}\n\nexport async function requireScopedApiUser/,
+)?.[0]
+assert.ok(humanGuard)
+assert.doesNotMatch(humanGuard, /auth\.kind === 'first-party-delegation'/)
+assert.match(humanGuard, /auth\.kind === 'agent-credential'/)
+
+console.log('Agent check-in + human notes contract OK')

--- a/utils/scripts/verifyAgentCheckins.test.ts
+++ b/utils/scripts/verifyAgentCheckins.test.ts
@@ -9,8 +9,14 @@ const migration = readFileSync(
 const scopes = readFileSync('utils/agentCredentialScopes.ts', 'utf8')
 const authGuard = readFileSync('server/utils/authGuard.ts', 'utf8')
 const checkIn = readFileSync('server/api/v1/agent/check-in.post.ts', 'utf8')
-const notes = readFileSync('server/api/agent-profiles/[id]/notes.post.ts', 'utf8')
-const activity = readFileSync('server/api/agent-profiles/[id]/activity.get.ts', 'utf8')
+const notes = readFileSync(
+  'server/api/agent-profiles/[id]/notes.post.ts',
+  'utf8',
+)
+const activity = readFileSync(
+  'server/api/agent-profiles/[id]/activity.get.ts',
+  'utf8',
+)
 
 assert.match(schema, /model AgentCheckIn \{/)
 assert.match(schema, /model AgentNote \{/)
@@ -38,18 +44,36 @@ assert.match(checkIn, /where:\s*\{ deliveredCheckInId: checkIn\.id \}/)
 assert.match(checkIn, /take:\s*20/)
 
 for (const source of [notes, activity]) {
-  assert.match(source, /requireHumanApiUser\(event\)/)
+  assert.match(source, /requireHumanOrDelegatedApiUser\(event\)/)
   assert.match(source, /profile\.userId !== auth\.user\.id/)
 }
 assert.match(notes, /Note queued for the agent’s next check-in/)
 assert.match(activity, /pendingNotes/)
 assert.match(activity, /lastCheckInAt/)
 
+// requireHumanApiUser stays strict: it guards AgentCredential administration
+// and AgentProfile create/patch/delete, so it must keep rejecting BOTH
+// machine AgentCredentials and first-party delegation tokens.
 const humanGuard = authGuard.match(
-  /export async function requireHumanApiUser[\s\S]*?\n}\n\nexport async function requireScopedApiUser/,
+  /export async function requireHumanApiUser[\s\S]*?\n}\n\n\/\*\*/,
 )?.[0]
-assert.ok(humanGuard)
-assert.doesNotMatch(humanGuard, /auth\.kind === 'first-party-delegation'/)
-assert.match(humanGuard, /auth\.kind === 'agent-credential'/)
+assert.ok(humanGuard, 'requireHumanApiUser contract was not found')
+assert.match(
+  humanGuard,
+  /auth\.kind === 'agent-credential' \|\| auth\.kind === 'first-party-delegation'/,
+)
+
+// requireHumanOrDelegatedApiUser is the narrow allowance: it rejects machine
+// AgentCredentials but lets a first-party delegation token through, for use
+// only on the non-credential, non-admin routes above.
+const delegatedGuard = authGuard.match(
+  /export async function requireHumanOrDelegatedApiUser[\s\S]*?\n}/,
+)?.[0]
+assert.ok(
+  delegatedGuard,
+  'requireHumanOrDelegatedApiUser contract was not found',
+)
+assert.match(delegatedGuard, /auth\.kind === 'agent-credential'/)
+assert.doesNotMatch(delegatedGuard, /auth\.kind === 'first-party-delegation'/)
 
 console.log('Agent check-in + human notes contract OK')


### PR DESCRIPTION
Rebuilds kind_robots#2290's check-in/notes feature on top of the reverted, safe `requireHumanApiUser` (#2291), without the bundled guard regression #2290 carried.

### What this is
The durable agent heartbeat + human-note-inbox feature from #2290, cherry-picked from its 10 feature commits unchanged (schema, migration, scoped `agent:checkin` credential scope, the `check-in.post.ts` endpoint, the concurrency-safe note-claiming, the dedicated contract + workflow). #2290 itself is superseded by this PR and should be closed.

### What's different from #2290
#2290 bundled the same `authGuard.ts` change #2289 made and #2291 reverted — dropping `first-party-delegation` from `requireHumanApiUser`'s reject list, which reopens the AgentCredential self-escalation path (rainbow-butterflies/t-035, kind_robots#2289/#2291's thread).

This PR keeps `requireHumanApiUser` exactly as reverted (rejects both `agent-credential` and `first-party-delegation` — still guards `agent-credentials/**` and `agent-profiles/index.post.ts` / `[id].patch.ts` / `[id].delete.ts`), and adds a new, narrower `requireHumanOrDelegatedApiUser` that rejects only `agent-credential`. Only the two routes that actually need Rainbow's BFF delegation use it:
- `server/api/agent-profiles/[id]/notes.post.ts` (human queues a note for their agent)
- `server/api/agent-profiles/[id]/activity.get.ts` (human reads check-in/note history)

Both routes' ownership check (`profile.userId !== auth.user.id`) is unchanged — the only thing that changed is which auth *kinds* can reach the route at all. `AgentCredential` (machine) creation/deletion stays behind the strict guard everywhere.

### Verification
- `npx tsx utils/scripts/verifyAgentCheckins.test.ts` → pass (updated to assert `requireHumanApiUser` still rejects both kinds, and `requireHumanOrDelegatedApiUser` rejects only `agent-credential`)
- `npx tsx tests/contracts/verifyFirstPartyDelegation.ts` → pass (unmodified by this PR, confirms the underlying delegation flow is untouched)
- `npx eslint` on all 4 changed files → clean
- `npx prettier --check` → clean (formatted)
- `npx vue-tsc --noEmit` → same 29 pre-existing errors as `origin/main` before this diff (all from kind-robots/t-087, the already-tracked stale-checked-in-Prisma-client issue predating #2285; confirmed via `git stash` — this diff adds zero new errors). CI regenerates the Prisma client fresh, so this is green there.
- Did not commit any `prisma/generated/**` diff — matches this repo's established convention (see kind-robots/t-088's PR note) of leaving that regeneration to CI/t-087 rather than sweeping an unrelated 300+ line generated diff into a feature PR.

### Context
rainbow-butterflies/t-035 (conductor) tracks the whole incident. Silas gave explicit live authorization to resolve the guard question this session ("not sure what the call is, just fix it").

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhLGUDWaU2gQAnw9KNb9cA)_