### PR TITLE
Reuse kr-btn-secondary for exact-match secondary-button sites

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -673,6 +673,15 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-primary btn-sm;
   }
 
+  /* The most-repeated *secondary*-color button shape (interface-vision t-104
+   * slice 61): the same `sm`/`rounded-xl` shape as .kr-btn-primary, filled
+   * with the secondary color instead — `btn btn-secondary btn-sm rounded-xl`,
+   * previously hand-rolled in 11 files (12 occurrences). Named to mirror
+   * .kr-btn-primary's own naming on the color-filled branch of the family. */
+  .kr-btn-secondary {
+    @apply btn btn-secondary btn-sm rounded-xl;
+  }
+
   /* The most-repeated *unstyled* (no color modifier, no ghost) button shape
    * in the app (interface-vision t-104 slice 52): the same `sm`/`rounded-xl`
    * shape as .kr-btn-ghost and .kr-btn-primary, but with neither `btn-ghost`

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -35,7 +35,7 @@
             </div>
 
             <button
-              class="btn btn-sm btn-secondary rounded-xl"
+              class="kr-btn-secondary"
               type="button"
               @click="seedBot"
             >

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -78,11 +78,7 @@
           </div>
 
           <div class="flex shrink-0 flex-col gap-2">
-            <button
-              class="btn btn-sm btn-secondary rounded-xl"
-              type="button"
-              @click="newChat"
-            >
+            <button class="kr-btn-secondary" type="button" @click="newChat">
               New Chat
             </button>
 

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -289,7 +289,7 @@
 
               <button
                 v-if="canEditSelected"
-                class="btn btn-secondary btn-sm rounded-xl"
+                class="kr-btn-secondary"
                 type="button"
                 @click="startEditingSelectedBot"
               >

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -35,7 +35,7 @@
             </div>
 
             <button
-              class="btn btn-sm btn-secondary rounded-xl"
+              class="kr-btn-secondary"
               type="button"
               @click="seedCharacter"
             >
@@ -289,7 +289,7 @@
           </div>
 
           <button
-            class="btn btn-sm btn-secondary rounded-xl"
+            class="kr-btn-secondary"
             type="button"
             @click="characterStore.rerollCharacterStats"
           >

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -176,7 +176,7 @@
 
               <button
                 v-if="canEditSelected"
-                class="btn btn-secondary btn-sm rounded-xl"
+                class="kr-btn-secondary"
                 type="button"
                 @click="startEditingSelectedCharacter"
               >

--- a/components/dreams/daily-dream-generator.vue
+++ b/components/dreams/daily-dream-generator.vue
@@ -58,7 +58,7 @@
         </p>
         <button
           type="button"
-          class="btn btn-secondary btn-sm rounded-xl"
+          class="kr-btn-secondary"
           :disabled="loading"
           @click="createDailyDream"
         >

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -339,7 +339,7 @@
 
             <button
               v-if="canEditSelected"
-              class="btn btn-secondary btn-sm rounded-xl"
+              class="kr-btn-secondary"
               type="button"
               @click="startEditingSelectedDream"
             >

--- a/components/facets/facet-interact.vue
+++ b/components/facets/facet-interact.vue
@@ -13,11 +13,7 @@
 <template>
   <div v-if="!selectedFacet" class="flex h-full min-h-0 flex-col gap-2">
     <div class="flex shrink-0 justify-end">
-      <button
-        type="button"
-        class="btn btn-secondary btn-sm rounded-xl"
-        @click="goToCreateFacet"
-      >
+      <button type="button" class="kr-btn-secondary" @click="goToCreateFacet">
         <Icon name="kind-icon:plus" class="size-3.5" />
         New Facet
       </button>

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -226,7 +226,7 @@
 
             <button
               v-if="canEditSelected"
-              class="btn btn-secondary btn-sm rounded-xl"
+              class="kr-btn-secondary"
               type="button"
               @click="startEditingReward"
             >

--- a/components/servers/server-card.vue
+++ b/components/servers/server-card.vue
@@ -57,7 +57,7 @@
 
         <button
           v-if="isTextServer"
-          class="btn btn-sm btn-secondary rounded-xl"
+          class="kr-btn-secondary"
           type="button"
           @click="useForText"
         >

--- a/components/wonderlab/reaction-card.vue
+++ b/components/wonderlab/reaction-card.vue
@@ -151,7 +151,7 @@
         <button
           v-for="platform in sharePlatforms"
           :key="platform.key"
-          class="btn btn-sm btn-secondary rounded-xl"
+          class="kr-btn-secondary"
           type="button"
           @click="share(platform.key)"
         >


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 61: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Added `.kr-btn-secondary` to `assets/css/tailwind.css` (`btn btn-secondary btn-sm rounded-xl`), mirroring `.kr-btn-primary`'s naming on the color-filled branch of the family.
- Migrated all 12 exact-match occurrences (11 files, both `btn btn-secondary btn-sm rounded-xl` and `btn btn-sm btn-secondary rounded-xl` orderings) of this hand-rolled shape to the new primitive.

### How I verified
- `npm run test` (vue-tsc typecheck via nuxi prepare): clean.
- `eslint` on all changed files: 0 new issues (5 pre-existing errors across `add-bot.vue`/`character-gallery.vue`/`dream-gallery.vue` confirmed present on unmodified `origin/main` via `git stash`).
- `prettier --check` on all changed files: 5 pre-existing warnings, all confirmed via `git stash` against `origin/main`. `bot-chat.vue` and `facet-interact.vue` picked up incidental reflow from the shorter class attribute — applied `prettier --write` and reverified clean.
- `test:layout-contract`: holds at the 207-violation baseline.
- `test:lint-ratchet`: holds at 332/-60, no rule regressed.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Next `t-104` slice: survey the next-largest remaining hand-rolled shapes — bare `btn btn-sm` (10 files) and `btn btn-primary btn-sm rounded-2xl` (9 files) are the current leaders once this slice's shape is excluded.

### Notes for reviewer
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjNwyyYSA8FofHB32Ac8hz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjNwyyYSA8FofHB32Ac8hz)_