### PR TITLE
storybook/t-010: refocus casting-board role chip after a tier move

### DIFF
--- a/components/narrative/narrative-cast-card.vue
+++ b/components/narrative/narrative-cast-card.vue
@@ -12,6 +12,7 @@
 -->
 <template>
   <li
+    :data-cast-member="member.slug"
     class="flex flex-col overflow-hidden rounded-2xl border bg-base-100 transition"
     :class="[
       role ? 'border-secondary/60 ring-1 ring-secondary/30' : 'border-base-300',
@@ -74,6 +75,7 @@
       <button
         v-for="option in NARRATIVE_ROLES"
         :key="option.key"
+        :data-role-key="option.key"
         type="button"
         class="btn btn-xs rounded-lg px-1.5 text-[0.65rem] font-bold"
         :class="role === option.key ? 'btn-secondary' : 'btn-ghost'"

--- a/components/narrative/narrative-role-assigner.vue
+++ b/components/narrative/narrative-role-assigner.vue
@@ -147,7 +147,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 import {
   duplicateSingularRoles,
   NARRATIVE_ROLES,
@@ -197,6 +197,31 @@ function toggle(slug: string, key: string): void {
   )
   if (roleFor(slug) !== key) next[slug] = key
   emit('update:modelValue', next)
+  refocusRoleButton(slug, key)
+}
+
+/**
+ * A role toggle can move a card to a different tier -- a different `<ul>`
+ * entirely (protagonist/antagonist/support/back are four separate v-for
+ * blocks, not one list Vue can reorder in place). That unmounts the pressed
+ * button and mounts a new one in the new tier, dropping keyboard focus back
+ * to the document body. Find the same member's same-role button in its new
+ * position and refocus it, so a keyboard user can keep casting without
+ * re-navigating from the top every time a press changes tiers.
+ */
+function refocusRoleButton(slug: string, key: string): void {
+  if (typeof document === 'undefined') return
+  nextTick(() => {
+    const card = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-cast-member]'),
+    ).find((el) => el.dataset.castMember === slug)
+    const button = card
+      ? Array.from(
+          card.querySelectorAll<HTMLButtonElement>('[data-role-key]'),
+        ).find((el) => el.dataset.roleKey === key)
+      : null
+    button?.focus()
+  })
 }
 
 function assignRole(slug: string, key: string): void {

--- a/utils/scripts/verifyNarrativeCastTiers.ts
+++ b/utils/scripts/verifyNarrativeCastTiers.ts
@@ -108,6 +108,18 @@ check(
     /closest\('\[data-cast-role\]'\)/.test(component),
   'touch drag completion resolves the role slot under the pointer',
 )
+check(
+  /:data-cast-member="member\.slug"/.test(card) &&
+    /:data-role-key="option\.key"/.test(card),
+  'cast cards expose stable member/role markers for post-move focus lookup',
+)
+check(
+  /refocusRoleButton\(slug, key\)/.test(component) &&
+    /nextTick\(/.test(component) &&
+    /data-cast-member/.test(component) &&
+    /data-role-key/.test(component),
+  'toggling a role refocuses the pressed chip after a tier move, so keyboard casting does not lose its place',
+)
 
 if (failures) {
   console.error(


### PR DESCRIPTION
### Task
storybook/t-010: Polish and upgrade Storybook front-end surface (recurring; kind: software)

Follows up on the previous PR's (#2394) kaizen suggestion: audit the narrative role assigner's keyboard flow, which had not been read end-to-end recently.

### What changed / what I found
`narrative-role-assigner.vue`'s casting board arranges cast cards into four tiers (protagonist/antagonist/support/back), each rendered by its own separate `v-for … <ul>` block. Pressing a role chip (`narrative-cast-card.vue`'s pressable buttons — the documented "keyboard/accessibility path alongside drag-and-drop") can move a member to a different tier. Because the four tiers are separate lists, not one Vue can reorder in place, that move unmounts the pressed chip and mounts a fresh one inside a different `<ul>` — which silently drops keyboard focus back to `<body>`. A keyboard user casting several members in a row loses their place after every press that changes tiers and has to re-tab from the top of the board each time.

### Fix
- Added stable `data-cast-member`/`data-role-key` markers to each card's chips.
- After `toggle()` emits the role change, look up the same member's same-role chip in its new DOM position (post-`nextTick`) and refocus it.
- Extended `verifyNarrativeCastTiers.ts` (already wired into `contract-tests.yml`) to pin both the new markers and the refocus call, following this task's established narrow-textual-guard convention.

### Verification
- `npx vue-tsc --noEmit`: clean
- `npx eslint` on all three touched files: 0 issues
- `npx prettier --check`: unchanged pre-existing warning on `narrative-role-assigner.vue` (git-stash-confirmed against unmodified `main`)
- `npm run test:layout-contract`: holds (207 baseline, unchanged)
- `npm run test:lint-ratchet`: holds (332 problems / -60, unchanged)
- `npm run test:narrative-cast-tiers`: passes, including the two new checks
- Grepped `utils/scripts/*.ts` for the touched components before editing (slice 69 lesson) — only `verifyDaVinciDimensionGroupGuard.ts` mentions `narrative-role-assigner.vue`, and only in a comment, not a literal-string check

### Stakes
reversible

### Kaizen suggestion
The casting board's live region has no `aria-live` announcement when a card moves tiers — a screen-reader user still gets no auditory confirmation that their press actually changed something, even though focus now follows correctly. Worth a dedicated slice rather than folding into this one (scope discipline per this task's own retry history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013txJpV6WaiVnuco5viWCcb

---
_Generated by [Claude Code](https://claude.ai/code/session_013txJpV6WaiVnuco5viWCcb)_