### PR TITLE
interface-vision/t-104 slice 42: extract kr-btn-ghost primitive, codemod 42 files

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -573,6 +573,15 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply border-error/40 bg-error/10 text-error;
   }
 
+  /* The most-repeated ghost-button shape in the app (interface-vision t-104
+   * slice 42): a small, rounded, low-emphasis action button used for
+   * dismiss/close/secondary controls in headers and toolbars. Previously
+   * hand-rolled as `btn btn-ghost btn-sm rounded-xl` in 40+ files with no
+   * shared name to hang future changes on. */
+  .kr-btn-ghost {
+    @apply btn btn-ghost btn-sm rounded-xl;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/animation/animation-manager.vue
+++ b/components/animation/animation-manager.vue
@@ -40,7 +40,7 @@
         </NuxtLink>
         <button
           v-if="activeCount > 0"
-          class="btn btn-ghost btn-sm rounded-xl"
+          class="kr-btn-ghost"
           type="button"
           @click="store.clearEffects()"
         >

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -488,7 +488,7 @@
               </div>
             </div>
             <button
-              class="btn btn-ghost btn-sm rounded-xl"
+              class="kr-btn-ghost"
               type="button"
               @click="clearSelectedImage"
             >

--- a/components/art/art-generator.vue
+++ b/components/art/art-generator.vue
@@ -530,7 +530,7 @@
           </div>
           <button
             type="button"
-            class="btn btn-ghost btn-sm rounded-xl"
+            class="kr-btn-ghost"
             @click="goToGallery"
           >
             <Icon name="kind-icon:gallery" class="h-4 w-4" />

--- a/components/art/forum-art-generation-context.vue
+++ b/components/art/forum-art-generation-context.vue
@@ -18,7 +18,7 @@
         </p>
       </div>
       <a
-        class="btn btn-ghost btn-sm rounded-xl"
+        class="kr-btn-ghost"
         href="https://rainbowbutterflies.org/#commons"
         target="_blank"
         rel="noopener noreferrer"

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -48,7 +48,7 @@
 
           <button
             v-if="allowRefresh && !isDropdownMode"
-            class="btn btn-ghost btn-sm rounded-xl"
+            class="kr-btn-ghost"
             type="button"
             :disabled="isLoading || botStore.loading"
             @click="refreshBots(true)"
@@ -80,7 +80,7 @@
         </div>
 
         <button
-          class="btn btn-ghost btn-sm rounded-xl"
+          class="kr-btn-ghost"
           type="button"
           @click="closeBotForm"
         >
@@ -553,7 +553,7 @@
                  the absence of the thing it clears. -->
             <button
               v-if="botStore.currentBot"
-              class="btn btn-ghost btn-sm rounded-xl"
+              class="kr-btn-ghost"
               type="button"
               @click="clearSelectedBot"
             >

--- a/components/bots/bot-manager.vue
+++ b/components/bots/bot-manager.vue
@@ -13,7 +13,7 @@
         <div v-if="botStore.selectedBot" class="flex shrink-0 justify-end">
           <button
             type="button"
-            class="btn btn-ghost btn-sm rounded-xl"
+            class="kr-btn-ghost"
             title="Brainstorm variations grounded in this Bot"
             @click="startBrainstormWithBot"
           >

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -45,7 +45,7 @@
             </div>
 
             <button
-              class="btn btn-ghost btn-sm rounded-xl"
+              class="kr-btn-ghost"
               type="button"
               :disabled="isSendingChat"
               @click="clearSelectedCharacter"
@@ -211,7 +211,7 @@
               </div>
 
               <button
-                class="btn btn-ghost btn-sm rounded-xl"
+                class="kr-btn-ghost"
                 type="button"
                 :disabled="chatMessages.length === 0 || isSendingChat"
                 @click="clearChatMessages"

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -109,7 +109,7 @@
               </div>
 
               <button
-                class="btn btn-ghost btn-sm rounded-xl"
+                class="kr-btn-ghost"
                 type="button"
                 :disabled="chatMessages.length === 0 || isSendingChat"
                 @click="clearChatMessages"

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -19,7 +19,7 @@
         </div>
 
         <button
-          class="btn btn-ghost btn-sm rounded-xl"
+          class="kr-btn-ghost"
           type="button"
           @click="closeCharacterForm"
         >

--- a/components/characters/character-manager.vue
+++ b/components/characters/character-manager.vue
@@ -24,7 +24,7 @@
           </button>
           <button
             type="button"
-            class="btn btn-ghost btn-sm rounded-xl"
+            class="kr-btn-ghost"
             title="Brainstorm variations grounded in this Character"
             @click="startBrainstormWithCharacter"
           >

--- a/components/conductor/challenge-center-page.vue
+++ b/components/conductor/challenge-center-page.vue
@@ -51,7 +51,7 @@
               </NuxtLink>
               <button
                 type="button"
-                class="btn btn-ghost btn-sm rounded-xl"
+                class="kr-btn-ghost"
                 :disabled="loading"
                 aria-label="Refresh challenges"
                 @click="loadChallenges"

--- a/components/curation/cthulhuquarium-curation.vue
+++ b/components/curation/cthulhuquarium-curation.vue
@@ -207,7 +207,7 @@
                 <span v-if="isGenerating(fish.slug)" class="loading loading-spinner loading-xs" />
                 {{ isGenerating(fish.slug) ? generationLabel(fish.slug) : 'Generate idea' }}
               </button>
-              <button type="button" class="btn btn-ghost btn-sm rounded-xl" :disabled="isSaving(fish.slug)" @click="save(fish)">
+              <button type="button" class="kr-btn-ghost" :disabled="isSaving(fish.slug)" @click="save(fish)">
                 <span v-if="isSaving(fish.slug)" class="loading loading-spinner loading-xs" />
                 Save curation
               </button>

--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -302,7 +302,7 @@
             </button>
             <button
               v-if="draftDirty"
-              class="btn btn-ghost btn-sm rounded-xl"
+              class="kr-btn-ghost"
               type="button"
               :disabled="saving"
               @click="store.discardDraft()"

--- a/components/dreams/dream-narration.vue
+++ b/components/dreams/dream-narration.vue
@@ -28,7 +28,7 @@
 
           <button
             type="button"
-            class="btn btn-ghost btn-sm rounded-xl"
+            class="kr-btn-ghost"
             @click="backToGallery"
           >
             <Icon name="kind-icon:arrow-left" class="h-4 w-4" />

--- a/components/facets/facet-profile.vue
+++ b/components/facets/facet-profile.vue
@@ -14,7 +14,7 @@
     <header class="kr-toolbar shrink-0 kr-panel-flat p-3">
       <button
         type="button"
-        class="btn btn-ghost btn-sm rounded-xl"
+        class="kr-btn-ghost"
         @click="closeFacet"
       >
         <Icon name="kind-icon:chevron-left" class="size-4" /> All Facets

--- a/components/lora/add-lora.vue
+++ b/components/lora/add-lora.vue
@@ -25,7 +25,7 @@
 
       <button
         v-if="showClose"
-        class="btn btn-ghost btn-sm rounded-xl"
+        class="kr-btn-ghost"
         type="button"
         @click="emit('close')"
       >

--- a/components/model/add-model.vue
+++ b/components/model/add-model.vue
@@ -25,7 +25,7 @@
 
       <button
         v-if="showClose"
-        class="btn btn-ghost btn-sm rounded-xl"
+        class="kr-btn-ghost"
         type="button"
         @click="emit('close')"
       >

--- a/components/pages/creator-earnings-page.vue
+++ b/components/pages/creator-earnings-page.vue
@@ -79,7 +79,7 @@
               </p>
             </div>
             <button
-              class="btn btn-ghost btn-sm rounded-xl"
+              class="kr-btn-ghost"
               :disabled="earningsStore.loading"
               @click="earningsStore.fetch()"
             >

--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -68,7 +68,7 @@
             <button
               v-if="userStore.isAdmin"
               type="button"
-              class="btn btn-ghost btn-sm rounded-xl"
+              class="kr-btn-ghost"
               :disabled="conductorStore.pending"
               @click="conductorStore.fetchProjects(true)"
             >
@@ -271,7 +271,7 @@
                         </button>
                         <button
                           type="button"
-                          class="btn btn-ghost btn-sm rounded-xl"
+                          class="kr-btn-ghost"
                           :disabled="
                             taskIsUpdating(gate.project.slug, gate.task.id) ||
                             !gateMessage(gate.project.slug, gate.task.id).trim()
@@ -394,7 +394,7 @@
                   </button>
                   <button
                     type="button"
-                    class="btn btn-ghost btn-sm rounded-xl"
+                    class="kr-btn-ghost"
                     @click="navigateTo('/conductor')"
                   >
                     Full review

--- a/components/pages/mission-accrual-page.vue
+++ b/components/pages/mission-accrual-page.vue
@@ -133,7 +133,7 @@
               Log a remittance
             </h2>
             <button
-              class="btn btn-ghost btn-sm rounded-xl"
+              class="kr-btn-ghost"
               :disabled="store.loading"
               @click="store.fetch()"
             >

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -626,7 +626,7 @@
           </span>
           <button
             type="button"
-            class="btn btn-ghost btn-sm rounded-xl"
+            class="kr-btn-ghost"
             :disabled="store.isWeaving"
             @click="startOver"
           >

--- a/components/pages/wallet-page.vue
+++ b/components/pages/wallet-page.vue
@@ -40,7 +40,7 @@
             </div>
           </div>
           <button
-            class="btn btn-ghost btn-sm rounded-xl"
+            class="kr-btn-ghost"
             :disabled="karmaStore.loading"
             @click="karmaStore.fetch()"
           >

--- a/components/projects/project-placement-manager.vue
+++ b/components/projects/project-placement-manager.vue
@@ -80,7 +80,7 @@
 
             <button
               type="button"
-              class="btn btn-ghost btn-sm rounded-xl"
+              class="kr-btn-ghost"
               :disabled="busy"
               @click="loadProjects"
             >

--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -461,7 +461,7 @@ onMounted(async () => {
         </button>
         <button
           type="button"
-          class="btn btn-ghost btn-sm rounded-xl"
+          class="kr-btn-ghost"
           @click="closeForm"
         >
           Cancel

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -59,7 +59,7 @@
 
           <button
             v-if="allowRefresh && !isDropdownMode"
-            class="btn btn-ghost btn-sm rounded-xl"
+            class="kr-btn-ghost"
             type="button"
             :disabled="isLoading"
             @click="refreshRewards(true)"
@@ -88,7 +88,7 @@
         </div>
 
         <button
-          class="btn btn-ghost btn-sm rounded-xl"
+          class="kr-btn-ghost"
           type="button"
           @click="closeRewardForm"
         >
@@ -424,7 +424,7 @@
                  note there. Clear has nothing to say without a selection. -->
             <button
               v-if="rewardStore.selectedReward"
-              class="btn btn-ghost btn-sm rounded-xl"
+              class="kr-btn-ghost"
               type="button"
               @click="clearSelectedReward"
             >

--- a/components/rewards/reward-manager.vue
+++ b/components/rewards/reward-manager.vue
@@ -16,7 +16,7 @@
         >
           <button
             type="button"
-            class="btn btn-ghost btn-sm rounded-xl"
+            class="kr-btn-ghost"
             title="Brainstorm variations grounded in this Reward"
             @click="startBrainstormWithReward"
           >

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -33,7 +33,7 @@
 
           <button
             v-if="allowRefresh && !isDropdownMode"
-            class="btn btn-ghost btn-sm rounded-xl"
+            class="kr-btn-ghost"
             type="button"
             :disabled="isLoading"
             @click="refreshScenarios(true)"
@@ -55,7 +55,7 @@
         </h3>
 
         <button
-          class="btn btn-ghost btn-sm rounded-xl"
+          class="kr-btn-ghost"
           type="button"
           @click="showScenarioForm = false"
         >

--- a/components/scenarios/scenario-manager.vue
+++ b/components/scenarios/scenario-manager.vue
@@ -27,7 +27,7 @@
           </button>
           <button
             type="button"
-            class="btn btn-ghost btn-sm rounded-xl"
+            class="kr-btn-ghost"
             title="Brainstorm variations grounded in this Scenario"
             @click="startBrainstormWithScenario"
           >

--- a/components/scenarios/scenario-relationship-gallery.vue
+++ b/components/scenarios/scenario-relationship-gallery.vue
@@ -72,7 +72,7 @@
 
         <button
           type="button"
-          class="btn btn-ghost btn-sm rounded-xl"
+          class="kr-btn-ghost"
           @click="showScenarioForm = false"
         >
           <Icon name="kind-icon:x" class="h-4 w-4" />

--- a/components/servers/add-checkpoint.vue
+++ b/components/servers/add-checkpoint.vue
@@ -18,7 +18,7 @@
 
       <button
         v-if="showClose"
-        class="btn btn-ghost btn-sm rounded-xl"
+        class="kr-btn-ghost"
         type="button"
         @click="emit('close')"
       >

--- a/components/stages/performer-creator.vue
+++ b/components/stages/performer-creator.vue
@@ -30,7 +30,7 @@
         </div>
         <button
           type="button"
-          class="btn btn-ghost btn-sm rounded-xl"
+          class="kr-btn-ghost"
           @click="emit('close')"
         >
           <Icon name="mdi:close" class="h-4 w-4" />
@@ -485,7 +485,7 @@
         <div class="flex gap-2">
           <button
             type="button"
-            class="btn btn-ghost btn-sm rounded-xl"
+            class="kr-btn-ghost"
             @click="emit('close')"
           >
             Cancel

--- a/components/user/avatar-picker.vue
+++ b/components/user/avatar-picker.vue
@@ -31,7 +31,7 @@
 
       <button
         v-if="dismissible"
-        class="btn btn-ghost btn-sm rounded-xl"
+        class="kr-btn-ghost"
         type="button"
         title="Close"
         @click="emit('close')"

--- a/components/user/first-launch-intro.vue
+++ b/components/user/first-launch-intro.vue
@@ -23,7 +23,7 @@
         </div>
 
         <button
-          class="btn btn-ghost btn-sm rounded-xl"
+          class="kr-btn-ghost"
           type="button"
           @click="dismiss"
         >
@@ -90,7 +90,7 @@
         <div class="flex gap-2">
           <button
             v-if="step > 0"
-            class="btn btn-ghost btn-sm rounded-xl"
+            class="kr-btn-ghost"
             type="button"
             @click="back"
           >

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -18,7 +18,7 @@
 
       <button
         v-if="!isGuest"
-        class="btn btn-ghost btn-sm rounded-xl"
+        class="kr-btn-ghost"
         type="button"
         @click="introStore.open()"
       >

--- a/pages/admin/forum-moderation.vue
+++ b/pages/admin/forum-moderation.vue
@@ -17,7 +17,7 @@
         </div>
         <button
           type="button"
-          class="btn btn-ghost btn-sm rounded-xl"
+          class="kr-btn-ghost"
           :disabled="loading"
           @click="moderationStore.fetchHiddenPosts()"
         >

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -246,7 +246,7 @@
           <div class="flex items-center gap-2">
             <button
               type="button"
-              class="btn btn-ghost btn-sm rounded-xl"
+              class="kr-btn-ghost"
               :disabled="safePage <= 1"
               @click="page = safePage - 1"
             >
@@ -255,7 +255,7 @@
             <span class="text-sm font-bold">Page {{ safePage }} / {{ totalPages }}</span>
             <button
               type="button"
-              class="btn btn-ghost btn-sm rounded-xl"
+              class="kr-btn-ghost"
               :disabled="safePage >= totalPages"
               @click="page = safePage + 1"
             >

--- a/pages/admin/social-drafts.vue
+++ b/pages/admin/social-drafts.vue
@@ -100,7 +100,7 @@
           </label>
           <button
             type="button"
-            class="btn btn-ghost btn-sm rounded-xl"
+            class="kr-btn-ghost"
             :disabled="loading"
             @click="draftsStore.fetchDrafts()"
           >

--- a/pages/play/aquarium/browse/[username]/[slug].vue
+++ b/pages/play/aquarium/browse/[username]/[slug].vue
@@ -13,7 +13,7 @@
       <nav>
         <NuxtLink
           to="/play/aquarium/browse"
-          class="btn btn-ghost btn-sm rounded-xl"
+          class="kr-btn-ghost"
         >
           <Icon name="kind-icon:arrow-left" class="size-4" />
           Public tanks

--- a/pages/play/aquarium/browse/index.vue
+++ b/pages/play/aquarium/browse/index.vue
@@ -10,7 +10,7 @@
       class="kr-scroll kr-container max-w-5xl space-y-5 px-3 py-5 sm:px-6 sm:py-8"
     >
       <nav class="flex items-center justify-between gap-3">
-        <NuxtLink to="/play/aquarium" class="btn btn-ghost btn-sm rounded-xl">
+        <NuxtLink to="/play/aquarium" class="kr-btn-ghost">
           <Icon name="kind-icon:arrow-left" class="size-4" />
           Your tank
         </NuxtLink>

--- a/pages/play/aquarium/leaderboard/index.vue
+++ b/pages/play/aquarium/leaderboard/index.vue
@@ -11,7 +11,7 @@
       class="kr-scroll kr-container max-w-3xl space-y-5 px-3 py-5 sm:px-6 sm:py-8"
     >
       <nav class="flex items-center justify-between gap-3">
-        <NuxtLink to="/play/aquarium" class="btn btn-ghost btn-sm rounded-xl">
+        <NuxtLink to="/play/aquarium" class="kr-btn-ghost">
           <Icon name="kind-icon:arrow-left" class="size-4" />
           Your tank
         </NuxtLink>

--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -4,7 +4,7 @@
       class="kr-scroll kr-container max-w-7xl space-y-5 px-3 py-5 sm:px-6 sm:py-8"
     >
       <nav class="flex flex-wrap items-center justify-between gap-3">
-        <NuxtLink to="/play/challenges" class="btn btn-ghost btn-sm rounded-xl">
+        <NuxtLink to="/play/challenges" class="kr-btn-ghost">
           <Icon name="kind-icon:arrow-left" class="size-4" />
           Fight card
         </NuxtLink>
@@ -445,7 +445,7 @@
             </div>
             <NuxtLink
               to="/play/challenges/leaderboard"
-              class="btn btn-ghost btn-sm rounded-xl"
+              class="kr-btn-ghost"
             >
               Full championship table →
             </NuxtLink>

--- a/pages/play/challenges/leaderboard.vue
+++ b/pages/play/challenges/leaderboard.vue
@@ -4,7 +4,7 @@
       class="kr-scroll kr-container max-w-7xl space-y-5 px-3 py-5 sm:px-6 sm:py-8"
     >
       <nav class="flex flex-wrap items-center justify-between gap-3">
-        <NuxtLink to="/play/challenges" class="btn btn-ghost btn-sm rounded-xl">
+        <NuxtLink to="/play/challenges" class="kr-btn-ghost">
           <Icon name="kind-icon:arrow-left" class="size-4" />
           Fight card
         </NuxtLink>


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (recurring umbrella, slice 42)  (kind: software)

### What changed / what I produced
- Added `.kr-btn-ghost` to `assets/css/tailwind.css`'s `@layer components` block, bundling the most-repeated ghost-button shape in the app (`btn btn-ghost btn-sm rounded-xl`, 54 occurrences repo-wide per a fresh survey) as a named `kr-*` primitive — same pattern as the existing `.kr-panel`/`.kr-panel-section`/`.kr-note` classes.
- Codemodded the 42 files whose `class` attribute matched this exact shape as a static string (no conditional binding) to `class="kr-btn-ghost"`.

### How I verified
- **CSS equivalence**: compiled `assets/css/tailwind.css` standalone via `@tailwindcss/node`'s `compile()` before committing and confirmed `.kr-btn-ghost` expands to the full daisyUI `.btn`/`.btn-ghost`/`.btn-sm` ruleset plus `border-radius: var(--radius-xl)` — byte-equivalent to the literal class combination it replaces. No geometry or behavior change.
- `npm run test` (vue-tsc --noEmit): clean.
- `npm run test:lint-ratchet`: holds, 332 problems across 24 rules (-60 vs. baseline), no rule regressed.
- `npm run test:layout-contract`: holds, no new violations.
- Confirmed every ESLint finding still present in the diff's files (art-gallery.vue, character-flip-card.vue, character-gallery.vue, for-you-manager.vue, add-checkpoint.vue) is pre-existing on `main`, on lines untouched by this diff.
- Confirmed the repo's pre-existing `prettier --check` drift on several of these files (color-mix formatting, attribute wrapping, etc.) predates this change — reproduced the same failures against the unmodified `HEAD` copies before touching anything, and deliberately did not run `prettier --write` across whole files to avoid dragging unrelated reformatting into this diff. CI here does not gate on `lint:prettier` (only `test:lint-ratchet` runs in `contract-tests.yml`).

### Stakes
reversible

### Flags for Reviewer
- None — bounded, mechanical, verified equivalent.

### Kaizen suggestion
The umbrella's own note already tracks the next dimension: `btn-ghost` still has several other distinct exact shapes not yet surveyed (`btn btn-ghost btn-xs rounded-xl` ×32, `btn btn-ghost btn-xs` ×30, `btn btn-ghost btn-sm rounded-2xl` ×23, `btn btn-ghost btn-xs rounded-lg` ×21, `btn btn-ghost btn-sm` ×21) — good material for slice 43.

### Notes for reviewer
This is a recurring consistency-umbrella task (interface-vision/t-104); the conductor roadmap task re-arms to `ready` after this merges rather than closing to `done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Avjohxo1x9eQVsF4PQ7j7q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Avjohxo1x9eQVsF4PQ7j7q)_