### PR TITLE
interface-vision/t-104 slice 51: introduce kr-btn-primary and codemod exact-match sites

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -640,6 +640,19 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-ghost rounded-xl;
   }
 
+  /* The most-repeated *filled* (non-ghost) button shape in the app
+   * (interface-vision t-104 slice 51): the primary-color small action
+   * button used for form submits and gallery/manager primary actions —
+   * `btn btn-primary btn-sm rounded-xl`, previously hand-rolled in 31
+   * files (39 occurrences). Named to mirror the .kr-btn-ghost* family:
+   * same size/radius shape, filled with the primary color instead of
+   * ghost. Near-miss sites with extra appended classes (gap-1.5, mt-3,
+   * text-white, focus-visible:* utilities) are left out of scope for a
+   * follow-up slice, matching the ghost family's own convention. */
+  .kr-btn-primary {
+    @apply btn btn-primary btn-sm rounded-xl;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -38,7 +38,7 @@
 
           <button
             v-if="allowAdd && !isDropdownMode"
-            class="btn btn-primary btn-sm rounded-xl"
+            class="kr-btn-primary"
             type="button"
             @click="startAddingBot"
           >
@@ -79,11 +79,7 @@
           </p>
         </div>
 
-        <button
-          class="kr-btn-ghost"
-          type="button"
-          @click="closeBotForm"
-        >
+        <button class="kr-btn-ghost" type="button" @click="closeBotForm">
           <Icon name="kind-icon:x" class="h-4 w-4" />
           <span class="hidden sm:inline">Close</span>
         </button>
@@ -381,7 +377,7 @@
 
         <button
           v-if="allowAdd"
-          class="btn btn-primary btn-sm rounded-xl"
+          class="kr-btn-primary"
           type="button"
           @click="startAddingBot"
         >
@@ -916,8 +912,9 @@ const filteredBots = computed<Bot[]>(() => {
 // interface-vision/t-066: earned karma for the rendered set, batched through
 // the shared userStore earned-karma tracker. Scoped to
 // filteredBots — the set the grid actually renders.
-const { earnedKarma: earnedKarmaByBotId } = userStore.trackEarnedKarma('bot', () =>
-  filteredBots.value.map((bot) => bot.id),
+const { earnedKarma: earnedKarmaByBotId } = userStore.trackEarnedKarma(
+  'bot',
+  () => filteredBots.value.map((bot) => bot.id),
 )
 
 onMounted(async () => {

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -18,11 +18,7 @@
           </p>
         </div>
 
-        <button
-          class="kr-btn-ghost"
-          type="button"
-          @click="closeCharacterForm"
-        >
+        <button class="kr-btn-ghost" type="button" @click="closeCharacterForm">
           <Icon name="kind-icon:x" class="h-4 w-4" />
           <span class="hidden sm:inline">Close</span>
         </button>
@@ -315,7 +311,7 @@
 
         <button
           v-if="allowAdd"
-          class="btn btn-primary btn-sm rounded-xl"
+          class="kr-btn-primary"
           type="button"
           @click="startAddingCharacter"
         >

--- a/components/characters/character-manager.vue
+++ b/components/characters/character-manager.vue
@@ -15,7 +15,7 @@
         >
           <button
             type="button"
-            class="btn btn-primary btn-sm rounded-xl"
+            class="kr-btn-primary"
             title="Start a Storybook story seeded with this Character"
             @click="startStoryWithCharacter"
           >

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -50,7 +50,7 @@
             <p class="max-w-md text-sm text-base-content/65">
               Log in to seed a life, make choices, and leave a legacy.
             </p>
-            <NuxtLink to="/login" class="btn btn-primary btn-sm rounded-xl">
+            <NuxtLink to="/login" class="kr-btn-primary">
               Log in to play
             </NuxtLink>
           </div>

--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -31,10 +31,7 @@
           <Icon name="kind-icon:plus" class="size-3.5" />
           New pack
         </button>
-        <button
-          class="kr-btn-ghost-xs"
-          @click="showImport = !showImport"
-        >
+        <button class="kr-btn-ghost-xs" @click="showImport = !showImport">
           Load manifest JSON
         </button>
       </div>
@@ -58,9 +55,7 @@
         placeholder='{"schemaVersion": 1, "id": "my-pack", "title": "My Pack", "visibility": "draft", "price": {"hook": "free"}, "items": [...]}'
       />
       <div class="flex items-center gap-2">
-        <button class="btn btn-primary btn-sm rounded-xl" @click="onImport">
-          Import pack
-        </button>
+        <button class="kr-btn-primary" @click="onImport">Import pack</button>
         <span
           v-if="importMessage"
           class="text-xs font-semibold"

--- a/components/conductor/project-deliverables-panel.vue
+++ b/components/conductor/project-deliverables-panel.vue
@@ -88,7 +88,7 @@
       >
       <button
         type="button"
-        class="btn btn-primary btn-sm rounded-xl"
+        class="kr-btn-primary"
         :disabled="saving"
         @click="save"
       >

--- a/components/conductor/project-detail.vue
+++ b/components/conductor/project-detail.vue
@@ -21,23 +21,35 @@
         <button
           type="button"
           class="btn btn-circle btn-ghost btn-xs"
-          :class="linkedProject.isPublic ? 'text-success' : 'text-base-content/35'"
+          :class="
+            linkedProject.isPublic ? 'text-success' : 'text-base-content/35'
+          "
           :title="linkedProject.isPublic ? 'Public project' : 'Private project'"
-          :aria-label="linkedProject.isPublic ? 'Make project private' : 'Make project public'"
+          :aria-label="
+            linkedProject.isPublic
+              ? 'Make project private'
+              : 'Make project public'
+          "
           :disabled="projectSaving"
           @click="patchProject({ isPublic: !linkedProject.isPublic })"
         >
           <Icon
-            :name="linkedProject.isPublic ? 'kind-icon:eye' : 'kind-icon:eye-off'"
+            :name="
+              linkedProject.isPublic ? 'kind-icon:eye' : 'kind-icon:eye-off'
+            "
             class="size-3.5"
           />
         </button>
         <button
           type="button"
           class="btn btn-circle btn-ghost btn-xs"
-          :class="linkedProject.isMature ? 'text-warning' : 'text-base-content/35'"
+          :class="
+            linkedProject.isMature ? 'text-warning' : 'text-base-content/35'
+          "
           :title="linkedProject.isMature ? 'Mature content' : 'Safe content'"
-          :aria-label="linkedProject.isMature ? 'Mark project safe' : 'Mark project mature'"
+          :aria-label="
+            linkedProject.isMature ? 'Mark project safe' : 'Mark project mature'
+          "
           :disabled="projectSaving"
           @click="patchProject({ isMature: !linkedProject.isMature })"
         >
@@ -46,9 +58,13 @@
         <button
           type="button"
           class="btn btn-circle btn-ghost btn-xs"
-          :class="linkedProject.allowReviews ? 'text-success' : 'text-base-content/35'"
+          :class="
+            linkedProject.allowReviews ? 'text-success' : 'text-base-content/35'
+          "
           :title="linkedProject.allowReviews ? 'Reviews on' : 'Reviews off'"
-          :aria-label="linkedProject.allowReviews ? 'Turn reviews off' : 'Turn reviews on'"
+          :aria-label="
+            linkedProject.allowReviews ? 'Turn reviews off' : 'Turn reviews on'
+          "
           :disabled="projectSaving"
           @click="patchProject({ allowReviews: !linkedProject.allowReviews })"
         >
@@ -129,12 +145,18 @@
 
       <div class="flex min-w-0 flex-col gap-2">
         <section class="kr-panel-flat overflow-hidden" data-project-profile>
-          <header class="flex items-center gap-2 border-b border-base-300/70 px-3 py-2">
+          <header
+            class="flex items-center gap-2 border-b border-base-300/70 px-3 py-2"
+          >
             <Icon name="kind-icon:dream" class="size-4 text-primary" />
-            <span class="text-xs font-bold uppercase tracking-wide text-base-content/60">
+            <span
+              class="text-xs font-bold uppercase tracking-wide text-base-content/60"
+            >
               Project Profile
             </span>
-            <span class="ml-auto text-[0.65rem] text-base-content/35">saves on blur</span>
+            <span class="ml-auto text-[0.65rem] text-base-content/35"
+              >saves on blur</span
+            >
           </header>
           <div class="project-profile-fields grid gap-2 p-3">
             <div class="form-control min-w-0">
@@ -152,7 +174,9 @@
             </div>
             <div class="form-control min-w-0">
               <label class="label py-0.5">
-                <span class="label-text text-xs font-semibold">Description</span>
+                <span class="label-text text-xs font-semibold"
+                  >Description</span
+                >
               </label>
               <textarea
                 class="textarea textarea-bordered min-h-16 w-full rounded-xl text-sm leading-relaxed"
@@ -236,7 +260,9 @@
           @submit.prevent="submitProjectTask"
         >
           <label class="min-w-0">
-            <span class="mb-1 block text-[0.65rem] font-bold uppercase tracking-wide text-base-content/50">
+            <span
+              class="mb-1 block text-[0.65rem] font-bold uppercase tracking-wide text-base-content/50"
+            >
               Add task / comment
             </span>
             <textarea
@@ -267,7 +293,7 @@
             </select>
             <button
               type="submit"
-              class="btn btn-primary btn-sm rounded-xl"
+              class="kr-btn-primary"
               :disabled="!projectTaskText.trim() || projectTaskSubmitting"
             >
               <span
@@ -294,7 +320,9 @@
           name="kind-icon:chevron-right"
           class="size-3.5 shrink-0 transition-transform group-open:rotate-90"
         />
-        <span class="text-xs font-bold uppercase tracking-wide text-base-content/60">
+        <span
+          class="text-xs font-bold uppercase tracking-wide text-base-content/60"
+        >
           Roadmap
         </span>
         <span class="badge badge-ghost badge-xs ml-auto">
@@ -318,11 +346,15 @@
               <p class="break-words text-sm font-semibold leading-snug">
                 {{ task.title }}
               </p>
-              <div class="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-base-content/50">
+              <div
+                class="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-base-content/50"
+              >
                 <span>{{ task.id }}</span>
                 <span v-if="task.milestone">· {{ task.milestone }}</span>
                 <span v-if="task.owner">· {{ task.owner }}</span>
-                <span v-if="task.passes > 0" class="text-warning">· pass {{ task.passes }}/3</span>
+                <span v-if="task.passes > 0" class="text-warning"
+                  >· pass {{ task.passes }}/3</span
+                >
                 <span
                   v-if="task.stakes && task.stakes !== 'reversible'"
                   class="badge badge-xs"
@@ -362,11 +394,15 @@
               class="size-3.5 shrink-0 transition-transform group-open:rotate-90"
             />
             Completed
-            <span class="badge badge-success badge-xs ml-auto">{{ doneTaskCount }}</span>
+            <span class="badge badge-success badge-xs ml-auto">{{
+              doneTaskCount
+            }}</span>
           </summary>
           <div class="space-y-2 px-3 pb-3">
             <div v-for="group in doneTasksByMilestone" :key="group.id">
-              <p class="mb-1 text-[0.65rem] font-bold uppercase tracking-wide text-base-content/40">
+              <p
+                class="mb-1 text-[0.65rem] font-bold uppercase tracking-wide text-base-content/40"
+              >
                 {{ group.title }}
               </p>
               <div class="space-y-1">
@@ -375,12 +411,19 @@
                   :key="task.id"
                   class="flex items-start gap-2 rounded-lg bg-base-100/60 px-2.5 py-2"
                 >
-                  <Icon name="kind-icon:check" class="mt-0.5 size-3.5 shrink-0 text-success/70" />
+                  <Icon
+                    name="kind-icon:check"
+                    class="mt-0.5 size-3.5 shrink-0 text-success/70"
+                  />
                   <div class="min-w-0 flex-1">
-                    <p class="break-words text-xs font-medium leading-snug text-base-content/70">
+                    <p
+                      class="break-words text-xs font-medium leading-snug text-base-content/70"
+                    >
                       {{ task.title }}
                     </p>
-                    <span class="text-[0.65rem] text-base-content/40">{{ task.id }}</span>
+                    <span class="text-[0.65rem] text-base-content/40">{{
+                      task.id
+                    }}</span>
                   </div>
                 </div>
               </div>
@@ -402,7 +445,9 @@
           name="kind-icon:chevron-right"
           class="size-3.5 shrink-0 transition-transform group-open:rotate-90"
         />
-        <span class="text-xs font-bold uppercase tracking-wide text-base-content/60">
+        <span
+          class="text-xs font-bold uppercase tracking-wide text-base-content/60"
+        >
           Milestones
         </span>
         <span class="badge badge-ghost badge-xs ml-auto">
@@ -429,7 +474,8 @@
               <span v-if="milestoneTaskCounts.get(milestone.id)?.total">
                 {{ milestoneTaskCounts.get(milestone.id)?.done }}/{{
                   milestoneTaskCounts.get(milestone.id)?.total
-                }} done
+                }}
+                done
               </span>
               <span v-else>weight {{ milestone.weight }}</span>
             </p>
@@ -457,7 +503,9 @@
           class="size-3.5 shrink-0 transition-transform group-open:rotate-90"
         />
         <Icon name="kind-icon:document" class="size-4 text-info" />
-        <span class="text-xs font-bold uppercase tracking-wide text-base-content/60">
+        <span
+          class="text-xs font-bold uppercase tracking-wide text-base-content/60"
+        >
           Project Notes
         </span>
         <span class="ml-auto text-xs text-base-content/35">Conductor</span>
@@ -511,9 +559,27 @@ const projectTaskSubmitting = ref(false)
 let saveMessageTimer: ReturnType<typeof setTimeout> | null = null
 
 const projectArtSlots = [
-  { field: 'heroPath', label: 'Hero', aspect: '16 / 9', width: 1280, height: 720 },
-  { field: 'cardPath', label: 'Card', aspect: '2 / 3', width: 512, height: 768 },
-  { field: 'imagePath', label: 'Icon', aspect: '1 / 1', width: 256, height: 256 },
+  {
+    field: 'heroPath',
+    label: 'Hero',
+    aspect: '16 / 9',
+    width: 1280,
+    height: 720,
+  },
+  {
+    field: 'cardPath',
+    label: 'Card',
+    aspect: '2 / 3',
+    width: 512,
+    height: 768,
+  },
+  {
+    field: 'imagePath',
+    label: 'Icon',
+    aspect: '1 / 1',
+    width: 256,
+    height: 256,
+  },
 ]
 
 type ProjectPatch = {
@@ -539,7 +605,9 @@ const LIFECYCLE_PRIORITIES: ProjectPriorityLevel[] = ['HIGH', 'NORMAL', 'LOW']
 
 const linkedProject = computed(() => projectStore.projectForSlug(props.slug))
 
-function projectRecordToConductor(project: ProjectWithRelations): ConductorProject {
+function projectRecordToConductor(
+  project: ProjectWithRelations,
+): ConductorProject {
   return {
     slug: project.conductorSlug || project.slug || props.slug,
     name: project.title,
@@ -554,9 +622,13 @@ function projectRecordToConductor(project: ProjectWithRelations): ConductorProje
 }
 
 const selectedProject = computed<ConductorProject | null>(() => {
-  const projected = conductorStore.projects.find((project) => project.slug === props.slug)
+  const projected = conductorStore.projects.find(
+    (project) => project.slug === props.slug,
+  )
   if (projected) return projected
-  return linkedProject.value ? projectRecordToConductor(linkedProject.value) : null
+  return linkedProject.value
+    ? projectRecordToConductor(linkedProject.value)
+    : null
 })
 
 const matchedProjectCollection = computed(() => {
@@ -566,17 +638,24 @@ const matchedProjectCollection = computed(() => {
 
 const projectCollectionSlides = computed(() => {
   if (!matchedProjectCollection.value) return []
-  const images = collectionStore.getCollectionImages?.(matchedProjectCollection.value.id) ?? []
+  const images =
+    collectionStore.getCollectionImages?.(matchedProjectCollection.value.id) ??
+    []
   return images
     .map((image, index) => ({
-      src: image.imagePath || (image as { path?: string | null }).path || image.fileName || '',
+      src:
+        image.imagePath ||
+        (image as { path?: string | null }).path ||
+        image.fileName ||
+        '',
       label: `Collection ${index + 1}`,
     }))
     .filter((slide) => Boolean(slide.src))
 })
 
 const activeTasks = computed(
-  () => selectedProject.value?.tasks.filter((task) => task.status !== 'done') ?? [],
+  () =>
+    selectedProject.value?.tasks.filter((task) => task.status !== 'done') ?? [],
 )
 
 const doneTasksByMilestone = computed(() => {
@@ -595,7 +674,8 @@ const doneTasksByMilestone = computed(() => {
   const groups: { id: string; title: string; tasks: ConductorTask[] }[] = []
   for (const milestone of project.milestones) {
     const tasks = doneByMilestone.get(milestone.id)
-    if (tasks?.length) groups.push({ id: milestone.id, title: milestone.title, tasks })
+    if (tasks?.length)
+      groups.push({ id: milestone.id, title: milestone.title, tasks })
     doneByMilestone.delete(milestone.id)
   }
   for (const [key, tasks] of doneByMilestone) {
@@ -605,7 +685,10 @@ const doneTasksByMilestone = computed(() => {
 })
 
 const doneTaskCount = computed(() =>
-  doneTasksByMilestone.value.reduce((total, group) => total + group.tasks.length, 0),
+  doneTasksByMilestone.value.reduce(
+    (total, group) => total + group.tasks.length,
+    0,
+  ),
 )
 
 const milestoneTaskCounts = computed(() => {
@@ -622,11 +705,20 @@ const milestoneTaskCounts = computed(() => {
   return counts
 })
 
-const statusOrder = ['done', 'review', 'claimed', 'ready', 'waiting', 'blocked', 'needs-human']
+const statusOrder = [
+  'done',
+  'review',
+  'claimed',
+  'ready',
+  'waiting',
+  'blocked',
+  'needs-human',
+]
 
 function taskStatusSummary(project: ConductorProject): [string, number][] {
   const counts: Record<string, number> = {}
-  for (const task of project.tasks) counts[task.status] = (counts[task.status] ?? 0) + 1
+  for (const task of project.tasks)
+    counts[task.status] = (counts[task.status] ?? 0) + 1
   return Object.entries(counts).sort(([a], [b]) => {
     const ai = statusOrder.indexOf(a)
     const bi = statusOrder.indexOf(b)
@@ -692,7 +784,8 @@ function milestoneIcon(status: string): string {
 
 function milestoneIconClass(status: string): string {
   if (status === 'done') return 'border-success/40 bg-success/10 text-success'
-  if (status === 'in-progress') return 'border-warning/40 bg-warning/10 text-warning'
+  if (status === 'in-progress')
+    return 'border-warning/40 bg-warning/10 text-warning'
   return 'border-base-300 bg-base-200 text-base-content/40'
 }
 
@@ -738,20 +831,25 @@ async function patchProject(patch: ProjectPatch) {
     await projectStore.updateProject(linkedProject.value.id, patch)
     showSaveMessage('Saved')
   } catch (error) {
-    showSaveMessage(error instanceof Error ? error.message : 'Save failed', true)
+    showSaveMessage(
+      error instanceof Error ? error.message : 'Save failed',
+      true,
+    )
   } finally {
     projectSaving.value = false
   }
 }
 
 function onStatusSelect(event: Event) {
-  const value = (event.target as HTMLSelectElement).value as ProjectLifecycleStatus
+  const value = (event.target as HTMLSelectElement)
+    .value as ProjectLifecycleStatus
   if (!linkedProject.value || value === linkedProject.value.status) return
   patchProject({ status: value })
 }
 
 function onPrioritySelect(event: Event) {
-  const value = (event.target as HTMLSelectElement).value as ProjectPriorityLevel
+  const value = (event.target as HTMLSelectElement)
+    .value as ProjectPriorityLevel
   if (!linkedProject.value || value === linkedProject.value.priority) return
   patchProject({ priority: value })
 }
@@ -761,7 +859,9 @@ async function autosave(field: keyof ProjectPatch, event: FocusEvent) {
   const element = event.target as HTMLInputElement | HTMLTextAreaElement | null
   if (!element) return
   const value = element.value.trim() || null
-  const current = (linkedProject.value[field as keyof typeof linkedProject.value] ?? null) as string | null
+  const current = (linkedProject.value[
+    field as keyof typeof linkedProject.value
+  ] ?? null) as string | null
   if (value === current) return
   await patchProject({ [field]: value })
 }
@@ -770,11 +870,15 @@ async function refreshProject() {
   refreshing.value = true
   try {
     await Promise.all([
-      projectStore.fetchProjects({ includeInactive: true, includeMature: true }, true),
+      projectStore.fetchProjects(
+        { includeInactive: true, includeMature: true },
+        true,
+      ),
       conductorStore.fetchProjects(true),
       collectionStore.fetchCollections(),
     ])
-    if (linkedProject.value?.id) await todoStore.fetchProjectTodos(linkedProject.value.id)
+    if (linkedProject.value?.id)
+      await todoStore.fetchProjectTodos(linkedProject.value.id)
   } finally {
     refreshing.value = false
   }
@@ -808,7 +912,9 @@ async function submitProjectTask() {
       .trim()
     const description =
       projectTaskCategory.value === 'AGENT'
-        ? [`Project: ${selectedProject.value.slug}`, userContext].filter(Boolean).join('\n\n')
+        ? [`Project: ${selectedProject.value.slug}`, userContext]
+            .filter(Boolean)
+            .join('\n\n')
         : userContext || null
 
     const created = await todoStore.createTodo({
@@ -878,7 +984,9 @@ onBeforeUnmount(() => {
   display: none;
 }
 
-:deep(.project-art-compact:has(.group.relative.mt-3.min-h-40) .mt-3.grid.gap-3) {
+:deep(
+  .project-art-compact:has(.group.relative.mt-3.min-h-40) .mt-3.grid.gap-3
+) {
   display: none;
 }
 

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -4,7 +4,10 @@
      undefined, which Vue drops entirely, leaving the reader's global theme
      in charge — see storybookStore reading-mode state. -->
 <template>
-  <section :data-theme="store.dataTheme" class="kr-surface gap-4 kr-panel-flat p-4">
+  <section
+    :data-theme="store.dataTheme"
+    class="kr-surface gap-4 kr-panel-flat p-4"
+  >
     <header class="flex shrink-0 flex-wrap items-start gap-3">
       <div
         class="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-primary/30 bg-primary/10 text-primary"
@@ -49,7 +52,7 @@
         <button
           v-if="store.canFinish"
           type="button"
-          class="btn btn-primary btn-sm rounded-xl"
+          class="kr-btn-primary"
           @click="store.finishStory()"
         >
           <Icon name="kind-icon:moon" class="size-4" /> Finish this tale

--- a/components/curation/coloring-book-curation.vue
+++ b/components/curation/coloring-book-curation.vue
@@ -8,8 +8,15 @@
           class="select select-bordered select-sm rounded-xl"
           @change="store.selectBook(eventValue($event))"
         >
-          <option v-for="book in store.books" :key="book.slug" :value="book.slug">
-            {{ book.title }} · {{ book.counts.acceptedColor }}/{{ book.counts.total }} color accepted
+          <option
+            v-for="book in store.books"
+            :key="book.slug"
+            :value="book.slug"
+          >
+            {{ book.title }} · {{ book.counts.acceptedColor }}/{{
+              book.counts.total
+            }}
+            color accepted
           </option>
         </select>
       </label>
@@ -24,8 +31,14 @@
         />
       </label>
 
-      <label class="flex cursor-pointer items-center gap-2 rounded-xl border border-base-300 px-3 py-2 text-sm font-bold">
-        <input v-model="hideFinal" type="checkbox" class="checkbox checkbox-sm" />
+      <label
+        class="flex cursor-pointer items-center gap-2 rounded-xl border border-base-300 px-3 py-2 text-sm font-bold"
+      >
+        <input
+          v-model="hideFinal"
+          type="checkbox"
+          class="checkbox checkbox-sm"
+        />
         Hide final pairs
       </label>
 
@@ -42,14 +55,21 @@
 
     <div v-if="notice" class="alert border border-info/25 bg-info/10">
       <span>{{ notice }}</span>
-      <button class="kr-btn-ghost-xs-plain" type="button" @click="notice = ''">Dismiss</button>
+      <button class="kr-btn-ghost-xs-plain" type="button" @click="notice = ''">
+        Dismiss
+      </button>
     </div>
     <div v-if="error" class="alert border border-error/25 bg-error/10">
       <span>{{ error }}</span>
-      <button class="kr-btn-ghost-xs-plain" type="button" @click="error = ''">Dismiss</button>
+      <button class="kr-btn-ghost-xs-plain" type="button" @click="error = ''">
+        Dismiss
+      </button>
     </div>
 
-    <div v-if="store.loading && !store.books.length" class="grid min-h-64 place-items-center kr-panel">
+    <div
+      v-if="store.loading && !store.books.length"
+      class="grid min-h-64 place-items-center kr-panel"
+    >
       <span class="loading loading-spinner loading-lg text-primary" />
     </div>
 
@@ -63,7 +83,9 @@
     <div
       v-else
       class="grid gap-4"
-      style="grid-template-columns: repeat(auto-fill, minmax(min(540px, 100%), 1fr))"
+      style="
+        grid-template-columns: repeat(auto-fill, minmax(min(540px, 100%), 1fr));
+      "
     >
       <article
         v-for="proposal in visibleProposals"
@@ -81,14 +103,19 @@
                   class="size-full object-contain"
                   loading="lazy"
                 />
-                <div v-else class="grid size-full place-items-center text-base-content/30">
+                <div
+                  v-else
+                  class="grid size-full place-items-center text-base-content/30"
+                >
                   <div class="text-center">
                     <Icon name="kind-icon:image" class="mx-auto size-10" />
                     <p class="mt-2 text-xs font-bold">No color candidate</p>
                   </div>
                 </div>
               </div>
-              <figcaption class="absolute bottom-3 left-3 badge border-0 bg-base-100/90 font-black shadow-sm backdrop-blur">
+              <figcaption
+                class="absolute bottom-3 left-3 badge border-0 bg-base-100/90 font-black shadow-sm backdrop-blur"
+              >
                 Color
               </figcaption>
             </figure>
@@ -102,24 +129,36 @@
                   class="size-full object-contain grayscale"
                   loading="lazy"
                 />
-                <div v-else class="grid size-full place-items-center text-base-content/30">
+                <div
+                  v-else
+                  class="grid size-full place-items-center text-base-content/30"
+                >
                   <div class="text-center">
                     <Icon name="kind-icon:image" class="mx-auto size-10" />
                     <p class="mt-2 text-xs font-bold">No B&amp;W candidate</p>
                   </div>
                 </div>
               </div>
-              <figcaption class="absolute bottom-3 left-3 badge border-0 bg-base-100/90 font-black shadow-sm backdrop-blur">
+              <figcaption
+                class="absolute bottom-3 left-3 badge border-0 bg-base-100/90 font-black shadow-sm backdrop-blur"
+              >
                 B&amp;W
               </figcaption>
             </figure>
           </div>
 
-          <div class="pointer-events-none absolute inset-x-0 top-0 flex items-start justify-between gap-2 p-3">
-            <span class="badge border-0 bg-base-100/90 font-black shadow-sm backdrop-blur">
+          <div
+            class="pointer-events-none absolute inset-x-0 top-0 flex items-start justify-between gap-2 p-3"
+          >
+            <span
+              class="badge border-0 bg-base-100/90 font-black shadow-sm backdrop-blur"
+            >
               {{ proposal.id }}
             </span>
-            <span class="badge border-0 shadow-sm" :class="stageBadge(proposal)">
+            <span
+              class="badge border-0 shadow-sm"
+              :class="stageBadge(proposal)"
+            >
               {{ stageLabel(proposal) }}
             </span>
           </div>
@@ -127,16 +166,26 @@
 
         <div class="space-y-4 p-4">
           <div>
-            <p class="text-[11px] font-black uppercase tracking-wider text-primary">
+            <p
+              class="text-[11px] font-black uppercase tracking-wider text-primary"
+            >
               Slot {{ proposal.slot }}
             </p>
-            <h2 class="mt-1 text-xl font-black leading-tight">{{ proposal.title }}</h2>
-            <p v-if="proposal.notes.length" class="mt-2 line-clamp-2 text-xs leading-5 text-base-content/55">
+            <h2 class="mt-1 text-xl font-black leading-tight">
+              {{ proposal.title }}
+            </h2>
+            <p
+              v-if="proposal.notes.length"
+              class="mt-2 line-clamp-2 text-xs leading-5 text-base-content/55"
+            >
               {{ proposal.notes.join(' · ') }}
             </p>
           </div>
 
-          <div v-if="proposal.inspirations.length" class="flex gap-2 overflow-x-auto pb-1">
+          <div
+            v-if="proposal.inspirations.length"
+            class="flex gap-2 overflow-x-auto pb-1"
+          >
             <figure
               v-for="asset in proposal.inspirations"
               :key="`${proposal.id}:${asset.path}`"
@@ -169,7 +218,7 @@
 
           <div v-if="userStore.isAdmin" class="flex flex-wrap gap-2">
             <button
-              class="btn btn-primary btn-sm rounded-xl"
+              class="kr-btn-primary"
               type="button"
               :disabled="store.savingPrompt || !promptChanged(proposal)"
               @click="savePrompt(proposal.id)"
@@ -198,7 +247,9 @@
               class="btn btn-success btn-outline btn-sm rounded-xl"
               type="button"
               :disabled="store.requestingAction"
-              @click="acceptColor(proposal.id, colorCandidatePath(proposal) || '')"
+              @click="
+                acceptColor(proposal.id, colorCandidatePath(proposal) || '')
+              "
             >
               Accept color
             </button>
@@ -212,7 +263,11 @@
               Accept B&amp;W
             </button>
             <button
-              v-if="proposal.accepted.color && proposal.accepted.bw && !(proposal.final.color && proposal.final.bw)"
+              v-if="
+                proposal.accepted.color &&
+                proposal.accepted.bw &&
+                !(proposal.final.color && proposal.final.bw)
+              "
               class="btn btn-success btn-sm rounded-xl"
               type="button"
               :disabled="store.requestingAction"
@@ -222,7 +277,10 @@
             </button>
           </div>
 
-          <div v-else class="flex items-center gap-2 text-xs text-base-content/45">
+          <div
+            v-else
+            class="flex items-center gap-2 text-xs text-base-content/45"
+          >
             <Icon name="kind-icon:lock" class="size-4" />
             Production edits are admin-only.
           </div>
@@ -252,7 +310,8 @@ const drafts = reactive<Record<string, string>>({})
 const visibleProposals = computed<ColoringBookProposal[]>(() => {
   const query = search.value.trim().toLowerCase()
   return (store.selectedBook?.proposals || []).filter((proposal) => {
-    if (hideFinal.value && proposal.final.color && proposal.final.bw) return false
+    if (hideFinal.value && proposal.final.color && proposal.final.bw)
+      return false
     if (!query) return true
     return [proposal.title, proposal.id, proposal.prompt, ...proposal.notes]
       .join(' ')
@@ -285,8 +344,12 @@ function eventValue(event: Event): string {
   return (event.target as HTMLSelectElement).value
 }
 
-function productionState(proposalId: string): ColoringBookProductionState | null {
-  return store.productionStates[`${store.selectedBookSlug}:${proposalId}`] ?? null
+function productionState(
+  proposalId: string,
+): ColoringBookProductionState | null {
+  return (
+    store.productionStates[`${store.selectedBookSlug}:${proposalId}`] ?? null
+  )
 }
 
 function bwDisplayUrl(proposal: ColoringBookProposal): string | null {
@@ -309,14 +372,21 @@ function promptChanged(proposal: ColoringBookProposal): boolean {
 
 function stageLabel(proposal: ColoringBookProposal): string {
   if (proposal.final.color && proposal.final.bw) return 'Final pair'
-  if (proposal.accepted.color && proposal.accepted.bw) return 'Ready to finalize'
+  if (proposal.accepted.color && proposal.accepted.bw)
+    return 'Ready to finalize'
   if (bwCandidatePath(proposal)) return 'Accept B&W'
   if (proposal.accepted.color) return 'Build B&W'
   if (colorCandidatePath(proposal)) return 'Accept color'
-  if (proposal.queue.status === 'pending' || proposal.queue.status === 'running') {
+  if (
+    proposal.queue.status === 'pending' ||
+    proposal.queue.status === 'running'
+  ) {
     return 'Rendering color'
   }
-  if (proposal.queue.status === 'needs_review' || proposal.queue.semanticGateError) {
+  if (
+    proposal.queue.status === 'needs_review' ||
+    proposal.queue.semanticGateError
+  ) {
     return 'Needs review'
   }
   return 'Needs color'
@@ -325,10 +395,16 @@ function stageLabel(proposal: ColoringBookProposal): string {
 function stageBadge(proposal: ColoringBookProposal): string {
   if (proposal.final.color && proposal.final.bw) return 'badge-success'
   if (proposal.accepted.color && proposal.accepted.bw) return 'badge-success'
-  if (proposal.queue.status === 'needs_review' || proposal.queue.semanticGateError) {
+  if (
+    proposal.queue.status === 'needs_review' ||
+    proposal.queue.semanticGateError
+  ) {
     return 'badge-warning'
   }
-  if (proposal.queue.status === 'pending' || proposal.queue.status === 'running') {
+  if (
+    proposal.queue.status === 'pending' ||
+    proposal.queue.status === 'running'
+  ) {
     return 'badge-info'
   }
   return 'badge-neutral'
@@ -349,11 +425,17 @@ async function savePrompt(proposalId: string): Promise<void> {
   }
 }
 
-async function render(proposalId: string, variant: 'color' | 'bw'): Promise<void> {
+async function render(
+  proposalId: string,
+  variant: 'color' | 'bw',
+): Promise<void> {
   select(proposalId)
   const ok =
     variant === 'color'
-      ? await store.requestColorRender(true, 'Requested from Coloring Book curation')
+      ? await store.requestColorRender(
+          true,
+          'Requested from Coloring Book curation',
+        )
       : await store.requestBw(true, 'Requested from Coloring Book curation')
   if (ok) {
     notice.value = store.message || `${variant} render requested.`
@@ -363,9 +445,14 @@ async function render(proposalId: string, variant: 'color' | 'bw'): Promise<void
   }
 }
 
-async function acceptColor(proposalId: string, sourcePath: string): Promise<void> {
+async function acceptColor(
+  proposalId: string,
+  sourcePath: string,
+): Promise<void> {
   select(proposalId)
-  if (await store.acceptColor('Accepted from Coloring Book curation', sourcePath)) {
+  if (
+    await store.acceptColor('Accepted from Coloring Book curation', sourcePath)
+  ) {
     notice.value = store.message || 'Color candidate accepted.'
     syncDrafts()
   } else if (store.error) {
@@ -375,7 +462,9 @@ async function acceptColor(proposalId: string, sourcePath: string): Promise<void
 
 async function acceptBw(proposalId: string, sourcePath: string): Promise<void> {
   select(proposalId)
-  if (await store.acceptBw('Accepted from Coloring Book curation', sourcePath)) {
+  if (
+    await store.acceptBw('Accepted from Coloring Book curation', sourcePath)
+  ) {
     notice.value = store.message || 'B&W candidate accepted.'
     syncDrafts()
   } else if (store.error) {

--- a/components/curation/cthulhuquarium-curation.vue
+++ b/components/curation/cthulhuquarium-curation.vue
@@ -2,7 +2,9 @@
   <section class="space-y-4">
     <div class="kr-panel flex flex-wrap items-end gap-3 p-4">
       <label class="form-control min-w-56 flex-1 gap-1">
-        <span class="text-xs font-bold text-base-content/55">Find a monster</span>
+        <span class="text-xs font-bold text-base-content/55"
+          >Find a monster</span
+        >
         <input
           v-model="search"
           type="search"
@@ -11,17 +13,30 @@
         />
       </label>
 
-      <label class="flex cursor-pointer items-center gap-2 rounded-xl border border-base-300 px-3 py-2 text-sm font-bold">
-        <input v-model="hideSettled" type="checkbox" class="checkbox checkbox-sm" />
+      <label
+        class="flex cursor-pointer items-center gap-2 rounded-xl border border-base-300 px-3 py-2 text-sm font-bold"
+      >
+        <input
+          v-model="hideSettled"
+          type="checkbox"
+          class="checkbox checkbox-sm"
+        />
         Hide settled designs
       </label>
 
       <div class="ml-auto text-right text-xs text-base-content/50">
-        <p class="font-black text-base-content/80">{{ visibleRows.length }} shown</p>
+        <p class="font-black text-base-content/80">
+          {{ visibleRows.length }} shown
+        </p>
         <p>{{ settledCount }} / {{ data?.fish.length || 0 }} designs settled</p>
       </div>
 
-      <button class="btn btn-sm rounded-xl" type="button" :disabled="loading" @click="load">
+      <button
+        class="btn btn-sm rounded-xl"
+        type="button"
+        :disabled="loading"
+        @click="load"
+      >
         <span v-if="loading" class="loading loading-spinner loading-xs" />
         Refresh
       </button>
@@ -29,11 +44,15 @@
 
     <div v-if="notice" class="alert border border-info/25 bg-info/10">
       <span>{{ notice }}</span>
-      <button class="kr-btn-ghost-xs-plain" type="button" @click="notice = ''">Dismiss</button>
+      <button class="kr-btn-ghost-xs-plain" type="button" @click="notice = ''">
+        Dismiss
+      </button>
     </div>
     <div v-if="error" class="alert border border-error/25 bg-error/10">
       <span class="min-w-0 flex-1 break-words">{{ error }}</span>
-      <button class="kr-btn-ghost-xs-plain" type="button" @click="error = ''">Dismiss</button>
+      <button class="kr-btn-ghost-xs-plain" type="button" @click="error = ''">
+        Dismiss
+      </button>
     </div>
 
     <div v-if="loading" class="grid min-h-64 place-items-center kr-panel">
@@ -58,46 +77,91 @@
             <div class="min-w-0">
               <div class="flex flex-wrap items-center gap-2">
                 <h2 class="text-xl font-black">{{ fish.name }}</h2>
-                <span class="badge badge-sm badge-outline">{{ fish.rarity }}</span>
+                <span class="badge badge-sm badge-outline">{{
+                  fish.rarity
+                }}</span>
               </div>
-              <p class="mt-1 text-xs italic text-base-content/50">{{ fish.species }}</p>
+              <p class="mt-1 text-xs italic text-base-content/50">
+                {{ fish.species }}
+              </p>
             </div>
-            <a :href="fish.sourceUrl" target="_blank" rel="noreferrer" class="kr-btn-ghost-xs-plain">
+            <a
+              :href="fish.sourceUrl"
+              target="_blank"
+              rel="noreferrer"
+              class="kr-btn-ghost-xs-plain"
+            >
               YAML ↗
             </a>
           </div>
 
-          <div class="mt-3 rounded-xl border border-base-content/10 bg-base-100/70 p-3">
-            <p class="text-[11px] font-black uppercase tracking-wider text-primary">Ichthyonomicon</p>
-            <p class="mt-1 text-sm leading-6">{{ fish.fieldNote || 'Entry not written yet.' }}</p>
+          <div
+            class="mt-3 rounded-xl border border-base-content/10 bg-base-100/70 p-3"
+          >
+            <p
+              class="text-[11px] font-black uppercase tracking-wider text-primary"
+            >
+              Ichthyonomicon
+            </p>
+            <p class="mt-1 text-sm leading-6">
+              {{ fish.fieldNote || 'Entry not written yet.' }}
+            </p>
           </div>
         </div>
 
         <div class="space-y-4 p-4">
           <div class="grid grid-cols-3 gap-2">
-            <ArtSlot label="Inspiration" :src="fish.curation.inspirations[0]?.url || ''" empty="No reference yet" />
+            <ArtSlot
+              label="Inspiration"
+              :src="fish.curation.inspirations[0]?.url || ''"
+              empty="No reference yet"
+            />
             <ArtSlot
               label="Chosen design"
-              :src="fish.curation.selectedDesignImageId ? artImageUrl(fish.curation.selectedDesignImageId) : ''"
+              :src="
+                fish.curation.selectedDesignImageId
+                  ? artImageUrl(fish.curation.selectedDesignImageId)
+                  : ''
+              "
               empty="Still deciding"
             />
             <ArtSlot
               label="Sprite"
-              :src="fish.curation.spriteImageIds[0] ? artImageUrl(fish.curation.spriteImageIds[0]) : ''"
+              :src="
+                fish.curation.spriteImageIds[0]
+                  ? artImageUrl(fish.curation.spriteImageIds[0])
+                  : ''
+              "
               empty="No sprite yet"
               contain
             />
           </div>
 
-          <p v-if="fish.curation.inspirations.length > 1 || fish.curation.spriteImageIds.length > 1" class="text-[11px] text-base-content/45">
-            {{ fish.curation.inspirations.length }} inspiration{{ fish.curation.inspirations.length === 1 ? '' : 's' }} ·
-            {{ fish.curation.spriteImageIds.length }} sprite{{ fish.curation.spriteImageIds.length === 1 ? '' : 's' }}
+          <p
+            v-if="
+              fish.curation.inspirations.length > 1 ||
+              fish.curation.spriteImageIds.length > 1
+            "
+            class="text-[11px] text-base-content/45"
+          >
+            {{ fish.curation.inspirations.length }} inspiration{{
+              fish.curation.inspirations.length === 1 ? '' : 's'
+            }}
+            · {{ fish.curation.spriteImageIds.length }} sprite{{
+              fish.curation.spriteImageIds.length === 1 ? '' : 's'
+            }}
           </p>
 
           <label class="form-control gap-1">
-            <span class="flex items-center justify-between gap-2 text-xs font-black">
+            <span
+              class="flex items-center justify-between gap-2 text-xs font-black"
+            >
               Art prompt
-              <span v-if="fish.curation.promptOverride" class="badge badge-xs badge-warning">draft override</span>
+              <span
+                v-if="fish.curation.promptOverride"
+                class="badge badge-xs badge-warning"
+                >draft override</span
+              >
             </span>
             <textarea
               v-model="draft.prompt"
@@ -105,7 +169,8 @@
               :placeholder="fish.artPrompt"
             />
             <span class="text-[11px] text-base-content/45">
-              The curation draft is production state; the merged YAML bible remains the portable Monster canon until the seed bridge lands.
+              The curation draft is production state; the merged YAML bible
+              remains the portable Monster canon until the seed bridge lands.
             </span>
           </label>
 
@@ -126,15 +191,24 @@
             </button>
           </div>
 
-          <details v-if="fish.curation.inspirations.length" class="rounded-xl border border-base-300 bg-base-100 p-3">
-            <summary class="cursor-pointer text-xs font-black">All inspiration art</summary>
+          <details
+            v-if="fish.curation.inspirations.length"
+            class="rounded-xl border border-base-300 bg-base-100 p-3"
+          >
+            <summary class="cursor-pointer text-xs font-black">
+              All inspiration art
+            </summary>
             <div class="mt-3 flex gap-2 overflow-x-auto pb-1">
               <div
                 v-for="inspiration in fish.curation.inspirations"
                 :key="inspiration.id"
                 class="relative w-20 shrink-0"
               >
-                <img :src="inspiration.url" :alt="inspiration.label" class="aspect-square w-full rounded-lg object-cover" />
+                <img
+                  :src="inspiration.url"
+                  :alt="inspiration.label"
+                  class="aspect-square w-full rounded-lg object-cover"
+                />
                 <button
                   type="button"
                   class="btn btn-circle btn-error btn-xs absolute right-1 top-1"
@@ -151,19 +225,31 @@
             <div class="flex flex-wrap gap-3">
               <label class="form-control min-w-52 flex-1 gap-1">
                 <span class="text-xs font-black">Render preset</span>
-                <select v-model="draft.presetId" class="select select-bordered select-sm rounded-xl">
-                  <option v-for="preset in presets" :key="preset.id" :value="preset.id">
+                <select
+                  v-model="draft.presetId"
+                  class="select select-bordered select-sm rounded-xl"
+                >
+                  <option
+                    v-for="preset in presets"
+                    :key="preset.id"
+                    :value="preset.id"
+                  >
                     {{ preset.label }}
                   </option>
                 </select>
                 <span class="text-[11px] leading-5 text-base-content/45">
-                  FLUX schnell remains the proven Cthulhuquarium default; Krea2 is restored and FLUX.2's model configuration is repaired, so every house preset stays selectable.
+                  FLUX schnell remains the proven Cthulhuquarium default; Krea2
+                  is restored and FLUX.2's model configuration is repaired, so
+                  every house preset stays selectable.
                 </span>
               </label>
 
               <label class="form-control min-w-52 flex-1 gap-1">
                 <span class="text-xs font-black">Starting point</span>
-                <select v-model="draft.sourceMode" class="select select-bordered select-sm rounded-xl">
+                <select
+                  v-model="draft.sourceMode"
+                  class="select select-bordered select-sm rounded-xl"
+                >
                   <option value="fresh">Fresh composition</option>
                   <option value="existing">Existing candidate art</option>
                 </select>
@@ -171,44 +257,85 @@
             </div>
 
             <label
-              v-if="selectedPreset(fish.slug).engine === 'comfy' || draft.sourceMode === 'existing'"
+              v-if="
+                selectedPreset(fish.slug).engine === 'comfy' ||
+                draft.sourceMode === 'existing'
+              "
               class="form-control mt-3 gap-1"
             >
               <span class="text-xs font-black">SDXL checkpoint</span>
-              <select v-model="draft.checkpoint" class="select select-bordered select-sm rounded-xl">
+              <select
+                v-model="draft.checkpoint"
+                class="select select-bordered select-sm rounded-xl"
+              >
                 <option value="">Choose checkpoint</option>
-                <option v-for="checkpoint in checkpoints" :key="String(checkpoint.id || checkpoint.name)" :value="checkpoint.name || ''">
+                <option
+                  v-for="checkpoint in checkpoints"
+                  :key="String(checkpoint.id || checkpoint.name)"
+                  :value="checkpoint.name || ''"
+                >
                   {{ checkpoint.customLabel || checkpoint.name }}
                 </option>
               </select>
             </label>
 
-            <label v-if="draft.sourceMode === 'existing'" class="form-control mt-3 gap-1">
+            <label
+              v-if="draft.sourceMode === 'existing'"
+              class="form-control mt-3 gap-1"
+            >
               <span class="text-xs font-black">Source ArtImage</span>
-              <select v-model.number="draft.sourceImageId" class="select select-bordered select-sm rounded-xl">
+              <select
+                v-model.number="draft.sourceImageId"
+                class="select select-bordered select-sm rounded-xl"
+              >
                 <option :value="0">Choose candidate</option>
-                <option v-if="fish.curation.selectedDesignImageId" :value="fish.curation.selectedDesignImageId">
+                <option
+                  v-if="fish.curation.selectedDesignImageId"
+                  :value="fish.curation.selectedDesignImageId"
+                >
                   #{{ fish.curation.selectedDesignImageId }} · chosen design
                 </option>
-                <option v-for="id in fish.curation.candidateImageIds" :key="id" :value="id">#{{ id }}</option>
+                <option
+                  v-for="id in fish.curation.candidateImageIds"
+                  :key="id"
+                  :value="id"
+                >
+                  #{{ id }}
+                </option>
               </select>
               <span class="text-[11px] leading-5 text-base-content/45">
-                Existing-art revisions run through the normal SDXL img2img queue with this candidate as the conditioning image.
+                Existing-art revisions run through the normal SDXL img2img queue
+                with this candidate as the conditioning image.
               </span>
             </label>
 
             <div class="mt-3 flex flex-wrap items-center gap-2">
               <button
                 type="button"
-                class="btn btn-primary btn-sm rounded-xl"
+                class="kr-btn-primary"
                 :disabled="isGenerating(fish.slug) || !canGenerate(fish)"
                 @click="generate(fish)"
               >
-                <span v-if="isGenerating(fish.slug)" class="loading loading-spinner loading-xs" />
-                {{ isGenerating(fish.slug) ? generationLabel(fish.slug) : 'Generate idea' }}
+                <span
+                  v-if="isGenerating(fish.slug)"
+                  class="loading loading-spinner loading-xs"
+                />
+                {{
+                  isGenerating(fish.slug)
+                    ? generationLabel(fish.slug)
+                    : 'Generate idea'
+                }}
               </button>
-              <button type="button" class="kr-btn-ghost" :disabled="isSaving(fish.slug)" @click="save(fish)">
-                <span v-if="isSaving(fish.slug)" class="loading loading-spinner loading-xs" />
+              <button
+                type="button"
+                class="kr-btn-ghost"
+                :disabled="isSaving(fish.slug)"
+                @click="save(fish)"
+              >
+                <span
+                  v-if="isSaving(fish.slug)"
+                  class="loading loading-spinner loading-xs"
+                />
                 Save curation
               </button>
               <span v-if="draft.jobId" class="text-xs text-base-content/45">
@@ -218,20 +345,32 @@
           </div>
 
           <div v-if="fish.curation.candidateImageIds.length" class="space-y-2">
-            <p class="text-xs font-black uppercase tracking-wider text-base-content/45">Candidates</p>
+            <p
+              class="text-xs font-black uppercase tracking-wider text-base-content/45"
+            >
+              Candidates
+            </p>
             <div class="flex flex-wrap gap-2">
               <div
                 v-for="id in fish.curation.candidateImageIds"
                 :key="id"
                 class="w-24 shrink-0 rounded-xl border border-base-300 bg-base-100 p-1.5"
               >
-                <img :src="artImageUrl(id)" :alt="`${fish.name} candidate ${id}`" class="aspect-square w-full rounded-lg object-cover" />
+                <img
+                  :src="artImageUrl(id)"
+                  :alt="`${fish.name} candidate ${id}`"
+                  class="aspect-square w-full rounded-lg object-cover"
+                />
                 <p class="mt-1 text-center text-[10px] font-bold">#{{ id }}</p>
                 <div class="mt-1 grid grid-cols-2 gap-1">
                   <button
                     type="button"
                     class="btn btn-xs h-auto min-h-7 px-1"
-                    :class="fish.curation.selectedDesignImageId === id ? 'btn-success' : 'btn-ghost'"
+                    :class="
+                      fish.curation.selectedDesignImageId === id
+                        ? 'btn-success'
+                        : 'btn-ghost'
+                    "
                     @click="chooseDesign(fish, id)"
                   >
                     Design
@@ -239,7 +378,11 @@
                   <button
                     type="button"
                     class="btn btn-xs h-auto min-h-7 px-1"
-                    :class="fish.curation.spriteImageIds.includes(id) ? 'btn-secondary' : 'btn-ghost'"
+                    :class="
+                      fish.curation.spriteImageIds.includes(id)
+                        ? 'btn-secondary'
+                        : 'btn-ghost'
+                    "
                     @click="toggleSprite(fish, id)"
                   >
                     Sprite
@@ -301,9 +444,14 @@ type MonsterRow = {
 }
 
 const drafts = reactive<Record<string, MonsterDraft>>({})
-const checkpoints = computed<Partial<Resource>[]>(() => checkpointStore.visibleCheckpoints)
+const checkpoints = computed<Partial<Resource>[]>(
+  () => checkpointStore.visibleCheckpoints,
+)
 
-function makeDraft(fish: CthulhuquariumCurationMonster, previous?: MonsterDraft): MonsterDraft {
+function makeDraft(
+  fish: CthulhuquariumCurationMonster,
+  previous?: MonsterDraft,
+): MonsterDraft {
   return {
     prompt: fish.curation.promptOverride || fish.artPrompt,
     inspirationUrl: previous?.inspirationUrl || '',
@@ -314,7 +462,9 @@ function makeDraft(fish: CthulhuquariumCurationMonster, previous?: MonsterDraft)
       fish.curation.selectedDesignImageId ||
       fish.curation.candidateImageIds[0] ||
       0,
-    checkpoint: previous?.checkpoint || String(checkpointStore.selectedCheckpoint?.name || ''),
+    checkpoint:
+      previous?.checkpoint ||
+      String(checkpointStore.selectedCheckpoint?.name || ''),
     jobId: previous?.jobId || null,
     jobStatus: previous?.jobStatus || '',
   }
@@ -334,7 +484,13 @@ const visibleRows = computed<MonsterRow[]>(() => {
     .filter((fish) => {
       if (hideSettled.value && fish.curation.selectedDesignImageId) return false
       if (!query) return true
-      return [fish.name, fish.slug, fish.species, fish.fieldNote, fish.artPrompt]
+      return [
+        fish.name,
+        fish.slug,
+        fish.species,
+        fish.fieldNote,
+        fish.artPrompt,
+      ]
         .join(' ')
         .toLowerCase()
         .includes(query)
@@ -343,7 +499,9 @@ const visibleRows = computed<MonsterRow[]>(() => {
 })
 
 const settledCount = computed(
-  () => data.value?.fish.filter((fish) => fish.curation.selectedDesignImageId).length || 0,
+  () =>
+    data.value?.fish.filter((fish) => fish.curation.selectedDesignImageId)
+      .length || 0,
 )
 
 const ArtSlot = defineComponent({
@@ -356,16 +514,36 @@ const ArtSlot = defineComponent({
   setup(props) {
     return () =>
       h('div', { class: 'space-y-1' }, [
-        h('p', { class: 'text-[10px] font-black uppercase tracking-wider text-base-content/45' }, props.label),
-        h('div', { class: 'aspect-square overflow-hidden rounded-xl bg-base-200' }, [
-          props.src
-            ? h('img', {
-                src: props.src,
-                alt: props.label,
-                class: props.contain ? 'size-full object-contain p-1' : 'size-full object-cover',
-              })
-            : h('div', { class: 'grid size-full place-items-center p-2 text-center text-xs text-base-content/35' }, props.empty),
-        ]),
+        h(
+          'p',
+          {
+            class:
+              'text-[10px] font-black uppercase tracking-wider text-base-content/45',
+          },
+          props.label,
+        ),
+        h(
+          'div',
+          { class: 'aspect-square overflow-hidden rounded-xl bg-base-200' },
+          [
+            props.src
+              ? h('img', {
+                  src: props.src,
+                  alt: props.label,
+                  class: props.contain
+                    ? 'size-full object-contain p-1'
+                    : 'size-full object-cover',
+                })
+              : h(
+                  'div',
+                  {
+                    class:
+                      'grid size-full place-items-center p-2 text-center text-xs text-base-content/35',
+                  },
+                  props.empty,
+                ),
+          ],
+        ),
       ])
   },
 })
@@ -383,14 +561,17 @@ async function load() {
       '/api/admin/curation-studio/cthulhuquarium',
     )
     if (!response.success || !response.data) {
-      throw new Error(response.message || 'Failed to load Cthulhuquarium curation data.')
+      throw new Error(
+        response.message || 'Failed to load Cthulhuquarium curation data.',
+      )
     }
     data.value = response.data
     for (const fish of response.data.fish) {
       drafts[fish.slug] = makeDraft(fish, drafts[fish.slug])
     }
   } catch (cause) {
-    error.value = cause instanceof Error ? cause.message : 'Failed to load Cthulhuquarium.'
+    error.value =
+      cause instanceof Error ? cause.message : 'Failed to load Cthulhuquarium.'
   } finally {
     loading.value = false
   }
@@ -421,8 +602,11 @@ function selectedPreset(slug: string): ArtGeneratorPreset {
 function canGenerate(fish: CthulhuquariumCurationMonster): boolean {
   const draft = draftFor(fish)
   if (!draft.prompt.trim()) return false
-  if (draft.sourceMode === 'existing') return Boolean(draft.sourceImageId && draft.checkpoint)
-  return selectedPreset(fish.slug).engine !== 'comfy' || Boolean(draft.checkpoint)
+  if (draft.sourceMode === 'existing')
+    return Boolean(draft.sourceImageId && draft.checkpoint)
+  return (
+    selectedPreset(fish.slug).engine !== 'comfy' || Boolean(draft.checkpoint)
+  )
 }
 
 function replaceCuration(slug: string, entry: CthulhuquariumCurationEntry) {
@@ -430,7 +614,10 @@ function replaceCuration(slug: string, entry: CthulhuquariumCurationEntry) {
   if (fish) fish.curation = entry
 }
 
-async function persist(fish: CthulhuquariumCurationMonster, patch: Partial<CthulhuquariumCurationEntry>) {
+async function persist(
+  fish: CthulhuquariumCurationMonster,
+  patch: Partial<CthulhuquariumCurationEntry>,
+) {
   if (isSaving(fish.slug)) return false
   saving.value = [...saving.value, fish.slug]
   error.value = ''
@@ -449,7 +636,8 @@ async function persist(fish: CthulhuquariumCurationMonster, patch: Partial<Cthul
     replaceCuration(fish.slug, response.data)
     return true
   } catch (cause) {
-    error.value = cause instanceof Error ? cause.message : `Failed to save ${fish.name}.`
+    error.value =
+      cause instanceof Error ? cause.message : `Failed to save ${fish.name}.`
     return false
   } finally {
     saving.value = saving.value.filter((slug) => slug !== fish.slug)
@@ -481,14 +669,18 @@ async function addInspiration(fish: CthulhuquariumCurationMonster) {
   if (await persist(fish, { inspirations })) draft.inspirationUrl = ''
 }
 
-async function removeInspiration(fish: CthulhuquariumCurationMonster, id: string) {
+async function removeInspiration(
+  fish: CthulhuquariumCurationMonster,
+  id: string,
+) {
   await persist(fish, {
     inspirations: fish.curation.inspirations.filter((item) => item.id !== id),
   })
 }
 
 async function chooseDesign(fish: CthulhuquariumCurationMonster, id: number) {
-  const selectedDesignImageId = fish.curation.selectedDesignImageId === id ? null : id
+  const selectedDesignImageId =
+    fish.curation.selectedDesignImageId === id ? null : id
   if (await persist(fish, { selectedDesignImageId })) {
     draftFor(fish).sourceImageId = selectedDesignImageId || id
   }
@@ -508,7 +700,8 @@ async function sourceImageDataUrl(id: number): Promise<string> {
   return await new Promise<string>((resolve, reject) => {
     const reader = new FileReader()
     reader.onload = () => resolve(String(reader.result || ''))
-    reader.onerror = () => reject(new Error(`Could not read source ArtImage #${id}.`))
+    reader.onerror = () =>
+      reject(new Error(`Could not read source ArtImage #${id}.`))
     reader.readAsDataURL(blob)
   })
 }
@@ -560,7 +753,10 @@ async function generate(fish: CthulhuquariumCurationMonster) {
       }
       jobId = response.data.jobId
     } else {
-      const queued = await artStore.enqueueArtGeneration({ ...base, engine: preset.engine })
+      const queued = await artStore.enqueueArtGeneration({
+        ...base,
+        engine: preset.engine,
+      })
       if (!queued.success || !queued.jobId) {
         throw new Error(queued.message || 'Failed to queue render.')
       }
@@ -575,19 +771,24 @@ async function generate(fish: CthulhuquariumCurationMonster) {
       const job = await artStore.getArtJobStatus(jobId)
       if (!job) {
         pollFailures += 1
-        if (pollFailures >= 6) throw new Error(`Lost track of ArtJob #${jobId}.`)
+        if (pollFailures >= 6)
+          throw new Error(`Lost track of ArtJob #${jobId}.`)
         continue
       }
       pollFailures = 0
       draft.jobStatus = job.status
       if (job.status === 'PENDING' || job.status === 'RUNNING') continue
       if (job.status !== 'DONE' || !job.artImageId) {
-        throw new Error(job.error || `ArtJob #${jobId} ${job.status.toLowerCase()}.`)
+        throw new Error(
+          job.error || `ArtJob #${jobId} ${job.status.toLowerCase()}.`,
+        )
       }
 
       const candidateImageIds = [
         job.artImageId,
-        ...fish.curation.candidateImageIds.filter((id) => id !== job.artImageId),
+        ...fish.curation.candidateImageIds.filter(
+          (id) => id !== job.artImageId,
+        ),
       ]
       await persist(fish, {
         promptOverride: draft.prompt.trim(),
@@ -598,7 +799,10 @@ async function generate(fish: CthulhuquariumCurationMonster) {
       break
     }
   } catch (cause) {
-    error.value = cause instanceof Error ? cause.message : `Failed to generate ${fish.name}.`
+    error.value =
+      cause instanceof Error
+        ? cause.message
+        : `Failed to generate ${fish.name}.`
   } finally {
     generating.value = generating.value.filter((slug) => slug !== fish.slug)
   }

--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -5,16 +5,26 @@
         <div>
           <h1 class="text-xl font-black">Mandarin catalog</h1>
           <p class="mt-1 max-w-3xl text-xs leading-5 text-base-content/55">
-            Curate one canonical learner-facing entry while the pinned source data stays untouched. Changes are global overrides with an append-only audit trail, not parallel editions.
+            Curate one canonical learner-facing entry while the pinned source
+            data stays untouched. Changes are global overrides with an
+            append-only audit trail, not parallel editions.
           </p>
         </div>
-        <button class="btn btn-sm rounded-xl" type="button" :disabled="loading" @click="store.load()">
+        <button
+          class="btn btn-sm rounded-xl"
+          type="button"
+          :disabled="loading"
+          @click="store.load()"
+        >
           <span v-if="loading" class="loading loading-spinner loading-xs" />
           Refresh
         </button>
       </div>
 
-      <div v-if="payload" class="stats stats-horizontal max-w-full overflow-x-auto bg-base-200 shadow-sm">
+      <div
+        v-if="payload"
+        class="stats stats-horizontal max-w-full overflow-x-auto bg-base-200 shadow-sm"
+      >
         <div class="stat px-4 py-2">
           <div class="stat-title text-xs">Canonical cards</div>
           <div class="stat-value text-xl">{{ payload.stats.cards }}</div>
@@ -37,9 +47,19 @@
         </div>
       </div>
 
-      <div class="grid gap-3" style="grid-template-columns: repeat(auto-fit, minmax(min(12rem, 100%), 1fr));">
+      <div
+        class="grid gap-3"
+        style="
+          grid-template-columns: repeat(
+            auto-fit,
+            minmax(min(12rem, 100%), 1fr)
+          );
+        "
+      >
         <label class="form-control gap-1">
-          <span class="text-xs font-black text-base-content/55">Search catalog</span>
+          <span class="text-xs font-black text-base-content/55"
+            >Search catalog</span
+          >
           <input
             v-model="search"
             type="search"
@@ -50,9 +70,16 @@
 
         <label class="form-control gap-1">
           <span class="text-xs font-black text-base-content/55">Category</span>
-          <select v-model="categoryFilter" class="select select-bordered select-sm rounded-xl">
+          <select
+            v-model="categoryFilter"
+            class="select select-bordered select-sm rounded-xl"
+          >
             <option value="all">All categories</option>
-            <option v-for="category in payload?.categories || []" :key="category" :value="category">
+            <option
+              v-for="category in payload?.categories || []"
+              :key="category"
+              :value="category"
+            >
               {{ category }}
             </option>
           </select>
@@ -60,7 +87,10 @@
 
         <label class="form-control gap-1">
           <span class="text-xs font-black text-base-content/55">HSK</span>
-          <select v-model="hskFilter" class="select select-bordered select-sm rounded-xl">
+          <select
+            v-model="hskFilter"
+            class="select select-bordered select-sm rounded-xl"
+          >
             <option value="all">All levels</option>
             <option value="1">HSK 1</option>
             <option value="2">HSK 2</option>
@@ -69,7 +99,10 @@
 
         <label class="form-control gap-1">
           <span class="text-xs font-black text-base-content/55">Sort</span>
-          <select v-model="sortKey" class="select select-bordered select-sm rounded-xl">
+          <select
+            v-model="sortKey"
+            class="select select-bordered select-sm rounded-xl"
+          >
             <option value="hsk">HSK / frequency</option>
             <option value="hanzi">Hanzi</option>
             <option value="pinyin">Pinyin</option>
@@ -78,36 +111,57 @@
           </select>
         </label>
 
-        <label class="mt-auto flex cursor-pointer items-center gap-2 rounded-xl border border-base-300 px-3 py-2 text-sm font-bold">
-          <input v-model="overrideOnly" type="checkbox" class="checkbox checkbox-sm" />
+        <label
+          class="mt-auto flex cursor-pointer items-center gap-2 rounded-xl border border-base-300 px-3 py-2 text-sm font-bold"
+        >
+          <input
+            v-model="overrideOnly"
+            type="checkbox"
+            class="checkbox checkbox-sm"
+          />
           Changed only
         </label>
       </div>
     </div>
 
-    <div v-if="notice" class="alert border border-success/25 bg-success/10 text-sm">
+    <div
+      v-if="notice"
+      class="alert border border-success/25 bg-success/10 text-sm"
+    >
       <span>{{ notice }}</span>
-      <button class="kr-btn-ghost-xs-plain" type="button" @click="notice = ''">Dismiss</button>
+      <button class="kr-btn-ghost-xs-plain" type="button" @click="notice = ''">
+        Dismiss
+      </button>
     </div>
     <div v-if="error" class="alert border border-error/25 bg-error/10 text-sm">
       <span class="min-w-0 flex-1 break-words">{{ error }}</span>
-      <button class="kr-btn-ghost-xs-plain" type="button" @click="error = ''">Dismiss</button>
+      <button class="kr-btn-ghost-xs-plain" type="button" @click="error = ''">
+        Dismiss
+      </button>
     </div>
 
-    <div v-if="loading && !payload" class="grid min-h-64 place-items-center kr-panel">
+    <div
+      v-if="loading && !payload"
+      class="grid min-h-64 place-items-center kr-panel"
+    >
       <span class="loading loading-spinner loading-lg text-primary" />
     </div>
 
     <div
       v-else
       class="grid min-h-0 gap-4"
-      style="grid-template-columns: repeat(auto-fit, minmax(min(25rem, 100%), 1fr));"
+      style="
+        grid-template-columns: repeat(auto-fit, minmax(min(25rem, 100%), 1fr));
+      "
     >
       <div class="kr-panel min-w-0 overflow-hidden">
-        <div class="flex flex-wrap items-center justify-between gap-2 border-b border-base-300 bg-base-200/60 px-4 py-3">
+        <div
+          class="flex flex-wrap items-center justify-between gap-2 border-b border-base-300 bg-base-200/60 px-4 py-3"
+        >
           <p class="font-black">{{ visibleRows.length }} words shown</p>
           <p class="text-xs text-base-content/45">
-            Source identity is immutable. Select a row to edit its effective learner-facing values.
+            Source identity is immutable. Select a row to edit its effective
+            learner-facing values.
           </p>
         </div>
 
@@ -135,21 +189,34 @@
               >
                 <td>
                   <div class="flex items-center gap-2">
-                    <span class="text-2xl font-black">{{ row.effective.simplified }}</span>
-                    <span v-if="row.effective.traditional" class="text-xs text-base-content/45">
+                    <span class="text-2xl font-black">{{
+                      row.effective.simplified
+                    }}</span>
+                    <span
+                      v-if="row.effective.traditional"
+                      class="text-xs text-base-content/45"
+                    >
                       {{ row.effective.traditional }}
                     </span>
                   </div>
                 </td>
                 <td class="font-semibold">
                   {{ row.effective.pinyin }}
-                  <span v-if="fieldChanged(row, 'pinyin')" class="text-warning" title="Admin override">•</span>
+                  <span
+                    v-if="fieldChanged(row, 'pinyin')"
+                    class="text-warning"
+                    title="Admin override"
+                    >•</span
+                  >
                 </td>
                 <td class="max-w-80">
                   <span class="line-clamp-2">{{ row.effective.meaning }}</span>
                 </td>
                 <td>
-                  <span v-if="row.effective.hskLevel" class="badge badge-sm badge-outline">
+                  <span
+                    v-if="row.effective.hskLevel"
+                    class="badge badge-sm badge-outline"
+                  >
                     {{ row.effective.hskLevel }}
                   </span>
                 </td>
@@ -165,16 +232,33 @@
                   </div>
                 </td>
                 <td>
-                  <span class="badge badge-sm" :class="row.audioReady ? 'badge-success badge-outline' : 'badge-ghost'">
+                  <span
+                    class="badge badge-sm"
+                    :class="
+                      row.audioReady
+                        ? 'badge-success badge-outline'
+                        : 'badge-ghost'
+                    "
+                  >
                     {{ row.audioReady ? 'audio' : 'no audio' }}
                   </span>
                 </td>
                 <td>
-                  <span v-if="row.hasOverride" class="badge badge-warning badge-sm">overridden</span>
-                  <span v-else class="text-xs text-base-content/35">source</span>
+                  <span
+                    v-if="row.hasOverride"
+                    class="badge badge-warning badge-sm"
+                    >overridden</span
+                  >
+                  <span v-else class="text-xs text-base-content/35"
+                    >source</span
+                  >
                 </td>
                 <td>
-                  <button class="kr-btn-ghost-xs-plain" type="button" @click.stop="store.selectCard(row.cardKey)">
+                  <button
+                    class="kr-btn-ghost-xs-plain"
+                    type="button"
+                    @click.stop="store.selectCard(row.cardKey)"
+                  >
                     Edit
                   </button>
                 </td>
@@ -184,19 +268,35 @@
         </div>
       </div>
 
-      <aside v-if="selectedRow && draft" class="kr-panel min-w-0 overflow-hidden xl:sticky xl:top-4 xl:self-start">
-        <div class="flex items-start justify-between gap-3 border-b border-base-300 bg-base-200/60 p-4">
+      <aside
+        v-if="selectedRow && draft"
+        class="kr-panel min-w-0 overflow-hidden xl:sticky xl:top-4 xl:self-start"
+      >
+        <div
+          class="flex items-start justify-between gap-3 border-b border-base-300 bg-base-200/60 p-4"
+        >
           <div>
             <div class="flex flex-wrap items-center gap-2">
-              <span class="text-4xl font-black">{{ selectedRow.effective.simplified }}</span>
-              <span v-if="selectedRow.hasOverride" class="badge badge-warning">global override</span>
-              <span v-if="draftDirty" class="badge badge-info badge-outline">unsaved</span>
+              <span class="text-4xl font-black">{{
+                selectedRow.effective.simplified
+              }}</span>
+              <span v-if="selectedRow.hasOverride" class="badge badge-warning"
+                >global override</span
+              >
+              <span v-if="draftDirty" class="badge badge-info badge-outline"
+                >unsaved</span
+              >
             </div>
             <p class="mt-1 text-xs text-base-content/50">
               {{ selectedRow.cardKey }} · {{ selectedRow.source.sourceLabel }}
             </p>
           </div>
-          <button class="btn btn-circle btn-ghost btn-sm" type="button" aria-label="Close editor" @click="store.closeEditor()">
+          <button
+            class="btn btn-circle btn-ghost btn-sm"
+            type="button"
+            aria-label="Close editor"
+            @click="store.closeEditor()"
+          >
             ×
           </button>
         </div>
@@ -207,51 +307,92 @@
             class="rounded-xl border border-info/30 bg-info/10 p-3 text-xs leading-5"
             role="status"
           >
-            This draft has unsaved changes. Saving, discarding, or restoring to the source is explicit so a row switch cannot erase work silently.
+            This draft has unsaved changes. Saving, discarding, or restoring to
+            the source is explicit so a row switch cannot erase work silently.
           </div>
 
-          <div class="rounded-xl border border-base-300 bg-base-200/40 p-3 text-xs leading-5">
-            <p class="font-black uppercase tracking-wide text-base-content/55">Immutable source</p>
+          <div
+            class="rounded-xl border border-base-300 bg-base-200/40 p-3 text-xs leading-5"
+          >
+            <p class="font-black uppercase tracking-wide text-base-content/55">
+              Immutable source
+            </p>
             <p class="mt-1">
-              <strong>{{ selectedRow.source.pinyin }}</strong> · {{ selectedRow.source.meaning }}
+              <strong>{{ selectedRow.source.pinyin }}</strong> ·
+              {{ selectedRow.source.meaning }}
             </p>
             <p class="mt-1 text-base-content/50">
               {{ selectedRow.source.sourceVersion }}
             </p>
             <div class="mt-2 flex flex-wrap gap-1">
-              <span v-for="category in selectedRow.source.categories" :key="category" class="badge badge-ghost badge-xs">
+              <span
+                v-for="category in selectedRow.source.categories"
+                :key="category"
+                class="badge badge-ghost badge-xs"
+              >
                 {{ category }}
               </span>
             </div>
           </div>
 
-          <div v-if="selectedRow.overriddenFields.length" class="flex flex-wrap gap-1">
+          <div
+            v-if="selectedRow.overriddenFields.length"
+            class="flex flex-wrap gap-1"
+          >
             <span class="mr-1 text-xs font-black">Overridden:</span>
-            <span v-for="field in selectedRow.overriddenFields" :key="field" class="badge badge-warning badge-outline badge-sm">
+            <span
+              v-for="field in selectedRow.overriddenFields"
+              :key="field"
+              class="badge badge-warning badge-outline badge-sm"
+            >
               {{ field }}
             </span>
           </div>
 
           <label class="form-control gap-1">
             <span class="text-xs font-black">Traditional form</span>
-            <input v-model="draft.traditional" class="input input-bordered input-sm rounded-xl" placeholder="Leave blank if none" />
+            <input
+              v-model="draft.traditional"
+              class="input input-bordered input-sm rounded-xl"
+              placeholder="Leave blank if none"
+            />
           </label>
 
           <label class="form-control gap-1">
-            <span class="flex items-center justify-between gap-2 text-xs font-black">
+            <span
+              class="flex items-center justify-between gap-2 text-xs font-black"
+            >
               Pinyin
-              <span v-if="draft.pinyin !== selectedRow.source.pinyin" class="text-warning">changed</span>
+              <span
+                v-if="draft.pinyin !== selectedRow.source.pinyin"
+                class="text-warning"
+                >changed</span
+              >
             </span>
-            <input v-model="draft.pinyin" class="input input-bordered input-sm rounded-xl" />
-            <span class="text-[11px] text-base-content/45">Use tone marks, not tone numbers.</span>
+            <input
+              v-model="draft.pinyin"
+              class="input input-bordered input-sm rounded-xl"
+            />
+            <span class="text-[11px] text-base-content/45"
+              >Use tone marks, not tone numbers.</span
+            >
           </label>
 
           <label class="form-control gap-1">
-            <span class="flex items-center justify-between gap-2 text-xs font-black">
+            <span
+              class="flex items-center justify-between gap-2 text-xs font-black"
+            >
               Primary meaning
-              <span v-if="draft.meaning !== selectedRow.source.meaning" class="text-warning">changed</span>
+              <span
+                v-if="draft.meaning !== selectedRow.source.meaning"
+                class="text-warning"
+                >changed</span
+              >
             </span>
-            <input v-model="draft.meaning" class="input input-bordered input-sm rounded-xl" />
+            <input
+              v-model="draft.meaning"
+              class="input input-bordered input-sm rounded-xl"
+            />
           </label>
 
           <label class="form-control gap-1">
@@ -261,7 +402,10 @@
               class="textarea textarea-bordered min-h-28 rounded-xl text-sm leading-5"
               placeholder="One sense per line"
             />
-            <span class="text-[11px] text-base-content/45">One sense per line. The primary meaning is always kept first.</span>
+            <span class="text-[11px] text-base-content/45"
+              >One sense per line. The primary meaning is always kept
+              first.</span
+            >
           </label>
 
           <label class="form-control gap-1">
@@ -272,7 +416,8 @@
               placeholder="animals, food-drink, casino"
             />
             <span class="text-[11px] leading-5 text-base-content/45">
-              Comma-separated. Beginner and HSK tags are source-controlled and cannot be removed here.
+              Comma-separated. Beginner and HSK tags are source-controlled and
+              cannot be removed here.
             </span>
           </label>
 
@@ -292,11 +437,18 @@
               class="textarea textarea-bordered min-h-16 rounded-xl text-sm leading-5"
               placeholder="Why are we changing this entry?"
             />
-            <span class="text-[11px] text-base-content/45">Stored with the audit record. Useful, but not required.</span>
+            <span class="text-[11px] text-base-content/45"
+              >Stored with the audit record. Useful, but not required.</span
+            >
           </label>
 
           <div class="flex flex-wrap gap-2">
-            <button class="btn btn-primary btn-sm rounded-xl" type="button" :disabled="!canSave" @click="store.saveSelected()">
+            <button
+              class="kr-btn-primary"
+              type="button"
+              :disabled="!canSave"
+              @click="store.saveSelected()"
+            >
               <span v-if="saving" class="loading loading-spinner loading-xs" />
               Save changes
             </button>
@@ -309,22 +461,40 @@
             >
               Discard draft
             </button>
-            <button class="btn btn-outline btn-sm rounded-xl" type="button" :disabled="saving" @click="store.resetDraftToSource()">
+            <button
+              class="btn btn-outline btn-sm rounded-xl"
+              type="button"
+              :disabled="saving"
+              @click="store.resetDraftToSource()"
+            >
               Restore source values
             </button>
           </div>
 
-          <details v-if="selectedRow.changes.length" class="rounded-xl border border-base-300 bg-base-100 p-3">
+          <details
+            v-if="selectedRow.changes.length"
+            class="rounded-xl border border-base-300 bg-base-100 p-3"
+          >
             <summary class="cursor-pointer text-xs font-black">
-              Audit history · {{ selectedRow.changes.length }} recent change{{ selectedRow.changes.length === 1 ? '' : 's' }}
+              Audit history · {{ selectedRow.changes.length }} recent change{{
+                selectedRow.changes.length === 1 ? '' : 's'
+              }}
             </summary>
             <div class="mt-3 space-y-3">
-              <article v-for="change in selectedRow.changes" :key="change.id" class="rounded-lg bg-base-200/60 p-3 text-xs leading-5">
-                <div class="flex flex-wrap justify-between gap-2 text-base-content/50">
+              <article
+                v-for="change in selectedRow.changes"
+                :key="change.id"
+                class="rounded-lg bg-base-200/60 p-3 text-xs leading-5"
+              >
+                <div
+                  class="flex flex-wrap justify-between gap-2 text-base-content/50"
+                >
                   <span>#{{ change.id }} · admin {{ change.adminUserId }}</span>
                   <span>{{ formatTime(change.createdAt) }}</span>
                 </div>
-                <p v-if="change.note" class="mt-1 font-semibold">{{ change.note }}</p>
+                <p v-if="change.note" class="mt-1 font-semibold">
+                  {{ change.note }}
+                </p>
                 <p class="mt-1">
                   <span class="text-base-content/45">Before:</span>
                   {{ change.before.pinyin }} · {{ change.before.meaning }}

--- a/components/dreams/dream-narration.vue
+++ b/components/dreams/dream-narration.vue
@@ -18,7 +18,7 @@
           <button
             v-if="locationStorySlug"
             type="button"
-            class="btn btn-primary btn-sm rounded-xl"
+            class="kr-btn-primary"
             title="Start a Storybook story seeded with this Location"
             @click="startStoryWithLocation"
           >
@@ -26,11 +26,7 @@
             <span class="hidden sm:inline">Start a story with this</span>
           </button>
 
-          <button
-            type="button"
-            class="kr-btn-ghost"
-            @click="backToGallery"
-          >
+          <button type="button" class="kr-btn-ghost" @click="backToGallery">
             <Icon name="kind-icon:arrow-left" class="h-4 w-4" />
             All Dreams
           </button>

--- a/components/gallery/kr-card-back.vue
+++ b/components/gallery/kr-card-back.vue
@@ -266,7 +266,7 @@
       <button
         v-if="canInteract"
         type="button"
-        class="btn btn-primary btn-sm rounded-xl"
+        class="kr-btn-primary"
         @click="emit('interact')"
       >
         {{ interactLabel }}

--- a/components/model-builder/model-builder-recipe-selector.vue
+++ b/components/model-builder/model-builder-recipe-selector.vue
@@ -155,7 +155,7 @@
       </div>
       <button
         type="button"
-        class="btn btn-primary btn-sm rounded-xl"
+        class="kr-btn-primary"
         :disabled="!store.canStartRun"
         :aria-busy="store.startingRun"
         @click="store.startRun()"

--- a/components/pages/mission-accrual-page.vue
+++ b/components/pages/mission-accrual-page.vue
@@ -179,7 +179,7 @@
             <div class="sm:col-span-4 flex items-center gap-3">
               <button
                 type="submit"
-                class="btn btn-primary btn-sm rounded-xl"
+                class="kr-btn-primary"
                 :disabled="store.submitting"
               >
                 {{ store.submitting ? 'Logging…' : 'Log remittance' }}

--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -5,12 +5,15 @@
       class="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-base-300 bg-(--kr-surface-raised) p-3 shadow-sm"
     >
       <div class="min-w-0">
-        <p class="text-[0.7rem] font-bold uppercase tracking-wide text-primary/70">
+        <p
+          class="text-[0.7rem] font-bold uppercase tracking-wide text-primary/70"
+        >
           Story library
         </p>
         <p class="mt-0.5 text-sm text-base-content/60">
           {{ storyStore.recentStories.length }} saved
-          {{ storyStore.recentStories.length === 1 ? 'story' : 'stories' }} on this account
+          {{ storyStore.recentStories.length === 1 ? 'story' : 'stories' }} on
+          this account
         </p>
       </div>
 
@@ -48,8 +51,28 @@
               tabindex="0"
               class="menu dropdown-content z-20 mt-2 w-44 kr-panel-flat p-2 shadow-xl"
             >
-              <li><button type="button" @click="downloadStory(undefined, 'markdown'); closeExportMenu()">Markdown</button></li>
-              <li><button type="button" @click="downloadStory(undefined, 'json'); closeExportMenu()">JSON</button></li>
+              <li>
+                <button
+                  type="button"
+                  @click="
+                    downloadStory(undefined, 'markdown')
+                    closeExportMenu()
+                  "
+                >
+                  Markdown
+                </button>
+              </li>
+              <li>
+                <button
+                  type="button"
+                  @click="
+                    downloadStory(undefined, 'json')
+                    closeExportMenu()
+                  "
+                >
+                  JSON
+                </button>
+              </li>
             </ul>
           </div>
 
@@ -70,13 +93,14 @@
             @click="restartCurrent"
             @blur="restartArmed = false"
           >
-            <Icon name="kind-icon:alert" class="size-4" /> Restart from the beginning?
+            <Icon name="kind-icon:alert" class="size-4" /> Restart from the
+            beginning?
           </button>
 
           <button
             v-if="!newStoryArmed"
             type="button"
-            class="btn btn-primary btn-sm rounded-xl"
+            class="kr-btn-primary"
             :disabled="storyStore.isWeaving"
             @click="newStoryArmed = true"
           >
@@ -104,7 +128,8 @@
         <div>
           <h2 class="text-lg font-black">Recent stories</h2>
           <p class="mt-1 text-xs leading-relaxed text-base-content/55">
-            Open an existing branch, duplicate it safely, or export a portable copy.
+            Open an existing branch, duplicate it safely, or export a portable
+            copy.
           </p>
         </div>
         <span class="badge badge-ghost rounded-xl">
@@ -126,17 +151,25 @@
               <h3 class="truncate font-black">{{ story.bible.title }}</h3>
               <span
                 class="badge badge-sm rounded-xl"
-                :class="story.status === 'complete' ? 'badge-success' : 'badge-primary'"
+                :class="
+                  story.status === 'complete'
+                    ? 'badge-success'
+                    : 'badge-primary'
+                "
               >
                 {{ story.status }}
               </span>
             </div>
-            <p class="mt-1 line-clamp-2 text-xs leading-relaxed text-base-content/55">
+            <p
+              class="mt-1 line-clamp-2 text-xs leading-relaxed text-base-content/55"
+            >
               {{ story.bible.premise }}
             </p>
             <p class="mt-2 text-[0.68rem] text-base-content/40">
-              {{ story.beats.length }} scene{{ story.beats.length === 1 ? '' : 's' }} ·
-              updated {{ formatStoryDate(story.updatedAt) }}
+              {{ story.beats.length }} scene{{
+                story.beats.length === 1 ? '' : 's'
+              }}
+              · updated {{ formatStoryDate(story.updatedAt) }}
             </p>
           </div>
 
@@ -313,7 +346,10 @@ function formatStoryDate(value: string): string {
     : new Intl.DateTimeFormat('en-US', {
         month: 'short',
         day: 'numeric',
-        year: date.getFullYear() === new Date().getFullYear() ? undefined : 'numeric',
+        year:
+          date.getFullYear() === new Date().getFullYear()
+            ? undefined
+            : 'numeric',
       }).format(date)
 }
 

--- a/components/projects/project-placement-manager.vue
+++ b/components/projects/project-placement-manager.vue
@@ -2,13 +2,17 @@
 <template>
   <section class="kr-container flex flex-col gap-4 p-4 sm:p-6">
     <header class="overflow-hidden kr-panel p-0">
-      <div class="flex flex-col gap-3 p-5 sm:flex-row sm:items-start sm:justify-between">
+      <div
+        class="flex flex-col gap-3 p-5 sm:flex-row sm:items-start sm:justify-between"
+      >
         <div class="min-w-0">
           <div class="flex items-center gap-2">
             <Icon name="kind-icon:map" class="h-6 w-6 text-primary" />
             <h1 class="text-xl font-black sm:text-2xl">Project Placement</h1>
           </div>
-          <p class="mt-2 max-w-3xl text-sm leading-relaxed text-base-content/65">
+          <p
+            class="mt-2 max-w-3xl text-sm leading-relaxed text-base-content/65"
+          >
             Apply the canonical channel, tab, and live URL map to existing
             Project rows. The operation uses the normal guarded Project PATCH
             endpoint and reports every updated, unchanged, missing, or failed
@@ -54,10 +58,10 @@
         />
       </section>
 
-      <section
-        class="flex flex-col gap-4 kr-panel-flat p-4 shadow-sm sm:p-5"
-      >
-        <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+      <section class="flex flex-col gap-4 kr-panel-flat p-4 shadow-sm sm:p-5">
+        <div
+          class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between"
+        >
           <div>
             <h2 class="font-black">Backfill controls</h2>
             <p class="mt-1 text-sm text-base-content/60">
@@ -84,18 +88,24 @@
               :disabled="busy"
               @click="loadProjects"
             >
-              <span v-if="projectStore.loading" class="loading loading-spinner loading-xs" />
+              <span
+                v-if="projectStore.loading"
+                class="loading loading-spinner loading-xs"
+              />
               <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
               Load projects
             </button>
 
             <button
               type="button"
-              class="btn btn-primary btn-sm rounded-xl"
+              class="kr-btn-primary"
               :disabled="busy || !projectStore.loaded"
               @click="applyPlacements"
             >
-              <span v-if="applying" class="loading loading-spinner loading-xs" />
+              <span
+                v-if="applying"
+                class="loading loading-spinner loading-xs"
+              />
               <Icon v-else name="kind-icon:wand" class="h-4 w-4" />
               Apply placements
             </button>
@@ -108,7 +118,9 @@
           :class="messageTone === 'error' ? 'alert-error' : 'alert-success'"
         >
           <Icon
-            :name="messageTone === 'error' ? 'kind-icon:error' : 'kind-icon:check'"
+            :name="
+              messageTone === 'error' ? 'kind-icon:error' : 'kind-icon:check'
+            "
             class="h-5 w-5"
           />
           <span>{{ message }}</span>
@@ -219,7 +231,9 @@ const messageTone = ref<'success' | 'error'>('success')
 
 const canManage = computed(() => userStore.role === 'ADMIN')
 const expectedCount = Object.keys(PROJECT_PLACEMENTS).length
-const busy = computed(() => projectStore.loading || projectStore.saving || applying.value)
+const busy = computed(
+  () => projectStore.loading || projectStore.saving || applying.value,
+)
 const matchedCount = computed(() => {
   const slugs = new Set(Object.keys(PROJECT_PLACEMENTS))
 
@@ -230,7 +244,10 @@ const matchedCount = computed(() => {
   ).length
 })
 
-function setMessage(value: string, tone: 'success' | 'error' = 'success'): void {
+function setMessage(
+  value: string,
+  tone: 'success' | 'error' = 'success',
+): void {
   message.value = value
   messageTone.value = tone
 }

--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -447,23 +447,15 @@ onMounted(async () => {
       <div class="flex flex-wrap gap-2">
         <button
           type="button"
-          class="btn btn-primary btn-sm rounded-xl"
+          class="kr-btn-primary"
           @click="startAdd('CHECKPOINT')"
         >
           Checkpoint
         </button>
-        <button
-          type="button"
-          class="btn btn-primary btn-sm rounded-xl"
-          @click="startAdd('LORA')"
-        >
+        <button type="button" class="kr-btn-primary" @click="startAdd('LORA')">
           LoRA / LyCORIS
         </button>
-        <button
-          type="button"
-          class="kr-btn-ghost"
-          @click="closeForm"
-        >
+        <button type="button" class="kr-btn-ghost" @click="closeForm">
           Cancel
         </button>
       </div>
@@ -546,7 +538,7 @@ onMounted(async () => {
 
             <button
               type="button"
-              class="btn btn-primary btn-sm rounded-xl"
+              class="kr-btn-primary"
               @click="addToGeneration(infoResource)"
             >
               <Icon name="kind-icon:plus" class="h-4 w-4" />

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -49,7 +49,7 @@
 
           <button
             v-if="allowAdd && !isDropdownMode"
-            class="btn btn-primary btn-sm rounded-xl"
+            class="kr-btn-primary"
             type="button"
             @click="startAddingReward"
           >
@@ -87,11 +87,7 @@
           </p>
         </div>
 
-        <button
-          class="kr-btn-ghost"
-          type="button"
-          @click="closeRewardForm"
-        >
+        <button class="kr-btn-ghost" type="button" @click="closeRewardForm">
           <Icon name="kind-icon:x" class="h-4 w-4" />
           <span class="hidden sm:inline">Close</span>
         </button>
@@ -314,7 +310,7 @@
 
         <button
           v-if="allowAdd"
-          class="btn btn-primary btn-sm rounded-xl"
+          class="kr-btn-primary"
           type="button"
           @click="startAddingReward"
         >
@@ -636,8 +632,9 @@ const visibleRewards = computed<Reward[]>(() => {
 // refinement) rather than re-fetching on every keystroke — those filters only
 // narrow an already-fetched set. the earned-karma tracker keys its watch on the id list,
 // so a refilter that yields the same rewards does not re-request.
-const { earnedKarma: earnedKarmaByRewardId } = userStore.trackEarnedKarma('reward', () =>
-  visibleRewards.value.map((reward) => reward.id),
+const { earnedKarma: earnedKarmaByRewardId } = userStore.trackEarnedKarma(
+  'reward',
+  () => visibleRewards.value.map((reward) => reward.id),
 )
 
 const collections = computed(() => {

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -23,7 +23,7 @@
 
           <button
             v-if="allowAdd && !isDropdownMode"
-            class="btn btn-primary btn-sm rounded-xl"
+            class="kr-btn-primary"
             type="button"
             @click="startAddingScenario"
           >
@@ -272,7 +272,7 @@
 
         <button
           v-if="allowAdd && !searchQuery"
-          class="btn btn-primary btn-sm rounded-xl"
+          class="kr-btn-primary"
           type="button"
           @click="startAddingScenario"
         >

--- a/components/scenarios/scenario-manager.vue
+++ b/components/scenarios/scenario-manager.vue
@@ -18,7 +18,7 @@
         >
           <button
             type="button"
-            class="btn btn-primary btn-sm rounded-xl"
+            class="kr-btn-primary"
             title="Start a Storybook story seeded with this Scenario"
             @click="startStoryWithScenario"
           >

--- a/components/scenarios/scenario-relationship-gallery.vue
+++ b/components/scenarios/scenario-relationship-gallery.vue
@@ -38,7 +38,7 @@
           <button
             v-if="allowAdd"
             type="button"
-            class="btn btn-primary btn-sm rounded-xl"
+            class="kr-btn-primary"
             @click="startAddingScenario"
           >
             <Icon name="kind-icon:plus" class="h-4 w-4" />
@@ -125,7 +125,7 @@
         <button
           v-if="allowAdd && !searchQuery"
           type="button"
-          class="btn btn-primary btn-sm rounded-xl"
+          class="kr-btn-primary"
           @click="startAddingScenario"
         >
           <Icon name="kind-icon:plus" class="h-4 w-4" />

--- a/components/user/account-settings.vue
+++ b/components/user/account-settings.vue
@@ -117,7 +117,7 @@
           <div class="flex items-center gap-3 sm:col-span-2">
             <button
               type="submit"
-              class="btn btn-primary btn-sm rounded-xl"
+              class="kr-btn-primary"
               :disabled="account.isSaving || !canSubmitPassword"
             >
               <span

--- a/components/user/first-launch-intro.vue
+++ b/components/user/first-launch-intro.vue
@@ -12,9 +12,7 @@
         class="flex shrink-0 items-start justify-between gap-3 border-b border-base-300 bg-base-100 p-4"
       >
         <div class="min-w-0">
-          <p
-            class="text-xs font-black uppercase tracking-widest text-primary"
-          >
+          <p class="text-xs font-black uppercase tracking-widest text-primary">
             {{ step + 1 }} / {{ steps.length }}
           </p>
           <h2 class="mt-0.5 truncate text-lg font-black sm:text-xl">
@@ -22,11 +20,7 @@
           </h2>
         </div>
 
-        <button
-          class="kr-btn-ghost"
-          type="button"
-          @click="dismiss"
-        >
+        <button class="kr-btn-ghost" type="button" @click="dismiss">
           Skip
         </button>
       </header>
@@ -99,19 +93,14 @@
 
           <button
             v-if="step < steps.length - 1"
-            class="btn btn-primary btn-sm rounded-xl"
+            class="kr-btn-primary"
             type="button"
             @click="next"
           >
             Next
           </button>
 
-          <button
-            v-else
-            class="btn btn-primary btn-sm rounded-xl"
-            type="button"
-            @click="dismiss"
-          >
+          <button v-else class="kr-btn-primary" type="button" @click="dismiss">
             <Icon name="kind-icon:check" class="h-4 w-4" />
             Let's go
           </button>
@@ -163,7 +152,7 @@ const steps: IntroStep[] = [
   {
     title: 'Karma and mana',
     icon: 'kind-icon:jellybean',
-    body: "Karma is your standing on the site — it only ever grows, earned by creating, sharing, and discovering. Mana is your usage budget for AI generation — it refills on its own schedule and has a cap, so it can run low and recover. Karma is a record; mana is a resource.",
+    body: 'Karma is your standing on the site — it only ever grows, earned by creating, sharing, and discovering. Mana is your usage budget for AI generation — it refills on its own schedule and has a cap, so it can run low and recover. Karma is a record; mana is a resource.',
   },
   {
     title: 'Seven kinds of things to build',

--- a/components/user/password-reset.vue
+++ b/components/user/password-reset.vue
@@ -36,7 +36,7 @@
       </label>
       <button
         type="submit"
-        class="btn btn-primary btn-sm rounded-xl"
+        class="kr-btn-primary"
         :disabled="account.isSaving || !email"
       >
         <span
@@ -75,7 +75,7 @@
       </label>
       <button
         type="submit"
-        class="btn btn-primary btn-sm rounded-xl"
+        class="kr-btn-primary"
         :disabled="account.isSaving || next.length < 8 || next !== confirm"
       >
         <span

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -1,9 +1,7 @@
 <!-- /components/content/user/user-dashboard.vue -->
 <template>
   <section class="kr-surface gap-4 rounded-2xl bg-base-200 p-3 sm:p-4">
-    <header
-      class="kr-toolbar kr-panel-flat px-4 py-3"
-    >
+    <header class="kr-toolbar kr-panel-flat px-4 py-3">
       <Icon name="kind-icon:sparkles" class="h-5 w-5 shrink-0 text-primary" />
 
       <div class="min-w-0 flex-1">
@@ -26,11 +24,7 @@
         Replay intro
       </button>
 
-      <NuxtLink
-        v-if="isGuest"
-        to="/login"
-        class="btn btn-primary btn-sm rounded-xl"
-      >
+      <NuxtLink v-if="isGuest" to="/login" class="kr-btn-primary">
         <Icon name="kind-icon:login" class="h-4 w-4" />
         Sign in
       </NuxtLink>
@@ -75,15 +69,15 @@
             class="grid w-full grid-cols-1 gap-4 xl:grid-cols-[minmax(16rem,22rem)_minmax(0,1fr)]"
           >
             <aside class="flex w-full flex-col gap-3">
-              <div
-                class="flex flex-col items-center gap-3 kr-panel-flat p-4"
-              >
+              <div class="flex flex-col items-center gap-3 kr-panel-flat p-4">
                 <user-avatar
                   class="h-24 w-24 rounded-full ring-2 ring-accent ring-offset-2 ring-offset-base-100"
                 />
 
                 <div class="flex w-full flex-col items-center gap-1">
-                  <h2 class="max-w-full truncate text-xl font-black text-base-content">
+                  <h2
+                    class="max-w-full truncate text-xl font-black text-base-content"
+                  >
                     {{ displayName }}
                   </h2>
 
@@ -147,9 +141,7 @@
 
               <!-- Karma / mana / achievements ─────────────────────────────── -->
               <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
-                <div
-                  class="kr-panel-flat p-4"
-                >
+                <div class="kr-panel-flat p-4">
                   <div class="flex items-center gap-2">
                     <Icon
                       name="kind-icon:jellybean"
@@ -165,9 +157,7 @@
                   <p class="mt-1 text-xs text-base-content/55">
                     {{ karmaStore.transactions.length }} recent
                     {{
-                      karmaStore.transactions.length === 1
-                        ? 'entry'
-                        : 'entries'
+                      karmaStore.transactions.length === 1 ? 'entry' : 'entries'
                     }}
                   </p>
 
@@ -179,9 +169,7 @@
                   </NuxtLink>
                 </div>
 
-                <div
-                  class="kr-panel-flat p-4"
-                >
+                <div class="kr-panel-flat p-4">
                   <div class="flex items-center gap-2">
                     <Icon
                       name="kind-icon:sparkles"
@@ -212,9 +200,7 @@
                   </p>
                 </div>
 
-                <div
-                  class="kr-panel-flat p-4"
-                >
+                <div class="kr-panel-flat p-4">
                   <div class="flex items-center gap-2">
                     <Icon
                       name="kind-icon:trophy"
@@ -239,11 +225,10 @@
                 </div>
               </div>
 
-              <div
-                v-if="earnedAchievements.length"
-                class="kr-panel-flat p-3"
-              >
-                <p class="mb-2 text-xs font-black uppercase tracking-widest text-base-content/50">
+              <div v-if="earnedAchievements.length" class="kr-panel-flat p-3">
+                <p
+                  class="mb-2 text-xs font-black uppercase tracking-widest text-base-content/50"
+                >
                   Recent achievements
                 </p>
 
@@ -259,9 +244,7 @@
 
               <!-- Theme / maturity / server preferences ───────────────────── -->
               <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
-                <div
-                  class="flex flex-col gap-2 kr-panel-flat p-4"
-                >
+                <div class="flex flex-col gap-2 kr-panel-flat p-4">
                   <div class="flex items-center gap-2">
                     <Icon
                       name="kind-icon:paintbrush"
@@ -283,9 +266,7 @@
                   </button>
                 </div>
 
-                <div
-                  class="flex flex-col gap-2 kr-panel-flat p-4"
-                >
+                <div class="flex flex-col gap-2 kr-panel-flat p-4">
                   <label class="flex cursor-pointer items-center gap-2">
                     <Icon name="kind-icon:eye" class="h-5 w-5 text-warning" />
                     <span class="text-sm font-black">Show mature content</span>
@@ -311,14 +292,9 @@
                   </label>
                 </div>
 
-                <div
-                  class="flex flex-col gap-2 kr-panel-flat p-4"
-                >
+                <div class="flex flex-col gap-2 kr-panel-flat p-4">
                   <div class="flex items-center gap-2">
-                    <Icon
-                      name="kind-icon:server"
-                      class="h-5 w-5 text-info"
-                    />
+                    <Icon name="kind-icon:server" class="h-5 w-5 text-info" />
                     <span class="text-sm font-black">Server preferences</span>
                   </div>
 

--- a/components/user/user-manager-directory.vue
+++ b/components/user/user-manager-directory.vue
@@ -32,7 +32,7 @@
           <option value="ALL">All roles</option>
           <option v-for="r in ROLES" :key="r" :value="r">{{ r }}</option>
         </select>
-        <button class="btn btn-primary btn-sm rounded-xl" @click="openCreate">
+        <button class="kr-btn-primary" @click="openCreate">
           <Icon name="kind-icon:plus" class="h-4 w-4" /> New user
         </button>
       </div>
@@ -207,9 +207,7 @@
           <p v-if="createError" class="text-sm text-error">{{ createError }}</p>
         </div>
         <div class="modal-action">
-          <button class="kr-btn-ghost-md" @click="closeCreate">
-            Cancel
-          </button>
+          <button class="kr-btn-ghost-md" @click="closeCreate">Cancel</button>
           <button
             class="btn btn-primary rounded-xl"
             :disabled="store.isSaving || !createForm.username"
@@ -238,9 +236,7 @@
         />
         <p v-if="pwError" class="mt-2 text-sm text-error">{{ pwError }}</p>
         <div class="modal-action">
-          <button class="kr-btn-ghost-md" @click="closePassword">
-            Cancel
-          </button>
+          <button class="kr-btn-ghost-md" @click="closePassword">Cancel</button>
           <button
             class="btn btn-primary rounded-xl"
             :disabled="store.isSaving || newPassword.length < 8"

--- a/components/user/user-panel.vue
+++ b/components/user/user-panel.vue
@@ -28,7 +28,7 @@
 
       <button
         type="button"
-        class="btn btn-primary btn-sm rounded-xl"
+        class="kr-btn-primary"
         :disabled="isSaving || !hasProfile"
         @click="updateProfile"
       >

--- a/pages/admin/achievement-art.vue
+++ b/pages/admin/achievement-art.vue
@@ -1,19 +1,22 @@
 <template>
   <main class="kr-surface h-full min-h-0 overflow-hidden">
     <div class="kr-scroll kr-container-wide space-y-4 p-4 md:p-6">
-      <header class="kr-toolbar flex flex-wrap items-start justify-between gap-4">
+      <header
+        class="kr-toolbar flex flex-wrap items-start justify-between gap-4"
+      >
         <div>
           <p class="text-xs font-black uppercase tracking-widest text-primary">
             Achievement administration
           </p>
           <p class="mt-1 text-2xl font-black">Achievement artwork</p>
           <p class="mt-1 text-sm text-base-content/60">
-            Generate, upload, and replace the image attached to each achievement definition.
+            Generate, upload, and replace the image attached to each achievement
+            definition.
           </p>
         </div>
         <button
           type="button"
-          class="btn btn-primary btn-sm rounded-xl"
+          class="kr-btn-primary"
           :disabled="loading"
           @click="loadAchievements(true)"
         >
@@ -30,17 +33,23 @@
         v-else-if="!userStore.isAdmin"
         class="kr-note kr-note-error p-8 text-center font-normal"
       >
-        <p class="text-xl font-black text-base-content">Administrator access required</p>
+        <p class="text-xl font-black text-base-content">
+          Administrator access required
+        </p>
         <p class="mt-2 text-sm text-base-content/60">
           Achievement artwork management is restricted to administrators.
         </p>
       </div>
 
       <template v-else>
-        <section class="grid gap-4 lg:grid-cols-[minmax(260px,0.38fr)_minmax(0,1fr)]">
+        <section
+          class="grid gap-4 lg:grid-cols-[minmax(260px,0.38fr)_minmax(0,1fr)]"
+        >
           <aside class="kr-panel space-y-3 p-4">
             <label class="form-control gap-1">
-              <span class="text-xs font-bold text-base-content/60">Find achievement</span>
+              <span class="text-xs font-bold text-base-content/60"
+                >Find achievement</span
+              >
               <input
                 v-model="search"
                 type="search"
@@ -49,8 +58,12 @@
               />
             </label>
             <div class="flex flex-wrap gap-2 text-xs">
-              <span class="badge badge-ghost">{{ achievements.length }} total</span>
-              <span class="badge badge-warning">{{ missingArtCount }} without art</span>
+              <span class="badge badge-ghost"
+                >{{ achievements.length }} total</span
+              >
+              <span class="badge badge-warning"
+                >{{ missingArtCount }} without art</span
+              >
             </div>
             <div class="space-y-2 pr-1">
               <button
@@ -58,22 +71,32 @@
                 :key="achievement.id"
                 type="button"
                 class="flex w-full items-center gap-3 rounded-xl border p-2 text-left transition"
-                :class="selectedId === achievement.id
-                  ? 'border-primary bg-primary/10'
-                  : 'border-base-300 bg-base-100 hover:border-primary/50'"
+                :class="
+                  selectedId === achievement.id
+                    ? 'border-primary bg-primary/10'
+                    : 'border-base-300 bg-base-100 hover:border-primary/50'
+                "
                 @click="selectedId = achievement.id"
               >
-                <div class="grid size-12 shrink-0 place-items-center overflow-hidden rounded-xl bg-base-200">
+                <div
+                  class="grid size-12 shrink-0 place-items-center overflow-hidden rounded-xl bg-base-200"
+                >
                   <img
                     v-if="achievement.imagePath"
                     :src="achievement.imagePath"
                     :alt="achievement.label"
                     class="size-full object-cover"
                   />
-                  <Icon v-else name="kind-icon:trophy" class="size-5 text-base-content/35" />
+                  <Icon
+                    v-else
+                    name="kind-icon:trophy"
+                    class="size-5 text-base-content/35"
+                  />
                 </div>
                 <div class="min-w-0 flex-1">
-                  <p class="truncate text-sm font-black">{{ achievement.label }}</p>
+                  <p class="truncate text-sm font-black">
+                    {{ achievement.label }}
+                  </p>
                   <p class="truncate text-xs text-base-content/50">
                     {{ achievement.triggerCode || achievement.message }}
                   </p>
@@ -103,12 +126,21 @@
                   >
                     {{ selectedAchievement.triggerCode }}
                   </p>
-                  <h2 class="mt-1 text-xl font-black">{{ selectedAchievement.label }}</h2>
+                  <h2 class="mt-1 text-xl font-black">
+                    {{ selectedAchievement.label }}
+                  </h2>
                   <p class="mt-2 max-w-3xl text-sm text-base-content/60">
                     {{ selectedAchievement.message }}
                   </p>
                 </div>
-                <span class="badge" :class="selectedAchievement.isActive ? 'badge-success' : 'badge-ghost'">
+                <span
+                  class="badge"
+                  :class="
+                    selectedAchievement.isActive
+                      ? 'badge-success'
+                      : 'badge-ghost'
+                  "
+                >
                   {{ selectedAchievement.isActive ? 'Active' : 'Inactive' }}
                 </span>
               </div>
@@ -123,7 +155,10 @@
             />
           </section>
 
-          <div v-else class="grid min-h-72 place-items-center kr-panel text-base-content/50">
+          <div
+            v-else
+            class="grid min-h-72 place-items-center kr-panel text-base-content/50"
+          >
             Select an achievement to manage its artwork.
           </div>
         </section>
@@ -157,13 +192,19 @@ const artSlots = [
 
 const achievements = computed(() => achievementStore.achievements)
 const missingArtCount = computed(
-  () => achievements.value.filter((achievement) => !achievement.imagePath).length,
+  () =>
+    achievements.value.filter((achievement) => !achievement.imagePath).length,
 )
 const filteredAchievements = computed(() => {
   const query = search.value.trim().toLowerCase()
   if (!query) return achievements.value
   return achievements.value.filter((achievement) =>
-    [achievement.label, achievement.triggerCode, achievement.message, achievement.tooltip]
+    [
+      achievement.label,
+      achievement.triggerCode,
+      achievement.message,
+      achievement.tooltip,
+    ]
       .filter(Boolean)
       .some((value) => String(value).toLowerCase().includes(query)),
   )
@@ -182,7 +223,10 @@ async function loadAchievements(force = false) {
   loading.value = true
   try {
     await achievementStore.initialize({ force, fetchRemote: true })
-    if (!selectedId.value || !achievements.value.some((item) => item.id === selectedId.value)) {
+    if (
+      !selectedId.value ||
+      !achievements.value.some((item) => item.id === selectedId.value)
+    ) {
       selectedId.value = achievements.value[0]?.id ?? null
     }
   } finally {
@@ -191,7 +235,9 @@ async function loadAchievements(force = false) {
 }
 
 function applyUpdate(updated: Record<string, unknown>) {
-  const achievement = achievements.value.find((item) => item.id === Number(updated.id))
+  const achievement = achievements.value.find(
+    (item) => item.id === Number(updated.id),
+  )
   if (achievement) Object.assign(achievement, updated as Partial<Achievement>)
 }
 </script>

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -1,15 +1,18 @@
 <template>
   <main class="kr-surface h-full min-h-0 overflow-hidden">
     <div class="kr-scroll kr-container-wide space-y-4 p-4 md:p-6">
-      <header class="kr-toolbar flex flex-wrap items-start justify-between gap-4">
+      <header
+        class="kr-toolbar flex flex-wrap items-start justify-between gap-4"
+      >
         <div>
           <p class="text-xs font-black uppercase tracking-widest text-primary">
             Temporary catalog cleanup
           </p>
           <div class="mt-1 text-2xl font-black">LoRA maturity triage</div>
           <p class="mt-1 max-w-3xl text-sm text-base-content/60">
-            Confirm LoRAs as SFW or NSFW here, then save the changed maturity flags in one pass.
-            Review progress stays in this browser until this cleanup page is removed.
+            Confirm LoRAs as SFW or NSFW here, then save the changed maturity
+            flags in one pass. Review progress stays in this browser until this
+            cleanup page is removed.
           </p>
         </div>
 
@@ -26,13 +29,20 @@
           </button>
           <button
             type="button"
-            class="btn btn-primary btn-sm rounded-xl"
-            :disabled="triageStore.isSaving || triageStore.pendingChanges.length === 0"
+            class="kr-btn-primary"
+            :disabled="
+              triageStore.isSaving || triageStore.pendingChanges.length === 0
+            "
             @click="triageStore.saveChanges()"
           >
-            <span v-if="triageStore.isSaving" class="loading loading-spinner loading-xs" />
+            <span
+              v-if="triageStore.isSaving"
+              class="loading loading-spinner loading-xs"
+            />
             <Icon v-else name="kind-icon:save" class="size-4" />
-            Save {{ triageStore.pendingChanges.length }} change{{ triageStore.pendingChanges.length === 1 ? '' : 's' }}
+            Save {{ triageStore.pendingChanges.length }} change{{
+              triageStore.pendingChanges.length === 1 ? '' : 's'
+            }}
           </button>
         </div>
       </header>
@@ -45,7 +55,9 @@
         v-else-if="!userStore.isAdmin"
         class="kr-note kr-note-error p-8 text-center font-normal"
       >
-        <p class="text-xl font-black text-base-content">Administrator access required</p>
+        <p class="text-xl font-black text-base-content">
+          Administrator access required
+        </p>
         <p class="mt-2 text-sm text-base-content/60">
           LoRA maturity triage is restricted to administrators.
         </p>
@@ -54,20 +66,36 @@
       <template v-else>
         <section class="grid grid-cols-2 gap-2 sm:grid-cols-4">
           <div class="kr-panel p-3">
-            <p class="text-xs font-black uppercase text-base-content/45">LoRAs</p>
-            <p class="mt-1 text-2xl font-black">{{ triageStore.loras.length }}</p>
+            <p class="text-xs font-black uppercase text-base-content/45">
+              LoRAs
+            </p>
+            <p class="mt-1 text-2xl font-black">
+              {{ triageStore.loras.length }}
+            </p>
           </div>
           <div class="kr-panel p-3">
-            <p class="text-xs font-black uppercase text-base-content/45">Confirmed</p>
-            <p class="mt-1 text-2xl font-black text-success">{{ triageStore.confirmedCount }}</p>
+            <p class="text-xs font-black uppercase text-base-content/45">
+              Confirmed
+            </p>
+            <p class="mt-1 text-2xl font-black text-success">
+              {{ triageStore.confirmedCount }}
+            </p>
           </div>
           <div class="kr-panel p-3">
-            <p class="text-xs font-black uppercase text-base-content/45">Remaining</p>
-            <p class="mt-1 text-2xl font-black">{{ triageStore.remainingCount }}</p>
+            <p class="text-xs font-black uppercase text-base-content/45">
+              Remaining
+            </p>
+            <p class="mt-1 text-2xl font-black">
+              {{ triageStore.remainingCount }}
+            </p>
           </div>
           <div class="kr-panel p-3">
-            <p class="text-xs font-black uppercase text-base-content/45">Unsaved changes</p>
-            <p class="mt-1 text-2xl font-black text-warning">{{ triageStore.pendingChanges.length }}</p>
+            <p class="text-xs font-black uppercase text-base-content/45">
+              Unsaved changes
+            </p>
+            <p class="mt-1 text-2xl font-black text-warning">
+              {{ triageStore.pendingChanges.length }}
+            </p>
           </div>
         </section>
 
@@ -92,7 +120,9 @@
               </option>
             </select>
 
-            <label class="flex cursor-pointer items-center gap-2 rounded-xl px-2 py-1 text-sm">
+            <label
+              class="flex cursor-pointer items-center gap-2 rounded-xl px-2 py-1 text-sm"
+            >
               <input
                 type="checkbox"
                 class="toggle toggle-sm toggle-primary"
@@ -103,8 +133,12 @@
             </label>
           </div>
 
-          <div class="flex flex-wrap items-center gap-2 border-t border-base-300 pt-3">
-            <span class="text-sm font-bold">{{ triageStore.selectedCount }} selected</span>
+          <div
+            class="flex flex-wrap items-center gap-2 border-t border-base-300 pt-3"
+          >
+            <span class="text-sm font-bold"
+              >{{ triageStore.selectedCount }} selected</span
+            >
             <button
               type="button"
               class="kr-btn-ghost-xs"
@@ -153,12 +187,17 @@
           {{ triageStore.saveError }}
         </div>
 
-        <section v-if="pageResources.length" class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+        <section
+          v-if="pageResources.length"
+          class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5"
+        >
           <article
             v-for="resource in pageResources"
             :key="resource.id"
             class="overflow-hidden kr-panel p-0"
-            :class="triageStore.isSelected(resource.id) ? 'ring-2 ring-primary' : ''"
+            :class="
+              triageStore.isSelected(resource.id) ? 'ring-2 ring-primary' : ''
+            "
           >
             <div class="relative aspect-square overflow-hidden bg-base-200">
               <kr-deferred-image
@@ -167,7 +206,9 @@
                 class="size-full object-cover"
               />
 
-              <label class="absolute left-2 top-2 grid size-8 cursor-pointer place-items-center rounded-lg bg-base-100/90 shadow">
+              <label
+                class="absolute left-2 top-2 grid size-8 cursor-pointer place-items-center rounded-lg bg-base-100/90 shadow"
+              >
                 <input
                   type="checkbox"
                   class="checkbox checkbox-primary checkbox-sm"
@@ -177,25 +218,37 @@
                 />
               </label>
 
-              <div class="absolute right-2 top-2 flex flex-wrap justify-end gap-1">
-                <span class="badge badge-sm" :class="resource.isMature ? 'badge-error' : 'badge-success'">
+              <div
+                class="absolute right-2 top-2 flex flex-wrap justify-end gap-1"
+              >
+                <span
+                  class="badge badge-sm"
+                  :class="resource.isMature ? 'badge-error' : 'badge-success'"
+                >
                   DB: {{ resource.isMature ? 'NSFW' : 'SFW' }}
                 </span>
                 <span
                   v-if="triageStore.decisionFor(resource.id)"
                   class="badge badge-sm badge-primary"
                 >
-                  Confirmed {{ triageStore.decisionFor(resource.id)?.toUpperCase() }}
+                  Confirmed
+                  {{ triageStore.decisionFor(resource.id)?.toUpperCase() }}
                 </span>
               </div>
             </div>
 
             <div class="space-y-3 p-3">
               <div class="min-w-0">
-                <h2 class="line-clamp-2 break-words text-sm font-black" :title="resourceLabel(resource)">
+                <h2
+                  class="line-clamp-2 break-words text-sm font-black"
+                  :title="resourceLabel(resource)"
+                >
                   {{ resourceLabel(resource) }}
                 </h2>
-                <p v-if="resource.generation" class="mt-1 text-xs text-base-content/50">
+                <p
+                  v-if="resource.generation"
+                  class="mt-1 text-xs text-base-content/50"
+                >
                   {{ resource.generation }}
                 </p>
                 <p
@@ -211,7 +264,11 @@
                 <button
                   type="button"
                   class="btn btn-sm rounded-xl"
-                  :class="triageStore.decisionFor(resource.id) === 'sfw' ? 'btn-success' : 'btn-outline'"
+                  :class="
+                    triageStore.decisionFor(resource.id) === 'sfw'
+                      ? 'btn-success'
+                      : 'btn-outline'
+                  "
                   @click="triageStore.setDecision(resource.id, 'sfw')"
                 >
                   SFW
@@ -219,7 +276,11 @@
                 <button
                   type="button"
                   class="btn btn-sm rounded-xl"
-                  :class="triageStore.decisionFor(resource.id) === 'nsfw' ? 'btn-error' : 'btn-outline'"
+                  :class="
+                    triageStore.decisionFor(resource.id) === 'nsfw'
+                      ? 'btn-error'
+                      : 'btn-outline'
+                  "
                   @click="triageStore.setDecision(resource.id, 'nsfw')"
                 >
                   NSFW
@@ -229,19 +290,29 @@
           </article>
         </section>
 
-        <div v-else class="grid min-h-64 place-items-center kr-panel text-center text-base-content/55">
+        <div
+          v-else
+          class="grid min-h-64 place-items-center kr-panel text-center text-base-content/55"
+        >
           <div>
             <Icon name="kind-icon:check" class="mx-auto size-10 text-success" />
             <p class="mt-2 font-black">No LoRAs left in this view.</p>
             <p class="mt-1 text-sm">
-              {{ triageStore.hideConfirmed ? 'Turn off “Hide confirmed” to review completed decisions.' : 'Try changing the search or base-model filter.' }}
+              {{
+                triageStore.hideConfirmed
+                  ? 'Turn off “Hide confirmed” to review completed decisions.'
+                  : 'Try changing the search or base-model filter.'
+              }}
             </p>
           </div>
         </div>
 
-        <footer class="kr-panel flex flex-wrap items-center justify-between gap-3 p-3">
+        <footer
+          class="kr-panel flex flex-wrap items-center justify-between gap-3 p-3"
+        >
           <div class="text-sm text-base-content/60">
-            Showing {{ pageStart }}–{{ pageEnd }} of {{ filteredResources.length }} matching LoRAs
+            Showing {{ pageStart }}–{{ pageEnd }} of
+            {{ filteredResources.length }} matching LoRAs
           </div>
           <div class="flex items-center gap-2">
             <button
@@ -252,7 +323,9 @@
             >
               Previous
             </button>
-            <span class="text-sm font-bold">Page {{ safePage }} / {{ totalPages }}</span>
+            <span class="text-sm font-bold"
+              >Page {{ safePage }} / {{ totalPages }}</span
+            >
             <button
               type="button"
               class="kr-btn-ghost"
@@ -293,19 +366,23 @@ const generation = ref('ALL')
 const page = ref(1)
 
 const generations = computed(() =>
-  [...new Set(
-    triageStore.loras
-      .map((resource) => resource.generation?.trim())
-      .filter((value): value is string => Boolean(value)),
-  )].sort((a, b) => a.localeCompare(b)),
+  [
+    ...new Set(
+      triageStore.loras
+        .map((resource) => resource.generation?.trim())
+        .filter((value): value is string => Boolean(value)),
+    ),
+  ].sort((a, b) => a.localeCompare(b)),
 )
 
 const filteredResources = computed(() => {
   const search = query.value.trim().toLowerCase()
 
   return triageStore.loras.filter((resource) => {
-    if (triageStore.hideConfirmed && triageStore.decisionFor(resource.id)) return false
-    if (generation.value !== 'ALL' && resource.generation !== generation.value) return false
+    if (triageStore.hideConfirmed && triageStore.decisionFor(resource.id))
+      return false
+    if (generation.value !== 'ALL' && resource.generation !== generation.value)
+      return false
     if (!search) return true
 
     return [
@@ -321,21 +398,29 @@ const filteredResources = computed(() => {
   })
 })
 
-const totalPages = computed(() => Math.max(1, Math.ceil(filteredResources.value.length / PAGE_SIZE)))
+const totalPages = computed(() =>
+  Math.max(1, Math.ceil(filteredResources.value.length / PAGE_SIZE)),
+)
 const safePage = computed(() => Math.min(page.value, totalPages.value))
 const pageResources = computed(() => {
   const start = (safePage.value - 1) * PAGE_SIZE
   return filteredResources.value.slice(start, start + PAGE_SIZE)
 })
-const pageStart = computed(() => filteredResources.value.length ? (safePage.value - 1) * PAGE_SIZE + 1 : 0)
-const pageEnd = computed(() => Math.min(safePage.value * PAGE_SIZE, filteredResources.value.length))
+const pageStart = computed(() =>
+  filteredResources.value.length ? (safePage.value - 1) * PAGE_SIZE + 1 : 0,
+)
+const pageEnd = computed(() =>
+  Math.min(safePage.value * PAGE_SIZE, filteredResources.value.length),
+)
 
 function resourceLabel(resource: ResourceGalleryRecord): string {
   return resource.customLabel || resource.name
 }
 
 function triggerText(resource: ResourceGalleryRecord): string {
-  return resource.defaultTrigger || resource.triggerWords || resource.artPrompt || ''
+  return (
+    resource.defaultTrigger || resource.triggerWords || resource.artPrompt || ''
+  )
 }
 
 function previewSrc(resource: ResourceGalleryRecord): string {
@@ -351,12 +436,14 @@ function previewSrc(resource: ResourceGalleryRecord): string {
 
 function handleHideConfirmed(event: Event): void {
   const input = event.target
-  if (input instanceof HTMLInputElement) triageStore.setHideConfirmed(input.checked)
+  if (input instanceof HTMLInputElement)
+    triageStore.setHideConfirmed(input.checked)
 }
 
 function handleSelection(resourceId: number, event: Event): void {
   const input = event.target
-  if (input instanceof HTMLInputElement) triageStore.setSelected(resourceId, input.checked)
+  if (input instanceof HTMLInputElement)
+    triageStore.setSelected(resourceId, input.checked)
 }
 
 function selectPage(): void {
@@ -365,7 +452,11 @@ function selectPage(): void {
 
 function clearProgress(): void {
   if (typeof window === 'undefined') return
-  if (window.confirm('Clear local triage decisions? Saved Resource maturity flags will not be changed.')) {
+  if (
+    window.confirm(
+      'Clear local triage decisions? Saved Resource maturity flags will not be changed.',
+    )
+  ) {
     triageStore.clearProgress()
   }
 }

--- a/pages/admin/social-drafts.vue
+++ b/pages/admin/social-drafts.vue
@@ -18,7 +18,7 @@
         </div>
         <button
           type="button"
-          class="btn btn-primary btn-sm rounded-xl"
+          class="kr-btn-primary"
           :disabled="loading"
           @click="draftsStore.populate()"
         >


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Added `.kr-btn-primary` (`btn btn-primary btn-sm rounded-xl`) to `assets/css/tailwind.css`, mirroring the existing `.kr-btn-ghost*` primitive family — the most-repeated filled (non-ghost) button shape in the app, previously hand-rolled in 31 files (39 occurrences).
- Codemodded every exact-match `class="btn btn-primary btn-sm rounded-xl"` site onto `class="kr-btn-primary"` across 31 components/pages. No geometry or behavior change.
- Ran `prettier --write` on every touched file — several already carried pre-existing formatting drift on `main` (confirmed via `git stash` diffs before writing), so some diffs include that collateral reflow, matching the precedent set by slice 49.
- Left near-miss sites out of scope (same shape plus extra appended classes like `gap-1.5`, `mt-3`, `text-white`, `focus-visible:*` utilities) for a follow-up slice, matching the `.kr-btn-ghost-xs` family's own convention.

### How I verified
- `vue-tsc --noEmit`: clean.
- `eslint` on all changed files: clean except one pre-existing, unrelated `no-unused-vars` error in `character-gallery.vue`, confirmed present on unmodified `origin/main` via `git stash`.
- `npm run test:lint-ratchet`: holds at the existing 332/-60 baseline, no rule regressed.
- `npm run test:layout-contract`: holds at the existing 207-violation baseline, no new violations.
- `prettier --check`: clean except `assets/css/tailwind.css`'s own pre-existing drift (unrelated `--kr-surface-*` token lines), confirmed present on unmodified `origin/main` via `git stash` — left untouched to keep the CSS diff scoped to the new primitive only.

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
Next slice should survey a new repeated component shape now that both the ghost-button and primary-button exact-match families are exhausted — candidates spotted during this survey: `btn btn-sm rounded-xl` (32 files, no color modifier) and `btn btn-outline btn-sm rounded-xl` (21 files).

### Notes for reviewer
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JXuKm4NoumuZpm9x44ARF

---
_Generated by [Claude Code](https://claude.ai/code/session_011JXuKm4NoumuZpm9x44ARF)_