### PR TITLE
Migrate remaining project-page panels to kr-panel-section (slice 34)

### DIFF
--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -112,7 +112,7 @@
 
     <header
       v-else
-      class="flex flex-wrap items-start justify-between gap-3 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
+      class="flex flex-wrap items-start justify-between gap-3 kr-panel-section"
     >
       <div class="flex min-w-0 flex-col gap-2">
         <div class="flex flex-wrap items-center gap-2">
@@ -325,7 +325,7 @@
           </div>
         </section>
 
-        <section class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm">
+        <section class="kr-panel-section">
           <p class="flex items-center gap-1.5 text-xs font-black uppercase tracking-[0.16em] text-base-content/45">
             <Icon name="kind-icon:chat" class="h-4 w-4" />
             Reflect

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="flex flex-col gap-5">
     <header
-      class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm lg:flex-row lg:items-center lg:justify-between"
+      class="flex flex-col gap-4 kr-panel-section lg:flex-row lg:items-center lg:justify-between"
     >
       <div>
         <div class="flex items-center gap-2">

--- a/components/conductor/coat-dance-page.vue
+++ b/components/conductor/coat-dance-page.vue
@@ -2,9 +2,7 @@
 <template>
   <project-front-page class="kr-surface" slug="coat-dance" :fallback="config">
     <template #interactive>
-      <section
-        class="flex flex-col gap-3 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
-      >
+      <section class="flex flex-col gap-3 kr-panel-section">
         <div class="flex items-center gap-2">
           <Icon name="kind-icon:sparkles" class="size-5 text-primary" />
           <h3

--- a/components/conductor/conductor-app-page.vue
+++ b/components/conductor/conductor-app-page.vue
@@ -6,9 +6,7 @@
     :fallback="config"
   >
     <template #interactive>
-      <section
-        class="flex flex-col items-start gap-3 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
-      >
+      <section class="flex flex-col items-start gap-3 kr-panel-section">
         <div class="flex items-center gap-2">
           <Icon name="kind-icon:server" class="size-5 text-primary" />
           <h3

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -2,9 +2,7 @@
 <template>
   <project-front-page class="kr-surface" slug="davinci" :fallback="config">
     <template #interactive>
-      <section
-        class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
-      >
+      <section class="flex flex-col gap-4 kr-panel-section">
         <div class="flex items-center gap-2">
           <Icon name="kind-icon:castle" class="size-5 text-primary" />
           <h3
@@ -412,9 +410,7 @@
         </div>
       </section>
 
-      <section
-        class="flex flex-col items-start gap-3 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
-      >
+      <section class="flex flex-col items-start gap-3 kr-panel-section">
         <div class="flex items-center gap-2">
           <Icon name="kind-icon:trophy" class="size-5 text-primary" />
           <h3

--- a/components/conductor/newsfeed-page.vue
+++ b/components/conductor/newsfeed-page.vue
@@ -2,9 +2,7 @@
 <template>
   <project-front-page class="kr-surface" slug="newsfeed" :fallback="config">
     <template #interactive>
-      <section
-        class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
-      >
+      <section class="kr-panel-section">
         <h2 class="mb-4 text-base font-black text-base-content">Live feed</h2>
         <NewsfeedFeed />
       </section>

--- a/components/conductor/project-deliverables-panel.vue
+++ b/components/conductor/project-deliverables-panel.vue
@@ -5,7 +5,7 @@
   deliverables, persisted via projectStore.updateProject.
 -->
 <template>
-  <section class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm">
+  <section class="kr-panel-section">
     <div class="mb-3 flex items-center gap-2">
       <Icon name="kind-icon:check-circle" class="size-5 text-primary" />
       <h3

--- a/components/conductor/project-gallery-strip.vue
+++ b/components/conductor/project-gallery-strip.vue
@@ -5,10 +5,7 @@
   empty or missing, so a project without art doesn't leave a hole.
 -->
 <template>
-  <section
-    v-if="images.length"
-    class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
-  >
+  <section v-if="images.length" class="kr-panel-section">
     <div class="mb-3 flex items-center gap-2">
       <Icon name="kind-icon:image" class="size-5 text-primary" />
       <h3

--- a/components/conductor/sketchy-page.vue
+++ b/components/conductor/sketchy-page.vue
@@ -2,9 +2,7 @@
 <template>
   <project-front-page class="kr-surface" slug="sketchy" :fallback="config">
     <template #interactive>
-      <section
-        class="flex flex-col items-start gap-3 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
-      >
+      <section class="flex flex-col items-start gap-3 kr-panel-section">
         <div class="flex items-center gap-2">
           <Icon name="kind-icon:pencil" class="size-5 text-primary" />
           <h3

--- a/components/conductor/voice-lab-page.vue
+++ b/components/conductor/voice-lab-page.vue
@@ -2,9 +2,7 @@
 <template>
   <project-front-page class="kr-surface" slug="alexa-integration" :fallback="config">
     <template #interactive>
-      <section
-        class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
-      >
+      <section class="flex flex-col gap-4 kr-panel-section">
         <div class="flex flex-wrap items-center justify-between gap-2">
           <div class="flex items-center gap-2">
             <Icon name="kind-icon:server" class="size-5 text-primary" />
@@ -82,9 +80,7 @@
         </NuxtLink>
       </section>
 
-      <section
-        class="flex flex-col gap-3 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
-      >
+      <section class="flex flex-col gap-3 kr-panel-section">
         <div class="flex items-center gap-2">
           <Icon name="kind-icon:book" class="size-5 text-primary" />
           <h3


### PR DESCRIPTION
### Task
conductor interface-vision/t-104 (recurring): drive live front-end consistency onto shared kr-* components. (kind: software)

### What changed / what I produced
Byte-equivalent substitution of the hand-rolled `rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm` cluster for `kr-panel-section` (added in slice 33, kind_robots#2324) across the remaining exact-match occurrences that slice's note flagged as left over:
- `components/conductor/coat-dance-page.vue`
- `components/conductor/project-gallery-strip.vue`
- `components/conductor/project-deliverables-panel.vue`
- `components/conductor/voice-lab-page.vue` (x2)
- `components/conductor/davinci-page.vue` (x2)
- `components/conductor/sketchy-page.vue`
- `components/conductor/conductor-app-page.vue`
- `components/conductor/newsfeed-page.vue`
- `components/academy/academy-style-detail.vue` (x2)
- `components/coloring/coloring-book-studio.vue` (1 of several panels — see below)

No geometry or behavior change — every other layout utility (`flex`/`gap`/`items-*`/`justify-*`) on each element is left exactly where it was.

Left for a future slice (not byte-exact matches, so out of scope here):
- `components/conductor/challenge-center-page.vue` — both occurrences carry `shadow-xl`/hover-transition variants instead of the plain `p-5 shadow-sm` shape.
- `components/coloring/coloring-book-studio.vue`'s remaining panels — several use `p-5`/`p-4` **without** `shadow-sm`, which is a different, currently-unnamed surface shape, not `kr-panel-section`.

### How I verified
- `eslint` on all 10 changed files — 0 issues
- `vue-tsc --noEmit` (full project) — 0 errors
- `npm run test:layout-contract` — holds, no new violations
- Diffed each substitution by hand against the file's prior content to confirm byte-equivalence
- Noted 3 of the touched files (`academy-style-detail.vue`, `coloring-book-studio.vue`, `voice-lab-page.vue`) have pre-existing `prettier --check` warnings (long single-line class attributes) — confirmed via `git stash` that these predate this change and aren't introduced by it

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Name the `p-5`/`p-4` (no shadow) rounded-3xl surface still used across several `coloring-book-studio.vue` panels as its own `kr-*` primitive, the same way `kr-panel-section` was approved for the shadow variant — it looks like a distinct, deliberate secondary surface rather than a one-off.

### Notes for reviewer
This is a routine recurring-task slice; interface-vision/t-104 will be re-armed to `ready` in the conductor roadmap once this PR merges.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTaNJiTNHommPmfydddA1w

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTaNJiTNHommPmfydddA1w)_