### PR TITLE
Add canonical AgentProfile messaging

### DIFF
--- a/.github/workflows/agent-checkin-contract.yml
+++ b/.github/workflows/agent-checkin-contract.yml
@@ -7,16 +7,20 @@ on:
       - 'prisma/agent-profile.prisma'
       - 'prisma/migrations/**agent_checkins_notes/**'
       - 'prisma/migrations/**agent_attention_requests/**'
+      - 'prisma/migrations/**agent_profile_messages/**'
       - 'utils/agentCredentialScopes.ts'
       - 'server/utils/authGuard.ts'
       - 'server/utils/agentAttentionRequests.ts'
       - 'server/utils/agentProfileRuntime.ts'
       - 'server/utils/agentWorkingContext.ts'
+      - 'server/utils/agentMessaging.ts'
+      - 'server/utils/agentMessagingPolicy.ts'
       - 'server/api/v1/agent/**'
       - 'server/api/agent-profiles/**'
       - 'utils/scripts/verifyAgentCheckins.test.ts'
       - 'utils/scripts/verifyAgentWorkingContext.test.ts'
       - 'tests/contracts/verifyAgentAttentionRequests.ts'
+      - 'tests/contracts/verifyAgentMessaging.ts'
       - '.github/workflows/agent-checkin-contract.yml'
   push:
     branches: [main]
@@ -24,16 +28,20 @@ on:
       - 'prisma/agent-profile.prisma'
       - 'prisma/migrations/**agent_checkins_notes/**'
       - 'prisma/migrations/**agent_attention_requests/**'
+      - 'prisma/migrations/**agent_profile_messages/**'
       - 'utils/agentCredentialScopes.ts'
       - 'server/utils/authGuard.ts'
       - 'server/utils/agentAttentionRequests.ts'
       - 'server/utils/agentProfileRuntime.ts'
       - 'server/utils/agentWorkingContext.ts'
+      - 'server/utils/agentMessaging.ts'
+      - 'server/utils/agentMessagingPolicy.ts'
       - 'server/api/v1/agent/**'
       - 'server/api/agent-profiles/**'
       - 'utils/scripts/verifyAgentCheckins.test.ts'
       - 'utils/scripts/verifyAgentWorkingContext.test.ts'
       - 'tests/contracts/verifyAgentAttentionRequests.ts'
+      - 'tests/contracts/verifyAgentMessaging.ts'
       - '.github/workflows/agent-checkin-contract.yml'
   workflow_dispatch:
 
@@ -59,3 +67,5 @@ jobs:
         run: npx tsx utils/scripts/verifyAgentWorkingContext.test.ts
       - name: Verify agent human-attention request contract
         run: npx tsx tests/contracts/verifyAgentAttentionRequests.ts
+      - name: Verify AgentProfile messaging contract
+        run: npx tsx tests/contracts/verifyAgentMessaging.ts

--- a/prisma/migrations/20260903003000_add_agent_profile_messages/migration.sql
+++ b/prisma/migrations/20260903003000_add_agent_profile_messages/migration.sql
@@ -1,0 +1,44 @@
+-- Rainbow Butterflies v2: canonical opt-in human <-> AgentProfile messaging.
+--
+-- This is deliberately separate from the legacy Chat table. A message thread
+-- has exactly one human participant and one AgentProfile participant, so actor
+-- identity and privacy checks do not depend on client-supplied sender fields.
+
+CREATE TABLE `AgentMessageThread` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `humanUserId` INTEGER NOT NULL,
+    `agentProfileId` INTEGER NOT NULL,
+
+    PRIMARY KEY (`id`),
+    UNIQUE INDEX `AgentMessageThread_human_agent_key` (`humanUserId`, `agentProfileId`),
+    INDEX `AgentMessageThread_human_updated_idx` (`humanUserId`, `updatedAt`),
+    INDEX `AgentMessageThread_agent_updated_idx` (`agentProfileId`, `updatedAt`),
+    CONSTRAINT `AgentMessageThread_agentProfileId_fkey`
+      FOREIGN KEY (`agentProfileId`) REFERENCES `AgentProfile`(`id`)
+      ON DELETE CASCADE ON UPDATE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `AgentMessage` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `threadId` INTEGER NOT NULL,
+    `senderKind` VARCHAR(16) NOT NULL,
+    `senderUserId` INTEGER NOT NULL,
+    `senderAgentProfileId` INTEGER NULL,
+    `credentialId` INTEGER NULL,
+    `clientKey` VARCHAR(120) NOT NULL,
+    `body` TEXT NOT NULL,
+    `readAt` DATETIME(3) NULL,
+
+    PRIMARY KEY (`id`),
+    UNIQUE INDEX `AgentMessage_thread_sender_client_key` (`threadId`, `senderKind`, `clientKey`),
+    INDEX `AgentMessage_thread_created_idx` (`threadId`, `createdAt`, `id`),
+    INDEX `AgentMessage_thread_read_sender_idx` (`threadId`, `readAt`, `senderKind`),
+    INDEX `AgentMessage_sender_user_created_idx` (`senderUserId`, `createdAt`),
+    INDEX `AgentMessage_sender_agent_created_idx` (`senderAgentProfileId`, `createdAt`),
+    CONSTRAINT `AgentMessage_threadId_fkey`
+      FOREIGN KEY (`threadId`) REFERENCES `AgentMessageThread`(`id`)
+      ON DELETE CASCADE ON UPDATE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/server/api/v1/agent/messages/[threadId].get.ts
+++ b/server/api/v1/agent/messages/[threadId].get.ts
@@ -1,0 +1,33 @@
+import { defineEventHandler, getQuery, getRouterParam, setHeader } from 'h3'
+import {
+  listAgentMessages,
+  parseAgentMessageListLimit,
+  parseAgentMessagePositiveId,
+  requireAgentMessageActor,
+} from '@/server/utils/agentMessaging'
+import { errorHandler } from '@/server/utils/error'
+
+export default defineEventHandler(async (event) => {
+  setHeader(event, 'Cache-Control', 'no-store')
+
+  try {
+    const actor = await requireAgentMessageActor(event)
+    const threadId = parseAgentMessagePositiveId(
+      getRouterParam(event, 'threadId'),
+      'threadId',
+    )
+    const query = getQuery(event)
+    const limit = parseAgentMessageListLimit(query.limit)
+    const beforeId =
+      query.beforeId === undefined || query.beforeId === null || query.beforeId === ''
+        ? null
+        : parseAgentMessagePositiveId(query.beforeId, 'beforeId')
+
+    const result = await listAgentMessages({ actor, threadId, limit, beforeId })
+    return { success: true, ...result }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode ?? 500
+    return { success: false, message: handled.message }
+  }
+})

--- a/server/api/v1/agent/messages/[threadId].post.ts
+++ b/server/api/v1/agent/messages/[threadId].post.ts
@@ -1,0 +1,51 @@
+import { defineEventHandler, getRouterParam, readBody, setHeader } from 'h3'
+import {
+  assertAgentMessageRateAllowed,
+  parseAgentMessageInput,
+  parseAgentMessagePositiveId,
+  requireAgentMessageActor,
+  requireAgentMessageThread,
+  sendAgentMessageInThread,
+} from '@/server/utils/agentMessaging'
+import { assertAgentMessagePairMaturity } from '@/server/utils/agentMessagingPolicy'
+import { errorHandler } from '@/server/utils/error'
+
+type MessageBody = {
+  body?: unknown
+  clientKey?: unknown
+}
+
+export default defineEventHandler(async (event) => {
+  setHeader(event, 'Cache-Control', 'no-store')
+
+  try {
+    const actor = await requireAgentMessageActor(event)
+    assertAgentMessageRateAllowed(event, actor)
+    const threadId = parseAgentMessagePositiveId(
+      getRouterParam(event, 'threadId'),
+      'threadId',
+    )
+    const thread = await requireAgentMessageThread(threadId, actor)
+    await assertAgentMessagePairMaturity({
+      humanUserId: thread.humanUserId,
+      agentProfileId: thread.agentProfileId,
+    })
+
+    const body = (await readBody<MessageBody>(event)) ?? {}
+    const message = parseAgentMessageInput(body)
+    const result = await sendAgentMessageInThread({ actor, threadId, ...message })
+
+    event.node.res.statusCode = result.created ? 201 : 200
+    return {
+      success: true,
+      ...result,
+      message: result.created
+        ? 'Message stored.'
+        : 'Existing message returned for this clientKey.',
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode ?? 500
+    return { success: false, message: handled.message }
+  }
+})

--- a/server/api/v1/agent/messages/[threadId]/read.patch.ts
+++ b/server/api/v1/agent/messages/[threadId]/read.patch.ts
@@ -1,0 +1,25 @@
+import { defineEventHandler, getRouterParam, setHeader } from 'h3'
+import {
+  markAgentMessageThreadRead,
+  parseAgentMessagePositiveId,
+  requireAgentMessageActor,
+} from '@/server/utils/agentMessaging'
+import { errorHandler } from '@/server/utils/error'
+
+export default defineEventHandler(async (event) => {
+  setHeader(event, 'Cache-Control', 'no-store')
+
+  try {
+    const actor = await requireAgentMessageActor(event)
+    const threadId = parseAgentMessagePositiveId(
+      getRouterParam(event, 'threadId'),
+      'threadId',
+    )
+    const result = await markAgentMessageThreadRead({ actor, threadId })
+    return { success: true, ...result }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode ?? 500
+    return { success: false, message: handled.message }
+  }
+})

--- a/server/api/v1/agent/messages/index.get.ts
+++ b/server/api/v1/agent/messages/index.get.ts
@@ -1,0 +1,20 @@
+import { defineEventHandler, setHeader } from 'h3'
+import {
+  listAgentMessageThreads,
+  requireAgentMessageActor,
+} from '@/server/utils/agentMessaging'
+import { errorHandler } from '@/server/utils/error'
+
+export default defineEventHandler(async (event) => {
+  setHeader(event, 'Cache-Control', 'no-store')
+
+  try {
+    const actor = await requireAgentMessageActor(event)
+    const threads = await listAgentMessageThreads(actor)
+    return { success: true, threads }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode ?? 500
+    return { success: false, message: handled.message }
+  }
+})

--- a/server/api/v1/agent/messages/index.post.ts
+++ b/server/api/v1/agent/messages/index.post.ts
@@ -1,0 +1,59 @@
+import { defineEventHandler, readBody, setHeader } from 'h3'
+import {
+  assertAgentMessageRateAllowed,
+  parseAgentMessageInput,
+  parseAgentMessagePositiveId,
+  requireAgentMessageActor,
+  sendInitialAgentMessage,
+} from '@/server/utils/agentMessaging'
+import { assertAgentMessagePairMaturity } from '@/server/utils/agentMessagingPolicy'
+import { errorHandler } from '@/server/utils/error'
+
+type MessageBody = {
+  body?: unknown
+  clientKey?: unknown
+  humanUserId?: unknown
+  agentProfileId?: unknown
+}
+
+export default defineEventHandler(async (event) => {
+  setHeader(event, 'Cache-Control', 'no-store')
+
+  try {
+    const actor = await requireAgentMessageActor(event)
+    assertAgentMessageRateAllowed(event, actor)
+
+    const body = (await readBody<MessageBody>(event)) ?? {}
+    const message = parseAgentMessageInput(body)
+    const humanUserId =
+      actor.kind === 'HUMAN'
+        ? actor.userId
+        : parseAgentMessagePositiveId(body.humanUserId, 'humanUserId')
+    const agentProfileId =
+      actor.kind === 'AGENT'
+        ? actor.agentProfileId
+        : parseAgentMessagePositiveId(body.agentProfileId, 'agentProfileId')
+
+    await assertAgentMessagePairMaturity({ humanUserId, agentProfileId })
+
+    const result = await sendInitialAgentMessage({
+      actor,
+      humanUserId,
+      agentProfileId,
+      ...message,
+    })
+
+    event.node.res.statusCode = result.created ? 201 : 200
+    return {
+      success: true,
+      ...result,
+      message: result.created
+        ? 'Message stored.'
+        : 'Existing message returned for this clientKey.',
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode ?? 500
+    return { success: false, message: handled.message }
+  }
+})

--- a/server/utils/agentMessaging.ts
+++ b/server/utils/agentMessaging.ts
@@ -1,0 +1,630 @@
+import { createError, setHeader, type H3Event } from 'h3'
+import { Prisma } from '~/prisma/generated/prisma/client'
+import {
+  authHasScope,
+  RAINBOW_FIRST_PARTY_CLIENT_ID,
+  requireApiUser,
+  type AuthGuardResult,
+} from './authGuard'
+import { getRainbowDirectoryPreference } from './rainbowDirectory'
+import prisma from './prisma'
+
+const MESSAGE_BODY_LIMIT = 5000
+const CLIENT_KEY_LIMIT = 120
+const THREAD_LIST_LIMIT = 50
+const MESSAGE_LIST_DEFAULT = 50
+const MESSAGE_LIST_MAX = 100
+const MESSAGE_WINDOW_MS = 10 * 60 * 1000
+const MESSAGE_WINDOW_LIMIT = 30
+const MESSAGE_WINDOW_CLEANUP_THRESHOLD = 1000
+
+const messageWindows = new Map<string, { startedAt: number; count: number }>()
+
+export type AgentMessageActor =
+  | {
+      kind: 'HUMAN'
+      userId: number
+      username: string
+      authKind: 'jwt' | 'first-party-delegation'
+    }
+  | {
+      kind: 'AGENT'
+      userId: number
+      username: string
+      agentProfileId: number
+      agentName: string
+      credentialId: number
+      authKind: 'agent-credential'
+    }
+
+type ThreadRow = {
+  id: number
+  createdAt: Date
+  updatedAt: Date
+  humanUserId: number
+  agentProfileId: number
+  humanUsername: string | null
+  humanDisplayName: string | null
+  humanAvatarImage: string | null
+  agentName: string | null
+  agentAvatarImage: string | null
+}
+
+type ThreadSummaryRow = ThreadRow & {
+  lastMessageAt: Date | null
+  lastMessagePreview: string | null
+  lastSenderKind: string | null
+  unreadCount: bigint | number
+}
+
+type MessageRow = {
+  id: number
+  createdAt: Date
+  threadId: number
+  senderKind: string
+  senderUserId: number
+  senderAgentProfileId: number | null
+  credentialId: number | null
+  clientKey: string
+  body: string
+  readAt: Date | null
+}
+
+type RawExecutor = Pick<Prisma.TransactionClient, '$queryRaw' | '$executeRaw'>
+
+function requiredText(value: unknown, field: string, maxLength: number): string {
+  if (typeof value !== 'string') {
+    throw createError({ statusCode: 400, message: `${field} must be text.` })
+  }
+  const text = value.trim()
+  if (!text) {
+    throw createError({ statusCode: 400, message: `${field} is required.` })
+  }
+  if (text.length > maxLength) {
+    throw createError({
+      statusCode: 400,
+      message: `${field} must be ${maxLength} characters or fewer.`,
+    })
+  }
+  return text
+}
+
+export function parseAgentMessageInput(input: {
+  body?: unknown
+  clientKey?: unknown
+}) {
+  return {
+    body: requiredText(input.body, 'body', MESSAGE_BODY_LIMIT),
+    clientKey: requiredText(input.clientKey, 'clientKey', CLIENT_KEY_LIMIT),
+  }
+}
+
+export function parseAgentMessagePositiveId(value: unknown, field: string): number {
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError({ statusCode: 400, message: `${field} must be a positive integer.` })
+  }
+  return parsed
+}
+
+export function parseAgentMessageListLimit(value: unknown): number {
+  if (value === undefined || value === null || value === '') return MESSAGE_LIST_DEFAULT
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > MESSAGE_LIST_MAX) {
+    throw createError({
+      statusCode: 400,
+      message: `limit must be an integer from 1 to ${MESSAGE_LIST_MAX}.`,
+    })
+  }
+  return parsed
+}
+
+function humanAuthAllowed(auth: AuthGuardResult): auth is AuthGuardResult & {
+  kind: 'jwt' | 'first-party-delegation'
+} {
+  if (auth.kind === 'jwt') return true
+  return (
+    auth.kind === 'first-party-delegation' &&
+    auth.clientId === RAINBOW_FIRST_PARTY_CLIENT_ID
+  )
+}
+
+export async function requireAgentMessageActor(event: H3Event): Promise<AgentMessageActor> {
+  const auth = await requireApiUser(event)
+
+  if (auth.kind === 'agent-credential') {
+    if (!authHasScope(auth, 'agent:message')) {
+      throw createError({
+        statusCode: 403,
+        message: 'This credential is not authorized for scope "agent:message".',
+      })
+    }
+    if (!auth.agentProfileId || !auth.credentialId) {
+      throw createError({
+        statusCode: 403,
+        message: 'Agent messaging requires a persistent credential bound to an AgentProfile.',
+      })
+    }
+
+    const profile = await prisma.agentProfile.findUnique({
+      where: { id: auth.agentProfileId },
+      select: { id: true, userId: true, name: true, isActive: true },
+    })
+    if (!profile || !profile.isActive || profile.userId !== auth.user.id) {
+      throw createError({ statusCode: 403, message: 'This AgentProfile is not active.' })
+    }
+
+    return {
+      kind: 'AGENT',
+      userId: auth.user.id,
+      username: auth.user.username,
+      agentProfileId: profile.id,
+      agentName: profile.name,
+      credentialId: auth.credentialId,
+      authKind: 'agent-credential',
+    }
+  }
+
+  if (!humanAuthAllowed(auth)) {
+    throw createError({
+      statusCode: 403,
+      message: 'Agent messaging requires a signed-in human or Rainbow first-party session.',
+    })
+  }
+
+  return {
+    kind: 'HUMAN',
+    userId: auth.user.id,
+    username: auth.user.username,
+    authKind: auth.kind,
+  }
+}
+
+function cleanupMessageWindows(now: number) {
+  if (messageWindows.size < MESSAGE_WINDOW_CLEANUP_THRESHOLD) return
+  for (const [key, window] of messageWindows) {
+    if (now - window.startedAt >= MESSAGE_WINDOW_MS) messageWindows.delete(key)
+  }
+}
+
+export function assertAgentMessageRateAllowed(event: H3Event, actor: AgentMessageActor) {
+  const key =
+    actor.kind === 'HUMAN'
+      ? `human:${actor.userId}`
+      : `agent:${actor.agentProfileId}:credential:${actor.credentialId}`
+  const now = Date.now()
+  cleanupMessageWindows(now)
+  const existing = messageWindows.get(key)
+
+  if (!existing || now - existing.startedAt >= MESSAGE_WINDOW_MS) {
+    messageWindows.set(key, { startedAt: now, count: 1 })
+    return
+  }
+
+  if (existing.count >= MESSAGE_WINDOW_LIMIT) {
+    const retryAfter = Math.max(
+      1,
+      Math.ceil((existing.startedAt + MESSAGE_WINDOW_MS - now) / 1000),
+    )
+    setHeader(event, 'Retry-After', retryAfter)
+    throw createError({
+      statusCode: 429,
+      message: 'Agent messaging rate limit exceeded. Try again later.',
+    })
+  }
+
+  existing.count += 1
+}
+
+async function requireHumanMessagingOptIn(userId: number) {
+  const [preference, user] = await Promise.all([
+    getRainbowDirectoryPreference(userId),
+    prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        username: true,
+        designerName: true,
+        avatarImage: true,
+        isActive: true,
+        isGuest: true,
+        isRestricted: true,
+      },
+    }),
+  ])
+
+  if (
+    !user ||
+    !user.isActive ||
+    user.isGuest ||
+    user.isRestricted ||
+    !preference.isPublic ||
+    !preference.allowMessages
+  ) {
+    throw createError({
+      statusCode: 403,
+      message: 'This human is not accepting Rainbow messages.',
+    })
+  }
+
+  return user
+}
+
+async function requireAgentMessagingOptIn(agentProfileId: number) {
+  const profile = await prisma.agentProfile.findUnique({
+    where: { id: agentProfileId },
+    select: {
+      id: true,
+      userId: true,
+      name: true,
+      avatarImage: true,
+      isPublic: true,
+      allowMessages: true,
+      isActive: true,
+    },
+  })
+
+  if (!profile || !profile.isActive || !profile.isPublic || !profile.allowMessages) {
+    throw createError({
+      statusCode: 403,
+      message: 'This AgentProfile is not accepting Rainbow messages.',
+    })
+  }
+
+  const owner = await prisma.user.findUnique({
+    where: { id: profile.userId },
+    select: { isActive: true, isRestricted: true },
+  })
+  if (!owner || !owner.isActive || owner.isRestricted) {
+    throw createError({
+      statusCode: 403,
+      message: 'This AgentProfile is not accepting Rainbow messages.',
+    })
+  }
+
+  return profile
+}
+
+async function requirePairCanMessage(humanUserId: number, agentProfileId: number) {
+  const [human, agent] = await Promise.all([
+    requireHumanMessagingOptIn(humanUserId),
+    requireAgentMessagingOptIn(agentProfileId),
+  ])
+  return { human, agent }
+}
+
+function serializeThread(row: ThreadRow) {
+  return {
+    id: row.id,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    human: {
+      id: row.humanUserId,
+      username: row.humanUsername,
+      displayName: row.humanDisplayName,
+      avatarImage: row.humanAvatarImage,
+    },
+    agent: {
+      id: row.agentProfileId,
+      name: row.agentName,
+      avatarImage: row.agentAvatarImage,
+    },
+  }
+}
+
+function serializeMessage(row: MessageRow) {
+  return {
+    id: row.id,
+    createdAt: row.createdAt,
+    senderKind: row.senderKind === 'AGENT' ? ('AGENT' as const) : ('HUMAN' as const),
+    senderUserId: row.senderUserId,
+    senderAgentProfileId: row.senderAgentProfileId,
+    body: row.body,
+    readAt: row.readAt,
+    delivery: 'stored' as const,
+  }
+}
+
+async function findThreadById(executor: RawExecutor, threadId: number): Promise<ThreadRow | null> {
+  const rows = await executor.$queryRaw<ThreadRow[]>(Prisma.sql`
+    SELECT
+      t.id, t.createdAt, t.updatedAt, t.humanUserId, t.agentProfileId,
+      u.username AS humanUsername,
+      u.designerName AS humanDisplayName,
+      u.avatarImage AS humanAvatarImage,
+      p.name AS agentName,
+      p.avatarImage AS agentAvatarImage
+    FROM AgentMessageThread t
+    LEFT JOIN User u ON u.id = t.humanUserId
+    LEFT JOIN AgentProfile p ON p.id = t.agentProfileId
+    WHERE t.id = ${threadId}
+    LIMIT 1
+  `)
+  return rows[0] ?? null
+}
+
+function assertThreadActor(row: ThreadRow, actor: AgentMessageActor) {
+  const allowed =
+    actor.kind === 'HUMAN'
+      ? row.humanUserId === actor.userId
+      : row.agentProfileId === actor.agentProfileId
+  if (!allowed) {
+    throw createError({ statusCode: 404, message: 'Message thread not found.' })
+  }
+}
+
+export async function requireAgentMessageThread(threadId: number, actor: AgentMessageActor) {
+  const row = await findThreadById(prisma, threadId)
+  if (!row) throw createError({ statusCode: 404, message: 'Message thread not found.' })
+  assertThreadActor(row, actor)
+  return row
+}
+
+async function getOrCreateThread(
+  executor: RawExecutor,
+  humanUserId: number,
+  agentProfileId: number,
+): Promise<ThreadRow> {
+  await executor.$executeRaw(Prisma.sql`
+    INSERT INTO AgentMessageThread (humanUserId, agentProfileId)
+    VALUES (${humanUserId}, ${agentProfileId})
+    ON DUPLICATE KEY UPDATE id = id
+  `)
+
+  const rows = await executor.$queryRaw<ThreadRow[]>(Prisma.sql`
+    SELECT
+      t.id, t.createdAt, t.updatedAt, t.humanUserId, t.agentProfileId,
+      u.username AS humanUsername,
+      u.designerName AS humanDisplayName,
+      u.avatarImage AS humanAvatarImage,
+      p.name AS agentName,
+      p.avatarImage AS agentAvatarImage
+    FROM AgentMessageThread t
+    LEFT JOIN User u ON u.id = t.humanUserId
+    LEFT JOIN AgentProfile p ON p.id = t.agentProfileId
+    WHERE t.humanUserId = ${humanUserId}
+      AND t.agentProfileId = ${agentProfileId}
+    LIMIT 1
+  `)
+
+  const row = rows[0]
+  if (!row) {
+    throw createError({ statusCode: 500, message: 'Message thread could not be created.' })
+  }
+  return row
+}
+
+async function findMessageByClientKey(
+  executor: RawExecutor,
+  threadId: number,
+  senderKind: AgentMessageActor['kind'],
+  clientKey: string,
+): Promise<MessageRow | null> {
+  const rows = await executor.$queryRaw<MessageRow[]>(Prisma.sql`
+    SELECT
+      id, createdAt, threadId, senderKind, senderUserId,
+      senderAgentProfileId, credentialId, clientKey, body, readAt
+    FROM AgentMessage
+    WHERE threadId = ${threadId}
+      AND senderKind = ${senderKind}
+      AND clientKey = ${clientKey}
+    LIMIT 1
+  `)
+  return rows[0] ?? null
+}
+
+async function persistMessage(input: {
+  actor: AgentMessageActor
+  thread: ThreadRow
+  body: string
+  clientKey: string
+}) {
+  return await prisma.$transaction(async (tx) => {
+    const existing = await findMessageByClientKey(
+      tx,
+      input.thread.id,
+      input.actor.kind,
+      input.clientKey,
+    )
+    if (existing) return { message: existing, created: false }
+
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO AgentMessage (
+        threadId, senderKind, senderUserId, senderAgentProfileId,
+        credentialId, clientKey, body
+      ) VALUES (
+        ${input.thread.id},
+        ${input.actor.kind},
+        ${input.actor.userId},
+        ${input.actor.kind === 'AGENT' ? input.actor.agentProfileId : null},
+        ${input.actor.kind === 'AGENT' ? input.actor.credentialId : null},
+        ${input.clientKey},
+        ${input.body}
+      )
+      ON DUPLICATE KEY UPDATE id = id
+    `)
+
+    await tx.$executeRaw(Prisma.sql`
+      UPDATE AgentMessageThread
+      SET updatedAt = CURRENT_TIMESTAMP(3)
+      WHERE id = ${input.thread.id}
+    `)
+
+    const message = await findMessageByClientKey(
+      tx,
+      input.thread.id,
+      input.actor.kind,
+      input.clientKey,
+    )
+    if (!message) {
+      throw createError({ statusCode: 500, message: 'Message could not be persisted.' })
+    }
+    return { message, created: true }
+  })
+}
+
+export async function sendInitialAgentMessage(input: {
+  actor: AgentMessageActor
+  humanUserId?: number
+  agentProfileId?: number
+  body: string
+  clientKey: string
+}) {
+  const humanUserId =
+    input.actor.kind === 'HUMAN'
+      ? input.actor.userId
+      : parseAgentMessagePositiveId(input.humanUserId, 'humanUserId')
+  const agentProfileId =
+    input.actor.kind === 'AGENT'
+      ? input.actor.agentProfileId
+      : parseAgentMessagePositiveId(input.agentProfileId, 'agentProfileId')
+
+  if (input.actor.kind === 'AGENT' && input.actor.userId === humanUserId) {
+    // Messaging your own operator is allowed, but only when that human has
+    // explicitly opted into the public Rainbow messaging surface too.
+  }
+
+  await requirePairCanMessage(humanUserId, agentProfileId)
+  const thread = await getOrCreateThread(prisma, humanUserId, agentProfileId)
+  assertThreadActor(thread, input.actor)
+  const result = await persistMessage({
+    actor: input.actor,
+    thread,
+    body: input.body,
+    clientKey: input.clientKey,
+  })
+
+  return {
+    thread: serializeThread(thread),
+    message: serializeMessage(result.message),
+    created: result.created,
+  }
+}
+
+export async function sendAgentMessageInThread(input: {
+  actor: AgentMessageActor
+  threadId: number
+  body: string
+  clientKey: string
+}) {
+  const thread = await requireAgentMessageThread(input.threadId, input.actor)
+  await requirePairCanMessage(thread.humanUserId, thread.agentProfileId)
+  const result = await persistMessage({
+    actor: input.actor,
+    thread,
+    body: input.body,
+    clientKey: input.clientKey,
+  })
+  return {
+    thread: serializeThread(thread),
+    message: serializeMessage(result.message),
+    created: result.created,
+  }
+}
+
+export async function listAgentMessageThreads(actor: AgentMessageActor) {
+  const actorId = actor.kind === 'HUMAN' ? actor.userId : actor.agentProfileId
+  const rows = await prisma.$queryRaw<ThreadSummaryRow[]>(Prisma.sql`
+    SELECT
+      t.id, t.createdAt, t.updatedAt, t.humanUserId, t.agentProfileId,
+      u.username AS humanUsername,
+      u.designerName AS humanDisplayName,
+      u.avatarImage AS humanAvatarImage,
+      p.name AS agentName,
+      p.avatarImage AS agentAvatarImage,
+      (
+        SELECT m.createdAt
+        FROM AgentMessage m
+        WHERE m.threadId = t.id
+        ORDER BY m.id DESC
+        LIMIT 1
+      ) AS lastMessageAt,
+      (
+        SELECT LEFT(m.body, 240)
+        FROM AgentMessage m
+        WHERE m.threadId = t.id
+        ORDER BY m.id DESC
+        LIMIT 1
+      ) AS lastMessagePreview,
+      (
+        SELECT m.senderKind
+        FROM AgentMessage m
+        WHERE m.threadId = t.id
+        ORDER BY m.id DESC
+        LIMIT 1
+      ) AS lastSenderKind,
+      (
+        SELECT COUNT(*)
+        FROM AgentMessage m
+        WHERE m.threadId = t.id
+          AND m.readAt IS NULL
+          AND m.senderKind <> ${actor.kind}
+      ) AS unreadCount
+    FROM AgentMessageThread t
+    LEFT JOIN User u ON u.id = t.humanUserId
+    LEFT JOIN AgentProfile p ON p.id = t.agentProfileId
+    WHERE ${actor.kind === 'HUMAN' ? Prisma.sql`t.humanUserId = ${actorId}` : Prisma.sql`t.agentProfileId = ${actorId}`}
+    ORDER BY COALESCE(lastMessageAt, t.updatedAt) DESC, t.id DESC
+    LIMIT ${THREAD_LIST_LIMIT}
+  `)
+
+  return rows.map((row) => ({
+    ...serializeThread(row),
+    lastMessageAt: row.lastMessageAt,
+    lastMessagePreview: row.lastMessagePreview,
+    lastSenderKind:
+      row.lastSenderKind === 'AGENT'
+        ? ('AGENT' as const)
+        : row.lastSenderKind === 'HUMAN'
+          ? ('HUMAN' as const)
+          : null,
+    unreadCount: Number(row.unreadCount || 0),
+  }))
+}
+
+export async function listAgentMessages(input: {
+  actor: AgentMessageActor
+  threadId: number
+  limit: number
+  beforeId?: number | null
+}) {
+  const thread = await requireAgentMessageThread(input.threadId, input.actor)
+  const beforeId = input.beforeId ?? null
+  const rows = await prisma.$queryRaw<MessageRow[]>(Prisma.sql`
+    SELECT
+      id, createdAt, threadId, senderKind, senderUserId,
+      senderAgentProfileId, credentialId, clientKey, body, readAt
+    FROM AgentMessage
+    WHERE threadId = ${thread.id}
+      AND (${beforeId} IS NULL OR id < ${beforeId})
+    ORDER BY id DESC
+    LIMIT ${input.limit}
+  `)
+
+  const chronological = [...rows].reverse()
+  return {
+    thread: serializeThread(thread),
+    messages: chronological.map(serializeMessage),
+    page: {
+      nextBeforeId: rows.length === input.limit ? rows[rows.length - 1]?.id ?? null : null,
+    },
+  }
+}
+
+export async function markAgentMessageThreadRead(input: {
+  actor: AgentMessageActor
+  threadId: number
+}) {
+  const thread = await requireAgentMessageThread(input.threadId, input.actor)
+  const updated = await prisma.$executeRaw(Prisma.sql`
+    UPDATE AgentMessage
+    SET readAt = CURRENT_TIMESTAMP(3)
+    WHERE threadId = ${thread.id}
+      AND readAt IS NULL
+      AND senderKind <> ${input.actor.kind}
+  `)
+  return {
+    thread: serializeThread(thread),
+    markedRead: Number(updated),
+  }
+}

--- a/server/utils/agentMessagingPolicy.ts
+++ b/server/utils/agentMessagingPolicy.ts
@@ -1,0 +1,54 @@
+import { createError } from 'h3'
+import { isMaturityRestricted } from './contentAccess'
+import prisma from './prisma'
+
+type MaturityParticipant = {
+  id: number
+  Role: string | null
+  UserRoles: Array<{ role: string }>
+}
+
+async function loadMaturityParticipant(userId: number): Promise<MaturityParticipant | null> {
+  return prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      Role: true,
+      UserRoles: { select: { role: true } },
+    },
+  })
+}
+
+export async function assertAgentMessagePairMaturity(input: {
+  humanUserId: number
+  agentProfileId: number
+}) {
+  const profile = await prisma.agentProfile.findUnique({
+    where: { id: input.agentProfileId },
+    select: { userId: true },
+  })
+
+  if (!profile) {
+    throw createError({
+      statusCode: 403,
+      message: 'Messaging is not available for this participant pair.',
+    })
+  }
+
+  const [human, operator] = await Promise.all([
+    loadMaturityParticipant(input.humanUserId),
+    loadMaturityParticipant(profile.userId),
+  ])
+
+  if (
+    !human ||
+    !operator ||
+    isMaturityRestricted(human) ||
+    isMaturityRestricted(operator)
+  ) {
+    throw createError({
+      statusCode: 403,
+      message: 'Messaging is not available for this participant pair.',
+    })
+  }
+}

--- a/tests/contracts/verifyAgentMessaging.ts
+++ b/tests/contracts/verifyAgentMessaging.ts
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const migration = readFileSync(
+  'prisma/migrations/20260903003000_add_agent_profile_messages/migration.sql',
+  'utf8',
+)
+const scopes = readFileSync('utils/agentCredentialScopes.ts', 'utf8')
+const credentials = readFileSync('server/utils/agentCredentials.ts', 'utf8')
+const runtime = readFileSync('server/utils/agentMessaging.ts', 'utf8')
+const policy = readFileSync('server/utils/agentMessagingPolicy.ts', 'utf8')
+const listRoute = readFileSync('server/api/v1/agent/messages/index.get.ts', 'utf8')
+const startRoute = readFileSync('server/api/v1/agent/messages/index.post.ts', 'utf8')
+const historyRoute = readFileSync('server/api/v1/agent/messages/[threadId].get.ts', 'utf8')
+const replyRoute = readFileSync('server/api/v1/agent/messages/[threadId].post.ts', 'utf8')
+const readRoute = readFileSync(
+  'server/api/v1/agent/messages/[threadId]/read.patch.ts',
+  'utf8',
+)
+const mcp = readFileSync('server/api/v1/mcp.post.ts', 'utf8')
+
+// Messaging has its own canonical persistence. Do not retrofit private
+// AgentProfile identity onto the legacy user-centric Chat model.
+assert.match(migration, /CREATE TABLE `AgentMessageThread`/)
+assert.match(migration, /CREATE TABLE `AgentMessage`/)
+assert.match(
+  migration,
+  /UNIQUE INDEX `AgentMessageThread_human_agent_key` \(`humanUserId`, `agentProfileId`\)/,
+)
+assert.match(
+  migration,
+  /UNIQUE INDEX `AgentMessage_thread_sender_client_key` \(`threadId`, `senderKind`, `clientKey`\)/,
+)
+for (const field of [
+  '`senderUserId` INTEGER NOT NULL',
+  '`senderAgentProfileId` INTEGER NULL',
+  '`credentialId` INTEGER NULL',
+  '`readAt` DATETIME(3) NULL',
+]) {
+  assert.match(migration, new RegExp(field.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+}
+assert.match(migration, /REFERENCES `AgentProfile`\(`id`\)/)
+assert.match(migration, /REFERENCES `AgentMessageThread`\(`id`\)/)
+assert.doesNotMatch(migration, /DROP TABLE|DROP COLUMN|ALTER TABLE .* DROP/i)
+assert.doesNotMatch(runtime, /\b(?:FROM|INTO|UPDATE)\s+Chat\b/i)
+
+// The new machine capability is explicit and never silently joins the default
+// forum credential bundle. Existing credentials stay as narrow as they were.
+assert.match(scopes, /'agent:message'/)
+const defaultScopes = scopes.match(
+  /DEFAULT_FORUM_AGENT_SCOPES:[\s\S]*?=\s*\[([\s\S]*?)\]/,
+)?.[1] ?? ''
+assert.doesNotMatch(defaultScopes, /agent:message/)
+assert.match(credentials, /if \(row\.revokedAt\) return null/)
+assert.match(credentials, /expiresAt.*Date\.now\(\)/)
+
+// Actor identity comes from authenticated server state. Agents require an
+// active bound AgentProfile plus the new scope; humans are direct JWT users or
+// the registered Rainbow first-party delegation, never an arbitrary sender.
+assert.match(runtime, /requireApiUser\(event\)/)
+assert.match(runtime, /authHasScope\(auth, 'agent:message'\)/)
+assert.match(runtime, /auth\.kind === 'agent-credential'/)
+assert.match(runtime, /!auth\.agentProfileId \|\| !auth\.credentialId/)
+assert.match(runtime, /profile\.userId !== auth\.user\.id/)
+assert.match(runtime, /RAINBOW_FIRST_PARTY_CLIENT_ID/)
+assert.match(runtime, /auth\.kind === 'jwt'/)
+assert.doesNotMatch(startRoute, /sender(?:Kind|UserId|AgentProfileId)?\s*\?:/)
+assert.doesNotMatch(replyRoute, /sender(?:Kind|UserId|AgentProfileId)?\s*\?:/)
+
+// Both sides must deliberately advertise and opt into messages for every new
+// write. Restricted/guest/inactive accounts fail closed, and CHILD maturity on
+// either the human or the accountable AgentProfile operator blocks writes.
+assert.match(runtime, /getRainbowDirectoryPreference\(userId\)/)
+assert.match(runtime, /!preference\.isPublic/)
+assert.match(runtime, /!preference\.allowMessages/)
+assert.match(runtime, /!profile\.isPublic \|\| !profile\.allowMessages/)
+assert.match(runtime, /user\.isRestricted/)
+assert.match(runtime, /owner\.isRestricted/)
+assert.match(policy, /isMaturityRestricted\(human\)/)
+assert.match(policy, /isMaturityRestricted\(operator\)/)
+for (const route of [startRoute, replyRoute]) {
+  assert.match(route, /assertAgentMessagePairMaturity/)
+  assert.match(route, /assertAgentMessageRateAllowed/)
+}
+
+// Writes are bounded, rate-limited, idempotent, and attributable. The client
+// key can retry an ambiguous request without producing a duplicate message.
+assert.match(runtime, /MESSAGE_BODY_LIMIT = 5000/)
+assert.match(runtime, /MESSAGE_LIST_MAX = 100/)
+assert.match(runtime, /THREAD_LIST_LIMIT = 50/)
+assert.match(runtime, /MESSAGE_WINDOW_MS = 10 \* 60 \* 1000/)
+assert.match(runtime, /MESSAGE_WINDOW_LIMIT = 30/)
+assert.match(runtime, /Retry-After/)
+assert.match(runtime, /ON DUPLICATE KEY UPDATE id = id/)
+assert.match(runtime, /senderUserId, senderAgentProfileId/)
+assert.match(runtime, /input\.actor\.userId/)
+assert.match(runtime, /input\.actor\.credentialId/)
+
+// Thread access is participant-scoped. The owner/operator remains present in
+// the audit fields for agent-authored messages, but unrelated humans/agents get
+// a not-found boundary instead of a cross-user thread leak.
+assert.match(runtime, /row\.humanUserId === actor\.userId/)
+assert.match(runtime, /row\.agentProfileId === actor\.agentProfileId/)
+assert.match(runtime, /statusCode: 404, message: 'Message thread not found\.'/)
+
+// Read state is recipient-oriented and history remains readable after opt-out:
+// list/history/read routes do not re-run the opt-in write policy.
+assert.match(runtime, /senderKind <> \$\{input\.actor\.kind\}/)
+assert.match(runtime, /SET readAt = CURRENT_TIMESTAMP\(3\)/)
+assert.doesNotMatch(listRoute, /assertAgentMessagePairMaturity/)
+assert.doesNotMatch(historyRoute, /assertAgentMessagePairMaturity/)
+assert.doesNotMatch(readRoute, /assertAgentMessagePairMaturity/)
+
+// Every route is private/no-store and uses the repository error boundary.
+for (const route of [listRoute, startRoute, historyRoute, replyRoute, readRoute]) {
+  assert.match(route, /Cache-Control', 'no-store'/)
+  assert.match(route, /errorHandler\(error\)/)
+  assert.match(route, /requireAgentMessageActor\(event\)/)
+}
+assert.match(startRoute, /sendInitialAgentMessage/)
+assert.match(replyRoute, /sendAgentMessageInThread/)
+assert.match(historyRoute, /listAgentMessages/)
+assert.match(listRoute, /listAgentMessageThreads/)
+assert.match(readRoute, /markAgentMessageThreadRead/)
+
+// This substrate does not widen the narrow MCP bridge and does not turn email
+// delivery into message state.
+assert.doesNotMatch(mcp, /agent:message|AgentMessage|messages\//)
+for (const source of [runtime, policy, listRoute, startRoute, historyRoute, replyRoute, readRoute]) {
+  assert.doesNotMatch(source, /Brevo|brevo|rainbowNotificationDelivery/)
+}
+
+console.log('AgentProfile messaging contract OK')

--- a/utils/agentCredentialScopes.ts
+++ b/utils/agentCredentialScopes.ts
@@ -13,6 +13,7 @@
 export const AGENT_CREDENTIAL_SCOPES = [
   'profile:read',
   'agent:checkin',
+  'agent:message',
   'forum:read',
   'forum:write',
   'forum:thread:create',
@@ -23,9 +24,10 @@ export type AgentCredentialScope = (typeof AGENT_CREDENTIAL_SCOPES)[number]
 
 // Scopes a freshly-created forum-agent credential gets when the caller
 // doesn't specify its own set. Creating new top-level threads is deliberately
-// NOT included: a human liaison opts an agent into that separately. Generation
-// and recurring check-ins are also opt-in because they respectively spend
-// generation balance and enable background agent activity.
+// NOT included: a human liaison opts an agent into that separately. Generation,
+// recurring check-ins, and private AgentProfile messaging are also opt-in
+// because they respectively spend generation balance, enable background agent
+// activity, and let an agent participate in private conversations.
 export const DEFAULT_FORUM_AGENT_SCOPES: AgentCredentialScope[] = [
   'profile:read',
   'forum:read',


### PR DESCRIPTION
Implements #2345 as the canonical Kind Robots substrate for optional human ↔ AgentProfile messaging.

This deliberately does not reuse legacy `Chat` and does not add Rainbow-owned message state.

Adds:
- additive `AgentMessageThread` + `AgentMessage` migration, one thread per human/AgentProfile pair;
- server-derived human vs AgentProfile actor identity and audit fields for the accountable operator / credential;
- explicit `agent:message` credential scope, not present in default credential scopes;
- both-side public + `allowMessages` opt-in on every new write;
- existing restricted-account checks plus the canonical CHILD maturity restriction for both the human and AgentProfile operator;
- 5,000-character message cap, 30 writes / 10 minutes rate limit, bounded thread/history lists, cursor pagination;
- idempotent `clientKey` writes;
- recipient-oriented durable read timestamps;
- participant-scoped thread access returning 404 across user/profile boundaries;
- shared REST route family usable by signed-in humans / Rainbow first-party delegation and profile-bound agent credentials;
- focused AgentProfile messaging contract added to the existing Agent Check-in CI lane.

Important boundaries:
- opt-out blocks new messages but does not erase or strand prior history;
- MCP remains the same narrow two-tool bridge and gains no messaging proxy;
- no Brevo/email message state;
- no provider account, provider secret, external posting, or Rainbow publication;
- no silent widening of existing credentials.

**Schema-affecting:** yes. The migration is additive and backward-compatible with the currently running build during the migration-before-container-replacement window described in `AGENTS.md`.

Merge is not deployment. Production/Alexandria schema state must still be verified separately after the normal deployment path runs.