### PR TITLE
interface-vision t-104 slice 94: migrate user-dashboard.vue btn-xs buttons to kr-btn-xs

### DIFF
--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -163,7 +163,7 @@
 
                   <NuxtLink
                     to="/wallet"
-                    class="btn btn-ghost btn-xs mt-2 w-full rounded-xl"
+                    class="kr-btn-xs btn-ghost mt-2 w-full"
                   >
                     Full history
                   </NuxtLink>
@@ -217,7 +217,7 @@
 
                   <button
                     type="button"
-                    class="btn btn-ghost btn-xs mt-2 w-full rounded-xl"
+                    class="kr-btn-xs btn-ghost mt-2 w-full"
                     @click="goToAchievementsTab"
                   >
                     See all
@@ -259,7 +259,7 @@
 
                   <button
                     type="button"
-                    class="btn btn-ghost btn-xs w-full rounded-xl"
+                    class="kr-btn-xs btn-ghost w-full"
                     @click="goToThemesTab"
                   >
                     Change theme


### PR DESCRIPTION
Recurring interface-vision/t-104 btn-xs consistency sweep — slice 94.

Migrates all 3 hand-rolled `btn btn-ghost btn-xs ... rounded-xl` occurrences in `components/user/user-dashboard.vue` to the shared `.kr-btn-xs` class, preserving all layout modifiers (`mt-2`, `w-full`) and the `btn-ghost` color/state modifier. No geometry or behavior change.

**Verification:**
- `vue-tsc --noEmit`: clean
- `eslint` on the changed file: 0 issues
- `prettier --check`: clean, no drift
- `test:layout-contract`: held (207 baseline)
- `test:lint-ratchet`: held (333 problems / -59)

Remaining families for the next slice (per `kr_btn_xs_codemod.py` dry-run): `scenarios/{add-scenario,scenario-story}.vue` (3 occurrences, 2 files), `pages/storybook-library-page.vue` (3), `navigation/account-hub.vue` (2), `wonderlab/mural-manager.vue` (2), `servers/{checkpoint-gallery,server-gallery}.vue` (2, 2 files), `brainstorm-manager.vue` (1), `newsfeed-filters.vue` (1), `taskmaster-page.vue` (1), `pages/admin/lora-triage.vue` (1) — 16 occurrences across 11 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQc6FNFNu93VqHHccbrPS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQc6FNFNu93VqHHccbrPS2)_