### PR TITLE
refactor: reuse shared primary button in relay diagnostics

### DIFF
--- a/components/art/stylist-relay-status.vue
+++ b/components/art/stylist-relay-status.vue
@@ -31,7 +31,7 @@
         </div>
         <button
           type="button"
-          class="btn btn-primary btn-sm rounded-2xl"
+          class="kr-btn-primary rounded-2xl"
           :disabled="loading"
           @click="refresh"
         >


### PR DESCRIPTION
Interface Vision t-104 slice 66.

Migrates the Relay Diagnostics Refresh action from the hand-rolled `btn btn-primary btn-sm rounded-2xl` shape to `kr-btn-primary rounded-2xl`. `.kr-btn-primary` supplies the same `btn btn-primary btn-sm` tokens, while the retained `rounded-2xl` preserves the existing radius. No behavior, API, schema, data, route, or deployment changes.

Session: `openai-scheduled-20260904T041404Z-interface-vision-t104-oai7f3`