### PR TITLE
interface-vision/t-104 slice 50: codemod near-miss kr-btn-ghost-xs sites

### DIFF
--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -27,7 +27,7 @@
 
         <button
           v-if="currentArtImage"
-          class="btn btn-xs btn-ghost rounded-xl sm:btn-sm"
+          class="kr-btn-ghost-xs sm:btn-sm"
           type="button"
           @click="deselectAndReturn"
         >
@@ -72,7 +72,7 @@
         <template v-if="currentArtImage && canDeleteCurrentImage">
           <button
             v-if="!deleteArmed"
-            class="btn btn-xs btn-ghost rounded-xl border border-error/30 text-error sm:btn-sm hover:btn-error hover:text-error-content"
+            class="kr-btn-ghost-xs border border-error/30 text-error sm:btn-sm hover:btn-error hover:text-error-content"
             type="button"
             title="Delete this image"
             @click="deleteArmed = true"

--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -44,7 +44,7 @@
         </button>
         <button
           type="button"
-          class="btn btn-xs btn-ghost rounded-xl text-base-content/60"
+          class="kr-btn-ghost-xs text-base-content/60"
           @click="store.resetRun()"
         >
           <Icon name="kind-icon:arrow-left" class="h-3.5 w-3.5" />

--- a/components/model-builder/model-builder-run-history.vue
+++ b/components/model-builder/model-builder-run-history.vue
@@ -12,7 +12,7 @@
       <div class="flex shrink-0 items-center gap-1">
         <button
           type="button"
-          class="btn btn-xs btn-ghost rounded-xl text-base-content/60"
+          class="kr-btn-ghost-xs text-base-content/60"
           :disabled="store.loadingRuns || Boolean(cancellingRunId)"
           @click="store.fetchRuns()"
         >

--- a/components/navigation/account-hub.vue
+++ b/components/navigation/account-hub.vue
@@ -234,7 +234,7 @@
           <button
             v-if="userStore.isLoggedIn"
             type="button"
-            class="btn btn-xs btn-ghost rounded-xl text-error"
+            class="kr-btn-ghost-xs text-error"
             @click="logout"
           >
             <Icon name="kind-icon:logout" class="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary

Continues the interface-vision/t-104 kr-* consistency sweep. Sweeps the near-miss sites left out of scope by slice 49 (kind_robots#2361): the same base shape (`btn btn-xs btn-ghost rounded-xl`) with extra appended classes, 5 occurrences across 4 files:

- `components/model-builder/model-builder-run-history.vue` — `text-base-content/60`
- `components/model-builder/model-builder-progress-matrix.vue` — `text-base-content/60`
- `components/navigation/account-hub.vue` — `text-error`
- `components/art/art-interact.vue` (x2) — `sm:btn-sm`, and `border border-error/30 text-error sm:btn-sm hover:btn-error hover:text-error-content`

No geometry or behavior change: `.kr-btn-ghost-xs` already exists (slice 43), and the extra classes are preserved verbatim, just appended after the new class name instead of the old hand-rolled base classes.

## Verification

- Confirmed against the real compiled CSS (not assumed) that the `sm:btn-sm` responsive override still wins over `.kr-btn-ghost-xs`'s baked-in `btn-xs` sizing: `.kr-btn-ghost-xs` lives in `@layer components`, while `sm:btn-sm` (and every DaisyUI utility) lives in `@layer utilities`, and Tailwind's global layer order (`theme, base, components, utilities`) makes utilities win regardless of source position.
- `vue-tsc --noEmit`: clean
- `verifyLintRatchet`: 332 problems / 24 rules (-60) — no rule regressed
- `verifyLayoutContract`: 207 baseline unchanged — no new violations
- The 2 remaining prettier warnings (the two model-builder files) confirmed pre-existing drift on unmodified `origin/main` via `git stash`, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHxkyXgFEYCDEoGDKXUQec

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHxkyXgFEYCDEoGDKXUQec)_