### PR TITLE
Refactor sample manager status surface to kr-panel-flat

### DIFF
--- a/sample/sample-manager.vue.txt
+++ b/sample/sample-manager.vue.txt
@@ -6,7 +6,7 @@
   <section class="flex h-full min-h-0 w-full flex-col overflow-hidden">
     <div
       v-if="isLoadingManager || managerError"
-      class="mb-3 flex shrink-0 flex-wrap items-center justify-between gap-2 rounded-2xl border border-base-300 bg-base-100 p-3 text-sm shadow"
+      class="mb-3 flex shrink-0 flex-wrap items-center justify-between gap-2 kr-panel-flat p-3 text-sm shadow"
     >
       <p
         class="min-w-0 flex-1 text-base-content/70"


### PR DESCRIPTION
## Summary
- continue interface-vision t-104's bounded consistency sweep
- replace the canonical sample manager loading/error surface's hand-rolled `rounded-2xl border border-base-300 bg-base-100` quartet with `kr-panel-flat`
- preserve its existing `p-3`, `text-sm`, `shadow`, flex layout, and behavior

Conductor session: `openai-scheduled-20260902T051155Z-interface-vision-t104-k3p7`

No production data or outward-facing action involved.