### PR TITLE
interface-vision: add kr-btn-xs migration codemod

### DIFF
--- a/utils/scripts/codemods/kr_btn_xs_codemod.py
+++ b/utils/scripts/codemods/kr_btn_xs_codemod.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+REQUIRED = {"btn", "btn-xs", "rounded-xl"}
+
+
+def rewrite_classes(value: str) -> tuple[str, bool]:
+    tokens = value.split()
+    if not REQUIRED.issubset(tokens) or "kr-btn-xs" in tokens:
+        return value, False
+
+    remaining = [token for token in tokens if token not in REQUIRED]
+    return " ".join(["kr-btn-xs", *remaining]), True
+
+
+def rewrite_text(text: str) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        rewritten, changed = rewrite_classes(match.group(1))
+        if not changed:
+            return match.group(0)
+        count += 1
+        return f'class="{rewritten}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def candidates() -> list[Path]:
+    return sorted(
+        path
+        for path in ROOT.rglob("*.vue")
+        if "node_modules" not in path.parts and ".nuxt" not in path.parts
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--apply", action="store_true")
+    args = parser.parse_args()
+
+    total = 0
+    changed_files = 0
+    for path in candidates():
+        original = path.read_text(encoding="utf-8")
+        rewritten, count = rewrite_text(original)
+        if not count:
+            continue
+        total += count
+        changed_files += 1
+        print(f"{path.relative_to(ROOT)}: {count}")
+        if args.apply:
+            path.write_text(rewritten, encoding="utf-8")
+
+    mode = "applied" if args.apply else "would replace"
+    print(f"{mode} {total} occurrence(s) across {changed_files} file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Interface Vision t-104 slice 84 adds a narrowly-scoped codemod for static Vue `class="..."` attributes that still hand-roll the now-canonical `btn btn-xs rounded-xl` geometry.

The transform removes only those three tokens and inserts `kr-btn-xs`, preserving variant classes such as `btn-ghost`, `btn-outline`, `btn-error`, `btn-primary`, and any additional layout/text utilities. It is dry-run by default and requires `--apply` to write files.

This follows slice 83, which introduced `.kr-btn-xs` and migrated the first five exact base cases. The remaining search pool is mostly variant-specific combinations, so a token-set transform is safer than another sequence of order-sensitive string substitutions.

## Safety

- static `class="..."` attributes only
- requires all three canonical geometry tokens: `btn`, `btn-xs`, `rounded-xl`
- skips classes already carrying `kr-btn-xs`
- does not touch dynamic `:class` expressions
- dry-run by default
- no production data, schema, API, ArtJob, or deployment changes

Conductor: `interface-vision/t-104`
Session: `openai-scheduled-20260905T141358Z-interface-vision-t104-oai6f2`