### PR TITLE
fix(storybook): guard library storage recovery (resubmit)

### DIFF
--- a/stores/helpers/storybookLibraryHelper.ts
+++ b/stores/helpers/storybookLibraryHelper.ts
@@ -164,7 +164,18 @@ export function createStorybookLibraryController(bridge: StorybookLibraryBridge)
           : []
       }
     } catch {
-      localStorage.removeItem(LIBRARY_STORAGE_KEY)
+      // Recovering from a bad read shouldn't itself be able to throw: a
+      // storage-access failure (privacy mode, a strict cookie/site-data
+      // policy, quota exhaustion) can make removeItem() throw the same way
+      // getItem()/setItem() just did, which would otherwise escape this
+      // catch block and break Storybook initialization entirely instead of
+      // just falling back to an empty in-memory library.
+      try {
+        localStorage.removeItem(LIBRARY_STORAGE_KEY)
+      } catch {
+        // Best-effort cleanup only — an empty in-memory library below is
+        // the actual recovery; a stale key left behind isn't harmful.
+      }
       library.value = []
     }
     initialized.value = true


### PR DESCRIPTION
## Summary
Resubmits cycle 52's PR #2337, which was rejected on review for scope: it deleted 86 unrelated lines of pre-existing explanatory comments alongside the actual fix.

This PR is the fix only: wrap `localStorage.removeItem(LIBRARY_STORAGE_KEY)` in its own try/catch inside `storybookLibraryHelper.ts`'s `initialize()` catch block, so a storage-recovery attempt can't itself throw while already handling a storage read failure (privacy mode, a strict site-data policy, quota exhaustion). It now falls back to an empty in-memory library instead of breaking Storybook initialization entirely.

No other lines touched — every existing comment in the file is untouched.

## Verification
- `npx eslint` on the changed file: clean
- `npm run test` (`vue-tsc --noEmit`, repo-wide): clean
- `git diff --stat`: scoped to exactly this one file (12 insertions, 1 deletion — the one catch block)

Conductor: `storybook/t-010`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gu9KhM2Etvc5U1pCxopYGE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu9KhM2Etvc5U1pCxopYGE)_