### PR TITLE
style: migrate servers/{checkpoint,server}-gallery.vue buttons to kr-btn-xs

### DIFF
--- a/components/servers/checkpoint-gallery.vue
+++ b/components/servers/checkpoint-gallery.vue
@@ -34,7 +34,7 @@
 
       <button
         v-if="allowAdd"
-        class="btn btn-xs btn-primary shrink-0 rounded-xl"
+        class="kr-btn-xs btn-primary shrink-0"
         type="button"
         @click="showAdd = !showAdd"
       >

--- a/components/servers/server-gallery.vue
+++ b/components/servers/server-gallery.vue
@@ -22,7 +22,7 @@
 
       <button
         v-if="showCardActions"
-        class="btn btn-xs btn-primary shrink-0 rounded-xl"
+        class="kr-btn-xs btn-primary shrink-0"
         type="button"
         @click="startAddServer"
       >


### PR DESCRIPTION
interface-vision/t-104 slice 99 of the recurring btn-xs consistency sweep.

Migrates the single hand-rolled `btn btn-xs btn-primary shrink-0 rounded-xl` occurrence in each of `components/servers/checkpoint-gallery.vue` and `components/servers/server-gallery.vue` to the shared `kr-btn-xs` primitive:
- `btn btn-xs btn-primary shrink-0 rounded-xl` → `kr-btn-xs btn-primary shrink-0`

Color/state modifier (`btn-primary`) and layout utility (`shrink-0`) preserved. No geometry or behavior change.

### Verified before opening
- Checked `utils/scripts/*.mjs` for the filenames and exact class string — no regression-guard hits.
- `vue-tsc --noEmit` clean
- `eslint` on both changed files: 0 issues
- `prettier --check`: `server-gallery.vue` flags pre-existing drift (confirmed via `git stash`, not introduced this slice); `checkpoint-gallery.vue` clean
- `test:layout-contract`: holds (207 baseline unchanged)
- `test:lint-ratchet`: holds (333/-59 unchanged)

Remaining families for the next slice: `brainstorm-manager.vue` (1), `newsfeed-filters.vue` (1), `taskmaster-page.vue` (1), `pages/admin/lora-triage.vue` (1) — 4 occurrences across 4 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YaWRecbEgeyL3LNKS7t68e

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaWRecbEgeyL3LNKS7t68e)_