### PR TITLE
interface-vision/t-104 slice 46: extract kr-btn-ghost-xs-lg, codemod 21 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -609,6 +609,16 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-ghost btn-sm rounded-2xl;
   }
 
+  /* Fifth-most-repeated ghost-button shape (interface-vision t-104 slice 46):
+   * the `xs` size from .kr-btn-ghost-xs-plain, but with a `rounded-lg` corner
+   * override instead of no override — `btn btn-ghost btn-xs rounded-lg`,
+   * previously hand-rolled in 21 files. Named for the radius it overrides,
+   * matching the `-2xl` suffix convention above rather than colliding with
+   * the unrelated `-xs`/`-xs-plain` shapes. */
+  .kr-btn-ghost-xs-lg {
+    @apply btn btn-ghost btn-xs rounded-lg;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -43,7 +43,7 @@
 
           <button
             v-if="activeGroup"
-            class="btn btn-ghost btn-xs rounded-lg"
+            class="kr-btn-ghost-xs-lg"
             type="button"
             @click="clearActiveGroup"
           >
@@ -81,7 +81,7 @@
 
           <button
             v-if="selectedImageForOverlay"
-            class="btn btn-ghost btn-xs rounded-lg"
+            class="kr-btn-ghost-xs-lg"
             type="button"
             @click="clearSelectedImage"
           >

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -248,7 +248,7 @@
         </div>
         <button
           type="button"
-          class="btn btn-ghost btn-xs rounded-lg"
+          class="kr-btn-ghost-xs-lg"
           :disabled="submitting"
           @click="closeForms"
         >
@@ -411,7 +411,7 @@
         </div>
         <button
           type="button"
-          class="btn btn-ghost btn-xs rounded-lg"
+          class="kr-btn-ghost-xs-lg"
           :disabled="submitting"
           @click="closeForms"
         >

--- a/components/conductor/project-detail.vue
+++ b/components/conductor/project-detail.vue
@@ -96,7 +96,7 @@
       <button
         v-if="linkedProject"
         type="button"
-        class="btn btn-ghost btn-xs rounded-lg"
+        class="kr-btn-ghost-xs-lg"
         title="Brainstorm variations grounded in this Project"
         aria-label="Brainstorm variations grounded in this Project"
         @click="startBrainstormWithProject"
@@ -105,7 +105,7 @@
       </button>
       <button
         type="button"
-        class="btn btn-ghost btn-xs rounded-lg"
+        class="kr-btn-ghost-xs-lg"
         :disabled="refreshing"
         title="Refresh project"
         @click="refreshProject"

--- a/components/navigation/account-hub.vue
+++ b/components/navigation/account-hub.vue
@@ -330,7 +330,7 @@
           <button
             v-if="unreadCount"
             type="button"
-            class="btn btn-ghost btn-xs rounded-lg"
+            class="kr-btn-ghost-xs-lg"
             @click="notifications.markAllRead()"
           >
             Mark all read

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -175,7 +175,7 @@
         >
         <button
           type="button"
-          class="btn btn-ghost btn-xs rounded-lg"
+          class="kr-btn-ghost-xs-lg"
           :disabled="pending"
           @click="refreshWorkspace"
         >

--- a/components/pages/memory-dungeon.vue
+++ b/components/pages/memory-dungeon.vue
@@ -411,7 +411,7 @@
           <span>📜 Dungeon Log</span>
           <button
             type="button"
-            class="btn btn-ghost btn-xs rounded-lg"
+            class="kr-btn-ghost-xs-lg"
             aria-label="Close dungeon log"
             @click="logOpen = false"
           >
@@ -487,7 +487,7 @@
 
       <div class="flex shrink-0 items-center gap-1">
         <button
-          class="btn btn-ghost btn-xs rounded-lg"
+          class="kr-btn-ghost-xs-lg"
           type="button"
           @click="logOpen = !logOpen"
         >
@@ -495,7 +495,7 @@
         </button>
 
         <button
-          class="btn btn-ghost btn-xs rounded-lg"
+          class="kr-btn-ghost-xs-lg"
           type="button"
           @click="isOpen = !isOpen"
         >
@@ -513,7 +513,7 @@
           <h2 class="text-sm font-bold">🏆 Global Leaderboard</h2>
           <button
             type="button"
-            class="btn btn-ghost btn-xs rounded-lg"
+            class="kr-btn-ghost-xs-lg"
             aria-label="Close leaderboard"
             @click="isOpen = false"
           >

--- a/components/user/agent-credentials-panel.vue
+++ b/components/user/agent-credentials-panel.vue
@@ -22,7 +22,7 @@
         >{{ justCreatedToken }}</code>
         <button
           type="button"
-          class="btn btn-ghost btn-xs rounded-lg"
+          class="kr-btn-ghost-xs-lg"
           @click="copyToken"
         >
           {{ copied ? 'Copied' : 'Copy' }}
@@ -40,7 +40,7 @@
         </button>
         <button
           type="button"
-          class="btn btn-ghost btn-xs rounded-lg"
+          class="kr-btn-ghost-xs-lg"
           @click="dismissCreatedToken"
         >
           Done
@@ -115,7 +115,7 @@
         <div v-if="!credential.revokedAt" class="mt-3 flex flex-wrap gap-2">
           <button
             type="button"
-            class="btn btn-ghost btn-xs rounded-lg"
+            class="kr-btn-ghost-xs-lg"
             @click="prepareReplacement(credential)"
           >
             Replace
@@ -143,7 +143,7 @@
         <button
           v-if="replacingCredentialId"
           type="button"
-          class="btn btn-ghost btn-xs rounded-lg"
+          class="kr-btn-ghost-xs-lg"
           @click="resetForm"
         >
           Cancel replacement

--- a/components/user/friends-panel.vue
+++ b/components/user/friends-panel.vue
@@ -33,7 +33,7 @@
               Accept
             </button>
             <button
-              class="btn btn-ghost btn-xs rounded-lg"
+              class="kr-btn-ghost-xs-lg"
               @click="friends.rejectRequest(r.id)"
             >
               Decline
@@ -77,7 +77,7 @@
               Message
             </button>
             <button
-              class="btn btn-ghost btn-xs rounded-lg"
+              class="kr-btn-ghost-xs-lg"
               @click="friends.removeFriend(id)"
             >
               Remove
@@ -146,7 +146,7 @@
             >
             <button
               v-if="u.messagePolicy !== 'NONE'"
-              class="btn btn-ghost btn-xs rounded-lg"
+              class="kr-btn-ghost-xs-lg"
               @click="message(u.id)"
             >
               Message
@@ -167,7 +167,7 @@
         >
           <span class="font-semibold">{{ nameFor(id) }}</span>
           <button
-            class="btn btn-ghost btn-xs rounded-lg"
+            class="kr-btn-ghost-xs-lg"
             @click="friends.unblockUser(id)"
           >
             Unblock

--- a/components/user/user-manager-directory.vue
+++ b/components/user/user-manager-directory.vue
@@ -140,7 +140,7 @@
             <td>
               <div class="flex items-center justify-end gap-1">
                 <button
-                  class="btn btn-ghost btn-xs rounded-lg"
+                  class="kr-btn-ghost-xs-lg"
                   title="Reset password"
                   @click="openPassword(u)"
                 >


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Added `.kr-btn-ghost-xs-lg` (`btn btn-ghost btn-xs rounded-lg`) to `assets/css/tailwind.css` — the fifth-most-repeated ghost-button shape after slices 42-45 (`.kr-btn-ghost`, `.kr-btn-ghost-xs`, `.kr-btn-ghost-xs-plain`, `.kr-btn-ghost-2xl`).
- Codemodded the 21 occurrences across 9 files whose `class` attribute matched the exact static string `"btn btn-ghost btn-xs rounded-lg"` (no conditional binding): `components/art/art-gallery.vue`, `components/art/entity-art-manager.vue`, `components/conductor/project-detail.vue`, `components/navigation/account-hub.vue`, `components/pages/conductor-page.vue`, `components/pages/memory-dungeon.vue`, `components/user/agent-credentials-panel.vue`, `components/user/friends-panel.vue`, `components/user/user-manager-directory.vue`.

### How I verified
- Compiled the new `.kr-btn-ghost-xs-lg` primitive through the real `@tailwindcss/postcss` plugin (v4) and diffed its emitted ruleset against a probe compiling the original hand-rolled `btn btn-ghost btn-xs rounded-lg` combo — byte-identical (whitespace-normalized for nesting depth only).
- `npm run test` (vue-tsc --noEmit): clean.
- `npm run test:lint-ratchet`: 332 problems across 24 rules (-60), no rule regressed — holds the existing baseline.
- `npm run test:layout-contract`: 207 baseline unchanged, no new violations.
- `npx prettier --check` on the 9 touched files: 8 flag pre-existing formatting drift; confirmed each of those 8 already fails `prettier --check` on its unmodified `origin/main` copy — not introduced by this change.

### Stakes
reversible

### Flags for Reviewer
None — mechanical extraction following the established slice 42-45 pattern, no geometry or behavior change intended or observed.

### Kaizen suggestion
The remaining `btn-ghost` shape count has narrowed to one (`btn-ghost btn-sm`, 21 occurrences) — worth checking after that slice whether the long tail of `btn-ghost` variants with extra appended classes (previously deliberately out of scope per slice 43's note) is now worth a follow-up sweep, since the "no conditional binding, exact string match" filter has been leaving double-digit counts of near-miss sites on the table each slice.

### Notes for reviewer
Re-arming `interface-vision/t-104` to `ready` in conductor per the recurring-task convention once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du62BDxQ1w7X46DfJgejZf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Du62BDxQ1w7X46DfJgejZf)_