### PR TITLE
Fix the facet block sizing itself from its content below the lg breakpoint

### DIFF
--- a/components/home/home-dream-hero.vue
+++ b/components/home/home-dream-hero.vue
@@ -329,6 +329,16 @@
         sliver of itself. Silas, 2026-09-02: "weird whitespace formatting
         preventing the facets from full size."
 
+        A WIDTH IS STILL REQUIRED BELOW lg, and dropping it was a real bug.
+        Silas, 2026-09-02, on a phone: "looked good until I swiped into the
+        facets and the resolution jumped and hijaked the screen." Below lg the
+        cast row has no definite height -- `h-full` is `lg:h-full` on its parent
+        -- so with neither a width nor an aspect this block fell back to its
+        content's intrinsic size and rendered one facet at roughly full-screen.
+        `w-44` matches a cast card, which is what it was before and what the row
+        expects; `lg:w-auto` hands sizing back to the aspect where the band
+        finally has a height for it to derive from.
+
         `aspect-[9/10]` derives the block's width from the band height instead,
         which is the one number that actually decides how tall a cell is. At a
         420px band that is a 378px block: two ~187px columns, each cell ~208 tall
@@ -344,9 +354,18 @@
       -->
         <div
           v-if="facets.length"
-          class="flex h-full shrink-0 flex-col lg:aspect-[9/10]"
+          class="flex h-full w-44 shrink-0 flex-col lg:aspect-[9/10] lg:w-auto"
         >
-          <div class="grid min-h-0 flex-1 grid-cols-2 grid-rows-2 gap-1">
+          <!--
+            `min-w-0` alongside `min-h-0`: a grid item's automatic minimum size
+            is its content, so without it a column can be pushed wider than its
+            track by the image inside it. The cells below already carry it; the
+            grid did not, which left one more path by which an image's intrinsic
+            width could drive the layout instead of the other way round.
+          -->
+          <div
+            class="grid min-h-0 min-w-0 flex-1 grid-cols-2 grid-rows-2 gap-1"
+          >
             <a
               v-for="facet in facets.slice(0, 4)"
               :key="`facet-${facet.id}`"


### PR DESCRIPTION
> "looked good until I swiped into the facets and the resolution jumped and hijaked the screen"

My regression, from #2318.

## What I broke

Deriving the facet block's width from the band height was right at `lg`. But I wrote it as `lg:aspect-[9/10]` and **deleted `w-44` outright**. Below `lg` the block then had neither a width nor an aspect — and no definite height either, since the row's `h-full` is also `lg:`-gated — so its width had to come from its content, whose own width was a percentage of the block.

That's a circular dependency, and engines resolve those differently. Chromium settles it at 219px. iOS Safari evidently resolved it far larger, which inside `overflow-x-auto` reads as one image filling the screen, clipped at the right — exactly the screenshot.

## The fix

`w-44` with `lg:w-auto` **removes the cycle rather than tuning it**, so the result stops depending on the engine:

```
176px block → 86px grid columns → 86px square plates
```

Every step definite, nothing inferred from content. Plus `min-w-0` on the grid, which closes the last path by which a grid item's automatic minimum size could let an image's intrinsic width drive the layout instead of the reverse. (The cells already carried it; the grid didn't.)

## Measured

Chromium, both ends, **with real production art actually loading** — a broken image cannot reproduce an intrinsic-width bug, and my first pass at reproducing this was useless for exactly that reason:

| viewport | block | cell | overflow |
|---|---|---|---|
| 390 × 844 | 176 × 208 | 86 × 102 | 0 |
| 1920 × 1080 | 378 × 420 | 187 × 208 | 0 |

Desktop unchanged. Layout contract and MDC scroll ownership clean.

## Not reproduced, and worth saying plainly

There is no WebKit in this environment, and Chromium's 219px is wrong but not a hijack. **This fixes a mechanism I'm confident in, not a failure I watched fail.** It wants a real device to confirm — if it's still wrong on the phone, that tells us something my reasoning missed.

## Root cause on my side

Narrower than the CSS: I measured #2318 at 1920, 1366, 1280, 1024 and 900 — and never once below `lg`, which is the breakpoint whose branch I had just written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aNg3fsHLGUGCwiMp25hkA

---
_Generated by [Claude Code](https://claude.ai/code/session_017aNg3fsHLGUGCwiMp25hkA)_