### PR TITLE
interface-vision/t-104 slice 74: add .kr-btn-join-xs, migrate hand-rolled 'btn btn-xs join-item'

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -747,6 +747,17 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-sm join-item;
   }
 
+  /* The `xs`-size counterpart to .kr-btn-join-sm (interface-vision t-104
+   * slice 74): the same bare (no color modifier, no ghost) join-group shape,
+   * one size down — `btn btn-xs join-item`, previously hand-rolled in 3
+   * files (5 occurrences, split across two class-order variants: `btn
+   * btn-xs join-item` and `btn join-item btn-xs`). Named `.kr-btn-join-xs`
+   * (shape-size) mirroring `.kr-btn-join-sm`'s naming on the `sm` branch of
+   * the same shape axis. */
+  .kr-btn-join-xs {
+    @apply btn btn-xs join-item;
+  }
+
   /* The most-repeated *icon* button shape in the app (interface-vision t-104
    * slice 64): a small circular ghost button used for close/dismiss/icon-only
    * controls — `btn btn-ghost btn-xs btn-circle`, previously hand-rolled in

--- a/components/user/user-galleries.vue
+++ b/components/user/user-galleries.vue
@@ -91,7 +91,7 @@
               <div class="join">
                 <button
                   type="button"
-                  class="btn join-item btn-xs"
+                  class="kr-btn-join-xs"
                   :class="
                     sectionDisplayModes[section.key] === 'list'
                       ? 'btn-secondary'
@@ -103,7 +103,7 @@
                 </button>
                 <button
                   type="button"
-                  class="btn join-item btn-xs"
+                  class="kr-btn-join-xs"
                   :class="
                     sectionDisplayModes[section.key] === 'gallery'
                       ? 'btn-secondary'

--- a/components/video-lora-picker.vue
+++ b/components/video-lora-picker.vue
@@ -14,7 +14,7 @@
         <div class="join" aria-label="LoRA browser size">
           <button
             type="button"
-            class="btn btn-xs join-item"
+            class="kr-btn-join-xs"
             :class="browserSize === 'comfortable' ? 'btn-accent' : 'btn-ghost'"
             @click="browserSize = 'comfortable'"
           >
@@ -22,7 +22,7 @@
           </button>
           <button
             type="button"
-            class="btn btn-xs join-item"
+            class="kr-btn-join-xs"
             :class="browserSize === 'expanded' ? 'btn-accent' : 'btn-ghost'"
             @click="browserSize = 'expanded'"
           >

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -216,7 +216,7 @@
                   v-for="prompt in promptModes"
                   :key="prompt.value"
                   type="button"
-                  class="btn btn-xs join-item"
+                  class="kr-btn-join-xs"
                   :class="studyPromptMode === prompt.value ? 'btn-secondary' : 'btn-ghost'"
                   :title="prompt.title"
                   @click="studyPromptMode = prompt.value"


### PR DESCRIPTION
## What

Recurring `interface-vision/t-104` slice 74 (the kr-* consistency sweep). Continuing from slice 73's next-lead notes.

Added `.kr-btn-join-xs` (the `xs`-size counterpart to slice 73's `.kr-btn-join-sm`) and migrated all 5 occurrences of hand-rolled `btn btn-xs join-item` / `btn join-item btn-xs` (2 class-order variants) across 3 files:

- `components/user/user-galleries.vue` (2 occurrences)
- `components/video-lora-picker.vue` (2 occurrences)
- `pages/play/mandarin.vue` (1 occurrence)

No geometry or behavior change — each button's dynamic color/state `:class` binding (e.g. `btn-secondary`/`btn-ghost`, `btn-accent`/`btn-ghost`) is preserved unchanged alongside the new static class.

## Guard check

Per the slice 69 lesson, grepped `utils/scripts/*.mjs` and `*.ts` for the literal class strings being replaced before migrating — no hardcoded source-text regression guard references either variant.

## Verification

- `vue-tsc --noEmit`: clean
- `eslint` on all touched files: clean (the CSS file warns "no matching configuration," expected/pre-existing)
- `prettier --check`: flagged the same 4 files pre-edit (confirmed via `git stash`) — no new drift introduced
- `test:layout-contract`: holds (207 baseline, unchanged)
- `test:lint-ratchet`: holds (333/-59, no rule regressed)

## Next slice candidate

The one remaining `btn btn-outline btn-sm join-item` occurrence (lone instance, `pages/play/mandarin.vue`) wasn't migrated this slice — it's a single occurrence, below the "most-repeated" bar this task's convention has used for spinning up a new primitive so far. Left as a candidate for a future slice if another occurrence of that exact combination turns up elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wy3U6XEy2Npr1xjShZzRjm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy3U6XEy2Npr1xjShZzRjm)_