### PR TITLE
fix(facet-art): never let seed-provenance metadata prompts into the identity prompt

### DIFF
--- a/scripts/generate_facet_art_v4.ts
+++ b/scripts/generate_facet_art_v4.ts
@@ -21,7 +21,10 @@
 
 import 'dotenv/config'
 import { buildKrea2WorkflowFromRequest } from '../server/api/comfy/krea2/utils/workflow'
-import { assertArtPromptContract } from '../server/utils/artPromptContract'
+import {
+  assertArtPromptContract,
+  checkArtPromptContract,
+} from '../server/utils/artPromptContract'
 import { enrichArtJobPayload } from '../server/utils/artJobProvenance'
 import {
   auditFacetCatalog,
@@ -220,6 +223,28 @@ function compactLines(values: unknown[]): string[] {
   return values.map(clean).filter(Boolean)
 }
 
+// FacetProfile.metadata.artworkPrompt is seed-time provenance written for the
+// old contextual producers ("Kind Robots premium Builder card illustration for
+// Dream Types: Art. ...", "Expressive inclusive character-card illustration
+// representing ..."). It restates the description and adds app-name and
+// card-format vocabulary that Krea paints literally and the prompt contract
+// rejects (2026-09-05 repair run: 28 Facets, format-vocabulary). Only a
+// metadata prompt that stands on its own as a caption is used; otherwise the
+// title/description/flavor prose carries the identity, as for every other
+// Facet.
+function usableMetadataArtworkPrompt(metadata: JsonObject): string {
+  const prompt = metadataArtworkPrompt(metadata)
+  if (!prompt) return ''
+  if (/\bKind Robots\b/i.test(prompt)) return ''
+  const violations = checkArtPromptContract({
+    prompt,
+    engine: 'krea2',
+    steps: 8,
+    cfg: 1,
+  })
+  return violations.length ? '' : prompt
+}
+
 function metadataArtworkPrompt(metadata: JsonObject): string {
   const direct = clean(metadata.artworkPrompt)
   if (direct) return direct
@@ -290,7 +315,7 @@ export function buildFacetIdentityPrompt(
   if (existing && !isLegacyGeneratedFacetPrompt(existing)) return existing
 
   const metadata = parseMetadata(profile.metadata)
-  const metadataPrompt = metadataArtworkPrompt(metadata)
+  const metadataPrompt = usableMetadataArtworkPrompt(metadata)
   const scientificName = clean(metadata.scientificName)
   const category = clean(metadata.category)
   const prose = compactLines([

--- a/utils/scripts/verifyFacetLegacyPromptSignature.ts
+++ b/utils/scripts/verifyFacetLegacyPromptSignature.ts
@@ -10,7 +10,11 @@
 // used one character class excluding both quote styles, so those prompts read
 // as curated, went to Krea verbatim, and the prompt contract rejected them.
 import assert from 'node:assert/strict'
-import { isLegacyGeneratedFacetPrompt } from '../../scripts/generate_facet_art_v4'
+import { checkArtPromptContract } from '../../server/utils/artPromptContract'
+import {
+  buildFacetIdentityPrompt,
+  isLegacyGeneratedFacetPrompt,
+} from '../../scripts/generate_facet_art_v4'
 
 const wrapperPrompts = [
   'Illustrate the Facet concept “Surreal Horror”. A dream logic nightmare. Build one iconic scene.',
@@ -43,5 +47,75 @@ for (const prompt of curatedPrompts) {
     `curated or empty prompt must never be treated as the generated wrapper: ${String(prompt)}`,
   )
 }
+
+// FacetProfile.metadata.artworkPrompt is seed-time provenance for the old
+// contextual producers. It must never reach the identity prompt when it names
+// the app or asks for a card format (2026-09-05 repair run: 28 Facets rejected
+// by the format-vocabulary rule), while a metadata prompt that is a usable
+// caption on its own is still honoured.
+const seedFacet = {
+  id: 1757,
+  title: 'Art',
+  slug: 'art',
+  description:
+    'A visual seed for image generation, mood boards, covers, and weird little art goblins.',
+  flavorText: null,
+  examples: null,
+  artPrompt: 'Illustrate the Facet concept “Art”. A visual seed for image generation.',
+  userId: 1,
+  isPublic: true,
+  isMature: false,
+}
+const seedProfile = (artworkPrompt: string) => ({
+  facetId: 1757,
+  taxonomy: 'DREAM_TYPE',
+  canonicalValue: 'art',
+  groupKey: null,
+  groupLabel: null,
+  isRandomizable: false,
+  randomWeight: 0,
+  artRequired: true,
+  sourceRank: null,
+  metadata: JSON.stringify({ source: 'seed', artworkPrompt }),
+})
+
+const provenanceIdentity = buildFacetIdentityPrompt(
+  seedFacet as never,
+  seedProfile(
+    'Kind Robots premium Builder card illustration for Dream Types: Art. A visual seed for image generation. Single centered subject or emblem, polished fantasy-software dashboard art, readable silhouette, no text, WebP.',
+  ) as never,
+)
+assert.doesNotMatch(provenanceIdentity, /Kind Robots|card illustration|WebP/i)
+assert.match(provenanceIdentity, /^Art\. A visual seed for image generation/)
+assert.deepEqual(
+  checkArtPromptContract({
+    prompt: provenanceIdentity,
+    engine: 'krea2',
+    steps: 8,
+    cfg: 1,
+  }),
+  [],
+  'a seed-provenance metadata prompt must not leak into the identity prompt',
+)
+
+const cardIdentity = buildFacetIdentityPrompt(
+  seedFacet as never,
+  seedProfile(
+    'Expressive inclusive character-card illustration representing non-binary identity, confident and specific.',
+  ) as never,
+)
+assert.doesNotMatch(cardIdentity, /card illustration/i)
+
+const captionIdentity = buildFacetIdentityPrompt(
+  seedFacet as never,
+  seedProfile(
+    'A paint-splattered easel under a skylight, brushes fanned in a jar, one canvas turned to the wall.',
+  ) as never,
+)
+assert.match(
+  captionIdentity,
+  /paint-splattered easel under a skylight/,
+  'a metadata prompt that is a usable caption on its own is still honoured',
+)
 
 console.log('Facet legacy prompt signature contract verified.')


### PR DESCRIPTION
## What broke

Third guard hit by the production Facet tainted-job repair ([run 33981068746](https://github.com/silasfelinus/kind_robots/actions/runs/33981068746)), again inside the validate-before-write step with nothing mutated:

```
[format-vocabulary] "card illustration" asks for a physical format, so the model renders the format
```

28 Facets (Dream Types, Reward Types, Rarity, Gender) carry a seed-time `FacetProfile.metadata.artworkPrompt` written for the old contextual producers, e.g. `Kind Robots premium Builder card illustration for Dream Types: Art. …` or `Expressive inclusive character-card illustration representing …`. It restates the description and adds app-name and card-format vocabulary that Krea paints literally. `buildFacetIdentityPrompt` appended it verbatim, and the prompt contract rejected the result. The semantic scrubber does not recognize this wrapper shape either, so it would otherwise have reached conditioning.

## Changes

- `scripts/generate_facet_art_v4.ts`: a metadata artwork prompt is used only when it stands on its own as a caption. It must not name the app and must pass the Krea prompt contract; otherwise title/description/flavor prose carries the identity, exactly as for every other Facet.
- `utils/scripts/verifyFacetLegacyPromptSignature.ts`: covers the seed wrapper, the character-card variant, and a usable caption that must still be honoured.

## Verification

- Full-catalog probe (all 1617 live Facets via the API, all four art variants through `buildFacetArtPayload`): 0 failures, 28 before.
- `verifyFacetLegacyPromptSignature`, `verifyFacetCatalogMaintenance`, `verifyArtPromptContract` pass locally; `eslint` shows only the 4 pre-existing `no-useless-escape` findings in the producer.

Conductor: `dream-cycle/t-006`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoXLrc2yHnkZtNBY4b8zSX

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoXLrc2yHnkZtNBY4b8zSX)_