### PR TITLE
Add kr-panel-section primitive; migrate 5 coloring-book panels

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -538,6 +538,14 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-2xl border border-base-300 bg-base-100;
   }
 
+  /* Larger-radius page-section surface: coloring-book studio panels and
+   * conductor-app project pages. Approved by Silas (interface-vision/t-123)
+   * as the named primitive for the previously hand-rolled
+   * rounded-3xl/border/base-100/p-5/shadow-sm shape. */
+  .kr-panel-section {
+    @apply rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm;
+  }
+
   /*
    * Status callouts — inline tinted notices (the most-repeated surface in
    * the app, previously written by hand with drifting opacities like

--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -2,7 +2,7 @@
   <section
     v-if="book && cover"
     id="coloring-cover-studio"
-    class="flex flex-col gap-5 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
+    class="flex flex-col gap-5 kr-panel-section"
   >
     <header class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
       <div>

--- a/components/coloring/coloring-book-package-readiness.vue
+++ b/components/coloring/coloring-book-package-readiness.vue
@@ -2,7 +2,7 @@
   <section
     v-if="packageData"
     id="coloring-package-readiness"
-    class="flex flex-col gap-5 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
+    class="flex flex-col gap-5 kr-panel-section"
   >
     <header class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
       <div>

--- a/components/coloring/coloring-book-production-history.vue
+++ b/components/coloring/coloring-book-production-history.vue
@@ -1,7 +1,7 @@
 <template>
   <section
     v-if="proposal"
-    class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
+    class="flex flex-col gap-4 kr-panel-section"
   >
     <header class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
       <div>

--- a/components/coloring/coloring-book-production-toolbar.vue
+++ b/components/coloring/coloring-book-production-toolbar.vue
@@ -1,7 +1,7 @@
 <template>
   <section
     v-if="proposal"
-    class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
+    class="flex flex-col gap-4 kr-panel-section"
   >
     <header class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
       <div>

--- a/components/coloring/coloring-book-readiness.vue
+++ b/components/coloring/coloring-book-readiness.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm">
+  <section class="flex flex-col gap-4 kr-panel-section">
     <header class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
       <div>
         <div class="flex items-center gap-2">


### PR DESCRIPTION
### Task
interface-vision/t-104 (slice 33): front-end consistency sweep onto shared kr-* components (kind: software)

### What changed
- New `.kr-panel-section` primitive in `assets/css/tailwind.css` — `rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm`, matching the shape approved by Silas in interface-vision/t-123 for the previously hand-rolled page-section surface.
- Migrated 5 of the 16 flagged files (all in `components/coloring/`) from the hand-rolled utility string to `kr-panel-section`, keeping every other layout utility (`flex flex-col gap-4/5`, `id=`, `v-if=`) untouched:
  - `coloring-book-production-history.vue`
  - `coloring-book-production-toolbar.vue`
  - `coloring-book-package-readiness.vue`
  - `coloring-book-cover-studio.vue`
  - `coloring-book-readiness.vue`
- Byte-equivalent substitution — no geometry or behavior change. The remaining 11 flagged files (9 conductor-app project pages + academy-style-detail.vue) are left for the next bounded slice; several of them mix in extra responsive overrides (e.g. `sm:p-6`) or heavy hover-state classes worth their own careful pass.

### How I verified
- `npm run test` (`vue-tsc --noEmit`) — clean, exit 0.
- `npx eslint` on the 5 changed `.vue` files — 0 errors.
- `npm run test:layout-contract` — holds, no new violations.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
None beyond continuing the remaining 11-file slice next cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019X4oVcMJWyT5PbwGMDwMAS

---
_Generated by [Claude Code](https://claude.ai/code/session_019X4oVcMJWyT5PbwGMDwMAS)_