### PR TITLE
feat(model-builder): show loading state on Start build run button

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -920,6 +920,12 @@ jobs:
       - name: Model Builder item-panel Reject wiring guard contract
         run: npm run test:model-builder-item-panel-reject-wiring-guard
 
+      - name: Model Builder "Start build run" loading-state guard checker self-test
+        run: npm run test:model-builder-start-run-loading-guard-selftest
+
+      - name: Model Builder "Start build run" loading-state guard contract
+        run: npm run test:model-builder-start-run-loading-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/components/model-builder/model-builder-recipe-selector.vue
+++ b/components/model-builder/model-builder-recipe-selector.vue
@@ -74,7 +74,11 @@
         v-for="output in store.recipeOutputs"
         :key="output.key"
         class="flex cursor-pointer items-center gap-3 kr-panel-flat rounded-xl p-2.5 transition hover:border-primary/50"
-        :class="store.selections[output.key]?.on ? 'border-primary/60 bg-primary/5' : ''"
+        :class="
+          store.selections[output.key]?.on
+            ? 'border-primary/60 bg-primary/5'
+            : ''
+        "
       >
         <input
           type="checkbox"
@@ -89,7 +93,9 @@
             <span class="truncate text-sm font-bold text-base-content">
               {{ output.label }}
             </span>
-            <span class="badge badge-xs badge-ghost">{{ output.generation }}</span>
+            <span class="badge badge-xs badge-ghost">{{
+              output.generation
+            }}</span>
             <span v-if="output.size" class="text-[10px] text-base-content/40">
               {{ output.size }}
             </span>
@@ -126,12 +132,13 @@
     </div>
 
     <!-- Footer -->
-    <div
-      class="kr-toolbar justify-between border-t border-base-300 pt-2"
-    >
+    <div class="kr-toolbar justify-between border-t border-base-300 pt-2">
       <div class="flex items-center gap-3">
         <span class="text-xs text-base-content/60">
-          {{ store.selectedOutputCount }} output{{ store.selectedOutputCount === 1 ? '' : 's' }} selected
+          {{ store.selectedOutputCount }} output{{
+            store.selectedOutputCount === 1 ? '' : 's'
+          }}
+          selected
         </span>
         <label
           class="flex cursor-pointer items-center gap-1.5 text-xs text-base-content/70"
@@ -150,10 +157,18 @@
         type="button"
         class="btn btn-primary btn-sm rounded-xl"
         :disabled="!store.canStartRun"
+        :aria-busy="store.startingRun"
         @click="store.startRun()"
       >
-        <Icon name="kind-icon:play" class="h-4 w-4" />
-        Start build run
+        <span
+          v-if="store.startingRun"
+          class="loading loading-dots loading-sm"
+          aria-hidden="true"
+        />
+        <template v-else>
+          <Icon name="kind-icon:play" class="h-4 w-4" />
+          Start build run
+        </template>
       </button>
     </div>
   </div>

--- a/package.json
+++ b/package.json
@@ -404,6 +404,8 @@
     "test:model-builder-resume-run-request-guard": "tsx utils/scripts/verifyModelBuilderResumeRunRequestGuard.ts",
     "test:model-builder-item-panel-reject-wiring-guard-selftest": "tsx utils/scripts/verifyModelBuilderItemPanelRejectWiringGuard.test.ts",
     "test:model-builder-item-panel-reject-wiring-guard": "tsx utils/scripts/verifyModelBuilderItemPanelRejectWiringGuard.ts",
+    "test:model-builder-start-run-loading-guard-selftest": "tsx utils/scripts/verifyModelBuilderStartRunLoadingGuard.test.ts",
+    "test:model-builder-start-run-loading-guard": "tsx utils/scripts/verifyModelBuilderStartRunLoadingGuard.ts",
     "test:storybook-active-story-resume-guard": "npx tsx utils/scripts/verifyStorybookActiveStoryResumeGuard.ts",
     "test:storybook-answer-input-preservation-guard": "node utils/scripts/verifyStorybookAnswerInputPreservationGuard.mjs",
     "test:storybook-answer-rollback-guard": "node utils/scripts/verifyStorybookAnswerRollbackGuard.mjs",

--- a/utils/scripts/verifyModelBuilderStartRunLoadingGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderStartRunLoadingGuard.test.ts
@@ -1,0 +1,95 @@
+// /utils/scripts/verifyModelBuilderStartRunLoadingGuard.test.ts
+//
+// Regression test for checkStartRunLoadingGuard() in
+// verifyModelBuilderStartRunLoadingGuard.ts (model-builder/t-029, cycle 80).
+// Exercises the real check against synthetic file-shaped fixtures covering:
+// the pre-fix shape (plain button, no aria-busy, no spinner), the fully
+// fixed shape (aria-busy + spinner + icon/label fallback), and a partial fix
+// (aria-busy present but no spinner wired).
+import assert from 'node:assert/strict'
+
+import { checkStartRunLoadingGuard } from './verifyModelBuilderStartRunLoadingGuard.js'
+
+const BUGGY_FIXTURE = `
+<template>
+  <button
+    type="button"
+    class="btn btn-primary btn-sm rounded-xl"
+    :disabled="!store.canStartRun"
+    @click="store.startRun()"
+  >
+    <Icon name="kind-icon:play" class="h-4 w-4" />
+    Start build run
+  </button>
+</template>
+`
+
+const FIXED_FIXTURE = `
+<template>
+  <button
+    type="button"
+    class="btn btn-primary btn-sm rounded-xl"
+    :disabled="!store.canStartRun"
+    :aria-busy="store.startingRun"
+    @click="store.startRun()"
+  >
+    <span
+      v-if="store.startingRun"
+      class="loading loading-dots loading-sm"
+      aria-hidden="true"
+    />
+    <template v-else>
+      <Icon name="kind-icon:play" class="h-4 w-4" />
+      Start build run
+    </template>
+  </button>
+</template>
+`
+
+const PARTIAL_FIX_FIXTURE = `
+<template>
+  <button
+    type="button"
+    class="btn btn-primary btn-sm rounded-xl"
+    :disabled="!store.canStartRun"
+    :aria-busy="store.startingRun"
+    @click="store.startRun()"
+  >
+    <Icon name="kind-icon:play" class="h-4 w-4" />
+    Start build run
+  </button>
+</template>
+`
+
+const buggyErrors = checkStartRunLoadingGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  2,
+  'expected the pre-fix shape (no aria-busy, no spinner) to raise 2 ' +
+    `errors, got ${buggyErrors.length}: ${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(buggyErrors[0]!.includes('aria-busy="store.startingRun"'))
+assert.ok(buggyErrors[1]!.includes('loading-dots spinner'))
+
+const fixedErrors = checkStartRunLoadingGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fully fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const partialErrors = checkStartRunLoadingGuard(PARTIAL_FIX_FIXTURE)
+assert.equal(
+  partialErrors.length,
+  1,
+  'expected the partial-fix shape (aria-busy present, spinner missing) to ' +
+    `raise exactly 1 error, got ${partialErrors.length}: ` +
+    `${JSON.stringify(partialErrors)}`,
+)
+assert.ok(partialErrors[0]!.includes('loading-dots spinner'))
+
+console.log(
+  'Model Builder "Start build run" loading-state guard checker verified: ' +
+    'flags the pre-fix shape (no aria-busy, no spinner), clears the fully ' +
+    'fixed shape, and flags a partial fix missing the spinner.',
+)

--- a/utils/scripts/verifyModelBuilderStartRunLoadingGuard.ts
+++ b/utils/scripts/verifyModelBuilderStartRunLoadingGuard.ts
@@ -1,0 +1,96 @@
+// /utils/scripts/verifyModelBuilderStartRunLoadingGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 80) -- store.startRun() in
+// stores/modelBuilderStore.ts is a real async POST to /api/model-builder/runs
+// (serializes every selected output into an itemsPayload, potentially many
+// items across quantity/expansion outputs) and already sets/clears
+// state.startingRun around the call (also already folded into canStartRun
+// to block double-submission), but the "Start build run" button in
+// model-builder-recipe-selector.vue rendered no spinner, no "starting..."
+// label, and no aria-busy while that request was in flight -- it just went
+// visually inert. Every other async action button in this feature
+// (model-builder-item-panel.vue's Auto/Draft/Generate/Execute buttons,
+// model-builder-progress-matrix.vue's Auto-build all, model-builder-batch-
+// editor.vue's header spinner, etc.) already shows an in-flight state; this
+// was the one step-content button in the whole feature with none.
+//
+// Fixed by adding :aria-busy="store.startingRun" and a conditional spinner
+// span (mirroring model-builder-item-panel.vue's Execute-commit button
+// pattern) that replaces the icon + label while store.startingRun is true.
+//
+// This asserts the textual shape of that fix stays in place: the button
+// carries aria-busy bound to store.startingRun, and a loading-dots spinner
+// guarded by v-if="store.startingRun" appears before the icon/label
+// fallback -- deliberately scoped to this fix, mirroring this project's
+// other narrow textual guards over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const RECIPE_SELECTOR_PATH = join(
+  repositoryRoot,
+  'components/model-builder/model-builder-recipe-selector.vue',
+)
+
+// The "Start build run" button: an aria-busy attribute bound to
+// store.startingRun and a click handler calling store.startRun(), followed
+// (within a bounded window) by a v-if="store.startingRun" loading-dots
+// spinner span.
+const START_RUN_LOADING_PATTERN =
+  /:aria-busy="store\.startingRun"[\s\S]{0,120}?@click="store\.startRun\(\)"[\s\S]{0,120}?v-if="store\.startingRun"[\s\S]{0,60}?loading loading-dots/
+
+export function checkStartRunLoadingGuard(content: string): string[] {
+  const errors: string[] = []
+
+  if (!content.includes(':aria-busy="store.startingRun"')) {
+    errors.push(
+      'Could not find `:aria-busy="store.startingRun"` on the "Start ' +
+        'build run" button in model-builder-recipe-selector.vue -- ' +
+        'without it, screen-reader users get no live-region signal that ' +
+        'starting a build run (a real async POST that can take a while ' +
+        'for large item selections) is in flight.',
+    )
+  }
+
+  if (!START_RUN_LOADING_PATTERN.test(content)) {
+    errors.push(
+      'Could not find a loading-dots spinner gated on ' +
+        'v-if="store.startingRun" wired into the "Start build run" ' +
+        'button in model-builder-recipe-selector.vue -- without it, the ' +
+        'button goes silently inert while store.startRun() is in ' +
+        'flight, unlike every other async action button in this feature ' +
+        '(Auto/Draft/Generate/Execute in model-builder-item-panel.vue, ' +
+        'Auto-build all in model-builder-progress-matrix.vue, etc).',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(RECIPE_SELECTOR_PATH, 'utf8')
+  const errors = checkStartRunLoadingGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder "Start build run" loading-state guard contract ' +
+        'failed for model-builder-recipe-selector.vue:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder "Start build run" loading-state guard contract passed: ' +
+      'the button carries aria-busy bound to store.startingRun and shows a ' +
+      'loading-dots spinner while the run-creation request is in flight.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Summary
`store.startRun()` is a real async POST to `/api/model-builder/runs` that serializes every selected output into an `itemsPayload` (potentially many items across quantity/expansion outputs) and can take a while for large selections. It already sets/clears `state.startingRun` around the call (already folded into `canStartRun` to block double-submission) — but the "Start build run" button rendered no spinner, no `aria-busy`, and no in-flight feedback while the request was in flight, unlike every other async action button in this feature (Auto/Draft/Generate/Execute in `model-builder-item-panel.vue`, Auto-build all in `model-builder-progress-matrix.vue`, etc).

- Added `:aria-busy="store.startingRun"` and a conditional `loading-dots` spinner to the "Start build run" button, mirroring the existing pattern used by `model-builder-item-panel.vue`'s Execute-commit button.
- Added `verifyModelBuilderStartRunLoadingGuard.ts`/`.test.ts` (this recurring task's established narrow-textual-guard convention), wired into `package.json` and `contract-tests.yml`.

## Scope
Model Builder recurring polish task (`t-029`, cycle 80). One component, one regression guard + its test. No runtime/data/schema changes.

## Verification
- `eslint` clean on all 3 changed files
- `vue-tsc --noEmit` repo-wide clean
- All 161 `test:model-builder-*` scripts pass (159 prior + 2 new)
- `test:model-builder-contract-tests-coverage-guard` passes
- `test:layout-contract` holds at the 207-violation baseline (unchanged)
- `prettier --check` clean
- `git status --porcelain` scoped to exactly 5 files throughout

Session: `claude-scheduled-20260901T212858-mb-t029-cycle80`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NB33Xj5wGEiQjwX6uvU4Z

---
_Generated by [Claude Code](https://claude.ai/code/session_011NB33Xj5wGEiQjwX6uvU4Z)_