### PR TITLE
refactor: use shared primary button on Giving cart

### DIFF
--- a/components/pages/giving-page.vue
+++ b/components/pages/giving-page.vue
@@ -75,7 +75,7 @@
           <button
             v-if="added || cartStore.hasItems"
             type="button"
-            class="btn btn-primary btn-sm rounded-2xl"
+            class="kr-btn-primary rounded-2xl"
             @click="openCart"
           >
             <Icon name="kind-icon:cart" class="h-4 w-4" />


### PR DESCRIPTION
Interface Vision t-104 slice 65.

Migrates the Giving page's `View cart` action from the hand-rolled `btn btn-primary btn-sm rounded-2xl` shape to `kr-btn-primary rounded-2xl`. `.kr-btn-primary` supplies the same `btn btn-primary btn-sm` tokens and its `rounded-xl` is overridden by the existing `rounded-2xl`, so geometry and behavior are unchanged.

Session: `openai-scheduled-20260904T031520Z-interface-vision-t104-a8f3`