### PR TITLE
interface-vision/t-104 slice 82: add .kr-btn-ghost-md-2xl, migrate hand-rolled 'btn btn-ghost rounded-2xl'

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -651,6 +651,18 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-ghost rounded-xl;
   }
 
+  /* The `md`-size counterpart to .kr-btn-ghost-2xl (interface-vision t-104
+   * slice 82): the same DaisyUI default (unmodified) button size as
+   * .kr-btn-ghost-md, but with a wider `rounded-2xl` corner radius instead
+   * of `rounded-xl` — `btn btn-ghost rounded-2xl`, previously hand-rolled in
+   * 5 files (5 occurrences, all in the identical class order). Suffixed
+   * `-md-2xl` (size then radius) mirroring `.kr-btn-primary-md-2xl`'s
+   * identical two-axis naming convention on the primary-color branch of
+   * this family. */
+  .kr-btn-ghost-md-2xl {
+    @apply btn btn-ghost rounded-2xl;
+  }
+
   /* The most-repeated *filled* (non-ghost) button shape in the app
    * (interface-vision t-104 slice 51): the primary-color small action
    * button used for form submits and gallery/manager primary actions —

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -591,7 +591,7 @@
       <button
         v-if="selectedStyle"
         type="button"
-        class="btn btn-ghost rounded-2xl"
+        class="kr-btn-ghost-md-2xl"
         :disabled="isGenerating"
         @click="clearSelection"
       >

--- a/components/art/art-test.vue
+++ b/components/art/art-test.vue
@@ -1258,7 +1258,7 @@ onMounted(async () => {
 
             <button
               type="button"
-              class="btn btn-ghost rounded-2xl"
+              class="kr-btn-ghost-md-2xl"
               :disabled="isGenerating"
               @click="clearResult"
             >

--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -490,7 +490,7 @@
       <button
         v-if="queuedFiles.length && !isUploading && !isFinalizingUpload"
         type="button"
-        class="btn btn-ghost rounded-2xl"
+        class="kr-btn-ghost-md-2xl"
         @click="clearQueue"
       >
         Clear

--- a/components/giftshop/giftshop-interact.vue
+++ b/components/giftshop/giftshop-interact.vue
@@ -202,7 +202,7 @@
 
         <button
           type="button"
-          class="btn btn-ghost rounded-2xl"
+          class="kr-btn-ghost-md-2xl"
           :disabled="!cartStore.hasItems"
           @click="cartStore.clearCart()"
         >

--- a/error.vue
+++ b/error.vue
@@ -32,7 +32,7 @@
           </button>
           <button
             type="button"
-            class="btn btn-ghost rounded-2xl"
+            class="kr-btn-ghost-md-2xl"
             @click="retry"
           >
             Try again


### PR DESCRIPTION
## What changed

Adds `.kr-btn-ghost-md-2xl` (`btn btn-ghost rounded-2xl`) to `assets/css/tailwind.css`, mirroring `.kr-btn-primary-md-2xl`'s naming convention (size then radius) on the primary-color branch of the shared button-primitive family. Migrates the 5 files that used this exact hand-rolled class (5 occurrences, all identical class order, found via a systematic grep of `btn`+`rounded-*` class combos not yet covered by the existing `kr-btn-*` family):

- `components/giftshop/giftshop-interact.vue`
- `components/art/art-test.vue`
- `components/art/art-styler.vue`
- `components/art/image-upload.vue`
- `error.vue`

No geometry or behavior change — the new class applies the identical declarations as the hand-rolled string it replaces.

## How I verified

- `npm run test` (vue-tsc `--noEmit`, full project): clean.
- `npx eslint` on all 5 changed `.vue` files: 0 issues.
- `npx tsx utils/scripts/verifyLayoutContract.ts`: holds (207 baseline, unchanged).
- `npx tsx utils/scripts/verifyLintRatchet.ts`: holds (333/-59, matches prior slice baseline).
- Grepped `utils/scripts/*.mjs`/`*.ts` for the literal replaced class string (per the interface-vision/t-104 slice 69 lesson about source-text regression guards) — no hits.
- `prettier --check` flagged pre-existing drift on `components/art/art-test.vue` and `assets/css/tailwind.css` (confirmed via `git stash` against `origin/main` — same files flagged before this change), plus one new, expected reflow on `error.vue` where the shortened class name now lets the surrounding `<button>` tag fit on one line under prettier's line-length rule. Left alone, matching this recurring task's established convention of not folding unrelated formatting into a scoped slice — not enforced by CI (no prettier check in `.github/workflows/`).

## Stakes

reversible

## Notes for reviewer

Conductor: `interface-vision/t-104` (recurring front-end-consistency sweep), slice 82. Claimed via `claim_task.py` before implementing.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9suYHCD9RSEjhMqcayViY

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9suYHCD9RSEjhMqcayViY)_