### PR TITLE
interface-vision/t-104 slice 71: add .kr-btn-primary-md-2xl and migrate 9 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -673,6 +673,19 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-primary btn-sm;
   }
 
+  /* Fourth filled-button shape (interface-vision t-104 slice 71): DaisyUI's
+   * own default (unmodified) button size — no `btn-sm` utility at all —
+   * combined with a wider `rounded-2xl` corner radius instead of
+   * `rounded-xl` — `btn btn-primary rounded-2xl`, previously hand-rolled in
+   * 9 files (9 occurrences, all in the identical `btn btn-primary
+   * rounded-2xl` class order). Suffixed `-md-2xl` (size then radius) since
+   * both the size and the radius deviate from the base .kr-btn-primary
+   * shape at once, mirroring .kr-btn-ghost-xs-lg's identical two-axis
+   * naming convention on the ghost family. */
+  .kr-btn-primary-md-2xl {
+    @apply btn btn-primary rounded-2xl;
+  }
+
   /* The most-repeated *secondary*-color button shape (interface-vision t-104
    * slice 61): the same `sm`/`rounded-xl` shape as .kr-btn-primary, filled
    * with the secondary color instead — `btn btn-secondary btn-sm rounded-xl`,

--- a/components/art/forum-art-generation-context.vue
+++ b/components/art/forum-art-generation-context.vue
@@ -128,7 +128,7 @@
       <div class="mt-4 flex flex-wrap items-center gap-2">
         <button
           type="button"
-          class="btn btn-primary rounded-2xl"
+          class="kr-btn-primary-md-2xl"
           :disabled="
             store.queueing || activeJob || store.promptDraft.trim().length < 3
           "

--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -100,7 +100,7 @@
         <button
           v-if="userStore.isAdmin"
           type="button"
-          class="btn btn-primary rounded-2xl"
+          class="kr-btn-primary-md-2xl"
           :disabled="!promptDirty || studio.savingCoverPrompt || promptDraft.trim().length < 40"
           @click="savePrompt"
         >

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -434,7 +434,7 @@
           <button
             v-if="userStore.isAdmin"
             type="button"
-            class="btn btn-primary rounded-2xl"
+            class="kr-btn-primary-md-2xl"
             :disabled="
               !promptDirty ||
               studio.savingPrompt ||

--- a/components/giftshop/checkout-cancel.vue
+++ b/components/giftshop/checkout-cancel.vue
@@ -31,7 +31,7 @@
       </div>
 
       <div class="mt-6 flex flex-wrap justify-center gap-3">
-        <NuxtLink to="/cart" class="btn btn-primary rounded-2xl">
+        <NuxtLink to="/cart" class="kr-btn-primary-md-2xl">
           <Icon name="kind-icon:cart" class="h-4 w-4" />
           Return to cart
         </NuxtLink>

--- a/components/giftshop/checkout-success.vue
+++ b/components/giftshop/checkout-success.vue
@@ -30,7 +30,7 @@
       </div>
 
       <div class="mt-6 flex flex-wrap justify-center gap-3">
-        <NuxtLink to="/sanctuary" class="btn btn-primary rounded-2xl">
+        <NuxtLink to="/sanctuary" class="kr-btn-primary-md-2xl">
           <Icon name="kind-icon:butterfly" class="h-4 w-4" />
           Return to Sanctuary
         </NuxtLink>

--- a/components/giftshop/giftshop-interact.vue
+++ b/components/giftshop/giftshop-interact.vue
@@ -27,11 +27,7 @@
             </p>
           </div>
 
-          <button
-            type="button"
-            class="btn btn-primary rounded-2xl"
-            @click="goToCart"
-          >
+          <button type="button" class="kr-btn-primary-md-2xl" @click="goToCart">
             <Icon name="kind-icon:cart" class="h-4 w-4" />
             Cart
             <span v-if="cartStore.totalItems" class="badge badge-secondary">
@@ -199,11 +195,7 @@
           </div>
         </div>
 
-        <button
-          type="button"
-          class="btn btn-primary rounded-2xl"
-          @click="goToCart"
-        >
+        <button type="button" class="kr-btn-primary-md-2xl" @click="goToCart">
           <Icon name="kind-icon:cart" class="h-4 w-4" />
           Review cart
         </button>

--- a/components/giftshop/shopping-cart.vue
+++ b/components/giftshop/shopping-cart.vue
@@ -42,7 +42,7 @@
         The butterflies have returned the receipt printer to sleep mode.
       </p>
       <div class="mt-5 flex flex-wrap justify-center gap-2">
-        <NuxtLink to="/sanctuary" class="btn btn-primary rounded-2xl">
+        <NuxtLink to="/sanctuary" class="kr-btn-primary-md-2xl">
           Browse the giftshop
         </NuxtLink>
         <NuxtLink to="/giving" class="kr-btn-outline-md rounded-2xl">

--- a/error.vue
+++ b/error.vue
@@ -27,11 +27,7 @@
         </p>
 
         <div class="mt-6 flex flex-wrap justify-center gap-3">
-          <button
-            type="button"
-            class="btn btn-primary rounded-2xl"
-            @click="goHome"
-          >
+          <button type="button" class="kr-btn-primary-md-2xl" @click="goHome">
             Go home
           </button>
           <button


### PR DESCRIPTION
## Summary
Continues the recurring `interface-vision/t-104` button-consistency migration (conductor roadmap). This slice's fresh repo-wide grep for the next most-repeated hand-rolled `btn` combination (per slice 70's guidance) found `btn btn-primary rounded-2xl` — DaisyUI's default button size, primary color, `rounded-2xl` override — hand-rolled identically (same class order) in 9 places across 8 files.

- Added `.kr-btn-primary-md-2xl` to `assets/css/tailwind.css`, the fourth shape in the `.kr-btn-primary` family (mirrors `.kr-btn-ghost-xs-lg`'s two-axis size+radius naming convention, since both size and radius deviate from the base `.kr-btn-primary` shape at once).
- Migrated all 9 occurrences across 8 files onto the new primitive: no geometry or behavior change.
- Deliberately excluded `components/ui/ui-gallery.vue`'s bare `btn btn-primary` usages (a different, unrelated class combo) — that page is an intentional design-system showcase displaying raw DaisyUI classes for comparison, not hand-rolled duplication.

## Verification
- `vue-tsc --noEmit`: clean
- `utils/scripts/verifyLintRatchet.ts`: holds (332 problems / -60, no new issues)
- `prettier --check`: clean on all touched files (6 pre-existing warnings unchanged elsewhere in the repo; 2 files needed `prettier --write` after the shorter class name let their button tags collapse onto a single line)
- `utils/scripts/verifyLayoutContract.ts`: holds (207 baseline, unchanged)
- Grepped `utils/scripts/*.mjs`/`*.ts` for the literal replaced class string first — no contract script references it (slice 69 lesson)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7ffP2nveFuzv68fFW5ZaX

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7ffP2nveFuzv68fFW5ZaX)_