### PR TITLE
interface-vision/t-104 slice 52: introduce kr-btn and codemod exact-match sites

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -653,6 +653,16 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-primary btn-sm rounded-xl;
   }
 
+  /* The most-repeated *unstyled* (no color modifier, no ghost) button shape
+   * in the app (interface-vision t-104 slice 52): the same `sm`/`rounded-xl`
+   * shape as .kr-btn-ghost and .kr-btn-primary, but with neither `btn-ghost`
+   * nor a color utility — `btn btn-sm rounded-xl`, previously hand-rolled in
+   * 20 files (32 occurrences). Named `.kr-btn` (the bare base of the family)
+   * since it carries no modifier beyond the shared size/radius shape. */
+  .kr-btn {
+    @apply btn btn-sm rounded-xl;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/art-generator.vue
+++ b/components/art/art-generator.vue
@@ -111,7 +111,7 @@
                 v-for="preset in presets"
                 :key="preset.id"
                 type="button"
-                class="btn btn-sm rounded-xl"
+                class="kr-btn"
                 :class="preset.id === presetId ? 'btn-primary' : 'btn-outline'"
                 :aria-pressed="preset.id === presetId"
                 :title="preset.blurb"

--- a/components/art/art-studio.vue
+++ b/components/art/art-studio.vue
@@ -6,7 +6,7 @@
     >
       <button
         type="button"
-        class="btn btn-sm rounded-xl"
+        class="kr-btn"
         :class="activeTab === 'generate' ? 'btn-primary' : 'btn-ghost'"
         :aria-pressed="activeTab === 'generate'"
         @click="selectPrimaryTab('generate')"
@@ -17,7 +17,7 @@
 
       <button
         type="button"
-        class="btn btn-sm rounded-xl"
+        class="kr-btn"
         :class="activeTab === 'gallery' ? 'btn-primary' : 'btn-ghost'"
         :aria-pressed="activeTab === 'gallery'"
         @click="selectPrimaryTab('gallery')"

--- a/components/art/art-test.vue
+++ b/components/art/art-test.vue
@@ -924,28 +924,28 @@ onMounted(async () => {
 
               <div class="flex flex-wrap gap-2">
                 <button
-                  class="btn btn-sm rounded-xl"
+                  class="kr-btn"
                   type="button"
                   @click="setSize(768, 768)"
                 >
                   768²
                 </button>
                 <button
-                  class="btn btn-sm rounded-xl"
+                  class="kr-btn"
                   type="button"
                   @click="setSize(1024, 1024)"
                 >
                   1024²
                 </button>
                 <button
-                  class="btn btn-sm rounded-xl"
+                  class="kr-btn"
                   type="button"
                   @click="setSize(1216, 832)"
                 >
                   16:9
                 </button>
                 <button
-                  class="btn btn-sm rounded-xl"
+                  class="kr-btn"
                   type="button"
                   @click="setSize(832, 1216)"
                 >
@@ -1289,14 +1289,14 @@ onMounted(async () => {
             <div v-if="resultImage" class="flex flex-wrap gap-2">
               <button
                 type="button"
-                class="btn btn-sm rounded-xl"
+                class="kr-btn"
                 @click="downloadImage"
               >
                 Download
               </button>
               <button
                 type="button"
-                class="btn btn-sm rounded-xl"
+                class="kr-btn"
                 @click="copyOutput"
               >
                 Copy JSON

--- a/components/art/stylist-manager.vue
+++ b/components/art/stylist-manager.vue
@@ -12,7 +12,7 @@
         v-for="view in visibleViews"
         :key="view.key"
         type="button"
-        class="btn btn-sm rounded-xl"
+        class="kr-btn"
         :class="superkate.activeView === view.key ? 'btn-primary' : 'btn-ghost'"
         @click="superkate.activeView = view.key"
       >

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -376,7 +376,7 @@
           </label>
           <button
             type="button"
-            class="btn btn-sm rounded-xl"
+            class="kr-btn"
             :disabled="isSearchingSource"
             data-testid="brainstorm-source-search"
             @click="runSourceSearch"

--- a/components/characters/character-card.vue
+++ b/components/characters/character-card.vue
@@ -109,7 +109,7 @@
 
         <div v-if="showModeButtons" class="grid grid-cols-2 gap-2 pt-1">
           <button
-            class="btn btn-sm rounded-xl"
+            class="kr-btn"
             :class="
               activeMode === 'chat' ? 'btn-primary text-white' : 'btn-outline'
             "
@@ -121,7 +121,7 @@
           </button>
 
           <button
-            class="btn btn-sm rounded-xl"
+            class="kr-btn"
             :class="
               activeMode === 'adventure' ? 'btn-secondary' : 'btn-outline'
             "

--- a/components/conductor/challenge-center-page.vue
+++ b/components/conductor/challenge-center-page.vue
@@ -79,7 +79,7 @@
                   v-for="option in typeOptions"
                   :key="option.value"
                   type="button"
-                  class="btn btn-sm rounded-xl"
+                  class="kr-btn"
                   :class="
                     typeFilter === option.value
                       ? 'btn-primary shadow-md'

--- a/components/curation/coloring-book-curation.vue
+++ b/components/curation/coloring-book-curation.vue
@@ -43,7 +43,7 @@
       </label>
 
       <button
-        class="btn btn-sm rounded-xl"
+        class="kr-btn"
         type="button"
         :disabled="store.loading"
         @click="refresh"
@@ -226,7 +226,7 @@
               Save prompt
             </button>
             <button
-              class="btn btn-sm rounded-xl"
+              class="kr-btn"
               type="button"
               :disabled="store.requestingAction"
               @click="render(proposal.id, 'color')"
@@ -235,7 +235,7 @@
             </button>
             <button
               v-if="proposal.accepted.color"
-              class="btn btn-sm rounded-xl"
+              class="kr-btn"
               type="button"
               :disabled="store.requestingAction"
               @click="render(proposal.id, 'bw')"

--- a/components/curation/cthulhuquarium-curation.vue
+++ b/components/curation/cthulhuquarium-curation.vue
@@ -31,12 +31,7 @@
         <p>{{ settledCount }} / {{ data?.fish.length || 0 }} designs settled</p>
       </div>
 
-      <button
-        class="btn btn-sm rounded-xl"
-        type="button"
-        :disabled="loading"
-        @click="load"
-      >
+      <button class="kr-btn" type="button" :disabled="loading" @click="load">
         <span v-if="loading" class="loading loading-spinner loading-xs" />
         Refresh
       </button>

--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -11,7 +11,7 @@
           </p>
         </div>
         <button
-          class="btn btn-sm rounded-xl"
+          class="kr-btn"
           type="button"
           :disabled="loading"
           @click="store.load()"

--- a/components/dreams/daily-dream-object-art-workbench.vue
+++ b/components/dreams/daily-dream-object-art-workbench.vue
@@ -7,7 +7,7 @@
             v-for="slot in slots"
             :key="slot.field"
             type="button"
-            class="btn btn-sm rounded-xl"
+            class="kr-btn"
             :class="selectedField === slot.field ? 'btn-secondary' : 'btn-ghost border border-base-300'"
             @click="selectedField = slot.field"
           >

--- a/components/gallery/kr-card-back.vue
+++ b/components/gallery/kr-card-back.vue
@@ -244,7 +244,7 @@
       <button
         v-if="canReview && $slots.reviews"
         type="button"
-        class="btn btn-sm rounded-xl"
+        class="kr-btn"
         :class="reviewsOpen ? 'btn-accent' : 'btn-outline'"
         :aria-expanded="reviewsOpen"
         @click="reviewsOpen = !reviewsOpen"

--- a/components/lora/lora-discover.vue
+++ b/components/lora/lora-discover.vue
@@ -175,7 +175,7 @@
 
     <footer v-if="nextCursor" class="flex shrink-0 justify-center pt-1">
       <button
-        class="btn btn-sm rounded-xl"
+        class="kr-btn"
         type="button"
         :disabled="loading"
         @click="runSearch(false)"

--- a/components/servers/add-server.vue
+++ b/components/servers/add-server.vue
@@ -169,7 +169,7 @@
 
           <div class="flex flex-wrap gap-2 md:col-span-2">
             <button
-              class="btn btn-sm rounded-xl"
+              class="kr-btn"
               type="button"
               @click="showApiKey = !showApiKey"
             >

--- a/components/servers/server-status.vue
+++ b/components/servers/server-status.vue
@@ -17,10 +17,10 @@
         </div>
 
         <div class="flex flex-wrap gap-2">
-          <button class="btn btn-sm rounded-xl" type="button" :disabled="!activeServer" @click="refreshHealth">
+          <button class="kr-btn" type="button" :disabled="!activeServer" @click="refreshHealth">
             Health
           </button>
-          <button class="btn btn-sm rounded-xl" type="button" :disabled="!activeServer" @click="refreshModelStatus">
+          <button class="kr-btn" type="button" :disabled="!activeServer" @click="refreshModelStatus">
             Model
           </button>
           <button

--- a/components/user/account-settings.vue
+++ b/components/user/account-settings.vue
@@ -255,7 +255,7 @@
             v-for="opt in newsletterOptions"
             :key="opt.value"
             type="button"
-            class="btn btn-sm rounded-xl"
+            class="kr-btn"
             :class="
               newsletterFreq === opt.value ? 'btn-primary' : 'btn-outline'
             "

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -263,7 +263,7 @@
               <div class="grid grid-cols-2 gap-2">
                 <button
                   type="button"
-                  class="btn btn-sm rounded-xl"
+                  class="kr-btn"
                   :class="
                     triageStore.decisionFor(resource.id) === 'sfw'
                       ? 'btn-success'
@@ -275,7 +275,7 @@
                 </button>
                 <button
                   type="button"
-                  class="btn btn-sm rounded-xl"
+                  class="kr-btn"
                   :class="
                     triageStore.decisionFor(resource.id) === 'nsfw'
                       ? 'btn-error'

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -17,7 +17,7 @@
           <span class="badge badge-outline">ArtJob-backed resume</span>
           <button
             type="button"
-            class="btn btn-sm rounded-xl"
+            class="kr-btn"
             :disabled="store.loading || store.queueing || !userStore.isAdmin"
             @click="store.load()"
           >

--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -381,7 +381,7 @@
                       v-for="reaction in reactionOptions"
                       :key="reaction.value"
                       type="button"
-                      class="btn btn-sm rounded-xl"
+                      class="kr-btn"
                       :class="
                         submission.myReaction === reaction.value
                           ? reaction.activeClass

--- a/pages/play/challenges/leaderboard.vue
+++ b/pages/play/challenges/leaderboard.vue
@@ -77,7 +77,7 @@
                 v-for="option in typeOptions"
                 :key="option.value"
                 type="button"
-                class="btn btn-sm rounded-xl"
+                class="kr-btn"
                 :class="
                   typeFilter === option.value
                     ? 'btn-primary'
@@ -110,7 +110,7 @@
                 v-for="option in facetOptions"
                 :key="option.value"
                 type="button"
-                class="btn btn-sm rounded-xl"
+                class="kr-btn"
                 :class="
                   facetFilter === option.value
                     ? 'btn-secondary'


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 52: continue the shared kr-btn* primitive family (kind: software)

### What changed / what I produced
- Adds `.kr-btn` (`btn btn-sm rounded-xl`, no color/ghost modifier) to `assets/css/tailwind.css`, mirroring the existing `.kr-btn-ghost*`/`.kr-btn-primary` family — this is the "unstyled" base of the family (no color utility, no `btn-ghost`).
- Codemods all 32 exact-match occurrences of `class="btn btn-sm rounded-xl"` across 20 files to `class="kr-btn"`.
- One touched button (`components/curation/cthulhuquarium-curation.vue`) collapses from a multi-line tag to a single line — a direct prettier consequence of the shorter class string on that exact line, not unrelated reflow.
- Deliberately did NOT run a blanket `prettier --write` across all 20 touched files: several (`art-test.vue`, `scene-animator.vue`, `brainstorm-manager.vue`, `server-status.vue`, `daily-dream-object-art-workbench.vue`, `challenge-center-page.vue`) carry large pre-existing formatting drift unrelated to this change (hundreds to ~2700 lines each); pulling that in as "collateral" would have blown a 32-line codemod up into a 2000+ line diff. Kept the diff scoped to the actual codemod plus the one line whose own reformat was caused by it.

### How I verified
- `npx vue-tsc --noEmit` — clean.
- `npx eslint <touched files>` — one pre-existing `vue/no-mutating-props` error in `daily-dream-object-art-workbench.vue`, confirmed present and unchanged on unmodified `origin/main` via `git stash` comparison (unrelated to this change).
- `npm run test:lint-ratchet` — holds at 332 problems / 24 rules (-60), no rule regressed.
- `npm run test:layout-contract` — holds at the 207-violation baseline, no new violations.
- `npx prettier --check` on touched files — pre-existing drift confirmed unrelated via per-file diff inspection (see above); only the one directly-caused reformat was applied.

### Stakes
reversible

### Flags for Reviewer
- None — bounded, verified slice matching the established `.kr-btn-ghost*`/`.kr-btn-primary` convention.

### Kaizen suggestion
The next slice candidate is `btn btn-outline btn-sm rounded-xl` (21 files per the prior slice's survey) — recorded in the `t-104` roadmap note for whoever picks up slice 53.

### Notes for reviewer
Several files touched here (art-test.vue, scene-animator.vue, brainstorm-manager.vue, server-status.vue, daily-dream-object-art-workbench.vue, challenge-center-page.vue) have substantial pre-existing prettier drift not addressed by this PR — intentionally out of scope, left for a dedicated formatting pass if one is ever wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hYUHnoyhvA15tqdPu4TFs

---
_Generated by [Claude Code](https://claude.ai/code/session_016hYUHnoyhvA15tqdPu4TFs)_