### PR TITLE
Add Rainbow notification preferences and delivery seam

### DIFF
--- a/.github/workflows/rainbow-notification-contract.yml
+++ b/.github/workflows/rainbow-notification-contract.yml
@@ -1,0 +1,22 @@
+name: Rainbow Notification Contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'prisma/migrations/**rainbow_notification_preferences/**'
+      - 'server/utils/rainbowNotifications.ts'
+      - 'server/api/rainbow/notifications/**'
+      - 'tests/contracts/verifyRainbowNotifications.ts'
+      - '.github/workflows/rainbow-notification-contract.yml'
+
+jobs:
+  verify:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: npm ci
+      - run: npx tsx tests/contracts/verifyRainbowNotifications.ts

--- a/prisma/migrations/20260902080000_add_rainbow_notification_preferences/migration.sql
+++ b/prisma/migrations/20260902080000_add_rainbow_notification_preferences/migration.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `RainbowNotificationPreference` (
+    `userId` INTEGER NOT NULL,
+    `agentAttention` BOOLEAN NOT NULL DEFAULT false,
+    `forumReplyMention` BOOLEAN NOT NULL DEFAULT false,
+    `scheduledAgentFailure` BOOLEAN NOT NULL DEFAULT false,
+    `updatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`userId`),
+    CONSTRAINT `RainbowNotificationPreference_userId_fkey`
+      FOREIGN KEY (`userId`) REFERENCES `User`(`id`)
+      ON DELETE CASCADE ON UPDATE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/server/api/rainbow/notifications/preferences.get.ts
+++ b/server/api/rainbow/notifications/preferences.get.ts
@@ -1,0 +1,21 @@
+import { defineEventHandler, setHeader } from 'h3'
+import { errorHandler } from '@/server/utils/error'
+import { requireHumanOrRainbowApiUser } from '@/server/utils/authGuard'
+import { getRainbowNotificationPreference } from '@/server/utils/rainbowNotifications'
+
+export default defineEventHandler(async (event) => {
+  setHeader(event, 'Cache-Control', 'no-store')
+
+  try {
+    const auth = await requireHumanOrRainbowApiUser(event)
+    const preference = await getRainbowNotificationPreference(auth.user.id)
+    return { success: true, preference }
+  } catch (error) {
+    const { message, statusCode } = errorHandler(error)
+    event.node.res.statusCode = statusCode || 500
+    return {
+      success: false,
+      message: message || 'Failed to load Rainbow notification preferences.',
+    }
+  }
+})

--- a/server/api/rainbow/notifications/preferences.patch.ts
+++ b/server/api/rainbow/notifications/preferences.patch.ts
@@ -1,0 +1,43 @@
+import { createError, defineEventHandler, readBody, setHeader } from 'h3'
+import { errorHandler } from '@/server/utils/error'
+import { requireHumanOrRainbowApiUser } from '@/server/utils/authGuard'
+import { setRainbowNotificationPreference } from '@/server/utils/rainbowNotifications'
+
+type PreferenceBody = {
+  agentAttention?: unknown
+  forumReplyMention?: unknown
+  scheduledAgentFailure?: unknown
+}
+
+function requiredBoolean(value: unknown, label: string): boolean {
+  if (typeof value !== 'boolean') {
+    throw createError({ statusCode: 400, message: `${label} must be a boolean.` })
+  }
+  return value
+}
+
+export default defineEventHandler(async (event) => {
+  setHeader(event, 'Cache-Control', 'no-store')
+
+  try {
+    const auth = await requireHumanOrRainbowApiUser(event)
+    const body = (await readBody<PreferenceBody>(event)) ?? {}
+    const preference = await setRainbowNotificationPreference({
+      userId: auth.user.id,
+      agentAttention: requiredBoolean(body.agentAttention, 'agentAttention'),
+      forumReplyMention: requiredBoolean(body.forumReplyMention, 'forumReplyMention'),
+      scheduledAgentFailure: requiredBoolean(
+        body.scheduledAgentFailure,
+        'scheduledAgentFailure',
+      ),
+    })
+    return { success: true, preference }
+  } catch (error) {
+    const { message, statusCode } = errorHandler(error)
+    event.node.res.statusCode = statusCode || 500
+    return {
+      success: false,
+      message: message || 'Failed to update Rainbow notification preferences.',
+    }
+  }
+})

--- a/server/utils/rainbowNotifications.ts
+++ b/server/utils/rainbowNotifications.ts
@@ -1,0 +1,156 @@
+import { Prisma } from '~/prisma/generated/prisma/client'
+import prisma from './prisma'
+
+export type RainbowNotificationClass =
+  | 'AGENT_ATTENTION'
+  | 'FORUM_REPLY_MENTION'
+  | 'SCHEDULED_AGENT_FAILURE'
+
+export type RainbowNotificationPreference = {
+  userId: number
+  agentAttention: boolean
+  forumReplyMention: boolean
+  scheduledAgentFailure: boolean
+  updatedAt: Date | null
+}
+
+export type RainbowNotificationDeliveryReason =
+  | 'READY'
+  | 'OPTED_OUT'
+  | 'EMAIL_MISSING'
+  | 'EMAIL_UNVERIFIED'
+
+export type RainbowNotificationDeliveryDecision = {
+  userId: number
+  notificationClass: RainbowNotificationClass
+  optedIn: boolean
+  reason: RainbowNotificationDeliveryReason
+  targets: Array<{
+    transport: 'EMAIL'
+    address: string
+  }>
+}
+
+type PreferenceRow = {
+  userId: number
+  agentAttention: boolean | number
+  forumReplyMention: boolean | number
+  scheduledAgentFailure: boolean | number
+  updatedAt: Date
+}
+
+function preferenceEnabled(
+  preference: RainbowNotificationPreference,
+  notificationClass: RainbowNotificationClass,
+): boolean {
+  switch (notificationClass) {
+    case 'AGENT_ATTENTION':
+      return preference.agentAttention
+    case 'FORUM_REPLY_MENTION':
+      return preference.forumReplyMention
+    case 'SCHEDULED_AGENT_FAILURE':
+      return preference.scheduledAgentFailure
+  }
+}
+
+export async function getRainbowNotificationPreference(
+  userId: number,
+): Promise<RainbowNotificationPreference> {
+  const rows = await prisma.$queryRaw<PreferenceRow[]>(Prisma.sql`
+    SELECT userId, agentAttention, forumReplyMention, scheduledAgentFailure, updatedAt
+    FROM RainbowNotificationPreference
+    WHERE userId = ${userId}
+    LIMIT 1
+  `)
+
+  const row = rows[0]
+  return {
+    userId,
+    agentAttention: Boolean(row?.agentAttention),
+    forumReplyMention: Boolean(row?.forumReplyMention),
+    scheduledAgentFailure: Boolean(row?.scheduledAgentFailure),
+    updatedAt: row?.updatedAt ?? null,
+  }
+}
+
+export async function setRainbowNotificationPreference(input: {
+  userId: number
+  agentAttention: boolean
+  forumReplyMention: boolean
+  scheduledAgentFailure: boolean
+}): Promise<RainbowNotificationPreference> {
+  await prisma.$executeRaw(Prisma.sql`
+    INSERT INTO RainbowNotificationPreference (
+      userId,
+      agentAttention,
+      forumReplyMention,
+      scheduledAgentFailure,
+      updatedAt
+    ) VALUES (
+      ${input.userId},
+      ${input.agentAttention},
+      ${input.forumReplyMention},
+      ${input.scheduledAgentFailure},
+      CURRENT_TIMESTAMP(3)
+    )
+    ON DUPLICATE KEY UPDATE
+      agentAttention = VALUES(agentAttention),
+      forumReplyMention = VALUES(forumReplyMention),
+      scheduledAgentFailure = VALUES(scheduledAgentFailure),
+      updatedAt = CURRENT_TIMESTAMP(3)
+  `)
+
+  return getRainbowNotificationPreference(input.userId)
+}
+
+export async function planRainbowNotificationDelivery(input: {
+  userId: number
+  notificationClass: RainbowNotificationClass
+}): Promise<RainbowNotificationDeliveryDecision> {
+  const preference = await getRainbowNotificationPreference(input.userId)
+  const optedIn = preferenceEnabled(preference, input.notificationClass)
+
+  if (!optedIn) {
+    return {
+      userId: input.userId,
+      notificationClass: input.notificationClass,
+      optedIn: false,
+      reason: 'OPTED_OUT',
+      targets: [],
+    }
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: input.userId },
+    select: { email: true, emailVerified: true },
+  })
+  const email = user?.email?.trim() || ''
+
+  if (!email) {
+    return {
+      userId: input.userId,
+      notificationClass: input.notificationClass,
+      optedIn: true,
+      reason: 'EMAIL_MISSING',
+      targets: [],
+    }
+  }
+
+  if (!user?.emailVerified) {
+    return {
+      userId: input.userId,
+      notificationClass: input.notificationClass,
+      optedIn: true,
+      reason: 'EMAIL_UNVERIFIED',
+      targets: [],
+    }
+  }
+
+  return {
+    userId: input.userId,
+    notificationClass: input.notificationClass,
+    optedIn: true,
+    reason: 'READY',
+    targets: [{ transport: 'EMAIL', address: email }],
+  }
+}

--- a/tests/contracts/verifyRainbowNotifications.ts
+++ b/tests/contracts/verifyRainbowNotifications.ts
@@ -52,7 +52,7 @@ for (const route of [preferenceGet, preferencePatch]) {
   assert.doesNotMatch(route, /userId.*readBody|body\.userId/)
 }
 for (const field of ['agentAttention', 'forumReplyMention', 'scheduledAgentFailure']) {
-  assert.match(preferencePatch, new RegExp(`requiredBoolean\\(body\\.${field}`))
+  assert.match(preferencePatch, new RegExp(`requiredBoolean\\(\\s*body\\.${field}`))
 }
 assert.doesNotMatch(preferencePatch, /Brevo|sendTransactionalEmail|newsletter/i)
 

--- a/tests/contracts/verifyRainbowNotifications.ts
+++ b/tests/contracts/verifyRainbowNotifications.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const migration = readFileSync(
+  'prisma/migrations/20260902080000_add_rainbow_notification_preferences/migration.sql',
+  'utf8',
+)
+const storage = readFileSync('server/utils/rainbowNotifications.ts', 'utf8')
+const preferenceGet = readFileSync(
+  'server/api/rainbow/notifications/preferences.get.ts',
+  'utf8',
+)
+const preferencePatch = readFileSync(
+  'server/api/rainbow/notifications/preferences.patch.ts',
+  'utf8',
+)
+
+// Preference storage is additive, canonical, and private-by-default.
+assert.match(migration, /CREATE TABLE `RainbowNotificationPreference`/)
+assert.match(migration, /`agentAttention` BOOLEAN NOT NULL DEFAULT false/)
+assert.match(migration, /`forumReplyMention` BOOLEAN NOT NULL DEFAULT false/)
+assert.match(migration, /`scheduledAgentFailure` BOOLEAN NOT NULL DEFAULT false/)
+assert.match(migration, /REFERENCES `User`\(`id`\)/)
+assert.match(migration, /ON DELETE CASCADE/)
+assert.doesNotMatch(migration, /DROP TABLE|DROP COLUMN|TRUNCATE|DELETE FROM/i)
+
+// The three product classes are explicit and map to those three opt-ins only.
+for (const notificationClass of [
+  'AGENT_ATTENTION',
+  'FORUM_REPLY_MENTION',
+  'SCHEDULED_AGENT_FAILURE',
+]) {
+  assert.match(storage, new RegExp(`'${notificationClass}'`))
+}
+assert.match(storage, /getRainbowNotificationPreference/)
+assert.match(storage, /setRainbowNotificationPreference/)
+assert.match(storage, /planRainbowNotificationDelivery/)
+
+// Delivery planning is provider-neutral. It may resolve a verified EMAIL target,
+// but this reversible slice must not know or invoke Brevo or any mail sender.
+assert.match(storage, /transport: 'EMAIL'/)
+assert.match(storage, /emailVerified/)
+assert.match(storage, /reason: 'OPTED_OUT'/)
+assert.match(storage, /reason: 'EMAIL_MISSING'/)
+assert.match(storage, /reason: 'EMAIL_UNVERIFIED'/)
+assert.match(storage, /reason: 'READY'/)
+assert.doesNotMatch(storage, /Brevo|BREVO|sendTransactionalEmail|api\.brevo\.com|fetch\(/)
+
+// Rainbow's first-party BFF delegation may manage only the authenticated human's settings.
+for (const route of [preferenceGet, preferencePatch]) {
+  assert.match(route, /requireHumanOrRainbowApiUser\(event\)/)
+  assert.doesNotMatch(route, /userId.*readBody|body\.userId/)
+}
+for (const field of ['agentAttention', 'forumReplyMention', 'scheduledAgentFailure']) {
+  assert.match(preferencePatch, new RegExp(`requiredBoolean\\(body\\.${field}`))
+}
+assert.doesNotMatch(preferencePatch, /Brevo|sendTransactionalEmail|newsletter/i)
+
+console.log('Rainbow notification preference + delivery seam contract: OK')


### PR DESCRIPTION
## What changed
- adds an additive `RainbowNotificationPreference` table keyed to the canonical Kind Robots User, with three false-by-default opt-ins: agent attention, direct forum reply/mention, and scheduled-agent failure
- adds authenticated Rainbow-first-party GET/PATCH preference APIs; clients cannot nominate another user
- adds `planRainbowNotificationDelivery`, a provider-neutral server seam that resolves whether a class is opted in and, only for a verified account email, returns a generic `EMAIL` target
- deliberately contains no Brevo client, mail send, provider secret, contact sync, or side effect
- adds a focused contract workflow pinning additive migration safety, private defaults, verified-email gating, auth boundaries, and the no-Brevo/no-send rule

## Architecture
This mirrors the existing `RainbowDirectoryPreference` pattern: canonical website state lives in the Kind Robots database and is accessed through a small typed raw-SQL utility. It does not add notification columns to `User` or create a Rainbow-side database.

## Safety
The migration is CREATE TABLE only with a User FK and cascade cleanup; no DROP/ALTER/delete. No email is sent and no production secret or account is required. Brevo activation remains the separate human-gated rainbow-butterflies/t-049.

Conductor: rainbow-butterflies/t-048