### PR TITLE
Home: add the dream's location, and real scroll controls where rows scroll

### DIFF
--- a/components/home/home-art-shelf.vue
+++ b/components/home/home-art-shelf.vue
@@ -33,6 +33,7 @@
     plate-variant="card"
     placeholder-icon="kind-icon:palette-color"
     fit="contain"
+    show-label
     :interactive="mode === 'fresh'"
     @select="emit('select', $event)"
   >

--- a/components/home/home-dream-hero.vue
+++ b/components/home/home-dream-hero.vue
@@ -174,12 +174,19 @@
       cards, single row, scrollable horizontally depending on room in the
       middle."
 
-      Each tile is sized by the BAND HEIGHT rather than by a width: `h-full`
-      plus `aspect-[2/3]` makes it as tall as the row and derives its width from
-      the portrait shape these objects are actually drawn at. So the cards fill
-      the space (they are ~230px wide here, not 72px thumbnails), the row is as
-      tall as the dream card beside it by construction, and however many cast
-      members a dream has, they scroll sideways instead of shrinking or wrapping.
+      Each tile is as tall as the row (`h-full`) with a FIXED width. It used to
+      derive its width from `aspect-2/3`, which made a handsome card and left no
+      say over how much of it was text. Silas, 2026-09-01: "having a little more
+      vertical space for larger text would be great on those, with some width
+      cut back so we can fit the location entry." A fixed 11rem is narrower than
+      the ~15rem the aspect produced -- enough to fit the newly-added location
+      card on screen -- and the plate simply takes whatever height the caption
+      does not, so widening the caption no longer fights the picture for room.
+
+      So the cards fill the space (measured at 1920: 176px wide and 420px tall,
+      not 72px thumbnails), the row is as tall as the dream card beside it by
+      construction, and however many cast members a dream has, they scroll
+      sideways instead of shrinking or wrapping.
 
       This replaces a three-row grid of 4.5rem tiles. That grid existed to solve
       two earlier problems -- tiles that would not stay small (`minmax(X,1fr)`
@@ -192,11 +199,31 @@
       card at the right edge is the affordance, and eight shelves each reserving
       a scrollbar gutter was a complaint in its own right.
     -->
+    <!--
+      A REAL SCROLL CONTROL, because the row genuinely does not always fit.
+      Silas, 2026-09-01: "it's reasonable that there will be a need to scroll on
+      smaller displays, but if so, we need an actual scroll selector."
+
+      Six full-height slots at 11rem come to more than the middle column has at
+      1920, and narrower screens are worse. The track stays `.no-scrollbar` for
+      the reason home-rail.vue gives -- a reserved scrollbar gutter is a row of
+      nothing -- so the affordance is a pair of chevrons instead.
+
+      They OVERLAY the ends of the row rather than sitting in a header, because
+      unlike a rail this panel has no header row to put them in and adding one
+      would cost the height the cards just gained. `v-show` keeps the buttons out
+      of the tab order's way only when there is nothing to scroll.
+    -->
     <div
       v-if="hero.cast.length"
-      class="no-scrollbar flex gap-1.5 overflow-x-auto lg:h-full lg:min-w-0 lg:flex-1"
+      class="relative lg:h-full lg:min-w-0 lg:flex-1"
     >
-      <!--
+      <div
+        ref="castTrack"
+        class="no-scrollbar flex h-full gap-1.5 overflow-x-auto scroll-smooth"
+        @scroll.passive="measureCast"
+      >
+        <!--
         A cast member opens the interstitial rather than navigating away. Silas,
         2026-08-29: "Whenever I click on one of the new objects, I want it to
         expand to tell me about it ... with clicking outside the container
@@ -208,37 +235,37 @@
         click -- see the same note in home-rail.vue for why the <button> version
         of this was worse, and why it is a plain <a> rather than a NuxtLink.
       -->
-      <a
-        v-for="member in hero.cast"
-        :key="`${member.kind}-${member.id}`"
-        :href="showcaseHref(member)"
-        :data-theme="themeFor(member)"
-        class="group flex aspect-2/3 h-full shrink-0 flex-col overflow-hidden rounded-lg border-2 border-primary/70 bg-base-100 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:hover:-translate-y-0.5"
-        :title="
-          member.subtitle
-            ? `${member.title} — ${member.subtitle}`
-            : member.title
-        "
-        @click="onCastClick($event, member)"
-      >
-        <kr-art-plate
-          class="min-h-0 flex-1"
-          :source="member.art"
-          variant="card"
-          shape="square"
-          frame="none"
-          :alt="member.title"
-          :fallback="fallbackFor(member)"
-          hover-zoom
-          fit="cover"
+        <a
+          v-for="member in principals"
+          :key="`${member.kind}-${member.id}`"
+          :href="showcaseHref(member)"
+          :data-theme="themeFor(member)"
+          class="group flex h-full w-44 shrink-0 flex-col overflow-hidden rounded-lg border-2 border-primary/70 bg-base-100 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:hover:-translate-y-0.5"
+          :title="
+            member.subtitle
+              ? `${member.title} — ${member.subtitle}`
+              : member.title
+          "
+          @click="onCastClick($event, member)"
         >
-          <!--
+          <kr-art-plate
+            class="min-h-0 flex-1"
+            :source="member.art"
+            variant="card"
+            shape="square"
+            frame="none"
+            :alt="member.title"
+            :fallback="fallbackFor(member)"
+            hover-zoom
+            fit="cover"
+          >
+            <!--
             The kind rides on the plate rather than taking a line of its own
             beneath it. Two text lines per chip made the cast column taller than
             the plate beside it, which is where the panel's dead space came from.
           -->
-          <template v-if="member.badge" #overlay>
-            <!--
+            <template v-if="member.badge" #overlay>
+              <!--
               text-base-content, not text-primary: each chip sits inside its
               record's own daisyUI theme, and several themes' primary is far too
               pale to read on base-100 (the "Facet" chip on a pastel tile
@@ -248,15 +275,15 @@
 
               max-w + truncate because "CHARACTER" is wider than a 4rem tile.
             -->
-            <span
-              class="absolute left-1 top-1 max-w-[calc(100%-0.5rem)] truncate rounded bg-base-100/90 px-1 text-[0.45rem] font-black uppercase tracking-[0.08em] text-base-content backdrop-blur"
-            >
-              {{ member.badge }}
-            </span>
-          </template>
-        </kr-art-plate>
+              <span
+                class="absolute left-1 top-1 max-w-[calc(100%-0.5rem)] truncate rounded bg-base-100/90 px-1 text-[0.45rem] font-black uppercase tracking-[0.08em] text-base-content backdrop-blur"
+              >
+                {{ member.badge }}
+              </span>
+            </template>
+          </kr-art-plate>
 
-        <!--
+          <!--
           THE CARD SAYS WHAT THE THING IS. Silas, 2026-09-01: "we should see
           description text on the character, item, skill, etc for the daily
           dream (facets is just the title)."
@@ -267,26 +294,96 @@
           character's backstory. Everything else gets two clamped lines under
           its name.
         -->
-        <div class="min-w-0 shrink-0 px-1.5 py-1">
-          <p
-            class="truncate text-xs font-bold leading-tight group-hover:text-primary"
-          >
-            {{ member.title }}
-          </p>
-          <p
-            v-if="member.subtitle"
-            class="line-clamp-2 text-[0.65rem] leading-snug text-base-content/60"
-          >
-            {{ member.subtitle }}
-          </p>
+          <!--
+          The caption gets a definite share of the card rather than whatever is
+          left after the picture. Silas, 2026-09-01: "having a little more
+          vertical space for larger text". Two lines of name and three of
+          description at a readable size; the plate above flexes into the rest,
+          so this is the half of the card that sets the split.
+        -->
+          <div class="min-w-0 shrink-0 px-2 py-1.5">
+            <p
+              class="line-clamp-2 text-sm font-bold leading-tight group-hover:text-primary"
+            >
+              {{ member.title }}
+            </p>
+            <p
+              v-if="member.subtitle"
+              class="mt-0.5 line-clamp-3 text-xs leading-snug text-base-content/65"
+            >
+              {{ member.subtitle }}
+            </p>
+          </div>
+        </a>
+
+        <!--
+        THE FACETS SHARE ONE CARD'S SLOT, as a 2x2 of picture-and-title. Silas,
+        2026-09-01: "since facets are just images ... we should have a 2x2 grid
+        with image and title in the space the other cards have image, title, and
+        description."
+
+        Same width as a cast card (w-44) so the row keeps its rhythm, and each
+        cell is still a link that opens the interstitial. A facet is a one-word
+        tag on the dream rather than a character in it, which is why it gets a
+        quarter of a card while a character gets a whole one.
+      -->
+        <div v-if="facets.length" class="flex h-full w-44 shrink-0 flex-col">
+          <div class="grid min-h-0 flex-1 grid-cols-2 grid-rows-2 gap-1">
+            <a
+              v-for="facet in facets.slice(0, 4)"
+              :key="`facet-${facet.id}`"
+              :href="showcaseHref(facet)"
+              :data-theme="themeFor(facet)"
+              class="group/facet flex min-h-0 min-w-0 flex-col overflow-hidden rounded-lg border-2 border-primary/60 bg-base-100 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+              :title="facet.title"
+              @click="onCastClick($event, facet)"
+            >
+              <kr-art-plate
+                class="min-h-0 flex-1"
+                :source="facet.art"
+                variant="card"
+                shape="square"
+                frame="none"
+                :alt="facet.title"
+                :fallback="fallbackFor(facet)"
+                fit="cover"
+              />
+              <p
+                class="shrink-0 truncate px-1 py-0.5 text-[0.6rem] font-bold leading-tight group-hover/facet:text-primary"
+              >
+                {{ facet.title }}
+              </p>
+            </a>
+          </div>
         </div>
-      </a>
+      </div>
+
+      <button
+        v-show="castCanScroll"
+        type="button"
+        class="absolute left-0 top-1/2 grid size-7 -translate-y-1/2 place-items-center rounded-full border border-base-300 bg-base-100/90 text-base-content/60 shadow backdrop-blur transition-colors hover:text-primary disabled:opacity-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+        :disabled="castAtStart"
+        aria-label="Scroll the cast backwards"
+        @click="scrollCast(-1)"
+      >
+        <Icon name="kind-icon:chevron-left" class="size-4" />
+      </button>
+      <button
+        v-show="castCanScroll"
+        type="button"
+        class="absolute right-0 top-1/2 grid size-7 -translate-y-1/2 place-items-center rounded-full border border-base-300 bg-base-100/90 text-base-content/60 shadow backdrop-blur transition-colors hover:text-primary disabled:opacity-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+        :disabled="castAtEnd"
+        aria-label="Scroll the cast forwards"
+        @click="scrollCast(1)"
+      >
+        <Icon name="kind-icon:chevron-right" class="size-4" />
+      </button>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import {
   showcaseHref,
   type ShowcaseCard,
@@ -296,6 +393,35 @@ import { defaultArtFor } from '@/utils/defaultArtPool'
 import { resolveEntityTheme } from '@/utils/entityTheme'
 
 const props = defineProps<{ hero: ShowcaseHero }>()
+
+/*
+ * THE CAST IS TWO KINDS OF THING, and only one of them is a character.
+ *
+ * A daily dream's cast runs to nine: a location, a character, an item, a skill,
+ * a scenario -- and four FACETS, which are one-word tags on the dream ("Noir",
+ * "Hacker"). Nine full cards do not fit the middle column at a readable size:
+ * measured at 1920 only 5.1 of nine were on screen, so Silas saw a sixth card
+ * clipped ("I can tell that there is a sixth entry cut off").
+ *
+ * Shrinking every card until nine fit would undo the larger text he asked for
+ * in the same breath. So the split follows what he already said about facets --
+ * "(facets is just the title)" -- and gives the five real cast members the cards
+ * while the four facets share ONE card's slot as a 2x2 of picture-and-title.
+ * Nothing is hidden; the thing that gave up room is the thing that was only
+ * ever a word.
+ *
+ * SIX SLOTS STILL DO NOT ALL FIT (six x 182px against a ~933px middle at 1920),
+ * and that is fine now: "it's reasonable that there will be a need to scroll on
+ * smaller displays, but if so, we need an actual scroll selector." The row has
+ * chevrons.
+ */
+const principals = computed(() =>
+  props.hero.cast.filter((member) => member.kind !== 'facet'),
+)
+
+const facets = computed(() =>
+  props.hero.cast.filter((member) => member.kind === 'facet'),
+)
 const emit = defineEmits<{ select: [card: ShowcaseCard] }>()
 
 /*
@@ -336,4 +462,62 @@ function fallbackFor(member: ShowcaseCard): string {
 function themeFor(member: ShowcaseCard): string {
   return resolveEntityTheme({ id: member.id, theme: member.theme })
 }
+
+/*
+ * The cast row's chevrons, same mechanism as home-rail.vue's -- deliberately a
+ * copy of about twenty lines rather than a shared composable, because the two
+ * differ in every respect that matters (a rail puts its buttons in a header it
+ * already has; this overlays them on a track that has none) and the shared part
+ * is three DOM measurements.
+ */
+const castTrack = ref<HTMLElement | null>(null)
+const castCanScroll = ref(false)
+const castAtStart = ref(true)
+const castAtEnd = ref(false)
+
+/** The 2px slack absorbs sub-pixel rounding; see the same note in home-rail. */
+function measureCast(): void {
+  const element = castTrack.value
+  if (!element) return
+
+  const max = element.scrollWidth - element.clientWidth
+  castCanScroll.value = max > 2
+  castAtStart.value = element.scrollLeft <= 2
+  castAtEnd.value = element.scrollLeft >= max - 2
+}
+
+/** One press moves about a screenful, keeping a card of context. */
+function scrollCast(direction: 1 | -1): void {
+  const element = castTrack.value
+  if (!element) return
+
+  element.scrollBy({
+    left: direction * Math.max(element.clientWidth * 0.8, 176),
+    behavior: 'smooth',
+  })
+}
+
+let castObserver: ResizeObserver | null = null
+
+onMounted(() => {
+  measureCast()
+  if (typeof ResizeObserver === 'undefined') return
+
+  // The row's width is set by the page band, not by its contents, so a content
+  // watcher alone leaves stale chevrons after a resize.
+  castObserver = new ResizeObserver(() => measureCast())
+  if (castTrack.value) castObserver.observe(castTrack.value)
+})
+
+onBeforeUnmount(() => {
+  castObserver?.disconnect()
+  castObserver = null
+})
+
+watch(
+  () => props.hero.cast.length,
+  () => {
+    void nextTick(measureCast)
+  },
+)
 </script>

--- a/components/home/home-page.vue
+++ b/components/home/home-page.vue
@@ -144,6 +144,7 @@
               :plate-variant="entry.plateVariant"
               :placeholder-icon="entry.placeholderIcon"
               :fit="entry.fit ?? 'cover'"
+              show-label
               interactive
               @select="openCard"
             />

--- a/components/home/home-rail.vue
+++ b/components/home/home-rail.vue
@@ -58,14 +58,30 @@
         words so a screen reader and a hover both still get "New characters".
       -->
       <span
-        class="flex shrink-0 items-center gap-1 text-primary"
+        class="flex min-w-0 shrink items-center gap-1 text-primary"
         :title="label"
         :aria-label="label"
       >
-        <Icon :name="icon || placeholderIcon" class="size-4" />
+        <Icon :name="icon || placeholderIcon" class="size-4 shrink-0" />
+        <!--
+          THE WORDS COME BACK WHERE THERE IS ROOM. Silas, 2026-09-01: "objects
+          section should be labeled if the screen supports it."
+
+          The HOST decides, via `showLabel`, rather than this component guessing
+          with a breakpoint -- that is the t-089 lesson: a breakpoint asks how
+          big the WINDOW is, which is only the same question as how big this
+          shelf is when the shelf is the window. It is not: below xl these
+          shelves are 17rem cells in a scrolling row, and at xl they are ~480px
+          cells in a 3x2 grid. Only the page knows which.
+        -->
+        <span
+          v-if="showLabel"
+          class="hidden truncate text-[0.6rem] font-black uppercase tracking-[0.14em] xl:inline"
+          >{{ label }}</span
+        >
         <span
           v-if="items.length"
-          class="text-[0.6rem] font-black tabular-nums text-base-content/40"
+          class="shrink-0 text-[0.6rem] font-black tabular-nums text-base-content/40"
           >{{ items.length }}</span
         >
       </span>
@@ -173,12 +189,27 @@
         :key="`${item.kind}-${item.id}`"
         :href="showcaseHref(item)"
         :data-theme="themeFor(item)"
-        class="group flex shrink-0 flex-col overflow-hidden rounded-xl border-2 border-primary/70 bg-base-100 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:duration-300 motion-safe:hover:-translate-y-0.5"
+        class="group flex h-full shrink-0 flex-col overflow-hidden rounded-xl border-2 border-primary/70 bg-base-100 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:duration-300 motion-safe:hover:-translate-y-0.5"
         :class="cardWidthClass"
         :title="item.subtitle ? `${item.title} — ${item.subtitle}` : item.title"
         @click="onTileClick($event, item)"
       >
+        <!--
+          THE PICTURE TAKES WHATEVER THE CAPTION LEAVES. Silas, 2026-09-01:
+          "there is wayyyy to much negative space on the object galleries ... we
+          should also just have the space for the text and the images fill the
+          rest."
+
+          The tile used to be its plate's natural height plus one caption line,
+          sitting inside a grid cell much taller than that -- so every gallery
+          card had a band of empty panel under it. `min-h-0 flex-1` on the plate
+          plus `h-full` on the tile inverts that: the caption claims its two
+          lines and the plate expands into everything else. An aspect-ratio only
+          sizes a box while a dimension is auto, so giving the plate a definite
+          height makes `shape` inert here and the art crops to fill.
+        -->
         <kr-art-plate
+          class="min-h-0 flex-1"
           :source="item.art"
           :variant="plateVariant"
           :shape="shape"
@@ -205,13 +236,14 @@
         </kr-art-plate>
 
         <!--
-          Title only. The subtitle used to sit under it, but at a 5rem tile it
-          truncated to "a short line of co…" on every card -- a line of height
-          per rail spent on nothing. It survives as the link's tooltip.
+          TWO LINES, not one truncated one. Silas, 2026-09-01: "if we had two
+          lines allocated we wouldn't have to cut so much text". Most object
+          names fit in two at this width; the tooltip still carries the full
+          name plus its subtitle for the ones that do not.
         -->
-        <div class="min-w-0 px-1.5 py-1">
+        <div class="min-w-0 shrink-0 px-1.5 py-1">
           <p
-            class="truncate text-xs font-bold leading-tight text-base-content group-hover:text-primary"
+            class="line-clamp-2 text-xs font-bold leading-tight text-base-content group-hover:text-primary"
           >
             {{ item.title }}
           </p>
@@ -238,6 +270,12 @@ const props = withDefaults(
     seeAllLabel?: string
     /** The glyph that replaces the shelf's written label on screen. */
     icon?: string
+    /**
+     * Show the written label beside the glyph. The host sets this when its
+     * layout gives the shelf room for words; see the note in the template for
+     * why this is a prop rather than a breakpoint decided in here.
+     */
+    showLabel?: boolean
     /** 'card' is the 2:3 portrait shelf; 'wide' is the 4:3 art shelf. */
     shape?: ArtPlateShape
     plateVariant?: ArtVariant
@@ -265,6 +303,7 @@ const props = withDefaults(
     plateVariant: 'card',
     placeholderIcon: 'kind-icon:image',
     icon: '',
+    showLabel: false,
     rows: 1,
     interactive: false,
   },

--- a/components/newsfeed/newsfeed-feed.vue
+++ b/components/newsfeed/newsfeed-feed.vue
@@ -38,7 +38,41 @@
       -->
       <slot name="lead" />
 
-      <div class="no-scrollbar flex min-w-0 flex-1 gap-1.5 overflow-x-auto">
+      <!--
+        A DROPDOWN WHEN THE COLUMN IS NARROW, chips when it is not. Silas,
+        2026-09-01: "the news section is missing a scroll or dropdown to choose
+        different news tabs."
+
+        The chip row was already `overflow-x-auto`, so it was scrollABLE -- but
+        in the 414px right column the visible chips ("All", part of one topic)
+        filled the strip edge to edge with no partial chip showing, so nothing
+        on screen said there were seven more. That is a scroll with no
+        affordance, which is the same complaint as the cast row's, and here a
+        select answers it better than chevrons: it costs one control instead of
+        three, it names the tab you are on, and it lists every feed at once
+        rather than a slice.
+
+        `compact` and not a breakpoint, on the t-089 rule: the question is how
+        wide THIS panel is, and only the host knows that. The Newsfeed Lab page
+        passes nothing and keeps its chips.
+      -->
+      <label v-if="compact" class="min-w-0 flex-1">
+        <span class="sr-only">Choose a news feed</span>
+        <select
+          v-model="activeSlug"
+          class="select select-sm w-full rounded-xl border-base-300 bg-base-100 font-bold focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+        >
+          <option :value="ALL_FEEDS_SLUG">All</option>
+          <option v-for="group in groups" :key="group.slug" :value="group.slug">
+            {{ group.title }}
+          </option>
+        </select>
+      </label>
+
+      <div
+        v-else
+        class="no-scrollbar flex min-w-0 flex-1 gap-1.5 overflow-x-auto"
+      >
         <button
           type="button"
           class="btn btn-sm shrink-0 rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"

--- a/server/api/showcase/home.get.ts
+++ b/server/api/showcase/home.get.ts
@@ -356,7 +356,29 @@ const heroDreamInclude = {
   },
   Scenarios: {
     where: PUBLIC,
-    select: { ...heroCastSelect, title: true, description: true },
+    select: {
+      ...heroCastSelect,
+      title: true,
+      description: true,
+      /*
+       * THE DAILY DREAM'S LOCATION, which had no way to reach the page.
+       * Silas, 2026-09-01: "We are missing locations."
+       *
+       * A location is not its own model -- it is a Dream with
+       * `dreamType: LOCATION`, and utils/scripts/publishDreamLocations.ts links
+       * it to the SCENARIOS it hosts rather than to the daily dream directly.
+       * So the only path from the hero to its setting runs through the
+       * scenario, which is why nothing surfaced it before. Verified against
+       * production 2026-09-01: LOCATION dream 5723 "The Shadow Oak Common" ->
+       * Scenario 2203 "The Signal That Answered Back", the scenario in that
+       * day's cast, and the place the scenario's own prose names.
+       */
+      Dreams: {
+        where: { ...PUBLIC, dreamType: 'LOCATION' },
+        select: { ...heroCastSelect, title: true, description: true },
+        take: 2,
+      },
+    },
     take: 3,
   },
   FacetLinks: {
@@ -375,6 +397,37 @@ type HeroDream = Prisma.DreamGetPayload<{
 
 function buildHeroCast(dream: HeroDream): ShowcaseCard[] {
   const cast: ShowcaseCard[] = []
+
+  /*
+   * LOCATIONS FIRST: the setting before the cast standing in it, which is also
+   * the order the scenario's own prose uses ("In Nightfall Pasture at The
+   * Shadow Oak Common, Ronan Okafor..."). Reached through the scenarios, and
+   * deduped -- two scenarios in one dream can share a location, and it should
+   * appear once.
+   *
+   * `kind: 'dream'` because a location IS a Dream (dreamType LOCATION), so the
+   * card opens at /dreams?dream=<id> like any other. Only the badge differs.
+   */
+  const seenLocations = new Set<number>()
+  for (const scenario of dream.Scenarios ?? []) {
+    for (const location of scenario.Dreams ?? []) {
+      if (seenLocations.has(location.id)) continue
+      seenLocations.add(location.id)
+
+      cast.push(
+        card('dream', {
+          id: location.id,
+          title: location.title,
+          subtitle: summarize(location.description),
+          slug: location.slug,
+          theme: location.theme,
+          badge: 'Location',
+          createdAt: location.createdAt,
+          art: artOf(location),
+        }),
+      )
+    }
+  }
 
   for (const character of dream.Characters ?? []) {
     cast.push(


### PR DESCRIPTION
Ninth pass on the home page, answering the four things in the last round of feedback.

## Locations were unreachable, not merely unrendered

> "We are missing locations, they are cut off on the daily dream section."

A location is not its own model — it is a `Dream` with `dreamType: LOCATION`, and `utils/scripts/publishDreamLocations.ts` links it to the **scenarios** it hosts rather than to the daily dream. So `/api/showcase/home` had no path from the hero to its own setting. It now reaches locations through the scenarios, deduped (two scenarios in one dream can share one), and puts the location first in the cast — the order the scenario's own prose uses.

Verified against production: LOCATION dream 5723 "The Shadow Oak Common" → Scenario 2203 "The Signal That Answered Back", the scenario in that day's cast.

## Cast cards trade width for text

> "having a little more vertical space for larger text would be great on those, with some width cut back so we can fit the location entry"

A fixed `w-44` (11rem) instead of the aspect-derived ~15rem, with two lines of name and three of description at a readable size. The plate takes whatever the caption leaves, so widening the caption no longer fights the picture. Measured at 1920: 176×420.

## Facets share one card's slot

> "since facets are just images … we should have a 2x2 grid with image and title in the space the other cards have image, title, and description"

A dream carries four facets, so the cast runs to nine. Nine full cards do not fit the middle column at a size worth reading — measured, 5.1 of nine were on screen, which is the sixth entry that was visibly cut off. The five real cast members keep whole cards; the four facets share one card's slot as a 2×2 of picture-and-title. Nothing is hidden, and the thing that gave up room is the thing that was only ever a word.

**On the count itself:** conductor `dream-cycle/t-018` specifies 1–2 seed facets per dream. The live showcase returns 4 against a `take: 4` cap, so the real number is *at least* four — genuine drift from spec, and the public dreams API doesn't expose `FacetLinks`, so the exact figure isn't pinnable from outside. Worth a look on the conductor side; this PR just renders what is there.

## Real scroll controls, both places

> "it's reasonable that there will be a need to scroll on smaller displays, but if so, we need an actual scroll selector. also, the news section is missing a scroll or dropdown to choose different news tabs"

- **Cast row**: overlaid chevrons at the row's ends, same `measure()`/`scrollBy()`/`ResizeObserver` mechanism as `home-rail.vue`. Overlaid rather than in a header because this panel has no header row and adding one would cost the height the cards just gained.
- **Newsfeed**: a `<select>` of every feed when `compact`. The chip row was already scrollable, but in the 414px right column the visible chips filled it edge to edge with no partial chip showing — a scroll with no affordance. Gated on `compact`, not a breakpoint, because the question is how wide *this panel* is and only the host knows that. The Newsfeed Lab page keeps its chips, unchanged.

Also: gallery shelves show their written labels where the page says there is room ("objects section should be labeled if the screen supports it").

## Measurements

Playwright against a mocked payload, 1920×1080 unless noted:

| | |
|---|---|
| Forward chevron | moves the row 153px, its exact overhang; last card becomes fully visible; button disables at the end; back chevron returns |
| News dropdown | lists all 7 tabs; selecting AI Gaming narrows 24 cards to 8 |
| Horizontal overflow | 0 at 1920, 1366, 1280 and 900 — chevrons visible at each |
| Newsfeed Lab (`/plan/newsfeed`) | chips intact, no dropdown |

One thing the harness itself was getting wrong and is now fixed: its `/api/newsfeed` mock returned a flat item list, but the endpoint answers with one aggregated entry *per feed*. The component was logging `res.data.map is not a function`, which is why the topic selector had exactly one option and couldn't be measured at all.

## Verification

`prettier` · `eslint` · `npm run test:layout-contract` (holds, no new violations) · `verifyMdcScrollOwnership.ts` (15 existing, no new) · `npm run test` (`vue-tsc`, exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aNg3fsHLGUGCwiMp25hkA

---
_Generated by [Claude Code](https://claude.ai/code/session_017aNg3fsHLGUGCwiMp25hkA)_