### PR TITLE
refactor: reuse shared primary button in PDF purchase

### DIFF
--- a/components/giftshop/mermaids-pdf-purchase.vue
+++ b/components/giftshop/mermaids-pdf-purchase.vue
@@ -48,7 +48,7 @@
     <div v-else class="flex flex-wrap items-center gap-2">
       <button
         type="button"
-        class="btn btn-primary btn-sm rounded-2xl"
+        class="kr-btn-primary rounded-2xl"
         :disabled="purchasing"
         @click="purchase"
       >


### PR DESCRIPTION
Interface Vision t-104 slice 67.

Migrates the Mermaids PDF purchase action from the hand-rolled `btn btn-primary btn-sm rounded-2xl` shape to `kr-btn-primary rounded-2xl`. The shared primitive supplies the same DaisyUI primary/small button tokens while the retained radius preserves existing geometry. No behavior, API, schema, data, route, deployment, or checkout logic changes.

Session: `openai-scheduled-20260904T051135Z-interface-vision-t104-67x`