### PR TITLE
Reuse kr-btn-primary-plain for remaining sm/no-radius primary-button sites

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -663,6 +663,16 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-primary rounded-xl;
   }
 
+  /* Third filled-button shape (interface-vision t-104 slice 60): the same
+   * `sm` size as .kr-btn-primary, but with no `rounded-xl` override, so it
+   * renders at DaisyUI's own default button radius — `btn btn-primary
+   * btn-sm`, previously hand-rolled in 16 files (19 occurrences). Suffixed
+   * `-plain` for the dropped radius override, mirroring
+   * .kr-btn-ghost-plain's identical naming on the ghost family. */
+  .kr-btn-primary-plain {
+    @apply btn btn-primary btn-sm;
+  }
+
   /* The most-repeated *unstyled* (no color modifier, no ghost) button shape
    * in the app (interface-vision t-104 slice 52): the same `sm`/`rounded-xl`
    * shape as .kr-btn-ghost and .kr-btn-primary, but with neither `btn-ghost`

--- a/components/art/build-bench.vue
+++ b/components/art/build-bench.vue
@@ -16,7 +16,7 @@
         </div>
       </div>
       <div class="flex flex-wrap items-center gap-2">
-        <button class="btn btn-primary btn-sm" :disabled="running" @click="store.runBoth">
+        <button class="kr-btn-primary-plain" :disabled="running" @click="store.runBoth">
           <span v-if="running" class="loading loading-spinner loading-xs" />
           Run both
         </button>

--- a/components/art/stylist-calculator.vue
+++ b/components/art/stylist-calculator.vue
@@ -111,7 +111,7 @@
 
     <button
       type="button"
-      class="btn btn-primary btn-sm"
+      class="kr-btn-primary-plain"
       :disabled="!canSave"
       @click="save"
     >

--- a/components/art/stylist-client-gallery.vue
+++ b/components/art/stylist-client-gallery.vue
@@ -56,7 +56,7 @@
         />
       </label>
       <label
-        class="btn btn-primary btn-sm"
+        class="kr-btn-primary-plain"
         :class="{ 'btn-disabled': uploading }"
       >
         <span v-if="uploading" class="loading loading-spinner loading-xs" />

--- a/components/art/stylist-clients.vue
+++ b/components/art/stylist-clients.vue
@@ -16,7 +16,7 @@
         <span class="text-xs font-black">Email (optional)</span>
         <input v-model="email" type="email" placeholder="For receipt prefill" class="input input-sm input-bordered w-full" />
       </label>
-      <button type="submit" class="btn btn-primary btn-sm" :disabled="!name.trim()">
+      <button type="submit" class="kr-btn-primary-plain" :disabled="!name.trim()">
         {{ editingId ? 'Update' : 'Add client' }}
       </button>
       <button v-if="editingId" type="button" class="kr-btn-ghost-plain" @click="resetForm">Cancel</button>

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -108,7 +108,7 @@
         <!-- eslint-disable-next-line vuejs-accessibility/media-has-caption -->
         <video ref="videoEl" autoplay playsinline class="max-h-64 w-full rounded-lg bg-black object-contain" />
         <div class="flex gap-2">
-          <button type="button" class="btn btn-primary btn-sm" @click="capturePhoto">
+          <button type="button" class="kr-btn-primary-plain" @click="capturePhoto">
             <Icon name="kind-icon:camera" class="h-4 w-4" /> Capture
           </button>
           <button type="button" class="kr-btn-ghost-plain" @click="closeCamera">Cancel</button>
@@ -269,7 +269,7 @@
     <!-- Action -->
     <button
       type="button"
-      class="btn btn-primary btn-sm"
+      class="kr-btn-primary-plain"
       :disabled="!canGenerate"
       @click="submit"
     >

--- a/components/conductor/ruler-hooked-page.vue
+++ b/components/conductor/ruler-hooked-page.vue
@@ -22,7 +22,7 @@
           <div class="flex gap-2">
             <button
               type="button"
-              class="btn btn-primary btn-sm"
+              class="kr-btn-primary-plain"
               @click="pwa?.install()"
             >
               Install

--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -970,7 +970,7 @@
             </button>
             <button
               type="button"
-              class="btn btn-primary btn-sm"
+              class="kr-btn-primary-plain"
               :disabled="!canConfirmBreed"
               @click="onConfirmBreed"
             >

--- a/components/dreams/dream-inspire-button.vue
+++ b/components/dreams/dream-inspire-button.vue
@@ -22,7 +22,7 @@
             Cancel
           </button>
           <button
-            class="btn btn-primary btn-sm"
+            class="kr-btn-primary-plain"
             :disabled="!selectedServerId"
             @click="confirmServer"
           >

--- a/components/pages/appmaker-page.vue
+++ b/components/pages/appmaker-page.vue
@@ -75,7 +75,7 @@
           </label>
           <div class="flex items-center gap-3">
             <button
-              class="btn btn-primary btn-sm"
+              class="kr-btn-primary-plain"
               :disabled="creating || !form.title.trim() || !!slugError"
               @click="createApp"
             >

--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -96,7 +96,7 @@
           class="input input-bordered input-sm flex-1"
           placeholder="Serendipity, turn butterflies on"
         />
-        <button class="btn btn-sm btn-primary" type="submit">Send</button>
+        <button class="kr-btn-primary-plain" type="submit">Send</button>
       </form>
     </div>
 

--- a/components/ruler-hooked/ruler-hooked-cosmetics.vue
+++ b/components/ruler-hooked/ruler-hooked-cosmetics.vue
@@ -16,7 +16,7 @@
       <div class="flex justify-end gap-2">
         <button
           type="button"
-          class="btn btn-primary btn-sm"
+          class="kr-btn-primary-plain"
           :disabled="saving"
           @click="save"
         >

--- a/components/ruler-hooked/ruler-hooked-slots.vue
+++ b/components/ruler-hooked/ruler-hooked-slots.vue
@@ -41,7 +41,7 @@
             <option v-for="h in honorificSuggestions" :key="h" :value="h" />
           </datalist>
         </label>
-        <button type="button" class="btn btn-primary btn-sm" :disabled="!rulerName.trim()" @click="start">
+        <button type="button" class="kr-btn-primary-plain" :disabled="!rulerName.trim()" @click="start">
           New reign
         </button>
       </div>

--- a/components/ui/ui-gallery.vue
+++ b/components/ui/ui-gallery.vue
@@ -260,7 +260,7 @@
           </div>
           <div class="flex flex-wrap items-center gap-2">
             <button class="btn btn-primary btn-xs">xs</button>
-            <button class="btn btn-primary btn-sm">sm</button>
+            <button class="kr-btn-primary-plain">sm</button>
             <button class="btn btn-primary">md</button>
             <button class="btn btn-primary btn-lg">lg</button>
             <button class="btn btn-primary">
@@ -399,7 +399,7 @@
                 A dream with an orderable wishlist of desired features.
               </p>
               <div class="card-actions justify-end">
-                <button class="btn btn-primary btn-sm">Open</button>
+                <button class="kr-btn-primary-plain">Open</button>
               </div>
             </div>
           </div>

--- a/components/user/forum-thread.vue
+++ b/components/user/forum-thread.vue
@@ -32,7 +32,7 @@
         </h2>
         <button
           v-if="userStore.isLoggedIn"
-          class="btn btn-sm btn-primary"
+          class="kr-btn-primary-plain"
           @click="startNewThread(channel.slug)"
         >
           ➕ New Post
@@ -145,7 +145,7 @@
               placeholder="Write a reply…"
             />
             <button
-              class="btn btn-sm btn-primary"
+              class="kr-btn-primary-plain"
               :disabled="posting || !replyDrafts[thread.id]?.trim()"
               @click="postReply(thread.id)"
             >

--- a/components/user/friend-gallery.vue
+++ b/components/user/friend-gallery.vue
@@ -63,7 +63,7 @@
 
             <div class="mt-3 flex gap-2">
               <button
-                class="btn btn-primary btn-sm"
+                class="kr-btn-primary-plain"
                 type="button"
                 @click="toggleCollection(Number(item.id))"
               >

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -158,7 +158,7 @@
                   <p class="font-semibold">Not in the catalog yet.</p>
                   <p class="text-xs opacity-60">Create “{{ searchQuery.trim() }}” as a requested learning card.</p>
                 </div>
-                <button class="btn btn-primary btn-sm" type="button" :disabled="requestingWord" @click="requestCurrentWord">
+                <button class="kr-btn-primary-plain" type="button" :disabled="requestingWord" @click="requestCurrentWord">
                   <span v-if="requestingWord" class="loading loading-spinner loading-xs" />
                   {{ requestingWord ? 'Creating…' : 'Create requested card' }}
                 </button>


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 60: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Added `.kr-btn-primary-plain` to `assets/css/tailwind.css` (`btn btn-primary btn-sm`, no `rounded-xl` override), mirroring `.kr-btn-ghost-plain`'s identical naming convention on the ghost family.
- Migrated all 19 exact-match occurrences (16 files, both `btn btn-primary btn-sm` and `btn btn-sm btn-primary` orderings) of this hand-rolled shape to the new primitive.

### How I verified
- `npm run test` (vue-tsc typecheck via nuxi prepare): clean.
- `eslint` on all changed files: 0 new issues (3 pre-existing `@typescript-eslint/no-dynamic-delete` errors in `stylist-client-gallery.vue`/`stylist-clients.vue` confirmed present on unmodified `origin/main` via `git stash`).
- `prettier --check` on all changed files: 10 pre-existing warnings, all confirmed via `git stash` against `origin/main` — left untouched rather than reflowing unrelated formatting.
- `test:layout-contract`: holds at the 207-violation baseline.
- `test:lint-ratchet`: holds at 332/-60, no rule regressed.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Next `t-104` slice: survey the next-largest remaining hand-rolled shapes — `btn btn-secondary btn-sm rounded-xl` (11 files) and `btn btn-sm` bare (10 files) are the current leaders once this slice's shape is excluded.

### Notes for reviewer
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjNwyyYSA8FofHB32Ac8hz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjNwyyYSA8FofHB32Ac8hz)_