### PR TITLE
model-builder/t-029: skip comments/strings in guard-script brace scanner

### DIFF
--- a/utils/scripts/verifyModelBuilderCompletionGate.test.ts
+++ b/utils/scripts/verifyModelBuilderCompletionGate.test.ts
@@ -9,9 +9,18 @@
 // not be flagged), and a synchronous function with no `await` at all (must
 // not be flagged even though it writes item.stages unconditionally, matching
 // approveStage/rejectStage/reopenStage's real shape).
+//
+// Also covers the comment/string-brace parser blind spot (model-builder/t-029
+// cycle 88, kaizen from OpenAI cycle 87's guard-integrity audit): before
+// computeCodeMask existed, a `}` inside a `//` comment silently truncated a
+// function's extracted body (a real violation inside the truncated-away tail
+// would go undetected -- a false negative), and a `{` inside a string
+// literal made the brace scan overrun looking for a closing brace that was
+// never coming, throwing on a file whose shape hadn't actually changed.
 import assert from 'node:assert/strict'
 
 import {
+  computeCodeMask,
   extractFunctionBodies,
   findGuardIntervals,
   findUngatedCompletionWrites,
@@ -128,4 +137,108 @@ console.log(
     'post-await stage-status write, clears the named-helper and inline-' +
     'guard shapes, and never flags a pre-await write or a synchronous ' +
     'function with no await.',
+)
+
+// --- comment/string-brace parser blind spot ---------------------------
+
+// A `}` inside a `//` line comment, before the function's real closing
+// brace, must not be counted as the end of the body -- the real write two
+// lines later must still be captured.
+const COMMENT_BRACE_FIXTURE = `
+  async function commentBraceTruncation(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item) return false
+    // note: unrelated aside mentioning a curly brace }
+    const response = await performFetch('/x', {})
+    item.stages.COMMIT = { status: 'approved' }
+    return true
+  }
+
+  function afterCommentBrace(): void {
+    doSomething()
+  }
+`
+
+const commentBraceFunctions = extractFunctionBodies(COMMENT_BRACE_FIXTURE)
+assert.equal(
+  commentBraceFunctions.map((f) => f.name).join(','),
+  'commentBraceTruncation,afterCommentBrace',
+  `a '}' inside a comment must not truncate extraction, got: ${commentBraceFunctions
+    .map((f) => f.name)
+    .join(',')}`,
+)
+assert.ok(
+  commentBraceFunctions[0]!.body.includes('item.stages.COMMIT'),
+  "commentBraceTruncation's body must include its real write, not stop at the comment's stray '}'",
+)
+
+const commentBraceViolations = findUngatedCompletionWrites(
+  COMMENT_BRACE_FIXTURE,
+)
+assert.equal(
+  commentBraceViolations.length,
+  1,
+  `expected the real ungated write past the comment to still be flagged, got ${commentBraceViolations.length}: ${JSON.stringify(commentBraceViolations)}`,
+)
+assert.equal(commentBraceViolations[0]!.functionName, 'commentBraceTruncation')
+
+// A `{` inside a string literal must not be counted as opening a real
+// block -- it must not make the scan overrun into (or swallow) the next
+// function looking for a closing brace that was never coming.
+const STRING_BRACE_FIXTURE = `
+  async function stringBraceOverextension(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item) return false
+    const note = 'unexpected token: {'
+    const response = await performFetch('/x', {})
+    item.stages.COMMIT = { status: 'approved' }
+    return true
+  }
+
+  function afterStringBrace(): void {
+    doSomething()
+  }
+`
+
+const stringBraceFunctions = extractFunctionBodies(STRING_BRACE_FIXTURE)
+assert.equal(
+  stringBraceFunctions.map((f) => f.name).join(','),
+  'stringBraceOverextension,afterStringBrace',
+  `a '{' inside a string literal must not extend a function's body into ` +
+    `the next function, got: ${stringBraceFunctions.map((f) => f.name).join(',')}`,
+)
+assert.ok(
+  !stringBraceFunctions[0]!.body.includes('afterStringBrace'),
+  "stringBraceOverextension's body must not swallow the next function's source",
+)
+
+// A guard condition inside a function whose body also contains a
+// comment/string brace must still resolve correctly (findGuardIntervals
+// shares the same masking).
+const guardWithStringBrace = findGuardIntervals(
+  `if (item.stages.COMMIT.status === 'in-progress') { const n = 'note: {'; item.stages.COMMIT = { status: 'approved' } }`,
+)
+assert.equal(
+  guardWithStringBrace.length,
+  1,
+  'a guard interval containing a string-literal brace must still resolve to exactly one interval',
+)
+assert.equal(guardWithStringBrace[0]!.key, 'COMMIT')
+
+// computeCodeMask itself: spot-check that comment/string content is masked
+// out and real code is not.
+const maskSample = "a{'{'}b" // code, quote, code, quote, code -- only the outer a/{/}/b are real code
+const mask = computeCodeMask(maskSample)
+assert.equal(mask[0], true, "'a' is real code")
+assert.equal(mask[1], true, "the first '{' is real code")
+assert.equal(mask[2], false, 'the opening quote starts a string and is masked')
+assert.equal(mask[3], false, "the '{' inside the string is masked")
+assert.equal(mask[4], false, 'the closing quote is masked')
+assert.equal(mask[5], true, "the second '}' is real code")
+assert.equal(mask[6], true, "'b' is real code")
+
+console.log(
+  'Model Builder completion-gate checker verified: a comment/string ' +
+    "literal's brace no longer truncates or overruns function extraction, " +
+    'and a real violation past such a comment is still flagged.',
 )

--- a/utils/scripts/verifyModelBuilderCompletionGate.ts
+++ b/utils/scripts/verifyModelBuilderCompletionGate.ts
@@ -45,13 +45,82 @@ export interface FunctionBody {
   body: string
 }
 
+// Regression fixture (model-builder/t-029 cycle 88, kaizen from OpenAI cycle
+// 87's guard-integrity audit): the brace/paren counters below used to scan
+// raw characters, so a `{`/`}`/`(`/`)` that only exists inside a `//`/`/* */`
+// comment or a string/template literal was counted as real structure. A
+// stray `}` in a comment silently truncated a function's extracted body
+// (the completion-gate check would then miss any real violation the
+// truncated-away code contained -- a false negative), and a stray `{` in a
+// string literal made the scan overrun into later code looking for a
+// closing brace that was never coming, throwing "has ...'s shape changed?"
+// on a file whose shape hadn't changed at all. `computeCodeMask` marks
+// which offsets are genuine code (not comment/string content) so the
+// counters below can skip the rest.
+export function computeCodeMask(content: string): boolean[] {
+  const mask = new Array<boolean>(content.length).fill(true)
+  type State =
+    | 'code'
+    | 'line-comment'
+    | 'block-comment'
+    | 'single-quote'
+    | 'double-quote'
+    | 'template'
+  let state: State = 'code'
+
+  for (let i = 0; i < content.length; i++) {
+    const ch = content[i]
+    if (state === 'code') {
+      if (ch === '/' && content[i + 1] === '/') {
+        state = 'line-comment'
+        mask[i] = false
+      } else if (ch === '/' && content[i + 1] === '*') {
+        state = 'block-comment'
+        mask[i] = false
+      } else if (ch === "'" || ch === '"' || ch === '`') {
+        state =
+          ch === "'" ? 'single-quote' : ch === '"' ? 'double-quote' : 'template'
+        mask[i] = false
+      }
+      continue
+    }
+
+    mask[i] = false
+    if (state === 'line-comment') {
+      if (ch === '\n') state = 'code'
+    } else if (state === 'block-comment') {
+      if (ch === '*' && content[i + 1] === '/') {
+        mask[i + 1] = false
+        i++
+        state = 'code'
+      }
+    } else {
+      // single-quote / double-quote / template: an unescaped backslash
+      // consumes the following character too (so `\'`/`\"`/`` \` `` never
+      // ends the string), then the matching quote closes it.
+      const closingQuote =
+        state === 'single-quote' ? "'" : state === 'double-quote' ? '"' : '`'
+      if (ch === '\\') {
+        if (i + 1 < content.length) mask[++i] = false
+      } else if (ch === closingQuote) {
+        state = 'code'
+      }
+    }
+  }
+
+  return mask
+}
+
 // Finds every top-level `function NAME(` / `async function NAME(` declared
 // at 2-space indent (this store's setup-function convention) and extracts
 // its body via paren-matching (to skip past a parameter list, which may
 // itself contain `{ ... }` object-type braces) followed by brace-matching
-// from the body's own opening `{`.
+// from the body's own opening `{`. Braces/parens inside a comment or string
+// literal are ignored (see computeCodeMask) rather than counted as
+// structure.
 export function extractFunctionBodies(content: string): FunctionBody[] {
   const functions: FunctionBody[] = []
+  const codeMask = computeCodeMask(content)
   const signaturePattern = /^ {2}(async )?function (\w+)\s*\(/gm
 
   for (const match of content.matchAll(signaturePattern)) {
@@ -62,6 +131,7 @@ export function extractFunctionBodies(content: string): FunctionBody[] {
     let parenDepth = 0
     let i = parenOpen
     for (; i < content.length; i++) {
+      if (!codeMask[i]) continue
       if (content[i] === '(') parenDepth++
       else if (content[i] === ')') {
         parenDepth--
@@ -86,6 +156,7 @@ export function extractFunctionBodies(content: string): FunctionBody[] {
     let braceDepth = 0
     let j = braceOpen
     for (; j < content.length; j++) {
+      if (!codeMask[j]) continue
       if (content[j] === '{') braceDepth++
       else if (content[j] === '}') {
         braceDepth--
@@ -120,9 +191,11 @@ export interface GuardInterval {
 // Every `if (item.stages.KEY.status === 'VALUE') { ... }` block in `body`,
 // as a [start, end) offset interval spanning its own braces -- covers both
 // the named-helper idiom (finishGenerateAssets/finishCommit's own bodies)
-// and an inline guard written directly in an async function.
+// and an inline guard written directly in an async function. Braces inside
+// a comment or string literal are ignored (see computeCodeMask).
 export function findGuardIntervals(body: string): GuardInterval[] {
   const intervals: GuardInterval[] = []
+  const codeMask = computeCodeMask(body)
   const guardPattern = /if \(item\.stages\.(\w+)\.status === '[\w-]+'\) \{/g
 
   for (const match of body.matchAll(guardPattern)) {
@@ -131,6 +204,7 @@ export function findGuardIntervals(body: string): GuardInterval[] {
     let depth = 0
     let k = braceOpen
     for (; k < body.length; k++) {
+      if (!codeMask[k]) continue
       if (body[k] === '{') depth++
       else if (body[k] === '}') {
         depth--


### PR DESCRIPTION
### Task
model-builder/t-029 cycle 88 — kaizen from OpenAI cycle 87's guard-integrity audit, which flagged (but did not yet reproduce or fix) a parser blind spot in the shared brace-matching scanner used by ~40 `verifyModelBuilder*.ts` guard scripts.

### What changed
`extractFunctionBodies()` / `findGuardIntervals()` in `verifyModelBuilderCompletionGate.ts` brace/paren-matched by scanning raw source characters, so a stray `{`/`}`/`(`/`)` inside a `//`/`/* */` comment or a string/template literal was counted as real structure.

Confirmed both failure modes before touching the scanner (per cycle 87's own instruction — reproduce first, then harden only if the fixture reproduces the failure):
- A `}` inside a comment silently **truncated** a function's extracted body, so a real violation in the truncated-away tail would go undetected — a false negative in every guard built on `extractFunctionBodies`.
- A `{` inside a string literal made the scan **overrun** looking for a closing brace that was never coming, throwing `"has ...'s shape changed?"` on a file whose shape hadn't actually changed.

Added `computeCodeMask()` to mark which offsets are genuine code (not comment/string content) and wired both brace/paren counters in `extractFunctionBodies` and `findGuardIntervals` to skip masked offsets. Added a regression fixture in `verifyModelBuilderCompletionGate.test.ts` covering both failure modes plus a direct spot-check of `computeCodeMask()` itself.

### How I verified
- Reproduced both bugs standalone against the pre-fix code before making any scanner change.
- All 167 `test:model-builder-*` npm scripts pass (covers every guard script built on this shared module).
- `npm run test` (vue-tsc) — clean.
- `eslint` on both touched files — clean.
- `npm run test:lint-ratchet` — holds (332 problems, -60, no rule regressed).
- `npm run test:layout-contract` — holds (207-violation baseline unchanged; no layout touched).
- `prettier --check` — clean (formatted the new code to match; the pre-existing files were already prettier-clean).

### Stakes
reversible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyqbAz6fgEHMsH1SVS9ThJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyqbAz6fgEHMsH1SVS9ThJ)_