### PR TITLE
interface-vision/t-104 slice 80: add .kr-btn-xs-2xl, migrate hand-rolled 'btn btn-xs rounded-2xl'

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -797,6 +797,17 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-sm rounded-2xl;
   }
 
+  /* The bare-family counterpart to .kr-btn-ghost-xs-2xl (interface-vision
+   * t-104 slice 80): the `xs` size from .kr-btn-xs-lg, but with a
+   * `rounded-2xl` corner override instead of `rounded-lg` — `btn btn-xs
+   * rounded-2xl`, previously hand-rolled in 4 files (6 occurrences). Named
+   * `.kr-btn-xs-2xl` (size-radius) mirroring `.kr-btn-ghost-xs-2xl`'s
+   * identical two-axis naming, since both the size and the radius deviate
+   * from the base .kr-btn shape at once. */
+  .kr-btn-xs-2xl {
+    @apply btn btn-xs rounded-2xl;
+  }
+
   /* The joined-button-group shape (interface-vision t-104 slice 73): a bare
    * (no color modifier, no ghost) `sm` button with DaisyUI's `join-item`
    * modifier for `.join` button groups — `btn btn-sm join-item`, previously

--- a/components/art/artjob-feedback-manager.vue
+++ b/components/art/artjob-feedback-manager.vue
@@ -36,7 +36,7 @@
           v-for="option in reviewModes"
           :key="option.value"
           type="button"
-          class="btn btn-xs rounded-2xl"
+          class="kr-btn-xs-2xl"
           :class="reviewMode === option.value ? 'btn-primary' : 'btn-ghost'"
           @click="reviewMode = option.value"
         >

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -84,7 +84,7 @@
             <h3 class="text-sm font-semibold">Private art servers</h3>
             <button
               type="button"
-              class="btn btn-xs rounded-2xl"
+              class="kr-btn-xs-2xl"
               :class="
                 artJobStore.queuePaused
                   ? 'btn-success'
@@ -230,7 +230,7 @@
                 v-for="filter in statusFilters"
                 :key="filter"
                 type="button"
-                class="btn btn-xs rounded-2xl"
+                class="kr-btn-xs-2xl"
                 :class="
                   artJobStore.jobStatusFilter === filter
                     ? 'btn-primary'

--- a/components/art/artjob-queue-card.vue
+++ b/components/art/artjob-queue-card.vue
@@ -297,7 +297,7 @@
           <button
             v-if="job.status === 'PENDING'"
             type="button"
-            class="btn btn-xs rounded-2xl"
+            class="kr-btn-xs-2xl"
             :class="job.priority > 0 ? 'btn-outline' : 'btn-accent'"
             :disabled="priorityStore.prioritizingJobIds.includes(job.id)"
             @click="togglePriority"

--- a/components/art/artjob-slideshow.vue
+++ b/components/art/artjob-slideshow.vue
@@ -277,7 +277,7 @@
                   v-for="choice in intervalChoices"
                   :key="choice"
                   type="button"
-                  class="btn btn-xs rounded-2xl"
+                  class="kr-btn-xs-2xl"
                   :class="
                     intervalSeconds === choice ? 'btn-primary' : 'btn-ghost'
                   "
@@ -299,7 +299,7 @@
                   v-for="choice in depthChoices"
                   :key="choice"
                   type="button"
-                  class="btn btn-xs rounded-2xl"
+                  class="kr-btn-xs-2xl"
                   :class="depth === choice ? 'btn-primary' : 'btn-ghost'"
                   @click="selectDepth(choice)"
                 >


### PR DESCRIPTION
## What changed

Adds `.kr-btn-xs-2xl` — the bare-family counterpart to `.kr-btn-ghost-xs-2xl` (slice 76): the `xs` size with no color modifier and no ghost, with a `rounded-2xl` corner override instead of `.kr-btn-xs-lg`'s `rounded-lg` — `btn btn-xs rounded-2xl`.

Previously hand-rolled identically (same class order, no extra utilities, no color modifier) in 4 files, 6 occurrences:
- `components/art/artjob-feedback-manager.vue`
- `components/art/artjob-slideshow.vue` (x2)
- `components/art/artjob-queue-card.vue`
- `components/art/artjob-queue-browser.vue` (x2)

All 6 migrated to `.kr-btn-xs-2xl`. Each site keeps its existing dynamic `:class` color-state binding untouched (e.g. `btn-primary`/`btn-ghost` toggling) — only the static base class changes. Zero geometry/behavior change.

Checked `utils/scripts/*.mjs`/`*.ts` for a hardcoded class-string regression guard first (slice 69 lesson) — none found referencing this pattern.

## Verification

- `vue-tsc --noEmit` (`npm run test`): clean, exit 0
- `eslint` on changed files: 0 new issues
- `prettier --check` on changed files: 2 files flagged (`artjob-feedback-manager.vue`, `tailwind.css`) — confirmed **pre-existing on `main`** via `git stash` + re-check, not introduced by this diff
- `npm run test:layout-contract`: holds, 207 baseline unchanged
- `npm run test:lint-ratchet`: 333 problems / -59, matches prior slice's baseline, holds

## Out of scope

Only the exact bare `btn btn-xs rounded-2xl` combination (no color modifier, no extra utility classes) was touched. Near-miss occurrences with color modifiers, `gap-*`, `shrink-0`, `flex-1`, or `h-auto`/`py-*` overrides in `dream-brainstorm.vue`, `dream-art-chooser.vue`, `resource-gallery.vue`, `resource-manager.vue`, and elsewhere in the `artjob-*` files were left untouched, matching this family's established convention of only migrating exact matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1yyAtsouV5WN43qqxmFZw

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1yyAtsouV5WN43qqxmFZw)_