### PR TITLE
test(storybook): lock library storage recovery guard

### DIFF
--- a/.github/workflows/storybook-library-storage-recovery-contract.yml
+++ b/.github/workflows/storybook-library-storage-recovery-contract.yml
@@ -1,0 +1,30 @@
+name: Storybook Library Storage Recovery Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: storybook-library-storage-recovery-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Storybook library storage recovery contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify Storybook library storage recovery guard
+        run: node utils/scripts/verifyStorybookLibraryStorageRecoveryGuard.mjs

--- a/utils/scripts/verifyStorybookLibraryStorageRecoveryGuard.mjs
+++ b/utils/scripts/verifyStorybookLibraryStorageRecoveryGuard.mjs
@@ -1,0 +1,24 @@
+// /utils/scripts/verifyStorybookLibraryStorageRecoveryGuard.mjs
+// Regression guard for Storybook library initialization recovery.
+// A failed localStorage read can mean storage access itself is forbidden, so
+// cleanup in the catch block must be best-effort rather than another throwing
+// storage operation.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { extractTsFunctionBody } from './lib/extractTsFunctionBody.mjs'
+
+const HELPER_PATH = 'stores/helpers/storybookLibraryHelper.ts'
+const helperContent = readFileSync(resolve(process.cwd(), HELPER_PATH), 'utf8')
+const initializeBody = extractTsFunctionBody(helperContent, 'initialize', {
+  path: HELPER_PATH,
+  notFoundHint: 'If library initialization moved, move this recovery guard with it.',
+})
+
+assert.match(
+  initializeBody,
+  /catch\s*\{[\s\S]*?try\s*\{[\s\S]*?localStorage\.removeItem\(LIBRARY_STORAGE_KEY\)[\s\S]*?\}\s*catch\s*\{[\s\S]*?\}/,
+  `${HELPER_PATH} initialize() must keep localStorage.removeItem(LIBRARY_STORAGE_KEY) inside its own try/catch when recovering from a failed read. Storage access failures can make cleanup throw too.`,
+)
+
+console.log('Storybook library storage recovery guard verified.')


### PR DESCRIPTION
## Summary
- add a source-level regression contract for Storybook library initialization recovery
- require the recovery `removeItem()` to remain inside its own best-effort try/catch
- run the contract in dedicated Node 24 CI

The actual recovery fix requested by `storybook/t-010` is already present on current `main`; this PR makes that invariant durable without touching unrelated Storybook code.

Conductor session: `openai-scheduled-20260903T041220Z-storybook-t010-q7n3`