### PR TITLE
security: throttle first-party password delegation exchange

### DIFF
--- a/server/api/auth/first-party/password.post.ts
+++ b/server/api/auth/first-party/password.post.ts
@@ -1,5 +1,10 @@
 import { createError, defineEventHandler, readBody, setHeader } from 'h3'
 import { validateUserCredentials } from '@/server/api/auth'
+import {
+  assertAuthAttemptAllowed,
+  clearAuthFailures,
+  recordAuthFailure,
+} from '@/server/utils/authAttemptLimit'
 import { getFirstPartyClients } from '@/server/utils/firstPartySso'
 import { issueFirstPartyDelegation } from '@/server/utils/firstPartyDelegation'
 import { findFirstPartyClient } from '~/utils/firstPartySsoContract'
@@ -26,10 +31,13 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, message: 'Username and password are required.' })
   }
 
+  assertAuthAttemptAllowed(event, username)
   const result = await validateUserCredentials(username, password)
   if (!result?.user || result.user.isActive === false) {
+    recordAuthFailure(event, username)
     throw createError({ statusCode: 401, message: 'Invalid username or password.' })
   }
+  clearAuthFailures(event, username)
 
   const delegationToken = await issueFirstPartyDelegation({
     userId: result.user.id,

--- a/server/utils/authAttemptLimit.ts
+++ b/server/utils/authAttemptLimit.ts
@@ -35,7 +35,10 @@ function retryAfterSeconds(window: FailureWindow, now: number): number {
   return Math.max(1, Math.ceil((window.resetAt - now) / 1000))
 }
 
-export function assertAuthAttemptAllowed(event: H3Event, username: string): void {
+export function assertAuthAttemptAllowed(
+  event: H3Event,
+  username: string,
+): void {
   const now = Date.now()
   const pair = currentWindow(pairFailures, pairKey(event, username), now)
   const ipKey = requestIp(event)
@@ -49,7 +52,7 @@ export function assertAuthAttemptAllowed(event: H3Event, username: string): void
 
   if (!blocked) return
 
-  setHeader(event, 'Retry-After', String(retryAfterSeconds(blocked, now)))
+  setHeader(event, 'Retry-After', retryAfterSeconds(blocked, now))
   throw createError({
     statusCode: 429,
     message: 'Too many failed sign-in attempts. Please try again later.',

--- a/server/utils/authAttemptLimit.ts
+++ b/server/utils/authAttemptLimit.ts
@@ -12,12 +12,12 @@ type FailureWindow = {
 const pairFailures = new Map<string, FailureWindow>()
 const ipFailures = new Map<string, FailureWindow>()
 
-function requestIp(event: H3Event): string {
-  return getRequestIP(event, { xForwardedFor: true }) || 'unknown'
+function requestIp(event: H3Event): string | undefined {
+  return getRequestIP(event, { xForwardedFor: true }) || undefined
 }
 
 function pairKey(event: H3Event, username: string): string {
-  return `${requestIp(event)}:${username.trim().toLowerCase()}`
+  return `${requestIp(event) ?? 'unknown'}:${username.trim().toLowerCase()}`
 }
 
 function currentWindow(
@@ -38,7 +38,8 @@ function retryAfterSeconds(window: FailureWindow, now: number): number {
 export function assertAuthAttemptAllowed(event: H3Event, username: string): void {
   const now = Date.now()
   const pair = currentWindow(pairFailures, pairKey(event, username), now)
-  const ip = currentWindow(ipFailures, requestIp(event), now)
+  const ipKey = requestIp(event)
+  const ip = ipKey ? currentWindow(ipFailures, ipKey, now) : undefined
   const blocked =
     pair && pair.count >= MAX_PAIR_FAILURES
       ? pair
@@ -71,7 +72,8 @@ function recordFailure(
 export function recordAuthFailure(event: H3Event, username: string): void {
   const now = Date.now()
   recordFailure(pairFailures, pairKey(event, username), now)
-  recordFailure(ipFailures, requestIp(event), now)
+  const ipKey = requestIp(event)
+  if (ipKey) recordFailure(ipFailures, ipKey, now)
 }
 
 export function clearAuthFailures(event: H3Event, username: string): void {

--- a/server/utils/authAttemptLimit.ts
+++ b/server/utils/authAttemptLimit.ts
@@ -1,0 +1,79 @@
+import { createError, getRequestIP, setHeader, type H3Event } from 'h3'
+
+const WINDOW_MS = 15 * 60 * 1000
+const MAX_PAIR_FAILURES = 5
+const MAX_IP_FAILURES = 20
+
+type FailureWindow = {
+  count: number
+  resetAt: number
+}
+
+const pairFailures = new Map<string, FailureWindow>()
+const ipFailures = new Map<string, FailureWindow>()
+
+function requestIp(event: H3Event): string {
+  return getRequestIP(event, { xForwardedFor: true }) || 'unknown'
+}
+
+function pairKey(event: H3Event, username: string): string {
+  return `${requestIp(event)}:${username.trim().toLowerCase()}`
+}
+
+function currentWindow(
+  windows: Map<string, FailureWindow>,
+  key: string,
+  now: number,
+): FailureWindow | undefined {
+  const current = windows.get(key)
+  if (current && current.resetAt > now) return current
+  if (current) windows.delete(key)
+  return undefined
+}
+
+function retryAfterSeconds(window: FailureWindow, now: number): number {
+  return Math.max(1, Math.ceil((window.resetAt - now) / 1000))
+}
+
+export function assertAuthAttemptAllowed(event: H3Event, username: string): void {
+  const now = Date.now()
+  const pair = currentWindow(pairFailures, pairKey(event, username), now)
+  const ip = currentWindow(ipFailures, requestIp(event), now)
+  const blocked =
+    pair && pair.count >= MAX_PAIR_FAILURES
+      ? pair
+      : ip && ip.count >= MAX_IP_FAILURES
+        ? ip
+        : undefined
+
+  if (!blocked) return
+
+  setHeader(event, 'Retry-After', String(retryAfterSeconds(blocked, now)))
+  throw createError({
+    statusCode: 429,
+    message: 'Too many failed sign-in attempts. Please try again later.',
+  })
+}
+
+function recordFailure(
+  windows: Map<string, FailureWindow>,
+  key: string,
+  now: number,
+): void {
+  const current = currentWindow(windows, key, now)
+  if (current) {
+    current.count += 1
+    return
+  }
+  windows.set(key, { count: 1, resetAt: now + WINDOW_MS })
+}
+
+export function recordAuthFailure(event: H3Event, username: string): void {
+  const now = Date.now()
+  recordFailure(pairFailures, pairKey(event, username), now)
+  recordFailure(ipFailures, requestIp(event), now)
+}
+
+export function clearAuthFailures(event: H3Event, username: string): void {
+  pairFailures.delete(pairKey(event, username))
+}

--- a/tests/contracts/verifyFirstPartyDelegation.ts
+++ b/tests/contracts/verifyFirstPartyDelegation.ts
@@ -13,6 +13,10 @@ const passwordExchange = readFileSync(
   'server/api/auth/first-party/password.post.ts',
   'utf8',
 )
+const authAttemptLimit = readFileSync(
+  'server/utils/authAttemptLimit.ts',
+  'utf8',
+)
 const delegation = readFileSync(
   'server/utils/firstPartyDelegation.ts',
   'utf8',
@@ -26,6 +30,13 @@ for (const source of [googleExchange, codeExchange, passwordExchange]) {
 
 assert.match(passwordExchange, /findFirstPartyClient/)
 assert.match(passwordExchange, /validateUserCredentials/)
+assert.match(passwordExchange, /assertAuthAttemptAllowed\(event, username\)/)
+assert.match(passwordExchange, /recordAuthFailure\(event, username\)/)
+assert.match(passwordExchange, /clearAuthFailures\(event, username\)/)
+assert.match(authAttemptLimit, /statusCode:\s*429/)
+assert.match(authAttemptLimit, /'Retry-After'/)
+assert.match(authAttemptLimit, /MAX_PAIR_FAILURES/)
+assert.match(authAttemptLimit, /MAX_IP_FAILURES/)
 assert.match(delegation, /kind:\s*TOKEN_KIND/)
 assert.match(delegation, /setSubject\(String\(input\.userId\)\)/)
 assert.match(delegation, /setAudience\(input\.client\.id\)/)


### PR DESCRIPTION
## Summary
- add a shared in-memory failed-auth attempt limiter keyed by IP+username and by IP
- apply it to the first-party password delegation exchange
- return `429` with `Retry-After` after repeated failures and clear the pair budget after successful auth
- extend the First-Party Delegation contract so throttling cannot silently disappear

## Scope
This implements only Rainbow Butterflies `t-036` point (1), the unambiguous credential-testing hardening. It deliberately does **not** decide the two human-gated security/product tradeoffs: whether first-party clients need a client secret, or whether 7-day delegation JWTs need revocation state.

The existing ordinary `/api/auth/login` endpoint also has no rate limiter on current main. I did not quietly broaden this PR into a general login-auth rewrite; the new helper is reusable for that follow-up.

Conductor session: `openai-scheduled-20260901T131524Z-rainbow-t036-a9f4`