### PR TITLE
fix(model-builder): guard cross-run singleton release against a same-run revisit

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -518,6 +518,12 @@ jobs:
       - name: Model Builder cross-run release guard contract
         run: npm run test:model-builder-cross-run-release-guard
 
+      - name: Model Builder run-epoch guard checker self-test
+        run: npm run test:model-builder-run-epoch-guard-selftest
+
+      - name: Model Builder run-epoch guard contract
+        run: npm run test:model-builder-run-epoch-guard
+
       - name: Model Builder async poll-failure guard checker self-test
         run: npm run test:model-builder-async-poll-failure-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -278,6 +278,8 @@
     "test:model-builder-batch-items-cap-guard": "tsx utils/scripts/verifyModelBuilderBatchItemsCapGuard.ts",
     "test:model-builder-cross-run-release-guard-selftest": "tsx utils/scripts/verifyModelBuilderCrossRunReleaseGuard.test.ts",
     "test:model-builder-cross-run-release-guard": "tsx utils/scripts/verifyModelBuilderCrossRunReleaseGuard.ts",
+    "test:model-builder-run-epoch-guard-selftest": "tsx utils/scripts/verifyModelBuilderRunEpochGuard.test.ts",
+    "test:model-builder-run-epoch-guard": "tsx utils/scripts/verifyModelBuilderRunEpochGuard.ts",
     "test:model-builder-async-poll-failure-guard-selftest": "tsx utils/scripts/verifyModelBuilderAsyncPollFailureGuard.test.ts",
     "test:model-builder-async-poll-failure-guard": "tsx utils/scripts/verifyModelBuilderAsyncPollFailureGuard.ts",
     "test:art-queue-poll-failure-guard-selftest": "tsx utils/scripts/verifyArtQueuePollFailureGuard.test.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -491,6 +491,22 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   // unreachable from the now-different state.run). See generateItemAsset.
   const cancelledRunIds = new Set<string>()
 
+  // Bumped every time the user abandons the active run's in-flight work via
+  // resetRun/resetAll/openRun/resumeRun (model-builder/t-029, cycle 76). Cycle
+  // 75's own fix guarded autoBuildRun/batchDraftField/batchSetField/
+  // batchApproveStage/batchAutoBuild's loop-abort checks and finally-block
+  // flag clears with `state.run?.id === runId` -- but a run id is not a
+  // one-shot token: openRun()'s cached-adopt branch reuses the exact same
+  // cached run object on a revisit, and state.runs is never purged by
+  // resetRun(), so reopening the SAME run after abandoning it (e.g. "New
+  // run" mid auto-build, then History → Open on the run just left) makes
+  // `state.run?.id === runId` true again even though the abandon event
+  // already happened. A captured runId alone can't tell "still the same
+  // continuous session on this run" apart from "abandoned this run, then
+  // later revisited the same run id" -- runEpoch can, because it is bumped
+  // once per abandon and never reused.
+  let runEpoch = 0
+
   // --- display helpers ------------------------------------------------------
 
   function sourceLabel(record: SourceRecord | null): string {
@@ -2280,13 +2296,18 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     // would then also overwrite whatever the user is now looking at with a
     // completed count for a run they've navigated away from).
     const runId = state.run.id
+    // See runEpoch's own doc comment (model-builder/t-029, cycle 76) -- a
+    // run id alone doesn't catch a *revisit* of this same run after it was
+    // abandoned mid-loop (History → Open on the run just reset away from);
+    // runEpoch does, since it's bumped once per abandon and never reused.
+    const epoch = runEpoch
     const items = [...state.run.items]
     let committed = 0
     let skipped = 0
     let failed = 0
     try {
       for (const item of items) {
-        if (state.run?.id !== runId) return
+        if (state.run?.id !== runId || runEpoch !== epoch) return
         if (item.stages.COMMIT.status === 'approved') {
           committed++
           // Already committed before this pass touched it -- not routed
@@ -2310,7 +2331,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         else if (outcome === 'skipped') skipped++
         else failed++
       }
-      if (state.run?.id === runId) {
+      if (state.run?.id === runId && runEpoch === epoch) {
         // A 'failed' outcome (a rejected commit — e.g. the ASSET_ONLY
         // attachability re-check in commit.post.ts firing because the
         // ArtImage's owner changed its visibility mid-run — a draft that
@@ -2351,8 +2372,11 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       // its own auto-build is still genuinely running, opening the door to
       // exactly the double-invocation race isRunOperationInFlight() exists
       // to prevent. Only clear when this call still owns the flag, i.e. the
-      // active run is still the one this call started for.
-      if (state.run?.id === runId) state.autoBuilding = false
+      // active run is still the one this call started for. Also checked
+      // against runEpoch (model-builder/t-029, cycle 76) -- see its own doc
+      // comment for why a plain run-id match isn't enough on a revisit.
+      if (state.run?.id === runId && runEpoch === epoch)
+        state.autoBuilding = false
     }
   }
 
@@ -2428,8 +2452,12 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     // of which run was on screen by then, popping a misleading "Drafted
     // X/N items." banner over whatever OTHER run the user has since
     // switched to, about a group that isn't even part of what's on screen.
-    // Captured up front, mirroring autoBuildRun's own runId capture.
+    // Captured up front, mirroring autoBuildRun's own runId capture. epoch
+    // mirrors autoBuildRun's own epoch capture (model-builder/t-029, cycle
+    // 76) -- see runEpoch's doc comment for why runId alone misses a
+    // same-run revisit.
     const runId = state.run?.id
+    const epoch = runEpoch
     const stageKey = stageForDraftField(field)
     batchingOutputSingleton.claim(outputKey)
     clearStatus()
@@ -2519,8 +2547,12 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       // NEW operation's own in-flight claim out from under it.
       // batchingOutputSingleton.release only checks that the VALUE still
       // matches, which a same-named group on a different run also satisfies
-      // -- only release when this call is still the one that owns it.
-      if (state.run?.id === runId) batchingOutputSingleton.release(outputKey)
+      // -- only release when this call is still the one that owns it. Also
+      // checked against runEpoch (model-builder/t-029, cycle 76) -- see its
+      // own doc comment for why a plain run-id match isn't enough on a
+      // revisit.
+      if (state.run?.id === runId && runEpoch === epoch)
+        batchingOutputSingleton.release(outputKey)
     }
   }
 
@@ -2574,6 +2606,9 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     // "Set ... on N/M items." success banner over whatever OTHER run is now
     // on screen, about a group that isn't even part of what's on screen.
     const runId = state.run?.id
+    // See batchDraftField's identical epoch capture (model-builder/t-029,
+    // cycle 76) and runEpoch's own doc comment.
+    const epoch = runEpoch
     const items = groupItems(outputKey)
     const entries: Array<{
       item: BuildItem
@@ -2652,8 +2687,12 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       // See autoBuildRun's identical fix (model-builder/t-029, cycle 75) --
       // only release when this call still owns the claim, or an abandoned
       // call for a different run sharing this same outputKey can release a
-      // brand-new operation's in-flight claim out from under it.
-      if (state.run?.id === runId) batchingOutputSingleton.release(outputKey)
+      // brand-new operation's in-flight claim out from under it. Also
+      // checked against runEpoch (model-builder/t-029, cycle 76) -- see its
+      // own doc comment for why a plain run-id match isn't enough on a
+      // revisit.
+      if (state.run?.id === runId && runEpoch === epoch)
+        batchingOutputSingleton.release(outputKey)
     }
   }
 
@@ -2700,6 +2739,9 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     // switch runs during via History, and this function's success toast was
     // a bare, unscoped setStatus with no runId at all.
     const runId = state.run?.id
+    // See batchDraftField's identical epoch capture (model-builder/t-029,
+    // cycle 76) and runEpoch's own doc comment.
+    const epoch = runEpoch
     const entries: Array<{
       item: BuildItem
       payload: Record<string, unknown>
@@ -2768,8 +2810,12 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       // See autoBuildRun's identical fix (model-builder/t-029, cycle 75) --
       // only release when this call still owns the claim, or an abandoned
       // call for a different run sharing this same outputKey can release a
-      // brand-new operation's in-flight claim out from under it.
-      if (state.run?.id === runId) batchingOutputSingleton.release(outputKey)
+      // brand-new operation's in-flight claim out from under it. Also
+      // checked against runEpoch (model-builder/t-029, cycle 76) -- see its
+      // own doc comment for why a plain run-id match isn't enough on a
+      // revisit.
+      if (state.run?.id === runId && runEpoch === epoch)
+        batchingOutputSingleton.release(outputKey)
     }
   }
 
@@ -2802,6 +2848,10 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     // (mirroring batchDraftField/batchSetField/batchApproveStage's own
     // identical `state.run?.id` capture) rather than a non-null assertion.
     const runId = state.run?.id
+    // See autoBuildRun's identical epoch capture (model-builder/t-029, cycle
+    // 76) and runEpoch's own doc comment -- a run id alone doesn't catch a
+    // revisit of this same run after it was abandoned mid-loop.
+    const epoch = runEpoch
     batchingOutputSingleton.claim(outputKey)
     clearStatus()
     let committed = 0
@@ -2814,7 +2864,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         // rather than continuing to await autoBuildItem() calls that can
         // now only fail fast (findItem() won't find this item in whatever
         // OTHER run is now active).
-        if (state.run?.id !== runId) return
+        if (state.run?.id !== runId || runEpoch !== epoch) return
         if (item.stages.COMMIT.status === 'approved') {
           committed++
           // See autoBuildRun's identical branch: keep the badge from
@@ -2844,7 +2894,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       const failedNote = failed
         ? ` (${failed} failed — see the item's own error for details)`
         : ''
-      if (state.run?.id === runId) {
+      if (state.run?.id === runId && runEpoch === epoch) {
         setStatus(
           failed ? 'error' : 'success',
           `Auto-built ${committed}/${items.length} in this group${failedNote}${skippedNote}.`,
@@ -2854,8 +2904,12 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       // See autoBuildRun's identical fix (model-builder/t-029, cycle 75) --
       // only release when this call still owns the claim, or an abandoned
       // call for a different run sharing this same outputKey can release a
-      // brand-new operation's in-flight claim out from under it.
-      if (state.run?.id === runId) batchingOutputSingleton.release(outputKey)
+      // brand-new operation's in-flight claim out from under it. Also
+      // checked against runEpoch (model-builder/t-029, cycle 76) -- see its
+      // own doc comment for why a plain run-id match isn't enough on a
+      // revisit.
+      if (state.run?.id === runId && runEpoch === epoch)
+        batchingOutputSingleton.release(outputKey)
     }
   }
 
@@ -2954,6 +3008,8 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
           state.autoBuildingItemId = null
           state.batchingOutputKey = null
           draftingField.value = null
+          // See runEpoch's own doc comment (model-builder/t-029, cycle 76).
+          runEpoch++
           state.run = adaptRun(data)
           state.sourceType = data.sourceType as SourceTypeKey
           state.recipeKey = data.recipeKey as RecipeKey
@@ -3101,6 +3157,13 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       state.autoBuildingItemId = null
       state.batchingOutputKey = null
       draftingField.value = null
+      // See runEpoch's own doc comment (model-builder/t-029, cycle 76) --
+      // this branch is reachable on a revisit (opening a run whose id
+      // matches one abandoned earlier this session), so the eager flag
+      // clears above aren't enough on their own to stop an abandoned loop
+      // that's still in flight from resuming once the id compares equal
+      // again.
+      runEpoch++
       state.run = cached
       state.sourceType = cached.sourceType
       state.recipeKey = cached.recipeKey
@@ -3140,6 +3203,8 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         state.autoBuildingItemId = null
         state.batchingOutputKey = null
         draftingField.value = null
+        // See runEpoch's own doc comment (model-builder/t-029, cycle 76).
+        runEpoch++
         state.run = adaptRun(response.data)
         state.sourceType = state.run.sourceType
         state.recipeKey = state.run.recipeKey
@@ -3229,6 +3294,8 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     state.autoBuildingItemId = null
     state.batchingOutputKey = null
     draftingField.value = null
+    // See runEpoch's own doc comment (model-builder/t-029, cycle 76).
+    runEpoch++
     safeRemove(runIdKey)
     clearStatus()
   }
@@ -3252,6 +3319,8 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     state.autoBuildingItemId = null
     state.batchingOutputKey = null
     draftingField.value = null
+    // See runEpoch's own doc comment (model-builder/t-029, cycle 76).
+    runEpoch++
     safeRemove(runIdKey)
     clearStatus()
   }

--- a/utils/scripts/verifyModelBuilderBatchGroupStatusScopeGuard.ts
+++ b/utils/scripts/verifyModelBuilderBatchGroupStatusScopeGuard.ts
@@ -72,9 +72,13 @@ function findUnguardedBareSetStatusCalls(body: string): number {
   // Remove the one sanctioned guarded shape: an `if (state.run?.id ===
   // runId)` block whose body calls the bare setStatus(. Non-greedy across
   // newlines so this only eats up to the next closing brace, not the rest
-  // of the function.
+  // of the function. The optional `&& runEpoch === epoch` clause is cycle
+  // 76's strengthening of this same guard (see runEpoch's own doc comment
+  // in the store) -- accepted here too so this check keeps passing
+  // regardless of whether that clause has been added alongside the run-id
+  // check.
   scrubbed = scrubbed.replace(
-    /if\s*\(\s*state\.run\?\.id\s*===\s*runId\s*\)\s*\{[\s\S]*?setStatus\([\s\S]*?\n\s*\}/,
+    /if\s*\(\s*state\.run\?\.id\s*===\s*runId(?:\s*&&\s*runEpoch\s*===\s*epoch)?\s*\)\s*\{[\s\S]*?setStatus\([\s\S]*?\n\s*\}/,
     '',
   )
   const matches = scrubbed.match(/\bsetStatus\(/g)

--- a/utils/scripts/verifyModelBuilderCrossRunReleaseGuard.ts
+++ b/utils/scripts/verifyModelBuilderCrossRunReleaseGuard.ts
@@ -35,6 +35,17 @@
 // in the `finally` block of all five functions: if a future refactor reverts
 // any one of them to an unconditional clear/release, this fails loudly
 // rather than silently reopening the race for just that entry point.
+//
+// Cycle 76 strengthened this same guard with an additional `runEpoch`
+// condition (a run id alone can't tell "still the same continuous session on
+// this run" apart from "abandoned this run, then later revisited the same
+// run id" -- see runEpoch's own doc comment in the store and
+// verifyModelBuilderRunEpochGuard.ts, which asserts that stronger shape
+// specifically). This guard only checks that the run-id half of the
+// condition is still present -- it deliberately does not care whether an
+// `&& runEpoch === epoch` clause has been added alongside it, so it keeps
+// working unchanged as a baseline regardless of which cycle's fix shape is
+// currently in place.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -46,7 +57,12 @@ const repositoryRoot = resolve(scriptDirectory, '../..')
 
 const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
 
-const RUN_ID_GUARD = /if\s*\(\s*state\.run\?\.id\s*===\s*runId\s*\)/
+// Deliberately not anchored to an immediately-following `)` -- cycle 76's
+// `&& runEpoch === epoch` addition (see the doc comment above) puts other
+// text between `runId` and the closing paren, and this guard only cares
+// that the run-id half of the condition is still present somewhere in the
+// `if (...)` guarding the clear/release.
+const RUN_ID_GUARD = /if\s*\(\s*state\.run\?\.id\s*===\s*runId/
 
 const BATCH_FUNCTIONS = [
   'batchDraftField',

--- a/utils/scripts/verifyModelBuilderRunEpochGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderRunEpochGuard.test.ts
@@ -1,0 +1,338 @@
+// /utils/scripts/verifyModelBuilderRunEpochGuard.test.ts
+//
+// Regression test for checkRunEpochGuard() in
+// verifyModelBuilderRunEpochGuard.ts (model-builder/t-029, cycle 76).
+// Exercises the real check against synthetic store-shaped fixtures covering:
+// the fixed shape (runEpoch declared, every abandon site bumps it, every
+// run/batch function captures and re-checks its own epoch), the pre-fix
+// shape (no runEpoch at all), a partial fix that leaves one abandon site
+// and one release function behind, and every target function missing.
+import assert from 'node:assert/strict'
+
+import { checkRunEpochGuard } from './verifyModelBuilderRunEpochGuard.js'
+
+const FIXED_FIXTURE = `
+  let runEpoch = 0
+
+  async function autoBuildRun(): Promise<void> {
+    const runId = state.run.id
+    const epoch = runEpoch
+    try {
+      for (const item of items) {
+        if (state.run?.id !== runId || runEpoch !== epoch) return
+      }
+    } finally {
+      if (state.run?.id === runId && runEpoch === epoch) state.autoBuilding = false
+    }
+  }
+
+  async function batchDraftField(outputKey: string): Promise<void> {
+    const runId = state.run?.id
+    const epoch = runEpoch
+    try {
+      // ...
+    } finally {
+      if (state.run?.id === runId && runEpoch === epoch)
+        batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchSetField(outputKey: string): Promise<void> {
+    const runId = state.run?.id
+    const epoch = runEpoch
+    try {
+      // ...
+    } finally {
+      if (state.run?.id === runId && runEpoch === epoch)
+        batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchApproveStage(outputKey: string): Promise<void> {
+    const runId = state.run?.id
+    const epoch = runEpoch
+    try {
+      // ...
+    } finally {
+      if (state.run?.id === runId && runEpoch === epoch)
+        batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchAutoBuild(outputKey: string): Promise<void> {
+    const runId = state.run?.id
+    const epoch = runEpoch
+    try {
+      for (const item of items) {
+        if (state.run?.id !== runId || runEpoch !== epoch) return
+      }
+    } finally {
+      if (state.run?.id === runId && runEpoch === epoch)
+        batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function openRun(runId: string): Promise<void> {
+    if (cached) {
+      runEpoch++
+      state.run = cached
+    }
+    if (fetched) {
+      runEpoch++
+      state.run = adaptRun(response.data)
+    }
+  }
+
+  async function resumeRun(): Promise<void> {
+    if (differentRun) {
+      runEpoch++
+      state.run = adaptRun(data)
+    }
+  }
+
+  function resetRun(): void {
+    state.run = null
+    runEpoch++
+  }
+
+  function resetAll(): void {
+    state.run = null
+    runEpoch++
+  }
+`
+
+const BUGGY_FIXTURE = `
+  async function autoBuildRun(): Promise<void> {
+    const runId = state.run.id
+    try {
+      for (const item of items) {
+        if (state.run?.id !== runId) return
+      }
+    } finally {
+      if (state.run?.id === runId) state.autoBuilding = false
+    }
+  }
+
+  async function batchDraftField(outputKey: string): Promise<void> {
+    const runId = state.run?.id
+    try {
+      // ...
+    } finally {
+      if (state.run?.id === runId) batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchSetField(outputKey: string): Promise<void> {
+    const runId = state.run?.id
+    try {
+      // ...
+    } finally {
+      if (state.run?.id === runId) batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchApproveStage(outputKey: string): Promise<void> {
+    const runId = state.run?.id
+    try {
+      // ...
+    } finally {
+      if (state.run?.id === runId) batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchAutoBuild(outputKey: string): Promise<void> {
+    const runId = state.run?.id
+    try {
+      for (const item of items) {
+        if (state.run?.id !== runId) return
+      }
+    } finally {
+      if (state.run?.id === runId) batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function openRun(runId: string): Promise<void> {
+    if (cached) {
+      state.run = cached
+    }
+    if (fetched) {
+      state.run = adaptRun(response.data)
+    }
+  }
+
+  async function resumeRun(): Promise<void> {
+    if (differentRun) {
+      state.run = adaptRun(data)
+    }
+  }
+
+  function resetRun(): void {
+    state.run = null
+  }
+
+  function resetAll(): void {
+    state.run = null
+  }
+`
+
+// Everything bumps/captures/checks runEpoch except: resetAll() never bumps
+// it, and batchApproveStage()'s finally block clears without the epoch
+// check.
+const PARTIAL_FIX_FIXTURE = `
+  let runEpoch = 0
+
+  async function autoBuildRun(): Promise<void> {
+    const runId = state.run.id
+    const epoch = runEpoch
+    try {
+      for (const item of items) {
+        if (state.run?.id !== runId || runEpoch !== epoch) return
+      }
+    } finally {
+      if (state.run?.id === runId && runEpoch === epoch) state.autoBuilding = false
+    }
+  }
+
+  async function batchDraftField(outputKey: string): Promise<void> {
+    const runId = state.run?.id
+    const epoch = runEpoch
+    try {
+      // ...
+    } finally {
+      if (state.run?.id === runId && runEpoch === epoch)
+        batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchSetField(outputKey: string): Promise<void> {
+    const runId = state.run?.id
+    const epoch = runEpoch
+    try {
+      // ...
+    } finally {
+      if (state.run?.id === runId && runEpoch === epoch)
+        batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchApproveStage(outputKey: string): Promise<void> {
+    const runId = state.run?.id
+    const epoch = runEpoch
+    try {
+      // ...
+    } finally {
+      if (state.run?.id === runId) batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchAutoBuild(outputKey: string): Promise<void> {
+    const runId = state.run?.id
+    const epoch = runEpoch
+    try {
+      for (const item of items) {
+        if (state.run?.id !== runId || runEpoch !== epoch) return
+      }
+    } finally {
+      if (state.run?.id === runId && runEpoch === epoch)
+        batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function openRun(runId: string): Promise<void> {
+    if (cached) {
+      runEpoch++
+      state.run = cached
+    }
+    if (fetched) {
+      runEpoch++
+      state.run = adaptRun(response.data)
+    }
+  }
+
+  async function resumeRun(): Promise<void> {
+    if (differentRun) {
+      runEpoch++
+      state.run = adaptRun(data)
+    }
+  }
+
+  function resetRun(): void {
+    state.run = null
+    runEpoch++
+  }
+
+  function resetAll(): void {
+    state.run = null
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const fixedErrors = checkRunEpochGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const buggyErrors = checkRunEpochGuard(BUGGY_FIXTURE)
+assert.ok(
+  buggyErrors.some((e) => e.startsWith('Could not find `let runEpoch = 0`')),
+  'expected a missing-declaration error when runEpoch is absent entirely',
+)
+for (const name of ['resetRun', 'resetAll', 'openRun', 'resumeRun']) {
+  assert.ok(
+    buggyErrors.some((e) => e.startsWith(`${name}() bumps runEpoch`)),
+    `expected a bump-count error for ${name}()`,
+  )
+}
+for (const name of [
+  'autoBuildRun',
+  'batchDraftField',
+  'batchSetField',
+  'batchApproveStage',
+  'batchAutoBuild',
+]) {
+  assert.ok(
+    buggyErrors.some((e) =>
+      e.startsWith(`${name}() no longer captures \`const epoch = runEpoch\``),
+    ),
+    `expected an epoch-capture error for ${name}()`,
+  )
+}
+
+const partialErrors = checkRunEpochGuard(PARTIAL_FIX_FIXTURE)
+assert.equal(
+  partialErrors.length,
+  2,
+  `expected the partial-fix shape to raise exactly 2 errors, got ` +
+    `${partialErrors.length}: ${JSON.stringify(partialErrors)}`,
+)
+assert.ok(partialErrors.some((e) => e.startsWith('resetAll() bumps runEpoch')))
+assert.ok(
+  partialErrors.some((e) =>
+    e.startsWith("batchApproveStage()'s finally block no longer checks"),
+  ),
+)
+
+const missingErrors = checkRunEpochGuard(MISSING_FIXTURE)
+// 1 declaration error + 4 abandon-function-missing + 5 release-function-missing.
+assert.equal(
+  missingErrors.length,
+  10,
+  `expected 10 violations when runEpoch and every target function are ` +
+    `absent, got ${missingErrors.length}: ${JSON.stringify(missingErrors)}`,
+)
+
+console.log(
+  'Model Builder run-epoch guard checker verified: flags a missing runEpoch ' +
+    'declaration, missing bumps at abandon sites, missing epoch capture/' +
+    'checks in the five run/batch functions, a partial fix that leaves one ' +
+    'of each behind, and every target function being absent.',
+)

--- a/utils/scripts/verifyModelBuilderRunEpochGuard.ts
+++ b/utils/scripts/verifyModelBuilderRunEpochGuard.ts
@@ -1,0 +1,204 @@
+// /utils/scripts/verifyModelBuilderRunEpochGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 76). Cycle 75 fixed
+// autoBuildRun()/batchDraftField()/batchSetField()/batchApproveStage()/
+// batchAutoBuild() so their loop-abort checks and `finally`-block flag
+// clears only fire `if (state.run?.id === runId)` -- i.e. only while the
+// run they started for is still the active one (see
+// verifyModelBuilderCrossRunReleaseGuard.ts for that fix's own guard).
+//
+// A captured run id is not a one-shot token, though. openRun()'s
+// cached-adopt branch reuses the exact same cached run object on a revisit,
+// and state.runs is never purged by resetRun(), so reopening the SAME run
+// after abandoning it (e.g. "New run" mid auto-build, then History → Open
+// on the run just left) makes `state.run?.id === runId` true again even
+// though the abandon event already happened. Concrete repro: start
+// "Auto-build all" on Run A (several items, each a real await), click "New
+// run" mid-loop (resetRun() clears state.run/state.autoBuilding
+// immediately, but the abandoned loop keeps awaiting -- JS doesn't cancel
+// in-flight promises), then reopen Run A from History before the abandoned
+// loop's next iteration runs. `state.run?.id === runId` now reads true
+// again, so the abandoned loop's per-iteration guard no longer stops it: it
+// keeps processing Run A's remaining items in the background while the user
+// believes they're looking at a fresh, idle run, and its `finally` can
+// later clear/stomp a genuinely new operation's own in-flight flag.
+//
+// Fixed with a monotonic `runEpoch` counter, bumped once at every "abandon
+// the active run's in-flight work" site (resetRun, resetAll, openRun's two
+// adopt-a-different-run branches, resumeRun's adopt-a-different-run
+// branch) -- never reused, so unlike a run id it reliably distinguishes
+// "still the same continuous session on this run" from "abandoned this
+// run, then later revisited the same run id". autoBuildRun and the four
+// batch functions each capture `const epoch = runEpoch` alongside their
+// existing `runId` capture and additionally require `runEpoch === epoch`
+// everywhere they previously checked only `state.run?.id === runId`.
+//
+// This guard asserts both halves of that fix stay in place: every abandon
+// site still bumps runEpoch, and every one of the five run/batch operation
+// functions still captures and re-checks its own epoch. If a future
+// refactor drops either half, this fails loudly rather than silently
+// reopening the revisit race for just that entry point.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const RUN_EPOCH_DECLARATION = /let\s+runEpoch\s*=\s*0/
+const EPOCH_BUMP = /runEpoch\+\+/
+const EPOCH_CAPTURE = /const\s+epoch\s*=\s*runEpoch/
+const EPOCH_CHECK = /runEpoch\s*===\s*epoch/
+const EPOCH_MISMATCH_CHECK = /runEpoch\s*!==\s*epoch/
+
+// Functions that must abandon the active run's in-flight work by bumping
+// runEpoch (in addition to their existing singleton clears).
+const ABANDON_FUNCTIONS = [
+  'resetRun',
+  'resetAll',
+  'openRun',
+  'resumeRun',
+] as const
+
+// openRun() has two abandon branches (cached-adopt, freshly-fetched-adopt);
+// every other abandon function only has one.
+const MIN_BUMPS_PER_FUNCTION: Record<
+  (typeof ABANDON_FUNCTIONS)[number],
+  number
+> = {
+  resetRun: 1,
+  resetAll: 1,
+  openRun: 2,
+  resumeRun: 1,
+}
+
+// Functions whose loop-abort check (not just their finally block) must also
+// check runEpoch -- the two entry points with a per-item loop that can span
+// a run revisit mid-pass, mirroring their existing runId-mismatch check.
+const LOOPING_FUNCTIONS = ['autoBuildRun', 'batchAutoBuild'] as const
+
+// All five run/batch operation functions whose finally block releases a
+// store-wide "in flight" flag and must therefore re-check both the run id
+// and the epoch before doing so.
+const RELEASE_FUNCTIONS = [
+  'autoBuildRun',
+  'batchDraftField',
+  'batchSetField',
+  'batchApproveStage',
+  'batchAutoBuild',
+] as const
+
+export function checkRunEpochGuard(content: string): string[] {
+  const errors: string[] = []
+
+  if (!RUN_EPOCH_DECLARATION.test(content)) {
+    errors.push(
+      'Could not find `let runEpoch = 0` -- has the run-epoch counter been ' +
+        'renamed, removed, or changed to a different declaration shape? If ' +
+        'so, this guard (and the fix it protects) needs to move with it.',
+    )
+  }
+
+  const functions = extractFunctionBodies(content)
+
+  for (const name of ABANDON_FUNCTIONS) {
+    const fn = functions.find((f) => f.name === name)
+    if (!fn) {
+      errors.push(
+        `Could not find a function named ${name}() -- has it been renamed, ` +
+          'removed, or inlined? If so, this guard needs to move with it.',
+      )
+      continue
+    }
+    const bumps = fn.body.match(new RegExp(EPOCH_BUMP.source, 'g'))
+    const bumpCount = bumps ? bumps.length : 0
+    const required = MIN_BUMPS_PER_FUNCTION[name]
+    if (bumpCount < required) {
+      errors.push(
+        `${name}() bumps runEpoch ${bumpCount} time(s), expected at least ` +
+          `${required} -- every branch that abandons the active run's ` +
+          'in-flight work must bump runEpoch, or a revisit of the same ' +
+          "run id after abandoning it won't be distinguishable from never " +
+          'having left (model-builder/t-029, cycle 76).',
+      )
+    }
+  }
+
+  for (const name of RELEASE_FUNCTIONS) {
+    const fn = functions.find((f) => f.name === name)
+    if (!fn) {
+      errors.push(
+        `Could not find a function named ${name}() -- has it been renamed, ` +
+          'removed, or inlined? If so, this guard needs to move with it.',
+      )
+      continue
+    }
+    if (!EPOCH_CAPTURE.test(fn.body)) {
+      errors.push(
+        `${name}() no longer captures \`const epoch = runEpoch\` -- ` +
+          'without it, this function cannot tell a same-run revisit apart ' +
+          'from an uninterrupted session on the same run.',
+      )
+      continue
+    }
+    const finallyMatch = /finally\s*\{([\s\S]*?)\n {4}\}/.exec(fn.body)
+    const finallyBody = finallyMatch?.[1] ?? ''
+    if (!EPOCH_CHECK.test(finallyBody)) {
+      errors.push(
+        `${name}()'s finally block no longer checks \`runEpoch === epoch\` ` +
+          'before clearing/releasing its in-flight flag -- an abandoned ' +
+          'call revisiting the same run id (state.run?.id === runId reads ' +
+          "true again) can silently clear a brand-new operation's own " +
+          'in-flight flag out from under it (model-builder/t-029, cycle 76).',
+      )
+    }
+  }
+
+  for (const name of LOOPING_FUNCTIONS) {
+    const fn = functions.find((f) => f.name === name)
+    if (!fn) {
+      // Already reported above via RELEASE_FUNCTIONS.
+      continue
+    }
+    if (!EPOCH_MISMATCH_CHECK.test(fn.body)) {
+      errors.push(
+        `${name}()'s per-item loop no longer checks \`runEpoch !== epoch\` ` +
+          'to abort -- a revisited run (same id, but abandoned and later ' +
+          "reopened mid-loop) would keep walking the abandoned pass's " +
+          'remaining items instead of stopping (model-builder/t-029, ' +
+          'cycle 76).',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkRunEpochGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder run-epoch guard contract failed in modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder run-epoch guard contract passed: every abandon site ' +
+      'bumps runEpoch, and autoBuildRun()/batchDraftField()/batchSetField()/' +
+      'batchApproveStage()/batchAutoBuild() each capture and re-check their ' +
+      'own epoch before clearing/releasing their in-flight flag.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
model-builder/t-029 (cycle 76): recurring polish/bug-hunt sweep on the Model Builder front-end.  (kind: software)

### What changed / what I produced
Cycle 75 (PR #2295) guarded `autoBuildRun()`'s and the four group batch operations' (`batchDraftField`/`batchSetField`/`batchApproveStage`/`batchAutoBuild`) loop-abort checks and `finally`-block flag clears with `state.run?.id === runId` — but a run id is not a one-shot token. `openRun()`'s cached-adopt branch reuses the exact same cached run object on a revisit, and `state.runs` is never purged by `resetRun()`, so **reopening the SAME run after abandoning it mid-operation** makes `state.run?.id === runId` true again even though the abandon event already happened.

**Concrete failure scenario:**
1. Start "Auto-build all" on Run A (several items, each a real network await).
2. Mid-loop, click "New run" (`resetRun()` clears `state.run`/`state.autoBuilding` immediately, but the abandoned loop keeps `await`ing — JS doesn't cancel in-flight promises).
3. Reopen Run A from History before the abandoned loop's next iteration runs.
4. The loop's per-iteration guard no longer stops it (`state.run?.id === runId` reads true again): it keeps processing Run A's remaining items in the background while the user believes they're looking at a fresh, idle run.
5. If the user then starts a new "Auto-build all" on Run A, the abandoned loop's `finally` can later clear/stomp the new operation's own in-flight flag mid-flight — reopening the exact double-invocation race `isRunOperationInFlight()` exists to prevent.

**Fix:** a monotonic `runEpoch` counter, bumped once at every "abandon the active run's in-flight work" site (`resetRun`, `resetAll`, `openRun`'s two adopt-a-different-run branches, `resumeRun`'s adopt-a-different-run branch) — never reused, so unlike a run id it reliably distinguishes "still the same continuous session on this run" from "abandoned this run, then later revisited the same run id". `autoBuildRun` and the four batch functions each capture their own `epoch` alongside their existing `runId` capture and additionally require `runEpoch === epoch` everywhere they previously checked only `state.run?.id === runId`.

Also broadened cycle 75's own two guards (`verifyModelBuilderCrossRunReleaseGuard.ts`, `verifyModelBuilderBatchGroupStatusScopeGuard.ts`) so their regexes don't require an immediately-following `)` after the runId check — the new `&& runEpoch === epoch` clause now sits between them. Added a dedicated `verifyModelBuilderRunEpochGuard.ts` + `.test.ts` asserting the new mechanism itself: every abandon site bumps `runEpoch`, and all five run/batch functions capture and re-check their own epoch. Wired both new npm scripts into `contract-tests.yml`.

### How I verified
- `eslint` clean on all touched files (2 pre-existing, unrelated `no-empty` errors elsewhere in `modelBuilderStore.ts`, confirmed via `git stash` to predate this change).
- `vue-tsc --noEmit` (repo-wide) — clean, exit 0.
- All 157 `test:model-builder-*` npm scripts pass, including the 2 broadened guards and the 2 new ones (self-test + live contract).
- `prettier --check` clean on every changed file.
- `npm run test:layout-contract` — holds at the 207-violation baseline, zero new.
- `git status --porcelain` scoped to exactly the 7 intended files throughout.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
`batchDraftField`'s per-item loop (unlike `autoBuildRun`/`batchAutoBuild`) still has no per-iteration abort check at all — only its `finally` release is guarded. Each `draftText`/`batchPushItems` call does its own fresh item lookup so it fails safely against a genuinely different run, but a revisited-same-run abandoned pass can still burn real network calls it doesn't need to. Not fixed here to keep this cycle's diff narrowly scoped to the actual reported race; a future cycle could add the same `runEpoch`-based abort check to `batchDraftField`'s loop body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXC3LZqHdvWpbUN4LXTuB5)_