### PR TITLE
Add the canonical Rainbow dashboard workspace feed

### DIFF
--- a/.github/workflows/rainbow-dashboard-contract.yml
+++ b/.github/workflows/rainbow-dashboard-contract.yml
@@ -1,0 +1,34 @@
+name: Rainbow Dashboard Contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/v1/rainbow/dashboard.get.ts'
+      - 'server/utils/rainbowDashboard.ts'
+      - 'utils/scripts/verifyRainbowDashboard.test.ts'
+      - '.github/workflows/rainbow-dashboard-contract.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'server/api/v1/rainbow/dashboard.get.ts'
+      - 'server/utils/rainbowDashboard.ts'
+      - 'utils/scripts/verifyRainbowDashboard.test.ts'
+      - '.github/workflows/rainbow-dashboard-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: npm install --include=optional
+      - name: Verify private Rainbow dashboard workspace contract
+        run: npx tsx utils/scripts/verifyRainbowDashboard.test.ts

--- a/server/api/v1/rainbow/dashboard.get.ts
+++ b/server/api/v1/rainbow/dashboard.get.ts
@@ -1,0 +1,31 @@
+import { defineEventHandler, setHeader } from 'h3'
+import { requireHumanOrDelegatedApiUser } from '@/server/utils/authGuard'
+import { effectiveShowMature } from '@/server/utils/contentAccess'
+import { errorHandler } from '@/server/utils/error'
+import { buildRainbowDashboardWorkspace } from '@/server/utils/rainbowDashboard'
+
+export default defineEventHandler(async (event) => {
+  try {
+    setHeader(event, 'Cache-Control', 'no-store')
+    const auth = await requireHumanOrDelegatedApiUser(event)
+    const data = await buildRainbowDashboardWorkspace({
+      userId: auth.user.id,
+      includeMature: effectiveShowMature(auth.user),
+    })
+
+    return {
+      success: true,
+      data,
+      statusCode: 200,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      data: null,
+      message: handled.message,
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/utils/rainbowDashboard.ts
+++ b/server/utils/rainbowDashboard.ts
@@ -154,8 +154,8 @@ async function loadRecentObjects(input: { userId: number; includeMature: boolean
       detail: clip(item.promptString || item.artPrompt, 280),
       createdAt: item.createdAt,
       updatedAt: item.updatedAt,
-      isPublic: item.isPublic,
-      isMature: item.isMature,
+      isPublic: Boolean(item.isPublic),
+      isMature: Boolean(item.isMature),
       imagePath: item.thumbnailPath || item.cardPath || item.imagePath,
     })),
     ...characters.map((item) => ({
@@ -165,8 +165,8 @@ async function loadRecentObjects(input: { userId: number; includeMature: boolean
       detail: clip([item.species, item.role].filter(Boolean).join(' · '), 280),
       createdAt: item.createdAt,
       updatedAt: item.updatedAt,
-      isPublic: item.isPublic,
-      isMature: item.isMature,
+      isPublic: Boolean(item.isPublic),
+      isMature: Boolean(item.isMature),
       imagePath: item.iconPath || item.cardPath || item.imagePath,
     })),
     ...projects.map((item) => ({
@@ -176,8 +176,8 @@ async function loadRecentObjects(input: { userId: number; includeMature: boolean
       detail: clip(item.description, 280),
       createdAt: item.createdAt,
       updatedAt: item.updatedAt,
-      isPublic: item.isPublic,
-      isMature: item.isMature,
+      isPublic: Boolean(item.isPublic),
+      isMature: Boolean(item.isMature),
       imagePath: item.iconPath || item.cardPath || item.imagePath,
     })),
   ]

--- a/server/utils/rainbowDashboard.ts
+++ b/server/utils/rainbowDashboard.ts
@@ -154,8 +154,8 @@ async function loadRecentObjects(input: { userId: number; includeMature: boolean
       detail: clip(item.promptString || item.artPrompt, 280),
       createdAt: item.createdAt,
       updatedAt: item.updatedAt,
-      isPublic: Boolean(item.isPublic),
-      isMature: Boolean(item.isMature),
+      isPublic: item.isPublic ?? true,
+      isMature: item.isMature ?? false,
       imagePath: item.thumbnailPath || item.cardPath || item.imagePath,
     })),
     ...characters.map((item) => ({
@@ -165,8 +165,8 @@ async function loadRecentObjects(input: { userId: number; includeMature: boolean
       detail: clip([item.species, item.role].filter(Boolean).join(' · '), 280),
       createdAt: item.createdAt,
       updatedAt: item.updatedAt,
-      isPublic: Boolean(item.isPublic),
-      isMature: Boolean(item.isMature),
+      isPublic: item.isPublic,
+      isMature: item.isMature,
       imagePath: item.iconPath || item.cardPath || item.imagePath,
     })),
     ...projects.map((item) => ({
@@ -176,8 +176,8 @@ async function loadRecentObjects(input: { userId: number; includeMature: boolean
       detail: clip(item.description, 280),
       createdAt: item.createdAt,
       updatedAt: item.updatedAt,
-      isPublic: Boolean(item.isPublic),
-      isMature: Boolean(item.isMature),
+      isPublic: item.isPublic,
+      isMature: item.isMature,
       imagePath: item.iconPath || item.cardPath || item.imagePath,
     })),
   ]

--- a/server/utils/rainbowDashboard.ts
+++ b/server/utils/rainbowDashboard.ts
@@ -1,0 +1,220 @@
+import { Prisma } from '~/prisma/generated/prisma/client'
+import prisma from './prisma'
+
+const RECENT_REPLY_LIMIT = 12
+const RECENT_OBJECT_LIMIT_PER_KIND = 8
+const RECENT_OBJECT_LIMIT = 16
+const EXCERPT_LIMIT = 1200
+
+type RecentReplyRow = {
+  id: number
+  createdAt: Date
+  threadId: number
+  parentId: number
+  channel: string | null
+  sender: string | null
+  threadTitle: string | null
+  excerpt: string
+  isMature: boolean
+}
+
+type DashboardObject = {
+  kind: 'ART_IMAGE' | 'CHARACTER' | 'PROJECT'
+  id: number
+  label: string
+  detail: string | null
+  createdAt: Date
+  updatedAt: Date | null
+  isPublic: boolean
+  isMature: boolean
+  imagePath: string | null
+}
+
+function clip(value: string | null | undefined, limit = EXCERPT_LIMIT): string | null {
+  if (!value) return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  return trimmed.length > limit ? `${trimmed.slice(0, limit - 1)}…` : trimmed
+}
+
+async function loadRecentDirectReplies(input: { userId: number; includeMature: boolean }) {
+  const rows = await prisma.$queryRaw<RecentReplyRow[]>(Prisma.sql`
+    SELECT
+      reply.id AS id,
+      reply.createdAt AS createdAt,
+      COALESCE(reply.originId, reply.id) AS threadId,
+      reply.previousEntryId AS parentId,
+      reply.channel AS channel,
+      reply.sender AS sender,
+      root.title AS threadTitle,
+      LEFT(reply.content, ${EXCERPT_LIMIT}) AS excerpt,
+      reply.isMature AS isMature
+    FROM Chat reply
+    INNER JOIN Chat parent ON parent.id = reply.previousEntryId
+    LEFT JOIN Chat root ON root.id = COALESCE(reply.originId, reply.id)
+    WHERE parent.userId = ${input.userId}
+      AND (reply.userId IS NULL OR reply.userId <> ${input.userId})
+      AND reply.type = 'ToForum'
+      AND reply.isPublic = true
+      AND reply.isActive = true
+      AND (${input.includeMature} = true OR reply.isMature = false)
+    ORDER BY reply.createdAt DESC, reply.id DESC
+    LIMIT ${RECENT_REPLY_LIMIT}
+  `)
+
+  return rows.map((row) => ({
+    id: row.id,
+    createdAt: row.createdAt,
+    threadId: row.threadId,
+    parentId: row.parentId,
+    channel: row.channel,
+    sender: row.sender,
+    threadTitle: row.threadTitle,
+    excerpt: clip(row.excerpt),
+    isMature: row.isMature,
+  }))
+}
+
+async function loadRecentObjects(input: { userId: number; includeMature: boolean }) {
+  const matureWhere = input.includeMature ? {} : { isMature: false }
+
+  const [artImages, characters, projects] = await Promise.all([
+    prisma.artImage.findMany({
+      where: {
+        userId: input.userId,
+        isActive: true,
+        ...matureWhere,
+      },
+      orderBy: [{ updatedAt: 'desc' }, { createdAt: 'desc' }, { id: 'desc' }],
+      take: RECENT_OBJECT_LIMIT_PER_KIND,
+      select: {
+        id: true,
+        createdAt: true,
+        updatedAt: true,
+        isPublic: true,
+        isMature: true,
+        artPrompt: true,
+        promptString: true,
+        thumbnailPath: true,
+        cardPath: true,
+        imagePath: true,
+      },
+    }),
+    prisma.character.findMany({
+      where: {
+        userId: input.userId,
+        isActive: true,
+        ...matureWhere,
+      },
+      orderBy: [{ updatedAt: 'desc' }, { createdAt: 'desc' }, { id: 'desc' }],
+      take: RECENT_OBJECT_LIMIT_PER_KIND,
+      select: {
+        id: true,
+        createdAt: true,
+        updatedAt: true,
+        isPublic: true,
+        isMature: true,
+        name: true,
+        title: true,
+        species: true,
+        role: true,
+        iconPath: true,
+        cardPath: true,
+        imagePath: true,
+      },
+    }),
+    prisma.project.findMany({
+      where: {
+        userId: input.userId,
+        isActive: true,
+        ...matureWhere,
+      },
+      orderBy: [{ updatedAt: 'desc' }, { createdAt: 'desc' }, { id: 'desc' }],
+      take: RECENT_OBJECT_LIMIT_PER_KIND,
+      select: {
+        id: true,
+        createdAt: true,
+        updatedAt: true,
+        isPublic: true,
+        isMature: true,
+        title: true,
+        description: true,
+        iconPath: true,
+        cardPath: true,
+        imagePath: true,
+      },
+    }),
+  ])
+
+  const objects: DashboardObject[] = [
+    ...artImages.map((item) => ({
+      kind: 'ART_IMAGE' as const,
+      id: item.id,
+      label: clip(item.artPrompt || item.promptString, 120) || `ArtImage #${item.id}`,
+      detail: clip(item.promptString || item.artPrompt, 280),
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+      isPublic: item.isPublic,
+      isMature: item.isMature,
+      imagePath: item.thumbnailPath || item.cardPath || item.imagePath,
+    })),
+    ...characters.map((item) => ({
+      kind: 'CHARACTER' as const,
+      id: item.id,
+      label: item.name || item.title || `Character #${item.id}`,
+      detail: clip([item.species, item.role].filter(Boolean).join(' · '), 280),
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+      isPublic: item.isPublic,
+      isMature: item.isMature,
+      imagePath: item.iconPath || item.cardPath || item.imagePath,
+    })),
+    ...projects.map((item) => ({
+      kind: 'PROJECT' as const,
+      id: item.id,
+      label: item.title || `Project #${item.id}`,
+      detail: clip(item.description, 280),
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+      isPublic: item.isPublic,
+      isMature: item.isMature,
+      imagePath: item.iconPath || item.cardPath || item.imagePath,
+    })),
+  ]
+
+  objects.sort((a, b) => {
+    const aTime = (a.updatedAt || a.createdAt).getTime()
+    const bTime = (b.updatedAt || b.createdAt).getTime()
+    return bTime - aTime || b.id - a.id
+  })
+
+  return objects.slice(0, RECENT_OBJECT_LIMIT)
+}
+
+/**
+ * Private workspace context for the authenticated human behind Rainbow.
+ *
+ * Agent-created forum posts and canonical objects already carry the accountable
+ * human's userId, so querying by userId includes work from that human's agents
+ * without inventing a second ownership graph in Rainbow.
+ */
+export async function buildRainbowDashboardWorkspace(input: {
+  userId: number
+  includeMature: boolean
+}) {
+  const [recentReplies, recentObjects] = await Promise.all([
+    loadRecentDirectReplies(input),
+    loadRecentObjects(input),
+  ])
+
+  return {
+    recentReplies,
+    recentObjects,
+    semantics: {
+      repliesAreUnread: false,
+      mentionsAvailable: false,
+      objectOwnership:
+        'Canonical Kind Robots userId ownership; agent-created objects are accountable to the same human user.',
+    },
+  }
+}

--- a/utils/scripts/verifyRainbowDashboard.test.ts
+++ b/utils/scripts/verifyRainbowDashboard.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const endpoint = readFileSync('server/api/v1/rainbow/dashboard.get.ts', 'utf8')
+const workspace = readFileSync('server/utils/rainbowDashboard.ts', 'utf8')
+
+// The dashboard is private human workspace data. Rainbow may call it through
+// first-party delegation, but an arbitrary agent credential is not enough.
+assert.match(endpoint, /requireHumanOrDelegatedApiUser/)
+assert.match(endpoint, /effectiveShowMature\(auth\.user\)/)
+assert.match(endpoint, /Cache-Control', 'no-store'/)
+assert.match(endpoint, /userId: auth\.user\.id/)
+
+// Conversation context is intentionally "recent direct replies", not a fake
+// unread/mention inbox. A direct reply must target a post accountable to this
+// human and must come from somebody outside the same human/agent account.
+assert.match(workspace, /RECENT_REPLY_LIMIT = 12/)
+assert.match(workspace, /parent\.userId = \$\{input\.userId\}/)
+assert.match(workspace, /reply\.userId IS NULL OR reply\.userId <> \$\{input\.userId\}/)
+assert.match(workspace, /reply\.isPublic = true/)
+assert.match(workspace, /reply\.isActive = true/)
+assert.match(workspace, /reply\.isMature = false/)
+assert.match(workspace, /repliesAreUnread: false/)
+assert.match(workspace, /mentionsAvailable: false/)
+
+// Canonical objects stay in Kind Robots. All three useful starter kinds are
+// scoped to the accountable userId, active state, and the operator's maturity
+// setting, then merged into one bounded recent-work feed.
+assert.match(workspace, /RECENT_OBJECT_LIMIT_PER_KIND = 8/)
+assert.match(workspace, /RECENT_OBJECT_LIMIT = 16/)
+assert.match(workspace, /prisma\.artImage\.findMany/)
+assert.match(workspace, /prisma\.character\.findMany/)
+assert.match(workspace, /prisma\.project\.findMany/)
+assert.equal(
+  [...workspace.matchAll(/userId: input\.userId/g)].length >= 3,
+  true,
+  'all canonical object queries must be user-scoped',
+)
+assert.equal(
+  [...workspace.matchAll(/isActive: true/g)].length >= 3,
+  true,
+  'all canonical object queries must require active records',
+)
+assert.match(workspace, /kind: 'ART_IMAGE'/)
+assert.match(workspace, /kind: 'CHARACTER'/)
+assert.match(workspace, /kind: 'PROJECT'/)
+assert.match(workspace, /objects\.slice\(0, RECENT_OBJECT_LIMIT\)/)
+
+// No Rainbow shadow database, no private Conductor projection, and no claim
+// that a missing read-state system exists.
+assert.doesNotMatch(workspace, /ConductorProjection|readConductorProjection|buildConductorData/)
+assert.match(workspace, /Canonical Kind Robots userId ownership/)
+
+console.log('Rainbow dashboard workspace contract OK')


### PR DESCRIPTION
Conductor: rainbow-butterflies/t-027 current-v2 completion, lane 2 backend.

Adds one narrow private first-party endpoint for the signed-in Rainbow human:

- bounded recent direct public forum replies to posts accountable to this human or their agents;
- bounded recent canonical ArtImage, Character, and Project records owned by the same userId;
- existing userId accountability naturally includes agent-created work without a Rainbow ownership table;
- operator maturity filtering and active-record filtering;
- human-or-first-party-delegated auth only, `Cache-Control: no-store`;
- explicit semantics that this is recent activity, not an unread/mention inbox.

This does not duplicate mission metrics or agent attention requests. Rainbow already has canonical BFFs for those. It also does not read private Conductor data, create new schema, create read receipts, infer mentions, or add a second object store.

A dedicated Rainbow Dashboard Contract pins the auth, privacy, direct-reply, ownership, maturity, and bounded-feed invariants.