### PR TITLE
model-builder/t-029 cycle 85: fix blank List-view icon, widen icon coverage guard

### DIFF
--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -269,10 +269,21 @@ const sourceTypes = SOURCE_TYPES
 
 type ViewMode = 'gallery' | 'grid' | 'list'
 
+// The List button's icon named a "document" glyph until this cycle
+// (model-builder/t-029) -- no matching svg has ever existed under
+// assets/icons/ (confirmed via `git log` on that directory), so the Nuxt
+// Icon module silently rendered a blank glyph for the List button with no
+// error anywhere -- the exact "hand-typed icon name silently resolves to
+// nothing" shape this task's history already hit twice for other hand-typed
+// field names (cycle 22's Bot/Facet subtitleFields, cycle 82/84's
+// SOURCE_TYPES icon coverage guard). The three-horizontal-lines glyph below
+// is the conventional "list view" icon and already exists; BUILD_STAGES' own
+// FIELDS_AND_PROMPTS entry names the same glyph but is never rendered
+// decoratively anywhere in this app today, so there is no visual collision.
 const viewModes: { value: ViewMode; label: string; icon: string }[] = [
   { value: 'gallery', label: 'Gallery', icon: 'kind-icon:image' },
   { value: 'grid', label: 'Grid', icon: 'kind-icon:cards' },
-  { value: 'list', label: 'List', icon: 'kind-icon:document' },
+  { value: 'list', label: 'List', icon: 'kind-icon:list' },
 ]
 
 const VIEW_PREFERENCE_SCOPE = 'model-builder-source-picker'

--- a/utils/scripts/verifyModelBuilderIconCoverageGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderIconCoverageGuard.test.ts
@@ -7,10 +7,18 @@
 // shape with every icon present, and (cycle 84) a leading comment
 // containing literal `{`/`}` characters, which broke the original
 // brace-matching extraction by hiding the real Facet-shaped entry entirely.
+//
+// Also covers checkComponentIconCoverageGuard()/extractComponentIconLiterals()
+// (cycle 85), the widened component-family literal scan -- its regression
+// fixture is the exact real bug this cycle found: model-builder-source-
+// picker.vue's List view-mode button referenced `kind-icon:document`, which
+// has never existed in assets/icons/.
 import assert from 'node:assert/strict'
 
 import {
+  checkComponentIconCoverageGuard,
   checkIconCoverageGuard,
+  extractComponentIconLiterals,
   extractIconEntries,
 } from './verifyModelBuilderIconCoverageGuard.js'
 
@@ -148,4 +156,85 @@ console.log(
   'Model Builder icon coverage guard checker verified: parses all three ' +
     'icon-carrying arrays, passes on the clean shape, and flags a typo in ' +
     'any of BUILD_STAGES/SOURCE_TYPES/RECIPES individually.',
+)
+
+// --- component-family literal scan (cycle 85) -------------------------------
+
+const COMPONENT_AVAILABLE_ICONS = new Set(['image', 'cards', 'list', 'check'])
+
+// The real bug shape this cycle found: a view-mode toggle array whose 'list'
+// entry references an icon that was never added to assets/icons/.
+const brokenComponentFixture = `
+const viewModes = [
+  { value: 'gallery', label: 'Gallery', icon: 'kind-icon:image' },
+  { value: 'grid', label: 'Grid', icon: 'kind-icon:cards' },
+  { value: 'list', label: 'List', icon: 'kind-icon:document' },
+]
+`
+const brokenLiterals = extractComponentIconLiterals(
+  'model-builder-source-picker.vue',
+  brokenComponentFixture,
+)
+assert.deepEqual(
+  brokenLiterals.map((entry) => entry.icon),
+  ['image', 'cards', 'document'],
+  `expected all three literal icon names to be extracted in order, got: ${JSON.stringify(brokenLiterals)}`,
+)
+const brokenComponentErrors = checkComponentIconCoverageGuard(
+  brokenLiterals,
+  COMPONENT_AVAILABLE_ICONS,
+)
+assert.equal(
+  brokenComponentErrors.length,
+  1,
+  `expected exactly 1 error for the missing 'document' icon, got: ${JSON.stringify(brokenComponentErrors)}`,
+)
+assert.ok(
+  brokenComponentErrors[0]!.includes('model-builder-source-picker.vue') &&
+    brokenComponentErrors[0]!.includes('document'),
+  `expected the error to name the file and the missing icon, got: ${brokenComponentErrors[0]}`,
+)
+
+// The fixed shape (this cycle's actual fix: 'document' -> 'list') raises no
+// errors.
+const fixedLiterals = extractComponentIconLiterals(
+  'model-builder-source-picker.vue',
+  brokenComponentFixture.replace(
+    "icon: 'kind-icon:document'",
+    "icon: 'kind-icon:list'",
+  ),
+)
+assert.equal(
+  checkComponentIconCoverageGuard(fixedLiterals, COMPONENT_AVAILABLE_ICONS)
+    .length,
+  0,
+  'expected the fixed shape to raise no errors',
+)
+
+// A file referencing the same broken icon twice (e.g. once in a data array,
+// once directly in a template attribute) is reported once, not twice.
+const repeatedLiterals = extractComponentIconLiterals(
+  'model-builder-item-panel.vue',
+  `<Icon name="kind-icon:document" />\nconst x = 'kind-icon:document'`,
+)
+assert.equal(
+  repeatedLiterals.length,
+  2,
+  `expected both raw occurrences to be extracted, got: ${JSON.stringify(repeatedLiterals)}`,
+)
+const repeatedErrors = checkComponentIconCoverageGuard(
+  repeatedLiterals,
+  COMPONENT_AVAILABLE_ICONS,
+)
+assert.equal(
+  repeatedErrors.length,
+  1,
+  `expected the duplicate reference to be deduplicated into 1 error, got: ${JSON.stringify(repeatedErrors)}`,
+)
+
+console.log(
+  'Model Builder component icon coverage guard checker verified: extracts ' +
+    'every kind-icon: literal from a component file, passes on the fixed ' +
+    "shape, flags the real 'document' regression this cycle found, and " +
+    'deduplicates repeated references within the same file.',
 )

--- a/utils/scripts/verifyModelBuilderIconCoverageGuard.ts
+++ b/utils/scripts/verifyModelBuilderIconCoverageGuard.ts
@@ -35,6 +35,18 @@
 // already uses for exactly this reason -- it never looks at brace characters
 // at all, so a comment (or any other free text) containing them can't
 // desynchronize the split.
+//
+// Widened (cycle 85) -- this guard only ever read modelBuilderRecipes.ts, but
+// every components/model-builder/*.vue file also carries its own hand-typed
+// `'kind-icon:<name>'` literals outside those three arrays (button icons,
+// view-mode toggles, status glyphs). Those were entirely uncovered: found via
+// this exact gap, model-builder-source-picker.vue's List view-mode button
+// referenced `kind-icon:document`, and assets/icons/document.svg has never
+// existed in this repo's history -- the button silently rendered a blank
+// glyph with no error anywhere, live on production. checkComponentIconCoverage
+// below extends the same "every 'kind-icon:<name>' literal resolves to a real
+// assets/icons/<name>.svg file" contract across the whole component family,
+// not just the three recipe-catalog arrays.
 import { readFileSync, readdirSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -45,6 +57,10 @@ const repositoryRoot = resolve(scriptDirectory, '../..')
 const MODEL_BUILDER_RECIPES_PATH = join(
   repositoryRoot,
   'stores/helpers/modelBuilderRecipes.ts',
+)
+const MODEL_BUILDER_COMPONENTS_DIRECTORY = join(
+  repositoryRoot,
+  'components/model-builder',
 )
 const ICONS_DIRECTORY = join(repositoryRoot, 'assets/icons')
 
@@ -133,22 +149,85 @@ export function checkIconCoverageGuard(
   return errors
 }
 
-function main(): void {
-  const content = readFileSync(MODEL_BUILDER_RECIPES_PATH, 'utf8')
-  const entries = extractIconEntries(content)
+export interface ComponentIconLiteral {
+  file: string
+  icon: string
+}
 
+// Every `kind-icon:<name>` literal appearing anywhere in a component-family
+// .vue file's content -- template icon names, view-mode/status-badge data
+// arrays, anything -- regardless of quote style or surrounding context. Not
+// brace/object-shaped like extractIconEntries above: a Vue SFC mixes markup
+// and script freely, so this deliberately looks for the one substring that
+// actually determines the Iconify lookup rather than trying to parse the
+// surrounding array/attribute shape.
+export function extractComponentIconLiterals(
+  fileName: string,
+  content: string,
+): ComponentIconLiteral[] {
+  return [...content.matchAll(/kind-icon:([\w-]+)/g)].map((match) => ({
+    file: fileName,
+    icon: match[1]!,
+  }))
+}
+
+// Same contract as checkIconCoverageGuard, applied to the component-literal
+// shape above. Deduplicates by file+icon so one bad reference used in several
+// places within the same file is reported once, not once per occurrence.
+export function checkComponentIconCoverageGuard(
+  entries: ComponentIconLiteral[],
+  availableIcons: Set<string>,
+): string[] {
+  const errors: string[] = []
+  const seen = new Set<string>()
+
+  for (const entry of entries) {
+    const dedupeKey = `${entry.file}:${entry.icon}`
+    if (seen.has(dedupeKey)) continue
+    seen.add(dedupeKey)
+    if (!availableIcons.has(entry.icon)) {
+      errors.push(
+        `${entry.file} references 'kind-icon:${entry.icon}' but ` +
+          `assets/icons/${entry.icon}.svg does not exist -- the component ` +
+          'renders a blank icon instead of erroring anywhere.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
   const availableIcons = new Set(
     readdirSync(ICONS_DIRECTORY)
       .filter((file) => file.endsWith('.svg'))
       .map((file) => file.slice(0, -'.svg'.length)),
   )
 
-  const errors = checkIconCoverageGuard(entries, availableIcons)
+  const content = readFileSync(MODEL_BUILDER_RECIPES_PATH, 'utf8')
+  const entries = extractIconEntries(content)
+  const catalogErrors = checkIconCoverageGuard(entries, availableIcons)
+
+  const componentFiles = readdirSync(MODEL_BUILDER_COMPONENTS_DIRECTORY)
+    .filter((file) => file.endsWith('.vue'))
+    .sort()
+  const componentLiterals = componentFiles.flatMap((file) =>
+    extractComponentIconLiterals(
+      file,
+      readFileSync(join(MODEL_BUILDER_COMPONENTS_DIRECTORY, file), 'utf8'),
+    ),
+  )
+  const componentErrors = checkComponentIconCoverageGuard(
+    componentLiterals,
+    availableIcons,
+  )
+
+  const errors = [...catalogErrors, ...componentErrors]
 
   if (errors.length) {
     console.error(
       `Model Builder icon coverage guard failed: ${errors.length} icon ` +
-        'reference(s) in modelBuilderRecipes.ts have no matching svg file:',
+        'reference(s) have no matching svg file:',
     )
     for (const error of errors) console.error(`- ${error}`)
     process.exitCode = 1
@@ -157,8 +236,10 @@ function main(): void {
 
   console.log(
     `Model Builder icon coverage guard passed: all ${entries.length} ` +
-      'icon references in BUILD_STAGES/SOURCE_TYPES/RECIPES resolve to a ' +
-      'real assets/icons/*.svg file.',
+      'icon references in BUILD_STAGES/SOURCE_TYPES/RECIPES, and all ' +
+      `${componentLiterals.length} kind-icon: literal(s) across ` +
+      `${componentFiles.length} components/model-builder/*.vue files, ` +
+      'resolve to a real assets/icons/*.svg file.',
   )
 }
 


### PR DESCRIPTION
### Task
model-builder/t-029 cycle 85: fix a blank List-view icon + widen the icon coverage guard to cover components (kind: software)

### What changed / what I produced
- `components/model-builder/model-builder-source-picker.vue`: the "List" view-mode toggle button referenced `kind-icon:document`, but `assets/icons/document.svg` has never existed in this repo's history — the Nuxt Icon module (`kind-icon` custom collection, `dir: './assets/icons'` in `nuxt.config.ts`) silently rendered a blank glyph for that button with no error anywhere. Swapped to `kind-icon:list` (the conventional three-line "list view" glyph, a real existing icon, and not visually rendered anywhere else in this app today — `BUILD_STAGES`' own `FIELDS_AND_PROMPTS` entry names the same icon but that field is never rendered decoratively, so no visual collision).
- `utils/scripts/verifyModelBuilderIconCoverageGuard.ts`: previously only scanned the three data arrays (`BUILD_STAGES`/`SOURCE_TYPES`/`RECIPES`) in `stores/helpers/modelBuilderRecipes.ts`. Widened it to also scan every `kind-icon:<name>` literal across all `components/model-builder/*.vue` files (the exact class of file this bug actually lived in), so a future hand-typed icon typo/rename fails loudly here instead of shipping a blank glyph.
- `utils/scripts/verifyModelBuilderIconCoverageGuard.test.ts`: extended with the real bug shape as its regression fixture (the exact `document`→`list` fix), plus a dedupe case for a broken icon referenced twice in the same file.

This continues this recurring task's established "hand-typed field/icon name silently resolves to nothing" bug class (cycle 22's Bot/Facet `subtitleField`, cycle 82/84's `SOURCE_TYPES` icon coverage guard) — just found in a new place (component-level literals, not the shared recipe catalog).

### How I verified
- New/widened guard fails pre-fix / passes post-fix, verified via a scoped `git stash` round-trip on the component file alone (guard + test changes kept in place).
- Guard self-test passes (`test:model-builder-icon-coverage-guard-selftest`).
- All 167 `test:model-builder-*` scripts pass, checked via actual exit code per script (not output grep).
- `eslint` clean on all 3 changed files.
- `vue-tsc --noEmit` repo-wide: clean.
- `prettier --check` clean on the two `.ts` files; the `.vue` file carries pre-existing, unrelated formatting drift (confirmed via a `git stash` diff before editing that none of it touches the edited region) — left untouched per the davinci/t-025 precedent (don't run `prettier --write` across a whole file that isn't already prettier-clean).
- `test:layout-contract` holds at the 207 baseline, zero new violations.
- `test:model-builder-contract-tests-coverage-guard` passes (no new script name added — the existing guard was widened in place, so no `package.json`/`contract-tests.yml` wiring change was needed).
- `git status --porcelain` scoped to exactly these 3 files.

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
`kind-icon:document` is also referenced (and equally broken) in `components/pages/conductor-project-gallery-page.vue` — out of scope for this model-builder-only task, but worth a small follow-up either adding a real `assets/icons/document.svg` or swapping that reference too, so the same silent-blank-icon bug doesn't linger there.

### Notes for reviewer
None.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUU5fMuL3pGWvVLhXahLFZ)_