### PR TITLE
art: primary render wins, card/hero/icon retired, old renders become inspiration

### DIFF
--- a/.github/workflows/entity-art-slot-cleanup.yml
+++ b/.github/workflows/entity-art-slot-cleanup.yml
@@ -27,8 +27,15 @@ name: Entity art slot cleanup
 on:
   workflow_dispatch:
     inputs:
+      task:
+        description: 'cancel-pending-jobs clears queued work for retiring slots; link-inspiration turns rendered card/hero/icon art into inspiration entries'
+        type: choice
+        options:
+          - cancel-pending-jobs
+          - link-inspiration
+        default: cancel-pending-jobs
       mode:
-        description: 'dry-run reports the plan; write cancels the pending jobs'
+        description: 'dry-run reports the plan; write applies it'
         type: choice
         options:
           - dry-run
@@ -55,6 +62,7 @@ jobs:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DATABASE_SSL_CA_BASE64: ${{ secrets.DATABASE_SSL_CA_BASE64 }}
       DATABASE_SSL_CA: ${{ secrets.DATABASE_SSL_CA }}
+      CLEANUP_TASK: ${{ inputs.task }}
       CLEANUP_MODE: ${{ inputs.mode }}
       CLEANUP_FIELDS: ${{ inputs.fields }}
       CLEANUP_INCLUDE_UNMARKED: ${{ inputs.include_unmarked }}
@@ -72,7 +80,7 @@ jobs:
             echo "::error::TS_OAUTH_CLIENT_ID / TS_OAUTH_SECRET are empty. The database host is a tailnet address; without them this fails as a Prisma pool timeout."
             exit 1
           fi
-          echo "mode=$CLEANUP_MODE fields=$CLEANUP_FIELDS include_unmarked=$CLEANUP_INCLUDE_UNMARKED"
+          echo "task=$CLEANUP_TASK mode=$CLEANUP_MODE fields=$CLEANUP_FIELDS include_unmarked=$CLEANUP_INCLUDE_UNMARKED"
 
       - uses: actions/checkout@v4
 
@@ -97,6 +105,7 @@ jobs:
           tags: tag:ci
 
       - name: Cancel pending jobs for retiring slots
+        if: inputs.task == 'cancel-pending-jobs'
         run: |
           mkdir -p cleanup-output
           ARGS="--fields=$CLEANUP_FIELDS"
@@ -107,24 +116,40 @@ jobs:
             2>&1 | tee cleanup-output/slot-cleanup.log
           test "${PIPESTATUS[0]}" -eq 0
 
+      # Insert-only: every rendered card/hero/icon image gains an
+      # EntityArtImage join row so it shows up as inspiration. Nothing is
+      # deleted, moved or rewritten -- see the script header.
+      - name: Link retired slot art as inspiration
+        if: inputs.task == 'link-inspiration'
+        run: |
+          mkdir -p cleanup-output
+          ARGS=""
+          if [ "$CLEANUP_MODE" = "write" ]; then ARGS="--write"; fi
+          echo "Running with ${ARGS:-<dry-run>}"
+          npx tsx scripts/link_entity_art_slots_as_inspiration.ts $ARGS \
+            2>&1 | tee cleanup-output/inspiration-link.log
+          test "${PIPESTATUS[0]}" -eq 0
+
       - name: Summarize
         if: always()
         run: |
           {
-            echo "## Entity art slot cleanup — mode: $CLEANUP_MODE, fields: $CLEANUP_FIELDS"
-            if [ -f cleanup-output/slot-cleanup.log ]; then
+            echo "## Entity art slot cleanup — task: $CLEANUP_TASK, mode: $CLEANUP_MODE"
+            for f in cleanup-output/*.log; do
+              [ -f "$f" ] || continue
               echo
+              echo "### $(basename "$f")"
               echo '```'
-              tail -c 6000 cleanup-output/slot-cleanup.log
+              tail -c 6000 "$f"
               echo '```'
-            fi
+            done
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload cleanup report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: entity-art-slot-cleanup-${{ inputs.mode }}-${{ github.run_id }}
+          name: entity-art-slot-cleanup-${{ inputs.task }}-${{ inputs.mode }}-${{ github.run_id }}
           path: cleanup-output/
           retention-days: 90
           if-no-files-found: ignore

--- a/scripts/generate_facet_art_v4.ts
+++ b/scripts/generate_facet_art_v4.ts
@@ -95,6 +95,17 @@ const ART_VARIANTS = [
   },
 ] as const
 
+/**
+ * Slots the entity-art collapse retired. Kept as data rather than removed from
+ * ART_VARIANTS because repair still has to map a legacy job's stored field back
+ * onto its variant geometry; only NEW queueing is suppressed.
+ */
+const RETIRED_VARIANT_FIELDS = new Set<string>([
+  'cardPath',
+  'heroPath',
+  'iconPath',
+])
+
 type FacetArtField = (typeof ART_VARIANTS)[number]['field']
 type FacetArtVariant = (typeof ART_VARIANTS)[number]
 
@@ -677,14 +688,14 @@ export async function main(): Promise<void> {
           aliases: aliasesByFacet.get(facet.id) ?? [],
           artBacked: Boolean(
             facet.imagePath ||
-              facet.cardPath ||
-              facet.heroPath ||
-              facet.iconPath ||
-              facet.icon ||
-              facet.artImageId !== null ||
-              facet.artCollectionId !== null ||
-              linkedPrimaryArt.has(facet.id) ||
-              linkedCollections.has(facet.id),
+            facet.cardPath ||
+            facet.heroPath ||
+            facet.iconPath ||
+            facet.icon ||
+            facet.artImageId !== null ||
+            facet.artCollectionId !== null ||
+            linkedPrimaryArt.has(facet.id) ||
+            linkedCollections.has(facet.id),
           ),
         }
       })
@@ -732,7 +743,7 @@ export async function main(): Promise<void> {
         for (const variant of ART_VARIANTS) {
           const primaryLinked = Boolean(
             variant.field === 'imagePath' &&
-              (facet.artImageId !== null || linkedPrimaryArt.has(facet.id)),
+            (facet.artImageId !== null || linkedPrimaryArt.has(facet.id)),
           )
           if (clean(facet[variant.field]) || primaryLinked) {
             available.set(
@@ -745,11 +756,11 @@ export async function main(): Promise<void> {
         if (!ALL_VARIANTS) {
           const hasDisplayArt = Boolean(
             clean(facet.imagePath) ||
-              clean(facet.cardPath) ||
-              clean(facet.heroPath) ||
-              clean(facet.iconPath) ||
-              facet.artImageId !== null ||
-              linkedPrimaryArt.has(facet.id),
+            clean(facet.cardPath) ||
+            clean(facet.heroPath) ||
+            clean(facet.iconPath) ||
+            facet.artImageId !== null ||
+            linkedPrimaryArt.has(facet.id),
           )
           if (hasDisplayArt) continue
 
@@ -771,9 +782,19 @@ export async function main(): Promise<void> {
         }
 
         for (const variant of ART_VARIANTS) {
+          /*
+           * The slot collapse (2026-09-05): card/hero/icon are retired, so even
+           * --all-variants only tops up the primary now. This producer writes
+           * ArtJobs straight to the table rather than going through
+           * prepareEntityArtEnqueue, so it does not inherit that gate and has
+           * to refuse the retired slots itself. Repair still maps a legacy
+           * job's field back onto its variant via fieldVariant(), which is why
+           * the entries stay in ART_VARIANTS rather than being deleted.
+           */
+          if (RETIRED_VARIANT_FIELDS.has(variant.field)) continue
           const primaryLinked = Boolean(
             variant.field === 'imagePath' &&
-              (facet.artImageId !== null || linkedPrimaryArt.has(facet.id)),
+            (facet.artImageId !== null || linkedPrimaryArt.has(facet.id)),
           )
           if (clean(facet[variant.field]) || primaryLinked) continue
           if (pendingFacetFields.has(`${facet.id}:${variant.field}`)) {
@@ -811,7 +832,8 @@ export async function main(): Promise<void> {
       if (REPAIR_TAINTED) {
         for (const job of history) {
           const target = artTarget(job.payload)
-          if (!target || !LEGACY_FACET_ART_VERSIONS.has(target.version)) continue
+          if (!target || !LEGACY_FACET_ART_VERSIONS.has(target.version))
+            continue
           if (!['PENDING', 'RUNNING', 'DONE'].includes(job.status)) continue
 
           const key = `${target.entityId}:${target.field}`
@@ -827,11 +849,7 @@ export async function main(): Promise<void> {
 
           if (
             job.status === 'DONE' &&
-            !likelyStillCarriesLegacyOutput(
-              facet,
-              target.field,
-              job.artImageId,
-            )
+            !likelyStillCarriesLegacyOutput(facet, target.field, job.artImageId)
           ) {
             repairSkippedSuperseded.push(job.id)
             continue
@@ -843,7 +861,8 @@ export async function main(): Promise<void> {
           // needs repair.
           if (
             job.status === 'PENDING' &&
-            (slotArtImageId(facet, target.field) || slotPath(facet, target.field))
+            (slotArtImageId(facet, target.field) ||
+              slotPath(facet, target.field))
           ) {
             continue
           }

--- a/scripts/link_entity_art_slots_as_inspiration.ts
+++ b/scripts/link_entity_art_slots_as_inspiration.ts
@@ -1,0 +1,231 @@
+// /scripts/link_entity_art_slots_as_inspiration.ts
+//
+// Turn the retired card/hero/icon renders into inspiration entries.
+//
+// Entity art is collapsing to one primary render plus the inspiration gallery
+// (Silas, 2026-09-05). The ~1800 images already rendered into the retired slots
+// are NOT discarded by that collapse -- they become inspiration, exactly as
+// Silas asked: "we aren't deleting anything, we are turning them into
+// inspiration entries."
+//
+// Mechanically that is one join row each. listEntityArtHistory reads
+// EntityArtImage (interface-vision/t-079: "one join row is how an ArtImage
+// becomes visible in an entity's history ... not ArtImage.path prefixes"), so
+// inserting the link is the whole job and the ArtImage itself is never copied,
+// moved or touched.
+//
+// Safety:
+// - dry-run by default; --write is required to insert anything
+// - INSERT ONLY. No ArtImage, entity row, slot column or path is modified, so
+//   there is nothing here to roll back beyond deleting join rows.
+// - skipCreateMany-style dedupe: a slot already linked (the repair's
+//   preserveOriginal archiving linked many of them today) is counted, not
+//   re-inserted.
+// - a slot holding only a path string with no ArtImage row cannot be linked --
+//   there is no id to join to. Those are reported, never invented, and must be
+//   resolved before any column is cleared or they would become unreferenced.
+//
+// Usage:
+//   npx tsx scripts/link_entity_art_slots_as_inspiration.ts
+//   npx tsx scripts/link_entity_art_slots_as_inspiration.ts --write
+
+import 'dotenv/config'
+import {
+  createScriptPrismaClient,
+  withDatabaseRetry,
+} from './lib/databaseRetry'
+
+const WRITE = process.argv.includes('--write')
+
+/**
+ * Only these carry per-slot ArtImage foreign keys. Dream's secondary slots are
+ * path-only and, per the live census, entirely unpopulated -- so there is
+ * nothing to link there and inventing rows for it would be fabrication.
+ */
+const SLOT_FKS = {
+  character: {
+    cardPath: 'cardArtImageId',
+    heroPath: 'heroArtImageId',
+    iconPath: 'iconArtImageId',
+  },
+  bot: {
+    cardPath: 'cardArtImageId',
+    heroPath: 'heroArtImageId',
+    iconPath: 'iconArtImageId',
+  },
+  scenario: {
+    cardPath: 'cardArtImageId',
+    heroPath: 'heroArtImageId',
+    iconPath: 'iconArtImageId',
+  },
+  reward: {
+    cardPath: 'cardArtImageId',
+    heroPath: 'heroArtImageId',
+    iconPath: 'iconArtImageId',
+  },
+  facet: {
+    cardPath: 'cardArtImageId',
+    heroPath: 'heroArtImageId',
+    iconPath: 'iconArtImageId',
+  },
+} as const
+
+type EntityKey = keyof typeof SLOT_FKS
+
+const DELEGATE: Record<EntityKey, string> = {
+  character: 'character',
+  bot: 'bot',
+  scenario: 'scenario',
+  reward: 'reward',
+  facet: 'facet',
+}
+
+type Report = {
+  linked: number
+  alreadyLinked: number
+  pathOnlyNoArtImage: number
+  missingArtImageRow: number
+}
+
+function emptyReport(): Report {
+  return {
+    linked: 0,
+    alreadyLinked: 0,
+    pathOnlyNoArtImage: 0,
+    missingArtImageRow: 0,
+  }
+}
+
+export async function main(): Promise<void> {
+  await withDatabaseRetry('Entity art inspiration linking', async () => {
+    const prisma = createScriptPrismaClient()
+    const client = prisma as unknown as Record<
+      string,
+      { findMany: (args: unknown) => Promise<Array<Record<string, unknown>>> }
+    >
+
+    try {
+      const byEntity: Record<string, Record<string, Report>> = {}
+      const totals = emptyReport()
+
+      for (const entityType of Object.keys(SLOT_FKS) as EntityKey[]) {
+        const fields = SLOT_FKS[entityType]
+        byEntity[entityType] = {}
+
+        const select: Record<string, boolean> = { id: true }
+        for (const [pathField, fkField] of Object.entries(fields)) {
+          select[pathField] = true
+          select[fkField] = true
+        }
+
+        const rows = await client[DELEGATE[entityType]]!.findMany({ select })
+
+        for (const [pathField, fkField] of Object.entries(fields)) {
+          const report = emptyReport()
+
+          const candidates = rows.filter((row) => {
+            const id = Number(row[fkField])
+            const path =
+              typeof row[pathField] === 'string' ? row[pathField] : ''
+            if (Number.isInteger(id) && id > 0) return true
+            // Populated as a bare path with no ArtImage behind it: not linkable.
+            if (path) report.pathOnlyNoArtImage += 1
+            return false
+          })
+
+          const artImageIds = [
+            ...new Set(candidates.map((row) => Number(row[fkField]))),
+          ]
+
+          // Only link ArtImage rows that actually exist. A dangling FK would
+          // otherwise fail the insert and abort an otherwise clean run.
+          const existing = new Set(
+            (
+              (await prisma.artImage.findMany({
+                where: { id: { in: artImageIds } },
+                select: { id: true },
+              })) as Array<{ id: number }>
+            ).map((row) => row.id),
+          )
+
+          const alreadyLinked = new Set(
+            (
+              (await prisma.entityArtImage.findMany({
+                where: {
+                  entityType,
+                  artImageId: { in: artImageIds },
+                },
+                select: { entityId: true, artImageId: true },
+              })) as Array<{ entityId: number; artImageId: number }>
+            ).map((row) => `${row.entityId}:${row.artImageId}`),
+          )
+
+          const toLink: Array<{
+            entityType: string
+            entityId: number
+            artImageId: number
+          }> = []
+
+          for (const row of candidates) {
+            const entityId = Number(row.id)
+            const artImageId = Number(row[fkField])
+            if (!existing.has(artImageId)) {
+              report.missingArtImageRow += 1
+              continue
+            }
+            if (alreadyLinked.has(`${entityId}:${artImageId}`)) {
+              report.alreadyLinked += 1
+              continue
+            }
+            toLink.push({ entityType, entityId, artImageId })
+          }
+
+          if (WRITE && toLink.length) {
+            for (let index = 0; index < toLink.length; index += 500) {
+              const chunk = toLink.slice(index, index + 500)
+              await prisma.entityArtImage.createMany({
+                data: chunk,
+                skipDuplicates: true,
+              })
+            }
+          }
+          report.linked = toLink.length
+
+          byEntity[entityType][pathField] = report
+          totals.linked += report.linked
+          totals.alreadyLinked += report.alreadyLinked
+          totals.pathOnlyNoArtImage += report.pathOnlyNoArtImage
+          totals.missingArtImageRow += report.missingArtImageRow
+        }
+      }
+
+      console.log(
+        JSON.stringify(
+          {
+            mode: WRITE ? 'write' : 'dry-run',
+            totals: {
+              ...totals,
+              linked: WRITE ? totals.linked : 0,
+              wouldLink: WRITE ? 0 : totals.linked,
+            },
+            byEntity,
+            policy:
+              'Insert-only. Every card/hero/icon render becomes an inspiration entry via one EntityArtImage join row. No ArtImage, entity row, slot column or path is modified, and no image is deleted.',
+            note: 'pathOnlyNoArtImage slots hold a bare path with no ArtImage row to join to. They must be resolved before any slot column is cleared, or those images would end up unreferenced.',
+          },
+          null,
+          2,
+        ),
+      )
+    } finally {
+      await prisma.$disconnect()
+    }
+  })
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/server/utils/entityArt.ts
+++ b/server/utils/entityArt.ts
@@ -6,14 +6,8 @@ import { createError, getRequestURL, type H3Event } from 'h3'
  * breaks that contract. This file is intentionally excluded from prettier
  * formatting for that reason.
  */
-import type {
-  Prisma,
-  PrismaClient,
-} from '~/prisma/generated/prisma/client'
-import {
-  artContextRules,
-  artSlotFraming,
-} from '~/utils/entityArtPromptFraming'
+import type { Prisma, PrismaClient } from '~/prisma/generated/prisma/client'
+import { artContextRules, artSlotFraming } from '~/utils/entityArtPromptFraming'
 
 export type EntityArtType =
   | 'bot'
@@ -69,6 +63,15 @@ type EntityArtFieldConfig = {
   width: number
   height: number
   primary: boolean
+  /**
+   * A slot that is no longer generated. Entity art is collapsing to one
+   * primary render plus the inspiration gallery (Silas, 2026-09-05), so
+   * card/hero/icon are retired: prepareEntityArtEnqueue refuses new work for
+   * them, while completion, reads and the existing stored images are all left
+   * alone so any straggler already in the queue still lands and no rendered
+   * art disappears from a page.
+   */
+  retired?: boolean
 }
 
 export const ENTITY_FIELDS: Record<
@@ -105,18 +108,21 @@ export const ENTITY_FIELDS: Record<
       width: 256,
       height: 256,
       primary: false,
+      retired: true,
     },
     cardPath: {
       label: 'Card',
       width: 512,
       height: 768,
       primary: false,
+      retired: true,
     },
     heroPath: {
       label: 'Hero',
       width: 1280,
       height: 720,
       primary: false,
+      retired: true,
     },
   },
   dream: {
@@ -139,18 +145,21 @@ export const ENTITY_FIELDS: Record<
       width: 256,
       height: 256,
       primary: false,
+      retired: true,
     },
     cardPath: {
       label: 'Card',
       width: 512,
       height: 768,
       primary: false,
+      retired: true,
     },
     heroPath: {
       label: 'Hero',
       width: 1280,
       height: 720,
       primary: false,
+      retired: true,
     },
   },
   scenario: {
@@ -165,18 +174,21 @@ export const ENTITY_FIELDS: Record<
       width: 256,
       height: 256,
       primary: false,
+      retired: true,
     },
     cardPath: {
       label: 'Card',
       width: 512,
       height: 768,
       primary: false,
+      retired: true,
     },
     heroPath: {
       label: 'Hero',
       width: 1280,
       height: 720,
       primary: false,
+      retired: true,
     },
   },
   reward: {
@@ -191,18 +203,21 @@ export const ENTITY_FIELDS: Record<
       width: 256,
       height: 256,
       primary: false,
+      retired: true,
     },
     cardPath: {
       label: 'Card',
       width: 512,
       height: 768,
       primary: false,
+      retired: true,
     },
     heroPath: {
       label: 'Hero',
       width: 1280,
       height: 720,
       primary: false,
+      retired: true,
     },
   },
   facet: {
@@ -217,18 +232,21 @@ export const ENTITY_FIELDS: Record<
       width: 256,
       height: 256,
       primary: false,
+      retired: true,
     },
     cardPath: {
       label: 'Card',
       width: 512,
       height: 768,
       primary: false,
+      retired: true,
     },
     heroPath: {
       label: 'Hero',
       width: 1280,
       height: 720,
       primary: false,
+      retired: true,
     },
   },
   achievement: {
@@ -251,12 +269,14 @@ export const ENTITY_FIELDS: Record<
       width: 512,
       height: 768,
       primary: false,
+      retired: true,
     },
     heroPath: {
       label: 'Hero',
       width: 1280,
       height: 720,
       primary: false,
+      retired: true,
     },
   },
 }
@@ -1126,6 +1146,20 @@ export async function prepareEntityArtEnqueue(
     request.field,
     auth,
   )
+  /*
+   * The enqueue gate for the slot collapse. Refusing here rather than in
+   * getEntityArtFieldConfig is deliberate: completion, reads and history all
+   * resolve the same config, and blocking those would strand jobs already in
+   * the queue and hide art that is still on the page.
+   */
+  if (target.config.retired) {
+    throw createError({
+      statusCode: 400,
+      message:
+        `The ${target.config.label} slot is no longer generated. One primary image now serves every ` +
+        `view, cropped per frame, and previous renders remain available as inspiration.`,
+    })
+  }
   const mode =
     safeText(request.mode).toLowerCase() === 'img2img' ? 'img2img' : 'recreate'
   const metadata: EntityArtMetadata = {

--- a/utils/artImageSrc.ts
+++ b/utils/artImageSrc.ts
@@ -109,17 +109,24 @@ const VARIANT_DATA_KEYS = {
 } as const
 
 /**
- * Renderable source for a purpose-built art variant.
+ * Renderable source for an entity's art in a requested shape.
  *
- * These three slots have existed on the type since the card/hero/icon migration
- * (interface-vision t-007), but until now nothing read them: the only resolvers
- * were the full-size and thumbnail ones, so every card fell back to the entity's
- * avatar or primary image. That left hundreds of rendered card images sitting in
- * the database, invisible.
+ * PRIMARY FIRST (2026-09-05). Entity art is collapsing from four stored slots
+ * per object to one primary render plus an inspiration gallery, because four
+ * renders per object made the library unwieldy for no display benefit -- the
+ * frames differ, but the picture does not need to. The primary now wins, and
+ * the purpose-built variants are only a fallback for an object that has no
+ * primary yet.
  *
- * Degrades deliberately: requested variant path -> requested variant base64 ->
- * the full-size resolver -> `fallback`. A gallery that asks for a card therefore
- * gets the card when one exists and the general imagePath when it does not.
+ * The old order (variant first) is exactly what made every object cost four
+ * renders. Keeping the variants as a fallback rather than deleting the branch
+ * means nothing goes blank during the migration: the entities that have variant
+ * art but no primary keep rendering as before until a primary arrives.
+ *
+ * Degrades: primary -> requested variant path -> requested variant base64 ->
+ * `fallback`. Callers that need to know which they got -- a stand-in primary
+ * must be re-cropped, a composed variant must not -- read `origin` from
+ * resolveArtVariantSource().
  */
 export function resolveArtVariantSrc(
   image: ArtImageSrcLike,
@@ -142,6 +149,9 @@ export function resolveArtVariantSource(
   variant: ArtVariant,
   fallback = '',
 ): ResolvedArtSrc {
+  const primary = resolveArtImageSrc(image)
+  if (primary) return { src: primary, origin: 'primary' }
+
   const path = cleanValue(image?.[VARIANT_PATH_KEYS[variant]])
   if (path) return { src: path, origin: 'variant' }
 
@@ -150,9 +160,6 @@ export function resolveArtVariantSource(
     image?.fileType,
   )
   if (data) return { src: data, origin: 'variant' }
-
-  const primary = resolveArtImageSrc(image)
-  if (primary) return { src: primary, origin: 'primary' }
 
   const cleanFallback = cleanValue(fallback)
   return cleanFallback

--- a/utils/scripts/verifyEntityArtPrimaryCrop.ts
+++ b/utils/scripts/verifyEntityArtPrimaryCrop.ts
@@ -15,6 +15,11 @@
 //      purpose-built variant is NOT. Variants are composed for their aspect;
 //      re-cropping one fights the composition, while failing to crop a
 //      stand-in square into 2:3 cuts the subject's head off.
+//
+// And since 2026-09-05 the primary WINS over a stored variant, which is the
+// change that actually retires three renders per object. The variant branch
+// stays as a fallback purely so an object with variant art but no primary does
+// not go blank mid-migration.
 import assert from 'node:assert/strict'
 import {
   ART_VARIANT_FOCUS,
@@ -53,6 +58,31 @@ assert.equal(
 // ── Origin reporting drives the crop ────────────────────────────────────────
 
 for (const variant of VARIANTS) {
+  // The collapse itself: one good primary beats three purpose-built variants.
+  assert.deepEqual(
+    resolveArtVariantSource(
+      {
+        imagePath: '/primary.webp',
+        cardPath: '/card.webp',
+        heroPath: '/hero.webp',
+        iconPath: '/icon.webp',
+      },
+      variant,
+    ),
+    { src: '/primary.webp', origin: 'primary' },
+    `${variant}: the primary render must win over a stored variant`,
+  )
+
+  // A Bot's avatar is a primary too, so it also outranks stored variants.
+  assert.deepEqual(
+    resolveArtVariantSource(
+      { avatarImage: '/avatar.webp', cardPath: '/card.webp' },
+      variant,
+    ),
+    { src: '/avatar.webp', origin: 'primary' },
+    `${variant}: a Bot's avatar counts as the primary and outranks variants`,
+  )
+
   const composed = resolveArtVariantSource(
     { cardPath: '/card.webp', heroPath: '/hero.webp', iconPath: '/icon.webp' },
     variant,
@@ -60,7 +90,7 @@ for (const variant of VARIANTS) {
   assert.equal(
     composed.origin,
     'variant',
-    `${variant}: a purpose-built variant must report origin 'variant' so it is shown as composed`,
+    `${variant}: with no primary, the stored variant is the fallback and is shown as composed`,
   )
 
   const standIn = resolveArtVariantSource(
@@ -118,5 +148,6 @@ for (const source of cases) {
 }
 
 console.log(
-  'Entity art primary/crop contract verified: Bot primaries resolve, and only a stand-in primary is re-cropped.',
+  'Entity art primary/crop contract verified: the primary wins, Bot primaries resolve, ' +
+    'and only a stand-in primary is re-cropped.',
 )

--- a/utils/scripts/verifyEntityArtPrimaryCrop.ts
+++ b/utils/scripts/verifyEntityArtPrimaryCrop.ts
@@ -21,6 +21,8 @@
 // stays as a fallback purely so an object with variant art but no primary does
 // not go blank mid-migration.
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve as resolvePath } from 'node:path'
 import {
   ART_VARIANT_FOCUS,
   resolveArtImageSrc,
@@ -150,4 +152,41 @@ for (const source of cases) {
 console.log(
   'Entity art primary/crop contract verified: the primary wins, Bot primaries resolve, ' +
     'and only a stand-in primary is re-cropped.',
+)
+
+// ── Retired slots must not accept new work ──────────────────────────────────
+//
+// The collapse only holds if nothing keeps queueing the slots it retires. Two
+// independent producers had to be stopped, and each is easy to regress:
+// prepareEntityArtEnqueue (the API path) and generate_facet_art_v4 (which
+// writes ArtJobs straight to the table and so inherits no API gate).
+const entityArtSource = readFileSync(
+  resolvePath(process.cwd(), 'server/utils/entityArt.ts'),
+  'utf8',
+)
+const facetProducerSource = readFileSync(
+  resolvePath(process.cwd(), 'scripts/generate_facet_art_v4.ts'),
+  'utf8',
+)
+
+assert.ok(
+  /if \(target\.config\.retired\) \{/.test(entityArtSource),
+  'prepareEntityArtEnqueue must refuse a retired slot, or the collapse keeps queueing card/hero/icon',
+)
+assert.equal(
+  (entityArtSource.match(/^\s+retired: true,$/gm) || []).length,
+  17,
+  'every card/hero/icon slot across bot/character/scenario/reward/facet/project must be marked retired',
+)
+assert.ok(
+  !/^\s+primary: true,\n\s+retired: true,$/m.test(entityArtSource),
+  'a primary slot must never be marked retired -- that would block the one render we keep',
+)
+assert.ok(
+  /RETIRED_VARIANT_FIELDS\.has\(variant\.field\)/.test(facetProducerSource),
+  'generate_facet_art_v4 writes ArtJobs directly, so it must skip retired variants itself',
+)
+
+console.log(
+  'Retired-slot producers verified: no new card/hero/icon work is queued.',
 )


### PR DESCRIPTION
Three steps of the entity-art collapse: flip what gets displayed, stop producing the slots nobody displays any more, and keep every render already made — as inspiration.

## 1. Primary first

`resolveArtVariantSource` now degrades **primary → variant path → variant base64 → fallback**, inverting the variant-first order that made every entity cost four renders for no display benefit — the frames differ, but the picture does not need to.

The variant branch stays as a *fallback* rather than being deleted, so nothing goes blank mid-migration: the ~68 of 910 entities that have variant art but no primary keep rendering exactly as before.

Cards, heroes and icons now show the primary, cropped by `kr-art-plate` with the above-centre `ART_VARIANT_FOCUS` anchors from #2441 — which is why those shipped first, so a square portrait in a 2:3 or 16:9 frame keeps its subject instead of being centre-cropped through the head. The anchors are a starting point and easy to tune; `position` art-directs any single surface meanwhile.

## 2. Retire the slots

Two producers, gated separately because only one goes through the API:

- `EntityArtFieldConfig` gains `retired`, and all **17** card/hero/icon slots across bot/character/scenario/reward/facet/project are marked. `prepareEntityArtEnqueue` refuses them.
- The gate sits at **enqueue**, deliberately *not* in `getEntityArtFieldConfig`: completion, reads and history resolve the same config, so blocking there would strand queued jobs and hide art still on the page.
- `generate_facet_art_v4` writes ArtJobs straight to the table and inherits no API gate, so `--all-variants` now skips retired fields itself. The entries stay in `ART_VARIANTS` because repair still maps a legacy job's field onto its variant geometry.

## 3. Old renders become inspiration

The ~1,820 card/hero/icon images already rendered are kept, as inspiration. Mechanically that is one join row each: `listEntityArtHistory` reads `EntityArtImage` (t-079: *"one join row is how an ArtImage becomes visible in an entity's history … not ArtImage.path prefixes"*), so inserting the link is the whole job and the ArtImage is never copied or moved.

`scripts/link_entity_art_slots_as_inspiration.ts` is **insert-only** and dry-run by default. It dedupes against links the repair's `preserveOriginal` archiving already made today, skips dangling FKs rather than aborting a clean run, and *reports* path-only slots (a bare path with no ArtImage row to join to) rather than inventing rows for them. Dream is deliberately absent — its secondary slots carry no ArtImage FK and none are populated.

**No column is cleared here.** Clearing waits until every affected image is provably linked and retagged, because `ArtImage.path`'s entity tag is what keeps an image out of the unfiled landing zone the triage pass deletes. That ordering is the difference between "turned into inspiration" and "accidentally reaped".

The cleanup workflow gains a `task` input so job cancellation and inspiration linking share one dispatch-only, dry-run-default surface.

## Verification

`verifyEntityArtPrimaryCrop.ts` pins the precedence (primary beats all three variants; a Bot's `avatarImage` counts as primary; a stored variant still wins and still reports `origin: 'variant'` when there is no primary), both producer gates, the count of 17, and that no primary slot is ever marked retired.

`vue-tsc --noEmit` clean, `eslint` clean on changed files, Facet catalog maintenance contract passes, layout contract holds, lint ratchet holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoXLrc2yHnkZtNBY4b8zSX