### PR TITLE
refactor: reuse kr-btn-primary in server card

### DIFF
--- a/components/servers/server-card.vue
+++ b/components/servers/server-card.vue
@@ -48,7 +48,7 @@
       <div v-if="showUseButtons" class="mt-3 flex flex-wrap gap-2">
         <button
           v-if="isArtServer"
-          class="btn btn-sm btn-primary rounded-xl"
+          class="kr-btn-primary"
           type="button"
           @click="useForArt"
         >


### PR DESCRIPTION
### Conductor
`interface-vision/t-104` slice 59
Session: `openai-scheduled-20260903T231424Z-interface-vision-t104-k6p9`

### What changed
- Replace the exact hand-rolled `btn btn-sm btn-primary rounded-xl` shape on Server Card's **Use for Art** action with the established `kr-btn-primary` primitive.
- Leave the adjacent `btn-secondary` action unchanged because it is a different visual primitive.

### Scope
One template class substitution in `components/servers/server-card.vue`. No behavior, API, schema, data, route, or deployment changes.

### Verification
Conductor review transition was processed successfully before PR creation. Relying on the repository's exact-head CI fleet for type/contract/layout verification before merge.