### PR TITLE
style: use shared muted panel for stylist clients

### DIFF
--- a/components/art/stylist-clients.vue
+++ b/components/art/stylist-clients.vue
@@ -1,6 +1,6 @@
 <!-- /components/art/stylist-clients.vue -->
 <template>
-  <section class="stylist-clients flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-200 p-4">
+  <section class="stylist-clients kr-panel-muted flex flex-col gap-4 p-4">
     <header class="flex items-center gap-2">
       <Icon name="kind-icon:heart" class="h-5 w-5 text-primary" />
       <h2 class="text-base font-black text-base-content">Clients</h2>


### PR DESCRIPTION
## Summary
- migrate the Stylist Clients root surface to `kr-panel-muted`
- preserve the existing `p-4`, layout classes, and behavior
- interface-vision/t-104 bounded consistency slice

The shared primitive is byte-equivalent to the removed `rounded-2xl border border-base-300 bg-base-200` utilities, so this is a zero-geometry, zero-behavior consistency change.

Session: `openai-scheduled-20260901T201244Z-interface-vision-t104-q4x7`