### PR TITLE
Add per-human Krea2 public free capacity

### DIFF
--- a/.github/workflows/krea2-public-quota-contract.yml
+++ b/.github/workflows/krea2-public-quota-contract.yml
@@ -1,0 +1,24 @@
+name: Krea2 Public Quota Contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'prisma/migrations/**add_krea2_public_quota**'
+      - 'server/utils/krea2Quota.ts'
+      - 'server/utils/krea2GenerationGate.ts'
+      - 'server/utils/artJobQueueCoverage.ts'
+      - 'server/api/rainbow/generation/krea2/**'
+      - 'tests/contracts/verifyKrea2PublicQuota.ts'
+      - '.github/workflows/krea2-public-quota-contract.yml'
+
+jobs:
+  verify:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: npm install --include=optional
+      - run: npx tsx tests/contracts/verifyKrea2PublicQuota.ts

--- a/prisma/migrations/20260902022500_add_krea2_public_quota/migration.sql
+++ b/prisma/migrations/20260902022500_add_krea2_public_quota/migration.sql
@@ -1,0 +1,63 @@
+-- Rainbow Butterflies / Kind Robots shared Krea2 public-free capacity ledger.
+--
+-- Quota identity is always the canonical human User id. AgentProfile and
+-- credential ids are audit provenance only, so connecting more agents never
+-- multiplies a human's allowance.
+
+CREATE TABLE `Krea2DailyUserQuota` (
+    `quotaDate` DATE NOT NULL,
+    `userId` INTEGER NOT NULL,
+    `used` INTEGER NOT NULL DEFAULT 0,
+    `updatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`quotaDate`, `userId`),
+    INDEX `Krea2DailyUserQuota_userId_idx` (`userId`),
+    CONSTRAINT `Krea2DailyUserQuota_userId_fkey`
+      FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `Krea2DailyPublicPool` (
+    `quotaDate` DATE NOT NULL,
+    `used` INTEGER NOT NULL DEFAULT 0,
+    `updatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`quotaDate`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `Krea2QuotaReservation` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `quotaDate` DATE NOT NULL,
+    `userId` INTEGER NOT NULL,
+    `agentProfileId` INTEGER NULL,
+    `credentialId` INTEGER NULL,
+    `artJobId` INTEGER NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    UNIQUE INDEX `Krea2QuotaReservation_artJobId_key` (`artJobId`),
+    INDEX `Krea2QuotaReservation_user_day_idx` (`userId`, `quotaDate`),
+    INDEX `Krea2QuotaReservation_agent_idx` (`agentProfileId`, `quotaDate`),
+    PRIMARY KEY (`id`),
+    CONSTRAINT `Krea2QuotaReservation_userId_fkey`
+      FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT `Krea2QuotaReservation_agentProfileId_fkey`
+      FOREIGN KEY (`agentProfileId`) REFERENCES `AgentProfile`(`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT `Krea2QuotaReservation_artJobId_fkey`
+      FOREIGN KEY (`artJobId`) REFERENCES `ArtJob`(`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `Krea2DeferredFreeJob` (
+    `artJobId` INTEGER NOT NULL,
+    `userId` INTEGER NOT NULL,
+    `agentProfileId` INTEGER NULL,
+    `credentialId` INTEGER NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`artJobId`),
+    INDEX `Krea2DeferredFreeJob_user_created_idx` (`userId`, `createdAt`),
+    CONSTRAINT `Krea2DeferredFreeJob_artJobId_fkey`
+      FOREIGN KEY (`artJobId`) REFERENCES `ArtJob`(`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT `Krea2DeferredFreeJob_userId_fkey`
+      FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT `Krea2DeferredFreeJob_agentProfileId_fkey`
+      FOREIGN KEY (`agentProfileId`) REFERENCES `AgentProfile`(`id`) ON DELETE SET NULL ON UPDATE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/server/api/rainbow/generation/krea2/enqueue.post.ts
+++ b/server/api/rainbow/generation/krea2/enqueue.post.ts
@@ -1,0 +1,153 @@
+import { createError, defineEventHandler, readBody } from 'h3'
+import { buildKrea2WorkflowFromRequest } from '@/server/api/comfy/krea2/utils/workflow'
+import { assertArtPromptContract } from '@/server/utils/artPromptContract'
+import { errorHandler } from '@/server/utils/error'
+import { krea2GenerationGate } from '@/server/utils/krea2GenerationGate'
+
+const ALLOWED_FIELDS = new Set([
+  'prompt',
+  'negativePrompt',
+  'width',
+  'height',
+  'steps',
+  'cfg',
+  'seed',
+  'sampler',
+  'scheduler',
+  'isPublic',
+  'isMature',
+])
+
+function integerOrDefault(value: unknown, fallback: number, min: number, max: number) {
+  if (value == null) return fallback
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
+    throw createError({
+      statusCode: 400,
+      message: `Expected an integer between ${min} and ${max}.`,
+    })
+  }
+  return parsed
+}
+
+function finiteOrDefault(value: unknown, fallback: number, min: number, max: number) {
+  if (value == null) return fallback
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed < min || parsed > max) {
+    throw createError({
+      statusCode: 400,
+      message: `Expected a number between ${min} and ${max}.`,
+    })
+  }
+  return parsed
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const raw = (await readBody<Record<string, unknown> | null>(event)) ?? {}
+    for (const key of Object.keys(raw)) {
+      if (!ALLOWED_FIELDS.has(key)) {
+        throw createError({
+          statusCode: 400,
+          message: `Unsupported Krea 2 generation field: ${key}.`,
+        })
+      }
+    }
+
+    const prompt = typeof raw.prompt === 'string' ? raw.prompt.trim() : ''
+    if (!prompt || prompt.length > 4000) {
+      throw createError({
+        statusCode: 400,
+        message: 'prompt is required and may contain at most 4000 characters.',
+      })
+    }
+
+    const negativePrompt =
+      typeof raw.negativePrompt === 'string' ? raw.negativePrompt.trim() : ''
+    const width = integerOrDefault(raw.width, 1024, 256, 2048)
+    const height = integerOrDefault(raw.height, 1024, 256, 2048)
+    const steps = integerOrDefault(raw.steps, 8, 1, 20)
+    const cfg = finiteOrDefault(raw.cfg, 1, 0, 20)
+    const seed = raw.seed == null ? null : integerOrDefault(raw.seed, 0, 0, 2_147_483_647)
+    const sampler = typeof raw.sampler === 'string' ? raw.sampler.trim() || null : null
+    const scheduler =
+      typeof raw.scheduler === 'string' ? raw.scheduler.trim() || null : null
+    const isPublic = raw.isPublic !== false
+    const isMature = raw.isMature === true
+
+    assertArtPromptContract({ prompt, engine: 'krea2', steps, cfg })
+
+    const gate = await krea2GenerationGate(event, { steps, width, height })
+    const { workflow } = buildKrea2WorkflowFromRequest({
+      prompt,
+      negativePrompt,
+      width,
+      height,
+      steps,
+      cfg,
+      seed,
+      sampler,
+      scheduler,
+      denoise: null,
+      loraName: null,
+      loraStrength: null,
+      loras: null,
+    })
+
+    const outcome = await gate.enqueueArtJob(
+      {
+        engine: 'COMFY',
+        payload: JSON.stringify({
+          workflow,
+          promptString: prompt,
+          save: {
+            isPublic,
+            isMature,
+            designer: null,
+            artCollectionIds: [],
+          },
+          rainbowQuota: {
+            requestedAt: new Date().toISOString(),
+            requestedByAgentProfileId: gate.quota?.deferredForUser != null ? undefined : undefined,
+          },
+        }),
+        priority: 100,
+        projectSlug: 'rainbow-butterflies',
+        userId: gate.user.id,
+      },
+      'rainbow-krea2-enqueue',
+    )
+
+    event.node.res.statusCode = 201
+    const message =
+      outcome.quotaMode === 'DEFERRED_FREE'
+        ? 'Your free Krea 2 request is queued for the next available public-capacity slot. No tokens were charged.'
+        : outcome.quotaMode === 'PAID_TOKENS'
+          ? 'Your daily free Krea 2 allowance is used, so this generation was queued with paid-token priority.'
+          : outcome.quotaMode === 'FREE_QUOTA'
+            ? 'Krea 2 generation queued using today’s shared free allowance.'
+            : 'Krea 2 generation queued on free compute you control or may use.'
+
+    return {
+      success: true,
+      message,
+      data: {
+        jobId: outcome.job.id,
+        status: outcome.job.status,
+        quotaMode: outcome.quotaMode,
+        quota: outcome.quota,
+        tokens: { charged: outcome.charged },
+      },
+      statusCode: 201,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+    event.node.res.statusCode = statusCode
+    return {
+      success: false,
+      message: handled.message || 'Failed to queue Krea 2 generation.',
+      statusCode,
+    }
+  }
+})

--- a/server/api/rainbow/generation/krea2/enqueue.post.ts
+++ b/server/api/rainbow/generation/krea2/enqueue.post.ts
@@ -66,8 +66,8 @@ export default defineEventHandler(async (event) => {
       typeof raw.negativePrompt === 'string' ? raw.negativePrompt.trim() : ''
     const width = integerOrDefault(raw.width, 1024, 256, 2048)
     const height = integerOrDefault(raw.height, 1024, 256, 2048)
-    const steps = integerOrDefault(raw.steps, 8, 1, 20)
-    const cfg = finiteOrDefault(raw.cfg, 1, 0, 20)
+    const steps = integerOrDefault(raw.steps, 8, 1, 8)
+    const cfg = finiteOrDefault(raw.cfg, 1, 0, 1)
     const seed = raw.seed == null ? null : integerOrDefault(raw.seed, 0, 0, 2_147_483_647)
     const sampler = typeof raw.sampler === 'string' ? raw.sampler.trim() || null : null
     const scheduler =
@@ -108,7 +108,6 @@ export default defineEventHandler(async (event) => {
           },
           rainbowQuota: {
             requestedAt: new Date().toISOString(),
-            requestedByAgentProfileId: gate.quota?.deferredForUser != null ? undefined : undefined,
           },
         }),
         priority: 100,

--- a/server/api/rainbow/generation/krea2/quota.get.ts
+++ b/server/api/rainbow/generation/krea2/quota.get.ts
@@ -1,0 +1,19 @@
+import { defineEventHandler } from 'h3'
+import { requireApiUser } from '@/server/utils/authGuard'
+import { getKrea2QuotaStatus } from '@/server/utils/krea2Quota'
+
+export default defineEventHandler(async (event) => {
+  const auth = await requireApiUser(event)
+  const quota = await getKrea2QuotaStatus(auth.user.id)
+
+  return {
+    success: true,
+    quota: {
+      ...quota,
+      // Quota is human-owned. AgentProfile identity is useful provenance, but
+      // it never changes the allowance denominator.
+      sharedAcrossAgents: true,
+      agentProfileId: auth.agentProfileId ?? null,
+    },
+  }
+})

--- a/server/utils/artJobQueueCoverage.ts
+++ b/server/utils/artJobQueueCoverage.ts
@@ -18,15 +18,24 @@
 //      are duplicate work. Keep the candidate (or an already-RUNNING sibling)
 //      and cancel the other PENDING copies.
 //
-// Explicit retries carry payload.retry and are excluded from both policies.
-// Cancellation preserves the ArtJob row/provenance while removing it from the
-// runnable queue.
+// It also acts as the final claim-time capacity gate for Rainbow's deferred
+// Krea2 public-free jobs. Those jobs own no future credit when enqueued; they
+// become runnable only after a fresh human + public daily slot is atomically
+// reserved here.
+//
+// Explicit retries carry payload.retry and are excluded from both coverage
+// policies. Cancellation preserves the ArtJob row/provenance while removing it
+// from the runnable queue.
 
 import type { ArtJob } from '~/prisma/generated/prisma/client'
 import prisma from './prisma'
 import { parseArtJobPayload } from './artJobPayload'
 import { queuedArtPrompt } from './artJobQueueSettings'
 import { normalizeArtPrompt } from './artJobProvenance'
+import {
+  getDeferredKrea2JobIds,
+  tryPromoteDeferredKrea2Job,
+} from './krea2Quota'
 
 export const FACET_COVERAGE_FIELD_ORDER = [
   'imagePath',
@@ -347,6 +356,18 @@ async function reconcileStaticDelivery(
 export async function reconcileQueuedArtJobCoverage(
   candidate: QueueCandidate,
 ): Promise<CoverageResult> {
+  const deferred = await getDeferredKrea2JobIds([candidate.id])
+  if (deferred.has(candidate.id)) {
+    const promoted = await tryPromoteDeferredKrea2Job(candidate.id)
+    if (!promoted) {
+      return {
+        skipCandidate: true,
+        cancelledCount: 0,
+        reason: 'krea2-free-capacity-wait',
+      }
+    }
+  }
+
   const parsedPayload = parseArtJobPayload(candidate.payload)
   const facet = await reconcileFacetCoverage(candidate, parsedPayload)
   if (facet) return facet

--- a/server/utils/krea2GenerationGate.ts
+++ b/server/utils/krea2GenerationGate.ts
@@ -1,0 +1,230 @@
+import { createError, type H3Event } from 'h3'
+import type { Prisma } from '~/prisma/generated/prisma/client'
+import { requireScopedApiUser } from './authGuard'
+import { userRoles } from './authUser'
+import { estimateArtCostUsd } from './manaCost'
+import { manaGate } from './manaGate'
+import prisma from './prisma'
+import {
+  deferredKrea2QueueError,
+  enqueueKrea2PublicFreeJob,
+  getKrea2QuotaStatus,
+  type Krea2QuotaStatus,
+} from './krea2Quota'
+
+type Krea2GateInput = {
+  steps?: number | null
+  width?: number | null
+  height?: number | null
+  serverId?: number | null
+}
+
+type Krea2QuotaMode =
+  | 'RESOURCE_FREE'
+  | 'FREE_QUOTA'
+  | 'DEFERRED_FREE'
+  | 'PAID_TOKENS'
+
+type Krea2EnqueueOutcome = {
+  job: Awaited<ReturnType<typeof prisma.artJob.create>>
+  balance: number
+  charged: number
+  quotaMode: Krea2QuotaMode
+  quota: Krea2QuotaStatus | null
+}
+
+export type Krea2GenerationGate = {
+  user: { id: number }
+  isAdmin: boolean
+  cost: number
+  free: boolean
+  quotaMode: Krea2QuotaMode
+  quota: Krea2QuotaStatus | null
+  enqueueArtJob: (
+    data: Prisma.ArtJobUncheckedCreateInput,
+    refPrefix: string,
+  ) => Promise<Krea2EnqueueOutcome>
+}
+
+async function usesFreeCompute(input: {
+  userId: number
+  serverId?: number | null
+  isAdmin: boolean
+  isServerKey: boolean
+  roles: readonly string[]
+}): Promise<boolean> {
+  if (input.isAdmin || input.isServerKey) return true
+  if (input.roles.some((role) => String(role).toUpperCase() === 'FAMILY')) {
+    return true
+  }
+  if (!input.serverId) return false
+
+  const server = await prisma.server.findFirst({
+    where: { id: input.serverId, isActive: true },
+    select: { userId: true, isPublic: true, isOfficial: true },
+  })
+  if (!server) return false
+  return (
+    server.userId === input.userId ||
+    (server.isPublic === true && server.isOfficial === false)
+  )
+}
+
+async function requirePaidTokenGate(
+  event: H3Event,
+  input: Krea2GateInput,
+) {
+  const paid = await manaGate(event, {
+    kind: 'art',
+    estCostUsd: estimateArtCostUsd({
+      engine: 'comfy',
+      steps: input.steps,
+      width: input.width,
+      height: input.height,
+    }),
+    serverId: input.serverId ?? null,
+  })
+
+  if (!paid.free && paid.fundedBy !== 'TOKENS') {
+    throw createError({
+      statusCode: 402,
+      message:
+        'Your daily free Krea 2 allowance is used. Additional Krea 2 generations require paid tokens; free mana is not used as an overflow pool.',
+    })
+  }
+  return paid
+}
+
+/**
+ * Krea 2 public capacity is intentionally separate from mana. Ordinary humans
+ * and all AgentProfiles they operate share one daily allowance. Own/community
+ * compute remains free without consuming the public pool. Once the human daily
+ * allowance is used, additional work must be funded by paid TOKENS.
+ */
+export async function krea2GenerationGate(
+  event: H3Event,
+  input: Krea2GateInput,
+): Promise<Krea2GenerationGate> {
+  const auth = await requireScopedApiUser(event, 'generation:art')
+  const intrinsicFree = await usesFreeCompute({
+    userId: auth.user.id,
+    serverId: input.serverId ?? null,
+    isAdmin: auth.isAdmin,
+    isServerKey: auth.isServerKey,
+    roles: [...userRoles(auth.user)],
+  })
+
+  if (intrinsicFree) {
+    const gate = await manaGate(event, {
+      kind: 'art',
+      estCostUsd: estimateArtCostUsd({
+        engine: 'comfy',
+        steps: input.steps,
+        width: input.width,
+        height: input.height,
+      }),
+      serverId: input.serverId ?? null,
+    })
+    return {
+      user: { id: auth.user.id },
+      isAdmin: auth.isAdmin,
+      cost: 0,
+      free: true,
+      quotaMode: 'RESOURCE_FREE',
+      quota: null,
+      enqueueArtJob: async (data, refPrefix) => {
+        const job = await prisma.artJob.create({ data })
+        const committed = await gate.commit(`${refPrefix}:${job.id}`)
+        return {
+          job,
+          balance: committed.balance,
+          charged: 0,
+          quotaMode: 'RESOURCE_FREE',
+          quota: null,
+        }
+      },
+    }
+  }
+
+  const quota = await getKrea2QuotaStatus(auth.user.id)
+  if (quota.userRemaining <= 0) {
+    const paid = await requirePaidTokenGate(event, input)
+    return {
+      user: { id: auth.user.id },
+      isAdmin: auth.isAdmin,
+      cost: paid.cost,
+      free: false,
+      quotaMode: 'PAID_TOKENS',
+      quota,
+      enqueueArtJob: async (data, refPrefix) => {
+        const priority = Math.max(Number(data.priority ?? 100), 200)
+        const job = await prisma.artJob.create({ data: { ...data, priority } })
+        const committed = await paid.commit(`${refPrefix}:${job.id}`)
+        return {
+          job,
+          balance: committed.balance,
+          charged: paid.cost,
+          quotaMode: 'PAID_TOKENS',
+          quota: await getKrea2QuotaStatus(auth.user.id),
+        }
+      },
+    }
+  }
+
+  const initialMode: Krea2QuotaMode =
+    quota.publicRemaining > 0 ? 'FREE_QUOTA' : 'DEFERRED_FREE'
+
+  return {
+    user: { id: auth.user.id },
+    isAdmin: auth.isAdmin,
+    cost: 0,
+    free: true,
+    quotaMode: initialMode,
+    quota,
+    enqueueArtJob: async (data, refPrefix) => {
+      const freeResult = await enqueueKrea2PublicFreeJob(data, {
+        userId: auth.user.id,
+        agentProfileId: auth.agentProfileId ?? null,
+        credentialId: auth.credentialId ?? null,
+      })
+
+      if (freeResult.mode === 'DEFERRED_LIMIT') {
+        deferredKrea2QueueError()
+      }
+
+      if (freeResult.mode === 'USER_LIMIT') {
+        // Another tab/agent may have claimed the human's final daily slot after
+        // the preflight above. Fall back to the same explicit paid-token rule;
+        // never silently consume legacy free mana.
+        const paid = await requirePaidTokenGate(event, input)
+        const priority = Math.max(Number(data.priority ?? 100), 200)
+        const job = await prisma.artJob.create({ data: { ...data, priority } })
+        const committed = await paid.commit(`${refPrefix}:${job.id}`)
+        return {
+          job,
+          balance: committed.balance,
+          charged: paid.cost,
+          quotaMode: 'PAID_TOKENS',
+          quota: await getKrea2QuotaStatus(auth.user.id),
+        }
+      }
+
+      const job = await prisma.artJob.findUnique({
+        where: { id: freeResult.job.id },
+      })
+      if (!job) {
+        throw createError({
+          statusCode: 500,
+          message: 'The Krea 2 queue job could not be reloaded after enqueue.',
+        })
+      }
+      return {
+        job,
+        balance: Number(auth.user.mana ?? 0),
+        charged: 0,
+        quotaMode: freeResult.mode,
+        quota: await getKrea2QuotaStatus(auth.user.id),
+      }
+    },
+  }
+}

--- a/server/utils/krea2Quota.ts
+++ b/server/utils/krea2Quota.ts
@@ -1,0 +1,343 @@
+import { createError } from 'h3'
+import { Prisma } from '~/prisma/generated/prisma/client'
+import prisma from './prisma'
+
+const DEFAULT_PER_HUMAN_DAILY = 10
+const DEFAULT_PUBLIC_DAILY_POOL = 1000
+const DEFAULT_INTERNAL_DAILY_RESERVE = 500
+const DEFAULT_MAX_DEFERRED_PER_HUMAN = 10
+
+function positiveInt(raw: string | undefined, fallback: number, max: number): number {
+  const value = Number(raw)
+  return Number.isInteger(value) && value > 0 && value <= max ? value : fallback
+}
+
+export function krea2QuotaConfig() {
+  return {
+    perHumanDaily: positiveInt(
+      process.env.KREA2_FREE_PER_HUMAN_DAILY,
+      DEFAULT_PER_HUMAN_DAILY,
+      1000,
+    ),
+    publicDailyPool: positiveInt(
+      process.env.KREA2_PUBLIC_DAILY_POOL,
+      DEFAULT_PUBLIC_DAILY_POOL,
+      1_000_000,
+    ),
+    internalDailyReserve: positiveInt(
+      process.env.KREA2_INTERNAL_DAILY_RESERVE,
+      DEFAULT_INTERNAL_DAILY_RESERVE,
+      1_000_000,
+    ),
+    maxDeferredPerHuman: positiveInt(
+      process.env.KREA2_MAX_DEFERRED_PER_HUMAN,
+      DEFAULT_MAX_DEFERRED_PER_HUMAN,
+      1000,
+    ),
+  }
+}
+
+export function krea2QuotaDate(now = new Date()): string {
+  return now.toISOString().slice(0, 10)
+}
+
+export function krea2QuotaResetsAt(now = new Date()): string {
+  const reset = new Date(now)
+  reset.setUTCHours(24, 0, 0, 0)
+  return reset.toISOString()
+}
+
+type RawCount = { used: number | bigint }
+type DeferredRow = {
+  artJobId: number
+  userId: number
+  agentProfileId: number | null
+  credentialId: number | null
+}
+
+type QuotaAudit = {
+  userId: number
+  agentProfileId?: number | null
+  credentialId?: number | null
+}
+
+export type Krea2QuotaStatus = {
+  quotaDate: string
+  resetsAt: string
+  perHumanDaily: number
+  userUsed: number
+  userRemaining: number
+  publicDailyPool: number
+  publicUsed: number
+  publicRemaining: number
+  internalDailyReserve: number
+  deferredForUser: number
+}
+
+async function ensureCounterRows(
+  tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0],
+  quotaDate: string,
+  userId: number,
+) {
+  await tx.$executeRaw(Prisma.sql`
+    INSERT INTO Krea2DailyUserQuota (quotaDate, userId, used, updatedAt)
+    VALUES (${quotaDate}, ${userId}, 0, CURRENT_TIMESTAMP(3))
+    ON DUPLICATE KEY UPDATE quotaDate = VALUES(quotaDate)
+  `)
+  await tx.$executeRaw(Prisma.sql`
+    INSERT INTO Krea2DailyPublicPool (quotaDate, used, updatedAt)
+    VALUES (${quotaDate}, 0, CURRENT_TIMESTAMP(3))
+    ON DUPLICATE KEY UPDATE quotaDate = VALUES(quotaDate)
+  `)
+}
+
+async function lockedUsage(
+  tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0],
+  quotaDate: string,
+  userId: number,
+): Promise<{ userUsed: number; publicUsed: number }> {
+  const userRows = await tx.$queryRaw<RawCount[]>(Prisma.sql`
+    SELECT used
+    FROM Krea2DailyUserQuota
+    WHERE quotaDate = ${quotaDate} AND userId = ${userId}
+    FOR UPDATE
+  `)
+  const publicRows = await tx.$queryRaw<RawCount[]>(Prisma.sql`
+    SELECT used
+    FROM Krea2DailyPublicPool
+    WHERE quotaDate = ${quotaDate}
+    FOR UPDATE
+  `)
+  return {
+    userUsed: Number(userRows[0]?.used ?? 0),
+    publicUsed: Number(publicRows[0]?.used ?? 0),
+  }
+}
+
+async function incrementUsage(
+  tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0],
+  quotaDate: string,
+  userId: number,
+) {
+  await tx.$executeRaw(Prisma.sql`
+    UPDATE Krea2DailyUserQuota
+    SET used = used + 1, updatedAt = CURRENT_TIMESTAMP(3)
+    WHERE quotaDate = ${quotaDate} AND userId = ${userId}
+  `)
+  await tx.$executeRaw(Prisma.sql`
+    UPDATE Krea2DailyPublicPool
+    SET used = used + 1, updatedAt = CURRENT_TIMESTAMP(3)
+    WHERE quotaDate = ${quotaDate}
+  `)
+}
+
+export async function getKrea2QuotaStatus(userId: number): Promise<Krea2QuotaStatus> {
+  const quotaDate = krea2QuotaDate()
+  const config = krea2QuotaConfig()
+  const [userRows, publicRows, deferredRows] = await Promise.all([
+    prisma.$queryRaw<RawCount[]>(Prisma.sql`
+      SELECT used FROM Krea2DailyUserQuota
+      WHERE quotaDate = ${quotaDate} AND userId = ${userId}
+      LIMIT 1
+    `),
+    prisma.$queryRaw<RawCount[]>(Prisma.sql`
+      SELECT used FROM Krea2DailyPublicPool
+      WHERE quotaDate = ${quotaDate}
+      LIMIT 1
+    `),
+    prisma.$queryRaw<Array<{ count: bigint }>>(Prisma.sql`
+      SELECT COUNT(*) AS count FROM Krea2DeferredFreeJob WHERE userId = ${userId}
+    `),
+  ])
+  const userUsed = Number(userRows[0]?.used ?? 0)
+  const publicUsed = Number(publicRows[0]?.used ?? 0)
+  return {
+    quotaDate,
+    resetsAt: krea2QuotaResetsAt(),
+    perHumanDaily: config.perHumanDaily,
+    userUsed,
+    userRemaining: Math.max(0, config.perHumanDaily - userUsed),
+    publicDailyPool: config.publicDailyPool,
+    publicUsed,
+    publicRemaining: Math.max(0, config.publicDailyPool - publicUsed),
+    internalDailyReserve: config.internalDailyReserve,
+    deferredForUser: Number(deferredRows[0]?.count ?? 0),
+  }
+}
+
+export type Krea2EnqueueResult =
+  | { mode: 'FREE_QUOTA'; job: { id: number }; reservationId: bigint }
+  | { mode: 'DEFERRED_FREE'; job: { id: number } }
+  | { mode: 'USER_LIMIT' }
+  | { mode: 'DEFERRED_LIMIT' }
+
+/**
+ * Atomically decides the public-free path and creates the ArtJob. The daily
+ * counters and reservation live in the same transaction as the job, so two
+ * simultaneous agents for one human can never turn a 10/day allowance into 11.
+ */
+export async function enqueueKrea2PublicFreeJob(
+  data: Prisma.ArtJobUncheckedCreateInput,
+  audit: QuotaAudit,
+): Promise<Krea2EnqueueResult> {
+  const config = krea2QuotaConfig()
+  const quotaDate = krea2QuotaDate()
+
+  return await prisma.$transaction(async (tx) => {
+    await ensureCounterRows(tx, quotaDate, audit.userId)
+    const usage = await lockedUsage(tx, quotaDate, audit.userId)
+
+    if (usage.userUsed >= config.perHumanDaily) {
+      return { mode: 'USER_LIMIT' } as const
+    }
+
+    if (usage.publicUsed >= config.publicDailyPool) {
+      const deferred = await tx.$queryRaw<Array<{ artJobId: number }>>(Prisma.sql`
+        SELECT artJobId
+        FROM Krea2DeferredFreeJob
+        WHERE userId = ${audit.userId}
+        ORDER BY artJobId ASC
+        FOR UPDATE
+      `)
+      if (deferred.length >= config.maxDeferredPerHuman) {
+        return { mode: 'DEFERRED_LIMIT' } as const
+      }
+
+      const job = await tx.artJob.create({ data })
+      await tx.$executeRaw(Prisma.sql`
+        INSERT INTO Krea2DeferredFreeJob
+          (artJobId, userId, agentProfileId, credentialId, createdAt)
+        VALUES (
+          ${job.id},
+          ${audit.userId},
+          ${audit.agentProfileId ?? null},
+          ${audit.credentialId ?? null},
+          CURRENT_TIMESTAMP(3)
+        )
+      `)
+      return { mode: 'DEFERRED_FREE', job: { id: job.id } } as const
+    }
+
+    await incrementUsage(tx, quotaDate, audit.userId)
+    const job = await tx.artJob.create({ data })
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO Krea2QuotaReservation
+        (quotaDate, userId, agentProfileId, credentialId, artJobId, createdAt)
+      VALUES (
+        ${quotaDate},
+        ${audit.userId},
+        ${audit.agentProfileId ?? null},
+        ${audit.credentialId ?? null},
+        ${job.id},
+        CURRENT_TIMESTAMP(3)
+      )
+    `)
+    const reservationRows = await tx.$queryRaw<Array<{ id: bigint }>>(Prisma.sql`
+      SELECT id FROM Krea2QuotaReservation WHERE artJobId = ${job.id} LIMIT 1
+    `)
+    return {
+      mode: 'FREE_QUOTA',
+      job: { id: job.id },
+      reservationId: reservationRows[0]?.id ?? BigInt(0),
+    } as const
+  })
+}
+
+export async function getDeferredKrea2JobIds(jobIds: readonly number[]): Promise<Set<number>> {
+  if (!jobIds.length) return new Set()
+  const ids = Array.from(new Set(jobIds))
+  const rows = await prisma.$queryRaw<Array<{ artJobId: number }>>(Prisma.sql`
+    SELECT artJobId FROM Krea2DeferredFreeJob
+    WHERE artJobId IN (${Prisma.join(ids)})
+  `)
+  return new Set(rows.map((row) => row.artJobId))
+}
+
+/**
+ * Promote one deferred free job only when today's human and public pools both
+ * have room. A deferred request owns no future credits; it competes for a fresh
+ * daily slot when the relay sees it, so unused allowance never stockpiles.
+ */
+export async function tryPromoteDeferredKrea2Job(jobId: number): Promise<boolean> {
+  const config = krea2QuotaConfig()
+  const quotaDate = krea2QuotaDate()
+
+  return await prisma.$transaction(async (tx) => {
+    const rows = await tx.$queryRaw<DeferredRow[]>(Prisma.sql`
+      SELECT artJobId, userId, agentProfileId, credentialId
+      FROM Krea2DeferredFreeJob
+      WHERE artJobId = ${jobId}
+      FOR UPDATE
+    `)
+    const deferred = rows[0]
+    if (!deferred) return true
+
+    await ensureCounterRows(tx, quotaDate, deferred.userId)
+    const usage = await lockedUsage(tx, quotaDate, deferred.userId)
+    if (
+      usage.userUsed >= config.perHumanDaily ||
+      usage.publicUsed >= config.publicDailyPool
+    ) {
+      return false
+    }
+
+    await incrementUsage(tx, quotaDate, deferred.userId)
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO Krea2QuotaReservation
+        (quotaDate, userId, agentProfileId, credentialId, artJobId, createdAt)
+      VALUES (
+        ${quotaDate},
+        ${deferred.userId},
+        ${deferred.agentProfileId},
+        ${deferred.credentialId},
+        ${deferred.artJobId},
+        CURRENT_TIMESTAMP(3)
+      )
+    `)
+    await tx.$executeRaw(Prisma.sql`
+      DELETE FROM Krea2DeferredFreeJob WHERE artJobId = ${deferred.artJobId}
+    `)
+    return true
+  })
+}
+
+export async function releaseKrea2ReservationForJob(jobId: number): Promise<void> {
+  await prisma.$transaction(async (tx) => {
+    const rows = await tx.$queryRaw<
+      Array<{ id: bigint; quotaDate: Date | string; userId: number }>
+    >(Prisma.sql`
+      SELECT id, quotaDate, userId
+      FROM Krea2QuotaReservation
+      WHERE artJobId = ${jobId}
+      FOR UPDATE
+    `)
+    const row = rows[0]
+    if (!row) return
+    const quotaDate =
+      row.quotaDate instanceof Date
+        ? row.quotaDate.toISOString().slice(0, 10)
+        : String(row.quotaDate).slice(0, 10)
+
+    await tx.$executeRaw(Prisma.sql`
+      DELETE FROM Krea2QuotaReservation WHERE id = ${row.id}
+    `)
+    await tx.$executeRaw(Prisma.sql`
+      UPDATE Krea2DailyUserQuota
+      SET used = GREATEST(used - 1, 0), updatedAt = CURRENT_TIMESTAMP(3)
+      WHERE quotaDate = ${quotaDate} AND userId = ${row.userId}
+    `)
+    await tx.$executeRaw(Prisma.sql`
+      UPDATE Krea2DailyPublicPool
+      SET used = GREATEST(used - 1, 0), updatedAt = CURRENT_TIMESTAMP(3)
+      WHERE quotaDate = ${quotaDate}
+    `)
+  })
+}
+
+export function deferredKrea2QueueError(): never {
+  throw createError({
+    statusCode: 429,
+    message:
+      'Your free Krea 2 queue is already full. No tokens were charged. Use your own generator server, use paid generation, or try again after queued work advances.',
+  })
+}

--- a/tests/contracts/verifyKrea2PublicQuota.ts
+++ b/tests/contracts/verifyKrea2PublicQuota.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const migration = readFileSync(
+  'prisma/migrations/20260902022500_add_krea2_public_quota/migration.sql',
+  'utf8',
+)
+const quota = readFileSync('server/utils/krea2Quota.ts', 'utf8')
+const gate = readFileSync('server/utils/krea2GenerationGate.ts', 'utf8')
+const enqueue = readFileSync(
+  'server/api/rainbow/generation/krea2/enqueue.post.ts',
+  'utf8',
+)
+const status = readFileSync(
+  'server/api/rainbow/generation/krea2/quota.get.ts',
+  'utf8',
+)
+const coverage = readFileSync('server/utils/artJobQueueCoverage.ts', 'utf8')
+
+// Capacity is an additive ledger, not another balance/token system.
+for (const table of [
+  'Krea2DailyUserQuota',
+  'Krea2DailyPublicPool',
+  'Krea2QuotaReservation',
+  'Krea2DeferredFreeJob',
+]) {
+  assert.match(migration, new RegExp(`CREATE TABLE \\`${table}\\``))
+}
+assert.doesNotMatch(migration, /DROP TABLE|DROP COLUMN/i)
+assert.match(migration, /`userId` INTEGER NOT NULL/)
+assert.match(migration, /`agentProfileId` INTEGER NULL/)
+assert.match(migration, /`credentialId` INTEGER NULL/)
+
+// Launch defaults protect ~500/day for internal work while exposing ~1000/day
+// to the public. All values remain environment-configurable.
+assert.match(quota, /DEFAULT_PER_HUMAN_DAILY = 10/)
+assert.match(quota, /DEFAULT_PUBLIC_DAILY_POOL = 1000/)
+assert.match(quota, /DEFAULT_INTERNAL_DAILY_RESERVE = 500/)
+assert.match(quota, /KREA2_FREE_PER_HUMAN_DAILY/)
+assert.match(quota, /KREA2_PUBLIC_DAILY_POOL/)
+assert.match(quota, /KREA2_INTERNAL_DAILY_RESERVE/)
+
+// Reservation locks the canonical human/day and global/day counters before
+// incrementing them, and creates the reservation with AgentProfile provenance
+// only as audit metadata. Extra agents never enlarge the user's allowance.
+assert.match(quota, /FOR UPDATE/)
+assert.match(quota, /usage\.userUsed >= config\.perHumanDaily/)
+assert.match(quota, /usage\.publicUsed >= config\.publicDailyPool/)
+assert.match(quota, /incrementUsage\(tx, quotaDate, audit\.userId\)/)
+assert.match(quota, /agentProfileId: auth\.agentProfileId|agentProfileId\?: number/)
+assert.match(status, /getKrea2QuotaStatus\(auth\.user\.id\)/)
+assert.match(status, /sharedAcrossAgents: true/)
+
+// Free quota is separate from mana. Once the human's 10/day is actually used,
+// existing Kind Economy charging may proceed only when it resolves to TOKENS.
+assert.match(gate, /quota\.userRemaining <= 0/)
+assert.match(gate, /paid\.fundedBy !== 'TOKENS'/)
+assert.match(gate, /free mana is not used as an overflow pool/i)
+assert.match(gate, /Math\.max\(Number\(data\.priority \?\? 100\), 200\)/)
+
+// Public-pool exhaustion queues rather than silently charging. Deferred work
+// owns no future credit and is promoted only when the relay can reserve a
+// fresh current-day user + public slot.
+assert.match(quota, /mode: 'DEFERRED_FREE'/)
+assert.match(quota, /tryPromoteDeferredKrea2Job/)
+assert.match(coverage, /tryPromoteDeferredKrea2Job\(candidate\.id\)/)
+assert.match(coverage, /krea2-free-capacity-wait/)
+assert.match(enqueue, /No tokens were charged/)
+
+// Rainbow's public endpoint is deliberately Krea2-only and cannot claim an
+// arbitrary personal server while actually consuming the shared relay.
+assert.match(enqueue, /buildKrea2WorkflowFromRequest/)
+assert.match(enqueue, /krea2GenerationGate\(event, \{ steps, width, height \}\)/)
+assert.doesNotMatch(enqueue, /serverId/)
+assert.match(enqueue, /projectSlug: 'rainbow-butterflies'/)
+
+console.log('Krea2 public quota + capacity contract OK')

--- a/tests/contracts/verifyKrea2PublicQuota.ts
+++ b/tests/contracts/verifyKrea2PublicQuota.ts
@@ -24,7 +24,7 @@ for (const table of [
   'Krea2QuotaReservation',
   'Krea2DeferredFreeJob',
 ]) {
-  assert.match(migration, new RegExp(`CREATE TABLE \\`${table}\\``))
+  assert.match(migration, new RegExp('CREATE TABLE `' + table + '`'))
 }
 assert.doesNotMatch(migration, /DROP TABLE|DROP COLUMN/i)
 assert.match(migration, /`userId` INTEGER NOT NULL/)
@@ -47,7 +47,7 @@ assert.match(quota, /FOR UPDATE/)
 assert.match(quota, /usage\.userUsed >= config\.perHumanDaily/)
 assert.match(quota, /usage\.publicUsed >= config\.publicDailyPool/)
 assert.match(quota, /incrementUsage\(tx, quotaDate, audit\.userId\)/)
-assert.match(quota, /agentProfileId: auth\.agentProfileId|agentProfileId\?: number/)
+assert.match(quota, /agentProfileId\?: number/)
 assert.match(status, /getKrea2QuotaStatus\(auth\.user\.id\)/)
 assert.match(status, /sharedAcrossAgents: true/)
 
@@ -57,6 +57,8 @@ assert.match(gate, /quota\.userRemaining <= 0/)
 assert.match(gate, /paid\.fundedBy !== 'TOKENS'/)
 assert.match(gate, /free mana is not used as an overflow pool/i)
 assert.match(gate, /Math\.max\(Number\(data\.priority \?\? 100\), 200\)/)
+assert.match(gate, /agentProfileId: auth\.agentProfileId/)
+assert.match(gate, /credentialId: auth\.credentialId/)
 
 // Public-pool exhaustion queues rather than silently charging. Deferred work
 // owns no future credit and is promoted only when the relay can reserve a


### PR DESCRIPTION
Implements the Rainbow v2 Krea2 public-capacity policy as a dedicated compute allowance rather than folding it into mana.

## Human-level free allowance
- defaults to 10 Krea2 generations per UTC day per canonical human User
- AgentProfiles and credentials share that same human quota; agentProfileId/credentialId are audit provenance only
- quota status explicitly reports sharedAcrossAgents=true

## Public capacity + internal reserve
- defaults to 1,000 public-free Krea2 slots/day
- documents/configures a 500/day internal reserve separately from the public pool
- limits are environment-configurable
- own/community compute remains on the existing zero-token server path rather than consuming this public allowance

## Queue behavior
- human + global counters are locked and incremented atomically with the ArtJob reservation
- if the human still has free allowance but the public pool is full, the request becomes a durable deferred-free ArtJob and no tokens are charged
- deferred jobs own no future credits; claim-time reconciliation promotes one only when a fresh current-day human + public slot is available
- bounded per-human deferred queue prevents unlimited future-demand stockpiling

## Paid overflow
- once the human's 10/day allowance is actually used, additional Krea2 work requires Kind Economy TOKENS
- legacy free mana is explicitly rejected as the overflow source
- paid Krea2 jobs receive higher queue priority

## Rainbow API
- adds quota status endpoint
- adds a Krea2-only public enqueue endpoint with a narrow request allowlist and distilled Krea2 limits
- the public endpoint cannot submit an arbitrary serverId to fake own-server billing

Migration is additive only. Includes a dedicated Krea2 Public Quota contract.