### PR TITLE
interface-vision/t-104 slice 44: extract kr-btn-ghost-xs-plain, codemod 17 files

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -589,6 +589,17 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-ghost btn-xs rounded-xl;
   }
 
+  /* Third-most-repeated ghost-button shape (interface-vision t-104 slice 44):
+   * same size as .kr-btn-ghost-xs but with no rounded-* override, so it
+   * renders at DaisyUI's own default button radius instead of rounded-xl —
+   * `btn btn-ghost btn-xs`, previously hand-rolled in 17 files. Suffixed
+   * `-plain` (not `-xs`, already taken by the rounded-xl shape above) to
+   * keep the "no radius override" case a distinct, correctly-named primitive
+   * rather than conflating it with the rounded variant. */
+  .kr-btn-ghost-xs-plain {
+    @apply btn btn-ghost btn-xs;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/animation/animation-manager.vue
+++ b/components/animation/animation-manager.vue
@@ -136,7 +136,7 @@
             </h3>
           </div>
           <button
-            class="btn btn-ghost btn-xs"
+            class="kr-btn-ghost-xs-plain"
             type="button"
             title="Close details"
             @click="store.selectSlug(null)"

--- a/components/art/build-bench.vue
+++ b/components/art/build-bench.vue
@@ -45,7 +45,7 @@
             <span v-if="store.state.winner === side" class="badge badge-success badge-sm">🏆 winner</span>
           </div>
           <button
-            class="btn btn-ghost btn-xs"
+            class="kr-btn-ghost-xs-plain"
             :disabled="running"
             :title="`Copy Build ${side}'s entire config onto Build ${side === 'A' ? 'B' : 'A'}`"
             @click="store.cloneTo(side)"
@@ -201,7 +201,7 @@
             <span class="ml-1 opacity-60">{{ m.note }}</span>
           </span>
           <span class="flex gap-1">
-            <button class="btn btn-ghost btn-xs" @click="store.loadSaved(m)">Load</button>
+            <button class="kr-btn-ghost-xs-plain" @click="store.loadSaved(m)">Load</button>
             <button class="btn btn-ghost btn-xs text-error" @click="store.deleteSaved(m.id)">✕</button>
           </span>
         </li>

--- a/components/art/stylist-clients.vue
+++ b/components/art/stylist-clients.vue
@@ -61,7 +61,7 @@
               <Icon name="kind-icon:image" class="size-3.5" />
               {{ openGalleryId === customer.id ? 'Close gallery' : 'Open gallery' }}
             </button>
-            <button type="button" class="btn btn-ghost btn-xs" @click="edit(customer)">Edit</button>
+            <button type="button" class="kr-btn-ghost-xs-plain" @click="edit(customer)">Edit</button>
             <button type="button" class="btn btn-ghost btn-xs text-error" @click="confirmRemove(customer)">Delete</button>
           </div>
         </div>

--- a/components/art/stylist-history.vue
+++ b/components/art/stylist-history.vue
@@ -59,7 +59,7 @@
           </span>
           <button
             type="button"
-            class="btn btn-ghost btn-xs"
+            class="kr-btn-ghost-xs-plain"
             @click="toggleReceipt(appointment.id)"
           >
             Receipt

--- a/components/art/stylist-mask-brush.vue
+++ b/components/art/stylist-mask-brush.vue
@@ -37,7 +37,7 @@
       <button
         v-if="hasPainted"
         type="button"
-        class="btn btn-ghost btn-xs"
+        class="kr-btn-ghost-xs-plain"
         @click="clear"
       >
         <Icon name="mdi:eraser" class="h-3.5 w-3.5" /> Clear

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -333,7 +333,7 @@
             <button
               v-if="job.status === 'failed'"
               type="button"
-              class="btn btn-ghost btn-xs"
+              class="kr-btn-ghost-xs-plain"
               @click="stylist.retryJob(job.id)"
             >
               Retry
@@ -385,7 +385,7 @@
         </span>
         <span v-if="stylist.isLoadingHistory" class="loading loading-spinner loading-xs text-primary" />
         <div class="flex-1" />
-        <button type="button" class="btn btn-ghost btn-xs" @click="stylist.loadHistory(true)">
+        <button type="button" class="kr-btn-ghost-xs-plain" @click="stylist.loadHistory(true)">
           Refresh
         </button>
       </div>

--- a/components/brainstorm/brainstorm-candidate-card.vue
+++ b/components/brainstorm/brainstorm-candidate-card.vue
@@ -262,7 +262,7 @@
           <div v-if="!entry.current" class="mt-2 flex justify-end">
             <button
               type="button"
-              class="btn btn-ghost btn-xs"
+              class="kr-btn-ghost-xs-plain"
               :disabled="disabled"
               @click="emit('restoreRevision', entry.index)"
             >

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -481,7 +481,7 @@
               </p>
               <button
                 type="button"
-                class="btn btn-ghost btn-xs"
+                class="kr-btn-ghost-xs-plain"
                 :disabled="isPersisting"
                 data-testid="brainstorm-load-saved-list"
                 @click="loadSavedSessions"

--- a/components/curation/coloring-book-curation.vue
+++ b/components/curation/coloring-book-curation.vue
@@ -42,11 +42,11 @@
 
     <div v-if="notice" class="alert border border-info/25 bg-info/10">
       <span>{{ notice }}</span>
-      <button class="btn btn-ghost btn-xs" type="button" @click="notice = ''">Dismiss</button>
+      <button class="kr-btn-ghost-xs-plain" type="button" @click="notice = ''">Dismiss</button>
     </div>
     <div v-if="error" class="alert border border-error/25 bg-error/10">
       <span>{{ error }}</span>
-      <button class="btn btn-ghost btn-xs" type="button" @click="error = ''">Dismiss</button>
+      <button class="kr-btn-ghost-xs-plain" type="button" @click="error = ''">Dismiss</button>
     </div>
 
     <div v-if="store.loading && !store.books.length" class="grid min-h-64 place-items-center kr-panel">

--- a/components/curation/cthulhuquarium-curation.vue
+++ b/components/curation/cthulhuquarium-curation.vue
@@ -29,11 +29,11 @@
 
     <div v-if="notice" class="alert border border-info/25 bg-info/10">
       <span>{{ notice }}</span>
-      <button class="btn btn-ghost btn-xs" type="button" @click="notice = ''">Dismiss</button>
+      <button class="kr-btn-ghost-xs-plain" type="button" @click="notice = ''">Dismiss</button>
     </div>
     <div v-if="error" class="alert border border-error/25 bg-error/10">
       <span class="min-w-0 flex-1 break-words">{{ error }}</span>
-      <button class="btn btn-ghost btn-xs" type="button" @click="error = ''">Dismiss</button>
+      <button class="kr-btn-ghost-xs-plain" type="button" @click="error = ''">Dismiss</button>
     </div>
 
     <div v-if="loading" class="grid min-h-64 place-items-center kr-panel">
@@ -62,7 +62,7 @@
               </div>
               <p class="mt-1 text-xs italic text-base-content/50">{{ fish.species }}</p>
             </div>
-            <a :href="fish.sourceUrl" target="_blank" rel="noreferrer" class="btn btn-ghost btn-xs">
+            <a :href="fish.sourceUrl" target="_blank" rel="noreferrer" class="kr-btn-ghost-xs-plain">
               YAML ↗
             </a>
           </div>

--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -87,11 +87,11 @@
 
     <div v-if="notice" class="alert border border-success/25 bg-success/10 text-sm">
       <span>{{ notice }}</span>
-      <button class="btn btn-ghost btn-xs" type="button" @click="notice = ''">Dismiss</button>
+      <button class="kr-btn-ghost-xs-plain" type="button" @click="notice = ''">Dismiss</button>
     </div>
     <div v-if="error" class="alert border border-error/25 bg-error/10 text-sm">
       <span class="min-w-0 flex-1 break-words">{{ error }}</span>
-      <button class="btn btn-ghost btn-xs" type="button" @click="error = ''">Dismiss</button>
+      <button class="kr-btn-ghost-xs-plain" type="button" @click="error = ''">Dismiss</button>
     </div>
 
     <div v-if="loading && !payload" class="grid min-h-64 place-items-center kr-panel">
@@ -174,7 +174,7 @@
                   <span v-else class="text-xs text-base-content/35">source</span>
                 </td>
                 <td>
-                  <button class="btn btn-ghost btn-xs" type="button" @click.stop="store.selectCard(row.cardKey)">
+                  <button class="kr-btn-ghost-xs-plain" type="button" @click.stop="store.selectCard(row.cardKey)">
                     Edit
                   </button>
                 </td>

--- a/components/ruler-hooked/ruler-hooked-cosmetics-picker.vue
+++ b/components/ruler-hooked/ruler-hooked-cosmetics-picker.vue
@@ -66,7 +66,7 @@
           class="size-8 rounded object-cover"
         />
         {{ customFile.name }}
-        <button type="button" class="btn btn-ghost btn-xs" @click="clearCustom">
+        <button type="button" class="kr-btn-ghost-xs-plain" @click="clearCustom">
           clear
         </button>
       </span>

--- a/components/ruler-hooked/ruler-hooked-slots.vue
+++ b/components/ruler-hooked/ruler-hooked-slots.vue
@@ -16,7 +16,7 @@
           <span class="font-medium">{{ slot.name }}</span>
           <span class="ml-2 text-xs opacity-60">turn {{ slot.turnCount }} · {{ slot.status.toLowerCase() }}</span>
         </button>
-        <button type="button" class="btn btn-ghost btn-xs" @click="rename(slot.saveId, slot.name)">rename</button>
+        <button type="button" class="kr-btn-ghost-xs-plain" @click="rename(slot.saveId, slot.name)">rename</button>
         <button type="button" class="btn btn-ghost btn-xs text-error" @click="store.deleteSlot(slot.saveId)">delete</button>
       </div>
     </div>

--- a/components/stages/stage-slot.vue
+++ b/components/stages/stage-slot.vue
@@ -27,7 +27,7 @@
         </div>
 
         <button
-          class="btn btn-ghost btn-xs"
+          class="kr-btn-ghost-xs-plain"
           title="Clear slot"
           @click="emit('clear', slot.slotId)"
         >
@@ -77,7 +77,7 @@
         </select>
 
         <button
-          class="btn btn-ghost btn-xs"
+          class="kr-btn-ghost-xs-plain"
           title="Generate temporary bot for this role"
           @click="emit('requestTemporary', slot.slotId, slot.roleKey)"
         >
@@ -86,7 +86,7 @@
 
         <button
           v-if="removable"
-          class="btn btn-ghost btn-xs"
+          class="kr-btn-ghost-xs-plain"
           title="Remove slot"
           @click="emit('removeSlot', slot.slotId)"
         >

--- a/components/user/messenger.vue
+++ b/components/user/messenger.vue
@@ -15,7 +15,7 @@
       >
         <h2 class="font-black">Messages</h2>
         <button
-          class="btn btn-ghost btn-xs"
+          class="kr-btn-ghost-xs-plain"
           :disabled="convo.isLoadingList"
           @click="convo.loadConversations()"
         >

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -201,7 +201,7 @@
             >
               <div class="flex items-start justify-between gap-3">
                 <pre class="whitespace-pre-wrap font-sans text-sm text-error">{{ store.error }}</pre>
-                <button class="btn btn-ghost btn-xs" type="button" @click="store.clearError()">Dismiss</button>
+                <button class="kr-btn-ghost-xs-plain" type="button" @click="store.clearError()">Dismiss</button>
               </div>
             </div>
 

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -175,11 +175,11 @@
               </span>
             </div>
             <div class="flex items-center gap-1">
-              <button v-if="focusKey" type="button" class="btn btn-ghost btn-xs" @click="store.clearFocus()">
+              <button v-if="focusKey" type="button" class="kr-btn-ghost-xs-plain" @click="store.clearFocus()">
                 Return to deck
               </button>
-              <button type="button" class="btn btn-ghost btn-xs" @click="workspaceView = 'sets'">Change set</button>
-              <button type="button" class="btn btn-ghost btn-xs" @click="workspaceView = 'gallery'">Gallery</button>
+              <button type="button" class="kr-btn-ghost-xs-plain" @click="workspaceView = 'sets'">Change set</button>
+              <button type="button" class="kr-btn-ghost-xs-plain" @click="workspaceView = 'gallery'">Gallery</button>
             </div>
           </div>
 
@@ -307,7 +307,7 @@
                       <button
                         v-if="currentArtJobId"
                         type="button"
-                        class="btn btn-ghost btn-xs"
+                        class="kr-btn-ghost-xs-plain"
                         :disabled="artBusy"
                         @click="refreshCurrentIllustration"
                       >
@@ -369,7 +369,7 @@
                   <button v-if="canQueueArt" type="button" class="btn btn-outline btn-xs" :disabled="artBusy" @click="queueCurrentIllustration">
                     {{ artBusy ? 'Submitting…' : 'Request illustration' }}
                   </button>
-                  <button v-if="currentArtJobId" type="button" class="btn btn-ghost btn-xs" :disabled="artBusy" @click="refreshCurrentIllustration">
+                  <button v-if="currentArtJobId" type="button" class="kr-btn-ghost-xs-plain" :disabled="artBusy" @click="refreshCurrentIllustration">
                     Check art #{{ currentArtJobId }}
                   </button>
                 </div>


### PR DESCRIPTION
Conductor: interface-vision/t-104 slice 44.

Third-most-repeated ghost-button shape flagged by slice 42/43's survey: `btn btn-ghost btn-xs` (no `rounded-*` override) — 30 exact occurrences across 17 files.

- Added `.kr-btn-ghost-xs-plain` to `assets/css/tailwind.css`, immediately after `.kr-btn-ghost-xs`. Named `-plain` rather than reusing `-xs` since that name is already taken by the rounded-xl variant from slice 43 — this shape deliberately carries no radius override, using DaisyUI's own default button radius instead.
- Verified the compiled ruleset via the actual `@tailwindcss/postcss` plugin (the same one Nuxt's build uses) before codemodding, confirming `.kr-btn-ghost-xs-plain` expands to the full DaisyUI ghost-button rule set.
- Codemodded the 17 files whose `class` attribute matched the exact static string `btn btn-ghost btn-xs` (no conditional binding) to `class="kr-btn-ghost-xs-plain"`. No geometry or behavior change.

Verified:
- `npm run test` (vue-tsc --noEmit) clean.
- `npm run test:lint-ratchet` holds (332 problems, -60 vs. baseline, no rule regressed).
- `npm run test:layout-contract` holds (no new violations, 207 baseline unchanged).
- `prettier --check` flags 15 of the touched files, but confirmed byte-identical against unmodified `HEAD` copies of the same files — pre-existing repo-wide drift, not introduced by this diff. CI here doesn't gate on `lint:prettier`.

Remaining `btn-ghost` shapes for the next slice: `btn-ghost btn-sm rounded-2xl` (23), `btn-ghost btn-xs rounded-lg` (21), `btn-ghost btn-sm` (21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHAmbbQPAKet1vaXfovz1n

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHAmbbQPAKet1vaXfovz1n)_