### PR TITLE
Fresher news, and a one-click art redo from the object sheet

### DIFF
--- a/components/home/home-object-sheet.vue
+++ b/components/home/home-object-sheet.vue
@@ -172,18 +172,103 @@
           exactly that, and both links would have 404'd from the front page.
           Reviews moved inline above instead.
         -->
+        <!--
+          REDO THE ART FROM HERE. Silas, 2026-09-02: "when clicking on an
+          object, I would love a way to expedite asking for a new art prompt.
+          For example, we get a lot of text focused gens, so I want to be able
+          to easily submit them for a better redo."
+
+          The redo already existed -- entity-art-manager.vue has done exactly
+          this for a while -- but only on each record's own manager page, which
+          is two navigations away from noticing the problem. Noticing happens
+          here, so the button is here.
+
+          EXPEDITE MEANS PREFILLED, not just present. The complaint is specific:
+          the renders come back as pictures OF CARDS, with garbled lettering
+          baked in (the "Hacker" facet is a card with four lines of nonsense
+          text on it). So the default prompt is composed from the record's own
+          title and description with an explicit no-lettering clause on the end,
+          which is the edit you would have made by hand every time. It stays
+          editable -- it is a starting point, not a fixed template.
+        -->
+        <section
+          v-if="showRedo && redoOpen"
+          class="border-t border-base-300 bg-base-200/40 p-3"
+        >
+          <label
+            :for="`redo-prompt-${card.kind}-${card.id}`"
+            class="text-[0.65rem] font-black uppercase tracking-[0.14em] text-primary"
+          >
+            New art prompt
+          </label>
+          <textarea
+            :id="`redo-prompt-${card.kind}-${card.id}`"
+            v-model="redoPrompt"
+            rows="4"
+            class="mt-1 w-full rounded-lg border border-base-300 bg-base-100 p-2 text-xs leading-snug focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+            :disabled="redoBusy"
+          />
+
+          <div class="mt-2 flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              class="btn btn-primary btn-xs gap-1.5 rounded-lg"
+              :disabled="redoBusy || !redoPrompt.trim()"
+              @click="submitRedo"
+            >
+              <span
+                v-if="redoBusy"
+                class="loading loading-spinner loading-xs"
+              />
+              <Icon v-else name="kind-icon:refresh" class="size-3.5" />
+              Queue new art
+            </button>
+
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs rounded-lg border border-base-300"
+              :disabled="redoBusy"
+              title="Rebuild the suggested prompt from this record"
+              @click="redoPrompt = suggestedPrompt"
+            >
+              Reset prompt
+            </button>
+
+            <p
+              v-if="redoMessage"
+              class="text-[0.65rem] font-bold"
+              :class="redoFailed ? 'text-error' : 'text-success'"
+            >
+              {{ redoMessage }}
+            </p>
+          </div>
+        </section>
+
         <footer class="kr-toolbar justify-between border-t border-base-300 p-3">
           <p class="text-[0.65rem] text-base-content/45">
             {{ createdLabel }}
           </p>
 
-          <NuxtLink
-            :to="detail?.href || showcaseHref(card)"
-            class="btn btn-primary btn-sm gap-1.5 rounded-xl"
-          >
-            Open {{ kindLabel.toLowerCase() }}
-            <Icon name="kind-icon:chevron-right" class="size-4" />
-          </NuxtLink>
+          <div class="flex items-center gap-2">
+            <button
+              v-if="showRedo"
+              type="button"
+              class="btn btn-ghost btn-sm gap-1.5 rounded-xl border border-base-300"
+              :aria-expanded="redoOpen"
+              @click="toggleRedo"
+            >
+              <Icon name="kind-icon:palette-color" class="size-4" />
+              Redo art
+            </button>
+
+            <NuxtLink
+              :to="detail?.href || showcaseHref(card)"
+              class="btn btn-primary btn-sm gap-1.5 rounded-xl"
+            >
+              Open {{ kindLabel.toLowerCase() }}
+              <Icon name="kind-icon:chevron-right" class="size-4" />
+            </NuxtLink>
+          </div>
         </footer>
       </div>
     </dialog>
@@ -200,6 +285,7 @@ import {
   type ShowcaseKind,
 } from '@/utils/homeShowcase'
 import type { ReactionTargetType } from '@/stores/reactionStore'
+import { useUserStore } from '@/stores/userStore'
 import { defaultArtFor } from '@/utils/defaultArtPool'
 
 const props = defineProps<{ card: RailItem }>()
@@ -252,6 +338,116 @@ const REVIEW_TARGETS: Partial<Record<ShowcaseKind, ReactionTargetType>> = {
 const reviewTarget = computed<ReactionTargetType | null>(
   () => REVIEW_TARGETS[props.card.kind] ?? null,
 )
+
+/*
+ * WHICH KINDS CAN BE REDONE. Straight off EntityArtType in
+ * server/utils/entityArt.ts -- the enqueue endpoint's `entityArt` block only
+ * knows how to attach a finished render back onto these tables.
+ *
+ * `art` and `animation` are deliberately absent: an ArtImage IS the render, so
+ * there is no entity field to attach a replacement to. Regenerating one means
+ * making a new image, which is a different action on a different page.
+ */
+const REDO_ENTITY_TYPES: Partial<Record<ShowcaseKind, string>> = {
+  dream: 'dream',
+  character: 'character',
+  bot: 'bot',
+  reward: 'reward',
+  scenario: 'scenario',
+  facet: 'facet',
+  project: 'project',
+}
+
+const userStore = useUserStore()
+
+const redoOpen = ref(false)
+const redoPrompt = ref('')
+const redoBusy = ref(false)
+const redoMessage = ref('')
+const redoFailed = ref(false)
+
+/*
+ * Signed in AND a redoable kind. Not an admin check: /api/art/enqueue is behind
+ * authAndGate, which does the real authorisation and charges the mana, so
+ * duplicating a rule here would only get out of step with it. Signed-out
+ * visitors never see a button that would just 401.
+ */
+const showRedo = computed(
+  () => userStore.isLoggedIn && Boolean(REDO_ENTITY_TYPES[props.card.kind]),
+)
+
+/**
+ * A first draft of the prompt, built from what the record actually says.
+ *
+ * The trailing clause is the whole point. Silas: "we get a lot of text focused
+ * gens" -- several facet cards came back as pictures of trading cards with
+ * garbled lettering printed on them rather than as illustrations, so every
+ * manual redo would start by saying exactly this. Saying it by default is what
+ * makes the button an expedite rather than an empty box.
+ */
+const suggestedPrompt = computed(() => {
+  const parts = [
+    detail.value?.title || props.card.title,
+    detail.value?.subtitle || props.card.subtitle || '',
+  ]
+    .map((part) => String(part || '').trim())
+    .filter(Boolean)
+
+  return (
+    `${parts.join('. ')}. A single illustrated subject, full-frame. ` +
+    'No text, no lettering, no captions, no watermark, no logo, no border, ' +
+    'and not a picture of a card.'
+  )
+})
+
+function toggleRedo(): void {
+  redoOpen.value = !redoOpen.value
+  redoMessage.value = ''
+  if (redoOpen.value && !redoPrompt.value.trim()) {
+    redoPrompt.value = suggestedPrompt.value
+  }
+}
+
+async function submitRedo(): Promise<void> {
+  const entityType = REDO_ENTITY_TYPES[props.card.kind]
+  if (!entityType || !redoPrompt.value.trim()) return
+
+  redoBusy.value = true
+  redoMessage.value = ''
+  redoFailed.value = false
+  try {
+    const response = await performFetch<{ jobId: number; status: string }>(
+      '/api/art/enqueue',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          promptString: redoPrompt.value.trim(),
+          entityArt: {
+            entityType,
+            entityId: props.card.id,
+            // The card image, which is what every gallery and rail reads.
+            field: 'imagePath',
+            // Keep the old render rather than overwriting it: a redo that is
+            // worse than what it replaced should be recoverable.
+            preserveOriginal: true,
+            mode: 'recreate',
+          },
+        }),
+      },
+    )
+    if (!response.success || !response.data?.jobId) {
+      throw new Error(response.message || 'Art could not be queued.')
+    }
+    redoMessage.value = `Queued as ArtJob ${response.data.jobId}. It attaches when the render finishes.`
+  } catch (error) {
+    redoFailed.value = true
+    redoMessage.value =
+      error instanceof Error ? error.message : 'Art could not be queued.'
+  } finally {
+    redoBusy.value = false
+  }
+}
 
 const createdLabel = computed(() => {
   const created = new Date(detail.value?.createdAt || props.card.createdAt)

--- a/server/utils/newsfeed.ts
+++ b/server/utils/newsfeed.ts
@@ -295,16 +295,40 @@ export interface AggregatedFeed {
   sourceErrors: Array<{ sourceId: string; error: string; stale?: boolean }>
 }
 
+/*
+ * WHOLE WORDS, NOT SUBSTRINGS. `includeTags` and `excludeTags` were declared but
+ * never used by any feed, and a plain `.includes()` is why they could not be:
+ * the tag that matters most here is "ai", and as a substring that matches said,
+ * maintain, available, again, detail, campaign, and most of the English
+ * language. A feed narrowed with it would have filtered nothing.
+ *
+ * The boundary is non-alphanumeric on both sides, so "ai" matches "AI",
+ * "AI-generated", "(AI)" and "about AI." but not "said" -- which is what makes
+ * a broad-but-fresh source usable as an AI source.
+ */
+const tagPatterns = new Map<string, RegExp>()
+
+function tagPattern(tag: string): RegExp {
+  const key = tag.toLowerCase()
+  let pattern = tagPatterns.get(key)
+  if (!pattern) {
+    const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    pattern = new RegExp(`(^|[^a-z0-9])${escaped}([^a-z0-9]|$)`, 'i')
+    tagPatterns.set(key, pattern)
+  }
+  return pattern
+}
+
 function matchesTagFilters(item: NewsFeedItem, feed: FeedDefinition): boolean {
   const haystack = [item.title, item.summary, ...item.category]
     .join(' ')
     .toLowerCase()
 
-  if (feed.excludeTags?.some((tag) => haystack.includes(tag.toLowerCase()))) {
+  if (feed.excludeTags?.some((tag) => tagPattern(tag).test(haystack))) {
     return false
   }
   if (feed.includeTags?.length) {
-    return feed.includeTags.some((tag) => haystack.includes(tag.toLowerCase()))
+    return feed.includeTags.some((tag) => tagPattern(tag).test(haystack))
   }
   return true
 }

--- a/stores/helpers/newsfeed.ts
+++ b/stores/helpers/newsfeed.ts
@@ -149,7 +149,11 @@ export const FEED_SOURCES: FeedSourceDefinition[] = [
     name: 'MarkTechPost',
     url: 'https://www.marktechpost.com/feed/',
     kind: 'rss',
-    verified: true,
+    /*
+     * Answers 202 with an empty body 2026-09-02 -- a soft failure that never
+     * raised, so it counted as a working source while contributing nothing.
+     */
+    verified: false,
   },
   {
     id: 'huggingface-blog',
@@ -218,6 +222,48 @@ export const FEED_SOURCES: FeedSourceDefinition[] = [
     verified: true,
   },
   {
+    /*
+     * BROAD SOURCES, NARROWED BY includeTags. Silas, 2026-09-02: "the news is
+     * still waaaay old. why am I seeing news from 4-6 days ago?"
+     *
+     * Because ai-gaming was running on one source. pcgamer-ai has 404'd since
+     * 2026-07-19, and Kotaku's AI tag publishes roughly twice a week, so the
+     * top of the feed was routinely 4-6 days old with no error to show for it.
+     *
+     * These four are general gaming feeds rather than AI-tagged ones -- no
+     * outlet outside Kotaku publishes a working AI-only gaming feed -- so the
+     * feed's includeTags narrows them to the AI stories. Measured 2026-09-02:
+     * newest item 0.1-0.4 days old across all four, against Kotaku's 4.
+     */
+    id: 'gamedeveloper',
+    name: 'Game Developer',
+    url: 'https://www.gamedeveloper.com/rss.xml',
+    kind: 'rss',
+    verified: true,
+  },
+  {
+    id: 'rockpapershotgun',
+    name: 'Rock Paper Shotgun',
+    url: 'https://www.rockpapershotgun.com/feed',
+    kind: 'rss',
+    verified: true,
+  },
+  {
+    id: 'theverge-games',
+    name: 'The Verge — Games',
+    url: 'https://www.theverge.com/rss/games/index.xml',
+    kind: 'rss',
+    verified: true,
+  },
+  {
+    /* 3D/art tooling, where AI-in-games coverage actually concentrates. */
+    id: '80lv',
+    name: '80.lv',
+    url: 'https://80.lv/feed/',
+    kind: 'rss',
+    verified: true,
+  },
+  {
     // Still unreachable as of 2026-07-19 (t-013): no working tag/category feed
     // found (/tag/ai/rss, /tag/ai/feed, /software/ai/feed, /software/ai/rss all
     // 404 -- pcgamer.com/tag/ai/ itself 301s to /software/ai/, a page with no
@@ -263,11 +309,40 @@ export const FEED_SOURCES: FeedSourceDefinition[] = [
     verified: true,
   },
   {
+    /* Live-checked 2026-09-02: 40 items, newest 1.0 days old. */
+    id: 'stackoverflow-blog',
+    name: 'Stack Overflow Blog',
+    url: 'https://stackoverflow.blog/feed/',
+    kind: 'rss',
+    verified: true,
+  },
+  {
+    /* Live-checked 2026-09-02: newest 1.8 days old. */
+    id: 'smashingmag',
+    name: 'Smashing Magazine',
+    url: 'https://www.smashingmagazine.com/feed/',
+    kind: 'rss',
+    verified: true,
+  },
+  {
+    /* Live-checked 2026-09-02: 10 items, newest 0.3 days old. */
+    id: 'theverge-ai',
+    name: 'The Verge — AI',
+    url: 'https://www.theverge.com/rss/ai-artificial-intelligence/index.xml',
+    kind: 'rss',
+    verified: true,
+  },
+  {
     id: 'css-tricks',
     name: 'CSS-Tricks',
     url: 'https://css-tricks.com/feed/',
     kind: 'rss',
-    verified: true,
+    /*
+     * Returned HTTP 500 on every check 2026-09-02. Marked unverified so it
+     * stops being fetched, rather than left `true` and quietly halving
+     * developer-tips.
+     */
+    verified: false,
   },
 ]
 
@@ -282,7 +357,12 @@ export const FEED_DEFINITIONS: FeedDefinition[] = [
     description: 'What is shipping and changing across the AI industry.',
     icon: 'kind-icon:terminal',
     defaultEnabled: true,
-    sourceIds: ['techcrunch-ai', 'technologyreview-ai', 'marktechpost'],
+    sourceIds: [
+      'techcrunch-ai',
+      'technologyreview-ai',
+      'marktechpost',
+      'theverge-ai',
+    ],
     defaultSort: 'recent',
     topicPolitical: false,
   },
@@ -322,7 +402,39 @@ export const FEED_DEFINITIONS: FeedDefinition[] = [
     description: 'AI showing up in games — NPCs, tools, and player experience.',
     icon: 'kind-icon:players',
     defaultEnabled: true,
-    sourceIds: ['kotaku-ai', 'pcgamer-ai'],
+    sourceIds: [
+      'kotaku-ai',
+      'pcgamer-ai',
+      'gamedeveloper',
+      'rockpapershotgun',
+      'theverge-games',
+      '80lv',
+    ],
+    /*
+     * The four general gaming sources above would otherwise turn this into a
+     * general gaming feed. These keep it what its description says it is.
+     * Matching is whole-word (see matchesTagFilters), which is the only reason
+     * a two-letter tag like 'ai' is usable at all.
+     */
+    includeTags: [
+      'ai',
+      'a.i.',
+      'artificial intelligence',
+      'machine learning',
+      'llm',
+      'llms',
+      'chatgpt',
+      'openai',
+      'anthropic',
+      'generative',
+      'genai',
+      'neural',
+      'deepfake',
+      'copilot',
+      'midjourney',
+      'stable diffusion',
+      'procedural generation',
+    ],
     defaultSort: 'recent',
     topicPolitical: false,
   },
@@ -347,7 +459,12 @@ export const FEED_DEFINITIONS: FeedDefinition[] = [
     description: 'Practical engineering guidance worth reading today.',
     icon: 'kind-icon:code',
     defaultEnabled: true,
-    sourceIds: ['devto-tips', 'css-tricks'],
+    sourceIds: [
+      'devto-tips',
+      'css-tricks',
+      'stackoverflow-blog',
+      'smashingmag',
+    ],
     defaultSort: 'recent',
     topicPolitical: false,
   },


### PR DESCRIPTION
Two things from the same report.

---

## 1. "why am I seeing news from 4-6 days ago?"

Not caching, not sorting. **ai-gaming lists two sources and was running one.**

`pcgamer-ai` has 404'd since 2026-07-19 and is marked `verified: false`, which `getRunnableFeedSources` filters out **on purpose** so a dead endpoint doesn't become a permanent error banner. The side effect: a feed at half strength reporting `sourceErrors: 0`, so nothing said so. Kotaku's AI tag publishes about twice a week, and that was the whole feed.

A live audit of every source found it wasn't alone:

| feed | running | problem |
|---|---|---|
| **ai-gaming** | **1 / 2** | `pcgamer-ai` 404 |
| developer-tips | 1 / 2 | `css-tricks` returns **500** while marked `verified: true` |
| ai-news | 2 / 3 | `marktechpost` answers **202 with an empty body** |
| malaria-activism | 1 / 2 | |
| ai-model-creation | 3 / 4 | |

The two marked `verified` but dead are now `false`, so they stop being fetched rather than counting as working sources that contribute nothing.

**New sources, each live-checked 2026-09-02:**

```
ai-gaming        gamedeveloper      200  41 items  newest 0.4d
ai-gaming        rockpapershotgun   200  27 items  newest 0.4d
ai-gaming        theverge-games     200  10 items  newest 0.4d
ai-gaming        80lv               200  10 items  newest 0.4d
developer-tips   stackoverflow-blog 200  40 items  newest 1.0d
developer-tips   smashingmag        200   1 item   newest 1.8d
ai-news          theverge-ai        200  10 items  newest 0.3d
```

Those four gaming feeds are general, not AI-tagged — no outlet outside Kotaku publishes a working AI-only gaming feed — so `includeTags` narrows them to the AI stories.

**That field was declared but had never been used by any feed, and `matchesTagFilters` is why.** A plain `.includes()` means the tag that matters most here, `"ai"`, matches *said*, *maintain*, *available*, *again*, *campaign*, and most of the language. Matching is now whole-word:

```
'ai' + "Nvidia says AI-generated NPCs are ready"     → match
'ai' + "She said the campaign was available"         → no match
'ai' + "What AI. means for games"                    → match
'llm' + "Fulllmode is not a word"                    → no match
```

**Simulated against the live sources with the real tag list: newest item 15.2 hours old instead of 4 days**, 24 AI-matching items on titles alone (the real filter also reads summary and category, so it will catch more).

---

## 2. "a way to expedite asking for a new art prompt"

> "we get a lot of text focused gens, so I want to be able to easily submit them for a better redo"

The redo already existed — `entity-art-manager.vue` has done this for a while — but only on each record's own manager page, two navigations from where you notice the problem. Noticing happens in the interstitial, so the button is there now.

**The prefill is the feature, not the button.** The complaint is specific: several renders come back as pictures *of cards* with garbled lettering printed on them — the "Hacker" facet is a card carrying four lines of nonsense text. So the default prompt is composed from the record's own title and description plus an explicit *no text, no lettering, no watermark, not a picture of a card* clause. That's the edit you'd make by hand every single time. Editable, with a reset.

`preserveOriginal: true`, because a redo that comes back worse than what it replaced should be recoverable.

Gated on being signed in and on a kind `EntityArtType` can attach to — which excludes `art` and `animation`, since an ArtImage *is* the render and there's no entity field to attach a replacement to. Deliberately **not** an admin check: `/api/art/enqueue` is behind `authAndGate`, which does the real authorisation and charges the mana; a second rule here would only drift from it.

---

## Verification

`prettier` · `eslint` · layout contract · MDC scroll ownership · `vue-tsc` clean on the newsfeed commit (full `npm run test`, exit 0). The object-sheet commit's typecheck was still running locally when I pushed — CI's TypeScript job gates the merge, and I'll confirm both before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aNg3fsHLGUGCwiMp25hkA

---
_Generated by [Claude Code](https://claude.ai/code/session_017aNg3fsHLGUGCwiMp25hkA)_