### PR TITLE
Reuse kr-btn base for outline bot action

### DIFF
--- a/components/bots/bot-card.vue
+++ b/components/bots/bot-card.vue
@@ -83,7 +83,7 @@
           </button>
 
           <button
-            class="btn btn-sm btn-outline rounded-xl"
+            class="kr-btn btn-outline"
             type="button"
             @click.stop="selectBot"
           >
@@ -101,7 +101,8 @@
 
           <pre
             class="mt-2 max-h-48 overflow-auto text-xs text-base-content/70"
-            >{{ JSON.stringify(bot, null, 2) }}</pre>
+            >{{ JSON.stringify(bot, null, 2) }}</pre
+          >
         </details>
       </section>
     </reactable-card>


### PR DESCRIPTION
## Summary
- continue interface-vision/t-104's button consistency sweep
- replace the hand-rolled `btn btn-sm btn-outline rounded-xl` Select action in `bot-card.vue` with the existing `.kr-btn` base plus `btn-outline`
- establishes that the surveyed outline family does not need another CSS primitive: `.kr-btn` already owns the shared size/radius and DaisyUI's outline modifier composes cleanly

## Scope
One reachable shared Bot card action only. No behavior, data, schema, route, or deployment changes.

Session: `openai-scheduled-20260903T191417Z-interface-vision-t104-k7q3`