### PR TITLE
add safe kr-panel-section migration codemod

### DIFF
--- a/utils/scripts/codemods/kr_panel_section_codemod.py
+++ b/utils/scripts/codemods/kr_panel_section_codemod.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Find or migrate exact hand-rolled kr-panel-section surfaces.
+
+Dry-run is the default. Pass --write to update matching Vue files in place.
+Only the approved rounded-3xl/base-100/shadow-sm shape is touched; variants
+with different borders, backgrounds, or shadows are intentionally ignored.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+BASE_TOKENS = {
+    "rounded-3xl",
+    "border",
+    "border-base-300",
+    "bg-base-100",
+    "shadow-sm",
+}
+
+
+def migrate_classes(classes: str) -> str | None:
+    tokens = classes.split()
+    if "kr-panel-section" in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    # kr-panel-section owns p-5. Preserve a deliberate smaller base padding override,
+    # while removing a redundant p-5 if the hand-rolled surface carried one.
+    remaining = [token for token in remaining if token != "p-5"]
+    return " ".join(["kr-panel-section", *remaining])
+
+
+def migrate_text(text: str) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1))
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        text = path.read_text(encoding="utf-8")
+        migrated, count = migrate_text(text)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            path.write_text(migrated, encoding="utf-8")
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-panel-section {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a dry-run-by-default codemod for the newly approved `kr-panel-section` primitive
- match only the approved rounded-3xl / base-100 / border / shadow-sm token set
- preserve deliberate padding overrides and require `--write` before modifying files

Conductor: interface-vision/t-104
Session: `openai-scheduled-20260902T121410Z-interface-vision-t104-q4v8`

No production data or runtime behavior changes.