### PR TITLE
interface-vision t-104 slice 92: migrate dreams/ family btn-xs buttons to kr-btn-xs

### DIFF
--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -76,7 +76,7 @@
             </div>
             <button
               type="button"
-              class="btn btn-xs btn-outline rounded-xl"
+              class="kr-btn-xs btn-outline"
               :disabled="dreamStore.loading"
               @click="refreshDreams"
             >
@@ -273,7 +273,7 @@
                   <div class="flex gap-1">
                     <button
                       type="button"
-                      class="btn btn-primary btn-xs rounded-xl"
+                      class="kr-btn-xs btn-primary"
                       :disabled="candidate.status === 'accepted'"
                       @click="acceptCandidate(candidate.id)"
                     >
@@ -281,7 +281,7 @@
                     </button>
                     <button
                       type="button"
-                      class="btn btn-error btn-outline btn-xs rounded-xl"
+                      class="kr-btn-xs btn-error btn-outline"
                       :disabled="candidate.status === 'rejected'"
                       @click="rejectCandidate(candidate.id)"
                     >
@@ -329,7 +329,7 @@
                   </button>
                   <button
                     type="button"
-                    class="btn btn-secondary btn-xs rounded-xl"
+                    class="kr-btn-xs btn-secondary"
                     @click="copyCandidateToExamples(candidate)"
                   >
                     Add Example
@@ -479,7 +479,7 @@
               />
               <button
                 type="button"
-                class="btn btn-square btn-ghost btn-xs rounded-xl text-error"
+                class="kr-btn-xs btn-square btn-ghost text-error"
                 @click="removeExample(index)"
               >
                 <Icon name="kind-icon:x" class="h-3 w-3" />

--- a/components/dreams/dream-list.vue
+++ b/components/dreams/dream-list.vue
@@ -12,7 +12,7 @@
       <button
         v-if="showRefresh"
         type="button"
-        class="btn btn-xs btn-outline rounded-xl"
+        class="kr-btn-xs btn-outline"
         :disabled="isLoading"
         @click="refreshList"
       >


### PR DESCRIPTION
Migrates the remaining `btn btn-xs ... rounded-xl` button shapes in the `dreams/` component family to the shared `kr-btn-xs` primitive, preserving color/state modifier classes (`btn-outline`, `btn-primary`, `btn-error`, `btn-secondary`, `btn-square`, `btn-ghost`) and layout utilities (`text-error`). No geometry or behavior change.

**Files (6 occurrences across 2 files, next-largest family after slice 91's `art/` family):**
- `components/dreams/dream-brainstorm.vue` (5)
- `components/dreams/dream-list.vue` (1)

**Verification:**
- `vue-tsc --noEmit` (full project): clean
- `eslint` on both changed files: 0 new issues (17 pre-existing errors in `dream-list.vue` — `import/no-duplicates`, `@typescript-eslint/unified-signatures` — confirmed present on `origin/main` via `git stash`, unrelated to this change)
- `test:layout-contract`: held (207 baseline)
- `test:lint-ratchet`: held (333/-59)
- `prettier --check`: pre-existing drift on `dream-brainstorm.vue`, confirmed via `git stash` against `origin/main`

Conductor: `interface-vision/t-104`, claimed for slice 92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtBMJYgdx4RsYnHFPfGPMq

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtBMJYgdx4RsYnHFPfGPMq)_