### PR TITLE
storybook/t-010: announce casting-board role changes for screen readers

### DIFF
--- a/components/narrative/narrative-role-assigner.vue
+++ b/components/narrative/narrative-role-assigner.vue
@@ -143,6 +143,8 @@
     >
       {{ duplicateWarning }}
     </p>
+
+    <p class="sr-only" role="status" aria-live="polite">{{ announcement }}</p>
   </div>
 </template>
 
@@ -167,6 +169,7 @@ const emit = defineEmits<{
 
 const draggingSlug = ref<string | null>(null)
 const dragOverRole = ref<string | null>(null)
+const announcement = ref('')
 
 const roleFor = (slug: string): string | null => props.modelValue[slug] ?? null
 
@@ -195,9 +198,25 @@ function toggle(slug: string, key: string): void {
   const next = Object.fromEntries(
     Object.entries(props.modelValue).filter(([entry]) => entry !== slug),
   )
-  if (roleFor(slug) !== key) next[slug] = key
+  const assigning = roleFor(slug) !== key
+  if (assigning) next[slug] = key
   emit('update:modelValue', next)
   refocusRoleButton(slug, key)
+  announceRole(slug, assigning ? key : null)
+}
+
+/**
+ * The board otherwise gives no feedback a screen reader can hear: focus now
+ * follows a tier-changing press (see refocusRoleButton), but nothing ever
+ * says what the press actually did. Mirrors duplicateWarning's existing
+ * role="status" pattern, in its own sr-only region so it doesn't compete
+ * visually with the warning.
+ */
+function announceRole(slug: string, key: string | null): void {
+  const title = props.members.find((member) => member.slug === slug)?.title
+  announcement.value = key
+    ? `${title} is now the ${narrativeRoleLabel(key)}.`
+    : `${title} is now unassigned.`
 }
 
 /**
@@ -226,6 +245,7 @@ function refocusRoleButton(slug: string, key: string): void {
 
 function assignRole(slug: string, key: string): void {
   emit('update:modelValue', { ...props.modelValue, [slug]: key })
+  announceRole(slug, key)
 }
 
 function startDrag(slug: string): void {

--- a/utils/scripts/verifyNarrativeCastTiers.ts
+++ b/utils/scripts/verifyNarrativeCastTiers.ts
@@ -120,6 +120,17 @@ check(
     /data-role-key/.test(component),
   'toggling a role refocuses the pressed chip after a tier move, so keyboard casting does not lose its place',
 )
+check(
+  /aria-live="polite"/.test(component) &&
+    /class="sr-only"/.test(component) &&
+    /\{\{ announcement \}\}/.test(component),
+  'the board has an sr-only live region for role-change announcements',
+)
+check(
+  /announceRole\(slug, assigning \? key : null\)/.test(component) &&
+    /announceRole\(slug, key\)/.test(component),
+  'both the chip toggle and the drag-drop assignment announce the role change',
+)
 
 if (failures) {
   console.error(


### PR DESCRIPTION
### Task
storybook/t-010: Polish and upgrade Storybook front-end surface (recurring; kind: software)

Follows up on #2395's own kaizen note: keyboard focus now follows a tier-changing role press, but nothing tells a screen reader what the press actually did.

### What changed
- Added an `sr-only` `role="status" aria-live="polite"` region to `narrative-role-assigner.vue`.
- `toggle()` (chip press) and `assignRole()` (drag-and-drop completion) both call a new `announceRole(slug, key)` helper: `"<Member> is now the <Role>."` when assigning, `"<Member> is now unassigned."` when a chip press clears the role.
- Extended `verifyNarrativeCastTiers.ts` (wired into `contract-tests.yml`) with two more checks pinning the live region and both announcement call sites.

### Verification
- `npx vue-tsc --noEmit`: clean
- `npx eslint` on both touched files: 0 issues
- `npx prettier --check`: unchanged pre-existing warning on `narrative-role-assigner.vue` (git-stash-confirmed against unmodified `main`)
- `npm run test:layout-contract`: holds (207 baseline, unchanged)
- `npm run test:lint-ratchet`: holds (332 problems / -60, unchanged)
- `npm run test:narrative-cast-tiers`: passes, including the two new checks

### Stakes
reversible

### Kaizen suggestion
`narrative-role-assigner.vue`'s drop zones themselves have no keyboard path at all — a keyboard user can only assign via the per-card chips, never by "focusing a drop zone and pressing a card into it." That's fine today since the chips are a complete alternative, but worth a look if the drop-zone-first mental model (the header text says "Drag a card onto a part") ever needs full parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013txJpV6WaiVnuco5viWCcb

---
_Generated by [Claude Code](https://claude.ai/code/session_013txJpV6WaiVnuco5viWCcb)_