### PR TITLE
style: migrate add-bot/character/reward/scenario panels to kr-panel-muted

### DIFF
--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -1,8 +1,6 @@
 <!-- /components/content/bots/add-bot.vue -->
 <template>
-  <div
-    class="kr-container-wide flex flex-col gap-6 rounded-2xl border border-base-300 bg-base-200 p-4"
-  >
+  <div class="kr-container-wide flex flex-col gap-6 kr-panel-muted p-4">
     <header class="text-center">
       <h1 class="text-3xl font-bold text-primary md:text-4xl">
         {{ title }}

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -1,8 +1,6 @@
 <!-- /components/characters/add-character.vue -->
 <template>
-  <section
-    class="kr-container-wide flex flex-col gap-6 rounded-2xl border border-base-300 bg-base-200 p-4"
-  >
+  <section class="kr-container-wide flex flex-col gap-6 kr-panel-muted p-4">
     <header class="text-center">
       <h1 class="text-3xl font-black text-primary md:text-4xl">
         {{ title }}

--- a/components/rewards/add-reward.vue
+++ b/components/rewards/add-reward.vue
@@ -1,8 +1,6 @@
 <!-- /components/content/rewards/add-reward.vue -->
 <template>
-  <div
-    class="kr-container-wide flex flex-col gap-6 rounded-2xl border border-base-300 bg-base-200 p-4"
-  >
+  <div class="kr-container-wide flex flex-col gap-6 kr-panel-muted p-4">
     <header class="text-center">
       <h1 class="text-3xl font-bold text-primary md:text-4xl">
         {{ heading }}

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -1,8 +1,6 @@
 <!-- /components/content/weird/add-scenario.vue -->
 <template>
-  <div
-    class="kr-container-wide flex flex-col gap-6 rounded-2xl border border-base-300 bg-base-200 p-4"
-  >
+  <div class="kr-container-wide flex flex-col gap-6 kr-panel-muted p-4">
     <header class="text-center">
       <h1 class="text-3xl font-bold text-primary md:text-4xl">
         {{ heading }}


### PR DESCRIPTION
## What changed

The four `add-*` creation forms (`add-bot.vue`, `add-character.vue`, `add-reward.vue`, `add-scenario.vue`) shared an identical hand-rolled root panel class:

```
kr-container-wide flex flex-col gap-6 rounded-2xl border border-base-300 bg-base-200 p-4
```

`rounded-2xl border border-base-300 bg-base-200` is a byte-exact match for the shared `kr-panel-muted` primitive (`assets/css/tailwind.css:532`, `rounded-2xl border border-base-300 bg-base-200 p-6`), so each file now composes it with its own `p-4` override:

```
kr-container-wide flex flex-col gap-6 kr-panel-muted p-4
```

## Why

`interface-vision/t-104` — drive live front-end consistency onto shared `kr-* `components and composition rules. This is the same padding-override pattern already used elsewhere in this same component family (`add-checkpoint.vue`, `add-server.vue` already compose `kr-panel-flat`), and a repo-wide grep confirms these four files were the only remaining un-migrated instance of this exact shape (`kr-container-wide flex flex-col gap-6 ...`).

## What was preserved

- `p-4` — the only real override; `kr-panel-muted` ships `p-6`.
- Everything else (`kr-container-wide flex flex-col gap-6`) untouched.

No geometry, markup structure, or behavior change — purely a class-list consolidation.

## Verification

- `eslint` on all 4 changed files — clean (one pre-existing, unrelated `no-extra-boolean-cast` error at `add-bot.vue:686` confirmed via `git stash` to exist before this change too).
- `vue-tsc --noEmit` (repo-wide) — clean, exit 0.
- `npm run test:layout-contract` — holds at the 207-violation baseline, zero new.
- `prettier --check` — `add-scenario.vue` was prettier-clean before this change and stays clean (the shortened class string now fits on one line, collapsed to match). `add-bot.vue`/`add-character.vue`/`add-reward.vue` carry pre-existing formatting drift elsewhere in each file, confirmed via `git stash` to exist identically before this change — left untouched per the established convention against running `prettier --write` on a file that isn't already prettier-clean.
- `git status --porcelain` scoped to exactly the 4 intended files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcxHrFVe1AkFEC3DH3i2j9)_