### PR TITLE
Mobile panes, whole-tile shelves, visible labels, and readable dream copy

### DIFF
--- a/components/home/home-page.vue
+++ b/components/home/home-page.vue
@@ -171,7 +171,49 @@
         six short rows and scrolling it would be silly.
       -->
       <div class="flex min-w-0 flex-col gap-2 xl:min-h-0 xl:w-[22%]">
-        <home-attention class="xl:min-h-0 xl:flex-1" />
+        <!--
+          ONE PANE AT A TIME ON A PHONE. Silas, 2026-09-02: "Thinking we should
+          move the news, todo, project section to a different screen on mobile.
+          I don't love scrolling vertically forever to finish my todos before
+          seeing projects and news."
+
+          Stacked, these three are a very long page: the gate list alone has run
+          to seventy-plus rows, and projects and news sit underneath it. On a
+          desktop that is fine because they are a column beside the galleries;
+          on a phone the column unrolls into the page and buries the last two.
+
+          A switcher rather than a separate route: they are the same dashboard,
+          and a route change would cost the hero and galleries above. The tabs
+          are CSS-only below xl -- `hidden xl:flex` on the inactive panes -- so
+          the xl layout keeps all three stacked exactly as before, and nothing
+          here has to know the viewport width in JavaScript.
+        -->
+        <div
+          role="tablist"
+          aria-label="Dashboard sections"
+          class="flex shrink-0 gap-1 kr-panel-flat p-1 xl:hidden"
+        >
+          <button
+            v-for="pane in RIGHT_PANES"
+            :key="pane.key"
+            type="button"
+            role="tab"
+            :aria-selected="activePane === pane.key"
+            class="flex-1 rounded-lg px-2 py-1.5 text-[0.7rem] font-black uppercase tracking-[0.1em] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+            :class="
+              activePane === pane.key
+                ? 'bg-primary text-primary-content'
+                : 'text-base-content/55 hover:text-primary'
+            "
+            @click="activePane = pane.key"
+          >
+            {{ pane.label }}
+          </button>
+        </div>
+
+        <div :class="paneClass('attention')">
+          <home-attention class="xl:min-h-0 xl:flex-1" />
+        </div>
 
         <!--
           The projects strip. Silas, 2026-08-29: "I do like how projects appear
@@ -179,88 +221,90 @@
           icon-plus-text card shape. In a narrow column that becomes one card
           per row, which is what the container-width columns already do.
         -->
-        <section
-          v-if="showcaseStore.projects.length"
-          class="flex shrink-0 flex-col gap-1.5 kr-panel-flat p-3"
-        >
-          <header class="flex flex-wrap items-baseline justify-between gap-3">
-            <h2
-              class="text-[0.7rem] font-black uppercase tracking-[0.16em] text-primary"
-            >
-              What we're building
-            </h2>
-
-            <NuxtLink
-              to="/conductor"
-              class="link link-hover text-[0.7rem] font-bold text-base-content/50 hover:text-primary"
-            >
-              every project →
-            </NuxtLink>
-          </header>
-
-          <div
-            class="grid gap-2 grid-cols-[repeat(auto-fit,minmax(min(100%,11rem),1fr))]"
+        <div :class="paneClass('projects')">
+          <section
+            v-if="showcaseStore.projects.length"
+            class="flex w-full shrink-0 flex-col gap-1.5 kr-panel-flat p-3"
           >
-            <NuxtLink
-              v-for="project in showcaseStore.projects"
-              :key="project.id"
-              :to="showcaseHref(project)"
-              class="group flex items-center gap-2 rounded-xl border border-base-300 bg-base-100 p-1.5 transition-shadow hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:hover:-translate-y-0.5"
+            <header class="flex flex-wrap items-baseline justify-between gap-3">
+              <h2
+                class="text-[0.7rem] font-black uppercase tracking-[0.16em] text-primary"
+              >
+                What we're building
+              </h2>
+
+              <NuxtLink
+                to="/conductor"
+                class="link link-hover text-[0.7rem] font-bold text-base-content/50 hover:text-primary"
+              >
+                every project →
+              </NuxtLink>
+            </header>
+
+            <div
+              class="grid gap-2 grid-cols-[repeat(auto-fit,minmax(min(100%,11rem),1fr))]"
             >
-              <div class="size-10 shrink-0 overflow-hidden rounded-lg">
-                <kr-art-plate
-                  :source="project.art"
-                  variant="icon"
-                  shape="square"
-                  frame="none"
-                  :alt="project.title"
-                  :fallback="fallbackFor(project)"
-                  placeholder-icon="kind-icon:blueprint"
-                  fit="cover"
-                />
-              </div>
-
-              <div class="min-w-0 flex-1">
-                <p
-                  class="truncate text-xs font-black leading-tight group-hover:text-primary"
-                  :title="project.title"
-                >
-                  {{ project.title }}
-                </p>
-
-                <div class="mt-1 flex items-center gap-1.5">
-                  <span
-                    v-if="priorityLetter(project)"
-                    class="grid size-3.5 shrink-0 place-items-center rounded bg-primary text-[0.5rem] font-black text-primary-content"
-                    :title="`${project.badge || 'Priority'}`"
-                  >
-                    {{ priorityLetter(project) }}
-                  </span>
-
-                  <template v-if="progressFor(project) !== null">
-                    <span
-                      class="h-1.5 min-w-0 flex-1 overflow-hidden rounded-full bg-base-300"
-                      :title="`${progressFor(project)}% complete`"
-                    >
-                      <span
-                        class="block h-full rounded-full bg-primary"
-                        :style="{ width: `${progressFor(project)}%` }"
-                      />
-                    </span>
-
-                    <span
-                      class="shrink-0 text-[0.6rem] font-bold tabular-nums text-base-content/55"
-                    >
-                      {{ progressFor(project) }}%
-                    </span>
-                  </template>
-
-                  <span v-else class="min-w-0 flex-1" />
+              <NuxtLink
+                v-for="project in showcaseStore.projects"
+                :key="project.id"
+                :to="showcaseHref(project)"
+                class="group flex items-center gap-2 rounded-xl border border-base-300 bg-base-100 p-1.5 transition-shadow hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:hover:-translate-y-0.5"
+              >
+                <div class="size-10 shrink-0 overflow-hidden rounded-lg">
+                  <kr-art-plate
+                    :source="project.art"
+                    variant="icon"
+                    shape="square"
+                    frame="none"
+                    :alt="project.title"
+                    :fallback="fallbackFor(project)"
+                    placeholder-icon="kind-icon:blueprint"
+                    fit="cover"
+                  />
                 </div>
-              </div>
-            </NuxtLink>
-          </div>
-        </section>
+
+                <div class="min-w-0 flex-1">
+                  <p
+                    class="truncate text-xs font-black leading-tight group-hover:text-primary"
+                    :title="project.title"
+                  >
+                    {{ project.title }}
+                  </p>
+
+                  <div class="mt-1 flex items-center gap-1.5">
+                    <span
+                      v-if="priorityLetter(project)"
+                      class="grid size-3.5 shrink-0 place-items-center rounded bg-primary text-[0.5rem] font-black text-primary-content"
+                      :title="`${project.badge || 'Priority'}`"
+                    >
+                      {{ priorityLetter(project) }}
+                    </span>
+
+                    <template v-if="progressFor(project) !== null">
+                      <span
+                        class="h-1.5 min-w-0 flex-1 overflow-hidden rounded-full bg-base-300"
+                        :title="`${progressFor(project)}% complete`"
+                      >
+                        <span
+                          class="block h-full rounded-full bg-primary"
+                          :style="{ width: `${progressFor(project)}%` }"
+                        />
+                      </span>
+
+                      <span
+                        class="shrink-0 text-[0.6rem] font-bold tabular-nums text-base-content/55"
+                      >
+                        {{ progressFor(project) }}%
+                      </span>
+                    </template>
+
+                    <span v-else class="min-w-0 flex-1" />
+                  </div>
+                </div>
+              </NuxtLink>
+            </div>
+          </section>
+        </div>
 
         <!--
           The feed, its heading inside its own control strip rather than in a
@@ -270,35 +314,37 @@
           count a `max-h-*` region -- nested preview, not the page's scroll
           owner, which is still pages/[...slug].vue's content-host.
         -->
-        <section
-          class="flex max-h-80 flex-col overflow-y-auto overscroll-contain kr-panel-flat p-3 xl:max-h-full xl:min-h-0 xl:flex-1"
-        >
-          <NewsfeedFeed :initial-limit="24" compact>
-            <!--
+        <div :class="paneClass('news')">
+          <section
+            class="flex max-h-80 w-full flex-col overflow-y-auto overscroll-contain kr-panel-flat p-3 xl:max-h-full xl:min-h-0 xl:flex-1"
+          >
+            <NewsfeedFeed :initial-limit="24" compact>
+              <!--
               "News", not "From around the web". Silas, 2026-09-01: "we might as
               well change 'from around the web' to 'News'". It also buys back the
               width the topic chips were short of: the heading shares one row
               with the chips, three controls and the lab link inside a 22%
               column, and the long version was eating roughly 150px of it.
             -->
-            <template #lead>
-              <h2
-                class="hidden shrink-0 text-[0.7rem] font-black uppercase tracking-[0.16em] text-primary lg:block"
-              >
-                News
-              </h2>
-            </template>
+              <template #lead>
+                <h2
+                  class="hidden shrink-0 text-[0.7rem] font-black uppercase tracking-[0.16em] text-primary lg:block"
+                >
+                  News
+                </h2>
+              </template>
 
-            <template #trail>
-              <NuxtLink
-                to="/plan/newsfeed"
-                class="link link-hover shrink-0 text-[0.7rem] font-bold text-base-content/50 hover:text-primary"
-              >
-                lab →
-              </NuxtLink>
-            </template>
-          </NewsfeedFeed>
-        </section>
+              <template #trail>
+                <NuxtLink
+                  to="/plan/newsfeed"
+                  class="link link-hover shrink-0 text-[0.7rem] font-bold text-base-content/50 hover:text-primary"
+                >
+                  lab →
+                </NuxtLink>
+              </template>
+            </NewsfeedFeed>
+          </section>
+        </div>
       </div>
     </div>
 
@@ -331,6 +377,34 @@ import {
 import { defaultArtFor } from '@/utils/defaultArtPool'
 import type { ArtVariant } from '@/utils/artImageSrc'
 import type { ArtPlateShape } from '@/utils/galleryVocabulary'
+
+/*
+ * The three right-column sections, as phone tabs. See the tablist in the
+ * template for why this is a switcher rather than a route.
+ */
+const RIGHT_PANES = [
+  { key: 'attention', label: 'Needs you' },
+  { key: 'projects', label: 'Building' },
+  { key: 'news', label: 'News' },
+] as const
+
+type RightPane = (typeof RIGHT_PANES)[number]['key']
+
+const activePane = ref<RightPane>('attention')
+
+/**
+ * Show this pane on a phone only when it is the selected tab; always show it
+ * from xl up, where the three stack in a column as they did before.
+ *
+ * `hidden xl:flex` rather than a JS breakpoint check: the xl layout must not
+ * depend on a media query listener having fired, and a server-rendered page
+ * would otherwise flash the wrong pane set before hydration.
+ */
+function paneClass(pane: RightPane): string {
+  const shared = 'min-w-0 flex-col xl:flex xl:min-h-0'
+  const grow = pane === 'projects' ? 'xl:shrink-0' : 'xl:flex-1'
+  return `${activePane.value === pane ? 'flex' : 'hidden'} ${shared} ${grow}`
+}
 
 type RailDefinition = {
   key: ShowcaseRailKey

--- a/components/home/home-rail.vue
+++ b/components/home/home-rail.vue
@@ -350,9 +350,19 @@ const atEnd = ref(false)
  * whole tiles land nearest it, so a shelf always ends on a tile boundary at any
  * width. `Math.round` rather than `floor`: flooring would rather grow tiles 40%
  * than fit one more, which reads worse than a slightly narrow tile.
+ *
+ * MAX_GROWTH is the other half of that, and it was missing. Rounding down to one
+ * column is the same "grow the tile enormously" move the comment above rejects:
+ * a 256px mobile shelf against the 192px wide ideal rounds to a single 256px
+ * tile, a third over target and most of a phone screen. Silas, 2026-09-02:
+ * "Still weird use of whitespace on the facet section on mobile when I scroll."
+ * So a tile may run up to a quarter over the ideal and no further; past that,
+ * fit one more column instead. Desktop is unaffected -- its shelves land at 149
+ * and 228 against ceilings of 160 and 240.
  */
 const GAP = 8 // gap-2
 const IDEAL_TILE = { wide: 192, portrait: 128 } as const
+const MAX_GROWTH = 1.25
 
 const measuredTileWidth = ref(0)
 
@@ -377,11 +387,17 @@ function fitTiles(available: number): { columns: number; width: number } {
     props.shape === 'wide' || props.shape === 'hero'
       ? IDEAL_TILE.wide
       : IDEAL_TILE.portrait
-  const columns = Math.max(1, Math.round((available + GAP) / (ideal + GAP)))
-  return {
-    columns,
-    width: Math.floor((available - (columns - 1) * GAP) / columns),
+  let columns = Math.max(1, Math.round((available + GAP) / (ideal + GAP)))
+  const widthAt = (n: number) => Math.floor((available - (n - 1) * GAP) / n)
+
+  // One extra column rather than one oversized tile. Guarded on the resulting
+  // width staying usable, so a very narrow track still yields a single tile
+  // instead of shrinking towards zero.
+  if (widthAt(columns) > ideal * MAX_GROWTH && widthAt(columns + 1) >= 96) {
+    columns += 1
   }
+
+  return { columns, width: widthAt(columns) }
 }
 
 /**


### PR DESCRIPTION
Five notes across two review rounds. Two commits.

## Shelf tiles ballooned on mobile

> "Still weird use of whitespace on the facet section on mobile when I scroll."

`fitTiles` rounds to the nearest whole column count. On a 256px phone shelf against the 192px `wide` ideal that rounds to **one** column — a 256px tile, a third over target and most of the screen. The comment directly above that line already rejected this exact move ("flooring would rather grow tiles 40% than fit one more") and then the rounding did the same thing from the other direction.

A tile may now run at most 25% over ideal before fitting another column, guarded so a very narrow track still yields one tile rather than shrinking toward nothing.

```
                       before          after
mobile art shelf    1 × 256px  →   2 × 123px
desktop art shelf   2 × 228px      2 × 228px   (unchanged, ceiling 240)
desktop objects     3 × 149px      3 × 149px   (unchanged, ceiling 160)
```

## Scrolling forever to reach projects and news

> "I don't love scrolling vertically forever to finish my todos before seeing projects and news."

Below `xl`, Needs-you / Building / News are tabs — one pane at a time, defaulting to Needs you. The gate list alone has run past seventy rows, with the other two underneath it.

**A switcher rather than a separate route,** deliberately: same dashboard, and a route change would cost the hero and galleries above it. If real separate screens with their own URLs is what was wanted, that's a different build.

CSS-only below `xl` (`hidden xl:flex` on inactive panes), so the `xl` layout keeps all three stacked, no JS breakpoint listener, no hydration flash.

| | 390×844 | 1920×1080 |
|---|---|---|
| tabs | visible | hidden |
| panes shown | 1 | 3 |
| page height | **844** (= viewport) | 1080 (= viewport) |
| horizontal overflow | 0 | 0 |

## Labels were gated twice

> "we are still missing text labels on the objects when we have room."

The shelf name carried `hidden xl:inline` **on top of** the `showLabel` prop — so the prop the page sets was overruled by exactly the kind of breakpoint the comment right above it says not to use. The prop is the only gate now, as it was always documented to be.

## The label is the see-all link

> "the see all link on the objects should not be there, it can be a link on the text that you will add instead."

The arrow was a second control pointing where the heading already pointed, and on a phone it competed with the chevrons for a strip a few hundred pixels wide. The whole icon-label-count group is the destination now — a far bigger tap target than a 20px glyph.

## Titles grow rather than truncate

> "if the title is larger than two lines, I'd rather we push to take up vertical space than truncate."

No clamp. The caption is `shrink-0` above a `flex-1` plate, so a third or fourth line takes its room from the picture rather than from the name. The plate keeps a `min-h-12` floor so a pathological title can't erase the artwork.

## The dream descriptions were light grey, literally

> "better readable text for the dream creation descriptions, a different color that isn't light grey, it gets lost."

They ran at `text-base-content/65` — a 65% tint of base-content on a pale panel is the lowest-contrast text on the page, under the prose most meant to be read. Now full strength; hierarchy against the title still comes from weight and size.

**Deliberately not a hue** like `text-secondary`: each cast card wears its own record's daisyUI theme, so a hue that reads well on one card is illegible on the next — the trap the badge chip already hit and documented.

Also rewrote the header comment claiming the label is "removed from the screen, not from the accessibility tree" — this change makes that false, and the saving that justified dropping the words (eight shelves × one text line) doesn't apply to six shelves in a 3×2 grid.

## Verification

`prettier` · `eslint` · layout contract · MDC scroll ownership · `vue-tsc`

One note on process: a local typecheck reported failures mid-round that turned out to be a `.nuxt` I'd corrupted myself with a stray `pkill` matching `nuxi` — CI's TypeScript job passed on the identical commit, and a clean rebuild confirmed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aNg3fsHLGUGCwiMp25hkA