### PR TITLE
refactor: reuse shared outline buttons for the remaining kr-* shapes

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -735,6 +735,26 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-outline btn-sm;
   }
 
+  /* The outline-family counterpart to .kr-btn-primary-md (interface-vision
+   * t-104 slice 70): DaisyUI's own default button size on the outline
+   * branch, with the same `rounded-xl` override as .kr-btn -- `btn
+   * btn-outline rounded-xl`, previously hand-rolled in 4 files (6
+   * occurrences). Suffixed `-md` for the default size, mirroring
+   * .kr-btn-primary-md's identical naming on the primary-color branch. */
+  .kr-btn-outline-md {
+    @apply btn btn-outline rounded-xl;
+  }
+
+  /* The outline-family `xs` shape (interface-vision t-104 slice 70): a
+   * small outline button with no radius override -- `btn btn-outline
+   * btn-xs`, previously hand-rolled in 3 files (5 occurrences). Named
+   * `.kr-btn-outline-xs` (color-size) to add the `xs` size as its own
+   * dimension, mirroring `.kr-btn-ghost-circle-xs`'s convention of naming
+   * a shape that isn't already covered by the `-plain`/`-md` suffixes. */
+  .kr-btn-outline-xs {
+    @apply btn btn-outline btn-xs;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/artjob-queue-card.vue
+++ b/components/art/artjob-queue-card.vue
@@ -46,7 +46,7 @@
         <button
           v-if="canLoadProtectedPreview"
           type="button"
-          class="btn btn-outline btn-sm rounded-2xl"
+          class="kr-btn-outline-plain rounded-2xl"
           :disabled="isLoadingPreview"
           @click="loadProtectedPreview"
         >

--- a/components/art/stylist-history.vue
+++ b/components/art/stylist-history.vue
@@ -78,7 +78,7 @@
           class="flex flex-col gap-2 rounded-lg bg-base-200 p-2"
         >
           <pre class="whitespace-pre-wrap text-xs">{{ superkate.receiptText(appointment) }}</pre>
-          <a :href="superkate.receiptMailto(appointment)" class="btn btn-outline btn-xs">
+          <a :href="superkate.receiptMailto(appointment)" class="kr-btn-outline-xs">
             <Icon name="mdi:email-outline" class="h-4 w-4" />
             Open receipt email
           </a>

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -432,7 +432,7 @@
 
             <div class="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-3">
               <button
-                class="btn btn-outline rounded-xl"
+                class="kr-btn-outline-md"
                 type="button"
                 @click="buildCharacterPrompt"
               >
@@ -440,7 +440,7 @@
               </button>
 
               <button
-                class="btn btn-outline rounded-xl"
+                class="kr-btn-outline-md"
                 type="button"
                 @click="copyPromptToChat"
               >

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -311,7 +311,7 @@
 
             <div class="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-3">
               <button
-                class="btn btn-outline rounded-xl"
+                class="kr-btn-outline-md"
                 type="button"
                 @click="buildCharacterPrompt"
               >
@@ -319,7 +319,7 @@
               </button>
 
               <button
-                class="btn btn-outline rounded-xl"
+                class="kr-btn-outline-md"
                 type="button"
                 @click="copyPromptToChat"
               >

--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -191,7 +191,7 @@
                 />
                 <button
                   type="button"
-                  class="btn btn-outline rounded-2xl"
+                  class="kr-btn-outline-md rounded-2xl"
                   :disabled="!validLegacyPath || studio.requestingAction"
                   @click="adoptExisting"
                 >

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -16,7 +16,7 @@
 
       <button
         type="button"
-        class="btn btn-outline rounded-2xl"
+        class="kr-btn-outline-md rounded-2xl"
         :disabled="studio.loading"
         @click="studio.fetchStudio()"
       >

--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -196,7 +196,7 @@
       <!-- Pack-level actions -->
       <div class="flex flex-wrap items-center gap-2">
         <button
-          class="btn btn-outline btn-sm rounded-2xl"
+          class="kr-btn-outline-plain rounded-2xl"
           :disabled="anyBusy"
           @click="onGenerateAll"
         >

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -36,7 +36,7 @@
           </button>
           <button
             type="button"
-            class="btn btn-outline btn-sm rounded-2xl"
+            class="kr-btn-outline-plain rounded-2xl"
             @click="clearForm"
           >
             <Icon name="kind-icon:x" class="h-4 w-4" />

--- a/components/giftshop/checkout-cancel.vue
+++ b/components/giftshop/checkout-cancel.vue
@@ -36,7 +36,7 @@
           Return to cart
         </NuxtLink>
 
-        <NuxtLink to="/sanctuary" class="btn btn-outline rounded-2xl">
+        <NuxtLink to="/sanctuary" class="kr-btn-outline-md rounded-2xl">
           Continue browsing
         </NuxtLink>
       </div>

--- a/components/giftshop/checkout-success.vue
+++ b/components/giftshop/checkout-success.vue
@@ -38,7 +38,7 @@
         <NuxtLink
           v-if="state === 'error' || state === 'unpaid'"
           to="/cart"
-          class="btn btn-outline rounded-2xl"
+          class="kr-btn-outline-md rounded-2xl"
         >
           <Icon name="kind-icon:cart" class="h-4 w-4" />
           Review cart

--- a/components/giftshop/mermaids-pdf-purchase.vue
+++ b/components/giftshop/mermaids-pdf-purchase.vue
@@ -24,7 +24,7 @@
         <Icon name="kind-icon:sparkles" class="h-3.5 w-3.5" />
         PDF edition — $9.99
       </span>
-      <NuxtLink to="/login" class="btn btn-outline btn-sm rounded-2xl">
+      <NuxtLink to="/login" class="kr-btn-outline-plain rounded-2xl">
         Log in to buy the PDF
       </NuxtLink>
     </div>

--- a/components/giftshop/shopping-cart.vue
+++ b/components/giftshop/shopping-cart.vue
@@ -45,7 +45,7 @@
         <NuxtLink to="/sanctuary" class="btn btn-primary rounded-2xl">
           Browse the giftshop
         </NuxtLink>
-        <NuxtLink to="/giving" class="btn btn-outline rounded-2xl">
+        <NuxtLink to="/giving" class="kr-btn-outline-md rounded-2xl">
           Support Against Malaria
         </NuxtLink>
       </div>

--- a/components/pages/giving-page.vue
+++ b/components/pages/giving-page.vue
@@ -64,7 +64,7 @@
         <div class="mt-4 flex flex-wrap gap-2">
           <button
             type="button"
-            class="btn btn-outline btn-sm rounded-2xl"
+            class="kr-btn-outline-plain rounded-2xl"
             :disabled="!donationItem"
             @click="addDonationToCart"
           >

--- a/components/ruler-hooked/ruler-hooked-cosmetics-picker.vue
+++ b/components/ruler-hooked/ruler-hooked-cosmetics-picker.vue
@@ -46,7 +46,7 @@
     <div
       class="flex flex-wrap items-center gap-2 border-t border-base-300 pt-2"
     >
-      <label class="btn btn-outline btn-xs">
+      <label class="kr-btn-outline-xs">
         Use my own picture instead
         <input
           type="file"

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -638,7 +638,7 @@
           <div class="flex items-center gap-3 pt-2">
             <button
               type="button"
-              class="btn btn-outline rounded-xl"
+              class="kr-btn-outline-md"
               @click="activeCard = 'cast'"
             >
               <Icon name="mdi:arrow-left" class="h-4 w-4" /> Back

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -74,7 +74,7 @@
           {{ errorMessage }}
         </p>
         <button
-          class="btn btn-outline btn-sm rounded-2xl"
+          class="kr-btn-outline-plain rounded-2xl"
           type="button"
           @click="refreshChats"
         >

--- a/pages/email-confirmation.vue
+++ b/pages/email-confirmation.vue
@@ -42,7 +42,7 @@
             <NuxtLink to="/account" class="kr-btn-primary-md">
               Open account settings
             </NuxtLink>
-            <NuxtLink to="/" class="btn btn-outline rounded-xl">
+            <NuxtLink to="/" class="kr-btn-outline-md">
               Return home
             </NuxtLink>
           </div>

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -250,7 +250,7 @@
                         @error="markArtBroken"
                       />
                     </div>
-                    <button v-if="canQueueArt" type="button" class="btn btn-outline btn-xs" :disabled="artBusy" @click="queueCurrentIllustration">
+                    <button v-if="canQueueArt" type="button" class="kr-btn-outline-xs" :disabled="artBusy" @click="queueCurrentIllustration">
                       {{ artBusy ? 'Submitting…' : 'Request illustration' }}
                     </button>
                     <p v-if="artNotice" class="mt-1 text-xs text-success">{{ artNotice }}</p>
@@ -297,7 +297,7 @@
                       <button
                         v-if="canQueueArt"
                         type="button"
-                        class="btn btn-outline btn-xs"
+                        class="kr-btn-outline-xs"
                         :disabled="artBusy"
                         @click="queueCurrentIllustration"
                       >
@@ -366,7 +366,7 @@
                 <p class="text-xl font-bold tracking-wide">{{ currentCard.pinyin }}</p>
                 <p v-if="currentCard.traditional" class="text-xs opacity-55">Traditional: {{ currentCard.traditional }}</p>
                 <div class="flex flex-wrap justify-center gap-1">
-                  <button v-if="canQueueArt" type="button" class="btn btn-outline btn-xs" :disabled="artBusy" @click="queueCurrentIllustration">
+                  <button v-if="canQueueArt" type="button" class="kr-btn-outline-xs" :disabled="artBusy" @click="queueCurrentIllustration">
                     {{ artBusy ? 'Submitting…' : 'Request illustration' }}
                   </button>
                   <button v-if="currentArtJobId" type="button" class="kr-btn-ghost-xs-plain" :disabled="artBusy" @click="refreshCurrentIllustration">


### PR DESCRIPTION
interface-vision/t-104 slice 70. Adds `.kr-btn-outline-md` (`btn btn-outline rounded-xl`) and `.kr-btn-outline-xs` (`btn btn-outline btn-xs`) alongside the existing `.kr-btn-outline-plain`, then migrates the remaining hand-rolled outline-family button shapes across 18 files (22 occurrences):

- `btn btn-outline rounded-xl` -> `kr-btn-outline-md` (4 files, 6 occurrences)
- `btn btn-outline btn-sm rounded-2xl` -> `kr-btn-outline-plain rounded-2xl` (6 files, 6 occurrences)
- `btn btn-outline rounded-2xl` -> `kr-btn-outline-md rounded-2xl` (5 files, 5 occurrences)
- `btn btn-outline btn-xs` -> `kr-btn-outline-xs` (3 files, 5 occurrences)

The `rounded-2xl` combinations reuse the same "component class + trailing utility override" pattern already established for `kr-btn-primary`/`kr-btn-primary-plain` in earlier slices; Tailwind's layer ordering puts the utility after the component so the override always wins regardless of source order.

Grepped `utils/scripts/*.mjs` and `*.ts` for the literal class strings being replaced before touching any file, per the slice 69 lesson (`verifyBrainstormWorkbench.mjs` hardcodes a pre-migration class as a regression guard) — no other contract script references these strings.

`components/stages/stage-manager.vue` is CRLF; migrated it in binary mode to avoid normalizing the whole file to LF (2026-09-04 TALKBACK lesson).

**Verified:** `vue-tsc` clean, `eslint` 0 new issues (4 pre-existing errors, git-stash-confirmed against unmodified `origin/main`), `prettier --check` identical 13 pre-existing warnings (git-stash-confirmed), `test:layout-contract` holds (207 baseline), `test:lint-ratchet` holds (332/-60), `verifyBrainstormWorkbench.mjs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzyWrPVDqZ5UKLpCKQCUuW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzyWrPVDqZ5UKLpCKQCUuW)_