### PR TITLE
interface-vision/t-104 slice 75: add .kr-btn-2xl, migrate hand-rolled 'btn btn-sm rounded-2xl'

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -734,6 +734,17 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-xs rounded-lg;
   }
 
+  /* The bare-family counterpart to .kr-btn-ghost-2xl (interface-vision
+   * t-104 slice 75): the same `sm` size as .kr-btn, but with a wider
+   * `rounded-2xl` corner radius instead of `rounded-xl` — `btn btn-sm
+   * rounded-2xl`, previously hand-rolled in 7 files (8 occurrences). Named
+   * for the radius it overrides (not a size suffix) since the size matches
+   * the base .kr-btn shape, mirroring `.kr-btn-ghost-2xl`'s identical
+   * naming on the ghost branch of the family. */
+  .kr-btn-2xl {
+    @apply btn btn-sm rounded-2xl;
+  }
+
   /* The joined-button-group shape (interface-vision t-104 slice 73): a bare
    * (no color modifier, no ghost) `sm` button with DaisyUI's `join-item`
    * modifier for `.join` button groups — `btn btn-sm join-item`, previously

--- a/components/art/artjob-slideshow.vue
+++ b/components/art/artjob-slideshow.vue
@@ -99,7 +99,7 @@
               </button>
               <button
                 type="button"
-                class="btn btn-sm rounded-2xl"
+                class="kr-btn-2xl"
                 :class="isPlaying ? 'btn-ghost' : 'btn-primary'"
                 title="Play or pause (space)"
                 @click="togglePlaying"
@@ -124,7 +124,7 @@
               </button>
               <button
                 type="button"
-                class="btn btn-sm rounded-2xl"
+                class="kr-btn-2xl"
                 :class="settingsOpen ? 'btn-primary' : 'btn-ghost'"
                 title="Slideshow options (s)"
                 @click="settingsOpen = !settingsOpen"

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -185,7 +185,7 @@
             v-for="tab in modeTabs"
             :key="tab.key"
             type="button"
-            class="btn btn-sm rounded-2xl"
+            class="kr-btn-2xl"
             :class="
               activeMode === tab.key ? 'btn-primary text-white' : 'btn-ghost'
             "

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -42,7 +42,7 @@
           v-for="tab in modeTabs"
           :key="tab.key"
           type="button"
-          class="btn btn-sm rounded-2xl"
+          class="kr-btn-2xl"
           :class="
             activeMode === tab.key ? 'btn-primary text-white' : 'btn-ghost'
           "

--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -70,7 +70,7 @@
       <button
         v-for="pack in packStore.manifests"
         :key="pack.id"
-        class="btn btn-sm rounded-2xl"
+        class="kr-btn-2xl"
         :class="
           pack.id === selectedPackId
             ? 'btn-primary'

--- a/components/conductor/sketchy-page.vue
+++ b/components/conductor/sketchy-page.vue
@@ -24,7 +24,7 @@
             type="button"
             role="tab"
             :aria-selected="activeTier === tier.key"
-            class="btn btn-sm rounded-2xl"
+            class="kr-btn-2xl"
             :class="
               activeTier === tier.key
                 ? 'btn-primary'

--- a/components/giftshop/giftshop-manager.vue
+++ b/components/giftshop/giftshop-manager.vue
@@ -14,7 +14,7 @@
 
       <button
         type="button"
-        class="btn btn-sm rounded-2xl"
+        class="kr-btn-2xl"
         :class="managerError ? 'btn-error' : 'btn-ghost'"
         :disabled="isLoadingManager"
         @click="refreshManagerData"

--- a/components/manager/kr-manager.vue
+++ b/components/manager/kr-manager.vue
@@ -81,7 +81,7 @@
 
       <button
         type="button"
-        class="btn btn-sm rounded-2xl"
+        class="kr-btn-2xl"
         :class="error ? 'btn-error' : 'btn-ghost'"
         :disabled="loading"
         @click="emit('refresh')"


### PR DESCRIPTION
### Task
interface-vision/t-104: recurring kr-* front-end consistency sweep — slice 75 (kind: software)

### What changed / what I produced
- Added `.kr-btn-2xl` (`btn btn-sm rounded-2xl`) to `assets/css/tailwind.css`, the bare-family counterpart to `.kr-btn-ghost-2xl` (same `sm` size as `.kr-btn`, `rounded-2xl` radius instead of `rounded-xl`).
- Migrated all 8 occurrences of hand-rolled `btn btn-sm rounded-2xl` across 7 files: `components/art/artjob-slideshow.vue` (x2), `components/conductor/sketchy-page.vue`, `components/conductor/packmaker-admin-panel.vue`, `components/giftshop/giftshop-manager.vue`, `components/manager/kr-manager.vue`, `components/characters/character-flip-card.vue`, `components/characters/character-chat.vue`.
- No geometry or behavior change — each site's dynamic `:class` color/state binding on top of the base class is preserved unchanged.
- Left out of scope (not real duplication): `components/ui/ui-gallery.vue`'s 4 `btn btn-primary` occurrences (intentional style-guide demo of the raw DaisyUI variant) and `sample/sample-manager.vue.txt` (a non-live scaffold template, not part of the compiled app).

### How I verified
- Checked `utils/scripts/*.mjs`/`*.ts` for a hardcoded regression-guard string matching the replaced class first (slice 69 lesson) — none found.
- `npm run test` (vue-tsc --noEmit): clean.
- `eslint` on changed files: 0 new issues (2 pre-existing errors on `character-flip-card.vue`/`giftshop-manager.vue`, confirmed present on `main` via `git stash`).
- `prettier --check`: only pre-existing drift on `tailwind.css` (confirmed via `git stash`).
- `npm run test:layout-contract`: holds at the 207-violation baseline, zero new violations.
- `npm run test:lint-ratchet`: holds (333/-59, no rule worsened).

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Next slice candidate: the lone `btn btn-outline btn-sm join-item` occurrence in `mandarin.vue`, still below the most-repeated bar this task's convention uses to justify a new primitive — worth combining with any future sibling occurrence if one turns up elsewhere.

### Notes for reviewer
Conductor roadmap task `interface-vision/t-104` will be re-armed to `status: ready` in a companion conductor PR once this merges, per the recurring-task convention (never `done`).

https://claude.ai/code/session_0181kdyHRjm6oNduPYZQJeyv

---
_Generated by [Claude Code](https://claude.ai/code/session_0181kdyHRjm6oNduPYZQJeyv)_