### PR TITLE
feat(model-builder): wire up rejectStage to the item-panel UI

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -914,6 +914,12 @@ jobs:
       - name: Model Builder resumeRun request guard contract
         run: npm run test:model-builder-resume-run-request-guard
 
+      - name: Model Builder item-panel Reject wiring guard checker self-test
+        run: npm run test:model-builder-item-panel-reject-wiring-guard-selftest
+
+      - name: Model Builder item-panel Reject wiring guard contract
+        run: npm run test:model-builder-item-panel-reject-wiring-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -81,15 +81,24 @@
         >
           Edit
         </button>
-        <button
-          v-else
-          type="button"
-          class="btn btn-xs btn-primary rounded-lg"
-          :disabled="isLocked('PITCH') || !pitch.trim()"
-          @click="approve('PITCH')"
-        >
-          Approve pitch
-        </button>
+        <template v-else>
+          <button
+            type="button"
+            class="btn btn-xs btn-ghost rounded-lg text-error"
+            :disabled="isLocked('PITCH') || isAnyDraftInFlight"
+            @click="reject('PITCH')"
+          >
+            Reject
+          </button>
+          <button
+            type="button"
+            class="btn btn-xs btn-primary rounded-lg"
+            :disabled="isLocked('PITCH') || !pitch.trim()"
+            @click="approve('PITCH')"
+          >
+            Approve pitch
+          </button>
+        </template>
       </div>
     </section>
 
@@ -181,15 +190,24 @@
         >
           Edit
         </button>
-        <button
-          v-else
-          type="button"
-          class="btn btn-xs btn-primary rounded-lg"
-          :disabled="isLocked('FIELDS_AND_PROMPTS')"
-          @click="approve('FIELDS_AND_PROMPTS')"
-        >
-          Approve fields &amp; prompts
-        </button>
+        <template v-else>
+          <button
+            type="button"
+            class="btn btn-xs btn-ghost rounded-lg text-error"
+            :disabled="isLocked('FIELDS_AND_PROMPTS') || isAnyDraftInFlight"
+            @click="reject('FIELDS_AND_PROMPTS')"
+          >
+            Reject
+          </button>
+          <button
+            type="button"
+            class="btn btn-xs btn-primary rounded-lg"
+            :disabled="isLocked('FIELDS_AND_PROMPTS')"
+            @click="approve('FIELDS_AND_PROMPTS')"
+          >
+            Approve fields &amp; prompts
+          </button>
+        </template>
       </div>
     </section>
 
@@ -297,15 +315,24 @@
         >
           Edit
         </button>
-        <button
-          v-else
-          type="button"
-          class="btn btn-xs btn-primary rounded-lg"
-          :disabled="!canApproveAssets"
-          @click="approve('GENERATE_ASSETS')"
-        >
-          Keep this asset
-        </button>
+        <template v-else>
+          <button
+            type="button"
+            class="btn btn-xs btn-ghost rounded-lg text-error"
+            :disabled="isLocked('GENERATE_ASSETS') || isGenerating || isQueued"
+            @click="reject('GENERATE_ASSETS')"
+          >
+            Reject
+          </button>
+          <button
+            type="button"
+            class="btn btn-xs btn-primary rounded-lg"
+            :disabled="!canApproveAssets"
+            @click="approve('GENERATE_ASSETS')"
+          >
+            Keep this asset
+          </button>
+        </template>
       </div>
     </section>
 
@@ -593,6 +620,20 @@ function isEditable(stage: BuildStageKey): boolean {
 
 function approve(stage: BuildStageKey): void {
   store.approveStage(props.itemId, stage)
+}
+
+// Bug (model-builder/t-029, cycle 78): rejectStage() is a fully-built store
+// action (mirroring approveStage/reopenStage -- flips the stage to
+// 'rejected', invalidates downstream via markDownstreamStale, reverts on a
+// failed PATCH) and badgeFor()/isEditable() above have handled the
+// 'rejected' status for a long time (badge-error styling, textareas stay
+// editable), but no component ever called store.rejectStage -- a real user
+// session could never actually produce a 'rejected' stage. Wires the
+// existing action to a "Reject" control next to each review-gate stage's
+// Approve button (PITCH/FIELDS_AND_PROMPTS/GENERATE_ASSETS -- COMMIT has no
+// approve/reject concept of its own; commitItem sets its status directly).
+function reject(stage: BuildStageKey): void {
+  store.rejectStage(props.itemId, stage)
 }
 
 function badgeFor(stage: BuildStageKey): string {

--- a/package.json
+++ b/package.json
@@ -402,6 +402,8 @@
     "test:model-builder-run-swap-singleton-leak-guard": "tsx utils/scripts/verifyModelBuilderRunSwapSingletonLeakGuard.ts",
     "test:model-builder-resume-run-request-guard-selftest": "tsx utils/scripts/verifyModelBuilderResumeRunRequestGuard.test.ts",
     "test:model-builder-resume-run-request-guard": "tsx utils/scripts/verifyModelBuilderResumeRunRequestGuard.ts",
+    "test:model-builder-item-panel-reject-wiring-guard-selftest": "tsx utils/scripts/verifyModelBuilderItemPanelRejectWiringGuard.test.ts",
+    "test:model-builder-item-panel-reject-wiring-guard": "tsx utils/scripts/verifyModelBuilderItemPanelRejectWiringGuard.ts",
     "test:storybook-active-story-resume-guard": "npx tsx utils/scripts/verifyStorybookActiveStoryResumeGuard.ts",
     "test:storybook-answer-input-preservation-guard": "node utils/scripts/verifyStorybookAnswerInputPreservationGuard.mjs",
     "test:storybook-answer-rollback-guard": "node utils/scripts/verifyStorybookAnswerRollbackGuard.mjs",

--- a/utils/scripts/verifyModelBuilderItemPanelRejectWiringGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderItemPanelRejectWiringGuard.test.ts
@@ -1,0 +1,161 @@
+// /utils/scripts/verifyModelBuilderItemPanelRejectWiringGuard.test.ts
+//
+// Regression test for checkItemPanelRejectWiringGuard() in
+// verifyModelBuilderItemPanelRejectWiringGuard.ts (model-builder/t-029,
+// cycle 78). Exercises the real check against synthetic file-shaped
+// fixtures covering: the pre-fix shape (no reject() wrapper, no Reject
+// buttons at all -- store.rejectStage has no caller), the fixed shape (all
+// three stages wired), a partial fix (wrapper defined but one stage's
+// button missing), and the wrapper defined with a differently-shaped body
+// (should still be flagged, since the guard checks the exact call shape).
+import assert from 'node:assert/strict'
+
+import { checkItemPanelRejectWiringGuard } from './verifyModelBuilderItemPanelRejectWiringGuard.js'
+
+const BUGGY_FIXTURE = `
+<template>
+  <button type="button" :disabled="isLocked('PITCH') || !pitch.trim()" @click="approve('PITCH')">
+    Approve pitch
+  </button>
+</template>
+<script setup lang="ts">
+function approve(stage: BuildStageKey): void {
+  store.approveStage(props.itemId, stage)
+}
+</script>
+`
+
+const FIXED_FIXTURE = `
+<template>
+  <button
+    type="button"
+    :disabled="isLocked('PITCH') || isAnyDraftInFlight"
+    @click="reject('PITCH')"
+  >
+    Reject
+  </button>
+  <button
+    type="button"
+    :disabled="isLocked('FIELDS_AND_PROMPTS') || isAnyDraftInFlight"
+    @click="reject('FIELDS_AND_PROMPTS')"
+  >
+    Reject
+  </button>
+  <button
+    type="button"
+    :disabled="isLocked('GENERATE_ASSETS') || isGenerating || isQueued"
+    @click="reject('GENERATE_ASSETS')"
+  >
+    Reject
+  </button>
+</template>
+<script setup lang="ts">
+function approve(stage: BuildStageKey): void {
+  store.approveStage(props.itemId, stage)
+}
+
+function reject(stage: BuildStageKey): void {
+  store.rejectStage(props.itemId, stage)
+}
+</script>
+`
+
+const PARTIAL_FIX_FIXTURE = `
+<template>
+  <button
+    type="button"
+    :disabled="isLocked('PITCH') || isAnyDraftInFlight"
+    @click="reject('PITCH')"
+  >
+    Reject
+  </button>
+  <button
+    type="button"
+    :disabled="isLocked('FIELDS_AND_PROMPTS') || isAnyDraftInFlight"
+    @click="reject('FIELDS_AND_PROMPTS')"
+  >
+    Reject
+  </button>
+</template>
+<script setup lang="ts">
+function reject(stage: BuildStageKey): void {
+  store.rejectStage(props.itemId, stage)
+}
+</script>
+`
+
+const WRONG_BODY_FIXTURE = `
+<template>
+  <button
+    type="button"
+    :disabled="isLocked('PITCH') || isAnyDraftInFlight"
+    @click="reject('PITCH')"
+  >
+    Reject
+  </button>
+  <button
+    type="button"
+    :disabled="isLocked('FIELDS_AND_PROMPTS') || isAnyDraftInFlight"
+    @click="reject('FIELDS_AND_PROMPTS')"
+  >
+    Reject
+  </button>
+  <button
+    type="button"
+    :disabled="isLocked('GENERATE_ASSETS') || isGenerating || isQueued"
+    @click="reject('GENERATE_ASSETS')"
+  >
+    Reject
+  </button>
+</template>
+<script setup lang="ts">
+function reject(stage: BuildStageKey): void {
+  console.log('rejecting', stage)
+}
+</script>
+`
+
+const buggyErrors = checkItemPanelRejectWiringGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  4,
+  'expected the pre-fix shape (no reject() wrapper, no Reject buttons) to ' +
+    `raise 4 errors (wrapper + 3 stages), got ${buggyErrors.length}: ` +
+    `${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(buggyErrors[0]!.includes('reject(stage: BuildStageKey)` wrapper'))
+
+const fixedErrors = checkItemPanelRejectWiringGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const partialErrors = checkItemPanelRejectWiringGuard(PARTIAL_FIX_FIXTURE)
+assert.equal(
+  partialErrors.length,
+  1,
+  'expected the partial-fix shape (GENERATE_ASSETS button missing) to ' +
+    `raise exactly 1 error, got ${partialErrors.length}: ` +
+    `${JSON.stringify(partialErrors)}`,
+)
+assert.ok(partialErrors[0]!.includes('GENERATE_ASSETS stage'))
+
+const wrongBodyErrors = checkItemPanelRejectWiringGuard(WRONG_BODY_FIXTURE)
+assert.equal(
+  wrongBodyErrors.length,
+  1,
+  'expected the wrong-body shape (reject() defined but not calling ' +
+    `store.rejectStage) to raise exactly 1 error, got ` +
+    `${wrongBodyErrors.length}: ${JSON.stringify(wrongBodyErrors)}`,
+)
+assert.ok(wrongBodyErrors[0]!.includes('reject(stage: BuildStageKey)` wrapper'))
+
+console.log(
+  'Model Builder item-panel Reject wiring guard checker verified: flags ' +
+    'the pre-fix shape (no reject() wrapper, no Reject buttons at all), ' +
+    "clears the fixed shape, flags a partial fix missing one stage's " +
+    "button, and flags reject() being redefined with a body that doesn't " +
+    'actually call store.rejectStage.',
+)

--- a/utils/scripts/verifyModelBuilderItemPanelRejectWiringGuard.ts
+++ b/utils/scripts/verifyModelBuilderItemPanelRejectWiringGuard.ts
@@ -1,0 +1,106 @@
+// /utils/scripts/verifyModelBuilderItemPanelRejectWiringGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 78) -- rejectStage() in
+// stores/modelBuilderStore.ts is a fully-built action (mirrors approveStage/
+// reopenStage: flips a stage to 'rejected', invalidates downstream via
+// markDownstreamStale, reverts on a failed PATCH) and badgeFor()/isEditable()
+// in model-builder-item-panel.vue have handled the 'rejected' status for a
+// long time (badge-error styling, textareas stay editable while rejected),
+// but no component ever called store.rejectStage -- a real user session
+// could never actually produce a 'rejected' stage. Found by a deliberate
+// re-sweep after cycle 77 closed the run-epoch/cross-run race class this
+// recurring task had concentrated on for several cycles running.
+//
+// Fixed by adding a `reject(stage: BuildStageKey)` wrapper (mirroring the
+// existing `approve(stage)` wrapper) and a "Reject" button next to each
+// review-gate stage's Approve button -- PITCH, FIELDS_AND_PROMPTS, and
+// GENERATE_ASSETS. COMMIT deliberately has no Reject control: it has no
+// approve/reject concept of its own, since commitItem() writes
+// item.stages.COMMIT directly from the server response rather than through
+// approveStage/rejectStage.
+//
+// This asserts the textual shape of that fix stays in place: the `reject()`
+// wrapper calling store.rejectStage, and each of the three stages' Reject
+// button wired to it via a gated `:disabled` attribute -- deliberately
+// scoped to this one fix, mirroring this project's other narrow textual
+// guards over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const ITEM_PANEL_PATH = join(
+  repositoryRoot,
+  'components/model-builder/model-builder-item-panel.vue',
+)
+
+const REJECT_FUNCTION_DEF =
+  'function reject(stage: BuildStageKey): void {\n  store.rejectStage(props.itemId, stage)\n}'
+
+// One review-gate stage's Reject button: a `:disabled="..."` attribute
+// immediately followed by `@click="reject('<STAGE>')"`. COMMIT is
+// deliberately excluded -- it has no approve/reject concept of its own.
+const REJECTABLE_STAGES = ['PITCH', 'FIELDS_AND_PROMPTS', 'GENERATE_ASSETS']
+
+function rejectButtonPattern(stage: string): RegExp {
+  return new RegExp(
+    `:disabled="[^"]*"\\s*\\n\\s*@click="reject\\('${stage}'\\)"`,
+  )
+}
+
+export function checkItemPanelRejectWiringGuard(content: string): string[] {
+  const errors: string[] = []
+
+  if (!content.includes(REJECT_FUNCTION_DEF)) {
+    errors.push(
+      'Could not find the `reject(stage: BuildStageKey)` wrapper calling ' +
+        'store.rejectStage(props.itemId, stage) in model-builder-item-' +
+        "panel.vue -- without it, this recurring task's own rejectStage " +
+        'store action has no caller, and a real user session can never ' +
+        "produce a 'rejected' stage no matter what the badge/editability " +
+        'logic elsewhere in this file assumes is reachable.',
+    )
+  }
+
+  for (const stage of REJECTABLE_STAGES) {
+    if (!rejectButtonPattern(stage).test(content)) {
+      errors.push(
+        `Could not find a gated Reject button for the ${stage} stage ` +
+          `(a ":disabled=\\"...\\"" attribute immediately followed by ` +
+          `"@click=\\"reject('${stage}')\\"") in model-builder-item-panel.vue ` +
+          "-- has this stage's button block been renamed or restructured? " +
+          'If so, this guard (and the bug it protects against) needs to ' +
+          'move with it.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(ITEM_PANEL_PATH, 'utf8')
+  const errors = checkItemPanelRejectWiringGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder item-panel Reject wiring guard contract failed for ' +
+        'model-builder-item-panel.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder item-panel Reject wiring guard contract passed: the ' +
+      'reject() wrapper calls store.rejectStage, and PITCH/FIELDS_AND_' +
+      'PROMPTS/GENERATE_ASSETS each carry a gated Reject button wired to it.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
model-builder/t-029: recurring front-end polish sweep, cycle 78 (kind: software)

### What changed / what I produced
- `stores/modelBuilderStore.ts`'s `rejectStage()` action has existed since an earlier cycle, mirrors `approveStage`/`reopenStage` exactly (flips the stage to `'rejected'`, invalidates downstream via `markDownstreamStale`, reverts on a failed PATCH), and `badgeFor()`/`isEditable()` in `model-builder-item-panel.vue` have handled the `'rejected'` status for a long time — but no component ever called `store.rejectStage`. A real user session could never actually produce a `'rejected'` stage.
- Added a `reject(stage: BuildStageKey)` wrapper (mirroring the existing `approve(stage)` wrapper) and a "Reject" button next to each review-gate stage's Approve button — `PITCH`, `FIELDS_AND_PROMPTS`, `GENERATE_ASSETS`. `COMMIT` is deliberately excluded: it has no approve/reject concept of its own (`commitItem()` writes `item.stages.COMMIT` directly from the server response).
- Each Reject button is gated the same way its sibling Approve/textarea controls already are (`isLocked(stage)` plus `isAnyDraftInFlight` for `PITCH`/`FIELDS_AND_PROMPTS`, or `isGenerating`/`isQueued` for `GENERATE_ASSETS`) so it can't fire mid-flight.
- Added `verifyModelBuilderItemPanelRejectWiringGuard.ts` + `.test.ts` (mirroring this task's established narrow-textual-guard pattern) and wired both into `package.json`/`contract-tests.yml`, verified via `test:model-builder-contract-tests-coverage-guard`.

### How I verified
- `eslint` on all 5 changed files — clean.
- `vue-tsc --noEmit` (repo-wide) — clean, exit 0.
- All 159 `test:model-builder-*` npm scripts pass (157 pre-existing + 2 new).
- `npm run test:model-builder-contract-tests-coverage-guard` — passes (new guard's package.json script is referenced in `contract-tests.yml`).
- `npm run test:layout-contract` — holds at the 207-violation baseline, zero new.
- `prettier --check` — clean on all 5 changed files (the two new files were reformatted once with `--write` immediately after creation, before this check, since they had no pre-existing content to preserve drift on).
- `git status --porcelain` scoped to exactly the 5 intended files throughout.

### Stakes
reversible

### Flags for Reviewer
- No note-capture UI was added for `rejectStage`'s optional `note` param — the button calls `store.rejectStage(item.id, stage)` with no note, keeping this fix bounded to "the action is reachable at all." A follow-up could add a small reason-entry affordance if that's wanted; see Kaizen below.

### Kaizen suggestion
`rejectStage`'s `note` param, and the `.note` field it can set on a stage, are still fully write-only from the UI's perspective even after this fix (nothing renders `item.stages[stage].note` anywhere) — a future cycle could add a lightweight way to capture *why* a stage was rejected (even a simple text prompt) and surface it near the stage's badge.

### Notes for reviewer
Session: scheduled conductor run, cycle 78 of this recurring task. Found via a deliberate Explore-agent re-sweep after cycle 77's TALKBACK note closed out the run-epoch/cross-run-race class this recurring task had concentrated on for several prior cycles — this is a different bug class (dead/unreachable UI action, not a race condition).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MjYo4L7PEXgp4g1eGAc1YD)_