### PR TITLE
fix(watchlist): align landing copy with the real media log

### DIFF
--- a/components/conductor/watchlist-page.vue
+++ b/components/conductor/watchlist-page.vue
@@ -14,9 +14,9 @@ const config: ProjectFrontConfig = {
   slug: 'media-watchlist',
   title: 'Media Watchlist',
   icon: 'kind-icon:movie',
-  tagline: 'Everything you meant to watch, in one honest list.',
+  tagline: 'A decade-plus of books, games, movies, TV, comics, and more.',
   description:
-    'A structured log for films and shows. Queue what you want to watch, mark what you are in the middle of, and archive what you finished — so "what should we watch tonight" finally has a single source of truth.',
+    'A structured personal media log spanning 12 media types. Browse what you consumed, filter by year, type, month, season, or favorites, review individual entries, and explore the patterns in more than a decade of media history.',
   stats: [
     { label: 'entries logged', value: '2,440', icon: 'kind-icon:list' },
     { label: 'years tracked', value: '12', icon: 'kind-icon:calendar' },
@@ -24,16 +24,16 @@ const config: ProjectFrontConfig = {
   ],
   sections: [
     {
-      key: 'queue',
-      title: 'Queue it',
-      body: 'Capture titles the moment you hear about them, before they vanish from memory.',
-      icon: 'kind-icon:plus',
+      key: 'browse',
+      title: 'Browse the log',
+      body: 'Search and filter the full history by media type, year, month, season, or starred favorites.',
+      icon: 'kind-icon:list',
     },
     {
-      key: 'track',
-      title: 'Track it',
-      body: 'Queue, in-progress, and finished — a clean three-state flow with no clutter.',
-      icon: 'kind-icon:check-circle',
+      key: 'patterns',
+      title: 'See the patterns',
+      body: 'Compare years, media types, active months, reading totals, listening hours, and favorite entries.',
+      icon: 'kind-icon:chart',
     },
   ],
   deliverables: {


### PR DESCRIPTION
## Summary
- replace stale fallback copy that described Media Watchlist as a films/shows queue
- describe the actual 12-media-type consumption log and its shipped filters/reviews/stats
- replace nonexistent queue/in-progress/finished feature cards with Browse the log / See the patterns

## Scope
Copy/config only in `components/conductor/watchlist-page.vue`. No data, API, schema, or behavior changes.

Conductor: `media-watchlist/t-006`
Session: `openai-scheduled-20260902T221425Z-media-watchlist-t006-oai11m7`