### PR TITLE
interface-vision/t-104 slice 73: add .kr-btn-join-sm, migrate hand-rolled 'btn btn-sm join-item'

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -734,6 +734,19 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-xs rounded-lg;
   }
 
+  /* The joined-button-group shape (interface-vision t-104 slice 73): a bare
+   * (no color modifier, no ghost) `sm` button with DaisyUI's `join-item`
+   * modifier for `.join` button groups — `btn btn-sm join-item`, previously
+   * hand-rolled in 7 files (11 occurrences, split across two class-order
+   * variants: `btn btn-sm join-item` and `btn join-item btn-sm`). This is a
+   * distinct shape axis from every other `.kr-btn-*` primitive so far — none
+   * of them carry `join-item` — flagged as the next lead by slices 70 and 71.
+   * Named `.kr-btn-join-sm` (shape-size) mirroring `.kr-btn-ghost-circle-xs`'s
+   * convention of adding a shape modifier as its own naming dimension. */
+  .kr-btn-join-sm {
+    @apply btn btn-sm join-item;
+  }
+
   /* The most-repeated *icon* button shape in the app (interface-vision t-104
    * slice 64): a small circular ghost button used for close/dismiss/icon-only
    * controls — `btn btn-ghost btn-xs btn-circle`, previously hand-rolled in

--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -22,7 +22,7 @@
               v-for="option in lessonFilterOptions"
               :key="option.value"
               type="button"
-              class="btn btn-sm join-item"
+              class="kr-btn-join-sm"
               :class="lessonFilter === option.value ? 'btn-primary' : 'btn-ghost'"
               :aria-pressed="lessonFilter === option.value"
               @click="lessonFilter = option.value"

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -467,7 +467,7 @@
                 v-for="segment in botTypeSegments"
                 :key="segment.value"
                 type="button"
-                class="btn join-item btn-sm"
+                class="kr-btn-join-sm"
                 :class="
                   botTypeFilter === segment.value
                     ? 'btn-primary'

--- a/components/coloring/coloring-book-production-history.vue
+++ b/components/coloring/coloring-book-production-history.vue
@@ -19,7 +19,7 @@
           v-for="option in filters"
           :key="option.value"
           type="button"
-          class="btn btn-sm join-item"
+          class="kr-btn-join-sm"
           :class="filter === option.value ? 'btn-secondary' : 'btn-ghost'"
           @click="filter = option.value"
         >

--- a/components/conductor/challenge-center-page.vue
+++ b/components/conductor/challenge-center-page.vue
@@ -103,7 +103,7 @@
                   v-for="option in statusOptions"
                   :key="option"
                   type="button"
-                  class="btn btn-sm join-item"
+                  class="kr-btn-join-sm"
                   :class="statusFilter === option ? 'btn-secondary' : 'btn-ghost'"
                   @click="statusFilter = option"
                 >

--- a/components/dreams/daily-digest-browser.vue
+++ b/components/dreams/daily-digest-browser.vue
@@ -171,7 +171,7 @@
         <div class="join shrink-0">
           <button
             type="button"
-            class="btn join-item btn-sm"
+            class="kr-btn-join-sm"
             :disabled="!canGoOlder"
             aria-label="Show the previous daily digest"
             @click="showOlder"
@@ -181,7 +181,7 @@
           </button>
           <button
             type="button"
-            class="btn join-item btn-sm"
+            class="kr-btn-join-sm"
             :disabled="!canGoNewer"
             aria-label="Show the next daily digest"
             @click="showNewer"

--- a/components/pages/mermaids-page.vue
+++ b/components/pages/mermaids-page.vue
@@ -8,7 +8,7 @@
         <div class="join">
           <button
             type="button"
-            class="btn btn-sm join-item"
+            class="kr-btn-join-sm"
             :class="visitorPreview ? 'btn-ghost' : 'btn-primary'"
             @click="visitorPreview = false"
           >
@@ -16,7 +16,7 @@
           </button>
           <button
             type="button"
-            class="btn btn-sm join-item"
+            class="kr-btn-join-sm"
             :class="visitorPreview ? 'btn-primary' : 'btn-ghost'"
             @click="visitorPreview = true"
           >

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -17,7 +17,7 @@
             type="button"
             role="tab"
             :aria-selected="interactionMode === 'study'"
-            class="btn btn-sm join-item"
+            class="kr-btn-join-sm"
             :class="interactionMode === 'study' ? 'btn-primary' : 'btn-ghost'"
             @click="setMode('study')"
           >
@@ -27,7 +27,7 @@
             type="button"
             role="tab"
             :aria-selected="interactionMode === 'explore'"
-            class="btn btn-sm join-item"
+            class="kr-btn-join-sm"
             :class="interactionMode === 'explore' ? 'btn-primary' : 'btn-ghost'"
             @click="setMode('explore')"
           >
@@ -41,7 +41,7 @@
             :key="view.value"
             type="button"
             role="tab"
-            class="btn btn-sm join-item"
+            class="kr-btn-join-sm"
             :class="workspaceView === view.value ? 'btn-accent' : 'btn-ghost'"
             :aria-selected="workspaceView === view.value"
             @click="workspaceView = view.value"


### PR DESCRIPTION
## Summary
- Repo-wide grep for the next most-repeated hand-rolled `btn` combination (the lead slices 70/71 flagged) surfaced `btn-sm join-item` as the top uncovered shape: a bare (no color, no ghost) `sm` button with DaisyUI's `join-item` modifier for `.join` button groups, hand-rolled in 7 files (11 occurrences) split across two class-order variants (`btn btn-sm join-item` and `btn join-item btn-sm`). No existing `.kr-btn-*` primitive carries `join-item`.
- Added `.kr-btn-join-sm` and migrated all 11 occurrences across 7 files: `academy-styles-browser.vue`, `bot-gallery.vue`, `coloring-book-production-history.vue`, `challenge-center-page.vue`, `daily-digest-browser.vue`, `mermaids-page.vue`, `mandarin.vue`.
- No geometry or behavior change.
- Left out of scope (distinct shapes, next-slice candidates): `btn-xs join-item` (2 files/4 occ) and the one outline+join-item occurrence in `mandarin.vue`.

## Verification
- `vue-tsc --noEmit`: clean.
- `eslint` on touched `.vue` files: 0 new issues.
- `prettier --check`: flags the same pre-existing drift on all 7 touched files as unmodified `main` (confirmed via `git stash`).
- `test:layout-contract`: holds (207 baseline, unchanged).
- `test:lint-ratchet`: holds (333/-59, no rule regressed).

## Context
Picked up as the recurring `interface-vision/t-104` (front-end kr-* component consistency sweep) task from a Conductor session-start sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E82ScwFpTH7QR6LX4E4Ufj

---
_Generated by [Claude Code](https://claude.ai/code/session_01E82ScwFpTH7QR6LX4E4Ufj)_