### PR TITLE
style: migrate storybook-library-page.vue buttons to kr-btn-xs (slice 95)

### DIFF
--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -170,21 +170,21 @@
           <div class="mt-3 flex flex-wrap gap-2">
             <button
               type="button"
-              class="btn btn-primary btn-xs rounded-xl"
+              class="kr-btn-xs btn-primary"
               @click="openStory(story.id)"
             >
               {{ story.status === 'complete' ? 'Open' : 'Resume' }}
             </button>
             <button
               type="button"
-              class="btn btn-ghost btn-xs rounded-xl border border-base-300"
+              class="kr-btn-xs btn-ghost border border-base-300"
               @click="duplicateStory(story.id)"
             >
               Duplicate
             </button>
             <button
               type="button"
-              class="btn btn-ghost btn-xs rounded-xl border border-base-300"
+              class="kr-btn-xs btn-ghost border border-base-300"
               @click="downloadStory(story.id, 'markdown')"
             >
               Export


### PR DESCRIPTION
### Task
interface-vision/t-104: recurring btn-xs consistency sweep, slice 95 (kind: software)

### What changed / what I produced
- Migrated all 3 hand-rolled `btn btn-{primary,ghost} btn-xs ... rounded-xl` occurrences in `components/pages/storybook-library-page.vue` to the shared `kr-btn-xs` class, preserving color/state modifiers (`btn-primary`, `btn-ghost`) and layout utilities (`border border-base-300`). No geometry or behavior change.
- Applied via `utils/scripts/codemods/kr_btn_xs_codemod.py --apply` globally, then kept only this file's occurrences (largest remaining single-file family) and reverted the rest.

### How I verified
- Grepped `utils/scripts/*.mjs` for the exact class strings being replaced and for the filename — several `verifyStorybook*.mjs` guards reference `storybook-library-page.vue` but none hardcode these button classes. Ran all 6 storybook regression guards directly (`verifyStorybookConfirmArmScopeGuard.mjs`, `verifyStorybookLibraryMountReopenGuard.mjs`, `verifyStorybookLibraryNewStoryConfirmGuard.mjs`, `verifyStorybookRestoreIdempotencyGuard.mjs`, `verifyStorybookSeedQueryRaceGuard.mjs`, `verifyStorybookSessionLibrary.mjs`) — all pass.
- `vue-tsc --noEmit`: clean.
- `eslint` on the changed file: 0 issues.
- `prettier --check`: flags pre-existing drift on this file — confirmed via `git stash` that the same warning exists on `main` before this change, so it's not introduced here.
- `npm run test:layout-contract`: holds (207 baseline, unchanged).
- `npm run test:lint-ratchet`: holds (333 problems / -59, unchanged).

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
None new this cycle — remaining backlog (13 occurrences across 10 files after this slice) is already tracked in the roadmap task's own note for the next slice.

### Notes for reviewer
Remaining families for the next slice (per `kr_btn_xs_codemod.py` dry-run, pre-this-change): `scenarios/{add-scenario,scenario-story}.vue` (3 occ/2 files), `navigation/account-hub.vue` (2), `wonderlab/mural-manager.vue` (2), `servers/{checkpoint-gallery,server-gallery}.vue` (2/2 files), `brainstorm-manager.vue` (1), `newsfeed-filters.vue` (1), `taskmaster-page.vue` (1), `pages/admin/lora-triage.vue` (1) — 13 occurrences across 10 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFmpbtxTBpiyMWUuEUJ9RU

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFmpbtxTBpiyMWUuEUJ9RU)_