### PR TITLE
Stop Unraid orphan image accumulation

### DIFF
--- a/.github/workflows/python-scripts.yml
+++ b/.github/workflows/python-scripts.yml
@@ -8,19 +8,21 @@ name: Python scripts
 # container_log_triage.py prints log lines from ~50 containers into a terminal
 # whose output Silas pastes back, which makes its redaction path a hard safety
 # rule (AGENTS.md 15), not a nicety. Those tests have to run in the CI that
-# gates deployment; tests one repo away from the code they guard are tests
-# that quietly stop running.
+# gates deployment; tests one repo away from the code they guard are tests that
+# quietly stop running.
 
 on:
   pull_request:
     paths:
       - "scripts/**.py"
+      - "scripts/deploy-unraid.sh"
       - "tests/python/**"
       - ".github/workflows/python-scripts.yml"
   push:
     branches: [main]
     paths:
       - "scripts/**.py"
+      - "scripts/deploy-unraid.sh"
       - "tests/python/**"
       - ".github/workflows/python-scripts.yml"
   workflow_dispatch:

--- a/docs/runbooks/unraid-auto-deploy.md
+++ b/docs/runbooks/unraid-auto-deploy.md
@@ -10,6 +10,7 @@ The production path is therefore host-driven:
 4. Pending Prisma migrations from that image run through the isolated `kindrobot_migrate` credential.
 5. Only after migrations succeed does Unraid's own DockerMan updater recreate `KindRobots` from its saved template.
 6. The script waits for the container health check before reporting success.
+7. After a healthy handoff, the deployer removes dangling Docker images carrying Kind Robots' `org.opencontainers.image.source` label. It does not run a host-wide image prune or touch other projects' images.
 
 If migration fails, the container update is not attempted. The long-running application never receives `MIGRATION_DATABASE_URL`.
 
@@ -52,6 +53,8 @@ No human migration step is required after ordinary merges once the User Script i
 The scheduled launcher refreshes a clean `main` checkout with `git pull --ff-only`, then runs `scripts/deploy-unraid.sh`.
 
 The deployer uses `flock`, so overlapping User Script runs cannot race each other. It records the image whose migrations were last verified and rechecks migrations at least once per day even when the image has not changed. This repairs the common failure mode where a container was manually Force Updated while the migration step was skipped.
+
+DockerMan's `latest`-tag handoff can leave the previously running image untagged, which Unraid displays as an **orphan image**. Each scheduled deploy check now removes only dangling images labeled as originating from `silasfelinus/kind_robots`, including backlog from earlier deploys. Images belonging to Kapowarr or any other container are outside this cleanup's scope.
 
 User Scripts captures each run's output. For direct troubleshooting, run:
 

--- a/scripts/deploy-unraid.sh
+++ b/scripts/deploy-unraid.sh
@@ -13,6 +13,7 @@ LOCK_FILE="${KIND_ROBOTS_DEPLOY_LOCK:-/var/lock/kindrobots-auto-deploy.lock}"
 UNRAID_UPDATE_SCRIPT="${KIND_ROBOTS_UNRAID_UPDATE_SCRIPT:-/usr/local/emhttp/plugins/dynamix.docker.manager/scripts/update_container}"
 MIGRATION_RECHECK_SECONDS="${KIND_ROBOTS_MIGRATION_RECHECK_SECONDS:-86400}"
 HEALTH_TIMEOUT_SECONDS="${KIND_ROBOTS_HEALTH_TIMEOUT_SECONDS:-120}"
+IMAGE_SOURCE_LABEL="${KIND_ROBOTS_IMAGE_SOURCE_LABEL:-https://github.com/silasfelinus/kind_robots}"
 
 log() {
   printf '[kindrobots-deploy] %s %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
@@ -113,6 +114,36 @@ wait_for_health() {
   fail "container did not become healthy within ${HEALTH_TIMEOUT_SECONDS}s"
 }
 
+cleanup_dangling_kindrobots_images() {
+  local current_id="$1"
+  local image_id removed=0
+
+  # DockerMan retags `latest` to the new image when it recreates the container,
+  # which leaves the prior locally-pulled build as a dangling image. Only remove
+  # dangling images that carry Kind Robots' OCI source label. This deliberately
+  # avoids a host-wide `docker image prune`, so other containers keep their own
+  # rollback/cache images.
+  while IFS= read -r image_id; do
+    [[ -n "$image_id" ]] || continue
+    [[ "$image_id" == "$current_id" ]] && continue
+
+    if docker image rm "$image_id" >/dev/null 2>&1; then
+      removed=$((removed + 1))
+    else
+      log "WARNING: could not remove dangling KindRobots image $image_id; leaving it alone"
+    fi
+  done < <(
+    docker image ls \
+      --quiet \
+      --filter dangling=true \
+      --filter "label=org.opencontainers.image.source=$IMAGE_SOURCE_LABEL"
+  )
+
+  if (( removed > 0 )); then
+    log "removed $removed dangling KindRobots image(s)"
+  fi
+}
+
 log "checking registry image $IMAGE"
 docker pull "$IMAGE"
 
@@ -134,6 +165,7 @@ else
 fi
 
 if [[ "$needs_update" == false ]]; then
+  cleanup_dangling_kindrobots_images "$running_id"
   log 'KindRobots already runs the latest image'
   exit 0
 fi
@@ -156,4 +188,5 @@ fi
 wait_for_health
 
 final_id="$(docker inspect -f '{{.Image}}' "$CONTAINER")"
+cleanup_dangling_kindrobots_images "$final_id"
 log "deploy complete: container=$CONTAINER image=$final_id"

--- a/tests/python/test_deploy_unraid.py
+++ b/tests/python/test_deploy_unraid.py
@@ -15,7 +15,9 @@ def test_orphan_cleanup_is_scoped_to_kindrobots_images() -> None:
     assert '--filter dangling=true' in text
     assert '--filter "label=org.opencontainers.image.source=$IMAGE_SOURCE_LABEL"' in text
     assert 'docker image rm "$image_id"' in text
-    assert "docker image prune" not in text
+    assert not any(
+        line.lstrip().startswith("docker image prune") for line in text.splitlines()
+    )
 
 
 def test_orphan_cleanup_never_precedes_successful_health_check() -> None:

--- a/tests/python/test_deploy_unraid.py
+++ b/tests/python/test_deploy_unraid.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+
+DEPLOY_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "deploy-unraid.sh"
+
+
+def script_text() -> str:
+    return DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+
+def test_orphan_cleanup_is_scoped_to_kindrobots_images() -> None:
+    text = script_text()
+
+    assert 'IMAGE_SOURCE_LABEL="${KIND_ROBOTS_IMAGE_SOURCE_LABEL:-https://github.com/silasfelinus/kind_robots}"' in text
+    assert '--filter dangling=true' in text
+    assert '--filter "label=org.opencontainers.image.source=$IMAGE_SOURCE_LABEL"' in text
+    assert 'docker image rm "$image_id"' in text
+    assert "docker image prune" not in text
+
+
+def test_orphan_cleanup_never_precedes_successful_health_check() -> None:
+    text = script_text()
+
+    wait_index = text.index("wait_for_health\n\nfinal_id=")
+    post_health_cleanup_index = text.index(
+        'cleanup_dangling_kindrobots_images "$final_id"', wait_index
+    )
+
+    assert post_health_cleanup_index > wait_index
+
+
+def test_noop_deploy_also_cleans_existing_kindrobots_orphans() -> None:
+    text = script_text()
+    noop_block = text.split('if [[ "$needs_update" == false ]]; then', 1)[1].split("fi", 1)[0]
+
+    assert 'cleanup_dangling_kindrobots_images "$running_id"' in noop_block
+    assert "exit 0" in noop_block


### PR DESCRIPTION
## Root cause

The Alexandria deploy loop pulls `ghcr.io/silasfelinus/kind_robots:latest` and DockerMan recreates `KindRobots`, but the deployer never removes the previously pulled image after `latest` moves. With the current high merge cadence, those untagged builds pile up in Unraid as `(orphan image)` entries.

## Fix

- After a no-op deploy check or a successful healthy handoff, remove **only** dangling images carrying Kind Robots' `org.opencontainers.image.source` label.
- Deliberately avoid a host-wide `docker image prune`, so Kapowarr and unrelated containers are untouched.
- Add regression coverage for label scoping, health-check ordering, and cleanup during no-op checks so the existing backlog is reclaimed even without another container replacement.
- Document the cleanup behavior in the Alexandria runbook.

## Verification

CI should run the Python ops tests because `scripts/deploy-unraid.sh` is now included in that workflow's path filter. The production container is not manually updated by this PR; Alexandria remains host-driven through the existing User Script path.