### PR TITLE
refactor: introduce kr-btn-secondary-md, migrate 11 exact-match sites

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -682,6 +682,16 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-secondary btn-sm rounded-xl;
   }
 
+  /* DaisyUI's own default (unmodified) button size on the secondary-color
+   * branch — no `btn-sm` utility at all — with the same `rounded-xl`
+   * override as .kr-btn-secondary, `btn btn-secondary rounded-xl`,
+   * previously hand-rolled in 6 files (11 occurrences). Suffixed `-md` for
+   * the default size, mirroring .kr-btn-primary-md's identical naming on
+   * the primary-color branch of the family. */
+  .kr-btn-secondary-md {
+    @apply btn btn-secondary rounded-xl;
+  }
+
   /* The most-repeated *unstyled* (no color modifier, no ghost) button shape
    * in the app (interface-vision t-104 slice 52): the same `sm`/`rounded-xl`
    * shape as .kr-btn-ghost and .kr-btn-primary, but with neither `btn-ghost`

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -195,7 +195,7 @@
             </div>
 
             <button
-              class="btn btn-secondary rounded-xl"
+              class="kr-btn-secondary-md"
               type="button"
               @click="useRandomArtImage"
             >
@@ -468,7 +468,7 @@
 
         <button
           v-if="mode === 'edit'"
-          class="btn btn-secondary rounded-xl"
+          class="kr-btn-secondary-md"
           type="button"
           @click="resetFromSelected"
         >
@@ -477,7 +477,7 @@
 
         <button
           v-else
-          class="btn btn-secondary rounded-xl"
+          class="kr-btn-secondary-md"
           type="button"
           @click="resetForAdd"
         >

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -187,7 +187,7 @@
             </button>
 
             <button
-              class="btn btn-secondary rounded-xl"
+              class="kr-btn-secondary-md"
               type="button"
               @click="useRandomArtImage"
             >
@@ -487,7 +487,7 @@
         </button>
 
         <button
-          class="btn btn-secondary rounded-xl"
+          class="kr-btn-secondary-md"
           type="button"
           @click="mode === 'edit' ? resetFromSelected() : resetForAdd()"
         >

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -326,7 +326,7 @@
               </button>
 
               <button
-                class="btn btn-secondary rounded-xl"
+                class="kr-btn-secondary-md"
                 type="button"
                 :disabled="!characterStore.selectedCharacter || isSendingChat"
                 @click="seedGettingToKnowYouQuestion"
@@ -385,7 +385,7 @@
 
             <div class="mt-3 flex flex-col gap-2 sm:flex-row sm:justify-end">
               <button
-                class="btn btn-secondary rounded-xl"
+                class="kr-btn-secondary-md"
                 type="button"
                 @click="buildAdventurePrompt"
               >

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -218,7 +218,7 @@
               </button>
 
               <button
-                class="btn btn-secondary rounded-xl"
+                class="kr-btn-secondary-md"
                 type="button"
                 :disabled="!characterStore.selectedCharacter || isSendingChat"
                 @click="seedGettingToKnowYouQuestion"
@@ -277,7 +277,7 @@
 
             <div class="mt-3 flex flex-col gap-2 sm:flex-row sm:justify-end">
               <button
-                class="btn btn-secondary rounded-xl"
+                class="kr-btn-secondary-md"
                 type="button"
                 @click="buildAdventurePrompt"
               >

--- a/components/screenfx/animation-selector.vue
+++ b/components/screenfx/animation-selector.vue
@@ -52,7 +52,7 @@
 
       <div class="flex items-end gap-2">
         <button
-          class="btn btn-secondary rounded-xl"
+          class="kr-btn-secondary-md"
           type="button"
           @click="preview"
         >

--- a/components/servers/server-interact.vue
+++ b/components/servers/server-interact.vue
@@ -13,7 +13,7 @@
           Comfy
         </button>
         <button
-          class="btn btn-secondary rounded-xl"
+          class="kr-btn-secondary-md"
           type="button"
           @click="startServerPreset('A1111')"
         >


### PR DESCRIPTION
Adds `.kr-btn-secondary-md` (`btn btn-secondary rounded-xl`, DaisyUI's own default size) mirroring `.kr-btn-primary-md`'s naming convention on the secondary-color branch of the button-primitive family, and migrates all 6 files (11 occurrences) that hand-rolled the exact `class="btn btn-secondary rounded-xl"` shape to it.

Part of interface-vision/t-104 (Conductor's recurring front-end consistency umbrella), slice 63.

### Verification
- `vue-tsc --noEmit` clean
- `eslint` — 0 new issues (2 pre-existing, git-stash-confirmed against unmodified `origin/main`)
- `prettier --check` — same 3 pre-existing warnings as unmodified `origin/main` (git-stash-confirmed), not introduced by this change
- `npm run test:layout-contract` — holds at the 207-violation baseline
- `npm run test:lint-ratchet` — holds at 332/-60, no rule regressed

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LimD2uHc2UXq9yfYp3TLim

---
_Generated by [Claude Code](https://claude.ai/code/session_01LimD2uHc2UXq9yfYp3TLim)_