### PR TITLE
refactor: introduce kr-btn-ghost-circle-xs, migrate 12 exact-match sites

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -711,6 +711,18 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-sm;
   }
 
+  /* The most-repeated *icon* button shape in the app (interface-vision t-104
+   * slice 64): a small circular ghost button used for close/dismiss/icon-only
+   * controls — `btn btn-ghost btn-xs btn-circle`, previously hand-rolled in
+   * 5 files (12 occurrences, split across two class-order variants:
+   * `btn btn-ghost btn-xs btn-circle` and `btn btn-circle btn-ghost btn-xs`).
+   * Named `.kr-btn-ghost-circle-xs` (color-shape-size) to add the `btn-circle`
+   * shape modifier as its own dimension alongside the existing color/size/
+   * radius axes, rather than overloading an existing suffix. */
+  .kr-btn-ghost-circle-xs {
+    @apply btn btn-ghost btn-xs btn-circle;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/art-facet-selector.vue
+++ b/components/art/art-facet-selector.vue
@@ -129,7 +129,7 @@
             </button>
             <button
               type="button"
-              class="btn btn-ghost btn-xs btn-circle"
+              class="kr-btn-ghost-circle-xs"
               :disabled="selectedSet.has(facet.id)"
               aria-label="Add Facet"
               @click="addFacet(facet.id)"

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -340,7 +340,7 @@
             </button>
             <button
               type="button"
-              class="btn btn-circle btn-ghost btn-xs"
+              class="kr-btn-ghost-circle-xs"
               title="Dismiss"
               @click="stylist.dismissJob(job.id)"
             >

--- a/components/conductor/project-detail.vue
+++ b/components/conductor/project-detail.vue
@@ -20,7 +20,7 @@
         <span class="mx-0.5 h-3.5 w-px shrink-0 bg-base-content/10" />
         <button
           type="button"
-          class="btn btn-circle btn-ghost btn-xs"
+          class="kr-btn-ghost-circle-xs"
           :class="
             linkedProject.isPublic ? 'text-success' : 'text-base-content/35'
           "
@@ -42,7 +42,7 @@
         </button>
         <button
           type="button"
-          class="btn btn-circle btn-ghost btn-xs"
+          class="kr-btn-ghost-circle-xs"
           :class="
             linkedProject.isMature ? 'text-warning' : 'text-base-content/35'
           "
@@ -57,7 +57,7 @@
         </button>
         <button
           type="button"
-          class="btn btn-circle btn-ghost btn-xs"
+          class="kr-btn-ghost-circle-xs"
           :class="
             linkedProject.allowReviews ? 'text-success' : 'text-base-content/35'
           "

--- a/components/navigation/workspace-narrator.vue
+++ b/components/navigation/workspace-narrator.vue
@@ -46,7 +46,7 @@
                   <div class="flex shrink-0 gap-1">
                     <button
                       type="button"
-                      class="btn btn-ghost btn-xs btn-circle"
+                      class="kr-btn-ghost-circle-xs"
                       :class="pinOpen ? 'text-primary' : ''"
                       :title="
                         pinOpen ? 'Narrator pinned open' : 'Pin narrator open'
@@ -58,7 +58,7 @@
 
                     <button
                       type="button"
-                      class="btn btn-ghost btn-xs btn-circle"
+                      class="kr-btn-ghost-circle-xs"
                       aria-label="Close narrator"
                       @click="closeNarrator"
                     >
@@ -222,7 +222,7 @@
                   <div class="flex shrink-0 gap-1">
                     <button
                       type="button"
-                      class="btn btn-ghost btn-xs btn-circle"
+                      class="kr-btn-ghost-circle-xs"
                       :class="showTopics ? 'text-primary' : ''"
                       aria-label="Toggle narrator topics"
                       @click="showTopics = !showTopics"
@@ -232,7 +232,7 @@
 
                     <button
                       type="button"
-                      class="btn btn-ghost btn-xs btn-circle"
+                      class="kr-btn-ghost-circle-xs"
                       aria-label="Return to narrator portrait"
                       @click="closeChatFace"
                     >

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -63,7 +63,7 @@
           <span class="mx-0.5 h-3.5 w-px shrink-0 bg-base-content/10" />
           <button
             type="button"
-            class="btn btn-circle btn-ghost btn-xs"
+            class="kr-btn-ghost-circle-xs"
             :class="linkedProject.isPublic ? 'text-success' : 'text-base-content/35'"
             :title="linkedProject.isPublic ? 'Public project' : 'Private project'"
             :aria-label="linkedProject.isPublic ? 'Make project private' : 'Make project public'"
@@ -77,7 +77,7 @@
           </button>
           <button
             type="button"
-            class="btn btn-circle btn-ghost btn-xs"
+            class="kr-btn-ghost-circle-xs"
             :class="linkedProject.isMature ? 'text-warning' : 'text-base-content/35'"
             :title="linkedProject.isMature ? 'Mature content' : 'Safe content'"
             :aria-label="linkedProject.isMature ? 'Mark project safe' : 'Mark project mature'"
@@ -88,7 +88,7 @@
           </button>
           <button
             type="button"
-            class="btn btn-circle btn-ghost btn-xs"
+            class="kr-btn-ghost-circle-xs"
             :class="linkedProject.allowReviews ? 'text-success' : 'text-base-content/35'"
             :title="linkedProject.allowReviews ? 'Reviews on' : 'Reviews off'"
             :aria-label="linkedProject.allowReviews ? 'Turn reviews off' : 'Turn reviews on'"


### PR DESCRIPTION
Adds `.kr-btn-ghost-circle-xs` (`btn btn-ghost btn-xs btn-circle`) mirroring the established `.kr-btn-*` naming convention, and migrates all 5 files (12 occurrences, across both class-order variants — `btn btn-ghost btn-xs btn-circle` and `btn btn-circle btn-ghost btn-xs`) that hand-rolled the exact small-circular-ghost icon-button shape to it.

Part of interface-vision/t-104 (Conductor's recurring front-end consistency umbrella), slice 64.

### Verification
- `vue-tsc --noEmit` clean
- `eslint` — 0 new issues (1 pre-existing empty-block error in `workspace-narrator.vue`, git-stash-confirmed against unmodified `origin/main`)
- `prettier --check` — same 4 pre-existing warnings as unmodified `origin/main` (git-stash-confirmed), not introduced by this change
- `npm run test:layout-contract` — holds at the 207-violation baseline
- `npm run test:lint-ratchet` — holds at 332/-60, no rule regressed

### Note
One of the migrated files (`components/navigation/workspace-narrator.vue`) uses CRLF line endings; the edit there was made in binary mode to preserve them exactly (avoiding the line-ending-normalization diff-bloat bug documented in a prior slice's TALKBACK entry).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6Tj87z1RWgazHGS17kz8X

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6Tj87z1RWgazHGS17kz8X)_