### PR TITLE
model-builder/t-029 cycle 84: source-endpoint coverage guard + fix a Facet coverage gap in the icon guard

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -941,6 +941,12 @@ jobs:
       - name: Model Builder icon coverage guard contract
         run: npm run test:model-builder-icon-coverage-guard
 
+      - name: Model Builder source-endpoint coverage guard checker self-test
+        run: npm run test:model-builder-source-endpoint-coverage-guard-selftest
+
+      - name: Model Builder source-endpoint coverage guard contract
+        run: npm run test:model-builder-source-endpoint-coverage-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -412,6 +412,8 @@
     "test:model-builder-source-blurb-coverage-guard": "tsx utils/scripts/verifyModelBuilderSourceBlurbCoverageGuard.ts",
     "test:model-builder-icon-coverage-guard-selftest": "tsx utils/scripts/verifyModelBuilderIconCoverageGuard.test.ts",
     "test:model-builder-icon-coverage-guard": "tsx utils/scripts/verifyModelBuilderIconCoverageGuard.ts",
+    "test:model-builder-source-endpoint-coverage-guard-selftest": "tsx utils/scripts/verifyModelBuilderSourceEndpointCoverageGuard.test.ts",
+    "test:model-builder-source-endpoint-coverage-guard": "tsx utils/scripts/verifyModelBuilderSourceEndpointCoverageGuard.ts",
     "test:storybook-active-story-resume-guard": "npx tsx utils/scripts/verifyStorybookActiveStoryResumeGuard.ts",
     "test:storybook-answer-input-preservation-guard": "node utils/scripts/verifyStorybookAnswerInputPreservationGuard.mjs",
     "test:storybook-answer-rollback-guard": "node utils/scripts/verifyStorybookAnswerRollbackGuard.mjs",

--- a/utils/scripts/verifyModelBuilderIconCoverageGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderIconCoverageGuard.test.ts
@@ -3,8 +3,10 @@
 // Regression test for checkIconCoverageGuard()/extractIconEntries() in
 // verifyModelBuilderIconCoverageGuard.ts (model-builder/t-029, cycle 82).
 // Exercises the real check against a synthetic modelBuilderRecipes.ts-shaped
-// fixture covering: a typo'd icon name, a renamed/removed icon, and the
-// clean shape with every icon present.
+// fixture covering: a typo'd icon name, a renamed/removed icon, the clean
+// shape with every icon present, and (cycle 84) a leading comment
+// containing literal `{`/`}` characters, which broke the original
+// brace-matching extraction by hiding the real Facet-shaped entry entirely.
 import assert from 'node:assert/strict'
 
 import {
@@ -29,10 +31,12 @@ function fixture(options: {
   stageIcon?: string
   sourceIcon?: string
   recipeIcon?: string
+  sourceLeadingComment?: string
 }): string {
   const stageIcon = options.stageIcon ?? 'lightbulb'
   const sourceIcon = options.sourceIcon ?? 'blueprint'
   const recipeIcon = options.recipeIcon ?? 'megaphone'
+  const sourceLeadingComment = options.sourceLeadingComment ?? ''
   return `
 export const BUILD_STAGES: BuildStageConfig[] = [
   { key: 'PITCH', label: 'Pitch', short: 'Pitch', description: 'x', icon: 'kind-icon:${stageIcon}' },
@@ -40,7 +44,7 @@ export const BUILD_STAGES: BuildStageConfig[] = [
 ]
 
 export const SOURCE_TYPES: SourceTypeConfig[] = [
-  {
+  {${sourceLeadingComment}
     key: 'Project',
     label: 'Project',
     plural: 'Projects',
@@ -117,6 +121,27 @@ assert.equal(
   multipleMissingErrors.length,
   2,
   `expected 2 errors for the two missing icons, got: ${JSON.stringify(multipleMissingErrors)}`,
+)
+
+// A leading comment mentioning a brace-containing path (the real Facet
+// entry's actual shape in modelBuilderRecipes.ts) must not hide the entry
+// that follows it, and the comment's own `{`/`}` characters must not be
+// mistaken for a phantom entry (cycle 84 -- see this file's header note).
+const braceCommentEntries = extractIconEntries(
+  fixture({
+    sourceLeadingComment:
+      '\n    // see server/api/{dreams,scenarios}/[id]/facets.put.ts for context',
+  }),
+)
+assert.equal(
+  braceCommentEntries.length,
+  4,
+  `expected the brace-containing comment not to swallow or duplicate any entry, got: ${JSON.stringify(braceCommentEntries)}`,
+)
+assert.deepEqual(
+  braceCommentEntries.find((e) => e.array === 'SOURCE_TYPES'),
+  { array: 'SOURCE_TYPES', key: 'Project', icon: 'blueprint' },
+  `expected the Project entry to survive a brace-containing leading comment, got: ${JSON.stringify(braceCommentEntries)}`,
 )
 
 console.log(

--- a/utils/scripts/verifyModelBuilderIconCoverageGuard.ts
+++ b/utils/scripts/verifyModelBuilderIconCoverageGuard.ts
@@ -21,6 +21,20 @@
 // project's other narrow textual guards over a general-purpose static
 // analyzer (see verifyModelBuilderSourceBlurbCoverageGuard.ts's header for
 // the same rationale).
+//
+// Fixed (cycle 84) -- extractIconEntries originally split each array's body
+// into per-entry objects with a naive `/\{[^{}]*\}/g` non-nested-brace
+// regex. SOURCE_TYPES' Facet entry carries a leading comment mentioning
+// `server/api/{dreams,scenarios}/...` -- a literal `{`/`}` pair inside prose
+// -- which broke that assumption: the regex matched the comment's
+// `{dreams,scenarios}` as a fake "entry" and skipped the real Facet object
+// entirely, so this guard silently checked only 6 of SOURCE_TYPES' 7 icons
+// (Facet's `kind-icon:gem` was never verified) while still reporting a
+// plausible-looking total. Rewritten to split on `key: '...'` boundaries
+// instead, the same index-based chunking verifyModelBuilderSourceFieldGuard.ts
+// already uses for exactly this reason -- it never looks at brace characters
+// at all, so a comment (or any other free text) containing them can't
+// desynchronize the split.
 import { readFileSync, readdirSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -56,8 +70,11 @@ export interface IconEntry {
 }
 
 // Every `{ key: '...', ..., icon: 'kind-icon:...', ... }` entry across the
-// three arrays that carry an `icon` field. Exported so the self-test can
-// exercise it against a synthetic fixture.
+// three arrays that carry an `icon` field. Splits each array's body on
+// `key: '...'` boundaries (not brace matching -- see the cycle-84 fix note
+// above) so free-text comments containing `{`/`}` can't desynchronize the
+// split. Exported so the self-test can exercise it against a synthetic
+// fixture.
 export function extractIconEntries(recipesFileContent: string): IconEntry[] {
   const entries: IconEntry[] = []
 
@@ -69,13 +86,25 @@ export function extractIconEntries(recipesFileContent: string): IconEntry[] {
           'has its shape changed?',
       )
     }
-    for (const objMatch of match[1]!.matchAll(/\{[^{}]*\}/g)) {
-      const obj = objMatch[0]
-      const keyMatch = obj.match(/key:\s*'([\w-]+)'/)
-      const iconMatch = obj.match(/icon:\s*'kind-icon:([\w-]+)'/)
-      if (!keyMatch || !iconMatch) continue
-      entries.push({ array: name, key: keyMatch![1]!, icon: iconMatch![1]! })
+    const body = match[1]!
+    const keyMatches = [...body.matchAll(/key:\s*'([\w-]+)'/g)]
+    if (!keyMatches.length) {
+      throw new Error(
+        `Found the ${name} array literal but no key: entries inside it -- ` +
+          'has its shape changed?',
+      )
     }
+    keyMatches.forEach((keyMatch, index) => {
+      const start = keyMatch.index!
+      const end =
+        index + 1 < keyMatches.length
+          ? keyMatches[index + 1]!.index!
+          : body.length
+      const chunk = body.slice(start, end)
+      const iconMatch = chunk.match(/icon:\s*'kind-icon:([\w-]+)'/)
+      if (!iconMatch) return
+      entries.push({ array: name, key: keyMatch[1]!, icon: iconMatch[1]! })
+    })
   }
 
   return entries

--- a/utils/scripts/verifyModelBuilderSourceEndpointCoverageGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderSourceEndpointCoverageGuard.test.ts
@@ -1,0 +1,133 @@
+// /utils/scripts/verifyModelBuilderSourceEndpointCoverageGuard.test.ts
+//
+// Regression test for checkSourceEndpointCoverageGuard()/
+// extractSourceEndpointEntries() in
+// verifyModelBuilderSourceEndpointCoverageGuard.ts (model-builder/t-029,
+// cycle 84). Exercises the real check against a synthetic
+// modelBuilderRecipes.ts-shaped fixture covering: a typo'd endpoint, a
+// renamed/removed route, the clean shape with every endpoint present, and a
+// leading comment containing literal `{`/`}` characters (the real Facet
+// entry's actual shape -- see this file's header note).
+import assert from 'node:assert/strict'
+
+import {
+  checkSourceEndpointCoverageGuard,
+  extractSourceEndpointEntries,
+} from './verifyModelBuilderSourceEndpointCoverageGuard.js'
+
+const AVAILABLE_ROUTES = new Set([
+  '/api/projects',
+  '/api/characters',
+  '/api/bots',
+])
+
+function fixture(options: {
+  botEndpoint?: string
+  projectLeadingComment?: string
+}): string {
+  const botEndpoint = options.botEndpoint ?? '/api/bots'
+  const projectLeadingComment = options.projectLeadingComment ?? ''
+  return `
+export const SOURCE_TYPES: SourceTypeConfig[] = [
+  {${projectLeadingComment}
+    key: 'Project',
+    label: 'Project',
+    plural: 'Projects',
+    icon: 'kind-icon:blueprint',
+    endpoint: '/api/projects',
+    titleField: 'title',
+    defaultRecipe: 'marketing-deck',
+    recipes: ['marketing-deck'],
+    blurb: 'x',
+  },
+  {
+    key: 'Bot',
+    label: 'Bot',
+    plural: 'Bots',
+    icon: 'kind-icon:robot',
+    endpoint: '${botEndpoint}',
+    titleField: 'name',
+    defaultRecipe: 'character-deck',
+    recipes: ['character-deck'],
+    blurb: 'x',
+  },
+]
+`
+}
+
+// --- extraction --------------------------------------------------------
+
+const cleanFixture = fixture({})
+const entries = extractSourceEndpointEntries(cleanFixture)
+assert.equal(
+  entries.length,
+  2,
+  `expected 2 parsed endpoint entries, got ${entries.length}`,
+)
+assert.deepEqual(
+  entries.map((e) => `${e.key}:${e.endpoint}`),
+  ['Project:/api/projects', 'Bot:/api/bots'],
+)
+
+// --- the real check ------------------------------------------------------
+
+const routeExists = (endpoint: string): boolean =>
+  AVAILABLE_ROUTES.has(endpoint)
+
+const cleanErrors = checkSourceEndpointCoverageGuard(entries, routeExists)
+assert.equal(
+  cleanErrors.length,
+  0,
+  `expected the clean shape to raise no errors, got: ${JSON.stringify(cleanErrors)}`,
+)
+
+const typoEntries = extractSourceEndpointEntries(
+  fixture({ botEndpoint: '/api/botz' }),
+)
+const typoErrors = checkSourceEndpointCoverageGuard(typoEntries, routeExists)
+assert.equal(
+  typoErrors.length,
+  1,
+  `expected exactly 1 error for the typo'd endpoint, got: ${JSON.stringify(typoErrors)}`,
+)
+assert.ok(
+  typoErrors[0]!.includes("SOURCE_TYPES['Bot']") &&
+    typoErrors[0]!.includes('/api/botz'),
+  `expected the error to name the SOURCE_TYPES Bot entry and the typo'd endpoint, got: ${typoErrors[0]}`,
+)
+
+const renamedEntries = extractSourceEndpointEntries(
+  fixture({ botEndpoint: '/api/robots' }),
+)
+const renamedErrors = checkSourceEndpointCoverageGuard(
+  renamedEntries,
+  routeExists,
+)
+assert.equal(
+  renamedErrors.length,
+  1,
+  `expected exactly 1 error for the renamed-away-from route, got: ${JSON.stringify(renamedErrors)}`,
+)
+
+const braceCommentEntries = extractSourceEndpointEntries(
+  fixture({
+    projectLeadingComment:
+      '\n    // see server/api/{dreams,scenarios}/[id]/facets.put.ts for context',
+  }),
+)
+assert.equal(
+  braceCommentEntries.length,
+  2,
+  `expected the brace-containing comment not to swallow or duplicate any entry, got: ${JSON.stringify(braceCommentEntries)}`,
+)
+assert.deepEqual(
+  braceCommentEntries.map((e) => `${e.key}:${e.endpoint}`),
+  ['Project:/api/projects', 'Bot:/api/bots'],
+  `expected both entries to survive a brace-containing leading comment, got: ${JSON.stringify(braceCommentEntries)}`,
+)
+
+console.log(
+  'Model Builder source-endpoint coverage guard checker verified: parses ' +
+    'SOURCE_TYPES endpoint entries, passes on the clean shape, and flags a ' +
+    'typo or a renamed-away-from route.',
+)

--- a/utils/scripts/verifyModelBuilderSourceEndpointCoverageGuard.ts
+++ b/utils/scripts/verifyModelBuilderSourceEndpointCoverageGuard.ts
@@ -1,0 +1,155 @@
+// /utils/scripts/verifyModelBuilderSourceEndpointCoverageGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 84) -- every SOURCE_TYPES
+// entry (stores/helpers/modelBuilderRecipes.ts) carries a hand-written
+// `endpoint: '/api/<slug>'` string, fetched directly by
+// modelBuilderStore.ts's loadSources() (`performFetch<SourceRecord[]>
+// (config.endpoint)`) whenever a user opens that source type's tab in
+// model-builder-source-picker.vue. Nothing ties that string to a real
+// server route: a typo, a stale path left behind by an API rename, or a
+// route that never had a GET handler in the first place would only be
+// caught the moment a user actually clicks that specific tab -- the same
+// "nothing at compile time or CI time stops a hand-typed field from
+// silently going stale" shape this task's own history has hit repeatedly
+// for other SOURCE_TYPES fields (titleField/subtitleField cycle 22 and 31,
+// blurb cycle 81, icon cycle 82), just one step later in the failure chain:
+// loadSources() does surface a visible "Failed to load <plural>." error
+// rather than rendering blank, but only at click time, in production, per
+// affected source type -- not at PR time, before it ships.
+//
+// This reads every `endpoint: '/api/<slug>'` literal out of SOURCE_TYPES
+// and asserts server/api/<slug>/index.get.ts (Nuxt/Nitro's file-based
+// routing convention for a GET handler on that path) actually exists, so a
+// route rename or typo fails loudly here instead of shipping a source type
+// whose tab silently errors for every user who opens it. Deliberately
+// scoped to this one field/convention pairing, mirroring this project's
+// other narrow textual guards over a general-purpose static analyzer (see
+// verifyModelBuilderIconCoverageGuard.ts's header for the same rationale).
+//
+// Extraction splits SOURCE_TYPES' body on `key: '...'` boundaries rather
+// than brace-matching each entry object -- verifyModelBuilderIconCoverageGuard.ts
+// shipped last cycle with a brace-matching version of this exact split and
+// it silently dropped the Facet entry, because Facet's leading comment
+// mentions `server/api/{dreams,scenarios}/...`, a literal `{`/`}` pair in
+// prose that desynchronized the naive regex (fixed there this same cycle).
+// Written correctly from the start here so the new guard doesn't ship with
+// the identical gap.
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const MODEL_BUILDER_RECIPES_PATH = join(
+  repositoryRoot,
+  'stores/helpers/modelBuilderRecipes.ts',
+)
+const SERVER_API_DIRECTORY = join(repositoryRoot, 'server/api')
+
+export interface SourceEndpointEntry {
+  key: string
+  endpoint: string
+}
+
+// Every `{ key: '...', ..., endpoint: '/api/...', ... }` entry in
+// SOURCE_TYPES. Splits the array body on `key: '...'` boundaries (not brace
+// matching -- see the header note above) so free-text comments containing
+// `{`/`}` can't desynchronize the split. Exported so the self-test can
+// exercise it against a synthetic fixture.
+export function extractSourceEndpointEntries(
+  recipesFileContent: string,
+): SourceEndpointEntry[] {
+  const match = recipesFileContent.match(
+    /SOURCE_TYPES:\s*SourceTypeConfig\[\]\s*=\s*\[([\s\S]*?)\n\]\n/,
+  )
+  if (!match) {
+    throw new Error(
+      'Could not find SOURCE_TYPES array literal in modelBuilderRecipes.ts ' +
+        '-- has its shape changed?',
+    )
+  }
+
+  const body = match[1]!
+  const keyMatches = [...body.matchAll(/key:\s*'(\w+)'/g)]
+  if (!keyMatches.length) {
+    throw new Error(
+      'Found the SOURCE_TYPES array literal but no key: entries inside it ' +
+        '-- has its shape changed?',
+    )
+  }
+
+  const entries: SourceEndpointEntry[] = []
+  keyMatches.forEach((keyMatch, index) => {
+    const start = keyMatch.index!
+    const end =
+      index + 1 < keyMatches.length
+        ? keyMatches[index + 1]!.index!
+        : body.length
+    const chunk = body.slice(start, end)
+    const endpointMatch = chunk.match(/endpoint:\s*'(\/api\/[\w-]+)'/)
+    if (!endpointMatch) return
+    entries.push({ key: keyMatch[1]!, endpoint: endpointMatch[1]! })
+  })
+
+  return entries
+}
+
+// Checks the real contract: every extracted endpoint resolves to a real
+// server/api/<slug>/index.get.ts route file. Takes a `routeExists`
+// predicate (rather than reading the filesystem directly) so the self-test
+// can exercise the logic against a synthetic route set without touching
+// disk.
+export function checkSourceEndpointCoverageGuard(
+  entries: SourceEndpointEntry[],
+  routeExists: (endpoint: string) => boolean,
+): string[] {
+  const errors: string[] = []
+
+  for (const entry of entries) {
+    if (!routeExists(entry.endpoint)) {
+      const slug = entry.endpoint.replace(/^\/api\//, '')
+      errors.push(
+        `SOURCE_TYPES['${entry.key}'].endpoint = '${entry.endpoint}' has no ` +
+          `matching server/api/${slug}/index.get.ts route -- loadSources() ` +
+          `will fail (a visible "Failed to load ..." error) for every user ` +
+          `who opens the ${entry.key} source tab.`,
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(MODEL_BUILDER_RECIPES_PATH, 'utf8')
+  const entries = extractSourceEndpointEntries(content)
+
+  const routeExists = (endpoint: string): boolean => {
+    const slug = endpoint.replace(/^\/api\//, '')
+    return existsSync(join(SERVER_API_DIRECTORY, slug, 'index.get.ts'))
+  }
+
+  const errors = checkSourceEndpointCoverageGuard(entries, routeExists)
+
+  if (errors.length) {
+    console.error(
+      `Model Builder source-endpoint coverage guard failed: ${errors.length} ` +
+        'SOURCE_TYPES endpoint(s) in modelBuilderRecipes.ts have no matching ' +
+        'server route:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Model Builder source-endpoint coverage guard passed: all ${entries.length} ` +
+      'SOURCE_TYPES endpoint references resolve to a real ' +
+      'server/api/<slug>/index.get.ts route.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Summary
- Adds `verifyModelBuilderSourceEndpointCoverageGuard.ts`, which reads every `SOURCE_TYPES[].endpoint` literal (`stores/helpers/modelBuilderRecipes.ts`) and asserts a matching `server/api/<slug>/index.get.ts` route exists. A future route rename or typo now fails loudly in CI instead of shipping a source tab that errors for every user who opens it.
- While building it, found that `verifyModelBuilderIconCoverageGuard.ts` (cycle 82) had a real coverage gap: its brace-matching entry split broke on SOURCE_TYPES' `Facet` entry, whose leading comment mentions `server/api/{dreams,scenarios}/...` — a literal `{`/`}` pair in prose. The regex matched that comment fragment as a fake "entry" and silently skipped the real Facet object, so the guard was checking only 6 of SOURCE_TYPES' 7 icons (Facet's `kind-icon:gem` was never verified) while still printing a plausible-looking total (`15`, coincidentally right because `RECIPES` actually has 5 entries, not the 4 the original PR description assumed).
- Fixed both guards' extraction to split on `key: '...'` boundaries instead of brace matching — the same index-based chunking `verifyModelBuilderSourceFieldGuard.ts` already uses, deliberately chosen there for this exact reason. Added regression tests to both self-tests covering a brace-containing leading comment.
- Wired the new guard into `package.json` and `contract-tests.yml` per this task's established convention.

## Verification
- `npm run test:model-builder-icon-coverage-guard-selftest` / `test:model-builder-icon-coverage-guard`: pass — now correctly reports **16** icon references (was silently 15, missing Facet).
- `npm run test:model-builder-source-endpoint-coverage-guard-selftest` / `test:model-builder-source-endpoint-coverage-guard`: pass — all 7 SOURCE_TYPES endpoints resolve to a real route.
- `npm run test:model-builder-contract-tests-coverage-guard`: confirms the new scripts are wired into CI.
- All 167 `test:model-builder-*` npm scripts pass (165 prior + 2 new).
- `npx eslint` on all 4 changed/new `.ts` files: clean.
- `npm run test` (`vue-tsc --noEmit`): clean, repo-wide.
- `npx prettier --check`: clean.
- `git diff --stat`: scoped to exactly 6 files (4 modified, 2 new).

Conductor: `model-builder/t-029`
Session: `claude-scheduled-20260902T212945Z-conductor-mb-t029-cycle84`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015v86bS2nwRiZyXoDJyUxhH

---
_Generated by [Claude Code](https://claude.ai/code/session_015v86bS2nwRiZyXoDJyUxhH)_