### PR TITLE
Apply human Krea2 quota to agent forum art

### DIFF
--- a/server/api/v1/forum/posts/[id]/generate-art.post.ts
+++ b/server/api/v1/forum/posts/[id]/generate-art.post.ts
@@ -2,7 +2,7 @@ import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { authHasScope } from '@/server/utils/authGuard'
-import { authAndGate } from '@/server/utils/comfyGate'
+import { krea2GenerationGate } from '@/server/utils/krea2GenerationGate'
 import {
   assertMatureForumWriteAllowed,
   forumPostSelect,
@@ -83,11 +83,12 @@ export default defineEventHandler(async (event) => {
       'prompt',
       MAX_PROMPT_LENGTH,
     )
-    const promptString =
-      promptOverride || sourcePrompt(post.title, post.content)
+    const promptString = promptOverride || sourcePrompt(post.title, post.content)
 
-    const gate = await authAndGate(event, {
-      engine: 'comfy',
+    // Forum Krea2 generation draws from the same canonical-human allowance as
+    // Rainbow's ordinary Generate page. AgentProfile credentials remain useful
+    // provenance, but connecting extra agents can never multiply the 10/day pool.
+    const gate = await krea2GenerationGate(event, {
       steps: DEFAULT_STEPS,
       width: DEFAULT_WIDTH,
       height: DEFAULT_HEIGHT,
@@ -150,34 +151,53 @@ export default defineEventHandler(async (event) => {
       forumContext,
     }
 
-    const job = await prisma.artJob.create({
-      data: {
+    const outcome = await gate.enqueueArtJob(
+      {
         engine: 'COMFY',
         payload: JSON.stringify(payload),
         priority: 100,
         projectSlug: 'rainbow-butterflies',
         userId: actor.userId,
       },
-    })
-
-    const { balance } = await gate.commit(`forum-art-enqueue:${job.id}`)
+      'forum-art-enqueue',
+    )
+    const job = outcome.job
 
     event.node.res.statusCode = 201
+    const capacityMessage =
+      outcome.quotaMode === 'DEFERRED_FREE'
+        ? ' Free public capacity is currently full, so this request will wait without charging tokens.'
+        : outcome.quotaMode === 'PAID_TOKENS'
+          ? ' The human liaison’s daily free Krea2 allowance is used, so this request uses paid tokens.'
+          : ''
+
     return {
       success: true,
       message:
-        mode === 'contribute'
-          ? 'Forum contribution queued. The finished ArtImage will be added as a new contribution in the source thread so the original object and provenance remain intact. Generation resource spending is not a charitable donation.'
-          : 'Forum illustration queued. The finished ArtImage will attach to your source contribution. Generation resource spending is not a charitable donation.',
+        (mode === 'contribute'
+          ? 'Forum contribution queued. The finished ArtImage will be added as a new contribution in the source thread so the original object and provenance remain intact.'
+          : 'Forum illustration queued. The finished ArtImage will attach to your source contribution.') +
+        capacityMessage +
+        ' Generation resource spending is not a charitable donation.',
       data: {
         jobId: job.id,
         status: job.status,
         postId: post.id,
         threadId: post.originId ?? post.id,
         mode,
+        // Compatibility for existing clients. `charged` may be TOKENS on the
+        // paid-overflow path, just as manaGate historically could fund art from
+        // tokens; the explicit generation block below is the canonical v2 view.
         mana: {
-          balance,
-          charged: gate.cost,
+          balance: outcome.balance,
+          charged: outcome.charged,
+        },
+        generation: {
+          engine: 'krea2',
+          quotaMode: outcome.quotaMode,
+          quota: outcome.quota,
+          tokensCharged: outcome.charged,
+          sharedAcrossAgents: true,
         },
       },
       statusCode: 201,

--- a/utils/scripts/verifyForumGeneration.test.ts
+++ b/utils/scripts/verifyForumGeneration.test.ts
@@ -162,9 +162,10 @@ type ChatCreateInput = {
   assert.equal(result?.reason, 'job-user-mismatch')
 }
 
-const [comfyGate, generationMana, actionRoute, completionRoute, handoff] =
+const [comfyGate, krea2Gate, generationMana, actionRoute, completionRoute, handoff] =
   await Promise.all([
     readFile('server/utils/comfyGate.ts', 'utf8'),
+    readFile('server/utils/krea2GenerationGate.ts', 'utf8'),
     readFile('server/utils/generationMana.ts', 'utf8'),
     readFile('server/api/v1/forum/posts/[id]/generate-art.post.ts', 'utf8'),
     readFile('server/api/art/queue/[id]/complete.post.ts', 'utf8'),
@@ -172,13 +173,21 @@ const [comfyGate, generationMana, actionRoute, completionRoute, handoff] =
   ])
 
 assert.match(comfyGate, /requireScopedApiUser\(event, 'generation:art'\)/)
+assert.match(krea2Gate, /requireScopedApiUser\(event, 'generation:art'\)/)
+assert.match(krea2Gate, /shared|perHumanDaily|enqueueKrea2PublicFreeJob/)
 assert.match(generationMana, /requireScopedApiUser\(event, 'generation:art'\)/)
 assert.match(actionRoute, /authHasScope\(actor\.auth, 'generation:art'\)/)
+assert.match(actionRoute, /krea2GenerationGate\(event/)
+assert.doesNotMatch(actionRoute, /authAndGate\(event/)
 assert.match(actionRoute, /mode: 'attach' \| 'contribute'/)
 assert.match(actionRoute, /hasCanonicalObject/)
 assert.match(actionRoute, /const sourceBotId = post\.botId \?\? actor\.botId/)
 assert.match(actionRoute, /botId: mode === 'attach' \? sourceBotId : actor\.botId/)
-assert.match(actionRoute, /forum-art-enqueue:/)
+assert.match(actionRoute, /'forum-art-enqueue'/)
+assert.match(actionRoute, /quotaMode/)
+assert.match(actionRoute, /sharedAcrossAgents: true/)
+assert.match(actionRoute, /tokensCharged/)
+assert.match(actionRoute, /Free public capacity is currently full/)
 assert.match(completionRoute, /attachCompletedForumArt/)
 
 const handoffProse = handoff.replace(/\s+/g, ' ')


### PR DESCRIPTION
Closes the remaining Rainbow v2 generation-quota bypass: forum-triggered Krea2 art now uses the same per-human daily allowance as ordinary Rainbow generation.

## Shared human quota
- replaces the forum route's generic `authAndGate(engine: comfy)` call with `krea2GenerationGate`
- AgentProfile art still requires explicit `generation:art`
- gate identity must match the forum actor's canonical human userId
- multiple agents for one human therefore share the same 10/day allowance

## Capacity behavior
- public pool full => the forum ArtJob is deferred free, no hidden token charge
- human daily allowance used => paid TOKENS overflow, consistent with the Rainbow Generate page
- response exposes `generation.quotaMode`, quota status, tokensCharged, and `sharedAcrossAgents=true`
- preserves the historical `mana` response block for client compatibility

## Provenance preserved
- attach vs contribute behavior is unchanged
- AgentProfile provenance continues through ForumArtGenerationContext and async ArtJob completion
- generation spending remains explicitly distinct from charitable donations

Updates the existing Forum Generation contract to require the Krea2 human-quota gate and reject regression to the generic art gate.