### PR TITLE
animation-manager/t-007: register geode-bloom in the animation catalog

### DIFF
--- a/stores/animationCatalog.ts
+++ b/stores/animationCatalog.ts
@@ -511,6 +511,17 @@ export const ANIMATION_EFFECTS = [
     generationSafe: true,
     preferredSurface: 'fullscreen',
   },
+  {
+    id: 'geode-bloom',
+    label: 'Geode Bloom',
+    reveal: 'Crystal catches the light',
+    icon: 'kind-icon:gem',
+    tooltip:
+      'Faceted crystal clusters nucleate in a hollow geode cavity, grow outward along fixed lattice directions until they catch the light, then recede facet-by-facet to free room for the next formation 💎 hover for a glint, click to seed a new cluster',
+    color: '#3fb6d1',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
 ] as const satisfies readonly AnimationEffectDefinition[]
 
 export type AnimationEffectId = (typeof ANIMATION_EFFECTS)[number]['id']


### PR DESCRIPTION
### Task
animation-manager/t-007: Build or polish one animation candidate from reaction evidence (kind: software)

### What changed / what I produced
- PR #2407 shipped `components/screenfx/geode-bloom.vue` but never added the matching `stores/animationCatalog.ts` entry — found on Reviewer follow-up audit after merging #2407. Every other build in this project registers its catalog entry in the same PR (e.g. `hourglass-cascade`, PR #2367); this closes that gap so Geode Bloom is actually reachable from Screen FX, explicit startup preferences, and the random opening pool, per the project's own goal.
- Added the `geode-bloom` entry: `kind-icon:gem`, color `#3fb6d1` (matching the component's cyan-to-violet facet hue range), tooltip summarizing the pitch's passive loop and optional interaction.

### How I verified
- `npm run test:animation-catalog`: 49 effects, 62 screenfx components resolved (was 61/48 before this entry — geode-bloom now included and consistent).
- `npm run test:animation-component-attempts`: clean.
- `npm run test` (vue-tsc): clean.
- `npx eslint stores/animationCatalog.ts`: clean (exit 0).
- `npx prettier --check`: pre-existing drift on this file confirmed via `git stash` (unrelated to this change).

### Stakes
reversible

### Kaizen suggestion
None beyond a general note: worth double-checking catalog registration explicitly in the animation-manager PR review checklist, since a component can ship, pass all CI, and still be silently unreachable if the catalog entry is missed (as it was here).

### Notes for reviewer
Fixes a self-merged gap — I reviewed and merged #2407 as animation-manager/t-007's Reviewer, then found the missing registration on a follow-up audit before closing out. Filing this immediately rather than leaving it live on main.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AoNv9WmPa1XWPGKBvccvS7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AoNv9WmPa1XWPGKBvccvS7)_