### PR TITLE
Rename the feed heading to "News", and greet the signed-in user in the header

### DIFF
--- a/components/home/home-page.vue
+++ b/components/home/home-page.vue
@@ -273,11 +273,18 @@
           class="flex max-h-80 flex-col overflow-y-auto overscroll-contain kr-panel-flat p-3 xl:max-h-full xl:min-h-0 xl:flex-1"
         >
           <NewsfeedFeed :initial-limit="24" compact>
+            <!--
+              "News", not "From around the web". Silas, 2026-09-01: "we might as
+              well change 'from around the web' to 'News'". It also buys back the
+              width the topic chips were short of: the heading shares one row
+              with the chips, three controls and the lab link inside a 22%
+              column, and the long version was eating roughly 150px of it.
+            -->
             <template #lead>
               <h2
                 class="hidden shrink-0 text-[0.7rem] font-black uppercase tracking-[0.16em] text-primary lg:block"
               >
-                From around the web
+                News
               </h2>
             </template>
 

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -138,20 +138,52 @@
             selectable"). Only the tab label to its left opens the menu.
           -->
           <div
-            class="pointer-events-none hidden min-w-0 flex-1 flex-col justify-center px-3 leading-tight lg:flex"
-            :title="headerMessage"
+            class="pointer-events-none hidden min-w-0 flex-1 items-center gap-4 px-3 lg:flex"
           >
-            <span
-              class="truncate text-[0.65rem] font-black uppercase tracking-[0.18em] text-primary/75"
+            <div
+              class="flex min-w-0 shrink flex-col justify-center leading-tight"
+              :title="headerMessage"
             >
-              {{ brandLine }}
-            </span>
-            <span
-              v-if="headerMessage"
-              class="truncate text-sm text-base-content/55"
+              <span
+                class="truncate text-[0.65rem] font-black uppercase tracking-[0.18em] text-primary/75"
+              >
+                {{ brandLine }}
+              </span>
+              <span
+                v-if="headerMessage"
+                class="truncate text-sm text-base-content/55"
+              >
+                {{ headerMessage }}
+              </span>
+            </div>
+
+            <!--
+              THE GREETING. Silas, 2026-09-01: "it's more a part of the main
+              content dash, but we really should see a Welcome {username} in
+              large letters after the room and room info piece."
+
+              "After the room and room info piece" places it exactly: those two
+              lines are to its left, and this takes the rest of the stretch. It
+              stays in the header rather than moving into the page because that
+              is where the room and its blurb live, and because the home page is
+              now a fixed-height desktop layout -- a greeting band there would
+              come out of the dream's height rather than out of space that was
+              already empty.
+
+              THE ONE RULE THIS ROW HAS is that nothing in it grows (see the
+              note at the top of this file: the strip that preceded it needed
+              300 lines of measurement precisely because a child's width was
+              unbounded). So this is `min-w-0 truncate` inside a `shrink`
+              sibling pair, and it appears only from `xl`, where the stretch has
+              room to spare. A long username shortens; it never pushes.
+            -->
+            <p
+              v-if="greeting"
+              class="hidden min-w-0 flex-1 truncate text-right text-lg font-black text-base-content/80 xl:block xl:text-xl"
+              :title="greeting"
             >
-              {{ headerMessage }}
-            </span>
+              {{ greeting }}
+            </p>
           </div>
         </div>
 
@@ -218,6 +250,7 @@ import type { ResolvedTab } from '@/stores/helpers/channelContent'
 import { useChannelContentStore } from '@/stores/channelContentStore'
 import { useNavStore } from '@/stores/navStore'
 import { usePageStore } from '@/stores/pageStore'
+import { useUserStore } from '@/stores/userStore'
 import { tabRouteTarget } from '@/utils/tabNavigation'
 
 const fallbackIcon = 'kind-icon:sparkles'
@@ -225,6 +258,7 @@ const fallbackIcon = 'kind-icon:sparkles'
 const channelContentStore = useChannelContentStore()
 const navStore = useNavStore()
 const pageStore = usePageStore()
+const userStore = useUserStore()
 const router = useRouter()
 const route = useRoute()
 
@@ -385,6 +419,18 @@ const activeTitle = computed(
  * subtitle, then the page's. `activeTabConfig` resolves to fallbackTab (built
  * from pageStore) on routes outside any channel, so this holds there too.
  */
+/**
+ * "Welcome <username>", or nothing at all.
+ *
+ * Nothing for a signed-out visitor: userStore.username falls back to the
+ * literal "Kind Guest" so that everyone has a name for attribution purposes,
+ * and greeting a stranger by a placeholder reads worse than not greeting them.
+ * `isLoggedIn` is the check that distinguishes the two.
+ */
+const greeting = computed(() =>
+  userStore.isLoggedIn ? `Welcome ${userStore.username}` : '',
+)
+
 const brandLine = computed(
   () => pageStore.room || activeTitle.value || 'Kind Robots',
 )

--- a/components/newsfeed/newsfeed-feed.vue
+++ b/components/newsfeed/newsfeed-feed.vue
@@ -20,10 +20,10 @@
         ONE ROW WITH ITS HOST'S HEADING, not a row beneath it. Silas,
         2026-08-29: "The selections like all ai news, etc, and the other icons,
         should be in line with the From around the web and newsfeed tab
-        section."
+        section." (That heading is just "News" now, 2026-09-01.)
 
-        The home page used to render its own "From around the web" heading and
-        "newsfeed lab" link in a section header, and then this strip below it --
+        The home page used to render its own heading and "newsfeed lab" link in
+        a section header, and then this strip below it --
         two full rows of chrome above the first story. These slots let the host
         put its heading and its link INTO this row, so there is one. The
         Newsfeed Lab page passes neither and is unchanged.


### PR DESCRIPTION
Two small asks from 2026-09-01.

## "From around the web" → "News"

> "we might as well change 'from around the web' to 'News'"

It also settles the one thing I'd flagged for your eye on #2307. That heading shares a single row with the topic chips, three controls and the lab link inside a 22% side column; at roughly 150px the long version was most of what left the chips ~100px to scroll within. "News" gives it back.

The two remaining mentions in `newsfeed-feed.vue` are quotes of what you said at the time, kept as the record of why the header slots exist.

## Welcome {username}

> "it's more a part of the main content dash, but we really should see a Welcome {username} in large letters after the room and room info piece."

"After the room and room info piece" places it exactly, and those two lines live in the **header**, so that's where it goes. It also has to: the home page is now a fixed-height desktop layout, so a greeting band there would come out of the dream's height — while the header stretch had spare width sitting empty.

**The one rule this row has is that nothing in it grows.** The note at the top of that file records why: the tab strip this row replaced needed ~300 lines of capacity arithmetic, a `ResizeObserver` and per-breakpoint measurement precisely because a child's width was unbounded. So the greeting is `min-w-0 truncate` inside a shrinking pair, and appears only from `xl`.

Verified with a 46-character username at 1920×1080 — the paragraph takes the leftover 1070px and truncates inside it, and the document reports **zero horizontal overflow**. A long name shortens; it never pushes.

Nothing is shown to a signed-out visitor: `userStore.username` falls back to the literal `"Kind Guest"` so everyone has a name for attribution, and greeting a stranger by a placeholder reads worse than not greeting them.

## Verification

`vue-tsc`, `eslint`, `prettier`, `npm run test:layout-contract`, `verifyMdcScrollOwnership.ts` all clean, plus the long-username overflow measurement above.

One note on process: a mid-run `git stash` to compare against `main` left a stale `.nuxt` type cache that produced ~5 phantom errors in `achievement-gallery.vue`, a file neither commit touches. Re-run clean both with and without these changes — they're not real, and the greeting change was re-verified after recovering it from the stash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aNg3fsHLGUGCwiMp25hkA

---
_Generated by [Claude Code](https://claude.ai/code/session_017aNg3fsHLGUGCwiMp25hkA)_