### PR TITLE
interface-vision/t-104 slice 37: migrate academy gallery-wall panel to kr-panel-section

### DIFF
--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -138,7 +138,7 @@
 
     <section
       v-if="!compact && lesson.exampleWorks?.length"
-      class="rounded-3xl border border-base-300 bg-base-100 p-4 shadow-sm sm:p-5"
+      class="kr-panel-section p-4 sm:p-5"
     >
       <div class="mb-4 flex flex-wrap items-end justify-between gap-2">
         <div>


### PR DESCRIPTION
## Summary
- migrate `academy-style-detail.vue`'s "Gallery wall" section to the approved `kr-panel-section` primitive
- preserve the existing responsive `p-4 sm:p-5` geometry via explicit overrides (same pattern as slice 36, #2331)

## Scope
One Vue file, one class substitution, no behavior/data/schema changes.

## Skipped this slice (real geometry risk, not byte-equivalent)
- `academy-style-detail.vue`'s compact preview `<section>` and `coloring-book-page.vue`'s `<details>` wrapper: neither carries its own padding today (children own the padding), so migrating would add unopposed `p-5` on top of existing child padding.
- `academy-styles-browser.vue`'s empty-state panel: `px-4` only, no vertical padding, `min-h-40` flex-centered — `kr-panel-section`'s `p-5` would add new vertical padding, changing the min-height-driven box.
- `challenge-center-page.vue`'s card grid item: already excluded per slice 34's note (hover/shadow-xl variant).

## Verification
- `npx eslint` on the changed file: clean
- `npm run test` (`vue-tsc --noEmit`): clean
- `npm run test:layout-contract`: holds at existing 207-violation baseline (unchanged)

Conductor: `interface-vision/t-104`
Session: `claude-web-20260902T1427Z-iv-t104`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P73vipy2cQ8RryhH7Nhm8L

---
_Generated by [Claude Code](https://claude.ai/code/session_01P73vipy2cQ8RryhH7Nhm8L)_