### PR TITLE
art: normalize Bot's primary and crop a stand-in primary correctly

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Art-request YAML indentation contract
         run: npm run test:art-request-yaml
 
+      - name: Entity art primary/crop contract
+        run: npm run test:entity-art-primary-crop
+
       - name: GitHub file-read contract
         run: npm run test:github-file-contents
 

--- a/components/narrative/kr-art-plate.vue
+++ b/components/narrative/kr-art-plate.vue
@@ -30,6 +30,7 @@
           : '',
       ]"
       :eager="eager"
+      :style="objectPosition ? { objectPosition } : undefined"
       @error="onError"
     />
 
@@ -58,7 +59,8 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import {
-  resolveArtVariantSrc,
+  ART_VARIANT_FOCUS,
+  resolveArtVariantSource,
   type ArtVariant,
   type ArtImageSrcLike,
 } from '@/utils/artImageSrc'
@@ -96,6 +98,12 @@ const props = withDefaults(
      * contain, which is why this is a prop and not a constant.
      */
     fit?: 'cover' | 'contain'
+    /**
+     * CSS object-position for the crop. Left unset, a purpose-built variant is
+     * shown as composed and a primary standing in for a missing variant gets
+     * that variant's ART_VARIANT_FOCUS. Set it to art-direct one surface.
+     */
+    position?: string
     /** The gallery-card lift: art scales slightly on the ancestor's :hover. */
     hoverZoom?: boolean
     eager?: boolean
@@ -110,6 +118,7 @@ const props = withDefaults(
     compact: false,
     frame: 'plate',
     fit: 'cover',
+    position: '',
     hoverZoom: false,
     eager: false,
     placeholderIcon: 'kind-icon:image',
@@ -143,21 +152,39 @@ function onError(event: Event): void {
   }
 }
 
+const resolved = computed(() =>
+  resolveArtVariantSource(props.source, props.variant, props.fallback),
+)
+
 const src = computed(() => {
-  const resolved = resolveArtVariantSrc(
-    props.source,
-    props.variant,
-    props.fallback,
-  )
-  if (resolved && !failedSources.value.includes(resolved)) return resolved
+  const candidate = resolved.value.src
+  if (candidate && !failedSources.value.includes(candidate)) return candidate
   if (
     props.fallback &&
-    props.fallback !== resolved &&
+    props.fallback !== candidate &&
     !failedSources.value.includes(props.fallback)
   ) {
     return props.fallback
   }
   return ''
+})
+
+/*
+ * A purpose-built variant is already composed FOR this frame -- the card prompt
+ * asks for breathing room around the subject, the hero for the subject inside
+ * the centre region -- so it is shown exactly as stored. A primary standing in
+ * for a missing variant is a different situation: object-cover is cropping it,
+ * and a centred crop of a square portrait into 2:3 or 16:9 reliably cuts the
+ * head off. That case, and only that case, gets the variant's focus.
+ *
+ * 'contain' never crops, so it never needs repositioning.
+ */
+const objectPosition = computed(() => {
+  if (props.position) return props.position
+  if (props.fit === 'contain') return undefined
+  return resolved.value.origin === 'primary'
+    ? ART_VARIANT_FOCUS[props.variant]
+    : undefined
 })
 
 /*

--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "test:github-file-contents": "tsx utils/scripts/verifyGithubFileContents.ts",
     "test:art-prompt-repair": "tsx utils/scripts/verifyArtPromptRepair.ts",
     "test:art-prompt-contract": "tsx utils/scripts/verifyArtPromptContract.ts",
+    "test:entity-art-primary-crop": "tsx utils/scripts/verifyEntityArtPrimaryCrop.ts",
     "test:artjob-sampler-repair": "tsx utils/scripts/verifyArtJobSamplerRepair.ts",
     "test:comfy-only-generation": "tsx utils/scripts/verifyComfyOnlyGeneration.ts",
     "test:art-generator-presets": "tsx utils/scripts/verifyArtGeneratorPresets.ts",

--- a/utils/artImageSrc.ts
+++ b/utils/artImageSrc.ts
@@ -9,6 +9,16 @@
 export type ArtImageSrcLike =
   | {
       imagePath?: string | null
+      /**
+       * Bot's primary render lives in `avatarImage`, not `imagePath` -- a
+       * naming split that predates the shared entity-art slots and forced every
+       * bot surface to special-case its own primary. Resolving it here makes
+       * one good render enough for a Bot exactly as it already is for every
+       * other entity (Silas, 2026-09-05: normalize Bot onto the common
+       * primary). `Bot.imagePath` exists too and wins when populated, so the
+       * eventual backfill needs no code change.
+       */
+      avatarImage?: string | null
       path?: string | null
       thumbnailPath?: string | null
       cardPath?: string | null
@@ -47,12 +57,44 @@ export function resolveArtImageSrc(
   image: ArtImageSrcLike,
   fallback = '',
 ): string {
-  const path = cleanValue(image?.imagePath) || cleanValue(image?.path)
+  const path =
+    cleanValue(image?.imagePath) ||
+    cleanValue(image?.avatarImage) ||
+    cleanValue(image?.path)
   if (path) return path
   return toArtDataUri(image?.imageData, image?.fileType) || fallback
 }
 
 export type ArtVariant = 'card' | 'hero' | 'icon'
+
+/**
+ * Where to anchor a crop when a purpose-built variant does not exist and the
+ * primary render has to fill the frame instead.
+ *
+ * A purpose-built variant is already COMPOSED for its aspect -- the card prompt
+ * asks for "a vertical 2:3 composition with breathing room around the focal
+ * subject", the hero for "the focal subject safely inside the center region".
+ * Cropping one of those again would fight the composition, so these offsets are
+ * applied only to a primary standing in for a missing variant.
+ *
+ * Vertical bias, not centre: entity primaries are overwhelmingly figures and
+ * objects with their subject in the upper half, so a centred crop of a square
+ * into 2:3 or 16:9 reliably cuts heads off. 35% keeps the head and loses the
+ * feet, which is the right trade for a card.
+ */
+export const ART_VARIANT_FOCUS: Record<ArtVariant, string> = {
+  card: '50% 35%',
+  hero: '50% 40%',
+  icon: '50% 30%',
+}
+
+/** Where a resolved source came from, so callers know whether to re-crop it. */
+export type ArtSrcOrigin = 'variant' | 'primary' | 'fallback' | 'none'
+
+export type ResolvedArtSrc = {
+  src: string
+  origin: ArtSrcOrigin
+}
 
 const VARIANT_PATH_KEYS = {
   card: 'cardPath',
@@ -84,13 +126,38 @@ export function resolveArtVariantSrc(
   variant: ArtVariant,
   fallback = '',
 ): string {
+  return resolveArtVariantSource(image, variant, fallback).src
+}
+
+/**
+ * As resolveArtVariantSrc, but also reports WHERE the source came from.
+ *
+ * Display surfaces need that distinction to crop correctly: a purpose-built
+ * variant is composed for its frame and must be shown as-is, while a primary
+ * standing in for a missing variant wants ART_VARIANT_FOCUS applied. The
+ * string-returning wrapper above keeps every existing caller working.
+ */
+export function resolveArtVariantSource(
+  image: ArtImageSrcLike,
+  variant: ArtVariant,
+  fallback = '',
+): ResolvedArtSrc {
   const path = cleanValue(image?.[VARIANT_PATH_KEYS[variant]])
-  if (path) return path
+  if (path) return { src: path, origin: 'variant' }
 
-  const data = toArtDataUri(image?.[VARIANT_DATA_KEYS[variant]], image?.fileType)
-  if (data) return data
+  const data = toArtDataUri(
+    image?.[VARIANT_DATA_KEYS[variant]],
+    image?.fileType,
+  )
+  if (data) return { src: data, origin: 'variant' }
 
-  return resolveArtImageSrc(image, fallback)
+  const primary = resolveArtImageSrc(image)
+  if (primary) return { src: primary, origin: 'primary' }
+
+  const cleanFallback = cleanValue(fallback)
+  return cleanFallback
+    ? { src: cleanFallback, origin: 'fallback' }
+    : { src: '', origin: 'none' }
 }
 
 /**

--- a/utils/scripts/verifyEntityArtPrimaryCrop.ts
+++ b/utils/scripts/verifyEntityArtPrimaryCrop.ts
@@ -1,0 +1,122 @@
+// /utils/scripts/verifyEntityArtPrimaryCrop.ts
+//
+// Entity art is collapsing from four stored slots per object (imagePath +
+// cardPath + heroPath + iconPath) to one primary render plus an inspiration
+// gallery (Silas, 2026-09-05: "we really don't need three different images just
+// so we can show a hero view, card view, icon view").
+//
+// Two behaviours have to hold for that to look right, and both are easy to
+// regress silently because the fallback chain hides them:
+//
+//   1. A Bot's primary is found. Bot stores its render in `avatarImage` while
+//      every other entity uses `imagePath`, so a resolver that only knows
+//      `imagePath` renders bots as blank placeholders.
+//   2. A primary standing in for a missing variant is re-cropped, and a
+//      purpose-built variant is NOT. Variants are composed for their aspect;
+//      re-cropping one fights the composition, while failing to crop a
+//      stand-in square into 2:3 cuts the subject's head off.
+import assert from 'node:assert/strict'
+import {
+  ART_VARIANT_FOCUS,
+  resolveArtImageSrc,
+  resolveArtVariantSource,
+  resolveArtVariantSrc,
+  type ArtVariant,
+} from '../artImageSrc'
+
+const VARIANTS: ArtVariant[] = ['card', 'hero', 'icon']
+
+// ── Bot primary normalization ───────────────────────────────────────────────
+
+assert.equal(
+  resolveArtImageSrc({ avatarImage: '/images/bots/ami-bot.webp' }),
+  '/images/bots/ami-bot.webp',
+  "a Bot's avatarImage must resolve as its primary render",
+)
+
+assert.equal(
+  resolveArtImageSrc({
+    imagePath: '/api/art/images/42/file',
+    avatarImage: '/images/bots/ami-bot.webp',
+  }),
+  '/api/art/images/42/file',
+  'imagePath wins when both are set, so backfilling Bot.imagePath needs no code change',
+)
+
+assert.equal(
+  resolveArtVariantSource({ avatarImage: '/images/bots/ami-bot.webp' }, 'card')
+    .origin,
+  'primary',
+  'a Bot with only an avatar is a stand-in primary, not a composed variant',
+)
+
+// ── Origin reporting drives the crop ────────────────────────────────────────
+
+for (const variant of VARIANTS) {
+  const composed = resolveArtVariantSource(
+    { cardPath: '/card.webp', heroPath: '/hero.webp', iconPath: '/icon.webp' },
+    variant,
+  )
+  assert.equal(
+    composed.origin,
+    'variant',
+    `${variant}: a purpose-built variant must report origin 'variant' so it is shown as composed`,
+  )
+
+  const standIn = resolveArtVariantSource(
+    { imagePath: '/primary.webp' },
+    variant,
+  )
+  assert.deepEqual(
+    standIn,
+    { src: '/primary.webp', origin: 'primary' },
+    `${variant}: a missing variant must fall back to the primary and say so`,
+  )
+
+  assert.equal(
+    resolveArtVariantSource(null, variant, '/fallback.webp').origin,
+    'fallback',
+    `${variant}: an empty source with a fallback must report origin 'fallback'`,
+  )
+
+  assert.deepEqual(
+    resolveArtVariantSource(null, variant),
+    { src: '', origin: 'none' },
+    `${variant}: nothing at all must report origin 'none', not an empty variant`,
+  )
+
+  assert.ok(
+    /^\d+% \d+%$/.test(ART_VARIANT_FOCUS[variant]),
+    `${variant}: needs a usable object-position focus for stand-in crops`,
+  )
+
+  // Vertical bias is the whole point: a centred crop of a square portrait into
+  // 2:3 or 16:9 cuts heads off, so every focus sits above centre.
+  const vertical = ART_VARIANT_FOCUS[variant].split(' ')[1] ?? ''
+  assert.ok(
+    Number.parseInt(vertical, 10) < 50,
+    `${variant}: focus must sit above centre so stand-in crops keep the subject`,
+  )
+}
+
+// ── The string wrapper stays byte-compatible for existing callers ───────────
+
+const cases = [
+  { cardPath: '/card.webp' },
+  { imagePath: '/primary.webp' },
+  { avatarImage: '/avatar.webp' },
+  null,
+]
+for (const source of cases) {
+  for (const variant of VARIANTS) {
+    assert.equal(
+      resolveArtVariantSrc(source, variant, '/fallback.webp'),
+      resolveArtVariantSource(source, variant, '/fallback.webp').src,
+      'resolveArtVariantSrc must stay a thin wrapper over resolveArtVariantSource',
+    )
+  }
+}
+
+console.log(
+  'Entity art primary/crop contract verified: Bot primaries resolve, and only a stand-in primary is re-cropped.',
+)


### PR DESCRIPTION
First slice of the entity-art collapse: four stored slots per object (`imagePath` + `cardPath` + `heroPath` + `iconPath`) become **one primary render plus the inspiration gallery** `EntityArtImage` already provides.

This slice is plumbing only. An object that has purpose-built variants renders byte-identically to before — the priority inversion that actually retires the variants comes next, and lands safely because the crop behaviour is already in place.

## Bot normalization

Bot stores its render in `avatarImage` while every other entity uses `imagePath`, so every bot surface special-cased its own primary and a bot without one rendered blank. `resolveArtImageSrc` now resolves `imagePath → avatarImage → path`.

No schema rename was needed: `Bot.imagePath` already exists (3 of 71 bots have it populated, 64 have only `avatarImage`, and where both are set the values are identical). `imagePath` still wins when set, so backfilling it later needs no code change.

## Crop correctness

New `resolveArtVariantSource()` reports whether a source is a **composed variant** or a **primary standing in** for a missing one. `resolveArtVariantSrc()` becomes a thin wrapper over it, so every existing caller is untouched.

`kr-art-plate` applies `ART_VARIANT_FOCUS` **only to a stand-in primary**. That distinction matters: a purpose-built variant is composed for its frame (the card prompt asks for "breathing room around the focal subject", the hero for "the subject safely inside the center region"), so re-cropping it would fight the composition. A square primary cropped to 2:3 or 16:9 by `object-cover` is the opposite case — a centred crop reliably cuts the subject's head off, so those get an above-centre anchor. A new `position` prop art-directs any single surface.

## Verification

- `utils/scripts/verifyEntityArtPrimaryCrop.ts` covers both behaviours (Bot primary resolution and precedence; origin reporting for variant / primary / fallback / none; the focus anchors all sitting above centre; the string wrapper staying byte-compatible). Wired into the Contract verifiers job.
- `vue-tsc --noEmit` clean, `eslint` clean on all changed files, layout contract holds, lint ratchet holds (333, −59).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoXLrc2yHnkZtNBY4b8zSX

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoXLrc2yHnkZtNBY4b8zSX)_