### PR TITLE
fix: stop Character PATCH from wiping pipeline-attached Facets

### DIFF
--- a/server/utils/characterFacetSync.ts
+++ b/server/utils/characterFacetSync.ts
@@ -128,8 +128,10 @@ export async function syncCharacterFacetsInTransaction(
   )
 
   if (!lookupKeys.length) {
+    // Scoped to this function's own rows only -- see the note on the second
+    // deleteMany below for why an unscoped delete here is the bug.
     await tx.characterFacet.deleteMany({
-      where: { characterId: character.id },
+      where: { characterId: character.id, source: 'CHARACTER_MUTATION' },
     })
     return 0
   }
@@ -195,7 +197,27 @@ export async function syncCharacterFacetsInTransaction(
     })
   }
 
-  await tx.characterFacet.deleteMany({ where: { characterId: character.id } })
+  // Scoped to `source: 'CHARACTER_MUTATION'` -- this function's own rows --
+  // not every row the Character has. An unscoped delete here silently erased
+  // Facets attached through PUT /api/characters/:id/facets (source CURATED /
+  // MANUAL, the Daily Dream pipeline's path) on the next unrelated PATCH,
+  // because CHARACTER_FIELD_TAXONOMIES only recognizes Facet vocabulary
+  // written literally into genre/species/class/alignment/gender/personality/
+  // backstory/quirks/role -- ordinary prose in those fields (a character's
+  // `backstory`, say) matches nothing, so `pending` comes back empty and the
+  // deleteMany ran with zero replacements. Observed live 2026-09-03: a prose
+  // repair that PATCHed only `backstory` on Character #3294 (a field this
+  // sync already tracks, but whose sentence contained no literal Facet alias)
+  // wiped its six Daily Dream Facets, though it never touched Facets at all.
+  // `fieldKey` cannot be the scope instead -- `characterFacetFieldKey()`
+  // assigns the *same* fieldKey names to pipeline-sourced Facets, so a
+  // fieldKey-scoped delete (the pattern `syncBotFacetsInTransaction` uses,
+  // safely, only because Bot's fieldKeys are disjoint from any other source)
+  // would still catch pipeline rows here. `source` is the one column that
+  // actually distinguishes what this function wrote from what did not.
+  await tx.characterFacet.deleteMany({
+    where: { characterId: character.id, source: 'CHARACTER_MUTATION' },
+  })
   if (rows.size) {
     await tx.characterFacet.createMany({
       data: Array.from(rows.values()),


### PR DESCRIPTION
## Summary

`syncCharacterFacetsInTransaction` runs on every `PATCH /api/characters/:id`
(and on create), and unconditionally deleted **all** of a Character's
`CharacterFacet` rows before re-deriving assignments purely from literal
Facet-vocabulary matches inside `genre`/`species`/`class`/`alignment`/
`gender`/`personality`/`backstory`/`quirks`/`role` text. Ordinary prose in
those fields matches nothing, so a routine edit (e.g. a `backstory` rewrite)
zeroed `pending` and the unscoped `deleteMany` erased every Facet the
Character had — including ones attached correctly through
`PUT /api/characters/:id/facets` (source `CURATED`/`MANUAL`), which is the
Daily Dream pipeline's own path.

## How this was found

Observed live 2026-09-03 during a scheduled conductor sweep: a prose-repair
`PATCH` that touched only Character #3294's `backstory` field (recomposing
stale card copy back to what the builder would write today) silently dropped
all six of its Daily Dream Facets, confirmed via
`scripts/check_live_facet_coverage.py` before and after the patch. Repaired
live via `apply_daily_dream_facets.py --force`; this PR fixes the root cause
so it can't recur on the next unrelated PATCH.

## Fix

Scope both `deleteMany` calls to `source: 'CHARACTER_MUTATION'`, the tag
this function's own writes already carry, so it only ever manages the rows
it created.

`fieldKey` cannot be the scope instead: `characterFacetFieldKey()` assigns
the *same* fieldKey names to pipeline-sourced Facets, so a fieldKey-scoped
delete (the pattern `syncBotFacetsInTransaction` uses safely, only because
Bot's fieldKeys are disjoint from any other source) would still catch
pipeline rows here. `source` is the one column that actually distinguishes
what this function wrote from what did not.

## Verification

- `vue-tsc --noEmit` clean
- `eslint server/utils/characterFacetSync.ts` clean
- `prettier --check server/utils/characterFacetSync.ts` clean
- `npm run test:facet-catalog` (cutover / canonical-merge / daily-dream-facet
  / curation / selection-route contracts) passes
- `npm run test:model-builder-link-coverage` passes (this file is also read
  by the Model Builder commit path)

Tracked as `conductor/kind-robots/t-093`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqQnKSvhwawmnvbbavG2dK)_