### PR TITLE
interface-vision t-104 slice 91: migrate art/ family btn-xs buttons to kr-btn-xs

### DIFF
--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -264,7 +264,7 @@
             </button>
 
             <button
-              class="btn btn-ghost btn-xs ml-auto rounded-xl"
+              class="kr-btn-xs btn-ghost ml-auto"
               type="button"
               :disabled="isBatchWorking"
               @click="toggleBulkSelect"
@@ -292,7 +292,7 @@
             </select>
 
             <button
-              class="btn btn-secondary btn-xs rounded-xl"
+              class="kr-btn-xs btn-secondary"
               type="button"
               :disabled="
                 isBatchWorking ||
@@ -306,7 +306,7 @@
             </button>
 
             <button
-              class="btn btn-warning btn-xs rounded-xl"
+              class="kr-btn-xs btn-warning"
               type="button"
               :disabled="
                 isBatchWorking ||
@@ -321,7 +321,7 @@
 
             <button
               v-if="activeGroup && activeGroup.id > 0"
-              class="btn btn-warning btn-xs rounded-xl"
+              class="kr-btn-xs btn-warning"
               type="button"
               :disabled="isBatchWorking || !selectedImageCount"
               @click="removeSelectedFromActiveCollection"
@@ -353,7 +353,7 @@
             </select>
 
             <button
-              class="btn btn-info btn-xs rounded-xl"
+              class="kr-btn-xs btn-info"
               type="button"
               :disabled="isBatchWorking || !canBatchModifyImages"
               @click="applySelectedImageFlags"
@@ -363,7 +363,7 @@
             </button>
 
             <button
-              class="btn btn-error btn-xs rounded-xl"
+              class="kr-btn-xs btn-error"
               type="button"
               :disabled="isBatchWorking || !canBatchModifyImages"
               @click="deleteSelectedImages"

--- a/components/art/art-generator.vue
+++ b/components/art/art-generator.vue
@@ -193,7 +193,7 @@
               </span>
               <button
                 type="button"
-                class="btn btn-secondary btn-xs rounded-xl"
+                class="kr-btn-xs btn-secondary"
                 :disabled="artStore.isGenerating"
                 @click="randomStore.applyMakePretty()"
               >
@@ -201,7 +201,7 @@
               </button>
               <button
                 type="button"
-                class="btn btn-accent btn-xs rounded-xl"
+                class="kr-btn-xs btn-accent"
                 :disabled="artStore.isGenerating"
                 @click="randomStore.applySurprise()"
               >
@@ -278,7 +278,7 @@
                 This checkpoint usually wants
                 <button
                   type="button"
-                  class="btn btn-outline btn-xs rounded-xl"
+                  class="kr-btn-xs btn-outline"
                   @click="applyPreset(recommendedPreset.id)"
                 >
                   {{ recommendedPreset.label }}

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -17,7 +17,7 @@
 
       <div class="flex shrink-0 flex-wrap gap-2">
         <button
-          class="btn btn-xs btn-outline rounded-xl sm:btn-sm"
+          class="kr-btn-xs btn-outline sm:btn-sm"
           type="button"
           @click="navStore.setDashboardTab('art', 'gallery')"
         >
@@ -37,7 +37,7 @@
 
         <button
           v-if="userStore.isLoggedIn"
-          class="btn btn-xs rounded-xl sm:btn-sm"
+          class="kr-btn-xs sm:btn-sm"
           :class="
             isCurrentAvatar ? 'btn-success text-success-content' : 'btn-outline'
           "
@@ -59,7 +59,7 @@
         </button>
 
         <button
-          class="btn btn-xs btn-primary rounded-xl text-white sm:btn-sm"
+          class="kr-btn-xs btn-primary text-white sm:btn-sm"
           type="button"
           :disabled="!currentArtImage"
           @click="startRemix"
@@ -83,7 +83,7 @@
 
           <button
             v-else
-            class="btn btn-xs btn-error rounded-xl text-error-content sm:btn-sm"
+            class="kr-btn-xs btn-error text-error-content sm:btn-sm"
             type="button"
             :disabled="isDeleting"
             @click="confirmDelete"

--- a/components/art/artjob-editor.vue
+++ b/components/art/artjob-editor.vue
@@ -197,7 +197,7 @@
               </summary>
               <button
                 type="button"
-                class="btn btn-xs rounded-xl mt-2"
+                class="kr-btn-xs mt-2"
                 @click="copyPayloadJson"
               >
                 {{ copiedJson ? 'Copied' : 'Copy JSON' }}

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -116,7 +116,7 @@
                 <div class="flex shrink-0 items-center gap-1">
                   <button
                     type="button"
-                    class="btn btn-ghost btn-xs rounded-xl px-2"
+                    class="kr-btn-xs btn-ghost px-2"
                     :disabled="refreshingServerIds.includes(server.id)"
                     title="Re-check this server now"
                     @click="refreshServer(server.id)"
@@ -129,7 +129,7 @@
                   </button>
                   <button
                     type="button"
-                    class="btn btn-ghost btn-xs rounded-xl px-2 text-error"
+                    class="kr-btn-xs btn-ghost px-2 text-error"
                     :disabled="removingServerIds.includes(server.id)"
                     title="Remove this server"
                     @click="removeServer(server)"

--- a/components/art/stylist-client-gallery.vue
+++ b/components/art/stylist-client-gallery.vue
@@ -15,7 +15,7 @@
 
       <button
         type="button"
-        class="btn btn-xs gap-1 rounded-xl"
+        class="kr-btn-xs gap-1"
         :class="uploadOpen ? 'btn-primary' : 'btn-ghost'"
         :aria-expanded="uploadOpen"
         @click="uploadOpen = !uploadOpen"


### PR DESCRIPTION
Migrates the remaining `btn btn-xs ... rounded-xl` button shapes in the `art/` component family to the shared `kr-btn-xs` primitive, preserving color/state modifier classes (`btn-secondary`, `btn-warning`, `btn-info`, `btn-error`, `btn-ghost`, `btn-outline`, `btn-primary`, `btn-accent`) and layout utilities (`sm:btn-sm`, `gap-1`, `px-2`, `mt-2`, `ml-auto`, `text-white`, `text-error-content`). No geometry or behavior change.

**Files (17 occurrences across 6 files, the `art/` family flagged as next in the slice-90 reconciliation note):**
- `components/art/art-gallery.vue` (6)
- `components/art/art-generator.vue` (3)
- `components/art/art-interact.vue` (4)
- `components/art/artjob-editor.vue` (1)
- `components/art/artjob-queue-browser.vue` (2)
- `components/art/stylist-client-gallery.vue` (1)

**Verification:**
- `vue-tsc --noEmit` (full project): clean
- `eslint` on all 6 changed files: 0 new issues (3 pre-existing `no-dynamic-delete` errors in `art-gallery.vue`/`stylist-client-gallery.vue` confirmed present on `origin/main` via `git stash`, unrelated to this change)
- `test:layout-contract`: held (207 baseline)
- `test:lint-ratchet`: held (333/-59)
- `prettier --check`: pre-existing drift on 4 of 6 files, confirmed via `git stash` against `origin/main`

Conductor: `interface-vision/t-104`, claimed for slice 91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtBMJYgdx4RsYnHFPfGPMq

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtBMJYgdx4RsYnHFPfGPMq)_