### PR TITLE
interface-vision/t-104 slice 85: apply kr-btn-xs codemod to model-builder family

### DIFF
--- a/components/model-builder/model-builder-manager.vue
+++ b/components/model-builder/model-builder-manager.vue
@@ -20,7 +20,7 @@
           v-for="(crumb, index) in crumbs"
           :key="crumb.step"
           type="button"
-          class="btn btn-xs h-7 min-h-7 rounded-xl px-2 text-xs font-semibold"
+          class="kr-btn-xs h-7 min-h-7 px-2 text-xs font-semibold"
           :class="
             store.step === crumb.step
               ? 'btn-primary'
@@ -39,7 +39,7 @@
       <button
         ref="historyToggleButton"
         type="button"
-        class="btn btn-xs btn-ghost ml-auto h-7 min-h-7 rounded-xl px-2"
+        class="kr-btn-xs btn-ghost ml-auto h-7 min-h-7 px-2"
         :class="
           showHistory
             ? 'text-primary'
@@ -56,7 +56,7 @@
 
       <button
         type="button"
-        class="btn btn-xs btn-ghost h-7 min-h-7 rounded-xl px-2 text-base-content/60 hover:text-error"
+        class="kr-btn-xs btn-ghost h-7 min-h-7 px-2 text-base-content/60 hover:text-error"
         :disabled="store.startingRun || resumingRun"
         aria-label="Reset Model Builder"
         @click="store.resetAll()"

--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -23,7 +23,7 @@
       <div class="flex shrink-0 items-center gap-1">
         <button
           type="button"
-          class="btn btn-xs btn-primary rounded-xl"
+          class="kr-btn-xs btn-primary"
           :disabled="autoBuildAllDisabled"
           :title="autoBuildAllTitle"
           :aria-busy="store.autoBuilding"

--- a/components/model-builder/model-builder-recipe-selector.vue
+++ b/components/model-builder/model-builder-recipe-selector.vue
@@ -15,7 +15,7 @@
       </div>
       <button
         type="button"
-        class="btn btn-xs btn-ghost shrink-0 rounded-xl text-base-content/60"
+        class="kr-btn-xs btn-ghost shrink-0 text-base-content/60"
         :disabled="store.startingRun"
         @click="store.goToStep('source')"
       >

--- a/components/model-builder/model-builder-run-history.vue
+++ b/components/model-builder/model-builder-run-history.vue
@@ -21,7 +21,7 @@
         </button>
         <button
           type="button"
-          class="btn btn-xs btn-primary rounded-xl"
+          class="kr-btn-xs btn-primary"
           :disabled="Boolean(cancellingRunId)"
           @click="startNew"
         >

--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -88,7 +88,7 @@
         {{ store.sourcesError }}
         <button
           type="button"
-          class="btn btn-xs btn-ghost mt-1 rounded-xl"
+          class="kr-btn-xs btn-ghost mt-1"
           @click="store.loadSources()"
         >
           Retry


### PR DESCRIPTION
## What changed

Runs the slice-84 codemod (`utils/scripts/codemods/kr_btn_xs_codemod.py`) against the Model Builder component family: 7 hand-rolled `btn btn-xs ... rounded-xl` sites across 5 files migrated to `kr-btn-xs`, preserving variant classes (`btn-primary`/`btn-ghost`) and any other layout/text utilities untouched.

- `components/model-builder/model-builder-manager.vue` (3 sites)
- `components/model-builder/model-builder-progress-matrix.vue` (1 site)
- `components/model-builder/model-builder-recipe-selector.vue` (1 site)
- `components/model-builder/model-builder-run-history.vue` (1 site)
- `components/model-builder/model-builder-source-picker.vue` (1 site)

No geometry or behavior change. This is a deliberately bounded subset of the ~68 total remaining occurrences the codemod's dry-run reports (34 files) — following this project's established convention of small, reviewable slices per cycle rather than one large mechanical sweep.

## Verification

- `npm run test` (`vue-tsc --noEmit`, full project): clean.
- `npx eslint` on all 5 changed files: 0 issues.
- `npm run test:layout-contract`: holds (207 baseline unchanged).
- `npm run test:lint-ratchet`: holds (333 problems / -59, matches prior baseline).
- `npx prettier --check`: 3 of the 5 files show pre-existing drift, confirmed via `git stash` against `origin/main` (present on the unmodified head too, unrelated to this change).

Conductor: `interface-vision/t-104`, slice 85.
Session: `claude-20260905T143459Z-iv-t104-s85`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_015wXCYKs6c9dZ19sLBo5EJ5)_