### PR TITLE
fix(storybook): repair export click handlers

### DIFF
--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -54,10 +54,7 @@
               <li>
                 <button
                   type="button"
-                  @click="
-                    downloadStory(undefined, 'markdown')
-                    closeExportMenu()
-                  "
+                  @click="downloadStory(undefined, 'markdown'); closeExportMenu()"
                 >
                   Markdown
                 </button>
@@ -65,10 +62,7 @@
               <li>
                 <button
                   type="button"
-                  @click="
-                    downloadStory(undefined, 'json')
-                    closeExportMenu()
-                  "
+                  @click="downloadStory(undefined, 'json'); closeExportMenu()"
                 >
                   JSON
                 </button>


### PR DESCRIPTION
### Task
storybook/t-010: Polish and upgrade Storybook front-end surface  (kind: software)

### What changed / what I produced
- Fixed the two Storybook Export menu `@click` expressions that caused the production Nuxt/Vite build to fail parsing.
- Preserved both intended actions: download the selected format, then blur/close the export menu.
- Scope is exactly one Vue file and two handler expressions.

### How I verified
- Diagnosed failed `Publish Production Container` run 33798861864 / job 100793073633 from its full GitHub Actions logs.
- Confirmed the build dies at `components/pages/storybook-library-page.vue` with Vue parser `Unexpected token, expected ","` at the multi-statement handler.
- Compared this branch against `main`: 1 file changed, 2 additions / 8 deletions, only the two malformed handlers.
- PR CI must complete green before merge.

### Stakes
reversible

### Flags for Reviewer
- This is a production-image build fix, but merging code does not itself prove Alexandria has deployed the new image. Keep merged/image-published/deployed states separate.

### Kaizen suggestion
Add a required PR check that exercises the same Nuxt production template compilation path used by the container build, so malformed Vue expressions cannot first surface after merge.

### Notes for reviewer
The unrelated Node 20 deprecation, Prisma/OpenSSL, Tailwind/DaisyUI, duplicate-import, and npm-audit warnings in the failed image build were non-fatal; the Vue parser error is the terminating failure.