### PR TITLE
style: migrate account-hub.vue buttons to kr-btn-xs (slice 97)

### DIFF
--- a/components/navigation/account-hub.vue
+++ b/components/navigation/account-hub.vue
@@ -213,7 +213,7 @@
 
             <button
               type="button"
-              class="btn btn-xs btn-secondary rounded-xl"
+              class="kr-btn-xs btn-secondary"
               @click="addAccount"
             >
               <Icon name="kind-icon:plus" class="h-3.5 w-3.5" />
@@ -224,7 +224,7 @@
           <NuxtLink
             v-else
             to="/login"
-            class="btn btn-primary btn-xs w-full justify-center gap-1.5 rounded-xl"
+            class="kr-btn-xs btn-primary w-full justify-center gap-1.5"
             @click="store.close"
           >
             <Icon name="kind-icon:login" class="h-3.5 w-3.5 shrink-0" />


### PR DESCRIPTION
### Task
interface-vision/t-104: recurring btn-xs consistency sweep, slice 97 (kind: software)

### What changed / what I produced
- Migrated both hand-rolled `btn btn-{secondary,primary} btn-xs ... rounded-xl` occurrences in `components/navigation/account-hub.vue` to the shared `kr-btn-xs` class, preserving color/state modifiers (`btn-secondary`, `btn-primary`) and layout utilities (`w-full justify-center gap-1.5`). No geometry or behavior change.
- Applied via `utils/scripts/codemods/kr_btn_xs_codemod.py --apply` globally, then kept only this file (largest remaining single-file family) and reverted the rest.

### How I verified
- Grepped `utils/scripts/*.mjs` for the filename and exact class strings. One hit: `verify-giftshop-checkout.mjs` reads `account-hub.vue`'s source, but only asserts it mounts `<cart-button />` — unrelated to button classes. Ran it directly — passes.
- `vue-tsc --noEmit`: clean.
- `eslint` on the changed file: 0 issues.
- `prettier --check`: flags pre-existing drift — confirmed via `git stash` that the same warning exists on `main` before this change.
- `npm run test:layout-contract`: holds (207 baseline, unchanged).
- `npm run test:lint-ratchet`: holds (333 problems / -59, unchanged).

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
None new this cycle — remaining backlog (8 occurrences across 7 files after this slice) is already tracked in the roadmap task's own note for the next slice.

### Notes for reviewer
Remaining families for the next slice (per `kr_btn_xs_codemod.py` dry-run, pre-this-change): `wonderlab/mural-manager.vue` (2), `servers/{checkpoint-gallery,server-gallery}.vue` (2/2 files), `brainstorm-manager.vue` (1), `newsfeed-filters.vue` (1), `taskmaster-page.vue` (1), `pages/admin/lora-triage.vue` (1) — 8 occurrences across 7 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFmpbtxTBpiyMWUuEUJ9RU

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFmpbtxTBpiyMWUuEUJ9RU)_