### PR TITLE
interface-vision/t-104 slice 76: add .kr-btn-ghost-xs-2xl, migrate hand-rolled 'btn btn-ghost btn-xs rounded-2xl'

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -619,6 +619,17 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-ghost btn-xs rounded-lg;
   }
 
+  /* The `xs`-size counterpart to .kr-btn-ghost-2xl (interface-vision t-104
+   * slice 76): the `xs` size from .kr-btn-ghost-xs/-xs-plain/-xs-lg, but
+   * with a `rounded-2xl` corner override instead — `btn btn-ghost btn-xs
+   * rounded-2xl`, previously hand-rolled in 5 files (7 occurrences). Named
+   * `.kr-btn-ghost-xs-2xl` (size-radius) mirroring `.kr-btn-ghost-xs-lg`'s
+   * identical two-axis naming, since both the size and the radius deviate
+   * from the base .kr-btn-ghost shape at once. */
+  .kr-btn-ghost-xs-2xl {
+    @apply btn btn-ghost btn-xs rounded-2xl;
+  }
+
   /* Sixth-most-repeated ghost-button shape (interface-vision t-104 slice 47):
    * the `sm` size from .kr-btn-ghost, but with no rounded-* override, so it
    * renders at DaisyUI's own default button radius instead of rounded-xl —

--- a/components/art/artjob-feedback-manager.vue
+++ b/components/art/artjob-feedback-manager.vue
@@ -19,7 +19,7 @@
         </div>
         <button
           type="button"
-          class="btn btn-ghost btn-xs rounded-2xl"
+          class="kr-btn-ghost-xs-2xl"
           :disabled="artJobStore.loadingTrainerJobs"
           @click="artJobStore.fetchTrainerJobs()"
         >

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -276,7 +276,7 @@
             <div class="flex items-center gap-2">
               <button
                 type="button"
-                class="btn btn-ghost btn-xs rounded-2xl"
+                class="kr-btn-ghost-xs-2xl"
                 :disabled="
                   !artJobStore.jobHasPreviousPage || artJobStore.loadingJobs
                 "
@@ -298,7 +298,7 @@
               </label>
               <button
                 type="button"
-                class="btn btn-ghost btn-xs rounded-2xl"
+                class="kr-btn-ghost-xs-2xl"
                 :disabled="
                   !artJobStore.jobHasNextPage || artJobStore.loadingJobs
                 "

--- a/components/art/artjob-queue-card.vue
+++ b/components/art/artjob-queue-card.vue
@@ -281,7 +281,7 @@
       <div class="mt-auto flex flex-wrap items-center justify-between gap-2">
         <button
           type="button"
-          class="btn btn-ghost btn-xs rounded-2xl"
+          class="kr-btn-ghost-xs-2xl"
           :disabled="!jobPrompt || !canShowJobContent"
           :title="
             canShowJobContent
@@ -347,7 +347,7 @@
           <button
             v-if="job.status === 'FAILED'"
             type="button"
-            class="btn btn-ghost btn-xs rounded-2xl"
+            class="kr-btn-ghost-xs-2xl"
             @click="artJobStore.requeueJob(job.id)"
           >
             Resume unchanged

--- a/components/art/artjob-slideshow.vue
+++ b/components/art/artjob-slideshow.vue
@@ -241,7 +241,7 @@
               <h3 class="text-sm font-black">Slideshow options</h3>
               <button
                 type="button"
-                class="btn btn-ghost btn-xs rounded-2xl"
+                class="kr-btn-ghost-xs-2xl"
                 @click="settingsOpen = false"
               >
                 Done

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -241,7 +241,7 @@
                 <button
                   v-if="candidates.length"
                   type="button"
-                  class="btn btn-ghost btn-xs rounded-2xl"
+                  class="kr-btn-ghost-xs-2xl"
                   @click="clearCandidates"
                 >
                   Clear


### PR DESCRIPTION
### Task
interface-vision/t-104: recurring kr-* front-end consistency sweep — slice 76 (kind: software)

### What changed / what I produced
- Added `.kr-btn-ghost-xs-2xl` (`btn btn-ghost btn-xs rounded-2xl`) to `assets/css/tailwind.css`, the `xs`-size counterpart to `.kr-btn-ghost-2xl` (mirrors `.kr-btn-ghost-xs-lg`'s two-axis size+radius naming).
- Migrated all 7 occurrences of hand-rolled `btn btn-ghost btn-xs rounded-2xl` across 5 files: `components/art/artjob-queue-browser.vue` (x2), `components/art/artjob-queue-card.vue` (x2), `components/art/artjob-slideshow.vue`, `components/art/artjob-feedback-manager.vue`, `components/dreams/dream-brainstorm.vue`.
- No geometry or behavior change.

### How I verified
- Checked `utils/scripts/*.mjs`/`*.ts` for a hardcoded regression-guard string matching the replaced class first (slice 69 lesson) — none found.
- `npm run test` (vue-tsc --noEmit): clean.
- `eslint` on changed files: 0 new issues.
- `prettier --check`: only pre-existing drift on `artjob-feedback-manager.vue`/`dream-brainstorm.vue`/`tailwind.css` (confirmed via `git stash`).
- `npm run test:layout-contract`: holds at the 207-violation baseline, zero new violations.
- `npm run test:lint-ratchet`: holds (333/-59, no rule worsened).

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Next slice candidates spotted this pass: `btn btn-primary` bare (7 real occurrences across 5 files, excluding `ui-gallery.vue`'s intentional style-guide demo) and `btn btn-xs rounded-2xl` bare (6 occurrences) — either is a clean next slice.

### Notes for reviewer
Conductor roadmap task `interface-vision/t-104` will be re-armed to `status: ready` in a companion conductor PR once this merges, per the recurring-task convention (never `done`).

https://claude.ai/code/session_0181kdyHRjm6oNduPYZQJeyv

---
_Generated by [Claude Code](https://claude.ai/code/session_0181kdyHRjm6oNduPYZQJeyv)_