### PR TITLE
interface-vision/t-104 slice 81: add .kr-btn-md-2xl, migrate 'btn rounded-2xl'

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -808,6 +808,19 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-xs rounded-2xl;
   }
 
+  /* The bare-family counterpart to .kr-btn-primary-md-2xl (interface-vision
+   * t-104 slice 81): DaisyUI's own default (unmodified) button size — no
+   * `btn-sm`/`btn-xs` utility at all — combined with a wider `rounded-2xl`
+   * corner radius instead of `rounded-xl` — `btn rounded-2xl`, previously
+   * hand-rolled in 4 files (5 occurrences, all identical class order).
+   * Suffixed `-md-2xl` (size then radius) since both the size and the
+   * radius deviate from the base .kr-btn shape at once, mirroring
+   * `.kr-btn-primary-md-2xl`'s identical two-axis naming on the primary
+   * branch of this family. */
+  .kr-btn-md-2xl {
+    @apply btn rounded-2xl;
+  }
+
   /* The joined-button-group shape (interface-vision t-104 slice 73): a bare
    * (no color modifier, no ghost) `sm` button with DaisyUI's `join-item`
    * modifier for `.join` button groups — `btn btn-sm join-item`, previously

--- a/components/art/art-test.vue
+++ b/components/art/art-test.vue
@@ -883,14 +883,14 @@ onMounted(async () => {
                   @input="updateSeed"
                 />
                 <button
-                  class="btn rounded-2xl"
+                  class="kr-btn-md-2xl"
                   type="button"
                   @click="seed = null"
                 >
                   ⟳
                 </button>
                 <button
-                  class="btn rounded-2xl"
+                  class="kr-btn-md-2xl"
                   type="button"
                   @click="seed = Math.floor(Math.random() * 999999999)"
                 >

--- a/components/coloring/coloring-book-production-toolbar.vue
+++ b/components/coloring/coloring-book-production-toolbar.vue
@@ -136,7 +136,7 @@
 
         <button
           type="button"
-          class="btn rounded-2xl"
+          class="kr-btn-md-2xl"
           :class="canRequestBw ? 'btn-secondary' : 'btn-disabled'"
           :disabled="!canRequestBw || studio.requestingAction"
           @click="requestBw(false)"

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -463,7 +463,7 @@
           <button
             v-if="userStore.isAdmin"
             type="button"
-            class="btn rounded-2xl"
+            class="kr-btn-md-2xl"
             :class="requestNeedsForce ? 'btn-secondary' : 'btn-accent'"
             :disabled="studio.requestingRender || promptDirty"
             @click="requestRender"

--- a/components/coloring/production-action-button.vue
+++ b/components/coloring/production-action-button.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     type="button"
-    class="btn rounded-2xl"
+    class="kr-btn-md-2xl"
     :class="armed ? 'btn-warning' : enabled ? 'btn-primary' : 'btn-disabled'"
     :disabled="!enabled || busy"
     @click="emit('click')"


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Added `.kr-btn-md-2xl` to `assets/css/tailwind.css` -- the bare-family counterpart to `.kr-btn-primary-md-2xl`: DaisyUI's default (unmodified) button size with a `rounded-2xl` radius override, no color modifier.
- Migrated all 5 hand-rolled `btn rounded-2xl` occurrences across 4 files: `components/coloring/coloring-book-production-toolbar.vue`, `components/coloring/production-action-button.vue`, `components/coloring/coloring-book-studio.vue`, `components/art/art-test.vue` (x2). Each site's dynamic `:class` color-state binding is preserved untouched.
- No geometry or behavior change -- pure class-string substitution to an existing shape.

### How I verified
- `vue-tsc --noEmit` (via `npm run test`): clean, 0 errors.
- `eslint` on all 5 changed files: 0 new issues.
- `prettier --check`: flagged pre-existing drift on 3 of the 5 files (`art-test.vue`, `coloring-book-production-toolbar.vue`, `coloring-book-studio.vue`, plus `tailwind.css`), confirmed identical via `git stash` + recheck against `origin/main` -- not introduced by this diff.
- `npm run test:layout-contract`: holds, 207 baseline unchanged.
- `npm run test:lint-ratchet`: holds, 333 problems/-59, matches the prior slice's exact baseline.
- Checked `utils/scripts/*.mjs` and `*.ts` for a hardcoded class-string regression guard on the outgoing `btn rounded-2xl` string or the 4 touched files first (slice 69 lesson) -- none found; the one file that mentions `coloring-book-studio.vue` in a comment (`verifyDaVinciNarrationErrorRoleGuard.ts`) only checks a different component (`davinci-page.vue`).

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
None new this cycle -- the mechanical grep-and-migrate loop is still working cleanly.

### Notes for reviewer
Conductor: interface-vision/t-104, session `2026-09-05T093000Z-interface-vision-t104-sweep`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNY91CVn2RzLbw7w8SYmg1

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNY91CVn2RzLbw7w8SYmg1)_