### PR TITLE
interface-vision/t-104 slice 89: migrate stages family to kr-btn-xs; fix codemod CRLF clobbering

### DIFF
--- a/components/stages/performer-creator.vue
+++ b/components/stages/performer-creator.vue
@@ -150,7 +150,7 @@
               >
               <button
                 type="button"
-                class="btn btn-ghost btn-xs rounded-xl gap-1 border border-base-300"
+                class="kr-btn-xs btn-ghost gap-1 border border-base-300"
                 :disabled="!form.name.trim() || llmLoading"
                 @click="generatePrompt"
               >
@@ -181,7 +181,7 @@
               >
               <button
                 type="button"
-                class="btn btn-ghost btn-xs rounded-xl gap-1 border border-base-300"
+                class="kr-btn-xs btn-ghost gap-1 border border-base-300"
                 :disabled="!form.name.trim()"
                 @click="buildArtPrompt"
               >
@@ -449,7 +449,7 @@
             />
             <button
               type="button"
-              class="btn btn-primary btn-xs rounded-xl"
+              class="kr-btn-xs btn-primary"
               @click="addCustomTrait"
             >
               Add

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -40,7 +40,7 @@
           <button
             v-if="!store.isPaused"
             type="button"
-            class="btn btn-warning btn-xs rounded-xl"
+            class="kr-btn-xs btn-warning"
             @click="store.pause()"
           >
             <Icon name="mdi:pause" class="h-3.5 w-3.5" /> Pause
@@ -48,7 +48,7 @@
           <button
             v-else
             type="button"
-            class="btn btn-success btn-xs rounded-xl"
+            class="kr-btn-xs btn-success"
             @click="store.resume()"
           >
             <Icon name="mdi:play" class="h-3.5 w-3.5" /> Resume
@@ -70,7 +70,7 @@
         </button>
         <button
           type="button"
-          class="btn btn-ghost btn-xs rounded-xl text-error/60 hover:text-error"
+          class="kr-btn-xs btn-ghost text-error/60 hover:text-error"
           @click="store.clearTranscript()"
         >
           <Icon name="mdi:broom" class="h-3.5 w-3.5" />

--- a/utils/scripts/codemods/kr_btn_xs_codemod.py
+++ b/utils/scripts/codemods/kr_btn_xs_codemod.py
@@ -66,7 +66,14 @@ def main() -> int:
     total = 0
     changed_files = 0
     for path in candidates(args.path):
-        original = path.read_text(encoding="utf-8")
+        # newline="" disables universal-newline translation on read AND write,
+        # so a CRLF source file round-trips as CRLF instead of silently
+        # collapsing to LF on every line -- not just the lines this codemod
+        # actually touches. Path.read_text()/write_text() always translate
+        # newlines and have no `newline=` param before Python 3.13, so this
+        # opens the file directly instead.
+        with path.open(encoding="utf-8", newline="") as fh:
+            original = fh.read()
         rewritten, count = rewrite_text(original)
         if not count:
             continue
@@ -74,7 +81,8 @@ def main() -> int:
         changed_files += 1
         print(f"{path.relative_to(ROOT)}: {count}")
         if args.apply:
-            path.write_text(rewritten, encoding="utf-8")
+            with path.open("w", encoding="utf-8", newline="") as fh:
+                fh.write(rewritten)
 
     mode = "applied" if args.apply else "would replace"
     print(f"{mode} {total} occurrence(s) across {changed_files} file(s)")


### PR DESCRIPTION
## Summary

Interface Vision t-104 slice 89, continuing the recurring `kr-btn-xs`
consistency migration.

- Applied the codemod (`--path components/stages`) to the Stage component
  family: `components/stages/performer-creator.vue` (3 sites),
  `components/stages/stage-manager.vue` (3 sites). Preserves
  `btn-primary`/`btn-warning`/`btn-success`/`btn-ghost` variants and other
  utilities untouched.
- **Also fixes a real bug in the codemod tool**, found while running it:
  `Path.read_text()`/`write_text()` always perform universal-newline
  translation, so any CRLF `.vue` file it touched would silently collapse to
  LF for its *entire* content, not just the lines actually changed —
  `stage-manager.vue` alone would have turned this bounded 6-occurrence slice
  into a 2566-line diff. Fixed by opening files directly with `newline=""`
  (disables translation on both read and write) so CRLF sources round-trip as
  CRLF. Verified the fix: `stage-manager.vue`'s diff is now exactly the 6
  intended class substitutions, and `file` confirms CRLF line terminators
  survive the round-trip.

## Verification

- `vue-tsc --noEmit` clean
- `eslint` 0 new issues on both changed `.vue` files (1 pre-existing
  `vue/no-deprecated-slot-attribute` error in `stage-manager.vue` confirmed
  via `git stash`)
- `test:layout-contract` held (207 baseline unchanged)
- `test:lint-ratchet` held (333/-59, matches prior slice's baseline)
- `prettier --check` pre-existing drift on both files confirmed via `git stash`

## Safety

- Static-class-only, exact-token rewrite; no runtime/app behavior change
- No weakening of checks

Conductor: `interface-vision/t-104`, slice 89

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiJ9QyjFEKDrfvHcYYzrG8

---
_Generated by [Claude Code](https://claude.ai/code/session_01BiJ9QyjFEKDrfvHcYYzrG8)_