### PR TITLE
interface-vision/t-104 slice 79: add .kr-btn-primary-md-white, migrate hand-rolled 'btn btn-primary rounded-xl text-white'

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -725,6 +725,19 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-primary btn-xs rounded-lg;
   }
 
+  /* Seventh filled-button shape (interface-vision t-104 slice 79): closes
+   * the `text-white` near-miss `.kr-btn-primary`'s own comment (slice 51)
+   * flagged as deferred scope. DaisyUI's own default (unmodified) button
+   * size plus the same `rounded-xl` override as .kr-btn-primary-md, with an
+   * explicit `text-white` override on top — `btn btn-primary rounded-xl
+   * text-white`, previously hand-rolled in 4 files (7 occurrences, all in
+   * the identical class order). Suffixed `-md-white` (size then text-color)
+   * mirroring `.kr-btn-primary-md-2xl`'s identical two-axis naming on this
+   * same family, with `white` naming the added axis instead of a radius. */
+  .kr-btn-primary-md-white {
+    @apply btn btn-primary rounded-xl text-white;
+  }
+
   /* The most-repeated *secondary*-color button shape (interface-vision t-104
    * slice 61): the same `sm`/`rounded-xl` shape as .kr-btn-primary, filled
    * with the secondary color instead — `btn btn-secondary btn-sm rounded-xl`,

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -336,7 +336,7 @@
               </button>
 
               <button
-                class="btn btn-primary rounded-xl text-white"
+                class="kr-btn-primary-md-white"
                 type="button"
                 :disabled="!canSendChat"
                 @click="sendCharacterChat"
@@ -393,7 +393,7 @@
               </button>
 
               <button
-                class="btn btn-primary rounded-xl text-white"
+                class="kr-btn-primary-md-white"
                 type="button"
                 :disabled="!adventurePrompt"
                 @click="copyAdventurePrompt"
@@ -448,7 +448,7 @@
               </button>
 
               <button
-                class="btn btn-primary rounded-xl text-white"
+                class="kr-btn-primary-md-white"
                 type="button"
                 :disabled="!promptText.trim()"
                 @click="copyPrompt"

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -228,7 +228,7 @@
               </button>
 
               <button
-                class="btn btn-primary rounded-xl text-white"
+                class="kr-btn-primary-md-white"
                 type="button"
                 :disabled="!canSendChat"
                 @click="sendCharacterChat"
@@ -285,7 +285,7 @@
               </button>
 
               <button
-                class="btn btn-primary rounded-xl text-white"
+                class="kr-btn-primary-md-white"
                 type="button"
                 :disabled="!adventurePrompt"
                 @click="copyAdventurePrompt"
@@ -327,7 +327,7 @@
               </button>
 
               <button
-                class="btn btn-primary rounded-xl text-white"
+                class="kr-btn-primary-md-white"
                 type="button"
                 :disabled="!promptText.trim()"
                 @click="copyPrompt"

--- a/components/wonderlab/reaction-card.vue
+++ b/components/wonderlab/reaction-card.vue
@@ -128,7 +128,7 @@
         </div>
 
         <button
-          class="btn btn-primary rounded-xl text-white"
+          class="kr-btn-primary-md-white"
           :class="compact ? 'btn-sm' : ''"
           type="button"
           :disabled="isSubmitting || !canSubmit"


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Added `.kr-btn-primary-md-white` to `assets/css/tailwind.css`'s `.kr-btn-primary` family — `btn btn-primary rounded-xl text-white`, the exact `text-white` near-miss `.kr-btn-primary`'s own slice-51 comment flagged as deferred scope.
- Migrated all 7 occurrences (4 files, identical class order) from the hand-rolled class to the new primitive: `components/characters/character-chat.vue` (x3), `components/characters/character-flip-card.vue` (x3), `components/wonderlab/reaction-card.vue` (x1).
- No geometry or behavior change — same DaisyUI classes, just centralized.

### How I verified
- `npm run test` (vue-tsc, full project): clean.
- `npx eslint` on all 4 changed files: one pre-existing `no-unused-vars` error in `character-flip-card.vue` (confirmed via `git stash` — present before this change, unrelated to this diff).
- `npx prettier --check` on changed files: pre-existing drift on `tailwind.css` and `reaction-card.vue` (confirmed via `git stash` — present before this change).
- `npm run test:layout-contract`: holds at the 207 baseline, no new violations.
- `npm run test:lint-ratchet`: holds at 333/-59, no rule got worse.

### Stakes
reversible

### Kaizen suggestion
None beyond continuing the umbrella sweep — no new systemic issue surfaced this slice.

### Notes for reviewer
Conductor task `interface-vision/t-104` set to `status: review` (recurring umbrella; will re-arm to `ready` after merge, per AGENTS.md's recurring-task convention).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AoNv9WmPa1XWPGKBvccvS7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AoNv9WmPa1XWPGKBvccvS7)_