### PR TITLE
Size shelf tiles and the facet grid to their containers, not to fixed widths

### DIFF
--- a/components/home/home-dream-hero.vue
+++ b/components/home/home-dream-hero.vue
@@ -322,12 +322,30 @@
         with image and title in the space the other cards have image, title, and
         description."
 
-        Same width as a cast card (w-44) so the row keeps its rhythm, and each
-        cell is still a link that opens the interstitial. A facet is a one-word
-        tag on the dream rather than a character in it, which is why it gets a
-        quarter of a card while a character gets a whole one.
+        SIZED FROM THE ROW HEIGHT, NOT FROM A CARD WIDTH. It first took one cast
+        card's slot (w-44), which sounded right -- four quarter-cards in the
+        space of one -- and measured terribly: at 1920 each cell came out 86 wide
+        by 208 tall, so a square facet illustration was cropped to a vertical
+        sliver of itself. Silas, 2026-09-02: "weird whitespace formatting
+        preventing the facets from full size."
+
+        `aspect-[9/10]` derives the block's width from the band height instead,
+        which is the one number that actually decides how tall a cell is. At a
+        420px band that is a 378px block: two ~187px columns, each cell ~208 tall
+        with a ~16px caption, so the picture above it is ~187x188 -- square, and
+        the whole facet is visible. It rescales with the band rather than being
+        correct at one viewport, which is the mistake `w-44` made.
+
+        The row scrolls to reach it, and that is fine: Silas, 2026-09-01, "it's
+        reasonable that there will be a need to scroll on smaller displays, but
+        if so, we need an actual scroll selector" -- the chevrons are that.
+        Cramming four facets into a card's width to avoid one chevron press is
+        what produced the slivers.
       -->
-        <div v-if="facets.length" class="flex h-full w-44 shrink-0 flex-col">
+        <div
+          v-if="facets.length"
+          class="flex h-full shrink-0 flex-col lg:aspect-[9/10]"
+        >
           <div class="grid min-h-0 flex-1 grid-cols-2 grid-rows-2 gap-1">
             <a
               v-for="facet in facets.slice(0, 4)"
@@ -486,15 +504,45 @@ function measureCast(): void {
   castAtEnd.value = element.scrollLeft >= max - 2
 }
 
-/** One press moves about a screenful, keeping a card of context. */
+/**
+ * One press lands on whole slots, never mid-card.
+ *
+ * A percentage-of-width scroll is fine on a rail of uniform tiles and wrong
+ * here: this row is five 176px cards followed by a ~378px facet block, so any
+ * fixed distance stops partway through something. Scrolling forward instead
+ * aligns the first slot that is currently overflowing to the right edge, which
+ * means one press from the start brings the facets fully into view -- the point
+ * of widening them at all.
+ */
 function scrollCast(direction: 1 | -1): void {
   const element = castTrack.value
   if (!element) return
 
-  element.scrollBy({
-    left: direction * Math.max(element.clientWidth * 0.8, 176),
-    behavior: 'smooth',
-  })
+  const slots = Array.from(element.children)
+  const left = element.scrollLeft
+  const right = left + element.clientWidth
+  const offset = (slot: Element) =>
+    (slot as HTMLElement).offsetLeft - element.offsetLeft
+
+  if (direction === 1) {
+    const next = slots.find(
+      (slot) => offset(slot) + slot.clientWidth > right + 1,
+    )
+    if (!next) return
+    // Align its right edge, so the slot arrives whole rather than just started.
+    element.scrollTo({
+      left: Math.min(
+        offset(next) + next.clientWidth - element.clientWidth,
+        element.scrollWidth - element.clientWidth,
+      ),
+      behavior: 'smooth',
+    })
+    return
+  }
+
+  const previous = [...slots].reverse().find((slot) => offset(slot) < left - 1)
+  if (!previous) return
+  element.scrollTo({ left: Math.max(offset(previous), 0), behavior: 'smooth' })
 }
 
 let castObserver: ResizeObserver | null = null

--- a/components/home/home-rail.vue
+++ b/components/home/home-rail.vue
@@ -191,6 +191,7 @@
         :data-theme="themeFor(item)"
         class="group flex h-full shrink-0 flex-col overflow-hidden rounded-xl border-2 border-primary/70 bg-base-100 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:duration-300 motion-safe:hover:-translate-y-0.5"
         :class="cardWidthClass"
+        :style="tileStyle"
         :title="item.subtitle ? `${item.title} — ${item.subtitle}` : item.title"
         @click="onTileClick($event, item)"
       >
@@ -331,9 +332,57 @@ const atEnd = ref(false)
  * ~90px short of the cell the six object shelves define beside it, leaving a
  * dead corner. w-48 fills it, and bigger plates suit the art queue anyway.
  */
+/*
+ * WHOLE TILES ONLY. Silas, 2026-09-02: "the other new objects should be properly
+ * sized to fit their container space, no allow those partial cutoffs."
+ *
+ * A fixed tile width leaves whatever the track's width happens not to divide by.
+ * Measured at 1920: a 465px shelf fitted three 128px tiles and left 65px, which
+ * rendered as a 57px sliver of a fourth card at every shelf edge, on all six
+ * shelves at once.
+ *
+ * The sliver used to be deliberate -- it was the only thing telling you the row
+ * continued. That argument expired when the chevrons landed (2026-09-01, at
+ * Silas's "we need an actual scroll selector"): the affordance now has its own
+ * control, so the sliver is just a broken-looking edge.
+ *
+ * IDEAL_TILE is a target, not a size. The track is divided into however many
+ * whole tiles land nearest it, so a shelf always ends on a tile boundary at any
+ * width. `Math.round` rather than `floor`: flooring would rather grow tiles 40%
+ * than fit one more, which reads worse than a slightly narrow tile.
+ */
+const GAP = 8 // gap-2
+const IDEAL_TILE = { wide: 192, portrait: 128 } as const
+
+const measuredTileWidth = ref(0)
+
 const cardWidthClass = computed(() =>
   props.shape === 'wide' || props.shape === 'hero' ? 'w-48' : 'w-32',
 )
+
+/*
+ * The class above stays as the pre-measurement value, so server-rendered markup
+ * and the first paint are already the right ballpark rather than zero-width;
+ * the inline width takes over on mount and on every resize.
+ */
+const tileStyle = computed(() =>
+  measuredTileWidth.value
+    ? { width: `${measuredTileWidth.value}px` }
+    : undefined,
+)
+
+/** How many whole tiles the track is currently divided into. */
+function fitTiles(available: number): { columns: number; width: number } {
+  const ideal =
+    props.shape === 'wide' || props.shape === 'hero'
+      ? IDEAL_TILE.wide
+      : IDEAL_TILE.portrait
+  const columns = Math.max(1, Math.round((available + GAP) / (ideal + GAP)))
+  return {
+    columns,
+    width: Math.floor((available - (columns - 1) * GAP) / columns),
+  }
+}
 
 /**
  * What a plain left click on a tile does: open the interstitial on an
@@ -414,19 +463,30 @@ function measure(): void {
   const element = track.value
   if (!element) return
 
+  // Sized before the overflow is read, because the width IS what decides
+  // whether the track overflows at all.
+  measuredTileWidth.value = fitTiles(element.clientWidth).width
+
   const max = element.scrollWidth - element.clientWidth
   canScroll.value = max > 2
   atStart.value = element.scrollLeft <= 2
   atEnd.value = element.scrollLeft >= max - 2
 }
 
-/** One press moves about a screenful of shelf, keeping a tile of context. */
+/**
+ * One press moves a whole page of whole tiles.
+ *
+ * Deliberately the full page rather than the 80% it used to scroll: 80% of a
+ * track that holds exactly N tiles lands mid-tile, which would put back the
+ * clipped edge this all exists to remove.
+ */
 function scrollBy(direction: 1 | -1): void {
   const element = track.value
   if (!element) return
 
+  const { columns, width } = fitTiles(element.clientWidth)
   element.scrollBy({
-    left: direction * Math.max(element.clientWidth * 0.8, 160),
+    left: direction * columns * (width + GAP),
     behavior: 'smooth',
   })
 }


### PR DESCRIPTION
Two fixed widths that were only ever right at one viewport.

## The facets

> "weird whitespace formatting preventing the facets from full size"

The 2×2 took one cast card's slot, which *sounded* right — four quarter-cards in the space of one — and measured terribly. At 1920 each cell came out **86 wide × 208 tall**, so a square facet illustration was cropped to a vertical sliver of itself.

The block now derives its width from the band height (`aspect-[9/10]`), since the band height is the one number that actually decides how tall a cell is:

| | before | after |
|---|---|---|
| block | 176 × 420 | **378 × 420** |
| cell | 86 × 208 | **187 × 208** |
| picture | 86 × 188 (sliver) | **187 × 188 (square)** |

And it rescales with the band instead of being correct at one width — 304px at 1366, 322px at 1024, 219px at 900, with cells staying near-square throughout. That's the mistake `w-44` made.

## The shelves

> "the other new objects should be properly sized to fit their container space, no allow those partial cutoffs"

A fixed tile width leaves whatever the track doesn't divide by. At 1920 a 465px shelf fitted three 128px tiles and left **65px**, rendering a 57px sliver of a fourth card — on all six shelves at once.

Tiles are now measured: the track is divided into however many whole tiles land nearest the ideal, so a shelf always ends on a tile boundary.

```
                          before                    after
New dreams          tile=128 leftover=65 [57]   tile=149 leftover=2 []
New characters      tile=128 leftover=65 [57]   tile=149 leftover=2 []
New scenarios       tile=128 leftover=65 [57]   tile=149 leftover=2 []
New items and skills tile=128 leftover=65 [57]  tile=149 leftover=2 []
New facets          tile=128 leftover=65 [57]   tile=149 leftover=2 []
Fresh from the art queue tile=192 leftover=73 [65]  tile=228 leftover=1 []
```

Zero slivers on every real shelf at **1920, 1366, 1280, 1024 and 900**.

The sliver used to be deliberate — it was the only thing telling you the row continued. That argument expired when the chevrons landed at your request on 2026-09-01; it's now just a broken-looking edge.

## Both chevrons follow

- A rail pages by a **whole column count** instead of 80% of the track. 80% of a track holding exactly N tiles lands mid-tile, which would put the clipped edge straight back.
- The cast row can't use a fixed distance at all now that its slots are uneven (five 176px cards, then a 378px facet block), so it **aligns the first overflowing slot to the right edge**. One forward press brings the facets fully into view — the point of widening them.

Verified by clicking it: `{"scrollLeft": 355, "facetsFullyVisible": true, "facetW": 378}`.

## A note on method

The first measurement pass used the synthetic mock and reported `imgW: null` on the facet cells, which looked like the plate failing to render. That was a harness artifact — placeholder images that never loaded. I re-ran against the **real production `/api/showcase/home` payload with real art** before concluding anything, which is where the 86×208 crop actually showed up.

## Verification

`prettier` · `eslint` · `npm run test` (`vue-tsc`, exit 0) · layout contract · MDC scroll ownership · zero horizontal overflow at 1920 / 1366 / 900

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aNg3fsHLGUGCwiMp25hkA

---
_Generated by [Claude Code](https://claude.ai/code/session_017aNg3fsHLGUGCwiMp25hkA)_