### PR TITLE
refactor: introduce kr-btn-plain, migrate 11 exact-match sites

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -692,6 +692,15 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-sm rounded-xl;
   }
 
+  /* Same bare (no color modifier, no ghost) `sm` button as .kr-btn, but with
+   * no `rounded-xl` override, so it renders at DaisyUI's own default button
+   * radius instead — `btn btn-sm`, previously hand-rolled in 10 files (11
+   * occurrences). Named for the dropped radius override, matching the
+   * `-plain` convention already used on the ghost and primary families. */
+  .kr-btn-plain {
+    @apply btn btn-sm;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/build-bench.vue
+++ b/components/art/build-bench.vue
@@ -183,7 +183,7 @@
         placeholder="Notes on this matchup (why the winner won)…"
         class="input input-bordered input-sm flex-1"
       />
-      <button class="btn btn-sm" @click="store.saveMatchup">Save matchup</button>
+      <button class="kr-btn-plain" @click="store.saveMatchup">Save matchup</button>
     </div>
 
     <!-- saved matchups -->

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -658,7 +658,7 @@
         v-for="(batch, index) in batches"
         :key="batch.id"
         type="button"
-        class="btn btn-sm"
+        class="kr-btn-plain"
         :class="batch.id === activeBatchId ? 'btn-primary' : 'btn-ghost'"
         :disabled="isGenerating"
         @click="setActiveBatch(batch.id)"

--- a/components/pages/appmaker-page.vue
+++ b/components/pages/appmaker-page.vue
@@ -19,7 +19,7 @@
         </div>
       </div>
       <div class="flex items-center gap-2">
-        <button class="btn btn-sm" :disabled="loading" @click="refresh">
+        <button class="kr-btn-plain" :disabled="loading" @click="refresh">
           {{ loading ? 'Refreshing…' : 'Refresh' }}
         </button>
         <button

--- a/components/pages/mermaids-page.vue
+++ b/components/pages/mermaids-page.vue
@@ -37,7 +37,7 @@
         <span class="flex-1">{{ lastError }}</span>
         <button
           type="button"
-          class="btn btn-sm"
+          class="kr-btn-plain"
           @click="mermaidsStore.loadDraft(true)"
         >
           Retry load

--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -42,7 +42,7 @@
           {{ voice.connected ? 'Relay connected' : 'Relay offline' }}
         </span>
         <button
-          class="btn btn-sm"
+          class="kr-btn-plain"
           :class="voice.polling ? 'btn-warning' : 'btn-primary'"
           type="button"
           @click="toggleConnection"

--- a/components/ui/ui-gallery.vue
+++ b/components/ui/ui-gallery.vue
@@ -410,7 +410,7 @@
                 Uses primary as the surface with primary-content text.
               </p>
               <div class="card-actions justify-end">
-                <button class="btn btn-sm">Act</button>
+                <button class="kr-btn-plain">Act</button>
               </div>
             </div>
           </div>

--- a/components/user/forum-thread.vue
+++ b/components/user/forum-thread.vue
@@ -9,7 +9,7 @@
       <button
         v-for="channel in channels"
         :key="channel.slug"
-        class="btn btn-sm"
+        class="kr-btn-plain"
         :class="{
           'btn-accent': visibleChannels.includes(channel.slug),
           'btn-outline': !visibleChannels.includes(channel.slug),

--- a/pages/music-mentor.vue
+++ b/pages/music-mentor.vue
@@ -68,7 +68,7 @@
             v-for="opt in DIMENSIONS"
             :key="opt.value"
             type="button"
-            class="btn btn-sm"
+            class="kr-btn-plain"
             :class="selected.includes(opt.value) ? 'btn-accent' : 'btn-outline'"
             @click="toggle(opt.value)"
           >

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -54,7 +54,7 @@
 
       <div v-if="store.error" class="alert alert-error text-sm" role="alert">
         <span>{{ store.error }}</span>
-        <button class="btn btn-sm" type="button" @click="store.loadCatalog()">Retry</button>
+        <button class="kr-btn-plain" type="button" @click="store.loadCatalog()">Retry</button>
       </div>
 
       <div v-if="loading && !initialized" class="flex min-h-64 items-center justify-center">

--- a/pages/play/video-generator.vue
+++ b/pages/play/video-generator.vue
@@ -20,7 +20,7 @@
             v-for="opt in engines"
             :key="opt.value"
             type="button"
-            class="btn btn-sm"
+            class="kr-btn-plain"
             :class="engine === opt.value ? 'btn-accent' : 'btn-outline'"
             @click="selectEngine(opt.value)"
           >
@@ -206,7 +206,7 @@
             v-for="opt in outputFormats"
             :key="opt.value"
             type="button"
-            class="btn btn-sm"
+            class="kr-btn-plain"
             :class="outputFormat === opt.value ? 'btn-accent' : 'btn-outline'"
             @click="outputFormat = opt.value"
           >


### PR DESCRIPTION
Adds `.kr-btn-plain` (`btn btn-sm`, no `rounded-xl` override) mirroring the `.kr-btn-ghost-plain` / `.kr-btn-primary-plain` naming convention already established on the button-primitive family, and migrates all 10 files (11 occurrences) that hand-rolled the exact `class="btn btn-sm"` shape to it.

Part of interface-vision/t-104 (Conductor's recurring front-end consistency umbrella), slice 62.

### Verification
- `vue-tsc --noEmit` clean
- `eslint` — 0 new issues on all changed files
- `prettier --check` — same 6 pre-existing warnings as unmodified `origin/main` (git-stash-confirmed), not introduced by this change
- `npm run test:layout-contract` — holds at the 207-violation baseline
- `npm run test:lint-ratchet` — holds at 332/-60, no rule regressed

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LimD2uHc2UXq9yfYp3TLim

---
_Generated by [Claude Code](https://claude.ai/code/session_01LimD2uHc2UXq9yfYp3TLim)_