### PR TITLE
Activate opt-in Rainbow Brevo notifications

### DIFF
--- a/.github/workflows/rainbow-notification-contract.yml
+++ b/.github/workflows/rainbow-notification-contract.yml
@@ -9,7 +9,7 @@ on:
       - 'server/utils/rainbowNotificationDelivery.ts'
       - 'server/api/rainbow/notifications/**'
       - 'server/api/v1/agent/attention/index.post.ts'
-      - 'server/api/v1/forum/threads/[id]/replies.post.ts'
+      - 'server/api/v1/forum/threads/**/replies.post.ts'
       - 'tests/contracts/verifyRainbowNotifications.ts'
       - '.github/workflows/rainbow-notification-contract.yml'
 

--- a/.github/workflows/rainbow-notification-contract.yml
+++ b/.github/workflows/rainbow-notification-contract.yml
@@ -6,7 +6,10 @@ on:
     paths:
       - 'prisma/migrations/**rainbow_notification_preferences/**'
       - 'server/utils/rainbowNotifications.ts'
+      - 'server/utils/rainbowNotificationDelivery.ts'
       - 'server/api/rainbow/notifications/**'
+      - 'server/api/v1/agent/attention/index.post.ts'
+      - 'server/api/v1/forum/threads/[id]/replies.post.ts'
       - 'tests/contracts/verifyRainbowNotifications.ts'
       - '.github/workflows/rainbow-notification-contract.yml'
 

--- a/server/api/v1/agent/attention/index.post.ts
+++ b/server/api/v1/agent/attention/index.post.ts
@@ -5,6 +5,7 @@ import {
   createOrGetAgentAttentionRequest,
   parseAgentAttentionRequestInput,
 } from '@/server/utils/agentAttentionRequests'
+import { deliverRainbowNotification } from '@/server/utils/rainbowNotificationDelivery'
 
 type AttentionBody = {
   kind?: unknown
@@ -40,6 +41,17 @@ export default defineEventHandler(async (event) => {
     credentialId: auth.credentialId ?? null,
     ...input,
   })
+
+  if (result.created) {
+    await deliverRainbowNotification({
+      userId: auth.user.id,
+      notificationClass: 'AGENT_ATTENTION',
+      agentName: profile.name,
+      kind: input.kind,
+      title: input.title,
+      body: input.body,
+    })
+  }
 
   event.node.res.statusCode = result.created ? 201 : 200
   return {

--- a/server/api/v1/forum/threads/[id]/replies.post.ts
+++ b/server/api/v1/forum/threads/[id]/replies.post.ts
@@ -24,6 +24,7 @@ import {
   optionalPositiveId,
   requiredString,
 } from '@/server/utils/chatApi'
+import { deliverRainbowNotification } from '@/server/utils/rainbowNotificationDelivery'
 
 const FORUM_REPLY_CREATE_FIELDS = new Set([
   'content',
@@ -99,6 +100,18 @@ export default defineEventHandler(async (event) => {
       await persistForumAgentAuthor(tx, reply.id, actor)
       return reply
     })
+
+    if (created.isPublic && parent.userId && parent.userId !== actor.userId) {
+      await deliverRainbowNotification({
+        userId: parent.userId,
+        notificationClass: 'FORUM_REPLY_MENTION',
+        actorName: actor.displayName,
+        threadId: thread.id,
+        threadTitle: thread.title,
+        excerpt: content,
+        isMature,
+      })
+    }
 
     event.node.res.statusCode = 201
     return {

--- a/server/utils/rainbowNotificationDelivery.ts
+++ b/server/utils/rainbowNotificationDelivery.ts
@@ -1,0 +1,207 @@
+import { sendTransactionalEmail } from './email'
+import {
+  planRainbowNotificationDelivery,
+  type RainbowNotificationClass,
+  type RainbowNotificationDeliveryReason,
+} from './rainbowNotifications'
+
+const RAINBOW_BASE_URL = 'https://rainbowbutterflies.org'
+
+type AgentAttentionNotification = {
+  userId: number
+  notificationClass: 'AGENT_ATTENTION'
+  agentName: string
+  kind: string
+  title: string
+  body?: string | null
+}
+
+type ForumReplyNotification = {
+  userId: number
+  notificationClass: 'FORUM_REPLY_MENTION'
+  actorName: string
+  threadId: number
+  threadTitle?: string | null
+  excerpt?: string | null
+  isMature?: boolean
+}
+
+type ScheduledAgentFailureNotification = {
+  userId: number
+  notificationClass: 'SCHEDULED_AGENT_FAILURE'
+  agentName: string
+  summary?: string | null
+}
+
+export type RainbowNotificationDeliveryInput =
+  | AgentAttentionNotification
+  | ForumReplyNotification
+  | ScheduledAgentFailureNotification
+
+export type RainbowNotificationSendReason =
+  | RainbowNotificationDeliveryReason
+  | 'SENT'
+  | 'SEND_FAILED'
+  | 'DELIVERY_ERROR'
+
+export type RainbowNotificationSendResult = {
+  sent: boolean
+  skipped: boolean
+  reason: RainbowNotificationSendReason
+  error?: string
+}
+
+type EmailContent = {
+  subject: string
+  html: string
+  text: string
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;')
+}
+
+function compactText(value: unknown, limit = 360): string {
+  const clean = String(value ?? '')
+    .replace(/\s+/g, ' ')
+    .trim()
+  if (clean.length <= limit) return clean
+  return `${clean.slice(0, Math.max(0, limit - 1)).trimEnd()}…`
+}
+
+function emailShell(title: string, bodyHtml: string): string {
+  return `<!doctype html><html><body style="margin:0;background:#f4f4f7;font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#1f2430;">
+  <div style="max-width:560px;margin:0 auto;padding:32px 16px;">
+    <div style="background:#ffffff;border-radius:16px;padding:32px;border:1px solid #e6e6ef;">
+      <p style="margin:0 0 8px;font-size:12px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:#6b7280;">Rainbow Butterflies</p>
+      <h1 style="margin:0 0 16px;font-size:20px;">${title}</h1>
+      ${bodyHtml}
+      <hr style="border:none;border-top:1px solid #eee;margin:28px 0 16px;">
+      <p style="font-size:12px;color:#8a8f9c;margin:0;">Optional Rainbow notification · manage preferences on Rainbow Butterflies</p>
+    </div>
+  </div>
+</body></html>`
+}
+
+function button(href: string, label: string): string {
+  return `<p style="margin:24px 0 0;"><a href="${href}" style="display:inline-block;background:#6366f1;color:#fff;text-decoration:none;padding:12px 22px;border-radius:12px;font-weight:600;">${label}</a></p>`
+}
+
+function buildEmail(input: RainbowNotificationDeliveryInput): EmailContent {
+  switch (input.notificationClass) {
+    case 'AGENT_ATTENTION': {
+      const agentName = compactText(input.agentName, 120) || 'Your agent'
+      const title = compactText(input.title, 180) || 'Human attention requested'
+      const detail = compactText(input.body)
+      const kind = compactText(input.kind, 80)
+      const href = `${RAINBOW_BASE_URL}/dashboard`
+      return {
+        subject: `Rainbow: ${agentName} needs your attention`,
+        html: emailShell(
+          'Your agent asked for human input',
+          `<p><strong>${escapeHtml(agentName)}</strong> requested ${escapeHtml(kind || 'attention')}.</p><p><strong>${escapeHtml(title)}</strong></p>${
+            detail ? `<p>${escapeHtml(detail)}</p>` : ''
+          }${button(href, 'Open your Rainbow dashboard')}`,
+        ),
+        text: `${agentName} requested ${kind || 'attention'}: ${title}${detail ? `\n\n${detail}` : ''}\n\n${href}`,
+      }
+    }
+
+    case 'FORUM_REPLY_MENTION': {
+      const actorName = compactText(input.actorName, 120) || 'Someone'
+      const threadTitle = compactText(input.threadTitle, 180)
+      const excerpt = input.isMature ? '' : compactText(input.excerpt)
+      const href = `${RAINBOW_BASE_URL}/#commons`
+      return {
+        subject: `Rainbow: ${actorName} replied to you`,
+        html: emailShell(
+          'New reply in the commons',
+          `<p><strong>${escapeHtml(actorName)}</strong> replied${
+            threadTitle ? ` in <strong>${escapeHtml(threadTitle)}</strong>` : ''
+          }.</p>${
+            input.isMature
+              ? '<p>The reply is in a mature thread, so its content is not copied into email.</p>'
+              : excerpt
+                ? `<p>${escapeHtml(excerpt)}</p>`
+                : ''
+          }${button(href, 'Open the Rainbow commons')}`,
+        ),
+        text: `${actorName} replied to you${threadTitle ? ` in ${threadTitle}` : ''}.${
+          input.isMature
+            ? '\n\nThe reply is in a mature thread; open Rainbow to read it.'
+            : excerpt
+              ? `\n\n${excerpt}`
+              : ''
+        }\n\n${href}`,
+      }
+    }
+
+    case 'SCHEDULED_AGENT_FAILURE': {
+      const agentName = compactText(input.agentName, 120) || 'Your agent'
+      const summary = compactText(input.summary)
+      const href = `${RAINBOW_BASE_URL}/dashboard`
+      return {
+        subject: `Rainbow: ${agentName} scheduled run needs attention`,
+        html: emailShell(
+          'A scheduled agent run failed',
+          `<p><strong>${escapeHtml(agentName)}</strong> reported a scheduled-run failure.</p>${
+            summary ? `<p>${escapeHtml(summary)}</p>` : ''
+          }${button(href, 'Open your Rainbow dashboard')}`,
+        ),
+        text: `${agentName} reported a scheduled-run failure.${summary ? `\n\n${summary}` : ''}\n\n${href}`,
+      }
+    }
+  }
+}
+
+export async function deliverRainbowNotification(
+  input: RainbowNotificationDeliveryInput,
+): Promise<RainbowNotificationSendResult> {
+  try {
+    const decision = await planRainbowNotificationDelivery({
+      userId: input.userId,
+      notificationClass: input.notificationClass as RainbowNotificationClass,
+    })
+
+    const target = decision.targets.find((candidate) => candidate.transport === 'EMAIL')
+    if (decision.reason !== 'READY' || !target) {
+      return {
+        sent: false,
+        skipped: true,
+        reason: decision.reason,
+      }
+    }
+
+    const email = buildEmail(input)
+    const result = await sendTransactionalEmail({
+      to: target.address,
+      subject: email.subject,
+      html: email.html,
+      text: email.text,
+    })
+
+    if (result.sent) {
+      return { sent: true, skipped: false, reason: 'SENT' }
+    }
+
+    return {
+      sent: false,
+      skipped: Boolean(result.skipped),
+      reason: 'SEND_FAILED',
+      error: result.error,
+    }
+  } catch (error) {
+    console.error('[rainbow-notification] delivery failed:', error)
+    return {
+      sent: false,
+      skipped: false,
+      reason: 'DELIVERY_ERROR',
+      error: error instanceof Error ? error.message : 'unknown',
+    }
+  }
+}

--- a/tests/contracts/verifyRainbowNotifications.ts
+++ b/tests/contracts/verifyRainbowNotifications.ts
@@ -6,12 +6,24 @@ const migration = readFileSync(
   'utf8',
 )
 const storage = readFileSync('server/utils/rainbowNotifications.ts', 'utf8')
+const delivery = readFileSync(
+  'server/utils/rainbowNotificationDelivery.ts',
+  'utf8',
+)
 const preferenceGet = readFileSync(
   'server/api/rainbow/notifications/preferences.get.ts',
   'utf8',
 )
 const preferencePatch = readFileSync(
   'server/api/rainbow/notifications/preferences.patch.ts',
+  'utf8',
+)
+const attentionCreate = readFileSync(
+  'server/api/v1/agent/attention/index.post.ts',
+  'utf8',
+)
+const forumReplyCreate = readFileSync(
+  'server/api/v1/forum/threads/[id]/replies.post.ts',
   'utf8',
 )
 
@@ -31,13 +43,13 @@ for (const notificationClass of [
   'SCHEDULED_AGENT_FAILURE',
 ]) {
   assert.match(storage, new RegExp(`'${notificationClass}'`))
+  assert.match(delivery, new RegExp(`'${notificationClass}'`))
 }
 assert.match(storage, /getRainbowNotificationPreference/)
 assert.match(storage, /setRainbowNotificationPreference/)
 assert.match(storage, /planRainbowNotificationDelivery/)
 
-// Delivery planning is provider-neutral. It may resolve a verified EMAIL target,
-// but this reversible slice must not know or invoke Brevo or any mail sender.
+// Delivery planning stays provider-neutral. Brevo belongs only in the transport adapter.
 assert.match(storage, /transport: 'EMAIL'/)
 assert.match(storage, /emailVerified/)
 assert.match(storage, /reason: 'OPTED_OUT'/)
@@ -45,6 +57,11 @@ assert.match(storage, /reason: 'EMAIL_MISSING'/)
 assert.match(storage, /reason: 'EMAIL_UNVERIFIED'/)
 assert.match(storage, /reason: 'READY'/)
 assert.doesNotMatch(storage, /Brevo|BREVO|sendTransactionalEmail|api\.brevo\.com|fetch\(/)
+assert.match(delivery, /planRainbowNotificationDelivery/)
+assert.match(delivery, /sendTransactionalEmail/)
+assert.match(delivery, /decision\.reason !== 'READY' \|\| !target/)
+assert.match(delivery, /Optional Rainbow notification/)
+assert.doesNotMatch(delivery, /newsletter|brevoApiKey|BREVO_API_KEY|x-api-key/i)
 
 // Rainbow's first-party BFF delegation may manage only the authenticated human's settings.
 for (const route of [preferenceGet, preferencePatch]) {
@@ -56,4 +73,20 @@ for (const field of ['agentAttention', 'forumReplyMention', 'scheduledAgentFailu
 }
 assert.doesNotMatch(preferencePatch, /Brevo|sendTransactionalEmail|newsletter/i)
 
-console.log('Rainbow notification preference + delivery seam contract: OK')
+// Attention requests are idempotent by clientKey; email only on the newly-created branch.
+assert.match(attentionCreate, /if \(result\.created\)/)
+assert.match(attentionCreate, /deliverRainbowNotification\(\{/)
+assert.match(attentionCreate, /notificationClass: 'AGENT_ATTENTION'/)
+
+// Direct forum replies notify the parent author only for visible, non-self replies.
+assert.match(forumReplyCreate, /created\.isPublic/)
+assert.match(forumReplyCreate, /parent\.userId/)
+assert.match(forumReplyCreate, /parent\.userId !== actor\.userId/)
+assert.match(forumReplyCreate, /notificationClass: 'FORUM_REPLY_MENTION'/)
+assert.match(forumReplyCreate, /isMature,/)
+
+// Mature forum content is never copied into the email body or text excerpt.
+assert.match(delivery, /input\.isMature \? '' : compactText\(input\.excerpt\)/)
+assert.match(delivery, /reply is in a mature thread, so its content is not copied into email/)
+
+console.log('Rainbow notification preference + Brevo delivery contract: OK')


### PR DESCRIPTION
## What
Activates the Brevo transport for Rainbow Butterflies notification preferences without changing the provider-neutral t-048 planner.

- adds `server/utils/rainbowNotificationDelivery.ts`, a fixed-class Brevo adapter over `planRainbowNotificationDelivery`
- sends email only when the canonical preference is opted in and the account email is verified
- wires newly-created AgentProfile attention requests to `AGENT_ATTENTION`
- wires visible, non-self direct forum replies to `FORUM_REPLY_MENTION`
- suppresses content excerpts for mature forum replies
- keeps delivery best-effort so a mail failure cannot roll back the canonical attention request or forum reply
- expands the Rainbow notification contract workflow to cover the adapter and producers

## Safety / scope
- no Brevo API key, sender secret, account, DNS, contact list, or subscription state is added or changed
- no existing user is silently opted in; t-048 preferences remain false-by-default
- attention requests notify only on `result.created`, preserving clientKey idempotency and avoiding retry spam
- forum reply notifications skip self-replies and private/shadow-restricted replies
- provider-neutral planning remains free of Brevo-specific code

## Known producer gaps
The dispatcher includes the already-defined `SCHEDULED_AGENT_FAILURE` class, but Kind Robots has no canonical scheduled-run-failure event today, so this PR does not invent one. Likewise there is no existing forum `@mention` parser; this PR wires direct replies only rather than smuggling new forum semantics into the transport task. Those gaps should be separate follow-ups.

## Human gate
Silas confirmed in the active ChatGPT session that Brevo is already set up and configured, clearing rainbow-butterflies/t-049's account/secret gate. No account or secret mutation was needed for this implementation.