### PR TITLE
fix(krea): keep curly quotes in workflow request provenance so enqueue reconciles

### DIFF
--- a/utils/kreaSemanticPrompt.ts
+++ b/utils/kreaSemanticPrompt.ts
@@ -106,6 +106,22 @@ function normalize(value: unknown): string {
     .trim()
 }
 
+// Whitespace-only normalization, byte-for-byte what
+// server/utils/artJobProvenance.ts#normalizeArtPrompt applies to the
+// top-level promptString. The `_meta.request_prompt` provenance copy must
+// use THIS, not normalize(): provenance reconciles the request by exact
+// string equality against the workflow's text candidates, so folding curly
+// quotes to straight ones there made every request containing ’ “ ” fail
+// enqueue with "workflow prompt does not match the top-level promptString"
+// (22 Facet titles such as "Pallas’s Cat" and "Can’t resist counting things
+// aloud." hit it in the 2026-09-05 repair run; any user-typed smart quote
+// hit it through /api/art/enqueue).
+function normalizeWhitespace(value: unknown): string {
+  return String(value || '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
 function cleanFragment(value: string): string {
   let text = normalize(value)
   if (!text) return ''
@@ -261,7 +277,7 @@ export function rewriteKreaWorkflowPositivePrompt<T>(
   const workflow = structuredClone(workflowValue) as T
   const root = asRecord(workflow)
   const semanticPrompt = buildKreaSemanticPrompt(requestPrompt)
-  const rawPrompt = normalize(requestPrompt)
+  const rawPrompt = normalizeWhitespace(requestPrompt)
   let rewrittenNodes = 0
   let provenanceAttached = false
 

--- a/utils/scripts/verifyArtJobProvenance.ts
+++ b/utils/scripts/verifyArtJobProvenance.ts
@@ -6,6 +6,7 @@ import {
   hashArtImageData,
   validateArtJobCompletionProof,
 } from '../../server/utils/artJobProvenance'
+import { rewriteKreaWorkflowPositivePrompt } from '../kreaSemanticPrompt'
 
 function workflow(prompt: string, seed: number) {
   return {
@@ -203,6 +204,34 @@ assert.throws(
 assert.throws(
   () => validateArtJobCompletionProof(attemptA.payload, null),
   /requires completion provenance/i,
+)
+
+// 2026-09-05: a prompt containing curly quotes must still enqueue through the
+// Krea semantic rewrite. rewriteKreaWorkflowPositivePrompt keeps the raw
+// request in `_meta.request_prompt` so this reconciliation can find it; that
+// copy used to fold ’ “ ” to straight quotes, so it never equalled the
+// whitespace-normalized promptString and every such request was refused as
+// "workflow prompt does not match" (22 Facet titles, plus any user-typed
+// smart quote via /api/art/enqueue).
+const curlyPrompt = 'Pallas’s Cat, “the last lamp” at dawn,  one full creature'
+const curlyRewrite = rewriteKreaWorkflowPositivePrompt(
+  workflow(curlyPrompt, 840011),
+  curlyPrompt,
+)
+assert.equal(curlyRewrite.rewrittenNodes, 1)
+const curlyAttempt = enrichArtJobPayload('COMFY', {
+  promptString: curlyPrompt,
+  workflow: curlyRewrite.workflow,
+})
+assert.equal(
+  curlyAttempt.payload.promptString,
+  'Pallas’s Cat, “the last lamp” at dawn, one full creature',
+  'the top-level promptString keeps its curly quotes, whitespace-normalized only',
+)
+assert.equal(
+  curlyAttempt.provenance.workflowPromptMatches,
+  true,
+  'a curly-quoted request must reconcile against its own _meta.request_prompt provenance',
 )
 
 console.log('ArtJob prompt provenance contract passed.')

--- a/utils/scripts/verifyArtPromptContract.ts
+++ b/utils/scripts/verifyArtPromptContract.ts
@@ -173,6 +173,23 @@ assert.equal(
   'raw request stays available only as non-conditioning provenance metadata',
 )
 
+// Provenance is reconciled by exact string equality against the top-level
+// promptString, which server/utils/artJobProvenance.ts normalizes for
+// whitespace only. The `_meta.request_prompt` copy must therefore keep curly
+// quotes verbatim; folding them to straight quotes made every request
+// containing ’ “ ” fail enqueue (2026-09-05 Facet repair run).
+const curlyRequest = 'Pallas’s Cat, “the last lamp”  at dawn'
+const curlyRewritten = rewriteKreaWorkflowPositivePrompt(
+  rawWorkflow,
+  curlyRequest,
+)
+assert.equal(
+  (curlyRewritten.workflow['1']._meta as { request_prompt?: string })
+    .request_prompt,
+  'Pallas’s Cat, “the last lamp” at dawn',
+  'raw request provenance must preserve curly quotes and normalize whitespace only',
+)
+
 // Scoped to a cast noun plus a presence verb, so prose about people is fine.
 assert.deepEqual(
   rules({


### PR DESCRIPTION
## What broke

The second production run of the Facet tainted-job repair ([run 33979282248](https://github.com/silasfelinus/kind_robots/actions/runs/33979282248)) aborted, again inside the validate-before-write guard with nothing mutated:

```
COMFY workflow prompt does not match the top-level promptString. Refusing to enqueue ambiguous prompt metadata.
```

`rewriteKreaWorkflowPositivePrompt` (from #2414) stores the raw request in the workflow's `_meta.request_prompt` so provenance can reconcile it against `promptString`. That copy folded curly quotes to straight ones, while `artJobProvenance.normalizeArtPrompt` normalizes the top-level `promptString` for whitespace only. Any request containing `’ “ ”` therefore never matched its own provenance and was refused.

This is not Facet-specific. Reproduced locally through the same builder the API uses (`buildKrea2WorkflowFromRequest` + `enrichArtJobPayload`): an API-shaped prompt with a curly apostrophe has been refused at `/api/art/enqueue` since the semantic rewrite landed.

## Changes

- `utils/kreaSemanticPrompt.ts`: the provenance copy is now whitespace-normalized only, byte-for-byte what `normalizeArtPrompt` applies to `promptString`. The positive CLIP text is unchanged (still the fully normalized semantic prompt).
- `verifyArtJobProvenance.ts`: round-trip a curly-quoted prompt through the rewrite and `enrichArtJobPayload`; assert `workflowPromptMatches` and that `promptString` keeps its quotes.
- `verifyArtPromptContract.ts`: assert `_meta.request_prompt` preserves curly quotes and normalizes whitespace only.

## Verification

- `buildFacetArtPayload` now builds for all 1617 live Facets fetched via the API (22 failed before: "Pallas’s Cat", "Can’t resist counting things aloud.", …).
- `verifyArtJobProvenance`, `verifyArtPromptContract`, `verifyFacetLegacyPromptSignature`, `verifyFacetCatalogMaintenance` all pass locally; `eslint` clean on the three files; `prettier --check` drift on them is pre-existing on `main`.

Conductor: `dream-cycle/t-006`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoXLrc2yHnkZtNBY4b8zSX

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoXLrc2yHnkZtNBY4b8zSX)_