### PR TITLE
style: migrate newsfeed-filters.vue button to kr-btn-xs

### DIFF
--- a/components/newsfeed/newsfeed-filters.vue
+++ b/components/newsfeed/newsfeed-filters.vue
@@ -114,7 +114,7 @@
           v-for="category in categories"
           :key="category"
           type="button"
-          class="btn btn-xs gap-1 rounded-xl"
+          class="kr-btn-xs gap-1"
           :class="
             isCategorySelected(category)
               ? 'btn-primary'


### PR DESCRIPTION
interface-vision/t-104 slice 100 of the recurring btn-xs consistency sweep.

Migrates the single hand-rolled `btn btn-xs gap-1 rounded-xl` occurrence in `components/newsfeed/newsfeed-filters.vue` to the shared `kr-btn-xs` primitive:
- `btn btn-xs gap-1 rounded-xl` → `kr-btn-xs gap-1`

Layout utility (`gap-1`) preserved; the element's dynamic `:class` binding (`btn-primary` when selected, `btn-ghost border border-base-300` otherwise) is untouched. No geometry or behavior change.

### Verified before opening
- Checked `utils/scripts/*.mjs` for the filename — no regression-guard hits.
- `vue-tsc --noEmit` clean
- `eslint` on the changed file: 0 issues
- `prettier --check`: flags pre-existing drift (confirmed via `git stash`, not introduced this slice)
- `test:layout-contract`: holds (207 baseline unchanged)
- `test:lint-ratchet`: holds (333/-59 unchanged)

Remaining families for the next slice: `brainstorm-manager.vue` (1), `taskmaster-page.vue` (1), `pages/admin/lora-triage.vue` (1) — 3 occurrences across 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YaWRecbEgeyL3LNKS7t68e

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaWRecbEgeyL3LNKS7t68e)_