### PR TITLE
Reuse kr-btn for account verification action

### DIFF
--- a/components/user/account-settings.vue
+++ b/components/user/account-settings.vue
@@ -63,7 +63,7 @@
             <button
               v-if="userEmail && !emailVerified"
               type="button"
-              class="btn btn-outline btn-sm rounded-xl"
+              class="kr-btn btn-outline"
               :disabled="account.isSaving"
               @click="onSendVerification"
             >


### PR DESCRIPTION
## Summary
- continue `interface-vision/t-104`'s outline-button consistency sweep
- replace the Account & Privacy email-verification action's hand-rolled `btn btn-outline btn-sm rounded-xl` shape with the established `kr-btn btn-outline` composition
- preserve behavior, disabled state, loading state, geometry, and outline styling

## Scope
One reachable account-settings action, one class substitution. No API, schema, data, route, or deployment changes.

Session: `openai-scheduled-20260903T211054Z-interface-vision-t104-a7c4`