### PR TITLE
Fix Flux.2 LoRA generation compatibility

### DIFF
--- a/server/utils/artLoraResource.ts
+++ b/server/utils/artLoraResource.ts
@@ -2,7 +2,10 @@
 import { createError } from 'h3'
 import { ResourceType, SupportedServer } from '~/prisma/generated/prisma/client'
 import { resolveMaturityPrivacy } from '~/utils/maturityPrivacy'
-import { krea2LoraCompatibilityRank } from '~/utils/loraSelection'
+import {
+  flux2LoraCompatibilityRank,
+  krea2LoraCompatibilityRank,
+} from '~/utils/loraSelection'
 import { MAX_LORAS_PER_JOB } from '~/server/api/comfy/utils/loraChain'
 import prisma from './prisma'
 
@@ -160,9 +163,7 @@ function compatibilityRank(
   }
 
   if (engine === 'flux2') {
-    if (resource.supportedServer === SupportedServer.FLUX) return 30
-    if (resource.supportedServer === SupportedServer.KONTEXT) return 20
-    if (resource.supportedServer === SupportedServer.GENERIC) return 10
+    return flux2LoraCompatibilityRank(resource)
   }
 
   if (engine === 'sdxl-img2img') {

--- a/utils/loraSelection.ts
+++ b/utils/loraSelection.ts
@@ -35,6 +35,17 @@ export function krea2LoraCompatibilityRank(resource: LoraResourceLike): number {
   return 0
 }
 
+export function flux2LoraCompatibilityRank(resource: LoraResourceLike): number {
+  const server = normalizedServer(resource)
+  const generation = normalizedGeneration(resource)
+
+  if (!/\bFLUX[\s._-]*2\b/.test(generation)) return 0
+  if (server === 'FLUX') return 30
+  if (server === 'COMFY') return 20
+  if (server === 'GENERIC') return 10
+  return 0
+}
+
 export function videoLoraCompatible(
   resource: LoraResourceLike,
   engine: VideoEngine,
@@ -55,10 +66,7 @@ export function artLoraCompatibilityRank(
   }
 
   if (engine === 'flux2') {
-    if (server === 'FLUX') return 30
-    if (server === 'KONTEXT') return 20
-    if (server === 'GENERIC') return 10
-    return 0
+    return flux2LoraCompatibilityRank(resource)
   }
 
   if (engine !== 'comfy') return 0

--- a/utils/scripts/verifyArtGeneratorPresets.ts
+++ b/utils/scripts/verifyArtGeneratorPresets.ts
@@ -11,6 +11,7 @@ import {
 } from '../artGeneratorPresets'
 import {
   artLoraCompatibilityRank,
+  flux2LoraCompatibilityRank,
   krea2LoraCompatibilityRank,
 } from '../loraSelection'
 
@@ -109,6 +110,16 @@ const krea1Lora = {
   generation: 'Krea 1',
   supportedServer: 'COMFY',
 }
+const flux2Lora = {
+  id: 6,
+  generation: 'Flux.2 Klein',
+  supportedServer: 'FLUX',
+}
+const genericFlux2Lora = {
+  id: 7,
+  generation: 'Flux 2',
+  supportedServer: 'GENERIC',
+}
 
 assert.equal(krea2LoraCompatibilityRank(krea2Lora), 30)
 assert.equal(krea2LoraCompatibilityRank(genericKreaLora), 20)
@@ -118,11 +129,14 @@ assert.equal(krea2LoraCompatibilityRank(krea1Lora), 0)
 assert.equal(artLoraCompatibilityRank(fluxLora, 'krea2'), 0)
 assert.equal(artLoraCompatibilityRank(kontextLora, 'krea2'), 0)
 assert.equal(artLoraCompatibilityRank(krea2Lora, 'krea2'), 30)
-assert.equal(
-  artLoraCompatibilityRank(fluxLora, 'flux2'),
-  30,
-  'splitting Krea compatibility must not silently change the existing Flux.2 policy',
-)
+
+assert.equal(flux2LoraCompatibilityRank(fluxLora), 0)
+assert.equal(flux2LoraCompatibilityRank(kontextLora), 0)
+assert.equal(flux2LoraCompatibilityRank(flux2Lora), 30)
+assert.equal(flux2LoraCompatibilityRank(genericFlux2Lora), 10)
+assert.equal(artLoraCompatibilityRank(fluxLora, 'flux2'), 0)
+assert.equal(artLoraCompatibilityRank(kontextLora, 'flux2'), 0)
+assert.equal(artLoraCompatibilityRank(flux2Lora, 'flux2'), 30)
 
 for (const name of [
   'dreamshaperXL_v21TurboDPMSDE.safetensors',
@@ -172,8 +186,12 @@ assert.ok(
   'the enqueue resolver must enforce the same Krea family check as the picker',
 )
 assert.ok(
+  loraResolver.includes('flux2LoraCompatibilityRank(resource)'),
+  'the enqueue resolver must enforce the same Flux.2 generation check as the picker',
+)
+assert.ok(
   loraResolver.includes('generation: true'),
-  'the enqueue resolver must fetch Resource.generation before checking Krea compatibility',
+  'the enqueue resolver must fetch Resource.generation before checking model-family compatibility',
 )
 
 function laneBody(marker: string): string {
@@ -231,5 +249,5 @@ assert.ok(bench.includes('defaultsFromPreset'))
 assert.ok(!bench.includes('POLL_TIMEOUT_MS'))
 
 console.log(
-  'Art generation quality contract OK: presets are product-owned, Krea LoRAs stay in the Krea family, shared generation uses the canonical profile registry, and browser polling follows durable ArtJobs until terminal state.',
+  'Art generation quality contract OK: Krea and Flux.2 LoRAs stay in their model families, presets are product-owned, shared generation uses the canonical profile registry, and browser polling follows durable ArtJobs until terminal state.',
 )


### PR DESCRIPTION
## Root cause addressed
ArtJob 21616 exposed that the Flux.2 lane accepted any `supportedServer: FLUX` LoRA, including a `generation: Flux.1 D` Resource. That pairing is architecture-crossed and should never reach ComfyUI.

## Changes
- make Flux.2 LoRA compatibility generation-aware in the shared picker policy
- reuse that exact policy in server-side enqueue resolution, so stale/direct API selections are rejected too
- replace the old contract that explicitly blessed Flux.1-on-Flux.2 with regression coverage for Flux.1/Kontext rejection and Flux.2 acceptance

## Scope
Three files only. No schema changes. No production mutations. This removes one verified unsafe input path associated with conductor/t-147. It does **not** claim the Flux.1 LoRA was conclusively the cause of the relay process going silent; relay/Comfy host inspection remains separate runtime evidence.

Related: conductor/t-147, ArtJob 21616, LoRA Resource 1055.