### PR TITLE
model-builder: guard cross-run flag release on abandoned auto-build/batch calls

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -512,6 +512,12 @@ jobs:
       - name: Model Builder batch items-cap guard contract
         run: npm run test:model-builder-batch-items-cap-guard
 
+      - name: Model Builder cross-run release guard checker self-test
+        run: npm run test:model-builder-cross-run-release-guard-selftest
+
+      - name: Model Builder cross-run release guard contract
+        run: npm run test:model-builder-cross-run-release-guard
+
       - name: Model Builder async poll-failure guard checker self-test
         run: npm run test:model-builder-async-poll-failure-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -276,6 +276,8 @@
     "test:model-builder-run-create-items-cap-guard": "tsx utils/scripts/verifyModelBuilderRunCreateItemsCapGuard.ts",
     "test:model-builder-batch-items-cap-guard-selftest": "tsx utils/scripts/verifyModelBuilderBatchItemsCapGuard.test.ts",
     "test:model-builder-batch-items-cap-guard": "tsx utils/scripts/verifyModelBuilderBatchItemsCapGuard.ts",
+    "test:model-builder-cross-run-release-guard-selftest": "tsx utils/scripts/verifyModelBuilderCrossRunReleaseGuard.test.ts",
+    "test:model-builder-cross-run-release-guard": "tsx utils/scripts/verifyModelBuilderCrossRunReleaseGuard.ts",
     "test:model-builder-async-poll-failure-guard-selftest": "tsx utils/scripts/verifyModelBuilderAsyncPollFailureGuard.test.ts",
     "test:model-builder-async-poll-failure-guard": "tsx utils/scripts/verifyModelBuilderAsyncPollFailureGuard.ts",
     "test:art-queue-poll-failure-guard-selftest": "tsx utils/scripts/verifyArtQueuePollFailureGuard.test.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -2335,7 +2335,24 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         )
       }
     } finally {
-      state.autoBuilding = false
+      // Bug (model-builder/t-029, cycle 75): unlike the loop body and the
+      // summary setStatus above, this used to clear state.autoBuilding
+      // unconditionally regardless of which run was active by the time this
+      // call's own awaited work finally settled. openRun/resetRun/resetAll
+      // eagerly clear state.autoBuilding the instant the user switches away
+      // (see their own doc comments) precisely so a *new* operation on the
+      // newly-active run isn't blocked by this abandoned one -- but that
+      // eager clear only protects the moment of the switch itself. If the
+      // user starts a genuinely new autoBuildRun/batchAutoBuild on the new
+      // run before this abandoned call's last awaited autoBuildItem()
+      // settles, this unconditional clear fires *after* that new operation
+      // has already re-set state.autoBuilding = true, silently stomping it
+      // back to false mid-flight -- the new run's UI reads "not busy" while
+      // its own auto-build is still genuinely running, opening the door to
+      // exactly the double-invocation race isRunOperationInFlight() exists
+      // to prevent. Only clear when this call still owns the flag, i.e. the
+      // active run is still the one this call started for.
+      if (state.run?.id === runId) state.autoBuilding = false
     }
   }
 
@@ -2493,7 +2510,17 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         )
       }
     } finally {
-      batchingOutputSingleton.release(outputKey)
+      // See autoBuildRun's identical fix (model-builder/t-029, cycle 75):
+      // releasing unconditionally let this abandoned call's finally fire
+      // after the user switched to a different run and started a brand-new
+      // batch operation that happens to share this same outputKey (a
+      // realistic collision -- output keys like "characters"/"rewards" are
+      // recipe-level names reused across many runs), silently releasing the
+      // NEW operation's own in-flight claim out from under it.
+      // batchingOutputSingleton.release only checks that the VALUE still
+      // matches, which a same-named group on a different run also satisfies
+      // -- only release when this call is still the one that owns it.
+      if (state.run?.id === runId) batchingOutputSingleton.release(outputKey)
     }
   }
 
@@ -2622,7 +2649,11 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         }
       }
     } finally {
-      batchingOutputSingleton.release(outputKey)
+      // See autoBuildRun's identical fix (model-builder/t-029, cycle 75) --
+      // only release when this call still owns the claim, or an abandoned
+      // call for a different run sharing this same outputKey can release a
+      // brand-new operation's in-flight claim out from under it.
+      if (state.run?.id === runId) batchingOutputSingleton.release(outputKey)
     }
   }
 
@@ -2734,7 +2765,11 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         }
       }
     } finally {
-      batchingOutputSingleton.release(outputKey)
+      // See autoBuildRun's identical fix (model-builder/t-029, cycle 75) --
+      // only release when this call still owns the claim, or an abandoned
+      // call for a different run sharing this same outputKey can release a
+      // brand-new operation's in-flight claim out from under it.
+      if (state.run?.id === runId) batchingOutputSingleton.release(outputKey)
     }
   }
 
@@ -2816,7 +2851,11 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         )
       }
     } finally {
-      batchingOutputSingleton.release(outputKey)
+      // See autoBuildRun's identical fix (model-builder/t-029, cycle 75) --
+      // only release when this call still owns the claim, or an abandoned
+      // call for a different run sharing this same outputKey can release a
+      // brand-new operation's in-flight claim out from under it.
+      if (state.run?.id === runId) batchingOutputSingleton.release(outputKey)
     }
   }
 

--- a/utils/scripts/verifyModelBuilderCrossRunReleaseGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderCrossRunReleaseGuard.test.ts
@@ -1,0 +1,284 @@
+// /utils/scripts/verifyModelBuilderCrossRunReleaseGuard.test.ts
+//
+// Regression test for checkCrossRunReleaseGuard() in
+// verifyModelBuilderCrossRunReleaseGuard.ts (model-builder/t-029, cycle 75).
+// Exercises the real check against synthetic store-shaped fixtures covering:
+// the pre-fix shape (all five functions clear/release unconditionally in
+// their finally block), the fixed shape (all five guarded on
+// `state.run?.id === runId`), a partial fix that leaves one function behind,
+// and all five target functions being absent entirely.
+import assert from 'node:assert/strict'
+
+import { checkCrossRunReleaseGuard } from './verifyModelBuilderCrossRunReleaseGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function autoBuildRun(): Promise<void> {
+    if (!state.run || isRunOperationInFlight()) return
+    state.autoBuilding = true
+    const runId = state.run.id
+    try {
+      // ...
+    } finally {
+      state.autoBuilding = false
+    }
+  }
+
+  async function batchDraftField(
+    outputKey: string,
+    field: DraftField,
+  ): Promise<void> {
+    const items = groupItems(outputKey)
+    if (!items.length) return
+    if (state.autoBuilding) return
+    const runId = state.run?.id
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchSetField(
+    outputKey: string,
+    fieldKey: string,
+    value: string,
+  ): Promise<void> {
+    if (state.autoBuilding) return
+    const runId = state.run?.id
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchApproveStage(
+    outputKey: string,
+    stageKey: BuildStageKey,
+  ): Promise<void> {
+    if (state.autoBuilding) return
+    const runId = state.run?.id
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchAutoBuild(outputKey: string): Promise<void> {
+    const items = groupItems(outputKey)
+    if (!items.length) return
+    if (state.autoBuilding) return
+    const runId = state.run?.id
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function autoBuildRun(): Promise<void> {
+    if (!state.run || isRunOperationInFlight()) return
+    state.autoBuilding = true
+    const runId = state.run.id
+    try {
+      // ...
+    } finally {
+      if (state.run?.id === runId) state.autoBuilding = false
+    }
+  }
+
+  async function batchDraftField(
+    outputKey: string,
+    field: DraftField,
+  ): Promise<void> {
+    const items = groupItems(outputKey)
+    if (!items.length) return
+    if (state.autoBuilding) return
+    const runId = state.run?.id
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      if (state.run?.id === runId) batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchSetField(
+    outputKey: string,
+    fieldKey: string,
+    value: string,
+  ): Promise<void> {
+    if (state.autoBuilding) return
+    const runId = state.run?.id
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      if (state.run?.id === runId) batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchApproveStage(
+    outputKey: string,
+    stageKey: BuildStageKey,
+  ): Promise<void> {
+    if (state.autoBuilding) return
+    const runId = state.run?.id
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      if (state.run?.id === runId) batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchAutoBuild(outputKey: string): Promise<void> {
+    const items = groupItems(outputKey)
+    if (!items.length) return
+    if (state.autoBuilding) return
+    const runId = state.run?.id
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      if (state.run?.id === runId) batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+
+const PARTIAL_FIX_FIXTURE = `
+  async function autoBuildRun(): Promise<void> {
+    if (!state.run || isRunOperationInFlight()) return
+    state.autoBuilding = true
+    const runId = state.run.id
+    try {
+      // ...
+    } finally {
+      if (state.run?.id === runId) state.autoBuilding = false
+    }
+  }
+
+  async function batchDraftField(
+    outputKey: string,
+    field: DraftField,
+  ): Promise<void> {
+    const items = groupItems(outputKey)
+    if (!items.length) return
+    if (state.autoBuilding) return
+    const runId = state.run?.id
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      if (state.run?.id === runId) batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchSetField(
+    outputKey: string,
+    fieldKey: string,
+    value: string,
+  ): Promise<void> {
+    if (state.autoBuilding) return
+    const runId = state.run?.id
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      if (state.run?.id === runId) batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchApproveStage(
+    outputKey: string,
+    stageKey: BuildStageKey,
+  ): Promise<void> {
+    if (state.autoBuilding) return
+    const runId = state.run?.id
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      if (state.run?.id === runId) batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchAutoBuild(outputKey: string): Promise<void> {
+    const items = groupItems(outputKey)
+    if (!items.length) return
+    if (state.autoBuilding) return
+    const runId = state.run?.id
+    batchingOutputSingleton.claim(outputKey)
+    try {
+      // ...
+    } finally {
+      batchingOutputSingleton.release(outputKey)
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkCrossRunReleaseGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  5,
+  `expected the pre-fix shape to raise exactly 5 violations (one per ` +
+    `unguarded function), got ${buggyErrors.length}: ${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(buggyErrors.some((e) => e.startsWith('autoBuildRun()')))
+for (const name of [
+  'batchDraftField',
+  'batchSetField',
+  'batchApproveStage',
+  'batchAutoBuild',
+]) {
+  assert.ok(
+    buggyErrors.some((e) => e.startsWith(`${name}()`)),
+    `expected an error for ${name}() releasing without the runId guard`,
+  )
+}
+
+const fixedErrors = checkCrossRunReleaseGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const partialErrors = checkCrossRunReleaseGuard(PARTIAL_FIX_FIXTURE)
+assert.equal(
+  partialErrors.length,
+  1,
+  'expected the partial-fix shape (batchAutoBuild left unguarded) to raise ' +
+    `exactly 1 error, got ${partialErrors.length}: ${JSON.stringify(partialErrors)}`,
+)
+assert.ok(partialErrors[0]!.startsWith('batchAutoBuild()'))
+
+const missingErrors = checkCrossRunReleaseGuard(MISSING_FIXTURE)
+assert.equal(
+  missingErrors.length,
+  5,
+  'expected 5 "function not found" violations when all five target ' +
+    `functions are absent, got ${missingErrors.length}: ${JSON.stringify(missingErrors)}`,
+)
+
+console.log(
+  'Model Builder cross-run release guard checker verified: flags all five ' +
+    'functions clearing/releasing their in-flight flag unconditionally, ' +
+    'clears the fixed shape, flags a partial fix that leaves one function ' +
+    'behind, and flags all five target functions being absent.',
+)

--- a/utils/scripts/verifyModelBuilderCrossRunReleaseGuard.ts
+++ b/utils/scripts/verifyModelBuilderCrossRunReleaseGuard.ts
@@ -1,0 +1,151 @@
+// /utils/scripts/verifyModelBuilderCrossRunReleaseGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 75) -- autoBuildRun() and the
+// four group batch operations (batchDraftField/batchSetField/
+// batchApproveStage/batchAutoBuild) each capture a `runId` up front so their
+// per-item loop and completion toast can tell "the user switched to a
+// different run via History mid-pass" apart from "still the same run" (see
+// verifyModelBuilderAutoBuildBatchExclusionGuard.ts and the runId doc
+// comments in the store itself) -- but until this cycle, that same runId was
+// never checked before each function's own `finally` block cleared its
+// store-wide "in flight" flag.
+//
+// openRun()/resetRun()/resetAll() already clear state.autoBuilding and
+// state.batchingOutputKey the instant the user switches away, precisely so a
+// *new* operation on the newly-active run isn't blocked by an abandoned one.
+// But an abandoned call's own `finally` still runs later, when its last
+// awaited autoBuildItem()/batchPushItems() call finally settles -- and if the
+// user has since started a genuinely new operation on the new run before
+// that happens, the abandoned call's unconditional clear/release silently
+// stomps the NEW operation's own in-flight flag back to false/null while it
+// is still genuinely running. For batchingOutputSingleton specifically this
+// is a real cross-run collision, not just a same-run one:
+// createOwnedSingleton's release(value) only checks that the VALUE still
+// matches, and output keys ("characters", "rewards", ...) are recipe-level
+// names reused across many different runs, so an abandoned call for Run A's
+// "rewards" group can release Run B's unrelated, still-running "rewards"
+// batch the moment they share that name. Either way, the busy indicator
+// clears while a real operation is still in flight, reopening the exact
+// double-invocation race isRunOperationInFlight()/anyBatching exist to
+// prevent.
+//
+// Fixed by guarding each function's own flag clear/release with
+// `if (state.run?.id === runId) ...` -- the same check each function's
+// completion-toast branch already used. This guard asserts that guard stays
+// in the `finally` block of all five functions: if a future refactor reverts
+// any one of them to an unconditional clear/release, this fails loudly
+// rather than silently reopening the race for just that entry point.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const RUN_ID_GUARD = /if\s*\(\s*state\.run\?\.id\s*===\s*runId\s*\)/
+
+const BATCH_FUNCTIONS = [
+  'batchDraftField',
+  'batchSetField',
+  'batchApproveStage',
+  'batchAutoBuild',
+] as const
+
+// Checks the fix's exact shape against the full source text of a file
+// containing autoBuildRun/batchXxx-named functions. Exported (rather than
+// only exercised via main()) so the self-test below can run it against
+// synthetic buggy/fixed fixtures without touching the real store file.
+export function checkCrossRunReleaseGuard(content: string): string[] {
+  const errors: string[] = []
+  const functions = extractFunctionBodies(content)
+
+  const runFn = functions.find((f) => f.name === 'autoBuildRun')
+  if (!runFn) {
+    errors.push(
+      'Could not find a function named autoBuildRun() -- has it been ' +
+        'renamed, removed, or inlined? If so, this guard (and the fix it ' +
+        'protects) needs to move with it.',
+    )
+  } else {
+    const finallyMatch = /finally\s*\{([\s\S]*?)\n {4}\}/.exec(runFn.body)
+    const finallyBody = finallyMatch?.[1] ?? ''
+    if (!/state\.autoBuilding\s*=\s*false/.test(finallyBody)) {
+      errors.push(
+        'autoBuildRun() no longer clears state.autoBuilding in its ' +
+          'finally block at all -- has the cleanup been moved or renamed?',
+      )
+    } else if (!RUN_ID_GUARD.test(finallyBody)) {
+      errors.push(
+        "autoBuildRun()'s finally block clears state.autoBuilding " +
+          'without first checking `state.run?.id === runId` -- an ' +
+          'abandoned call for a run the user has since switched away ' +
+          'from can clear a brand-new autoBuildRun()/batchAutoBuild() ' +
+          "call's own in-flight flag out from under it the moment the " +
+          'abandoned call finally settles.',
+      )
+    }
+  }
+
+  for (const name of BATCH_FUNCTIONS) {
+    const fn = functions.find((f) => f.name === name)
+    if (!fn) {
+      errors.push(
+        `Could not find a function named ${name}() -- has it been ` +
+          'renamed, removed, or inlined? If so, this guard (and the fix ' +
+          'it protects) needs to move with it.',
+      )
+      continue
+    }
+    const finallyMatch = /finally\s*\{([\s\S]*?)\n {4}\}/.exec(fn.body)
+    const finallyBody = finallyMatch?.[1] ?? ''
+    if (!/batchingOutputSingleton\.release\(outputKey\)/.test(finallyBody)) {
+      errors.push(
+        `${name}() no longer releases batchingOutputSingleton in its ` +
+          'finally block at all -- has the cleanup been moved or renamed?',
+      )
+    } else if (!RUN_ID_GUARD.test(finallyBody)) {
+      errors.push(
+        `${name}()'s finally block releases batchingOutputSingleton ` +
+          'without first checking `state.run?.id === runId` -- an ' +
+          'abandoned call for a run the user has since switched away ' +
+          "from can release a brand-new same-outputKey batch call's " +
+          'own in-flight claim out from under it the moment the ' +
+          'abandoned call finally settles (output keys are recipe-level ' +
+          'names reused across many different runs, so this is a real ' +
+          'cross-run collision, not just a same-run one).',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkCrossRunReleaseGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder cross-run release guard contract failed in ' +
+        'modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder cross-run release guard contract passed: ' +
+      'autoBuildRun() and every group batch operation only clear/release ' +
+      'their own in-flight flag when the active run is still the one the ' +
+      'call started for.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Bug

`autoBuildRun()` and the four group batch operations (`batchDraftField`/`batchSetField`/`batchApproveStage`/`batchAutoBuild`) each capture a `runId` up front so their per-item loop and completion toast can tell "the user switched to a different run via History mid-pass" apart from "still the same run" — but their own `finally` block cleared/released the store-wide in-flight flag (`state.autoBuilding` / `state.batchingOutputKey`) unconditionally, without that same `runId` check.

`openRun()`/`resetRun()`/`resetAll()` already clear these flags the instant the user switches runs via History, so a *new* operation on the newly-active run isn't blocked by an abandoned one — but if the user starts a genuinely new operation on the new run before the abandoned call's last awaited work (`autoBuildItem()`/`batchPushItems()`) settles, that abandoned call's unconditional `finally` later stomps the new operation's own in-flight flag back to `false`/`null` while it is still genuinely running. The UI then reads "not busy" for an operation that's still active, reopening the exact double-invocation race `isRunOperationInFlight()`/`anyBatching` exist to prevent.

For `batchingOutputSingleton` specifically this is a real **cross-run** collision, not just same-run: `createOwnedSingleton`'s `release(value)` only checks that the value still matches, and output keys (`"characters"`, `"rewards"`, ...) are recipe-level names reused across many different runs — so an abandoned call for Run A's "rewards" group can release Run B's unrelated, still-running "rewards" batch the moment they share that name.

Reachable through the UI: `model-builder-run-history.vue`'s "Open"/"New run" buttons are not disabled while `store.autoBuilding`/`store.batchingOutputKey` are set, so a user can switch runs mid-operation.

## Fix

Guarded all five `finally` sites with the same `state.run?.id === runId` check already used for each function's own completion toast.

Added `verifyModelBuilderCrossRunReleaseGuard.ts` + `.test.ts`, wired into `package.json`/`contract-tests.yml`, matching this task's established guard convention.

## Verification

- New guard checker passes against the real (fixed) store file; self-test covers the buggy/fixed/partial-fix/missing-function shapes
- All 155 `test:model-builder-*` npm scripts pass (checked via exit code)
- `eslint` clean on all changed/added files (2 pre-existing `no-empty` errors elsewhere in `modelBuilderStore.ts` confirmed unrelated via `git stash`)
- `prettier --check` clean
- `vue-tsc --noEmit` repo-wide: exit 0, zero errors
- `git status --porcelain` scoped to exactly the 5 intended files

model-builder/t-029 cycle 75 (Conductor coordination repo — recurring polish/bugfix task on the Model Builder front-end/server surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmKRTykCGGa9kvRiM9UM8W)_