### PR TITLE
Add bounded working context to Rainbow agent check-ins

### DIFF
--- a/.github/workflows/agent-checkin-contract.yml
+++ b/.github/workflows/agent-checkin-contract.yml
@@ -11,9 +11,11 @@ on:
       - 'server/utils/authGuard.ts'
       - 'server/utils/agentAttentionRequests.ts'
       - 'server/utils/agentProfileRuntime.ts'
+      - 'server/utils/agentWorkingContext.ts'
       - 'server/api/v1/agent/**'
       - 'server/api/agent-profiles/**'
       - 'utils/scripts/verifyAgentCheckins.test.ts'
+      - 'utils/scripts/verifyAgentWorkingContext.test.ts'
       - 'tests/contracts/verifyAgentAttentionRequests.ts'
       - '.github/workflows/agent-checkin-contract.yml'
   push:
@@ -26,9 +28,11 @@ on:
       - 'server/utils/authGuard.ts'
       - 'server/utils/agentAttentionRequests.ts'
       - 'server/utils/agentProfileRuntime.ts'
+      - 'server/utils/agentWorkingContext.ts'
       - 'server/api/v1/agent/**'
       - 'server/api/agent-profiles/**'
       - 'utils/scripts/verifyAgentCheckins.test.ts'
+      - 'utils/scripts/verifyAgentWorkingContext.test.ts'
       - 'tests/contracts/verifyAgentAttentionRequests.ts'
       - '.github/workflows/agent-checkin-contract.yml'
   workflow_dispatch:
@@ -51,5 +55,7 @@ jobs:
         run: npm install --include=optional
       - name: Verify agent check-in and note contract
         run: npx tsx utils/scripts/verifyAgentCheckins.test.ts
+      - name: Verify agent working-context contract
+        run: npx tsx utils/scripts/verifyAgentWorkingContext.test.ts
       - name: Verify agent human-attention request contract
         run: npx tsx tests/contracts/verifyAgentAttentionRequests.ts

--- a/.github/workflows/rainbow-mcp-contract.yml
+++ b/.github/workflows/rainbow-mcp-contract.yml
@@ -10,8 +10,10 @@ on:
       - 'server/api/v1/agent/check-in.post.ts'
       - 'server/middleware/rainbow-mcp-origin.ts'
       - 'server/utils/agentProfileRuntime.ts'
+      - 'server/utils/agentWorkingContext.ts'
       - 'server/utils/rainbowMcpProtocol.ts'
       - 'utils/scripts/verifyAgentCheckins.test.ts'
+      - 'utils/scripts/verifyAgentWorkingContext.test.ts'
       - 'utils/scripts/verifyRainbowMcpProtocol.test.ts'
       - '.github/workflows/agent-checkin-contract.yml'
       - '.github/workflows/rainbow-mcp-contract.yml'
@@ -24,8 +26,10 @@ on:
       - 'server/api/v1/agent/check-in.post.ts'
       - 'server/middleware/rainbow-mcp-origin.ts'
       - 'server/utils/agentProfileRuntime.ts'
+      - 'server/utils/agentWorkingContext.ts'
       - 'server/utils/rainbowMcpProtocol.ts'
       - 'utils/scripts/verifyAgentCheckins.test.ts'
+      - 'utils/scripts/verifyAgentWorkingContext.test.ts'
       - 'utils/scripts/verifyRainbowMcpProtocol.test.ts'
       - '.github/workflows/agent-checkin-contract.yml'
       - '.github/workflows/rainbow-mcp-contract.yml'
@@ -48,3 +52,5 @@ jobs:
         run: npx tsx utils/scripts/verifyRainbowMcpProtocol.test.ts
       - name: Verify shared AgentProfile check-in contract
         run: npx tsx utils/scripts/verifyAgentCheckins.test.ts
+      - name: Verify bounded AgentProfile working context
+        run: npx tsx utils/scripts/verifyAgentWorkingContext.test.ts

--- a/server/api/v1/mcp.post.ts
+++ b/server/api/v1/mcp.post.ts
@@ -58,7 +58,7 @@ const tools = [
     name: TOOL_CHECK_IN,
     title: 'Rainbow Agent Check-in',
     description:
-      'Record a heartbeat for the AgentProfile bound to this credential and receive queued human notes plus resolved attention requests. Requires agent:checkin.',
+      'Record a heartbeat for the AgentProfile bound to this credential and receive queued human notes, resolved attention requests, and bounded working context. Forum conversation context is included only when forum:read is granted. Requires agent:checkin.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/server/utils/agentProfileRuntime.ts
+++ b/server/utils/agentProfileRuntime.ts
@@ -1,8 +1,13 @@
 import { createError, setHeader, type H3Event } from 'h3'
 import type { AgentCredentialScope } from './agentCredentials'
-import { requireScopedApiUser, type AuthGuardResult } from './authGuard'
-import prisma from './prisma'
 import { claimResolvedAgentAttentionRequests } from './agentAttentionRequests'
+import {
+  agentCapabilityFlags,
+  buildAgentWorkingContext,
+} from './agentWorkingContext'
+import { requireScopedApiUser, type AuthGuardResult } from './authGuard'
+import { effectiveShowMature } from './contentAccess'
+import prisma from './prisma'
 
 const AGENT_CHECKIN_STATUSES = new Set(['idle', 'working', 'blocked', 'completed'])
 const CHECKIN_WINDOW_MS = 10 * 60 * 1000
@@ -146,6 +151,28 @@ export function assertAgentCheckInRateAllowed(event: H3Event, credentialId: numb
   existing.count += 1
 }
 
+async function safeAgentWorkingContext(context: BoundAgentContext) {
+  const { auth, profile } = context
+
+  try {
+    return await buildAgentWorkingContext({
+      agentProfileId: profile.id,
+      userId: auth.user.id,
+      scopes: auth.scopes ?? [],
+      includeMature: effectiveShowMature(auth.user),
+    })
+  } catch {
+    // The heartbeat has already been durably recorded at this point. Context is
+    // additive, so a transient read-side failure must not turn a successful
+    // check-in into an apparent failure that provider schedulers retry.
+    return {
+      available: false as const,
+      message:
+        'Working context is temporarily unavailable; the check-in was still recorded.',
+    }
+  }
+}
+
 export async function recordAgentCheckIn(input: {
   context: BoundAgentContext
   status: string | null
@@ -233,6 +260,8 @@ export async function recordAgentCheckIn(input: {
     )
   }
 
+  const workingContext = await safeAgentWorkingContext(input.context)
+
   return {
     agent: {
       id: profile.id,
@@ -246,6 +275,7 @@ export async function recordAgentCheckIn(input: {
     },
     notes: result.notes,
     attention,
+    context: workingContext,
     message:
       deliveries.length > 0
         ? `${deliveries.join(' and ')} delivered.`
@@ -276,13 +306,6 @@ export function serializeAgentIdentity(context: BoundAgentContext) {
       id: auth.credentialId ?? null,
       scopes,
     },
-    capabilities: {
-      profileRead: scopes.includes('profile:read'),
-      agentCheckIn: scopes.includes('agent:checkin'),
-      forumRead: scopes.includes('forum:read'),
-      forumWrite: scopes.includes('forum:write'),
-      forumThreadCreate: scopes.includes('forum:thread:create'),
-      generationArt: scopes.includes('generation:art'),
-    },
+    capabilities: agentCapabilityFlags(scopes),
   }
 }

--- a/server/utils/agentWorkingContext.ts
+++ b/server/utils/agentWorkingContext.ts
@@ -189,10 +189,12 @@ export async function buildAgentWorkingContext(input: {
     allowedChannels = await getAgentForumChannels(input.agentProfileId)
   }
   if (capabilities.forumRead) {
-    ;[recentPosts, directReplies] = await Promise.all([
+    const [loadedRecentPosts, loadedDirectReplies] = await Promise.all([
       recentForumPosts(input),
       directForumReplies(input),
     ])
+    recentPosts = loadedRecentPosts
+    directReplies = loadedDirectReplies
   }
 
   return {

--- a/server/utils/agentWorkingContext.ts
+++ b/server/utils/agentWorkingContext.ts
@@ -1,0 +1,223 @@
+import { Prisma } from '~/prisma/generated/prisma/client'
+import type { AgentCredentialScope } from './agentCredentials'
+import { listAgentAttentionRequests } from './agentAttentionRequests'
+import { getAgentForumChannels } from './agentForumPolicy'
+import prisma from './prisma'
+
+const MAX_CONTEXT_TEXT = 1200
+const RECENT_CHECKIN_LIMIT = 5
+const OPEN_ATTENTION_LIMIT = 10
+const RECENT_FORUM_POST_LIMIT = 5
+const DIRECT_REPLY_LIMIT = 10
+
+export type AgentCapabilityFlags = {
+  profileRead: boolean
+  agentCheckIn: boolean
+  forumRead: boolean
+  forumWrite: boolean
+  forumThreadCreate: boolean
+  generationArt: boolean
+}
+
+type ForumContextRow = {
+  id: number
+  createdAt: Date
+  threadId: number
+  parentId: number | null
+  channel: string | null
+  sender: string | null
+  threadTitle: string | null
+  excerpt: string
+  isMature: boolean
+}
+
+function clip(value: string | null | undefined): string | null {
+  if (!value) return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  return trimmed.length > MAX_CONTEXT_TEXT
+    ? `${trimmed.slice(0, MAX_CONTEXT_TEXT - 1)}…`
+    : trimmed
+}
+
+export function agentCapabilityFlags(
+  scopes: readonly AgentCredentialScope[],
+): AgentCapabilityFlags {
+  return {
+    profileRead: scopes.includes('profile:read'),
+    agentCheckIn: scopes.includes('agent:checkin'),
+    forumRead: scopes.includes('forum:read'),
+    forumWrite: scopes.includes('forum:write'),
+    forumThreadCreate: scopes.includes('forum:thread:create'),
+    generationArt: scopes.includes('generation:art'),
+  }
+}
+
+async function recentForumPosts(input: {
+  agentProfileId: number
+  includeMature: boolean
+}): Promise<ForumContextRow[]> {
+  return await prisma.$queryRaw<ForumContextRow[]>(Prisma.sql`
+    SELECT
+      c.id AS id,
+      c.createdAt AS createdAt,
+      COALESCE(c.originId, c.id) AS threadId,
+      c.previousEntryId AS parentId,
+      c.channel AS channel,
+      c.sender AS sender,
+      root.title AS threadTitle,
+      LEFT(c.content, ${MAX_CONTEXT_TEXT}) AS excerpt,
+      c.isMature AS isMature
+    FROM Chat c
+    INNER JOIN ForumAgentAuthor author ON author.chatId = c.id
+    LEFT JOIN Chat root ON root.id = COALESCE(c.originId, c.id)
+    WHERE author.agentProfileId = ${input.agentProfileId}
+      AND c.type = 'ToForum'
+      AND c.isPublic = true
+      AND c.isActive = true
+      AND (${input.includeMature} = true OR c.isMature = false)
+    ORDER BY c.createdAt DESC, c.id DESC
+    LIMIT ${RECENT_FORUM_POST_LIMIT}
+  `)
+}
+
+async function directForumReplies(input: {
+  agentProfileId: number
+  includeMature: boolean
+}): Promise<ForumContextRow[]> {
+  return await prisma.$queryRaw<ForumContextRow[]>(Prisma.sql`
+    SELECT
+      reply.id AS id,
+      reply.createdAt AS createdAt,
+      COALESCE(reply.originId, reply.id) AS threadId,
+      reply.previousEntryId AS parentId,
+      reply.channel AS channel,
+      reply.sender AS sender,
+      root.title AS threadTitle,
+      LEFT(reply.content, ${MAX_CONTEXT_TEXT}) AS excerpt,
+      reply.isMature AS isMature
+    FROM Chat reply
+    INNER JOIN ForumAgentAuthor parentAuthor
+      ON parentAuthor.chatId = reply.previousEntryId
+    LEFT JOIN ForumAgentAuthor replyAuthor ON replyAuthor.chatId = reply.id
+    LEFT JOIN Chat root ON root.id = COALESCE(reply.originId, reply.id)
+    WHERE parentAuthor.agentProfileId = ${input.agentProfileId}
+      AND (replyAuthor.agentProfileId IS NULL OR replyAuthor.agentProfileId <> ${input.agentProfileId})
+      AND reply.type = 'ToForum'
+      AND reply.isPublic = true
+      AND reply.isActive = true
+      AND (${input.includeMature} = true OR reply.isMature = false)
+    ORDER BY reply.createdAt DESC, reply.id DESC
+    LIMIT ${DIRECT_REPLY_LIMIT}
+  `)
+}
+
+function serializeForumRows(rows: readonly ForumContextRow[]) {
+  return rows.map((row) => ({
+    id: row.id,
+    createdAt: row.createdAt,
+    threadId: row.threadId,
+    parentId: row.parentId,
+    channel: row.channel,
+    sender: row.sender,
+    threadTitle: row.threadTitle,
+    excerpt: clip(row.excerpt),
+    isMature: row.isMature,
+  }))
+}
+
+/**
+ * Build a bounded, profile-scoped wake-up packet for recurring Rainbow agents.
+ *
+ * The important privacy boundary is deliberate: this only exposes state already
+ * owned by the bound AgentProfile, public forum conversation state the credential
+ * may read, and that profile's own recent heartbeat history. It does not read the
+ * private Conductor projection because no canonical AgentProfile-to-project/task
+ * assignment contract exists yet.
+ */
+export async function buildAgentWorkingContext(input: {
+  agentProfileId: number
+  userId: number
+  scopes: readonly AgentCredentialScope[]
+  includeMature: boolean
+}) {
+  const capabilities = agentCapabilityFlags(input.scopes)
+
+  const [attentionRows, recentCheckIns] = await Promise.all([
+    listAgentAttentionRequests({
+      agentProfileId: input.agentProfileId,
+      userId: input.userId,
+      limit: OPEN_ATTENTION_LIMIT,
+    }),
+    prisma.agentCheckIn.findMany({
+      where: {
+        agentProfileId: input.agentProfileId,
+        userId: input.userId,
+      },
+      orderBy: { createdAt: 'desc' },
+      take: RECENT_CHECKIN_LIMIT,
+      select: {
+        id: true,
+        createdAt: true,
+        status: true,
+        summary: true,
+      },
+    }),
+  ])
+
+  const openAttention = attentionRows
+    .filter((request) => request.status === 'OPEN')
+    .slice(0, OPEN_ATTENTION_LIMIT)
+    .map((request) => ({
+      id: request.id,
+      createdAt: request.createdAt,
+      kind: request.kind,
+      title: request.title,
+      body: clip(request.body),
+      clientKey: request.clientKey,
+      status: request.status,
+    }))
+
+  const hasForumCapability =
+    capabilities.forumRead || capabilities.forumWrite || capabilities.forumThreadCreate
+
+  let allowedChannels: string[] = []
+  let recentPosts: ForumContextRow[] = []
+  let directReplies: ForumContextRow[] = []
+
+  if (hasForumCapability) {
+    allowedChannels = await getAgentForumChannels(input.agentProfileId)
+  }
+  if (capabilities.forumRead) {
+    ;[recentPosts, directReplies] = await Promise.all([
+      recentForumPosts(input),
+      directForumReplies(input),
+    ])
+  }
+
+  return {
+    available: true as const,
+    capabilities,
+    attention: {
+      open: openAttention,
+      openCount: openAttention.length,
+    },
+    recentCheckIns: recentCheckIns.map((checkIn) => ({
+      ...checkIn,
+      summary: clip(checkIn.summary),
+    })),
+    forum: {
+      readEnabled: capabilities.forumRead,
+      writeEnabled: capabilities.forumWrite,
+      threadCreateEnabled: capabilities.forumThreadCreate,
+      allowedChannels,
+      recentPosts: serializeForumRows(recentPosts),
+      directReplies: serializeForumRows(directReplies),
+    },
+    coordination: {
+      projectAssignmentsAvailable: false,
+      reason:
+        'No canonical AgentProfile-to-project assignment exists yet, so private Conductor roadmap data is not exposed in agent check-ins.',
+    },
+  }
+}

--- a/utils/scripts/verifyAgentWorkingContext.test.ts
+++ b/utils/scripts/verifyAgentWorkingContext.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const runtime = readFileSync('server/utils/agentProfileRuntime.ts', 'utf8')
+const context = readFileSync('server/utils/agentWorkingContext.ts', 'utf8')
+const mcp = readFileSync('server/api/v1/mcp.post.ts', 'utf8')
+
+// The durable heartbeat remains the source action. Working context is an
+// additive read after the transaction, and a context read failure must not
+// make a successfully recorded check-in look failed to a scheduler.
+assert.match(runtime, /buildAgentWorkingContext/)
+assert.match(runtime, /effectiveShowMature\(auth\.user\)/)
+assert.match(runtime, /const workingContext = await safeAgentWorkingContext\(input\.context\)/)
+assert.match(runtime, /context: workingContext/)
+assert.match(runtime, /Working context is temporarily unavailable; the check-in was still recorded/)
+assert.match(runtime, /capabilities: agentCapabilityFlags\(scopes\)/)
+
+// Wake-up context is bounded and AgentProfile-scoped.
+assert.match(context, /MAX_CONTEXT_TEXT = 1200/)
+assert.match(context, /RECENT_CHECKIN_LIMIT = 5/)
+assert.match(context, /OPEN_ATTENTION_LIMIT = 10/)
+assert.match(context, /RECENT_FORUM_POST_LIMIT = 5/)
+assert.match(context, /DIRECT_REPLY_LIMIT = 10/)
+assert.match(context, /agentProfileId: input\.agentProfileId/)
+assert.match(context, /userId: input\.userId/)
+assert.match(context, /request\.status === 'OPEN'/)
+assert.match(context, /getAgentForumChannels\(input\.agentProfileId\)/)
+
+// Forum conversation context is capability-gated and only exposes public,
+// active posts. Mature content follows the operator's effective mature setting.
+assert.match(context, /capabilities\.forumRead/)
+assert.match(context, /author\.agentProfileId = \$\{input\.agentProfileId\}/)
+assert.match(context, /parentAuthor\.agentProfileId = \$\{input\.agentProfileId\}/)
+assert.match(context, /replyAuthor\.agentProfileId <> \$\{input\.agentProfileId\}/)
+assert.match(context, /c\.isPublic = true/)
+assert.match(context, /c\.isActive = true/)
+assert.match(context, /reply\.isPublic = true/)
+assert.match(context, /reply\.isActive = true/)
+assert.match(context, /isMature = false/)
+
+// There is deliberately no inferred bridge from an AgentProfile into private
+// Conductor roadmaps. Until a canonical assignment relationship exists, the
+// check-in says that coordination assignments are unavailable instead of
+// leaking a global projection to any scoped agent credential.
+assert.match(context, /projectAssignmentsAvailable: false/)
+assert.doesNotMatch(context, /readConductorProjection|buildConductorData|ConductorProjection/)
+
+// Both REST and the existing narrow MCP check-in keep using recordAgentCheckIn,
+// so this richer context reaches providers without adding a generic third tool.
+assert.match(mcp, /const TOOL_CHECK_IN = 'rainbow_check_in'/)
+assert.match(mcp, /recordAgentCheckIn\(\{ context, \.\.\.input \}\)/)
+assert.doesNotMatch(mcp, /rainbow_working_context|generic.*proxy/i)
+
+console.log('Agent working-context contract OK')

--- a/utils/scripts/verifyAgentWorkingContext.test.ts
+++ b/utils/scripts/verifyAgentWorkingContext.test.ts
@@ -46,9 +46,15 @@ assert.match(context, /projectAssignmentsAvailable: false/)
 assert.doesNotMatch(context, /readConductorProjection|buildConductorData|ConductorProjection/)
 
 // Both REST and the existing narrow MCP check-in keep using recordAgentCheckIn,
-// so this richer context reaches providers without adding a generic third tool.
+// so this richer context reaches providers without adding a third context tool.
+assert.match(mcp, /const TOOL_IDENTITY = 'rainbow_agent_identity'/)
 assert.match(mcp, /const TOOL_CHECK_IN = 'rainbow_check_in'/)
+assert.equal(
+  [...mcp.matchAll(/const TOOL_[A-Z_]+ =/g)].length,
+  2,
+  'Rainbow MCP must remain a two-tool bridge',
+)
 assert.match(mcp, /recordAgentCheckIn\(\{ context, \.\.\.input \}\)/)
-assert.doesNotMatch(mcp, /rainbow_working_context|generic.*proxy/i)
+assert.doesNotMatch(mcp, /rainbow_working_context/)
 
 console.log('Agent working-context contract OK')


### PR DESCRIPTION
Conductor: rainbow-butterflies/t-027 current-v2 completion, lane 1 partial.

This extends the existing durable AgentProfile heartbeat instead of adding another MCP tool or a broad proxy. After a successful check-in, the response now includes a bounded working-context packet with:

- open attention/approval requests for this AgentProfile;
- recent check-in history for this AgentProfile;
- explicitly configured forum-channel permissions when the credential has forum capabilities;
- recent posts and direct replies only when `forum:read` is granted;
- the operator's existing maturity restriction/preference applied to forum context;
- a clear `projectAssignmentsAvailable: false` boundary because no canonical AgentProfile-to-Conductor project/task assignment exists yet.

The durable heartbeat/note/resolution transaction still happens first. Working context is additive and read-only: a transient context-read failure does not make an already-recorded heartbeat look failed to provider schedulers, avoiding duplicate retries.

No schema migration, credential scope widening, provider secret, generic HTTP forwarding, Conductor projection leak, new MCP tool, generation write, or external account/action is introduced.

Verification added to both Agent Check-in Contract and Rainbow MCP Contract, including bounded sizes, profile/user scoping, capability gating, public/active/maturity filters, no private Conductor projection import, and preservation of the two-tool MCP boundary.