### PR TITLE
ops: cancel pending art jobs for the card/hero/icon slots being retired

### DIFF
--- a/.github/workflows/entity-art-slot-cleanup.yml
+++ b/.github/workflows/entity-art-slot-cleanup.yml
@@ -1,0 +1,130 @@
+# Entity art slot cleanup — manual, operator-dispatched only.
+#
+# Silas, 2026-09-05: "we really don't need three different images just so we
+# can show a hero view, card view, icon view. We can just have an image and
+# selectively display parts depending on what object it is."
+#
+# The 2026-09-05 Krea semantic repair enqueued ~1800 replacement renders for
+# exactly the cardPath/heroPath/iconPath slots that collapse is going to
+# retire. This workflow cancels those still-PENDING jobs so the render box
+# spends its hours on art we are keeping.
+#
+# It only ever cancels PENDING jobs. RUNNING renders finish, DONE jobs and
+# every existing ArtImage are untouched, and cancellation is reversible — the
+# ordinary producers can re-enqueue this coverage if the collapse is dropped.
+#
+# Runs here rather than from a sandbox because the DB host is a tailnet
+# address; without the Tailscale step every Prisma call fails as a 10s pool
+# timeout (`active=0 idle=0`) that looks like a dead database.
+#
+# Required repository Actions secrets (same as krea-semantic-art-repair.yml):
+#   DATABASE_URL
+#   DATABASE_SSL_CA_BASE64 or DATABASE_SSL_CA
+#   TS_OAUTH_CLIENT_ID
+#   TS_OAUTH_SECRET
+name: Entity art slot cleanup
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'dry-run reports the plan; write cancels the pending jobs'
+        type: choice
+        options:
+          - dry-run
+          - write
+        default: dry-run
+      fields:
+        description: 'Comma-separated entity art slots to clear pending jobs for'
+        type: string
+        default: 'cardPath,heroPath,iconPath'
+      include_unmarked:
+        description: 'Also cancel pending jobs for these slots that are NOT semantic-repair replacements'
+        type: boolean
+        default: false
+
+concurrency:
+  group: entity-art-slot-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      DATABASE_SSL_CA_BASE64: ${{ secrets.DATABASE_SSL_CA_BASE64 }}
+      DATABASE_SSL_CA: ${{ secrets.DATABASE_SSL_CA }}
+      CLEANUP_MODE: ${{ inputs.mode }}
+      CLEANUP_FIELDS: ${{ inputs.fields }}
+      CLEANUP_INCLUDE_UNMARKED: ${{ inputs.include_unmarked }}
+    steps:
+      - name: Require secrets
+        env:
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "::error::DATABASE_URL is empty. Add it as a REPOSITORY ACTIONS SECRET (Settings → Secrets and variables → Actions)."
+            exit 1
+          fi
+          if [ -z "$TS_OAUTH_CLIENT_ID" ] || [ -z "$TS_OAUTH_SECRET" ]; then
+            echo "::error::TS_OAUTH_CLIENT_ID / TS_OAUTH_SECRET are empty. The database host is a tailnet address; without them this fails as a Prisma pool timeout."
+            exit 1
+          fi
+          echo "mode=$CLEANUP_MODE fields=$CLEANUP_FIELDS include_unmarked=$CLEANUP_INCLUDE_UNMARKED"
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Cancel pending jobs for retiring slots
+        run: |
+          mkdir -p cleanup-output
+          ARGS="--fields=$CLEANUP_FIELDS"
+          if [ "$CLEANUP_MODE" = "write" ]; then ARGS="$ARGS --write"; fi
+          if [ "$CLEANUP_INCLUDE_UNMARKED" = "true" ]; then ARGS="$ARGS --include-unmarked"; fi
+          echo "Running with $ARGS"
+          npx tsx scripts/cancel_entity_art_slot_jobs.ts $ARGS \
+            2>&1 | tee cleanup-output/slot-cleanup.log
+          test "${PIPESTATUS[0]}" -eq 0
+
+      - name: Summarize
+        if: always()
+        run: |
+          {
+            echo "## Entity art slot cleanup — mode: $CLEANUP_MODE, fields: $CLEANUP_FIELDS"
+            if [ -f cleanup-output/slot-cleanup.log ]; then
+              echo
+              echo '```'
+              tail -c 6000 cleanup-output/slot-cleanup.log
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload cleanup report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: entity-art-slot-cleanup-${{ inputs.mode }}-${{ github.run_id }}
+          path: cleanup-output/
+          retention-days: 90
+          if-no-files-found: ignore

--- a/scripts/cancel_entity_art_slot_jobs.ts
+++ b/scripts/cancel_entity_art_slot_jobs.ts
@@ -1,0 +1,150 @@
+// /scripts/cancel_entity_art_slot_jobs.ts
+//
+// Cancel still-PENDING entity-art ArtJobs that target art slots we are
+// retiring. Written for the card/hero/icon collapse (Silas, 2026-09-05:
+// "we really don't need three different images just so we can show a hero
+// view, card view, icon view"), where the 2026-09-05 Krea semantic repair had
+// already enqueued ~1800 replacements for exactly the slots being dropped.
+// Rendering those costs days of GPU time to produce art the migration deletes.
+//
+// Safety:
+// - dry-run by default; --write is required to mutate anything
+// - PENDING only. A RUNNING job is left to finish (killing it mid-render
+//   strands the relay's output), and a DONE job is never touched, so no
+//   existing ArtImage or entity slot is altered by this script at all.
+// - by default only jobs carrying the `kreaSemanticRepair` marker (the
+//   replacements this migration made moot) are cancelled; --include-unmarked
+//   widens to every pending job for those slots
+// - cancellation is reversible: nothing is deleted, and the same coverage can
+//   be re-enqueued by the ordinary producers if the migration is abandoned
+//
+// Usage:
+//   npx tsx scripts/cancel_entity_art_slot_jobs.ts
+//   npx tsx scripts/cancel_entity_art_slot_jobs.ts --write
+//   npx tsx scripts/cancel_entity_art_slot_jobs.ts --fields cardPath,iconPath --write
+
+import 'dotenv/config'
+import { parseArtJobPayload } from '../server/utils/artJobPayload'
+import {
+  createScriptPrismaClient,
+  withDatabaseRetry,
+} from './lib/databaseRetry'
+
+const WRITE = process.argv.includes('--write')
+const INCLUDE_UNMARKED = process.argv.includes('--include-unmarked')
+const DEFAULT_FIELDS = ['cardPath', 'heroPath', 'iconPath']
+
+function targetFields(): string[] {
+  const argument = process.argv.find((value) => value.startsWith('--fields='))
+  if (!argument) return DEFAULT_FIELDS
+  const fields = argument
+    .slice('--fields='.length)
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+  return fields.length ? fields : DEFAULT_FIELDS
+}
+
+type JsonRecord = Record<string, unknown>
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : {}
+}
+
+function text(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+export async function main(): Promise<void> {
+  const fields = new Set(targetFields())
+
+  await withDatabaseRetry('Entity art slot job cancellation', async () => {
+    const prisma = createScriptPrismaClient()
+    try {
+      const rows = (await prisma.artJob.findMany({
+        where: {
+          status: 'PENDING',
+          payload: { contains: '"entityArt"' },
+        },
+        orderBy: { id: 'asc' },
+        select: { id: true, payload: true, projectSlug: true },
+      })) as Array<{ id: number; payload: string; projectSlug: string | null }>
+
+      const marked: number[] = []
+      const unmarked: number[] = []
+      const byField: Record<string, number> = {}
+      const byEntityType: Record<string, number> = {}
+
+      for (const row of rows) {
+        const payload = parseArtJobPayload(row.payload) as JsonRecord
+        const entityArt = asRecord(payload.entityArt)
+        const field = text(entityArt.field)
+        if (!fields.has(field)) continue
+
+        const entityType = text(entityArt.entityType).toLowerCase()
+        const isRepairReplacement =
+          asRecord(payload.kreaSemanticRepair).version === 1
+        if (isRepairReplacement) marked.push(row.id)
+        else unmarked.push(row.id)
+
+        if (isRepairReplacement || INCLUDE_UNMARKED) {
+          byField[field] = (byField[field] ?? 0) + 1
+          byEntityType[entityType] = (byEntityType[entityType] ?? 0) + 1
+        }
+      }
+
+      const cancelling = INCLUDE_UNMARKED ? [...marked, ...unmarked] : marked
+
+      if (WRITE && cancelling.length) {
+        // Re-assert status: 'PENDING' in the update filter so a job the relay
+        // claimed between the read above and this write is not yanked out from
+        // under an in-flight render.
+        for (let index = 0; index < cancelling.length; index += 200) {
+          const chunk = cancelling.slice(index, index + 200)
+          await prisma.artJob.updateMany({
+            where: { id: { in: chunk }, status: 'PENDING' },
+            data: {
+              status: 'CANCELLED',
+              claimedAt: null,
+              claimedBy: null,
+              error:
+                'Cancelled by entity-art slot cleanup: the card/hero/icon slots are being retired in favour of one primary image plus a tagged inspiration gallery.',
+            },
+          })
+        }
+      }
+
+      console.log(
+        JSON.stringify(
+          {
+            mode: WRITE ? 'write' : 'dry-run',
+            fields: [...fields],
+            includeUnmarked: INCLUDE_UNMARKED,
+            scannedPendingEntityArtJobs: rows.length,
+            repairReplacements: marked.length,
+            otherPendingJobsForTheseSlots: unmarked.length,
+            cancelled: WRITE ? cancelling.length : 0,
+            wouldCancel: WRITE ? 0 : cancelling.length,
+            byField,
+            byEntityType,
+            policy:
+              'PENDING only. RUNNING jobs finish, DONE jobs and every existing ArtImage are untouched. Cancellation is reversible: the ordinary producers can re-enqueue this coverage.',
+          },
+          null,
+          2,
+        ),
+      )
+    } finally {
+      await prisma.$disconnect()
+    }
+  })
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}


### PR DESCRIPTION
## Why

Entity art is moving from four slots per object (`imagePath` + `cardPath` + `heroPath` + `iconPath`) to one primary image plus a tagged inspiration gallery. Today's Krea semantic repair enqueued **~1,796 replacement renders for exactly the three slots that collapse retires** — measured at 84% of the 2,138 entity replacements (iconPath 31%, heroPath 28%, cardPath 25%; imagePath only 16%). At the render box's ~8–12 jobs/hour that is days of GPU time producing art the migration deletes.

## What

- `scripts/cancel_entity_art_slot_jobs.ts` — cancels still-PENDING entity-art jobs whose `entityArt.field` is in the retiring set. Dry-run by default; `--write` required. `--fields=` overrides the slot list, `--include-unmarked` widens beyond the repair replacements.
- `.github/workflows/entity-art-slot-cleanup.yml` — dispatch-only, dry-run default, behind the Tailscale step (the DB host is a tailnet address), with the report in the step summary and a 90-day artifact.

## Safety

**PENDING only.** RUNNING renders are left to finish rather than yanked mid-render, and DONE jobs, existing `ArtImage` rows and every entity art slot are untouched — so nothing visible changes anywhere in the app. The `updateMany` filter re-asserts `status: 'PENDING'` so a job the relay claims between read and write is not pulled out from under an in-flight render. Cancellation is reversible: nothing is deleted and the ordinary producers can re-enqueue this coverage if the collapse is abandoned.

By default only jobs carrying the `kreaSemanticRepair` marker are cancelled — the replacements this migration made moot — so unrelated pending work for those slots is reported but left alone unless `--include-unmarked` is passed.

The 998 Facet repair jobs are unaffected: Facet coverage runs in baseline mode and queues `imagePath` only.

## Verification

`vue-tsc --noEmit` clean; `eslint` clean on the new script; workflow YAML parses. The script has no effect until dispatched, and its first dispatch will be a dry run.

Conductor: `dream-cycle/t-006` follow-on (entity art slot collapse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoXLrc2yHnkZtNBY4b8zSX

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoXLrc2yHnkZtNBY4b8zSX)_