### PR TITLE
Fix the art-redo prefill: the prompt contract rejects a pile of negations

### DIFF
--- a/components/home/home-object-sheet.vue
+++ b/components/home/home-object-sheet.vue
@@ -381,9 +381,17 @@ const showRedo = computed(
  *
  * The trailing clause is the whole point. Silas: "we get a lot of text focused
  * gens" -- several facet cards came back as pictures of trading cards with
- * garbled lettering printed on them rather than as illustrations, so every
- * manual redo would start by saying exactly this. Saying it by default is what
- * makes the button an expedite rather than an empty box.
+ * garbled lettering printed on them, so every manual redo would start by saying
+ * so. Saying it by default is what makes this an expedite rather than an empty
+ * box.
+ *
+ * SAID ONCE, AND POSITIVELY. The first version of this piled up five negations
+ * ("No text, no lettering, no captions, no watermark, no logo") and the repo's
+ * own prompt contract rejects that with a 422: this engine's negative prompt is
+ * inert, so every one of those words lands in POSITIVE conditioning and asks
+ * for the thing it names. Shipped like that, the button would have failed on
+ * every click. "Unmarked surfaces" states the wanted result instead, which is
+ * what the contract asks for and what actually works.
  */
 const suggestedPrompt = computed(() => {
   const parts = [
@@ -394,9 +402,8 @@ const suggestedPrompt = computed(() => {
     .filter(Boolean)
 
   return (
-    `${parts.join('. ')}. A single illustrated subject, full-frame. ` +
-    'No text, no lettering, no captions, no watermark, no logo, no border, ' +
-    'and not a picture of a card.'
+    `${parts.join('. ')}. A single illustrated subject, full-frame, ` +
+    'unmarked surfaces, edge-to-edge scene with no printed matter in view.'
   )
 })
 


### PR DESCRIPTION
The "Redo art" button I shipped in #2321 would have **failed on every click**, and the reason turns out to explain the problem it was built to solve.

## What happened

Its prefill ended with `No text, no lettering, no captions, no watermark, no logo, no border, and not a picture of a card`. `POST /api/art/enqueue` answers that with a 422:

```
[text-exclusion-pile] 5 text exclusions (No text, no lettering, no captions,
no watermark, no logo) on an engine whose negative prompt is inert, so every
one of those words lands in POSITIVE conditioning. Say it once, or state the
wanted result instead — "unmarked surfaces" beats naming text five times.
```

That isn't just a validation rule. It's the **explanation for the original complaint** — "we get a lot of text focused gens." On this engine, piling up "no text" *asks for text*. My prefill was reproducing the exact failure mode it claimed to prevent.

## The fix

State the wanted result once, positively:

```
… A single illustrated subject, full-frame, unmarked surfaces,
edge-to-edge scene with no printed matter in view.
```

**Verified against the live endpoint**, not just read: the old prefill 422s, the new one is accepted.

## How it was found

By using the feature rather than reviewing it. Queueing the three card-style facet redos Silas asked for hit the same 422 first — the button's own prompt shape, rejected by the server.

Those three are now queued with contract-compliant prompts and are `PENDING`: **Hacker** (ArtJob 18436), **Noir** (18437), **Cozy Undead** (18438). Sugar Glider was left alone — its art was already a real illustration rather than a picture of a card.

One cleanup: verifying the new prefill created a real job against Sugar Glider because `dryRun` isn't honored by that endpoint. Cancelled as 18439 with a reason; the queue is back to the three intended.

## Verification

`prettier` · `eslint` · layout contract (holds) · `vue-tsc` **0 errors** · live 422→accepted check against production

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aNg3fsHLGUGCwiMp25hkA

---
_Generated by [Claude Code](https://claude.ai/code/session_017aNg3fsHLGUGCwiMp25hkA)_