### PR TITLE
interface-vision/t-104 slice 78: add .kr-btn-primary-xs-lg, migrate hand-rolled 'btn btn-primary btn-xs rounded-lg'

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -711,6 +711,20 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-primary;
   }
 
+  /* Sixth filled-button shape (interface-vision t-104 slice 78): a small
+   * `xs` primary button with a `rounded-lg` corner radius instead of
+   * `rounded-xl` — `btn btn-primary btn-xs rounded-lg`, previously
+   * hand-rolled in 4 files (8 occurrences, split across two class-order
+   * variants: `btn btn-xs btn-primary rounded-lg` and `btn btn-primary
+   * btn-xs rounded-lg`). Suffixed `-xs-lg` (size then radius) mirroring
+   * `.kr-btn-ghost-xs-lg`'s identical two-axis naming on the ghost family.
+   * Near-miss sites with extra appended classes (shrink-0, gap-1, gap-1.5)
+   * are left out of scope for a follow-up slice, matching this family's
+   * own convention. */
+  .kr-btn-primary-xs-lg {
+    @apply btn btn-primary btn-xs rounded-lg;
+  }
+
   /* The most-repeated *secondary*-color button shape (interface-vision t-104
    * slice 61): the same `sm`/`rounded-xl` shape as .kr-btn-primary, filled
    * with the secondary color instead — `btn btn-secondary btn-sm rounded-xl`,

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -70,7 +70,7 @@
           />
 
           <button
-            class="btn btn-primary btn-xs rounded-lg"
+            class="kr-btn-primary-xs-lg"
             type="button"
             :disabled="isLoading"
             @click="refreshGallery"

--- a/components/model-builder/model-builder-batch-editor.vue
+++ b/components/model-builder/model-builder-batch-editor.vue
@@ -98,7 +98,7 @@
         </button>
         <button
           type="button"
-          class="btn btn-xs btn-primary rounded-lg"
+          class="kr-btn-primary-xs-lg"
           :disabled="anyBatching || store.autoBuilding"
           :title="autoBuildGroupTitle"
           @click="store.batchAutoBuild(group.outputKey)"

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -98,7 +98,7 @@
           </button>
           <button
             type="button"
-            class="btn btn-xs btn-primary rounded-lg"
+            class="kr-btn-primary-xs-lg"
             :disabled="isLocked('PITCH') || !pitch.trim()"
             @click="approve('PITCH')"
           >
@@ -213,7 +213,7 @@
           </button>
           <button
             type="button"
-            class="btn btn-xs btn-primary rounded-lg"
+            class="kr-btn-primary-xs-lg"
             :disabled="isLocked('FIELDS_AND_PROMPTS')"
             @click="approve('FIELDS_AND_PROMPTS')"
           >
@@ -345,7 +345,7 @@
           </button>
           <button
             type="button"
-            class="btn btn-xs btn-primary rounded-lg"
+            class="kr-btn-primary-xs-lg"
             :disabled="!canApproveAssets"
             @click="approve('GENERATE_ASSETS')"
           >

--- a/components/user/friends-panel.vue
+++ b/components/user/friends-panel.vue
@@ -27,7 +27,7 @@
           >
           <div class="flex gap-1">
             <button
-              class="btn btn-primary btn-xs rounded-lg"
+              class="kr-btn-primary-xs-lg"
               @click="friends.confirmRequest(r.id)"
             >
               Accept
@@ -71,7 +71,7 @@
           </div>
           <div class="flex gap-1">
             <button
-              class="btn btn-primary btn-xs rounded-lg"
+              class="kr-btn-primary-xs-lg"
               @click="message(id)"
             >
               Message
@@ -129,7 +129,7 @@
               v-if="
                 friends.relationship(u.id) === 'none' && u.allowFriendRequests
               "
-              class="btn btn-primary btn-xs rounded-lg"
+              class="kr-btn-primary-xs-lg"
               @click="friends.sendFriendRequest(u.id)"
             >
               Add friend


### PR DESCRIPTION
## What

Recurring `interface-vision/t-104` (kr-* consistency sweep), slice 78. Continuing the search for the most-repeated hand-rolled DaisyUI/Tailwind button combination not yet covered by an existing `.kr-btn-*` primitive.

Found `btn btn-primary btn-xs rounded-lg` — previously hand-rolled in 4 files (8 occurrences, split across two class-order variants: `btn btn-xs btn-primary rounded-lg` and `btn btn-primary btn-xs rounded-lg`).

## Fix

Added `.kr-btn-primary-xs-lg` (`btn btn-primary btn-xs rounded-lg`), mirroring `.kr-btn-ghost-xs-lg`'s established two-axis (size then radius) naming convention on the primary-color branch of the family. Migrated all 8 occurrences:
- `components/model-builder/model-builder-item-panel.vue` (3)
- `components/model-builder/model-builder-batch-editor.vue` (1)
- `components/user/friends-panel.vue` (3)
- `components/art/art-gallery.vue` (1)

No geometry/behavior change. Left out of scope (matching this family's own convention): near-miss sites with extra appended classes (`shrink-0`, `gap-1`, `gap-1.5`) — a future slice candidate.

## Verification

- `vue-tsc --noEmit`: clean
- `eslint` on touched files: 0 new issues (2 pre-existing `no-dynamic-delete` errors in `art-gallery.vue`, confirmed unrelated and pre-existing via `git stash`)
- `prettier --check`: pre-existing formatting drift on 4 files, confirmed via `git stash` (unchanged by this diff)
- `npm run test:layout-contract`: holds (207 baseline, unchanged)
- `npm run test:lint-ratchet`: holds (333/-59, no rule regressed)
- `git status --porcelain` scoped to exactly the 5 intended files

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017HZnwXmSQ43UKda853uqJr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HZnwXmSQ43UKda853uqJr

---
_Generated by [Claude Code](https://claude.ai/code/session_017HZnwXmSQ43UKda853uqJr)_