### PR TITLE
interface-vision/t-104 slice 86: migrate Newsfeed reset button to kr-btn-xs

### DIFF
--- a/components/newsfeed/newsfeed-preferences.vue
+++ b/components/newsfeed/newsfeed-preferences.vue
@@ -16,7 +16,7 @@
       </div>
       <button
         type="button"
-        class="btn btn-ghost btn-xs rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+        class="kr-btn-xs btn-ghost focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
         @click="feedPreferenceStore.resetToDefaults()"
       >
         Reset to defaults


### PR DESCRIPTION
## Summary

Interface Vision t-104 slice 86 continues the bounded `kr-btn-xs` adoption from slices 84–85. `components/newsfeed/newsfeed-preferences.vue` now uses `kr-btn-xs btn-ghost` for the Manage Feeds reset action instead of hand-rolled `btn btn-ghost btn-xs rounded-xl` geometry.

The focus-visible utilities and click behavior are unchanged. This is the exact token-set substitution encoded by `utils/scripts/codemods/kr_btn_xs_codemod.py`, kept to one small live Newsfeed surface for reviewability.

## Safety

- template class-only change
- no script/store/API/schema changes
- no production data or ArtJob changes
- exact shared geometry substitution

Conductor: `interface-vision/t-104`, slice 86
Session: `openai-scheduled-20260905T151524Z-interface-vision-t104-oai8c4`