### PR TITLE
feat(model-builder): wire an optional reject note into the item panel

### DIFF
--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -44,6 +44,12 @@
           {{ item.stages.PITCH.status }}
         </span>
       </div>
+      <p
+        v-if="rejectionNoteFor('PITCH')"
+        class="mb-1.5 rounded-lg bg-error/10 px-2 py-1 text-xs text-error/80"
+      >
+        {{ rejectionNoteFor('PITCH') }}
+      </p>
       <textarea
         v-model="pitch"
         rows="2"
@@ -116,6 +122,12 @@
           {{ item.stages.FIELDS_AND_PROMPTS.status }}
         </span>
       </div>
+      <p
+        v-if="rejectionNoteFor('FIELDS_AND_PROMPTS')"
+        class="mb-1.5 rounded-lg bg-error/10 px-2 py-1 text-xs text-error/80"
+      >
+        {{ rejectionNoteFor('FIELDS_AND_PROMPTS') }}
+      </p>
       <div class="mb-0.5 flex items-center justify-between">
         <label class="block text-[10px] uppercase text-base-content/40">
           Proposed fields / relationships
@@ -225,6 +237,13 @@
           {{ item.stages.GENERATE_ASSETS.status }}
         </span>
       </div>
+
+      <p
+        v-if="rejectionNoteFor('GENERATE_ASSETS')"
+        class="mb-1.5 rounded-lg bg-error/10 px-2 py-1 text-xs text-error/80"
+      >
+        {{ rejectionNoteFor('GENERATE_ASSETS') }}
+      </p>
 
       <div
         v-if="item.generation !== 'image'"
@@ -632,8 +651,28 @@ function approve(stage: BuildStageKey): void {
 // existing action to a "Reject" control next to each review-gate stage's
 // Approve button (PITCH/FIELDS_AND_PROMPTS/GENERATE_ASSETS -- COMMIT has no
 // approve/reject concept of its own; commitItem sets its status directly).
+//
+// Bug (model-builder/t-029, cycle 79): rejectStage()'s optional `note` param
+// was still write-only from this component's own perspective -- cycle 78
+// wired the reject *action* but never passed a note through it, and nothing
+// rendered item.stages[stage].note anywhere, so a rejected stage carried no
+// visible record of why. window.prompt() mirrors the same optional-reason
+// pattern user-manager-directory.vue's onRestrict() already uses elsewhere
+// in this app: null (Cancel) aborts the reject entirely rather than
+// rejecting with a blank note.
 function reject(stage: BuildStageKey): void {
-  store.rejectStage(props.itemId, stage)
+  const note = window.prompt('Reject this stage? Optional note for why:', '')
+  if (note === null) return
+  store.rejectStage(props.itemId, stage, note.trim() || undefined)
+}
+
+// item.stages[stage].note is reused for non-rejection bookkeeping too (e.g.
+// GENERATE_ASSETS stashes 'queued' or a carried-over error there while
+// 'in-progress'/'ready') -- only surface it here when the stage is actually
+// 'rejected', so those unrelated uses never leak into this note callout.
+function rejectionNoteFor(stage: BuildStageKey): string | undefined {
+  const current = item.value?.stages[stage]
+  return current?.status === 'rejected' ? current.note : undefined
 }
 
 function badgeFor(stage: BuildStageKey): string {

--- a/utils/scripts/verifyModelBuilderItemPanelRejectWiringGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderItemPanelRejectWiringGuard.test.ts
@@ -2,12 +2,15 @@
 //
 // Regression test for checkItemPanelRejectWiringGuard() in
 // verifyModelBuilderItemPanelRejectWiringGuard.ts (model-builder/t-029,
-// cycle 78). Exercises the real check against synthetic file-shaped
-// fixtures covering: the pre-fix shape (no reject() wrapper, no Reject
-// buttons at all -- store.rejectStage has no caller), the fixed shape (all
-// three stages wired), a partial fix (wrapper defined but one stage's
-// button missing), and the wrapper defined with a differently-shaped body
-// (should still be flagged, since the guard checks the exact call shape).
+// cycles 78-79). Exercises the real check against synthetic file-shaped
+// fixtures covering: the pre-cycle-78 shape (no reject() wrapper, no Reject
+// buttons or note callouts at all -- store.rejectStage has no caller), the
+// cycle-78-only shape (Reject buttons wired but reject() never collects or
+// passes a note, and nothing renders it), the fully fixed shape (all three
+// stages wired with a note-collecting reject() and a note callout), a
+// partial fix (one stage missing its note callout), and reject() redefined
+// with a differently-shaped body (should still be flagged, since the guard
+// checks the exact call shape).
 import assert from 'node:assert/strict'
 
 import { checkItemPanelRejectWiringGuard } from './verifyModelBuilderItemPanelRejectWiringGuard.js'
@@ -25,29 +28,34 @@ function approve(stage: BuildStageKey): void {
 </script>
 `
 
-const FIXED_FIXTURE = `
+function rejectButton(stage: string): string {
+  return `
+  <button
+    type="button"
+    :disabled="isLocked('${stage}') || isAnyDraftInFlight"
+    @click="reject('${stage}')"
+  >
+    Reject
+  </button>`
+}
+
+function rejectionNoteCallout(stage: string): string {
+  return `
+      <p
+        v-if="rejectionNoteFor('${stage}')"
+        class="mb-1.5 rounded-lg bg-error/10 px-2 py-1 text-xs text-error/80"
+      >
+        {{ rejectionNoteFor('${stage}') }}
+      </p>`
+}
+
+const STAGES = ['PITCH', 'FIELDS_AND_PROMPTS', 'GENERATE_ASSETS']
+
+// Cycle 78 only: buttons wired, but reject() never collected/passed a note,
+// and no template callout renders it at all.
+const CYCLE_78_ONLY_FIXTURE = `
 <template>
-  <button
-    type="button"
-    :disabled="isLocked('PITCH') || isAnyDraftInFlight"
-    @click="reject('PITCH')"
-  >
-    Reject
-  </button>
-  <button
-    type="button"
-    :disabled="isLocked('FIELDS_AND_PROMPTS') || isAnyDraftInFlight"
-    @click="reject('FIELDS_AND_PROMPTS')"
-  >
-    Reject
-  </button>
-  <button
-    type="button"
-    :disabled="isLocked('GENERATE_ASSETS') || isGenerating || isQueued"
-    @click="reject('GENERATE_ASSETS')"
-  >
-    Reject
-  </button>
+  ${STAGES.map(rejectButton).join('\n')}
 </template>
 <script setup lang="ts">
 function approve(stage: BuildStageKey): void {
@@ -60,57 +68,60 @@ function reject(stage: BuildStageKey): void {
 </script>
 `
 
+const FIXED_FIXTURE = `
+<template>
+  ${STAGES.map((s) => rejectionNoteCallout(s) + rejectButton(s)).join('\n')}
+</template>
+<script setup lang="ts">
+function approve(stage: BuildStageKey): void {
+  store.approveStage(props.itemId, stage)
+}
+
+function reject(stage: BuildStageKey): void {
+  const note = window.prompt('Reject this stage? Optional note for why:', '')
+  if (note === null) return
+  store.rejectStage(props.itemId, stage, note.trim() || undefined)
+}
+
+function rejectionNoteFor(stage: BuildStageKey): string | undefined {
+  const current = item.value?.stages[stage]
+  return current?.status === 'rejected' ? current.note : undefined
+}
+</script>
+`
+
 const PARTIAL_FIX_FIXTURE = `
 <template>
-  <button
-    type="button"
-    :disabled="isLocked('PITCH') || isAnyDraftInFlight"
-    @click="reject('PITCH')"
-  >
-    Reject
-  </button>
-  <button
-    type="button"
-    :disabled="isLocked('FIELDS_AND_PROMPTS') || isAnyDraftInFlight"
-    @click="reject('FIELDS_AND_PROMPTS')"
-  >
-    Reject
-  </button>
+  ${rejectionNoteCallout('PITCH') + rejectButton('PITCH')}
+  ${rejectButton('FIELDS_AND_PROMPTS')}
+  ${rejectionNoteCallout('GENERATE_ASSETS') + rejectButton('GENERATE_ASSETS')}
 </template>
 <script setup lang="ts">
 function reject(stage: BuildStageKey): void {
-  store.rejectStage(props.itemId, stage)
+  const note = window.prompt('Reject this stage? Optional note for why:', '')
+  if (note === null) return
+  store.rejectStage(props.itemId, stage, note.trim() || undefined)
+}
+
+function rejectionNoteFor(stage: BuildStageKey): string | undefined {
+  const current = item.value?.stages[stage]
+  return current?.status === 'rejected' ? current.note : undefined
 }
 </script>
 `
 
 const WRONG_BODY_FIXTURE = `
 <template>
-  <button
-    type="button"
-    :disabled="isLocked('PITCH') || isAnyDraftInFlight"
-    @click="reject('PITCH')"
-  >
-    Reject
-  </button>
-  <button
-    type="button"
-    :disabled="isLocked('FIELDS_AND_PROMPTS') || isAnyDraftInFlight"
-    @click="reject('FIELDS_AND_PROMPTS')"
-  >
-    Reject
-  </button>
-  <button
-    type="button"
-    :disabled="isLocked('GENERATE_ASSETS') || isGenerating || isQueued"
-    @click="reject('GENERATE_ASSETS')"
-  >
-    Reject
-  </button>
+  ${STAGES.map((s) => rejectionNoteCallout(s) + rejectButton(s)).join('\n')}
 </template>
 <script setup lang="ts">
 function reject(stage: BuildStageKey): void {
   console.log('rejecting', stage)
+}
+
+function rejectionNoteFor(stage: BuildStageKey): string | undefined {
+  const current = item.value?.stages[stage]
+  return current?.status === 'rejected' ? current.note : undefined
 }
 </script>
 `
@@ -118,29 +129,47 @@ function reject(stage: BuildStageKey): void {
 const buggyErrors = checkItemPanelRejectWiringGuard(BUGGY_FIXTURE)
 assert.equal(
   buggyErrors.length,
-  4,
-  'expected the pre-fix shape (no reject() wrapper, no Reject buttons) to ' +
-    `raise 4 errors (wrapper + 3 stages), got ${buggyErrors.length}: ` +
+  8,
+  'expected the pre-cycle-78 shape (no reject() wrapper, no rejectionNoteFor ' +
+    'helper, no Reject buttons or note callouts) to raise 8 errors (wrapper ' +
+    `+ helper + 3 stages x 2), got ${buggyErrors.length}: ` +
     `${JSON.stringify(buggyErrors)}`,
 )
 assert.ok(buggyErrors[0]!.includes('reject(stage: BuildStageKey)` wrapper'))
+assert.ok(buggyErrors[1]!.includes('rejectionNoteFor(stage)` helper'))
+
+const cycle78Errors = checkItemPanelRejectWiringGuard(CYCLE_78_ONLY_FIXTURE)
+assert.equal(
+  cycle78Errors.length,
+  5,
+  'expected the cycle-78-only shape (buttons wired, but reject() collects ' +
+    'no note and nothing renders one) to raise 5 errors (reject() body + ' +
+    `helper + 3 note callouts; the 3 buttons themselves are already wired), ` +
+    `got ${cycle78Errors.length}: ${JSON.stringify(cycle78Errors)}`,
+)
+assert.ok(cycle78Errors[0]!.includes('reject(stage: BuildStageKey)` wrapper'))
+assert.ok(cycle78Errors[1]!.includes('rejectionNoteFor(stage)` helper'))
+assert.ok(
+  cycle78Errors.slice(2).every((e) => e.includes('rejection-note callout')),
+)
 
 const fixedErrors = checkItemPanelRejectWiringGuard(FIXED_FIXTURE)
 assert.equal(
   fixedErrors.length,
   0,
-  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+  `expected the fully fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
 )
 
 const partialErrors = checkItemPanelRejectWiringGuard(PARTIAL_FIX_FIXTURE)
 assert.equal(
   partialErrors.length,
   1,
-  'expected the partial-fix shape (GENERATE_ASSETS button missing) to ' +
-    `raise exactly 1 error, got ${partialErrors.length}: ` +
+  'expected the partial-fix shape (FIELDS_AND_PROMPTS note callout missing) ' +
+    `to raise exactly 1 error, got ${partialErrors.length}: ` +
     `${JSON.stringify(partialErrors)}`,
 )
-assert.ok(partialErrors[0]!.includes('GENERATE_ASSETS stage'))
+assert.ok(partialErrors[0]!.includes('FIELDS_AND_PROMPTS stage'))
+assert.ok(partialErrors[0]!.includes('rejection-note callout'))
 
 const wrongBodyErrors = checkItemPanelRejectWiringGuard(WRONG_BODY_FIXTURE)
 assert.equal(
@@ -154,8 +183,9 @@ assert.ok(wrongBodyErrors[0]!.includes('reject(stage: BuildStageKey)` wrapper'))
 
 console.log(
   'Model Builder item-panel Reject wiring guard checker verified: flags ' +
-    'the pre-fix shape (no reject() wrapper, no Reject buttons at all), ' +
-    "clears the fixed shape, flags a partial fix missing one stage's " +
-    "button, and flags reject() being redefined with a body that doesn't " +
-    'actually call store.rejectStage.',
+    'the pre-cycle-78 shape (nothing wired), flags the cycle-78-only shape ' +
+    '(buttons wired but no note collected/rendered), clears the fully ' +
+    "fixed shape, flags a partial fix missing one stage's note callout, " +
+    "and flags reject() being redefined with a body that doesn't actually " +
+    'call store.rejectStage.',
 )

--- a/utils/scripts/verifyModelBuilderItemPanelRejectWiringGuard.ts
+++ b/utils/scripts/verifyModelBuilderItemPanelRejectWiringGuard.ts
@@ -19,11 +19,23 @@
 // item.stages.COMMIT directly from the server response rather than through
 // approveStage/rejectStage.
 //
+// Cycle 79: rejectStage()'s optional `note` param was still write-only --
+// reject() never collected or passed one through, and nothing rendered
+// item.stages[stage].note. Fixed by prompting for an optional note
+// (window.prompt(), matching user-manager-directory.vue's onRestrict()
+// convention -- Cancel aborts the reject entirely) and adding a
+// `rejectionNoteFor(stage)` helper that surfaces the note only while the
+// stage is actually 'rejected' (the same `note` field is reused for
+// unrelated bookkeeping on other statuses, e.g. GENERATE_ASSETS's 'queued'
+// marker).
+//
 // This asserts the textual shape of that fix stays in place: the `reject()`
-// wrapper calling store.rejectStage, and each of the three stages' Reject
-// button wired to it via a gated `:disabled` attribute -- deliberately
-// scoped to this one fix, mirroring this project's other narrow textual
-// guards over a general-purpose static analyzer.
+// wrapper prompting for a note and calling store.rejectStage with it, each
+// of the three stages' Reject button wired to it via a gated `:disabled`
+// attribute, and the `rejectionNoteFor` guard scoping the note to the
+// 'rejected' status -- deliberately scoped to this fix, mirroring this
+// project's other narrow textual guards over a general-purpose static
+// analyzer.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -37,7 +49,17 @@ const ITEM_PANEL_PATH = join(
 )
 
 const REJECT_FUNCTION_DEF =
-  'function reject(stage: BuildStageKey): void {\n  store.rejectStage(props.itemId, stage)\n}'
+  'function reject(stage: BuildStageKey): void {\n' +
+  "  const note = window.prompt('Reject this stage? Optional note for why:', '')\n" +
+  '  if (note === null) return\n' +
+  '  store.rejectStage(props.itemId, stage, note.trim() || undefined)\n' +
+  '}'
+
+const REJECTION_NOTE_HELPER_DEF =
+  'function rejectionNoteFor(stage: BuildStageKey): string | undefined {\n' +
+  '  const current = item.value?.stages[stage]\n' +
+  "  return current?.status === 'rejected' ? current.note : undefined\n" +
+  '}'
 
 // One review-gate stage's Reject button: a `:disabled="..."` attribute
 // immediately followed by `@click="reject('<STAGE>')"`. COMMIT is
@@ -50,17 +72,39 @@ function rejectButtonPattern(stage: string): RegExp {
   )
 }
 
+// A stage's rejection-note callout: `rejectionNoteFor('<STAGE>')` used as a
+// v-if guard, with the same call rendered as the paragraph's interpolated
+// content.
+function rejectionNotePattern(stage: string): RegExp {
+  return new RegExp(
+    `v-if="rejectionNoteFor\\('${stage}'\\)"[\\s\\S]{0,300}?` +
+      `\\{\\{\\s*rejectionNoteFor\\('${stage}'\\)\\s*\\}\\}`,
+  )
+}
+
 export function checkItemPanelRejectWiringGuard(content: string): string[] {
   const errors: string[] = []
 
   if (!content.includes(REJECT_FUNCTION_DEF)) {
     errors.push(
-      'Could not find the `reject(stage: BuildStageKey)` wrapper calling ' +
-        'store.rejectStage(props.itemId, stage) in model-builder-item-' +
-        "panel.vue -- without it, this recurring task's own rejectStage " +
-        'store action has no caller, and a real user session can never ' +
-        "produce a 'rejected' stage no matter what the badge/editability " +
-        'logic elsewhere in this file assumes is reachable.',
+      'Could not find the `reject(stage: BuildStageKey)` wrapper prompting ' +
+        'for an optional note and calling store.rejectStage(props.itemId, ' +
+        'stage, note) in model-builder-item-panel.vue -- without it, this ' +
+        "recurring task's own rejectStage store action has no caller (or " +
+        'no way to collect a reason), and a real user session can never ' +
+        "produce a 'rejected' stage with a visible note no matter what the " +
+        'badge/editability logic elsewhere in this file assumes is ' +
+        'reachable.',
+    )
+  }
+
+  if (!content.includes(REJECTION_NOTE_HELPER_DEF)) {
+    errors.push(
+      'Could not find the `rejectionNoteFor(stage)` helper in model-' +
+        "builder-item-panel.vue -- without it, a rejected stage's note " +
+        'has no way to reach the template, and item.stages[stage].note ' +
+        '(also reused for unrelated bookkeeping on other statuses) risks ' +
+        'leaking into the UI unscoped if re-added by hand later.',
     )
   }
 
@@ -73,6 +117,17 @@ export function checkItemPanelRejectWiringGuard(content: string): string[] {
           "-- has this stage's button block been renamed or restructured? " +
           'If so, this guard (and the bug it protects against) needs to ' +
           'move with it.',
+      )
+    }
+
+    if (!rejectionNotePattern(stage).test(content)) {
+      errors.push(
+        `Could not find a rejection-note callout for the ${stage} stage ` +
+          `(a "v-if=\\"rejectionNoteFor('${stage}')\\"" element rendering ` +
+          `"{{ rejectionNoteFor('${stage}') }}") in model-builder-item-` +
+          "panel.vue -- has this stage's markup been renamed or " +
+          'restructured? If so, this guard (and the bug it protects ' +
+          'against) needs to move with it.',
       )
     }
   }
@@ -96,8 +151,10 @@ function main(): void {
 
   console.log(
     'Model Builder item-panel Reject wiring guard contract passed: the ' +
-      'reject() wrapper calls store.rejectStage, and PITCH/FIELDS_AND_' +
-      'PROMPTS/GENERATE_ASSETS each carry a gated Reject button wired to it.',
+      'reject() wrapper prompts for a note and calls store.rejectStage ' +
+      'with it, rejectionNoteFor() scopes the note to the rejected status, ' +
+      'and PITCH/FIELDS_AND_PROMPTS/GENERATE_ASSETS each carry a gated ' +
+      'Reject button and note callout wired to them.',
   )
 }
 


### PR DESCRIPTION
## Summary
`rejectStage()` has taken an optional `note` param since it was written (model-builder/t-029, cycle 78), but no caller ever collected or passed one, and nothing rendered `item.stages[stage].note` anywhere — a rejected stage carried no visible record of why.

- `reject(stage)` now prompts for an optional note via `window.prompt()`, mirroring `user-manager-directory.vue`'s `onRestrict()` convention (Cancel aborts the reject entirely rather than rejecting with a blank note), and passes it through to `store.rejectStage`.
- Added a `rejectionNoteFor(stage)` helper that surfaces the note only while the stage is actually `'rejected'` — the same `note` field is reused for unrelated bookkeeping on other statuses (e.g. `GENERATE_ASSETS`'s `'queued'` marker), so this scopes the callout to avoid leaking those into the UI.
- Rendered the note as a small inline callout under each of the three review-gate stages' badge (PITCH, FIELDS_AND_PROMPTS, GENERATE_ASSETS).
- Updated `verifyModelBuilderItemPanelRejectWiringGuard.ts`/`.test.ts` (the cycle-78 regression guard) to also assert the note-collecting `reject()` body and the `rejectionNoteFor()`-gated callout per stage.

## Scope
Model Builder recurring polish task (`t-029`, cycle 79). One component, one regression guard + its test. No runtime/data/schema changes.

## Verification
- `eslint` clean on all 3 changed files
- `vue-tsc --noEmit` repo-wide clean
- All 159 `test:model-builder-*` scripts pass (including the updated guard + its selftest)
- `test:model-builder-contract-tests-coverage-guard` passes
- `test:layout-contract` holds at the 207-violation baseline (unchanged)
- `prettier --check` clean
- `git status --porcelain` scoped to exactly 3 files throughout

Session: `claude-scheduled-20260901T202908Z-mb-t029-cycle79`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRfeFgmaGumX47CjrmiztY

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRfeFgmaGumX47CjrmiztY)_