### PR TITLE
interface-vision/t-104 slice 90: migrate narrative art retry button to kr-btn-xs

### DIFF
--- a/components/narrative/narrative-art-status.vue
+++ b/components/narrative/narrative-art-status.vue
@@ -47,7 +47,7 @@
       </div>
       <button
         type="button"
-        class="btn btn-error btn-outline btn-xs rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-error/70 motion-reduce:transform-none motion-reduce:transition-none"
+        class="kr-btn-xs btn-error btn-outline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-error/70 motion-reduce:transform-none motion-reduce:transition-none"
         @click="$emit('retry')"
       >
         Retry image


### PR DESCRIPTION
Conductor: interface-vision/t-104
Session: openai-scheduled-20260905T171115Z-interface-vision-t104-a7c9

Bounded consistency slice following the established kr-btn-xs migration pass. `components/narrative/narrative-art-status.vue` had one remaining hand-rolled `btn btn-xs rounded-xl` retry button. This replaces only those shared geometry tokens with `kr-btn-xs`, preserving `btn-error`, `btn-outline`, focus-visible, and motion-reduction utilities.

No behavior, API, schema, production-data, or deployment changes.