### PR TITLE
refactor(sample): use shared flat panel in card scaffold

### DIFF
--- a/sample/sample-card.vue.txt
+++ b/sample/sample-card.vue.txt
@@ -120,7 +120,7 @@
 
       <details
         v-if="showDebug"
-        class="rounded-2xl border border-base-300 bg-base-100 p-2"
+        class="kr-panel-flat p-2"
         @click.stop
       >
         <summary class="cursor-pointer text-xs font-bold text-base-content/70">


### PR DESCRIPTION
## Summary
- replace the sample card scaffold's byte-exact hand-rolled flat panel surface with `kr-panel-flat`
- preserve the debug disclosure's `p-2` spacing and behavior
- keep future generated model cards from reintroducing the duplicated panel vocabulary

## Scope
Interface Vision recurring consistency slice (`t-104`). One scaffold file, one class substitution, no runtime/data/schema changes.

Session: `openai-scheduled-20260901T191620Z-interface-vision-t104-q6n8`