### PR TITLE
Migrate two academy panels and achievement-popup to kr-panel-section/kr-container

### DIFF
--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -191,7 +191,7 @@
       class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,24rem),1fr))] items-start gap-5"
     >
       <div class="flex min-w-0 flex-col gap-5">
-        <section class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm sm:p-6">
+        <section class="kr-panel-section sm:p-6">
           <p class="flex items-center gap-1.5 text-xs font-black uppercase tracking-[0.16em] text-primary">
             <Icon name="kind-icon:search" class="h-4 w-4" />
             How to spot it
@@ -213,7 +213,7 @@
           </div>
         </section>
 
-        <section class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm sm:p-6">
+        <section class="kr-panel-section sm:p-6">
           <div class="flex flex-wrap items-end justify-between gap-2">
             <div>
               <p class="flex items-center gap-1.5 text-xs font-black uppercase tracking-[0.16em] text-secondary">

--- a/components/achievements/achievement-popup.vue
+++ b/components/achievements/achievement-popup.vue
@@ -8,7 +8,7 @@
     aria-modal="true"
   >
     <div
-      class="pointer-events-auto mx-auto w-full max-w-md overflow-hidden rounded-2xl border border-accent/40 bg-base-100 shadow-2xl shadow-accent/20"
+      class="pointer-events-auto kr-container max-w-md overflow-hidden rounded-2xl border border-accent/40 bg-base-100 shadow-2xl shadow-accent/20"
       @click.stop
     >
       <!-- Coloured top band -->


### PR DESCRIPTION
## Why
interface-vision/t-104 (Conductor, recurring consistency-migration task) slice 35. Continuing the byte-exact class-token migration onto shared `kr-*` primitives.

## Change
Two files, three occurrences, zero geometry/behavior change:

- `components/academy/academy-style-detail.vue`: the two remaining hand-rolled `rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm sm:p-6` section surfaces ("How to spot it" / "Meet the masters") now use `kr-panel-section sm:p-6` — the same primitive this file's other two panels already use (slice 33/34). `sm:p-6` is kept as a utility-layer override on top of the component-layer class's `p-5`, exactly like `kr-panel-section`'s existing precedent.
- `components/achievements/achievement-popup.vue`: the modal content `<div>` (`mx-auto w-full max-w-md ...`) now uses `kr-container max-w-md`, the same substitution pattern established for `password-reset.vue` in slice 30 — `kr-container`'s own `mx-auto w-full max-w-6xl` plus the appended `max-w-md` utility override reproduces the exact prior computed styles.

Repo-wide search confirmed these are the only remaining byte-exact candidates for these two primitives (kr-panel/-flat/-muted codemod reports 0 remaining candidates; the only other `rounded-3xl`+`p-5`+`shadow-sm` hit is `challenge-center-page.vue`, already explicitly out of scope — hover/shadow-xl variants, not byte-exact).

## Verification
- `npx eslint` on both changed files: clean.
- `npm run test:layout-contract`: holds, no new violations (neither changed element is a page root).
- `npm run test` (`vue-tsc --noEmit`): clean.

## Flags for Reviewer
Pure `class="..."` string edits, no logic/template structure changes. Low risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQMw1tptg3z2JeKKXeqGi9)_