### PR TITLE
fix(triage): normalize word-form timestamps so Apache lines share one signature

### DIFF
--- a/scripts/container_log_triage.py
+++ b/scripts/container_log_triage.py
@@ -350,7 +350,21 @@ def redact(text):
 # Skeletonization — collapse a line to its shape so repeats collapse together
 # --------------------------------------------------------------------------
 
+_MONTHS = r"(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"
+_DAYS = r"(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)"
+
 SKELETON_STEPS = (
+    # Word-form timestamps first, before the numeric rules below chew them up
+    # piecemeal. Apache's error log stamps every line `[Sat Sep 05 05:35:07.291452
+    # 2026]`; the generic rules turned that into `[sat sep <num> <ts> <num>]`,
+    # which keeps the WEEKDAY, so one scoopspress PHP warning earned a fresh
+    # fingerprint every day and was reported as `new` on 2026-09-03, 09-04 and
+    # 09-05 in turn -- never once as spiking or quiet, and never against a
+    # baseline. Same shape covers the CLF access-log form `[05/Sep/2026:05:35:07
+    # +0000]` and the syslog form `Sep  5 05:35:07`.
+    (re.compile(r"\b" + _DAYS + r" " + _MONTHS + r" +\d{1,2} \d{2}:\d{2}:\d{2}(?:[.,]\d+)? \d{4}\b"), "<TS>"),
+    (re.compile(r"\b\d{1,2}/" + _MONTHS + r"/\d{4}:\d{2}:\d{2}:\d{2}(?: [+-]\d{4})?\b"), "<TS>"),
+    (re.compile(r"\b" + _MONTHS + r" +\d{1,2} \d{2}:\d{2}:\d{2}(?:[.,]\d+)?\b"), "<TS>"),
     (re.compile(r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?(?:Z|[+-]\d{2}:?\d{2})?"), "<TS>"),
     (re.compile(r"\b\d{2}:\d{2}:\d{2}(?:[.,]\d+)?\b"), "<TS>"),
     (re.compile(r"\b\d{4}-\d{2}-\d{2}\b"), "<DATE>"),

--- a/tests/python/test_container_log_triage.py
+++ b/tests/python/test_container_log_triage.py
@@ -203,6 +203,32 @@ def test_timestamps_do_not_split_a_signature():
     assert a == b
 
 
+def test_word_form_timestamps_do_not_split_a_signature():
+    # Apache's error log leads with `[Sat Sep 05 05:35:07.291452 2026]`. The
+    # numeric rules alone left `[sat sep <num> <ts> <num>]` behind -- the
+    # weekday survived -- so scoopspress's one standing PHP warning was
+    # reported as a brand-new signature on three consecutive days (2026-09-03
+    # to 09-05) instead of once, and could never accumulate a baseline.
+    apache = [
+        skeletonize("[Thu Sep 03 08:17:14.569014 2026] [php:warn] [pid 53:tid 53] "
+                    "[client 1.2.3.4:0] PHP Warning:  Undefined variable $x in /a/b.php on line 90"),
+        skeletonize("[Fri Sep 04 02:20:15.941655 2026] [php:warn] [pid 103:tid 103] "
+                    "[client 5.6.7.8:0] PHP Warning:  Undefined variable $x in /a/b.php on line 90"),
+        skeletonize("[Sat Sep 05 00:39:51.669169 2026] [php:warn] [pid 322:tid 322] "
+                    "[client 9.9.9.9:0] PHP Warning:  Undefined variable $x in /a/b.php on line 90"),
+    ]
+    assert len(set(apache)) == 1
+    assert "sat" not in apache[0] and "sep" not in apache[0]
+
+    clf_a = skeletonize('1.2.3.4 - - [05/Sep/2026:05:35:07 +0000] "GET /phpinfo.php HTTP/1.1" 404 196')
+    clf_b = skeletonize('5.6.7.8 - - [06/Oct/2026:23:01:59 -0700] "GET /wp-login.php HTTP/1.1" 404 196')
+    assert clf_a == clf_b
+
+    syslog_a = skeletonize("Sep  5 05:35:07 alexandria kernel: eth0: link down")
+    syslog_b = skeletonize("Dec 25 23:59:59 alexandria kernel: eth0: link down")
+    assert syslog_a == syslog_b
+
+
 def test_fingerprint_is_per_container():
     skeleton = skeletonize("connection refused")
     assert fingerprint("plex", skeleton) != fingerprint("sonarr", skeleton)


### PR DESCRIPTION
## Why

Day one of the Alexandria container-log digest reported three scoopspress signatures as `new`. Two of them were the same PHP warning that already appeared in the 2026-09-04 digest, and the day before that. They kept looking new because Apache's error log stamps every line `[Sat Sep 05 05:35:07.291452 2026]`, and the skeleton rules only understood numeric timestamps. The result was `[sat sep <num> <ts> <num>]` with the weekday intact, so one warning earned a fresh fingerprint every day and could never build a baseline or be muted once.

## What

- Add word-form timestamp rules ahead of the numeric ones: Apache error log (`[Sat Sep 05 05:35:07 2026]`), CLF access log (`[05/Sep/2026:05:35:07 +0000]`), and syslog (`Sep  5 05:35:07`).
- Regression test covering all three shapes across different days.

The `referer` variant of the same warning now also collapses into the base row, because the existing `<PATH>` rule already swallows the trailing clause once the timestamp is gone.

## Verified

- `python -m pytest tests/python/ -q`: 67 passed
- Executable bit intact; no new imports (stdlib-only check unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5UF9Ebtt9aM8WEwZA7eNz

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5UF9Ebtt9aM8WEwZA7eNz)_