### PR TITLE
refactor: reuse shared outline button in outline-plain sites

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -723,6 +723,18 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-ghost btn-xs btn-circle;
   }
 
+  /* The outline-family counterpart to .kr-btn-plain (interface-vision t-104
+   * slice 69): a bare `sm` outline button with no `rounded-xl` override, so
+   * it renders at DaisyUI's own default button radius — `btn btn-outline
+   * btn-sm`, previously hand-rolled in 7 files (7 occurrences, split across
+   * two class-order variants: `btn btn-outline btn-sm` and `btn btn-sm
+   * btn-outline`). Named `.kr-btn-outline-plain` to mirror `.kr-btn-plain`'s
+   * `-plain` convention (dropped radius override) on the outline branch of
+   * the family. */
+  .kr-btn-outline-plain {
+    @apply btn btn-outline btn-sm;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/build-bench.vue
+++ b/components/art/build-bench.vue
@@ -133,7 +133,7 @@
           </div>
         </details>
 
-        <button class="btn btn-outline btn-sm" :disabled="running" @click="store.runSide(side)">
+        <button class="kr-btn-outline-plain" :disabled="running" @click="store.runSide(side)">
           Render Build {{ side }}
         </button>
 

--- a/components/art/stylist-calculator.vue
+++ b/components/art/stylist-calculator.vue
@@ -129,7 +129,7 @@
       }}</pre>
       <a
         :href="superkate.receiptMailto(savedAppointment)"
-        class="btn btn-outline btn-sm"
+        class="kr-btn-outline-plain"
       >
         <Icon name="mdi:email-outline" class="h-4 w-4" />
         Open receipt email

--- a/components/brainstorm/brainstorm-candidate-card.vue
+++ b/components/brainstorm/brainstorm-candidate-card.vue
@@ -360,7 +360,7 @@
         <button
           v-if="candidate.status === 'kept'"
           type="button"
-          class="btn btn-outline btn-sm"
+          class="kr-btn-outline-plain"
           data-testid="brainstorm-promote-to-character"
           :disabled="disabled"
           @click="promote"

--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -963,7 +963,7 @@
           <div class="flex gap-2">
             <button
               type="button"
-              class="btn btn-outline btn-sm"
+              class="kr-btn-outline-plain"
               @click="breedConfirmPair = null"
             >
               Cancel

--- a/components/pages/appmaker-page.vue
+++ b/components/pages/appmaker-page.vue
@@ -152,7 +152,7 @@
             </template>
             <div class="card-actions justify-end pt-1">
               <button
-                class="btn btn-sm btn-outline"
+                class="kr-btn-outline-plain"
                 @click="pageStore.setWorkspaceCardKey(app.slug)"
               >
                 Open project

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -393,7 +393,7 @@
 
                 <div class="flex items-center justify-between gap-2 border-t border-base-300 pt-3">
                   <button type="button" class="kr-btn-ghost-plain" :disabled="focusNavigationLocked" @click="store.previousCard()">Previous</button>
-                  <button type="button" class="btn btn-outline btn-sm" @click="store.toggleDetails()">{{ detailsVisible ? 'Hide parts' : 'Parts & history' }}</button>
+                  <button type="button" class="kr-btn-outline-plain" @click="store.toggleDetails()">{{ detailsVisible ? 'Hide parts' : 'Parts & history' }}</button>
                   <button type="button" class="kr-btn-ghost-plain" :disabled="focusNavigationLocked" @click="store.nextCard()">Next</button>
                 </div>
               </div>

--- a/pages/play/video-generator.vue
+++ b/pages/play/video-generator.vue
@@ -387,7 +387,7 @@
         <a
           :href="videoStore.state.videoSrc"
           :download="downloadFilename"
-          class="btn btn-sm btn-outline"
+          class="kr-btn-outline-plain"
         >
           ⬇ Download clip
         </a>

--- a/utils/scripts/verifyBrainstormWorkbench.mjs
+++ b/utils/scripts/verifyBrainstormWorkbench.mjs
@@ -123,7 +123,7 @@ assert.doesNotMatch(card, /(?:sm|md|lg|xl):grid-cols-/)
 // silently regaining visibility on pending/rejected ones.
 assert.match(
   card,
-  /v-if="candidate\.status === 'kept'"\s*\n\s*type="button"\s*\n\s*class="btn btn-outline btn-sm"\s*\n\s*data-testid="brainstorm-promote-to-character"/,
+  /v-if="candidate\.status === 'kept'"\s*\n\s*type="button"\s*\n\s*class="kr-btn-outline-plain"\s*\n\s*data-testid="brainstorm-promote-to-character"/,
   'the "Promote to Character" button must stay gated to kept candidates only',
 )
 


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring)

### What changed / what I produced
- Added `.kr-btn-outline-plain` (`btn btn-outline btn-sm`) to `assets/css/tailwind.css`, mirroring `.kr-btn-plain`'s `-plain` convention (dropped `rounded-xl` override) on the outline branch of the button family.
- Migrated the 7 sites hand-rolling this exact shape (split across two class-order variants — `btn btn-outline btn-sm` and `btn btn-sm btn-outline`) to the new shared class:
  - `components/cthulhuquarium/cthulhuquarium-game.vue`
  - `components/brainstorm/brainstorm-candidate-card.vue`
  - `components/art/build-bench.vue`
  - `components/art/stylist-calculator.vue`
  - `pages/play/mandarin.vue`
  - `components/pages/appmaker-page.vue`
  - `pages/play/video-generator.vue`
- No geometry or behavior change — `.kr-btn-outline-plain` supplies the same `btn btn-outline btn-sm` tokens each site already used.

### How I verified
- `vue-tsc --noEmit` clean (no errors).
- `eslint` on the 7 changed `.vue` files: 0 errors (the CSS file is outside eslint's config scope, as expected).
- `prettier --check`: same 5 pre-existing warnings on this branch and on unmodified `origin/main` (git-stash-confirmed) — no new formatting issues introduced.
- `npm run test:layout-contract`: holds, 207 baseline, no new violations.
- `npm run test:lint-ratchet`: holds, 332 problems/-60, no rule regressed.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Continue the remaining-size/outline-family button-shape survey — `btn btn-outline rounded-xl` (6), `btn btn-outline btn-sm rounded-2xl` (6), `btn btn-outline rounded-2xl` (5), and `btn btn-outline btn-xs` (5) remain as the next candidate shapes.

### Notes for reviewer
Slice 69 of the recurring interface-vision/t-104 consistency umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01RATZ3YjnRJ3xzS5mub8uQT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RATZ3YjnRJ3xzS5mub8uQT)_