### PR TITLE
model-builder/t-029 cycle 81: fix SOURCE_TYPES blurb drift from OUTPUT_CATALOG

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -929,6 +929,12 @@ jobs:
       - name: Model Builder "Start build run" loading-state guard contract
         run: npm run test:model-builder-start-run-loading-guard
 
+      - name: Model Builder source-blurb coverage guard checker self-test
+        run: npm run test:model-builder-source-blurb-coverage-guard-selftest
+
+      - name: Model Builder source-blurb coverage guard contract
+        run: npm run test:model-builder-source-blurb-coverage-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -408,6 +408,8 @@
     "test:model-builder-item-panel-reject-wiring-guard": "tsx utils/scripts/verifyModelBuilderItemPanelRejectWiringGuard.ts",
     "test:model-builder-start-run-loading-guard-selftest": "tsx utils/scripts/verifyModelBuilderStartRunLoadingGuard.test.ts",
     "test:model-builder-start-run-loading-guard": "tsx utils/scripts/verifyModelBuilderStartRunLoadingGuard.ts",
+    "test:model-builder-source-blurb-coverage-guard-selftest": "tsx utils/scripts/verifyModelBuilderSourceBlurbCoverageGuard.test.ts",
+    "test:model-builder-source-blurb-coverage-guard": "tsx utils/scripts/verifyModelBuilderSourceBlurbCoverageGuard.ts",
     "test:storybook-active-story-resume-guard": "npx tsx utils/scripts/verifyStorybookActiveStoryResumeGuard.ts",
     "test:storybook-answer-input-preservation-guard": "node utils/scripts/verifyStorybookAnswerInputPreservationGuard.mjs",
     "test:storybook-answer-rollback-guard": "node utils/scripts/verifyStorybookAnswerRollbackGuard.mjs",

--- a/stores/helpers/modelBuilderRecipes.ts
+++ b/stores/helpers/modelBuilderRecipes.ts
@@ -148,7 +148,7 @@ export const SOURCE_TYPES: SourceTypeConfig[] = [
     subtitleField: 'class',
     defaultRecipe: 'character-deck',
     recipes: ['character-deck', 'art-upgrade', 'relationship-expansion'],
-    blurb: 'Full character deck, signature rewards, or an art upgrade.',
+    blurb: 'Full character deck, signature rewards, scenarios, or an art upgrade.',
   },
   {
     key: 'Bot',
@@ -212,7 +212,7 @@ export const SOURCE_TYPES: SourceTypeConfig[] = [
     subtitleField: 'rewardType',
     defaultRecipe: 'reward-deck',
     recipes: ['reward-deck', 'art-upgrade', 'relationship-expansion'],
-    blurb: 'Reward deck with type-aware art and optional 3D reference.',
+    blurb: 'Reward deck with type-aware art, optional 3D reference, or expand into characters.',
   },
   {
     key: 'Scenario',
@@ -224,7 +224,7 @@ export const SOURCE_TYPES: SourceTypeConfig[] = [
     subtitleField: 'difficulty',
     defaultRecipe: 'art-upgrade',
     recipes: ['art-upgrade', 'relationship-expansion'],
-    blurb: 'Art upgrade, or expand into cast characters and rewards.',
+    blurb: 'Art upgrade, or expand into cast characters.',
   },
 ]
 

--- a/utils/scripts/verifyModelBuilderSourceBlurbCoverageGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderSourceBlurbCoverageGuard.test.ts
@@ -1,0 +1,163 @@
+// /utils/scripts/verifyModelBuilderSourceBlurbCoverageGuard.test.ts
+//
+// Regression test for checkSourceBlurbCoverageGuard() in
+// verifyModelBuilderSourceBlurbCoverageGuard.ts (model-builder/t-029, cycle
+// 81). Exercises the real check against a synthetic modelBuilderRecipes.ts-
+// shaped fixture covering: the actual pre-fix drift found in the real file
+// (Scenario falsely promising "rewards", Character omitting "scenarios",
+// Reward omitting "characters"), the fixed shape, and a source type with no
+// relationship-expansion recipe at all (must be skipped entirely).
+import assert from 'node:assert/strict'
+
+import {
+  checkSourceBlurbCoverageGuard,
+  extractOutputCatalogEntries,
+  extractSourceTypeEntries,
+} from './verifyModelBuilderSourceBlurbCoverageGuard.js'
+
+const OUTPUT_CATALOG_BLOCK = `
+export const OUTPUT_CATALOG: BuildOutputConfig[] = [
+  { key: 'primary-image', label: 'Primary image', recipe: 'art-upgrade', action: 'ASSET_ONLY', generation: 'image', description: 'x', defaultOn: true },
+  { key: 'expand-characters', label: 'Characters', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', quantity: true, description: 'x', sourceTypes: ['Dream', 'Reward', 'Scenario'] },
+  { key: 'expand-rewards', label: 'Rewards', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', quantity: true, description: 'x', sourceTypes: ['Dream', 'Character'] },
+  { key: 'expand-scenarios', label: 'Scenarios', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', quantity: true, description: 'x', sourceTypes: ['Dream', 'Character'] },
+  { key: 'expand-narrator-bot', label: 'Narrator bot', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', description: 'x', sourceTypes: ['Dream'] },
+  { key: 'expand-manager-bot', label: 'Manager bot', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', description: 'x', sourceTypes: ['Project'] },
+  { key: 'expand-signature-rewards', label: 'Signature rewards', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', quantity: true, description: 'x', sourceTypes: ['Character'] },
+]
+`
+
+function fixtureWith(sourceTypesBlock: string): string {
+  return `
+export const SOURCE_TYPES: SourceTypeConfig[] = [
+${sourceTypesBlock}
+]
+${OUTPUT_CATALOG_BLOCK}
+`
+}
+
+const BUGGY_FIXTURE = fixtureWith(`
+  {
+    key: 'Character',
+    label: 'Character',
+    defaultRecipe: 'character-deck',
+    recipes: ['character-deck', 'art-upgrade', 'relationship-expansion'],
+    blurb: 'Full character deck, signature rewards, or an art upgrade.',
+  },
+  {
+    key: 'Reward',
+    label: 'Reward',
+    defaultRecipe: 'reward-deck',
+    recipes: ['reward-deck', 'art-upgrade', 'relationship-expansion'],
+    blurb: 'Reward deck with type-aware art and optional 3D reference.',
+  },
+  {
+    key: 'Scenario',
+    label: 'Scenario',
+    defaultRecipe: 'art-upgrade',
+    recipes: ['art-upgrade', 'relationship-expansion'],
+    blurb: 'Art upgrade, or expand into cast characters and rewards.',
+  },
+  {
+    key: 'Bot',
+    label: 'Bot',
+    defaultRecipe: 'character-deck',
+    recipes: ['character-deck', 'art-upgrade'],
+    blurb: 'Character deck with expressions, transitions, and an art upgrade.',
+  },
+`)
+
+const FIXED_FIXTURE = fixtureWith(`
+  {
+    key: 'Character',
+    label: 'Character',
+    defaultRecipe: 'character-deck',
+    recipes: ['character-deck', 'art-upgrade', 'relationship-expansion'],
+    blurb: 'Full character deck, signature rewards, scenarios, or an art upgrade.',
+  },
+  {
+    key: 'Reward',
+    label: 'Reward',
+    defaultRecipe: 'reward-deck',
+    recipes: ['reward-deck', 'art-upgrade', 'relationship-expansion'],
+    blurb: 'Reward deck with type-aware art, optional 3D reference, or expand into characters.',
+  },
+  {
+    key: 'Scenario',
+    label: 'Scenario',
+    defaultRecipe: 'art-upgrade',
+    recipes: ['art-upgrade', 'relationship-expansion'],
+    blurb: 'Art upgrade, or expand into cast characters.',
+  },
+  {
+    key: 'Bot',
+    label: 'Bot',
+    defaultRecipe: 'character-deck',
+    recipes: ['character-deck', 'art-upgrade'],
+    blurb: 'Character deck with expressions, transitions, and an art upgrade.',
+  },
+`)
+
+// --- extraction helpers ------------------------------------------------
+
+const parsedSources = extractSourceTypeEntries(FIXED_FIXTURE)
+assert.equal(parsedSources.length, 4, 'expected 4 parsed SOURCE_TYPES entries')
+assert.deepEqual(parsedSources.find((s) => s.key === 'Character')?.recipes, [
+  'character-deck',
+  'art-upgrade',
+  'relationship-expansion',
+])
+
+const parsedOutputs = extractOutputCatalogEntries(FIXED_FIXTURE)
+assert.equal(
+  parsedOutputs.length,
+  7,
+  'expected 7 parsed OUTPUT_CATALOG entries',
+)
+assert.deepEqual(
+  parsedOutputs.find((o) => o.key === 'expand-rewards')?.sourceTypes,
+  ['Dream', 'Character'],
+)
+assert.equal(
+  parsedOutputs.find((o) => o.key === 'primary-image')?.sourceTypes,
+  null,
+)
+
+// --- the real check ------------------------------------------------------
+
+const buggyErrors = checkSourceBlurbCoverageGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  3,
+  'expected the pre-fix shape to raise exactly 3 errors -- Character omits ' +
+    '"scenario", Reward omits "character", Scenario falsely promises ' +
+    `"reward" -- got ${buggyErrors.length}: ${JSON.stringify(buggyErrors)}`,
+)
+// Order follows SOURCE_TYPES array order: Character (omits scenario), then
+// Reward (omits character), then Scenario (false-promises reward).
+assert.ok(
+  buggyErrors.some((e) => e.includes('Character\'s blurb omits "scenario"')),
+  `expected a Character/scenario omission error, got: ${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes('Reward\'s blurb omits "character"')),
+  `expected a Reward/character omission error, got: ${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes('Scenario\'s blurb mentions "reward"')),
+  `expected a Scenario/reward false-promise error, got: ${JSON.stringify(buggyErrors)}`,
+)
+
+const fixedErrors = checkSourceBlurbCoverageGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+console.log(
+  'Model Builder source-blurb coverage guard checker verified: flags the ' +
+    'real pre-fix drift (Character omitting scenarios, Scenario falsely ' +
+    'promising rewards), clears the fixed shape, and correctly skips a ' +
+    'source type (Bot) with no relationship-expansion recipe.',
+)

--- a/utils/scripts/verifyModelBuilderSourceBlurbCoverageGuard.ts
+++ b/utils/scripts/verifyModelBuilderSourceBlurbCoverageGuard.ts
@@ -75,9 +75,9 @@ export function extractSourceTypeEntries(
     const blurbMatch = obj.match(/blurb:\s*'([^']*)'/)
     if (!keyMatch || !recipesMatch || !blurbMatch) continue
     entries.push({
-      key: keyMatch[1]!,
-      recipes: [...recipesMatch[1]!.matchAll(/'([\w-]+)'/g)].map((m) => m[1]!),
-      blurb: blurbMatch[1]!,
+      key: keyMatch![1]!,
+      recipes: [...recipesMatch![1]!.matchAll(/'([\w-]+)'/g)].map((m) => m[1]!),
+      blurb: blurbMatch![1]!,
     })
   }
   return entries
@@ -105,9 +105,13 @@ export function extractOutputCatalogEntries(
     if (!keyMatch || !recipeMatch) continue
     const sourceTypesMatch = obj.match(/sourceTypes:\s*\[([^\]]*)\]/)
     const sourceTypes = sourceTypesMatch
-      ? [...sourceTypesMatch[1]!.matchAll(/'(\w+)'/g)].map((m) => m[1]!)
+      ? [...sourceTypesMatch![1]!.matchAll(/'(\w+)'/g)].map((m) => m[1]!)
       : null
-    entries.push({ key: keyMatch[1]!, recipe: recipeMatch[1]!, sourceTypes })
+    entries.push({
+      key: keyMatch![1]!,
+      recipe: recipeMatch![1]!,
+      sourceTypes,
+    })
   }
   return entries
 }

--- a/utils/scripts/verifyModelBuilderSourceBlurbCoverageGuard.ts
+++ b/utils/scripts/verifyModelBuilderSourceBlurbCoverageGuard.ts
@@ -1,0 +1,210 @@
+// /utils/scripts/verifyModelBuilderSourceBlurbCoverageGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 81) -- SOURCE_TYPES' `blurb`
+// strings (stores/helpers/modelBuilderRecipes.ts) are hand-written prose
+// describing what a source type's "relationship-expansion" recipe actually
+// offers, rendered verbatim to the user by
+// components/model-builder/model-builder-source-picker.vue
+// (`{{ activeType.blurb }}`). Nothing ties that prose to OUTPUT_CATALOG, so
+// it silently drifted out of sync with the real eligibility rules
+// (BuildOutputConfig.sourceTypes, the same source getOutputsForRecipe()
+// filters by):
+//
+// - Scenario's blurb promised "expand into cast characters and rewards", but
+//   'expand-rewards'.sourceTypes is ['Dream', 'Character'] -- Scenario was
+//   never eligible, so a Scenario-source relationship-expansion run never
+//   actually offered a Rewards output. A false promise.
+// - Character's blurb ("signature rewards, or an art upgrade") never
+//   mentioned that 'expand-scenarios' also lists Character as an eligible
+//   source -- a real, silently-omitted capability.
+// - Reward's blurb didn't mention relationship-expansion at all, though
+//   'expand-characters'.sourceTypes includes Reward -- another omission.
+//
+// This derives, from OUTPUT_CATALOG itself, which of the six relationship-
+// expansion outputs each source type can actually reach, and asserts each
+// output's keyword is present in that source's blurb when available and
+// absent when not -- so a future OUTPUT_CATALOG.sourceTypes edit that isn't
+// mirrored in the prose fails loudly here instead of shipping a silently
+// wrong claim to the picker UI. The exclusion side is skipped for a source
+// type's own name (e.g. Character's blurb legitimately says "character
+// deck" even where expand-characters itself is not Character-eligible) --
+// deliberately scoped to this one drift shape, mirroring this project's
+// other narrow textual guards over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const MODEL_BUILDER_RECIPES_PATH = join(
+  repositoryRoot,
+  'stores/helpers/modelBuilderRecipes.ts',
+)
+
+interface SourceTypeEntry {
+  key: string
+  recipes: string[]
+  blurb: string
+}
+
+interface OutputCatalogEntry {
+  key: string
+  recipe: string
+  sourceTypes: string[] | null
+}
+
+// Every entry object literal in SOURCE_TYPES -- key, recipes[], blurb.
+export function extractSourceTypeEntries(
+  recipesFileContent: string,
+): SourceTypeEntry[] {
+  const match = recipesFileContent.match(
+    /SOURCE_TYPES:\s*SourceTypeConfig\[\]\s*=\s*\[([\s\S]*?)\n\]\n/,
+  )
+  if (!match) {
+    throw new Error(
+      'Could not find SOURCE_TYPES array literal in modelBuilderRecipes.ts ' +
+        '-- has its shape changed?',
+    )
+  }
+  const entries: SourceTypeEntry[] = []
+  for (const objMatch of match[1]!.matchAll(/\{(?:[^{}]|\{[^{}]*\})*\}/g)) {
+    const obj = objMatch[0]
+    const keyMatch = obj.match(/key:\s*'(\w+)'/)
+    const recipesMatch = obj.match(/recipes:\s*\[([^\]]*)\]/)
+    const blurbMatch = obj.match(/blurb:\s*'([^']*)'/)
+    if (!keyMatch || !recipesMatch || !blurbMatch) continue
+    entries.push({
+      key: keyMatch[1]!,
+      recipes: [...recipesMatch[1]!.matchAll(/'([\w-]+)'/g)].map((m) => m[1]!),
+      blurb: blurbMatch[1]!,
+    })
+  }
+  return entries
+}
+
+// Every entry object literal in OUTPUT_CATALOG -- key, recipe, sourceTypes
+// (null when the output carries no sourceTypes restriction).
+export function extractOutputCatalogEntries(
+  recipesFileContent: string,
+): OutputCatalogEntry[] {
+  const match = recipesFileContent.match(
+    /OUTPUT_CATALOG:\s*BuildOutputConfig\[\]\s*=\s*\[([\s\S]*?)\n\]/,
+  )
+  if (!match) {
+    throw new Error(
+      'Could not find OUTPUT_CATALOG array literal in modelBuilderRecipes.ts ' +
+        '-- has its shape changed?',
+    )
+  }
+  const entries: OutputCatalogEntry[] = []
+  for (const objMatch of match[1]!.matchAll(/\{[^{}]*\}/g)) {
+    const obj = objMatch[0]
+    const keyMatch = obj.match(/key:\s*'([\w-]+)'/)
+    const recipeMatch = obj.match(/recipe:\s*'([\w-]+)'/)
+    if (!keyMatch || !recipeMatch) continue
+    const sourceTypesMatch = obj.match(/sourceTypes:\s*\[([^\]]*)\]/)
+    const sourceTypes = sourceTypesMatch
+      ? [...sourceTypesMatch[1]!.matchAll(/'(\w+)'/g)].map((m) => m[1]!)
+      : null
+    entries.push({ key: keyMatch[1]!, recipe: recipeMatch[1]!, sourceTypes })
+  }
+  return entries
+}
+
+// The six relationship-expansion outputs, each paired with the keyword its
+// availability should control in a source type's blurb prose. 'reward' and
+// 'signature' are kept separate so expand-rewards and expand-signature-
+// rewards drift independently -- a source eligible for only one of them
+// still needs its own keyword covered.
+const RELATIONSHIP_EXPANSION_KEYWORDS: {
+  outputKey: string
+  keyword: string
+}[] = [
+  { outputKey: 'expand-characters', keyword: 'character' },
+  { outputKey: 'expand-rewards', keyword: 'reward' },
+  { outputKey: 'expand-scenarios', keyword: 'scenario' },
+  { outputKey: 'expand-narrator-bot', keyword: 'narrator' },
+  { outputKey: 'expand-manager-bot', keyword: 'manager' },
+  { outputKey: 'expand-signature-rewards', keyword: 'signature' },
+]
+
+// A source type's own name legitimately appears in its blurb for reasons
+// unrelated to relationship-expansion eligibility (e.g. Character's "Full
+// character deck" even when expand-characters itself excludes Character) --
+// skip the exclusion (false-promise) side of the check for these.
+const SELF_KEYWORDS: Record<string, string> = {
+  Character: 'character',
+  Reward: 'reward',
+  Scenario: 'scenario',
+}
+
+export function checkSourceBlurbCoverageGuard(
+  recipesFileContent: string,
+): string[] {
+  const sourceTypes = extractSourceTypeEntries(recipesFileContent)
+  const outputs = extractOutputCatalogEntries(recipesFileContent)
+  const errors: string[] = []
+
+  for (const source of sourceTypes) {
+    if (!source.recipes.includes('relationship-expansion')) continue
+    const blurb = source.blurb.toLowerCase()
+    const selfKeyword = SELF_KEYWORDS[source.key]
+
+    for (const { outputKey, keyword } of RELATIONSHIP_EXPANSION_KEYWORDS) {
+      const output = outputs.find(
+        (o) => o.key === outputKey && o.recipe === 'relationship-expansion',
+      )
+      if (!output) continue
+      const available =
+        !output.sourceTypes || output.sourceTypes.includes(source.key)
+      const mentioned = blurb.includes(keyword)
+
+      if (available && !mentioned) {
+        errors.push(
+          `${source.key}'s blurb omits "${keyword}" but '${outputKey}' is ` +
+            `an eligible relationship-expansion output for it (sourceTypes ` +
+            `${output.sourceTypes ? JSON.stringify(output.sourceTypes) : 'unrestricted'}) -- ` +
+            'the picker UI never tells the user this expansion is actually ' +
+            `available. Current blurb: "${source.blurb}"`,
+        )
+      } else if (!available && mentioned && keyword !== selfKeyword) {
+        errors.push(
+          `${source.key}'s blurb mentions "${keyword}" but '${outputKey}' ` +
+            `does not list ${source.key} in its sourceTypes ` +
+            `(${output.sourceTypes ? JSON.stringify(output.sourceTypes) : 'unrestricted'}) -- ` +
+            'a false promise: the picker UI tells the user this expansion ' +
+            `is available, but it never appears. Current blurb: "${source.blurb}"`,
+        )
+      }
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(MODEL_BUILDER_RECIPES_PATH, 'utf8')
+  const errors = checkSourceBlurbCoverageGuard(content)
+
+  if (errors.length) {
+    console.error(
+      `Model Builder source-blurb coverage guard failed: ${errors.length} ` +
+        'SOURCE_TYPES blurb(s) disagree with OUTPUT_CATALOG relationship-' +
+        'expansion eligibility:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder source-blurb coverage guard passed: every SOURCE_TYPES ' +
+      'blurb mentioning a relationship-expansion output agrees with what ' +
+      "OUTPUT_CATALOG's sourceTypes actually make eligible.",
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
model-builder/t-029: Polish and upgrade Model Builder front-end surface (kind: software, recurring, cycle 81)

### What changed / what I produced
`stores/helpers/modelBuilderRecipes.ts`'s `SOURCE_TYPES[].blurb` strings are hand-written prose describing what a source type's `relationship-expansion` recipe offers, rendered verbatim to the user by `model-builder-source-picker.vue` (`{{ activeType.blurb }}`). Nothing ties that prose to `OUTPUT_CATALOG`, so it had silently drifted:

- **Scenario** promised "expand into cast characters **and rewards**", but `expand-rewards`.sourceTypes is `['Dream', 'Character']` — Scenario was never eligible. A false promise the picker UI made to every user who picked a Scenario source.
- **Character** omitted that `expand-scenarios` also lists Character as an eligible source — a real, silently-omitted capability.
- **Reward** didn't mention relationship-expansion at all, though `expand-characters`.sourceTypes includes Reward — another omission.

Fixed all three blurbs, and added `verifyModelBuilderSourceBlurbCoverageGuard.ts` (+ `.test.ts`), which derives each source type's actual relationship-expansion eligibility from `OUTPUT_CATALOG` and asserts the blurb text agrees with it in both directions (present when eligible, absent when not — skipping a source type's own name, since e.g. Character's blurb legitimately says "character deck" for unrelated reasons). Wired into `package.json` and `contract-tests.yml` per this task's established convention.

### How I verified
- `npx eslint` on all 5 changed files: clean
- `npx vue-tsc --noEmit` repo-wide: clean (exit 0)
- All 163 `test:model-builder-*` npm scripts pass (161 prior + this cycle's 2 new)
- `npm run test:layout-contract`: holds at 207 baseline, no new violations
- `npx prettier --check` on the changed files: clean
- `git diff --stat`: scoped to exactly 5 files, `modelBuilderRecipes.ts`'s own diff is 3 lines changed (deliberately did **not** run `prettier --write` across that whole file — it predates this repo's current prettier formatting and CI doesn't enforce prettier, so a blanket reformat would have produced a ~600-line unrelated diff; reverted that and hand-edited just the 3 blurb lines instead)

### Stakes
reversible

### Flags for Reviewer
- None

### Kaizen suggestion
`rejectStage`'s optional note is still fully write-only per an earlier cycle's own kaizen note — unrelated to this cycle, still open for a future one. For this cycle's own area: SOURCE_TYPES' `label`/`plural`/`icon` fields have no analogous drift guard, but they're far less likely to silently rot since they don't encode cross-file eligibility logic the way `blurb` did.

### Notes for reviewer
Recurring task (model-builder/t-029) — re-arming to `ready` in the companion conductor PR after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128rhDCQeremSiozLupnNQB

---
_Generated by [Claude Code](https://claude.ai/code/session_0128rhDCQeremSiozLupnNQB)_