### PR TITLE
Reuse kr-btn-primary-md for remaining default-size primary-button sites

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -653,6 +653,16 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-primary btn-sm rounded-xl;
   }
 
+  /* Second-most-repeated filled-button shape (interface-vision t-104 slice 58):
+   * DaisyUI's own default (unmodified) button size — no `btn-sm` utility at
+   * all — with the same `rounded-xl` override as .kr-btn-primary, `btn
+   * btn-primary rounded-xl`, previously hand-rolled in 15 files (17
+   * occurrences). Suffixed `-md` for the default size, mirroring
+   * .kr-btn-ghost-md's identical size-ladder convention on the ghost family. */
+  .kr-btn-primary-md {
+    @apply btn btn-primary rounded-xl;
+  }
+
   /* The most-repeated *unstyled* (no color modifier, no ghost) button shape
    * in the app (interface-vision t-104 slice 52): the same `sm`/`rounded-xl`
    * shape as .kr-btn-ghost and .kr-btn-primary, but with neither `btn-ghost`

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -485,7 +485,7 @@
         </button>
 
         <button
-          class="btn btn-primary rounded-xl"
+          class="kr-btn-primary-md"
           type="button"
           :disabled="botStore.isSaving || !canSave"
           @click="saveBot"

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -495,7 +495,7 @@
         </button>
 
         <button
-          class="btn btn-primary rounded-xl"
+          class="kr-btn-primary-md"
           type="button"
           :disabled="characterStore.isSaving || !canSave"
           @click="saveCharacter"

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -537,7 +537,7 @@
             <button
               v-if="setupStep < setupSteps.length - 1"
               type="button"
-              class="btn btn-primary rounded-xl"
+              class="kr-btn-primary-md"
               :disabled="!canAdvance"
               @click="advanceSetup"
             >
@@ -546,7 +546,7 @@
             <button
               v-else
               type="button"
-              class="btn btn-primary rounded-xl"
+              class="kr-btn-primary-md"
               :disabled="!canBegin || store.isWeaving"
               @click="beginStory"
             >

--- a/components/lora/add-lora.vue
+++ b/components/lora/add-lora.vue
@@ -210,7 +210,7 @@
       </label>
 
       <button
-        class="btn btn-primary rounded-xl"
+        class="kr-btn-primary-md"
         type="submit"
         :disabled="isSaving || !canSubmit"
       >

--- a/components/lora/lora-discover.vue
+++ b/components/lora/lora-discover.vue
@@ -64,7 +64,7 @@
         </select>
 
         <button
-          class="btn btn-primary rounded-xl"
+          class="kr-btn-primary-md"
           type="submit"
           :disabled="loading"
         >

--- a/components/model/add-model.vue
+++ b/components/model/add-model.vue
@@ -158,7 +158,7 @@
       </label>
 
       <button
-        class="btn btn-primary rounded-xl"
+        class="kr-btn-primary-md"
         type="submit"
         :disabled="isSaving || !canSubmit"
       >

--- a/components/rewards/add-reward.vue
+++ b/components/rewards/add-reward.vue
@@ -250,7 +250,7 @@
             </label>
 
             <button
-              class="btn btn-primary rounded-xl"
+              class="kr-btn-primary-md"
               type="button"
               :disabled="isGeneratingArt"
               @click="generateArtImage"

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -179,11 +179,7 @@
             class="textarea textarea-bordered min-h-12 bg-base-200"
           />
 
-          <button
-            class="btn btn-primary rounded-xl"
-            type="button"
-            @click="addIntro"
-          >
+          <button class="kr-btn-primary-md" type="button" @click="addIntro">
             <Icon name="kind-icon:plus" class="h-4 w-4" />
             Add
           </button>
@@ -268,7 +264,7 @@
             </label>
 
             <button
-              class="btn btn-primary rounded-xl"
+              class="kr-btn-primary-md"
               type="button"
               :disabled="isGeneratingArt"
               @click="generateArtImage"

--- a/components/servers/add-checkpoint.vue
+++ b/components/servers/add-checkpoint.vue
@@ -215,7 +215,7 @@
       </label>
 
       <button
-        class="btn btn-primary rounded-xl"
+        class="kr-btn-primary-md"
         type="submit"
         :disabled="isSaving || !canSubmit"
       >

--- a/components/servers/add-server.vue
+++ b/components/servers/add-server.vue
@@ -272,7 +272,7 @@
       </button>
 
       <button
-        class="btn btn-primary rounded-xl"
+        class="kr-btn-primary-md"
         type="submit"
         :disabled="serverStore.isSaving || !form.title || !form.baseUrl"
       >

--- a/components/servers/server-interact.vue
+++ b/components/servers/server-interact.vue
@@ -6,7 +6,7 @@
     >
       <div class="flex flex-wrap justify-center gap-2 lg:justify-end">
         <button
-          class="btn btn-primary rounded-xl"
+          class="kr-btn-primary-md"
           type="button"
           @click="startServerPreset('COMFY')"
         >

--- a/components/user/messenger.vue
+++ b/components/user/messenger.vue
@@ -118,7 +118,7 @@
           />
           <button
             type="submit"
-            class="btn btn-primary rounded-xl"
+            class="kr-btn-primary-md"
             :disabled="convo.isSending || !draft.trim()"
           >
             <span

--- a/components/user/user-manager-directory.vue
+++ b/components/user/user-manager-directory.vue
@@ -209,7 +209,7 @@
         <div class="modal-action">
           <button class="kr-btn-ghost-md" @click="closeCreate">Cancel</button>
           <button
-            class="btn btn-primary rounded-xl"
+            class="kr-btn-primary-md"
             :disabled="store.isSaving || !createForm.username"
             @click="onCreate"
           >
@@ -238,7 +238,7 @@
         <div class="modal-action">
           <button class="kr-btn-ghost-md" @click="closePassword">Cancel</button>
           <button
-            class="btn btn-primary rounded-xl"
+            class="kr-btn-primary-md"
             :disabled="store.isSaving || newPassword.length < 8"
             @click="onSetPassword"
           >

--- a/pages/email-confirmation.vue
+++ b/pages/email-confirmation.vue
@@ -39,7 +39,7 @@
           </div>
 
           <div class="flex flex-wrap justify-center gap-3">
-            <NuxtLink to="/account" class="btn btn-primary rounded-xl">
+            <NuxtLink to="/account" class="kr-btn-primary-md">
               Open account settings
             </NuxtLink>
             <NuxtLink to="/" class="btn btn-outline rounded-xl">


### PR DESCRIPTION
## Summary
- continue `interface-vision/t-104`'s consistency adoption (slice 58)
- add `.kr-btn-primary-md` (`btn btn-primary rounded-xl`) to `assets/css/tailwind.css`, mirroring `.kr-btn-ghost-md`'s identical size-ladder convention on the ghost family (DaisyUI's default size, no `btn-sm`, with the shared `rounded-xl` override)
- replace the remaining hand-rolled `btn btn-primary rounded-xl` shape with `kr-btn-primary-md` across all 17 exact-match sites (15 files)
- preserve behavior and geometry — class-order-equivalent substitution

## Scope
15 files, 17 class substitutions, plus the new primitive definition. No API, schema, store, data, route, or deployment changes. Near-miss sites with extra utility classes (e.g. `btn btn-primary rounded-xl text-white`, 7 occurrences) are left out of scope for a future slice, matching this sweep's established convention.

## Verification
- `vue-tsc --noEmit`: clean
- `eslint` on all 15 changed files + `tailwind.css`: 0 new issues (2 pre-existing errors in `add-bot.vue`/`add-checkpoint.vue`, confirmed present on unmodified `origin/main` via `git stash`)
- `prettier --check`: 8 pre-existing formatting warnings confirmed present on unmodified `origin/main` via `git stash`; `add-scenario.vue`'s collateral reflow (button tag now fits one line) applied via `prettier --write` and re-verified clean
- `npm run test:layout-contract`: holds at the 207-violation baseline, zero new violations
- `npm run test:lint-ratchet`: holds at 332 problems/-60, no rule regressed

Session: `claude-scheduled-20260903T223800Z-iv-t104-slice58`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxU1iRaP6iR35EVScCVCNb

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxU1iRaP6iR35EVScCVCNb)_