### PR TITLE
fix(model-builder): guard batchDraftField's per-item loop against a same-run revisit

### DIFF
--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -2478,6 +2478,24 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     let failed = 0
     try {
       for (const item of items) {
+        // Bug (model-builder/t-029, cycle 77): unlike its two sibling loops
+        // that each suspend once per item (autoBuildRun, batchAutoBuild),
+        // this loop had no per-iteration abort check at all -- only its own
+        // finally-block release was guarded against a same-run revisit
+        // (cycle 76). A revisit reopens the exact race the epoch mechanism
+        // exists to catch: abandon this run mid-draft (e.g. "New run" while
+        // item 2 of 5 is still mid-draftText), then reopen the SAME run from
+        // History before the abandoned loop's next iteration runs --
+        // `state.run?.id === runId` reads true again (openRun's cached-adopt
+        // branch reuses the cached run object), and without this check the
+        // abandoned loop keeps calling draftText for the run's remaining
+        // items in the background while the user believes they're looking
+        // at an idle run, still writing item.pitch/fieldsDraft/promptDraft
+        // and pushing stage-status changes for a pass they thought they'd
+        // left. Stop walking the group the instant either the active run or
+        // this call's own epoch has moved on, mirroring autoBuildRun's/
+        // batchAutoBuild's identical guard.
+        if (state.run?.id !== runId || runEpoch !== epoch) return
         // Skip items whose stage is already approved/locked — see
         // isStageEditable's doc comment.
         if (!isStageEditable(item, stageKey)) continue

--- a/utils/scripts/verifyModelBuilderRunEpochGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderRunEpochGuard.test.ts
@@ -1,12 +1,15 @@
 // /utils/scripts/verifyModelBuilderRunEpochGuard.test.ts
 //
 // Regression test for checkRunEpochGuard() in
-// verifyModelBuilderRunEpochGuard.ts (model-builder/t-029, cycle 76).
+// verifyModelBuilderRunEpochGuard.ts (model-builder/t-029, cycle 76;
+// extended cycle 77 for batchDraftField's own loop-abort check).
 // Exercises the real check against synthetic store-shaped fixtures covering:
 // the fixed shape (runEpoch declared, every abandon site bumps it, every
-// run/batch function captures and re-checks its own epoch), the pre-fix
-// shape (no runEpoch at all), a partial fix that leaves one abandon site
-// and one release function behind, and every target function missing.
+// run/batch function captures and re-checks its own epoch, and all three
+// looping functions' loops abort on an epoch mismatch), the pre-fix shape
+// (no runEpoch at all), a partial fix that leaves one abandon site and one
+// release function behind, batchDraftField's loop-abort check missing on
+// its own (the cycle-77 gap), and every target function missing.
 import assert from 'node:assert/strict'
 
 import { checkRunEpochGuard } from './verifyModelBuilderRunEpochGuard.js'
@@ -30,7 +33,106 @@ const FIXED_FIXTURE = `
     const runId = state.run?.id
     const epoch = runEpoch
     try {
+      for (const item of items) {
+        if (state.run?.id !== runId || runEpoch !== epoch) return
+      }
+    } finally {
+      if (state.run?.id === runId && runEpoch === epoch)
+        batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchSetField(outputKey: string): Promise<void> {
+    const runId = state.run?.id
+    const epoch = runEpoch
+    try {
       // ...
+    } finally {
+      if (state.run?.id === runId && runEpoch === epoch)
+        batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchApproveStage(outputKey: string): Promise<void> {
+    const runId = state.run?.id
+    const epoch = runEpoch
+    try {
+      // ...
+    } finally {
+      if (state.run?.id === runId && runEpoch === epoch)
+        batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function batchAutoBuild(outputKey: string): Promise<void> {
+    const runId = state.run?.id
+    const epoch = runEpoch
+    try {
+      for (const item of items) {
+        if (state.run?.id !== runId || runEpoch !== epoch) return
+      }
+    } finally {
+      if (state.run?.id === runId && runEpoch === epoch)
+        batchingOutputSingleton.release(outputKey)
+    }
+  }
+
+  async function openRun(runId: string): Promise<void> {
+    if (cached) {
+      runEpoch++
+      state.run = cached
+    }
+    if (fetched) {
+      runEpoch++
+      state.run = adaptRun(response.data)
+    }
+  }
+
+  async function resumeRun(): Promise<void> {
+    if (differentRun) {
+      runEpoch++
+      state.run = adaptRun(data)
+    }
+  }
+
+  function resetRun(): void {
+    state.run = null
+    runEpoch++
+  }
+
+  function resetAll(): void {
+    state.run = null
+    runEpoch++
+  }
+`
+
+// Everything else matches FIXED_FIXTURE, but batchDraftField's finally block
+// still captures and re-checks its epoch (cycle 76) while its own per-item
+// loop never checks it at all (the cycle-77 gap this fixture targets) --
+// isolates the new LOOPING_FUNCTIONS entry from the pre-existing
+// RELEASE_FUNCTIONS one so each is verified independently.
+const LOOP_CHECK_MISSING_FIXTURE = `
+  let runEpoch = 0
+
+  async function autoBuildRun(): Promise<void> {
+    const runId = state.run.id
+    const epoch = runEpoch
+    try {
+      for (const item of items) {
+        if (state.run?.id !== runId || runEpoch !== epoch) return
+      }
+    } finally {
+      if (state.run?.id === runId && runEpoch === epoch) state.autoBuilding = false
+    }
+  }
+
+  async function batchDraftField(outputKey: string): Promise<void> {
+    const runId = state.run?.id
+    const epoch = runEpoch
+    try {
+      for (const item of items) {
+        // no epoch check here -- the cycle-77 bug this fixture reproduces
+      }
     } finally {
       if (state.run?.id === runId && runEpoch === epoch)
         batchingOutputSingleton.release(outputKey)
@@ -197,7 +299,9 @@ const PARTIAL_FIX_FIXTURE = `
     const runId = state.run?.id
     const epoch = runEpoch
     try {
-      // ...
+      for (const item of items) {
+        if (state.run?.id !== runId || runEpoch !== epoch) return
+      }
     } finally {
       if (state.run?.id === runId && runEpoch === epoch)
         batchingOutputSingleton.release(outputKey)
@@ -321,6 +425,27 @@ assert.ok(
   ),
 )
 
+// Cycle-77 regression case: batchDraftField's finally block is fully fixed
+// (epoch captured and re-checked, cycle 76) but its own per-item loop never
+// checks the epoch at all -- the exact gap cycle 77 closed in the real
+// store. Isolates the LOOPING_FUNCTIONS check from the RELEASE_FUNCTIONS one
+// so a future regression in either half is caught independently.
+const loopCheckMissingErrors = checkRunEpochGuard(LOOP_CHECK_MISSING_FIXTURE)
+assert.equal(
+  loopCheckMissingErrors.length,
+  1,
+  `expected exactly 1 error when only batchDraftField's loop-abort check is ` +
+    `missing, got ${loopCheckMissingErrors.length}: ` +
+    `${JSON.stringify(loopCheckMissingErrors)}`,
+)
+assert.ok(
+  loopCheckMissingErrors[0]?.startsWith(
+    "batchDraftField()'s per-item loop no longer checks",
+  ),
+  `expected the one error to name batchDraftField()'s missing loop check, ` +
+    `got: ${JSON.stringify(loopCheckMissingErrors)}`,
+)
+
 const missingErrors = checkRunEpochGuard(MISSING_FIXTURE)
 // 1 declaration error + 4 abandon-function-missing + 5 release-function-missing.
 assert.equal(
@@ -333,6 +458,8 @@ assert.equal(
 console.log(
   'Model Builder run-epoch guard checker verified: flags a missing runEpoch ' +
     'declaration, missing bumps at abandon sites, missing epoch capture/' +
-    'checks in the five run/batch functions, a partial fix that leaves one ' +
-    'of each behind, and every target function being absent.',
+    'checks in the five run/batch functions, a missing loop-abort check in ' +
+    "any of the three looping functions (isolated to batchDraftField's own " +
+    'cycle-77 gap here), a partial fix that leaves one of each behind, and ' +
+    'every target function being absent.',
 )

--- a/utils/scripts/verifyModelBuilderRunEpochGuard.ts
+++ b/utils/scripts/verifyModelBuilderRunEpochGuard.ts
@@ -38,6 +38,14 @@
 // functions still captures and re-checks its own epoch. If a future
 // refactor drops either half, this fails loudly rather than silently
 // reopening the revisit race for just that entry point.
+//
+// Cycle 77 closed a gap in the fix itself, not just the guard: batchDraftField
+// captured and re-checked its epoch in its finally block (per the above) but,
+// unlike autoBuildRun/batchAutoBuild, never checked it inside its own
+// per-item loop -- so a revisited run's abandoned draft pass kept awaiting
+// draftText for the run's remaining items instead of stopping. Fixed the
+// same way as the other two loops, and LOOPING_FUNCTIONS below now covers
+// all three.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -77,9 +85,22 @@ const MIN_BUMPS_PER_FUNCTION: Record<
 }
 
 // Functions whose loop-abort check (not just their finally block) must also
-// check runEpoch -- the two entry points with a per-item loop that can span
-// a run revisit mid-pass, mirroring their existing runId-mismatch check.
-const LOOPING_FUNCTIONS = ['autoBuildRun', 'batchAutoBuild'] as const
+// check runEpoch -- the three entry points with a per-item-await loop that
+// can span a run revisit mid-pass, mirroring their existing runId-mismatch
+// check. batchDraftField joined autoBuildRun/batchAutoBuild here in cycle 77
+// -- it awaits draftText once per item, same shape as the other two, but its
+// loop had no abort check at all pre-fix (only its finally-block release was
+// epoch-guarded, from cycle 76). batchSetField/batchApproveStage stay out of
+// this list on purpose: their per-item loops build up a payload
+// synchronously with no await inside the loop body, then await once via a
+// single batchPushItems() call after the loop -- there's no per-iteration
+// await to abandon mid-loop, so a loop-abort check would have nothing to
+// guard.
+const LOOPING_FUNCTIONS = [
+  'autoBuildRun',
+  'batchDraftField',
+  'batchAutoBuild',
+] as const
 
 // All five run/batch operation functions whose finally block releases a
 // store-wide "in flight" flag and must therefore re-check both the run id
@@ -193,9 +214,11 @@ function main(): void {
 
   console.log(
     'Model Builder run-epoch guard contract passed: every abandon site ' +
-      'bumps runEpoch, and autoBuildRun()/batchDraftField()/batchSetField()/' +
+      'bumps runEpoch, autoBuildRun()/batchDraftField()/batchSetField()/' +
       'batchApproveStage()/batchAutoBuild() each capture and re-check their ' +
-      'own epoch before clearing/releasing their in-flight flag.',
+      'own epoch before clearing/releasing their in-flight flag, and ' +
+      "autoBuildRun()/batchDraftField()/batchAutoBuild()'s own per-item " +
+      'loops abort on an epoch mismatch too.',
   )
 }
 


### PR DESCRIPTION
## What changed

`model-builder/t-029`, cycle 77 (the recurring Model Builder polish task). `autoBuildRun()` and `batchAutoBuild()` both check `runEpoch` inside their per-item loop — see `runEpoch`'s doc comment (cycle 76) — so an abandoned pass stops walking a run's items the instant the active run or epoch has moved on, including on a *revisit* (abandon this run mid-loop, then reopen the same run id from History before the abandoned loop's next iteration runs). `batchDraftField()` awaits `draftText` once per item in exactly the same shape, but its loop never had this check — only its `finally`-block release was epoch-guarded (cycle 76's fix). Added the identical per-iteration guard, mirroring `autoBuildRun`/`batchAutoBuild`.

## Why

Recorded as the concrete kaizen lead from cycle 76's own note: *"batchDraftField's per-item loop still has no per-iteration abort check at all (unlike autoBuildRun/batchAutoBuild) -- only its finally release is guarded."* Without the check, an abandoned draft pass keeps calling `draftText` for a run's remaining items in the background after a same-run revisit, still writing `item.pitch`/`fieldsDraft`/`promptDraft` and pushing stage-status changes for a pass the user believes they left.

## What was preserved

Extended `verifyModelBuilderRunEpochGuard.ts`'s `LOOPING_FUNCTIONS` to include `batchDraftField` (now `autoBuildRun`/`batchDraftField`/`batchAutoBuild`), with an explanatory note on why `batchSetField`/`batchApproveStage` are deliberately excluded (their per-item loops build a payload synchronously with no per-item await; there's nothing mid-loop to abandon). Updated the guard's selftest fixtures (`FIXED_FIXTURE`, `PARTIAL_FIX_FIXTURE`) so batchDraftField's loop matches the fixed shape, and added a new dedicated `LOOP_CHECK_MISSING_FIXTURE` that isolates the cycle-77 loop-check regression from the pre-existing finally-block one, asserting exactly one targeted error.

## How I verified

- `npx eslint` on all 3 changed files — clean (2 pre-existing, unrelated `no-empty` errors elsewhere in the store, confirmed via `git stash` to predate this change).
- `npx vue-tsc --noEmit` (repo-wide) — clean, exit 0.
- `npm run test:model-builder-run-epoch-guard-selftest` and `test:model-builder-run-epoch-guard` — both pass.
- All 157 `test:model-builder-*` scripts — pass.
- `npm run test:layout-contract` — holds at the 207-violation baseline, zero new.
- `npx prettier --check` on all 3 changed files — clean.
- `git status --porcelain` scoped to exactly the 3 intended files throughout.

Caught and fixed one thing along the way: my first draft of the new loop-guard's comment used the standalone word "await" (in "per-item-await loops"), which `verifyModelBuilderCompletionGate.ts`'s `\bawait\b` regex-based first-await detection picked up as if it were real code — shifting where it thinks the function's first `await` occurs and producing a false-positive "ungated write" flag against an unrelated pre-existing comment later in the same function. Reworded to avoid the bare word; the guard passes clean now.

## Stakes
reversible

## Notes for reviewer
Pure store-logic fix + guard/test extension, no UI/markup change, no behavior change for the happy path (only the abandon-then-revisit race is affected).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHvDqjEJDLXDNwF6EYfvbU)_