### PR TITLE
interface-vision/t-104 slice 72: add .kr-btn-xs-lg, migrate hand-rolled 'btn btn-xs rounded-lg'

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -724,6 +724,16 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-sm;
   }
 
+  /* The bare-family counterpart to .kr-btn-ghost-xs-lg (interface-vision
+   * t-104 slice 72): the `xs` size with no color modifier, no ghost, and a
+   * `rounded-lg` override instead of .kr-btn's `rounded-xl` — `btn btn-xs
+   * rounded-lg`, previously hand-rolled in 7 files (10 occurrences). Named
+   * `.kr-btn-xs-lg` (size-radius) mirroring `.kr-btn-ghost-xs-lg`'s identical
+   * naming on the ghost branch of the family. */
+  .kr-btn-xs-lg {
+    @apply btn btn-xs rounded-lg;
+  }
+
   /* The most-repeated *icon* button shape in the app (interface-vision t-104
    * slice 64): a small circular ghost button used for close/dismiss/icon-only
    * controls — `btn btn-ghost btn-xs btn-circle`, previously hand-rolled in

--- a/components/animation/animation-manager.vue
+++ b/components/animation/animation-manager.vue
@@ -103,7 +103,7 @@
 
           <div class="mt-auto flex flex-wrap items-center gap-2">
             <button
-              class="btn btn-xs rounded-lg"
+              class="kr-btn-xs-lg"
               :class="store.isEffectActive(effect.id) ? 'btn-secondary' : 'btn-outline'"
               type="button"
               :title="store.isEffectActive(effect.id) ? 'Turn this effect off' : 'Trigger this effect live on screen'"

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -53,7 +53,7 @@
 
           <button
             v-if="activeGroup"
-            class="btn btn-xs rounded-lg"
+            class="kr-btn-xs-lg"
             :class="bulkSelectEnabled ? 'btn-primary' : 'btn-ghost'"
             type="button"
             @click="toggleBulkSelect"

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -38,7 +38,7 @@
         v-for="slot in slots"
         :key="slot.field"
         type="button"
-        class="btn btn-xs rounded-lg"
+        class="kr-btn-xs-lg"
         :class="selectedField === slot.field ? 'btn-secondary' : 'btn-ghost border border-base-300'"
         @click="selectSlot(slot.field)"
       >

--- a/components/art/stylist-calculator.vue
+++ b/components/art/stylist-calculator.vue
@@ -68,7 +68,7 @@
           v-for="chip in TIME_CHIPS"
           :key="chip.minutes"
           type="button"
-          class="btn btn-xs rounded-lg"
+          class="kr-btn-xs-lg"
           :class="totalMinutes === chip.minutes ? 'btn-primary' : 'btn-ghost border border-base-300'"
           @click="setMinutes(chip.minutes)"
         >

--- a/components/model-builder/model-builder-batch-editor.vue
+++ b/components/model-builder/model-builder-batch-editor.vue
@@ -58,7 +58,7 @@
       <div class="flex flex-wrap gap-1.5">
         <button
           type="button"
-          class="btn btn-xs rounded-lg"
+          class="kr-btn-xs-lg"
           :disabled="anyBatching || store.autoBuilding"
           @click="draftAll('pitch')"
         >
@@ -68,7 +68,7 @@
         <button
           v-if="!isAsset"
           type="button"
-          class="btn btn-xs rounded-lg"
+          class="kr-btn-xs-lg"
           :disabled="anyBatching || store.autoBuilding"
           @click="draftAll('fields')"
         >
@@ -78,7 +78,7 @@
         <button
           v-if="wantArt"
           type="button"
-          class="btn btn-xs rounded-lg"
+          class="kr-btn-xs-lg"
           :disabled="anyBatching || store.autoBuilding"
           @click="draftAll('artPrompt')"
         >
@@ -161,7 +161,7 @@
           />
           <button
             type="button"
-            class="btn btn-xs rounded-lg"
+            class="kr-btn-xs-lg"
             :disabled="
               anyBatching || store.autoBuilding || !batchValues[field.key]
             "

--- a/components/narrative/narrative-cast-card.vue
+++ b/components/narrative/narrative-cast-card.vue
@@ -78,7 +78,7 @@
         :key="option.key"
         :data-role-key="option.key"
         type="button"
-        class="btn btn-xs rounded-lg px-1.5 text-[0.65rem] font-bold"
+        class="kr-btn-xs-lg px-1.5 text-[0.65rem] font-bold"
         :class="role === option.key ? 'btn-secondary' : 'btn-ghost'"
         :aria-pressed="role === option.key"
         :title="`${option.label} — ${option.description}`"

--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -391,7 +391,7 @@
               v-for="monthOption in MONTH_LABELS"
               :key="monthOption.value"
               type="button"
-              class="btn btn-xs rounded-lg"
+              class="kr-btn-xs-lg"
               :class="
                 activeMonths.has(monthOption.value)
                   ? 'btn-primary'


### PR DESCRIPTION
### What
Continuing conductor's `interface-vision/t-104` front-end-consistency sweep (slice 72). Adds `.kr-btn-xs-lg`, the bare-family counterpart to `.kr-btn-ghost-xs-lg`: the `xs` size with no color modifier, no ghost, and a `rounded-lg` override instead of `.kr-btn`'s `rounded-xl` — `btn btn-xs rounded-lg`, previously hand-rolled in 7 files (10 occurrences).

### What changed
- `assets/css/tailwind.css`: new `.kr-btn-xs-lg { @apply btn btn-xs rounded-lg; }` primitive, named to mirror `.kr-btn-ghost-xs-lg`'s identical naming on the ghost branch of the family.
- Migrated all 10 occurrences across 7 files to the new class:
  - `components/animation/animation-manager.vue`
  - `components/art/art-gallery.vue`
  - `components/art/entity-art-manager.vue`
  - `components/art/stylist-calculator.vue`
  - `components/model-builder/model-builder-batch-editor.vue` (4 occurrences)
  - `components/narrative/narrative-cast-card.vue` (kept its appended `px-1.5 text-[0.65rem] font-bold` instance overrides)
  - `components/watchlist/watchlist-browse.vue`
- No geometry or behavior change — each site's dynamic `:class` color/state binding is untouched.

### Verification
- Checked `utils/scripts/*.mjs` for a hardcoded regression guard on the `btn btn-xs rounded-lg` class string (the slice 69 lesson) — none found.
- `vue-tsc --noEmit` — clean
- `eslint` on all touched files — no new errors (the 5 pre-existing errors in `art-gallery.vue`/`entity-art-manager.vue` reproduce identically on `main`, unrelated to this diff)
- `prettier --check` — no new drift (identical file list flags on `main` before this change)
- `npm run test:layout-contract` — holds, no new violations
- `npm run test:lint-ratchet` — holds, 333 problems / -59 (unchanged)

### Stakes
reversible (CSS primitive + class-name swap only, no geometry/behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExrJftLvDKcVFnpyxtmAEF

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExrJftLvDKcVFnpyxtmAEF)_