### PR TITLE
Reuse kr-btn-primary for Bot card launch action

### DIFF
--- a/components/bots/bot-card.vue
+++ b/components/bots/bot-card.vue
@@ -74,7 +74,7 @@
 
         <div v-if="showLaunchButton" class="grid grid-cols-2 gap-2 pt-1">
           <button
-            class="btn btn-sm btn-primary rounded-xl text-primary-content"
+            class="kr-btn-primary text-primary-content"
             type="button"
             @click.stop="launchBot"
           >


### PR DESCRIPTION
## Summary
- continue `interface-vision/t-104` consistency adoption
- replace the Bot card Chat action's hand-rolled `btn btn-sm btn-primary rounded-xl` geometry with the existing `kr-btn-primary` primitive
- preserve `text-primary-content` and all behavior

## Scope
One class-only substitution in `components/bots/bot-card.vue`. No API, schema, store, data, route, or deployment changes.

Session: `openai-scheduled-20260903T221214Z-interface-vision-t104-k4m7`