### PR TITLE
interface-vision/t-104 slice 45: extract kr-btn-ghost-2xl

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -600,6 +600,15 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-ghost btn-xs;
   }
 
+  /* Fourth-most-repeated ghost-button shape (interface-vision t-104 slice 45):
+   * same `sm` size as .kr-btn-ghost, but with a wider `rounded-2xl` corner
+   * radius instead of `rounded-xl` — `btn btn-ghost btn-sm rounded-2xl`,
+   * previously hand-rolled in 23 files. Named for the radius it overrides
+   * (not a size suffix) since the size matches the base .kr-btn-ghost shape. */
+  .kr-btn-ghost-2xl {
+    @apply btn btn-ghost btn-sm rounded-2xl;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/artjob-editor.vue
+++ b/components/art/artjob-editor.vue
@@ -325,7 +325,7 @@
         <div class="flex gap-2">
           <button
             type="button"
-            class="btn btn-ghost btn-sm rounded-2xl"
+            class="kr-btn-ghost-2xl"
             :disabled="saving"
             @click="emit('close')"
           >

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -332,7 +332,7 @@
         >
           <button
             type="button"
-            class="btn btn-ghost btn-sm rounded-2xl"
+            class="kr-btn-ghost-2xl"
             :disabled="!artJobStore.jobHasPreviousPage"
             @click="artJobStore.setJobPage(artJobStore.jobPage - 1)"
           >
@@ -344,7 +344,7 @@
           >
           <button
             type="button"
-            class="btn btn-ghost btn-sm rounded-2xl"
+            class="kr-btn-ghost-2xl"
             :disabled="!artJobStore.jobHasNextPage"
             @click="artJobStore.setJobPage(artJobStore.jobPage + 1)"
           >

--- a/components/art/artjob-slideshow.vue
+++ b/components/art/artjob-slideshow.vue
@@ -90,7 +90,7 @@
             <div class="flex flex-wrap items-center gap-1">
               <button
                 type="button"
-                class="btn btn-ghost btn-sm rounded-2xl"
+                class="kr-btn-ghost-2xl"
                 :disabled="!slideshowStore.hasPreviousSlide"
                 title="Previous (left arrow)"
                 @click="previousSlide"
@@ -108,7 +108,7 @@
               </button>
               <button
                 type="button"
-                class="btn btn-ghost btn-sm rounded-2xl"
+                class="kr-btn-ghost-2xl"
                 title="Next (right arrow)"
                 @click="nextSlide"
               >
@@ -116,7 +116,7 @@
               </button>
               <button
                 type="button"
-                class="btn btn-ghost btn-sm rounded-2xl"
+                class="kr-btn-ghost-2xl"
                 title="Show or hide the caption (i)"
                 @click="toggleAllOverlay"
               >
@@ -133,7 +133,7 @@
               </button>
               <button
                 type="button"
-                class="btn btn-ghost btn-sm rounded-2xl"
+                class="kr-btn-ghost-2xl"
                 title="Toggle browser fullscreen (f)"
                 @click="toggleFullscreen"
               >

--- a/components/coloring/coloring-book-manager.vue
+++ b/components/coloring/coloring-book-manager.vue
@@ -102,7 +102,7 @@
         <div class="flex items-center gap-2">
           <button
             type="button"
-            class="btn btn-ghost btn-sm rounded-2xl"
+            class="kr-btn-ghost-2xl"
             @click="closePage"
           >
             <Icon name="mdi:arrow-left" class="h-4 w-4" />
@@ -116,7 +116,7 @@
         <div class="flex items-center gap-1.5">
           <button
             type="button"
-            class="btn btn-ghost btn-sm rounded-2xl"
+            class="kr-btn-ghost-2xl"
             title="Undo last fill"
             @click="coloringStore.undo()"
           >
@@ -125,7 +125,7 @@
           </button>
           <button
             type="button"
-            class="btn btn-ghost btn-sm rounded-2xl"
+            class="kr-btn-ghost-2xl"
             title="Clear all fills"
             @click="coloringStore.resetPage()"
           >
@@ -134,7 +134,7 @@
           </button>
           <button
             type="button"
-            class="btn btn-ghost btn-sm rounded-2xl"
+            class="kr-btn-ghost-2xl"
             title="Download your colored page as a PNG image"
             :disabled="isExporting"
             @click="saveImage"
@@ -148,7 +148,7 @@
           </button>
           <button
             type="button"
-            class="btn btn-ghost btn-sm rounded-2xl"
+            class="kr-btn-ghost-2xl"
             title="Download your color assignments as JSON"
             @click="downloadAssignments"
           >

--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -219,7 +219,7 @@
         </button>
         <button
           v-else
-          class="btn btn-ghost btn-sm rounded-2xl"
+          class="kr-btn-ghost-2xl"
           @click="packStore.markPackDraft(selectedPack.id)"
         >
           Back to draft

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -46,7 +46,7 @@
 
           <button
             type="button"
-            class="btn btn-ghost btn-sm rounded-2xl"
+            class="kr-btn-ghost-2xl"
             @click="resetSession"
           >
             <Icon name="kind-icon:x" class="h-4 w-4" />

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -28,7 +28,7 @@
         <div class="flex flex-wrap gap-2">
           <button
             type="button"
-            class="btn btn-ghost btn-sm rounded-2xl"
+            class="kr-btn-ghost-2xl"
             @click="randomizeSeed"
           >
             <Icon name="kind-icon:dice" class="h-4 w-4" />

--- a/components/navigation/workspace-narrator.vue
+++ b/components/navigation/workspace-narrator.vue
@@ -421,7 +421,7 @@
                   <div class="flex flex-wrap gap-2">
                     <button
                       type="button"
-                      class="btn btn-ghost btn-sm rounded-2xl"
+                      class="kr-btn-ghost-2xl"
                       :disabled="isNarratorResponding"
                       @click="clearNarratorThread"
                     >

--- a/components/pages/conductor-pitch-manager.vue
+++ b/components/pages/conductor-pitch-manager.vue
@@ -6,7 +6,7 @@
       <div class="flex flex-wrap items-start gap-3">
         <button
           type="button"
-          class="btn btn-ghost btn-sm rounded-2xl"
+          class="kr-btn-ghost-2xl"
           @click="goBack"
         >
           <Icon name="kind-icon:chevron-left" class="size-4" />
@@ -38,7 +38,7 @@
           </span>
           <button
             type="button"
-            class="btn btn-ghost btn-sm rounded-2xl"
+            class="kr-btn-ghost-2xl"
             :disabled="isLoading"
             @click="refresh"
           >
@@ -253,7 +253,7 @@
               <div v-else class="flex flex-wrap justify-end gap-2 border-t border-base-300/60 pt-3">
                 <button
                   type="button"
-                  class="btn btn-ghost btn-sm rounded-2xl"
+                  class="kr-btn-ghost-2xl"
                   :disabled="isUpdating(pitch.slug)"
                   @click="setStatus(pitch, 'awaiting-silas')"
                 >

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -755,14 +755,14 @@
             <button
               v-if="store.isRunning"
               type="button"
-              class="btn btn-ghost btn-sm rounded-2xl"
+              class="kr-btn-ghost-2xl"
               @click="store.stop()"
             >
               <Icon name="mdi:stop" class="h-4 w-4" />
             </button>
             <button
               type="button"
-              class="btn btn-ghost btn-sm rounded-2xl"
+              class="kr-btn-ghost-2xl"
               :disabled="store.isGenerating || !store.transcript.length"
               @click="store.regenerateLastTurn()"
             >
@@ -770,7 +770,7 @@
             </button>
             <button
               type="button"
-              class="btn btn-ghost btn-sm rounded-2xl"
+              class="kr-btn-ghost-2xl"
               :disabled="store.isGenerating"
               @click="store.generateNextTurn()"
             >
@@ -822,7 +822,7 @@
               />
               <button
                 type="button"
-                class="btn btn-ghost btn-sm rounded-2xl"
+                class="kr-btn-ghost-2xl"
                 :disabled="!narratorBeat.trim()"
                 @click="submitNarratorBeat"
               >


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring umbrella sweep). Slice 45 — 4th-most-repeated `btn-ghost` shape identified by slice 44's note.

### What changed / what I produced
- Added `.kr-btn-ghost-2xl` (`btn btn-ghost btn-sm rounded-2xl`) to `assets/css/tailwind.css`, following the same documentation/naming pattern as `.kr-btn-ghost`/`.kr-btn-ghost-xs`/`.kr-btn-ghost-xs-plain`.
- Codemodded the 23 exact-match occurrences of `class="btn btn-ghost btn-sm rounded-2xl"` across 10 files to `class="kr-btn-ghost-2xl"`:
  - `components/navigation/workspace-narrator.vue`
  - `components/stages/stage-manager.vue` (4)
  - `components/dreams/dream-brainstorm.vue`
  - `components/dreams/dream-maker.vue`
  - `components/coloring/coloring-book-manager.vue` (5)
  - `components/conductor/packmaker-admin-panel.vue`
  - `components/art/artjob-slideshow.vue` (4)
  - `components/art/artjob-editor.vue`
  - `components/art/artjob-queue-browser.vue` (2)
  - `components/pages/conductor-pitch-manager.vue` (3)
- No geometry or behavior change — this is a pure class-name substitution.

### How I verified
- Compiled `assets/css/tailwind.css` through the real `@tailwindcss/postcss` plugin (the same one Nuxt's build uses) and confirmed `.kr-btn-ghost-2xl` emits the full DaisyUI ghost-button ruleset, *before* codemodding any files.
- `npm run test` (vue-tsc): clean, exit 0.
- `npm run test:lint-ratchet`: holds — 332 problems, -60 vs. baseline, no rule regressed.
- `npm run test:layout-contract`: holds — no new violations (207 baseline shared-component grid-cols finding unchanged).
- `prettier --check` flags all 8 of the 10 touched files that have any formatting issue at all; confirmed each fails identically against its unmodified `origin/main` copy (fetched via `git show`) — pre-existing repo-wide drift, not introduced by this diff. CI does not gate on `lint:prettier`.
- Counted occurrences before and after codemod (23 in, 23 out, 0 remaining exact matches) to confirm nothing was missed or double-replaced.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Remaining `btn-ghost` shapes for a future slice: `btn-ghost btn-xs rounded-lg` (21), `btn-ghost btn-sm` (21).

### Notes for reviewer
Conductor task `interface-vision/t-104` will be re-armed to `ready` (recurring umbrella, per AGENTS.md convention) once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHPqQZrzy5KDt3FWef1GQV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHPqQZrzy5KDt3FWef1GQV)_