### PR TITLE
interface-vision/t-104 slice 77: add .kr-btn-primary-md-plain, migrate hand-rolled 'btn btn-primary'

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -697,6 +697,20 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-primary rounded-2xl;
   }
 
+  /* Fifth filled-button shape (interface-vision t-104 slice 77): DaisyUI's
+   * pure, wholly unmodified `btn btn-primary` — no `btn-sm` utility and no
+   * `rounded-*` override at all — previously hand-rolled in 6 files (7
+   * occurrences; ui-gallery.vue's 4 identical-looking occurrences are its
+   * intentional style-guide demo and stay out of scope, matching every
+   * prior slice's convention for that page). Suffixed `-md-plain` (size
+   * then dropped radius) since it combines .kr-btn-primary-md's default
+   * size with .kr-btn-primary-plain's dropped radius override — both axes
+   * at once, mirroring .kr-btn-primary-md-2xl's identical two-axis naming
+   * on this same family. */
+  .kr-btn-primary-md-plain {
+    @apply btn btn-primary;
+  }
+
   /* The most-repeated *secondary*-color button shape (interface-vision t-104
    * slice 61): the same `sm`/`rounded-xl` shape as .kr-btn-primary, filled
    * with the secondary color instead — `btn btn-secondary btn-sm rounded-xl`,

--- a/components/animation/animation-manager.vue
+++ b/components/animation/animation-manager.vue
@@ -172,7 +172,7 @@
         </dl>
 
         <button
-          class="btn btn-primary"
+          class="kr-btn-primary-md-plain"
           type="button"
           @click="store.previewEffect(store.selectedItem.id)"
         >

--- a/components/mandarin/mandarin-voice-coach.vue
+++ b/components/mandarin/mandarin-voice-coach.vue
@@ -42,7 +42,7 @@
         <button
           v-if="!recording"
           type="button"
-          class="btn btn-primary"
+          class="kr-btn-primary-md-plain"
           :disabled="evaluating || !voiceSupported"
           @click="startRecording"
         >

--- a/components/ruler-hooked/ruler-hooked-game.vue
+++ b/components/ruler-hooked/ruler-hooked-game.vue
@@ -21,7 +21,7 @@
           </div>
           <button
             type="button"
-            class="btn btn-primary"
+            class="kr-btn-primary-md-plain"
             :disabled="!store.canFish"
             @click="store.startFishing()"
           >

--- a/components/user/forum-thread.vue
+++ b/components/user/forum-thread.vue
@@ -67,7 +67,7 @@
         />
         <div class="flex gap-2">
           <button
-            class="btn btn-primary"
+            class="kr-btn-primary-md-plain"
             :disabled="posting"
             @click="postThread(channel.slug)"
           >

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -257,7 +257,7 @@
                   </div>
                   <div v-else class="space-y-3">
                     <Icon name="kind-icon:volume" class="mx-auto size-12 opacity-60" />
-                    <button type="button" class="btn btn-primary" @click="store.speak(currentCard)">Hear prompt</button>
+                    <button type="button" class="kr-btn-primary-md-plain" @click="store.speak(currentCard)">Hear prompt</button>
                     <p class="text-xs opacity-55">Listen without seeing the answer.</p>
                   </div>
                 </div>
@@ -287,7 +287,7 @@
               <div class="flex min-h-72 flex-col justify-between gap-4 p-4 sm:p-5">
                 <div v-if="studyPhase !== 'revealed'" class="my-auto space-y-3 text-center">
                   <p class="text-sm font-semibold opacity-55">Recall the meaning before revealing.</p>
-                  <button type="button" class="btn btn-primary" @click="store.revealStudyCard()">Reveal answer</button>
+                  <button type="button" class="kr-btn-primary-md-plain" @click="store.revealStudyCard()">Reveal answer</button>
                 </div>
 
                 <div v-else class="space-y-3">
@@ -384,7 +384,7 @@
                 </div>
 
                 <div class="my-auto py-5 text-center">
-                  <button v-if="!meaningVisible" type="button" class="btn btn-primary" @click="store.toggleMeaning()">Reveal meaning</button>
+                  <button v-if="!meaningVisible" type="button" class="kr-btn-primary-md-plain" @click="store.toggleMeaning()">Reveal meaning</button>
                   <div v-else class="space-y-1">
                     <p class="text-3xl font-bold">{{ currentCard.meaning }}</p>
                     <p v-if="currentCard.meanings.length > 1" class="text-sm opacity-60">{{ currentCard.meanings.slice(1).join(' · ') }}</p>


### PR DESCRIPTION
## What

Recurring `interface-vision/t-104` (the ongoing kr-* front-end consistency sweep). Continuing from slice 76, grepped for the next most-repeated hand-rolled `btn` combination not yet covered by an existing `.kr-btn-*` primitive.

DaisyUI's pure, wholly unmodified `btn btn-primary` — no `btn-sm` utility and no `rounded-*` override at all — was hand-rolled in 6 files (7 occurrences). None of the existing primary-family primitives (`.kr-btn-primary` = sm+rounded-xl, `.kr-btn-primary-md` = default-size+rounded-xl, `.kr-btn-primary-plain` = sm+no-radius, `.kr-btn-primary-md-2xl` = default-size+rounded-2xl) matches this shape.

## Fix

Added `.kr-btn-primary-md-plain { @apply btn btn-primary; }` — named "size then dropped radius" since it combines `.kr-btn-primary-md`'s default size with `.kr-btn-primary-plain`'s dropped radius override, mirroring `.kr-btn-primary-md-2xl`'s identical two-axis naming convention on this same family.

Migrated all 7 occurrences: `components/user/forum-thread.vue`, `components/mandarin/mandarin-voice-coach.vue`, `components/animation/animation-manager.vue`, `components/ruler-hooked/ruler-hooked-game.vue`, `pages/play/mandarin.vue` (3 occurrences). No geometry or behavior change.

Left out of scope: `ui-gallery.vue`'s 4 identical-looking `btn btn-primary` occurrences — its intentional style-guide demo page, matching every prior slice's convention for that page.

Checked `utils/scripts/*.mjs`/`*.ts` for a hardcoded class-string regression guard first (slice 69 lesson) — none found.

## Verification

- `vue-tsc --noEmit`: clean
- `eslint` on touched files: 0 issues (the `tailwind.css` warning is expected — CSS isn't linted)
- `prettier --check`: pre-existing drift on 4 of 5 touched `.vue`/`.css` files confirmed via `git stash` (unchanged by this diff); `forum-thread.vue` clean
- `test:layout-contract`: holds (207 baseline, unchanged)
- `test:lint-ratchet`: holds (333/-59, no rule regressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRop5oc2yHeo9MksAoSB37

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRop5oc2yHeo9MksAoSB37)_