### PR TITLE
interface-vision t-104 slice 93: migrate rewards/ family btn-xs buttons to kr-btn-xs

### DIFF
--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -435,7 +435,7 @@
 
             <button
               v-if="characterStore.selectedCharacter"
-              class="btn btn-ghost btn-xs mt-3 rounded-xl"
+              class="kr-btn-xs btn-ghost mt-3"
               type="button"
               :disabled="isStarting"
               @click="characterStore.deselectCharacter?.()"
@@ -468,7 +468,7 @@
             </button>
 
             <button
-              class="btn btn-xs btn-ghost shrink-0 rounded-xl"
+              class="kr-btn-xs btn-ghost shrink-0"
               type="button"
               :disabled="!rewardPromptPreview"
               @click="copyPrompt"

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -25,7 +25,7 @@
             </p>
 
             <button
-              class="btn btn-primary btn-xs shrink-0 rounded-xl"
+              class="kr-btn-xs btn-primary shrink-0"
               type="button"
               @click="continueWithSelected"
             >


### PR DESCRIPTION
Continuation of the recurring interface-vision/t-104 btn-xs → kr-btn-xs consistency sweep.

`components/rewards/reward-encounter.vue`, `components/rewards/reward-gallery.vue` — 3 occurrences across 2 files, the `rewards/` family (next-largest after slice 92's `dreams/` family) — migrated from hand-rolled `btn btn-* btn-xs ... rounded-xl` to `kr-btn-xs`, preserving all color/state modifiers (`btn-ghost`, `btn-primary`) and layout utilities (`mt-3`, `shrink-0`); no geometry or behavior change.

## Verification
- `vue-tsc --noEmit`: clean
- `eslint` on both changed files: 0 issues
- `test:layout-contract`: held (207 baseline, unchanged)
- `test:lint-ratchet`: held (333/-59, unchanged)
- `prettier --check`: clean on both files

Remaining families for the next slice (per `kr_btn_xs_codemod.py` dry-run): `scenarios/` (3 occurrences, 2 files), `user-dashboard.vue` (3), `storybook-library-page.vue` (3), `navigation/account-hub.vue` (2), `wonderlab/mural-manager.vue` (2), `servers/` (2, 2 files), `brainstorm-manager.vue` (1), `newsfeed-filters.vue` (1), `taskmaster-page.vue` (1), `pages/admin/lora-triage.vue` (1) — 19 occurrences across 11 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S44TVW13z3yL8gQ7gwBigY

---
_Generated by [Claude Code](https://claude.ai/code/session_01S44TVW13z3yL8gQ7gwBigY)_