### PR TITLE
interface-vision/t-104 slice 87: migrate Conductor pack/gallery buttons to kr-btn-xs

### DIFF
--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -27,7 +27,7 @@
         </div>
       </div>
       <div class="flex items-center gap-1.5">
-        <button class="btn btn-primary btn-xs rounded-xl" @click="openNewPack">
+        <button class="kr-btn-xs btn-primary" @click="openNewPack">
           <Icon name="kind-icon:plus" class="size-3.5" />
           New pack
         </button>
@@ -158,7 +158,7 @@
           <div class="flex shrink-0 items-center gap-1.5">
             <button
               v-if="!stateFor(item.id).refId"
-              class="btn btn-primary btn-xs rounded-xl"
+              class="kr-btn-xs btn-primary"
               :disabled="isBusy(item.id)"
               @click="onCreate(item.id)"
             >
@@ -170,7 +170,7 @@
             </button>
             <button
               v-if="stateFor(item.id).refId && !stateFor(item.id).artImageId"
-              class="btn btn-secondary btn-xs rounded-xl"
+              class="kr-btn-xs btn-secondary"
               :disabled="isBusy(item.id)"
               @click="onArt(item.id)"
             >

--- a/components/conductor/packmaker-pack-editor.vue
+++ b/components/conductor/packmaker-pack-editor.vue
@@ -35,7 +35,7 @@
       />
       <div class="flex items-center gap-2">
         <button
-          class="btn btn-secondary btn-xs rounded-xl"
+          class="kr-btn-xs btn-secondary"
           :disabled="scaffolding"
           @click="onScaffold"
         >

--- a/components/pages/conductor-project-gallery-page.vue
+++ b/components/pages/conductor-project-gallery-page.vue
@@ -161,7 +161,7 @@
             <button
               v-for="option in filters"
               :key="option.value"
-              class="btn btn-xs gap-1 rounded-xl"
+              class="kr-btn-xs gap-1"
               :class="filter === option.value ? 'btn-primary' : 'btn-ghost'"
               :aria-pressed="filter === option.value"
               @click="filter = option.value"
@@ -173,7 +173,7 @@
 
             <button
               v-if="syncIssueCount"
-              class="btn btn-xs gap-1 rounded-xl"
+              class="kr-btn-xs gap-1"
               :class="showSync ? 'btn-warning' : 'btn-ghost'"
               :aria-pressed="showSync"
               @click="showSync = !showSync"
@@ -185,7 +185,7 @@
 
             <button
               v-if="blockedTasks.length"
-              class="btn btn-xs gap-1 rounded-xl"
+              class="kr-btn-xs gap-1"
               :class="showBlocked ? 'btn-error' : 'btn-ghost'"
               :aria-pressed="showBlocked"
               @click="showBlocked = !showBlocked"
@@ -196,7 +196,7 @@
             </button>
 
             <button
-              class="btn btn-xs gap-1 rounded-xl"
+              class="kr-btn-xs gap-1"
               :class="createOpen ? 'btn-primary' : 'btn-ghost'"
               :aria-expanded="createOpen"
               @click="createOpen = !createOpen"


### PR DESCRIPTION
## Summary

Interface Vision t-104 slice 87 continues the bounded `kr-btn-xs` adoption from slices 84–86. Runs the slice-84 codemod (`utils/scripts/codemods/kr_btn_xs_codemod.py`) against the Conductor-domain component family: 8 hand-rolled `btn ... btn-xs ... rounded-xl` sites across 3 files migrated to `kr-btn-xs`, preserving variant classes (`btn-primary`/`btn-secondary`/`btn-ghost`/`btn-warning`/`btn-error`) and any other layout/text utilities untouched.

- `components/conductor/packmaker-admin-panel.vue` (3 sites)
- `components/conductor/packmaker-pack-editor.vue` (1 site)
- `components/pages/conductor-project-gallery-page.vue` (4 sites)

No geometry or behavior change.

## Verification

- `npm run test` (`vue-tsc --noEmit`, full project): clean.
- `npx eslint` on all 3 changed files: 0 issues.
- `npm run test:layout-contract`: holds (207 baseline unchanged).
- `npm run test:lint-ratchet`: holds (333 problems / -59, matches prior baseline).
- `npx prettier --check`: 2 of the 3 files show pre-existing drift, confirmed via `git stash` against `origin/main` (present on the unmodified head too, unrelated to this change).

## Safety

- template class-only change
- no script/store/API/schema changes
- no production data or ArtJob changes
- exact shared geometry substitution

Conductor: `interface-vision/t-104`, slice 87.
Session: `claude-20260905T153154Z-iv-t104-s87`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXCj2K4MAVDre6b8feZ6mS

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXCj2K4MAVDre6b8feZ6mS)_