### PR TITLE
security: rate-limit the ordinary /api/auth/login endpoint

### DIFF
--- a/.github/workflows/login-throttle-contract.yml
+++ b/.github/workflows/login-throttle-contract.yml
@@ -1,0 +1,37 @@
+name: Login Throttle Contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/auth/login.post.ts'
+      - 'server/utils/authAttemptLimit.ts'
+      - 'tests/contracts/verifyLoginThrottle.ts'
+      - '.github/workflows/login-throttle-contract.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'server/api/auth/login.post.ts'
+      - 'server/utils/authAttemptLimit.ts'
+      - 'tests/contracts/verifyLoginThrottle.ts'
+      - '.github/workflows/login-throttle-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Install dependencies
+        run: npm install --include=optional
+      - name: Verify login throttle contract
+        run: npx tsx tests/contracts/verifyLoginThrottle.ts

--- a/server/api/auth/login.post.ts
+++ b/server/api/auth/login.post.ts
@@ -1,6 +1,11 @@
 // server/api/auth/login.post.ts
-import { defineEventHandler, readBody, sendError, setCookie } from 'h3'
+import { defineEventHandler, isError, readBody, sendError, setCookie } from 'h3'
 import { validateUserCredentials } from '.'
+import {
+  assertAuthAttemptAllowed,
+  clearAuthFailures,
+  recordAuthFailure,
+} from '../../utils/authAttemptLimit'
 import { logSafeError } from '../../utils/error'
 
 export default defineEventHandler(async (event) => {
@@ -10,9 +15,13 @@ export default defineEventHandler(async (event) => {
       password: string
     }>(event)
 
+    const safeUsername = typeof username === 'string' ? username : ''
+    assertAuthAttemptAllowed(event, safeUsername)
+
     const result = await validateUserCredentials(username, password)
 
     if (result && result.user) {
+      clearAuthFailures(event, safeUsername)
       const sessionValue = String(result.token ?? '')
 
       if (sessionValue) {
@@ -33,9 +42,13 @@ export default defineEventHandler(async (event) => {
       return { success: true, data }
     }
 
+    recordAuthFailure(event, safeUsername)
     event.node.res.statusCode = 401
     return { success: false, message: 'Invalid credentials' }
   } catch (error: unknown) {
+    if (isError(error)) {
+      return sendError(event, error)
+    }
     logSafeError('Error during login:', error)
     const errorMessage =
       error instanceof Error ? error.message : 'Unknown error occurred'

--- a/tests/contracts/verifyLoginThrottle.ts
+++ b/tests/contracts/verifyLoginThrottle.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const login = readFileSync('server/api/auth/login.post.ts', 'utf8')
+const authAttemptLimit = readFileSync(
+  'server/utils/authAttemptLimit.ts',
+  'utf8',
+)
+
+// The ordinary /api/auth/login endpoint reuses the same failure-window helper
+// the first-party password exchange uses (rainbow-butterflies/t-036 ->
+// t-037), rather than growing its own ad hoc rate limiter.
+assert.match(login, /assertAuthAttemptAllowed\(event, safeUsername\)/)
+assert.match(login, /recordAuthFailure\(event, safeUsername\)/)
+assert.match(login, /clearAuthFailures\(event, safeUsername\)/)
+
+// A thrown H3Error (the helper's 429) must reach the client with its real
+// status code, not get flattened into a generic 500 by the handler's own
+// catch block.
+assert.match(login, /isError\(error\)/)
+assert.match(login, /sendError\(event, error\)/)
+
+assert.match(authAttemptLimit, /statusCode:\s*429/)
+assert.match(authAttemptLimit, /'Retry-After'/)
+assert.match(authAttemptLimit, /MAX_PAIR_FAILURES/)
+assert.match(authAttemptLimit, /MAX_IP_FAILURES/)
+
+console.log('Login throttle contract OK')


### PR DESCRIPTION
## Summary
- reuse `server/utils/authAttemptLimit.ts` (added in #2297 for the first-party password exchange) to rate-limit the ordinary `/api/auth/login` endpoint, instead of growing a second ad hoc limiter
- fix `login.post.ts`'s catch block, which previously flattened every thrown error — including the helper's new 429 — into a generic 500 via `sendError(event, new Error(message))`; now checks `isError()` and forwards an `H3Error`'s real status/message unchanged
- add `tests/contracts/verifyLoginThrottle.ts` (mirrors `verifyFirstPartyDelegation.ts`'s static source-assertion pattern) and a dedicated path-triggered workflow, matching the convention of the repo's other narrow contract checks

## Scope
This is `rainbow-butterflies/t-037`, the direct kaizen follow-up from `t-036` (#2297): that PR's own body flagged `/api/auth/login` as the other unthrottled credential-testing surface and built the helper to be reusable there. No other behavior changes.

Conductor session: `claude-scheduled-20260901T135130Z-rbf-t037`

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJBEtiAHE561F9VfRaJ9tf)_