### PR TITLE
fix: stop a >1MB art-prompts.yaml from being read as empty and overwritten

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Art-request YAML indentation contract
         run: npm run test:art-request-yaml
 
+      - name: GitHub file-read contract
+        run: npm run test:github-file-contents
+
       - name: Art prompt contract
         run: npm run test:art-prompt-contract
 

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "seed:resource-commercial-safe": "tsx scripts/seed_resource_commercial_safe.ts",
     "generate:achievement-art": "tsx scripts/generate_achievement_art.ts",
     "test:art-request-yaml": "tsx utils/scripts/verifyArtRequestYaml.ts && tsx utils/scripts/verifyArtAssetSuggest.ts",
+    "test:github-file-contents": "tsx utils/scripts/verifyGithubFileContents.ts",
     "test:art-prompt-repair": "tsx utils/scripts/verifyArtPromptRepair.ts",
     "test:art-prompt-contract": "tsx utils/scripts/verifyArtPromptContract.ts",
     "test:artjob-sampler-repair": "tsx utils/scripts/verifyArtJobSamplerRepair.ts",

--- a/server/api/conductor/art-request.post.ts
+++ b/server/api/conductor/art-request.post.ts
@@ -7,9 +7,14 @@ import { buildContextualArtPrompt } from '@/server/utils/conductorArtPrompt'
 import { errorHandler } from '@/server/utils/error'
 import {
   appendRequest,
+  requestBlockIds,
   type ArtQueueEntry,
   type ArtVariant,
 } from '@/server/utils/artRequestYaml'
+import {
+  githubPathExists,
+  readGithubFile,
+} from '@/server/utils/githubFileContents'
 import { validateApiKey } from '@/server/utils/validateKey'
 
 const GITHUB_API = 'https://api.github.com'
@@ -88,12 +93,6 @@ type MissingArtRequestBody = {
   projectId?: number
   projectSlug?: string
   projectField?: string
-}
-
-type GitHubFile = {
-  content: string
-  sha: string
-  encoding: string
 }
 
 type ImageTarget = {
@@ -272,32 +271,15 @@ function githubHeaders(token: string): HeadersInit {
   }
 }
 
-async function fetchGithubFile(
-  repo: string,
-  path: string,
-  token: string,
-  ref = DEFAULT_BRANCH,
-): Promise<GitHubFile | null> {
-  const url = `${GITHUB_API}/repos/${repo}/contents/${encodePath(path)}?ref=${encodeURIComponent(ref)}`
-  const res = await fetch(url, { headers: githubHeaders(token) })
-  if (res.status === 404) return null
-  if (!res.ok) {
-    throw new Error(`GitHub ${res.status} while fetching ${repo}/${path}`)
-  }
-  return (await res.json()) as GitHubFile
-}
-
 async function githubFileExists(
   target: ImageTarget,
   token: string,
 ): Promise<boolean> {
-  return Boolean(
-    await fetchGithubFile(
-      target.targetRepo,
-      target.imagePath,
-      token,
-      target.targetRef,
-    ),
+  return githubPathExists(
+    target.targetRepo,
+    target.imagePath,
+    token,
+    target.targetRef,
   )
 }
 
@@ -330,12 +312,6 @@ async function imageAlreadyExists(
 ): Promise<boolean> {
   if (await mediaFileExists(target)) return true
   return githubFileExists(target, token)
-}
-
-function decodeGithubContent(file: GitHubFile): string {
-  return Buffer.from(file.content.replace(/\n/g, ''), 'base64').toString(
-    'utf-8',
-  )
 }
 
 function encodeGithubContent(content: string): string {
@@ -411,7 +387,11 @@ async function updateConductorQueue(
   force: boolean,
 ) {
   const branch = getConductorBranch()
-  const file = await fetchGithubFile(
+  // readGithubFile rather than a bare Contents API read: past 1 MB that
+  // endpoint answers 200 with a usable sha and an empty `content`, and this is
+  // a read-modify-write. Decoding that empty body as the queue is what let
+  // 0e671cd commit a two-entry file over conductor's whole art queue.
+  const file = await readGithubFile(
     CONDUCTOR_REPO,
     ART_PROMPTS_PATH,
     token,
@@ -424,9 +404,22 @@ async function updateConductorQueue(
     })
   }
 
-  const current = decodeGithubContent(file)
+  const current = file.content
   const next = appendRequest(current, entry, { allowDuplicate: force })
   if (next === current) return { created: false, branch }
+
+  // Appending must never drop a request another producer already staged. This
+  // is the invariant a bad read breaks, so it is asserted against the bytes
+  // about to be committed rather than trusted from the read alone.
+  const dropped = requestBlockIds(current).filter(
+    (id) => !requestBlockIds(next).includes(id),
+  )
+  if (dropped.length) {
+    throw new Error(
+      `Refusing to update ${ART_PROMPTS_PATH}: the write would drop ` +
+        `${dropped.length} existing request(s), starting with "${dropped[0]}".`,
+    )
+  }
 
   const res = await fetch(
     `${GITHUB_API}/repos/${CONDUCTOR_REPO}/contents/${encodePath(ART_PROMPTS_PATH)}`,

--- a/server/utils/artRequestYaml.ts
+++ b/server/utils/artRequestYaml.ts
@@ -137,6 +137,19 @@ function requestBlocks(content: string): string[] {
     .filter((block) => block.startsWith('- id:'))
 }
 
+/**
+ * Every request id currently present in the file, in order.
+ *
+ * appendRequest only ever adds, so a caller can compare this before and after
+ * to prove a write is append-only. That check is what stands between a bad read
+ * of art-prompts.yaml and a commit that silently deletes the queue.
+ */
+export function requestBlockIds(content: string): string[] {
+  return requestBlocks(content)
+    .map((block) => requestValue(block, 'id'))
+    .filter(Boolean)
+}
+
 export function requestAlreadyQueued(
   content: string,
   entry: ArtQueueEntry,

--- a/server/utils/conductor-github.ts
+++ b/server/utils/conductor-github.ts
@@ -6,6 +6,10 @@
 // config defaults are serialized when that image is built. Read the live Node
 // environment first so a runtime-only secret is not mistaken for a missing one;
 // keep runtimeConfig as the development / NUXT_GITHUB_TOKEN fallback.
+import { readGithubFile } from './githubFileContents'
+
+const CONDUCTOR_REPO = 'silasfelinus/conductor'
+const DEFAULT_BRANCH = 'main'
 
 export interface ConductorFile {
   sha: string
@@ -20,38 +24,32 @@ function conductorGithubToken(): string {
   ).trim()
 }
 
+// Reads go through readGithubFile because the Contents API stops inlining a
+// body at 1 MB: past that it answers 200 with a real sha and an empty
+// `content`. Every caller here is a read-modify-write, so decoding that as ""
+// would commit an empty file over a roadmap the moment one outgrew the limit --
+// exactly how conductor's art-prompts.yaml lost 11,014 lines on 2026-09-02.
 export async function conductorGet(
   path: string,
 ): Promise<ConductorFile | null> {
   const githubToken = conductorGithubToken()
 
-  const headers: Record<string, string> = {
-    Accept: 'application/vnd.github.v3+json',
-  }
-
-  if (githubToken) {
-    headers.Authorization = `Bearer ${githubToken}`
-  }
-
-  const res = await fetch(
-    `https://api.github.com/repos/silasfelinus/conductor/contents/${path}`,
-    { headers },
-  )
-
-  if (res.status === 404) return null
-
-  if (!res.ok) {
+  try {
+    const file = await readGithubFile(
+      CONDUCTOR_REPO,
+      path,
+      githubToken,
+      DEFAULT_BRANCH,
+    )
+    return file ? { sha: file.sha, content: file.content } : null
+  } catch (error) {
     throw createError({
       statusCode: 502,
-      statusMessage: `GitHub read error ${res.status}`,
+      statusMessage:
+        error instanceof Error
+          ? error.message
+          : `GitHub read error for ${path}`,
     })
-  }
-
-  const data = (await res.json()) as { sha: string; content: string }
-
-  return {
-    sha: data.sha,
-    content: Buffer.from(data.content, 'base64').toString('utf-8'),
   }
 }
 

--- a/server/utils/githubFileContents.ts
+++ b/server/utils/githubFileContents.ts
@@ -1,0 +1,171 @@
+// /server/utils/githubFileContents.ts
+//
+// Safe reads of a single file through the GitHub REST API.
+//
+// The Contents API only inlines a file body up to 1 MB. From 1 MB to 100 MB it
+// still answers 200 with the real `sha` and `size`, but `content` is an empty
+// string and `encoding` is "none". Code that decodes `content` unconditionally
+// therefore sees a perfectly valid-looking empty file, and any read-modify-write
+// built on it rewrites the whole path from nothing while carrying a `sha` GitHub
+// accepts.
+//
+// That is not hypothetical. On 2026-09-02 conductor's projects/art-prompts.yaml
+// crossed 1 MB (1,424,189 bytes). The next missing-image request read it as "",
+// found no duplicate to skip, and committed a two-entry file over it
+// (conductor 0e671cd, -11,014 lines): 577 Mandarin request rows and three
+// in-flight missing-image requests gone in one silent write.
+//
+// So: fall back to the Git Blobs API, which carries base64 up to 100 MB, and
+// refuse to hand back an empty body for a file GitHub says is not empty. A read
+// that cannot be trusted must fail loudly rather than become an empty string
+// upstream of a write.
+//
+// Dependency-free on purpose (global fetch, plain Error, no Nuxt auto-imports)
+// so utils/scripts/verifyGithubFileContents.ts can exercise it under bare tsx.
+import { Buffer } from 'node:buffer'
+
+const GITHUB_API = 'https://api.github.com'
+
+export type GithubContentsPayload = {
+  content?: string | null
+  encoding?: string | null
+  sha?: string | null
+  size?: number | null
+}
+
+export type GithubFileRead = {
+  sha: string
+  content: string
+  size: number
+}
+
+export type GithubFetch = (
+  url: string,
+  init?: { headers?: Record<string, string> },
+) => Promise<{
+  ok: boolean
+  status: number
+  json: () => Promise<unknown>
+}>
+
+export function githubJsonHeaders(token: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  }
+  if (token) headers.Authorization = `Bearer ${token}`
+  return headers
+}
+
+export function decodeBase64Content(content: string): string {
+  return Buffer.from(content.replace(/\s/g, ''), 'base64').toString('utf-8')
+}
+
+/**
+ * True when the payload is one of the oversized responses whose body GitHub
+ * withholds — either an explicit non-base64 encoding, or an empty content
+ * string for a file the same response reports as non-empty.
+ */
+export function payloadNeedsBlobFallback(
+  payload: GithubContentsPayload,
+): boolean {
+  const encoding = String(payload.encoding || '').toLowerCase()
+  if (encoding && encoding !== 'base64') return true
+  const size = Number(payload.size || 0)
+  return !String(payload.content || '').trim() && size > 0
+}
+
+/**
+ * Read one file and return its decoded body, its blob sha, and the size GitHub
+ * reported. Returns null when the path does not exist on the ref.
+ *
+ * Throws when GitHub reports a non-empty file whose body could not be recovered
+ * from either endpoint — never returns "" for a file that is not empty.
+ */
+export async function readGithubFile(
+  repo: string,
+  path: string,
+  token: string,
+  ref: string,
+  fetchImpl: GithubFetch = fetch as unknown as GithubFetch,
+): Promise<GithubFileRead | null> {
+  const encodedPath = path.split('/').map(encodeURIComponent).join('/')
+  const contentsUrl = `${GITHUB_API}/repos/${repo}/contents/${encodedPath}?ref=${encodeURIComponent(ref)}`
+  const res = await fetchImpl(contentsUrl, { headers: githubJsonHeaders(token) })
+
+  if (res.status === 404) return null
+  if (!res.ok) {
+    throw new Error(`GitHub ${res.status} while fetching ${repo}/${path}`)
+  }
+
+  const payload = (await res.json()) as GithubContentsPayload
+  const sha = String(payload.sha || '')
+  const size = Number(payload.size || 0)
+
+  if (!sha) {
+    throw new Error(`GitHub returned no blob sha for ${repo}/${path}`)
+  }
+
+  let content = payloadNeedsBlobFallback(payload)
+    ? await readGithubBlob(repo, sha, token, fetchImpl)
+    : decodeBase64Content(String(payload.content || ''))
+
+  if (!content && size > 0) {
+    throw new Error(
+      `GitHub returned an empty body for ${repo}/${path} (${size} bytes, blob ${sha}). ` +
+        'Refusing to treat an unreadable file as empty.',
+    )
+  }
+
+  return { sha, content, size }
+}
+
+/**
+ * Existence probe that never downloads a body.
+ *
+ * readGithubFile has to recover an oversized body from the Blobs API, which is
+ * the right cost when the caller is about to rewrite the file and the wrong one
+ * when it only wants to know whether a path is there.
+ */
+export async function githubPathExists(
+  repo: string,
+  path: string,
+  token: string,
+  ref: string,
+  fetchImpl: GithubFetch = fetch as unknown as GithubFetch,
+): Promise<boolean> {
+  const encodedPath = path.split('/').map(encodeURIComponent).join('/')
+  const url = `${GITHUB_API}/repos/${repo}/contents/${encodedPath}?ref=${encodeURIComponent(ref)}`
+  const res = await fetchImpl(url, { headers: githubJsonHeaders(token) })
+
+  if (res.status === 404) return false
+  if (!res.ok) {
+    throw new Error(`GitHub ${res.status} while checking ${repo}/${path}`)
+  }
+  return true
+}
+
+async function readGithubBlob(
+  repo: string,
+  sha: string,
+  token: string,
+  fetchImpl: GithubFetch,
+): Promise<string> {
+  const url = `${GITHUB_API}/repos/${repo}/git/blobs/${encodeURIComponent(sha)}`
+  const res = await fetchImpl(url, { headers: githubJsonHeaders(token) })
+
+  if (!res.ok) {
+    throw new Error(`GitHub ${res.status} while fetching blob ${repo}@${sha}`)
+  }
+
+  const payload = (await res.json()) as GithubContentsPayload
+  const encoding = String(payload.encoding || '').toLowerCase()
+
+  if (encoding && encoding !== 'base64') {
+    throw new Error(
+      `GitHub blob ${repo}@${sha} came back as "${encoding}" rather than base64.`,
+    )
+  }
+
+  return decodeBase64Content(String(payload.content || ''))
+}

--- a/server/utils/githubFileContents.ts
+++ b/server/utils/githubFileContents.ts
@@ -106,7 +106,7 @@ export async function readGithubFile(
     throw new Error(`GitHub returned no blob sha for ${repo}/${path}`)
   }
 
-  let content = payloadNeedsBlobFallback(payload)
+  const content = payloadNeedsBlobFallback(payload)
     ? await readGithubBlob(repo, sha, token, fetchImpl)
     : decodeBase64Content(String(payload.content || ''))
 

--- a/utils/scripts/verifyGithubFileContents.ts
+++ b/utils/scripts/verifyGithubFileContents.ts
@@ -1,0 +1,259 @@
+// utils/scripts/verifyGithubFileContents.ts
+//
+// Regression guard for the 2026-09-02 art-queue wipe (conductor 0e671cd).
+//
+// conductor's projects/art-prompts.yaml crossed 1 MB, so the GitHub Contents
+// API stopped inlining its body: 200, real sha, `content: ""`,
+// `encoding: "none"`. art-request.post.ts decoded that as an empty file, found
+// no duplicate to skip, and PUT a two-entry file over it with the very sha
+// GitHub had just handed it. 11,014 lines went, including 577 Mandarin request
+// rows and three in-flight missing-image requests.
+//
+// These checks pin both halves of the fix: readGithubFile recovers an oversized
+// body from the Blobs API and never reports a non-empty file as empty, and
+// requestBlockIds gives the writer an append-only invariant to assert before it
+// commits.
+//
+// Dependency-free on purpose: a stub fetch, no Nuxt/Prisma runtime, so it runs
+// under bare `tsx` alongside the other art contract tests.
+//
+// Run: npm run test:github-file-contents
+
+import { Buffer } from 'node:buffer'
+import {
+  type GithubFetch,
+  githubPathExists,
+  payloadNeedsBlobFallback,
+  readGithubFile,
+} from '../../server/utils/githubFileContents'
+import { requestBlockIds } from '../../server/utils/artRequestYaml'
+
+let failures = 0
+function check(name: string, cond: boolean, detail = '') {
+  if (cond) {
+    console.log(`  PASS  ${name}`)
+  } else {
+    failures += 1
+    console.log(`  FAIL  ${name}${detail ? ` — ${detail}` : ''}`)
+  }
+}
+
+function b64(value: string): string {
+  return Buffer.from(value, 'utf-8').toString('base64')
+}
+
+function stubFetch(
+  routes: Record<string, { status?: number; body: unknown }>,
+  seen: string[] = [],
+): GithubFetch {
+  return async (url: string) => {
+    seen.push(url)
+    const key = Object.keys(routes).find((fragment) => url.includes(fragment))
+    const route = key ? routes[key]! : { status: 404, body: {} }
+    const status = route.status ?? 200
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => route.body,
+    }
+  }
+}
+
+async function expectThrow(fn: () => Promise<unknown>): Promise<string | null> {
+  try {
+    await fn()
+    return null
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error)
+  }
+}
+
+const QUEUE = 'requests:\n- id: "keep-me-0001"\n  status: "pending"\n'
+
+// --- small file: plain Contents API decode ---------------------------------
+console.log('readGithubFile on a file GitHub inlines')
+{
+  const seen: string[] = []
+  const fetchImpl = stubFetch(
+    {
+      '/contents/': {
+        body: {
+          sha: 'sha-small',
+          size: QUEUE.length,
+          encoding: 'base64',
+          content: b64(QUEUE),
+        },
+      },
+    },
+    seen,
+  )
+  const file = await readGithubFile('o/r', 'a/b.yaml', 't', 'main', fetchImpl)
+
+  check('returns the decoded body', file?.content === QUEUE)
+  check('returns the blob sha', file?.sha === 'sha-small')
+  check(
+    'does not reach for the Blobs API',
+    !seen.some((url) => url.includes('/git/blobs/')),
+  )
+}
+
+// --- oversized file: Blobs API fallback ------------------------------------
+console.log('')
+console.log('readGithubFile on a file over the 1 MB inline limit')
+{
+  const big = `${QUEUE}${'# padding\n'.repeat(4000)}`
+  const seen: string[] = []
+  const fetchImpl = stubFetch(
+    {
+      '/contents/': {
+        body: { sha: 'sha-big', size: big.length, encoding: 'none', content: '' },
+      },
+      '/git/blobs/': {
+        body: { sha: 'sha-big', encoding: 'base64', content: b64(big) },
+      },
+    },
+    seen,
+  )
+  const file = await readGithubFile('o/r', 'a/b.yaml', 't', 'main', fetchImpl)
+
+  check('recovers the withheld body from the Blobs API', file?.content === big)
+  check('keeps the sha the Contents API reported', file?.sha === 'sha-big')
+  check(
+    'asks the Blobs API for exactly that sha',
+    seen.some((url) => url.endsWith('/git/blobs/sha-big')),
+  )
+  check(
+    'the recovered body still holds the existing requests',
+    requestBlockIds(file?.content ?? '').includes('keep-me-0001'),
+  )
+}
+
+// --- the shape that caused the wipe ----------------------------------------
+console.log('')
+console.log('an unrecoverable body fails loudly instead of reading as empty')
+{
+  const fetchImpl = stubFetch({
+    '/contents/': {
+      body: { sha: 'sha-big', size: 1424189, encoding: 'none', content: '' },
+    },
+    '/git/blobs/': {
+      body: { sha: 'sha-big', encoding: 'base64', content: '' },
+    },
+  })
+  const message = await expectThrow(() =>
+    readGithubFile('o/r', 'a/b.yaml', 't', 'main', fetchImpl),
+  )
+
+  check('throws rather than returning ""', message !== null)
+  check(
+    'says the file was unreadable, not empty',
+    (message ?? '').includes('Refusing to treat an unreadable file as empty'),
+  )
+}
+
+// --- a genuinely empty file is still readable ------------------------------
+console.log('')
+console.log('a genuinely empty file reads as empty')
+{
+  const fetchImpl = stubFetch({
+    '/contents/': {
+      body: { sha: 'sha-empty', size: 0, encoding: 'base64', content: '' },
+    },
+  })
+  const file = await readGithubFile('o/r', 'a/b.yaml', 't', 'main', fetchImpl)
+
+  check('returns an empty body without throwing', file?.content === '')
+  check('reports size 0', file?.size === 0)
+}
+
+// --- 404 still means "no such file" ----------------------------------------
+console.log('')
+console.log('a missing path returns null')
+{
+  const fetchImpl = stubFetch({ '/contents/': { status: 404, body: {} } })
+  const file = await readGithubFile('o/r', 'gone.yaml', 't', 'main', fetchImpl)
+  check('returns null for 404', file === null)
+}
+
+// --- payloadNeedsBlobFallback ----------------------------------------------
+console.log('')
+console.log('payloadNeedsBlobFallback')
+{
+  check(
+    'inlined base64 needs no fallback',
+    !payloadNeedsBlobFallback({
+      encoding: 'base64',
+      content: b64('x'),
+      size: 1,
+    }),
+  )
+  check(
+    'encoding "none" needs the fallback',
+    payloadNeedsBlobFallback({ encoding: 'none', content: '', size: 1424189 }),
+  )
+  check(
+    'empty content for a non-empty file needs the fallback',
+    payloadNeedsBlobFallback({ encoding: '', content: '', size: 1424189 }),
+  )
+  check(
+    'an empty file needs no fallback',
+    !payloadNeedsBlobFallback({ encoding: 'base64', content: '', size: 0 }),
+  )
+}
+
+// --- existence probes stay cheap -------------------------------------------
+console.log('')
+console.log('githubPathExists does not download a body')
+{
+  const seen: string[] = []
+  const fetchImpl = stubFetch(
+    {
+      '/contents/': {
+        body: { sha: 'sha-huge', size: 9_000_000, encoding: 'none', content: '' },
+      },
+    },
+    seen,
+  )
+  const exists = await githubPathExists('o/r', 'big.webp', 't', 'main', fetchImpl)
+
+  check('reports an oversized file as present', exists === true)
+  check(
+    'never reaches the Blobs API for a mere existence check',
+    !seen.some((url) => url.includes('/git/blobs/')),
+  )
+
+  const missing = await githubPathExists(
+    'o/r',
+    'gone.webp',
+    't',
+    'main',
+    stubFetch({ '/contents/': { status: 404, body: {} } }),
+  )
+  check('reports a 404 as absent', missing === false)
+}
+
+// --- the append-only invariant the writer asserts --------------------------
+console.log('')
+console.log('requestBlockIds gives the writer an append-only invariant')
+{
+  const before = requestBlockIds(QUEUE)
+  const appended = `${QUEUE}- id: "new-0002"\n  status: "pending"\n`
+  const truncated = 'requests:\n- id: "new-0002"\n  status: "pending"\n'
+
+  check('lists the ids present', before.join(',') === 'keep-me-0001')
+  check(
+    'an append keeps every prior id',
+    before.every((id) => requestBlockIds(appended).includes(id)),
+  )
+  check(
+    'the wipe shape drops a prior id',
+    before.some((id) => !requestBlockIds(truncated).includes(id)),
+  )
+}
+
+console.log('')
+if (failures > 0) {
+  console.error(`GitHub file-read contract: ${failures} check(s) FAILED`)
+  process.exit(1)
+}
+console.log('GitHub file-read contract: all checks passed')


### PR DESCRIPTION
## What happened

The GitHub Contents API only inlines a file body up to 1 MB. Past that it still answers `200` with the real `sha` and `size`, but `content` is `""` and `encoding` is `"none"`. Both of this repo's read-modify-write paths into conductor decoded that blindly.

On 2026-09-02 conductor's `projects/art-prompts.yaml` crossed the limit (1,424,189 bytes) when the Mandarin v2 corpus was re-staged. The next missing-image request read it as an *empty* file, so `appendRequest` found no duplicate to skip, and the handler committed a two-entry file over it with the sha GitHub had just handed back — [conductor 0e671cd](https://github.com/silasfelinus/conductor/commit/0e671cd80524d1616a5bd0034507acc46279a69a), **-11,014 lines**.

Lost in that one write: 577 Mandarin request rows and three in-flight missing-image requests (`mandarin-tutor-hero`, `rainbow-butterflies-hero`, `rainbow-butterflies-card`). The wiped `rainbow-butterflies-icon` request was then re-enqueued as a fourth duplicate ArtJob for a target that already had three pending.

The proof it was an empty read, not a stale one: the PUT carried a sha GitHub accepted (so the read was current), and `appendRequest` cannot delete content in any of its branches — the only input that yields a two-entry file is `current === ""`.

## Changes

- **New `server/utils/githubFileContents.ts`.** `readGithubFile` falls back to the Git Blobs API (base64, up to 100 MB) when the Contents API withholds a body, and **throws rather than returning `""`** for a file GitHub reports as non-empty. `githubPathExists` keeps existence probes body-free so a missing-image check never pulls a multi-MB blob.
- **`art-request.post.ts`** reads the queue through it, and probes for an existing image with `githubPathExists`.
- **`conductor-github.ts`'s `conductorGet`** reads through it too. It backs `task-action`, `overrides`, `pitch-vote`, `project-state`, `inbox` and the coloring-book writers — all read-modify-write against files that can grow past 1 MB (conductor's `TALKBACK.md` is already 2.9 MB; `LEARNING.yaml` is 630 KB and climbing).
- **Append-only invariant** asserted before committing `art-prompts.yaml`: a write that would drop an existing request id now fails loudly instead of silently deleting another producer's queued work. Backed by a new exported `requestBlockIds` in `artRequestYaml.ts`.

## Testing

New `utils/scripts/verifyGithubFileContents.ts`, wired into `contract-tests.yml` as `npm run test:github-file-contents`. Dependency-free (stub fetch, bare `tsx`), matching the existing art-contract test style. Covers:

- a small file decoded straight from the Contents API, with no Blobs call
- an oversized file recovered from the Blobs API, keeping the Contents sha
- the exact wipe shape (`encoding: "none"`, unrecoverable blob) throwing instead of returning `""`
- a genuinely empty file still reading as empty
- `404` still returning `null`
- `githubPathExists` reporting a 9 MB file present without touching the Blobs API
- `requestBlockIds` catching the truncating write

All checks pass locally, `test:art-request-yaml` still passes unchanged, and the new module typechecks clean under `--strict`.

## Related cleanup (outside this PR)

The 1,913 redundant `PENDING` ArtJobs this and the Mandarin re-staging bug produced have been cancelled — the queue is back to 4 pending, one per genuinely-missing conductor project image. All 577 Mandarin v2 card paths were HEAD-verified live on media first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G64z5RJoQmrvytG7poGFQf

---
_Generated by [Claude Code](https://claude.ai/code/session_01G64z5RJoQmrvytG7poGFQf)_