### PR TITLE
storybook/t-010: hide the pointer-only touch drag handle from keyboard/AT

### DIFF
--- a/components/narrative/narrative-cast-card.vue
+++ b/components/narrative/narrative-cast-card.vue
@@ -36,8 +36,9 @@
 
       <button
         type="button"
+        tabindex="-1"
+        aria-hidden="true"
         class="absolute right-2 top-2 z-10 cursor-grab touch-none rounded-lg bg-base-100/90 px-2 py-1 text-xs font-black shadow active:cursor-grabbing"
-        :aria-label="`Drag ${member.title} to a part`"
         title="Drag to a part"
         @pointerdown="startPointerDrag"
         @pointermove="movePointerDrag"

--- a/utils/scripts/verifyNarrativeCastTiers.ts
+++ b/utils/scripts/verifyNarrativeCastTiers.ts
@@ -99,6 +99,15 @@ check(
   'the touch drag handle suppresses browser panning while a pointer drag is active',
 )
 check(
+  /tabindex="-1"[^>]*aria-hidden="true"[\s\S]{0,200}?@pointerdown="startPointerDrag"/.test(
+    card,
+  ) ||
+    /aria-hidden="true"[^>]*tabindex="-1"[\s\S]{0,200}?@pointerdown="startPointerDrag"/.test(
+      card,
+    ),
+  'the pointer-only touch drag handle is out of the tab order and hidden from assistive tech, since keyboard/screen-reader users have no pointermove/pointerup path to complete a drag with it and the pressable role chips are their real path',
+)
+check(
   /:aria-pressed="role === option\.key"/.test(card) &&
     /@click="emit\('toggle-role', option\.key\)"/.test(card),
   'pressable role chips remain as the keyboard/accessibility fallback',


### PR DESCRIPTION
## Summary
- The casting board's per-card drag handle (⋮⋮, previously `aria-label="Drag <member> to a part"`) is a real `<button>`, so it lands in the tab order and the accessibility tree.
- Its only handlers are `pointerdown`/`pointermove`/`pointerup`/`pointercancel`, and `startPointerDrag()` bails immediately for `event.pointerType === 'mouse'` — there is no click handler at all.
- A keyboard or screen-reader user who reaches it and presses Enter/Space (a synthetic `click`, not a pointer event) gets nothing: a focusable, named control that announces an action and performs none.
- The board's own header comment already states the intended contract — "the role chips remain the keyboard/accessibility path alongside drag-and-drop" — so the fix takes this pointer/touch-only affordance out of the tab order and the AT tree (`tabindex="-1"`, `aria-hidden="true"`) rather than inventing a keyboard interaction it was never designed to have.

## Verification
- Extended `verifyNarrativeCastTiers.ts` (wired into `contract-tests.yml`) with a check pinning the fix; confirmed via `git stash` that it fails on the pre-fix file.
- `vue-tsc --noEmit`: clean.
- `eslint` on both touched files: clean.
- `prettier --check`: clean (caught and fixed a formatting miss in my own edit to the guard; confirmed the pre-existing baseline was clean via `git stash`).
- `test:layout-contract`: holds (207 baseline, unchanged).
- `test:lint-ratchet`: holds (333/-59, no rule regressed).
- `test:narrative-cast-tiers` and `test:narrative-kit`: both pass.

## Context
Picked up as the recurring `storybook/t-010` (Storybook front-end polish) task from a Conductor session-start sweep — a never-audited hypothesis about `narrative-cast-card.vue`'s pointer-drag handle, confirmed as a real defect rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRMXFYbtvo1Z47AESxF9Q7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRMXFYbtvo1Z47AESxF9Q7)_