### PR TITLE
fix: keep Krea LoRAs separate from Flux

### DIFF
--- a/server/utils/artLoraResource.ts
+++ b/server/utils/artLoraResource.ts
@@ -2,6 +2,7 @@
 import { createError } from 'h3'
 import { ResourceType, SupportedServer } from '~/prisma/generated/prisma/client'
 import { resolveMaturityPrivacy } from '~/utils/maturityPrivacy'
+import { krea2LoraCompatibilityRank } from '~/utils/loraSelection'
 import { MAX_LORAS_PER_JOB } from '~/server/api/comfy/utils/loraChain'
 import prisma from './prisma'
 
@@ -30,6 +31,7 @@ type LoraResourceRecord = {
   customUrl: string | null
   civitaiUrl: string | null
   huggingUrl: string | null
+  generation: string | null
   supportedServer: SupportedServer
   defaultTrigger: string | null
   triggerWords: string | null
@@ -153,7 +155,11 @@ function compatibilityRank(
     if (resource.supportedServer === SupportedServer.GENERIC) return 10
   }
 
-  if (engine === 'krea2' || engine === 'flux2') {
+  if (engine === 'krea2') {
+    return krea2LoraCompatibilityRank(resource)
+  }
+
+  if (engine === 'flux2') {
     if (resource.supportedServer === SupportedServer.FLUX) return 30
     if (resource.supportedServer === SupportedServer.KONTEXT) return 20
     if (resource.supportedServer === SupportedServer.GENERIC) return 10
@@ -366,6 +372,7 @@ export async function resolveEnqueueLoraResource(input: {
     customUrl: true,
     civitaiUrl: true,
     huggingUrl: true,
+    generation: true,
     supportedServer: true,
     defaultTrigger: true,
     triggerWords: true,

--- a/utils/loraSelection.ts
+++ b/utils/loraSelection.ts
@@ -11,6 +11,7 @@ export type LoraPick = {
 
 export type LoraResourceLike = {
   id: number
+  generation?: string | null
   supportedServer?: string | null
   defaultTrigger?: string | null
   triggerWords?: string | null
@@ -18,6 +19,20 @@ export type LoraResourceLike = {
 
 function normalizedServer(resource: LoraResourceLike): string {
   return String(resource.supportedServer || '').trim().toUpperCase()
+}
+
+function normalizedGeneration(resource: LoraResourceLike): string {
+  return String(resource.generation || '').trim().toUpperCase()
+}
+
+export function krea2LoraCompatibilityRank(resource: LoraResourceLike): number {
+  const server = normalizedServer(resource)
+  const generation = normalizedGeneration(resource)
+
+  if (server !== 'COMFY' && server !== 'GENERIC') return 0
+  if (/\bKREA[\s._-]*2\b/.test(generation)) return 30
+  if (generation === 'KREA') return 20
+  return 0
 }
 
 export function videoLoraCompatible(
@@ -35,7 +50,11 @@ export function artLoraCompatibilityRank(
 ): number {
   const server = normalizedServer(resource)
 
-  if (engine === 'krea2' || engine === 'flux2') {
+  if (engine === 'krea2') {
+    return krea2LoraCompatibilityRank(resource)
+  }
+
+  if (engine === 'flux2') {
     if (server === 'FLUX') return 30
     if (server === 'KONTEXT') return 20
     if (server === 'GENERIC') return 10

--- a/utils/scripts/verifyArtGeneratorPresets.ts
+++ b/utils/scripts/verifyArtGeneratorPresets.ts
@@ -9,6 +9,10 @@ import {
   getPreset,
   presetForCheckpoint,
 } from '../artGeneratorPresets'
+import {
+  artLoraCompatibilityRank,
+  krea2LoraCompatibilityRank,
+} from '../loraSelection'
 
 function preset(id: string) {
   const found = ART_GENERATOR_PRESETS.find((entry) => entry.id === id)
@@ -80,6 +84,46 @@ for (const engine of ['krea2', 'flux2'] as const) {
   )
 }
 
+const krea2Lora = {
+  id: 1,
+  generation: 'Krea 2',
+  supportedServer: 'COMFY',
+}
+const genericKreaLora = {
+  id: 2,
+  generation: 'Krea',
+  supportedServer: 'GENERIC',
+}
+const fluxLora = {
+  id: 3,
+  generation: 'Flux.1 D',
+  supportedServer: 'FLUX',
+}
+const kontextLora = {
+  id: 4,
+  generation: 'Flux.1 Kontext',
+  supportedServer: 'KONTEXT',
+}
+const krea1Lora = {
+  id: 5,
+  generation: 'Krea 1',
+  supportedServer: 'COMFY',
+}
+
+assert.equal(krea2LoraCompatibilityRank(krea2Lora), 30)
+assert.equal(krea2LoraCompatibilityRank(genericKreaLora), 20)
+assert.equal(krea2LoraCompatibilityRank(fluxLora), 0)
+assert.equal(krea2LoraCompatibilityRank(kontextLora), 0)
+assert.equal(krea2LoraCompatibilityRank(krea1Lora), 0)
+assert.equal(artLoraCompatibilityRank(fluxLora, 'krea2'), 0)
+assert.equal(artLoraCompatibilityRank(kontextLora, 'krea2'), 0)
+assert.equal(artLoraCompatibilityRank(krea2Lora, 'krea2'), 30)
+assert.equal(
+  artLoraCompatibilityRank(fluxLora, 'flux2'),
+  30,
+  'splitting Krea compatibility must not silently change the existing Flux.2 policy',
+)
+
 for (const name of [
   'dreamshaperXL_v21TurboDPMSDE.safetensors',
   'RealitiesEdgeXLLIGHTNING_TURBOV7.safetensors',
@@ -120,6 +164,16 @@ const enqueue = readFileSync('server/api/art/enqueue.post.ts', 'utf8')
 assert.ok(
   !enqueue.includes("from '../../utils/artGeneratorPresets'"),
   'the enqueue API must not import product preset policy',
+)
+
+const loraResolver = readFileSync('server/utils/artLoraResource.ts', 'utf8')
+assert.ok(
+  loraResolver.includes('krea2LoraCompatibilityRank(resource)'),
+  'the enqueue resolver must enforce the same Krea family check as the picker',
+)
+assert.ok(
+  loraResolver.includes('generation: true'),
+  'the enqueue resolver must fetch Resource.generation before checking Krea compatibility',
 )
 
 function laneBody(marker: string): string {
@@ -177,5 +231,5 @@ assert.ok(bench.includes('defaultsFromPreset'))
 assert.ok(!bench.includes('POLL_TIMEOUT_MS'))
 
 console.log(
-  'Art generation quality contract OK: presets are product-owned, shared generation uses the canonical profile registry, and browser polling follows durable ArtJobs until terminal state.',
+  'Art generation quality contract OK: presets are product-owned, Krea LoRAs stay in the Krea family, shared generation uses the canonical profile registry, and browser polling follows durable ArtJobs until terminal state.',
 )


### PR DESCRIPTION
### Task
`lora-ingestion/t-003`: keep Krea 2 LoRA selection within the Krea model family.

### Root cause
Krea 2 and Flux.2 shared one LoRA compatibility branch. That was reasonable for their similar Comfy workflow shape, but wrong for model-family compatibility: FLUX/KONTEXT Resources ranked as the best LoRAs for Krea.

### What changed
- split Krea 2 from the existing Flux.2 LoRA compatibility branch
- use canonical `Resource.generation` lineage to recognize Krea 2 resources while rejecting FLUX/KONTEXT resources for Krea
- reuse the same Krea-family rule in enqueue resolution so stale/direct Krea + Flux selections return 409 instead of reaching Comfy
- add art-generator preset contract coverage, including a guard that Flux.2 compatibility remains unchanged

### Verification so far
- connector diff audit: branch is 3 commits ahead / 0 behind, exactly 3 intended files
- regression assertions added to `npm run test:art-generator-presets`
- local execution was unavailable in this connector-only session because the repository clone requires authenticated Git access; PR CI is the authoritative test run

### Risk
Reversible, no schema/data migration, no production mutation. This changes only which LoRA Resources are considered compatible with Krea 2 and rejects mismatched enqueue attempts server-side.