### PR TITLE
model-builder/t-029 cycle 82: icon coverage guard for BUILD_STAGES/SOURCE_TYPES/RECIPES

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -935,6 +935,12 @@ jobs:
       - name: Model Builder source-blurb coverage guard contract
         run: npm run test:model-builder-source-blurb-coverage-guard
 
+      - name: Model Builder icon coverage guard checker self-test
+        run: npm run test:model-builder-icon-coverage-guard-selftest
+
+      - name: Model Builder icon coverage guard contract
+        run: npm run test:model-builder-icon-coverage-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -410,6 +410,8 @@
     "test:model-builder-start-run-loading-guard": "tsx utils/scripts/verifyModelBuilderStartRunLoadingGuard.ts",
     "test:model-builder-source-blurb-coverage-guard-selftest": "tsx utils/scripts/verifyModelBuilderSourceBlurbCoverageGuard.test.ts",
     "test:model-builder-source-blurb-coverage-guard": "tsx utils/scripts/verifyModelBuilderSourceBlurbCoverageGuard.ts",
+    "test:model-builder-icon-coverage-guard-selftest": "tsx utils/scripts/verifyModelBuilderIconCoverageGuard.test.ts",
+    "test:model-builder-icon-coverage-guard": "tsx utils/scripts/verifyModelBuilderIconCoverageGuard.ts",
     "test:storybook-active-story-resume-guard": "npx tsx utils/scripts/verifyStorybookActiveStoryResumeGuard.ts",
     "test:storybook-answer-input-preservation-guard": "node utils/scripts/verifyStorybookAnswerInputPreservationGuard.mjs",
     "test:storybook-answer-rollback-guard": "node utils/scripts/verifyStorybookAnswerRollbackGuard.mjs",

--- a/utils/scripts/verifyModelBuilderIconCoverageGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderIconCoverageGuard.test.ts
@@ -1,0 +1,126 @@
+// /utils/scripts/verifyModelBuilderIconCoverageGuard.test.ts
+//
+// Regression test for checkIconCoverageGuard()/extractIconEntries() in
+// verifyModelBuilderIconCoverageGuard.ts (model-builder/t-029, cycle 82).
+// Exercises the real check against a synthetic modelBuilderRecipes.ts-shaped
+// fixture covering: a typo'd icon name, a renamed/removed icon, and the
+// clean shape with every icon present.
+import assert from 'node:assert/strict'
+
+import {
+  checkIconCoverageGuard,
+  extractIconEntries,
+} from './verifyModelBuilderIconCoverageGuard.js'
+
+const AVAILABLE_ICONS = new Set([
+  'lightbulb',
+  'list',
+  'sparkles',
+  'check',
+  'blueprint',
+  'user',
+  'robot',
+  'megaphone',
+  'trophy',
+  'link',
+])
+
+function fixture(options: {
+  stageIcon?: string
+  sourceIcon?: string
+  recipeIcon?: string
+}): string {
+  const stageIcon = options.stageIcon ?? 'lightbulb'
+  const sourceIcon = options.sourceIcon ?? 'blueprint'
+  const recipeIcon = options.recipeIcon ?? 'megaphone'
+  return `
+export const BUILD_STAGES: BuildStageConfig[] = [
+  { key: 'PITCH', label: 'Pitch', short: 'Pitch', description: 'x', icon: 'kind-icon:${stageIcon}' },
+  { key: 'COMMIT', label: 'Commit', short: 'Commit', description: 'x', icon: 'kind-icon:check' },
+]
+
+export const SOURCE_TYPES: SourceTypeConfig[] = [
+  {
+    key: 'Project',
+    label: 'Project',
+    plural: 'Projects',
+    icon: 'kind-icon:${sourceIcon}',
+    endpoint: '/api/projects',
+    titleField: 'title',
+    defaultRecipe: 'marketing-deck',
+    recipes: ['marketing-deck'],
+    blurb: 'x',
+  },
+]
+
+export const RECIPES: RecipeConfig[] = [
+  {
+    key: 'marketing-deck',
+    label: 'Marketing Deck',
+    icon: 'kind-icon:${recipeIcon}',
+    summary: 'x',
+    sourceTypes: ['Project'],
+  },
+]
+`
+}
+
+// --- extraction ------------------------------------------------------------
+
+const cleanFixture = fixture({})
+const entries = extractIconEntries(cleanFixture)
+assert.equal(
+  entries.length,
+  4,
+  `expected 4 parsed icon entries, got ${entries.length}`,
+)
+assert.deepEqual(
+  entries.map((e) => `${e.array}:${e.key}:${e.icon}`),
+  [
+    'BUILD_STAGES:PITCH:lightbulb',
+    'BUILD_STAGES:COMMIT:check',
+    'SOURCE_TYPES:Project:blueprint',
+    'RECIPES:marketing-deck:megaphone',
+  ],
+)
+
+// --- the real check ----------------------------------------------------
+
+const cleanErrors = checkIconCoverageGuard(entries, AVAILABLE_ICONS)
+assert.equal(
+  cleanErrors.length,
+  0,
+  `expected the clean shape to raise no errors, got: ${JSON.stringify(cleanErrors)}`,
+)
+
+const typoEntries = extractIconEntries(fixture({ sourceIcon: 'bluepirnt' }))
+const typoErrors = checkIconCoverageGuard(typoEntries, AVAILABLE_ICONS)
+assert.equal(
+  typoErrors.length,
+  1,
+  `expected exactly 1 error for the typo'd source icon, got: ${JSON.stringify(typoErrors)}`,
+)
+assert.ok(
+  typoErrors[0]!.includes("SOURCE_TYPES['Project']") &&
+    typoErrors[0]!.includes('bluepirnt'),
+  `expected the error to name the SOURCE_TYPES Project entry and the typo'd icon, got: ${typoErrors[0]}`,
+)
+
+const multipleMissingEntries = extractIconEntries(
+  fixture({ stageIcon: 'lightbulbb', recipeIcon: 'megaphonee' }),
+)
+const multipleMissingErrors = checkIconCoverageGuard(
+  multipleMissingEntries,
+  AVAILABLE_ICONS,
+)
+assert.equal(
+  multipleMissingErrors.length,
+  2,
+  `expected 2 errors for the two missing icons, got: ${JSON.stringify(multipleMissingErrors)}`,
+)
+
+console.log(
+  'Model Builder icon coverage guard checker verified: parses all three ' +
+    'icon-carrying arrays, passes on the clean shape, and flags a typo in ' +
+    'any of BUILD_STAGES/SOURCE_TYPES/RECIPES individually.',
+)

--- a/utils/scripts/verifyModelBuilderIconCoverageGuard.ts
+++ b/utils/scripts/verifyModelBuilderIconCoverageGuard.ts
@@ -1,0 +1,138 @@
+// /utils/scripts/verifyModelBuilderIconCoverageGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 82) -- BUILD_STAGES,
+// SOURCE_TYPES, and RECIPES (stores/helpers/modelBuilderRecipes.ts) each
+// carry a hand-written `icon: 'kind-icon:<name>'` string, rendered directly
+// by the Model Builder UI (model-builder-source-picker.vue,
+// model-builder-recipe-selector.vue, and the stage stepper) via the
+// `kind-icon` Iconify collection registered in nuxt.config.ts
+// (`prefix: 'kind-icon', dir: './assets/icons'`). Nothing ties that string
+// to the actual icon set: a typo'd or renamed icon silently resolves to a
+// missing/blank glyph in the picker with no error anywhere, the same failure
+// shape this task's own history already hit twice for other hand-typed
+// field names (Bot's stale `botType` subtitleField, Facet's stale `kind`
+// subtitleField -- both cycle 22, both a silent blank rather than a thrown
+// error).
+//
+// This reads every `icon: 'kind-icon:<name>'` literal out of the three
+// arrays and asserts assets/icons/<name>.svg actually exists, so a future
+// rename or typo fails loudly here instead of shipping a blank icon.
+// Deliberately scoped to this one file/collection pairing, mirroring this
+// project's other narrow textual guards over a general-purpose static
+// analyzer (see verifyModelBuilderSourceBlurbCoverageGuard.ts's header for
+// the same rationale).
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const MODEL_BUILDER_RECIPES_PATH = join(
+  repositoryRoot,
+  'stores/helpers/modelBuilderRecipes.ts',
+)
+const ICONS_DIRECTORY = join(repositoryRoot, 'assets/icons')
+
+const ICON_ARRAYS: { name: string; pattern: RegExp }[] = [
+  {
+    name: 'BUILD_STAGES',
+    pattern: /BUILD_STAGES:\s*BuildStageConfig\[\]\s*=\s*\[([\s\S]*?)\n\]\n/,
+  },
+  {
+    name: 'SOURCE_TYPES',
+    pattern: /SOURCE_TYPES:\s*SourceTypeConfig\[\]\s*=\s*\[([\s\S]*?)\n\]\n/,
+  },
+  {
+    name: 'RECIPES',
+    pattern: /RECIPES:\s*RecipeConfig\[\]\s*=\s*\[([\s\S]*?)\n\]\n/,
+  },
+]
+
+export interface IconEntry {
+  array: string
+  key: string
+  icon: string
+}
+
+// Every `{ key: '...', ..., icon: 'kind-icon:...', ... }` entry across the
+// three arrays that carry an `icon` field. Exported so the self-test can
+// exercise it against a synthetic fixture.
+export function extractIconEntries(recipesFileContent: string): IconEntry[] {
+  const entries: IconEntry[] = []
+
+  for (const { name, pattern } of ICON_ARRAYS) {
+    const match = recipesFileContent.match(pattern)
+    if (!match) {
+      throw new Error(
+        `Could not find ${name} array literal in modelBuilderRecipes.ts -- ` +
+          'has its shape changed?',
+      )
+    }
+    for (const objMatch of match[1]!.matchAll(/\{[^{}]*\}/g)) {
+      const obj = objMatch[0]
+      const keyMatch = obj.match(/key:\s*'([\w-]+)'/)
+      const iconMatch = obj.match(/icon:\s*'kind-icon:([\w-]+)'/)
+      if (!keyMatch || !iconMatch) continue
+      entries.push({ array: name, key: keyMatch![1]!, icon: iconMatch![1]! })
+    }
+  }
+
+  return entries
+}
+
+// Checks the real contract: every extracted icon name resolves to a real
+// file in the given available-icons set. Takes the set as a parameter
+// (rather than reading the filesystem directly) so the self-test can
+// exercise the logic against a synthetic set without touching disk.
+export function checkIconCoverageGuard(
+  entries: IconEntry[],
+  availableIcons: Set<string>,
+): string[] {
+  const errors: string[] = []
+
+  for (const entry of entries) {
+    if (!availableIcons.has(entry.icon)) {
+      errors.push(
+        `${entry.array}['${entry.key}'].icon references 'kind-icon:${entry.icon}' ` +
+          `but assets/icons/${entry.icon}.svg does not exist -- the picker/stepper ` +
+          'renders a blank icon instead of erroring anywhere.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(MODEL_BUILDER_RECIPES_PATH, 'utf8')
+  const entries = extractIconEntries(content)
+
+  const availableIcons = new Set(
+    readdirSync(ICONS_DIRECTORY)
+      .filter((file) => file.endsWith('.svg'))
+      .map((file) => file.slice(0, -'.svg'.length)),
+  )
+
+  const errors = checkIconCoverageGuard(entries, availableIcons)
+
+  if (errors.length) {
+    console.error(
+      `Model Builder icon coverage guard failed: ${errors.length} icon ` +
+        'reference(s) in modelBuilderRecipes.ts have no matching svg file:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Model Builder icon coverage guard passed: all ${entries.length} ` +
+      'icon references in BUILD_STAGES/SOURCE_TYPES/RECIPES resolve to a ' +
+      'real assets/icons/*.svg file.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Summary
- Adds `verifyModelBuilderIconCoverageGuard.ts`, which reads every `icon: 'kind-icon:<name>'` literal out of `BUILD_STAGES`, `SOURCE_TYPES`, and `RECIPES` (`stores/helpers/modelBuilderRecipes.ts`) and asserts a matching `assets/icons/<name>.svg` exists.
- A future typo or icon rename now fails loudly in CI instead of silently rendering a blank icon in the source picker / recipe selector / stage stepper — the same failure shape this task already hit twice for other hand-typed field names (Bot's stale `botType` subtitleField, Facet's stale `kind` subtitleField, both cycle 22, per the file's own history).
- All 15 current icon references (4 BUILD_STAGES + 7 SOURCE_TYPES + 4 RECIPES) pass — no existing bug, this is a pure regression guard for the future.
- Wired into `package.json` and `contract-tests.yml` per this task's established convention.

## Verification
- `npm run test:model-builder-icon-coverage-guard-selftest` and `test:model-builder-icon-coverage-guard`: pass.
- `npm run test:model-builder-contract-tests-coverage-guard`: confirms the new scripts are wired into CI.
- All 165 `test:model-builder-*` npm scripts pass (163 prior + 2 new).
- `npx eslint` on both new files: clean.
- `npm run test` (`vue-tsc --noEmit`): clean, repo-wide.
- `npx prettier --check`: clean.
- `npm run test:layout-contract`: holds at existing 207-violation baseline (unchanged).
- `git diff --stat`: scoped to exactly 4 files (2 new, 2 wiring edits).

Conductor: `model-builder/t-029`
Session: `claude-scheduled-20260902T-conductor-modelbuilder-t029`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYBCzTUsUK4hpFyoHh3tte

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYBCzTUsUK4hpFyoHh3tte)_