### PR TITLE
fix(storybook): guard session/draft storage recovery, sibling of library fix

### DIFF
--- a/.github/workflows/storybook-session-storage-recovery-contract.yml
+++ b/.github/workflows/storybook-session-storage-recovery-contract.yml
@@ -1,0 +1,30 @@
+name: Storybook Session Storage Recovery Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: storybook-session-storage-recovery-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Storybook session storage recovery contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify Storybook session storage recovery guard
+        run: node utils/scripts/verifyStorybookSessionStorageRecoveryGuard.mjs

--- a/stores/storybookStore.ts
+++ b/stores/storybookStore.ts
@@ -474,8 +474,21 @@ export const useStorybookStore = defineStore('storybookStore', () => {
         resumeNarrativeArtJobs()
       }
     } catch {
-      localStorage.removeItem(DRAFT_STORAGE_KEY)
-      localStorage.removeItem(STORAGE_KEY)
+      // Recovering from a bad read shouldn't itself be able to throw: a
+      // storage-access failure (privacy mode, a strict cookie/site-data
+      // policy, quota exhaustion) can make removeItem() throw the same way
+      // getItem()/JSON.parse() just did, which would otherwise escape this
+      // catch block and break Storybook initialization entirely instead of
+      // just falling back to in-memory-only state (storybook/t-010, sibling
+      // of storybookLibraryHelper.ts's initialize() guard).
+      try {
+        localStorage.removeItem(DRAFT_STORAGE_KEY)
+        localStorage.removeItem(STORAGE_KEY)
+      } catch {
+        // Best-effort cleanup only — falling through with in-memory-only
+        // setupDraft/session below is the actual recovery; stale keys left
+        // behind aren't harmful.
+      }
     }
   }
 

--- a/utils/scripts/verifyStorybookSessionStorageRecoveryGuard.mjs
+++ b/utils/scripts/verifyStorybookSessionStorageRecoveryGuard.mjs
@@ -1,0 +1,32 @@
+// /utils/scripts/verifyStorybookSessionStorageRecoveryGuard.mjs
+// Regression guard for Storybook session/draft restoration recovery.
+// Sibling of verifyStorybookLibraryStorageRecoveryGuard.mjs (storybook/t-010,
+// cycle 55): stores/storybookStore.ts's restoreFromLocalStorage() has the
+// same shape of bug as storybookLibraryHelper.ts's initialize() once did — a
+// failed localStorage read can mean storage access itself is forbidden, so
+// cleanup in the catch block must be best-effort rather than another
+// throwing storage operation.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { extractTsFunctionBody } from './lib/extractTsFunctionBody.mjs'
+
+const STORE_PATH = 'stores/storybookStore.ts'
+const storeContent = readFileSync(resolve(process.cwd(), STORE_PATH), 'utf8')
+const restoreBody = extractTsFunctionBody(
+  storeContent,
+  'restoreFromLocalStorage',
+  {
+    path: STORE_PATH,
+    notFoundHint:
+      'If session restoration moved, move this recovery guard with it.',
+  },
+)
+
+assert.match(
+  restoreBody,
+  /catch\s*\{[\s\S]*?try\s*\{[\s\S]*?localStorage\.removeItem\(DRAFT_STORAGE_KEY\)[\s\S]*?localStorage\.removeItem\(STORAGE_KEY\)[\s\S]*?\}\s*catch\s*\{[\s\S]*?\}/,
+  `${STORE_PATH} restoreFromLocalStorage() must keep its localStorage.removeItem(DRAFT_STORAGE_KEY)/removeItem(STORAGE_KEY) cleanup inside its own try/catch when recovering from a failed read. Storage access failures can make cleanup throw too.`,
+)
+
+console.log('Storybook session storage recovery guard verified.')


### PR DESCRIPTION
### Task
storybook/t-010: Polish and upgrade Storybook front-end surface (cycle 55)

### What changed
`restoreFromLocalStorage()`'s catch block in `stores/storybookStore.ts` called `localStorage.removeItem(DRAFT_STORAGE_KEY)`/`removeItem(STORAGE_KEY)` unguarded while already handling a failed `getItem()`/`JSON.parse()` read. A storage-access failure (privacy mode, strict cookie/site-data policy, quota exhaustion) can make `removeItem()` throw the same way the read just did, escaping this catch and breaking Storybook initialization entirely instead of falling back to in-memory-only state.

This is the sibling of `storybookLibraryHelper.ts`'s `initialize()` guard (storybook/t-010 cycle 53, kind_robots#2338) — same shape of bug, different file. It was identified in cycle 54 but not fixed then because that session's connector could only replace whole files, not patch this 1000+ line store safely.

Adds `verifyStorybookSessionStorageRecoveryGuard.mjs` (+ dedicated CI workflow), mirroring `verifyStorybookLibraryStorageRecoveryGuard.mjs`'s existing contract for the sibling fix, so this can't silently regress.

### How I verified
- New guard script confirmed to fail against the pre-fix code (stashed the change and re-ran it) and pass against the fixed code.
- `vue-tsc --noEmit` — clean.
- `npm run test:layout-contract` — holds (207-violation baseline unchanged).
- `eslint stores/storybookStore.ts` — flags 2 pre-existing errors (`no-empty` at an unrelated `setMode()` catch block, `no-useless-assignment` elsewhere); confirmed both already present identically on unmodified `main` — not introduced by this diff.
- `prettier --check` flags `stores/storybookStore.ts`; confirmed it already fails identically against its unmodified `main` copy — pre-existing repo-wide drift, not introduced here. CI doesn't gate on `lint:prettier`.

### Stakes
reversible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEPHBaDWQPANsrAcUfSt5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEPHBaDWQPANsrAcUfSt5W)_