### PR TITLE
interface-vision/t-104 slice 49: codemod class-order duplicate of kr-btn-ghost-xs

### DIFF
--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -154,35 +154,19 @@
         />
 
         <div class="mb-2 flex flex-wrap items-center gap-2">
-          <button
-            class="btn btn-xs btn-ghost rounded-xl"
-            type="button"
-            @click="fillStarter"
-          >
+          <button class="kr-btn-ghost-xs" type="button" @click="fillStarter">
             Starter
           </button>
 
-          <button
-            class="btn btn-xs btn-ghost rounded-xl"
-            type="button"
-            @click="fillWeird"
-          >
+          <button class="kr-btn-ghost-xs" type="button" @click="fillWeird">
             Weird
           </button>
 
-          <button
-            class="btn btn-xs btn-ghost rounded-xl"
-            type="button"
-            @click="copyBotIntro"
-          >
+          <button class="kr-btn-ghost-xs" type="button" @click="copyBotIntro">
             Bot Intro
           </button>
 
-          <button
-            class="btn btn-xs btn-ghost rounded-xl"
-            type="button"
-            @click="clearMessage"
-          >
+          <button class="kr-btn-ghost-xs" type="button" @click="clearMessage">
             Clear
           </button>
 
@@ -390,7 +374,7 @@
           <h2 class="text-lg font-bold text-base-content">Prompt Preview</h2>
 
           <button
-            class="btn btn-xs btn-ghost rounded-xl"
+            class="kr-btn-ghost-xs"
             type="button"
             :disabled="!promptPreview"
             @click="copyPromptPreview"

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -224,7 +224,7 @@
             :class="sessionChats.length === 0 ? 'mb-2' : ''"
           >
             <button
-              class="btn btn-xs btn-ghost rounded-xl"
+              class="kr-btn-ghost-xs"
               type="button"
               :disabled="isStarting"
               @click="clearPromptOptions"
@@ -233,7 +233,7 @@
             </button>
 
             <button
-              class="btn btn-xs btn-ghost rounded-xl"
+              class="kr-btn-ghost-xs"
               type="button"
               :disabled="isStarting"
               @click="newStory"
@@ -242,7 +242,7 @@
             </button>
 
             <button
-              class="btn btn-xs btn-ghost rounded-xl"
+              class="kr-btn-ghost-xs"
               type="button"
               :disabled="!rewardPromptPreview"
               @click="copyPrompt"

--- a/components/servers/server-card.vue
+++ b/components/servers/server-card.vue
@@ -16,7 +16,7 @@
     >
       <div v-if="showActions" class="mt-3 flex flex-wrap gap-1">
         <button
-          class="btn btn-xs btn-ghost rounded-xl"
+          class="kr-btn-ghost-xs"
           type="button"
           title="Select"
           @click="selectServer"
@@ -26,7 +26,7 @@
 
         <button
           v-if="allowEdit"
-          class="btn btn-xs btn-ghost rounded-xl"
+          class="kr-btn-ghost-xs"
           type="button"
           title="Edit"
           @click="editServer"
@@ -36,7 +36,7 @@
 
         <button
           v-if="allowTest"
-          class="btn btn-xs btn-ghost rounded-xl"
+          class="kr-btn-ghost-xs"
           type="button"
           title="Test health"
           @click="testServer"

--- a/components/themes/theme-gallery.vue
+++ b/components/themes/theme-gallery.vue
@@ -337,7 +337,7 @@
             </div>
 
             <button
-              class="btn btn-xs btn-ghost rounded-xl"
+              class="kr-btn-ghost-xs"
               type="button"
               @click="inspectValues = null"
             >

--- a/components/wonderlab/reactable-card.vue
+++ b/components/wonderlab/reactable-card.vue
@@ -62,7 +62,7 @@
           </p>
 
           <button
-            class="btn btn-xs btn-ghost rounded-xl"
+            class="kr-btn-ghost-xs"
             type="button"
             @click="reactionOpen = false"
           >

--- a/components/wonderlab/reaction-card.vue
+++ b/components/wonderlab/reaction-card.vue
@@ -41,7 +41,7 @@
 
           <button
             v-if="rating"
-            class="btn btn-xs btn-ghost rounded-xl"
+            class="kr-btn-ghost-xs"
             type="button"
             @click="rating = 0"
           >


### PR DESCRIPTION
## Summary

Continues the interface-vision/t-104 kr-* consistency sweep (conductor roadmap task, recurring). Replaces the class-order duplicate of `.kr-btn-ghost-xs` — `btn btn-xs btn-ghost rounded-xl` (btn-xs and btn-ghost swapped vs. the canonical `btn btn-ghost btn-xs rounded-xl`, same computed shape) — with `kr-btn-ghost-xs` across 14 occurrences in 6 files:

- `components/bots/bot-chat.vue`
- `components/rewards/reward-encounter.vue`
- `components/servers/server-card.vue`
- `components/themes/theme-gallery.vue`
- `components/wonderlab/reactable-card.vue`
- `components/wonderlab/reaction-card.vue`

No new CSS primitive needed — `.kr-btn-ghost-xs` already exists (slice 43). This is a pure exact-string codemod: no geometry or behavior change.

## Verification

- `prettier --write` run on the touched files (several `<button>` tags now fit on one line since the class attribute is shorter); the 2 remaining prettier warnings (`reactable-card.vue`, `reaction-card.vue`) confirmed as pre-existing drift on unmodified `origin/main`, not introduced by this change.
- `vue-tsc --noEmit`: clean
- `verifyLintRatchet`: 332 problems / 24 rules (-60) — no rule regressed
- `verifyLayoutContract`: 207 baseline unchanged — no new violations

## Scope note

Sites with extra appended classes (e.g. `text-base-content/60`, `text-error`, `sm:btn-sm`) were intentionally left out of scope, consistent with prior slices' near-miss handling — flagged for a future slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHxkyXgFEYCDEoGDKXUQec

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHxkyXgFEYCDEoGDKXUQec)_