### PR TITLE
style: migrate wonderlab/mural-manager.vue buttons to kr-btn-xs

### DIFF
--- a/components/wonderlab/mural-manager.vue
+++ b/components/wonderlab/mural-manager.vue
@@ -118,7 +118,7 @@
               </button>
 
               <button
-                class="btn btn-ghost btn-xs self-center rounded-xl"
+                class="kr-btn-xs btn-ghost self-center"
                 type="button"
                 :disabled="!isCustomColor(color.id)"
                 :title="
@@ -277,7 +277,7 @@
                 </div>
 
                 <button
-                  class="btn btn-xs btn-secondary rounded-xl text-white"
+                  class="kr-btn-xs btn-secondary text-white"
                   type="button"
                   @click="coloringStore.paintGroup(group.id)"
                 >


### PR DESCRIPTION
interface-vision/t-104 slice 98 of the recurring btn-xs consistency sweep.

Migrates both hand-rolled `btn btn-xs ... rounded-xl` occurrences in `components/wonderlab/mural-manager.vue` to the shared `kr-btn-xs` primitive:
- `btn btn-ghost btn-xs self-center rounded-xl` → `kr-btn-xs btn-ghost self-center`
- `btn btn-xs btn-secondary rounded-xl text-white` → `kr-btn-xs btn-secondary text-white`

Color/state modifiers (`btn-ghost`, `btn-secondary`) and other utilities (`self-center`, `text-white`) preserved. No geometry or behavior change.

Verified before opening:
- Checked `utils/scripts/*.mjs` for the filename and exact class strings — no regression-guard hits.
- `vue-tsc --noEmit` clean
- `eslint` on the changed file: 0 issues
- `prettier --check`: clean, no drift
- `test:layout-contract`: holds (207 baseline unchanged)
- `test:lint-ratchet`: holds (333/-59 unchanged)

Remaining families for the next slice: `servers/{checkpoint-gallery,server-gallery}.vue` (2, 2 files), `brainstorm-manager.vue` (1), `newsfeed-filters.vue` (1), `taskmaster-page.vue` (1), `pages/admin/lora-triage.vue` (1) — 6 occurrences across 6 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqH1C81AkM4KJyVcRNyDuK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqH1C81AkM4KJyVcRNyDuK)_