### PR TITLE
model-builder/t-029 cycle 97: fix stale openRun() fetch surviving resetRun/resetAll

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -755,6 +755,12 @@ jobs:
       - name: Model Builder openRun request guard contract
         run: npm run test:model-builder-open-run-request-guard
 
+      - name: Model Builder reset/openRun race guard checker self-test
+        run: npm run test:model-builder-reset-open-run-guard-selftest
+
+      - name: Model Builder reset/openRun race guard contract
+        run: npm run test:model-builder-reset-open-run-guard
+
       - name: Model Builder openRun cancelled-run guard checker self-test
         run: npm run test:model-builder-open-run-cancelled-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -360,6 +360,8 @@
     "test:model-builder-fetch-runs-staleness-guard": "tsx utils/scripts/verifyModelBuilderFetchRunsStalenessGuard.ts",
     "test:model-builder-open-run-request-guard-selftest": "tsx utils/scripts/verifyModelBuilderOpenRunRequestGuard.test.ts",
     "test:model-builder-open-run-request-guard": "tsx utils/scripts/verifyModelBuilderOpenRunRequestGuard.ts",
+    "test:model-builder-reset-open-run-guard-selftest": "tsx utils/scripts/verifyModelBuilderResetOpenRunGuard.test.ts",
+    "test:model-builder-reset-open-run-guard": "tsx utils/scripts/verifyModelBuilderResetOpenRunGuard.ts",
     "test:model-builder-open-run-cancelled-guard-selftest": "tsx utils/scripts/verifyModelBuilderOpenRunCancelledGuard.test.ts",
     "test:model-builder-open-run-cancelled-guard": "tsx utils/scripts/verifyModelBuilderOpenRunCancelledGuard.ts",
     "test:model-builder-async-fetch-staleness-coverage-selftest": "tsx utils/scripts/verifyModelBuilderAsyncFetchStalenessCoverage.test.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -3314,6 +3314,20 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     draftingField.value = null
     // See runEpoch's own doc comment (model-builder/t-029, cycle 76).
     runEpoch++
+    // openRun()'s own ticket (openRunRequestId) only guards a second openRun()
+    // call against an earlier one -- it does nothing to stop a slow, still-
+    // in-flight openRun() fetch from landing *after* the user abandons it a
+    // different way (model-builder/t-029, cycle 97). Run History's "New run"
+    // button sits right next to "Open" with no guard between them: click Open
+    // on a run that isn't cached yet (falls through to the network fetch),
+    // then New run before that fetch resolves -- resetRun() above already
+    // nulls state.run and flips state.step back to 'source', but nothing told
+    // the pending openRun() its response is now stale, so it still lands,
+    // unconditionally reassigning state.run and flipping state.step back to
+    // 'run'. Bumping the same ticket here invalidates any openRun() fetch
+    // outstanding at reset time, the same way a second openRun() call already
+    // invalidates a slower first one.
+    openRunRequestId++
     safeRemove(runIdKey)
     clearStatus()
   }
@@ -3339,6 +3353,11 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     draftingField.value = null
     // See runEpoch's own doc comment (model-builder/t-029, cycle 76).
     runEpoch++
+    // See resetRun()'s identical fix and doc comment (model-builder/t-029,
+    // cycle 97) -- resetAll() is the same "abandon this run" moment as
+    // resetRun(), reachable from a different button, so a still-in-flight
+    // openRun() fetch needs the same invalidation here.
+    openRunRequestId++
     safeRemove(runIdKey)
     clearStatus()
   }

--- a/utils/scripts/verifyModelBuilderResetOpenRunGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderResetOpenRunGuard.test.ts
@@ -1,0 +1,139 @@
+// /utils/scripts/verifyModelBuilderResetOpenRunGuard.test.ts
+//
+// Regression test for checkResetOpenRunGuard() in
+// verifyModelBuilderResetOpenRunGuard.ts (model-builder/t-029, cycle 97).
+// Exercises the real check against synthetic store-shaped fixtures covering:
+// the pre-fix shape (neither resetRun() nor resetAll() bumps
+// openRunRequestId), the fixed shape (both do), a partially-fixed shape
+// (only resetRun() bumps it, resetAll() still doesn't), and both functions
+// being absent entirely.
+import assert from 'node:assert/strict'
+
+import { checkResetOpenRunGuard } from './verifyModelBuilderResetOpenRunGuard.js'
+
+const BUGGY_FIXTURE = `
+  function resetRun(): void {
+    state.run = null
+    state.step = state.selectedSource ? 'recipe' : 'source'
+    state.generatingItemId = null
+    draftingField.value = null
+    runEpoch++
+    safeRemove(runIdKey)
+    clearStatus()
+  }
+
+  function resetAll(): void {
+    state.step = 'source'
+    state.sourceType = null
+    state.run = null
+    state.generatingItemId = null
+    draftingField.value = null
+    runEpoch++
+    safeRemove(runIdKey)
+    clearStatus()
+  }
+`
+
+const FIXED_FIXTURE = `
+  function resetRun(): void {
+    state.run = null
+    state.step = state.selectedSource ? 'recipe' : 'source'
+    state.generatingItemId = null
+    draftingField.value = null
+    runEpoch++
+    openRunRequestId++
+    safeRemove(runIdKey)
+    clearStatus()
+  }
+
+  function resetAll(): void {
+    state.step = 'source'
+    state.sourceType = null
+    state.run = null
+    state.generatingItemId = null
+    draftingField.value = null
+    runEpoch++
+    openRunRequestId++
+    safeRemove(runIdKey)
+    clearStatus()
+  }
+`
+
+const PARTIAL_FIXTURE = `
+  function resetRun(): void {
+    state.run = null
+    state.step = state.selectedSource ? 'recipe' : 'source'
+    state.generatingItemId = null
+    draftingField.value = null
+    runEpoch++
+    openRunRequestId++
+    safeRemove(runIdKey)
+    clearStatus()
+  }
+
+  function resetAll(): void {
+    state.step = 'source'
+    state.sourceType = null
+    state.run = null
+    state.generatingItemId = null
+    draftingField.value = null
+    runEpoch++
+    safeRemove(runIdKey)
+    clearStatus()
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkResetOpenRunGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  2,
+  `expected the pre-fix shape to flag both resetRun() and resetAll(), got: ${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes('resetRun()')),
+  `expected a resetRun() violation, got: ${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes('resetAll()')),
+  `expected a resetAll() violation, got: ${JSON.stringify(buggyErrors)}`,
+)
+
+const fixedErrors = checkResetOpenRunGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const partialErrors = checkResetOpenRunGuard(PARTIAL_FIXTURE)
+assert.equal(
+  partialErrors.length,
+  1,
+  `expected the partial fix to flag exactly one violation, got: ${JSON.stringify(partialErrors)}`,
+)
+assert.ok(
+  partialErrors.some((e) => e.includes('resetAll()')),
+  `expected the partial fix's violation to name resetAll(), got: ${JSON.stringify(partialErrors)}`,
+)
+
+const missingErrors = checkResetOpenRunGuard(MISSING_FIXTURE)
+assert.equal(
+  missingErrors.length,
+  2,
+  `expected both functions to be flagged as missing, got: ${JSON.stringify(missingErrors)}`,
+)
+
+console.log(
+  'Model Builder reset/openRun race guard checker verified: flags the ' +
+    'pre-fix shape (neither function bumps openRunRequestId), clears the ' +
+    'fixed shape (both do), flags a partial fix (only one does), and flags ' +
+    'both functions being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderResetOpenRunGuard.ts
+++ b/utils/scripts/verifyModelBuilderResetOpenRunGuard.ts
@@ -1,0 +1,103 @@
+// /utils/scripts/verifyModelBuilderResetOpenRunGuard.ts
+//
+// Regression guard (model-builder/t-029, cycle 97) -- openRun()'s own request
+// ticket (openRunRequestId, see verifyModelBuilderOpenRunRequestGuard.ts) only
+// guards a second openRun() call against a slower first one. It does nothing
+// to stop a still-in-flight openRun() fetch from landing *after* the user
+// abandons that run a different way: resetRun() and resetAll() both
+// unconditionally null state.run and reset state.step, but neither used to
+// touch openRunRequestId, so a pending openRun() fetch's stale-response check
+// (`if (openRunRequestId !== requestId) return`) still passed and its
+// response still landed afterward.
+//
+// Concrete repro: model-builder-run-history.vue's "Open" button and "New run"
+// button sit side by side with no guard between them (only cancellingRunId
+// disables either). Click Open on a run that is not yet cached in
+// state.runs (falls through to the network fetch), then click New run before
+// that fetch resolves. resetRun() correctly nulls state.run and flips
+// state.step back to 'source' -- but when Open's fetch then resolves, its
+// success branch still passed the (unchanged) ticket check and unconditionally
+// reassigned state.run and flipped state.step back to 'run', silently
+// resurrecting the run the user just abandoned. The same gap applies to
+// resetAll() (bound to the top-level "Reset" control in
+// model-builder-manager.vue).
+//
+// Fixed by bumping the same openRunRequestId ticket inside resetRun() and
+// resetAll(), immediately alongside their existing runEpoch++ (which guards a
+// different, sibling class of abandoned-work races -- see runEpoch's own doc
+// comment). This asserts the textual shape of that fix stays in place,
+// deliberately scoped to this one bug, mirroring
+// verifyModelBuilderOpenRunRequestGuard.ts's identical pattern for openRun()
+// itself.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const TICKET_VAR = 'openRunRequestId'
+const REQUIRED_STATEMENT = `${TICKET_VAR}++`
+const TARGET_FUNCTIONS = ['resetRun', 'resetAll']
+
+// Checks the fix's exact shape against the full source text of a file
+// containing `resetRun`/`resetAll`-named functions. Exported (rather than
+// only exercised via main()) so the self-test below can run it against
+// synthetic buggy/fixed fixtures without touching the real store file.
+export function checkResetOpenRunGuard(content: string): string[] {
+  const errors: string[] = []
+  const functions = extractFunctionBodies(content)
+
+  for (const name of TARGET_FUNCTIONS) {
+    const fn = functions.find((f) => f.name === name)
+    if (!fn) {
+      errors.push(
+        `Could not find a function named ${name}() -- has it been renamed, ` +
+          'removed, or inlined? If so, this guard (and the race it protects ' +
+          'against) needs to move with it.',
+      )
+      continue
+    }
+
+    if (!fn.body.includes(REQUIRED_STATEMENT)) {
+      errors.push(
+        `${name}() no longer contains \`${REQUIRED_STATEMENT}\`. Without ` +
+          'it, a still-in-flight openRun() fetch outstanding when the user ' +
+          `calls ${name}() can land afterward and silently resurrect the ` +
+          'run/step the user just abandoned -- see the doc comment at the ' +
+          'top of this file for the concrete repro.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkResetOpenRunGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder reset/openRun race guard contract failed for ' +
+        'modelBuilderStore.ts:',
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder reset/openRun race guard contract passed: resetRun() ' +
+      'and resetAll() both invalidate any openRun() fetch still in flight ' +
+      'when the user abandons the run a different way.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## What

Recurring `model-builder/t-029` cycle 97. Read `model-builder-run-history.vue` end-to-end — the least-recently-fully-read Model Builder surface per the roadmap note's own tracking (last touched at cycle 72, 24 cycles ago).

Found a genuine bug matching this task's most common bug class (stale async response landing after the user has moved on):

`openRun(runId)`'s own request ticket (`openRunRequestId`) only guards a second `openRun()` call against a slower earlier one. It does nothing to stop a still-in-flight `openRun()` fetch from landing *after* the user abandons that run a different way.

**Concrete repro:** Run History's "New run" button sits right next to "Open" with no guard between them (only `cancellingRunId` disables either). Click Open on a run that isn't cached yet in `state.runs` (falls through to the network fetch), then click New run before that fetch resolves. `resetRun()` correctly nulls `state.run` and flips `state.step` back to `'source'` — but when Open's fetch then resolves, its success branch still passes the unchanged ticket check and unconditionally reassigns `state.run`, flipping `state.step` back to `'run'` — silently resurrecting the run the user just abandoned. The identical gap applies to `resetAll()` (the top-level "Reset" control in `model-builder-manager.vue`).

## Fix

Bump `openRunRequestId` inside `resetRun()` and `resetAll()`, immediately alongside their existing `runEpoch++` (a different, sibling guard that protects long-running per-item auto-build/batch loops — not this single-fetch race). This invalidates any `openRun()` fetch outstanding at reset time, the same way a second `openRun()` call already invalidates a slower first one.

## Guard

Added `verifyModelBuilderResetOpenRunGuard.ts` + self-test, following this task's established narrow-textual-checker convention (mirrors `verifyModelBuilderOpenRunRequestGuard.ts`'s pattern for `openRun()` itself). Asserts both `resetRun()` and `resetAll()` contain `openRunRequestId++`. Wired into `package.json` and `.github/workflows/contract-tests.yml` (verified every `test:model-builder-*` script has a matching CI step, per `verifyModelBuilderContractTestsCoverageGuard.ts`'s own contract).

## Verification

No local `node_modules`/`tsx` available this session, so verified by:
- Hand-simulating the guard's real `extractFunctionBodies`/`computeCodeMask` logic (copied verbatim from `verifyModelBuilderCompletionGate.ts`) against the patched store file and all four test fixtures (buggy/fixed/partial/missing) — all pass as expected.
- Running the same parser against the *entire* patched file (all 50 top-level functions, including `openRun`/`resetRun`/`resetAll`/`cancelRun`/`fetchRuns`/`resumeRun`/`startRun`/`draftText`) with clean brace/paren matching throughout — confirms no structural damage from the edit.
- `stores/modelBuilderStore.ts`'s pushed content was verified byte-for-byte against a locally-computed git blob SHA before and after upload (server returned the exact precomputed SHA `380a36a82b5cf7c76506baefebd1d9b264c4fbc0`, size 155723).
- Diff scoped to exactly the two intended insertions (14+1 lines in `resetRun()`, 4+1 lines in `resetAll()`), confirmed via diff against the original file.
- CI (`contract-tests.yml`) will run the full guard suite, ESLint, and `test:layout-contract` on this PR — will confirm green before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rr2GMKHmw4EynS2gaGMsKL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rr2GMKHmw4EynS2gaGMsKL)_