### PR TITLE
fix(facet-art): recognize legacy wrappers whose titles contain straight quotes

### DIFF
--- a/.github/workflows/facet-catalog-contract.yml
+++ b/.github/workflows/facet-catalog-contract.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Verify retired Facet cleanup and artwork queue
         run: npx tsx utils/scripts/verifyFacetCatalogMaintenance.ts
 
+      - name: Verify legacy Facet art prompt signature
+        run: npx tsx utils/scripts/verifyFacetLegacyPromptSignature.ts
+
       - name: Verify whole-catalog Facet audit
         run: npx tsx utils/scripts/verifyFacetCatalogAudit.ts
 

--- a/scripts/generate_facet_art_v4.ts
+++ b/scripts/generate_facet_art_v4.ts
@@ -46,8 +46,14 @@ const LEGACY_FACET_ART_VERSIONS = new Set([
 // provenance, not curated prose. Recognize only the generator signature so a
 // human-authored artPrompt is never rewritten just because it contains words
 // such as "facet" or "illustrate" somewhere in its subject matter.
+//
+// The quoted title may itself contain straight quotes (`Carries a candle
+// everywhere "just in case."`), so a curly-quoted title runs to the closing
+// curly quote and a straight-quoted one to the closing straight quote; a
+// single character class excluding both left ten wrapper prompts unrecognized
+// and the contract then rejected them at write time (2026-09-05 repair run).
 const LEGACY_GENERATED_IDENTITY =
-  /^Illustrate the Facet concept [“"][^”"]+[”"]\.\s*/i
+  /^Illustrate the Facet concept (?:“[^”]+”|"[^"]+")\.\s*/i
 
 // Order matters. It is the same coverage fallback contract used by the UI and
 // claim-time deduper: a general image is most reusable, then card, hero, icon.
@@ -829,40 +835,44 @@ export async function main(): Promise<void> {
         }
       }
 
-      if (WRITE) {
-        // Build and validate the complete replacement job payload set BEFORE
-        // committing any mutation. buildFacetArtPayload() synchronously
-        // throws via assertArtPromptContract() on an invalid prompt, so
-        // constructing jobRows first guarantees a bad entry aborts the whole
-        // write before any legacy job is cancelled or Facet.artPrompt is
-        // rewritten. Previously this ran last, after the cancellation and
-        // prompt-update writes had already committed — if any single entry's
-        // payload failed to build, those writes were left in place with no
-        // replacement ArtJob created, silently stranding the facet
-        // (dream-cycle/t-006 pass 1 + pass 2 review finding on PR #2414).
-        const jobRows = queue.map((entry) => ({
-          engine: 'COMFY' as const,
-          userId: entry.facet.userId,
-          projectSlug: PROJECT_SLUG,
-          priority: entry.repairSourceJobId
-            ? repairPriority(entry.profile)
-            : priorityFor(entry.profile),
-          payload: JSON.stringify(
-            buildFacetArtPayload(
-              entry.facet,
-              entry.profile,
-              entry.identityPrompt,
-              entry.variant,
-              entry.repairSourceJobId && entry.repairSourceVersion
-                ? {
-                    sourceJobId: entry.repairSourceJobId,
-                    sourceVersion: entry.repairSourceVersion,
-                  }
-                : undefined,
-            ),
+      // Build and validate the complete replacement job payload set BEFORE
+      // committing any mutation. buildFacetArtPayload() synchronously
+      // throws via assertArtPromptContract() on an invalid prompt, so
+      // constructing jobRows first guarantees a bad entry aborts the whole
+      // write before any legacy job is cancelled or Facet.artPrompt is
+      // rewritten. Previously this ran last, after the cancellation and
+      // prompt-update writes had already committed — if any single entry's
+      // payload failed to build, those writes were left in place with no
+      // replacement ArtJob created, silently stranding the facet
+      // (dream-cycle/t-006 pass 1 + pass 2 review finding on PR #2414).
+      //
+      // Built in dry-run mode too, so a dry run exercises the same prompt
+      // contract as the write and reports a rejected prompt instead of
+      // passing a plan the write then refuses.
+      const jobRows = queue.map((entry) => ({
+        engine: 'COMFY' as const,
+        userId: entry.facet.userId,
+        projectSlug: PROJECT_SLUG,
+        priority: entry.repairSourceJobId
+          ? repairPriority(entry.profile)
+          : priorityFor(entry.profile),
+        payload: JSON.stringify(
+          buildFacetArtPayload(
+            entry.facet,
+            entry.profile,
+            entry.identityPrompt,
+            entry.variant,
+            entry.repairSourceJobId && entry.repairSourceVersion
+              ? {
+                  sourceJobId: entry.repairSourceJobId,
+                  sourceVersion: entry.repairSourceVersion,
+                }
+              : undefined,
           ),
-        }))
+        ),
+      }))
 
+      if (WRITE) {
         if (REPAIR_TAINTED && legacyPendingIds.length) {
           await prisma.artJob.updateMany({
             where: {

--- a/utils/scripts/verifyFacetLegacyPromptSignature.ts
+++ b/utils/scripts/verifyFacetLegacyPromptSignature.ts
@@ -1,0 +1,47 @@
+// /utils/scripts/verifyFacetLegacyPromptSignature.ts
+//
+// The v2/v3 Facet art producers persisted a generated wrapper into
+// Facet.artPrompt. The v4 repair must recognize every shape of that wrapper
+// (so it regenerates a semantic prompt) while never touching a curated prompt.
+//
+// 2026-09-05: the first production `--repair-tainted --write` run aborted on
+// ten Facets whose titles contain straight quotes inside the curly-quoted
+// wrapper ("Carries a candle everywhere "just in case.""). The old signature
+// used one character class excluding both quote styles, so those prompts read
+// as curated, went to Krea verbatim, and the prompt contract rejected them.
+import assert from 'node:assert/strict'
+import { isLegacyGeneratedFacetPrompt } from '../../scripts/generate_facet_art_v4'
+
+const wrapperPrompts = [
+  'Illustrate the Facet concept “Surreal Horror”. A dream logic nightmare. Build one iconic scene.',
+  'Illustrate the Facet concept "Surreal Horror". A dream logic nightmare.',
+  'Illustrate the Facet concept “Carries a candle everywhere "just in case."”. The case has arrived twice. Use a character-centered visual metaphor with a clear emotional read and no written explanation.',
+  'Illustrate the Facet concept “Clone #47 — the one who finally asked "why?"”. Forty-six of them did not ask.',
+  'Illustrate the Facet concept “Keeps an invisible "force field" around themselves.”. Maintains a precise personal radius.',
+  '  Illustrate the Facet concept “Aardvark”.  ',
+]
+for (const prompt of wrapperPrompts) {
+  assert.ok(
+    isLegacyGeneratedFacetPrompt(prompt),
+    `generated wrapper must be recognized as legacy provenance: ${prompt}`,
+  )
+}
+
+const curatedPrompts = [
+  'A surreal dreamscape where physics gently misbehaves, floating impossible objects, warm and uncanny.',
+  'A hand-painted rescue buoy, its paint chipped down to bare metal along one whole side.',
+  'A poster that says "Illustrate the Facet concept" in peeling letters on a brick wall.',
+  'Facet of a cut gemstone, illustrate the refraction with prismatic light.',
+  '',
+  null,
+  undefined,
+]
+for (const prompt of curatedPrompts) {
+  assert.equal(
+    isLegacyGeneratedFacetPrompt(prompt),
+    false,
+    `curated or empty prompt must never be treated as the generated wrapper: ${String(prompt)}`,
+  )
+}
+
+console.log('Facet legacy prompt signature contract verified.')


### PR DESCRIPTION
## What broke

The first production `generate_facet_art.ts --repair-tainted --write` run (Krea semantic art repair run [33978459554](https://github.com/silasfelinus/kind_robots/actions/runs/33978459554)) aborted with:

```
[contextual-wrapper] "Illustrate the Facet concept" is application/prompt-writing context, not image content.
```

It failed inside the pass-3 validate-before-write guard from #2414, so nothing was mutated and the catalog lock was released cleanly. Root cause: ten Facets have titles containing straight quotes inside the curly-quoted v2/v3 wrapper, e.g. `Illustrate the Facet concept “Carries a candle everywhere "just in case."”. …`. `LEGACY_GENERATED_IDENTITY` used a single character class excluding both quote styles, so those prompts were not recognized as generated provenance, were kept as if curated, and were then rejected by the Krea prompt contract.

## Changes

- Match a curly-quoted title up to its closing curly quote and a straight-quoted one up to its closing straight quote. Checked against all 1617 live Facet `artPrompt` values via the API: every wrapper prompt now classifies as legacy, and the 27 curated prompts are untouched.
- Build the replacement payload set in dry-run mode too, so a dry run exercises the prompt contract and reports a rejected prompt instead of passing a plan the write then refuses. Write-path ordering is unchanged: validation still precedes every mutation.
- Add `utils/scripts/verifyFacetLegacyPromptSignature.ts` (wrapper shapes incl. straight quotes inside curly quotes must be legacy; curated/empty prompts must not) and wire it into the Facet Catalog Contract.

## Verification

- `verifyFacetLegacyPromptSignature.ts` passes locally; `verifyFacetCatalogMaintenance.ts` passes.
- `eslint` on the producer shows only the 4 pre-existing `no-useless-escape` findings (#2414 noted the same); `prettier --check` drift on this file is pre-existing on `main`.

Conductor: `dream-cycle/t-006`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoXLrc2yHnkZtNBY4b8zSX

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoXLrc2yHnkZtNBY4b8zSX)_