### PR TITLE
Never back an own-resource request with the site provider key

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -965,6 +965,9 @@ jobs:
       - name: Text-provider-service shared mechanics contract
         run: npm run test:text-provider-service
 
+      - name: Site provider key policy contract (own-resource requests never spend the site key)
+        run: npm run test:site-provider-key-policy
+
       - name: Server capability routing contract
         run: npm run test:server-capability-routing
 

--- a/package.json
+++ b/package.json
@@ -451,6 +451,7 @@
     "test:pod-vendor-client-selftest": "tsx utils/scripts/verifyPodVendorClient.test.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",
     "test:text-provider-service": "tsx utils/scripts/verifyTextProviderService.ts",
+    "test:site-provider-key-policy": "tsx utils/scripts/verifySiteProviderKeyPolicy.ts",
     "test:server-capability-routing": "tsx utils/scripts/verifyServerCapabilityRouting.ts",
     "test:server-uptime-default-scope": "tsx utils/scripts/verifyServerUptimeDefaultScope.ts",
     "test:text-generation-dispatch": "tsx utils/scripts/verifyTextGenerationDispatch.ts",

--- a/server/api/botcafe/chat.ts
+++ b/server/api/botcafe/chat.ts
@@ -6,6 +6,7 @@ import { manaGate } from '@/server/utils/manaGate'
 import { estimateTextCostUsd } from '@/server/utils/manaCost'
 import { resolveServer } from '@/server/utils/serverResolver'
 import { createTextCompletion } from '@/server/utils/textServer'
+import { resolveGatedProviderKey } from '@/server/utils/textProviderService'
 import {
   ServerAccessMode,
   ServerAuthType,
@@ -47,15 +48,6 @@ type TextResponsePayload = {
   }
 }
 
-function cleanProviderKey(value?: string | null): string {
-  return (
-    value
-      ?.trim()
-      .replace(/^Bearer\s+/i, '')
-      .trim() || ''
-  )
-}
-
 function looksLikeOpenAiKey(value: string): boolean {
   return value.startsWith('sk-')
 }
@@ -67,17 +59,21 @@ function looksLikeAnthropicKey(value: string): boolean {
 function getProviderApiKey(options: {
   server: Server
   userApiKey?: string | null
+  siteKeyAllowed: boolean
 }): string {
-  const userApiKey = cleanProviderKey(options.userApiKey)
-  const serverApiKey = cleanProviderKey(options.server.apiKey)
-  const runtimeOpenAiKey = cleanProviderKey(process.env.OPENAI_API_KEY)
+  const ownKey = resolveGatedProviderKey({
+    siteKeyAllowed: options.siteKeyAllowed,
+    userApiKey: options.userApiKey,
+    serverApiKey: options.server.apiKey,
+    // Only the true OpenAI cloud server may fall through to the site key.
+    runtimeApiKey:
+      options.server.serverType === 'OPENAI'
+        ? process.env.OPENAI_API_KEY
+        : null,
+    providerLabel: 'OpenAI',
+  })
 
-  if (userApiKey) return userApiKey
-  if (serverApiKey) return serverApiKey
-
-  if (options.server.serverType === 'OPENAI') {
-    return runtimeOpenAiKey
-  }
+  if (ownKey) return ownKey
 
   return ''
 }
@@ -237,6 +233,7 @@ export default defineEventHandler(async (event) => {
     const apiKey = getProviderApiKey({
       server,
       userApiKey: body.userApiKey,
+      siteKeyAllowed: gate.siteKeyAllowed,
     })
 
     assertProviderKeyMatchesServer({

--- a/server/api/brainstorm/generate.post.ts
+++ b/server/api/brainstorm/generate.post.ts
@@ -23,6 +23,11 @@ import {
 } from '../../../types/brainstorm'
 import { errorHandler } from '../../utils/error'
 import { manaGate } from '../../utils/manaGate'
+import {
+  getRuntimeAnthropicKey,
+  getRuntimeOpenAiKey,
+  resolveGatedProviderKey,
+} from '../../utils/textProviderService'
 import { estimateTextCostUsd } from '../../utils/manaCost'
 import {
   canReadServer,
@@ -390,11 +395,18 @@ export default defineEventHandler(async (event) => {
       model,
       count: request.count,
       maxTokens,
-      apiKey: brainstormProviderApiKey(provider, {
-        serverApiKey: server.apiKey,
-        anthropicApiKey: config.anthropicApiKey,
-        openaiApiKey: config.openaiApiKey,
-      }),
+      apiKey:
+        provider === 'anthropic' || provider === 'openai'
+          ? resolveGatedProviderKey({
+              siteKeyAllowed: gate.siteKeyAllowed,
+              serverApiKey: server.apiKey,
+              runtimeApiKey:
+                provider === 'anthropic'
+                  ? getRuntimeAnthropicKey(config)
+                  : getRuntimeOpenAiKey(config),
+              providerLabel: provider === 'anthropic' ? 'Anthropic' : 'OpenAI',
+            }) || undefined
+          : brainstormProviderApiKey(provider, { serverApiKey: server.apiKey }),
       baseUrl:
         provider === 'ollama'
           ? str(

--- a/server/api/chats/anthropic/stream.post.ts
+++ b/server/api/chats/anthropic/stream.post.ts
@@ -11,7 +11,7 @@ import {
   buildCloudProviderAuthHeaders,
   getErrorStatusCode,
   getRuntimeAnthropicKey,
-  resolveApiKeyPrecedence,
+  resolveGatedProviderKey,
   resolveOptionalTextServer,
   sendMeteredStream,
   setStreamHeaders,
@@ -66,10 +66,12 @@ export default defineEventHandler(async (event) => {
 
     const messages = normalizeMessages(body)
     const endpoint = getAnthropicEndpoint(server)
-    const apiKey = resolveApiKeyPrecedence({
+    const apiKey = resolveGatedProviderKey({
+      siteKeyAllowed: gate.siteKeyAllowed,
       userApiKey: body.userApiKey,
       serverApiKey: server?.apiKey,
       runtimeApiKey: getRuntimeAnthropicKey(config),
+      providerLabel: 'Anthropic',
     })
 
     assertProviderApiKey({

--- a/server/api/chats/openai/stream.post.ts
+++ b/server/api/chats/openai/stream.post.ts
@@ -11,7 +11,7 @@ import {
   buildCloudProviderAuthHeaders,
   getErrorStatusCode,
   getRuntimeOpenAiKey,
-  resolveApiKeyPrecedence,
+  resolveGatedProviderKey,
   resolveOptionalTextServer,
   sendMeteredStream,
   setStreamHeaders,
@@ -68,10 +68,12 @@ export default defineEventHandler(async (event) => {
 
     const messages = normalizeMessages(body)
     const endpoint = getOpenAiCompatibleEndpoint(server)
-    const apiKey = resolveApiKeyPrecedence({
+    const apiKey = resolveGatedProviderKey({
+      siteKeyAllowed: gate.siteKeyAllowed,
       userApiKey: body.userApiKey,
       serverApiKey: server?.apiKey,
       runtimeApiKey: getRuntimeOpenAiKey(config),
+      providerLabel: 'OpenAI',
     })
 
     assertProviderApiKey({

--- a/server/api/generate/text.post.ts
+++ b/server/api/generate/text.post.ts
@@ -25,7 +25,7 @@ import {
   getRuntimeAnthropicKey,
   getRuntimeOpenAiKey,
   readJsonWithSizeCap,
-  resolveApiKeyPrecedence,
+  resolveGatedProviderKey,
   sendMeteredStream,
   setStreamHeaders,
 } from '../../utils/textProviderService'
@@ -124,6 +124,7 @@ export default defineEventHandler(async (event) => {
       provider,
       server,
       userApiKey: body.userApiKey,
+      siteKeyAllowed: gate.siteKeyAllowed,
       config,
     })
 
@@ -282,9 +283,10 @@ async function buildUpstreamAuth(input: {
   provider: GenerationProvider
   server: Server | null
   userApiKey?: string | null
+  siteKeyAllowed: boolean
   config: ReturnType<typeof useRuntimeConfig>
 }): Promise<UpstreamAuth> {
-  const { provider, server, userApiKey, config } = input
+  const { provider, server, userApiKey, siteKeyAllowed, config } = input
 
   if (provider === 'ollama') {
     // Guaranteed non-null by the caller's earlier 400 guard.
@@ -293,13 +295,15 @@ async function buildUpstreamAuth(input: {
     return { headers, apiKeyPrefix: '', apiKeyLength: 0 }
   }
 
-  const apiKey = resolveApiKeyPrecedence({
+  const apiKey = resolveGatedProviderKey({
+    siteKeyAllowed,
     userApiKey,
     serverApiKey: server?.apiKey,
     runtimeApiKey:
       provider === 'anthropic'
         ? getRuntimeAnthropicKey(config)
         : getRuntimeOpenAiKey(config),
+    providerLabel: provider === 'anthropic' ? 'Anthropic' : 'OpenAI',
   })
 
   assertProviderApiKey({

--- a/server/api/music-mentor/analyze.post.ts
+++ b/server/api/music-mentor/analyze.post.ts
@@ -17,6 +17,11 @@ import {
   str,
 } from '../../utils/suggest/suggestProviders'
 import type { SuggestServerSnapshot } from '../../utils/suggest/suggestTypes'
+import {
+  getRuntimeAnthropicKey,
+  getRuntimeOpenAiKey,
+  resolveGatedProviderKey,
+} from '../../utils/textProviderService'
 
 type Dimension = 'intonation' | 'timing' | 'dynamics' | 'arrangement'
 
@@ -119,9 +124,16 @@ export default defineEventHandler(async (event) => {
       model,
       maxTokens,
       apiKey:
-        provider === 'anthropic'
-          ? str(config.anthropicApiKey)
-          : str(config.openaiApiKey),
+        provider === 'anthropic' || provider === 'openai'
+          ? resolveGatedProviderKey({
+              siteKeyAllowed: gate.siteKeyAllowed,
+              runtimeApiKey:
+                provider === 'anthropic'
+                  ? getRuntimeAnthropicKey(config)
+                  : getRuntimeOpenAiKey(config),
+              providerLabel: provider === 'anthropic' ? 'Anthropic' : 'OpenAI',
+            }) || undefined
+          : undefined,
       baseUrl:
         provider === 'ollama'
           ? str(

--- a/server/api/suggest.post.ts
+++ b/server/api/suggest.post.ts
@@ -14,6 +14,7 @@ import {
 } from '../utils/suggest/suggestProviders'
 import {
   getRuntimeAnthropicKey,
+  resolveGatedProviderKey,
   getRuntimeOpenAiKey,
 } from '../utils/textProviderService'
 import type { SuggestBody } from '../utils/suggest/suggestTypes'
@@ -120,11 +121,16 @@ export default defineEventHandler(async (event) => {
       model,
       maxTokens,
       apiKey:
-        provider === 'anthropic'
-          ? str(config.anthropicApiKey) || getRuntimeAnthropicKey(config)
-          : provider === 'openai'
-            ? str(config.openaiApiKey) || getRuntimeOpenAiKey(config)
-            : undefined,
+        provider === 'anthropic' || provider === 'openai'
+          ? resolveGatedProviderKey({
+              siteKeyAllowed: gate.siteKeyAllowed,
+              runtimeApiKey:
+                provider === 'anthropic'
+                  ? getRuntimeAnthropicKey(config)
+                  : getRuntimeOpenAiKey(config),
+              providerLabel: provider === 'anthropic' ? 'Anthropic' : 'OpenAI',
+            }) || undefined
+          : undefined,
       baseUrl:
         provider === 'ollama'
           ? str(

--- a/server/api/suggest.post.ts
+++ b/server/api/suggest.post.ts
@@ -14,8 +14,8 @@ import {
 } from '../utils/suggest/suggestProviders'
 import {
   getRuntimeAnthropicKey,
-  resolveGatedProviderKey,
   getRuntimeOpenAiKey,
+  resolveGatedProviderKey,
 } from '../utils/textProviderService'
 import type { SuggestBody } from '../utils/suggest/suggestTypes'
 

--- a/server/utils/manaGate.ts
+++ b/server/utils/manaGate.ts
@@ -10,6 +10,10 @@ import { resolveSpendResource } from './manaSpendResolution'
 import { resolveManaAttribution } from './manaAttribution'
 import type { ManaSource } from './manaAttribution'
 import {
+  siteKeyAllowedForFreeReason,
+  type FreeGenerationReason,
+} from './siteProviderKeyPolicy'
+import {
   computeRevenueSplit,
   computePaymentProcessingFeeCents,
   tokensToGrossCents,
@@ -53,6 +57,16 @@ type ManaGateResult = {
   }
   cost: number
   free: boolean
+  // Why `free` is true, or null when the request is actually being charged.
+  freeReason: FreeGenerationReason | null
+  // May this request be backed by the SITE's cloud provider key (runtime
+  // ANTHROPIC_API_KEY / OPENAI_API_KEY)? False when the charge was waived
+  // because the request claimed its own resource (`useOwnResource`, or a
+  // public non-official Server) -- such a request must bring its own key.
+  // See server/utils/siteProviderKeyPolicy.ts. Routes that talk to a cloud
+  // provider MUST pass this into resolveGatedProviderKey() rather than
+  // falling through to the runtime key unconditionally.
+  siteKeyAllowed: boolean
   // kind-economy/t-006: which pool `cost` will actually be drawn from if
   // committed -- 'TOKENS' when the user's paid balance alone covers it,
   // 'MANA' as the fallback (preserves pre-split "any balance that covers
@@ -108,7 +122,7 @@ export async function manaGate(
     })
   }
 
-  const free = await isFreeGeneration({
+  const freeReason = await freeGenerationReason({
     userId: user.id,
     serverId: input.serverId ?? null,
     useOwnResource: input.useOwnResource ?? false,
@@ -120,6 +134,8 @@ export async function manaGate(
     userRoles: [...userRoles(user)],
     kind: input.kind,
   })
+  const free = freeReason !== null
+  const siteKeyAllowed = siteKeyAllowedForFreeReason(freeReason)
 
   const cost = free
     ? 0
@@ -149,6 +165,8 @@ export async function manaGate(
     user,
     cost,
     free,
+    freeReason,
+    siteKeyAllowed,
     fundedBy,
     commit: async (refId: string, providerCostUsd?: number) => {
       // fundedBy is only ever null when cost <= 0 (see resolution above --
@@ -173,7 +191,7 @@ export async function manaGate(
       const result = await applyMana({
         userId: user.id,
         amount: -cost,
-        // input.kind === 'free' here is unreachable in practice (isFreeGeneration
+        // input.kind === 'free' here is unreachable in practice (freeGenerationReason
         // forces cost to 0 for 'free', which returns above before this call), but
         // REASON_BY_KIND has no 'free' entry, so this ternary is kept for type
         // safety. `resource` is always passed explicitly regardless of reason.
@@ -251,7 +269,12 @@ export async function manaGate(
   }
 }
 
-async function isFreeGeneration(input: {
+/** Returns WHY the request is free, or null when it should be charged. The
+ * order matters only for the label: the first matching reason wins, and the
+ * labels feed siteKeyAllowedForFreeReason() (see siteProviderKeyPolicy.ts),
+ * so a caller that is both an admin and claims useOwnResource is reported as
+ * 'admin' and keeps site-key access. */
+async function freeGenerationReason(input: {
   userId: number
   serverId?: number | null
   useOwnResource: boolean
@@ -262,23 +285,25 @@ async function isFreeGeneration(input: {
   // holds FAMILY as a secondary role.
   userRoles?: readonly string[] | null
   kind: ManaGateKind
-}): Promise<boolean> {
-  if (input.kind === 'free') return true
-  if (input.useOwnResource) return true
-  if (input.isAdmin) return true
-  if (input.isServerKey) return true
+}): Promise<FreeGenerationReason | null> {
+  if (input.kind === 'free') return 'kind-free'
+  if (input.isAdmin) return 'admin'
+  if (input.isServerKey) return 'server-key'
   if (
     (input.userRoles ?? []).some(
       (role) => String(role).toUpperCase() === 'FAMILY',
     )
   ) {
-    return true
+    return 'family'
   }
+  if (input.useOwnResource) return 'own-resource'
 
-  return await isFreeServerForUser({
+  const freeServer = await isFreeServerForUser({
     userId: input.userId,
     serverId: input.serverId ?? null,
   })
+
+  return freeServer ? 'free-server' : null
 }
 
 async function isFreeServerForUser(input: {

--- a/server/utils/siteProviderKeyPolicy.ts
+++ b/server/utils/siteProviderKeyPolicy.ts
@@ -1,0 +1,54 @@
+// /server/utils/siteProviderKeyPolicy.ts
+//
+// Who may spend the SITE's cloud provider keys (runtime ANTHROPIC_API_KEY /
+// OPENAI_API_KEY)?
+//
+// Background (2026-09-04, Silas: "kill the leaks"): every text route resolved
+// its upstream key as user key > stored Server key > site key, and the mana
+// gate waived the charge for `useOwnResource: true` or for a public
+// non-official Server. Those two facts composed badly -- a request that said
+// "I bring my own resource" but attached no key was free to the caller AND
+// fell through to the site key, so the site paid the provider bill for a
+// request nobody paid mana for. The same fallthrough applied to a public
+// Server row saved without a key.
+//
+// The rule this module encodes: the site key backs a request only when the
+// request is actually paid for (mana/tokens debited) or when the caller is
+// someone Silas has deliberately trusted with the site's spend -- an admin,
+// the server key itself (agents, Conductor), or a FAMILY account. A request
+// that was free BECAUSE it claimed its own resource must supply that
+// resource: its own key, or a Server row that carries one.
+//
+// Pure and DB-free so it can be verified directly
+// (utils/scripts/verifySiteProviderKeyPolicy.ts).
+
+/** Why the mana gate waived the charge for a request, when it did. */
+export type FreeGenerationReason =
+  | 'kind-free'
+  | 'own-resource'
+  | 'admin'
+  | 'server-key'
+  | 'family'
+  | 'free-server'
+
+/** May the site's provider key back a request whose charge was waived for
+ * `reason` (or not waived at all, `null`)? */
+export function siteKeyAllowedForFreeReason(
+  reason: FreeGenerationReason | null,
+): boolean {
+  // Paid request: the caller's mana/tokens cover the provider cost.
+  if (reason === null) return true
+
+  // Deliberately trusted callers.
+  if (reason === 'admin' || reason === 'server-key' || reason === 'family') {
+    return true
+  }
+
+  // Internal-only bypass (never requestable by an external caller -- see
+  // ManaGateChargeableKind in manaGate.ts).
+  if (reason === 'kind-free') return true
+
+  // 'own-resource' / 'free-server': the request was free precisely because it
+  // said it brings its own provider; hold it to that.
+  return false
+}

--- a/server/utils/textProviderService.ts
+++ b/server/utils/textProviderService.ts
@@ -96,6 +96,43 @@ export function resolveApiKeyPrecedence(options: {
   )
 }
 
+/** Gated variant of `resolveApiKeyPrecedence` for routes that sit behind
+ * `manaGate`. Same precedence (user key > stored Server key > site/runtime
+ * key), except the site key is only reachable when the gate said it may be
+ * (`gate.siteKeyAllowed` -- see server/utils/siteProviderKeyPolicy.ts). A
+ * request whose charge was waived because it claimed its own resource, but
+ * which attached no key of its own, gets a 402 here instead of silently
+ * spending the site's provider credits. Returns '' (for the caller's own
+ * `assertProviderApiKey`) only when no key exists at any level. */
+export function resolveGatedProviderKey(options: {
+  siteKeyAllowed: boolean
+  userApiKey?: string | null
+  serverApiKey?: string | null
+  runtimeApiKey?: string | null
+  providerLabel: string
+}): string {
+  const ownKey =
+    cleanProviderKey(options.userApiKey) ||
+    cleanProviderKey(options.serverApiKey)
+
+  if (ownKey) return ownKey
+
+  const runtimeKey = cleanProviderKey(options.runtimeApiKey)
+
+  if (runtimeKey && !options.siteKeyAllowed) {
+    throw createError({
+      statusCode: 402,
+      message:
+        `This request was not charged because it uses its own resource, so ` +
+        `the site's ${options.providerLabel} key cannot back it. Supply a ` +
+        `userApiKey, choose a server that stores its own key, or drop ` +
+        `useOwnResource to pay with mana.`,
+    })
+  }
+
+  return runtimeKey
+}
+
 /** Auth-header construction for a stored `Server` profile, generalized from
  * the Ollama route's `authType`-driven builder (`NONE`/`BEARER`/`HEADER`/
  * `API_KEY`). Any text-capable server type can reuse this -- it does not

--- a/utils/scripts/verifyBrainstormGeneration.ts
+++ b/utils/scripts/verifyBrainstormGeneration.ts
@@ -443,8 +443,23 @@ const suggestEndpoint = readFileSync(
 )
 assert.match(
   suggestEndpoint,
-  /provider === 'openai'[\s\S]*?str\(config\.openaiApiKey\)[\s\S]*?: undefined/,
+  /provider === 'anthropic' \|\| provider === 'openai'[\s\S]*?resolveGatedProviderKey\([\s\S]*?: undefined/,
   'first-party OpenAI keys must not fall through to arbitrary compatible URLs',
 )
+assert.doesNotMatch(
+  suggestEndpoint,
+  /str\(config\.(openai|anthropic)ApiKey\)/,
+  'suggest must resolve site keys through resolveGatedProviderKey, never read them raw',
+)
+for (const [label, source] of [
+  ['brainstorm/generate', endpoint],
+  ['suggest', suggestEndpoint],
+] as const) {
+  assert.match(
+    source,
+    /siteKeyAllowed: gate\.siteKeyAllowed/,
+    `${label} must gate the site provider key on manaGate's siteKeyAllowed (an own-resource/free-server request must never spend the site key)`,
+  )
+}
 
 console.log('Brainstorm generation contract passed.')

--- a/utils/scripts/verifyEntityArtPromptSuggest.ts
+++ b/utils/scripts/verifyEntityArtPromptSuggest.ts
@@ -53,9 +53,12 @@ expectContains('server/api/suggest.post.ts', [
   "builder === 'art-asset'",
   'resolveArtModelContext',
   'buildSuggestUserPrompt',
-  "import {\n  getRuntimeAnthropicKey,\n  getRuntimeOpenAiKey,\n} from '../utils/textProviderService'",
+  "import {\n  getRuntimeAnthropicKey,\n  getRuntimeOpenAiKey,\n  resolveGatedProviderKey,\n} from '../utils/textProviderService'",
   'getRuntimeAnthropicKey(config)',
   'getRuntimeOpenAiKey(config)',
+  // The site key is only reachable when manaGate allowed it -- an
+  // own-resource / free-server request must bring its own key.
+  'siteKeyAllowed: gate.siteKeyAllowed',
 ])
 
 expectContains('server/utils/textProviderService.ts', [

--- a/utils/scripts/verifySiteProviderKeyPolicy.ts
+++ b/utils/scripts/verifySiteProviderKeyPolicy.ts
@@ -1,0 +1,147 @@
+// /utils/scripts/verifySiteProviderKeyPolicy.ts
+//
+// Regression guard for the 2026-09-04 provider-credit leak: a request whose
+// mana charge was waived because it claimed its own resource (`useOwnResource`
+// with no key, or a public non-official Server saved without one) must never
+// fall through to the SITE's Anthropic/OpenAI key. Covers the two pure,
+// DB-free pieces every cloud text route now goes through:
+//   - siteKeyAllowedForFreeReason (server/utils/siteProviderKeyPolicy.ts),
+//     the policy manaGate.ts evaluates into `gate.siteKeyAllowed`
+//   - resolveGatedProviderKey (server/utils/textProviderService.ts), the
+//     precedence resolver the routes call instead of resolveApiKeyPrecedence
+import assert from 'node:assert/strict'
+import { siteKeyAllowedForFreeReason } from '../../server/utils/siteProviderKeyPolicy'
+import { resolveGatedProviderKey } from '../../server/utils/textProviderService'
+
+let failures = 0
+
+function check(label: string, fn: () => void): void {
+  try {
+    fn()
+    console.log(`ok - ${label}`)
+  } catch (error) {
+    failures += 1
+    console.error(`FAIL - ${label}`)
+    console.error(error instanceof Error ? error.message : error)
+  }
+}
+
+function statusOf(fn: () => unknown): number | null {
+  try {
+    fn()
+    return null
+  } catch (error) {
+    return (error as { statusCode?: number }).statusCode ?? -1
+  }
+}
+
+// -- siteKeyAllowedForFreeReason --------------------------------------------
+
+check('a paid request (no free reason) may use the site key', () => {
+  assert.equal(siteKeyAllowedForFreeReason(null), true)
+})
+
+check('admin, server-key, FAMILY, and internal kind-free keep site-key access', () => {
+  for (const reason of ['admin', 'server-key', 'family', 'kind-free'] as const) {
+    assert.equal(siteKeyAllowedForFreeReason(reason), true, reason)
+  }
+})
+
+check('own-resource and free-server waivers do NOT unlock the site key', () => {
+  assert.equal(siteKeyAllowedForFreeReason('own-resource'), false)
+  assert.equal(siteKeyAllowedForFreeReason('free-server'), false)
+})
+
+// -- resolveGatedProviderKey ------------------------------------------------
+
+check('user key wins regardless of gating', () => {
+  assert.equal(
+    resolveGatedProviderKey({
+      siteKeyAllowed: false,
+      userApiKey: ' sk-user ',
+      serverApiKey: 'sk-server',
+      runtimeApiKey: 'sk-site',
+      providerLabel: 'Anthropic',
+    }),
+    'sk-user',
+  )
+})
+
+check('stored Server key is the caller\'s own resource and is always usable', () => {
+  assert.equal(
+    resolveGatedProviderKey({
+      siteKeyAllowed: false,
+      serverApiKey: 'sk-server',
+      runtimeApiKey: 'sk-site',
+      providerLabel: 'OpenAI',
+    }),
+    'sk-server',
+  )
+})
+
+check('site key backs a request the gate allowed', () => {
+  assert.equal(
+    resolveGatedProviderKey({
+      siteKeyAllowed: true,
+      runtimeApiKey: 'sk-site',
+      providerLabel: 'Anthropic',
+    }),
+    'sk-site',
+  )
+})
+
+check('the leak: own-resource request with no key of its own is refused with 402', () => {
+  assert.equal(
+    statusOf(() =>
+      resolveGatedProviderKey({
+        siteKeyAllowed: false,
+        userApiKey: '',
+        serverApiKey: null,
+        runtimeApiKey: 'sk-site',
+        providerLabel: 'Anthropic',
+      }),
+    ),
+    402,
+  )
+})
+
+check('refusal message tells the caller how to proceed', () => {
+  try {
+    resolveGatedProviderKey({
+      siteKeyAllowed: false,
+      runtimeApiKey: 'sk-site',
+      providerLabel: 'OpenAI',
+    })
+    assert.fail('expected a throw')
+  } catch (error) {
+    const message = String((error as { message?: string }).message)
+    assert.match(message, /OpenAI/)
+    assert.match(message, /userApiKey/)
+    assert.match(message, /useOwnResource/)
+  }
+})
+
+check('no key anywhere resolves to "" for the route\'s own assertProviderApiKey', () => {
+  assert.equal(
+    resolveGatedProviderKey({
+      siteKeyAllowed: false,
+      runtimeApiKey: '',
+      providerLabel: 'Anthropic',
+    }),
+    '',
+  )
+  assert.equal(
+    resolveGatedProviderKey({
+      siteKeyAllowed: true,
+      providerLabel: 'Anthropic',
+    }),
+    '',
+  )
+})
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`)
+  process.exit(1)
+}
+
+console.log('\nsite provider key policy: all checks passed')


### PR DESCRIPTION
## Why

Every cloud text route resolved its upstream key as user key → stored Server key → site key, while `manaGate` waived the charge for `useOwnResource: true` or a public non-official Server. A request that claimed its own resource but attached no key was therefore free to the caller **and** billed to the site's Anthropic/OpenAI account. Any logged-in user could hit it, and agents holding the server key reached the same fallthrough.

## What

- `manaGate` now records **why** a request was free (`freeReason`) and derives `siteKeyAllowed` from it. Paid requests, admins, the server key, FAMILY, and the internal kind-free bypass keep site-key access. `own-resource` and `free-server` waivers do not.
- New pure module `server/utils/siteProviderKeyPolicy.ts` holds that rule.
- New `resolveGatedProviderKey` in `textProviderService.ts`: same precedence as before, but returns **402** with a how-to-fix message instead of using the site key for an own-resource request that brought no key.
- All seven cloud text routes go through it: `chats/anthropic`, `chats/openai`, `generate/text`, `suggest`, `music-mentor/analyze`, `brainstorm/generate`, `botcafe/chat`.
- `utils/scripts/verifySiteProviderKeyPolicy.ts` (DB-free) covers the policy and the resolver; wired into `contract-tests.yml` as `test:site-provider-key-policy`.

## Verified

- `verifySiteProviderKeyPolicy.ts` and the existing `verifyTextProviderService.ts` both pass locally.
- Typecheck (`vue-tsc`) runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKqVk1Vv4R2Z1qQusMnNCj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKqVk1Vv4R2Z1qQusMnNCj)_