### PR TITLE
interface-vision/t-104 slice 47: extract kr-btn-ghost-plain, codemod 21 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -619,6 +619,17 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-ghost btn-xs rounded-lg;
   }
 
+  /* Sixth-most-repeated ghost-button shape (interface-vision t-104 slice 47):
+   * the `sm` size from .kr-btn-ghost, but with no rounded-* override, so it
+   * renders at DaisyUI's own default button radius instead of rounded-xl —
+   * `btn btn-ghost btn-sm`, previously hand-rolled in 21 files. Named for the
+   * dropped radius override, matching the `-xs-plain` convention above at
+   * the `sm` size (no size suffix, matching .kr-btn-ghost's own bare-sm
+   * convention). */
+  .kr-btn-ghost-plain {
+    @apply btn btn-ghost btn-sm;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/build-bench.vue
+++ b/components/art/build-bench.vue
@@ -20,7 +20,7 @@
           <span v-if="running" class="loading loading-spinner loading-xs" />
           Run both
         </button>
-        <button class="btn btn-ghost btn-sm" :disabled="running" @click="store.newMatchup">
+        <button class="kr-btn-ghost-plain" :disabled="running" @click="store.newMatchup">
           New matchup
         </button>
       </div>

--- a/components/art/stylist-client-gallery.vue
+++ b/components/art/stylist-client-gallery.vue
@@ -72,7 +72,7 @@
         />
       </label>
       <label
-        class="btn btn-ghost btn-sm"
+        class="kr-btn-ghost-plain"
         :class="{ 'btn-disabled': uploading }"
       >
         <Icon name="kind-icon:camera" class="size-4" />

--- a/components/art/stylist-clients.vue
+++ b/components/art/stylist-clients.vue
@@ -19,7 +19,7 @@
       <button type="submit" class="btn btn-primary btn-sm" :disabled="!name.trim()">
         {{ editingId ? 'Update' : 'Add client' }}
       </button>
-      <button v-if="editingId" type="button" class="btn btn-ghost btn-sm" @click="resetForm">Cancel</button>
+      <button v-if="editingId" type="button" class="kr-btn-ghost-plain" @click="resetForm">Cancel</button>
     </form>
 
     <p v-if="photoError" class="rounded-xl bg-error/10 p-2 text-xs text-error">{{ photoError }}</p>

--- a/components/art/stylist-history.vue
+++ b/components/art/stylist-history.vue
@@ -24,7 +24,7 @@
       <button
         v-if="query || date"
         type="button"
-        class="btn btn-ghost btn-sm"
+        class="kr-btn-ghost-plain"
         @click="clearFilters"
       >
         Clear

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -111,7 +111,7 @@
           <button type="button" class="btn btn-primary btn-sm" @click="capturePhoto">
             <Icon name="kind-icon:camera" class="h-4 w-4" /> Capture
           </button>
-          <button type="button" class="btn btn-ghost btn-sm" @click="closeCamera">Cancel</button>
+          <button type="button" class="kr-btn-ghost-plain" @click="closeCamera">Cancel</button>
         </div>
       </div>
 

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -441,7 +441,7 @@
             <div class="mt-3 flex flex-wrap gap-2">
               <button
                 type="button"
-                class="btn btn-ghost btn-sm"
+                class="kr-btn-ghost-plain"
                 :disabled="isPersisting || !premise.trim()"
                 @click="store.useSuggestedSessionName()"
               >
@@ -460,7 +460,7 @@
               <button
                 v-if="savedSessionId"
                 type="button"
-                class="btn btn-ghost btn-sm"
+                class="kr-btn-ghost-plain"
                 :disabled="isPersisting"
                 data-testid="brainstorm-save-as-new"
                 @click="store.detachSavedSession()"
@@ -554,7 +554,7 @@
             <p class="font-black">{{ persistenceErrorHeading }}</p>
             <p class="mt-1 break-words text-sm opacity-80">{{ persistenceError.message }}</p>
           </div>
-          <button type="button" class="btn btn-ghost btn-sm" @click="store.clearPersistenceError()">
+          <button type="button" class="kr-btn-ghost-plain" @click="store.clearPersistenceError()">
             Dismiss
           </button>
         </div>
@@ -572,7 +572,7 @@
         <p class="font-black">{{ errorHeading }}</p>
         <p class="mt-1 break-words text-sm opacity-80">{{ generationError.message }}</p>
       </div>
-      <button type="button" class="btn btn-ghost btn-sm" @click="store.clearGenerationError()">
+      <button type="button" class="kr-btn-ghost-plain" @click="store.clearGenerationError()">
         Dismiss
       </button>
     </div>
@@ -722,7 +722,7 @@
         </label>
         <button
           type="button"
-          class="btn btn-ghost btn-sm"
+          class="kr-btn-ghost-plain"
           :disabled="!selectedForArtCount || isGeneratingArt"
           @click="store.clearArtSelection()"
         >
@@ -764,7 +764,7 @@
       </div>
       <button
         type="button"
-        class="btn btn-ghost btn-sm"
+        class="kr-btn-ghost-plain"
         @click="store.clearArtGenerationError()"
       >
         Dismiss

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -31,7 +31,7 @@
       <span>{{ studio.error }}</span>
       <button
         type="button"
-        class="btn btn-ghost btn-sm"
+        class="kr-btn-ghost-plain"
         @click="studio.clearNotice()"
       >
         Dismiss
@@ -47,7 +47,7 @@
       <span>{{ studio.message }}</span>
       <button
         type="button"
-        class="btn btn-ghost btn-sm"
+        class="kr-btn-ghost-plain"
         @click="studio.clearNotice()"
       >
         Dismiss

--- a/components/conductor/ruler-hooked-page.vue
+++ b/components/conductor/ruler-hooked-page.vue
@@ -29,7 +29,7 @@
             </button>
             <button
               type="button"
-              class="btn btn-ghost btn-sm"
+              class="kr-btn-ghost-plain"
               @click="pwa?.cancelInstall()"
             >
               Not now

--- a/components/dreams/dream-inspire-button.vue
+++ b/components/dreams/dream-inspire-button.vue
@@ -18,7 +18,7 @@
           </option>
         </select>
         <div class="modal-action">
-          <button class="btn btn-ghost btn-sm" @click="closeModal">
+          <button class="kr-btn-ghost-plain" @click="closeModal">
             Cancel
           </button>
           <button

--- a/components/ruler-hooked/ruler-hooked-game.vue
+++ b/components/ruler-hooked/ruler-hooked-game.vue
@@ -65,7 +65,7 @@
           <p v-if="endingBody" class="text-sm opacity-80">{{ endingBody }}</p>
           <div class="mt-3 flex gap-2">
             <button type="button" class="btn btn-accent btn-sm" @click="store.acceptEnding()">Take this ending</button>
-            <button type="button" class="btn btn-ghost btn-sm" @click="store.declineEnding()">Keep fishing</button>
+            <button type="button" class="kr-btn-ghost-plain" @click="store.declineEnding()">Keep fishing</button>
           </div>
         </div>
 

--- a/components/ui/ui-gallery.vue
+++ b/components/ui/ui-gallery.vue
@@ -421,7 +421,7 @@
                 Flat kr-panel-flat variant for dense lists and inboxes.
               </p>
               <div class="card-actions justify-end">
-                <button class="btn btn-ghost btn-sm">Dismiss</button>
+                <button class="kr-btn-ghost-plain">Dismiss</button>
               </div>
             </div>
           </div>

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -331,12 +331,12 @@
                 </div>
 
                 <div class="flex items-center justify-between gap-2 border-t border-base-300 pt-3">
-                  <button type="button" class="btn btn-ghost btn-sm" :disabled="focusNavigationLocked" @click="store.previousCard()">
+                  <button type="button" class="kr-btn-ghost-plain" :disabled="focusNavigationLocked" @click="store.previousCard()">
                     <Icon name="kind-icon:back" class="size-4" />
                     Previous
                   </button>
                   <span class="text-xs opacity-55">{{ currentPositionLabel }}</span>
-                  <button type="button" class="btn btn-ghost btn-sm" :disabled="focusNavigationLocked" @click="store.nextCard()">
+                  <button type="button" class="kr-btn-ghost-plain" :disabled="focusNavigationLocked" @click="store.nextCard()">
                     Next
                     <Icon name="kind-icon:forward" class="size-4" />
                   </button>
@@ -392,9 +392,9 @@
                 </div>
 
                 <div class="flex items-center justify-between gap-2 border-t border-base-300 pt-3">
-                  <button type="button" class="btn btn-ghost btn-sm" :disabled="focusNavigationLocked" @click="store.previousCard()">Previous</button>
+                  <button type="button" class="kr-btn-ghost-plain" :disabled="focusNavigationLocked" @click="store.previousCard()">Previous</button>
                   <button type="button" class="btn btn-outline btn-sm" @click="store.toggleDetails()">{{ detailsVisible ? 'Hide parts' : 'Parts & history' }}</button>
-                  <button type="button" class="btn btn-ghost btn-sm" :disabled="focusNavigationLocked" @click="store.nextCard()">Next</button>
+                  <button type="button" class="kr-btn-ghost-plain" :disabled="focusNavigationLocked" @click="store.nextCard()">Next</button>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (slice 47)

### What changed
Sixth-most-repeated ghost-button shape: `btn btn-ghost btn-sm` (no `rounded-*` override), previously hand-rolled in 21 files across 12 components. Extracted to `.kr-btn-ghost-plain` in `assets/css/tailwind.css`, named for the dropped radius override — matching the existing `.kr-btn-ghost-xs-plain` convention at the `sm` size (bare, no size suffix, matching `.kr-btn-ghost`'s own bare-sm convention).

### How I verified
- Compiled the real stylesheet through the actual `@tailwindcss/postcss` plugin (the same one Nuxt's build uses) and diffed the emitted `.kr-btn-ghost-plain` ruleset against the already-shipped `.kr-btn-ghost-xs-plain`: identical structure, differing only in the expected `sm`-vs-`xs` size tokens (`--fontsize`, `--btn-p`, `--size`).
- `vue-tsc --noEmit` — clean.
- `npm run test:lint-ratchet` — holds (332 problems, -60, no rule regressed).
- `npm run test:layout-contract` — holds (207-violation baseline unchanged; this change touches no layout/CSS shape, only a class-name substitution).
- `prettier --check` flags all 11 touched files, but each already fails identically against its unmodified `origin/main` copy — pre-existing repo-wide drift this diff doesn't introduce; CI doesn't gate on `lint:prettier`.

This was the last of the exact-match repeated `btn-ghost` shapes flagged by slice 42's original survey.

### Stakes
reversible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNZWvBjqAjsiZS6PG94VUk)_