### PR TITLE
interface-vision/t-104 slice 43: extract kr-btn-ghost-xs, codemod 20 files

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -582,6 +582,13 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-ghost btn-sm rounded-xl;
   }
 
+  /* Second-most-repeated ghost-button shape (interface-vision t-104 slice 43):
+   * the same low-emphasis action button as .kr-btn-ghost, one size down —
+   * `btn btn-ghost btn-xs rounded-xl`, previously hand-rolled in 20+ files. */
+  .kr-btn-ghost-xs {
+    @apply btn btn-ghost btn-xs rounded-xl;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/add-collection.vue
+++ b/components/art/add-collection.vue
@@ -25,7 +25,7 @@
           <span class="label-text font-bold">New Collection</span>
 
           <button
-            class="btn btn-ghost btn-xs rounded-xl"
+            class="kr-btn-ghost-xs"
             type="button"
             :disabled="isSaving"
             @click="closeForm"

--- a/components/art/art-facet-selector.vue
+++ b/components/art/art-facet-selector.vue
@@ -13,7 +13,7 @@
       <button
         v-if="modelValue.length"
         type="button"
-        class="btn btn-ghost btn-xs rounded-xl"
+        class="kr-btn-ghost-xs"
         @click="emitValue([])"
       >
         Clear
@@ -115,7 +115,7 @@
             <button
               v-if="!facetArtwork(facet)"
               type="button"
-              class="btn btn-ghost btn-xs rounded-xl"
+              class="kr-btn-ghost-xs"
               :disabled="artRequests.requesting[facet.id]"
               :title="`Request curated artwork for ${facet.title}`"
               @click="requestArtwork(facet)"

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -254,7 +254,7 @@
             </button>
 
             <button
-              class="btn btn-ghost btn-xs rounded-xl"
+              class="kr-btn-ghost-xs"
               type="button"
               :disabled="isBatchWorking || !selectedImageCount"
               @click="clearImageSelection"

--- a/components/art/art-generator.vue
+++ b/components/art/art-generator.vue
@@ -99,7 +99,7 @@
               <button
                 v-if="hasDrifted"
                 type="button"
-                class="btn btn-ghost btn-xs rounded-xl"
+                class="kr-btn-ghost-xs"
                 @click="applyPreset(presetId)"
               >
                 Reset to {{ activePreset.label }}
@@ -155,7 +155,7 @@
                 </span>
                 <button
                   type="button"
-                  class="btn btn-ghost btn-xs rounded-xl"
+                  class="kr-btn-ghost-xs"
                   :disabled="artStore.isGenerating"
                   @click="clearPrompt"
                 >
@@ -209,7 +209,7 @@
               </button>
               <button
                 type="button"
-                class="btn btn-ghost btn-xs rounded-xl"
+                class="kr-btn-ghost-xs"
                 :disabled="artStore.isGenerating"
                 @click="randomStore.resetAll()"
               >

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -409,7 +409,7 @@
                     Collection Membership
                   </p>
                   <button
-                    class="btn btn-ghost btn-xs rounded-xl"
+                    class="kr-btn-ghost-xs"
                     type="button"
                     @click="isCollectionMenuOpen = false"
                   >

--- a/components/art/art-lora-picker.vue
+++ b/components/art/art-lora-picker.vue
@@ -16,7 +16,7 @@
         <button
           v-if="rankedLoras.length"
           type="button"
-          class="btn btn-ghost btn-xs rounded-xl"
+          class="kr-btn-ghost-xs"
           @click="expanded = !expanded"
         >
           {{ expanded ? 'Comfortable height' : 'Expand browser' }}
@@ -24,7 +24,7 @@
         <button
           v-if="modelValue.length"
           type="button"
-          class="btn btn-ghost btn-xs rounded-xl"
+          class="kr-btn-ghost-xs"
           @click="emitValue([])"
         >
           Clear all

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -264,7 +264,7 @@
               </label>
               <button
                 type="button"
-                class="btn btn-ghost btn-xs rounded-xl"
+                class="kr-btn-ghost-xs"
                 :disabled="artJobStore.loadingJobs"
                 @click="applyPageSize"
               >

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -282,7 +282,7 @@
 
               <div class="mt-3 flex justify-end">
                 <button
-                  class="btn btn-ghost btn-xs rounded-xl"
+                  class="kr-btn-ghost-xs"
                   type="button"
                   :disabled="!selectedGettingToKnowYouQuestion || isSendingChat"
                   @click="clearSelectedPrompt"

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -415,7 +415,7 @@
               </div>
 
               <button
-                class="btn btn-ghost btn-xs rounded-xl"
+                class="kr-btn-ghost-xs"
                 type="button"
                 :disabled="!selectedGettingToKnowYouQuestion || isSendingChat"
                 @click="clearSelectedPrompt"

--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -32,7 +32,7 @@
           New pack
         </button>
         <button
-          class="btn btn-ghost btn-xs rounded-xl"
+          class="kr-btn-ghost-xs"
           @click="showImport = !showImport"
         >
           Load manifest JSON
@@ -108,7 +108,7 @@
           >{{ packStore.packBuildStatus(selectedPack.id) }}</span
         >
         <button
-          class="btn btn-ghost btn-xs rounded-xl"
+          class="kr-btn-ghost-xs"
           title="Rename the pack or edit its manifest entries"
           @click="editorMode = 'edit'"
         >
@@ -187,7 +187,7 @@
             </button>
             <button
               v-if="stateFor(item.id).refId"
-              class="btn btn-ghost btn-xs rounded-xl"
+              class="kr-btn-ghost-xs"
               :disabled="isBusy(item.id)"
               title="Forget the local link and start this item over as a fresh row"
               @click="packStore.resetItem(selectedPack.id, item.id)"

--- a/components/conductor/packmaker-pack-editor.vue
+++ b/components/conductor/packmaker-pack-editor.vue
@@ -15,7 +15,7 @@
       <h4 class="text-sm font-black text-base-content">
         {{ editingExisting ? `Edit pack: ${draft.title}` : 'New pack' }}
       </h4>
-      <button class="btn btn-ghost btn-xs rounded-xl" @click="emit('close')">
+      <button class="kr-btn-ghost-xs" @click="emit('close')">
         Close
       </button>
     </div>
@@ -103,7 +103,7 @@
         <span class="text-xs font-bold text-base-content/70"
           >Items ({{ draft.items.length }})</span
         >
-        <button class="btn btn-ghost btn-xs rounded-xl" @click="addItem">
+        <button class="kr-btn-ghost-xs" @click="addItem">
           <Icon name="kind-icon:plus" class="size-3.5" />
           Add item
         </button>

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -322,7 +322,7 @@
                 <div class="mt-2 flex flex-wrap justify-between gap-2">
                   <button
                     type="button"
-                    class="btn btn-ghost btn-xs rounded-xl"
+                    class="kr-btn-ghost-xs"
                     @click="useCandidateAsSeed(candidate)"
                   >
                     Use as Seed

--- a/components/gallery/kr-card-back.vue
+++ b/components/gallery/kr-card-back.vue
@@ -175,7 +175,7 @@
 
           <button
             type="button"
-            class="btn btn-ghost btn-xs rounded-xl"
+            class="kr-btn-ghost-xs"
             @click="editing = false"
           >
             <Icon name="kind-icon:x" class="h-3.5 w-3.5" />

--- a/components/newsfeed/newsfeed-filters.vue
+++ b/components/newsfeed/newsfeed-filters.vue
@@ -18,7 +18,7 @@
       </div>
       <button
         type="button"
-        class="btn btn-ghost btn-xs rounded-xl"
+        class="kr-btn-ghost-xs"
         @click="clearFilters()"
       >
         Clear filters

--- a/components/servers/checkpoint-gallery.vue
+++ b/components/servers/checkpoint-gallery.vue
@@ -113,7 +113,7 @@
 
           <button
             v-if="showControls && allowRefresh"
-            class="btn btn-ghost btn-xs rounded-xl"
+            class="kr-btn-ghost-xs"
             type="button"
             @click="refreshStatus"
           >

--- a/components/servers/server-gallery.vue
+++ b/components/servers/server-gallery.vue
@@ -73,7 +73,7 @@
           </select>
 
           <button
-            class="btn btn-ghost btn-xs rounded-xl"
+            class="kr-btn-ghost-xs"
             type="button"
             @click="refreshServers"
           >

--- a/components/stages/performer-creator.vue
+++ b/components/stages/performer-creator.vue
@@ -328,7 +328,7 @@
             />
             <button
               type="button"
-              class="btn btn-ghost btn-xs rounded-xl"
+              class="kr-btn-ghost-xs"
               @click="speciesCustomMode = false"
             >
               Cancel
@@ -456,7 +456,7 @@
             </button>
             <button
               type="button"
-              class="btn btn-ghost btn-xs rounded-xl"
+              class="kr-btn-ghost-xs"
               @click="traitCustomMode = false"
             >
               Cancel

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -55,7 +55,7 @@
           </button>
           <button
             type="button"
-            class="btn btn-ghost btn-xs rounded-xl"
+            class="kr-btn-ghost-xs"
             @click="store.stop()"
           >
             <Icon name="mdi:stop" class="h-3.5 w-3.5" />
@@ -63,7 +63,7 @@
         </template>
         <button
           type="button"
-          class="btn btn-ghost btn-xs rounded-xl"
+          class="kr-btn-ghost-xs"
           @click="store.persist()"
         >
           <Icon name="mdi:content-save" class="h-3.5 w-3.5" />
@@ -392,7 +392,7 @@
 
                 <button
                   type="button"
-                  class="btn btn-ghost btn-xs rounded-xl"
+                  class="kr-btn-ghost-xs"
                   @click="clearPendingCastMember"
                 >
                   <Icon name="mdi:close" class="h-3.5 w-3.5" />
@@ -431,7 +431,7 @@
                   <button
                     v-if="canAddSlot(role.key)"
                     type="button"
-                    class="btn btn-ghost btn-xs rounded-xl"
+                    class="kr-btn-ghost-xs"
                     @click="store.addCastSlot(role.key)"
                   >
                     <Icon name="mdi:plus" class="h-3.5 w-3.5" />

--- a/components/user/user-galleries.vue
+++ b/components/user/user-galleries.vue
@@ -56,7 +56,7 @@
             <div class="flex flex-wrap gap-2">
               <NuxtLink
                 :to="section.to"
-                class="btn btn-ghost btn-xs rounded-xl"
+                class="kr-btn-ghost-xs"
               >
                 <Icon name="kind-icon:external-link" class="h-4 w-4" />
                 Open {{ section.label }}

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -107,7 +107,7 @@
             <span class="text-sm font-bold">{{ triageStore.selectedCount }} selected</span>
             <button
               type="button"
-              class="btn btn-ghost btn-xs rounded-xl"
+              class="kr-btn-ghost-xs"
               :disabled="pageResources.length === 0"
               @click="selectPage"
             >
@@ -115,7 +115,7 @@
             </button>
             <button
               type="button"
-              class="btn btn-ghost btn-xs rounded-xl"
+              class="kr-btn-ghost-xs"
               :disabled="triageStore.selectedCount === 0"
               @click="triageStore.clearSelection()"
             >


### PR DESCRIPTION
## Summary

Slice 43 of the ongoing interface-vision/t-104 consistency umbrella. Slice 42 extracted `.kr-btn-ghost` (`btn btn-ghost btn-sm rounded-xl`) and flagged the next-most-repeated `btn-ghost` shape for a future slice: `btn-ghost btn-xs rounded-xl` (32 raw occurrences).

- Added `.kr-btn-ghost-xs` to `assets/css/tailwind.css` (`@apply btn btn-ghost btn-xs rounded-xl`), following the same pattern as `.kr-btn-ghost`.
- Codemodded the 20 files whose `class` attribute matched the exact static string `class="btn btn-ghost btn-xs rounded-xl"` (no conditional binding) to `class="kr-btn-ghost-xs"`. 11 further sites carry extra classes appended (e.g. `gap-1 border border-base-300`, `text-error`) and are deliberately left out of scope, matching this project's exact-match-only codemod convention.

## Verification
- Compiled `.kr-btn-ghost-xs` standalone via `@tailwindcss/postcss` before committing and confirmed it expands to the full DaisyUI ghost-button ruleset (hover/active/focus states, size vars, border-radius) — same check slice 42 introduced when it first proved a DaisyUI *component* class works under `@apply` in this Tailwind v4 + DaisyUI 5 setup.
- `npm run test` (vue-tsc): clean.
- `npm run test:lint-ratchet`: 332 problems (-60 vs. baseline), no rule regressed.
- `npm run test:layout-contract`: no new violations.
- `prettier --check` on the 12 touched files: all 12 already fail on unmodified `main` too (confirmed against `git show HEAD:<file>` for each) — pre-existing repo-wide formatting drift, not introduced by this diff. CI here doesn't gate on `lint:prettier`.

## Remaining `btn-ghost` scope for a future slice
`btn-ghost btn-xs` (30), `btn-ghost btn-sm rounded-2xl` (23), `btn-ghost btn-xs rounded-lg` (21), `btn-ghost btn-sm` (21) — each a distinct exact shape, per slice 42's original survey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHAZ5mzUWABs9YBD33nD4g)_