### PR TITLE
Reuse kr-btn for remaining outline-button family sites

### DIFF
--- a/components/animation/animation-manager.vue
+++ b/components/animation/animation-manager.vue
@@ -24,7 +24,7 @@
       <div class="flex flex-wrap items-center gap-2">
         <NuxtLink
           to="/play/screenfx"
-          class="btn btn-outline btn-sm rounded-xl"
+          class="kr-btn btn-outline"
           title="Toggle effects live on-screen"
         >
           <Icon name="kind-icon:sparkles" class="h-4 w-4" />
@@ -32,7 +32,7 @@
         </NuxtLink>
         <NuxtLink
           to="/conductor"
-          class="btn btn-outline btn-sm rounded-xl"
+          class="kr-btn btn-outline"
           title="Animation development work lives in Conductor"
         >
           <Icon name="kind-icon:scroll" class="h-4 w-4" />

--- a/components/art/forum-art-generation-context.vue
+++ b/components/art/forum-art-generation-context.vue
@@ -149,14 +149,14 @@
 
         <a
           v-if="store.completedArtUrl && store.completedArtId"
-          class="btn btn-outline btn-sm rounded-xl"
+          class="kr-btn btn-outline"
           :href="store.completedArtUrl"
         >
           Open ArtImage #{{ store.completedArtId }}
         </a>
         <a
           v-else-if="store.attachedArt"
-          class="btn btn-outline btn-sm rounded-xl"
+          class="kr-btn btn-outline"
           :href="store.attachedArt.canonicalUrl"
         >
           Open source ArtImage #{{ store.attachedArt.id }}

--- a/components/conductor/challenge-center-page.vue
+++ b/components/conductor/challenge-center-page.vue
@@ -44,7 +44,7 @@
             <div class="flex gap-2">
               <NuxtLink
                 to="/play/challenges/leaderboard"
-                class="btn btn-outline btn-sm rounded-xl"
+                class="kr-btn btn-outline"
               >
                 <Icon name="kind-icon:trophy" class="size-4" />
                 Rankings

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -269,7 +269,7 @@
                   </button>
                   <button
                     type="button"
-                    class="btn btn-outline btn-sm rounded-xl"
+                    class="kr-btn btn-outline"
                     @click="useCuratedChapters"
                   >
                     Play the written chapters instead

--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -462,7 +462,7 @@
               Discard draft
             </button>
             <button
-              class="btn btn-outline btn-sm rounded-xl"
+              class="kr-btn btn-outline"
               type="button"
               :disabled="saving"
               @click="store.resetDraftToSource()"

--- a/components/dreams/dream-narration.vue
+++ b/components/dreams/dream-narration.vue
@@ -33,7 +33,7 @@
 
           <button
             type="button"
-            class="btn btn-outline btn-sm rounded-xl"
+            class="kr-btn btn-outline"
             :disabled="!dreamStore.selectedDreamId"
             @click="editDream"
           >

--- a/components/dreams/dream-pitch-sheet.vue
+++ b/components/dreams/dream-pitch-sheet.vue
@@ -170,7 +170,7 @@
 
         <button
           v-if="activeSheet && allowEdit"
-          class="btn btn-outline btn-sm rounded-xl"
+          class="kr-btn btn-outline"
           type="button"
           @click.stop="emit('edit', activeSheet.id)"
         >

--- a/components/facets/facet-editor.vue
+++ b/components/facets/facet-editor.vue
@@ -101,7 +101,7 @@
       <button
         v-else
         type="button"
-        class="btn btn-outline btn-sm rounded-xl"
+        class="kr-btn btn-outline"
         :disabled="facetStore.saving"
         @click="restore"
       >

--- a/components/gallery/kr-card-back.vue
+++ b/components/gallery/kr-card-back.vue
@@ -256,7 +256,7 @@
       <button
         v-if="canEdit"
         type="button"
-        class="btn btn-outline btn-sm rounded-xl"
+        class="kr-btn btn-outline"
         @click="editing = true"
       >
         <Icon name="kind-icon:edit" class="h-4 w-4" />

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -699,7 +699,7 @@
                 <button
                   v-if="!store.castReady"
                   type="button"
-                  class="btn btn-outline btn-sm rounded-xl"
+                  class="kr-btn btn-outline"
                   @click="activeCard = 'cast'"
                 >
                   <Icon name="mdi:account-multiple-plus" class="h-4 w-4" /> Cast

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -19,7 +19,7 @@
         <div class="flex flex-wrap items-center gap-2">
           <button
             type="button"
-            class="btn btn-outline btn-sm rounded-xl"
+            class="kr-btn btn-outline"
             :disabled="triageStore.isSaving || loading"
             @click="refresh"
           >

--- a/pages/play/aquarium/browse/index.vue
+++ b/pages/play/aquarium/browse/index.vue
@@ -106,7 +106,7 @@
         <div class="flex items-center justify-between gap-3 pt-2">
           <button
             type="button"
-            class="btn btn-outline btn-sm rounded-xl"
+            class="kr-btn btn-outline"
             :disabled="loading || skip <= 0"
             @click="prevPage"
           >
@@ -118,7 +118,7 @@
           </p>
           <button
             type="button"
-            class="btn btn-outline btn-sm rounded-xl"
+            class="kr-btn btn-outline"
             :disabled="loading || skip + tanks.length >= total"
             @click="nextPage"
           >

--- a/pages/play/aquarium/leaderboard/index.vue
+++ b/pages/play/aquarium/leaderboard/index.vue
@@ -105,7 +105,7 @@
         <div class="flex items-center justify-between gap-3 pt-2">
           <button
             type="button"
-            class="btn btn-outline btn-sm rounded-xl"
+            class="kr-btn btn-outline"
             :disabled="loading || skip <= 0"
             @click="prevPage"
           >
@@ -117,7 +117,7 @@
           </p>
           <button
             type="button"
-            class="btn btn-outline btn-sm rounded-xl"
+            class="kr-btn btn-outline"
             :disabled="loading || skip + entries.length >= total"
             @click="nextPage"
           >

--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -10,7 +10,7 @@
         </NuxtLink>
         <NuxtLink
           to="/play/challenges/leaderboard"
-          class="btn btn-outline btn-sm rounded-xl"
+          class="kr-btn btn-outline"
         >
           <Icon name="kind-icon:trophy" class="size-4" />
           Rankings

--- a/pages/play/challenges/leaderboard.vue
+++ b/pages/play/challenges/leaderboard.vue
@@ -10,7 +10,7 @@
         </NuxtLink>
         <button
           type="button"
-          class="btn btn-outline btn-sm rounded-xl"
+          class="kr-btn btn-outline"
           :disabled="loading"
           @click="loadLeaderboard"
         >


### PR DESCRIPTION
## Summary
- continue `interface-vision/t-104`'s outline-button consistency sweep (slice 56)
- replace the remaining hand-rolled `btn btn-outline btn-sm rounded-xl` shape with the established `kr-btn btn-outline` composition across all 19 exact-match sites (15 files)
- preserve behavior, geometry, and outline styling — `.kr-btn` = `btn btn-sm rounded-xl` in `tailwind.css`, so the substitution is class-order-equivalent

## Scope
15 files, 19 class substitutions. No API, schema, data, route, or deployment changes. Near-miss sites with color modifiers or extra utility classes (`user-dashboard.vue`'s error-tinted button, `coloring-book-curation.vue`'s success-outline buttons, `for-you-manager.vue`'s error-outline buttons) are left out of scope, matching this sweep's established convention.

## Verification
- `vue-tsc --noEmit`: clean
- `eslint` on all 15 changed files: 0 new issues (1 pre-existing `vue/no-deprecated-slot-attribute` in `stage-manager.vue`, confirmed present on unmodified `origin/main` via `git stash`)
- `prettier --check`: 4 pre-existing formatting warnings confirmed present on unmodified `origin/main` via `git stash`, none newly introduced
- `npm run test:layout-contract`: holds at the 207-violation baseline, zero new violations
- `npm run test:lint-ratchet`: holds at 332 problems/-60, no rule regressed

Session: `claude-20260903T213838Z-iv-t104-slice56`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtwWdzAdgp9LmeqENoHfpY

---
_Generated by [Claude Code](https://claude.ai/code/session_01KtwWdzAdgp9LmeqENoHfpY)_